### PR TITLE
build(lint): establish noExplicitAny ratchet + graduate first 6 packages (#1579)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -58,7 +58,9 @@
                 "selector": {
                   "kind": "interface"
                 },
-                "formats": ["PascalCase"]
+                "formats": [
+                  "PascalCase"
+                ]
               }
             ]
           }
@@ -120,7 +122,10 @@
       }
     },
     {
-      "includes": ["packages/*/src/**/*.ts", "packages/*/src/**/*.tsx"],
+      "includes": [
+        "packages/*/src/**/*.ts",
+        "packages/*/src/**/*.tsx"
+      ],
       "linter": {
         "rules": {
           "suspicious": {
@@ -241,6 +246,38 @@
         "rules": {
           "suspicious": {
             "noConsole": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": [
+        "packages/chat/src/**/*.ts",
+        "packages/chat/src/**/*.tsx",
+        "packages/social/src/**/*.ts",
+        "packages/social/src/**/*.tsx",
+        "packages/smrt-app-mcp/src/**/*.ts",
+        "packages/smrt-app-mcp/src/**/*.tsx",
+        "packages/gnode/src/**/*.ts",
+        "packages/gnode/src/**/*.tsx",
+        "packages/assets-local/src/**/*.ts",
+        "packages/assets-local/src/**/*.tsx",
+        "packages/config/src/**/*.ts",
+        "packages/config/src/**/*.tsx",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.spec.ts",
+        "!**/*.spec.tsx",
+        "!**/__tests__/**",
+        "!**/test/**",
+        "!**/tests/**",
+        "!**/mock-*.ts",
+        "!**/test-*.ts"
+      ],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "error"
           }
         }
       }

--- a/biome.json
+++ b/biome.json
@@ -58,9 +58,7 @@
                 "selector": {
                   "kind": "interface"
                 },
-                "formats": [
-                  "PascalCase"
-                ]
+                "formats": ["PascalCase"]
               }
             ]
           }
@@ -122,10 +120,7 @@
       }
     },
     {
-      "includes": [
-        "packages/*/src/**/*.ts",
-        "packages/*/src/**/*.tsx"
-      ],
+      "includes": ["packages/*/src/**/*.ts", "packages/*/src/**/*.tsx"],
       "linter": {
         "rules": {
           "suspicious": {
@@ -254,16 +249,22 @@
       "includes": [
         "packages/chat/src/**/*.ts",
         "packages/chat/src/**/*.tsx",
+        "packages/chat/src/**/*.svelte",
         "packages/social/src/**/*.ts",
         "packages/social/src/**/*.tsx",
+        "packages/social/src/**/*.svelte",
         "packages/smrt-app-mcp/src/**/*.ts",
         "packages/smrt-app-mcp/src/**/*.tsx",
+        "packages/smrt-app-mcp/src/**/*.svelte",
         "packages/gnode/src/**/*.ts",
         "packages/gnode/src/**/*.tsx",
+        "packages/gnode/src/**/*.svelte",
         "packages/assets-local/src/**/*.ts",
         "packages/assets-local/src/**/*.tsx",
+        "packages/assets-local/src/**/*.svelte",
         "packages/config/src/**/*.ts",
         "packages/config/src/**/*.tsx",
+        "packages/config/src/**/*.svelte",
         "!**/*.test.ts",
         "!**/*.test.tsx",
         "!**/*.spec.ts",

--- a/packages/config/src/merge.ts
+++ b/packages/config/src/merge.ts
@@ -21,7 +21,7 @@ globalThis.__smrtRuntimeConfig ??= {};
  * @param source - Override object (higher priority).
  * @returns A new merged object.
  */
-function deepMerge<T extends Record<string, any>>(
+function deepMerge<T extends Record<string, unknown>>(
   target: T,
   source: Partial<T>,
 ): T {
@@ -48,8 +48,8 @@ function deepMerge<T extends Record<string, any>>(
       !Array.isArray(targetValue)
     ) {
       result[key] = deepMerge(
-        targetValue as Record<string, any>,
-        sourceValue as Record<string, any>,
+        targetValue as Record<string, unknown>,
+        sourceValue as Record<string, unknown>,
       );
     } else if (sourceValue !== undefined && sourceValue !== null) {
       result[key] = sourceValue;


### PR DESCRIPTION
## Summary

Starts the held **S4 strictness ratchet** ([#1579](https://github.com/happyvertical/smrt/issues/1579)): retire the blanket `packages/*/src` `noExplicitAny` exemption package-by-package, locking each graduated package in at `error` so new `any` can't regress.

## Mechanism (the reusable part)
Append a single `noExplicitAny: "error"` override keyed by an **explicit graduated-package list** (Biome applies later overrides last, so it wins over the blanket-`off` override). Underwater packages stay soft (base `info`, non-failing); graduated packages fail CI on any new `any`. Test files are excluded via `!` negations so the existing test exemption still holds.

**A package graduates simply by joining that list** — purely additive, so future per-package graduation PRs don't fight over a shared glob.

## Graduated in this wave (all verified 0 `noExplicitAny`)
- `chat`, `social`, `smrt-app-mcp`, `gnode`, `assets-local` — already clean, no code change
- `config` — `merge.ts` `deepMerge`: internal generic constraint + two recursion casts move `Record<string, any>` → `Record<string, unknown>` (safe — `deepMerge` is non-exported and its only callers already use `unknown`; avoids the [generic-constraint trap](https://github.com/happyvertical/smrt/issues/1242))

## Verification
- Ratchet **bites**: an injected `any` in a graduated package is flagged by `biome lint`.
- Test exclusion works: `config/export.test.ts`'s `any` is not flagged.
- `config` typecheck clean + **261 tests pass**.

## Remaining debt (measured with rule=error)
core 1540 · content 765 · cli 599 · users 482 · then a long low/medium tail. These graduate in subsequent waves (low/medium tail via parallel agents; the heavy four as focused efforts).

Refs #1579