### PR TITLE
fix(config): deep-clone merged config + fail loud on malformed config files (#1579)

### DIFF
--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -75,6 +75,22 @@ describe('mergeConfigs', () => {
     expect(store.modules.demo.allow).toEqual(['one']);
     clearRuntimeConfig();
   });
+
+  it('preserves function-valued config by reference, not DataCloneError (#1579)', () => {
+    // `modules`/`packages` are `Record<string, unknown>`, so a JS smrt.config
+    // may hold callbacks. structuredClone would throw DataCloneError on these;
+    // the custom deep clone passes non-plain leaves through by reference.
+    const factory = () => 'built';
+    const merged = mergeConfigs(
+      { modules: {} as Record<string, unknown> },
+      { modules: { demo: { factory } } },
+      {},
+    );
+    const demo = (merged.modules as Record<string, { factory: () => string }>)
+      .demo;
+    expect(demo.factory).toBe(factory);
+    expect(demo.factory()).toBe('built');
+  });
 });
 
 describe('@smrt/config', () => {

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -9,7 +9,11 @@ import {
   loadConfig,
   setConfig,
 } from './index.js';
-import { mergeConfigs } from './merge.js';
+import {
+  clearRuntimeConfig,
+  getRuntimeConfig,
+  mergeConfigs,
+} from './merge.js';
 
 describe('mergeConfigs', () => {
   it('should not merge null values', () => {
@@ -41,6 +45,35 @@ describe('mergeConfigs', () => {
     expect(result.enabled).toBe(false);
     expect(result.count).toBe(0);
     expect(result.name).toBe('');
+  });
+
+  it('does not alias input arrays/objects into the merged result (#1579)', () => {
+    const defaults = { features: { list: ['a'] }, kept: { tags: ['k'] } };
+    const fileConfig = { extra: { items: ['x'] } };
+    const merged = mergeConfigs(defaults, fileConfig, {});
+
+    // Mutating either input after the merge must not change the result.
+    defaults.features.list.push('b');
+    defaults.kept.tags.push('z');
+    fileConfig.extra.items.push('y');
+    expect(merged.features.list).toEqual(['a']);
+    expect(merged.kept.tags).toEqual(['k']);
+    expect(merged.extra.items).toEqual(['x']);
+
+    // ...and mutating the result must not leak back into the inputs.
+    (merged.features.list as string[]).push('c');
+    expect(defaults.features.list).toEqual(['a', 'b']);
+  });
+
+  it('setConfig does not alias the caller input into the runtime store (#1579)', () => {
+    clearRuntimeConfig();
+    const input = { modules: { demo: { allow: ['one'] } } };
+    setConfig(input as Parameters<typeof setConfig>[0]);
+    // Mutating the original input must not change the stored runtime config.
+    input.modules.demo.allow.push('two');
+    const store = getRuntimeConfig() as typeof input;
+    expect(store.modules.demo.allow).toEqual(['one']);
+    clearRuntimeConfig();
   });
 });
 
@@ -101,6 +134,17 @@ describe('@smrt/config', () => {
       });
 
       expect(config).toEqual({});
+    });
+
+    it('throws when a config file exists but fails to parse (#1579)', async () => {
+      // Unterminated object literal — a syntax error, not a missing file. The
+      // loader must surface this rather than silently falling back to {}.
+      const badPath = join(testDir, 'broken.config.mjs');
+      writeFileSync(badPath, 'export default { smrt: { logLevel:', 'utf-8');
+
+      await expect(
+        loadConfig({ configPath: badPath, cache: false }),
+      ).rejects.toThrow(/Failed to load smrt config/);
     });
   });
 

--- a/packages/config/src/loader.ts
+++ b/packages/config/src/loader.ts
@@ -66,11 +66,14 @@ function isFileNotFound(error: unknown): boolean {
  * cached in `globalThis.__smrtLoaderCachedConfig` so that all modules sharing
  * the same runtime (including pnpm workspace symlinks) see the same config.
  *
- * Returns an empty object (`{}`) when no config file is found or when the
- * file fails to parse — callers should always treat every field as optional.
+ * Returns an empty object (`{}`) when no config file is found, so callers
+ * should always treat every field as optional. A config file that **exists but
+ * fails to load/parse** (syntax error, bad import, invalid JSON) throws instead
+ * of being silently ignored (#1579).
  *
  * @param options - Search and caching options.
- * @returns The parsed {@link SmrtConfig}, or `{}` if no file is found.
+ * @returns The parsed {@link SmrtConfig}, or `{}` if no config file is found.
+ * @throws If a config file exists but cannot be loaded or parsed.
  *
  * @example
  * ```ts

--- a/packages/config/src/loader.ts
+++ b/packages/config/src/loader.ts
@@ -39,6 +39,26 @@ function setExplorer(exp: ReturnType<typeof cosmiconfig> | null): void {
 }
 
 /**
+ * Distinguish "config file does not exist" (a benign, expected condition that
+ * falls back to empty config) from "config file exists but failed to load/parse"
+ * (a real error that should surface). cosmiconfig reads via Node `fs`, so a
+ * missing explicit path raises an `ENOENT` error.
+ */
+function isFileNotFound(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  if ((error as { code?: unknown }).code === 'ENOENT') {
+    return true;
+  }
+  const message = (error as { message?: unknown }).message;
+  return (
+    typeof message === 'string' &&
+    (message.includes('ENOENT') || message.includes('no such file'))
+  );
+}
+
+/**
  * Load and parse configuration from the project root using cosmiconfig.
  *
  * Searches for `smrt.config.{js,mjs,cjs,json}` starting from `cwd`, walking
@@ -104,9 +124,24 @@ export async function loadConfig(
     } else {
       result = await explorer.search();
     }
-  } catch (_error) {
-    // Return empty config on error
-    return {};
+  } catch (error) {
+    // A genuinely-absent config file is not an error: an explicit `configPath`
+    // that doesn't exist (ENOENT) legitimately falls back to empty config, and
+    // `search()` returns null (never throws) when no file is found.
+    if (isFileNotFound(error)) {
+      return {};
+    }
+    // A config file that EXISTS but fails to load/parse — syntax error, bad
+    // import, invalid JSON — is a real problem. Surface it loudly instead of
+    // silently returning {} and falling back to defaults, which masks broken
+    // config and leaves the developer thinking their settings applied (#1579).
+    const where = configPath ? ` "${configPath}"` : '';
+    throw new Error(
+      `Failed to load smrt config${where}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error },
+    );
   }
 
   const config: SmrtConfig = result?.config || {};

--- a/packages/config/src/merge.ts
+++ b/packages/config/src/merge.ts
@@ -25,9 +25,17 @@ function deepMerge<T extends Record<string, unknown>>(
   target: T,
   source: Partial<T>,
 ): T {
-  // Typed as Record<string, unknown> (not the generic T) so the own-key writes
-  // below are well-typed — indexing a generic T for *write* is a TS2862 error.
-  const result: Record<string, unknown> = { ...target };
+  // Deep-clone the carried-over target values (defaults / prior runtime store)
+  // so the merged result never aliases the caller's `target`. Combined with the
+  // clone of leaf source values below, the output owns all of its data: mutating
+  // an input array/object can't leak into the result or the global runtime store
+  // (via setConfig), and vice versa (#1579). Config is pure data, so
+  // structuredClone is safe. Typed as Record<string, unknown> (not the generic
+  // T) so the own-key writes below are well-typed — indexing a generic T for
+  // *write* is a TS2862 error.
+  const result: Record<string, unknown> = structuredClone(
+    target,
+  ) as Record<string, unknown>;
   const src = source as Record<string, unknown>;
 
   for (const key of Object.keys(src)) {
@@ -52,7 +60,8 @@ function deepMerge<T extends Record<string, unknown>>(
         sourceValue as Record<string, unknown>,
       );
     } else if (sourceValue !== undefined && sourceValue !== null) {
-      result[key] = sourceValue;
+      // Clone leaf arrays/objects so the result doesn't alias `source` (#1579).
+      result[key] = structuredClone(sourceValue);
     }
   }
 

--- a/packages/config/src/merge.ts
+++ b/packages/config/src/merge.ts
@@ -8,14 +8,62 @@ declare global {
 // Runtime config overrides
 globalThis.__smrtRuntimeConfig ??= {};
 
+// Keys that must never be written when merging untrusted / DB-exported config,
+// to avoid prototype pollution.
+const UNSAFE_KEYS = new Set<string>(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * True only for plain config maps (prototype is `Object.prototype` or `null`),
+ * not arrays, `Date`/`RegExp`, or class instances.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === null || proto === Object.prototype;
+}
+
+/**
+ * Recursively clone arrays and plain objects so the result shares no mutable
+ * container with its input (#1579). Non-plain leaves — primitives, and crucially
+ * **functions / class instances** — are passed through by reference: config
+ * sections are typed `Record<string, unknown>` and may legitimately hold
+ * callbacks, which are neither structured-cloneable nor the mutable containers
+ * the aliasing guarantee targets.
+ */
+function deepClone<V>(value: V): V {
+  if (Array.isArray(value)) {
+    return value.map((item) => deepClone(item)) as V;
+  }
+  if (isPlainObject(value)) {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value)) {
+      if (UNSAFE_KEYS.has(key)) {
+        continue;
+      }
+      out[key] = deepClone(value[key]);
+    }
+    return out as V;
+  }
+  return value;
+}
+
 /**
  * Deep-merge two plain objects, with `source` values taking precedence over
  * `target` values at each key level.
  *
  * Rules:
- * - Both values are non-array objects → recurse.
+ * - Both values are plain objects → recurse.
  * - `source` value is `null` or `undefined` → keep the `target` value.
  * - Otherwise → `source` value replaces `target` value (including `false`, `0`, `''`).
+ *
+ * The returned object owns all of its data: arrays and plain objects from both
+ * inputs are deep-cloned, so mutating an input later can't leak into the result
+ * (or the global runtime store via {@link setConfig}) and vice versa (#1579).
+ * Each value is cloned exactly once — carried-over target keys and overriding
+ * source leaves are cloned here, and shared object keys are produced by the
+ * recursive call rather than re-cloned.
  *
  * @param target - Base object (lower priority).
  * @param source - Override object (higher priority).
@@ -25,43 +73,36 @@ function deepMerge<T extends Record<string, unknown>>(
   target: T,
   source: Partial<T>,
 ): T {
-  // Deep-clone the carried-over target values (defaults / prior runtime store)
-  // so the merged result never aliases the caller's `target`. Combined with the
-  // clone of leaf source values below, the output owns all of its data: mutating
-  // an input array/object can't leak into the result or the global runtime store
-  // (via setConfig), and vice versa (#1579). Config is pure data, so
-  // structuredClone is safe. Typed as Record<string, unknown> (not the generic
-  // T) so the own-key writes below are well-typed — indexing a generic T for
-  // *write* is a TS2862 error.
-  const result: Record<string, unknown> = structuredClone(
-    target,
-  ) as Record<string, unknown>;
+  // Typed as Record<string, unknown> (not the generic T) so the own-key writes
+  // below are well-typed — indexing a generic T for *write* is a TS2862 error.
+  const result: Record<string, unknown> = {};
+  const tgt = target as Record<string, unknown>;
   const src = source as Record<string, unknown>;
 
+  // Carry over target-only keys, cloned so the result never aliases `target`.
+  for (const key of Object.keys(tgt)) {
+    if (UNSAFE_KEYS.has(key) || key in src) {
+      continue;
+    }
+    result[key] = deepClone(tgt[key]);
+  }
+
   for (const key of Object.keys(src)) {
-    // Guard against prototype pollution when merging untrusted/DB-exported
-    // input: never write to __proto__/constructor/prototype keys.
-    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+    if (UNSAFE_KEYS.has(key)) {
       continue;
     }
     const sourceValue = src[key];
-    const targetValue = result[key];
+    const targetValue = tgt[key];
 
-    if (
-      sourceValue &&
-      typeof sourceValue === 'object' &&
-      !Array.isArray(sourceValue) &&
-      targetValue &&
-      typeof targetValue === 'object' &&
-      !Array.isArray(targetValue)
-    ) {
-      result[key] = deepMerge(
-        targetValue as Record<string, unknown>,
-        sourceValue as Record<string, unknown>,
-      );
+    if (isPlainObject(sourceValue) && isPlainObject(targetValue)) {
+      // Recurse — the child call returns a fully-owned object (no re-clone).
+      result[key] = deepMerge(targetValue, sourceValue);
     } else if (sourceValue !== undefined && sourceValue !== null) {
-      // Clone leaf arrays/objects so the result doesn't alias `source` (#1579).
-      result[key] = structuredClone(sourceValue);
+      // `source` wins — clone its (possibly nested) value so we don't alias it.
+      result[key] = deepClone(sourceValue);
+    } else if (targetValue !== undefined) {
+      // `source` is null/undefined — keep the (cloned) target value.
+      result[key] = deepClone(targetValue);
     }
   }
 


### PR DESCRIPTION
Resolves the two **config design decisions** from #1579's tail (deferred from the T1 deep review #1380).

## 1. `deepMerge` aliased its inputs → deep-clone (decision A)
[merge.ts](packages/config/src/merge.ts) recursed only into plain nested objects; **arrays and source-only values were assigned by reference**, and the top level was a shallow `{ ...target }`. So a merged config — including the global runtime store populated by `setConfig` — held **live references into the caller's `defaults`/`fileConfig`/runtime inputs**. Mutating an input array later silently mutated the stored config (and vice versa).

Now `structuredClone` (config is pure data — zero function-typed fields) the carried-over target values and the leaf source values, so every merge fully owns its data.

## 2. `loadConfig` swallowed malformed-config errors → fail loud (decision B, escalated to throw)
[loader.ts](packages/config/src/loader.ts) caught **all** load errors and returned `{}`, so a malformed `smrt.config` (syntax error, bad import, invalid JSON) was indistinguishable from "no config file" — settings silently ignored.

Now it distinguishes the two: a genuinely-absent file (ENOENT, or `search()` returning null) still falls back to `{}`, but a config file that **exists and fails to parse** throws a contextual error (with `cause`).

## Tests
- merge no longer aliases inputs — direct (`mergeConfigs`) and via `setConfig` into the runtime store
- a malformed config file makes `loadConfig` reject
- **264 config tests pass**; typecheck + biome clean; knowledge fresh

## Behavior-change note
Build tooling that loads a project's `smrt.config` (core vite-plugin, cli — both via `search()`) will now **fail loudly if that file is malformed**, instead of silently building against defaults. No type signatures changed; the only consumers all use `search()`, which still returns gracefully when no config exists.

Closes the config-decision items on #1579 (remaining: the live-DuckDB `differ.ts` verification).