### PR TITLE
refactor(forms): migrate all domain packages to smrt-ui form primitives, flip strict (#1589)

### DIFF
--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -2,7 +2,7 @@
   "name": "@happyvertical/smrt-agents",
   "version": "0.34.5",
   "type": "module",
-  "smrtRawPrimitives": "strict-buttons",
+  "smrtRawPrimitives": "strict",
   "description": "Agent framework for building autonomous actors in the SMRT ecosystem",
   "author": "HappyVertical",
   "license": "MIT",

--- a/packages/agents/src/svelte/components/AgentScheduleForm.svelte
+++ b/packages/agents/src/svelte/components/AgentScheduleForm.svelte
@@ -102,8 +102,8 @@ const timezones = [
 // Validation
 const isValid = $derived(agentType.trim() !== '' && cron.trim() !== '');
 
-function handleSubmit(event: Event) {
-  event.preventDefault();
+function handleSubmit() {
+  // The Form primitive calls event.preventDefault() before invoking onsubmit.
   if (!isValid || loading) return;
 
   const data: ScheduleFormData = {

--- a/packages/agents/src/svelte/components/AgentScheduleForm.svelte
+++ b/packages/agents/src/svelte/components/AgentScheduleForm.svelte
@@ -3,6 +3,7 @@
  * AgentScheduleForm - Create or edit an agent schedule
  */
 
+import { Form, Input, Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button, Card } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
@@ -132,20 +133,21 @@ function handleCronPreset(preset: string) {
     <h2>{editMode ? 'Edit Schedule' : 'Create Schedule'}</h2>
   {/snippet}
 
-  <form class="schedule-form" onsubmit={handleSubmit}>
+  <div class="schedule-form-shell">
+  <Form class="schedule-form" onsubmit={handleSubmit}>
     <div class="form-grid">
       <!-- Agent Type -->
       <div class="form-field">
         <label for="agentType">{t(M['agents.schedule_form.agent_type'])}</label>
         {#if agentTypes.length > 0}
-          <select id="agentType" bind:value={agentType} required disabled={loading}>
+          <Select id="agentType" bind:value={agentType} required disabled={loading}>
             <option value="">{t(M['agents.schedule_form.select_agent_type'])}</option>
             {#each agentTypes as type}
               <option value={type}>{type}</option>
             {/each}
-          </select>
+          </Select>
         {:else}
-          <input
+          <Input
             type="text"
             id="agentType"
             bind:value={agentType}
@@ -159,7 +161,7 @@ function handleCronPreset(preset: string) {
       <!-- Agent ID (optional) -->
       <div class="form-field">
         <label for="agentId">{t(M['agents.schedule_form.agent_id'])}</label>
-        <input
+        <Input
           type="text"
           id="agentId"
           bind:value={agentId}
@@ -172,7 +174,7 @@ function handleCronPreset(preset: string) {
       <!-- Method -->
       <div class="form-field">
         <label for="method">Method</label>
-        <input
+        <Input
           type="text"
           id="method"
           bind:value={method}
@@ -185,7 +187,7 @@ function handleCronPreset(preset: string) {
       <!-- Cron Expression -->
       <div class="form-field form-field--full">
         <label for="cron">{t(M['agents.schedule_form.cron_schedule'])}</label>
-        <input
+        <Input
           type="text"
           id="cron"
           bind:value={cron}
@@ -211,17 +213,17 @@ function handleCronPreset(preset: string) {
       <!-- Timezone -->
       <div class="form-field">
         <label for="timezone">Timezone</label>
-        <select id="timezone" bind:value={timezone} disabled={loading}>
+        <Select id="timezone" bind:value={timezone} disabled={loading}>
           {#each timezones as tz}
             <option value={tz}>{tz}</option>
           {/each}
-        </select>
+        </Select>
       </div>
 
       <!-- Max Concurrent -->
       <div class="form-field">
         <label for="maxConcurrent">{t(M['agents.schedule_form.max_concurrent'])}</label>
-        <input
+        <Input
           type="number"
           id="maxConcurrent"
           bind:value={maxConcurrent}
@@ -235,7 +237,7 @@ function handleCronPreset(preset: string) {
       <!-- Timeout -->
       <div class="form-field">
         <label for="timeout">Timeout (ms)</label>
-        <input
+        <Input
           type="number"
           id="timeout"
           bind:value={timeout}
@@ -249,6 +251,7 @@ function handleCronPreset(preset: string) {
       <!-- Enabled -->
       <div class="form-field form-field--checkbox">
         <label>
+          <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
           <input type="checkbox" bind:checked={enabled} disabled={loading} />
           {t(M['agents.schedule_form.enable_schedule_immediately'])}
         </label>
@@ -265,11 +268,12 @@ function handleCronPreset(preset: string) {
         {loading ? 'Saving...' : editMode ? 'Update Schedule' : 'Create Schedule'}
       </Button>
     </div>
-  </form>
+  </Form>
+  </div>
 </Card>
 
 <style>
-  .schedule-form {
+  .schedule-form-shell :global(.schedule-form) {
     padding: var(--smrt-spacing-sm, 0.5rem) 0;
   }
 
@@ -308,28 +312,6 @@ function handleCronPreset(preset: string) {
     color: var(--smrt-color-on-surface, #1a1c1e);
   }
 
-  .form-field input,
-  .form-field select {
-    padding: var(--smrt-spacing-sm, 0.5rem);
-    border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
-    border-radius: var(--smrt-radius-medium, 0.5rem);
-    font: var(--smrt-typography-body-medium-font, 0.875rem / 1.25 sans-serif);
-    transition: border-color var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
-  }
-
-  .form-field input:focus,
-  .form-field select:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #005ac1);
-    box-shadow: 0 0 0 3px var(--smrt-color-primary-container, rgba(0, 90, 193, 0.1));
-  }
-
-  .form-field input:disabled,
-  .form-field select:disabled {
-    background: var(--smrt-color-surface-container, #f3f4f6);
-    cursor: not-allowed;
-  }
-
   .form-field small {
     font: var(--smrt-typography-body-small-font, 0.75rem / 1.25 sans-serif);
     color: var(--smrt-color-on-surface-variant, #43474e);
@@ -349,12 +331,5 @@ function handleCronPreset(preset: string) {
     margin-top: var(--smrt-spacing-lg, 1.5rem);
     padding-top: var(--smrt-spacing-md, 1rem);
     border-top: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .form-field input,
-    .form-field select {
-      transition: none;
-    }
   }
 </style>

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -3,7 +3,7 @@
   "version": "0.34.5",
   "description": "Asset management system with versioning, metadata, and AI-powered operations for SMRT framework",
   "type": "module",
-  "smrtRawPrimitives": "strict-buttons",
+  "smrtRawPrimitives": "strict",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/assets/src/svelte/AssetDetail.svelte
+++ b/packages/assets/src/svelte/AssetDetail.svelte
@@ -7,6 +7,7 @@
  */
 
 import { Modal } from '@happyvertical/smrt-ui/feedback';
+import { Input, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type { Snippet } from 'svelte';
@@ -202,7 +203,7 @@ function formatDate(date: Date | string | undefined): string {
           <div class="detail__form">
             <div class="form-field">
               <label for="detail-name" class="form-label">Name</label>
-              <input id="detail-name" type="text" class="form-input" bind:value={editName} />
+              <Input id="detail-name" type="text" bind:value={editName} />
             </div>
 
             {#if isImage}
@@ -213,13 +214,13 @@ function formatDate(date: Date | string | undefined): string {
                     <span class="label-warning">{t(M['assets.asset_detail.alt_text_missing_warning'])}</span>
                   {/if}
                 </label>
-                <input id="detail-alt" type="text" class="form-input" bind:value={editAlt} placeholder={t(M['assets.asset_detail.alt_text_placeholder'])} />
+                <Input id="detail-alt" type="text" bind:value={editAlt} placeholder={t(M['assets.asset_detail.alt_text_placeholder'])} />
               </div>
             {/if}
 
             <div class="form-field">
               <label for="detail-desc" class="form-label">Description</label>
-              <textarea id="detail-desc" class="form-textarea" bind:value={editDescription} rows="3" placeholder={t(M['assets.asset_detail.description_placeholder'])}></textarea>
+              <Textarea id="detail-desc" bind:value={editDescription} rows={3} placeholder={t(M['assets.asset_detail.description_placeholder'])} />
             </div>
           </div>
         </section>
@@ -403,29 +404,6 @@ function formatDate(date: Date | string | undefined): string {
     font-size: var(--smrt-typography-label-small-size, 0.7rem);
     color: var(--smrt-color-error, #dc2626);
     margin-left: var(--smrt-spacing-1, 4px);
-  }
-
-  .form-input, .form-textarea {
-    width: 100%;
-    padding: var(--smrt-spacing-2, 0.5rem) var(--smrt-spacing-3, 0.75rem);
-    border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
-    border-radius: var(--smrt-radius-medium, 0.5rem);
-    font-family: inherit;
-    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    color: var(--smrt-color-on-surface, #111827);
-    background: var(--smrt-color-surface, #ffffff);
-    box-sizing: border-box;
-  }
-
-  .form-input:focus, .form-textarea:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #005ac1);
-    box-shadow: 0 0 0 2px var(--smrt-color-primary-container, rgba(0, 90, 193, 0.1));
-  }
-
-  .form-textarea {
-    resize: vertical;
-    min-height: 60px;
   }
 
   /* Metadata */

--- a/packages/assets/src/svelte/AssetGrid.svelte
+++ b/packages/assets/src/svelte/AssetGrid.svelte
@@ -119,6 +119,7 @@ function getAltText(asset: PersistedAsset): string {
 
           <!-- Selection checkbox -->
           <div class="asset-card__checkbox">
+            <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
             <input
               type="checkbox"
               checked={selected}

--- a/packages/assets/src/svelte/AssetList.svelte
+++ b/packages/assets/src/svelte/AssetList.svelte
@@ -111,6 +111,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
     <thead class="list-table__head">
       <tr>
         <th class="col-checkbox">
+          <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
           <input
             type="checkbox"
             checked={allSelected}
@@ -171,6 +172,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
             class:list-table__row--selected={selected}
           >
             <td class="col-checkbox">
+              <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
               <input
                 type="checkbox"
                 checked={selected}

--- a/packages/assets/src/svelte/AssetToolbar.svelte
+++ b/packages/assets/src/svelte/AssetToolbar.svelte
@@ -7,6 +7,7 @@ import { onDestroy } from 'svelte';
  * and an upload button.
  */
 
+import { Input, Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from './i18n.js';
@@ -108,7 +109,7 @@ const views: { key: AssetViewMode; label: string; icon: string }[] = [
           <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
         </svg>
       </span>
-      <input
+      <Input
         type="search"
         class="search-field"
         placeholder={t(M['assets.asset_toolbar.search_placeholder'])}
@@ -127,22 +128,22 @@ const views: { key: AssetViewMode; label: string; icon: string }[] = [
     </div>
 
     <!-- Type Filter -->
-    <select class="asset-toolbar__select" value={typeValue} onchange={handleTypeFilter} aria-label={t(M['assets.asset_toolbar.filter_by_type'])}>
+    <Select class="asset-toolbar__select" value={typeValue} onchange={handleTypeFilter} aria-label={t(M['assets.asset_toolbar.filter_by_type'])}>
       <option value="">{t(M['assets.asset_toolbar.all_types'])}</option>
       <option value="image">Images</option>
       <option value="video">Videos</option>
       <option value="document">Documents</option>
       <option value="audio">Audio</option>
-    </select>
+    </Select>
 
     <!-- Sort -->
-    <select class="asset-toolbar__select" value={sortValue} onchange={handleSortChange} aria-label={t(M['assets.asset_toolbar.sort_assets'])}>
+    <Select class="asset-toolbar__select" value={sortValue} onchange={handleSortChange} aria-label={t(M['assets.asset_toolbar.sort_assets'])}>
       <option value="createdAt:desc">{t(M['assets.asset_toolbar.newest_first'])}</option>
       <option value="createdAt:asc">{t(M['assets.asset_toolbar.oldest_first'])}</option>
       <option value="name:asc">{t(M['assets.asset_toolbar.name_a_z'])}</option>
       <option value="name:desc">{t(M['assets.asset_toolbar.name_z_a'])}</option>
       <option value="updatedAt:desc">{t(M['assets.asset_toolbar.recently_updated'])}</option>
-    </select>
+    </Select>
   </div>
 
   <div class="asset-toolbar__right">
@@ -247,10 +248,16 @@ const views: { key: AssetViewMode; label: string; icon: string }[] = [
     color: var(--smrt-color-on-surface-variant, #6b7280);
   }
 
-  .search-field {
+  /* The search field renders via <Input class="search-field"> (issue #1589). It
+     sits inside the bordered .asset-toolbar__search shell, so the overrides strip
+     the primitive's own border/background/box-shadow to keep it transparent and
+     reach the child <input> through :global() scoping. */
+  .asset-toolbar__search :global(.search-field) {
     flex: 1;
     border: none;
+    border-radius: 0;
     background: transparent;
+    box-shadow: none;
     padding: var(--smrt-spacing-1, 0.25rem) var(--smrt-spacing-2, 0.5rem);
     font-family: inherit;
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
@@ -259,11 +266,16 @@ const views: { key: AssetViewMode; label: string; icon: string }[] = [
     min-width: 0;
   }
 
-  .search-field::placeholder {
+  .asset-toolbar__search :global(.search-field:focus) {
+    border: none;
+    box-shadow: none;
+  }
+
+  .asset-toolbar__search :global(.search-field::placeholder) {
     color: var(--smrt-color-on-surface-variant, #9ca3af);
   }
 
-  .search-field::-webkit-search-cancel-button {
+  .asset-toolbar__search :global(.search-field::-webkit-search-cancel-button) {
     display: none;
   }
 
@@ -286,22 +298,21 @@ const views: { key: AssetViewMode; label: string; icon: string }[] = [
     background: var(--smrt-color-surface-container, #f3f4f6);
   }
 
-  /* Selects */
-  .asset-toolbar__select {
+  /* Selects render via <Select class="asset-toolbar__select"> (issue #1589). The
+     base .select primitive owns the chevron + focus ring; these overrides pin the
+     toolbar-matching 36px height, container-low fill, and width, and reach the
+     child <select> through :global() scoping. */
+  .asset-toolbar__left :global(.asset-toolbar__select) {
+    width: auto;
     height: 36px;
-    padding: 0 var(--smrt-spacing-3, 0.75rem);
-    background: var(--smrt-color-surface-container-low, #f9fafb);
+    padding: 0 var(--smrt-spacing-8, 2rem) 0 var(--smrt-spacing-3, 0.75rem);
+    background-color: var(--smrt-color-surface-container-low, #f9fafb);
     border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
     border-radius: var(--smrt-radius-medium, 0.5rem);
     font-family: inherit;
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     color: var(--smrt-color-on-surface, #111827);
     cursor: pointer;
-  }
-
-  .asset-toolbar__select:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #005ac1);
   }
 
   /* View Toggle */

--- a/packages/assets/src/svelte/CreateAssetModal.svelte
+++ b/packages/assets/src/svelte/CreateAssetModal.svelte
@@ -12,6 +12,7 @@
 // entire smrt-svelte surface — including optional peers like smrt-agents /
 // smrt-users — just to compile this modal.
 import { Modal } from '@happyvertical/smrt-ui/feedback';
+import { Input, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from './i18n.js';
@@ -167,6 +168,7 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
           </svg>
           <p class="dropzone__text">{t(M['assets.create_asset_modal.dropzone_text'])}</p>
           <p class="dropzone__hint">{t(M['assets.create_asset_modal.dropzone_hint'])}</p>
+          <!-- raw-primitive-allow: hidden native file input behind the custom drop zone, triggered programmatically; styled Input is unwanted here (visually hidden, opened via the dropzone click/keydown) -->
           <input id="file-input" type="file" class="dropzone__input" onchange={handleFileSelect} />
         </div>
       {:else}
@@ -192,12 +194,12 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
         <div class="form-fields">
           <div class="form-field">
             <label for="asset-name" class="form-label">Name</label>
-            <input id="asset-name" type="text" class="form-input" bind:value={name} placeholder={t(M['assets.create_asset_modal.name_placeholder'])} />
+            <Input id="asset-name" type="text" bind:value={name} placeholder={t(M['assets.create_asset_modal.name_placeholder'])} />
           </div>
 
           <div class="form-field">
             <label for="asset-desc" class="form-label">Description</label>
-            <textarea id="asset-desc" class="form-textarea" bind:value={description} placeholder={t(M['assets.create_asset_modal.description_placeholder'])} rows="2"></textarea>
+            <Textarea id="asset-desc" bind:value={description} placeholder={t(M['assets.create_asset_modal.description_placeholder'])} rows={2} />
           </div>
 
           {#if isImage}
@@ -208,7 +210,7 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
                   <span class="form-label__warning">{t(M['assets.create_asset_modal.alt_text_recommended_warning'])}</span>
                 {/if}
               </label>
-              <input id="asset-alt" type="text" class="form-input" bind:value={altText} placeholder={t(M['assets.create_asset_modal.alt_text_placeholder'])} />
+              <Input id="asset-alt" type="text" bind:value={altText} placeholder={t(M['assets.create_asset_modal.alt_text_placeholder'])} />
             </div>
           {/if}
         </div>
@@ -375,29 +377,6 @@ const isLargeFile = $derived((file?.size ?? 0) > 2 * 1024 * 1024);
     font-size: var(--smrt-typography-body-small-size, 0.75rem);
     color: var(--smrt-color-error, #dc2626);
     margin-left: var(--smrt-spacing-1, 4px);
-  }
-
-  .form-input, .form-textarea {
-    width: 100%;
-    padding: var(--smrt-spacing-2, 0.5rem) var(--smrt-spacing-3, 0.75rem);
-    border: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
-    border-radius: var(--smrt-radius-medium, 0.5rem);
-    font-family: inherit;
-    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    color: var(--smrt-color-on-surface, #111827);
-    background: var(--smrt-color-surface, #ffffff);
-    box-sizing: border-box;
-  }
-
-  .form-input:focus, .form-textarea:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #005ac1);
-    box-shadow: 0 0 0 2px var(--smrt-color-primary-container, rgba(0, 90, 193, 0.1));
-  }
-
-  .form-textarea {
-    resize: vertical;
-    min-height: 60px;
   }
 
 </style>

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -3,7 +3,7 @@
   "version": "0.34.5",
   "description": "Chat rooms, DMs, threads, and agent conversations for the SMRT framework",
   "type": "module",
-  "smrtRawPrimitives": "strict-buttons",
+  "smrtRawPrimitives": "strict",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/chat/src/svelte/components/agent/AgentChat.svelte
+++ b/packages/chat/src/svelte/components/agent/AgentChat.svelte
@@ -5,6 +5,7 @@
  * Agent messages are styled differently from user messages.
  */
 
+import { Form, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.js';
@@ -92,13 +93,13 @@ $effect(() => {
 </script>
 
 <div class="agent-chat" aria-label={t(M['chat.agent_chat.conversation'])}>
-  <form class="agent-chat__input-bar" onsubmit={(e) => handleSubmit(e)}>
+  <Form class="agent-chat__input-bar" onsubmit={(e) => handleSubmit(e)}>
     {#if !isActive}
       <div class="agent-chat__inactive-notice">
         {t(M['chat.agent_chat.inactive_notice'], { status: session.status })}
       </div>
     {:else}
-      <textarea
+      <Textarea
         class="agent-chat__input"
         placeholder={t(M['chat.agent_chat.input_placeholder'])}
         bind:value={inputValue}
@@ -106,7 +107,7 @@ $effect(() => {
         rows={1}
         disabled={!isActive}
         aria-label={t(M['chat.agent_chat.message_input'])}
-      ></textarea>
+      />
       <Button
         variant="ghost"
         class="agent-chat__send-btn"
@@ -119,7 +120,7 @@ $effect(() => {
         </svg>
       </Button>
     {/if}
-  </form>
+  </Form>
 
   <div
     class="agent-chat__messages"
@@ -311,7 +312,8 @@ $effect(() => {
     color: var(--smrt-color-outline, #74777f);
   }
 
-  .agent-chat__input-bar {
+  /* :global() targets the Form primitive's rendered <form> (see #1589 scoping trap). */
+  :global(.agent-chat__input-bar) {
     display: flex;
     align-items: flex-end;
     gap: var(--smrt-spacing-2, 8px);
@@ -329,32 +331,18 @@ $effect(() => {
     font-style: italic;
   }
 
-  .agent-chat__input {
+  /* Layout for the Textarea primitive's rendered <textarea> (tokenised styling
+     comes from the primitive; this only sizes it within the input bar). */
+  :global(.agent-chat__input) {
     flex: 1;
-    border: none;
-    border-radius: var(--smrt-radius-md, 8px);
-    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
-    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
-    line-height: var(--smrt-typography-body-medium-line-height, 1.4);
-    color: var(--smrt-color-on-surface, #1a1c1e);
-    background: var(--smrt-color-surface-container-low, #f7f7fb);
     resize: none;
-    outline: none;
     min-height: 34px;
     max-height: 80px;
   }
 
-  .agent-chat__input:focus {
-    outline: none;
-    background: var(--smrt-color-surface-variant, #e1e2ec);
-  }
-
-  .agent-chat__input::placeholder {
-    color: var(--smrt-color-outline, #74777f);
-  }
-
-  /* :global() pierces into the Button child's rendered <button> (see #1589). */
-  .agent-chat__input-bar :global(.agent-chat__send-btn) {
+  /* :global() pierces into the Button child's rendered <button> (see #1589).
+     The ancestor is the Form primitive's <form>, also global. */
+  :global(.agent-chat__input-bar .agent-chat__send-btn) {
     width: 34px;
     height: 34px;
     padding: 0;
@@ -365,7 +353,7 @@ $effect(() => {
     transition: opacity 150ms;
   }
 
-  .agent-chat__input-bar :global(.agent-chat__send-btn:not(:disabled):hover) {
+  :global(.agent-chat__input-bar .agent-chat__send-btn:not(:disabled):hover) {
     background: var(--smrt-color-primary, #005ac1);
     opacity: 0.85;
   }

--- a/packages/chat/src/svelte/components/dialogs/RoomCreateDialog.svelte
+++ b/packages/chat/src/svelte/components/dialogs/RoomCreateDialog.svelte
@@ -8,6 +8,7 @@
  * hand-rolled backdrop it replaced had none of those.
  */
 import { Modal } from '@happyvertical/smrt-ui/feedback';
+import { Form, Input, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.js';
@@ -32,7 +33,6 @@ let { isOpen, onclose, oncreate }: Props = $props();
 let name = $state('');
 let roomType = $state('public');
 let description = $state('');
-let nameInput = $state<HTMLInputElement | null>(null);
 
 const canCreate = $derived(name.trim().length > 0);
 
@@ -81,10 +81,15 @@ function resetForm() {
 }
 
 // Modal traps focus and moves it to the dialog itself; nudge initial focus to
-// the name field once the dialog is open and the input is mounted.
+// the name field once the dialog is open and the input is mounted. The Input
+// primitive doesn't expose its inner element, so resolve it by id.
 $effect(() => {
-  if (isOpen && nameInput) {
-    nameInput.focus();
+  if (isOpen && typeof document !== 'undefined') {
+    // Defer a frame so the Modal body (and the name input) is mounted first.
+    const raf = requestAnimationFrame(() => {
+      document.getElementById('room-name')?.focus();
+    });
+    return () => cancelAnimationFrame(raf);
   }
 });
 </script>
@@ -96,7 +101,7 @@ $effect(() => {
   size="md"
   ariaLabel={t(M['chat.room_create_dialog.title'])}
 >
-  <form
+  <Form
     class="dialog__form"
     onsubmit={(e) => { e.preventDefault(); handleSubmit(); }}
   >
@@ -104,14 +109,13 @@ $effect(() => {
       <label class="field__label" for="room-name">
         {t(M['chat.room_create_dialog.room_name'])} <span class="field__required" aria-label={t(M['chat.room_create_dialog.required'])}>*</span>
       </label>
-      <input
-        bind:this={nameInput}
+      <Input
         bind:value={name}
         id="room-name"
         type="text"
         class="field__input"
         placeholder={t(M['chat.room_create_dialog.name_placeholder'])}
-        maxlength="100"
+        maxlength={100}
         autocomplete="off"
       />
     </div>
@@ -124,6 +128,7 @@ $effect(() => {
             class="type-option"
             class:type-option--selected={roomType === option.value}
           >
+            <!-- raw-primitive-allow: native radio for single-choice room-type selection; no Provider-free radio primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
             <input
               type="radio"
               name="roomType"
@@ -142,21 +147,21 @@ $effect(() => {
 
     <div class="field">
       <label class="field__label" for="room-description">Description</label>
-      <textarea
+      <Textarea
         bind:value={description}
         id="room-description"
         class="field__textarea"
         placeholder={t(M['chat.room_create_dialog.description_placeholder'])}
-        rows="3"
-        maxlength="500"
-      ></textarea>
+        rows={3}
+        maxlength={500}
+      />
       <span class="field__hint">{description.length}/500</span>
     </div>
 
     <!-- Hidden submit keeps Enter-to-submit working inside the Modal body. -->
     <!-- raw-primitive-allow: off-screen aria-hidden type=submit element with tabindex=-1 used only to enable native Enter-to-submit inside the Modal body; intentionally non-interactive and not a visible action button -->
     <button type="submit" class="visually-hidden" tabindex="-1" disabled={!canCreate} aria-hidden="true"></button>
-  </form>
+  </Form>
 
   {#snippet footer()}
     <Button
@@ -178,7 +183,8 @@ $effect(() => {
 </Modal>
 
 <style>
-  .dialog__form {
+  /* :global() targets the Form primitive's rendered <form> (see #1589 scoping trap). */
+  :global(.dialog__form) {
     display: flex;
     flex-direction: column;
     gap: 1.25rem;
@@ -212,40 +218,6 @@ $effect(() => {
 
   .field__required {
     color: var(--smrt-color-error, #b3261e);
-  }
-
-  .field__input {
-    padding: 0.75rem;
-    font: var(--smrt-typography-body-large-font, 1rem / 1.5 sans-serif);
-    font-family: inherit;
-    border: 1px solid var(--smrt-color-outline, #74777f);
-    border-radius: var(--smrt-radius-medium, 0.5rem);
-    background: var(--smrt-color-surface, #fefbff);
-    color: var(--smrt-color-on-surface, #1a1c1e);
-  }
-
-  .field__input:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #005ac1);
-    box-shadow: 0 0 0 1px var(--smrt-color-primary, #005ac1);
-  }
-
-  .field__textarea {
-    padding: 0.75rem;
-    font: var(--smrt-typography-body-large-font, 1rem / 1.5 sans-serif);
-    font-family: inherit;
-    border: 1px solid var(--smrt-color-outline, #74777f);
-    border-radius: var(--smrt-radius-medium, 0.5rem);
-    background: var(--smrt-color-surface, #fefbff);
-    color: var(--smrt-color-on-surface, #1a1c1e);
-    resize: vertical;
-    min-height: 80px;
-  }
-
-  .field__textarea:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #005ac1);
-    box-shadow: 0 0 0 1px var(--smrt-color-primary, #005ac1);
   }
 
   .field__hint {

--- a/packages/chat/src/svelte/components/dialogs/RoomCreateDialog.svelte
+++ b/packages/chat/src/svelte/components/dialogs/RoomCreateDialog.svelte
@@ -113,7 +113,6 @@ $effect(() => {
         bind:value={name}
         id="room-name"
         type="text"
-        class="field__input"
         placeholder={t(M['chat.room_create_dialog.name_placeholder'])}
         maxlength={100}
         autocomplete="off"
@@ -150,7 +149,6 @@ $effect(() => {
       <Textarea
         bind:value={description}
         id="room-description"
-        class="field__textarea"
         placeholder={t(M['chat.room_create_dialog.description_placeholder'])}
         rows={3}
         maxlength={500}

--- a/packages/chat/src/svelte/components/dialogs/SearchMessages.svelte
+++ b/packages/chat/src/svelte/components/dialogs/SearchMessages.svelte
@@ -3,6 +3,7 @@
  * SearchMessages - Message search interface with results list
  * Provides a search input and displays matching messages
  */
+import { Form, Input } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.js';
@@ -26,10 +27,15 @@ export interface Props {
 let { isOpen, onclose, onsearch, results, onselectresult }: Props = $props();
 
 let query = $state('');
-let searchInput = $state<HTMLInputElement | null>(null);
 
 const hasResults = $derived(results.length > 0);
 const hasQuery = $derived(query.trim().length > 0);
+
+// The Input primitive doesn't expose its inner element, so resolve it by id.
+function focusSearchInput() {
+  if (typeof document === 'undefined') return;
+  document.getElementById('search-messages-input')?.focus();
+}
 
 function handleSubmit() {
   const trimmed = query.trim();
@@ -95,8 +101,10 @@ $effect(() => {
 });
 
 $effect(() => {
-  if (isOpen && searchInput) {
-    searchInput.focus();
+  if (isOpen) {
+    // Defer a frame so the search input is mounted before focusing.
+    const raf = requestAnimationFrame(focusSearchInput);
+    return () => cancelAnimationFrame(raf);
   }
 });
 </script>
@@ -124,7 +132,7 @@ $effect(() => {
       </Button>
     </div>
 
-    <form
+    <Form
       class="search-form"
       onsubmit={(e) => { e.preventDefault(); handleSubmit(); }}
     >
@@ -133,9 +141,9 @@ $effect(() => {
           <circle cx="11" cy="11" r="8" />
           <path d="m21 21-4.35-4.35" />
         </svg>
-        <input
-          bind:this={searchInput}
+        <Input
           bind:value={query}
+          id="search-messages-input"
           type="search"
           class="search-input"
           placeholder={t(M['chat.search_messages.input_placeholder'])}
@@ -148,7 +156,7 @@ $effect(() => {
             size="sm"
             class="clear-btn"
             type="button"
-            onclick={() => { query = ''; searchInput?.focus(); }}
+            onclick={() => { query = ''; focusSearchInput(); }}
             aria-label={t(M['chat.search_messages.clear'])}
           >
             <svg class="clear-btn__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -158,7 +166,7 @@ $effect(() => {
           </Button>
         {/if}
       </div>
-    </form>
+    </Form>
 
     <div class="search-results" aria-label={t(M['chat.search_messages.results'])}>
       {#if hasResults}
@@ -257,7 +265,8 @@ $effect(() => {
     height: 1rem;
   }
 
-  .search-form {
+  /* :global() targets the Form primitive's rendered <form> (see #1589 scoping trap). */
+  :global(.search-form) {
     padding: 0.75rem 1rem;
     border-bottom: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
   }
@@ -285,17 +294,24 @@ $effect(() => {
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
-  .search-input {
+  /* The Input primitive sits inside the bordered .search-input-wrap, which owns
+     the border + focus-within ring — so neutralize the primitive's own chrome
+     (border/background/padding/box-shadow) and let it render borderless. */
+  :global(.search-input) {
     flex: 1;
     border: none;
     outline: none;
+    padding: 0;
     background: transparent;
+    box-shadow: none;
     font: var(--smrt-typography-body-medium-font, 0.875rem / 1.25 sans-serif);
     color: var(--smrt-color-on-surface, #1a1c1e);
   }
 
-  .search-input::placeholder {
-    color: var(--smrt-color-on-surface-variant, #43474e);
+  :global(.search-input:focus) {
+    border: none;
+    outline: none;
+    box-shadow: none;
   }
 
   /* :global() pierces into the Button child's rendered <button> (see #1589). */

--- a/packages/chat/src/svelte/components/messages/MessageInput.svelte
+++ b/packages/chat/src/svelte/components/messages/MessageInput.svelte
@@ -3,6 +3,7 @@
  * MessageInput - Chat message input bar
  * Text area with send button. Shows reply preview when replying.
  */
+import { Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.messages.js';
@@ -31,7 +32,9 @@ const {
 }: Props = $props();
 
 let content = $state('');
-let textareaEl: HTMLTextAreaElement | undefined = $state();
+// Captured from the textarea's input event so auto-resize works without binding
+// to the Textarea primitive's inner DOM node (the primitive doesn't expose it).
+let textareaEl: HTMLTextAreaElement | undefined;
 
 function handleSend() {
   const trimmed = content.trim();
@@ -50,10 +53,11 @@ function handleKeydown(event: KeyboardEvent) {
   }
 }
 
-function handleInput() {
-  if (!textareaEl) return;
-  textareaEl.style.height = 'auto';
-  textareaEl.style.height = `${Math.min(textareaEl.scrollHeight, 120)}px`;
+function handleInput(event: Event) {
+  const el = event.currentTarget as HTMLTextAreaElement;
+  textareaEl = el;
+  el.style.height = 'auto';
+  el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
 }
 </script>
 
@@ -80,17 +84,16 @@ function handleInput() {
   {/if}
 
   <div class="message-input__bar">
-    <textarea
-      bind:this={textareaEl}
+    <Textarea
       bind:value={content}
       class="message-input__textarea"
       {placeholder}
       {disabled}
-      rows="1"
+      rows={1}
       onkeydown={handleKeydown}
       oninput={handleInput}
       aria-label={t(M['chat.message_input.input_label'])}
-    ></textarea>
+    />
     <Button
       variant="ghost"
       class="message-input__send"
@@ -181,29 +184,15 @@ function handleInput() {
     padding: var(--smrt-spacing-3, 0.75rem) var(--smrt-spacing-4, 1rem);
   }
 
-  .message-input__textarea {
+  /* Layout/sizing for the Textarea primitive's rendered <textarea>; tokenised
+     border/focus/placeholder styling comes from the primitive. The height is
+     JS-driven (auto-resize), so resize is disabled and capped at max-height. */
+  :global(.message-input__textarea) {
     flex: 1;
     resize: none;
-    border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
-    border-radius: var(--smrt-radius-medium, 0.5rem);
-    padding: var(--smrt-spacing-2, 0.375rem) var(--smrt-spacing-3, 0.75rem);
-    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    font-family: inherit;
-    line-height: 1.4;
-    background: var(--smrt-color-surface-container-low, #f9fafb);
-    color: var(--smrt-color-on-surface, #1b1b1f);
+    min-height: auto;
     max-height: 120px;
     overflow-y: auto;
-  }
-
-  .message-input__textarea:focus {
-    outline: 2px solid var(--smrt-color-primary, #005ac1);
-    outline-offset: -1px;
-    border-color: transparent;
-  }
-
-  .message-input__textarea::placeholder {
-    color: var(--smrt-color-outline, #74777f);
   }
 
   /* :global() pierces into the Button child's rendered <button> (see #1589). */

--- a/packages/chat/src/svelte/components/shared/FileUpload.svelte
+++ b/packages/chat/src/svelte/components/shared/FileUpload.svelte
@@ -169,6 +169,7 @@ function getFileIcon(type: string): string {
     ondragleave={handleDragLeave}
   >
     <label class="file-upload__label">
+      <!-- raw-primitive-allow: visually-hidden native file input that backs a custom drag-and-drop zone; the base Input primitive renders a visible bordered control and cannot be the hidden picker behind this drop zone -->
       <input
         type="file"
         class="file-upload__input"

--- a/packages/chat/src/svelte/components/tabs/MiniChat.svelte
+++ b/packages/chat/src/svelte/components/tabs/MiniChat.svelte
@@ -4,6 +4,7 @@
  * Simplified message list + input in minimal space.
  * No thread panel, no reactions. Just messages and a send box.
  */
+import { Form, Input } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.messages.js';
@@ -86,8 +87,8 @@ $effect(() => {
     {/if}
   </div>
 
-  <form class="mini-chat__input-bar" onsubmit={handleSubmit}>
-    <input
+  <Form class="mini-chat__input-bar" onsubmit={handleSubmit}>
+    <Input
       class="mini-chat__input"
       type="text"
       placeholder={t(M['chat.mini_chat.placeholder'])}
@@ -106,7 +107,7 @@ $effect(() => {
         <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
       </svg>
     </Button>
-  </form>
+  </Form>
 </div>
 
 <style>
@@ -185,7 +186,8 @@ $effect(() => {
     color: var(--smrt-color-outline, #74777f);
   }
 
-  .mini-chat__input-bar {
+  /* :global() targets the Form primitive's rendered <form> (see #1589 scoping trap). */
+  :global(.mini-chat__input-bar) {
     display: flex;
     align-items: center;
     gap: var(--smrt-spacing-1, 4px);
@@ -194,28 +196,16 @@ $effect(() => {
     background: var(--smrt-color-surface, #fefbff);
   }
 
-  .mini-chat__input {
+  /* Layout for the Input primitive's rendered <input> (tokenised styling comes
+     from the primitive; this only sizes/shapes it within the input bar). */
+  :global(.mini-chat__input) {
     flex: 1;
-    border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     border-radius: var(--smrt-radius-full, 9999px);
-    padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
-    font: var(--smrt-typography-body-small-font, 0.8125rem/1.4 sans-serif);
-    color: var(--smrt-color-on-surface, #1a1c1e);
-    background: var(--smrt-color-surface-container-low, #f7f7fb);
-    outline: none;
   }
 
-  .mini-chat__input:focus {
-    border-color: var(--smrt-color-primary, #005ac1);
-    box-shadow: 0 0 0 1px var(--smrt-color-primary, #005ac1);
-  }
-
-  .mini-chat__input::placeholder {
-    color: var(--smrt-color-outline, #74777f);
-  }
-
-  /* :global() pierces into the Button child's rendered <button> (see #1589). */
-  .mini-chat__input-bar :global(.mini-chat__send-btn) {
+  /* :global() pierces into the Button child's rendered <button> (see #1589).
+     The ancestor is the Form primitive's <form>, also global. */
+  :global(.mini-chat__input-bar .mini-chat__send-btn) {
     width: 32px;
     height: 32px;
     padding: 0;
@@ -226,11 +216,11 @@ $effect(() => {
     transition: opacity var(--smrt-duration-short2, 150ms);
   }
 
-  .mini-chat__input-bar :global(.mini-chat__send-btn:disabled) {
+  :global(.mini-chat__input-bar .mini-chat__send-btn:disabled) {
     opacity: 0.4;
   }
 
-  .mini-chat__input-bar :global(.mini-chat__send-btn:not(:disabled):hover) {
+  :global(.mini-chat__input-bar .mini-chat__send-btn:not(:disabled):hover) {
     background: var(--smrt-color-primary, #005ac1);
     opacity: 0.85;
   }
@@ -240,7 +230,7 @@ $effect(() => {
       scroll-behavior: auto;
     }
 
-    .mini-chat__input-bar :global(.mini-chat__send-btn) {
+    :global(.mini-chat__input-bar .mini-chat__send-btn) {
       transition: none;
     }
   }

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -3,7 +3,7 @@
   "version": "0.34.5",
   "description": "Content processing module for SMRT framework - handles documents, web content, and media",
   "type": "module",
-  "smrtRawPrimitives": "strict-buttons",
+  "smrtRawPrimitives": "strict",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/content/src/svelte/components/ContentAgentChat.svelte
+++ b/packages/content/src/svelte/components/ContentAgentChat.svelte
@@ -6,6 +6,7 @@
  */
 
 import { AgentChat } from '@happyvertical/smrt-chat/svelte';
+import { Input, Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type {
@@ -432,11 +433,11 @@ async function handleSendMessage(content: string) {
     </div>
   {:else if session}
     <div class="model-bar">
-      <select class="smrt-select model-select" bind:value={selectedModelId}>
+      <Select class="smrt-select model-select" bind:value={selectedModelId}>
         {#each availableAIModels as model}
           <option value={model.id}>{model.label}</option>
         {/each}
-      </select>
+      </Select>
     </div>
     
     <div class="chat-main">
@@ -465,9 +466,9 @@ async function handleSendMessage(content: string) {
     <div class="topic-footer">
       {#if showNewTopicInput}
         <div class="new-topic-row">
-          <input 
-            class="new-topic-input" 
-            type="text" 
+          <Input
+            class="new-topic-input"
+            type="text"
             placeholder={t(M['content.content_agent_chat.topic_name_placeholder'])}
             bind:value={newTopicTitle}
             onkeydown={(e: KeyboardEvent) => { if (e.key === 'Enter') { createNewTopic(); showNewTopicInput = false; } }}
@@ -478,9 +479,9 @@ async function handleSendMessage(content: string) {
           <Button variant="ghost" size="sm" type="button" class="topic-action-btn topic-cancel-btn" onclick={() => { showNewTopicInput = false; }} aria-label={t(M['content.content_agent_chat.cancel'])} title={t(M['content.content_agent_chat.cancel'])}>✕</Button>
         </div>
       {:else}
-        <select 
-          class="smrt-select topic-select" 
-          bind:value={activeThreadId} 
+        <Select
+          class="smrt-select topic-select"
+          value={activeThreadId ?? ''}
           onchange={(e: Event) => loadThread((e.currentTarget as HTMLSelectElement).value)}
           disabled={!threads.length}
         >
@@ -490,7 +491,7 @@ async function handleSendMessage(content: string) {
           {#each threads as thread}
             <option value={thread.id}>{thread.title || t(M['content.content_agent_chat.untitled_topic'])}</option>
           {/each}
-        </select>
+        </Select>
         <Button variant="ghost" size="sm" type="button" class="topic-action-btn" onclick={() => { showNewTopicInput = true; newTopicTitle = ''; }} title={t(M['content.content_agent_chat.new_topic'])}>
           <svg viewBox="0 0 24 24" width="14" height="14" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
           {t(M['content.content_agent_chat.new'])}
@@ -541,7 +542,7 @@ async function handleSendMessage(content: string) {
     background: var(--smrt-color-surface-container-lowest, #ffffff);
   }
 
-  .smrt-select {
+  .content-agent-chat-container :global(.smrt-select) {
     width: 100%;
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border-radius: var(--smrt-radius-md, 8px);
@@ -552,15 +553,15 @@ async function handleSendMessage(content: string) {
     outline: none;
     cursor: pointer;
   }
-  
-  .smrt-select:disabled {
+
+  .content-agent-chat-container :global(.smrt-select:disabled) {
     background: var(--smrt-color-surface-container, #f3f4f9);
     color: var(--smrt-color-on-surface-variant, #43474e);
     cursor: not-allowed;
     opacity: 0.7;
   }
 
-  .smrt-select:focus {
+  .content-agent-chat-container :global(.smrt-select:focus) {
     background: var(--smrt-color-surface-variant, #e1e2ec);
   }
 
@@ -589,7 +590,7 @@ async function handleSendMessage(content: string) {
     background: var(--smrt-color-surface-container-lowest, #ffffff);
   }
 
-  .topic-footer .smrt-select {
+  .topic-footer :global(.smrt-select) {
     flex: 1;
   }
 
@@ -626,7 +627,7 @@ async function handleSendMessage(content: string) {
     width: 100%;
   }
 
-  .new-topic-input {
+  .new-topic-row :global(.new-topic-input) {
     flex: 1;
     padding: var(--smrt-spacing-1, 4px) var(--smrt-spacing-2, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
@@ -637,7 +638,7 @@ async function handleSendMessage(content: string) {
     color: var(--smrt-color-on-surface, #1a1c1e);
   }
 
-  .new-topic-input:focus {
+  .new-topic-row :global(.new-topic-input:focus) {
     border-color: var(--smrt-color-primary, #005ac1);
   }
 </style>

--- a/packages/content/src/svelte/components/ContentBodyEditor.svelte
+++ b/packages/content/src/svelte/components/ContentBodyEditor.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { ImageLike } from '@happyvertical/smrt-images/svelte';
+import { Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import {
@@ -1026,13 +1027,13 @@ function handleEditorDragEnd() {
 
     <label class="format-select">
       <span>{t(M['content.content_body_editor.save_as'])}</span>
-      <select
+      <Select
         value={currentFormat}
         onchange={(event) => setBodyFormat((event.currentTarget as HTMLSelectElement).value as ContentBodyFormat)}
       >
         <option value="html">HTML</option>
         <option value="markdown">Markdown</option>
-      </select>
+      </Select>
     </label>
   </div>
 
@@ -1247,7 +1248,7 @@ function handleEditorDragEnd() {
     color: var(--smrt-color-on-surface-variant);
   }
 
-  .format-select select {
+  .format-select :global(.select) {
     min-height: 2rem;
     border: 1px solid var(--smrt-color-outline-variant);
     border-radius: 0.45rem;

--- a/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
+++ b/packages/content/src/svelte/components/ContentClaimAuditTool.svelte
@@ -245,6 +245,7 @@ async function recheckFactClaims(claimIds: string[]) {
               <details class="tool-card">
                 <summary>
                   <label class="claim-audit-select">
+                    <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
                     <input
                       type="checkbox"
                       checked={isClaimSelected(claim)}

--- a/packages/content/src/svelte/components/ContentContributionForm.svelte
+++ b/packages/content/src/svelte/components/ContentContributionForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Form, Input, Select, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type {
@@ -119,83 +120,86 @@ function handleSubmit(event: SubmitEvent) {
 }
 </script>
 
-<form
-  class="contribution-form"
-  method="post"
-  enctype="multipart/form-data"
-  {action}
-  onsubmit={handleSubmit}
->
-  <h3>{t(M['content.contribution_form.heading'])}</h3>
+<div class="contribution-form-shell">
+  <Form
+    class="contribution-form"
+    method="post"
+    enctype="multipart/form-data"
+    {action}
+    preventDefault={false}
+    onsubmit={handleSubmit}
+  >
+    <h3>{t(M['content.contribution_form.heading'])}</h3>
 
-  <label>
-    {t(M['content.contribution_form.contribution_type'])}
-    <select name="typeKey" bind:value={draft.typeKey} required>
-      {#each types.filter((type) => type.enabled !== false) as type (type.key)}
-        <option value={type.key}>{type.label}</option>
-      {/each}
-    </select>
-  </label>
-
-  {#if showContributorFields}
-    <div class="grid">
-      <label>
-        Email
-        <input name="contributorEmail" type="email" bind:value={draft.contributorEmail} required />
-      </label>
-      <label>
-        Name
-        <input name="contributorName" type="text" bind:value={draft.contributorName} />
-      </label>
-    </div>
-  {/if}
-
-  <label>
-    Title
-    <input name="title" type="text" bind:value={draft.title} />
-  </label>
-
-  <label>
-    Description
-    <textarea name="description" bind:value={draft.description} rows="2"></textarea>
-  </label>
-
-  <label>
-    Body
-    <textarea name="body" bind:value={draft.body} rows="8"></textarea>
-  </label>
-
-  {#if activeType?.allowFiles !== false}
     <label>
-      {t(M['content.contribution_form.attach_files'])}
-      <input
-        name="files"
-        type="file"
-        multiple
-        onchange={handleFileChange}
-      />
-    </label>
-    {#if draft.files.length > 0}
-      <div class="file-list">
-        {#each draft.files as file (file.name + file.size)}
-          <span>{file.name} ({Math.max(1, Math.round(file.size / 1024))} KB)</span>
+      {t(M['content.contribution_form.contribution_type'])}
+      <Select name="typeKey" bind:value={draft.typeKey} required>
+        {#each types.filter((type) => type.enabled !== false) as type (type.key)}
+          <option value={type.key}>{type.label}</option>
         {/each}
+      </Select>
+    </label>
+
+    {#if showContributorFields}
+      <div class="grid">
+        <label>
+          Email
+          <Input name="contributorEmail" type="email" bind:value={draft.contributorEmail} required />
+        </label>
+        <label>
+          Name
+          <Input name="contributorName" type="text" bind:value={draft.contributorName} />
+        </label>
       </div>
     {/if}
-  {/if}
 
-  <div class="actions">
-    <Button variant="primary" type="submit">{submitLabel}</Button>
-    {#if onCancel}
-      <Button variant="secondary" type="button" onclick={() => onCancel?.()}>
-        Cancel
-      </Button>
+    <label>
+      Title
+      <Input name="title" type="text" bind:value={draft.title} />
+    </label>
+
+    <label>
+      Description
+      <Textarea name="description" bind:value={draft.description} rows={2}></Textarea>
+    </label>
+
+    <label>
+      Body
+      <Textarea name="body" bind:value={draft.body} rows={8}></Textarea>
+    </label>
+
+    {#if activeType?.allowFiles !== false}
+      <label>
+        {t(M['content.contribution_form.attach_files'])}
+        <Input
+          name="files"
+          type="file"
+          multiple
+          onchange={handleFileChange}
+        />
+      </label>
+      {#if draft.files.length > 0}
+        <div class="file-list">
+          {#each draft.files as file (file.name + file.size)}
+            <span>{file.name} ({Math.max(1, Math.round(file.size / 1024))} KB)</span>
+          {/each}
+        </div>
+      {/if}
     {/if}
-  </div>
-</form>
+
+    <div class="actions">
+      <Button variant="primary" type="submit">{submitLabel}</Button>
+      {#if onCancel}
+        <Button variant="secondary" type="button" onclick={() => onCancel?.()}>
+          Cancel
+        </Button>
+      {/if}
+    </div>
+  </Form>
+</div>
 
 <style>
-  .contribution-form {
+  .contribution-form-shell :global(.contribution-form) {
     display: grid;
     gap: 0.85rem;
   }

--- a/packages/content/src/svelte/components/ContentContributionForm.svelte
+++ b/packages/content/src/svelte/components/ContentContributionForm.svelte
@@ -171,7 +171,8 @@ function handleSubmit(event: SubmitEvent) {
     {#if activeType?.allowFiles !== false}
       <label>
         {t(M['content.contribution_form.attach_files'])}
-        <Input
+        <!-- raw-primitive-allow: native file input — the Input primitive binds value, which is invalid for type=file (throws InvalidStateError on the bind write-back) and renders a visible control; a file picker stays native -->
+        <input
           name="files"
           type="file"
           multiple

--- a/packages/content/src/svelte/components/ContentContributionInbox.svelte
+++ b/packages/content/src/svelte/components/ContentContributionInbox.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Form, Input, Select, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type { ContentContributionData } from '../../mock-smrt-client';
@@ -183,28 +184,29 @@ $effect(() => {
             {/if}
           </dl>
 
-          <form
+          <Form
             method="post"
             action={workflowFormAction}
+            preventDefault={false}
             onsubmit={handleWorkflowSubmit}
           >
             {#if selectedContribution.id}
-              <input type="hidden" name="contributionId" value={selectedContribution.id} />
+              <Input type="hidden" name="contributionId" value={selectedContribution.id} />
             {/if}
 
             <label>
               {t(M['content.contribution_inbox.editorial_note'])}
-              <textarea name="editorNote" bind:value={note} rows="4"></textarea>
+              <Textarea name="editorNote" bind:value={note} rows={4}></Textarea>
             </label>
 
             <div class="actions">
               {#if onApprove || workflowFormAction}
                 <label class="inline">
                   {t(M['content.contribution_inbox.promote_to'])}
-                  <select name="targetStatus" bind:value={targetStatus}>
+                  <Select name="targetStatus" bind:value={targetStatus}>
                     <option value="draft">draft</option>
                     <option value="review">review</option>
-                  </select>
+                  </Select>
                 </label>
                 <Button
                   variant="primary"
@@ -241,7 +243,7 @@ $effect(() => {
                 </Button>
               {/if}
             </div>
-          </form>
+          </Form>
         </article>
       {/if}
     </div>
@@ -253,7 +255,7 @@ $effect(() => {
   .inbox__header,
   .inbox__layout,
   .inbox__detail,
-  .inbox__detail form {
+  .inbox__detail :global(.form) {
     display: grid;
     gap: 1rem;
   }

--- a/packages/content/src/svelte/components/ContentContributionTypeManager.svelte
+++ b/packages/content/src/svelte/components/ContentContributionTypeManager.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Form, Input, Select, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type { ContentContributionTypeData } from '../../mock-smrt-client';
@@ -138,103 +139,128 @@ function handleSubmit() {
       {/each}
     </div>
 
-    <form
-      class="editor"
-      onsubmit={(event) => {
-        event.preventDefault();
-        handleSubmit();
-      }}
-    >
-      <label>
-        Key
-        <input type="text" bind:value={draft.key} required />
-      </label>
-      <label>
-        Label
-        <input type="text" bind:value={draft.label} required />
-      </label>
-
-      <div class="checkbox-grid">
-        <label><input type="checkbox" bind:checked={draft.enabled} /> Enabled</label>
-        <label><input type="checkbox" bind:checked={draft.allowText} /> {t(M['content.contribution_type_manager.allow_text'])}</label>
-        <label><input type="checkbox" bind:checked={draft.allowFiles} /> {t(M['content.contribution_type_manager.allow_files'])}</label>
-        <label><input type="checkbox" bind:checked={draft.allowEmptyText} /> {t(M['content.contribution_type_manager.allow_empty_text'])}</label>
-      </div>
-
-      <div class="checkbox-grid">
+    <div class="editor-shell">
+      <Form
+        class="editor"
+        onsubmit={(event) => {
+          event.preventDefault();
+          handleSubmit();
+        }}
+      >
         <label>
-          <input
-            type="checkbox"
-            checked={draft.allowedChannels.includes('web')}
-            onchange={() => toggleChannel('web')}
-          />
-          Web
+          Key
+          <Input type="text" bind:value={draft.key} required />
         </label>
         <label>
-          <input
-            type="checkbox"
-            checked={draft.allowedChannels.includes('email')}
-            onchange={() => toggleChannel('email')}
-          />
-          Email
+          Label
+          <Input type="text" bind:value={draft.label} required />
         </label>
-      </div>
 
-      <label>
-        {t(M['content.contribution_type_manager.promotion_content_type'])}
-        <input type="text" bind:value={draft.promotion.targetContentType} required />
-      </label>
-      <label>
-        {t(M['content.contribution_type_manager.promotion_variant'])}
-        <input type="text" bind:value={draft.promotion.targetContentVariant} />
-      </label>
-      <label>
-        {t(M['content.contribution_type_manager.promotion_status'])}
-        <select bind:value={draft.promotion.targetContentStatus}>
-          <option value="draft">draft</option>
-          <option value="review">review</option>
-        </select>
-      </label>
+        <div class="checkbox-grid">
+          <label>
+            <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+            <input type="checkbox" bind:checked={draft.enabled} /> Enabled
+          </label>
+          <label>
+            <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+            <input type="checkbox" bind:checked={draft.allowText} /> {t(M['content.contribution_type_manager.allow_text'])}
+          </label>
+          <label>
+            <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+            <input type="checkbox" bind:checked={draft.allowFiles} /> {t(M['content.contribution_type_manager.allow_files'])}
+          </label>
+          <label>
+            <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+            <input type="checkbox" bind:checked={draft.allowEmptyText} /> {t(M['content.contribution_type_manager.allow_empty_text'])}
+          </label>
+        </div>
 
-      <div class="checkbox-grid">
-        <label><input type="checkbox" bind:checked={draft.promotion.autoPromoteTrusted} /> {t(M['content.contribution_type_manager.auto_promote_trusted'])}</label>
-        <label><input type="checkbox" bind:checked={draft.promotion.createAssets} /> {t(M['content.contribution_type_manager.create_assets_on_promotion'])}</label>
-        <label><input type="checkbox" bind:checked={draft.intakeRules.trustedOnly} /> {t(M['content.contribution_type_manager.trusted_contributors_only'])}</label>
-      </div>
+        <div class="checkbox-grid">
+          <label>
+            <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+            <input
+              type="checkbox"
+              checked={draft.allowedChannels.includes('web')}
+              onchange={() => toggleChannel('web')}
+            />
+            Web
+          </label>
+          <label>
+            <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+            <input
+              type="checkbox"
+              checked={draft.allowedChannels.includes('email')}
+              onchange={() => toggleChannel('email')}
+            />
+            Email
+          </label>
+        </div>
 
-      <label>
-        {t(M['content.contribution_type_manager.max_files'])}
-        <input type="number" min="0" bind:value={draft.intakeRules.maxFiles} />
-      </label>
-      <label>
-        {t(M['content.contribution_type_manager.max_total_bytes'])}
-        <input type="number" min="0" bind:value={draft.intakeRules.maxTotalBytes} />
-      </label>
-      <label>
-        {t(M['content.contribution_type_manager.allowed_mime_patterns'])}
-        <input type="text" bind:value={draft.intakeRules.allowedMimePatterns} placeholder={t(M['content.contribution_type_manager.allowed_mime_patterns_placeholder'])} />
-      </label>
-      <label>
-        {t(M['content.contribution_type_manager.blocked_mime_patterns'])}
-        <input type="text" bind:value={draft.intakeRules.blockedMimePatterns} />
-      </label>
-      <label>
-        {t(M['content.contribution_type_manager.quarantine_mime_patterns'])}
-        <input type="text" bind:value={draft.intakeRules.quarantineMimePatterns} />
-      </label>
-      <label>
-        {t(M['content.contribution_type_manager.blocked_text_patterns'])}
-        <textarea bind:value={draft.intakeRules.blockedTextPatterns} rows="2"></textarea>
-      </label>
-      <label>
-        {t(M['content.contribution_type_manager.quarantine_text_patterns'])}
-        <textarea bind:value={draft.intakeRules.quarantineTextPatterns} rows="2"></textarea>
-      </label>
+        <label>
+          {t(M['content.contribution_type_manager.promotion_content_type'])}
+          <Input type="text" bind:value={draft.promotion.targetContentType} required />
+        </label>
+        <label>
+          {t(M['content.contribution_type_manager.promotion_variant'])}
+          <Input type="text" bind:value={draft.promotion.targetContentVariant} />
+        </label>
+        <label>
+          {t(M['content.contribution_type_manager.promotion_status'])}
+          <Select bind:value={draft.promotion.targetContentStatus}>
+            <option value="draft">draft</option>
+            <option value="review">review</option>
+          </Select>
+        </label>
 
-      <div class="actions">
-        <Button variant="primary" type="submit">{t(M['content.contribution_type_manager.save_type'])}</Button>
-      </div>
-    </form>
+        <div class="checkbox-grid">
+          <label>
+            <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+            <input type="checkbox" bind:checked={draft.promotion.autoPromoteTrusted} /> {t(M['content.contribution_type_manager.auto_promote_trusted'])}
+          </label>
+          <label>
+            <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+            <input type="checkbox" bind:checked={draft.promotion.createAssets} /> {t(M['content.contribution_type_manager.create_assets_on_promotion'])}
+          </label>
+          <label>
+            <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+            <input type="checkbox" bind:checked={draft.intakeRules.trustedOnly} /> {t(M['content.contribution_type_manager.trusted_contributors_only'])}
+          </label>
+        </div>
+
+        <label>
+          {t(M['content.contribution_type_manager.max_files'])}
+          <Input type="number" min="0" bind:value={draft.intakeRules.maxFiles} />
+        </label>
+        <label>
+          {t(M['content.contribution_type_manager.max_total_bytes'])}
+          <Input type="number" min="0" bind:value={draft.intakeRules.maxTotalBytes} />
+        </label>
+        <label>
+          {t(M['content.contribution_type_manager.allowed_mime_patterns'])}
+          <Input type="text" bind:value={draft.intakeRules.allowedMimePatterns} placeholder={t(M['content.contribution_type_manager.allowed_mime_patterns_placeholder'])} />
+        </label>
+        <label>
+          {t(M['content.contribution_type_manager.blocked_mime_patterns'])}
+          <Input type="text" bind:value={draft.intakeRules.blockedMimePatterns} />
+        </label>
+        <label>
+          {t(M['content.contribution_type_manager.quarantine_mime_patterns'])}
+          <Input type="text" bind:value={draft.intakeRules.quarantineMimePatterns} />
+        </label>
+        <label>
+          {t(M['content.contribution_type_manager.blocked_text_patterns'])}
+          <Textarea bind:value={draft.intakeRules.blockedTextPatterns} rows={2}></Textarea>
+        </label>
+        <label>
+          {t(M['content.contribution_type_manager.quarantine_text_patterns'])}
+          <Textarea bind:value={draft.intakeRules.quarantineTextPatterns} rows={2}></Textarea>
+        </label>
+
+        <div class="actions">
+          <Button variant="primary" type="submit">{t(M['content.contribution_type_manager.save_type'])}</Button>
+        </div>
+      </Form>
+    </div>
   </div>
 </section>
 
@@ -242,7 +268,7 @@ function handleSubmit() {
   .manager,
   .layout,
   .list,
-  .editor {
+  .editor-shell :global(.editor) {
     display: grid;
     gap: 1rem;
   }
@@ -252,7 +278,7 @@ function handleSubmit() {
   }
 
   .card,
-  .editor {
+  .editor-shell :global(.editor) {
     border: 1px solid var(--smrt-color-outline-variant);
     border-radius: 0.75rem;
     padding: 0.9rem;
@@ -269,7 +295,7 @@ function handleSubmit() {
     flex-wrap: wrap;
   }
 
-  .editor label {
+  .editor-shell label {
     display: grid;
     gap: 0.35rem;
   }

--- a/packages/content/src/svelte/components/ContentContributorManager.svelte
+++ b/packages/content/src/svelte/components/ContentContributorManager.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Form, Input, Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type { ContentContributorData } from '../../mock-smrt-client';
@@ -67,34 +68,36 @@ function handleSubmit() {
       {/each}
     </div>
 
-    <form
-      class="editor"
-      onsubmit={(event) => {
-        event.preventDefault();
-        handleSubmit();
-      }}
-    >
-      <label>
-        Email
-        <input type="email" bind:value={draft.email} required />
-      </label>
-      <label>
-        Name
-        <input type="text" bind:value={draft.name} />
-      </label>
-      <label>
-        {t(M['content.contributor_manager.trust_level'])}
-        <select bind:value={draft.trustLevel}>
-          <option value="standard">standard</option>
-          <option value="trusted">trusted</option>
-          <option value="blocked">blocked</option>
-        </select>
-      </label>
+    <div class="editor-shell">
+      <Form
+        class="editor"
+        onsubmit={(event) => {
+          event.preventDefault();
+          handleSubmit();
+        }}
+      >
+        <label>
+          Email
+          <Input type="email" bind:value={draft.email} required />
+        </label>
+        <label>
+          Name
+          <Input type="text" bind:value={draft.name} />
+        </label>
+        <label>
+          {t(M['content.contributor_manager.trust_level'])}
+          <Select bind:value={draft.trustLevel}>
+            <option value="standard">standard</option>
+            <option value="trusted">trusted</option>
+            <option value="blocked">blocked</option>
+          </Select>
+        </label>
 
-      <div class="actions">
-        <Button variant="primary" type="submit">{t(M['content.contributor_manager.save_contributor'])}</Button>
-      </div>
-    </form>
+        <div class="actions">
+          <Button variant="primary" type="submit">{t(M['content.contributor_manager.save_contributor'])}</Button>
+        </div>
+      </Form>
+    </div>
   </div>
 </section>
 
@@ -102,7 +105,7 @@ function handleSubmit() {
   .manager,
   .layout,
   .list,
-  .editor {
+  .editor-shell :global(.editor) {
     display: grid;
     gap: 1rem;
   }
@@ -112,7 +115,7 @@ function handleSubmit() {
   }
 
   .card,
-  .editor {
+  .editor-shell :global(.editor) {
     border: 1px solid var(--smrt-color-outline-variant);
     border-radius: 0.75rem;
     padding: 0.9rem;
@@ -128,7 +131,7 @@ function handleSubmit() {
     flex-wrap: wrap;
   }
 
-  .editor label {
+  .editor-shell label {
     display: grid;
     gap: 0.35rem;
   }

--- a/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
+++ b/packages/content/src/svelte/components/ContentCorrectionsTool.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Input, Select, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type { ContentCorrectionData, FactData } from '../../mock-smrt-client';
@@ -173,7 +174,7 @@ async function issueCorrection() {
   {:else}
     <label class="workflow-field">
       Summary
-      <input
+      <Input
         type="text"
         bind:value={correctionSummary}
         placeholder={t(M['content.corrections_tool.what_was_wrong'])}
@@ -182,33 +183,34 @@ async function issueCorrection() {
 
     <label class="workflow-field">
       {t(M['content.corrections_tool.related_fact'])}
-      <select bind:value={correctionFactId}>
+      <Select bind:value={correctionFactId}>
         <option value="">{t(M['content.corrections_tool.general_correction'])}</option>
         {#each facts as fact (fact.id)}
           <option value={fact.id ?? ''}>{fact.textRefined}</option>
         {/each}
-      </select>
+      </Select>
     </label>
 
     <label class="workflow-field">
       {t(M['content.corrections_tool.corrected_fact_text'])}
-      <textarea
-        rows="4"
+      <Textarea
+        rows={4}
         bind:value={correctedFactText}
         placeholder={t(M['content.corrections_tool.provide_corrected_wording'])}
-      ></textarea>
+      ></Textarea>
     </label>
 
     <label class="workflow-field">
       {t(M['content.corrections_tool.public_note'])}
-      <textarea
-        rows="3"
+      <Textarea
+        rows={3}
         bind:value={correctionPublicNote}
         placeholder={t(M['content.corrections_tool.optional_public_correction_note'])}
-      ></textarea>
+      ></Textarea>
     </label>
 
     <label class="checkbox-row">
+      <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
       <input type="checkbox" bind:checked={publishCorrection} />
       {t(M['content.corrections_tool.publish_immediately'])}
     </label>
@@ -258,19 +260,6 @@ async function issueCorrection() {
     color: var(--smrt-color-on-surface-variant);
     font-size: var(--smrt-typography-label-large-size, 0.875rem);
     font-weight: var(--smrt-typography-weight-medium, 500);
-  }
-
-  .workflow-field input,
-  .workflow-field textarea,
-  .workflow-field select {
-    width: 100%;
-    box-sizing: border-box;
-    padding: 0.75rem;
-    border-radius: 0.5rem;
-    border: 1px solid var(--smrt-color-outline);
-    background: var(--smrt-color-surface);
-    color: var(--smrt-color-on-surface);
-    font-family: inherit;
   }
 
   .tool-card {

--- a/packages/content/src/svelte/components/ContentEditor.svelte
+++ b/packages/content/src/svelte/components/ContentEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { ImageLike } from '@happyvertical/smrt-images/svelte';
 import { ImageUploader } from '@happyvertical/smrt-images/svelte';
+import { Form, Input, Select, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { untrack } from 'svelte';
@@ -75,10 +76,12 @@ let {
   onCancel,
 }: Props = $props();
 
-let editForm = $state<HTMLFormElement | null>(null);
-
 export function triggerSave() {
   if (saveDisabled) return;
+  const editForm =
+    typeof document !== 'undefined'
+      ? (document.getElementById('content-edit-form') as HTMLFormElement | null)
+      : null;
   if (editForm?.requestSubmit) {
     editForm.requestSubmit();
     return;
@@ -921,8 +924,7 @@ function removeAsset(id: string) {
 <div class="form-container">
   <div class="editor-grid" class:editor-grid--with-sidebar={showChatSidebar}>
     <!-- LEFT COLUMN (Document Canvas) -->
-    <form
-      bind:this={editForm}
+    <Form
       id="content-edit-form"
       class="editor-main-col"
       onsubmit={handleSubmit}
@@ -947,31 +949,31 @@ function removeAsset(id: string) {
       <div class="editor-toolbar">
         <div class="editor-toolbar-left">
           <div class="mui-field">
-            <select id="type-select" bind:value={formData.type} class="mui-input">
+            <Select id="type-select" bind:value={formData.type} class="mui-input">
               <option value="article">Article</option>
               <option value="document">Document</option>
               <option value="mirror">Mirror</option>
-            </select>
+            </Select>
             <label for="type-select">Type</label>
           </div>
           <div class="mui-field">
-            <select id="state-select" bind:value={formData.state} class="mui-input">
+            <Select id="state-select" bind:value={formData.state} class="mui-input">
               <option value="active">Active</option>
               <option value="highlighted">Highlighted</option>
               <option value="deprecated">Deprecated</option>
-            </select>
+            </Select>
             <label for="state-select">State</label>
           </div>
           <div class="mui-field">
-            <select id="status-select" bind:value={formData.status} class="mui-input">
+            <Select id="status-select" bind:value={formData.status} class="mui-input">
               <option value="draft">Draft</option>
               <option value="published">Published</option>
               <option value="archived">Archived</option>
-            </select>
+            </Select>
             <label for="status-select">Status</label>
           </div>
           <div class="mui-field">
-            <input id="publish-date-input" type="datetime-local" bind:value={formData.publish_date} class="mui-input" />
+            <Input id="publish-date-input" type="datetime-local" bind:value={formData.publish_date} class="mui-input" />
             <label for="publish-date-input">{t(M['content.content_editor.publish_date'])}</label>
           </div>
         </div>
@@ -989,12 +991,12 @@ function removeAsset(id: string) {
         <p class="save-notice">{saveNotice}</p>
       {/if}
 
-      <input 
-         type="text" 
-         class="document-title-input" 
+      <Input
+         type="text"
+         class="document-title-input"
          bind:value={formData.title}
          placeholder={t(M['content.content_editor.document_title_placeholder'])}
-         required 
+         required
       />
 
       {#if showUndoBanner}
@@ -1139,15 +1141,15 @@ function removeAsset(id: string) {
         <div class="editor-drawer-content">
           <label>
             Author:
-            <input type="text" bind:value={formData.author} placeholder={t(M['content.content_editor.author_name_placeholder'])} />
+            <Input type="text" bind:value={formData.author} placeholder={t(M['content.content_editor.author_name_placeholder'])} />
           </label>
           <label>
             Description:
-            <textarea bind:value={formData.description} rows="2" placeholder={t(M['content.content_editor.brief_summary_placeholder'])}></textarea>
+            <Textarea bind:value={formData.description} rows={2} placeholder={t(M['content.content_editor.brief_summary_placeholder'])}></Textarea>
           </label>
           <label>
             {t(M['content.content_editor.tags_comma_separated'])}
-            <input
+            <Input
               type="text"
               value={(formData.tags || []).join(', ')}
               placeholder={t(M['content.content_editor.tags_placeholder'])}
@@ -1205,11 +1207,11 @@ function removeAsset(id: string) {
                            : M['content.content_editor.evidence_item_plural'],
                        ),
                      })}</span>
-                     <select bind:value={bulkEvidenceStatus} disabled={selectedEvidenceCount === 0 || Boolean(evidenceBusy)}>
+                     <Select bind:value={bulkEvidenceStatus} disabled={selectedEvidenceCount === 0 || Boolean(evidenceBusy)}>
                        {#each evidenceStatuses as status}
                          <option value={status}>{status}</option>
                        {/each}
-                     </select>
+                     </Select>
                      <Button
                        variant="ghost"
                        size="sm"
@@ -1273,6 +1275,7 @@ function removeAsset(id: string) {
                              <details class="resource-claim">
                                <summary>
                                  <label class="evidence-select">
+                                   <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
                                    <input
                                      type="checkbox"
                                      checked={isResourceClaimSelected(claim)}
@@ -1356,22 +1359,22 @@ function removeAsset(id: string) {
                  </div>
                {/if}
                <div class="add-reference-row">
-                  <input type="text" bind:value={newReferenceId} placeholder={t(M['content.content_editor.reference_id_or_url_placeholder'])} />
+                  <Input type="text" bind:value={newReferenceId} placeholder={t(M['content.content_editor.reference_id_or_url_placeholder'])} />
                   <Button variant="ghost" type="button" class="add-reference-button" onclick={addReference}>Add</Button>
                </div>
             </div>
 
             <label>
               URL:
-              <input type="url" bind:value={formData.url} />
+              <Input type="url" bind:value={formData.url} />
             </label>
             <label>
               {t(M['content.content_editor.file_key'])}
-              <input type="text" bind:value={formData.fileKey} />
+              <Input type="text" bind:value={formData.fileKey} />
             </label>
           </div>
       </details>
-    </form>
+    </Form>
 
     {#if showChatSidebar}
       <aside class="editor-sidebar-col">
@@ -1430,7 +1433,7 @@ function removeAsset(id: string) {
     }
   }
 
-  .document-title-input {
+  .form-container :global(.document-title-input) {
     width: 100%;
     font-size: var(--smrt-typography-display-medium-size, 2.5rem);
     font-weight: var(--smrt-typography-weight-bold, 800);
@@ -1445,7 +1448,7 @@ function removeAsset(id: string) {
     font-family: inherit;
   }
 
-  .document-title-input::placeholder {
+  .form-container :global(.document-title-input)::placeholder {
     color: var(--smrt-color-outline-variant);
   }
 
@@ -1504,7 +1507,7 @@ function removeAsset(id: string) {
     z-index: 1;
   }
 
-  .mui-input {
+  .mui-field :global(.mui-input) {
     padding: 0.5rem 0.75rem;
     border-radius: 0.375rem;
     border: 1px solid var(--smrt-color-outline-variant);
@@ -1518,13 +1521,12 @@ function removeAsset(id: string) {
     transition: border-color 0.2s;
   }
 
-  .mui-input:focus {
+  .mui-field :global(.mui-input:focus) {
     outline: none;
     border-color: var(--smrt-color-primary);
   }
 
-  .editor-main-col {
-    display: flex;
+  .form-container :global(.editor-main-col) {
     flex-direction: column;
     background: transparent;
   }
@@ -1612,7 +1614,7 @@ function removeAsset(id: string) {
     font-size: var(--smrt-typography-headline-small-size, 1.5rem);
   }
 
-  .form-container form {
+  .form-container :global(.editor-main-col) {
     display: block;
     width: 100%;
   }
@@ -1626,34 +1628,6 @@ function removeAsset(id: string) {
     font-size: var(--smrt-typography-label-large-size, 0.875rem);
   }
 
-  .form-container input,
-  .form-container select,
-  .form-container textarea {
-    padding: 0.75rem;
-    border: 1px solid var(--smrt-color-outline);
-    border-radius: 0.5rem;
-    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    transition: border-color 0.2s, box-shadow 0.2s;
-    font-family: inherit;
-    box-sizing: border-box;
-    width: 100%;
-    background: var(--smrt-color-surface-container-low);
-    color: var(--smrt-color-on-surface);
-  }
-
-  .form-container input:focus,
-  .form-container select:focus,
-  .form-container textarea:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--smrt-color-primary) 10%, transparent);
-  }
-
-  .form-container textarea {
-    resize: vertical;
-    min-height: 120px;
-  }
-  
   .references-section {
     display: flex;
     flex-direction: column;
@@ -1775,7 +1749,7 @@ function removeAsset(id: string) {
     font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
   }
 
-  .evidence-bulk-toolbar select {
+  .evidence-bulk-toolbar :global(.select) {
     border: 1px solid var(--smrt-color-outline-variant);
     border-radius: 0.375rem;
     padding: 0.25rem 0.5rem;
@@ -1953,7 +1927,7 @@ function removeAsset(id: string) {
     gap: 0.5rem;
   }
   
-  .add-reference-row input {
+  .add-reference-row :global(.input) {
     flex: 1;
   }
 

--- a/packages/content/src/svelte/components/ContentEditor.svelte
+++ b/packages/content/src/svelte/components/ContentEditor.svelte
@@ -76,11 +76,16 @@ let {
   onCancel,
 }: Props = $props();
 
+// Unique per-instance form id so triggerSave() targets THIS editor's form even
+// when multiple ContentEditor / GovernedContentEditor instances are mounted
+// (a hardcoded id + getElementById would resolve to the first match in the DOM).
+const formId = $props.id();
+
 export function triggerSave() {
   if (saveDisabled) return;
   const editForm =
     typeof document !== 'undefined'
-      ? (document.getElementById('content-edit-form') as HTMLFormElement | null)
+      ? (document.getElementById(formId) as HTMLFormElement | null)
       : null;
   if (editForm?.requestSubmit) {
     editForm.requestSubmit();
@@ -925,7 +930,7 @@ function removeAsset(id: string) {
   <div class="editor-grid" class:editor-grid--with-sidebar={showChatSidebar}>
     <!-- LEFT COLUMN (Document Canvas) -->
     <Form
-      id="content-edit-form"
+      id={formId}
       class="editor-main-col"
       onsubmit={handleSubmit}
     >
@@ -1527,8 +1532,10 @@ function removeAsset(id: string) {
   }
 
   .form-container :global(.editor-main-col) {
+    display: flex;
     flex-direction: column;
     background: transparent;
+    width: 100%;
   }
 
   .editor-sidebar-col {
@@ -1612,11 +1619,6 @@ function removeAsset(id: string) {
     margin: 0;
     color: var(--smrt-color-on-surface);
     font-size: var(--smrt-typography-headline-small-size, 1.5rem);
-  }
-
-  .form-container :global(.editor-main-col) {
-    display: block;
-    width: 100%;
   }
 
   .form-container label {

--- a/packages/content/src/svelte/components/ContentEditor.test.ts
+++ b/packages/content/src/svelte/components/ContentEditor.test.ts
@@ -428,7 +428,7 @@ describe('ContentEditor component', () => {
     });
 
     target
-      .querySelector('#content-edit-form')
+      .querySelector('form.editor-main-col')
       ?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
 
     expect(onSave).toHaveBeenCalledWith(
@@ -471,7 +471,7 @@ describe('ContentEditor component', () => {
     flushSync();
 
     target
-      .querySelector('#content-edit-form')
+      .querySelector('form.editor-main-col')
       ?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
 
     expect(onSave).toHaveBeenCalledWith(
@@ -536,7 +536,7 @@ describe('ContentEditor component', () => {
     );
 
     target
-      .querySelector('#content-edit-form')
+      .querySelector('form.editor-main-col')
       ?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
 
     expect(onSave).toHaveBeenCalledWith(
@@ -595,7 +595,7 @@ describe('ContentEditor component', () => {
     );
 
     target
-      .querySelector('#content-edit-form')
+      .querySelector('form.editor-main-col')
       ?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
 
     expect(onSave).toHaveBeenCalledWith(
@@ -754,7 +754,7 @@ describe('ContentEditor component', () => {
     flushSync();
 
     target
-      .querySelector('#content-edit-form')
+      .querySelector('form.editor-main-col')
       ?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
 
     expect(onSave).toHaveBeenCalledWith(
@@ -773,7 +773,7 @@ describe('ContentEditor component', () => {
     flushSync();
 
     target
-      .querySelector('#content-edit-form')
+      .querySelector('form.editor-main-col')
       ?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
 
     expect(onSave.mock.calls[1]?.[0].body).not.toContain(
@@ -862,7 +862,7 @@ describe('ContentEditor component', () => {
     flushSync();
 
     target
-      .querySelector('#content-edit-form')
+      .querySelector('form.editor-main-col')
       ?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
 
     const saved = onSave.mock.calls[0]?.[0];
@@ -941,7 +941,7 @@ describe('ContentEditor component', () => {
     ).find((input) =>
       (input as HTMLInputElement).placeholder.includes('e.g. news, tech'),
     ) as HTMLInputElement | undefined;
-    const form = target.querySelector('#content-edit-form');
+    const form = target.querySelector('form.editor-main-col');
 
     expect(tagsInput).toBeDefined();
     if (!tagsInput) {
@@ -979,7 +979,7 @@ describe('ContentEditor component', () => {
     const publishDateInput = target.querySelector(
       '#publish-date-input',
     ) as HTMLInputElement | null;
-    const form = target.querySelector('#content-edit-form');
+    const form = target.querySelector('form.editor-main-col');
 
     expect(publishDateInput).not.toBeNull();
     if (!publishDateInput) {
@@ -1016,7 +1016,7 @@ describe('ContentEditor component', () => {
     });
 
     target
-      .querySelector('#content-edit-form')
+      .querySelector('form.editor-main-col')
       ?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
 
     expect(onSave).toHaveBeenCalledWith(
@@ -1045,7 +1045,7 @@ describe('ContentEditor component', () => {
     const typeSelect = target.querySelector(
       '#type-select',
     ) as HTMLSelectElement | null;
-    const form = target.querySelector('#content-edit-form');
+    const form = target.querySelector('form.editor-main-col');
 
     expect(typeSelect).not.toBeNull();
     if (!typeSelect) {

--- a/packages/content/src/svelte/components/ContentGovernanceAssignmentEditor.svelte
+++ b/packages/content/src/svelte/components/ContentGovernanceAssignmentEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Form, Input, Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type {
@@ -95,81 +96,87 @@ function handleSubmit() {
 }
 </script>
 
-<form class="governance-editor" onsubmit={(event) => {
-  event.preventDefault();
-  handleSubmit();
-}}>
-  <label>
-    Label
-    <input type="text" bind:value={draft.label} />
-  </label>
-  <label>
-    {t(M['content.governance_assignment_editor.content_type'])}
-    <input type="text" bind:value={draft.contentType} required />
-  </label>
-  <label>
-    {t(M['content.governance_assignment_editor.content_variant'])}
-    <input type="text" bind:value={draft.contentVariant} />
-  </label>
-  <label>
-    {t(M['content.governance_assignment_editor.publication_profile'])}
-    <select bind:value={draft.publicationProfileKey}>
-      <option value="" disabled={profiles.length > 0}>{t(M['content.governance_assignment_editor.select_a_profile'])}</option>
-      {#each profiles as profile (profile.key)}
-        <option value={profile.key}>{profile.label}</option>
-      {/each}
-    </select>
-  </label>
-  <label>
-    {t(M['content.governance_assignment_editor.correction_profile'])}
-    <select bind:value={draft.correctionProfileKey}>
-      <option value="" disabled={profiles.length > 0}>{t(M['content.governance_assignment_editor.select_a_profile'])}</option>
-      {#each profiles as profile (profile.key)}
-        <option value={profile.key}>{profile.label}</option>
-      {/each}
-    </select>
-  </label>
-  <label>
-    {t(M['content.governance_assignment_editor.default_fact_relationship'])}
-    <select bind:value={draft.defaultFactRelationship}>
-      <option value="supports">supports</option>
-      <option value="referenced_in">referenced_in</option>
-      <option value="contradicts">contradicts</option>
-      <option value="related">related</option>
-    </select>
-  </label>
+<div class="governance-editor-shell">
+  <Form class="governance-editor" onsubmit={(event) => {
+    event.preventDefault();
+    handleSubmit();
+  }}>
+    <label>
+      Label
+      <Input type="text" bind:value={draft.label} />
+    </label>
+    <label>
+      {t(M['content.governance_assignment_editor.content_type'])}
+      <Input type="text" bind:value={draft.contentType} required />
+    </label>
+    <label>
+      {t(M['content.governance_assignment_editor.content_variant'])}
+      <Input type="text" bind:value={draft.contentVariant} />
+    </label>
+    <label>
+      {t(M['content.governance_assignment_editor.publication_profile'])}
+      <Select bind:value={draft.publicationProfileKey}>
+        <option value="" disabled={profiles.length > 0}>{t(M['content.governance_assignment_editor.select_a_profile'])}</option>
+        {#each profiles as profile (profile.key)}
+          <option value={profile.key}>{profile.label}</option>
+        {/each}
+      </Select>
+    </label>
+    <label>
+      {t(M['content.governance_assignment_editor.correction_profile'])}
+      <Select bind:value={draft.correctionProfileKey}>
+        <option value="" disabled={profiles.length > 0}>{t(M['content.governance_assignment_editor.select_a_profile'])}</option>
+        {#each profiles as profile (profile.key)}
+          <option value={profile.key}>{profile.label}</option>
+        {/each}
+      </Select>
+    </label>
+    <label>
+      {t(M['content.governance_assignment_editor.default_fact_relationship'])}
+      <Select bind:value={draft.defaultFactRelationship}>
+        <option value="supports">supports</option>
+        <option value="referenced_in">referenced_in</option>
+        <option value="contradicts">contradicts</option>
+        <option value="related">related</option>
+      </Select>
+    </label>
 
-  <div class="checkbox-grid">
-    <label class="checkbox">
-      <input type="checkbox" bind:checked={draft.enabled} />
-      Enabled
-    </label>
-    <label class="checkbox">
-      <input type="checkbox" bind:checked={draft.factLinkingEnabled} />
-      {t(M['content.governance_assignment_editor.fact_linking'])}
-    </label>
-    <label class="checkbox">
-      <input type="checkbox" bind:checked={draft.transparencyEnabled} />
-      Transparency
-    </label>
-    <label class="checkbox">
-      <input type="checkbox" bind:checked={draft.enforcePublishReadiness} />
-      {t(M['content.governance_assignment_editor.enforce_publish_readiness'])}
-    </label>
-  </div>
+    <div class="checkbox-grid">
+      <label class="checkbox">
+        <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+        <input type="checkbox" bind:checked={draft.enabled} />
+        Enabled
+      </label>
+      <label class="checkbox">
+        <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+        <input type="checkbox" bind:checked={draft.factLinkingEnabled} />
+        {t(M['content.governance_assignment_editor.fact_linking'])}
+      </label>
+      <label class="checkbox">
+        <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+        <input type="checkbox" bind:checked={draft.transparencyEnabled} />
+        Transparency
+      </label>
+      <label class="checkbox">
+        <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+        <input type="checkbox" bind:checked={draft.enforcePublishReadiness} />
+        {t(M['content.governance_assignment_editor.enforce_publish_readiness'])}
+      </label>
+    </div>
 
-  <div class="actions">
-    <Button variant="primary" type="submit">{t(M['content.governance_assignment_editor.save_assignment'])}</Button>
-    {#if onCancel}
-      <Button variant="secondary" type="button" onclick={() => onCancel?.()}>
-        Cancel
-      </Button>
-    {/if}
-  </div>
-</form>
+    <div class="actions">
+      <Button variant="primary" type="submit">{t(M['content.governance_assignment_editor.save_assignment'])}</Button>
+      {#if onCancel}
+        <Button variant="secondary" type="button" onclick={() => onCancel?.()}>
+          Cancel
+        </Button>
+      {/if}
+    </div>
+  </Form>
+</div>
 
 <style>
-  .governance-editor {
+  .governance-editor-shell :global(.governance-editor) {
     display: grid;
     gap: 0.75rem;
   }
@@ -178,11 +185,6 @@ function handleSubmit() {
     display: grid;
     gap: 0.35rem;
     font-size: var(--smrt-typography-label-large-size, 0.9rem);
-  }
-
-  input,
-  select {
-    width: 100%;
   }
 
   .checkbox-grid,

--- a/packages/content/src/svelte/components/ContentGovernancePanel.svelte
+++ b/packages/content/src/svelte/components/ContentGovernancePanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { ConfirmDialog } from '@happyvertical/smrt-ui/feedback';
+import { Input, Select, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import {
@@ -1128,6 +1129,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
                   <details class="claim-audit-item">
                     <summary>
                       <label class="claim-audit-select">
+                        <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
                         <input
                           type="checkbox"
                           checked={isClaimSelected(claim)}
@@ -1251,7 +1253,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
 
           {#if showFactCatalog}
             <div class="fact-search">
-              <input
+              <Input
                 type="text"
                 bind:value={factQuery}
                 placeholder={t(M['content.governance_panel.search_fact_catalog'])}
@@ -1361,13 +1363,13 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
       {#if reviewProfiles.length > 0}
         <label class="workflow-field">
           {t(M['content.governance_panel.review_profile'])}
-          <select bind:value={activeReviewProfileKey}>
+          <Select bind:value={activeReviewProfileKey}>
             {#each reviewProfiles as profile (profile.profileKey)}
               <option value={profile.profileKey}>
                 {formatProfileLabel(profile.profileKey)}
               </option>
             {/each}
-          </select>
+          </Select>
         </label>
       {/if}
 
@@ -1440,23 +1442,23 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
         {#if availableCustomPolicies.length > 0}
           <label class="workflow-field">
             {t(M['content.governance_panel.app_review_policy'])}
-            <select bind:value={activeCustomPolicyKey}>
+            <Select bind:value={activeCustomPolicyKey}>
               {#each availableCustomPolicies as policy (policy.key)}
                 <option value={policy.key}>
                   {policy.label}
                 </option>
               {/each}
-            </select>
+            </Select>
           </label>
         {/if}
 
         <label class="workflow-field">
           {customReviewButtonLabel}
-          <textarea
-            rows="3"
+          <Textarea
+            rows={3}
             bind:value={customReviewText}
             placeholder={t(M['content.governance_panel.optional_review_instructions'])}
-          ></textarea>
+          ></Textarea>
         </label>
         <Button
           variant="primary"
@@ -1666,7 +1668,7 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
 
         <label class="workflow-field">
           Summary
-          <input
+          <Input
             type="text"
             bind:value={correctionSummary}
             placeholder={t(M['content.governance_panel.what_was_wrong'])}
@@ -1675,33 +1677,34 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
 
         <label class="workflow-field">
           {t(M['content.governance_panel.related_fact'])}
-          <select bind:value={correctionFactId}>
+          <Select bind:value={correctionFactId}>
             <option value="">{t(M['content.governance_panel.general_correction'])}</option>
             {#each selectedFactsResolved as fact (fact.id)}
               <option value={fact.id ?? ''}>{fact.textRefined}</option>
             {/each}
-          </select>
+          </Select>
         </label>
 
         <label class="workflow-field">
           {t(M['content.governance_panel.corrected_fact_text'])}
-          <textarea
-            rows="4"
+          <Textarea
+            rows={4}
             bind:value={correctedFactText}
             placeholder={t(M['content.governance_panel.provide_corrected_wording'])}
-          ></textarea>
+          ></Textarea>
         </label>
 
         <label class="workflow-field">
           {t(M['content.governance_panel.public_note'])}
-          <textarea
-            rows="3"
+          <Textarea
+            rows={3}
             bind:value={correctionPublicNote}
             placeholder={t(M['content.governance_panel.optional_public_correction_note'])}
-          ></textarea>
+          ></Textarea>
         </label>
 
         <label class="checkbox-row">
+          <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
           <input type="checkbox" bind:checked={publishCorrection} />
           {t(M['content.governance_panel.publish_immediately'])}
         </label>
@@ -1928,20 +1931,6 @@ function getVersionProvenanceCopy(version: ContentVersionData) {
     flex-wrap: wrap;
     color: var(--smrt-color-on-surface-variant);
     font-size: var(--smrt-typography-body-medium-size, 0.85rem);
-  }
-
-  .fact-search input,
-  .workflow-field input,
-  .workflow-field textarea,
-  .workflow-field select {
-    width: 100%;
-    box-sizing: border-box;
-    padding: 0.75rem;
-    border-radius: 0.5rem;
-    border: 1px solid var(--smrt-color-outline);
-    background: var(--smrt-color-surface);
-    color: var(--smrt-color-on-surface);
-    font-family: inherit;
   }
 
   .workflow-field {

--- a/packages/content/src/svelte/components/ContentGovernancePolicyEditor.svelte
+++ b/packages/content/src/svelte/components/ContentGovernancePolicyEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Form, Input, Select, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type { ContentReviewPolicyData } from '../../mock-smrt-client';
@@ -42,46 +43,49 @@ function handleSubmit() {
 }
 </script>
 
-<form class="governance-editor" onsubmit={(event) => {
-  event.preventDefault();
-  handleSubmit();
-}}>
-  <label>
-    Key
-    <input type="text" bind:value={draft.key} required />
-  </label>
-  <label>
-    Label
-    <input type="text" bind:value={draft.label} />
-  </label>
-  <label>
-    Kind
-    <select bind:value={draft.kind}>
-      <option value="facts">Facts</option>
-      <option value="safety">Safety</option>
-      <option value="custom">Custom</option>
-    </select>
-  </label>
-  <label>
-    Instructions
-    <textarea rows="4" bind:value={draft.instructions}></textarea>
-  </label>
-  <label class="checkbox">
-    <input type="checkbox" bind:checked={draft.enabled} />
-    Enabled
-  </label>
-  <div class="actions">
-    <Button variant="primary" type="submit">{t(M['content.governance_policy_editor.save_policy'])}</Button>
-    {#if onCancel}
-      <Button variant="secondary" type="button" onclick={() => onCancel?.()}>
-        Cancel
-      </Button>
-    {/if}
-  </div>
-</form>
+<div class="governance-editor-shell">
+  <Form class="governance-editor" onsubmit={(event) => {
+    event.preventDefault();
+    handleSubmit();
+  }}>
+    <label>
+      Key
+      <Input type="text" bind:value={draft.key} required />
+    </label>
+    <label>
+      Label
+      <Input type="text" bind:value={draft.label} />
+    </label>
+    <label>
+      Kind
+      <Select bind:value={draft.kind}>
+        <option value="facts">Facts</option>
+        <option value="safety">Safety</option>
+        <option value="custom">Custom</option>
+      </Select>
+    </label>
+    <label>
+      Instructions
+      <Textarea rows={4} bind:value={draft.instructions}></Textarea>
+    </label>
+    <label class="checkbox">
+      <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+      <input type="checkbox" bind:checked={draft.enabled} />
+      Enabled
+    </label>
+    <div class="actions">
+      <Button variant="primary" type="submit">{t(M['content.governance_policy_editor.save_policy'])}</Button>
+      {#if onCancel}
+        <Button variant="secondary" type="button" onclick={() => onCancel?.()}>
+          Cancel
+        </Button>
+      {/if}
+    </div>
+  </Form>
+</div>
 
 <style>
-  .governance-editor {
+  .governance-editor-shell :global(.governance-editor) {
     display: grid;
     gap: 0.75rem;
   }
@@ -90,12 +94,6 @@ function handleSubmit() {
     display: grid;
     gap: 0.35rem;
     font-size: var(--smrt-typography-label-large-size, 0.9rem);
-  }
-
-  input,
-  select,
-  textarea {
-    width: 100%;
   }
 
   .checkbox {

--- a/packages/content/src/svelte/components/ContentGovernanceProfileEditor.svelte
+++ b/packages/content/src/svelte/components/ContentGovernanceProfileEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Form, Input, Select, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type {
@@ -82,72 +83,76 @@ function handleSubmit() {
 }
 </script>
 
-<form class="governance-editor" onsubmit={(event) => {
-  event.preventDefault();
-  handleSubmit();
-}}>
-  <label>
-    Key
-    <input type="text" bind:value={draft.key} required />
-  </label>
-  <label>
-    Label
-    <input type="text" bind:value={draft.label} />
-  </label>
-  <label>
-    Description
-    <textarea rows="2" bind:value={draft.description}></textarea>
-  </label>
-  <label class="checkbox">
-    <input type="checkbox" bind:checked={draft.enabled} />
-    Enabled
-  </label>
+<div class="governance-editor-shell">
+  <Form class="governance-editor" onsubmit={(event) => {
+    event.preventDefault();
+    handleSubmit();
+  }}>
+    <label>
+      Key
+      <Input type="text" bind:value={draft.key} required />
+    </label>
+    <label>
+      Label
+      <Input type="text" bind:value={draft.label} />
+    </label>
+    <label>
+      Description
+      <Textarea rows={2} bind:value={draft.description}></Textarea>
+    </label>
+    <label class="checkbox">
+      <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+      <input type="checkbox" bind:checked={draft.enabled} />
+      Enabled
+    </label>
 
-  <div class="requirements">
-    <div class="requirements__header">
-      <strong>Requirements</strong>
-      <Button variant="secondary" type="button" onclick={addRequirement}>
-        {t(M['content.governance_profile_editor.add_requirement'])}
-      </Button>
-    </div>
-
-    {#each draft.requirements as requirement, index (`${requirement.policyKey}-${index}`)}
-      <div class="requirement-row">
-        <label>
-          Policy
-          <select bind:value={requirement.policyKey}>
-            {#each policies as policy (policy.key)}
-              <option value={policy.key}>{policy.label}</option>
-            {/each}
-          </select>
-        </label>
-        <label>
-          Label
-          <input type="text" bind:value={requirement.label} />
-        </label>
-        <label class="checkbox">
-          <input type="checkbox" bind:checked={requirement.blocking} />
-          Blocking
-        </label>
-        <Button variant="danger" type="button" onclick={() => removeRequirement(index)}>
-          Remove
+    <div class="requirements">
+      <div class="requirements__header">
+        <strong>Requirements</strong>
+        <Button variant="secondary" type="button" onclick={addRequirement}>
+          {t(M['content.governance_profile_editor.add_requirement'])}
         </Button>
       </div>
-    {/each}
-  </div>
 
-  <div class="actions">
-    <Button variant="primary" type="submit">{t(M['content.governance_profile_editor.save_profile'])}</Button>
-    {#if onCancel}
-      <Button variant="secondary" type="button" onclick={() => onCancel?.()}>
-        Cancel
-      </Button>
-    {/if}
-  </div>
-</form>
+      {#each draft.requirements as requirement, index (`${requirement.policyKey}-${index}`)}
+        <div class="requirement-row">
+          <label>
+            Policy
+            <Select bind:value={requirement.policyKey}>
+              {#each policies as policy (policy.key)}
+                <option value={policy.key}>{policy.label}</option>
+              {/each}
+            </Select>
+          </label>
+          <label>
+            Label
+            <Input type="text" bind:value={requirement.label} />
+          </label>
+          <label class="checkbox">
+            <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+            <input type="checkbox" bind:checked={requirement.blocking} />
+            Blocking
+          </label>
+          <Button variant="danger" type="button" onclick={() => removeRequirement(index)}>
+            Remove
+          </Button>
+        </div>
+      {/each}
+    </div>
+
+    <div class="actions">
+      <Button variant="primary" type="submit">{t(M['content.governance_profile_editor.save_profile'])}</Button>
+      {#if onCancel}
+        <Button variant="secondary" type="button" onclick={() => onCancel?.()}>
+          Cancel
+        </Button>
+      {/if}
+    </div>
+  </Form>
+</div>
 
 <style>
-  .governance-editor {
+  .governance-editor-shell :global(.governance-editor) {
     display: grid;
     gap: 0.75rem;
   }
@@ -156,12 +161,6 @@ function handleSubmit() {
     display: grid;
     gap: 0.35rem;
     font-size: var(--smrt-typography-label-large-size, 0.9rem);
-  }
-
-  input,
-  select,
-  textarea {
-    width: 100%;
   }
 
   .checkbox {

--- a/packages/content/src/svelte/components/ContentList.svelte
+++ b/packages/content/src/svelte/components/ContentList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { ConfirmDialog } from '@happyvertical/smrt-ui/feedback';
+import { Input, Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type { Snippet } from 'svelte';
@@ -152,23 +153,23 @@ function cancelDelete() {
   
   <div class="content-controls">
     <div class="search-filters">
-      <input type="text" placeholder={t(M['content.content_list.search_placeholder'])} bind:value={searchTerm} />
-      
+      <Input type="text" placeholder={t(M['content.content_list.search_placeholder'])} bind:value={searchTerm} />
+
       {#if !type}
-        <select bind:value={selectedType}>
+        <Select bind:value={selectedType}>
           <option value="All Types">{t(M['content.content_list.all_types'])}</option>
           <option value="Articles">Articles</option>
           <option value="Documents">Documents</option>
           <option value="Mirrors">Mirrors</option>
-        </select>
+        </Select>
       {/if}
-      
-      <select bind:value={selectedStatus}>
+
+      <Select bind:value={selectedStatus}>
         <option value="All Statuses">{t(M['content.content_list.all_statuses'])}</option>
         <option value="Published">Published</option>
         <option value="Draft">Draft</option>
         <option value="Archived">Archived</option>
-      </select>
+      </Select>
       
       {#if controls}
         {@render controls()}
@@ -439,8 +440,8 @@ function cancelDelete() {
     align-items: center;
   }
 
-  .search-filters input,
-  .search-filters select {
+  .search-filters :global(.input),
+  .search-filters :global(.select) {
     padding: 0.5rem 0.9rem;
     border: 1px solid var(--smrt-color-outline);
     border-radius: 0.5rem;
@@ -448,13 +449,6 @@ function cancelDelete() {
     height: 38px;
     background: var(--smrt-color-surface-container-low);
     color: var(--smrt-color-on-surface);
-  }
-
-  .search-filters input:focus,
-  .search-filters select:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary);
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--smrt-color-primary) 20%, transparent);
   }
 
   .actions-group {
@@ -926,8 +920,8 @@ function cancelDelete() {
       width: 100%;
     }
 
-    .search-filters input,
-    .search-filters select,
+    .search-filters :global(.input),
+    .search-filters :global(.select),
     .add-button {
       width: 100%;
     }

--- a/packages/content/src/svelte/components/ContentMetadataFields.svelte
+++ b/packages/content/src/svelte/components/ContentMetadataFields.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Input, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { M } from '../i18n.editor.js';
 
@@ -33,7 +34,7 @@ function updateTags(value: string) {
 <div class="content-metadata-fields">
   <label>
     <span>Author</span>
-    <input
+    <Input
       type="text"
       value={data.author || ''}
       oninput={(event) => updateField('author', event.currentTarget.value)}
@@ -41,15 +42,15 @@ function updateTags(value: string) {
   </label>
   <label>
     <span>Description</span>
-    <textarea
-      rows="4"
+    <Textarea
+      rows={4}
       value={data.description || ''}
       oninput={(event) => updateField('description', event.currentTarget.value)}
-    ></textarea>
+    ></Textarea>
   </label>
   <label>
     <span>Tags</span>
-    <input
+    <Input
       type="text"
       value={tagsValue}
       placeholder={t(M['content.content_metadata_fields.tags_placeholder'])}
@@ -58,7 +59,7 @@ function updateTags(value: string) {
   </label>
   <label>
     <span>URL</span>
-    <input
+    <Input
       type="url"
       value={data.url || ''}
       oninput={(event) => updateField('url', event.currentTarget.value)}
@@ -66,7 +67,7 @@ function updateTags(value: string) {
   </label>
   <label>
     <span>{t(M['content.content_metadata_fields.file_key'])}</span>
-    <input
+    <Input
       type="text"
       value={data.fileKey || ''}
       oninput={(event) => updateField('fileKey', event.currentTarget.value)}
@@ -88,20 +89,4 @@ function updateTags(value: string) {
     font-weight: var(--smrt-typography-weight-medium, 500);
   }
 
-  input,
-  textarea {
-    width: 100%;
-    box-sizing: border-box;
-    border: 1px solid color-mix(in srgb, var(--smrt-color-outline) 50%, transparent);
-    border-radius: 0.5rem;
-    background: var(--smrt-color-surface-container-low);
-    color: var(--smrt-color-on-surface);
-    font: inherit;
-    padding: 0.75rem 0.875rem;
-  }
-
-  textarea {
-    min-height: 7rem;
-    resize: vertical;
-  }
 </style>

--- a/packages/content/src/svelte/components/ContentReferencesPanel.svelte
+++ b/packages/content/src/svelte/components/ContentReferencesPanel.svelte
@@ -212,14 +212,10 @@ function removeReference(id: string) {
     min-height: 2.5rem;
     border: 1px solid color-mix(in srgb, var(--smrt-color-outline) 50%, transparent);
     border-radius: 0.5rem;
-    background: var(--smrt-color-surface-container-low);
+    background: var(--smrt-color-surface-container);
     color: var(--smrt-color-on-surface);
     font: inherit;
     padding: 0.55rem 0.875rem;
-  }
-
-  .content-references-panel :global(.reference-button) {
-    background: var(--smrt-color-surface-container);
     cursor: pointer;
     font-weight: var(--smrt-typography-weight-semibold, 600);
   }

--- a/packages/content/src/svelte/components/ContentReferencesPanel.svelte
+++ b/packages/content/src/svelte/components/ContentReferencesPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Input } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type { Snippet } from 'svelte';
@@ -114,7 +115,7 @@ function removeReference(id: string) {
   {/if}
 
   <div class="reference-input-row">
-    <input
+    <Input
       type="text"
       aria-label={t(M['content.content_references_panel.add_reference_by_id_or_url'])}
       placeholder={t(M['content.content_references_panel.reference_id_or_url_placeholder'])}
@@ -207,7 +208,6 @@ function removeReference(id: string) {
     gap: 0.65rem;
   }
 
-  input,
   .content-references-panel :global(.reference-button) {
     min-height: 2.5rem;
     border: 1px solid color-mix(in srgb, var(--smrt-color-outline) 50%, transparent);

--- a/packages/content/src/svelte/components/ContentReferencesPanel.svelte
+++ b/packages/content/src/svelte/components/ContentReferencesPanel.svelte
@@ -223,4 +223,12 @@ function removeReference(id: string) {
   .content-references-panel :global(.reference-button:hover) {
     background: var(--smrt-color-surface-container-high);
   }
+
+  /* Match the Input primitive's height/radius to the sibling reference-button so
+     the two grid columns of .reference-input-row align (the primitive's base
+     .input has no min-height). */
+  .content-references-panel :global(.input) {
+    min-height: 2.5rem;
+    border-radius: 0.5rem;
+  }
 </style>

--- a/packages/content/src/svelte/components/ContentStatusFields.svelte
+++ b/packages/content/src/svelte/components/ContentStatusFields.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Input, Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { M } from '../i18n.editor.js';
 
@@ -19,33 +20,33 @@ function updateField(key: string, value: unknown) {
 <div class="content-status-fields">
   <label>
     <span>Type</span>
-    <select value={data.type || 'article'} onchange={(event) => updateField('type', event.currentTarget.value)}>
+    <Select value={data.type || 'article'} onchange={(event) => updateField('type', event.currentTarget.value)}>
       <option value="article">Article</option>
       <option value="document">Document</option>
       <option value="mirror">Mirror</option>
       <option value="video-segment">{t(M['content.content_status_fields.video_segment'])}</option>
-    </select>
+    </Select>
   </label>
   <label>
     <span>State</span>
-    <select value={data.state || 'active'} onchange={(event) => updateField('state', event.currentTarget.value)}>
+    <Select value={data.state || 'active'} onchange={(event) => updateField('state', event.currentTarget.value)}>
       <option value="active">Active</option>
       <option value="highlighted">Highlighted</option>
       <option value="deprecated">Deprecated</option>
-    </select>
+    </Select>
   </label>
   <label>
     <span>Status</span>
-    <select value={data.status || 'draft'} onchange={(event) => updateField('status', event.currentTarget.value)}>
+    <Select value={data.status || 'draft'} onchange={(event) => updateField('status', event.currentTarget.value)}>
       <option value="draft">Draft</option>
       <option value="review">Review</option>
       <option value="published">Published</option>
       <option value="archived">Archived</option>
-    </select>
+    </Select>
   </label>
   <label>
     <span>Published</span>
-    <input
+    <Input
       type="datetime-local"
       value={data.publish_date || ''}
       onchange={(event) => updateField('publish_date', event.currentTarget.value)}
@@ -70,16 +71,4 @@ function updateField(key: string, value: unknown) {
     font-weight: var(--smrt-typography-weight-semibold, 600);
   }
 
-  select,
-  input {
-    min-height: 2.5rem;
-    border: 1px solid color-mix(in srgb, var(--smrt-color-outline) 50%, transparent);
-    border-radius: 0.5rem;
-    background: var(--smrt-color-surface-container-low);
-    color: var(--smrt-color-on-surface);
-    font: inherit;
-    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    font-weight: var(--smrt-typography-weight-medium, 500);
-    padding: 0.55rem 0.75rem;
-  }
 </style>

--- a/packages/content/src/svelte/components/ContentTitleField.svelte
+++ b/packages/content/src/svelte/components/ContentTitleField.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { Input } from '@happyvertical/smrt-ui/forms';
+
 export interface Props {
   value?: string;
   placeholder?: string;
@@ -14,17 +16,19 @@ let {
 }: Props = $props();
 </script>
 
-<input
-  class="content-title-field"
-  type="text"
-  {placeholder}
-  {required}
-  value={value || ''}
-  oninput={(event) => onChange?.(event.currentTarget.value)}
-/>
+<div class="content-title-field-shell">
+  <Input
+    class="content-title-field"
+    type="text"
+    {placeholder}
+    {required}
+    value={value || ''}
+    oninput={(event) => onChange?.(event.currentTarget.value)}
+  />
+</div>
 
 <style>
-  .content-title-field {
+  .content-title-field-shell :global(.content-title-field) {
     width: 100%;
     box-sizing: border-box;
     border: 0;
@@ -39,15 +43,15 @@ let {
     padding: 0;
   }
 
-  .content-title-field::placeholder {
+  .content-title-field-shell :global(.content-title-field)::placeholder {
     color: color-mix(in srgb, var(--smrt-color-on-surface-variant) 70%, transparent);
   }
 
-  .content-title-field:focus {
+  .content-title-field-shell :global(.content-title-field):focus {
     outline: none;
   }
 
-  .content-title-field:focus-visible {
+  .content-title-field-shell :global(.content-title-field):focus-visible {
     outline: 2px solid var(--smrt-color-primary, #005ac1);
     outline-offset: 0.35rem;
   }

--- a/packages/content/src/svelte/routes/ContentContributionsRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentContributionsRoute.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Form, Input } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { onMount } from 'svelte';
@@ -402,27 +403,29 @@ async function handleDeleteContributor(data: Record<string, any>) {
                 {t(M['content.contributions.portal_body'])}
               </p>
             </div>
-            <form
-              class="inline-form"
-              onsubmit={(event) => {
-                event.preventDefault();
-                void refreshPortalOnly();
-              }}
-            >
-              <input
-                type="email"
-                bind:value={portalEmail}
-                placeholder={t(M['content.contributions.portal_email_placeholder'])}
-              />
-              <Button
-                variant="ghost"
-                type="submit"
-                class="load-button"
-                disabled={refreshingPortal}
+            <div class="inline-form-shell">
+              <Form
+                class="inline-form"
+                onsubmit={(event) => {
+                  event.preventDefault();
+                  void refreshPortalOnly();
+                }}
               >
-                {refreshingPortal ? 'Loading...' : 'Load'}
-              </Button>
-            </form>
+                <Input
+                  type="email"
+                  bind:value={portalEmail}
+                  placeholder={t(M['content.contributions.portal_email_placeholder'])}
+                />
+                <Button
+                  variant="ghost"
+                  type="submit"
+                  class="load-button"
+                  disabled={refreshingPortal}
+                >
+                  {refreshingPortal ? 'Loading...' : 'Load'}
+                </Button>
+              </Form>
+            </div>
           </div>
 
           <ContentContributionPortal
@@ -707,14 +710,14 @@ async function handleDeleteContributor(data: Record<string, any>) {
     color: var(--smrt-color-on-surface-variant);
   }
 
-  .inline-form {
+  .inline-form-shell :global(.inline-form) {
     display: flex;
     gap: 0.5rem;
     flex-wrap: wrap;
     align-items: center;
   }
 
-  .inline-form input {
+  .inline-form-shell :global(.input) {
     min-width: min(22rem, 100%);
     padding: 0.7rem 0.85rem;
     border-radius: 0.75rem;
@@ -723,7 +726,7 @@ async function handleDeleteContributor(data: Record<string, any>) {
     color: var(--smrt-color-on-surface);
   }
 
-  .inline-form :global(.load-button) {
+  .inline-form-shell :global(.load-button) {
     border-radius: var(--smrt-radius-full, 9999px);
     border: 1px solid color-mix(
       in srgb,

--- a/packages/content/src/svelte/routes/ContentFactsRoute.svelte
+++ b/packages/content/src/svelte/routes/ContentFactsRoute.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Form, Input } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { onMount } from 'svelte';
@@ -118,10 +119,10 @@ onMount(() => {
 
   <main class="container page-main">
     <section class="filters-panel">
-      <form class="filters" onsubmit={handleSubmit}>
+      <Form class="filters" onsubmit={handleSubmit}>
         <label class="search-field">
           <span>Search</span>
-          <input
+          <Input
             type="search"
             bind:value={query}
             placeholder={t(M['content.facts.search_placeholder'])}
@@ -129,6 +130,7 @@ onMount(() => {
         </label>
 
         <label class="toggle">
+          <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
           <input
             type="checkbox"
             bind:checked={latestOnly}
@@ -138,6 +140,7 @@ onMount(() => {
         </label>
 
         <label class="toggle">
+          <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
           <input
             type="checkbox"
             bind:checked={includeSuperseded}
@@ -149,7 +152,7 @@ onMount(() => {
         <Button variant="primary" class="refresh-button" type="submit" disabled={refreshing}>
           {refreshing ? 'Refreshing…' : 'Refresh'}
         </Button>
-      </form>
+      </Form>
     </section>
 
     {#if error}
@@ -379,7 +382,7 @@ onMount(() => {
     border-color: color-mix(in srgb, var(--smrt-color-error) 30%, transparent);
   }
 
-  .filters {
+  .filters-panel :global(.filters) {
     display: grid;
     grid-template-columns: minmax(0, 1.8fr) repeat(2, auto) auto;
     gap: 0.75rem;
@@ -397,7 +400,7 @@ onMount(() => {
     color: var(--smrt-color-on-surface-variant);
   }
 
-  .search-field input {
+  .search-field :global(.input) {
     min-height: 2.85rem;
     border-radius: 0.85rem;
     border: 1px solid var(--smrt-color-outline-variant);
@@ -417,7 +420,7 @@ onMount(() => {
     color: var(--smrt-color-on-surface);
   }
 
-  .filters :global(.refresh-button) {
+  .filters-panel :global(.refresh-button) {
     min-height: 2.85rem;
     border-radius: 0.85rem;
     border: none;
@@ -606,7 +609,7 @@ onMount(() => {
       justify-content: flex-start;
     }
 
-    .filters {
+    .filters-panel :global(.filters) {
       grid-template-columns: 1fr;
     }
   }

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -3,7 +3,7 @@
   "version": "0.34.5",
   "description": "Image asset management with AI-powered categorization, search, editing, and metadata extraction for SMRT framework",
   "type": "module",
-  "smrtRawPrimitives": "strict-buttons",
+  "smrtRawPrimitives": "strict",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/images/src/svelte/components/AssetsGallery.svelte
+++ b/packages/images/src/svelte/components/AssetsGallery.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Input, Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { onMount } from 'svelte';
@@ -158,29 +159,29 @@ function handleDragStart(event: DragEvent, image: ImageLike) {
     
     <div class="toolbar">
       <div class="search-box">
-        <input 
-          type="search" 
+        <Input
+          type="search"
           bind:value={searchQuery}
           placeholder={t(M['images.assets_gallery.search_placeholder'])}
         />
       </div>
-      
+
       <div class="filters">
-        <select bind:value={orientationFilter}>
+        <Select class="orientation-select" bind:value={orientationFilter}>
           <option value="all">{t(M['images.assets_gallery.any_orientation'])}</option>
           <option value="landscape">Landscape</option>
           <option value="portrait">Portrait</option>
           <option value="square">Square</option>
-        </select>
-        
-        <input 
-          type="number" 
+        </Select>
+
+        <Input
+          type="number"
           bind:value={minWidth}
           placeholder={t(M['images.assets_gallery.min_width_placeholder'])}
           class="size-input"
         />
-        <input 
-          type="number" 
+        <Input
+          type="number"
           bind:value={minHeight}
           placeholder={t(M['images.assets_gallery.min_height_placeholder'])}
           class="size-input"
@@ -286,45 +287,22 @@ function handleDragStart(event: DragEvent, image: ImageLike) {
     min-width: 250px;
   }
 
-  .search-box input {
-    width: 100%;
-    padding: 0.75rem 1.25rem;
-    background: var(--smrt-color-surface-container-highest, #333);
-    border: 1px solid var(--smrt-color-outline-variant, #444);
-    border-radius: var(--smrt-radius-full, 9999px);
-    color: inherit;
-    font-size: var(--smrt-typography-body-large-size, 0.95rem);
-    transition: box-shadow 0.2s, border-color 0.2s;
-  }
-
-  .search-box input:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #3b82f6);
-    box-shadow: inset 0 0 0 1px var(--smrt-color-primary, #3b82f6);
-  }
-
   .filters {
     display: flex;
     gap: 0.75rem;
     flex-wrap: wrap;
   }
 
-  .filters select, .filters input {
-    padding: 0.75rem 1rem;
-    background: var(--smrt-color-surface-container-high, #242424);
-    border: 1px solid var(--smrt-color-outline-variant, #444);
-    border-radius: var(--smrt-radius-sm, 4px);
-    color: inherit;
-    transition: box-shadow 0.2s, border-color 0.2s;
+  /* Layout-only overrides for the migrated filter primitives. The Input / Select
+     primitives own the visual styling; these :global() rules only pierce their
+     rendered controls to size the boxes within the flex row (see #1589 scoping
+     rule). The orientation Select sizes to its content instead of the primitive's
+     full-width default; the min-width/min-height Inputs are capped. */
+  .filters :global(.orientation-select) {
+    width: auto;
   }
 
-  .filters select:focus, .filters input:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #3b82f6);
-    box-shadow: inset 0 0 0 1px var(--smrt-color-primary, #3b82f6);
-  }
-
-  .size-input {
+  .filters :global(.size-input) {
     width: 120px;
   }
 

--- a/packages/images/src/svelte/components/ImageEditor.svelte
+++ b/packages/images/src/svelte/components/ImageEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Input, Select, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
@@ -219,8 +220,8 @@ async function handleAIEdit() {
           <div class="tool-section">
             <h4>Resize</h4>
             <div class="row">
-              <label>Width <input type="number" bind:value={width} onfocus={() => isEditingDimensions = true} /></label>
-              <label>Height <input type="number" bind:value={height} onfocus={() => isEditingDimensions = true} /></label>
+              <label>Width <Input type="number" class="dim-input" bind:value={width} onfocus={() => isEditingDimensions = true} /></label>
+              <label>Height <Input type="number" class="dim-input" bind:value={height} onfocus={() => isEditingDimensions = true} /></label>
               <Button variant="ghost" class="tonal-btn--filled" disabled={isProcessing} onclick={handleResize}>{t(M['images.image_editor.apply_resize'])}</Button>
             </div>
             {#if isEditingDimensions}
@@ -231,12 +232,12 @@ async function handleAIEdit() {
           <div class="tool-section">
             <h4>Crop</h4>
             <div class="row">
-              <label>X <input type="number" bind:value={cropX} onfocus={() => isCropping = true} /></label>
-              <label>Y <input type="number" bind:value={cropY} onfocus={() => isCropping = true} /></label>
+              <label>X <Input type="number" class="dim-input" bind:value={cropX} onfocus={() => isCropping = true} /></label>
+              <label>Y <Input type="number" class="dim-input" bind:value={cropY} onfocus={() => isCropping = true} /></label>
             </div>
             <div class="row">
-              <label>W <input type="number" bind:value={cropW} onfocus={() => isCropping = true} /></label>
-              <label>H <input type="number" bind:value={cropH} onfocus={() => isCropping = true} /></label>
+              <label>W <Input type="number" class="dim-input" bind:value={cropW} onfocus={() => isCropping = true} /></label>
+              <label>H <Input type="number" class="dim-input" bind:value={cropH} onfocus={() => isCropping = true} /></label>
               <Button variant="ghost" class="tonal-btn--filled" disabled={isProcessing} onclick={handleCrop}>{t(M['images.image_editor.apply_crop'])}</Button>
             </div>
             {#if isCropping}
@@ -247,11 +248,11 @@ async function handleAIEdit() {
           <div class="tool-section">
             <h4>{t(M['images.image_editor.convert_format'])}</h4>
             <div class="row">
-              <select bind:value={format}>
+              <Select class="format-select" bind:value={format}>
                 <option value="webp">WebP</option>
                 <option value="jpeg">JPEG</option>
                 <option value="png">PNG</option>
-              </select>
+              </Select>
               <Button variant="ghost" class="tonal-btn--filled" disabled={isProcessing} onclick={handleConvert}>Convert</Button>
             </div>
           </div>
@@ -260,11 +261,12 @@ async function handleAIEdit() {
           <div class="tool-section">
             <h4>{t(M['images.image_editor.ai_powered_edit'])}</h4>
             <p class="hint">{t(M['images.image_editor.ai_powered_edit_hint'])}</p>
-            <textarea
+            <Textarea
+              class="ai-prompt"
               bind:value={prompt}
               placeholder={t(M['images.image_editor.ai_prompt_placeholder'])}
-              rows="4"
-            ></textarea>
+              rows={4}
+            />
             <Button
               variant="primary"
               class="primary-btn--pill"
@@ -390,30 +392,22 @@ async function handleAIEdit() {
     gap: 0.25rem;
   }
 
-  input, select, textarea {
-    background: var(--smrt-color-surface-container-high, #242424);
-    border: 1px solid var(--smrt-color-outline-variant, #444);
-    color: inherit;
-    padding: 0.6rem 0.75rem;
-    border-radius: var(--smrt-radius-sm, 4px);
-    transition: box-shadow 0.2s, border-color 0.2s;
-  }
-
-  input:focus, select:focus, textarea:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #3b82f6);
-    box-shadow: inset 0 0 0 1px var(--smrt-color-primary, #3b82f6);
-  }
-
-  input[type="number"] {
+  /* Layout-only overrides for the migrated form primitives. The Input / Select /
+     Textarea primitives own the visual styling (background, border, focus ring);
+     these :global() rules only pierce their rendered controls to constrain box
+     size and spacing (see #1589 scoping rule). */
+  .row label :global(.dim-input) {
     width: 90px;
   }
 
-  textarea {
-    width: 100%;
-    resize: vertical;
+  /* Size the format Select to its content instead of the primitive's full-width
+     default so it sits inline beside the Convert button in the flex row. */
+  .row :global(.format-select) {
+    width: auto;
+  }
+
+  .tool-section :global(.ai-prompt) {
     margin-bottom: 1rem;
-    font-family: inherit;
   }
 
   /* Migrated Buttons keep their bespoke filled-tonal / text-link / pill looks.

--- a/packages/images/src/svelte/components/ImageUploader.svelte
+++ b/packages/images/src/svelte/components/ImageUploader.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Input, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { onDestroy } from 'svelte';
@@ -320,12 +321,12 @@ onDestroy(() => {
       {#if showVariation}
         <div class="variation-form">
           <p class="variation-hint">{t(M['images.image_uploader.variation_hint'])}</p>
-          <textarea
+          <Textarea
             bind:value={variationPrompt}
             placeholder={t(M['images.image_uploader.variation_prompt_placeholder'])}
-            rows="3"
+            rows={3}
             disabled={isGenerating}
-          ></textarea>
+          />
           {#if variationError}
             <div class="variation-error">{variationError}</div>
           {/if}
@@ -420,12 +421,13 @@ onDestroy(() => {
           <p>{t(M['images.image_uploader.drag_and_drop'])}</p>
           <span class="divider">or</span>
           <Button variant="primary" class="browse-btn--decorative">{t(M['images.image_uploader.browse_files'])}</Button>
-          <input 
-            type="file" 
-            accept="image/*" 
-            bind:this={uploadInput} 
-            onchange={handleFileSelect} 
-            style="display: none;" 
+          <!-- raw-primitive-allow: hidden file input driven imperatively via a DOM ref (bind:this gives uploadInput so the parent can call .click() and onchange reads target.files); the Input primitive exposes a component instance, not the underlying HTMLInputElement -->
+          <input
+            type="file"
+            accept="image/*"
+            bind:this={uploadInput}
+            onchange={handleFileSelect}
+            style="display: none;"
           />
           {#if uploadError}
             <p class="error">{uploadError}</p>
@@ -458,8 +460,9 @@ onDestroy(() => {
         <div class="external-area">
           <p class="hint">{t(M['images.image_uploader.external_hint'])}</p>
           <div class="input-group">
-            <input 
-              type="url" 
+            <Input
+              type="url"
+              class="external-url-input"
               bind:value={externalUrl}
               placeholder={t(M['images.image_uploader.external_url_placeholder'])}
               onkeydown={(e) => e.key === 'Enter' && handleExternalSubmit()}
@@ -726,21 +729,11 @@ onDestroy(() => {
     gap: 0.5rem;
   }
 
-  .input-group input {
+  /* Layout-only override: let the migrated URL Input flex-grow to fill the row
+     beside the Add button. The Input primitive owns the visual styling; this
+     :global() rule only pierces its rendered <input> (see #1589 scoping rule). */
+  .input-group :global(.external-url-input) {
     flex: 1;
-    padding: 1rem 1.25rem;
-    background: var(--smrt-color-surface-container-high, #242424);
-    border: 1px solid var(--smrt-color-outline-variant, #444);
-    border-radius: var(--smrt-radius-sm, 4px);
-    color: var(--smrt-color-on-surface, #fff);
-    font-size: var(--smrt-typography-body-large-size, 1rem);
-    transition: border-color 0.2s, box-shadow 0.2s;
-  }
-
-  .input-group input:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #3b82f6);
-    box-shadow: inset 0 0 0 1px var(--smrt-color-primary, #3b82f6);
   }
 
   /* Migrated Add Button sits in the URL input group; keeps square-ish radius
@@ -881,29 +874,6 @@ onDestroy(() => {
     font-size: var(--smrt-typography-body-medium-size, 0.85rem);
     color: var(--smrt-color-outline, #888);
     margin: 0;
-  }
-
-  .variation-form textarea {
-    width: 100%;
-    padding: 0.75rem;
-    background: var(--smrt-color-surface-container, #1a1a1a);
-    border: 1px solid var(--smrt-color-outline-variant, #444);
-    border-radius: var(--smrt-radius-sm, 4px);
-    color: inherit;
-    font-family: inherit;
-    font-size: var(--smrt-typography-body-large-size, 0.95rem);
-    resize: vertical;
-    transition: border-color 0.2s, box-shadow 0.2s;
-  }
-
-  .variation-form textarea:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #3b82f6);
-    box-shadow: inset 0 0 0 1px var(--smrt-color-primary, #3b82f6);
-  }
-
-  .variation-form textarea:disabled {
-    opacity: 0.6;
   }
 
   .variation-error {

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -3,7 +3,7 @@
   "version": "0.34.5",
   "description": "Unified multi-channel messaging with STI-based hierarchies",
   "type": "module",
-  "smrtRawPrimitives": "strict-buttons",
+  "smrtRawPrimitives": "strict",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/messages/src/svelte/components/AttachmentUpload.svelte
+++ b/packages/messages/src/svelte/components/AttachmentUpload.svelte
@@ -11,6 +11,7 @@ export interface Props {
 
 <script lang="ts">
   import { useI18n } from '@happyvertical/smrt-ui/i18n';
+  import { Input } from '@happyvertical/smrt-ui/forms';
   import { Button } from '@happyvertical/smrt-ui/ui';
   import { M } from '../i18n.js';
 
@@ -80,11 +81,11 @@ export interface Props {
     ondragleave={handleDragLeave}
   >
     <label class="upload-label">
-      <input
+      <Input
         type="file"
         multiple
         class="file-input"
-        onchange={(e) => handleFiles((e.target as HTMLInputElement).files)}
+        onchange={(e) => handleFiles((e.currentTarget as HTMLInputElement).files)}
       />
       <span class="upload-text">{t(M['messages.attachment_upload.drop_files'])}</span>
     </label>
@@ -155,7 +156,13 @@ export interface Props {
     cursor: pointer;
   }
 
-  .file-input {
+  /*
+   * The file picker now renders through smrt-ui's <Input type="file">. It stays
+   * visually hidden — the visible affordance is the `.upload-text` label inside
+   * the styled drop-zone — so `.upload-label :global(.file-input)` pierces the
+   * Input child scope to keep `display: none` (issue #1589).
+   */
+  .upload-label :global(.file-input) {
     display: none;
   }
 

--- a/packages/messages/src/svelte/components/AttachmentUpload.svelte
+++ b/packages/messages/src/svelte/components/AttachmentUpload.svelte
@@ -11,7 +11,6 @@ export interface Props {
 
 <script lang="ts">
   import { useI18n } from '@happyvertical/smrt-ui/i18n';
-  import { Input } from '@happyvertical/smrt-ui/forms';
   import { Button } from '@happyvertical/smrt-ui/ui';
   import { M } from '../i18n.js';
 
@@ -81,7 +80,8 @@ export interface Props {
     ondragleave={handleDragLeave}
   >
     <label class="upload-label">
-      <Input
+      <!-- raw-primitive-allow: native file input — the Input primitive binds value, which is invalid for type=file (throws InvalidStateError on the bind write-back) and renders a visible control; this hidden picker behind the drop zone stays native -->
+      <input
         type="file"
         multiple
         class="file-input"
@@ -157,12 +157,10 @@ export interface Props {
   }
 
   /*
-   * The file picker now renders through smrt-ui's <Input type="file">. It stays
-   * visually hidden — the visible affordance is the `.upload-text` label inside
-   * the styled drop-zone — so `.upload-label :global(.file-input)` pierces the
-   * Input child scope to keep `display: none` (issue #1589).
+   * The native file input stays visually hidden — the visible affordance is the
+   * `.upload-text` label inside the styled drop-zone (issue #1589).
    */
-  .upload-label :global(.file-input) {
+  .upload-label .file-input {
     display: none;
   }
 

--- a/packages/messages/src/svelte/components/ComposeForm.svelte
+++ b/packages/messages/src/svelte/components/ComposeForm.svelte
@@ -18,6 +18,7 @@ export interface Props {
 
 <script lang="ts">
   import { useI18n } from '@happyvertical/smrt-ui/i18n';
+  import { Form, Input, Select, Textarea } from '@happyvertical/smrt-ui/forms';
   import { Button } from '@happyvertical/smrt-ui/ui';
   import { M } from '../i18n.js';
   import RecipientInput from './RecipientInput.svelte';
@@ -138,11 +139,12 @@ export interface Props {
   }
 </script>
 
-<form class="compose-form" onsubmit={(e) => { e.preventDefault(); handleSend(); }}>
+<div class="compose-form-shell">
+<Form class="compose-form" onsubmit={handleSend}>
   {#if accounts.length > 1}
     <div class="field">
       <label class="field-label" for="compose-account">From</label>
-      <select
+      <Select
         id="compose-account"
         class="select"
         bind:value={accountId}
@@ -153,7 +155,7 @@ export interface Props {
             {account.name}{account.email ? ` <${account.email}>` : ''}
           </option>
         {/each}
-      </select>
+      </Select>
     </div>
   {/if}
 
@@ -193,7 +195,7 @@ export interface Props {
 
     <div class="field">
       <label class="field-label" for="compose-subject">Subject</label>
-      <input
+      <Input
         id="compose-subject"
         type="text"
         class="text-input"
@@ -205,7 +207,7 @@ export interface Props {
   {:else if type === 'slack'}
     <div class="field">
       <label class="field-label" for="compose-channel">Channel</label>
-      <input
+      <Input
         id="compose-channel"
         type="text"
         class="text-input"
@@ -217,13 +219,12 @@ export interface Props {
   {/if}
 
   <div class="body-field">
-    <textarea
-      class="body-input"
+    <Textarea
       bind:value={body}
       oninput={markDirty}
       placeholder={type === 'tweet' ? "What's happening?" : 'Write your message...'}
       rows={type === 'tweet' ? 4 : 10}
-    ></textarea>
+    />
     {#if type === 'tweet'}
       <div class="char-count" class:over-limit={isOverLimit}>
         {charCount}/280
@@ -274,10 +275,17 @@ export interface Props {
       Discard
     </Button>
   </div>
-</form>
+</Form>
+</div>
 
 <style>
-  .compose-form {
+  /*
+   * The form now renders through smrt-ui's <Form> (Provider-free base `<form>`).
+   * `class="compose-form"` lands on the real `<form>` inside the Form child, so
+   * `.compose-form-shell :global(.compose-form)` anchors on the wrapper and
+   * pierces the child scope to keep the column layout / padding (issue #1589).
+   */
+  .compose-form-shell :global(.compose-form) {
     display: flex;
     flex-direction: column;
     gap: var(--smrt-spacing-2, 8px);
@@ -299,16 +307,38 @@ export interface Props {
     min-width: 56px;
   }
 
-  .select,
-  .text-input {
+  /*
+   * The From <Select> and Subject/Channel <Input>s now render through smrt-ui's
+   * form primitives. These are naked, borderless inline fields that sit on the
+   * `.field` row's bottom-border, so `.field :global(.select)` /
+   * `.field :global(.text-input)` pierce the child scopes to strip the
+   * primitives' border / background / focus box-shadow and restore the flush
+   * inline look. `appearance: auto` brings back the Select's native arrow (the
+   * primitive paints a chevron on its own background, which we've cleared) —
+   * issue #1589.
+   */
+  .field :global(.select),
+  .field :global(.text-input) {
     flex: 1;
     border: none;
     outline: none;
+    box-shadow: none;
     font-family: inherit;
     font-size: var(--smrt-typography-body-medium-size, 14px);
     padding: var(--smrt-spacing-2, 8px) 0;
     background: transparent;
     color: var(--smrt-color-on-surface, #1c1b1f);
+  }
+
+  .field :global(.select) {
+    appearance: auto;
+    cursor: pointer;
+  }
+
+  .field :global(.select):focus,
+  .field :global(.text-input):focus {
+    border: none;
+    box-shadow: none;
   }
 
   .cc-toggles {
@@ -333,24 +363,6 @@ export interface Props {
 
   .body-field {
     position: relative;
-  }
-
-  .body-input {
-    width: 100%;
-    border: 1px solid var(--smrt-color-outline-variant, #cac4d0);
-    border-radius: var(--smrt-radius-md, 12px);
-    padding: var(--smrt-spacing-3, 12px);
-    font-family: var(--smrt-font-family, system-ui);
-    font-size: var(--smrt-typography-body-medium-size, 14px);
-    resize: vertical;
-    background: var(--smrt-color-surface, #fffbfe);
-    color: var(--smrt-color-on-surface, #1c1b1f);
-    box-sizing: border-box;
-  }
-
-  .body-input:focus {
-    outline: 2px solid var(--smrt-color-primary, #6750a4);
-    outline-offset: -1px;
   }
 
   .char-count {

--- a/packages/messages/src/svelte/components/EmailAccountManager.svelte
+++ b/packages/messages/src/svelte/components/EmailAccountManager.svelte
@@ -5,6 +5,7 @@
  * Reusable component for adding, editing, testing, and removing
  * email accounts. Works with any backend via callback props.
  */
+import { Input, Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
@@ -188,20 +189,20 @@ function getProviderLabel(type: string): string {
       <div class="form-row">
         <div class="form-field" style="flex: 1;">
           <label class="form-label" for="ea-name">{t(M['messages.email_account_manager.account_name'])}</label>
-          <input id="ea-name" class="form-input" type="text" bind:value={maName} placeholder={t(M['messages.email_account_manager.account_name_placeholder'])} />
+          <Input id="ea-name" class="form-input" type="text" bind:value={maName} placeholder={t(M['messages.email_account_manager.account_name_placeholder'])} />
         </div>
         <div class="form-field" style="flex: 1;">
           <label class="form-label" for="ea-email">{t(M['messages.email_account_manager.email_address'])}</label>
-          <input id="ea-email" class="form-input" type="email" bind:value={maEmail} placeholder={t(M['messages.email_account_manager.email_placeholder'])} />
+          <Input id="ea-email" class="form-input" type="email" bind:value={maEmail} placeholder={t(M['messages.email_account_manager.email_placeholder'])} />
         </div>
         <div class="form-field" style="flex: 0 0 130px;">
           <label class="form-label" for="ea-provider">Provider</label>
-          <select id="ea-provider" class="form-select" bind:value={maProviderType}>
+          <Select id="ea-provider" class="form-select" bind:value={maProviderType}>
             <option value="imap">IMAP</option>
             <option value="gmail">Gmail</option>
             <option value="outlook">Outlook</option>
             <option value="exchange">Exchange</option>
-          </select>
+          </Select>
         </div>
       </div>
 
@@ -209,19 +210,19 @@ function getProviderLabel(type: string): string {
       <div class="form-row">
         <div class="form-field" style="flex: 2;">
           <label class="form-label" for="ea-imap-host">Host</label>
-          <input id="ea-imap-host" class="form-input" type="text" bind:value={maImapHost} placeholder={t(M['messages.email_account_manager.imap_host_placeholder'])} />
+          <Input id="ea-imap-host" class="form-input" type="text" bind:value={maImapHost} placeholder={t(M['messages.email_account_manager.imap_host_placeholder'])} />
         </div>
         <div class="form-field" style="flex: 0 0 90px;">
           <label class="form-label" for="ea-imap-port">Port</label>
-          <input id="ea-imap-port" class="form-input" type="number" bind:value={maImapPort} />
+          <Input id="ea-imap-port" class="form-input" type="number" bind:value={maImapPort} />
         </div>
         <div class="form-field" style="flex: 0 0 120px;">
           <label class="form-label" for="ea-imap-sec">Security</label>
-          <select id="ea-imap-sec" class="form-select" bind:value={maImapSecurity}>
+          <Select id="ea-imap-sec" class="form-select" bind:value={maImapSecurity}>
             <option value="ssl">SSL/TLS</option>
             <option value="starttls">STARTTLS</option>
             <option value="none">None</option>
-          </select>
+          </Select>
         </div>
       </div>
 
@@ -229,19 +230,19 @@ function getProviderLabel(type: string): string {
       <div class="form-row">
         <div class="form-field" style="flex: 2;">
           <label class="form-label" for="ea-smtp-host">Host</label>
-          <input id="ea-smtp-host" class="form-input" type="text" bind:value={maSmtpHost} placeholder={t(M['messages.email_account_manager.smtp_host_placeholder'])} />
+          <Input id="ea-smtp-host" class="form-input" type="text" bind:value={maSmtpHost} placeholder={t(M['messages.email_account_manager.smtp_host_placeholder'])} />
         </div>
         <div class="form-field" style="flex: 0 0 90px;">
           <label class="form-label" for="ea-smtp-port">Port</label>
-          <input id="ea-smtp-port" class="form-input" type="number" bind:value={maSmtpPort} />
+          <Input id="ea-smtp-port" class="form-input" type="number" bind:value={maSmtpPort} />
         </div>
         <div class="form-field" style="flex: 0 0 120px;">
           <label class="form-label" for="ea-smtp-sec">Security</label>
-          <select id="ea-smtp-sec" class="form-select" bind:value={maSmtpSecurity}>
+          <Select id="ea-smtp-sec" class="form-select" bind:value={maSmtpSecurity}>
             <option value="ssl">SSL/TLS</option>
             <option value="starttls">STARTTLS</option>
             <option value="none">None</option>
-          </select>
+          </Select>
         </div>
       </div>
 
@@ -249,14 +250,15 @@ function getProviderLabel(type: string): string {
       <div class="form-row">
         <div class="form-field" style="flex: 1;">
           <label class="form-label" for="ea-username">Username</label>
-          <input id="ea-username" class="form-input" type="text" bind:value={maUsername} placeholder={t(M['messages.email_account_manager.username_placeholder'])} />
+          <Input id="ea-username" class="form-input" type="text" bind:value={maUsername} placeholder={t(M['messages.email_account_manager.username_placeholder'])} />
         </div>
         <div class="form-field" style="flex: 1;">
           <label class="form-label" for="ea-password">Password</label>
-          <input id="ea-password" class="form-input" type="password" bind:value={maPassword} placeholder={editingId ? '(unchanged)' : ''} />
+          <Input id="ea-password" class="form-input" type="password" bind:value={maPassword} placeholder={editingId ? '(unchanged)' : ''} />
         </div>
         <div class="form-field checkbox-field">
           <label class="form-label checkbox-label">
+            <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
             <input type="checkbox" bind:checked={maIsActive} />
             Active
           </label>
@@ -432,29 +434,14 @@ function getProviderLabel(type: string): string {
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
-  .form-input,
-  .form-select {
-    padding: 0.5rem 0.625rem;
-    border-radius: var(--smrt-radius-md, 8px);
-    border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
-    background: var(--smrt-color-surface, #fefbff);
-    color: var(--smrt-color-on-surface, #1a1c1e);
-    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
-    font-family: inherit;
-    transition: border-color 150ms ease;
-  }
-
-  .form-input:focus,
-  .form-select:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #005ac1);
-  }
-
-  .form-input::placeholder {
-    color: var(--smrt-color-on-surface-variant, #43474e);
-    opacity: 0.5;
-  }
-
+  /*
+   * The account-form fields now render through smrt-ui's <Input> / <Select>,
+   * which bring their own tokenised border / background / focus / placeholder
+   * styling and honor prefers-reduced-motion themselves. The old `.form-input` /
+   * `.form-select` rules (and their :focus / ::placeholder overrides) are dropped
+   * as dead — they targeted the raw elements that now live inside the primitive
+   * child scopes (issue #1589).
+   */
   .checkbox-field {
     justify-content: flex-end;
     padding-bottom: 0.5rem;

--- a/packages/messages/src/svelte/components/EmailFilterManager.svelte
+++ b/packages/messages/src/svelte/components/EmailFilterManager.svelte
@@ -5,6 +5,7 @@
  * Reusable component for managing email allow/block lists.
  * Works with any backend via callback props.
  */
+import { Input, Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
@@ -215,15 +216,15 @@ function getPatternPlaceholder(type: string): string {
           <div class="form-row">
             <div class="form-field" style="flex: 0 0 120px;">
               <label class="form-label" for="wl-type">Type</label>
-              <select id="wl-type" class="form-select" bind:value={wlType}>
+              <Select id="wl-type" class="form-select" bind:value={wlType}>
                 <option value="email">Email</option>
                 <option value="domain">Domain</option>
                 <option value="regex">Regex</option>
-              </select>
+              </Select>
             </div>
             <div class="form-field" style="flex: 1;">
               <label class="form-label" for="wl-pattern">Pattern</label>
-              <input
+              <Input
                 id="wl-pattern"
                 class="form-input"
                 type="text"
@@ -235,7 +236,7 @@ function getPatternPlaceholder(type: string): string {
           <div class="form-row">
             <div class="form-field" style="flex: 1;">
               <label class="form-label" for="wl-category">Category <span class="optional">(optional)</span></label>
-              <input
+              <Input
                 id="wl-category"
                 class="form-input"
                 type="text"
@@ -245,7 +246,7 @@ function getPatternPlaceholder(type: string): string {
             </div>
             <div class="form-field" style="flex: 2;">
               <label class="form-label" for="wl-desc">Description</label>
-              <input
+              <Input
                 id="wl-desc"
                 class="form-input"
                 type="text"
@@ -319,15 +320,15 @@ function getPatternPlaceholder(type: string): string {
           <div class="form-row">
             <div class="form-field" style="flex: 0 0 120px;">
               <label class="form-label" for="bl-type">Type</label>
-              <select id="bl-type" class="form-select" bind:value={blType}>
+              <Select id="bl-type" class="form-select" bind:value={blType}>
                 <option value="email">Email</option>
                 <option value="domain">Domain</option>
                 <option value="regex">Regex</option>
-              </select>
+              </Select>
             </div>
             <div class="form-field" style="flex: 1;">
               <label class="form-label" for="bl-pattern">Pattern</label>
-              <input
+              <Input
                 id="bl-pattern"
                 class="form-input"
                 type="text"
@@ -339,7 +340,7 @@ function getPatternPlaceholder(type: string): string {
           <div class="form-row">
             <div class="form-field" style="flex: 1;">
               <label class="form-label" for="bl-reason">Reason</label>
-              <input
+              <Input
                 id="bl-reason"
                 class="form-input"
                 type="text"
@@ -349,6 +350,7 @@ function getPatternPlaceholder(type: string): string {
             </div>
             <div class="form-field checkbox-field">
               <label class="form-label checkbox-label">
+                <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
                 <input type="checkbox" bind:checked={blAutoArchive} />
                 Auto-archive
               </label>
@@ -502,29 +504,14 @@ function getPatternPlaceholder(type: string): string {
     opacity: 0.7;
   }
 
-  .form-input,
-  .form-select {
-    padding: 0.5rem 0.625rem;
-    border-radius: var(--smrt-radius-md, 8px);
-    border: 1px solid var(--smrt-color-outline-variant, #c2c7cf);
-    background: var(--smrt-color-surface, #fefbff);
-    color: var(--smrt-color-on-surface, #1a1c1e);
-    font-size: var(--smrt-typography-body-medium-size, 0.8125rem);
-    font-family: inherit;
-    transition: border-color 150ms ease;
-  }
-
-  .form-input:focus,
-  .form-select:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #005ac1);
-  }
-
-  .form-input::placeholder {
-    color: var(--smrt-color-on-surface-variant, #43474e);
-    opacity: 0.5;
-  }
-
+  /*
+   * The form fields now render through smrt-ui's <Input> / <Select>, which bring
+   * their own tokenised border / background / focus / placeholder styling and
+   * honor prefers-reduced-motion themselves. The old `.form-input` / `.form-select`
+   * rules (and their :focus / ::placeholder overrides) are dropped as dead — they
+   * targeted the raw elements that now live inside the primitive child scopes
+   * (issue #1589).
+   */
   .checkbox-field {
     justify-content: flex-end;
     padding-bottom: 0.5rem;

--- a/packages/messages/src/svelte/components/ForwardForm.svelte
+++ b/packages/messages/src/svelte/components/ForwardForm.svelte
@@ -10,6 +10,7 @@ export interface Props {
 
 <script lang="ts">
   import { useI18n } from '@happyvertical/smrt-ui/i18n';
+  import { Textarea } from '@happyvertical/smrt-ui/forms';
   import { Button } from '@happyvertical/smrt-ui/ui';
   import { M } from '../i18n.js';
   import RecipientInput from './RecipientInput.svelte';
@@ -68,12 +69,11 @@ export interface Props {
     onchange={(r) => { to = r; }}
   />
 
-  <textarea
-    class="forward-body"
+  <Textarea
     bind:value={body}
     placeholder={t(M['messages.forward_form.note_placeholder'])}
     rows={3}
-  ></textarea>
+  />
 
   <div class="forwarded-original">
     <pre class="forwarded-text">{forwardedBlock}</pre>
@@ -115,22 +115,6 @@ export interface Props {
     font-size: var(--smrt-typography-title-small-size, 13px);
     color: var(--smrt-color-on-surface-variant, #49454f);
     font-weight: var(--smrt-typography-weight-medium, 500);
-  }
-
-  .forward-body {
-    width: 100%;
-    border: 1px solid var(--smrt-color-outline-variant, #cac4d0);
-    border-radius: var(--smrt-radius-sm, 8px);
-    padding: var(--smrt-spacing-2, 8px);
-    font-family: var(--smrt-font-family, system-ui);
-    font-size: var(--smrt-typography-body-medium-size, 14px);
-    resize: vertical;
-    box-sizing: border-box;
-  }
-
-  .forward-body:focus {
-    outline: 2px solid var(--smrt-color-primary, #6750a4);
-    outline-offset: -1px;
   }
 
   .forwarded-original {

--- a/packages/messages/src/svelte/components/MessageCard.svelte
+++ b/packages/messages/src/svelte/components/MessageCard.svelte
@@ -98,6 +98,7 @@ const _slackMeta = $derived.by(() => {
 >
   {#if onselect}
     <div class="select-col">
+      <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
       <input
         type="checkbox"
         checked={selected}

--- a/packages/messages/src/svelte/components/MessageFilters.svelte
+++ b/packages/messages/src/svelte/components/MessageFilters.svelte
@@ -2,6 +2,7 @@
 /**
  * MessageFilters - Filter/sort controls bar
  */
+import { Input, Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.messages.js';
@@ -78,7 +79,7 @@ const _hasActiveFilters = $derived(
 
 <div class="message-filters" role="search" aria-label={t(M['messages.message_filters.filters_label'])}>
   <div class="search-row">
-    <input
+    <Input
       type="search"
       class="search-input"
       placeholder={t(M['messages.message_filters.search_placeholder'])}
@@ -90,37 +91,37 @@ const _hasActiveFilters = $derived(
   </div>
 
   <div class="filter-row">
-    <select
+    <Select
       class="filter-select"
       value={filters.type || ''}
-      onchange={(e) => updateFilter('type', (e.target as HTMLSelectElement).value)}
+      onchange={(e) => updateFilter('type', (e.currentTarget as HTMLSelectElement).value)}
       aria-label={t(M['messages.message_filters.filter_by_type'])}
     >
       <option value="">{t(M['messages.message_filters.all_types'])}</option>
       {#each availableTypes as type}
         <option value={type}>{type === 'email' ? 'Email' : type === 'tweet' ? 'Tweet' : type === 'slack' ? 'Slack' : type}</option>
       {/each}
-    </select>
+    </Select>
 
     {#if accounts.length > 0}
-      <select
+      <Select
         class="filter-select"
         value={filters.accountId || ''}
-        onchange={(e) => updateFilter('accountId', (e.target as HTMLSelectElement).value)}
+        onchange={(e) => updateFilter('accountId', (e.currentTarget as HTMLSelectElement).value)}
         aria-label={t(M['messages.message_filters.filter_by_account'])}
       >
         <option value="">{t(M['messages.message_filters.all_accounts'])}</option>
         {#each accounts as account}
           <option value={account.id}>{account.name}</option>
         {/each}
-      </select>
+      </Select>
     {/if}
 
-    <select
+    <Select
       class="filter-select"
       value={filters.isRead === undefined ? '' : filters.isRead ? 'read' : 'unread'}
       onchange={(e) => {
-        const val = (e.target as HTMLSelectElement).value;
+        const val = (e.currentTarget as HTMLSelectElement).value;
         updateFilter('isRead', val === '' ? undefined : val === 'read');
       }}
       aria-label={t(M['messages.message_filters.filter_by_read_status'])}
@@ -128,13 +129,14 @@ const _hasActiveFilters = $derived(
       <option value="">Read & unread</option>
       <option value="unread">{t(M['messages.message_filters.unread_only'])}</option>
       <option value="read">{t(M['messages.message_filters.read_only'])}</option>
-    </select>
+    </Select>
 
     <label class="filter-checkbox">
+      <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
       <input
         type="checkbox"
         checked={filters.isFlagged === true}
-        onchange={(e) => updateFilter('isFlagged', (e.target as HTMLInputElement).checked ? true : undefined)}
+        onchange={(e) => updateFilter('isFlagged', (e.currentTarget as HTMLInputElement).checked ? true : undefined)}
       />
       Flagged
     </label>
@@ -163,19 +165,14 @@ const _hasActiveFilters = $derived(
     gap: 0.5rem;
   }
 
-  .search-input {
+  /*
+   * The search field now renders through smrt-ui's <Input>. The primitive owns
+   * border / background / focus; `.search-row :global(.search-input)` only
+   * re-asserts `flex: 1` so it shares the row with the Search button, piercing
+   * the Input child scope (issue #1589).
+   */
+  .search-row :global(.search-input) {
     flex: 1;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--smrt-color-outline, #72787e);
-    border-radius: var(--smrt-radius-small, 0.25rem);
-    font: var(--smrt-typography-body-medium-font, 0.875rem / 1.25 sans-serif);
-    background: var(--smrt-color-surface, #fefbff);
-    color: var(--smrt-color-on-surface, #1a1c1e);
-  }
-
-  .search-input:focus {
-    outline: 2px solid var(--smrt-color-primary, #005ac1);
-    outline-offset: -1px;
   }
 
   /*
@@ -197,13 +194,16 @@ const _hasActiveFilters = $derived(
     gap: 0.5rem;
   }
 
-  .filter-select {
-    padding: 0.375rem 0.5rem;
-    border: 1px solid var(--smrt-color-outline, #72787e);
-    border-radius: var(--smrt-radius-small, 0.25rem);
+  /*
+   * The filter dropdowns now render through smrt-ui's <Select>. The primitive
+   * owns border / background / focus / chevron; `.filter-row :global(.filter-select)`
+   * re-asserts the compact filter-bar sizing (auto width, tighter padding, small
+   * font) by piercing the Select child scope (issue #1589).
+   */
+  .filter-row :global(.filter-select) {
+    width: auto;
+    padding: 0.375rem 2rem 0.375rem 0.5rem;
     font: var(--smrt-typography-body-small-font, 0.75rem / 1.33 sans-serif);
-    background: var(--smrt-color-surface, #fefbff);
-    color: var(--smrt-color-on-surface, #1a1c1e);
   }
 
   .filter-checkbox {

--- a/packages/messages/src/svelte/components/RecipientInput.svelte
+++ b/packages/messages/src/svelte/components/RecipientInput.svelte
@@ -10,6 +10,7 @@ export interface Props {
 </script>
 
 <script lang="ts">
+  import { Input } from '@happyvertical/smrt-ui/forms';
   import { Button } from '@happyvertical/smrt-ui/ui';
 
   let {
@@ -71,10 +72,10 @@ export interface Props {
         >×</Button>
       </span>
     {/each}
-    <input
+    <Input
       id={inputId}
       type="text"
-      class="input"
+      class="recipient-field"
       bind:value={inputValue}
       {placeholder}
       onkeydown={handleKeydown}
@@ -145,15 +146,28 @@ export interface Props {
     opacity: 1;
   }
 
-  .input {
+  /*
+   * The chip-bar field now renders through smrt-ui's <Input>. This is a naked,
+   * borderless inline field that sits among the recipient chips, so
+   * `.chips-container :global(.recipient-field)` pierces the Input child scope to
+   * strip the primitive's border / background / block padding / focus box-shadow
+   * and restore the flush inline look (issue #1589).
+   */
+  .chips-container :global(.recipient-field) {
     flex: 1;
     min-width: 120px;
     border: none;
     outline: none;
+    box-shadow: none;
     font-family: var(--smrt-font-family, system-ui);
     font-size: var(--smrt-typography-body-medium-size, 14px);
     padding: var(--smrt-spacing-1, 4px) 0;
     background: transparent;
     color: var(--smrt-color-on-surface, #1c1b1f);
+  }
+
+  .chips-container :global(.recipient-field):focus {
+    border: none;
+    box-shadow: none;
   }
 </style>

--- a/packages/messages/src/svelte/components/ReplyForm.svelte
+++ b/packages/messages/src/svelte/components/ReplyForm.svelte
@@ -11,6 +11,7 @@ export interface Props {
 
 <script lang="ts">
   import { useI18n } from '@happyvertical/smrt-ui/i18n';
+  import { Textarea } from '@happyvertical/smrt-ui/forms';
   import { Button } from '@happyvertical/smrt-ui/ui';
   import { M } from '../i18n.js';
 
@@ -60,12 +61,11 @@ export interface Props {
     {replyAll ? 'Reply All' : 'Reply'} to {originalMessage.senderName || originalMessage.senderAddress}
   </div>
 
-  <textarea
-    class="reply-body"
+  <Textarea
     bind:value={body}
     placeholder={t(M['messages.reply_form.body_placeholder'])}
     rows={5}
-  ></textarea>
+  />
 
   <div class="quoted-original">
     <pre class="quoted-text">{quotedBody}</pre>
@@ -107,22 +107,6 @@ export interface Props {
     font-size: var(--smrt-typography-title-small-size, 13px);
     color: var(--smrt-color-on-surface-variant, #49454f);
     font-weight: var(--smrt-typography-weight-medium, 500);
-  }
-
-  .reply-body {
-    width: 100%;
-    border: 1px solid var(--smrt-color-outline-variant, #cac4d0);
-    border-radius: var(--smrt-radius-sm, 8px);
-    padding: var(--smrt-spacing-2, 8px);
-    font-family: var(--smrt-font-family, system-ui);
-    font-size: var(--smrt-typography-body-medium-size, 14px);
-    resize: vertical;
-    box-sizing: border-box;
-  }
-
-  .reply-body:focus {
-    outline: 2px solid var(--smrt-color-primary, #6750a4);
-    outline-offset: -1px;
   }
 
   .quoted-original {

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -4,7 +4,7 @@
   "description": "SMRT products module: triple-purpose microservice template for standalone apps, federated modules, and NPM libraries",
   "author": "HappyVertical",
   "type": "module",
-  "smrtRawPrimitives": "strict-buttons",
+  "smrtRawPrimitives": "strict",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
   "files": [

--- a/packages/products/src/lib/components/ProductForm.svelte
+++ b/packages/products/src/lib/components/ProductForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Form, Input, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
@@ -66,128 +67,126 @@ function handleSubmit(event: Event) {
 }
 </script>
 
-<form onsubmit={handleSubmit} class="product-form">
-  <div class="form-group">
-    <label for="name">{t(M['products.product_form.name_label'])}</label>
-    <input
-      id="name"
-      type="text"
-      bind:value={formData.name}
-      disabled={loading}
-      class="form-input"
-      class:error={errors.name}
-      placeholder={t(M['products.product_form.name_placeholder'])}
-    />
-    {#if errors.name}
-      <span class="error-message">{errors.name}</span>
-    {/if}
-  </div>
-
-  <div class="form-group">
-    <label for="description">Description</label>
-    <textarea
-      id="description"
-      bind:value={formData.description}
-      disabled={loading}
-      class="form-textarea"
-      placeholder={t(M['products.product_form.description_placeholder'])}
-      rows="3"
-    ></textarea>
-  </div>
-
-  <div class="form-row">
+<div class="product-form-shell">
+  <Form onsubmit={handleSubmit} class="product-form">
     <div class="form-group">
-      <label for="price">Price *</label>
-      <input
-        id="price"
-        type="number"
-        step="0.01"
-        min="0"
-        bind:value={formData.price}
-        disabled={loading}
-        class="form-input"
-        class:error={errors.price}
-        placeholder="0.00"
-      />
-      {#if errors.price}
-        <span class="error-message">{errors.price}</span>
-      {/if}
-    </div>
-
-    <div class="form-group">
-      <label for="category">Category</label>
-      <input
-        id="category"
+      <label for="name">{t(M['products.product_form.name_label'])}</label>
+      <Input
+        id="name"
         type="text"
-        bind:value={formData.category}
+        bind:value={formData.name}
         disabled={loading}
-        class="form-input"
-        placeholder={t(M['products.product_form.category_placeholder'])}
+        class={errors.name ? 'error' : ''}
+        placeholder={t(M['products.product_form.name_placeholder'])}
       />
-    </div>
-  </div>
-
-  <div class="form-group">
-    <label for="tags">Tags</label>
-    <input
-      id="tags"
-      type="text"
-      bind:value={formData.tags}
-      disabled={loading}
-      class="form-input"
-      placeholder={t(M['products.product_form.tags_placeholder'])}
-    />
-    <small class="form-hint">{t(M['products.product_form.tags_hint'])}</small>
-  </div>
-
-  <div class="form-group">
-    <label class="checkbox-label">
-      <input
-        type="checkbox"
-        bind:checked={formData.inStock}
-        disabled={loading}
-        class="form-checkbox"
-      />
-      {t(M['products.product_form.in_stock_label'])}
-    </label>
-  </div>
-
-  <div class="form-actions">
-    {#if onCancel}
-      <Button type="button" variant="secondary" onclick={onCancel} disabled={loading}>
-        Cancel
-      </Button>
-    {/if}
-
-    <Button type="submit" variant="primary" disabled={loading}>
-      {#if loading}
-        Saving...
-      {:else}
-        {product.id ? 'Update Product' : 'Create Product'}
+      {#if errors.name}
+        <span class="error-message">{errors.name}</span>
       {/if}
-    </Button>
-  </div>
-</form>
+    </div>
+
+    <div class="form-group">
+      <label for="description">Description</label>
+      <Textarea
+        id="description"
+        bind:value={formData.description}
+        disabled={loading}
+        placeholder={t(M['products.product_form.description_placeholder'])}
+        rows={3}
+      ></Textarea>
+    </div>
+
+    <div class="form-row">
+      <div class="form-group">
+        <label for="price">Price *</label>
+        <Input
+          id="price"
+          type="number"
+          step="0.01"
+          min="0"
+          bind:value={formData.price}
+          disabled={loading}
+          class={errors.price ? 'error' : ''}
+          placeholder="0.00"
+        />
+        {#if errors.price}
+          <span class="error-message">{errors.price}</span>
+        {/if}
+      </div>
+
+      <div class="form-group">
+        <label for="category">Category</label>
+        <Input
+          id="category"
+          type="text"
+          bind:value={formData.category}
+          disabled={loading}
+          placeholder={t(M['products.product_form.category_placeholder'])}
+        />
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label for="tags">Tags</label>
+      <Input
+        id="tags"
+        type="text"
+        bind:value={formData.tags}
+        disabled={loading}
+        placeholder={t(M['products.product_form.tags_placeholder'])}
+      />
+      <small class="form-hint">{t(M['products.product_form.tags_hint'])}</small>
+    </div>
+
+    <div class="form-group">
+      <label class="checkbox-label">
+        <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+        <input
+          type="checkbox"
+          bind:checked={formData.inStock}
+          disabled={loading}
+          class="form-checkbox"
+        />
+        {t(M['products.product_form.in_stock_label'])}
+      </label>
+    </div>
+
+    <div class="form-actions">
+      {#if onCancel}
+        <Button type="button" variant="secondary" onclick={onCancel} disabled={loading}>
+          Cancel
+        </Button>
+      {/if}
+
+      <Button type="submit" variant="primary" disabled={loading}>
+        {#if loading}
+          Saving...
+        {:else}
+          {product.id ? 'Update Product' : 'Create Product'}
+        {/if}
+      </Button>
+    </div>
+  </Form>
+</div>
 
 <style>
-  .product-form {
+  .product-form-shell :global(.product-form) {
     max-width: 500px;
     padding: 1.5rem;
     background: var(--smrt-color-surface, #fff);
     border-radius: var(--smrt-radius-md, 8px);
     border: 1px solid var(--smrt-color-outline-variant, #e2e8f0);
   }
-  
+
   .form-group {
     margin-bottom: 1rem;
   }
-  
+
   .form-row {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 1rem;
   }
-  
+
   label {
     display: block;
     margin-bottom: 0.25rem;
@@ -196,30 +195,13 @@ function handleSubmit(event: Event) {
     font-size: var(--smrt-typography-label-large-size, 0.875rem);
   }
 
-  .form-input, .form-textarea {
-    width: 100%;
-    padding: 0.5rem;
-    border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
-    border-radius: var(--smrt-radius-sm, 4px);
-    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    transition: border-color 0.2s;
-  }
-
-  .form-input:focus, .form-textarea:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #3b82f6);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--smrt-color-primary, #3b82f6) 10%, transparent);
-  }
-
-  .form-input.error {
+  /* Error border on the migrated <Input>. The primitive renders the inner
+     <input class="input error"> inside its own component, so the scoped class
+     can't reach it without :global (#1589). */
+  .product-form-shell :global(.input.error) {
     border-color: var(--smrt-color-error, #dc2626);
   }
-  
-  .form-textarea {
-    resize: vertical;
-    min-height: 80px;
-  }
-  
+
   .checkbox-label {
     display: flex;
     align-items: center;

--- a/packages/products/src/lib/components/auto-generated/AutoForm.svelte
+++ b/packages/products/src/lib/components/auto-generated/AutoForm.svelte
@@ -4,6 +4,7 @@
  * Demonstrates "Define Once, Consume Everywhere" - form is generated from Product class definition
  */
 
+import { Form } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.js';
@@ -113,31 +114,33 @@ function _getFieldType(
     </div>
   </header>
 
-  <form class="form-content" onsubmit={handleSubmit}>
-    {#each fieldSchema as field}
-      <FieldRenderer
-        fieldName={field.name}
-        fieldType={field.type}
-        value={formData[field.name]}
-        label={field.label}
-        placeholder={field.placeholder}
-        required={field.required || false}
-        {readonly}
-        onUpdate={(value) => updateField(field.name, value)}
-      />
-    {/each}
+  <div class="form-content-shell">
+    <Form class="form-content" onsubmit={handleSubmit}>
+      {#each fieldSchema as field}
+        <FieldRenderer
+          fieldName={field.name}
+          fieldType={field.type}
+          value={formData[field.name]}
+          label={field.label}
+          placeholder={field.placeholder}
+          required={field.required || false}
+          {readonly}
+          onUpdate={(value) => updateField(field.name, value)}
+        />
+      {/each}
 
-    {#if !readonly}
-      <div class="form-actions">
-        <Button type="submit" variant="primary">
-          {submitLabel}
-        </Button>
-        <Button type="button" variant="secondary" onclick={() => formData = {}}>
-          Reset
-        </Button>
-      </div>
-    {/if}
-  </form>
+      {#if !readonly}
+        <div class="form-actions">
+          <Button type="submit" variant="primary">
+            {submitLabel}
+          </Button>
+          <Button type="button" variant="secondary" onclick={() => formData = {}}>
+            Reset
+          </Button>
+        </div>
+      {/if}
+    </Form>
+  </div>
 
   <!-- Demo: Show current form state -->
   <details class="form-debug">
@@ -174,7 +177,7 @@ function _getFieldType(
     font-style: italic;
   }
 
-  .form-content {
+  .form-content-shell :global(.form-content) {
     display: flex;
     flex-direction: column;
     gap: 1rem;

--- a/packages/products/src/lib/components/auto-generated/FieldRenderer.svelte
+++ b/packages/products/src/lib/components/auto-generated/FieldRenderer.svelte
@@ -4,6 +4,7 @@
  * This demonstrates the "Define Once, Consume Everywhere" vision
  */
 
+import { Input, Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { M } from '../../i18n.js';
 
@@ -92,10 +93,9 @@ function handleObjectInput(event: Event) {
   </label>
 
   {#if fieldType === 'string'}
-    <input
+    <Input
       id={fieldId}
       type="text"
-      class="field-input"
       {value}
       {placeholder}
       {readonly}
@@ -103,10 +103,9 @@ function handleObjectInput(event: Event) {
       oninput={handleStringInput}
     />
   {:else if fieldType === 'number'}
-    <input
+    <Input
       id={fieldId}
       type="number"
-      class="field-input"
       value={value || 0}
       {placeholder}
       {readonly}
@@ -114,6 +113,7 @@ function handleObjectInput(event: Event) {
       oninput={handleNumberInput}
     />
   {:else if fieldType === 'boolean'}
+    <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
     <input
       id={fieldId}
       type="checkbox"
@@ -123,26 +123,24 @@ function handleObjectInput(event: Event) {
       onchange={handleBooleanInput}
     />
   {:else if fieldType === 'array'}
-    <textarea
+    <Textarea
       id={fieldId}
-      class="field-textarea"
       value={Array.isArray(value) ? value.join(', ') : ''}
       placeholder={placeholder || 'Enter comma-separated values'}
       {readonly}
       {required}
       oninput={handleArrayInput}
-    />
+    ></Textarea>
     <div class="field-hint">{t(M['products.field_renderer.array_hint'])}</div>
   {:else if fieldType === 'object'}
-    <textarea
+    <Textarea
       id={fieldId}
-      class="field-textarea"
       value={typeof value === 'object' ? JSON.stringify(value, null, 2) : '{}'}
       placeholder={placeholder || 'Enter JSON object'}
       {readonly}
       {required}
       oninput={handleObjectInput}
-    />
+    ></Textarea>
     <div class="field-hint">{t(M['products.field_renderer.object_hint'])}</div>
   {/if}
 </div>
@@ -165,27 +163,6 @@ function handleObjectInput(event: Event) {
     color: var(--smrt-color-error, #dc2626);
   }
 
-  .field-input,
-  .field-textarea {
-    padding: 0.5rem 0.75rem;
-    border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
-    border-radius: var(--smrt-radius-sm, 0.375rem);
-    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-    transition: border-color 0.2s, box-shadow 0.2s;
-  }
-
-  .field-input:focus,
-  .field-textarea:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #3b82f6);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--smrt-color-primary, #3b82f6) 10%, transparent);
-  }
-
-  .field-textarea {
-    min-height: 4rem;
-    resize: vertical;
-  }
-
   .field-checkbox {
     width: 1rem;
     height: 1rem;
@@ -195,11 +172,5 @@ function handleObjectInput(event: Event) {
     font-size: var(--smrt-typography-body-small-size, 0.75rem);
     color: var(--smrt-color-on-surface-variant, #6b7280);
     font-style: italic;
-  }
-
-  .field-input:read-only,
-  .field-textarea:read-only {
-    background-color: var(--smrt-color-surface-container-low, #f9fafb);
-    cursor: not-allowed;
   }
 </style>

--- a/packages/products/src/lib/features/ProductCatalog.svelte
+++ b/packages/products/src/lib/features/ProductCatalog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Input, Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { onMount } from 'svelte';
@@ -103,20 +104,20 @@ function handleCancelForm() {
   
   <div class="catalog-controls">
     <div class="search-filters">
-      <input
+      <Input
         type="text"
         bind:value={searchQuery}
         placeholder={t(M['products.product_catalog.search_placeholder'])}
         aria-label={t(M['products.product_catalog.search_placeholder'])}
         class="search-input"
       />
-      
-      <select bind:value={selectedCategory} class="category-filter">
+
+      <Select bind:value={selectedCategory} class="category-filter">
         <option value="">{t(M['products.product_catalog.all_categories'])}</option>
         {#each productStore.categories as category}
           <option value={category}>{category}</option>
         {/each}
-      </select>
+      </Select>
     </div>
     
     {#if !readonly && (showCreateForm || productStore.items.length === 0)}
@@ -224,20 +225,17 @@ function handleCancelForm() {
     gap: 0.75rem;
     flex: 1;
   }
-  
-  .search-input, .category-filter {
-    padding: 0.5rem;
-    border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
-    border-radius: var(--smrt-radius-sm, 4px);
-    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
-  }
-  
-  .search-input {
+
+  /* Layout sizing for the migrated <Input>/<Select>. The primitives render the
+     inner element with the forwarded class, so pierce with :global to keep the
+     flex sizing the old scoped rules supplied (#1589); padding/border/font come
+     from the primitives' tokenised styling now. */
+  .search-filters :global(.search-input) {
     flex: 1;
     max-width: 300px;
   }
-  
-  .category-filter {
+
+  .search-filters :global(.category-filter) {
     min-width: 150px;
   }
   

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -3,7 +3,7 @@
   "version": "0.34.5",
   "description": "Svelte 5 components for SMRT user management - auth, users, tenants, roles, permissions, groups",
   "type": "module",
-  "smrtRawPrimitives": "strict-buttons",
+  "smrtRawPrimitives": "strict",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "svelte": "./dist/index.js",

--- a/packages/smrt-svelte/src/browser-ai/svelte/components/STTTest.svelte
+++ b/packages/smrt-svelte/src/browser-ai/svelte/components/STTTest.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { useAppState } from '../../../hooks/useAppState.svelte.js';
@@ -111,11 +112,20 @@ function clearLogs() {
   <div class="controls">
     <div class="adapter-select">
       <label for="adapter">Adapter:</label>
-      <select id="adapter" bind:value={selectedAdapter} disabled={isRecording}>
+      <Select
+        id="adapter"
+        bind:value={
+          () => selectedAdapter,
+          (v) => {
+            selectedAdapter = v as AdapterType;
+          }
+        }
+        disabled={isRecording}
+      >
         <option value="browser-speech">{t(M['ui.stt_test.adapter_browser'])}</option>
         <option value="whisper-wasm">{t(M['ui.stt_test.adapter_whisper_wasm'])}</option>
         <option value="whisper-cpp">{t(M['ui.stt_test.adapter_whisper_cpp'])}</option>
-      </select>
+      </Select>
     </div>
 
     <Button
@@ -222,13 +232,6 @@ function clearLogs() {
 
   .adapter-select label {
     font: var(--smrt-typography-body-medium-font, 500 0.875rem / 1.25 sans-serif);
-  }
-
-  .adapter-select select {
-    padding: var(--smrt-spacing-sm, 8px);
-    border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
-    border-radius: var(--smrt-radius-small, 6px);
-    font: var(--smrt-typography-body-medium-font, 0.875rem / 1.25 sans-serif);
   }
 
   .status {

--- a/packages/smrt-ui/src/components/forms/Form.svelte
+++ b/packages/smrt-ui/src/components/forms/Form.svelte
@@ -44,8 +44,10 @@ function handleSubmit(event: SubmitEvent & { currentTarget: HTMLFormElement }) {
 	{@render children()}
 </form>
 
-<style>
-	.form {
-		display: block;
-	}
-</style>
+<!--
+  No base styles: a <form> is `display: block` by default, so an explicit
+  `.form { display: block }` rule would only add a specificity floor that ties
+  with a consumer's single-class layout override (e.g. `:global(.x){display:flex}`)
+  and can win by stylesheet order. The `form` class stays as a stable hook.
+-->
+

--- a/packages/smrt-ui/src/components/forms/Input.svelte
+++ b/packages/smrt-ui/src/components/forms/Input.svelte
@@ -80,4 +80,10 @@ const resolvedInvalid = $derived(
 	.input::placeholder {
 		color: var(--smrt-color-on-surface-variant, #9ca3af);
 	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.input {
+			transition: none;
+		}
+	}
 </style>

--- a/packages/smrt-ui/src/components/forms/Select.svelte
+++ b/packages/smrt-ui/src/components/forms/Select.svelte
@@ -80,4 +80,10 @@ const resolvedInvalid = $derived(
 		cursor: not-allowed;
 		opacity: 0.7;
 	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.select {
+			transition: none;
+		}
+	}
 </style>

--- a/packages/smrt-ui/src/components/forms/Textarea.svelte
+++ b/packages/smrt-ui/src/components/forms/Textarea.svelte
@@ -82,4 +82,10 @@ const resolvedInvalid = $derived(
 	.textarea::placeholder {
 		color: var(--smrt-color-on-surface-variant, #9ca3af);
 	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.textarea {
+			transition: none;
+		}
+	}
 </style>

--- a/packages/smrt-ui/src/components/forms/Toggle.svelte
+++ b/packages/smrt-ui/src/components/forms/Toggle.svelte
@@ -214,4 +214,11 @@ const sizeClasses = {
   .toggle--lg .toggle__label {
     font-size: var(--smrt-typography-body-large-size, 1rem);
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    .toggle__thumb,
+    .toggle__thumb::after {
+      transition: none;
+    }
+  }
 </style>

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -3,7 +3,7 @@
   "version": "0.34.5",
   "description": "Multi-tenant user management for the SMRT framework - users, tenants, roles, permissions, groups",
   "type": "module",
-  "smrtRawPrimitives": "strict-buttons",
+  "smrtRawPrimitives": "strict",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/users/src/svelte/components/InviteUserModal.svelte
+++ b/packages/users/src/svelte/components/InviteUserModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { RoleSelector } from '@happyvertical/smrt-ui';
 import { Modal } from '@happyvertical/smrt-ui/feedback';
+import { Form, Input } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type { Role, Tenant } from '@happyvertical/smrt-users';
@@ -45,8 +46,7 @@ $effect(() => {
   }
 });
 
-function handleSubmit(e: Event) {
-  e.preventDefault();
+function handleSubmit() {
   error = '';
 
   if (!email) {
@@ -85,45 +85,48 @@ function handleClose() {
   closeOnBackdrop={!loading}
   closeOnEscape={!loading}
 >
-  <form id={formId} onsubmit={handleSubmit}>
-    {#if error}
-      <div class="error">{error}</div>
-    {/if}
+  <div class="invite-form-shell">
+    <Form id={formId} class="invite-form" onsubmit={handleSubmit}>
+      {#if error}
+        <div class="error">{error}</div>
+      {/if}
 
-    <div class="field">
-      <label for="invite-email">{t(M['users.invite_user_modal.email_address'])}</label>
-      <input
-        id="invite-email"
-        type="email"
-        bind:value={email}
-        placeholder={t(M['users.invite_user_modal.email_placeholder'])}
-        disabled={loading}
-        required
-      />
-    </div>
-
-    <div class="field">
-      <label for="invite-role">Role</label>
-      <RoleSelector
-        {roles}
-        value={roleId}
-        onchange={(id: string) => (roleId = id)}
-        disabled={loading}
-        showDescription
-      />
-    </div>
-
-    <div class="checkbox-field">
-      <input id="send-email" type="checkbox" bind:checked={sendEmail} disabled={loading} />
-      <label for="send-email">{t(M['users.invite_user_modal.send_invitation_email'])}</label>
-    </div>
-
-    {#if !sendEmail}
-      <div class="hint">
-        {t(M['users.invite_user_modal.pending_hint'])}
+      <div class="field">
+        <label for="invite-email">{t(M['users.invite_user_modal.email_address'])}</label>
+        <Input
+          id="invite-email"
+          type="email"
+          bind:value={email}
+          placeholder={t(M['users.invite_user_modal.email_placeholder'])}
+          disabled={loading}
+          required
+        />
       </div>
-    {/if}
-  </form>
+
+      <div class="field">
+        <label for="invite-role">Role</label>
+        <RoleSelector
+          {roles}
+          value={roleId}
+          onchange={(id: string) => (roleId = id)}
+          disabled={loading}
+          showDescription
+        />
+      </div>
+
+      <div class="checkbox-field">
+        <!-- raw-primitive-allow: native checkbox; no Provider-free checkbox primitive (Toggle is a switch with different semantics, CheckboxInput requires a Provider) -->
+        <input id="send-email" type="checkbox" bind:checked={sendEmail} disabled={loading} />
+        <label for="send-email">{t(M['users.invite_user_modal.send_invitation_email'])}</label>
+      </div>
+
+      {#if !sendEmail}
+        <div class="hint">
+          {t(M['users.invite_user_modal.pending_hint'])}
+        </div>
+      {/if}
+    </Form>
+  </div>
 
   {#snippet footer()}
     <Button variant="secondary" type="button" onclick={handleClose} disabled={loading}>
@@ -143,7 +146,7 @@ function handleClose() {
   /* The dialog chrome (backdrop, surface, header, footer bar, close button) is
      supplied by the smrt-ui Modal. Only the form-content + footer-button styles
      live here. */
-  form {
+  .invite-form-shell :global(.invite-form) {
     display: flex;
     flex-direction: column;
     gap: var(--smrt-spacing-md, 1rem);
@@ -169,25 +172,6 @@ function handleClose() {
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
-  input[type='email'] {
-    padding: var(--smrt-spacing-sm, 0.5rem) var(--smrt-spacing-md, 0.75rem);
-    border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
-    border-radius: var(--smrt-radius-medium, 0.5rem);
-    font: var(--smrt-typography-body-medium-font, 0.875rem / 1.25 sans-serif);
-    transition: border-color var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
-  }
-
-  input[type='email']:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #005ac1);
-    box-shadow: 0 0 0 3px var(--smrt-color-primary-container, rgba(0, 90, 193, 0.1));
-  }
-
-  input[type='email']:disabled {
-    background: var(--smrt-color-surface-container, #f3f4f6);
-    cursor: not-allowed;
-  }
-
   .checkbox-field {
     display: flex;
     align-items: center;
@@ -210,11 +194,5 @@ function handleClose() {
     padding: var(--smrt-spacing-sm, 0.5rem);
     background: var(--smrt-color-surface-container-low, #f9fafb);
     border-radius: var(--smrt-radius-small, 0.25rem);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    input[type='email'] {
-      transition: none;
-    }
   }
 </style>

--- a/packages/users/src/svelte/components/UserForm.svelte
+++ b/packages/users/src/svelte/components/UserForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { Profile } from '@happyvertical/smrt-profiles';
 import { UserStatus } from '@happyvertical/smrt-types';
+import { Form, Input, Select } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import type { User } from '@happyvertical/smrt-users';
@@ -61,53 +62,54 @@ $effect(() => {
   status = user?.status ?? UserStatus.ACTIVE;
 });
 
-function handleSubmit(e: Event) {
-  e.preventDefault();
+function handleSubmit() {
   onsubmit({ name, email, status });
 }
 </script>
 
-<form class="user-form" onsubmit={handleSubmit}>
-  <div class="field">
-    <label for="name">Name</label>
-    <input id="name" type="text" bind:value={name} required disabled={loading} />
-  </div>
+<div class="user-form-shell">
+  <Form class="user-form" onsubmit={handleSubmit}>
+    <div class="field">
+      <label for="name">Name</label>
+      <Input id="name" type="text" bind:value={name} required disabled={loading} />
+    </div>
 
-  <div class="field">
-    <label for="email">Email</label>
-    <input id="email" type="email" bind:value={email} required disabled={loading || !!user} />
-    {#if user}
-      <span class="hint">{t(M['users.user_form.email_cannot_be_changed'])}</span>
-    {/if}
-  </div>
-
-  <div class="field">
-    <label for="status">Status</label>
-    <select id="status" bind:value={status} disabled={loading}>
-      {#each statusOptions as option (option.value)}
-        <option value={option.value}>{option.label}</option>
-      {/each}
-    </select>
-  </div>
-
-  <div class="actions">
-    {#if oncancel}
-      <Button variant="secondary" type="button" onclick={oncancel} disabled={loading}>
-        Cancel
-      </Button>
-    {/if}
-    <Button variant="primary" type="submit" disabled={loading}>
-      {#if loading}
-        Saving...
-      {:else}
-        {user ? 'Update User' : 'Create User'}
+    <div class="field">
+      <label for="email">Email</label>
+      <Input id="email" type="email" bind:value={email} required disabled={loading || !!user} />
+      {#if user}
+        <span class="hint">{t(M['users.user_form.email_cannot_be_changed'])}</span>
       {/if}
-    </Button>
-  </div>
-</form>
+    </div>
+
+    <div class="field">
+      <label for="status">Status</label>
+      <Select id="status" bind:value={status} disabled={loading}>
+        {#each statusOptions as option (option.value)}
+          <option value={option.value}>{option.label}</option>
+        {/each}
+      </Select>
+    </div>
+
+    <div class="actions">
+      {#if oncancel}
+        <Button variant="secondary" type="button" onclick={oncancel} disabled={loading}>
+          Cancel
+        </Button>
+      {/if}
+      <Button variant="primary" type="submit" disabled={loading}>
+        {#if loading}
+          Saving...
+        {:else}
+          {user ? 'Update User' : 'Create User'}
+        {/if}
+      </Button>
+    </div>
+  </Form>
+</div>
 
 <style>
-  .user-form {
+  .user-form-shell :global(.user-form) {
     display: flex;
     flex-direction: column;
     gap: var(--smrt-spacing-md, 1rem);
@@ -124,28 +126,6 @@ function handleSubmit(e: Event) {
     color: var(--smrt-color-on-surface-variant, #43474e);
   }
 
-  input,
-  select {
-    padding: var(--smrt-spacing-sm, 0.5rem) var(--smrt-spacing-md, 0.75rem);
-    border: 1px solid var(--smrt-color-outline-variant, #c4c6cf);
-    border-radius: var(--smrt-radius-medium, 0.5rem);
-    font: var(--smrt-typography-body-medium-font, 0.875rem / 1.25 sans-serif);
-    transition: border-color var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
-  }
-
-  input:focus,
-  select:focus {
-    outline: none;
-    border-color: var(--smrt-color-primary, #005ac1);
-    box-shadow: 0 0 0 3px var(--smrt-color-primary-container, rgba(0, 90, 193, 0.1));
-  }
-
-  input:disabled,
-  select:disabled {
-    background: var(--smrt-color-surface-container, #f3f4f6);
-    cursor: not-allowed;
-  }
-
   .hint {
     font: var(--smrt-typography-body-small-font, 0.75rem / 1.25 sans-serif);
     color: var(--smrt-color-on-surface-variant, #43474e);
@@ -156,12 +136,5 @@ function handleSubmit(e: Event) {
     justify-content: flex-end;
     gap: var(--smrt-spacing-sm, 0.5rem);
     margin-top: var(--smrt-spacing-sm, 0.5rem);
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    input,
-    select {
-      transition: none;
-    }
   }
 </style>

--- a/packages/vitest/src/__tests__/workspace-aliases.test.ts
+++ b/packages/vitest/src/__tests__/workspace-aliases.test.ts
@@ -42,6 +42,22 @@ describe('getWorkspaceViteAliases', () => {
     );
   });
 
+  it('aliases the smrt-ui leaf subpaths to source, including forms (#1589)', () => {
+    // smrt-ui's nested component subpaths are special-cased (they map to dirs,
+    // not the generic `${pkg}/ui` → `src/ui.ts` convention). /forms is the
+    // relocated Provider-free form primitives — without it, consumer tests that
+    // render a migrated form component fail to resolve the import.
+    expect(byFind.get('@happyvertical/smrt-ui/forms')).toMatch(
+      /src\/components\/forms\/index\.ts$/,
+    );
+    expect(byFind.get('@happyvertical/smrt-ui/ui')).toMatch(
+      /src\/components\/ui\/index\.ts$/,
+    );
+    expect(byFind.get('@happyvertical/smrt-ui/chat')).toMatch(
+      /src\/components\/chat\/index\.ts$/,
+    );
+  });
+
   it('sorts entries most-specific first so subpaths win over the bare-package root', () => {
     const lengths = aliases.map((entry) => entry.find.length);
     expect(lengths).toEqual([...lengths].sort((a, b) => b - a));

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -402,7 +402,7 @@ export function getWorkspaceViteAliases(
     }
 
     if (packageName === '@happyvertical/smrt-ui') {
-      // smrt-ui holds the domain-agnostic UI leaf (primitives, feedback,
+      // smrt-ui holds the domain-agnostic UI leaf (primitives, forms, feedback,
       // layout, calendar, chat, registry, theme system, i18n client). These
       // subpaths map to nested source dirs, so the generic `${packageName}/ui`
       // → `src/ui.ts` convention misses them; alias the exact source files.
@@ -430,6 +430,11 @@ export function getWorkspaceViteAliases(
         aliases,
         '@happyvertical/smrt-ui/chat',
         join(packageRoot, 'src/components/chat/index.ts'),
+      );
+      addAliasIfPresent(
+        aliases,
+        '@happyvertical/smrt-ui/forms',
+        join(packageRoot, 'src/components/forms/index.ts'),
       );
       addAliasIfPresent(
         aliases,


### PR DESCRIPTION
## What & why

Completes the **deferred form-primitive phase** of #1589 (epic #1354). Builds on the merged relocation (PR #1625) by migrating every remaining domain package's raw form markup onto the relocated Provider-free `@happyvertical/smrt-ui/forms` primitives and flipping each package's `smrtRawPrimitives` ratchet from `strict-buttons` to **`strict`**.

After this PR, `scripts/check-raw-primitives.mjs` reports **only strict packages with zero violations — no `strict-buttons` remain**. The raw-interactive-primitive ratchet is fully strict across the monorepo.

Consolidated into **one PR** (one CI run, one release) instead of per-package PRs. Each package was migrated and fully gated independently (in isolated worktrees) before being folded in.

## Contents (12 commits)

**Foundational (test-infra + a11y):**
- `fix(vitest)` — register the `@happyvertical/smrt-ui/forms` source alias in the smrt-vitest workspace alias map (PR #1625 added the export but not the test alias; consumer tests rendering a migrated component otherwise fail to resolve it). + a regression test.
- `fix(ui)` — `Input`/`Select`/`Textarea`/`Toggle` now honor `prefers-reduced-motion` (matching every other smrt-ui primitive), so packages dropping their now-dead local overrides don't regress.

**Package migrations (9):** agents, smrt-svelte, users, assets, images, messages, chat, products, content — raw `<input>`/`<select>`/`<textarea>`/`<form>` → `Input`/`Select`/`Textarea`/`Form` from `@happyvertical/smrt-ui/forms`; dead element-scoped CSS removed; root/field layout classes preserved via `:global` piercing; each package flipped to `strict`.

## Escape-hatches (genuinely no Provider-free primitive)

Native **checkboxes/radios** (no Provider-free checkbox/radio primitive — `Toggle` is a switch, `CheckboxInput` needs a Provider) and **hidden file inputs behind custom drop zones** (the base `Input` renders a visible control and doesn't expose its inner DOM node) are kept native with a documented `raw-primitive-allow: <reason>`. Pre-existing structural escape-hatches (selection cards, drag handles, off-screen submit) were left untouched.

## Verification (full suite, on the assembled branch)
- `check-raw-primitives` → all strict, 0 violations, no strict-buttons ✅
- `check-hardcoded-strings` ✅ · `check-package-dag` ✅ · `check-no-smrt-peers` ✅
- `pnpm build` → 51/51 turbo tasks, no cycle ✅
- Test suites for all 9 migrated packages + smrt-ui + smrt-vitest → green ✅
- `knowledge:check` → fresh ✅ · `biome check` (read-only) on changed files → clean ✅

Supersedes (closed, folded in): #1627, #1628, #1629, #1630, #1631.

Refs #1589 #1354
