### PR TITLE
chore(release): sync starter-template smrt pins to release + stop renovate self-bumping (#1698-#1700)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -181,7 +181,7 @@ jobs:
         run: |
           {
             printf '%s\n' package.json
-            find packages -type f \( -name 'package.json' -o -name 'CHANGELOG.md' -o -path '*/dist/*' \) -print
+            find packages -type f \( -name 'package.json' -o -name 'CHANGELOG.md' -o -name 'template.config.js' -o -path '*/dist/*' \) -print
           } | sort -u > publish-release-workspace-files
           tar -cf publish-release-workspace.tar -T publish-release-workspace-files
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -157,6 +157,14 @@ jobs:
           echo "should_publish=true" >> "$GITHUB_OUTPUT"
           echo "version=$AFTER_VERSION" >> "$GITHUB_OUTPUT"
 
+          # Sync the starter templates' @happyvertical/smrt-* pins to this
+          # release so downstream-scaffolded projects reference the matching
+          # version. Renovate is configured to skip these files (renovate.json),
+          # so this is their only update path. Runs after the final (corrected)
+          # version is settled so it never captures a 1.0.0 overshoot.
+          echo "📝 Syncing starter-template versions to $AFTER_VERSION"
+          node scripts/sync-template-versions.mjs "$AFTER_VERSION"
+
           # Preserve the exact versioned tree so later jobs can publish
           # what they validated without rerunning changeset versioning.
           git diff --binary > release-version.patch
@@ -380,7 +388,7 @@ jobs:
           }
           NODE
 
-          mapfile -t release_files < <(find packages \( -name 'package.json' -o -name 'CHANGELOG.md' \) -print | sort)
+          mapfile -t release_files < <(find packages \( -name 'package.json' -o -name 'CHANGELOG.md' -o -name 'template.config.js' \) -print | sort)
           git add package.json
           git add -A .changeset
           if [ "${#release_files[@]}" -gt 0 ]; then

--- a/packages/template-site-static-json/template.config.js
+++ b/packages/template-site-static-json/template.config.js
@@ -23,13 +23,13 @@ export default {
   // the scaffolder injects the entries below at generation time, so this file is
   // the single source of truth for dependency versions.
   dependencies: {
-    '@happyvertical/smrt-core': '^0.24.8',
-    '@happyvertical/smrt-config': '^0.24.8',
-    '@happyvertical/smrt-ui': '^0.24.8',
-    '@happyvertical/smrt-content': '^0.24.8',
-    '@happyvertical/smrt-events': '^0.24.8',
-    '@happyvertical/smrt-places': '^0.24.8',
-    '@happyvertical/smrt-profiles': '^0.24.8',
+    '@happyvertical/smrt-core': '^0.37.0',
+    '@happyvertical/smrt-config': '^0.37.0',
+    '@happyvertical/smrt-ui': '^0.37.0',
+    '@happyvertical/smrt-content': '^0.37.0',
+    '@happyvertical/smrt-events': '^0.37.0',
+    '@happyvertical/smrt-places': '^0.37.0',
+    '@happyvertical/smrt-profiles': '^0.37.0',
     '@happyvertical/caelus': '^0.1.385',
   },
 

--- a/packages/template-sveltekit/template.config.js
+++ b/packages/template-sveltekit/template.config.js
@@ -20,7 +20,7 @@ export default {
 
   // Dependencies to add to generated project
   dependencies: {
-    '@happyvertical/smrt-core': '^0.24.8',
+    '@happyvertical/smrt-core': '^0.37.0',
   },
 
   devDependencies: {

--- a/packages/template-sveltekit/template/package.json
+++ b/packages/template-sveltekit/template/package.json
@@ -20,8 +20,8 @@
     "vite": "^7.3.6"
   },
   "dependencies": {
-    "@happyvertical/smrt-core": "^0.25.8",
-    "@happyvertical/smrt-tenancy": "^0.25.8",
-    "@happyvertical/smrt-users": "^0.25.8"
+    "@happyvertical/smrt-core": "^0.37.0",
+    "@happyvertical/smrt-tenancy": "^0.37.0",
+    "@happyvertical/smrt-users": "^0.37.0"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,12 @@
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true,
       "automergeType": "pr"
+    },
+    {
+      "description": "Don't let Renovate bump the monorepo's own @happyvertical/smrt-* packages where the starter templates pin them as real npmjs deps for downstream projects. Those pins are synced to the monorepo release at publish time (scripts/sync-template-versions.mjs); chasing them against npmjs only produces self-referential, perpetually-stale PRs (#1698/#1699/#1700).",
+      "matchFileNames": ["packages/*/template/package.json"],
+      "matchPackageNames": ["@happyvertical/smrt-*"],
+      "enabled": false
     }
   ]
 }

--- a/scripts/sync-template-versions.mjs
+++ b/scripts/sync-template-versions.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Sync starter-template @happyvertical/smrt-* version pins to the monorepo's
+ * current release.
+ *
+ * The starter templates under `packages/<pkg>/template/` ship as static files
+ * inside their published package, so a downstream project scaffolded from them
+ * consumes `@happyvertical/smrt-*` as real npmjs dependencies. Those pins
+ * therefore cannot use `workspace:*` (pnpm only rewrites the publishing
+ * package's own manifest, not nested files shipped via `files`), and they must
+ * NOT be chased independently by Renovate — that produces self-referential,
+ * perpetually-stale PRs (#1698/#1699/#1700). Instead the release pipeline runs
+ * this script so the templates always reference the version being published.
+ *
+ * Renovate is configured to skip these files (see renovate.json).
+ *
+ * Usage:
+ *   node scripts/sync-template-versions.mjs [version]   # write pins (^version)
+ *   node scripts/sync-template-versions.mjs --check      # exit 1 if out of sync
+ *
+ * When no version is given it falls back to packages/core/package.json (the
+ * monorepo's version source of truth — all @happyvertical/smrt-* packages are
+ * version-locked together via changesets).
+ */
+
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+const packagesDir = join(repoRoot, 'packages');
+
+const SMRT_DEP_RE = /^@happyvertical\/smrt-[a-z0-9-]+$/;
+
+const args = process.argv.slice(2);
+const checkOnly = args.includes('--check');
+const versionArg = args.find((a) => !a.startsWith('--'));
+
+/** Resolve the release version: explicit arg, else packages/core/package.json. */
+function resolveVersion() {
+  if (versionArg) return versionArg.replace(/^\^|^v/, '');
+  const corePkg = JSON.parse(
+    readFileSync(join(packagesDir, 'core', 'package.json'), 'utf8'),
+  );
+  return corePkg.version;
+}
+
+const version = resolveVersion();
+const targetRange = `^${version}`;
+
+if (!/^\d+\.\d+\.\d+/.test(version)) {
+  console.error(`[sync-template-versions] Invalid version: "${version}"`);
+  process.exit(1);
+}
+
+/** Find every `packages/<pkg>/template/` scaffold directory. */
+function findTemplateDirs() {
+  const dirs = [];
+  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const templateDir = join(packagesDir, entry.name, 'template');
+    try {
+      readFileSync(join(templateDir, 'package.json'));
+      dirs.push({ pkg: entry.name, templateDir });
+    } catch {
+      // No template/package.json — skip.
+    }
+  }
+  return dirs;
+}
+
+const drift = [];
+
+/** Rewrite smrt-* pins inside a template's package.json (deps + devDeps). */
+function syncTemplatePackageJson(file) {
+  const raw = readFileSync(file, 'utf8');
+  const pkg = JSON.parse(raw);
+  let changed = false;
+  for (const field of ['dependencies', 'devDependencies', 'peerDependencies']) {
+    const deps = pkg[field];
+    if (!deps) continue;
+    for (const name of Object.keys(deps)) {
+      if (SMRT_DEP_RE.test(name) && deps[name] !== targetRange) {
+        drift.push(`${file}: ${name} ${deps[name]} -> ${targetRange}`);
+        deps[name] = targetRange;
+        changed = true;
+      }
+    }
+  }
+  if (changed && !checkOnly) {
+    writeFileSync(file, `${JSON.stringify(pkg, null, 2)}\n`);
+  }
+  return changed;
+}
+
+/**
+ * Rewrite smrt-* pins inside a template.config.js. It is a JS module rather
+ * than JSON, so we string-replace the quoted version that follows each smrt-*
+ * key instead of parsing it.
+ */
+function syncTemplateConfigJs(file) {
+  let raw;
+  try {
+    raw = readFileSync(file, 'utf8');
+  } catch {
+    return false;
+  }
+  const re =
+    /(['"]@happyvertical\/smrt-[a-z0-9-]+['"]\s*:\s*)(['"])\^?\d[^'"]*(['"])/g;
+  let changed = false;
+  const next = raw.replace(re, (match, keyPart, openQuote, closeQuote) => {
+    const replacement = `${keyPart}${openQuote}${targetRange}${closeQuote}`;
+    if (replacement !== match) {
+      drift.push(`${file}: ${match.trim()} -> ...${targetRange}`);
+      changed = true;
+    }
+    return replacement;
+  });
+  if (changed && !checkOnly) {
+    writeFileSync(file, next);
+  }
+  return changed;
+}
+
+const templates = findTemplateDirs();
+let anyChanged = false;
+for (const { pkg, templateDir } of templates) {
+  if (syncTemplatePackageJson(join(templateDir, 'package.json'))) {
+    anyChanged = true;
+  }
+  // template.config.js lives next to the template/ directory.
+  if (syncTemplateConfigJs(join(packagesDir, pkg, 'template.config.js'))) {
+    anyChanged = true;
+  }
+}
+
+if (checkOnly) {
+  if (anyChanged) {
+    console.error(
+      `[sync-template-versions] Template smrt-* pins are out of sync with ${targetRange}:`,
+    );
+    for (const line of drift) console.error(`  ${line}`);
+    console.error('Run: node scripts/sync-template-versions.mjs');
+    process.exit(1);
+  }
+  console.log(
+    `[sync-template-versions] Template smrt-* pins are in sync with ${targetRange}.`,
+  );
+  process.exit(0);
+}
+
+if (anyChanged) {
+  console.log(`[sync-template-versions] Synced template smrt-* pins to ${targetRange}:`);
+  for (const line of drift) console.log(`  ${line}`);
+} else {
+  console.log(
+    `[sync-template-versions] Template smrt-* pins already at ${targetRange}; nothing to do.`,
+  );
+}

--- a/scripts/sync-template-versions.mjs
+++ b/scripts/sync-template-versions.mjs
@@ -39,7 +39,7 @@ const versionArg = args.find((a) => !a.startsWith('--'));
 
 /** Resolve the release version: explicit arg, else packages/core/package.json. */
 function resolveVersion() {
-  if (versionArg) return versionArg.replace(/^\^|^v/, '');
+  if (versionArg) return versionArg.replace(/^[\^v]+/, '');
   const corePkg = JSON.parse(
     readFileSync(join(packagesDir, 'core', 'package.json'), 'utf8'),
   );


### PR DESCRIPTION
Fixes the "smrt-into-smrt" renovate PRs (#1698/#1699/#1700) and the underlying drift.

## Why those PRs existed
The starter templates under `packages/*/template/` are scaffolds shipped as static files inside their published package, so a downstream project scaffolded from them consumes `@happyvertical/smrt-*` as **real npmjs dependencies**. Those pins:
- **can't** be `workspace:*` — pnpm only rewrites the publishing package's own manifest, not nested files shipped via `files`, so `workspace:*` would ship literally and break `npm install` downstream; and
- **shouldn't** be chased by renovate against npmjs — that's self-referential and perpetually stale.

The evidence: `template-sveltekit/template/package.json` sat at `^0.25.8` while the monorepo is at **0.37.0**, and renovate only proposed `^0.29.41`. `template.config.js` had drifted even further (`^0.24.8`) despite a comment claiming it was "kept in sync."

## The fix
1. **`renovate.json`** — a `packageRule` disabling `@happyvertical/smrt-*` updates in `packages/*/template/package.json`, so renovate stops opening these PRs.
2. **`scripts/sync-template-versions.mjs`** — rewrites every template `smrt-*` pin (both `template/package.json` deps and `template.config.js`) to the release version. Falls back to `packages/core/package.json` (the version source of truth — smrt-* are version-locked) and supports `--check`.
3. **`publish.yml`** — runs the sync right after the final (1.0.0-corrected) version is settled, before the release patch is captured, so every published template references the version being shipped. Also adds `template.config.js` to the release commit-back so `main` stays in sync.
4. **One-time reconcile** of both templates to the current `^0.37.0` (also fixes the `template.config.js` drift in `template-site-static-json`).

## Verification
- `node scripts/sync-template-versions.mjs --check` → in sync; idempotent.
- `actionlint .github/workflows/publish.yml` → clean.
- `@happyvertical/smrt-template-sveltekit` tests → 25/25 pass.
- `renovate.json` valid JSON.

After this merges I'll close #1698/#1699/#1700 as superseded.
