### PR TITLE
fix(smrt-ui): seed ThemeProvider config from props for SSR

### DIFF
--- a/packages/smrt-ui/src/themes/ThemeProvider.svelte
+++ b/packages/smrt-ui/src/themes/ThemeProvider.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { Snippet } from 'svelte';
-import { onMount } from 'svelte';
+import { onMount, untrack } from 'svelte';
 import { setThemeContext, type ThemeContext } from './context.svelte.js';
 import { generateThemeVariables } from './css-generator.js';
 import { getTheme } from './registry.js';
@@ -43,16 +43,24 @@ let {
   children,
 }: Props = $props();
 
-// Internal state
-let config = $state<ThemeConfig>({
-  preset: defaultThemeConfig.preset,
-  colorScheme: defaultThemeConfig.colorScheme,
-  primaryColor: undefined,
-  borderRadius: defaultThemeConfig.borderRadius,
-  overrides: {},
-  persist: defaultThemeConfig.persist,
-  storageKey: defaultThemeConfig.storageKey,
-});
+// Internal state — seed from the props (which already default to
+// defaultThemeConfig) rather than the defaults directly, so the FIRST render
+// reflects the requested preset. The prop-sync $effect below only runs on the
+// client, so seeding from defaults made SSR / first paint / JS-disabled emit
+// the default (material) theme regardless of `preset` (happyvertical/smrt).
+let config = $state<ThemeConfig>(
+  // untrack: intentionally capture the props' initial values here; the
+  // "Sync props to state" $effect below keeps config reactive to later changes.
+  untrack(() => ({
+    preset,
+    colorScheme,
+    primaryColor,
+    borderRadius,
+    overrides,
+    persist,
+    storageKey,
+  })),
+);
 
 let systemPrefersDark = $state(false);
 let mounted = $state(false);

--- a/packages/smrt-ui/src/themes/ThemeProvider.svelte
+++ b/packages/smrt-ui/src/themes/ThemeProvider.svelte
@@ -47,7 +47,7 @@ let {
 // defaultThemeConfig) rather than the defaults directly, so the FIRST render
 // reflects the requested preset. The prop-sync $effect below only runs on the
 // client, so seeding from defaults made SSR / first paint / JS-disabled emit
-// the default (material) theme regardless of `preset` (happyvertical/smrt).
+// the default preset regardless of the `preset` prop.
 let config = $state<ThemeConfig>(
   // untrack: intentionally capture the props' initial values here; the
   // "Sync props to state" $effect below keeps config reactive to later changes.


### PR DESCRIPTION
## Problem
`ThemeProvider` (`./themes`) seeds its `config` `$state` from `defaultThemeConfig` (preset `material`) and applies the `preset`/`colorScheme`/… props only through a **client-only** "sync props to state" `$effect`. That effect doesn't run during SSR, so server-rendered / first-paint / JS-disabled output emits the default (material) theme regardless of `<ThemeProvider preset="…">`, then flashes to the requested preset on hydration.

Verified against the source: `config` init used `defaultThemeConfig.preset`, and the only prop→config application is `$effect(() => { config.preset = preset })`.

## Fix
Seed `config` from the props at init (wrapped in `untrack` — the initial capture is intentional; the existing sync `$effect` keeps it reactive to later prop changes), so the very first render already reflects the requested preset.

Backward-compatible: the props already default to `defaultThemeConfig`, and **client behavior is unchanged** (the sync effect already forced `config.preset = preset` after mount). The only difference is SSR / first paint now emits the requested preset instead of material.

## Verification
- `typecheck` (tsc + svelte-check-a11y): 0 errors
- `check` (svelte-check): 0 errors, 0 warnings (the `untrack` wrap silences `state_referenced_locally`)
- `build` (svelte-package): clean
- `knowledge:check --changed --strict`: fresh
- Package tests: blocked locally by the known Darwin/vite8 config-load issue (`@happyvertical/smrt-core` entry resolution) — CI is the gate.

## Context
Surfaced by a review on anytown.ai PR #663 (smrt-ui 0.38.9). Fixing here benefits every consumer; anytown picks it up on the next smrt-ui bump.