### PR TITLE
fix(ui): lay out Button children inside the content wrapper (#1589)

### DIFF
--- a/packages/smrt-ui/src/components/ui/Button.svelte
+++ b/packages/smrt-ui/src/components/ui/Button.svelte
@@ -247,6 +247,20 @@ const linkProps = $derived(() => {
     to { transform: translate(-50%, -50%) rotate(360deg); }
   }
 
+  /* Lay out the button's own children. The children are rendered inside this
+     wrapper span, so the button-level `gap` does not reach them — without this,
+     an icon + label (`<Button><svg/>Save</Button>`) would render with no gap.
+     Inheriting the wrapper makes multi-child buttons (icon+text, label+count)
+     lay out correctly after the #1589 migration, instead of needing per-button
+     CSS to reach into `.content`. Callers can still override via the `class`
+     passthrough (e.g. `.x :global(.content) { justify-content: space-between }`). */
+  .content {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--smrt-spacing-2);
+  }
+
   .content.loading {
     opacity: 0;
   }

--- a/packages/smrt-ui/src/components/ui/Button.svelte
+++ b/packages/smrt-ui/src/components/ui/Button.svelte
@@ -247,13 +247,15 @@ const linkProps = $derived(() => {
     to { transform: translate(-50%, -50%) rotate(360deg); }
   }
 
-  /* Lay out the button's own children. The children are rendered inside this
-     wrapper span, so the button-level `gap` does not reach them — without this,
-     an icon + label (`<Button><svg/>Save</Button>`) would render with no gap.
-     Inheriting the wrapper makes multi-child buttons (icon+text, label+count)
-     lay out correctly after the #1589 migration, instead of needing per-button
-     CSS to reach into `.content`. Callers can still override via the `class`
-     passthrough (e.g. `.x :global(.content) { justify-content: space-between }`). */
+  /* Lay out the button's own children. The children render inside this wrapper
+     span, so the button-level `gap` never reaches them — without making the
+     wrapper itself a flex row, an icon + label (`<Button><svg/>Save</Button>`)
+     would render with no gap. Making `.content` a centered flex row lays out
+     multi-child buttons (icon+text, label+count) correctly after the #1589
+     migration, instead of needing per-button CSS to reach into `.content`. The
+     wrapper is shrink-to-fit, so a caller wanting a spread layout must also give
+     it width — e.g. a full-width button with
+     `.x :global(.content) { width: 100%; justify-content: space-between }`. */
   .content {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## Summary

Primitive-level fix for a cross-cutting layout regression the #1589 button migration introduced.

`<Button>` renders its children inside an internal `<span class="content">`. The button is `display: inline-flex` with `gap`, but that gap applies between the (optional) spinner and the content span — **not** between the children inside `.content`. So:
- `<Button><svg/>Save</Button>` rendered the icon and label with **no gap** (cramped).
- A migrated custom button class with `display: flex; gap` (to lay out e.g. an icon + label, or a label + count) no longer worked, because those children live inside `.content`, not as direct children of the `<button>`. (Flagged by the Copilot/codex auto-review on the messages PR #1620 across 6 buttons — FolderNav, AttachmentChip, ThreadView, EmailFilterManager.)

Fix: give `.content` itself `display: inline-flex; align-items: center; justify-content: center; gap: var(--smrt-spacing-2)`. Multi-child buttons now lay out correctly **at the primitive level**, fixing the latent regression across every migrated package (commerce, assets, images, products, messages, smrt-svelte, …) at once. Callers needing a non-centered layout can still override via the `class` passthrough: `.x :global(.content) { justify-content: space-between }`.

## Verification
- `pnpm --filter @happyvertical/smrt-ui typecheck` → 0 errors/warnings; `test` → 407 passed (the golden Button suite unaffected — role/name/state/axe are layout-independent).
- Safe for existing Button usages: a text-only button's content is a single inline-flex item (renders identically); icon+text buttons gain the intended gap.

Part of #1589.
