### PR TITLE
docs(core): document discoverSmrtPackages split + STI-cache/embeddings limits (#1579)

### DIFF
--- a/packages/core/src/consumer-plugin/index.ts
+++ b/packages/core/src/consumer-plugin/index.ts
@@ -187,7 +187,15 @@ export function smrtConsumer(options: SmrtConsumerOptions = {}): Plugin {
 }
 
 /**
- * Discover SMRT packages in node_modules
+ * Discover SMRT packages from a consumer app's dependencies.
+ *
+ * Intentional split (#1579): this **consumer-plugin** path is async and
+ * resolves SMRT packages from the downstream app's `package.json` dependency
+ * names (`@have/`/`smrt` heuristic + `hasSmrtManifest` probe) inside the Vite
+ * consumer plugin. It is deliberately separate from the build-time
+ * `discoverSmrtPackages()` in `src/manifest/discover-smrt-packages.ts` — a
+ * synchronous, lockfile-cached `node_modules` manifest scan used for manifest
+ * generation. Different inputs, contexts, and lifecycles, not duplicated logic.
  */
 async function discoverSmrtPackages(projectRoot: string): Promise<string[]> {
   const packages: string[] = [];

--- a/packages/core/src/manifest/discover-smrt-packages.ts
+++ b/packages/core/src/manifest/discover-smrt-packages.ts
@@ -470,6 +470,16 @@ export interface DiscoveryOptions {
  * - Automatically invalidates when any manifest.json changes (packages rebuilt)
  *
  * Disable with SMRT_DISABLE_DISCOVERY_CACHE=true for debugging
+ *
+ * Intentional split (#1579): this is the **build-time** discovery path —
+ * synchronous, scans `node_modules` for `manifest.json` files with
+ * `moduleType: "smrt"`, and caches by lockfile/manifest hash for fast manifest
+ * generation. It is deliberately distinct from the consumer-plugin's
+ * `discoverSmrtPackages(projectRoot)` (`src/consumer-plugin/index.ts`), which is
+ * **async**, reads a downstream app's `package.json` dependency names with a
+ * lightweight `@have/`/`smrt` heuristic, and runs inside the Vite consumer
+ * plugin. Different inputs, contexts, and lifecycles — not duplicated logic to
+ * consolidate.
  */
 export function discoverSmrtPackages(options: DiscoveryOptions = {}): string[] {
   const startTime = options.timing ? performance.now() : 0;

--- a/packages/core/src/manifest/manifest-loader.ts
+++ b/packages/core/src/manifest/manifest-loader.ts
@@ -1409,6 +1409,16 @@ export function getLoadedManifests(): Array<[string, Manifest]> {
  *
  * @param collection - The collection/table name to find siblings for
  * @returns Array of manifest entries that share the same collection
+ *
+ * Known limitation (#1579, won't-fix): the per-collection result is cached on
+ * `globalThis.__smrtSTISiblingCache` after the first call and is not invalidated
+ * when a manifest is registered *afterwards* and isn't reachable via
+ * `smrtDependencies` (the Release-A self-register path). A sibling registered
+ * after first discovery for a given collection can therefore be missed until the
+ * cache is cleared. Accepted as low-risk: STI manifests are registered at
+ * startup before query traffic, and the few self-register flows that could hit
+ * it can reset the cache. Fixing it properly means a registration→cache
+ * invalidation hook, which is disproportionate to the exposure.
  */
 export function discoverSTISiblingsSync(
   collection: string,

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -3663,7 +3663,16 @@ export class SmrtObject extends SmrtClass {
       throw new Error('Object must have an ID before generating embeddings.');
     }
 
-    // Get embedding configuration for this class
+    // Get embedding configuration for this class.
+    // Known limitation (#1579, won't-fix): keyed by the *simple* runtime class
+    // name (`this.constructor.name`), so two classes with the same simple name
+    // in different packages but different embeddings config could collide
+    // (R5-canon). This mirrors the deliberate simple-name keying elsewhere
+    // (relationship graph, `loadRelated`'s `this.constructor.name` lookups —
+    // the tested #951 contract). Accepted as low-risk: duplicate simple class
+    // names carrying *different* embeddings config is rare, and switching to
+    // qualified names would need consistent instance→qualified-name resolution
+    // across STI and non-STI, a coordinated change beyond this config lookup.
     const config = ObjectRegistry.resolveEmbeddingConfig(this.constructor.name);
     if (!config) {
       throw new Error(


### PR DESCRIPTION
Dispositions the remaining cross-cutting tail of #1579 as documented decisions (the issue's acceptance bar: each item *fixed by a focused PR* or *explicitly resolved as won't-fix with rationale*). Comment-only, no behavior change.

- **`discoverSmrtPackages` split (box 5)** — documents that the two implementations are intentionally separate, not duplicated logic: the build-time `manifest/discover-smrt-packages.ts` (sync, lockfile-cached `node_modules` manifest scan for manifest generation) vs. the `consumer-plugin/index.ts` one (async, reads a downstream app's `package.json` deps inside the Vite consumer plugin). Cross-reference comments on both.
- **`discoverSTISiblingsSync` cache (box 7)** — records the per-collection `globalThis` cache not invalidating on post-first-call self-registration (Release-A path) as a known low-risk limitation; a registration→invalidation hook is disproportionate to the exposure.
- **embeddings config lookup (box 8)** — records the simple-name keying collision risk (duplicate simple class names with different embeddings config), consistent with the deliberate simple-name keying contract (#951, same class as the relationship-graph won't-fix).

Closes the documentation items on #1579. Core typecheck + biome clean.