### PR TITLE
feat(smrt-web): relationship-derived cache invalidation (#1761)

### DIFF
--- a/packages/core/src/prebuild/index.ts
+++ b/packages/core/src/prebuild/index.ts
@@ -302,6 +302,23 @@ declare module '@smrt/web' {
     default?: unknown;
   }
 
+  export type SmrtWebRelationshipKind =
+    | 'foreignKey'
+    | 'crossPackageRef'
+    | 'oneToMany'
+    | 'manyToMany';
+
+  /**
+   * A manifest-derived edge to a sibling REST collection. Mutating this
+   * collection invalidates the caches of the collections named by these edges
+   * (#1761 relationship-derived invalidation).
+   */
+  export interface SmrtWebRelationship {
+    field: string;
+    kind: SmrtWebRelationshipKind;
+    relatedCollection: string;
+  }
+
   export interface SmrtWebCollectionDefinition<TData = Record<string, unknown>> {
     name: string;
     className: string;
@@ -309,6 +326,8 @@ declare module '@smrt/web' {
     idField: string;
     actions: string[];
     fields: Record<string, SmrtWebFieldDefinition>;
+    /** Manifest-derived relationship edges to sibling REST collections. */
+    relationships: SmrtWebRelationship[];
     /** Phantom row-type carrier for inference — never present at runtime. */
     _row?: TData;
   }

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -28,6 +28,7 @@ import {
 } from './sveltekit-generator.js';
 import {
   buildWebFieldDefinitions,
+  buildWebRelationships,
   selectWebCollectionEntries,
 } from './web-collections.js';
 
@@ -1325,6 +1326,7 @@ function generateWebModule(manifest: SmartObjectManifest): string {
       idField: 'id',
       actions,
       fields: buildWebFieldDefinitions(obj),
+      relationships: buildWebRelationships(obj, manifest),
     };
   }
 
@@ -1808,6 +1810,23 @@ declare module '@happyvertical/smrt-virt-web' {
     default?: unknown;
   }
 
+  export type SmrtWebRelationshipKind =
+    | 'foreignKey'
+    | 'crossPackageRef'
+    | 'oneToMany'
+    | 'manyToMany';
+
+  /**
+   * A manifest-derived edge to a sibling REST collection. Mutating this
+   * collection invalidates the caches of the collections named by these edges
+   * (#1761 relationship-derived invalidation).
+   */
+  export interface SmrtWebRelationship {
+    field: string;
+    kind: SmrtWebRelationshipKind;
+    relatedCollection: string;
+  }
+
   export interface SmrtWebCollectionDefinition<TData = Record<string, unknown>> {
     name: string;
     className: string;
@@ -1815,6 +1834,8 @@ declare module '@happyvertical/smrt-virt-web' {
     idField: string;
     actions: string[];
     fields: Record<string, SmrtWebFieldDefinition>;
+    /** Manifest-derived relationship edges to sibling REST collections. */
+    relationships: SmrtWebRelationship[];
     /** Phantom row-type carrier for inference — never present at runtime. */
     _row?: TData;
   }

--- a/packages/core/src/vite-plugin/web-collections.test.ts
+++ b/packages/core/src/vite-plugin/web-collections.test.ts
@@ -17,6 +17,7 @@ import type {
 } from '../scanner/types.js';
 import {
   buildWebFieldDefinitions,
+  buildWebRelationships,
   selectWebCollectionEntries,
 } from './web-collections.js';
 
@@ -230,5 +231,151 @@ describe('buildWebFieldDefinitions', () => {
       }),
     );
     expect(fields).toEqual({ name: { type: 'text' } });
+  });
+});
+
+describe('buildWebRelationships', () => {
+  const field = (f: Partial<FieldDefinition>): FieldDefinition =>
+    ({ type: 'text', ...f }) as FieldDefinition;
+
+  it('emits a foreignKey edge to the related model REST collection (same-package class name)', () => {
+    // `@foreignKey(AdGroup)` stores the SIMPLE class name in `related`; the edge
+    // resolves to that model's REST collection.
+    const variation = obj({
+      className: 'AdVariation',
+      collection: 'ad_variations',
+      fields: {
+        name: field({ type: 'text' }),
+        groupId: field({ type: 'foreignKey', related: 'AdGroup' }),
+      },
+    });
+    const group = obj({ className: 'AdGroup', collection: 'ad_groups' });
+
+    const edges = buildWebRelationships(variation, manifest(variation, group));
+    expect(edges).toEqual([
+      { field: 'groupId', kind: 'foreignKey', relatedCollection: 'ad_groups' },
+    ]);
+  });
+
+  it('emits oneToMany and manyToMany edges to their related REST collections', () => {
+    // A join relationship (`@manyToMany`) and a reverse-FK (`@oneToMany`) both
+    // carry a `related` class name that resolves to a sibling collection.
+    const post = obj({
+      className: 'Post',
+      collection: 'posts',
+      fields: {
+        title: field({ type: 'text' }),
+        comments: field({ type: 'oneToMany', related: 'Comment' }),
+        tags: field({ type: 'manyToMany', related: 'Tag' }),
+      },
+    });
+    const comment = obj({ className: 'Comment', collection: 'comments' });
+    const tag = obj({ className: 'Tag', collection: 'tags' });
+
+    const edges = buildWebRelationships(post, manifest(post, comment, tag));
+    expect(edges).toEqual([
+      { field: 'comments', kind: 'oneToMany', relatedCollection: 'comments' },
+      { field: 'tags', kind: 'manyToMany', relatedCollection: 'tags' },
+    ]);
+  });
+
+  it('resolves a crossPackageRef edge by its qualified name when the target is in the manifest', () => {
+    const ad = obj({
+      className: 'AdVariation',
+      collection: 'ad_variations',
+      fields: {
+        assetId: field({
+          type: 'crossPackageRef',
+          related: '@happyvertical/smrt-assets:Asset',
+        }),
+      },
+    });
+    const asset = obj({
+      className: 'Asset',
+      collection: 'assets',
+      qualifiedName: '@happyvertical/smrt-assets:Asset',
+    });
+
+    const edges = buildWebRelationships(ad, manifest(ad, asset));
+    expect(edges).toEqual([
+      {
+        field: 'assetId',
+        kind: 'crossPackageRef',
+        relatedCollection: 'assets',
+      },
+    ]);
+  });
+
+  it('skips an edge whose related model is not in the manifest (unresolved target)', () => {
+    // A cross-package ref to a model that was never scanned into this manifest
+    // (the common per-package build case) has no collection to invalidate.
+    const ad = obj({
+      className: 'AdVariation',
+      collection: 'ad_variations',
+      fields: {
+        zoneId: field({
+          type: 'crossPackageRef',
+          related: '@happyvertical/smrt-properties:Zone',
+        }),
+      },
+    });
+    const edges = buildWebRelationships(ad, manifest(ad));
+    expect(edges).toEqual([]);
+  });
+
+  it('skips an edge whose related model exists but is not API-exposed', () => {
+    // The related model resolves, but exposes no read surface (api:false), so it
+    // never becomes a web collection — there is no cache to invalidate.
+    const order = obj({
+      className: 'Order',
+      collection: 'orders',
+      fields: {
+        secretId: field({ type: 'foreignKey', related: 'Secret' }),
+      },
+    });
+    const secret = obj({
+      className: 'Secret',
+      collection: 'secrets',
+      decoratorConfig: {
+        api: false,
+      } as SmartObjectDefinition['decoratorConfig'],
+    });
+    const edges = buildWebRelationships(order, manifest(order, secret));
+    expect(edges).toEqual([]);
+  });
+
+  it('ignores relationship fields with no related target and non-relationship fields', () => {
+    const model = obj({
+      className: 'Thing',
+      collection: 'things',
+      fields: {
+        name: field({ type: 'text' }),
+        count: field({ type: 'integer' }),
+        // Relationship type but no `related` — cannot resolve an edge.
+        orphan: field({ type: 'foreignKey' }),
+      },
+    });
+    const edges = buildWebRelationships(model, manifest(model));
+    expect(edges).toEqual([]);
+  });
+
+  it('keeps a self-referential edge (a collection related to itself)', () => {
+    // Self edges are harmless: the runtime always invalidates the mutated
+    // collection anyway. Keeping it avoids a special case.
+    const category = obj({
+      className: 'Category',
+      collection: 'categories',
+      fields: {
+        parentId: field({ type: 'foreignKey', related: 'Category' }),
+      },
+    });
+    const edges = buildWebRelationships(category, manifest(category));
+    expect(edges).toEqual([
+      {
+        field: 'parentId',
+        kind: 'foreignKey',
+        relatedCollection: 'categories',
+      },
+    ]);
   });
 });

--- a/packages/core/src/vite-plugin/web-collections.test.ts
+++ b/packages/core/src/vite-plugin/web-collections.test.ts
@@ -306,6 +306,31 @@ describe('buildWebRelationships', () => {
     ]);
   });
 
+  it('resolves a thunk forward-ref edge (@foreignKey(() => Scene)) to the related collection', () => {
+    // Thunk forward-refs (heavy in video/voice) serialize `related` as the raw
+    // arrow-function source "() => Scene", which findByName cannot match on its
+    // own; buildWebRelationships must extract the class name so the edge resolves
+    // — regression for edges silently dropped from those collections (#1761).
+    const character = obj({
+      className: 'Character',
+      collection: 'characters',
+      fields: {
+        name: field({ type: 'text' }),
+        defaultSceneId: field({ type: 'foreignKey', related: '() => Scene' }),
+      },
+    });
+    const scene = obj({ className: 'Scene', collection: 'scenes' });
+
+    const edges = buildWebRelationships(character, manifest(character, scene));
+    expect(edges).toEqual([
+      {
+        field: 'defaultSceneId',
+        kind: 'foreignKey',
+        relatedCollection: 'scenes',
+      },
+    ]);
+  });
+
   it('skips an edge whose related model is not in the manifest (unresolved target)', () => {
     // A cross-package ref to a model that was never scanned into this manifest
     // (the common per-package build case) has no collection to invalidate.

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -30,11 +30,47 @@ const RELATIONSHIP_FIELD_TYPES: ReadonlySet<FieldDefinition['type']> = new Set([
   'manyToMany',
 ]);
 
+/**
+ * Field types that describe a relationship to another model. A superset of
+ * {@link RELATIONSHIP_FIELD_TYPES}: `foreignKey`/`crossPackageRef` are persisted
+ * scalar id columns (they DO appear on the wire), while `oneToMany`/`manyToMany`
+ * are pseudo-columns — but all four carry a `related` edge to a sibling model.
+ */
+const RELATIONSHIP_EDGE_TYPES: ReadonlySet<FieldDefinition['type']> = new Set([
+  'foreignKey',
+  'crossPackageRef',
+  'oneToMany',
+  'manyToMany',
+]);
+
 /** Informational per-column metadata carried by a collection definition. */
 export interface WebFieldDefinition {
   type: FieldDefinition['type'];
   required?: boolean;
   default?: unknown;
+}
+
+/** The relationship kinds a web collection edge can describe. */
+export type WebRelationshipKind =
+  | 'foreignKey'
+  | 'crossPackageRef'
+  | 'oneToMany'
+  | 'manyToMany';
+
+/**
+ * One manifest-derived relationship edge from a collection to a sibling REST
+ * collection. Consumed by the browser client-data runtime to invalidate
+ * dependent collection caches when this collection is mutated (#1761) — the
+ * cache-invalidation graph is derived entirely from these edges, never
+ * hand-wired. SMRT-owned data: no client-engine type appears here.
+ */
+export interface WebRelationship {
+  /** The declaring field carrying the relationship (e.g. `groupId`, `items`). */
+  field: string;
+  /** The relationship kind, mirroring the manifest field type. */
+  kind: WebRelationshipKind;
+  /** REST collection name the edge resolves to (e.g. `ad_groups`). */
+  relatedCollection: string;
 }
 
 /** One selected REST collection and the model that owns its definition. */
@@ -173,4 +209,62 @@ export function buildWebFieldDefinitions(
     };
   }
   return fields;
+}
+
+/**
+ * Build the manifest-derived relationship edges for a web collection
+ * definition (#1761): one entry per relationship field (`foreignKey`,
+ * `crossPackageRef`, `oneToMany`, `manyToMany`) whose `related` target resolves
+ * to another API-exposed REST collection.
+ *
+ * These edges drive relationship-derived cache invalidation in the browser
+ * client-data runtime: mutating this collection invalidates the caches of the
+ * collections named here. The invalidation graph is thus derived entirely from
+ * the manifest — no hand-wired cache keys.
+ *
+ * An edge is SKIPPED (not emitted) when:
+ *  - `related` is missing, or
+ *  - `related` cannot be resolved to a manifest object (e.g. a cross-package
+ *    target not present in this package's manifest), or
+ *  - the resolved target is not itself an API-exposed web collection (no read
+ *    surface to invalidate — it never appears in {@link selectWebCollectionEntries}).
+ *
+ * Self-referential edges (a collection related to itself) are kept: the runtime
+ * always invalidates the mutated collection anyway, so a self edge is harmless
+ * and keeping it avoids a special case.
+ */
+export function buildWebRelationships(
+  obj: SmartObjectDefinition,
+  manifest: SmartObjectManifest,
+): WebRelationship[] {
+  // The set of REST collections that are actually materialized as web
+  // collections. An edge to a model outside this set has no client cache to
+  // invalidate, so it is dropped.
+  const exposedCollections = new Set(
+    selectWebCollectionEntries(manifest).map((entry) => entry.collection),
+  );
+
+  const relationships: WebRelationship[] = [];
+  const seen = new Set<string>();
+  for (const [fieldName, field] of Object.entries(obj.fields ?? {})) {
+    if (!RELATIONSHIP_EDGE_TYPES.has(field.type)) continue;
+    if (!field.related) continue;
+
+    const target = findByName(manifest, field.related);
+    if (!target) continue;
+    if (!exposedCollections.has(target.collection)) continue;
+
+    // De-dupe on (field, relatedCollection): a model never declares the same
+    // field twice, but guard anyway so the emitted edge list is stable.
+    const dedupeKey = `${fieldName} ${target.collection}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    relationships.push({
+      field: fieldName,
+      kind: field.type as WebRelationshipKind,
+      relatedCollection: target.collection,
+    });
+  }
+  return relationships;
 }

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -95,6 +95,25 @@ function findByName(
 }
 
 /**
+ * Normalize a relationship field's `related` value to a resolvable class name.
+ *
+ * Thunk forward-ref decorators — `@foreignKey(() => Scene)`, used heavily in
+ * video/voice for models that reference a class declared later — serialize as
+ * the RAW arrow-function source string `"() => Scene"` in the manifest, which
+ * neither `className` nor `qualifiedName` matches. Extract the target class
+ * name from the thunk so the edge resolves. Plain (`"Scene"`) and qualified
+ * (`"@happyvertical/smrt-assets:Asset"`) forms contain no `=>` and pass through
+ * untouched — the qualified `:` separator is preserved.
+ *
+ * Kept local to the relationship-edge path on purpose: extends-chain resolution
+ * never sees a thunk, so `findByName` and the scanner stay unchanged.
+ */
+function normalizeRelatedName(related: string): string {
+  const thunk = related.match(/=>\s*([A-Za-z_$][\w$]*)/);
+  return thunk ? thunk[1] : related.trim();
+}
+
+/**
  * True when `obj` is (transitively) a SmrtCollection subclass. Collection
  * classes describe access, not row shapes, so they never become web
  * collection definitions.
@@ -250,7 +269,9 @@ export function buildWebRelationships(
     if (!RELATIONSHIP_EDGE_TYPES.has(field.type)) continue;
     if (!field.related) continue;
 
-    const target = findByName(manifest, field.related);
+    // Normalize first: `@foreignKey(() => Scene)` thunks serialize as the raw
+    // "() => Scene" source, which findByName cannot match on its own.
+    const target = findByName(manifest, normalizeRelatedName(field.related));
     if (!target) continue;
     if (!exposedCollections.has(target.collection)) continue;
 

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -256,7 +256,7 @@ export function buildWebRelationships(
 
     // De-dupe on (field, relatedCollection): a model never declares the same
     // field twice, but guard anyway so the emitted edge list is stable.
-    const dedupeKey = `${fieldName} ${target.collection}`;
+    const dedupeKey = `${fieldName}:${target.collection}`;
     if (seen.has(dedupeKey)) continue;
     seen.add(dedupeKey);
 

--- a/packages/core/src/vite-plugin/web-module.test.ts
+++ b/packages/core/src/vite-plugin/web-module.test.ts
@@ -48,7 +48,7 @@ describe('smrtPlugin load (\0smrt:web virtual module)', () => {
     );
     writeFileSync(
       join(projectRoot, 'src', 'objects.ts'),
-      `import { SmrtCollection, SmrtObject } from '@happyvertical/smrt-core';
+      `import { SmrtCollection, SmrtObject, foreignKey } from '@happyvertical/smrt-core';
 
 // STI child declared BEFORE its base: the base model must still own the
 // shared table's collection definition (regression: Material extends Product
@@ -63,6 +63,15 @@ export class Widget extends SmrtObject {
   name: string = '';
   price: number = 0.0;
   inStock: boolean = true;
+  // FK to an API-exposed sibling: the runtime module must emit a manifest-
+  // derived relationship edge to that model's REST collection (#1761).
+  @foreignKey('Category')
+  categoryId: string = '';
+}
+
+@smrt({ api: { include: ['list', 'get'] } })
+export class Category extends SmrtObject {
+  label: string = '';
 }
 
 export class WidgetCollection extends SmrtCollection<Widget> {
@@ -114,7 +123,7 @@ export class HiddenGadget extends SmrtObject {
     expect(code).toContain('export function getCollectionDefinition');
 
     const definitions = extractDefinitions(code as string);
-    expect(Object.keys(definitions)).toEqual(['widgets']);
+    expect(Object.keys(definitions).sort()).toEqual(['categories', 'widgets']);
 
     const widgets = definitions.widgets as Record<string, unknown>;
     expect(widgets.className).toBe('Widget');
@@ -126,6 +135,26 @@ export class HiddenGadget extends SmrtObject {
       price: { type: 'decimal' },
       inStock: { type: 'boolean' },
     });
+  });
+
+  it('emits manifest-derived relationship edges to related REST collections (#1761)', async () => {
+    const code = (await load('\0smrt:web')) as string;
+    const definitions = extractDefinitions(code);
+
+    // Widget declares `@foreignKey('Category')`; the edge resolves to the
+    // categories REST collection — no hand-wired cache key.
+    const widgets = definitions.widgets as Record<string, unknown>;
+    expect(widgets.relationships).toEqual([
+      {
+        field: 'categoryId',
+        kind: 'foreignKey',
+        relatedCollection: 'categories',
+      },
+    ]);
+
+    // Category has no relationship fields — an empty edge list, never absent.
+    const categories = definitions.categories as Record<string, unknown>;
+    expect(categories.relationships).toEqual([]);
   });
 
   it('folds STI children into the base model definition even when the child is scanned first', async () => {

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -21,10 +21,15 @@
  * - concurrent-read dedup (one network request per in-flight collection load)
  * - optimistic create that persists through the generated REST surface and
  *   rolls back automatically when the server errors
+ * - relationship-derived invalidation (#1761): a settled mutation invalidates
+ *   the caches of the collections related to the mutated one, with the edges
+ *   derived from the manifest (`definition.relationships`) — no hand-wired
+ *   cache keys. Cross-collection reach requires a shared client from
+ *   {@link createSmrtWebClient}; with a private client only the mutated
+ *   collection refetches.
  *
- * Deliberately NOT here yet (see PRD #1755): relationship-derived invalidation,
- * SvelteKit hydration seeding, offline outbox, SSE invalidation, persistence,
- * version awareness.
+ * Deliberately NOT here yet (see PRD #1755): SvelteKit hydration seeding,
+ * offline outbox, SSE invalidation, persistence, version awareness.
  */
 
 import { createCollection } from '@tanstack/db';
@@ -43,6 +48,32 @@ export interface SmrtWebFieldDefinition {
   type: string;
   required?: boolean;
   default?: unknown;
+}
+
+/** The relationship kinds a generated web collection edge can describe. */
+export type SmrtWebRelationshipKind =
+  | 'foreignKey'
+  | 'crossPackageRef'
+  | 'oneToMany'
+  | 'manyToMany';
+
+/**
+ * A manifest-derived edge from this collection to a sibling REST collection,
+ * emitted by the `@happyvertical/smrt-virt-web` virtual module. When a mutation
+ * on this collection settles, the caches of the collections named by these
+ * edges are invalidated (relationship-derived invalidation, #1761), so a
+ * dependent view refetches without any hand-wired cache key.
+ *
+ * SMRT-owned data — no client-engine (`@tanstack/*`) type appears here, so it
+ * stays inside the engine-absorption boundary.
+ */
+export interface SmrtWebRelationship {
+  /** The declaring field carrying the relationship (e.g. `groupId`, `items`). */
+  field: string;
+  /** The relationship kind, mirroring the manifest field type. */
+  kind: SmrtWebRelationshipKind;
+  /** REST collection name the edge resolves to (e.g. `ad_groups`). */
+  relatedCollection: string;
 }
 
 /**
@@ -64,6 +95,14 @@ export interface SmrtWebCollectionDefinition<TData extends object = object> {
   actions: string[];
   /** Persisted field metadata keyed by field name. */
   fields: Record<string, SmrtWebFieldDefinition>;
+  /**
+   * Manifest-derived relationship edges to sibling REST collections. Drives
+   * relationship-derived cache invalidation: a settled mutation on this
+   * collection invalidates the caches of the collections these edges name.
+   * Optional so hand-built definitions (older codegen, tests) still satisfy the
+   * type; a missing value means "no derived edges".
+   */
+  relationships?: SmrtWebRelationship[];
   /** Phantom row-type carrier — never present at runtime. */
   _row?: TData;
 }
@@ -450,6 +489,13 @@ export function getEngineCollection<TData extends object>(
  * persists through `fetchers.create()` (the temp id is stripped — the server
  * assigns the real one), then refetches to reconcile. A failed create rejects
  * the transaction and the optimistic row rolls back automatically.
+ *
+ * Relationship-derived invalidation: once a create/update/delete has persisted,
+ * the query caches of this collection AND the collections named by
+ * `definition.relationships` (manifest-derived edges) are invalidated, so
+ * dependent views refetch. Reaching OTHER collections requires them to share
+ * this collection's `client` (see {@link createSmrtWebClient}); with a private
+ * client only this collection refetches.
  */
 export function createSmrtCollection<TData extends object>(
   definition: SmrtWebCollectionDefinition<TData>,
@@ -473,6 +519,45 @@ export function createSmrtCollection<TData extends object>(
     ? ['smrt', scope, definition.name]
     : ['smrt', definition.name];
 
+  // Relationship-derived invalidation target set (#1761): the collections
+  // whose caches a settled mutation on THIS collection must invalidate. Always
+  // includes this collection itself (so its own read revalidates) plus every
+  // manifest-derived related collection. Built once; a settled write matches
+  // any cached query whose collection-name segment (the LAST queryKey element,
+  // mirroring the `['smrt', (scope,) name]` scheme above) is in this set.
+  //
+  // Over-invalidation is safe — a stale query merely refetches. Under-
+  // invalidation is the bug (a dependent view showing stale rows), so the
+  // predicate matches by collection name across ALL scopes rather than an exact
+  // key: a mutation in one scope refreshes the related collection in every
+  // scope sharing the client.
+  const invalidationTargets = new Set<string>([definition.name]);
+  for (const relationship of definition.relationships ?? []) {
+    invalidationTargets.add(relationship.relatedCollection);
+  }
+
+  /**
+   * Invalidate the query caches of this collection and its manifest-derived
+   * related collections. Cross-collection reach requires those collections to
+   * share this collection's `client` (from {@link createSmrtWebClient}); with a
+   * private client only THIS collection's query lives here, so only it
+   * refetches. Fire-and-forget: invalidation schedules a background refetch and
+   * must not delay the mutation's own settle.
+   */
+  const invalidateRelated = (): void => {
+    void queryClient.invalidateQueries({
+      predicate: (query) => {
+        const key = query.queryKey;
+        if (!Array.isArray(key) || key.length === 0) return false;
+        const collectionSegment = key[key.length - 1];
+        return (
+          typeof collectionSegment === 'string' &&
+          invalidationTargets.has(collectionSegment)
+        );
+      },
+    });
+  };
+
   const collection = createCollection(
     queryCollectionOptions<Row>({
       id: cacheId,
@@ -495,6 +580,10 @@ export function createSmrtCollection<TData extends object>(
             `create(${definition.name})`,
           );
         }
+        // Persisted: refresh this collection and its related collections. Runs
+        // only after every create resolved — a rejected create rolls the
+        // optimistic row back and never reaches here.
+        invalidateRelated();
       },
       onUpdate: fetchers.update
         ? async ({ transaction }) => {
@@ -507,6 +596,7 @@ export function createSmrtCollection<TData extends object>(
                 `update(${definition.name})`,
               );
             }
+            invalidateRelated();
           }
         : undefined,
       onDelete: fetchers.delete
@@ -515,6 +605,7 @@ export function createSmrtCollection<TData extends object>(
               // biome-ignore lint/style/noNonNullAssertion: guarded by the surrounding ternary
               await fetchers.delete!(String(mutation.key));
             }
+            invalidateRelated();
           }
         : undefined,
     }),

--- a/packages/smrt-web/src/invalidation.test.ts
+++ b/packages/smrt-web/src/invalidation.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Relationship-derived cache invalidation tests for smrt-web (#1761).
+ *
+ * A settled mutation on one collection must refresh the collections related to
+ * it — with the edges derived from the manifest (`definition.relationships`),
+ * not hand-wired here. Cross-collection reach requires a SHARED client from
+ * {@link createSmrtWebClient}: the invalidation runs on that shared query cache.
+ *
+ * Per the repo mocking policy only the network boundary is mocked (the
+ * generated REST client fetchers). The client-data engine, its query cache, and
+ * the transaction lifecycle are all real, so a refetch is a real `list()` call
+ * observable through the scripted fetcher's call counter.
+ *
+ * Coverage: one foreign-key relationship (Comment.articleId -> articles) and
+ * one join/one-to-many relationship (Article.tags -> tags), the two edge kinds
+ * the acceptance criteria call for.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createSmrtCollection,
+  createSmrtWebClient,
+  newLocalId,
+  type SmrtCrudFetchers,
+  type SmrtWebCollection,
+  type SmrtWebCollectionDefinition,
+} from './index.js';
+
+interface ArticleData {
+  id?: string;
+  title: string;
+}
+interface CommentData {
+  id?: string;
+  body: string;
+  articleId?: string;
+}
+interface TagData {
+  id?: string;
+  label: string;
+}
+
+/**
+ * `comments` with a foreign-key edge to `articles` — mirrors what
+ * `@happyvertical/smrt-virt-web` emits for a `@foreignKey('Article')` field.
+ */
+function commentsDefinition(): SmrtWebCollectionDefinition<CommentData> {
+  return {
+    name: 'comments',
+    className: 'Comment',
+    endpoint: '/comments',
+    idField: 'id',
+    actions: ['create', 'delete', 'get', 'list', 'update'],
+    fields: {
+      body: { type: 'text', required: true },
+      articleId: { type: 'foreignKey' },
+    },
+    relationships: [
+      { field: 'articleId', kind: 'foreignKey', relatedCollection: 'articles' },
+    ],
+  };
+}
+
+/**
+ * `articles` with a many-to-many (join) edge to `tags` — mirrors what codegen
+ * emits for a `@manyToMany('Tag')` field.
+ */
+function articlesDefinition(): SmrtWebCollectionDefinition<ArticleData> {
+  return {
+    name: 'articles',
+    className: 'Article',
+    endpoint: '/articles',
+    idField: 'id',
+    actions: ['create', 'delete', 'get', 'list', 'update'],
+    fields: { title: { type: 'text', required: true } },
+    relationships: [
+      { field: 'tags', kind: 'manyToMany', relatedCollection: 'tags' },
+    ],
+  };
+}
+
+/** `tags` — a leaf collection with no outbound edges. */
+function tagsDefinition(): SmrtWebCollectionDefinition<TagData> {
+  return {
+    name: 'tags',
+    className: 'Tag',
+    endpoint: '/tags',
+    idField: 'id',
+    actions: ['create', 'delete', 'get', 'list', 'update'],
+    fields: { label: { type: 'text', required: true } },
+    relationships: [],
+  };
+}
+
+/**
+ * A scripted stand-in for a generated REST client surface: resolves the way the
+ * generated fetchers do (JSON payloads, never rejects on HTTP errors) and
+ * counts `list()` so a relationship-driven refetch is observable.
+ */
+function makeScriptedFetchers(initialRows: Array<Record<string, unknown>>) {
+  const serverRows = [...initialRows];
+  const calls = { list: 0, create: 0, update: 0, delete: 0 };
+
+  const fetchers: SmrtCrudFetchers = {
+    list: async () => {
+      calls.list += 1;
+      return serverRows.map((row) => ({ ...row }));
+    },
+    create: async (data) => {
+      calls.create += 1;
+      const created = { ...data, id: `server-${serverRows.length + 1}` };
+      serverRows.push(created);
+      return { ...created };
+    },
+    update: async (id, data) => {
+      calls.update += 1;
+      return { ...data, id };
+    },
+    delete: async () => {
+      calls.delete += 1;
+      return true;
+    },
+  };
+
+  return { fetchers, calls };
+}
+
+/**
+ * Wait until `predicate` holds, polling microtask-by-microtask. Invalidation is
+ * fire-and-forget (it schedules a background refetch), so a settled mutation's
+ * effect on a RELATED collection lands a few ticks later — this bridges that
+ * gap without a fixed sleep. Fails loudly if it never settles.
+ */
+async function waitFor(
+  predicate: () => boolean,
+  { tries = 50 }: { tries?: number } = {},
+): Promise<void> {
+  for (let i = 0; i < tries; i += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  if (!predicate()) {
+    throw new Error('waitFor: predicate never became true');
+  }
+}
+
+describe('relationship-derived invalidation (shared client)', () => {
+  const cleanups: Array<SmrtWebCollection<object>> = [];
+  const track = <T extends object>(c: SmrtWebCollection<T>) => {
+    cleanups.push(c as unknown as SmrtWebCollection<object>);
+    return c;
+  };
+
+  afterEach(async () => {
+    await Promise.all(cleanups.map((c) => c.cleanup()));
+    cleanups.length = 0;
+  });
+
+  it('refetches a foreign-key-related collection when the owning collection is mutated', async () => {
+    const client = createSmrtWebClient();
+    const commentsBackend = makeScriptedFetchers([
+      { id: 'c1', body: 'first', articleId: 'a1' },
+    ]);
+    const articlesBackend = makeScriptedFetchers([
+      { id: 'a1', title: 'Hello' },
+    ]);
+
+    const comments = track(
+      createSmrtCollection(commentsDefinition(), {
+        fetchers: commentsBackend.fetchers,
+        client,
+        staleTimeMs: 60_000,
+      }),
+    );
+    const articles = track(
+      createSmrtCollection(articlesDefinition(), {
+        fetchers: articlesBackend.fetchers,
+        client,
+        staleTimeMs: 60_000,
+      }),
+    );
+
+    // Keep the articles collection "active" — a live subscriber, as a rendered
+    // view would be — so an invalidation actually triggers a background refetch.
+    const articlesSub = articles.subscribeChanges(() => {});
+    await Promise.all([comments.preload(), articles.preload()]);
+    expect(articlesBackend.calls.list).toBe(1);
+    expect(commentsBackend.calls.list).toBe(1);
+
+    // Mutate comments (the FK owner). Its relationships name `articles`, so once
+    // the create settles the articles cache is invalidated and refetches.
+    const tx = comments.insert({
+      id: newLocalId(),
+      body: 'second',
+      articleId: 'a1',
+    });
+    await tx.isPersisted.promise;
+
+    await waitFor(() => articlesBackend.calls.list >= 2);
+    expect(articlesBackend.calls.list).toBeGreaterThanOrEqual(2);
+
+    articlesSub.unsubscribe();
+  });
+
+  it('refetches a join-related collection when the owning collection is mutated', async () => {
+    const client = createSmrtWebClient();
+    const articlesBackend = makeScriptedFetchers([
+      { id: 'a1', title: 'Hello' },
+    ]);
+    const tagsBackend = makeScriptedFetchers([{ id: 't1', label: 'news' }]);
+
+    const articles = track(
+      createSmrtCollection(articlesDefinition(), {
+        fetchers: articlesBackend.fetchers,
+        client,
+        staleTimeMs: 60_000,
+      }),
+    );
+    const tags = track(
+      createSmrtCollection(tagsDefinition(), {
+        fetchers: tagsBackend.fetchers,
+        client,
+        staleTimeMs: 60_000,
+      }),
+    );
+
+    const tagsSub = tags.subscribeChanges(() => {});
+    await Promise.all([articles.preload(), tags.preload()]);
+    expect(tagsBackend.calls.list).toBe(1);
+
+    // Articles' relationships name `tags` (manyToMany join). An update on an
+    // article invalidates the tags cache — a join membership may have changed.
+    const tx = articles.insert({ id: newLocalId(), title: 'World' });
+    await tx.isPersisted.promise;
+
+    await waitFor(() => tagsBackend.calls.list >= 2);
+    expect(tagsBackend.calls.list).toBeGreaterThanOrEqual(2);
+
+    tagsSub.unsubscribe();
+  });
+
+  it('does not refetch an UNRELATED collection sharing the same client', async () => {
+    const client = createSmrtWebClient();
+    const commentsBackend = makeScriptedFetchers([
+      { id: 'c1', body: 'first', articleId: 'a1' },
+    ]);
+    // `tags` is unrelated to `comments` (comments only edges to articles).
+    const tagsBackend = makeScriptedFetchers([{ id: 't1', label: 'news' }]);
+
+    const comments = track(
+      createSmrtCollection(commentsDefinition(), {
+        fetchers: commentsBackend.fetchers,
+        client,
+        staleTimeMs: 60_000,
+      }),
+    );
+    const tags = track(
+      createSmrtCollection(tagsDefinition(), {
+        fetchers: tagsBackend.fetchers,
+        client,
+        staleTimeMs: 60_000,
+      }),
+    );
+
+    const tagsSub = tags.subscribeChanges(() => {});
+    await Promise.all([comments.preload(), tags.preload()]);
+    expect(tagsBackend.calls.list).toBe(1);
+
+    const tx = comments.insert({
+      id: newLocalId(),
+      body: 'second',
+      articleId: 'a1',
+    });
+    await tx.isPersisted.promise;
+    // Give any (erroneous) invalidation time to fire.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // The mutated collection refetched (it is always in its own target set),
+    // but the unrelated tags collection did not.
+    expect(commentsBackend.calls.list).toBeGreaterThanOrEqual(2);
+    expect(tagsBackend.calls.list).toBe(1);
+
+    tagsSub.unsubscribe();
+  });
+
+  it('with a PRIVATE client, only the mutated collection refetches (no cross-collection reach)', async () => {
+    // No shared client: each collection gets its own private query cache, so a
+    // mutation on comments cannot reach the articles cache — documents the
+    // shared-client requirement.
+    const commentsBackend = makeScriptedFetchers([
+      { id: 'c1', body: 'first', articleId: 'a1' },
+    ]);
+    const articlesBackend = makeScriptedFetchers([
+      { id: 'a1', title: 'Hello' },
+    ]);
+
+    const comments = track(
+      createSmrtCollection(commentsDefinition(), {
+        fetchers: commentsBackend.fetchers,
+        staleTimeMs: 60_000,
+      }),
+    );
+    const articles = track(
+      createSmrtCollection(articlesDefinition(), {
+        fetchers: articlesBackend.fetchers,
+        staleTimeMs: 60_000,
+      }),
+    );
+
+    const articlesSub = articles.subscribeChanges(() => {});
+    await Promise.all([comments.preload(), articles.preload()]);
+    expect(articlesBackend.calls.list).toBe(1);
+
+    const tx = comments.insert({
+      id: newLocalId(),
+      body: 'second',
+      articleId: 'a1',
+    });
+    await tx.isPersisted.promise;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // comments refetched on its own private cache; articles (private, separate
+    // cache) was untouched.
+    expect(commentsBackend.calls.list).toBeGreaterThanOrEqual(2);
+    expect(articlesBackend.calls.list).toBe(1);
+
+    articlesSub.unsubscribe();
+  });
+});


### PR DESCRIPTION
## Summary

Slice B of #1761 (smrt-web track): **relationship-derived cache invalidation** for the `@happyvertical/smrt-web` browser client-data runtime. Mutating an entity now invalidates the client caches of the collections derived from its **manifest** relationships, so a dependent view refetches — with the edges derived from the manifest, never hand-wired cache keys.

Satisfies the AC: *"Mutating an entity invalidates dependent collections derived from manifest relationships (demonstrated across at least one foreign-key and one join relationship)."*

## Emitted relationship schema

`buildWebRelationships(obj, manifest)` (added to the shared selector `packages/core/src/vite-plugin/web-collections.ts`) emits, per collection definition, a `relationships` array of SMRT-owned edges:

```ts
interface SmrtWebRelationship {
  field: string;                 // declaring field, e.g. "categoryId", "tags"
  kind: 'foreignKey' | 'crossPackageRef' | 'oneToMany' | 'manyToMany';
  relatedCollection: string;     // resolved REST collection, e.g. "categories"
}
```

An edge is derived from every `obj.fields` entry whose `type` is a relationship type and whose `related` resolves — via the file's existing `findByName` lookup — to another API-exposed REST collection:
- `foreignKey`/`oneToMany`/`manyToMany` store a **simple class name** in `related` (matches `className`).
- `crossPackageRef` stores a **qualified name** like `@happyvertical/smrt-assets:Asset` (matches `qualifiedName`).

An edge is **skipped** when `related` is missing, cannot be resolved (e.g. a cross-package target absent from this package's manifest), or resolves to a model that is not itself an API-exposed web collection (no cache to invalidate). Self-referential edges are kept (harmless — the mutated collection is always invalidated anyway).

The `relationships` field + `SmrtWebRelationship`/`SmrtWebRelationshipKind` types were added to **all three** declaration sites plus the runtime module, keeping the "shared selector drives every emission site" invariant:
- runtime `\0smrt:web` module — `generateWebModule` (vite-plugin)
- `@happyvertical/smrt-virt-web` d.ts (vite-plugin)
- `@smrt/web` d.ts (prebuild)
- smrt-web's own `SmrtWebCollectionDefinition` (`relationships?` optional there so hand-built/older definitions still typecheck; the core-emitted contract has it required)

## Invalidation mechanism

In `createSmrtCollection` (`packages/smrt-web/src/index.ts`), a target set is built once from `definition.relationships` plus this collection itself. After a create/update/delete **persists** through the fetcher (inside `onInsert`/`onUpdate`/`onDelete`, once the call resolves — a rolled-back mutation never reaches it), `invalidateRelated()` calls `queryClient.invalidateQueries` with a **predicate** matching any queryKey whose collection-name segment (the last element of `['smrt', name]` / `['smrt', scope, name]`) is in the target set. Fire-and-forget: it schedules a background refetch and does not delay the mutation's own settle.

Over-invalidation is safe (a stale query merely refetches); under-invalidation would be the bug (a dependent view showing stale rows), so the predicate matches by collection **name across all scopes** rather than an exact key.

## Shared-client requirement

Cross-collection invalidation runs on the shared query cache, so it only reaches **other** collections when they share a client from `createSmrtWebClient()`. With a private (omitted) client, each collection has its own cache and only the mutated collection refetches. Documented on the module, the factory, and `SmrtWebRelationship`; covered by a dedicated test.

## Engine-absorption boundary (no slice-1 regression)

`SmrtWebRelationship` / `relationships` are SMRT-owned data — no `@tanstack/*` type enters the public API. The `check-smrt-web-engine-boundary.mjs` guard (end of smrt-web's `build`) prints `OK — 1 declaration file(s) engine-agnostic`. The plain-DTO wrapper and `getEngineCollection` bridge are untouched.

## Verification

| Check | Result |
| --- | --- |
| `pnpm --filter @happyvertical/smrt-core build` | pass |
| core web tests (`web-collections.test.ts` + `web-module.test.ts`) | **23 passed** |
| `pnpm --filter @happyvertical/smrt-web build` (engine-boundary guard) | pass — guard **OK** |
| `pnpm --filter @happyvertical/smrt-web typecheck` | pass |
| `pnpm --filter @happyvertical/smrt-web test` | **20 passed** (16 existing + 4 new) |
| `packages/core` typecheck | pass (after root build for composite deps) |
| `biome check` on changed files | pass |
| `check-no-smrt-peers.mjs` | pass |
| `check-package-dag.mjs` | pass — 54 pkgs form a DAG |
| `dev:knowledge-check --format markdown` | **fresh** (0 errors, 0 warnings) |

Note: `npm run build` (full repo) fails on the unrelated `smrt-playground-host` app (`Tsconfig not found .../packages/accounts` — a stale reference in the sibling worktree path, pre-existing, untouched by this PR). It does not affect any package changed here.

Refs #1761.
