### PR TITLE
feat(smrt-web,core): WebMCP data-plane tool registration (#1812)

### DIFF
--- a/packages/core/src/generators/tool-schema.test.ts
+++ b/packages/core/src/generators/tool-schema.test.ts
@@ -78,11 +78,13 @@ describe('buildToolInputSchema', () => {
     );
   });
 
-  it('requires id (not slug) for get', () => {
+  it('accepts id OR slug for get (neither required at the schema level)', () => {
     const schema = buildToolInputSchema('get', PRODUCT_FIELDS);
-    expect(schema.required).toEqual(['id']);
     const props = schema.properties as Record<string, unknown>;
+    expect(props).toHaveProperty('id');
     expect(props).toHaveProperty('slug');
+    // Relaxed from the historical required:['id'] so a slug-only call is valid.
+    expect(schema.required).toBeUndefined();
   });
 
   it('promotes required model fields onto the create schema', () => {

--- a/packages/core/src/generators/tool-schema.test.ts
+++ b/packages/core/src/generators/tool-schema.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildToolDescriptors,
+  buildToolInputSchema,
+  fieldTypeToJsonSchema,
+  isCrudAction,
+  type ToolFieldMeta,
+} from './tool-schema.js';
+
+// A small fixture model standing in for a `@smrt()` class's public fields.
+const PRODUCT_FIELDS: ToolFieldMeta[] = [
+  { name: 'name', type: 'text', required: true, maxLength: 120 },
+  { name: 'price', type: 'decimal', min: 0 },
+  { name: 'stock', type: 'integer', min: 0, default: 0 },
+  { name: 'active', type: 'boolean', default: true },
+  { name: 'launchAt', type: 'datetime' },
+  { name: 'specs', type: 'json' },
+  { name: 'categoryId', type: 'foreignKey', related: 'Category' },
+];
+
+describe('fieldTypeToJsonSchema', () => {
+  it('maps each SMRT field kind to the right JSON-Schema primitive', () => {
+    expect(fieldTypeToJsonSchema({ name: 'n', type: 'text' }).type).toBe(
+      'string',
+    );
+    expect(fieldTypeToJsonSchema({ name: 'n', type: 'integer' }).type).toBe(
+      'integer',
+    );
+    expect(fieldTypeToJsonSchema({ name: 'n', type: 'decimal' }).type).toBe(
+      'number',
+    );
+    expect(fieldTypeToJsonSchema({ name: 'n', type: 'boolean' }).type).toBe(
+      'boolean',
+    );
+    expect(fieldTypeToJsonSchema({ name: 'n', type: 'json' }).type).toBe(
+      'object',
+    );
+  });
+
+  it('emits date-time format for datetime fields', () => {
+    const schema = fieldTypeToJsonSchema({
+      name: 'launchAt',
+      type: 'datetime',
+    });
+    expect(schema).toMatchObject({ type: 'string', format: 'date-time' });
+  });
+
+  it('describes a foreign key as the id of the related class', () => {
+    const schema = fieldTypeToJsonSchema({
+      name: 'categoryId',
+      type: 'foreignKey',
+      related: 'Category',
+    });
+    expect(schema).toMatchObject({
+      type: 'string',
+      description: 'ID of related Category',
+    });
+  });
+
+  it('carries min/max and default through onto the schema', () => {
+    const schema = fieldTypeToJsonSchema({
+      name: 'stock',
+      type: 'integer',
+      min: 0,
+      max: 9999,
+      default: 0,
+    });
+    expect(schema).toMatchObject({ minimum: 0, maximum: 9999, default: 0 });
+  });
+});
+
+describe('buildToolInputSchema', () => {
+  it('builds a paginated, filterable list schema', () => {
+    const schema = buildToolInputSchema('list', PRODUCT_FIELDS);
+    const props = (schema.properties ?? {}) as Record<string, unknown>;
+    expect(Object.keys(props)).toEqual(
+      expect.arrayContaining(['limit', 'offset', 'orderBy', 'where']),
+    );
+  });
+
+  it('requires id (not slug) for get', () => {
+    const schema = buildToolInputSchema('get', PRODUCT_FIELDS);
+    expect(schema.required).toEqual(['id']);
+    const props = schema.properties as Record<string, unknown>;
+    expect(props).toHaveProperty('slug');
+  });
+
+  it('promotes required model fields onto the create schema', () => {
+    const schema = buildToolInputSchema('create', PRODUCT_FIELDS);
+    expect(schema.required).toEqual(['name']);
+    const props = schema.properties as Record<string, unknown>;
+    expect(props).toHaveProperty('price');
+    expect(props).not.toHaveProperty('id'); // server-assigned, never on create
+  });
+
+  it('requires id and includes every field on update', () => {
+    const schema = buildToolInputSchema('update', PRODUCT_FIELDS);
+    expect(schema.required).toEqual(['id']);
+    const props = schema.properties as Record<string, unknown>;
+    expect(props).toHaveProperty('id');
+    expect(props).toHaveProperty('name');
+  });
+
+  it('gives a custom action the id + options shape', () => {
+    const schema = buildToolInputSchema('publish', PRODUCT_FIELDS);
+    expect(schema.required).toEqual(['id']);
+    const props = schema.properties as Record<string, unknown>;
+    expect(props).toHaveProperty('options');
+  });
+});
+
+describe('buildToolDescriptors', () => {
+  const descriptors = buildToolDescriptors({
+    className: 'Product',
+    fields: PRODUCT_FIELDS,
+    actions: ['list', 'get', 'create', 'update', 'delete', 'publish'],
+  });
+
+  it('names tools <class>_<action>, matching the Node MCP surface', () => {
+    expect(descriptors.map((d) => d.name)).toEqual([
+      'product_list',
+      'product_get',
+      'product_create',
+      'product_update',
+      'product_delete',
+      'product_publish',
+    ]);
+  });
+
+  it('marks only list and get as read-only (WebMCP readOnlyHint)', () => {
+    const readOnly = descriptors.filter((d) => d.readOnly).map((d) => d.action);
+    expect(readOnly).toEqual(['list', 'get']);
+  });
+
+  it('produces a complete, WebMCP-ready descriptor per action', () => {
+    for (const d of descriptors) {
+      expect(d.name).toBeTruthy();
+      expect(d.description).toBeTruthy();
+      expect(d.inputSchema).toMatchObject({ type: 'object' });
+    }
+  });
+
+  it('honors an explicit toolPrefix for custom vocabularies', () => {
+    const [tool] = buildToolDescriptors({
+      className: 'Product',
+      fields: [],
+      actions: ['list'],
+      toolPrefix: 'catalog_item',
+    });
+    expect(tool.name).toBe('catalog_item_list');
+  });
+});
+
+describe('isCrudAction', () => {
+  it('separates CRUD verbs from custom methods', () => {
+    expect(isCrudAction('list')).toBe(true);
+    expect(isCrudAction('delete')).toBe(true);
+    expect(isCrudAction('publish')).toBe(false);
+  });
+});

--- a/packages/core/src/generators/tool-schema.ts
+++ b/packages/core/src/generators/tool-schema.ts
@@ -1,0 +1,269 @@
+/**
+ * Transport-agnostic tool-descriptor builder (#1812, tracer).
+ *
+ * The single source of truth for turning a model's fields + exposed actions into
+ * MCP-shaped tool descriptors (`{ name, description, inputSchema }`). This is the
+ * shape both the Model Context Protocol AND Chrome's WebMCP
+ * (`document.modelContext.registerTool`) consume — see
+ * https://developer.chrome.com/docs/ai/webmcp.
+ *
+ * It is deliberately pure and free of `ObjectRegistry` / manifest coupling: it
+ * takes a normalized {@link ToolFieldMeta}[] so BOTH callers can share it —
+ *  - `MCPGenerator` (`src/generators/mcp.ts`) for the Node stdio server, and
+ *  - the web-collections emitter (`src/vite-plugin/web-collections.ts`) for the
+ *    browser client-data runtime's WebMCP descriptors.
+ *
+ * Keeping one implementation removes the field-mapping drift risk the
+ * "three emission sites must agree" contract in web-collections.ts already warns
+ * about. The `fieldTypeToJsonSchema` / per-action skeletons below are ported
+ * verbatim from mcp.ts's `fieldToMCPSchema` + `generateObjectTools`, so wiring
+ * mcp.ts to call this helper is a mechanical, behavior-preserving refactor.
+ */
+
+/**
+ * A JSON Schema fragment. Values vary by field kind, so this is only ever
+ * serialized into tool descriptors, never read back structurally.
+ */
+export type ToolJsonSchema = Record<string, unknown>;
+
+/**
+ * Normalized field metadata — the intersection of what the runtime registry
+ * (`FieldDefinition._meta`) and the build-time manifest (`WebFieldDefinition`)
+ * can each supply. Callers flatten their own field source into this shape.
+ */
+export interface ToolFieldMeta {
+  name: string;
+  /** Field kind: text | integer | decimal | boolean | datetime | json | foreignKey | … */
+  type: string;
+  required?: boolean;
+  description?: string;
+  default?: unknown;
+  maxLength?: number;
+  minLength?: number;
+  min?: number;
+  max?: number;
+  /** For `foreignKey`: the related class name, for the generated description. */
+  related?: string;
+}
+
+/** The CRUD verbs with dedicated input-schema skeletons; anything else is custom. */
+const CRUD_ACTIONS = new Set(['list', 'get', 'create', 'update', 'delete']);
+
+/** A single generated tool descriptor — the WebMCP / MCP tool shape. */
+export interface ToolDescriptor {
+  /** The action this tool performs (`list` | `get` | … | a custom method name). */
+  action: string;
+  /** Tool id, `${toolPrefix}_${action}` (e.g. `product_list`). */
+  name: string;
+  description: string;
+  inputSchema: ToolJsonSchema;
+  /** True for non-mutating reads (`list`/`get`) → WebMCP `annotations.readOnlyHint`. */
+  readOnly: boolean;
+}
+
+/**
+ * Map one normalized field to its JSON-Schema fragment. Ported from
+ * `MCPGenerator.fieldToMCPSchema` (mcp.ts) — keep the two in lockstep until
+ * mcp.ts is switched to call this.
+ */
+export function fieldTypeToJsonSchema(field: ToolFieldMeta): ToolJsonSchema {
+  const schema: ToolJsonSchema = {
+    description: field.description || `${field.type} field`,
+  };
+
+  switch (field.type) {
+    case 'text':
+      schema.type = 'string';
+      if (field.maxLength !== undefined) schema.maxLength = field.maxLength;
+      if (field.minLength !== undefined) schema.minLength = field.minLength;
+      break;
+    case 'integer':
+      schema.type = 'integer';
+      if (field.min !== undefined) schema.minimum = field.min;
+      if (field.max !== undefined) schema.maximum = field.max;
+      break;
+    case 'decimal':
+      schema.type = 'number';
+      if (field.min !== undefined) schema.minimum = field.min;
+      if (field.max !== undefined) schema.maximum = field.max;
+      break;
+    case 'boolean':
+      schema.type = 'boolean';
+      break;
+    case 'datetime':
+      schema.type = 'string';
+      schema.format = 'date-time';
+      break;
+    case 'json':
+      schema.type = 'object';
+      break;
+    case 'foreignKey':
+      schema.type = 'string';
+      schema.description = `ID of related ${field.related || 'object'}`;
+      break;
+    default:
+      schema.type = 'string';
+  }
+
+  if (field.default !== undefined) {
+    schema.default = field.default;
+  }
+
+  return schema;
+}
+
+/**
+ * Build the `inputSchema` for one action. CRUD verbs get the fixed skeletons
+ * ported from mcp.ts's `generateObjectTools`; any other action is treated as a
+ * custom method taking `{ id, options }`.
+ */
+export function buildToolInputSchema(
+  action: string,
+  fields: ToolFieldMeta[],
+): ToolJsonSchema {
+  switch (action) {
+    case 'list':
+      return {
+        type: 'object',
+        properties: {
+          limit: {
+            type: 'integer',
+            description: 'Maximum number of items to return',
+            default: 50,
+            minimum: 1,
+            maximum: 1000,
+          },
+          offset: {
+            type: 'integer',
+            description: 'Number of items to skip',
+            default: 0,
+            minimum: 0,
+          },
+          orderBy: {
+            type: 'string',
+            description: 'Field to order by (e.g., "created_at DESC")',
+          },
+          where: {
+            type: 'object',
+            description: 'Filter conditions as key-value pairs',
+            additionalProperties: true,
+          },
+        },
+      };
+
+    case 'get':
+      return {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            description: 'Unique identifier of the object',
+          },
+          slug: {
+            type: 'string',
+            description: 'URL-friendly identifier of the object',
+          },
+        },
+        required: ['id'],
+      };
+
+    case 'create': {
+      const properties: Record<string, ToolJsonSchema> = {};
+      const required: string[] = [];
+      for (const field of fields) {
+        properties[field.name] = fieldTypeToJsonSchema(field);
+        if (field.required) required.push(field.name);
+      }
+      return { type: 'object', properties, required };
+    }
+
+    case 'update': {
+      const properties: Record<string, ToolJsonSchema> = {
+        id: { type: 'string', description: 'ID of the object to update' },
+      };
+      for (const field of fields) {
+        properties[field.name] = fieldTypeToJsonSchema(field);
+      }
+      return { type: 'object', properties, required: ['id'] };
+    }
+
+    case 'delete':
+      return {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'ID of the object to delete' },
+        },
+        required: ['id'],
+      };
+
+    default:
+      // Custom method: mirrors mcp.ts's custom-action tool shape.
+      return {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            description: 'ID of the object to execute action on',
+          },
+          options: {
+            type: 'object',
+            description: 'Additional options for the custom action',
+            additionalProperties: true,
+          },
+        },
+        required: ['id'],
+      };
+  }
+}
+
+/**
+ * Human-readable description for a tool, matching mcp.ts's phrasing so the Node
+ * MCP and WebMCP surfaces read identically.
+ */
+function describeAction(action: string, className: string): string {
+  switch (action) {
+    case 'list':
+      return `List ${className} objects with optional filtering`;
+    case 'get':
+      return `Get a specific ${className} by ID or slug`;
+    case 'create':
+      return `Create a new ${className}`;
+    case 'update':
+      return `Update an existing ${className}`;
+    case 'delete':
+      return `Delete a ${className} by ID`;
+    default:
+      return `Execute ${action} action on ${className}`;
+  }
+}
+
+/**
+ * Build the full descriptor set for a model. `toolPrefix` defaults to the
+ * lowercased class name so tool ids match the existing Node MCP surface exactly
+ * (`product_list`, `invoice_record_payment`), giving one stable tool vocabulary
+ * across MCP and WebMCP.
+ */
+export function buildToolDescriptors(opts: {
+  className: string;
+  fields: ToolFieldMeta[];
+  actions: string[];
+  toolPrefix?: string;
+}): ToolDescriptor[] {
+  const { className, fields, actions } = opts;
+  const prefix = (opts.toolPrefix ?? className).toLowerCase();
+
+  return actions.map((action) => ({
+    action,
+    // Custom method names can contain underscores; the runtime splits on the
+    // FIRST underscore only (mcp.ts #1378), so a lowercased join is safe here.
+    name: `${prefix}_${action}`.toLowerCase(),
+    description: describeAction(action, className),
+    inputSchema: buildToolInputSchema(action, fields),
+    readOnly: action === 'list' || action === 'get',
+  }));
+}
+
+/** True when `action` is one of the fixed CRUD verbs (vs. a custom method). */
+export function isCrudAction(action: string): boolean {
+  return CRUD_ACTIONS.has(action);
+}

--- a/packages/core/src/generators/tool-schema.ts
+++ b/packages/core/src/generators/tool-schema.ts
@@ -152,6 +152,11 @@ export function buildToolInputSchema(
       };
 
     case 'get':
+      // Either `id` OR `slug` identifies the object (collection.get resolves
+      // both), so neither is required at the schema level — the handler validates
+      // that at least one is present. This intentionally relaxes mcp.ts's
+      // historical `required: ['id']`, which over-constrained slug-only lookups;
+      // when mcp.ts adopts this helper it inherits the fix.
       return {
         type: 'object',
         properties: {
@@ -164,7 +169,6 @@ export function buildToolInputSchema(
             description: 'URL-friendly identifier of the object',
           },
         },
-        required: ['id'],
       };
 
     case 'create': {

--- a/packages/core/src/prebuild/index.ts
+++ b/packages/core/src/prebuild/index.ts
@@ -319,6 +319,15 @@ declare module '@smrt/web' {
     relatedCollection: string;
   }
 
+  /** A WebMCP/MCP tool descriptor for one collection action (#1812). */
+  export interface WebToolDescriptor {
+    action: string;
+    name: string;
+    description: string;
+    inputSchema: Record<string, unknown>;
+    readOnly: boolean;
+  }
+
   export interface SmrtWebCollectionDefinition<TData = Record<string, unknown>> {
     name: string;
     className: string;
@@ -328,6 +337,8 @@ declare module '@smrt/web' {
     fields: Record<string, SmrtWebFieldDefinition>;
     /** Manifest-derived relationship edges to sibling REST collections. */
     relationships: SmrtWebRelationship[];
+    /** WebMCP/MCP tool descriptors for the exposed actions (#1812). */
+    toolDescriptors: WebToolDescriptor[];
     /** Phantom row-type carrier for inference — never present at runtime. */
     _row?: TData;
   }

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -28,6 +28,7 @@ import {
 } from './sveltekit-generator.js';
 import {
   buildWebCollectionDefinition,
+  buildWebToolDescriptors,
   computeWebManifestHash,
   selectWebCollectionEntries,
 } from './web-collections.js';
@@ -1332,10 +1333,13 @@ function generateWebModule(manifest: SmartObjectManifest): string {
   // can never drift (a drift would let the hash under-cover a change → stale
   // caches). See buildWebCollectionDefinition's docblock.
   for (const entry of selectWebCollectionEntries(manifest)) {
-    definitions[entry.collection] = buildWebCollectionDefinition(
-      entry,
-      manifest,
-    );
+    definitions[entry.collection] = {
+      ...buildWebCollectionDefinition(entry, manifest),
+      // WebMCP/MCP tool descriptors (#1812) — layered ON TOP of the shared shape
+      // so the #1764 shape digest (computeWebManifestHash, which calls
+      // buildWebCollectionDefinition directly) keeps hashing only the row shape.
+      toolDescriptors: buildWebToolDescriptors(entry),
+    };
   }
 
   // The web-collection SHAPE digest (#1764): a deterministic, replica-stable
@@ -1847,6 +1851,15 @@ declare module '@happyvertical/smrt-virt-web' {
     relatedCollection: string;
   }
 
+  /** A WebMCP/MCP tool descriptor for one collection action (#1812). */
+  export interface WebToolDescriptor {
+    action: string;
+    name: string;
+    description: string;
+    inputSchema: Record<string, unknown>;
+    readOnly: boolean;
+  }
+
   export interface SmrtWebCollectionDefinition<TData = Record<string, unknown>> {
     name: string;
     className: string;
@@ -1856,6 +1869,8 @@ declare module '@happyvertical/smrt-virt-web' {
     fields: Record<string, SmrtWebFieldDefinition>;
     /** Manifest-derived relationship edges to sibling REST collections. */
     relationships: SmrtWebRelationship[];
+    /** WebMCP/MCP tool descriptors for the exposed actions (#1812). */
+    toolDescriptors: WebToolDescriptor[];
     /** Phantom row-type carrier for inference — never present at runtime. */
     _row?: TData;
   }

--- a/packages/core/src/vite-plugin/web-collections.test.ts
+++ b/packages/core/src/vite-plugin/web-collections.test.ts
@@ -16,8 +16,10 @@ import type {
   SmartObjectManifest,
 } from '../scanner/types.js';
 import {
+  buildWebCollectionDefinition,
   buildWebFieldDefinitions,
   buildWebRelationships,
+  buildWebToolDescriptors,
   computeWebManifestHash,
   selectWebCollectionEntries,
 } from './web-collections.js';
@@ -50,6 +52,70 @@ function manifest(...objects: SmartObjectDefinition[]): SmartObjectManifest {
     ),
   } as SmartObjectManifest;
 }
+
+describe('buildWebToolDescriptors', () => {
+  const field = (f: Partial<FieldDefinition>): FieldDefinition =>
+    ({ type: 'text', ...f }) as FieldDefinition;
+
+  const productEntry = () =>
+    selectWebCollectionEntries(
+      manifest(
+        obj({
+          className: 'Product',
+          collection: 'products',
+          fields: {
+            name: field({ type: 'text', required: true }),
+            price: field({ type: 'decimal' }),
+          },
+        }),
+      ),
+    )[0];
+
+  it('emits one WebMCP descriptor per exposed action, named <class>_<action>', () => {
+    const names = buildWebToolDescriptors(productEntry()).map((d) => d.name);
+    // default (omitted) api config = full CRUD
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'product_list',
+        'product_get',
+        'product_create',
+        'product_update',
+        'product_delete',
+      ]),
+    );
+  });
+
+  it('marks only reads read-only and builds create inputs from public fields', () => {
+    const descriptors = buildWebToolDescriptors(productEntry());
+    expect(descriptors.find((d) => d.action === 'list')?.readOnly).toBe(true);
+    const create = descriptors.find((d) => d.action === 'create');
+    expect(create?.readOnly).toBe(false);
+    const props = (create?.inputSchema.properties ?? {}) as Record<
+      string,
+      unknown
+    >;
+    expect(props).toHaveProperty('name');
+    expect(props).toHaveProperty('price');
+    expect(create?.inputSchema.required).toContain('name');
+  });
+
+  it('stays OUT of buildWebCollectionDefinition, so the #1764 shape digest never covers it', () => {
+    const m = manifest(
+      obj({
+        className: 'Product',
+        collection: 'products',
+        fields: { name: field({ type: 'text' }) },
+      }),
+    );
+    const def = buildWebCollectionDefinition(
+      selectWebCollectionEntries(m)[0],
+      m,
+    );
+    // Descriptors are layered on in generateWebModule, NOT here — that is what
+    // keeps computeWebManifestHash (which hashes this shape) row-shape-only.
+    expect(def).not.toHaveProperty('toolDescriptors');
+  });
+});
 
 describe('selectWebCollectionEntries', () => {
   it('includes a model with the default (omitted) api config as full CRUD', () => {

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -20,6 +20,11 @@
  */
 
 import { createHash } from 'node:crypto';
+import {
+  buildToolDescriptors,
+  type ToolDescriptor,
+  type ToolFieldMeta,
+} from '../generators/tool-schema.js';
 import type {
   FieldDefinition,
   SmartObjectDefinition,
@@ -359,6 +364,39 @@ export function buildWebRelationships(
     });
   }
   return relationships;
+}
+
+/**
+ * Build the WebMCP / MCP tool descriptors for a web collection (#1812): one
+ * descriptor per exposed action, over the SAME public-DTO fields the definition
+ * already exposes (`buildWebFieldDefinitions`). The tool ids match the Node MCP
+ * surface (`<class>_<action>`), so a page's WebMCP tools and its MCP-server
+ * tools share one vocabulary.
+ *
+ * Deliberately NOT part of {@link buildWebCollectionDefinition}: descriptors are
+ * layered onto the emitted value by {@link generateWebModule} instead, so the
+ * #1764 {@link computeWebManifestHash} shape digest keeps hashing ONLY the row
+ * shape. That is safe because a descriptor is a pure function of
+ * className/actions/fields — all already in the hash — so excluding it never
+ * lets the digest under-cover a real shape change.
+ */
+export function buildWebToolDescriptors(
+  entry: WebCollectionEntry,
+): ToolDescriptor[] {
+  const webFields = buildWebFieldDefinitions(entry.obj);
+  const fields: ToolFieldMeta[] = Object.entries(webFields).map(
+    ([name, def]) => ({
+      name,
+      type: def.type,
+      ...(def.required !== undefined ? { required: def.required } : {}),
+      ...(def.default !== undefined ? { default: def.default } : {}),
+    }),
+  );
+  return buildToolDescriptors({
+    className: entry.obj.className,
+    fields,
+    actions: entry.actions,
+  });
 }
 
 /**

--- a/packages/core/src/vite-plugin/web-module.test.ts
+++ b/packages/core/src/vite-plugin/web-module.test.ts
@@ -135,6 +135,26 @@ export class HiddenGadget extends SmrtObject {
       price: { type: 'decimal' },
       inStock: { type: 'boolean' },
     });
+
+    // WebMCP tool descriptors (#1812) are emitted alongside the row shape: one
+    // per exposed action, named <class>_<action>, read-only for reads. This is
+    // what makes registerWebMcpTools non-inert for real generated definitions.
+    const toolDescriptors = widgets.toolDescriptors as Array<{
+      name: string;
+      action: string;
+      readOnly: boolean;
+    }>;
+    expect(toolDescriptors.map((t) => t.name).sort()).toEqual([
+      'widget_create',
+      'widget_get',
+      'widget_list',
+    ]);
+    expect(toolDescriptors.find((t) => t.action === 'list')?.readOnly).toBe(
+      true,
+    );
+    expect(toolDescriptors.find((t) => t.action === 'create')?.readOnly).toBe(
+      false,
+    );
   });
 
   it('emits the build-time manifestHash constant (#1764)', async () => {

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -167,6 +167,25 @@ export interface SmrtWebRelationship {
  * type carrier threaded through codegen — it never exists at runtime, it only
  * lets factories infer the row type from a definition.
  */
+/**
+ * One WebMCP / MCP tool descriptor for a collection action (#1812). Emitted by
+ * the core web-collections codegen as PLAIN DATA (this package has no smrt
+ * dependency), shaped to match Chrome's `document.modelContext.registerTool`
+ * input — see https://developer.chrome.com/docs/ai/webmcp. Consumed by
+ * {@link registerWebMcpTools} in `./webmcp`.
+ */
+export interface WebToolDescriptor {
+  /** The action this tool performs (`list` | `get` | … | a custom method name). */
+  action: string;
+  /** Tool id, `${className.toLowerCase()}_${action}` (e.g. `product_list`). */
+  name: string;
+  description: string;
+  /** JSON Schema for the tool's arguments. */
+  inputSchema: Record<string, unknown>;
+  /** True for non-mutating reads → WebMCP `annotations.readOnlyHint`. */
+  readOnly: boolean;
+}
+
 export interface SmrtWebCollectionDefinition<TData extends object = object> {
   /** REST collection name (e.g. `products`). */
   name: string;
@@ -178,6 +197,12 @@ export interface SmrtWebCollectionDefinition<TData extends object = object> {
   idField: string;
   /** CRUD + custom actions exposed by the api decorator config. */
   actions: string[];
+  /**
+   * WebMCP/MCP tool descriptors for the exposed actions (#1812). Optional so
+   * hand-built definitions (older codegen, tests) still satisfy the type; a
+   * missing value means "no WebMCP tools to register".
+   */
+  toolDescriptors?: WebToolDescriptor[];
   /** Persisted field metadata keyed by field name. */
   fields: Record<string, SmrtWebFieldDefinition>;
   /**
@@ -1118,3 +1143,12 @@ export function createSmrtCollection<TData extends object>(
 
   return handle;
 }
+
+// ---------------------------------------------------------------------------
+// WebMCP browser tool registration (#1812)
+// ---------------------------------------------------------------------------
+
+export {
+  registerWebMcpTools,
+  type RegisterWebMcpToolsOptions,
+} from './webmcp.js';

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -320,6 +320,61 @@ export function unwrapItemResult(
   );
 }
 
+/** SMRT WHERE operator → the generated REST route's `field[op]=value` token. */
+const SMRT_TO_REST_OPERATOR: Record<string, string> = {
+  '>': 'gt',
+  '>=': 'gte',
+  '<': 'lt',
+  '<=': 'lte',
+  '!=': 'ne',
+  in: 'in',
+  like: 'like',
+};
+
+/**
+ * Serialize `list` query params into the query string the generated REST list
+ * route parses (`handleList` in `core/src/generators/rest.ts`): `limit`,
+ * `offset`, `orderBy` as scalars, and `where` entries as `field=value`
+ * (equality) or `field[op]=value` for a `{ op, value }` condition (`in` joins an
+ * array with commas). Called with no params (the collection runtime's argument-
+ * free `list()`) it returns `''`, so the bare-URL behavior is unchanged.
+ */
+export function buildListQuery(params?: Record<string, unknown>): string {
+  if (!params) return '';
+  const search = new URLSearchParams();
+  const { limit, offset, orderBy, where } = params;
+  if (limit !== undefined) search.set('limit', String(limit));
+  if (offset !== undefined) search.set('offset', String(offset));
+  if (orderBy !== undefined) {
+    search.set(
+      'orderBy',
+      Array.isArray(orderBy) ? orderBy.join(', ') : String(orderBy),
+    );
+  }
+  if (where && typeof where === 'object') {
+    for (const [field, condition] of Object.entries(
+      where as Record<string, unknown>,
+    )) {
+      if (
+        condition &&
+        typeof condition === 'object' &&
+        !Array.isArray(condition) &&
+        'op' in condition &&
+        'value' in condition
+      ) {
+        const { op, value } = condition as { op: string; value: unknown };
+        const restOp = SMRT_TO_REST_OPERATOR[op];
+        const token = Array.isArray(value) ? value.join(',') : String(value);
+        search.set(restOp ? `${field}[${restOp}]` : field, token);
+      } else if (condition !== undefined && condition !== null) {
+        search.set(field, String(condition));
+      }
+    }
+  }
+  const qs = search.toString();
+  return qs ? `?${qs}` : '';
+}
+
 /**
  * Build CRUD fetchers from a generated collection definition — the same URL
  * scheme and payload handling as the generated REST client
@@ -352,7 +407,10 @@ export function createDefinitionFetchers(
   };
 
   return {
-    list: async () => parse(await fetchFn(collectionUrl, { headers })),
+    list: async (params) =>
+      parse(
+        await fetchFn(`${collectionUrl}${buildListQuery(params)}`, { headers }),
+      ),
     get: async (id) =>
       parse(await fetchFn(`${collectionUrl}/${id}`, { headers })),
     create: async (data) =>
@@ -1149,6 +1207,6 @@ export function createSmrtCollection<TData extends object>(
 // ---------------------------------------------------------------------------
 
 export {
-  registerWebMcpTools,
   type RegisterWebMcpToolsOptions,
+  registerWebMcpTools,
 } from './webmcp.js';

--- a/packages/smrt-web/src/webmcp.test.ts
+++ b/packages/smrt-web/src/webmcp.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { SmrtCrudFetchers, SmrtWebCollectionDefinition } from './index.js';
+import { buildListQuery } from './index.js';
 import { registerWebMcpTools } from './webmcp.js';
 
 // ---------------------------------------------------------------------------
@@ -203,5 +204,70 @@ describe('registerWebMcpTools', () => {
     };
     registerWebMcpTools([bare], { resolveFetchers: () => mockFetchers() });
     expect(registry.tools).toHaveLength(0);
+  });
+
+  it('serializes list query params into the REST URL on the default fetcher path', async () => {
+    const registry = installModelContext();
+    const calls: string[] = [];
+    const fetchFn = (async (url: string | URL) => {
+      calls.push(String(url));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => [{ id: 'p1' }],
+      } as Response;
+    }) as unknown as typeof fetch;
+
+    // No resolveFetchers → exercises the real createDefinitionFetchers path.
+    registerWebMcpTools([PRODUCT_DEF], { basePath: '/api/v1', fetchFn });
+    const listTool = registry.tools.find((t) => t.name === 'product_list');
+    await listTool?.execute({
+      limit: 10,
+      offset: 20,
+      where: { status: 'active' },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('/api/v1/products?');
+    expect(calls[0]).toContain('limit=10');
+    expect(calls[0]).toContain('offset=20');
+    expect(calls[0]).toContain('status=active');
+  });
+});
+
+describe('buildListQuery', () => {
+  const parse = (qs: string) => new URLSearchParams(qs.replace(/^\?/, ''));
+
+  it('is empty for no params (the collection runtime bare list())', () => {
+    expect(buildListQuery()).toBe('');
+    expect(buildListQuery({})).toBe('');
+  });
+
+  it('serializes limit/offset/orderBy as scalars', () => {
+    const p = parse(
+      buildListQuery({ limit: 10, offset: 5, orderBy: 'name ASC' }),
+    );
+    expect(p.get('limit')).toBe('10');
+    expect(p.get('offset')).toBe('5');
+    expect(p.get('orderBy')).toBe('name ASC');
+  });
+
+  it('serializes an equality where as field=value', () => {
+    const p = parse(buildListQuery({ where: { status: 'active' } }));
+    expect(p.get('status')).toBe('active');
+  });
+
+  it('maps a SMRT operator condition to the REST field[op]=value token', () => {
+    const p = parse(
+      buildListQuery({ where: { price: { op: '>', value: 10 } } }),
+    );
+    expect(p.get('price[gt]')).toBe('10');
+  });
+
+  it('joins an in-array with commas', () => {
+    const p = parse(
+      buildListQuery({ where: { id: { op: 'in', value: ['a', 'b'] } } }),
+    );
+    expect(p.get('id[in]')).toBe('a,b');
   });
 });

--- a/packages/smrt-web/src/webmcp.test.ts
+++ b/packages/smrt-web/src/webmcp.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SmrtCrudFetchers, SmrtWebCollectionDefinition } from './index.js';
+import { registerWebMcpTools } from './webmcp.js';
+
+// ---------------------------------------------------------------------------
+// A fake WebMCP registry standing in for Chrome's document.modelContext.
+// ---------------------------------------------------------------------------
+
+interface CapturedTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: { readOnlyHint?: boolean };
+  execute: (args: Record<string, unknown>) => Promise<string> | string;
+}
+
+function installModelContext(): {
+  tools: CapturedTool[];
+  unregistered: string[];
+} {
+  const tools: CapturedTool[] = [];
+  const unregistered: string[] = [];
+  (globalThis as { document?: unknown }).document = {
+    modelContext: {
+      registerTool(tool: CapturedTool) {
+        tools.push(tool);
+        return { unregister: () => unregistered.push(tool.name) };
+      },
+    },
+  };
+  return { tools, unregistered };
+}
+
+function clearModelContext(): void {
+  (globalThis as { document?: unknown }).document = undefined;
+}
+
+// A Product definition as the core codegen would emit it, tool descriptors and
+// all. Only the fields registerWebMcpTools reads are populated.
+const PRODUCT_DEF: SmrtWebCollectionDefinition = {
+  name: 'products',
+  className: 'Product',
+  endpoint: '/products',
+  idField: 'id',
+  actions: ['list', 'get', 'create', 'update', 'delete', 'publish'],
+  toolDescriptors: [
+    {
+      action: 'list',
+      name: 'product_list',
+      description: 'List Product objects with optional filtering',
+      inputSchema: { type: 'object', properties: {} },
+      readOnly: true,
+    },
+    {
+      action: 'create',
+      name: 'product_create',
+      description: 'Create a new Product',
+      inputSchema: { type: 'object', properties: {} },
+      readOnly: false,
+    },
+    {
+      action: 'publish',
+      name: 'product_publish',
+      description: 'Execute publish action on Product',
+      inputSchema: { type: 'object', properties: {} },
+      readOnly: false,
+    },
+  ],
+};
+
+function mockFetchers(overrides: Partial<SmrtCrudFetchers> = {}) {
+  return {
+    list: vi.fn(async () => [{ id: 'p1', name: 'Widget' }]),
+    get: vi.fn(async (id: string) => ({ id, name: 'Widget' })),
+    create: vi.fn(async (data: Record<string, unknown>) => ({
+      id: 'p2',
+      ...data,
+    })),
+    update: vi.fn(async (id: string, data: Record<string, unknown>) => ({
+      id,
+      ...data,
+    })),
+    delete: vi.fn(async () => true),
+    ...overrides,
+  } satisfies SmrtCrudFetchers;
+}
+
+describe('registerWebMcpTools', () => {
+  afterEach(() => {
+    clearModelContext();
+    vi.restoreAllMocks();
+  });
+
+  it('is a no-op when the browser has no WebMCP support', () => {
+    clearModelContext();
+    const dispose = registerWebMcpTools([PRODUCT_DEF], {
+      resolveFetchers: () => mockFetchers(),
+    });
+    expect(dispose).toBeInstanceOf(Function);
+    expect(() => dispose()).not.toThrow(); // inert disposer, no crash
+  });
+
+  it('registers one tool per descriptor with the right names', () => {
+    const registry = installModelContext();
+    registerWebMcpTools([PRODUCT_DEF], {
+      resolveFetchers: () => mockFetchers(),
+    });
+    expect(registry.tools.map((t) => t.name)).toEqual([
+      'product_list',
+      'product_create',
+      'product_publish',
+    ]);
+  });
+
+  it('maps readOnly to WebMCP readOnlyHint annotations', () => {
+    const registry = installModelContext();
+    registerWebMcpTools([PRODUCT_DEF], {
+      resolveFetchers: () => mockFetchers(),
+    });
+    const byName = new Map(registry.tools.map((t) => [t.name, t]));
+    expect(byName.get('product_list')?.annotations?.readOnlyHint).toBe(true);
+    expect(byName.get('product_create')?.annotations?.readOnlyHint).toBe(false);
+  });
+
+  it('routes a list tool call through the fetchers and returns a JSON string', async () => {
+    const registry = installModelContext();
+    const fetchers = mockFetchers();
+    registerWebMcpTools([PRODUCT_DEF], { resolveFetchers: () => fetchers });
+
+    const listTool = registry.tools.find((t) => t.name === 'product_list');
+    const result = await listTool?.execute({ limit: 10 });
+
+    expect(fetchers.list).toHaveBeenCalledWith({ limit: 10 });
+    expect(typeof result).toBe('string');
+    expect(JSON.parse(result as string)).toEqual([
+      { id: 'p1', name: 'Widget' },
+    ]);
+  });
+
+  it('routes a create tool call through the fetchers with the tool args as the body', async () => {
+    const registry = installModelContext();
+    const fetchers = mockFetchers();
+    registerWebMcpTools([PRODUCT_DEF], { resolveFetchers: () => fetchers });
+
+    const createTool = registry.tools.find((t) => t.name === 'product_create');
+    const result = await createTool?.execute({ name: 'Gadget', price: 9.99 });
+
+    expect(fetchers.create).toHaveBeenCalledWith({
+      name: 'Gadget',
+      price: 9.99,
+    });
+    expect(JSON.parse(result as string)).toMatchObject({
+      id: 'p2',
+      name: 'Gadget',
+    });
+  });
+
+  it('returns a clear not-wired payload for custom actions (tracer scope)', async () => {
+    const registry = installModelContext();
+    registerWebMcpTools([PRODUCT_DEF], {
+      resolveFetchers: () => mockFetchers(),
+    });
+
+    const publishTool = registry.tools.find(
+      (t) => t.name === 'product_publish',
+    );
+    const parsed = JSON.parse(
+      (await publishTool?.execute({ id: 'p1' })) as string,
+    );
+    expect(parsed.error).toMatch(/not wired/i);
+    expect(parsed.action).toBe('publish');
+  });
+
+  it('deregisters every registered tool when disposed', () => {
+    const registry = installModelContext();
+    const dispose = registerWebMcpTools([PRODUCT_DEF], {
+      resolveFetchers: () => mockFetchers(),
+    });
+    dispose();
+    // Disposer pops LIFO, so compare as a set — order is incidental.
+    expect(new Set(registry.unregistered)).toEqual(
+      new Set(['product_list', 'product_create', 'product_publish']),
+    );
+  });
+
+  it('skips tools rejected by the filter predicate', () => {
+    const registry = installModelContext();
+    registerWebMcpTools([PRODUCT_DEF], {
+      resolveFetchers: () => mockFetchers(),
+      filter: (_def, descriptor) => descriptor.readOnly, // reads-only surface
+    });
+    expect(registry.tools.map((t) => t.name)).toEqual(['product_list']);
+  });
+
+  it('ignores definitions with no tool descriptors', () => {
+    const registry = installModelContext();
+    const bare: SmrtWebCollectionDefinition = {
+      name: 'tags',
+      className: 'Tag',
+      endpoint: '/tags',
+      idField: 'id',
+      actions: ['list'],
+    };
+    registerWebMcpTools([bare], { resolveFetchers: () => mockFetchers() });
+    expect(registry.tools).toHaveLength(0);
+  });
+});

--- a/packages/smrt-web/src/webmcp.test.ts
+++ b/packages/smrt-web/src/webmcp.test.ts
@@ -23,9 +23,12 @@ function installModelContext(): {
   const unregistered: string[] = [];
   (globalThis as { document?: unknown }).document = {
     modelContext: {
-      registerTool(tool: CapturedTool) {
+      // WebMCP removes a tool when the signal it was registered with aborts.
+      registerTool(tool: CapturedTool, opts?: { signal?: AbortSignal }) {
         tools.push(tool);
-        return { unregister: () => unregistered.push(tool.name) };
+        opts?.signal?.addEventListener('abort', () =>
+          unregistered.push(tool.name),
+        );
       },
     },
   };
@@ -232,6 +235,27 @@ describe('registerWebMcpTools', () => {
     expect(calls[0]).toContain('limit=10');
     expect(calls[0]).toContain('offset=20');
     expect(calls[0]).toContain('status=active');
+  });
+
+  it('resolves a get tool by slug when no id is provided', async () => {
+    const registry = installModelContext();
+    const fetchers = mockFetchers();
+    const defWithGet: SmrtWebCollectionDefinition = {
+      ...PRODUCT_DEF,
+      toolDescriptors: [
+        {
+          action: 'get',
+          name: 'product_get',
+          description: 'Get a specific Product by ID or slug',
+          inputSchema: { type: 'object', properties: {} },
+          readOnly: true,
+        },
+      ],
+    };
+    registerWebMcpTools([defWithGet], { resolveFetchers: () => fetchers });
+    const getTool = registry.tools.find((t) => t.name === 'product_get');
+    await getTool?.execute({ slug: 'my-widget' });
+    expect(fetchers.get).toHaveBeenCalledWith('my-widget');
   });
 });
 

--- a/packages/smrt-web/src/webmcp.ts
+++ b/packages/smrt-web/src/webmcp.ts
@@ -1,0 +1,226 @@
+/**
+ * WebMCP browser tool registration (#1812, tracer).
+ *
+ * Registers each collection's generated {@link WebToolDescriptor}s with the
+ * browser's WebMCP registry (`document.modelContext.registerTool`) so an
+ * in-page AI agent can discover and invoke them — see
+ * https://developer.chrome.com/docs/ai/webmcp. Each tool's `execute` runs
+ * through the collection's REST fetchers AS THE PAGE'S AUTHENTICATED USER, so
+ * the generated REST guards (auth, tenant gate #1554, writable + sensitive-field
+ * policy #1540) are the security boundary — nothing is re-implemented here.
+ *
+ * Framework-agnostic and engine-free: this module imports no UI framework and no
+ * client-data engine. `document.modelContext` is a browser global, not a
+ * dependency. Reads/writes go through {@link createDefinitionFetchers} (plain
+ * fetch), so registering tools never drags the TanStack engine onto a page.
+ *
+ * TRACER SCOPE: CRUD actions (list/get/create/update/delete) are fully wired;
+ * custom actions return a clear "not wired" payload. The full slice can route
+ * `execute` through the shared-client collection instead of raw fetchers so
+ * agent mutations reflect in on-page live collections (cache coherence).
+ */
+
+import {
+  createDefinitionFetchers,
+  type SmrtCrudFetchers,
+  type SmrtWebCollectionDefinition,
+  unwrapItemResult,
+  unwrapListResult,
+} from './index.js';
+
+/** The subset of Chrome's WebMCP `registerTool` input this tracer emits. */
+interface WebMcpToolRegistration {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: { readOnlyHint?: boolean; untrustedContentHint?: boolean };
+  execute: (args: Record<string, unknown>) => Promise<string> | string;
+}
+
+/** What `registerTool` returns — a handle we can later `unregister()`. */
+interface RegisteredToolHandle {
+  unregister?: () => void;
+}
+
+/** The slice of `document.modelContext` this module depends on. */
+interface ModelContextLike {
+  registerTool: (
+    tool: WebMcpToolRegistration,
+  ) => RegisteredToolHandle | undefined;
+}
+
+/**
+ * Feature-detect `document.modelContext`. Returns undefined off-WebMCP (SSR,
+ * non-Chrome, or Chrome without the origin trial) so every entry point no-ops.
+ */
+function getModelContext(): ModelContextLike | undefined {
+  const doc = (globalThis as { document?: { modelContext?: unknown } })
+    .document;
+  const mc = doc?.modelContext;
+  if (mc && typeof (mc as ModelContextLike).registerTool === 'function') {
+    return mc as ModelContextLike;
+  }
+  return undefined;
+}
+
+export interface RegisterWebMcpToolsOptions {
+  /** REST base path for the fetchers (default `/api/v1`). */
+  basePath?: string;
+  /** Injectable fetch (tests / SSR-safe wrappers). */
+  fetchFn?: typeof fetch;
+  /**
+   * Override how a definition's CRUD fetchers are built. Defaults to
+   * {@link createDefinitionFetchers}; the primary seam for testing `execute`
+   * without a live server.
+   */
+  resolveFetchers?: (
+    definition: SmrtWebCollectionDefinition,
+  ) => SmrtCrudFetchers;
+  /** Predicate to include/exclude individual tools (e.g. reads-only surfaces). */
+  filter?: (
+    definition: SmrtWebCollectionDefinition,
+    descriptor: NonNullable<
+      SmrtWebCollectionDefinition['toolDescriptors']
+    >[number],
+  ) => boolean;
+}
+
+/**
+ * Register every collection's generated tool descriptors with WebMCP.
+ *
+ * @returns a disposer that deregisters all tools this call registered. On a
+ * browser without WebMCP the call is a no-op and the disposer is inert.
+ */
+export function registerWebMcpTools(
+  definitions: SmrtWebCollectionDefinition[],
+  options: RegisterWebMcpToolsOptions = {},
+): () => void {
+  const ctx = getModelContext();
+  if (!ctx) return () => {};
+
+  const basePath = options.basePath ?? '/api/v1';
+  const disposers: Array<() => void> = [];
+
+  for (const definition of definitions) {
+    const descriptors = definition.toolDescriptors;
+    if (!descriptors || descriptors.length === 0) continue;
+
+    const fetchers = options.resolveFetchers
+      ? options.resolveFetchers(definition)
+      : createDefinitionFetchers(definition, basePath, options.fetchFn);
+
+    for (const descriptor of descriptors) {
+      if (options.filter && !options.filter(definition, descriptor)) continue;
+
+      const handle = ctx.registerTool({
+        name: descriptor.name,
+        description: descriptor.description,
+        inputSchema: descriptor.inputSchema,
+        annotations: { readOnlyHint: descriptor.readOnly },
+        execute: (args) =>
+          dispatch(fetchers, definition, descriptor.action, args ?? {}),
+      });
+
+      if (handle && typeof handle.unregister === 'function') {
+        const unregister = handle.unregister.bind(handle);
+        disposers.push(unregister);
+      }
+    }
+  }
+
+  return () => {
+    while (disposers.length > 0) {
+      const dispose = disposers.pop();
+      dispose?.();
+    }
+  };
+}
+
+/** Require and return a string `id` from tool args, or throw a clear error. */
+function requireId(args: Record<string, unknown>, action: string): string {
+  const id = args.id;
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new Error(`WebMCP ${action} requires a string 'id' argument`);
+  }
+  return id;
+}
+
+/** Narrow the list-tool args to the fetcher's query params. */
+function listParams(args: Record<string, unknown>): Record<string, unknown> {
+  const params: Record<string, unknown> = {};
+  if (args.limit !== undefined) params.limit = args.limit;
+  if (args.offset !== undefined) params.offset = args.offset;
+  if (args.orderBy !== undefined) params.orderBy = args.orderBy;
+  if (args.where !== undefined) params.where = args.where;
+  return params;
+}
+
+/**
+ * Route a tool call to the collection's REST fetchers and return a STRING —
+ * WebMCP's `execute` contract. Reuses the package's existing payload
+ * normalization ({@link unwrapListResult} / {@link unwrapItemResult}), so
+ * `{ error }` bodies surface as thrown `SmrtWebRequestError`s the agent sees.
+ */
+async function dispatch(
+  fetchers: SmrtCrudFetchers,
+  definition: SmrtWebCollectionDefinition,
+  action: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  switch (action) {
+    case 'list': {
+      const rows = unwrapListResult(
+        await fetchers.list(listParams(args)),
+        definition.name,
+      );
+      return JSON.stringify(rows);
+    }
+
+    case 'get': {
+      if (!fetchers.get)
+        throw new Error(`${definition.name} has no get action`);
+      const row = unwrapItemResult(
+        await fetchers.get(requireId(args, 'get')),
+        `get(${definition.name})`,
+      );
+      return JSON.stringify(row);
+    }
+
+    case 'create': {
+      const row = unwrapItemResult(
+        await fetchers.create(args),
+        `create(${definition.name})`,
+      );
+      return JSON.stringify(row);
+    }
+
+    case 'update': {
+      if (!fetchers.update) {
+        throw new Error(`${definition.name} has no update action`);
+      }
+      const { id: _id, ...body } = args;
+      const row = unwrapItemResult(
+        await fetchers.update(requireId(args, 'update'), body),
+        `update(${definition.name})`,
+      );
+      return JSON.stringify(row);
+    }
+
+    case 'delete': {
+      if (!fetchers.delete) {
+        throw new Error(`${definition.name} has no delete action`);
+      }
+      await fetchers.delete(requireId(args, 'delete'));
+      return JSON.stringify({ success: true });
+    }
+
+    default:
+      // Custom actions (e.g. invoice_record_payment) hit bespoke REST routes not
+      // covered by the CRUD fetchers. Wired in the full slice (#1812).
+      return JSON.stringify({
+        error: `WebMCP custom action '${action}' is not wired in the tracer`,
+        action,
+        collection: definition.name,
+      });
+  }
+}

--- a/packages/smrt-web/src/webmcp.ts
+++ b/packages/smrt-web/src/webmcp.ts
@@ -37,16 +37,14 @@ interface WebMcpToolRegistration {
   execute: (args: Record<string, unknown>) => Promise<string> | string;
 }
 
-/** What `registerTool` returns — a handle we can later `unregister()`. */
-interface RegisteredToolHandle {
-  unregister?: () => void;
-}
-
 /** The slice of `document.modelContext` this module depends on. */
 interface ModelContextLike {
+  // WebMCP removes a tool via an AbortSignal passed as the second arg, NOT via a
+  // returned handle — see https://developer.chrome.com/docs/ai/webmcp/imperative-api.
   registerTool: (
     tool: WebMcpToolRegistration,
-  ) => RegisteredToolHandle | undefined;
+    options?: { signal?: AbortSignal },
+  ) => void;
 }
 
 /**
@@ -99,7 +97,10 @@ export function registerWebMcpTools(
   if (!ctx) return () => {};
 
   const basePath = options.basePath ?? '/api/v1';
-  const disposers: Array<() => void> = [];
+  // ONE controller deregisters every tool this call registers: WebMCP removes a
+  // tool when the signal it was registered with aborts, so the returned disposer
+  // simply aborts. Idempotent — a second call is a harmless no-op.
+  const controller = new AbortController();
 
   for (const definition of definitions) {
     const descriptors = definition.toolDescriptors;
@@ -112,28 +113,21 @@ export function registerWebMcpTools(
     for (const descriptor of descriptors) {
       if (options.filter && !options.filter(definition, descriptor)) continue;
 
-      const handle = ctx.registerTool({
-        name: descriptor.name,
-        description: descriptor.description,
-        inputSchema: descriptor.inputSchema,
-        annotations: { readOnlyHint: descriptor.readOnly },
-        execute: (args) =>
-          dispatch(fetchers, definition, descriptor.action, args ?? {}),
-      });
-
-      if (handle && typeof handle.unregister === 'function') {
-        const unregister = handle.unregister.bind(handle);
-        disposers.push(unregister);
-      }
+      ctx.registerTool(
+        {
+          name: descriptor.name,
+          description: descriptor.description,
+          inputSchema: descriptor.inputSchema,
+          annotations: { readOnlyHint: descriptor.readOnly },
+          execute: (args) =>
+            dispatch(fetchers, definition, descriptor.action, args ?? {}),
+        },
+        { signal: controller.signal },
+      );
     }
   }
 
-  return () => {
-    while (disposers.length > 0) {
-      const dispose = disposers.pop();
-      dispose?.();
-    }
-  };
+  return () => controller.abort();
 }
 
 /** Require and return a string `id` from tool args, or throw a clear error. */
@@ -143,6 +137,19 @@ function requireId(args: Record<string, unknown>, action: string): string {
     throw new Error(`WebMCP ${action} requires a string 'id' argument`);
   }
   return id;
+}
+
+/**
+ * Resolve a `get` identifier: `id`, or `slug` as a fallback. The generated REST
+ * route and `collection.get()` both resolve either, and the get tool schema
+ * advertises both, so a slug-only call must work.
+ */
+function requireIdentifier(args: Record<string, unknown>): string {
+  const value = args.id ?? args.slug;
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error("WebMCP get requires a string 'id' or 'slug' argument");
+  }
+  return value;
 }
 
 /** Narrow the list-tool args to the fetcher's query params. */
@@ -180,7 +187,7 @@ async function dispatch(
       if (!fetchers.get)
         throw new Error(`${definition.name} has no get action`);
       const row = unwrapItemResult(
-        await fetchers.get(requireId(args, 'get')),
+        await fetchers.get(requireIdentifier(args)),
         `get(${definition.name})`,
       );
       return JSON.stringify(row);


### PR DESCRIPTION
## What & why

Brings SMRT to Chrome's in-page **WebMCP** API
([`document.modelContext.registerTool`](https://developer.chrome.com/docs/ai/webmcp)):
every API-exposed collection's CRUD actions become tools an in-page AI agent can
discover and invoke, executing against the generated REST surface **as the
page's authenticated user**. The descriptor shape SMRT already emits for its Node
MCP server *is* the WebMCP tool shape, so this is a thin bridge over the #1761
runtime.

Part of #1812 · epic #1755.

## What's in this PR

- **core — `src/generators/tool-schema.ts`** (new): pure, transport-agnostic
  `fieldTypeToJsonSchema` / `buildToolInputSchema` / `buildToolDescriptors`,
  shared so the Node MCP generator can adopt it as a single source of truth.
- **core codegen** emits `toolDescriptors` into the generated web collection
  definitions (`buildWebToolDescriptors` → `generateWebModule` + both d.ts
  emission sites). Layered ON TOP of the shared `buildWebCollectionDefinition`,
  so the #1764 shape digest (`computeWebManifestHash`) stays row-shape-only
  (a descriptor is a pure function of already-hashed className/actions/fields).
- **smrt-web — `src/webmcp.ts`** (new): `registerWebMcpTools(defs, opts)` —
  feature-detects `document.modelContext`, registers each descriptor, routes
  `execute()` through the CRUD fetchers, and removes tools via a single
  `AbortController` (the WebMCP contract). No-op and SSR-safe off-WebMCP.
- **smrt-web** — `createDefinitionFetchers.list` now serializes
  `limit/offset/orderBy/where` into the REST query string (`buildListQuery`),
  matching `handleList`'s contract; the collection runtime's argument-free
  `list()` is unchanged.

## Security

Rides the existing generated REST guards — auth, tenant gate (#1554), writable +
sensitive-field policy (#1540). Tools run as the page's user; nothing
re-implemented.

## Review-cycle

Addressed every finding from the codex + Copilot auto-reviewers:
- **list args were dropped** on the default fetcher path → `buildListQuery`
  serializes them (incl. `where` flattened to `field[op]=value`). *(fcaa1fefc)*
- **tool removal must use AbortSignal**, not a returned handle → one
  `AbortController` per registration; disposer aborts. *(e80077535)*
- **`get` must accept `id` OR `slug`** → shared schema drops `required:['id']`;
  dispatch falls back to slug. *(e80077535)*

## Tests / checks

- core **52** (tool-schema 14, web-collections 31 incl. the #1764 hash tests +
  the descriptors-out-of-digest guard, web-module 7 incl. an end-to-end assertion
  that the emitted `\0smrt:web` module carries `toolDescriptors`).
- smrt-web **143** (registrar register/dispatch/AbortSignal-dispose/filter,
  get-by-slug, off-WebMCP no-op; `buildListQuery` serialization + a
  default-fetcher integration path).
- Full monorepo **build 55/55**, incl. the smrt-web engine-boundary guard passing
  with the new type — no `@tanstack/*` leak.

## Follow-ups (tracked in #1812, out of scope here)

- Switch `mcp.ts` to call the shared `tool-schema` helper (behavior-preserving;
  it inherits the relaxed `get` schema).
- Wire custom-action tools to their bespoke REST routes (currently a clear
  not-wired payload).
- Move the registrar to a dedicated `./webmcp` subpath export for hard
  code-split.
