### PR TITLE
refactor(scripts): derive raw-primitive strict set from per-package flag (#1589)

### DIFF
--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -2,6 +2,7 @@
   "name": "@happyvertical/smrt-social",
   "version": "0.34.1",
   "type": "module",
+  "smrtRawPrimitives": "strict",
   "description": "Social media account management for multi-platform publishing in the SMRT ecosystem",
   "author": "HappyVertical",
   "license": "MIT",

--- a/packages/subscriptions/package.json
+++ b/packages/subscriptions/package.json
@@ -3,6 +3,7 @@
   "version": "0.34.1",
   "description": "Tenant subscriptions, entitlement resolution, usage thresholds, and subscription UI for SMRT",
   "type": "module",
+  "smrtRawPrimitives": "strict",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/scripts/check-raw-primitives.mjs
+++ b/scripts/check-raw-primitives.mjs
@@ -73,6 +73,9 @@ function readStrictPackages() {
   } catch {
     return strict;
   }
+  // Sort so the derived set's iteration order (and thus the printed strict-list)
+  // is deterministic — `readdirSync` order is not guaranteed across OS/filesystems.
+  entries.sort((a, b) => a.name.localeCompare(b.name));
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
     let pkgJson;

--- a/scripts/check-raw-primitives.mjs
+++ b/scripts/check-raw-primitives.mjs
@@ -21,8 +21,11 @@
  *
  * Phased rollout (Wave 0 = this baseline):
  *   - Every package is REPORT-ONLY (warn): occurrences are listed but do not
- *     fail. Packages migrate in Waves 1-5 of #1589; flipping a package to strict
- *     means adding it to STRICT_PACKAGES once it is clean.
+ *     fail. Packages migrate in Waves 1-5 of #1589; a package opts into STRICT
+ *     enforcement once it is clean by declaring `"smrtRawPrimitives": "strict"`
+ *     in ITS OWN package.json (read below). This per-package flag — rather than a
+ *     central allowlist in this file — keeps each migration PR touching only its
+ *     own package, so concurrent #1589 PRs never conflict on a shared line.
  *
  * What is allowed (never flagged):
  *   - PRIMITIVE-SOURCE files (PRIMITIVE_SOURCE_FRAGMENTS): smrt-ui's own
@@ -50,10 +53,42 @@ const ROOT = resolve(import.meta.dirname, '..');
 const PACKAGES = join(ROOT, 'packages');
 
 /**
- * Packages held to ERROR. Everything else is report-only for now (#1589 Wave 0
- * establishes the baseline; later waves flip packages strict as they migrate).
+ * Packages held to ERROR. A package opts in by declaring
+ * `"smrtRawPrimitives": "strict"` in its own package.json — so the strict list
+ * is DERIVED from the per-package flags rather than maintained centrally here.
+ * Everything without the flag stays report-only (#1589 Wave 0 baseline; later
+ * waves flip packages strict in their own migration PR as they go clean).
+ *
+ * Why per-package instead of a central Set: every #1589 migration PR would
+ * otherwise edit this one line, so two PRs branched from a `main` lacking each
+ * other's entry 3-way-conflict on it. Reading the flag from each package's own
+ * package.json keeps every PR's footprint inside its own package, so they merge
+ * independently in any order.
  */
-const STRICT_PACKAGES = new Set(['subscriptions', 'social']);
+function readStrictPackages() {
+  const strict = new Set();
+  let entries;
+  try {
+    entries = readdirSync(PACKAGES, { withFileTypes: true });
+  } catch {
+    return strict;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    let pkgJson;
+    try {
+      pkgJson = JSON.parse(
+        readFileSync(join(PACKAGES, entry.name, 'package.json'), 'utf8'),
+      );
+    } catch {
+      continue; // no/invalid package.json — not a publishable package
+    }
+    if (pkgJson.smrtRawPrimitives === 'strict') strict.add(entry.name);
+  }
+  return strict;
+}
+
+const STRICT_PACKAGES = readStrictPackages();
 
 /**
  * Packages skipped entirely — dev/playground hosts, not shippable product


### PR DESCRIPTION
## Summary

Infrastructure change that makes the remaining ~14 **#1589** per-package migration PRs **independently mergeable** (no shared-line conflicts), now that "require branches up to date" is off.

### Problem
The raw-primitive ratchet held its strict list in a central `STRICT_PACKAGES` Set inside `scripts/check-raw-primitives.mjs`. Every migration PR flips its package strict by editing that one line, so two PRs branched from a `main` that lacks each other's entry **3-way-conflict** on it — and GitHub blocks a conflicting merge even without the up-to-date requirement. That re-serializes the whole wave for no real reason.

### Fix
Derive the strict set from a **per-package opt-in**: a package declares `"smrtRawPrimitives": "strict"` in its **own** `package.json`, and the ratchet scans each package.json for the flag. Each migration PR now only touches its own package's files, so the remaining PRs merge in any order with zero shared-file conflicts.

- `scripts/check-raw-primitives.mjs`: `STRICT_PACKAGES` is now computed by `readStrictPackages()` (scans `packages/*/package.json` for the flag) instead of a hand-maintained literal. All downstream logic is unchanged (it still consumes a `Set`).
- `subscriptions` + `social` (the two already-strict packages from #1608) move onto the flag.

### Why this field name
`smrt-config` uses cosmiconfig with module name `smrt`, i.e. it reads the `smrt` **key** from package.json. The flag is `smrtRawPrimitives` (a distinct key), so it does **not** pollute runtime SMRT config.

## Verification (local)
- `node scripts/check-raw-primitives.mjs` → exit 0; reports `social, subscriptions` strict & clean (read from the flags).
- **Negative test**: temporarily setting `"smrtRawPrimitives": "strict"` on `jobs` (which still has 4 raw inputs) makes the ratchet exit **1** — the flag is honored both ways.
- `check-package-dag.mjs` + `check-no-smrt-peers.mjs` → 0; `pnpm knowledge:check --changed --strict` → fresh; full `npm run build` → green (the custom package.json field is inert for build/publish; npm ignores unknown keys).
- biome doesn't lint `.mjs`/`package.json` (its `includes` cover `scripts/**/*.{js,ts}` only), so these files are out of its surface — no lint delta.

Scoped to the raw-primitive ratchet only; the other token ratchets (radius/spacing/color/…) keep their central sets (not part of an active per-package migration wave).

Part of #1589.
