### PR TITLE
fix(core): generated-client URL/emission/error/type fixes + integration test (#1794-#1797)

### DIFF
--- a/packages/core/src/consumer-plugin/index.ts
+++ b/packages/core/src/consumer-plugin/index.ts
@@ -6,6 +6,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { Plugin } from 'vite';
+import { CLIENT_FETCH_RUNTIME } from '../generated-client-runtime.js';
 import { generateDeclarations } from '../prebuild/index.js';
 import type { SmartObjectManifest } from '../scanner/types.js';
 
@@ -76,12 +77,19 @@ export interface SmrtConsumerOptions {
   disableScanning?: boolean;
 }
 
+// Distinct resolved ids per plugin (#1795). smrtPlugin resolves
+// `@happyvertical/smrt-virt-*` to `\0smrt:*`; if this consumer plugin also
+// resolved its `@smrt/*` specifiers to `\0smrt:*` the two virtual modules would
+// share a rollup id, and in standalone/federation builds the consumer's
+// fallback `load` would non-deterministically win and shadow smrtPlugin's real
+// module. Namespacing the consumer ids (`\0smrt-consumer:*`) keeps them
+// separate so each plugin only ever loads its own module.
 const VIRTUAL_MODULES = {
-  '@smrt/routes': 'smrt:routes',
-  '@smrt/client': 'smrt:client',
-  '@smrt/mcp': 'smrt:mcp',
-  '@smrt/types': 'smrt:types',
-  '@smrt/manifest': 'smrt:manifest',
+  '@smrt/routes': 'smrt-consumer:routes',
+  '@smrt/client': 'smrt-consumer:client',
+  '@smrt/mcp': 'smrt-consumer:mcp',
+  '@smrt/types': 'smrt-consumer:types',
+  '@smrt/manifest': 'smrt-consumer:manifest',
 };
 
 /**
@@ -164,19 +172,19 @@ export function smrtConsumer(options: SmrtConsumerOptions = {}): Plugin {
       }
 
       switch (cleanId) {
-        case 'smrt:routes':
+        case 'smrt-consumer:routes':
           return generateFallbackRoutesModule();
 
-        case 'smrt:client':
+        case 'smrt-consumer:client':
           return generateFallbackClientModule(typeManifest);
 
-        case 'smrt:mcp':
+        case 'smrt-consumer:mcp':
           return generateFallbackMcpModule();
 
-        case 'smrt:types':
+        case 'smrt-consumer:types':
           return generateFallbackTypesModule(typeManifest);
 
-        case 'smrt:manifest':
+        case 'smrt-consumer:manifest':
           return generateFallbackManifestModule(typeManifest);
 
         default:
@@ -689,33 +697,42 @@ export default createClient;
 `;
   }
 
-  // Generate basic client from manifest
+  // Generate basic client from manifest.
+  //
+  // Object keys are QUOTED via JSON.stringify (#1795): a manifest key can be a
+  // package-qualified name like `@happyvertical/smrt-assets:AssetAssociation`,
+  // which is not a valid bare object-literal key and produced a build-breaking
+  // syntax error in the emitted module. Fetchers reject on !response.ok (#1796)
+  // via the shared __smrtFetchJson/__smrtFetchOk runtime.
   const clientMethods = objects
     .map(([name, obj]) => {
       const { collection } = obj;
       return `
-  ${name}: {
-    list: () => fetch(basePath + '/${collection}').then(r => r.json()),
-    get: (id) => fetch(basePath + '/${collection}/' + id).then(r => r.json()),
-    create: (data) => fetch(basePath + '/${collection}', {
+  ${JSON.stringify(name)}: {
+    list: () => __smrtFetchJson(basePath + '/${collection}', { method: 'GET' }),
+    get: (id) => __smrtFetchJson(basePath + '/${collection}/' + id, { method: 'GET' }),
+    create: (data) => __smrtFetchJson(basePath + '/${collection}', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data)
-    }).then(r => r.json()),
-    update: (id, data) => fetch(basePath + '/${collection}/' + id, {
+    }),
+    update: (id, data) => __smrtFetchJson(basePath + '/${collection}/' + id, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data)
-    }).then(r => r.json()),
-    delete: (id) => fetch(basePath + '/${collection}/' + id, {
+    }),
+    delete: (id) => __smrtFetchOk(basePath + '/${collection}/' + id, {
       method: 'DELETE'
-    }).then(r => r.ok)
+    })
   }`;
     })
     .join(',');
 
   return `
 // Auto-generated API client from SMRT consumer
+
+${CLIENT_FETCH_RUNTIME}
+
 export function createClient(basePath = '/api/v1') {
   return {${clientMethods}
   };

--- a/packages/core/src/consumer-plugin/index.ts
+++ b/packages/core/src/consumer-plugin/index.ts
@@ -723,7 +723,8 @@ export default createClient;
     }),
     delete: (id) => __smrtFetchOk(basePath + '/${collection}/' + id, {
       method: 'DELETE'
-    })
+    }),
+    search: (query) => __smrtFetchJson(basePath + '/${collection}/search?q=' + encodeURIComponent(query), { method: 'GET' })
   }`;
     })
     .join(',');

--- a/packages/core/src/consumer-plugin/load-resolve.test.ts
+++ b/packages/core/src/consumer-plugin/load-resolve.test.ts
@@ -219,6 +219,10 @@ describe('smrtConsumer load with a populated manifest', () => {
     // Object keys are quoted (#1795), so a simple name appears as "Widget":.
     expect(client).toContain('"Widget":');
     expect(client).toContain("'/widgets'");
+    // The fallback emits every CRUD verb the declared CrudOperations promises,
+    // including search — otherwise the @smrt/client d.ts would advertise a
+    // method the runtime object lacks (TypeError at call time).
+    expect(client).toContain('search:');
 
     const types = await load.call({}, '\0smrt-consumer:types');
     expect(types).toContain('export interface WidgetData');
@@ -281,8 +285,19 @@ describe('smrtConsumer load with a populated manifest', () => {
     expect(typeof mod.createClient).toBe('function');
     // The client exposes the qualified key as a collection accessor.
     const api = mod.createClient('/api/v1');
-    expect(api['@acme/assets:AssetAssociation']).toBeDefined();
-    expect(typeof api['@acme/assets:AssetAssociation'].list).toBe('function');
+    const accessor = api['@acme/assets:AssetAssociation'];
+    expect(accessor).toBeDefined();
+    // Every CRUD verb the declared CrudOperations promises is present.
+    for (const verb of [
+      'list',
+      'get',
+      'create',
+      'update',
+      'delete',
+      'search',
+    ]) {
+      expect(typeof accessor[verb]).toBe('function');
+    }
   });
 });
 

--- a/packages/core/src/consumer-plugin/load-resolve.test.ts
+++ b/packages/core/src/consumer-plugin/load-resolve.test.ts
@@ -20,6 +20,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { smrtPlugin } from '../vite-plugin/index.js';
 import { smrtConsumer } from './index.js';
 
 let projectRoot: string;
@@ -46,7 +47,7 @@ function getHook(plugin: any, name: 'resolveId' | 'load') {
 }
 
 describe('smrtConsumer resolveId', () => {
-  it('resolves a known virtual module to the \\0 virtual id when no .d.ts exists', () => {
+  it('resolves a known virtual module to the \\0 consumer virtual id when no .d.ts exists', () => {
     const plugin = smrtConsumer({
       packages: [],
       projectRoot,
@@ -55,7 +56,40 @@ describe('smrtConsumer resolveId', () => {
     const resolveId = getHook(plugin, 'resolveId');
 
     const resolved = resolveId.call({}, '@smrt/routes', undefined);
-    expect(resolved).toBe('\0smrt:routes');
+    // Namespaced id (#1795): distinct from smrtPlugin's `\0smrt:routes` so the
+    // two virtual modules never share a rollup id.
+    expect(resolved).toBe('\0smrt-consumer:routes');
+  });
+
+  it('resolves to a DISTINCT virtual id from smrtPlugin so neither shadows the other (#1795)', () => {
+    // Regression guard for #1795: smrtPlugin's `@happyvertical/smrt-virt-client`
+    // and smrtConsumer's `@smrt/client` used to BOTH resolve to `\0smrt:client`.
+    // Sharing that id let the consumer fallback non-deterministically win in
+    // standalone/federation builds and shadow the real generated client. The two
+    // ids must differ.
+    const consumer = smrtConsumer({
+      packages: [],
+      projectRoot,
+      disableScanning: true,
+    });
+    const producer: any = smrtPlugin();
+
+    const consumerResolve = getHook(consumer, 'resolveId');
+    const producerResolveRaw = producer.resolveId;
+    const producerResolve =
+      typeof producerResolveRaw === 'function'
+        ? producerResolveRaw
+        : producerResolveRaw.handler;
+
+    const consumerId = consumerResolve.call({}, '@smrt/client', undefined);
+    const producerId = producerResolve.call(
+      producer,
+      '@happyvertical/smrt-virt-client',
+    );
+
+    expect(consumerId).toBe('\0smrt-consumer:client');
+    expect(producerId).toBe('\0smrt:client');
+    expect(consumerId).not.toBe(producerId);
   });
 
   it('resolves a virtual module to the physical .d.ts file when it exists', () => {
@@ -90,41 +124,41 @@ describe('smrtConsumer load fallback modules', () => {
 
   it('returns a fallback routes module', async () => {
     const load = getHook(makePlugin(), 'load');
-    const code = await load.call({}, '\0smrt:routes');
+    const code = await load.call({}, '\0smrt-consumer:routes');
     expect(code).toContain('export function setupRoutes');
     expect(code).toContain('export default setupRoutes');
   });
 
   it('returns an empty-client fallback when the manifest has no objects', async () => {
     const load = getHook(makePlugin(), 'load');
-    const code = await load.call({}, '\0smrt:client');
+    const code = await load.call({}, '\0smrt-consumer:client');
     expect(code).toContain('export function createClient');
     expect(code).toContain('No API client available');
   });
 
   it('returns a fallback mcp module', async () => {
     const load = getHook(makePlugin(), 'load');
-    const code = await load.call({}, '\0smrt:mcp');
+    const code = await load.call({}, '\0smrt-consumer:mcp');
     expect(code).toContain('export function createMCPServer');
     expect(code).toContain('tools: []');
   });
 
   it('returns a no-types message when the manifest has no objects', async () => {
     const load = getHook(makePlugin(), 'load');
-    const code = await load.call({}, '\0smrt:types');
+    const code = await load.call({}, '\0smrt-consumer:types');
     expect(code).toContain('No types available');
   });
 
   it('returns a manifest module embedding the manifest JSON', async () => {
     const load = getHook(makePlugin(), 'load');
-    const code = await load.call({}, '\0smrt:manifest');
+    const code = await load.call({}, '\0smrt-consumer:manifest');
     expect(code).toContain('export const manifest =');
     expect(code).toContain('export default manifest');
   });
 
   it('returns null for an unknown virtual id', async () => {
     const load = getHook(makePlugin(), 'load');
-    expect(await load.call({}, '\0smrt:nope')).toBeNull();
+    expect(await load.call({}, '\0smrt-consumer:nope')).toBeNull();
   });
 });
 
@@ -181,12 +215,74 @@ describe('smrtConsumer load with a populated manifest', () => {
     const plugin = await pluginWithObjects();
     const load = getHook(plugin, 'load');
 
-    const client = await load.call({}, '\0smrt:client');
-    expect(client).toContain('Widget:');
+    const client = await load.call({}, '\0smrt-consumer:client');
+    // Object keys are quoted (#1795), so a simple name appears as "Widget":.
+    expect(client).toContain('"Widget":');
     expect(client).toContain("'/widgets'");
 
-    const types = await load.call({}, '\0smrt:types');
+    const types = await load.call({}, '\0smrt-consumer:types');
     expect(types).toContain('export interface WidgetData');
+  });
+
+  it('emits SYNTACTICALLY VALID client code for a package-qualified manifest key (#1795)', async () => {
+    // Regression guard for #1795: a qualified STI key like
+    // `@happyvertical/smrt-assets:AssetAssociation` is not a valid bare
+    // object-literal key. The pre-fix emission wrote it unquoted, producing a
+    // build-breaking syntax error. The key must be quoted so the module parses.
+    mkdirSync(join(projectRoot, 'node_modules', '@acme', 'assets', 'dist'), {
+      recursive: true,
+    });
+    writePackageJson(projectRoot, { name: 'consumer-app', version: '1.0.0' });
+    writePackageJson(join(projectRoot, 'node_modules', '@acme', 'assets'), {
+      name: '@acme/assets',
+      version: '1.0.0',
+      exports: { '.': './dist/index.js' },
+    });
+    writeFileSync(
+      join(
+        projectRoot,
+        'node_modules',
+        '@acme',
+        'assets',
+        'dist',
+        'manifest.json',
+      ),
+      JSON.stringify({
+        packageName: '@acme/assets',
+        objects: {
+          '@acme/assets:AssetAssociation': {
+            className: 'AssetAssociation',
+            collection: 'asset_associations',
+            fields: {},
+            methods: {},
+            decoratorConfig: {},
+          },
+        },
+      }),
+    );
+
+    const plugin = smrtConsumer({
+      packages: ['@acme/assets'],
+      generateTypes: false,
+      projectRoot,
+      disableScanning: true,
+    });
+    await plugin.buildStart?.call({} as any);
+    const load = getHook(plugin, 'load');
+    const client = (await load.call({}, '\0smrt-consumer:client')) as string;
+
+    // The qualified key is present and QUOTED.
+    expect(client).toContain('"@acme/assets:AssetAssociation":');
+
+    // The emitted module must be syntactically valid: import it as a data URI.
+    // A pre-fix unquoted key throws SyntaxError here.
+    const dataUri = `data:text/javascript,${encodeURIComponent(client)}`;
+    const mod = await import(dataUri);
+    expect(typeof mod.createClient).toBe('function');
+    // The client exposes the qualified key as a collection accessor.
+    const api = mod.createClient('/api/v1');
+    expect(api['@acme/assets:AssetAssociation']).toBeDefined();
+    expect(typeof api['@acme/assets:AssetAssociation'].list).toBe('function');
   });
 });
 

--- a/packages/core/src/generated-client-runtime.ts
+++ b/packages/core/src/generated-client-runtime.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared runtime source injected into every generated API client
+ * (`smrtPlugin`'s `@happyvertical/smrt-virt-client` and `smrtConsumer`'s
+ * `@smrt/client` fallback).
+ *
+ * The generated fetchers MUST reject on `!response.ok` (#1796): before this,
+ * every fetcher resolved `r.json()` regardless of HTTP status, so a 500 (or any
+ * error response) resolved successfully with the error payload. Mutation
+ * failures were therefore invisible to callers — an optimistic-update layer
+ * (e.g. TanStack DB `onInsert`) could never observe the failure and roll back.
+ *
+ * `SmrtClientError` carries the HTTP `status` and the parsed error `body` (when
+ * the response was JSON), so callers can branch on status and surface server
+ * messages. Both helpers are emitted with a `__smrt` prefix so they cannot
+ * collide with a collection key in the generated module.
+ *
+ * WIRE-SHAPE POLICY (#1797, ADR 0001): the server returns BARE JSON — a bare
+ * array for list, a bare object for get/create/update — with snake_case field
+ * names (`created_at`, `updated_at`) exactly as `SmrtObject.toJSON()` emits
+ * them. These helpers pass that JSON through unchanged; they do NOT wrap it in
+ * an envelope or camelCase the keys. The generated `.d.ts` declarations
+ * (vite-plugin + prebuild) are written to match this shape. This same
+ * snake_case wire feeds the mobile DTO codegen; do not change the wire here.
+ */
+export const CLIENT_FETCH_RUNTIME = `class SmrtClientError extends Error {
+  constructor(message, status, body) {
+    super(message);
+    this.name = 'SmrtClientError';
+    this.status = status;
+    this.body = body;
+  }
+}
+
+async function __smrtParseBody(response) {
+  const contentType = response.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    try {
+      return await response.json();
+    } catch {
+      return undefined;
+    }
+  }
+  try {
+    return await response.text();
+  } catch {
+    return undefined;
+  }
+}
+
+// Rejects on !response.ok with a typed SmrtClientError; otherwise resolves the
+// parsed JSON body exactly as the server sent it (bare array/object, snake_case
+// fields).
+async function __smrtFetchJson(url, init) {
+  const response = await fetch(url, init);
+  const body = await __smrtParseBody(response);
+  if (!response.ok) {
+    const detail =
+      body && typeof body === 'object' && body.error ? ': ' + body.error : '';
+    throw new SmrtClientError(
+      'Request failed with status ' + response.status + detail,
+      response.status,
+      body,
+    );
+  }
+  return body;
+}
+
+// DELETE variant: rejects on !response.ok (so a failed delete is observable),
+// otherwise resolves true.
+async function __smrtFetchOk(url, init) {
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    const body = await __smrtParseBody(response);
+    const detail =
+      body && typeof body === 'object' && body.error ? ': ' + body.error : '';
+    throw new SmrtClientError(
+      'Request failed with status ' + response.status + detail,
+      response.status,
+      body,
+    );
+  }
+  return true;
+}`;

--- a/packages/core/src/generators/rest-routes.spec.ts
+++ b/packages/core/src/generators/rest-routes.spec.ts
@@ -442,19 +442,31 @@ describe('REST generator auto-discovery (#1500)', () => {
     await db?.close?.();
   });
 
-  it('resolves a registered class through the registry fallback (no 404)', async () => {
-    // The discovery matcher pluralizes BOTH sides, so the registered simple
-    // name `RestDiscoveryWidget` is matched by its singular URL segment. This
+  it('resolves a registered class through the registry fallback by its plural collection segment (no 404)', async () => {
+    // #1794: the URL segment IS the canonical `collection` value (`RestDiscoveryWidget`
+    // -> `restdiscoverywidgets`) — the SAME segment the generated client emits.
+    // Auto-discovery matches that segment VERBATIM (no re-pluralization). This
     // exercises the whole ObjectRegistry fallback path (class lookup + auth gate
-    // + getCollection factory). The generator builds the auto-discovered
-    // collection but does not call initialize() on it, so list() surfaces a 500
-    // rather than a 200 — the resolution branch is what we assert here (it is
-    // NOT a 404 "object type not found").
+    // + getCollection factory, which now awaits initialize() so the
+    // auto-discovered collection is actually usable). A resolved list() returns
+    // 200 with an array — NOT a 404 "object type not found".
+    const res = await handler(
+      new Request('http://local/api/v1/restdiscoverywidgets'),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+  });
+
+  it('404s the singular class name (only the plural collection segment routes) (#1794)', async () => {
+    // Regression guard for #1794: the pre-fix matcher pluralized BOTH sides and
+    // matched the SINGULAR segment, which is exactly what made the generated
+    // client's plural URL 404. The canonical collection segment is plural; the
+    // singular must NOT resolve.
     const res = await handler(
       new Request('http://local/api/v1/restdiscoverywidget'),
     );
-    expect(res.status).not.toBe(404);
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(404);
   });
 
   it('returns 404 through the discovery path for an unknown type', async () => {
@@ -466,18 +478,20 @@ describe('REST generator auto-discovery (#1500)', () => {
 
   it('fail-closes a non-public discovered object with no auth middleware', async () => {
     // public is not set → isRoutePublic returns false → 401 on the discovery
-    // path (no api.registerCollection, no authMiddleware).
+    // path (no api.registerCollection, no authMiddleware). Uses the plural
+    // collection segment (`restdiscoveryprivates`) the client would emit.
     const api = new APIGenerator({ basePath: '/api/v1' }, { db });
     const h = api.generateHandler();
     const res = await h(
-      new Request('http://local/api/v1/restdiscoveryprivate'),
+      new Request('http://local/api/v1/restdiscoveryprivates'),
     );
     expect(res.status).toBe(401);
   });
 
   it('applies auth middleware on the auto-discovery path', async () => {
     // No api.registerCollection → discovery path; the middleware short-circuits
-    // with a Response before any collection work, covering lines 271-285.
+    // with a Response before any collection work. Uses the plural collection
+    // segment the client emits.
     const api = new APIGenerator(
       {
         basePath: '/api/v1',
@@ -488,7 +502,7 @@ describe('REST generator auto-discovery (#1500)', () => {
     );
     const denyHandler = api.generateHandler();
     const res = await denyHandler(
-      new Request('http://local/api/v1/restdiscoverywidget'),
+      new Request('http://local/api/v1/restdiscoverywidgets'),
     );
     expect(res.status).toBe(401);
   });

--- a/packages/core/src/generators/rest.ts
+++ b/packages/core/src/generators/rest.ts
@@ -304,19 +304,9 @@ export class APIGenerator {
       );
     }
 
-    // Fall back to auto-discovery via ObjectRegistry
-    const registeredClasses = ObjectRegistry.getAllClasses();
-    const pluralName = this.pluralize(objectType);
-
-    let classInfo: RegisteredClass | null = null;
-    for (const [_key, info] of registeredClasses) {
-      // Issue #951: Use simple name (info.name) for URL matching, not the map key
-      // which may be a qualified name like '@happyvertical/smrt-events:Event'
-      if (this.pluralize((info.name || _key).toLowerCase()) === pluralName) {
-        classInfo = info;
-        break;
-      }
-    }
+    // Fall back to auto-discovery via ObjectRegistry, matching the URL segment
+    // against the canonical manifest `collection` value (#1794).
+    const classInfo = this.findClassByCollectionSegment(objectType);
 
     if (!classInfo) {
       return this.createErrorResponse(
@@ -343,7 +333,7 @@ export class APIGenerator {
     }
 
     // Get or create collection
-    const collection = this.getCollection(classInfo);
+    const collection = await this.getCollection(classInfo);
 
     return await this.executeCrudOperation(
       req,
@@ -797,11 +787,11 @@ export class APIGenerator {
    * resolves a CRUD URL segment (registered collections first, then registry
    * auto-discovery), and wrap the generator's per-object machinery.
    */
-  private resolveSyncApplyTarget(
+  private async resolveSyncApplyTarget(
     objectSegment: string,
     req: Request,
     rawBody: string,
-  ): SyncApplyTarget | null {
+  ): Promise<SyncApplyTarget | null> {
     let collection: SmrtCollection<SmrtObject> | null = null;
     let objectName: string | null = null;
 
@@ -810,13 +800,12 @@ export class APIGenerator {
       collection = registered;
       objectName = this.getCollectionObjectName(registered) || objectSegment;
     } else {
-      const pluralName = this.pluralize(objectSegment);
-      for (const [key, info] of ObjectRegistry.getAllClasses()) {
-        if (this.pluralize((info.name || key).toLowerCase()) === pluralName) {
-          collection = this.getCollection(info);
-          objectName = info.name;
-          break;
-        }
+      // Same canonical-`collection` match as the CRUD path so a client and the
+      // batch contract resolve identical segments (#1794).
+      const info = this.findClassByCollectionSegment(objectSegment);
+      if (info) {
+        collection = await this.getCollection(info);
+        objectName = info.name;
       }
     }
 
@@ -864,9 +853,9 @@ export class APIGenerator {
   /**
    * Get or create collection instance
    */
-  private getCollection(
+  private async getCollection(
     classInfo: RegisteredClass,
-  ): SmrtCollection<SmrtObject> {
+  ): Promise<SmrtCollection<SmrtObject>> {
     if (!this.collections.has(classInfo.name)) {
       // `collectionConstructor` is typed optional on RegisteredClass, but the
       // auto-discovery path only reaches here for classes that declare one.
@@ -878,6 +867,14 @@ export class APIGenerator {
         ai: this.context.ai,
         db: this.context.db,
       });
+      // Await initialize() so the auto-discovered collection is actually usable
+      // (its DB is wired). Without this, list()/get() throw "Database accessed
+      // before initialization" — a latent bug that was masked while the
+      // generated client's plural URLs never matched the singular-only
+      // auto-discovery segment (#1794). The explicit-registerCollection() path
+      // receives an already-initialized collection from the caller, so this
+      // only affects the auto-discovery factory.
+      await collection.initialize();
       this.collections.set(classInfo.name, collection);
     }
     const collection = this.collections.get(classInfo.name);
@@ -1059,6 +1056,44 @@ export class APIGenerator {
       statusText: response.statusText,
       headers,
     });
+  }
+
+  /**
+   * Resolve a URL/collection segment to a registered class via auto-discovery.
+   *
+   * The segment IS the canonical `collection` value from the manifest
+   * (`RegisteredClass.collection`, e.g. `products` for `Product`) — the same
+   * value the generated client, the SvelteKit route generator, and the registry
+   * all derive. Match it VERBATIM; do not re-pluralize. The previous
+   * implementation pluralized both the URL segment and the class name and
+   * compared them, turning an already-plural client URL (`/products`) into
+   * `productses`, so the generated client 404'd against auto-discovered routes
+   * (#1794). Shared by the CRUD path and the `sync/apply` batch path so they can
+   * never drift.
+   *
+   * @param segment - The URL/collection path segment (e.g. `products`).
+   * @returns The matching registered class, or null if none matches.
+   */
+  private findClassByCollectionSegment(
+    segment: string,
+  ): RegisteredClass | null {
+    for (const [key, info] of ObjectRegistry.getAllClasses()) {
+      // Primary match: the canonical manifest `collection` segment.
+      if (info.collection === segment) {
+        return info;
+      }
+      // Back-compat fallback for classes registered without a `collection`
+      // (inline/test stubs): derive the plural segment from the simple name and
+      // compare to the raw URL segment. Issue #951: use the simple name
+      // (info.name), not the qualified map key.
+      if (
+        !info.collection &&
+        this.pluralize((info.name || key).toLowerCase()) === segment
+      ) {
+        return info;
+      }
+    }
+    return null;
   }
 
   /**

--- a/packages/core/src/prebuild/index.ts
+++ b/packages/core/src/prebuild/index.ts
@@ -175,23 +175,35 @@ declare module '@smrt/manifest' {
     })
     .join('\n');
 
+  // Wire-shape policy (#1797): the server returns BARE JSON — a bare array for
+  // list/search, a bare object for get/create/update — with snake_case field
+  // names (created_at, updated_at). These declarations match that shape (no
+  // envelope, no camelCase) and are byte-identical to the vite-plugin client
+  // declaration. Fetchers reject on non-2xx with a SmrtClientError (#1796).
   const clientDeclaration = `/**
  * Auto-generated API client module declaration
  */
 declare module '@smrt/client' {
-  export interface ApiResponse<T = any> {
-    id?: string;
-    data?: T;
+  /** Shape of a JSON error body carried by a rejected request (SmrtClientError.body). */
+  export interface ApiError {
     error?: string;
     message?: string;
   }
 
+  /** Typed error thrown by every fetcher on a non-2xx response (#1796). */
+  export interface SmrtClientError extends Error {
+    name: 'SmrtClientError';
+    status: number;
+    body?: ApiError | string;
+  }
+
   export interface CrudOperations<T = any> {
-    list(params?: Record<string, any>): Promise<ApiResponse<T[]>>;
-    get(id: string): Promise<ApiResponse<T>>;
-    create(data: Partial<T>): Promise<ApiResponse<T>>;
-    update(id: string, data: Partial<T>): Promise<ApiResponse<T>>;
+    list(params?: Record<string, any>): Promise<T[]>;
+    get(id: string): Promise<T>;
+    create(data: Partial<T>): Promise<T>;
+    update(id: string, data: Partial<T>): Promise<T>;
     delete(id: string): Promise<boolean>;
+    search(query: string): Promise<T[]>;
   }
 
   export interface ApiClient {

--- a/packages/core/src/vite-plugin/generated-client-integration.test.ts
+++ b/packages/core/src/vite-plugin/generated-client-integration.test.ts
@@ -215,6 +215,10 @@ export class GenClientProduct extends SmrtObject {
   });
 
   it('#1797: list() returns a BARE array whose items carry snake_case created_at', async () => {
+    // Seed this test's own row so the assertion doesn't depend on test order.
+    const seeded = await collection.create({ name: 'Sprocket', price: 3 });
+    await seeded.save();
+
     stubFetchToServer(handler);
     const client = createClient('/api/v1');
 
@@ -223,7 +227,11 @@ export class GenClientProduct extends SmrtObject {
 
     const rows = result as Array<Record<string, unknown>>;
     expect(rows.length).toBeGreaterThan(0);
-    const row = rows[0];
+    const row = rows.find((r) => r.name === 'Sprocket') as Record<
+      string,
+      unknown
+    >;
+    expect(row).toBeDefined();
     // Wire field naming is snake_case (matches toJSON()/toPublicJSON()).
     expect(row).toHaveProperty('created_at');
     expect(row).not.toHaveProperty('createdAt');

--- a/packages/core/src/vite-plugin/generated-client-integration.test.ts
+++ b/packages/core/src/vite-plugin/generated-client-integration.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Integration coverage for the GENERATED CLIENT driven against the GENERATED
+ * SERVER (#1794, #1796, #1797).
+ *
+ * The reference apps never caught these bugs because their pages ran on a mock
+ * client — the generated `@happyvertical/smrt-virt-client` and the generated
+ * `APIGenerator` server had never been exercised against each other. This suite
+ * is the "one integration test suite" the #1756 spike asked for: it scans a real
+ * mini-project into a genuine manifest, loads the generated client module the
+ * way Vite does (through the plugin's `load` hook), and points it at a real
+ * `APIGenerator` bound to an in-memory SQLite collection.
+ *
+ * What each concern proves:
+ * - #1794: the client's URL scheme (`/<collection>`) resolves against the
+ *   server's auto-discovery (no explicit `registerCollection`) — no 404 from a
+ *   re-pluralized (`products` -> `productses`) segment.
+ * - #1796: an error response (HTTP 500) makes the client fetcher REJECT, so an
+ *   optimistic-update layer can observe the failure and roll back.
+ * - #1797: the response shape the client receives matches its declared type —
+ *   a BARE array for list, and snake_case `created_at` on the wire.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { SmrtCollection } from '../collection';
+import { field } from '../decorators';
+import { APIGenerator } from '../generators/rest';
+import { SmrtObject } from '../object';
+import { ObjectRegistry, smrt } from '../registry';
+import { getTestDatabase } from '../testing/database';
+import { smrtPlugin } from './index.js';
+
+// A collection whose canonical segment is already plural
+// (`GenClientProduct` -> `genclientproducts`). The generated client emits GET
+// /genclientproducts; the pre-fix server re-pluralized that URL segment
+// (-> `genclientproductses`) on the auto-discovery path and 404'd. Public so
+// route dispatch isn't gated by auth on the integration path.
+@smrt({ api: { public: true } })
+class GenClientProduct extends SmrtObject {
+  @field({ type: 'text' })
+  name: string = '';
+
+  @field({ type: 'integer' })
+  price: number = 0;
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+    if (options.price !== undefined) this.price = options.price;
+  }
+}
+
+class GenClientProductCollection extends SmrtCollection<GenClientProduct> {
+  static readonly _itemClass = GenClientProduct;
+}
+
+function getHook(plugin: any, name: string) {
+  const hook = plugin[name];
+  return typeof hook === 'function' ? hook : hook.handler;
+}
+
+/**
+ * Shape of the runtime object the generated client module exports.
+ * Each collection key exposes CRUD fetchers.
+ */
+interface GeneratedClient {
+  [collectionKey: string]: {
+    list: (params?: unknown) => Promise<unknown>;
+    get: (id: string) => Promise<unknown>;
+    create: (data: unknown) => Promise<unknown>;
+    update: (id: string, data: unknown) => Promise<unknown>;
+    delete: (id: string) => Promise<unknown>;
+    search: (query: string) => Promise<unknown>;
+  };
+}
+
+describe('generated client <-> generated server integration (#1794/#1796/#1797)', () => {
+  let projectRoot: string;
+  let clientModuleDir: string;
+  let db: any;
+  let collection: GenClientProductCollection;
+  let createClient: (basePath?: string) => GeneratedClient;
+  let handler: (req: Request) => Promise<Response>;
+
+  beforeAll(async () => {
+    // Register the collection so the server can auto-discover it WITHOUT an
+    // explicit registerCollection() call — the exact path #1794 broke.
+    ObjectRegistry.registerCollection(
+      'GenClientProduct',
+      GenClientProductCollection,
+    );
+
+    // Real mini-project scanned into a genuine manifest so the generated client
+    // uses the same `collection` segment the server derives.
+    projectRoot = mkdtempSync(join(tmpdir(), 'smrt-gen-client-'));
+    mkdirSync(join(projectRoot, 'src'), { recursive: true });
+    writeFileSync(
+      join(projectRoot, 'package.json'),
+      JSON.stringify({
+        name: 'gen-client-app',
+        version: '0.0.1',
+        type: 'module',
+      }),
+    );
+    writeFileSync(
+      join(projectRoot, 'src', 'objects.ts'),
+      `import { SmrtObject } from '@happyvertical/smrt-core';
+
+@smrt({ api: { public: true } })
+export class GenClientProduct extends SmrtObject {
+  name: string = '';
+  price: number = 0;
+}
+`,
+    );
+
+    const plugin: any = smrtPlugin({
+      generateTypes: false,
+      include: ['src/**/*.ts'],
+    });
+    await plugin.configResolved?.call(plugin, {
+      root: projectRoot,
+      mode: 'production',
+      plugins: [],
+      build: {},
+    } as any);
+
+    const load = getHook(plugin, 'load').bind(plugin);
+    const clientSource = (await load('\0smrt:client')) as string;
+    // The client key is the manifest `collection` segment. `GenClientProduct`
+    // pluralizes to `genclientproducts`; assert that here so a future
+    // inflection change surfaces as a readable failure rather than an
+    // `undefined.list()` TypeError below.
+    expect(clientSource).toContain('genclientproducts:');
+
+    // Evaluate the generated ESM the way a bundler would: write it to disk and
+    // dynamic-import it. This exercises the ACTUAL emitted source, not a
+    // hand-rolled reimplementation.
+    clientModuleDir = mkdtempSync(join(tmpdir(), 'smrt-gen-client-mod-'));
+    const clientModulePath = join(clientModuleDir, 'client.mjs');
+    writeFileSync(clientModulePath, clientSource, 'utf-8');
+    const mod = await import(pathToFileURL(clientModulePath).href);
+    createClient = mod.createClient;
+
+    // Real in-memory SQLite collection + generated server. No registerCollection
+    // on the APIGenerator — force the auto-discovery path.
+    db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['GenClientProduct'],
+    });
+    collection = await GenClientProductCollection.create({ db });
+    const api = new APIGenerator({ basePath: '/api/v1' }, { db });
+    handler = api.generateHandler();
+  }, 60_000);
+
+  afterAll(async () => {
+    await db?.close?.();
+    if (projectRoot) rmSync(projectRoot, { recursive: true, force: true });
+    if (clientModuleDir)
+      rmSync(clientModuleDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * Route the generated client's `fetch(url, init)` calls into the generated
+   * server's request handler. This is what wires CLIENT -> SERVER in-process.
+   */
+  function stubFetchToServer(
+    routeHandler: (req: Request) => Promise<Response>,
+  ): void {
+    vi.stubGlobal('fetch', async (input: string | URL, init?: RequestInit) => {
+      const url =
+        typeof input === 'string'
+          ? input.startsWith('http')
+            ? input
+            : `http://local${input}`
+          : input.toString();
+      return routeHandler(new Request(url, init));
+    });
+  }
+
+  it('#1794: generated client list() URL resolves against server auto-discovery (no 404)', async () => {
+    // Seed a row so a resolved route returns data.
+    const seeded = await collection.create({ name: 'Widget', price: 5 });
+    await seeded.save();
+
+    stubFetchToServer(handler);
+    const client = createClient('/api/v1');
+
+    // The generated client uses the manifest `collection` segment (`products`);
+    // the server must resolve that same segment. Pre-fix, auto-discovery
+    // re-pluralized and returned 404 -> the client received the {error} body.
+    const result = await client.genclientproducts.list();
+
+    expect(Array.isArray(result)).toBe(true);
+    const rows = result as Array<Record<string, unknown>>;
+    // A 404 would have surfaced `{ error: "Object type '...' not found" }`,
+    // which is NOT an array of products.
+    expect(rows.some((r) => r.name === 'Widget')).toBe(true);
+  });
+
+  it('#1797: list() returns a BARE array whose items carry snake_case created_at', async () => {
+    stubFetchToServer(handler);
+    const client = createClient('/api/v1');
+
+    const result = await client.genclientproducts.list();
+    expect(Array.isArray(result)).toBe(true); // bare array, not { data: [...] }
+
+    const rows = result as Array<Record<string, unknown>>;
+    expect(rows.length).toBeGreaterThan(0);
+    const row = rows[0];
+    // Wire field naming is snake_case (matches toJSON()/toPublicJSON()).
+    expect(row).toHaveProperty('created_at');
+    expect(row).not.toHaveProperty('createdAt');
+  });
+
+  it('#1794/#1797: create() then get() round-trips through the generated client', async () => {
+    stubFetchToServer(handler);
+    const client = createClient('/api/v1');
+
+    const created = (await client.genclientproducts.create({
+      name: 'Gadget',
+      price: 12,
+    })) as Record<string, unknown>;
+    expect(created).toHaveProperty('id');
+    expect(created.name).toBe('Gadget');
+    expect(created).toHaveProperty('created_at');
+
+    const fetched = (await client.genclientproducts.get(
+      created.id as string,
+    )) as Record<string, unknown>;
+    expect(fetched.id).toBe(created.id);
+    expect(fetched.name).toBe('Gadget');
+  });
+
+  it('#1796: a 500 response makes the generated client REJECT (optimistic rollback can observe it)', async () => {
+    // A server that always 500s — models a failing mutation.
+    const failing: (req: Request) => Promise<Response> = async () =>
+      new Response(JSON.stringify({ error: 'boom' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      });
+    stubFetchToServer(failing);
+    const client = createClient('/api/v1');
+
+    // An optimistic-update layer applies its change, then awaits the mutation;
+    // if the promise resolves on a 500 the rollback can never fire. Assert it
+    // rejects instead.
+    let rolledBack = false;
+    await expect(
+      client.genclientproducts
+        .create({ name: 'DoomedGadget', price: 1 })
+        .catch((err) => {
+          rolledBack = true;
+          throw err;
+        }),
+    ).rejects.toBeDefined();
+    expect(rolledBack).toBe(true);
+  });
+});

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -11,6 +11,7 @@ import type {
   DomainKnowledgeManifest,
 } from '@happyvertical/smrt-types';
 import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite';
+import { CLIENT_FETCH_RUNTIME } from '../generated-client-runtime.js';
 import { buildDomainKnowledgeManifest } from '../knowledge.js';
 import { discoverSmrtPackages } from '../manifest/discover-smrt-packages.js';
 import type { SmartObjectManifest } from '../scanner/types';
@@ -1220,14 +1221,15 @@ function generateClientModule(
 
       // Generate custom method implementations.
       // Custom methods are instance methods: POST /{collection}/{id}/{urlSegment}.
+      // All fetchers reject on !response.ok (#1796) via __smrtFetchJson.
       const customMethodImpls = customMethods
         .map(([methodName, _method]) => {
           const urlSegment = segmentFor(methodName);
-          return `    ${methodName}: (id, options) => fetch(basePath + '/${collection}/' + id + '/${urlSegment}', {
+          return `    ${methodName}: (id, options) => __smrtFetchJson(basePath + '/${collection}/' + id + '/${urlSegment}', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(options || {})
-    }).then(r => r.json())`;
+    })`;
         })
         .join(',\n');
 
@@ -1236,37 +1238,37 @@ function generateClientModule(
 
       return `
   ${clientKey}: {
-    list: (params) => fetch(basePath + '/${collection}', {
+    list: (params) => __smrtFetchJson(basePath + '/${collection}', {
       method: 'GET',
       headers: { 'Content-Type': 'application/json' }
-    }).then(r => r.json()),
+    }),
 
-    get: (id) => fetch(basePath + '/${collection}/' + id, {
+    get: (id) => __smrtFetchJson(basePath + '/${collection}/' + id, {
       method: 'GET',
       headers: { 'Content-Type': 'application/json' }
-    }).then(r => r.json()),
+    }),
 
-    create: (data) => fetch(basePath + '/${collection}', {
+    create: (data) => __smrtFetchJson(basePath + '/${collection}', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data)
-    }).then(r => r.json()),
+    }),
 
-    update: (id, data) => fetch(basePath + '/${collection}/' + id, {
+    update: (id, data) => __smrtFetchJson(basePath + '/${collection}/' + id, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data)
-    }).then(r => r.json()),
+    }),
 
-    delete: (id) => fetch(basePath + '/${collection}/' + id, {
+    delete: (id) => __smrtFetchOk(basePath + '/${collection}/' + id, {
       method: 'DELETE',
       headers: { 'Content-Type': 'application/json' }
-    }).then(r => r.ok),
+    }),
 
-    search: (query) => fetch(basePath + '/${collection}/search?q=' + encodeURIComponent(query), {
+    search: (query) => __smrtFetchJson(basePath + '/${collection}/search?q=' + encodeURIComponent(query), {
       method: 'GET',
       headers: { 'Content-Type': 'application/json' }
-    }).then(r => r.json())${customMethodsBlock}
+    })${customMethodsBlock}
   }`;
     })
     .join(',');
@@ -1274,6 +1276,8 @@ function generateClientModule(
   return `
 // Auto-generated API client from SMRT objects
 // This file is generated automatically - do not edit
+
+${CLIENT_FETCH_RUNTIME}
 
 export function createClient(basePath = '/api/v1') {
   return {${clientMethods}

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -1516,11 +1516,14 @@ async function generateTypeDeclarationFile(
           })
           .join('\n');
 
+        // Timestamps are snake_case on the wire (#1797): the server returns
+        // `created_at`/`updated_at` exactly as SmrtObject.toJSON() emits them,
+        // matching the prebuild + client-mode type paths.
         return `  export interface ${interfaceName} {
     id?: string;
 ${fields}
-    createdAt?: string;
-    updatedAt?: string;
+    created_at?: string;
+    updated_at?: string;
   }`;
       })
       .join('\n\n');
@@ -1647,13 +1650,24 @@ declare module '@happyvertical/smrt-virt-routes' {
   export default setupRoutes;
 }
 
-// Client module - Auto-generated API client  
+// Client module - Auto-generated API client
+// Wire-shape policy (#1797): the server returns BARE JSON — a bare array for
+// list/search, a bare object for get/create/update — with snake_case field
+// names (created_at, updated_at). These declarations match that shape (no
+// envelope, no camelCase). Fetchers reject on non-2xx with a SmrtClientError
+// (#1796). This is byte-identical to the prebuild declaration path.
 declare module '@happyvertical/smrt-virt-client' {
-  export interface ApiResponse<T = any> {
-    id?: string;
-    data?: T;
+  /** Shape of a JSON error body carried by a rejected request (SmrtClientError.body). */
+  export interface ApiError {
     error?: string;
     message?: string;
+  }
+
+  /** Typed error thrown by every fetcher on a non-2xx response (#1796). */
+  export interface SmrtClientError extends Error {
+    name: 'SmrtClientError';
+    status: number;
+    body?: ApiError | string;
   }
 
   export interface CrudOperations<T = any> {


### PR DESCRIPTION
Fixes four interrelated generated-client bugs found by the #1756 TanStack DB spike, plus the capstone integration test the spike asked for ("the generated client needs one owner and one integration test suite"). These block #1761 (the smrt-web collection runtime).

The reference apps never caught these because their pages ran on a **mock** client — the generated `@happyvertical/smrt-virt-client` and the generated `APIGenerator` server had never been exercised against each other.

Closes #1794
Closes #1795
Closes #1796
Closes #1797

## Per-bug summary (red -> green)

### #1794 — client URLs 404 against auto-discovery (`products` -> `productses`)
The generated client builds URLs from the manifest `collection` value (`/products`), but `APIGenerator` auto-discovery re-pluralized the already-plural URL segment and compared it to the pluralized class name, so they never matched.

- **Red:** driving the generated client at the generated server, `list()` returned `{ error: "Object type '...' not found" }` (a 404 body), not an array.
- **Fix:** match the URL segment VERBATIM against `RegisteredClass.collection` — the single source of truth shared by the client, the SvelteKit route generator, and the registry. A shared `findClassByCollectionSegment()` helper backs both the CRUD path and the `sync/apply` batch path so they can't drift. Also `await collection.initialize()` in the auto-discovery `getCollection()` factory (a latent bug the routing fix exposed: the constructed collection was never initialized, so `list()` threw "Database accessed before initialization").
- **Green:** the integration test + a unit regression asserting the plural segment resolves (200) and the singular 404s.

### #1795 — virtual-module collision + invalid emission for qualified keys
`smrtPlugin`'s `@happyvertical/smrt-virt-client` and `smrtConsumer`'s `@smrt/client` both resolved to `\0smrt:client`; in standalone/federation the consumer fallback non-deterministically won and shadowed the real client, and its emitted code was syntactically invalid for package-qualified keys.

- **Red:** both plugins resolved to `\0smrt:client` (`COLLIDE: true`); the consumer fallback emitted `@acme/things:AssetAssociation: {` (unquoted) → `SyntaxError` on import.
- **Fix:** (a) the consumer plugin resolves to namespaced ids (`\0smrt-consumer:*`) so neither shadows the other; (b) the consumer fallback quotes object keys via `JSON.stringify`.
- **Green:** a distinct-id assertion across both plugins, and a qualified-key emission imported as a data URI to prove it parses.

### #1796 — fetchers resolve on HTTP errors (mutation failures invisible)
Generated fetchers resolved `r.json()` regardless of status, so a 500 resolved successfully with the error payload — optimistic-update rollback could never trigger.

- **Red:** a 500-returning server made `create()` **resolve** `{ error: 'boom' }` instead of rejecting.
- **Fix:** fetchers reject on `!response.ok` with a typed `SmrtClientError` (status + parsed body), consistently across list/get/create/update/delete/search and custom methods, via a shared runtime injected into both plugins.
- **Green:** the integration test's 500-rejects case (an optimistic layer observes the rejection).

### #1797 — declarations disagree with each other and the wire
`prebuild` declared `ApiResponse<T[]>` envelopes; the vite-plugin declared bare `T[]`; the server returns bare arrays. Timestamps were `createdAt` in one d.ts but `created_at` on the wire.

- **Red:** the integration test asserted the client-declared shape (bare array, `created_at`) against a real generated-server response — the wire was a bare array with `created_at`, but the declarations disagreed.
- **Fix:** converge both declaration paths on the ACTUAL wire — bare arrays, snake_case `created_at`/`updated_at` (as `SmrtObject.toJSON()` emits), plus the `SmrtClientError`/`ApiError` types and the previously-missing `search` method so the two paths are byte-identical. The snake_case-wire policy is documented (it also feeds the mobile DTO codegen / ADR 0001). The wire itself is unchanged.

## Capstone integration test
`packages/core/src/vite-plugin/generated-client-integration.test.ts` scans a real mini-project into a genuine manifest, loads the generated client the way Vite does (via the plugin `load` hook), evaluates the emitted ESM, and points it at a real `APIGenerator` over an in-memory SQLite collection with **no** `registerCollection` (forcing auto-discovery). It exercises list + get + create through the CLIENT against the SERVER and asserts URLs resolve (#1794), the shape/field-names match the declared types (#1797), and an error response rejects (#1796).

## Gates
- `pnpm test` (core, via package script): **2873 passed, 30 skipped, 0 failed**
- `pnpm typecheck` (core): clean
- `npx biome check` on touched files: clean
- `node scripts/check-coverage.mjs --packages core`: **core 84.90% (floor 80%)**
- `pnpm knowledge:check --strict`: fresh, 0 errors / 0 warnings

Note: `products` tests fail to start in this environment on a pre-existing, change-independent tooling error (rolldown dep-optimization "Tsconfig not found" — reproduced identically on the clean base via `git stash`). `products` consumes the generated client only through a mock (`mock-smrt-client.ts`), so it is unaffected by these changes; CI runs it on ubuntu.
