### PR TITLE
feat(smrt-web): manifest-generated web collection runtime (#1761)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -56,7 +56,8 @@
       "@happyvertical/smrt-scanner",
       "@happyvertical/smrt-social",
       "@happyvertical/smrt-video",
-      "@happyvertical/smrt-voice"
+      "@happyvertical/smrt-voice",
+      "@happyvertical/smrt-web"
     ]
   ],
   "linked": [],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ All `@happyvertical/smrt-*` packages are version-locked via changesets. pnpm wor
 ### Tooling
 | Package | Purpose |
 |---------|---------|
+| smrt-web | Browser client data runtime (web twin of smrt-mobile): manifest-generated collections over the generated REST surface with SWR reads, request dedup, optimistic mutations; wraps the client-data engine (TanStack DB) behind SMRT-owned types so it never leaks |
 | smrt-svelte | Svelte 5: Provider, browser AI (STT/TTS/LLM) with warm cache, theme system |
 | smrt-dev-mcp | Tier 2 dev MCP: code generation, project introspection, deterministic knowledge reflection, review/architecture context bundles, bundled agent skills |
 | gnode | Federation library — stubs only, not implemented |

--- a/packages/core/src/prebuild/index.ts
+++ b/packages/core/src/prebuild/index.ts
@@ -6,6 +6,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { SmartObjectManifest } from '../scanner/types';
+import { selectWebCollectionEntries } from '../vite-plugin/web-collections.js';
 
 export interface PrebuildOptions {
   /** Path to manifest file or manifest object */
@@ -280,6 +281,49 @@ ${objectImports}
   }
 }`;
 
+  // Generate web collection-definition module declaration (#1761). Selection
+  // shares selectWebCollectionEntries with the vite-plugin runtime module and
+  // its virt-web d.ts, so this `tsc`-only consumer declaration cannot drift
+  // from the emitted values.
+  const webCollectionEntries = selectWebCollectionEntries(manifest)
+    .map(
+      ({ collection, obj }) =>
+        `    ${collection}: SmrtWebCollectionDefinition<import('./smrt-objects').${obj.className}Data>;`,
+    )
+    .join('\n');
+
+  const webDeclaration = `/**
+ * Auto-generated web collection-definition module declaration (#1761)
+ */
+declare module '@smrt/web' {
+  export interface SmrtWebFieldDefinition {
+    type: string;
+    required?: boolean;
+    default?: unknown;
+  }
+
+  export interface SmrtWebCollectionDefinition<TData = Record<string, unknown>> {
+    name: string;
+    className: string;
+    endpoint: string;
+    idField: string;
+    actions: string[];
+    fields: Record<string, SmrtWebFieldDefinition>;
+    /** Phantom row-type carrier for inference — never present at runtime. */
+    _row?: TData;
+  }
+
+  export interface SmrtWebCollectionDefinitions {
+${webCollectionEntries}
+  }
+
+  export const collectionDefinitions: SmrtWebCollectionDefinitions;
+  export function getCollectionDefinition<
+    K extends keyof SmrtWebCollectionDefinitions,
+  >(name: K): SmrtWebCollectionDefinitions[K];
+  export default collectionDefinitions;
+}`;
+
   // Write all virtual module declarations
   fs.writeFileSync(
     path.join(outDir, 'smrt-manifest.d.ts'),
@@ -289,6 +333,7 @@ ${objectImports}
   fs.writeFileSync(path.join(outDir, 'smrt-routes.d.ts'), routesDeclaration);
   fs.writeFileSync(path.join(outDir, 'smrt-mcp.d.ts'), mcpDeclaration);
   fs.writeFileSync(path.join(outDir, 'smrt-types.d.ts'), typesDeclaration);
+  fs.writeFileSync(path.join(outDir, 'smrt-web.d.ts'), webDeclaration);
 }
 
 /**

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -26,6 +26,10 @@ import {
   resolveApiActionSet,
   validateCliIncludeAgainstApi,
 } from './sveltekit-generator.js';
+import {
+  buildWebFieldDefinitions,
+  selectWebCollectionEntries,
+} from './web-collections.js';
 
 export type {
   CliApiCoherenceViolation,
@@ -119,6 +123,7 @@ const VIRTUAL_MODULES = {
   '@happyvertical/smrt-virt-schema': 'smrt:schema',
   '@happyvertical/smrt-virt-ui': 'smrt:ui',
   '@happyvertical/smrt-virt-cli': 'smrt:cli',
+  '@happyvertical/smrt-virt-web': 'smrt:web',
 };
 
 async function importScanner() {
@@ -825,6 +830,11 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
           // CLI module for command-line interface generation
           return await generateCLIModule(manifest);
 
+        case 'smrt:web':
+          // Web collection definitions for the browser client data runtime
+          // (@happyvertical/smrt-web, #1761)
+          return generateWebModule(manifest);
+
         default:
           return null;
       }
@@ -1289,6 +1299,56 @@ export { createClient as default };
 }
 
 /**
+ * Generate the virtual web-collection definition module
+ * (`@happyvertical/smrt-virt-web`, #1761).
+ *
+ * Emits typed per-collection metadata — REST collection name, endpoint path,
+ * id field, exposed CRUD actions, and persisted field definitions — for every
+ * API-exposed model in the manifest. This is the codegen contract consumed by
+ * `@happyvertical/smrt-web` to construct client collections over the generated
+ * REST surface. Deliberately data-only: no fetch code is emitted here, so the
+ * runtime wrapper owns all HTTP/error semantics in one place. Selection and
+ * field rules live in {@link selectWebCollectionEntries} /
+ * {@link buildWebFieldDefinitions} so this value emission and the matching
+ * d.ts type emission cannot drift.
+ */
+function generateWebModule(manifest: SmartObjectManifest): string {
+  const definitions: Record<string, unknown> = {};
+
+  for (const { collection, obj, actions } of selectWebCollectionEntries(
+    manifest,
+  )) {
+    definitions[collection] = {
+      name: collection,
+      className: obj.className,
+      endpoint: `/${collection}`,
+      idField: 'id',
+      actions,
+      fields: buildWebFieldDefinitions(obj),
+    };
+  }
+
+  return `
+// Auto-generated web collection definitions from SMRT objects (#1761)
+// This file is generated automatically - do not edit
+
+export const collectionDefinitions = ${JSON.stringify(definitions, null, 2)};
+
+export function getCollectionDefinition(name) {
+  const definition = collectionDefinitions[name];
+  if (!definition) {
+    throw new Error(
+      \`[smrt] Unknown web collection definition: \${name}. Known: \${Object.keys(collectionDefinitions).join(', ')}\`,
+    );
+  }
+  return definition;
+}
+
+export { collectionDefinitions as default };
+`;
+}
+
+/**
  * Generate virtual MCP module
  */
 async function generateMCPModule(
@@ -1568,6 +1628,18 @@ ${fields}
       })
       .join('\n');
 
+    // Typed web collection definitions (#1761): one entry per REST collection,
+    // with the row type threaded through the phantom `_row` carrier so
+    // downstream factories (`@happyvertical/smrt-web`) can infer it. Selection
+    // shares selectWebCollectionEntries with the runtime module so the declared
+    // types and the emitted values cannot drift.
+    const webCollectionInterface = selectWebCollectionEntries(manifest)
+      .map(
+        ({ collection, obj }) =>
+          `    ${collection}: SmrtWebCollectionDefinition<import('@happyvertical/smrt-virt-types').${obj.className}Data>;`,
+      )
+      .join('\n');
+
     // Generate MCP tool interfaces based on discovered methods
     const _mcpTools = Object.entries(manifest.objects).flatMap(([_name, obj]) =>
       Object.entries(obj.methods).map(([methodName, method]) => ({
@@ -1714,6 +1786,48 @@ declare module '@happyvertical/smrt-virt-types' {
 ${objectInterfaces}
 
   export default types;
+}
+
+// Web module - Typed collection definitions for the browser client data
+// runtime (@happyvertical/smrt-web, #1761)
+declare module '@happyvertical/smrt-virt-web' {
+  export type SmrtWebFieldType =
+    | 'text'
+    | 'decimal'
+    | 'boolean'
+    | 'integer'
+    | 'datetime'
+    | 'json'
+    | 'foreignKey'
+    | 'crossPackageRef'
+    | 'meta';
+
+  export interface SmrtWebFieldDefinition {
+    type: SmrtWebFieldType;
+    required?: boolean;
+    default?: unknown;
+  }
+
+  export interface SmrtWebCollectionDefinition<TData = Record<string, unknown>> {
+    name: string;
+    className: string;
+    endpoint: string;
+    idField: string;
+    actions: string[];
+    fields: Record<string, SmrtWebFieldDefinition>;
+    /** Phantom row-type carrier for inference — never present at runtime. */
+    _row?: TData;
+  }
+
+  export interface SmrtWebCollectionDefinitions {
+${webCollectionInterface}
+  }
+
+  export const collectionDefinitions: SmrtWebCollectionDefinitions;
+  export function getCollectionDefinition<
+    K extends keyof SmrtWebCollectionDefinitions,
+  >(name: K): SmrtWebCollectionDefinitions[K];
+  export default collectionDefinitions;
 }
 
 // CLI module - Auto-generated command-line interface

--- a/packages/core/src/vite-plugin/web-collections.test.ts
+++ b/packages/core/src/vite-plugin/web-collections.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for the shared web-collection selector (#1761).
+ *
+ * These drive {@link selectWebCollectionEntries} and
+ * {@link buildWebFieldDefinitions} directly over synthetic manifests — the
+ * single source of truth all three emission sites (runtime module, virt-web
+ * d.ts, prebuild @smrt/web d.ts) import. The vite-plugin load-hook integration
+ * lives in web-module.test.ts; this file covers the selection + field rules
+ * exhaustively without a scanner round-trip.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type {
+  FieldDefinition,
+  SmartObjectDefinition,
+  SmartObjectManifest,
+} from '../scanner/types.js';
+import {
+  buildWebFieldDefinitions,
+  selectWebCollectionEntries,
+} from './web-collections.js';
+
+type ObjInput = Partial<SmartObjectDefinition> & {
+  className: string;
+  collection: string;
+};
+
+/** Build a minimal manifest object; only selector-relevant fields matter. */
+function obj(input: ObjInput): SmartObjectDefinition {
+  return {
+    name: input.className.toLowerCase(),
+    qualifiedName:
+      input.qualifiedName ?? `@happyvertical/smrt-core:${input.className}`,
+    filePath: `src/${input.className}.ts`,
+    fields: {},
+    methods: {},
+    decoratorConfig: {},
+    ...input,
+  } as SmartObjectDefinition;
+}
+
+function manifest(...objects: SmartObjectDefinition[]): SmartObjectManifest {
+  return {
+    version: '1.0.0',
+    timestamp: 0,
+    objects: Object.fromEntries(
+      objects.map((o) => [o.qualifiedName ?? o.className, o]),
+    ),
+  } as SmartObjectManifest;
+}
+
+describe('selectWebCollectionEntries', () => {
+  it('includes a model with the default (omitted) api config as full CRUD', () => {
+    const entries = selectWebCollectionEntries(
+      manifest(obj({ className: 'Product', collection: 'products' })),
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0].collection).toBe('products');
+    expect(entries[0].obj.className).toBe('Product');
+    // Omitted api config exposes the full CRUD surface.
+    expect(entries[0].actions).toEqual([
+      'create',
+      'delete',
+      'get',
+      'list',
+      'update',
+    ]);
+  });
+
+  it('excludes api:false models (no read surface)', () => {
+    const entries = selectWebCollectionEntries(
+      manifest(
+        obj({
+          className: 'Secret',
+          collection: 'secrets',
+          decoratorConfig: {
+            api: false,
+          } as SmartObjectDefinition['decoratorConfig'],
+        }),
+      ),
+    );
+    expect(entries).toEqual([]);
+  });
+
+  it('excludes models that do not expose list', () => {
+    const entries = selectWebCollectionEntries(
+      manifest(
+        obj({
+          className: 'WriteOnly',
+          collection: 'writeonlys',
+          decoratorConfig: {
+            api: { exclude: ['list'] },
+          } as SmartObjectDefinition['decoratorConfig'],
+        }),
+      ),
+    );
+    expect(entries).toEqual([]);
+  });
+
+  it('emits the exposed action set, sorted', () => {
+    const entries = selectWebCollectionEntries(
+      manifest(
+        obj({
+          className: 'Article',
+          collection: 'articles',
+          decoratorConfig: {
+            api: { include: ['list', 'get'] },
+          } as SmartObjectDefinition['decoratorConfig'],
+        }),
+      ),
+    );
+    expect(entries[0].actions).toEqual(['get', 'list']);
+  });
+
+  it('excludes direct SmrtCollection subclasses', () => {
+    const entries = selectWebCollectionEntries(
+      manifest(
+        obj({
+          className: 'ProductCollection',
+          collection: 'products',
+          extends: 'SmrtCollection',
+          extendsTypeArg: 'Product',
+        }),
+      ),
+    );
+    expect(entries).toEqual([]);
+  });
+
+  it('excludes transitive collection subclasses (no type arg of their own)', () => {
+    const entries = selectWebCollectionEntries(
+      manifest(
+        obj({
+          className: 'ProductCollection',
+          collection: 'products',
+          extends: 'SmrtCollection',
+          extendsTypeArg: 'Product',
+        }),
+        // Deeper subclass carries no type arg — must still be excluded via the
+        // extends chain, not mistaken for a model owning `products`.
+        obj({
+          className: 'SpecialProductCollection',
+          collection: 'products',
+          extends: 'ProductCollection',
+          extendsQualified: '@happyvertical/smrt-core:ProductCollection',
+        }),
+      ),
+    );
+    expect(entries).toEqual([]);
+  });
+
+  it('folds STI children into the base model even when the child is scanned first', () => {
+    // Child listed BEFORE the base to prove order-independence.
+    const entries = selectWebCollectionEntries(
+      manifest(
+        obj({
+          className: 'Material',
+          collection: 'products',
+          extends: 'Product',
+          extendsQualified: '@happyvertical/smrt-core:Product',
+        }),
+        obj({ className: 'Product', collection: 'products' }),
+      ),
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0].obj.className).toBe('Product');
+  });
+
+  it('emits one entry per REST collection across many models', () => {
+    const entries = selectWebCollectionEntries(
+      manifest(
+        obj({ className: 'Product', collection: 'products' }),
+        obj({ className: 'Order', collection: 'orders' }),
+        obj({ className: 'Customer', collection: 'customers' }),
+      ),
+    );
+    expect(entries.map((e) => e.collection).sort()).toEqual([
+      'customers',
+      'orders',
+      'products',
+    ]);
+  });
+});
+
+describe('buildWebFieldDefinitions', () => {
+  const field = (f: Partial<FieldDefinition>): FieldDefinition =>
+    ({ type: 'text', ...f }) as FieldDefinition;
+
+  it('carries scalar and reference columns through with required/default', () => {
+    const fields = buildWebFieldDefinitions(
+      obj({
+        className: 'Product',
+        collection: 'products',
+        fields: {
+          name: field({ type: 'text', required: true }),
+          price: field({ type: 'decimal', default: 0 }),
+          inStock: field({ type: 'boolean' }),
+          count: field({ type: 'integer' }),
+          releasedAt: field({ type: 'datetime' }),
+          meta: field({ type: 'json' }),
+          ownerId: field({ type: 'foreignKey' }),
+          tenantRef: field({ type: 'crossPackageRef' }),
+        },
+      }),
+    );
+    expect(fields).toEqual({
+      name: { type: 'text', required: true },
+      price: { type: 'decimal', default: 0 },
+      inStock: { type: 'boolean' },
+      count: { type: 'integer' },
+      releasedAt: { type: 'datetime' },
+      meta: { type: 'json' },
+      ownerId: { type: 'foreignKey' },
+      tenantRef: { type: 'crossPackageRef' },
+    });
+  });
+
+  it('excludes relationship pseudo-fields, STI meta, transient and sensitive columns', () => {
+    const fields = buildWebFieldDefinitions(
+      obj({
+        className: 'Product',
+        collection: 'products',
+        fields: {
+          name: field({ type: 'text' }),
+          items: field({ type: 'oneToMany' }),
+          tags: field({ type: 'manyToMany' }),
+          _meta_type: field({ type: 'meta' }),
+          computed: field({ type: 'text', transient: true }),
+          apiKey: field({ type: 'text', sensitive: true }),
+        },
+      }),
+    );
+    expect(fields).toEqual({ name: { type: 'text' } });
+  });
+});

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -1,0 +1,173 @@
+/**
+ * Manifest → web collection selection (single source of truth).
+ *
+ * The browser client data runtime (`@happyvertical/smrt-web`, #1761) consumes
+ * one typed collection definition per API-exposed REST collection. Three
+ * emission sites need the SAME selection and field rules, or the emitted
+ * runtime values and their declared types drift apart:
+ *
+ *  - the `\0smrt:web` runtime virtual module (JSON literal — {@link generateWebModule})
+ *  - the `@happyvertical/smrt-virt-web` ambient d.ts (vite-plugin)
+ *  - the physical `@smrt/web` d.ts (prebuild, for `tsc`-only consumers)
+ *
+ * All three import {@link selectWebCollectionEntries} from here so the value
+ * emission and the type emission can never disagree.
+ */
+
+import type {
+  FieldDefinition,
+  SmartObjectDefinition,
+  SmartObjectManifest,
+} from '../scanner/types.js';
+import { resolveApiActionSet } from './sveltekit-generator.js';
+
+/**
+ * Field types that are relationship pseudo-columns rather than persisted
+ * public-DTO columns — they never appear on the wire as scalar values.
+ */
+const RELATIONSHIP_FIELD_TYPES: ReadonlySet<FieldDefinition['type']> = new Set([
+  'oneToMany',
+  'manyToMany',
+]);
+
+/** Informational per-column metadata carried by a collection definition. */
+export interface WebFieldDefinition {
+  type: FieldDefinition['type'];
+  required?: boolean;
+  default?: unknown;
+}
+
+/** One selected REST collection and the model that owns its definition. */
+export interface WebCollectionEntry {
+  /** REST collection name (pluralized), e.g. `products`. */
+  collection: string;
+  /** The manifest object that owns this collection's definition. */
+  obj: SmartObjectDefinition;
+  /** Sorted set of exposed CRUD + custom actions. */
+  actions: string[];
+}
+
+/** Resolve a manifest object by qualified name or simple class name. */
+function findByName(
+  manifest: SmartObjectManifest,
+  name: string,
+): SmartObjectDefinition | undefined {
+  return Object.values(manifest.objects).find(
+    (candidate) =>
+      candidate.qualifiedName === name || candidate.className === name,
+  );
+}
+
+/**
+ * True when `obj` is (transitively) a SmrtCollection subclass. Collection
+ * classes describe access, not row shapes, so they never become web
+ * collection definitions.
+ *
+ * NOTE: deliberately stronger than sveltekit-generator's private
+ * `isCollectionClass`, which only inspects the direct base / a type argument.
+ * A deeper subclass (`SpecialWidgetCollection extends WidgetCollection`)
+ * carries no type argument of its own; without walking the extends chain it
+ * would be mistaken for a model and claim its base model's REST collection.
+ */
+function isWebCollectionClass(
+  manifest: SmartObjectManifest,
+  obj: SmartObjectDefinition,
+  seen: Set<string> = new Set(),
+): boolean {
+  if (obj.extends === 'SmrtCollection' || obj.extendsTypeArg !== undefined) {
+    return true;
+  }
+  const parentName = obj.extendsQualified || obj.extends;
+  if (!parentName || seen.has(parentName)) return false;
+  seen.add(parentName);
+  const parent = findByName(manifest, parentName);
+  return parent ? isWebCollectionClass(manifest, parent, seen) : false;
+}
+
+/**
+ * True when some ancestor model maps to the SAME REST collection (a shared STI
+ * table). The STI base model owns the shared table's single definition.
+ */
+function isStiChildModel(
+  manifest: SmartObjectManifest,
+  obj: SmartObjectDefinition,
+): boolean {
+  const seen = new Set<string>();
+  let parentName = obj.extendsQualified || obj.extends;
+  while (parentName && !seen.has(parentName)) {
+    seen.add(parentName);
+    const parent = findByName(manifest, parentName);
+    if (!parent) return false;
+    if (parent.collection === obj.collection) return true;
+    parentName = parent.extendsQualified || parent.extends;
+  }
+  return false;
+}
+
+/**
+ * Select the manifest entries that become web collection definitions: one per
+ * REST collection, STI children folding into their base model, collection
+ * classes excluded, and only models that expose `list` (a read surface is
+ * required to materialize a collection). Uses the canonical
+ * {@link resolveApiActionSet} so the exposed-action set matches exactly what
+ * the REST/SvelteKit generators actually emit.
+ */
+export function selectWebCollectionEntries(
+  manifest: SmartObjectManifest,
+): WebCollectionEntry[] {
+  const byCollection = new Map<
+    string,
+    WebCollectionEntry & { isStiChild: boolean }
+  >();
+
+  for (const obj of Object.values(manifest.objects)) {
+    if (isWebCollectionClass(manifest, obj)) continue;
+
+    const exposedActions = resolveApiActionSet(obj);
+    if (!exposedActions.has('list')) continue;
+
+    const isStiChild = isStiChildModel(manifest, obj);
+    const existing = byCollection.get(obj.collection);
+    // One definition per REST collection. The STI BASE model owns it: a child
+    // only wins while no base has been recorded yet, so the result is
+    // independent of declaration / scan order.
+    if (existing && !(existing.isStiChild && !isStiChild)) continue;
+
+    byCollection.set(obj.collection, {
+      collection: obj.collection,
+      obj,
+      actions: [...exposedActions].sort(),
+      isStiChild,
+    });
+  }
+
+  return [...byCollection.values()].map(({ collection, obj, actions }) => ({
+    collection,
+    obj,
+    actions,
+  }));
+}
+
+/**
+ * Build the informational per-field metadata for a web collection definition:
+ * the persisted public-DTO columns only. Relationship pseudo-fields, STI meta
+ * internals, transient (unpersisted) and sensitive (wire-stripped) fields are
+ * excluded — they are not columns a client reads back over the REST surface.
+ */
+export function buildWebFieldDefinitions(
+  obj: SmartObjectDefinition,
+): Record<string, WebFieldDefinition> {
+  const fields: Record<string, WebFieldDefinition> = {};
+  for (const [fieldName, field] of Object.entries(obj.fields ?? {})) {
+    if (RELATIONSHIP_FIELD_TYPES.has(field.type)) continue;
+    if (field.type === 'meta') continue;
+    if (field.transient) continue;
+    if (field.sensitive) continue;
+    fields[fieldName] = {
+      type: field.type,
+      ...(field.required !== undefined ? { required: field.required } : {}),
+      ...(field.default !== undefined ? { default: field.default } : {}),
+    };
+  }
+  return fields;
+}

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -74,7 +74,10 @@ function isWebCollectionClass(
   obj: SmartObjectDefinition,
   seen: Set<string> = new Set(),
 ): boolean {
-  if (obj.extends === 'SmrtCollection' || obj.extendsTypeArg !== undefined) {
+  // Truthy check (not `!== undefined`) mirrors the scanner's own
+  // manifest-generator: a scanner that emits `extendsTypeArg: null` for a
+  // non-generic base must not be misread as a collection.
+  if (obj.extends === 'SmrtCollection' || !!obj.extendsTypeArg) {
     return true;
   }
   const parentName = obj.extendsQualified || obj.extends;

--- a/packages/core/src/vite-plugin/web-module.test.ts
+++ b/packages/core/src/vite-plugin/web-module.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for the `@happyvertical/smrt-virt-web` virtual module (#1761).
+ *
+ * The generator is module-private; it is reached the way Vite does — through
+ * the plugin's `resolveId`/`load` hooks over a real mini-project scan
+ * (mirroring load-hooks.test.ts). The fixture deliberately includes a
+ * transitive collection subclass (SpecialWidgetCollection extends
+ * WidgetCollection) — regression for the selection bug where only direct
+ * `extends SmrtCollection` was treated as a collection class and the deeper
+ * subclass claimed the model's REST collection definition.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { smrtPlugin } from './index.js';
+
+function getHook(plugin: Record<string, unknown>, name: string) {
+  const hook = plugin[name] as
+    | ((...args: unknown[]) => unknown)
+    | { handler: (...args: unknown[]) => unknown };
+  return typeof hook === 'function' ? hook : hook.handler;
+}
+
+describe('smrtPlugin load (\0smrt:web virtual module)', () => {
+  let projectRoot: string;
+  // biome config exempts tests from noExplicitAny; Vite plugin hooks are duck-typed here
+  let plugin: any;
+  let load: (id: string) => Promise<string | null>;
+
+  beforeAll(async () => {
+    projectRoot = mkdtempSync(join(tmpdir(), 'smrt-vite-web-'));
+    mkdirSync(join(projectRoot, 'src'), { recursive: true });
+    writeFileSync(
+      join(projectRoot, 'package.json'),
+      JSON.stringify({
+        name: 'mini-web-app',
+        version: '0.0.1',
+        type: 'module',
+      }),
+    );
+    writeFileSync(
+      join(projectRoot, 'src', 'objects.ts'),
+      `import { SmrtCollection, SmrtObject } from '@happyvertical/smrt-core';
+
+// STI child declared BEFORE its base: the base model must still own the
+// shared table's collection definition (regression: Material extends Product
+// claimed 'products' by iteration order).
+@smrt({ api: { include: ['list', 'get', 'create'] } })
+export class FancyWidget extends Widget {
+  shine: string = '';
+}
+
+@smrt({ api: { include: ['list', 'get', 'create'] }, tableStrategy: 'sti' })
+export class Widget extends SmrtObject {
+  name: string = '';
+  price: number = 0.0;
+  inStock: boolean = true;
+}
+
+export class WidgetCollection extends SmrtCollection<Widget> {
+  static readonly _itemClass = Widget;
+}
+
+// Transitive collection subclass: no type argument of its own — must still
+// be excluded from web collection definitions via the extends chain.
+export class SpecialWidgetCollection extends WidgetCollection {}
+
+@smrt({ api: false })
+export class HiddenGadget extends SmrtObject {
+  label: string = '';
+}
+`,
+    );
+
+    plugin = smrtPlugin({
+      generateTypes: false,
+      include: ['src/**/*.ts'],
+    });
+
+    await plugin.configResolved?.call(plugin, {
+      root: projectRoot,
+      mode: 'production',
+      plugins: [],
+      build: {},
+    });
+
+    load = getHook(plugin, 'load').bind(plugin) as typeof load;
+  }, 60_000);
+
+  afterAll(() => {
+    if (existsSync(projectRoot)) {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves the virt-web specifier to its \0-prefixed id', () => {
+    const resolveId = getHook(plugin, 'resolveId');
+    expect(resolveId.call(plugin, '@happyvertical/smrt-virt-web')).toBe(
+      '\0smrt:web',
+    );
+  });
+
+  it('emits one typed definition per API-exposed REST collection', async () => {
+    const code = await load('\0smrt:web');
+    expect(code).toContain('export const collectionDefinitions');
+    expect(code).toContain('export function getCollectionDefinition');
+
+    const definitions = extractDefinitions(code as string);
+    expect(Object.keys(definitions)).toEqual(['widgets']);
+
+    const widgets = definitions.widgets as Record<string, unknown>;
+    expect(widgets.className).toBe('Widget');
+    expect(widgets.endpoint).toBe('/widgets');
+    expect(widgets.idField).toBe('id');
+    expect(widgets.actions).toEqual(['create', 'get', 'list']);
+    expect(widgets.fields).toMatchObject({
+      name: { type: 'text' },
+      price: { type: 'decimal' },
+      inStock: { type: 'boolean' },
+    });
+  });
+
+  it('folds STI children into the base model definition even when the child is scanned first', async () => {
+    const code = (await load('\0smrt:web')) as string;
+    const definitions = extractDefinitions(code);
+    // FancyWidget shares the widgets table; the base Widget owns the
+    // definition regardless of declaration/scan order.
+    const widgets = definitions.widgets as Record<string, unknown>;
+    expect(widgets.className).toBe('Widget');
+    expect(code).not.toContain('FancyWidget');
+  });
+
+  it('excludes collection classes across the whole extends chain', async () => {
+    const code = (await load('\0smrt:web')) as string;
+    // Neither the direct nor the transitive collection subclass may appear.
+    expect(code).not.toContain('WidgetCollection');
+    expect(code).not.toContain('SpecialWidgetCollection');
+  });
+
+  it('excludes api:false objects (no read surface)', async () => {
+    const code = (await load('\0smrt:web')) as string;
+    expect(code).not.toContain('HiddenGadget');
+  });
+});
+
+/** Parse the emitted `export const collectionDefinitions = {...}` literal. */
+function extractDefinitions(code: string): Record<string, unknown> {
+  const match = code.match(
+    /export const collectionDefinitions = (\{[\s\S]*?\n\});/,
+  );
+  if (!match) {
+    throw new Error('collectionDefinitions literal not found in emitted code');
+  }
+  return JSON.parse(match[1]) as Record<string, unknown>;
+}

--- a/packages/smrt-web/AGENTS.md
+++ b/packages/smrt-web/AGENTS.md
@@ -1,0 +1,56 @@
+# @happyvertical/smrt-web
+
+Browser client data runtime — the web twin of `smrt-mobile`. Materializes the
+manifest-generated web collection definitions (`@happyvertical/smrt-virt-web`)
+as cached, reactive collections over the generated SMRT REST surface.
+
+## What it does
+
+Wraps a client-data engine (currently TanStack DB) so consumers get
+stale-while-revalidate reads, concurrent-request dedup, and optimistic
+mutations without hand-wiring cache keys or fetch/state.
+
+- `createSmrtCollection(definition, options)` — typed collection factory over a
+  generated `@happyvertical/smrt-virt-web` definition. Stale-while-revalidate
+  reads (`staleTimeMs`, default 30s); N concurrent identical reads coalesce into
+  one request; optimistic inserts persist through the REST surface and roll back
+  automatically on server error.
+- `createSmrtWebClient()` — an opaque shared-cache handle. Pass one app-wide
+  instance so collections share a cache and deduplicate requests.
+- `createDefinitionFetchers(definition, basePath, fetchFn)` — CRUD fetchers
+  derived from the generated definition (same URL scheme as the generated
+  client, but HTTP error statuses reject instead of resolving).
+- `unwrapListResult` / `unwrapItemResult` — normalize generated-client payloads
+  (`T[]`, `{ data }` envelopes, `{ error }` bodies → thrown
+  `SmrtWebRequestError`).
+
+## The engine-absorption boundary (ratified conditions, #1761)
+
+1. **No engine types in the public API.** `@tanstack/*` types must never appear
+   on this package's public surface. Collections are handed back as the
+   SMRT-owned `SmrtWebCollection`, and the shared cache as the opaque
+   `SmrtWebClient`. Enforced by `scripts/check-smrt-web-engine-boundary.mjs`,
+   run at the end of `build` (fails the build on any `@tanstack/` reference in
+   an emitted `.d.ts`).
+2. **Framework-agnostic core.** This entry imports no UI framework and must not
+   import `@tanstack/svelte-db` (it ships only a `svelte` export condition,
+   unresolvable outside Svelte bundlers). Svelte live-query bindings ship in a
+   separate entry/package.
+3. **Code-split / lazy.** The engine (~76 kB gzip) must never load on public /
+   smrt-sites pages. Consumers load the runtime only on surfaces that use live
+   collections.
+
+## Conventions
+
+- **No inter-smrt dependencies** — depends only on TanStack packages
+  (dependency-DAG guardrails). Definitions and fetchers arrive as arguments.
+- Rows are plain DTOs with a required `id`; optimistic inserts use
+  `newLocalId()` — the generated REST layer strips client ids on create
+  (#1540), so the post-persist refetch reconciles server-assigned ids.
+- To swap the engine, reimplement the SMRT-owned public types over a different
+  backend; the boundary guard keeps consumers insulated from the change.
+
+## Reference consumer
+
+`packages/products` consumes the runtime as its reference store across npm,
+federation, and standalone modes (see the smrt-web track, PRD #1755).

--- a/packages/smrt-web/CLAUDE.md
+++ b/packages/smrt-web/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/smrt-web/package.json
+++ b/packages/smrt-web/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@happyvertical/smrt-web",
+  "version": "0.37.8",
+  "description": "SMRT browser client data runtime: typed collection factory wrapping the client-data engine over generated REST clients",
+  "author": "HappyVertical",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "CLAUDE.md",
+    "dist",
+    "AGENTS.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@tanstack/db": "^0.6.14",
+    "@tanstack/query-core": "^5.90.5",
+    "@tanstack/query-db-collection": "^1.0.46"
+  },
+  "scripts": {
+    "build": "vite build --mode library && node ../../scripts/check-smrt-web-engine-boundary.mjs",
+    "build:watch": "vite build --mode library --watch",
+    "dev": "vite build --mode library --watch",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "verify:pack": "node ../../scripts/verify-package-types-exports.js .",
+    "prepack": "node ../../scripts/prepack-package.js"
+  },
+  "devDependencies": {
+    "@types/node": "24.13.2",
+    "typescript": "^5.9.3",
+    "vite": "8.1.2",
+    "vitest": "^4.1.9"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/smrt.git",
+    "directory": "packages/smrt-web"
+  }
+}

--- a/packages/smrt-web/src/collection.test.ts
+++ b/packages/smrt-web/src/collection.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createSmrtCollection,
   createSmrtWebClient,
+  getEngineCollection,
   newLocalId,
   type SmrtCrudFetchers,
   type SmrtWebCollectionDefinition,
@@ -242,6 +243,94 @@ describe('createSmrtCollection', () => {
 
     await collection.preload();
     expect(collection.size).toBe(1);
+
+    await collection.cleanup();
+  });
+
+  it('exposes plain DTO rows with no engine virtual props ($key/$origin/...)', async () => {
+    const scripted = makeScriptedFetchers([
+      { id: 'p1', name: 'Widget', price: 9.99 },
+    ]);
+    const collection = createSmrtCollection(productDefinition('products-dto'), {
+      fetchers: scripted.fetchers,
+      staleTimeMs: 60_000,
+    });
+    await collection.preload();
+
+    const [row] = collection.toArray;
+    // Exact equality (not toMatchObject): the row must be a plain DTO — no
+    // $synced/$origin/$key/$collectionId that would leak through spread/JSON.
+    expect(row).toEqual({ id: 'p1', name: 'Widget', price: 9.99 });
+    expect(Object.keys(row).some((k) => k.startsWith('$'))).toBe(false);
+    expect(JSON.stringify(row)).not.toContain('$');
+    // get() is projected too.
+    expect(collection.get('p1')).toEqual({
+      id: 'p1',
+      name: 'Widget',
+      price: 9.99,
+    });
+
+    await collection.cleanup();
+  });
+
+  it('isolates reads per scope so a shared client never cross-serves backends', async () => {
+    const client = createSmrtWebClient();
+    const backendA = makeScriptedFetchers([{ id: 'p1', name: 'from-A' }]);
+    const backendB = makeScriptedFetchers([{ id: 'p1', name: 'from-B' }]);
+
+    // Same generated collection name, one shared client, different backends —
+    // distinct scopes must keep their caches separate.
+    const collA = createSmrtCollection(productDefinition('products'), {
+      fetchers: backendA.fetchers,
+      client,
+      scope: 'tenant-a',
+      staleTimeMs: 60_000,
+    });
+    const collB = createSmrtCollection(productDefinition('products'), {
+      fetchers: backendB.fetchers,
+      client,
+      scope: 'tenant-b',
+      staleTimeMs: 60_000,
+    });
+
+    await Promise.all([collA.preload(), collB.preload()]);
+
+    expect(collA.get('p1')?.name).toBe('from-A');
+    expect(collB.get('p1')?.name).toBe('from-B');
+    expect(backendA.calls.list).toBe(1);
+    expect(backendB.calls.list).toBe(1);
+
+    await Promise.all([collA.cleanup(), collB.cleanup()]);
+  });
+
+  it('rejects a client handle not produced by createSmrtWebClient', () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    expect(() =>
+      createSmrtCollection(productDefinition('products-badclient'), {
+        fetchers: scripted.fetchers,
+        // Foreign object masquerading as a client handle.
+        client: {} as ReturnType<typeof createSmrtWebClient>,
+      }),
+    ).toThrow(SmrtWebRequestError);
+  });
+});
+
+describe('getEngineCollection (internal binding bridge)', () => {
+  it('returns the engine collection for a real handle and rejects foreign handles', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const collection = createSmrtCollection(
+      productDefinition('products-bridge'),
+      { fetchers: scripted.fetchers, staleTimeMs: 60_000 },
+    );
+
+    const engine = getEngineCollection(collection);
+    expect(engine).toBeDefined();
+    // The bridge yields the live engine collection (has its own preload()).
+    expect(typeof (engine as { preload?: unknown }).preload).toBe('function');
+
+    expect(() =>
+      getEngineCollection({} as unknown as typeof collection),
+    ).toThrow(SmrtWebRequestError);
 
     await collection.cleanup();
   });

--- a/packages/smrt-web/src/collection.test.ts
+++ b/packages/smrt-web/src/collection.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Behavior tests for the smrt-web collection factory (#1761).
+ *
+ * Per the repo mocking policy only the external boundary is mocked: the
+ * generated REST client fetchers (thin fetch wrappers). Everything else — the
+ * client-data engine collection, transactions, live state — is real.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  createSmrtCollection,
+  createSmrtWebClient,
+  newLocalId,
+  type SmrtCrudFetchers,
+  type SmrtWebCollectionDefinition,
+  SmrtWebRequestError,
+  unwrapItemResult,
+  unwrapListResult,
+} from './index.js';
+
+interface ProductData {
+  id?: string;
+  name: string;
+  price?: number;
+  inStock?: boolean;
+}
+
+function productDefinition(
+  name: string,
+): SmrtWebCollectionDefinition<ProductData> {
+  // Mirrors what @happyvertical/smrt-virt-web emits for the products package.
+  return {
+    name,
+    className: 'Product',
+    endpoint: `/${name}`,
+    idField: 'id',
+    actions: ['create', 'get', 'list', 'update'],
+    fields: {
+      name: { type: 'text', required: true },
+      price: { type: 'decimal' },
+      inStock: { type: 'boolean' },
+    },
+  };
+}
+
+/**
+ * A scripted stand-in for `createClient('/api/v1').products`: resolves like the
+ * generated fetchers do (JSON payloads, never rejects on HTTP errors) and
+ * counts calls so caching behavior is observable.
+ */
+function makeScriptedFetchers(initialRows: Array<Record<string, unknown>>) {
+  const serverRows = [...initialRows];
+  const calls = { list: 0, create: 0 };
+  let failNextCreate: string | null = null;
+  let gateListResolve: (() => void) | null = null;
+
+  const fetchers: SmrtCrudFetchers = {
+    list: async () => {
+      calls.list += 1;
+      if (gateListResolve) {
+        await new Promise<void>((resolve) => {
+          gateListResolve = resolve;
+        });
+      }
+      return serverRows.map((row) => ({ ...row }));
+    },
+    create: async (data) => {
+      calls.create += 1;
+      if (failNextCreate) {
+        const error = failNextCreate;
+        failNextCreate = null;
+        // Generated REST routes return `{ error }` bodies on failure and the
+        // generated client resolves them (fetch only rejects on network
+        // errors) — this is exactly the shape smrt-web must translate into a
+        // rollback.
+        return { error };
+      }
+      const created = {
+        ...data,
+        id: `server-${serverRows.length + 1}`,
+      };
+      serverRows.push(created);
+      return { ...created };
+    },
+  };
+
+  return {
+    fetchers,
+    calls,
+    failCreateWith(message: string) {
+      failNextCreate = message;
+    },
+    /** Hold the next list() open until released — for concurrency assertions. */
+    gateNextList() {
+      gateListResolve = () => {};
+    },
+    releaseList() {
+      const resolve = gateListResolve;
+      gateListResolve = null;
+      resolve?.();
+    },
+  };
+}
+
+describe('createSmrtCollection', () => {
+  it('loads rows through the generated fetchers and serves repeat reads from cache within the staleness window', async () => {
+    const scripted = makeScriptedFetchers([
+      { id: 'p1', name: 'Widget', price: 9.99 },
+    ]);
+    const collection = createSmrtCollection(productDefinition('products-swr'), {
+      fetchers: scripted.fetchers,
+      staleTimeMs: 60_000,
+    });
+
+    await collection.preload();
+    // Note: the engine decorates rows with virtual props ($key, $origin, ...),
+    // so assertions match the DTO subset rather than deep equality.
+    expect(collection.toArray).toMatchObject([
+      { id: 'p1', name: 'Widget', price: 9.99 },
+    ]);
+    expect(scripted.calls.list).toBe(1);
+
+    // Simulate leaving and re-entering a page: drop the subscriber, then read
+    // again within the staleness window — no extra network call.
+    const subscription = collection.subscribeChanges(() => {});
+    subscription.unsubscribe();
+    const again = collection.subscribeChanges(() => {});
+    expect(collection.toArray).toHaveLength(1);
+    again.unsubscribe();
+    expect(scripted.calls.list).toBe(1);
+
+    await collection.cleanup();
+  });
+
+  it('coalesces N concurrent identical reads into a single network request', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    scripted.gateNextList();
+    const collection = createSmrtCollection(
+      productDefinition('products-dedup'),
+      { fetchers: scripted.fetchers, staleTimeMs: 60_000 },
+    );
+
+    // Fire five concurrent preloads while the first list() is held open.
+    const reads = Promise.all(
+      Array.from({ length: 5 }, () => collection.preload()),
+    );
+    // All five share the single in-flight request.
+    expect(scripted.calls.list).toBe(1);
+    scripted.releaseList();
+    await reads;
+    expect(scripted.calls.list).toBe(1);
+    expect(collection.size).toBe(1);
+
+    await collection.cleanup();
+  });
+
+  it('revalidates after the collection is restarted once data is stale', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const collection = createSmrtCollection(
+      productDefinition('products-revalidate'),
+      { fetchers: scripted.fetchers, staleTimeMs: 0 },
+    );
+
+    await collection.preload();
+    expect(scripted.calls.list).toBe(1);
+
+    // Full lifecycle drop (what gc after navigation does), then a new
+    // subscriber: staleTime 0 means the restart must revalidate.
+    await collection.cleanup();
+    await collection.preload();
+    expect(scripted.calls.list).toBe(2);
+
+    await collection.cleanup();
+  });
+
+  it('applies an optimistic create instantly and reconciles with the server row', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const collection = createSmrtCollection(
+      productDefinition('products-create'),
+      { fetchers: scripted.fetchers, staleTimeMs: 60_000 },
+    );
+    await collection.preload();
+
+    const localId = newLocalId();
+    const tx = collection.insert({
+      id: localId,
+      name: 'Gadget',
+      price: 19.99,
+    });
+
+    // Optimistic row is visible synchronously, before any network response.
+    expect(collection.has(localId)).toBe(true);
+    expect(collection.size).toBe(2);
+
+    await tx.isPersisted.promise;
+
+    // The create persisted through the generated client (temp id stripped), and
+    // the post-persist refetch swapped in the server-assigned row.
+    expect(scripted.calls.create).toBe(1);
+    expect(collection.has(localId)).toBe(false);
+    const names = collection.toArray.map((row) => row.name).sort();
+    expect(names).toEqual(['Gadget', 'Widget']);
+    const created = collection.toArray.find((row) => row.name === 'Gadget');
+    expect(created?.id).toBe('server-2');
+
+    await collection.cleanup();
+  });
+
+  it('rolls the optimistic row back when the server rejects the create', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const collection = createSmrtCollection(
+      productDefinition('products-rollback'),
+      { fetchers: scripted.fetchers, staleTimeMs: 60_000 },
+    );
+    await collection.preload();
+
+    scripted.failCreateWith('Validation failed: name is reserved');
+
+    const localId = newLocalId();
+    const tx = collection.insert({ id: localId, name: 'FAIL Gadget' });
+    expect(collection.has(localId)).toBe(true);
+
+    await expect(tx.isPersisted.promise).rejects.toThrow(
+      'Validation failed: name is reserved',
+    );
+
+    // Optimistic state rolled back: the row is gone, server state intact.
+    expect(collection.has(localId)).toBe(false);
+    expect(collection.toArray).toMatchObject([{ id: 'p1', name: 'Widget' }]);
+    expect(collection.size).toBe(1);
+
+    await collection.cleanup();
+  });
+
+  it('accepts a shared client handle without leaking the engine', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const client = createSmrtWebClient();
+    const collection = createSmrtCollection(
+      productDefinition('products-shared'),
+      { fetchers: scripted.fetchers, client, staleTimeMs: 60_000 },
+    );
+
+    await collection.preload();
+    expect(collection.size).toBe(1);
+
+    await collection.cleanup();
+  });
+});
+
+describe('definition-derived fetchers', () => {
+  it('serves reads and rolls back failed creates using only the generated definition and a base path', async () => {
+    const serverRows = [{ id: 'p1', name: 'Widget' }];
+    const requests: Array<{ url: string; method: string }> = [];
+
+    // Mock ONLY the network boundary: a fetch stand-in for the generated REST
+    // routes (bare array list, `{ error }` + status on failure).
+    const fetchFn = (async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      requests.push({ url, method });
+      if (method === 'GET') {
+        return new Response(JSON.stringify(serverRows), { status: 200 });
+      }
+      if (method === 'POST') {
+        const body = JSON.parse(String(init?.body)) as { name?: string };
+        if (body.name?.startsWith('FAIL')) {
+          return new Response(JSON.stringify({ error: 'rejected by server' }), {
+            status: 500,
+          });
+        }
+        const created = { ...body, id: `server-${serverRows.length + 1}` };
+        serverRows.push(created as (typeof serverRows)[number]);
+        return new Response(JSON.stringify(created), { status: 201 });
+      }
+      return new Response(null, { status: 405 });
+    }) as typeof fetch;
+
+    const collection = createSmrtCollection(
+      productDefinition('products-deffetch'),
+      { basePath: '/api/v1', fetchFn, staleTimeMs: 60_000 },
+    );
+
+    await collection.preload();
+    expect(requests[0]).toEqual({
+      url: '/api/v1/products-deffetch',
+      method: 'GET',
+    });
+    expect(collection.size).toBe(1);
+
+    // Failed create: HTTP 500 rejects and rolls back the optimistic row.
+    const localId = newLocalId();
+    const tx = collection.insert({ id: localId, name: 'FAIL thing' });
+    expect(collection.has(localId)).toBe(true);
+    await expect(tx.isPersisted.promise).rejects.toThrow('rejected by server');
+    expect(collection.has(localId)).toBe(false);
+    expect(collection.size).toBe(1);
+
+    // Successful create persists and reconciles to the server id.
+    const okTx = collection.insert({ id: newLocalId(), name: 'Gadget' });
+    await okTx.isPersisted.promise;
+    expect(collection.size).toBe(2);
+    expect(collection.toArray.find((row) => row.name === 'Gadget')?.id).toBe(
+      'server-2',
+    );
+
+    await collection.cleanup();
+  });
+});
+
+describe('payload normalization', () => {
+  it('passes bare arrays through (generated REST list shape)', () => {
+    expect(unwrapListResult([{ id: '1' }], 'products')).toEqual([{ id: '1' }]);
+  });
+
+  it('tolerates ApiResponse envelopes ({ data: [...] })', () => {
+    expect(unwrapListResult({ data: [{ id: '1' }] }, 'products')).toEqual([
+      { id: '1' },
+    ]);
+  });
+
+  it('turns { error } list payloads into SmrtWebRequestError', () => {
+    expect(() => unwrapListResult({ error: 'nope' }, 'products')).toThrow(
+      SmrtWebRequestError,
+    );
+  });
+
+  it('unwraps item payloads and rejects { error } bodies', () => {
+    expect(unwrapItemResult({ id: '1' }, 'create(products)')).toEqual({
+      id: '1',
+    });
+    expect(unwrapItemResult({ data: { id: '1' } }, 'create(products)')).toEqual(
+      { id: '1' },
+    );
+    expect(() =>
+      unwrapItemResult({ error: 'denied' }, 'create(products)'),
+    ).toThrow(SmrtWebRequestError);
+    expect(() => unwrapItemResult(null, 'create(products)')).toThrow(
+      SmrtWebRequestError,
+    );
+  });
+});
+
+describe('newLocalId', () => {
+  it('generates unique ids', () => {
+    expect(newLocalId()).not.toEqual(newLocalId());
+  });
+});

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -268,8 +268,12 @@ export interface SmrtWebClient {
   readonly __smrtWebClient: 'SmrtWebClient';
 }
 
-/** Engine-side shape of a {@link SmrtWebClient}. Never exported. */
-interface SmrtWebClientEngine {
+/**
+ * Engine-side shape of a {@link SmrtWebClient}. Never exported, so the engine
+ * type never reaches the public surface. Extends the public brand so the value
+ * created here carries the brand at runtime (enabling the validation below).
+ */
+interface SmrtWebClientEngine extends SmrtWebClient {
   readonly queryClient: QueryClient;
 }
 
@@ -279,13 +283,54 @@ interface SmrtWebClientEngine {
  * share a cache and deduplicate requests app-wide.
  */
 export function createSmrtWebClient(): SmrtWebClient {
-  const engine: SmrtWebClientEngine = { queryClient: new QueryClient() };
-  return engine as unknown as SmrtWebClient;
+  const engine: SmrtWebClientEngine = {
+    __smrtWebClient: 'SmrtWebClient',
+    queryClient: new QueryClient(),
+  };
+  return engine;
 }
 
 function resolveQueryClient(client?: SmrtWebClient): QueryClient {
   if (!client) return new QueryClient();
-  return (client as unknown as SmrtWebClientEngine).queryClient;
+  const engine = client as Partial<SmrtWebClientEngine>;
+  if (engine.__smrtWebClient !== 'SmrtWebClient' || !engine.queryClient) {
+    throw new SmrtWebRequestError(
+      '[smrt-web] options.client must be a handle from createSmrtWebClient()',
+    );
+  }
+  return engine.queryClient;
+}
+
+/**
+ * Project an engine row to a plain public DTO. The client-data engine decorates
+ * stored rows with enumerable virtual props (`$synced`/`$origin`/`$key`/
+ * `$collectionId`) that would otherwise cross the SMRT boundary through spread
+ * or JSON serialization. The `$` prefix is reserved for the engine; SMRT
+ * columns never begin with it.
+ */
+function toPlainRow<TData extends object>(row: unknown): SmrtWebRow<TData> {
+  const plain: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(row as Record<string, unknown>)) {
+    if (key.charCodeAt(0) !== 36 /* '$' */) plain[key] = value;
+  }
+  return plain as SmrtWebRow<TData>;
+}
+
+/** Project the row values carried by a change notification to plain DTOs. */
+function projectChanges(changes: unknown): unknown {
+  if (!Array.isArray(changes)) return changes;
+  return changes.map((change) => {
+    if (!change || typeof change !== 'object') return change;
+    const record = change as Record<string, unknown>;
+    const projected: Record<string, unknown> = { ...record };
+    if (record.value && typeof record.value === 'object') {
+      projected.value = toPlainRow(record.value);
+    }
+    if (record.previousValue && typeof record.previousValue === 'object') {
+      projected.previousValue = toPlainRow(record.previousValue);
+    }
+    return projected;
+  });
 }
 
 /**
@@ -349,6 +394,15 @@ export interface CreateSmrtCollectionOptions {
    */
   client?: SmrtWebClient;
   /**
+   * Cache namespace for this collection's reads. Fold a backend / tenant /
+   * preview discriminator in here when the SAME generated collection is
+   * materialized against DIFFERENT backends while sharing one {@link client} —
+   * without it those reads share a cache key and could serve one backend's rows
+   * for the other for the whole `staleTimeMs` window. Omit for the common
+   * single-backend case.
+   */
+  scope?: string;
+  /**
    * Stale-while-revalidate window in milliseconds (default 30s): reads within
    * the window are served from the local collection without a network request;
    * the first read after it revalidates in the background.
@@ -356,6 +410,32 @@ export interface CreateSmrtCollectionOptions {
   staleTimeMs?: number;
   /** Retry failed loads (default false: fail fast, surface errors). */
   retry?: boolean;
+}
+
+/**
+ * Registry mapping a public collection handle to its underlying engine
+ * collection. Keyed weakly so a handle and its engine collection are collected
+ * together. Read only through {@link getEngineCollection}.
+ */
+const engineCollections = new WeakMap<object, unknown>();
+
+/**
+ * @internal Retrieve the underlying engine collection backing a handle. For
+ * trusted framework bindings only (e.g. smrt-svelte live queries), which must
+ * feed the engine collection to the query builder. Returns `unknown` so no
+ * engine type crosses the public boundary — callers cast. Throws for a handle
+ * not produced by {@link createSmrtCollection}.
+ */
+export function getEngineCollection<TData extends object>(
+  handle: SmrtWebCollection<TData>,
+): unknown {
+  const engine = engineCollections.get(handle);
+  if (engine === undefined) {
+    throw new SmrtWebRequestError(
+      '[smrt-web] getEngineCollection: not a smrt-web collection handle',
+    );
+  }
+  return engine;
 }
 
 /**
@@ -377,17 +457,26 @@ export function createSmrtCollection<TData extends object>(
 ): SmrtWebCollection<TData> {
   type Row = SmrtWebRow<TData>;
 
-  const { staleTimeMs = 30_000, retry = false } = options;
+  const { staleTimeMs = 30_000, retry = false, scope } = options;
   const fetchers =
     options.fetchers ??
     createDefinitionFetchers(definition, options.basePath, options.fetchFn);
   const queryClient = resolveQueryClient(options.client);
   const idField = definition.idField || 'id';
 
+  // Scope discriminates the cache key so a shared client can materialize the
+  // same collection against different backends without cross-serving reads.
+  const cacheId = scope
+    ? `smrt:${scope}:${definition.name}`
+    : `smrt:${definition.name}`;
+  const queryKey = scope
+    ? ['smrt', scope, definition.name]
+    : ['smrt', definition.name];
+
   const collection = createCollection(
     queryCollectionOptions<Row>({
-      id: `smrt:${definition.name}`,
-      queryKey: ['smrt', definition.name],
+      id: cacheId,
+      queryKey,
       queryClient,
       staleTime: staleTimeMs,
       retry,
@@ -431,7 +520,41 @@ export function createSmrtCollection<TData extends object>(
     }),
   );
 
-  // The engine object satisfies the committed public surface at runtime; the
-  // SMRT-owned type is asserted here so the engine's own types never escape.
-  return collection as unknown as SmrtWebCollection<TData>;
+  // Wrap the engine collection in the SMRT-owned public surface. The wrapper
+  // projects rows to plain DTOs at every read boundary (toArray/get and change
+  // payloads) so the engine's virtual props never escape, and confines the
+  // engine's own types to this module.
+  const handle: SmrtWebCollection<TData> = {
+    get toArray() {
+      return collection.toArray.map((row) => toPlainRow<TData>(row));
+    },
+    get size() {
+      return collection.size;
+    },
+    has(key) {
+      return collection.has(key);
+    },
+    get(key) {
+      const row = collection.get(key);
+      return row === undefined ? undefined : toPlainRow<TData>(row);
+    },
+    preload() {
+      return collection.preload();
+    },
+    cleanup() {
+      return collection.cleanup();
+    },
+    subscribeChanges(callback) {
+      const subscription = collection.subscribeChanges((changes: unknown) =>
+        callback(projectChanges(changes)),
+      );
+      return { unsubscribe: () => subscription.unsubscribe() };
+    },
+    insert(row) {
+      return collection.insert(row) as unknown as SmrtWebTransaction;
+    },
+  };
+
+  engineCollections.set(handle, collection);
+  return handle;
 }

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -1,0 +1,437 @@
+/**
+ * @happyvertical/smrt-web — browser client data runtime (#1761).
+ *
+ * A typed collection factory that materializes the manifest-generated web
+ * collection definitions (`@happyvertical/smrt-virt-web`) as cached, reactive
+ * collections over the generated SMRT REST surface.
+ *
+ * This package is the **engine-absorption boundary**: the client-data engine
+ * (currently TanStack DB) is an implementation detail held entirely inside
+ * this module. Its types never appear on the public API — collections are
+ * handed back as the SMRT-owned {@link SmrtWebCollection}, and the shared cache
+ * as the opaque {@link SmrtWebClient} — so the engine stays swappable without a
+ * consumer-visible break. Consumers never import `@tanstack/*` directly.
+ *
+ * Framework-agnostic by construction: this entry imports no UI framework.
+ * Svelte live-query bindings ship separately (see PRD #1755) so this core never
+ * pulls the Svelte-only `@tanstack/svelte-db` export condition.
+ *
+ * Scope of this slice:
+ * - stale-while-revalidate reads (a `staleTimeMs` window, background revalidation)
+ * - concurrent-read dedup (one network request per in-flight collection load)
+ * - optimistic create that persists through the generated REST surface and
+ *   rolls back automatically when the server errors
+ *
+ * Deliberately NOT here yet (see PRD #1755): relationship-derived invalidation,
+ * SvelteKit hydration seeding, offline outbox, SSE invalidation, persistence,
+ * version awareness.
+ */
+
+import { createCollection } from '@tanstack/db';
+import { QueryClient } from '@tanstack/query-core';
+import { queryCollectionOptions } from '@tanstack/query-db-collection';
+
+// ---------------------------------------------------------------------------
+// Generated definition contract (mirrors @happyvertical/smrt-virt-web)
+// ---------------------------------------------------------------------------
+
+/**
+ * Field metadata emitted per column by the `@happyvertical/smrt-virt-web`
+ * virtual module (generated from the package manifest).
+ */
+export interface SmrtWebFieldDefinition {
+  type: string;
+  required?: boolean;
+  default?: unknown;
+}
+
+/**
+ * One generated collection definition: everything needed to construct a client
+ * collection over the generated REST surface. The `_row` property is a phantom
+ * type carrier threaded through codegen — it never exists at runtime, it only
+ * lets factories infer the row type from a definition.
+ */
+export interface SmrtWebCollectionDefinition<TData extends object = object> {
+  /** REST collection name (e.g. `products`). */
+  name: string;
+  /** Source class name (e.g. `Product`). */
+  className: string;
+  /** Path under the API base path (e.g. `/products`). */
+  endpoint: string;
+  /** Primary key field name (`id` for SmrtObject). */
+  idField: string;
+  /** CRUD + custom actions exposed by the api decorator config. */
+  actions: string[];
+  /** Persisted field metadata keyed by field name. */
+  fields: Record<string, SmrtWebFieldDefinition>;
+  /** Phantom row-type carrier — never present at runtime. */
+  _row?: TData;
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher contract + payload normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * The per-collection CRUD surface of the generated REST client
+ * (`createClient(basePath).<collection>` from `@happyvertical/smrt-virt-client`).
+ *
+ * Return types are `unknown` on purpose: generated fetchers resolve with
+ * whatever the server sent, so this package normalizes and validates payloads
+ * centrally — see {@link unwrapListResult} / {@link unwrapItemResult}.
+ */
+export interface SmrtCrudFetchers {
+  list(params?: Record<string, unknown>): Promise<unknown>;
+  get?(id: string): Promise<unknown>;
+  create(data: Record<string, unknown>): Promise<unknown>;
+  update?(id: string, data: Record<string, unknown>): Promise<unknown>;
+  delete?(id: string): Promise<unknown>;
+}
+
+/**
+ * Raised when a generated-client call resolved with an error payload
+ * (`{ error: string }` from the generated REST routes) or an unexpected shape.
+ * Thrown inside a mutation handler, this triggers the automatic rollback of
+ * optimistic state.
+ */
+export class SmrtWebRequestError extends Error {
+  readonly payload: unknown;
+
+  constructor(message: string, payload?: unknown) {
+    super(message);
+    this.name = 'SmrtWebRequestError';
+    this.payload = payload;
+  }
+}
+
+/** A row as stored in the client collection: the DTO plus a required key. */
+export type SmrtWebRow<TData extends object> = TData & { id: string };
+
+/**
+ * Normalize a generated-client list result to an array of rows.
+ *
+ * The generated REST routes return a bare JSON array; `{ error }` payloads are
+ * surfaced as failures. The `{ data: [...] }` envelope is tolerated for
+ * ApiResponse-shaped clients (e.g. a mock client).
+ */
+export function unwrapListResult(
+  result: unknown,
+  collectionName: string,
+): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) {
+    return result as Array<Record<string, unknown>>;
+  }
+  if (result && typeof result === 'object') {
+    const record = result as Record<string, unknown>;
+    if (typeof record.error === 'string') {
+      throw new SmrtWebRequestError(
+        `[smrt-web] list(${collectionName}) failed: ${record.error}`,
+        result,
+      );
+    }
+    if (Array.isArray(record.data)) {
+      return record.data as Array<Record<string, unknown>>;
+    }
+  }
+  throw new SmrtWebRequestError(
+    `[smrt-web] list(${collectionName}) returned an unexpected payload shape`,
+    result,
+  );
+}
+
+/**
+ * Normalize a generated-client item result (create/update) to a row.
+ * `{ error }` payloads become failures — inside mutation handlers this is what
+ * makes optimistic state roll back.
+ */
+export function unwrapItemResult(
+  result: unknown,
+  context: string,
+): Record<string, unknown> {
+  if (result && typeof result === 'object' && !Array.isArray(result)) {
+    const record = result as Record<string, unknown>;
+    if (typeof record.error === 'string') {
+      throw new SmrtWebRequestError(
+        `[smrt-web] ${context} failed: ${record.error}`,
+        result,
+      );
+    }
+    if (
+      record.data &&
+      typeof record.data === 'object' &&
+      !Array.isArray(record.data)
+    ) {
+      return record.data as Record<string, unknown>;
+    }
+    return record;
+  }
+  throw new SmrtWebRequestError(
+    `[smrt-web] ${context} returned an unexpected payload shape`,
+    result,
+  );
+}
+
+/**
+ * Build CRUD fetchers from a generated collection definition — the same URL
+ * scheme and payload handling as the generated REST client
+ * (`basePath + endpoint`), with one improvement: HTTP error statuses reject
+ * with the server's `{ error }` body instead of resolving with it.
+ */
+export function createDefinitionFetchers(
+  definition: SmrtWebCollectionDefinition<object>,
+  basePath = '/api/v1',
+  fetchFn: typeof fetch = (...args) => globalThis.fetch(...args),
+): SmrtCrudFetchers {
+  const collectionUrl = `${basePath}${definition.endpoint}`;
+  const headers = { 'Content-Type': 'application/json' };
+
+  const parse = async (response: Response): Promise<unknown> => {
+    const payload: unknown = await response.json().catch(() => null);
+    if (!response.ok) {
+      const message =
+        payload &&
+        typeof payload === 'object' &&
+        typeof (payload as Record<string, unknown>).error === 'string'
+          ? String((payload as Record<string, unknown>).error)
+          : `HTTP ${response.status}`;
+      throw new SmrtWebRequestError(
+        `[smrt-web] ${definition.name} request failed: ${message}`,
+        payload,
+      );
+    }
+    return payload;
+  };
+
+  return {
+    list: async () => parse(await fetchFn(collectionUrl, { headers })),
+    get: async (id) =>
+      parse(await fetchFn(`${collectionUrl}/${id}`, { headers })),
+    create: async (data) =>
+      parse(
+        await fetchFn(collectionUrl, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(data),
+        }),
+      ),
+    update: async (id, data) =>
+      parse(
+        await fetchFn(`${collectionUrl}/${id}`, {
+          method: 'PUT',
+          headers,
+          body: JSON.stringify(data),
+        }),
+      ),
+    delete: async (id) => {
+      const response = await fetchFn(`${collectionUrl}/${id}`, {
+        method: 'DELETE',
+        headers,
+      });
+      if (!response.ok) {
+        throw new SmrtWebRequestError(
+          `[smrt-web] delete(${definition.name}) failed: HTTP ${response.status}`,
+        );
+      }
+      return true;
+    },
+  };
+}
+
+/**
+ * Generate a client-local id for optimistic inserts. The generated REST layer
+ * strips client-supplied ids on create (mass-assignment guard #1540), so this
+ * id only identifies the optimistic row until the post-persist refetch swaps in
+ * the server-assigned row.
+ */
+export function newLocalId(): string {
+  const cryptoRef = globalThis.crypto as Crypto | undefined;
+  if (cryptoRef?.randomUUID) {
+    return cryptoRef.randomUUID();
+  }
+  return `local-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Engine-absorbing public surface (no @tanstack/* types leak past here)
+// ---------------------------------------------------------------------------
+
+/**
+ * Opaque handle to the shared client cache / request-dedup layer. Create one
+ * with {@link createSmrtWebClient} and pass the SAME instance to every
+ * collection that should share a cache and deduplicate in-flight requests.
+ *
+ * The engine (currently a TanStack Query client) is intentionally hidden behind
+ * this brand so it stays swappable — do not depend on its concrete shape.
+ */
+export interface SmrtWebClient {
+  /** Phantom brand — this handle wraps the hidden client-cache engine. */
+  readonly __smrtWebClient: 'SmrtWebClient';
+}
+
+/** Engine-side shape of a {@link SmrtWebClient}. Never exported. */
+interface SmrtWebClientEngine {
+  readonly queryClient: QueryClient;
+}
+
+/**
+ * Create a shared client-cache handle. Pass the returned handle as
+ * {@link CreateSmrtCollectionOptions.client} to every collection that should
+ * share a cache and deduplicate requests app-wide.
+ */
+export function createSmrtWebClient(): SmrtWebClient {
+  const engine: SmrtWebClientEngine = { queryClient: new QueryClient() };
+  return engine as unknown as SmrtWebClient;
+}
+
+function resolveQueryClient(client?: SmrtWebClient): QueryClient {
+  if (!client) return new QueryClient();
+  return (client as unknown as SmrtWebClientEngine).queryClient;
+}
+
+/**
+ * A pending optimistic mutation. Await {@link isPersisted} to observe the
+ * server outcome: it resolves once the write has been persisted through the
+ * REST surface, and rejects (rolling the optimistic state back) on error.
+ */
+export interface SmrtWebTransaction {
+  readonly isPersisted: { readonly promise: Promise<unknown> };
+}
+
+/** A change-subscription handle. Call {@link unsubscribe} to detach. */
+export interface SmrtWebSubscription {
+  unsubscribe(): void;
+}
+
+/**
+ * A live, cached collection of plain-DTO rows — the SMRT-owned public contract
+ * over the client-data engine. Exposes only the committed surface; the engine's
+ * own type is never named here so it stays swappable.
+ */
+export interface SmrtWebCollection<TData extends object> {
+  /** All rows currently in the collection (plain DTOs, insertion order). */
+  readonly toArray: ReadonlyArray<SmrtWebRow<TData>>;
+  /** Number of rows currently in the collection. */
+  readonly size: number;
+  /** True when a row with `key` is present. */
+  has(key: string): boolean;
+  /** The row with `key`, or `undefined`. */
+  get(key: string): SmrtWebRow<TData> | undefined;
+  /** Resolve once the first load has completed. */
+  preload(): Promise<void>;
+  /** Tear down subscriptions and cached state. */
+  cleanup(): Promise<void>;
+  /** Subscribe to change notifications; returns a detach handle. */
+  subscribeChanges(callback: (changes: unknown) => void): SmrtWebSubscription;
+  /**
+   * Optimistically insert a row and persist it through the create fetcher. The
+   * row is visible synchronously; the returned transaction settles on the
+   * server outcome (see {@link SmrtWebTransaction}).
+   */
+  insert(row: SmrtWebRow<TData>): SmrtWebTransaction;
+}
+
+export interface CreateSmrtCollectionOptions {
+  /**
+   * Generated REST client surface for this collection, e.g.
+   * `createClient('/api/v1').products` from the virt-client module. When
+   * omitted, fetchers are derived from the definition's endpoint and `basePath`
+   * with the same URL scheme and payload shapes the generated client uses.
+   */
+  fetchers?: SmrtCrudFetchers;
+  /** API base path for definition-derived fetchers (default `/api/v1`). */
+  basePath?: string;
+  /** Fetch implementation override (tests, SSR). Defaults to global fetch. */
+  fetchFn?: typeof fetch;
+  /**
+   * Shared cache handle from {@link createSmrtWebClient}. Pass one app-wide
+   * instance so collections share a cache and deduplicate requests; a private
+   * cache is created when omitted.
+   */
+  client?: SmrtWebClient;
+  /**
+   * Stale-while-revalidate window in milliseconds (default 30s): reads within
+   * the window are served from the local collection without a network request;
+   * the first read after it revalidates in the background.
+   */
+  staleTimeMs?: number;
+  /** Retry failed loads (default false: fail fast, surface errors). */
+  retry?: boolean;
+}
+
+/**
+ * Create a typed client collection over a generated SMRT collection definition
+ * and the matching generated REST client fetchers.
+ *
+ * Reads: stale-while-revalidate. The first subscriber triggers a fetch;
+ * re-subscribing within `staleTimeMs` serves local data with no request. N
+ * concurrent identical reads coalesce into one network request.
+ *
+ * Writes: `collection.insert({ ...data, id: newLocalId() })` applies instantly,
+ * persists through `fetchers.create()` (the temp id is stripped — the server
+ * assigns the real one), then refetches to reconcile. A failed create rejects
+ * the transaction and the optimistic row rolls back automatically.
+ */
+export function createSmrtCollection<TData extends object>(
+  definition: SmrtWebCollectionDefinition<TData>,
+  options: CreateSmrtCollectionOptions,
+): SmrtWebCollection<TData> {
+  type Row = SmrtWebRow<TData>;
+
+  const { staleTimeMs = 30_000, retry = false } = options;
+  const fetchers =
+    options.fetchers ??
+    createDefinitionFetchers(definition, options.basePath, options.fetchFn);
+  const queryClient = resolveQueryClient(options.client);
+  const idField = definition.idField || 'id';
+
+  const collection = createCollection(
+    queryCollectionOptions<Row>({
+      id: `smrt:${definition.name}`,
+      queryKey: ['smrt', definition.name],
+      queryClient,
+      staleTime: staleTimeMs,
+      retry,
+      queryFn: async () =>
+        unwrapListResult(await fetchers.list(), definition.name) as Array<Row>,
+      getKey: (row) => String((row as Record<string, unknown>)[idField]),
+      onInsert: async ({ transaction }) => {
+        for (const mutation of transaction.mutations) {
+          const modified = mutation.modified as Record<string, unknown>;
+          // Strip the client-local id: the generated REST layer rejects or
+          // ignores client-supplied ids on create (#1540); the follow-up
+          // refetch swaps the optimistic row for the server-assigned one.
+          const { [idField]: _localId, ...data } = modified;
+          unwrapItemResult(
+            await fetchers.create(data),
+            `create(${definition.name})`,
+          );
+        }
+      },
+      onUpdate: fetchers.update
+        ? async ({ transaction }) => {
+            for (const mutation of transaction.mutations) {
+              const key = String(mutation.key);
+              const changes = mutation.changes as Record<string, unknown>;
+              unwrapItemResult(
+                // biome-ignore lint/style/noNonNullAssertion: guarded by the surrounding ternary
+                await fetchers.update!(key, changes),
+                `update(${definition.name})`,
+              );
+            }
+          }
+        : undefined,
+      onDelete: fetchers.delete
+        ? async ({ transaction }) => {
+            for (const mutation of transaction.mutations) {
+              // biome-ignore lint/style/noNonNullAssertion: guarded by the surrounding ternary
+              await fetchers.delete!(String(mutation.key));
+            }
+          }
+        : undefined,
+    }),
+  );
+
+  // The engine object satisfies the committed public surface at runtime; the
+  // SMRT-owned type is asserted here so the engine's own types never escape.
+  return collection as unknown as SmrtWebCollection<TData>;
+}

--- a/packages/smrt-web/tsconfig.json
+++ b/packages/smrt-web/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": ["node"],
+    "lib": ["ES2023", "DOM"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/smrt-web/vite.config.ts
+++ b/packages/smrt-web/vite.config.ts
@@ -1,0 +1,3 @@
+import { createPackageConfig } from '../../vite.config.base.js';
+
+export default createPackageConfig('smrt-web');

--- a/packages/smrt-web/vitest.config.ts
+++ b/packages/smrt-web/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import { smrtVitestPlugin } from '../vitest/src/index.ts';
+
+// smrt-web tests are pure-function / mocked-fetch (no DB), so they need none of
+// the fork isolation the DB packages use. The plugin still runs for the shared
+// CI retry policy and workspace-alias conventions.
+export default defineConfig({
+  plugins: [smrtVitestPlugin({ verbose: true })],
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
+    testTimeout: 30000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2088,6 +2088,31 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/smrt-web:
+    dependencies:
+      '@tanstack/db':
+        specifier: ^0.6.14
+        version: 0.6.14(typescript@5.9.3)
+      '@tanstack/query-core':
+        specifier: ^5.90.5
+        version: 5.101.2
+      '@tanstack/query-db-collection':
+        specifier: ^1.0.46
+        version: 1.0.46(@tanstack/query-core@5.101.2)(typescript@5.9.3)
+    devDependencies:
+      '@types/node':
+        specifier: 24.13.2
+        version: 24.13.2
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 8.1.2
+        version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/social:
     dependencies:
       '@happyvertical/smrt-config':
@@ -5559,6 +5584,29 @@ packages:
       svelte: 5.56.4
       vite: ^8.0.0-beta.7 || ^8.0.0
 
+  '@tanstack/db-ivm@0.1.18':
+    resolution: {integrity: sha512-+pZJiRKdoKRM5Epq9T7otD9ZJl82pRFauo7LKuJGrarjVKQ7r+QQlPe3kGdN9LEKSnuNGIWjX9OOY4M8kH4eLw==}
+    peerDependencies:
+      typescript: '>=4.7'
+
+  '@tanstack/db@0.6.14':
+    resolution: {integrity: sha512-Kqma/PcWhn2e21iJPM/FMKwdMuJUYII9zkKPUsD42/ceEOYRtimbBSe+xll7EY805xE2HuQ3NGSSU8UiYXpHUw==}
+    peerDependencies:
+      typescript: '>=4.7'
+
+  '@tanstack/pacer-lite@0.2.2':
+    resolution: {integrity: sha512-eQ1MyLKCHyXiH7NbdmB80W77OhiMgGBUb+qDx/8WMGbwg5Lf/NlfD0TfNYAqY77i8V3AxoDoYdICrQE5ADw4Yw==}
+    engines: {node: '>=18'}
+
+  '@tanstack/query-core@5.101.2':
+    resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
+
+  '@tanstack/query-db-collection@1.0.46':
+    resolution: {integrity: sha512-5rRGESbfcKlNUNvGGvlQQWnCFP1yfunE0MUAyweJJUMTOupG0kFXOjQB64CX7Ij7L4VpFZpa3hVMMIgG/ntytg==}
+    peerDependencies:
+      '@tanstack/query-core': ^5.0.0
+      typescript: '>=4.7'
+
   '@techstark/opencv-js@4.9.0-release.3':
     resolution: {integrity: sha512-y+KoLLlkXVUHWozYlN1vmMD9TQMPJObqml5nPA5vPWgHtOgm8q5O74UtzM23eayidvmeFX6tF5e2gDdyxcpy3Q==}
 
@@ -6856,6 +6904,10 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  fractional-indexing@3.4.0:
+    resolution: {integrity: sha512-8J3glhz2rrpKG6KmI7wmJo3zH1VjeOpN+vTJSw1fOyO+Viqq3zX6/5NGh6oaZB2qIAYdOYuu5Dz9xp4faOO0Pg==}
+    engines: {node: ^14.13.1 || >=16.0.0}
 
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
@@ -8791,6 +8843,9 @@ packages:
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
+  sorted-btree@1.8.1:
+    resolution: {integrity: sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -13075,6 +13130,30 @@ snapshots:
       vite: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0)
       vitefu: 1.1.2(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  '@tanstack/db-ivm@0.1.18(typescript@5.9.3)':
+    dependencies:
+      fractional-indexing: 3.4.0
+      sorted-btree: 1.8.1
+      typescript: 5.9.3
+
+  '@tanstack/db@0.6.14(typescript@5.9.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@tanstack/db-ivm': 0.1.18(typescript@5.9.3)
+      '@tanstack/pacer-lite': 0.2.2
+      typescript: 5.9.3
+
+  '@tanstack/pacer-lite@0.2.2': {}
+
+  '@tanstack/query-core@5.101.2': {}
+
+  '@tanstack/query-db-collection@1.0.46(@tanstack/query-core@5.101.2)(typescript@5.9.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@tanstack/db': 0.6.14(typescript@5.9.3)
+      '@tanstack/query-core': 5.101.2
+      typescript: 5.9.3
+
   '@techstark/opencv-js@4.9.0-release.3': {}
 
   '@testing-library/dom@10.4.1':
@@ -14431,6 +14510,8 @@ snapshots:
       fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
+
+  fractional-indexing@3.4.0: {}
 
   fresh@2.0.0: {}
 
@@ -16753,6 +16834,8 @@ snapshots:
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
+
+  sorted-btree@1.8.1: {}
 
   source-map-js@1.2.1: {}
 

--- a/scripts/check-smrt-web-engine-boundary.mjs
+++ b/scripts/check-smrt-web-engine-boundary.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Engine-boundary guard for @happyvertical/smrt-web (#1761, ratified condition #2).
+ *
+ * The client-data engine (currently TanStack DB) must stay an implementation
+ * detail: no `@tanstack/*` type may appear in smrt-web's PUBLIC API. If an
+ * exported type references an engine type, `tsc` emits a `@tanstack/...`
+ * reference into the corresponding `.d.ts` — as a quoted module specifier
+ * (`from '@tanstack/…'`, `import('@tanstack/…')`), so scanning for that is an
+ * exact check. Matching the quoted specifier (not a bare substring) means
+ * doc-comment prose that mentions `@tanstack/*` in backticks is not a false
+ * positive. Runs as the last step of `smrt-web`'s build; a leak fails the
+ * build (and thus CI).
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const distDir = fileURLToPath(
+  new URL('../packages/smrt-web/dist', import.meta.url),
+);
+
+/** Recursively collect every `.d.ts` file under `dir`. */
+function collectDeclarations(dir) {
+  const found = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...collectDeclarations(full));
+    } else if (entry.name.endsWith('.d.ts')) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+if (!existsSync(distDir)) {
+  console.error(
+    '[smrt-web boundary] packages/smrt-web/dist not found — build must run first',
+  );
+  process.exit(1);
+}
+
+const files = collectDeclarations(distDir).sort();
+if (files.length === 0) {
+  console.error(
+    '[smrt-web boundary] no .d.ts found under packages/smrt-web/dist — build must run first',
+  );
+  process.exit(1);
+}
+
+// A real engine reference in a `.d.ts` is always a quoted module specifier
+// (`from '@tanstack/…'` or inline `import("@tanstack/…")`). Backtick prose in
+// doc comments is not.
+const ENGINE_SPECIFIER = /["']@tanstack\//;
+
+const leaks = [];
+for (const file of files) {
+  const lines = readFileSync(file, 'utf8').split('\n');
+  lines.forEach((line, i) => {
+    if (ENGINE_SPECIFIER.test(line)) {
+      leaks.push({ file, line: i + 1, text: line.trim() });
+    }
+  });
+}
+
+if (leaks.length > 0) {
+  console.error(
+    '[smrt-web boundary] FAIL — public API leaks engine (@tanstack) types:',
+  );
+  for (const leak of leaks) {
+    const rel = leak.file.slice(leak.file.indexOf('packages/'));
+    console.error(`  ${rel}:${leak.line}: ${leak.text}`);
+  }
+  console.error(
+    '\nWrap engine types behind a SMRT-owned type so the engine stays swappable.',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `[smrt-web boundary] OK — ${files.length} declaration file(s) engine-agnostic`,
+);

--- a/vite.config.base.ts
+++ b/vite.config.base.ts
@@ -229,6 +229,9 @@ export function createPackageConfig(
     'scanner',
     'vitest',
     'smrt-playground',
+    // Framework wrapper library — has no @smrt() classes of its own; it
+    // consumes generated definitions passed in as arguments (#1761).
+    'smrt-web',
   ];
 
   return async () => {
@@ -392,6 +395,11 @@ export function createPackageConfig(
 
             // External SDK packages
             /^@have\//,
+
+            // TanStack client-data engine (smrt-web): externalized so the
+            // consumer resolves a single lockstep-pinned copy, and so the
+            // ~76 kB runtime code-splits cleanly out of public/site bundles.
+            /^@tanstack\//,
 
             // Virtual modules from SMRT framework
             '@smrt/routes',


### PR DESCRIPTION
## Summary

First slice of **#1761** — the keystone of the smrt-web track (PRD #1755). Productionizes the `#1756` TanStack DB spike into the real package plus its core codegen, under the ratified engine conditions.

This slice deliberately lands the **core emission + the framework-agnostic runtime package** (low blast radius, independently mergeable). Svelte bindings, code-split wiring, products reference integration, relationship-derived invalidation, and SvelteKit hydration seeding are subsequent slices (see below).

## What's in this slice

### Core emission (`packages/core`)
- New `@happyvertical/smrt-virt-web` runtime virtual module + the matching `@smrt/web` and virt-web `.d.ts`.
- A single shared selector — `vite-plugin/web-collections.ts` (`selectWebCollectionEntries` / `buildWebFieldDefinitions`) — used by **all three** emission sites so emitted values and declared types cannot drift. (The spike duplicated this logic across prebuild and vite-plugin, and prebuild used a naive list-exposure check; both are now unified on the canonical `resolveApiActionSet`.)
- Selection rules: one definition per REST collection; STI children fold into their base; `SmrtCollection` subclasses excluded **across the whole extends chain** (transitive subclasses too); models must expose `list`. The field map is restricted to persisted public-DTO columns (relationship / meta / transient / sensitive fields dropped).

### `@happyvertical/smrt-web` package
- `createSmrtCollection(definition, options)` — SWR reads, concurrent-read dedup, optimistic create that persists through the REST surface and rolls back on server error.
- `createDefinitionFetchers`, `unwrapListResult` / `unwrapItemResult`, `SmrtWebRequestError`, `newLocalId`.

## Ratified conditions (hard acceptance criteria)

- **② No engine types in the public API.** Collections return the SMRT-owned `SmrtWebCollection`; the shared cache is the opaque `SmrtWebClient`. A build-time guard (`scripts/check-smrt-web-engine-boundary.mjs`, run as the last step of `smrt-web`'s `build`) fails on any `@tanstack/` reference in an emitted `.d.ts`. Verified: the public `.d.ts` contains zero engine type references (only backtick prose in doc comments).
- **③ Framework-agnostic core.** The package has **no** `@tanstack/svelte-db` dependency at all; the Svelte-only export condition never enters this bundle. Svelte bindings ship in a separate entry/package (next slice).
- **① Lazy / code-split** is set up structurally (the engine is externalized so it code-splits cleanly and resolves as one lockstep-pinned copy) but is *demonstrated* in the products-integration slice, where a public-page bundle assertion will prove the ~76 kB layer never loads on smrt-sites pages.

## Tests (per the repo mocking policy — only the network boundary is mocked)
- **core**: `web-collections.test.ts` (selector + field rules over synthetic manifests) and `web-module.test.ts` (the vite `resolveId`/`load` path over a real mini-scan, incl. the transitive-collection regression). 15 tests.
- **smrt-web**: `collection.test.ts` — SWR cache window, **N-concurrent-read dedup**, optimistic create + server-id reconcile, server-error rollback, definition-derived fetchers, payload normalization. 12 tests.

## Verification (local)
- Full workspace build **55/55**; `core` + `smrt-web` typecheck clean.
- core web tests 15/15; smrt-web tests 12/12.
- Biome clean; `check-no-smrt-peers` ✓; `check-package-dag` ✓ (54 pkgs, no cycles — smrt-web has zero inter-smrt deps); `knowledge-check` fresh (0/0).
- Engine-boundary guard ✓.

## Deferred to later slices of #1761
1. **Svelte live-query bindings** (runes-idiomatic live queries + mutation state) in a separate entry.
2. **Code-split demonstration + products reference store** across npm / federation / standalone, with a public-page bundle assertion.
3. **Relationship-derived invalidation** (mutating an entity refreshes dependent collections/joins from manifest relationships).
4. **SvelteKit hydration seeding** (server-load data seeds the cache; no duplicate first-render fetch).

Refs #1755. Part of #1761.
