### PR TITLE
feat(smrt-users): AccessRequest primitive (request-access / waitlist) with graduation to User

### DIFF
--- a/packages/core/src/__tests__/meta-indexed.test.ts
+++ b/packages/core/src/__tests__/meta-indexed.test.ts
@@ -19,6 +19,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { field, meta, SmrtObject, smrt } from '../index.js';
 import { ObjectRegistry } from '../registry';
 import { SQLiteStrategy } from '../schema/ddl/sqlite-strategy.js';
+import { SchemaGenerator } from '../schema/generator.js';
 import { getTestDatabase } from '../testing/database';
 
 // STI base
@@ -123,6 +124,36 @@ describe('@meta({ indexed: true }) (R9)', () => {
       (row: any) => row.name?.includes('notes') && !row.name?.includes('id'),
     );
     expect(notesIdx).toBeUndefined();
+  });
+
+  it('generateCTISchemaFromManifest emits plain column indexes for indexed fields', () => {
+    // The build-time manifest path (used by db:migrate / the schema differ) must
+    // honor `@field({ indexed: true })` the same way the runtime path and the STI
+    // manifest path do — otherwise the declared index is silently dropped.
+    const generator = new SchemaGenerator();
+    const schema = generator.generateCTISchemaFromManifest(
+      'IdxCustomer',
+      'idx_customers',
+      {
+        name: { type: 'text' },
+        externalRef: { type: 'text', _meta: { indexed: true } },
+        notes: { type: 'text' },
+      } as any,
+    );
+
+    // `schema.indexes` is the source of truth the schema differ / db:migrate
+    // compares against (the manifest `ddl` string carries only CREATE TABLE).
+    const refIdx = schema.indexes.find(
+      (i) => i.name === 'idx_customers_external_ref_idx',
+    );
+    expect(refIdx).toBeDefined();
+    expect(refIdx?.columns).toEqual(['external_ref']);
+    expect(refIdx?.unique).toBeFalsy();
+
+    // Unindexed columns get no index.
+    expect(
+      schema.indexes.find((i) => i.columns?.includes('notes')),
+    ).toBeUndefined();
   });
 
   it('actually creates the index in the live SQLite database', async () => {

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -1409,8 +1409,9 @@ export class SchemaGenerator {
 
       // Opt-in plain column index. FK columns and unique columns get their own
       // indexes, so skip those here.
+      const indexedField: RegistryField = field;
       const isIndexed =
-        (field as any).indexed === true || field._meta?.indexed === true;
+        indexedField.indexed === true || field._meta?.indexed === true;
       if (isIndexed && field.type !== 'foreignKey' && !columnDef.unique) {
         indexedColumns.add(columnName);
       }

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -1323,6 +1323,11 @@ export class SchemaGenerator {
   ): ManifestSchema {
     const columns: Record<string, ManifestColumnDefinition> = {};
 
+    // Track regular columns opted into a plain index via `@field({ indexed: true })`.
+    // Mirrors the STI path (generateSTISchemaFromManifest) so CTI tables honor
+    // the documented `FieldOptions.indexed` flag too.
+    const indexedColumns = new Set<string>();
+
     // Add default SMRT fields
     columns.id = {
       type: this.getIdColumnType(config),
@@ -1402,6 +1407,14 @@ export class SchemaGenerator {
         columnDef.default = field.default;
       }
 
+      // Opt-in plain column index. FK columns and unique columns get their own
+      // indexes, so skip those here.
+      const isIndexed =
+        (field as any).indexed === true || field._meta?.indexed === true;
+      if (isIndexed && field.type !== 'foreignKey' && !columnDef.unique) {
+        indexedColumns.add(columnName);
+      }
+
       columns[columnName] = columnDef;
     }
 
@@ -1425,6 +1438,14 @@ export class SchemaGenerator {
       columns: conflictColumns,
       unique: true,
     });
+
+    // Plain column indexes for regular columns opted in via `indexed: true`.
+    for (const colName of indexedColumns) {
+      indexes.push({
+        name: `${tableName}_${colName}_idx`,
+        columns: [colName],
+      });
+    }
 
     // Generate DDL
     const schemaDefinition: SchemaDefinition = {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -52,6 +52,7 @@ export type { Signal, SignalAdapter, SignalType } from './signals.js';
 
 // User status enums (browser-safe, no server dependencies)
 export {
+  AccessRequestStatus,
   MembershipStatus,
   OverrideEffect,
   SessionStatus,

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -83,6 +83,46 @@ export enum MembershipStatus {
   PENDING = 'pending',
 }
 
+// ============= Access Request Status =============
+
+/**
+ * Lifecycle status of an {@link AccessRequest} — the "request access / join the
+ * waitlist" identity primitive that captures a prospective user from a public
+ * form before they become a real `User`.
+ *
+ * Operators triage `REQUESTED` records, then either decline them or approve and
+ * **graduate** them into a `User` (optionally attached to a tenant).
+ *
+ * State machine:
+ * ```
+ * REQUESTED ──approve──> APPROVED ──graduate──> GRADUATED
+ *     │                      │
+ *     ├──decline──> DECLINED ┘ (decline also valid from APPROVED)
+ *     └──cancel───> CANCELED
+ * ```
+ *
+ * @example
+ * ```typescript
+ * if (request.status === AccessRequestStatus.APPROVED) {
+ *   await service.graduateAccessRequest(request.id, { by: operatorId });
+ * }
+ * ```
+ *
+ * @see {@link UserStatus} for the account-level status set when a request graduates
+ */
+export enum AccessRequestStatus {
+  /** Open request awaiting operator triage (the default on creation) */
+  REQUESTED = 'requested',
+  /** Operator approved the request; ready to graduate into a User */
+  APPROVED = 'approved',
+  /** Operator declined the request */
+  DECLINED = 'declined',
+  /** Request was graduated into a real User (terminal) */
+  GRADUATED = 'graduated',
+  /** Request was canceled before a decision (terminal) */
+  CANCELED = 'canceled',
+}
+
 // ============= Session Status =============
 
 /**

--- a/packages/users/AGENTS.md
+++ b/packages/users/AGENTS.md
@@ -2,11 +2,12 @@
 
 Multi-tenant user management with RBAC, hierarchical tenants, session handling, and SvelteKit integration.
 
-## Models (13)
+## Models (14)
 
 | Model | Key Pattern |
 |-------|-------------|
 | User | Auth identity. `profileId` is plain string (not FK) to smrt-profiles. Email auto-lowercased. |
+| AccessRequest | "Request access / waitlist" record captured before a `User` exists. CLOSED generated surface (`api`/`mcp`/`cli` = `[]`) — all access via `AccessRequestService`. Email normalized + indexed; JSON `requestContext` (NOT `context` — reserved for slug scoping). |
 | Tenant | **STI** + hierarchical parent-child. `hierarchyPath` (materialized path), `hierarchyLevel`. Max depth 10. |
 | Session | Server-side. Secure UUID. TTL in **seconds** (not ms). Status auto-updates to EXPIRED on access. |
 | MagicLinkToken | Single-use email login token. Backed by `MagicLinkService`. |

--- a/packages/users/README.md
+++ b/packages/users/README.md
@@ -228,6 +228,64 @@ Optional-tenancy and global tables are skipped and returned in
 `result.skipped` instead of generating unsafe policies. Custom permissions can
 participate in RLS by adding explicit Postgres bindings as shown above.
 
+### Access requests (request access / waitlist)
+
+Capture a prospective user from a public form *before* they are a real `User`,
+let an operator triage, and **graduate** an approved request into a `User`
+(optionally attached to a tenant). `createAccessRequest` is **public-safe** (no
+auth) — expose it from your own rate-limited endpoint. Operator methods are gated
+by an optional `authorize` hook (capabilities `access-requests:read` /
+`access-requests:manage`). Lifecycle events let apps send invites/notifications;
+this package never owns email delivery.
+
+```typescript
+import { AccessRequestService } from '@happyvertical/smrt-users';
+
+const accessRequests = await AccessRequestService.create({
+  db: { type: 'postgres', url: process.env.DATABASE_URL },
+
+  // Optional: gate operator methods against your permission system.
+  // (createAccessRequest is always public-safe and never calls this.)
+  authorize: async ({ capability, by }) => {
+    if (!by || !(await isPlatformOperator(by, capability))) {
+      throw new Error(`Missing capability: ${capability}`);
+    }
+  },
+
+  // Optional: react to lifecycle changes (send a magic link on graduate, etc.).
+  onEvent: async (event) => {
+    if (event.type === 'access-request.graduated' && event.user) {
+      await sendWelcomeEmail(event.user.email);
+    }
+  },
+});
+
+// 1) Public form handler (app adds rate-limiting) — no auth required.
+const request = await accessRequests.createAccessRequest({
+  email: 'jane@example.com',
+  name: 'Jane Doe',
+  source: 'www',
+  context: { company: 'Acme', intendedUse: 'evaluation' },
+});
+
+// 2) Operator triages the queue.
+const open = await accessRequests.listAccessRequests({
+  status: AccessRequestStatus.REQUESTED,
+  by: operatorId,
+});
+await accessRequests.approveAccessRequest(request.id, { by: operatorId });
+
+// 3) Graduate into a User — operator picks new-vs-existing tenant per request:
+//    a) brand-new tenant, requester as owner
+const { user, tenant, membership } = await accessRequests.graduateAccessRequest(
+  request.id,
+  { by: operatorId, tenant: { create: { name: 'Acme Inc' } } },
+);
+//    b) existing tenant:  { tenant: { tenantId, role: 'member' } }
+//    c) user only:        { tenant: 'none' }
+// Graduation is idempotent and reuses the existing User/Membership paths.
+```
+
 ### SvelteKit hooks
 
 ```typescript
@@ -399,6 +457,7 @@ TenantService supports three modes: `flexible` (no auto-create), `personal` (aut
 | `MembershipOverride` | Per-user permission grant/deny on a membership. |
 | `TenantPermissionOverride` | Tenant-level permission override (INHERIT/GRANT/DENY). |
 | `GroupMember`, `GroupRole`, `RolePermission` | Junction tables for groups and role-permission assignments. |
+| `AccessRequest` | "Request access / waitlist" record captured before a `User` exists. Closed generated surface — all access via `AccessRequestService`. |
 
 ### Collections
 
@@ -409,6 +468,7 @@ TenantService supports three modes: `flexible` (no auto-create), `personal` (aut
 | `MembershipCollection` | Membership CRUD, `findByUserAndTenant()` |
 | `MembershipOverrideCollection`, `TenantPermissionOverrideCollection` | Override management at membership and tenant levels |
 | `GroupCollection`, `GroupMemberCollection`, `GroupRoleCollection`, `RolePermissionCollection` | Group and role-permission junction management |
+| `AccessRequestCollection` | AccessRequest queries: `findByEmail()`, `findOpenByEmail()`, `findByStatus()`, `findOpen()` |
 
 ### Services
 
@@ -423,6 +483,7 @@ TenantService supports three modes: `flexible` (no auto-create), `personal` (aut
 | `withSessionPermissionContext()` | Loads a session, optionally enters tenancy context, and exposes a request-scoped database/permission context. |
 | `getCurrentSessionPermissionContext()`, `getRequestScopedDatabase()` | Read the active request/session context inside app code. |
 | `TenantService` | Policy-driven tenant lifecycle. `ensureTenantForUser()`, `createTenantWithOwnership()`. |
+| `AccessRequestService` | Request-access/waitlist lifecycle + graduation. `createAccessRequest()` (public-safe), `list`/`get`/`approve`/`decline`/`cancel`, `graduateAccessRequest()` (new/existing/no tenant). Capability + event hooks. |
 
 ### SvelteKit (`@happyvertical/smrt-users/sveltekit`)
 
@@ -441,7 +502,9 @@ TenantService supports three modes: `flexible` (no auto-create), `personal` (aut
 | Export | Description |
 |--------|-------------|
 | `UserStatus`, `TenantStatus`, `SessionStatus`, `MembershipStatus` | Status enums |
+| `AccessRequestStatus` | Access-request lifecycle enum (`REQUESTED`/`APPROVED`/`DECLINED`/`GRADUATED`/`CANCELED`) |
 | `OverrideEffect`, `TenantPermissionEffect` | Override effect enums |
+| `ACCESS_REQUEST_CAPABILITIES`, `AccessRequestError` | Operator capability slugs; typed domain error (`error.code`) |
 | `DEFAULT_ROLE_SLUGS`, `DEFAULT_ROLES`, `DEFAULT_TENANT_POLICY` | System role slugs, role configs, default tenant policy |
 | `DEFAULT_SESSION_TTL`, `MAX_TENANT_HIERARCHY_DEPTH` | 604800 (7 days in seconds), 10 |
 | `TenantHierarchyError` | Thrown when hierarchy depth limit is exceeded |

--- a/packages/users/src/__tests__/access-request.test.ts
+++ b/packages/users/src/__tests__/access-request.test.ts
@@ -582,6 +582,36 @@ describe('AccessRequest', () => {
       ).rejects.toMatchObject({ code: 'TENANT_NOT_FOUND' });
     });
 
+    it('rejects an invalid role without leaving an orphan tenant or user', async () => {
+      // codex review #1713: a bad role slug used to create the tenant first, then
+      // throw ROLE_NOT_FOUND — orphaning the tenant (and the just-created user).
+      // Tenant option is now validated before any write.
+      const request = await service.createAccessRequest({
+        email: 'badrole@example.com',
+      });
+      await service.approveAccessRequest(request.id as string);
+
+      const tenantsBefore = (await tenants.findActive()).length;
+      const usersBefore = await users.findByEmail('badrole@example.com');
+
+      await expect(
+        service.graduateAccessRequest(request.id as string, {
+          tenant: {
+            create: { name: 'Should Not Persist' },
+            role: 'nonexistent',
+          },
+        }),
+      ).rejects.toMatchObject({ code: 'ROLE_NOT_FOUND' });
+
+      // No orphan tenant, no orphan user, and the request is still ungraduated.
+      expect((await tenants.findActive()).length).toBe(tenantsBefore);
+      expect(await tenants.findBySlug('should-not-persist')).toBeNull();
+      expect(usersBefore).toBeNull();
+      expect(await users.findByEmail('badrole@example.com')).toBeNull();
+      const reloaded = await service.getAccessRequest(request.id as string);
+      expect(reloaded?.status).toBe(AccessRequestStatus.APPROVED);
+    });
+
     it('exposes AccessRequestError for instanceof checks', async () => {
       const error = await service
         .approveAccessRequest('missing')

--- a/packages/users/src/__tests__/access-request.test.ts
+++ b/packages/users/src/__tests__/access-request.test.ts
@@ -1,0 +1,570 @@
+/**
+ * AccessRequest lifecycle tests
+ *
+ * Covers the "request access / waitlist" identity primitive end to end:
+ * 1. Public-safe creation (email validation + normalization + dedup)
+ * 2. State machine (approve / decline / cancel) with idempotency + invalid-
+ *    transition guards
+ * 3. Operator reads (list filters / get)
+ * 4. Capability gating (authorize hook) — create stays public-safe
+ * 5. Lifecycle events (created / approved / declined / graduated), best-effort
+ * 6. Graduation across all three tenant paths (new / existing / none),
+ *    idempotency, and create-or-link by email
+ */
+
+import { randomUUID } from 'node:crypto';
+import { existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { MembershipCollection } from '../collections/MembershipCollection.js';
+import { RoleCollection } from '../collections/RoleCollection.js';
+import { TenantCollection } from '../collections/TenantCollection.js';
+import { UserCollection } from '../collections/UserCollection.js';
+import {
+  ACCESS_REQUEST_CAPABILITIES,
+  type AccessRequestAuthorizationContext,
+  AccessRequestError,
+  type AccessRequestEvent,
+  AccessRequestService,
+} from '../services/AccessRequestService.js';
+import {
+  AccessRequestStatus,
+  DEFAULT_ROLE_SLUGS,
+  MembershipStatus,
+  UserStatus,
+} from '../types/index.js';
+
+describe('AccessRequest', () => {
+  let dbPath: string;
+  let db: { type: 'sqlite'; url: string };
+  let events: AccessRequestEvent[];
+  let service: AccessRequestService;
+  let users: UserCollection;
+  let tenants: TenantCollection;
+  let roles: RoleCollection;
+  let memberships: MembershipCollection;
+
+  beforeEach(async () => {
+    dbPath = join(tmpdir(), `smrt-access-request-${randomUUID()}.db`);
+    db = { type: 'sqlite', url: dbPath };
+    events = [];
+    service = await AccessRequestService.create({
+      db,
+      onEvent: (event) => {
+        events.push(event);
+      },
+    });
+    users = await UserCollection.create({ db });
+    tenants = await TenantCollection.create({ db });
+    roles = await RoleCollection.create({ db });
+    memberships = await MembershipCollection.create({ db });
+  });
+
+  afterEach(() => {
+    if (existsSync(dbPath)) {
+      try {
+        rmSync(dbPath, { force: true });
+      } catch (err) {
+        console.warn(`Test cleanup warning: failed to remove ${dbPath}:`, err);
+      }
+    }
+  });
+
+  const eventTypes = () => events.map((e) => e.type);
+
+  describe('createAccessRequest (public-safe)', () => {
+    it('creates a REQUESTED record, normalizing the email and storing context', async () => {
+      const request = await service.createAccessRequest({
+        email: '  Jane@Example.COM ',
+        name: 'Jane Doe',
+        source: 'www',
+        context: { company: 'Acme', intendedUse: 'evaluation' },
+        tenantHint: { org: 'acme' },
+      });
+
+      expect(request.email).toBe('jane@example.com');
+      expect(request.name).toBe('Jane Doe');
+      expect(request.source).toBe('www');
+      expect(request.status).toBe(AccessRequestStatus.REQUESTED);
+      expect(request.isOpen()).toBe(true);
+      expect(request.getRequestContext()).toEqual({
+        company: 'Acme',
+        intendedUse: 'evaluation',
+      });
+      expect(request.getTenantHint()).toEqual({ org: 'acme' });
+      expect(request.requestedAt).toBeInstanceOf(Date);
+      expect(eventTypes()).toEqual(['access-request.created']);
+    });
+
+    it('rejects an invalid email', async () => {
+      await expect(
+        service.createAccessRequest({ email: 'not-an-email' }),
+      ).rejects.toMatchObject({
+        name: 'AccessRequestError',
+        code: 'INVALID_EMAIL',
+      });
+      expect(events).toHaveLength(0);
+    });
+
+    it('is idempotent on an open email: merges context, no duplicate, no second event', async () => {
+      const first = await service.createAccessRequest({
+        email: 'dup@example.com',
+        context: { a: 1 },
+      });
+      const second = await service.createAccessRequest({
+        email: 'DUP@example.com',
+        name: 'Filled Later',
+        context: { b: 2 },
+      });
+
+      expect(second.id).toBe(first.id);
+      expect(second.name).toBe('Filled Later');
+      expect(second.getRequestContext()).toEqual({ a: 1, b: 2 });
+
+      const all = await service.collection.findByEmail('dup@example.com');
+      expect(all).toHaveLength(1);
+      // Only the first creation emits `created`.
+      expect(eventTypes()).toEqual(['access-request.created']);
+    });
+
+    it('does not dedup against a non-open (decided) request', async () => {
+      const first = await service.createAccessRequest({
+        email: 'reopen@example.com',
+      });
+      await service.declineAccessRequest(first.id as string);
+
+      const second = await service.createAccessRequest({
+        email: 'reopen@example.com',
+      });
+
+      expect(second.id).not.toBe(first.id);
+      expect(second.status).toBe(AccessRequestStatus.REQUESTED);
+      const all = await service.collection.findByEmail('reopen@example.com');
+      expect(all).toHaveLength(2);
+    });
+  });
+
+  describe('state machine', () => {
+    it('approves REQUESTED → APPROVED and records the operator', async () => {
+      const request = await service.createAccessRequest({
+        email: 'approve@example.com',
+      });
+      const approved = await service.approveAccessRequest(
+        request.id as string,
+        {
+          by: 'operator-1',
+          note: 'looks legit',
+        },
+      );
+
+      expect(approved.status).toBe(AccessRequestStatus.APPROVED);
+      expect(approved.decidedBy).toBe('operator-1');
+      expect(approved.note).toBe('looks legit');
+      expect(approved.decidedAt).toBeInstanceOf(Date);
+      expect(eventTypes()).toContain('access-request.approved');
+    });
+
+    it('approve is idempotent', async () => {
+      const request = await service.createAccessRequest({
+        email: 'idem-approve@example.com',
+      });
+      await service.approveAccessRequest(request.id as string);
+      const again = await service.approveAccessRequest(request.id as string);
+      expect(again.status).toBe(AccessRequestStatus.APPROVED);
+      // Only one approved event (the second call is a no-op).
+      expect(
+        eventTypes().filter((t) => t === 'access-request.approved'),
+      ).toHaveLength(1);
+    });
+
+    it('declines from REQUESTED and from APPROVED', async () => {
+      const a = await service.createAccessRequest({ email: 'd1@example.com' });
+      const declinedFromRequested = await service.declineAccessRequest(
+        a.id as string,
+        { by: 'op', reason: 'spam' },
+      );
+      expect(declinedFromRequested.status).toBe(AccessRequestStatus.DECLINED);
+      expect(declinedFromRequested.note).toBe('spam');
+
+      const b = await service.createAccessRequest({ email: 'd2@example.com' });
+      await service.approveAccessRequest(b.id as string);
+      const declinedFromApproved = await service.declineAccessRequest(
+        b.id as string,
+      );
+      expect(declinedFromApproved.status).toBe(AccessRequestStatus.DECLINED);
+    });
+
+    it('cancels from REQUESTED', async () => {
+      const request = await service.createAccessRequest({
+        email: 'cancel@example.com',
+      });
+      const canceled = await service.cancelAccessRequest(request.id as string, {
+        reason: 'changed mind',
+      });
+      expect(canceled.status).toBe(AccessRequestStatus.CANCELED);
+      expect(canceled.note).toBe('changed mind');
+      expect(eventTypes()).toContain('access-request.canceled');
+    });
+
+    it('throws on invalid transitions from a terminal state', async () => {
+      const request = await service.createAccessRequest({
+        email: 'terminal@example.com',
+      });
+      await service.declineAccessRequest(request.id as string);
+
+      await expect(
+        service.approveAccessRequest(request.id as string),
+      ).rejects.toMatchObject({ code: 'INVALID_TRANSITION' });
+      await expect(
+        service.cancelAccessRequest(request.id as string),
+      ).rejects.toMatchObject({ code: 'INVALID_TRANSITION' });
+    });
+
+    it('throws NOT_FOUND for an unknown id', async () => {
+      await expect(
+        service.approveAccessRequest('does-not-exist'),
+      ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    });
+  });
+
+  describe('operator reads', () => {
+    it('lists with status, email, and source filters', async () => {
+      const r1 = await service.createAccessRequest({
+        email: 'list1@example.com',
+        source: 'www',
+      });
+      await service.createAccessRequest({
+        email: 'list2@example.com',
+        source: 'sdk',
+      });
+      await service.approveAccessRequest(r1.id as string);
+
+      const requested = await service.listAccessRequests({
+        status: AccessRequestStatus.REQUESTED,
+      });
+      expect(requested.map((r) => r.email)).toEqual(['list2@example.com']);
+
+      const bySource = await service.listAccessRequests({ source: 'www' });
+      expect(bySource.map((r) => r.email)).toEqual(['list1@example.com']);
+
+      const byEmail = await service.listAccessRequests({
+        email: 'LIST2@example.com',
+      });
+      expect(byEmail).toHaveLength(1);
+
+      const multi = await service.listAccessRequests({
+        status: [AccessRequestStatus.REQUESTED, AccessRequestStatus.APPROVED],
+      });
+      expect(multi).toHaveLength(2);
+    });
+
+    it('gets a request by id', async () => {
+      const created = await service.createAccessRequest({
+        email: 'get@example.com',
+      });
+      const fetched = await service.getAccessRequest(created.id as string);
+      expect(fetched?.id).toBe(created.id);
+      expect(await service.getAccessRequest('nope')).toBeNull();
+    });
+  });
+
+  describe('capability gating', () => {
+    it('gates operator methods but leaves create public-safe', async () => {
+      const calls: AccessRequestAuthorizationContext[] = [];
+      let deny = false;
+      const gated = await AccessRequestService.create({
+        db,
+        authorize: (ctx) => {
+          calls.push(ctx);
+          if (deny) throw new Error('forbidden');
+        },
+      });
+
+      // create() never calls the authorizer.
+      const request = await gated.createAccessRequest({
+        email: 'gate@example.com',
+      });
+      expect(calls).toHaveLength(0);
+
+      // read → access-requests:read
+      await gated.listAccessRequests({ by: 'op' });
+      expect(calls.at(-1)).toMatchObject({
+        capability: ACCESS_REQUEST_CAPABILITIES.READ,
+        by: 'op',
+      });
+
+      // manage → access-requests:manage
+      await gated.approveAccessRequest(request.id as string, { by: 'op' });
+      expect(calls.at(-1)).toMatchObject({
+        capability: ACCESS_REQUEST_CAPABILITIES.MANAGE,
+        by: 'op',
+        accessRequestId: request.id,
+      });
+
+      // a throwing authorizer denies operator methods…
+      deny = true;
+      await expect(
+        gated.declineAccessRequest(request.id as string),
+      ).rejects.toThrow('forbidden');
+      // …but create remains callable.
+      await expect(
+        gated.createAccessRequest({ email: 'still-open@example.com' }),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('events are best-effort', () => {
+    it('swallows a throwing event handler so the transition still persists', async () => {
+      const svc = await AccessRequestService.create({
+        db,
+        onEvent: () => {
+          throw new Error('handler boom');
+        },
+      });
+      const request = await svc.createAccessRequest({
+        email: 'besteffort@example.com',
+      });
+      expect(request.status).toBe(AccessRequestStatus.REQUESTED);
+      // The record is persisted despite the handler throwing.
+      const fetched = await svc.getAccessRequest(request.id as string);
+      expect(fetched).not.toBeNull();
+    });
+  });
+
+  describe('graduation', () => {
+    it('new-tenant path: creates user + tenant + owner membership', async () => {
+      const request = await service.createAccessRequest({
+        email: 'newtenant@example.com',
+        name: 'New Tenant Owner',
+      });
+      await service.approveAccessRequest(request.id as string, { by: 'op' });
+
+      const result = await service.graduateAccessRequest(request.id as string, {
+        by: 'op',
+        tenant: { create: { name: 'Acme Inc' } },
+      });
+
+      expect(result.created).toBe(true);
+      expect(result.user.email).toBe('newtenant@example.com');
+      expect(result.user.status).toBe(UserStatus.ACTIVE);
+      expect(result.tenant?.name).toBe('Acme Inc');
+      expect(result.membership).toBeDefined();
+
+      const ownerRole = await roles.findBySlug(DEFAULT_ROLE_SLUGS.OWNER);
+      expect(result.membership?.roleId).toBe(ownerRole?.id);
+      expect(result.membership?.status).toBe(MembershipStatus.ACTIVE);
+
+      expect(result.accessRequest.status).toBe(AccessRequestStatus.GRADUATED);
+      expect(result.accessRequest.resultingUserId).toBe(result.user.id);
+      expect(eventTypes()).toContain('access-request.graduated');
+
+      // No duplicate user.
+      const allUsers = await users.findByEmail('newtenant@example.com');
+      expect(allUsers).not.toBeNull();
+    });
+
+    it('existing-tenant path: enrolls the user with the requested role', async () => {
+      const tenant = await tenants.create({ name: 'Existing Org' });
+      await tenant.save();
+
+      const request = await service.createAccessRequest({
+        email: 'existing@example.com',
+      });
+      await service.approveAccessRequest(request.id as string);
+
+      const result = await service.graduateAccessRequest(request.id as string, {
+        tenant: {
+          tenantId: tenant.id as string,
+          role: DEFAULT_ROLE_SLUGS.ADMIN,
+        },
+      });
+
+      expect(result.tenant?.id).toBe(tenant.id);
+      const adminRole = await roles.findBySlug(DEFAULT_ROLE_SLUGS.ADMIN);
+      expect(result.membership?.roleId).toBe(adminRole?.id);
+      expect(result.membership?.tenantId).toBe(tenant.id);
+    });
+
+    it('existing-tenant path defaults to the member role', async () => {
+      const tenant = await tenants.create({ name: 'Default Role Org' });
+      await tenant.save();
+
+      const request = await service.createAccessRequest({
+        email: 'defaultrole@example.com',
+      });
+      await service.approveAccessRequest(request.id as string);
+      const result = await service.graduateAccessRequest(request.id as string, {
+        tenant: { tenantId: tenant.id as string },
+      });
+
+      const memberRole = await roles.findBySlug(DEFAULT_ROLE_SLUGS.MEMBER);
+      expect(result.membership?.roleId).toBe(memberRole?.id);
+    });
+
+    it('no-tenant path: user only, no membership', async () => {
+      const request = await service.createAccessRequest({
+        email: 'notenant@example.com',
+      });
+      await service.approveAccessRequest(request.id as string);
+
+      const result = await service.graduateAccessRequest(request.id as string, {
+        tenant: 'none',
+      });
+
+      expect(result.user.email).toBe('notenant@example.com');
+      expect(result.membership).toBeUndefined();
+      expect(result.tenant).toBeUndefined();
+
+      const userMemberships = await memberships.findByUser(
+        result.user.id as string,
+      );
+      expect(userMemberships).toHaveLength(0);
+    });
+
+    it('defaults to the no-tenant path when no tenant option is given', async () => {
+      const request = await service.createAccessRequest({
+        email: 'implicitnone@example.com',
+      });
+      await service.approveAccessRequest(request.id as string);
+      const result = await service.graduateAccessRequest(request.id as string);
+      expect(result.membership).toBeUndefined();
+      expect(result.tenant).toBeUndefined();
+    });
+
+    it('is idempotent: a second graduate returns the same user without duplicating', async () => {
+      const request = await service.createAccessRequest({
+        email: 'idem-grad@example.com',
+      });
+      await service.approveAccessRequest(request.id as string);
+
+      const first = await service.graduateAccessRequest(request.id as string, {
+        tenant: 'none',
+      });
+      const second = await service.graduateAccessRequest(request.id as string, {
+        tenant: 'none',
+      });
+
+      expect(second.user.id).toBe(first.user.id);
+      expect(second.created).toBe(false);
+      // Only one graduated event (the second call short-circuits).
+      expect(
+        eventTypes().filter((t) => t === 'access-request.graduated'),
+      ).toHaveLength(1);
+    });
+
+    it('idempotent re-graduation returns the existing membership for an existing tenant', async () => {
+      const tenant = await tenants.create({ name: 'Idem Tenant' });
+      await tenant.save();
+      const request = await service.createAccessRequest({
+        email: 'idem-tenant@example.com',
+      });
+      await service.approveAccessRequest(request.id as string);
+
+      const first = await service.graduateAccessRequest(request.id as string, {
+        tenant: { tenantId: tenant.id as string },
+      });
+      const second = await service.graduateAccessRequest(request.id as string, {
+        tenant: { tenantId: tenant.id as string },
+      });
+
+      expect(second.membership?.id).toBe(first.membership?.id);
+      const all = await memberships.findByUserAndTenant(
+        first.user.id as string,
+        tenant.id as string,
+      );
+      expect(all).not.toBeNull();
+    });
+
+    it('links an existing user by email instead of creating a duplicate', async () => {
+      const existing = await users.create({
+        email: 'preexisting@example.com',
+        status: UserStatus.PENDING,
+      });
+
+      const request = await service.createAccessRequest({
+        email: 'preexisting@example.com',
+      });
+      await service.approveAccessRequest(request.id as string);
+
+      const result = await service.graduateAccessRequest(request.id as string, {
+        tenant: 'none',
+        activate: UserStatus.ACTIVE,
+      });
+
+      expect(result.created).toBe(false);
+      expect(result.user.id).toBe(existing.id);
+      expect(result.user.status).toBe(UserStatus.ACTIVE);
+    });
+
+    it('does not silently change an existing linked user status without explicit activate', async () => {
+      const existing = await users.create({
+        email: 'suspended@example.com',
+        status: UserStatus.SUSPENDED,
+      });
+
+      const request = await service.createAccessRequest({
+        email: 'suspended@example.com',
+      });
+      await service.approveAccessRequest(request.id as string);
+
+      // No `activate` passed → the existing suspended account is left untouched.
+      const result = await service.graduateAccessRequest(request.id as string, {
+        tenant: 'none',
+      });
+
+      expect(result.created).toBe(false);
+      expect(result.user.id).toBe(existing.id);
+      expect(result.user.status).toBe(UserStatus.SUSPENDED);
+    });
+
+    it('requires approval before graduation unless allowFromRequested is set', async () => {
+      const request = await service.createAccessRequest({
+        email: 'fromrequested@example.com',
+      });
+
+      await expect(
+        service.graduateAccessRequest(request.id as string, { tenant: 'none' }),
+      ).rejects.toMatchObject({ code: 'INVALID_TRANSITION' });
+
+      const result = await service.graduateAccessRequest(request.id as string, {
+        tenant: 'none',
+        allowFromRequested: true,
+      });
+      expect(result.user.email).toBe('fromrequested@example.com');
+      expect(result.accessRequest.status).toBe(AccessRequestStatus.GRADUATED);
+    });
+
+    it('throws when graduating a declined request', async () => {
+      const request = await service.createAccessRequest({
+        email: 'declined-grad@example.com',
+      });
+      await service.declineAccessRequest(request.id as string);
+      await expect(
+        service.graduateAccessRequest(request.id as string, {
+          tenant: 'none',
+          allowFromRequested: true,
+        }),
+      ).rejects.toMatchObject({ code: 'INVALID_TRANSITION' });
+    });
+
+    it('throws TENANT_NOT_FOUND for an unknown existing tenant', async () => {
+      const request = await service.createAccessRequest({
+        email: 'badtenant@example.com',
+      });
+      await service.approveAccessRequest(request.id as string);
+      await expect(
+        service.graduateAccessRequest(request.id as string, {
+          tenant: { tenantId: 'no-such-tenant' },
+        }),
+      ).rejects.toMatchObject({ code: 'TENANT_NOT_FOUND' });
+    });
+
+    it('exposes AccessRequestError for instanceof checks', async () => {
+      const error = await service
+        .approveAccessRequest('missing')
+        .catch((e) => e);
+      expect(error).toBeInstanceOf(AccessRequestError);
+    });
+  });
+});

--- a/packages/users/src/__tests__/access-request.test.ts
+++ b/packages/users/src/__tests__/access-request.test.ts
@@ -128,6 +128,28 @@ describe('AccessRequest', () => {
       expect(eventTypes()).toEqual(['access-request.created']);
     });
 
+    it('keeps separate rows for different emails that share a display name', async () => {
+      // Regression: slug derives from `name`, so without an id-based conflict key
+      // two "Jane Doe" submissions would upsert over each other.
+      const a = await service.createAccessRequest({
+        email: 'jane1@example.com',
+        name: 'Jane Doe',
+      });
+      const b = await service.createAccessRequest({
+        email: 'jane2@example.com',
+        name: 'Jane Doe',
+      });
+
+      expect(b.id).not.toBe(a.id);
+      const all = await service.listAccessRequests({});
+      const janes = all.filter((r) => r.name === 'Jane Doe');
+      expect(janes).toHaveLength(2);
+      expect(janes.map((r) => r.email).sort()).toEqual([
+        'jane1@example.com',
+        'jane2@example.com',
+      ]);
+    });
+
     it('does not dedup against a non-open (decided) request', async () => {
       const first = await service.createAccessRequest({
         email: 'reopen@example.com',

--- a/packages/users/src/collections/AccessRequestCollection.ts
+++ b/packages/users/src/collections/AccessRequestCollection.ts
@@ -1,0 +1,66 @@
+/**
+ * AccessRequestCollection — query helpers for {@link AccessRequest} records.
+ *
+ * This is the low-level data accessor. Lifecycle orchestration (the public-safe
+ * create path, the state machine, capability gating, events, and graduation
+ * into a `User`) lives in {@link AccessRequestService} — prefer the service for
+ * application code.
+ *
+ * @packageDocumentation
+ */
+
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { AccessRequest } from '../models/AccessRequest.js';
+import { normalizeEmail } from '../models/User.js';
+import { AccessRequestStatus } from '../types/index.js';
+
+/**
+ * Collection for managing {@link AccessRequest} objects.
+ */
+export class AccessRequestCollection extends SmrtCollection<AccessRequest> {
+  static readonly _itemClass = AccessRequest;
+
+  /**
+   * Find all access requests for an email (any status), newest first. The email
+   * is normalized before querying so callers can pass any case.
+   */
+  async findByEmail(email: string): Promise<AccessRequest[]> {
+    return await this.list({
+      where: { email: normalizeEmail(email) },
+      orderBy: 'created_at DESC',
+    });
+  }
+
+  /**
+   * Find the single open (`REQUESTED`) request for an email, if any. This is
+   * the dedup key used by {@link AccessRequestService.createAccessRequest}.
+   */
+  async findOpenByEmail(email: string): Promise<AccessRequest | null> {
+    const results = await this.list({
+      where: {
+        email: normalizeEmail(email),
+        status: AccessRequestStatus.REQUESTED,
+      },
+      limit: 1,
+      orderBy: 'created_at DESC',
+    });
+    return results.length > 0 ? results[0] : null;
+  }
+
+  /**
+   * Find access requests by status, newest first.
+   */
+  async findByStatus(status: AccessRequestStatus): Promise<AccessRequest[]> {
+    return await this.list({
+      where: { status },
+      orderBy: 'created_at DESC',
+    });
+  }
+
+  /**
+   * Find all open (`REQUESTED`) access requests — the operator triage queue.
+   */
+  async findOpen(): Promise<AccessRequest[]> {
+    return await this.findByStatus(AccessRequestStatus.REQUESTED);
+  }
+}

--- a/packages/users/src/collections/index.ts
+++ b/packages/users/src/collections/index.ts
@@ -3,6 +3,8 @@
  * @packageDocumentation
  */
 
+// Access requests (request access / waitlist)
+export { AccessRequestCollection } from './AccessRequestCollection.js';
 // CLI / terminal auth
 export {
   CliAuthRequestCollection,

--- a/packages/users/src/index.ts
+++ b/packages/users/src/index.ts
@@ -61,6 +61,7 @@ import './__smrt-register__.js';
 
 // Collections
 export {
+  AccessRequestCollection,
   CliAuthRequestCollection,
   type CreateChildTenantOptions,
   type CreateSessionOptions,
@@ -87,6 +88,8 @@ export {
 } from './collections/index.js';
 // Models
 export {
+  AccessRequest,
+  type AccessRequestOptions,
   CliAuthRequest,
   type CliAuthRequestStatus,
   DEFAULT_SESSION_TTL,
@@ -112,22 +115,43 @@ export {
 
 // Services
 export {
+  ACCESS_REQUEST_CAPABILITIES,
+  type AccessRequestAuthorizationContext,
+  type AccessRequestAuthorizer,
+  type AccessRequestCapability,
+  AccessRequestError,
+  type AccessRequestErrorCode,
+  type AccessRequestEvent,
+  type AccessRequestEventHandler,
+  type AccessRequestEventType,
+  AccessRequestService,
+  type AccessRequestServiceOptions,
+  type ApproveAccessRequestOptions,
   type ApproveCliAuthRequestInput,
   applyPostgresPermissionPolicies,
+  type CancelAccessRequestOptions,
   type CliAuthStartResult,
   type CliAuthTokenResult,
+  type CreateAccessRequestInput,
   type CreateAuthorizationUrlOptions,
   DEFAULT_CLI_AUTH_POLL_INTERVAL_SECONDS,
   DEFAULT_CLI_AUTH_REQUEST_TTL_SECONDS,
   DEFAULT_CLI_SESSION_TTL_SECONDS,
+  type DeclineAccessRequestOptions,
   decodeOidcTransaction,
   type EnsureTenantResult,
   encodeOidcTransaction,
   type GeneratePostgresPermissionSqlResult,
+  type GraduateAccessRequestOptions,
+  type GraduateAccessRequestResult,
+  type GraduateExistingTenantOption,
+  type GraduateNewTenantOption,
+  type GraduateTenantOption,
   generatePostgresPermissionSql,
   getCurrentSessionPermissionContext,
   getRequestScopedDatabase,
   getUsersOidcConfig,
+  type ListAccessRequestsFilter,
   MagicLinkError,
   type MagicLinkResult,
   MagicLinkService,
@@ -182,6 +206,7 @@ export {
 
 // Types
 export {
+  AccessRequestStatus,
   DEFAULT_ROLE_SLUGS,
   DEFAULT_ROLES,
   DEFAULT_TENANT_POLICY,

--- a/packages/users/src/models/AccessRequest.ts
+++ b/packages/users/src/models/AccessRequest.ts
@@ -1,0 +1,241 @@
+/**
+ * AccessRequest model — the "request access / join the waitlist" identity
+ * primitive.
+ *
+ * Captures a prospective user from a public form *before* they are a real
+ * {@link User}: an operator triages the record, then either declines it or
+ * approves and **graduates** it into a `User` (optionally attached to a
+ * tenant). This keeps the `User` table clean — unverified/spam signups live as
+ * requests, not users — while still giving operators a triage queue.
+ *
+ * The generated REST/MCP/CLI surface is intentionally CLOSED (`include: []`):
+ * every read and mutation must go through {@link AccessRequestService} so the
+ * public-safe creation path (email normalization + dedup), the lifecycle state
+ * machine, capability gating, and event emission can never be bypassed by a
+ * generated CRUD route. Creation is meant to be exposed *unauthenticated* by
+ * consuming apps via their own rate-limited endpoint calling
+ * `createAccessRequest`. The model is still registered (and its table created
+ * via the consumer's normal migrate flow) regardless of the empty generation
+ * config.
+ *
+ * @packageDocumentation
+ */
+
+import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { AccessRequestStatus } from '../types/index.js';
+import { normalizeEmail } from './User.js';
+
+/**
+ * Options accepted by the {@link AccessRequest} constructor / collection
+ * `create`. `requestContext` and `tenantHint` are stored as JSON *strings* —
+ * use {@link AccessRequest.setRequestContext} / {@link AccessRequest.setTenantHint}
+ * (or pass pre-serialized strings) rather than raw objects.
+ */
+export interface AccessRequestOptions {
+  email?: string;
+  name?: string | null;
+  status?: AccessRequestStatus;
+  source?: string;
+  requestContext?: string;
+  note?: string | null;
+  requestedAt?: Date;
+  decidedAt?: Date | null;
+  decidedBy?: string | null;
+  resultingUserId?: string | null;
+  tenantHint?: string | null;
+  [key: string]: unknown;
+}
+
+/**
+ * A prospective user's request for access, captured before they become a
+ * {@link User}.
+ *
+ * @example
+ * ```typescript
+ * // Public, unauthenticated path (app adds rate-limiting):
+ * const request = await service.createAccessRequest({
+ *   email: 'Jane@Example.com',
+ *   name: 'Jane Doe',
+ *   source: 'www',
+ *   context: { company: 'Acme', intendedUse: 'evaluation' },
+ * });
+ * // request.email === 'jane@example.com', request.status === 'requested'
+ * ```
+ */
+@smrt({
+  tableName: 'access_requests',
+  // CLOSED generated surface — all access flows through AccessRequestService.
+  api: { include: [] },
+  mcp: { include: [] },
+  cli: { include: [] },
+})
+export class AccessRequest extends SmrtObject {
+  /**
+   * Requester's email address. Required, normalized to lowercase, and indexed
+   * for lookup + open-request dedup. NOT unique: the same email may accumulate
+   * multiple requests over time (e.g. an old GRADUATED record plus a new
+   * REQUESTED one); dedup is enforced on *open* requests by the service.
+   */
+  @field({ required: true, indexed: true })
+  email: string = '';
+
+  /**
+   * Requester's display name, if supplied on the form.
+   */
+  @field({ nullable: true })
+  name: string | null = null;
+
+  /**
+   * Lifecycle status. Indexed so the operator triage queue can filter by status
+   * efficiently.
+   */
+  @field({ type: 'text', indexed: true })
+  status: AccessRequestStatus = AccessRequestStatus.REQUESTED;
+
+  /**
+   * Where the request came from, e.g. `www`, `sdk`. Indexed for per-source
+   * filtering in the operator queue.
+   */
+  @field({ indexed: true })
+  source: string = '';
+
+  /**
+   * Free-form JSON metadata captured with the request (intended use, company,
+   * message, referrer, etc.), stored as a JSON string.
+   *
+   * NOT named `context`: {@link SmrtObject} reserves the `context` field for
+   * slug scoping, so this mirrors smrt-chat's `sessionContext` convention. Use
+   * {@link getRequestContext} / {@link setRequestContext} for typed access.
+   */
+  @field()
+  requestContext: string = '{}';
+
+  /**
+   * Operator note / decision reason (set on approve / decline / cancel).
+   */
+  @field({ nullable: true })
+  note: string | null = null;
+
+  /**
+   * When the request was submitted. Defaults to creation time.
+   */
+  @field()
+  requestedAt: Date = new Date();
+
+  /**
+   * When an operator decided the request (approve / decline / cancel /
+   * graduate). Null while still `REQUESTED`.
+   */
+  @field({ nullable: true })
+  decidedAt: Date | null = null;
+
+  /**
+   * User id of the operator who decided the request. Null while still pending.
+   */
+  @field({ nullable: true })
+  decidedBy: string | null = null;
+
+  /**
+   * Id of the `User` produced (or linked) when the request graduated. Null
+   * until graduation.
+   */
+  @field({ nullable: true })
+  resultingUserId: string | null = null;
+
+  /**
+   * Optional JSON hint about the org/tenant the requester wants, stored as a
+   * JSON string (null when absent). Advisory only — the operator decides the
+   * actual tenant at graduation time. Use {@link getTenantHint} /
+   * {@link setTenantHint} for typed access.
+   */
+  @field({ nullable: true })
+  tenantHint: string | null = null;
+
+  constructor(options: AccessRequestOptions = {}) {
+    super(options);
+    if (options.email !== undefined) this.email = normalizeEmail(options.email);
+    if (options.name !== undefined) this.name = options.name;
+    if (options.status !== undefined) this.status = options.status;
+    if (options.source !== undefined) this.source = options.source;
+    if (options.requestContext !== undefined)
+      this.requestContext = options.requestContext;
+    if (options.note !== undefined) this.note = options.note;
+    if (options.requestedAt !== undefined)
+      this.requestedAt = options.requestedAt;
+    if (options.decidedAt !== undefined) this.decidedAt = options.decidedAt;
+    if (options.decidedBy !== undefined) this.decidedBy = options.decidedBy;
+    if (options.resultingUserId !== undefined)
+      this.resultingUserId = options.resultingUserId;
+    if (options.tenantHint !== undefined) this.tenantHint = options.tenantHint;
+  }
+
+  /**
+   * Parse {@link requestContext} into an object. Returns `{}` on missing or
+   * malformed JSON (graceful — never throws).
+   */
+  getRequestContext(): Record<string, unknown> {
+    try {
+      const parsed = JSON.parse(this.requestContext);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+
+  /**
+   * Serialize and store {@link requestContext} from an object.
+   */
+  setRequestContext(value: Record<string, unknown>): void {
+    this.requestContext = JSON.stringify(value ?? {});
+  }
+
+  /**
+   * Parse {@link tenantHint} into an object, or `null` when unset / malformed.
+   */
+  getTenantHint(): Record<string, unknown> | null {
+    if (!this.tenantHint) return null;
+    try {
+      const parsed = JSON.parse(this.tenantHint);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Serialize and store {@link tenantHint} from an object (or clear with null).
+   */
+  setTenantHint(value: Record<string, unknown> | null): void {
+    this.tenantHint = value ? JSON.stringify(value) : null;
+  }
+
+  /**
+   * Whether the request is still open (awaiting a decision).
+   */
+  isOpen(): boolean {
+    return this.status === AccessRequestStatus.REQUESTED;
+  }
+
+  /**
+   * Whether the request has been approved (and not yet graduated).
+   */
+  isApproved(): boolean {
+    return this.status === AccessRequestStatus.APPROVED;
+  }
+
+  /**
+   * Whether the request reached a terminal state (declined, graduated, or
+   * canceled) and can no longer transition.
+   */
+  isTerminal(): boolean {
+    return (
+      this.status === AccessRequestStatus.DECLINED ||
+      this.status === AccessRequestStatus.GRADUATED ||
+      this.status === AccessRequestStatus.CANCELED
+    );
+  }
+}

--- a/packages/users/src/models/AccessRequest.ts
+++ b/packages/users/src/models/AccessRequest.ts
@@ -64,6 +64,13 @@ export interface AccessRequestOptions {
  */
 @smrt({
   tableName: 'access_requests',
+  // Append-style: the natural key is the surrogate id, so a new request never
+  // upserts over an existing row. Without this, SMRT defaults to upserting on
+  // `slug`/`context`, and `slug` is derived from `name` — two public submissions
+  // sharing a display name (e.g. two "Jane Doe"s with different emails) would
+  // collide and overwrite each other. Open-request dedup is handled explicitly
+  // by AccessRequestService.createAccessRequest, not by the storage conflict key.
+  conflictColumns: ['id'],
   // CLOSED generated surface — all access flows through AccessRequestService.
   api: { include: [] },
   mcp: { include: [] },

--- a/packages/users/src/models/index.ts
+++ b/packages/users/src/models/index.ts
@@ -3,6 +3,8 @@
  * @packageDocumentation
  */
 
+// Access requests (request access / waitlist)
+export { AccessRequest, type AccessRequestOptions } from './AccessRequest.js';
 // CLI / terminal auth (device code grant)
 export {
   CliAuthRequest,

--- a/packages/users/src/services/AccessRequestService.ts
+++ b/packages/users/src/services/AccessRequestService.ts
@@ -366,18 +366,14 @@ export class AccessRequestService {
    * Initialize the backing collections (creates/verifies their tables).
    */
   async initialize(): Promise<void> {
-    // SmrtClassOptions carries `authorize`/`onEvent` too; the collections ignore
-    // unknown keys, so passing the whole options bag is harmless and keeps the
-    // db/ai config in one place.
-    this.#requests = await (AccessRequestCollection as any).create(
-      this.#options,
-    );
-    this.#users = await (UserCollection as any).create(this.#options);
-    this.#tenants = await (TenantCollection as any).create(this.#options);
-    this.#memberships = await (MembershipCollection as any).create(
-      this.#options,
-    );
-    this.#roles = await (RoleCollection as any).create(this.#options);
+    // SmrtClassOptions carries `authorize`/`onEvent` too; the collection factory
+    // only reads the db/ai keys and ignores the rest, so passing the whole
+    // options bag is harmless and keeps the db config in one place.
+    this.#requests = await AccessRequestCollection.create(this.#options);
+    this.#users = await UserCollection.create(this.#options);
+    this.#tenants = await TenantCollection.create(this.#options);
+    this.#memberships = await MembershipCollection.create(this.#options);
+    this.#roles = await RoleCollection.create(this.#options);
   }
 
   /**

--- a/packages/users/src/services/AccessRequestService.ts
+++ b/packages/users/src/services/AccessRequestService.ts
@@ -407,6 +407,18 @@ export class AccessRequestService {
    * supplied context/name/source/hint into it and returns it instead of
    * creating a duplicate (no second `created` event).
    *
+   * @remarks
+   * De-duplication is **best-effort, not atomic**: it is a read-then-write
+   * (`findOpenByEmail` → `create`) with no DB-level partial-unique constraint
+   * (the table is append-style, keyed on `id`, because the same email may
+   * accumulate many requests over its lifetime). Two requests for the same
+   * email racing concurrently can therefore both create an open row. This is by
+   * design — the spec makes dedup configurable and pushes abuse control to the
+   * app (rate-limiting on the public endpoint). Operators triaging two open rows
+   * for one email is benign; apps needing a hard single-open-request guarantee
+   * should add a partial unique index (`UNIQUE(email) WHERE status='requested'`)
+   * in their migration.
+   *
    * @throws {@link AccessRequestError} (`INVALID_EMAIL`) when the email is invalid.
    */
   async createAccessRequest(
@@ -687,6 +699,14 @@ export class AccessRequestService {
       }
     }
 
+    // Validate the tenant option BEFORE any write (user / tenant / membership):
+    // an invalid role slug or missing tenant must fail fast so graduation never
+    // leaves an orphan user or tenant behind (codex review #1713).
+    if (tenantOption !== 'none') {
+      await this.#ensureRolesSeeded();
+      await this.#validateTenantOption(tenantOption);
+    }
+
     // Create-or-link the user by normalized email. A brand-new user defaults to
     // ACTIVE (or `options.activate`). An existing linked user keeps its current
     // status unless the operator *explicitly* passes `activate` — so graduation
@@ -800,6 +820,46 @@ export class AccessRequestService {
         `AccessRequest event handler threw for "${event.type}" (request ${event.accessRequest.id})`,
         { error },
       );
+    }
+  }
+
+  /**
+   * Throw `ROLE_NOT_FOUND` if no role with `roleSlug` is resolvable (tenant-
+   * specific first, then system). Roles must already be seeded.
+   */
+  async #assertRoleExists(roleSlug: string, tenantId?: string): Promise<void> {
+    if (!(await this.#roles.findBySlug(roleSlug, tenantId))) {
+      throw new AccessRequestError(
+        `Role "${roleSlug}" not found — seed system roles or pass a valid role slug.`,
+        'ROLE_NOT_FOUND',
+      );
+    }
+  }
+
+  /**
+   * Validate a graduation tenant option with NO side effects: the target tenant
+   * must exist (existing-tenant variant) and the role slug must resolve. Run
+   * before any persistence so a bad option can't leave orphan rows.
+   */
+  async #validateTenantOption(
+    option: GraduateNewTenantOption | GraduateExistingTenantOption,
+  ): Promise<void> {
+    if ('tenantId' in option) {
+      const tenant = await this.#tenants.get(option.tenantId);
+      if (!tenant) {
+        throw new AccessRequestError(
+          `Target tenant "${option.tenantId}" not found.`,
+          'TENANT_NOT_FOUND',
+        );
+      }
+      await this.#assertRoleExists(
+        option.role ?? DEFAULT_ROLE_SLUGS.MEMBER,
+        option.tenantId,
+      );
+    } else {
+      // A brand-new tenant has no tenant-specific roles yet, so the role must
+      // resolve as a system role.
+      await this.#assertRoleExists(option.role ?? DEFAULT_ROLE_SLUGS.OWNER);
     }
   }
 

--- a/packages/users/src/services/AccessRequestService.ts
+++ b/packages/users/src/services/AccessRequestService.ts
@@ -1,0 +1,907 @@
+/**
+ * AccessRequestService — the mechanism behind the "request access / waitlist"
+ * identity primitive, plus graduation of an approved request into a `User`.
+ *
+ * ## Responsibilities
+ *
+ * - **Public-safe creation** ({@link AccessRequestService.createAccessRequest}):
+ *   validates + normalizes the email and de-duplicates against any open request
+ *   for the same email. Intended to be called *unauthenticated* by consuming
+ *   apps from their own rate-limited endpoint (the app owns rate-limiting).
+ * - **Operator triage** (`list` / `get` / `approve` / `decline` / `cancel`):
+ *   gated behind capabilities (see {@link AccessRequestAuthorizer}).
+ * - **Graduation** ({@link AccessRequestService.graduateAccessRequest}): creates
+ *   or links a `User` from the request — reusing the existing user / membership
+ *   / tenant collections rather than duplicating them — and (optionally)
+ *   attaches the user to a brand-new tenant (requester as owner), an existing
+ *   tenant, or no tenant at all. Idempotent.
+ * - **Events** ({@link AccessRequestEventHandler}): emits
+ *   `access-request.created | approved | declined | canceled | graduated` so
+ *   apps can react (send a magic-link/invite on `graduated`, notify ops on
+ *   `created`, …). This service deliberately does **not** own email/notification
+ *   delivery — bridge the event hook to your delivery channel (a function, an
+ *   `EventEmitter`, the core `DispatchBus`, …).
+ *
+ * @remarks
+ * **Security.** Operator methods are gated only when an {@link AccessRequestAuthorizer}
+ * is supplied via {@link AccessRequestServiceOptions.authorize}; without one
+ * they are ungated, exactly like {@link TerminalAuthService.approveRequest}
+ * trusts its caller to authenticate first. Production apps that expose these
+ * methods MUST either provide an `authorize` hook or perform their own
+ * capability checks at the route layer. `createAccessRequest` is *always*
+ * ungated by design (public-safe). The model's generated REST/MCP/CLI surface
+ * is closed, so there is no unauthenticated network route by default.
+ *
+ * @packageDocumentation
+ */
+
+import { createLogger } from '@happyvertical/logger';
+import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import { AccessRequestCollection } from '../collections/AccessRequestCollection.js';
+import { MembershipCollection } from '../collections/MembershipCollection.js';
+import { RoleCollection } from '../collections/RoleCollection.js';
+import { TenantCollection } from '../collections/TenantCollection.js';
+import { UserCollection } from '../collections/UserCollection.js';
+import type { AccessRequest } from '../models/AccessRequest.js';
+import type { Membership } from '../models/Membership.js';
+import type { Tenant } from '../models/Tenant.js';
+import type { User } from '../models/User.js';
+import { isValidEmail, normalizeEmail } from '../models/User.js';
+import {
+  AccessRequestStatus,
+  DEFAULT_ROLE_SLUGS,
+  MembershipStatus,
+  type TenantStatus,
+  UserStatus,
+} from '../types/index.js';
+
+const logger = createLogger({ level: 'info' });
+
+/**
+ * Capabilities that gate the operator-facing methods of
+ * {@link AccessRequestService}.
+ */
+export const ACCESS_REQUEST_CAPABILITIES = {
+  /** Read the access-request queue (`list` / `get`). */
+  READ: 'access-requests:read',
+  /** Decide requests (`approve` / `decline` / `cancel` / `graduate`). */
+  MANAGE: 'access-requests:manage',
+} as const;
+
+/**
+ * One of the capability slugs in {@link ACCESS_REQUEST_CAPABILITIES}.
+ */
+export type AccessRequestCapability =
+  (typeof ACCESS_REQUEST_CAPABILITIES)[keyof typeof ACCESS_REQUEST_CAPABILITIES];
+
+/**
+ * Context passed to an {@link AccessRequestAuthorizer} before an operator method
+ * runs.
+ */
+export interface AccessRequestAuthorizationContext {
+  /** The capability the operation requires. */
+  capability: AccessRequestCapability;
+  /** The operator user id supplied to the method (`by`), if any. */
+  by?: string | null;
+  /** The target access-request id, when the operation targets a specific row. */
+  accessRequestId?: string;
+}
+
+/**
+ * Hook that authorizes an operator action. Throw (or reject) to deny — the
+ * thrown error propagates to the caller unchanged. Resolve/return to allow.
+ *
+ * Wire this to your permission system, e.g. resolve the operator's permissions
+ * and assert the required capability:
+ *
+ * ```typescript
+ * const service = await AccessRequestService.create({
+ *   db,
+ *   authorize: async ({ capability, by }) => {
+ *     if (!by || !(await isPlatformOperator(by, capability))) {
+ *       throw new Error(`Missing capability: ${capability}`);
+ *     }
+ *   },
+ * });
+ * ```
+ */
+export type AccessRequestAuthorizer = (
+  context: AccessRequestAuthorizationContext,
+) => void | Promise<void>;
+
+/**
+ * Lifecycle event types emitted by {@link AccessRequestService}.
+ */
+export type AccessRequestEventType =
+  | 'access-request.created'
+  | 'access-request.approved'
+  | 'access-request.declined'
+  | 'access-request.canceled'
+  | 'access-request.graduated';
+
+/**
+ * Payload delivered to an {@link AccessRequestEventHandler}.
+ */
+export interface AccessRequestEvent {
+  /** Which lifecycle transition fired. */
+  type: AccessRequestEventType;
+  /** The access request after the transition. */
+  accessRequest: AccessRequest;
+  /** When the event was emitted. */
+  at: Date;
+  /** Operator user id responsible, for operator-driven transitions. */
+  by?: string | null;
+  /** Graduated user (only on `access-request.graduated`). */
+  user?: User;
+  /** Membership created/linked on graduation, when a tenant was attached. */
+  membership?: Membership;
+  /** Tenant created/linked on graduation, when a tenant was attached. */
+  tenant?: Tenant;
+}
+
+/**
+ * Event hook apps provide to react to access-request lifecycle changes.
+ * Delivery is best-effort: a throwing handler is logged and swallowed so it
+ * never rolls back an already-persisted transition. Do not rely on it for
+ * critical-path work that must share the request's transaction.
+ */
+export type AccessRequestEventHandler = (
+  event: AccessRequestEvent,
+) => void | Promise<void>;
+
+/**
+ * Options for {@link AccessRequestService}.
+ */
+export interface AccessRequestServiceOptions extends SmrtClassOptions {
+  /** Optional capability gate for operator methods (see {@link AccessRequestAuthorizer}). */
+  authorize?: AccessRequestAuthorizer;
+  /** Optional lifecycle event hook (see {@link AccessRequestEventHandler}). */
+  onEvent?: AccessRequestEventHandler;
+}
+
+/**
+ * Input for {@link AccessRequestService.createAccessRequest}. Only `email` is
+ * required.
+ */
+export interface CreateAccessRequestInput {
+  /** Requester email (validated + normalized to lowercase). */
+  email: string;
+  /** Requester display name. */
+  name?: string | null;
+  /** Where the request came from, e.g. `www`, `sdk`. */
+  source?: string;
+  /** Free-form metadata (intended use, company, message, referrer, …). */
+  context?: Record<string, unknown>;
+  /** Optional requested org/tenant hint (advisory). */
+  tenantHint?: Record<string, unknown> | null;
+  /** Optional initial note. */
+  note?: string | null;
+}
+
+/**
+ * Filter for {@link AccessRequestService.listAccessRequests}.
+ */
+export interface ListAccessRequestsFilter {
+  /** Restrict to one status or any of several. */
+  status?: AccessRequestStatus | AccessRequestStatus[];
+  /** Restrict to a single (normalized) email. */
+  email?: string;
+  /** Restrict to a single source. */
+  source?: string;
+  /** Operator user id, forwarded to the authorizer as `by`. */
+  by?: string | null;
+  /** Max rows to return. */
+  limit?: number;
+  /** Rows to skip. */
+  offset?: number;
+  /** Order-by clause (defaults to `created_at DESC`). */
+  orderBy?: string;
+}
+
+/**
+ * Options shared by the operator decision methods.
+ */
+export interface DecideAccessRequestOptions {
+  /** Operator user id recorded as `decidedBy` and forwarded to the authorizer. */
+  by?: string | null;
+}
+
+/**
+ * Options for {@link AccessRequestService.approveAccessRequest}.
+ */
+export interface ApproveAccessRequestOptions
+  extends DecideAccessRequestOptions {
+  /** Operator note stored on the request. */
+  note?: string | null;
+}
+
+/**
+ * Options for {@link AccessRequestService.declineAccessRequest}.
+ */
+export interface DeclineAccessRequestOptions
+  extends DecideAccessRequestOptions {
+  /** Decision reason stored as the request's note. */
+  reason?: string | null;
+}
+
+/**
+ * Options for {@link AccessRequestService.cancelAccessRequest}.
+ */
+export interface CancelAccessRequestOptions extends DecideAccessRequestOptions {
+  /** Cancellation reason stored as the request's note. */
+  reason?: string | null;
+}
+
+/**
+ * Graduate into a **new** tenant, enrolling the requester (owner by default).
+ */
+export interface GraduateNewTenantOption {
+  /** New tenant attributes — `name` is required. */
+  create: {
+    name: string;
+    slug?: string;
+    description?: string;
+    status?: TenantStatus;
+  };
+  /** Role slug for the requester's membership (default `owner`). */
+  role?: string;
+}
+
+/**
+ * Graduate into an **existing** tenant, enrolling the requester.
+ */
+export interface GraduateExistingTenantOption {
+  /** Target tenant id. */
+  tenantId: string;
+  /** Role slug for the requester's membership (default `member`). */
+  role?: string;
+}
+
+/**
+ * Tenant handling at graduation: create a new tenant, attach to an existing
+ * one, or `'none'` (user only, no membership).
+ */
+export type GraduateTenantOption =
+  | GraduateNewTenantOption
+  | GraduateExistingTenantOption
+  | 'none';
+
+/**
+ * Options for {@link AccessRequestService.graduateAccessRequest}.
+ */
+export interface GraduateAccessRequestOptions
+  extends DecideAccessRequestOptions {
+  /** Tenant handling (default `'none'`). */
+  tenant?: GraduateTenantOption;
+  /** Status applied to the user produced/linked by graduation (default `ACTIVE`). */
+  activate?: UserStatus;
+  /**
+   * Convenience: allow graduating directly from `REQUESTED` (skipping the
+   * `APPROVED` step). Defaults to `false`.
+   */
+  allowFromRequested?: boolean;
+  /** Operator note stored on the request. */
+  note?: string | null;
+}
+
+/**
+ * Result of {@link AccessRequestService.graduateAccessRequest}.
+ */
+export interface GraduateAccessRequestResult {
+  /** The graduated (created or linked) user. */
+  user: User;
+  /** The membership, when a tenant was attached. */
+  membership?: Membership;
+  /** The tenant, when one was created or attached. */
+  tenant?: Tenant;
+  /** The access request, now `GRADUATED`. */
+  accessRequest: AccessRequest;
+  /** Whether a brand-new user was created (`false` when an existing one was linked). */
+  created: boolean;
+}
+
+/**
+ * Error codes raised by {@link AccessRequestError}.
+ */
+export type AccessRequestErrorCode =
+  | 'INVALID_EMAIL'
+  | 'NOT_FOUND'
+  | 'INVALID_TRANSITION'
+  | 'TENANT_NOT_FOUND'
+  | 'ROLE_NOT_FOUND';
+
+/**
+ * Error thrown for access-request domain failures the caller is expected to
+ * surface (invalid email, unknown id, illegal state transition, …). Authorizer
+ * denials are not wrapped — those propagate from the supplied authorizer
+ * unchanged.
+ */
+export class AccessRequestError extends Error {
+  readonly code: AccessRequestErrorCode;
+
+  constructor(message: string, code: AccessRequestErrorCode) {
+    super(message);
+    this.name = 'AccessRequestError';
+    this.code = code;
+  }
+}
+
+/**
+ * Source statuses each transition may legally start from. Idempotent no-ops
+ * (e.g. approving an already-`APPROVED` request) are handled separately, before
+ * these guards run.
+ */
+const APPROVE_FROM: AccessRequestStatus[] = [AccessRequestStatus.REQUESTED];
+const DECLINE_FROM: AccessRequestStatus[] = [
+  AccessRequestStatus.REQUESTED,
+  AccessRequestStatus.APPROVED,
+];
+const CANCEL_FROM: AccessRequestStatus[] = [
+  AccessRequestStatus.REQUESTED,
+  AccessRequestStatus.APPROVED,
+];
+
+/**
+ * High-level orchestration for the access-request lifecycle and graduation.
+ */
+export class AccessRequestService {
+  readonly #options: AccessRequestServiceOptions;
+  readonly #authorize?: AccessRequestAuthorizer;
+  readonly #onEvent?: AccessRequestEventHandler;
+
+  #requests!: AccessRequestCollection;
+  #users!: UserCollection;
+  #tenants!: TenantCollection;
+  #memberships!: MembershipCollection;
+  #roles!: RoleCollection;
+  #rolesSeeded = false;
+
+  constructor(options: AccessRequestServiceOptions) {
+    this.#options = options;
+    this.#authorize = options.authorize;
+    this.#onEvent = options.onEvent;
+  }
+
+  /**
+   * Initialize the backing collections (creates/verifies their tables).
+   */
+  async initialize(): Promise<void> {
+    // SmrtClassOptions carries `authorize`/`onEvent` too; the collections ignore
+    // unknown keys, so passing the whole options bag is harmless and keeps the
+    // db/ai config in one place.
+    this.#requests = await (AccessRequestCollection as any).create(
+      this.#options,
+    );
+    this.#users = await (UserCollection as any).create(this.#options);
+    this.#tenants = await (TenantCollection as any).create(this.#options);
+    this.#memberships = await (MembershipCollection as any).create(
+      this.#options,
+    );
+    this.#roles = await (RoleCollection as any).create(this.#options);
+  }
+
+  /**
+   * Static factory — construct and initialize in one call.
+   */
+  static async create(
+    options: AccessRequestServiceOptions,
+  ): Promise<AccessRequestService> {
+    const service = new AccessRequestService(options);
+    await service.initialize();
+    return service;
+  }
+
+  /**
+   * The underlying collection, for advanced read scenarios. Prefer the service
+   * methods, which apply normalization, the state machine, capability gating,
+   * and events.
+   */
+  get collection(): AccessRequestCollection {
+    return this.#requests;
+  }
+
+  // ============= Public-safe creation =============
+
+  /**
+   * Create an access request. **Public-safe**: no capability check — meant to be
+   * callable unauthenticated by apps (which add their own rate-limiting).
+   *
+   * Validates and normalizes the email, then de-duplicates: if an open
+   * (`REQUESTED`) request already exists for the email, this merges any newly
+   * supplied context/name/source/hint into it and returns it instead of
+   * creating a duplicate (no second `created` event).
+   *
+   * @throws {@link AccessRequestError} (`INVALID_EMAIL`) when the email is invalid.
+   */
+  async createAccessRequest(
+    input: CreateAccessRequestInput,
+  ): Promise<AccessRequest> {
+    const email = normalizeEmail(input.email);
+    if (!isValidEmail(email)) {
+      throw new AccessRequestError(
+        'A valid email address is required to request access.',
+        'INVALID_EMAIL',
+      );
+    }
+
+    // Dedup against an existing open request for this email (idempotent).
+    const existing = await this.#requests.findOpenByEmail(email);
+    if (existing) {
+      let changed = false;
+      if (input.context && Object.keys(input.context).length > 0) {
+        existing.setRequestContext({
+          ...existing.getRequestContext(),
+          ...input.context,
+        });
+        changed = true;
+      }
+      if (input.tenantHint) {
+        existing.setTenantHint({
+          ...(existing.getTenantHint() ?? {}),
+          ...input.tenantHint,
+        });
+        changed = true;
+      }
+      if (input.name && !existing.name) {
+        existing.name = input.name;
+        changed = true;
+      }
+      if (input.source && !existing.source) {
+        existing.source = input.source;
+        changed = true;
+      }
+      if (changed) await existing.save();
+      return existing;
+    }
+
+    const request = await this.#requests.create({
+      email,
+      name: input.name ?? null,
+      source: input.source ?? '',
+      status: AccessRequestStatus.REQUESTED,
+      requestedAt: new Date(),
+      requestContext: JSON.stringify(input.context ?? {}),
+      tenantHint: input.tenantHint ? JSON.stringify(input.tenantHint) : null,
+      note: input.note ?? null,
+    });
+
+    await this.#emit({
+      type: 'access-request.created',
+      accessRequest: request,
+      at: new Date(),
+    });
+
+    return request;
+  }
+
+  // ============= Operator reads =============
+
+  /**
+   * List access requests (operator-facing). Requires the `access-requests:read`
+   * capability when an authorizer is configured.
+   */
+  async listAccessRequests(
+    filter: ListAccessRequestsFilter = {},
+  ): Promise<AccessRequest[]> {
+    await this.#requireCapability(ACCESS_REQUEST_CAPABILITIES.READ, {
+      by: filter.by,
+    });
+
+    const where: Record<string, unknown> = {};
+    if (filter.status !== undefined) where.status = filter.status;
+    if (filter.email !== undefined) where.email = normalizeEmail(filter.email);
+    if (filter.source !== undefined) where.source = filter.source;
+
+    return await this.#requests.list({
+      where,
+      limit: filter.limit,
+      offset: filter.offset,
+      orderBy: filter.orderBy ?? 'created_at DESC',
+    });
+  }
+
+  /**
+   * Get a single access request by id (operator-facing). Requires the
+   * `access-requests:read` capability when an authorizer is configured.
+   */
+  async getAccessRequest(
+    id: string,
+    options: { by?: string | null } = {},
+  ): Promise<AccessRequest | null> {
+    await this.#requireCapability(ACCESS_REQUEST_CAPABILITIES.READ, {
+      by: options.by,
+      accessRequestId: id,
+    });
+    return await this.#requests.get(id);
+  }
+
+  // ============= Operator decisions =============
+
+  /**
+   * Approve a request: `REQUESTED → APPROVED`. Idempotent (re-approving an
+   * already-`APPROVED` request is a no-op returning it). Requires
+   * `access-requests:manage`.
+   *
+   * @throws {@link AccessRequestError} (`INVALID_TRANSITION`) from a terminal state.
+   */
+  async approveAccessRequest(
+    id: string,
+    options: ApproveAccessRequestOptions = {},
+  ): Promise<AccessRequest> {
+    await this.#requireCapability(ACCESS_REQUEST_CAPABILITIES.MANAGE, {
+      by: options.by,
+      accessRequestId: id,
+    });
+
+    const request = await this.#load(id);
+    if (request.status === AccessRequestStatus.APPROVED) return request;
+    this.#assertTransition(request, APPROVE_FROM, 'approve');
+
+    request.status = AccessRequestStatus.APPROVED;
+    request.decidedAt = new Date();
+    if (options.by) request.decidedBy = options.by;
+    if (options.note != null) request.note = options.note;
+    await request.save();
+
+    await this.#emit({
+      type: 'access-request.approved',
+      accessRequest: request,
+      at: new Date(),
+      by: options.by,
+    });
+    return request;
+  }
+
+  /**
+   * Decline a request: `REQUESTED | APPROVED → DECLINED`. Idempotent. Requires
+   * `access-requests:manage`.
+   *
+   * @throws {@link AccessRequestError} (`INVALID_TRANSITION`) from a terminal state.
+   */
+  async declineAccessRequest(
+    id: string,
+    options: DeclineAccessRequestOptions = {},
+  ): Promise<AccessRequest> {
+    await this.#requireCapability(ACCESS_REQUEST_CAPABILITIES.MANAGE, {
+      by: options.by,
+      accessRequestId: id,
+    });
+
+    const request = await this.#load(id);
+    if (request.status === AccessRequestStatus.DECLINED) return request;
+    this.#assertTransition(request, DECLINE_FROM, 'decline');
+
+    request.status = AccessRequestStatus.DECLINED;
+    request.decidedAt = new Date();
+    if (options.by) request.decidedBy = options.by;
+    if (options.reason != null) request.note = options.reason;
+    await request.save();
+
+    await this.#emit({
+      type: 'access-request.declined',
+      accessRequest: request,
+      at: new Date(),
+      by: options.by,
+    });
+    return request;
+  }
+
+  /**
+   * Cancel a request: `REQUESTED | APPROVED → CANCELED`. Idempotent. Requires
+   * `access-requests:manage`.
+   *
+   * @throws {@link AccessRequestError} (`INVALID_TRANSITION`) from a terminal state.
+   */
+  async cancelAccessRequest(
+    id: string,
+    options: CancelAccessRequestOptions = {},
+  ): Promise<AccessRequest> {
+    await this.#requireCapability(ACCESS_REQUEST_CAPABILITIES.MANAGE, {
+      by: options.by,
+      accessRequestId: id,
+    });
+
+    const request = await this.#load(id);
+    if (request.status === AccessRequestStatus.CANCELED) return request;
+    this.#assertTransition(request, CANCEL_FROM, 'cancel');
+
+    request.status = AccessRequestStatus.CANCELED;
+    request.decidedAt = new Date();
+    if (options.by) request.decidedBy = options.by;
+    if (options.reason != null) request.note = options.reason;
+    await request.save();
+
+    await this.#emit({
+      type: 'access-request.canceled',
+      accessRequest: request,
+      at: new Date(),
+      by: options.by,
+    });
+    return request;
+  }
+
+  // ============= Graduation =============
+
+  /**
+   * Graduate an approved request into a `User`, optionally attaching a tenant.
+   *
+   * Valid from `APPROVED` (or from `REQUESTED` when
+   * {@link GraduateAccessRequestOptions.allowFromRequested} is set). Creates a
+   * user when none exists for the email, or **links** the existing one
+   * otherwise (reusing {@link UserCollection}). Idempotent: a second call on an
+   * already-`GRADUATED` request returns the same user (and an existing
+   * membership for the requested tenant, if any) without re-creating anything.
+   *
+   * Requires `access-requests:manage`.
+   *
+   * @throws {@link AccessRequestError} — `NOT_FOUND` (unknown id),
+   *   `INVALID_TRANSITION` (terminal/declined/canceled or `REQUESTED` without
+   *   `allowFromRequested`), `TENANT_NOT_FOUND`, or `ROLE_NOT_FOUND`.
+   */
+  async graduateAccessRequest(
+    id: string,
+    options: GraduateAccessRequestOptions = {},
+  ): Promise<GraduateAccessRequestResult> {
+    await this.#requireCapability(ACCESS_REQUEST_CAPABILITIES.MANAGE, {
+      by: options.by,
+      accessRequestId: id,
+    });
+
+    const request = await this.#load(id);
+    const tenantOption = options.tenant ?? 'none';
+
+    // Idempotent re-graduation: return the same user (and existing membership
+    // for the requested tenant, if resolvable) without mutating anything.
+    if (
+      request.status === AccessRequestStatus.GRADUATED &&
+      request.resultingUserId
+    ) {
+      const existingUser = await this.#users.get(request.resultingUserId);
+      if (existingUser) {
+        const membership = await this.#resolveExistingMembership(
+          existingUser.id as string,
+          tenantOption,
+        );
+        return {
+          user: existingUser,
+          membership: membership ?? undefined,
+          accessRequest: request,
+          created: false,
+        };
+      }
+      // resultingUserId is stale/missing — fall through and re-link by email.
+    }
+
+    // State-machine guard for a fresh graduation.
+    if (request.status !== AccessRequestStatus.GRADUATED) {
+      const allowFromRequested = options.allowFromRequested ?? false;
+      const canGraduate =
+        request.status === AccessRequestStatus.APPROVED ||
+        (request.status === AccessRequestStatus.REQUESTED &&
+          allowFromRequested);
+      if (!canGraduate) {
+        const hint =
+          request.status === AccessRequestStatus.REQUESTED
+            ? ' (approve it first, or pass allowFromRequested)'
+            : '';
+        throw new AccessRequestError(
+          `Cannot graduate an access request in status "${request.status}"${hint}.`,
+          'INVALID_TRANSITION',
+        );
+      }
+    }
+
+    // Create-or-link the user by normalized email. A brand-new user defaults to
+    // ACTIVE (or `options.activate`). An existing linked user keeps its current
+    // status unless the operator *explicitly* passes `activate` — so graduation
+    // never silently un-suspends an already-managed account.
+    const email = normalizeEmail(request.email);
+    let user = await this.#users.findByEmail(email);
+    let created = false;
+    if (!user) {
+      user = await this.#users.create({
+        email,
+        status: options.activate ?? UserStatus.ACTIVE,
+      });
+      created = true;
+    } else if (
+      options.activate !== undefined &&
+      user.status !== options.activate
+    ) {
+      user.status = options.activate;
+      await user.save();
+    }
+
+    // Attach a tenant if requested.
+    let membership: Membership | undefined;
+    let tenant: Tenant | undefined;
+    if (tenantOption !== 'none') {
+      const attached = await this.#attachTenant(
+        user.id as string,
+        tenantOption,
+      );
+      membership = attached.membership;
+      tenant = attached.tenant;
+    }
+
+    // Mark graduated.
+    request.status = AccessRequestStatus.GRADUATED;
+    request.resultingUserId = user.id as string;
+    request.decidedAt = new Date();
+    if (options.by) request.decidedBy = options.by;
+    if (options.note != null) request.note = options.note;
+    await request.save();
+
+    await this.#emit({
+      type: 'access-request.graduated',
+      accessRequest: request,
+      at: new Date(),
+      by: options.by,
+      user,
+      membership,
+      tenant,
+    });
+
+    return { user, membership, tenant, accessRequest: request, created };
+  }
+
+  // ============= Internals =============
+
+  /**
+   * Load a request or throw `NOT_FOUND`.
+   */
+  async #load(id: string): Promise<AccessRequest> {
+    const request = await this.#requests.get(id);
+    if (!request) {
+      throw new AccessRequestError('Access request not found.', 'NOT_FOUND');
+    }
+    return request;
+  }
+
+  /**
+   * Guard a state transition; throw `INVALID_TRANSITION` if the current status
+   * is not an allowed source.
+   */
+  #assertTransition(
+    request: AccessRequest,
+    allowedFrom: AccessRequestStatus[],
+    action: string,
+  ): void {
+    if (!allowedFrom.includes(request.status)) {
+      throw new AccessRequestError(
+        `Cannot ${action} an access request in status "${request.status}".`,
+        'INVALID_TRANSITION',
+      );
+    }
+  }
+
+  /**
+   * Run the configured authorizer (if any). Absent an authorizer, operator
+   * methods are ungated — see the class-level security note.
+   */
+  async #requireCapability(
+    capability: AccessRequestCapability,
+    context: { by?: string | null; accessRequestId?: string },
+  ): Promise<void> {
+    if (!this.#authorize) return;
+    await this.#authorize({
+      capability,
+      by: context.by ?? null,
+      accessRequestId: context.accessRequestId,
+    });
+  }
+
+  /**
+   * Best-effort event delivery — a throwing handler is logged and swallowed so
+   * it cannot roll back an already-persisted transition.
+   */
+  async #emit(event: AccessRequestEvent): Promise<void> {
+    if (!this.#onEvent) return;
+    try {
+      await this.#onEvent(event);
+    } catch (error) {
+      logger.error(
+        `AccessRequest event handler threw for "${event.type}" (request ${event.accessRequest.id})`,
+        { error },
+      );
+    }
+  }
+
+  /**
+   * Create-or-attach the requester to a tenant, reusing the tenant / role /
+   * membership collections (no duplication of user/membership logic).
+   */
+  async #attachTenant(
+    userId: string,
+    option: GraduateNewTenantOption | GraduateExistingTenantOption,
+  ): Promise<{ tenant: Tenant; membership: Membership }> {
+    await this.#ensureRolesSeeded();
+
+    if ('tenantId' in option) {
+      const tenant = await this.#tenants.get(option.tenantId);
+      if (!tenant) {
+        throw new AccessRequestError(
+          `Target tenant "${option.tenantId}" not found.`,
+          'TENANT_NOT_FOUND',
+        );
+      }
+      const membership = await this.#getOrCreateMembership(
+        userId,
+        tenant.id as string,
+        option.role ?? DEFAULT_ROLE_SLUGS.MEMBER,
+      );
+      return { tenant, membership };
+    }
+
+    const tenant = await this.#tenants.create({
+      name: option.create.name,
+      slug: option.create.slug,
+      description: option.create.description,
+      status: option.create.status,
+    });
+    const membership = await this.#getOrCreateMembership(
+      userId,
+      tenant.id as string,
+      option.role ?? DEFAULT_ROLE_SLUGS.OWNER,
+    );
+    return { tenant, membership };
+  }
+
+  /**
+   * Resolve (creating if needed) the user's membership in a tenant with the
+   * given role slug. Idempotent — returns any existing membership for the pair.
+   */
+  async #getOrCreateMembership(
+    userId: string,
+    tenantId: string,
+    roleSlug: string,
+  ): Promise<Membership> {
+    const existing = await this.#memberships.findByUserAndTenant(
+      userId,
+      tenantId,
+    );
+    if (existing) return existing;
+
+    const role = await this.#roles.findBySlug(roleSlug, tenantId);
+    if (!role) {
+      throw new AccessRequestError(
+        `Role "${roleSlug}" not found — seed system roles or pass a valid role slug.`,
+        'ROLE_NOT_FOUND',
+      );
+    }
+
+    return await this.#memberships.create({
+      userId,
+      tenantId,
+      roleId: role.id as string,
+      status: MembershipStatus.ACTIVE,
+    });
+  }
+
+  /**
+   * For idempotent re-graduation: find an existing membership for the requested
+   * tenant. Only the existing-tenant variant is resolvable (a `{ create }`
+   * variant has no known tenant id on a re-call).
+   */
+  async #resolveExistingMembership(
+    userId: string,
+    tenantOption: GraduateTenantOption,
+  ): Promise<Membership | null> {
+    if (tenantOption === 'none' || !('tenantId' in tenantOption)) return null;
+    return await this.#memberships.findByUserAndTenant(
+      userId,
+      tenantOption.tenantId,
+    );
+  }
+
+  /**
+   * Lazily seed the default system roles (owner/admin/member/viewer) the first
+   * time graduation attaches a tenant — so the public create path never incurs
+   * the write.
+   */
+  async #ensureRolesSeeded(): Promise<void> {
+    if (this.#rolesSeeded) return;
+    await this.#roles.seedSystemRoles();
+    this.#rolesSeeded = true;
+  }
+}

--- a/packages/users/src/services/index.ts
+++ b/packages/users/src/services/index.ts
@@ -4,6 +4,29 @@
  */
 
 export {
+  ACCESS_REQUEST_CAPABILITIES,
+  type AccessRequestAuthorizationContext,
+  type AccessRequestAuthorizer,
+  type AccessRequestCapability,
+  AccessRequestError,
+  type AccessRequestErrorCode,
+  type AccessRequestEvent,
+  type AccessRequestEventHandler,
+  type AccessRequestEventType,
+  AccessRequestService,
+  type AccessRequestServiceOptions,
+  type ApproveAccessRequestOptions,
+  type CancelAccessRequestOptions,
+  type CreateAccessRequestInput,
+  type DeclineAccessRequestOptions,
+  type GraduateAccessRequestOptions,
+  type GraduateAccessRequestResult,
+  type GraduateExistingTenantOption,
+  type GraduateNewTenantOption,
+  type GraduateTenantOption,
+  type ListAccessRequestsFilter,
+} from './AccessRequestService.js';
+export {
   MagicLinkError,
   type MagicLinkResult,
   MagicLinkService,

--- a/packages/users/src/types/index.ts
+++ b/packages/users/src/types/index.ts
@@ -6,6 +6,7 @@
 // Re-export status enums from smrt-types for backwards compatibility
 // These are defined in smrt-types to allow browser-safe packages to import them
 export {
+  AccessRequestStatus,
   MembershipStatus,
   OverrideEffect,
   SessionStatus,


### PR DESCRIPTION
## Summary

Adds a first-class **`AccessRequest`** primitive to `@happyvertical/smrt-users` for the common *"request access / join the waitlist"* pattern: capture a prospective user from a public form **before** they are a real `User`, let an operator triage, and **graduate** an approved request into a `User` (optionally attached to a tenant). Today every app hand-rolls this; `User.status=PENDING` / `Membership.status=PENDING` existed but there was no request entity or graduation flow.

Closes #1711.

## What's included

**Model + collection** (`AccessRequest`, `AccessRequestCollection`)
- Fields: `email` (required, lowercased, indexed), `name?`, `status`, `source`, `requestContext` (json), `note?`, `requestedAt`/`decidedAt`/`decidedBy`, `resultingUserId?`, `tenantHint?`, timestamps.
- The json metadata field is named **`requestContext`** (not `context`) because `SmrtObject` reserves `context` for slug scoping — same trap `smrt-chat` avoided with `sessionContext`. Helpers: `getRequestContext()/setRequestContext()`, `getTenantHint()/setTenantHint()`.
- **Closed generated surface** (`api`/`mcp`/`cli` = `[]`, like `CliAuthRequest`/`AgentSession`) so the raw CRUD routes can't bypass email normalization, the state machine, or capability checks. The model is still registered, so consuming apps pick up the `access_requests` table via their normal migrate flow. `email`/`status`/`source` are indexed.

**Status enum** — `AccessRequestStatus` (`REQUESTED | APPROVED | DECLINED | GRADUATED | CANCELED`) added to `smrt-types` and re-exported from `smrt-users`.

**Service** (`AccessRequestService`)
- `createAccessRequest(input)` — **public-safe** (no auth): validates + normalizes the email and de-dups against any open `REQUESTED` record (merges context, no duplicate).
- `listAccessRequests(filter)` / `getAccessRequest(id)` — operator reads.
- `approveAccessRequest` / `declineAccessRequest` / `cancelAccessRequest` — state-machine transitions; idempotent; invalid transitions throw `AccessRequestError`.
- `graduateAccessRequest(id, options)` — creates **or links** a `User` (reuses `UserCollection`), idempotent, sets `status=GRADUATED` + `resultingUserId`. `options.tenant` is `{ create: { name, slug?, … }, role }` | `{ tenantId, role }` | `'none'` (operator decides new-vs-existing tenant per request); `options.activate` sets the new user's status (default `ACTIVE`, and never silently re-activates an existing linked account unless passed explicitly). Reuses the existing membership/tenant/role paths.

**Events** — optional `onEvent` hook emits `access-request.created | approved | declined | canceled | graduated` (best-effort; a throwing handler is logged, never rolls back a persisted transition). This package never owns email delivery — apps bridge the hook to their channel (function / `EventEmitter` / `DispatchBus`).

**Capability gating** — optional `authorize` hook gates operator methods (`access-requests:read` / `access-requests:manage`); `createAccessRequest` is intentionally ungated. Mirrors `TerminalAuthService`'s "caller authenticates" model; documented in the service's `@remarks`.

## Drive-by core fix (`fix(core)`)

`AccessRequest` is the **first** model to use `@field({ indexed: true })` on a regular column, which surfaced a gap: `generateCTISchemaFromManifest` didn't emit plain column indexes for `indexed` fields, so the documented `FieldOptions.indexed` flag was silently dropped from the build-time manifest that `db:migrate` / the schema differ consume. The STI manifest path and the runtime registry path already honored it — this brings the CTI path to parity (one focused commit + a core unit test). Additive: only models that opt a regular column into `indexed: true` gain an index, so the only manifest that changes is `AccessRequest`'s.

## Tests

27 unit tests (smrt-users) covering creation (validation/normalization/dedup), the state machine + idempotency + invalid-transition guards, list/get filters, capability gating (create stays public-safe), best-effort events, and graduation across **all three tenant paths** (new / existing / none) including create-or-link by email and idempotent re-graduation. Plus a core unit test for the manifest-path index emission.

## Verification

- `pnpm test` smrt-users — **219 passed** / 4 skipped; smrt-core — **190 files passed** / 2 skipped.
- `pnpm typecheck` (smrt-users) — tsc + svelte-check, **0 errors**.
- `pnpm build` + `pnpm knowledge:check --strict` — **fresh, 0 errors/warnings**.
- Coverage gate: `users` **81.16%** (T2 floor 70%). `biome check` on changed files — clean.

## Backwards compatibility

Purely additive — no behavior changes to `User` or `Membership`.

## Downstream (out of scope)

Unblocks Ergot: a public `POST /api/access-requests` → `createAccessRequest`, the `apps/www` invite form, and an operator approve/graduate UI choosing new-vs-existing tenant per request.
