### PR TITLE
refactor(projects): adopt Button/form primitives, flip projects strict (#1589)

### DIFF
--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -3,6 +3,7 @@
   "version": "0.34.3",
   "description": "Provider-agnostic project management models (Issues, PRs, Repositories, Projects) for SMRT framework",
   "type": "module",
+  "smrtRawPrimitives": "strict",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/projects/src/svelte/components/ApprovalActions.svelte
+++ b/packages/projects/src/svelte/components/ApprovalActions.svelte
@@ -5,6 +5,7 @@
  */
 
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
 import type { ApprovalStatus } from './utils.js';
 
@@ -47,58 +48,33 @@ const canDelete = $derived(status === 'draft' && ondelete);
 
 <div class="approval-actions" class:vertical={layout === 'vertical'}>
   {#if canSubmit}
-    <button
-      type="button"
-      class="btn btn-filled"
-      onclick={onsubmit}
-      disabled={disabled || loading}
-    >
+    <Button variant="primary" onclick={onsubmit} disabled={disabled || loading}>
       {loading ? 'Submitting...' : 'Submit for Approval'}
-    </button>
+    </Button>
   {/if}
 
   {#if canApprove}
-    <button
-      type="button"
-      class="btn btn-filled-tonal"
-      onclick={onapprove}
-      disabled={disabled || loading}
-    >
+    <Button variant="primary" onclick={onapprove} disabled={disabled || loading}>
       {loading ? 'Approving...' : 'Approve'}
-    </button>
+    </Button>
   {/if}
 
   {#if canReject}
-    <button
-      type="button"
-      class="btn btn-error"
-      onclick={onreject}
-      disabled={disabled || loading}
-    >
+    <Button variant="danger" onclick={onreject} disabled={disabled || loading}>
       Reject
-    </button>
+    </Button>
   {/if}
 
   {#if canEdit}
-    <button
-      type="button"
-      class="btn btn-outlined"
-      onclick={onedit}
-      disabled={disabled || loading}
-    >
+    <Button variant="secondary" onclick={onedit} disabled={disabled || loading}>
       Edit
-    </button>
+    </Button>
   {/if}
 
   {#if canDelete}
-    <button
-      type="button"
-      class="btn btn-error-outlined"
-      onclick={ondelete}
-      disabled={disabled || loading}
-    >
+    <Button variant="danger" onclick={ondelete} disabled={disabled || loading}>
       Delete
-    </button>
+    </Button>
   {/if}
 
   {#if status === 'approved'}
@@ -125,73 +101,6 @@ const canDelete = $derived(status === 'draft' && ondelete);
   .approval-actions.vertical {
     flex-direction: column;
     align-items: stretch;
-  }
-
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    padding: 0.625rem 1.5rem;
-    font-size: var(--smrt-typography-label-large-size, 0.875rem);
-    font-weight: var(--smrt-typography-label-large-weight, 500);
-    letter-spacing: var(--smrt-typography-label-large-tracking, 0.1px);
-    border-radius: var(--smrt-radius-full, 9999px);
-    border: none;
-    cursor: pointer;
-    transition: all 0.2s var(--smrt-easing-standard);
-  }
-
-  .btn:disabled {
-    opacity: 0.38;
-    cursor: not-allowed;
-  }
-
-  .btn-filled {
-    background: var(--smrt-color-primary);
-    color: var(--smrt-color-on-primary);
-  }
-
-  .btn-filled:hover:not(:disabled) {
-    box-shadow: var(--smrt-elevation-1);
-  }
-
-  .btn-filled-tonal {
-    background: var(--smrt-color-secondary-container);
-    color: var(--smrt-color-on-secondary-container);
-  }
-
-  .btn-filled-tonal:hover:not(:disabled) {
-    box-shadow: var(--smrt-elevation-1);
-  }
-
-  .btn-error {
-    background: var(--smrt-color-error);
-    color: var(--smrt-color-on-error);
-  }
-
-  .btn-error:hover:not(:disabled) {
-    box-shadow: var(--smrt-elevation-1);
-  }
-
-  .btn-error-outlined {
-    background: transparent;
-    border: 1px solid var(--smrt-color-error);
-    color: var(--smrt-color-error);
-  }
-
-  .btn-error-outlined:hover:not(:disabled) {
-    background: var(--smrt-color-error-container);
-  }
-
-  .btn-outlined {
-    background: transparent;
-    border: 1px solid var(--smrt-color-outline);
-    color: var(--smrt-color-on-surface);
-  }
-
-  .btn-outlined:hover:not(:disabled) {
-    background: var(--smrt-color-surface-container-highest);
   }
 
   .status-message {

--- a/packages/projects/src/svelte/components/BulkActions.svelte
+++ b/packages/projects/src/svelte/components/BulkActions.svelte
@@ -5,6 +5,7 @@
  */
 
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
 
 const { t } = useI18n();
@@ -39,55 +40,41 @@ const visible = $derived(selectedCount > 0);
       <span class="count">{selectedCount}</span>
       <span class="label">{selectedCount === 1 ? 'item' : 'items'} selected</span>
       {#if onclear}
-        <button type="button" class="clear-btn" onclick={onclear} disabled={loading}>
+        <Button
+          variant="ghost"
+          size="sm"
+          class="clear-action"
+          onclick={onclear}
+          disabled={loading}
+        >
           Clear
-        </button>
+        </Button>
       {/if}
     </div>
 
     <div class="actions">
       {#if onapprove}
-        <button
-          type="button"
-          class="btn btn-filled"
-          onclick={onapprove}
-          disabled={loading}
-        >
+        <Button variant="primary" onclick={onapprove} disabled={loading}>
           {t(M['projects.bulk_actions.approve_all'])}
-        </button>
+        </Button>
       {/if}
 
       {#if onreject}
-        <button
-          type="button"
-          class="btn btn-error"
-          onclick={onreject}
-          disabled={loading}
-        >
+        <Button variant="danger" onclick={onreject} disabled={loading}>
           {t(M['projects.bulk_actions.reject_all'])}
-        </button>
+        </Button>
       {/if}
 
       {#if onexport}
-        <button
-          type="button"
-          class="btn btn-outlined"
-          onclick={onexport}
-          disabled={loading}
-        >
+        <Button variant="secondary" onclick={onexport} disabled={loading}>
           Export
-        </button>
+        </Button>
       {/if}
 
       {#if ondelete}
-        <button
-          type="button"
-          class="btn btn-error-outlined"
-          onclick={ondelete}
-          disabled={loading}
-        >
+        <Button variant="danger" onclick={ondelete} disabled={loading}>
           Delete
-        </button>
+        </Button>
       {/if}
     </div>
   </div>
@@ -122,87 +109,18 @@ const visible = $derived(selectedCount > 0);
     color: var(--smrt-color-on-secondary-container);
   }
 
-  .clear-btn {
-    background: none;
-    border: none;
+  /* Keep the bespoke text-link look for the migrated Clear Button. The
+     :global() pierces into the Button child's rendered <button>, which carries
+     its own scope hash (see #1589 scoping rule). */
+  .selection-info :global(.clear-action) {
     padding: 0.25rem 0.5rem;
     font-size: var(--smrt-typography-label-medium-size, 0.75rem);
-    color: var(--smrt-color-primary);
-    cursor: pointer;
     text-decoration: underline;
-  }
-
-  .clear-btn:hover:not(:disabled) {
-    color: var(--smrt-color-primary);
-    opacity: 0.8;
-  }
-
-  .clear-btn:disabled {
-    opacity: 0.38;
-    cursor: not-allowed;
   }
 
   .actions {
     display: flex;
     gap: 0.5rem;
-  }
-
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    font-size: var(--smrt-typography-label-large-size, 0.875rem);
-    font-weight: var(--smrt-typography-label-large-weight, 500);
-    letter-spacing: var(--smrt-typography-label-large-tracking, 0.1px);
-    border-radius: var(--smrt-radius-full, 9999px);
-    border: none;
-    cursor: pointer;
-    transition: all 0.2s var(--smrt-easing-standard);
-  }
-
-  .btn:disabled {
-    opacity: 0.38;
-    cursor: not-allowed;
-  }
-
-  .btn-filled {
-    background: var(--smrt-color-primary);
-    color: var(--smrt-color-on-primary);
-  }
-
-  .btn-filled:hover:not(:disabled) {
-    box-shadow: var(--smrt-elevation-1);
-  }
-
-  .btn-error {
-    background: var(--smrt-color-error);
-    color: var(--smrt-color-on-error);
-  }
-
-  .btn-error:hover:not(:disabled) {
-    box-shadow: var(--smrt-elevation-1);
-  }
-
-  .btn-error-outlined {
-    background: transparent;
-    border: 1px solid var(--smrt-color-error);
-    color: var(--smrt-color-error);
-  }
-
-  .btn-error-outlined:hover:not(:disabled) {
-    background: var(--smrt-color-error-container);
-  }
-
-  .btn-outlined {
-    background: transparent;
-    border: 1px solid var(--smrt-color-outline);
-    color: var(--smrt-color-on-surface);
-  }
-
-  .btn-outlined:hover:not(:disabled) {
-    background: var(--smrt-color-surface-container-highest);
   }
 
   @media (max-width: 640px) {
@@ -216,7 +134,7 @@ const visible = $derived(selectedCount > 0);
       flex-wrap: wrap;
     }
 
-    .actions .btn {
+    .actions :global(.button) {
       flex: 1;
       min-width: 100px;
     }

--- a/packages/projects/src/svelte/components/RejectDialog.svelte
+++ b/packages/projects/src/svelte/components/RejectDialog.svelte
@@ -5,6 +5,7 @@
  */
 
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
 
 const { t } = useI18n();
@@ -74,6 +75,7 @@ $effect(() => {
 
 {#if open}
   <div class="dialog-backdrop">
+    <!-- raw-primitive-allow: click-catching modal backdrop; structural overlay, not a primitive -->
     <button
       type="button"
       class="dialog-overlay"
@@ -92,6 +94,7 @@ $effect(() => {
 
       <p class="dialog-message">{message}</p>
 
+      <!-- raw-primitive-allow: base Textarea primitive cannot resolve in this package's vitest component tests (smrt-vitest does not map the smrt-svelte forms subpath alias); keep native until that shared harness gap is fixed -->
       <textarea
         bind:this={textarea}
         bind:value={reason}
@@ -106,22 +109,16 @@ $effect(() => {
       {/if}
 
       <div class="dialog-actions">
-        <button
-          type="button"
-          class="btn btn-secondary"
-          onclick={handleCancel}
-          disabled={loading}
-        >
+        <Button variant="secondary" onclick={handleCancel} disabled={loading}>
           {cancelLabel}
-        </button>
-        <button
-          type="button"
-          class="btn btn-error"
+        </Button>
+        <Button
+          variant="danger"
           onclick={handleConfirm}
           disabled={!canConfirm || loading}
         >
           {loading ? 'Rejecting...' : confirmLabel}
-        </button>
+        </Button>
       </div>
     </div>
   </div>
@@ -208,43 +205,5 @@ $effect(() => {
     justify-content: flex-end;
     gap: 0.5rem;
     margin-top: 1.5rem;
-  }
-
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.625rem 1.5rem;
-    font-size: var(--smrt-typography-label-large-size, 0.875rem);
-    font-weight: var(--smrt-typography-label-large-weight, 500);
-    letter-spacing: var(--smrt-typography-label-large-tracking, 0.1px);
-    border-radius: var(--smrt-radius-full, 9999px);
-    border: none;
-    cursor: pointer;
-    transition: all 0.2s var(--smrt-easing-standard);
-  }
-
-  .btn:disabled {
-    opacity: 0.38;
-    cursor: not-allowed;
-  }
-
-  .btn-secondary {
-    background: transparent;
-    color: var(--smrt-color-primary);
-  }
-
-  .btn-secondary:hover:not(:disabled) {
-    background: var(--smrt-color-primary);
-    background: color-mix(in srgb, var(--smrt-color-primary) 8%, transparent);
-  }
-
-  .btn-error {
-    background: var(--smrt-color-error);
-    color: var(--smrt-color-on-error);
-  }
-
-  .btn-error:hover:not(:disabled) {
-    box-shadow: var(--smrt-elevation-1);
   }
 </style>

--- a/packages/projects/src/svelte/components/TimeEntryCard.svelte
+++ b/packages/projects/src/svelte/components/TimeEntryCard.svelte
@@ -74,6 +74,7 @@ function handleKeydown(event: KeyboardEvent) {
 >
   {#if selectable}
     <div class="checkbox-wrapper">
+      <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive, kept native to match the indeterminate select-all in TimeEntryList -->
       <input
         type="checkbox"
         checked={selected}
@@ -93,6 +94,7 @@ function handleKeydown(event: KeyboardEvent) {
       {@render cardBody()}
     </a>
   {:else if onclick}
+    <!-- raw-primitive-allow: pressable selection card wrapping rich content; structural, not a standard action button -->
     <button
       type="button"
       class="card-content"

--- a/packages/projects/src/svelte/components/TimeEntryList.svelte
+++ b/packages/projects/src/svelte/components/TimeEntryList.svelte
@@ -85,6 +85,7 @@ function getEntryHref(entry: TimeEntry): string | undefined {
     {#if selectable && selectableEntries.length > 0}
       <div class="list-header">
         <label class="select-all">
+          <!-- raw-primitive-allow: select-all checkbox needs the indeterminate state; must stay native -->
           <input
             type="checkbox"
             checked={allSelected}
@@ -114,6 +115,7 @@ function getEntryHref(entry: TimeEntry): string | undefined {
           {#if selectable && selectableEntries.length > 0}
             <div class="checkbox-cell">
               {#if isSelectable}
+                <!-- raw-primitive-allow: native row checkbox; no Provider-free checkbox primitive, kept native to match the indeterminate select-all -->
                 <input
                   type="checkbox"
                   checked={isSelected}


### PR DESCRIPTION
## Summary

Migrates the `projects` package's raw interactive markup to shared SMRT
primitives and flips the package to strict raw-primitive enforcement (#1589).

`projects` is NOT in `smrt-svelte`'s DAG closure, so form primitives were
allowed. In practice every migrated form element ended up native/escape-hatched
(see below), so **no `smrt-svelte` dependency is added** and the lockfile is
unchanged — only `smrt-ui` `Button` (already a dependency) is used.

## Per-file changes

- **ApprovalActions.svelte** — 5 raw buttons -> `<Button>`. Submit/Approve ->
  `primary` (no success variant); Reject/Delete -> `danger`; Edit ->
  `secondary`. Dead `.btn*` CSS deleted.
- **BulkActions.svelte** — 5 raw buttons -> `<Button>`. Clear -> `ghost`
  `size="sm"` with non-colliding `class="clear-action"` (underlined text-link
  look kept via `.selection-info :global(.clear-action)`); Approve All ->
  `primary`; Reject All / Delete -> `danger`; Export -> `secondary`. Responsive
  `.btn` rule rewritten as `.actions :global(.button)`. Dead CSS deleted.
- **RejectDialog.svelte** — cancel/confirm buttons -> `<Button>`
  (`secondary`/`danger`), dead `.btn*` CSS removed. Backdrop overlay button and
  the `<textarea>` stay native + escape-hatched (see below).
- **TimeEntryCard.svelte** — selection checkbox and pressable card-content
  button stay native + escape-hatched.
- **TimeEntryList.svelte** — select-all and row checkboxes stay native +
  escape-hatched.
- **package.json** — added `"smrtRawPrimitives": "strict"`.

## Escape-hatches (with reasons)

1. `RejectDialog` backdrop overlay button — structural click-catching modal
   backdrop; no primitive owns it.
2. `RejectDialog` `<textarea>` — the base `Textarea` primitive is correct and
   **compiles in the shipped build**, but it cannot resolve under this package's
   vitest component tests: `smrt-vitest` does not map the
   `@happyvertical/smrt-svelte/forms` subpath alias, and its bare-root
   `@happyvertical/smrt-svelte` alias matches the subpath as a prefix and
   mangles it to `…/src/index.ts/forms`. The alias plugin runs before any
   in-package plugin can intercept, and the plugin appends consumer aliases
   after its own (bare root wins on first-match), so it cannot be fixed within
   `packages/projects`. Kept native until the shared harness maps the subpath.
3. `TimeEntryList` select-all checkbox — needs the `indeterminate` state; must
   stay native.
4. `TimeEntryList` row checkbox + `TimeEntryCard` checkbox — no Provider-free
   checkbox primitive; kept native to stay visually consistent with the
   indeterminate select-all.
5. `TimeEntryCard` card-content button — pressable selection card wrapping rich
   content; structural, not a standard action button.

## Dropped behavior

None — no `use:` actions were present on the migrated buttons.

## smrt-svelte dep + DAG

No `smrt-svelte` dependency added (every form element is native/escape-hatched).
`node scripts/check-package-dag.mjs` -> exit 0; `node scripts/check-no-smrt-peers.mjs`
-> exit 0.

## Follow-up (out of scope for this package-scoped PR)

`projects` is the first repo consumer to import `@happyvertical/smrt-svelte/forms`
in a vitest-tested `.svelte` component. A 1-line addition to
`packages/vitest/src/index.ts` mapping the `/forms` subpath (mirroring the
existing `smrt-ui` `/ui` handling) would let the `RejectDialog` `<textarea>` be
upgraded to the base `Textarea` primitive and the escape-hatch removed.

## Gates (all green)

- raw-primitives ratchet -> exit 0
- `pnpm --filter @happyvertical/smrt-projects typecheck` -> 0 errors / 0 warnings
- `pnpm --filter @happyvertical/smrt-projects test` -> 11 files / 88 tests passed
- `check-package-dag.mjs` + `check-no-smrt-peers.mjs` -> exit 0
- `biome check` (read-only) on edited files -> clean
