### PR TITLE
fix(secrets): widen createAuditEntry actor id to optional/nullable (#1444)

### DIFF
--- a/packages/secrets/src/__tests__/secret-service.test.ts
+++ b/packages/secrets/src/__tests__/secret-service.test.ts
@@ -449,6 +449,23 @@ describe('SecretService', () => {
       });
       expect(entry.userId).toBe(realId);
     });
+
+    it('treats an omitted or null actor id as null (no authenticated user)', () => {
+      const omitted = createAuditEntry({
+        secretName: 'api-key',
+        action: 'read',
+        result: 'success',
+      });
+      expect(omitted.userId).toBeNull();
+
+      const explicitNull = createAuditEntry({
+        secretName: 'api-key',
+        userId: null,
+        action: 'read',
+        result: 'success',
+      });
+      expect(explicitNull.userId).toBeNull();
+    });
   });
 
   describe('SecretAuditLogCollection compliance-helper tenant scoping (issue #1503)', () => {

--- a/packages/secrets/src/models/SecretAuditLog.ts
+++ b/packages/secrets/src/models/SecretAuditLog.ts
@@ -217,7 +217,7 @@ export function createAuditEntry(params: {
   secretId?: string | null;
   secretName: string;
   tenantId?: string | null;
-  userId: string;
+  userId?: string | null;
   action: SecretAuditAction;
   result: SecretAuditResult;
   ipAddress?: string;
@@ -229,11 +229,16 @@ export function createAuditEntry(params: {
       ? null
       : params.tenantId;
 
-  // The `userId` column is a native `uuid` on Postgres. The actor sentinel
-  // `'system'` (and an empty id) are not valid UUIDs, so normalize them to
-  // null — a system-initiated operation has no authenticated user (#1444).
+  // The `userId` column is a native `uuid` on Postgres. A missing actor and the
+  // `'system'`/empty sentinels are not valid UUIDs, so normalize them all to
+  // null — a system-initiated operation has no authenticated user. Callers may
+  // pass `null`/`undefined` directly to express that (#1444).
   const userId =
-    params.userId === 'system' || params.userId === '' ? null : params.userId;
+    params.userId == null ||
+    params.userId === 'system' ||
+    params.userId === ''
+      ? null
+      : params.userId;
 
   const entry: SmrtCreateInput<SecretAuditLog> = {
     secretId: params.secretId ?? null,


### PR DESCRIPTION
Follow-up to the Copilot review on #1686.

`createAuditEntry()` already normalizes the `'system'`/empty actor sentinels to `null` (so they never reach the `uuid` column), and the model field `SecretAuditLog.userId` is now `string | null`. But the function's `userId` parameter was still typed `string` (required) — forcing callers to pass a sentinel string rather than expressing "no authenticated user" directly.

This widens the param to `userId?: string | null` and normalizes `undefined`/`null` alongside the existing sentinels. **Non-breaking** — existing string callers are unaffected. Adds a regression test for the omitted/null cases.

42 secrets tests pass; typecheck + biome clean.