### PR TITLE
feat(mobile): Phase 4 — shared KMP Ktor client (bearer + multipart + 401 hook)

### DIFF
--- a/packages/smrt-mobile/AGENTS.md
+++ b/packages/smrt-mobile/AGENTS.md
@@ -5,14 +5,14 @@ non-TypeScript package in the monorepo. Design: **ADR 0001**
 (`docs/content/adr/0001-kmp-mobile-foundation.md`) + extraction plan; epic
 #1745. Decision record: `README.md` here and issue #1737.
 
-**Status: Phase 3.** Present: framework contract types, pack i18n resolver,
-pack integrity/snapshot model, evidence-capture model, shell state, platform
-seams, the **durable SQLDelight-backed offline write-queue + pack store**
-(Phase 2, #1739), and the **PKCE auth/session module** (Phase 3, #1740).
-NOT here yet (later phases — do not add ad hoc): Ktor networking (Phase 4,
-#1741 — `AuthTransport`/`QueueSender` are its seams), platform adapters
-(Phases 5–6). **Productionize, don't lift** governs all porting from the
-seed apps.
+**Status: Phases 1–4 complete** — the shared-logic core. Present: framework
+contract types, pack i18n resolver, pack integrity/snapshot model,
+evidence-capture model, shell state, the **durable SQLDelight write-queue +
+pack store** (Phase 2, #1739), the **PKCE auth/session module** (Phase 3,
+#1740), and the **shared Ktor client** (Phase 4, #1741) implementing the
+`AuthTransport`/`QueueSender` seams. NOT here: platform adapters, engines,
+and secure-storage impls — those land with smrt-android/smrt-ios (Phases
+5–6). **Productionize, don't lift** governs all porting from the seed apps.
 
 ## Layout
 
@@ -36,6 +36,15 @@ consumers use Gradle `includeBuild`).
   `AuthTransport` (Phase 4 Ktor), `ExternalAuthLauncher` (custom tab /
   ASWebAuthenticationSession). `onUnauthorized()` is the networking client's
   401 hook: clears the session; the write-queue keeps its entries.
+- `src/commonMain/kotlin/.../network/` — `MobileApiClient`: engine-agnostic
+  Ktor client for the `/api/mobile` contract (apps supply okhttp/darwin
+  engines; tests use MockEngine). Bearer on every authenticated request;
+  multipart evidence upload; `Idempotency-Key` from the queue entry id;
+  401 → `UnauthorizedHandler` (wire to `MobileSessionManager.onUnauthorized`)
+  then `AuthUnauthorizedException`. `HttpQueueSender` maps HTTP outcomes to
+  the queue's `SendOutcome` semantics; request routing per entry kind is app
+  policy. No auto-retry — queued writes retry via flush triggers (reporter
+  parity).
 - `src/commonMain/kotlin/.../i18n/` — `PackTextResolver`: requested →
   fallback → source locale chain with review-state/safety-critical
   provenance.
@@ -102,8 +111,9 @@ wrapper is checked in — always invoke via `./gradlew`.
   renovate keeps these current; bump deliberately in
   `gradle/libs.versions.toml`.
 - commonMain dependencies stay minimal (kotlinx-serialization,
-  kotlinx-datetime, kotlinx-coroutines, SQLDelight runtime). Ktor arrives in
-  Phase 4. No other deps without an ADR note.
+  kotlinx-datetime, kotlinx-coroutines, SQLDelight runtime, ktor-client-core
+  as `api`). No engine deps here — consumers pick okhttp/darwin. No other
+  deps without an ADR note.
 - Adapter seams are plain Kotlin interfaces (amaru precedent), not
   `expect`/`actual`.
 - Wire DTO fields default-initialize (safe partial deserialization); decimals

--- a/packages/smrt-mobile/AGENTS.md
+++ b/packages/smrt-mobile/AGENTS.md
@@ -42,9 +42,14 @@ consumers use Gradle `includeBuild`).
   multipart evidence upload; `Idempotency-Key` from the queue entry id;
   401 → `UnauthorizedHandler` (wire to `MobileSessionManager.onUnauthorized`)
   then `AuthUnauthorizedException`. `HttpQueueSender` maps HTTP outcomes to
-  the queue's `SendOutcome` semantics; request routing per entry kind is app
-  policy. No auto-retry — queued writes retry via flush triggers (reporter
-  parity).
+  the queue's `SendOutcome` semantics **for the hand-written `/api/mobile`
+  single-item endpoints only** (4xx permanent except 408/429; the handlers
+  dedupe on `Idempotency-Key`). Framework-model writes need the planned
+  batch `sync/apply` sender instead (per-item statuses inside HTTP 200,
+  non-2xx retryable, dedupe by construction — see
+  `docs/content/architecture/sync-apply-contract.md`). Request routing per
+  entry kind is app policy. No auto-retry — queued writes retry via flush
+  triggers (reporter parity).
 - `src/commonMain/kotlin/.../i18n/` — `PackTextResolver`: requested →
   fallback → source locale chain with review-state/safety-critical
   provenance.

--- a/packages/smrt-mobile/README.md
+++ b/packages/smrt-mobile/README.md
@@ -86,7 +86,9 @@ in Phase 6, #1743).
 - Phase 3 (#1740) — **landed**: PKCE/OIDC session module (`MobileSessionManager`)
   with platform browser/deep-link/secure-storage seams.
 - Phase 3.5 (#1748): `/api/mobile` server handlers in `smrt-users`.
-- Phase 4 (#1741): shared Ktor client (bearer + multipart + retry).
+- Phase 4 (#1741) — **landed**: shared Ktor client (`MobileApiClient` +
+  `HttpQueueSender`): bearer everywhere, multipart with idempotency keys,
+  401 hook, queue flush end-to-end.
 - Phases 5–6 (#1742/#1743): `smrt-android` (Compose) and `smrt-ios` (SwiftUI +
   real KMP framework wiring).
 - Phase 7 (#1744): rebuild amaru FieldOps and anytown reporter on the

--- a/packages/smrt-mobile/build.gradle.kts
+++ b/packages/smrt-mobile/build.gradle.kts
@@ -42,11 +42,15 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.datetime)
             implementation(libs.kotlinx.serialization.json)
+            // Engine-agnostic on purpose: apps supply their platform engine
+            // (okhttp on Android, darwin on iOS); tests use MockEngine.
+            api(libs.ktor.client.core)
             implementation(libs.sqldelight.runtime)
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
             implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.ktor.client.mock)
         }
         jvmTest.dependencies {
             // Queue/store tests run against real SQLite on the JVM target —

--- a/packages/smrt-mobile/gradle/libs.versions.toml
+++ b/packages/smrt-mobile/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ kotlin = "2.4.0"
 kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.8.0-0.6.x-compat"
 kotlinx-serialization = "1.11.0"
+ktor = "3.2.0"
 sqldelight = "2.1.0"
 
 [libraries]
@@ -17,6 +18,8 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 sqldelight-runtime = { module = "app.cash.sqldelight:runtime", version.ref = "sqldelight" }
 sqldelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 

--- a/packages/smrt-mobile/scripts/validate-shell.mjs
+++ b/packages/smrt-mobile/scripts/validate-shell.mjs
@@ -95,6 +95,18 @@ const SPEC = [
     ],
   },
   {
+    path: `${KOTLIN_ROOT}/network/MobileApiClient.kt`,
+    mustContain: [
+      'class MobileApiClient(',
+      'suspend fun submitMultipart(',
+      'Idempotency-Key',
+    ],
+  },
+  {
+    path: `${KOTLIN_ROOT}/network/HttpQueueSender.kt`,
+    mustContain: ['class HttpQueueSender(', 'SendOutcome.Unauthorized'],
+  },
+  {
     path: `${KOTLIN_ROOT}/i18n/PackTextResolver.kt`,
     mustContain: ['class PackTextResolver(', 'fun resolve(key: String'],
   },
@@ -141,12 +153,14 @@ const SPEC = [
   // schema-evolution guardrail (see AGENTS.md § Schema changes).
   { path: 'src/commonMain/sqldelight/databases/1.db' },
   { path: `${TEST_ROOT}/auth/MobileSessionManagerTest.kt` },
+  { path: `${TEST_ROOT}/network/MobileApiClientTest.kt` },
   { path: `${TEST_ROOT}/i18n/PackTextResolverTest.kt` },
   { path: `${TEST_ROOT}/packs/PackIntegrityCheckTest.kt` },
   { path: `${TEST_ROOT}/shell/MobileShellStateTest.kt` },
   { path: `${TEST_ROOT}/evidence/EvidenceCaptureTest.kt` },
   { path: `${JVM_TEST_ROOT}/sync/DurableWriteQueueTest.kt` },
   { path: `${JVM_TEST_ROOT}/packs/DurableOfflinePackStoreTest.kt` },
+  { path: `${JVM_TEST_ROOT}/network/QueueFlushIntegrationTest.kt` },
 ];
 
 const failures = [];

--- a/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/network/HttpQueueSender.kt
+++ b/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/network/HttpQueueSender.kt
@@ -24,18 +24,27 @@ sealed interface QueueHttpRequest {
 }
 
 /**
- * The Phase 2 queue's transport, wired end-to-end through [MobileApiClient]
- * (ADR 0001 Phase 4). Outcome mapping carries the reporter semantics the
- * queue expects:
+ * The queue's transport for the HAND-WRITTEN `/api/mobile` endpoints
+ * (single-item semantics — anytown reference; issue #1748), wired through
+ * [MobileApiClient] (ADR 0001 Phase 4). Outcome mapping carries the
+ * reporter semantics the queue expects:
  *
  * - 2xx → [SendOutcome.Success] (entry removed)
  * - 401 → [SendOutcome.Unauthorized] (flush aborts; queue intact; the
  *   client has already fired its 401 hook)
+ * - 408/429 → [SendOutcome.Retryable] (transient by definition)
  * - other 4xx → [SendOutcome.Rejected] (permanent; entry removed)
  * - 5xx / transport failure → [SendOutcome.Retryable] (until the cap)
  *
- * The entry id travels as the `Idempotency-Key`, so a retry of an entry the
- * server already accepted dedupes server-side.
+ * The entry id travels as the `Idempotency-Key`; the `/api/mobile`
+ * handlers dedupe re-sent POSTs on it.
+ *
+ * Framework-MODEL writes are a different contract: core's `sync/apply`
+ * batch endpoint (docs/content/architecture/sync-apply-contract.md, which
+ * names this queue as a consumer) returns per-item statuses inside
+ * HTTP 200, treats any non-2xx batch response as retryable, and dedupes by
+ * construction (no header). A batch-shaped sync/apply sender is planned as
+ * a follow-up — do not point this single-item sender at `sync/apply`.
  */
 class HttpQueueSender(
     private val client: MobileApiClient,
@@ -66,6 +75,9 @@ class HttpQueueSender(
 
         return when {
             response.isSuccess -> SendOutcome.Success
+            // Request-timeout and rate-limit are transient, not verdicts.
+            response.status == 408 || response.status == 429 ->
+                SendOutcome.Retryable("http ${response.status}")
             response.status in 400..499 -> SendOutcome.Rejected("http ${response.status}")
             else -> SendOutcome.Retryable("http ${response.status}")
         }

--- a/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/network/HttpQueueSender.kt
+++ b/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/network/HttpQueueSender.kt
@@ -1,0 +1,73 @@
+package com.happyvertical.smrt.mobile.network
+
+import com.happyvertical.smrt.mobile.auth.AuthUnauthorizedException
+import com.happyvertical.smrt.mobile.sync.QueueEntry
+import com.happyvertical.smrt.mobile.sync.QueueSender
+import com.happyvertical.smrt.mobile.sync.SendOutcome
+import kotlinx.coroutines.CancellationException
+
+/**
+ * How a queue entry becomes an HTTP request. Routing is app policy (the
+ * queue payload/kind are app-defined); the outcome mapping below is the
+ * framework's.
+ */
+sealed interface QueueHttpRequest {
+    /** POST the entry's JSON payload to [path]. */
+    data class JsonPost(val path: String) : QueueHttpRequest
+
+    /** POST a multipart submission (evidence/media upload) to [path]. */
+    data class Multipart(
+        val path: String,
+        val fields: Map<String, String>,
+        val files: List<MobileUploadPart>,
+    ) : QueueHttpRequest
+}
+
+/**
+ * The Phase 2 queue's transport, wired end-to-end through [MobileApiClient]
+ * (ADR 0001 Phase 4). Outcome mapping carries the reporter semantics the
+ * queue expects:
+ *
+ * - 2xx → [SendOutcome.Success] (entry removed)
+ * - 401 → [SendOutcome.Unauthorized] (flush aborts; queue intact; the
+ *   client has already fired its 401 hook)
+ * - other 4xx → [SendOutcome.Rejected] (permanent; entry removed)
+ * - 5xx / transport failure → [SendOutcome.Retryable] (until the cap)
+ *
+ * The entry id travels as the `Idempotency-Key`, so a retry of an entry the
+ * server already accepted dedupes server-side.
+ */
+class HttpQueueSender(
+    private val client: MobileApiClient,
+    private val requestForEntry: (QueueEntry) -> QueueHttpRequest,
+) : QueueSender {
+    override suspend fun send(entry: QueueEntry): SendOutcome {
+        val response = try {
+            when (val plan = requestForEntry(entry)) {
+                is QueueHttpRequest.JsonPost -> client.postJson(
+                    path = plan.path,
+                    body = entry.payload,
+                    idempotencyKey = entry.id,
+                )
+                is QueueHttpRequest.Multipart -> client.submitMultipart(
+                    path = plan.path,
+                    fields = plan.fields,
+                    files = plan.files,
+                    idempotencyKey = entry.id,
+                )
+            }
+        } catch (unauthorized: AuthUnauthorizedException) {
+            return SendOutcome.Unauthorized
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (failure: Exception) {
+            return SendOutcome.Retryable(failure.message ?: "network failure")
+        }
+
+        return when {
+            response.isSuccess -> SendOutcome.Success
+            response.status in 400..499 -> SendOutcome.Rejected("http ${response.status}")
+            else -> SendOutcome.Retryable("http ${response.status}")
+        }
+    }
+}

--- a/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/network/MobileApiClient.kt
+++ b/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/network/MobileApiClient.kt
@@ -133,9 +133,14 @@ class MobileApiClient(
         execute(HttpMethod.Delete, path, bearer = tokenProvider.accessToken())
 
     /**
-     * Streams a multipart/form-data submission (evidence upload): plain
+     * Sends a multipart/form-data submission (evidence upload): plain
      * fields plus file parts, with the entry id as `Idempotency-Key` so the
      * server dedupes re-sent queue entries.
+     *
+     * v0 buffers each part as a [ByteArray] — sized for reporter-parity
+     * photo evidence. True streamed parts (kotlinx-io sources fed by
+     * platform file handles) land with the platform file seams in
+     * Phases 5-6; don't push video-scale uploads through this until then.
      */
     suspend fun submitMultipart(
         path: String,

--- a/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/network/MobileApiClient.kt
+++ b/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/network/MobileApiClient.kt
@@ -1,0 +1,214 @@
+package com.happyvertical.smrt.mobile.network
+
+import com.happyvertical.smrt.mobile.auth.AuthTransport
+import com.happyvertical.smrt.mobile.auth.AuthUnauthorizedException
+import com.happyvertical.smrt.mobile.contract.MobileAuthCompleteRequest
+import com.happyvertical.smrt.mobile.contract.MobileAuthSession
+import com.happyvertical.smrt.mobile.contract.MobileAuthStartRequest
+import com.happyvertical.smrt.mobile.contract.MobileAuthStartResponse
+import com.happyvertical.smrt.mobile.contract.MobileSessionBootstrap
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.timeout
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
+import io.ktor.client.request.header
+import io.ktor.client.request.request
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.json.Json
+
+/**
+ * Shared KMP HTTP client for the `/api/mobile` contract (ADR 0001 Phase 4) —
+ * replaces both seed apps' raw HttpURLConnection/URLSession transports.
+ * Carries the reporter's networking semantics: bearer on every
+ * authenticated request, multipart evidence upload with an idempotency key,
+ * and 401 → [UnauthorizedHandler] (the [com.happyvertical.smrt.mobile.auth.MobileSessionManager]
+ * hook) before failing. Retry of queued writes stays trigger-driven in
+ * `DurableWriteQueue` — this client does not auto-retry (reporter parity).
+ */
+data class MobileApiConfig(
+    val baseUrl: String,
+    val apiPath: String = "/api/mobile",
+    val requestTimeoutMs: Long = 20_000,
+    val uploadTimeoutMs: Long = 60_000,
+)
+
+fun interface BearerTokenProvider {
+    suspend fun accessToken(): String?
+}
+
+fun interface UnauthorizedHandler {
+    suspend fun onUnauthorized()
+}
+
+/** One uploaded file part of a multipart submission. */
+data class MobileUploadPart(
+    val fileName: String,
+    val contentType: String,
+    val bytes: ByteArray,
+    val fieldName: String = "file",
+)
+
+/** A raw response envelope; apps decode with the contract serializers. */
+data class MobileApiResponse(
+    val status: Int,
+    val body: String,
+) {
+    val isSuccess: Boolean get() = status in 200..299
+}
+
+class MobileApiClient(
+    engine: HttpClientEngine,
+    private val config: MobileApiConfig,
+    private val tokenProvider: BearerTokenProvider,
+    private val unauthorizedHandler: UnauthorizedHandler = UnauthorizedHandler {},
+) : AuthTransport {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    private val client = HttpClient(engine) {
+        expectSuccess = false
+        install(HttpTimeout) {
+            requestTimeoutMillis = config.requestTimeoutMs
+        }
+    }
+
+    // ---- AuthTransport ----
+
+    override suspend fun start(request: MobileAuthStartRequest): MobileAuthStartResponse =
+        postJson(
+            path = "auth/start",
+            body = json.encodeToString(MobileAuthStartRequest.serializer(), request),
+            authenticated = false,
+        ).decodeOrThrow(MobileAuthStartResponse.serializer())
+
+    override suspend fun complete(request: MobileAuthCompleteRequest): MobileAuthSession =
+        postJson(
+            path = "auth/complete",
+            body = json.encodeToString(MobileAuthCompleteRequest.serializer(), request),
+            authenticated = false,
+        ).decodeOrThrow(MobileAuthSession.serializer())
+
+    override suspend fun bootstrap(accessToken: String): MobileSessionBootstrap =
+        execute(HttpMethod.Get, "session", bearer = accessToken)
+            .decodeOrThrow(MobileSessionBootstrap.serializer())
+
+    override suspend fun logout(accessToken: String) {
+        execute(HttpMethod.Delete, "session", bearer = accessToken)
+    }
+
+    // ---- Generic surface (queue sender + app calls) ----
+
+    suspend fun get(path: String): MobileApiResponse =
+        execute(HttpMethod.Get, path, bearer = tokenProvider.accessToken())
+
+    suspend fun postJson(
+        path: String,
+        body: String,
+        idempotencyKey: String? = null,
+        authenticated: Boolean = true,
+    ): MobileApiResponse = execute(
+        method = HttpMethod.Post,
+        path = path,
+        bearer = if (authenticated) tokenProvider.accessToken() else null,
+        idempotencyKey = idempotencyKey,
+    ) {
+        contentType(ContentType.Application.Json)
+        setBody(body)
+    }
+
+    suspend fun delete(path: String): MobileApiResponse =
+        execute(HttpMethod.Delete, path, bearer = tokenProvider.accessToken())
+
+    /**
+     * Streams a multipart/form-data submission (evidence upload): plain
+     * fields plus file parts, with the entry id as `Idempotency-Key` so the
+     * server dedupes re-sent queue entries.
+     */
+    suspend fun submitMultipart(
+        path: String,
+        fields: Map<String, String>,
+        files: List<MobileUploadPart>,
+        idempotencyKey: String? = null,
+    ): MobileApiResponse = execute(
+        method = HttpMethod.Post,
+        path = path,
+        bearer = tokenProvider.accessToken(),
+        idempotencyKey = idempotencyKey,
+        timeoutMs = config.uploadTimeoutMs,
+    ) {
+        setBody(
+            MultiPartFormDataContent(
+                formData {
+                    for ((name, value) in fields) {
+                        append(name, value)
+                    }
+                    for (part in files) {
+                        append(
+                            part.fieldName,
+                            part.bytes,
+                            Headers.build {
+                                append(HttpHeaders.ContentType, part.contentType)
+                                append(
+                                    HttpHeaders.ContentDisposition,
+                                    "filename=\"${part.fileName}\"",
+                                )
+                            },
+                        )
+                    }
+                },
+            ),
+        )
+    }
+
+    private suspend fun execute(
+        method: HttpMethod,
+        path: String,
+        bearer: String?,
+        idempotencyKey: String? = null,
+        timeoutMs: Long? = null,
+        configure: HttpRequestBuilder.() -> Unit = {},
+    ): MobileApiResponse {
+        val response = client.request(url(path)) {
+            this.method = method
+            header(HttpHeaders.Accept, ContentType.Application.Json.toString())
+            bearer?.let { header(HttpHeaders.Authorization, "Bearer $it") }
+            idempotencyKey?.let { header("Idempotency-Key", it) }
+            timeoutMs?.let { uploadTimeout ->
+                timeout { requestTimeoutMillis = uploadTimeout }
+            }
+            configure()
+        }
+        if (response.status == HttpStatusCode.Unauthorized) {
+            unauthorizedHandler.onUnauthorized()
+            throw AuthUnauthorizedException("401 from ${url(path)}")
+        }
+        return MobileApiResponse(status = response.status.value, body = response.bodyAsText())
+    }
+
+    private fun url(path: String): String =
+        "${config.baseUrl.trimEnd('/')}${config.apiPath}/${path.trimStart('/')}"
+
+    private fun <T> MobileApiResponse.decodeOrThrow(strategy: DeserializationStrategy<T>): T {
+        if (!isSuccess) {
+            throw MobileApiException(status, body)
+        }
+        return json.decodeFromString(strategy, body)
+    }
+}
+
+/** A non-401 error response from the mobile API. */
+class MobileApiException(val status: Int, val responseBody: String) :
+    Exception("mobile api returned http $status")

--- a/packages/smrt-mobile/src/commonTest/kotlin/com/happyvertical/smrt/mobile/network/MobileApiClientTest.kt
+++ b/packages/smrt-mobile/src/commonTest/kotlin/com/happyvertical/smrt/mobile/network/MobileApiClientTest.kt
@@ -197,6 +197,20 @@ class HttpQueueSenderTest {
     }
 
     @Test
+    fun transientClientErrorsMapToRetryable() = runTest {
+        // 408/429 are transient, not verdicts — they must not consume the
+        // entry like other 4xx rejections do.
+        for (status in listOf(HttpStatusCode.RequestTimeout, HttpStatusCode.TooManyRequests)) {
+            val engine = MockEngine { respond("busy", status) }
+
+            val outcome = sender(engine).send(entry())
+
+            assertTrue(outcome is SendOutcome.Retryable, "expected Retryable for $status")
+            assertEquals("http ${status.value}", outcome.reason)
+        }
+    }
+
+    @Test
     fun unauthorizedMapsAndFiresHook() = runTest {
         val engine = MockEngine { respond("denied", HttpStatusCode.Unauthorized) }
         var hookCalls = 0

--- a/packages/smrt-mobile/src/commonTest/kotlin/com/happyvertical/smrt/mobile/network/MobileApiClientTest.kt
+++ b/packages/smrt-mobile/src/commonTest/kotlin/com/happyvertical/smrt/mobile/network/MobileApiClientTest.kt
@@ -1,0 +1,219 @@
+package com.happyvertical.smrt.mobile.network
+
+import com.happyvertical.smrt.mobile.auth.AuthUnauthorizedException
+import com.happyvertical.smrt.mobile.contract.MobileAuthStartRequest
+import com.happyvertical.smrt.mobile.sync.QueueEntry
+import com.happyvertical.smrt.mobile.sync.SendOutcome
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val START_RESPONSE = """
+{
+  "providerId": "kanidm",
+  "authorizationUrl": "https://idp.example.com/authorize",
+  "state": "state-1",
+  "codeVerifier": "verifier-1",
+  "redirectUri": "app://auth"
+}
+"""
+
+private fun jsonHeaders() = headersOf(HttpHeaders.ContentType, "application/json")
+
+private fun client(
+    engine: MockEngine,
+    token: String? = "token-1",
+    onUnauthorized: UnauthorizedHandler = UnauthorizedHandler {},
+) = MobileApiClient(
+    engine = engine,
+    config = MobileApiConfig(baseUrl = "https://app.example.com/"),
+    tokenProvider = { token },
+    unauthorizedHandler = onUnauthorized,
+)
+
+class MobileApiClientTest {
+    @Test
+    fun startPostsJsonWithoutBearerAndDecodes() = runTest {
+        val engine = MockEngine { respond(START_RESPONSE, HttpStatusCode.OK, jsonHeaders()) }
+
+        val response = client(engine).start(
+            MobileAuthStartRequest(providerId = "kanidm", redirectUri = "app://auth"),
+        )
+
+        assertEquals("state-1", response.state)
+        val request = engine.requestHistory.single()
+        assertEquals(HttpMethod.Post, request.method)
+        assertEquals("https://app.example.com/api/mobile/auth/start", request.url.toString())
+        assertNull(request.headers[HttpHeaders.Authorization])
+        val body = request.body.toByteArray().decodeToString()
+        assertTrue(body.contains("\"providerId\":\"kanidm\""))
+        assertTrue(body.contains("\"redirectUri\":\"app://auth\""))
+    }
+
+    @Test
+    fun authenticatedRequestsCarryBearerAndAccept() = runTest {
+        val engine = MockEngine { respond("{}", HttpStatusCode.OK, jsonHeaders()) }
+
+        client(engine).get("events/nearby?lat=50.4&lng=-104.6")
+
+        val request = engine.requestHistory.single()
+        assertEquals("Bearer token-1", request.headers[HttpHeaders.Authorization])
+        assertEquals("application/json", request.headers[HttpHeaders.Accept])
+        assertEquals(
+            "https://app.example.com/api/mobile/events/nearby?lat=50.4&lng=-104.6",
+            request.url.toString(),
+        )
+    }
+
+    @Test
+    fun unauthorizedResponseFiresHookAndThrows() = runTest {
+        val engine = MockEngine { respond("denied", HttpStatusCode.Unauthorized) }
+        var hookCalls = 0
+
+        assertFailsWith<AuthUnauthorizedException> {
+            client(engine, onUnauthorized = { hookCalls++ }).get("session")
+        }
+        assertEquals(1, hookCalls)
+    }
+
+    @Test
+    fun bootstrapAndLogoutUseExplicitBearer() = runTest {
+        val engine = MockEngine { request ->
+            if (request.method == HttpMethod.Delete) {
+                respond("", HttpStatusCode.NoContent)
+            } else {
+                respond("""{"user":{"id":"u1"}}""", HttpStatusCode.OK, jsonHeaders())
+            }
+        }
+        val apiClient = client(engine, token = null)
+
+        apiClient.bootstrap("explicit-bearer")
+        apiClient.logout("explicit-bearer")
+
+        assertEquals(2, engine.requestHistory.size)
+        assertTrue(
+            engine.requestHistory.all {
+                it.headers[HttpHeaders.Authorization] == "Bearer explicit-bearer"
+            },
+        )
+        assertEquals(HttpMethod.Delete, engine.requestHistory[1].method)
+    }
+
+    @Test
+    fun non2xxContractResponseThrowsApiException() = runTest {
+        val engine = MockEngine { respond("boom", HttpStatusCode.InternalServerError) }
+
+        val failure = assertFailsWith<MobileApiException> {
+            client(engine).start(MobileAuthStartRequest(redirectUri = "app://auth"))
+        }
+        assertEquals(500, failure.status)
+    }
+
+    @Test
+    fun multipartCarriesFieldsFilesBearerAndIdempotencyKey() = runTest {
+        val engine = MockEngine { respond("""{"id":"c1"}""", HttpStatusCode.Created, jsonHeaders()) }
+
+        client(engine).submitMultipart(
+            path = "contributions",
+            fields = mapOf("eventId" to "event-1", "note" to "hail damage"),
+            files = listOf(
+                MobileUploadPart(
+                    fileName = "asset-1.jpg",
+                    contentType = "image/jpeg",
+                    bytes = "jpegbytes".encodeToByteArray(),
+                ),
+            ),
+            idempotencyKey = "entry-1",
+        )
+
+        val request = engine.requestHistory.single()
+        assertEquals("entry-1", request.headers["Idempotency-Key"])
+        assertEquals("Bearer token-1", request.headers[HttpHeaders.Authorization])
+        val contentType = request.body.contentType.toString()
+        assertTrue(contentType.startsWith("multipart/form-data"), contentType)
+        val body = request.body.toByteArray().decodeToString()
+        assertTrue(body.contains("name=eventId") || body.contains("name=\"eventId\""))
+        assertTrue(body.contains("filename=\"asset-1.jpg\""))
+        assertTrue(body.contains("jpegbytes"))
+    }
+}
+
+class HttpQueueSenderTest {
+    private fun entry(id: String = "e1") = QueueEntry(
+        id = id,
+        kind = "capture",
+        tenantId = "",
+        payload = """{"eventId":"event-1"}""",
+        state = "uploading",
+        attemptCount = 1,
+        lastError = "",
+        createdAtEpochMs = 0,
+        updatedAtEpochMs = 0,
+    )
+
+    private fun sender(engine: MockEngine, onUnauthorized: UnauthorizedHandler = UnauthorizedHandler {}) =
+        HttpQueueSender(client(engine, onUnauthorized = onUnauthorized)) {
+            QueueHttpRequest.JsonPost("contributions")
+        }
+
+    @Test
+    fun successMapsFrom2xx() = runTest {
+        val engine = MockEngine { respond("""{"id":"c1"}""", HttpStatusCode.Created, jsonHeaders()) }
+
+        assertEquals(SendOutcome.Success, sender(engine).send(entry()))
+        val request = engine.requestHistory.single()
+        assertEquals("e1", request.headers["Idempotency-Key"])
+        assertTrue(request.body.toByteArray().decodeToString().contains("event-1"))
+    }
+
+    @Test
+    fun clientErrorMapsToRejected() = runTest {
+        val engine = MockEngine { respond("bad", HttpStatusCode.UnprocessableEntity) }
+
+        val outcome = sender(engine).send(entry())
+
+        assertTrue(outcome is SendOutcome.Rejected)
+        assertEquals("http 422", outcome.reason)
+    }
+
+    @Test
+    fun serverErrorMapsToRetryable() = runTest {
+        val engine = MockEngine { respond("down", HttpStatusCode.ServiceUnavailable) }
+
+        val outcome = sender(engine).send(entry())
+
+        assertTrue(outcome is SendOutcome.Retryable)
+        assertEquals("http 503", outcome.reason)
+    }
+
+    @Test
+    fun unauthorizedMapsAndFiresHook() = runTest {
+        val engine = MockEngine { respond("denied", HttpStatusCode.Unauthorized) }
+        var hookCalls = 0
+
+        val outcome = sender(engine, onUnauthorized = { hookCalls++ }).send(entry())
+
+        assertEquals(SendOutcome.Unauthorized, outcome)
+        assertEquals(1, hookCalls)
+    }
+
+    @Test
+    fun transportFailureMapsToRetryable() = runTest {
+        val engine = MockEngine { throw RuntimeException("connection reset") }
+
+        val outcome = sender(engine).send(entry())
+
+        assertTrue(outcome is SendOutcome.Retryable)
+        assertTrue(outcome.reason.contains("connection reset"))
+    }
+}

--- a/packages/smrt-mobile/src/jvmTest/kotlin/com/happyvertical/smrt/mobile/network/QueueFlushIntegrationTest.kt
+++ b/packages/smrt-mobile/src/jvmTest/kotlin/com/happyvertical/smrt/mobile/network/QueueFlushIntegrationTest.kt
@@ -1,0 +1,105 @@
+package com.happyvertical.smrt.mobile.network
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.happyvertical.smrt.mobile.db.SmrtMobileDatabase
+import com.happyvertical.smrt.mobile.sync.DurableWriteQueue
+import com.happyvertical.smrt.mobile.sync.NewQueueEntry
+import com.happyvertical.smrt.mobile.sync.QueueEntryState
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Phase 4 acceptance: the durable queue flushes end-to-end through the
+ * shared Ktor client — bearer on every request, idempotency keys attached,
+ * and the reporter outcome semantics driving queue state.
+ */
+class QueueFlushIntegrationTest {
+    private fun newQueue(): DurableWriteQueue {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        SmrtMobileDatabase.Schema.create(driver)
+        return DurableWriteQueue(SmrtMobileDatabase(driver))
+    }
+
+    private fun sender(engine: MockEngine): HttpQueueSender {
+        val client = MobileApiClient(
+            engine = engine,
+            config = MobileApiConfig(baseUrl = "https://app.example.com"),
+            tokenProvider = { "bearer-1" },
+        )
+        return HttpQueueSender(client) { entry ->
+            if (entry.kind == "evidence") {
+                QueueHttpRequest.Multipart(
+                    path = "contributions",
+                    fields = mapOf("eventId" to "event-1"),
+                    files = listOf(
+                        MobileUploadPart(
+                            fileName = "asset.jpg",
+                            contentType = "image/jpeg",
+                            bytes = "img".encodeToByteArray(),
+                        ),
+                    ),
+                )
+            } else {
+                QueueHttpRequest.JsonPost("plays")
+            }
+        }
+    }
+
+    @Test
+    fun queueDrainsThroughTheHttpClient() = runBlocking {
+        val engine = MockEngine {
+            respond("""{"id":"c1"}""", HttpStatusCode.Created, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        val queue = newQueue()
+        queue.enqueue(NewQueueEntry(id = "e1", kind = "play", payload = """{"statKey":"goal"}"""))
+        queue.enqueue(NewQueueEntry(id = "e2", kind = "evidence", payload = """{"eventId":"event-1"}"""))
+
+        val summary = queue.flush(sender(engine))
+
+        assertEquals(2, summary.sent)
+        assertTrue(queue.all().isEmpty())
+        assertEquals(2, engine.requestHistory.size)
+        assertTrue(engine.requestHistory.all { it.headers[HttpHeaders.Authorization] == "Bearer bearer-1" })
+        assertEquals(listOf("e1", "e2"), engine.requestHistory.map { it.headers["Idempotency-Key"] })
+        assertTrue(
+            engine.requestHistory[1].body.contentType.toString().startsWith("multipart/form-data"),
+        )
+    }
+
+    @Test
+    fun serverOutageLeavesEntriesPendingForNextTrigger() = runBlocking {
+        val engine = MockEngine { respond("down", HttpStatusCode.ServiceUnavailable) }
+        val queue = newQueue()
+        queue.enqueue(NewQueueEntry(id = "e1", kind = "play", payload = "{}"))
+
+        val summary = queue.flush(sender(engine))
+
+        assertEquals(1, summary.retried)
+        val entry = queue.pending().single()
+        assertEquals(1, entry.attemptCount)
+        assertEquals("http 503", entry.lastError)
+    }
+
+    @Test
+    fun expiredBearerAbortsFlushAndKeepsQueueIntact() = runBlocking {
+        val engine = MockEngine { respond("denied", HttpStatusCode.Unauthorized) }
+        val queue = newQueue()
+        queue.enqueue(NewQueueEntry(id = "e1", kind = "play", payload = "{}"))
+        queue.enqueue(NewQueueEntry(id = "e2", kind = "play", payload = "{}"))
+
+        val summary = queue.flush(sender(engine))
+
+        assertTrue(summary.unauthorized)
+        assertEquals(2, queue.all().size)
+        assertTrue(queue.all().all { it.state == QueueEntryState.PENDING })
+        // Only the first entry hit the wire before the abort.
+        assertEquals(1, engine.requestHistory.size)
+    }
+}


### PR DESCRIPTION
Phase 4 of the KMP mobile foundation (epic #1745, ADR 0001): **one shared HTTP client in `commonMain`**, replacing both seed apps' raw `HttpURLConnection`/`URLSession` transports and closing the loop on the Phase 2/3 seams. Closes #1741.

**Stacked on #1752 (Phase 3)** — base `feat/issue-1740-auth-session`; retarget down the stack as parents merge (#1749 → #1751 → #1752 → this). With this, the shared-logic core (Phases 1–4) is complete; what remains is platform work (5/6), the server handlers (3.5, #1748), and the consumer rebuilds (7).

## What's here

### `network/MobileApiClient.kt` (Ktor 3.2.0, engine-agnostic)
- Implements Phase 3's `AuthTransport`: `auth/start` / `auth/complete` (unauthenticated), `session` bootstrap GET / logout DELETE with explicit bearer.
- Generic authenticated surface for apps and the queue: `get` / `postJson` / `delete` / `submitMultipart`. Bearer comes from a `BearerTokenProvider` (wire to `MobileSessionManager::accessToken`) on every authenticated request — the reporter invariant.
- **Multipart evidence upload**: fields + file parts with per-part content type and filename, `Idempotency-Key` header carrying the queue-entry id (the server dedupe contract verified in Phase 0 research), and the longer upload timeout (60s vs 20s — reporter's values).
- **401 semantics**: any 401 fires the `UnauthorizedHandler` (wire to `MobileSessionManager::onUnauthorized` — clears the session, queue entries stay) then raises `AuthUnauthorizedException`.
- **No auto-retry by design**: queued writes retry via the queue's flush triggers (reporter parity — trigger-driven, battery-friendly); non-queued reads surface failures to the caller.
- Engine-agnostic on purpose: `ktor-client-core` is an `api` dependency; apps supply `okhttp`/`darwin` engines (Phases 5–6 sample apps); tests use `MockEngine`.

### `network/HttpQueueSender.kt`
The Phase 2 queue's transport: apps route entries (`kind` → `JsonPost`/`Multipart` plan); the framework owns the outcome mapping — 2xx → `Success` (entry removed), 401 → `Unauthorized` (flush aborts, queue intact), other 4xx → `Rejected`, 5xx/transport failure → `Retryable` (until the attempt cap).

### Tests
- 11 commonTest cases (MockEngine, run on jvm/Android-unit/iOS-simulator lanes): request shapes (URL building, Accept, bearer present/absent), 401 hook firing, contract decode + `MobileApiException` on non-2xx, multipart body/boundary/idempotency assertions, and the full `SendOutcome` mapping table including transport exceptions.
- 3 jvmTest **end-to-end** cases (real SQLite queue + `HttpQueueSender` + MockEngine) — the plan's acceptance: queue drains through the client (bearer + idempotency keys on the wire, multipart for evidence kinds); a 503 leaves entries `pending` with `lastError` for the next trigger; an expired bearer aborts the flush after one request with the queue intact.

## Verification (local, macOS)
- `./gradlew build` — all targets, all test lanes green
- `pnpm --filter @happyvertical/smrt-mobile validate:shell`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
