### PR TITLE
[codex] inherit weekly Renovate strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,12 +3,6 @@
   "extends": ["local>happyvertical/renovate-config:smrt"],
   "packageRules": [
     {
-      "description": "Automerge minor and patch updates on green PRs",
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
-      "automergeType": "pr"
-    },
-    {
       "description": "Don't let Renovate bump the monorepo's own @happyvertical/smrt-* packages where the starter templates pin them as real npmjs deps for downstream projects. Those pins are synced to the monorepo release at publish time (scripts/sync-template-versions.mjs); chasing them against npmjs only produces self-referential, perpetually-stale PRs (#1698/#1699/#1700).",
       "matchFileNames": ["packages/*/template/package.json"],
       "matchPackageNames": ["@happyvertical/smrt-*"],


### PR DESCRIPTION
## Summary

Simplifies SMRT's Renovate config so it inherits the shared weekly dependency update strategy from `happyvertical/renovate-config:smrt`.

The existing SMRT template self-update exclusion remains in place.

## Validation

- `jq . renovate.json`
- `git diff --check`
- `pnpm knowledge:check --changed --strict --format markdown`
- pre-commit hook passed
- pre-push hook passed

Local note: this Codex worktree needed the ignored generated `packages/core/dist/smrt-knowledge.json` rebuilt before the knowledge hook could run.