### PR TITLE
feat(core): add copyable endpoint preview examples

### DIFF
--- a/packages/core/src/mcp-advisor/tools/preview-api-endpoints.test.ts
+++ b/packages/core/src/mcp-advisor/tools/preview-api-endpoints.test.ts
@@ -41,10 +41,18 @@ describe('mcp-advisor: previewApiEndpoints', () => {
     );
     const titleParam = create?.parameters?.find((p) => p.name === 'title');
     expect(titleParam).toMatchObject({
+      description: 'Product display name',
+      example: 'example-title',
       location: 'body',
       required: true,
       type: 'text',
     });
+
+    expect(create?.example).toBe(
+      'curl -X POST "http://localhost:3000/api/v1/advisorrichproducts" -H "Content-Type: application/json" -d \'{"title":"example-title","quantity":1,"rate":9.99}\'',
+    );
+    expect(result.markdown).toContain('## POST /api/v1/advisorrichproducts');
+    expect(result.markdown).toContain('```bash\ncurl -X POST');
   });
 
   it('honours an exclude list (delete removed)', async () => {
@@ -58,6 +66,39 @@ describe('mcp-advisor: previewApiEndpoints', () => {
     expect(byKey).toContain('POST /api/v1/advisorexcludenotes');
     expect(byKey).toContain('PUT /api/v1/advisorexcludenotes/:id');
     expect(byKey).not.toContain('DELETE /api/v1/advisorexcludenotes/:id');
+  });
+
+  it('includes query parameters and copyable examples for list endpoints', async () => {
+    const result = await previewApiEndpoints({
+      className: 'AdvisorRichProduct',
+    });
+
+    const list = result.endpoints.find(
+      (e) => e.method === 'GET' && e.path === '/api/v1/advisorrichproducts',
+    );
+    expect(list?.parameters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          example: 25,
+          location: 'query',
+          name: 'limit',
+          type: 'integer',
+        }),
+        expect.objectContaining({
+          example: 'example-title',
+          location: 'query',
+          name: 'title',
+          type: 'text',
+        }),
+      ]),
+    );
+    expect(list?.parameters?.map((p) => p.name)).not.toContain('where');
+    expect(list?.example).toContain(
+      'http://localhost:3000/api/v1/advisorrichproducts?',
+    );
+    expect(list?.example).toContain('limit=25');
+    expect(list?.example).toContain('title=example-title');
+    expect(result.markdown).toContain('| title | query | text | no |');
   });
 
   it('respects a custom base path', async () => {
@@ -75,5 +116,7 @@ describe('mcp-advisor: previewApiEndpoints', () => {
     const result = await previewApiEndpoints({ className: 'UnknownApiClass' });
     const methods = result.endpoints.map((e) => e.method).sort();
     expect(methods).toEqual(['DELETE', 'GET', 'GET', 'POST', 'PUT']);
+    expect(result.endpoints.every((e) => e.parameters)).toBe(true);
+    expect(result.endpoints.every((e) => e.example)).toBe(true);
   });
 });

--- a/packages/core/src/mcp-advisor/tools/preview-api-endpoints.ts
+++ b/packages/core/src/mcp-advisor/tools/preview-api-endpoints.ts
@@ -10,7 +10,7 @@ import type { ApiEndpoint, PreviewApiEndpointsInput } from '../types.js';
  */
 export async function previewApiEndpoints(
   input: PreviewApiEndpointsInput,
-): Promise<{ endpoints: ApiEndpoint[]; basePath: string }> {
+): Promise<{ endpoints: ApiEndpoint[]; basePath: string; markdown: string }> {
   try {
     const { className, basePath = '/api/v1' } = input;
 
@@ -36,11 +36,19 @@ export async function previewApiEndpoints(
 
     // Get fields for request/response documentation
     const fields = ObjectRegistry.getFields(className);
-    const fieldsList = Array.from(fields.entries()).map(([name, field]) => ({
-      name,
-      type: field.type,
-      required: field._meta?.required || false,
-    }));
+    const fieldsList = Array.from(fields.entries()).map(([name, field]) => {
+      const type = field.type;
+      return {
+        name,
+        type,
+        required: field._meta?.required || false,
+        description:
+          typeof field._meta?.description === 'string'
+            ? field._meta.description
+            : undefined,
+        example: sampleValueForType(type, name),
+      };
+    });
 
     // Generate endpoint definitions
     const endpoints: ApiEndpoint[] = [];
@@ -59,25 +67,33 @@ export async function previewApiEndpoints(
             type: 'integer',
             required: false,
             location: 'query',
+            description: 'Maximum number of objects to return',
+            example: 25,
           },
           {
             name: 'offset',
             type: 'integer',
             required: false,
             location: 'query',
+            description: 'Number of objects to skip',
+            example: 0,
           },
           {
             name: 'orderBy',
             type: 'string',
             required: false,
             location: 'query',
+            description: 'SQL-style ordering expression',
+            example: 'created_at DESC',
           },
-          {
-            name: 'where',
-            type: 'object',
+          ...fieldsList.map((field) => ({
+            name: field.name,
+            type: field.type,
             required: false,
-            location: 'query',
-          },
+            location: 'query' as const,
+            description: `Filter by ${field.name}. Operator suffixes like [gt], [gte], [lt], [lte], [ne], [in], and [like] are also supported.`,
+            example: field.example,
+          })),
         ],
       });
     }
@@ -94,6 +110,8 @@ export async function previewApiEndpoints(
             type: 'string',
             required: true,
             location: 'path',
+            description: `${className} id or slug`,
+            example: 'example-id',
           },
         ],
       });
@@ -110,6 +128,8 @@ export async function previewApiEndpoints(
           type: field.type,
           required: field.required,
           location: 'body',
+          description: field.description,
+          example: field.example,
         })),
       });
     }
@@ -126,12 +146,16 @@ export async function previewApiEndpoints(
             type: 'string',
             required: true,
             location: 'path',
+            description: `${className} id or slug`,
+            example: 'example-id',
           },
           ...fieldsList.map((field) => ({
             name: field.name,
             type: field.type,
             required: false,
             location: 'body' as const,
+            description: field.description,
+            example: field.example,
           })),
         ],
       });
@@ -149,6 +173,8 @@ export async function previewApiEndpoints(
             type: 'string',
             required: true,
             location: 'path',
+            description: `${className} id or slug`,
+            example: 'example-id',
           },
         ],
       });
@@ -172,12 +198,16 @@ export async function previewApiEndpoints(
                 type: 'string',
                 required: true,
                 location: 'path',
+                description: `${className} id or slug`,
+                example: 'example-id',
               },
               {
                 name: 'options',
                 type: 'object',
                 required: false,
                 location: 'body',
+                description: `Options for the ${action} action`,
+                example: {},
               },
             ],
           });
@@ -185,12 +215,15 @@ export async function previewApiEndpoints(
       }
     }
 
-    // Format as markdown table
-    const _markdown = formatEndpointsAsMarkdown(endpoints, className);
+    const endpointsWithExamples = endpoints.map((endpoint) => ({
+      ...endpoint,
+      example: buildCurlExample(endpoint),
+    }));
 
     return {
-      endpoints,
+      endpoints: endpointsWithExamples,
       basePath,
+      markdown: formatEndpointsAsMarkdown(endpointsWithExamples, className),
     };
   } catch (error) {
     throw new Error(
@@ -200,18 +233,156 @@ export async function previewApiEndpoints(
 }
 
 /**
- * Format endpoints as markdown table
+ * Generate a deterministic example value for endpoint documentation.
+ */
+function sampleValueForType(type: string, name: string): unknown {
+  const normalizedType = type.toLowerCase();
+  const normalizedName = name.toLowerCase();
+
+  if (normalizedName === 'id' || normalizedName.endsWith('id')) {
+    return 'example-id';
+  }
+
+  if (
+    normalizedType.includes('integer') ||
+    normalizedType.includes('int') ||
+    normalizedType === 'number'
+  ) {
+    return 1;
+  }
+
+  if (
+    normalizedType.includes('decimal') ||
+    normalizedType.includes('float') ||
+    normalizedType.includes('double')
+  ) {
+    return 9.99;
+  }
+
+  if (normalizedType.includes('boolean')) {
+    return true;
+  }
+
+  if (
+    normalizedType.includes('datetime') ||
+    normalizedType.includes('timestamp') ||
+    normalizedType === 'date'
+  ) {
+    return '2026-01-01T00:00:00.000Z';
+  }
+
+  if (normalizedType.includes('json') || normalizedType.includes('object')) {
+    return {};
+  }
+
+  if (normalizedType.includes('array')) {
+    return [];
+  }
+
+  return `example-${toKebabCase(name)}`;
+}
+
+function toKebabCase(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+}
+
+function buildCurlExample(endpoint: ApiEndpoint): string {
+  const path = endpoint.path.replaceAll(':id', 'example-id');
+  const url = new URL(`http://localhost:3000${path}`);
+
+  for (const parameter of endpoint.parameters ?? []) {
+    if (parameter.location !== 'query') {
+      continue;
+    }
+    url.searchParams.set(parameter.name, formatQueryValue(parameter));
+  }
+
+  const body = buildBodyExample(endpoint);
+  const parts = [`curl -X ${endpoint.method} "${url.toString()}"`];
+  if (body) {
+    parts.push('-H "Content-Type: application/json"');
+    parts.push(`-d '${JSON.stringify(body)}'`);
+  }
+
+  return parts.join(' ');
+}
+
+function buildBodyExample(
+  endpoint: ApiEndpoint,
+): Record<string, unknown> | null {
+  const bodyParameters =
+    endpoint.parameters?.filter((parameter) => parameter.location === 'body') ??
+    [];
+  if (bodyParameters.length === 0) {
+    return null;
+  }
+
+  const body: Record<string, unknown> = {};
+  for (const parameter of bodyParameters) {
+    body[parameter.name] =
+      parameter.example ?? sampleValueForType(parameter.type, parameter.name);
+  }
+
+  return body;
+}
+
+function formatExampleValue(value: unknown): string {
+  if (value === undefined) {
+    return '';
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return JSON.stringify(value) ?? '';
+}
+
+function formatQueryValue(
+  parameter: NonNullable<ApiEndpoint['parameters']>[number],
+): string {
+  return formatExampleValue(
+    parameter.example ?? sampleValueForType(parameter.type, parameter.name),
+  );
+}
+
+function escapeMarkdownCell(value: string): string {
+  return value.replaceAll('|', '\\|').replaceAll('\n', '<br />');
+}
+
+/**
+ * Format endpoints as copyable markdown sections.
  */
 function formatEndpointsAsMarkdown(
   endpoints: ApiEndpoint[],
   className: string,
 ): string {
   let markdown = `# API Endpoints for ${className}\n\n`;
-  markdown += `| Method | Path | Description |\n`;
-  markdown += `|--------|------|-------------|\n`;
 
   for (const endpoint of endpoints) {
-    markdown += `| ${endpoint.method} | ${endpoint.path} | ${endpoint.description} |\n`;
+    markdown += `## ${endpoint.method} ${endpoint.path}\n\n`;
+    markdown += `${endpoint.description}\n\n`;
+    markdown += `| Parameter | Location | Type | Required | Example | Description |\n`;
+    markdown += `|-----------|----------|------|----------|---------|-------------|\n`;
+
+    if (endpoint.parameters?.length) {
+      for (const parameter of endpoint.parameters) {
+        markdown +=
+          `| ${escapeMarkdownCell(parameter.name)}` +
+          ` | ${parameter.location}` +
+          ` | ${escapeMarkdownCell(parameter.type)}` +
+          ` | ${parameter.required ? 'yes' : 'no'}` +
+          ` | ${escapeMarkdownCell(formatExampleValue(parameter.example))}` +
+          ` | ${escapeMarkdownCell(parameter.description ?? '')} |\n`;
+      }
+    } else {
+      markdown += `| _none_ | | | | | |\n`;
+    }
+
+    markdown += `\nExample:\n\n`;
+    markdown += `\`\`\`bash\n${endpoint.example}\n\`\`\`\n\n`;
   }
 
   return markdown;

--- a/packages/core/src/mcp-advisor/types.ts
+++ b/packages/core/src/mcp-advisor/types.ts
@@ -143,7 +143,10 @@ export interface ApiEndpoint {
     type: string;
     required: boolean;
     location: 'path' | 'query' | 'body';
+    description?: string;
+    example?: unknown;
   }>;
+  example?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add endpoint-level copyable curl examples to the `preview-api-endpoints` advisor output.
- Include parameter descriptions and example values in each returned endpoint parameter.
- Return markdown with per-endpoint parameter tables and bash example blocks.
- Align list endpoint preview parameters with the generated REST query behavior by using field query filters instead of a synthetic `where` object.

## Validation

- `pnpm run build`
- `pnpm --filter @happyvertical/smrt-core typecheck`
- `pnpm --filter @happyvertical/smrt-core exec vitest run src/mcp-advisor`
- `pnpm exec biome check packages/core/src/mcp-advisor/types.ts packages/core/src/mcp-advisor/tools/preview-api-endpoints.ts packages/core/src/mcp-advisor/tools/preview-api-endpoints.test.ts`
- `pnpm run knowledge:check -- --strict --format markdown`
- pre-push hooks passed