### PR TITLE
[codex] harden release publish guard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -267,6 +267,9 @@ jobs:
       needs.validate-release-shards.result == 'success'
     runs-on: arc-happyvertical
     timeout-minutes: 20
+    concurrency:
+      group: release-publish-${{ github.repository }}-${{ github.ref }}
+      cancel-in-progress: false
 
     steps:
       - name: Generate token from GitHub App
@@ -325,6 +328,12 @@ jobs:
           git config user.email \
             "41898282+github-actions[bot]@users.noreply.github.com"
 
+      - name: Guard release publish target
+        env:
+          RELEASE_BASE_BRANCH: main
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: node scripts/guard-release-publish.js
+
       - name: Publish validated release
         env:
           CI: true
@@ -335,58 +344,6 @@ jobs:
           RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
         run: |
           echo "🚀 Publishing validated release $RELEASE_VERSION"
-
-          node - <<'NODE'
-          const { existsSync, readFileSync, readdirSync } = require('fs');
-          const { join } = require('path');
-
-          const changesetConfig = JSON.parse(readFileSync('.changeset/config.json', 'utf8'));
-          const releasePackageNames = new Set(
-            (changesetConfig.fixed ?? []).flatMap((group) =>
-              Array.isArray(group) ? group : [],
-            ),
-          );
-
-          const packageJsonFiles = ['package.json'];
-          for (const entry of readdirSync('packages', { withFileTypes: true })) {
-            if (!entry.isDirectory()) {
-              continue;
-            }
-
-            const file = join('packages', entry.name, 'package.json');
-            if (!existsSync(file)) {
-              continue;
-            }
-
-            const packageJson = JSON.parse(readFileSync(file, 'utf8'));
-            const packageName = packageJson.name ?? entry.name;
-            const isReleasePackage = releasePackageNames.has(packageName);
-            const isExplicitlyPublishable = Boolean(packageJson.publishConfig);
-
-            if (packageJson.private === true || (!isReleasePackage && !isExplicitlyPublishable)) {
-              continue;
-            }
-
-            packageJsonFiles.push(file);
-          }
-
-          const offenders = [];
-          for (const file of packageJsonFiles) {
-            const version = JSON.parse(readFileSync(file, 'utf8')).version;
-            const major = Number.parseInt(String(version).split('.')[0] ?? '0', 10);
-            if (Number.isInteger(major) && major >= 1) {
-              offenders.push(`${file}: ${version}`);
-            }
-          }
-
-          if (offenders.length > 0) {
-            console.error('❌ Refusing to publish a major version release:');
-            for (const offender of offenders) {
-              console.error(`- ${offender}`);
-            }
-            process.exit(1);
-          }
-          NODE
 
           mapfile -t release_files < <(find packages \( -name 'package.json' -o -name 'CHANGELOG.md' -o -name 'template.config.js' \) -print | sort)
           git add package.json

--- a/scripts/guard-release-publish.js
+++ b/scripts/guard-release-publish.js
@@ -1,0 +1,353 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function readEnv(name) {
+  return process.env[name];
+}
+
+function requireCleanRefName(name, label) {
+  if (!/^[A-Za-z0-9._/-]+$/.test(name)) {
+    fail(`${label} contains unsupported characters: ${JSON.stringify(name)}`);
+  }
+}
+
+export function listPublishablePackages(repoRoot = process.cwd()) {
+  const packagesDir = resolve(repoRoot, 'packages');
+  const changesetConfigPath = resolve(repoRoot, '.changeset/config.json');
+
+  if (!existsSync(packagesDir)) {
+    fail(`Packages directory not found: ${packagesDir}`);
+  }
+
+  if (!existsSync(changesetConfigPath)) {
+    fail(`Changeset config not found: ${changesetConfigPath}`);
+  }
+
+  const changesetConfig = readJson(changesetConfigPath);
+  const releasePackageNames = new Set(
+    (changesetConfig.fixed ?? []).flatMap((group) =>
+      Array.isArray(group) ? group : [],
+    ),
+  );
+  const privateWorkspacePackageNames = new Set();
+
+  const publishablePackages = readdirSync(packagesDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const packageDir = join(packagesDir, entry.name);
+      const packageJsonPath = join(packageDir, 'package.json');
+
+      if (!existsSync(packageJsonPath)) {
+        return null;
+      }
+
+      const packageJson = readJson(packageJsonPath);
+      const packageName = packageJson.name ?? entry.name;
+      const isReleasePackage = releasePackageNames.has(packageName);
+      const isExplicitlyPublishable = Boolean(packageJson.publishConfig);
+
+      if (packageJson.private === true) {
+        privateWorkspacePackageNames.add(packageName);
+        return null;
+      }
+
+      if (!isReleasePackage && !isExplicitlyPublishable) {
+        return null;
+      }
+
+      return {
+        dir: packageDir,
+        manifestPath: packageJsonPath,
+        name: packageName,
+        version: packageJson.version,
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  const discoveredPackageNames = new Set(
+    publishablePackages.map((pkg) => pkg.name),
+  );
+  const missingReleasePackages = [...releasePackageNames].filter(
+    (packageName) =>
+      !discoveredPackageNames.has(packageName) &&
+      !privateWorkspacePackageNames.has(packageName),
+  );
+
+  if (missingReleasePackages.length > 0) {
+    fail(
+      `Release packages declared in .changeset/config.json were not found in the workspace:\n${missingReleasePackages
+        .map((packageName) => `- ${packageName}`)
+        .join('\n')}`,
+    );
+  }
+
+  return publishablePackages;
+}
+
+export function listVersionedManifests(repoRoot, publishablePackages) {
+  const rootPackageJsonPath = resolve(repoRoot, 'package.json');
+  const manifests = [];
+
+  if (existsSync(rootPackageJsonPath)) {
+    const rootPackageJson = readJson(rootPackageJsonPath);
+    manifests.push({
+      manifestPath: rootPackageJsonPath,
+      name: rootPackageJson.name ?? 'package.json',
+      version: rootPackageJson.version,
+    });
+  }
+
+  manifests.push(...publishablePackages);
+  return manifests;
+}
+
+export function findMajorVersionOffenders(manifests) {
+  return manifests.filter((manifest) => {
+    const major = Number.parseInt(String(manifest.version).split('.')[0], 10);
+    return Number.isInteger(major) && major >= 1;
+  });
+}
+
+export function assertHeadMatchesRemote({
+  baseBranch = 'main',
+  repoRoot = process.cwd(),
+  spawn = spawnSync,
+} = {}) {
+  requireCleanRefName(baseBranch, 'Base branch');
+
+  const fetchResult = spawn(
+    'git',
+    [
+      'fetch',
+      '--no-tags',
+      'origin',
+      `+refs/heads/${baseBranch}:refs/remotes/origin/${baseBranch}`,
+    ],
+    { cwd: repoRoot, encoding: 'utf8', stdio: 'pipe' },
+  );
+
+  if (fetchResult.error) {
+    fail(`Failed to fetch origin/${baseBranch}: ${fetchResult.error.message}`);
+  }
+
+  if (fetchResult.status !== 0) {
+    fail(
+      `Failed to fetch origin/${baseBranch}:\n${fetchResult.stderr || fetchResult.stdout}`,
+    );
+  }
+
+  const headResult = spawn('git', ['rev-parse', 'HEAD'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  const remoteResult = spawn(
+    'git',
+    ['rev-parse', `refs/remotes/origin/${baseBranch}`],
+    { cwd: repoRoot, encoding: 'utf8', stdio: 'pipe' },
+  );
+
+  if (headResult.error) {
+    fail(`Failed to read HEAD: ${headResult.error.message}`);
+  }
+  if (remoteResult.error) {
+    fail(`Failed to read origin/${baseBranch}: ${remoteResult.error.message}`);
+  }
+  if (headResult.status !== 0) {
+    fail(`Failed to read HEAD:\n${headResult.stderr || headResult.stdout}`);
+  }
+  if (remoteResult.status !== 0) {
+    fail(
+      `Failed to read origin/${baseBranch}:\n${remoteResult.stderr || remoteResult.stdout}`,
+    );
+  }
+
+  const head = headResult.stdout.trim();
+  const remoteHead = remoteResult.stdout.trim();
+
+  if (head !== remoteHead) {
+    fail(
+      [
+        `Refusing to publish from a stale ${baseBranch} checkout.`,
+        `Workflow HEAD: ${head}`,
+        `origin/${baseBranch}: ${remoteHead}`,
+        'A newer merge has landed; let the newer main run compute and publish the next version.',
+      ].join('\n'),
+    );
+  }
+}
+
+export function assertReleaseTagIsUnused({
+  releaseVersion,
+  repoRoot = process.cwd(),
+  spawn = spawnSync,
+} = {}) {
+  if (!releaseVersion) {
+    fail('RELEASE_VERSION is required');
+  }
+
+  requireCleanRefName(`v${releaseVersion}`, 'Release tag');
+
+  const result = spawn(
+    'git',
+    [
+      'ls-remote',
+      '--exit-code',
+      '--tags',
+      'origin',
+      `refs/tags/v${releaseVersion}`,
+    ],
+    { cwd: repoRoot, encoding: 'utf8', stdio: 'pipe' },
+  );
+
+  if (result.error) {
+    fail(
+      `Failed to check release tag v${releaseVersion}: ${result.error.message}`,
+    );
+  }
+
+  if (result.status === 0) {
+    fail(
+      `Refusing to publish because release tag v${releaseVersion} already exists on origin.`,
+    );
+  }
+
+  if (result.status !== 2) {
+    fail(
+      `Failed to check release tag v${releaseVersion}:\n${result.stderr || result.stdout}`,
+    );
+  }
+}
+
+export function npmVersionExists({
+  packageName,
+  version,
+  repoRoot = process.cwd(),
+  spawn = spawnSync,
+} = {}) {
+  const spec = `${packageName}@${version}`;
+  const result = spawn(
+    'npm',
+    [
+      'view',
+      spec,
+      'version',
+      '--registry=https://registry.npmjs.org',
+      '--json',
+    ],
+    { cwd: repoRoot, encoding: 'utf8', stdio: 'pipe' },
+  );
+
+  if (result.error) {
+    fail(`Failed to check npm package ${spec}: ${result.error.message}`);
+  }
+
+  if (result.status === 0) {
+    return true;
+  }
+
+  const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+  if (
+    output.includes('E404') ||
+    output.includes('404 Not Found') ||
+    output.includes('is not in this registry')
+  ) {
+    return false;
+  }
+
+  fail(`Failed to check npm package ${spec}:\n${output.trim()}`);
+}
+
+export function findPublishedPackageConflicts({
+  packages,
+  repoRoot = process.cwd(),
+  spawn = spawnSync,
+} = {}) {
+  return packages.filter((pkg) =>
+    npmVersionExists({
+      packageName: pkg.name,
+      repoRoot,
+      spawn,
+      version: pkg.version,
+    }),
+  );
+}
+
+export function guardReleasePublish({
+  baseBranch = readEnv('RELEASE_BASE_BRANCH') ?? 'main',
+  releaseVersion = readEnv('RELEASE_VERSION'),
+  repoRoot = process.cwd(),
+  skipGitCheck = readEnv('SKIP_RELEASE_GIT_GUARD') === 'true',
+  skipNpmCheck = readEnv('SKIP_RELEASE_NPM_GUARD') === 'true',
+  spawn = spawnSync,
+} = {}) {
+  if (!releaseVersion) {
+    fail('RELEASE_VERSION is required');
+  }
+
+  const publishablePackages = listPublishablePackages(repoRoot);
+  const majorOffenders = findMajorVersionOffenders(
+    listVersionedManifests(repoRoot, publishablePackages),
+  );
+
+  if (majorOffenders.length > 0) {
+    fail(
+      `Refusing to publish a major version release:\n${majorOffenders
+        .map((offender) => `- ${offender.manifestPath}: ${offender.version}`)
+        .join('\n')}`,
+    );
+  }
+
+  if (!skipGitCheck) {
+    assertHeadMatchesRemote({ baseBranch, repoRoot, spawn });
+    assertReleaseTagIsUnused({ releaseVersion, repoRoot, spawn });
+  }
+
+  if (!skipNpmCheck) {
+    const conflicts = findPublishedPackageConflicts({
+      packages: publishablePackages,
+      repoRoot,
+      spawn,
+    });
+
+    if (conflicts.length > 0) {
+      fail(
+        `Refusing to publish because package versions already exist on npm:\n${conflicts
+          .map((pkg) => `- ${pkg.name}@${pkg.version}`)
+          .join(
+            '\n',
+          )}\nAn earlier job may already have performed the irreversible npm publish. Bump a new version instead of retagging this one.`,
+      );
+    }
+  }
+
+  console.log(
+    `Release publish guard passed for v${releaseVersion} (${publishablePackages.length} package(s)).`,
+  );
+}
+
+const isCli =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
+
+if (isCli) {
+  try {
+    guardReleasePublish();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/guard-release-publish.test.js
+++ b/scripts/guard-release-publish.test.js
@@ -1,0 +1,162 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertHeadMatchesRemote,
+  assertReleaseTagIsUnused,
+  findMajorVersionOffenders,
+  findPublishedPackageConflicts,
+  listPublishablePackages,
+  npmVersionExists,
+} from './guard-release-publish.js';
+
+function writeJson(path, value) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function createRepoFixture() {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'smrt-release-guard-'));
+  mkdirSync(join(repoRoot, '.changeset'), { recursive: true });
+  mkdirSync(join(repoRoot, 'packages/core'), { recursive: true });
+  mkdirSync(join(repoRoot, 'packages/private-mobile'), { recursive: true });
+  mkdirSync(join(repoRoot, 'packages/extra'), { recursive: true });
+
+  writeJson(join(repoRoot, 'package.json'), {
+    name: '@happyvertical/smrt',
+    version: '0.39.0',
+  });
+  writeJson(join(repoRoot, '.changeset/config.json'), {
+    fixed: [['@happyvertical/smrt-core', '@happyvertical/smrt-mobile']],
+  });
+  writeJson(join(repoRoot, 'packages/core/package.json'), {
+    name: '@happyvertical/smrt-core',
+    publishConfig: { access: 'public' },
+    version: '0.39.0',
+  });
+  writeJson(join(repoRoot, 'packages/private-mobile/package.json'), {
+    name: '@happyvertical/smrt-mobile',
+    private: true,
+    version: '0.39.0',
+  });
+  writeJson(join(repoRoot, 'packages/extra/package.json'), {
+    name: '@happyvertical/smrt-extra',
+    publishConfig: { access: 'public' },
+    version: '0.39.0',
+  });
+
+  return repoRoot;
+}
+
+function spawnFromResponses(responses) {
+  return (command, args) => {
+    const key = `${command} ${args.join(' ')}`;
+    const response = responses.get(key);
+    if (!response) {
+      throw new Error(`Unexpected command: ${key}`);
+    }
+    return { stderr: '', stdout: '', ...response };
+  };
+}
+
+describe('guard-release-publish', () => {
+  it('discovers fixed and explicitly publishable packages', () => {
+    const repoRoot = createRepoFixture();
+
+    expect(listPublishablePackages(repoRoot).map((pkg) => pkg.name)).toEqual([
+      '@happyvertical/smrt-core',
+      '@happyvertical/smrt-extra',
+    ]);
+  });
+
+  it('flags major version manifests', () => {
+    expect(
+      findMajorVersionOffenders([
+        { manifestPath: 'package.json', version: '0.39.0' },
+        { manifestPath: 'packages/core/package.json', version: '1.0.0' },
+      ]),
+    ).toEqual([
+      { manifestPath: 'packages/core/package.json', version: '1.0.0' },
+    ]);
+  });
+
+  it('fails when the workflow checkout is behind origin/main', () => {
+    const spawn = spawnFromResponses(
+      new Map([
+        [
+          'git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main',
+          { status: 0 },
+        ],
+        ['git rev-parse HEAD', { status: 0, stdout: 'old-head\n' }],
+        [
+          'git rev-parse refs/remotes/origin/main',
+          { status: 0, stdout: 'new-head\n' },
+        ],
+      ]),
+    );
+
+    expect(() => assertHeadMatchesRemote({ spawn })).toThrow(
+      /Refusing to publish from a stale main checkout/,
+    );
+  });
+
+  it('fails when the release tag already exists', () => {
+    const spawn = spawnFromResponses(
+      new Map([
+        [
+          'git ls-remote --exit-code --tags origin refs/tags/v0.39.0',
+          { status: 0, stdout: 'abc\trefs/tags/v0.39.0\n' },
+        ],
+      ]),
+    );
+
+    expect(() =>
+      assertReleaseTagIsUnused({ releaseVersion: '0.39.0', spawn }),
+    ).toThrow(/release tag v0.39.0 already exists/);
+  });
+
+  it('treats npm 404 as an unpublished package version', () => {
+    const spawn = spawnFromResponses(
+      new Map([
+        [
+          'npm view @happyvertical/smrt-core@0.39.0 version --registry=https://registry.npmjs.org --json',
+          { status: 1, stderr: 'npm ERR! code E404\n' },
+        ],
+      ]),
+    );
+
+    expect(
+      npmVersionExists({
+        packageName: '@happyvertical/smrt-core',
+        spawn,
+        version: '0.39.0',
+      }),
+    ).toBe(false);
+  });
+
+  it('reports package versions that are already published on npm', () => {
+    const spawn = spawnFromResponses(
+      new Map([
+        [
+          'npm view @happyvertical/smrt-core@0.39.0 version --registry=https://registry.npmjs.org --json',
+          { status: 0, stdout: '"0.39.0"\n' },
+        ],
+        [
+          'npm view @happyvertical/smrt-extra@0.39.0 version --registry=https://registry.npmjs.org --json',
+          { status: 1, stderr: 'npm ERR! code E404\n' },
+        ],
+      ]),
+    );
+
+    expect(
+      findPublishedPackageConflicts({
+        packages: [
+          { name: '@happyvertical/smrt-core', version: '0.39.0' },
+          { name: '@happyvertical/smrt-extra', version: '0.39.0' },
+        ],
+        spawn,
+      }).map((pkg) => pkg.name),
+    ).toEqual(['@happyvertical/smrt-core']);
+  });
+});


### PR DESCRIPTION
## Summary
- add a release-publish preflight that refuses stale main checkouts, preexisting release tags, and already-published npm package versions
- move the existing major-version release guard into the reusable preflight script
- serialize `publish-release` jobs with an explicit concurrency group

## Root cause
Refs #1849.

The issue was reopened because #1848's merge run published `0.38.5` to npm from an older `main` checkout, then failed pushing `main` after #1850 had already advanced the branch. #1850's merge run built the correct artifact, but `changeset publish` skipped npm because `0.38.5` already existed, then the workflow force-updated `v0.38.5` and release metadata to the newer source. That left the GitHub tag/release containing the fix while the npm tarball was still the stale package.

This PR makes that failure mode stop before the irreversible npm publish step: the publish job now verifies it is still at current `origin/main`, that the release tag does not already exist, and that none of the publishable package versions already exist on npm.

## Validation
- `fnm exec --using 24.18.0 corepack pnpm exec vitest run scripts/guard-release-publish.test.js`
- `fnm exec --using 24.18.0 corepack pnpm exec biome check scripts/guard-release-publish.js scripts/guard-release-publish.test.js`
- `RELEASE_VERSION=0.38.6 SKIP_RELEASE_GIT_GUARD=true SKIP_RELEASE_NPM_GUARD=true fnm exec --using 24.18.0 node scripts/guard-release-publish.js`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "publish.yml YAML parses"'`
- `fnm exec --using 24.18.0 corepack pnpm run build`
- `fnm exec --using 24.18.0 corepack pnpm run lint`
- `fnm exec --using 24.18.0 corepack pnpm test`
- `fnm exec --using 24.18.0 corepack pnpm run typecheck`
