### PR TITLE
refactor(content): migrate buttons to Button, flip content strict-buttons (#1589)

### DIFF
--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -3,6 +3,7 @@
   "version": "0.34.4",
   "description": "Content processing module for SMRT framework - handles documents, web content, and media",
   "type": "module",
+  "smrtRawPrimitives": "strict-buttons",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/content/src/routes/api-explorer/+page.svelte
+++ b/packages/content/src/routes/api-explorer/+page.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { Button } from '@happyvertical/smrt-ui/ui';
+
 let activeGroup = $state<string>('contents');
 let tryEndpoint = $state<{ method: string; path: string } | null>(null);
 let tryResult = $state<string | null>(null);
@@ -468,15 +470,16 @@ function closeTry() {
   <div class="explorer-layout">
     <aside class="group-nav">
       {#each groups as group}
-        <button
-          class="group-btn"
-          class:active={activeGroup === group.key}
+        <Button
+          variant="ghost"
+          class={`group-btn${activeGroup === group.key ? ' group-btn--active' : ''}`}
+          aria-pressed={activeGroup === group.key}
           onclick={() => { activeGroup = group.key; closeTry(); }}
         >
           <span class="group-icon">{group.icon}</span>
           <span class="group-label">{group.label}</span>
           <span class="group-count">{group.endpoints.length}</span>
-        </button>
+        </Button>
       {/each}
     </aside>
 
@@ -490,7 +493,7 @@ function closeTry() {
             <code class="endpoint-path">{endpoint.path}</code>
             <span class="endpoint-desc">{endpoint.description}</span>
             {#if canTry(endpoint)}
-              <button class="try-btn" onclick={() => void handleTry(endpoint)}>Try</button>
+              <Button variant="ghost" size="sm" class="try-btn" onclick={() => void handleTry(endpoint)}>Try</Button>
             {/if}
           </div>
         {/each}
@@ -501,7 +504,7 @@ function closeTry() {
           <div class="try-header">
             <span class="method-badge" style="background: {methodColor(tryEndpoint.method)}">{tryEndpoint.method}</span>
             <code>{tryEndpoint.path}</code>
-            <button class="close-btn" onclick={closeTry}>✕</button>
+            <Button variant="ghost" size="sm" class="close-btn" onclick={closeTry}>✕</Button>
           </div>
           {#if tryLoading}
             <p class="try-loading">Fetching...</p>
@@ -556,7 +559,7 @@ function closeTry() {
     top: 70px;
   }
 
-  .group-btn {
+  .group-nav :global(.group-btn) {
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -571,11 +574,11 @@ function closeTry() {
     transition: background 0.15s;
   }
 
-  .group-btn:hover {
+  .group-nav :global(.group-btn:hover) {
     background: var(--smrt-color-surface-variant, #e1e2ec);
   }
 
-  .group-btn.active {
+  .group-nav :global(.group-btn.group-btn--active) {
     background: var(--smrt-color-primary-container, #d8e2ff);
     color: var(--smrt-color-on-primary-container, #001a41);
     font-weight: var(--smrt-typography-weight-semibold, 600);
@@ -593,7 +596,7 @@ function closeTry() {
     font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
-  .group-btn.active .group-count {
+  .group-nav :global(.group-btn.group-btn--active .group-count) {
     background: color-mix(in srgb, var(--smrt-color-shadow) 8%, transparent);
   }
 
@@ -653,7 +656,7 @@ function closeTry() {
     text-align: right;
   }
 
-  .try-btn {
+  .endpoint-row :global(.try-btn) {
     padding: 0.2rem 0.6rem;
     border: 1px solid var(--smrt-color-primary, #005ac1);
     border-radius: 0.25rem;
@@ -665,7 +668,7 @@ function closeTry() {
     transition: all 0.15s;
   }
 
-  .try-btn:hover {
+  .endpoint-row :global(.try-btn:hover) {
     background: var(--smrt-color-primary, #005ac1);
     color: white;
   }
@@ -691,7 +694,7 @@ function closeTry() {
     font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
   }
 
-  .close-btn {
+  .try-header :global(.close-btn) {
     border: none;
     background: none;
     cursor: pointer;
@@ -701,7 +704,7 @@ function closeTry() {
     border-radius: 0.25rem;
   }
 
-  .close-btn:hover {
+  .try-header :global(.close-btn:hover) {
     background: var(--smrt-color-surface-variant, #e1e2ec);
   }
 
@@ -744,7 +747,7 @@ function closeTry() {
       position: static;
     }
 
-    .group-btn {
+    .group-nav :global(.group-btn) {
       white-space: nowrap;
     }
   }

--- a/packages/content/src/routes/api-explorer/+page.svelte
+++ b/packages/content/src/routes/api-explorer/+page.svelte
@@ -504,7 +504,7 @@ function closeTry() {
           <div class="try-header">
             <span class="method-badge" style="background: {methodColor(tryEndpoint.method)}">{tryEndpoint.method}</span>
             <code>{tryEndpoint.path}</code>
-            <Button variant="ghost" size="sm" class="close-btn" onclick={closeTry}>✕</Button>
+            <Button variant="ghost" size="sm" class="close-btn" onclick={closeTry} aria-label="Close" title="Close">✕</Button>
           </div>
           {#if tryLoading}
             <p class="try-loading">Fetching...</p>

--- a/packages/content/src/svelte/components/ContentAgentChat.svelte
+++ b/packages/content/src/svelte/components/ContentAgentChat.svelte
@@ -7,6 +7,7 @@
 
 import { AgentChat } from '@happyvertical/smrt-chat/svelte';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type {
   ContentEditorAssistantContext,
   ContentEditorAssistantFieldUpdateAllowList,
@@ -426,7 +427,7 @@ async function handleSendMessage(content: string) {
     <div class="error-state">
       <p>{error}</p>
       {#if canRetrySessionLoad}
-        <button onclick={loadSession}>Retry</button>
+        <Button variant="primary" type="button" onclick={loadSession}>Retry</Button>
       {/if}
     </div>
   {:else if session}
@@ -471,10 +472,10 @@ async function handleSendMessage(content: string) {
             bind:value={newTopicTitle}
             onkeydown={(e: KeyboardEvent) => { if (e.key === 'Enter') { createNewTopic(); showNewTopicInput = false; } }}
           />
-          <button class="topic-action-btn" onclick={() => { createNewTopic(); showNewTopicInput = false; }} disabled={isCreatingTopic}>
+          <Button variant="ghost" size="sm" type="button" class="topic-action-btn" onclick={() => { createNewTopic(); showNewTopicInput = false; }} disabled={isCreatingTopic}>
             {isCreatingTopic ? '...' : 'Create'}
-          </button>
-          <button class="topic-action-btn topic-cancel-btn" onclick={() => { showNewTopicInput = false; }}>✕</button>
+          </Button>
+          <Button variant="ghost" size="sm" type="button" class="topic-action-btn topic-cancel-btn" onclick={() => { showNewTopicInput = false; }}>✕</Button>
         </div>
       {:else}
         <select 
@@ -490,10 +491,10 @@ async function handleSendMessage(content: string) {
             <option value={thread.id}>{thread.title || t(M['content.content_agent_chat.untitled_topic'])}</option>
           {/each}
         </select>
-        <button class="topic-action-btn" onclick={() => { showNewTopicInput = true; newTopicTitle = ''; }} title={t(M['content.content_agent_chat.new_topic'])}>
+        <Button variant="ghost" size="sm" type="button" class="topic-action-btn" onclick={() => { showNewTopicInput = true; newTopicTitle = ''; }} title={t(M['content.content_agent_chat.new_topic'])}>
           <svg viewBox="0 0 24 24" width="14" height="14" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
           {t(M['content.content_agent_chat.new'])}
-        </button>
+        </Button>
       {/if}
     </div>
   {/if}
@@ -533,16 +534,6 @@ async function handleSendMessage(content: string) {
   
   @keyframes spin {
     to { transform: rotate(360deg); }
-  }
-
-  .error-state button {
-    margin-top: 1rem;
-    padding: 0.5rem 1rem;
-    background: var(--smrt-color-primary, #005ac1);
-    color: var(--smrt-color-on-primary, #ffffff);
-    border: none;
-    border-radius: var(--smrt-radius-sm, 4px);
-    cursor: pointer;
   }
 
   .model-bar {
@@ -602,7 +593,7 @@ async function handleSendMessage(content: string) {
     flex: 1;
   }
 
-  .topic-action-btn {
+  .topic-footer :global(.topic-action-btn) {
     display: inline-flex;
     align-items: center;
     gap: var(--smrt-spacing-1, 4px);
@@ -617,12 +608,12 @@ async function handleSendMessage(content: string) {
     transition: background 0.15s;
   }
 
-  .topic-action-btn:hover:not(:disabled) {
+  .topic-footer :global(.topic-action-btn:hover:not(:disabled)) {
     background: var(--smrt-color-surface-variant, #e1e2e8);
     color: var(--smrt-color-primary, #005ac1);
   }
 
-  .topic-cancel-btn {
+  .topic-footer :global(.topic-cancel-btn) {
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border: none;
     color: var(--smrt-color-outline, #74777f);

--- a/packages/content/src/svelte/components/ContentAgentChat.svelte
+++ b/packages/content/src/svelte/components/ContentAgentChat.svelte
@@ -475,7 +475,7 @@ async function handleSendMessage(content: string) {
           <Button variant="ghost" size="sm" type="button" class="topic-action-btn" onclick={() => { createNewTopic(); showNewTopicInput = false; }} disabled={isCreatingTopic}>
             {isCreatingTopic ? '...' : 'Create'}
           </Button>
-          <Button variant="ghost" size="sm" type="button" class="topic-action-btn topic-cancel-btn" onclick={() => { showNewTopicInput = false; }}>✕</Button>
+          <Button variant="ghost" size="sm" type="button" class="topic-action-btn topic-cancel-btn" onclick={() => { showNewTopicInput = false; }} aria-label={t(M['content.content_agent_chat.cancel'])} title={t(M['content.content_agent_chat.cancel'])}>✕</Button>
         </div>
       {:else}
         <select 

--- a/packages/content/src/svelte/components/ContentBodyEditor.svelte
+++ b/packages/content/src/svelte/components/ContentBodyEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { ImageLike } from '@happyvertical/smrt-images/svelte';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import {
   bodyToEditorHtml,
   type ContentBodyFormat,
@@ -996,16 +997,16 @@ function handleEditorDragEnd() {
 
 <div bind:this={rootElement} class="content-body-editor">
   <div class="body-editor-toolbar" aria-label={t(M['content.content_body_editor.toolbar'])}>
-    <button type="button" title={t(M['content.content_body_editor.bold'])} aria-label={t(M['content.content_body_editor.bold'])} onclick={() => runCommand('bold')}>
+    <Button variant="ghost" size="sm" class="editor-toolbar-button" type="button" title={t(M['content.content_body_editor.bold'])} aria-label={t(M['content.content_body_editor.bold'])} onclick={() => runCommand('bold')}>
       <strong>B</strong>
-    </button>
-    <button type="button" title={t(M['content.content_body_editor.italic'])} aria-label={t(M['content.content_body_editor.italic'])} onclick={() => runCommand('italic')}>
+    </Button>
+    <Button variant="ghost" size="sm" class="editor-toolbar-button" type="button" title={t(M['content.content_body_editor.italic'])} aria-label={t(M['content.content_body_editor.italic'])} onclick={() => runCommand('italic')}>
       <em>I</em>
-    </button>
-    <button type="button" title={t(M['content.content_body_editor.heading'])} aria-label={t(M['content.content_body_editor.heading'])} onclick={() => runCommand('formatBlock', 'h2')}>
+    </Button>
+    <Button variant="ghost" size="sm" class="editor-toolbar-button" type="button" title={t(M['content.content_body_editor.heading'])} aria-label={t(M['content.content_body_editor.heading'])} onclick={() => runCommand('formatBlock', 'h2')}>
       H2
-    </button>
-    <button type="button" title={t(M['content.content_body_editor.bulleted_list'])} aria-label={t(M['content.content_body_editor.bulleted_list'])} onclick={() => runCommand('insertUnorderedList')}>
+    </Button>
+    <Button variant="ghost" size="sm" class="editor-toolbar-button" type="button" title={t(M['content.content_body_editor.bulleted_list'])} aria-label={t(M['content.content_body_editor.bulleted_list'])} onclick={() => runCommand('insertUnorderedList')}>
       <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
         <line x1="9" y1="6" x2="21" y2="6"></line>
         <line x1="9" y1="12" x2="21" y2="12"></line>
@@ -1014,14 +1015,14 @@ function handleEditorDragEnd() {
         <circle cx="4" cy="12" r="1"></circle>
         <circle cx="4" cy="18" r="1"></circle>
       </svg>
-    </button>
-    <button type="button" title={t(M['content.content_body_editor.insert_image'])} aria-label={t(M['content.content_body_editor.insert_image'])} onclick={() => onOpenImageChooser?.()}>
+    </Button>
+    <Button variant="ghost" size="sm" class="editor-toolbar-button" type="button" title={t(M['content.content_body_editor.insert_image'])} aria-label={t(M['content.content_body_editor.insert_image'])} onclick={() => onOpenImageChooser?.()}>
       <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <rect x="3" y="3" width="18" height="18" rx="2"></rect>
         <circle cx="8.5" cy="8.5" r="1.5"></circle>
         <polyline points="21 15 16 10 5 21"></polyline>
       </svg>
-    </button>
+    </Button>
 
     <label class="format-select">
       <span>{t(M['content.content_body_editor.save_as'])}</span>
@@ -1041,7 +1042,7 @@ function handleEditorDragEnd() {
       style={`top: ${Math.max(44, selectedImageBox.top + 8)}px; left: ${selectedImageBox.left + selectedImageBox.width / 2}px;`}
       aria-label={t(M['content.content_body_editor.selected_image_controls'])}
     >
-      <button type="button" title={t(M['content.content_body_editor.move_image'])} aria-label={t(M['content.content_body_editor.move_image'])} onpointerdown={startImageMove}>
+      <Button variant="ghost" size="sm" class="editor-popover-button" type="button" title={t(M['content.content_body_editor.move_image'])} aria-label={t(M['content.content_body_editor.move_image'])} onpointerdown={startImageMove}>
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M12 2v20"></path>
           <path d="M2 12h20"></path>
@@ -1050,13 +1051,16 @@ function handleEditorDragEnd() {
           <path d="m9 5 3-3 3 3"></path>
           <path d="m9 19 3 3 3-3"></path>
         </svg>
-      </button>
+      </Button>
       <span class="image-control-divider"></span>
-      <button
+      <Button
+        variant="ghost"
+        size="sm"
+        class={`editor-popover-button${selectedImagePlacement === 'left' ? ' editor-popover-button--active' : ''}`}
         type="button"
         title={t(M['content.content_body_editor.wrap_text_on_right'])}
         aria-label={t(M['content.content_body_editor.wrap_text_on_right'])}
-        class:active={selectedImagePlacement === 'left'}
+        aria-pressed={selectedImagePlacement === 'left'}
         onclick={() => applyImagePlacement('left')}
       >
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
@@ -1066,12 +1070,15 @@ function handleEditorDragEnd() {
           <path d="M3 17h18"></path>
           <path d="M3 21h14"></path>
         </svg>
-      </button>
-      <button
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        class={`editor-popover-button${selectedImagePlacement === 'center' || selectedImagePlacement === 'block' ? ' editor-popover-button--active' : ''}`}
         type="button"
         title={t(M['content.content_body_editor.center_image'])}
         aria-label={t(M['content.content_body_editor.center_image'])}
-        class:active={selectedImagePlacement === 'center' || selectedImagePlacement === 'block'}
+        aria-pressed={selectedImagePlacement === 'center' || selectedImagePlacement === 'block'}
         onclick={() => applyImagePlacement('center')}
       >
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
@@ -1079,12 +1086,15 @@ function handleEditorDragEnd() {
           <rect x="7" y="9" width="10" height="6" rx="1"></rect>
           <path d="M4 18h16"></path>
         </svg>
-      </button>
-      <button
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        class={`editor-popover-button${selectedImagePlacement === 'right' ? ' editor-popover-button--active' : ''}`}
         type="button"
         title={t(M['content.content_body_editor.wrap_text_on_left'])}
         aria-label={t(M['content.content_body_editor.wrap_text_on_left'])}
-        class:active={selectedImagePlacement === 'right'}
+        aria-pressed={selectedImagePlacement === 'right'}
         onclick={() => applyImagePlacement('right')}
       >
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
@@ -1094,12 +1104,15 @@ function handleEditorDragEnd() {
           <path d="M3 17h18"></path>
           <path d="M7 21h14"></path>
         </svg>
-      </button>
-      <button
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
+        class={`editor-popover-button${selectedImagePlacement === 'full' ? ' editor-popover-button--active' : ''}`}
         type="button"
         title={t(M['content.content_body_editor.full_width'])}
         aria-label={t(M['content.content_body_editor.full_width'])}
-        class:active={selectedImagePlacement === 'full'}
+        aria-pressed={selectedImagePlacement === 'full'}
         onclick={() => applyImagePlacement('full')}
       >
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -1107,38 +1120,39 @@ function handleEditorDragEnd() {
           <rect x="4" y="8" width="16" height="8" rx="1"></rect>
           <path d="M3 19h18"></path>
         </svg>
-      </button>
+      </Button>
       <span class="image-control-divider"></span>
-      <button type="button" title={t(M['content.content_body_editor.make_smaller'])} aria-label={t(M['content.content_body_editor.make_image_smaller'])} onclick={() => resizeSelectedImage(-IMAGE_WIDTH_STEP)}>
+      <Button variant="ghost" size="sm" class="editor-popover-button" type="button" title={t(M['content.content_body_editor.make_smaller'])} aria-label={t(M['content.content_body_editor.make_image_smaller'])} onclick={() => resizeSelectedImage(-IMAGE_WIDTH_STEP)}>
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
           <path d="M5 12h14"></path>
           <path d="M9 8 5 12l4 4"></path>
           <path d="m15 8 4 4-4 4"></path>
         </svg>
-      </button>
-      <button type="button" title={t(M['content.content_body_editor.make_larger'])} aria-label={t(M['content.content_body_editor.make_image_larger'])} onclick={() => resizeSelectedImage(IMAGE_WIDTH_STEP)}>
+      </Button>
+      <Button variant="ghost" size="sm" class="editor-popover-button" type="button" title={t(M['content.content_body_editor.make_larger'])} aria-label={t(M['content.content_body_editor.make_image_larger'])} onclick={() => resizeSelectedImage(IMAGE_WIDTH_STEP)}>
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
           <path d="M3 12h18"></path>
           <path d="m7 8-4 4 4 4"></path>
           <path d="m17 8 4 4-4 4"></path>
         </svg>
-      </button>
+      </Button>
       {#if selectedImageAssetId && onUseImageAsThumbnail}
-        <button type="button" title={t(M['content.content_body_editor.use_as_primary_image'])} aria-label={t(M['content.content_body_editor.use_as_primary_image'])} onclick={useSelectedImageAsThumbnail}>
+        <Button variant="ghost" size="sm" class="editor-popover-button" type="button" title={t(M['content.content_body_editor.use_as_primary_image'])} aria-label={t(M['content.content_body_editor.use_as_primary_image'])} onclick={useSelectedImageAsThumbnail}>
           <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round">
             <path d="m12 3 2.8 5.7 6.2.9-4.5 4.4 1.1 6.2L12 17.3 6.4 20.2 7.5 14 3 9.6l6.2-.9L12 3Z"></path>
           </svg>
-        </button>
+        </Button>
       {/if}
-      <button type="button" title={t(M['content.content_body_editor.remove_image'])} aria-label={t(M['content.content_body_editor.remove_image'])} onclick={removeSelectedImage}>
+      <Button variant="ghost" size="sm" class="editor-popover-button" type="button" title={t(M['content.content_body_editor.remove_image'])} aria-label={t(M['content.content_body_editor.remove_image'])} onclick={removeSelectedImage}>
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M3 6h18"></path>
           <path d="M8 6V4h8v2"></path>
           <path d="M19 6l-1 14H6L5 6"></path>
         </svg>
-      </button>
+      </Button>
     </div>
 
+    <!-- raw-primitive-allow: custom press-and-drag image resize handle driven by onpointerdown pointer-capture gesture and absolute positioning; no Button primitive owns this draggable resize grabber -->
     <button
       type="button"
       class="image-resize-handle"
@@ -1207,7 +1221,7 @@ function handleEditorDragEnd() {
     background: var(--smrt-color-surface-container-low, var(--smrt-color-surface-container));
   }
 
-  .body-editor-toolbar button {
+  .body-editor-toolbar :global(.editor-toolbar-button) {
     width: 2rem;
     height: 2rem;
     display: inline-grid;
@@ -1219,7 +1233,7 @@ function handleEditorDragEnd() {
     cursor: pointer;
   }
 
-  .body-editor-toolbar button:hover {
+  .body-editor-toolbar :global(.editor-toolbar-button:hover) {
     border-color: var(--smrt-color-outline-variant);
     background: var(--smrt-color-surface-container);
   }
@@ -1399,7 +1413,7 @@ function handleEditorDragEnd() {
     backdrop-filter: blur(10px);
   }
 
-  .image-control-popover button,
+  .image-control-popover :global(.editor-popover-button),
   .image-resize-handle {
     display: inline-grid;
     place-items: center;
@@ -1409,14 +1423,14 @@ function handleEditorDragEnd() {
     cursor: pointer;
   }
 
-  .image-control-popover button {
+  .image-control-popover :global(.editor-popover-button) {
     width: 1.85rem;
     height: 1.85rem;
     border-radius: var(--smrt-radius-full, 9999px);
   }
 
-  .image-control-popover button:hover,
-  .image-control-popover button.active {
+  .image-control-popover :global(.editor-popover-button:hover),
+  .image-control-popover :global(.editor-popover-button.editor-popover-button--active) {
     background: var(--smrt-color-surface-container);
     color: var(--smrt-color-primary);
   }

--- a/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
+++ b/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type {
   FactAuditClaimData,
   FactAuditStateData,
@@ -197,22 +198,22 @@ async function recheckFactClaims(claimIds: string[]) {
         <span><strong>{factAudit?.counts.contradicted ?? 0}</strong> contradicted</span>
         <span><strong>{factAudit?.counts.needs_review ?? 0}</strong> review</span>
       </div>
-      <button
+      <Button
+        variant="secondary"
         type="button"
-        class="secondary-button"
         disabled={busy || selectedClaimCount === 0}
         onclick={() => void recheckFactClaims(selectedClaimIds)}
       >
         {busy ? 'Checking...' : `Recheck selected (${selectedClaimCount})`}
-      </button>
-      <button
+      </Button>
+      <Button
+        variant="secondary"
         type="button"
-        class="secondary-button"
         disabled={busy}
         onclick={() => void repairFactAudit()}
       >
         {busy ? 'Working...' : 'Repair audit'}
-      </button>
+      </Button>
     </div>
     <p class="empty-copy">
       {t(M['content.claim_audit_tool.article_claims_help'])}
@@ -258,9 +259,9 @@ async function recheckFactClaims(claimIds: string[]) {
                 </summary>
                 <div class="tool-card-body">
                   <div class="claim-audit-actions">
-                    <button
+                    <Button
+                      variant="secondary"
                       type="button"
-                      class="secondary-button"
                       disabled={busy || !getClaimId(claim)}
                       onclick={() => {
                         const claimId = getClaimId(claim);
@@ -268,7 +269,7 @@ async function recheckFactClaims(claimIds: string[]) {
                       }}
                     >
                       {t(M['content.claim_audit_tool.recheck_support'])}
-                    </button>
+                    </Button>
                   </div>
                   {#if claim.claimQuote}
                     <p><strong>{t(M['content.claim_audit_tool.article_claim_label'])}</strong> {claim.claimQuote}</p>
@@ -375,21 +376,6 @@ async function recheckFactClaims(claimIds: string[]) {
   .claim-audit-select {
     display: inline-flex;
     line-height: 1;
-  }
-
-  .secondary-button {
-    border-radius: 0.5rem;
-    padding: 0.65rem 0.85rem;
-    border: 1px solid var(--smrt-color-outline-variant);
-    background: var(--smrt-color-surface);
-    color: var(--smrt-color-on-surface);
-    cursor: pointer;
-    font-weight: var(--smrt-typography-weight-semibold, 600);
-  }
-
-  .secondary-button:disabled {
-    cursor: not-allowed;
-    opacity: 0.65;
   }
 
   .pill {

--- a/packages/content/src/svelte/components/ContentContributionForm.svelte
+++ b/packages/content/src/svelte/components/ContentContributionForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type {
   ContentContributionData,
   ContentContributionTypeData,
@@ -184,11 +185,11 @@ function handleSubmit(event: SubmitEvent) {
   {/if}
 
   <div class="actions">
-    <button type="submit">{submitLabel}</button>
+    <Button variant="primary" type="submit">{submitLabel}</Button>
     {#if onCancel}
-      <button type="button" class="secondary" onclick={() => onCancel?.()}>
+      <Button variant="secondary" type="button" onclick={() => onCancel?.()}>
         Cancel
-      </button>
+      </Button>
     {/if}
   </div>
 </form>

--- a/packages/content/src/svelte/components/ContentContributionInbox.svelte
+++ b/packages/content/src/svelte/components/ContentContributionInbox.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { ContentContributionData } from '../../mock-smrt-client';
 import { M } from '../i18n.contribution.js';
 
@@ -132,6 +133,7 @@ $effect(() => {
     <div class="inbox__layout">
       <div class="inbox__list">
         {#each contributions as contribution (contribution.id)}
+          <!-- raw-primitive-allow: large pressable selection card wrapping a title and metadata with a selected state -->
           <button
             type="button"
             class:selected={selectedContribution?.id === contribution.id}
@@ -204,38 +206,39 @@ $effect(() => {
                     <option value="review">review</option>
                   </select>
                 </label>
-                <button
+                <Button
+                  variant="primary"
                   type="submit"
                   name="intent"
                   value="approve"
                   disabled={!canSubmitWorkflow}
                 >
                   {approveActionLabel(selectedContribution)}
-                </button>
+                </Button>
               {/if}
 
               {#if onRequestChanges || workflowFormAction}
-                <button
+                <Button
+                  variant="secondary"
                   type="submit"
                   name="intent"
                   value="request-changes"
-                  class="secondary"
                   disabled={!canSubmitWorkflow}
                 >
                   {t(M['content.contribution_inbox.request_changes'])}
-                </button>
+                </Button>
               {/if}
 
               {#if onReject || workflowFormAction}
-                <button
+                <Button
+                  variant="danger"
                   type="submit"
                   name="intent"
                   value="reject"
-                  class="danger"
                   disabled={!canSubmitWorkflow}
                 >
                   Reject
-                </button>
+                </Button>
               {/if}
             </div>
           </form>

--- a/packages/content/src/svelte/components/ContentContributionPortal.svelte
+++ b/packages/content/src/svelte/components/ContentContributionPortal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { ContentContributionData } from '../../mock-smrt-client';
 import { M } from '../i18n.contribution.js';
 
@@ -49,6 +50,7 @@ function canWithdraw(contribution: ContentContributionData) {
     <div class="portal__layout">
       <div class="portal__list">
         {#each contributions as contribution (contribution.id)}
+          <!-- raw-primitive-allow: large pressable selection card wrapping rich content (title, status) with selected state; no Button primitive owns this list-row selection pattern -->
           <button
             type="button"
             class:selected={selectedContribution?.id === contribution.id}
@@ -91,9 +93,9 @@ function canWithdraw(contribution: ContentContributionData) {
           </dl>
 
           {#if onWithdraw && canWithdraw(selectedContribution)}
-            <button type="button" class="secondary" onclick={() => onWithdraw?.(selectedContribution)}>
+            <Button variant="secondary" type="button" onclick={() => onWithdraw?.(selectedContribution)}>
               {t(M['content.contribution_portal.withdraw_submission'])}
-            </button>
+            </Button>
           {/if}
         </article>
       {/if}

--- a/packages/content/src/svelte/components/ContentContributionTypeManager.svelte
+++ b/packages/content/src/svelte/components/ContentContributionTypeManager.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { ContentContributionTypeData } from '../../mock-smrt-client';
 import { M } from '../i18n.contribution.js';
 
@@ -116,7 +117,7 @@ function handleSubmit() {
       <h3>{t(M['content.contribution_type_manager.heading'])}</h3>
       <p>{t(M['content.contribution_type_manager.intro'])}</p>
     </div>
-    <button type="button" onclick={() => (editing = {})}>{t(M['content.contribution_type_manager.add_type'])}</button>
+    <Button variant="ghost" type="button" onclick={() => (editing = {})}>{t(M['content.contribution_type_manager.add_type'])}</Button>
   </header>
 
   <div class="layout">
@@ -128,9 +129,9 @@ function handleSubmit() {
             <div>{type.key}</div>
           </div>
           <div class="actions">
-            <button type="button" class="secondary" onclick={() => (editing = type)}>Edit</button>
+            <Button variant="secondary" type="button" onclick={() => (editing = type)}>Edit</Button>
             {#if onDelete && type.id}
-              <button type="button" class="danger" onclick={() => onDelete?.(type)}>Delete</button>
+              <Button variant="danger" type="button" onclick={() => onDelete?.(type)}>Delete</Button>
             {/if}
           </div>
         </article>
@@ -231,7 +232,7 @@ function handleSubmit() {
       </label>
 
       <div class="actions">
-        <button type="submit">{t(M['content.contribution_type_manager.save_type'])}</button>
+        <Button variant="primary" type="submit">{t(M['content.contribution_type_manager.save_type'])}</Button>
       </div>
     </form>
   </div>

--- a/packages/content/src/svelte/components/ContentContributorManager.svelte
+++ b/packages/content/src/svelte/components/ContentContributorManager.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { ContentContributorData } from '../../mock-smrt-client';
 import { M } from '../i18n.contribution.js';
 
@@ -45,7 +46,7 @@ function handleSubmit() {
       <h3>Contributors</h3>
       <p>{t(M['content.contributor_manager.intro'])}</p>
     </div>
-    <button type="button" onclick={() => (editing = {})}>{t(M['content.contributor_manager.add_contributor'])}</button>
+    <Button variant="ghost" type="button" onclick={() => (editing = {})}>{t(M['content.contributor_manager.add_contributor'])}</Button>
   </header>
 
   <div class="layout">
@@ -57,9 +58,9 @@ function handleSubmit() {
             <div>{contributor.trustLevel || 'standard'}</div>
           </div>
           <div class="actions">
-            <button type="button" class="secondary" onclick={() => (editing = contributor)}>Edit</button>
+            <Button variant="secondary" type="button" onclick={() => (editing = contributor)}>Edit</Button>
             {#if onDelete}
-              <button type="button" class="danger" onclick={() => onDelete?.(contributor)}>Delete</button>
+              <Button variant="danger" type="button" onclick={() => onDelete?.(contributor)}>Delete</Button>
             {/if}
           </div>
         </article>
@@ -91,7 +92,7 @@ function handleSubmit() {
       </label>
 
       <div class="actions">
-        <button type="submit">{t(M['content.contributor_manager.save_contributor'])}</button>
+        <Button variant="primary" type="submit">{t(M['content.contributor_manager.save_contributor'])}</Button>
       </div>
     </form>
   </div>

--- a/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
+++ b/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { ContentCorrectionData, FactData } from '../../mock-smrt-client';
 import { createClient } from '../../mock-smrt-client';
 import { normalizeApiBaseUrl } from '../api';
@@ -212,13 +213,14 @@ async function issueCorrection() {
       {t(M['content.corrections_tool.publish_immediately'])}
     </label>
 
-    <button
+    <Button
+      variant="primary"
       type="button"
       disabled={busy || correctionSummary.trim().length === 0}
       onclick={() => void issueCorrection()}
     >
       {busy ? 'Issuing correction...' : 'Issue correction'}
-    </button>
+    </Button>
 
     <div class="tool-list">
       <div class="section-caption">{t(M['content.corrections_tool.published_history'])}</div>
@@ -269,21 +271,6 @@ async function issueCorrection() {
     background: var(--smrt-color-surface);
     color: var(--smrt-color-on-surface);
     font-family: inherit;
-  }
-
-  button {
-    border: none;
-    border-radius: 0.5rem;
-    padding: 0.7rem 0.95rem;
-    background: var(--smrt-color-primary);
-    color: var(--smrt-color-on-primary, white);
-    cursor: pointer;
-    font-weight: var(--smrt-typography-weight-semibold, 600);
-  }
-
-  button:disabled {
-    cursor: not-allowed;
-    opacity: 0.65;
   }
 
   .tool-card {

--- a/packages/content/src/svelte/components/ContentEditor.svelte
+++ b/packages/content/src/svelte/components/ContentEditor.svelte
@@ -1086,12 +1086,12 @@ function removeAsset(id: string) {
                         <img class="media-item-image" src={getAssetImageSource(asset)} alt={asset.name || 'Asset image'} />
                         <div class="media-item-overlay">
                            {#if assetId && assetId !== formData.thumbnailAssetId}
-                             <Button variant="ghost" size="sm" type="button" class="btn-make-thumbnail" title={t(M['content.content_editor.make_thumbnail'])} onclick={() => setThumbnail(assetId)}>
+                             <Button variant="ghost" size="sm" type="button" class="btn-make-thumbnail" aria-label={t(M['content.content_editor.make_thumbnail'])} title={t(M['content.content_editor.make_thumbnail'])} onclick={() => setThumbnail(assetId)}>
                                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
                              </Button>
                            {/if}
                            {#if assetId}
-                             <Button variant="ghost" size="sm" type="button" class="btn-remove-asset" title={t(M['content.content_editor.remove'])} onclick={() => removeAsset(assetId)}>
+                             <Button variant="ghost" size="sm" type="button" class="btn-remove-asset" aria-label={t(M['content.content_editor.remove'])} title={t(M['content.content_editor.remove'])} onclick={() => removeAsset(assetId)}>
                                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
                              </Button>
                            {/if}
@@ -1181,7 +1181,7 @@ function removeAsset(id: string) {
                   {#each formData.referenceIds as refId}
                     <div class="reference-badge">
                       <span class="ref-id">{refId}</span>
-                      <Button variant="ghost" size="sm" type="button" class="remove-ref-btn" onclick={() => removeReference(refId)}>×</Button>
+                      <Button variant="ghost" size="sm" type="button" class="remove-ref-btn" aria-label={t(M['content.content_editor.remove'])} title={t(M['content.content_editor.remove'])} onclick={() => removeReference(refId)}>×</Button>
                     </div>
                   {/each}
                   {#if formData.referenceIds.length === 0 && auditReferences.length === 0}

--- a/packages/content/src/svelte/components/ContentEditor.svelte
+++ b/packages/content/src/svelte/components/ContentEditor.svelte
@@ -2,6 +2,7 @@
 import type { ImageLike } from '@happyvertical/smrt-images/svelte';
 import { ImageUploader } from '@happyvertical/smrt-images/svelte';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { untrack } from 'svelte';
 import { extractBodyImages, resolveBodyFormat } from '../../body-format';
 import type {
@@ -929,7 +930,9 @@ function removeAsset(id: string) {
       {#if editorError}
         <div class="editor-message editor-message--error" role="alert" aria-live="assertive">
           <span>{editorError}</span>
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             type="button"
             class="editor-message__dismiss"
             onclick={() => {
@@ -938,7 +941,7 @@ function removeAsset(id: string) {
             aria-label={t(M['content.content_editor.dismiss_message'])}
           >
             ×
-          </button>
+          </Button>
         </div>
       {/if}
       <div class="editor-toolbar">
@@ -974,10 +977,10 @@ function removeAsset(id: string) {
         </div>
         {#if showActions}
           <div class="editor-toolbar-right">
-            <button type="submit" class="save-button" disabled={saveDisabled}>{content ? 'Update Content' : 'Save Content'}</button>
-            <button type="button" class="cancel-button" onclick={handleCancel}>
+            <Button variant="primary" type="submit" class="save-button" disabled={saveDisabled}>{content ? 'Update Content' : 'Save Content'}</Button>
+            <Button variant="secondary" type="button" onclick={handleCancel}>
               Cancel
-            </button>
+            </Button>
           </div>
         {/if}
       </div>
@@ -1008,9 +1011,9 @@ function removeAsset(id: string) {
               fields: lastAppliedFields.join(', '),
             })}
           </span>
-          <button type="button" class="undo-banner__btn" onclick={undoLastApply}>
+          <Button variant="ghost" size="sm" type="button" class="undo-banner__btn" onclick={undoLastApply}>
             Undo{fieldUndoStack.length > 1 ? ` (${fieldUndoStack.length})` : ''}
-          </button>
+          </Button>
         </div>
       {/if}
 
@@ -1083,14 +1086,14 @@ function removeAsset(id: string) {
                         <img class="media-item-image" src={getAssetImageSource(asset)} alt={asset.name || 'Asset image'} />
                         <div class="media-item-overlay">
                            {#if assetId && assetId !== formData.thumbnailAssetId}
-                             <button type="button" class="btn-make-thumbnail" title={t(M['content.content_editor.make_thumbnail'])} onclick={() => setThumbnail(assetId)}>
+                             <Button variant="ghost" size="sm" type="button" class="btn-make-thumbnail" title={t(M['content.content_editor.make_thumbnail'])} onclick={() => setThumbnail(assetId)}>
                                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
-                             </button>
+                             </Button>
                            {/if}
                            {#if assetId}
-                             <button type="button" class="btn-remove-asset" title={t(M['content.content_editor.remove'])} onclick={() => removeAsset(assetId)}>
+                             <Button variant="ghost" size="sm" type="button" class="btn-remove-asset" title={t(M['content.content_editor.remove'])} onclick={() => removeAsset(assetId)}>
                                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
-                             </button>
+                             </Button>
                            {/if}
                         </div>
                         {#if assetId === formData.thumbnailAssetId}
@@ -1103,14 +1106,14 @@ function removeAsset(id: string) {
                   <p class="no-media-text">{t(M['content.content_editor.no_images_attached'])}</p>
                 {/if}
                 {#if !showImageUploader}
-                  <button type="button" class="add-image-btn" onclick={() => showImageUploader = true} style="margin-top: 1rem;">
+                  <Button variant="ghost" type="button" class="add-image-btn" onclick={() => showImageUploader = true} style="margin-top: 1rem;">
                     <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
                       <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
                       <circle cx="8.5" cy="8.5" r="1.5"></circle>
                       <polyline points="21 15 16 10 5 21"></polyline>
                     </svg>
                     {t(M['content.content_editor.add_image'])}
-                  </button>
+                  </Button>
                 {/if}
 
                 {#if showImageUploader}
@@ -1178,7 +1181,7 @@ function removeAsset(id: string) {
                   {#each formData.referenceIds as refId}
                     <div class="reference-badge">
                       <span class="ref-id">{refId}</span>
-                      <button type="button" class="remove-ref-btn" onclick={() => removeReference(refId)}>×</button>
+                      <Button variant="ghost" size="sm" type="button" class="remove-ref-btn" onclick={() => removeReference(refId)}>×</Button>
                     </div>
                   {/each}
                   {#if formData.referenceIds.length === 0 && auditReferences.length === 0}
@@ -1207,20 +1210,26 @@ function removeAsset(id: string) {
                          <option value={status}>{status}</option>
                        {/each}
                      </select>
-                     <button
+                     <Button
+                       variant="ghost"
+                       size="sm"
                        type="button"
+                       class="evidence-action-button"
                        disabled={selectedEvidenceCount === 0 || Boolean(evidenceBusy)}
                        onclick={() => void updateSelectedEvidenceStatus()}
                      >
                        Mark
-                     </button>
-                     <button
+                     </Button>
+                     <Button
+                       variant="ghost"
+                       size="sm"
                        type="button"
+                       class="evidence-action-button"
                        disabled={selectedEvidenceCount === 0 || Boolean(evidenceBusy)}
                        onclick={() => void repairSelectedReferenceEvidence()}
                      >
                        {t(M['content.content_editor.repair_resources'])}
-                     </button>
+                     </Button>
                    </div>
                    {#each auditReferences as reference, referenceIndex (reference._auditSourceId ?? reference.id ?? reference.url ?? reference.title)}
                      {@const resourceClaims = getResourceClaimsForReference(reference)}
@@ -1245,13 +1254,16 @@ function removeAsset(id: string) {
                                  : M['content.content_editor.evidence_claim_plural'],
                              ),
                            })}</span>
-                           <button
+                           <Button
+                             variant="ghost"
+                             size="sm"
                              type="button"
+                             class="evidence-action-button"
                              disabled={Boolean(evidenceBusy)}
                              onclick={() => void repairReferenceEvidence(reference)}
                            >
                              {evidenceBusy === `repair:${reference.id}` ? 'Repairing...' : 'Repair'}
-                           </button>
+                           </Button>
                          </div>
                        </div>
                        {#if resourceClaims.length > 0}
@@ -1311,26 +1323,31 @@ function removeAsset(id: string) {
                                  {/each}
                                  <div class="resource-claim-actions">
                                    {#each evidenceStatuses as status}
-                                     <button
+                                     <Button
+                                       variant="ghost"
+                                       size="sm"
                                        type="button"
+                                       class="evidence-action-button"
                                        disabled={evidenceIds.length === 0 || Boolean(evidenceBusy)}
                                        onclick={() => void updateEvidenceStatus(evidenceIds, status)}
                                      >
                                        {status}
-                                     </button>
+                                     </Button>
                                    {/each}
                                  </div>
                                </div>
                              </details>
                            {/each}
                            {#if resourceClaims.length > 6}
-                             <button
+                             <Button
+                               variant="ghost"
+                               size="sm"
                                type="button"
                                class="resource-claim-more"
                                onclick={() => toggleReferenceClaims(reference, referenceIndex)}
                              >
                                {resourceClaimsExpanded ? 'Show fewer' : `+ ${resourceClaims.length - 6} more`}
-                             </button>
+                             </Button>
                            {/if}
                          </div>
                        {/if}
@@ -1340,7 +1357,7 @@ function removeAsset(id: string) {
                {/if}
                <div class="add-reference-row">
                   <input type="text" bind:value={newReferenceId} placeholder={t(M['content.content_editor.reference_id_or_url_placeholder'])} />
-                  <button type="button" onclick={addReference}>Add</button>
+                  <Button variant="ghost" type="button" class="add-reference-button" onclick={addReference}>Add</Button>
                </div>
             </div>
 
@@ -1664,7 +1681,7 @@ function removeAsset(id: string) {
     color: var(--smrt-color-on-surface);
   }
 
-  .remove-ref-btn {
+  .reference-badge :global(.remove-ref-btn) {
     background: none;
     border: none;
     color: var(--smrt-color-outline);
@@ -1675,7 +1692,7 @@ function removeAsset(id: string) {
     margin-left: 0.25rem;
   }
 
-  .remove-ref-btn:hover {
+  .reference-badge :global(.remove-ref-btn:hover) {
     color: var(--smrt-color-error);
   }
 
@@ -1725,9 +1742,7 @@ function removeAsset(id: string) {
     white-space: nowrap;
   }
 
-  .reference-detail-actions button,
-  .resource-claim-actions button,
-  .evidence-bulk-toolbar button {
+  .references-section :global(.evidence-action-button) {
     background: var(--smrt-color-surface);
     border: 1px solid var(--smrt-color-outline-variant);
     border-radius: 0.375rem;
@@ -1738,9 +1753,7 @@ function removeAsset(id: string) {
     padding: 0.25rem 0.5rem;
   }
 
-  .reference-detail-actions button:disabled,
-  .resource-claim-actions button:disabled,
-  .evidence-bulk-toolbar button:disabled {
+  .references-section :global(.evidence-action-button:disabled) {
     cursor: not-allowed;
     opacity: 0.55;
   }
@@ -1796,7 +1809,7 @@ function removeAsset(id: string) {
     background: color-mix(in srgb, var(--smrt-color-error) 12%, transparent);
   }
 
-  .editor-message__dismiss {
+  .editor-message :global(.editor-message__dismiss) {
     border: none;
     background: transparent;
     color: inherit;
@@ -1808,18 +1821,19 @@ function removeAsset(id: string) {
 
   .reference-detail-header a,
   .reference-detail-header span,
-  .resource-claim-body,
-  .resource-claim-more {
+  .resource-claim-body {
     color: var(--smrt-color-on-surface-variant);
     font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
   }
 
-  .resource-claim-more {
+  .references-section :global(.resource-claim-more) {
     align-self: flex-start;
     border: 0;
     background: transparent;
     padding: 0;
     cursor: pointer;
+    color: var(--smrt-color-on-surface-variant);
+    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
     font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
@@ -1943,7 +1957,7 @@ function removeAsset(id: string) {
     flex: 1;
   }
 
-  .add-reference-row button {
+  .add-reference-row :global(.add-reference-button) {
     background: var(--smrt-color-surface);
     border: 1px solid var(--smrt-color-outline);
     color: var(--smrt-color-on-surface-variant);
@@ -1953,11 +1967,11 @@ function removeAsset(id: string) {
     font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
-  .add-reference-row button:hover {
+  .add-reference-row :global(.add-reference-button:hover) {
     background: var(--smrt-color-surface-container-low, #f1f5f9);
   }
   
-  .add-image-btn {
+  .media-gallery :global(.add-image-btn) {
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -1970,14 +1984,14 @@ function removeAsset(id: string) {
     cursor: pointer;
     transition: all 0.2s;
   }
-  
-  .add-image-btn:hover {
+
+  .media-gallery :global(.add-image-btn:hover) {
     border-color: var(--smrt-color-primary, #94a3b8);
     color: var(--smrt-color-on-surface, #1e293b);
     background: var(--smrt-color-surface-container-low, #f1f5f9);
   }
 
-  .save-button {
+  .editor-toolbar-right :global(.save-button) {
     background: linear-gradient(
       135deg,
       var(--smrt-color-primary) 0%,
@@ -1992,25 +2006,15 @@ function removeAsset(id: string) {
     transition: transform 0.2s, box-shadow 0.2s;
   }
 
-  .save-button:hover {
+  .editor-toolbar-right :global(.save-button:hover) {
     transform: translateY(-1px);
     box-shadow: 0 4px 6px -1px color-mix(in srgb, var(--smrt-color-primary) 40%, transparent);
   }
 
-  .save-button:disabled {
+  .editor-toolbar-right :global(.save-button:disabled) {
     opacity: 0.65;
     transform: none;
     box-shadow: none;
-  }
-
-  .cancel-button {
-    background: var(--smrt-color-surface);
-    color: var(--smrt-color-on-surface);
-    border: 1px solid var(--smrt-color-outline-variant);
-    padding: 0.75rem 1.25rem;
-    border-radius: 0.5rem;
-    font-weight: var(--smrt-typography-weight-semibold, 600);
-    cursor: pointer;
   }
 
   .save-notice {
@@ -2069,7 +2073,7 @@ function removeAsset(id: string) {
     flex-shrink: 0;
   }
 
-  .undo-banner__btn {
+  .undo-banner :global(.undo-banner__btn) {
     background: var(--smrt-color-surface);
     color: var(--smrt-color-primary);
     border: 1px solid var(--smrt-color-outline);
@@ -2082,7 +2086,7 @@ function removeAsset(id: string) {
     transition: all 0.15s ease;
   }
 
-  .undo-banner__btn:hover {
+  .undo-banner :global(.undo-banner__btn:hover) {
     background: var(--smrt-color-surface-variant);
     border-color: var(--smrt-color-primary);
   }
@@ -2138,7 +2142,8 @@ function removeAsset(id: string) {
     opacity: 1;
   }
 
-  .media-item-overlay button {
+  .media-item-overlay :global(.btn-make-thumbnail),
+  .media-item-overlay :global(.btn-remove-asset) {
     padding: 0.4rem;
     border: none;
     border-radius: 0.375rem;
@@ -2151,12 +2156,13 @@ function removeAsset(id: string) {
     justify-content: center;
   }
 
-  .media-item-overlay button:hover {
+  .media-item-overlay :global(.btn-make-thumbnail:hover),
+  .media-item-overlay :global(.btn-remove-asset:hover) {
     transform: scale(1.1);
     background: var(--smrt-color-surface);
   }
 
-  .btn-remove-asset:hover {
+  .media-item-overlay :global(.btn-remove-asset:hover) {
     background: var(--smrt-color-error-container) !important;
     color: var(--smrt-color-error) !important;
     border-color: var(--smrt-color-error) !important;

--- a/packages/content/src/svelte/components/ContentGovernanceAssignmentEditor.svelte
+++ b/packages/content/src/svelte/components/ContentGovernanceAssignmentEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type {
   ContentGovernanceAssignmentData,
   ContentGovernanceProfileData,
@@ -158,11 +159,11 @@ function handleSubmit() {
   </div>
 
   <div class="actions">
-    <button type="submit">{t(M['content.governance_assignment_editor.save_assignment'])}</button>
+    <Button variant="primary" type="submit">{t(M['content.governance_assignment_editor.save_assignment'])}</Button>
     {#if onCancel}
-      <button type="button" class="secondary" onclick={() => onCancel?.()}>
+      <Button variant="secondary" type="button" onclick={() => onCancel?.()}>
         Cancel
-      </button>
+      </Button>
     {/if}
   </div>
 </form>

--- a/packages/content/src/svelte/components/ContentGovernanceManager.svelte
+++ b/packages/content/src/svelte/components/ContentGovernanceManager.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { onMount } from 'svelte';
 import {
   type ContentGovernanceAssignmentData,
@@ -141,9 +142,9 @@ function cancelEditing() {
       <h3>{t(M['content.governance_manager.content_governance'])}</h3>
       <p>{t(M['content.governance_manager.manage_governed_content'])}</p>
     </div>
-    <button type="button" class="secondary" onclick={() => void loadDefinitions()}>
+    <Button variant="secondary" type="button" onclick={() => void loadDefinitions()}>
       Refresh
-    </button>
+    </Button>
   </div>
 
   {#if loading}
@@ -155,12 +156,12 @@ function cancelEditing() {
       <section>
         <div class="section-header">
           <h4>Policies</h4>
-          <button type="button" onclick={() => {
+          <Button variant="primary" type="button" onclick={() => {
             editMode = 'policy';
             editingPolicy = null;
           }}>
             {t(M['content.governance_manager.add_policy'])}
-          </button>
+          </Button>
         </div>
         {#if editMode === 'policy'}
           {#key editingPolicy?.id ?? editingPolicy?.key ?? 'new-policy'}
@@ -179,16 +180,16 @@ function cancelEditing() {
                 <span>{policy.key} · {policy.kind}</span>
               </div>
               <div class="actions">
-                <button type="button" class="secondary" onclick={() => {
+                <Button variant="secondary" type="button" onclick={() => {
                   editMode = 'policy';
                   editingPolicy = policy;
                 }}>
                   Edit
-                </button>
+                </Button>
                 {#if definitions.persisted.policies.some((item) => item.key === policy.key)}
-                  <button type="button" class="secondary" onclick={() => void deletePolicy(policy.id)}>
+                  <Button variant="danger" type="button" onclick={() => void deletePolicy(policy.id)}>
                     {t(M['content.governance_manager.delete_override'])}
-                  </button>
+                  </Button>
                 {/if}
               </div>
             </article>
@@ -199,12 +200,12 @@ function cancelEditing() {
       <section>
         <div class="section-header">
           <h4>Profiles</h4>
-          <button type="button" onclick={() => {
+          <Button variant="primary" type="button" onclick={() => {
             editMode = 'profile';
             editingProfile = null;
           }}>
             {t(M['content.governance_manager.add_profile'])}
-          </button>
+          </Button>
         </div>
         {#if editMode === 'profile'}
           {#key editingProfile?.id ?? editingProfile?.key ?? 'new-profile'}
@@ -224,16 +225,16 @@ function cancelEditing() {
                 <span>{profile.key} · {profile.requirements.length} requirement(s)</span>
               </div>
               <div class="actions">
-                <button type="button" class="secondary" onclick={() => {
+                <Button variant="secondary" type="button" onclick={() => {
                   editMode = 'profile';
                   editingProfile = profile;
                 }}>
                   Edit
-                </button>
+                </Button>
                 {#if definitions.persisted.profiles.some((item) => item.key === profile.key)}
-                  <button type="button" class="secondary" onclick={() => void deleteProfile(profile.id)}>
+                  <Button variant="danger" type="button" onclick={() => void deleteProfile(profile.id)}>
                     {t(M['content.governance_manager.delete_override'])}
-                  </button>
+                  </Button>
                 {/if}
               </div>
             </article>
@@ -244,12 +245,12 @@ function cancelEditing() {
       <section>
         <div class="section-header">
           <h4>Assignments</h4>
-          <button type="button" onclick={() => {
+          <Button variant="primary" type="button" onclick={() => {
             editMode = 'assignment';
             editingAssignment = null;
           }}>
             {t(M['content.governance_manager.add_assignment'])}
-          </button>
+          </Button>
         </div>
         {#if editMode === 'assignment'}
           {#key editingAssignment?.id ?? editingAssignment?.key ?? 'new-assignment'}
@@ -272,16 +273,16 @@ function cancelEditing() {
                 </span>
               </div>
               <div class="actions">
-                <button type="button" class="secondary" onclick={() => {
+                <Button variant="secondary" type="button" onclick={() => {
                   editMode = 'assignment';
                   editingAssignment = assignment;
                 }}>
                   Edit
-                </button>
+                </Button>
                 {#if assignment.id}
-                  <button type="button" class="secondary" onclick={() => void deleteAssignment(assignment.id)}>
+                  <Button variant="danger" type="button" onclick={() => void deleteAssignment(assignment.id)}>
                     Delete
-                  </button>
+                  </Button>
                 {/if}
               </div>
             </article>

--- a/packages/content/src/svelte/components/ContentGovernancePanel.svelte
+++ b/packages/content/src/svelte/components/ContentGovernancePanel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { ConfirmDialog } from '@happyvertical/smrt-ui/feedback';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import {
   type ContentCorrectionData,
   type ContentGovernanceDefinitionsData,
@@ -1078,22 +1079,22 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
             <span><strong>{factAudit?.counts.contradicted ?? 0}</strong> contradicted</span>
             <span><strong>{factAudit?.counts.needs_review ?? 0}</strong> review</span>
           </div>
-          <button
+          <Button
+            variant="secondary"
             type="button"
-            class="secondary-button"
             disabled={factAuditBusy || selectedClaimCount === 0}
             onclick={() => void recheckSelectedClaims()}
           >
             {factAuditBusy ? 'Checking...' : `Recheck selected (${selectedClaimCount})`}
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="secondary"
             type="button"
-            class="secondary-button"
             disabled={factAuditBusy}
             onclick={() => void repairFactAudit()}
           >
             {factAuditBusy ? 'Repairing...' : 'Repair audit'}
-          </button>
+          </Button>
         </div>
         <p class="claim-audit-help">
           {t(M['content.governance_panel.article_claims_help'])}
@@ -1141,9 +1142,9 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
                     </summary>
                     <div class="claim-audit-item__body">
                       <div class="claim-audit-item__actions">
-                        <button
+                        <Button
+                          variant="secondary"
                           type="button"
-                          class="secondary-button"
                           disabled={factAuditBusy || !getClaimId(claim)}
                           onclick={() => {
                             const claimId = getClaimId(claim);
@@ -1151,7 +1152,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
                           }}
                         >
                           {t(M['content.governance_panel.recheck_support'])}
-                        </button>
+                        </Button>
                       </div>
                       {#if claim.claimQuote}
                         <p><strong>{t(M['content.governance_panel.article_claim_label'])}</strong> {claim.claimQuote}</p>
@@ -1233,13 +1234,15 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
                         {fact.status} · confidence {formatPercent(fact.confidence)}
                       </span>
                     </div>
-                    <button
+                    <Button
+                      variant="ghost"
+                      size="sm"
                       type="button"
                       class="fact-chip__remove"
                       onclick={() => fact.id && removeFact(fact.id)}
                     >
                       Remove
-                    </button>
+                    </Button>
                   </div>
                 {/each}
               </div>
@@ -1253,9 +1256,9 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
                 bind:value={factQuery}
                 placeholder={t(M['content.governance_panel.search_fact_catalog'])}
               />
-              <button type="button" onclick={searchFactsFirstPage}>
+              <Button variant="primary" type="button" onclick={searchFactsFirstPage}>
                 Search
-              </button>
+              </Button>
             </div>
 
             {#if catalogError}
@@ -1278,13 +1281,15 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
                           {fact.status} · {fact.domain || 'general'} · confidence {formatPercent(fact.confidence)}
                         </span>
                       </div>
-                      <button
+                      <Button
+                        variant="ghost"
+                        size="sm"
                         type="button"
                         disabled={!fact.id || selectedFactIds.includes(fact.id ?? '')}
                         onclick={() => addFact(fact)}
                       >
                         {!fact.id || selectedFactIds.includes(fact.id ?? '') ? 'Selected' : 'Add'}
-                      </button>
+                      </Button>
                     </div>
                   {/each}
                 </div>
@@ -1299,22 +1304,24 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
                     {/if}
                   </span>
                   <div class="fact-pagination__actions">
-                    <button
+                    <Button
+                      variant="ghost"
+                      size="sm"
                       type="button"
-                      class="secondary-button"
                       disabled={catalogLoading || catalogPage <= 1}
                       onclick={browsePreviousFacts}
                     >
                       Previous
-                    </button>
-                    <button
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
                       type="button"
-                      class="secondary-button"
                       disabled={catalogLoading || !catalogHasNextPage}
                       onclick={browseNextFacts}
                     >
                       Next
-                    </button>
+                    </Button>
                   </div>
                 </div>
               {/if}
@@ -1414,7 +1421,8 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
 
       <div class="review-actions">
         {#each activeProfileReviewActions as action (action.policyKey ?? action.kind)}
-          <button
+          <Button
+            variant="primary"
             type="button"
             disabled={reviewBusy !== null}
             onclick={() => void runReview(action)}
@@ -1424,7 +1432,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
             {:else}
               Run {action.label}
             {/if}
-          </button>
+          </Button>
         {/each}
       </div>
 
@@ -1450,7 +1458,8 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
             placeholder={t(M['content.governance_panel.optional_review_instructions'])}
           ></textarea>
         </label>
-        <button
+        <Button
+          variant="primary"
           type="button"
           disabled={reviewBusy !== null || !canRunCustomReview()}
           onclick={() =>
@@ -1468,7 +1477,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
           {:else}
             Run {customReviewButtonLabel}
           {/if}
-        </button>
+        </Button>
       </div>
 
       <div class="review-list">
@@ -1697,13 +1706,14 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
           {t(M['content.governance_panel.publish_immediately'])}
         </label>
 
-        <button
+        <Button
+          variant="primary"
           type="button"
           disabled={correctionBusy || correctionSummary.trim().length === 0}
           onclick={() => void issueCorrection()}
         >
           {correctionBusy ? 'Issuing correction...' : 'Issue Correction'}
-        </button>
+        </Button>
 
         <div class="review-list">
           <div class="section-caption">{t(M['content.governance_panel.published_history'])}</div>
@@ -1736,14 +1746,14 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
             <div style="display: flex; align-items: center; gap: 0.5rem;">
               Versions
             </div>
-            <button
+            <Button
+              variant="secondary"
               type="button"
-              class="secondary-button"
               disabled={versionBusy}
               onclick={(e) => { e.preventDefault(); void createSnapshot(); }}
             >
               {versionBusy ? 'Working...' : 'Create Snapshot'}
-            </button>
+            </Button>
           </div>
           <svg class="drawer-icon" style="margin-left: 1rem;" viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
         </summary>
@@ -1765,9 +1775,9 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
                 {/if}
                 <div class="version-card__footer">
                   <span>{formatTimestamp(version.createdAt)}</span>
-                  <button
+                  <Button
+                    variant="secondary"
                     type="button"
-                    class="secondary-button"
                     disabled={versionBusy || version.version === null || version.version === undefined}
                     onclick={() => {
                       if (
@@ -1779,7 +1789,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
                     }}
                   >
                     Restore
-                  </button>
+                  </Button>
                 </div>
               </div>
             {/each}
@@ -1943,30 +1953,6 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
     font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
-  .fact-search button,
-  .review-actions button {
-    border: none;
-    border-radius: 0.5rem;
-    padding: 0.7rem 0.95rem;
-    background: var(--smrt-color-primary);
-    color: var(--smrt-color-on-primary, white);
-    cursor: pointer;
-    font-weight: var(--smrt-typography-weight-semibold, 600);
-  }
-
-  .fact-search button:disabled,
-  .review-actions button:disabled,
-  .fact-pagination button:disabled {
-    cursor: not-allowed;
-    opacity: 0.65;
-  }
-
-  .secondary-button {
-    background: var(--smrt-color-surface);
-    color: var(--smrt-color-on-surface);
-    border: 1px solid var(--smrt-color-outline-variant);
-  }
-
   .fact-chip-list,
   .fact-catalog__list,
   .claim-audit-group,
@@ -2060,7 +2046,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
     gap: 0.25rem;
   }
 
-  .fact-chip__remove {
+  .fact-chip :global(.fact-chip__remove) {
     background: transparent !important;
     color: var(--smrt-color-error) !important;
     padding: 0 !important;

--- a/packages/content/src/svelte/components/ContentGovernancePolicyEditor.svelte
+++ b/packages/content/src/svelte/components/ContentGovernancePolicyEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { ContentReviewPolicyData } from '../../mock-smrt-client';
 import { M } from '../i18n.tools.js';
 
@@ -70,11 +71,11 @@ function handleSubmit() {
     Enabled
   </label>
   <div class="actions">
-    <button type="submit">{t(M['content.governance_policy_editor.save_policy'])}</button>
+    <Button variant="primary" type="submit">{t(M['content.governance_policy_editor.save_policy'])}</Button>
     {#if onCancel}
-      <button type="button" class="secondary" onclick={() => onCancel?.()}>
+      <Button variant="secondary" type="button" onclick={() => onCancel?.()}>
         Cancel
-      </button>
+      </Button>
     {/if}
   </div>
 </form>

--- a/packages/content/src/svelte/components/ContentGovernanceProfileEditor.svelte
+++ b/packages/content/src/svelte/components/ContentGovernanceProfileEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type {
   ContentGovernanceProfileData,
   ContentReviewPolicyData,
@@ -105,9 +106,9 @@ function handleSubmit() {
   <div class="requirements">
     <div class="requirements__header">
       <strong>Requirements</strong>
-      <button type="button" class="secondary" onclick={addRequirement}>
+      <Button variant="secondary" type="button" onclick={addRequirement}>
         {t(M['content.governance_profile_editor.add_requirement'])}
-      </button>
+      </Button>
     </div>
 
     {#each draft.requirements as requirement, index (`${requirement.policyKey}-${index}`)}
@@ -128,19 +129,19 @@ function handleSubmit() {
           <input type="checkbox" bind:checked={requirement.blocking} />
           Blocking
         </label>
-        <button type="button" class="secondary" onclick={() => removeRequirement(index)}>
+        <Button variant="danger" type="button" onclick={() => removeRequirement(index)}>
           Remove
-        </button>
+        </Button>
       </div>
     {/each}
   </div>
 
   <div class="actions">
-    <button type="submit">{t(M['content.governance_profile_editor.save_profile'])}</button>
+    <Button variant="primary" type="submit">{t(M['content.governance_profile_editor.save_profile'])}</Button>
     {#if onCancel}
-      <button type="button" class="secondary" onclick={() => onCancel?.()}>
+      <Button variant="secondary" type="button" onclick={() => onCancel?.()}>
         Cancel
-      </button>
+      </Button>
     {/if}
   </div>
 </form>

--- a/packages/content/src/svelte/components/ContentImageBrowser.svelte
+++ b/packages/content/src/svelte/components/ContentImageBrowser.svelte
@@ -4,6 +4,7 @@ import {
   ImageUploader,
 } from '@happyvertical/smrt-images/svelte';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { ContentEditorAsset } from '../content-editor-form';
 import { M } from '../i18n.editor.js';
 
@@ -87,13 +88,13 @@ function handleSelect(selected: ImageLike | File | string) {
           </div>
           <div class="asset-actions">
             {#if onUseAsset}
-              <button type="button" onclick={() => onUseAsset?.(asset)}>{selectActionLabel}</button>
+              <Button variant="ghost" type="button" class="asset-action-btn" onclick={() => onUseAsset?.(asset)}>{selectActionLabel}</Button>
             {/if}
             {#if onUseAsThumbnail && assetId && thumbnailAssetId !== assetId}
-              <button type="button" onclick={() => onUseAsThumbnail?.(assetId)}>Thumbnail</button>
+              <Button variant="ghost" type="button" class="asset-action-btn" onclick={() => onUseAsThumbnail?.(assetId)}>Thumbnail</Button>
             {/if}
             {#if onRemoveAsset && assetId}
-              <button type="button" class="danger" onclick={() => onRemoveAsset?.(assetId)}>Remove</button>
+              <Button variant="ghost" type="button" class="asset-action-btn asset-action-btn--danger" onclick={() => onRemoveAsset?.(assetId)}>Remove</Button>
             {/if}
           </div>
         </article>
@@ -108,14 +109,14 @@ function handleSelect(selected: ImageLike | File | string) {
       <ImageUploader {apiBaseUrl} onSelect={handleSelect} onCancel={() => showUploader = false} />
     </div>
   {:else if onSelectImage}
-    <button type="button" class="add-image-button" onclick={() => showUploader = true}>
+    <Button variant="ghost" type="button" class="asset-action-btn add-image-button" onclick={() => showUploader = true}>
       <svg viewBox="0 0 24 24" aria-hidden="true">
         <rect x="3" y="3" width="18" height="18" rx="2"></rect>
         <circle cx="8.5" cy="8.5" r="1.5"></circle>
         <path d="m21 15-5-5L5 21"></path>
       </svg>
       {addButtonLabel}
-    </button>
+    </Button>
   {/if}
 </div>
 
@@ -197,7 +198,7 @@ function handleSelect(selected: ImageLike | File | string) {
     gap: 0.5rem;
   }
 
-  button {
+  .content-image-browser :global(.asset-action-btn) {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -214,19 +215,19 @@ function handleSelect(selected: ImageLike | File | string) {
     padding: 0.5rem 0.875rem;
   }
 
-  button:hover {
+  .content-image-browser :global(.asset-action-btn:hover) {
     background: var(--smrt-color-surface-container-high);
   }
 
-  button.danger {
+  .content-image-browser :global(.asset-action-btn--danger) {
     color: var(--smrt-color-error);
   }
 
-  .add-image-button {
+  .content-image-browser :global(.add-image-button) {
     justify-self: start;
   }
 
-  .add-image-button svg {
+  .content-image-browser :global(.add-image-button svg) {
     width: 1rem;
     height: 1rem;
     fill: none;

--- a/packages/content/src/svelte/components/ContentImageChooser.svelte
+++ b/packages/content/src/svelte/components/ContentImageChooser.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import {
   type ContentBodyFormat,
   extractBodyImages,
@@ -48,7 +49,9 @@ function cycle(delta: number) {
 {#if activeImage}
   <div class="content-image-chooser" aria-label={t(M['content.content_image_chooser.body_images'])}>
     {#if hasMultiple}
-      <button
+      <Button
+        variant="ghost"
+        size="sm"
         type="button"
         class="chooser-arrow"
         aria-label={t(M['content.content_image_chooser.previous_body_image'])}
@@ -57,10 +60,12 @@ function cycle(delta: number) {
         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <polyline points="15 18 9 12 15 6"></polyline>
         </svg>
-      </button>
+      </Button>
     {/if}
 
-    <button
+    <Button
+      variant="ghost"
+      size="sm"
       type="button"
       class="chooser-preview"
       aria-label={t(M['content.content_image_chooser.focus_selected_body_image'])}
@@ -68,10 +73,12 @@ function cycle(delta: number) {
     >
       <img src={activeImage.src} alt={activeImage.alt || 'Body image'} />
       <span>{normalizedIndex + 1} / {images.length}</span>
-    </button>
+    </Button>
 
     {#if hasMultiple}
-      <button
+      <Button
+        variant="ghost"
+        size="sm"
         type="button"
         class="chooser-arrow"
         aria-label={t(M['content.content_image_chooser.next_body_image'])}
@@ -80,7 +87,7 @@ function cycle(delta: number) {
         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <polyline points="9 18 15 12 9 6"></polyline>
         </svg>
-      </button>
+      </Button>
     {/if}
   </div>
 {/if}
@@ -93,8 +100,8 @@ function cycle(delta: number) {
     min-height: 2.75rem;
   }
 
-  .chooser-arrow,
-  .chooser-preview {
+  .content-image-chooser :global(.chooser-arrow),
+  .content-image-chooser :global(.chooser-preview) {
     border: 1px solid var(--smrt-color-outline-variant);
     background: var(--smrt-color-surface-container);
     color: var(--smrt-color-on-surface);
@@ -102,7 +109,7 @@ function cycle(delta: number) {
     cursor: pointer;
   }
 
-  .chooser-arrow {
+  .content-image-chooser :global(.chooser-arrow) {
     width: 2.25rem;
     height: 2.25rem;
     display: grid;
@@ -110,12 +117,12 @@ function cycle(delta: number) {
     padding: 0;
   }
 
-  .chooser-arrow:disabled {
+  .content-image-chooser :global(.chooser-arrow:disabled) {
     cursor: not-allowed;
     opacity: 0.38;
   }
 
-  .chooser-preview {
+  .content-image-chooser :global(.chooser-preview) {
     display: inline-flex;
     align-items: center;
     gap: 0.45rem;
@@ -124,7 +131,7 @@ function cycle(delta: number) {
     font-weight: var(--smrt-typography-weight-bold, 650);
   }
 
-  .chooser-preview img {
+  .content-image-chooser :global(.chooser-preview img) {
     width: 2rem;
     height: 2rem;
     border-radius: var(--smrt-radius-full, 9999px);

--- a/packages/content/src/svelte/components/ContentList.svelte
+++ b/packages/content/src/svelte/components/ContentList.svelte
@@ -184,6 +184,7 @@ function cancelDelete() {
           class={`view-toggle-btn${viewMode === 'grid' ? ' view-toggle-btn--active' : ''}`}
           aria-pressed={viewMode === 'grid'}
           onclick={() => viewMode = 'grid'}
+          aria-label={t(M['content.content_list.grid_view'])}
           title={t(M['content.content_list.grid_view'])}
         >
           <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none">
@@ -200,6 +201,7 @@ function cancelDelete() {
           class={`view-toggle-btn${viewMode === 'detailed' ? ' view-toggle-btn--active' : ''}`}
           aria-pressed={viewMode === 'detailed'}
           onclick={() => viewMode = 'detailed'}
+          aria-label={t(M['content.content_list.detailed_list'])}
           title={t(M['content.content_list.detailed_list'])}
         >
           <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none">
@@ -218,6 +220,7 @@ function cancelDelete() {
           class={`view-toggle-btn${viewMode === 'compact' ? ' view-toggle-btn--active' : ''}`}
           aria-pressed={viewMode === 'compact'}
           onclick={() => viewMode = 'compact'}
+          aria-label={t(M['content.content_list.compact_list'])}
           title={t(M['content.content_list.compact_list'])}
         >
           <svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none">

--- a/packages/content/src/svelte/components/ContentList.svelte
+++ b/packages/content/src/svelte/components/ContentList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { ConfirmDialog } from '@happyvertical/smrt-ui/feedback';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { Snippet } from 'svelte';
 import { untrack } from 'svelte';
 import { M } from '../i18n.contribution.js';
@@ -176,9 +177,12 @@ function cancelDelete() {
     
     <div class="actions-group">
       <div class="view-toggles">
-        <button 
+        <Button
+          variant="ghost"
+          size="sm"
           type="button"
-          class:active={viewMode === 'grid'} 
+          class={`view-toggle-btn${viewMode === 'grid' ? ' view-toggle-btn--active' : ''}`}
+          aria-pressed={viewMode === 'grid'}
           onclick={() => viewMode = 'grid'}
           title={t(M['content.content_list.grid_view'])}
         >
@@ -188,10 +192,13 @@ function cancelDelete() {
             <rect x="14" y="14" width="7" height="7"></rect>
             <rect x="3" y="14" width="7" height="7"></rect>
           </svg>
-        </button>
-        <button 
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
           type="button"
-          class:active={viewMode === 'detailed'} 
+          class={`view-toggle-btn${viewMode === 'detailed' ? ' view-toggle-btn--active' : ''}`}
+          aria-pressed={viewMode === 'detailed'}
           onclick={() => viewMode = 'detailed'}
           title={t(M['content.content_list.detailed_list'])}
         >
@@ -203,10 +210,13 @@ function cancelDelete() {
             <line x1="3" y1="12" x2="3.01" y2="12"></line>
             <line x1="3" y1="18" x2="3.01" y2="18"></line>
           </svg>
-        </button>
-        <button 
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
           type="button"
-          class:active={viewMode === 'compact'} 
+          class={`view-toggle-btn${viewMode === 'compact' ? ' view-toggle-btn--active' : ''}`}
+          aria-pressed={viewMode === 'compact'}
           onclick={() => viewMode = 'compact'}
           title={t(M['content.content_list.compact_list'])}
         >
@@ -215,16 +225,16 @@ function cancelDelete() {
             <line x1="3" y1="12" x2="21" y2="12"></line>
             <line x1="3" y1="18" x2="21" y2="18"></line>
           </svg>
-        </button>
+        </Button>
       </div>
-      
-      <button class="add-button" type="button" onclick={() => onAdd()}>
+
+      <Button variant="ghost" class="add-button" type="button" onclick={() => onAdd()}>
         <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
           <line x1="12" y1="5" x2="12" y2="19"></line>
           <line x1="5" y1="12" x2="19" y2="12"></line>
         </svg>
         {t(M['content.content_list.add_content'])}
-      </button>
+      </Button>
     </div>
   </div>
 
@@ -261,8 +271,8 @@ function cancelDelete() {
                 {#if getViewHref?.(content)}
                   <a class="icon-btn" href={getViewHref(content) || '#'} title={t(M['content.content_list.view_published_article'])} aria-label={t(M['content.content_list.view_published_article'])}>🔎</a>
                 {/if}
-                <button class="icon-btn" type="button" onclick={() => onEdit(content)} title={t(M['content.content_list.edit'])} aria-label={t(M['content.content_list.edit'])}>✏️</button>
-                <button class="icon-btn delete-icon" type="button" onclick={() => handleDeleteContent(content)} title={t(M['content.content_list.delete'])} aria-label={t(M['content.content_list.delete'])}>🗑️</button>
+                <Button variant="ghost" size="sm" class="icon-btn" type="button" onclick={() => onEdit(content)} title={t(M['content.content_list.edit'])} aria-label={t(M['content.content_list.edit'])}>✏️</Button>
+                <Button variant="ghost" size="sm" class="icon-btn delete-icon" type="button" onclick={() => handleDeleteContent(content)} title={t(M['content.content_list.delete'])} aria-label={t(M['content.content_list.delete'])}>🗑️</Button>
               </td>
             </tr>
           {/each}
@@ -314,14 +324,15 @@ function cancelDelete() {
             {#if getViewHref?.(content)}
               <a href={getViewHref(content) || '#'} class="quiet-action">{t(M['content.content_list.view_article'])}</a>
             {/if}
-            <button type="button" class="quiet-action" onclick={() => onEdit(content)}>{t(M['content.content_list.edit'])}</button>
-            <button
+            <Button variant="ghost" type="button" class="quiet-action" onclick={() => onEdit(content)}>{t(M['content.content_list.edit'])}</Button>
+            <Button
+              variant="ghost"
               type="button"
               class="quiet-action quiet-action--danger"
               onclick={() => handleDeleteContent(content)}
             >
               {t(M['content.content_list.delete'])}
-            </button>
+            </Button>
           </div>
         </article>
       {/each}
@@ -374,8 +385,8 @@ function cancelDelete() {
               {#if getViewHref?.(content)}
                 <a href={getViewHref(content) || '#'} class="view-btn">{t(M['content.content_list.view_article_button'])}</a>
               {/if}
-              <button onclick={() => onEdit(content)}>{t(M['content.content_list.edit'])}</button>
-              <button onclick={() => handleDeleteContent(content)} class="delete-btn">{t(M['content.content_list.delete'])}</button>
+              <Button variant="ghost" type="button" class="content-action-btn" onclick={() => onEdit(content)}>{t(M['content.content_list.edit'])}</Button>
+              <Button variant="ghost" type="button" class="content-action-btn delete-btn" onclick={() => handleDeleteContent(content)}>{t(M['content.content_list.delete'])}</Button>
             </div>
           </div>
         </div>
@@ -457,7 +468,7 @@ function cancelDelete() {
     border: 1px solid var(--smrt-color-outline-variant);
   }
 
-  .view-toggles button {
+  .view-toggles :global(.view-toggle-btn) {
     background: transparent;
     border: none;
     padding: 0.4rem;
@@ -470,18 +481,18 @@ function cancelDelete() {
     transition: all 0.2s;
   }
 
-  .view-toggles button:hover {
+  .view-toggles :global(.view-toggle-btn:hover) {
     color: var(--smrt-color-on-surface);
     background: color-mix(in srgb, var(--smrt-color-shadow) 5%, transparent);
   }
 
-  .view-toggles button.active {
+  .view-toggles :global(.view-toggle-btn.view-toggle-btn--active) {
     background: var(--smrt-color-surface);
     color: var(--smrt-color-on-surface);
     box-shadow: var(--smrt-elevation-1, 0 1px 2px rgba(0,0,0,0.1));
   }
 
-  .add-button {
+  .actions-group :global(.add-button) {
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -500,7 +511,7 @@ function cancelDelete() {
     transition: transform 0.2s, box-shadow 0.2s;
   }
 
-  .add-button:hover {
+  .actions-group :global(.add-button:hover) {
     transform: translateY(-1px);
     box-shadow: 0 4px 6px -1px color-mix(in srgb, var(--smrt-color-primary) 50%, transparent);
   }
@@ -660,7 +671,7 @@ function cancelDelete() {
     padding-top: 1rem;
   }
 
-  .content-actions button,
+  .content-actions :global(.content-action-btn),
   .content-actions a {
     flex: 1;
     padding: 0.5rem 1rem;
@@ -676,7 +687,7 @@ function cancelDelete() {
     text-decoration: none;
   }
 
-  .content-actions button:hover,
+  .content-actions :global(.content-action-btn:hover),
   .content-actions a:hover {
     background: var(--smrt-color-surface-variant);
     border-color: var(--smrt-color-outline);
@@ -686,11 +697,11 @@ function cancelDelete() {
     color: var(--smrt-color-primary) !important;
   }
 
-  .delete-btn {
+  .content-actions :global(.delete-btn) {
     color: var(--smrt-color-error) !important;
   }
 
-  .delete-btn:hover {
+  .content-actions :global(.delete-btn:hover) {
     background: var(--smrt-color-error-container) !important;
     border-color: var(--smrt-color-error) !important;
   }
@@ -754,7 +765,7 @@ function cancelDelete() {
     min-width: 8.5rem;
   }
 
-  .quiet-action {
+  .content-row__actions :global(.quiet-action) {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -769,11 +780,11 @@ function cancelDelete() {
     cursor: pointer;
   }
 
-  .quiet-action:hover {
+  .content-row__actions :global(.quiet-action:hover) {
     background: var(--smrt-color-surface-container-low);
   }
 
-  .quiet-action--danger {
+  .content-row__actions :global(.quiet-action--danger) {
     color: var(--smrt-color-error);
   }
 
@@ -855,7 +866,7 @@ function cancelDelete() {
     white-space: nowrap;
   }
 
-  .icon-btn {
+  .actions-cell :global(.icon-btn) {
     background: transparent;
     border: none;
     cursor: pointer;
@@ -866,12 +877,12 @@ function cancelDelete() {
     opacity: 0.7;
   }
 
-  .icon-btn:hover {
+  .actions-cell :global(.icon-btn:hover) {
     background: var(--smrt-color-surface-variant);
     opacity: 1;
   }
 
-  .delete-icon:hover {
+  .actions-cell :global(.delete-icon:hover) {
     background: var(--smrt-color-error-container);
   }
 

--- a/packages/content/src/svelte/components/ContentReferencesPanel.svelte
+++ b/packages/content/src/svelte/components/ContentReferencesPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { Snippet } from 'svelte';
 import type { ContentEditorReference } from '../content-editor-form';
 import { M } from '../i18n.editor.js';
@@ -99,7 +100,11 @@ function removeReference(id: string) {
             {/if}
           </div>
           {#if referenceId}
-            <button type="button" onclick={() => removeReference(referenceId)}>Remove</button>
+            <Button
+              variant="ghost"
+              type="button"
+              class="reference-button"
+              onclick={() => removeReference(referenceId)}>Remove</Button>
           {/if}
         </div>
       {/each}
@@ -121,7 +126,11 @@ function removeReference(id: string) {
         }
       }}
     />
-    <button type="button" onclick={addReference}>Add</button>
+    <Button
+      variant="ghost"
+      type="button"
+      class="reference-button"
+      onclick={addReference}>Add</Button>
   </div>
 
   {#if children}
@@ -199,7 +208,7 @@ function removeReference(id: string) {
   }
 
   input,
-  button {
+  .content-references-panel :global(.reference-button) {
     min-height: 2.5rem;
     border: 1px solid color-mix(in srgb, var(--smrt-color-outline) 50%, transparent);
     border-radius: 0.5rem;
@@ -209,13 +218,13 @@ function removeReference(id: string) {
     padding: 0.55rem 0.875rem;
   }
 
-  button {
+  .content-references-panel :global(.reference-button) {
     background: var(--smrt-color-surface-container);
     cursor: pointer;
     font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
-  button:hover {
+  .content-references-panel :global(.reference-button:hover) {
     background: var(--smrt-color-surface-container-high);
   }
 </style>

--- a/packages/content/src/svelte/components/ContentReviewStatusTray.svelte
+++ b/packages/content/src/svelte/components/ContentReviewStatusTray.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { Button } from '@happyvertical/smrt-ui/ui';
+
 export type ContentReviewStatusTone =
   | 'neutral'
   | 'danger'
@@ -64,18 +66,20 @@ let {
 {#if items.length > 0}
   <div class="content-review-status-tray" role="group" aria-label={label}>
     {#each items as item (item.id)}
-      <button
+      <Button
+        variant="ghost"
         type="button"
         aria-pressed={activeId === item.id && open}
-        class={`tray-button tray-button--${item.tone}`}
-        class:active={activeId === item.id && open}
+        class={`tray-button tray-button--${item.tone}${
+          activeId === item.id && open ? ' tray-button--active' : ''
+        }`}
         title={`${item.label}: ${item.status}`}
         onclick={() => onSelect?.(item)}
       >
         {@render trayIcon(item.icon)}
         <span class="tray-button__indicator" aria-hidden="true"></span>
         <span class="sr-only">{item.label}: {item.status}</span>
-      </button>
+      </Button>
     {/each}
   </div>
 {/if}
@@ -88,7 +92,7 @@ let {
     min-height: 2.5rem;
   }
 
-  .tray-button {
+  .content-review-status-tray :global(.tray-button) {
     position: relative;
     display: inline-grid;
     place-items: center;
@@ -102,13 +106,13 @@ let {
     padding: 0;
   }
 
-  .tray-button:hover,
-  .tray-button.active {
+  .content-review-status-tray :global(.tray-button:hover),
+  .content-review-status-tray :global(.tray-button.tray-button--active) {
     background: var(--smrt-color-surface-container);
     color: var(--smrt-color-on-surface);
   }
 
-  .tray-button svg {
+  .content-review-status-tray :global(.tray-button svg) {
     width: 1.15rem;
     height: 1.15rem;
     fill: none;
@@ -118,7 +122,7 @@ let {
     stroke-linejoin: round;
   }
 
-  .tray-button__indicator {
+  .content-review-status-tray :global(.tray-button__indicator) {
     position: absolute;
     right: 0.35rem;
     bottom: 0.35rem;
@@ -128,19 +132,19 @@ let {
     background: var(--smrt-color-outline);
   }
 
-  .tray-button--danger .tray-button__indicator {
+  .content-review-status-tray :global(.tray-button--danger .tray-button__indicator) {
     background: var(--smrt-color-error);
   }
 
-  .tray-button--warning .tray-button__indicator {
+  .content-review-status-tray :global(.tray-button--warning .tray-button__indicator) {
     background: var(--smrt-color-tertiary, #d97706);
   }
 
-  .tray-button--success .tray-button__indicator {
+  .content-review-status-tray :global(.tray-button--success .tray-button__indicator) {
     background: var(--smrt-color-primary);
   }
 
-  .sr-only {
+  .content-review-status-tray :global(.sr-only) {
     position: absolute;
     width: 1px;
     height: 1px;

--- a/packages/content/src/svelte/components/ContentVersionsTool.svelte
+++ b/packages/content/src/svelte/components/ContentVersionsTool.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { ConfirmDialog } from '@happyvertical/smrt-ui/feedback';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import type { ContentVersionData } from '../../mock-smrt-client';
 import { createClient } from '../../mock-smrt-client';
 import { normalizeApiBaseUrl } from '../api';
@@ -165,14 +166,14 @@ async function restoreVersion(versionNumber: number) {
 
 <div class="governance-tool">
   <div class="tool-toolbar">
-    <button
+    <Button
+      variant="secondary"
       type="button"
-      class="secondary-button"
       disabled={busy || !savedContentId}
       onclick={() => void createSnapshot()}
     >
       {busy ? 'Working...' : 'Create snapshot'}
-    </button>
+    </Button>
   </div>
 
   {#if error}
@@ -201,9 +202,9 @@ async function restoreVersion(versionNumber: number) {
           {/if}
           <div class="tool-card-footer">
             <span>{formatTimestamp(version.createdAt)}</span>
-            <button
+            <Button
+              variant="secondary"
               type="button"
-              class="secondary-button"
               disabled={busy || version.version === null || version.version === undefined}
               onclick={() => {
                 if (version.version !== null && version.version !== undefined) {
@@ -212,7 +213,7 @@ async function restoreVersion(versionNumber: number) {
               }}
             >
               Restore
-            </button>
+            </Button>
           </div>
         </div>
       {/each}
@@ -269,21 +270,6 @@ async function restoreVersion(versionNumber: number) {
   .empty-copy {
     color: var(--smrt-color-on-surface-variant);
     font-size: var(--smrt-typography-body-medium-size, 0.85rem);
-  }
-
-  .secondary-button {
-    border-radius: 0.5rem;
-    padding: 0.65rem 0.85rem;
-    border: 1px solid var(--smrt-color-outline-variant);
-    background: var(--smrt-color-surface);
-    color: var(--smrt-color-on-surface);
-    cursor: pointer;
-    font-weight: var(--smrt-typography-weight-semibold, 600);
-  }
-
-  .secondary-button:disabled {
-    cursor: not-allowed;
-    opacity: 0.65;
   }
 
   .pill {

--- a/packages/content/src/svelte/i18n.editor.ts
+++ b/packages/content/src/svelte/i18n.editor.ts
@@ -15,6 +15,7 @@ export const M = defineMessages({
   'content.content_agent_chat.no_topics': 'No topics...',
   'content.content_agent_chat.topic_name_placeholder': 'Topic name...',
   'content.content_agent_chat.new_topic': 'New Topic',
+  'content.content_agent_chat.cancel': 'Cancel',
   'content.content_agent_chat.new': 'New',
   'content.content_agent_chat.untitled_topic': 'Untitled Topic',
 

--- a/packages/content/src/svelte/routes/ContentContributionsRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentContributionsRoute.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { onMount } from 'svelte';
 import {
   type ContentContributionData,
@@ -413,13 +414,14 @@ async function handleDeleteContributor(data: Record<string, any>) {
                 bind:value={portalEmail}
                 placeholder={t(M['content.contributions.portal_email_placeholder'])}
               />
-              <button
+              <Button
+                variant="ghost"
                 type="submit"
-                class="secondary"
+                class="load-button"
                 disabled={refreshingPortal}
               >
                 {refreshingPortal ? 'Loading...' : 'Load'}
-              </button>
+              </Button>
             </form>
           </div>
 
@@ -721,8 +723,7 @@ async function handleDeleteContributor(data: Record<string, any>) {
     color: var(--smrt-color-on-surface);
   }
 
-  .inline-form button,
-  .secondary {
+  .inline-form :global(.load-button) {
     border-radius: var(--smrt-radius-full, 9999px);
     border: 1px solid color-mix(
       in srgb,

--- a/packages/content/src/svelte/routes/ContentFactsRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentFactsRoute.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { onMount } from 'svelte';
 import { createClient, type FactData } from '../../mock-smrt-client.js';
 import { M } from '../i18n.routes.js';
@@ -145,9 +146,9 @@ onMount(() => {
           <span>{t(M['content.facts.include_superseded'])}</span>
         </label>
 
-        <button class="refresh-button" type="submit" disabled={refreshing}>
+        <Button variant="primary" class="refresh-button" type="submit" disabled={refreshing}>
           {refreshing ? 'Refreshing…' : 'Refresh'}
-        </button>
+        </Button>
       </form>
     </section>
 
@@ -416,7 +417,7 @@ onMount(() => {
     color: var(--smrt-color-on-surface);
   }
 
-  .refresh-button {
+  .filters :global(.refresh-button) {
     min-height: 2.85rem;
     border-radius: 0.85rem;
     border: none;

--- a/packages/content/src/svelte/routes/ContentWorkspaceRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentWorkspaceRoute.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { onMount } from 'svelte';
 import type { ContentData } from '../../mock-smrt-client.js';
 import { createClient } from '../../mock-smrt-client.js';
@@ -195,7 +196,7 @@ function closeForms() {
     {:else if error}
       <section class="panel panel--error">
         <p><strong>Error:</strong> {error}</p>
-        <button type="button" onclick={loadContents}>{t(M['content.workspace.try_again'])}</button>
+        <Button variant="secondary" type="button" onclick={loadContents}>{t(M['content.workspace.try_again'])}</Button>
       </section>
     {:else if showAddForm || editingContent}
       <section class="panel">
@@ -230,13 +231,14 @@ function closeForms() {
         >
           {#snippet controls()}
             <div class="workspace-controls">
-              <button
+              <Button
+                variant="ghost"
                 type="button"
                 class="secondary-action"
                 onclick={handleAddGovernedContent}
               >
                 {t(M['content.workspace.create_governed'])}
-              </button>
+              </Button>
               <a class="inline-link" href={governanceHref}>
                 {t(M['content.workspace.review_governance'])}
               </a>
@@ -404,7 +406,7 @@ function closeForms() {
     gap: 0.75rem;
   }
 
-  .secondary-action {
+  .workspace-controls :global(.secondary-action) {
     border: 1px solid color-mix(
       in srgb,
       var(--smrt-color-primary) 30%,


### PR DESCRIPTION
## Summary

Large, mechanical **buttons-only** migration for the `content` package (issue #1589). Every raw `<button>` in the package's Svelte components is migrated to the shared `@happyvertical/smrt-ui` `Button` primitive, and the package is flipped to the `strict-buttons` ratchet mode. This is the largest package in the sweep — ~110 buttons across 25 `.svelte` files migrated in one PR (the ratchet flips all-or-nothing).

Forms (`input`/`select`/`textarea`/`form`) are intentionally left raw and are **exempt** under `strict-buttons`; form-primitive adoption is a separate follow-up.

## What changed

- **Variant mapping**: save/submit/publish/approve/confirm → `primary`; cancel/secondary → `secondary`; delete/remove/reject (destructive) → `danger`; icon / toolbar / text-link / dismiss / pagination / toggle buttons → `ghost` (`size="sm"` for small controls). `onclick`/`disabled`/`type`/`title`/`aria-*` preserved (Button forwards them); `type="submit"` buttons stay submit.
- **Custom-styled buttons** keep their class via `<Button class="x">` with the CSS rewritten as `.ancestor :global(.x)` so the rule reaches the button rendered inside the Button child. `class:active` toggles are folded into the class string (`x--active`) with `aria-pressed` added where they convey pressed state.
- **Dead CSS** for variant-mapped buttons deleted; CSS for still-raw inputs and shared `input, button` rules split and kept.
- **package.json**: `"smrtRawPrimitives": "strict-buttons"`.

## Escape-hatches (3, all genuinely structural)

- `ContentBodyEditor` — custom press-and-drag image **resize handle** (`onpointerdown` pointer-capture gesture, absolute positioning).
- `ContentContributionPortal` and `ContentContributionInbox` — large pressable **selection cards** (list rows that are themselves buttons wrapping rich content with a selected state).

## Notes

- No `use:ripple` or other `use:` action was dropped (none existed on any migrated button).
- No new user-facing string or `aria-label` literals introduced; existing `t(M[...])` calls and pre-existing labels are byte-identical.
- Scope: only `packages/content/**`; no `input/select/textarea/form` markup changed; no `console.*` removed; no lockfile change; no new dependency.

## Gates (all green locally)

- `node scripts/check-raw-primitives.mjs` → exit 0 (`content` listed under buttons-only, forms deferred)
- `pnpm --filter @happyvertical/smrt-content typecheck` → 0 errors / 0 warnings (tsc + svelte-check a11y)
- `pnpm --filter @happyvertical/smrt-content test` → 44 files / 297 tests passed (6 skipped)
- `node scripts/check-package-dag.mjs` + `node scripts/check-no-smrt-peers.mjs` → exit 0
- `biome check` (read-only) → no new findings in changed files

Closes part of #1589.
