### PR TITLE
refactor(smrt-svelte): migrate raw form elements to smrt-ui form primitives, flip strict (#1589)

### DIFF
--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -3,7 +3,7 @@
   "version": "0.34.5",
   "description": "Svelte 5 components for SMRT user management - auth, users, tenants, roles, permissions, groups",
   "type": "module",
-  "smrtRawPrimitives": "strict-buttons",
+  "smrtRawPrimitives": "strict",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "svelte": "./dist/index.js",

--- a/packages/smrt-svelte/src/browser-ai/svelte/components/STTTest.svelte
+++ b/packages/smrt-svelte/src/browser-ai/svelte/components/STTTest.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { useAppState } from '../../../hooks/useAppState.svelte.js';
@@ -111,11 +112,20 @@ function clearLogs() {
   <div class="controls">
     <div class="adapter-select">
       <label for="adapter">Adapter:</label>
-      <select id="adapter" bind:value={selectedAdapter} disabled={isRecording}>
+      <Select
+        id="adapter"
+        bind:value={
+          () => selectedAdapter,
+          (v) => {
+            selectedAdapter = v as AdapterType;
+          }
+        }
+        disabled={isRecording}
+      >
         <option value="browser-speech">{t(M['ui.stt_test.adapter_browser'])}</option>
         <option value="whisper-wasm">{t(M['ui.stt_test.adapter_whisper_wasm'])}</option>
         <option value="whisper-cpp">{t(M['ui.stt_test.adapter_whisper_cpp'])}</option>
-      </select>
+      </Select>
     </div>
 
     <Button
@@ -222,13 +232,6 @@ function clearLogs() {
 
   .adapter-select label {
     font: var(--smrt-typography-body-medium-font, 500 0.875rem / 1.25 sans-serif);
-  }
-
-  .adapter-select select {
-    padding: var(--smrt-spacing-sm, 8px);
-    border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
-    border-radius: var(--smrt-radius-small, 6px);
-    font: var(--smrt-typography-body-medium-font, 0.875rem / 1.25 sans-serif);
   }
 
   .status {


### PR DESCRIPTION
## Summary

Deferred form-primitive phase of #1589 for **smrt-svelte**. Replaces the only
raw form element in the package (outside the exempt `src/components/forms/`
primitive dir) with the Provider-free `Select` from `@happyvertical/smrt-ui/forms`
(relocated there in PR #1625), then flips the package's `smrtRawPrimitives`
ratchet from `strict-buttons` to `strict`.

### Changes

- **`src/browser-ai/svelte/components/STTTest.svelte`** — the STT adapter picker
  `<select id="adapter" bind:value={selectedAdapter} disabled>` becomes
  `<Select>`, with its three `<option>`s passed through as Select children.
  `selectedAdapter` is a string-literal union (`AdapterType`), so the bind uses a
  Svelte 5 function binding (`bind:value={() => selectedAdapter, (v) => ...}`) to
  narrow the primitive's `string` value back to `AdapterType` on write. The dead
  scoped `.adapter-select select { }` rule is deleted (the primitive ships its own
  tokenized styling); the `<label for="adapter">` association and `.adapter-select`
  layout are unchanged.
- **`package.json`** — `"smrtRawPrimitives": "strict-buttons"` → `"strict"`.

### Escape hatches

None added. The pre-existing escape-hatched press-and-hold record `<button>` in
STTTest (push-to-talk, driven by mousedown/up/leave + touchstart/end) is left
exactly as-is — it is not a raw form element and `Button` has no press-and-hold model.

### Gate results

| Gate | Result |
|------|--------|
| `check-raw-primitives.mjs` | PASS (exit 0; `smrt-svelte` on the strict line) |
| `smrt-svelte typecheck` | PASS (0 errors, 0 warnings; no unused-CSS warning) |
| `smrt-svelte test` | PASS (433 tests, 39 files) |
| `check-hardcoded-strings.mjs` | PASS (exit 0) |
| `check-package-dag.mjs` | PASS (50 smrt packages form a DAG) |
| `check-no-smrt-peers.mjs` | PASS (exit 0) |
| `biome check` (read-only, changed files) | PASS (exit 0) |
| `knowledge:check` | PASS (fresh, 0 errors/warnings) |
| `pnpm build` | PASS |

Refs #1589 #1354
