### PR TITLE
refactor(commerce): adopt Button primitive, flip commerce strict (#1589)

### DIFF
--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -3,6 +3,7 @@
   "version": "0.34.2",
   "description": "Commerce models for the SMRT framework - contracts, fulfillments, payments",
   "type": "module",
+  "smrtRawPrimitives": "strict",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/commerce/src/svelte/components/InvoiceActions.svelte
+++ b/packages/commerce/src/svelte/components/InvoiceActions.svelte
@@ -6,6 +6,7 @@
  */
 
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
 import type { InvoiceStatus } from '../types.js';
 
@@ -54,61 +55,61 @@ const canMarkPaid = $derived(
 const canDelete = $derived(status === 'draft');
 </script>
 
-<div class="invoice-actions" class:sm={size === 'sm'}>
+<div class="invoice-actions">
   {#if canSend && onsend}
-    <button type="button" class="btn btn-primary" onclick={onsend} disabled={loading}>
+    <Button variant="primary" {size} onclick={onsend} disabled={loading}>
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
         <path d="M14 2L7 9M14 2l-4 12-3-5-5-3 12-4z" />
       </svg>
       {t(M['commerce.invoice_actions.send_invoice'])}
-    </button>
+    </Button>
   {/if}
 
   {#if canMarkPaid && onmarkpaid}
-    <button type="button" class="btn btn-success" onclick={onmarkpaid} disabled={loading}>
+    <Button variant="primary" {size} onclick={onmarkpaid} disabled={loading}>
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2">
         <path d="M3 8l4 4 6-8" />
       </svg>
       {t(M['commerce.invoice_actions.mark_as_paid'])}
-    </button>
+    </Button>
   {/if}
 
   {#if canEdit && onedit}
-    <button type="button" class="btn btn-secondary" onclick={onedit} disabled={loading}>
+    <Button variant="secondary" {size} onclick={onedit} disabled={loading}>
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
         <path d="M11.5 2.5l2 2-8 8H3.5v-2l8-8z" />
       </svg>
       Edit
-    </button>
+    </Button>
   {/if}
 
   {#if onprint}
-    <button type="button" class="btn btn-secondary" onclick={onprint} disabled={loading}>
+    <Button variant="secondary" {size} onclick={onprint} disabled={loading}>
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
         <path d="M4 5V2h8v3M4 11h8M2 5h12v6H2z" />
         <path d="M4 11v3h8v-3" />
       </svg>
       Print
-    </button>
+    </Button>
   {/if}
 
   {#if onexport}
-    <button type="button" class="btn btn-secondary" onclick={onexport} disabled={loading}>
+    <Button variant="secondary" {size} onclick={onexport} disabled={loading}>
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
         <path d="M8 2v8M4 6l4-4 4 4M2 12v2h12v-2" />
       </svg>
       Export
-    </button>
+    </Button>
   {/if}
 
   {#if canDelete && ondelete}
-    <button type="button" class="btn btn-danger" onclick={ondelete} disabled={loading}>
+    <Button variant="danger" {size} onclick={ondelete} disabled={loading}>
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
         <path d="M3 4h10M5 4V3a1 1 0 011-1h4a1 1 0 011 1v1M6 7v5M10 7v5" />
         <path d="M4 4l1 10h6l1-10" />
       </svg>
       Delete
-    </button>
+    </Button>
   {/if}
 </div>
 
@@ -117,75 +118,5 @@ const canDelete = $derived(status === 'draft');
     display: flex;
     gap: var(--smrt-spacing-2, 0.5rem);
     flex-wrap: wrap;
-  }
-
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--smrt-spacing-2, 0.5rem);
-    padding: var(--smrt-spacing-2, 0.5rem) var(--smrt-spacing-4, 1rem);
-    font: var(--smrt-typography-label-large-font);
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    border: none;
-    border-radius: var(--smrt-radius-small, 0.375rem);
-    cursor: pointer;
-    transition: all var(--smrt-duration-fast, 150ms) var(--smrt-easing-standard, cubic-bezier(0.2, 0, 0, 1));
-    white-space: nowrap;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .btn {
-      transition: none;
-    }
-  }
-
-  .sm .btn {
-    padding: var(--smrt-spacing-1_5, 0.375rem) var(--smrt-spacing-3, 0.75rem);
-    font: var(--smrt-typography-label-medium-font);
-  }
-
-  .btn:disabled {
-    opacity: 0.38;
-    cursor: not-allowed;
-  }
-
-  .btn-primary {
-    background: var(--smrt-color-primary, #005ac1);
-    color: var(--smrt-color-on-primary, #ffffff);
-  }
-
-  .btn-primary:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--smrt-color-primary, #005ac1) 85%, var(--smrt-color-shadow, #000));
-  }
-
-  .btn-success {
-    background: var(--smrt-color-tertiary, #006c4c);
-    color: var(--smrt-color-on-tertiary, #ffffff);
-  }
-
-  .btn-success:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--smrt-color-tertiary, #006c4c) 85%, var(--smrt-color-shadow, #000));
-  }
-
-  .btn-secondary {
-    background: var(--smrt-color-surface-container-lowest, #ffffff);
-    color: var(--smrt-color-on-surface-variant, #44474e);
-    border: 1px solid var(--smrt-color-outline, #74777f);
-  }
-
-  .btn-secondary:hover:not(:disabled) {
-    background: var(--smrt-color-surface-container-low, #f7f2fa);
-    border-color: var(--smrt-color-on-surface-variant, #44474e);
-  }
-
-  .btn-danger {
-    background: var(--smrt-color-surface-container-lowest, #ffffff);
-    color: var(--smrt-color-error, #ba1a1a);
-    border: 1px solid var(--smrt-color-error-container, #ffdad6);
-  }
-
-  .btn-danger:hover:not(:disabled) {
-    background: var(--smrt-color-error-container, #ffdad6);
-    border-color: var(--smrt-color-error, #ba1a1a);
   }
 </style>

--- a/packages/commerce/src/svelte/components/InvoiceCard.svelte
+++ b/packages/commerce/src/svelte/components/InvoiceCard.svelte
@@ -99,6 +99,7 @@ const isOverdue = $derived.by(() => {
     </div>
   </a>
 {:else}
+  <!-- raw-primitive-allow: large pressable invoice card wrapping rich header/body/footer content with use:ripple, a structural selection control no Button primitive should own (mirrors the href anchor branch) -->
   <button type="button" class="invoice-card" onclick={onclick} use:ripple>
     <div class="card-header">
       <span class="invoice-number">{invoice.invoiceNumber}</span>

--- a/packages/commerce/src/svelte/components/InvoiceLineItems.svelte
+++ b/packages/commerce/src/svelte/components/InvoiceLineItems.svelte
@@ -7,6 +7,7 @@
  */
 
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { Snippet } from 'svelte';
 import { M } from '../i18n.js';
 import type { LineItem } from '../types.js';
@@ -70,9 +71,9 @@ const total = $derived(items.reduce((sum, item) => sum + item.amount, 0));
     <div class="empty-state">
       <p>{emptyMessage}</p>
       {#if editable && onadd}
-        <button type="button" class="add-btn" onclick={onadd}>
+        <Button variant="ghost" class="add-btn" onclick={onadd}>
           {t(M['commerce.invoice_line_items.add_item'])}
-        </button>
+        </Button>
       {/if}
     </div>
   {:else}
@@ -112,8 +113,8 @@ const total = $derived(items.reduce((sum, item) => sum + item.amount, 0));
             <td class="col-amount">{formatMoney(item.amount)}</td>
             {#if editable}
               <td class="col-actions">
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
                   class="action-btn delete"
                   title={t(M['commerce.invoice_line_items.remove_item'])}
                   onclick={() => ondelete?.(item.id)}
@@ -121,7 +122,7 @@ const total = $derived(items.reduce((sum, item) => sum + item.amount, 0));
                   <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2">
                     <path d="M4 4l8 8M4 12l8-8" />
                   </svg>
-                </button>
+                </Button>
               </td>
             {/if}
           </tr>
@@ -139,12 +140,12 @@ const total = $derived(items.reduce((sum, item) => sum + item.amount, 0));
     </table>
 
     {#if editable && onadd}
-      <button type="button" class="add-btn add-btn-below" onclick={onadd}>
+      <Button variant="ghost" class="add-btn add-btn-below" onclick={onadd}>
         <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2">
           <path d="M8 3v10M3 8h10" />
         </svg>
         {t(M['commerce.invoice_line_items.add_item'])}
-      </button>
+      </Button>
     {/if}
   {/if}
 </div>
@@ -262,7 +263,15 @@ const total = $derived(items.reduce((sum, item) => sum + item.amount, 0));
     color: var(--smrt-color-on-surface, #1c1b1f);
   }
 
-  .action-btn {
+  /*
+   * These rules style the <button> rendered *inside* the smrt-ui <Button>
+   * child component (issue #1589). A plain scoped `.action-btn {}` rule would
+   * not reach it (no parent scope hash), so each is written as
+   * `.line-items-container :global(.class)` — Svelte compiles the ancestor to
+   * `.line-items-container.svelte-HASH .class`, which pierces into the child.
+   * Overrides cover sizing/shape/color; the ghost variant owns the base.
+   */
+  .line-items-container :global(.action-btn) {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -271,28 +280,27 @@ const total = $derived(items.reduce((sum, item) => sum + item.amount, 0));
     background: transparent;
     border: none;
     border-radius: var(--smrt-radius-extra-small, 0.25rem);
-    cursor: pointer;
     color: var(--smrt-color-on-surface-variant, #49454f);
     transition: all var(--smrt-duration-fast, 150ms) var(--smrt-easing-standard, cubic-bezier(0.2, 0, 0, 1));
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .action-btn {
+    .line-items-container :global(.action-btn) {
       transition: none;
     }
   }
 
-  .action-btn:hover {
+  .line-items-container :global(.action-btn:hover) {
     background: var(--smrt-color-surface-variant, #e7e0ec);
     color: var(--smrt-color-on-surface, #1c1b1f);
   }
 
-  .action-btn.delete:hover {
+  .line-items-container :global(.action-btn.delete:hover) {
     background: var(--smrt-color-error-container, #ffdad6);
     color: var(--smrt-color-error, #ba1a1a);
   }
 
-  .add-btn {
+  .line-items-container :global(.add-btn) {
     display: inline-flex;
     align-items: center;
     gap: var(--smrt-spacing-2, 0.5rem);
@@ -303,21 +311,20 @@ const total = $derived(items.reduce((sum, item) => sum + item.amount, 0));
     background: transparent;
     border: 1px dashed var(--smrt-color-primary, #005ac1);
     border-radius: var(--smrt-radius-small, 0.375rem);
-    cursor: pointer;
     transition: all var(--smrt-duration-fast, 150ms) var(--smrt-easing-standard, cubic-bezier(0.2, 0, 0, 1));
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .add-btn {
+    .line-items-container :global(.add-btn) {
       transition: none;
     }
   }
 
-  .add-btn:hover {
+  .line-items-container :global(.add-btn:hover) {
     background: var(--smrt-color-primary-container, #d3e3fd);
   }
 
-  .add-btn-below {
+  .line-items-container :global(.add-btn-below) {
     margin-top: var(--smrt-spacing-3, 0.75rem);
   }
 </style>

--- a/packages/commerce/src/svelte/components/UnbilledItems.svelte
+++ b/packages/commerce/src/svelte/components/UnbilledItems.svelte
@@ -6,6 +6,7 @@
  */
 
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
 import type { UnbilledItem } from '../types.js';
 
@@ -105,6 +106,7 @@ const someSelected = $derived(
   {:else}
     <div class="items-header">
       <label class="select-all">
+        <!-- raw-primitive-allow: tri-state select-all checkbox needs the indeterminate flag for the some-but-not-all state; neither CheckboxInput nor Toggle exposes indeterminate, and a use action cannot be applied to a component -->
         <input
           type="checkbox"
           checked={allSelected}
@@ -121,6 +123,7 @@ const someSelected = $derived(
     <div class="items-list">
       {#each items as item (item.id)}
         <label class="item-row" class:selected={selectedIds.has(item.id)}>
+          <!-- raw-primitive-allow: native checkbox kept for visual + behavioral consistency with the indeterminate select-all checkbox above (which must stay native); the only checkbox primitive, CheckboxInput, also requires a smrt-svelte Provider in context, which this standalone presentational component does not assume -->
           <input
             type="checkbox"
             checked={selectedIds.has(item.id)}
@@ -150,13 +153,12 @@ const someSelected = $derived(
           <span class="summary-value">{formatMoney(selectedTotal)}</span>
         </div>
         {#if oncreate}
-          <button
-            type="button"
-            class="create-btn"
+          <Button
+            variant="primary"
             onclick={() => oncreate?.([...selectedIds])}
           >
             {t(M['commerce.unbilled_items.create_invoice'])}
-          </button>
+          </Button>
         {/if}
       </div>
     {/if}
@@ -328,29 +330,5 @@ const someSelected = $derived(
     font: var(--smrt-typography-title-large-font);
     font-weight: var(--smrt-typography-weight-semibold, 600);
     color: var(--smrt-color-on-surface, #1c1b1f);
-  }
-
-  .create-btn {
-    display: inline-flex;
-    align-items: center;
-    padding: var(--smrt-spacing-2, 0.5rem) var(--smrt-spacing-4, 1rem);
-    font: var(--smrt-typography-label-large-font);
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    color: var(--smrt-color-on-primary, #ffffff);
-    background: var(--smrt-color-primary, #005ac1);
-    border: none;
-    border-radius: var(--smrt-radius-small, 0.375rem);
-    cursor: pointer;
-    transition: background var(--smrt-duration-fast, 150ms) var(--smrt-easing-standard, cubic-bezier(0.2, 0, 0, 1));
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .create-btn {
-      transition: none;
-    }
-  }
-
-  .create-btn:hover {
-    background: color-mix(in srgb, var(--smrt-color-primary, #005ac1) 85%, var(--smrt-color-shadow, #000));
   }
 </style>


### PR DESCRIPTION
## Summary

#1589 migration for **commerce** — adopt the shared Button primitive and flip the package strict. commerce ends up **buttons-only** (no smrt-svelte form dependency).

- **`InvoiceActions.svelte`** — the 6 status buttons → `<Button>` variants (`btn-primary`/`btn-success` → `primary` (no success variant; never shown alongside Send, a canonical-look change), `btn-secondary` → `secondary`, `btn-danger` → `danger`). Inline `<svg>`+text kept as children; `onclick`/`disabled`/`size` preserved. All dead `.btn*` CSS deleted.
- **`InvoiceLineItems.svelte`** — add/remove buttons → `<Button variant="ghost">`. The custom `.add-btn`/`.action-btn` CSS is rescoped to `.line-items-container :global(.class)` so it pierces Svelte's scoping into the `<button>` the Button child renders (a plain scoped rule wouldn't match it).
- **`UnbilledItems.svelte`** — "create invoice" button → `<Button variant="primary">`. The two checkboxes stay **native + escape-hatched**: the select-all needs the native `indeterminate` tri-state, and the per-row checkboxes stay native for visual/behavioral consistency with it. (The only checkbox primitive, `CheckboxInput`, also requires a smrt-svelte `<Provider>` in context — which this standalone presentational component doesn't assume.)
- **`InvoiceCard.svelte`** — the large pressable invoice card (`use:ripple`, rich content, mirrors the sibling `<a>` branch) is escape-hatched as a structural control.
- **`package.json`** — opt into strict via `"smrtRawPrimitives": "strict"`. **No** smrt-svelte dependency added (no form primitive used).

## Verification (local, all green)
- `node scripts/check-raw-primitives.mjs` → exit 0 (commerce strict & clean; 3 annotated escape-hatches).
- `pnpm --filter @happyvertical/smrt-commerce typecheck` → 0 errors; `test` → 222 passed.
- `check-package-dag.mjs` + `check-no-smrt-peers.mjs` → 0; `biome check` (read-only) → clean.
- Scope-checked: only commerce files; lockfile unchanged.

> Migrated by a delegated agent, then reviewed + corrected (the agent's initial `CheckboxInput` swap introduced a Provider coupling + visual mismatch with the native select-all; reverted to native checkboxes, dropping the smrt-svelte dep).

Part of #1589.
