### PR TITLE
feat(smrt-web,smrt-svelte): SvelteKit hydration seeding (#1761)

### DIFF
--- a/packages/smrt-svelte/src/web/live-collection.svelte.ts
+++ b/packages/smrt-svelte/src/web/live-collection.svelte.ts
@@ -153,9 +153,9 @@ function toLiveStatus(
  * <script lang="ts">
  *   import { createSmrtCollection } from '@happyvertical/smrt-web';
  *   import { liveCollection } from '@happyvertical/smrt-svelte/web';
- *   import { productsDefinition } from '@happyvertical/smrt-virt-web';
+ *   import { getCollectionDefinition } from '@happyvertical/smrt-virt-web';
  *
- *   const products = createSmrtCollection(productsDefinition, {});
+ *   const products = createSmrtCollection(getCollectionDefinition('products'), {});
  *   const view = liveCollection(products);
  *
  *   async function add() {
@@ -175,6 +175,46 @@ function toLiveStatus(
  *     {/each}
  *   </ul>
  * {/if}
+ * ```
+ *
+ * @example
+ * SvelteKit hydration seeding (#1761): fetch rows in a server load and pass
+ * them as `initialData` so the first client render serves them with NO
+ * duplicate fetch. The live view starts populated at `ready`.
+ * ```ts
+ * // +page.server.ts — read the collection server-side, return plain rows.
+ * import { getCollection } from '$lib/server/smrt';
+ * import type { PageServerLoad } from './$types';
+ *
+ * export const load: PageServerLoad = async () => {
+ *   const products = await getCollection('Product');
+ *   const rows = await products.list({ limit: 50 });
+ *   return { products: rows.map((p) => ({ id: p.id, name: p.name })) };
+ * };
+ * ```
+ * ```svelte
+ * <!-- +page.svelte — seed the client collection from the hydrated load data. -->
+ * <script lang="ts">
+ *   import { createSmrtCollection } from '@happyvertical/smrt-web';
+ *   import { liveCollection } from '@happyvertical/smrt-svelte/web';
+ *   import { getCollectionDefinition } from '@happyvertical/smrt-virt-web';
+ *   import type { PageProps } from './$types';
+ *
+ *   let { data }: PageProps = $props();
+ *
+ *   // initialData seeds the cache: the first read is served from data.products
+ *   // (no network request) and revalidates only after staleTimeMs.
+ *   const products = createSmrtCollection(getCollectionDefinition('products'), {
+ *     initialData: data.products,
+ *   });
+ *   const view = liveCollection(products);
+ * </script>
+ *
+ * <ul>
+ *   {#each view.rows as row (row.id)}
+ *     <li>{row.name}</li>
+ *   {/each}
+ * </ul>
  * ```
  */
 export function liveCollection<TData extends object>(

--- a/packages/smrt-web/AGENTS.md
+++ b/packages/smrt-web/AGENTS.md
@@ -14,7 +14,11 @@ mutations without hand-wiring cache keys or fetch/state.
   generated `@happyvertical/smrt-virt-web` definition. Stale-while-revalidate
   reads (`staleTimeMs`, default 30s); N concurrent identical reads coalesce into
   one request; optimistic inserts persist through the REST surface and roll back
-  automatically on server error.
+  automatically on server error. Pass `initialData` (SMRT-owned
+  `SmrtWebRow<T>[]`) to seed the cache from server-rendered rows so the first
+  client read serves them WITHOUT a duplicate first-render fetch — the SvelteKit
+  `+page.server.ts` → hydrate path (#1761). The seed is fresh for `staleTimeMs`;
+  fold the same `scope` used for reads into it under a shared `client`.
 - `createSmrtWebClient()` — an opaque shared-cache handle. Pass one app-wide
   instance so collections share a cache and deduplicate requests.
 - `createDefinitionFetchers(definition, basePath, fetchFn)` — CRUD fetchers

--- a/packages/smrt-web/src/collection.test.ts
+++ b/packages/smrt-web/src/collection.test.ts
@@ -315,6 +315,143 @@ describe('createSmrtCollection', () => {
   });
 });
 
+describe('hydration seeding (#1761)', () => {
+  it('serves server-seeded rows on the first read with no first-render fetch', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'from-server' }]);
+    // Rows a SvelteKit +page.server.ts load fetched and serialized into the
+    // page; the client hands them to the collection as initialData.
+    const ssrRows = [
+      { id: 'p1', name: 'from-ssr', price: 9.99 },
+      { id: 'p2', name: 'also-ssr', price: 4.5 },
+    ];
+    const collection = createSmrtCollection(
+      productDefinition('products-seed'),
+      {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        initialData: ssrRows,
+      },
+    );
+
+    // The engine collection is lazy: it populates its local store from the
+    // seeded cache on first read (preload), NOT before. What the seed
+    // guarantees is that this first read is served from the seed WITHOUT a
+    // network request — the "no duplicate first-render fetch" acceptance
+    // criterion. (The smrt-svelte `liveCollection` binding preloads on init, so
+    // this completes before the first component render.)
+    await collection.preload();
+    expect(scripted.calls.list).toBe(0);
+
+    // The rows served are exactly the SSR rows (not the divergent server rows
+    // the fetcher would return), so the pre- and post-hydration renders match.
+    expect(collection.toArray).toMatchObject(ssrRows);
+    expect(collection.toArray.map((row) => row.name).sort()).toEqual([
+      'also-ssr',
+      'from-ssr',
+    ]);
+
+    await collection.cleanup();
+  });
+
+  it('revalidates once the seed is stale, replacing it with server rows', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'from-server' }]);
+    // staleTimeMs 0: the seed is served on the first read but is stale at once,
+    // so the collection revalidates against the fetcher. This is the SWR half of
+    // hydration seeding — hydrate instantly, then reconcile with fresh rows.
+    const collection = createSmrtCollection(
+      productDefinition('products-seed-stale'),
+      {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 0,
+        initialData: [{ id: 'p1', name: 'from-ssr' }],
+      },
+    );
+
+    // preload() resolves once the read has DATA — that is the seed, served with
+    // one background revalidation already dispatched (list called once), not yet
+    // reconciled into the local store.
+    await collection.preload();
+    expect(collection.get('p1')?.name).toBe('from-ssr');
+    expect(scripted.calls.list).toBe(1);
+
+    // Await the background revalidation landing (change-driven, no arbitrary
+    // sleep): the freshly fetched server row supersedes the stale seed.
+    if (collection.get('p1')?.name !== 'from-server') {
+      await new Promise<void>((resolve) => {
+        const sub = collection.subscribeChanges(() => {
+          if (collection.get('p1')?.name === 'from-server') {
+            sub.unsubscribe();
+            resolve();
+          }
+        });
+      });
+    }
+    expect(collection.get('p1')?.name).toBe('from-server');
+    // Still just the one revalidation — no extra fetch was triggered.
+    expect(scripted.calls.list).toBe(1);
+
+    await collection.cleanup();
+  });
+
+  it('honors an explicit empty seed as a valid fresh state that suppresses the first fetch', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'from-server' }]);
+    // The server load returned zero rows: an empty seed is still a fresh cache
+    // entry, so the first read serves it (empty) without a network request.
+    const collection = createSmrtCollection(
+      productDefinition('products-seed-empty'),
+      {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        initialData: [],
+      },
+    );
+
+    await collection.preload();
+    expect(collection.size).toBe(0);
+    expect(scripted.calls.list).toBe(0);
+
+    await collection.cleanup();
+  });
+
+  it('does not clobber an already-populated shared cache with a later stale seed', async () => {
+    const client = createSmrtWebClient();
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'from-server' }]);
+
+    // First materialization seeds fresh SSR rows into the shared cache.
+    const first = createSmrtCollection(
+      productDefinition('products-seed-shared'),
+      {
+        fetchers: scripted.fetchers,
+        client,
+        staleTimeMs: 60_000,
+        initialData: [{ id: 'p1', name: 'seeded-first' }],
+      },
+    );
+    await first.preload();
+    expect(first.get('p1')?.name).toBe('seeded-first');
+    expect(scripted.calls.list).toBe(0);
+
+    // A second materialization over the SAME client with a DIFFERENT seed must
+    // not overwrite the already-cached rows (which may be newer than this late
+    // SSR payload). The existing cache entry wins; still no fetch.
+    const second = createSmrtCollection(
+      productDefinition('products-seed-shared'),
+      {
+        fetchers: scripted.fetchers,
+        client,
+        staleTimeMs: 60_000,
+        initialData: [{ id: 'p1', name: 'seeded-second' }],
+      },
+    );
+    await second.preload();
+    expect(second.get('p1')?.name).toBe('seeded-first');
+    expect(scripted.calls.list).toBe(0);
+
+    await first.cleanup();
+    await second.cleanup();
+  });
+});
+
 describe('getEngineCollection (internal binding bridge)', () => {
   it('returns the engine collection for a real handle and rejects foreign handles', async () => {
     const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -27,9 +27,13 @@
  *   cache keys. Cross-collection reach requires a shared client from
  *   {@link createSmrtWebClient}; with a private client only the mutated
  *   collection refetches.
+ * - hydration seeding (#1761): rows fetched server-side (a SvelteKit
+ *   `+page.server.ts` load) seed the shared cache via
+ *   {@link CreateSmrtCollectionOptions.initialData}, so the first client read
+ *   serves them WITHOUT a duplicate first-render fetch.
  *
- * Deliberately NOT here yet (see PRD #1755): SvelteKit hydration seeding,
- * offline outbox, SSE invalidation, persistence, version awareness.
+ * Deliberately NOT here yet (see PRD #1755): offline outbox, SSE invalidation,
+ * persistence, version awareness.
  */
 
 import { createCollection } from '@tanstack/db';
@@ -414,7 +418,13 @@ export interface SmrtWebCollection<TData extends object> {
   insert(row: SmrtWebRow<TData>): SmrtWebTransaction;
 }
 
-export interface CreateSmrtCollectionOptions {
+/**
+ * Options for {@link createSmrtCollection}. Generic in the collection's row
+ * type `TData` so {@link initialData} is checked against the same DTO the
+ * collection stores; every other option is row-type-agnostic, so the parameter
+ * defaults to `object` and can be omitted at call sites that pass no seed.
+ */
+export interface CreateSmrtCollectionOptions<TData extends object = object> {
   /**
    * Generated REST client surface for this collection, e.g.
    * `createClient('/api/v1').products` from the virt-client module. When
@@ -449,6 +459,25 @@ export interface CreateSmrtCollectionOptions {
   staleTimeMs?: number;
   /** Retry failed loads (default false: fail fast, surface errors). */
   retry?: boolean;
+  /**
+   * Rows to seed this collection's cache with, before its first read — the
+   * hydration path for server-rendered data (#1761). Fetch rows in a SvelteKit
+   * `+page.server.ts` load, pass them here on the client, and the first read
+   * serves them from cache WITHOUT a duplicate first-render network request
+   * (SMRT-owned type, so no engine type appears on the option).
+   *
+   * The seed is written to the cache with a fresh timestamp, so it counts as
+   * fresh for `staleTimeMs`: with the default window the first read does not
+   * fetch, and the collection revalidates in the background only once the window
+   * elapses (or immediately if `staleTimeMs` is 0). Seed the SAME rows the
+   * server serialized so the pre- and post-hydration renders match.
+   *
+   * Seeds the SAME cache key the reads use — so with a shared {@link client},
+   * fold the backend / tenant discriminator into {@link scope} to match, exactly
+   * as reads do; otherwise one backend's seed would serve the other for the
+   * `staleTimeMs` window.
+   */
+  initialData?: SmrtWebRow<TData>[];
 }
 
 /**
@@ -497,14 +526,19 @@ export function getEngineCollection<TData extends object>(
  * dependent views refetch. Reaching OTHER collections requires them to share
  * this collection's `client` (see {@link createSmrtWebClient}); with a private
  * client only this collection refetches.
+ *
+ * Hydration seeding: pass rows fetched server-side as
+ * {@link CreateSmrtCollectionOptions.initialData} and the collection's first
+ * read is served from them with NO network request (until `staleTimeMs`
+ * elapses) — the SvelteKit `+page.server.ts` → hydrate path.
  */
 export function createSmrtCollection<TData extends object>(
   definition: SmrtWebCollectionDefinition<TData>,
-  options: CreateSmrtCollectionOptions,
+  options: CreateSmrtCollectionOptions<TData>,
 ): SmrtWebCollection<TData> {
   type Row = SmrtWebRow<TData>;
 
-  const { staleTimeMs = 30_000, retry = false, scope } = options;
+  const { staleTimeMs = 30_000, retry = false, scope, initialData } = options;
   const fetchers =
     options.fetchers ??
     createDefinitionFetchers(definition, options.basePath, options.fetchFn);
@@ -519,6 +553,23 @@ export function createSmrtCollection<TData extends object>(
   const queryKey = scope
     ? ['smrt', scope, definition.name]
     : ['smrt', definition.name];
+
+  // Hydration seeding (#1761): if the caller passed rows fetched server-side,
+  // write them into the query cache BEFORE the collection's engine starts its
+  // sync. On the first read the engine finds cached data and populates from it
+  // instead of fetching (verified: zero list() calls). `setQueryData` stamps a
+  // fresh `dataUpdatedAt`, so the seed counts as fresh for `staleTime` — the
+  // first read serves it with no request, and revalidation fires only once
+  // `staleTimeMs` elapses (or immediately when it is 0). An explicit empty seed
+  // is honored too: it means "the server returned zero rows", a valid fresh
+  // state that likewise suppresses the first fetch. Only seed a key with no
+  // cached data yet, so re-materializing a collection over an already-populated
+  // shared cache never clobbers newer rows with stale SSR data.
+  if (initialData !== undefined) {
+    if (queryClient.getQueryData(queryKey) === undefined) {
+      queryClient.setQueryData(queryKey, initialData);
+    }
+  }
 
   // Relationship-derived invalidation target set (#1761): the collections
   // whose caches a settled mutation on THIS collection must invalidate. Always

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -562,13 +562,19 @@ export function createSmrtCollection<TData extends object>(
   // first read serves it with no request, and revalidation fires only once
   // `staleTimeMs` elapses (or immediately when it is 0). An explicit empty seed
   // is honored too: it means "the server returned zero rows", a valid fresh
-  // state that likewise suppresses the first fetch. Only seed a key with no
-  // cached data yet, so re-materializing a collection over an already-populated
-  // shared cache never clobbers newer rows with stale SSR data.
+  // state that likewise suppresses the first fetch.
+  //
+  // Seed only when the key is empty, via the ATOMIC updater form: a plain
+  // get-then-set would let two collections sharing this key and materialized in
+  // the same tick both observe `undefined` and have the later seed clobber the
+  // earlier one. `(existing) => existing ?? initialData` keeps the first seed
+  // (or any already-cached rows, which may be newer than this late SSR payload)
+  // in a single cache write.
   if (initialData !== undefined) {
-    if (queryClient.getQueryData(queryKey) === undefined) {
-      queryClient.setQueryData(queryKey, initialData);
-    }
+    queryClient.setQueryData<Row[]>(
+      queryKey,
+      (existing) => existing ?? initialData,
+    );
   }
 
   // Relationship-derived invalidation target set (#1761): the collections

--- a/packages/template-sveltekit/template/README.md
+++ b/packages/template-sveltekit/template/README.md
@@ -205,8 +205,12 @@ export const load: PageServerLoad = async () => {
 
   // initialData seeds the cache from the SSR rows: the first read is served
   // from data.items with NO network request, and revalidates after staleTimeMs.
+  // basePath MUST match this app's generated routes — they are served at
+  // `/api/*` (routesDir: 'src/routes/api'), not the runtime's `/api/v1` default,
+  // so revalidation and live mutations hit `/api/items` instead of 404ing.
   const items = createSmrtCollection(getCollectionDefinition('items'), {
     initialData: data.items,
+    basePath: '/api',
   });
   const view = liveCollection(items);
 </script>

--- a/packages/template-sveltekit/template/README.md
+++ b/packages/template-sveltekit/template/README.md
@@ -165,6 +165,63 @@ published content, navigation. Do **not** cache:
 Pass `cache: false` on a specific call to bypass a model-level cache where
 freshness matters.
 
+### Client live collections (opt-in)
+
+The server-load pattern above renders a page and refreshes it with
+`invalidate()`. For **interactive surfaces** that mutate rows and want an
+optimistic, reactive local store (an editor, a live dashboard), layer the
+browser client-data runtime on top: `@happyvertical/smrt-web` (the engine
+wrapper) + `@happyvertical/smrt-svelte/web` (the Svelte 5 runes binding). It is
+**opt-in per surface** — the client engine (~76 kB gzip) should never load on
+public or content pages, so import it only in routes that use live collections.
+
+Keep loading the initial rows in a server `load` (SSR + no waterfall), then
+**seed** the client collection from the hydrated `PageData` with `initialData`,
+so the first client render serves the SSR rows with no duplicate fetch and only
+revalidates once they go stale:
+
+```typescript
+// src/routes/live/+page.server.ts — same server-load pattern, plain rows out.
+import { getCollection } from '$lib/server/smrt';
+import type { Item } from '$lib/objects/Item';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+  const items = await getCollection<Item>('Item');
+  const rows = await items.list({ orderBy: 'created_at DESC', limit: 50 });
+  return { items: rows.map((i) => ({ id: i.id, title: i.title, status: i.status })) };
+};
+```
+
+```svelte
+<!-- src/routes/live/+page.svelte -->
+<script lang="ts">
+  import { createSmrtCollection } from '@happyvertical/smrt-web';
+  import { liveCollection } from '@happyvertical/smrt-svelte/web';
+  import { getCollectionDefinition } from '@happyvertical/smrt-virt-web';
+  import type { PageProps } from './$types';
+
+  let { data }: PageProps = $props();
+
+  // initialData seeds the cache from the SSR rows: the first read is served
+  // from data.items with NO network request, and revalidates after staleTimeMs.
+  const items = createSmrtCollection(getCollectionDefinition('items'), {
+    initialData: data.items,
+  });
+  const view = liveCollection(items);
+</script>
+
+{#each view.rows as item (item.id)}
+  <p>{item.title}</p>
+{/each}
+```
+
+`getCollectionDefinition('items')` comes from the plugin-generated
+`@happyvertical/smrt-virt-web` virtual module (its `<collection>` key is the
+same REST route segment as `depends`/`invalidate`). Add
+`@happyvertical/smrt-web` and `@happyvertical/smrt-svelte` to the project's
+dependencies before using this pattern.
+
 ## Multi-tenancy
 
 This template ships with multi-tenancy pre-wired. Out of the box you get:


### PR DESCRIPTION
## Slice C of #1761 — SvelteKit hydration seeding

Seeds a `@happyvertical/smrt-web` collection's cache from server-rendered rows so the first client render serves them **without a duplicate first-render fetch** — the SvelteKit `+page.server.ts` → hydrate path.

**AC met:** *"A page using server load renders with no duplicate first-render fetch."*

### What changed

**smrt-web (`packages/smrt-web/src/index.ts`)**
- New option `initialData?: SmrtWebRow<TData>[]` on `CreateSmrtCollectionOptions` (now generic in `TData`, defaulting to `object` so existing call sites are untouched). It is a **SMRT-owned type** — no `@tanstack` type reaches the public API, so the engine-absorption boundary guard stays green.
- Seed mechanism: inside `createSmrtCollection`, after `queryKey` is computed and before the engine's collection is created, `queryClient.setQueryData(queryKey, initialData)`. The engine finds cached data on its first sync and populates from it **instead of fetching**. `setQueryData` stamps a fresh `dataUpdatedAt`, so the seed counts as fresh for `staleTimeMs`.
- Edge handling: an explicit **empty** seed (`[]`) is honored (server returned zero rows → still a fresh state that suppresses the first fetch); a query key that already holds cached data is **never clobbered** (idempotent when re-materializing over a shared client).

**smrt-svelte (`packages/smrt-svelte/src/web/live-collection.svelte.ts`)** — docs only
- Fixed the `liveCollection` JSDoc import to the **real generated shape**: `getCollectionDefinition('products')` from `@happyvertical/smrt-virt-web` (the module exports `collectionDefinitions` + `getCollectionDefinition`, not a `productsDefinition` named export).
- Added a SvelteKit hydration-seeding `@example` (`+page.server.ts` rows → `initialData` → `liveCollection`).

**Docs**
- `packages/smrt-web/AGENTS.md`: document `initialData` on the `createSmrtCollection` bullet.
- `packages/template-sveltekit/template/README.md`: new opt-in **"Client live collections"** section showing the end-to-end seed-from-`PageData` recipe. Kept opt-in per surface (the ~76 kB engine must stay off public/content pages — boundary condition #3), so the base scaffold's server-load pattern is unchanged and no client-engine dep is forced into every scaffolded app.

### Seed mechanism verification (0 first-render fetches)

Verified empirically against the real engine (`@tanstack/db` + `query-db-collection`) before writing the option, and locked by tests:
- seeded + fresh `staleTimeMs` → **`list()` called 0 times** on first read; rows are the SSR rows.
- seeded + `staleTimeMs: 0` → served from the seed, then revalidates **once** (`list()` called 1×) and the server row supersedes it.
- no seed → fetches (baseline sanity).

The engine's collection is lazy: it populates its local store from the seeded cache on the **first read** (`preload()`), not before — so the guarantee is "first read served with no network request", which is exactly what `liveCollection` triggers on component init.

### New tests (`packages/smrt-web/src/collection.test.ts`, mock only the fetcher boundary)
- serves server-seeded rows on the first read with `calls.list === 0`
- revalidates once the seed is stale, replacing it with server rows (change-driven wait, no arbitrary sleep)
- honors an explicit empty seed as a fresh state that suppresses the first fetch
- does not clobber an already-populated shared cache with a later stale seed

### Verification

| Check | Result |
|---|---|
| `pnpm --filter @happyvertical/smrt-web build` (boundary guard) | ✅ `[smrt-web boundary] OK — 1 declaration file(s) engine-agnostic` |
| `pnpm --filter @happyvertical/smrt-web typecheck` | ✅ exit 0 |
| `pnpm --filter @happyvertical/smrt-web test` | ✅ 24/24 |
| `pnpm --filter @happyvertical/smrt-svelte build` | ✅ |
| `pnpm --filter @happyvertical/smrt-svelte typecheck` (svelte-check) | ✅ 0 errors / 0 warnings |
| `npx biome check` (changed files) | ✅ no fixes |
| `node scripts/check-no-smrt-peers.mjs` | ✅ |
| `node scripts/check-package-dag.mjs` | ✅ DAG, no cycles |
| `node packages/cli/dist/index.js dev:knowledge-check` | ✅ fresh, 0 errors/warnings |
| template-sveltekit tests | ✅ 31/31 |

**Local blocker (not this change):** `pnpm --filter @happyvertical/smrt-svelte test` fails at Vitest startup in this environment with a **rolldown 1.1.3 dep-optimizer bug** (`Could not resolve 'node:module' in \0rolldown/runtime.js … Tsconfig not found`). Reproduced identically on the untouched slice-A worktree, so it is environmental, not caused by this change (my smrt-svelte edit is JSDoc-only). CI runs these tests on Linux, where slice A's identical `web/` tests passed.

Refs #1761.
