### PR TITLE
refactor(smrt-svelte): migrate shell buttons to Button, flip strict-buttons (#1589)

### DIFF
--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -3,6 +3,7 @@
   "version": "0.34.4",
   "description": "Svelte 5 components for SMRT user management - auth, users, tenants, roles, permissions, groups",
   "type": "module",
+  "smrtRawPrimitives": "strict-buttons",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "svelte": "./dist/index.js",

--- a/packages/smrt-svelte/src/browser-ai/svelte/components/STTTest.svelte
+++ b/packages/smrt-svelte/src/browser-ai/svelte/components/STTTest.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { useAppState } from '../../../hooks/useAppState.svelte.js';
 import { M } from '../../../i18n/strings.workspace.js';
 import type { GetSTTOptions } from '../../index.js';
@@ -117,13 +118,13 @@ function clearLogs() {
       </select>
     </div>
 
-    <button
-      type="button"
+    <Button
+      variant="primary"
       onclick={initializeAdapter}
       disabled={isRecording || isInitializing}
     >
       Initialize
-    </button>
+    </Button>
   </div>
 
   <div class="status">
@@ -153,6 +154,7 @@ function clearLogs() {
   {/if}
 
   <div class="record-controls">
+    <!-- raw-primitive-allow: press-and-hold record control driven by mousedown/up/leave + touchstart/end (push-to-talk), not a click action; Button has no press-and-hold model so this stays a native button -->
     <button
       type="button"
       class="record-btn"
@@ -180,7 +182,7 @@ function clearLogs() {
   <div class="logs">
     <div class="logs-header">
       <strong>Logs:</strong>
-      <button type="button" onclick={clearLogs}>Clear</button>
+      <Button variant="ghost" size="sm" onclick={clearLogs}>Clear</Button>
     </div>
     <div class="log-list">
       {#each logs as logEntry}
@@ -227,27 +229,6 @@ function clearLogs() {
     border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
     border-radius: var(--smrt-radius-small, 6px);
     font: var(--smrt-typography-body-medium-font, 0.875rem / 1.25 sans-serif);
-  }
-
-  .controls button {
-    padding: var(--smrt-spacing-sm, 8px) var(--smrt-spacing-md, 16px);
-    background: var(--smrt-color-primary, #005ac1);
-    color: var(--smrt-color-on-primary, #ffffff);
-    border: none;
-    border-radius: var(--smrt-radius-small, 6px);
-    cursor: pointer;
-    font: var(--smrt-typography-label-large-font, 0.875rem / 1.25 sans-serif);
-    transition: all var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
-  }
-
-  .controls button:hover:not(:disabled) {
-    background: var(--smrt-color-primary-container, #005ac1);
-    opacity: 0.9;
-  }
-
-  .controls button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
   }
 
   .status {
@@ -337,20 +318,6 @@ function clearLogs() {
     margin-bottom: var(--smrt-spacing-sm, 8px);
   }
 
-  .logs-header button {
-    padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-sm, 8px);
-    font: var(--smrt-typography-label-small-font, 0.75rem / 1 sans-serif);
-    background: var(--smrt-color-surface-container, #e5e7eb);
-    border: none;
-    border-radius: var(--smrt-radius-small, 4px);
-    cursor: pointer;
-    transition: background-color var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
-  }
-
-  .logs-header button:hover {
-    background: var(--smrt-color-surface-container-high, #d1d5db);
-  }
-
   .log-list {
     background: var(--smrt-color-inverse-surface, #1f2937);
     color: var(--smrt-color-inverse-on-surface, #d1d5db);
@@ -366,9 +333,7 @@ function clearLogs() {
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .controls button,
-    .record-btn,
-    .logs-header button {
+    .record-btn {
       transition: none;
     }
     

--- a/packages/smrt-svelte/src/browser-ai/svelte/components/VoiceInput.svelte
+++ b/packages/smrt-svelte/src/browser-ai/svelte/components/VoiceInput.svelte
@@ -66,6 +66,7 @@ async function handleToggle() {
       <span>{stt.error.message}</span>
     </div>
   {:else}
+    <!-- raw-primitive-allow: bespoke circular mic toggle with a listening-state pulse animation, the core voice-input control; not a standard action button -->
     <button
       type="button"
       class="mic-button"

--- a/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/WorkspaceShell.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { Snippet } from 'svelte';
 import { M } from '../../i18n/strings.workspace.js';
 
@@ -261,6 +262,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
   class:has-inspector-rail={hasInspectorRail}
 >
   <!-- Mobile sidebar backdrop -->
+  <!-- raw-primitive-allow: full-bleed click-catching navigation backdrop/scrim; a structural overlay surface, not a styled action button -->
   <button
     class="mobile-backdrop"
     type="button"
@@ -277,6 +279,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
   -->
   {#if hasInspector}
     {#if onCloseInspector}
+      <!-- raw-primitive-allow: full-bleed click-catching inspector backdrop/scrim; a structural overlay surface, not a styled action button -->
       <button
         class="inspector-backdrop"
         type="button"
@@ -311,9 +314,10 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
       </div>
 
       {#if collapsible && onToggleCollapsed}
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
           class="shell-toggle"
-          type="button"
           onclick={handleCollapseToggle}
           aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           aria-expanded={!collapsed}
@@ -321,7 +325,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
           <span class="shell-toggle-glyph" aria-hidden="true">
             {collapsed ? '›' : '‹'}
           </span>
-        </button>
+        </Button>
       {/if}
     </div>
 
@@ -341,15 +345,16 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
   <div class="smrt-workspace-main">
     <header class="smrt-workspace-topbar">
       <div class="topbar-left">
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
           class="mobile-menu"
-          type="button"
           onclick={toggleMobileNav}
           aria-label={mobileNavOpen ? 'Close navigation' : 'Open navigation'}
           aria-expanded={mobileNavOpen}
         >
           <span aria-hidden="true">≡</span>
-        </button>
+        </Button>
         <div class="topbar-brand">
           {#if eyebrow}
             <div class="eyebrow topbar-eyebrow">{eyebrow}</div>
@@ -396,14 +401,15 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
           <div class="inspector-header">
             <span class="inspector-title">{inspectorTitle}</span>
             {#if onCloseInspector}
-              <button
+              <Button
+                variant="ghost"
+                size="sm"
                 class="inspector-close"
-                type="button"
                 onclick={handleInspectorClose}
                 aria-label={t(M['ui.workspace_shell.close_inspector'])}
               >
                 <span aria-hidden="true">×</span>
-              </button>
+              </Button>
             {/if}
           </div>
           <div class="inspector-body">
@@ -518,8 +524,11 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
     color: var(--smrt-color-on-surface-variant, #6b7280);
   }
 
-  .shell-toggle {
-    appearance: none;
+  /* These shell-chrome controls now render through smrt-ui <Button>; pierce
+     Svelte scoping into the child <button> with `.smrt-workspace-shell
+     :global(.class)` (#1589). Button owns focus-visible, so those rules are
+     dropped. The responsive `display` toggles below are preserved. */
+  .smrt-workspace-shell :global(.shell-toggle) {
     border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
     background: var(--smrt-color-surface-container, #f3f4f6);
     color: var(--smrt-color-on-surface, #111827);
@@ -529,20 +538,14 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    cursor: pointer;
     flex-shrink: 0;
     transition:
       background-color 150ms ease,
       color 150ms ease;
   }
 
-  .shell-toggle:hover {
+  .smrt-workspace-shell :global(.shell-toggle):hover {
     background: var(--smrt-color-surface-container-high, #e5e7eb);
-  }
-
-  .shell-toggle:focus-visible {
-    outline: 2px solid var(--smrt-color-primary, #2563eb);
-    outline-offset: 2px;
   }
 
   .shell-toggle-glyph {
@@ -680,9 +683,8 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
     background: var(--smrt-color-warning, #f59e0b);
   }
 
-  .mobile-menu {
+  .smrt-workspace-shell :global(.mobile-menu) {
     display: none;
-    appearance: none;
     border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
     background: var(--smrt-color-surface, #ffffff);
     color: var(--smrt-color-on-surface, #111827);
@@ -691,15 +693,8 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
     height: 2.35rem;
     align-items: center;
     justify-content: center;
-    cursor: pointer;
     font-size: var(--smrt-typography-body-large-size, 1.1rem);
     line-height: 1;
-  }
-
-  .mobile-menu:focus-visible,
-  .inspector-close:focus-visible {
-    outline: 2px solid var(--smrt-color-primary, #2563eb);
-    outline-offset: 2px;
   }
 
   /* ─── Stage / content / inspector ─────────────────────── */
@@ -743,8 +738,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
     font-size: var(--smrt-typography-title-medium-size, 0.95rem);
   }
 
-  .inspector-close {
-    appearance: none;
+  .smrt-workspace-shell :global(.inspector-close) {
     border: 1px solid transparent;
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #6b7280);
@@ -756,13 +750,12 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
     justify-content: center;
     font-size: var(--smrt-typography-title-large-size, 1.25rem);
     line-height: 1;
-    cursor: pointer;
     transition:
       background-color 150ms ease,
       color 150ms ease;
   }
 
-  .inspector-close:hover {
+  .smrt-workspace-shell :global(.inspector-close):hover {
     background: var(--smrt-color-surface-container-high, #e5e7eb);
     color: var(--smrt-color-on-surface, #111827);
   }
@@ -851,7 +844,7 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
       justify-content: center;
     }
 
-    .smrt-workspace-shell .shell-toggle {
+    .smrt-workspace-shell :global(.shell-toggle) {
       display: none;
     }
 
@@ -869,11 +862,11 @@ const sidebarInert = $derived(isMobileViewport && !mobileNavOpen);
       grid-template-columns: 1fr;
     }
 
-    .mobile-menu {
+    .smrt-workspace-shell :global(.mobile-menu) {
       display: inline-flex;
     }
 
-    .shell-toggle {
+    .smrt-workspace-shell :global(.shell-toggle) {
       display: none;
     }
 

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/ToolsDock.svelte
@@ -31,6 +31,7 @@
   import { onDestroy, onMount, tick } from 'svelte';
   import { M } from '../../../i18n/strings.workspace.js';
   import { useI18n } from '@happyvertical/smrt-ui/i18n';
+  import { Button } from '@happyvertical/smrt-ui/ui';
   import type { ToolsDockContext } from '../types.js';
   import type { ToolsDockInstance } from './define-tools-dock.svelte.js';
 
@@ -159,6 +160,7 @@
   {@const def = toolDefById(tool.id)}
   {@const IconComponent = def?.iconComponent}
   {@const iconString = def?.icon}
+  <!-- raw-primitive-allow: dock tool-selector toggle (aria-pressed) with variant-dependent rail/topbar styling, part of the ToolsDock segmented control; not a standard action button -->
   <button
     type="button"
     class:active={isActive}
@@ -209,15 +211,16 @@
   >
     <header class="tools-dock__panel-header">
       <h3>{dock.activeTool ? labelFor(dock.activeTool) : 'Tools'}</h3>
-      <button
-        type="button"
+      <Button
+        variant="ghost"
+        size="sm"
         class="tools-dock__close"
         onclick={handleClose}
         aria-label={closeLabel}
         title={closeLabel}
       >
         ×
-      </button>
+      </Button>
     </header>
 
     <div class="tools-dock__panel-body">
@@ -254,6 +257,7 @@
 {:else}
   <aside class="tools-dock tools-dock--rail" class:tools-dock--open={dock.isOpen}>
     {#if dock.isOpen}
+      <!-- raw-primitive-allow: click-catching overlay/backdrop that closes the dock; a structural full-bleed surface, not a styled action button -->
       <button
         type="button"
         class="tools-dock__overlay"
@@ -326,8 +330,7 @@
   }
 
   .tools-dock__rail-button:focus-visible,
-  .tools-dock__topbar-button:focus-visible,
-  .tools-dock__close:focus-visible {
+  .tools-dock__topbar-button:focus-visible {
     outline: 2px solid var(--smrt-color-primary, #7dd3fc);
     outline-offset: 2px;
   }
@@ -411,7 +414,9 @@
     overflow-y: auto;
   }
 
-  .tools-dock__close {
+  /* The close control now renders through smrt-ui <Button>; pierce Svelte
+     scoping into the child-rendered <button> with `:global` (#1589). */
+  .tools-dock__panel-header :global(.tools-dock__close) {
     width: 2rem;
     height: 2rem;
     display: inline-grid;
@@ -420,7 +425,6 @@
     border-radius: 0.5rem;
     background: var(--smrt-color-surface-container-high, #1d2228);
     color: inherit;
-    cursor: pointer;
     font-size: var(--smrt-typography-title-large-size, 1.2rem);
     line-height: 1;
   }


### PR DESCRIPTION
## Summary

#1589 **buttons-only** migration for `smrt-svelte`'s own shell + browser-ai composites (the 15th package — 12 raw `<button>`s outside `src/components/forms/`). 6 migrated to `<Button>`, 6 escape-hatched.

- **STTTest.svelte** — Initialize → `Button(primary)`, Clear → `Button(ghost sm)`; dead `.controls button` / `.logs-header button` CSS removed. The push-and-hold record control (`onmousedown`/`up`/`leave` + touch, no onclick) stays raw + escape-hatched — Button has no press-and-hold model.
- **VoiceInput.svelte** — the bespoke circular mic toggle (listening-state pulse) stays raw + escape-hatched.
- **ToolsDock.svelte** — panel close → `Button(ghost sm)` with `.tools-dock__close` rescoped via `.tools-dock__panel-header :global(.tools-dock__close)`. The `aria-pressed` dock tool-toggle and the click-catching overlay stay raw + escape-hatched.
- **WorkspaceShell.svelte** — collapse-toggle, mobile menu, inspector close → `Button(ghost sm)`; their positioning + **responsive `display` toggles** (`.shell-toggle`/`.mobile-menu`/`.inspector-close` across breakpoints) rescoped via `.smrt-workspace-shell :global(.class)` so they pierce into the child `<button>`; Button owns focus-visible (those rules dropped). The two click-catching backdrops stay raw + escape-hatched.
- **package.json** — `"smrtRawPrimitives": "strict-buttons"`. No dependency change.

## Verification (local, all green)
- `node scripts/check-raw-primitives.mjs` → exit 0 (smrt-svelte under "buttons-only"; 6 annotated escape-hatches; forms exempt).
- `pnpm --filter @happyvertical/smrt-svelte typecheck` → **0 errors, 0 warnings** (tsc + svelte-check a11y); `test` → 459 passed.
- `npx turbo build --filter=@happyvertical/smrt-svelte` → no cycle; `biome check` (read-only) → clean.
- Scope: only smrt-svelte files; the STTTest adapter `<select>` stays raw (deferred); no dep/lockfile change; no stripped console.

Part of #1589.
