### PR TITLE
fix(core): align endpoint previews with API policies

### DIFF
--- a/packages/core/src/__tests__/fixtures/advisor-test-classes.ts
+++ b/packages/core/src/__tests__/fixtures/advisor-test-classes.ts
@@ -48,6 +48,42 @@ export class AdvisorRichProduct extends SmrtObject {
   }
 }
 
+@smrt({
+  api: {
+    include: ['list', 'create', 'update'],
+    writable: [
+      'displayName',
+      'customerId',
+      'externalId',
+      'secretToken',
+      'internalCode',
+      'tenantId',
+    ],
+  },
+})
+export class AdvisorPolicyRecord extends SmrtObject {
+  @field({ required: true })
+  displayName: string = '';
+
+  @field({ type: 'foreignKey' })
+  customerId: string = '';
+
+  @field({ type: 'integer' })
+  externalId: number = 0;
+
+  @field({ sensitive: true })
+  secretToken: string = '';
+
+  @field({ readonly: true })
+  internalCode: string = '';
+
+  @field()
+  tenantId: string = '';
+
+  @field()
+  ignoredValue: string = '';
+}
+
 /**
  * Boolean-config object: api/mcp enabled via `true`, cli disabled. Exercises
  * the boolean branches in list-registered-objects and get-object-config.

--- a/packages/core/src/mcp-advisor/tools/preview-api-endpoints.test.ts
+++ b/packages/core/src/mcp-advisor/tools/preview-api-endpoints.test.ts
@@ -9,12 +9,16 @@
 import { describe, expect, it } from 'vitest';
 import {
   AdvisorExcludeNote,
+  AdvisorPolicyRecord,
   AdvisorRichProduct,
 } from '../../__tests__/fixtures/advisor-test-classes.js';
 import { previewApiEndpoints } from './preview-api-endpoints.js';
 
 void AdvisorExcludeNote;
+void AdvisorPolicyRecord;
 void AdvisorRichProduct;
+
+const EXAMPLE_UUID = '00000000-0000-4000-8000-000000000001';
 
 describe('mcp-advisor: previewApiEndpoints', () => {
   it('generates endpoints honouring an include list plus custom actions', async () => {
@@ -49,7 +53,7 @@ describe('mcp-advisor: previewApiEndpoints', () => {
     });
 
     expect(create?.example).toBe(
-      'curl -X POST "http://localhost:3000/api/v1/advisorrichproducts" -H "Content-Type: application/json" -d \'{"title":"example-title","quantity":1,"rate":9.99}\'',
+      'curl -X POST "https://api.example.com/api/v1/advisorrichproducts" -H "Content-Type: application/json" -d \'{"title":"example-title","quantity":1,"rate":9.99}\'',
     );
     expect(result.markdown).toContain('## POST /api/v1/advisorrichproducts');
     expect(result.markdown).toContain('```bash\ncurl -X POST');
@@ -94,11 +98,61 @@ describe('mcp-advisor: previewApiEndpoints', () => {
     );
     expect(list?.parameters?.map((p) => p.name)).not.toContain('where');
     expect(list?.example).toContain(
-      'http://localhost:3000/api/v1/advisorrichproducts?',
+      'https://api.example.com/api/v1/advisorrichproducts?',
     );
     expect(list?.example).toContain('limit=25');
     expect(list?.example).toContain('title=example-title');
     expect(result.markdown).toContain('| title | query | text | no |');
+    expect(result.markdown).toContain('title[in]=value1,value2');
+  });
+
+  it('mirrors sensitive filter and writable body policies', async () => {
+    const result = await previewApiEndpoints({
+      className: 'AdvisorPolicyRecord',
+    });
+
+    const list = result.endpoints.find(
+      (e) => e.method === 'GET' && e.path === '/api/v1/advisorpolicyrecords',
+    );
+    const listParamNames = list?.parameters?.map((p) => p.name) ?? [];
+    expect(listParamNames).toContain('displayName');
+    expect(listParamNames).toContain('customerId');
+    expect(listParamNames).toContain('externalId');
+    expect(listParamNames).not.toContain('secretToken');
+    expect(list?.example).not.toContain('secretToken');
+
+    expect(
+      list?.parameters?.find((p) => p.name === 'customerId')?.example,
+    ).toBe(EXAMPLE_UUID);
+    expect(
+      list?.parameters?.find((p) => p.name === 'externalId')?.example,
+    ).toBe(1);
+
+    const create = result.endpoints.find(
+      (e) => e.method === 'POST' && e.path === '/api/v1/advisorpolicyrecords',
+    );
+    const createParamNames = create?.parameters?.map((p) => p.name) ?? [];
+    expect(createParamNames).toEqual([
+      'displayName',
+      'customerId',
+      'externalId',
+      'secretToken',
+    ]);
+    expect(create?.example).toContain(`"customerId":"${EXAMPLE_UUID}"`);
+    expect(create?.example).toContain('"externalId":1');
+    expect(create?.example).not.toContain('internalCode');
+    expect(create?.example).not.toContain('tenantId');
+    expect(create?.example).not.toContain('ignoredValue');
+
+    const update = result.endpoints.find(
+      (e) =>
+        e.method === 'PUT' && e.path === '/api/v1/advisorpolicyrecords/:id',
+    );
+    const updateBodyParamNames =
+      update?.parameters
+        ?.filter((parameter) => parameter.location === 'body')
+        .map((parameter) => parameter.name) ?? [];
+    expect(updateBodyParamNames).toEqual(createParamNames);
   });
 
   it('respects a custom base path', async () => {
@@ -108,6 +162,17 @@ describe('mcp-advisor: previewApiEndpoints', () => {
     });
     expect(result.basePath).toBe('/v2');
     expect(result.endpoints.every((e) => e.path.startsWith('/v2/'))).toBe(true);
+  });
+
+  it('uses a custom base URL for generated curl examples', async () => {
+    const result = await previewApiEndpoints({
+      className: 'AdvisorExcludeNote',
+      baseUrl: 'http://localhost:5173',
+    });
+
+    expect(result.endpoints[0]?.example).toContain(
+      'http://localhost:5173/api/v1/advisorexcludenotes',
+    );
   });
 
   it('returns the full default endpoint set for an unregistered class', async () => {

--- a/packages/core/src/mcp-advisor/tools/preview-api-endpoints.ts
+++ b/packages/core/src/mcp-advisor/tools/preview-api-endpoints.ts
@@ -5,6 +5,19 @@
 import { ObjectRegistry } from '../../registry.js';
 import type { ApiEndpoint, PreviewApiEndpointsInput } from '../types.js';
 
+const DEFAULT_EXAMPLE_BASE_URL = 'https://api.example.com';
+const EXAMPLE_UUID = '00000000-0000-4000-8000-000000000001';
+
+interface EndpointPreviewField {
+  name: string;
+  type: string;
+  required: boolean;
+  description?: string;
+  example: unknown;
+  readonly: boolean;
+  sensitive: boolean;
+}
+
 /**
  * Preview API endpoints that would be generated for a class
  */
@@ -12,7 +25,11 @@ export async function previewApiEndpoints(
   input: PreviewApiEndpointsInput,
 ): Promise<{ endpoints: ApiEndpoint[]; basePath: string; markdown: string }> {
   try {
-    const { className, basePath = '/api/v1' } = input;
+    const {
+      className,
+      basePath = '/api/v1',
+      baseUrl = DEFAULT_EXAMPLE_BASE_URL,
+    } = input;
 
     // Get class configuration
     const config = ObjectRegistry.getConfig(className);
@@ -27,6 +44,7 @@ export async function previewApiEndpoints(
       typeof apiConfig === 'object' && apiConfig?.exclude
         ? apiConfig.exclude
         : [];
+    const writableAllowlist = getApiWritableAllowlist(apiConfig);
 
     const shouldInclude = (endpoint: string) => {
       if (included && !included.includes(endpoint)) return false;
@@ -47,8 +65,14 @@ export async function previewApiEndpoints(
             ? field._meta.description
             : undefined,
         example: sampleValueForType(type, name),
+        readonly: isReadonlyField(field),
+        sensitive: isSensitiveField(field),
       };
-    });
+    }) satisfies EndpointPreviewField[];
+    const filterableFields = fieldsList.filter((field) => !field.sensitive);
+    const writableFields = fieldsList.filter((field) =>
+      isWritableRequestField(field, writableAllowlist),
+    );
 
     // Generate endpoint definitions
     const endpoints: ApiEndpoint[] = [];
@@ -86,12 +110,12 @@ export async function previewApiEndpoints(
             description: 'SQL-style ordering expression',
             example: 'created_at DESC',
           },
-          ...fieldsList.map((field) => ({
+          ...filterableFields.map((field) => ({
             name: field.name,
             type: field.type,
             required: false,
             location: 'query' as const,
-            description: `Filter by ${field.name}. Operator suffixes like [gt], [gte], [lt], [lte], [ne], [in], and [like] are also supported.`,
+            description: formatListFilterDescription(field),
             example: field.example,
           })),
         ],
@@ -123,7 +147,7 @@ export async function previewApiEndpoints(
         method: 'POST',
         path: `${basePath}/${pluralName}`,
         description: `Create a new ${className}`,
-        parameters: fieldsList.map((field) => ({
+        parameters: writableFields.map((field) => ({
           name: field.name,
           type: field.type,
           required: field.required,
@@ -149,7 +173,7 @@ export async function previewApiEndpoints(
             description: `${className} id or slug`,
             example: 'example-id',
           },
-          ...fieldsList.map((field) => ({
+          ...writableFields.map((field) => ({
             name: field.name,
             type: field.type,
             required: false,
@@ -217,7 +241,7 @@ export async function previewApiEndpoints(
 
     const endpointsWithExamples = endpoints.map((endpoint) => ({
       ...endpoint,
-      example: buildCurlExample(endpoint),
+      example: buildCurlExample(endpoint, baseUrl),
     }));
 
     return {
@@ -238,10 +262,6 @@ export async function previewApiEndpoints(
 function sampleValueForType(type: string, name: string): unknown {
   const normalizedType = type.toLowerCase();
   const normalizedName = name.toLowerCase();
-
-  if (normalizedName === 'id' || normalizedName.endsWith('id')) {
-    return 'example-id';
-  }
 
   if (
     normalizedType.includes('integer') ||
@@ -279,6 +299,15 @@ function sampleValueForType(type: string, name: string): unknown {
     return [];
   }
 
+  if (
+    normalizedType.includes('foreignkey') ||
+    normalizedType.includes('crosspackageref') ||
+    normalizedType.includes('uuid') ||
+    normalizedName === 'id'
+  ) {
+    return EXAMPLE_UUID;
+  }
+
   return `example-${toKebabCase(name)}`;
 }
 
@@ -290,9 +319,9 @@ function toKebabCase(value: string): string {
     .toLowerCase();
 }
 
-function buildCurlExample(endpoint: ApiEndpoint): string {
+function buildCurlExample(endpoint: ApiEndpoint, baseUrl: string): string {
   const path = endpoint.path.replaceAll(':id', 'example-id');
-  const url = new URL(`http://localhost:3000${path}`);
+  const url = new URL(path, baseUrl);
 
   for (const parameter of endpoint.parameters ?? []) {
     if (parameter.location !== 'query') {
@@ -305,7 +334,7 @@ function buildCurlExample(endpoint: ApiEndpoint): string {
   const parts = [`curl -X ${endpoint.method} "${url.toString()}"`];
   if (body) {
     parts.push('-H "Content-Type: application/json"');
-    parts.push(`-d '${JSON.stringify(body)}'`);
+    parts.push(`-d ${shellSingleQuote(JSON.stringify(body))}`);
   }
 
   return parts.join(' ');
@@ -330,6 +359,10 @@ function buildBodyExample(
   return body;
 }
 
+function shellSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
 function formatExampleValue(value: unknown): string {
   if (value === undefined) {
     return '';
@@ -338,6 +371,71 @@ function formatExampleValue(value: unknown): string {
     return value;
   }
   return JSON.stringify(value) ?? '';
+}
+
+function formatListFilterDescription(field: EndpointPreviewField): string {
+  return `Filter by ${field.name}. Operator suffixes like [gt], [gte], [lt], [lte], [ne], [like], and [in] are also supported; use [in] with comma-separated values, for example ${field.name}[in]=value1,value2.`;
+}
+
+function getApiWritableAllowlist(apiConfig: unknown): Set<string> | null {
+  if (!apiConfig || typeof apiConfig !== 'object') {
+    return null;
+  }
+
+  const writable = (apiConfig as { writable?: unknown }).writable;
+  if (!Array.isArray(writable)) {
+    return null;
+  }
+
+  return new Set(
+    writable.filter((value): value is string => typeof value === 'string'),
+  );
+}
+
+function isWritableRequestField(
+  field: EndpointPreviewField,
+  writableAllowlist: Set<string> | null,
+): boolean {
+  if (isServerManagedField(field.name)) return false;
+  if (field.readonly) return false;
+  if (writableAllowlist && !writableAllowlist.has(field.name)) return false;
+  return true;
+}
+
+function isServerManagedField(name: string): boolean {
+  return (
+    name.startsWith('_') ||
+    [
+      'id',
+      'tenantId',
+      'tenant_id',
+      'createdAt',
+      'created_at',
+      'updatedAt',
+      'updated_at',
+    ].includes(name)
+  );
+}
+
+function isSensitiveField(field: {
+  sensitive?: unknown;
+  _meta?: unknown;
+}): boolean {
+  return field.sensitive === true || readMetaBoolean(field._meta, 'sensitive');
+}
+
+function isReadonlyField(field: {
+  readonly?: unknown;
+  _meta?: unknown;
+}): boolean {
+  return field.readonly === true || readMetaBoolean(field._meta, 'readonly');
+}
+
+function readMetaBoolean(meta: unknown, key: string): boolean {
+  if (!meta || typeof meta !== 'object') {
+    return false;
+  }
+  return (meta as Record<string, unknown>)[key] === true;
 }
 
 function formatQueryValue(

--- a/packages/core/src/mcp-advisor/types.ts
+++ b/packages/core/src/mcp-advisor/types.ts
@@ -129,6 +129,7 @@ export interface ValidationResult {
 export interface PreviewApiEndpointsInput {
   className: string;
   basePath?: string;
+  baseUrl?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses the unresolved review feedback from #1838 for `previewApiEndpoints`:

- exclude sensitive fields from list filter parameter previews and generated list curl examples
- mirror generated REST writable policy for create/update body params (`id`, tenant fields, timestamps, `_` fields, readonly fields, and `api.writable` allowlists)
- generate UUID-shaped examples for relationship/id fields while letting declared numeric/boolean/date types win
- make `[in]` comma-separated query syntax discoverable in parameter descriptions
- switch the default curl host to `https://api.example.com`, add `baseUrl`, and shell-quote JSON bodies safely

## Validation

- `CI=true fnm exec --using 24.18.0 pnpm exec biome check packages/core/src/mcp-advisor/types.ts packages/core/src/mcp-advisor/tools/preview-api-endpoints.ts packages/core/src/mcp-advisor/tools/preview-api-endpoints.test.ts packages/core/src/__tests__/fixtures/advisor-test-classes.ts`
- `CI=true fnm exec --using 24.18.0 pnpm --filter @happyvertical/smrt-core exec vitest run src/mcp-advisor/tools/preview-api-endpoints.test.ts`
- `CI=true fnm exec --using 24.18.0 pnpm --filter @happyvertical/smrt-core exec vitest run src/mcp-advisor`
- `CI=true fnm exec --using 24.18.0 pnpm --filter @happyvertical/smrt-core typecheck`
- `CI=true fnm exec --using 24.18.0 pnpm run build`
- `CI=true fnm exec --using 24.18.0 pnpm run typecheck`
- `CI=true fnm exec --using 24.18.0 pnpm run knowledge:check -- --strict --format markdown`
- pre-push hooks