### PR TITLE
refactor(social): adopt Button primitive, flip social/subscriptions strict (#1589)

### DIFF
--- a/packages/smrt-ui/src/components/ui/Button.svelte
+++ b/packages/smrt-ui/src/components/ui/Button.svelte
@@ -54,6 +54,12 @@ const {
   class: className = '',
   onclick,
   children,
+  // Anchor-mode attributes pulled out of `rest` so they are only ever applied
+  // in link mode below — in button mode they are dropped, matching the doc and
+  // avoiding invalid `<button target=...>` HTML (PR #1608 review).
+  target,
+  rel,
+  download,
   ...rest
 }: Props = $props();
 
@@ -95,6 +101,9 @@ const linkProps = $derived(() => {
 {#if isLink}
   <a
     href={isDisabled ? undefined : href}
+    {target}
+    {rel}
+    {download}
     class="button {variant} {size} {className}"
     class:disabled={isDisabled}
     class:full-width={fullWidth}

--- a/packages/smrt-ui/src/components/ui/Button.svelte
+++ b/packages/smrt-ui/src/components/ui/Button.svelte
@@ -32,6 +32,15 @@ export interface Props extends Omit<HTMLButtonAttributes, 'class' | 'href'> {
    * own CSS (issue #1589) — the base button styling still applies.
    */
   class?: string;
+  /**
+   * Anchor-mode attributes (link mode only, i.e. when `href` is set). The
+   * component already spreads these onto the rendered `<a>`; they are declared
+   * here so callers migrating an external `<a target="_blank" rel="...">` to
+   * Button (issue #1589) keep them type-checked. Ignored in button mode.
+   */
+  target?: HTMLAnchorAttributes['target'];
+  rel?: HTMLAnchorAttributes['rel'];
+  download?: HTMLAnchorAttributes['download'];
 }
 
 const {

--- a/packages/smrt-ui/src/components/ui/__tests__/Button.test.ts
+++ b/packages/smrt-ui/src/components/ui/__tests__/Button.test.ts
@@ -93,6 +93,22 @@ describe('Button', () => {
     expect(link).toHaveClass('button');
   });
 
+  it('passes target/rel through to the anchor in link mode (#1589)', () => {
+    // External links migrated from `<a target="_blank" rel="...">` to Button
+    // must keep their new-tab + opener-isolation semantics on the rendered <a>.
+    render(Button, {
+      props: {
+        children: textSnippet('Open'),
+        href: 'https://example.com',
+        target: '_blank',
+        rel: 'noreferrer',
+      },
+    });
+    const link = screen.getByRole('link', { name: 'Open' });
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noreferrer');
+  });
+
   it('is not navigable when disabled in link mode', async () => {
     const { container } = render(Button, {
       props: { children: textSnippet('Home'), href: '/home', disabled: true },

--- a/packages/smrt-ui/src/components/ui/__tests__/Button.test.ts
+++ b/packages/smrt-ui/src/components/ui/__tests__/Button.test.ts
@@ -109,6 +109,22 @@ describe('Button', () => {
     expect(link).toHaveAttribute('rel', 'noreferrer');
   });
 
+  it('drops anchor-only attrs in button mode (no invalid <button target>) (#1608)', () => {
+    // In button mode the anchor-only props must NOT reach the <button> — they
+    // are pulled out of `rest` so the runtime matches the "ignored in button
+    // mode" doc and never emits invalid HTML.
+    render(Button, {
+      props: {
+        children: textSnippet('Save'),
+        target: '_blank',
+        rel: 'noreferrer',
+      },
+    });
+    const button = screen.getByRole('button', { name: 'Save' });
+    expect(button).not.toHaveAttribute('target');
+    expect(button).not.toHaveAttribute('rel');
+  });
+
   it('is not navigable when disabled in link mode', async () => {
     const { container } = render(Button, {
       props: { children: textSnippet('Home'), href: '/home', disabled: true },

--- a/packages/social/src/svelte/components/SocialAccountSettings.svelte
+++ b/packages/social/src/svelte/components/SocialAccountSettings.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { SocialPlatformType } from '../../social-account.js';
 import { M } from '../i18n.js';
 import type { SocialAccountSettingsItem } from '../types.js';
@@ -46,7 +47,7 @@ function statusLabel(account: SocialAccountSettingsItem): string {
       <p>{accounts.length === 1 ? t(M['social.account_settings.configured_one'], { count: accounts.length }) : t(M['social.account_settings.configured_other'], { count: accounts.length })}</p>
     </div>
     {#if onRefresh}
-      <button type="button" class="secondary" onclick={() => onRefresh?.()} disabled={loading}>Refresh</button>
+      <Button variant="secondary" onclick={() => onRefresh?.()} disabled={loading}>Refresh</Button>
     {/if}
   </header>
 
@@ -54,9 +55,9 @@ function statusLabel(account: SocialAccountSettingsItem): string {
     <div class="connect-row" aria-label={t(M['social.account_settings.connect_aria'])}>
       {#each platforms as item}
         {#if connectHrefs[item.platform]}
-          <a class="connect-button" href={connectHrefs[item.platform]}>{item.label}</a>
+          <Button variant="primary" href={connectHrefs[item.platform]}>{item.label}</Button>
         {:else}
-          <button type="button" class="connect-button" disabled>{item.label}</button>
+          <Button variant="primary" disabled>{item.label}</Button>
         {/if}
       {/each}
     </div>
@@ -92,13 +93,13 @@ function statusLabel(account: SocialAccountSettingsItem): string {
           <div class="account-actions">
             <span class:attention={account.needsAttention} class="status">{statusLabel(account)}</span>
             {#if account.platformUrl}
-              <a class="secondary" href={account.platformUrl} target="_blank" rel="noreferrer">Open</a>
+              <Button variant="secondary" href={account.platformUrl} target="_blank" rel="noreferrer">Open</Button>
             {/if}
             {#if onTest}
-              <button type="button" class="secondary" onclick={() => onTest?.(account)}>Test</button>
+              <Button variant="secondary" onclick={() => onTest?.(account)}>Test</Button>
             {/if}
             {#if !readonly && onDeactivate && account.isActive}
-              <button type="button" class="danger" onclick={() => onDeactivate?.(account)}>Deactivate</button>
+              <Button variant="danger" onclick={() => onDeactivate?.(account)}>Deactivate</Button>
             {/if}
           </div>
         </article>
@@ -187,39 +188,6 @@ function statusLabel(account: SocialAccountSettingsItem): string {
     justify-content: flex-end;
     flex-wrap: wrap;
     gap: 0.5rem;
-  }
-
-  button,
-  a {
-    border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
-    border-radius: var(--smrt-radius-md, 8px);
-    background: var(--smrt-color-surface, #fff);
-    color: var(--smrt-color-on-surface, #111827);
-    cursor: pointer;
-    font: inherit;
-    font-size: var(--smrt-typography-label-large-size, 0.82rem);
-    line-height: 1;
-    padding: 0.55rem 0.7rem;
-    text-decoration: none;
-  }
-
-  button:disabled {
-    cursor: not-allowed;
-    opacity: 0.55;
-  }
-
-  .connect-button {
-    background: var(--smrt-color-primary, #2563eb);
-    border-color: var(--smrt-color-primary, #2563eb);
-    color: var(--smrt-color-on-primary, #fff);
-  }
-
-  .secondary {
-    background: var(--smrt-color-surface-container, #f3f4f6);
-  }
-
-  .danger {
-    color: var(--smrt-color-error, #b91c1c);
   }
 
   .empty {

--- a/packages/subscriptions/src/svelte/PlanPicker.svelte
+++ b/packages/subscriptions/src/svelte/PlanPicker.svelte
@@ -14,6 +14,7 @@ let {
 
 <div class="smrt-plan-picker">
   {#each plans as plan (plan.id)}
+    <!-- raw-primitive-allow: pressable selection card (aria-pressed toggle with multi-line plan summary), not a standard action button -->
     <button
       aria-pressed={plan.planKey === selectedPlanKey}
       class:selected={plan.planKey === selectedPlanKey}

--- a/scripts/check-raw-primitives.mjs
+++ b/scripts/check-raw-primitives.mjs
@@ -53,7 +53,7 @@ const PACKAGES = join(ROOT, 'packages');
  * Packages held to ERROR. Everything else is report-only for now (#1589 Wave 0
  * establishes the baseline; later waves flip packages strict as they migrate).
  */
-const STRICT_PACKAGES = new Set([]);
+const STRICT_PACKAGES = new Set(['subscriptions', 'social']);
 
 /**
  * Packages skipped entirely — dev/playground hosts, not shippable product


### PR DESCRIPTION
## Summary

First per-package wave of the **#1589** raw-primitive migration — and the end-to-end **shake-out** that validates the recipe before fanning out the remaining ~12 packages. Migrates the two smallest UI packages and flips them strict in the ratchet.

- **`social` — `SocialAccountSettings.svelte`**: the 4 raw `<button>`s (Refresh / connect / Test / Deactivate) and their 2 sibling `<a>` links (connect / Open) all become `<Button>` — variant buttons for actions, `href` link-mode for the connect links and the external "Open" link (`target="_blank" rel="noreferrer"` preserved). Because the buttons and links shared one `button, a {}` CSS rule, migrating the whole cluster together keeps them visually consistent. The now-dead local `button, a {}` / `.secondary` / `.danger` / `.connect-button` rules are deleted.
- **`subscriptions` — `PlanPicker.svelte`**: its one `<button>` is a pressable plan-**selection card** (`aria-pressed` toggle wrapping a multi-line plan summary), not a standard action button — annotated `<!-- raw-primitive-allow: … -->` rather than forced onto `Button`.
- **`smrt-ui` — `Button.svelte`**: widen `Props` to type the anchor-mode passthrough attributes (`target` / `rel` / `download`). The component already spread these onto the rendered `<a>`; only the type was too narrow, which blocked migrating external `<a target="_blank">` links. Added a regression test asserting they reach the `<a>`. This unblocks the same pattern across every later package.
- **`scripts/check-raw-primitives.mjs`**: `subscriptions` + `social` added to `STRICT_PACKAGES`.

Report-only raw-element count drops 554 → 549.

## Verification (all green, run locally)

- `node scripts/check-raw-primitives.mjs` → 0 (both packages strict & clean)
- `pnpm --filter @happyvertical/smrt-{social,subscriptions,ui} typecheck` → 0 errors (tsc + svelte-check a11y)
- `pnpm --filter @happyvertical/smrt-{social,subscriptions,ui} test` → green (social 21, subscriptions 44, smrt-ui 406 incl. new Button target/rel test)
- `node scripts/check-package-dag.mjs` + `check-no-smrt-peers.mjs` → 0
- `biome check` (read-only) on changed files → clean
- `pnpm knowledge:check --changed --strict` → fresh; `gitleaks` → no leaks

No behavior/a11y change beyond the intended canonical-Button look: handlers, `disabled`, `type`, `aria-*`, and the external-link new-tab semantics are all preserved.

Part of #1589.
