### PR TITLE
refactor(jobs): adopt Button primitive, flip jobs strict (#1589)

### DIFF
--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -4,6 +4,7 @@
   "description": "Background job processing for SMRT objects with persistence and scheduling",
   "author": "HappyVertical",
   "type": "module",
+  "smrtRawPrimitives": "strict",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/jobs/src/svelte/components/JobDashboard.svelte
+++ b/packages/jobs/src/svelte/components/JobDashboard.svelte
@@ -4,7 +4,7 @@
  */
 
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
-import { Card } from '@happyvertical/smrt-ui/ui';
+import { Button, Card } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
 import JobList from './JobList.svelte';
 import JobStatsSummary from './JobStats.svelte';
@@ -63,7 +63,7 @@ let {
           <div class="panel-header">
             <h2>{t(M['jobs.job_dashboard.recent_jobs'])}</h2>
             {#if onViewAll}
-              <button class="view-all-btn" onclick={onViewAll}>{t(M['jobs.job_dashboard.view_all'])}</button>
+              <Button variant="ghost" size="sm" onclick={onViewAll}>{t(M['jobs.job_dashboard.view_all'])}</Button>
             {/if}
           </div>
         {/snippet}
@@ -89,9 +89,9 @@ let {
             <div class="panel-header panel-header--error">
               <h2>{t(M['jobs.job_dashboard.failed_jobs'])}</h2>
               {#if onViewFailed}
-                <button class="view-all-btn" onclick={onViewFailed}
-                  >{t(M['jobs.job_dashboard.view_all_count'], { count: stats.failed })}</button
-                >
+                <Button variant="ghost" size="sm" onclick={onViewFailed}>
+                  {t(M['jobs.job_dashboard.view_all_count'], { count: stats.failed })}
+                </Button>
               {/if}
             </div>
           {/snippet}
@@ -166,21 +166,6 @@ let {
     color: var(--smrt-color-error, #ba1a1a);
   }
 
-  .view-all-btn {
-    padding: var(--smrt-spacing-xs, 0.25rem) var(--smrt-spacing-sm, 0.5rem);
-    border: none;
-    background: none;
-    color: var(--smrt-color-primary, #005ac1);
-    font: var(--smrt-typography-label-large-font, 500 0.875rem / 1.25 sans-serif);
-    cursor: pointer;
-    border-radius: var(--smrt-radius-small, 0.25rem);
-    transition: background-color var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
-  }
-
-  .view-all-btn:hover {
-    background: var(--smrt-color-primary-container, #d6e3ff);
-  }
-
   .empty-message {
     padding: var(--smrt-spacing-md, 1rem);
     text-align: center;
@@ -191,9 +176,4 @@ let {
     color: var(--smrt-color-tertiary, #006c4f);
   }
 
-  @media (prefers-reduced-motion: reduce) {
-    .view-all-btn {
-      transition: none;
-    }
-  }
 </style>

--- a/packages/jobs/src/svelte/components/JobList.svelte
+++ b/packages/jobs/src/svelte/components/JobList.svelte
@@ -111,6 +111,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
       <tr>
         {#if selectable}
           <th class="job-list__cell job-list__cell--checkbox">
+            <!-- raw-primitive-allow: the CheckboxInput form primitive lives in @happyvertical/smrt-svelte, which transitively depends on smrt-jobs (smrt-svelte to smrt-languages to smrt-jobs), so importing it would close a DAG cycle (#1582); this select-all control also needs the use:setIndeterminate action, which cannot be applied to a component -->
             <input
               type="checkbox"
               checked={allSelected}
@@ -171,6 +172,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
           >
             {#if selectable}
               <td class="job-list__cell job-list__cell--checkbox">
+                <!-- raw-primitive-allow: the CheckboxInput form primitive lives in @happyvertical/smrt-svelte, which transitively depends on smrt-jobs (smrt-svelte to smrt-languages to smrt-jobs), so importing it would close a DAG cycle (#1582); native checkbox keeps full keyboard/AT a11y -->
                 <input
                   type="checkbox"
                   checked={isSelected}


### PR DESCRIPTION
## Summary

#1589 migration for **jobs** — adopt the shared Button primitive and flip the package strict.

- **`JobDashboard.svelte`** — the two "view all" text buttons become `<Button variant="ghost" size="sm">`. The ghost variant (transparent background, primary-colored text, primary-container hover) matches the old `.view-all-btn` look, so that local CSS is deleted.
- **`JobList.svelte`** — the two table checkboxes (select-all header + per-row) are **escape-hatched**, not migrated: the `CheckboxInput` form primitive lives in `@happyvertical/smrt-svelte`, which transitively depends on `smrt-jobs` (`smrt-svelte → smrt-languages → smrt-jobs`), so importing it would close a DAG cycle (#1582). The select-all checkbox additionally relies on the `use:setIndeterminate` action, which can't apply to a component. Native checkboxes keep full keyboard/AT a11y.
- **`package.json`** — opt into strict via the per-package `"smrtRawPrimitives": "strict"` flag.

## Verification (local, all green)
- `node scripts/check-raw-primitives.mjs` → exit 0 (jobs strict & clean; two annotated escape-hatches).
- `pnpm --filter @happyvertical/smrt-jobs typecheck` → 0 errors; `test` → 108 passed.
- `check-package-dag.mjs` + `check-no-smrt-peers.mjs` → 0; `biome check` (read-only) → clean.
- Scope-checked: only jobs' own files.

Part of #1589.
