### PR TITLE
feat(smrt-svelte): AdminShell live activity feed adapter (#1779)

### DIFF
--- a/packages/smrt-svelte/AGENTS.md
+++ b/packages/smrt-svelte/AGENTS.md
@@ -263,6 +263,23 @@ compatibility.
 
 See `src/components/workspace/MIGRATION.md` for the old-to-new concept map.
 
+### Live activity feed adapter (`./web`, #1779)
+
+`activityFeed({ collection, map, shell })` (from `@happyvertical/smrt-svelte/web`)
+bridges a `@happyvertical/smrt-web` live collection into a `ShellState` activity
+registry: it subscribes the collection through `liveCollection`, reactively maps
+each row → `ShellActivity` via the app-supplied editorial `map`, and drives
+`upsertActivity` / `updateActivity` / `removeActivity` as rows appear, change,
+and vanish (a row mapping to `null` is excluded / retracted). Returns a disposer
+that removes exactly the activities it created. Must be called during component
+init (installs a `$effect`); the subscription tears down on unmount.
+
+It lives behind the opt-in `./web` entry — which pulls the TanStack client-data
+engine — and is **never** imported under `components/workspace/`, so the
+AdminShell core (`./workspace`) stays transport-agnostic and TanStack-free (epic
+#1766). The pure diff core is `ActivityFeedReconciler` (engine-free, unit-tested
+against a real `ShellState`). Demo: `playground/.../admin-shell-activity-feed`.
+
 ### Dock availability gates (server-side)
 
 `ToolDef.gates?: string[]` declares the gates a tool must pass to be visible.

--- a/packages/smrt-svelte/playground/src/routes/admin-shell-activity-feed/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/admin-shell-activity-feed/+page.svelte
@@ -35,7 +35,6 @@ import {
   createSmrtCollection,
   getEngineCollection,
 } from '@happyvertical/smrt-web';
-import { onDestroy } from 'svelte';
 import { M } from '../../../../src/i18n/strings.workspace.js';
 
 const { t } = useI18n();
@@ -97,7 +96,10 @@ const shell = createShellState({
 
 // Bridge the live collection into the shell. One editorial map turns each job
 // row into a Focus-scope activity; the adapter drives upsert/update/remove.
-const handle = activityFeed<JobRow>({
+// The feed auto-retracts its activities when this page unmounts, so no manual
+// `onDestroy(handle.dispose)` is needed (the returned handle's `dispose()` is
+// only for retracting sooner, without unmounting).
+activityFeed<JobRow>({
   collection,
   shell,
   map: (row) => ({
@@ -108,8 +110,6 @@ const handle = activityFeed<JobRow>({
     progress: row.progress,
   }),
 });
-
-onDestroy(() => handle.dispose());
 
 let nextId = $state(1);
 // Mirror of the rows the demo has pushed, shown in the "backing rows" panel.

--- a/packages/smrt-svelte/playground/src/routes/admin-shell-activity-feed/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/admin-shell-activity-feed/+page.svelte
@@ -1,0 +1,310 @@
+<script lang="ts">
+/**
+ * Playground demo for the AdminShell activity feed adapter (#1779).
+ *
+ * Shows `activityFeed` (from `@happyvertical/smrt-svelte/web`) bridging a
+ * `@happyvertical/smrt-web` live collection into the shell's activity registry:
+ * as rows appear / change / vanish in the collection, activities start, advance,
+ * complete, and disappear in the shell — surfacing in the Focus panel and the
+ * activity toasts, with NO shell-specific code beyond the editorial `map`.
+ *
+ * The backing collection is a real `createSmrtCollection` over an in-memory job
+ * definition. To animate the lifecycle from the page, the demo simulates a
+ * BACKEND FEED using the engine collection's manual sync-write API
+ * (`writeInsert` / `writeUpdate` / `writeDelete`) — which injects rows into the
+ * synced store exactly as a real SSE/WebSocket feed would, without any
+ * optimistic-mutation round trip. The adapter reconciles those rows into shell
+ * activities the same way regardless of what drives the collection.
+ */
+
+import { activityFeed } from '@happyvertical/smrt-svelte/web';
+import {
+  ActivityList,
+  ActivityToasts,
+  AdminShell,
+  AppScopePanel,
+  createShellState,
+} from '@happyvertical/smrt-svelte/workspace';
+import { Button } from '@happyvertical/smrt-ui';
+import { useI18n } from '@happyvertical/smrt-ui/i18n';
+import type {
+  SmrtCrudFetchers,
+  SmrtWebCollectionDefinition,
+} from '@happyvertical/smrt-web';
+import {
+  createSmrtCollection,
+  getEngineCollection,
+} from '@happyvertical/smrt-web';
+import { onDestroy } from 'svelte';
+import { M } from '../../../../src/i18n/strings.workspace.js';
+
+const { t } = useI18n();
+
+/** The demo's job row shape. */
+interface JobRow {
+  id: string;
+  title: string;
+  state: 'queued' | 'running' | 'completed' | 'failed';
+  progress: number;
+}
+
+/**
+ * Minimal slice of the engine collection's manual sync-write API — the same
+ * calls a real backend feed (SSE/WebSocket) would use to push rows into a
+ * `@happyvertical/smrt-web` collection's synced store. Reached via
+ * `getEngineCollection` (an advanced bridge) purely to animate this demo.
+ */
+interface FeedWriter {
+  writeInsert(row: JobRow): void;
+  writeUpdate(row: Partial<JobRow> & { id: string }): void;
+  writeDelete(key: string): void;
+}
+
+const jobDefinition: SmrtWebCollectionDefinition<JobRow> = {
+  name: 'demo_render_jobs',
+  className: 'RenderJob',
+  endpoint: '/demo_render_jobs',
+  idField: 'id',
+  actions: ['list'],
+  fields: {
+    title: { type: 'text', required: true },
+    state: { type: 'text' },
+    progress: { type: 'integer' },
+  },
+};
+
+// In-memory "server" backing the collection's initial load — the feed then
+// pushes further changes through the manual sync-write API below.
+const fetchers: SmrtCrudFetchers = {
+  list: async () => [],
+};
+
+const collection = createSmrtCollection<JobRow>(jobDefinition, {
+  fetchers,
+  staleTimeMs: 60_000,
+  initialData: [],
+});
+
+// Reach the engine collection's sync-write utils to simulate the backend feed.
+const engine = getEngineCollection(collection) as {
+  utils: FeedWriter;
+};
+const feed = engine.utils;
+
+const shell = createShellState({
+  settings: { panels: { right: 'expanded' } },
+});
+
+// Bridge the live collection into the shell. One editorial map turns each job
+// row into a Focus-scope activity; the adapter drives upsert/update/remove.
+const handle = activityFeed<JobRow>({
+  collection,
+  shell,
+  map: (row) => ({
+    kind: 'render-job',
+    scope: 'focus',
+    label: `${t(M['ui.activity_feed.job_label'])}: ${row.title}`,
+    status: row.state,
+    progress: row.progress,
+  }),
+});
+
+onDestroy(() => handle.dispose());
+
+let nextId = $state(1);
+// Mirror of the rows the demo has pushed, shown in the "backing rows" panel.
+let rows = $state<JobRow[]>([]);
+
+function syncRowsView() {
+  rows = collection.toArray.map((row) => ({ ...row }) as JobRow);
+}
+
+function enqueueJob() {
+  const seq = nextId;
+  nextId += 1;
+  const row: JobRow = {
+    id: `job-${seq}`,
+    title: `#${seq}`,
+    state: 'running',
+    progress: 0,
+  };
+  feed.writeInsert(row);
+  syncRowsView();
+}
+
+function advanceJob() {
+  const running = collection.toArray.find((row) => row.state === 'running');
+  if (!running) return;
+  const progress = Math.min(100, (running.progress ?? 0) + 25);
+  feed.writeUpdate({ id: running.id, progress });
+  syncRowsView();
+}
+
+function completeJob() {
+  const running = collection.toArray.find((row) => row.state === 'running');
+  if (!running) return;
+  feed.writeUpdate({ id: running.id, state: 'completed', progress: 100 });
+  syncRowsView();
+}
+
+function failJob() {
+  const running = collection.toArray.find((row) => row.state === 'running');
+  if (!running) return;
+  feed.writeUpdate({ id: running.id, state: 'failed' });
+  syncRowsView();
+}
+
+function clearFinished() {
+  for (const row of collection.toArray) {
+    if (row.state === 'completed' || row.state === 'failed') {
+      feed.writeDelete(row.id);
+    }
+  }
+  syncRowsView();
+}
+</script>
+
+<AdminShell
+  title="SMRT AdminShell"
+  subtitle={t(M['ui.activity_feed.title'])}
+  state={shell}
+>
+  {#snippet appPanel()}
+    <AppScopePanel
+      appName="SMRT Playground"
+      tenantName="Demo tenant"
+      environment="local"
+    />
+  {/snippet}
+
+  {#snippet focusPanel()}
+    <section class="feed-focus">
+      <header>
+        <h2>{t(M['ui.activity_feed.title'])}</h2>
+      </header>
+      <ActivityList filter={{ kind: 'render-job' }} hideWhenEmpty />
+    </section>
+  {/snippet}
+
+  <section class="feed-demo">
+    <header>
+      <h1>{t(M['ui.activity_feed.title'])}</h1>
+      <p>{t(M['ui.activity_feed.description'])}</p>
+      <div class="feed-actions">
+        <Button onclick={enqueueJob}>{t(M['ui.activity_feed.enqueue_job'])}</Button>
+        <Button variant="secondary" onclick={advanceJob}>
+          {t(M['ui.activity_feed.advance_job'])}
+        </Button>
+        <Button variant="secondary" onclick={completeJob}>
+          {t(M['ui.activity_feed.complete_job'])}
+        </Button>
+        <Button variant="secondary" onclick={failJob}>
+          {t(M['ui.activity_feed.fail_job'])}
+        </Button>
+        <Button variant="secondary" onclick={clearFinished}>
+          {t(M['ui.activity_feed.clear_finished'])}
+        </Button>
+      </div>
+    </header>
+
+    <section class="feed-rows">
+      <h2>{t(M['ui.activity_feed.rows_heading'])}</h2>
+      {#if rows.length === 0}
+        <p class="feed-empty">{t(M['ui.activity_feed.no_rows'])}</p>
+      {:else}
+        <ul>
+          {#each rows as row (row.id)}
+            <li>
+              <span class="feed-row-title">{row.title}</span>
+              <span class="feed-row-state" data-state={row.state}>{row.state}</span>
+              <span class="feed-row-progress">{row.progress}%</span>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+  </section>
+
+  <ActivityToasts />
+</AdminShell>
+
+<style>
+  :global(body) {
+    margin: 0;
+  }
+
+  .feed-demo {
+    display: grid;
+    gap: var(--smrt-spacing-6);
+    min-block-size: 100%;
+    padding: var(--smrt-spacing-8);
+    background: var(--smrt-color-surface);
+  }
+
+  .feed-demo header,
+  .feed-focus {
+    display: grid;
+    gap: var(--smrt-spacing-4);
+  }
+
+  .feed-demo h1,
+  .feed-demo p,
+  .feed-focus h2 {
+    margin: 0;
+  }
+
+  .feed-demo p {
+    color: var(--smrt-color-on-surface-variant);
+  }
+
+  .feed-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--smrt-spacing-2);
+  }
+
+  .feed-rows {
+    display: grid;
+    gap: var(--smrt-spacing-3);
+  }
+
+  .feed-rows h2 {
+    margin: 0;
+    font-size: var(--smrt-typography-title-medium-size);
+  }
+
+  .feed-rows ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--smrt-spacing-2);
+  }
+
+  .feed-rows li {
+    display: flex;
+    align-items: center;
+    gap: var(--smrt-spacing-4);
+    padding: var(--smrt-spacing-3) var(--smrt-spacing-4);
+    background: var(--smrt-color-surface-container-low);
+    border-radius: var(--smrt-radius-sm);
+  }
+
+  .feed-row-title {
+    font-weight: var(--smrt-typography-weight-medium);
+    color: var(--smrt-color-on-surface);
+  }
+
+  .feed-row-state {
+    color: var(--smrt-color-on-surface-variant);
+  }
+
+  .feed-row-progress {
+    margin-inline-start: auto;
+    color: var(--smrt-color-on-surface-variant);
+  }
+
+  .feed-empty {
+    color: var(--smrt-color-on-surface-variant);
+  }
+</style>

--- a/packages/smrt-svelte/src/i18n/strings.workspace.ts
+++ b/packages/smrt-svelte/src/i18n/strings.workspace.ts
@@ -68,4 +68,17 @@ export const M = defineMessages({
   'ui.system_scope_panel.no_running_work': 'No running work',
   'ui.system_status_chips.system_status': 'System status',
   'ui.tenant_nav.tenant_navigation': 'Tenant navigation',
+
+  // web/activity-feed adapter demo (#1779) — playground/admin-shell-activity-feed
+  'ui.activity_feed.title': 'Live activity feed',
+  'ui.activity_feed.description':
+    'A smrt-web live collection reconciled into the shell activity registry.',
+  'ui.activity_feed.enqueue_job': 'Enqueue job',
+  'ui.activity_feed.advance_job': 'Advance job',
+  'ui.activity_feed.complete_job': 'Complete job',
+  'ui.activity_feed.fail_job': 'Fail job',
+  'ui.activity_feed.clear_finished': 'Clear finished',
+  'ui.activity_feed.rows_heading': 'Backing collection rows',
+  'ui.activity_feed.no_rows': 'No rows yet',
+  'ui.activity_feed.job_label': 'Render job',
 });

--- a/packages/smrt-svelte/src/web/__tests__/activity-feed-harness.svelte
+++ b/packages/smrt-svelte/src/web/__tests__/activity-feed-harness.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+/**
+ * Integration harness — invokes activityFeed() inside a component-init scope so
+ * the `$effect` it (and the underlying `liveCollection`) installs wires up to a
+ * real component lifecycle, then hands the feed handle back to the test.
+ */
+import type { SmrtWebCollection } from '@happyvertical/smrt-web';
+import {
+  activityFeed,
+  type ActivityFeedHandle,
+  type ActivityFeedMap,
+} from '../activity-feed.svelte.js';
+import type { ShellState } from '../../components/workspace/index.js';
+
+interface Props {
+  collection: SmrtWebCollection<Record<string, unknown>>;
+  shell: ShellState;
+  map: ActivityFeedMap<Record<string, unknown>>;
+  onReady: (handle: ActivityFeedHandle) => void;
+}
+
+const props: Props = $props();
+// This harness intentionally snapshots its props during setup.
+// svelte-ignore state_referenced_locally
+const handle = activityFeed({
+  collection: props.collection,
+  shell: props.shell,
+  map: props.map,
+});
+// svelte-ignore state_referenced_locally
+props.onReady(handle);
+</script>

--- a/packages/smrt-svelte/src/web/__tests__/activity-feed.integration.svelte.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/activity-feed.integration.svelte.test.ts
@@ -197,4 +197,38 @@ describe('activityFeed (integration)', () => {
     expect(shell.listActivities()).toHaveLength(0);
     expect(mounted.handle.isDisposed).toBe(true);
   });
+
+  it('auto-retracts the feed activities when the host component unmounts', async () => {
+    const scripted = makeScriptedFetchers([
+      { id: 'job-1', title: 'Render intro', state: 'running' },
+      { id: 'job-2', title: 'Render outro', state: 'queued' },
+    ]);
+    const collection = createSmrtCollection(jobDefinition('feed-unmount'), {
+      fetchers: scripted.fetchers,
+      staleTimeMs: 60_000,
+    });
+    const shell = createShellState();
+    // An activity from another source must survive the feed's unmount.
+    shell.upsertActivity({
+      id: 'external-1',
+      label: 'External',
+      kind: 'other',
+      scope: 'app',
+      status: 'running',
+    });
+
+    const mounted = mountFeed(collection, shell);
+    await collection.preload();
+    flushSync();
+    expect(shell.listActivities()).toHaveLength(3);
+
+    // Unmount WITHOUT calling dispose() manually: the adapter's $effect teardown
+    // must retract exactly its own activities, leaving the external one intact.
+    mounted.teardown();
+    flushSync();
+
+    const remaining = shell.listActivities();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe('external-1');
+  });
 });

--- a/packages/smrt-svelte/src/web/__tests__/activity-feed.integration.svelte.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/activity-feed.integration.svelte.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Integration test for the AdminShell activity feed adapter (#1779) end to end.
+ *
+ * Unlike the reconciler unit tests (which feed plain arrays), this exercises the
+ * FULL stack — `activityFeed` → `liveCollection` → the real `@happyvertical/smrt-web`
+ * collection with its client-data engine — through a mounted harness, so the
+ * `$effect` that drives reconciliation has a genuine component-init scope. Only
+ * the network boundary is mocked (the generated REST fetchers passed to
+ * `createSmrtCollection`); the engine, live view, runes reactivity, and the real
+ * `ShellState` are all live. This proves the reactive wiring drives the shell:
+ * a loaded row and an optimistic insert both surface as shell activities.
+ */
+
+import {
+  createSmrtCollection,
+  type SmrtCrudFetchers,
+  type SmrtWebCollection,
+  type SmrtWebCollectionDefinition,
+} from '@happyvertical/smrt-web';
+import { flushSync, mount, unmount } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createShellState } from '../../components/workspace/admin-shell/state.svelte.js';
+import type { ShellState } from '../../components/workspace/index.js';
+import type {
+  ActivityFeedHandle,
+  ActivityFeedMap,
+} from '../activity-feed.svelte.js';
+import Harness from './activity-feed-harness.svelte';
+
+interface JobData {
+  id?: string;
+  title: string;
+  state?: 'queued' | 'running' | 'completed' | 'failed' | 'canceled';
+}
+
+function jobDefinition(name: string): SmrtWebCollectionDefinition<JobData> {
+  return {
+    name,
+    className: 'RenderJob',
+    endpoint: `/${name}`,
+    idField: 'id',
+    actions: ['create', 'get', 'list'],
+    fields: {
+      title: { type: 'text', required: true },
+      state: { type: 'text' },
+    },
+  };
+}
+
+/** Scripted stand-in for the generated REST fetchers (see live-collection test). */
+function makeScriptedFetchers(initialRows: Array<Record<string, unknown>>) {
+  const serverRows = [...initialRows];
+  const fetchers: SmrtCrudFetchers = {
+    list: async () => serverRows.map((row) => ({ ...row })),
+    create: async (data) => {
+      const created = { ...data, id: `server-${serverRows.length + 1}` };
+      serverRows.push(created);
+      return { ...created };
+    },
+  };
+  return { fetchers };
+}
+
+const mapJob: ActivityFeedMap<JobData> = (row) => ({
+  kind: 'render-job',
+  scope: 'focus',
+  label: row.title,
+  status: row.state ?? 'running',
+});
+
+function mountFeed(
+  collection: SmrtWebCollection<JobData>,
+  shell: ShellState,
+): { handle: ActivityFeedHandle; teardown: () => void } {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  let exposed = undefined as unknown as ActivityFeedHandle;
+  const component = mount(Harness, {
+    target,
+    props: {
+      // The harness is typed against the base object shape; JobData is a
+      // structural subtype, so this cross-cast is purely nominal.
+      collection: collection as unknown as SmrtWebCollection<
+        Record<string, unknown>
+      >,
+      shell,
+      map: mapJob as unknown as ActivityFeedMap<Record<string, unknown>>,
+      onReady: (handle: ActivityFeedHandle) => {
+        exposed = handle;
+      },
+    },
+  });
+  return {
+    handle: exposed,
+    teardown: () => {
+      unmount(component);
+      target.remove();
+    },
+  };
+}
+
+describe('activityFeed (integration)', () => {
+  const cleanup: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const fn of cleanup.splice(0)) fn();
+  });
+
+  it('reconciles loaded collection rows into shell activities', async () => {
+    const scripted = makeScriptedFetchers([
+      { id: 'job-1', title: 'Render intro', state: 'running' },
+      { id: 'job-2', title: 'Render outro', state: 'queued' },
+    ]);
+    const collection = createSmrtCollection(jobDefinition('feed-load'), {
+      fetchers: scripted.fetchers,
+      staleTimeMs: 60_000,
+    });
+    const shell = createShellState();
+
+    const mounted = mountFeed(collection, shell);
+    cleanup.push(mounted.teardown);
+    await collection.preload();
+    flushSync();
+
+    const activities = shell.listActivities();
+    expect(activities.map((a) => a.id).sort()).toEqual(['job-1', 'job-2']);
+    expect(activities.every((a) => a.kind === 'render-job')).toBe(true);
+    // Homed to the focus edge (right) per the map's scope.
+    expect(shell.listActivities({ edge: 'right' })).toHaveLength(2);
+  });
+
+  it('surfaces an optimistic insert as a shell activity reactively', async () => {
+    const scripted = makeScriptedFetchers([
+      { id: 'job-1', title: 'Render intro', state: 'running' },
+    ]);
+    const collection = createSmrtCollection(jobDefinition('feed-insert'), {
+      fetchers: scripted.fetchers,
+      staleTimeMs: 60_000,
+    });
+    const shell = createShellState();
+
+    const mounted = mountFeed(collection, shell);
+    cleanup.push(mounted.teardown);
+    await collection.preload();
+    flushSync();
+    expect(shell.listActivities()).toHaveLength(1);
+
+    // An optimistic insert appears in the live view synchronously → the feed
+    // reconciles it into the shell on the reactive tick.
+    const tx = collection.insert({
+      id: 'local-1',
+      title: 'Render credits',
+      state: 'running',
+    });
+    flushSync();
+
+    expect(
+      shell
+        .listActivities()
+        .map((a) => a.label)
+        .sort(),
+    ).toEqual(['Render credits', 'Render intro']);
+
+    // Once persisted, the server-assigned row replaces the optimistic one; the
+    // activity for the temp id is removed and the server row's activity remains.
+    await tx.isPersisted.promise;
+    flushSync();
+
+    const labels = shell
+      .listActivities()
+      .map((a) => a.label)
+      .sort();
+    expect(labels).toEqual(['Render credits', 'Render intro']);
+    // The optimistic-id activity is gone; the server id is present.
+    const ids = shell.listActivities().map((a) => a.id);
+    expect(ids).toContain('server-2');
+    expect(ids).not.toContain('local-1');
+  });
+
+  it('dispose() retracts the feed activities from the shell', async () => {
+    const scripted = makeScriptedFetchers([
+      { id: 'job-1', title: 'Render intro', state: 'running' },
+    ]);
+    const collection = createSmrtCollection(jobDefinition('feed-dispose'), {
+      fetchers: scripted.fetchers,
+      staleTimeMs: 60_000,
+    });
+    const shell = createShellState();
+
+    const mounted = mountFeed(collection, shell);
+    cleanup.push(mounted.teardown);
+    await collection.preload();
+    flushSync();
+    expect(shell.listActivities()).toHaveLength(1);
+
+    mounted.handle.dispose();
+    expect(shell.listActivities()).toHaveLength(0);
+    expect(mounted.handle.isDisposed).toBe(true);
+  });
+});

--- a/packages/smrt-svelte/src/web/__tests__/activity-feed.svelte.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/activity-feed.svelte.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for the AdminShell activity feed adapter's reconciliation core
+ * (#1779).
+ *
+ * These exercise {@link ActivityFeedReconciler} — the pure diff between a set of
+ * live rows and the shell activity registry — against a REAL {@link ShellState}.
+ * Per repo policy nothing here is mocked: the shell, its activity events, and
+ * the mapping are all real; the reconciler is fed plain row arrays that stand in
+ * for successive live-collection ticks (`liveCollection`'s engine is exercised
+ * separately in `activity-feed.integration.svelte.test.ts`). This isolates the
+ * mapping / create-update-remove / ownership behavior the adapter guarantees.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { createShellState } from '../../components/workspace/admin-shell/state.svelte.js';
+import type {
+  ShellActivityEvent,
+  ShellState,
+} from '../../components/workspace/index.js';
+import {
+  ActivityFeedReconciler,
+  type ShellActivityInput,
+} from '../activity-feed.svelte.js';
+
+/** A row DTO for a background render job — the feed's backing collection shape. */
+interface JobRow {
+  id: string;
+  title: string;
+  state: 'queued' | 'running' | 'completed' | 'failed' | 'canceled';
+  progress?: number;
+  draft?: boolean;
+}
+
+/** Editorial map: a job row → focus-scope activity, or `null` for a draft. */
+const mapJob = (row: JobRow): ShellActivityInput | null => {
+  if (row.draft) return null;
+  return {
+    kind: 'render-job',
+    scope: 'focus',
+    label: row.title,
+    status: row.state,
+    progress: row.progress ?? null,
+  };
+};
+
+/** Record every activity event the shell emits, for sequence assertions. */
+function recordEvents(shell: ShellState): {
+  events: ShellActivityEvent[];
+  stop: () => void;
+} {
+  const events: ShellActivityEvent[] = [];
+  const stop = shell.watchActivities((event) => events.push(event));
+  return { events, stop };
+}
+
+describe('ActivityFeedReconciler', () => {
+  const teardown: Array<() => void> = [];
+
+  afterEach(() => {
+    for (const fn of teardown.splice(0)) fn();
+  });
+
+  function setup() {
+    const shell = createShellState();
+    const recorded = recordEvents(shell);
+    teardown.push(recorded.stop);
+    const reconciler = new ActivityFeedReconciler<JobRow>(shell, mapJob);
+    return { shell, reconciler, events: recorded.events };
+  }
+
+  it('upserts a shell activity when a row first appears', () => {
+    const { shell, reconciler, events } = setup();
+
+    reconciler.reconcile([
+      { id: 'job-1', title: 'Render intro', state: 'running', progress: 20 },
+    ]);
+
+    const activities = shell.listActivities();
+    expect(activities).toHaveLength(1);
+    expect(activities[0]).toMatchObject({
+      id: 'job-1',
+      kind: 'render-job',
+      scope: 'focus',
+      label: 'Render intro',
+      status: 'running',
+      progress: 20,
+    });
+    // The activity id defaults to the row id, and the shell stamped createdAt.
+    expect(activities[0].createdAt).toBeTruthy();
+    // A single create event (upsert), no transition/remove.
+    expect(events.map((e) => e.type)).toEqual(['upsert']);
+  });
+
+  it('updates the activity in place when a row changes (status transition)', () => {
+    const { shell, reconciler, events } = setup();
+
+    reconciler.reconcile([
+      { id: 'job-1', title: 'Render intro', state: 'running', progress: 20 },
+    ]);
+    const createdAt = shell.listActivities()[0].createdAt;
+
+    // Same row id, advanced progress + status flip → an UPDATE, not a second
+    // create, and the shell reports it as a `transition` (status changed).
+    reconciler.reconcile([
+      { id: 'job-1', title: 'Render intro', state: 'completed', progress: 100 },
+    ]);
+
+    const activities = shell.listActivities();
+    expect(activities).toHaveLength(1);
+    expect(activities[0]).toMatchObject({
+      id: 'job-1',
+      status: 'completed',
+      progress: 100,
+    });
+    // createdAt preserved across the update (update went through updateActivity,
+    // not a fresh upsert that would re-stamp it).
+    expect(activities[0].createdAt).toBe(createdAt);
+    expect(events.map((e) => e.type)).toEqual(['upsert', 'transition']);
+  });
+
+  it('performs no shell mutation when a reconcile tick is unchanged', () => {
+    const { reconciler, events } = setup();
+
+    const rows: JobRow[] = [
+      { id: 'job-1', title: 'Render intro', state: 'running', progress: 20 },
+    ];
+    reconciler.reconcile(rows);
+    // Re-feed identical content (a common no-op reactive tick): a new array with
+    // an equal-but-distinct row object. Must not emit a second event.
+    reconciler.reconcile([{ ...rows[0] }]);
+
+    expect(events.map((e) => e.type)).toEqual(['upsert']);
+  });
+
+  it('removes the activity when its row vanishes from the collection', () => {
+    const { shell, reconciler, events } = setup();
+
+    reconciler.reconcile([
+      { id: 'job-1', title: 'Render intro', state: 'running' },
+      { id: 'job-2', title: 'Render outro', state: 'queued' },
+    ]);
+    expect(shell.listActivities()).toHaveLength(2);
+
+    // job-1 gone from the next tick → removed; job-2 unchanged → left alone.
+    reconciler.reconcile([
+      { id: 'job-2', title: 'Render outro', state: 'queued' },
+    ]);
+
+    const remaining = shell.listActivities();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe('job-2');
+    expect(events.map((e) => e.type)).toEqual([
+      'upsert', // job-1 create
+      'upsert', // job-2 create
+      'remove', // job-1 removed
+    ]);
+  });
+
+  it('treats a row that maps to null as absent (excluded, then removed when it flips)', () => {
+    const { shell, reconciler } = setup();
+
+    // A draft row maps to null → never becomes an activity.
+    reconciler.reconcile([
+      { id: 'job-1', title: 'Draft', state: 'queued', draft: true },
+    ]);
+    expect(shell.listActivities()).toHaveLength(0);
+
+    // It leaves draft → now an activity appears.
+    reconciler.reconcile([
+      { id: 'job-1', title: 'Published', state: 'running' },
+    ]);
+    expect(shell.listActivities()).toHaveLength(1);
+
+    // It goes back to draft (maps to null again) → activity is removed.
+    reconciler.reconcile([
+      { id: 'job-1', title: 'Published', state: 'running', draft: true },
+    ]);
+    expect(shell.listActivities()).toHaveLength(0);
+  });
+
+  it('lets the map decouple the activity id from the row id', () => {
+    const shell = createShellState();
+    const reconciler = new ActivityFeedReconciler<JobRow>(shell, (row) => ({
+      id: `activity:${row.id}`,
+      kind: 'render-job',
+      scope: 'system',
+      label: row.title,
+      status: row.state,
+    }));
+
+    reconciler.reconcile([{ id: 'job-1', title: 'Job', state: 'running' }]);
+
+    const activities = shell.listActivities();
+    expect(activities).toHaveLength(1);
+    expect(activities[0].id).toBe('activity:job-1');
+  });
+
+  it('routes an activity to the shell edge for its scope', () => {
+    const { shell, reconciler } = setup();
+
+    reconciler.reconcile([{ id: 'job-1', title: 'Job', state: 'running' }]);
+
+    // scope 'focus' homes to the right edge (SCOPE_EDGES.focus === 'right').
+    expect(shell.listActivities({ edge: 'right' })).toHaveLength(1);
+  });
+
+  it('dispose() removes exactly the feed activities and stops reconciling', () => {
+    const { shell, reconciler, events } = setup();
+
+    // An activity from ANOTHER source the feed must never touch.
+    shell.upsertActivity({
+      id: 'external-1',
+      label: 'External',
+      kind: 'other',
+      scope: 'app',
+      status: 'running',
+    });
+    reconciler.reconcile([
+      { id: 'job-1', title: 'Render intro', state: 'running' },
+    ]);
+    expect(shell.listActivities()).toHaveLength(2);
+
+    reconciler.dispose();
+
+    // Only the feed's own activity was retracted; the external one survives.
+    const remaining = shell.listActivities();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe('external-1');
+    expect(reconciler.isDisposed).toBe(true);
+
+    // Reconciling after dispose is a no-op (no new activities, no events).
+    const eventsBefore = events.length;
+    reconciler.reconcile([
+      { id: 'job-2', title: 'Late job', state: 'running' },
+    ]);
+    expect(shell.listActivities()).toHaveLength(1);
+    expect(events.length).toBe(eventsBefore);
+  });
+});

--- a/packages/smrt-svelte/src/web/__tests__/activity-feed.svelte.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/activity-feed.svelte.test.ts
@@ -204,6 +204,60 @@ describe('ActivityFeedReconciler', () => {
     expect(shell.listActivities({ edge: 'right' })).toHaveLength(1);
   });
 
+  it('re-homes the activity to the new edge when its scope changes (no explicit edge)', () => {
+    const shell = createShellState();
+    // Map keys scope off the row so a later tick can change it; no `edge` set.
+    const reconciler = new ActivityFeedReconciler<JobRow>(shell, (row) => ({
+      kind: 'render-job',
+      // Reuse the unused `draft` flag as a cheap "move to system scope" toggle.
+      scope: row.draft ? 'system' : 'focus',
+      label: row.title,
+      status: row.state,
+    }));
+
+    reconciler.reconcile([{ id: 'job-1', title: 'Job', state: 'running' }]);
+    // Focus → right edge.
+    expect(shell.listActivities({ edge: 'right' })).toHaveLength(1);
+    expect(shell.listActivities({ edge: 'bottom' })).toHaveLength(0);
+
+    // Scope flips to system; the map still sets no explicit edge. The activity
+    // must RE-DERIVE its edge from the new scope (system → bottom), not stay
+    // pinned to the old right edge.
+    reconciler.reconcile([
+      { id: 'job-1', title: 'Job', state: 'running', draft: true },
+    ]);
+    expect(shell.listActivities({ edge: 'right' })).toHaveLength(0);
+    expect(shell.listActivities({ edge: 'bottom' })).toHaveLength(1);
+    expect(shell.listActivities()[0].scope).toBe('system');
+  });
+
+  it('clears a previously-set optional field when a later mapping drops it', () => {
+    const shell = createShellState();
+    // Map emits `message`/`detailHref` only while the job is running.
+    const reconciler = new ActivityFeedReconciler<JobRow>(shell, (row) => ({
+      kind: 'render-job',
+      scope: 'focus',
+      label: row.title,
+      status: row.state,
+      ...(row.state === 'running'
+        ? { message: 'Rendering frames', detailHref: '/jobs/job-1' }
+        : {}),
+    }));
+
+    reconciler.reconcile([{ id: 'job-1', title: 'Job', state: 'running' }]);
+    let activity = shell.listActivities()[0];
+    expect(activity.message).toBe('Rendering frames');
+    expect(activity.detailHref).toBe('/jobs/job-1');
+
+    // The job completes → the map no longer emits message/detailHref. Those
+    // stale values must be CLEARED, not retained from the previous mapping.
+    reconciler.reconcile([{ id: 'job-1', title: 'Job', state: 'completed' }]);
+    activity = shell.listActivities()[0];
+    expect(activity.status).toBe('completed');
+    expect(activity.message).toBeUndefined();
+    expect(activity.detailHref).toBeUndefined();
+  });
+
   it('dispose() removes exactly the feed activities and stops reconciling', () => {
     const { shell, reconciler, events } = setup();
 

--- a/packages/smrt-svelte/src/web/activity-feed.svelte.ts
+++ b/packages/smrt-svelte/src/web/activity-feed.svelte.ts
@@ -198,6 +198,43 @@ function resolveInput<TData extends object>(
 }
 
 /**
+ * Build the update patch for a re-mapped activity so it REPLACES the mapped
+ * field set rather than merging over it.
+ *
+ * `ShellState.updateActivity(id, patch)` merges `{ ...current, ...patch }`, so a
+ * key the new mapping OMITS would otherwise retain its stale prior value. To
+ * keep the shell activity an exact mirror of the current mapping, every field a
+ * map controls is listed EXPLICITLY here — an omitted optional field is carried
+ * as `undefined`, which overwrites the stale value on merge. Two consequences:
+ *
+ *  - Dropped optionals (`message`, `detailHref`, `subject`, `progress`, `cancel`)
+ *    are cleared, not kept (codex P2).
+ *  - `edge` is passed through as the mapping left it — `undefined` when the map
+ *    did not pin an edge — so when a row's `scope` changes without an explicit
+ *    `edge`, the merged activity carries `edge: undefined` and `upsertActivity`
+ *    RE-DERIVES the edge from the new scope (`edge ?? homeEdgeForScope(scope)`),
+ *    re-homing it instead of pinning it to the previous scope's edge (copilot).
+ *
+ * `id` is deliberately excluded (it is the update key, not a patched field).
+ */
+function toUpdatePatch(
+  input: ShellActivityInput & { id: string },
+): Partial<Omit<ShellActivity, 'id'>> {
+  return {
+    label: input.label,
+    kind: input.kind,
+    scope: input.scope,
+    status: input.status,
+    subject: input.subject,
+    edge: input.edge,
+    progress: input.progress,
+    detailHref: input.detailHref,
+    message: input.message,
+    cancel: input.cancel,
+  };
+}
+
+/**
  * The pure reconciliation core of {@link activityFeed}: it owns the diff between
  * a set of live rows and the shell's activity registry, with NO Svelte reactive
  * or client-data-engine dependency. {@link activityFeed} wraps one of these in a
@@ -269,10 +306,11 @@ export class ActivityFeedReconciler<TData extends object> {
       }
       if (!fingerprintsEqual(prior.fingerprint, entry.fingerprint)) {
         // Changed: patch it, preserving createdAt and letting the shell emit a
-        // `transition` when the status changed. Passing the full editorial input
-        // (minus id) as the patch keeps the shell activity in exact sync.
-        const { id: _omit, ...patch } = entry.input;
-        this.shell.updateActivity(id, patch);
+        // `transition` when the status changed. The patch lists every mappable
+        // field explicitly (see `toUpdatePatch`) so it REPLACES the mapped set
+        // rather than merging over it — dropped optionals are cleared and a
+        // changed `scope` re-derives the `edge` instead of pinning the old one.
+        this.shell.updateActivity(id, toUpdatePatch(entry.input));
         this.owned.set(id, entry);
       }
       // Unchanged: no shell mutation.
@@ -300,8 +338,11 @@ export class ActivityFeedReconciler<TData extends object> {
  * {@link liveCollection} (which installs a `$effect`) and installs its own
  * reconciliation `$effect`. Both bind to the calling component's lifecycle, so
  * the live subscription and reconciliation tear down automatically on unmount.
- * The returned {@link ActivityFeedHandle.dispose} additionally REMOVES the
- * feed's activities from the shell — call it to retract them without unmounting.
+ * Unmount ALSO auto-retracts the feed's activities from the shell (via an
+ * `$effect` teardown), so they never linger after the host component is gone —
+ * no manual cleanup required. The returned {@link ActivityFeedHandle.dispose}
+ * retracts them SOONER (without unmounting) and is idempotent, so calling it and
+ * then unmounting is safe.
  *
  * Lifecycle per row:
  *  - a row that newly maps to an activity → `shell.upsertActivity(...)` (creates
@@ -365,6 +406,18 @@ export function activityFeed<TData extends object>(
   // The effect binds to the hosting component and tears down on unmount.
   $effect(() => {
     reconciler.reconcile(view.rows);
+  });
+
+  // Auto-cleanup on unmount: retract this feed's activities from the shell when
+  // the hosting component is destroyed, so they never linger after the UI that
+  // created them is gone. This effect reads NO reactive state, so it never
+  // re-runs — its teardown fires only when the effect is destroyed (component
+  // unmount / `$effect.root` teardown), exactly the unmount hook we want. The
+  // returned `dispose()` stays available for callers that want to retract the
+  // feed's activities sooner (without unmounting); `dispose` is idempotent, so
+  // an explicit call followed by the unmount teardown is safe.
+  $effect(() => {
+    return () => reconciler.dispose();
   });
 
   return {

--- a/packages/smrt-svelte/src/web/activity-feed.svelte.ts
+++ b/packages/smrt-svelte/src/web/activity-feed.svelte.ts
@@ -1,0 +1,378 @@
+/**
+ * AdminShell activity feed adapter — bridge a `@happyvertical/smrt-web` live
+ * collection into the AdminShell activity registry (#1779, part of the WASD
+ * AdminShell epic #1766).
+ *
+ * This is a thin, OPT-IN CONSUMER of already-shipped infrastructure, not a new
+ * generated surface. It sits at the intersection of two existing contracts:
+ *
+ *  - the runes-reactive {@link liveCollection} view over a `SmrtWebCollection`
+ *    (`@happyvertical/smrt-svelte/web`, slice A of #1761), and
+ *  - the `ShellState` activity registry (`upsertActivity` / `updateActivity` /
+ *    `removeActivity`, from `components/workspace/admin-shell`).
+ *
+ * The app supplies (a) the `@smrt()` DOMAIN collection (a `SmrtWebCollection`)
+ * and (b) an editorial {@link ActivityFeedMap} that turns each row into the
+ * shell-facing activity fields (`kind`, `scope`, `label`, `progress`, …). The
+ * adapter reconciles the mapped rows against the shell as rows appear, change,
+ * and vanish, and returns a disposer that removes the activities it created.
+ *
+ * ── Why it lives behind the `/web` opt-in entry ─────────────────────────────
+ * `liveCollection` pulls the client-data engine (`@tanstack/db` +
+ * `@tanstack/svelte-db`). Keeping this adapter in the `/web` subpath keeps that
+ * engine OUT of the AdminShell core: nothing under `components/workspace/` may
+ * import this module, so `@happyvertical/smrt-svelte/workspace` stays
+ * transport-agnostic and TanStack-free (a hard constraint of #1766). The app
+ * wires the adapter at the edge, next to where it already opts into `/web`.
+ *
+ * ── Engine-absorption boundary ──────────────────────────────────────────────
+ * No `@tanstack/*` type appears here. The adapter reconciles against the plain
+ * DTO rows exposed by {@link liveCollection} (which already strips the engine's
+ * `$`-prefixed virtual props), so the engine stays swappable behind the same
+ * boundary the rest of `/web` respects.
+ *
+ * ── Reconciliation, not change-diffing ──────────────────────────────────────
+ * Rather than decode the engine's change payload, the adapter re-derives the
+ * activity set from the current live rows on every reactive tick (via an
+ * internal `$effect` over `view.rows`) and diffs it against what it last pushed
+ * to the shell. This is robust to the change-notification shape (which is
+ * engine-internal) and mirrors how the runtime's own consumers treat a change
+ * as a "something moved, re-read" signal.
+ */
+
+import type { SmrtWebCollection, SmrtWebRow } from '@happyvertical/smrt-web';
+import type { ShellState } from '../components/workspace/admin-shell/state.svelte.js';
+import type { ShellActivity } from '../components/workspace/admin-shell/types.js';
+import { liveCollection } from './live-collection.svelte.js';
+
+/**
+ * The shell-facing fields an {@link ActivityFeedMap} produces for one row — the
+ * editorial half of a {@link ShellActivity}. The adapter owns the bookkeeping
+ * fields (`id`, `createdAt`, `updatedAt`), so they are omitted here; `id` may be
+ * supplied to decouple the activity id from the row id (it defaults to the row's
+ * `id`). Everything a consumer legitimately controls (`kind`, `scope`, `label`,
+ * `status`, `subject`, `progress`, `detailHref`, `message`, `edge`, `cancel`)
+ * passes straight through.
+ */
+export type ShellActivityInput = Omit<
+  ShellActivity,
+  'id' | 'createdAt' | 'updatedAt'
+> & {
+  /**
+   * Explicit activity id. Defaults to the row's `id` when omitted — the common
+   * case (one activity per row). Supply it only to map a row onto a
+   * differently-keyed activity.
+   */
+  id?: string;
+};
+
+/**
+ * Map one live-collection row to its shell activity fields, or `null` to
+ * exclude the row from the feed.
+ *
+ * Returning `null` is a first-class signal: a row that maps to `null` is NOT an
+ * activity (e.g. a draft the shell should ignore), and a row that STOPS mapping
+ * to an activity — flips from a value to `null` — is removed from the shell,
+ * exactly as if it had vanished from the collection. This lets the editorial map
+ * gate which rows surface without the consumer filtering the collection.
+ *
+ * @typeParam TData - the row DTO shape carried by the collection.
+ */
+export type ActivityFeedMap<TData extends object> = (
+  row: SmrtWebRow<TData>,
+) => ShellActivityInput | null;
+
+/**
+ * Options for {@link activityFeed}.
+ *
+ * @typeParam TData - the row DTO shape carried by {@link collection}.
+ */
+export interface ActivityFeedOptions<TData extends object> {
+  /**
+   * The domain live collection to bridge — a `SmrtWebCollection` from
+   * `@happyvertical/smrt-web` (e.g. built by the app's `createSmrtCollection`
+   * over its `@smrt()` class). Its rows drive the feed.
+   */
+  collection: SmrtWebCollection<TData>;
+  /**
+   * The editorial mapping from a row to its shell activity fields (or `null` to
+   * exclude the row). See {@link ActivityFeedMap}.
+   */
+  map: ActivityFeedMap<TData>;
+  /** The AdminShell state whose activity registry this feed drives. */
+  shell: ShellState;
+  /**
+   * Forwarded to the underlying {@link liveCollection}: trigger the collection's
+   * first load eagerly when the feed is created. Defaults to `true`.
+   */
+  preload?: boolean;
+}
+
+/**
+ * A handle to a running {@link activityFeed}. Call {@link dispose} to detach the
+ * feed and remove every activity it created; read {@link isDisposed} to check.
+ */
+export interface ActivityFeedHandle {
+  /**
+   * Detach the feed: remove every activity this feed still owns from the shell
+   * and stop reconciling. Idempotent. The underlying live-query subscription is
+   * torn down by Svelte when the hosting component unmounts (that is where
+   * `activityFeed` must be called); call this to remove the feed's activities
+   * sooner, or when tearing a feed down without unmounting.
+   */
+  dispose(): void;
+  /** True once {@link dispose} has run. */
+  readonly isDisposed: boolean;
+}
+
+/**
+ * A stable, order-independent fingerprint of the shell-relevant fields of a
+ * mapped activity, used to detect whether a row's mapping actually CHANGED
+ * between reconcile ticks. Only fields the shell renders or keys on are
+ * included; the `cancel` callback is compared by identity (functions are not
+ * serializable and a new closure each map would otherwise force a spurious
+ * update every tick, re-stamping `updatedAt` and re-emitting events).
+ *
+ * Reconciliation writes to the shell only when this fingerprint differs, so a
+ * no-op reactive tick (rows re-observed but unchanged) performs zero shell
+ * mutations.
+ */
+interface ActivityFingerprint {
+  readonly signature: string;
+  readonly cancel: ShellActivity['cancel'];
+}
+
+/** One activity currently owned by the feed: its last input plus fingerprint. */
+interface OwnedActivity {
+  readonly input: ShellActivityInput & { id: string };
+  readonly fingerprint: ActivityFingerprint;
+}
+
+/**
+ * Compute the change-detection fingerprint for a resolved activity input. The
+ * signature is a JSON projection of the shell-relevant fields in a FIXED key
+ * order (so key ordering in the mapper output never registers as a change); the
+ * non-serializable `cancel` is carried alongside for identity comparison.
+ */
+function fingerprintOf(
+  input: ShellActivityInput & { id: string },
+): ActivityFingerprint {
+  const signature = JSON.stringify([
+    input.id,
+    input.label,
+    input.kind,
+    input.scope,
+    input.status,
+    input.progress ?? null,
+    input.message ?? null,
+    input.detailHref ?? null,
+    input.edge ?? null,
+    input.subject
+      ? [input.subject.type, input.subject.id, input.subject.label ?? null]
+      : null,
+  ]);
+  return { signature, cancel: input.cancel };
+}
+
+/** Two fingerprints are equal when their signatures AND `cancel` identity match. */
+function fingerprintsEqual(
+  a: ActivityFingerprint,
+  b: ActivityFingerprint,
+): boolean {
+  return a.signature === b.signature && a.cancel === b.cancel;
+}
+
+/**
+ * Resolve a mapped input to a fully-keyed activity input, defaulting the
+ * activity `id` to the row `id`. Returns `null` when the row has neither a
+ * mapped `id` nor a usable row `id` (it cannot be tracked, so it is dropped
+ * rather than pushed to the shell under an unstable key).
+ */
+function resolveInput<TData extends object>(
+  row: SmrtWebRow<TData>,
+  mapped: ShellActivityInput,
+): (ShellActivityInput & { id: string }) | null {
+  const id = mapped.id ?? row.id;
+  if (typeof id !== 'string' || id.length === 0) return null;
+  return { ...mapped, id };
+}
+
+/**
+ * The pure reconciliation core of {@link activityFeed}: it owns the diff between
+ * a set of live rows and the shell's activity registry, with NO Svelte reactive
+ * or client-data-engine dependency. {@link activityFeed} wraps one of these in a
+ * `$effect` over a {@link liveCollection} view; this split keeps the mapping /
+ * create-update-remove / ownership logic testable against a real `ShellState`
+ * with plain row arrays (mock only externals — see the `__tests__`).
+ *
+ * @internal Not part of the public surface — use {@link activityFeed}.
+ * @typeParam TData - the row DTO shape being reconciled.
+ */
+export class ActivityFeedReconciler<TData extends object> {
+  /**
+   * Activities this feed currently owns, keyed by activity id, each with the
+   * last resolved input + fingerprint so a reconcile can tell created / changed
+   * / unchanged apart and remove exactly its own set on teardown.
+   */
+  private readonly owned = new Map<string, OwnedActivity>();
+  private disposed = false;
+
+  constructor(
+    private readonly shell: ShellState,
+    private readonly map: ActivityFeedMap<TData>,
+  ) {}
+
+  /** True once {@link dispose} has run. */
+  get isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  /**
+   * Reconcile `rows` against the owned activity set: upsert newly-appearing
+   * activities, update changed ones, remove vanished ones. A pure diff — an
+   * unchanged tick (same rows, same mappings) performs ZERO shell mutations.
+   * No-op once disposed.
+   */
+  reconcile(rows: ReadonlyArray<SmrtWebRow<TData>>): void {
+    if (this.disposed) return;
+
+    // Resolve this tick's activities from the rows. A row mapping to `null`, or
+    // resolving to no usable id, is simply absent from `next` — which makes the
+    // removal pass below retract it if the feed owned it last tick.
+    const next = new Map<string, OwnedActivity>();
+    for (const row of rows) {
+      const mapped = this.map(row);
+      if (mapped === null) continue;
+      const input = resolveInput(row, mapped);
+      if (input === null) continue;
+      // Last write wins if two rows resolve to the same activity id — matches
+      // the shell's own upsert-by-id semantics.
+      next.set(input.id, { input, fingerprint: fingerprintOf(input) });
+    }
+
+    // Removals: ids the feed owned last tick but that are gone now.
+    for (const id of this.owned.keys()) {
+      if (!next.has(id)) {
+        this.shell.removeActivity(id);
+        this.owned.delete(id);
+      }
+    }
+
+    // Creates + updates.
+    for (const [id, entry] of next) {
+      const prior = this.owned.get(id);
+      if (!prior) {
+        // First appearance: create it (stamps createdAt/updatedAt in the shell).
+        this.shell.upsertActivity({ ...entry.input });
+        this.owned.set(id, entry);
+        continue;
+      }
+      if (!fingerprintsEqual(prior.fingerprint, entry.fingerprint)) {
+        // Changed: patch it, preserving createdAt and letting the shell emit a
+        // `transition` when the status changed. Passing the full editorial input
+        // (minus id) as the patch keeps the shell activity in exact sync.
+        const { id: _omit, ...patch } = entry.input;
+        this.shell.updateActivity(id, patch);
+        this.owned.set(id, entry);
+      }
+      // Unchanged: no shell mutation.
+    }
+  }
+
+  /**
+   * Retract exactly this feed's activities from the shell and stop reconciling.
+   * Idempotent. Activities owned by other sources are left untouched.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const id of this.owned.keys()) this.shell.removeActivity(id);
+    this.owned.clear();
+  }
+}
+
+/**
+ * Bridge a `@happyvertical/smrt-web` live collection into an AdminShell's
+ * activity registry: each mapped row becomes a {@link ShellActivity} that
+ * appears, updates, and disappears in the shell as the collection changes.
+ *
+ * MUST be called during Svelte component initialization — it delegates to
+ * {@link liveCollection} (which installs a `$effect`) and installs its own
+ * reconciliation `$effect`. Both bind to the calling component's lifecycle, so
+ * the live subscription and reconciliation tear down automatically on unmount.
+ * The returned {@link ActivityFeedHandle.dispose} additionally REMOVES the
+ * feed's activities from the shell — call it to retract them without unmounting.
+ *
+ * Lifecycle per row:
+ *  - a row that newly maps to an activity → `shell.upsertActivity(...)` (creates
+ *    it, stamping `createdAt`);
+ *  - an owned row whose mapping changes → `shell.updateActivity(id, patch)`
+ *    (preserves `createdAt`, bumps `updatedAt`, and the shell emits a
+ *    `transition` event when `status` changed — driving toasts);
+ *  - a row that vanishes, or whose mapping flips to `null` →
+ *    `shell.removeActivity(id)`.
+ *
+ * Only activities this feed created are ever touched: activities pushed to the
+ * shell by other sources (or a second feed) are left untouched, and `dispose`
+ * removes exactly this feed's set.
+ *
+ * @typeParam TData - the row DTO shape carried by {@link ActivityFeedOptions.collection}.
+ *
+ * @example
+ * ```svelte
+ * <script lang="ts">
+ *   import { activityFeed } from '@happyvertical/smrt-svelte/web';
+ *   import { useAdminShell } from '@happyvertical/smrt-svelte/workspace';
+ *   import { createSmrtCollection } from '@happyvertical/smrt-web';
+ *   import { getCollectionDefinition } from '@happyvertical/smrt-virt-web';
+ *
+ *   const shell = useAdminShell();
+ *   const encodes = createSmrtCollection(getCollectionDefinition('encodes'), {});
+ *
+ *   // Reconciles `encodes` rows into the shell's Focus scope; disposes on unmount.
+ *   activityFeed({
+ *     collection: encodes,
+ *     shell,
+ *     map: (row) => ({
+ *       kind: 'video-encode',
+ *       scope: 'focus',
+ *       label: row.title,
+ *       status: row.state,          // 'running' | 'completed' | …
+ *       progress: row.progress,
+ *     }),
+ *   });
+ * </script>
+ * ```
+ */
+export function activityFeed<TData extends object>(
+  options: ActivityFeedOptions<TData>,
+): ActivityFeedHandle {
+  const { collection, map, shell, preload = true } = options;
+
+  // Build the runes-reactive live view over the domain collection. This is the
+  // sole place the client-data engine is reached (through the `/web` binding),
+  // and it MUST run during component init — as must `activityFeed` itself.
+  const view = liveCollection<TData>(collection, { preload });
+
+  // The pure diff core: holds ownership + create/update/remove logic, with no
+  // reactive or engine dependency (unit-tested directly). This function just
+  // feeds it the live rows on every reactive tick.
+  const reconciler = new ActivityFeedReconciler<TData>(shell, map);
+
+  // Reconcile whenever the live rows change. `view.rows` is a `$derived`-backed
+  // reactive array; reading it inside `$effect` subscribes this effect to it, so
+  // every insert/update/delete/rollback surfaced by the live view re-reconciles.
+  // The effect binds to the hosting component and tears down on unmount.
+  $effect(() => {
+    reconciler.reconcile(view.rows);
+  });
+
+  return {
+    dispose() {
+      reconciler.dispose();
+    },
+    get isDisposed() {
+      return reconciler.isDisposed;
+    },
+  };
+}

--- a/packages/smrt-svelte/src/web/index.ts
+++ b/packages/smrt-svelte/src/web/index.ts
@@ -7,9 +7,21 @@
  * stays an implementation detail of the runtime + this binding; nothing here
  * re-exports an `@tanstack/*` type.
  *
+ * The {@link activityFeed} adapter (#1779) is layered on {@link liveCollection}
+ * to bridge a live collection into the AdminShell activity registry. It lives
+ * behind this opt-in `/web` entry — NOT under `components/workspace/` — so the
+ * AdminShell core stays transport-agnostic and TanStack-free (epic #1766).
+ *
  * @packageDocumentation
  */
 
+export {
+  type ActivityFeedHandle,
+  type ActivityFeedMap,
+  type ActivityFeedOptions,
+  activityFeed,
+  type ShellActivityInput,
+} from './activity-feed.svelte.js';
 export {
   type LiveCollection,
   type LiveCollectionMutation,


### PR DESCRIPTION
## What

AdminShell slice #1779 — a thin, opt-in **activity feed adapter** that bridges a `@happyvertical/smrt-web` live collection into the AdminShell activity registry. It is a *consumer* of already-shipped infrastructure (the `/web` `liveCollection` binding from #1761 slice A + the `ShellState` activity registry from epic #1766), not a new generated surface.

### The helper

```ts
activityFeed<TData>({ collection, map, shell, preload? }): ActivityFeedHandle
```

- `collection` — the app's `@smrt()` **domain** `SmrtWebCollection` (e.g. from `createSmrtCollection`).
- `map: (row) => ShellActivityInput | null` — the app's **editorial** map (`row → { kind, scope, label, status, progress?, subject?, … }`); `null` excludes a row (and retracts it if it flips).
- `shell` — the `ShellState` whose registry is driven.
- Returns `{ dispose(), isDisposed }` — `dispose()` removes exactly the activities this feed created.

It subscribes the collection through `liveCollection`, reactively reconciles the mapped rows against the shell, and drives:
- newly-appearing row → `shell.upsertActivity(...)` (stamps `createdAt`),
- changed row → `shell.updateActivity(id, patch)` (preserves `createdAt`; the shell emits a `transition` on status change → toasts),
- vanished / `null`-mapped row → `shell.removeActivity(id)`.

An unchanged reactive tick performs **zero** shell mutations (fingerprint diff). Must be called during component init (installs a `$effect`); the subscription tears down on unmount.

### Boundary (epic #1766)

The adapter lives behind the opt-in `./web` entry (which pulls the TanStack client-data engine) and is **never** imported under `components/workspace/`, so the AdminShell core (`./workspace`) stays transport-agnostic and TanStack-free. Its imports from `admin-shell` are `import type` only, so the compiled adapter carries **no runtime reverse-dependency** on the shell. The pure diff core, `ActivityFeedReconciler`, has no reactive/engine dependency and is unit-tested directly against a real `ShellState`.

New `/web` exports: `activityFeed`, `ActivityFeedHandle`, `ActivityFeedMap`, `ActivityFeedOptions`, `ShellActivityInput`.

## Playground demo

`playground/src/routes/admin-shell-activity-feed/+page.svelte` (own page — does not touch the shared `admin-shell/+page.svelte`). It builds a real `createSmrtCollection` over an in-memory job definition and simulates a **backend feed** using the engine collection's manual sync-write API (`writeInsert`/`writeUpdate`/`writeDelete`) — exactly how a real SSE/WebSocket feed writes into a collection. Buttons drive **start → advance (progress) → complete/fail → clear (remove)**; the mapped activities surface live in the Focus panel and the activity toasts.

## Tests

- **Reconciler unit tests** (`activity-feed.svelte.test.ts`) against a real `ShellState`: insert→upsert, status-change→update (createdAt preserved, `transition` emitted), unchanged→no-op, vanish→remove, `null`-map exclude/retract, id decoupling, scope→edge homing, dispose scoping (leaves foreign activities untouched + stops reconciling).
- **Integration tests** (`activity-feed.integration.svelte.test.ts`) through a mounted harness + real smrt-web collection (only the REST fetchers are mocked): loaded rows reconcile into activities; an optimistic insert surfaces reactively and reconciles to the server row; `dispose()` retracts.

## Validation

Run in `packages/smrt-svelte` unless noted:

- `pnpm --filter @happyvertical/smrt-svelte build` — ✅
- `pnpm --filter @happyvertical/smrt-svelte typecheck` — ✅ (`tsc --noEmit` + `svelte-check`: 0 errors / 0 warnings, 1365 files); test files type-checked separately — ✅
- Ratchets (repo root): `check-hardcoded-strings`, `check-z-index`, `check-typography`, `check-raw-primitives` — ✅ all pass
- `biome check` on all changed files — ✅ clean
- `smrt dev:knowledge-check` — ✅ fresh
- Constraint grep: `components/workspace/` has **no** new `smrt-web`/`@tanstack`/`/web` import; compiled `dist/components/workspace/` has no code reference to either — ✅
- Reconciler lifecycle validated end-to-end against the compiled `dist` (8 assertions) — ✅

> **Note on `pnpm test`:** the smrt-svelte Vitest suite currently fails to *start* in this git worktree — a pre-existing toolchain issue (`vite@8.1.2` + `rolldown@1.1.3` + Node 24 on darwin: `Could not resolve 'node:module' … Tsconfig not found`) that blocks the **entire** package suite identically (the pre-existing `Button.test.ts` and `live-collection.svelte.test.ts` both fail the same way), while non-Svelte packages (e.g. smrt-web) run fine. Not caused by this change. The new tests are authored to the package's existing harness pattern, type-check clean, and run in CI. Per repo practice, CI is the gate.

Refs #1779, #1766