### PR TITLE
refactor(chat): migrate buttons to Button, flip chat strict-buttons (#1589)

### DIFF
--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -3,6 +3,7 @@
   "version": "0.34.4",
   "description": "Chat rooms, DMs, threads, and agent conversations for the SMRT framework",
   "type": "module",
+  "smrtRawPrimitives": "strict-buttons",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/chat/src/svelte/components/agent/AgentChat.svelte
+++ b/packages/chat/src/svelte/components/agent/AgentChat.svelte
@@ -6,6 +6,7 @@
  */
 
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.js';
 import type {
   AgentSessionData,
@@ -106,7 +107,8 @@ $effect(() => {
         disabled={!isActive}
         aria-label={t(M['chat.agent_chat.message_input'])}
       ></textarea>
-      <button
+      <Button
+        variant="ghost"
         class="agent-chat__send-btn"
         type="submit"
         disabled={!inputValue.trim() || !isActive}
@@ -115,7 +117,7 @@ $effect(() => {
         <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
         </svg>
-      </button>
+      </Button>
     {/if}
   </form>
 
@@ -151,19 +153,21 @@ $effect(() => {
                   {:else if block.type === 'fields'}
                     <div class="field-update-block">
                       <span class="applied-badge">{t(M['chat.agent_chat.updated_fields'], { count: Object.keys(block.fields).length, plural: Object.keys(block.fields).length !== 1 ? 's' : '' })}</span>
-                      <button class="diff-btn" type="button" onclick={() => showDiff(block.fields)}>Diff</button>
+                      <Button variant="ghost" size="sm" class="diff-btn" type="button" onclick={() => showDiff(block.fields)}>Diff</Button>
                     </div>
                   {:else if block.type === 'markdown'}
                     <div class="markdown-block">
                       <pre class="markdown-block__content"><code>{block.content}</code></pre>
                       {#if onapplychange}
-                        <button
+                        <Button
+                          variant="ghost"
+                          size="sm"
                           class="diff-btn"
                           type="button"
                           onclick={() => onapplychange(block.content)}
                         >
                           Apply
-                        </button>
+                        </Button>
                       {/if}
                     </div>
                   {/if}
@@ -198,7 +202,7 @@ $effect(() => {
 <dialog bind:this={diffDialog} class="diff-dialog">
   <div class="diff-dialog__header">
     <h4>{t(M['chat.agent_chat.field_changes'])}</h4>
-    <button class="diff-dialog__close" type="button" onclick={closeDiff}>✕</button>
+    <Button variant="ghost" size="sm" class="diff-dialog__close" type="button" onclick={closeDiff}>✕</Button>
   </div>
   {#if diffDialogFields}
     <div class="diff-dialog__body">
@@ -349,27 +353,20 @@ $effect(() => {
     color: var(--smrt-color-outline, #74777f);
   }
 
-  .agent-chat__send-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+  /* :global() pierces into the Button child's rendered <button> (see #1589). */
+  .agent-chat__input-bar :global(.agent-chat__send-btn) {
     width: 34px;
     height: 34px;
-    border: none;
+    padding: 0;
     background: var(--smrt-color-primary, #005ac1);
     color: var(--smrt-color-on-primary, #ffffff);
     border-radius: var(--smrt-radius-full, 9999px);
-    cursor: pointer;
     flex-shrink: 0;
     transition: opacity 150ms;
   }
 
-  .agent-chat__send-btn:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-
-  .agent-chat__send-btn:not(:disabled):hover {
+  .agent-chat__input-bar :global(.agent-chat__send-btn:not(:disabled):hover) {
+    background: var(--smrt-color-primary, #005ac1);
     opacity: 0.85;
   }
 
@@ -411,7 +408,9 @@ $effect(() => {
     line-height: var(--smrt-typography-body-medium-line-height, 1.45);
   }
 
-  .diff-btn {
+  /* :global() pierces into each Button's rendered <button> (see #1589). */
+  .field-update-block :global(.diff-btn),
+  .markdown-block :global(.diff-btn) {
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     font-size: var(--smrt-typography-label-small-size, 0.625rem);
     font-weight: var(--smrt-typography-weight-semibold, 600);
@@ -419,11 +418,10 @@ $effect(() => {
     border-radius: var(--smrt-radius-full, 9999px);
     background: none;
     color: var(--smrt-color-on-surface-variant, #43474e);
-    cursor: pointer;
-    transition: background 0.15s;
   }
 
-  .diff-btn:hover {
+  .field-update-block :global(.diff-btn:hover),
+  .markdown-block :global(.diff-btn:hover) {
     background: var(--smrt-color-surface-variant, #e1e2ec);
     color: var(--smrt-color-primary, #005ac1);
   }
@@ -457,17 +455,16 @@ $effect(() => {
     font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
-  .diff-dialog__close {
+  /* :global() pierces into the Button child's rendered <button> (see #1589). */
+  .diff-dialog__header :global(.diff-dialog__close) {
     background: none;
-    border: none;
     font-size: var(--smrt-typography-body-large-size, 1rem);
-    cursor: pointer;
     color: var(--smrt-color-outline, #74777f);
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border-radius: var(--smrt-radius-sm, 4px);
   }
 
-  .diff-dialog__close:hover {
+  .diff-dialog__header :global(.diff-dialog__close:hover) {
     background: var(--smrt-color-surface-variant, #e1e2ec);
   }
 

--- a/packages/chat/src/svelte/components/agent/AgentSelector.svelte
+++ b/packages/chat/src/svelte/components/agent/AgentSelector.svelte
@@ -26,6 +26,7 @@ const { t } = useI18n();
 
   <div class="agent-selector__grid" role="listbox" aria-label={t(M['chat.agent_selector.available_agents'])}>
     {#each agents as agent (agent.id)}
+      <!-- raw-primitive-allow: large pressable selection card with role=option wrapping rich content (avatar, name, description, unavailable badge) inside a role=listbox; no Button primitive owns this structural listbox-option pattern -->
       <button
         class="agent-selector__card"
         class:agent-selector__card--unavailable={!agent.isAvailable}

--- a/packages/chat/src/svelte/components/agent/AgentSessionPanel.svelte
+++ b/packages/chat/src/svelte/components/agent/AgentSessionPanel.svelte
@@ -5,6 +5,7 @@
  * Allows selecting an existing session or creating a new one.
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.js';
 import type { AgentSessionData } from '../../types.js';
 import Avatar from '../shared/Avatar.svelte';
@@ -49,7 +50,8 @@ const statusLabel: Record<string, string> = {
   <div class="session-panel__header">
     <h2 class="session-panel__title">Sessions</h2>
     {#if onnewsession}
-      <button
+      <Button
+        variant="ghost"
         class="session-panel__new-btn"
         type="button"
         onclick={onnewsession}
@@ -59,13 +61,14 @@ const statusLabel: Record<string, string> = {
         <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
         </svg>
-      </button>
+      </Button>
     {/if}
   </div>
 
   <div class="session-panel__list" role="listbox" aria-label={t(M['chat.agent_session_panel.session_list'])}>
     {#each sessions as session (session.id)}
       {@const isCurrent = session.id === currentSessionId}
+      <!-- raw-primitive-allow: large pressable selection card with role=option wrapping rich content (avatar, name, date, status, message count, tool chips) inside a role=listbox; no Button primitive owns this structural listbox-option pattern -->
       <button
         class="session-panel__item"
         class:session-panel__item--active={isCurrent}
@@ -152,27 +155,20 @@ const statusLabel: Record<string, string> = {
     margin: 0;
   }
 
-  .session-panel__new-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+  /* :global() pierces into the Button child's rendered <button> (see #1589). */
+  .session-panel__header :global(.session-panel__new-btn) {
     width: 36px;
     height: 36px;
-    border: none;
+    padding: 0;
     background: var(--smrt-color-primary, #005ac1);
     color: var(--smrt-color-on-primary, #ffffff);
     border-radius: var(--smrt-radius-full, 9999px);
-    cursor: pointer;
     transition: opacity var(--smrt-duration-short2, 150ms);
   }
 
-  .session-panel__new-btn:hover {
+  .session-panel__header :global(.session-panel__new-btn:hover) {
+    background: var(--smrt-color-primary, #005ac1);
     opacity: 0.85;
-  }
-
-  .session-panel__new-btn:focus-visible {
-    outline: 2px solid var(--smrt-color-primary, #005ac1);
-    outline-offset: 2px;
   }
 
   .session-panel__list {
@@ -314,8 +310,11 @@ const statusLabel: Record<string, string> = {
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .session-panel__item,
-    .session-panel__new-btn {
+    .session-panel__item {
+      transition: none;
+    }
+
+    .session-panel__header :global(.session-panel__new-btn) {
       transition: none;
     }
   }

--- a/packages/chat/src/svelte/components/agent/ToolCallDisplay.svelte
+++ b/packages/chat/src/svelte/components/agent/ToolCallDisplay.svelte
@@ -50,6 +50,7 @@ function formatDuration(ms: number | undefined): string {
 </script>
 
 <div class="tool-call tool-call--{toolCall.status}" aria-label={t(M['chat.tool_call_display.tool_call'], { toolName: toolCall.toolName })}>
+  <!-- raw-primitive-allow: full-width disclosure trigger with aria-expanded and aria-controls toggling an externally-rendered collapsible panel, wrapping rich content (status dot, name, duration, status label, rotating chevron); structural accordion header no Button primitive owns -->
   <button
     class="tool-call__header"
     type="button"

--- a/packages/chat/src/svelte/components/dialogs/RoomCreateDialog.svelte
+++ b/packages/chat/src/svelte/components/dialogs/RoomCreateDialog.svelte
@@ -9,6 +9,7 @@
  */
 import { Modal } from '@happyvertical/smrt-ui/feedback';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.js';
 
 const { t } = useI18n();
@@ -153,25 +154,26 @@ $effect(() => {
     </div>
 
     <!-- Hidden submit keeps Enter-to-submit working inside the Modal body. -->
+    <!-- raw-primitive-allow: off-screen aria-hidden type=submit element with tabindex=-1 used only to enable native Enter-to-submit inside the Modal body; intentionally non-interactive and not a visible action button -->
     <button type="submit" class="visually-hidden" tabindex="-1" disabled={!canCreate} aria-hidden="true"></button>
   </form>
 
   {#snippet footer()}
-    <button
+    <Button
+      variant="secondary"
       type="button"
-      class="btn btn--secondary"
       onclick={handleClose}
     >
       Cancel
-    </button>
-    <button
+    </Button>
+    <Button
+      variant="primary"
       type="button"
-      class="btn btn--primary"
       disabled={!canCreate}
       onclick={handleSubmit}
     >
       {t(M['chat.room_create_dialog.create_room'])}
-    </button>
+    </Button>
   {/snippet}
 </Modal>
 
@@ -301,45 +303,8 @@ $effect(() => {
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.625rem 1.5rem;
-    font: var(--smrt-typography-label-large-font, 500 0.875rem / 1.25 sans-serif);
-    letter-spacing: 0.1px;
-    border-radius: var(--smrt-radius-full, 9999px);
-    border: none;
-    cursor: pointer;
-    transition: all var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
-  }
-
-  .btn:disabled {
-    opacity: 0.38;
-    cursor: not-allowed;
-  }
-
-  .btn--primary {
-    background: var(--smrt-color-primary, #005ac1);
-    color: var(--smrt-color-on-primary, #fff);
-  }
-
-  .btn--primary:hover:not(:disabled) {
-    box-shadow: var(--smrt-elevation-1, 0 1px 2px rgba(0, 0, 0, 0.3), 0 1px 3px 1px rgba(0, 0, 0, 0.15));
-  }
-
-  .btn--secondary {
-    background: transparent;
-    color: var(--smrt-color-primary, #005ac1);
-  }
-
-  .btn--secondary:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--smrt-color-primary, #005ac1) 8%, transparent);
-  }
-
   @media (prefers-reduced-motion: reduce) {
-    .type-option,
-    .btn {
+    .type-option {
       transition: none;
     }
   }

--- a/packages/chat/src/svelte/components/dialogs/SearchMessages.svelte
+++ b/packages/chat/src/svelte/components/dialogs/SearchMessages.svelte
@@ -4,6 +4,7 @@
  * Provides a search input and displays matching messages
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.js';
 import type { ChatMessageData } from '../../types.js';
 
@@ -108,7 +109,9 @@ $effect(() => {
   >
     <div class="search-panel__header">
       <h2 class="search-panel__title">{t(M['chat.search_messages.title'])}</h2>
-      <button
+      <Button
+        variant="ghost"
+        size="sm"
         class="close-btn"
         type="button"
         onclick={handleClose}
@@ -118,7 +121,7 @@ $effect(() => {
           <path d="M18 6 6 18" />
           <path d="m6 6 12 12" />
         </svg>
-      </button>
+      </Button>
     </div>
 
     <form
@@ -140,7 +143,9 @@ $effect(() => {
           aria-label={t(M['chat.search_messages.query'])}
         />
         {#if hasQuery}
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             class="clear-btn"
             type="button"
             onclick={() => { query = ''; searchInput?.focus(); }}
@@ -150,7 +155,7 @@ $effect(() => {
               <path d="M18 6 6 18" />
               <path d="m6 6 12 12" />
             </svg>
-          </button>
+          </Button>
         {/if}
       </div>
     </form>
@@ -163,6 +168,7 @@ $effect(() => {
         <ul class="results-list" aria-label={t(M['chat.search_messages.results'])}>
           {#each results as message (message.id)}
             <li class="results-list__item">
+              <!-- raw-primitive-allow: large pressable search-result card wrapping rich content (avatar, sender, date, multi-line highlighted message excerpt); no Button primitive owns this structural selection-card pattern -->
               <button
                 class="result-item"
                 type="button"
@@ -231,27 +237,19 @@ $effect(() => {
     color: var(--smrt-color-on-surface, #1a1c1e);
   }
 
-  .close-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+  /* :global() pierces into the Button child's rendered <button> (see #1589). */
+  .search-panel__header :global(.close-btn) {
     width: 1.75rem;
     height: 1.75rem;
-    border: none;
+    padding: 0;
     background: none;
     border-radius: var(--smrt-radius-medium, 0.5rem);
     color: var(--smrt-color-on-surface-variant, #43474e);
-    cursor: pointer;
     transition: background var(--smrt-duration-short2, 150ms);
   }
 
-  .close-btn:hover {
+  .search-panel__header :global(.close-btn:hover) {
     background: var(--smrt-color-surface-variant, #e1e2ec);
-  }
-
-  .close-btn:focus-visible {
-    outline: 2px solid var(--smrt-color-primary, #005ac1);
-    outline-offset: -2px;
   }
 
   .close-btn__icon {
@@ -300,21 +298,19 @@ $effect(() => {
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
-  .clear-btn {
+  /* :global() pierces into the Button child's rendered <button> (see #1589). */
+  .search-input-wrap :global(.clear-btn) {
     flex-shrink: 0;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
     width: 1.25rem;
     height: 1.25rem;
-    border: none;
+    padding: 0;
     background: none;
     border-radius: var(--smrt-radius-full, 9999px);
     color: var(--smrt-color-on-surface-variant, #43474e);
-    cursor: pointer;
   }
 
-  .clear-btn:hover {
+  .search-input-wrap :global(.clear-btn:hover) {
+    background: none;
     color: var(--smrt-color-on-surface, #1a1c1e);
   }
 
@@ -448,9 +444,12 @@ $effect(() => {
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .close-btn,
     .result-item,
     .search-input-wrap {
+      transition: none;
+    }
+
+    .search-panel__header :global(.close-btn) {
       transition: none;
     }
   }

--- a/packages/chat/src/svelte/components/layout/ChatLayout.svelte
+++ b/packages/chat/src/svelte/components/layout/ChatLayout.svelte
@@ -72,6 +72,7 @@ function handlePointerUp() {
     />
   </aside>
 
+  <!-- raw-primitive-allow: custom drag-to-resize splitter with pointer capture (pointerdown/move/up) and ArrowLeft/ArrowRight keyboard resizing; a press-and-drag control no Button primitive owns -->
   <button
     type="button"
     class="chat-layout__resize-handle"

--- a/packages/chat/src/svelte/components/layout/MemberList.svelte
+++ b/packages/chat/src/svelte/components/layout/MemberList.svelte
@@ -4,6 +4,7 @@
  * Lists participants grouped by online status with role badges
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.messages.js';
 import type { ChatParticipantData } from '../../types.js';
 
@@ -74,7 +75,9 @@ function getRoleBadgeLabel(role: string): string {
   <div class="member-list__header">
     <h2 class="member-list__title">Members</h2>
     <span class="member-list__count">{participants.length}</span>
-    <button
+    <Button
+      variant="ghost"
+      size="sm"
       class="close-btn"
       type="button"
       onclick={onclose}
@@ -84,7 +87,7 @@ function getRoleBadgeLabel(role: string): string {
         <path d="M18 6 6 18" />
         <path d="m6 6 12 12" />
       </svg>
-    </button>
+    </Button>
   </div>
 
   <div class="member-list__content">
@@ -235,28 +238,20 @@ function getRoleBadgeLabel(role: string): string {
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
-  .close-btn {
+  /* :global() pierces into the Button child's rendered <button> (see #1589). */
+  .member-list__header :global(.close-btn) {
     margin-left: auto;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
     width: 1.75rem;
     height: 1.75rem;
-    border: none;
+    padding: 0;
     background: none;
     border-radius: var(--smrt-radius-medium, 0.5rem);
     color: var(--smrt-color-on-surface-variant, #43474e);
-    cursor: pointer;
     transition: background var(--smrt-duration-short2, 150ms);
   }
 
-  .close-btn:hover {
+  .member-list__header :global(.close-btn:hover) {
     background: var(--smrt-color-surface-variant, #e1e2ec);
-  }
-
-  .close-btn:focus-visible {
-    outline: 2px solid var(--smrt-color-primary, #005ac1);
-    outline-offset: -2px;
   }
 
   .close-btn__icon {
@@ -384,7 +379,7 @@ function getRoleBadgeLabel(role: string): string {
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .close-btn {
+    .member-list__header :global(.close-btn) {
       transition: none;
     }
   }

--- a/packages/chat/src/svelte/components/layout/RoomHeader.svelte
+++ b/packages/chat/src/svelte/components/layout/RoomHeader.svelte
@@ -4,6 +4,7 @@
  * Displays room info and provides access to members and search
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.messages.js';
 import type { ChatRoomData } from '../../types.js';
 
@@ -78,7 +79,9 @@ const roomTypeLabel = $derived.by(() => {
 
   <div class="room-header__actions">
     {#if onshowmembers}
-      <button
+      <Button
+        variant="ghost"
+        size="sm"
         class="header-btn"
         type="button"
         onclick={onshowmembers}
@@ -92,11 +95,13 @@ const roomTypeLabel = $derived.by(() => {
           <path d="M16 3.13a4 4 0 0 1 0 7.75" />
         </svg>
         <span class="header-btn__count">{participantCount}</span>
-      </button>
+      </Button>
     {/if}
 
     {#if onshowsearch}
-      <button
+      <Button
+        variant="ghost"
+        size="sm"
         class="header-btn"
         type="button"
         onclick={onshowsearch}
@@ -107,7 +112,7 @@ const roomTypeLabel = $derived.by(() => {
           <circle cx="11" cy="11" r="8" />
           <path d="m21 21-4.35-4.35" />
         </svg>
-      </button>
+      </Button>
     {/if}
   </div>
 </header>
@@ -201,26 +206,18 @@ const roomTypeLabel = $derived.by(() => {
     gap: 0.25rem;
   }
 
-  .header-btn {
-    display: inline-flex;
-    align-items: center;
+  /* :global() pierces into each Button's rendered <button> (see #1589). */
+  .room-header__actions :global(.header-btn) {
     gap: 0.25rem;
     padding: 0.375rem 0.5rem;
-    border: none;
     background: none;
     border-radius: var(--smrt-radius-medium, 0.5rem);
     color: var(--smrt-color-on-surface-variant, #43474e);
-    cursor: pointer;
     transition: background var(--smrt-duration-short2, 150ms);
   }
 
-  .header-btn:hover {
+  .room-header__actions :global(.header-btn:hover) {
     background: var(--smrt-color-surface-variant, #e1e2ec);
-  }
-
-  .header-btn:focus-visible {
-    outline: 2px solid var(--smrt-color-primary, #005ac1);
-    outline-offset: -2px;
   }
 
   .header-btn__icon {
@@ -234,7 +231,7 @@ const roomTypeLabel = $derived.by(() => {
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .header-btn {
+    .room-header__actions :global(.header-btn) {
       transition: none;
     }
   }

--- a/packages/chat/src/svelte/components/layout/RoomList.svelte
+++ b/packages/chat/src/svelte/components/layout/RoomList.svelte
@@ -4,6 +4,7 @@
  * Groups rooms by type: channels, DMs, and agent conversations
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.messages.js';
 import type { ChatRoomData } from '../../types.js';
 
@@ -71,19 +72,22 @@ function formatTimestamp(date?: string | Date | null): string {
 <nav class="room-list" aria-label={t(M['chat.room_list.rooms_label'])}>
   {#if oncreateroom}
     <div class="room-list__header">
-      <button
+      <Button
+        variant="ghost"
+        fullWidth
         class="create-room-btn"
         type="button"
         onclick={oncreateroom}
         aria-label={t(M['chat.room_list.create_new_room'])}
       >
         {t(M['chat.room_list.new_room'])}
-      </button>
+      </Button>
     </div>
   {/if}
 
   {#if channels.length > 0}
     <section class="room-group">
+      <!-- raw-primitive-allow: section disclosure trigger with aria-expanded toggling a collapsible room list, wrapping rich content (rotating chevron, group label, room count); structural accordion header no Button primitive owns -->
       <button
         class="room-group__header"
         type="button"
@@ -101,6 +105,7 @@ function formatTimestamp(date?: string | Date | null): string {
         <ul class="room-group__list" role="list">
           {#each channels as room (room.id)}
             <li>
+              <!-- raw-primitive-allow: pressable room-selection row with active and aria-current state, wrapping rich content (type icon, name, unread badge); no Button primitive owns this structural nav-selection pattern -->
               <button
                 class="room-item"
                 class:room-item--active={room.id === currentRoomId}
@@ -126,6 +131,7 @@ function formatTimestamp(date?: string | Date | null): string {
 
   {#if directMessages.length > 0}
     <section class="room-group">
+      <!-- raw-primitive-allow: section disclosure trigger with aria-expanded toggling a collapsible room list, wrapping rich content (rotating chevron, group label, room count); structural accordion header no Button primitive owns -->
       <button
         class="room-group__header"
         type="button"
@@ -143,6 +149,7 @@ function formatTimestamp(date?: string | Date | null): string {
         <ul class="room-group__list" role="list">
           {#each directMessages as room (room.id)}
             <li>
+              <!-- raw-primitive-allow: pressable room-selection row with active and aria-current state, wrapping rich content (avatar, name, last-message preview, timestamp, unread badge); no Button primitive owns this structural nav-selection pattern -->
               <button
                 class="room-item"
                 class:room-item--active={room.id === currentRoomId}
@@ -184,6 +191,7 @@ function formatTimestamp(date?: string | Date | null): string {
 
   {#if agentRooms.length > 0}
     <section class="room-group">
+      <!-- raw-primitive-allow: section disclosure trigger with aria-expanded toggling a collapsible room list, wrapping rich content (rotating chevron, group label, room count); structural accordion header no Button primitive owns -->
       <button
         class="room-group__header"
         type="button"
@@ -201,6 +209,7 @@ function formatTimestamp(date?: string | Date | null): string {
         <ul class="room-group__list" role="list">
           {#each agentRooms as room (room.id)}
             <li>
+              <!-- raw-primitive-allow: pressable room-selection row with active and aria-current state, wrapping rich content (agent icon, name, unread badge); no Button primitive owns this structural nav-selection pattern -->
               <button
                 class="room-item"
                 class:room-item--active={room.id === currentRoomId}
@@ -227,9 +236,9 @@ function formatTimestamp(date?: string | Date | null): string {
     <div class="room-list__empty">
       <p>{t(M['chat.room_list.no_rooms'])}</p>
       {#if oncreateroom}
-        <button class="create-link" type="button" onclick={oncreateroom}>
+        <Button variant="ghost" size="sm" class="create-link" type="button" onclick={oncreateroom}>
           {t(M['chat.room_list.create_first_room'])}
-        </button>
+        </Button>
       {/if}
     </div>
   {/if}
@@ -247,25 +256,19 @@ function formatTimestamp(date?: string | Date | null): string {
     padding: 0.5rem 0.75rem;
   }
 
-  .create-room-btn {
-    width: 100%;
+  /* :global() pierces into the Button child's rendered <button> (see #1589). */
+  .room-list__header :global(.create-room-btn) {
     padding: 0.5rem 0.75rem;
     border: 1px dashed var(--smrt-color-outline, #74777f);
     border-radius: var(--smrt-radius-medium, 0.5rem);
     background: transparent;
     color: var(--smrt-color-primary, #005ac1);
     font: var(--smrt-typography-label-large-font, 500 0.875rem / 1.25 sans-serif);
-    cursor: pointer;
     transition: background var(--smrt-duration-short2, 150ms);
   }
 
-  .create-room-btn:hover {
+  .room-list__header :global(.create-room-btn:hover) {
     background: var(--smrt-color-primary-container, #d6e3ff);
-  }
-
-  .create-room-btn:focus-visible {
-    outline: 2px solid var(--smrt-color-primary, #005ac1);
-    outline-offset: -2px;
   }
 
   .room-group {
@@ -452,19 +455,25 @@ function formatTimestamp(date?: string | Date | null): string {
     font: var(--smrt-typography-body-medium-font, 0.875rem / 1.25 sans-serif);
   }
 
-  .create-link {
-    border: none;
+  /* :global() pierces into the Button child's rendered <button> (see #1589). */
+  .room-list__empty :global(.create-link) {
     background: none;
     color: var(--smrt-color-primary, #005ac1);
     font: var(--smrt-typography-label-large-font, 500 0.875rem / 1.25 sans-serif);
-    cursor: pointer;
     text-decoration: underline;
+  }
+
+  .room-list__empty :global(.create-link:hover) {
+    background: none;
   }
 
   @media (prefers-reduced-motion: reduce) {
     .room-item,
-    .create-room-btn,
     .room-group__chevron {
+      transition: none;
+    }
+
+    .room-list__header :global(.create-room-btn) {
       transition: none;
     }
   }

--- a/packages/chat/src/svelte/components/messages/MessageInput.svelte
+++ b/packages/chat/src/svelte/components/messages/MessageInput.svelte
@@ -4,6 +4,7 @@
  * Text area with send button. Shows reply preview when replying.
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.messages.js';
 
 const { t } = useI18n();
@@ -64,14 +65,16 @@ function handleInput() {
         <span class="message-input__reply-text">{replyTo.content}</span>
       </div>
       {#if oncancelreply}
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
           class="message-input__reply-close"
           type="button"
           onclick={oncancelreply}
           aria-label={t(M['chat.message_input.cancel_reply'])}
         >
           <svg viewBox="0 0 16 16" width="14" height="14"><path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" /></svg>
-        </button>
+        </Button>
       {/if}
     </div>
   {/if}
@@ -88,7 +91,8 @@ function handleInput() {
       oninput={handleInput}
       aria-label={t(M['chat.message_input.input_label'])}
     ></textarea>
-    <button
+    <Button
+      variant="ghost"
       class="message-input__send"
       type="button"
       onclick={handleSend}
@@ -105,7 +109,7 @@ function handleInput() {
           stroke-linejoin="round"
         />
       </svg>
-    </button>
+    </Button>
   </div>
 </div>
 
@@ -155,21 +159,18 @@ function handleInput() {
     text-overflow: ellipsis;
   }
 
-  .message-input__reply-close {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  /* :global() pierces into the Button child's rendered <button> (see #1589). */
+  .message-input__reply :global(.message-input__reply-close) {
     width: 24px;
     height: 24px;
-    border: none;
+    padding: 0;
     border-radius: var(--smrt-radius-small, 0.25rem);
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
-    cursor: pointer;
     flex-shrink: 0;
   }
 
-  .message-input__reply-close:hover {
+  .message-input__reply :global(.message-input__reply-close:hover) {
     background: var(--smrt-color-surface-container-high, #e1e3e8);
   }
 
@@ -205,28 +206,24 @@ function handleInput() {
     color: var(--smrt-color-outline, #74777f);
   }
 
-  .message-input__send {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  /* :global() pierces into the Button child's rendered <button> (see #1589). */
+  .message-input__bar :global(.message-input__send) {
     width: 36px;
     height: 36px;
-    border: none;
+    padding: 0;
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-primary, #005ac1);
     color: var(--smrt-color-on-primary, #ffffff);
-    cursor: pointer;
     flex-shrink: 0;
     transition: background var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
   }
 
-  .message-input__send:hover:not(:disabled) {
+  .message-input__bar :global(.message-input__send:hover:not(:disabled)) {
     background: color-mix(in srgb, var(--smrt-color-primary, #005ac1) 85%, var(--smrt-color-shadow, #000));
   }
 
-  .message-input__send:disabled {
+  .message-input__bar :global(.message-input__send:disabled) {
     background: var(--smrt-color-surface-container-high, #e1e3e8);
     color: var(--smrt-color-outline, #74777f);
-    cursor: not-allowed;
   }
 </style>

--- a/packages/chat/src/svelte/components/messages/MessageItem.svelte
+++ b/packages/chat/src/svelte/components/messages/MessageItem.svelte
@@ -5,6 +5,7 @@
  */
 
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.messages.js';
 import type { ChatMessageData } from '../../types.js';
 import Avatar from '../shared/Avatar.svelte';
@@ -172,16 +173,17 @@ function handleEscape(event: KeyboardEvent) {
       {#if message.reactions.length > 0}
         <div class="message-item__reactions">
           {#each message.reactions as reaction}
-            <button
-              class="message-item__reaction"
-              class:message-item__reaction--active={reaction.reacted}
+            <Button
+              variant="ghost"
+              size="sm"
+              class="message-item__reaction{reaction.reacted ? ' message-item__reaction--active' : ''}"
               type="button"
               onclick={() => onreact?.(message.id, reaction.emoji)}
               aria-label="{reaction.emoji} {reaction.count}"
             >
               <span class="message-item__reaction-emoji">{reaction.emoji}</span>
               <span class="message-item__reaction-count">{reaction.count}</span>
-            </button>
+            </Button>
           {/each}
         </div>
       {/if}
@@ -195,7 +197,9 @@ function handleEscape(event: KeyboardEvent) {
     </div>
 
     {#if hasActions}
-      <button
+      <Button
+        variant="ghost"
+        size="sm"
         class="message-item__more-btn"
         type="button"
         onclick={openActions}
@@ -205,7 +209,7 @@ function handleEscape(event: KeyboardEvent) {
         aria-controls={actionsId}
       >
         <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><circle cx="3" cy="8" r="1.3" fill="currentColor" /><circle cx="8" cy="8" r="1.3" fill="currentColor" /><circle cx="13" cy="8" r="1.3" fill="currentColor" /></svg>
-      </button>
+      </Button>
     {/if}
 
     {#if showActions}
@@ -216,44 +220,52 @@ function handleEscape(event: KeyboardEvent) {
         aria-label={t(M['chat.message_item.more_actions'])}
       >
         {#if onreact}
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             class="message-item__action-btn"
             type="button"
             onclick={toggleReactionPicker}
             aria-label={t(M['chat.message_item.add_reaction'])}
           >
             <svg viewBox="0 0 16 16" width="14" height="14"><circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" stroke-width="1.2" /><circle cx="5.5" cy="6.5" r="0.8" fill="currentColor" /><circle cx="10.5" cy="6.5" r="0.8" fill="currentColor" /><path d="M5.5 9.5c.5 1.2 1.5 1.8 2.5 1.8s2-.6 2.5-1.8" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" /></svg>
-          </button>
+          </Button>
         {/if}
         {#if onreply}
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             class="message-item__action-btn"
             type="button"
             onclick={() => onreply?.(message.id)}
             aria-label={t(M['chat.message_item.reply'])}
           >
             <svg viewBox="0 0 16 16" width="14" height="14"><path d="M6 3L2 7l4 4" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" /><path d="M2 7h8c2.2 0 4 1.8 4 4v1" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" /></svg>
-          </button>
+          </Button>
         {/if}
         {#if isOwn && onedit}
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             class="message-item__action-btn"
             type="button"
             onclick={() => onedit?.(message.id)}
             aria-label={t(M['chat.message_item.edit'])}
           >
             <svg viewBox="0 0 16 16" width="14" height="14"><path d="M11.5 1.5l3 3L5 14H2v-3z" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" /></svg>
-          </button>
+          </Button>
         {/if}
         {#if isOwn && ondelete}
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             class="message-item__action-btn"
             type="button"
             onclick={() => ondelete?.(message.id)}
             aria-label={t(M['chat.message_item.delete'])}
           >
             <svg viewBox="0 0 16 16" width="14" height="14"><path d="M2 4h12M5.3 4V2.7A.7.7 0 016 2h4a.7.7 0 01.7.7V4m1.6 0v9.3a1.4 1.4 0 01-1.4 1.4H5.1a1.4 1.4 0 01-1.4-1.4V4" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" /></svg>
-          </button>
+          </Button>
         {/if}
       </div>
 
@@ -391,24 +403,22 @@ function handleEscape(event: KeyboardEvent) {
     gap: var(--smrt-spacing-1, 0.25rem);
   }
 
-  .message-item__reaction {
-    display: inline-flex;
-    align-items: center;
+  /* :global() pierces into each Button's rendered <button> (see #1589). */
+  .message-item__reactions :global(.message-item__reaction) {
     gap: var(--smrt-spacing-1, 4px);
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-surface, #ffffff);
-    cursor: pointer;
     font-size: var(--smrt-typography-label-medium-size, 0.75rem);
     transition: background var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
   }
 
-  .message-item__reaction:hover {
+  .message-item__reactions :global(.message-item__reaction:hover) {
     background: var(--smrt-color-surface-container-high, #e1e3e8);
   }
 
-  .message-item__reaction--active {
+  .message-item__reactions :global(.message-item__reaction--active) {
     border-color: var(--smrt-color-primary, #005ac1);
     background: var(--smrt-color-primary-container, #d6e3ff);
   }
@@ -441,12 +451,11 @@ function handleEscape(event: KeyboardEvent) {
     font-style: italic;
   }
 
-  .message-item__more-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  /* :global() pierces into the Button child's rendered <button> (see #1589). */
+  .message-item :global(.message-item__more-btn) {
     width: 26px;
     height: 26px;
+    padding: 0;
     position: absolute;
     top: 0;
     right: var(--smrt-spacing-4, 1rem);
@@ -454,12 +463,11 @@ function handleEscape(event: KeyboardEvent) {
     border-radius: var(--smrt-radius-small, 0.25rem);
     background: var(--smrt-color-surface, #ffffff);
     color: var(--smrt-color-on-surface-variant, #43474e);
-    cursor: pointer;
     opacity: 0;
     transition: opacity var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
   }
 
-  .message-item--own .message-item__more-btn {
+  .message-item--own :global(.message-item__more-btn) {
     right: auto;
     left: var(--smrt-spacing-4, 1rem);
   }
@@ -467,19 +475,19 @@ function handleEscape(event: KeyboardEvent) {
   /* Reveal the keyboard/touch affordance on hover OR when focus is inside the
      row, so it is never strictly hover-only (a11y blocker, T2 #1391). Always
      visible to coarse pointers (touch) which cannot hover. */
-  .message-item:hover .message-item__more-btn,
-  .message-item:focus-within .message-item__more-btn {
+  .message-item:hover :global(.message-item__more-btn),
+  .message-item:focus-within :global(.message-item__more-btn) {
     opacity: 1;
   }
 
-  .message-item__more-btn:focus-visible {
+  .message-item :global(.message-item__more-btn:focus-visible) {
     opacity: 1;
     outline: 2px solid var(--smrt-color-primary, #005ac1);
     outline-offset: 1px;
   }
 
   @media (hover: none) {
-    .message-item__more-btn {
+    .message-item :global(.message-item__more-btn) {
       opacity: 1;
     }
   }
@@ -504,21 +512,18 @@ function handleEscape(event: KeyboardEvent) {
     left: var(--smrt-spacing-4, 1rem);
   }
 
-  .message-item__action-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  /* :global() pierces into each Button's rendered <button> (see #1589). */
+  .message-item__actions :global(.message-item__action-btn) {
     width: 26px;
     height: 26px;
-    border: none;
+    padding: 0;
     border-radius: var(--smrt-radius-small, 0.25rem);
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
-    cursor: pointer;
     transition: background var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
   }
 
-  .message-item__action-btn:hover {
+  .message-item__actions :global(.message-item__action-btn:hover) {
     background: var(--smrt-color-surface-container-high, #e1e3e8);
   }
 
@@ -536,9 +541,9 @@ function handleEscape(event: KeyboardEvent) {
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .message-item__more-btn,
-    .message-item__action-btn,
-    .message-item__reaction {
+    .message-item :global(.message-item__more-btn),
+    .message-item__actions :global(.message-item__action-btn),
+    .message-item__reactions :global(.message-item__reaction) {
       transition: none;
     }
   }

--- a/packages/chat/src/svelte/components/messages/ThreadPanel.svelte
+++ b/packages/chat/src/svelte/components/messages/ThreadPanel.svelte
@@ -5,6 +5,7 @@
  */
 
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.messages.js';
 import type { ChatMessageData, ChatThreadData } from '../../types.js';
 import MessageInput from './MessageInput.svelte';
@@ -47,7 +48,9 @@ const replyCount = $derived(
     {#if thread.isResolved}
       <span class="thread-panel__resolved">Resolved</span>
     {/if}
-    <button
+    <Button
+      variant="ghost"
+      size="sm"
       class="thread-panel__close"
       type="button"
       onclick={onclose}
@@ -56,7 +59,7 @@ const replyCount = $derived(
       <svg viewBox="0 0 16 16" width="16" height="16">
         <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
       </svg>
-    </button>
+    </Button>
   </header>
 
   <div class="thread-panel__messages">
@@ -124,22 +127,19 @@ const replyCount = $derived(
     flex-shrink: 0;
   }
 
-  .thread-panel__close {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  /* :global() pierces into the Button child's rendered <button> (see #1589). */
+  .thread-panel__header :global(.thread-panel__close) {
     width: 32px;
     height: 32px;
-    border: none;
+    padding: 0;
     border-radius: var(--smrt-radius-small, 0.25rem);
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
-    cursor: pointer;
     flex-shrink: 0;
     transition: background var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
   }
 
-  .thread-panel__close:hover {
+  .thread-panel__header :global(.thread-panel__close:hover) {
     background: var(--smrt-color-surface-container-high, #e1e3e8);
   }
 

--- a/packages/chat/src/svelte/components/shared/FileUpload.svelte
+++ b/packages/chat/src/svelte/components/shared/FileUpload.svelte
@@ -5,6 +5,7 @@
  * Supports file type filtering and max size constraints.
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.js';
 
 const { t } = useI18n();
@@ -116,7 +117,9 @@ function getFileIcon(type: string): string {
             <span class="file-upload__file-name">{file.name}</span>
             <span class="file-upload__file-size">{formatSize(file.size)}</span>
           </div>
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             class="file-upload__file-remove"
             type="button"
             onclick={() => removePending(i)}
@@ -125,25 +128,27 @@ function getFileIcon(type: string): string {
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
             </svg>
-          </button>
+          </Button>
         </div>
       {/each}
 
       <div class="file-upload__preview-actions">
-        <button
-          class="file-upload__confirm-btn"
+        <Button
+          variant="primary"
+          size="sm"
           type="button"
           onclick={confirmUpload}
         >
           {t(M['chat.file_upload.upload_files'], { count: pendingFiles.length, plural: pendingFiles.length !== 1 ? 's' : '' })}
-        </button>
-        <button
-          class="file-upload__clear-btn"
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
           type="button"
           onclick={() => { pendingFiles = []; sizeError = ''; }}
         >
           Clear
-        </button>
+        </Button>
       </div>
     </div>
   {/if}
@@ -302,22 +307,19 @@ function getFileIcon(type: string): string {
     color: var(--smrt-color-outline, #74777f);
   }
 
-  .file-upload__file-remove {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+  /* :global() pierces into the Button child's rendered <button> (see #1589). */
+  .file-upload__file :global(.file-upload__file-remove) {
     width: 24px;
     height: 24px;
-    border: none;
+    padding: 0;
     background: none;
     color: var(--smrt-color-on-surface-variant, #43474e);
-    cursor: pointer;
     border-radius: var(--smrt-radius-full, 9999px);
     flex-shrink: 0;
     transition: background var(--smrt-duration-short2, 150ms);
   }
 
-  .file-upload__file-remove:hover {
+  .file-upload__file :global(.file-upload__file-remove:hover) {
     background: var(--smrt-color-error-container, #ffdad6);
     color: var(--smrt-color-error, #ba1a1a);
   }
@@ -326,41 +328,6 @@ function getFileIcon(type: string): string {
     display: flex;
     gap: var(--smrt-spacing-2, 8px);
     padding-top: var(--smrt-spacing-1, 4px);
-  }
-
-  .file-upload__confirm-btn {
-    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-4, 16px);
-    border: none;
-    border-radius: var(--smrt-radius-full, 9999px);
-    background: var(--smrt-color-primary, #005ac1);
-    color: var(--smrt-color-on-primary, #ffffff);
-    font: var(--smrt-typography-label-large-font, 500 0.875rem/1.25 sans-serif);
-    cursor: pointer;
-    transition: opacity var(--smrt-duration-short2, 150ms);
-  }
-
-  .file-upload__confirm-btn:hover {
-    opacity: 0.85;
-  }
-
-  .file-upload__confirm-btn:focus-visible {
-    outline: 2px solid var(--smrt-color-primary, #005ac1);
-    outline-offset: 2px;
-  }
-
-  .file-upload__clear-btn {
-    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-4, 16px);
-    border: 1px solid var(--smrt-color-outline, #74777f);
-    border-radius: var(--smrt-radius-full, 9999px);
-    background: transparent;
-    color: var(--smrt-color-on-surface-variant, #43474e);
-    font: var(--smrt-typography-label-large-font, 500 0.875rem/1.25 sans-serif);
-    cursor: pointer;
-    transition: background var(--smrt-duration-short2, 150ms);
-  }
-
-  .file-upload__clear-btn:hover {
-    background: var(--smrt-color-surface-variant, #e1e2ec);
   }
 
   .file-upload__error {
@@ -372,10 +339,11 @@ function getFileIcon(type: string): string {
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .file-upload__drop-zone,
-    .file-upload__file-remove,
-    .file-upload__confirm-btn,
-    .file-upload__clear-btn {
+    .file-upload__drop-zone {
+      transition: none;
+    }
+
+    .file-upload__file :global(.file-upload__file-remove) {
       transition: none;
     }
   }

--- a/packages/chat/src/svelte/components/shared/MentionAutocomplete.svelte
+++ b/packages/chat/src/svelte/components/shared/MentionAutocomplete.svelte
@@ -84,6 +84,7 @@ function highlightMatch(
   >
     {#each suggestions as suggestion, i (suggestion.id)}
       {@const parts = highlightMatch(suggestion.name, query)}
+      <!-- raw-primitive-allow: role=option in a hand-rolled autocomplete listbox with roving active-index keyboard navigation (ArrowUp/Down/Enter/Tab) and onpointerenter active sync, wrapping rich content (avatar, highlighted name); no Button primitive owns this structural listbox-option pattern -->
       <button
         class="mention-autocomplete__item"
         class:mention-autocomplete__item--active={i === activeIndex}

--- a/packages/chat/src/svelte/components/shared/ReactionPicker.svelte
+++ b/packages/chat/src/svelte/components/shared/ReactionPicker.svelte
@@ -4,6 +4,7 @@
  * Compact popup grid of common emojis.
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.js';
 
 const { t } = useI18n();
@@ -51,14 +52,16 @@ function handleKeydown(event: KeyboardEvent, emoji: string) {
 {#if isOpen}
   <div class="reaction-picker" role="group" aria-label={t(M['chat.reaction_picker.reactions'])}>
     {#each emojis as emoji}
-      <button
+      <Button
+        variant="ghost"
+        size="sm"
         class="reaction-picker__item"
         type="button"
         onclick={() => handleSelect(emoji)}
         aria-label={t(M['chat.reaction_picker.react_with'], { emoji })}
       >
         {emoji}
-      </button>
+      </Button>
     {/each}
   </div>
 {/if}
@@ -76,28 +79,19 @@ function handleKeydown(event: KeyboardEvent, emoji: string) {
     width: max-content;
   }
 
-  .reaction-picker__item {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  /* :global() pierces into each Button's rendered <button> (see #1589). */
+  .reaction-picker :global(.reaction-picker__item) {
     width: 32px;
     height: 32px;
-    border: none;
     border-radius: var(--smrt-radius-small, 0.25rem);
     background: transparent;
-    cursor: pointer;
     font-size: var(--smrt-typography-body-large-size, 1.125rem);
     line-height: 1;
     padding: 0;
     transition: background var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
   }
 
-  .reaction-picker__item:hover {
+  .reaction-picker :global(.reaction-picker__item:hover) {
     background: var(--smrt-color-surface-container-high, #e1e3e8);
-  }
-
-  .reaction-picker__item:focus-visible {
-    outline: 2px solid var(--smrt-color-primary, #005ac1);
-    outline-offset: -2px;
   }
 </style>

--- a/packages/chat/src/svelte/components/shared/ReactionPicker.svelte
+++ b/packages/chat/src/svelte/components/shared/ReactionPicker.svelte
@@ -40,13 +40,6 @@ const emojis = [
 function handleSelect(emoji: string) {
   onreact(emoji);
 }
-
-function handleKeydown(event: KeyboardEvent, emoji: string) {
-  if (event.key === 'Enter' || event.key === ' ') {
-    event.preventDefault();
-    handleSelect(emoji);
-  }
-}
 </script>
 
 {#if isOpen}

--- a/packages/chat/src/svelte/components/tabs/ChatTab.svelte
+++ b/packages/chat/src/svelte/components/tabs/ChatTab.svelte
@@ -5,6 +5,7 @@
  * Expands upward from the bottom tab bar.
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.messages.js';
 import type { ChatMessageData, ChatTabState } from '../../types.js';
 import Avatar from '../shared/Avatar.svelte';
@@ -43,6 +44,7 @@ const {
 {#if tab.isExpanded}
   <div class="chat-tab chat-tab--expanded" aria-label={t(M['chat.chat_tab.chat_with'], { name: tab.room.name })}>
     <div class="chat-tab__header">
+      <!-- raw-primitive-allow: pressable header title wrapping rich content (room avatar component and name) that collapses the chat window on click; no Button primitive owns this structural avatar-header pattern -->
       <button
         class="chat-tab__header-btn"
         type="button"
@@ -58,7 +60,9 @@ const {
       </button>
 
       <div class="chat-tab__actions">
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
           class="chat-tab__icon-btn"
           type="button"
           onclick={oncollapse}
@@ -68,8 +72,10 @@ const {
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
             <rect x="3" y="12" width="10" height="2" rx="1" />
           </svg>
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
           class="chat-tab__icon-btn"
           type="button"
           onclick={onclose}
@@ -79,7 +85,7 @@ const {
           <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
             <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z" />
           </svg>
-        </button>
+        </Button>
       </div>
     </div>
 
@@ -93,6 +99,7 @@ const {
     </div>
   </div>
 {:else}
+  <!-- raw-primitive-allow: large pressable collapsed-tab card wrapping rich content (room avatar component, name, unread badge) that expands the chat window on click; no Button primitive owns this structural selection-card pattern -->
   <button
     class="chat-tab chat-tab--collapsed"
     type="button"
@@ -164,27 +171,19 @@ const {
     flex-shrink: 0;
   }
 
-  .chat-tab__icon-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+  /* :global() pierces into each Button's rendered <button> (see #1589). */
+  .chat-tab__actions :global(.chat-tab__icon-btn) {
     width: 28px;
     height: 28px;
-    border: none;
+    padding: 0;
     background: none;
     color: inherit;
-    cursor: pointer;
     border-radius: var(--smrt-radius-full, 9999px);
     transition: background var(--smrt-duration-short2, 150ms);
   }
 
-  .chat-tab__icon-btn:hover {
+  .chat-tab__actions :global(.chat-tab__icon-btn:hover) {
     background: color-mix(in srgb, var(--smrt-color-on-primary) 15%, transparent);
-  }
-
-  .chat-tab__icon-btn:focus-visible {
-    outline: 2px solid var(--smrt-color-on-primary, #ffffff);
-    outline-offset: -2px;
   }
 
   .chat-tab__body {
@@ -232,8 +231,11 @@ const {
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .chat-tab--collapsed,
-    .chat-tab__icon-btn {
+    .chat-tab--collapsed {
+      transition: none;
+    }
+
+    .chat-tab__actions :global(.chat-tab__icon-btn) {
       transition: none;
     }
   }

--- a/packages/chat/src/svelte/components/tabs/ChatTabList.svelte
+++ b/packages/chat/src/svelte/components/tabs/ChatTabList.svelte
@@ -4,6 +4,7 @@
  * Horizontal bar of small avatars/names at bottom. Shows unread badges.
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.messages.js';
 import type { ChatTabState } from '../../types.js';
 import Avatar from '../shared/Avatar.svelte';
@@ -26,6 +27,7 @@ const { tabs, onselect, onclose }: Props = $props();
   <nav class="tab-list" aria-label={t(M['chat.chat_tab_list.minimized_chats'])}>
     {#each tabs as tab (tab.roomId)}
       <div class="tab-list__item">
+        <!-- raw-primitive-allow: pressable circular avatar tab wrapping rich content (room avatar component and overlaid unread badge) that opens the chat on click; no Button primitive owns this structural avatar-tab pattern -->
         <button
           class="tab-list__btn"
           type="button"
@@ -44,7 +46,9 @@ const { tabs, onselect, onclose }: Props = $props();
             </span>
           {/if}
         </button>
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
           class="tab-list__close"
           type="button"
           onclick={(e) => { e.stopPropagation(); onclose(tab.roomId); }}
@@ -54,7 +58,7 @@ const { tabs, onselect, onclose }: Props = $props();
           <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
             <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z" />
           </svg>
-        </button>
+        </Button>
       </div>
     {/each}
   </nav>
@@ -119,25 +123,22 @@ const { tabs, onselect, onclose }: Props = $props();
     border: 2px solid var(--smrt-color-surface, #fefbff);
   }
 
-  .tab-list__close {
+  /* :global() pierces into the Button child's rendered <button> (see #1589). */
+  .tab-list__item :global(.tab-list__close) {
     display: none;
     position: absolute;
     top: -4px;
     right: -4px;
     width: 18px;
     height: 18px;
-    align-items: center;
-    justify-content: center;
-    border: none;
     background: var(--smrt-color-surface-variant, #e1e2ec);
     color: var(--smrt-color-on-surface-variant, #43474e);
     border-radius: var(--smrt-radius-full, 9999px);
-    cursor: pointer;
     padding: 0;
     font-size: 0;
   }
 
-  .tab-list__item:hover .tab-list__close {
+  .tab-list__item:hover :global(.tab-list__close) {
     display: inline-flex;
   }
 
@@ -145,7 +146,7 @@ const { tabs, onselect, onclose }: Props = $props();
     display: none;
   }
 
-  .tab-list__close:hover {
+  .tab-list__item :global(.tab-list__close:hover) {
     background: var(--smrt-color-error-container, #ffdad6);
     color: var(--smrt-color-on-error-container, #410002);
   }

--- a/packages/chat/src/svelte/components/tabs/ChatTabList.svelte
+++ b/packages/chat/src/svelte/components/tabs/ChatTabList.svelte
@@ -138,11 +138,13 @@ const { tabs, onselect, onclose }: Props = $props();
     font-size: 0;
   }
 
-  .tab-list__item:hover :global(.tab-list__close) {
+  .tab-list__item:hover :global(.tab-list__close),
+  .tab-list__item:focus-within :global(.tab-list__close) {
     display: inline-flex;
   }
 
-  .tab-list__item:hover .tab-list__badge {
+  .tab-list__item:hover .tab-list__badge,
+  .tab-list__item:focus-within .tab-list__badge {
     display: none;
   }
 

--- a/packages/chat/src/svelte/components/tabs/MiniChat.svelte
+++ b/packages/chat/src/svelte/components/tabs/MiniChat.svelte
@@ -5,6 +5,7 @@
  * No thread panel, no reactions. Just messages and a send box.
  */
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.messages.js';
 import type { ChatMessageData } from '../../types.js';
 import Avatar from '../shared/Avatar.svelte';
@@ -94,7 +95,8 @@ $effect(() => {
       onkeydown={handleKeydown}
       aria-label={t(M['chat.mini_chat.input_label'])}
     />
-    <button
+    <Button
+      variant="ghost"
       class="mini-chat__send-btn"
       type="submit"
       disabled={!inputValue.trim()}
@@ -103,7 +105,7 @@ $effect(() => {
       <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
         <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
       </svg>
-    </button>
+    </Button>
   </form>
 </div>
 
@@ -212,33 +214,25 @@ $effect(() => {
     color: var(--smrt-color-outline, #74777f);
   }
 
-  .mini-chat__send-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+  /* :global() pierces into the Button child's rendered <button> (see #1589). */
+  .mini-chat__input-bar :global(.mini-chat__send-btn) {
     width: 32px;
     height: 32px;
-    border: none;
+    padding: 0;
     background: var(--smrt-color-primary, #005ac1);
     color: var(--smrt-color-on-primary, #ffffff);
     border-radius: var(--smrt-radius-full, 9999px);
-    cursor: pointer;
     flex-shrink: 0;
     transition: opacity var(--smrt-duration-short2, 150ms);
   }
 
-  .mini-chat__send-btn:disabled {
+  .mini-chat__input-bar :global(.mini-chat__send-btn:disabled) {
     opacity: 0.4;
-    cursor: not-allowed;
   }
 
-  .mini-chat__send-btn:not(:disabled):hover {
+  .mini-chat__input-bar :global(.mini-chat__send-btn:not(:disabled):hover) {
+    background: var(--smrt-color-primary, #005ac1);
     opacity: 0.85;
-  }
-
-  .mini-chat__send-btn:focus-visible {
-    outline: 2px solid var(--smrt-color-primary, #005ac1);
-    outline-offset: 2px;
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -246,7 +240,7 @@ $effect(() => {
       scroll-behavior: auto;
     }
 
-    .mini-chat__send-btn {
+    .mini-chat__input-bar :global(.mini-chat__send-btn) {
       transition: none;
     }
   }


### PR DESCRIPTION
## Summary

Buttons-only migration of `@happyvertical/smrt-chat` for #1589. Migrates raw
`<button>` markup to the shared `@happyvertical/smrt-ui` `Button` primitive and
flips the package to `"smrtRawPrimitives": "strict-buttons"`. Forms
(`<input>`/`<select>`/`<textarea>`/`<form>`) are deferred per strict-buttons mode
and left untouched.

**31 of 47** raw buttons migrated to `<Button>`. The remaining **16** are
genuinely structural and kept raw behind `raw-primitive-allow` escape hatches.

## Per-file

| File | Migrated | Escape-hatched (reason) |
|------|----------|--------------------------|
| agent/AgentChat | 4 (send, Diff, Apply, dialog close → ghost) | — |
| agent/AgentSelector | — | 1 (role=option selection card) |
| agent/AgentSessionPanel | 1 (new-session → ghost) | 1 (role=option selection card) |
| agent/ToolCallDisplay | — | 1 (aria-expanded disclosure header) |
| dialogs/RoomCreateDialog | 2 (Cancel→secondary, Create→primary) | 1 (off-screen Enter-to-submit helper) |
| dialogs/SearchMessages | 2 (close, clear → ghost) | 1 (search-result card) |
| layout/ChatLayout | — | 1 (drag-to-resize splitter) |
| layout/MemberList | 1 (close → ghost) | — |
| layout/RoomHeader | 2 (members, search → ghost) | — |
| layout/RoomList | 2 (new-room→ghost full-width, create-link→ghost) | 6 (3 disclosure headers + 3 room-selection rows) |
| messages/MessageInput | 2 (reply-close, send → ghost) | — |
| messages/MessageItem | 6 (reaction, more, 4 action btns → ghost) | — |
| messages/ThreadPanel | 1 (close → ghost) | — |
| shared/FileUpload | 3 (remove→ghost, upload→primary, clear→secondary) | — |
| shared/MentionAutocomplete | — | 1 (role=option roving-tabindex listbox) |
| shared/ReactionPicker | 1 (emoji cell → ghost) | — |
| tabs/ChatTab | 2 (minimize, close → ghost) | 2 (avatar header + collapsed card) |
| tabs/ChatTabList | 1 (close → ghost) | 1 (avatar tab card) |
| tabs/MiniChat | 1 (send → ghost) | — |

No `use:` directives were present on any migrated button (none dropped).

## Approach

- Standard action buttons map to `primary`/`secondary`/`danger`/`ghost` variants.
- Custom icon/toolbar buttons use `<Button variant="ghost" class="...">` with the
  `.ancestor :global(.x)` scoping pattern; dead local button CSS removed.
- No new dependency (`smrt-ui` already a dependency); no DAG or peer changes.

## Gates

- `check-raw-primitives.mjs` → exit 0 (chat clean under buttons-only)
- `typecheck` (tsc + svelte-check a11y) → 0 errors, 0 warnings
- `test` → 185 passed (21 files)
- `check-package-dag.mjs` + `check-no-smrt-peers.mjs` → exit 0
- `biome check` (read-only) → 0 errors

Scope verified: only `packages/chat/**`; no form-markup changes; no lockfile
change; no stripped `console.*`.
