### PR TITLE
fix(vitest): alias @happyvertical/smrt-ui/forms to source for workspace tests (#1589)

### DIFF
--- a/packages/vitest/src/__tests__/workspace-aliases.test.ts
+++ b/packages/vitest/src/__tests__/workspace-aliases.test.ts
@@ -42,6 +42,22 @@ describe('getWorkspaceViteAliases', () => {
     );
   });
 
+  it('aliases the smrt-ui leaf subpaths to source, including forms (#1589)', () => {
+    // smrt-ui's nested component subpaths are special-cased (they map to dirs,
+    // not the generic `${pkg}/ui` → `src/ui.ts` convention). /forms is the
+    // relocated Provider-free form primitives — without it, consumer tests that
+    // render a migrated form component fail to resolve the import.
+    expect(byFind.get('@happyvertical/smrt-ui/forms')).toMatch(
+      /src\/components\/forms\/index\.ts$/,
+    );
+    expect(byFind.get('@happyvertical/smrt-ui/ui')).toMatch(
+      /src\/components\/ui\/index\.ts$/,
+    );
+    expect(byFind.get('@happyvertical/smrt-ui/chat')).toMatch(
+      /src\/components\/chat\/index\.ts$/,
+    );
+  });
+
   it('sorts entries most-specific first so subpaths win over the bare-package root', () => {
     const lengths = aliases.map((entry) => entry.find.length);
     expect(lengths).toEqual([...lengths].sort((a, b) => b - a));

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -402,7 +402,7 @@ export function getWorkspaceViteAliases(
     }
 
     if (packageName === '@happyvertical/smrt-ui') {
-      // smrt-ui holds the domain-agnostic UI leaf (primitives, feedback,
+      // smrt-ui holds the domain-agnostic UI leaf (primitives, forms, feedback,
       // layout, calendar, chat, registry, theme system, i18n client). These
       // subpaths map to nested source dirs, so the generic `${packageName}/ui`
       // → `src/ui.ts` convention misses them; alias the exact source files.
@@ -430,6 +430,11 @@ export function getWorkspaceViteAliases(
         aliases,
         '@happyvertical/smrt-ui/chat',
         join(packageRoot, 'src/components/chat/index.ts'),
+      );
+      addAliasIfPresent(
+        aliases,
+        '@happyvertical/smrt-ui/forms',
+        join(packageRoot, 'src/components/forms/index.ts'),
       );
       addAliasIfPresent(
         aliases,


### PR DESCRIPTION
## What & why

Foundational fix for the #1589 deferred-forms phase, split out of the package migrations.

PR #1625 added the `@happyvertical/smrt-ui/forms` **package export** but did not register the matching **source alias** in the smrt-vitest plugin's smrt-ui subpath map (`getWorkspaceViteAliases`, `packages/vitest/src/index.ts`). That map aliases every other smrt-ui subpath (`/ui`, `/chat`, `/feedback`, `/layout`, …) to `src` so workspace consumers test against source. With `/forms` missing, any consumer **test** that renders a component importing `@happyvertical/smrt-ui/forms` fails with `Failed to resolve import "@happyvertical/smrt-ui/forms"`. `typecheck` passes (it uses the dist `.d.ts`), which masks the gap — so it only surfaces in packages whose test suites render a migrated component (e.g. smrt-users).

## Change

One `addAliasIfPresent` for `@happyvertical/smrt-ui/forms` → `src/components/forms/index.ts`, mirroring the sibling subpaths, plus the subpath in the explanatory comment.

## Verification
- Throwaway consumer test importing all six base primitives (`Form`/`FormGroup`/`Input`/`Select`/`Textarea`/`Toggle`) from the subpath resolves and passes.
- `pnpm --filter @happyvertical/smrt-vitest test` → 41 green; `typecheck` clean; `biome check` clean.
- `check-package-dag` / `check-no-smrt-peers` / `knowledge:check` all pass.

Unblocks the per-package forms migrations (#1589). Must land before they fan out so they don't each edit this shared file and conflict.

Refs #1589 #1354
