### PR TITLE
refactor(types): core noExplicitAny Phase 1 — leaf files (#1579)

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -57,7 +57,7 @@ export interface AIConfig {
   /**
    * Additional provider-specific options
    */
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 /**

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -7,7 +7,7 @@
  * @module
  */
 
-import type { DatabaseInterface } from '@happyvertical/sql';
+import type { DatabaseInterface, SchemasOption } from '@happyvertical/sql';
 import { getDatabase } from '@happyvertical/sql';
 
 /**
@@ -41,7 +41,7 @@ export type DatabaseConfig =
       url?: string;
       type?: 'sqlite' | 'postgres' | 'duckdb' | 'json';
       authToken?: string;
-      [key: string]: any;
+      [key: string]: unknown;
     }
   | DatabaseInterface;
 
@@ -66,7 +66,7 @@ export function isDatabaseInterface(
     value !== null &&
     typeof value === 'object' &&
     'query' in value &&
-    typeof (value as any).query === 'function'
+    typeof (value as { query: unknown }).query === 'function'
   );
 }
 
@@ -86,7 +86,7 @@ export interface ResolveDatabaseOptions {
    * Intended for explicit tooling and test utilities that bootstrap schema
    * ahead of runtime. Core runtime no longer passes these automatically.
    */
-  schemas?: Record<string, any>;
+  schemas?: SchemasOption;
 }
 
 /**
@@ -145,10 +145,14 @@ export async function resolveDatabase(
   const canUseMemory = !config.type || config.type === 'sqlite';
   const dbUrl = config.url || (canUseMemory ? ':memory:' : '');
   const isMemoryDb = dbUrl === ':memory:';
+  // `config` is the loosely-typed config-object variant of `DatabaseConfig`
+  // (it carries an open `[key: string]: unknown` index for adapter-specific
+  // options). Cast the merged options to `getDatabase`'s own parameter type at
+  // this boundary; the adapter validates the concrete shape at runtime.
   return getDatabase({
     ...config,
     url: dbUrl,
     schemas,
     ...(isMemoryDb ? {} : { dbid: dbid ?? `smrt:${dbUrl}` }),
-  } as any);
+  } as Parameters<typeof getDatabase>[0]);
 }

--- a/packages/core/src/embeddings/provider.ts
+++ b/packages/core/src/embeddings/provider.ts
@@ -11,14 +11,17 @@ import type { EmbeddingProviderType, ProjectEmbeddingConfig } from './types';
 /**
  * Dynamically import an optional dependency.
  * Uses a variable to prevent TypeScript from statically analyzing the import.
+ *
+ * The resolved value is the imported module namespace; callers narrow it to a
+ * concrete shape (e.g. {@link TransformersModule}) at the point of use.
  */
-async function importOptional(moduleName: string): Promise<any> {
+async function importOptional(moduleName: string): Promise<unknown> {
   // Using a variable prevents TypeScript from trying to resolve the module at compile time
   const name = moduleName;
   return import(/* @vite-ignore */ name);
 }
 
-export type OptionalModuleImporter = (moduleName: string) => Promise<any>;
+export type OptionalModuleImporter = (moduleName: string) => Promise<unknown>;
 
 export const LOCAL_TRANSFORMERS_PACKAGES = [
   '@huggingface/transformers',
@@ -28,8 +31,21 @@ export const LOCAL_TRANSFORMERS_PACKAGES = [
 export type LocalTransformersPackage =
   (typeof LOCAL_TRANSFORMERS_PACKAGES)[number];
 
+/**
+ * Minimal surface of a transformers.js package used for local embeddings.
+ * Only the `pipeline` factory is consumed; its result is narrowed to a
+ * {@link FeatureExtractionPipeline} at the call site.
+ */
+export interface TransformersModule {
+  pipeline: (task: string, model: string) => Promise<unknown>;
+}
+
 export interface TransformersModuleResolution {
-  module: any;
+  /**
+   * The imported module namespace. Typed as `unknown` because the importer may
+   * resolve arbitrary modules; consumers cast to {@link TransformersModule}.
+   */
+  module: unknown;
   packageName: LocalTransformersPackage;
 }
 
@@ -109,7 +125,11 @@ export class EmbeddingProvider {
   constructor(config: ProjectEmbeddingConfig, ai?: unknown) {
     this.config = config;
     // Cast to EmbeddingCapableAI if it has an embed method
-    if (ai && typeof (ai as any).embed === 'function') {
+    if (
+      typeof ai === 'object' &&
+      ai !== null &&
+      typeof (ai as { embed?: unknown }).embed === 'function'
+    ) {
       this.ai = ai as EmbeddingCapableAI;
     } else {
       this.ai = null;
@@ -185,8 +205,10 @@ export class EmbeddingProvider {
    * Initialize the local embedding pipeline
    */
   private async initLocalPipeline(): Promise<FeatureExtractionPipeline> {
-    const { module: transformers } = await resolveLocalTransformersModule();
-    const { pipeline } = transformers;
+    const { module } = await resolveLocalTransformersModule();
+    // The resolved module is the transformers.js namespace; narrow to the
+    // minimal surface we consume.
+    const { pipeline } = module as TransformersModule;
 
     const model = this.config.localModel || 'Xenova/bge-base-en-v1.5';
 

--- a/packages/core/src/embeddings/storage.ts
+++ b/packages/core/src/embeddings/storage.ts
@@ -120,7 +120,7 @@ export class EmbeddingStorage {
         // Parameter numbering starts at $2 because vector.search() reserves
         // $1 for the query vector embedding in its internal SQL query.
         const conditions: string[] = ['object_class = $2'];
-        const params: any[] = [objectClass];
+        const params: unknown[] = [objectClass];
 
         if (field) {
           conditions.push(`field_name = $${params.length + 2}`);

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -45,14 +45,14 @@ export abstract class SmrtError extends Error {
     | 'network'
     | 'configuration'
     | 'runtime';
-  public readonly details?: Record<string, any>;
+  public readonly details?: Record<string, unknown>;
   public readonly cause?: Error;
 
   constructor(
     message: string,
     code: string,
     category: SmrtError['category'],
-    details?: Record<string, any>,
+    details?: Record<string, unknown>,
     cause?: Error,
   ) {
     super(message);
@@ -177,7 +177,7 @@ export class DatabaseError extends SmrtError {
   constructor(
     message: string,
     code: string,
-    details?: Record<string, any>,
+    details?: Record<string, unknown>,
     cause?: Error,
   ) {
     super(message, code, 'database', details, cause);
@@ -223,7 +223,7 @@ export class DatabaseError extends SmrtError {
 
   static constraintViolation(
     constraint: string,
-    value: any,
+    value: unknown,
     cause?: Error,
   ): DatabaseError {
     return new DatabaseError(
@@ -268,7 +268,7 @@ export class DatabaseError extends SmrtError {
     id: string;
     slug: string;
     context: string;
-    conflictIdentity: Record<string, any>;
+    conflictIdentity: Record<string, unknown>;
     legacyMetaType: string;
     qualifiedMetaType: string;
     duplicateId: string;
@@ -313,7 +313,7 @@ export class AIError extends SmrtError {
   constructor(
     message: string,
     code: string,
-    details?: Record<string, any>,
+    details?: Record<string, unknown>,
     cause?: Error,
   ) {
     super(message, code, 'ai', details, cause);
@@ -340,7 +340,7 @@ export class AIError extends SmrtError {
     );
   }
 
-  static invalidResponse(provider: string, response: any): AIError {
+  static invalidResponse(provider: string, response: unknown): AIError {
     return new AIError(
       `AI provider '${provider}' returned invalid response`,
       'AI_INVALID_RESPONSE',
@@ -371,7 +371,7 @@ export class FilesystemError extends SmrtError {
   constructor(
     message: string,
     code: string,
-    details?: Record<string, any>,
+    details?: Record<string, unknown>,
     cause?: Error,
   ) {
     super(message, code, 'filesystem', details, cause);
@@ -422,7 +422,7 @@ export class ValidationError extends SmrtError {
   constructor(
     message: string,
     code: string,
-    details?: Record<string, any>,
+    details?: Record<string, unknown>,
     cause?: Error,
   ) {
     super(message, code, 'validation', details, cause);
@@ -438,7 +438,7 @@ export class ValidationError extends SmrtError {
 
   static invalidValue(
     fieldName: string,
-    value: any,
+    value: unknown,
     expectedType: string,
   ): ValidationError {
     return new ValidationError(
@@ -448,9 +448,9 @@ export class ValidationError extends SmrtError {
     );
   }
 
-  static uniqueConstraint(fieldName: string, value: any): ValidationError {
+  static uniqueConstraint(fieldName: string, value: unknown): ValidationError {
     return new ValidationError(
-      `Unique constraint violation for field '${fieldName}' with value: ${value}`,
+      `Unique constraint violation for field '${fieldName}' with value: ${String(value)}`,
       'VALIDATION_UNIQUE_CONSTRAINT',
       { fieldName, value },
     );
@@ -492,7 +492,7 @@ export class NetworkError extends SmrtError {
   constructor(
     message: string,
     code: string,
-    details?: Record<string, any>,
+    details?: Record<string, unknown>,
     cause?: Error,
   ) {
     super(message, code, 'network', details, cause);
@@ -553,7 +553,7 @@ export class ConfigurationError extends SmrtError {
   constructor(
     message: string,
     code: string,
-    details?: Record<string, any>,
+    details?: Record<string, unknown>,
     cause?: Error,
   ) {
     super(message, code, 'configuration', details, cause);
@@ -572,7 +572,7 @@ export class ConfigurationError extends SmrtError {
 
   static invalidConfiguration(
     configKey: string,
-    value: any,
+    value: unknown,
     expected: string,
   ): ConfigurationError {
     return new ConfigurationError(
@@ -655,7 +655,7 @@ export class RuntimeError extends SmrtError {
   constructor(
     message: string,
     code: string,
-    details?: Record<string, any>,
+    details?: Record<string, unknown>,
     cause?: Error,
   ) {
     super(message, code, 'runtime', details, cause);
@@ -676,7 +676,7 @@ export class RuntimeError extends SmrtError {
 
   static invalidState(
     message: string,
-    context?: Record<string, any>,
+    context?: Record<string, unknown>,
   ): RuntimeError {
     return new RuntimeError(message, 'RUNTIME_INVALID_STATE', context);
   }
@@ -741,7 +741,7 @@ export class TenantIsolationError extends SmrtError {
     details?: {
       tenantId?: string;
       attemptedTenantId?: string;
-      [key: string]: any;
+      [key: string]: unknown;
     },
     cause?: Error,
   ) {
@@ -857,8 +857,8 @@ export class ErrorUtils {
   /**
    * Sanitizes an error for safe logging (removes sensitive information)
    */
-  static sanitizeError(error: Error): Record<string, any> {
-    const sanitized: Record<string, any> = {
+  static sanitizeError(error: Error): Record<string, unknown> {
+    const sanitized: Record<string, unknown> = {
       name: error.name,
       message: error.message,
       stack: error.stack,
@@ -870,7 +870,8 @@ export class ErrorUtils {
 
       // Sanitize details to remove potential sensitive information
       if (error.details) {
-        sanitized.details = { ...error.details };
+        const details: Record<string, unknown> = { ...error.details };
+        sanitized.details = details;
 
         // Remove common sensitive fields
         const sensitiveFields = [
@@ -881,8 +882,8 @@ export class ErrorUtils {
           'apiKey',
         ];
         for (const field of sensitiveFields) {
-          if (sanitized.details[field]) {
-            sanitized.details[field] = '[REDACTED]';
+          if (details[field]) {
+            details[field] = '[REDACTED]';
           }
         }
       }
@@ -1006,7 +1007,7 @@ export class ValidationUtils {
    */
   static async validateField(
     fieldName: string,
-    value: any,
+    value: unknown,
     options: {
       required?: boolean;
       min?: number;
@@ -1015,7 +1016,7 @@ export class ValidationUtils {
       maxLength?: number;
       pattern?: string | RegExp;
       type?: string;
-      customValidator?: (value: any) => boolean | Promise<boolean>;
+      customValidator?: (value: unknown) => boolean | Promise<boolean>;
       customMessage?: string;
     },
     objectType: string = 'Object',
@@ -1114,7 +1115,7 @@ export class ValidationUtils {
    */
   static validateRequired(
     fieldName: string,
-    value: any,
+    value: unknown,
     objectType: string = 'Object',
   ): ValidationError | null {
     if (value === null || value === undefined || value === '') {

--- a/packages/core/src/knowledge.ts
+++ b/packages/core/src/knowledge.ts
@@ -12,10 +12,22 @@ import type {
   SmartObjectManifest,
 } from './scanner/types.js';
 
+/**
+ * Minimal package.json shape consumed by the knowledge builder.
+ * `name`/`version` are typed concretely because they flow into the manifest's
+ * string-typed metadata fields; everything else is read via `unknown`-accepting
+ * helpers (`record()`, `exportKeys()`), so an index signature is sufficient.
+ */
+export interface PackageJsonLike {
+  name?: string;
+  version?: string;
+  [key: string]: unknown;
+}
+
 export interface BuildDomainKnowledgeOptions {
   manifest: SmartObjectManifest;
   rootDir: string;
-  packageJson?: Record<string, any>;
+  packageJson?: PackageJsonLike;
   manifestPath?: string;
   config?: DomainKnowledgeConfig;
 }
@@ -365,7 +377,7 @@ function existingPath(rootDir: string, path: string): string | undefined {
   return existsSync(fullPath) ? fullPath : undefined;
 }
 
-function readPackageJson(rootDir: string): Record<string, any> | null {
+function readPackageJson(rootDir: string): PackageJsonLike | null {
   const path = join(rootDir, 'package.json');
   if (!existsSync(path)) return null;
   return JSON.parse(readFileSync(path, 'utf8'));

--- a/packages/core/src/lazy-config.ts
+++ b/packages/core/src/lazy-config.ts
@@ -355,11 +355,14 @@ export function getClassConfigResolvers(
 ): Record<string, ConfigResolver> | undefined {
   if (typeof ctor !== 'function') return undefined;
 
-  let current: any = ctor;
+  let current: unknown = ctor;
   let collected: Record<string, ConfigResolver> | undefined;
 
   while (current && current !== Function.prototype) {
-    const resolvers = current.configResolvers;
+    // Each link in the prototype chain is an object/function; read its optional
+    // static `configResolvers` map through a typed shape rather than `any`.
+    const resolvers = (current as { configResolvers?: unknown })
+      .configResolvers;
     if (resolvers && typeof resolvers === 'object') {
       collected = {
         ...(resolvers as Record<string, ConfigResolver>),

--- a/packages/core/src/manifest/generator.ts
+++ b/packages/core/src/manifest/generator.ts
@@ -80,6 +80,30 @@ interface PackageInfo {
 }
 
 /**
+ * Subset of the smrt-auto-service Vite plugin options we probe when reading
+ * baseClasses out of a project's vite.config.ts.
+ */
+interface VitePluginOptions {
+  baseClasses?: string[];
+  followImports?: boolean;
+}
+
+/**
+ * Structural shape of a loaded Vite plugin entry as probed by
+ * loadViteConfigBaseClasses(). The plugin may expose its options directly, on
+ * `_options`, or via an `api` object/function — all optional and discovered at
+ * runtime, so each is modeled as optional here.
+ */
+interface VitePluginProbe {
+  name?: string;
+  options?: VitePluginOptions;
+  _options?: VitePluginOptions;
+  api?:
+    | { options?: VitePluginOptions }
+    | (() => { options?: VitePluginOptions });
+}
+
+/**
  * Orchestrates manifest generation with configurable options
  *
  * Consolidates logic from generate-manifest.js and generate-test-manifest.js
@@ -252,13 +276,13 @@ export class ManifestBuilder {
     // Read package.json for metadata
     let packageName: string | undefined;
     let packageVersion: string | undefined;
-    let packageJson: any;
+    let packageJson: { name?: string; version?: string } | undefined;
     try {
       const pkgPath = resolve(process.cwd(), 'package.json');
       const pkgContent = readFileSync(pkgPath, 'utf-8');
       packageJson = JSON.parse(pkgContent);
-      packageName = packageJson.name || undefined;
-      packageVersion = packageJson.version || undefined;
+      packageName = packageJson?.name || undefined;
+      packageVersion = packageJson?.version || undefined;
     } catch {
       // package.json not found - continue without packageName
     }
@@ -439,15 +463,18 @@ export default ${exportName};
         return null;
       }
 
+      // Vite's loaded plugins are a recursive PluginOption[] (plugins, arrays,
+      // falsy values, promises). We only probe a few optional fields, so model
+      // them structurally and narrow defensively instead of using `any`.
+      const plugins = loaded.config.plugins as readonly VitePluginProbe[];
+
       console.log(
         '[smrt] Vite config loaded, plugins:',
-        loaded.config.plugins.map((p: any) => p?.name),
+        plugins.map((p) => p?.name),
       );
 
       // Find smrtPlugin in plugins array
-      const smrtPlugin = loaded.config.plugins.find(
-        (p: any) => p?.name === 'smrt-auto-service',
-      );
+      const smrtPlugin = plugins.find((p) => p?.name === 'smrt-auto-service');
 
       if (!smrtPlugin) {
         console.log(
@@ -459,15 +486,15 @@ export default ${exportName};
       console.log('[smrt] Found smrt-auto-service plugin');
 
       // Try different ways to access options
-      let opts =
-        (smrtPlugin as any).api?.options ||
-        (smrtPlugin as any).options ||
-        (smrtPlugin as any)._options;
+      const api = smrtPlugin.api;
+      let opts: VitePluginOptions | undefined =
+        (typeof api === 'object' && api !== null ? api.options : undefined) ||
+        smrtPlugin.options ||
+        smrtPlugin._options;
 
-      if (!opts && typeof (smrtPlugin as any).api === 'function') {
+      if (!opts && typeof api === 'function') {
         try {
-          const api = (smrtPlugin as any).api();
-          opts = api.options;
+          opts = api().options;
         } catch (e) {
           console.log('[smrt] Could not call plugin.api()');
         }
@@ -486,8 +513,11 @@ export default ${exportName};
 
       console.log('[smrt] Could not access plugin options');
       return null;
-    } catch (error: any) {
-      console.log('[smrt] Error loading vite.config.ts:', error.message);
+    } catch (error) {
+      console.log(
+        '[smrt] Error loading vite.config.ts:',
+        error instanceof Error ? error.message : String(error),
+      );
       console.log('[smrt] Using default baseClasses');
       return null;
     }
@@ -511,13 +541,13 @@ export default ${exportName};
 
       try {
         const manifestContent = readFileSync(manifestPath, 'utf-8');
-        const manifest = JSON.parse(manifestContent);
+        const manifest: SmartObjectManifest = JSON.parse(manifestContent);
 
         // Extract all class names from this package
         const foundClassNames: string[] = [];
         for (const objDef of Object.values(manifest.objects)) {
-          if ((objDef as any).className) {
-            const className = (objDef as any).className;
+          if (objDef.className) {
+            const className = objDef.className;
             foundClassNames.push(className);
             externalBaseClasses.push(className);
           }
@@ -526,9 +556,9 @@ export default ${exportName};
         console.log(
           `[smrt]   ${pkgName}: found ${foundClassNames.length} class(es) - ${foundClassNames.join(', ')}`,
         );
-      } catch (error: any) {
+      } catch (error) {
         console.log(
-          `[smrt]   ${pkgName}: manifest not found or invalid - ${error.message}`,
+          `[smrt]   ${pkgName}: manifest not found or invalid - ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     }

--- a/packages/core/src/manifest/manager.ts
+++ b/packages/core/src/manifest/manager.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { createLogger } from '@happyvertical/logger';
 import { ManifestGenerator } from '../scanner/manifest-generator.js';
-import type { SmartObjectManifest } from '../scanner/types.js';
+import type { ScanResult, SmartObjectManifest } from '../scanner/types.js';
 
 const logger = createLogger({ level: 'info' });
 
@@ -97,12 +97,12 @@ export class ManifestManager {
    * Generates a manifest from scan results and writes it.
    */
   async generateFromScanResults(
-    scanResults: any[],
+    scanResults: ScanResult[],
     options: {
       mode: 'dev' | 'build';
       packageName?: string;
       packageVersion?: string;
-      packageJson?: any;
+      packageJson?: Record<string, unknown>;
       smrtDependencies?: string[];
     },
   ): Promise<SmartObjectManifest> {

--- a/packages/core/src/manifest/manifest-loader.ts
+++ b/packages/core/src/manifest/manifest-loader.ts
@@ -25,6 +25,7 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import { createLogger } from '@happyvertical/logger';
+import type { SmrtObjectConstructor } from '../registry/types.js';
 import { ObjectRegistry } from '../registry.js';
 import type {
   FieldDefinition,
@@ -468,7 +469,7 @@ export function loadLocalTestManifestSync(): Manifest | null | undefined {
  * @returns Package name (e.g., '@happyvertical/smrt-places') or null
  */
 export function getPackageName(
-  ctor: new (...args: any[]) => any,
+  ctor: SmrtObjectConstructor,
   skipRegistry: boolean = false,
 ): string | null {
   try {
@@ -486,8 +487,9 @@ export function getPackageName(
     }
 
     // 2. Check if class has __package__ metadata (could be added by build tooling)
-    if ((ctor as any).__package__) {
-      return (ctor as any).__package__;
+    const packageMeta = (ctor as { __package__?: string }).__package__;
+    if (packageMeta) {
+      return packageMeta;
     }
 
     // 3. Try require.resolve() to find package.json from constructor location
@@ -1100,14 +1102,14 @@ export function findManifestEntryByQualifiedName(
  * @throws {Error} If class name collision detected across different packages
  */
 export async function discoverManifestEntry(
-  ctor: new (...args: any[]) => any,
+  ctor: SmrtObjectConstructor,
   className: string,
 ): Promise<ManifestEntry | undefined> {
   // ✅ FAST PATH: O(1) constructor-based lookup for already-registered classes
   // Skip manifest scanning if we already know this constructor's qualified name via WeakMap
   // This provides instant resolution and prevents collisions (each constructor is unique in memory)
-  if (!(ctor as any)._isManifestStub) {
-    const registered = ObjectRegistry.getClassByConstructor(ctor as any);
+  if (!(ctor as { _isManifestStub?: boolean })._isManifestStub) {
+    const registered = ObjectRegistry.getClassByConstructor(ctor);
     if (
       registered?.qualifiedName &&
       isQualifiedName(registered.qualifiedName)

--- a/packages/core/src/mcp-advisor/index.ts
+++ b/packages/core/src/mcp-advisor/index.ts
@@ -30,6 +30,19 @@ import { listRegisteredObjects } from './tools/list-registered-objects.js';
 import { previewApiEndpoints } from './tools/preview-api-endpoints.js';
 import { previewMcpTools } from './tools/preview-mcp-tools.js';
 import { validateSmrtObject } from './tools/validate-smrt-object.js';
+import type {
+  AddAiMethodsInput,
+  ConfigureDecoratorsInput,
+  GenerateCollectionInput,
+  GenerateFieldDefinitionsInput,
+  GenerateSmrtClassInput,
+  GetObjectConfigInput,
+  GetObjectSchemaInput,
+  ListRegisteredObjectsInput,
+  PreviewApiEndpointsInput,
+  PreviewMcpToolsInput,
+  ValidateSmrtObjectInput,
+} from './types.js';
 
 // Server configuration
 const SERVER_NAME = 'smrt-advisor';
@@ -375,30 +388,37 @@ export const TOOLS = [
  * Exported so the routing switch can be unit-tested in-process (the stdio
  * entrypoint guard below keeps importing this module side-effect free).
  */
-export async function handleToolCall(name: string, args: any): Promise<any> {
+export async function handleToolCall(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
   switch (name) {
     case 'generate-smrt-class':
-      return generateSmrtClass(args);
+      return generateSmrtClass(args as unknown as GenerateSmrtClassInput);
     case 'add-ai-methods':
-      return addAiMethods(args);
+      return addAiMethods(args as unknown as AddAiMethodsInput);
     case 'generate-field-definitions':
-      return generateFieldDefinitions(args);
+      return generateFieldDefinitions(
+        args as unknown as GenerateFieldDefinitionsInput,
+      );
     case 'generate-collection':
-      return generateCollection(args);
+      return generateCollection(args as unknown as GenerateCollectionInput);
     case 'configure-decorators':
-      return configureDecorators(args);
+      return configureDecorators(args as unknown as ConfigureDecoratorsInput);
     case 'validate-smrt-object':
-      return validateSmrtObject(args);
+      return validateSmrtObject(args as unknown as ValidateSmrtObjectInput);
     case 'preview-api-endpoints':
-      return previewApiEndpoints(args);
+      return previewApiEndpoints(args as unknown as PreviewApiEndpointsInput);
     case 'preview-mcp-tools':
-      return previewMcpTools(args);
+      return previewMcpTools(args as unknown as PreviewMcpToolsInput);
     case 'list-registered-objects':
-      return listRegisteredObjects(args);
+      return listRegisteredObjects(
+        args as unknown as ListRegisteredObjectsInput,
+      );
     case 'get-object-schema':
-      return getObjectSchema(args);
+      return getObjectSchema(args as unknown as GetObjectSchemaInput);
     case 'get-object-config':
-      return getObjectConfig(args);
+      return getObjectConfig(args as unknown as GetObjectConfigInput);
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/packages/core/src/mcp-advisor/tools/get-object-config.ts
+++ b/packages/core/src/mcp-advisor/tools/get-object-config.ts
@@ -43,7 +43,9 @@ export async function getObjectConfig(
       for (const methodName of methodNames) {
         if (
           methodName !== 'constructor' &&
-          typeof (prototype as any)[methodName] === 'function' &&
+          typeof (prototype as unknown as Record<string, unknown>)[
+            methodName
+          ] === 'function' &&
           ![
             'save',
             'delete',
@@ -100,8 +102,10 @@ export async function getObjectConfig(
 /**
  * Extract constraints from field options
  */
-function extractConstraints(options: any): Record<string, any> {
-  const constraints: Record<string, any> = {};
+function extractConstraints(
+  options: Record<string, unknown>,
+): Record<string, unknown> {
+  const constraints: Record<string, unknown> = {};
 
   if (options.min !== undefined) constraints.min = options.min;
   if (options.max !== undefined) constraints.max = options.max;

--- a/packages/core/src/mcp-advisor/tools/get-object-schema.ts
+++ b/packages/core/src/mcp-advisor/tools/get-object-schema.ts
@@ -64,8 +64,10 @@ export async function getObjectSchema(
 /**
  * Extract constraints from field options
  */
-function extractConstraints(options: any): Record<string, any> {
-  const constraints: Record<string, any> = {};
+function extractConstraints(
+  options: Record<string, unknown>,
+): Record<string, unknown> {
+  const constraints: Record<string, unknown> = {};
 
   if (options.min !== undefined) constraints.min = options.min;
   if (options.max !== undefined) constraints.max = options.max;

--- a/packages/core/src/mcp-advisor/tools/preview-mcp-tools.ts
+++ b/packages/core/src/mcp-advisor/tools/preview-mcp-tools.ts
@@ -54,7 +54,10 @@ export async function previewMcpTools(
 /**
  * Format tools as markdown table
  */
-function formatToolsAsMarkdown(tools: any[], className: string): string {
+function formatToolsAsMarkdown(
+  tools: McpToolDefinition[],
+  className: string,
+): string {
   let markdown = `# MCP Tools for ${className}\n\n`;
   markdown += `| Tool Name | Description | Parameters |\n`;
   markdown += `|-----------|-------------|------------|\n`;

--- a/packages/core/src/mcp-advisor/types.ts
+++ b/packages/core/src/mcp-advisor/types.ts
@@ -9,7 +9,7 @@
  */
 export interface ToolResponse {
   success: boolean;
-  data?: any;
+  data?: unknown;
   error?: string;
   warnings?: string[];
 }
@@ -54,7 +54,7 @@ export interface GenerateFieldDefinitionsInput {
       | 'datetime'
       | 'json'
       | 'foreignKey';
-    _meta?: Record<string, any>;
+    _meta?: Record<string, unknown>;
   }>;
 }
 
@@ -161,7 +161,7 @@ export interface McpToolDefinition {
   description: string;
   inputSchema: {
     type: string;
-    properties: Record<string, any>;
+    properties: Record<string, unknown>;
     required?: string[];
   };
 }
@@ -201,9 +201,9 @@ export interface FieldDefinition {
   name: string;
   type: string;
   required: boolean;
-  default?: any;
+  default?: unknown;
   description?: string;
-  constraints?: Record<string, any>;
+  constraints?: Record<string, unknown>;
 }
 
 /**

--- a/packages/core/src/migrations/differ.ts
+++ b/packages/core/src/migrations/differ.ts
@@ -123,7 +123,7 @@ export class SchemaComparer {
     // lets callers override when `db.url` is empty or points at an adapter
     // whose engine isn't obvious from the URL alone (some in-memory wrappers).
     this.engine =
-      typeof (this.db as any).exportTable === 'function'
+      typeof (this.db as { exportTable?: unknown }).exportTable === 'function'
         ? 'json'
         : detectEngine(resolveDatabaseUrl(this.db), this.options.engineHint);
     this.ddlStrategy = getDDLStrategy(this.engine);

--- a/packages/core/src/schema/code-generator.ts
+++ b/packages/core/src/schema/code-generator.ts
@@ -4,7 +4,13 @@
  */
 
 import type { SmartObjectDefinition } from '../scanner/types.js';
-import type { SchemaDefinition } from './types.js';
+import type {
+  ColumnDefinition,
+  ForeignKeyDefinition,
+  IndexDefinition,
+  SchemaDefinition,
+  TriggerDefinition,
+} from './types.js';
 
 export class SchemaCodeGenerator {
   /**
@@ -86,7 +92,7 @@ export class SchemaCodeGenerator {
   /**
    * Generate columns object
    */
-  private generateColumns(columns: Record<string, any>): string {
+  private generateColumns(columns: Record<string, ColumnDefinition>): string {
     const entries = Object.entries(columns).map(([name, def]) => {
       const defStr = JSON.stringify(def, null, 6).replace(/^/gm, '      ');
       return `    ${JSON.stringify(name)}: ${defStr}`;
@@ -100,7 +106,7 @@ ${entries.join(',\n')}
   /**
    * Generate indexes array
    */
-  private generateIndexes(indexes: any[]): string {
+  private generateIndexes(indexes: IndexDefinition[]): string {
     if (indexes.length === 0) return '[]';
 
     const indexStrings = indexes.map((idx) =>
@@ -115,7 +121,7 @@ ${indexStrings.join(',\n')}
   /**
    * Generate triggers array
    */
-  private generateTriggers(triggers: any[]): string {
+  private generateTriggers(triggers: TriggerDefinition[]): string {
     if (triggers.length === 0) return '[]';
 
     const triggerStrings = triggers.map((trigger) =>
@@ -130,7 +136,7 @@ ${triggerStrings.join(',\n')}
   /**
    * Generate foreign keys array
    */
-  private generateForeignKeys(foreignKeys: any[]): string {
+  private generateForeignKeys(foreignKeys: ForeignKeyDefinition[]): string {
     if (foreignKeys.length === 0) return '[]';
 
     const fkStrings = foreignKeys.map((fk) =>

--- a/packages/core/src/schema/ddl/base-strategy.ts
+++ b/packages/core/src/schema/ddl/base-strategy.ts
@@ -320,7 +320,7 @@ export abstract class BaseDDLStrategy implements DDLStrategy {
    * the SQL NULL keyword. Boolean rendering is bridged through
    * `formatBooleanDefault` so engine overrides (SQLite → 0/1) still apply.
    */
-  formatDefaultValue(value: any, type: SQLDataType): string {
+  formatDefaultValue(value: unknown, type: SQLDataType): string {
     return formatDefaultValueShared(value, type, {
       booleanLiterals: [
         this.formatBooleanDefault(true),
@@ -333,7 +333,7 @@ export abstract class BaseDDLStrategy implements DDLStrategy {
    * Format boolean default
    * Override for engines that use INTEGER (SQLite)
    */
-  protected formatBooleanDefault(value: any): string {
+  protected formatBooleanDefault(value: boolean): string {
     return value ? 'TRUE' : 'FALSE';
   }
 

--- a/packages/core/src/schema/ddl/sqlite-strategy.ts
+++ b/packages/core/src/schema/ddl/sqlite-strategy.ts
@@ -77,7 +77,7 @@ export class SQLiteStrategy extends BaseDDLStrategy {
    * literals — so SQLite booleans render as 0/1 and no CAST expression is ever
    * emitted in a DEFAULT clause.
    */
-  protected formatBooleanDefault(value: any): string {
+  protected formatBooleanDefault(value: boolean): string {
     return value ? '1' : '0';
   }
 

--- a/packages/core/src/schema/ddl/types.ts
+++ b/packages/core/src/schema/ddl/types.ts
@@ -90,7 +90,7 @@ export interface DDLStrategy {
    * @param type - The column type
    * @returns Formatted default value SQL
    */
-  formatDefaultValue(value: any, type: SQLDataType): string;
+  formatDefaultValue(value: unknown, type: SQLDataType): string;
 
   /**
    * Whether this engine supports database triggers

--- a/packages/core/src/schema/override-system.ts
+++ b/packages/core/src/schema/override-system.ts
@@ -6,8 +6,11 @@
 import { createHash } from 'node:crypto';
 import type {
   ColumnDefinition,
+  ForeignKeyDefinition,
+  IndexDefinition,
   SchemaDefinition,
   SchemaOverride,
+  TriggerDefinition,
 } from './types.js';
 
 export class SchemaOverrideSystem {
@@ -91,9 +94,9 @@ export class SchemaOverrideSystem {
     extensions: {
       addColumns?: Record<string, ColumnDefinition>;
       removeColumns?: string[];
-      addIndexes?: Array<any>;
+      addIndexes?: IndexDefinition[];
       removeIndexes?: string[];
-      addTriggers?: Array<any>;
+      addTriggers?: TriggerDefinition[];
       removeTriggers?: string[];
     },
   ): SchemaOverride {
@@ -273,8 +276,8 @@ export class SchemaOverrideSystem {
    */
   private static extractForeignKeys(
     columns: Record<string, ColumnDefinition>,
-  ): Array<any> {
-    const foreignKeys: Array<any> = [];
+  ): ForeignKeyDefinition[] {
+    const foreignKeys: ForeignKeyDefinition[] = [];
 
     for (const [columnName, columnDef] of Object.entries(columns)) {
       if (columnDef.foreignKey) {

--- a/packages/core/src/schema/schema-aggregator.ts
+++ b/packages/core/src/schema/schema-aggregator.ts
@@ -339,10 +339,12 @@ export class SchemaAggregator {
       const localPath = localPaths[packageName];
       if (existsSync(localPath)) {
         try {
-          const content = JSON.parse(readFileSync(localPath, 'utf-8'));
+          const content = JSON.parse(
+            readFileSync(localPath, 'utf-8'),
+          ) as SmartObjectManifest;
           // Only use local if it has schemas
           const hasSchemas = Object.values(content.objects || {}).some(
-            (obj: any) => obj.schema?.ddl,
+            (obj) => obj.schema?.ddl,
           );
           if (hasSchemas) return content;
         } catch {
@@ -393,10 +395,10 @@ export class SchemaAggregator {
 
     for (const manifest of manifests) {
       for (const [_key, object] of Object.entries(manifest.objects)) {
-        const schema = (object as any).schema;
+        const schema = object.schema;
         if (!schema?.ddl) continue;
 
-        const className: string = (object as any).className || _key;
+        const className: string = object.className || _key;
         const tableName: string = schema.tableName;
         const existing = tables.get(tableName);
 

--- a/packages/core/src/schema/schema-manager.ts
+++ b/packages/core/src/schema/schema-manager.ts
@@ -19,6 +19,21 @@ import {
 import type { SchemaDefinition } from './types.js';
 
 /**
+ * Normalize a `db.query` result into an array of rows.
+ *
+ * Adapters return either a bare row array or a `{ rows }` envelope. This
+ * mirrors the prior inline `Array.isArray(result) ? result : result?.rows ?? []`
+ * narrowing while keeping the row shape typed for callers.
+ */
+function extractRows<Row>(result: unknown): Row[] {
+  if (Array.isArray(result)) {
+    return result as Row[];
+  }
+  const rows = (result as { rows?: unknown } | null | undefined)?.rows;
+  return Array.isArray(rows) ? (rows as Row[]) : [];
+}
+
+/**
  * Schema Manager Options
  */
 export interface SchemaManagerOptions {
@@ -52,7 +67,7 @@ export class SchemaManager {
     // Detect or use provided engine
     if (options.engine) {
       this.engine = options.engine;
-    } else if ((db as any).exportTable) {
+    } else if ((db as { exportTable?: unknown }).exportTable) {
       // JSON adapter detected (has unique exportTable method)
       // JSON adapter uses DuckDB internally, but native UUID values do not
       // round-trip through the SDK row objects as canonical UUID strings.
@@ -100,7 +115,13 @@ export class SchemaManager {
     // Prefer adapter's syncSchema if available (handles adapter-specific transformations)
     // This is critical for JSON adapter which needs to convert UNIQUE indexes to
     // inline constraints for DuckDB compatibility
-    if ((this.db as any).syncSchema) {
+    // Adapters that support direct DDL sync expose an optional `syncSchema`
+    // method beyond the base `DatabaseInterface`; narrow to it here so both the
+    // capability check and the call preserve `this.db` as the receiver.
+    const dbWithSync = this.db as DatabaseInterface & {
+      syncSchema?: (schema: string) => Promise<void>;
+    };
+    if (dbWithSync.syncSchema) {
       // Combine DDL into single schema string for adapter's syncSchema
       const fullSchema = [
         ddl.createTable,
@@ -116,7 +137,7 @@ export class SchemaManager {
       }
 
       try {
-        await (this.db as any).syncSchema(fullSchema);
+        await dbWithSync.syncSchema(fullSchema);
 
         // FIX #735: Verify table was actually created
         // Some adapters (notably PostgreSQL) may silently fail to create tables
@@ -198,9 +219,7 @@ export class SchemaManager {
           'SELECT column_name FROM information_schema.columns WHERE table_name = $1',
           tableName,
         );
-        const rows = Array.isArray(result)
-          ? result
-          : ((result as any)?.rows ?? []);
+        const rows = extractRows<{ column_name: string }>(result);
         for (const row of rows) {
           columns.add(row.column_name);
         }
@@ -209,9 +228,7 @@ export class SchemaManager {
         const result = await this.db.query(
           `PRAGMA table_info(${this.quoteIdentifier(tableName)})`,
         );
-        const rows = Array.isArray(result)
-          ? result
-          : ((result as any)?.rows ?? []);
+        const rows = extractRows<{ name: string }>(result);
         for (const row of rows) {
           columns.add(row.name);
         }

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -28,7 +28,7 @@ export interface ColumnDefinition {
   referenceKind?: 'id' | 'foreignKey' | 'crossPackageRef' | 'tenantId';
   unique?: boolean;
   notNull?: boolean;
-  defaultValue?: any;
+  defaultValue?: unknown;
   foreignKey?: {
     table: string;
     column: string;

--- a/packages/core/src/schema/utils.ts
+++ b/packages/core/src/schema/utils.ts
@@ -9,7 +9,9 @@
  */
 
 import type { DatabaseInterface } from '@happyvertical/sql';
+import type { SmrtObject } from '../object.js';
 import { ObjectRegistry } from '../registry.js';
+import type { FieldDefinition } from '../scanner/types.js';
 import { tableNameFromClass } from '../utils.js';
 import type { DatabaseEngine } from './ddl/types.js';
 import { SchemaManager } from './schema-manager.js';
@@ -33,8 +35,13 @@ export { isJsonPathIndex, renderIndexTarget } from './index-utils.js';
  * @returns SQL schema creation statement with CREATE TABLE and CREATE INDEX statements
  */
 export async function generateSchema(
-  ClassType: new (...args: any[]) => any,
-  providedFields?: Map<string, any>,
+  // Accepts any SmrtObject constructor: the registry-stored `typeof SmrtObject`
+  // as well as collection item classes whose construct signature is narrower
+  // than the full static surface. Only `.name` and the construct identity are
+  // used here. `never[]` keeps the construct signature contravariantly
+  // compatible with constructors that declare their own argument shapes.
+  ClassType: { new (...args: never[]): SmrtObject; readonly name: string },
+  providedFields?: Map<string, FieldDefinition>,
   options: { engine?: DatabaseEngine } = {},
 ) {
   const className = ClassType.name;
@@ -55,11 +62,15 @@ export async function generateSchema(
   // Throw error if no fields found
   if (cachedFields.size === 0) {
     // Detect if running in test environment
+    const testGlobals = globalThis as {
+      describe?: unknown;
+      it?: unknown;
+    };
     const isTestEnv =
       process.env.NODE_ENV === 'test' ||
       process.env.VITEST === 'true' ||
-      typeof (globalThis as any).describe !== 'undefined' ||
-      typeof (globalThis as any).it !== 'undefined';
+      typeof testGlobals.describe !== 'undefined' ||
+      typeof testGlobals.it !== 'undefined';
 
     const testHint = isTestEnv
       ? `\n\n⚠️  Are you using 'smrt test'? ` +

--- a/packages/core/src/signals/sanitizer.ts
+++ b/packages/core/src/signals/sanitizer.ts
@@ -21,7 +21,7 @@ export interface SanitizationConfig {
    * Custom replacer function for sanitization
    * Return undefined to redact the value entirely
    */
-  replacer?: (key: string, value: any) => any;
+  replacer?: (key: string, value: unknown) => unknown;
 
   /**
    * Replacement value for redacted fields
@@ -89,7 +89,7 @@ export class SignalSanitizer {
    *
    * Redacts sensitive keys and truncates long strings
    */
-  private defaultReplacer(key: string, value: any): any {
+  private defaultReplacer(key: string, value: unknown): unknown {
     // Check if key should be redacted
     const lowerKey = key.toLowerCase();
     if (
@@ -109,7 +109,7 @@ export class SignalSanitizer {
   /**
    * Sanitize a value using the configured replacer
    */
-  private sanitizeValue(value: any, seen = new WeakSet()): any {
+  private sanitizeValue(value: unknown, seen = new WeakSet()): unknown {
     // Handle null/undefined
     if (value == null) {
       return value;
@@ -146,7 +146,7 @@ export class SignalSanitizer {
     }
 
     // Handle regular objects
-    const sanitized: Record<string, any> = {};
+    const sanitized: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value)) {
       const replacedValue = this.config.replacer(key, val);
       if (replacedValue !== undefined) {
@@ -173,12 +173,25 @@ export class SignalSanitizer {
       timestamp: signal.timestamp,
       ...(signal.step && { step: signal.step }),
       ...(signal.duration !== undefined && { duration: signal.duration }),
-      ...(signal.args && { args: this.sanitizeValue(signal.args) }),
+      // `signal.args` is an array, so `sanitizeValue` always returns an array
+      // (the `Array.isArray` branch maps element-wise).
+      ...(signal.args && { args: this.sanitizeValue(signal.args) as unknown[] }),
       ...(signal.result !== undefined
         ? { result: this.sanitizeValue(signal.result) }
         : {}),
-      ...(signal.error && { error: this.sanitizeValue(signal.error) }),
-      ...(signal.metadata && { metadata: this.sanitizeValue(signal.metadata) }),
+      // `sanitizeValue` flattens an `Error` into an Error-shaped plain object
+      // (`{ message, name, stack }`); the Signal contract still types it as
+      // `Error`, so retain that surface here.
+      ...(signal.error && {
+        error: this.sanitizeValue(signal.error) as Error,
+      }),
+      // Sanitizing an object yields a `Record<string, unknown>`.
+      ...(signal.metadata && {
+        metadata: this.sanitizeValue(signal.metadata) as Record<
+          string,
+          unknown
+        >,
+      }),
     };
   }
 }

--- a/packages/core/src/system-fields.ts
+++ b/packages/core/src/system-fields.ts
@@ -7,35 +7,40 @@
  * the exact SQL defaults and constraints for these columns.
  */
 
-export const SMRT_SYSTEM_FIELDS = Object.freeze({
-  id: Object.freeze({
-    type: 'text',
-    _meta: Object.freeze({ __smrtSystemField: true }),
-  }),
-  slug: Object.freeze({
-    type: 'text',
-    _meta: Object.freeze({ __smrtSystemField: true }),
-  }),
-  context: Object.freeze({
-    type: 'text',
-    _meta: Object.freeze({ __smrtSystemField: true }),
-  }),
-  created_at: Object.freeze({
-    type: 'datetime',
-    _meta: Object.freeze({ __smrtSystemField: true }),
-  }),
-  updated_at: Object.freeze({
-    type: 'datetime',
-    _meta: Object.freeze({ __smrtSystemField: true }),
-  }),
-});
+import type { FieldDefinition } from './scanner/types.js';
 
-export function isInjectedSmrtSystemField(field: any): boolean {
-  return Boolean(field?._meta?.__smrtSystemField);
+export const SMRT_SYSTEM_FIELDS: Readonly<Record<string, FieldDefinition>> =
+  Object.freeze({
+    id: Object.freeze({
+      type: 'text',
+      _meta: Object.freeze({ __smrtSystemField: true }),
+    }),
+    slug: Object.freeze({
+      type: 'text',
+      _meta: Object.freeze({ __smrtSystemField: true }),
+    }),
+    context: Object.freeze({
+      type: 'text',
+      _meta: Object.freeze({ __smrtSystemField: true }),
+    }),
+    created_at: Object.freeze({
+      type: 'datetime',
+      _meta: Object.freeze({ __smrtSystemField: true }),
+    }),
+    updated_at: Object.freeze({
+      type: 'datetime',
+      _meta: Object.freeze({ __smrtSystemField: true }),
+    }),
+  });
+
+export function isInjectedSmrtSystemField(field: unknown): boolean {
+  const meta = (field as { _meta?: { __smrtSystemField?: unknown } } | null)
+    ?._meta;
+  return Boolean(meta?.__smrtSystemField);
 }
 
-export function cloneSmrtSystemFields(): Record<string, any> {
-  const fields: Record<string, any> = {};
+export function cloneSmrtSystemFields(): Record<string, FieldDefinition> {
+  const fields: Record<string, FieldDefinition> = {};
 
   for (const [fieldName, fieldDef] of Object.entries(SMRT_SYSTEM_FIELDS)) {
     fields[fieldName] = {
@@ -48,9 +53,9 @@ export function cloneSmrtSystemFields(): Record<string, any> {
 }
 
 export function prependSmrtSystemFields(
-  fields: Map<string, any>,
-): Map<string, any> {
-  const merged = new Map<string, any>();
+  fields: Map<string, FieldDefinition>,
+): Map<string, FieldDefinition> {
+  const merged = new Map<string, FieldDefinition>();
 
   for (const [fieldName, fieldDef] of Object.entries(cloneSmrtSystemFields())) {
     merged.set(fieldName, fieldDef);

--- a/packages/core/src/system/types.ts
+++ b/packages/core/src/system/types.ts
@@ -11,7 +11,7 @@ export interface NoteOptions {
   /** Normalized identifier (e.g., URL, entity ID) */
   key: string;
   /** Strategy data (regex patterns, selectors, etc.) */
-  value: any;
+  value: unknown;
   /** Additional metadata */
   metadata?: NoteMetadata;
   /** Confidence score (0.0 to 1.0) */
@@ -56,7 +56,7 @@ export interface NoteMetadata {
   /** Review notes */
   reviewNotes?: string;
   /** Allow any other properties */
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 /**

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -5,28 +5,48 @@
  * to support both CLI and API generator testing scenarios.
  */
 
-import { vi } from 'vitest';
+import { type Mock, vi } from 'vitest';
 import { ObjectRegistry } from './registry.js';
 
-type RegistryTestState = {
+/**
+ * Internal test-only view onto ObjectRegistry's private registration maps.
+ * Snapshot/restore copies these Maps opaquely (values are never inspected),
+ * so the value types are `unknown` rather than the registry's concrete
+ * registration shapes. This is the single boundary where test utilities reach
+ * into registry internals; access goes through a documented cast below.
+ */
+interface RegistryTestSurface {
   // Release B (#1133) removed classNameMap — the `classes` Map below is the
   // single source of truth for every case-insensitive lookup.
-  classes: Map<string, any>;
+  classes: Map<string, unknown>;
   collectionTableNames: Map<string, string>;
-  collections: Map<string, any>;
-  fieldDecorators: Map<string, Map<string, any>>;
+  collections: Map<string, unknown>;
+  fieldDecorators: Map<string, Map<string, unknown>>;
   nextDbId: number;
   stiSiblingsLoaded: Set<string>;
-};
+  clear(): void;
+}
+
+type RegistryTestState = Pick<
+  RegistryTestSurface,
+  | 'classes'
+  | 'collectionTableNames'
+  | 'collections'
+  | 'fieldDecorators'
+  | 'nextDbId'
+  | 'stiSiblingsLoaded'
+>;
 
 function cloneNestedMap(
-  source: Map<string, Map<string, any>>,
-): Map<string, Map<string, any>> {
+  source: Map<string, Map<string, unknown>>,
+): Map<string, Map<string, unknown>> {
   return new Map(Array.from(source, ([key, value]) => [key, new Map(value)]));
 }
 
-function getRegistryForTests() {
-  return ObjectRegistry as any;
+function getRegistryForTests(): RegistryTestSurface {
+  // Documented boundary cast: ObjectRegistry's registration maps are private
+  // statics; tests snapshot them to isolate registry mutations.
+  return ObjectRegistry as unknown as RegistryTestSurface;
 }
 
 /**
@@ -80,20 +100,33 @@ export interface MockObject {
   slug?: string;
   created_at?: string;
   updated_at?: string;
-  [key: string]: any;
+  [key: string]: unknown;
   save: () => Promise<MockObject>;
   delete: () => Promise<void>;
   initialize: () => Promise<void>;
 }
 
 /**
+ * Query options accepted by the mock collection's `list()`.
+ * Mirrors the loosely-typed SmrtCollection query surface used in tests:
+ * `where` keys may carry operator suffixes (e.g. `"age >"`), values are
+ * arbitrary, and ordering/pagination are simple primitives.
+ */
+export interface MockListOptions {
+  where?: Record<string, unknown>;
+  orderBy?: string;
+  offset?: number;
+  limit?: number;
+}
+
+/**
  * Mock collection with all CRUD operations
  */
 export interface MockCollection {
-  list: (options?: any) => Promise<MockObject[]>;
+  list: (options?: MockListOptions) => Promise<MockObject[]>;
   get: (id: string) => Promise<MockObject | null>;
-  create: (data: any) => Promise<MockObject>;
-  update: (id: string, data: any) => Promise<MockObject>;
+  create: (data: Partial<MockObject>) => Promise<MockObject>;
+  update: (id: string, data: Partial<MockObject>) => Promise<MockObject>;
   delete: (id: string) => Promise<void>;
   initialize: () => Promise<void>;
   save: (object: MockObject) => Promise<MockObject>;
@@ -185,85 +218,86 @@ export class MockCollectionFactory {
     }
 
     return {
-      list: vi.fn().mockImplementation(async (options: any = {}) => {
-        let results = Array.from(this.storage.values());
+      list: vi
+        .fn()
+        .mockImplementation(async (options: MockListOptions = {}) => {
+          let results = Array.from(this.storage.values());
 
-        // Apply where filters
-        if (options.where) {
-          results = results.filter((obj) => {
-            return Object.entries(options.where).every(
-              ([key, value]: [string, any]) => {
+          // Apply where filters
+          const where = options.where;
+          if (where) {
+            results = results.filter((obj) => {
+              return Object.entries(where).every(([key, value]) => {
                 if (key.includes(' >')) {
                   const field = key.replace(' >', '');
-                  return obj[field] > (value as number);
+                  return (obj[field] as number) > (value as number);
                 }
                 if (key.includes(' <')) {
                   const field = key.replace(' <', '');
-                  return obj[field] < (value as number);
+                  return (obj[field] as number) < (value as number);
                 }
                 if (key.includes(' >=')) {
                   const field = key.replace(' >=', '');
-                  return obj[field] >= (value as number);
+                  return (obj[field] as number) >= (value as number);
                 }
                 if (key.includes(' like')) {
                   const field = key.replace(' like', '');
-                  return obj[field]
+                  return (obj[field] as { toString(): string } | undefined)
                     ?.toString()
                     .includes((value as string).replace(/%/g, ''));
                 }
                 if (key.includes(' in')) {
                   const field = key.replace(' in', '');
-                  return (
-                    Array.isArray(value) &&
-                    (value as any[]).includes(obj[field])
-                  );
+                  return Array.isArray(value) && value.includes(obj[field]);
                 }
                 return obj[key] === value;
-              },
-            );
-          });
-        }
+              });
+            });
+          }
 
-        // Apply ordering
-        if (options.orderBy) {
-          const [field, direction] = options.orderBy.split(' ');
-          results.sort((a, b) => {
-            const comparison = a[field] > b[field] ? 1 : -1;
-            return direction === 'DESC' ? -comparison : comparison;
-          });
-        }
+          // Apply ordering
+          if (options.orderBy) {
+            const [field, direction] = options.orderBy.split(' ');
+            results.sort((a, b) => {
+              const comparison =
+                (a[field] as number) > (b[field] as number) ? 1 : -1;
+              return direction === 'DESC' ? -comparison : comparison;
+            });
+          }
 
-        // Apply pagination
-        const offset = options.offset || 0;
-        const limit = options.limit || 50;
-        results = results.slice(offset, offset + limit);
+          // Apply pagination
+          const offset = options.offset || 0;
+          const limit = options.limit || 50;
+          results = results.slice(offset, offset + limit);
 
-        return results;
-      }),
+          return results;
+        }),
 
       get: vi.fn().mockImplementation(async (id: string) => {
         return this.storage.get(id) || null;
       }),
 
-      create: vi.fn().mockImplementation(async (data: any) => {
+      create: vi.fn().mockImplementation(async (data: Partial<MockObject>) => {
         const obj = generator({ ...data, id: TestDataFactory.generateId() });
         this.storage.set(obj.id, obj);
         return obj;
       }),
 
-      update: vi.fn().mockImplementation(async (id: string, data: any) => {
-        const existing = this.storage.get(id);
-        if (!existing) {
-          throw new Error(`Object with id ${id} not found`);
-        }
-        const updated = {
-          ...existing,
-          ...data,
-          updated_at: new Date().toISOString(),
-        };
-        this.storage.set(id, updated);
-        return updated;
-      }),
+      update: vi
+        .fn()
+        .mockImplementation(async (id: string, data: Partial<MockObject>) => {
+          const existing = this.storage.get(id);
+          if (!existing) {
+            throw new Error(`Object with id ${id} not found`);
+          }
+          const updated = {
+            ...existing,
+            ...data,
+            updated_at: new Date().toISOString(),
+          };
+          this.storage.set(id, updated);
+          return updated;
+        }),
 
       delete: vi.fn().mockImplementation(async (id: string) => {
         const deleted = this.storage.delete(id);
@@ -297,6 +331,18 @@ export class MockCollectionFactory {
 }
 
 /**
+ * Overrides accepted by {@link MockContextFactory.createMockContext}.
+ * `db`/`ai`/`user` are shallow-merged into the default mock sub-contexts; any
+ * additional keys are spread onto the resulting context object.
+ */
+export interface MockContextOverrides {
+  db?: Record<string, unknown>;
+  ai?: Record<string, unknown>;
+  user?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/**
  * Complete mock context factory for CLI and API testing
  */
 export class MockContextFactory {
@@ -305,7 +351,7 @@ export class MockContextFactory {
   /**
    * Create a comprehensive mock context with database and AI
    */
-  createMockContext(overrides: any = {}) {
+  createMockContext(overrides: MockContextOverrides = {}) {
     return {
       db: {
         query: vi.fn().mockResolvedValue({ rows: [] }),
@@ -369,13 +415,17 @@ export class TestSetup {
   /**
    * Mock collection constructor to return mock instances
    */
-  static mockCollectionConstructors(mockCollections: any): any {
-    return vi.fn().mockImplementation((options: any) => {
+  static mockCollectionConstructors(
+    mockCollections: Partial<
+      Record<'TestUser' | 'TestProduct', MockCollection>
+    >,
+  ): Mock {
+    return vi.fn().mockImplementation((options?: Record<string, unknown>) => {
       const mockCollection =
         mockCollections.TestUser || mockCollections.TestProduct;
       // Add context options to mock if needed
       if (options) {
-        Object.assign(mockCollection, options);
+        Object.assign(mockCollection as object, options);
       }
       return mockCollection;
     });

--- a/packages/core/src/testing/database.ts
+++ b/packages/core/src/testing/database.ts
@@ -310,7 +310,8 @@ export async function getTestDatabase(
   // Use the same schema generation as production
   const schemaGenerator = new SchemaGenerator();
   const ddlEngine =
-    type === 'json' || typeof (db as any).exportTable === 'function'
+    type === 'json' ||
+    typeof (db as { exportTable?: unknown }).exportTable === 'function'
       ? 'json'
       : 'sqlite';
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,5 +1,7 @@
 import { createLogger } from '@happyvertical/logger';
+import type { SmrtObject } from './object';
 import { ObjectRegistry } from './registry';
+import type { SmrtObjectConstructor } from './registry/types';
 import {
   classnameToTablename,
   pluralize,
@@ -36,8 +38,10 @@ export function toCamelCase(str: string): string {
  * @param obj - Object with camelCase keys
  * @returns Object with snake_case keys
  */
-export function keysToSnakeCase(obj: Record<string, any>): Record<string, any> {
-  const result: Record<string, any> = {};
+export function keysToSnakeCase(
+  obj: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
     result[toSnakeCase(key)] = value;
   }
@@ -50,8 +54,10 @@ export function keysToSnakeCase(obj: Record<string, any>): Record<string, any> {
  * @param obj - Object with snake_case keys
  * @returns Object with camelCase keys
  */
-export function keysToCamelCase(obj: Record<string, any>): Record<string, any> {
-  const result: Record<string, any> = {};
+export function keysToCamelCase(
+  obj: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
     result[toCamelCase(key)] = value;
   }
@@ -130,12 +136,15 @@ export function dateAsObject(date: Date | string) {
  * ```
  */
 export async function fieldsFromClass(
-  ClassType: new (...args: any[]) => any,
-  values?: Record<string, any>,
+  ClassType: new (...args: never[]) => SmrtObject,
+  values?: Record<string, unknown>,
 ) {
+  // `getClassByConstructor` expects the registry's `SmrtObjectConstructor`
+  // (`new (...args: any[]) => SmrtObject`); the narrower `never[]` param type
+  // is contravariantly assignable, so this widening cast is purely structural.
   const className =
-    ObjectRegistry.getClassByConstructor(ClassType as any)?.name ||
-    ClassType.name;
+    ObjectRegistry.getClassByConstructor(ClassType as SmrtObjectConstructor)
+      ?.name || ClassType.name;
   // NEW: Use getAllFields() to include inherited fields from parent classes
   const cachedFields = await ObjectRegistry.getAllFields(className);
 
@@ -147,7 +156,7 @@ export async function fieldsFromClass(
   }
 
   // Use cached field definitions from AST manifest
-  const fields: Record<string, any> = {};
+  const fields: Record<string, unknown> = {};
 
   // Add/override with fields from cached registry
   for (const [key, field] of cachedFields.entries()) {
@@ -256,11 +265,13 @@ export function generateTableRenameMigrations(classNames: string[]): string[] {
  */
 export function tableNameFromClass(
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  ClassType: Function | (new (...args: any[]) => any),
+  ClassType: Function | (new (...args: never[]) => SmrtObject),
 ) {
   // Check for SMRT_TABLE_NAME property set by @smrt() decorator (survives minification)
   if ('SMRT_TABLE_NAME' in ClassType) {
-    return (ClassType as any).SMRT_TABLE_NAME;
+    // The `in` guard above proves the static decorator property exists; read it
+    // through a typed shape rather than `any`.
+    return (ClassType as { SMRT_TABLE_NAME: string }).SMRT_TABLE_NAME;
   }
 
   // Fallback: derive from class name (breaks with minification)
@@ -277,15 +288,21 @@ export function tableNameFromClass(
  * Formats data for JavaScript by converting date strings to Date objects
  * and snake_case column names to camelCase properties
  *
+ * Generic over the input row type `T` so callers preserve their (typically
+ * loose) row typing across the hydration boundary — this matches the historic
+ * behavior where a `Record<string, any>` / `any` row produced an equally loose
+ * result. Keys are re-cased and values are type-converted at runtime; the
+ * return is the same `Record` shape, so it is reasserted as `T` at this DB
+ * boundary rather than widened to an unrelated type.
+ *
  * @param data - Object with data to format (snake_case column names from DB)
  * @param fields - Optional field definitions to determine types (from fieldsFromClass)
  * @returns Object with properly typed values and camelCase property names for JavaScript
  */
-export function formatDataJs(
-  data: Record<string, any>,
-  fields?: Record<string, { type?: string }>,
-) {
-  const normalizedData: Record<string, any> = {};
+export function formatDataJs<
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(data: T, fields?: Record<string, { type?: string }>): T {
+  const normalizedData: Record<string, unknown> = {};
 
   if (process.env.DEBUG_STI) {
     logger.debug('[formatDataJs] Input data', {
@@ -299,12 +316,15 @@ export function formatDataJs(
   // fields are available during formatting. This must never mutate the caller's
   // `data` argument — `formatDataJs` is a public export and external callers may
   // pass shared objects that would otherwise get silent field injection (#1378).
-  let mergedData: Record<string, any> = data;
+  let mergedData: Record<string, unknown> = data;
   if (data._meta_data) {
-    const metaData =
+    // `_meta_data` is the STI meta column: a JSON string from the DB or an
+    // already-parsed object. Either way it is an object of meta fields; type it
+    // as such at this boundary so the merge/key-walk below stays sound.
+    const metaData: Record<string, unknown> =
       typeof data._meta_data === 'string'
         ? JSON.parse(data._meta_data)
-        : data._meta_data;
+        : (data._meta_data as Record<string, unknown>);
 
     if (process.env.DEBUG_STI) {
       logger.debug('[formatDataJs] Merging _meta_data', {
@@ -396,7 +416,10 @@ export function formatDataJs(
     });
   }
 
-  return normalizedData;
+  // Reassert the re-cased/type-converted row as the caller's row type `T`.
+  // The output is structurally a `Record<string, unknown>`; this boundary cast
+  // preserves the historic loose-in/loose-out hydration contract without `any`.
+  return normalizedData as T;
 }
 
 /**
@@ -406,7 +429,7 @@ export function formatDataJs(
  * @param value - Value to check
  * @returns Always false (Field class no longer exists)
  */
-export function isFieldInstance(value: any): value is never {
+export function isFieldInstance(value: unknown): value is never {
   return false;
 }
 
@@ -417,8 +440,8 @@ export function isFieldInstance(value: any): value is never {
  * @param data - Object with data to format (camelCase property names from JavaScript)
  * @returns Object with properly formatted values and snake_case column names for SQL
  */
-export function formatDataSql(data: Record<string, any>) {
-  const normalizedData: Record<string, any> = {};
+export function formatDataSql(data: Record<string, unknown>) {
+  const normalizedData: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(data)) {
     // Convert camelCase to snake_case for SQL
     const snakeKey = toSnakeCase(key);

--- a/packages/core/src/utils/json.ts
+++ b/packages/core/src/utils/json.ts
@@ -64,7 +64,7 @@ export function stringify(
     | null,
   space?: number | string,
 ): string {
-  return getAdapter().stringify(value, replacer as any, space as any);
+  return getAdapter().stringify(value, replacer, space);
 }
 
 /**


### PR DESCRIPTION
## Summary

**Phase 1 of the core `noExplicitAny` graduation** (S4 ratchet #1579, epic #1354). Core is the last ungraduated package (737 prod `any`); this is a planned multi-phase effort. This PR clears the **leaf / low-blast-radius** files.

**156 production `any` eliminated across 32 files → core now at 581** (737 → 581). Done via 4 parallel isolated-worktree agents (disjoint file sets, clean cherry-picks).

> **Core does NOT graduate to `error` yet** — that's the final phase, once all sub-areas reach ~0. This PR is a pure type reduction; `biome.json` is unchanged.

| Batch | Scope | `any` |
|---|---|---:|
| errors/utils/config | `errors`, `utils`, `utils/json`, `database`, `config`, `lazy-config` | 50 |
| test-utils/manifest | `test-utils`, `testing/database`, `manifest/*`, `knowledge` | 44 |
| schema/signals/system | `schema/*` (excl. generator), `signals/sanitizer`, `system-fields`, `migrations/differ` | 42 |
| mcp-advisor/embeddings | `mcp-advisor/*`, `embeddings/*` | 20 |

## Approach
- Real framework types used throughout: `FieldDefinition`/`ColumnDefinition`/`IndexDefinition` (schema), `SmartObjectManifest` (manifest), `SmrtObjectConstructor` (registry), `DatabaseInterface`/`SchemasOption` (sql).
- The recurring constructor-constraint pattern: `new (...args: never[]) => SmrtObject` (contravariant-safe), or imported the registry's existing `SmrtObjectConstructor` where call sites required `any[]`-arg compatibility (deferred to the Phase 5 registry work).
- Opaque boundaries (MCP tool args, dynamic imports, private-member probes) → documented `as <SpecificType>` / `as unknown as {…}` views.
- A masked type hole surfaced and was preserved exactly: the signal sanitizer flattens `Error` into a plain object while `Signal.error` is typed `Error`.

## Constraints honored
No `as any`, no `biome-ignore`, no type-alias-to-`any`. Generated type-text string literals (e.g. `'Record<string, any>'` emitted by `mapFieldTypeToTS`) correctly left untouched.

## Verification
- `biome lint --only=suspicious/noExplicitAny`: **0** in all 32 Phase 1 files (core total 737 → 581).
- `turbo typecheck`: **0 errors** (combined branch — confirms the cross-file `formatDataJs` generic holds against `object.ts`).
- Tests: **2648 passed**, 29 skipped (236 files).
- Coverage: **84.42%** (T1 floor 80%) — unchanged.
- Knowledge freshness: ✓.

## Remaining core phases
2. build tooling (scanner/vite-plugin/consumer-plugin) · 3. generators · 4. runtime · 5. registry (defines the `AnyCollection` alias) · 6. ORM (`object`/`collection`) · 7. decorators + **graduate**.

Refs #1579 #1354