### PR TITLE
fix(secrets)!: tenant-scope audit-log helpers + normalize system actor id (#1444, #1503)

### DIFF
--- a/packages/secrets/src/__tests__/secret-service.test.ts
+++ b/packages/secrets/src/__tests__/secret-service.test.ts
@@ -29,6 +29,7 @@ vi.mock('@happyvertical/logger', async (importOriginal) => ({
   createLogger: () => mockLogger,
 }));
 
+import { SecretAuditLogCollection } from '../collections/SecretAuditLogCollection.js';
 import { SecretCollection } from '../collections/SecretCollection.js';
 import { TenantKeyCollection } from '../collections/TenantKeyCollection.js';
 import { createAuditEntry } from '../models/SecretAuditLog.js';
@@ -411,6 +412,101 @@ describe('SecretService', () => {
         expect(secrets.length).toBe(1);
         expect(secrets[0].name).toBe('tenant-1-secret');
       });
+    });
+  });
+
+  describe('createAuditEntry actor normalization (issue #1444)', () => {
+    it("normalizes the 'system' actor sentinel to null (uuid column safety)", () => {
+      // userId is a native `uuid` column on Postgres; the 'system' sentinel
+      // (from getCurrentUserId() when there is no authenticated principal) is
+      // not a valid UUID and would raise `invalid input syntax for type uuid`.
+      const entry = createAuditEntry({
+        secretName: 'api-key',
+        userId: 'system',
+        action: 'read',
+        result: 'success',
+      });
+      expect(entry.userId).toBeNull();
+    });
+
+    it('normalizes an empty actor id to null', () => {
+      const entry = createAuditEntry({
+        secretName: 'api-key',
+        userId: '',
+        action: 'read',
+        result: 'success',
+      });
+      expect(entry.userId).toBeNull();
+    });
+
+    it('passes a real (UUID) actor id through unchanged', () => {
+      const realId = 'a3f1c2d4-0000-4000-8000-000000000001';
+      const entry = createAuditEntry({
+        secretName: 'api-key',
+        userId: realId,
+        action: 'read',
+        result: 'success',
+      });
+      expect(entry.userId).toBe(realId);
+    });
+  });
+
+  describe('SecretAuditLogCollection compliance-helper tenant scoping (issue #1503)', () => {
+    beforeEach(() => {
+      // Prove the helpers scope by their own explicit tenantId argument, not by
+      // an ambient tenancy interceptor.
+      disableTenancy();
+    });
+
+    async function seedTwoTenantFailures(): Promise<SecretAuditLogCollection> {
+      const logs = await SecretAuditLogCollection.create({ db });
+      await logs.create(
+        createAuditEntry({
+          tenantId: 'tenant-a',
+          secretName: 'a-secret',
+          userId: '',
+          action: 'read',
+          result: 'failure',
+        }),
+      );
+      await logs.create(
+        createAuditEntry({
+          tenantId: 'tenant-b',
+          secretName: 'b-secret',
+          userId: '',
+          action: 'read',
+          result: 'failure',
+        }),
+      );
+      return logs;
+    }
+
+    it('getRecentFailures scopes to the supplied tenant', async () => {
+      const logs = await seedTwoTenantFailures();
+      const scoped = await logs.getRecentFailures('tenant-a');
+      expect(scoped).toHaveLength(1);
+      expect(scoped[0].tenantId).toBe('tenant-a');
+    });
+
+    it('getRecentFailures(null) returns cross-tenant rows (super-admin compliance path)', async () => {
+      const logs = await seedTwoTenantFailures();
+      const all = await logs.getRecentFailures(null);
+      expect(new Set(all.map((l) => l.tenantId))).toEqual(
+        new Set(['tenant-a', 'tenant-b']),
+      );
+    });
+
+    it('getSecretHistory scopes to the supplied tenant', async () => {
+      const logs = await seedTwoTenantFailures();
+      const history = await logs.getSecretHistory('tenant-a', 'a-secret');
+      expect(history).toHaveLength(1);
+      expect(history[0].tenantId).toBe('tenant-a');
+    });
+
+    it('countByResult scopes to the supplied tenant', async () => {
+      const logs = await seedTwoTenantFailures();
+      const counts = await logs.countByResult('tenant-a');
+      expect(counts.failure).toBe(1);
     });
   });
 

--- a/packages/secrets/src/collections/SecretAuditLogCollection.ts
+++ b/packages/secrets/src/collections/SecretAuditLogCollection.ts
@@ -91,46 +91,84 @@ export class SecretAuditLogCollection extends SmrtCollection<SecretAuditLog> {
   }
 
   /**
-   * Get audit logs for a specific secret
+   * Get audit logs for a specific secret.
+   *
+   * @param tenantId - Scope to this tenant's audit trail, or `null` for a
+   *   cross-tenant compliance query (which must run under
+   *   `withSuperAdminBypass()` from `@happyvertical/smrt-tenancy`). Audit rows
+   *   reference secret names and must not leak across tenants (#1503).
    */
   async getSecretHistory(
+    tenantId: string | null,
     secretName: string,
     limit: number = 50,
   ): Promise<SecretAuditLog[]> {
-    return this.listLogs({ secretName, limit });
+    return this.listLogs({ tenantId: tenantId ?? undefined, secretName, limit });
   }
 
   /**
-   * Get audit logs for a specific user
+   * Get audit logs for a specific user.
+   *
+   * @param tenantId - Scope to this tenant's audit trail, or `null` for a
+   *   cross-tenant compliance query under `withSuperAdminBypass()` (#1503).
    */
   async getUserActivity(
+    tenantId: string | null,
     userId: string,
     limit: number = 50,
   ): Promise<SecretAuditLog[]> {
-    return this.listLogs({ userId, limit });
+    return this.listLogs({ tenantId: tenantId ?? undefined, userId, limit });
   }
 
   /**
-   * Get recent failures
+   * Get recent failures.
+   *
+   * @param tenantId - Scope to this tenant's audit trail, or `null` for a
+   *   cross-tenant compliance query under `withSuperAdminBypass()` (#1503).
    */
-  async getRecentFailures(limit: number = 20): Promise<SecretAuditLog[]> {
-    return this.listLogs({ result: 'failure', limit });
+  async getRecentFailures(
+    tenantId: string | null,
+    limit: number = 20,
+  ): Promise<SecretAuditLog[]> {
+    return this.listLogs({
+      tenantId: tenantId ?? undefined,
+      result: 'failure',
+      limit,
+    });
   }
 
   /**
-   * Get recent denied access attempts
+   * Get recent denied access attempts.
+   *
+   * @param tenantId - Scope to this tenant's audit trail, or `null` for a
+   *   cross-tenant compliance query under `withSuperAdminBypass()` (#1503).
    */
-  async getRecentDenials(limit: number = 20): Promise<SecretAuditLog[]> {
-    return this.listLogs({ result: 'denied', limit });
+  async getRecentDenials(
+    tenantId: string | null,
+    limit: number = 20,
+  ): Promise<SecretAuditLog[]> {
+    return this.listLogs({
+      tenantId: tenantId ?? undefined,
+      result: 'denied',
+      limit,
+    });
   }
 
   /**
-   * Count operations by action type
+   * Count operations by action type.
+   *
+   * @param tenantId - Scope to this tenant's audit trail, or `null` for a
+   *   cross-tenant compliance count under `withSuperAdminBypass()` (#1503).
    */
   async countByAction(
+    tenantId: string | null,
     since?: Date,
   ): Promise<Record<SecretAuditAction, number>> {
-    const logs = await this.listLogs({ since, limit: 10000 });
+    const logs = await this.listLogs({
+      tenantId: tenantId ?? undefined,
+      since,
+      limit: 10000,
+    });
 
     const counts: Record<SecretAuditAction, number> = {
       create: 0,
@@ -151,12 +189,20 @@ export class SecretAuditLogCollection extends SmrtCollection<SecretAuditLog> {
   }
 
   /**
-   * Count operations by result
+   * Count operations by result.
+   *
+   * @param tenantId - Scope to this tenant's audit trail, or `null` for a
+   *   cross-tenant compliance count under `withSuperAdminBypass()` (#1503).
    */
   async countByResult(
+    tenantId: string | null,
     since?: Date,
   ): Promise<Record<SecretAuditResult, number>> {
-    const logs = await this.listLogs({ since, limit: 10000 });
+    const logs = await this.listLogs({
+      tenantId: tenantId ?? undefined,
+      since,
+      limit: 10000,
+    });
 
     const counts: Record<SecretAuditResult, number> = {
       success: 0,

--- a/packages/secrets/src/models/SecretAuditLog.ts
+++ b/packages/secrets/src/models/SecretAuditLog.ts
@@ -40,7 +40,7 @@ export interface SecretAuditLogOptions extends SmrtObjectOptions {
   tenantId?: string | null;
   secretId?: string | null;
   secretName?: string;
-  userId?: string;
+  userId?: string | null;
   action?: SecretAuditAction;
   result?: SecretAuditResult;
   ipAddress?: string;
@@ -119,10 +119,13 @@ export class SecretAuditLog extends SmrtObject {
   secretName: string = '';
 
   /**
-   * ID of the user who performed the action
+   * ID of the user who performed the action, or `null` for system-initiated
+   * operations with no authenticated user. Stored as a native `uuid` column on
+   * Postgres, so a non-UUID actor sentinel must never reach it —
+   * {@link createAuditEntry} normalizes the `'system'` sentinel to null (#1444).
    */
   @crossPackageRef('@happyvertical/smrt-users:User')
-  userId: string = '';
+  userId: string | null = null;
 
   /**
    * The action that was performed
@@ -226,10 +229,16 @@ export function createAuditEntry(params: {
       ? null
       : params.tenantId;
 
+  // The `userId` column is a native `uuid` on Postgres. The actor sentinel
+  // `'system'` (and an empty id) are not valid UUIDs, so normalize them to
+  // null — a system-initiated operation has no authenticated user (#1444).
+  const userId =
+    params.userId === 'system' || params.userId === '' ? null : params.userId;
+
   const entry: SmrtCreateInput<SecretAuditLog> = {
     secretId: params.secretId ?? null,
     secretName: params.secretName,
-    userId: params.userId,
+    userId,
     action: params.action,
     result: params.result,
     ipAddress: params.ipAddress ?? '',


### PR DESCRIPTION
Closes two genuinely-open remediation items from the production-hardening epic #1354.

## #1444 — system actor written into a `uuid` column
`SecretAuditLog.userId` is a native `uuid` column on Postgres, but `getCurrentUserId()` returns the `'system'` sentinel when no principal is authenticated, and that string (plus the `''` default) was persisted verbatim — raising `invalid input syntax for type uuid: "system"` and 500-ing the request path. Notably `createAuditEntry()` already normalized `tenantId === 'system'` → null but did **not** do the same for `userId`.

**Fix:** `userId` is now nullable (`string | null`, a system-initiated operation has no authenticated user), and `createAuditEntry()` normalizes the `'system'`/`''` sentinels to `null` at the single audit-write boundary (all writes funnel through `SecretService` → `createAuditEntry`).

## #1503 — audit-log compliance helpers leaked cross-tenant
The six `SecretAuditLogCollection` helpers — `getSecretHistory`, `getUserActivity`, `getRecentFailures`, `getRecentDenials`, `countByAction`, `countByResult` — called `listLogs()` with no tenant filter, returning rows across all tenants (the `#1502` fix scoped `SecretCollection` but never reached the audit-log helpers).

**Fix:** each helper now takes an explicit `tenantId: string | null` first argument — pass a tenant id to scope, or `null` for a deliberate cross-tenant compliance query (which must run under `withSuperAdminBypass()`, per the package's documented audit-read contract). No in-repo callers exist.

## Tests
Adds regression tests for the actor-id normalization (`'system'`/`''` → null, real UUID passes through) and per-tenant helper scoping (`getRecentFailures('tenant-a')` scopes; `getRecentFailures(null)` returns cross-tenant). Full secrets suite: **41 passed**; typecheck clean; biome clean (graduated package); knowledge fresh.

## Breaking
`SecretAuditLogCollection` helper signatures gain a leading `tenantId` argument, and `SecretAuditLog.userId` is now `string | null`. Per repo convention this ships as a normal 0.x minor.