### PR TITLE
refactor(products): migrate buttons to Button, flip products strict-buttons (#1589)

### DIFF
--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -4,6 +4,7 @@
   "description": "SMRT products module: triple-purpose microservice template for standalone apps, federated modules, and NPM libraries",
   "author": "HappyVertical",
   "type": "module",
+  "smrtRawPrimitives": "strict-buttons",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
   "files": [

--- a/packages/products/src/app/pages/DemoPage.svelte
+++ b/packages/products/src/app/pages/DemoPage.svelte
@@ -5,6 +5,7 @@
  */
 
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import AutoForm from '../../lib/components/auto-generated/AutoForm.svelte';
 import ProductCard from '../../lib/components/ProductCard.svelte';
 import ProductForm from '../../lib/components/ProductForm.svelte';
@@ -51,27 +52,24 @@ function handleCustomSubmit(data: ProductData) {
   </header>
 
   <nav class="demo-nav">
-    <button
-      class="nav-btn"
-      class:active={currentTab === 'auto'}
+    <Button
+      variant={currentTab === 'auto' ? 'primary' : 'secondary'}
       onclick={() => currentTab = 'auto'}
     >
       Auto-Generated
-    </button>
-    <button
-      class="nav-btn"
-      class:active={currentTab === 'custom'}
+    </Button>
+    <Button
+      variant={currentTab === 'custom' ? 'primary' : 'secondary'}
       onclick={() => currentTab = 'custom'}
     >
       {t(M['products.demo_page.custom_components_tab'])}
-    </button>
-    <button
-      class="nav-btn"
-      class:active={currentTab === 'comparison'}
+    </Button>
+    <Button
+      variant={currentTab === 'comparison' ? 'primary' : 'secondary'}
       onclick={() => currentTab = 'comparison'}
     >
       Side-by-Side
-    </button>
+    </Button>
   </nav>
 
   <main class="demo-content">
@@ -221,27 +219,6 @@ function handleCustomSubmit(data: ProductData) {
     gap: 1rem;
     margin-bottom: 2rem;
     padding: 0 1rem;
-  }
-
-  .nav-btn {
-    padding: 0.75rem 1.5rem;
-    background: color-mix(in srgb, var(--smrt-color-surface, #fff) 90%, transparent);
-    border: 2px solid transparent;
-    border-radius: var(--smrt-radius-md, 0.5rem);
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-
-  .nav-btn:hover {
-    background: var(--smrt-color-surface, #fff);
-    transform: translateY(-2px);
-  }
-
-  .nav-btn.active {
-    background: var(--smrt-color-surface, #fff);
-    border-color: var(--smrt-color-primary, #3b82f6);
-    color: var(--smrt-color-primary, #3b82f6);
   }
 
   .demo-content {

--- a/packages/products/src/lib/components/ProductCard.svelte
+++ b/packages/products/src/lib/components/ProductCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { ProductData } from '../types';
 
 interface Props {
@@ -42,15 +43,15 @@ const { product, onEdit, onDelete }: Props = $props();
   
   <div class="product-actions">
     {#if onEdit}
-      <button type="button" onclick={() => onEdit?.(product)} class="edit-btn">
+      <Button type="button" variant="secondary" size="sm" onclick={() => onEdit?.(product)}>
         Edit
-      </button>
+      </Button>
     {/if}
-    
+
     {#if onDelete}
-      <button type="button" onclick={() => onDelete?.(product.id)} class="delete-btn">
+      <Button type="button" variant="danger" size="sm" onclick={() => onDelete?.(product.id)}>
         Delete
-      </button>
+      </Button>
     {/if}
   </div>
 </div>
@@ -139,35 +140,5 @@ const { product, onEdit, onDelete }: Props = $props();
     margin-top: 1rem;
     padding-top: 0.75rem;
     border-top: 1px solid var(--smrt-color-outline-variant, #f3f4f6);
-  }
-  
-  .edit-btn, .delete-btn {
-    padding: 0.375rem 0.75rem;
-    border-radius: var(--smrt-radius-sm, 4px);
-    font-size: var(--smrt-typography-label-large-size, 0.875rem);
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    border: 1px solid;
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-  
-  .edit-btn {
-    background: var(--smrt-color-surface-container-low, #f9fafb);
-    border-color: var(--smrt-color-outline-variant, #d1d5db);
-    color: var(--smrt-color-on-surface, #374151);
-  }
-
-  .edit-btn:hover {
-    background: var(--smrt-color-surface-container, #f3f4f6);
-  }
-
-  .delete-btn {
-    background: var(--smrt-color-error-container, #fef2f2);
-    border-color: var(--smrt-color-error, #fecaca);
-    color: var(--smrt-color-error, #dc2626);
-  }
-
-  .delete-btn:hover {
-    background: var(--smrt-color-error-container, #fee2e2);
   }
 </style>

--- a/packages/products/src/lib/components/ProductForm.svelte
+++ b/packages/products/src/lib/components/ProductForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
 import type { ProductData } from '../types';
 
@@ -153,18 +154,18 @@ function handleSubmit(event: Event) {
 
   <div class="form-actions">
     {#if onCancel}
-      <button type="button" onclick={onCancel} disabled={loading} class="cancel-btn">
+      <Button type="button" variant="secondary" onclick={onCancel} disabled={loading}>
         Cancel
-      </button>
+      </Button>
     {/if}
-    
-    <button type="submit" disabled={loading} class="submit-btn">
+
+    <Button type="submit" variant="primary" disabled={loading}>
       {#if loading}
         Saving...
       {:else}
         {product.id ? 'Update Product' : 'Create Product'}
       {/if}
-    </button>
+    </Button>
   </div>
 </form>
 
@@ -250,40 +251,5 @@ function handleSubmit(event: Event) {
     margin-top: 1.5rem;
     padding-top: 1rem;
     border-top: 1px solid var(--smrt-color-outline-variant, #f3f4f6);
-  }
-  
-  .cancel-btn, .submit-btn {
-    padding: 0.5rem 1rem;
-    border-radius: var(--smrt-radius-sm, 4px);
-    font-size: var(--smrt-typography-label-large-size, 0.875rem);
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    cursor: pointer;
-    border: 1px solid;
-    transition: all 0.2s;
-  }
-  
-  .cancel-btn {
-    background: var(--smrt-color-surface, #fff);
-    border-color: var(--smrt-color-outline-variant, #d1d5db);
-    color: var(--smrt-color-on-surface, #374151);
-  }
-
-  .cancel-btn:hover:not(:disabled) {
-    background: var(--smrt-color-surface-container-low, #f9fafb);
-  }
-
-  .submit-btn {
-    background: var(--smrt-color-primary, #3b82f6);
-    border-color: var(--smrt-color-primary, #3b82f6);
-    color: var(--smrt-color-on-primary, white);
-  }
-
-  .submit-btn:hover:not(:disabled) {
-    background: var(--smrt-color-primary, #2563eb);
-  }
-  
-  .submit-btn:disabled, .cancel-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
   }
 </style>

--- a/packages/products/src/lib/components/auto-generated/AutoForm.svelte
+++ b/packages/products/src/lib/components/auto-generated/AutoForm.svelte
@@ -5,6 +5,7 @@
  */
 
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.js';
 import type { ProductData } from '../../types';
 import FieldRenderer from './FieldRenderer.svelte';
@@ -128,12 +129,12 @@ function _getFieldType(
 
     {#if !readonly}
       <div class="form-actions">
-        <button type="submit" class="submit-btn">
+        <Button type="submit" variant="primary">
           {submitLabel}
-        </button>
-        <button type="button" class="reset-btn" onclick={() => formData = {}}>
+        </Button>
+        <Button type="button" variant="secondary" onclick={() => formData = {}}>
           Reset
-        </button>
+        </Button>
       </div>
     {/if}
   </form>
@@ -185,36 +186,6 @@ function _getFieldType(
     margin-top: 1.5rem;
     padding-top: 1.5rem;
     border-top: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
-  }
-
-  .submit-btn {
-    background: var(--smrt-color-primary, #3b82f6);
-    color: var(--smrt-color-on-primary, white);
-    border: none;
-    padding: 0.75rem 1.5rem;
-    border-radius: var(--smrt-radius-sm, 0.375rem);
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    cursor: pointer;
-    transition: background-color 0.2s;
-  }
-
-  .submit-btn:hover {
-    background: var(--smrt-color-primary, #2563eb);
-  }
-
-  .reset-btn {
-    background: var(--smrt-color-surface-container, #f3f4f6);
-    color: var(--smrt-color-on-surface, #374151);
-    border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
-    padding: 0.75rem 1.5rem;
-    border-radius: var(--smrt-radius-sm, 0.375rem);
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    cursor: pointer;
-    transition: background-color 0.2s;
-  }
-
-  .reset-btn:hover {
-    background: var(--smrt-color-surface-container-high, #e5e7eb);
   }
 
   .form-debug {

--- a/packages/products/src/lib/features/ProductCatalog.svelte
+++ b/packages/products/src/lib/features/ProductCatalog.svelte
@@ -253,6 +253,14 @@ function handleCancelForm() {
     color: var(--smrt-color-on-surface-variant, #6b7280);
   }
 
+  /* Restore the retry button's spacing from the error message. The old
+     `.error-state button` rule can't reach the <button> rendered inside the
+     smrt-ui <Button>, so pierce into it with `:global` (#1589); the danger
+     variant already supplies the background/color the old rule set. */
+  .error-state :global(.button) {
+    margin-top: 0.5rem;
+  }
+
   .form-overlay {
     position: fixed;
     top: 0;

--- a/packages/products/src/lib/features/ProductCatalog.svelte
+++ b/packages/products/src/lib/features/ProductCatalog.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { onMount } from 'svelte';
 import ProductCard from '../components/ProductCard.svelte';
 import ProductForm from '../components/ProductForm.svelte';
@@ -119,13 +120,13 @@ function handleCancelForm() {
     </div>
     
     {#if !readonly && (showCreateForm || productStore.items.length === 0)}
-      <button 
-        type="button" 
+      <Button
+        type="button"
+        variant="primary"
         onclick={handleCreateProduct}
-        class="create-btn"
       >
         {t(M['products.product_catalog.add_product'])}
-      </button>
+      </Button>
     {/if}
   </div>
   
@@ -136,18 +137,18 @@ function handleCancelForm() {
   {:else if productStore.error}
     <div class="error-state" role="alert" aria-live="assertive">
       <p>Error: {productStore.error}</p>
-      <button type="button" onclick={() => productStore.loadProducts()}>
+      <Button type="button" variant="danger" onclick={() => productStore.loadProducts()}>
         Retry
-      </button>
+      </Button>
     </div>
   {:else if filteredProducts.length === 0}
     <div class="empty-state" role="status" aria-live="polite">
       {#if productStore.items.length === 0}
         <p>{t(M['products.product_catalog.empty'])}</p>
         {#if !readonly}
-          <button type="button" onclick={handleCreateProduct} class="create-btn">
+          <Button type="button" variant="primary" onclick={handleCreateProduct}>
             {t(M['products.product_catalog.create_first'])}
-          </button>
+          </Button>
         {/if}
       {:else}
         <p>{t(M['products.product_catalog.no_match'])}</p>
@@ -240,21 +241,6 @@ function handleCancelForm() {
     min-width: 150px;
   }
   
-  .create-btn {
-    background: var(--smrt-color-primary, #3b82f6);
-    color: var(--smrt-color-on-primary, white);
-    border: none;
-    padding: 0.5rem 1rem;
-    border-radius: var(--smrt-radius-sm, 4px);
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    cursor: pointer;
-    transition: background-color 0.2s;
-  }
-
-  .create-btn:hover {
-    background: var(--smrt-color-primary, #2563eb);
-  }
-  
   .products-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
@@ -265,16 +251,6 @@ function handleCancelForm() {
     text-align: center;
     padding: 3rem 1rem;
     color: var(--smrt-color-on-surface-variant, #6b7280);
-  }
-
-  .error-state button {
-    margin-top: 0.5rem;
-    background: var(--smrt-color-error, #dc2626);
-    color: var(--smrt-color-on-error, white);
-    border: none;
-    padding: 0.5rem 1rem;
-    border-radius: var(--smrt-radius-sm, 4px);
-    cursor: pointer;
   }
 
   .form-overlay {


### PR DESCRIPTION
## Summary

BUTTONS-ONLY migration for #1589 in the `products` package. Migrates every raw
`<button>` in `packages/products/src/**` to the shared `@happyvertical/smrt-ui`
`Button` primitive and flips the package to `"smrtRawPrimitives": "strict-buttons"`.

Raw `<input>`/`<select>`/`<textarea>`/`<form>` are deliberately untouched — form
primitives are a deferred follow-up and `strict-buttons` exempts them. No new
dependency added (`@happyvertical/smrt-ui` was already a dependency; no
`@happyvertical/smrt-svelte` added).

## Per-file mapping (12 buttons)

| File | Button | Variant |
|------|--------|---------|
| `app/pages/DemoPage.svelte` | 3 nav/tab toggles | active tab -> `primary`, inactive -> `secondary` |
| `lib/components/auto-generated/AutoForm.svelte` | submit | `primary` (`type="submit"`) |
| | reset | `secondary` |
| `lib/components/ProductCard.svelte` | edit | `secondary` `size="sm"` |
| | delete | `danger` `size="sm"` |
| `lib/components/ProductForm.svelte` | cancel | `secondary` (keeps `disabled={loading}`) |
| | submit | `primary` (`type="submit"`, keeps `disabled={loading}`) |
| `lib/features/ProductCatalog.svelte` | add product | `primary` |
| | retry (error state) | `danger` |
| | create first | `primary` |

Dead local button CSS for each migrated button was removed; container/layout CSS
(`.product-actions`, `.form-actions`, `.demo-nav`, state containers) kept. No
`use:ripple` (or any `use:` action) was present on any migrated button, so none
was dropped.

## Gates

- `node scripts/check-raw-primitives.mjs` -> exit 0 (products listed under buttons-only, no raw `<button>`)
- `pnpm --filter @happyvertical/smrt-products typecheck` -> 0 errors
- `pnpm --filter @happyvertical/smrt-products test` -> 78 passed, 4 skipped
- `node scripts/check-package-dag.mjs` + `node scripts/check-no-smrt-peers.mjs` -> exit 0
- `npx biome check <changed files>` -> exit 0 (read-only)
- Scope: only `packages/products/**`; no form markup changes; no lockfile change; no stripped `console.*`

Closes #1589 (products).
