### PR TITLE
test+fix(profiles): T2 coverage floor and two latent defects (#1600)

### DIFF
--- a/packages/profiles/src/__tests__/api-keys.test.ts
+++ b/packages/profiles/src/__tests__/api-keys.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for API key authentication: the ApiKey model and ApiKeyCollection,
+ * plus the Profile-level convenience wrappers (getApiKeys / getActiveApiKeys /
+ * generateApiKey).
+ *
+ * Following the Organization-Wide Testing Standard:
+ * - Real in-memory/file SQLite, no DB mocking
+ * - Tests behaviour, not implementation
+ */
+
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  ApiKey,
+  ApiKeyCollection,
+  ProfileCollection,
+  ProfileTypeCollection,
+} from '../index.js';
+
+function getTestDbUrl(name: string): string {
+  return `file:${join(tmpdir(), `${name}-${randomUUID()}.db`)}`;
+}
+
+async function createProfileFixture(dbUrl: string) {
+  const db = { type: 'sqlite' as const, url: dbUrl };
+  const profiles = await ProfileCollection.create({ db });
+  const profileTypes = await ProfileTypeCollection.create({ db });
+
+  const type = await profileTypes.create({ name: 'Person' });
+  await type.save();
+
+  const profile = await profiles.create({
+    typeId: type.id,
+    name: 'Alice Example',
+    email: `alice-${randomUUID()}@example.com`,
+  });
+  await profile.save();
+
+  return { db, profiles, profile };
+}
+
+describe('ApiKey model', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('api-keys');
+  });
+
+  it('hashes keys deterministically', () => {
+    const hashA = ApiKey.hashKey('sk_live_secret');
+    const hashB = ApiKey.hashKey('sk_live_secret');
+    expect(hashA).toBe(hashB);
+    expect(hashA).toHaveLength(64); // SHA-256 hex
+    expect(ApiKey.hashKey('different')).not.toBe(hashA);
+  });
+
+  it('generates a key, returns the plaintext once, and stores only the hash', async () => {
+    const { db, profile } = await createProfileFixture(dbUrl);
+
+    const { key, apiKey } = await ApiKey.generate(profile, {
+      name: 'CI Bot',
+      scopes: ['repo:read'],
+      db,
+    });
+
+    expect(key.startsWith('sk_live_')).toBe(true);
+    expect(apiKey.keyPrefix).toBe(key.substring(0, 16));
+    expect(apiKey.keyHash).toBe(ApiKey.hashKey(key));
+    expect(apiKey.keyHash).not.toBe(key);
+    expect(apiKey.name).toBe('CI Bot');
+    expect(apiKey.scopes).toEqual(['repo:read']);
+    expect(apiKey.profileId).toBe(profile.id);
+  });
+
+  it('defaults to the wildcard scope when none are provided', async () => {
+    const { db, profile } = await createProfileFixture(dbUrl);
+    const { apiKey } = await ApiKey.generate(profile, { name: 'CLI', db });
+
+    expect(apiKey.scopes).toEqual(['*']);
+    expect(apiKey.hasScope('anything')).toBe(true);
+    expect(apiKey.hasScope('repo:write')).toBe(true);
+  });
+
+  it('checks specific scopes', async () => {
+    const { db, profile } = await createProfileFixture(dbUrl);
+    const { apiKey } = await ApiKey.generate(profile, {
+      name: 'scoped',
+      scopes: ['repo:read', 'issues:write'],
+      db,
+    });
+
+    expect(apiKey.hasScope('repo:read')).toBe(true);
+    expect(apiKey.hasScope('issues:write')).toBe(true);
+    expect(apiKey.hasScope('admin')).toBe(false);
+  });
+
+  it('reports validity based on revocation and expiry', async () => {
+    const { db, profile } = await createProfileFixture(dbUrl);
+
+    const active = await ApiKey.generate(profile, { name: 'active', db });
+    expect(active.apiKey.isValid()).toBe(true);
+
+    const expired = await ApiKey.generate(profile, {
+      name: 'expired',
+      expiresAt: new Date(Date.now() - 60_000),
+      db,
+    });
+    expect(expired.apiKey.isValid()).toBe(false);
+
+    await active.apiKey.revoke();
+    expect(active.apiKey.isValid()).toBe(false);
+    expect(active.apiKey.revokedAt).toBeInstanceOf(Date);
+  });
+
+  it('records usage timestamps', async () => {
+    const { db, profile } = await createProfileFixture(dbUrl);
+    const { apiKey } = await ApiKey.generate(profile, { name: 'used', db });
+
+    expect(apiKey.lastUsedAt).toBeNull();
+    await apiKey.recordUsage();
+    expect(apiKey.lastUsedAt).toBeInstanceOf(Date);
+  });
+
+  it('resolves the linked profile', async () => {
+    const { db, profile } = await createProfileFixture(dbUrl);
+    const { apiKey } = await ApiKey.generate(profile, { name: 'linked', db });
+
+    const linked = await apiKey.getProfile();
+    expect(linked?.id).toBe(profile.id);
+  });
+
+  it('verifies a valid key and records usage; rejects unknown/expired/revoked', async () => {
+    const { db, profile } = await createProfileFixture(dbUrl);
+
+    const { key } = await ApiKey.generate(profile, { name: 'verify', db });
+    const verified = await ApiKey.verify(key, { db });
+    expect(verified).not.toBeNull();
+    expect(verified?.lastUsedAt).toBeInstanceOf(Date);
+
+    expect(await ApiKey.verify('sk_live_nope', { db })).toBeNull();
+
+    const expired = await ApiKey.generate(profile, {
+      name: 'expired',
+      expiresAt: new Date(Date.now() - 60_000),
+      db,
+    });
+    expect(await ApiKey.verify(expired.key, { db })).toBeNull();
+  });
+});
+
+describe('ApiKeyCollection', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('api-key-collection');
+  });
+
+  it('generates, finds, and filters keys by profile', async () => {
+    const { db, profile } = await createProfileFixture(dbUrl);
+    const collection = await ApiKeyCollection.create({ db });
+
+    await collection.generateForProfile(profile, { name: 'first' });
+    const second = await collection.generateForProfile(profile, {
+      name: 'second',
+    });
+
+    const all = await collection.findByProfile(profile.id as string);
+    expect(all).toHaveLength(2);
+
+    // Revoke one; only active keys remain in findActiveByProfile.
+    await second.apiKey.revoke();
+    const active = await collection.findActiveByProfile(profile.id as string);
+    expect(active).toHaveLength(1);
+    expect(active[0].name).toBe('first');
+  });
+
+  it('finds a key by hash and verifies a key string', async () => {
+    const { db, profile } = await createProfileFixture(dbUrl);
+    const collection = await ApiKeyCollection.create({ db });
+
+    const { key, apiKey } = await collection.generateForProfile(profile, {
+      name: 'hash',
+    });
+
+    const byHash = await collection.findByHash(apiKey.keyHash);
+    expect(byHash?.id).toBe(apiKey.id);
+
+    const verified = await collection.verify(key);
+    expect(verified?.id).toBe(apiKey.id);
+
+    expect(await collection.verify('sk_live_unknown')).toBeNull();
+  });
+
+  it('revokes all active keys for a profile', async () => {
+    const { db, profile } = await createProfileFixture(dbUrl);
+    const collection = await ApiKeyCollection.create({ db });
+
+    await collection.generateForProfile(profile, { name: 'a' });
+    await collection.generateForProfile(profile, { name: 'b' });
+
+    const revokedCount = await collection.revokeAllForProfile(
+      profile.id as string,
+    );
+    expect(revokedCount).toBe(2);
+    expect(await collection.findActiveByProfile(profile.id as string)).toEqual(
+      [],
+    );
+  });
+
+  it('revokes a key by prefix', async () => {
+    const { db, profile } = await createProfileFixture(dbUrl);
+    const collection = await ApiKeyCollection.create({ db });
+
+    const { apiKey } = await collection.generateForProfile(profile, {
+      name: 'prefixed',
+    });
+
+    expect(await collection.revokeByPrefix(apiKey.keyPrefix)).toBe(true);
+    // A second attempt finds the now-revoked key but does not re-revoke it.
+    expect(await collection.revokeByPrefix(apiKey.keyPrefix)).toBe(false);
+    // Unknown prefix.
+    expect(await collection.revokeByPrefix('sk_live_missing')).toBe(false);
+  });
+
+  it('cleans up expired keys by soft-revoking them', async () => {
+    const { db, profile } = await createProfileFixture(dbUrl);
+    const collection = await ApiKeyCollection.create({ db });
+
+    await collection.generateForProfile(profile, {
+      name: 'expired',
+      expiresAt: new Date(Date.now() - 60_000),
+    });
+    await collection.generateForProfile(profile, { name: 'active' });
+
+    const cleaned = await collection.cleanupExpired();
+    expect(cleaned).toBe(1);
+    // Idempotent: re-running cleans up nothing new.
+    expect(await collection.cleanupExpired()).toBe(0);
+  });
+});
+
+describe('Profile auth helpers (API keys)', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('profile-api-keys');
+  });
+
+  it('exposes API keys through the profile model', async () => {
+    const { profile } = await createProfileFixture(dbUrl);
+
+    const generated = await profile.generateApiKey({
+      name: 'profile-key',
+      scopes: ['*'],
+    });
+    expect(generated.key.startsWith('sk_live_')).toBe(true);
+
+    const all = await profile.getApiKeys();
+    expect(all).toHaveLength(1);
+
+    const active = await profile.getActiveApiKeys();
+    expect(active).toHaveLength(1);
+
+    await active[0].revoke();
+    expect(await profile.getActiveApiKeys()).toHaveLength(0);
+  });
+});

--- a/packages/profiles/src/__tests__/audit-log.test.ts
+++ b/packages/profiles/src/__tests__/audit-log.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for audit logging: the AuditLog model and AuditLogCollection, plus the
+ * Profile-level recordAction / getAuditLogs wrappers.
+ *
+ * Real file-backed SQLite, no DB mocking.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  AuditLog,
+  AuditLogCollection,
+  ProfileCollection,
+  ProfileTypeCollection,
+} from '../index.js';
+
+function getTestDbUrl(name: string): string {
+  return `file:${join(tmpdir(), `${name}-${randomUUID()}.db`)}`;
+}
+
+async function setup(dbUrl: string) {
+  const db = { type: 'sqlite' as const, url: dbUrl };
+  const profiles = await ProfileCollection.create({ db });
+  const profileTypes = await ProfileTypeCollection.create({ db });
+
+  const type = await profileTypes.create({ name: 'Person' });
+  await type.save();
+
+  const actor = await profiles.create({
+    typeId: type.id,
+    name: 'Actor',
+    email: `actor-${randomUUID()}@example.com`,
+  });
+  await actor.save();
+
+  const principal = await profiles.create({
+    typeId: type.id,
+    name: 'Principal',
+    email: `principal-${randomUUID()}@example.com`,
+  });
+  await principal.save();
+
+  return { db, profiles, actor, principal };
+}
+
+describe('AuditLog model', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('audit-log');
+  });
+
+  it('records an entry via the static record() helper', async () => {
+    const { db, actor } = await setup(dbUrl);
+
+    const log = await AuditLog.record({
+      db,
+      profile: actor,
+      action: 'issue.update',
+      resourceType: 'Issue',
+      resourceId: 'issue-1',
+      source: 'cli',
+      metadata: { runId: 'abc' },
+    });
+
+    expect(log.id).toBeDefined();
+    expect(log.profileId).toBe(actor.id);
+    expect(log.action).toBe('issue.update');
+    expect(log.source).toBe('cli');
+    expect(log.metadata).toEqual({ runId: 'abc' });
+  });
+
+  it('resolves the acting profile', async () => {
+    const { db, actor } = await setup(dbUrl);
+    const log = await AuditLog.record({
+      db,
+      profile: actor,
+      action: 'a',
+      resourceType: 'R',
+      resourceId: '1',
+    });
+
+    const resolved = await log.getProfile();
+    expect(resolved?.id).toBe(actor.id);
+  });
+
+  it('resolves on-behalf-of identity and effective actor', async () => {
+    const { db, actor, principal } = await setup(dbUrl);
+
+    // Pass-through identity: CI bot (actor) acting on behalf of principal.
+    const passthrough = await AuditLog.record({
+      db,
+      profile: actor,
+      onBehalfOf: principal,
+      action: 'ci.run',
+      resourceType: 'Workflow',
+      resourceId: 'wf-1',
+      source: 'ci',
+    });
+
+    expect((await passthrough.getOnBehalfOf())?.id).toBe(principal.id);
+    // Effective actor is the on-behalf-of profile when present.
+    expect((await passthrough.getEffectiveActor())?.id).toBe(principal.id);
+
+    // Without on-behalf-of, the effective actor is the acting profile.
+    const direct = await AuditLog.record({
+      db,
+      profile: actor,
+      action: 'direct',
+      resourceType: 'X',
+      resourceId: '1',
+    });
+    expect(await direct.getOnBehalfOf()).toBeNull();
+    expect((await direct.getEffectiveActor())?.id).toBe(actor.id);
+  });
+});
+
+describe('AuditLogCollection', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('audit-log-collection');
+  });
+
+  it('records and queries logs across the available filters', async () => {
+    const { db, actor, principal } = await setup(dbUrl);
+    const logs = await AuditLogCollection.create({ db });
+
+    await logs.record({
+      profile: actor,
+      action: 'issue.create',
+      resourceType: 'Issue',
+      resourceId: 'issue-1',
+      source: 'web',
+    });
+    await logs.record({
+      profile: actor,
+      action: 'issue.update',
+      resourceType: 'Issue',
+      resourceId: 'issue-1',
+      source: 'cli',
+    });
+    await logs.record({
+      profile: actor,
+      onBehalfOf: principal,
+      action: 'deploy',
+      resourceType: 'Service',
+      resourceId: 'svc-1',
+      source: 'ci',
+    });
+
+    expect(await logs.findByProfile(actor.id as string)).toHaveLength(3);
+    expect(
+      await logs.findByResource('Issue', 'issue-1'),
+    ).toHaveLength(2);
+    expect(await logs.findByAction('issue.update')).toHaveLength(1);
+    expect(await logs.findBySource('ci')).toHaveLength(1);
+    expect(await logs.findOnBehalfOf(principal.id as string)).toHaveLength(1);
+  });
+
+  it('defaults the source to web and metadata to an empty object', async () => {
+    const { db, actor } = await setup(dbUrl);
+    const logs = await AuditLogCollection.create({ db });
+
+    const log = await logs.record({
+      profile: actor,
+      action: 'noop',
+      resourceType: 'X',
+      resourceId: '1',
+    });
+
+    expect(log.source).toBe('web');
+    expect(log.metadata).toEqual({});
+  });
+
+  it('returns recent activity and resource timelines', async () => {
+    const { db, actor } = await setup(dbUrl);
+    const logs = await AuditLogCollection.create({ db });
+
+    for (let i = 0; i < 3; i++) {
+      await logs.record({
+        profile: actor,
+        action: `act.${i}`,
+        resourceType: 'Doc',
+        resourceId: 'doc-1',
+      });
+    }
+
+    const recent = await logs.getRecentActivity(actor.id as string, 2);
+    expect(recent).toHaveLength(2);
+
+    const timeline = await logs.getResourceTimeline('Doc', 'doc-1');
+    expect(timeline).toHaveLength(3);
+  });
+});
+
+describe('Profile audit helpers', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('profile-audit');
+  });
+
+  it('records and reads audit logs through the profile model', async () => {
+    const { actor } = await setup(dbUrl);
+
+    await actor.recordAction({
+      action: 'login',
+      resourceType: 'Session',
+      resourceId: 'sess-1',
+      source: 'web',
+    });
+
+    const recent = await actor.getAuditLogs(10);
+    expect(recent).toHaveLength(1);
+    expect(recent[0].action).toBe('login');
+  });
+});

--- a/packages/profiles/src/__tests__/magic-link-service.test.ts
+++ b/packages/profiles/src/__tests__/magic-link-service.test.ts
@@ -6,13 +6,9 @@
  * sendEmail callback (an external side effect), which we stub to capture the
  * generated link.
  *
- * NOTE: `initiate()`'s brand-new-user branch builds a `Person` without a
- * `typeId` and saves it, which fails Profile's required-FK validation — a
- * pre-existing defect in magicLinkService.ts (the file previously had no
- * coverage). These tests therefore exercise the service against a
- * pre-existing, correctly-typed identity (the "returning user" path), which
- * still covers rate limiting, token generation, email delivery, and the full
- * verify() flow.
+ * Covers both the brand-new-user branch (which seeds the canonical 'person'
+ * ProfileType and creates the profile) and the returning-user branch, plus
+ * rate limiting, token generation, email delivery, and the full verify() flow.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -95,6 +91,35 @@ describe('createMagicLinkService.initiate', () => {
 
   beforeEach(() => {
     dbUrl = getTestDbUrl('magic-link-initiate');
+  });
+
+  it('creates a profile + identity for a brand-new user', async () => {
+    const { service, sentLinks } = makeService(dbUrl);
+    const email = `new-${randomUUID()}@example.com`;
+
+    const result = await service.initiate(email, { nip05Username: 'newbie' });
+
+    expect(result.success).toBe(true);
+    expect(result.created).toBe(true);
+    expect(result.profile?.email).toBe(email.toLowerCase());
+    expect(result.profile?.id).toBeDefined();
+    expect(result.nostrIdentity?.nip05Username).toBe('newbie');
+    expect(sentLinks).toHaveLength(1);
+
+    // The canonical 'person' type was seeded and backs the new profile.
+    const db = { type: 'sqlite' as const, url: dbUrl };
+    const types = await ProfileTypeCollection.create({ db });
+    const personType = await types.getBySlug('person');
+    expect(personType).not.toBeNull();
+    expect(String((result.profile as any)?.typeId)).toBe(
+      String(personType?.id),
+    );
+
+    // The freshly issued link verifies end-to-end.
+    const token = tokenFromLink(sentLinks[0]);
+    const verified = await service.verify(token);
+    expect(verified.success).toBe(true);
+    expect(verified.profile?.id).toBe(result.profile?.id);
   });
 
   it('reuses an existing identity and sends a link', async () => {

--- a/packages/profiles/src/__tests__/magic-link-service.test.ts
+++ b/packages/profiles/src/__tests__/magic-link-service.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for the magic link authentication service (createMagicLinkService) and
+ * the rate-limiting / lifecycle helpers on MagicLinkTokenCollection.
+ *
+ * Real file-backed SQLite, no DB mocking. The only injected dependency is the
+ * sendEmail callback (an external side effect), which we stub to capture the
+ * generated link.
+ *
+ * NOTE: `initiate()`'s brand-new-user branch builds a `Person` without a
+ * `typeId` and saves it, which fails Profile's required-FK validation — a
+ * pre-existing defect in magicLinkService.ts (the file previously had no
+ * coverage). These tests therefore exercise the service against a
+ * pre-existing, correctly-typed identity (the "returning user" path), which
+ * still covers rate limiting, token generation, email delivery, and the full
+ * verify() flow.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMagicLinkService,
+  type MagicLinkConfig,
+  MagicLinkToken,
+  MagicLinkTokenCollection,
+  NostrIdentityCollection,
+  ProfileCollection,
+  ProfileTypeCollection,
+} from '../index.js';
+
+const TEST_MASTER_SECRET = 'test-master-secret-32-bytes-long';
+
+function getTestDbUrl(name: string): string {
+  return `file:${join(tmpdir(), `${name}-${randomUUID()}.db`)}`;
+}
+
+function tokenFromLink(link: string): string {
+  return new URL(link).searchParams.get('token') as string;
+}
+
+function makeService(
+  dbUrl: string,
+  overrides: Partial<MagicLinkConfig> = {},
+): {
+  service: ReturnType<typeof createMagicLinkService>;
+  sentLinks: string[];
+} {
+  const db = { type: 'sqlite' as const, url: dbUrl };
+  const sentLinks: string[] = [];
+
+  const service = createMagicLinkService({
+    baseUrl: 'https://example.com',
+    masterSecret: TEST_MASTER_SECRET,
+    sendEmail: async (_to, link) => {
+      sentLinks.push(link);
+    },
+    db,
+    ...overrides,
+  });
+
+  return { service, sentLinks };
+}
+
+/**
+ * Seed a properly-typed Profile + NostrIdentity for `email` so the service can
+ * treat the caller as a returning user.
+ */
+async function seedIdentity(dbUrl: string, email: string) {
+  const db = { type: 'sqlite' as const, url: dbUrl };
+  const profileTypes = await ProfileTypeCollection.create({ db });
+  const type = await profileTypes.create({ name: 'Person' });
+  await type.save();
+
+  const profiles = await ProfileCollection.create({ db });
+  const profile = await profiles.create({
+    typeId: type.id,
+    name: 'Returning User',
+    email,
+  });
+  await profile.save();
+
+  const identities = await NostrIdentityCollection.create({ db });
+  const identity = await identities.createForProfile(
+    profile,
+    email,
+    TEST_MASTER_SECRET,
+  );
+
+  return { db, profile, identity };
+}
+
+describe('createMagicLinkService.initiate', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('magic-link-initiate');
+  });
+
+  it('reuses an existing identity and sends a link', async () => {
+    const email = `existing-${randomUUID()}@example.com`;
+    const { profile } = await seedIdentity(dbUrl, email);
+    const { service, sentLinks } = makeService(dbUrl);
+
+    const result = await service.initiate(email);
+
+    expect(result.success).toBe(true);
+    expect(result.created).toBe(false);
+    expect(result.profile?.id).toBe(profile.id);
+    expect(sentLinks).toHaveLength(1);
+    expect(sentLinks[0]).toContain('https://example.com/auth/verify?token=');
+  });
+
+  it('rate-limits by email', async () => {
+    const email = `rl-email-${randomUUID()}@example.com`;
+    await seedIdentity(dbUrl, email);
+    const { service } = makeService(dbUrl, { maxTokensPerEmailPerHour: 1 });
+
+    const first = await service.initiate(email);
+    expect(first.success).toBe(true);
+
+    const second = await service.initiate(email);
+    expect(second.success).toBe(false);
+    expect(second.errorCode).toBe('RATE_LIMITED_EMAIL');
+  });
+
+  it('rate-limits by IP', async () => {
+    const email = `rl-ip-${randomUUID()}@example.com`;
+    await seedIdentity(dbUrl, email);
+    const { service } = makeService(dbUrl, {
+      maxTokensPerEmailPerHour: 10,
+      maxTokensPerIpPerHour: 1,
+    });
+    const ip = '203.0.113.7';
+
+    const first = await service.initiate(email, { requestedFromIp: ip });
+    expect(first.success).toBe(true);
+
+    const second = await service.initiate(email, { requestedFromIp: ip });
+    expect(second.success).toBe(false);
+    expect(second.errorCode).toBe('RATE_LIMITED_IP');
+  });
+
+  it('reports EMAIL_SEND_FAILED when the email callback throws', async () => {
+    const email = `fail-${randomUUID()}@example.com`;
+    await seedIdentity(dbUrl, email);
+    const { service } = makeService(dbUrl, {
+      sendEmail: vi.fn().mockRejectedValue(new Error('smtp down')),
+    });
+
+    const result = await service.initiate(email);
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe('EMAIL_SEND_FAILED');
+    expect(result.nostrIdentity).toBeDefined();
+  });
+});
+
+describe('createMagicLinkService.verify', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('magic-link-verify');
+  });
+
+  it('verifies a valid token and returns the decrypted keypair', async () => {
+    const email = `verify-${randomUUID()}@example.com`;
+    const { profile } = await seedIdentity(dbUrl, email);
+    const { service, sentLinks } = makeService(dbUrl);
+
+    await service.initiate(email);
+    const token = tokenFromLink(sentLinks[0]);
+
+    const result = await service.verify(token);
+    expect(result.success).toBe(true);
+    expect(result.profile?.id).toBe(profile.id);
+    expect(result.nostrIdentity?.isVerified()).toBe(true);
+    expect(result.keypair?.npub.startsWith('npub1')).toBe(true);
+    expect(result.keypair?.nsec.startsWith('nsec1')).toBe(true);
+  });
+
+  it('returns NOT_FOUND for an unknown token', async () => {
+    await seedIdentity(dbUrl, `seed-${randomUUID()}@example.com`);
+    const { service } = makeService(dbUrl);
+
+    const result = await service.verify('totally-made-up-token');
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe('NOT_FOUND');
+  });
+
+  it('returns USED_TOKEN when a token is replayed', async () => {
+    const email = `used-${randomUUID()}@example.com`;
+    await seedIdentity(dbUrl, email);
+    const { service, sentLinks } = makeService(dbUrl);
+
+    await service.initiate(email);
+    const token = tokenFromLink(sentLinks[0]);
+
+    expect((await service.verify(token)).success).toBe(true);
+    const replay = await service.verify(token);
+    expect(replay.success).toBe(false);
+    expect(replay.errorCode).toBe('USED_TOKEN');
+  });
+
+  it('returns EXPIRED_TOKEN for a token past its expiry', async () => {
+    const email = `expired-${randomUUID()}@example.com`;
+    const { db, identity } = await seedIdentity(dbUrl, email);
+    const { service } = makeService(dbUrl);
+
+    // Mint an already-expired token directly for the seeded identity.
+    const { token } = await MagicLinkToken.generate(identity, email, {
+      expiresInMinutes: -5,
+      db,
+    });
+
+    const result = await service.verify(token);
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe('EXPIRED_TOKEN');
+  });
+});
+
+describe('MagicLinkTokenCollection lifecycle helpers', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('magic-link-collection');
+  });
+
+  it('finds tokens by hash, email, and identity; verifies validity', async () => {
+    const email = `mlt-${randomUUID()}@example.com`;
+    const { db, identity } = await seedIdentity(dbUrl, email);
+    const tokens = await MagicLinkTokenCollection.create({ db });
+
+    const { token, magicLinkToken } = await MagicLinkToken.generate(
+      identity,
+      email,
+      { db },
+    );
+
+    expect((await tokens.findByTokenHash(magicLinkToken.tokenHash))?.id).toBe(
+      magicLinkToken.id,
+    );
+    expect(await tokens.findActiveForEmail(email)).toHaveLength(1);
+    expect(await tokens.findByIdentity(identity.id as string)).toHaveLength(1);
+    expect((await tokens.verify(token))?.id).toBe(magicLinkToken.id);
+    expect(await tokens.verify('not-a-real-token')).toBeNull();
+  });
+
+  it('counts and rate-limits by IP', async () => {
+    const email = `mlt-ip-${randomUUID()}@example.com`;
+    const { db, identity } = await seedIdentity(dbUrl, email);
+    const tokens = await MagicLinkTokenCollection.create({ db });
+
+    for (let i = 0; i < 3; i++) {
+      await MagicLinkToken.generate(identity, email, {
+        requestedFromIp: '198.51.100.4',
+        db,
+      });
+    }
+
+    expect(await tokens.countRecentByIp('198.51.100.4', 60)).toBe(3);
+    expect(await tokens.isRateLimitedByIp('198.51.100.4', 2)).toBe(true);
+    expect(await tokens.isRateLimitedByIp('198.51.100.4', 5)).toBe(false);
+  });
+
+  it('cleans up expired/used tokens and revokes tokens for an identity', async () => {
+    const email = `mlt-clean-${randomUUID()}@example.com`;
+    const { db, identity } = await seedIdentity(dbUrl, email);
+    const tokens = await MagicLinkTokenCollection.create({ db });
+
+    // One expired, one active.
+    await MagicLinkToken.generate(identity, email, {
+      expiresInMinutes: -10,
+      db,
+    });
+    const active = await MagicLinkToken.generate(identity, email, { db });
+
+    expect(await tokens.cleanupExpired()).toBe(1);
+
+    // Revoking marks the still-active token as used.
+    const revoked = await tokens.revokeForIdentity(identity.id as string);
+    expect(revoked).toBe(1);
+    const refetched = await tokens.findByTokenHash(
+      active.magicLinkToken.tokenHash,
+    );
+    expect(refetched?.isUsed()).toBe(true);
+  });
+});

--- a/packages/profiles/src/__tests__/profile-collection.test.ts
+++ b/packages/profiles/src/__tests__/profile-collection.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for ProfileCollection query/batch helpers, assorted Profile model
+ * methods (type slug, identity linking, static stubs), and the remaining
+ * NostrIdentityCollection helpers.
+ *
+ * Real file-backed SQLite, no DB mocking.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  encryptPrivkey,
+  generateNostrKeypair,
+  NostrIdentityCollection,
+  Profile,
+  ProfileCollection,
+  ProfileMetafieldCollection,
+  ProfileTypeCollection,
+} from '../index.js';
+
+const TEST_MASTER_SECRET = 'test-master-secret-32-bytes-long';
+
+function getTestDbUrl(name: string): string {
+  return `file:${join(tmpdir(), `${name}-${randomUUID()}.db`)}`;
+}
+
+async function setup(dbUrl: string) {
+  const db = { type: 'sqlite' as const, url: dbUrl };
+  const profiles = await ProfileCollection.create({ db });
+  const profileTypes = await ProfileTypeCollection.create({ db });
+  const metafields = await ProfileMetafieldCollection.create({ db });
+
+  const type = await profileTypes.create({ name: 'Person' });
+  await type.save();
+
+  const mkProfile = async (name: string, extra: Record<string, any> = {}) => {
+    const p = await profiles.create({
+      typeId: type.id,
+      name,
+      email: `${name.toLowerCase()}-${randomUUID()}@example.com`,
+      ...extra,
+    });
+    await p.save();
+    return p;
+  };
+
+  return { db, profiles, profileTypes, metafields, type, mkProfile };
+}
+
+describe('ProfileCollection query and batch helpers', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('profile-collection');
+  });
+
+  it('finds profiles by type slug', async () => {
+    const { profiles, profileTypes, mkProfile } = await setup(dbUrl);
+
+    await mkProfile('Person A');
+    await mkProfile('Person B');
+
+    const orgType = await profileTypes.create({ name: 'Organization' });
+    await orgType.save();
+    const org = await profiles.create({
+      typeId: orgType.id,
+      name: 'Acme',
+      email: `acme-${randomUUID()}@example.com`,
+    });
+    await org.save();
+
+    const people = await profiles.findByType('person');
+    expect(people).toHaveLength(2);
+    const orgs = await profiles.findByType('organization');
+    expect(orgs).toHaveLength(1);
+    expect(orgs[0].name).toBe('Acme');
+  });
+
+  it('batch-updates and batch-reads metadata', async () => {
+    const { profiles, metafields, mkProfile } = await setup(dbUrl);
+
+    const city = await metafields.create({ name: 'City' });
+    await city.save();
+
+    const alice = await mkProfile('Alice');
+    const bob = await mkProfile('Bob');
+
+    await profiles.batchUpdateMetadata([
+      { profileId: alice.id as string, data: { city: 'Paris' } },
+      { profileId: bob.id as string, data: { city: 'Rome' } },
+    ]);
+
+    const result = await profiles.batchGetMetadata([
+      alice.id as string,
+      bob.id as string,
+    ]);
+    expect(result.get(alice.id as string)).toEqual({ city: 'Paris' });
+    expect(result.get(bob.id as string)).toEqual({ city: 'Rome' });
+  });
+
+  it('finds profiles scoped to a tenant', async () => {
+    const { profiles, mkProfile } = await setup(dbUrl);
+
+    const scoped = await mkProfile('Scoped');
+    scoped.tenantId = 'tenant-xyz';
+    await scoped.save();
+    await mkProfile('Global'); // tenantId stays null
+
+    const tenantProfiles = await profiles.findByTenant('tenant-xyz');
+    expect(tenantProfiles).toHaveLength(1);
+    expect(tenantProfiles[0].name).toBe('Scoped');
+  });
+});
+
+describe('Profile model misc methods', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('profile-misc');
+  });
+
+  it('returns the profile type slug', async () => {
+    const { mkProfile } = await setup(dbUrl);
+    const profile = await mkProfile('Alice');
+    expect(await profile.getTypeSlug()).toBe('person');
+  });
+
+  it('setTypeBySlug throws for an unresolved static lookup', async () => {
+    const { mkProfile } = await setup(dbUrl);
+    const profile = await mkProfile('Alice');
+    // ProfileType.getBySlug is a static stub that returns null, so the lookup
+    // always reports "not found".
+    await expect(profile.setTypeBySlug('person')).rejects.toThrow(/not found/);
+  });
+
+  it('static finder stubs return empty defaults', async () => {
+    expect(await Profile.findByType('person')).toEqual([]);
+    expect(await Profile.findByMetadata('k', 'v')).toEqual([]);
+    expect(await Profile.findRelated('id')).toEqual([]);
+    expect(await Profile.searchByEmail('x@example.com')).toBeNull();
+  });
+
+  it('links and reads OIDC identities through the profile model', async () => {
+    const { mkProfile } = await setup(dbUrl);
+    const profile = await mkProfile('Olive');
+
+    const identity = await profile.linkOidcIdentity({
+      provider: 'github',
+      issuer: 'https://github.com',
+      subject: 'gh-123',
+      email: 'olive@example.com',
+    });
+    expect(identity.profileId).toBe(profile.id);
+
+    const identities = await profile.getOidcIdentities();
+    expect(identities).toHaveLength(1);
+    expect(identities[0].subject).toBe('gh-123');
+  });
+
+  it('links and reads Nostr identities through the profile model', async () => {
+    const { mkProfile } = await setup(dbUrl);
+    const profile = await mkProfile('Nova');
+
+    const keypair = generateNostrKeypair();
+    const encrypted = encryptPrivkey(keypair.privkey, TEST_MASTER_SECRET);
+    const identity = await profile.linkNostrIdentity({
+      pubkey: keypair.pubkey,
+      encryptedPrivkey: encrypted.ciphertext,
+      encryptionIv: encrypted.iv,
+      encryptionTag: encrypted.tag,
+      email: `nova-link-${randomUUID()}@example.com`,
+      nip05Username: 'nova',
+    });
+    expect(identity.profileId).toBe(profile.id);
+
+    const identities = await profile.getNostrIdentities();
+    expect(identities).toHaveLength(1);
+    expect(identities[0].pubkey).toBe(keypair.pubkey);
+  });
+});
+
+describe('NostrIdentityCollection helpers', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('nostr-identity-collection');
+  });
+
+  it('manages NIP-05 usernames and unlinking', async () => {
+    const { db, mkProfile } = await setup(dbUrl);
+    const profile = await mkProfile('Ned');
+    const identities = await NostrIdentityCollection.create({ db });
+
+    const email = `ned-${randomUUID()}@example.com`;
+    const identity = await identities.createForProfile(
+      profile,
+      email,
+      TEST_MASTER_SECRET,
+      'ned',
+    );
+
+    expect(await identities.findByProfile(profile.id as string)).toHaveLength(
+      1,
+    );
+    expect((await identities.findByNip05('ned'))?.id).toBe(identity.id);
+    expect(await identities.isNip05Available('ned')).toBe(false);
+    expect(await identities.isNip05Available('free-name')).toBe(true);
+
+    const updated = await identities.updateNip05Username(identity, 'ned2');
+    expect(updated.nip05Username).toBe('ned2');
+    expect(await identities.isNip05Available('ned')).toBe(true);
+
+    // Unlink removes the identity.
+    expect(
+      await identities.unlinkFromProfile(
+        profile.id as string,
+        identity.pubkey,
+      ),
+    ).toBe(true);
+    expect(await identities.findByProfile(profile.id as string)).toEqual([]);
+    // Unlinking again is a no-op.
+    expect(
+      await identities.unlinkFromProfile(
+        profile.id as string,
+        identity.pubkey,
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a NIP-05 rename that collides with another identity', async () => {
+    const { db, mkProfile } = await setup(dbUrl);
+    const profileA = await mkProfile('Amy');
+    const profileB = await mkProfile('Ben');
+    const identities = await NostrIdentityCollection.create({ db });
+
+    const a = await identities.createForProfile(
+      profileA,
+      `amy-${randomUUID()}@example.com`,
+      TEST_MASTER_SECRET,
+      'amy',
+    );
+    await identities.createForProfile(
+      profileB,
+      `ben-${randomUUID()}@example.com`,
+      TEST_MASTER_SECRET,
+      'ben',
+    );
+
+    await expect(
+      identities.updateNip05Username(a, 'ben'),
+    ).rejects.toThrow(/already taken/);
+  });
+});

--- a/packages/profiles/src/__tests__/profile-metadata.test.ts
+++ b/packages/profiles/src/__tests__/profile-metadata.test.ts
@@ -9,7 +9,7 @@
 import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import {
   ProfileCollection,
   ProfileMetadataCollection,
@@ -106,18 +106,22 @@ describe('ProfileMetafield.validateValue', () => {
   });
 
   describe('custom validators', () => {
-    afterEach(() => {
-      // Clean up the global registry between tests.
-      (globalThis as any).__smrtProfileMetafieldValidators?.delete('isEven');
-    });
-
+    // The validator registry is a process-global singleton (issue #543) with no
+    // public unregister hook, so each test registers under a unique name to stay
+    // isolated rather than reaching into the private registry to clean up.
     it('runs a registered custom validator', async () => {
-      ProfileMetafield.registerValidator('isEven', (v: any) => v % 2 === 0);
-      expect(ProfileMetafield.getValidator('isEven')).toBeTypeOf('function');
+      const validatorName = `isEven-${randomUUID().slice(0, 8)}`;
+      ProfileMetafield.registerValidator(
+        validatorName,
+        (v: any) => v % 2 === 0,
+      );
+      expect(ProfileMetafield.getValidator(validatorName)).toBeTypeOf(
+        'function',
+      );
 
       const field = new ProfileMetafield({
         name: 'EvenNumber',
-        validation: { custom: 'isEven', message: 'must be even' },
+        validation: { custom: validatorName, message: 'must be even' },
       });
 
       expect(await field.validateValue(4)).toBe(true);
@@ -127,11 +131,9 @@ describe('ProfileMetafield.validateValue', () => {
     it('throws when the custom validator is not registered', async () => {
       const field = new ProfileMetafield({
         name: 'Mystery',
-        validation: { custom: 'doesNotExist' },
+        validation: { custom: `unregistered-${randomUUID().slice(0, 8)}` },
       });
-      await expect(field.validateValue('x')).rejects.toThrow(
-        /not registered/,
-      );
+      await expect(field.validateValue('x')).rejects.toThrow(/not registered/);
     });
   });
 });

--- a/packages/profiles/src/__tests__/profile-metadata.test.ts
+++ b/packages/profiles/src/__tests__/profile-metadata.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for controlled profile metadata: ProfileMetafield validation, the
+ * ProfileMetadata model, both collections, and the Profile-level metadata
+ * helpers (addMetadata / getMetadata / updateMetadata / removeMetadata).
+ *
+ * Real file-backed SQLite, no DB mocking.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ProfileCollection,
+  ProfileMetadataCollection,
+  ProfileMetafield,
+  ProfileMetafieldCollection,
+  ProfileTypeCollection,
+} from '../index.js';
+
+function getTestDbUrl(name: string): string {
+  return `file:${join(tmpdir(), `${name}-${randomUUID()}.db`)}`;
+}
+
+async function setup(dbUrl: string) {
+  const db = { type: 'sqlite' as const, url: dbUrl };
+  const profiles = await ProfileCollection.create({ db });
+  const profileTypes = await ProfileTypeCollection.create({ db });
+  const metafields = await ProfileMetafieldCollection.create({ db });
+  const metadata = await ProfileMetadataCollection.create({ db });
+
+  const type = await profileTypes.create({ name: 'Person' });
+  await type.save();
+
+  const profile = await profiles.create({
+    typeId: type.id,
+    name: 'Alice',
+    email: `alice-${randomUUID()}@example.com`,
+  });
+  await profile.save();
+
+  return { db, profiles, profile, metafields, metadata };
+}
+
+describe('ProfileMetafield.validateValue', () => {
+  it('accepts any value when no validation schema is set', async () => {
+    const field = new ProfileMetafield({ name: 'Freeform' });
+    expect(await field.validateValue('anything')).toBe(true);
+    expect(await field.validateValue(42)).toBe(true);
+  });
+
+  it('enforces type validation', async () => {
+    const numberField = new ProfileMetafield({
+      name: 'Age',
+      validation: { type: 'number' },
+    });
+    expect(await numberField.validateValue(30)).toBe(true);
+    await expect(numberField.validateValue('thirty')).rejects.toThrow();
+
+    const stringField = new ProfileMetafield({
+      name: 'City',
+      validation: { type: 'string' },
+    });
+    expect(await stringField.validateValue('Berlin')).toBe(true);
+    await expect(stringField.validateValue(5)).rejects.toThrow();
+
+    const boolField = new ProfileMetafield({
+      name: 'Active',
+      validation: { type: 'boolean' },
+    });
+    expect(await boolField.validateValue(true)).toBe(true);
+    await expect(boolField.validateValue('yes')).rejects.toThrow();
+  });
+
+  it('enforces pattern and length constraints on strings', async () => {
+    const pattern = new ProfileMetafield({
+      name: 'Code',
+      validation: { pattern: '^[A-Z]{3}$', message: 'Need 3 caps' },
+    });
+    expect(await pattern.validateValue('ABC')).toBe(true);
+    await expect(pattern.validateValue('abc')).rejects.toThrow('Need 3 caps');
+
+    const minLen = new ProfileMetafield({
+      name: 'Bio',
+      validation: { minLength: 5 },
+    });
+    expect(await minLen.validateValue('hello')).toBe(true);
+    await expect(minLen.validateValue('hi')).rejects.toThrow();
+
+    const maxLen = new ProfileMetafield({
+      name: 'Nick',
+      validation: { maxLength: 3 },
+    });
+    expect(await maxLen.validateValue('abc')).toBe(true);
+    await expect(maxLen.validateValue('abcd')).rejects.toThrow();
+  });
+
+  it('enforces numeric min/max constraints', async () => {
+    const field = new ProfileMetafield({
+      name: 'Score',
+      validation: { min: 0, max: 100 },
+    });
+    expect(await field.validateValue(50)).toBe(true);
+    await expect(field.validateValue(-1)).rejects.toThrow();
+    await expect(field.validateValue(101)).rejects.toThrow();
+  });
+
+  describe('custom validators', () => {
+    afterEach(() => {
+      // Clean up the global registry between tests.
+      (globalThis as any).__smrtProfileMetafieldValidators?.delete('isEven');
+    });
+
+    it('runs a registered custom validator', async () => {
+      ProfileMetafield.registerValidator('isEven', (v: any) => v % 2 === 0);
+      expect(ProfileMetafield.getValidator('isEven')).toBeTypeOf('function');
+
+      const field = new ProfileMetafield({
+        name: 'EvenNumber',
+        validation: { custom: 'isEven', message: 'must be even' },
+      });
+
+      expect(await field.validateValue(4)).toBe(true);
+      await expect(field.validateValue(3)).rejects.toThrow('must be even');
+    });
+
+    it('throws when the custom validator is not registered', async () => {
+      const field = new ProfileMetafield({
+        name: 'Mystery',
+        validation: { custom: 'doesNotExist' },
+      });
+      await expect(field.validateValue('x')).rejects.toThrow(
+        /not registered/,
+      );
+    });
+  });
+});
+
+describe('ProfileMetafieldCollection', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('metafield-collection');
+  });
+
+  it('looks up and lazily creates metafields by slug', async () => {
+    const { metafields } = await setup(dbUrl);
+
+    const created = await metafields.getOrCreateBySlug('location', {
+      name: 'Location',
+      description: 'Where they live',
+    });
+    expect(created.slug).toBe('location');
+
+    // Second call returns the existing record (no duplicate).
+    const again = await metafields.getOrCreateBySlug('location', {
+      name: 'Location',
+    });
+    expect(again.id).toBe(created.id);
+
+    expect((await metafields.getBySlug('location'))?.id).toBe(created.id);
+    expect(await metafields.getBySlug('missing')).toBeNull();
+  });
+});
+
+describe('ProfileMetadata model + collection', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('profile-metadata');
+  });
+
+  it('validates a stored value against its metafield', async () => {
+    const { db, profile, metafields, metadata } = await setup(dbUrl);
+
+    const field = await metafields.create({
+      name: 'Age',
+      validation: { type: 'number', min: 0 },
+    });
+    await field.save();
+
+    const record = await metadata.create({
+      db,
+      profileId: profile.id,
+      metafieldId: field.id,
+      value: '5',
+    });
+    await record.save();
+
+    expect(await record.getMetafieldSlug()).toBe(field.slug);
+    // validate() runs the metafield schema against the stored string; the
+    // string '5' is not a number, so number-type validation rejects it.
+    await expect(record.validate()).rejects.toThrow();
+  });
+
+  it('builds a key-value metadata object and finds profiles by metadata', async () => {
+    const { profile, metafields, metadata } = await setup(dbUrl);
+
+    const city = await metafields.create({ name: 'City' });
+    await city.save();
+    const role = await metafields.create({ name: 'Role' });
+    await role.save();
+
+    const cityValue = await metadata.create({
+      profileId: profile.id,
+      metafieldId: city.id,
+      value: 'Berlin',
+    });
+    await cityValue.save();
+    const roleValue = await metadata.create({
+      profileId: profile.id,
+      metafieldId: role.id,
+      value: 'Engineer',
+    });
+    await roleValue.save();
+
+    expect(await metadata.getByProfile(profile.id as string)).toHaveLength(2);
+
+    const asObject = await metadata.getMetadataObject(profile.id as string);
+    expect(asObject).toEqual({ city: 'Berlin', role: 'Engineer' });
+
+    const matches = await metadata.findProfilesByMetadata(
+      city.id as string,
+      'Berlin',
+    );
+    expect(matches).toEqual([profile.id]);
+  });
+});
+
+describe('Profile metadata helpers', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('profile-metadata-helpers');
+  });
+
+  it('adds, reads, updates, and removes metadata by metafield slug', async () => {
+    const { profile, metafields } = await setup(dbUrl);
+
+    const city = await metafields.create({ name: 'City' });
+    await city.save();
+    const role = await metafields.create({ name: 'Role' });
+    await role.save();
+
+    await profile.addMetadata('city', 'Paris');
+    expect(await profile.getMetadata()).toEqual({ city: 'Paris' });
+
+    // Re-adding the same slug updates the existing value rather than inserting.
+    await profile.addMetadata('city', 'London');
+    expect(await profile.getMetadata()).toEqual({ city: 'London' });
+
+    await profile.updateMetadata({ city: 'Rome', role: 'Designer' });
+    expect(await profile.getMetadata()).toEqual({
+      city: 'Rome',
+      role: 'Designer',
+    });
+
+    await profile.removeMetadata('city');
+    expect(await profile.getMetadata()).toEqual({ role: 'Designer' });
+  });
+
+  it('throws when adding metadata for an unknown metafield slug', async () => {
+    const { profile } = await setup(dbUrl);
+    await expect(profile.addMetadata('nonexistent', 'x')).rejects.toThrow(
+      /not found/,
+    );
+  });
+
+  it('validates values when adding metadata', async () => {
+    const { profile, metafields } = await setup(dbUrl);
+
+    const score = await metafields.create({
+      name: 'Score',
+      validation: { type: 'number', max: 10 },
+    });
+    await score.save();
+
+    // 5 is a valid number; 99 exceeds the max.
+    await profile.addMetadata('score', 5);
+    expect(await profile.getMetadata()).toEqual({ score: '5' });
+    await expect(profile.addMetadata('score', 99)).rejects.toThrow();
+  });
+
+  it('does nothing when removing metadata for a slug with no value set', async () => {
+    const { profile, metafields } = await setup(dbUrl);
+    const field = await metafields.create({ name: 'Pronoun' });
+    await field.save();
+
+    // No metadata stored yet — removeMetadata is a no-op (does not throw).
+    await expect(profile.removeMetadata('pronoun')).resolves.toBeUndefined();
+  });
+});

--- a/packages/profiles/src/__tests__/profile-relationships.test.ts
+++ b/packages/profiles/src/__tests__/profile-relationships.test.ts
@@ -15,7 +15,7 @@
 import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import {
   ProfileCollection,
   ProfileRelationship,
@@ -97,6 +97,8 @@ describe('Profile.addRelationship / getRelationships / getRelatedProfiles', () =
 
   it('fires a registered reciprocal handler for reciprocal types', async () => {
     const { relTypes, relationships, alice, bob } = await setup(dbUrl);
+    // Unique slug so this registration stays isolated in the process-global
+    // handler registry (issue #543) without a private-registry cleanup.
     const slug = `recip-${randomUUID().slice(0, 8)}`;
 
     let handlerArgs: any[] | null = null;
@@ -122,8 +124,6 @@ describe('Profile.addRelationship / getRelationships / getRelatedProfiles', () =
     expect(await relationships.getFromProfile(alice.id as string)).toHaveLength(
       1,
     );
-
-    (globalThis as any).__smrtProfileRelationshipHandlers?.delete(slug);
   });
 
   it('creates both edges via the bundled reciprocal handler without recursing forever', async () => {
@@ -356,14 +356,13 @@ describe('ProfileRelationshipTermCollection', () => {
 
 describe('ProfileRelationshipType statics and collection', () => {
   let dbUrl: string;
+  // The reciprocal-handler registry is a process-global singleton (issue #543)
+  // with no public unregister hook; a unique slug keeps this registration
+  // isolated without reaching into the private registry to clean up.
   const customSlug = `custom-${randomUUID().slice(0, 8)}`;
 
   beforeEach(() => {
     dbUrl = getTestDbUrl('relationship-types');
-  });
-
-  afterEach(() => {
-    (globalThis as any).__smrtProfileRelationshipHandlers?.delete(customSlug);
   });
 
   it('ships default reciprocal handlers and supports custom registration', () => {

--- a/packages/profiles/src/__tests__/profile-relationships.test.ts
+++ b/packages/profiles/src/__tests__/profile-relationships.test.ts
@@ -5,11 +5,11 @@
  *
  * Real file-backed SQLite, no DB mocking.
  *
- * Note: Profile.addRelationship fires a registered reciprocal handler whenever
- * the type is reciprocal, *unconditionally*. The bundled default handlers
- * (friend/spouse/…) call back into addRelationship and would recurse, so these
- * tests drive reciprocal behaviour with purpose-built non-recursive handlers
- * and never invoke addRelationship with a default reciprocal slug.
+ * Note: Profile.addRelationship fires a registered reciprocal handler only when
+ * it creates a new edge (the `!exists` guard). That guard terminates the mutual
+ * recursion the bundled friend/spouse/… handlers would otherwise cause. Both
+ * the custom-handler and the bundled 'friend' default-handler paths are
+ * exercised below.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -101,9 +101,12 @@ describe('Profile.addRelationship / getRelationships / getRelatedProfiles', () =
 
     let handlerArgs: any[] | null = null;
     // Non-recursive handler so we don't trigger the addRelationship recursion.
-    ProfileRelationshipType.registerReciprocalHandler(slug, async (from, to) => {
-      handlerArgs = [from.id, to.id];
-    });
+    ProfileRelationshipType.registerReciprocalHandler(
+      slug,
+      async (from, to) => {
+        handlerArgs = [from.id, to.id];
+      },
+    );
 
     const recipType = await relTypes.create({
       slug,
@@ -122,6 +125,34 @@ describe('Profile.addRelationship / getRelationships / getRelatedProfiles', () =
 
     (globalThis as any).__smrtProfileRelationshipHandlers?.delete(slug);
   });
+
+  it('creates both edges via the bundled reciprocal handler without recursing forever', async () => {
+    const { relTypes, relationships, alice, bob } = await setup(dbUrl);
+    // Name 'Friend' → slug 'friend', which matches a bundled default handler
+    // that creates the inverse edge. Before the `!exists` guard this recursed
+    // infinitely; the explicit timeout fails fast if that regresses.
+    const friend = await relTypes.create({ name: 'Friend', reciprocal: true });
+    await friend.save();
+
+    await alice.addRelationship(bob, 'friend');
+
+    // Both directed edges exist (the handler created the inverse).
+    expect(await relationships.getFromProfile(alice.id as string)).toHaveLength(
+      1,
+    );
+    expect(await relationships.getFromProfile(bob.id as string)).toHaveLength(
+      1,
+    );
+    expect(await relationships.getForProfile(alice.id as string)).toHaveLength(
+      2,
+    );
+
+    // Re-invoking is idempotent: no duplicate edges, still terminates.
+    await alice.addRelationship(bob, 'friend');
+    expect(await relationships.getForProfile(alice.id as string)).toHaveLength(
+      2,
+    );
+  }, 15_000);
 
   it('reads relationships by direction and filters by type slug', async () => {
     const { relTypes, alice, bob, charlie } = await setup(dbUrl);
@@ -423,14 +454,25 @@ describe('ProfileRelationshipCollection', () => {
 
     // Type-filtered queries.
     expect(
-      await relationships.getFromProfile(alice.id as string, mentor.id as string),
+      await relationships.getFromProfile(
+        alice.id as string,
+        mentor.id as string,
+      ),
     ).toHaveLength(1);
 
     expect(
-      await relationships.exists(alice.id as string, bob.id as string, mentor.id as string),
+      await relationships.exists(
+        alice.id as string,
+        bob.id as string,
+        mentor.id as string,
+      ),
     ).toBe(true);
     expect(
-      await relationships.exists(bob.id as string, alice.id as string, mentor.id as string),
+      await relationships.exists(
+        bob.id as string,
+        alice.id as string,
+        mentor.id as string,
+      ),
     ).toBe(false);
   });
 });

--- a/packages/profiles/src/__tests__/profile-relationships.test.ts
+++ b/packages/profiles/src/__tests__/profile-relationships.test.ts
@@ -1,0 +1,467 @@
+/**
+ * Tests for the profile relationship graph: Profile relationship helpers,
+ * ProfileRelationship / ProfileRelationshipTerm / ProfileRelationshipType
+ * models, their collections, and the ProfileCollection network helpers.
+ *
+ * Real file-backed SQLite, no DB mocking.
+ *
+ * Note: Profile.addRelationship fires a registered reciprocal handler whenever
+ * the type is reciprocal, *unconditionally*. The bundled default handlers
+ * (friend/spouse/…) call back into addRelationship and would recurse, so these
+ * tests drive reciprocal behaviour with purpose-built non-recursive handlers
+ * and never invoke addRelationship with a default reciprocal slug.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ProfileCollection,
+  ProfileRelationship,
+  ProfileRelationshipCollection,
+  ProfileRelationshipTerm,
+  ProfileRelationshipTermCollection,
+  ProfileRelationshipType,
+  ProfileRelationshipTypeCollection,
+  ProfileTypeCollection,
+} from '../index.js';
+
+function getTestDbUrl(name: string): string {
+  return `file:${join(tmpdir(), `${name}-${randomUUID()}.db`)}`;
+}
+
+async function setup(dbUrl: string) {
+  const db = { type: 'sqlite' as const, url: dbUrl };
+  const profiles = await ProfileCollection.create({ db });
+  const profileTypes = await ProfileTypeCollection.create({ db });
+  const relTypes = await ProfileRelationshipTypeCollection.create({ db });
+  const relationships = await ProfileRelationshipCollection.create({ db });
+  const terms = await ProfileRelationshipTermCollection.create({ db });
+
+  const personType = await profileTypes.create({ name: 'Person' });
+  await personType.save();
+
+  const mkProfile = async (name: string) => {
+    const p = await profiles.create({
+      typeId: personType.id,
+      name,
+      email: `${name.toLowerCase()}-${randomUUID()}@example.com`,
+    });
+    await p.save();
+    return p;
+  };
+
+  const alice = await mkProfile('Alice');
+  const bob = await mkProfile('Bob');
+  const charlie = await mkProfile('Charlie');
+
+  return {
+    db,
+    profiles,
+    relTypes,
+    relationships,
+    terms,
+    alice,
+    bob,
+    charlie,
+  };
+}
+
+describe('Profile.addRelationship / getRelationships / getRelatedProfiles', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('profile-relationships');
+  });
+
+  it('adds a directional relationship and is idempotent', async () => {
+    const { relTypes, relationships, alice, bob } = await setup(dbUrl);
+    const mentor = await relTypes.create({ name: 'Mentor', reciprocal: false });
+    await mentor.save();
+
+    await alice.addRelationship(bob, 'mentor');
+    await alice.addRelationship(bob, 'mentor'); // duplicate — should be a no-op
+
+    const fromAlice = await relationships.getFromProfile(alice.id as string);
+    expect(fromAlice).toHaveLength(1);
+    expect(String(fromAlice[0].toProfileId)).toBe(String(bob.id));
+  });
+
+  it('throws when the relationship slug is unknown', async () => {
+    const { alice, bob } = await setup(dbUrl);
+    await expect(alice.addRelationship(bob, 'nope')).rejects.toThrow(
+      /not found/,
+    );
+  });
+
+  it('fires a registered reciprocal handler for reciprocal types', async () => {
+    const { relTypes, relationships, alice, bob } = await setup(dbUrl);
+    const slug = `recip-${randomUUID().slice(0, 8)}`;
+
+    let handlerArgs: any[] | null = null;
+    // Non-recursive handler so we don't trigger the addRelationship recursion.
+    ProfileRelationshipType.registerReciprocalHandler(slug, async (from, to) => {
+      handlerArgs = [from.id, to.id];
+    });
+
+    const recipType = await relTypes.create({
+      slug,
+      name: 'Reciprocal',
+      reciprocal: true,
+    });
+    await recipType.save();
+
+    await alice.addRelationship(bob, slug);
+
+    expect(handlerArgs).toEqual([alice.id, bob.id]);
+    // The forward relationship is still created.
+    expect(await relationships.getFromProfile(alice.id as string)).toHaveLength(
+      1,
+    );
+
+    (globalThis as any).__smrtProfileRelationshipHandlers?.delete(slug);
+  });
+
+  it('reads relationships by direction and filters by type slug', async () => {
+    const { relTypes, alice, bob, charlie } = await setup(dbUrl);
+    const mentor = await relTypes.create({ name: 'Mentor', reciprocal: false });
+    await mentor.save();
+    const knows = await relTypes.create({ name: 'Knows', reciprocal: false });
+    await knows.save();
+
+    await alice.addRelationship(bob, 'mentor');
+    await charlie.addRelationship(alice, 'knows');
+
+    const from = await alice.getRelationships({ direction: 'from' });
+    expect(from).toHaveLength(1);
+
+    const to = await alice.getRelationships({ direction: 'to' });
+    expect(to).toHaveLength(1);
+
+    const all = await alice.getRelationships({ direction: 'all' });
+    expect(all).toHaveLength(2);
+
+    // Type-slug filter narrows to the matching relationship type.
+    const onlyMentor = await alice.getRelationships({
+      direction: 'all',
+      typeSlug: 'mentor',
+    });
+    expect(onlyMentor).toHaveLength(1);
+  });
+
+  it('resolves related profiles in both directions, de-duplicated', async () => {
+    const { relTypes, alice, bob, charlie } = await setup(dbUrl);
+    const mentor = await relTypes.create({ name: 'Mentor', reciprocal: false });
+    await mentor.save();
+
+    await alice.addRelationship(bob, 'mentor');
+    await charlie.addRelationship(alice, 'mentor');
+
+    const related = await alice.getRelatedProfiles();
+    const ids = related.map((p) => String(p.id)).sort();
+    expect(ids).toEqual([String(bob.id), String(charlie.id)].sort());
+  });
+
+  it('removes a directional relationship and rejects unknown slugs', async () => {
+    const { relTypes, relationships, alice, bob } = await setup(dbUrl);
+    const mentor = await relTypes.create({ name: 'Mentor', reciprocal: false });
+    await mentor.save();
+
+    await alice.addRelationship(bob, 'mentor');
+    await alice.removeRelationship(bob, 'mentor');
+    expect(await relationships.getFromProfile(alice.id as string)).toEqual([]);
+
+    await expect(alice.removeRelationship(bob, 'ghost')).rejects.toThrow(
+      /not found/,
+    );
+  });
+
+  it('removes the inverse edge for reciprocal types', async () => {
+    const { relTypes, relationships, alice, bob } = await setup(dbUrl);
+    // reciprocal:true so removeRelationship also deletes the inverse edge.
+    const peer = await relTypes.create({ name: 'Peer', reciprocal: true });
+    await peer.save();
+    const typeId = peer.id as string;
+
+    // Build both directions directly (avoiding addRelationship's handler path).
+    for (const [fromId, toId] of [
+      [alice.id, bob.id],
+      [bob.id, alice.id],
+    ] as const) {
+      const rel = await relationships.create({
+        fromProfileId: fromId,
+        toProfileId: toId,
+        typeId,
+      });
+      await rel.save();
+    }
+
+    await alice.removeRelationship(bob, 'peer');
+
+    expect(await relationships.getFromProfile(alice.id as string)).toEqual([]);
+    expect(await relationships.getFromProfile(bob.id as string)).toEqual([]);
+  });
+});
+
+describe('ProfileRelationship instance methods and terms', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('relationship-terms');
+  });
+
+  it('exposes the type slug and manages temporal terms', async () => {
+    const { relTypes, relationships, alice, bob } = await setup(dbUrl);
+    const knows = await relTypes.create({ name: 'Knows', reciprocal: false });
+    await knows.save();
+
+    const rel = await relationships.create({
+      fromProfileId: alice.id,
+      toProfileId: bob.id,
+      typeId: knows.id,
+    });
+    await rel.save();
+
+    expect(await rel.getTypeSlug()).toBe(knows.slug);
+
+    // No terms yet.
+    expect(await rel.getActiveTerm()).toBeNull();
+
+    // Add an open-ended (active) term.
+    await rel.addTerm(new Date('2020-01-01'));
+    const active = await rel.getActiveTerm();
+    expect(active).not.toBeNull();
+    expect(active?.isActive()).toBe(true);
+
+    expect(await rel.getTerms()).toHaveLength(1);
+
+    // Ending the current term closes it out.
+    await rel.endCurrentTerm(new Date('2021-01-01'));
+    expect(await rel.getActiveTerm()).toBeNull();
+  });
+});
+
+describe('ProfileRelationshipTerm model', () => {
+  it('reports active state and computes duration', () => {
+    const open = new ProfileRelationshipTerm({
+      startedAt: new Date('2020-01-01'),
+    });
+    expect(open.isActive()).toBe(true);
+
+    const future = new ProfileRelationshipTerm({
+      startedAt: new Date('2020-01-01'),
+      endedAt: new Date(Date.now() + 86_400_000),
+    });
+    expect(future.isActive()).toBe(true);
+
+    const past = new ProfileRelationshipTerm({
+      startedAt: new Date('2020-01-01'),
+      endedAt: new Date('2020-01-11'),
+    });
+    expect(past.isActive()).toBe(false);
+    expect(past.getDurationDays()).toBe(10);
+  });
+
+  it('end() defaults to now and marks the term closed', async () => {
+    const dbUrl = getTestDbUrl('term-end');
+    const { relTypes, relationships, alice, bob } = await setup(dbUrl);
+    const t = await relTypes.create({ name: 'Knows', reciprocal: false });
+    await t.save();
+    const rel = await relationships.create({
+      fromProfileId: alice.id,
+      toProfileId: bob.id,
+      typeId: t.id,
+    });
+    await rel.save();
+    await rel.addTerm(new Date('2020-01-01'));
+
+    const [term] = await rel.getTerms();
+    await term.end();
+    expect(term.endedAt).toBeInstanceOf(Date);
+    expect(term.isActive()).toBe(false);
+  });
+});
+
+describe('ProfileRelationshipTermCollection', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('term-collection');
+  });
+
+  it('separates active and historical terms', async () => {
+    const { relTypes, relationships, terms, alice, bob } = await setup(dbUrl);
+    const t = await relTypes.create({ name: 'Knows', reciprocal: false });
+    await t.save();
+    const rel = await relationships.create({
+      fromProfileId: alice.id,
+      toProfileId: bob.id,
+      typeId: t.id,
+    });
+    await rel.save();
+    const relId = rel.id as string;
+
+    // One ended term, one active term.
+    const ended = await terms.create({
+      relationshipId: relId,
+      startedAt: new Date('2019-01-01'),
+      endedAt: new Date('2019-06-01'),
+    });
+    await ended.save();
+    const current = await terms.create({
+      relationshipId: relId,
+      startedAt: new Date('2020-01-01'),
+    });
+    await current.save();
+
+    expect(await terms.getByRelationship(relId)).toHaveLength(2);
+    expect((await terms.getActiveTerm(relId))?.id).toBe(current.id);
+    const historical = await terms.getHistoricalTerms(relId);
+    expect(historical).toHaveLength(1);
+    expect(historical[0].id).toBe(ended.id);
+  });
+});
+
+describe('ProfileRelationshipType statics and collection', () => {
+  let dbUrl: string;
+  const customSlug = `custom-${randomUUID().slice(0, 8)}`;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('relationship-types');
+  });
+
+  afterEach(() => {
+    (globalThis as any).__smrtProfileRelationshipHandlers?.delete(customSlug);
+  });
+
+  it('ships default reciprocal handlers and supports custom registration', () => {
+    // Bundled defaults are present.
+    expect(ProfileRelationshipType.getReciprocalHandler('friend')).toBeTypeOf(
+      'function',
+    );
+    expect(ProfileRelationshipType.getReciprocalHandler('sibling')).toBeTypeOf(
+      'function',
+    );
+    expect(
+      ProfileRelationshipType.getReciprocalHandler('does-not-exist'),
+    ).toBeUndefined();
+
+    const handler = async () => {};
+    ProfileRelationshipType.registerReciprocalHandler(customSlug, handler);
+    expect(ProfileRelationshipType.getReciprocalHandler(customSlug)).toBe(
+      handler,
+    );
+  });
+
+  it('getBySlug static stub returns null and isReciprocal falls back to false', async () => {
+    expect(await ProfileRelationshipType.getBySlug('anything')).toBeNull();
+    expect(await ProfileRelationshipType.isReciprocal('anything')).toBe(false);
+  });
+
+  it('looks up, lazily creates, and partitions types by reciprocity', async () => {
+    const { relTypes } = await setup(dbUrl);
+
+    const created = await relTypes.getOrCreateBySlug('mentor', {
+      name: 'Mentor',
+      reciprocal: false,
+    });
+    expect(created.slug).toBe('mentor');
+    // Idempotent.
+    const again = await relTypes.getOrCreateBySlug('mentor', {
+      name: 'Mentor',
+    });
+    expect(again.id).toBe(created.id);
+    expect((await relTypes.getBySlug('mentor'))?.id).toBe(created.id);
+
+    const friend = await relTypes.create({ name: 'Friend', reciprocal: true });
+    await friend.save();
+
+    const reciprocal = await relTypes.getReciprocal();
+    expect(reciprocal.map((t) => t.slug)).toContain('friend');
+    const directional = await relTypes.getDirectional();
+    expect(directional.map((t) => t.slug)).toContain('mentor');
+  });
+});
+
+describe('ProfileRelationshipCollection', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('relationship-collection');
+  });
+
+  it('queries by direction, both directions, and existence', async () => {
+    const { relTypes, relationships, alice, bob, charlie } = await setup(dbUrl);
+    const mentor = await relTypes.create({ name: 'Mentor', reciprocal: false });
+    await mentor.save();
+    const knows = await relTypes.create({ name: 'Knows', reciprocal: false });
+    await knows.save();
+
+    const r1 = await relationships.create({
+      fromProfileId: alice.id,
+      toProfileId: bob.id,
+      typeId: mentor.id,
+    });
+    await r1.save();
+    const r2 = await relationships.create({
+      fromProfileId: charlie.id,
+      toProfileId: alice.id,
+      typeId: knows.id,
+    });
+    await r2.save();
+
+    expect(await relationships.getFromProfile(alice.id as string)).toHaveLength(
+      1,
+    );
+    expect(await relationships.getToProfile(alice.id as string)).toHaveLength(
+      1,
+    );
+    expect(await relationships.getForProfile(alice.id as string)).toHaveLength(
+      2,
+    );
+
+    // Type-filtered queries.
+    expect(
+      await relationships.getFromProfile(alice.id as string, mentor.id as string),
+    ).toHaveLength(1);
+
+    expect(
+      await relationships.exists(alice.id as string, bob.id as string, mentor.id as string),
+    ).toBe(true);
+    expect(
+      await relationships.exists(bob.id as string, alice.id as string, mentor.id as string),
+    ).toBe(false);
+  });
+});
+
+describe('ProfileCollection relationship helpers', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('profile-collection-relationships');
+  });
+
+  it('finds related profiles and walks the relationship network', async () => {
+    const { profiles, relTypes, alice, bob, charlie } = await setup(dbUrl);
+    const mentor = await relTypes.create({ name: 'Mentor', reciprocal: false });
+    await mentor.save();
+
+    // alice -> bob -> charlie chain.
+    await alice.addRelationship(bob, 'mentor');
+    await bob.addRelationship(charlie, 'mentor');
+
+    const related = await profiles.findRelated(alice.id as string);
+    expect(related.map((p) => String(p.id))).toContain(String(bob.id));
+
+    // Unknown profile id yields no related profiles.
+    expect(await profiles.findRelated('missing-id')).toEqual([]);
+
+    const network = await profiles.getRelationshipNetwork(alice.id as string, {
+      maxDepth: 2,
+    });
+    expect(network.get(alice.id as string)).toBe(0);
+    expect(network.get(bob.id as string)).toBe(1);
+    expect(network.get(charlie.id as string)).toBe(2);
+  });
+});

--- a/packages/profiles/src/__tests__/resolve-identity.test.ts
+++ b/packages/profiles/src/__tests__/resolve-identity.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Tests for the identity-resolution dispatcher (resolveIdentity) and the
+ * createProfileFromNostr helper. Exercises every resolution branch: API key,
+ * OIDC session, Nostr signed event, CI actor pass-through, and the
+ * unauthenticated fallback.
+ *
+ * Real file-backed SQLite, no DB mocking.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  ApiKey,
+  createAuthEvent,
+  createProfileFromNostr,
+  createProfileFromOidc,
+  encryptPrivkey,
+  generateNostrKeypair,
+  NostrIdentityCollection,
+  OidcIdentityCollection,
+  ProfileCollection,
+  ProfileTypeCollection,
+  resolveIdentity,
+} from '../index.js';
+
+const TEST_MASTER_SECRET = 'test-master-secret-32-bytes-long';
+
+function getTestDbUrl(name: string): string {
+  return `file:${join(tmpdir(), `${name}-${randomUUID()}.db`)}`;
+}
+
+async function createProfile(dbUrl: string, email: string) {
+  const db = { type: 'sqlite' as const, url: dbUrl };
+  const profileTypes = await ProfileTypeCollection.create({ db });
+  const type = await profileTypes.create({ name: 'Person' });
+  await type.save();
+
+  const profiles = await ProfileCollection.create({ db });
+  const profile = await profiles.create({ typeId: type.id, name: 'User', email });
+  await profile.save();
+  return { db, profile };
+}
+
+describe('resolveIdentity', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('resolve-identity');
+  });
+
+  it('resolves via API key', async () => {
+    const { db, profile } = await createProfile(
+      dbUrl,
+      `apikey-${randomUUID()}@example.com`,
+    );
+    const { key } = await ApiKey.generate(profile, { name: 'CI', db });
+
+    const result = await resolveIdentity({ apiKey: key, db });
+    expect(result.source).toBe('api_key');
+    expect(result.profile?.id).toBe(profile.id);
+    expect(result.apiKey).toBeDefined();
+  });
+
+  it('resolves via OIDC session', async () => {
+    const db = { type: 'sqlite' as const, url: dbUrl };
+    const { profile } = await createProfileFromOidc(
+      {
+        sub: 'oidc-sub-1',
+        iss: 'https://issuer.example.com',
+        email: `oidc-${randomUUID()}@example.com`,
+        email_verified: true,
+        name: 'OIDC User',
+      },
+      'keycloak',
+      { db },
+    );
+
+    const result = await resolveIdentity({
+      oidcSession: { sub: 'oidc-sub-1', iss: 'https://issuer.example.com' },
+      db,
+    });
+    expect(result.source).toBe('oidc');
+    expect(result.profile?.id).toBe(profile.id);
+    expect(result.oidcIdentity?.lastUsedAt).toBeInstanceOf(Date);
+  });
+
+  it('resolves via a Nostr signed auth event', async () => {
+    const { db, profile } = await createProfile(
+      dbUrl,
+      `nostr-${randomUUID()}@example.com`,
+    );
+
+    const keypair = generateNostrKeypair();
+    const encrypted = encryptPrivkey(keypair.privkey, TEST_MASTER_SECRET);
+    const identities = await NostrIdentityCollection.create({ db });
+    const identity = await identities.create({
+      profileId: profile.id,
+      pubkey: keypair.pubkey,
+      encryptedPrivkey: encrypted.ciphertext,
+      encryptionIv: encrypted.iv,
+      encryptionTag: encrypted.tag,
+      email: profile.email,
+    });
+    await identity.save();
+
+    const challenge = 'challenge-123';
+    const event = createAuthEvent(keypair.privkey, challenge);
+
+    const result = await resolveIdentity({
+      nostrAuth: { event, challenge },
+      db,
+    });
+    expect(result.source).toBe('nostr');
+    expect(result.profile?.id).toBe(profile.id);
+    expect(result.nostrIdentity?.pubkey).toBe(keypair.pubkey);
+  });
+
+  it('does not resolve a Nostr event with the wrong challenge', async () => {
+    const { db, profile } = await createProfile(
+      dbUrl,
+      `nostr-bad-${randomUUID()}@example.com`,
+    );
+    const keypair = generateNostrKeypair();
+    const encrypted = encryptPrivkey(keypair.privkey, TEST_MASTER_SECRET);
+    const identities = await NostrIdentityCollection.create({ db });
+    const identity = await identities.create({
+      profileId: profile.id,
+      pubkey: keypair.pubkey,
+      encryptedPrivkey: encrypted.ciphertext,
+      encryptionIv: encrypted.iv,
+      encryptionTag: encrypted.tag,
+      email: profile.email,
+    });
+    await identity.save();
+
+    const event = createAuthEvent(keypair.privkey, 'real-challenge');
+    const result = await resolveIdentity({
+      nostrAuth: { event, challenge: 'different-challenge' },
+      db,
+    });
+    expect(result.source).toBe('none');
+    expect(result.profile).toBeNull();
+  });
+
+  it('resolves via CI actor pass-through (matched OIDC subject)', async () => {
+    const db = { type: 'sqlite' as const, url: dbUrl };
+    const { profile } = await createProfileFromOidc(
+      {
+        sub: 'octocat',
+        iss: 'https://github.com',
+        email: `actor-${randomUUID()}@example.com`,
+        email_verified: true,
+        name: 'Octo Cat',
+      },
+      'github',
+      { db },
+    );
+
+    const result = await resolveIdentity({ actor: 'octocat', db });
+    expect(result.source).toBe('actor');
+    expect(result.profile?.id).toBe(profile.id);
+  });
+
+  it('returns source "none" when nothing matches', async () => {
+    const db = { type: 'sqlite' as const, url: dbUrl };
+    // Initialise the schema so collection lookups have tables to read.
+    await ProfileTypeCollection.create({ db });
+    await ProfileCollection.create({ db });
+
+    const result = await resolveIdentity({
+      apiKey: 'sk_live_unknown',
+      actor: 'nobody',
+      db,
+    });
+    expect(result.source).toBe('none');
+    expect(result.profile).toBeNull();
+  });
+});
+
+describe('createProfileFromNostr', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('create-profile-nostr');
+  });
+
+  it('creates a profile + identity, then reuses them on a second call', async () => {
+    const db = { type: 'sqlite' as const, url: dbUrl };
+    const email = `nostr-create-${randomUUID()}@example.com`;
+    const keypair = generateNostrKeypair();
+    const encrypted = encryptPrivkey(keypair.privkey, TEST_MASTER_SECRET);
+    const nostrData = {
+      pubkey: keypair.pubkey,
+      encryptedPrivkey: encrypted.ciphertext,
+      encryptionIv: encrypted.iv,
+      encryptionTag: encrypted.tag,
+      nip05Username: 'creator',
+    };
+
+    const first = await createProfileFromNostr(email, nostrData, { db });
+    expect(first.created).toBe(true);
+    expect(first.profile.email).toBe(email.toLowerCase());
+    expect(first.nostrIdentity.nip05Username).toBe('creator');
+
+    const second = await createProfileFromNostr(email, nostrData, { db });
+    expect(second.created).toBe(false);
+    expect(second.profile.id).toBe(first.profile.id);
+  });
+});
+
+describe('OidcIdentity model and collection', () => {
+  let dbUrl: string;
+
+  beforeEach(() => {
+    dbUrl = getTestDbUrl('oidc-identity');
+  });
+
+  it('links, finds, updates, and unlinks OIDC identities', async () => {
+    const { db, profile } = await createProfile(
+      dbUrl,
+      `oidc-coll-${randomUUID()}@example.com`,
+    );
+    const identities = await OidcIdentityCollection.create({ db });
+
+    const identity = await identities.linkToProfile(profile, {
+      provider: 'google',
+      issuer: 'https://accounts.google.com',
+      subject: 'google-1',
+      email: 'g@example.com',
+    });
+    expect(identity.profileId).toBe(profile.id);
+
+    // Re-linking the same issuer+subject updates rather than duplicates.
+    const relinked = await identities.linkToProfile(profile, {
+      provider: 'google',
+      issuer: 'https://accounts.google.com',
+      subject: 'google-1',
+      email: 'updated@example.com',
+    });
+    expect(relinked.id).toBe(identity.id);
+    expect(relinked.email).toBe('updated@example.com');
+
+    expect(
+      await identities.findByProfile(profile.id as string),
+    ).toHaveLength(1);
+    expect(await identities.findByProvider('google')).toHaveLength(1);
+    expect(
+      (await identities.findBySubject('https://accounts.google.com', 'google-1'))
+        ?.id,
+    ).toBe(identity.id);
+
+    // recordUsage bumps lastUsedAt.
+    await identity.recordUsage();
+    expect(identity.lastUsedAt).toBeInstanceOf(Date);
+    expect((await identity.getProfile())?.id).toBe(profile.id);
+
+    expect(
+      await identities.unlinkFromProfile(
+        profile.id as string,
+        'https://accounts.google.com',
+        'google-1',
+      ),
+    ).toBe(true);
+    expect(
+      await identities.unlinkFromProfile(
+        profile.id as string,
+        'https://accounts.google.com',
+        'missing',
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/profiles/src/auth/magicLinkService.ts
+++ b/packages/profiles/src/auth/magicLinkService.ts
@@ -156,10 +156,32 @@ export function createMagicLinkService(
       if (!nostrIdentity) {
         // Create new identity and profile
         const { Person } = await import('../models/ProfileTypes');
+        const { ProfileTypeCollection } = await import(
+          '../collections/ProfileTypeCollection'
+        );
+
+        // Profile.typeId is a required FK, so resolve (or seed) the canonical
+        // 'person' type before creating the profile — otherwise `.save()`
+        // fails required-field validation. Mirrors createProfileFromNostr /
+        // createProfileFromOidc in resolveIdentity.ts.
+        const typeCollection = await ProfileTypeCollection.create({ db });
+        let personType = await typeCollection.getBySlug('person');
+        if (!personType) {
+          const { ProfileType } = await import('../models/ProfileType');
+          personType = new ProfileType({
+            db,
+            slug: 'person',
+            name: 'Person',
+            description: 'Individual person profile',
+          });
+          await personType.initialize();
+          await personType.save();
+        }
 
         // Create a new profile for this user (Person is an STI subclass of Profile)
         profile = new Person({
           db,
+          typeId: personType.id as string,
           email: normalizedEmail,
           name: normalizedEmail.split('@')[0], // Default name from email
         });

--- a/packages/profiles/src/models/Profile.ts
+++ b/packages/profiles/src/models/Profile.ts
@@ -335,14 +335,20 @@ export class Profile extends SmrtObject {
         contextProfileId: contextProfile?.id,
       });
       await relationship.save();
-    }
 
-    // Handle reciprocal relationships
-    if (relationshipType.reciprocal) {
-      const handler =
-        ProfileRelationshipType.getReciprocalHandler(relationshipSlug);
-      if (handler) {
-        await handler(this, toProfile, contextProfile);
+      // Handle reciprocal relationships. A reciprocal handler creates the
+      // inverse edge by calling addRelationship() back on `toProfile`. Gating
+      // this on `!exists` is what terminates the recursion: the inverse call
+      // creates its own edge and re-enters, but by then the original edge
+      // already exists, so the handler is skipped and the cycle stops. Firing
+      // it unconditionally instead recurses forever (the bundled friend /
+      // spouse / partner / colleague / sibling handlers all call back here).
+      if (relationshipType.reciprocal) {
+        const handler =
+          ProfileRelationshipType.getReciprocalHandler(relationshipSlug);
+        if (handler) {
+          await handler(this, toProfile, contextProfile);
+        }
       }
     }
   }


### PR DESCRIPTION
## Why

The #1600 tenant-global query sweep (PR #1603) touches `@happyvertical/smrt-profiles`. The CI **Coverage Gate** (`scripts/check-coverage.mjs`, per-tier floors, **no grandfathering**) was failing because profiles measured **38.37%** lines, below its **T2 70%** floor (real pre-existing debt: ~34 source files, ~6 test files).

This PR targets `fix/issue-1600-tenant-global-query-sweep` so that, once merged into it, the profiles Coverage Gate on #1603 passes — and it fixes two latent defects surfaced while writing the tests.

## Coverage uplift (tests only)

Added **7 test files** (real in-memory/file SQLite, no DB mocking, per `.claude/rules/testing.md`):

| File | Covers |
|------|--------|
| `api-keys.test.ts` | `ApiKey` model, `ApiKeyCollection`, `Profile` key helpers |
| `audit-log.test.ts` | `AuditLog` model, `AuditLogCollection`, `Profile.recordAction`/`getAuditLogs` |
| `profile-metadata.test.ts` | `ProfileMetafield.validateValue` (all branches), `ProfileMetadata`, both collections, `Profile` metadata helpers |
| `profile-relationships.test.ts` | relationship graph, terms, types, all three collections, `ProfileCollection` network helpers |
| `magic-link-service.test.ts` | `createMagicLinkService` initiate/verify flows, `MagicLinkTokenCollection` lifecycle/rate-limit helpers |
| `resolve-identity.test.ts` | every `resolveIdentity` branch (api_key/oidc/nostr/actor/none), `createProfileFromNostr`, `OidcIdentity` model + collection |
| `profile-collection.test.ts` | `ProfileCollection` query/batch helpers, `Profile` type/identity-linking methods, `NostrIdentityCollection` helpers |

## Fixes (2 latent defects found while testing)

**1. `fix(profiles): seed person type when magic link creates a new user`**
`createMagicLinkService().initiate()` built a `Person` with no `typeId` and saved it, failing Profile's required-FK validation — so **first-time magic link sign-in always threw**. The path had no prior coverage. Now resolves/seeds the canonical `person` ProfileType first (mirrors `createProfileFromNostr`/`createProfileFromOidc`). Regression test exercises the new-user branch end-to-end.

**2. `fix(profiles): stop reciprocal addRelationship from recursing forever`**
`Profile.addRelationship()` fired the reciprocal handler unconditionally, even when the forward edge already existed. The bundled `friend`/`spouse`/`partner`/`colleague`/`sibling` handlers call `addRelationship()` back on the target, so two profiles **recursed into each other without end**. Now gated on `!exists`, which terminates with exactly the two reciprocal edges. Regression test drives the bundled `friend` handler (with a fail-fast timeout).

Both are non-breaking bug fixes (previously-broken paths now work).

## Result

```
$ node scripts/check-coverage.mjs --packages profiles
  ✓ profiles (T2): 95.63% (floor 70%)
✓ coverage-gate: 1 package(s) at or above tier floor.
```

`38.37% → 95.63%` lines, **168 profiles tests pass**. Source changes are isolated to profiles internals — no other package's source or tests reference the changed methods. This unblocks the #1603 coverage gate for profiles.