### PR TITLE
docs(core): record that sqlite_master works on DuckDB for differ introspection (#1579)

### DIFF
--- a/packages/core/src/migrations/differ.ts
+++ b/packages/core/src/migrations/differ.ts
@@ -592,7 +592,11 @@ export class SchemaComparer {
     if (this.engine === 'postgres') {
       query = `SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`;
     } else {
-      // SQLite and DuckDB
+      // SQLite and DuckDB both expose the SQLite-compatible `sqlite_master`
+      // catalog — DuckDB ships it as a built-in compatibility view, so a single
+      // introspection query covers both engines. Verified against a live DuckDB
+      // v1.4.3 (json mode): `SELECT name FROM sqlite_master WHERE type='table'`
+      // returns user tables with the expected `name` column (#1579).
       query = `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`;
     }
 


### PR DESCRIPTION
Resolves the **`differ.ts` DuckDB introspection** item on #1579 — a *verify-then-maybe-fix* task.

## What was asked
`SchemaDiffer.getExistingTables()` ([differ.ts:594](packages/core/src/migrations/differ.ts)) uses `SELECT name FROM sqlite_master` for the shared SQLite/DuckDB branch. #1579 asked: does that actually work on DuckDB, or must DuckDB use `information_schema` / `duckdb_tables()`?

## Verification (empirical, live DuckDB v1.4.3, json mode)
Ran the differ's exact query plus alternatives against a live DuckDB connection (`getDatabase({ type: 'json', ... })`):

| query | result |
|---|---|
| `SELECT name FROM sqlite_master WHERE type='table'` (the differ's) | ✅ returns user tables, with the `name` column |
| `information_schema.tables` | ✅ works |
| `duckdb_tables()` | ✅ works |
| `SHOW TABLES` | ✅ works |

DuckDB ships a built-in **`sqlite_master` compatibility view** (type/name/tbl_name columns). The differ's shared SQLite/DuckDB branch is **correct** — **no code change needed**. This PR just documents the verification at the call site so the line isn't re-flagged.

## Note on the *other* differ.ts #1579 item
The partial-index WHERE-clause drift (`getIndexSignature` drops the predicate) is a **real, separate** limitation — SMRT does emit partial indexes (STI tables get `WHERE _meta_type = '...'`). A correct fix needs richer introspection on **both** the manifest and DB sides (the DB side can't currently supply the predicate, so adding it to only one side would create false-positive drift). Left as the documented limitation; tracked on #1579.
