### PR TITLE
refactor(users): migrate raw form elements to smrt-ui form primitives, flip strict (#1589)

### DIFF
--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -3,7 +3,7 @@
   "version": "0.34.5",
   "description": "Multi-tenant user management for the SMRT framework - users, tenants, roles, permissions, groups",
   "type": "module",
-  "smrtRawPrimitives": "strict-buttons",
+  "smrtRawPrimitives": "strict",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/users/src/svelte/components/InviteUserModal.svelte
+++ b/packages/users/src/svelte/components/InviteUserModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { RoleSelector } from '@happyvertical/smrt-ui';
 import { Modal } from '@happyvertical/smrt-ui/feedback';
+import { Form, Input } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type { Role, Tenant } from '@happyvertical/smrt-users';
@@ -45,8 +46,7 @@ $effect(() => {
   }
 });
 
-function handleSubmit(e: Event) {
-  e.preventDefault();
+function handleSubmit() {
   error = '';
 
   if (!email) {
@@ -85,45 +85,48 @@ function handleClose() {
   closeOnBackdrop={!loading}
   closeOnEscape={!loading}
 >
-  <form id={formId} onsubmit={handleSubmit}>
-    {#if error}
-      <div class="error">{error}</div>
-    {/if}
+  <div class="invite-form-shell">
+    <Form id={formId} class="invite-form" onsubmit={handleSubmit}>
+      {#if error}
+        <div class="error">{error}</div>
+      {/if}
 
-    <div class="field">
-      <label for="invite-email">{t(M['users.invite_user_modal.email_address'])}</label>
-      <input
-        id="invite-email"
-        type="email"
-        bind:value={email}
-        placeholder={t(M['users.invite_user_modal.email_placeholder'])}
-        disabled={loading}
-        required
-      />
-    </div>
-
-    <div class="field">
-      <label for="invite-role">Role</label>
-      <RoleSelector
-        {roles}
-        value={roleId}
-        onchange={(id: string) => (roleId = id)}
-        disabled={loading}
-        showDescription
-      />
-    </div>
-
-    <div class="checkbox-field">
-      <input id="send-email" type="checkbox" bind:checked={sendEmail} disabled={loading} />
-      <label for="send-email">{t(M['users.invite_user_modal.send_invitation_email'])}</label>
-    </div>
-
-    {#if !sendEmail}
-      <div class="hint">
-        {t(M['users.invite_user_modal.pending_hint'])}
+      <div class="field">
+        <label for="invite-email">{t(M['users.invite_user_modal.email_address'])}</label>
+        <Input
+          id="invite-email"
+          type="email"
+          bind:value={email}
+          placeholder={t(M['users.invite_user_modal.email_placeholder'])}
+          disabled={loading}
+          required
+        />
       </div>
-    {/if}
-  </form>
+
+      <div class="field">
+        <label for="invite-role">Role</label>
+        <RoleSelector
+          {roles}
+          value={roleId}
+          onchange={(id: string) => (roleId = id)}
+          disabled={loading}
+          showDescription
+        />
+      </div>
+
+      <div class="checkbox-field">
+        <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+        <input id="send-email" type="checkbox" bind:checked={sendEmail} disabled={loading} />
+        <label for="send-email">{t(M['users.invite_user_modal.send_invitation_email'])}</label>
+      </div>
+
+      {#if !sendEmail}
+        <div class="hint">
+          {t(M['users.invite_user_modal.pending_hint'])}
+        </div>
+      {/if}
+    </Form>
+  </div>
 
   {#snippet footer()}
     <Button variant="secondary" type="button" onclick={handleClose} disabled={loading}>
@@ -143,7 +146,7 @@ function handleClose() {
   /* The dialog chrome (backdrop, surface, header, footer bar, close button) is
      supplied by the smrt-ui Modal. Only the form-content + footer-button styles
      live here. */
-  form {
+  .invite-form-shell :global(.invite-form) {
     display: flex;
     flex-direction: column;
     gap: var(--smrt-spacing-md, 1rem);
@@ -169,25 +172,6 @@ function handleClose() {
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
-  input[type='email'] {
-    padding: var(--smrt-spacing-sm, 0.5rem) var(--smrt-spacing-md, 0.75rem);
-    border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
-    border-radius: var(--smrt-radius-medium, 0.5rem);
-    font: var(--smrt-typography-body-medium-font, 0.875rem / 1.25 sans-serif);
-    transition: border-color var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
-  }
-
-  input[type='email']:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #005ac1);
-    box-shadow: 0 0 0 3px var(--smrt-color-primary-container, rgba(0, 90, 193, 0.1));
-  }
-
-  input[type='email']:disabled {
-    background: var(--smrt-color-surface-container, #f3f4f6);
-    cursor: not-allowed;
-  }
-
   .checkbox-field {
     display: flex;
     align-items: center;
@@ -210,11 +194,5 @@ function handleClose() {
     padding: var(--smrt-spacing-sm, 0.5rem);
     background: var(--smrt-color-surface-container-low, #f9fafb);
     border-radius: var(--smrt-radius-small, 0.25rem);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    input[type='email'] {
-      transition: none;
-    }
   }
 </style>

--- a/packages/users/src/svelte/components/UserForm.svelte
+++ b/packages/users/src/svelte/components/UserForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { Profile } from '@happyvertical/smrt-profiles';
 import { UserStatus } from '@happyvertical/smrt-types';
+import { Form, Input, Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type { User } from '@happyvertical/smrt-users';
@@ -61,53 +62,54 @@ $effect(() => {
   status = user?.status ?? UserStatus.ACTIVE;
 });
 
-function handleSubmit(e: Event) {
-  e.preventDefault();
+function handleSubmit() {
   onsubmit({ name, email, status });
 }
 </script>
 
-<form class="user-form" onsubmit={handleSubmit}>
-  <div class="field">
-    <label for="name">Name</label>
-    <input id="name" type="text" bind:value={name} required disabled={loading} />
-  </div>
+<div class="user-form-shell">
+  <Form class="user-form" onsubmit={handleSubmit}>
+    <div class="field">
+      <label for="name">Name</label>
+      <Input id="name" type="text" bind:value={name} required disabled={loading} />
+    </div>
 
-  <div class="field">
-    <label for="email">Email</label>
-    <input id="email" type="email" bind:value={email} required disabled={loading || !!user} />
-    {#if user}
-      <span class="hint">{t(M['users.user_form.email_cannot_be_changed'])}</span>
-    {/if}
-  </div>
-
-  <div class="field">
-    <label for="status">Status</label>
-    <select id="status" bind:value={status} disabled={loading}>
-      {#each statusOptions as option (option.value)}
-        <option value={option.value}>{option.label}</option>
-      {/each}
-    </select>
-  </div>
-
-  <div class="actions">
-    {#if oncancel}
-      <Button variant="secondary" type="button" onclick={oncancel} disabled={loading}>
-        Cancel
-      </Button>
-    {/if}
-    <Button variant="primary" type="submit" disabled={loading}>
-      {#if loading}
-        Saving...
-      {:else}
-        {user ? 'Update User' : 'Create User'}
+    <div class="field">
+      <label for="email">Email</label>
+      <Input id="email" type="email" bind:value={email} required disabled={loading || !!user} />
+      {#if user}
+        <span class="hint">{t(M['users.user_form.email_cannot_be_changed'])}</span>
       {/if}
-    </Button>
-  </div>
-</form>
+    </div>
+
+    <div class="field">
+      <label for="status">Status</label>
+      <Select id="status" bind:value={status} disabled={loading}>
+        {#each statusOptions as option (option.value)}
+          <option value={option.value}>{option.label}</option>
+        {/each}
+      </Select>
+    </div>
+
+    <div class="actions">
+      {#if oncancel}
+        <Button variant="secondary" type="button" onclick={oncancel} disabled={loading}>
+          Cancel
+        </Button>
+      {/if}
+      <Button variant="primary" type="submit" disabled={loading}>
+        {#if loading}
+          Saving...
+        {:else}
+          {user ? 'Update User' : 'Create User'}
+        {/if}
+      </Button>
+    </div>
+  </Form>
+</div>
 
 <style>
-  .user-form {
+  .user-form-shell :global(.user-form) {
     display: flex;
     flex-direction: column;
     gap: var(--smrt-spacing-md, 1rem);
@@ -124,28 +126,6 @@ function handleSubmit(e: Event) {
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
-  input,
-  select {
-    padding: var(--smrt-spacing-sm, 0.5rem) var(--smrt-spacing-md, 0.75rem);
-    border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
-    border-radius: var(--smrt-radius-medium, 0.5rem);
-    font: var(--smrt-typography-body-medium-font, 0.875rem / 1.25 sans-serif);
-    transition: border-color var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
-  }
-
-  input:focus,
-  select:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #005ac1);
-    box-shadow: 0 0 0 3px var(--smrt-color-primary-container, rgba(0, 90, 193, 0.1));
-  }
-
-  input:disabled,
-  select:disabled {
-    background: var(--smrt-color-surface-container, #f3f4f6);
-    cursor: not-allowed;
-  }
-
   .hint {
     font: var(--smrt-typography-body-small-font, 0.75rem / 1.25 sans-serif);
     color: var(--smrt-color-on-surface-variant, #43474e);
@@ -156,12 +136,5 @@ function handleSubmit(e: Event) {
     justify-content: flex-end;
     gap: var(--smrt-spacing-sm, 0.5rem);
     margin-top: var(--smrt-spacing-sm, 0.5rem);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    input,
-    select {
-      transition: none;
-    }
   }
 </style>

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -416,6 +416,13 @@ export function getWorkspaceViteAliases(
         '@happyvertical/smrt-ui/feedback',
         join(packageRoot, 'src/components/feedback/index.ts'),
       );
+      // Provider-free base form primitives relocated here from smrt-svelte for
+      // the #1589 deferred-forms phase. Domain packages adopt them from source.
+      addAliasIfPresent(
+        aliases,
+        '@happyvertical/smrt-ui/forms',
+        join(packageRoot, 'src/components/forms/index.ts'),
+      );
       addAliasIfPresent(
         aliases,
         '@happyvertical/smrt-ui/layout',


### PR DESCRIPTION
## Summary

Migrates the raw form markup in **smrt-users** to the Provider-free base form primitives relocated to `@happyvertical/smrt-ui/forms` (issue #1589 deferred-forms phase), and flips the package ratchet `strict-buttons` -> `strict`.

### Changes
- **`UserForm.svelte`**: `<form>` -> `<Form>`, both `<input>` -> `<Input>`, `<select>` -> `<Select>` (keeping `id`/`name`/`type`/`required`/`disabled`/`bind:value` and the existing `<option>` children). Wrapped the form in `.user-form-shell` and moved the flex layout to `.user-form-shell :global(.user-form)` (the scoped `.user-form` rule no longer matches the element rendered inside the smrt-ui component). Removed now-dead `input/select` + `:focus`/`:disabled`/reduced-motion selectors — the primitives carry their own tokenized styling. `handleSubmit` drops `e.preventDefault()` since `Form` prevents default by default.
- **`InviteUserModal.svelte`**: email `<input>` -> `<Input>`, `<form id={formId}>` -> `<Form id={formId}>` (so the footer `<Button form={formId}>` still submits it), same `.invite-form-shell` + `:global(.invite-form)` wrap for the form's flex layout. Removed dead `input[type='email']` selectors. Kept the native send-email checkbox (see escape hatch below) and its `.checkbox-field input` styling.
- **`packages/users/package.json`**: `smrtRawPrimitives` `strict-buttons` -> `strict`.
- **`packages/vitest/src/index.ts`**: registered the missing `@happyvertical/smrt-ui/forms` source alias. PR 1 added the package `./forms` export + dist build but omitted this vitest alias, so any package adopting the relocated primitives failed to resolve the import under vitest (`Failed to resolve import "@happyvertical/smrt-ui/forms"`). This is a one-line addition mirroring the sibling `/feedback`, `/layout` subpath aliases and unblocks every forms consumer's test suite, not just users.

### Native-checkbox escape hatch
`InviteUserModal`'s `<input type="checkbox" id="send-email">` is kept native behind a `raw-primitive-allow` comment. Reason: there is no Provider-free checkbox primitive — `Toggle` is a switch with different semantics, and `CheckboxInput` requires a Provider this component does not mount.

### Gate results (all green)
- `check-raw-primitives.mjs` -> exit 0, `users` on the full strict line.
- `pnpm --filter @happyvertical/smrt-users typecheck` -> 0 errors / 0 warnings (no unused-CSS-selector flags).
- `pnpm --filter @happyvertical/smrt-users test` -> 239 passed, 4 skipped.
- `check-hardcoded-strings.mjs` -> no hardcoded UI strings.
- `check-package-dag.mjs` / `check-no-smrt-peers.mjs` -> pass.
- `biome check` (read-only) -> clean.
- `pnpm knowledge:check` -> fresh (0 errors, 0 warnings).
- `pnpm build` -> all 51 tasks succeed.

Refs #1589 #1354
