### PR TITLE
feat(mobile): evidence-capture adapters for iOS + Android (#1880)

### DIFF
--- a/docs/content/adr/0001-kmp-mobile-foundation-extraction-plan.md
+++ b/docs/content/adr/0001-kmp-mobile-foundation-extraction-plan.md
@@ -224,8 +224,18 @@ record lives as a comment on the issue.
 **Landed** (issue #1743): `packages/smrt-ios` — the locked design
 record lives as a comment on the issue. smrt-mobile gained a first `iosMain`
 (`SmrtMobileIos` factories) so Swift can obtain the durable store + Ktor client
-it cannot construct itself. The iOS evidence-capture adapter is deferred (joint
-design pass with the Android half, #1880).
+it cannot construct itself.
+
+**Landed** (issue #1880): the **joint iOS + Android evidence-capture adapters**
+(deferred from Phase 5 D9 and Phase 6 D9 for a single cross-platform design
+pass — locked record on the issue). `EvidenceCapturePlatformAdapter` impls on
+**both** platforms, resolving the shared contract once: **drive-to-completion**
+`captureOrPickPhoto` (Android full-res `TakePicture` into a library-shipped
+`FileProvider`; iOS `UIImagePickerController`/`PHPickerViewController` →
+`Documents/Evidence/` with security-scoped-resource handling), a unified
+`app_private` `storageRoot`, sha256 pins, and a `LocationManager`/
+`CLLocationManager` geo sidecar (never EXIF). smrt-mobile's `iosMain` gained
+`instantFromEpochMillis` for the iOS DTO timestamps.
 
 **Goal:** SwiftUI design system + adapters **actually consuming the exported KMP
 framework**. Riskiest phase.

--- a/packages/smrt-android/AGENTS.md
+++ b/packages/smrt-android/AGENTS.md
@@ -41,16 +41,25 @@ publishing deferred, consumers are local-fs).
   `AndroidSha256Hasher` (`Sha256Hasher`), `AndroidSqlDriverFactory`
   (SQLDelight android-driver for `SmrtMobileDatabase`),
   `KeystoreAuthStorage` (`AuthStorage`; AES/GCM via Android Keystore — the
-  named upgrade over the reporter's plain SharedPreferences), and
-  `CustomTabAuthLauncher` (`ExternalAuthLauncher`).
+  named upgrade over the reporter's plain SharedPreferences),
+  `CustomTabAuthLauncher` (`ExternalAuthLauncher`), and
+  `AndroidEvidenceCaptureAdapter` (`EvidenceCapturePlatformAdapter`;
+  drive-to-completion `captureOrPickPhoto` — full-res `TakePicture` into a
+  library-shipped `FileProvider` URI, or the system photo picker — app-private
+  storage, sha256 pin, `LocationManager` geo sidecar; #1880). The evidence
+  FileProvider (`SmrtEvidenceFileProvider`) ships in the library manifest with a
+  `${applicationId}.evidence.files` authority (per-consumer via manifest merge,
+  overridable via the constructor + `tools:replace`).
 - `library/src/test/` — local JVM unit tests for the pure
   platform-to-shared mappings (barcode formats, speech error codes,
-  FeatureStatus→availability, sha256 vector). Camera/recognizer/AICore
-  behavior needs a device: the sample app is the manual acceptance surface.
-- `sample/` — four tabs exercising shell+theme (Home, incl. a live
-  `DurableWriteQueue` on the Android driver), barcode preview (Scan),
-  speech + Gemini Nano round-trip (Talk), and the capability probe
-  (Settings).
+  FeatureStatus→availability, sha256 vector, evidence
+  segment/content-type/permission/location/verify projections).
+  Camera/recognizer/AICore/capture behavior needs a device: the sample app is
+  the manual acceptance surface.
+- `sample/` — five tabs exercising shell+theme (Home, incl. a live
+  `DurableWriteQueue` on the Android driver), barcode preview (Scan), evidence
+  capture (Capture), speech + Gemini Nano round-trip (Talk), and the capability
+  probe (Settings).
 
 ## Commands
 

--- a/packages/smrt-android/gradle/libs.versions.toml
+++ b/packages/smrt-android/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
+androidx-activity = { module = "androidx.activity:activity", version.ref = "activity-compose" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 androidx-browser = { module = "androidx.browser:browser", version.ref = "browser" }
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }

--- a/packages/smrt-android/library/build.gradle.kts
+++ b/packages/smrt-android/library/build.gradle.kts
@@ -55,6 +55,9 @@ dependencies {
     debugImplementation(libs.compose.ui.tooling)
 
     implementation(libs.androidx.core.ktx)
+    // ComponentActivity + ActivityResultContracts/Registry drive the evidence
+    // camera/picker capture; only activity-compose (sample) had this before.
+    implementation(libs.androidx.activity)
     implementation(libs.androidx.browser)
     // Directly imported (LocalLifecycleOwner) — declared, not left to a
     // compose-ui transitive.

--- a/packages/smrt-android/library/src/main/AndroidManifest.xml
+++ b/packages/smrt-android/library/src/main/AndroidManifest.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  smrt-android library manifest (issue #1880). Ships the evidence-capture
+  FileProvider so consumer apps get full-resolution camera capture with zero
+  config: the authority is per-consumer via the ${applicationId} placeholder
+  (merged into each app as <applicationId>.evidence.files), so no two apps
+  collide. A consumer wanting a different authority overrides it in their app
+  manifest with tools:replace="android:authorities" AND passes the matching
+  string to AndroidEvidenceCaptureAdapter(fileProviderAuthority = ...). Runtime
+  permissions (CAMERA, ACCESS_FINE/COARSE_LOCATION) stay the consumer's
+  responsibility — the library forces none.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Camera is optional: a device without one falls back to the photo picker. -->
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
+    <!--
+      Package visibility (Android 11+) so the evidence photo-picker fallback can
+      resolve an ACTION_GET_CONTENT image handler on devices without the system
+      photo picker.
+    -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.GET_CONTENT" />
+            <data android:mimeType="image/*" />
+        </intent>
+    </queries>
+
+    <application>
+        <provider
+            android:name="com.happyvertical.smrt.android.platform.SmrtEvidenceFileProvider"
+            android:authorities="${applicationId}.evidence.files"
+            android:exported="false"
+            android:grantUriPermissions="true" />
+    </application>
+
+</manifest>

--- a/packages/smrt-android/library/src/main/kotlin/com/happyvertical/smrt/android/platform/AndroidEvidenceCaptureAdapter.kt
+++ b/packages/smrt-android/library/src/main/kotlin/com/happyvertical/smrt/android/platform/AndroidEvidenceCaptureAdapter.kt
@@ -1,0 +1,419 @@
+package com.happyvertical.smrt.android.platform
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.location.Location
+import android.location.LocationManager
+import android.net.Uri
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.FileProvider
+import com.happyvertical.smrt.mobile.evidence.EvidenceAssetRef
+import com.happyvertical.smrt.mobile.evidence.EvidenceAssetStorageState
+import com.happyvertical.smrt.mobile.evidence.EvidenceCapturePlatformAdapter
+import com.happyvertical.smrt.mobile.evidence.EvidenceCaptureRequest
+import com.happyvertical.smrt.mobile.evidence.EvidenceCaptureResult
+import com.happyvertical.smrt.mobile.evidence.EvidenceCaptureSource
+import com.happyvertical.smrt.mobile.evidence.EvidenceLocationMetadata
+import com.happyvertical.smrt.mobile.evidence.EvidenceNativePermissionState
+import com.happyvertical.smrt.mobile.evidence.EvidencePermissionStatus
+import com.happyvertical.smrt.mobile.platform.Sha256Hasher
+import java.io.File
+import java.io.FileOutputStream
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * Android implementation of smrt-mobile's [EvidenceCapturePlatformAdapter]
+ * (issue #1880; joint iOS+Android design record on that issue).
+ *
+ * **Drive-to-completion**, unlike amaru's prepare-only seed: [captureOrPickPhoto]
+ * requests the permissions it needs, presents the OS camera or system photo
+ * picker, awaits the user, copies the result into app-private storage, computes
+ * a SHA-256 pin, verifies the file, and returns a `STORED_OFFLINE`
+ * [EvidenceAssetRef] (or a null asset on cancel / no-capture-surface). One
+ * awaitable call — the `ActivityResult` plumbing lives here, not in every
+ * consumer.
+ *
+ * Full-resolution capture uses [ActivityResultContracts.TakePicture] writing to
+ * a **library-shipped FileProvider** content URI (the external camera app fills
+ * our app-private file at full res — fixing the reporter's thumbnail-only
+ * anti-pattern of `ACTION_IMAGE_CAPTURE` without `EXTRA_OUTPUT`). The provider
+ * authority defaults to `${applicationId}.evidence.files` (the merged manifest
+ * placeholder); a consumer overriding it via `tools:replace` must pass the
+ * matching [fileProviderAuthority].
+ *
+ * Geo travels as an [EvidenceLocationMetadata] **sidecar** (lat/long/accuracy
+ * fields), never EXIF — recompression strips EXIF (ADR Correction 2). Storage
+ * root is the platform-neutral `app_private`; the SHA-256 pin is bare lowercase
+ * hex from [AndroidSha256Hasher].
+ *
+ * Needs a [ComponentActivity] (it is both the [Context] and the
+ * `ActivityResultRegistryOwner`). The register→launch→resume path does not
+ * survive process death of an in-flight capture — acceptable for the
+ * foundation + sample; a consumer needing it should re-register on lifecycle.
+ */
+class AndroidEvidenceCaptureAdapter(
+    private val activity: ComponentActivity,
+    private val fileProviderAuthority: String = "${activity.packageName}.evidence.files",
+    private val hasher: Sha256Hasher = AndroidSha256Hasher,
+    private val clock: () -> Instant = { Clock.System.now() },
+) : EvidenceCapturePlatformAdapter {
+
+    private val requestCounter = AtomicInteger(0)
+
+    override suspend fun captureOrPickPhoto(request: EvidenceCaptureRequest): EvidenceCaptureResult {
+        val hasCameraFeature =
+            activity.packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY)
+        val wantsCamera =
+            request.preferredSource == EvidenceCaptureSource.CAMERA && hasCameraFeature
+
+        // Drive-to-completion: request what the flow needs before capturing.
+        val toRequest = buildList {
+            if (wantsCamera && !hasPermission(Manifest.permission.CAMERA)) {
+                add(Manifest.permission.CAMERA)
+            }
+            if (!hasPermission(Manifest.permission.ACCESS_FINE_LOCATION) &&
+                !hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
+            ) {
+                add(Manifest.permission.ACCESS_FINE_LOCATION)
+                add(Manifest.permission.ACCESS_COARSE_LOCATION)
+            }
+        }
+        if (toRequest.isNotEmpty()) {
+            withContext(Dispatchers.Main.immediate) {
+                launchForResult(
+                    ActivityResultContracts.RequestMultiplePermissions(),
+                    toRequest.toTypedArray(),
+                )
+            }
+        }
+
+        val location = currentLocationMetadata()
+        val cameraGranted = hasPermission(Manifest.permission.CAMERA)
+        val pickerReady = nativePickerAvailable()
+        val permissions = EvidenceNativePermissionState(
+            cameraStatus = evidenceCameraStatus(hasCameraFeature, cameraGranted),
+            photoLibraryStatus = evidencePhotoLibraryStatus(pickerReady),
+            locationStatus = location.permissionStatus,
+        )
+        val cameraReady = hasCameraFeature && cameraGranted
+
+        return when {
+            request.preferredSource == EvidenceCaptureSource.CAMERA && cameraReady ->
+                captureFromCamera(request, location, permissions)
+
+            pickerReady -> pickFromLibrary(request, location, permissions)
+            cameraReady -> captureFromCamera(request, location, permissions)
+            else -> EvidenceCaptureResult(
+                localAsset = null,
+                location = location,
+                permissions = permissions,
+                captureAvailable = false,
+                userMessage = "No camera or image picker is available on this device.",
+            )
+        }
+    }
+
+    override suspend fun currentLocationMetadata(): EvidenceLocationMetadata =
+        withContext(Dispatchers.IO) {
+            val granted = hasPermission(Manifest.permission.ACCESS_FINE_LOCATION) ||
+                hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
+            if (!granted) {
+                return@withContext evidenceLocationMetadata(false, false, null)
+            }
+            val manager = activity.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+                ?: return@withContext evidenceLocationMetadata(true, false, null)
+            val location = listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)
+                .firstNotNullOfOrNull { provider -> lastKnownLocation(manager, provider) }
+            evidenceLocationMetadata(true, true, location?.toSnapshot())
+        }
+
+    private suspend fun captureFromCamera(
+        request: EvidenceCaptureRequest,
+        location: EvidenceLocationMetadata,
+        permissions: EvidenceNativePermissionState,
+    ): EvidenceCaptureResult {
+        val assetId = evidenceAssetId(evidenceCaptureSegment(request), clock().toEpochMilliseconds())
+        val file = File(evidenceDir(), "$assetId.jpg")
+        val outputUri = FileProvider.getUriForFile(activity, fileProviderAuthority, file)
+        val base = pendingAsset(assetId, file, "image/jpeg", EvidenceCaptureSource.CAMERA, "")
+
+        val saved = withContext(Dispatchers.Main.immediate) {
+            launchForResult(ActivityResultContracts.TakePicture(), outputUri)
+        }
+        if (!saved) {
+            withContext(Dispatchers.IO) { runCatching { if (file.exists()) file.delete() } }
+            return cancelled(location, permissions)
+        }
+        val asset = withContext(Dispatchers.IO) { finalize(base, file) }
+        return EvidenceCaptureResult(
+            localAsset = asset,
+            location = location,
+            permissions = permissions,
+            captureAvailable = true,
+            userMessage = capturedMessage(asset),
+        )
+    }
+
+    private suspend fun pickFromLibrary(
+        request: EvidenceCaptureRequest,
+        location: EvidenceLocationMetadata,
+        permissions: EvidenceNativePermissionState,
+    ): EvidenceCaptureResult {
+        val picked: Uri? = withContext(Dispatchers.Main.immediate) {
+            launchForResult(
+                ActivityResultContracts.PickVisualMedia(),
+                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+            )
+        }
+        if (picked == null) return cancelled(location, permissions)
+
+        val asset = withContext(Dispatchers.IO) {
+            val contentType = activity.contentResolver.getType(picked) ?: "image/jpeg"
+            val extension = evidenceExtensionForContentType(contentType)
+            val assetId =
+                evidenceAssetId(evidenceCaptureSegment(request), clock().toEpochMilliseconds())
+            val file = File(evidenceDir(), "$assetId.$extension")
+            activity.contentResolver.openInputStream(picked)?.use { input ->
+                FileOutputStream(file).use { output -> input.copyTo(output) }
+            } ?: error("Cannot open selected evidence asset")
+            finalize(
+                pendingAsset(
+                    assetId,
+                    file,
+                    contentType,
+                    EvidenceCaptureSource.NATIVE_PICKER,
+                    picked.toString(),
+                ),
+                file,
+            )
+        }
+        return EvidenceCaptureResult(
+            localAsset = asset,
+            location = location,
+            permissions = permissions,
+            captureAvailable = true,
+            userMessage = capturedMessage(asset),
+        )
+    }
+
+    /** Reserved asset before the file exists (`pending_capture`, not offline-safe). */
+    private fun pendingAsset(
+        assetId: String,
+        file: File,
+        contentType: String,
+        source: String,
+        originalUri: String,
+    ): EvidenceAssetRef = EvidenceAssetRef(
+        assetId = assetId,
+        localUri = file.toURI().toString(),
+        fileName = file.name,
+        contentType = contentType,
+        sizeBytes = null,
+        sha256 = "",
+        captureSource = source,
+        originalUri = originalUri,
+        storageRoot = STORAGE_ROOT,
+        relativePath = "evidence/${file.name}",
+        storageState = EvidenceAssetStorageState.PENDING_CAPTURE,
+        offlineSafe = false,
+        persistedAt = null,
+    )
+
+    /** Reads the on-disk file and pins it (size + sha256) via the pure verifier. */
+    private fun finalize(base: EvidenceAssetRef, file: File): EvidenceAssetRef {
+        val exists = file.exists()
+        val sizeBytes = if (exists) file.length() else 0L
+        val sha256 = if (exists && sizeBytes > 0L) hasher.sha256Hex(file.readBytes()) else ""
+        return verifiedEvidenceAsset(base, exists, sizeBytes, sha256, clock())
+    }
+
+    private fun cancelled(
+        location: EvidenceLocationMetadata,
+        permissions: EvidenceNativePermissionState,
+    ): EvidenceCaptureResult = EvidenceCaptureResult(
+        localAsset = null,
+        location = location,
+        permissions = permissions,
+        captureAvailable = true,
+        userMessage = "Capture cancelled.",
+    )
+
+    private fun capturedMessage(asset: EvidenceAssetRef): String =
+        if (asset.storageState == EvidenceAssetStorageState.STORED_OFFLINE) {
+            "Evidence stored offline (${asset.sizeBytes ?: 0L} bytes)."
+        } else {
+            "Capture could not be verified; the local file is missing."
+        }
+
+    private fun evidenceDir(): File = File(activity.filesDir, "evidence").apply { mkdirs() }
+
+    private fun nativePickerAvailable(): Boolean =
+        ActivityResultContracts.PickVisualMedia.isPhotoPickerAvailable(activity) ||
+            Intent(Intent.ACTION_GET_CONTENT)
+                .setType("image/*")
+                .addCategory(Intent.CATEGORY_OPENABLE)
+                .resolveActivity(activity.packageManager) != null
+
+    private fun hasPermission(permission: String): Boolean =
+        activity.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED
+
+    // currentLocationMetadata() verifies ACCESS_FINE/COARSE_LOCATION before this
+    // is reached; the library declares no location permission (consumer's call).
+    @SuppressLint("MissingPermission")
+    private fun lastKnownLocation(manager: LocationManager, provider: String): Location? =
+        try {
+            if (manager.isProviderEnabled(provider)) manager.getLastKnownLocation(provider) else null
+        } catch (_: SecurityException) {
+            null
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+
+    /**
+     * Bridges an `ActivityResultContract` into a suspend call via the activity's
+     * [androidx.activity.result.ActivityResultRegistry]. Must run on the main
+     * thread (registration is `@MainThread`). Registers under a unique key,
+     * launches, resumes on the callback, and always unregisters.
+     */
+    private suspend fun <I, O> launchForResult(
+        contract: ActivityResultContract<I, O>,
+        input: I,
+    ): O = suspendCancellableCoroutine { continuation ->
+        val key = "smrt_evidence_${requestCounter.incrementAndGet()}"
+        var launcher: ActivityResultLauncher<I>? = null
+        launcher = activity.activityResultRegistry.register(key, contract) { result ->
+            launcher?.unregister()
+            if (continuation.isActive) continuation.resume(result)
+        }
+        continuation.invokeOnCancellation { launcher?.unregister() }
+        try {
+            launcher.launch(input)
+        } catch (error: Throwable) {
+            launcher.unregister()
+            if (continuation.isActive) continuation.resumeWithException(error)
+        }
+    }
+
+    private companion object {
+        const val STORAGE_ROOT = "app_private"
+    }
+}
+
+/**
+ * A plain-data snapshot of an `android.location.Location` so the projection onto
+ * [EvidenceLocationMetadata] is a pure, device-free function.
+ */
+internal data class LocationSnapshot(
+    val latitude: Double,
+    val longitude: Double,
+    val accuracyMeters: Float,
+    val provider: String,
+    val timeEpochMillis: Long,
+)
+
+internal fun Location.toSnapshot(): LocationSnapshot = LocationSnapshot(
+    latitude = latitude,
+    longitude = longitude,
+    accuracyMeters = accuracy,
+    provider = provider ?: "android",
+    timeEpochMillis = time,
+)
+
+/** First non-blank context id (sorted by key for determinism), else `evidence`. */
+internal fun evidenceCaptureSegment(request: EvidenceCaptureRequest): String =
+    request.contextIds.toSortedMap().values
+        .firstOrNull { it.isNotBlank() }
+        ?.let(::sanitizeEvidenceSegment)
+        ?: "evidence"
+
+internal fun sanitizeEvidenceSegment(value: String): String =
+    value.replace(Regex("[^A-Za-z0-9_-]"), "_").ifBlank { "evidence" }
+
+internal fun evidenceAssetId(segment: String, epochMillis: Long): String =
+    "asset_${segment}_$epochMillis"
+
+internal fun evidenceExtensionForContentType(contentType: String): String =
+    when (contentType.substringBefore(';').trim().lowercase()) {
+        "image/png" -> "png"
+        "image/webp" -> "webp"
+        "image/heic", "image/heif" -> "heic"
+        "image/gif" -> "gif"
+        else -> "jpg"
+    }
+
+internal fun evidenceCameraStatus(hasCameraFeature: Boolean, granted: Boolean): String = when {
+    !hasCameraFeature -> EvidencePermissionStatus.UNAVAILABLE
+    granted -> EvidencePermissionStatus.GRANTED
+    else -> EvidencePermissionStatus.DENIED
+}
+
+internal fun evidencePhotoLibraryStatus(pickerAvailable: Boolean): String =
+    if (pickerAvailable) EvidencePermissionStatus.GRANTED else EvidencePermissionStatus.UNAVAILABLE
+
+/** Pure projection of last-known location + permission onto the geo sidecar. */
+internal fun evidenceLocationMetadata(
+    permissionGranted: Boolean,
+    providerAvailable: Boolean,
+    snapshot: LocationSnapshot?,
+): EvidenceLocationMetadata = when {
+    !permissionGranted -> EvidenceLocationMetadata.unavailable(
+        permissionStatus = EvidencePermissionStatus.DENIED,
+        unavailableReason = "permission_denied",
+    )
+
+    !providerAvailable -> EvidenceLocationMetadata.unavailable(
+        permissionStatus = EvidencePermissionStatus.UNAVAILABLE,
+        unavailableReason = "provider_unavailable",
+    )
+
+    snapshot == null -> EvidenceLocationMetadata.unavailable(
+        permissionStatus = EvidencePermissionStatus.GRANTED,
+        unavailableReason = "last_location_unavailable",
+    )
+
+    else -> EvidenceLocationMetadata.available(
+        latitude = snapshot.latitude.toString(),
+        longitude = snapshot.longitude.toString(),
+        accuracyMeters = snapshot.accuracyMeters.toString(),
+        provider = snapshot.provider,
+        capturedAt = Instant.fromEpochMilliseconds(snapshot.timeEpochMillis),
+    )
+}
+
+/** Pure verifier: a written file → `stored_offline`; a missing one → `missing_local_file`. */
+internal fun verifiedEvidenceAsset(
+    base: EvidenceAssetRef,
+    exists: Boolean,
+    sizeBytes: Long,
+    sha256: String,
+    persistedAt: Instant,
+): EvidenceAssetRef = if (exists && sizeBytes > 0L) {
+    base.copy(
+        sizeBytes = sizeBytes,
+        sha256 = sha256,
+        storageState = EvidenceAssetStorageState.STORED_OFFLINE,
+        offlineSafe = true,
+        persistedAt = persistedAt,
+    )
+} else {
+    base.copy(
+        sizeBytes = if (exists) sizeBytes else null,
+        storageState = EvidenceAssetStorageState.MISSING_LOCAL_FILE,
+        offlineSafe = false,
+        persistedAt = null,
+    )
+}

--- a/packages/smrt-android/library/src/main/kotlin/com/happyvertical/smrt/android/platform/AndroidEvidenceCaptureAdapter.kt
+++ b/packages/smrt-android/library/src/main/kotlin/com/happyvertical/smrt/android/platform/AndroidEvidenceCaptureAdapter.kt
@@ -14,6 +14,9 @@ import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.FileProvider
+import androidx.core.location.LocationManagerCompat
+import androidx.core.os.CancellationSignal
+import androidx.core.util.Consumer
 import com.happyvertical.smrt.mobile.evidence.EvidenceAssetRef
 import com.happyvertical.smrt.mobile.evidence.EvidenceAssetStorageState
 import com.happyvertical.smrt.mobile.evidence.EvidenceCapturePlatformAdapter
@@ -26,12 +29,14 @@ import com.happyvertical.smrt.mobile.evidence.EvidencePermissionStatus
 import com.happyvertical.smrt.mobile.platform.Sha256Hasher
 import java.io.File
 import java.io.FileOutputStream
+import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
@@ -127,19 +132,46 @@ class AndroidEvidenceCaptureAdapter(
         }
     }
 
-    override suspend fun currentLocationMetadata(): EvidenceLocationMetadata =
-        withContext(Dispatchers.IO) {
-            val granted = hasPermission(Manifest.permission.ACCESS_FINE_LOCATION) ||
-                hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
-            if (!granted) {
-                return@withContext evidenceLocationMetadata(false, false, null)
-            }
-            val manager = activity.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
-                ?: return@withContext evidenceLocationMetadata(true, false, null)
-            val location = listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)
+    override suspend fun currentLocationMetadata(): EvidenceLocationMetadata {
+        val granted = hasPermission(Manifest.permission.ACCESS_FINE_LOCATION) ||
+            hasPermission(Manifest.permission.ACCESS_COARSE_LOCATION)
+        if (!granted) return evidenceLocationMetadata(false, false, null)
+        val manager = activity.getSystemService(Context.LOCATION_SERVICE) as? LocationManager
+            ?: return evidenceLocationMetadata(true, false, null)
+        val cached = withContext(Dispatchers.IO) {
+            listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)
                 .firstNotNullOfOrNull { provider -> lastKnownLocation(manager, provider) }
-            evidenceLocationMetadata(true, true, location?.toSnapshot())
         }
+        // No cached last-known fix (common on first use): request one live fix.
+        val location = cached ?: requestSingleFix(manager)
+        return evidenceLocationMetadata(true, true, location?.toSnapshot())
+    }
+
+    /**
+     * Requests a single live fix, bounded by [FIX_TIMEOUT_MS], for the first-use
+     * case where no cached last-known location exists yet.
+     * [LocationManagerCompat.getCurrentLocation] handles the API-level split.
+     */
+    @SuppressLint("MissingPermission")
+    private suspend fun requestSingleFix(manager: LocationManager): Location? {
+        val provider = listOf(LocationManager.GPS_PROVIDER, LocationManager.NETWORK_PROVIDER)
+            .firstOrNull { provider ->
+                runCatching { manager.isProviderEnabled(provider) }.getOrDefault(false)
+            } ?: return null
+        return withTimeoutOrNull(FIX_TIMEOUT_MS) {
+            suspendCancellableCoroutine { continuation ->
+                val signal = CancellationSignal()
+                continuation.invokeOnCancellation { signal.cancel() }
+                LocationManagerCompat.getCurrentLocation(
+                    manager,
+                    provider,
+                    signal,
+                    Executor { it.run() },
+                    Consumer { location -> if (continuation.isActive) continuation.resume(location) },
+                )
+            }
+        }
+    }
 
     private suspend fun captureFromCamera(
         request: EvidenceCaptureRequest,
@@ -310,6 +342,7 @@ class AndroidEvidenceCaptureAdapter(
 
     private companion object {
         const val STORAGE_ROOT = "app_private"
+        const val FIX_TIMEOUT_MS = 8_000L
     }
 }
 

--- a/packages/smrt-android/library/src/main/kotlin/com/happyvertical/smrt/android/platform/SmrtEvidenceFileProvider.kt
+++ b/packages/smrt-android/library/src/main/kotlin/com/happyvertical/smrt/android/platform/SmrtEvidenceFileProvider.kt
@@ -1,0 +1,16 @@
+package com.happyvertical.smrt.android.platform
+
+import androidx.core.content.FileProvider
+import com.happyvertical.smrt.android.R
+
+/**
+ * Dedicated [FileProvider] subclass for library-shipped evidence capture
+ * (issue #1880). A distinct class name is deliberate: the Android manifest
+ * merger keys `<provider>` elements by their class, so declaring the base
+ * `androidx.core.content.FileProvider` from a library would collide with a
+ * consumer app's own FileProvider. The subclass passes the paths resource to
+ * the super constructor, so the manifest needs no `<meta-data>`. The system
+ * instantiates it via the generated no-arg constructor. Consumers never
+ * reference it directly — it is wired entirely by the merged library manifest.
+ */
+class SmrtEvidenceFileProvider : FileProvider(R.xml.smrt_evidence_file_paths)

--- a/packages/smrt-android/library/src/main/res/xml/smrt_evidence_file_paths.xml
+++ b/packages/smrt-android/library/src/main/res/xml/smrt_evidence_file_paths.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Grants the external camera app write access to the app-private evidence
+  directory (filesDir/evidence/) so ActivityResultContracts.TakePicture can
+  write a full-resolution photo directly into it. App-private internal storage:
+  not shared media, offline-safe, cleared with the app.
+-->
+<paths>
+    <files-path
+        name="evidence"
+        path="evidence/" />
+</paths>

--- a/packages/smrt-android/library/src/test/kotlin/com/happyvertical/smrt/android/platform/EvidenceCaptureMappingTest.kt
+++ b/packages/smrt-android/library/src/test/kotlin/com/happyvertical/smrt/android/platform/EvidenceCaptureMappingTest.kt
@@ -1,0 +1,155 @@
+package com.happyvertical.smrt.android.platform
+
+import com.happyvertical.smrt.mobile.evidence.EvidenceAssetRef
+import com.happyvertical.smrt.mobile.evidence.EvidenceAssetStorageState
+import com.happyvertical.smrt.mobile.evidence.EvidenceCaptureRequest
+import com.happyvertical.smrt.mobile.evidence.EvidenceCaptureSource
+import com.happyvertical.smrt.mobile.evidence.EvidencePermissionStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.datetime.Instant
+
+/**
+ * The evidence adapter's native-state → shared-DTO projection is a set of pure
+ * functions (issue #1880), so they run device-free here. The camera/picker
+ * drive itself needs an Activity + on-device UI and is exercised by the sample.
+ */
+class EvidenceCaptureMappingTest {
+    @Test
+    fun captureSegmentTakesFirstNonBlankContextIdBySortedKey() {
+        assertEquals(
+            "checklist-1",
+            evidenceCaptureSegment(
+                EvidenceCaptureRequest(contextIds = mapOf("checklistItemId" to "checklist-1")),
+            ),
+        )
+        // Sorted by key → "a" wins over "z" (deterministic regardless of map order).
+        assertEquals(
+            "first",
+            evidenceCaptureSegment(
+                EvidenceCaptureRequest(contextIds = mapOf("z" to "second", "a" to "first")),
+            ),
+        )
+        assertEquals("evidence", evidenceCaptureSegment(EvidenceCaptureRequest()))
+        assertEquals(
+            "evidence",
+            evidenceCaptureSegment(EvidenceCaptureRequest(contextIds = mapOf("k" to "  "))),
+        )
+        assertEquals(
+            "a_b_c",
+            evidenceCaptureSegment(EvidenceCaptureRequest(contextIds = mapOf("k" to "a/b c"))),
+        )
+    }
+
+    @Test
+    fun sanitizeSegmentStripsUnsafeCharacters() {
+        assertEquals("a_b", sanitizeEvidenceSegment("a/b"))
+        assertEquals("keep-this_1", sanitizeEvidenceSegment("keep-this_1"))
+        assertEquals("evidence", sanitizeEvidenceSegment(""))
+        // Separators become underscores; only genuinely blank input falls back.
+        assertEquals("___", sanitizeEvidenceSegment("///"))
+    }
+
+    @Test
+    fun assetIdComposesSegmentAndEpochMillis() {
+        assertEquals("asset_checklist-1_1700", evidenceAssetId("checklist-1", 1700L))
+    }
+
+    @Test
+    fun extensionMapsFromContentType() {
+        assertEquals("jpg", evidenceExtensionForContentType("image/jpeg"))
+        assertEquals("png", evidenceExtensionForContentType("image/png"))
+        assertEquals("heic", evidenceExtensionForContentType("image/heic"))
+        assertEquals("webp", evidenceExtensionForContentType("image/webp"))
+        assertEquals("jpg", evidenceExtensionForContentType("application/octet-stream"))
+        // Tolerates a charset parameter + casing.
+        assertEquals("png", evidenceExtensionForContentType("IMAGE/PNG; charset=binary"))
+    }
+
+    @Test
+    fun cameraStatusMapsFeatureAndGrant() {
+        assertEquals(
+            EvidencePermissionStatus.UNAVAILABLE,
+            evidenceCameraStatus(hasCameraFeature = false, granted = true),
+        )
+        assertEquals(
+            EvidencePermissionStatus.GRANTED,
+            evidenceCameraStatus(hasCameraFeature = true, granted = true),
+        )
+        assertEquals(
+            EvidencePermissionStatus.DENIED,
+            evidenceCameraStatus(hasCameraFeature = true, granted = false),
+        )
+    }
+
+    @Test
+    fun photoLibraryStatusMapsPickerAvailability() {
+        assertEquals(EvidencePermissionStatus.GRANTED, evidencePhotoLibraryStatus(true))
+        assertEquals(EvidencePermissionStatus.UNAVAILABLE, evidencePhotoLibraryStatus(false))
+    }
+
+    @Test
+    fun locationMetadataProjectsPermissionAndSnapshot() {
+        val denied = evidenceLocationMetadata(permissionGranted = false, providerAvailable = false, snapshot = null)
+        assertEquals("unavailable", denied.gpsStatus)
+        assertEquals(EvidencePermissionStatus.DENIED, denied.permissionStatus)
+        assertEquals("permission_denied", denied.unavailableReason)
+
+        val noProvider = evidenceLocationMetadata(permissionGranted = true, providerAvailable = false, snapshot = null)
+        assertEquals(EvidencePermissionStatus.UNAVAILABLE, noProvider.permissionStatus)
+        assertEquals("provider_unavailable", noProvider.unavailableReason)
+
+        val noFix = evidenceLocationMetadata(permissionGranted = true, providerAvailable = true, snapshot = null)
+        assertEquals(EvidencePermissionStatus.GRANTED, noFix.permissionStatus)
+        assertEquals("last_location_unavailable", noFix.unavailableReason)
+
+        val available = evidenceLocationMetadata(
+            permissionGranted = true,
+            providerAvailable = true,
+            snapshot = LocationSnapshot(45.5, -73.6, 8.0f, "gps", 1_700_000_000_000L),
+        )
+        assertEquals("available", available.gpsStatus)
+        assertEquals(EvidencePermissionStatus.GRANTED, available.permissionStatus)
+        assertEquals("45.5", available.latitude)
+        assertEquals("-73.6", available.longitude)
+        assertEquals("8.0", available.accuracyMeters)
+        assertEquals("gps", available.provider)
+        assertEquals(Instant.fromEpochMilliseconds(1_700_000_000_000L), available.capturedAt)
+    }
+
+    @Test
+    fun verifiedAssetFlipsStateOnFilePresence() {
+        val base = EvidenceAssetRef(
+            assetId = "asset_x_1",
+            localUri = "file:///x",
+            fileName = "asset_x_1.jpg",
+            contentType = "image/jpeg",
+            captureSource = EvidenceCaptureSource.CAMERA,
+            storageRoot = "app_private",
+            relativePath = "evidence/asset_x_1.jpg",
+            storageState = EvidenceAssetStorageState.PENDING_CAPTURE,
+            offlineSafe = false,
+        )
+        val at = Instant.fromEpochMilliseconds(1L)
+
+        val stored = verifiedEvidenceAsset(base, exists = true, sizeBytes = 2048L, sha256 = "abcd", persistedAt = at)
+        assertEquals(EvidenceAssetStorageState.STORED_OFFLINE, stored.storageState)
+        assertEquals(2048L, stored.sizeBytes)
+        assertEquals("abcd", stored.sha256)
+        assertTrue(stored.offlineSafe)
+        assertEquals(at, stored.persistedAt)
+
+        val missing = verifiedEvidenceAsset(base, exists = false, sizeBytes = 0L, sha256 = "", persistedAt = at)
+        assertEquals(EvidenceAssetStorageState.MISSING_LOCAL_FILE, missing.storageState)
+        assertFalse(missing.offlineSafe)
+        assertNull(missing.sizeBytes)
+        assertNull(missing.persistedAt)
+
+        val emptyFile = verifiedEvidenceAsset(base, exists = true, sizeBytes = 0L, sha256 = "", persistedAt = at)
+        assertEquals(EvidenceAssetStorageState.MISSING_LOCAL_FILE, emptyFile.storageState)
+        assertEquals(0L, emptyFile.sizeBytes)
+    }
+}

--- a/packages/smrt-android/sample/src/main/AndroidManifest.xml
+++ b/packages/smrt-android/sample/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
 
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <!-- Evidence capture geo sidecar (AndroidEvidenceCaptureAdapter). -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <uses-feature
         android:name="android.hardware.camera.any"

--- a/packages/smrt-android/sample/src/main/kotlin/com/happyvertical/smrt/android/sample/MainActivity.kt
+++ b/packages/smrt-android/sample/src/main/kotlin/com/happyvertical/smrt/android/sample/MainActivity.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
@@ -19,6 +20,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.Mic
+import androidx.compose.material.icons.outlined.PhotoCamera
 import androidx.compose.material.icons.outlined.QrCodeScanner
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Button
@@ -41,6 +43,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import com.happyvertical.smrt.android.platform.AndroidDeviceCapabilityAdapter
+import com.happyvertical.smrt.android.platform.AndroidEvidenceCaptureAdapter
 import com.happyvertical.smrt.android.platform.AndroidSqlDriverFactory
 import com.happyvertical.smrt.android.platform.AndroidSpeechTranscriber
 import com.happyvertical.smrt.android.platform.GeminiNanoLanguageModel
@@ -53,6 +56,9 @@ import com.happyvertical.smrt.android.ui.MobileStatusPill
 import com.happyvertical.smrt.android.ui.MobileTabHeader
 import com.happyvertical.smrt.android.ui.MobileTheme
 import com.happyvertical.smrt.mobile.db.SmrtMobileDatabase
+import com.happyvertical.smrt.mobile.evidence.EvidenceCaptureRequest
+import com.happyvertical.smrt.mobile.evidence.EvidenceCaptureResult
+import com.happyvertical.smrt.mobile.evidence.EvidenceCaptureSource
 import com.happyvertical.smrt.mobile.platform.BarcodeScan
 import com.happyvertical.smrt.mobile.platform.BarcodeScanListener
 import com.happyvertical.smrt.mobile.platform.BarcodeScanRequest
@@ -70,18 +76,21 @@ import kotlinx.coroutines.launch
 private object SampleTabs {
     const val HOME = "home"
     const val SCAN = "scan"
+    const val CAPTURE = "capture"
     const val TALK = "talk"
     const val SETTINGS = "settings"
 
     val all = listOf(
         MobileTab(id = HOME, label = "Home"),
         MobileTab(id = SCAN, label = "Scan"),
+        MobileTab(id = CAPTURE, label = "Capture"),
         MobileTab(id = TALK, label = "Talk"),
         MobileTab(id = SETTINGS, label = "Settings"),
     )
 
     fun icon(tabId: String): ImageVector = when (tabId) {
         SCAN -> Icons.Outlined.QrCodeScanner
+        CAPTURE -> Icons.Outlined.PhotoCamera
         TALK -> Icons.Outlined.Mic
         SETTINGS -> Icons.Outlined.Settings
         else -> Icons.Outlined.Home
@@ -132,6 +141,7 @@ private fun SampleShell() {
 
         when (selected.id) {
             SampleTabs.SCAN -> ScanTab(tabModifier)
+            SampleTabs.CAPTURE -> CaptureTab(tabModifier)
             SampleTabs.TALK -> TalkTab(tabModifier)
             SampleTabs.SETTINGS -> SettingsTab(tabModifier)
             else -> HomeTab(tabModifier, brandName = shellState.brandName, queue = queue)
@@ -287,6 +297,131 @@ private fun ScanTab(modifier: Modifier) {
             }
         }
     }
+}
+
+@Composable
+private fun CaptureTab(modifier: Modifier) {
+    val activity = LocalActivity.current as ComponentActivity
+    val adapter = remember { AndroidEvidenceCaptureAdapter(activity) }
+    val scope = rememberCoroutineScope()
+    var capturing by remember { mutableStateOf(false) }
+    var status by remember {
+        mutableStateOf(
+            "Capture a full-resolution evidence photo (or pick one) — SHA-256 pinned, " +
+                "with a geo sidecar.",
+        )
+    }
+    var result by remember { mutableStateOf<EvidenceCaptureResult?>(null) }
+
+    Column(
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .padding(MobileTheme.spacing.screenPadding),
+        verticalArrangement = Arrangement.spacedBy(MobileTheme.spacing.sectionGap),
+    ) {
+        MobileTabHeader(
+            title = "Capture",
+            subtitle = "AndroidEvidenceCaptureAdapter → EvidenceCaptureResult",
+        )
+
+        Button(
+            enabled = !capturing,
+            onClick = {
+                capturing = true
+                status = "Capturing…"
+                scope.launch {
+                    runCatching {
+                        adapter.captureOrPickPhoto(
+                            EvidenceCaptureRequest(
+                                contextIds = mapOf("checklistItemId" to "sample-capture"),
+                                preferredSource = EvidenceCaptureSource.CAMERA,
+                            ),
+                        )
+                    }.onSuccess { captured ->
+                        result = captured
+                        status = captured.userMessage
+                    }.onFailure { error ->
+                        result = null
+                        status = "[${error.message}]"
+                    }
+                    capturing = false
+                }
+            },
+        ) {
+            Text(if (capturing) "Capturing…" else "Capture evidence")
+        }
+
+        MobileResultCard(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                status,
+                modifier = Modifier.padding(MobileTheme.spacing.itemGap),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+
+        result?.localAsset?.let { asset ->
+            MobileSectionLabel("Stored asset", trailing = asset.storageState)
+            MobileResultCard(modifier = Modifier.fillMaxWidth()) {
+                Column(
+                    modifier = Modifier.padding(MobileTheme.spacing.itemGap),
+                    verticalArrangement = Arrangement.spacedBy(MobileTheme.spacing.tightGap),
+                ) {
+                    Text(asset.fileName, style = MaterialTheme.typography.bodyLarge)
+                    Text(
+                        "${asset.sizeBytes ?: 0L} bytes · ${asset.captureSource} · ${asset.storageRoot}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    if (asset.sha256.isNotBlank()) {
+                        Text(
+                            "sha256 ${asset.sha256.take(16)}…",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        }
+
+        result?.let { captured ->
+            MobileSectionLabel("Geo sidecar", trailing = captured.location.gpsStatus)
+            MobileResultCard(modifier = Modifier.fillMaxWidth()) {
+                val location = captured.location
+                Text(
+                    if (location.gpsStatus == "available") {
+                        "${location.latitude}, ${location.longitude} (±${location.accuracyMeters}m)"
+                    } else {
+                        location.unavailableReason.ifBlank { "unavailable" }
+                    },
+                    modifier = Modifier.padding(MobileTheme.spacing.itemGap),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+
+            MobileSectionLabel("Permissions")
+            MobileResultCard(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier.padding(MobileTheme.spacing.itemGap),
+                    horizontalArrangement = Arrangement.spacedBy(MobileTheme.spacing.tightGap),
+                ) {
+                    EvidencePermissionPill("Camera", captured.permissions.cameraStatus)
+                    EvidencePermissionPill("Photos", captured.permissions.photoLibraryStatus)
+                    EvidencePermissionPill("Location", captured.permissions.locationStatus)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EvidencePermissionPill(label: String, status: String) {
+    val color = when (status) {
+        "granted" -> MobileTheme.statusColors.go
+        "not_determined" -> MobileTheme.statusColors.info
+        "denied" -> MobileTheme.statusColors.caution
+        else -> MobileTheme.statusColors.neutral
+    }
+    MobileStatusPill("$label: $status", color)
 }
 
 @Composable

--- a/packages/smrt-android/scripts/validate-android.mjs
+++ b/packages/smrt-android/scripts/validate-android.mjs
@@ -117,14 +117,44 @@ const SPEC = [
     path: `${LIB_ROOT}/platform/CustomTabAuthLauncher.kt`,
     mustContain: ['class CustomTabAuthLauncher(', ': ExternalAuthLauncher'],
   },
+  {
+    path: `${LIB_ROOT}/platform/AndroidEvidenceCaptureAdapter.kt`,
+    mustContain: [
+      'class AndroidEvidenceCaptureAdapter(',
+      ': EvidenceCapturePlatformAdapter',
+      'suspend fun captureOrPickPhoto(',
+      'FileProvider.getUriForFile(',
+    ],
+  },
+  {
+    path: `${LIB_ROOT}/platform/SmrtEvidenceFileProvider.kt`,
+    mustContain: ['class SmrtEvidenceFileProvider : FileProvider('],
+  },
+  {
+    // Library-shipped FileProvider: manifest-merge authority + paths resource.
+    path: 'library/src/main/AndroidManifest.xml',
+    mustContain: [
+      'com.happyvertical.smrt.android.platform.SmrtEvidenceFileProvider',
+      '${applicationId}.evidence.files',
+    ],
+  },
+  {
+    path: 'library/src/main/res/xml/smrt_evidence_file_paths.xml',
+    mustContain: ['<files-path', 'evidence/'],
+  },
   { path: `${LIB_TEST_ROOT}/platform/AdapterMappingTest.kt` },
+  { path: `${LIB_TEST_ROOT}/platform/EvidenceCaptureMappingTest.kt` },
   {
     path: `${SAMPLE_ROOT}/AndroidManifest.xml`,
-    mustContain: ['android.permission.CAMERA', 'android.permission.RECORD_AUDIO'],
+    mustContain: [
+      'android.permission.CAMERA',
+      'android.permission.RECORD_AUDIO',
+      'android.permission.ACCESS_FINE_LOCATION',
+    ],
   },
   {
     path: `${SAMPLE_ROOT}/kotlin/com/happyvertical/smrt/android/sample/MainActivity.kt`,
-    mustContain: ['MobileShellScaffold(', 'MobileTheme {'],
+    mustContain: ['MobileShellScaffold(', 'MobileTheme {', 'CaptureTab('],
   },
 ];
 

--- a/packages/smrt-ios/AGENTS.md
+++ b/packages/smrt-ios/AGENTS.md
@@ -35,9 +35,14 @@ point for the KMP framework, so there are no duplicate static symbols.
   `IOSDeviceCapabilityAdapter` (`DeviceCapabilityAdapter`),
   `DataScannerBarcodeScanner` (`BarcodeScanner`, **net-new** + `BarcodeScannerPreview`),
   `FoundationModelsLanguageModel` (`OnDeviceLanguageModel`), `IOSSpeechTranscriber`
-  (`SpeechTranscriber`).
+  (`SpeechTranscriber`), and `IOSEvidenceCaptureAdapter`
+  (`EvidenceCapturePlatformAdapter`; drive-to-completion `captureOrPickPhoto` —
+  presents `UIImagePickerController`/`PHPickerViewController`, bridges the
+  delegate into `async`, copies into `Documents/Evidence/` with
+  security-scoped-resource handling, CryptoKit sha256 pin, `CLLocationManager`
+  geo sidecar; simulator falls back to the photo picker; #1880).
 - `Sample/SmrtIosSample/` — the demo app proving real shared logic (durable pack
-  store + write-queue, adapters, theme/shell). Never published.
+  store + write-queue, adapters, evidence capture, theme/shell). Never published.
 - `Tests/SmrtIosTests/` — XCTest over the pure seam-vocabulary mappings.
 - `project.yml` — XcodeGen spec. `Frameworks/SmrtMobile.framework` is staged by
   the validator; both are git-ignored.

--- a/packages/smrt-ios/Sample/SmrtIosSample/SampleScreens.swift
+++ b/packages/smrt-ios/Sample/SmrtIosSample/SampleScreens.swift
@@ -27,6 +27,7 @@ struct RootView: View {
         switch id {
         case "packs": return "shippingbox"
         case "scan": return "barcode.viewfinder"
+        case "capture": return "camera"
         case "device": return "iphone.gen3"
         default: return "circle"
         }
@@ -37,6 +38,7 @@ struct RootView: View {
         switch id {
         case "packs": PacksScreen(model: model)
         case "scan": ScanScreen(model: model)
+        case "capture": CaptureScreen(model: model)
         case "device": DeviceScreen(model: model)
         default: EmptyView()
         }
@@ -126,6 +128,85 @@ struct ScanScreen: View {
             }
             MobileSectionLabel("Last scan")
             MobileStatusPill(model.lastBarcode, color: status.info)
+        }
+    }
+}
+
+struct CaptureScreen: View {
+    @ObservedObject var model: SampleModel
+    @Environment(\.mobileSpacing) private var spacing
+    @Environment(\.mobileStatusColors) private var status
+
+    var body: some View {
+        ScreenScaffold(title: "Evidence Capture", subtitle: "IOSEvidenceCaptureAdapter → EvidenceCaptureResult") {
+            Button(model.capturing ? "Capturing…" : "Capture evidence") {
+                Task { await model.captureEvidence() }
+            }
+            .buttonStyle(.borderedProminent)
+            .frame(maxWidth: .infinity)
+            .disabled(model.capturing)
+
+            MobileResultCard {
+                Text(model.captureStatus)
+                    .font(MobileTypography.bodyMedium)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(14)
+            }
+
+            if let asset = model.lastCapture?.localAsset {
+                MobileSectionLabel("Stored asset", trailing: asset.storageState)
+                MobileResultCard {
+                    VStack(alignment: .leading, spacing: spacing.tightGap) {
+                        Text(asset.fileName).font(MobileTypography.bodyLarge)
+                        Text("\(asset.sizeBytes?.int64Value ?? 0) bytes · \(asset.captureSource) · \(asset.storageRoot)")
+                            .font(MobileTypography.bodySmall)
+                        if !asset.sha256.isEmpty {
+                            Text("sha256 \(asset.sha256.prefix(16))…")
+                                .font(MobileTypography.bodySmall.monospaced())
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(14)
+                }
+            }
+
+            if let capture = model.lastCapture {
+                MobileSectionLabel("Geo sidecar", trailing: capture.location.gpsStatus)
+                MobileResultCard {
+                    Text(geoText(capture.location))
+                        .font(MobileTypography.bodyMedium)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(14)
+                }
+
+                MobileSectionLabel("Permissions")
+                HStack(spacing: spacing.tightGap) {
+                    permissionPill("Camera", capture.permissions.cameraStatus)
+                    permissionPill("Photos", capture.permissions.photoLibraryStatus)
+                    permissionPill("Location", capture.permissions.locationStatus)
+                }
+            }
+        }
+    }
+
+    private func geoText(_ location: EvidenceLocationMetadata) -> String {
+        if location.gpsStatus == "available" {
+            return "\(location.latitude), \(location.longitude) (±\(location.accuracyMeters)m)"
+        }
+        return location.unavailableReason.isEmpty ? "unavailable" : location.unavailableReason
+    }
+
+    @ViewBuilder
+    private func permissionPill(_ label: String, _ value: String) -> some View {
+        MobileStatusPill("\(label): \(value)", color: color(for: value))
+    }
+
+    private func color(for permissionStatus: String) -> Color {
+        switch permissionStatus {
+        case EvidencePermissionStatus.shared.GRANTED: return status.go
+        case EvidencePermissionStatus.shared.DENIED: return status.stop
+        case EvidencePermissionStatus.shared.NOT_DETERMINED: return status.caution
+        default: return status.neutral
         }
     }
 }

--- a/packages/smrt-ios/Sample/SmrtIosSample/SmrtIosSampleApp.swift
+++ b/packages/smrt-ios/Sample/SmrtIosSample/SmrtIosSampleApp.swift
@@ -28,6 +28,7 @@ final class SampleModel: ObservableObject {
     let barcodeScanner = DataScannerBarcodeScanner()
     let deviceAdapter = IOSDeviceCapabilityAdapter()
     let languageModel = FoundationModelsLanguageModel()
+    let evidenceAdapter = IOSEvidenceCaptureAdapter()
     private let hasher = CryptoKitSha256Hasher.shared
 
     @Published var shell: MobileShellState
@@ -36,6 +37,9 @@ final class SampleModel: ObservableObject {
     @Published var lastBarcode: String = "—"
     @Published var capabilities: MobileDeviceCapabilities?
     @Published var llm: LanguageModelAvailability?
+    @Published var lastCapture: EvidenceCaptureResult?
+    @Published var captureStatus: String = "Capture a full-resolution evidence photo — SHA-256 pinned, geo sidecar."
+    @Published var capturing = false
     @Published var status: String = ""
 
     init() {
@@ -47,6 +51,7 @@ final class SampleModel: ObservableObject {
             tabs: [
                 MobileTab(id: "packs", label: "Packs"),
                 MobileTab(id: "scan", label: "Scan"),
+                MobileTab(id: "capture", label: "Capture"),
                 MobileTab(id: "device", label: "Device"),
             ],
             selectedTabId: "packs",
@@ -120,6 +125,28 @@ final class SampleModel: ObservableObject {
 
     func stopScanning() {
         barcodeScanner.stopScanning()
+    }
+
+    /// Drives a real capture: present camera/picker, verify + hash + geo-tag,
+    /// then publish the `EvidenceCaptureResult`.
+    func captureEvidence() async {
+        capturing = true
+        captureStatus = "Capturing…"
+        do {
+            let result = try await evidenceAdapter.captureOrPickPhoto(
+                request: EvidenceCaptureRequest(
+                    tenantId: "",
+                    contextIds: ["checklistItemId": "sample-capture"],
+                    preferredSource: EvidenceCaptureSource.shared.CAMERA
+                )
+            )
+            lastCapture = result
+            captureStatus = result.userMessage
+        } catch {
+            lastCapture = nil
+            captureStatus = "capture failed: \(error.localizedDescription)"
+        }
+        capturing = false
     }
 }
 

--- a/packages/smrt-ios/Sources/SmrtIos/Platform/IOSEvidenceCaptureAdapter.swift
+++ b/packages/smrt-ios/Sources/SmrtIos/Platform/IOSEvidenceCaptureAdapter.swift
@@ -28,7 +28,7 @@ import UniformTypeIdentifiers
 /// platform-neutral `app_private`.
 public final class IOSEvidenceCaptureAdapter: NSObject, EvidenceCapturePlatformAdapter,
     UIImagePickerControllerDelegate, UINavigationControllerDelegate,
-    PHPickerViewControllerDelegate {
+    PHPickerViewControllerDelegate, CLLocationManagerDelegate {
 
     /// Resolves the view controller to present from; defaults to the key
     /// window's top-most controller. Injectable for hosts that manage their own
@@ -36,13 +36,16 @@ public final class IOSEvidenceCaptureAdapter: NSObject, EvidenceCapturePlatformA
     private let presenter: () -> UIViewController?
     private let locationManager = CLLocationManager()
 
-    // Touched only on the main thread (present setup + UIKit delegate callbacks).
+    // Touched only on the main thread (present setup + UIKit/CoreLocation callbacks).
     private var pendingContinuation: CheckedContinuation<URL?, Error>?
     private var pendingSegment: String = "evidence"
+    private var authContinuation: CheckedContinuation<Void, Never>?
+    private var fixContinuation: CheckedContinuation<CLLocation?, Never>?
 
     public init(presenter: (() -> UIViewController?)? = nil) {
         self.presenter = presenter ?? { IOSEvidenceCaptureAdapter.topViewController() }
         super.init()
+        locationManager.delegate = self
     }
 
     // MARK: - EvidenceCapturePlatformAdapter
@@ -51,11 +54,19 @@ public final class IOSEvidenceCaptureAdapter: NSObject, EvidenceCapturePlatformA
         let segment = Self.evidenceCaptureSegment(request: request)
         let location = try await currentLocationMetadata()
 
-        let cameraAvailable = UIImagePickerController.isSourceTypeAvailable(.camera)
+        // Camera hardware presence is not permission: isSourceTypeAvailable(.camera)
+        // stays true even when the user denied access, so gate the camera path on
+        // authorization (requesting it if undetermined) and fall back to the photo
+        // picker on denial — otherwise the camera UI cannot complete a capture.
+        let cameraHardware = UIImagePickerController.isSourceTypeAvailable(.camera)
+        let wantsCameraSource =
+            request.preferredSource == EvidenceCaptureSource.shared.CAMERA && cameraHardware
+        let cameraAuthorized = wantsCameraSource ? await resolveCameraAuthorization() : false
+
         let permissions = EvidenceNativePermissionState(
             cameraStatus: Self.evidenceCameraStatus(
                 AVCaptureDevice.authorizationStatus(for: .video),
-                cameraAvailable: cameraAvailable
+                cameraAvailable: cameraHardware
             ),
             photoLibraryStatus: Self.evidencePhotoStatus(
                 PHPhotoLibrary.authorizationStatus(for: .readWrite)
@@ -63,13 +74,11 @@ public final class IOSEvidenceCaptureAdapter: NSObject, EvidenceCapturePlatformA
             locationStatus: location.permissionStatus
         )
 
-        let wantsCamera =
-            request.preferredSource == EvidenceCaptureSource.shared.CAMERA && cameraAvailable
-        let source = wantsCamera
+        let source = cameraAuthorized
             ? EvidenceCaptureSource.shared.CAMERA
             : EvidenceCaptureSource.shared.NATIVE_PICKER
 
-        let capturedURL = wantsCamera
+        let capturedURL = cameraAuthorized
             ? try await presentCamera(segment: segment)
             : try await presentPhotoPicker(segment: segment)
 
@@ -93,15 +102,93 @@ public final class IOSEvidenceCaptureAdapter: NSObject, EvidenceCapturePlatformA
     }
 
     public func currentLocationMetadata() async throws -> EvidenceLocationMetadata {
-        let status = locationManager.authorizationStatus
-        // Request once if undetermined so later captures can carry a fix.
+        var status = locationManager.authorizationStatus
+        // Await the user's decision so the sidecar reflects the resolved status,
+        // not the stale `notDetermined` — otherwise a first-use grant is missed.
         if status == .notDetermined {
-            await MainActor.run { self.locationManager.requestWhenInUseAuthorization() }
+            await awaitAuthorizationDecision()
+            status = locationManager.authorizationStatus
+        }
+        let mapping = Self.mapLocationAuthorization(status)
+        var location = locationManager.location
+        // No cached fix yet (common right after a first-use grant): request one.
+        if mapping == .granted, location == nil {
+            location = await requestOneShotFix()
         }
         return Self.evidenceLocationMetadata(
-            authorization: Self.mapLocationAuthorization(status),
-            snapshot: locationManager.location.map(Self.snapshot(from:))
+            authorization: mapping,
+            snapshot: location.map(Self.snapshot(from:))
         )
+    }
+
+    // MARK: - Permission + location resolution
+
+    /// Camera authorization → whether the camera path can proceed. Requests
+    /// access when undetermined; denied/restricted routes to the photo picker.
+    private func resolveCameraAuthorization() async -> Bool {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized: return true
+        case .notDetermined: return await AVCaptureDevice.requestAccess(for: .video)
+        default: return false
+        }
+    }
+
+    /// Awaits the location authorization prompt's resolution (or a safety-net
+    /// timeout if the app is backgrounded mid-prompt).
+    private func awaitAuthorizationDecision() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            Task { @MainActor in
+                self.authContinuation = continuation
+                self.locationManager.requestWhenInUseAuthorization()
+            }
+            Task {
+                try? await Task.sleep(nanoseconds: 15_000_000_000)
+                await MainActor.run { self.resumeAuth() }
+            }
+        }
+    }
+
+    /// Requests a single live fix (bounded), for the common first-use case where
+    /// no cached last-known location exists yet.
+    private func requestOneShotFix() async -> CLLocation? {
+        await withCheckedContinuation { (continuation: CheckedContinuation<CLLocation?, Never>) in
+            Task { @MainActor in
+                self.fixContinuation = continuation
+                self.locationManager.requestLocation()
+            }
+            Task {
+                try? await Task.sleep(nanoseconds: 8_000_000_000)
+                await MainActor.run { self.resumeFix(nil) }
+            }
+        }
+    }
+
+    private func resumeAuth() {
+        let continuation = authContinuation
+        authContinuation = nil
+        continuation?.resume()
+    }
+
+    private func resumeFix(_ location: CLLocation?) {
+        let continuation = fixContinuation
+        fixContinuation = nil
+        continuation?.resume(returning: location)
+    }
+
+    // MARK: - CLLocationManagerDelegate
+
+    public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        // Ignore the initial/undetermined callback; resume only on a real decision.
+        guard manager.authorizationStatus != .notDetermined else { return }
+        resumeAuth()
+    }
+
+    public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        resumeFix(locations.last)
+    }
+
+    public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        resumeFix(nil)
     }
 
     // MARK: - Presentation (delegate → async bridge)
@@ -109,6 +196,10 @@ public final class IOSEvidenceCaptureAdapter: NSObject, EvidenceCapturePlatformA
     private func presentCamera(segment: String) async throws -> URL? {
         try await withCheckedThrowingContinuation { continuation in
             Task { @MainActor in
+                guard self.pendingContinuation == nil else {
+                    continuation.resume(throwing: EvidenceCaptureError.captureInProgress)
+                    return
+                }
                 guard let host = self.presenter() else {
                     continuation.resume(throwing: EvidenceCaptureError.noPresenter)
                     return
@@ -126,6 +217,10 @@ public final class IOSEvidenceCaptureAdapter: NSObject, EvidenceCapturePlatformA
     private func presentPhotoPicker(segment: String) async throws -> URL? {
         try await withCheckedThrowingContinuation { continuation in
             Task { @MainActor in
+                guard self.pendingContinuation == nil else {
+                    continuation.resume(throwing: EvidenceCaptureError.captureInProgress)
+                    return
+                }
                 guard let host = self.presenter() else {
                     continuation.resume(throwing: EvidenceCaptureError.noPresenter)
                     return
@@ -242,29 +337,32 @@ public final class IOSEvidenceCaptureAdapter: NSObject, EvidenceCapturePlatformA
     /// Reads the stored file and pins it (size + sha256), mapping to a
     /// `stored_offline` or `missing_local_file` asset.
     private func finalize(url: URL, source: String) -> EvidenceAssetRef {
-        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
-        let size = (attributes?[.size] as? NSNumber)?.int64Value ?? 0
-        let stored = FileManager.default.fileExists(atPath: url.path) && size > 0
-        let sha = stored
-            ? CryptoKitSha256Hasher.sha256Hex(data: (try? Data(contentsOf: url)) ?? Data())
-            : ""
+        let attributeSize = (try? FileManager.default.attributesOfItem(atPath: url.path))
+            .flatMap { ($0[.size] as? NSNumber)?.int64Value }
+        // Verify by reading the bytes we hash: a read failure must NOT mark the
+        // asset stored with the sha256 of empty data (a false-positive pin). Carry
+        // the on-disk size (if any) for telemetry, but stay `missing_local_file`.
+        let data = try? Data(contentsOf: url)
+        let verified = data.map { !$0.isEmpty } ?? false
+        let sizeBytes: Int64? = verified ? Int64(data?.count ?? 0) : attributeSize
+        let sha = verified ? CryptoKitSha256Hasher.sha256Hex(data: data ?? Data()) : ""
         let nowMillis = Int64(Date().timeIntervalSince1970 * 1000)
         return EvidenceAssetRef(
             assetId: url.deletingPathExtension().lastPathComponent,
             localUri: url.absoluteString,
             fileName: url.lastPathComponent,
             contentType: Self.contentType(forExtension: url.pathExtension),
-            sizeBytes: stored ? KotlinLong(longLong: size) : nil,
+            sizeBytes: sizeBytes.map { KotlinLong(longLong: $0) },
             sha256: sha,
             captureSource: source,
             originalUri: "",
             storageRoot: "app_private",
             relativePath: "Evidence/\(url.lastPathComponent)",
-            storageState: stored
+            storageState: verified
                 ? EvidenceAssetStorageState.shared.STORED_OFFLINE
                 : EvidenceAssetStorageState.shared.MISSING_LOCAL_FILE,
-            offlineSafe: stored,
-            persistedAt: stored ? SmrtMobileIos.shared.instantFromEpochMillis(epochMillis: nowMillis) : nil
+            offlineSafe: verified,
+            persistedAt: verified ? SmrtMobileIos.shared.instantFromEpochMillis(epochMillis: nowMillis) : nil
         )
     }
 
@@ -421,4 +519,5 @@ public final class IOSEvidenceCaptureAdapter: NSObject, EvidenceCapturePlatformA
 enum EvidenceCaptureError: Error {
     case noPresenter
     case imageEncodingFailed
+    case captureInProgress
 }

--- a/packages/smrt-ios/Sources/SmrtIos/Platform/IOSEvidenceCaptureAdapter.swift
+++ b/packages/smrt-ios/Sources/SmrtIos/Platform/IOSEvidenceCaptureAdapter.swift
@@ -1,0 +1,424 @@
+import AVFoundation
+import CoreLocation
+import Foundation
+import Photos
+import PhotosUI
+import SmrtMobile
+import UIKit
+import UniformTypeIdentifiers
+
+/// iOS implementation of smrt-mobile's `EvidenceCapturePlatformAdapter`
+/// (issue #1880; joint iOS+Android design record on that issue). The real
+/// KMP-backed conformance amaru never wired up — its `EvidenceCaptureBridge`
+/// was a flat 18-field struct that implemented no interface and was dead code.
+///
+/// **Drive-to-completion**: `captureOrPickPhoto` presents the OS camera
+/// (`UIImagePickerController`) or the system photo picker
+/// (`PHPickerViewController`), bridges the delegate callback into `async` via a
+/// checked continuation, copies the result into `Documents/Evidence/`, computes
+/// a SHA-256 pin, verifies the file, and returns a `stored_offline`
+/// `EvidenceAssetRef` (or a nil asset on cancel). One awaitable call.
+///
+/// Simulator has no camera (`isSourceTypeAvailable(.camera) == false`), so it
+/// falls back to the photo picker (which works with the simulator's sample
+/// photos) — the path the CI native lane exercises. Picker URLs are copied with
+/// `startAccessingSecurityScopedResource()` / `defer stop`. Geo travels as an
+/// `EvidenceLocationMetadata` **sidecar** (never EXIF, ADR Correction 2); the
+/// SHA-256 pin reuses `CryptoKitSha256Hasher`; storage root is the
+/// platform-neutral `app_private`.
+public final class IOSEvidenceCaptureAdapter: NSObject, EvidenceCapturePlatformAdapter,
+    UIImagePickerControllerDelegate, UINavigationControllerDelegate,
+    PHPickerViewControllerDelegate {
+
+    /// Resolves the view controller to present from; defaults to the key
+    /// window's top-most controller. Injectable for hosts that manage their own
+    /// presentation.
+    private let presenter: () -> UIViewController?
+    private let locationManager = CLLocationManager()
+
+    // Touched only on the main thread (present setup + UIKit delegate callbacks).
+    private var pendingContinuation: CheckedContinuation<URL?, Error>?
+    private var pendingSegment: String = "evidence"
+
+    public init(presenter: (() -> UIViewController?)? = nil) {
+        self.presenter = presenter ?? { IOSEvidenceCaptureAdapter.topViewController() }
+        super.init()
+    }
+
+    // MARK: - EvidenceCapturePlatformAdapter
+
+    public func captureOrPickPhoto(request: EvidenceCaptureRequest) async throws -> EvidenceCaptureResult {
+        let segment = Self.evidenceCaptureSegment(request: request)
+        let location = try await currentLocationMetadata()
+
+        let cameraAvailable = UIImagePickerController.isSourceTypeAvailable(.camera)
+        let permissions = EvidenceNativePermissionState(
+            cameraStatus: Self.evidenceCameraStatus(
+                AVCaptureDevice.authorizationStatus(for: .video),
+                cameraAvailable: cameraAvailable
+            ),
+            photoLibraryStatus: Self.evidencePhotoStatus(
+                PHPhotoLibrary.authorizationStatus(for: .readWrite)
+            ),
+            locationStatus: location.permissionStatus
+        )
+
+        let wantsCamera =
+            request.preferredSource == EvidenceCaptureSource.shared.CAMERA && cameraAvailable
+        let source = wantsCamera
+            ? EvidenceCaptureSource.shared.CAMERA
+            : EvidenceCaptureSource.shared.NATIVE_PICKER
+
+        let capturedURL = wantsCamera
+            ? try await presentCamera(segment: segment)
+            : try await presentPhotoPicker(segment: segment)
+
+        guard let url = capturedURL else {
+            return EvidenceCaptureResult(
+                localAsset: nil,
+                location: location,
+                permissions: permissions,
+                captureAvailable: true,
+                userMessage: "Capture cancelled."
+            )
+        }
+        let asset = finalize(url: url, source: source)
+        return EvidenceCaptureResult(
+            localAsset: asset,
+            location: location,
+            permissions: permissions,
+            captureAvailable: true,
+            userMessage: Self.capturedMessage(asset)
+        )
+    }
+
+    public func currentLocationMetadata() async throws -> EvidenceLocationMetadata {
+        let status = locationManager.authorizationStatus
+        // Request once if undetermined so later captures can carry a fix.
+        if status == .notDetermined {
+            await MainActor.run { self.locationManager.requestWhenInUseAuthorization() }
+        }
+        return Self.evidenceLocationMetadata(
+            authorization: Self.mapLocationAuthorization(status),
+            snapshot: locationManager.location.map(Self.snapshot(from:))
+        )
+    }
+
+    // MARK: - Presentation (delegate → async bridge)
+
+    private func presentCamera(segment: String) async throws -> URL? {
+        try await withCheckedThrowingContinuation { continuation in
+            Task { @MainActor in
+                guard let host = self.presenter() else {
+                    continuation.resume(throwing: EvidenceCaptureError.noPresenter)
+                    return
+                }
+                self.pendingContinuation = continuation
+                self.pendingSegment = segment
+                let picker = UIImagePickerController()
+                picker.sourceType = .camera
+                picker.delegate = self
+                host.present(picker, animated: true)
+            }
+        }
+    }
+
+    private func presentPhotoPicker(segment: String) async throws -> URL? {
+        try await withCheckedThrowingContinuation { continuation in
+            Task { @MainActor in
+                guard let host = self.presenter() else {
+                    continuation.resume(throwing: EvidenceCaptureError.noPresenter)
+                    return
+                }
+                self.pendingContinuation = continuation
+                self.pendingSegment = segment
+                var config = PHPickerConfiguration()
+                config.filter = .images
+                config.selectionLimit = 1
+                let picker = PHPickerViewController(configuration: config)
+                picker.delegate = self
+                host.present(picker, animated: true)
+            }
+        }
+    }
+
+    /// Returns and clears the pending continuation (main-thread only).
+    private func takePending() -> CheckedContinuation<URL?, Error>? {
+        let continuation = pendingContinuation
+        pendingContinuation = nil
+        return continuation
+    }
+
+    // MARK: - UIImagePickerControllerDelegate (camera)
+
+    public func imagePickerController(
+        _ picker: UIImagePickerController,
+        didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+    ) {
+        picker.dismiss(animated: true)
+        guard let continuation = takePending() else { return }
+        guard let image = info[.originalImage] as? UIImage,
+              let data = image.jpegData(compressionQuality: 0.95) else {
+            continuation.resume(throwing: EvidenceCaptureError.imageEncodingFailed)
+            return
+        }
+        do {
+            let url = try writeIntoEvidence(data: data, segment: pendingSegment, ext: "jpg")
+            continuation.resume(returning: url)
+        } catch {
+            continuation.resume(throwing: error)
+        }
+    }
+
+    public func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        picker.dismiss(animated: true)
+        takePending()?.resume(returning: nil)
+    }
+
+    // MARK: - PHPickerViewControllerDelegate (photo library)
+
+    public func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true)
+        guard let continuation = takePending() else { return }
+        let segment = pendingSegment
+        guard let provider = results.first?.itemProvider else {
+            continuation.resume(returning: nil)
+            return
+        }
+        provider.loadFileRepresentation(forTypeIdentifier: UTType.image.identifier) { [weak self] tempURL, error in
+            if let error {
+                continuation.resume(throwing: error)
+                return
+            }
+            guard let self, let tempURL else {
+                continuation.resume(returning: nil)
+                return
+            }
+            // Picker URLs may be security-scoped (e.g. iCloud Drive); harmless no-op otherwise.
+            let scoped = tempURL.startAccessingSecurityScopedResource()
+            defer { if scoped { tempURL.stopAccessingSecurityScopedResource() } }
+            let ext = tempURL.pathExtension.isEmpty ? "jpg" : tempURL.pathExtension.lowercased()
+            do {
+                let url = try self.copyIntoEvidence(from: tempURL, segment: segment, ext: ext)
+                continuation.resume(returning: url)
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    // MARK: - Storage
+
+    private func evidenceDirectory() throws -> URL {
+        let base = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let directory = base.appendingPathComponent("Evidence", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func evidenceFileURL(segment: String, ext: String) throws -> URL {
+        let assetId = Self.evidenceAssetId(
+            segment: segment,
+            epochMillis: Int64(Date().timeIntervalSince1970 * 1000)
+        )
+        return try evidenceDirectory().appendingPathComponent("\(assetId).\(ext)")
+    }
+
+    private func writeIntoEvidence(data: Data, segment: String, ext: String) throws -> URL {
+        let url = try evidenceFileURL(segment: segment, ext: ext)
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+
+    private func copyIntoEvidence(from source: URL, segment: String, ext: String) throws -> URL {
+        let url = try evidenceFileURL(segment: segment, ext: ext)
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
+        }
+        try FileManager.default.copyItem(at: source, to: url)
+        return url
+    }
+
+    /// Reads the stored file and pins it (size + sha256), mapping to a
+    /// `stored_offline` or `missing_local_file` asset.
+    private func finalize(url: URL, source: String) -> EvidenceAssetRef {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+        let size = (attributes?[.size] as? NSNumber)?.int64Value ?? 0
+        let stored = FileManager.default.fileExists(atPath: url.path) && size > 0
+        let sha = stored
+            ? CryptoKitSha256Hasher.sha256Hex(data: (try? Data(contentsOf: url)) ?? Data())
+            : ""
+        let nowMillis = Int64(Date().timeIntervalSince1970 * 1000)
+        return EvidenceAssetRef(
+            assetId: url.deletingPathExtension().lastPathComponent,
+            localUri: url.absoluteString,
+            fileName: url.lastPathComponent,
+            contentType: Self.contentType(forExtension: url.pathExtension),
+            sizeBytes: stored ? KotlinLong(longLong: size) : nil,
+            sha256: sha,
+            captureSource: source,
+            originalUri: "",
+            storageRoot: "app_private",
+            relativePath: "Evidence/\(url.lastPathComponent)",
+            storageState: stored
+                ? EvidenceAssetStorageState.shared.STORED_OFFLINE
+                : EvidenceAssetStorageState.shared.MISSING_LOCAL_FILE,
+            offlineSafe: stored,
+            persistedAt: stored ? SmrtMobileIos.shared.instantFromEpochMillis(epochMillis: nowMillis) : nil
+        )
+    }
+
+    // MARK: - Top view controller
+
+    static func topViewController() -> UIViewController? {
+        let scenes = UIApplication.shared.connectedScenes
+        let windowScene = scenes.first { $0.activationState == .foregroundActive } as? UIWindowScene
+            ?? scenes.compactMap { $0 as? UIWindowScene }.first
+        let keyWindow = windowScene?.windows.first { $0.isKeyWindow } ?? windowScene?.windows.first
+        var top = keyWindow?.rootViewController
+        while let presented = top?.presentedViewController {
+            top = presented
+        }
+        return top
+    }
+
+    // MARK: - Pure mappings (unit-tested, device-free)
+
+    enum EvidenceLocationAuthorization {
+        case granted, denied, notDetermined, unavailable
+    }
+
+    struct EvidenceLocationSnapshot {
+        let latitude: Double
+        let longitude: Double
+        let accuracyMeters: Double
+        let timestampMillis: Int64
+    }
+
+    /// First non-blank context id (sorted by key for determinism), else `evidence`.
+    static func evidenceCaptureSegment(request: EvidenceCaptureRequest) -> String {
+        let ids = request.contextIds
+        let firstValue = ids.keys.sorted()
+            .compactMap { key -> String? in
+                let value = ids[key] ?? ""
+                return value.trimmingCharacters(in: .whitespaces).isEmpty ? nil : value
+            }
+            .first
+        guard let firstValue else { return "evidence" }
+        return sanitizeSegment(firstValue)
+    }
+
+    static func sanitizeSegment(_ value: String) -> String {
+        let sanitized = value.replacingOccurrences(
+            of: "[^A-Za-z0-9_-]",
+            with: "_",
+            options: .regularExpression
+        )
+        return sanitized.isEmpty ? "evidence" : sanitized
+    }
+
+    static func evidenceAssetId(segment: String, epochMillis: Int64) -> String {
+        "asset_\(segment)_\(epochMillis)"
+    }
+
+    static func contentType(forExtension ext: String) -> String {
+        switch ext.lowercased() {
+        case "png": return "image/png"
+        case "heic", "heif": return "image/heic"
+        case "webp": return "image/webp"
+        case "gif": return "image/gif"
+        default: return "image/jpeg"
+        }
+    }
+
+    static func evidenceCameraStatus(_ status: AVAuthorizationStatus, cameraAvailable: Bool) -> String {
+        guard cameraAvailable else { return EvidencePermissionStatus.shared.UNAVAILABLE }
+        switch status {
+        case .authorized: return EvidencePermissionStatus.shared.GRANTED
+        case .denied, .restricted: return EvidencePermissionStatus.shared.DENIED
+        case .notDetermined: return EvidencePermissionStatus.shared.NOT_DETERMINED
+        @unknown default: return EvidencePermissionStatus.shared.UNAVAILABLE
+        }
+    }
+
+    static func evidencePhotoStatus(_ status: PHAuthorizationStatus) -> String {
+        switch status {
+        case .authorized, .limited: return EvidencePermissionStatus.shared.GRANTED
+        case .denied, .restricted: return EvidencePermissionStatus.shared.DENIED
+        case .notDetermined: return EvidencePermissionStatus.shared.NOT_DETERMINED
+        @unknown default: return EvidencePermissionStatus.shared.UNAVAILABLE
+        }
+    }
+
+    static func mapLocationAuthorization(_ status: CLAuthorizationStatus) -> EvidenceLocationAuthorization {
+        switch status {
+        case .authorizedAlways, .authorizedWhenInUse: return .granted
+        case .denied, .restricted: return .denied
+        case .notDetermined: return .notDetermined
+        @unknown default: return .unavailable
+        }
+    }
+
+    static func snapshot(from location: CLLocation) -> EvidenceLocationSnapshot {
+        EvidenceLocationSnapshot(
+            latitude: location.coordinate.latitude,
+            longitude: location.coordinate.longitude,
+            accuracyMeters: location.horizontalAccuracy,
+            timestampMillis: Int64(location.timestamp.timeIntervalSince1970 * 1000)
+        )
+    }
+
+    /// Pure projection of location authorization + last-known fix onto the sidecar.
+    static func evidenceLocationMetadata(
+        authorization: EvidenceLocationAuthorization,
+        snapshot: EvidenceLocationSnapshot?
+    ) -> EvidenceLocationMetadata {
+        switch authorization {
+        case .denied:
+            return unavailableLocation(EvidencePermissionStatus.shared.DENIED, "permission_denied")
+        case .notDetermined:
+            return unavailableLocation(EvidencePermissionStatus.shared.NOT_DETERMINED, "permission_not_requested")
+        case .unavailable:
+            return unavailableLocation(EvidencePermissionStatus.shared.UNAVAILABLE, "authorization_unknown")
+        case .granted:
+            guard let snapshot else {
+                return unavailableLocation(EvidencePermissionStatus.shared.GRANTED, "last_location_unavailable")
+            }
+            return EvidenceLocationMetadata(
+                permissionStatus: EvidencePermissionStatus.shared.GRANTED,
+                gpsStatus: "available",
+                latitude: String(snapshot.latitude),
+                longitude: String(snapshot.longitude),
+                accuracyMeters: String(snapshot.accuracyMeters),
+                provider: "core_location",
+                capturedAt: SmrtMobileIos.shared.instantFromEpochMillis(epochMillis: snapshot.timestampMillis),
+                unavailableReason: ""
+            )
+        }
+    }
+
+    private static func unavailableLocation(_ permissionStatus: String, _ reason: String) -> EvidenceLocationMetadata {
+        EvidenceLocationMetadata(
+            permissionStatus: permissionStatus,
+            gpsStatus: "unavailable",
+            latitude: "",
+            longitude: "",
+            accuracyMeters: "",
+            provider: "",
+            capturedAt: nil,
+            unavailableReason: reason
+        )
+    }
+
+    static func capturedMessage(_ asset: EvidenceAssetRef) -> String {
+        if asset.storageState == EvidenceAssetStorageState.shared.STORED_OFFLINE {
+            return "Evidence stored offline (\(asset.sizeBytes?.int64Value ?? 0) bytes)."
+        }
+        return "Capture could not be verified; the local file is missing."
+    }
+}
+
+enum EvidenceCaptureError: Error {
+    case noPresenter
+    case imageEncodingFailed
+}

--- a/packages/smrt-ios/Tests/SmrtIosTests/EvidenceCaptureMappingTests.swift
+++ b/packages/smrt-ios/Tests/SmrtIosTests/EvidenceCaptureMappingTests.swift
@@ -1,0 +1,124 @@
+import AVFoundation
+import CoreLocation
+import Foundation
+import Photos
+import XCTest
+
+@testable import SmrtIos
+import SmrtMobile
+
+/// Pure-mapping tests for the evidence adapter (issue #1880) — the native
+/// state → shared-DTO projection, exercised device-free. The camera/picker
+/// drive itself needs an on-device UI and is verified by the sample app.
+final class EvidenceCaptureMappingTests: XCTestCase {
+
+    func testCaptureSegmentPicksFirstNonBlankBySortedKey() {
+        XCTAssertEqual(
+            IOSEvidenceCaptureAdapter.evidenceCaptureSegment(
+                request: EvidenceCaptureRequest(
+                    tenantId: "",
+                    contextIds: ["checklistItemId": "checklist-1"],
+                    preferredSource: EvidenceCaptureSource.shared.CAMERA
+                )
+            ),
+            "checklist-1"
+        )
+        // Sorted by key → "a" wins over "z" (deterministic regardless of order).
+        XCTAssertEqual(
+            IOSEvidenceCaptureAdapter.evidenceCaptureSegment(
+                request: EvidenceCaptureRequest(
+                    tenantId: "",
+                    contextIds: ["z": "second", "a": "first"],
+                    preferredSource: EvidenceCaptureSource.shared.CAMERA
+                )
+            ),
+            "first"
+        )
+        XCTAssertEqual(
+            IOSEvidenceCaptureAdapter.evidenceCaptureSegment(
+                request: EvidenceCaptureRequest(
+                    tenantId: "",
+                    contextIds: [:],
+                    preferredSource: EvidenceCaptureSource.shared.CAMERA
+                )
+            ),
+            "evidence"
+        )
+    }
+
+    func testSanitizeSegmentStripsUnsafeCharacters() {
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.sanitizeSegment("a/b c"), "a_b_c")
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.sanitizeSegment("keep-this_1"), "keep-this_1")
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.sanitizeSegment(""), "evidence")
+    }
+
+    func testAssetIdComposesSegmentAndEpochMillis() {
+        XCTAssertEqual(
+            IOSEvidenceCaptureAdapter.evidenceAssetId(segment: "checklist-1", epochMillis: 1700),
+            "asset_checklist-1_1700"
+        )
+    }
+
+    func testContentTypeFromExtension() {
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.contentType(forExtension: "jpg"), "image/jpeg")
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.contentType(forExtension: "PNG"), "image/png")
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.contentType(forExtension: "heic"), "image/heic")
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.contentType(forExtension: "bin"), "image/jpeg")
+    }
+
+    func testCameraStatusMapsAuthorizationAndAvailability() {
+        let p = EvidencePermissionStatus.shared
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.evidenceCameraStatus(.authorized, cameraAvailable: true), p.GRANTED)
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.evidenceCameraStatus(.denied, cameraAvailable: true), p.DENIED)
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.evidenceCameraStatus(.notDetermined, cameraAvailable: true), p.NOT_DETERMINED)
+        // No camera (e.g. simulator) → unavailable regardless of authorization.
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.evidenceCameraStatus(.authorized, cameraAvailable: false), p.UNAVAILABLE)
+    }
+
+    func testPhotoStatusMapsAuthorization() {
+        let p = EvidencePermissionStatus.shared
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.evidencePhotoStatus(.authorized), p.GRANTED)
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.evidencePhotoStatus(.limited), p.GRANTED)
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.evidencePhotoStatus(.denied), p.DENIED)
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.evidencePhotoStatus(.notDetermined), p.NOT_DETERMINED)
+    }
+
+    func testLocationAuthorizationMapsToTriState() {
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.mapLocationAuthorization(.authorizedWhenInUse), .granted)
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.mapLocationAuthorization(.authorizedAlways), .granted)
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.mapLocationAuthorization(.denied), .denied)
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.mapLocationAuthorization(.restricted), .denied)
+        XCTAssertEqual(IOSEvidenceCaptureAdapter.mapLocationAuthorization(.notDetermined), .notDetermined)
+    }
+
+    func testLocationMetadataProjection() {
+        let p = EvidencePermissionStatus.shared
+
+        let denied = IOSEvidenceCaptureAdapter.evidenceLocationMetadata(authorization: .denied, snapshot: nil)
+        XCTAssertEqual(denied.gpsStatus, "unavailable")
+        XCTAssertEqual(denied.permissionStatus, p.DENIED)
+        XCTAssertEqual(denied.unavailableReason, "permission_denied")
+
+        let notDetermined = IOSEvidenceCaptureAdapter.evidenceLocationMetadata(authorization: .notDetermined, snapshot: nil)
+        XCTAssertEqual(notDetermined.permissionStatus, p.NOT_DETERMINED)
+        XCTAssertEqual(notDetermined.unavailableReason, "permission_not_requested")
+
+        let noFix = IOSEvidenceCaptureAdapter.evidenceLocationMetadata(authorization: .granted, snapshot: nil)
+        XCTAssertEqual(noFix.permissionStatus, p.GRANTED)
+        XCTAssertEqual(noFix.unavailableReason, "last_location_unavailable")
+
+        let snapshot = IOSEvidenceCaptureAdapter.EvidenceLocationSnapshot(
+            latitude: 45.5,
+            longitude: -73.6,
+            accuracyMeters: 8,
+            timestampMillis: 1_700_000_000_000
+        )
+        let available = IOSEvidenceCaptureAdapter.evidenceLocationMetadata(authorization: .granted, snapshot: snapshot)
+        XCTAssertEqual(available.gpsStatus, "available")
+        XCTAssertEqual(available.permissionStatus, p.GRANTED)
+        XCTAssertEqual(available.latitude, "45.5")
+        XCTAssertEqual(available.longitude, "-73.6")
+        XCTAssertEqual(available.accuracyMeters, "8.0")
+        XCTAssertEqual(available.provider, "core_location")
+    }
+}

--- a/packages/smrt-ios/project.yml
+++ b/packages/smrt-ios/project.yml
@@ -59,6 +59,10 @@ targets:
       - sdk: AuthenticationServices.framework
       - sdk: VisionKit.framework
       - sdk: Speech.framework
+      # Evidence capture: photo picker (PhotosUI/Photos) + geo sidecar (CoreLocation).
+      - sdk: CoreLocation.framework
+      - sdk: Photos.framework
+      - sdk: PhotosUI.framework
 
   SmrtIosTests:
     type: bundle.unit-test

--- a/packages/smrt-ios/scripts/validate-ios.mjs
+++ b/packages/smrt-ios/scripts/validate-ios.mjs
@@ -83,12 +83,36 @@ const SPEC = [
     mustContain: ['SmrtMobile.SpeechTranscriber', 'SFSpeechRecognizer'],
   },
   {
-    path: `${SAMPLE}/SmrtIosSampleApp.swift`,
-    mustContain: ['@main', 'MobileShellState', 'createOfflinePackStore'],
+    path: `${PLATFORM}/IOSEvidenceCaptureAdapter.swift`,
+    mustContain: [
+      ', EvidenceCapturePlatformAdapter',
+      'captureOrPickPhoto',
+      'startAccessingSecurityScopedResource',
+      'PHPickerViewController',
+    ],
   },
-  { path: `${SAMPLE}/SampleScreens.swift`, mustContain: ['MobileShellScaffold', 'MobileTheme'] },
-  { path: `${SAMPLE}/Info.plist`, mustContain: ['NSCameraUsageDescription', 'NSSpeechRecognitionUsageDescription'] },
+  {
+    path: `${SAMPLE}/SmrtIosSampleApp.swift`,
+    mustContain: ['@main', 'MobileShellState', 'createOfflinePackStore', 'IOSEvidenceCaptureAdapter'],
+  },
+  {
+    path: `${SAMPLE}/SampleScreens.swift`,
+    mustContain: ['MobileShellScaffold', 'MobileTheme', 'CaptureScreen'],
+  },
+  {
+    path: `${SAMPLE}/Info.plist`,
+    mustContain: [
+      'NSCameraUsageDescription',
+      'NSSpeechRecognitionUsageDescription',
+      'NSLocationWhenInUseUsageDescription',
+      'NSPhotoLibraryUsageDescription',
+    ],
+  },
   { path: 'Tests/SmrtIosTests/AdapterMappingTests.swift', mustContain: ['XCTest', '@testable import SmrtIos'] },
+  {
+    path: 'Tests/SmrtIosTests/EvidenceCaptureMappingTests.swift',
+    mustContain: ['XCTest', '@testable import SmrtIos', 'evidenceLocationMetadata'],
+  },
 ];
 
 const failures = [];

--- a/packages/smrt-mobile/AGENTS.md
+++ b/packages/smrt-mobile/AGENTS.md
@@ -108,10 +108,11 @@ without an Android SDK.
 - `src/iosMain/kotlin/.../platform/SmrtMobileIos.kt` — the iOS platform
   factories the exported framework hands to Swift (Phase 6, #1743):
   `createDatabase` / `createApiClient` / `createOfflinePackStore` /
-  `createWriteQueue`. These build Kotlin/Native types Swift cannot instantiate
-  itself (`NativeSqliteDriver`, the Ktor `Darwin` engine); smrt-android, being
-  Kotlin, builds its own. This is the only `iosMain` code — everything else is
-  `commonMain`.
+  `createWriteQueue`, plus `instantFromEpochMillis` (a `kotlinx.datetime.Instant`
+  the iOS evidence adapter needs for `persistedAt`/`capturedAt`; #1880). These
+  build Kotlin/Native types Swift cannot instantiate itself (`NativeSqliteDriver`,
+  the Ktor `Darwin` engine, `Instant`); smrt-android, being Kotlin, builds its
+  own. This is the only `iosMain` code — everything else is `commonMain`.
 
 ## Commands
 

--- a/packages/smrt-mobile/scripts/validate-shell.mjs
+++ b/packages/smrt-mobile/scripts/validate-shell.mjs
@@ -165,7 +165,12 @@ const SPEC = [
   // the durable store + Ktor client Swift cannot construct itself.
   {
     path: `${IOS_ROOT}/platform/SmrtMobileIos.kt`,
-    mustContain: ['object SmrtMobileIos', 'NativeSqliteDriver', 'fun createDatabase('],
+    mustContain: [
+      'object SmrtMobileIos',
+      'NativeSqliteDriver',
+      'fun createDatabase(',
+      'fun instantFromEpochMillis(',
+    ],
   },
   {
     path: `${SQL_ROOT}/QueueEntry.sq`,

--- a/packages/smrt-mobile/src/iosMain/kotlin/com/happyvertical/smrt/mobile/platform/SmrtMobileIos.kt
+++ b/packages/smrt-mobile/src/iosMain/kotlin/com/happyvertical/smrt/mobile/platform/SmrtMobileIos.kt
@@ -9,6 +9,7 @@ import com.happyvertical.smrt.mobile.network.UnauthorizedHandler
 import com.happyvertical.smrt.mobile.packs.DurableOfflinePackStore
 import com.happyvertical.smrt.mobile.sync.DurableWriteQueue
 import io.ktor.client.engine.darwin.Darwin
+import kotlinx.datetime.Instant
 
 /**
  * iOS platform factories the exported `SmrtMobile` framework hands to Swift
@@ -73,6 +74,17 @@ object SmrtMobileIos {
      */
     fun createWriteQueue(database: SmrtMobileDatabase): DurableWriteQueue =
         DurableWriteQueue(database)
+
+    /**
+     * Builds a [kotlinx.datetime.Instant] from epoch milliseconds for Swift.
+     * Kotlin/Native does not surface a Swift-constructible `Instant`, so the
+     * iOS evidence-capture adapter (`IOSEvidenceCaptureAdapter`) defers the
+     * `EvidenceAssetRef.persistedAt` / `EvidenceLocationMetadata.capturedAt`
+     * timestamps here — the same "types Swift can't construct" rationale as
+     * the store/client factories above. iOS-only; Android builds its own.
+     */
+    fun instantFromEpochMillis(epochMillis: Long): Instant =
+        Instant.fromEpochMilliseconds(epochMillis)
 
     const val DEFAULT_DATABASE_NAME: String = "smrt_mobile.db"
 }


### PR DESCRIPTION
## What

Joint **iOS + Android** implementation of smrt-mobile's existing
`EvidenceCapturePlatformAdapter` seam — the last foundation gap before Phase 7
(#1744). Both halves land in one pass so the cross-platform contract is resolved
**once**. Locked design record: [comment on #1880](https://github.com/happyvertical/smrt/issues/1880#issuecomment-4917699190).

Closes #1880.

## Cross-platform contract (the three+one questions #1880 called out)

- **`storageRoot` → `app_private`** for both platforms — a platform-neutral
  privacy/portability class, correcting the three-way split (`app_private` DTO
  default / Android `app_private_files` / iOS `app_documents`). The per-platform
  directory difference lives in `relativePath`, where it belongs.
- **Async flow → drive-to-completion.** amaru's `captureOrPickPhoto` was
  prepare-only (its callers hand-wired CameraX/PHPicker + a separate verify pass;
  the iOS bridge was dead code). Here the `suspend`/`async` call presents the OS
  camera/picker, awaits the user, copies into app-private storage, computes a
  SHA-256 pin, verifies, and returns a `STORED_OFFLINE` asset (null on cancel).
  `currentLocationMetadata()` stays a pure read.
- **Permission + geo sidecar** — tri-state `EvidenceNativePermissionState` and a
  lat/long/accuracy `EvidenceLocationMetadata` sidecar as JSON fields (never EXIF,
  ADR Correction 2), mapping identically from Android `LocationManager` and iOS
  `CLLocationManager`.
- **Android FileProvider** — a library-shipped `SmrtEvidenceFileProvider` subclass
  (avoids the manifest-merger class-name collision with a consumer's own
  FileProvider) with a `${applicationId}.evidence.files` authority merged
  per-consumer and overridable via `tools:replace` + the adapter's
  `fileProviderAuthority` param.

## Changes

- **smrt-android** — `AndroidEvidenceCaptureAdapter` (full-res `TakePicture` into
  the library FileProvider + system photo picker + `LocationManager` sidecar,
  reusing `AndroidSha256Hasher`), the `SmrtEvidenceFileProvider` + library manifest
  + `res/xml` paths, a **Capture** sample tab, and pure-mapping unit tests.
- **smrt-ios** — `IOSEvidenceCaptureAdapter` (`UIImagePickerController` /
  `PHPickerViewController` bridged into `async`, `Documents/Evidence/` storage with
  security-scoped-resource handling, `CLLocationManager` sidecar, reusing
  `CryptoKitSha256Hasher`; simulator falls back to the picker), a **Capture** sample
  screen, `CoreLocation`/`Photos`/`PhotosUI` in `project.yml`, and XCTest mappings.
- **smrt-mobile** — one `iosMain` addition: `SmrtMobileIos.instantFromEpochMillis`
  (a `kotlinx.datetime.Instant` Swift can't construct) for the iOS DTO timestamps.
- Validators (`validate-android` / `validate-ios` / `validate-shell`) + `AGENTS.md`
  files + the extraction-plan updated.

No monorepo-gate registration needed — both packages are already in the changeset
fixed group, `check-standards` non-TS set, and the `mobile.yml` paths.

## Verification (local, macOS host)

- `smrt-android`: `./gradlew build` green — library + sample compile, lint clean,
  **8** evidence mapping tests pass. Confirmed the FileProvider merges into the
  sample as `com.happyvertical.smrt.android.sample.evidence.files`.
- `smrt-ios`: `validate-ios.mjs --native` green — Gradle framework export →
  XcodeGen → simulator build + XCTest, **18** tests pass (8 evidence). The adapter
  typechecks against the real exported framework header.
- `pnpm build` (57/57) + `pnpm knowledge:check --strict` green.

## Acceptance

- [x] `EvidenceCapturePlatformAdapter` impl in smrt-android and smrt-ios against one
      resolved `storageRoot`/permission/sidecar contract.
- [x] A capture tab in each sample app exercising it.
- [x] `validate-android` / `validate-ios` + `mobile.yml` lanes green.
