### PR TITLE
refactor(messages): migrate buttons to Button, flip messages strict-buttons (#1589)

### DIFF
--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -3,6 +3,7 @@
   "version": "0.34.4",
   "description": "Unified multi-channel messaging with STI-based hierarchies",
   "type": "module",
+  "smrtRawPrimitives": "strict-buttons",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/messages/src/svelte/components/AccountCard.svelte
+++ b/packages/messages/src/svelte/components/AccountCard.svelte
@@ -2,7 +2,7 @@
 /**
  * AccountCard - Individual account card with status and actions
  */
-import { Card } from '@happyvertical/smrt-ui/ui';
+import { Button, Card } from '@happyvertical/smrt-ui/ui';
 import type { AccountData } from '../types.js';
 import AccountAvatar from './AccountAvatar.svelte';
 
@@ -51,24 +51,24 @@ const _lastSyncFormatted = $derived.by(() => {
 
     <div class="actions">
       {#if onsync && account.isActive}
-        <button class="action-btn" type="button" onclick={() => onsync?.(account)}>
+        <Button variant="ghost" size="sm" class="action-btn" onclick={() => onsync?.(account)}>
           Sync
-        </button>
+        </Button>
       {/if}
       {#if account.isActive && ondeactivate}
-        <button class="action-btn" type="button" onclick={() => ondeactivate?.(account)}>
+        <Button variant="ghost" size="sm" class="action-btn" onclick={() => ondeactivate?.(account)}>
           Deactivate
-        </button>
+        </Button>
       {/if}
       {#if !account.isActive && onactivate}
-        <button class="action-btn" type="button" onclick={() => onactivate?.(account)}>
+        <Button variant="ghost" size="sm" class="action-btn" onclick={() => onactivate?.(account)}>
           Activate
-        </button>
+        </Button>
       {/if}
       {#if onremove}
-        <button class="action-btn action-btn--danger" type="button" onclick={() => onremove?.(account)}>
+        <Button variant="ghost" size="sm" class="action-btn action-btn--danger" onclick={() => onremove?.(account)}>
           Remove
-        </button>
+        </Button>
       {/if}
     </div>
   </div>
@@ -152,21 +152,30 @@ const _lastSyncFormatted = $derived.by(() => {
     gap: 0.375rem;
   }
 
-  .action-btn {
+  /*
+   * The action buttons now render through smrt-ui's <Button variant="ghost">.
+   * Svelte scopes `.action-btn` to this component, but the <button> is emitted
+   * inside the Button child, so a plain `.action-btn {}` rule would not match —
+   * `.actions :global(.action-btn)` anchors on `.actions` (a real element here)
+   * and pierces into the child (issue #1589). These overrides keep the original
+   * outlined-surface look (border/radius/color); the modifier class is
+   * `action-btn--danger`, NOT `danger`, so it never collides with Button's own
+   * `.danger` variant class.
+   */
+  .actions :global(.action-btn) {
     padding: 0.375rem 0.75rem;
     border: 1px solid var(--smrt-color-outline, #72787e);
     border-radius: var(--smrt-radius-small, 0.25rem);
     background: var(--smrt-color-surface, #fefbff);
     color: var(--smrt-color-on-surface, #1a1c1e);
     font: var(--smrt-typography-label-medium-font, 500 0.75rem / 1.33 sans-serif);
-    cursor: pointer;
   }
 
-  .action-btn:hover {
+  .actions :global(.action-btn):hover {
     background: var(--smrt-color-surface-variant, #e1e2ec);
   }
 
-  .action-btn--danger {
+  .actions :global(.action-btn--danger) {
     color: var(--smrt-color-error, #ba1a1a);
     border-color: var(--smrt-color-error, #ba1a1a);
   }

--- a/packages/messages/src/svelte/components/AttachmentChip.svelte
+++ b/packages/messages/src/svelte/components/AttachmentChip.svelte
@@ -76,7 +76,7 @@ const _formattedSize = $derived.by(() => {
    * #1589). The non-interactive `<span class="chip">` branch still uses the
    * scoped `.chip` rule above.
    */
-  :global(.chip--button) {
+  :global(.chip.chip--button) {
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;
@@ -90,11 +90,11 @@ const _formattedSize = $derived.by(() => {
     transition: background var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
   }
 
-  :global(.chip--button):hover {
+  :global(.chip.chip--button):hover {
     background: color-mix(in srgb, var(--smrt-color-surface-variant, #e1e2ec) 92%, var(--smrt-color-shadow, #000));
   }
 
-  :global(.chip--button):focus-visible {
+  :global(.chip.chip--button):focus-visible {
     outline: 2px solid var(--smrt-color-primary, #005ac1);
     outline-offset: 1px;
   }

--- a/packages/messages/src/svelte/components/AttachmentChip.svelte
+++ b/packages/messages/src/svelte/components/AttachmentChip.svelte
@@ -2,6 +2,7 @@
 /**
  * AttachmentChip - File chip with icon, name, and size
  */
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { AttachmentData } from '../types.js';
 
 export interface Props {
@@ -33,16 +34,16 @@ const _formattedSize = $derived.by(() => {
 </script>
 
 {#if onclick}
-  <button
-    class="chip"
-    type="button"
+  <Button
+    variant="ghost"
+    class="chip chip--button"
     onclick={() => onclick?.(attachment)}
     title={`${attachment.filename} (${_formattedSize})`}
   >
     <span class="icon">{_icon}</span>
     <span class="name">{attachment.filename}</span>
     <span class="size">{_formattedSize}</span>
-  </button>
+  </Button>
 {:else}
   <span class="chip" title={`${attachment.filename} (${_formattedSize})`}>
     <span class="icon">{_icon}</span>
@@ -66,16 +67,34 @@ const _formattedSize = $derived.by(() => {
     max-width: 200px;
   }
 
-  button.chip {
+  /*
+   * The interactive chip now renders through smrt-ui's <Button variant="ghost">.
+   * The <button> is emitted inside the Button child carrying Button's scope hash,
+   * so the local `.chip` rule above no longer reaches it. `:global(.chip--button)`
+   * pierces that scope to give the button the same chip styling plus the
+   * pressable affordances; `chip--button` is a non-colliding modifier (issue
+   * #1589). The non-interactive `<span class="chip">` branch still uses the
+   * scoped `.chip` rule above.
+   */
+  :global(.chip--button) {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.25rem 0.625rem;
+    border-radius: var(--smrt-radius-small, 0.25rem);
+    background: var(--smrt-color-surface-variant, #e1e2ec);
+    color: var(--smrt-color-on-surface-variant, #43474e);
+    font: var(--smrt-typography-label-medium-font, 500 0.75rem / 1.33 sans-serif);
     cursor: pointer;
+    max-width: 200px;
     transition: background var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
   }
 
-  button.chip:hover {
+  :global(.chip--button):hover {
     background: color-mix(in srgb, var(--smrt-color-surface-variant, #e1e2ec) 92%, var(--smrt-color-shadow, #000));
   }
 
-  button.chip:focus-visible {
+  :global(.chip--button):focus-visible {
     outline: 2px solid var(--smrt-color-primary, #005ac1);
     outline-offset: 1px;
   }

--- a/packages/messages/src/svelte/components/AttachmentUpload.svelte
+++ b/packages/messages/src/svelte/components/AttachmentUpload.svelte
@@ -11,6 +11,7 @@ export interface Props {
 
 <script lang="ts">
   import { useI18n } from '@happyvertical/smrt-ui/i18n';
+  import { Button } from '@happyvertical/smrt-ui/ui';
   import { M } from '../i18n.js';
 
   const { t } = useI18n();
@@ -59,11 +60,12 @@ export interface Props {
         <div class="attachment-item">
           <span class="filename">{attachment.filename}</span>
           <span class="size">{formatSize(attachment.size)}</span>
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             class="remove"
             onclick={() => onremove?.(i)}
-            type="button"
-          >×</button>
+          >×</Button>
         </div>
       {/each}
     </div>
@@ -122,10 +124,15 @@ export interface Props {
     font-size: var(--smrt-typography-label-small-size, 11px);
   }
 
-  .remove {
+  /*
+   * The remove button now renders through smrt-ui's <Button variant="ghost">.
+   * The <button> lives inside the Button child, so `.attachment-item :global(.remove)`
+   * anchors on the real `.attachment-item` element and pierces the child scope to
+   * keep the compact error-colored icon styling (issue #1589).
+   */
+  .attachment-item :global(.remove) {
     background: none;
     border: none;
-    cursor: pointer;
     padding: 0 var(--smrt-spacing-1, 4px);
     color: var(--smrt-color-error, #ba1a1a);
     font-size: var(--smrt-typography-label-large-size, 14px);

--- a/packages/messages/src/svelte/components/ComposeForm.svelte
+++ b/packages/messages/src/svelte/components/ComposeForm.svelte
@@ -18,6 +18,7 @@ export interface Props {
 
 <script lang="ts">
   import { useI18n } from '@happyvertical/smrt-ui/i18n';
+  import { Button } from '@happyvertical/smrt-ui/ui';
   import { M } from '../i18n.js';
   import RecipientInput from './RecipientInput.svelte';
   import AttachmentUpload from './AttachmentUpload.svelte';
@@ -182,10 +183,10 @@ export interface Props {
     {#if !showCc || !showBcc}
       <div class="cc-toggles">
         {#if !showCc}
-          <button type="button" class="link-btn" onclick={() => showCc = true}>Cc</button>
+          <Button variant="ghost" size="sm" class="link-btn" onclick={() => showCc = true}>Cc</Button>
         {/if}
         {#if !showBcc}
-          <button type="button" class="link-btn" onclick={() => showBcc = true}>Bcc</button>
+          <Button variant="ghost" size="sm" class="link-btn" onclick={() => showBcc = true}>Bcc</Button>
         {/if}
       </div>
     {/if}
@@ -259,19 +260,19 @@ export interface Props {
   {/if}
 
   <div class="actions">
-    <button
+    <Button
       type="submit"
-      class="btn-primary"
+      variant="primary"
       disabled={isSending || isOverLimit}
     >
       {isSending ? 'Sending...' : 'Send'}
-    </button>
-    <button type="button" class="btn-secondary" onclick={handleSaveDraft}>
+    </Button>
+    <Button variant="secondary" onclick={handleSaveDraft}>
       {t(M['messages.compose_form.save_draft'])}
-    </button>
-    <button type="button" class="btn-text" onclick={() => ondiscard?.()}>
+    </Button>
+    <Button variant="ghost" class="btn-text" onclick={() => ondiscard?.()}>
       Discard
-    </button>
+    </Button>
   </div>
 </form>
 
@@ -316,10 +317,15 @@ export interface Props {
     justify-content: flex-end;
   }
 
-  .link-btn {
+  /*
+   * The Cc/Bcc toggles now render through smrt-ui's <Button variant="ghost">.
+   * `.cc-toggles :global(.link-btn)` anchors on the real `.cc-toggles` element
+   * and pierces the Button child scope to keep the underlined text-link look
+   * (issue #1589).
+   */
+  .cc-toggles :global(.link-btn) {
     background: none;
     border: none;
-    cursor: pointer;
     color: var(--smrt-color-primary, #6750a4);
     font-size: var(--smrt-typography-label-large-size, 13px);
     text-decoration: underline;
@@ -373,40 +379,13 @@ export interface Props {
     padding-top: var(--smrt-spacing-2, 8px);
   }
 
-  .btn-primary {
-    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-6, 24px);
-    border-radius: var(--smrt-radius-full, 20px);
-    border: none;
-    background: var(--smrt-color-primary, #6750a4);
-    color: var(--smrt-color-on-primary, #fff);
-    font-family: var(--smrt-font-family, system-ui);
-    font-size: var(--smrt-typography-label-large-size, 14px);
-    cursor: pointer;
-  }
-
-  .btn-primary:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-
-  .btn-secondary {
-    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-4, 16px);
-    border-radius: var(--smrt-radius-full, 20px);
-    border: 1px solid var(--smrt-color-outline, #79747e);
-    background: transparent;
-    color: var(--smrt-color-primary, #6750a4);
-    font-family: var(--smrt-font-family, system-ui);
-    font-size: var(--smrt-typography-label-large-size, 14px);
-    cursor: pointer;
-  }
-
-  .btn-text {
-    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-4, 16px);
-    border: none;
-    background: transparent;
+  /*
+   * Send/Save-draft now use Button's primary/secondary variants directly (dead
+   * .btn-primary/.btn-secondary CSS removed). The Discard button keeps its
+   * neutral on-surface-variant text via `.actions :global(.btn-text)` (Button's
+   * ghost uses the primary color) — issue #1589.
+   */
+  .actions :global(.btn-text) {
     color: var(--smrt-color-on-surface-variant, #49454f);
-    font-family: var(--smrt-font-family, system-ui);
-    font-size: var(--smrt-typography-label-large-size, 14px);
-    cursor: pointer;
   }
 </style>

--- a/packages/messages/src/svelte/components/EmailAccountManager.svelte
+++ b/packages/messages/src/svelte/components/EmailAccountManager.svelte
@@ -6,6 +6,7 @@
  * email accounts. Works with any backend via callback props.
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
 import type { EmailAccountData } from '../types.js';
 
@@ -171,10 +172,12 @@ function getProviderLabel(type: string): string {
       {t(M['messages.email_account_manager.section_description'])}
     </div>
     {#if !isReadonly && onsave}
-      <button
+      <Button
+        variant="secondary"
+        size="sm"
         class="add-btn"
         onclick={() => { resetForm(); showForm = true; }}
-      >{t(M['messages.email_account_manager.add_account'])}</button>
+      >{t(M['messages.email_account_manager.add_account'])}</Button>
     {/if}
   </div>
 
@@ -261,10 +264,10 @@ function getProviderLabel(type: string): string {
       </div>
 
       <div class="form-actions">
-        <button class="cancel-btn" onclick={resetForm} disabled={saving}>Cancel</button>
-        <button class="save-btn" onclick={save} disabled={saving || !maName.trim() || !maEmail.trim()}>
+        <Button variant="secondary" size="sm" class="cancel-btn" onclick={resetForm} disabled={saving}>Cancel</Button>
+        <Button variant="primary" size="sm" class="save-btn" onclick={save} disabled={saving || !maName.trim() || !maEmail.trim()}>
           {saving ? 'Saving...' : editingId ? 'Update' : 'Add Account'}
-        </button>
+        </Button>
       </div>
     </div>
   {/if}
@@ -272,12 +275,13 @@ function getProviderLabel(type: string): string {
   {#if actionError}
     <div class="test-result failure" role="alert" aria-live="assertive">
       {actionError}
-      <button
-        type="button"
+      <Button
+        variant="ghost"
+        size="sm"
         class="dismiss-btn"
         aria-label={t(M['messages.email_account_manager.dismiss_error'])}
         onclick={() => actionError = null}
-      >&times;</button>
+      >&times;</Button>
     </div>
   {/if}
 
@@ -288,7 +292,7 @@ function getProviderLabel(type: string): string {
       {:else}
         {t(M['messages.email_account_manager.connection_failed'])} {testResult.error ?? 'Unknown error'}
       {/if}
-      <button class="dismiss-btn" onclick={() => testResult = null}>&times;</button>
+      <Button variant="ghost" size="sm" class="dismiss-btn" onclick={() => testResult = null}>&times;</Button>
     </div>
   {/if}
 
@@ -327,21 +331,25 @@ function getProviderLabel(type: string): string {
           {#if !isReadonly}
             <div class="entry-actions">
               {#if ontest}
-                <button
+                <Button
+                  variant="ghost"
+                  size="sm"
                   class="test-btn"
                   onclick={(e) => { e.stopPropagation(); testConnection(acct); }}
                   disabled={testingId === acct.id}
                   title={t(M['messages.email_account_manager.test_connection'])}
                 >
                   {testingId === acct.id ? '...' : 'Test'}
-                </button>
+                </Button>
               {/if}
               {#if ondelete}
-                <button
+                <Button
+                  variant="ghost"
+                  size="sm"
                   class="delete-btn"
                   onclick={(e) => { e.stopPropagation(); remove(acct); }}
                   title={t(M['messages.email_account_manager.remove'])}
-                >&times;</button>
+                >&times;</Button>
               {/if}
             </div>
           {/if}
@@ -370,23 +378,15 @@ function getProviderLabel(type: string): string {
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
-  .add-btn {
-    padding: 0.375rem 0.75rem;
+  /*
+   * The add button now renders through smrt-ui's <Button variant="secondary">.
+   * The variant owns the outlined-primary look + hover; `.section-header-row
+   * :global(.add-btn)` only re-asserts radius and the flex-shrink so the button
+   * keeps its place in the header row (issue #1589).
+   */
+  .section-header-row :global(.add-btn) {
     border-radius: var(--smrt-radius-md, 8px);
-    border: 1px solid var(--smrt-color-primary, #005ac1);
-    background: transparent;
-    color: var(--smrt-color-primary, #005ac1);
-    cursor: pointer;
-    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
-    font-family: inherit;
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    transition: all 150ms ease;
     flex-shrink: 0;
-  }
-
-  .add-btn:hover {
-    background: var(--smrt-color-primary, #005ac1);
-    color: var(--smrt-color-on-primary, #fff);
   }
 
   .entry-form {
@@ -481,42 +481,20 @@ function getProviderLabel(type: string): string {
     padding-top: 0.25rem;
   }
 
-  .cancel-btn {
-    padding: 0.375rem 0.75rem;
+  /*
+   * Cancel/Save now use Button's secondary/primary variants (dead bespoke CSS
+   * removed). `.form-actions :global(...)` only re-asserts the rounded radius so
+   * they match the form's other controls (issue #1589). Cancel's neutral outline
+   * color override keeps it from picking up secondary's primary border color.
+   */
+  .form-actions :global(.cancel-btn),
+  .form-actions :global(.save-btn) {
     border-radius: var(--smrt-radius-md, 8px);
-    border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
-    background: transparent;
+  }
+
+  .form-actions :global(.cancel-btn) {
+    border-color: var(--smrt-color-outline-variant, #c2c7cf);
     color: var(--smrt-color-on-surface-variant, #43474e);
-    cursor: pointer;
-    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
-    font-family: inherit;
-    transition: all 150ms ease;
-  }
-
-  .cancel-btn:hover {
-    background: var(--smrt-color-surface-container-high, #e6e7ef);
-  }
-
-  .save-btn {
-    padding: 0.375rem 0.75rem;
-    border-radius: var(--smrt-radius-md, 8px);
-    border: 1px solid var(--smrt-color-primary, #005ac1);
-    background: var(--smrt-color-primary, #005ac1);
-    color: var(--smrt-color-on-primary, #fff);
-    cursor: pointer;
-    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
-    font-family: inherit;
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    transition: all 150ms ease;
-  }
-
-  .save-btn:hover:not(:disabled) {
-    opacity: 0.9;
-  }
-
-  .save-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
   }
 
   .test-result {
@@ -538,11 +516,16 @@ function getProviderLabel(type: string): string {
     color: var(--smrt-color-error, #ba1a1a);
   }
 
-  .dismiss-btn {
+  /*
+   * The dismiss button now renders through smrt-ui's <Button variant="ghost">.
+   * `.test-result :global(.dismiss-btn)` anchors on the real `.test-result`
+   * element and pierces the Button child scope. `color: inherit` keeps the icon
+   * matching the success/failure banner color (issue #1589).
+   */
+  .test-result :global(.dismiss-btn) {
     background: transparent;
     border: none;
     font-size: var(--smrt-typography-body-large-size, 1rem);
-    cursor: pointer;
     color: inherit;
     padding: 0 0.25rem;
   }
@@ -661,29 +644,28 @@ function getProviderLabel(type: string): string {
     flex-shrink: 0;
   }
 
-  .test-btn {
+  /*
+   * The test and delete buttons now render through smrt-ui's <Button
+   * variant="ghost">. The <button> is emitted inside the Button child, so
+   * `.entry-actions :global(...)` anchors on the real `.entry-actions` element
+   * and pierces the child scope to keep the original outlined-pill styling and
+   * the delete button's red-on-hover affordance (issue #1589).
+   */
+  .entry-actions :global(.test-btn) {
     padding: 0.25rem 0.5rem;
     border-radius: var(--smrt-radius-sm, 4px);
     border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
-    cursor: pointer;
     font-size: var(--smrt-typography-label-small-size, 0.6875rem);
-    font-family: inherit;
-    transition: all 150ms ease;
   }
 
-  .test-btn:hover:not(:disabled) {
+  .entry-actions :global(.test-btn):hover:not(:disabled) {
     border-color: var(--smrt-color-primary, #005ac1);
     color: var(--smrt-color-primary, #005ac1);
   }
 
-  .test-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .delete-btn {
+  .entry-actions :global(.delete-btn) {
     font-size: var(--smrt-typography-body-large-size, 1rem);
     line-height: 1;
     padding: 0.125rem 0.5rem;
@@ -691,13 +673,10 @@ function getProviderLabel(type: string): string {
     border: 1px solid transparent;
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
-    cursor: pointer;
-    font-family: inherit;
-    transition: all 150ms ease;
     flex-shrink: 0;
   }
 
-  .delete-btn:hover {
+  .entry-actions :global(.delete-btn):hover {
     background: var(--smrt-color-error-container, #fce4ec);
     color: var(--smrt-color-error, #ba1a1a);
     border-color: var(--smrt-color-error, #ba1a1a);

--- a/packages/messages/src/svelte/components/EmailFilterManager.svelte
+++ b/packages/messages/src/svelte/components/EmailFilterManager.svelte
@@ -6,6 +6,7 @@
  * Works with any backend via callback props.
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
 import type { BlacklistEntry, WhitelistEntry } from '../types.js';
 
@@ -158,33 +159,36 @@ function getPatternPlaceholder(type: string): string {
 
 <div class="email-filter-manager">
   <div class="section-toggle">
-    <button
+    <Button
+      variant={activeSection === 'whitelist' ? 'primary' : 'ghost'}
+      size="sm"
       class="section-btn"
-      class:active={activeSection === 'whitelist'}
       onclick={() => activeSection = 'whitelist'}
     >
       Whitelist
       <span class="count">{whitelist.length}</span>
-    </button>
-    <button
+    </Button>
+    <Button
+      variant={activeSection === 'blacklist' ? 'primary' : 'ghost'}
+      size="sm"
       class="section-btn"
-      class:active={activeSection === 'blacklist'}
       onclick={() => activeSection = 'blacklist'}
     >
       Blacklist
       <span class="count">{blacklist.length}</span>
-    </button>
+    </Button>
   </div>
 
   {#if filterError}
     <div class="filter-error" role="alert" aria-live="assertive">
       {filterError}
-      <button
-        type="button"
+      <Button
+        variant="ghost"
+        size="sm"
         class="dismiss-btn"
         aria-label={t(M['messages.email_filter_manager.dismiss_error'])}
         onclick={() => filterError = null}
-      >&times;</button>
+      >&times;</Button>
     </div>
   {/if}
 
@@ -196,10 +200,12 @@ function getPatternPlaceholder(type: string): string {
           {t(M['messages.email_filter_manager.whitelist_description'])}
         </div>
         {#if !isReadonly && onaddwhitelist}
-          <button
+          <Button
+            variant="secondary"
+            size="sm"
             class="add-btn"
             onclick={() => { resetWhitelistForm(); showWhitelistForm = true; }}
-          >+ Add</button>
+          >+ Add</Button>
         {/if}
       </div>
 
@@ -249,10 +255,10 @@ function getPatternPlaceholder(type: string): string {
             </div>
           </div>
           <div class="form-actions">
-            <button class="cancel-btn" onclick={resetWhitelistForm} disabled={savingWhitelist}>Cancel</button>
-            <button class="save-btn" onclick={saveWhitelistEntry} disabled={savingWhitelist || !wlPattern.trim()}>
+            <Button variant="secondary" size="sm" class="cancel-btn" onclick={resetWhitelistForm} disabled={savingWhitelist}>Cancel</Button>
+            <Button variant="primary" size="sm" class="save-btn" onclick={saveWhitelistEntry} disabled={savingWhitelist || !wlPattern.trim()}>
               {savingWhitelist ? 'Saving...' : 'Add'}
-            </button>
+            </Button>
           </div>
         </div>
       {/if}
@@ -276,11 +282,13 @@ function getPatternPlaceholder(type: string): string {
                 {/if}
               </div>
               {#if !isReadonly && onremovewhitelist}
-                <button
+                <Button
+                  variant="ghost"
+                  size="sm"
                   class="delete-btn"
                   onclick={() => removeWhitelistEntry(entry)}
                   title={t(M['messages.email_filter_manager.whitelist_remove'])}
-                >&times;</button>
+                >&times;</Button>
               {/if}
             </div>
           {/each}
@@ -296,10 +304,12 @@ function getPatternPlaceholder(type: string): string {
           {t(M['messages.email_filter_manager.blacklist_description'])}
         </div>
         {#if !isReadonly && onaddblacklist}
-          <button
+          <Button
+            variant="secondary"
+            size="sm"
             class="add-btn"
             onclick={() => { resetBlacklistForm(); showBlacklistForm = true; }}
-          >+ Add</button>
+          >+ Add</Button>
         {/if}
       </div>
 
@@ -345,10 +355,10 @@ function getPatternPlaceholder(type: string): string {
             </div>
           </div>
           <div class="form-actions">
-            <button class="cancel-btn" onclick={resetBlacklistForm} disabled={savingBlacklist}>Cancel</button>
-            <button class="save-btn" onclick={saveBlacklistEntry} disabled={savingBlacklist || !blPattern.trim()}>
+            <Button variant="secondary" size="sm" class="cancel-btn" onclick={resetBlacklistForm} disabled={savingBlacklist}>Cancel</Button>
+            <Button variant="primary" size="sm" class="save-btn" onclick={saveBlacklistEntry} disabled={savingBlacklist || !blPattern.trim()}>
               {savingBlacklist ? 'Saving...' : 'Add'}
-            </button>
+            </Button>
           </div>
         </div>
       {/if}
@@ -372,11 +382,13 @@ function getPatternPlaceholder(type: string): string {
                 {/if}
               </div>
               {#if !isReadonly && onremoveblacklist}
-                <button
+                <Button
+                  variant="ghost"
+                  size="sm"
                   class="delete-btn"
                   onclick={() => removeBlacklistEntry(entry)}
                   title={t(M['messages.email_filter_manager.blacklist_remove'])}
-                >&times;</button>
+                >&times;</Button>
               {/if}
             </div>
           {/each}
@@ -401,28 +413,19 @@ function getPatternPlaceholder(type: string): string {
     border-radius: var(--smrt-radius-md, 8px);
   }
 
-  .section-btn {
+  /*
+   * The whitelist/blacklist toggle now renders through smrt-ui's <Button>,
+   * driven by `variant={active ? 'primary' : 'ghost'}` (a plain class:active view
+   * toggle, not an ARIA tablist). The variants own background/color/hover;
+   * `.section-toggle :global(.section-btn)` only re-asserts the row layout
+   * (flex/gap/radius) inside the pierced Button child scope (issue #1589).
+   */
+  .section-toggle :global(.section-btn) {
     display: flex;
     align-items: center;
     gap: 0.375rem;
-    padding: 0.375rem 0.75rem;
-    border: none;
     border-radius: var(--smrt-radius-md, 8px);
-    background: transparent;
-    color: var(--smrt-color-on-surface-variant, #43474e);
     font-size: var(--smrt-typography-label-large-size, 0.8125rem);
-    font-family: inherit;
-    cursor: pointer;
-    transition: all 150ms ease;
-  }
-
-  .section-btn.active {
-    background: var(--smrt-color-primary-container, #d8e2ff);
-    color: var(--smrt-color-primary, #005ac1);
-  }
-
-  .section-btn:hover:not(.active) {
-    background: var(--smrt-color-surface-container-high, #e6e7ef);
   }
 
   .count {
@@ -450,23 +453,14 @@ function getPatternPlaceholder(type: string): string {
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
-  .add-btn {
-    padding: 0.375rem 0.75rem;
+  /*
+   * The add button now renders through smrt-ui's <Button variant="secondary">.
+   * The variant owns the outlined-primary look + hover; `.section-header-row
+   * :global(.add-btn)` only re-asserts radius and flex-shrink (issue #1589).
+   */
+  .section-header-row :global(.add-btn) {
     border-radius: var(--smrt-radius-md, 8px);
-    border: 1px solid var(--smrt-color-primary, #005ac1);
-    background: transparent;
-    color: var(--smrt-color-primary, #005ac1);
-    cursor: pointer;
-    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
-    font-family: inherit;
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    transition: all 150ms ease;
     flex-shrink: 0;
-  }
-
-  .add-btn:hover {
-    background: var(--smrt-color-primary, #005ac1);
-    color: var(--smrt-color-on-primary, #fff);
   }
 
   .entry-form {
@@ -557,42 +551,20 @@ function getPatternPlaceholder(type: string): string {
     padding-top: 0.25rem;
   }
 
-  .cancel-btn {
-    padding: 0.375rem 0.75rem;
+  /*
+   * Cancel/Save now use Button's secondary/primary variants (dead bespoke CSS
+   * removed). `.form-actions :global(...)` only re-asserts the rounded radius;
+   * Cancel's neutral outline override keeps it from picking up secondary's
+   * primary border color (issue #1589).
+   */
+  .form-actions :global(.cancel-btn),
+  .form-actions :global(.save-btn) {
     border-radius: var(--smrt-radius-md, 8px);
-    border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
-    background: transparent;
+  }
+
+  .form-actions :global(.cancel-btn) {
+    border-color: var(--smrt-color-outline-variant, #c2c7cf);
     color: var(--smrt-color-on-surface-variant, #43474e);
-    cursor: pointer;
-    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
-    font-family: inherit;
-    transition: all 150ms ease;
-  }
-
-  .cancel-btn:hover {
-    background: var(--smrt-color-surface-container-high, #e6e7ef);
-  }
-
-  .save-btn {
-    padding: 0.375rem 0.75rem;
-    border-radius: var(--smrt-radius-md, 8px);
-    border: 1px solid var(--smrt-color-primary, #005ac1);
-    background: var(--smrt-color-primary, #005ac1);
-    color: var(--smrt-color-on-primary, #fff);
-    cursor: pointer;
-    font-size: var(--smrt-typography-label-large-size, 0.8125rem);
-    font-family: inherit;
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    transition: all 150ms ease;
-  }
-
-  .save-btn:hover:not(:disabled) {
-    opacity: 0.9;
-  }
-
-  .save-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
   }
 
   .entries-list {
@@ -684,7 +656,13 @@ function getPatternPlaceholder(type: string): string {
     flex-shrink: 0;
   }
 
-  .delete-btn {
+  /*
+   * The remove button now renders through smrt-ui's <Button variant="ghost">.
+   * `.entry-card :global(.delete-btn)` anchors on the real `.entry-card` element
+   * and pierces the Button child scope to keep the round icon button and its
+   * red-on-hover affordance (issue #1589).
+   */
+  .entry-card :global(.delete-btn) {
     font-size: var(--smrt-typography-body-large-size, 1rem);
     line-height: 1;
     padding: 0.125rem 0.5rem;
@@ -692,13 +670,10 @@ function getPatternPlaceholder(type: string): string {
     border: 1px solid transparent;
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
-    cursor: pointer;
-    font-family: inherit;
-    transition: all 150ms ease;
     flex-shrink: 0;
   }
 
-  .delete-btn:hover {
+  .entry-card :global(.delete-btn):hover {
     background: var(--smrt-color-error-container, #fce4ec);
     color: var(--smrt-color-error, #ba1a1a);
     border-color: var(--smrt-color-error, #ba1a1a);
@@ -724,11 +699,16 @@ function getPatternPlaceholder(type: string): string {
     font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
   }
 
-  .dismiss-btn {
+  /*
+   * The dismiss button now renders through smrt-ui's <Button variant="ghost">.
+   * `.filter-error :global(.dismiss-btn)` anchors on the real `.filter-error`
+   * element and pierces the Button child scope. `color: inherit` keeps the icon
+   * matching the error banner color (issue #1589).
+   */
+  .filter-error :global(.dismiss-btn) {
     background: transparent;
     border: none;
     font-size: var(--smrt-typography-body-large-size, 1rem);
-    cursor: pointer;
     color: inherit;
     padding: 0 0.25rem;
   }

--- a/packages/messages/src/svelte/components/FolderNav.svelte
+++ b/packages/messages/src/svelte/components/FolderNav.svelte
@@ -3,6 +3,7 @@
  * FolderNav - Folder/label navigation sidebar
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.messages.js';
 import type { FolderData } from '../types.js';
 
@@ -50,10 +51,10 @@ function getFolderIcon(specialUse?: string): string {
     <ul class="folder-list" role="list">
       {#each _systemFolders as folder (folder.id)}
         <li>
-          <button
-            class="folder-item"
-            class:folder-item--active={folder.id === activeFolderId}
-            type="button"
+          <Button
+            variant="ghost"
+            fullWidth
+            class={folder.id === activeFolderId ? 'folder-item folder-item--active' : 'folder-item'}
             onclick={() => onfolderclick?.(folder)}
             aria-current={folder.id === activeFolderId ? 'true' : undefined}
           >
@@ -62,7 +63,7 @@ function getFolderIcon(specialUse?: string): string {
             {#if showCounts && folder.unreadCount > 0}
               <span class="unread-badge">{folder.unreadCount}</span>
             {/if}
-          </button>
+          </Button>
         </li>
       {/each}
     </ul>
@@ -75,10 +76,10 @@ function getFolderIcon(specialUse?: string): string {
     <ul class="folder-list" role="list">
       {#each _userFolders as folder (folder.id)}
         <li>
-          <button
-            class="folder-item"
-            class:folder-item--active={folder.id === activeFolderId}
-            type="button"
+          <Button
+            variant="ghost"
+            fullWidth
+            class={folder.id === activeFolderId ? 'folder-item folder-item--active' : 'folder-item'}
             onclick={() => onfolderclick?.(folder)}
             aria-current={folder.id === activeFolderId ? 'true' : undefined}
           >
@@ -87,7 +88,7 @@ function getFolderIcon(specialUse?: string): string {
             {#if showCounts && folder.unreadCount > 0}
               <span class="unread-badge">{folder.unreadCount}</span>
             {/if}
-          </button>
+          </Button>
         </li>
       {/each}
     </ul>
@@ -107,7 +108,14 @@ function getFolderIcon(specialUse?: string): string {
     padding: 0;
   }
 
-  .folder-item {
+  /*
+   * Folder rows now render through smrt-ui's <Button variant="ghost" fullWidth>.
+   * The <button> is emitted inside the Button child, so `.folder-list :global(.folder-item)`
+   * anchors on the real `.folder-list` element and pierces the child scope to keep
+   * the nav-row layout, neutral color, hover and active styling (issue #1589). The
+   * active modifier is `folder-item--active`, NOT a Button variant class.
+   */
+  .folder-list :global(.folder-item) {
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -115,7 +123,6 @@ function getFolderIcon(specialUse?: string): string {
     padding: 0.5rem 0.75rem;
     border: none;
     background: none;
-    cursor: pointer;
     font: var(--smrt-typography-body-medium-font, 0.875rem / 1.25 sans-serif);
     color: var(--smrt-color-on-surface, #1a1c1e);
     border-radius: var(--smrt-radius-small, 0.25rem);
@@ -123,16 +130,16 @@ function getFolderIcon(specialUse?: string): string {
     text-align: left;
   }
 
-  .folder-item:hover {
+  .folder-list :global(.folder-item):hover {
     background: var(--smrt-color-surface-variant, #e1e2ec);
   }
 
-  .folder-item--active {
+  .folder-list :global(.folder-item--active) {
     background: var(--smrt-color-secondary-container, #d7e3f7);
     font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
-  .folder-item:focus-visible {
+  .folder-list :global(.folder-item):focus-visible {
     outline: 2px solid var(--smrt-color-primary, #005ac1);
     outline-offset: -2px;
   }

--- a/packages/messages/src/svelte/components/ForwardForm.svelte
+++ b/packages/messages/src/svelte/components/ForwardForm.svelte
@@ -10,6 +10,7 @@ export interface Props {
 
 <script lang="ts">
   import { useI18n } from '@happyvertical/smrt-ui/i18n';
+  import { Button } from '@happyvertical/smrt-ui/ui';
   import { M } from '../i18n.js';
   import RecipientInput from './RecipientInput.svelte';
 
@@ -85,17 +86,16 @@ export interface Props {
   {/if}
 
   <div class="actions">
-    <button
-      type="button"
-      class="btn-primary"
+    <Button
+      variant="primary"
       disabled={isSending || to.length === 0}
       onclick={handleSend}
     >
       {isSending ? 'Sending...' : 'Forward'}
-    </button>
-    <button type="button" class="btn-text" onclick={() => oncancel?.()}>
+    </Button>
+    <Button variant="ghost" class="btn-text" onclick={() => oncancel?.()}>
       Cancel
-    </button>
+    </Button>
   </div>
 </div>
 
@@ -162,29 +162,13 @@ export interface Props {
     gap: var(--smrt-spacing-2, 8px);
   }
 
-  .btn-primary {
-    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-6, 24px);
-    border-radius: var(--smrt-radius-full, 20px);
-    border: none;
-    background: var(--smrt-color-primary, #6750a4);
-    color: var(--smrt-color-on-primary, #fff);
-    font-family: var(--smrt-font-family, system-ui);
-    font-size: var(--smrt-typography-label-large-size, 14px);
-    cursor: pointer;
-  }
-
-  .btn-primary:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-
-  .btn-text {
-    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-4, 16px);
-    border: none;
-    background: transparent;
+  /*
+   * Forward now uses Button's primary variant directly (dead .btn-primary CSS
+   * removed). The Cancel button keeps its neutral on-surface-variant text via
+   * `.actions :global(.btn-text)` (Button's ghost uses the primary color) —
+   * issue #1589.
+   */
+  .actions :global(.btn-text) {
     color: var(--smrt-color-on-surface-variant, #49454f);
-    font-family: var(--smrt-font-family, system-ui);
-    font-size: var(--smrt-typography-label-large-size, 14px);
-    cursor: pointer;
   }
 </style>

--- a/packages/messages/src/svelte/components/MessageCard.svelte
+++ b/packages/messages/src/svelte/components/MessageCard.svelte
@@ -4,6 +4,7 @@
  */
 
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { Snippet } from 'svelte';
 import { M } from '../i18n.messages.js';
 import type { AccountData, MessageData } from '../types.js';
@@ -106,6 +107,7 @@ const _slackMeta = $derived.by(() => {
     </div>
   {/if}
 
+  <!-- raw-primitive-allow: large pressable message row wrapping rich header/subject/preview content (a structural selection surface with descendant compact-mode layout rules), not a standard action button -->
   <button
     class="message-content"
     type="button"
@@ -162,15 +164,15 @@ const _slackMeta = $derived.by(() => {
   </button>
 
   {#if onflag}
-    <button
+    <Button
+      variant="ghost"
       class="flag-btn"
-      type="button"
       onclick={() => onflag?.(message)}
       title={message.isFlagged ? 'Unflag' : 'Flag'}
       aria-label={message.isFlagged ? 'Unflag' : 'Flag'}
     >
       {message.isFlagged ? '⚑' : '⚐'}
-    </button>
+    </Button>
   {/if}
 </div>
 
@@ -308,21 +310,26 @@ const _slackMeta = $derived.by(() => {
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
-  .flag-btn {
+  /*
+   * The flag toggle now renders through smrt-ui's <Button variant="ghost">.
+   * `.message-card :global(.flag-btn)` anchors on the real `.message-card`
+   * element and pierces the Button child scope to keep the dimmed icon-toggle
+   * styling (issue #1589).
+   */
+  .message-card :global(.flag-btn) {
     display: flex;
     align-items: center;
     justify-content: center;
     width: 2rem;
     border: none;
     background: none;
-    cursor: pointer;
     font-size: var(--smrt-typography-body-large-size, 1rem);
     color: var(--smrt-color-on-surface-variant, #43474e);
     opacity: 0.5;
     transition: opacity var(--smrt-duration-short2, 150ms);
   }
 
-  .flag-btn:hover {
+  .message-card :global(.flag-btn):hover {
     opacity: 1;
   }
 

--- a/packages/messages/src/svelte/components/MessageDetail.svelte
+++ b/packages/messages/src/svelte/components/MessageDetail.svelte
@@ -3,7 +3,7 @@
  * MessageDetail - Full message view with type-adaptive sections
  */
 
-import { Card } from '@happyvertical/smrt-ui/ui';
+import { Button, Card } from '@happyvertical/smrt-ui/ui';
 import type { Snippet } from 'svelte';
 import type { AccountData, AttachmentData, MessageData } from '../types.js';
 import AttachmentChip from './AttachmentChip.svelte';
@@ -162,19 +162,19 @@ const _displayBody = $derived.by(() => {
     {#if onreply || onforward || ondelete}
       <div class="actions">
         {#if onreply}
-          <button class="action-btn" type="button" onclick={() => onreply?.(message)}>
+          <Button variant="ghost" class="action-btn" onclick={() => onreply?.(message)}>
             ↩ Reply
-          </button>
+          </Button>
         {/if}
         {#if onforward}
-          <button class="action-btn" type="button" onclick={() => onforward?.(message)}>
+          <Button variant="ghost" class="action-btn" onclick={() => onforward?.(message)}>
             ↪ Forward
-          </button>
+          </Button>
         {/if}
         {#if ondelete}
-          <button class="action-btn action-btn--danger" type="button" onclick={() => ondelete?.(message)}>
+          <Button variant="ghost" class="action-btn action-btn--danger" onclick={() => ondelete?.(message)}>
             🗑 Delete
-          </button>
+          </Button>
         {/if}
       </div>
     {/if}
@@ -280,27 +280,34 @@ const _displayBody = $derived.by(() => {
     border-top: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
   }
 
-  .action-btn {
+  /*
+   * Action buttons now render through smrt-ui's <Button variant="ghost">. The
+   * <button> is emitted inside the Button child, so `.actions :global(.action-btn)`
+   * anchors on the real `.actions` element and pierces the child scope to keep
+   * the original outlined-surface styling (issue #1589). The destructive button's
+   * modifier is `action-btn--danger`, NOT `danger`, to avoid colliding with
+   * Button's own `.danger` variant class.
+   */
+  .actions :global(.action-btn) {
     padding: 0.5rem 1rem;
     border: 1px solid var(--smrt-color-outline, #72787e);
     border-radius: var(--smrt-radius-small, 0.25rem);
     background: var(--smrt-color-surface, #fefbff);
     color: var(--smrt-color-on-surface, #1a1c1e);
     font: var(--smrt-typography-label-large-font, 500 0.875rem / 1.25 sans-serif);
-    cursor: pointer;
     transition: background var(--smrt-duration-short2, 150ms);
   }
 
-  .action-btn:hover {
+  .actions :global(.action-btn):hover {
     background: var(--smrt-color-surface-variant, #e1e2ec);
   }
 
-  .action-btn--danger {
+  .actions :global(.action-btn--danger) {
     color: var(--smrt-color-error, #ba1a1a);
     border-color: var(--smrt-color-error, #ba1a1a);
   }
 
-  .action-btn--danger:hover {
+  .actions :global(.action-btn--danger):hover {
     background: var(--smrt-color-error-container, #ffdad6);
   }
 </style>

--- a/packages/messages/src/svelte/components/MessageFilters.svelte
+++ b/packages/messages/src/svelte/components/MessageFilters.svelte
@@ -3,6 +3,7 @@
  * MessageFilters - Filter/sort controls bar
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.messages.js';
 import type {
   AccountData,
@@ -85,7 +86,7 @@ const _hasActiveFilters = $derived(
       onkeydown={(e) => { if (e.key === 'Enter') handleSearch(); }}
       aria-label={t(M['messages.message_filters.search_label'])}
     />
-    <button class="search-btn" type="button" onclick={handleSearch}>Search</button>
+    <Button variant="primary" class="search-btn" onclick={handleSearch}>Search</Button>
   </div>
 
   <div class="filter-row">
@@ -139,9 +140,9 @@ const _hasActiveFilters = $derived(
     </label>
 
     {#if _hasActiveFilters}
-      <button class="clear-btn" type="button" onclick={clearFilters}>
+      <Button variant="ghost" size="sm" class="clear-btn" onclick={clearFilters}>
         {t(M['messages.message_filters.clear_filters'])}
-      </button>
+      </Button>
     {/if}
   </div>
 </div>
@@ -177,18 +178,16 @@ const _hasActiveFilters = $derived(
     outline-offset: -1px;
   }
 
-  .search-btn {
+  /*
+   * Search now renders through smrt-ui's <Button variant="primary">. The variant
+   * owns the filled-primary background + hover; `.search-row :global(.search-btn)`
+   * only re-asserts the original small radius and label font/padding by piercing
+   * the Button child scope (issue #1589).
+   */
+  .search-row :global(.search-btn) {
     padding: 0.5rem 1rem;
-    border: none;
     border-radius: var(--smrt-radius-small, 0.25rem);
-    background: var(--smrt-color-primary, #005ac1);
-    color: var(--smrt-color-on-primary, #fff);
     font: var(--smrt-typography-label-large-font, 500 0.875rem / 1.25 sans-serif);
-    cursor: pointer;
-  }
-
-  .search-btn:hover {
-    opacity: 0.9;
   }
 
   .filter-row {
@@ -216,13 +215,18 @@ const _hasActiveFilters = $derived(
     cursor: pointer;
   }
 
-  .clear-btn {
+  /*
+   * Clear filters now renders through smrt-ui's <Button variant="ghost">.
+   * `.filter-row :global(.clear-btn)` anchors on the real `.filter-row` element
+   * and pierces the Button child scope to keep the underlined text-link look
+   * (issue #1589).
+   */
+  .filter-row :global(.clear-btn) {
     padding: 0.25rem 0.5rem;
     border: none;
     background: none;
     font: var(--smrt-typography-label-medium-font, 500 0.75rem / 1.33 sans-serif);
     color: var(--smrt-color-primary, #005ac1);
-    cursor: pointer;
     text-decoration: underline;
   }
 </style>

--- a/packages/messages/src/svelte/components/MessageToolbar.svelte
+++ b/packages/messages/src/svelte/components/MessageToolbar.svelte
@@ -3,6 +3,7 @@
  * MessageToolbar - Bulk action toolbar
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { Snippet } from 'svelte';
 import { M } from '../i18n.messages.js';
 import type { BulkAction } from '../types.js';
@@ -33,37 +34,37 @@ const {
     {#if selectedCount > 0}
       <span class="count">{t(M['messages.message_toolbar.count_selected'], { selectedCount, totalCount })}</span>
       {#if onclearselection}
-        <button class="link-btn" type="button" onclick={onclearselection}>
+        <Button variant="ghost" size="sm" class="link-btn" onclick={onclearselection}>
           Clear
-        </button>
+        </Button>
       {/if}
     {:else}
       <span class="count">{totalCount} messages</span>
     {/if}
     {#if onselectall && selectedCount < totalCount}
-      <button class="link-btn" type="button" onclick={onselectall}>
+      <Button variant="ghost" size="sm" class="link-btn" onclick={onselectall}>
         {t(M['messages.message_toolbar.select_all'])}
-      </button>
+      </Button>
     {/if}
   </div>
 
   {#if selectedCount > 0 && onaction}
     <div class="actions">
-      <button class="action-btn" type="button" onclick={() => onaction?.('markRead')}>
+      <Button variant="ghost" size="sm" class="action-btn" onclick={() => onaction?.('markRead')}>
         {t(M['messages.message_toolbar.mark_read'])}
-      </button>
-      <button class="action-btn" type="button" onclick={() => onaction?.('markUnread')}>
+      </Button>
+      <Button variant="ghost" size="sm" class="action-btn" onclick={() => onaction?.('markUnread')}>
         {t(M['messages.message_toolbar.mark_unread'])}
-      </button>
-      <button class="action-btn" type="button" onclick={() => onaction?.('flag')}>
+      </Button>
+      <Button variant="ghost" size="sm" class="action-btn" onclick={() => onaction?.('flag')}>
         Flag
-      </button>
-      <button class="action-btn" type="button" onclick={() => onaction?.('unflag')}>
+      </Button>
+      <Button variant="ghost" size="sm" class="action-btn" onclick={() => onaction?.('unflag')}>
         Unflag
-      </button>
-      <button class="action-btn action-btn--danger" type="button" onclick={() => onaction?.('delete')}>
+      </Button>
+      <Button variant="ghost" size="sm" class="action-btn action-btn--danger" onclick={() => onaction?.('delete')}>
         Delete
-      </button>
+      </Button>
       {#if extraActions}
         {@render extraActions()}
       {/if}
@@ -94,12 +95,20 @@ const {
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
-  .link-btn {
+  /*
+   * The link and action buttons now render through smrt-ui's <Button
+   * variant="ghost">. The <button> is emitted inside the Button child, so a
+   * plain scoped rule would not match — anchoring on the real `.selection-info`
+   * / `.actions` elements and piercing with `:global(...)` keeps the original
+   * text-link / outlined-surface styling (issue #1589). The destructive button's
+   * modifier is `action-btn--danger`, NOT `danger`, so it never collides with
+   * Button's own `.danger` variant class.
+   */
+  .selection-info :global(.link-btn) {
     border: none;
     background: none;
     font: var(--smrt-typography-label-medium-font, 500 0.75rem / 1.33 sans-serif);
     color: var(--smrt-color-primary, #005ac1);
-    cursor: pointer;
     text-decoration: underline;
     padding: 0;
   }
@@ -110,21 +119,20 @@ const {
     flex-wrap: wrap;
   }
 
-  .action-btn {
+  .actions :global(.action-btn) {
     padding: 0.25rem 0.625rem;
     border: 1px solid var(--smrt-color-outline, #72787e);
     border-radius: var(--smrt-radius-small, 0.25rem);
     background: var(--smrt-color-surface, #fefbff);
     color: var(--smrt-color-on-surface, #1a1c1e);
     font: var(--smrt-typography-label-small-font, 500 0.6875rem / 1 sans-serif);
-    cursor: pointer;
   }
 
-  .action-btn:hover {
+  .actions :global(.action-btn):hover {
     background: var(--smrt-color-surface-variant, #e1e2ec);
   }
 
-  .action-btn--danger {
+  .actions :global(.action-btn--danger) {
     color: var(--smrt-color-error, #ba1a1a);
     border-color: var(--smrt-color-error, #ba1a1a);
   }

--- a/packages/messages/src/svelte/components/RecipientInput.svelte
+++ b/packages/messages/src/svelte/components/RecipientInput.svelte
@@ -10,6 +10,8 @@ export interface Props {
 </script>
 
 <script lang="ts">
+  import { Button } from '@happyvertical/smrt-ui/ui';
+
   let {
     label = 'To',
     recipients = [],
@@ -61,11 +63,12 @@ export interface Props {
     {#each recipients as recipient, i}
       <span class="chip" class:invalid={!recipient.isValid}>
         <span class="chip-text">{recipient.name || recipient.address}</span>
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
           class="chip-remove"
           onclick={() => removeRecipient(i)}
-          type="button"
-        >×</button>
+        >×</Button>
       </span>
     {/each}
     <input
@@ -122,17 +125,23 @@ export interface Props {
     color: var(--smrt-color-on-error-container, #410002);
   }
 
-  .chip-remove {
+  /*
+   * The chip remove button now renders through smrt-ui's <Button variant="ghost">.
+   * `.chips-container :global(.chip-remove)` anchors on the real `.chips-container`
+   * element and pierces the Button child scope to keep the compact icon styling.
+   * `color: inherit` keeps it matching the chip text color (including the invalid
+   * chip's error color) — issue #1589.
+   */
+  .chips-container :global(.chip-remove) {
     background: none;
     border: none;
-    cursor: pointer;
     padding: 0 var(--smrt-spacing-1, 4px);
     font-size: var(--smrt-typography-label-large-size, 14px);
     color: inherit;
     opacity: 0.7;
   }
 
-  .chip-remove:hover {
+  .chips-container :global(.chip-remove):hover {
     opacity: 1;
   }
 

--- a/packages/messages/src/svelte/components/ReplyForm.svelte
+++ b/packages/messages/src/svelte/components/ReplyForm.svelte
@@ -11,6 +11,7 @@ export interface Props {
 
 <script lang="ts">
   import { useI18n } from '@happyvertical/smrt-ui/i18n';
+  import { Button } from '@happyvertical/smrt-ui/ui';
   import { M } from '../i18n.js';
 
   const { t } = useI18n();
@@ -77,17 +78,16 @@ export interface Props {
   {/if}
 
   <div class="actions">
-    <button
-      type="button"
-      class="btn-primary"
+    <Button
+      variant="primary"
       disabled={isSending || !body.trim()}
       onclick={handleSend}
     >
       {isSending ? 'Sending...' : 'Send Reply'}
-    </button>
-    <button type="button" class="btn-text" onclick={() => oncancel?.()}>
+    </Button>
+    <Button variant="ghost" class="btn-text" onclick={() => oncancel?.()}>
       Cancel
-    </button>
+    </Button>
   </div>
 </div>
 
@@ -155,29 +155,13 @@ export interface Props {
     gap: var(--smrt-spacing-2, 8px);
   }
 
-  .btn-primary {
-    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-6, 24px);
-    border-radius: var(--smrt-radius-full, 20px);
-    border: none;
-    background: var(--smrt-color-primary, #6750a4);
-    color: var(--smrt-color-on-primary, #fff);
-    font-family: var(--smrt-font-family, system-ui);
-    font-size: var(--smrt-typography-label-large-size, 14px);
-    cursor: pointer;
-  }
-
-  .btn-primary:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-
-  .btn-text {
-    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-4, 16px);
-    border: none;
-    background: transparent;
+  /*
+   * Send Reply now uses Button's primary variant directly (dead .btn-primary CSS
+   * removed). The Cancel button keeps its neutral on-surface-variant text via
+   * `.actions :global(.btn-text)` (Button's ghost uses the primary color) —
+   * issue #1589.
+   */
+  .actions :global(.btn-text) {
     color: var(--smrt-color-on-surface-variant, #49454f);
-    font-family: var(--smrt-font-family, system-ui);
-    font-size: var(--smrt-typography-label-large-size, 14px);
-    cursor: pointer;
   }
 </style>

--- a/packages/messages/src/svelte/components/ThreadView.svelte
+++ b/packages/messages/src/svelte/components/ThreadView.svelte
@@ -3,6 +3,7 @@
  * ThreadView - Conversation thread with collapsible messages
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.messages.js';
 import type { MessageData } from '../types.js';
 import MessageDetail from './MessageDetail.svelte';
@@ -101,9 +102,10 @@ const _sortedMessages = $derived(
       role="listitem"
     >
       {#if collapsed.has(message.id)}
-        <button
+        <Button
+          variant="ghost"
+          fullWidth
           class="collapsed-header"
-          type="button"
           onclick={() => toggleCollapse(message.id)}
         >
           <span class="collapsed-sender">
@@ -117,19 +119,19 @@ const _sortedMessages = $derived(
               ? new Date(message.date).toLocaleDateString()
               : message.date?.toLocaleDateString() || ''}
           </span>
-        </button>
+        </Button>
       {:else}
         <div class="message-wrapper">
           {#if messages.length > 1}
-            <button
+            <Button
+              variant="ghost"
               class="collapse-btn"
-              type="button"
               onclick={() => toggleCollapse(message.id)}
               title={t(M['messages.thread_view.collapse'])}
               aria-label={t(M['messages.thread_view.collapse_message'])}
             >
               ▼
-            </button>
+            </Button>
           {/if}
           {#if onmessageclick}
             <div
@@ -187,13 +189,19 @@ const _sortedMessages = $derived(
     position: relative;
   }
 
-  .collapse-btn {
+  /*
+   * The collapse toggle and collapsed header now render through smrt-ui's
+   * <Button variant="ghost">. The <button> is emitted inside the Button child,
+   * so anchoring on the real `.message-wrapper` / `.thread-message` elements and
+   * piercing with `:global(...)` keeps the original positioning and styling
+   * (issue #1589).
+   */
+  .message-wrapper :global(.collapse-btn) {
     position: absolute;
     top: 0.75rem;
     right: 0.75rem;
     border: none;
     background: none;
-    cursor: pointer;
     font-size: var(--smrt-typography-label-medium-size, 0.75rem);
     color: var(--smrt-color-on-surface-variant, #43474e);
     z-index: 1;
@@ -201,11 +209,11 @@ const _sortedMessages = $derived(
     border-radius: var(--smrt-radius-small, 0.25rem);
   }
 
-  .collapse-btn:hover {
+  .message-wrapper :global(.collapse-btn):hover {
     background: var(--smrt-color-surface-variant, #e1e2ec);
   }
 
-  .collapsed-header {
+  .thread-message :global(.collapsed-header) {
     display: flex;
     align-items: center;
     gap: 0.75rem;
@@ -214,13 +222,12 @@ const _sortedMessages = $derived(
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     border-radius: var(--smrt-radius-medium, 0.5rem);
     background: var(--smrt-color-surface-variant, #e1e2ec);
-    cursor: pointer;
     text-align: left;
     color: inherit;
     font: inherit;
   }
 
-  .collapsed-header:hover {
+  .thread-message :global(.collapsed-header):hover {
     background: color-mix(in srgb, var(--smrt-color-surface-variant, #e1e2ec) 92%, var(--smrt-color-shadow, #000));
   }
 


### PR DESCRIPTION
## Summary

Buttons-only migration of the **messages** package for #1589: the ~52 raw
`<button>` elements across its Svelte components now render through smrt-ui's
`<Button>` primitive, and the package is flipped to
`"smrtRawPrimitives": "strict-buttons"`.

Forms (`<input>`/`<select>`/`<textarea>`/`<form>`) are **deferred** and left
exactly as-is (the `strict-buttons` ratchet mode exempts them). No new dependency
added — `@happyvertical/smrt-ui` was already a dependency.

## Mapping by role
- Primary actions (Send / Save / Update / Search / Add) → `variant="primary"`
- Secondary / cancel / add-entry → `variant="secondary"`
- Icon, toolbar, text-link, and bespoke buttons → `variant="ghost"` (`size="sm"` where compact)
- Whitelist/Blacklist segmented toggle → `variant={active ? 'primary' : 'ghost'}`
  (a plain `class:active` view toggle, **not** an ARIA tablist)

Custom-styled buttons keep their local class via Button's `class` prop, with the
CSS rewritten as `.ancestor :global(.class)` so it pierces the Button child scope
(mirrors the established `tenancy/TenantCard.svelte` pattern). Destructive
modifiers use `*--danger` class names (`action-btn--danger`, `delete-btn`) to
avoid colliding with Button's own `.danger` variant. Dead local button CSS for
migrated buttons is removed.

## Escape hatch (1)
`MessageCard.svelte` keeps one raw `<button class="message-content">` with a
`raw-primitive-allow` annotation: it is a large pressable message row wrapping
rich header/subject/preview content with descendant compact-mode layout rules —
a structural selection surface, not a standard action button.

## i18n
No new user-facing string or `aria-label` literals introduced. Existing
`t(M[...])` calls and any pre-existing hardcoded labels (e.g. `Cancel`, `Sync`,
`×`, emoji-prefixed `↩ Reply`) are kept byte-identical.

## Notes
- No `use:ripple` was present on any migrated button (none to drop).

## Gates (all green locally)
- `check-raw-primitives.mjs` → exit 0 (messages clean under buttons-only)
- `typecheck` (tsc + svelte-check a11y) → 0 errors / 0 warnings
- `test` → 244 passed, 15 skipped
- `check-package-dag.mjs` + `check-no-smrt-peers.mjs` → exit 0
- `check-hardcoded-strings.mjs` → exit 0 (no new hardcoded strings)
- `biome check` (read-only) on the 15 changed files → exit 0

Scope: only `packages/messages/**`; no form-element markup changed; no lockfile
change; no `console.*` stripped.
