### PR TITLE
fix(docs): correct ADR sidebar doc ids (numeric prefix is stripped)

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -53,12 +53,12 @@ const sidebars: SidebarsConfig = {
       items: [
         {
           type: 'doc',
-          id: 'adr/0001-kmp-mobile-foundation',
+          id: 'adr/kmp-mobile-foundation',
           label: 'ADR 0001: KMP Mobile Foundation',
         },
         {
           type: 'doc',
-          id: 'adr/0001-kmp-mobile-foundation-extraction-plan',
+          id: 'adr/kmp-mobile-foundation-extraction-plan',
           label: 'ADR 0001: Extraction Plan',
         },
       ],


### PR DESCRIPTION
## Summary

`Publish / Deploy Documentation` has failed on every merge to main since #1736: `docs/sidebars.ts` references `adr/0001-kmp-mobile-foundation` and `adr/0001-kmp-mobile-foundation-extraction-plan`, but Docusaurus strips the `NNNN-` filename prefix when deriving doc ids, so the actual ids are `adr/kmp-mobile-foundation` and `adr/kmp-mobile-foundation-extraction-plan`:

```
[cause]: Error: Invalid sidebar file at "sidebars.ts".
These sidebar document ids do not exist:
- adr/0001-kmp-mobile-foundation
- adr/0001-kmp-mobile-foundation-extraction-plan
```

(observed in the merge runs for #1736 and #1747)

## Fix

Point the two sidebar entries at the real doc ids. Verified with a local `docusaurus build` — completes with `[SUCCESS] Generated static files`.