### PR TITLE
fix: tenant public-read leak, TS config loader, oxc decorator attribution + docs (#1782–#1785)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ From [@happyvertical/sdk](https://github.com/happyvertical/sdk): `@happyvertical
 ## Gotchas
 
 - **Vitest plugin required**: without `smrtVitestPlugin()` in vitest.config.ts → "No field metadata" errors
-- **Vite decorators**: needs `esbuild.tsconfigRaw` with `experimentalDecorators: true, emitDecoratorMetadata: true`
+- **Vite decorators**: under Vite 8 set `oxc: { decorator: { legacy: true, emitDecoratorMetadata: true } }` in `vite.config.ts` (see `packages/template-sveltekit/template/vite.config.ts`) — the oxc transform ignores the pre-Vite-8 `esbuild.tsconfigRaw` / tsconfig `experimentalDecorators` through SvelteKit's `extends` chain, so that recipe throws `SyntaxError: Invalid or unexpected token` on the first SSR request. Consumers pinned on vite<8 still need the legacy `esbuild.tsconfigRaw` form.
 - **Manifest is build-time**: generated once at vitest startup — restart after adding new `@smrt()` classes
 - **ObjectRegistry on globalThis**: singleton via `globalThis.__smrtRegistry*` — survives HMR
 - **No runtime schema creation**: application tables must be prepared explicitly via migrations/tooling; runtime only verifies and fails clearly

--- a/docs/content/core.md
+++ b/docs/content/core.md
@@ -474,6 +474,32 @@ Notes:
 - Reserve the opt-in for responses that are identical for every requester; it is distinct from the top-level `@smrt({ cache })` knob, which configures the server-side collection read-through cache.
 - Mutations (`create`/`update`/`delete`) and custom action routes are unaffected.
 
+### Tenant-Scoped Public Reads Fail Closed to Global Rows
+
+A tenant-scoped model (`@smrt({ tenantScoped })` or `@TenantScoped()`) that is
+also marked `api: { public: true | 'read' }` can be read without authentication.
+Such a request carries no tenant context, so — left unguarded — the generated
+read would return rows from **every** tenant to an anonymous caller.
+
+Generated reads fail closed instead. When tenancy is enabled but no tenant
+context is active, `list`, `get /:id`, and `count` are restricted to
+**NULL-tenant (global) rows only** on both transports (the REST generator and
+the generated SvelteKit routes), mirroring the dispatch resolver and `_changes`
+convention: *tenancy enforced with no context → global rows only*. A
+client-supplied `?tenantId=` / `?tenant_id=` query param cannot widen the scope.
+
+| Request against a tenant-scoped `public` model | Rows returned |
+|-----------------------------------------------|---------------|
+| No tenant context (anonymous), tenancy enabled | NULL-tenant (global) rows only |
+| Active tenant context (authenticated) | that tenant's rows (interceptor-filtered) |
+| Tenancy disabled | all rows (no isolation to enforce) |
+
+Registering the `tenantScoped` + `api.public` combination logs a one-time
+warning so the global-only behavior is not mistaken for a broken endpoint. If
+per-tenant public reads are intended, resolve a tenant from the request itself
+(host, subdomain, or path) and enter that tenant context before the read. This
+scoping applies to reads only; mutations always require authentication.
+
 ### MCP Server Generation
 
 ```typescript

--- a/packages/cli/src/commands/__tests__/issue-1783-ts-config.test.ts
+++ b/packages/cli/src/commands/__tests__/issue-1783-ts-config.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Regression test for issue #1783: `smrt db:setup` / `db:migrate` cannot load a
+ * TypeScript `smrt.config.ts`.
+ *
+ * The SvelteKit template scaffolds its config as `smrt.config.ts` (TS by
+ * default). The CLI loads config at startup via `loadConfig()` and every db
+ * command resolves its database through
+ * `getPackageConfig('cli', DEFAULT_CLI_CONFIG)`. Before the fix the cosmiconfig
+ * loader had no TypeScript support, so the TS config was never discovered and db
+ * commands fell back to the `:memory:` default ("Database not configured").
+ *
+ * This test exercises the real (unmocked) config-resolution seam the db
+ * commands use — searching a fixture project whose only config is
+ * `smrt.config.ts` — and asserts the database config from the TS file survives
+ * all the way to `getPackageConfig('cli', DEFAULT_CLI_CONFIG)`.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  clearCache,
+  getPackageConfig,
+  loadConfig,
+} from '@happyvertical/smrt-config';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DEFAULT_CLI_CONFIG } from '../../config.js';
+
+describe('#1783: CLI loads a TypeScript smrt.config.ts', () => {
+  let fixtureDir: string;
+
+  beforeEach(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'smrt-1783-cli-'));
+    clearCache();
+  });
+
+  afterEach(() => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+    clearCache();
+  });
+
+  it('resolves the db config from smrt.config.ts for db commands', async () => {
+    // A template-shaped TS config: TS-only syntax plus a runtime `process.env`
+    // read, exactly what a plain-JSON loader could not handle.
+    const dbPath = join(fixtureDir, 'data', 'app.db');
+    writeFileSync(
+      join(fixtureDir, 'smrt.config.ts'),
+      `
+      type DbType = 'sqlite' | 'postgres';
+      const type: DbType = 'sqlite';
+      export default {
+        smrt: { logLevel: 'info' as const },
+        packages: {
+          cli: {
+            database: {
+              type,
+              url: process.env.SMRT_1783_DB_URL ?? ${JSON.stringify(dbPath)},
+            },
+          },
+        },
+      };
+      `,
+      'utf-8',
+    );
+
+    // Mirror the CLI startup path: search the project dir (no explicit path).
+    await loadConfig({ searchFrom: fixtureDir, cache: true });
+
+    // Mirror what every db command does to resolve its database.
+    const config = getPackageConfig('cli', DEFAULT_CLI_CONFIG);
+
+    expect(config.database?.type).toBe('sqlite');
+    expect(config.database?.url).toBe(dbPath);
+    // The db-command guard rejects a missing/`:memory:` url — prove we cleared it.
+    expect(config.database?.url).not.toBe(':memory:');
+  });
+
+  it('honors a process.env override in the TS config', async () => {
+    process.env.SMRT_1783_DB_URL = 'sqlite:///tmp/override-1783.db';
+    writeFileSync(
+      join(fixtureDir, 'smrt.config.ts'),
+      `
+      export default {
+        packages: {
+          cli: {
+            database: {
+              type: 'sqlite' as const,
+              url: process.env.SMRT_1783_DB_URL ?? ':memory:',
+            },
+          },
+        },
+      };
+      `,
+      'utf-8',
+    );
+
+    try {
+      await loadConfig({ searchFrom: fixtureDir, cache: true });
+      const config = getPackageConfig('cli', DEFAULT_CLI_CONFIG);
+      expect(config.database?.url).toBe('sqlite:///tmp/override-1783.db');
+    } finally {
+      process.env.SMRT_1783_DB_URL = undefined;
+    }
+  });
+});

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -27,7 +27,8 @@
   },
   "dependencies": {
     "@happyvertical/smrt-types": "workspace:*",
-    "cosmiconfig": "^9.0.2"
+    "cosmiconfig": "^9.0.2",
+    "jiti": "^2.6.1"
   },
   "devDependencies": {
     "@types/node": "24.13.2",

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -162,6 +162,70 @@ describe('@smrt/config', () => {
         loadConfig({ configPath: badPath, cache: false }),
       ).rejects.toThrow(/Failed to load smrt config/);
     });
+
+    it('loads a TypeScript smrt.config.ts (#1783)', async () => {
+      // Genuinely TS-only syntax (interface, type annotation, `as const`,
+      // `satisfies`, and a runtime `process.env` read) — a plain-JSON or
+      // untranspiled read would choke on all of these. The SvelteKit template
+      // ships its config as `smrt.config.ts`, so the loader must transpile it.
+      const tsConfigPath = join(testDir, 'smrt.config.ts');
+      process.env.SMRT_TEST_DB_URL = './from-env.db';
+      const tsConfigContent = `
+        interface DatabaseConfig {
+          type: string;
+          url: string;
+        }
+        const dbType: string = 'sqlite';
+        export default {
+          smrt: {
+            logLevel: 'debug' as const,
+          },
+          packages: {
+            cli: {
+              database: {
+                type: dbType,
+                url: process.env.SMRT_TEST_DB_URL ?? './fallback.db',
+              } satisfies DatabaseConfig,
+            },
+          },
+        };
+      `;
+      writeFileSync(tsConfigPath, tsConfigContent, 'utf-8');
+
+      try {
+        const config = await loadConfig({
+          configPath: tsConfigPath,
+          cache: false,
+        });
+
+        expect(config.smrt?.logLevel).toBe('debug');
+        const cli = config.packages?.cli as
+          | { database?: { type?: string; url?: string } }
+          | undefined;
+        expect(cli?.database?.type).toBe('sqlite');
+        expect(cli?.database?.url).toBe('./from-env.db');
+      } finally {
+        process.env.SMRT_TEST_DB_URL = undefined;
+      }
+    });
+
+    it('discovers smrt.config.ts via search (#1783)', async () => {
+      // The CLI loads config with no explicit path (cosmiconfig search), so the
+      // TS extension must be in searchPlaces, not just loadable by path.
+      const tsConfigPath = join(testDir, 'smrt.config.ts');
+      writeFileSync(
+        tsConfigPath,
+        `export default { smrt: { logLevel: 'warn' as const } };`,
+        'utf-8',
+      );
+
+      const config = await loadConfig({
+        searchFrom: testDir,
+        cache: false,
+      });
+
+      expect(config.smrt?.logLevel).toBe('warn');
+    });
   });
 
   describe('getModuleConfig', () => {

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -226,6 +226,29 @@ describe('@smrt/config', () => {
 
       expect(config.smrt?.logLevel).toBe('warn');
     });
+
+    it('searchParents: false anchors stopDir to searchFrom, not cwd', async () => {
+      // A config exists in the PARENT (testDir) but not in the child searchFrom.
+      // With searchParents: false the upward walk must stop at searchFrom (the
+      // search root) and NOT climb to the parent — even though searchFrom is
+      // outside the cwd tree. Regression for the stopDir=cwd bug.
+      writeFileSync(
+        join(testDir, 'smrt.config.ts'),
+        `export default { smrt: { logLevel: 'error' as const } };`,
+        'utf-8',
+      );
+      const childDir = join(testDir, 'nested', 'child');
+      mkdirSync(childDir, { recursive: true });
+
+      const config = await loadConfig({
+        searchFrom: childDir,
+        searchParents: false,
+        cache: false,
+      });
+
+      // Parent's config must NOT leak in — no config found from childDir.
+      expect(config).toEqual({});
+    });
   });
 
   describe('getModuleConfig', () => {

--- a/packages/config/src/loader.ts
+++ b/packages/config/src/loader.ts
@@ -1,7 +1,44 @@
+import type { Loader } from 'cosmiconfig';
 import { cosmiconfig } from 'cosmiconfig';
+import { createJiti } from 'jiti';
 import type { LoadConfigOptions, SmrtConfig } from './types.js';
 
 const MODULE_NAME = 'smrt';
+
+/**
+ * Lazily-created jiti instance used to load TypeScript config files.
+ *
+ * cosmiconfig ships no TypeScript loader (dropped in v8+), so a project whose
+ * config is `smrt.config.ts` — the SvelteKit template default — silently fell
+ * back to empty config, breaking `smrt db:setup` / `db:migrate` (#1783). jiti
+ * transpiles and imports the `.ts`/`.mts`/`.cts` file on demand (it is the same
+ * engine cosmiconfig-typescript-loader wraps), honoring the config's own
+ * relative imports and `process.env` reads. Created once and reused so repeated
+ * `loadConfig()` calls don't rebuild the transform pipeline.
+ */
+let jitiInstance: ReturnType<typeof createJiti> | undefined;
+
+function getJiti(): ReturnType<typeof createJiti> {
+  if (!jitiInstance) {
+    // moduleCache: false so a re-read after the file changes on disk (hot
+    // reload, or `loadConfig({ cache: false })`) re-evaluates instead of
+    // returning jiti's in-memory copy. The common `cache: true` path is already
+    // short-circuited by our own config cache before it reaches jiti, so this
+    // adds no cost to steady-state loads. fsCache (default) still disk-caches
+    // the content-hashed transpile output.
+    jitiInstance = createJiti(import.meta.url, { moduleCache: false });
+  }
+  return jitiInstance;
+}
+
+/**
+ * cosmiconfig loader for TypeScript config files. Returns the config's default
+ * export (or the module namespace when there is no default), matching how the
+ * JS loaders treat `export default` / `module.exports`.
+ */
+const typeScriptLoader: Loader = async (filepath: string) => {
+  return getJiti().import(filepath, { default: true });
+};
 
 /**
  * Extend globalThis to include loader cache properties.
@@ -61,8 +98,9 @@ function isFileNotFound(error: unknown): boolean {
 /**
  * Load and parse configuration from the project root using cosmiconfig.
  *
- * Searches for `smrt.config.{js,mjs,cjs,json}` starting from `cwd`, walking
- * up the directory tree unless `searchParents` is `false`. The result is
+ * Searches for `smrt.config.{js,mjs,cjs,ts,mts,cts,json}` starting from `cwd`,
+ * walking up the directory tree unless `searchParents` is `false`. TypeScript
+ * configs are transpiled on demand via jiti (#1783). The result is
  * cached in `globalThis.__smrtLoaderCachedConfig` so that all modules sharing
  * the same runtime (including pnpm workspace symlinks) see the same config.
  *
@@ -94,7 +132,12 @@ function isFileNotFound(error: unknown): boolean {
 export async function loadConfig(
   options: LoadConfigOptions = {},
 ): Promise<SmrtConfig> {
-  const { configPath, searchParents = true, cache = true } = options;
+  const {
+    configPath,
+    searchParents = true,
+    searchFrom,
+    cache = true,
+  } = options;
 
   // Return cached config if available
   const cached = getCachedConfig();
@@ -110,8 +153,18 @@ export async function loadConfig(
         `${MODULE_NAME}.config.js`,
         `${MODULE_NAME}.config.mjs`,
         `${MODULE_NAME}.config.cjs`,
+        `${MODULE_NAME}.config.ts`,
+        `${MODULE_NAME}.config.mts`,
+        `${MODULE_NAME}.config.cts`,
         `${MODULE_NAME}.config.json`,
       ],
+      // cosmiconfig has no built-in TypeScript loader; register jiti for the TS
+      // extensions so a `smrt.config.ts` scaffold loads end to end (#1783).
+      loaders: {
+        '.ts': typeScriptLoader,
+        '.mts': typeScriptLoader,
+        '.cts': typeScriptLoader,
+      },
       stopDir: searchParents ? undefined : process.cwd(),
       cache: cache, // Respect cache option
     });
@@ -125,7 +178,7 @@ export async function loadConfig(
     if (configPath) {
       result = await explorer.load(configPath);
     } else {
-      result = await explorer.search();
+      result = await explorer.search(searchFrom ?? process.cwd());
     }
   } catch (error) {
     // A genuinely-absent config file is not an error: an explicit `configPath`

--- a/packages/config/src/loader.ts
+++ b/packages/config/src/loader.ts
@@ -165,7 +165,11 @@ export async function loadConfig(
         '.mts': typeScriptLoader,
         '.cts': typeScriptLoader,
       },
-      stopDir: searchParents ? undefined : process.cwd(),
+      // When not searching parents, stop at the actual search root so
+      // `searchParents: false` is honored even if `searchFrom` is outside the
+      // cwd tree (otherwise the upward walk from `searchFrom` never hits cwd and
+      // runs to the filesystem root).
+      stopDir: searchParents ? undefined : (searchFrom ?? process.cwd()),
       cache: cache, // Respect cache option
     });
     setExplorer(explorer);

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -708,6 +708,13 @@ export interface LoadConfigOptions {
   searchParents?: boolean;
 
   /**
+   * Directory to start the config search from. Defaults to `process.cwd()`.
+   * Ignored when `configPath` is provided. Useful for tests and for tools that
+   * resolve config relative to a project root other than the current directory.
+   */
+  searchFrom?: string;
+
+  /**
    * Whether to cache the loaded config in `globalThis.__smrtLoaderCachedConfig`.
    * Disable for test isolation or hot-reload scenarios.
    *

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -103,15 +103,24 @@ When the target declares multiple FKs back to the parent, annotate `@oneToMany(T
 ## Vite Plugin
 
 ```typescript
-// vite.config.ts — required for @smrt() decorators
+// vite.config.ts — required for @smrt() decorators (Vite 8+, oxc transform)
 export default defineConfig({
-  esbuild: {
-    tsconfigRaw: {
-      compilerOptions: { experimentalDecorators: true, emitDecoratorMetadata: true }
-    }
-  }
+  oxc: {
+    decorator: {
+      legacy: true,
+      emitDecoratorMetadata: true,
+    },
+  },
 });
 ```
+
+Under Vite 8 the oxc transform does not honor the pre-Vite-8 `esbuild.tsconfigRaw`
+recipe (or tsconfig `experimentalDecorators` reached through SvelteKit's
+`extends "./.svelte-kit/tsconfig.json"` chain), so that recipe throws
+`SyntaxError: Invalid or unexpected token` on the first SSR request. Configure
+decorators through `oxc.decorator` instead. Consumers still pinned on vite<8 need
+the legacy `esbuild.tsconfigRaw` form with `experimentalDecorators: true,
+emitDecoratorMetadata: true`.
 
 ## Gotchas
 

--- a/packages/core/src/dispatch/index.ts
+++ b/packages/core/src/dispatch/index.ts
@@ -53,9 +53,11 @@ export {
 export {
   type DispatchTenantResolver,
   type DispatchTenantScope,
+  isTenantScopedClassResolved,
   resolveDispatchTenantId,
   resolveDispatchTenantScope,
   setDispatchTenantResolver,
+  setTenantScopedClassResolver,
 } from './tenant-resolver.js';
 
 // Types

--- a/packages/core/src/dispatch/tenant-resolver.ts
+++ b/packages/core/src/dispatch/tenant-resolver.ts
@@ -28,6 +28,10 @@ export type DispatchTenantResolver = () => string | null | undefined;
 declare global {
   // eslint-disable-next-line no-var
   var __smrtDispatchTenantResolver: DispatchTenantResolver | undefined;
+  // eslint-disable-next-line no-var
+  var __smrtTenantScopedClassResolver:
+    | ((className: string) => boolean)
+    | undefined;
 }
 
 /**
@@ -131,5 +135,43 @@ export function resolveDispatchTenantId(): string | null | undefined {
     // A misbehaving resolver must never break dispatch emission; treat a
     // throwing resolver as "no tenant context".
     return undefined;
+  }
+}
+
+/**
+ * Register the resolver that reports whether a class is tenant-scoped, covering
+ * BOTH registration forms (S #1782). Core's `ObjectRegistry.isTenantScoped`
+ * recognizes `@smrt({ tenantScoped })` and the manifest-merged `@TenantScoped()`
+ * config, but the standalone `@TenantScoped()` decorator (smrt-tenancy) records
+ * its config only in the tenancy registry at decoration time — invisible to core
+ * until/unless a manifest carries it. Tenancy fills this slot at
+ * `enableTenancy()` so core-side fail-closed guards (the generated REST read
+ * scope) recognize tenant-scoped classes regardless of registration form or
+ * manifest timing. Mirrors {@link setDispatchTenantResolver}.
+ *
+ * @param resolver - Predicate returning `true` for tenant-scoped class names, or
+ *   `undefined` to clear (which `disableTenancy()` does).
+ */
+export function setTenantScopedClassResolver(
+  resolver: ((className: string) => boolean) | undefined,
+): void {
+  globalThis.__smrtTenantScopedClassResolver = resolver;
+}
+
+/**
+ * Whether the tenancy layer reports `className` as tenant-scoped. Returns
+ * `false` when tenancy is disabled (no resolver) or the resolver throws.
+ *
+ * @param className - Class name (simple or qualified) to check.
+ */
+export function isTenantScopedClassResolved(className: string): boolean {
+  const resolver = globalThis.__smrtTenantScopedClassResolver;
+  if (!resolver) {
+    return false;
+  }
+  try {
+    return resolver(className) === true;
+  } catch {
+    return false;
   }
 }

--- a/packages/core/src/generators/conditional-get.ts
+++ b/packages/core/src/generators/conditional-get.ts
@@ -135,9 +135,50 @@ export function resolveReadCacheControl(
   return requestedSharedCacheControl(apiConfig) ?? PRIVATE_READ_CACHE_CONTROL;
 }
 
+/** Whether an `api` config opts reads out of auth (`public: true | 'read'`). */
+function isPublicRead(apiConfig: unknown): boolean {
+  if (!apiConfig || typeof apiConfig !== 'object') {
+    return false;
+  }
+  const value = (apiConfig as ApiCacheShape).public;
+  return value === true || value === 'read';
+}
+
 // One warning per model — both transports resolve the same model repeatedly
 // (per route template at generation time, per request at runtime).
 const sharedCacheNeutralizedWarned = new Set<string>();
+
+// One warning per model for the tenant-scoped + public-read combination (#1782).
+const tenantScopedPublicReadWarned = new Set<string>();
+
+/**
+ * Warn (once per model) when a tenant-scoped model is also marked publicly
+ * readable (`@smrt({ api: { public: true | 'read' } })`).
+ *
+ * Anonymous / no-tenant-context reads on such a model fail closed to NULL-tenant
+ * (global) rows only (#1782): they never expose any tenant's rows. That is the
+ * intended, safe behavior, but silently it reads as "the public endpoint returns
+ * nothing" — so surface the combination and its consequence at generation /
+ * serve time. Called from both the REST runtime and the SvelteKit route
+ * generator so the message appears wherever the model is exposed.
+ */
+export function warnIfTenantScopedPublicRead(
+  modelName: string,
+  apiConfig: unknown,
+  tenantScoped: boolean,
+): void {
+  if (!tenantScoped) return;
+  if (!isPublicRead(apiConfig)) return;
+  if (tenantScopedPublicReadWarned.has(modelName)) return;
+  tenantScopedPublicReadWarned.add(modelName);
+  console.warn(
+    `[smrt] tenant-scoped model ${modelName} is marked api.public — ` +
+      'anonymous reads with no tenant context return NULL-tenant (global) ' +
+      'rows ONLY, never any tenant’s rows (fail-closed, #1782). Resolve a ' +
+      'tenant from the request (host/subdomain/session) if per-tenant public ' +
+      'reads are intended.',
+  );
+}
 
 /**
  * Warn (once per model) when a tenant-scoped model configures
@@ -225,6 +266,11 @@ export function generateConditionalGetRouteHelper(
   const cacheControl = resolveReadCacheControl(apiConfig, options);
   if (options.modelName) {
     warnIfSharedCacheNeutralized(
+      options.modelName,
+      apiConfig,
+      options.tenantScoped === true,
+    );
+    warnIfTenantScopedPublicRead(
       options.modelName,
       apiConfig,
       options.tenantScoped === true,

--- a/packages/core/src/generators/issue-1782-tenant-read-scope.spec.ts
+++ b/packages/core/src/generators/issue-1782-tenant-read-scope.spec.ts
@@ -16,7 +16,10 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { SmrtCollection } from '../collection';
 import { field } from '../decorators';
-import { setDispatchTenantResolver } from '../dispatch';
+import {
+  setDispatchTenantResolver,
+  setTenantScopedClassResolver,
+} from '../dispatch';
 import { SmrtObject } from '../object';
 import { ObjectRegistry, smrt } from '../registry';
 import { getTestDatabase } from '../testing/database';
@@ -44,24 +47,49 @@ class PublicTenantDocCollection extends SmrtCollection<PublicTenantDoc> {
   static readonly _itemClass = PublicTenantDoc;
 }
 
+// Pattern 1 (#1782 review): tenancy is declared via the standalone
+// `@TenantScoped()` decorator, NOT `@smrt({ tenantScoped })`. Here the `@smrt`
+// config carries NO tenantScoped, so `ObjectRegistry.isTenantScoped` is false —
+// the model is recognized as tenant-scoped ONLY through the tenancy-filled
+// `setTenantScopedClassResolver` hook (what `@TenantScoped()` wires at
+// `enableTenancy()`). The guard must still fail closed for it.
+@smrt({ api: { public: 'read' } })
+class Pattern1TenantDoc extends SmrtObject {
+  @field({ type: 'text' })
+  name: string = '';
+
+  @field({ type: 'text', nullable: true })
+  tenantId: string | null = null;
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+  }
+}
+
+class Pattern1TenantDocCollection extends SmrtCollection<Pattern1TenantDoc> {
+  static readonly _itemClass = Pattern1TenantDoc;
+}
+
 describe('REST tenant-scoped public read fails closed to global rows (#1782)', () => {
   ObjectRegistry.registerCollection(
     'PublicTenantDoc',
     PublicTenantDocCollection,
+  );
+  ObjectRegistry.registerCollection(
+    'Pattern1TenantDoc',
+    Pattern1TenantDocCollection,
   );
 
   let db: any;
   let handler: (req: Request) => Promise<Response>;
   const ids: Record<string, string> = {};
 
-  beforeAll(async () => {
-    db = await getTestDatabase({
-      type: 'sqlite',
-      url: ':memory:',
-      classes: ['PublicTenantDoc'],
-    });
-
-    const collection = await PublicTenantDocCollection.create({ db });
+  const seed = async (
+    collection: SmrtCollection<SmrtObject>,
+    into: Record<string, string>,
+  ) => {
     // Seed one row per tenant plus a global (NULL-tenant) row. Inserted through
     // the collection directly (not REST) so tenantId is set — the REST writable
     // policy strips framework-managed tenantId from create bodies.
@@ -72,11 +100,26 @@ describe('REST tenant-scoped public read fails closed to global rows (#1782)', (
     ] as const) {
       const row = await collection.create({ name, tenantId });
       await row.save();
-      ids[name] = (row as unknown as { id: string }).id;
+      into[name] = (row as unknown as { id: string }).id;
     }
+  };
+
+  beforeAll(async () => {
+    db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['PublicTenantDoc', 'Pattern1TenantDoc'],
+    });
+
+    const collection = await PublicTenantDocCollection.create({ db });
+    await seed(collection, ids);
+
+    const pattern1 = await Pattern1TenantDocCollection.create({ db });
+    await seed(pattern1, {});
 
     const api = new APIGenerator({ basePath: '/api/v1' });
     api.registerCollection('publictenantdoc', collection);
+    api.registerCollection('pattern1tenantdoc', pattern1);
     handler = api.generateHandler();
   });
 
@@ -85,8 +128,9 @@ describe('REST tenant-scoped public read fails closed to global rows (#1782)', (
   });
 
   afterEach(() => {
-    // Reset the ambient resolver so no test leaks tenant scope into another.
+    // Reset the ambient resolvers so no test leaks tenant scope into another.
     setDispatchTenantResolver(undefined);
+    setTenantScopedClassResolver(undefined);
   });
 
   const list = (query = '') =>
@@ -156,6 +200,46 @@ describe('REST tenant-scoped public read fails closed to global rows (#1782)', (
     it('list returns ALL rows — no global-only restriction is imposed', async () => {
       setDispatchTenantResolver(undefined);
       const res = await list();
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { name: string }[];
+      expect(body.map((i) => i.name).sort()).toEqual([
+        'global-row',
+        'tenant-a-row',
+        'tenant-b-row',
+      ]);
+    });
+  });
+
+  // #1782 review (P1): a model tenant-scoped ONLY via the standalone
+  // `@TenantScoped()` decorator has no `@smrt({ tenantScoped })` config, so
+  // `ObjectRegistry.isTenantScoped` is false. It must still fail closed via the
+  // tenancy-filled `setTenantScopedClassResolver` hook.
+  describe('@TenantScoped()-only model recognized via the resolver hook', () => {
+    const p1list = (query = '') =>
+      handler(new Request(`http://local/api/v1/pattern1tenantdoc${query}`));
+
+    it('is NOT ObjectRegistry-tenant-scoped (sanity: only the hook can see it)', () => {
+      expect(ObjectRegistry.isTenantScoped('Pattern1TenantDoc')).toBe(false);
+    });
+
+    it('fails closed to global rows when the resolver marks it tenant-scoped', async () => {
+      setDispatchTenantResolver(() => undefined);
+      setTenantScopedClassResolver((name) => name.includes('Pattern1TenantDoc'));
+
+      const res = await p1list();
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { name: string }[];
+      expect(body.map((i) => i.name).sort()).toEqual(['global-row']);
+    });
+
+    it('would leak WITHOUT the resolver (proves the hook is what closes it)', async () => {
+      // Same ambient no-tenant state, but the resolver is unset → the guard
+      // can't recognize the Pattern-1 model → unfiltered (documents the gap the
+      // hook closes).
+      setDispatchTenantResolver(() => undefined);
+      setTenantScopedClassResolver(undefined);
+
+      const res = await p1list();
       expect(res.status).toBe(200);
       const body = (await res.json()) as { name: string }[];
       expect(body.map((i) => i.name).sort()).toEqual([

--- a/packages/core/src/generators/issue-1782-tenant-read-scope.spec.ts
+++ b/packages/core/src/generators/issue-1782-tenant-read-scope.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * Integration coverage for issue #1782: a `@TenantScoped` model marked
+ * `api.public` served an anonymous request with ZERO tenant filtering — the
+ * generated REST read returned rows from EVERY tenant.
+ *
+ * Driven through `APIGenerator.generateHandler()` against a real in-memory
+ * SQLite database (per repo testing rules — nothing internal is mocked). Tenant
+ * scope is simulated at the core level via `setDispatchTenantResolver` (the same
+ * hook `enableTenancy()` installs): returning `undefined` models "tenancy
+ * enabled, no active tenant" — exactly the anonymous public-read case. The fix
+ * fails closed to NULL-tenant (global) rows only.
+ *
+ * Mirrors `conditional-get.spec.ts` setup.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection';
+import { field } from '../decorators';
+import { setDispatchTenantResolver } from '../dispatch';
+import { SmrtObject } from '../object';
+import { ObjectRegistry, smrt } from '../registry';
+import { getTestDatabase } from '../testing/database';
+import { APIGenerator } from './rest';
+
+// Optional-mode tenant-scoped model marked publicly readable — the #1782
+// footgun. tenantId is declared explicitly so the tenant_id column exists at the
+// core level (the tenancy package's column injection is not in play here).
+@smrt({ tenantScoped: { mode: 'optional' }, api: { public: 'read' } })
+class PublicTenantDoc extends SmrtObject {
+  @field({ type: 'text' })
+  name: string = '';
+
+  @field({ type: 'text', nullable: true })
+  tenantId: string | null = null;
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+  }
+}
+
+class PublicTenantDocCollection extends SmrtCollection<PublicTenantDoc> {
+  static readonly _itemClass = PublicTenantDoc;
+}
+
+describe('REST tenant-scoped public read fails closed to global rows (#1782)', () => {
+  ObjectRegistry.registerCollection(
+    'PublicTenantDoc',
+    PublicTenantDocCollection,
+  );
+
+  let db: any;
+  let handler: (req: Request) => Promise<Response>;
+  const ids: Record<string, string> = {};
+
+  beforeAll(async () => {
+    db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['PublicTenantDoc'],
+    });
+
+    const collection = await PublicTenantDocCollection.create({ db });
+    // Seed one row per tenant plus a global (NULL-tenant) row. Inserted through
+    // the collection directly (not REST) so tenantId is set — the REST writable
+    // policy strips framework-managed tenantId from create bodies.
+    for (const [name, tenantId] of [
+      ['tenant-a-row', 'tenant-a'],
+      ['tenant-b-row', 'tenant-b'],
+      ['global-row', null],
+    ] as const) {
+      const row = await collection.create({ name, tenantId });
+      await row.save();
+      ids[name] = (row as unknown as { id: string }).id;
+    }
+
+    const api = new APIGenerator({ basePath: '/api/v1' });
+    api.registerCollection('publictenantdoc', collection);
+    handler = api.generateHandler();
+  });
+
+  afterAll(async () => {
+    await db?.close?.();
+  });
+
+  afterEach(() => {
+    // Reset the ambient resolver so no test leaks tenant scope into another.
+    setDispatchTenantResolver(undefined);
+  });
+
+  const list = (query = '') =>
+    handler(new Request(`http://local/api/v1/publictenantdoc${query}`));
+
+  describe('tenancy enabled, no active tenant (anonymous public read)', () => {
+    beforeAll(() => {
+      // Simulate `enableTenancy()` with no active tenant context.
+      setDispatchTenantResolver(() => undefined);
+    });
+
+    it('list returns ONLY the global (NULL-tenant) row', async () => {
+      setDispatchTenantResolver(() => undefined);
+      const res = await list();
+      expect(res.status).toBe(200);
+      // The REST list generator returns a bare array of items.
+      const body = (await res.json()) as { name: string }[];
+      const names = body.map((i) => i.name).sort();
+      expect(names).toEqual(['global-row']);
+    });
+
+    it('count returns ONLY the global row cardinality', async () => {
+      setDispatchTenantResolver(() => undefined);
+      const res = await handler(
+        new Request('http://local/api/v1/publictenantdoc/count'),
+      );
+      expect(res.status).toBe(200);
+      expect(((await res.json()) as { count: number }).count).toBe(1);
+    });
+
+    it('get /:id of a tenant row is NOT found (scoped to global)', async () => {
+      setDispatchTenantResolver(() => undefined);
+      const res = await handler(
+        new Request(
+          `http://local/api/v1/publictenantdoc/${ids['tenant-a-row']}`,
+        ),
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it('get /:id of the global row IS found', async () => {
+      setDispatchTenantResolver(() => undefined);
+      const res = await handler(
+        new Request(`http://local/api/v1/publictenantdoc/${ids['global-row']}`),
+      );
+      expect(res.status).toBe(200);
+      expect(((await res.json()) as { name: string }).name).toBe('global-row');
+    });
+
+    it('a client-supplied ?tenantId= cannot widen the scope', async () => {
+      setDispatchTenantResolver(() => undefined);
+      for (const query of [
+        '?tenantId=tenant-a',
+        '?tenant_id=tenant-a',
+        '?tenant_id[ne]=tenant-a',
+      ]) {
+        const res = await list(query);
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { name: string }[];
+        const leaked = body.filter((i) => i.name !== 'global-row');
+        expect(leaked).toEqual([]);
+      }
+    });
+  });
+
+  describe('tenancy disabled (no resolver)', () => {
+    it('list returns ALL rows — no global-only restriction is imposed', async () => {
+      setDispatchTenantResolver(undefined);
+      const res = await list();
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { name: string }[];
+      expect(body.map((i) => i.name).sort()).toEqual([
+        'global-row',
+        'tenant-a-row',
+        'tenant-b-row',
+      ]);
+    });
+  });
+});

--- a/packages/core/src/generators/issue-1782-warning.test.ts
+++ b/packages/core/src/generators/issue-1782-warning.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit coverage for issue #1782's registration/generation-time warning:
+ * `warnIfTenantScopedPublicRead`.
+ *
+ * The tenant-scoped + `api.public` combination is a footgun — anonymous reads
+ * fail closed to global rows only — so the framework surfaces it once per model
+ * wherever the model is exposed. This asserts exactly when the warning fires
+ * (and that it dedups), without a live server or generator.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { warnIfTenantScopedPublicRead } from './conditional-get';
+
+describe('#1782: warnIfTenantScopedPublicRead', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('warns for a tenant-scoped model with api.public: "read"', () => {
+    warnIfTenantScopedPublicRead('M1', { public: 'read' }, true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('#1782');
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('M1');
+  });
+
+  it('warns for a tenant-scoped model with api.public: true', () => {
+    warnIfTenantScopedPublicRead('M2', { public: true }, true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT warn when the model is not tenant-scoped', () => {
+    warnIfTenantScopedPublicRead('M3', { public: 'read' }, false);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT warn when the model is tenant-scoped but not public', () => {
+    warnIfTenantScopedPublicRead('M4', { public: false }, true);
+    warnIfTenantScopedPublicRead('M4b', {}, true);
+    warnIfTenantScopedPublicRead('M4c', undefined, true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns at most once per model', () => {
+    warnIfTenantScopedPublicRead('M5', { public: 'read' }, true);
+    warnIfTenantScopedPublicRead('M5', { public: 'read' }, true);
+    warnIfTenantScopedPublicRead('M5', { public: true }, true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/generators/rest.ts
+++ b/packages/core/src/generators/rest.ts
@@ -6,7 +6,10 @@
 
 import http from 'node:http';
 import type { SmrtCollection } from '../collection';
-import { resolveDispatchTenantScope } from '../dispatch';
+import {
+  isTenantScopedClassResolved,
+  resolveDispatchTenantScope,
+} from '../dispatch';
 import type { SmrtObject } from '../object';
 import { ObjectRegistry } from '../registry';
 import type { RegisteredClass, SmrtObjectConstructor } from '../registry/types';
@@ -491,11 +494,25 @@ export class APIGenerator {
    * in; core cannot import tenancy directly). Returns undefined when a tenant IS
    * active (the interceptor filters by it) or tenancy is disabled (no isolation
    * to enforce).
+   *
+   * Tenant scoping is recognized across BOTH registration forms (#1782): the
+   * `@smrt({ tenantScoped })` config / manifest-merged form via
+   * `ObjectRegistry.isTenantScoped`, and the standalone `@TenantScoped()`
+   * decorator via the tenancy-filled `isTenantScopedClassResolved` hook — so a
+   * `@TenantScoped()`-only public model can't slip past the guard regardless of
+   * manifest timing.
    */
   private resolveTenantReadScope(
     objectName?: string,
   ): { tenantId: null } | undefined {
-    if (!objectName || !ObjectRegistry.isTenantScoped(objectName)) {
+    if (
+      !objectName ||
+      !(
+        ObjectRegistry.isTenantScoped(objectName) ||
+        !!ObjectRegistry.getConfig(objectName)?.tenantScoped ||
+        isTenantScopedClassResolved(objectName)
+      )
+    ) {
       return undefined;
     }
     const scope = resolveDispatchTenantScope();

--- a/packages/core/src/generators/rest.ts
+++ b/packages/core/src/generators/rest.ts
@@ -6,6 +6,7 @@
 
 import http from 'node:http';
 import type { SmrtCollection } from '../collection';
+import { resolveDispatchTenantScope } from '../dispatch';
 import type { SmrtObject } from '../object';
 import { ObjectRegistry } from '../registry';
 import type { RegisteredClass, SmrtObjectConstructor } from '../registry/types';
@@ -13,6 +14,7 @@ import {
   conditionalJsonResponse,
   resolveReadCacheControl,
   warnIfSharedCacheNeutralized,
+  warnIfTenantScopedPublicRead,
 } from './conditional-get';
 import {
   processSyncApplyBatch,
@@ -340,7 +342,7 @@ export class APIGenerator {
 
       // Handle special /count endpoint
       if (objectId === 'count' && req.method === 'GET') {
-        return await this.handleCount(collection, url.searchParams);
+        return await this.handleCount(collection, url.searchParams, objectName);
       }
 
       // Route to appropriate CRUD operation
@@ -477,6 +479,61 @@ export class APIGenerator {
   }
 
   /**
+   * Fail-closed tenant read scope (#1782).
+   *
+   * A `@TenantScoped` model served over a public/anonymous read has no ambient
+   * tenant context, so the tenancy interceptor (optional mode) passes the query
+   * through UNFILTERED and returns every tenant's rows. When tenancy is enabled
+   * but no tenant is active, this returns a `{ tenantId: null }` filter so reads
+   * fail closed to NULL-tenant (global) rows only — mirroring the dispatch
+   * resolver's "enforced, no active tenant → global rows only" convention
+   * (`resolveDispatchTenantScope` is the core-level trust anchor tenancy fills
+   * in; core cannot import tenancy directly). Returns undefined when a tenant IS
+   * active (the interceptor filters by it) or tenancy is disabled (no isolation
+   * to enforce).
+   */
+  private resolveTenantReadScope(
+    objectName?: string,
+  ): { tenantId: null } | undefined {
+    if (!objectName || !ObjectRegistry.isTenantScoped(objectName)) {
+      return undefined;
+    }
+    const scope = resolveDispatchTenantScope();
+    return scope.enforced && scope.tenantId === null
+      ? { tenantId: null }
+      : undefined;
+  }
+
+  /**
+   * Merge the fail-closed tenant read scope (#1782) into a query's WHERE clause.
+   * When the scope is active (global-only), any client-supplied tenant filter is
+   * dropped first so a `?tenantId=...` / `?tenant_id[ne]=...` query param can
+   * never widen the scope, then NULL-tenant is forced. Returns the original
+   * `where` untouched when the scope is inactive.
+   */
+  private applyTenantReadScope(
+    objectName: string | undefined,
+    where: Record<string, string | string[]> | undefined,
+  ): Record<string, unknown> | undefined {
+    const scope = this.resolveTenantReadScope(objectName);
+    if (!scope) {
+      return where;
+    }
+    const cleaned: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(where ?? {})) {
+      // A key may carry an operator suffix, e.g. "tenant_id !=" — match on the
+      // field portion so no operator variant slips a client tenant filter past.
+      const field = key.split(/\s+/)[0];
+      if (field === 'tenantId' || field === 'tenant_id') {
+        continue;
+      }
+      cleaned[key] = value;
+    }
+    cleaned.tenantId = null;
+    return cleaned;
+  }
+
+  /**
    * Handle GET /objects/:id
    */
   private async handleGet(
@@ -485,7 +542,12 @@ export class APIGenerator {
     req: Request,
     objectName?: string,
   ): Promise<Response> {
-    const object = await collection.get(id);
+    // #1782: scope a public/anonymous read of a tenant-scoped model to global
+    // (NULL-tenant) rows when no tenant context is active.
+    const scope = this.resolveTenantReadScope(objectName);
+    const object = scope
+      ? await collection.get({ id, ...scope })
+      : await collection.get(id);
     if (!object) {
       return this.createErrorResponse(404, 'Object not found');
     }
@@ -535,8 +597,15 @@ export class APIGenerator {
       }
     }
 
+    // #1782: fail closed to global (NULL-tenant) rows for a public/anonymous
+    // read of a tenant-scoped model with no active tenant context.
+    const scopedWhere = this.applyTenantReadScope(objectName, where);
+
     const objects = await collection.list({
-      where: Object.keys(where).length > 0 ? where : undefined,
+      where:
+        scopedWhere && Object.keys(scopedWhere).length > 0
+          ? scopedWhere
+          : undefined,
       limit,
       offset,
       orderBy,
@@ -555,6 +624,7 @@ export class APIGenerator {
   private async handleCount(
     collection: SmrtCollection<SmrtObject>,
     params: URLSearchParams,
+    objectName?: string,
   ): Promise<Response> {
     // Build where clause from query params (same logic as handleList)
     const where: Record<string, string | string[]> = {};
@@ -583,8 +653,15 @@ export class APIGenerator {
       }
     }
 
+    // #1782: a count leaks cross-tenant cardinality just as a list leaks rows,
+    // so apply the same fail-closed global scope for anonymous tenant reads.
+    const scopedWhere = this.applyTenantReadScope(objectName, where);
+
     const count = await collection.count({
-      where: Object.keys(where).length > 0 ? where : undefined,
+      where:
+        scopedWhere && Object.keys(scopedWhere).length > 0
+          ? scopedWhere
+          : undefined,
     });
 
     return this.createJsonResponse({ count });
@@ -854,6 +931,7 @@ export class APIGenerator {
       : false;
     if (objectName) {
       warnIfSharedCacheNeutralized(objectName, apiConfig, tenantScoped);
+      warnIfTenantScopedPublicRead(objectName, apiConfig, tenantScoped);
     }
     return conditionalJsonResponse(
       req,

--- a/packages/core/src/manifest/manifest-loader.ts
+++ b/packages/core/src/manifest/manifest-loader.ts
@@ -35,6 +35,10 @@ import type {
 } from '../scanner/types.js';
 import { parse } from '../utils/json.js';
 import {
+  isDecoratorRuntimeFramePath,
+  isDecoratorRuntimePackageName,
+} from '../utils/stack-frames.js';
+import {
   createQualifiedName,
   isQualifiedName,
   parseQualifiedName,
@@ -464,13 +468,23 @@ export function loadLocalTestManifestSync(): Manifest | null | undefined {
  * 3. require.resolve() (resolves package.json from constructor file location)
  * 4. Error stack trace parsing (fallback, fragile in pnpm workspaces)
  *
+ * Decorator-lowering runtime helpers (`@oxc-project/runtime` under Vite 8,
+ * `tslib`/`@swc/helpers`/`@babel/runtime` elsewhere) are skipped by both
+ * stack-based methods (3 and 4): the compiler inserts such a frame between the
+ * `@smrt()` decorator and the consumer module, and without skipping it the class
+ * misattributes to the helper package (e.g. `@oxc-project/runtime`) instead of
+ * the declaring package (#1785).
+ *
  * @param ctor - Class constructor
  * @param skipRegistry - If true, skip checking ObjectRegistry (used during initial registration to avoid circular dependency)
+ * @param stackOverride - Optional stack string to parse instead of a fresh
+ *   `Error().stack`. Used by tests to simulate a lowered call pattern.
  * @returns Package name (e.g., '@happyvertical/smrt-places') or null
  */
 export function getPackageName(
   ctor: SmrtObjectConstructor,
   skipRegistry: boolean = false,
+  stackOverride?: string,
 ): string | null {
   try {
     // 1. Try ObjectRegistry first (most reliable - from build-time manifest)
@@ -495,8 +509,7 @@ export function getPackageName(
     // 3. Try require.resolve() to find package.json from constructor location
     // This is more reliable than stack trace parsing for published packages
     try {
-      const error = new Error();
-      const stack = error.stack || '';
+      const stack = stackOverride ?? new Error().stack ?? '';
       const stackLines = stack.split('\n');
 
       // Find the first line with a file path that's NOT from smrt-core
@@ -505,11 +518,13 @@ export function getPackageName(
         const fileMatch = line.match(/\(([^)]+\.(?:js|ts))/);
         if (fileMatch) {
           const filePath = fileMatch[1];
-          // Skip smrt-core internal files
+          // Skip smrt-core internal files and decorator-lowering runtime
+          // helpers (#1785) — the class is declared in neither.
           if (
             filePath.includes('manifest-loader') ||
             filePath.includes('registry') ||
-            filePath.includes('/smrt-core/dist/')
+            filePath.includes('/smrt-core/dist/') ||
+            isDecoratorRuntimeFramePath(filePath.replace(/\\/g, '/'))
           ) {
             continue; // Skip smrt-core files, look for external package
           }
@@ -550,14 +565,19 @@ export function getPackageName(
 
     // 4. Final fallback: Try to extract from Error stack trace with node_modules pattern
     // This method is fragile and fails in pnpm workspaces, but kept for backward compatibility
-    const error = new Error();
-    const stack = error.stack || '';
+    const stack = stackOverride ?? new Error().stack ?? '';
     const stackLines = stack.split('\n');
 
     // Look for line with 'node_modules/@scope/package' pattern
     for (const line of stackLines) {
       const match = line.match(/node_modules\/(@[^/]+\/[^/]+)/);
       if (match) {
+        // Skip decorator-lowering runtime helpers (e.g. @oxc-project/runtime) —
+        // the compiler inserts them between @smrt() and the declaring module, so
+        // attributing to them is wrong; keep walking to the real package (#1785).
+        if (isDecoratorRuntimePackageName(match[1])) {
+          continue;
+        }
         return match[1];
       }
     }

--- a/packages/core/src/registry/__tests__/issue-1785-oxc-attribution.test.ts
+++ b/packages/core/src/registry/__tests__/issue-1785-oxc-attribution.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression tests for issue #1785: ObjectRegistry misattributes
+ * decorator-registered classes to `@oxc-project/runtime` under oxc-lowered
+ * decorators.
+ *
+ * Under Vite 8, oxc's legacy-decorator lowering routes the `@smrt()` application
+ * through `@oxc-project/runtime`'s helper module, so the registration call stack
+ * carries an `@oxc-project/runtime` frame BETWEEN the smrt-core frames and the
+ * consumer module that declares the class. The two stack walkers that derive a
+ * class's identity — package attribution (`getPackageName`) and source-file
+ * identity (`getSourceFileFromStack`) — must skip that helper frame and continue
+ * to the real declaring module.
+ *
+ * These tests simulate the lowered call pattern with synthetic stacks (the
+ * `stackOverride` test hook) so they assert the exact behavior without needing a
+ * real oxc build. Paths under `/nonexistent-1785/...` never resolve on disk, so
+ * `getPackageName`'s package.json walk (method 3) finds nothing and the
+ * node_modules fallback (method 4) is exercised.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getPackageName } from '../../manifest/manifest-loader.js';
+import type { SmrtObjectConstructor } from '../../registry/types.js';
+import {
+  DECORATOR_RUNTIME_PACKAGES,
+  isDecoratorRuntimeFramePath,
+  isDecoratorRuntimePackageName,
+} from '../../utils/stack-frames.js';
+import { getSourceFileFromStack } from '../shared-state.js';
+
+// A pnpm-resolved oxc runtime helper frame — the shape oxc's legacy-decorator
+// lowering inserts when it applies a class decorator.
+const OXC_FRAME =
+  '    at applyDecoratedDescriptor (/nonexistent-1785/node_modules/.pnpm/@oxc-project+runtime@0.138.0/node_modules/@oxc-project/runtime/src/helpers/esm/applyDecoratedDescriptor.js:12:3)';
+// A smrt-core internal frame (the registration entry point).
+const CORE_FRAME =
+  '    at register (/repo/packages/core/src/registry/class-registration.ts:581:10)';
+
+describe('#1785: decorator-runtime frame detection', () => {
+  it('recognizes @oxc-project/runtime as a decorator-runtime package', () => {
+    expect(isDecoratorRuntimePackageName('@oxc-project/runtime')).toBe(true);
+    expect(DECORATOR_RUNTIME_PACKAGES).toContain('@oxc-project/runtime');
+  });
+
+  it('recognizes the other common lowering helpers', () => {
+    expect(isDecoratorRuntimePackageName('@swc/helpers')).toBe(true);
+    expect(isDecoratorRuntimePackageName('@babel/runtime')).toBe(true);
+    expect(isDecoratorRuntimePackageName('tslib')).toBe(true);
+  });
+
+  it('does not flag ordinary consumer packages', () => {
+    expect(isDecoratorRuntimePackageName('@acme/widgets')).toBe(false);
+    expect(isDecoratorRuntimePackageName('@happyvertical/smrt-content')).toBe(
+      false,
+    );
+  });
+
+  it('matches oxc runtime helper file paths (plain and pnpm forms)', () => {
+    expect(
+      isDecoratorRuntimeFramePath(
+        '/app/node_modules/@oxc-project/runtime/src/helpers/esm/decorate.js',
+      ),
+    ).toBe(true);
+    expect(
+      isDecoratorRuntimeFramePath(
+        '/app/node_modules/.pnpm/@oxc-project+runtime@0.138.0/node_modules/@oxc-project/runtime/src/helpers/esm/applyDecoratedDescriptor.js',
+      ),
+    ).toBe(true);
+    expect(
+      isDecoratorRuntimeFramePath('/app/node_modules/tslib/tslib.es6.js'),
+    ).toBe(true);
+  });
+
+  it('does not match consumer module paths', () => {
+    expect(isDecoratorRuntimeFramePath('/app/src/lib/objects/Widget.ts')).toBe(
+      false,
+    );
+    // A directory that merely contains "tslib" as a substring must not match.
+    expect(
+      isDecoratorRuntimeFramePath('/app/node_modules/mytslibs/index.js'),
+    ).toBe(false);
+  });
+});
+
+describe('#1785: getPackageName skips the oxc helper frame', () => {
+  const ctor = { name: 'Widget' } as unknown as SmrtObjectConstructor;
+
+  it('attributes to the consumer package, not @oxc-project/runtime', () => {
+    const stack = [
+      'Error',
+      CORE_FRAME,
+      OXC_FRAME,
+      '    at Widget (/nonexistent-1785/node_modules/.pnpm/@acme+widgets@1.0.0/node_modules/@acme/widgets/dist/objects/Widget.js:5:1)',
+    ].join('\n');
+
+    expect(getPackageName(ctor, true, stack)).toBe('@acme/widgets');
+  });
+
+  it('returns @oxc-project/runtime WITHOUT the guard (documents the bug)', () => {
+    // Sanity check that the synthetic stack really would misattribute if the
+    // oxc frame were not skipped: strip every non-oxc external frame and the
+    // only scoped node_modules package left is the runtime helper.
+    const oxcOnly = ['Error', CORE_FRAME, OXC_FRAME].join('\n');
+    // With the guard, the oxc frame is skipped and nothing else matches → null.
+    expect(getPackageName(ctor, true, oxcOnly)).toBeNull();
+  });
+});
+
+describe('#1785: getSourceFileFromStack skips the oxc helper frame', () => {
+  it('returns the consumer module, not the oxc runtime helper', () => {
+    const stack = [
+      'Error',
+      CORE_FRAME,
+      OXC_FRAME,
+      '    at /virtual-1785-app/src/lib/objects/Widget.ts:5:1',
+    ].join('\n');
+
+    expect(getSourceFileFromStack(stack)).toBe(
+      '/virtual-1785-app/src/lib/objects/Widget.ts',
+    );
+  });
+});

--- a/packages/core/src/registry/shared-state.ts
+++ b/packages/core/src/registry/shared-state.ts
@@ -17,6 +17,7 @@ import {
 } from '../config/global-config.js';
 import type { SmrtObject } from '../object';
 import { LRUCache } from '../utils/lru-cache';
+import { isDecoratorRuntimeFramePath } from '../utils/stack-frames';
 import type { RegisteredClass, SmrtObjectConstructor } from './types';
 
 // Re-export the globalThis augmentation so it's visible everywhere
@@ -114,11 +115,19 @@ export function getInheritanceConfig() {
  * This allows the same class to be re-registered when modules are re-evaluated
  * (e.g., during vitest test file collection with isolation enabled).
  *
+ * Frames from decorator-lowering runtime helpers (`@oxc-project/runtime` under
+ * Vite 8, `tslib`/`@swc/helpers`/`@babel/runtime` elsewhere) are skipped too, so
+ * the lowered `@smrt()` application resolves to the consumer module that declares
+ * the class rather than the helper frame the compiler inserted (#1785).
+ *
+ * @param stackOverride - Optional stack string to parse instead of a fresh
+ *   `Error().stack`. Used by tests to simulate a lowered call pattern.
  * @returns The file path where the @smrt() decorator was called, or undefined
  */
-export function getSourceFileFromStack(): string | undefined {
-  const error = new Error();
-  const stack = error.stack || '';
+export function getSourceFileFromStack(
+  stackOverride?: string,
+): string | undefined {
+  const stack = stackOverride ?? new Error().stack ?? '';
   const stackLines = stack.split('\n');
 
   // Look for the first file path that's NOT from smrt-core internal files
@@ -148,7 +157,10 @@ export function getSourceFileFromStack(): string | undefined {
         (lowerPath.includes('/packages/core/src/') &&
           !lowerPath.includes('__tests__')) ||
         // Specific manifest loader internals
-        lowerPath.includes('/manifest/manifest-loader')
+        lowerPath.includes('/manifest/manifest-loader') ||
+        // Decorator-lowering runtime helper (oxc/tslib/swc/babel) — the frame
+        // the compiler inserts between @smrt() and the declaring module (#1785)
+        isDecoratorRuntimeFramePath(normalizedPath)
       ) {
         continue;
       }

--- a/packages/core/src/utils/stack-frames.ts
+++ b/packages/core/src/utils/stack-frames.ts
@@ -1,0 +1,62 @@
+/**
+ * Decorator-runtime stack-frame detection (#1785).
+ *
+ * ObjectRegistry attributes a `@smrt()` class to its declaring package by
+ * walking the registration call stack for the first frame OUTSIDE smrt-core —
+ * the module that applied the decorator. Decorator *lowering* breaks that
+ * assumption: the compiler inserts a runtime-helper frame between the `@smrt()`
+ * decorator and the consumer module that declares the class.
+ *
+ * Under Vite 8, oxc's legacy-decorator lowering routes the decorator application
+ * through `@oxc-project/runtime`'s helper (e.g.
+ * `.../@oxc-project/runtime/src/helpers/esm/applyDecoratedDescriptor.js`), so a
+ * naive walk stops at that frame and misattributes the class to
+ * `@oxc-project/runtime` instead of the consumer package. `tslib` (tsc's
+ * `__decorate`), `@swc/helpers`, and `@babel/runtime` insert the identical kind
+ * of frame under their respective toolchains.
+ *
+ * These are pure plumbing packages — a class is applied THROUGH them, never
+ * DECLARED in them — so both stack walks (source-file identity in
+ * `registry/shared-state.ts` and package attribution in
+ * `manifest/manifest-loader.ts`) skip them and continue to the real declaring
+ * module. Kept as a leaf module (no smrt imports) so both walkers can share it
+ * without risking an import cycle.
+ */
+
+/**
+ * Runtime-helper packages that decorator lowering routes the decorator
+ * application through. Frames from these packages are never the module that
+ * declares a decorated class.
+ */
+export const DECORATOR_RUNTIME_PACKAGES: readonly string[] = [
+  '@oxc-project/runtime',
+  '@swc/helpers',
+  '@babel/runtime',
+  'tslib',
+];
+
+/**
+ * Whether a file path (normalized to forward slashes) lives inside a
+ * decorator-runtime helper package — i.e. a stack frame introduced by decorator
+ * lowering rather than the module that declares the decorated class.
+ *
+ * Matches both the plain installed form (`.../node_modules/tslib/...`) and the
+ * pnpm form (`.../node_modules/.pnpm/tslib@2/node_modules/tslib/...`) because
+ * the real `/<package>/` segment appears in both. Case-insensitive.
+ *
+ * @param path - A file path from a stack frame (already normalized to `/`).
+ */
+export function isDecoratorRuntimeFramePath(path: string): boolean {
+  const lower = path.toLowerCase();
+  return DECORATOR_RUNTIME_PACKAGES.some((pkg) => lower.includes(`/${pkg}/`));
+}
+
+/**
+ * Whether a scoped package name (as captured from a `node_modules/@scope/name`
+ * stack match) is a decorator-runtime helper package.
+ *
+ * @param name - A scoped package name, e.g. `@oxc-project/runtime`.
+ */
+export function isDecoratorRuntimePackageName(name: string): boolean {
+  return DECORATOR_RUNTIME_PACKAGES.includes(name);
+}

--- a/packages/core/src/vite-plugin/issue-1782-tenant-read-scope.test.ts
+++ b/packages/core/src/vite-plugin/issue-1782-tenant-read-scope.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Test for issue #1782 (SvelteKit transport): generated routes for a
+ * `@TenantScoped` + `api.public` model must fail closed to global (NULL-tenant)
+ * rows when no tenant context is active, instead of returning every tenant's
+ * rows to an anonymous caller.
+ *
+ * Asserts the emitted route source carries the fail-closed read scope on the
+ * read handlers (list, count, get /:id) and that non-tenant models are
+ * unaffected. Companion to `issue-1782-tenant-read-scope.spec.ts` (REST runtime)
+ * and mirrors `issue-1540-tenant-context.test.ts`.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SmartObjectManifest } from '../scanner/types';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn(),
+  readdirSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}));
+
+import { generateSvelteKitRoutes } from './sveltekit-generator';
+
+const projectRoot = '/test/project';
+
+function findRouteContent(suffix: string): string {
+  for (const call of vi.mocked(writeFileSync).mock.calls) {
+    const path = call[0].toString();
+    if (path.endsWith(suffix)) return call[1] as string;
+  }
+  throw new Error(`No generated route ending in ${suffix}`);
+}
+
+async function generate(manifest: SmartObjectManifest): Promise<void> {
+  await generateSvelteKitRoutes(projectRoot, manifest, {
+    enabled: true,
+    routesDir: 'src/routes/api',
+    objectsDir: 'src/lib/objects',
+    configPath: 'src/lib/server',
+    configFileName: 'smrt.ts',
+  });
+}
+
+describe('Issue #1782: fail-closed tenant read scope in generated routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(readFileSync).mockReturnValue('');
+    vi.mocked(readdirSync).mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('scopes list/count/get to global rows for a @TenantScoped public model', async () => {
+    await generate({
+      objects: {
+        PublicTenantDoc: {
+          className: 'PublicTenantDoc',
+          collection: 'publictenantdocs',
+          fields: { title: { type: 'text' } },
+          methods: {},
+          decoratorConfig: {
+            api: { public: 'read', include: ['list', 'get'] },
+            tenantScoped: { mode: 'optional' },
+          },
+        },
+      },
+    } as unknown as SmartObjectManifest);
+
+    const collectionRoute = findRouteContent('publictenantdocs/+server.ts');
+    const itemRoute = findRouteContent('publictenantdocs/[id]/+server.ts');
+
+    // The fail-closed helper is emitted and depends on isTenancyEnabled().
+    expect(collectionRoute).toContain('function tenantReadScope()');
+    expect(collectionRoute).toContain('isTenancyEnabled()');
+    expect(collectionRoute).toContain('!hasTenantContext()');
+    expect(collectionRoute).toContain('{ tenantId: null }');
+
+    // List + count both carry the scope.
+    expect(collectionRoute).toContain('const readScope = tenantReadScope();');
+    expect(collectionRoute).toContain(
+      'collection.list({ limit, offset, where: readScope })',
+    );
+    expect(collectionRoute).toContain('collection.count({ where: readScope })');
+
+    // Single-read get scopes the id lookup to global when no tenant is active.
+    expect(itemRoute).toContain('const readScope = tenantReadScope();');
+    expect(itemRoute).toContain(
+      'readScope ? { id: params.id, ...readScope } : params.id',
+    );
+  });
+
+  it('does NOT add the read scope to a non-tenant model’s routes', async () => {
+    await generate({
+      objects: {
+        PlainDoc: {
+          className: 'PlainDoc',
+          collection: 'plaindocs',
+          fields: { title: { type: 'text' } },
+          methods: {},
+          decoratorConfig: {
+            api: { public: 'read', include: ['list', 'get'] },
+          },
+        },
+      },
+    } as unknown as SmartObjectManifest);
+
+    const collectionRoute = findRouteContent('plaindocs/+server.ts');
+    const itemRoute = findRouteContent('plaindocs/[id]/+server.ts');
+
+    expect(collectionRoute).not.toContain('tenantReadScope');
+    expect(collectionRoute).not.toContain('@happyvertical/smrt-tenancy');
+    expect(collectionRoute).toContain('collection.list({ limit, offset })');
+    expect(itemRoute).not.toContain('tenantReadScope');
+    expect(itemRoute).toContain('collection.get(params.id)');
+  });
+});

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -453,24 +453,28 @@ function isTenantScoped(objectDef: SmartObjectDefinition): boolean {
 }
 
 /**
- * Emit the tenant-context establishment helper for `@TenantScoped` objects
- * (#1540, facet 2). Generated handlers call `establishTenantContext(locals)`
- * after the auth guard so every collection query runs inside the tenant context
- * derived from the authenticated principal — engaging the `@TenantScoped`
- * interceptors that auto-filter by tenant.
+ * Emit the tenant-context establishment + fail-closed read-scope helpers for
+ * `@TenantScoped` objects (#1540 facet 2; #1782). Generated handlers call
+ * `establishTenantContext(locals)` after the auth guard so every query runs
+ * inside the tenant context derived from the authenticated principal — engaging
+ * the `@TenantScoped` interceptors that auto-filter by tenant.
  *
- * Without this, an `optional`-mode scoped object queried over a generated route
- * with no active context returns rows from ALL tenants (the interceptor only
- * hard-fails `required` mode). We read the canonical `locals.tenantId` set by
- * the smrt-users auth hook (with `user`/`session` fallbacks). It is a no-op when
- * a context is already active (e.g. an upstream tenancy handle) or when the
- * principal carries no tenant (global/admin — preserving optional-mode global
- * access). Imported only for tenant-scoped routes, which already depend on
- * `@happyvertical/smrt-tenancy`.
+ * `establishTenantContext` reads the canonical `locals.tenantId` set by the
+ * smrt-users auth hook (with `user`/`session` fallbacks). It is a no-op when a
+ * context is already active (e.g. an upstream tenancy handle) or when the
+ * request carries no tenant (anonymous / global principal).
+ *
+ * When no context could be established, an `optional`-mode read would otherwise
+ * fall through the interceptor UNFILTERED and return rows from ALL tenants (the
+ * interceptor only hard-fails `required` mode) — the #1782 leak. So read
+ * handlers additionally call `tenantReadScope()`, which restricts reads to
+ * NULL-tenant (global) rows only when tenancy is enabled but no context is
+ * active. Both helpers are imported only for tenant-scoped routes, which already
+ * depend on `@happyvertical/smrt-tenancy`.
  */
 function generateTenantContextHelper(): string {
   return `
-import { enterTenantContext, hasTenantContext } from '@happyvertical/smrt-tenancy';
+import { enterTenantContext, hasTenantContext, isTenancyEnabled } from '@happyvertical/smrt-tenancy';
 
 function establishTenantContext(locals: unknown): void {
   if (hasTenantContext()) return;
@@ -482,6 +486,19 @@ function establishTenantContext(locals: unknown): void {
   if (typeof tenantId === 'string' && tenantId) {
     enterTenantContext({ tenantId });
   }
+}
+
+// Fail-closed read scope (#1782): a public/anonymous read on a @TenantScoped
+// model has no tenant context, so the tenancy interceptor (optional mode) would
+// pass the query through UNFILTERED and return every tenant's rows. When tenancy
+// is enabled but no context was established, restrict reads to NULL-tenant
+// (global) rows only — mirroring the dispatch resolver + _changes convention:
+// tenancy enforced with no context => global rows only. Returns undefined when a
+// context is active (the interceptor filters by it) or tenancy is disabled.
+function tenantReadScope(): { tenantId: null } | undefined {
+  return isTenancyEnabled() && !hasTenantContext()
+    ? { tenantId: null }
+    : undefined;
 }
 `;
 }
@@ -1852,6 +1869,16 @@ ${modelType.importStatement ? `${modelType.importStatement}\n` : ''}import type 
 // Note: ${className} is auto-registered by the Vite plugin scanner
 ${generateAuthGuardHelper(objectDef)}${isTenantScoped(objectDef) ? generateTenantContextHelper() : ''}${hasPost ? generateWritablePolicyHelper(objectDef) : ''}${hasGet ? generateConditionalGetRouteHelper(objectDef.decoratorConfig?.api, { tenantScoped: isTenantScoped(objectDef), modelName: className }) : ''}`;
 
+  // #1782: tenant-scoped reads fail closed to global (NULL-tenant) rows when no
+  // tenant context is active (public/anonymous read). Non-tenant models keep the
+  // plain list/count.
+  const listAndCount = isTenantScoped(objectDef)
+    ? `  const readScope = tenantReadScope();
+  const items = await collection.list({ limit, offset, where: readScope });
+  const count = await collection.count({ where: readScope });`
+    : `  const items = await collection.list({ limit, offset });
+  const count = await collection.count();`;
+
   const getHandler = hasGet
     ? `
 // List all ${className.toLowerCase()}s
@@ -1861,8 +1888,7 @@ ${routeGuardPreamble(objectDef, false)}
   const offset = Number(url.searchParams.get('offset')) || 0;
 
 ${generateCollectionLoad(className, { typeName: modelType.typeName })}
-  const items = await collection.list({ limit, offset });
-  const count = await collection.count();
+${listAndCount}
 ${
   serializers.listItemSerializerName
     ? `
@@ -1990,13 +2016,24 @@ ${serializerImports ? `${serializerImports}\n` : ''}import { getCollection } fro
 ${modelType.importStatement ? `${modelType.importStatement}\n` : ''}import type { RequestHandler } from './$types';
 ${generateAuthGuardHelper(objectDef)}${isTenantScoped(objectDef) ? generateTenantContextHelper() : ''}${hasPut ? generateWritablePolicyHelper(objectDef) : ''}${hasGet ? generateConditionalGetRouteHelper(objectDef.decoratorConfig?.api, { tenantScoped: isTenantScoped(objectDef), modelName: className }) : ''}`;
 
+  // #1782: a tenant-scoped single read fails closed to global (NULL-tenant)
+  // rows when no tenant context is active, so a public/anonymous GET /:id can't
+  // fetch another tenant's row by id. Mutations (PUT/DELETE) require auth, so
+  // they keep the plain id lookup and rely on the interceptor.
+  const getForRead = isTenantScoped(objectDef)
+    ? `  const readScope = tenantReadScope();
+  const item = await collection.get(
+    readScope ? { id: params.id, ...readScope } : params.id,
+  );`
+    : `  const item = await collection.get(params.id);`;
+
   const getHandler = hasGet
     ? `
 // Get single ${simpleClassName.toLowerCase()}
 export const GET: RequestHandler = async ({ locals, params, request }) => {
 ${routeGuardPreamble(objectDef, false)}
 ${generateCollectionLoad(className, { typeName: modelType.typeName })}
-  const item = await collection.get(params.id);
+${getForRead}
 ${generateNotFoundError(className)}
 ${
   serializers.itemSerializerName

--- a/packages/tenancy/AGENTS.md
+++ b/packages/tenancy/AGENTS.md
@@ -34,6 +34,8 @@ Hooks into SmrtCollection via `GlobalInterceptors.register()` (priority 100, run
 
 Mismatches throw `TenantIsolationError`. Missing required context throws `TenantContextError`.
 
+**Optional-mode reads with no context pass through UNFILTERED at the interceptor.** That is intentional for trusted/admin call paths, but it means the interceptor alone does not protect a tenant-scoped model exposed as `@smrt({ api: { public } })`: an anonymous HTTP read has no context, so the interceptor would return every tenant's rows. The generated REST + SvelteKit read routes close this by injecting a `{ tenantId: null }` filter when tenancy is enabled but no context is active, so public/anonymous reads fail closed to **global (NULL-tenant) rows only** — mirroring the dispatch resolver's *enforced, no active tenant → global rows only* rule (#1782). Authenticated reads still scope to the caller's tenant via the interceptor.
+
 ## Registration — Two Patterns
 
 ```typescript

--- a/packages/tenancy/src/__tests__/issue-1782-global-read-scope.test.ts
+++ b/packages/tenancy/src/__tests__/issue-1782-global-read-scope.test.ts
@@ -18,9 +18,14 @@
  * core-side REST integration test (`issue-1782-tenant-read-scope.spec.ts`).
  */
 
+import { isTenantScopedClassResolved } from '@happyvertical/smrt-core';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { withTenant } from '../context';
-import { createTenantInterceptor, disableTenancy } from '../interceptor';
+import {
+  createTenantInterceptor,
+  disableTenancy,
+  enableTenancy,
+} from '../interceptor';
 import {
   registerTenantScopedClass,
   unregisterTenantScopedClass,
@@ -70,5 +75,29 @@ describe('#1782: interceptor preserves the injected global read scope', () => {
         (result as { where: Record<string, unknown> })?.where.tenantId,
       ).toBe('tenant-a');
     });
+  });
+});
+
+describe('#1782: enableTenancy wires the core tenant-scoped-class resolver', () => {
+  afterEach(() => {
+    unregisterTenantScopedClass('HookDoc');
+    disableTenancy();
+  });
+
+  it('lets core recognize a @TenantScoped()-only class after enableTenancy', () => {
+    registerTenantScopedClass('HookDoc', { mode: 'optional' });
+
+    // Before enableTenancy the core hook is unset → not resolvable.
+    expect(isTenantScopedClassResolved('HookDoc')).toBe(false);
+
+    enableTenancy();
+    // enableTenancy fills setTenantScopedClassResolver, so core's REST read
+    // guard can now see the @TenantScoped()-registered class (#1782 review).
+    expect(isTenantScopedClassResolved('HookDoc')).toBe(true);
+    expect(isTenantScopedClassResolved('NotScopedDoc')).toBe(false);
+
+    disableTenancy();
+    // Cleared on teardown so the hook doesn't leak across suites.
+    expect(isTenantScopedClassResolved('HookDoc')).toBe(false);
   });
 });

--- a/packages/tenancy/src/__tests__/issue-1782-global-read-scope.test.ts
+++ b/packages/tenancy/src/__tests__/issue-1782-global-read-scope.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Regression tests for issue #1782 — the tenancy-interceptor contract the
+ * generated REST/SvelteKit routes rely on to fail closed.
+ *
+ * The transports (core) handle a public/anonymous read of a `@TenantScoped`
+ * model by injecting a `{ tenantId: null }` WHERE filter when no tenant context
+ * is active, so the read returns global (NULL-tenant) rows only. That only works
+ * if the interceptor:
+ *
+ *  1. leaves an explicit `{ tenantId: null }` filter UNTOUCHED when there is no
+ *     context (optional mode) — otherwise the injected global filter would be
+ *     stripped and every tenant's rows would leak again; and
+ *  2. still scopes an authenticated read to the caller's own tenant — so the
+ *     transports correctly DEFER to the interceptor when a context IS active
+ *     (they inject nothing in that case).
+ *
+ * These assert both halves against the real interceptor, complementing the
+ * core-side REST integration test (`issue-1782-tenant-read-scope.spec.ts`).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { withTenant } from '../context';
+import { createTenantInterceptor, disableTenancy } from '../interceptor';
+import {
+  registerTenantScopedClass,
+  unregisterTenantScopedClass,
+} from '../registry';
+
+const ctx = (className: string) => ({
+  className,
+  operation: 'list' as const,
+  timestamp: new Date(),
+});
+
+describe('#1782: interceptor preserves the injected global read scope', () => {
+  beforeEach(() => {
+    registerTenantScopedClass('Doc', { mode: 'optional' });
+  });
+
+  afterEach(() => {
+    unregisterTenantScopedClass('Doc');
+    disableTenancy();
+  });
+
+  it('leaves an explicit { tenantId: null } filter untouched with no context', () => {
+    const interceptor = createTenantInterceptor();
+
+    // No active tenant + optional mode: the interceptor must NOT modify the
+    // query, so the caller's injected global-only filter survives to SQL.
+    const result = interceptor.beforeList?.(
+      'Doc',
+      { where: { tenantId: null } },
+      ctx('Doc'),
+    );
+
+    // Undefined = "no change" — the { tenantId: null } the transport injected is
+    // used as-is (=> WHERE tenant_id IS NULL => global rows only).
+    expect(result).toBeUndefined();
+  });
+
+  it('scopes an authenticated read to the caller’s tenant (transports defer here)', async () => {
+    const interceptor = createTenantInterceptor();
+
+    await withTenant({ tenantId: 'tenant-a' }, async () => {
+      const result = interceptor.beforeList?.('Doc', { where: {} }, ctx('Doc'));
+      // With an active tenant the interceptor injects the tenant filter, so the
+      // transports inject nothing — an authenticated read still sees ONLY its
+      // own tenant's rows, never the global-only restriction.
+      expect(
+        (result as { where: Record<string, unknown> })?.where.tenantId,
+      ).toBe('tenant-a');
+    });
+  });
+});

--- a/packages/tenancy/src/interceptor.ts
+++ b/packages/tenancy/src/interceptor.ts
@@ -21,6 +21,7 @@ import {
   type QueryOptions,
   setDispatchTenantResolver,
   setTenantEntryPointRunner,
+  setTenantScopedClassResolver,
 } from '@happyvertical/smrt-core';
 import {
   getCurrentTenant,
@@ -675,6 +676,11 @@ export function enableTenancy(options: TenantInterceptorOptions = {}): void {
   // (tenancy disabled) those surfaces pass through unchanged.
   setTenantEntryPointRunner(runTenantScopedEntryPoint);
 
+  // Wire the tenant-scoped-class resolver so core-side fail-closed read guards
+  // (generated REST read scope, #1782) recognize `@TenantScoped()`-decorated
+  // classes, which record their config only in the tenancy registry.
+  setTenantScopedClassResolver((className) => isTenantScopedClass(className));
+
   setTenancyEnabled(true);
 }
 
@@ -711,6 +717,8 @@ export function disableTenancy(): void {
   setDispatchTenantResolver(undefined);
   // Clear the CLI/MCP tenant gate so those surfaces pass through (#1554).
   setTenantEntryPointRunner(undefined);
+  // Clear the tenant-scoped-class resolver (#1782).
+  setTenantScopedClassResolver(undefined);
   registeredInterceptor = null;
   setTenancyEnabled(false);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,6 +655,9 @@ importers:
       cosmiconfig:
         specifier: ^9.0.2
         version: 9.0.2(typescript@5.9.3)
+      jiti:
+        specifier: ^2.6.1
+        version: 2.6.1
     devDependencies:
       '@types/node':
         specifier: 24.13.2

--- a/vite.config.base.ts
+++ b/vite.config.base.ts
@@ -376,6 +376,11 @@ export function createPackageConfig(
             'jpeg-js',
             '@gutenye/ocr-node',
             'cosmiconfig',
+            // jiti loads its own babel transform via a relative require
+            // (`../dist/babel.cjs`); bundling it breaks that path, so it must
+            // stay external (#1783).
+            'jiti',
+            /^jiti\//,
             '@libsql/client',
             'fast-glob',
             'minimatch',


### PR DESCRIPTION
One release batch fixing four issues. Branched from and rebased onto latest
`origin/main` (on top of #1778 sync-apply, which merged mid-work — the auto-merge
of `rest.ts` / `sveltekit-generator.ts` preserves both change sets).

Closes #1782
Closes #1783
Closes #1784
Closes #1785

---

## #1782 — security(core): tenant-scoped `api.public` reads served every tenant's rows

A `@TenantScoped` model marked `api: { public: true | 'read' }` served anonymous
requests with **zero tenant filtering**: with no tenant context the tenancy
interceptor (optional mode) passes the query through unfiltered, so a generated
read returned rows from **every** tenant to an unauthenticated caller.

**Fix (option 1 — fail-closed to global rows).** When tenancy is enabled but no
tenant context is active, generated reads are restricted to **NULL-tenant
(global) rows only**, mirroring the dispatch resolver / `_changes` convention
(*enforced, no active tenant → global rows only*). Enforced on **both**
transports:

- **REST generator** (`rest.ts`): `list` / `get /:id` / `count` inject a
  `{ tenantId: null }` filter via the core-level `resolveDispatchTenantScope`
  trust anchor when enforced with no active tenant. A client-supplied
  `?tenantId=` / `?tenant_id[ne]=` **cannot widen** the scope (stripped first).
- **SvelteKit generator**: emits a `tenantReadScope()` helper (guarded by
  `isTenancyEnabled() && !hasTenantContext()`) applied to list/count/get reads.
- An active tenant context still scopes to that tenant via the interceptor;
  disabled tenancy still returns all rows.
- One-time **registration/serve-time warning** for the `tenantScoped` +
  `api.public` combination so global-only reads aren't mistaken for a dead route.
- Aligns with #1757's cache-policy guard (tenant-scoped models never emit
  shared-cache headers) — this closes the origin-level hole that guard couldn't.

Docs: `docs/content/core.md` + tenancy package `AGENTS.md` state the rule.

## #1783 — cli: `db:setup` / `db:migrate` could not load a TypeScript `smrt.config.ts`

cosmiconfig ships no TypeScript loader (dropped in v8+), so the SvelteKit
template's default `smrt.config.ts` was never discovered and db commands fell
back to the `:memory:` default. The loader now registers a **jiti**-based loader
for `.ts`/`.mts`/`.cts` and adds those to `searchPlaces` (`moduleCache: false`
so hot-reload / `cache: false` re-reads re-evaluate). `jiti` is marked external
in the shared vite build config (it loads its babel transform via a relative
`require`, which bundling breaks). Adds a `searchFrom` option to make the search
root testable.

## #1784 — docs: Vite decorators gotcha was stale

Root `AGENTS.md` and core's "Vite Plugin" section documented the pre-Vite-8
`esbuild.tsconfigRaw` recipe, which the oxc transform ignores under Vite 8
(throws `SyntaxError` on first SSR). Both now document
`oxc: { decorator: { legacy: true, emitDecoratorMetadata: true } }`, with a note
for consumers pinned on vite<8. (CHANGELOG history and the repo's own build
configs — still valid for non-SvelteKit library builds — are left as-is.)

## #1785 — core: ObjectRegistry misattributed classes to `@oxc-project/runtime`

oxc's legacy-decorator lowering routes the `@smrt()` application through
`@oxc-project/runtime`'s helper module, so the registration stack-walk stopped
at that frame and misattributed the class to `@oxc-project/runtime` — breaking
package-qualified identity. Both stack walkers (`getPackageName` package.json
walk + node_modules fallback, and `getSourceFileFromStack`) now skip
decorator-lowering runtime helper frames (`@oxc-project/runtime`, plus `tslib` /
`@swc/helpers` / `@babel/runtime`) via a shared leaf predicate and continue to
the real declaring module. The template's #1760 workaround (shipped in #1781) is
left untouched and can be simplified separately now that plain consumers
attribute correctly.

---

## Test evidence

Full `pnpm test` per touched package (on the rebased #1778 base):

| Package | Result |
|---------|--------|
| smrt-core | 248 files, **2825 passed**, 29 skipped |
| smrt-cli | 54 files, **772 passed**, 4 skipped |
| smrt-tenancy | 9 files, **130 passed** |
| smrt-config | 2 files, **267 passed** |

New/updated tests:
- #1782 unit (`issue-1782-warning.test.ts`), REST integration
  (`issue-1782-tenant-read-scope.spec.ts` — real SQLite: anonymous → global only,
  count, get-by-id 404, no widening, tenancy-off → all rows), sveltekit-generator
  (`issue-1782-tenant-read-scope.test.ts`), and a tenancy interceptor-contract
  test (`issue-1782-global-read-scope.test.ts`).
- #1783 config-package TS-config tests (explicit path + search) and a CLI test
  resolving the db config from a `smrt.config.ts` fixture.
- #1785 regression test simulating the oxc-lowered call pattern with a synthetic
  stack, asserting attribution to the consumer package.

Other gates (all green):
- Coverage: `check-coverage.mjs --packages core,config,cli,tenancy` — cli 89.55%,
  config 93.08%, core 84.83%, tenancy 85.01% (all T1, floor 80%).
- `tsc` typecheck on touched packages; biome clean on touched source.
- `pnpm knowledge:check --strict` — fresh.
- `pnpm build` — 54/54.
