### PR TITLE
feat(mobile): Phase 3 — provider-agnostic PKCE auth/session module

### DIFF
--- a/packages/smrt-mobile/AGENTS.md
+++ b/packages/smrt-mobile/AGENTS.md
@@ -5,12 +5,14 @@ non-TypeScript package in the monorepo. Design: **ADR 0001**
 (`docs/content/adr/0001-kmp-mobile-foundation.md`) + extraction plan; epic
 #1745. Decision record: `README.md` here and issue #1737.
 
-**Status: Phase 2.** Present: framework contract types, pack i18n resolver,
+**Status: Phase 3.** Present: framework contract types, pack i18n resolver,
 pack integrity/snapshot model, evidence-capture model, shell state, platform
-seams, and the **durable SQLDelight-backed offline write-queue + pack store**
-(Phase 2, #1739). NOT here yet (later phases — do not add ad hoc):
-auth/session (Phase 3, #1740), Ktor networking (Phase 4, #1741).
-**Productionize, don't lift** governs all porting from the seed apps.
+seams, the **durable SQLDelight-backed offline write-queue + pack store**
+(Phase 2, #1739), and the **PKCE auth/session module** (Phase 3, #1740).
+NOT here yet (later phases — do not add ad hoc): Ktor networking (Phase 4,
+#1741 — `AuthTransport`/`QueueSender` are its seams), platform adapters
+(Phases 5–6). **Productionize, don't lift** governs all porting from the
+seed apps.
 
 ## Layout
 
@@ -25,6 +27,15 @@ consumers use Gradle `includeBuild`).
   DTOs). Owner: `@happyvertical/smrt-mobile-contract`. Regenerate:
   `pnpm --filter @happyvertical/smrt-mobile-contract generate:framework`.
   Never edit by hand; the contract package's build verifies freshness.
+- `src/commonMain/kotlin/.../auth/` — `MobileSessionManager`: server-brokered
+  PKCE (begin → platform launcher opens the authorization URL → deep-link
+  redirect → `state` validation → code exchange → persisted session). The
+  pending handshake persists so the browser hand-off survives process death.
+  Seams: `AuthStorage` (Keystore/Keychain in Phases 5–6 — the reporter's
+  SharedPreferences/UserDefaults is explicitly the thing to upgrade),
+  `AuthTransport` (Phase 4 Ktor), `ExternalAuthLauncher` (custom tab /
+  ASWebAuthenticationSession). `onUnauthorized()` is the networking client's
+  401 hook: clears the session; the write-queue keeps its entries.
 - `src/commonMain/kotlin/.../i18n/` — `PackTextResolver`: requested →
   fallback → source locale chain with review-state/safety-critical
   provenance.
@@ -81,13 +92,14 @@ pnpm test:gradle        # ./gradlew allTests
 
 CI: every PR runs `validate:shell` via turbo build; `.github/workflows/mobile.yml`
 runs the real Gradle build+tests when `packages/smrt-mobile/**` changes
-(ubuntu), and iOS-target compilation nightly/on-demand (macOS). Gradle
-wrapper (8.14.4) is checked in — always invoke via `./gradlew`.
+(ubuntu), and iOS-target compilation nightly/on-demand (macOS). The Gradle
+wrapper is checked in — always invoke via `./gradlew`.
 
 ## Conventions
 
-- Kotlin 2.2.21 / AGP 8.13.1 / compileSdk 36 / minSdk 26 / JVM toolchain 21 /
-  iOS deployment 17.0 — reporter-proven set; bump deliberately in
+- Kotlin 2.4.0 / AGP 9.2.1 (androidKmpLibrary DSL) / Gradle 9.6.1 /
+  compileSdk 36 / minSdk 26 / JVM toolchain 21 / iOS deployment 17.0 —
+  renovate keeps these current; bump deliberately in
   `gradle/libs.versions.toml`.
 - commonMain dependencies stay minimal (kotlinx-serialization,
   kotlinx-datetime, kotlinx-coroutines, SQLDelight runtime). Ktor arrives in

--- a/packages/smrt-mobile/README.md
+++ b/packages/smrt-mobile/README.md
@@ -83,7 +83,8 @@ in Phase 6, #1743).
 - Phase 2 (#1739) — **landed**: durable offline write-queue + pack store
   (SQLDelight), carrying reporter's semantics: single-flight coalesced flush,
   attempt cap, `uploading → pending` crash recovery, idempotency keys.
-- Phase 3 (#1740): PKCE/OIDC session module + platform browser/deep-link seams.
+- Phase 3 (#1740) — **landed**: PKCE/OIDC session module (`MobileSessionManager`)
+  with platform browser/deep-link/secure-storage seams.
 - Phase 3.5 (#1748): `/api/mobile` server handlers in `smrt-users`.
 - Phase 4 (#1741): shared Ktor client (bearer + multipart + retry).
 - Phases 5–6 (#1742/#1743): `smrt-android` (Compose) and `smrt-ios` (SwiftUI +

--- a/packages/smrt-mobile/build.gradle.kts
+++ b/packages/smrt-mobile/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
+            implementation(libs.kotlinx.coroutines.test)
         }
         jvmTest.dependencies {
             // Queue/store tests run against real SQLite on the JVM target —

--- a/packages/smrt-mobile/gradle/libs.versions.toml
+++ b/packages/smrt-mobile/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ sqldelight = "2.1.0"
 
 [libraries]
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 sqldelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqldelight" }

--- a/packages/smrt-mobile/scripts/validate-shell.mjs
+++ b/packages/smrt-mobile/scripts/validate-shell.mjs
@@ -78,6 +78,23 @@ const SPEC = [
     mustContain: [GENERATED_HEADER],
   })),
   {
+    path: `${KOTLIN_ROOT}/auth/AuthSeams.kt`,
+    mustContain: [
+      'interface AuthStorage',
+      'interface AuthTransport',
+      'fun interface ExternalAuthLauncher',
+    ],
+  },
+  {
+    path: `${KOTLIN_ROOT}/auth/MobileSessionManager.kt`,
+    mustContain: [
+      'class MobileSessionManager(',
+      'suspend fun beginSignIn(',
+      'suspend fun handleRedirect(',
+      'suspend fun onUnauthorized()',
+    ],
+  },
+  {
     path: `${KOTLIN_ROOT}/i18n/PackTextResolver.kt`,
     mustContain: ['class PackTextResolver(', 'fun resolve(key: String'],
   },
@@ -123,6 +140,7 @@ const SPEC = [
   // Schema snapshot backing verifyMigrations — deleting it disables the
   // schema-evolution guardrail (see AGENTS.md § Schema changes).
   { path: 'src/commonMain/sqldelight/databases/1.db' },
+  { path: `${TEST_ROOT}/auth/MobileSessionManagerTest.kt` },
   { path: `${TEST_ROOT}/i18n/PackTextResolverTest.kt` },
   { path: `${TEST_ROOT}/packs/PackIntegrityCheckTest.kt` },
   { path: `${TEST_ROOT}/shell/MobileShellStateTest.kt` },

--- a/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/auth/AuthSeams.kt
+++ b/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/auth/AuthSeams.kt
@@ -1,0 +1,86 @@
+package com.happyvertical.smrt.mobile.auth
+
+import com.happyvertical.smrt.mobile.contract.MobileAuthCompleteRequest
+import com.happyvertical.smrt.mobile.contract.MobileAuthSession
+import com.happyvertical.smrt.mobile.contract.MobileAuthStartRequest
+import com.happyvertical.smrt.mobile.contract.MobileAuthStartResponse
+import com.happyvertical.smrt.mobile.contract.MobileSessionBootstrap
+
+/**
+ * Platform seams for the auth/session module (ADR 0001 Phase 3). Concrete
+ * implementations arrive with the platform libraries: Keystore/Keychain
+ * storage and custom-tab / ASWebAuthenticationSession launchers in
+ * smrt-android / smrt-ios (Phases 5-6); the HTTP transport in the shared
+ * Ktor client (Phase 4).
+ */
+
+/**
+ * Durable storage for the session and the in-flight auth handshake, as
+ * opaque strings (the manager owns serialization). The pending-auth slot
+ * must survive process death — the browser hand-off can outlive the app
+ * process. Platform implementations should be secure (Keystore/Keychain);
+ * the reporter seed's SharedPreferences/UserDefaults storage is explicitly
+ * the thing to upgrade.
+ */
+interface AuthStorage {
+    suspend fun readSession(): String?
+
+    suspend fun writeSession(value: String)
+
+    suspend fun clearSession()
+
+    suspend fun readPendingAuth(): String?
+
+    suspend fun writePendingAuth(value: String)
+
+    suspend fun clearPendingAuth()
+}
+
+/** Non-durable [AuthStorage] for tests and previews only. */
+class InMemoryAuthStorage : AuthStorage {
+    private var session: String? = null
+    private var pendingAuth: String? = null
+
+    override suspend fun readSession(): String? = session
+
+    override suspend fun writeSession(value: String) {
+        session = value
+    }
+
+    override suspend fun clearSession() {
+        session = null
+    }
+
+    override suspend fun readPendingAuth(): String? = pendingAuth
+
+    override suspend fun writePendingAuth(value: String) {
+        pendingAuth = value
+    }
+
+    override suspend fun clearPendingAuth() {
+        pendingAuth = null
+    }
+}
+
+/** Thrown by [AuthTransport] when the server answers 401. */
+class AuthUnauthorizedException(message: String = "unauthorized") : Exception(message)
+
+/**
+ * The `/api/mobile` auth endpoints (server-brokered PKCE — the server owns
+ * the verifier/state generation and the IdP exchange; issue #1748 tracks the
+ * SMRT-shipped handlers).
+ */
+interface AuthTransport {
+    suspend fun start(request: MobileAuthStartRequest): MobileAuthStartResponse
+
+    suspend fun complete(request: MobileAuthCompleteRequest): MobileAuthSession
+
+    suspend fun bootstrap(accessToken: String): MobileSessionBootstrap
+
+    suspend fun logout(accessToken: String)
+}
+
+/** Opens the authorization URL in the platform's auth browser surface. */
+fun interface ExternalAuthLauncher {
+    fun launch(authorizationUrl: String)
+}

--- a/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/auth/AuthSeams.kt
+++ b/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/auth/AuthSeams.kt
@@ -36,7 +36,21 @@ interface AuthStorage {
     suspend fun clearPendingAuth()
 }
 
+/**
+ * Marks auth storage that is NOT secure and NOT durable. Consumers must
+ * opt in, which keeps [InMemoryAuthStorage] from silently shipping in a
+ * production wiring — apps use a Keystore/Keychain-backed [AuthStorage]
+ * (Phases 5–6).
+ */
+@RequiresOptIn(
+    message = "InMemoryAuthStorage is not secure and not durable — tests/previews " +
+        "only. Apps must use a Keystore/Keychain-backed AuthStorage.",
+    level = RequiresOptIn.Level.WARNING,
+)
+annotation class InsecureAuthStorageApi
+
 /** Non-durable [AuthStorage] for tests and previews only. */
+@InsecureAuthStorageApi
 class InMemoryAuthStorage : AuthStorage {
     private var session: String? = null
     private var pendingAuth: String? = null

--- a/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/auth/MobileSessionManager.kt
+++ b/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/auth/MobileSessionManager.kt
@@ -1,0 +1,225 @@
+package com.happyvertical.smrt.mobile.auth
+
+import com.happyvertical.smrt.mobile.contract.MobileAuthCompleteRequest
+import com.happyvertical.smrt.mobile.contract.MobileAuthSession
+import com.happyvertical.smrt.mobile.contract.MobileAuthStartRequest
+import com.happyvertical.smrt.mobile.contract.MobileAuthStartResponse
+import com.happyvertical.smrt.mobile.contract.MobileSessionBootstrap
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Provider-agnostic mobile session manager (ADR 0001 Phase 3), seeded from
+ * the anytown reporter's PKCE flow and generalized: configurable provider,
+ * redirect scheme, and scopes instead of `ai.anytown.reporter` constants.
+ *
+ * Flow: [beginSignIn] → server-brokered PKCE start → the platform launcher
+ * opens the authorization URL → the IdP redirects to the app's deep link →
+ * [handleRedirect] validates `state`, exchanges the code, and persists the
+ * session. The pending handshake is persisted too — the browser hand-off can
+ * outlive the app process (reporter parity).
+ *
+ * 401 semantics: [onUnauthorized] (called by the networking client, Phase 4)
+ * clears the stored session so the UI re-enters sign-in — the queue keeps
+ * its entries (see `DurableWriteQueue`).
+ */
+data class MobileAuthConfig(
+    val redirectUri: String,
+    val providerId: String? = null,
+    val scopes: List<String> = emptyList(),
+)
+
+@Serializable
+internal data class PendingAuth(
+    val providerId: String,
+    val state: String,
+    val codeVerifier: String?,
+    val redirectUri: String,
+)
+
+sealed class AuthFailure(message: String) : Exception(message) {
+    /** A redirect arrived with no persisted handshake to match it. */
+    class NoPendingAuth : AuthFailure("no pending auth handshake")
+
+    /** The redirect `state` does not match the pending handshake. */
+    class StateMismatch : AuthFailure("redirect state does not match pending auth")
+
+    /** The IdP returned an error (e.g. `access_denied`). */
+    class ProviderError(val code: String, description: String) :
+        AuthFailure(if (description.isBlank()) code else "$code: $description")
+
+    /** The redirect carries no authorization code. */
+    class MissingCode : AuthFailure("redirect carries no authorization code")
+}
+
+class MobileSessionManager(
+    private val config: MobileAuthConfig,
+    private val transport: AuthTransport,
+    private val storage: AuthStorage,
+    private val launcher: ExternalAuthLauncher,
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /**
+     * Starts the handshake: persists the pending `state`/`codeVerifier` and
+     * hands the authorization URL to the platform launcher.
+     */
+    suspend fun beginSignIn(loginHint: String? = null): MobileAuthStartResponse {
+        val response = transport.start(
+            MobileAuthStartRequest(
+                providerId = config.providerId,
+                redirectUri = config.redirectUri,
+                scopes = config.scopes,
+                loginHint = loginHint,
+            ),
+        )
+        storage.writePendingAuth(
+            json.encodeToString(
+                PendingAuth.serializer(),
+                PendingAuth(
+                    providerId = response.providerId,
+                    state = response.state,
+                    codeVerifier = response.codeVerifier,
+                    redirectUri = response.redirectUri,
+                ),
+            ),
+        )
+        launcher.launch(response.authorizationUrl)
+        return response
+    }
+
+    /**
+     * Completes the handshake from the deep-link redirect. Validates `state`
+     * against the persisted handshake before exchanging the code. On a
+     * mismatch or provider error the pending handshake is kept — a correct
+     * redirect for it can still arrive.
+     */
+    suspend fun handleRedirect(url: String): MobileAuthSession {
+        val params = parseQueryParameters(url)
+        params["error"]?.let { code ->
+            throw AuthFailure.ProviderError(code, params["error_description"] ?: "")
+        }
+        val pending = readPendingAuth() ?: throw AuthFailure.NoPendingAuth()
+        val state = params["state"]
+        if (state == null || state != pending.state) {
+            throw AuthFailure.StateMismatch()
+        }
+        val code = params["code"] ?: throw AuthFailure.MissingCode()
+
+        val session = transport.complete(
+            MobileAuthCompleteRequest(
+                providerId = pending.providerId,
+                code = code,
+                state = state,
+                codeVerifier = pending.codeVerifier,
+                redirectUri = pending.redirectUri,
+            ),
+        )
+        storage.writeSession(json.encodeToString(MobileAuthSession.serializer(), session))
+        storage.clearPendingAuth()
+        return session
+    }
+
+    suspend fun currentSession(): MobileAuthSession? = storage.readSession()?.let { stored ->
+        try {
+            json.decodeFromString(MobileAuthSession.serializer(), stored)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    suspend fun accessToken(): String? = currentSession()?.accessToken
+
+    /**
+     * Loads the session bootstrap with the stored bearer. A 401 clears the
+     * stored session before rethrowing so callers re-enter sign-in.
+     */
+    suspend fun bootstrap(): MobileSessionBootstrap {
+        val token = accessToken() ?: throw AuthUnauthorizedException("no stored session")
+        return try {
+            transport.bootstrap(token)
+        } catch (unauthorized: AuthUnauthorizedException) {
+            storage.clearSession()
+            throw unauthorized
+        }
+    }
+
+    /** The 401 hook for the networking client: drops the stored session. */
+    suspend fun onUnauthorized() {
+        storage.clearSession()
+    }
+
+    /** Best-effort server logout, then clears session + pending handshake. */
+    suspend fun signOut() {
+        accessToken()?.let { token ->
+            try {
+                transport.logout(token)
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (_: Exception) {
+                // Best-effort: local sign-out proceeds regardless.
+            }
+        }
+        storage.clearSession()
+        storage.clearPendingAuth()
+    }
+
+    private suspend fun readPendingAuth(): PendingAuth? = storage.readPendingAuth()?.let { stored ->
+        try {
+            json.decodeFromString(PendingAuth.serializer(), stored)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (_: Exception) {
+            null
+        }
+    }
+}
+
+/** Parses query parameters from a redirect URL (fragment ignored). */
+internal fun parseQueryParameters(url: String): Map<String, String> {
+    val query = url.substringAfter('?', missingDelimiterValue = "").substringBefore('#')
+    if (query.isEmpty()) return emptyMap()
+    return query
+        .split('&')
+        .filter { it.isNotEmpty() }
+        .associate { pair ->
+            val key = percentDecode(pair.substringBefore('='))
+            val value = percentDecode(pair.substringAfter('=', missingDelimiterValue = ""))
+            key to value
+        }
+}
+
+/** Decodes %XX sequences (UTF-8) and `+` as space. */
+internal fun percentDecode(value: String): String {
+    val bytes = ArrayList<Byte>(value.length)
+    var i = 0
+    while (i < value.length) {
+        val char = value[i]
+        when {
+            char == '+' -> {
+                bytes.add(' '.code.toByte())
+                i++
+            }
+            char == '%' && i + 2 < value.length -> {
+                val parsed = value.substring(i + 1, i + 3).toIntOrNull(16)
+                if (parsed == null) {
+                    bytes.add(char.code.toByte())
+                    i++
+                } else {
+                    bytes.add(parsed.toByte())
+                    i += 3
+                }
+            }
+            else -> {
+                for (byte in char.toString().encodeToByteArray()) {
+                    bytes.add(byte)
+                }
+                i++
+            }
+        }
+    }
+    return bytes.toByteArray().decodeToString()
+}

--- a/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/auth/MobileSessionManager.kt
+++ b/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/auth/MobileSessionManager.kt
@@ -65,6 +65,7 @@ class MobileSessionManager(
      * Starts the handshake: persists the pending `state`/`codeVerifier` and
      * hands the authorization URL to the platform launcher.
      */
+    @Throws(CancellationException::class, Exception::class)
     suspend fun beginSignIn(loginHint: String? = null): MobileAuthStartResponse {
         val response = transport.start(
             MobileAuthStartRequest(
@@ -95,6 +96,7 @@ class MobileSessionManager(
      * mismatch or provider error the pending handshake is kept — a correct
      * redirect for it can still arrive.
      */
+    @Throws(CancellationException::class, Exception::class)
     suspend fun handleRedirect(url: String): MobileAuthSession {
         val params = parseQueryParameters(url)
         params["error"]?.let { code ->
@@ -137,6 +139,7 @@ class MobileSessionManager(
      * Loads the session bootstrap with the stored bearer. A 401 clears the
      * stored session before rethrowing so callers re-enter sign-in.
      */
+    @Throws(CancellationException::class, Exception::class)
     suspend fun bootstrap(): MobileSessionBootstrap {
         val token = accessToken() ?: throw AuthUnauthorizedException("no stored session")
         return try {
@@ -153,6 +156,7 @@ class MobileSessionManager(
     }
 
     /** Best-effort server logout, then clears session + pending handshake. */
+    @Throws(CancellationException::class, Exception::class)
     suspend fun signOut() {
         accessToken()?.let { token ->
             try {
@@ -214,10 +218,21 @@ internal fun percentDecode(value: String): String {
                 }
             }
             else -> {
-                for (byte in char.toString().encodeToByteArray()) {
+                // Encode whole code points: a surrogate pair split into two
+                // single-char encodes would produce replacement bytes.
+                val end = if (
+                    char.isHighSurrogate() &&
+                    i + 1 < value.length &&
+                    value[i + 1].isLowSurrogate()
+                ) {
+                    i + 2
+                } else {
+                    i + 1
+                }
+                for (byte in value.substring(i, end).encodeToByteArray()) {
                     bytes.add(byte)
                 }
-                i++
+                i = end
             }
         }
     }

--- a/packages/smrt-mobile/src/commonTest/kotlin/com/happyvertical/smrt/mobile/auth/MobileSessionManagerTest.kt
+++ b/packages/smrt-mobile/src/commonTest/kotlin/com/happyvertical/smrt/mobile/auth/MobileSessionManagerTest.kt
@@ -1,0 +1,250 @@
+package com.happyvertical.smrt.mobile.auth
+
+import com.happyvertical.smrt.mobile.contract.MobileAuthCompleteRequest
+import com.happyvertical.smrt.mobile.contract.MobileAuthSession
+import com.happyvertical.smrt.mobile.contract.MobileAuthStartRequest
+import com.happyvertical.smrt.mobile.contract.MobileAuthStartResponse
+import com.happyvertical.smrt.mobile.contract.MobileSessionBootstrap
+import com.happyvertical.smrt.mobile.contract.MobileUserSummary
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private class FakeTransport : AuthTransport {
+    var startRequests = mutableListOf<MobileAuthStartRequest>()
+    var completeRequests = mutableListOf<MobileAuthCompleteRequest>()
+    var bootstrapTokens = mutableListOf<String>()
+    var logoutTokens = mutableListOf<String>()
+    var bootstrapUnauthorized = false
+    var logoutThrows = false
+
+    override suspend fun start(request: MobileAuthStartRequest): MobileAuthStartResponse {
+        startRequests.add(request)
+        return MobileAuthStartResponse(
+            providerId = request.providerId ?: "kanidm",
+            authorizationUrl = "https://idp.example.com/oauth/authorize?state=state-1",
+            state = "state-1",
+            codeVerifier = "verifier-1",
+            redirectUri = request.redirectUri,
+        )
+    }
+
+    override suspend fun complete(request: MobileAuthCompleteRequest): MobileAuthSession {
+        completeRequests.add(request)
+        return MobileAuthSession(
+            accessToken = "bearer-1",
+            user = MobileUserSummary(id = "user-1", email = "reporter@example.com"),
+        )
+    }
+
+    override suspend fun bootstrap(accessToken: String): MobileSessionBootstrap {
+        bootstrapTokens.add(accessToken)
+        if (bootstrapUnauthorized) throw AuthUnauthorizedException()
+        return MobileSessionBootstrap(user = MobileUserSummary(id = "user-1"))
+    }
+
+    override suspend fun logout(accessToken: String) {
+        logoutTokens.add(accessToken)
+        if (logoutThrows) throw IllegalStateException("network down")
+    }
+}
+
+private class RecordingLauncher : ExternalAuthLauncher {
+    val launched = mutableListOf<String>()
+
+    override fun launch(authorizationUrl: String) {
+        launched.add(authorizationUrl)
+    }
+}
+
+class MobileSessionManagerTest {
+    private val config = MobileAuthConfig(
+        redirectUri = "com.example.app://auth",
+        providerId = "kanidm",
+        scopes = listOf("openid"),
+    )
+
+    private fun manager(
+        transport: FakeTransport = FakeTransport(),
+        storage: AuthStorage = InMemoryAuthStorage(),
+        launcher: RecordingLauncher = RecordingLauncher(),
+    ) = MobileSessionManager(config, transport, storage, launcher)
+
+    @Test
+    fun fullHandshakeRoundTrip() = runTest {
+        val transport = FakeTransport()
+        val storage = InMemoryAuthStorage()
+        val launcher = RecordingLauncher()
+        val manager = MobileSessionManager(config, transport, storage, launcher)
+
+        val started = manager.beginSignIn(loginHint = "reporter@example.com")
+        assertEquals(listOf(started.authorizationUrl), launcher.launched)
+        assertEquals("reporter@example.com", transport.startRequests.single().loginHint)
+        assertNotNull(storage.readPendingAuth())
+
+        val session = manager.handleRedirect("com.example.app://auth?code=code-1&state=state-1")
+
+        assertEquals("bearer-1", session.accessToken)
+        val complete = transport.completeRequests.single()
+        assertEquals("code-1", complete.code)
+        assertEquals("state-1", complete.state)
+        assertEquals("verifier-1", complete.codeVerifier)
+        assertEquals("com.example.app://auth", complete.redirectUri)
+        assertNull(storage.readPendingAuth())
+        assertEquals("bearer-1", manager.accessToken())
+    }
+
+    @Test
+    fun handshakeSurvivesProcessRestart() = runTest {
+        val storage = InMemoryAuthStorage()
+        manager(storage = storage).beginSignIn()
+
+        // A fresh manager over the same storage (new process) completes it.
+        val restarted = manager(storage = storage)
+        val session = restarted.handleRedirect("com.example.app://auth?code=code-1&state=state-1")
+
+        assertEquals("bearer-1", session.accessToken)
+    }
+
+    @Test
+    fun stateMismatchIsRejectedAndPendingKept() = runTest {
+        val storage = InMemoryAuthStorage()
+        val manager = manager(storage = storage)
+        manager.beginSignIn()
+
+        assertFailsWith<AuthFailure.StateMismatch> {
+            manager.handleRedirect("com.example.app://auth?code=code-1&state=forged")
+        }
+        assertNotNull(storage.readPendingAuth())
+
+        // The genuine redirect still completes.
+        assertEquals(
+            "bearer-1",
+            manager.handleRedirect("com.example.app://auth?code=code-1&state=state-1").accessToken,
+        )
+    }
+
+    @Test
+    fun providerErrorSurfacesDecodedDescription() = runTest {
+        val manager = manager()
+        manager.beginSignIn()
+
+        val failure = assertFailsWith<AuthFailure.ProviderError> {
+            manager.handleRedirect(
+                "com.example.app://auth?error=access_denied&error_description=User%20cancelled+sign-in",
+            )
+        }
+        assertEquals("access_denied", failure.code)
+        assertEquals("access_denied: User cancelled sign-in", failure.message)
+    }
+
+    @Test
+    fun redirectWithoutPendingHandshakeFails() = runTest {
+        assertFailsWith<AuthFailure.NoPendingAuth> {
+            manager().handleRedirect("com.example.app://auth?code=c&state=s")
+        }
+    }
+
+    @Test
+    fun redirectWithoutCodeFails() = runTest {
+        val manager = manager()
+        manager.beginSignIn()
+
+        assertFailsWith<AuthFailure.MissingCode> {
+            manager.handleRedirect("com.example.app://auth?state=state-1")
+        }
+    }
+
+    @Test
+    fun sessionPersistsAcrossManagerInstances() = runTest {
+        val storage = InMemoryAuthStorage()
+        val first = manager(storage = storage)
+        first.beginSignIn()
+        first.handleRedirect("com.example.app://auth?code=code-1&state=state-1")
+
+        assertEquals("bearer-1", manager(storage = storage).accessToken())
+    }
+
+    @Test
+    fun corruptedStoredSessionReadsAsNull() = runTest {
+        val storage = InMemoryAuthStorage()
+        storage.writeSession("{not json")
+
+        assertNull(manager(storage = storage).currentSession())
+    }
+
+    @Test
+    fun bootstrapForwardsBearerAndClearsSessionOn401() = runTest {
+        val transport = FakeTransport()
+        val storage = InMemoryAuthStorage()
+        val manager = manager(transport = transport, storage = storage)
+        manager.beginSignIn()
+        manager.handleRedirect("com.example.app://auth?code=code-1&state=state-1")
+
+        manager.bootstrap()
+        assertEquals(listOf("bearer-1"), transport.bootstrapTokens)
+
+        transport.bootstrapUnauthorized = true
+        assertFailsWith<AuthUnauthorizedException> { manager.bootstrap() }
+        assertNull(storage.readSession())
+    }
+
+    @Test
+    fun bootstrapWithoutSessionIsUnauthorized() = runTest {
+        assertFailsWith<AuthUnauthorizedException> { manager().bootstrap() }
+    }
+
+    @Test
+    fun onUnauthorizedClearsStoredSession() = runTest {
+        val storage = InMemoryAuthStorage()
+        val manager = manager(storage = storage)
+        manager.beginSignIn()
+        manager.handleRedirect("com.example.app://auth?code=code-1&state=state-1")
+
+        manager.onUnauthorized()
+
+        assertNull(manager.accessToken())
+    }
+
+    @Test
+    fun signOutLogsOutAndClearsEvenWhenServerCallFails() = runTest {
+        val transport = FakeTransport().apply { logoutThrows = true }
+        val storage = InMemoryAuthStorage()
+        val manager = manager(transport = transport, storage = storage)
+        manager.beginSignIn()
+        manager.handleRedirect("com.example.app://auth?code=code-1&state=state-1")
+
+        manager.signOut()
+
+        assertEquals(listOf("bearer-1"), transport.logoutTokens)
+        assertNull(storage.readSession())
+        assertNull(storage.readPendingAuth())
+    }
+}
+
+class RedirectParsingTest {
+    @Test
+    fun parsesQueryParameters() {
+        val params = parseQueryParameters("app://auth?code=abc&state=xyz")
+
+        assertEquals("abc", params["code"])
+        assertEquals("xyz", params["state"])
+    }
+
+    @Test
+    fun ignoresFragmentAndHandlesMissingQuery() {
+        assertEquals("abc", parseQueryParameters("app://auth?code=abc#fragment")["code"])
+        assertTrue(parseQueryParameters("app://auth").isEmpty())
+    }
+
+    @Test
+    fun percentDecodesUtf8AndPlus() {
+        assertEquals("User cancelled sign-in", percentDecode("User%20cancelled+sign-in"))
+        assertEquals("café", percentDecode("caf%C3%A9"))
+        assertEquals("100%", percentDecode("100%"))
+    }
+}

--- a/packages/smrt-mobile/src/commonTest/kotlin/com/happyvertical/smrt/mobile/auth/MobileSessionManagerTest.kt
+++ b/packages/smrt-mobile/src/commonTest/kotlin/com/happyvertical/smrt/mobile/auth/MobileSessionManagerTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(InsecureAuthStorageApi::class)
+
 package com.happyvertical.smrt.mobile.auth
 
 import com.happyvertical.smrt.mobile.contract.MobileAuthCompleteRequest
@@ -246,5 +248,12 @@ class RedirectParsingTest {
         assertEquals("User cancelled sign-in", percentDecode("User%20cancelled+sign-in"))
         assertEquals("café", percentDecode("caf%C3%A9"))
         assertEquals("100%", percentDecode("100%"))
+    }
+
+    @Test
+    fun preservesSurrogatePairsInUnescapedInput() {
+        // Non-BMP characters (emoji) must survive undecoded passthrough.
+        assertEquals("🎉 done", percentDecode("🎉+done"))
+        assertEquals("ok 🚀", percentDecode("ok%20🚀"))
     }
 }


### PR DESCRIPTION
Phase 3 of the KMP mobile foundation (epic #1745, ADR 0001): the provider-agnostic PKCE auth/session module in `commonMain` — **net-new for amaru**, generalized from the anytown reporter's proven flow. Closes #1740.

**Stacked on #1751 (Phase 2)** — base is `feat/issue-1739-durable-offline-queue`; retarget down the stack as the parents merge (#1749 → #1751 → this).

## What's here

### `auth/MobileSessionManager.kt`
The reporter's flow with the app-specific constants factored into `MobileAuthConfig` (redirect URI, optional provider id, scopes):

- `beginSignIn()` → `POST /api/mobile/auth/start` (server-brokered PKCE — the server generates `state`/`codeVerifier`, per the live anytown implementation and the contract types landed in Phase 1) → **persists the pending handshake** → hands the authorization URL to the platform launcher. Persisting the handshake matters: the browser hand-off can outlive the app process (reporter parity — it kept `state`/`codeVerifier` in prefs).
- `handleRedirect(url)` → validates `state` against the persisted handshake (mismatch = rejected, handshake kept so the genuine redirect can still land), surfaces IdP `error`/`error_description` params, exchanges the code via `auth/complete`, persists the session, clears the handshake.
- `bootstrap()` → `GET /api/mobile/session` with the stored bearer; a 401 clears the session before rethrowing.
- `onUnauthorized()` — the 401 hook the Phase 4 networking client calls: clears the session; the durable write-queue keeps its entries (matching reporter's clear-bearer→re-auth flow).
- `signOut()` — best-effort server logout, then clears session + handshake.
- Redirect parsing is dependency-free `commonMain` (query params with UTF-8 percent-decoding and `+`-as-space).

### `auth/AuthSeams.kt`
- `AuthStorage` — durable session + pending-handshake slots. **Platform impls are Phases 5–6 (Keystore/Keychain)** — the reporter's SharedPreferences/UserDefaults storage carried an explicit "production should use Keychain" note, so secure storage is the upgrade this seam demands. `InMemoryAuthStorage` ships for tests/previews only.
- `AuthTransport` — the `/api/mobile/auth/*` + session endpoints; implemented by the Phase 4 Ktor client; `AuthUnauthorizedException` models 401.
- `ExternalAuthLauncher` — custom-tab / `ASWebAuthenticationSession` seam.

### Tests (commonTest — run on jvm/Android-unit/iOS-simulator lanes)
15 new cases: full handshake round-trip (start → launcher → redirect → complete with echoed `state`/`codeVerifier`/`redirectUri` → session persisted, handshake cleared); **handshake survives process restart**; forged-`state` rejection keeping the handshake; IdP error surfacing with decoded description; no-pending/missing-code failures; session persistence across instances; corrupted-storage tolerance; bootstrap bearer forwarding + 401-clears-session; sign-out resilience to server failure; redirect/percent-decoding parsing.

### Acceptance note
The plan's "full PKCE round-trip against a test IdP" is exercised here against a scripted transport; the *live* round-trip lands with Phase 3.5 (#1748 — smrt-users handlers, which Phase 4's integration tests will target end-to-end).

## Verification (local, macOS)
- `./gradlew build` — all targets, all test lanes green (49 jvm tests total)
- `pnpm --filter @happyvertical/smrt-mobile validate:shell` (35 files, 19 content checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
