### PR TITLE
refactor(agents): migrate buttons to Button, flip agents strict-buttons (#1589)

### DIFF
--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -2,6 +2,7 @@
   "name": "@happyvertical/smrt-agents",
   "version": "0.34.4",
   "type": "module",
+  "smrtRawPrimitives": "strict-buttons",
   "description": "Agent framework for building autonomous actors in the SMRT ecosystem",
   "author": "HappyVertical",
   "license": "MIT",

--- a/packages/agents/src/svelte/components/AgentAdminTabs.svelte
+++ b/packages/agents/src/svelte/components/AgentAdminTabs.svelte
@@ -114,6 +114,7 @@ async function handleSave(config: unknown) {
 <div class="agent-admin-tabs">
 	<div class="tabs-nav" role="tablist" aria-label={t(M['ui.agent_admin_tabs.tablist_label'])} bind:this={tablistEl}>
 		{#each sortedSlots as [slotId, slot]}
+			<!-- raw-primitive-allow: tab control in a hand-rolled ARIA tablist with roving tabindex and bind:this keyboard navigation, driving externally-rendered aria-controls panels; this is a tab role (not a standard action button) and adopting the Tabs primitive would require restructuring the slot/panel wiring -->
 			<button
 				class="tab-button"
 				class:active={activeSlotId === slotId}

--- a/packages/agents/src/svelte/components/AgentScheduleForm.svelte
+++ b/packages/agents/src/svelte/components/AgentScheduleForm.svelte
@@ -195,14 +195,14 @@ function handleCronPreset(preset: string) {
         />
         <div class="cron-presets">
           {#each cronPresets as preset}
-            <button
-              type="button"
-              class="preset-btn"
+            <Button
+              variant="secondary"
+              size="sm"
               onclick={() => handleCronPreset(preset.value)}
               disabled={loading}
             >
               {preset.label}
-            </button>
+            </Button>
           {/each}
         </div>
         <small>{t(M['agents.schedule_form.cron_hint'])}</small>
@@ -342,26 +342,6 @@ function handleCronPreset(preset: string) {
     margin-top: var(--smrt-spacing-xs, 0.25rem);
   }
 
-  .preset-btn {
-    padding: 0.125rem var(--smrt-spacing-sm, 0.5rem);
-    border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
-    border-radius: var(--smrt-radius-small, 0.25rem);
-    background: var(--smrt-color-surface, #ffffff);
-    font: var(--smrt-typography-body-small-font, 0.75rem / 1.25 sans-serif);
-    cursor: pointer;
-    transition: all var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
-  }
-
-  .preset-btn:hover:not(:disabled) {
-    background: var(--smrt-color-surface-container, #f3f4f6);
-    border-color: var(--smrt-color-primary, #005ac1);
-  }
-
-  .preset-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
   .form-actions {
     display: flex;
     justify-content: flex-end;
@@ -373,8 +353,7 @@ function handleCronPreset(preset: string) {
 
   @media (prefers-reduced-motion: reduce) {
     .form-field input,
-    .form-field select,
-    .preset-btn {
+    .form-field select {
       transition: none;
     }
   }

--- a/packages/agents/src/svelte/components/AgentSettingsShell.svelte
+++ b/packages/agents/src/svelte/components/AgentSettingsShell.svelte
@@ -128,6 +128,7 @@ async function handleSave(slotId: string, config: unknown) {
 				bind:this={tablistEl}
 			>
 				{#each agents as agent}
+					<!-- raw-primitive-allow: tab control in a hand-rolled ARIA tablist with roving tabindex and bind:this keyboard navigation, driving an externally-rendered aria-controls panel; this is a tab role (not a standard action button) and adopting the Tabs primitive would require restructuring the agent/panel wiring -->
 					<button
 						class="agent-button"
 						class:active={activeAgentId === agent.id}


### PR DESCRIPTION
## Summary

#1589 **buttons-only** migration for **agents** (form-primitive adoption deferred — `smrt-agents` is in smrt-svelte's build-graph closure, so depending on it would create a turbo build cycle; see the `strict-buttons` mode in #1615).

- **`AgentScheduleForm.svelte`** — the cron-preset `<button>`s → `<Button variant="secondary" size="sm">`; dead `.preset-btn` CSS removed. The form `<input>`/`<select>`/checkbox stay raw (exempt under `strict-buttons`).
- **`AgentAdminTabs.svelte`** / **`AgentSettingsShell.svelte`** — the `role="tab"` buttons stay raw and **escape-hatched**: tab controls in hand-rolled ARIA tablists (roving tabindex + `bind:this` keyboard nav driving external `aria-controls` panels), not standard action buttons.
- **`package.json`** — `"smrtRawPrimitives": "strict-buttons"`. No smrt-svelte dependency; no DAG cycle.

## Verification (local, all green)
- `node scripts/check-raw-primitives.mjs` → exit 0 (agents in buttons-only mode, no raw `<button>`; 2 annotated tab escape-hatches).
- `pnpm --filter @happyvertical/smrt-agents typecheck` → 0 errors; `test` → 191 passed.
- `npx turbo build --filter=@happyvertical/smrt-agents` → no cycle; `check-package-dag.mjs` + `check-no-smrt-peers.mjs` → 0; `biome` (read-only) → clean.
- Scope-checked: only agents files; no lockfile/dep change; no stripped console.

> Reworked from the earlier form-primitive version (which created a turbo build cycle) to buttons-only per the #1589 scope decision.

Part of #1589.
