### PR TITLE
refactor(types): core noExplicitAny Phase 7 — decorators + graduate core (#1579)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -247,6 +247,9 @@
     },
     {
       "includes": [
+        "packages/core/src/**/*.ts",
+        "packages/core/src/**/*.tsx",
+        "packages/core/src/**/*.svelte",
         "packages/chat/src/**/*.ts",
         "packages/chat/src/**/*.tsx",
         "packages/chat/src/**/*.svelte",

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -173,8 +173,10 @@ export interface SmrtCollectionOptions extends SmrtClassOptions {}
 // `unknown` rejects those assignments. Mirrors the `SmrtObjectConstructor`
 // escape hatch in registry/types.
 export type SmrtCollectionItemClass<ModelType extends SmrtObject> = (new (
+  // biome-ignore lint/suspicious/noExplicitAny: contravariant constructor option bag — narrowing to `SmrtCreateInput<ModelType>`/`unknown` rejects every concrete `static _itemClass = Product` assignment. Mirrors `SmrtObjectConstructor`. S4 #1579.
   options: any,
 ) => ModelType) & {
+  // biome-ignore lint/suspicious/noExplicitAny: contravariant `create()` option bag — same variance constraint as the constructor above. S4 #1579.
   create(options: any): ModelType | Promise<ModelType>;
 };
 
@@ -590,6 +592,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    * `SmrtObjectConstructor` / `SmrtCollectionItemClass<SmrtObject>` type rejects
    * the heterogeneous concrete assignments. Mirrors the registry escape hatch.
    */
+  // biome-ignore lint/suspicious/noExplicitAny: subclasses assign a concrete `static _itemClass = Product`; `SmrtCollection` is invariant in `ModelType`, so a narrower constructor type rejects the heterogeneous assignments. S4 #1579.
   static readonly _itemClass: any;
 
   /**
@@ -691,6 +694,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
   // so a concrete `Products extends SmrtCollection<Product>` does not satisfy
   // `T extends SmrtCollection<SmrtObject>`. The `any` bound is the only constraint
   // every subclass collection satisfies.
+  // biome-ignore lint/suspicious/noExplicitAny: `SmrtCollection` is invariant in `ModelType`, so concrete `Products extends SmrtCollection<Product>` fails `T extends SmrtCollection<SmrtObject>`; the `any` bound is the only one every subclass satisfies. S4 #1579.
   static async create<T extends SmrtCollection<any>>(
     this: new (
       options?: SmrtCollectionOptions,

--- a/packages/core/src/decorators/compatibility.ts
+++ b/packages/core/src/decorators/compatibility.ts
@@ -23,7 +23,7 @@ export type CompatiblePropertyDecoratorContext<This, Value> =
   | symbol
   | ClassFieldDecoratorContext<This, Value>;
 
-export interface CompatiblePropertyDecorator<This = any, Value = any> {
+export interface CompatiblePropertyDecorator<This = unknown, Value = unknown> {
   (target: object, propertyKey: string | symbol): void;
   (value: undefined, context: ClassFieldDecoratorContext<This, Value>): void;
 }
@@ -62,7 +62,7 @@ function markStandardDecoratorRegistration(
 
 function getDecoratorMetadata(
   contextOrMetadata:
-    | ClassFieldDecoratorContext<any, any>
+    | ClassFieldDecoratorContext<unknown, unknown>
     | ClassDecoratorContext
     | DecoratorMetadataStore
     | undefined,

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -65,7 +65,7 @@ export interface FieldOptions {
   /** Whether the field is required */
   required?: boolean;
   /** Default value for the field */
-  default?: any;
+  default?: unknown;
   /** Whether the field is unique */
   unique?: boolean;
   /**
@@ -220,7 +220,7 @@ export function field(
 ) {
   return ((
     targetOrValue: LegacyPropertyDecoratorTarget | undefined,
-    propertyKeyOrContext: CompatiblePropertyDecoratorContext<any, any>,
+    propertyKeyOrContext: CompatiblePropertyDecoratorContext<unknown, unknown>,
   ) => {
     registerCompatibleFieldDecorator(
       targetOrValue,
@@ -267,12 +267,12 @@ export function field(
  * @see SmrtObject.loadRelated for lazy-loading the related object at runtime
  */
 export function foreignKey(
-  relatedClass: string | Function | any,
+  relatedClass: string | Function,
   options: Omit<RelationshipFieldOptions, 'related'> = {},
 ) {
   return ((
     targetOrValue: LegacyPropertyDecoratorTarget | undefined,
-    propertyKeyOrContext: CompatiblePropertyDecoratorContext<any, any>,
+    propertyKeyOrContext: CompatiblePropertyDecoratorContext<unknown, unknown>,
   ) => {
     const relatedClassName =
       typeof relatedClass === 'string' ? relatedClass : relatedClass.name;
@@ -337,7 +337,7 @@ export function crossPackageRef(
 ) {
   return ((
     targetOrValue: LegacyPropertyDecoratorTarget | undefined,
-    propertyKeyOrContext: CompatiblePropertyDecoratorContext<any, any>,
+    propertyKeyOrContext: CompatiblePropertyDecoratorContext<unknown, unknown>,
   ) => {
     registerCompatibleFieldDecorator(
       targetOrValue,
@@ -413,12 +413,12 @@ export function crossPackageRef(
  * @see SmrtObject.loadRelatedMany for lazy-loading at runtime
  */
 export function oneToMany(
-  relatedClass: string | Function | any,
+  relatedClass: string | Function,
   options: Omit<RelationshipFieldOptions, 'related'> = {},
 ) {
   return ((
     targetOrValue: LegacyPropertyDecoratorTarget | undefined,
-    propertyKeyOrContext: CompatiblePropertyDecoratorContext<any, any>,
+    propertyKeyOrContext: CompatiblePropertyDecoratorContext<unknown, unknown>,
   ) => {
     const relatedClassName =
       typeof relatedClass === 'string' ? relatedClass : relatedClass.name;
@@ -465,12 +465,12 @@ export function oneToMany(
  * @see {@link oneToMany} for one-to-many relationships
  */
 export function manyToMany(
-  relatedClass: string | Function | any,
+  relatedClass: string | Function,
   options: Omit<RelationshipFieldOptions, 'related'> = {},
 ) {
   return ((
     targetOrValue: LegacyPropertyDecoratorTarget | undefined,
-    propertyKeyOrContext: CompatiblePropertyDecoratorContext<any, any>,
+    propertyKeyOrContext: CompatiblePropertyDecoratorContext<unknown, unknown>,
   ) => {
     const relatedClassName =
       typeof relatedClass === 'string' ? relatedClass : relatedClass.name;
@@ -527,7 +527,7 @@ export function manyToMany(
 export function meta(options: FieldOptions = {}) {
   return ((
     targetOrValue: LegacyPropertyDecoratorTarget | undefined,
-    propertyKeyOrContext: CompatiblePropertyDecoratorContext<any, any>,
+    propertyKeyOrContext: CompatiblePropertyDecoratorContext<unknown, unknown>,
   ) => {
     registerCompatibleFieldDecorator(
       targetOrValue,

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -202,6 +202,7 @@ export interface SmrtObjectOptions extends SmrtClassOptions {
    * `[key: string]: any`. Narrowing it would break `super(options)` in every
    * downstream model. Documented irreducible leaf (S4 #1579).
    */
+  // biome-ignore lint/suspicious/noExplicitAny: subclass option interfaces (plain, no index signature) are assignable to `[key:string]:any` but NOT to `:unknown`; narrowing breaks `super(options)` in every downstream model. S4 #1579.
   [key: string]: any;
 }
 
@@ -972,6 +973,7 @@ export class SmrtObject extends SmrtClass {
   // OVERRIDE getFields() with domain-specific shapes (e.g. projects'
   // `Project.getFields(): Promise<ProjectField[]>`), which a precise field-map
   // return type would reject. The body below stays internally typed.
+  // biome-ignore lint/suspicious/noExplicitAny: subclasses OVERRIDE getFields() with domain shapes (e.g. `Project.getFields(): Promise<ProjectField[]>`); a precise base return type would reject those overrides. S4 #1579.
   async getFields(): Promise<any> {
     const className = this.getResolvedClassName();
     const cachedFields = await ObjectRegistry.getAllFields(className);
@@ -2738,6 +2740,7 @@ export class SmrtObject extends SmrtClass {
   public async loadRelated(
     fieldName: string,
     opts?: LoadRelatedOptions,
+    // biome-ignore lint/suspicious/noExplicitAny: returns a polymorphic related object whose concrete subclass only the CALLER knows (e.g. `metafield.validateValue(...)`); `any` lets callers use the concrete API without a cast. S4 #1579.
   ): Promise<any> {
     // Check if already loaded
     if (this._loadedRelationships.has(fieldName)) {
@@ -2937,6 +2940,7 @@ export class SmrtObject extends SmrtClass {
   public async loadRelatedMany(
     fieldName: string,
     opts?: LoadRelatedOptions,
+    // biome-ignore lint/suspicious/noExplicitAny: polymorphic related objects whose concrete type is caller-known (see loadRelated). S4 #1579.
   ): Promise<any[]> {
     // Check if already loaded
     if (this._loadedRelationships.has(fieldName)) {
@@ -3190,6 +3194,7 @@ export class SmrtObject extends SmrtClass {
   public async getRelated(
     fieldName: string,
     opts?: LoadRelatedOptions,
+    // biome-ignore lint/suspicious/noExplicitAny: polymorphic related object(s) whose concrete type is caller-known (see loadRelated). S4 #1579.
   ): Promise<any> {
     if (this._loadedRelationships.has(fieldName)) {
       const cached = this._loadedRelationships.get(fieldName);

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -247,6 +247,7 @@ interface FieldDecoratorOptions extends FieldOptions {
  * contravariant — `unknown` would reject those, `any` (like `SmrtObjectConstructor`)
  * stays assignable from any concrete options shape.
  */
+// biome-ignore lint/suspicious/noExplicitAny: registers CONCRETE collection constructors whose contravariant `options` reject `unknown`, and `SmrtCollection` is invariant in `ModelType` so the type arg cannot narrow to `SmrtObject`. Mirrors `SmrtObjectConstructor`. S4 #1579.
 type CollectionConstructor = new (options: any) => SmrtCollection<any>;
 
 /**
@@ -438,6 +439,7 @@ export class ObjectRegistry {
   /**
    * Get the collection cache from globalThis, initializing if needed
    */
+  // biome-ignore lint/suspicious/noExplicitAny: heterogeneous cache of concrete collections; `SmrtCollection` is invariant in `ModelType`, so the type arg cannot narrow to `SmrtObject` (read sites cast back). S4 #1579.
   private static get collectionCache(): LRUCache<string, SmrtCollection<any>> {
     return getCollectionCache();
   }
@@ -462,6 +464,7 @@ export class ObjectRegistry {
     }
     globalThis.__smrtRegistryCollectionCache = new LRUCache<
       string,
+      // biome-ignore lint/suspicious/noExplicitAny: heterogeneous cache of concrete collections; `SmrtCollection` is invariant in `ModelType` so the type arg cannot narrow to `SmrtObject`. S4 #1579.
       SmrtCollection<any>
     >(maxSize);
   }
@@ -1490,6 +1493,7 @@ export class ObjectRegistry {
   private static resolveCollectionRegistration(className: string): {
     canonicalName: string;
     registered?: RegisteredClass;
+    // biome-ignore lint/suspicious/noExplicitAny: concrete collection constructor with contravariant `options` and invariant `ModelType`; mirrors `CollectionConstructor`. S4 #1579.
     collectionConstructor?: new (options: any) => SmrtCollection<any>;
   } {
     let registered = ObjectRegistry.findClass(className);
@@ -3170,6 +3174,7 @@ export function smrt(config: SmartObjectConfig = {}) {
   // (every class constructor — including ones with specific parameter lists —
   // must satisfy it), so it is left as-is. Only the instance/return type is
   // narrowed from `any` to `object`.
+  // biome-ignore lint/suspicious/noExplicitAny: `(...args: any[])` is the idiomatic class-decorator constraint — every class constructor (incl. specific param lists) must satisfy it; `unknown[]`/`never[]` would reject concrete ctors. S4 #1579.
   return <T extends abstract new (...args: any[]) => object>(
     ctor: T,
     decoratorContext?: ClassDecoratorContext<T>,

--- a/packages/core/src/registry/shared-state.ts
+++ b/packages/core/src/registry/shared-state.ts
@@ -32,6 +32,7 @@ declare global {
   // to `SmrtCollection<SmrtObject>` — the type argument stays `any` (read sites
   // cast back to the concrete collection type).
   var __smrtRegistryCollectionCache:
+    // biome-ignore lint/suspicious/noExplicitAny: heterogeneous cache keyed by class name; `SmrtCollection` is invariant in `ModelType` so the type arg cannot narrow to `SmrtObject` (read sites cast back). S4 #1579.
     | LRUCache<string, SmrtCollection<any>>
     | undefined;
   // eslint-disable-next-line no-var
@@ -183,10 +184,12 @@ export function getCollectionTableNames(): Map<string, string> {
   return globalThis.__smrtRegistryCollectionTableNames;
 }
 
+// biome-ignore lint/suspicious/noExplicitAny: heterogeneous cache; `SmrtCollection` is invariant in `ModelType` so the type arg cannot narrow to `SmrtObject` (read sites cast back). S4 #1579.
 export function getCollectionCache(): LRUCache<string, SmrtCollection<any>> {
   if (!globalThis.__smrtRegistryCollectionCache) {
     globalThis.__smrtRegistryCollectionCache = new LRUCache<
       string,
+      // biome-ignore lint/suspicious/noExplicitAny: same heterogeneous-cache invariance as the return type above. S4 #1579.
       SmrtCollection<any>
     >(100);
   }

--- a/packages/core/src/registry/types.ts
+++ b/packages/core/src/registry/types.ts
@@ -27,6 +27,7 @@ import type { SchemaDefinition } from '../schema/types.js';
  * Type for any constructor function that extends SmrtObject.
  * Used for WeakMap keys where we need to accept any subclass constructor.
  */
+// biome-ignore lint/suspicious/noExplicitAny: must accept every concrete SmrtObject subclass constructor; `(...args: any[])` is bottom-compatible where `unknown[]`/`never[]` reject typed constructors (e.g. `new (options?: SmrtObjectOptions)`). S4 #1579.
 export type SmrtObjectConstructor = new (...args: any[]) => SmrtObject;
 
 export type ApiHttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
@@ -780,9 +781,8 @@ export interface RegisteredClass {
    * `typeof SmrtCollection`. This mirrors the `SmrtObjectConstructor` escape
    * hatch above.
    */
-  collectionConstructor?: new (
-    options: any,
-  ) => SmrtCollection<any>;
+  // biome-ignore lint/suspicious/noExplicitAny: assigned from `typeof SmrtCollection` (contravariant `options?`, invariant `ModelType`) and called by generators passing a loosely-typed `{ ai, db }` context; precise types break those sites. Mirrors `SmrtObjectConstructor`. S4 #1579.
+  collectionConstructor?: new (options: any) => SmrtCollection<any>;
   config: SmartObjectConfig;
   fields: Map<string, RegisteredField>;
   /** Method definitions from manifest (for custom CLI/API/MCP generation) */


### PR DESCRIPTION
## S4 #1579 — Phase 7 (FINAL): graduate core

The last phase of the core `noExplicitAny` graduation. After this, **the S4 ratchet is complete: 47/47 packages at `error`** and the blanket `packages/*/src` exemption is fully retired.

### 1. Decorators: 20 → 0 explicit `any` (genuine fixes, no suppressions)
- `CompatiblePropertyDecorator<This, Value>` defaults and the `getDecoratorMetadata` context union: `any` → `unknown` (only `.metadata` is read structurally).
- All six field-decorator inner-fn context params: `CompatiblePropertyDecoratorContext<any, any>` → `<unknown, unknown>` (the `as CompatiblePropertyDecorator` cast governs decorator application).
- `FieldOptions.default`: `any` → `unknown` (passed through generically).
- `foreignKey`/`oneToMany`/`manyToMany` `relatedClass`: dropped the redundant `| any` from `string | Function | any` (`.name` access stays valid after the `typeof === 'string'` guard).

### 2. The 22 irreducible variance/polymorphism leaves → documented `biome-ignore`
registry 13 + ORM 9, each already carried an explanatory comment; now each has a `biome-ignore lint/suspicious/noExplicitAny` directive stating why it cannot narrow:
- `SmrtCollection` invariance in `ModelType` (heterogeneous caches, `static create<T extends SmrtCollection<any>>`, `_itemClass`).
- Contravariant constructor option bags (`CollectionConstructor`, `collectionConstructor`, `SmrtCollectionItemClass`).
- `SmrtObjectConstructor = new (...args: any[])` — bottom-compatible spread that `unknown[]`/`never[]` reject.
- Polymorphic relationship accessors (`loadRelated`/`loadRelatedMany`/`getRelated`) whose concrete subclass only the caller knows.
- The options-bag index signature `[key: string]: any` that plain subclass option interfaces require (`super(options)`).

### 3. Flip core to `error`
`packages/core/src/**/*.{ts,tsx,svelte}` added to the graduated override in `biome.json`.

### Verification
- ✅ **0** `noExplicitAny` + **0** `suppressions/unused` errors under the graduated config
- ✅ Full build **52/52**
- ✅ Core suite **2650 passed** (29 skipped)
- ✅ `knowledge:check` fresh (0 errors)
- ✅ Full parallel typecheck: only the known content src/dist global-declaration flake (content passes isolated)

Closes the core graduation under #1579.