### PR TITLE
Fix runtime check nested manifest dependency resolution

### DIFF
--- a/packages/cli/src/__tests__/runtime-check.test.ts
+++ b/packages/cli/src/__tests__/runtime-check.test.ts
@@ -17,7 +17,11 @@ async function createExternalPackage(
   projectRoot: string,
   packageName: string,
   manifest: SmartObjectManifest,
-  options: { version?: string; baseDir?: string } = {},
+  options: {
+    version?: string;
+    baseDir?: string;
+    exports?: Record<string, unknown>;
+  } = {},
 ): Promise<void> {
   const packageDir = resolve(
     options.baseDir || resolve(projectRoot, 'node_modules'),
@@ -28,7 +32,7 @@ async function createExternalPackage(
     name: packageName,
     version: options.version || '0.0.0-test',
     type: 'module',
-    exports: {
+    exports: options.exports || {
       '.': './dist/index.js',
       './manifest': './dist/manifest.json',
       './manifest.json': './dist/manifest.json',
@@ -266,6 +270,119 @@ describe('runRuntimeCheck', () => {
         }),
       ]),
     );
+  });
+
+  it('warns and skips missing nested SMRT dependency manifests', async () => {
+    const projectRoot = await mkdtemp(
+      resolve(process.cwd(), '.tmp-runtime-check-'),
+    );
+    tempDirs.push(projectRoot);
+
+    await createExternalPackage(projectRoot, '@fixture/users', {
+      version: '1.0.0',
+      timestamp: Date.now(),
+      packageName: '@fixture/users',
+      smrtDependencies: ['@fixture/mobile-contract'],
+      objects: {
+        '@fixture/users:User': {
+          className: 'User',
+          qualifiedName: '@fixture/users:User',
+          packageName: '@fixture/users',
+          collection: 'users',
+          fields: {
+            email: { type: 'text', required: true },
+          },
+        },
+      },
+    });
+
+    await createProject(projectRoot, {
+      version: '1.0.0',
+      timestamp: Date.now(),
+      packageName: '@test/app',
+      smrtDependencies: ['@fixture/users'],
+      objects: {},
+    });
+    await createRegisterFile(projectRoot);
+
+    process.chdir(projectRoot);
+    const result = await runRuntimeCheck(projectRoot);
+
+    expect(
+      result.findings.some(
+        (finding) => finding.code === 'missing-dependency-manifest',
+      ),
+    ).toBe(false);
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'warning',
+          code: 'missing-nested-dependency-manifest',
+          message: expect.stringContaining('@fixture/mobile-contract'),
+        }),
+      ]),
+    );
+  });
+
+  it('loads nested import-only packages from their manifest file', async () => {
+    const projectRoot = await mkdtemp(
+      resolve(process.cwd(), '.tmp-runtime-check-'),
+    );
+    tempDirs.push(projectRoot);
+
+    await createExternalPackage(
+      projectRoot,
+      '@fixture/mobile-contract',
+      {
+        version: '1.0.0',
+        timestamp: Date.now(),
+        packageName: '@fixture/mobile-contract',
+        objects: {},
+      },
+      {
+        exports: {
+          '.': {
+            types: './dist/index.d.ts',
+            import: './dist/index.js',
+          },
+        },
+      },
+    );
+    await createExternalPackage(projectRoot, '@fixture/users', {
+      version: '1.0.0',
+      timestamp: Date.now(),
+      packageName: '@fixture/users',
+      smrtDependencies: ['@fixture/mobile-contract'],
+      objects: {
+        '@fixture/users:User': {
+          className: 'User',
+          qualifiedName: '@fixture/users:User',
+          packageName: '@fixture/users',
+          collection: 'users',
+          fields: {
+            email: { type: 'text', required: true },
+          },
+        },
+      },
+    });
+
+    await createProject(projectRoot, {
+      version: '1.0.0',
+      timestamp: Date.now(),
+      packageName: '@test/app',
+      smrtDependencies: ['@fixture/users'],
+      objects: {},
+    });
+    await createRegisterFile(projectRoot);
+
+    process.chdir(projectRoot);
+    const result = await runRuntimeCheck(projectRoot);
+
+    expect(
+      result.findings.filter((finding) =>
+        finding.code.includes('dependency-manifest'),
+      ),
+    ).toEqual([]);
   });
 
   it('reports malformed dependency manifests as missing findings instead of crashing', async () => {

--- a/packages/cli/src/runtime-check.ts
+++ b/packages/cli/src/runtime-check.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import {
@@ -45,6 +45,12 @@ interface ManifestEntryRef {
 interface LoadedDependencyManifest {
   manifest: SmartObjectManifest;
   resolverPath: string;
+}
+
+interface DependencyQueueEntry {
+  dependency: string;
+  issuerResolverPath: string;
+  parentDependency?: string;
 }
 
 type EntryLookupResult =
@@ -311,7 +317,9 @@ async function loadDependencyManifests(
   findings: RuntimeCheckFinding[],
 ): Promise<SmartObjectManifest[]> {
   const loaded = new Map<string, LoadedDependencyManifest>();
-  const queue = (rootManifest.smrtDependencies || []).map((dependency) => ({
+  const queue: DependencyQueueEntry[] = (
+    rootManifest.smrtDependencies || []
+  ).map((dependency) => ({
     dependency,
     issuerResolverPath: resolve(projectRoot, 'package.json'),
   }));
@@ -328,6 +336,16 @@ async function loadDependencyManifests(
     );
 
     if (!loadedDependency) {
+      if (next.parentDependency) {
+        addFinding(
+          findings,
+          'warning',
+          'missing-nested-dependency-manifest',
+          `Nested SMRT dependency "${next.dependency}" declared by "${next.parentDependency}" does not expose a runtime manifest; skipping it.`,
+        );
+        continue;
+      }
+
       addFinding(
         findings,
         'error',
@@ -344,6 +362,7 @@ async function loadDependencyManifests(
         queue.push({
           dependency: nestedDependency,
           issuerResolverPath: loadedDependency.resolverPath,
+          parentDependency: next.dependency,
         });
       }
     }
@@ -386,10 +405,58 @@ function resolvePackageJsonPath(
       );
 
       if (packageJsonPath) {
-        return packageJsonPath;
+        return realpathSync(packageJsonPath);
       }
     } catch {
       // Keep trying the next candidate.
+    }
+  }
+
+  return findPackageJsonFromNodeModules(packageName, issuerResolverPath);
+}
+
+function findPackageJsonFromNodeModules(
+  packageName: string,
+  issuerResolverPath: string,
+): string | null {
+  const packageParts = packageName.split('/');
+  const startDirs = new Set<string>([dirname(issuerResolverPath)]);
+
+  try {
+    startDirs.add(dirname(realpathSync(issuerResolverPath)));
+  } catch {
+    // Keep the lexical issuer path if the real path cannot be resolved.
+  }
+
+  for (const startDir of startDirs) {
+    let currentDir = startDir;
+
+    for (let index = 0; index < MAX_PACKAGE_JSON_ASCENTS; index += 1) {
+      const packageJsonPath = join(
+        currentDir,
+        'node_modules',
+        ...packageParts,
+        'package.json',
+      );
+
+      if (existsSync(packageJsonPath)) {
+        try {
+          const packageJson = JSON.parse(
+            readFileSync(packageJsonPath, 'utf-8'),
+          );
+          if (packageJson?.name === packageName) {
+            return realpathSync(packageJsonPath);
+          }
+        } catch {
+          // Keep walking upward.
+        }
+      }
+
+      const parentDir = dirname(currentDir);
+      if (parentDir === currentDir) {
+        break;
+      }
+      currentDir = parentDir;
     }
   }
 


### PR DESCRIPTION
## Summary
- resolve nested SMRT dependency manifests from real package paths so pnpm symlinked dependencies work
- fall back to node_modules package.json lookup for import-only packages that expose dist/manifest.json but not a CommonJS entry
- keep direct missing dependencies as errors while warning and skipping missing nested runtime metadata

## Test plan
- pnpm --dir packages/cli exec vitest run src/__tests__/runtime-check.test.ts
- pnpm --filter @happyvertical/smrt-cli build (exits 0; existing dts warnings remain for unbuilt sibling packages in this clean worktree)

## Notes
- Needed by anytown/anytown.ai#661 because @happyvertical/smrt-users@0.38.12 declares a nested non-runtime support package dependency.