### PR TITLE
[codex] guard ShellState mutations from Svelte tracking

### DIFF
--- a/packages/smrt-svelte/src/components/workspace/__tests__/admin-shell-mutation-effect-harness.svelte
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/admin-shell-mutation-effect-harness.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+/**
+ * Runs a caller-supplied ShellState mutation inside a consumer $effect. Tests
+ * use this to prove ShellState's internal reads do not become dependencies of
+ * the consumer effect.
+ */
+import type { ShellState } from '../admin-shell/state.svelte.js';
+import type { ShellActivity } from '../admin-shell/types.js';
+
+type EffectCleanup = () => void;
+
+interface MutationInputs {
+  activity: ShellActivity;
+}
+
+interface Props {
+  shell: ShellState;
+  run: (shell: ShellState, inputs: MutationInputs) => EffectCleanup | undefined;
+  onReady: (controls: {
+    getRuns: () => number;
+    setActivityProgress: (progress: number) => void;
+  }) => void;
+}
+
+const props: Props = $props();
+const activity = $state<ShellActivity>({
+  id: 'reactive-sync',
+  label: 'Reactive sync',
+  kind: 'sync',
+  scope: 'system',
+  status: 'running',
+  progress: 0,
+});
+
+// Plain let on purpose: making this $state would add tracking noise to the
+// effect-leak signal this harness exists to measure.
+let runs = 0;
+
+$effect(() => {
+  runs += 1;
+  return props.run(props.shell, { activity });
+});
+
+// This harness intentionally snapshots the callback during setup.
+// svelte-ignore state_referenced_locally
+props.onReady({
+  getRuns: () => runs,
+  setActivityProgress: (progress: number) => {
+    activity.progress = progress;
+  },
+});
+</script>

--- a/packages/smrt-svelte/src/components/workspace/__tests__/admin-shell-state.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/admin-shell-state.test.ts
@@ -1,5 +1,42 @@
+import { flushSync, mount, unmount } from 'svelte';
 import { describe, expect, it, vi } from 'vitest';
 import { createShellState } from '../admin-shell/state.svelte.js';
+import MutationEffectHarness from './admin-shell-mutation-effect-harness.svelte';
+
+type ShellMutationEffect = Parameters<typeof MutationEffectHarness>[0]['run'];
+
+function mountMutationEffect(
+  shell: ReturnType<typeof createShellState>,
+  run: ShellMutationEffect,
+): {
+  getRuns: () => number;
+  setActivityProgress: (progress: number) => void;
+  teardown: () => void;
+} {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  let getRuns = () => 0;
+  let setActivityProgress = (_progress: number) => {};
+  const component = mount(MutationEffectHarness, {
+    target,
+    props: {
+      shell,
+      run,
+      onReady: (controls) => {
+        getRuns = controls.getRuns;
+        setActivityProgress = controls.setActivityProgress;
+      },
+    },
+  });
+  return {
+    getRuns,
+    setActivityProgress,
+    teardown: () => {
+      unmount(component);
+      target.remove();
+    },
+  };
+}
 
 describe('ShellState', () => {
   it('allows panels to expand independently by default', () => {
@@ -116,5 +153,123 @@ describe('ShellState', () => {
     // A new activity is a notify-worthy "started"; a progress-only tick is an
     // upsert carrying `previous`, which the toaster filters out.
     expect(events).toEqual(['upsert:new', 'upsert:has-prev']);
+  });
+
+  it('does not leak focus-tool state reads into consumer effects', () => {
+    const shell = createShellState();
+    const harness = mountMutationEffect(shell, (state) => {
+      const unregister = state.registerFocusTool({
+        id: 'activity',
+        label: 'Activity',
+      });
+      state.openFocusTool('activity');
+      return unregister;
+    });
+
+    try {
+      flushSync();
+      expect(harness.getRuns()).toBe(1);
+
+      shell.collapsePanel('right');
+      flushSync();
+      shell.openFocusTool('activity');
+      flushSync();
+
+      expect(harness.getRuns()).toBe(1);
+      expect(shell.focusTools.map((tool) => tool.id)).toEqual(['activity']);
+    } finally {
+      harness.teardown();
+    }
+  });
+
+  it('does not leak panel state reads into consumer effects', () => {
+    const shell = createShellState();
+    const harness = mountMutationEffect(shell, (state) => {
+      state.setPanel('right', 'expanded');
+      return undefined;
+    });
+
+    try {
+      flushSync();
+      expect(harness.getRuns()).toBe(1);
+
+      shell.togglePanel('right');
+      flushSync();
+
+      expect(harness.getRuns()).toBe(1);
+      expect(shell.panels.right).toBe('collapsed');
+    } finally {
+      harness.teardown();
+    }
+  });
+
+  it('does not leak settings state reads into consumer effects', () => {
+    const shell = createShellState();
+    const harness = mountMutationEffect(shell, (state) => {
+      state.applySettings({ panels: { right: 'expanded' } });
+      return undefined;
+    });
+
+    try {
+      flushSync();
+      expect(harness.getRuns()).toBe(1);
+
+      shell.setHotkey('right', 'KeyR');
+      flushSync();
+
+      expect(harness.getRuns()).toBe(1);
+      expect(shell.settings.keymap?.right).toEqual({ code: 'KeyR' });
+    } finally {
+      harness.teardown();
+    }
+  });
+
+  it('does not leak activity state reads into consumer effects', () => {
+    const shell = createShellState();
+    const harness = mountMutationEffect(shell, (state) => {
+      state.upsertActivity({
+        id: 'sync-1',
+        label: 'Sync',
+        kind: 'sync',
+        scope: 'system',
+        status: 'running',
+      });
+      return undefined;
+    });
+
+    try {
+      flushSync();
+      expect(harness.getRuns()).toBe(1);
+
+      shell.updateActivity('sync-1', { progress: 50 });
+      flushSync();
+
+      expect(harness.getRuns()).toBe(1);
+      expect(shell.listActivities()[0]?.progress).toBe(50);
+    } finally {
+      harness.teardown();
+    }
+  });
+
+  it('keeps caller-supplied reactive activity inputs tracked', () => {
+    const shell = createShellState();
+    const harness = mountMutationEffect(shell, (state, inputs) => {
+      state.upsertActivity(inputs.activity);
+      return undefined;
+    });
+
+    try {
+      flushSync();
+      expect(harness.getRuns()).toBe(1);
+      expect(shell.listActivities()[0]?.progress).toBe(0);
+
+      harness.setActivityProgress(75);
+      flushSync();
+
+      expect(harness.getRuns()).toBe(2);
+      expect(shell.listActivities()[0]?.progress).toBe(75);
+    } finally {
+      harness.teardown();
+    }
   });
 });

--- a/packages/smrt-svelte/src/components/workspace/admin-shell/state.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/admin-shell/state.svelte.ts
@@ -1,3 +1,4 @@
+import { untrack } from 'svelte';
 import {
   LocalStorageShellSettingsAdapter,
   mergeShellSettingsDelta,
@@ -24,6 +25,7 @@ import type {
 import { PANEL_EDGES, SCOPE_EDGES } from './types.js';
 
 type ActivityListener = (event: ShellActivityEvent) => void;
+type ShellActivityPatch = Partial<Omit<ShellActivity, 'id'>>;
 
 export interface ShellStateOptions {
   config?: ShellPanelDefaults;
@@ -81,135 +83,166 @@ export class ShellState {
     delta: ShellSettingsDelta,
     options: { persist?: boolean } = {},
   ): void {
-    this.settings = mergeShellSettingsDelta(this.settings, delta);
-    for (const edge of PANEL_EDGES) {
-      this.panels[edge] = resolveInitialPanelState(
-        edge,
-        this.config.panels[edge],
-        this.settings,
-      );
-    }
-    this.activeFocusToolId =
-      this.settings.activeFocusToolId ?? this.activeFocusToolId;
-    if (options.persist !== false) void this.persistSettings();
+    const nextDelta = snapshotShellSettingsDelta(delta);
+    const persist = options.persist;
+    untrack(() => {
+      this.settings = mergeShellSettingsDelta(this.settings, nextDelta);
+      for (const edge of PANEL_EDGES) {
+        this.panels[edge] = resolveInitialPanelState(
+          edge,
+          this.config.panels[edge],
+          this.settings,
+        );
+      }
+      this.activeFocusToolId =
+        this.settings.activeFocusToolId ?? this.activeFocusToolId;
+      if (persist !== false) void this.persistSettings();
+    });
   }
 
   setHotkeysEnabled(enabled: boolean): void {
-    this.applySettings({ hotkeysEnabled: enabled });
+    untrack(() => this.applySettings({ hotkeysEnabled: enabled }));
   }
 
   setHotkey(edge: PanelEdge, code: string | null): void {
-    this.applySettings({
-      keymap: {
-        [edge]: code ? { code } : null,
-      },
+    untrack(() => {
+      this.applySettings({
+        keymap: {
+          [edge]: code ? { code } : null,
+        },
+      });
     });
   }
 
   setPanel(edge: PanelEdge, state: VisiblePanelState): void {
-    if (this.config.panels[edge].initial === 'hidden') {
-      this.panels[edge] = 'hidden';
-      return;
-    }
-    if (state === 'expanded') this.closeExclusivePeers(edge);
-    this.panels[edge] = state;
-    this.settings = mergeShellSettingsDelta(this.settings, {
-      panels: { [edge]: state },
+    untrack(() => {
+      if (this.config.panels[edge].initial === 'hidden') {
+        this.panels[edge] = 'hidden';
+        return;
+      }
+      if (state === 'expanded') this.closeExclusivePeers(edge);
+      this.panels[edge] = state;
+      this.settings = mergeShellSettingsDelta(this.settings, {
+        panels: { [edge]: state },
+      });
+      void this.persistSettings();
     });
-    void this.persistSettings();
   }
 
   togglePanel(edge: PanelEdge): void {
-    if (this.panels[edge] === 'hidden') return;
-    this.setPanel(
-      edge,
-      this.panels[edge] === 'expanded' ? 'collapsed' : 'expanded',
-    );
+    untrack(() => {
+      if (this.panels[edge] === 'hidden') return;
+      this.setPanel(
+        edge,
+        this.panels[edge] === 'expanded' ? 'collapsed' : 'expanded',
+      );
+    });
   }
 
   expandPanel(edge: PanelEdge): void {
-    this.setPanel(edge, 'expanded');
+    untrack(() => this.setPanel(edge, 'expanded'));
   }
 
   collapsePanel(edge: PanelEdge): void {
-    this.setPanel(edge, 'collapsed');
+    untrack(() => this.setPanel(edge, 'collapsed'));
   }
 
   closeTopmostExpanded(): boolean {
-    for (const edge of [...PANEL_EDGES].reverse()) {
-      if (this.panels[edge] === 'expanded') {
-        this.collapsePanel(edge);
-        return true;
+    return untrack(() => {
+      for (const edge of [...PANEL_EDGES].reverse()) {
+        if (this.panels[edge] === 'expanded') {
+          this.collapsePanel(edge);
+          return true;
+        }
       }
-    }
-    return false;
+      return false;
+    });
   }
 
   registerFocusTool(tool: ShellFocusTool): () => void {
-    this.focusTools = [
-      ...this.focusTools.filter((existing) => existing.id !== tool.id),
-      tool,
-    ].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
-    if (!this.activeFocusToolId) this.activeFocusToolId = tool.id;
-    return () => this.unregisterFocusTool(tool.id);
+    const nextTool = snapshotFocusTool(tool);
+    return untrack(() => {
+      this.focusTools = [
+        ...this.focusTools.filter((existing) => existing.id !== nextTool.id),
+        nextTool,
+      ].sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+      if (!this.activeFocusToolId) this.activeFocusToolId = nextTool.id;
+      return () => this.unregisterFocusTool(nextTool.id);
+    });
   }
 
   unregisterFocusTool(id: string): void {
-    this.focusTools = this.focusTools.filter((tool) => tool.id !== id);
-    if (this.activeFocusToolId === id) {
-      this.activeFocusToolId = this.focusTools[0]?.id ?? null;
-    }
+    untrack(() => {
+      this.focusTools = this.focusTools.filter((tool) => tool.id !== id);
+      if (this.activeFocusToolId === id) {
+        this.activeFocusToolId = this.focusTools[0]?.id ?? null;
+      }
+    });
   }
 
   openFocusTool(id: string): void {
-    if (!this.focusTools.some((tool) => tool.id === id)) return;
-    this.activeFocusToolId = id;
-    this.settings = mergeShellSettingsDelta(this.settings, {
-      activeFocusToolId: id,
+    untrack(() => {
+      if (!this.focusTools.some((tool) => tool.id === id)) return;
+      this.activeFocusToolId = id;
+      this.settings = mergeShellSettingsDelta(this.settings, {
+        activeFocusToolId: id,
+      });
+      this.expandPanel('right');
+      void this.persistSettings();
     });
-    this.expandPanel('right');
-    void this.persistSettings();
   }
 
   upsertActivity(activity: ShellActivity): void {
-    const now = new Date().toISOString();
-    const normalized: ShellActivity = {
-      ...activity,
-      edge: activity.edge ?? this.homeEdgeForScope(activity.scope),
-      createdAt: activity.createdAt ?? now,
-      updatedAt: activity.updatedAt ?? now,
-    };
-    const previous = this.activities.find((item) => item.id === activity.id);
-    this.activities = [
-      ...this.activities.filter((item) => item.id !== activity.id),
-      normalized,
-    ];
-    this.emitActivity({
-      type:
-        previous && previous.status !== normalized.status
-          ? 'transition'
-          : 'upsert',
-      activity: normalized,
-      previous,
+    const nextActivity = snapshotActivity(activity);
+    untrack(() => {
+      const now = new Date().toISOString();
+      const normalized: ShellActivity = {
+        ...nextActivity,
+        edge: nextActivity.edge ?? this.homeEdgeForScope(nextActivity.scope),
+        createdAt: nextActivity.createdAt ?? now,
+        updatedAt: nextActivity.updatedAt ?? now,
+      };
+      const previous = this.activities.find(
+        (item) => item.id === nextActivity.id,
+      );
+      this.activities = [
+        ...this.activities.filter((item) => item.id !== nextActivity.id),
+        normalized,
+      ];
+      this.emitActivity({
+        type:
+          previous && previous.status !== normalized.status
+            ? 'transition'
+            : 'upsert',
+        activity: normalized,
+        previous,
+      });
     });
   }
 
-  updateActivity(id: string, patch: Partial<Omit<ShellActivity, 'id'>>): void {
-    const current = this.activities.find((activity) => activity.id === id);
-    if (!current) return;
-    this.upsertActivity({
-      ...current,
-      ...patch,
-      id,
-      updatedAt: new Date().toISOString(),
+  updateActivity(id: string, patch: ShellActivityPatch): void {
+    const nextPatch = snapshotActivityPatch(patch);
+    untrack(() => {
+      const current = this.activities.find((activity) => activity.id === id);
+      if (!current) return;
+      this.upsertActivity({
+        ...current,
+        ...nextPatch,
+        id,
+        updatedAt: new Date().toISOString(),
+      });
     });
   }
 
   removeActivity(id: string): void {
-    const current = this.activities.find((activity) => activity.id === id);
-    if (!current) return;
-    this.activities = this.activities.filter((activity) => activity.id !== id);
-    this.emitActivity({ type: 'remove', activity: current });
+    untrack(() => {
+      const current = this.activities.find((activity) => activity.id === id);
+      if (!current) return;
+      this.activities = this.activities.filter(
+        (activity) => activity.id !== id,
+      );
+      this.emitActivity({ type: 'remove', activity: current });
+    });
   }
 
   watchActivities(listener: ActivityListener): () => void {
@@ -318,4 +351,62 @@ function matchesOne<T extends string>(value: T, expected: T | T[]): boolean {
 
 function isActiveStatus(status: ActivityStatus): boolean {
   return status === 'queued' || status === 'running';
+}
+
+function snapshotShellSettingsDelta(
+  delta: ShellSettingsDelta,
+): ShellSettingsDelta {
+  const snapshot: ShellSettingsDelta = { ...delta };
+  if ('keymap' in delta) {
+    snapshot.keymap = snapshotShellKeymap(delta.keymap);
+  }
+  if ('panels' in delta) {
+    snapshot.panels = delta.panels ? { ...delta.panels } : delta.panels;
+  }
+  return snapshot;
+}
+
+function snapshotShellKeymap(
+  keymap: ShellSettingsDelta['keymap'],
+): ShellSettingsDelta['keymap'] {
+  if (!keymap) return keymap;
+  const snapshot: ShellSettingsDelta['keymap'] = {};
+  for (const edge of PANEL_EDGES) {
+    if (edge in keymap) {
+      const binding = keymap[edge];
+      snapshot[edge] = binding ? { ...binding } : binding;
+    }
+  }
+  return snapshot;
+}
+
+function snapshotFocusTool(tool: ShellFocusTool): ShellFocusTool {
+  const snapshot: ShellFocusTool = { ...tool };
+  if ('subject' in tool) {
+    snapshot.subject = tool.subject ? { ...tool.subject } : tool.subject;
+  }
+  if ('activityKinds' in tool) {
+    snapshot.activityKinds = tool.activityKinds
+      ? [...tool.activityKinds]
+      : tool.activityKinds;
+  }
+  return snapshot;
+}
+
+function snapshotActivity(activity: ShellActivity): ShellActivity {
+  const snapshot: ShellActivity = { ...activity };
+  if ('subject' in activity) {
+    snapshot.subject = activity.subject
+      ? { ...activity.subject }
+      : activity.subject;
+  }
+  return snapshot;
+}
+
+function snapshotActivityPatch(patch: ShellActivityPatch): ShellActivityPatch {
+  const snapshot: ShellActivityPatch = { ...patch };
+  if ('subject' in patch) {
+    snapshot.subject = patch.subject ? { ...patch.subject } : patch.subject;
+  }
+  return snapshot;
 }


### PR DESCRIPTION
Fixes #1849.

## Summary

- Wrap ShellState imperative mutation paths in Svelte `untrack(...)` so internal `$state` reads do not become dependencies of consumer `$effect` scopes.
- Cover focus-tool, panel, and activity mutation paths with regression tests that mirror a consumer effect calling ShellState APIs.

## Root Cause

`ShellState` mutation methods read `$state` while also writing it. When downstream apps called methods like `registerFocusTool()` from a Svelte `$effect`, those internal reads could be captured by the caller effect. Later shell writes then retriggered the caller effect and could lead to `effect_update_depth_exceeded` loops.

## Review Notes

- Kept read APIs such as `snapshot()`, `listActivities()`, and `activityBadge()` trackable for normal `$derived` usage.
- Guarded mutation helpers, including settings, panels, focus tools, and activity lifecycle methods.
- Added a small Svelte harness that executes a supplied ShellState mutation from a real `$effect` and asserts later shell mutations do not increase the effect run count.

## Validation

- `biome check packages/smrt-svelte/src/components/workspace/admin-shell/state.svelte.ts packages/smrt-svelte/src/components/workspace/__tests__/admin-shell-state.test.ts packages/smrt-svelte/src/components/workspace/__tests__/admin-shell-mutation-effect-harness.svelte`
- `pnpm --dir packages/smrt-svelte exec vitest run src/components/workspace/__tests__/admin-shell-state.test.ts` (11 tests)
- `pnpm --filter @happyvertical/smrt-svelte typecheck`
- `pnpm --filter @happyvertical/smrt-svelte test` (48 files, 488 tests)
- `pnpm --filter @happyvertical/smrt-svelte build`
- pre-commit hooks: format, knowledge-check, secret-scan
- pre-push hooks: package DAG, format-check, knowledge-check, token/style guards, workflow validation