### PR TITLE
fix(core): recursively strip sensitive fields in toPublicJSON() (#1580)

### DIFF
--- a/packages/core/src/__tests__/issue-1580-public-json-recursive.test.ts
+++ b/packages/core/src/__tests__/issue-1580-public-json-recursive.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Test for issue #1580: `toPublicJSON()` must strip sensitive fields
+ * RECURSIVELY, not just at the top level.
+ * https://github.com/happyvertical/smrt/issues/1580
+ *
+ * `toPublicJSON()` previously stripped `@field({ sensitive: true })` values
+ * only at the top level (+ the STI `_meta_data` object). If a serialized value
+ * IS (or contains) a nested `SmrtObject` — e.g. surfaced by a `transformJSON()`
+ * override — `JSON.stringify` would invoke that nested object's `toJSON()` (not
+ * `toPublicJSON()`), leaking its secrets to REST / MCP / SvelteKit / AI
+ * consumers. The fix walks the payload and reduces every nested `SmrtObject`
+ * to its own public projection, with a cycle guard.
+ *
+ * These nested-object payloads are produced here via `transformJSON()` (the
+ * documented customization hook) so the test exercises the exact latent path,
+ * even though no current model embeds a `SmrtObject` in its serialization.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { field } from '../decorators';
+import { SmrtObject } from '../object';
+import { smrt } from '../registry';
+
+// Unique class names to avoid AST-scanner collisions (issue #543).
+@smrt()
+class Pub1580Nested extends SmrtObject {
+  @field({ type: 'text' })
+  label: string = '';
+
+  @field({ type: 'text', sensitive: true })
+  childSecret: string = '';
+
+  // Runtime-only back-reference, injected via transformJSON to build a cycle.
+  back?: SmrtObject;
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.label !== undefined) this.label = options.label;
+    if (options.childSecret !== undefined)
+      this.childSecret = options.childSecret;
+    this.back = options.back;
+  }
+
+  protected transformJSON(data: any) {
+    if (this.back) data.back = this.back;
+    return data;
+  }
+}
+
+@smrt()
+class Pub1580Host extends SmrtObject {
+  @field({ type: 'text' })
+  name: string = '';
+
+  @field({ type: 'text', sensitive: true })
+  hostSecret: string = '';
+
+  // Runtime-only holders injected into the payload via transformJSON.
+  child?: SmrtObject;
+  list: SmrtObject[] = [];
+  blob?: Record<string, unknown>;
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+    if (options.hostSecret !== undefined) this.hostSecret = options.hostSecret;
+    this.child = options.child;
+    this.list = options.list ?? [];
+    this.blob = options.blob;
+  }
+
+  protected transformJSON(data: any) {
+    if (this.child) data.child = this.child;
+    if (this.list.length) data.list = this.list;
+    if (this.blob) data.blob = this.blob;
+    return data;
+  }
+}
+
+describe('Issue #1580: recursive toPublicJSON() sensitive-field strip', () => {
+  it('strips a sensitive field on a nested SmrtObject held in a plain field', () => {
+    const host = new Pub1580Host({
+      name: 'h',
+      hostSecret: 'sk-host',
+      child: new Pub1580Nested({ label: 'c', childSecret: 'sk-child' }),
+    });
+
+    const pub = host.toPublicJSON();
+    // Own sensitive field gone (existing behavior preserved).
+    expect('hostSecret' in pub).toBe(false);
+    // Nested object reduced to its public projection: non-sensitive kept...
+    const child = pub.child as Record<string, unknown>;
+    expect(child.label).toBe('c');
+    // ...sensitive stripped.
+    expect('childSecret' in child).toBe(false);
+    // Belt-and-suspenders: the secret is nowhere in the serialized output.
+    expect(JSON.stringify(pub)).not.toContain('sk-child');
+    expect(JSON.stringify(pub)).not.toContain('sk-host');
+  });
+
+  it('strips sensitive fields on nested objects inside an array', () => {
+    const host = new Pub1580Host({
+      name: 'h',
+      list: [
+        new Pub1580Nested({ label: 'a', childSecret: 'sk-a' }),
+        new Pub1580Nested({ label: 'b', childSecret: 'sk-b' }),
+      ],
+    });
+
+    const pub = host.toPublicJSON();
+    const list = pub.list as Array<Record<string, unknown>>;
+    expect(list).toHaveLength(2);
+    expect(list[0].label).toBe('a');
+    expect(list[1].label).toBe('b');
+    expect('childSecret' in list[0]).toBe(false);
+    expect('childSecret' in list[1]).toBe(false);
+    expect(JSON.stringify(pub)).not.toContain('sk-a');
+    expect(JSON.stringify(pub)).not.toContain('sk-b');
+  });
+
+  it('strips sensitive fields on a nested object inside a plain JSON value', () => {
+    const host = new Pub1580Host({
+      name: 'h',
+      blob: { inner: new Pub1580Nested({ label: 'd', childSecret: 'sk-d' }) },
+    });
+
+    const pub = host.toPublicJSON();
+    const blob = pub.blob as Record<string, unknown>;
+    const inner = blob.inner as Record<string, unknown>;
+    expect(inner.label).toBe('d');
+    expect('childSecret' in inner).toBe(false);
+    expect(JSON.stringify(pub)).not.toContain('sk-d');
+  });
+
+  it('does not infinite-loop on a circular reference and breaks the cycle', () => {
+    const host = new Pub1580Host({ name: 'h', hostSecret: 'sk-host' });
+    const child = new Pub1580Nested({ label: 'c', childSecret: 'sk-child' });
+    host.child = child;
+    child.back = host; // host -> child -> host
+
+    let pub!: Record<string, unknown>;
+    expect(() => {
+      pub = host.toPublicJSON();
+    }).not.toThrow();
+
+    const projectedChild = pub.child as Record<string, unknown>;
+    expect(projectedChild.label).toBe('c');
+    expect('childSecret' in projectedChild).toBe(false);
+    // The cycle back to `host` is dropped rather than recursed into.
+    expect(projectedChild.back).toBeUndefined();
+    // No secret survives anywhere.
+    expect(JSON.stringify(pub)).not.toContain('sk-child');
+    expect(JSON.stringify(pub)).not.toContain('sk-host');
+  });
+
+  it('leaves a plain object with no nested SmrtObject untouched in shape', () => {
+    const host = new Pub1580Host({
+      name: 'plain',
+      blob: { a: 1, b: ['x', 'y'], c: { d: true } },
+    });
+    const pub = host.toPublicJSON();
+    expect(pub.name).toBe('plain');
+    expect(pub.blob).toEqual({ a: 1, b: ['x', 'y'], c: { d: true } });
+  });
+});

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -1255,24 +1255,93 @@ export class SmrtObject extends SmrtClass {
    * @returns A plain object safe to send to API consumers.
    */
   toPublicJSON(): Record<string, unknown> {
+    return this.projectPublicJSON(new WeakSet<SmrtObject>());
+  }
+
+  /**
+   * Recursive worker behind {@link toPublicJSON}.
+   *
+   * Strips this instance's sensitive fields (top-level + STI `_meta_data`),
+   * then walks the serialized payload and reduces any nested `SmrtObject`
+   * value to its OWN public projection. Without this, a nested instance held
+   * in a field value (or surfaced by a `transformJSON()` override) would be
+   * serialized via `JSON.stringify` -> its `toJSON()`, leaking that nested
+   * object's `@field({ sensitive: true })` values to API/MCP/AI consumers
+   * (#1580).
+   *
+   * @param seen - Ancestor path of `SmrtObject` instances on the current
+   *   branch, used purely to break reference cycles. An instance already on
+   *   the path is dropped rather than recursed into. It is a path set (entries
+   *   are removed on the way back up), not a global visited set, so an object
+   *   legitimately shared across sibling branches is still projected in each.
+   */
+  private projectPublicJSON(
+    seen: WeakSet<SmrtObject>,
+  ): Record<string, unknown> {
     const json = this.toJSON() as Record<string, unknown>;
     const sensitiveFields = this.getSensitiveFieldNames();
-    if (sensitiveFields.size === 0) {
-      return json;
-    }
 
-    const metaData =
-      json._meta_data && typeof json._meta_data === 'object'
-        ? (json._meta_data as Record<string, unknown>)
-        : null;
-
-    for (const name of sensitiveFields) {
-      delete json[name];
-      if (metaData) {
-        delete metaData[name];
+    if (sensitiveFields.size > 0) {
+      const metaData =
+        json._meta_data && typeof json._meta_data === 'object'
+          ? (json._meta_data as Record<string, unknown>)
+          : null;
+      for (const name of sensitiveFields) {
+        delete json[name];
+        if (metaData) {
+          delete metaData[name];
+        }
       }
     }
+
+    seen.add(this);
+    try {
+      for (const key of Object.keys(json)) {
+        json[key] = SmrtObject.sanitizePublicValue(json[key], seen);
+      }
+    } finally {
+      seen.delete(this);
+    }
     return json;
+  }
+
+  /**
+   * Reduce an arbitrary serialized value to its public-safe form: a nested
+   * `SmrtObject` becomes its `toPublicJSON()` projection; plain objects and
+   * arrays are walked; everything else passes through unchanged. Part of the
+   * {@link toPublicJSON} recursive sensitive-field strip (#1580).
+   */
+  private static sanitizePublicValue(
+    value: unknown,
+    seen: WeakSet<SmrtObject>,
+  ): unknown {
+    if (value instanceof SmrtObject) {
+      // Cycle: this instance is already on the current ancestor path.
+      // Drop it (undefined serializes away) rather than recurse forever.
+      if (seen.has(value)) {
+        return undefined;
+      }
+      return value.projectPublicJSON(seen);
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => SmrtObject.sanitizePublicValue(item, seen));
+    }
+    // Only descend into plain objects (e.g. `_meta_data`, parsed JSON fields).
+    // Leave Date / Map / other class instances untouched so we never rewrite
+    // their internals.
+    if (value !== null && typeof value === 'object') {
+      const proto = Object.getPrototypeOf(value);
+      if (proto === Object.prototype || proto === null) {
+        const out: Record<string, unknown> = {};
+        for (const [key, item] of Object.entries(
+          value as Record<string, unknown>,
+        )) {
+          out[key] = SmrtObject.sanitizePublicValue(item, seen);
+        }
+        return out;
+      }
+    }
+    return value;
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes [#1580](https://github.com/happyvertical/smrt/issues/1580). `SmrtObject.toPublicJSON()` — the canonical public serializer behind generated REST / MCP / SvelteKit routes and (since #1576) the `is()`/`do()`/`describe()` AI prompt path — stripped `@field({ sensitive: true })` values only at the **top level** + the STI `_meta_data` object. If a serialized value **is** or **contains** a nested `SmrtObject`, `JSON.stringify` invokes that nested object's `toJSON()` (not `toPublicJSON()`), so the nested instance's sensitive fields would leak to API consumers and third-party AI providers.

**Latent, not active:** no current model emits a nested `SmrtObject` from serialization (FKs serialize as string IDs; relationships/transients are excluded; every `transformJSON()` override only adds scalars or parsed-JSON records). This enforces the guarantee structurally instead of relying on that convention holding. Raised by the Codex reviewer on #1576.

## Change (`packages/core/src/object.ts`)
- `toPublicJSON()` now delegates to a recursive `projectPublicJSON(seen)` worker.
- After the existing top-level + `_meta_data` strip, it walks the payload (plain objects + arrays) and replaces any nested `SmrtObject` with its **own** `toPublicJSON()` projection — fixed in one place so REST, MCP, SvelteKit, and the AI path all benefit uniformly.
- **Cycle guard:** a per-branch ancestor-path `WeakSet` (entries removed on the way back up). An instance already on the current path is dropped rather than recursed into; an object legitimately shared across sibling branches is still projected in each.
- Only descends into plain objects and arrays — `Date` / `Map` / other class instances pass through untouched.

## Tests (`issue-1580-public-json-recursive.test.ts`)
Nested objects are forced into the payload via `transformJSON()` (the exact latent path):
- nested sensitive field stripped in a plain field, inside an array, and inside a JSON value
- non-sensitive nested fields preserved (it's a projection, not wholesale removal)
- circular reference terminates and breaks the cycle
- plain payloads keep their shape

Verified: full core suite **236 files passed / 2 skipped** (existing #1540 sensitive-field tests still green) · typecheck clean · new test 5/5.

Closes #1580