### PR TITLE
refactor(tenancy): adopt Button primitive, flip tenancy strict (#1589)

### DIFF
--- a/packages/tenancy/package.json
+++ b/packages/tenancy/package.json
@@ -3,6 +3,7 @@
   "version": "0.34.2",
   "description": "Production-ready multi-tenancy framework for SMRT with automatic tenant isolation and enforcement",
   "type": "module",
+  "smrtRawPrimitives": "strict",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/tenancy/src/svelte/components/TenantCard.svelte
+++ b/packages/tenancy/src/svelte/components/TenantCard.svelte
@@ -7,6 +7,7 @@
 import type { Tenant } from '@happyvertical/smrt-types';
 import { Icon, ripple } from '@happyvertical/smrt-ui';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
 
 export interface Props {
@@ -107,26 +108,24 @@ function getColor(name: string): string {
   {#if actions && (onedit || ondelete)}
     <div class="actions">
       {#if onedit}
-        <button 
-          type="button" 
-          class="action-btn" 
+        <Button
+          variant="ghost"
+          class="action-btn"
           onclick={(event: MouseEvent) => { event.stopPropagation(); onedit?.(); }}
-          use:ripple
           aria-label={t(M['tenancy.tenant_card.edit'])}
         >
           <Icon name="menu" size={18} />
-        </button>
+        </Button>
       {/if}
       {#if ondelete}
-        <button 
-          type="button" 
-          class="action-btn danger" 
+        <Button
+          variant="ghost"
+          class="action-btn action-btn--danger"
           onclick={(event: MouseEvent) => { event.stopPropagation(); ondelete?.(); }}
-          use:ripple
           aria-label={t(M['tenancy.tenant_card.delete'])}
         >
           <Icon name="close" size={18} />
-        </button>
+        </Button>
       {/if}
     </div>
   {/if}
@@ -246,27 +245,26 @@ function getColor(name: string): string {
     flex-shrink: 0;
   }
 
-  .action-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  /*
+   * The action buttons now render through smrt-ui's <Button variant="ghost">.
+   * Svelte scopes `.action-btn` to this component, but the <button> is emitted
+   * inside the Button child, so a plain `.action-btn {}` rule would not match —
+   * `.actions :global(.action-btn)` keeps the scope anchor on `.actions` (a real
+   * element here) and pierces into the child (issue #1589). These override only
+   * sizing/shape/color (higher specificity than Button's base rules); ghost owns
+   * the transparent background + hover layer. The delete button's modifier class
+   * is `action-btn--danger`, NOT `danger`, so it never collides with Button's own
+   * `.danger` variant class (which would otherwise apply the red-filled variant).
+   */
+  .actions :global(.action-btn) {
     width: 32px;
     height: 32px;
-    background: transparent;
-    border: none;
+    padding: 0;
     border-radius: var(--smrt-radius-full, 9999px);
-    cursor: pointer;
     color: var(--smrt-color-on-surface-variant);
-    position: relative;
-    overflow: hidden;
   }
 
-  .action-btn:hover {
-    background-color: var(--smrt-color-surface-container-highest);
-    color: var(--smrt-color-on-surface);
-  }
-
-  .action-btn.danger:hover {
+  .actions :global(.action-btn--danger):hover {
     color: var(--smrt-color-error);
   }
 </style>

--- a/packages/tenancy/src/svelte/components/TenantSwitcher.svelte
+++ b/packages/tenancy/src/svelte/components/TenantSwitcher.svelte
@@ -22,6 +22,7 @@ function handleChange(event: Event) {
   {#if memberships.length <= 1}
     <span class="tenant-name">{currentTenant?.name ?? 'Unknown'}</span>
   {:else}
+    <!-- raw-primitive-allow: the Select form primitive lives in @happyvertical/smrt-svelte, which transitively depends on smrt-tenancy (smrt-svelte to smrt-languages to smrt-tenancy), so importing it would create a DAG cycle (#1582); the native select element retains full keyboard/AT a11y -->
     <select value={currentTenantId} onchange={handleChange} class="tenant-select">
       {#each memberships as membership}
         {#if membership.tenantId}


### PR DESCRIPTION
## Summary

#1589 migration for **tenancy** — adopt the shared Button primitive and flip the package strict.

- **`TenantCard.svelte`** — the two icon action buttons (edit / delete) become `<Button variant="ghost">`. The custom `.action-btn` sizing/shape/color CSS is re-expressed as `.actions :global(.action-btn)` so it pierces Svelte's component scoping into the `<button>` the Button child renders (a plain scoped `.action-btn {}` would *not* match that element — it lacks the parent's scope hash). Sizing/color overrides out-specify Button's base rules; ghost owns the hover background; the red delete-hover is kept as a color override (ghost's hover only sets background, so no conflict). The card-level `use:ripple` stays; the per-button ripple is dropped (Svelte actions can't apply to a component) — a minor visual change.
- **`TenantSwitcher.svelte`** — the `<select>` is **escape-hatched**, not migrated: the `Select` form primitive lives in `@happyvertical/smrt-svelte`, which transitively depends on `smrt-tenancy` (`smrt-svelte → smrt-languages → smrt-tenancy`), so importing it would close a DAG cycle (#1582). `node scripts/check-package-dag.mjs` confirms. The native `<select>` keeps full keyboard/AT a11y.
- **`package.json`** — opt into strict enforcement via the per-package `"smrtRawPrimitives": "strict"` flag (the mechanism from #1609).

## Verification (local, all green)
- `node scripts/check-raw-primitives.mjs` → exit 0 (tenancy strict & clean; one annotated escape-hatch).
- `pnpm --filter @happyvertical/smrt-tenancy typecheck` → 0 errors (tsc + svelte-check a11y).
- `pnpm --filter @happyvertical/smrt-tenancy test` → 123 passed.
- `check-package-dag.mjs` + `check-no-smrt-peers.mjs` → 0; `biome check` (read-only) on changed files → clean.
- Scope-checked: only tenancy's own files; ratchet script untouched (per-package flag).

Part of #1589.
