### PR TITLE
refactor(users): migrate buttons to Button, flip users strict-buttons (#1589)

### DIFF
--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -3,6 +3,7 @@
   "version": "0.34.4",
   "description": "Multi-tenant user management for the SMRT framework - users, tenants, roles, permissions, groups",
   "type": "module",
+  "smrtRawPrimitives": "strict-buttons",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/users/src/svelte/components/InviteUserModal.svelte
+++ b/packages/users/src/svelte/components/InviteUserModal.svelte
@@ -2,6 +2,7 @@
 import { RoleSelector } from '@happyvertical/smrt-ui';
 import { Modal } from '@happyvertical/smrt-ui/feedback';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { Role, Tenant } from '@happyvertical/smrt-users';
 import { M } from '../i18n.js';
 
@@ -125,16 +126,16 @@ function handleClose() {
   </form>
 
   {#snippet footer()}
-    <button type="button" class="btn-secondary" onclick={handleClose} disabled={loading}>
+    <Button variant="secondary" type="button" onclick={handleClose} disabled={loading}>
       Cancel
-    </button>
-    <button type="submit" form={formId} class="btn-primary" disabled={loading}>
+    </Button>
+    <Button variant="primary" type="submit" form={formId} disabled={loading}>
       {#if loading}
         {t(M['users.invite_user_modal.sending'])}
       {:else}
         {t(M['users.invite_user_modal.send_invite'])}
       {/if}
-    </button>
+    </Button>
   {/snippet}
 </Modal>
 
@@ -211,42 +212,7 @@ function handleClose() {
     border-radius: var(--smrt-radius-small, 0.25rem);
   }
 
-  button {
-    padding: var(--smrt-spacing-sm, 0.5rem) var(--smrt-spacing-md, 1rem);
-    border-radius: var(--smrt-radius-medium, 0.5rem);
-    font: var(--smrt-typography-label-large-font, 500 0.875rem / 1.25 sans-serif);
-    cursor: pointer;
-    transition: all var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
-  }
-
-  button:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-
-  .btn-primary {
-    background: var(--smrt-color-primary, #005ac1);
-    color: var(--smrt-color-on-primary, #ffffff);
-    border: none;
-  }
-
-  .btn-primary:hover:not(:disabled) {
-    background: var(--smrt-color-primary-container, #005ac1);
-    opacity: 0.9;
-  }
-
-  .btn-secondary {
-    background: var(--smrt-color-surface, white);
-    color: var(--smrt-color-on-surface-variant, #43474e);
-    border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
-  }
-
-  .btn-secondary:hover:not(:disabled) {
-    background: var(--smrt-color-surface-container-low, #f9fafb);
-  }
-
   @media (prefers-reduced-motion: reduce) {
-    button,
     input[type='email'] {
       transition: none;
     }

--- a/packages/users/src/svelte/components/UserCard.svelte
+++ b/packages/users/src/svelte/components/UserCard.svelte
@@ -43,6 +43,7 @@ const statusClass = $derived.by(() => {
 });
 </script>
 
+<!-- raw-primitive-allow: large pressable selection card wrapping rich content (avatar, name, email, role/status) with selected state and ripple; no Button primitive owns this structural pattern -->
 <button
   type="button"
   class="user-card"

--- a/packages/users/src/svelte/components/UserForm.svelte
+++ b/packages/users/src/svelte/components/UserForm.svelte
@@ -2,6 +2,7 @@
 import type { Profile } from '@happyvertical/smrt-profiles';
 import { UserStatus } from '@happyvertical/smrt-types';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { User } from '@happyvertical/smrt-users';
 import { M } from '../i18n.js';
 
@@ -91,17 +92,17 @@ function handleSubmit(e: Event) {
 
   <div class="actions">
     {#if oncancel}
-      <button type="button" class="btn-secondary" onclick={oncancel} disabled={loading}>
+      <Button variant="secondary" type="button" onclick={oncancel} disabled={loading}>
         Cancel
-      </button>
+      </Button>
     {/if}
-    <button type="submit" class="btn-primary" disabled={loading}>
+    <Button variant="primary" type="submit" disabled={loading}>
       {#if loading}
         Saving...
       {:else}
         {user ? 'Update User' : 'Create User'}
       {/if}
-    </button>
+    </Button>
   </div>
 </form>
 
@@ -157,44 +158,9 @@ function handleSubmit(e: Event) {
     margin-top: var(--smrt-spacing-sm, 0.5rem);
   }
 
-  button {
-    padding: var(--smrt-spacing-sm, 0.5rem) var(--smrt-spacing-md, 1rem);
-    border-radius: var(--smrt-radius-medium, 0.5rem);
-    font: var(--smrt-typography-label-large-font, 500 0.875rem / 1.25 sans-serif);
-    cursor: pointer;
-    transition: all var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
-  }
-
-  button:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-
-  .btn-primary {
-    background: var(--smrt-color-primary, #005ac1);
-    color: var(--smrt-color-on-primary, #ffffff);
-    border: none;
-  }
-
-  .btn-primary:hover:not(:disabled) {
-    background: var(--smrt-color-primary-container, #005ac1);
-    opacity: 0.9;
-  }
-
-  .btn-secondary {
-    background: var(--smrt-color-surface, white);
-    color: var(--smrt-color-on-surface-variant, #43474e);
-    border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
-  }
-
-  .btn-secondary:hover:not(:disabled) {
-    background: var(--smrt-color-surface-container-low, #f9fafb);
-  }
-
   @media (prefers-reduced-motion: reduce) {
     input,
-    select,
-    button {
+    select {
       transition: none;
     }
   }

--- a/packages/users/src/svelte/components/UserMenu.svelte
+++ b/packages/users/src/svelte/components/UserMenu.svelte
@@ -171,6 +171,7 @@ function getInitials(name: string): string {
 <svelte:window onclick={handleClickOutside} onkeydown={handleKeydown} />
 
 <div class="user-menu" id={menuId}>
+  <!-- raw-primitive-allow: WAI-ARIA menu-button trigger with bind:this focus management, aria-haspopup/aria-expanded/aria-controls and roving-tabindex keyboard nav; structural menu button no primitive owns -->
   <button
     bind:this={triggerButton}
     id="{menuId}-trigger"


### PR DESCRIPTION
## Summary

Buttons-only migration for the `users` package (#1589). Migrates raw `<button>` action buttons to the shared smrt-ui `Button` primitive and flips `@happyvertical/smrt-users` to `"smrtRawPrimitives": "strict-buttons"`. Raw form controls (`input`/`select`/`textarea`/`form`) are intentionally left as-is — they are exempt under `strict-buttons` and adopt form primitives in a separate follow-up.

## Per-button outcome

| File | Button | Outcome |
|------|--------|---------|
| InviteUserModal | footer Cancel (`btn-secondary`, `type=button`) | `<Button variant="secondary" type="button">` |
| InviteUserModal | submit (`btn-primary`, `type=submit`, `form={formId}`) | `<Button variant="primary" type="submit" form={formId}>` |
| UserForm | Cancel (`btn-secondary`, `type=button`) | `<Button variant="secondary" type="button">` |
| UserForm | submit (`btn-primary`, `type=submit`) | `<Button variant="primary" type="submit">` |
| UserCard | pressable selection card | **escape-hatched** — large pressable card wrapping rich content (avatar/name/email/role/status) with `selected` state + `use:ripple`; no Button primitive owns this structural pattern |
| UserMenu | menu trigger | **escape-hatched** — WAI-ARIA menu-button with `bind:this` focus management, `aria-haspopup`/`aria-expanded`/`aria-controls`, roving-tabindex keyboard nav; structural menu button no primitive owns |

Dead local `.btn-primary`/`.btn-secondary`/`button` CSS deleted in both migrated files; `input`/`select`/`input[type='email']` rules kept for the still-raw fields. No `use:ripple` was dropped from a migrated button — the two buttons carrying it were the ones escape-hatched, so their ripple is preserved.

## Gates (all green)

- `check-raw-primitives.mjs` → exit 0 (`users` under buttons-only package(s), forms deferred)
- `pnpm --filter @happyvertical/smrt-users typecheck` → 0 errors, 0 warnings (1098 files)
- `pnpm --filter @happyvertical/smrt-users test` → 20 files passed (1 skipped), 239 tests passed (4 skipped)
- `check-package-dag.mjs` + `check-no-smrt-peers.mjs` → exit 0
- `biome check` (read-only) on changed files → exit 0, no fixes applied
- Scope: only `packages/users/**`; no `<input>/<select>/<textarea>/<form>` markup changes; no stripped `console.*`; no emptied `catch {}`; no lockfile change; no new dependency added
