### PR TITLE
fix(products): emit i18n catalog into raw svelte-package tree (#1536)

### DIFF
--- a/packages/products/src/lib-packaging.test.ts
+++ b/packages/products/src/lib-packaging.test.ts
@@ -14,9 +14,9 @@
  *
  * This guard fails if any *runtime* (value) relative import in the raw tree
  * points at a file the build never emitted — catching i18n and any other
- * shared module that drifts out of the packaged set. It is a no-op when the
- * package has not been built (the turbo `test` task depends on `build`, so it
- * always runs against a fresh `dist/` in CI).
+ * shared module that drifts out of the packaged set. The suite skips
+ * explicitly when the package has not been built (the turbo `test` task
+ * depends on `build`, so it always runs against a fresh `dist/` in CI).
  */
 
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
@@ -54,38 +54,42 @@ function resolvesAsRuntime(fromDir: string, spec: string): boolean {
 const STATEMENT =
   /(import|export)(\s+type\b)?[^;]*?from\s*["'](\.[^"']+)["']|import\s*["'](\.[^"']+)["']/g;
 
-describe('products raw dist/lib/lib packaging', () => {
-  it('emits the i18n catalog so packaged components can resolve it', () => {
-    if (!existsSync(rawTreeDir)) return; // not built; see file header
-    const catalog = join(rawTreeDir, 'i18n.js');
-    expect(existsSync(catalog), 'dist/lib/lib/i18n.js missing').toBe(true);
-    expect(readFileSync(catalog, 'utf8')).toContain('defineMessages');
-  });
+// Skips explicitly (not a silent pass) when the package has not been built;
+// the turbo `test` task depends on `build`, so CI always runs against fresh
+// `dist/`. Running bare `vitest` without a prior build shows this as skipped.
+describe.skipIf(!existsSync(rawTreeDir))(
+  'products raw dist/lib/lib packaging',
+  () => {
+    it('emits the i18n catalog so packaged components can resolve it', () => {
+      const catalog = join(rawTreeDir, 'i18n.js');
+      expect(existsSync(catalog), 'dist/lib/lib/i18n.js missing').toBe(true);
+      expect(readFileSync(catalog, 'utf8')).toContain('defineMessages');
+    });
 
-  it('resolves every runtime relative import in the raw tree', () => {
-    if (!existsSync(rawTreeDir)) return; // not built; see file header
-    const files = walk(rawTreeDir).filter(
-      (f) => f.endsWith('.js') || f.endsWith('.svelte'),
-    );
-    const unresolved: string[] = [];
-    for (const file of files) {
-      const src = readFileSync(file, 'utf8');
-      const fromDir = dirname(file);
-      STATEMENT.lastIndex = 0;
-      let match: RegExpExecArray | null;
-      // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
-      while ((match = STATEMENT.exec(src))) {
-        const isTypeOnly = Boolean(match[2]);
-        if (isTypeOnly) continue;
-        const spec = match[3] ?? match[4];
-        if (spec && !resolvesAsRuntime(fromDir, spec)) {
-          unresolved.push(`${relative(rawTreeDir, file)} -> ${spec}`);
+    it('resolves every runtime relative import in the raw tree', () => {
+      const files = walk(rawTreeDir).filter(
+        (f) => f.endsWith('.js') || f.endsWith('.svelte'),
+      );
+      const unresolved: string[] = [];
+      for (const file of files) {
+        const src = readFileSync(file, 'utf8');
+        const fromDir = dirname(file);
+        STATEMENT.lastIndex = 0;
+        let match: RegExpExecArray | null;
+        // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
+        while ((match = STATEMENT.exec(src))) {
+          const isTypeOnly = Boolean(match[2]);
+          if (isTypeOnly) continue;
+          const spec = match[3] ?? match[4];
+          if (spec && !resolvesAsRuntime(fromDir, spec)) {
+            unresolved.push(`${relative(rawTreeDir, file)} -> ${spec}`);
+          }
         }
       }
-    }
-    expect(
-      unresolved,
-      `unresolved runtime imports in dist/lib/lib:\n${unresolved.join('\n')}`,
-    ).toEqual([]);
-  });
-});
+      expect(
+        unresolved,
+        `unresolved runtime imports in dist/lib/lib:\n${unresolved.join('\n')}`,
+      ).toEqual([]);
+    });
+  },
+);

--- a/packages/products/src/lib-packaging.test.ts
+++ b/packages/products/src/lib-packaging.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Raw `dist/lib/lib/**` packaging topology guard (#1536).
+ *
+ * `build:lib` emits the package three ways: the public subpath bundles
+ * (`dist/lib/*.js`, wired to `package.json#exports`) plus a raw `.svelte`
+ * tree under `dist/lib/lib/` produced by `svelte-package` over
+ * `src/lib/{components,features,stores}`. `svelte-package` only emits files
+ * from its `-i` input dir, so shared modules that live directly under
+ * `src/lib` (e.g. `i18n.ts`, `mock-smrt-client.ts`) — imported by the
+ * packaged components as `../i18n.js` / `../mock-smrt-client` — must be
+ * emitted into `dist/lib/lib/` by the Vite library build's `lib/*` entries
+ * instead. #1536: `lib/i18n` was missing, so packaged components kept an
+ * `import { M } from '../i18n.js'` that never resolved.
+ *
+ * This guard fails if any *runtime* (value) relative import in the raw tree
+ * points at a file the build never emitted — catching i18n and any other
+ * shared module that drifts out of the packaged set. It is a no-op when the
+ * package has not been built (the turbo `test` task depends on `build`, so it
+ * always runs against a fresh `dist/` in CI).
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const rawTreeDir = join(packageDir, 'dist', 'lib', 'lib');
+
+function walk(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    return entry.isDirectory() ? walk(full) : [full];
+  });
+}
+
+function isFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function resolvesAsRuntime(fromDir: string, spec: string): boolean {
+  const base = resolve(fromDir, spec);
+  return [base, `${base}.js`, `${base}.svelte`, join(base, 'index.js')].some(
+    isFile,
+  );
+}
+
+// `import`/`export ... from '<relative>'` and bare `import '<relative>'`,
+// excluding type-only statements (erased at runtime by the Svelte/TS compiler).
+const STATEMENT =
+  /(import|export)(\s+type\b)?[^;]*?from\s*["'](\.[^"']+)["']|import\s*["'](\.[^"']+)["']/g;
+
+describe('products raw dist/lib/lib packaging', () => {
+  it('emits the i18n catalog so packaged components can resolve it', () => {
+    if (!existsSync(rawTreeDir)) return; // not built; see file header
+    const catalog = join(rawTreeDir, 'i18n.js');
+    expect(existsSync(catalog), 'dist/lib/lib/i18n.js missing').toBe(true);
+    expect(readFileSync(catalog, 'utf8')).toContain('defineMessages');
+  });
+
+  it('resolves every runtime relative import in the raw tree', () => {
+    if (!existsSync(rawTreeDir)) return; // not built; see file header
+    const files = walk(rawTreeDir).filter(
+      (f) => f.endsWith('.js') || f.endsWith('.svelte'),
+    );
+    const unresolved: string[] = [];
+    for (const file of files) {
+      const src = readFileSync(file, 'utf8');
+      const fromDir = dirname(file);
+      STATEMENT.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop
+      while ((match = STATEMENT.exec(src))) {
+        const isTypeOnly = Boolean(match[2]);
+        if (isTypeOnly) continue;
+        const spec = match[3] ?? match[4];
+        if (spec && !resolvesAsRuntime(fromDir, spec)) {
+          unresolved.push(`${relative(rawTreeDir, file)} -> ${spec}`);
+        }
+      }
+    }
+    expect(
+      unresolved,
+      `unresolved runtime imports in dist/lib/lib:\n${unresolved.join('\n')}`,
+    ).toEqual([]);
+  });
+});

--- a/packages/products/vite.config.ts
+++ b/packages/products/vite.config.ts
@@ -96,7 +96,18 @@ const libEntries = {
 	generated: resolve(packageDir, 'src/generated.ts'),
 	utils: resolve(packageDir, 'src/utils.ts'),
 	collections: resolve(packageDir, 'src/collections.ts'),
+	// These `lib/*` entries are NOT public subpaths (they have no
+	// `package.json#exports` mapping). They emit standalone modules into
+	// `dist/lib/lib/` so the raw `.svelte` files produced by the
+	// `svelte-package` passes below (over `src/lib/{components,features,stores}`)
+	// can resolve their shared-module imports. `svelte-package` only emits
+	// files under its `-i` input dir, so shared modules that live directly
+	// under `src/lib` (and are imported as `../mock-smrt-client` /
+	// `../i18n.js`) must be emitted here instead. `lib/i18n` closes the gap
+	// reported in #1536 — without it the packaged components keep an
+	// `import { M } from '../i18n.js'` that never resolves.
 	'lib/mock-smrt-client': resolve(packageDir, 'src/lib/mock-smrt-client.ts'),
+	'lib/i18n': resolve(packageDir, 'src/lib/i18n.ts'),
 } as const;
 
 /**


### PR DESCRIPTION
Closes #1536.

## Problem

`@happyvertical/smrt-products` `build:lib` packages the library two ways:

1. `vite build --mode library` → public subpath bundles (`dist/lib/*.js`, wired to `package.json#exports`). These correctly inline the i18n catalog.
2. Three `svelte-package` passes over `src/lib/{components,features,stores}` → the raw `dist/lib/lib/**` tree (raw `.svelte` + `.d.ts`).

`svelte-package` only emits files from its `-i` input dir. The catalog lives at `src/lib/i18n.ts` (directly under `src/lib`, not in any of the three input dirs), so the packaged components in `dist/lib/lib/components/*.svelte` kept an `import { M } from '../i18n.js'` resolving to `dist/lib/lib/i18n.js` — **a file that was never emitted** (only `i18n.d.ts` was).

Not a regression today (the raw tree is unreferenced by `exports`, so consumers only reach the package through the inlining bundles), but it would bite if `dist/lib/lib/**` were ever promoted to an `exports` entry, and it's a poor example for the triple-consumption reference template.

## Fix

Emit the catalog the **same way the existing `mock-smrt-client` shared module already works**: `src/lib/mock-smrt-client.ts` is imported by the raw stores as `../mock-smrt-client` and is satisfied by a Vite library entry (`'lib/mock-smrt-client'` → `dist/lib/lib/mock-smrt-client.js`), *not* by `svelte-package`. This PR adds the parallel `'lib/i18n'` entry so `dist/lib/lib/i18n.js` is emitted.

This keeps the three targeted `svelte-package` passes (deliberately scoped to coherent leaf UI modules) and introduces **zero new broken imports**. After the change, every runtime relative import in the raw tree resolves to an emitted file.

## Why not the issue's other options

- **(A) `svelte-package -i src/lib` wholesale** — does emit `i18n.js`, but also transpiles `collections`/`models`/`generated`/`index`, whose `../../__smrt-register__.js` (a top-level file Vite bundles into a chunk, never emitted as a sibling) and virtual `@smrt`-generated component imports (`./SmrtProductForm.svelte`, …) can **never** resolve in a raw `svelte-package` pass. That trades the i18n gap for a *more* incoherent tree — verified empirically.
- **(B) drop the raw `dist/lib/lib/**` tree** — breaks the public **type** surface. `dist/lib/components.d.ts` re-exports through `./lib/components/index` → `export { default as ProductCard } from './ProductCard.svelte'`, which resolves to `ProductCard.svelte.d.ts` — emitted **only** by `svelte-package`. Dropping the tree would break `./components` and `./stores` published types.
- **(C) relocate the catalog under a packaged subdir** — rejected in #1535 (misplaces app/page strings under the components layer).

## Verification

- `pnpm --filter @happyvertical/smrt-products build` → `dist/lib/lib/i18n.js` (+`.map`/`.d.ts`) now emitted; packaged `ProductForm.svelte`'s `import '../i18n.js'` resolves.
- Coherence walk over the built raw tree: **every** runtime (value) relative import resolves to an emitted `.js`/`.svelte`; every type import resolves to an emitted declaration. (`import type { ProductData } from '../types'` is type-only → resolves to the dts-plugin's `types.d.ts`, erased at runtime.)
- `verify:pack`, `typecheck`, full `vitest` suite (80 passed / 4 skipped) all green.
- All three consumption modes (`build:lib` / `build:app` / `build:federation`) build cleanly.
- New regression guard `src/lib-packaging.test.ts` fails if any runtime relative import in the raw tree points at a non-emitted file (verified via negative control: removing `i18n.js` makes it fail with `components/ProductForm.svelte -> ../i18n.js`). The turbo `test` task depends on `build`, so it runs against fresh `dist/` in CI.

Part of stabilization epic #1354 (closed; this was a non-blocking follow-up). Low priority / no consumer impact.