### PR TITLE
fix(ui): honor prefers-reduced-motion in base form primitives (#1589)

### DIFF
--- a/packages/smrt-ui/src/components/forms/Input.svelte
+++ b/packages/smrt-ui/src/components/forms/Input.svelte
@@ -80,4 +80,10 @@ const resolvedInvalid = $derived(
 	.input::placeholder {
 		color: var(--smrt-color-on-surface-variant, #9ca3af);
 	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.input {
+			transition: none;
+		}
+	}
 </style>

--- a/packages/smrt-ui/src/components/forms/Select.svelte
+++ b/packages/smrt-ui/src/components/forms/Select.svelte
@@ -80,4 +80,10 @@ const resolvedInvalid = $derived(
 		cursor: not-allowed;
 		opacity: 0.7;
 	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.select {
+			transition: none;
+		}
+	}
 </style>

--- a/packages/smrt-ui/src/components/forms/Textarea.svelte
+++ b/packages/smrt-ui/src/components/forms/Textarea.svelte
@@ -82,4 +82,10 @@ const resolvedInvalid = $derived(
 	.textarea::placeholder {
 		color: var(--smrt-color-on-surface-variant, #9ca3af);
 	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.textarea {
+			transition: none;
+		}
+	}
 </style>

--- a/packages/smrt-ui/src/components/forms/Toggle.svelte
+++ b/packages/smrt-ui/src/components/forms/Toggle.svelte
@@ -214,4 +214,11 @@ const sizeClasses = {
   .toggle--lg .toggle__label {
     font-size: var(--smrt-typography-body-large-size, 1rem);
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    .toggle__thumb,
+    .toggle__thumb::after {
+      transition: none;
+    }
+  }
 </style>


### PR DESCRIPTION
## What & why

Hardening for the #1589 deferred-forms phase, surfaced by the pilot review (Copilot on #1627).

The relocated base form primitives (`Input`/`Select`/`Textarea`/`Toggle`) animate focus/disabled state — and, for `Toggle`, the thumb `translateX` — via CSS transitions, but lacked a `prefers-reduced-motion` guard. Every **other** smrt-ui primitive honors it (Button, Skeleton, Modal, ProgressBar, LoadingOverlay, ConfirmDialog, Tree, TypingIndicator, ReactionPicker), so this was an inconsistency carried over when the primitives moved out of smrt-svelte in #1625.

## Change

Add `@media (prefers-reduced-motion: reduce) { transition: none }` to each of the four primitives (Toggle covers both `.toggle__thumb` and its `::after`).

## Why it matters for the migration

Domain components currently carry local `@media (prefers-reduced-motion)` overrides on their raw `<input>`/`<select>`. When they adopt these primitives, those local overrides become dead selectors (they can't target the primitive's internal element from component scope) and are removed. With this PR the **primitive** owns reduced-motion, so the migration is non-regressive.

## Verification
- `pnpm --filter @happyvertical/smrt-ui typecheck` → 0 errors; `test` → 446 green; `biome check` clean.
- `check-package-dag` / `check-no-smrt-peers` / `knowledge:check` pass.

Refs #1589 #1354
