### PR TITLE
fix(products): close out #1405 deep-review stragglers

### DIFF
--- a/packages/products/AGENTS.md
+++ b/packages/products/AGENTS.md
@@ -57,7 +57,7 @@ Same codebase consumed three ways:
 
 Auto-generated via Vite plugins: `@happyvertical/smrt-client` (TypeScript client), `@happyvertical/smrt-types`, `@happyvertical/smrt-routes` (Express), `@happyvertical/smrt-mcp`, `@happyvertical/smrt-manifest`.
 
-Svelte 5 stores use runes (`$state`, `$derived`, `$effect`). Separate `product-store.server.svelte.ts` vs `product-store.client.svelte.ts` for SSR safety.
+Svelte 5 stores use runes (`$state`, `$derived`, `$effect`). `product-store.svelte.ts` is the main store (backed by the SMRT client); `product-store.client.svelte.ts` is a virtual-module-free variant for federation builds.
 
 ## Schema migrations (Phase 1 release)
 

--- a/packages/products/src/lib/components/auto-generated/FieldRenderer.svelte
+++ b/packages/products/src/lib/components/auto-generated/FieldRenderer.svelte
@@ -33,12 +33,13 @@ const {
 }: Props = $props();
 
 // Auto-generate label from field name if not provided
-const displayLabel =
+const displayLabel = $derived(
   label ||
-  fieldName
-    .replace(/([A-Z])/g, ' $1')
-    .replace(/^./, (str) => str.toUpperCase());
-const fieldId = `field-${fieldName}`;
+    fieldName
+      .replace(/([A-Z])/g, ' $1')
+      .replace(/^./, (str) => str.toUpperCase()),
+);
+const fieldId = $derived(`field-${fieldName}`);
 
 function handleUpdate(newValue: any) {
   if (onUpdate && !readonly) {


### PR DESCRIPTION
## Summary

Closes out the [#1405](https://github.com/happyvertical/smrt/issues/1405) products deep-review remediation. **Re-auditing the review against current `main` found the bulk already landed** — in `a9e04c929` (standalone/federation build repair, slugify, dark-mode CSS, dead code) and the #1617/#1632 primitive migrations — so #1405 was effectively done and just never closed. This PR fixes the only two stragglers the review flagged that hadn't been addressed.

## Changes
- **AGENTS.md** — corrected a stale doc reference to a non-existent `product-store.server.svelte.ts`. The real pair is `product-store.svelte.ts` (main store, SMRT-client-backed) and `product-store.client.svelte.ts` (virtual-module-free variant for federation builds).
- **FieldRenderer.svelte** — `displayLabel`/`fieldId` were computed from props in a plain `const`, tripping Svelte 5 `state_referenced_locally`. Switched to `$derived` (these are read-only values → safe, correct conversion). Left the editable seed-from-prop `$state` in `ProductForm`/`AutoForm` intentionally unchanged — converting those to `$derived` would break two-way binding.

## Verification (current `main` re-audit)
Every #1405 finding confirmed resolved against source:
- ✅ 5 standalone-app runtime blockers (ProductCatalog/App/DemoPage/AutoForm/FieldRenderer) — fixed; **lib + standalone + federation all build and emit artifacts** (`dist/lib`, `dist/app/index.html`, `dist/federation/remoteEntry.js`)
- ✅ slugify — NFKD + `\p{L}\p{N}` + hyphen trim (verified: `已经`→`已经`, `Café`→`cafe`, `---x---`→`x`)
- ✅ `background: white` (10 sites) → tokenized; no raw border-radius/font-size/z-index literals remain
- ✅ dead-code stubs removed from `Product`/`Category`
- ✅ `ProductData` shape now consistent across mock-client/types/model
- ✅ empty `catch{}` surface `productStore.error`; search input labeled; loading/error/empty have `aria-live`
- ✅ vite multi-mode build gated on `mode` (was unconditional `build.lib`)
- ✅ this PR: stale store doc + FieldRenderer `$derived`

Checks: `typecheck` clean · full products suite **78 passed / 4 skipped** · `dev:knowledge-check` 0 errors / 0 warnings.

## Recommendation
Close [#1405](https://github.com/happyvertical/smrt/issues/1405) on merge.

Refs #1405