### PR TITLE
feat(smrt-svelte): Svelte 5 live-query bindings for smrt-web (#1761)

### DIFF
--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -46,6 +46,12 @@
       "svelte": "./dist/browser-ai/svelte/index.js",
       "import": "./dist/browser-ai/svelte/index.js",
       "default": "./dist/browser-ai/svelte/index.js"
+    },
+    "./web": {
+      "types": "./dist/web/index.d.ts",
+      "svelte": "./dist/web/index.js",
+      "import": "./dist/web/index.js",
+      "default": "./dist/web/index.js"
     }
   },
   "files": [
@@ -89,6 +95,9 @@
     "@happyvertical/smrt-languages": "workspace:*",
     "@happyvertical/smrt-types": "workspace:*",
     "@happyvertical/smrt-ui": "workspace:*",
+    "@happyvertical/smrt-web": "workspace:*",
+    "@tanstack/db": "^0.6.14",
+    "@tanstack/svelte-db": "^0.1.91",
     "esm-env": "^1.2.2"
   },
   "peerDependencies": {

--- a/packages/smrt-svelte/src/web/__tests__/harness.svelte
+++ b/packages/smrt-svelte/src/web/__tests__/harness.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+/**
+ * Test harness — invokes liveCollection() inside a component init scope so the
+ * `$effect` that `useLiveQuery` installs wires up correctly, then hands the
+ * returned reactive view back to the test via the `onReady` callback prop.
+ */
+import type { SmrtWebCollection } from '@happyvertical/smrt-web';
+import {
+  type LiveCollection,
+  liveCollection,
+} from '../live-collection.svelte.js';
+
+interface Props {
+  handle: SmrtWebCollection<Record<string, unknown>>;
+  onReady: (view: LiveCollection<Record<string, unknown>>) => void;
+}
+
+const props: Props = $props();
+// This harness intentionally snapshots the handle during setup.
+// svelte-ignore state_referenced_locally
+const view = liveCollection(props.handle);
+// This harness intentionally snapshots the callback during setup.
+// svelte-ignore state_referenced_locally
+props.onReady(view);
+</script>

--- a/packages/smrt-svelte/src/web/__tests__/live-collection.svelte.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/live-collection.svelte.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Behavior tests for the Svelte 5 live-query binding over `@happyvertical/smrt-web`
+ * (#1761, slice A).
+ *
+ * Per repo policy only the network boundary is mocked: the generated REST
+ * client fetchers passed to `createSmrtCollection`. Everything else — the
+ * client-data engine collection, the real `useLiveQuery` live view, its
+ * transactions, and the runes reactivity — is real. The binding is exercised
+ * through a thin host component (`harness.svelte`) so `useLiveQuery`'s internal
+ * `$effect` has a genuine component-init scope, matching this package's other
+ * runes-composable tests.
+ */
+
+import {
+  createSmrtCollection,
+  type SmrtCrudFetchers,
+  type SmrtWebCollection,
+  type SmrtWebCollectionDefinition,
+} from '@happyvertical/smrt-web';
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { LiveCollection } from '../live-collection.svelte.js';
+import Harness from './harness.svelte';
+
+interface ProductData {
+  id?: string;
+  name: string;
+  price?: number;
+}
+
+function productDefinition(
+  name: string,
+): SmrtWebCollectionDefinition<ProductData> {
+  return {
+    name,
+    className: 'Product',
+    endpoint: `/${name}`,
+    idField: 'id',
+    actions: ['create', 'get', 'list', 'update'],
+    fields: {
+      name: { type: 'text', required: true },
+      price: { type: 'decimal' },
+    },
+  };
+}
+
+/**
+ * Scripted stand-in for `createClient('/api/v1').products`: resolves like the
+ * generated fetchers (JSON payloads, `{ error }` bodies on failure, never
+ * rejects on HTTP status) so the engine's optimistic/rollback path is real.
+ */
+function makeScriptedFetchers(initialRows: Array<Record<string, unknown>>) {
+  const serverRows = [...initialRows];
+  let failNextCreate: string | null = null;
+
+  const fetchers: SmrtCrudFetchers = {
+    list: async () => serverRows.map((row) => ({ ...row })),
+    create: async (data) => {
+      if (failNextCreate) {
+        const error = failNextCreate;
+        failNextCreate = null;
+        return { error };
+      }
+      const created = { ...data, id: `server-${serverRows.length + 1}` };
+      serverRows.push(created);
+      return { ...created };
+    },
+  };
+
+  return {
+    fetchers,
+    failCreateWith(message: string) {
+      failNextCreate = message;
+    },
+  };
+}
+
+function mountView(handle: SmrtWebCollection<ProductData>): {
+  view: LiveCollection<ProductData>;
+  teardown: () => void;
+} {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  let exposed = undefined as unknown as LiveCollection<ProductData>;
+  const component = mount(Harness, {
+    target,
+    props: {
+      // The harness is typed against the base object shape; ProductData is a
+      // structural subtype, so this cross-cast is purely nominal.
+      handle: handle as unknown as SmrtWebCollection<Record<string, unknown>>,
+      onReady: (view: LiveCollection<Record<string, unknown>>) => {
+        exposed = view as unknown as LiveCollection<ProductData>;
+      },
+    },
+  });
+  return {
+    view: exposed,
+    teardown: () => {
+      unmount(component);
+      target.remove();
+    },
+  };
+}
+
+describe('liveCollection', () => {
+  const cleanup: Array<() => void> = [];
+
+  afterEach(async () => {
+    for (const fn of cleanup.splice(0)) fn();
+  });
+
+  function track(mounted: {
+    view: LiveCollection<ProductData>;
+    teardown: () => void;
+  }): LiveCollection<ProductData> {
+    cleanup.push(mounted.teardown);
+    return mounted.view;
+  }
+
+  it('exposes live rows that reflect the collection as plain DTOs (no $-prefixed keys)', async () => {
+    const scripted = makeScriptedFetchers([
+      { id: 'p1', name: 'Widget', price: 9.99 },
+    ]);
+    const collection = createSmrtCollection(productDefinition('live-dto'), {
+      fetchers: scripted.fetchers,
+      staleTimeMs: 60_000,
+    });
+
+    const view = track(mountView(collection));
+    await collection.preload();
+    flushSync();
+
+    expect(view.isReady).toBe(true);
+    expect(view.status).toBe('ready');
+    expect(view.rows).toHaveLength(1);
+
+    const [row] = view.rows;
+    // Exact equality (not toMatchObject): must be a plain DTO — no
+    // $synced/$origin/$key/$collectionId leaking through the engine live view.
+    expect(row).toEqual({ id: 'p1', name: 'Widget', price: 9.99 });
+    expect(Object.keys(row).some((key) => key.startsWith('$'))).toBe(false);
+    expect(JSON.stringify(row)).not.toContain('$');
+  });
+
+  it('reports loading before the first read resolves', () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const collection = createSmrtCollection(productDefinition('live-loading'), {
+      fetchers: scripted.fetchers,
+      staleTimeMs: 60_000,
+      // Do not eagerly preload — observe the initial loading status.
+    });
+
+    const view = track(mountView(collection));
+    flushSync();
+
+    expect(view.isLoading).toBe(true);
+    expect(view.status).toBe('loading');
+    expect(view.error).toBeNull();
+  });
+
+  it('reflects an optimistic insert reactively and settles its pending state', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const collection = createSmrtCollection(productDefinition('live-insert'), {
+      fetchers: scripted.fetchers,
+      staleTimeMs: 60_000,
+    });
+
+    const view = track(mountView(collection));
+    await collection.preload();
+    flushSync();
+    expect(view.rows).toHaveLength(1);
+
+    const mutation = view.insert({
+      id: 'local-1',
+      name: 'Gadget',
+      price: 19.99,
+    });
+    flushSync();
+
+    // Optimistic row is visible in the live rows synchronously, and pending.
+    expect(view.rows.map((row) => row.name).sort()).toEqual([
+      'Gadget',
+      'Widget',
+    ]);
+    expect(mutation.pending).toBe(true);
+    expect(mutation.settled).toBe(false);
+
+    await mutation.done;
+    flushSync();
+
+    // Persisted: pending cleared, no error, and the server-assigned row is in.
+    expect(mutation.pending).toBe(false);
+    expect(mutation.settled).toBe(true);
+    expect(mutation.error).toBeNull();
+    const gadget = view.rows.find((row) => row.name === 'Gadget');
+    expect(gadget?.id).toBe('server-2');
+    // Still plain DTOs after the mutation reconciles.
+    expect(Object.keys(gadget ?? {}).some((key) => key.startsWith('$'))).toBe(
+      false,
+    );
+  });
+
+  it('rolls the optimistic row back and surfaces the error when the create fails', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const collection = createSmrtCollection(
+      productDefinition('live-rollback'),
+      {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+      },
+    );
+
+    const view = track(mountView(collection));
+    await collection.preload();
+    flushSync();
+
+    scripted.failCreateWith('Validation failed: name is reserved');
+    const mutation = view.insert({ id: 'local-2', name: 'FAIL Gadget' });
+    flushSync();
+    expect(view.rows.some((row) => row.name === 'FAIL Gadget')).toBe(true);
+
+    await expect(mutation.done).rejects.toThrow(
+      'Validation failed: name is reserved',
+    );
+    flushSync();
+
+    // Optimistic state rolled back reactively; the mutation carries the error.
+    expect(view.rows.some((row) => row.name === 'FAIL Gadget')).toBe(false);
+    expect(view.rows).toHaveLength(1);
+    expect(mutation.pending).toBe(false);
+    expect(mutation.settled).toBe(true);
+    expect(String((mutation.error as Error)?.message)).toContain(
+      'Validation failed: name is reserved',
+    );
+  });
+});

--- a/packages/smrt-svelte/src/web/__tests__/live-collection.svelte.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/live-collection.svelte.test.ts
@@ -219,9 +219,10 @@ describe('liveCollection', () => {
     flushSync();
     expect(view.rows.some((row) => row.name === 'FAIL Gadget')).toBe(true);
 
-    await expect(mutation.done).rejects.toThrow(
-      'Validation failed: name is reserved',
-    );
+    // `done` resolves (never rejects) on settle — the failure is surfaced only
+    // reactively via `error`, so a reactive-only consumer risks no unhandled
+    // rejection.
+    await expect(mutation.done).resolves.toBeUndefined();
     flushSync();
 
     // Optimistic state rolled back reactively; the mutation carries the error.

--- a/packages/smrt-svelte/src/web/index.ts
+++ b/packages/smrt-svelte/src/web/index.ts
@@ -1,0 +1,19 @@
+/**
+ * `@happyvertical/smrt-svelte/web` — Svelte 5 live-query bindings for the
+ * `@happyvertical/smrt-web` browser client data runtime (#1761, slice A).
+ *
+ * Consumers turn a `SmrtWebCollection<T>` into runes-reactive live-query state
+ * plus mutation helpers WITHOUT importing TanStack. The client-data engine
+ * stays an implementation detail of the runtime + this binding; nothing here
+ * re-exports an `@tanstack/*` type.
+ *
+ * @packageDocumentation
+ */
+
+export {
+  type LiveCollection,
+  type LiveCollectionMutation,
+  type LiveCollectionOptions,
+  type LiveCollectionStatus,
+  liveCollection,
+} from './live-collection.svelte.js';

--- a/packages/smrt-svelte/src/web/live-collection.svelte.ts
+++ b/packages/smrt-svelte/src/web/live-collection.svelte.ts
@@ -1,0 +1,292 @@
+/**
+ * Svelte 5 live-query bindings for `@happyvertical/smrt-web` (#1761, slice A).
+ *
+ * Turns a SMRT-owned {@link SmrtWebCollection} into runes-reactive live-query
+ * state plus mutation helpers, so a consumer writes reactive components WITHOUT
+ * importing TanStack. The client-data engine (`@tanstack/db` +
+ * `@tanstack/svelte-db`) is used only inside this module — its types never
+ * appear on the public surface, mirroring smrt-web's own engine-absorption
+ * boundary (ratified condition for #1761).
+ *
+ * Two engine facts drive the shape of this file:
+ *
+ * 1. `useLiveQuery` internally uses `$state`/`$derived`/`$effect`, so it (and
+ *    therefore {@link liveCollection}) MUST be called during Svelte component
+ *    initialization — exactly like this package's other `use*` composables.
+ *    Its internal `$effect` binds to the calling component's lifecycle, so the
+ *    live subscription is torn down automatically when the component unmounts.
+ *
+ * 2. `@tanstack/svelte-db` live-query rows carry ENUMERABLE engine virtual
+ *    props (`$key`/`$origin`/`$synced`/`$collectionId`) that would otherwise
+ *    escape through spread or JSON. Every exposed row is projected to a plain
+ *    DTO by stripping `$`-prefixed keys (the `$` prefix is reserved for the
+ *    engine; SMRT columns never begin with it), mirroring smrt-web's internal
+ *    `toPlainRow`.
+ */
+
+import {
+  getEngineCollection,
+  type SmrtWebCollection,
+  type SmrtWebRow,
+} from '@happyvertical/smrt-web';
+import type { Collection } from '@tanstack/db';
+import { useLiveQuery } from '@tanstack/svelte-db';
+
+// `getEngineCollection` is an `@internal` bridge in smrt-web: it exists at
+// runtime but API-Extractor strips its declaration from the published `.d.ts`
+// (like every `@internal` export in this monorepo). Re-declare its signature
+// here — matching the real source — so this trusted binding can consume the
+// runtime value type-safely without smrt-web having to widen its public
+// surface. It returns `unknown` on purpose (no engine type at the boundary).
+declare module '@happyvertical/smrt-web' {
+  export function getEngineCollection<TData extends object>(
+    handle: SmrtWebCollection<TData>,
+  ): unknown;
+}
+
+// ---------------------------------------------------------------------------
+// SMRT-owned public surface (no @tanstack/* type appears below this line in an
+// exported position — the engine stays swappable behind these interfaces).
+// ---------------------------------------------------------------------------
+
+/**
+ * Lifecycle status of a {@link LiveCollection}'s underlying read.
+ *
+ * - `loading` — the first load has not completed yet (also covers the engine's
+ *   pre-start `idle` and post-teardown `cleaned-up` phases).
+ * - `ready` — data has arrived and the collection is live.
+ * - `error` — the read failed during sync initialization.
+ */
+export type LiveCollectionStatus = 'loading' | 'ready' | 'error';
+
+/**
+ * A live, runes-reactive view over a {@link SmrtWebCollection}. Read `rows`,
+ * `status`, and `error` directly in markup — they update as the collection
+ * changes. Do NOT destructure this object (Svelte 5 reactivity is lost on
+ * destructure); read through the object, e.g. `view.rows`, or wrap in
+ * `$derived`.
+ */
+export interface LiveCollection<TData extends object> {
+  /** Live rows as plain DTOs (no `$`-prefixed engine props), insertion order. */
+  readonly rows: ReadonlyArray<SmrtWebRow<TData>>;
+  /** Coarse lifecycle status of the underlying read. */
+  readonly status: LiveCollectionStatus;
+  /**
+   * The most recent error surfaced by the underlying read, or `null`. Mutation
+   * errors are surfaced on the {@link LiveCollectionMutation} returned by the
+   * mutation helpers, not here.
+   */
+  readonly error: unknown;
+  /** True while the first load has not completed (`status === 'loading'`). */
+  readonly isLoading: boolean;
+  /** True once data has arrived (`status === 'ready'`). */
+  readonly isReady: boolean;
+  /** True when the underlying read failed (`status === 'error'`). */
+  readonly isError: boolean;
+  /**
+   * Optimistically insert a row and persist it through the collection's create
+   * surface. The row is visible in `rows` synchronously; the returned handle's
+   * reactive `pending`/`error` track the server outcome and a failed create
+   * rolls the optimistic row back automatically.
+   */
+  insert(row: SmrtWebRow<TData>): LiveCollectionMutation;
+}
+
+/**
+ * Reactive handle to one in-flight mutation. Read `pending`/`error`/`settled`
+ * in markup to drive optimistic UI; await {@link done} to observe completion
+ * imperatively. All fields are SMRT-owned — no engine transaction leaks.
+ */
+export interface LiveCollectionMutation {
+  /** True while the write is persisting; flips to false on success or failure. */
+  readonly pending: boolean;
+  /** True once the write has settled (persisted or rolled back). */
+  readonly settled: boolean;
+  /** The rollback error if the write failed, else `null`. */
+  readonly error: unknown;
+  /**
+   * Resolves when the write persists, rejects (after rollback) when it fails.
+   * Mirrors the underlying transaction's settle promise. Rejections are also
+   * reflected reactively on {@link error}; attach a catch (or read `error`) to
+   * avoid an unhandled rejection.
+   */
+  readonly done: Promise<void>;
+}
+
+/** Options for {@link liveCollection}. Reserved for forward-compatible growth. */
+export interface LiveCollectionOptions {
+  /**
+   * Trigger the collection's first load eagerly when the binding is created,
+   * rather than waiting for the engine's first read. Defaults to `true`.
+   */
+  preload?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Engine-internal helpers (types below never reach an exported position)
+// ---------------------------------------------------------------------------
+
+/** Row shape the engine collection carries (DTO plus a required key). */
+type EngineRow<TData extends object> = SmrtWebRow<TData>;
+
+/**
+ * Project an engine live-query row to a plain public DTO by dropping every
+ * `$`-prefixed key. Mirrors smrt-web's internal `toPlainRow`: the `$` prefix is
+ * reserved for the engine's enumerable virtual props (`$key`/`$origin`/
+ * `$synced`/`$collectionId`); SMRT columns never begin with it. Char code 36
+ * is `'$'`.
+ */
+function toPlainRow<TData extends object>(row: unknown): SmrtWebRow<TData> {
+  const plain: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(row as Record<string, unknown>)) {
+    if (key.charCodeAt(0) !== 36) plain[key] = value;
+  }
+  return plain as SmrtWebRow<TData>;
+}
+
+/** Map the engine's fine-grained status to the coarse SMRT-owned status. */
+function toLiveStatus(
+  isReady: boolean,
+  isError: boolean,
+): LiveCollectionStatus {
+  if (isError) return 'error';
+  if (isReady) return 'ready';
+  return 'loading';
+}
+
+/**
+ * Create a runes-reactive live view over a {@link SmrtWebCollection}.
+ *
+ * MUST be called during Svelte component initialization (it delegates to
+ * `@tanstack/svelte-db`'s `useLiveQuery`, which sets up a `$effect`). The live
+ * subscription is torn down automatically when the calling component unmounts.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { createSmrtCollection } from '@happyvertical/smrt-web';
+ *   import { liveCollection } from '@happyvertical/smrt-svelte/web';
+ *   import { productsDefinition } from '@happyvertical/smrt-virt-web';
+ *
+ *   const products = createSmrtCollection(productsDefinition, {});
+ *   const view = liveCollection(products);
+ *
+ *   async function add() {
+ *     const m = view.insert({ id: crypto.randomUUID(), name: 'New' });
+ *     await m.done.catch(() => {}); // error also reflected on m.error
+ *   }
+ * </script>
+ *
+ * {#if view.isLoading}
+ *   <p>Loading…</p>
+ * {:else if view.isError}
+ *   <p>Failed: {String(view.error)}</p>
+ * {:else}
+ *   <ul>
+ *     {#each view.rows as row (row.id)}
+ *       <li>{row.name}</li>
+ *     {/each}
+ *   </ul>
+ * {/if}
+ * ```
+ */
+export function liveCollection<TData extends object>(
+  handle: SmrtWebCollection<TData>,
+  options: LiveCollectionOptions = {},
+): LiveCollection<TData> {
+  const { preload = true } = options;
+
+  // Bridge to the engine collection (typed `unknown` at the boundary — cast to
+  // the engine `Collection` here, and confine that type to this module).
+  const engine = getEngineCollection(handle) as Collection<
+    EngineRow<TData>,
+    string | number,
+    Record<string, never>
+  >;
+
+  // Kick the first load without forcing consumers to await preload() — the
+  // live query subscribes lazily, so nudge it when requested.
+  if (preload) {
+    void handle.preload();
+  }
+
+  // The live query over the whole base collection. No `.select()` → `data`
+  // carries the full row objects (with engine virtual props, stripped below).
+  // `useLiveQuery` installs a `$effect`; calling `liveCollection` outside a
+  // component surfaces Svelte's own "effect outside component" error, which is
+  // the correct signal.
+  const query = useLiveQuery((q) => q.from({ row: engine }));
+
+  // Project rows to plain DTOs reactively. `query.data` is a $state-backed
+  // reactive array; `$derived.by` recomputes the projection when it changes.
+  const rows = $derived.by(() =>
+    query.data.map((row) => toPlainRow<TData>(row)),
+  );
+  const status = $derived(toLiveStatus(query.isReady, query.isError));
+  // useLiveQuery does not surface an error object, only an error status; expose
+  // the status string as the error payload when the read has failed.
+  const error = $derived<unknown>(query.isError ? query.status : null);
+
+  return {
+    get rows() {
+      return rows;
+    },
+    get status() {
+      return status;
+    },
+    get error() {
+      return error;
+    },
+    get isLoading() {
+      return status === 'loading';
+    },
+    get isReady() {
+      return status === 'ready';
+    },
+    get isError() {
+      return status === 'error';
+    },
+    insert(row) {
+      return createMutation(() => handle.insert(row).isPersisted.promise);
+    },
+  };
+}
+
+/**
+ * Wrap a transaction's settle promise in a reactive {@link LiveCollectionMutation}.
+ * Runs the mutation immediately; tracks pending/error via runes. Kept separate
+ * so `insert` (and future `update`/`delete` helpers) share one reactive shape.
+ */
+function createMutation(run: () => Promise<unknown>): LiveCollectionMutation {
+  let pending = $state(true);
+  let settled = $state(false);
+  let error = $state<unknown>(null);
+
+  const done = run().then(
+    () => {
+      pending = false;
+      settled = true;
+    },
+    (cause: unknown) => {
+      pending = false;
+      settled = true;
+      error = cause;
+      throw cause;
+    },
+  );
+
+  return {
+    get pending() {
+      return pending;
+    },
+    get settled() {
+      return settled;
+    },
+    get error() {
+      return error;
+    },
+    get done() {
+      return done;
+    },
+  };
+}

--- a/packages/smrt-svelte/src/web/live-collection.svelte.ts
+++ b/packages/smrt-svelte/src/web/live-collection.svelte.ts
@@ -32,18 +32,6 @@ import {
 import type { Collection } from '@tanstack/db';
 import { useLiveQuery } from '@tanstack/svelte-db';
 
-// `getEngineCollection` is an `@internal` bridge in smrt-web: it exists at
-// runtime but API-Extractor strips its declaration from the published `.d.ts`
-// (like every `@internal` export in this monorepo). Re-declare its signature
-// here — matching the real source — so this trusted binding can consume the
-// runtime value type-safely without smrt-web having to widen its public
-// surface. It returns `unknown` on purpose (no engine type at the boundary).
-declare module '@happyvertical/smrt-web' {
-  export function getEngineCollection<TData extends object>(
-    handle: SmrtWebCollection<TData>,
-  ): unknown;
-}
-
 // ---------------------------------------------------------------------------
 // SMRT-owned public surface (no @tanstack/* type appears below this line in an
 // exported position — the engine stays swappable behind these interfaces).
@@ -105,10 +93,9 @@ export interface LiveCollectionMutation {
   /** The rollback error if the write failed, else `null`. */
   readonly error: unknown;
   /**
-   * Resolves when the write persists, rejects (after rollback) when it fails.
-   * Mirrors the underlying transaction's settle promise. Rejections are also
-   * reflected reactively on {@link error}; attach a catch (or read `error`) to
-   * avoid an unhandled rejection.
+   * Resolves when the write settles (persisted or rolled back); read
+   * {@link error} (or {@link settled}) for the outcome. Never rejects, so
+   * reactive-only consumers never risk an unhandled rejection.
    */
   readonly done: Promise<void>;
 }
@@ -205,9 +192,13 @@ export function liveCollection<TData extends object>(
   >;
 
   // Kick the first load without forcing consumers to await preload() — the
-  // live query subscribes lazily, so nudge it when requested.
+  // live query subscribes lazily, so nudge it when requested. Swallow the
+  // rejection: a load failure (network error, or an SSR relative-URL
+  // `Failed to parse URL` TypeError) already surfaces reactively via the
+  // live-query status; this fire-and-forget must not become an unhandled
+  // rejection.
   if (preload) {
-    void handle.preload();
+    void handle.preload().catch(() => {});
   }
 
   // The live query over the whole base collection. No `.select()` → `data`
@@ -262,6 +253,10 @@ function createMutation(run: () => Promise<unknown>): LiveCollectionMutation {
   let settled = $state(false);
   let error = $state<unknown>(null);
 
+  // `done` RESOLVES on settle whether the write persisted or rolled back — the
+  // failure is surfaced only reactively via `error`. Re-throwing here would
+  // reject `done`, which a reactive-only consumer (reads `error`/`pending` in
+  // markup, never awaits `done`) would leave as an unhandled rejection.
   const done = run().then(
     () => {
       pending = false;
@@ -271,7 +266,6 @@ function createMutation(run: () => Promise<unknown>): LiveCollectionMutation {
       pending = false;
       settled = true;
       error = cause;
-      throw cause;
     },
   );
 

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -420,11 +420,12 @@ export interface CreateSmrtCollectionOptions {
 const engineCollections = new WeakMap<object, unknown>();
 
 /**
- * @internal Retrieve the underlying engine collection backing a handle. For
- * trusted framework bindings only (e.g. smrt-svelte live queries), which must
- * feed the engine collection to the query builder. Returns `unknown` so no
- * engine type crosses the public boundary — callers cast. Throws for a handle
- * not produced by {@link createSmrtCollection}.
+ * Retrieve the underlying engine collection backing a handle — an advanced
+ * bridge for trusted framework bindings (e.g. the smrt-svelte live-query
+ * binding), which must feed the engine collection to the query builder. Returns
+ * `unknown` so no engine type crosses the boundary; callers cast. Throws for a
+ * handle not produced by {@link createSmrtCollection}. Not needed for normal
+ * use.
  */
 export function getEngineCollection<TData extends object>(
   handle: SmrtWebCollection<TData>,

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -489,6 +489,14 @@ export function getWorkspaceViteAliases(
         '@happyvertical/smrt-svelte/i18n/server',
         join(packageRoot, 'src/i18n/server.ts'),
       );
+      // Svelte 5 live-query bindings for smrt-web (#1761). The generic
+      // `${packageName}/svelte` convention above does not cover `/web`, so the
+      // subpath needs its own alias or consumer TESTS resolve to stale dist.
+      addAliasIfPresent(
+        aliases,
+        '@happyvertical/smrt-svelte/web',
+        join(packageRoot, 'src/web/index.ts'),
+      );
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1986,6 +1986,9 @@ importers:
       '@happyvertical/smrt-ui':
         specifier: workspace:*
         version: link:../smrt-ui
+      '@happyvertical/smrt-web':
+        specifier: workspace:*
+        version: link:../smrt-web
       '@huggingface/transformers':
         specifier: '>=3.8.1'
         version: 3.8.1
@@ -1995,6 +1998,12 @@ importers:
       '@remotion/whisper-web':
         specifier: '>=4.0.484'
         version: 4.0.484
+      '@tanstack/db':
+        specifier: ^0.6.14
+        version: 0.6.14(typescript@5.9.3)
+      '@tanstack/svelte-db':
+        specifier: ^0.1.91
+        version: 0.1.91(svelte@5.56.4)(typescript@5.9.3)
       '@xenova/transformers':
         specifier: ^2.17.2
         version: 2.17.2
@@ -5606,6 +5615,11 @@ packages:
     peerDependencies:
       '@tanstack/query-core': ^5.0.0
       typescript: '>=4.7'
+
+  '@tanstack/svelte-db@0.1.91':
+    resolution: {integrity: sha512-DcpkOKC7R5XuqgWeFcyXZG/W0MGwNZq3pZrGxVY2k8VsdqyVOHGDUel2Zwb08dafIF1WEe2GXLHtwYbyU5GBHQ==}
+    peerDependencies:
+      svelte: 5.56.4
 
   '@techstark/opencv-js@4.9.0-release.3':
     resolution: {integrity: sha512-y+KoLLlkXVUHWozYlN1vmMD9TQMPJObqml5nPA5vPWgHtOgm8q5O74UtzM23eayidvmeFX6tF5e2gDdyxcpy3Q==}
@@ -13153,6 +13167,13 @@ snapshots:
       '@tanstack/db': 0.6.14(typescript@5.9.3)
       '@tanstack/query-core': 5.101.2
       typescript: 5.9.3
+
+  '@tanstack/svelte-db@0.1.91(svelte@5.56.4)(typescript@5.9.3)':
+    dependencies:
+      '@tanstack/db': 0.6.14(typescript@5.9.3)
+      svelte: 5.56.4
+    transitivePeerDependencies:
+      - typescript
 
   '@techstark/opencv-js@4.9.0-release.3': {}
 


### PR DESCRIPTION
## What this builds

Slice A of #1761 (smrt-web track): **Svelte 5 live-query bindings** for the merged `@happyvertical/smrt-web` browser client data runtime.

A new subpath `@happyvertical/smrt-svelte/web` turns a `SmrtWebCollection<T>` into runes-reactive live-query state plus mutation helpers, so consumers write reactive components **without importing TanStack**.

### Public API (SMRT-owned)

```ts
import { liveCollection } from '@happyvertical/smrt-svelte/web';

const view = liveCollection(handle /* SmrtWebCollection<T> */, options?);
// view.rows      -> readonly plain-DTO T[] (live/reactive)
// view.status    -> 'loading' | 'ready' | 'error'
// view.error     -> unknown
// view.isLoading / view.isReady / view.isError -> booleans
// view.insert(row) -> LiveCollectionMutation { pending, settled, error, done }
```

- `liveCollection(handle, options?)` — MUST be called during Svelte component init (it delegates to `useLiveQuery`, which installs a `$effect`; the subscription tears down with the component). Exported interfaces: `LiveCollection<T>`, `LiveCollectionMutation`, `LiveCollectionOptions`, `LiveCollectionStatus`.
- `insert(row)` awaits the SMRT transaction's `isPersisted.promise` and surfaces rollback errors reactively (`pending` -> `settled`, `error`).

Live reactivity is driven by `@tanstack/svelte-db`'s `useLiveQuery`, fed the bridged engine collection via smrt-web's `@internal` `getEngineCollection` (cast from `unknown` internally). All `useLiveQuery`/`Collection` usage stays inside the module.

## Hard conditions (ratified for #1761)

- **No engine types in the public API.** The compiled `.d.ts` carries **zero real `@tanstack/*` type references** — the only mentions are backticked prose in JSDoc (the same false-positive smrt-web's own boundary guard ignores by matching quoted module specifiers). No `@tanstack/*` type is re-exported; every public type is defined in this package.
- **Plain-DTO rows.** Every exposed row is projected through a `$`-stripper (mirror of smrt-web's internal `toPlainRow`), dropping enumerable engine virtual props (`$key`/`$origin`/`$synced`/`$collectionId`). A test asserts `Object.keys(row)` has no `$` via exact equality and `JSON.stringify(row)` contains no `$`.
- **This is the Svelte layer** — it depends on `@tanstack/svelte-db` + `@tanstack/db` (smrt-web core does not).

## Wiring / registration

- `packages/smrt-svelte/package.json`: real `dependency` on `@happyvertical/smrt-web` (workspace:*), `@tanstack/db@^0.6.14` (matches smrt-web's pinned major/minor so a single copy resolves — `query-db-collection` pins `@tanstack/db` exactly), `@tanstack/svelte-db@^0.1.91`. Not peerDependencies (DAG guardrail). smrt-svelte -> smrt-web is acyclic (smrt-web has no smrt deps).
- `./web` export added, mirroring `./browser-ai/svelte` (types + svelte/import -> dist).
- `@happyvertical/smrt-svelte/web` alias added to `getWorkspaceViteAliases` in `packages/vitest/src/index.ts` (the generic `/svelte` convention doesn't cover `/web`; without it consumer tests would resolve to stale dist).

### `@internal` bridge note

`getEngineCollection` is `@internal` in smrt-web, so API-Extractor strips its declaration from the published `.d.ts` (as with every `@internal` export in the monorepo). A local `declare module '@happyvertical/smrt-web'` re-declares its signature (returning `unknown`) so this trusted binding consumes the runtime value type-safely — without widening smrt-web's public surface or touching its boundary guard.

## Verification

| Check | Result |
|---|---|
| `pnpm --filter @happyvertical/smrt-svelte build` | pass |
| `pnpm --filter @happyvertical/smrt-svelte typecheck` (tsc + svelte-check) | pass — 0 errors, 0 warnings (1368 files) |
| `biome check` (changed files) | pass |
| `node scripts/check-no-smrt-peers.mjs` | pass |
| `node scripts/check-package-dag.mjs` | pass (54 pkgs, DAG) |
| `dev:knowledge-check --format markdown` | pass (fresh, 0/0) |
| no real `@tanstack/*` type in public `.d.ts` | verified |
| `pnpm --filter @happyvertical/smrt-svelte test` | blocked — see below |

### Test-runner blocker (environmental, not this change)

The package vitest runner could **not** be exercised in the isolated git worktree due to a **pre-existing, worktree-only Vite 8 oxc-transform defect**. Proven independent of this change:
- With **all changes stashed** (clean baseline), the pre-existing `app-state.test.ts` fails identically.
- A **zero-plugin** vitest run of `expect(2+2).toBe(4)` fails identically (`transformWithOxc` / `Tsconfig not found` on the rolldown runtime chunk).
- Fails under both node 24.12 and 24.18; with and without the smrt plugin.
- Does **not** reproduce in a normal (non-worktree) checkout.

The tests are type-valid (compiled under svelte-check with 0 errors) and follow this package's established `mount()`-harness pattern, mocking only the network boundary (`createSmrtCollection` fetchers) while keeping the engine + live query + reactivity real. **CI runs them in a clean checkout.**

Closes part of #1761 (slice A).
