### PR TITLE
feat(users,types): opt-in hierarchical membership-role inheritance in PermissionResolver (#1866)

### DIFF
--- a/packages/types/src/identity.ts
+++ b/packages/types/src/identity.ts
@@ -70,6 +70,12 @@ export interface Role extends SmrtEntityFields {
   name: string;
   description: string;
   isSystem: boolean;
+  /**
+   * Opt-in hierarchical inheritance: when `true`, an ACTIVE membership holding
+   * this role also resolves permissions in descendant tenants where the user
+   * has no direct membership. Default `false` (authority is exact-tenant only).
+   */
+  inheritsToDescendants: boolean;
 }
 
 /** User↔Tenant↔Role junction. Runtime class: `@happyvertical/smrt-users:Membership`. */

--- a/packages/users/AGENTS.md
+++ b/packages/users/AGENTS.md
@@ -73,8 +73,10 @@ membership GRANT/DENY overrides travel with the ancestor membership used.
 when inheritance was used (`null` for direct resolution).
 
 Safety: resolution is bounded by `MAX_TENANT_HIERARCHY_DEPTH`; malformed
-`hierarchyPath` values (too deep, self-referential, duplicate ancestors) fail
-closed to the empty set. Tenant `status` is not consulted (parity with direct
+`hierarchyPath` values fail closed to the empty set — too deep,
+self-referential, duplicate ancestors, or inconsistent with the actual
+`parentTenantId` chain (the path is verified link-by-link against the loaded
+ancestor rows before it is trusted as an authorization source). Tenant `status` is not consulted (parity with direct
 resolution). Caching: a long-lived `(user, tenant)` permission cache must also
 invalidate on ancestor-membership changes and on `Role.inheritsToDescendants`
 flips — request-scoped caches (the common pattern) are unaffected.

--- a/packages/users/AGENTS.md
+++ b/packages/users/AGENTS.md
@@ -11,7 +11,7 @@ Multi-tenant user management with RBAC, hierarchical tenants, session handling, 
 | Tenant | **STI** + hierarchical parent-child. `hierarchyPath` (materialized path), `hierarchyLevel`. Max depth 10. |
 | Session | Server-side. Secure UUID. TTL in **seconds** (not ms). Status auto-updates to EXPIRED on access. |
 | MagicLinkToken | Single-use email login token. Backed by `MagicLinkService`. |
-| Role | `tenantId = null` → system role (available to all tenants). `isSystem: true` blocks deletion. |
+| Role | `tenantId = null` → system role (available to all tenants). `isSystem: true` blocks deletion. `inheritsToDescendants: true` (default false) opts the role's membership authority into descendant tenants. |
 | Permission | Slug format: `resource.action`. Parsed by PermissionResolver. |
 | Membership | User + Tenant + Role junction. UNIQUE(userId, tenantId). |
 | Group | Team within a tenant. Multiple roles via GroupRole. |
@@ -44,6 +44,46 @@ The hard block reflects the tenant cascade's **net** resolution, not an
 unconditional union of every DENY in the chain — so a more-specific tenant GRANT
 (e.g. a child sub-tenant re-granting a permission its parent DENYs) still wins.
 
+### Membership selection — hierarchical inheritance (opt-in, #1866)
+
+Which membership feeds step 2 above:
+
+1. **A direct membership row in the target tenant always pins resolution to
+   itself** — active rows resolve normally; an inactive (pending/suspended)
+   row resolves to the **empty set**. A direct row therefore *attenuates*
+   rather than unions: "viewer here, despite being network admin" gives
+   viewer, and a suspension in the child is effective even for users holding
+   inheritable authority on an ancestor.
+2. **No direct row** → the resolver walks the tenant's ancestors (nearest
+   first, from `hierarchyPath`) and resolves through the **nearest ACTIVE
+   ancestor membership whose role has `inheritsToDescendants: true`**.
+   Unflagged or inactive ancestor memberships are skipped (they neither confer
+   nor block); there is **no union across the chain** — the nearest flagged
+   membership alone is used. To attenuate a specific descendant, create a
+   direct membership there or use a tenant-level DENY.
+3. **No qualifying ancestor** → empty set (byte-identical to the
+   pre-inheritance resolver; with no role flagged, nothing changes).
+
+All later layers run unchanged against the **target** tenant: the tenant
+cascade and tenant-DENY hard block come from the target tenant (a child can
+carve authority out of an inherited role), group roles stay exact-tenant (only
+target-tenant groups contribute; ancestor groups never flow down), and
+membership GRANT/DENY overrides travel with the ancestor membership used.
+`PermissionResolutionResult.inheritedFromTenantId` reports the ancestor tenant
+when inheritance was used (`null` for direct resolution).
+
+Safety: resolution is bounded by `MAX_TENANT_HIERARCHY_DEPTH`; malformed
+`hierarchyPath` values (too deep, self-referential, duplicate ancestors) fail
+closed to the empty set. Tenant `status` is not consulted (parity with direct
+resolution). Caching: a long-lived `(user, tenant)` permission cache must also
+invalidate on ancestor-membership changes and on `Role.inheritsToDescendants`
+flips — request-scoped caches (the common pattern) are unaffected.
+
+Flag roles at seed time with
+`seedSystemRoles({ inheritsToDescendants: ['owner', 'admin'] })` (additive:
+listed slugs are flagged, omitted slugs are never unflagged; unknown slugs
+throw). The default seed leaves every role exact-tenant.
+
 ## Operation Permission Guards
 
 - Use `assertOperationPermission()` for hand-written mutations in SvelteKit form
@@ -54,9 +94,25 @@ unconditional union of every DENY in the chain — so a more-specific tenant GRA
 - `assertOperationPermission()` throws fail-closed by default. Use
   `{ onDeny: 'return' }`, `checkOperationPermission()`, or
   `hasOperationPermission()` when a structured/boolean result is needed.
+- **Resource-tenant calling convention**: for resource-anchored authorization,
+  pass the **resource's** tenant id — `tenantId: resourceTenantId` — not the
+  session's current tenant. With `Role.inheritsToDescendants` flagged, a
+  root-tenant admin then passes for any descendant resource with no app-side
+  authority logic (and no membership fan-out), while per-child delegation and
+  DENY precedence keep working. Do NOT pass a session-scoped `membership`
+  alongside a different resource `tenantId` — a membership/tenant mismatch
+  fails closed by design; omit `membership` and let the resolver look it up.
 - System context and super-admin bypass context are honored for parity with
   Postgres RLS. Pass `{ allowSuperAdminBypass: false }` on money-class or
   separation-of-duties operations that must require an explicit permission grant.
+- **Postgres RLS and membership inheritance**: RLS policies check the
+  session-injected `smrt.permissions` list (resolved app-side by
+  `PermissionResolver`), so a session whose `smrt.tenant_id` IS the child
+  tenant gets inherited authority in RLS automatically. But RLS row filtering
+  stays bound to the session's tenant setting — a root-tenant session acting
+  on child-tenant rows is authorized by the app-level guard (resource-tenant
+  convention above), not by RLS. This is a documented divergence, mirroring
+  how #1829 handled bypass parity.
 - Seed role mappings with `RolePermissionCollection.seedRolePermissions()` or
   `RoleCollection.seedSystemRoles({ seedPermissions: true })`. The default
   matrix maps owner/admin to all catalog permissions, member to read/create for
@@ -74,6 +130,11 @@ unconditional union of every DENY in the chain — so a more-specific tenant GRA
 - `moveToParent()` updates tenant + ALL descendants' paths/levels
 - `cascadePermissions` (parent pushes down) + `inheritPermissions` (child accepts) — both must be true
 - `getTree(rootId?)` returns nested structure for UI
+- Two independent downward flows: the `TenantPermissionOverride` **cascade**
+  (tenant-level permission config, flags above) and **membership-role
+  inheritance** (`Role.inheritsToDescendants`, per-role opt-in — see
+  "Membership selection" above). The cascade flags do not gate membership
+  inheritance.
 
 ## SvelteKit Integration
 

--- a/packages/users/src/__tests__/operation-permission.test.ts
+++ b/packages/users/src/__tests__/operation-permission.test.ts
@@ -215,6 +215,122 @@ describe('operation permission guards', () => {
     });
   });
 
+  it('resolves opt-in ancestor authority when guarding with the resource tenant id (#1866)', async () => {
+    await syncPermissionCatalog(options);
+
+    const root = await tenants.create({ name: `Network ${randomUUID()}` });
+    await root.save();
+    const child = await tenants.createChild(root.id!, {
+      name: `Publication ${randomUUID()}`,
+    });
+
+    const permission = await permissions.findBySlug(
+      'operation_permission_records.update',
+    );
+    if (!permission?.id) {
+      throw new Error('Expected synced operation permission.');
+    }
+
+    const flaggedAdminRole = await roles.create({
+      name: `Network Admin ${randomUUID()}`,
+      inheritsToDescendants: true,
+    });
+    await flaggedAdminRole.save();
+    await rolePermissions.addPermission(flaggedAdminRole.id!, permission.id);
+
+    // The unflagged role holds the SAME permission: possession at the root is
+    // not enough, the role itself must opt in to descendant inheritance.
+    const unflaggedMemberRole = await roles.create({
+      name: `Member ${randomUUID()}`,
+    });
+    await unflaggedMemberRole.save();
+    await rolePermissions.addPermission(unflaggedMemberRole.id!, permission.id);
+
+    const rootAdmin = await users.create({
+      email: `root-admin-${randomUUID()}@example.com`,
+    });
+    await rootAdmin.save();
+    await (
+      await memberships.create({
+        roleId: flaggedAdminRole.id,
+        tenantId: root.id,
+        userId: rootAdmin.id,
+      })
+    ).save();
+
+    const rootMember = await users.create({
+      email: `root-member-${randomUUID()}@example.com`,
+    });
+    await rootMember.save();
+    await (
+      await memberships.create({
+        roleId: unflaggedMemberRole.id,
+        tenantId: root.id,
+        userId: rootMember.id,
+      })
+    ).save();
+
+    const unrelatedRoot = await tenants.create({
+      name: `Unrelated Network ${randomUUID()}`,
+    });
+    await unrelatedRoot.save();
+    const unrelatedAdmin = await users.create({
+      email: `unrelated-admin-${randomUUID()}@example.com`,
+    });
+    await unrelatedAdmin.save();
+    await (
+      await memberships.create({
+        roleId: flaggedAdminRole.id,
+        tenantId: unrelatedRoot.id,
+        userId: unrelatedAdmin.id,
+      })
+    ).save();
+
+    // Flagged root admin passes for a child resource tenant even with the
+    // super-admin bypass suppressed — authority follows the hierarchy.
+    const adminDecision = await assertOperationPermission({
+      ...options,
+      action: 'update',
+      allowSuperAdminBypass: false,
+      collection: 'operation_permission_records',
+      tenantId: child.id,
+      userId: rootAdmin.id,
+    });
+    expect(adminDecision).toMatchObject({
+      allowed: true,
+      permission: 'operation_permission_records.update',
+      reason: 'permission_granted',
+    });
+
+    const memberDecision = await assertOperationPermission({
+      ...options,
+      action: 'update',
+      allowSuperAdminBypass: false,
+      collection: 'operation_permission_records',
+      onDeny: 'return',
+      tenantId: child.id,
+      userId: rootMember.id,
+    });
+    expect(memberDecision).toMatchObject({
+      allowed: false,
+      reason: 'permission_denied',
+    });
+
+    const unrelatedDecision = await assertOperationPermission({
+      ...options,
+      action: 'update',
+      allowSuperAdminBypass: false,
+      collection: 'operation_permission_records',
+      onDeny: 'return',
+      tenantId: child.id,
+      userId: unrelatedAdmin.id,
+    });
+    expect(unrelatedDecision).toMatchObject({
+      allowed: false,
+      reason: 'permission_denied',
+    });
+  });
+
   it('returns a structured deny for unknown catalog operations', async () => {
     const actor = await createActor(['operation_permission_records.update']);
 

--- a/packages/users/src/__tests__/permission-resolver.test.ts
+++ b/packages/users/src/__tests__/permission-resolver.test.ts
@@ -1671,4 +1671,33 @@ describe('PermissionResolver hierarchical membership inheritance (#1866)', () =>
     result = await resolver.resolvePermissions(user.id!, child.id!);
     expect(result.permissions.has('articles.update')).toBe(true);
   });
+
+  it('fails closed when hierarchyPath disagrees with the actual parent chain', async () => {
+    const { root, child } = await createTenantChain();
+
+    // The user's flagged authority lives on an UNRELATED tenant...
+    const unrelated = await tenants.create({ name: 'Unrelated Network' });
+    await unrelated.save();
+    const adminRole = await createRoleGranting(
+      'Unrelated Admin',
+      ['articles.update'],
+      { inheritsToDescendants: true },
+    );
+    const { user } = await createMember(
+      unrelated.id!,
+      adminRole.id!,
+      'stale-path@example.com',
+    );
+
+    // ...and a stale materialized path on the child claims that tenant as an
+    // ancestor while parentTenantId still points at the real root. The path
+    // passes the structural guards (short, no dupes, not self-referential)
+    // but must not be trusted as an authorization source.
+    child.hierarchyPath = unrelated.id!;
+    await child.save();
+
+    const result = await resolver.resolvePermissions(user.id!, child.id!);
+    expect(result.permissions.size).toBe(0);
+    expect(result.inheritedFromTenantId).toBeNull();
+  });
 });

--- a/packages/users/src/__tests__/permission-resolver.test.ts
+++ b/packages/users/src/__tests__/permission-resolver.test.ts
@@ -25,7 +25,7 @@ import { TenantCollection } from '../collections/TenantCollection.js';
 import { TenantPermissionOverrideCollection } from '../collections/TenantPermissionOverrideCollection.js';
 import { UserCollection } from '../collections/UserCollection.js';
 import { PermissionResolver } from '../services/PermissionResolver.js';
-import { UserStatus } from '../types/index.js';
+import { MembershipStatus, UserStatus } from '../types/index.js';
 
 describe('User', () => {
   let dbPath: string;
@@ -191,6 +191,45 @@ describe('Role and Permission', () => {
     const owner = await roles.findBySlug('owner');
     expect(owner).toBeDefined();
     expect(owner?.isSystem).toBe(true);
+  });
+
+  it('seeds roles as exact-tenant only unless inheritsToDescendants opts them in', async () => {
+    // Default: no role inherits down the tenant hierarchy.
+    await roles.seedSystemRoles();
+    for (const slug of ['owner', 'admin', 'member', 'viewer']) {
+      const role = await roles.findBySlug(slug);
+      expect(role?.inheritsToDescendants).toBe(false);
+    }
+
+    // Re-seeding with the opt-in list flags existing roles additively.
+    await roles.seedSystemRoles({ inheritsToDescendants: ['owner', 'admin'] });
+    expect((await roles.findBySlug('owner'))?.inheritsToDescendants).toBe(true);
+    expect((await roles.findBySlug('admin'))?.inheritsToDescendants).toBe(true);
+    expect((await roles.findBySlug('member'))?.inheritsToDescendants).toBe(
+      false,
+    );
+    expect((await roles.findBySlug('viewer'))?.inheritsToDescendants).toBe(
+      false,
+    );
+
+    // Omitting a previously flagged slug never unsets it (additive-only).
+    await roles.seedSystemRoles({ inheritsToDescendants: [] });
+    expect((await roles.findBySlug('owner'))?.inheritsToDescendants).toBe(true);
+    expect((await roles.findBySlug('admin'))?.inheritsToDescendants).toBe(true);
+  });
+
+  it('seeds fresh roles with the inheritsToDescendants flag applied', async () => {
+    await roles.seedSystemRoles({ inheritsToDescendants: ['owner'] });
+    expect((await roles.findBySlug('owner'))?.inheritsToDescendants).toBe(true);
+    expect((await roles.findBySlug('admin'))?.inheritsToDescendants).toBe(
+      false,
+    );
+  });
+
+  it('rejects unknown slugs in inheritsToDescendants', async () => {
+    await expect(
+      roles.seedSystemRoles({ inheritsToDescendants: ['amdin'] }),
+    ).rejects.toThrow(/Unknown system role slug 'amdin'/);
   });
 
   it('should assign permission to role', async () => {
@@ -1197,5 +1236,439 @@ describe('PermissionResolver', () => {
         'another',
       ]),
     ).toBe(false);
+  });
+});
+
+describe('PermissionResolver hierarchical membership inheritance (#1866)', () => {
+  let dbPath: string;
+  let users: UserCollection;
+  let tenants: TenantCollection;
+  let roles: RoleCollection;
+  let permissions: PermissionCollection;
+  let memberships: MembershipCollection;
+  let rolePermissions: RolePermissionCollection;
+  let groups: GroupCollection;
+  let groupMembers: GroupMemberCollection;
+  let groupRoles: GroupRoleCollection;
+  let membershipOverrides: MembershipOverrideCollection;
+  let tenantOverrides: TenantPermissionOverrideCollection;
+  let resolver: PermissionResolver;
+
+  beforeEach(async () => {
+    dbPath = join(
+      tmpdir(),
+      `smrt-inherit-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+    );
+    const options = { db: { type: 'sqlite' as const, url: dbPath } };
+
+    users = await UserCollection.create(options);
+    tenants = await TenantCollection.create(options);
+    roles = await RoleCollection.create(options);
+    permissions = await PermissionCollection.create(options);
+    memberships = await MembershipCollection.create(options);
+    rolePermissions = await RolePermissionCollection.create(options);
+    groups = await GroupCollection.create(options);
+    groupMembers = await GroupMemberCollection.create(options);
+    groupRoles = await GroupRoleCollection.create(options);
+    membershipOverrides = await MembershipOverrideCollection.create(options);
+    tenantOverrides = await TenantPermissionOverrideCollection.create(options);
+    resolver = await PermissionResolver.create(options);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (existsSync(dbPath)) {
+      try {
+        rmSync(dbPath, { force: true });
+      } catch (err) {
+        console.warn(`Test cleanup warning: failed to remove ${dbPath}:`, err);
+      }
+    }
+  });
+
+  /** root -> child -> grandchild tenant chain. */
+  async function createTenantChain() {
+    const root = await tenants.create({ name: 'Network Root' });
+    await root.save();
+    const child = await tenants.createChild(root.id!, { name: 'Child Org' });
+    const grandchild = await tenants.createChild(child.id!, {
+      name: 'Grandchild Org',
+    });
+    return { root, child, grandchild };
+  }
+
+  /** A role granting the given permission slugs (created on the fly). */
+  async function createRoleGranting(
+    name: string,
+    slugs: string[],
+    roleOptions: { inheritsToDescendants?: boolean } = {},
+  ) {
+    const role = await roles.create({
+      name,
+      inheritsToDescendants: roleOptions.inheritsToDescendants ?? false,
+    });
+    await role.save();
+    for (const slug of slugs) {
+      let permission = await permissions.list({ where: { slug }, limit: 1 });
+      let permissionRecord = permission[0];
+      if (!permissionRecord) {
+        permissionRecord = await permissions.create({ slug, name: slug });
+        await permissionRecord.save();
+      }
+      await rolePermissions.addPermission(role.id!, permissionRecord.id!);
+    }
+    return role;
+  }
+
+  async function createMember(tenantId: string, roleId: string, email: string) {
+    const user = await users.create({ email });
+    await user.save();
+    const membership = await memberships.create({
+      userId: user.id,
+      tenantId,
+      roleId,
+    });
+    await membership.save();
+    return { user, membership };
+  }
+
+  it('resolves a flagged root membership in a grandchild tenant (nearest-ancestor inheritance)', async () => {
+    const { root, child, grandchild } = await createTenantChain();
+    const adminRole = await createRoleGranting(
+      'Network Admin',
+      ['articles.update'],
+      { inheritsToDescendants: true },
+    );
+    const { user, membership } = await createMember(
+      root.id!,
+      adminRole.id!,
+      'network-admin@example.com',
+    );
+
+    const grandchildResult = await resolver.resolvePermissions(
+      user.id!,
+      grandchild.id!,
+    );
+    expect(grandchildResult.permissions.has('articles.update')).toBe(true);
+    expect(grandchildResult.inheritedFromTenantId).toBe(root.id);
+    expect(grandchildResult.membershipId).toBe(membership.id);
+    expect(grandchildResult.roleId).toBe(adminRole.id);
+
+    const childResult = await resolver.resolvePermissions(user.id!, child.id!);
+    expect(childResult.permissions.has('articles.update')).toBe(true);
+    expect(childResult.inheritedFromTenantId).toBe(root.id);
+
+    // hasPermission delegates to the same resolution path.
+    expect(
+      await resolver.hasPermission(user.id!, grandchild.id!, 'articles.update'),
+    ).toBe(true);
+  });
+
+  it('does not inherit when the ancestor role is unflagged (regression: exact-tenant only)', async () => {
+    const { root, grandchild } = await createTenantChain();
+    const unflaggedAdmin = await createRoleGranting(
+      'Unflagged Admin',
+      ['articles.update'],
+      { inheritsToDescendants: false },
+    );
+    const { user } = await createMember(
+      root.id!,
+      unflaggedAdmin.id!,
+      'plain-admin@example.com',
+    );
+
+    const result = await resolver.resolvePermissions(user.id!, grandchild.id!);
+    expect(result.permissions.size).toBe(0);
+    expect(result.membershipId).toBeNull();
+    expect(result.inheritedFromTenantId).toBeNull();
+  });
+
+  it('resolves empty for a user with no memberships anywhere', async () => {
+    const { grandchild } = await createTenantChain();
+    const user = await users.create({ email: 'nobody@example.com' });
+    await user.save();
+
+    const result = await resolver.resolvePermissions(user.id!, grandchild.id!);
+    expect(result.permissions.size).toBe(0);
+    expect(result.inheritedFromTenantId).toBeNull();
+  });
+
+  it('child tenant-level DENY subtracts an inherited role grant', async () => {
+    const { root, child } = await createTenantChain();
+    const adminRole = await createRoleGranting(
+      'Network Admin',
+      ['articles.update', 'articles.delete'],
+      { inheritsToDescendants: true },
+    );
+    const { user } = await createMember(
+      root.id!,
+      adminRole.id!,
+      'denied-in-child@example.com',
+    );
+
+    const deletePerm = (
+      await permissions.list({ where: { slug: 'articles.delete' }, limit: 1 })
+    )[0];
+    await tenantOverrides.denyPermission(child.id!, deletePerm.id!);
+
+    const result = await resolver.resolvePermissions(user.id!, child.id!);
+    expect(result.permissions.has('articles.update')).toBe(true);
+    expect(result.permissions.has('articles.delete')).toBe(false);
+    expect(result.inheritedFromTenantId).toBe(root.id);
+  });
+
+  it('membership DENY override on the ancestor membership stays absolute', async () => {
+    const { root, child } = await createTenantChain();
+    const adminRole = await createRoleGranting(
+      'Network Admin',
+      ['articles.update'],
+      { inheritsToDescendants: true },
+    );
+    const { user, membership } = await createMember(
+      root.id!,
+      adminRole.id!,
+      'override-deny@example.com',
+    );
+
+    const updatePerm = (
+      await permissions.list({ where: { slug: 'articles.update' }, limit: 1 })
+    )[0];
+    await membershipOverrides.denyPermission(membership.id!, updatePerm.id!);
+
+    const result = await resolver.resolvePermissions(user.id!, child.id!);
+    expect(result.permissions.has('articles.update')).toBe(false);
+    expect(result.deniedPermissionIds).toContain(updatePerm.id);
+  });
+
+  it('membership GRANT override travels with the ancestor membership', async () => {
+    const { root, child } = await createTenantChain();
+    const adminRole = await createRoleGranting('Network Admin', [], {
+      inheritsToDescendants: true,
+    });
+    const { user, membership } = await createMember(
+      root.id!,
+      adminRole.id!,
+      'override-grant@example.com',
+    );
+
+    const extraPerm = await permissions.create({
+      slug: 'special.grant',
+      name: 'Special Grant',
+    });
+    await extraPerm.save();
+    await membershipOverrides.grantPermission(membership.id!, extraPerm.id!);
+
+    const result = await resolver.resolvePermissions(user.id!, child.id!);
+    expect(result.permissions.has('special.grant')).toBe(true);
+    expect(result.inheritedFromTenantId).toBe(root.id);
+  });
+
+  it('a direct membership in the child attenuates: the lesser direct role wins over inheritance', async () => {
+    const { root, child } = await createTenantChain();
+    const adminRole = await createRoleGranting(
+      'Network Admin',
+      ['articles.update', 'articles.delete'],
+      { inheritsToDescendants: true },
+    );
+    const viewerRole = await createRoleGranting('Viewer', ['articles.read']);
+
+    const { user } = await createMember(
+      root.id!,
+      adminRole.id!,
+      'attenuated@example.com',
+    );
+    const childMembership = await memberships.create({
+      userId: user.id,
+      tenantId: child.id,
+      roleId: viewerRole.id,
+    });
+    await childMembership.save();
+
+    const result = await resolver.resolvePermissions(user.id!, child.id!);
+    expect(result.permissions.has('articles.read')).toBe(true);
+    expect(result.permissions.has('articles.update')).toBe(false);
+    expect(result.permissions.has('articles.delete')).toBe(false);
+    expect(result.membershipId).toBe(childMembership.id);
+    expect(result.inheritedFromTenantId).toBeNull();
+  });
+
+  it('an inactive direct membership pins resolution to the empty set (no inheritance bypass)', async () => {
+    const { root, child } = await createTenantChain();
+    const adminRole = await createRoleGranting(
+      'Network Admin',
+      ['articles.update'],
+      { inheritsToDescendants: true },
+    );
+    const { user } = await createMember(
+      root.id!,
+      adminRole.id!,
+      'suspended-in-child@example.com',
+    );
+
+    const suspended = await memberships.create({
+      userId: user.id,
+      tenantId: child.id,
+      roleId: adminRole.id,
+      status: MembershipStatus.INACTIVE,
+    });
+    await suspended.save();
+
+    const result = await resolver.resolvePermissions(user.id!, child.id!);
+    expect(result.permissions.size).toBe(0);
+    expect(result.membershipId).toBeNull();
+    expect(result.inheritedFromTenantId).toBeNull();
+  });
+
+  it('skips an active unflagged intermediate membership and resolves through a higher flagged one', async () => {
+    const { root, child, grandchild } = await createTenantChain();
+    const adminRole = await createRoleGranting(
+      'Network Admin',
+      ['articles.update'],
+      { inheritsToDescendants: true },
+    );
+    const memberRole = await createRoleGranting('Member', ['articles.read']);
+
+    const { user } = await createMember(
+      root.id!,
+      adminRole.id!,
+      'skip-mid@example.com',
+    );
+    const midMembership = await memberships.create({
+      userId: user.id,
+      tenantId: child.id,
+      roleId: memberRole.id,
+    });
+    await midMembership.save();
+
+    const result = await resolver.resolvePermissions(user.id!, grandchild.id!);
+    expect(result.permissions.has('articles.update')).toBe(true);
+    // Only the flagged ancestor role resolves; the unflagged mid role's grants
+    // do not union in.
+    expect(result.permissions.has('articles.read')).toBe(false);
+    expect(result.inheritedFromTenantId).toBe(root.id);
+  });
+
+  it('the nearest flagged ancestor membership wins (no union across the chain)', async () => {
+    const { root, child, grandchild } = await createTenantChain();
+    const adminRole = await createRoleGranting(
+      'Network Admin',
+      ['articles.delete'],
+      { inheritsToDescendants: true },
+    );
+    const editorRole = await createRoleGranting(
+      'Regional Editor',
+      ['articles.update'],
+      { inheritsToDescendants: true },
+    );
+
+    const { user } = await createMember(
+      root.id!,
+      adminRole.id!,
+      'nearest-wins@example.com',
+    );
+    const childMembership = await memberships.create({
+      userId: user.id,
+      tenantId: child.id,
+      roleId: editorRole.id,
+    });
+    await childMembership.save();
+
+    const result = await resolver.resolvePermissions(user.id!, grandchild.id!);
+    expect(result.permissions.has('articles.update')).toBe(true);
+    expect(result.permissions.has('articles.delete')).toBe(false);
+    expect(result.inheritedFromTenantId).toBe(child.id);
+    expect(result.membershipId).toBe(childMembership.id);
+  });
+
+  it('target-tenant group roles still contribute when resolution is inherited', async () => {
+    const { root, child } = await createTenantChain();
+    const adminRole = await createRoleGranting(
+      'Network Admin',
+      ['articles.update'],
+      { inheritsToDescendants: true },
+    );
+    const groupRole = await createRoleGranting('Child Group Role', [
+      'special.child-access',
+    ]);
+    const { user } = await createMember(
+      root.id!,
+      adminRole.id!,
+      'group-in-child@example.com',
+    );
+
+    const group = await groups.create({
+      tenantId: child.id,
+      name: 'Child Special Group',
+    });
+    await group.save();
+    await groupRoles.addRole(group.id!, groupRole.id!);
+    await groupMembers.addMember(group.id!, user.id!);
+
+    const result = await resolver.resolvePermissions(user.id!, child.id!);
+    expect(result.permissions.has('articles.update')).toBe(true);
+    expect(result.permissions.has('special.child-access')).toBe(true);
+    expect(result.groupIds).toContain(group.id);
+  });
+
+  it('honors an explicit `membership: null` option by applying inheritance', async () => {
+    const { root, child } = await createTenantChain();
+    const adminRole = await createRoleGranting(
+      'Network Admin',
+      ['articles.update'],
+      { inheritsToDescendants: true },
+    );
+    const { user } = await createMember(
+      root.id!,
+      adminRole.id!,
+      'null-membership-option@example.com',
+    );
+
+    const result = await resolver.resolvePermissions(user.id!, child.id!, {
+      membership: null,
+    });
+    expect(result.permissions.has('articles.update')).toBe(true);
+    expect(result.inheritedFromTenantId).toBe(root.id);
+  });
+
+  it('fails closed on malformed hierarchy paths', async () => {
+    const { root, child } = await createTenantChain();
+    const adminRole = await createRoleGranting(
+      'Network Admin',
+      ['articles.update'],
+      { inheritsToDescendants: true },
+    );
+    const { user } = await createMember(
+      root.id!,
+      adminRole.id!,
+      'malformed-path@example.com',
+    );
+
+    // Self-referential path: the tenant appears in its own ancestor chain.
+    child.hierarchyPath = `${root.id}/${child.id}`;
+    await child.save();
+    let result = await resolver.resolvePermissions(user.id!, child.id!);
+    expect(result.permissions.size).toBe(0);
+
+    // Duplicate ancestor ids.
+    child.hierarchyPath = `${root.id}/${root.id}`;
+    await child.save();
+    result = await resolver.resolvePermissions(user.id!, child.id!);
+    expect(result.permissions.size).toBe(0);
+
+    // Deeper than MAX_TENANT_HIERARCHY_DEPTH.
+    const fakeAncestors = Array.from(
+      { length: 10 },
+      (_, index) => `fake-ancestor-${index}`,
+    );
+    child.hierarchyPath = [root.id, ...fakeAncestors].join('/');
+    await child.save();
+    result = await resolver.resolvePermissions(user.id!, child.id!);
+    expect(result.permissions.size).toBe(0);
+
+    // Sanity: restoring the real path restores inheritance.
+    child.hierarchyPath = root.id!;
+    await child.save();
+    result = await resolver.resolvePermissions(user.id!, child.id!);
+    expect(result.permissions.has('articles.update')).toBe(true);
   });
 });

--- a/packages/users/src/collections/RoleCollection.ts
+++ b/packages/users/src/collections/RoleCollection.ts
@@ -15,6 +15,16 @@ export interface SeedSystemRolesOptions
   extends Omit<SeedRolePermissionsOptions, 'catalog'> {
   permissionMatrix?: RolePermissionPatternMatrix;
   seedPermissions?: boolean;
+  /**
+   * System role slugs to flag `inheritsToDescendants: true` (opt-in
+   * hierarchical membership inheritance, e.g. `['owner', 'admin']` for
+   * organizational hierarchies). Additive and idempotent: listed slugs are
+   * flagged on create and on already-seeded roles, but omitting a slug never
+   * unsets a previously flagged role — unflag explicitly via a role update.
+   * Unknown slugs throw (a typo here would silently withhold intended
+   * authority). Default: no role inherits.
+   */
+  inheritsToDescendants?: string[];
 }
 
 /**
@@ -84,10 +94,28 @@ export class RoleCollection extends SmrtCollection<Role> {
   async seedSystemRoles(options: SeedSystemRolesOptions = {}): Promise<Role[]> {
     const roles: Role[] = [];
 
+    const inheritableSlugs = new Set(options.inheritsToDescendants ?? []);
+    const knownSlugs = new Set<string>(DEFAULT_ROLES.map((def) => def.slug));
+    for (const slug of inheritableSlugs) {
+      if (!knownSlugs.has(slug)) {
+        throw new Error(
+          `Unknown system role slug '${slug}' in inheritsToDescendants. ` +
+            `Valid slugs: ${[...knownSlugs].join(', ')}.`,
+        );
+      }
+    }
+
     for (const roleDef of DEFAULT_ROLES) {
+      const inheritable = inheritableSlugs.has(roleDef.slug);
+
       // Check if role already exists
       const existing = await this.findBySlug(roleDef.slug);
       if (existing) {
+        // Additive-only convergence: flag a listed slug, never unset one.
+        if (inheritable && !existing.inheritsToDescendants) {
+          existing.inheritsToDescendants = true;
+          await existing.save();
+        }
         roles.push(existing);
         continue;
       }
@@ -99,6 +127,7 @@ export class RoleCollection extends SmrtCollection<Role> {
         description: roleDef.description,
         tenantId: null,
         isSystem: true,
+        inheritsToDescendants: inheritable,
       });
       await role.save();
       roles.push(role);

--- a/packages/users/src/models/Role.ts
+++ b/packages/users/src/models/Role.ts
@@ -19,6 +19,7 @@ export interface RoleOptions extends SmrtObjectOptions {
   name?: string;
   description?: string;
   isSystem?: boolean;
+  inheritsToDescendants?: boolean;
 }
 
 /**
@@ -76,6 +77,17 @@ export class Role extends SmrtObject implements RoleContract {
    */
   isSystem: boolean = false;
 
+  /**
+   * Opt-in hierarchical inheritance: when true, an ACTIVE membership holding
+   * this role also resolves permissions in descendant tenants where the user
+   * has no direct membership (nearest flagged ancestor membership wins).
+   *
+   * Default false: the role's authority is exact-tenant only, which is the
+   * pre-existing resolver behavior. Flag structural roles like a network-level
+   * owner/admin; leave per-tenant roles like member/viewer unflagged.
+   */
+  inheritsToDescendants: boolean = false;
+
   constructor(options: RoleOptions = {}) {
     super(options);
     if (options.tenantId !== undefined) this.tenantId = options.tenantId;
@@ -83,6 +95,8 @@ export class Role extends SmrtObject implements RoleContract {
     if (options.description !== undefined)
       this.description = options.description;
     if (options.isSystem !== undefined) this.isSystem = options.isSystem;
+    if (options.inheritsToDescendants !== undefined)
+      this.inheritsToDescendants = options.inheritsToDescendants;
   }
 
   /**

--- a/packages/users/src/services/PermissionResolver.ts
+++ b/packages/users/src/services/PermissionResolver.ts
@@ -9,11 +9,12 @@ import { GroupRoleCollection } from '../collections/GroupRoleCollection.js';
 import { MembershipCollection } from '../collections/MembershipCollection.js';
 import { MembershipOverrideCollection } from '../collections/MembershipOverrideCollection.js';
 import { PermissionCollection } from '../collections/PermissionCollection.js';
+import { RoleCollection } from '../collections/RoleCollection.js';
 import { RolePermissionCollection } from '../collections/RolePermissionCollection.js';
 import { TenantCollection } from '../collections/TenantCollection.js';
 import { TenantPermissionOverrideCollection } from '../collections/TenantPermissionOverrideCollection.js';
 import type { Membership } from '../models/Membership.js';
-import type { Tenant } from '../models/Tenant.js';
+import { MAX_TENANT_HIERARCHY_DEPTH, type Tenant } from '../models/Tenant.js';
 
 /**
  * Permission resolution result
@@ -29,13 +30,26 @@ export interface PermissionResolutionResult {
   groupIds: string[];
   /** Permission IDs explicitly denied */
   deniedPermissionIds: string[];
+  /**
+   * Ancestor tenant id the resolving membership belongs to, when resolution
+   * used opt-in hierarchical inheritance (no direct membership in the target
+   * tenant; nearest ACTIVE ancestor membership whose role has
+   * `inheritsToDescendants: true`). `null` for direct-membership resolution.
+   */
+  inheritedFromTenantId: string | null;
 }
 
 export interface PermissionResolutionOptions {
   /**
-   * Active membership already resolved by the caller for this user/tenant.
+   * Membership row already resolved by the caller for this user/tenant.
    * Passing this lets request-scoped session loaders avoid re-querying the
    * same membership row before resolving permissions.
+   *
+   * Pass the RAW lookup result: an inactive row pins resolution to the empty
+   * set (a suspended/pending direct membership stays effective), while an
+   * explicit `null` asserts "no direct membership row exists" and makes the
+   * resolver consider opt-in ancestor-membership inheritance. Leaving it
+   * `undefined` lets the resolver perform its own lookup.
    */
   membership?: Membership | null;
 }
@@ -88,6 +102,17 @@ export interface TenantPermissionInheritanceResult {
  * - GRANT: Explicitly grant at this level
  * - DENY: Explicitly block (even if parent grants)
  *
+ * ## Hierarchical Membership-Role Inheritance (opt-in)
+ *
+ * Independent of the tenant-level cascade above, membership-role authority
+ * can follow the hierarchy DOWN when a role is explicitly flagged
+ * `inheritsToDescendants: true`: a user with no direct membership in the
+ * target tenant resolves through the nearest ACTIVE ancestor membership
+ * holding such a role. A direct membership row in the target tenant always
+ * wins (including inactive rows, which resolve empty), child tenant-DENY
+ * overrides still subtract from inherited grants, and with no flagged role
+ * the resolver behaves exactly as before. See `resolvePermissions`.
+ *
  * @example
  * ```typescript
  * const resolver = new PermissionResolver(options);
@@ -107,6 +132,7 @@ export interface TenantPermissionInheritanceResult {
 export class PermissionResolver {
   private options: SmrtClassOptions;
   private membershipCollection!: MembershipCollection;
+  private roleCollection!: RoleCollection;
   private rolePermissionCollection!: RolePermissionCollection;
   private membershipOverrideCollection!: MembershipOverrideCollection;
   private groupMemberCollection!: GroupMemberCollection;
@@ -127,6 +153,7 @@ export class PermissionResolver {
    */
   async initialize(): Promise<void> {
     this.membershipCollection = await MembershipCollection.create(this.options);
+    this.roleCollection = await RoleCollection.create(this.options);
     this.rolePermissionCollection = await RolePermissionCollection.create(
       this.options,
     );
@@ -343,8 +370,29 @@ export class PermissionResolver {
    *     -> membership GRANT (re-adds; most specific, can win over a tenant-DENY)
    *     -> membership DENY  (absolute; always wins)
    *
+   * ## Membership selection
+   *
+   * A direct membership row in the target tenant always pins resolution to
+   * itself: active rows resolve normally, inactive (pending/suspended) rows
+   * resolve to the empty set — an explicit direct membership is authoritative
+   * even when it attenuates or suspends a user who holds broader authority on
+   * an ancestor tenant.
+   *
+   * Only when NO direct membership row exists does the resolver consider
+   * opt-in hierarchical inheritance: it walks the tenant's ancestors (nearest
+   * first) and resolves through the nearest ACTIVE ancestor membership whose
+   * role has `inheritsToDescendants: true`. All later layers then run
+   * unchanged against the TARGET tenant — the tenant cascade and tenant-DENY
+   * block come from the target tenant (so a child tenant can still carve
+   * authority out of an inherited role), group roles remain exact-tenant
+   * (only groups the user belongs to in the target tenant contribute), and
+   * membership GRANT/DENY overrides travel with the ancestor membership used.
+   * With no role flagged `inheritsToDescendants`, resolution is identical to
+   * the pre-inheritance behavior.
+   *
    * Algorithm:
-   * 1. Get membership and collect all permission IDs from all sources
+   * 1. Get membership (direct, or nearest inheritable ancestor membership)
+   *    and collect all permission IDs from all sources
    * 2. Batch fetch all permissions in a single query
    * 3. Apply permissions from role, then groups
    * 4. Subtract tenant-level DENY'd slugs (hard tenant-wide block)
@@ -362,19 +410,34 @@ export class PermissionResolver {
       roleId: null,
       groupIds: [],
       deniedPermissionIds: [],
+      inheritedFromTenantId: null,
     };
 
     // 1. Get membership, reusing a request-scoped row when the caller already
     // resolved it for this exact user/tenant.
-    const membership =
+    let membership =
       options.membership === undefined
         ? await this.membershipCollection.findByUserAndTenant(userId, tenantId)
         : options.membership;
-    if (!membership?.isActive()) {
-      return result;
-    }
-    if (membership.userId !== userId || membership.tenantId !== tenantId) {
-      return result;
+
+    if (membership) {
+      // A direct membership row pins resolution to itself: a mismatched
+      // caller-provided row is rejected, and an inactive row resolves empty
+      // (suspension/pending in the target tenant is effective even for users
+      // holding inheritable authority on an ancestor).
+      if (membership.userId !== userId || membership.tenantId !== tenantId) {
+        return result;
+      }
+      if (!membership.isActive()) {
+        return result;
+      }
+    } else {
+      // No direct membership row: opt-in nearest-ancestor inheritance.
+      membership = await this.resolveInheritedMembership(userId, tenantId);
+      if (!membership) {
+        return result;
+      }
+      result.inheritedFromTenantId = membership.tenantId ?? null;
     }
 
     result.membershipId = membership.id ?? null;
@@ -504,6 +567,99 @@ export class PermissionResolver {
     }
 
     return result;
+  }
+
+  /**
+   * Find the membership to resolve through when the user has no direct
+   * membership row in the target tenant.
+   *
+   * Walks the target tenant's ancestor chain (from the materialized
+   * `hierarchyPath`, nearest ancestor first) and returns the nearest ACTIVE
+   * ancestor membership whose role is explicitly flagged
+   * `inheritsToDescendants: true`. Ancestor memberships that are inactive or
+   * hold an unflagged role are skipped — they neither confer nor block
+   * inheritance from higher ancestors. Attenuating a user in a specific
+   * tenant is expressed with a direct membership row there (which pins
+   * resolution) or a tenant-level DENY, not with an intermediate unflagged
+   * membership.
+   *
+   * Fails closed (returns null, resolving to the empty set) when the tenant
+   * is missing or its `hierarchyPath` is malformed: deeper than
+   * `MAX_TENANT_HIERARCHY_DEPTH`, self-referential, or containing duplicate
+   * ancestor ids.
+   */
+  private async resolveInheritedMembership(
+    userId: string,
+    tenantId: string,
+  ): Promise<Membership | null> {
+    const tenant = await this.tenantCollection.get({ id: tenantId });
+    if (!tenant?.id) {
+      return null;
+    }
+
+    // Ordered root -> immediate parent, per the materialized path.
+    const ancestorIds = tenant.getAncestorIds();
+    if (ancestorIds.length === 0) {
+      return null;
+    }
+
+    // Malformed hierarchy paths fail closed: a well-formed path is bounded by
+    // MAX_TENANT_HIERARCHY_DEPTH (at most MAX-1 ancestors), never contains the
+    // tenant itself, and never repeats an ancestor.
+    if (
+      ancestorIds.length >= MAX_TENANT_HIERARCHY_DEPTH ||
+      ancestorIds.includes(tenant.id) ||
+      new Set(ancestorIds).size !== ancestorIds.length
+    ) {
+      return null;
+    }
+
+    // One query for the user's ACTIVE memberships, intersected with the
+    // ancestor chain. UNIQUE(userId, tenantId) guarantees at most one row per
+    // ancestor.
+    const activeMemberships =
+      await this.membershipCollection.findActiveByUser(userId);
+    if (activeMemberships.length === 0) {
+      return null;
+    }
+    const membershipByTenantId = new Map<string, Membership>();
+    for (const row of activeMemberships) {
+      if (row.tenantId && row.userId === userId) {
+        membershipByTenantId.set(row.tenantId, row);
+      }
+    }
+
+    // Candidates ordered nearest ancestor first.
+    const candidates: Membership[] = [];
+    for (let i = ancestorIds.length - 1; i >= 0; i--) {
+      const candidate = membershipByTenantId.get(ancestorIds[i]);
+      if (candidate?.roleId) {
+        candidates.push(candidate);
+      }
+    }
+    if (candidates.length === 0) {
+      return null;
+    }
+
+    // Batch load candidate roles; only an explicit `inheritsToDescendants:
+    // true` role confers inheritance, and the nearest such membership wins.
+    const roleIds = [
+      ...new Set(candidates.map((candidate) => candidate.roleId as string)),
+    ];
+    const roles = await this.roleCollection.listByIds(roleIds);
+    const inheritableRoleIds = new Set<string>();
+    for (const role of roles) {
+      if (role.id && role.inheritsToDescendants === true) {
+        inheritableRoleIds.add(role.id);
+      }
+    }
+
+    for (const candidate of candidates) {
+      if (candidate.roleId && inheritableRoleIds.has(candidate.roleId)) {
+        return candidate;
+      }
+    }
+    return null;
   }
 
   /**

--- a/packages/users/src/services/PermissionResolver.ts
+++ b/packages/users/src/services/PermissionResolver.ts
@@ -585,8 +585,9 @@ export class PermissionResolver {
    *
    * Fails closed (returns null, resolving to the empty set) when the tenant
    * is missing or its `hierarchyPath` is malformed: deeper than
-   * `MAX_TENANT_HIERARCHY_DEPTH`, self-referential, or containing duplicate
-   * ancestor ids.
+   * `MAX_TENANT_HIERARCHY_DEPTH`, self-referential, containing duplicate
+   * ancestor ids, or inconsistent with the actual `parentTenantId` chain
+   * (e.g. a stale path naming an unrelated tenant).
    */
   private async resolveInheritedMembership(
     userId: string,
@@ -611,6 +612,30 @@ export class PermissionResolver {
       ancestorIds.includes(tenant.id) ||
       new Set(ancestorIds).size !== ancestorIds.length
     ) {
+      return null;
+    }
+
+    // The materialized path is an authorization source here, so verify it
+    // against the actual parent chain before trusting it: batch-load the
+    // ancestors and require an unbroken parentTenantId link
+    // root -> ... -> immediate parent -> target. A stale or inconsistent path
+    // (e.g. naming a tenant that is not really an ancestor) fails closed.
+    const ancestors = await this.tenantCollection.listByIds(ancestorIds);
+    const ancestorsById = new Map(
+      ancestors.map((ancestor) => [ancestor.id, ancestor]),
+    );
+    let expectedParentId: string | null = null;
+    for (const ancestorId of ancestorIds) {
+      const ancestor = ancestorsById.get(ancestorId);
+      if (!ancestor?.id) {
+        return null;
+      }
+      if ((ancestor.parentTenantId ?? null) !== expectedParentId) {
+        return null;
+      }
+      expectedParentId = ancestor.id;
+    }
+    if ((tenant.parentTenantId ?? null) !== expectedParentId) {
       return null;
     }
 

--- a/packages/users/src/services/SessionService.ts
+++ b/packages/users/src/services/SessionService.ts
@@ -168,10 +168,13 @@ export class SessionService {
         );
       membership = resolvedMembership?.isActive() ? resolvedMembership : null;
 
+      // Pass the RAW row: an inactive direct membership pins resolution to
+      // the empty set, while a missing row (null) lets the resolver apply
+      // opt-in ancestor-membership inheritance (`Role.inheritsToDescendants`).
       const result = await this.permissionResolver.resolvePermissions(
         session.userId,
         session.tenantId,
-        { membership },
+        { membership: resolvedMembership },
       );
       permissions = Array.from(result.permissions);
     }


### PR DESCRIPTION
Closes #1866.

## What

Opt-in **hierarchical membership-role inheritance** in `PermissionResolver.resolvePermissions()`: when a principal has **no direct membership row** in the target tenant, the resolver walks the tenant's ancestor chain (`hierarchyPath`, nearest first) and resolves through the nearest ACTIVE ancestor membership whose role is flagged with the new `Role.inheritsToDescendants` field (default `false`).

With no role flagged, resolution is byte-identical to today — the regression test pins this.

## Semantics (per the issue spec)

- **Direct membership always pins.** An active direct row resolves exactly as before; an **inactive** (pending/suspended) direct row resolves to the **empty set** — so per-child delegation ("viewer here, despite being network admin") *attenuates*, and a suspension in the child is effective even for a flagged root admin. Inheritance applies only when no direct row exists at all.
- **Nearest flagged ancestor wins.** No union across the chain. Unflagged or inactive ancestor memberships are skipped (they neither confer nor block a higher flagged membership — attenuating a specific subtree is done with a direct membership or tenant-DENY).
- **All later layers run against the target tenant**: the tenant cascade + tenant-DENY hard block come from the target (a child can carve authority out of an inherited role), group roles stay exact-tenant (only target-tenant groups contribute; ancestor groups never flow down), and membership GRANT/DENY overrides travel with the ancestor membership used.
- **Fail-closed hierarchy handling**: the walk is bounded by `MAX_TENANT_HIERARCHY_DEPTH`; malformed `hierarchyPath` values (too deep, self-referential, duplicate ancestors) resolve to the empty set.
- **Auditability**: new `PermissionResolutionResult.inheritedFromTenantId` reports the ancestor tenant used (`null` for direct resolution).

## Guard: no API change

`assertOperationPermission` / `checkOperationPermission` pick this up for free. The documented calling convention (AGENTS.md): pass the **resource's** tenant id (`tenantId: resourceTenantId`) for resource-anchored authorization; a flagged root admin then passes for any descendant resource with `allowSuperAdminBypass: false`, while a root *member* and an unrelated tenant's admin are denied (guard test covers all three).

## Integration details

- **`SessionService.loadSessionContext`** now passes the *raw* membership row to the resolver: inactive rows still pin to empty, truly-missing rows get inheritance in session permissions. `SessionContext.membership` stays active-only (there is genuinely no direct membership when inherited).
- **Seeding**: `seedSystemRoles({ inheritsToDescendants: ['owner', 'admin'] })` flags system roles **additively** (listed slugs are flagged on create and on existing roles; omitting a slug never unsets; unknown slugs throw — a typo would otherwise silently withhold intended authority). Default seed leaves every role exact-tenant.
- **Contract**: `Role.inheritsToDescendants` added to the `Role` interface in `@happyvertical/smrt-types` (mirrors `isSystem`; repo-wide typecheck green).
- **Postgres RLS parity** (documented divergence, mirroring #1829's bypass-parity stance): RLS checks the session-injected `smrt.permissions` list, which is resolved app-side — so a session sitting *in* the child tenant gets inherited authority in RLS automatically, while a root-tenant session acting on child rows is authorized by the app-level guard convention. Noted in AGENTS.md.
- **Caching note** (AGENTS.md): long-lived `(user, tenant)` permission caches must also invalidate on ancestor-membership changes and flag flips; request-scoped caches unaffected.

## Cost

The inheritance walk only runs on the previous hard-miss path (no direct membership → empty). It adds 1 tenant get + 1 `findActiveByUser` query + 1 batched role load; the direct-membership hot path is untouched.

## Tests (all acceptance criteria)

`packages/users/src/__tests__/permission-resolver.test.ts` (new describe, 13 tests) + `operation-permission.test.ts` (guard) + seeding tests:

- flagged root membership resolves in a grandchild; unflagged → empty (regression)
- child tenant-DENY subtracts an inherited grant; ancestor membership-DENY absolute; ancestor membership-GRANT travels
- direct child membership (lesser role) attenuates; inactive direct membership pins to empty
- unflagged intermediate membership skipped; nearest flagged wins over root flagged
- target-tenant group roles still contribute; explicit `membership: null` option applies inheritance
- malformed `hierarchyPath` (self-referential / duplicated / >MAX depth) fails closed, and restoring the path restores inheritance
- guard: flagged root admin allowed in child with `allowSuperAdminBypass: false`; root member denied; unrelated tenant's admin denied
- seeding: default all-false; additive flagging; never-unset; unknown slug throws

## Verification

- `packages/users` full suite: **291 passed | 4 skipped** (pre-existing skips)
- `packages/types` suite: 9 passed
- Repo-wide `turbo typecheck`: 107/107 green
- `pnpm knowledge:check --changed --strict`: fresh
- Biome clean on changed files

## Non-goals (unchanged, per issue)

- `TenantPermissionOverride` cascade semantics untouched
- No union-across-ancestors or downward attenuation policies beyond nearest-ancestor-wins
- No system role auto-flagged by default
- `SessionService.switchTenant` remains fail-closed on direct membership (the anytown flow keeps the session at root and guards per-resource; loosening switchTenant would be a separate decision)
