### PR TITLE
refactor(core): route manifest-generator diagnostics through the logger (#1579)

### DIFF
--- a/packages/core/src/manifest/generator.ts
+++ b/packages/core/src/manifest/generator.ts
@@ -3,6 +3,7 @@
  * Consolidates manifest generation logic for both build and test manifests
  */
 
+import { createLogger } from '@happyvertical/logger';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import fg from 'fast-glob';
@@ -15,6 +16,11 @@ import {
   resolveManifestPath,
 } from './discover-smrt-packages.js';
 import { ManifestManager } from './manager.js';
+
+// Build-time manifest-generation diagnostics route through the shared logger
+// (S14 / dim-9, #1579) so consumers can control verbosity instead of receiving
+// unconditional stdout writes.
+const logger = createLogger({ level: 'info' });
 
 async function importScanner() {
   return importWorkspaceModule<ScannerModule>({
@@ -120,11 +126,11 @@ export class ManifestBuilder {
     const files = this.discoverFiles(options);
 
     if (files.length === 0) {
-      console.log('[smrt] No source files found');
+      logger.info('[smrt] No source files found');
       return this.createEmptyManifest(options);
     }
 
-    console.log(`[smrt] Scanning ${files.length} source file(s)...`);
+    logger.info(`[smrt] Scanning ${files.length} source file(s)...`);
 
     // 2. Configure scanner (baseClasses, external packages, vite config)
     const scannerConfig = await this.configureScanner(options);
@@ -211,7 +217,7 @@ export class ManifestBuilder {
       const viteBaseClasses = await this.loadViteConfigBaseClasses();
       if (viteBaseClasses && viteBaseClasses.length > 0) {
         baseClasses = viteBaseClasses;
-        console.log(
+        logger.info(
           `[smrt] Using baseClasses from vite.config.ts: ${baseClasses.join(', ')}`,
         );
       }
@@ -220,9 +226,9 @@ export class ManifestBuilder {
     // Discover external SMRT packages
     let smrtDependencies: string[] = [];
     if (options.discoverExternalPackages) {
-      console.log('[smrt] Discovering external SMRT packages...');
+      logger.info('[smrt] Discovering external SMRT packages...');
       smrtDependencies = discoverSmrtPackages();
-      console.log(
+      logger.info(
         `[smrt] Found ${smrtDependencies.length} SMRT package(s): ${smrtDependencies.join(', ')}`,
       );
 
@@ -232,10 +238,10 @@ export class ManifestBuilder {
           await this.loadExternalBaseClasses(smrtDependencies);
         if (externalClasses.length > 0) {
           baseClasses = [...baseClasses, ...externalClasses];
-          console.log(
+          logger.info(
             `[smrt] Added ${externalClasses.length} external base class(es) to scanner`,
           );
-          console.log(`[smrt] Total baseClasses: ${baseClasses.length}`);
+          logger.info(`[smrt] Total baseClasses: ${baseClasses.length}`);
         }
       }
     }
@@ -341,9 +347,9 @@ export class ManifestBuilder {
       const packageInfo = this.readPackageJson();
       if (packageInfo.name) {
         manifest.packageName = packageInfo.name;
-        console.log(`[smrt] Injected package name: ${packageInfo.name}`);
+        logger.info(`[smrt] Injected package name: ${packageInfo.name}`);
       } else {
-        console.warn(
+        logger.warn(
           '[smrt] Warning: Could not read package.json, packageName will be undefined',
         );
       }
@@ -392,8 +398,8 @@ export class ManifestBuilder {
     }
 
     const objectCount = Object.keys(manifest.objects).length;
-    console.log(`[smrt] ✅ Generated manifest with ${objectCount} object(s)`);
-    console.log(`[smrt]    Unified: ${unifiedPath}`);
+    logger.info(`[smrt] ✅ Generated manifest with ${objectCount} object(s)`);
+    logger.info(`[smrt]    Unified: ${unifiedPath}`);
   }
 
   /**
@@ -445,11 +451,11 @@ export default ${exportName};
     try {
       const viteConfigPath = resolve(process.cwd(), 'vite.config.ts');
       if (!existsSync(viteConfigPath)) {
-        console.log('[smrt] vite.config.ts not found');
+        logger.info('[smrt] vite.config.ts not found');
         return null;
       }
 
-      console.log('[smrt] Found vite.config.ts, attempting to load...');
+      logger.info('[smrt] Found vite.config.ts, attempting to load...');
 
       // Use vite to load config which handles TypeScript
       const { loadConfigFromFile } = await import('vite');
@@ -459,7 +465,7 @@ export default ${exportName};
       );
 
       if (!loaded?.config?.plugins) {
-        console.log('[smrt] No plugins found in vite config');
+        logger.info('[smrt] No plugins found in vite config');
         return null;
       }
 
@@ -468,22 +474,21 @@ export default ${exportName};
       // them structurally and narrow defensively instead of using `any`.
       const plugins = loaded.config.plugins as readonly VitePluginProbe[];
 
-      console.log(
-        '[smrt] Vite config loaded, plugins:',
-        plugins.map((p) => p?.name),
-      );
+      logger.info('[smrt] Vite config loaded', {
+        plugins: plugins.map((p) => p?.name),
+      });
 
       // Find smrtPlugin in plugins array
       const smrtPlugin = plugins.find((p) => p?.name === 'smrt-auto-service');
 
       if (!smrtPlugin) {
-        console.log(
+        logger.info(
           '[smrt] smrt-auto-service plugin not found in plugins array',
         );
         return null;
       }
 
-      console.log('[smrt] Found smrt-auto-service plugin');
+      logger.info('[smrt] Found smrt-auto-service plugin');
 
       // Try different ways to access options
       const api = smrtPlugin.api;
@@ -496,29 +501,25 @@ export default ${exportName};
         try {
           opts = api().options;
         } catch (e) {
-          console.log('[smrt] Could not call plugin.api()');
+          logger.info('[smrt] Could not call plugin.api()');
         }
       }
 
       if (opts?.baseClasses) {
-        console.log(
-          '[smrt] Plugin options:',
-          JSON.stringify({
-            baseClasses: opts.baseClasses,
-            followImports: opts.followImports,
-          }),
-        );
+        logger.info('[smrt] Plugin options', {
+          baseClasses: opts.baseClasses,
+          followImports: opts.followImports,
+        });
         return opts.baseClasses;
       }
 
-      console.log('[smrt] Could not access plugin options');
+      logger.info('[smrt] Could not access plugin options');
       return null;
     } catch (error) {
-      console.log(
-        '[smrt] Error loading vite.config.ts:',
-        error instanceof Error ? error.message : String(error),
-      );
-      console.log('[smrt] Using default baseClasses');
+      logger.warn('[smrt] Error loading vite.config.ts', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      logger.info('[smrt] Using default baseClasses');
       return null;
     }
   }
@@ -535,7 +536,7 @@ export default ${exportName};
       // still contribute base classes (#1378).
       const manifestPath = resolveManifestPath(pkgName, process.cwd());
       if (!manifestPath) {
-        console.log(`[smrt]   ${pkgName}: no SMRT manifest resolved`);
+        logger.info(`[smrt]   ${pkgName}: no SMRT manifest resolved`);
         continue;
       }
 
@@ -553,11 +554,11 @@ export default ${exportName};
           }
         }
 
-        console.log(
+        logger.info(
           `[smrt]   ${pkgName}: found ${foundClassNames.length} class(es) - ${foundClassNames.join(', ')}`,
         );
       } catch (error) {
-        console.log(
+        logger.info(
           `[smrt]   ${pkgName}: manifest not found or invalid - ${error instanceof Error ? error.message : String(error)}`,
         );
       }

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -2,6 +2,7 @@
  * Manifest generator for creating service manifests from AST scan results
  */
 
+import { createLogger } from '@happyvertical/logger';
 import { createHash } from 'node:crypto';
 import { createRequire } from 'node:module';
 import {
@@ -75,6 +76,10 @@ type SchemaGeneratorLike = {
 
 // Create require function for synchronous module loading in ESM context
 const require = createRequire(import.meta.url);
+
+// Build-time schema/manifest-generation diagnostics route through the shared
+// logger (S14 / dim-9, #1579) instead of unconditional stdout writes.
+const logger = createLogger({ level: 'info' });
 
 /**
  * Framework abstract base classes whose declared fields must be merged
@@ -349,7 +354,7 @@ export class ManifestGenerator {
       },
     };
 
-    console.log(
+    logger.info(
       `[manifest-generator] Injected ${fieldName} field for ${objectDef.className} (tenantScoped: ${JSON.stringify(tenantConfig)})`,
     );
   }
@@ -632,7 +637,7 @@ export class ManifestGenerator {
         if (processedSTIBases.has(name)) continue;
         processedSTIBases.add(name);
 
-        console.log(
+        logger.info(
           `[manifest-generator] Generating STI schema for ${name} (table: ${tableName})`,
         );
 
@@ -652,14 +657,14 @@ export class ManifestGenerator {
 
         if (baseIsLocal) {
           // STI base is in this manifest - skip (schema is on base class)
-          console.log(
+          logger.info(
             `[manifest-generator] Skipping schema for STI child ${name} (base ${stiBase?.className} is local)`,
           );
         } else {
           // STI base is EXTERNAL - generate STI schema for this child
           // CRITICAL: Use the external base's table name, not the child's!
           const baseTableName = stiBase?.tableName || tableName;
-          console.log(
+          logger.info(
             `[manifest-generator] Generating STI schema for ${name} (external base: ${stiBase?.className}, table: ${baseTableName})`,
           );
 
@@ -677,7 +682,7 @@ export class ManifestGenerator {
         }
       } else {
         // CTI class - generate individual table schema
-        console.log(
+        logger.info(
           `[manifest-generator] Generating CTI schema for ${name} (table: ${tableName})`,
         );
 
@@ -1030,7 +1035,7 @@ export class ManifestGenerator {
             }
           }
 
-          console.log(
+          logger.info(
             `[manifest-generator] Aggregated ${Object.keys(externalManifest.objects).length} objects from ${packageName}`,
           );
         }
@@ -1313,7 +1318,7 @@ export class ManifestGenerator {
         continue; // Plain CTI through a user-defined base — skip.
       }
 
-      console.log(
+      logger.info(
         `[manifest-generator] Merging inherited fields for ${obj.className} from ${obj.extends}`,
       );
 
@@ -1324,7 +1329,7 @@ export class ManifestGenerator {
 
       while (currentClass) {
         if (visited.has(currentClass)) {
-          console.warn(
+          logger.warn(
             `[manifest-generator] Circular inheritance detected for ${obj.className}`,
           );
           break;
@@ -1359,7 +1364,7 @@ export class ManifestGenerator {
         currentClass = parentObj.extends;
       }
 
-      console.log(
+      logger.info(
         `[manifest-generator] Inheritance chain for ${obj.className}: ${inheritanceChain.join(' -> ')}`,
       );
 
@@ -1437,7 +1442,7 @@ export class ManifestGenerator {
         // Inherit tableName from STI base
         obj.decoratorConfig = obj.decoratorConfig || {};
         obj.decoratorConfig.tableName = baseTableName;
-        console.log(
+        logger.info(
           `[manifest-generator] ${obj.className} inherits tableName: '${baseTableName}' from ${stiBase.className}`,
         );
 
@@ -1445,21 +1450,21 @@ export class ManifestGenerator {
         if (stiBase.decoratorConfig?.tableStrategy) {
           obj.decoratorConfig.tableStrategy =
             stiBase.decoratorConfig.tableStrategy;
-          console.log(
+          logger.info(
             `[manifest-generator] ${obj.className} inherits tableStrategy: '${stiBase.decoratorConfig.tableStrategy}' from ${stiBase.className}`,
           );
         }
 
         // Inherit collection name from STI base (all STI classes share one table)
         if (stiBase.collection !== obj.collection) {
-          console.log(
+          logger.info(
             `[manifest-generator] ${obj.className} inherits collection: '${stiBase.collection}' from ${stiBase.className}`,
           );
           obj.collection = stiBase.collection;
         }
       }
 
-      console.log(
+      logger.info(
         `[manifest-generator] ✅ ${obj.className} now has ${Object.keys(mergedFields).length} fields (including inherited)`,
       );
     }
@@ -1477,7 +1482,7 @@ export class ManifestGenerator {
         const itemClass = this.findItemClass(obj, manifest, objectsByName);
 
         if (itemClass) {
-          console.log(
+          logger.info(
             `[manifest-generator] ${obj.className} is a collection class for ${itemClass.className}`,
           );
 
@@ -1485,14 +1490,14 @@ export class ManifestGenerator {
           if (itemClass.decoratorConfig?.tableName) {
             obj.decoratorConfig = obj.decoratorConfig || {};
             obj.decoratorConfig.tableName = itemClass.decoratorConfig.tableName;
-            console.log(
+            logger.info(
               `[manifest-generator] ${obj.className} inherits tableName: '${itemClass.decoratorConfig.tableName}' from item class ${itemClass.className}`,
             );
           }
 
           // Inherit collection name from item class
           if (itemClass.collection !== obj.collection) {
-            console.log(
+            logger.info(
               `[manifest-generator] ${obj.className} inherits collection: '${itemClass.collection}' from item class ${itemClass.className} (was '${obj.collection}')`,
             );
             obj.collection = itemClass.collection;
@@ -1556,14 +1561,14 @@ export class ManifestGenerator {
     // This is the most reliable method: SmrtCollection<Meeting> -> "Meeting"
     if (collectionObj.extendsTypeArg) {
       const itemClassName = collectionObj.extendsTypeArg;
-      console.log(
+      logger.info(
         `[manifest-generator] ${collectionObj.className} has extendsTypeArg: ${itemClassName}`,
       );
 
       // Try to find the item class by name in local manifest
       const itemClass = objectsByName.get(itemClassName);
       if (itemClass) {
-        console.log(
+        logger.info(
           `[manifest-generator] Found item class ${itemClassName} in local manifest`,
         );
         return itemClass;
@@ -1577,7 +1582,7 @@ export class ManifestGenerator {
           objectsByName,
         );
         if (externalItemClass) {
-          console.log(
+          logger.info(
             `[manifest-generator] Found item class ${itemClassName} in external package`,
           );
           return externalItemClass;
@@ -2522,7 +2527,7 @@ ${fields}
 
       obj.agent = agentManifest;
 
-      console.log(
+      logger.info(
         `[manifest-generator] Generated agent manifest for ${obj.className}: ` +
           `${permissions.length} permissions, ${features.length} features, ` +
           `${menuItems.length} menu items, ${components.length} components`,


### PR DESCRIPTION
Addresses the **dim-9 logging** item from #1579 (deferred from the core deep review #1378): the two manifest generators emitted raw `console.*` from library code.

## Change
Migrated both files to `@happyvertical/logger` (`createLogger`, the established core convention — already used by collection/object/registry/config/etc.):
- `manifest/generator.ts` — 25 calls
- `scanner/manifest-generator.ts` — 20 calls

Mechanical 1:1 mapping (`log→info`, `warn→warn`, `error→error`). The three multi-arg `console.log` sites now pass a structured metadata object (`logger.info(msg, { … })`), and the vite-config load-failure path became a `logger.warn`. 

Per the #1579 item, the `import.meta.url` CLI block and emitted-template `console.*` stay exempt — but neither file actually has those (the `import.meta.url` is only `createRequire`, and the generators emit data, not code with `console` statements), so all 45 calls were real library diagnostics. Output/behavior is otherwise unchanged.

## Scope note
This is the two files named in #1579. The broader core `console.*` (vite-plugin progress, emitted-template strings in generators, prebuild CLI) is intentionally **out of scope** — the closed S14 #1432 sweep bounded it that way.

## Verification
- ✅ 2650 core tests pass (unchanged from baseline)
- ✅ core typecheck clean; biome clean (graduated `noExplicitAny`)
- ✅ knowledge:check fresh
- ✅ core rebuilt (scanner/* is loaded from `dist/` by the vite-plugin)