### PR TITLE
feat(smrt-web): capability extension seam for client-runtime slices (#1755)

### DIFF
--- a/packages/smrt-web/AGENTS.md
+++ b/packages/smrt-web/AGENTS.md
@@ -28,6 +28,74 @@ mutations without hand-wiring cache keys or fetch/state.
   (`T[]`, `{ data }` envelopes, `{ error }` bodies → thrown
   `SmrtWebRequestError`).
 
+## The capability extension seam (#1755)
+
+`createSmrtCollection` takes an optional `capabilities: SmrtWebCapability[]` —
+plug-ins that hook the collection lifecycle so the three follow-on client slices
+(offline outbox #1762, persistence #1764, live SSE invalidation #1763-client)
+each live in their OWN module instead of contending on `index.ts`. Capabilities
+run in **array order** at six fixed points:
+
+1. `contributeCacheKey(ctx)` — ONCE, before construction. Returned segments are
+   appended to the collection's cache id/key, extending the base
+   `smrt:(scope:)name` scheme so a capability can partition the cache.
+2. `warmStart(ctx)` — ONCE, before the first read. Returns rows that seed the
+   cache (the persistence rehydrate-from-disk path). **`initialData` wins**: it
+   is the fresher same-request SSR truth, so `warmStart` is consulted only when
+   `initialData` is undefined; the FIRST capability that returns rows contributes.
+3. `wrapMutation(envelope, ctx)` — per mutation, BEFORE the fetcher. Return
+   `{ handled: true, result }` to take over the write (the fetcher is skipped and
+   `result` reconciles the optimistic row — the offline path); return
+   `{ handled: false }`/`undefined` to fall through. The FIRST `{ handled: true }`
+   wins and later capabilities' `wrapMutation` are skipped (`runWrapMutation`).
+4. `onSettled(envelope, outcome, ctx)` — per mutation, after it settles, on BOTH
+   a successful persist (`{ ok: true, result }`) AND a fetcher throw
+   (`{ ok: false, error }`). Never swallows the throw — a rejected fetcher still
+   rolls the optimistic state back.
+5. `onAttach(ctx)` — ONCE, right after the engine collection is constructed. The
+   ONLY place a capability wires an external (non-mutation) trigger such as an
+   SSE subscription; `ctx.invalidate()` enters the same relationship-derived
+   invalidation the factory runs post-mutation.
+6. `teardown(ctx)` — inside `cleanup()`, AFTER the engine's own cleanup; awaited
+   if async.
+
+The context (`SmrtWebCapabilityContext`) and mutation envelope
+(`SmrtWebMutationEnvelope`) are typed **entirely in SMRT-owned terms**
+(`SmrtWebCollectionDefinition`, `SmrtCrudFetchers`, `SmrtWebRow`, plain TS) — no
+`@tanstack/*` type, so the seam stays inside the engine boundary. A capability
+needing deeper engine access reaches it through the existing
+`getEngineCollection()` unknown-bridge from its own module, never by widening
+these types.
+
+**No-op guarantee.** With `capabilities` undefined or `[]` every code path is
+byte-for-byte the collection of today: zero contributeCacheKey/warmStart/
+onAttach/teardown calls, `wrapMutation` always falls through to the real
+fetcher, `onSettled` runs nothing, and relationship-derived invalidation fires
+exactly as before. This PR ships the plug-in point and the shared durable-store
+foundation but **zero concrete capabilities** by design.
+
+### Shared durable-store foundation (#1755)
+
+`durable-store.ts` is the ONE SMRT-layer namespacing + wipe registry both the
+future outbox (#1762) and persistence (#1764) slices build on — pure
+bookkeeping, ZERO `@tanstack/*` imports.
+
+- `durableStoreNamespace(key)` — deterministic
+  `smrt-web:${apiBase}:${tenantId ?? '-'}:${identityId ?? '-'}:${manifestHash}`,
+  so a logout, tenant switch, or schema change each land on a different
+  namespace (`manifestHash` source is #1764's call; this layer is source-agnostic).
+- `registerDurableResource(namespace, resource)` → unregister; `wipeDurableStore(namespace)`
+  clears every registered `DurableResource` under a namespace (best-effort — a
+  rejected `clear()` doesn't abort the sweep) then drops it; a safe no-op on an
+  unknown/empty namespace.
+
+Rationale: TanStack DB persistence (SQLite-WASM/OPFS) and
+`@tanstack/offline-transactions` (IndexedDB) are **separate storage engines**,
+so the shared foundation lives one level up — each slice keys its own TanStack
+primitive under a shared namespace, and `wipe()` clears both through the registry
+without the two modules importing each other. Nothing calls this yet; it ships
+ahead of its consumers so #1762/#1764 agree on it from day one.
+
 ## The engine-absorption boundary (ratified conditions, #1761)
 
 1. **No engine types in the public API.** `@tanstack/*` types must never appear

--- a/packages/smrt-web/AGENTS.md
+++ b/packages/smrt-web/AGENTS.md
@@ -36,18 +36,36 @@ plug-ins that hook the collection lifecycle so the three follow-on client slices
 each live in their OWN module instead of contending on `index.ts`. Capabilities
 run in **array order** at six fixed points:
 
-1. `contributeCacheKey(ctx)` — ONCE, before construction. Returned segments are
-   appended to the collection's cache id/key, extending the base
-   `smrt:(scope:)name` scheme so a capability can partition the cache.
+1. `contributeCacheKey(ctx)` — ONCE, before construction. Returned segments
+   extend the base `smrt:(scope:)name` scheme so a capability can partition the
+   cache. Segments are spliced into the queryKey **just before the collection
+   name, so the name stays the LAST segment** — `invalidateRelated()`'s predicate
+   (and thus relationship-derived invalidation #1761 and a capability's own
+   `ctx.invalidate()`) identifies a collection by `key[key.length - 1]`, so a
+   name-last key is required or a collection using this hook would silently stop
+   invalidating. `cacheId` is an opaque engine id the predicate never reads, so it
+   appends.
 2. `warmStart(ctx)` — ONCE, before the first read. Returns rows that seed the
    cache (the persistence rehydrate-from-disk path). **`initialData` wins**: it
    is the fresher same-request SSR truth, so `warmStart` is consulted only when
    `initialData` is undefined; the FIRST capability that returns rows contributes.
+   A **sync** return seeds inline; an **async** return is captured and
+   `SmrtWebCollection.preload()` AWAITS it before the engine's own load, so an
+   async rehydrate reliably suppresses the first `list()` on the preload path (a
+   subscribe-driven read racing an unresolved warmStart may still fetch once —
+   bounded, self-heals via the atomic seed updater).
 3. `wrapMutation(envelope, ctx)` — per mutation, BEFORE the fetcher. Return
    `{ handled: true, result }` to take over the write (the fetcher is skipped and
    `result` reconciles the optimistic row — the offline path); return
    `{ handled: false }`/`undefined` to fall through. The FIRST `{ handled: true }`
    wins and later capabilities' `wrapMutation` are skipped (`runWrapMutation`).
+   When a write is handled offline, the engine's post-mutation refetch AND
+   `invalidateRelated()` are **suppressed** (the handler returns `{ refetch:
+   false }`) — the offline write never hit the server, so a refetch of the server
+   list would DROP the optimistic row #1762's outbox must keep until it replays.
+   A mixed batch is conservative: any handled mutation suppresses the whole
+   handler's refetch (common case is one mutation per transaction). An unhandled
+   write refetches/invalidates exactly as before the seam.
 4. `onSettled(envelope, outcome, ctx)` — per mutation, after it settles, on BOTH
    a successful persist (`{ ok: true, result }`) AND a fetcher throw
    (`{ ok: false, error }`). Never swallows the throw — a rejected fetcher still
@@ -58,6 +76,14 @@ run in **array order** at six fixed points:
    invalidation the factory runs post-mutation.
 6. `teardown(ctx)` — inside `cleanup()`, AFTER the engine's own cleanup; awaited
    if async.
+
+**Hook error isolation.** Every hook invocation is wrapped so one misbehaving
+capability cannot break the collection: a throwing `contributeCacheKey`,
+`warmStart` (sync throw or async reject), `onSettled`, `onAttach`, or `teardown`
+is logged via `console.warn` and skipped — a successful mutation still commits
+(no rollback), construction still completes, `cleanup()` still resolves, later
+capabilities' hooks still run, and an async warmStart rejection never escapes as
+an unhandled rejection.
 
 The context (`SmrtWebCapabilityContext`) and mutation envelope
 (`SmrtWebMutationEnvelope`) are typed **entirely in SMRT-owned terms**

--- a/packages/smrt-web/src/capability-integration.test.ts
+++ b/packages/smrt-web/src/capability-integration.test.ts
@@ -14,7 +14,7 @@
  * it received the contract-specified arguments.
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   createSmrtCollection,
   createSmrtWebClient,
@@ -272,12 +272,15 @@ describe('capability seam — contributeCacheKey', () => {
     // capability does not observe its own not-yet-applied segment.
     expect(contrib[0].cacheId).toBe('smrt:contrib');
     // But once every contribution is folded in, the ctx (captured in onAttach,
-    // which runs after construction) exposes the FINAL cache id/key.
+    // which runs after construction) exposes the FINAL cache id/key. Contributed
+    // segments are spliced in BEFORE the collection name so the name stays LAST
+    // in the queryKey — the invariant invalidateRelated()'s predicate relies on.
+    // cacheId is an opaque engine id (predicate never reads it) so it appends.
     expect(attachedCtx?.cacheId).toBe('smrt:contrib:variant-x');
     expect([...(attachedCtx?.cacheKey ?? [])]).toEqual([
       'smrt',
-      'contrib',
       'variant-x',
+      'contrib',
     ]);
 
     await collection.preload();
@@ -385,7 +388,7 @@ describe('capability seam — wrapMutation', () => {
     tracked.length = 0;
   });
 
-  it('{ handled: true } takes over the write — the fetcher is NEVER called and the optimistic row reconciles from result', async () => {
+  it('{ handled: true } takes over the write — the fetcher is NEVER called and the offline optimistic row is KEPT (not dropped by a post-mutation refetch)', async () => {
     const calls: HookCall[] = [];
     const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
     const capability = makeFakeCapability(calls, {
@@ -403,6 +406,7 @@ describe('capability seam — wrapMutation', () => {
       }),
     );
     await collection.preload();
+    const listAfterPreload = scripted.calls.list;
 
     const localId = newLocalId();
     const tx = collection.insert({ id: localId, name: 'Gadget', price: 5 });
@@ -419,6 +423,16 @@ describe('capability seam — wrapMutation', () => {
     // result), proving the handler's { result } flowed through the settle path.
     const settle = calls.find((c) => c.hook === 'onSettled');
     expect(settle?.settleOk).toBe(true);
+
+    // Fix B: an offline (handled) write never hit the server, so the engine's
+    // post-mutation refetch AND invalidateRelated() are suppressed — no extra
+    // list() fired. Give any (erroneous) refetch time to land, then confirm the
+    // offline row is STILL present (it would be dropped if the server list, which
+    // lacks it, had been refetched). This is what #1762's outbox depends on.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(scripted.calls.list).toBe(listAfterPreload);
+    expect(collection.has(localId)).toBe(true);
+    expect(collection.get(localId)?.name).toBe('Gadget');
   });
 
   it('{ handled: false } falls through to the real fetcher', async () => {
@@ -436,6 +450,7 @@ describe('capability seam — wrapMutation', () => {
       }),
     );
     await collection.preload();
+    const listAfterPreload = scripted.calls.list;
 
     const tx = collection.insert({ id: newLocalId(), name: 'Gadget' });
     await tx.isPersisted.promise;
@@ -444,6 +459,11 @@ describe('capability seam — wrapMutation', () => {
     expect(scripted.calls.create).toBe(1);
     expect(calls.filter((c) => c.hook === 'wrapMutation')).toHaveLength(1);
     expect(collection.toArray.some((r) => r.name === 'Gadget')).toBe(true);
+    // Fix B no-op side: an UNHANDLED write behaves exactly as before the seam —
+    // the engine's post-mutation refetch still runs, so a further list() fired
+    // (the row reconciles to its server id via that refetch).
+    await waitFor(() => scripted.calls.list > listAfterPreload);
+    expect(scripted.calls.list).toBeGreaterThan(listAfterPreload);
   });
 
   it('with two capabilities the FIRST { handled: true } wins and the later one is skipped', async () => {
@@ -619,5 +639,298 @@ describe('capability seam — teardown', () => {
     // A second cleanup() runs teardown again (idempotent from the seam's view —
     // it mirrors the engine's own cleanup being callable), but the common path
     // is a single cleanup; assert the single-call contract above holds.
+  });
+});
+
+// A capability that only contributes a cache-key segment (mirrors #1764
+// persistence keying its cache by a manifest hash) — the exact shape that
+// exercised the name-last invariant.
+function cacheKeyCapability(segment: string): SmrtWebCapability<object> {
+  return {
+    name: `key-${segment}`,
+    contributeCacheKey: () => [segment],
+  };
+}
+
+describe('capability seam — contributeCacheKey preserves relationship invalidation (Fix A)', () => {
+  const tracked: SmrtWebCollection<object>[] = [];
+  const track = <T extends object>(c: SmrtWebCollection<T>) => {
+    tracked.push(c as unknown as SmrtWebCollection<object>);
+    return c;
+  };
+  afterEach(async () => {
+    await Promise.all(tracked.map((c) => c.cleanup()));
+    tracked.length = 0;
+  });
+
+  interface CommentData {
+    id?: string;
+    body: string;
+    articleId?: string;
+  }
+  interface ArticleData {
+    id?: string;
+    title: string;
+  }
+
+  const commentsDefinition = (): SmrtWebCollectionDefinition<CommentData> => ({
+    name: 'comments',
+    className: 'Comment',
+    endpoint: '/comments',
+    idField: 'id',
+    actions: ['create', 'delete', 'get', 'list', 'update'],
+    fields: { body: { type: 'text', required: true } },
+    relationships: [
+      { field: 'articleId', kind: 'foreignKey', relatedCollection: 'articles' },
+    ],
+  });
+  const articlesDefinition = (): SmrtWebCollectionDefinition<ArticleData> => ({
+    name: 'articles',
+    className: 'Article',
+    endpoint: '/articles',
+    idField: 'id',
+    actions: ['create', 'delete', 'get', 'list', 'update'],
+    fields: { title: { type: 'text', required: true } },
+    relationships: [],
+  });
+
+  it('a collection using contributeCacheKey still self-invalidates after its OWN mutation', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const collection = track(
+      createSmrtCollection(productDefinition('self-inval'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        // A contributed segment means the queryKey is now
+        // ['smrt', 'mh', 'self-inval'] — name still LAST, so the predicate
+        // matches and the collection refetches itself after a settled mutation.
+        capabilities: [cacheKeyCapability('mh')],
+      }),
+    );
+
+    const sub = collection.subscribeChanges(() => {});
+    await collection.preload();
+    expect(scripted.calls.list).toBe(1);
+
+    const tx = collection.insert({ id: newLocalId(), name: 'Gadget' });
+    await tx.isPersisted.promise;
+
+    // Self-invalidation fired => a second list() (would NOT happen if the
+    // contributed segment had been appended after the name, hiding it from the
+    // predicate — the bug Fix A closes).
+    await waitFor(() => scripted.calls.list >= 2);
+    expect(scripted.calls.list).toBeGreaterThanOrEqual(2);
+    sub.unsubscribe();
+  });
+
+  it('a RELATED collection using contributeCacheKey is invalidated when its relation mutates', async () => {
+    const client = createSmrtWebClient();
+    const commentsBackend = makeScriptedFetchers([
+      { id: 'c1', body: 'first', articleId: 'a1' },
+    ]);
+    const articlesBackend = makeScriptedFetchers([
+      { id: 'a1', title: 'Hello' },
+    ]);
+
+    // BOTH collections carry a contributeCacheKey (persistence-keyed). comments
+    // edges to articles; a settled comments mutation must still reach the
+    // articles cache — only possible because 'articles' stays the LAST segment
+    // of the articles queryKey ['smrt', 'mh', 'articles'].
+    const comments = track(
+      createSmrtCollection(commentsDefinition(), {
+        fetchers: commentsBackend.fetchers,
+        client,
+        staleTimeMs: 60_000,
+        capabilities: [cacheKeyCapability('mh')],
+      }),
+    );
+    const articles = track(
+      createSmrtCollection(articlesDefinition(), {
+        fetchers: articlesBackend.fetchers,
+        client,
+        staleTimeMs: 60_000,
+        capabilities: [cacheKeyCapability('mh')],
+      }),
+    );
+
+    const articlesSub = articles.subscribeChanges(() => {});
+    await Promise.all([comments.preload(), articles.preload()]);
+    expect(articlesBackend.calls.list).toBe(1);
+
+    const tx = comments.insert({
+      id: newLocalId(),
+      body: 'second',
+      articleId: 'a1',
+    });
+    await tx.isPersisted.promise;
+
+    await waitFor(() => articlesBackend.calls.list >= 2);
+    expect(articlesBackend.calls.list).toBeGreaterThanOrEqual(2);
+    articlesSub.unsubscribe();
+  });
+});
+
+describe('capability seam — hook error isolation (Fix C)', () => {
+  const tracked: SmrtWebCollection<object>[] = [];
+  const track = <T extends object>(c: SmrtWebCollection<T>) => {
+    tracked.push(c as unknown as SmrtWebCollection<object>);
+    return c;
+  };
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  afterEach(async () => {
+    await Promise.all(tracked.map((c) => c.cleanup()));
+    tracked.length = 0;
+    warnSpy.mockClear();
+  });
+
+  it('a throwing onSettled does not reject a SUCCESSFUL mutation, and later capabilities still run', async () => {
+    const calls: HookCall[] = [];
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const thrower: SmrtWebCapability<ProductData> = {
+      name: 'bad-settle',
+      onSettled() {
+        throw new Error('onSettled boom');
+      },
+    };
+    const good = makeFakeCapability(calls, { name: 'good' });
+
+    const collection = track(
+      createSmrtCollection(productDefinition('iso-settle'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [thrower, good],
+      }),
+    );
+    await collection.preload();
+
+    const localId = newLocalId();
+    const tx = collection.insert({ id: localId, name: 'Gadget' });
+    // The successful mutation still commits — the throwing onSettled did not
+    // reject the transaction nor roll the row back.
+    await tx.isPersisted.promise;
+    expect(scripted.calls.create).toBe(1);
+    // The later (good) capability's onSettled still fired despite the earlier
+    // throw.
+    expect(good).toBeDefined();
+    expect(calls.filter((c) => c.hook === 'onSettled')).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('a throwing onAttach does not break construction, and later capabilities still attach', async () => {
+    const calls: HookCall[] = [];
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const thrower: SmrtWebCapability<ProductData> = {
+      name: 'bad-attach',
+      onAttach() {
+        throw new Error('onAttach boom');
+      },
+    };
+    const good = makeFakeCapability(calls, { name: 'good' });
+
+    // Construction must not throw even though the first capability's onAttach does.
+    const collection = track(
+      createSmrtCollection(productDefinition('iso-attach'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [thrower, good],
+      }),
+    );
+    expect(collection).toBeDefined();
+    // The later capability still attached.
+    expect(calls.filter((c) => c.hook === 'onAttach')).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalled();
+    await collection.preload();
+    expect(collection.size).toBe(1);
+  });
+
+  it('a rejecting teardown does not skip later teardowns nor reject cleanup()', async () => {
+    const calls: HookCall[] = [];
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const thrower: SmrtWebCapability<ProductData> = {
+      name: 'bad-teardown',
+      teardown() {
+        return Promise.reject(new Error('teardown boom'));
+      },
+    };
+    const good: SmrtWebCapability<ProductData> = {
+      name: 'good-teardown',
+      teardown() {
+        calls.push({ hook: 'teardown' });
+      },
+    };
+
+    const collection = createSmrtCollection(productDefinition('iso-teardown'), {
+      fetchers: scripted.fetchers,
+      staleTimeMs: 60_000,
+      capabilities: [thrower, good],
+    });
+    await collection.preload();
+
+    // cleanup() resolves despite the rejecting teardown, and the later teardown
+    // still ran.
+    await expect(collection.cleanup()).resolves.toBeUndefined();
+    expect(calls.filter((c) => c.hook === 'teardown')).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('a rejecting async warmStart does not surface as an unhandled rejection and does not break the read', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'from-server' }]);
+    const capability: SmrtWebCapability<ProductData> = {
+      name: 'bad-warm',
+      warmStart: () => Promise.reject(new Error('warmStart boom')),
+    };
+
+    const collection = track(
+      createSmrtCollection(productDefinition('iso-warm'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [capability],
+      }),
+    );
+
+    // preload() gates on the (rejecting) warmStart, which is caught internally,
+    // then falls through to a normal fetch — the read still works.
+    await collection.preload();
+    expect(collection.get('p1')?.name).toBe('from-server');
+    expect(scripted.calls.list).toBe(1);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe('capability seam — async warmStart suppresses the first read (Fix D)', () => {
+  const tracked: SmrtWebCollection<object>[] = [];
+  const track = <T extends object>(c: SmrtWebCollection<T>) => {
+    tracked.push(c as unknown as SmrtWebCollection<object>);
+    return c;
+  };
+  afterEach(async () => {
+    await Promise.all(tracked.map((c) => c.cleanup()));
+    tracked.length = 0;
+  });
+
+  it('an async warmStart (resolved next tick) suppresses the first list() when the consumer awaits preload()', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'from-server' }]);
+    const capability: SmrtWebCapability<ProductData> = {
+      name: 'async-warm',
+      // Resolves a couple of microtasks later — the persistence rehydrate shape.
+      warmStart: async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        return [{ id: 'p1', name: 'from-async-warm' }];
+      },
+    };
+
+    const collection = track(
+      createSmrtCollection(productDefinition('async-warm'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [capability],
+      }),
+    );
+
+    // preload() gates the engine's own load on the pending warmStart, so the
+    // seed lands FIRST and the first read is served from it — zero list().
+    await collection.preload();
+    expect(scripted.calls.list).toBe(0);
+    expect(collection.get('p1')?.name).toBe('from-async-warm');
   });
 });

--- a/packages/smrt-web/src/capability-integration.test.ts
+++ b/packages/smrt-web/src/capability-integration.test.ts
@@ -1025,3 +1025,99 @@ describe('capability seam — async warmStart suppresses the first read (Fix D)'
     expect(collection.get('p1')?.name).toBe('from-sync');
   });
 });
+
+describe('capability seam — cleanup races async warmStart (Fix G)', () => {
+  const tracked: SmrtWebCollection<object>[] = [];
+  const track = <T extends object>(c: SmrtWebCollection<T>) => {
+    tracked.push(c as unknown as SmrtWebCollection<object>);
+    return c;
+  };
+  afterEach(async () => {
+    await Promise.all(tracked.map((c) => c.cleanup()));
+    tracked.length = 0;
+  });
+
+  /** A promise whose resolution is controlled by the test. */
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((r) => {
+      resolve = r;
+    });
+    return { promise, resolve };
+  }
+
+  it('a cleanup() that races a pending async warmStart does NOT seed the shared cache afterward (no pollution of the next collection)', async () => {
+    const client = createSmrtWebClient();
+    // Both collections share client + scope => the SAME queryKey. If the first's
+    // late warmStart seed leaks into the shared cache after cleanup, the second's
+    // real fetch would be (wrongly) suppressed.
+    const firstBackend = makeScriptedFetchers([{ id: 'p1', name: 'srv-1' }]);
+    const secondBackend = makeScriptedFetchers([{ id: 'p1', name: 'srv-2' }]);
+
+    const gate = deferred<ProductData[] | undefined>();
+    const slowWarm: SmrtWebCapability<ProductData> = {
+      name: 'slow-rehydrate',
+      warmStart: () => gate.promise,
+    };
+
+    const first = createSmrtCollection(productDefinition('products'), {
+      fetchers: firstBackend.fetchers,
+      client,
+      scope: 'shared',
+      staleTimeMs: 60_000,
+      capabilities: [slowWarm],
+    });
+
+    // Kick off preload() (gates on the pending warmStart), then tear down BEFORE
+    // the rehydrate resolves.
+    const firstPreload = first.preload();
+    await first.cleanup();
+
+    // Now the rehydrate finishes — its seed continuation must observe disposed
+    // and skip writing to the shared cache; the gated preload must skip the dead
+    // engine.
+    gate.resolve([{ id: 'p1', name: 'from-late-warm' }]);
+    await firstPreload;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    // The shared cache was NOT seeded: a fresh collection on the same key must
+    // still do its real fetch (and see ITS backend's rows, not the leaked ones).
+    const second = track(
+      createSmrtCollection(productDefinition('products'), {
+        fetchers: secondBackend.fetchers,
+        client,
+        scope: 'shared',
+        staleTimeMs: 60_000,
+      }),
+    );
+    await second.preload();
+    expect(secondBackend.calls.list).toBe(1);
+    expect(second.get('p1')?.name).toBe('srv-2');
+  });
+
+  it('a normal (non-cleaned-up) async warmStart still seeds — no regression from the disposed guard', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'from-server' }]);
+    const gate = deferred<ProductData[] | undefined>();
+    const capability: SmrtWebCapability<ProductData> = {
+      name: 'async-warm',
+      warmStart: () => gate.promise,
+    };
+
+    const collection = track(
+      createSmrtCollection(productDefinition('fixg-control'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [capability],
+      }),
+    );
+
+    const preloadDone = collection.preload();
+    // Resolve the rehydrate while the collection is still alive.
+    gate.resolve([{ id: 'p1', name: 'from-warm' }]);
+    await preloadDone;
+
+    // Seeded => first list() suppressed, warm rows served.
+    expect(scripted.calls.list).toBe(0);
+    expect(collection.get('p1')?.name).toBe('from-warm');
+  });
+});

--- a/packages/smrt-web/src/capability-integration.test.ts
+++ b/packages/smrt-web/src/capability-integration.test.ts
@@ -1,0 +1,623 @@
+/**
+ * Integration tests for the capability seam wired into createSmrtCollection
+ * (#1755).
+ *
+ * Same harness as collection.test.ts / invalidation.test.ts: per the repo
+ * mocking policy only the network boundary (the generated REST fetchers) is
+ * mocked — the client-data engine collection, its query cache, transactions,
+ * and live state are all REAL. Fire-and-forget effects (invalidation) are
+ * awaited with a microtask poll, never a fixed sleep.
+ *
+ * The central fixture is a `FakeCapability` implementing all six hooks and
+ * recording each firing (with the salient ctx values) into a `calls[]` log, so
+ * every test asserts BOTH that a hook fired the right number of times and that
+ * it received the contract-specified arguments.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createSmrtCollection,
+  createSmrtWebClient,
+  newLocalId,
+  type SmrtCrudFetchers,
+  type SmrtWebCapability,
+  type SmrtWebCapabilityContext,
+  type SmrtWebCollection,
+  type SmrtWebCollectionDefinition,
+  type SmrtWebMutationEnvelope,
+} from './index.js';
+
+interface ProductData {
+  id?: string;
+  name: string;
+  price?: number;
+}
+
+function productDefinition(
+  name: string,
+): SmrtWebCollectionDefinition<ProductData> {
+  return {
+    name,
+    className: 'Product',
+    endpoint: `/${name}`,
+    idField: 'id',
+    actions: ['create', 'delete', 'get', 'list', 'update'],
+    fields: {
+      name: { type: 'text', required: true },
+      price: { type: 'decimal' },
+    },
+  };
+}
+
+/**
+ * A scripted stand-in for `createClient('/api/v1').products`. Resolves the way
+ * the generated fetchers do (JSON payloads, never rejects on HTTP errors) and
+ * counts calls. `pushServerRow` mutates the backing store so a later `list()` —
+ * e.g. one triggered by a manual `ctx.invalidate()` — observably returns more
+ * rows.
+ */
+function makeScriptedFetchers(initialRows: Array<Record<string, unknown>>) {
+  const serverRows = [...initialRows];
+  const calls = { list: 0, create: 0, update: 0, delete: 0 };
+  let failNextCreate: string | null = null;
+
+  const fetchers: SmrtCrudFetchers = {
+    list: async () => {
+      calls.list += 1;
+      return serverRows.map((row) => ({ ...row }));
+    },
+    create: async (data) => {
+      calls.create += 1;
+      if (failNextCreate) {
+        const error = failNextCreate;
+        failNextCreate = null;
+        return { error };
+      }
+      const created = { ...data, id: `server-${serverRows.length + 1}` };
+      serverRows.push(created);
+      return { ...created };
+    },
+    update: async (id, data) => {
+      calls.update += 1;
+      return { ...data, id };
+    },
+    delete: async () => {
+      calls.delete += 1;
+      return true;
+    },
+  };
+
+  return {
+    fetchers,
+    calls,
+    failCreateWith(message: string) {
+      failNextCreate = message;
+    },
+    pushServerRow(row: Record<string, unknown>) {
+      serverRows.push(row);
+    },
+  };
+}
+
+/** One recorded hook firing. */
+interface HookCall {
+  hook:
+    | 'contributeCacheKey'
+    | 'warmStart'
+    | 'wrapMutation'
+    | 'onSettled'
+    | 'onAttach'
+    | 'teardown';
+  cacheId?: string;
+  cacheKey?: readonly string[];
+  envelope?: SmrtWebMutationEnvelope;
+  settleOk?: boolean;
+  listCallsAtFire?: number;
+}
+
+/**
+ * Build a FakeCapability that logs every hook firing into `calls`. Options tune
+ * the two hooks with a return contract: `cacheKeySegments` (contributeCacheKey)
+ * and `warmRows` (warmStart). `wrap` decides wrapMutation's outcome per call.
+ */
+function makeFakeCapability(
+  calls: HookCall[],
+  opts: {
+    name?: string;
+    cacheKeySegments?: string[];
+    warmRows?: ProductData[];
+    wrap?: (
+      envelope: SmrtWebMutationEnvelope,
+    ) => { handled: true; result: unknown } | { handled: false };
+    listCounter?: { list: number };
+    onAttachCtx?: (ctx: SmrtWebCapabilityContext<ProductData>) => void;
+  } = {},
+): SmrtWebCapability<ProductData> {
+  return {
+    name: opts.name ?? 'fake',
+    contributeCacheKey(ctx) {
+      calls.push({
+        hook: 'contributeCacheKey',
+        cacheId: ctx.cacheId,
+        cacheKey: [...ctx.cacheKey],
+        listCallsAtFire: opts.listCounter?.list,
+      });
+      return opts.cacheKeySegments;
+    },
+    warmStart(ctx) {
+      calls.push({
+        hook: 'warmStart',
+        cacheId: ctx.cacheId,
+        listCallsAtFire: opts.listCounter?.list,
+      });
+      return opts.warmRows;
+    },
+    wrapMutation(envelope) {
+      calls.push({
+        hook: 'wrapMutation',
+        envelope,
+        listCallsAtFire: opts.listCounter?.list,
+      });
+      return opts.wrap ? opts.wrap(envelope) : { handled: false };
+    },
+    onSettled(envelope, outcome) {
+      calls.push({ hook: 'onSettled', envelope, settleOk: outcome.ok });
+    },
+    onAttach(ctx) {
+      calls.push({ hook: 'onAttach', cacheId: ctx.cacheId });
+      opts.onAttachCtx?.(ctx);
+    },
+    teardown() {
+      calls.push({ hook: 'teardown' });
+    },
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  { tries = 50 }: { tries?: number } = {},
+): Promise<void> {
+  for (let i = 0; i < tries; i += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  if (!predicate()) throw new Error('waitFor: predicate never became true');
+}
+
+describe('capability seam — no-op guarantee', () => {
+  const tracked: SmrtWebCollection<object>[] = [];
+  const track = <T extends object>(c: SmrtWebCollection<T>) => {
+    tracked.push(c as unknown as SmrtWebCollection<object>);
+    return c;
+  };
+  afterEach(async () => {
+    await Promise.all(tracked.map((c) => c.cleanup()));
+    tracked.length = 0;
+  });
+
+  it('an empty capabilities array is identical to passing none', async () => {
+    const withNone = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const withEmpty = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+
+    const a = track(
+      createSmrtCollection(productDefinition('noop-none'), {
+        fetchers: withNone.fetchers,
+        staleTimeMs: 60_000,
+      }),
+    );
+    const b = track(
+      createSmrtCollection(productDefinition('noop-empty'), {
+        fetchers: withEmpty.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [],
+      }),
+    );
+
+    await Promise.all([a.preload(), b.preload()]);
+    expect(withNone.calls.list).toBe(withEmpty.calls.list);
+
+    // A create still calls the real fetcher exactly once on both, reconciles to
+    // the server id, and rolls nothing back — the pre-seam behavior.
+    const [txA, txB] = [
+      a.insert({ id: newLocalId(), name: 'Gadget' }),
+      b.insert({ id: newLocalId(), name: 'Gadget' }),
+    ];
+    await Promise.all([txA.isPersisted.promise, txB.isPersisted.promise]);
+
+    expect(withEmpty.calls.create).toBe(withNone.calls.create);
+    expect(withEmpty.calls.create).toBe(1);
+    expect(b.toArray.map((r) => r.name).sort()).toEqual(
+      a.toArray.map((r) => r.name).sort(),
+    );
+  });
+});
+
+describe('capability seam — contributeCacheKey', () => {
+  const tracked: SmrtWebCollection<object>[] = [];
+  const track = <T extends object>(c: SmrtWebCollection<T>) => {
+    tracked.push(c as unknown as SmrtWebCollection<object>);
+    return c;
+  };
+  afterEach(async () => {
+    await Promise.all(tracked.map((c) => c.cleanup()));
+    tracked.length = 0;
+  });
+
+  it('fires once BEFORE any network request and extends the FINAL cache id/key', async () => {
+    const calls: HookCall[] = [];
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    let attachedCtx: SmrtWebCapabilityContext<ProductData> | undefined;
+    const capability = makeFakeCapability(calls, {
+      cacheKeySegments: ['variant-x'],
+      listCounter: scripted.calls,
+      onAttachCtx: (ctx) => {
+        attachedCtx = ctx;
+      },
+    });
+
+    const collection = track(
+      createSmrtCollection(productDefinition('contrib'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [capability],
+      }),
+    );
+
+    const contrib = calls.filter((c) => c.hook === 'contributeCacheKey');
+    // Fired exactly once, and before construction => before any list().
+    expect(contrib).toHaveLength(1);
+    expect(contrib[0].listCallsAtFire).toBe(0);
+    expect(scripted.calls.list).toBe(0);
+    // Mid-contribution the ctx still shows the pre-fold (base) key — a
+    // capability does not observe its own not-yet-applied segment.
+    expect(contrib[0].cacheId).toBe('smrt:contrib');
+    // But once every contribution is folded in, the ctx (captured in onAttach,
+    // which runs after construction) exposes the FINAL cache id/key.
+    expect(attachedCtx?.cacheId).toBe('smrt:contrib:variant-x');
+    expect([...(attachedCtx?.cacheKey ?? [])]).toEqual([
+      'smrt',
+      'contrib',
+      'variant-x',
+    ]);
+
+    await collection.preload();
+    expect(scripted.calls.list).toBe(1);
+  });
+
+  it('a differing contributeCacheKey partitions the cache under one shared client', async () => {
+    const calls: HookCall[] = [];
+    const client = createSmrtWebClient();
+    const backendX = makeScriptedFetchers([{ id: 'p1', name: 'from-X' }]);
+    const backendY = makeScriptedFetchers([{ id: 'p1', name: 'from-Y' }]);
+
+    // Same definition.name, one shared client, but distinct contributed
+    // segments — the caches must NOT collide (each fetches its own backend).
+    const collX = track(
+      createSmrtCollection(productDefinition('products'), {
+        fetchers: backendX.fetchers,
+        client,
+        staleTimeMs: 60_000,
+        capabilities: [makeFakeCapability(calls, { cacheKeySegments: ['x'] })],
+      }),
+    );
+    const collY = track(
+      createSmrtCollection(productDefinition('products'), {
+        fetchers: backendY.fetchers,
+        client,
+        staleTimeMs: 60_000,
+        capabilities: [makeFakeCapability(calls, { cacheKeySegments: ['y'] })],
+      }),
+    );
+
+    await Promise.all([collX.preload(), collY.preload()]);
+
+    expect(collX.get('p1')?.name).toBe('from-X');
+    expect(collY.get('p1')?.name).toBe('from-Y');
+    expect(backendX.calls.list).toBe(1);
+    expect(backendY.calls.list).toBe(1);
+  });
+});
+
+describe('capability seam — warmStart', () => {
+  const tracked: SmrtWebCollection<object>[] = [];
+  const track = <T extends object>(c: SmrtWebCollection<T>) => {
+    tracked.push(c as unknown as SmrtWebCollection<object>);
+    return c;
+  };
+  afterEach(async () => {
+    await Promise.all(tracked.map((c) => c.cleanup()));
+    tracked.length = 0;
+  });
+
+  it('suppresses the first list() by seeding the cache, like initialData', async () => {
+    const calls: HookCall[] = [];
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'from-server' }]);
+    const capability = makeFakeCapability(calls, {
+      warmRows: [{ id: 'p1', name: 'from-warm' }],
+    });
+
+    const collection = track(
+      createSmrtCollection(productDefinition('warm'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [capability],
+      }),
+    );
+
+    await collection.preload();
+    // Seeded from warmStart => no first-render fetch, and the warm rows served.
+    expect(scripted.calls.list).toBe(0);
+    expect(collection.get('p1')?.name).toBe('from-warm');
+    expect(calls.filter((c) => c.hook === 'warmStart')).toHaveLength(1);
+  });
+
+  it('initialData WINS over warmStart when both are supplied', async () => {
+    const calls: HookCall[] = [];
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'from-server' }]);
+    const capability = makeFakeCapability(calls, {
+      warmRows: [{ id: 'p1', name: 'from-warm' }],
+    });
+
+    const collection = track(
+      createSmrtCollection(productDefinition('warm-vs-initial'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        initialData: [{ id: 'p1', name: 'from-initial' }],
+        capabilities: [capability],
+      }),
+    );
+
+    await collection.preload();
+    expect(scripted.calls.list).toBe(0);
+    // initialData is the fresher same-request SSR truth => it wins.
+    expect(collection.get('p1')?.name).toBe('from-initial');
+  });
+});
+
+describe('capability seam — wrapMutation', () => {
+  const tracked: SmrtWebCollection<object>[] = [];
+  const track = <T extends object>(c: SmrtWebCollection<T>) => {
+    tracked.push(c as unknown as SmrtWebCollection<object>);
+    return c;
+  };
+  afterEach(async () => {
+    await Promise.all(tracked.map((c) => c.cleanup()));
+    tracked.length = 0;
+  });
+
+  it('{ handled: true } takes over the write — the fetcher is NEVER called and the optimistic row reconciles from result', async () => {
+    const calls: HookCall[] = [];
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const capability = makeFakeCapability(calls, {
+      wrap: () => ({
+        handled: true,
+        result: { id: 'offline-1', name: 'Gadget', price: 5 },
+      }),
+    });
+
+    const collection = track(
+      createSmrtCollection(productDefinition('wrap-handled'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [capability],
+      }),
+    );
+    await collection.preload();
+
+    const localId = newLocalId();
+    const tx = collection.insert({ id: localId, name: 'Gadget', price: 5 });
+    // Optimistic row is visible synchronously, from the handler's stand-in path.
+    expect(collection.has(localId)).toBe(true);
+
+    // The write settles WITHOUT rejection (no rollback) — the handler's result
+    // stood in for the fetcher — and the real create fetcher was never called.
+    // (A reject here would fail the test.)
+    await tx.isPersisted.promise;
+    expect(scripted.calls.create).toBe(0);
+    expect(calls.filter((c) => c.hook === 'wrapMutation')).toHaveLength(1);
+    // onSettled recorded a success carrying the handler result (not a fetcher
+    // result), proving the handler's { result } flowed through the settle path.
+    const settle = calls.find((c) => c.hook === 'onSettled');
+    expect(settle?.settleOk).toBe(true);
+  });
+
+  it('{ handled: false } falls through to the real fetcher', async () => {
+    const calls: HookCall[] = [];
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const capability = makeFakeCapability(calls, {
+      wrap: () => ({ handled: false }),
+    });
+
+    const collection = track(
+      createSmrtCollection(productDefinition('wrap-decline'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [capability],
+      }),
+    );
+    await collection.preload();
+
+    const tx = collection.insert({ id: newLocalId(), name: 'Gadget' });
+    await tx.isPersisted.promise;
+
+    // Declined => the real create fetcher ran, exactly once.
+    expect(scripted.calls.create).toBe(1);
+    expect(calls.filter((c) => c.hook === 'wrapMutation')).toHaveLength(1);
+    expect(collection.toArray.some((r) => r.name === 'Gadget')).toBe(true);
+  });
+
+  it('with two capabilities the FIRST { handled: true } wins and the later one is skipped', async () => {
+    const calls: HookCall[] = [];
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const first = makeFakeCapability(calls, {
+      name: 'first',
+      wrap: () => ({ handled: true, result: { id: 'by-first', name: 'X' } }),
+    });
+    const second = makeFakeCapability(calls, {
+      name: 'second',
+      wrap: () => ({ handled: true, result: { id: 'by-second', name: 'X' } }),
+    });
+
+    const collection = track(
+      createSmrtCollection(productDefinition('wrap-order'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [first, second],
+      }),
+    );
+    await collection.preload();
+
+    const tx = collection.insert({ id: newLocalId(), name: 'X' });
+    await tx.isPersisted.promise;
+
+    // The fetcher never ran; only the FIRST capability's wrapMutation fired.
+    expect(scripted.calls.create).toBe(0);
+    const wraps = calls.filter((c) => c.hook === 'wrapMutation');
+    expect(wraps).toHaveLength(1);
+  });
+});
+
+describe('capability seam — onSettled', () => {
+  const tracked: SmrtWebCollection<object>[] = [];
+  const track = <T extends object>(c: SmrtWebCollection<T>) => {
+    tracked.push(c as unknown as SmrtWebCollection<object>);
+    return c;
+  };
+  afterEach(async () => {
+    await Promise.all(tracked.map((c) => c.cleanup()));
+    tracked.length = 0;
+  });
+
+  it('fires once with { ok: true } on a successful create', async () => {
+    const calls: HookCall[] = [];
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    const collection = track(
+      createSmrtCollection(productDefinition('settle-ok'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [makeFakeCapability(calls)],
+      }),
+    );
+    await collection.preload();
+
+    const tx = collection.insert({ id: newLocalId(), name: 'Gadget' });
+    await tx.isPersisted.promise;
+
+    const settles = calls.filter((c) => c.hook === 'onSettled');
+    expect(settles).toHaveLength(1);
+    expect(settles[0].settleOk).toBe(true);
+    expect(settles[0].envelope?.kind).toBe('insert');
+  });
+
+  it('fires once with { ok: false } when the create fetcher rejects, and the row still rolls back', async () => {
+    const calls: HookCall[] = [];
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    scripted.failCreateWith('name is reserved');
+    const collection = track(
+      createSmrtCollection(productDefinition('settle-fail'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [makeFakeCapability(calls)],
+      }),
+    );
+    await collection.preload();
+
+    const localId = newLocalId();
+    const tx = collection.insert({ id: localId, name: 'FAIL' });
+    await expect(tx.isPersisted.promise).rejects.toThrow('name is reserved');
+
+    // onSettled saw the failure; the optimistic row rolled back (rollback
+    // preserved — the seam did not swallow the throw).
+    const settles = calls.filter((c) => c.hook === 'onSettled');
+    expect(settles).toHaveLength(1);
+    expect(settles[0].settleOk).toBe(false);
+    expect(collection.has(localId)).toBe(false);
+  });
+});
+
+describe('capability seam — onAttach', () => {
+  const tracked: SmrtWebCollection<object>[] = [];
+  const track = <T extends object>(c: SmrtWebCollection<T>) => {
+    tracked.push(c as unknown as SmrtWebCollection<object>);
+    return c;
+  };
+  afterEach(async () => {
+    await Promise.all(tracked.map((c) => c.cleanup()));
+    tracked.length = 0;
+  });
+
+  it('fires once with a callable ctx.invalidate that refetches this collection', async () => {
+    const calls: HookCall[] = [];
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    let captured: SmrtWebCapabilityContext<ProductData> | undefined;
+    const capability = makeFakeCapability(calls, {
+      onAttachCtx: (ctx) => {
+        captured = ctx;
+      },
+    });
+
+    const collection = track(
+      createSmrtCollection(productDefinition('attach'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [capability],
+      }),
+    );
+
+    const attaches = calls.filter((c) => c.hook === 'onAttach');
+    expect(attaches).toHaveLength(1);
+    expect(captured).toBeDefined();
+
+    // Keep the collection live so an invalidation triggers a background refetch.
+    const sub = collection.subscribeChanges(() => {});
+    await collection.preload();
+    expect(scripted.calls.list).toBe(1);
+
+    // A server-side row appears; the capability calls ctx.invalidate() off its
+    // external trigger and the collection refetches, picking it up.
+    scripted.pushServerRow({ id: 'p2', name: 'live-added' });
+    captured?.invalidate();
+
+    await waitFor(() => scripted.calls.list >= 2);
+    expect(scripted.calls.list).toBeGreaterThanOrEqual(2);
+    await waitFor(() => collection.has('p2'));
+    expect(collection.get('p2')?.name).toBe('live-added');
+
+    sub.unsubscribe();
+  });
+});
+
+describe('capability seam — teardown', () => {
+  it('fires once per cleanup(), after the engine collection is torn down', async () => {
+    const calls: HookCall[] = [];
+    const order: string[] = [];
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
+    // Wrap teardown to record ordering relative to a live subscription: after
+    // cleanup() the engine is stopped, so a subscription callback would no
+    // longer fire. We assert teardown runs exactly once and after cleanup
+    // resolves the engine work.
+    const capability: SmrtWebCapability<ProductData> = {
+      ...makeFakeCapability(calls),
+      teardown() {
+        order.push('teardown');
+        calls.push({ hook: 'teardown' });
+      },
+    };
+
+    const collection = createSmrtCollection(productDefinition('teardown'), {
+      fetchers: scripted.fetchers,
+      staleTimeMs: 60_000,
+      capabilities: [capability],
+    });
+    await collection.preload();
+
+    await collection.cleanup();
+
+    expect(calls.filter((c) => c.hook === 'teardown')).toHaveLength(1);
+    expect(order).toEqual(['teardown']);
+
+    // A second cleanup() runs teardown again (idempotent from the seam's view —
+    // it mirrors the engine's own cleanup being callable), but the common path
+    // is a single cleanup; assert the single-call contract above holds.
+  });
+});

--- a/packages/smrt-web/src/capability-integration.test.ts
+++ b/packages/smrt-web/src/capability-integration.test.ts
@@ -933,4 +933,95 @@ describe('capability seam — async warmStart suppresses the first read (Fix D)'
     expect(scripted.calls.list).toBe(0);
     expect(collection.get('p1')?.name).toBe('from-async-warm');
   });
+
+  it('Fix E: when the FIRST async warmStart resolves to undefined, a LATER capability that returns rows seeds', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'from-server' }]);
+    const first: SmrtWebCapability<ProductData> = {
+      name: 'async-miss',
+      // Async, resolves to undefined — a rehydrate that found nothing on disk.
+      warmStart: async () => {
+        await Promise.resolve();
+        return undefined;
+      },
+    };
+    const second: SmrtWebCapability<ProductData> = {
+      name: 'async-hit',
+      warmStart: async () => {
+        await Promise.resolve();
+        return [{ id: 'p1', name: 'from-second' }];
+      },
+    };
+
+    const collection = track(
+      createSmrtCollection(productDefinition('async-order-miss'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [first, second],
+      }),
+    );
+
+    // The ordered chain skips the first (undefined) and seeds from the second —
+    // the first list() is suppressed even though the FIRST provider missed.
+    await collection.preload();
+    expect(scripted.calls.list).toBe(0);
+    expect(collection.get('p1')?.name).toBe('from-second');
+  });
+
+  it('Fix E: when the FIRST async warmStart REJECTS, a later capability still seeds and no unhandled rejection leaks', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'from-server' }]);
+    const first: SmrtWebCapability<ProductData> = {
+      name: 'async-reject',
+      warmStart: async () => {
+        await Promise.resolve();
+        throw new Error('rehydrate failed');
+      },
+    };
+    const second: SmrtWebCapability<ProductData> = {
+      name: 'async-hit',
+      warmStart: async () => [{ id: 'p1', name: 'from-second' }],
+    };
+
+    const collection = track(
+      createSmrtCollection(productDefinition('async-order-reject'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [first, second],
+      }),
+    );
+
+    await collection.preload();
+    // The reject was caught (logged) and the chain moved on to the second.
+    expect(scripted.calls.list).toBe(0);
+    expect(collection.get('p1')?.name).toBe('from-second');
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('Fix E: a SYNC warmStart returning rows before an async one seeds inline (no preload needed)', async () => {
+    const scripted = makeScriptedFetchers([{ id: 'p1', name: 'from-server' }]);
+    const syncFirst: SmrtWebCapability<ProductData> = {
+      name: 'sync-hit',
+      warmStart: () => [{ id: 'p1', name: 'from-sync' }],
+    };
+    const asyncSecond: SmrtWebCapability<ProductData> = {
+      name: 'async-later',
+      warmStart: async () => [{ id: 'p1', name: 'from-async' }],
+    };
+
+    const collection = track(
+      createSmrtCollection(productDefinition('sync-before-async'), {
+        fetchers: scripted.fetchers,
+        staleTimeMs: 60_000,
+        capabilities: [syncFirst, asyncSecond],
+      }),
+    );
+
+    // The sync provider seeded synchronously at construction — the value is in
+    // cache before any preload(), and the later async provider never overrides
+    // it (first-that-returns-rows wins, and the atomic updater keeps the seed).
+    await collection.preload();
+    expect(scripted.calls.list).toBe(0);
+    expect(collection.get('p1')?.name).toBe('from-sync');
+  });
 });

--- a/packages/smrt-web/src/capability.test.ts
+++ b/packages/smrt-web/src/capability.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the capability seam's pure runner (#1755).
+ *
+ * These cover `runWrapMutation` in isolation — no engine, no factory — so the
+ * array-order / first-handled-wins contract is pinned down independently of the
+ * integration wiring (which lives in capability-integration.test.ts).
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  runWrapMutation,
+  type SmrtWebCapability,
+  type SmrtWebCapabilityContext,
+  type SmrtWebMutationEnvelope,
+} from './index.js';
+
+interface Row {
+  id?: string;
+  name: string;
+}
+
+const envelope: SmrtWebMutationEnvelope = {
+  kind: 'insert',
+  key: 'local-1',
+  data: { name: 'Widget' },
+};
+
+/** A throwaway context — the runner only forwards it, never reads it. */
+const ctx = {} as SmrtWebCapabilityContext<Row>;
+
+function cap(
+  name: string,
+  wrapMutation?: SmrtWebCapability<Row>['wrapMutation'],
+): SmrtWebCapability<Row> {
+  return { name, wrapMutation };
+}
+
+describe('runWrapMutation', () => {
+  it('returns { handled: false } when there are no capabilities', async () => {
+    expect(await runWrapMutation<Row>([], envelope, ctx)).toEqual({
+      handled: false,
+    });
+  });
+
+  it('returns { handled: false } when every capability declines', async () => {
+    const a = cap('a', async () => ({ handled: false }) as const);
+    const b = cap('b', async () => undefined);
+    const c = cap('c'); // no wrapMutation hook at all
+    expect(await runWrapMutation<Row>([a, b, c], envelope, ctx)).toEqual({
+      handled: false,
+    });
+  });
+
+  it('returns the first { handled: true } result', async () => {
+    const handled = cap('handler', async () => ({
+      handled: true,
+      result: { id: 'server-1', name: 'Widget' },
+    }));
+    const result = await runWrapMutation<Row>([handled], envelope, ctx);
+    expect(result).toEqual({
+      handled: true,
+      result: { id: 'server-1', name: 'Widget' },
+    });
+  });
+
+  it('iterates in array order and short-circuits on the first handler', async () => {
+    const order: string[] = [];
+    const first = cap('first', async () => {
+      order.push('first');
+      return { handled: false } as const;
+    });
+    const second = cap('second', async () => {
+      order.push('second');
+      return { handled: true, result: 'from-second' } as const;
+    });
+    const third = cap('third', async () => {
+      order.push('third');
+      return { handled: true, result: 'from-third' } as const;
+    });
+
+    const result = await runWrapMutation<Row>(
+      [first, second, third],
+      envelope,
+      ctx,
+    );
+
+    // second wins; third is never consulted.
+    expect(result).toEqual({ handled: true, result: 'from-second' });
+    expect(order).toEqual(['first', 'second']);
+  });
+
+  it('forwards the envelope and context to each capability', async () => {
+    const spy = vi.fn(async () => ({ handled: false }) as const);
+    await runWrapMutation<Row>([cap('spy', spy)], envelope, ctx);
+    expect(spy).toHaveBeenCalledWith(envelope, ctx);
+  });
+
+  it('supports a synchronous wrapMutation return', async () => {
+    const sync = cap('sync', () => ({ handled: true, result: 42 }));
+    expect(await runWrapMutation<Row>([sync], envelope, ctx)).toEqual({
+      handled: true,
+      result: 42,
+    });
+  });
+});

--- a/packages/smrt-web/src/capability.ts
+++ b/packages/smrt-web/src/capability.ts
@@ -1,0 +1,185 @@
+/**
+ * @happyvertical/smrt-web — capability extension seam (#1755).
+ *
+ * A capability is a small plug-in that hooks the {@link createSmrtCollection}
+ * lifecycle so a follow-on client slice — the offline outbox (#1762),
+ * persistence (#1764), or live SSE invalidation (#1763-client) — can live in
+ * its OWN module instead of contending on `index.ts`. The factory runs the six
+ * hooks below at fixed points; a collection with no capabilities is
+ * byte-for-byte the collection of today (the no-op guarantee).
+ *
+ * ## The engine boundary is sacred
+ *
+ * Every type here is expressed ENTIRELY in existing SMRT-owned terms
+ * (`SmrtWebCollectionDefinition`, `SmrtCrudFetchers`, `SmrtWebRow`, plain TS).
+ * No `@tanstack/*` type — no `QueryClient`, no engine `Collection` — appears on
+ * the capability surface, so the build's `.d.ts` boundary check stays green and
+ * the engine stays swappable. A capability that genuinely needs deeper engine
+ * access reaches it through the existing `getEngineCollection()` unknown-bridge
+ * from inside its own module — NEVER by widening these types.
+ *
+ * These types intentionally import nothing from `./index.ts` beyond the
+ * SMRT-owned contracts they name, so the seam is reviewable and unit-testable on
+ * its own (see {@link runWrapMutation}).
+ */
+
+import type {
+  SmrtCrudFetchers,
+  SmrtWebCollectionDefinition,
+  SmrtWebRow,
+} from './index.js';
+
+/**
+ * The context every capability hook receives — a stable, engine-free view of
+ * the collection being built. All fields are the exact values the factory uses
+ * internally (the resolved cache key/id, the same fetchers), so a capability
+ * keys its own storage or subscriptions off the identical discriminators.
+ */
+export interface SmrtWebCapabilityContext<TData extends object = object> {
+  /** The generated definition this collection materializes. */
+  readonly definition: SmrtWebCollectionDefinition<TData>;
+  /** The CRUD fetchers the collection persists through. */
+  readonly fetchers: SmrtCrudFetchers;
+  /**
+   * The `queryKey` segments the collection's reads use — a LIVE view: from
+   * `onAttach`/`warmStart` onward it is the final key (including every
+   * capability-contributed segment); read during `contributeCacheKey` it omits
+   * that capability's own not-yet-applied segment. Treat as read-only.
+   */
+  readonly cacheKey: readonly string[];
+  /** The engine-collection id string (mirrors {@link cacheKey}). */
+  readonly cacheId: string;
+  /**
+   * Enter the SAME relationship-derived invalidation the factory runs after a
+   * settled mutation. A capability calls this to refetch this collection and its
+   * manifest-related collections in response to an EXTERNAL trigger (e.g. an SSE
+   * message) without reaching into the engine.
+   */
+  invalidate(): void;
+}
+
+/**
+ * A single mutation described in SMRT-owned terms — handed to
+ * {@link SmrtWebCapability.wrapMutation} and {@link SmrtWebCapability.onSettled}
+ * so a capability can inspect or intercept a write without touching the engine's
+ * transaction type.
+ */
+export interface SmrtWebMutationEnvelope {
+  /** Which mutation kind this describes. */
+  readonly kind: 'insert' | 'update' | 'delete';
+  /** The row key: the client-local id on insert, else the target row's id. */
+  readonly key: string;
+  /**
+   * The write payload: the full row on insert, the changed fields on update,
+   * and an empty object on delete (the key carries the target).
+   */
+  readonly data: Record<string, unknown>;
+}
+
+/** The outcome handed to {@link SmrtWebCapability.wrapMutation}. */
+export type WrapMutationOutcome =
+  | { handled: true; result: unknown }
+  | { handled: false }
+  | undefined;
+
+/** The settle outcome handed to {@link SmrtWebCapability.onSettled}. */
+export type MutationSettleOutcome =
+  | { ok: true; result: unknown }
+  | { ok: false; error: unknown };
+
+/**
+ * A capability plugged into {@link createSmrtCollection}. Every hook is
+ * optional; a capability implements only the points its slice needs. Hooks fire
+ * in these fixed places, and capabilities run in ARRAY ORDER:
+ *
+ * - `contributeCacheKey` — ONCE, before the engine collection is constructed.
+ * - `warmStart` — ONCE, before the first read (seeds the cache).
+ * - `wrapMutation` — per mutation, BEFORE the fetcher, with a chance to handle
+ *   the write itself (offline).
+ * - `onSettled` — per mutation, AFTER it settles (success AND fetcher-throw).
+ * - `onAttach` — ONCE, right after the engine collection is constructed; the
+ *   ONLY place a capability registers an external (non-mutation) trigger such as
+ *   an SSE subscription.
+ * - `teardown` — in `cleanup()`, after the engine's own cleanup.
+ */
+export interface SmrtWebCapability<TData extends object = object> {
+  /** Diagnostic name (e.g. `'offline-outbox'`). */
+  readonly name: string;
+
+  /**
+   * Contribute extra cache-key segments so this capability can partition the
+   * collection's cache (e.g. an outbox variant). Runs ONCE, before construction;
+   * returned segments are appended to the collection's cache key/id. Return
+   * `undefined` (or omit) to contribute nothing.
+   */
+  contributeCacheKey?(
+    ctx: SmrtWebCapabilityContext<TData>,
+  ): string[] | undefined;
+
+  /**
+   * Provide rows to seed the cache before the first read — the persistence
+   * slice's rehydrate-from-disk path. Runs ONCE, before construction. NOTE:
+   * caller-supplied `initialData` (fresher same-request SSR truth) WINS over any
+   * capability `warmStart`. Return `undefined` to contribute no seed.
+   */
+  warmStart?(
+    ctx: SmrtWebCapabilityContext<TData>,
+  ): Promise<SmrtWebRow<TData>[] | undefined> | SmrtWebRow<TData>[] | undefined;
+
+  /**
+   * Intercept a mutation BEFORE its fetcher runs. Return `{ handled: true,
+   * result }` to take over the write (the fetcher is skipped and `result`
+   * reconciles the optimistic row — the offline path); return `{ handled: false
+   * }` or `undefined` to fall through to the real fetcher. With multiple
+   * capabilities the FIRST `{ handled: true }` wins and later capabilities'
+   * `wrapMutation` are skipped.
+   */
+  wrapMutation?(
+    envelope: SmrtWebMutationEnvelope,
+    ctx: SmrtWebCapabilityContext<TData>,
+  ): Promise<WrapMutationOutcome> | WrapMutationOutcome;
+
+  /**
+   * Observe a mutation after it settles — on BOTH a successful persist and a
+   * fetcher throw (before the optimistic rollback propagates). Never swallows
+   * the error: a thrown fetcher error still rolls the transaction back.
+   */
+  onSettled?(
+    envelope: SmrtWebMutationEnvelope,
+    outcome: MutationSettleOutcome,
+    ctx: SmrtWebCapabilityContext<TData>,
+  ): void;
+
+  /**
+   * Run ONCE, right after the engine collection is constructed. The ONLY hook
+   * where a capability wires an external trigger (SSE subscription, focus
+   * listener) — `ctx.invalidate()` is callable here.
+   */
+  onAttach?(ctx: SmrtWebCapabilityContext<TData>): void;
+
+  /** Run inside `cleanup()`, AFTER the engine's own cleanup. Awaited if async. */
+  teardown?(ctx: SmrtWebCapabilityContext<TData>): void | Promise<void>;
+}
+
+/**
+ * Run the `wrapMutation` hook across `capabilities` in array order for one
+ * mutation, short-circuiting on the FIRST capability that returns `{ handled:
+ * true }` (later capabilities' `wrapMutation` are then skipped). A capability
+ * that returns `{ handled: false }`, `undefined`, or omits the hook declines,
+ * and the next is tried. When every capability declines, resolves `{ handled:
+ * false }` so the factory falls through to the real fetcher.
+ */
+export async function runWrapMutation<TData extends object>(
+  capabilities: readonly SmrtWebCapability<TData>[],
+  envelope: SmrtWebMutationEnvelope,
+  ctx: SmrtWebCapabilityContext<TData>,
+): Promise<{ handled: true; result: unknown } | { handled: false }> {
+  for (const capability of capabilities) {
+    if (!capability.wrapMutation) continue;
+    const outcome = await capability.wrapMutation(envelope, ctx);
+    if (outcome?.handled) {
+      return { handled: true, result: outcome.result };
+    }
+  }
+  return { handled: false };
+}

--- a/packages/smrt-web/src/durable-store.test.ts
+++ b/packages/smrt-web/src/durable-store.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the shared durable-store namespace + wipe registry (#1755).
+ *
+ * This layer is pure SMRT-side bookkeeping — no client-data engine, no
+ * TanStack — so every collaborator here is real. The registry is the one thing
+ * the future offline outbox (#1762) and persistence (#1764) slices agree on:
+ * each uses its own TanStack storage primitive under a shared namespace, and
+ * `wipeDurableStore` clears both through the registry without the two modules
+ * importing each other.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type DurableResource,
+  type DurableStoreKey,
+  durableStoreNamespace,
+  registerDurableResource,
+  wipeDurableStore,
+} from './index.js';
+
+/** A minimal in-memory resource whose clear() is observable. */
+function fakeResource(
+  kind: DurableResource['kind'],
+): DurableResource & { cleared: number } {
+  const resource = {
+    kind,
+    cleared: 0,
+    clear: async () => {
+      resource.cleared += 1;
+    },
+  };
+  return resource;
+}
+
+describe('durableStoreNamespace', () => {
+  it('is deterministic: the same key yields the same namespace', () => {
+    const key: DurableStoreKey = {
+      apiBase: '/api/v1',
+      tenantId: 't1',
+      identityId: 'u1',
+      manifestHash: 'abc123',
+    };
+    expect(durableStoreNamespace(key)).toBe(durableStoreNamespace({ ...key }));
+  });
+
+  it('encodes every key segment in a stable order', () => {
+    expect(
+      durableStoreNamespace({
+        apiBase: '/api/v1',
+        tenantId: 't1',
+        identityId: 'u1',
+        manifestHash: 'abc123',
+      }),
+    ).toBe('smrt-web:/api/v1:t1:u1:abc123');
+  });
+
+  it("substitutes '-' for an absent tenant or identity", () => {
+    expect(
+      durableStoreNamespace({ apiBase: '/api/v1', manifestHash: 'abc123' }),
+    ).toBe('smrt-web:/api/v1:-:-:abc123');
+  });
+
+  it('changes when the manifest hash changes (a schema shift => a fresh namespace)', () => {
+    const base: DurableStoreKey = { apiBase: '/api/v1', manifestHash: 'v1' };
+    expect(durableStoreNamespace(base)).not.toBe(
+      durableStoreNamespace({ ...base, manifestHash: 'v2' }),
+    );
+  });
+
+  it('changes when the tenant or identity changes (no cross-tenant reuse)', () => {
+    const base: DurableStoreKey = { apiBase: '/api/v1', manifestHash: 'v1' };
+    expect(durableStoreNamespace({ ...base, tenantId: 'a' })).not.toBe(
+      durableStoreNamespace({ ...base, tenantId: 'b' }),
+    );
+    expect(durableStoreNamespace({ ...base, identityId: 'a' })).not.toBe(
+      durableStoreNamespace({ ...base, identityId: 'b' }),
+    );
+  });
+});
+
+describe('registerDurableResource + wipeDurableStore', () => {
+  it('clears every resource registered under a namespace', async () => {
+    const ns = durableStoreNamespace({ apiBase: '/api/v1', manifestHash: 'h' });
+    const outbox = fakeResource('outbox');
+    const persisted = fakeResource('persisted-collection');
+    registerDurableResource(ns, outbox);
+    registerDurableResource(ns, persisted);
+
+    await wipeDurableStore(ns);
+
+    expect(outbox.cleared).toBe(1);
+    expect(persisted.cleared).toBe(1);
+  });
+
+  it('does NOT clear resources registered under a different namespace', async () => {
+    const nsA = durableStoreNamespace({
+      apiBase: '/api/v1',
+      manifestHash: 'a',
+    });
+    const nsB = durableStoreNamespace({
+      apiBase: '/api/v1',
+      manifestHash: 'b',
+    });
+    const underA = fakeResource('outbox');
+    const underB = fakeResource('outbox');
+    registerDurableResource(nsA, underA);
+    registerDurableResource(nsB, underB);
+
+    await wipeDurableStore(nsA);
+
+    expect(underA.cleared).toBe(1);
+    expect(underB.cleared).toBe(0);
+  });
+
+  it('returns an unregister that removes the resource before a wipe', async () => {
+    const ns = durableStoreNamespace({ apiBase: '/api/v1', manifestHash: 'u' });
+    const resource = fakeResource('outbox');
+    const unregister = registerDurableResource(ns, resource);
+
+    unregister();
+    await wipeDurableStore(ns);
+
+    expect(resource.cleared).toBe(0);
+  });
+
+  it('drops the namespace after a wipe: re-wiping clears nothing more', async () => {
+    const ns = durableStoreNamespace({ apiBase: '/api/v1', manifestHash: 'd' });
+    const resource = fakeResource('outbox');
+    registerDurableResource(ns, resource);
+
+    await wipeDurableStore(ns);
+    await wipeDurableStore(ns);
+
+    expect(resource.cleared).toBe(1);
+  });
+
+  it('is a safe no-op on an unknown or empty namespace', async () => {
+    await expect(wipeDurableStore('never-registered')).resolves.toBeUndefined();
+    await expect(wipeDurableStore('')).resolves.toBeUndefined();
+  });
+
+  it('clears every registered resource even if one clear() rejects', async () => {
+    const ns = durableStoreNamespace({ apiBase: '/api/v1', manifestHash: 'e' });
+    const flaky: DurableResource = {
+      kind: 'outbox',
+      clear: vi.fn(async () => {
+        throw new Error('storage unavailable');
+      }),
+    };
+    const healthy = fakeResource('persisted-collection');
+    registerDurableResource(ns, flaky);
+    registerDurableResource(ns, healthy);
+
+    await wipeDurableStore(ns);
+
+    // The healthy resource still cleared; a rejected clear() did not abort the
+    // sweep (a wipe is a best-effort teardown, not a transaction).
+    expect(flaky.clear).toHaveBeenCalledTimes(1);
+    expect(healthy.cleared).toBe(1);
+  });
+});

--- a/packages/smrt-web/src/durable-store.test.ts
+++ b/packages/smrt-web/src/durable-store.test.ts
@@ -43,7 +43,8 @@ describe('durableStoreNamespace', () => {
     expect(durableStoreNamespace(key)).toBe(durableStoreNamespace({ ...key }));
   });
 
-  it('encodes every key segment in a stable order', () => {
+  it('encodes every key segment in a stable order (URI-encoded, empty for absent)', () => {
+    // Segments are encodeURIComponent-encoded, so '/api/v1' -> '%2Fapi%2Fv1'.
     expect(
       durableStoreNamespace({
         apiBase: '/api/v1',
@@ -51,13 +52,13 @@ describe('durableStoreNamespace', () => {
         identityId: 'u1',
         manifestHash: 'abc123',
       }),
-    ).toBe('smrt-web:/api/v1:t1:u1:abc123');
+    ).toBe('smrt-web:%2Fapi%2Fv1:t1:u1:abc123');
   });
 
-  it("substitutes '-' for an absent tenant or identity", () => {
+  it('uses an EMPTY segment for an absent tenant or identity', () => {
     expect(
       durableStoreNamespace({ apiBase: '/api/v1', manifestHash: 'abc123' }),
-    ).toBe('smrt-web:/api/v1:-:-:abc123');
+    ).toBe('smrt-web:%2Fapi%2Fv1:::abc123');
   });
 
   it('changes when the manifest hash changes (a schema shift => a fresh namespace)', () => {
@@ -75,6 +76,41 @@ describe('durableStoreNamespace', () => {
     expect(durableStoreNamespace({ ...base, identityId: 'a' })).not.toBe(
       durableStoreNamespace({ ...base, identityId: 'b' }),
     );
+  });
+
+  // Fix F — the namespace is an isolation boundary, so it MUST be injective:
+  // no two distinct keys may collide onto one namespace, or durable data would
+  // be reused/wiped across api/tenant/identity boundaries.
+  it('is collision-safe when a segment contains the separator character', () => {
+    // Without encoding, tenantId 'a:b' + identityId 'c' would render the same
+    // string as tenantId 'a' + identityId 'b:c'. Encoding the ':' to %3A keeps
+    // them distinct.
+    const base: DurableStoreKey = { apiBase: '/api/v1', manifestHash: 'h' };
+    expect(
+      durableStoreNamespace({ ...base, tenantId: 'a:b', identityId: 'c' }),
+    ).not.toBe(
+      durableStoreNamespace({ ...base, tenantId: 'a', identityId: 'b:c' }),
+    );
+  });
+
+  it('distinguishes a literal tenantId "-" from an absent tenantId', () => {
+    const base: DurableStoreKey = { apiBase: '/api/v1', manifestHash: 'h' };
+    // A real tenant whose id happens to be '-' must not share the "no tenant"
+    // namespace.
+    expect(durableStoreNamespace({ ...base, tenantId: '-' })).not.toBe(
+      durableStoreNamespace(base),
+    );
+    // Same for identity.
+    expect(durableStoreNamespace({ ...base, identityId: '-' })).not.toBe(
+      durableStoreNamespace(base),
+    );
+  });
+
+  it('is collision-safe when apiBase or manifestHash contains a separator', () => {
+    // A ':' in apiBase must not bleed into the tenant segment position.
+    expect(
+      durableStoreNamespace({ apiBase: 'a:b', manifestHash: 'h' }),
+    ).not.toBe(durableStoreNamespace({ apiBase: 'a', manifestHash: 'b:h' }));
   });
 });
 

--- a/packages/smrt-web/src/durable-store.test.ts
+++ b/packages/smrt-web/src/durable-store.test.ts
@@ -43,8 +43,10 @@ describe('durableStoreNamespace', () => {
     expect(durableStoreNamespace(key)).toBe(durableStoreNamespace({ ...key }));
   });
 
-  it('encodes every key segment in a stable order (URI-encoded, empty for absent)', () => {
-    // Segments are encodeURIComponent-encoded, so '/api/v1' -> '%2Fapi%2Fv1'.
+  it('encodes every key segment in a stable order (URI-encoded; present optionals marked with "_")', () => {
+    // Required segments are encodeURIComponent-encoded ('/api/v1' -> '%2Fapi%2Fv1');
+    // a PRESENT optional segment is prefixed with '_' ('t1' -> '_t1') so it can
+    // never equal the empty "absent" segment.
     expect(
       durableStoreNamespace({
         apiBase: '/api/v1',
@@ -52,13 +54,29 @@ describe('durableStoreNamespace', () => {
         identityId: 'u1',
         manifestHash: 'abc123',
       }),
-    ).toBe('smrt-web:%2Fapi%2Fv1:t1:u1:abc123');
+    ).toBe('smrt-web:%2Fapi%2Fv1:_t1:_u1:abc123');
   });
 
   it('uses an EMPTY segment for an absent tenant or identity', () => {
     expect(
       durableStoreNamespace({ apiBase: '/api/v1', manifestHash: 'abc123' }),
     ).toBe('smrt-web:%2Fapi%2Fv1:::abc123');
+  });
+
+  // Fix H — an explicitly-EMPTY id must not collide with an absent id: '' is a
+  // present value (a caller passed it), semantically distinct from "no id".
+  it('distinguishes an empty-string tenantId/identityId from an absent one', () => {
+    const base: DurableStoreKey = { apiBase: '/api/v1', manifestHash: 'h' };
+    expect(durableStoreNamespace({ ...base, tenantId: '' })).not.toBe(
+      durableStoreNamespace(base),
+    );
+    expect(durableStoreNamespace({ ...base, identityId: '' })).not.toBe(
+      durableStoreNamespace(base),
+    );
+    // And an empty tenant differs from an empty identity (position preserved).
+    expect(durableStoreNamespace({ ...base, tenantId: '' })).not.toBe(
+      durableStoreNamespace({ ...base, identityId: '' }),
+    );
   });
 
   it('changes when the manifest hash changes (a schema shift => a fresh namespace)', () => {

--- a/packages/smrt-web/src/durable-store.ts
+++ b/packages/smrt-web/src/durable-store.ts
@@ -43,13 +43,22 @@ export interface DurableStoreKey {
 
 /**
  * Compute the deterministic storage namespace for a {@link DurableStoreKey}.
- * The same key always yields the same string; any differing segment yields a
- * different one. Absent `tenantId` / `identityId` collapse to `-` so the
- * segment count is fixed. Both future slices key their own storage primitive
- * (IndexedDB store name, OPFS path, …) under this string.
+ * The same key always yields the same string; **any differing segment yields a
+ * different one** (injective) — this is critical because the namespace IS the
+ * tenant/identity/api isolation + wipe boundary, so a collision would reuse or
+ * wipe durable data ACROSS those boundaries.
+ *
+ * Injectivity is guaranteed two ways: every segment is `encodeURIComponent`-
+ * encoded, so a raw `:` in a value becomes `%3A` and can never be mistaken for a
+ * separator; and an ABSENT `tenantId` / `identityId` maps to the empty string
+ * while a PRESENT value is encoded, so a real id of `-` no longer collides with
+ * "no tenant". Both future slices key their own storage primitive (IndexedDB
+ * store name, OPFS path, …) under this string.
  */
 export function durableStoreNamespace(key: DurableStoreKey): string {
-  return `smrt-web:${key.apiBase}:${key.tenantId ?? '-'}:${key.identityId ?? '-'}:${key.manifestHash}`;
+  const seg = (value: string | undefined): string =>
+    value === undefined ? '' : encodeURIComponent(value);
+  return `smrt-web:${encodeURIComponent(key.apiBase)}:${seg(key.tenantId)}:${seg(key.identityId)}:${encodeURIComponent(key.manifestHash)}`;
 }
 
 /**

--- a/packages/smrt-web/src/durable-store.ts
+++ b/packages/smrt-web/src/durable-store.ts
@@ -48,17 +48,21 @@ export interface DurableStoreKey {
  * tenant/identity/api isolation + wipe boundary, so a collision would reuse or
  * wipe durable data ACROSS those boundaries.
  *
- * Injectivity is guaranteed two ways: every segment is `encodeURIComponent`-
+ * Injectivity is guaranteed three ways: every segment is `encodeURIComponent`-
  * encoded, so a raw `:` in a value becomes `%3A` and can never be mistaken for a
- * separator; and an ABSENT `tenantId` / `identityId` maps to the empty string
- * while a PRESENT value is encoded, so a real id of `-` no longer collides with
- * "no tenant". Both future slices key their own storage primitive (IndexedDB
- * store name, OPFS path, …) under this string.
+ * separator; an ABSENT `tenantId` / `identityId` maps to the empty string while
+ * a PRESENT value is prefixed with `_` (so undefined→``, ``→`_`, `x`→`_x`) — so
+ * an explicitly-EMPTY id no longer collides with "no id", nor does a real id of
+ * `-`. Both future slices key their own storage primitive (IndexedDB store name,
+ * OPFS path, …) under this string.
  */
 export function durableStoreNamespace(key: DurableStoreKey): string {
-  const seg = (value: string | undefined): string =>
-    value === undefined ? '' : encodeURIComponent(value);
-  return `smrt-web:${encodeURIComponent(key.apiBase)}:${seg(key.tenantId)}:${seg(key.identityId)}:${encodeURIComponent(key.manifestHash)}`;
+  // Optional segments: encode PRESENCE distinctly. undefined → '' (absent);
+  // any present value (including '') → `_<encoded>`, so '' → '_' can never equal
+  // the absent '' .
+  const optional = (value: string | undefined): string =>
+    value === undefined ? '' : `_${encodeURIComponent(value)}`;
+  return `smrt-web:${encodeURIComponent(key.apiBase)}:${optional(key.tenantId)}:${optional(key.identityId)}:${encodeURIComponent(key.manifestHash)}`;
 }
 
 /**

--- a/packages/smrt-web/src/durable-store.ts
+++ b/packages/smrt-web/src/durable-store.ts
@@ -1,0 +1,122 @@
+/**
+ * @happyvertical/smrt-web — shared durable-store foundation (#1755).
+ *
+ * The ONE SMRT-layer namespacing + wipe registry that the future offline
+ * outbox (#1762) and persistence (#1764) slices both build on. Pure bookkeeping
+ * — ZERO client-data-engine (`@tanstack/*`) imports — so it stays inside the
+ * engine-absorption boundary and ships now, before either consumer exists, so
+ * the two slices agree on it from day one.
+ *
+ * Why a SMRT-layer registry rather than one storage engine: TanStack DB
+ * persistence (SQLite-WASM / OPFS) and `@tanstack/offline-transactions`
+ * (IndexedDB) are SEPARATE storage engines. There is no single primitive that
+ * spans both, so the shared foundation lives one level up — a deterministic
+ * namespace both slices key their own storage under, plus a registry so
+ * {@link wipeDurableStore} can clear BOTH through one call without the outbox
+ * and persistence modules importing each other. A logout / tenant-switch wipes
+ * every durable artifact for a namespace in one place.
+ *
+ * Nothing in this package calls these yet — the seam ships ahead of its
+ * consumers by design (see PRD #1755).
+ */
+
+/**
+ * The identity a durable namespace is derived from. Combining the API base with
+ * the tenant + identity + manifest hash means a logout, a tenant switch, or a
+ * schema change each land on a DIFFERENT namespace, so durable artifacts are
+ * never reused across those boundaries.
+ *
+ * `manifestHash` is supplied by the caller (its source is #1764's call — a
+ * schema-shape digest); this module is source-agnostic and treats it as an
+ * opaque discriminator.
+ */
+export interface DurableStoreKey {
+  /** API base path the durable data was fetched against (e.g. `/api/v1`). */
+  apiBase: string;
+  /** Active tenant id, if any — absent means the single-tenant / global scope. */
+  tenantId?: string;
+  /** Authenticated identity id, if any — absent means anonymous. */
+  identityId?: string;
+  /** Opaque schema-shape digest; a change forces a fresh namespace. */
+  manifestHash: string;
+}
+
+/**
+ * Compute the deterministic storage namespace for a {@link DurableStoreKey}.
+ * The same key always yields the same string; any differing segment yields a
+ * different one. Absent `tenantId` / `identityId` collapse to `-` so the
+ * segment count is fixed. Both future slices key their own storage primitive
+ * (IndexedDB store name, OPFS path, …) under this string.
+ */
+export function durableStoreNamespace(key: DurableStoreKey): string {
+  return `smrt-web:${key.apiBase}:${key.tenantId ?? '-'}:${key.identityId ?? '-'}:${key.manifestHash}`;
+}
+
+/**
+ * A durable artifact registered under a namespace — the outbox queue (#1762) or
+ * a persisted collection store (#1764). Each owns its storage engine and
+ * exposes only a `clear()` so {@link wipeDurableStore} can tear it down without
+ * knowing which engine backs it.
+ */
+export interface DurableResource {
+  /** Which slice owns this artifact — for diagnostics and selective sweeps. */
+  readonly kind: 'outbox' | 'persisted-collection';
+  /** Drop this artifact's durable storage. Best-effort; may reject. */
+  clear(): Promise<void>;
+}
+
+/**
+ * Registry of durable artifacts keyed by namespace. A `Set` per namespace so a
+ * resource registers and unregisters without positional bookkeeping, and so two
+ * slices (outbox + persistence) coexist under one namespace.
+ */
+const registry = new Map<string, Set<DurableResource>>();
+
+/**
+ * Register a durable artifact under a namespace so {@link wipeDurableStore} can
+ * later clear it. Returns an unregister function that removes just this
+ * resource — call it when the artifact is disposed on its own (before any
+ * namespace-wide wipe) so it is not cleared twice.
+ */
+export function registerDurableResource(
+  namespace: string,
+  resource: DurableResource,
+): () => void {
+  let resources = registry.get(namespace);
+  if (!resources) {
+    resources = new Set<DurableResource>();
+    registry.set(namespace, resources);
+  }
+  resources.add(resource);
+
+  return () => {
+    const current = registry.get(namespace);
+    if (!current) return;
+    current.delete(resource);
+    if (current.size === 0) registry.delete(namespace);
+  };
+}
+
+/**
+ * Clear every durable artifact registered under `namespace`, then drop the
+ * namespace. This is the single teardown point a logout / tenant-switch calls:
+ * it fans out across BOTH the outbox and persistence slices via the registry,
+ * so neither module needs to import the other.
+ *
+ * Best-effort: a resource whose `clear()` rejects does not abort the sweep —
+ * every registered resource is still cleared (a wipe is a teardown, not a
+ * transaction). A safe no-op on an unknown or empty namespace.
+ */
+export async function wipeDurableStore(namespace: string): Promise<void> {
+  const resources = registry.get(namespace);
+  if (!resources || resources.size === 0) {
+    registry.delete(namespace);
+    return;
+  }
+  // Snapshot so a resource that unregisters itself inside clear() cannot mutate
+  // the set mid-iteration. allSettled keeps a rejected clear() from aborting the
+  // others.
+  const snapshot = [...resources];
+  registry.delete(namespace);
+  await Promise.allSettled(snapshot.map((resource) => resource.clear()));
+}

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -40,6 +40,34 @@ import { createCollection } from '@tanstack/db';
 import { QueryClient } from '@tanstack/query-core';
 import { queryCollectionOptions } from '@tanstack/query-db-collection';
 
+import type {
+  SmrtWebCapability,
+  SmrtWebCapabilityContext,
+  SmrtWebMutationEnvelope,
+} from './capability.js';
+import { runWrapMutation } from './capability.js';
+
+// Re-export the capability seam (#1755) and the shared durable-store foundation
+// through this single entry — the package ships one export subpath, so both are
+// reachable as `@happyvertical/smrt-web`. Kept in their own modules so each is
+// reviewable and testable on its own; surfaced here for consumers-to-be (the
+// offline outbox #1762, persistence #1764, and live SSE invalidation
+// #1763-client slices).
+export type {
+  MutationSettleOutcome,
+  SmrtWebCapability,
+  SmrtWebCapabilityContext,
+  SmrtWebMutationEnvelope,
+  WrapMutationOutcome,
+} from './capability.js';
+export { runWrapMutation } from './capability.js';
+export type { DurableResource, DurableStoreKey } from './durable-store.js';
+export {
+  durableStoreNamespace,
+  registerDurableResource,
+  wipeDurableStore,
+} from './durable-store.js';
+
 // ---------------------------------------------------------------------------
 // Generated definition contract (mirrors @happyvertical/smrt-virt-web)
 // ---------------------------------------------------------------------------
@@ -478,6 +506,16 @@ export interface CreateSmrtCollectionOptions<TData extends object = object> {
    * `staleTimeMs` window.
    */
   initialData?: SmrtWebRow<TData>[];
+  /**
+   * Capability plug-ins hooking the collection lifecycle (#1755) — the seam
+   * that lets the offline outbox (#1762), persistence (#1764), and live SSE
+   * invalidation (#1763-client) slices each live in their own module instead of
+   * contending on this factory. Capabilities run in array order at six fixed
+   * points (see {@link SmrtWebCapability}). Additive and defaulting to none: an
+   * undefined or empty array is byte-for-byte the collection of today (the
+   * no-op guarantee), so this ships zero concrete capabilities by design.
+   */
+  capabilities?: SmrtWebCapability<TData>[];
 }
 
 /**
@@ -539,6 +577,7 @@ export function createSmrtCollection<TData extends object>(
   type Row = SmrtWebRow<TData>;
 
   const { staleTimeMs = 30_000, retry = false, scope, initialData } = options;
+  const capabilities = options.capabilities ?? [];
   const fetchers =
     options.fetchers ??
     createDefinitionFetchers(definition, options.basePath, options.fetchFn);
@@ -547,35 +586,14 @@ export function createSmrtCollection<TData extends object>(
 
   // Scope discriminates the cache key so a shared client can materialize the
   // same collection against different backends without cross-serving reads.
-  const cacheId = scope
+  // `let` so capabilities can extend the scheme via `contributeCacheKey` below;
+  // with no capabilities these stay exactly the base `smrt:(scope:)name` form.
+  let cacheId = scope
     ? `smrt:${scope}:${definition.name}`
     : `smrt:${definition.name}`;
-  const queryKey = scope
+  let queryKey = scope
     ? ['smrt', scope, definition.name]
     : ['smrt', definition.name];
-
-  // Hydration seeding (#1761): if the caller passed rows fetched server-side,
-  // write them into the query cache BEFORE the collection's engine starts its
-  // sync. On the first read the engine finds cached data and populates from it
-  // instead of fetching (verified: zero list() calls). `setQueryData` stamps a
-  // fresh `dataUpdatedAt`, so the seed counts as fresh for `staleTime` — the
-  // first read serves it with no request, and revalidation fires only once
-  // `staleTimeMs` elapses (or immediately when it is 0). An explicit empty seed
-  // is honored too: it means "the server returned zero rows", a valid fresh
-  // state that likewise suppresses the first fetch.
-  //
-  // Seed only when the key is empty, via the ATOMIC updater form: a plain
-  // get-then-set would let two collections sharing this key and materialized in
-  // the same tick both observe `undefined` and have the later seed clobber the
-  // earlier one. `(existing) => existing ?? initialData` keeps the first seed
-  // (or any already-cached rows, which may be newer than this late SSR payload)
-  // in a single cache write.
-  if (initialData !== undefined) {
-    queryClient.setQueryData<Row[]>(
-      queryKey,
-      (existing) => existing ?? initialData,
-    );
-  }
 
   // Relationship-derived invalidation target set (#1761): the collections
   // whose caches a settled mutation on THIS collection must invalidate. Always
@@ -616,6 +634,123 @@ export function createSmrtCollection<TData extends object>(
     });
   };
 
+  // The engine-free context every capability hook receives (#1755). `cacheKey`
+  // / `cacheId` are getter-backed over the live `let` bindings, so a capability
+  // observes the key AS IT STANDS when it reads: during `contributeCacheKey`
+  // (below) that is the base key plus any EARLIER capability's segments (not its
+  // own, not-yet-applied one); from `onAttach`/`warmStart` onward it is the
+  // FINAL key. `invalidate` enters the same `invalidateRelated()` the factory
+  // runs post-mutation, so a capability can refetch off an external trigger.
+  const ctx: SmrtWebCapabilityContext<TData> = {
+    definition,
+    fetchers,
+    get cacheKey() {
+      return queryKey;
+    },
+    get cacheId() {
+      return cacheId;
+    },
+    invalidate: () => invalidateRelated(),
+  };
+
+  // contributeCacheKey (#1755): fold each capability's returned segments into
+  // the cache key/id, extending the base scope-based scheme. Runs ONCE, before
+  // construction. With no capabilities this loop is empty and the keys are
+  // untouched — the no-op path.
+  for (const capability of capabilities) {
+    const extra = capability.contributeCacheKey?.(ctx);
+    if (extra && extra.length > 0) {
+      queryKey = [...queryKey, ...extra];
+      cacheId = `${cacheId}:${extra.join(':')}`;
+    }
+  }
+
+  // Seed the query cache BEFORE the collection's engine starts its sync, so the
+  // first read populates from the seed instead of fetching (verified: zero
+  // list() calls). `setQueryData` stamps a fresh `dataUpdatedAt`, so the seed
+  // counts as fresh for `staleTime` — the first read serves it with no request,
+  // and revalidation fires only once `staleTimeMs` elapses (or immediately when
+  // it is 0). An explicit empty seed is honored too: it means "zero rows", a
+  // valid fresh state that likewise suppresses the first fetch.
+  //
+  // Two seed sources with a fixed precedence:
+  //   1. `initialData` — hydration seeding (#1761): rows a SvelteKit
+  //      `+page.server.ts` load serialized, the fresher same-request SSR truth.
+  //   2. a capability `warmStart` (#1755) — e.g. the persistence slice
+  //      rehydrating from disk. Only the FIRST capability that returns rows
+  //      contributes.
+  // `initialData` WINS: it is resolved first, and `warmStart` is only consulted
+  // when `initialData` is undefined. With no capabilities, step 2 never runs and
+  // this is byte-identical to the #1761 seed — the no-op path.
+  //
+  // Seed via the ATOMIC updater form: a plain get-then-set would let two
+  // collections sharing this key and materialized in the same tick both observe
+  // `undefined` and have the later seed clobber the earlier one.
+  // `(existing) => existing ?? seed` keeps the first seed (or any already-cached
+  // rows, which may be newer than this late payload) in a single cache write.
+  const seedCache = (rows: Row[]): void => {
+    queryClient.setQueryData<Row[]>(queryKey, (existing) => existing ?? rows);
+  };
+  if (initialData !== undefined) {
+    seedCache(initialData);
+  } else {
+    for (const capability of capabilities) {
+      const warm = capability.warmStart?.(ctx);
+      if (warm === undefined) continue;
+      if (warm instanceof Promise) {
+        // Async rehydrate (persistence over OPFS/IndexedDB): seed when it lands.
+        // The persistence slice preloads after its own rehydrate, so a late seed
+        // still suppresses that first read; the atomic updater keeps it from
+        // clobbering fresher rows. Fire-and-forget — construction stays sync.
+        void warm.then((rows) => {
+          if (rows !== undefined) seedCache(rows);
+        });
+        break;
+      }
+      seedCache(warm);
+      break;
+    }
+  }
+
+  // Notify every capability that a mutation settled (#1755) — on BOTH a
+  // successful persist and a fetcher throw. Never throws itself (it must not
+  // mask a fetcher error), so a capability's onSettled cannot break the
+  // rollback. With no capabilities this loop is empty — the no-op path.
+  const notifySettled = (
+    envelope: SmrtWebMutationEnvelope,
+    outcome: { ok: true; result: unknown } | { ok: false; error: unknown },
+  ): void => {
+    for (const capability of capabilities) {
+      capability.onSettled?.(envelope, outcome, ctx);
+    }
+  };
+
+  /**
+   * Persist one mutation through the capability seam then the real fetcher.
+   * First offers the write to `wrapMutation` (array order, first-handled-wins):
+   * a handling capability's result stands in for the fetcher (the offline
+   * path), otherwise `runFetcher` performs the real write. On success notifies
+   * `onSettled({ ok: true })`; on ANY throw notifies `onSettled({ ok: false })`
+   * and RE-THROWS so the optimistic state still rolls back. With no
+   * capabilities `runWrapMutation` returns `{ handled: false }` and both notify
+   * loops are empty, so this reduces to `await runFetcher()` — behavior
+   * identical to before the seam.
+   */
+  const persistMutation = async (
+    envelope: SmrtWebMutationEnvelope,
+    runFetcher: () => Promise<unknown>,
+  ): Promise<unknown> => {
+    try {
+      const wrapped = await runWrapMutation(capabilities, envelope, ctx);
+      const result = wrapped.handled ? wrapped.result : await runFetcher();
+      notifySettled(envelope, { ok: true, result });
+      return result;
+    } catch (error) {
+      notifySettled(envelope, { ok: false, error });
+      throw error;
+    }
+  };
+
   const collection = createCollection(
     queryCollectionOptions<Row>({
       id: cacheId,
@@ -629,14 +764,24 @@ export function createSmrtCollection<TData extends object>(
       onInsert: async ({ transaction }) => {
         for (const mutation of transaction.mutations) {
           const modified = mutation.modified as Record<string, unknown>;
-          // Strip the client-local id: the generated REST layer rejects or
-          // ignores client-supplied ids on create (#1540); the follow-up
-          // refetch swaps the optimistic row for the server-assigned one.
-          const { [idField]: _localId, ...data } = modified;
-          unwrapItemResult(
-            await fetchers.create(data),
-            `create(${definition.name})`,
-          );
+          // Offer the write to the capability seam first (#1755), then fall
+          // through to the real create fetcher. The envelope carries the FULL
+          // optimistic row; the fetcher closure strips the client-local id: the
+          // generated REST layer rejects or ignores client-supplied ids on
+          // create (#1540), and the follow-up refetch swaps the optimistic row
+          // for the server-assigned one.
+          const envelope: SmrtWebMutationEnvelope = {
+            kind: 'insert',
+            key: String(modified[idField]),
+            data: modified,
+          };
+          await persistMutation(envelope, async () => {
+            const { [idField]: _localId, ...data } = modified;
+            return unwrapItemResult(
+              await fetchers.create(data),
+              `create(${definition.name})`,
+            );
+          });
         }
         // Persisted: refresh this collection and its related collections. Runs
         // only after every create resolved — a rejected create rolls the
@@ -648,10 +793,17 @@ export function createSmrtCollection<TData extends object>(
             for (const mutation of transaction.mutations) {
               const key = String(mutation.key);
               const changes = mutation.changes as Record<string, unknown>;
-              unwrapItemResult(
-                // biome-ignore lint/style/noNonNullAssertion: guarded by the surrounding ternary
-                await fetchers.update!(key, changes),
-                `update(${definition.name})`,
+              const envelope: SmrtWebMutationEnvelope = {
+                kind: 'update',
+                key,
+                data: changes,
+              };
+              await persistMutation(envelope, async () =>
+                unwrapItemResult(
+                  // biome-ignore lint/style/noNonNullAssertion: guarded by the surrounding ternary
+                  await fetchers.update!(key, changes),
+                  `update(${definition.name})`,
+                ),
               );
             }
             invalidateRelated();
@@ -660,8 +812,16 @@ export function createSmrtCollection<TData extends object>(
       onDelete: fetchers.delete
         ? async ({ transaction }) => {
             for (const mutation of transaction.mutations) {
-              // biome-ignore lint/style/noNonNullAssertion: guarded by the surrounding ternary
-              await fetchers.delete!(String(mutation.key));
+              const key = String(mutation.key);
+              const envelope: SmrtWebMutationEnvelope = {
+                kind: 'delete',
+                key,
+                data: {},
+              };
+              await persistMutation(envelope, async () =>
+                // biome-ignore lint/style/noNonNullAssertion: guarded by the surrounding ternary
+                fetchers.delete!(key),
+              );
             }
             invalidateRelated();
           }
@@ -690,8 +850,15 @@ export function createSmrtCollection<TData extends object>(
     preload() {
       return collection.preload();
     },
-    cleanup() {
-      return collection.cleanup();
+    async cleanup() {
+      // Tear down the engine first, THEN each capability (#1755) — so a
+      // capability's teardown runs against a stopped engine. Awaited so async
+      // teardowns (closing an SSE stream, flushing a store) complete before
+      // cleanup() resolves. With no capabilities this awaits nothing extra.
+      await collection.cleanup();
+      for (const capability of capabilities) {
+        await capability.teardown?.(ctx);
+      }
     },
     subscribeChanges(callback) {
       const subscription = collection.subscribeChanges((changes: unknown) =>
@@ -705,5 +872,14 @@ export function createSmrtCollection<TData extends object>(
   };
 
   engineCollections.set(handle, collection);
+
+  // onAttach (#1755): now that the engine collection exists, let each capability
+  // wire an external (non-mutation) trigger — an SSE subscription, a focus
+  // listener — with a callable `ctx.invalidate()`. Runs ONCE, in array order.
+  // With no capabilities this loop is empty — the no-op path.
+  for (const capability of capabilities) {
+    capability.onAttach?.(ctx);
+  }
+
   return handle;
 }

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -729,6 +729,21 @@ export function createSmrtCollection<TData extends object>(
   const seedCache = (rows: Row[]): void => {
     queryClient.setQueryData<Row[]>(queryKey, (existing) => existing ?? rows);
   };
+  // Resolve a warmStart result to rows, isolating a sync throw / async reject
+  // (logged, treated as "no rows") so a misbehaving provider can neither abort
+  // construction nor leak an unhandled rejection.
+  const warmRowsFrom = async (
+    capability: SmrtWebCapability<TData>,
+    warm: Promise<Row[] | undefined> | Row[] | undefined,
+  ): Promise<Row[] | undefined> => {
+    try {
+      return await warm;
+    } catch (error) {
+      warnCapability(capability, 'warmStart', error);
+      return undefined;
+    }
+  };
+
   // A pending async `warmStart` (persistence rehydrating from OPFS/IndexedDB).
   // Construction stays synchronous, but `preload()` (below) AWAITS this before
   // starting the engine's own load, so an async rehydrate reliably suppresses
@@ -739,7 +754,15 @@ export function createSmrtCollection<TData extends object>(
   if (initialData !== undefined) {
     seedCache(initialData);
   } else {
-    for (const capability of capabilities) {
+    // Honor "the FIRST capability that returns ROWS" across BOTH sync and async
+    // warmStart. A sync provider that returns rows seeds inline immediately (so
+    // it suppresses even a non-preload read). The FIRST provider that returns a
+    // Promise hands off to an ORDERED async chain covering itself and every
+    // LATER capability, in array order: it awaits each, skips a result that is
+    // undefined or throws/rejects, and seeds the first that yields rows. So an
+    // async miss or reject no longer blocks a later provider from seeding.
+    for (let i = 0; i < capabilities.length; i += 1) {
+      const capability = capabilities[i];
       let warm: Promise<Row[] | undefined> | Row[] | undefined;
       try {
         warm = capability.warmStart?.(ctx);
@@ -750,17 +773,29 @@ export function createSmrtCollection<TData extends object>(
       }
       if (warm === undefined) continue;
       if (warm instanceof Promise) {
-        // Capture the promise so preload() can gate the first read on it, and
-        // isolate its rejection so a failed rehydrate can't surface as an
-        // unhandled rejection. The atomic updater keeps a late seed from
-        // clobbering fresher rows.
-        warmStartPending = warm
-          .then((rows) => {
-            if (rows !== undefined) seedCache(rows);
-          })
-          .catch((error) => {
-            warnCapability(capability, 'warmStart', error);
-          });
+        const firstPromise = warm;
+        warmStartPending = (async () => {
+          // This capability first (its promise is already in flight), then each
+          // later capability in order until one yields rows.
+          let rows = await warmRowsFrom(capability, firstPromise);
+          for (
+            let j = i + 1;
+            rows === undefined && j < capabilities.length;
+            j += 1
+          ) {
+            const later = capabilities[j];
+            let laterWarm: Promise<Row[] | undefined> | Row[] | undefined;
+            try {
+              laterWarm = later.warmStart?.(ctx);
+            } catch (error) {
+              warnCapability(later, 'warmStart', error);
+              continue;
+            }
+            if (laterWarm === undefined) continue;
+            rows = await warmRowsFrom(later, laterWarm);
+          }
+          if (rows !== undefined) seedCache(rows);
+        })();
         break;
       }
       seedCache(warm);

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -546,6 +546,26 @@ export function getEngineCollection<TData extends object>(
 }
 
 /**
+ * Report a capability hook that threw or rejected, without letting it break the
+ * collection (#1755). Capability hooks are third-party plug-ins; one misbehaving
+ * hook must not reject a successful mutation, abort construction, or wedge
+ * `cleanup()`. smrt-web has no logger dependency (TanStack-only), so this uses
+ * `console.warn` — a swallowed diagnostic, matching the package's fail-loud-in-
+ * the-console style.
+ */
+function warnCapability(
+  capability: { name: string },
+  hook: string,
+  error: unknown,
+): void {
+  // biome-ignore lint/suspicious/noConsole: smrt-web has no logger dep (TanStack-only); a swallowed capability fault is surfaced via console.warn by design (#1755)
+  console.warn(
+    `[smrt-web] capability "${capability.name}" ${hook} threw; ignoring`,
+    error,
+  );
+}
+
+/**
  * Create a typed client collection over a generated SMRT collection definition
  * and the matching generated REST client fetchers.
  *
@@ -655,12 +675,30 @@ export function createSmrtCollection<TData extends object>(
 
   // contributeCacheKey (#1755): fold each capability's returned segments into
   // the cache key/id, extending the base scope-based scheme. Runs ONCE, before
-  // construction. With no capabilities this loop is empty and the keys are
-  // untouched — the no-op path.
+  // construction. Isolated per capability: a throwing contributeCacheKey is
+  // logged and skipped rather than aborting construction. With no capabilities
+  // this loop is empty and the keys are untouched — the no-op path.
+  //
+  // CRITICAL — segments are spliced in JUST BEFORE the collection name, so the
+  // name stays the LAST queryKey element. `invalidateRelated()`'s predicate
+  // (and thus relationship-derived invalidation #1761, and a capability's own
+  // `ctx.invalidate()`) identifies a collection by `key[key.length - 1]`;
+  // appending segments after the name would hide it from that predicate and
+  // silently break invalidation for any collection using contributeCacheKey
+  // (exactly the #1764 persistence slice). `cacheId` is an opaque engine id the
+  // predicate never reads, so it can keep appending.
   for (const capability of capabilities) {
-    const extra = capability.contributeCacheKey?.(ctx);
+    let extra: string[] | undefined;
+    try {
+      extra = capability.contributeCacheKey?.(ctx);
+    } catch (error) {
+      warnCapability(capability, 'contributeCacheKey', error);
+    }
     if (extra && extra.length > 0) {
-      queryKey = [...queryKey, ...extra];
+      // Rebuild as [prefix..., ...extra, name] — name remains last.
+      const name = queryKey[queryKey.length - 1];
+      const prefix = queryKey.slice(0, -1);
+      queryKey = [...prefix, ...extra, name];
       cacheId = `${cacheId}:${extra.join(':')}`;
     }
   }
@@ -691,20 +729,38 @@ export function createSmrtCollection<TData extends object>(
   const seedCache = (rows: Row[]): void => {
     queryClient.setQueryData<Row[]>(queryKey, (existing) => existing ?? rows);
   };
+  // A pending async `warmStart` (persistence rehydrating from OPFS/IndexedDB).
+  // Construction stays synchronous, but `preload()` (below) AWAITS this before
+  // starting the engine's own load, so an async rehydrate reliably suppresses
+  // the first `list()` on the preload path. A subscribe-driven read that races
+  // an unresolved warmStart may still fetch once — bounded, and it self-heals
+  // via the atomic seed updater. Undefined when there is no async warmStart.
+  let warmStartPending: Promise<void> | undefined;
   if (initialData !== undefined) {
     seedCache(initialData);
   } else {
     for (const capability of capabilities) {
-      const warm = capability.warmStart?.(ctx);
+      let warm: Promise<Row[] | undefined> | Row[] | undefined;
+      try {
+        warm = capability.warmStart?.(ctx);
+      } catch (error) {
+        // A synchronous warmStart throw must not abort construction.
+        warnCapability(capability, 'warmStart', error);
+        continue;
+      }
       if (warm === undefined) continue;
       if (warm instanceof Promise) {
-        // Async rehydrate (persistence over OPFS/IndexedDB): seed when it lands.
-        // The persistence slice preloads after its own rehydrate, so a late seed
-        // still suppresses that first read; the atomic updater keeps it from
-        // clobbering fresher rows. Fire-and-forget — construction stays sync.
-        void warm.then((rows) => {
-          if (rows !== undefined) seedCache(rows);
-        });
+        // Capture the promise so preload() can gate the first read on it, and
+        // isolate its rejection so a failed rehydrate can't surface as an
+        // unhandled rejection. The atomic updater keeps a late seed from
+        // clobbering fresher rows.
+        warmStartPending = warm
+          .then((rows) => {
+            if (rows !== undefined) seedCache(rows);
+          })
+          .catch((error) => {
+            warnCapability(capability, 'warmStart', error);
+          });
         break;
       }
       seedCache(warm);
@@ -713,15 +769,21 @@ export function createSmrtCollection<TData extends object>(
   }
 
   // Notify every capability that a mutation settled (#1755) — on BOTH a
-  // successful persist and a fetcher throw. Never throws itself (it must not
-  // mask a fetcher error), so a capability's onSettled cannot break the
-  // rollback. With no capabilities this loop is empty — the no-op path.
+  // successful persist and a fetcher throw. Per-capability try/catch so this
+  // genuinely NEVER throws: a throwing onSettled must not reject a SUCCESSFUL
+  // mutation nor mask a fetcher error, and one bad capability must not stop the
+  // others being notified. With no capabilities this loop is empty — the no-op
+  // path.
   const notifySettled = (
     envelope: SmrtWebMutationEnvelope,
     outcome: { ok: true; result: unknown } | { ok: false; error: unknown },
   ): void => {
     for (const capability of capabilities) {
-      capability.onSettled?.(envelope, outcome, ctx);
+      try {
+        capability.onSettled?.(envelope, outcome, ctx);
+      } catch (error) {
+        warnCapability(capability, 'onSettled', error);
+      }
     }
   };
 
@@ -731,20 +793,25 @@ export function createSmrtCollection<TData extends object>(
    * a handling capability's result stands in for the fetcher (the offline
    * path), otherwise `runFetcher` performs the real write. On success notifies
    * `onSettled({ ok: true })`; on ANY throw notifies `onSettled({ ok: false })`
-   * and RE-THROWS so the optimistic state still rolls back. With no
-   * capabilities `runWrapMutation` returns `{ handled: false }` and both notify
-   * loops are empty, so this reduces to `await runFetcher()` — behavior
-   * identical to before the seam.
+   * and RE-THROWS so the optimistic state still rolls back.
+   *
+   * Returns `handled` so the caller can suppress the engine's post-mutation
+   * refetch for an offline write (#1762): a handled write never hit the server,
+   * so refetching the server list would DROP the optimistic row the outbox must
+   * keep until it replays. With no capabilities `runWrapMutation` returns
+   * `{ handled: false }` and both notify loops are empty, so this reduces to
+   * `await runFetcher()` with `handled: false` — behavior identical to before
+   * the seam.
    */
   const persistMutation = async (
     envelope: SmrtWebMutationEnvelope,
     runFetcher: () => Promise<unknown>,
-  ): Promise<unknown> => {
+  ): Promise<{ handled: boolean; result: unknown }> => {
     try {
       const wrapped = await runWrapMutation(capabilities, envelope, ctx);
       const result = wrapped.handled ? wrapped.result : await runFetcher();
       notifySettled(envelope, { ok: true, result });
-      return result;
+      return { handled: wrapped.handled, result };
     } catch (error) {
       notifySettled(envelope, { ok: false, error });
       throw error;
@@ -762,6 +829,7 @@ export function createSmrtCollection<TData extends object>(
         unwrapListResult(await fetchers.list(), definition.name) as Array<Row>,
       getKey: (row) => String((row as Record<string, unknown>)[idField]),
       onInsert: async ({ transaction }) => {
+        let anyHandled = false;
         for (const mutation of transaction.mutations) {
           const modified = mutation.modified as Record<string, unknown>;
           // Offer the write to the capability seam first (#1755), then fall
@@ -775,21 +843,30 @@ export function createSmrtCollection<TData extends object>(
             key: String(modified[idField]),
             data: modified,
           };
-          await persistMutation(envelope, async () => {
+          const outcome = await persistMutation(envelope, async () => {
             const { [idField]: _localId, ...data } = modified;
             return unwrapItemResult(
               await fetchers.create(data),
               `create(${definition.name})`,
             );
           });
+          anyHandled = anyHandled || outcome.handled;
         }
-        // Persisted: refresh this collection and its related collections. Runs
-        // only after every create resolved — a rejected create rolls the
-        // optimistic row back and never reaches here.
+        // If a capability handled the write offline (#1762) it never reached the
+        // server, so BOTH the engine's own post-mutation refetch (suppressed via
+        // `{ refetch: false }`) and `invalidateRelated()` are skipped — else the
+        // server list, which lacks the offline row, would drop the optimistic
+        // row the outbox must keep until it replays. A mixed batch (some
+        // handled, some not) is conservative: if ANY mutation was handled we
+        // suppress, so an unsent row is never dropped; the common case is one
+        // mutation per transaction. An UNHANDLED batch behaves exactly as
+        // before: refetch runs and related caches invalidate.
+        if (anyHandled) return { refetch: false };
         invalidateRelated();
       },
       onUpdate: fetchers.update
         ? async ({ transaction }) => {
+            let anyHandled = false;
             for (const mutation of transaction.mutations) {
               const key = String(mutation.key);
               const changes = mutation.changes as Record<string, unknown>;
@@ -798,19 +875,22 @@ export function createSmrtCollection<TData extends object>(
                 key,
                 data: changes,
               };
-              await persistMutation(envelope, async () =>
+              const outcome = await persistMutation(envelope, async () =>
                 unwrapItemResult(
                   // biome-ignore lint/style/noNonNullAssertion: guarded by the surrounding ternary
                   await fetchers.update!(key, changes),
                   `update(${definition.name})`,
                 ),
               );
+              anyHandled = anyHandled || outcome.handled;
             }
+            if (anyHandled) return { refetch: false };
             invalidateRelated();
           }
         : undefined,
       onDelete: fetchers.delete
         ? async ({ transaction }) => {
+            let anyHandled = false;
             for (const mutation of transaction.mutations) {
               const key = String(mutation.key);
               const envelope: SmrtWebMutationEnvelope = {
@@ -818,11 +898,13 @@ export function createSmrtCollection<TData extends object>(
                 key,
                 data: {},
               };
-              await persistMutation(envelope, async () =>
+              const outcome = await persistMutation(envelope, async () =>
                 // biome-ignore lint/style/noNonNullAssertion: guarded by the surrounding ternary
                 fetchers.delete!(key),
               );
+              anyHandled = anyHandled || outcome.handled;
             }
+            if (anyHandled) return { refetch: false };
             invalidateRelated();
           }
         : undefined,
@@ -848,16 +930,33 @@ export function createSmrtCollection<TData extends object>(
       return row === undefined ? undefined : toPlainRow<TData>(row);
     },
     preload() {
-      return collection.preload();
+      // Gate the first read on a pending async warmStart (#1755) so an async
+      // rehydrate (persistence over OPFS/IndexedDB) reliably seeds the cache
+      // BEFORE the engine's own load runs — otherwise the fetch that persistence
+      // was meant to suppress would race ahead. Resolved/rejected warmStart is
+      // already handled (seeded or logged); we only need to await settlement.
+      //
+      // When there is NO pending warmStart (incl. the no-op path and the
+      // `initialData` seed path) return the engine promise DIRECTLY — no extra
+      // async wrapper — so the microtask timing is byte-identical to before the
+      // seam (a wrapper tick would let a staleTime:0 revalidation land early).
+      if (!warmStartPending) return collection.preload();
+      return warmStartPending.then(() => collection.preload());
     },
     async cleanup() {
       // Tear down the engine first, THEN each capability (#1755) — so a
       // capability's teardown runs against a stopped engine. Awaited so async
       // teardowns (closing an SSE stream, flushing a store) complete before
-      // cleanup() resolves. With no capabilities this awaits nothing extra.
+      // cleanup() resolves. Per-capability try/catch so one rejecting teardown
+      // does not skip the others nor reject cleanup(). With no capabilities this
+      // awaits nothing extra.
       await collection.cleanup();
       for (const capability of capabilities) {
-        await capability.teardown?.(ctx);
+        try {
+          await capability.teardown?.(ctx);
+        } catch (error) {
+          warnCapability(capability, 'teardown', error);
+        }
       }
     },
     subscribeChanges(callback) {
@@ -876,9 +975,15 @@ export function createSmrtCollection<TData extends object>(
   // onAttach (#1755): now that the engine collection exists, let each capability
   // wire an external (non-mutation) trigger — an SSE subscription, a focus
   // listener — with a callable `ctx.invalidate()`. Runs ONCE, in array order.
-  // With no capabilities this loop is empty — the no-op path.
+  // Per-capability try/catch so a throwing onAttach cannot break construction
+  // after the handle is already registered, nor skip later capabilities. With
+  // no capabilities this loop is empty — the no-op path.
   for (const capability of capabilities) {
-    capability.onAttach?.(ctx);
+    try {
+      capability.onAttach?.(ctx);
+    } catch (error) {
+      warnCapability(capability, 'onAttach', error);
+    }
   }
 
   return handle;

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -729,6 +729,11 @@ export function createSmrtCollection<TData extends object>(
   const seedCache = (rows: Row[]): void => {
     queryClient.setQueryData<Row[]>(queryKey, (existing) => existing ?? rows);
   };
+  // Set by cleanup(); guards the async-warmStart continuations (#1755) so a
+  // collection torn down while a rehydrate is still in flight neither seeds the
+  // SHARED query cache after teardown (which could suppress the next collection's
+  // real fetch on the same client/key) nor preloads the dead engine.
+  let disposed = false;
   // Resolve a warmStart result to rows, isolating a sync throw / async reject
   // (logged, treated as "no rows") so a misbehaving provider can neither abort
   // construction nor leak an unhandled rejection.
@@ -794,7 +799,10 @@ export function createSmrtCollection<TData extends object>(
             if (laterWarm === undefined) continue;
             rows = await warmRowsFrom(later, laterWarm);
           }
-          if (rows !== undefined) seedCache(rows);
+          // Skip the seed if the collection was cleaned up while the rehydrate
+          // was in flight — a late write to the shared cache could otherwise
+          // suppress the NEXT collection's real fetch on the same client/key.
+          if (rows !== undefined && !disposed) seedCache(rows);
         })();
         break;
       }
@@ -976,9 +984,18 @@ export function createSmrtCollection<TData extends object>(
       // async wrapper — so the microtask timing is byte-identical to before the
       // seam (a wrapper tick would let a staleTime:0 revalidation land early).
       if (!warmStartPending) return collection.preload();
-      return warmStartPending.then(() => collection.preload());
+      // If cleanup() ran while the warmStart was still pending, don't preload the
+      // torn-down engine — resolve to nothing.
+      return warmStartPending.then(() => {
+        if (disposed) return;
+        return collection.preload();
+      });
     },
     async cleanup() {
+      // Mark disposed FIRST so any still-pending async warmStart continuation
+      // sees it and skips seeding the shared cache / preloading the dead engine
+      // (#1755, Fix G) — even though the continuation runs on a later tick.
+      disposed = true;
       // Tear down the engine first, THEN each capability (#1755) — so a
       // capability's teardown runs against a stopped engine. Awaited so async
       // teardowns (closing an SSE stream, flushing a store) complete before


### PR DESCRIPTION
## What

Adds a **capability extension seam** to `createSmrtCollection` in
`@happyvertical/smrt-web` — an optional `capabilities?: SmrtWebCapability[]`
plug-in point — plus the shared `durable-store.ts` foundation. Behavior-preserving
infra for the smrt-web track (PRD #1755). Ships **zero concrete capabilities** by
design.

## Why

The three follow-on client slices — offline outbox (#1762), persistence
(#1764), and live SSE invalidation (#1763-client) — would each need to reach
into the same regions of `index.ts` (cache-key construction, the seed write, the
mutation handlers, `cleanup()`). This seam lets each slice live in its **own
module** and register through a stable, engine-free interface, so they can be
built in parallel without contending on `index.ts`.

## The six hooks (run in array order)

1. **`contributeCacheKey(ctx)`** — once, before construction. Returned segments
   extend the base `smrt:(scope:)name` cache id/key so a capability can partition
   the cache.
2. **`warmStart(ctx)`** — once, before the first read. Returns rows that seed the
   cache (persistence rehydrate-from-disk). **`initialData` wins** — it is the
   fresher same-request SSR truth, so `warmStart` is consulted only when
   `initialData` is undefined; the first capability that returns rows contributes.
3. **`wrapMutation(envelope, ctx)`** — per mutation, before the fetcher. Return
   `{ handled: true, result }` to take over the write (fetcher skipped, `result`
   reconciles the optimistic row — the offline path) or `{ handled: false }` to
   fall through. First `{ handled: true }` wins; later capabilities' `wrapMutation`
   are skipped.
4. **`onSettled(envelope, outcome, ctx)`** — per mutation, after settle, on BOTH
   a successful persist (`{ ok: true, result }`) AND a fetcher throw
   (`{ ok: false, error }`). Never swallows the throw — a rejected fetcher still
   rolls the optimistic state back.
5. **`onAttach(ctx)`** — once, right after the engine collection is constructed.
   The only place a capability wires an external (non-mutation) trigger such as an
   SSE subscription; `ctx.invalidate()` enters the same relationship-derived
   invalidation the factory runs post-mutation.
6. **`teardown(ctx)`** — inside `cleanup()`, after the engine's own cleanup;
   awaited if async.

## No-op guarantee

With `capabilities` undefined or `[]`, every path is **byte-for-byte the
collection of today**: zero contributeCacheKey/warmStart/onAttach/teardown calls,
`wrapMutation` always falls through to the real fetcher, `onSettled` runs nothing,
and relationship-derived invalidation fires exactly as before. **The existing
`collection.test.ts` / `invalidation.test.ts` assertions pass unmodified.**

## Durable-store shared foundation

`durable-store.ts` is the one SMRT-layer namespace + wipe registry both the
outbox (#1762) and persistence (#1764) slices build on — pure bookkeeping, zero
`@tanstack/*` imports:

- `durableStoreNamespace(key)` → deterministic
  `smrt-web:${apiBase}:${tenantId ?? '-'}:${identityId ?? '-'}:${manifestHash}`.
- `registerDurableResource(ns, resource)` → unregister; `wipeDurableStore(ns)`
  clears every registered resource (best-effort — a rejected `clear()` doesn't
  abort the sweep) then drops the namespace; safe no-op on unknown/empty ns.

**Rationale:** TanStack DB persistence (SQLite-WASM/OPFS) and
`@tanstack/offline-transactions` (IndexedDB) are **separate storage engines**, so
the shared foundation lives one level up — each slice keys its own TanStack
primitive under a shared namespace, and `wipe()` clears both through the registry
without the two modules importing each other. Nothing calls it yet; it ships
ahead of its consumers so #1762/#1764 agree on it from day one.

## Engine boundary stays sacred

The capability context, mutation envelope, and durable-store types are all typed
entirely in existing SMRT-owned terms (`SmrtWebCollectionDefinition`,
`SmrtCrudFetchers`, `SmrtWebRow`, plain TS) — **no `@tanstack/*` type on the
surface**. The build's `.d.ts` boundary check
(`scripts/check-smrt-web-engine-boundary.mjs`) stays green. All new types are
re-exported through the single package entry — **no new export subpath**, so no
vitest alias change is needed.

## Verification

- `pnpm test` — **53 passed** (24 existing unmodified + 29 new: 11 durable-store,
  6 capability runner, 12 seam integration).
- `pnpm build` — engine-boundary check **green** (`1 declaration file(s)
  engine-agnostic`; the only `@tanstack` strings in the `.d.ts` are backtick
  prose, which the specifier regex correctly ignores).
- `pnpm typecheck` — clean.
- `biome check` — clean on all touched files.
- `pnpm knowledge:check --strict` — **fresh**, 0 errors / 0 warnings.

No `.changeset` (auto-bot on merge).
