### PR TITLE
feat(personas): new smrt-personas package — AgentPersona + PersonaResolver (#1887)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -35,6 +35,7 @@
       "@happyvertical/smrt-messages",
       "@happyvertical/smrt-mobile",
       "@happyvertical/smrt-mobile-contract",
+      "@happyvertical/smrt-personas",
       "@happyvertical/smrt-places",
       "@happyvertical/smrt-playground",
       "@happyvertical/smrt-products",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ All `@happyvertical/smrt-*` packages are version-locked via changesets. pnpm wor
 | jobs | Background execution: TaskRunner, ScheduleRunner, fluent JobBuilder, `withBackgroundJobs()` |
 | users | Auth/RBAC: 4-level permission cascade, hierarchical tenants, sessions, SvelteKit hooks |
 | profiles | Identity: multi-auth (Nostr/OIDC/API keys/magic links), relationships, audit logging, owned asset joins via `profile_assets` |
+| personas | Tenant-owned, context-scoped `AgentPersona` + `PersonaResolver`; layers over `smrt-agents` `TenantAgent` (availability/ceiling gate) with tenant-hierarchy inheritance and priority ordering |
 
 ### Content & Media
 | Package | Purpose |

--- a/packages/personas/AGENTS.md
+++ b/packages/personas/AGENTS.md
@@ -1,0 +1,85 @@
+# @happyvertical/smrt-personas
+
+Tenant-owned, context-scoped agent personas and their resolution. Layers over
+`@happyvertical/smrt-agents`' `TenantAgent` availability/ceiling gate to decide
+*how* an agent behaves for a given tenant and context (its `TenantAgent` binding
+decides *whether* it runs and caps its capabilities).
+
+This is the L2 foundation of the "learning agents" epic (#1885). Foundation
+only: `AgentPersona` + `PersonaResolver`. `ExecuteAsPrincipal`, feedback, the
+reflection runner, and multi-instance routing are separate issues
+(#1888/#1889/#1890).
+
+## Models
+
+- **AgentPersona** (`@TenantScoped({ mode: 'required' })`, table `agent_personas`):
+  a behavioral profile for one agent class within one tenant. Many per
+  `(tenant, agentClass)`; unique on `(tenant_id, agent_class, name)` via
+  `conflictColumns`. Fields:
+  - `agentClass` — canonical qualified agent type (e.g.
+    `@happyvertical/smrt-agents:Praeco`); stored canonical so it lines up with
+    `TenantAgent.agentClass`.
+  - `name` — persona name, unique per `(tenant, agentClass)`.
+  - `contextType` / `contextId` — optional scoping. No `contextType` = a
+    tenant-wide default; `contextType` only = type-scoped; both = exact context.
+  - `instructions` — system prompt layered onto the agent.
+  - `allowedTools` — JSON array of tool ids stored as a string; use
+    `getAllowedTools()` / `setAllowedTools()` (tolerant `try/catch` parse).
+  - `runAsUserId` — `@crossPackageRef('@happyvertical/smrt-users:User')`, the
+    principal the persona runs as.
+  - `actsAsProfileId` — optional `@crossPackageRef('@happyvertical/smrt-profiles:Profile')`,
+    a `Bot` identity for audit/attribution.
+  - `memoryScope` — memory/reflection partition key (empty → resolver-derived).
+  - `priority` — integer; higher wins among personas that apply at the same
+    tenant level.
+  - `enabled` — boolean; only enabled personas are resolved.
+
+## Collection
+
+`AgentPersonaCollection`:
+
+- `byTenantAndClass(tenantId, agentClass)` — all personas for the pair
+  (canonicalized), ordered by descending priority then name.
+- `findActive(tenantId, agentClass, context?)` — enabled personas applicable to
+  a context, same ordering.
+
+## PersonaResolver
+
+`resolve(tenantId, agentClass, context, options) → ResolvedPersona` layers,
+bottom to top: **manifest defaults → `TenantAgent` gate/ceiling → AgentPersona**.
+
+- **Hierarchy inheritance** mirrors `TenantAgentCollection.resolveForTenant`:
+  walks the requesting tenant then its ancestors (`options.getAncestorIds`,
+  nearest first). The nearest level with any applicable persona wins (a closer
+  level shadows a farther one).
+- **Selection within a level**: most context-specific first
+  (exact > type-scoped > tenant-wide), then highest `priority`, then name.
+- **Ceiling**: `options.availability` (a `PersonaAvailabilityGate`) gates
+  availability and intersects the resolved `allowedTools`. Build one from a
+  `ResolvedAgentAvailability` with `availabilityFromResolvedAgent()`.
+- **Default fallback**: when no persona applies, returns a defined default
+  (`source: 'default'`, `name: 'default'`) from manifest defaults + the gate.
+
+Because the walk reads personas across tenants, `resolve()` is intended for a
+system/admin path where cross-tenant reads are allowed — not inside a strict
+per-tenant interceptor context (same expectation as `resolveForTenant`).
+
+## Dependencies
+
+Leaf package (acyclic by construction — nothing depends back on it):
+
+- Runtime: `@happyvertical/smrt-core`, `@happyvertical/smrt-tenancy`,
+  `@happyvertical/smrt-agents` (the `TenantAgent` type it bridges).
+- `runAsUserId` / `actsAsProfileId` reference `@happyvertical/smrt-users` and
+  `@happyvertical/smrt-profiles` via `@crossPackageRef` string ids only — no
+  package edge (keeps the DAG minimal). No inter-`smrt-*` `peerDependencies`.
+
+## Gotchas
+
+- **`conflictColumns` replaces the default `(slug, context)` unique index** — the
+  unique key is `(tenant_id, agent_class, name)`, so same-named personas across
+  tenants are allowed and tenant isolation is preserved.
+- **`allowedTools` is text, not `type: 'json'`** — stored as a JSON string and
+  read through the helpers, so it never auto-hydrates to an object.
+- **Resolver runs outside strict tenant context** — it deliberately crosses
+  tenants to walk the hierarchy.

--- a/packages/personas/CLAUDE.md
+++ b/packages/personas/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/personas/package.json
+++ b/packages/personas/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@happyvertical/smrt-personas",
+  "version": "0.38.17",
+  "description": "Tenant-owned, context-scoped agent personas and resolution for the SMRT framework",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "CLAUDE.md",
+    "AGENTS.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./manifest": "./dist/manifest.json",
+    "./manifest.json": "./dist/manifest.json"
+  },
+  "scripts": {
+    "build": "vite build --mode library",
+    "build:watch": "vite build --mode library --watch",
+    "clean": "rm -rf dist",
+    "dev": "vite dev",
+    "prepack": "node ../../scripts/prepack-package.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
+  },
+  "dependencies": {
+    "@happyvertical/smrt-agents": "workspace:*",
+    "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-tenancy": "workspace:*"
+  },
+  "devDependencies": {
+    "@happyvertical/smrt-vitest": "workspace:*",
+    "@types/node": "24.13.2",
+    "typescript": "^5.9.3",
+    "vite": "^8.1.3",
+    "vitest": "^4.1.9"
+  },
+  "keywords": [
+    "smrt",
+    "agents",
+    "personas",
+    "multi-tenant",
+    "resolution"
+  ],
+  "author": "HappyVertical",
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/smrt.git",
+    "directory": "packages/personas"
+  }
+}

--- a/packages/personas/src/__smrt-register__.ts
+++ b/packages/personas/src/__smrt-register__.ts
@@ -1,0 +1,5 @@
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+
+ObjectRegistry.registerPackageManifest(
+  new URL('./manifest.json', import.meta.url),
+);

--- a/packages/personas/src/agent-persona.test.ts
+++ b/packages/personas/src/agent-persona.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Tests for AgentPersona and AgentPersonaCollection.
+ *
+ * Covers CRUD, the `(tenant_id, agent_class, name)` uniqueness constraint,
+ * `@TenantScoped` isolation via the tenancy interceptor, cross-package
+ * reference registration + round-trip, and the collection helpers.
+ *
+ * Uses real in-memory SQLite derived from the generated manifest so the
+ * conflictColumns unique index is exactly what ships. Mirrors the proven
+ * tenant-interceptor pattern from `smrt-users` (`enableTenancy()` + explicit
+ * `tenantId` on write + tenant-filtered reads).
+ */
+
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+import {
+  disableTenancy,
+  enableTenancy,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AgentPersona, AgentPersonaCollection } from './agent-persona.js';
+
+const PRAECO = '@happyvertical/smrt-agents:Praeco';
+const CAELUS = '@happyvertical/smrt-agents:Caelus';
+
+describe('AgentPersona', () => {
+  let ctx: Awaited<ReturnType<typeof createIsolatedTestDbFromManifest>>;
+  let personas: AgentPersonaCollection;
+
+  beforeEach(async () => {
+    // Schema + collection first, so DDL setup runs before the interceptor.
+    ctx = await createIsolatedTestDbFromManifest({
+      includeObjects: ['AgentPersona'],
+    });
+    personas = await AgentPersonaCollection.create({ db: ctx.db });
+    // enableTenancy() (not setupTestTenancy) preserves the @TenantScoped
+    // registry populated at import time; clearing it would leave AgentPersona
+    // unrecognized and disable tenant filtering.
+    enableTenancy();
+  });
+
+  afterEach(async () => {
+    disableTenancy();
+    await ctx.cleanup();
+  });
+
+  describe('CRUD', () => {
+    it('creates, reads, updates, and deletes a persona within a tenant', async () => {
+      await withTenant({ tenantId: 'tenant-a' }, async () => {
+        const created = await personas.create({
+          tenantId: 'tenant-a',
+          agentClass: PRAECO,
+          name: 'Support',
+          instructions: 'Be helpful.',
+          runAsUserId: 'user-1',
+          memoryScope: 'praeco:support',
+        });
+
+        expect(created.id).toBeTruthy();
+        expect(created.tenantId).toBe('tenant-a');
+        expect(created.enabled).toBe(true);
+        expect(created.priority).toBe(0);
+
+        const loaded = await personas.get({ id: created.id as string });
+        expect(loaded?.name).toBe('Support');
+        expect(loaded?.instructions).toBe('Be helpful.');
+        expect(loaded?.runAsUserId).toBe('user-1');
+
+        loaded!.instructions = 'Be concise.';
+        loaded!.priority = 5;
+        await loaded!.save();
+
+        const updated = await personas.get({ id: created.id as string });
+        expect(updated?.instructions).toBe('Be concise.');
+        expect(updated?.priority).toBe(5);
+
+        await updated!.delete();
+        const gone = await personas.get({ id: created.id as string });
+        expect(gone).toBeNull();
+      });
+    });
+
+    it('round-trips allowedTools through the JSON helpers', async () => {
+      await withTenant({ tenantId: 'tenant-a' }, async () => {
+        const created = await personas.create({
+          tenantId: 'tenant-a',
+          agentClass: PRAECO,
+          name: 'Tooled',
+          runAsUserId: 'user-1',
+        });
+        created.setAllowedTools(['search', 'summarize']);
+        await created.save();
+
+        const loaded = await personas.get({ id: created.id as string });
+        expect(loaded?.getAllowedTools()).toEqual(['search', 'summarize']);
+      });
+    });
+
+    it('returns an empty array for malformed allowedTools JSON', () => {
+      const persona = new AgentPersona();
+      persona.allowedTools = 'not json';
+      expect(persona.getAllowedTools()).toEqual([]);
+    });
+  });
+
+  describe('uniqueness on (tenant_id, agent_class, name)', () => {
+    it('rejects a second insert with the same tenant, agent class, and name', async () => {
+      await withTenant({ tenantId: 'tenant-a' }, async () => {
+        await personas.create({
+          tenantId: 'tenant-a',
+          agentClass: PRAECO,
+          name: 'Support',
+          runAsUserId: 'user-1',
+        });
+
+        await expect(
+          personas.create({
+            tenantId: 'tenant-a',
+            agentClass: PRAECO,
+            name: 'Support',
+            runAsUserId: 'user-2',
+            _insertOnly: true,
+          }),
+        ).rejects.toThrow();
+      });
+    });
+
+    it('allows the same name for a different agent class', async () => {
+      await withTenant({ tenantId: 'tenant-a' }, async () => {
+        await personas.create({
+          tenantId: 'tenant-a',
+          agentClass: PRAECO,
+          name: 'Support',
+          runAsUserId: 'user-1',
+        });
+        await personas.create({
+          tenantId: 'tenant-a',
+          agentClass: CAELUS,
+          name: 'Support',
+          runAsUserId: 'user-1',
+        });
+
+        const all = await personas.list({ where: { name: 'Support' } });
+        expect(all).toHaveLength(2);
+        expect(all.map((p) => p.agentClass).sort()).toEqual(
+          [CAELUS, PRAECO].sort(),
+        );
+      });
+    });
+  });
+
+  describe('@TenantScoped isolation', () => {
+    it("does not leak a tenant's personas to another tenant", async () => {
+      await withTenant({ tenantId: 'tenant-a' }, () =>
+        personas.create({
+          tenantId: 'tenant-a',
+          agentClass: PRAECO,
+          name: 'Support',
+          runAsUserId: 'user-a',
+        }),
+      );
+
+      const seenByB = await withTenant({ tenantId: 'tenant-b' }, () =>
+        personas.list({}),
+      );
+      expect(seenByB).toHaveLength(0);
+
+      const seenByA = await withTenant({ tenantId: 'tenant-a' }, () =>
+        personas.list({}),
+      );
+      expect(seenByA).toHaveLength(1);
+      expect(seenByA[0].tenantId).toBe('tenant-a');
+    });
+
+    it('lets two tenants each own a same-named persona for the same agent class', async () => {
+      await withTenant({ tenantId: 'tenant-a' }, () =>
+        personas.create({
+          tenantId: 'tenant-a',
+          agentClass: PRAECO,
+          name: 'Support',
+          runAsUserId: 'user-a',
+        }),
+      );
+      await withTenant({ tenantId: 'tenant-b' }, () =>
+        personas.create({
+          tenantId: 'tenant-b',
+          agentClass: PRAECO,
+          name: 'Support',
+          runAsUserId: 'user-b',
+        }),
+      );
+
+      const a = await withTenant({ tenantId: 'tenant-a' }, () =>
+        personas.list({}),
+      );
+      const b = await withTenant({ tenantId: 'tenant-b' }, () =>
+        personas.list({}),
+      );
+      expect(a).toHaveLength(1);
+      expect(b).toHaveLength(1);
+      expect(a[0].runAsUserId).toBe('user-a');
+      expect(b[0].runAsUserId).toBe('user-b');
+    });
+  });
+
+  describe('cross-package references', () => {
+    it('registers runAsUserId and actsAsProfileId as cross-package refs', () => {
+      const runAsRef = ObjectRegistry.getFieldDecorator(
+        'AgentPersona',
+        'runAsUserId',
+      );
+      expect(runAsRef?.type).toBe('crossPackageRef');
+      expect(runAsRef?.related).toBe('@happyvertical/smrt-users:User');
+
+      const actsAsRef = ObjectRegistry.getFieldDecorator(
+        'AgentPersona',
+        'actsAsProfileId',
+      );
+      expect(actsAsRef?.type).toBe('crossPackageRef');
+      expect(actsAsRef?.related).toBe('@happyvertical/smrt-profiles:Profile');
+    });
+
+    it('stores and round-trips the cross-package reference ids', async () => {
+      await withTenant({ tenantId: 'tenant-a' }, async () => {
+        const userId = crypto.randomUUID();
+        const profileId = crypto.randomUUID();
+        const created = await personas.create({
+          tenantId: 'tenant-a',
+          agentClass: PRAECO,
+          name: 'Identified',
+          runAsUserId: userId,
+          actsAsProfileId: profileId,
+        });
+
+        const loaded = await personas.get({ id: created.id as string });
+        expect(loaded?.runAsUserId).toBe(userId);
+        expect(loaded?.actsAsProfileId).toBe(profileId);
+      });
+    });
+  });
+
+  describe('collection helpers', () => {
+    it('byTenantAndClass returns personas ordered by descending priority', async () => {
+      await withTenant({ tenantId: 'tenant-a' }, async () => {
+        await personas.create({
+          tenantId: 'tenant-a',
+          agentClass: PRAECO,
+          name: 'Low',
+          priority: 1,
+          runAsUserId: 'user-1',
+        });
+        await personas.create({
+          tenantId: 'tenant-a',
+          agentClass: PRAECO,
+          name: 'High',
+          priority: 10,
+          runAsUserId: 'user-1',
+        });
+
+        const ordered = await personas.byTenantAndClass('tenant-a', PRAECO);
+        expect(ordered.map((p) => p.name)).toEqual(['High', 'Low']);
+      });
+    });
+
+    it('findActive filters out disabled personas and non-matching contexts', async () => {
+      await withTenant({ tenantId: 'tenant-a' }, async () => {
+        await personas.create({
+          tenantId: 'tenant-a',
+          agentClass: PRAECO,
+          name: 'TenantWide',
+          runAsUserId: 'user-1',
+        });
+        await personas.create({
+          tenantId: 'tenant-a',
+          agentClass: PRAECO,
+          name: 'Disabled',
+          enabled: false,
+          runAsUserId: 'user-1',
+        });
+        await personas.create({
+          tenantId: 'tenant-a',
+          agentClass: PRAECO,
+          name: 'SiteScoped',
+          contextType: 'site',
+          contextId: 'site-1',
+          runAsUserId: 'user-1',
+        });
+
+        const forSite1 = await personas.findActive('tenant-a', PRAECO, {
+          contextType: 'site',
+          contextId: 'site-1',
+        });
+        expect(forSite1.map((p) => p.name).sort()).toEqual([
+          'SiteScoped',
+          'TenantWide',
+        ]);
+
+        const forSite2 = await personas.findActive('tenant-a', PRAECO, {
+          contextType: 'site',
+          contextId: 'site-2',
+        });
+        // Only the tenant-wide default applies to a different site id.
+        expect(forSite2.map((p) => p.name)).toEqual(['TenantWide']);
+      });
+    });
+  });
+});

--- a/packages/personas/src/agent-persona.ts
+++ b/packages/personas/src/agent-persona.ts
@@ -19,6 +19,7 @@
 import {
   crossPackageRef,
   field,
+  getClassName,
   ObjectRegistry,
   SmrtCollection,
   SmrtObject,
@@ -38,6 +39,23 @@ import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 export function canonicalAgentClass(name: string): string {
   const registered = ObjectRegistry.getClass(name);
   return registered?.qualifiedName || registered?.name || name;
+}
+
+/**
+ * Return the meaningful aliases for an agent class — the canonical qualified
+ * name plus the simple class name — deduplicated.
+ *
+ * Lookups match against both so a persona persisted under a simple name (e.g.
+ * `Praeco`, when written through the generated create API without
+ * normalization) is still found when resolving under the canonical qualified
+ * name, and vice versa. Mirrors `getAgentTypeAliases()` in
+ * `@happyvertical/smrt-agents`.
+ */
+export function agentClassAliases(name: string): string[] {
+  const registered = ObjectRegistry.getClass(name);
+  const canonical = registered?.qualifiedName || registered?.name || name;
+  const simple = registered?.name || getClassName(name);
+  return Array.from(new Set([canonical, simple].filter(Boolean)));
 }
 
 /**
@@ -121,10 +139,11 @@ export class AgentPersona extends SmrtObject {
 
   /**
    * The user whose principal this persona runs as (cross-package reference to
-   * `@happyvertical/smrt-users:User`). Stored as a plain id column; no DDL FK
-   * constraint is emitted (cross-package).
+   * `@happyvertical/smrt-users:User`). Required — a persona always runs as a
+   * concrete principal. Stored as a plain id column; no DDL FK constraint is
+   * emitted (cross-package).
    */
-  @crossPackageRef('@happyvertical/smrt-users:User')
+  @crossPackageRef('@happyvertical/smrt-users:User', { required: true })
   runAsUserId: string = '';
 
   /**
@@ -177,7 +196,30 @@ export class AgentPersonaCollection extends SmrtCollection<AgentPersona> {
   static readonly _itemClass = AgentPersona;
 
   /**
-   * List every persona bound to a tenant + agent class (canonicalized).
+   * List personas for a tenant + agent class, matching either the canonical
+   * qualified name or the simple class name (see {@link agentClassAliases}).
+   *
+   * Ordered by descending priority then name.
+   *
+   * @param extraWhere - Additional equality filters merged into the query
+   *   (e.g. `{ enabled: true }`).
+   */
+  private async listForClass(
+    tenantId: string,
+    agentClass: string,
+    extraWhere: Record<string, unknown> = {},
+  ): Promise<AgentPersona[]> {
+    const aliases = agentClassAliases(agentClass);
+    const where =
+      aliases.length > 1
+        ? { tenantId, 'agentClass in': aliases, ...extraWhere }
+        : { tenantId, agentClass: aliases[0], ...extraWhere };
+    const personas = await this.list({ where });
+    return sortByPriorityThenName(personas);
+  }
+
+  /**
+   * List every persona bound to a tenant + agent class.
    *
    * Ordered by descending priority then name so callers that don't need the
    * full resolver still get a deterministic, priority-first ordering.
@@ -186,19 +228,18 @@ export class AgentPersonaCollection extends SmrtCollection<AgentPersona> {
     tenantId: string,
     agentClass: string,
   ): Promise<AgentPersona[]> {
-    const personas = await this.list({
-      where: { tenantId, agentClass: canonicalAgentClass(agentClass) },
-    });
-    return sortByPriorityThenName(personas);
+    return this.listForClass(tenantId, agentClass);
   }
 
   /**
-   * List the enabled personas for a tenant + agent class, optionally filtered
-   * to those applicable to a context.
+   * List the enabled personas for a tenant + agent class, filtered to those
+   * applicable to a context.
    *
-   * A persona is applicable when it is a tenant-wide default (no `contextType`)
-   * or its context matches the requested one. Ordered by descending priority
-   * then name.
+   * `enabled` is filtered in the query; the context predicate (tenant-wide vs
+   * type-scoped vs exact) is applied in memory since it is an OR over several
+   * columns. A persona is applicable when it is a tenant-wide default (no
+   * `contextType`) or its context matches the requested one. Ordered by
+   * descending priority then name.
    *
    * @param context - Optional `{ contextType, contextId }` to filter by.
    */
@@ -207,9 +248,11 @@ export class AgentPersonaCollection extends SmrtCollection<AgentPersona> {
     agentClass: string,
     context: { contextType?: string | null; contextId?: string | null } = {},
   ): Promise<AgentPersona[]> {
-    const personas = await this.byTenantAndClass(tenantId, agentClass);
-    return personas.filter(
-      (persona) => persona.enabled && personaAppliesToContext(persona, context),
+    const personas = await this.listForClass(tenantId, agentClass, {
+      enabled: true,
+    });
+    return personas.filter((persona) =>
+      personaAppliesToContext(persona, context),
     );
   }
 }

--- a/packages/personas/src/agent-persona.ts
+++ b/packages/personas/src/agent-persona.ts
@@ -1,0 +1,266 @@
+/**
+ * AgentPersona - Tenant-owned, context-scoped persona for an agent class.
+ *
+ * A persona layers behavioral configuration on top of a {@link TenantAgent}
+ * binding (from `@happyvertical/smrt-agents`). Where `TenantAgent` answers
+ * "is this agent available for the tenant, and what is its capability ceiling",
+ * an `AgentPersona` answers "how should this agent behave for this tenant in
+ * this context" — its instructions, allowed tools, run-as principal, acting
+ * identity, and memory scope.
+ *
+ * There can be many personas per `(tenant, agentClass)` — one per context
+ * (e.g. a site, property, or chat room) plus optional tenant-wide defaults.
+ * Personas are unique on `(tenant_id, agent_class, name)`.
+ *
+ * Resolution (context + hierarchy + priority) lives in {@link PersonaResolver};
+ * this class is the persisted record and its CRUD collection only.
+ */
+
+import {
+  crossPackageRef,
+  field,
+  ObjectRegistry,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+
+/**
+ * Return the canonical agent type identifier for storage and lookup.
+ *
+ * Uses the registry's qualified name when the class is registered and falls
+ * back to the raw input for dynamically defined or unregistered classes. This
+ * mirrors `getAgentTypeName()` in `@happyvertical/smrt-agents` without reaching
+ * into that package's internal module — personas store the same canonical form
+ * that `TenantAgent` does so the two layers line up.
+ */
+export function canonicalAgentClass(name: string): string {
+  const registered = ObjectRegistry.getClass(name);
+  return registered?.qualifiedName || registered?.name || name;
+}
+
+/**
+ * Parse a JSON-array-of-strings stored as text, tolerating malformed input.
+ */
+function parseStringArray(raw: string | null | undefined): string[] {
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((value): value is string => typeof value === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * AgentPersona SmrtObject — a tenant/context-scoped behavioral profile for an
+ * agent class.
+ */
+@TenantScoped({ mode: 'required' })
+@smrt({
+  tableName: 'agent_personas',
+  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  cli: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+  conflictColumns: ['tenant_id', 'agent_class', 'name'],
+})
+export class AgentPersona extends SmrtObject {
+  /** Owning tenant (required — personas are never global). */
+  @tenantId()
+  tenantId: string = '';
+
+  /**
+   * Canonical qualified agent type this persona configures
+   * (e.g. `@happyvertical/smrt-agents:Praeco`). Stored in canonical form so it
+   * lines up with `TenantAgent.agentClass`.
+   */
+  @field({ type: 'text' })
+  agentClass: string = '';
+
+  /**
+   * Human-readable persona name, unique per `(tenant, agentClass)`
+   * (see `conflictColumns`). Inherited `name` from {@link SmrtObject} is the
+   * conflict column; declared here for documentation and typing clarity.
+   */
+  name: string = '';
+
+  /**
+   * Optional context dimension type this persona is scoped to
+   * (e.g. `'site'`, `'property'`, `'chatRoom'`). `null` means the persona is a
+   * tenant-wide default that applies to every context for its agent class.
+   */
+  @field({ type: 'text', nullable: true })
+  contextType: string | null = null;
+
+  /**
+   * Optional context dimension id. Only meaningful alongside `contextType`:
+   * when set, the persona targets one specific context row; when `null` (with
+   * a `contextType` set) it applies to every context of that type.
+   */
+  @field({ type: 'text', nullable: true })
+  contextId: string | null = null;
+
+  /** System prompt / behavioral instructions layered onto the agent. */
+  @field({ type: 'text' })
+  instructions: string = '';
+
+  /**
+   * Allowed tool identifiers, stored as a JSON array string. Use
+   * {@link getAllowedTools} / {@link setAllowedTools} rather than reading this
+   * field directly. Empty array (`'[]'`) means "no persona-specific tools"
+   * (the resolver then falls back to manifest defaults, capped by the
+   * `TenantAgent` ceiling).
+   */
+  @field({ type: 'text' })
+  allowedTools: string = '[]';
+
+  /**
+   * The user whose principal this persona runs as (cross-package reference to
+   * `@happyvertical/smrt-users:User`). Stored as a plain id column; no DDL FK
+   * constraint is emitted (cross-package).
+   */
+  @crossPackageRef('@happyvertical/smrt-users:User')
+  runAsUserId: string = '';
+
+  /**
+   * Optional `Bot` profile the persona acts as for identity/audit
+   * (cross-package reference to `@happyvertical/smrt-profiles:Profile`).
+   * `null` when the persona has no distinct acting identity.
+   */
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { nullable: true })
+  actsAsProfileId: string | null = null;
+
+  /**
+   * Memory scope key controlling how the agent's memory/reflection is
+   * partitioned for this persona. Empty string means "use a resolver-derived
+   * default".
+   */
+  @field({ type: 'text' })
+  memoryScope: string = '';
+
+  /**
+   * Resolution priority — higher wins when several personas apply to the same
+   * context at the same tenant level. Integer.
+   */
+  priority: number = 0;
+
+  /** Whether this persona is active and eligible for resolution. */
+  @field({ type: 'boolean' })
+  enabled: boolean = true;
+
+  /**
+   * Allowed tool identifiers as an array.
+   *
+   * Tolerates malformed stored JSON by returning an empty array.
+   */
+  getAllowedTools(): string[] {
+    return parseStringArray(this.allowedTools);
+  }
+
+  /**
+   * Replace the allowed tool identifiers.
+   */
+  setAllowedTools(tools: string[]): void {
+    this.allowedTools = JSON.stringify(tools ?? []);
+  }
+}
+
+/**
+ * Collection for managing {@link AgentPersona} records.
+ */
+export class AgentPersonaCollection extends SmrtCollection<AgentPersona> {
+  static readonly _itemClass = AgentPersona;
+
+  /**
+   * List every persona bound to a tenant + agent class (canonicalized).
+   *
+   * Ordered by descending priority then name so callers that don't need the
+   * full resolver still get a deterministic, priority-first ordering.
+   */
+  async byTenantAndClass(
+    tenantId: string,
+    agentClass: string,
+  ): Promise<AgentPersona[]> {
+    const personas = await this.list({
+      where: { tenantId, agentClass: canonicalAgentClass(agentClass) },
+    });
+    return sortByPriorityThenName(personas);
+  }
+
+  /**
+   * List the enabled personas for a tenant + agent class, optionally filtered
+   * to those applicable to a context.
+   *
+   * A persona is applicable when it is a tenant-wide default (no `contextType`)
+   * or its context matches the requested one. Ordered by descending priority
+   * then name.
+   *
+   * @param context - Optional `{ contextType, contextId }` to filter by.
+   */
+  async findActive(
+    tenantId: string,
+    agentClass: string,
+    context: { contextType?: string | null; contextId?: string | null } = {},
+  ): Promise<AgentPersona[]> {
+    const personas = await this.byTenantAndClass(tenantId, agentClass);
+    return personas.filter(
+      (persona) => persona.enabled && personaAppliesToContext(persona, context),
+    );
+  }
+}
+
+/**
+ * Whether a persona applies to a requested context.
+ *
+ * - No `contextType` on the persona → tenant-wide default, applies to all.
+ * - `contextType` set, `contextId` null → type-scoped, applies when the
+ *   requested `contextType` matches.
+ * - Both set → exact, applies when both match.
+ */
+export function personaAppliesToContext(
+  persona: Pick<AgentPersona, 'contextType' | 'contextId'>,
+  context: { contextType?: string | null; contextId?: string | null },
+): boolean {
+  if (!persona.contextType) {
+    return true;
+  }
+  if (persona.contextType !== (context.contextType ?? null)) {
+    return false;
+  }
+  if (persona.contextId == null) {
+    return true;
+  }
+  return persona.contextId === (context.contextId ?? null);
+}
+
+/**
+ * Context-specificity rank used for resolution ordering.
+ *
+ * - `2` exact `(contextType, contextId)` match
+ * - `1` type-scoped match (`contextType` matches, persona `contextId` null)
+ * - `0` tenant-wide default (persona has no `contextType`)
+ */
+export function personaContextRank(
+  persona: Pick<AgentPersona, 'contextType' | 'contextId'>,
+): number {
+  if (!persona.contextType) {
+    return 0;
+  }
+  return persona.contextId == null ? 1 : 2;
+}
+
+function sortByPriorityThenName(personas: AgentPersona[]): AgentPersona[] {
+  return [...personas].sort((a, b) => {
+    if (b.priority !== a.priority) {
+      return b.priority - a.priority;
+    }
+    return (a.name ?? '').localeCompare(b.name ?? '');
+  });
+}
+
+export default AgentPersona;

--- a/packages/personas/src/index.ts
+++ b/packages/personas/src/index.ts
@@ -1,0 +1,31 @@
+/**
+ * @happyvertical/smrt-personas
+ *
+ * Tenant-owned, context-scoped agent personas and their resolution. Layers over
+ * `@happyvertical/smrt-agents`' `TenantAgent` availability/ceiling gate to
+ * decide how an agent should behave for a given tenant and context.
+ *
+ * @packageDocumentation
+ */
+
+// Self-register this package's manifest before any @smrt() decorator fires
+// downstream. Must come first so the side effect runs ahead of the class
+// module loads below. See __smrt-register__.ts for issue #1132 context.
+import './__smrt-register__.js';
+
+export {
+  AgentPersona,
+  AgentPersonaCollection,
+  canonicalAgentClass,
+  personaAppliesToContext,
+  personaContextRank,
+} from './agent-persona.js';
+export {
+  availabilityFromResolvedAgent,
+  type ManifestPersonaDefaults,
+  type PersonaAvailabilityGate,
+  type PersonaContext,
+  PersonaResolver,
+  type ResolvedPersona,
+  type ResolvePersonaOptions,
+} from './persona-resolver.js';

--- a/packages/personas/src/persona-resolver.test.ts
+++ b/packages/personas/src/persona-resolver.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Tests for PersonaResolver.
+ *
+ * Exercises the layering (manifest defaults → TenantAgent gate/ceiling →
+ * AgentPersona), tenant-hierarchy inheritance, context specificity, priority
+ * ordering, and the defined default fallback.
+ *
+ * Like `tenant-agent.test.ts`, resolution walks across tenants, so these tests
+ * run with the tenancy interceptor disabled and seed `tenantId` explicitly.
+ */
+
+import { disableTenancy } from '@happyvertical/smrt-tenancy';
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AgentPersonaCollection } from './agent-persona.js';
+import {
+  availabilityFromResolvedAgent,
+  type ManifestPersonaDefaults,
+  PersonaResolver,
+} from './persona-resolver.js';
+
+const PRAECO = '@happyvertical/smrt-agents:Praeco';
+
+interface SeedOptions {
+  tenantId: string;
+  name: string;
+  agentClass?: string;
+  instructions?: string;
+  allowedTools?: string[];
+  contextType?: string | null;
+  contextId?: string | null;
+  priority?: number;
+  enabled?: boolean;
+  runAsUserId?: string;
+  actsAsProfileId?: string | null;
+  memoryScope?: string;
+}
+
+describe('PersonaResolver', () => {
+  let ctx: Awaited<ReturnType<typeof createIsolatedTestDbFromManifest>>;
+  let personas: AgentPersonaCollection;
+  let resolver: PersonaResolver;
+
+  beforeEach(async () => {
+    // Resolution reads across tenants — keep the interceptor off so ancestor
+    // reads are not filtered/blocked. Use disableTenancy() (not resetTenancy)
+    // to avoid clearing the shared @TenantScoped registry other test files rely
+    // on within the same worker process.
+    disableTenancy();
+    ctx = await createIsolatedTestDbFromManifest({
+      includeObjects: ['AgentPersona'],
+    });
+    personas = await AgentPersonaCollection.create({ db: ctx.db });
+    resolver = new PersonaResolver(personas);
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  async function seed(options: SeedOptions) {
+    const persona = await personas.create({
+      tenantId: options.tenantId,
+      agentClass: options.agentClass ?? PRAECO,
+      name: options.name,
+      instructions: options.instructions ?? '',
+      contextType: options.contextType ?? null,
+      contextId: options.contextId ?? null,
+      priority: options.priority ?? 0,
+      enabled: options.enabled ?? true,
+      runAsUserId: options.runAsUserId ?? 'user-1',
+      actsAsProfileId: options.actsAsProfileId ?? null,
+      memoryScope: options.memoryScope ?? '',
+    });
+    if (options.allowedTools) {
+      persona.setAllowedTools(options.allowedTools);
+      await persona.save();
+    }
+    return persona;
+  }
+
+  describe('default fallback', () => {
+    it('returns a defined default when no persona exists', async () => {
+      const resolved = await resolver.resolve('tenant-a', PRAECO);
+
+      expect(resolved.source).toBe('default');
+      expect(resolved.name).toBe('default');
+      expect(resolved.agentClass).toBe(PRAECO);
+      expect(resolved.tenantId).toBe('tenant-a');
+      expect(resolved.instructions).toBe('');
+      expect(resolved.allowedTools).toEqual([]);
+      expect(resolved.available).toBe(true);
+      // Derived memory scope keeps agents partitioned by class + tenant.
+      expect(resolved.memoryScope).toBe(`${PRAECO}:tenant-a`);
+    });
+
+    it('layers manifest defaults into the fallback', async () => {
+      const manifestDefaults: ManifestPersonaDefaults = {
+        instructions: 'Default instructions.',
+        allowedTools: ['search'],
+        memoryScope: 'manifest-scope',
+      };
+      const resolved = await resolver.resolve(
+        'tenant-a',
+        PRAECO,
+        {},
+        {
+          manifestDefaults,
+        },
+      );
+
+      expect(resolved.source).toBe('default');
+      expect(resolved.instructions).toBe('Default instructions.');
+      expect(resolved.allowedTools).toEqual(['search']);
+      expect(resolved.memoryScope).toBe('manifest-scope');
+    });
+  });
+
+  describe('explicit resolution', () => {
+    it("returns the tenant's own persona over the default", async () => {
+      await seed({
+        tenantId: 'tenant-a',
+        name: 'Support',
+        instructions: 'Tenant instructions.',
+        allowedTools: ['search', 'summarize'],
+      });
+
+      const resolved = await resolver.resolve('tenant-a', PRAECO);
+      expect(resolved.source).toBe('persona');
+      expect(resolved.personaSource).toBe('explicit');
+      expect(resolved.sourceTenantId).toBe('tenant-a');
+      expect(resolved.name).toBe('Support');
+      expect(resolved.instructions).toBe('Tenant instructions.');
+      expect(resolved.allowedTools).toEqual(['search', 'summarize']);
+    });
+
+    it('falls back to manifest instructions when the persona leaves them blank', async () => {
+      await seed({ tenantId: 'tenant-a', name: 'Blank', instructions: '' });
+
+      const resolved = await resolver.resolve(
+        'tenant-a',
+        PRAECO,
+        {},
+        {
+          manifestDefaults: { instructions: 'Manifest instructions.' },
+        },
+      );
+      expect(resolved.source).toBe('persona');
+      expect(resolved.instructions).toBe('Manifest instructions.');
+    });
+
+    it('accepts a non-canonical agent class and resolves the same persona', async () => {
+      await seed({ tenantId: 'tenant-a', name: 'Support', agentClass: PRAECO });
+      // Unregistered simple name falls through canonicalization unchanged, so
+      // seed with the same string the resolver will look up.
+      const resolved = await resolver.resolve('tenant-a', PRAECO);
+      expect(resolved.name).toBe('Support');
+    });
+  });
+
+  describe('tenant-hierarchy inheritance', () => {
+    const getAncestorIds = async (tenantId: string): Promise<string[]> => {
+      if (tenantId === 'child') return ['parent', 'root'];
+      if (tenantId === 'parent') return ['root'];
+      return [];
+    };
+
+    it('inherits a persona from the parent tenant', async () => {
+      await seed({
+        tenantId: 'parent',
+        name: 'Inherited',
+        instructions: 'From parent.',
+      });
+
+      const resolved = await resolver.resolve(
+        'child',
+        PRAECO,
+        {},
+        {
+          getAncestorIds,
+        },
+      );
+      expect(resolved.source).toBe('persona');
+      expect(resolved.personaSource).toBe('inherited');
+      expect(resolved.sourceTenantId).toBe('parent');
+      expect(resolved.name).toBe('Inherited');
+      expect(resolved.instructions).toBe('From parent.');
+      // The result is still reported for the requesting tenant.
+      expect(resolved.tenantId).toBe('child');
+    });
+
+    it('prefers the closer ancestor over a more distant one', async () => {
+      await seed({ tenantId: 'root', name: 'RootPersona' });
+      await seed({ tenantId: 'parent', name: 'ParentPersona' });
+
+      const resolved = await resolver.resolve(
+        'child',
+        PRAECO,
+        {},
+        {
+          getAncestorIds,
+        },
+      );
+      expect(resolved.name).toBe('ParentPersona');
+      expect(resolved.sourceTenantId).toBe('parent');
+    });
+
+    it("prefers the tenant's own persona over an inherited one", async () => {
+      await seed({ tenantId: 'parent', name: 'ParentPersona' });
+      await seed({ tenantId: 'child', name: 'ChildPersona' });
+
+      const resolved = await resolver.resolve(
+        'child',
+        PRAECO,
+        {},
+        {
+          getAncestorIds,
+        },
+      );
+      expect(resolved.name).toBe('ChildPersona');
+      expect(resolved.personaSource).toBe('explicit');
+      expect(resolved.sourceTenantId).toBe('child');
+    });
+
+    it('inherits from a grandparent through the chain', async () => {
+      await seed({ tenantId: 'root', name: 'RootPersona' });
+
+      const resolved = await resolver.resolve(
+        'child',
+        PRAECO,
+        {},
+        {
+          getAncestorIds,
+        },
+      );
+      expect(resolved.name).toBe('RootPersona');
+      expect(resolved.sourceTenantId).toBe('root');
+    });
+  });
+
+  describe('priority ordering', () => {
+    it('selects the highest-priority persona at a tenant level', async () => {
+      await seed({ tenantId: 'tenant-a', name: 'Low', priority: 1 });
+      await seed({ tenantId: 'tenant-a', name: 'High', priority: 10 });
+      await seed({ tenantId: 'tenant-a', name: 'Mid', priority: 5 });
+
+      const resolved = await resolver.resolve('tenant-a', PRAECO);
+      expect(resolved.name).toBe('High');
+      expect(resolved.priority).toBe(10);
+    });
+  });
+
+  describe('context specificity', () => {
+    it('prefers an exact context match over type-scoped and tenant-wide', async () => {
+      await seed({ tenantId: 'tenant-a', name: 'Wide' });
+      await seed({
+        tenantId: 'tenant-a',
+        name: 'TypeScoped',
+        contextType: 'site',
+      });
+      await seed({
+        tenantId: 'tenant-a',
+        name: 'Exact',
+        contextType: 'site',
+        contextId: 'site-1',
+        // Lower priority than the others to prove specificity beats priority.
+        priority: 0,
+      });
+      await seed({ tenantId: 'tenant-a', name: 'WideHigh', priority: 99 });
+
+      const resolved = await resolver.resolve('tenant-a', PRAECO, {
+        contextType: 'site',
+        contextId: 'site-1',
+      });
+      expect(resolved.name).toBe('Exact');
+    });
+
+    it('ignores personas scoped to a different context', async () => {
+      await seed({
+        tenantId: 'tenant-a',
+        name: 'OtherSite',
+        contextType: 'site',
+        contextId: 'site-2',
+      });
+
+      const resolved = await resolver.resolve('tenant-a', PRAECO, {
+        contextType: 'site',
+        contextId: 'site-1',
+      });
+      // No applicable persona → default fallback.
+      expect(resolved.source).toBe('default');
+    });
+
+    it('applies a tenant-wide default to any context', async () => {
+      await seed({ tenantId: 'tenant-a', name: 'Wide' });
+
+      const resolved = await resolver.resolve('tenant-a', PRAECO, {
+        contextType: 'site',
+        contextId: 'site-1',
+      });
+      expect(resolved.name).toBe('Wide');
+      expect(resolved.contextType).toBe('site');
+      expect(resolved.contextId).toBe('site-1');
+    });
+  });
+
+  describe('enabled filtering', () => {
+    it('skips disabled personas', async () => {
+      await seed({
+        tenantId: 'tenant-a',
+        name: 'Disabled',
+        enabled: false,
+        priority: 100,
+      });
+
+      const resolved = await resolver.resolve('tenant-a', PRAECO);
+      expect(resolved.source).toBe('default');
+    });
+  });
+
+  describe('TenantAgent ceiling + availability gate', () => {
+    it('caps allowedTools to the availability ceiling', async () => {
+      await seed({
+        tenantId: 'tenant-a',
+        name: 'Tooled',
+        allowedTools: ['search', 'summarize', 'delete'],
+      });
+
+      const resolved = await resolver.resolve(
+        'tenant-a',
+        PRAECO,
+        {},
+        {
+          availability: {
+            status: 'active',
+            toolCeiling: ['search', 'summarize'],
+          },
+        },
+      );
+      expect(resolved.allowedTools).toEqual(['search', 'summarize']);
+      expect(resolved.available).toBe(true);
+    });
+
+    it('marks the persona unavailable when the TenantAgent gate is disabled', async () => {
+      await seed({ tenantId: 'tenant-a', name: 'Support' });
+
+      const resolved = await resolver.resolve(
+        'tenant-a',
+        PRAECO,
+        {},
+        {
+          availability: { status: 'disabled' },
+        },
+      );
+      expect(resolved.source).toBe('persona');
+      expect(resolved.available).toBe(false);
+    });
+
+    it('passes tools through unchanged when no ceiling is set', async () => {
+      await seed({
+        tenantId: 'tenant-a',
+        name: 'Tooled',
+        allowedTools: ['search', 'summarize'],
+      });
+
+      const resolved = await resolver.resolve(
+        'tenant-a',
+        PRAECO,
+        {},
+        {
+          availability: { status: 'active' },
+        },
+      );
+      expect(resolved.allowedTools).toEqual(['search', 'summarize']);
+    });
+  });
+
+  describe('availabilityFromResolvedAgent', () => {
+    it('returns null for a missing resolution', () => {
+      expect(availabilityFromResolvedAgent(null)).toBeNull();
+      expect(availabilityFromResolvedAgent(undefined)).toBeNull();
+    });
+
+    it('maps status and derives a tool ceiling from prefixed permissions', () => {
+      const gate = availabilityFromResolvedAgent(
+        {
+          agentClass: 'Praeco',
+          agentType: PRAECO,
+          status: 'active',
+          source: 'explicit',
+          sourceTenantId: 'tenant-a',
+          permissions: {
+            'tool:search': true,
+            'tool:delete': false,
+            'manage:sources': true,
+          },
+        },
+        { toolPermissionPrefix: 'tool:' },
+      );
+
+      expect(gate).not.toBeNull();
+      expect(gate?.status).toBe('active');
+      expect(gate?.sourceTenantId).toBe('tenant-a');
+      expect(gate?.toolCeiling).toEqual(['search']);
+    });
+
+    it('leaves the ceiling open when no prefix is given', () => {
+      const gate = availabilityFromResolvedAgent({
+        agentClass: 'Praeco',
+        agentType: PRAECO,
+        status: 'disabled',
+        source: 'inherited',
+        sourceTenantId: 'root',
+        permissions: {},
+      });
+      expect(gate?.status).toBe('disabled');
+      expect(gate?.toolCeiling).toBeUndefined();
+    });
+  });
+});

--- a/packages/personas/src/persona-resolver.test.ts
+++ b/packages/personas/src/persona-resolver.test.ts
@@ -9,10 +9,14 @@
  * run with the tenancy interceptor disabled and seed `tenantId` explicitly.
  */
 
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { disableTenancy } from '@happyvertical/smrt-tenancy';
 import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { AgentPersonaCollection } from './agent-persona.js';
+import {
+  AgentPersonaCollection,
+  canonicalAgentClass,
+} from './agent-persona.js';
 import {
   availabilityFromResolvedAgent,
   type ManifestPersonaDefaults,
@@ -20,6 +24,13 @@ import {
 } from './persona-resolver.js';
 
 const PRAECO = '@happyvertical/smrt-agents:Praeco';
+
+// A decorator-registered agent class so its simple name canonicalizes to a
+// distinct qualified name — the alias mismatch codex flagged. (Manifest-loaded
+// classes do not populate a qualified name under a simple-name lookup in this
+// test env, so a locally-declared @smrt() class is what actually exercises it.)
+@smrt()
+class DemoResolverAgent extends SmrtObject {}
 
 interface SeedOptions {
   tenantId: string;
@@ -149,12 +160,27 @@ describe('PersonaResolver', () => {
       expect(resolved.instructions).toBe('Manifest instructions.');
     });
 
-    it('accepts a non-canonical agent class and resolves the same persona', async () => {
-      await seed({ tenantId: 'tenant-a', name: 'Support', agentClass: PRAECO });
-      // Unregistered simple name falls through canonicalization unchanged, so
-      // seed with the same string the resolver will look up.
-      const resolved = await resolver.resolve('tenant-a', PRAECO);
-      expect(resolved.name).toBe('Support');
+    it('resolves a persona stored under a simple class name via canonical lookup', async () => {
+      const simple = 'DemoResolverAgent';
+      const canonical = canonicalAgentClass(simple);
+      // Precondition: registration canonicalizes the simple name to a distinct
+      // qualified name, so this genuinely exercises the alias bridge.
+      expect(canonical).not.toBe(simple);
+      expect(canonical.endsWith(':DemoResolverAgent')).toBe(true);
+
+      // Persisted under the SIMPLE name (as an un-normalized generated write
+      // would store it).
+      await seed({
+        tenantId: 'tenant-a',
+        name: 'SimpleStored',
+        agentClass: simple,
+      });
+
+      // Looked up by the canonical qualified name — the alias-aware lookup
+      // still finds the simple-named row.
+      const resolved = await resolver.resolve('tenant-a', canonical);
+      expect(resolved.source).toBe('persona');
+      expect(resolved.name).toBe('SimpleStored');
     });
   });
 

--- a/packages/personas/src/persona-resolver.ts
+++ b/packages/personas/src/persona-resolver.ts
@@ -1,0 +1,351 @@
+/**
+ * PersonaResolver - resolves the active {@link AgentPersona} for a
+ * `(tenant, agentClass, context)` request.
+ *
+ * Layering, bottom to top (each layer overrides the previous):
+ *
+ *   1. **Manifest defaults** — the agent's built-in instructions / tools /
+ *      memory scope (supplied by the caller as {@link ManifestPersonaDefaults}).
+ *   2. **TenantAgent** — the tenant/class availability gate and capability
+ *      ceiling (supplied as a {@link PersonaAvailabilityGate}; build one from a
+ *      `ResolvedAgentAvailability` via {@link availabilityFromResolvedAgent}).
+ *      `TenantAgent` decides *whether* the agent runs and *caps* its tools;
+ *      it never sets instructions.
+ *   3. **AgentPersona** — the tenant's own persona for the context: overrides
+ *      instructions, sets tools (within the ceiling), run-as principal, acting
+ *      identity, and memory scope.
+ *
+ * Tenant-hierarchy inheritance mirrors `TenantAgentCollection.resolveForTenant`:
+ * the resolver walks from the requesting tenant up its ancestors (nearest
+ * first). The nearest tenant level that has any applicable persona wins the
+ * resolution (a closer level shadows a farther one); within that level the most
+ * context-specific, highest-priority persona is selected. When no level has an
+ * applicable persona a defined default is returned.
+ *
+ * The hierarchy walk reads personas across tenants, so `resolve()` is meant to
+ * run in a system/admin path where cross-tenant reads are permitted (i.e. not
+ * inside a strict per-tenant interceptor context) — the same expectation
+ * `TenantAgentCollection.resolveForTenant` carries.
+ */
+
+import type { ResolvedAgentAvailability } from '@happyvertical/smrt-agents';
+import {
+  type AgentPersona,
+  type AgentPersonaCollection,
+  canonicalAgentClass,
+  personaAppliesToContext,
+  personaContextRank,
+} from './agent-persona.js';
+
+/**
+ * The context a persona is being resolved for.
+ */
+export interface PersonaContext {
+  /** Context dimension type (e.g. `'site'`). */
+  contextType?: string | null;
+  /** Context dimension id within `contextType`. */
+  contextId?: string | null;
+}
+
+/**
+ * Bottom-layer defaults for an agent class, typically derived from its build
+ * manifest.
+ */
+export interface ManifestPersonaDefaults {
+  /** Default system instructions when no persona overrides them. */
+  instructions?: string;
+  /** Default tool identifiers, capped by the availability ceiling. */
+  allowedTools?: string[];
+  /** Default memory scope. */
+  memoryScope?: string;
+}
+
+/**
+ * Middle-layer availability + capability ceiling, projected from a
+ * `TenantAgent` resolution.
+ */
+export interface PersonaAvailabilityGate {
+  /** Resolved `TenantAgent` status. `'disabled'` marks the persona unavailable. */
+  status: 'active' | 'disabled';
+  /**
+   * Tool identifiers the tenant is permitted to grant. When set, resolved
+   * `allowedTools` are intersected with this ceiling. `undefined` means no
+   * ceiling (tools pass through unchanged).
+   */
+  toolCeiling?: string[];
+  /** Tenant the binding was resolved from (provenance only). */
+  sourceTenantId?: string;
+}
+
+/**
+ * Options for {@link PersonaResolver.resolve}.
+ */
+export interface ResolvePersonaOptions {
+  /**
+   * Return ancestor tenant ids for a tenant, nearest parent first through to
+   * the root — mirrors `TenantAgentCollection.resolveForTenant`. Omit for a
+   * single-tenant resolution with no inheritance.
+   */
+  getAncestorIds?: (tenantId: string) => Promise<string[]>;
+  /** Bottom-layer manifest defaults for the agent class. */
+  manifestDefaults?: ManifestPersonaDefaults;
+  /**
+   * Middle-layer `TenantAgent` availability + ceiling. Omit to skip gating
+   * (the result is always `available: true` with no tool ceiling).
+   */
+  availability?: PersonaAvailabilityGate | null;
+}
+
+/**
+ * A fully resolved persona: the layered, ready-to-use configuration plus
+ * provenance describing how it was resolved.
+ */
+export interface ResolvedPersona {
+  /** Canonical qualified agent type the resolution was for. */
+  agentClass: string;
+  /** Tenant the resolution was requested for. */
+  tenantId: string;
+  /** Id of the selected persona, or `undefined` for the default fallback. */
+  personaId?: string;
+  /** Selected persona name, or `'default'` for the fallback. */
+  name: string;
+  /** Layered instructions (persona → manifest default). */
+  instructions: string;
+  /** Layered tool ids (persona/manifest tools, capped by the ceiling). */
+  allowedTools: string[];
+  /** Run-as user principal, if the selected persona sets one. */
+  runAsUserId?: string;
+  /** Acting `Bot` profile id, if the selected persona sets one. */
+  actsAsProfileId?: string | null;
+  /** Resolved memory scope (persona → manifest default → derived default). */
+  memoryScope: string;
+  /** Selected persona priority (`0` for the default fallback). */
+  priority: number;
+  /** Context type the resolution was requested for. */
+  contextType?: string | null;
+  /** Context id the resolution was requested for. */
+  contextId?: string | null;
+  /** Whether a persona matched (`'persona'`) or the default was used (`'default'`). */
+  source: 'persona' | 'default';
+  /** For a matched persona, whether it was the tenant's own or inherited. */
+  personaSource?: 'explicit' | 'inherited';
+  /** Tenant the matched persona came from (own tenant or an ancestor). */
+  sourceTenantId?: string;
+  /** Whether the `TenantAgent` gate reports the agent as available. */
+  available: boolean;
+}
+
+/**
+ * Project a `TenantAgent` resolution into a {@link PersonaAvailabilityGate}.
+ *
+ * This is the concrete bridge between the `@happyvertical/smrt-agents`
+ * availability layer and the persona layer. Pass `toolPermissionPrefix` to
+ * derive a tool ceiling from granted permission ids (permissions whose id
+ * starts with the prefix become the ceiling, with the prefix stripped); omit it
+ * to leave the ceiling open.
+ *
+ * @param resolved - A `ResolvedAgentAvailability` (or `null`/`undefined`).
+ * @param options.toolPermissionPrefix - Permission-id prefix that marks
+ *   tool grants (e.g. `'tool:'`).
+ * @returns A gate, or `null` when `resolved` is nullish.
+ */
+export function availabilityFromResolvedAgent(
+  resolved: ResolvedAgentAvailability | null | undefined,
+  options: { toolPermissionPrefix?: string } = {},
+): PersonaAvailabilityGate | null {
+  if (!resolved) {
+    return null;
+  }
+
+  const { toolPermissionPrefix } = options;
+  let toolCeiling: string[] | undefined;
+  if (toolPermissionPrefix) {
+    toolCeiling = Object.entries(resolved.permissions ?? {})
+      .filter(([id, granted]) => granted && id.startsWith(toolPermissionPrefix))
+      .map(([id]) => id.slice(toolPermissionPrefix.length));
+  }
+
+  return {
+    status: resolved.status,
+    toolCeiling,
+    sourceTenantId: resolved.sourceTenantId,
+  };
+}
+
+/**
+ * Resolves the active persona for a `(tenant, agentClass, context)` request.
+ */
+export class PersonaResolver {
+  constructor(private readonly personas: AgentPersonaCollection) {}
+
+  /**
+   * Resolve the active persona.
+   *
+   * @param tenantId - Requesting tenant.
+   * @param agentClass - Agent class (canonicalized internally).
+   * @param context - Context dimension being resolved for.
+   * @param options - Hierarchy walk, manifest defaults, and availability gate.
+   * @returns The layered {@link ResolvedPersona} — either a matched persona or
+   *   the defined default fallback.
+   */
+  async resolve(
+    tenantId: string,
+    agentClass: string,
+    context: PersonaContext = {},
+    options: ResolvePersonaOptions = {},
+  ): Promise<ResolvedPersona> {
+    const canonical = canonicalAgentClass(agentClass);
+    const { getAncestorIds, manifestDefaults, availability } = options;
+
+    const ancestorIds = getAncestorIds ? await getAncestorIds(tenantId) : [];
+    const levels = [tenantId, ...ancestorIds];
+
+    for (let level = 0; level < levels.length; level++) {
+      const levelTenantId = levels[level];
+      const candidates = await this.personas.findActive(
+        levelTenantId,
+        canonical,
+        context,
+      );
+
+      if (candidates.length === 0) {
+        continue;
+      }
+
+      const winner = pickWinner(candidates);
+      return this.layerPersona(winner, {
+        canonical,
+        tenantId,
+        context,
+        manifestDefaults,
+        availability,
+        personaSource: level === 0 ? 'explicit' : 'inherited',
+        sourceTenantId: levelTenantId,
+      });
+    }
+
+    return this.defaultResolution({
+      canonical,
+      tenantId,
+      context,
+      manifestDefaults,
+      availability,
+    });
+  }
+
+  private layerPersona(
+    persona: AgentPersona,
+    ctx: LayerContext & {
+      personaSource: 'explicit' | 'inherited';
+      sourceTenantId: string;
+    },
+  ): ResolvedPersona {
+    const { manifestDefaults, availability } = ctx;
+    const personaTools = persona.getAllowedTools();
+    const baseTools =
+      personaTools.length > 0
+        ? personaTools
+        : (manifestDefaults?.allowedTools ?? []);
+
+    return {
+      agentClass: ctx.canonical,
+      tenantId: ctx.tenantId,
+      personaId: persona.id ?? undefined,
+      name: persona.name,
+      instructions:
+        persona.instructions || manifestDefaults?.instructions || '',
+      allowedTools: applyCeiling(baseTools, availability),
+      runAsUserId: persona.runAsUserId || undefined,
+      actsAsProfileId: persona.actsAsProfileId ?? null,
+      memoryScope: resolveMemoryScope(persona.memoryScope, ctx),
+      priority: persona.priority,
+      contextType: ctx.context.contextType ?? null,
+      contextId: ctx.context.contextId ?? null,
+      source: 'persona',
+      personaSource: ctx.personaSource,
+      sourceTenantId: ctx.sourceTenantId,
+      available: isAvailable(availability),
+    };
+  }
+
+  private defaultResolution(ctx: LayerContext): ResolvedPersona {
+    const { manifestDefaults, availability } = ctx;
+    return {
+      agentClass: ctx.canonical,
+      tenantId: ctx.tenantId,
+      name: 'default',
+      instructions: manifestDefaults?.instructions ?? '',
+      allowedTools: applyCeiling(
+        manifestDefaults?.allowedTools ?? [],
+        availability,
+      ),
+      actsAsProfileId: null,
+      memoryScope: resolveMemoryScope('', ctx),
+      priority: 0,
+      contextType: ctx.context.contextType ?? null,
+      contextId: ctx.context.contextId ?? null,
+      source: 'default',
+      available: isAvailable(availability),
+    };
+  }
+}
+
+interface LayerContext {
+  canonical: string;
+  tenantId: string;
+  context: PersonaContext;
+  manifestDefaults?: ManifestPersonaDefaults;
+  availability?: PersonaAvailabilityGate | null;
+}
+
+/**
+ * Pick the winning persona from candidates already known to apply to the
+ * requested context and be enabled.
+ *
+ * Order: most context-specific first, then highest priority, then name for a
+ * stable deterministic tie-break.
+ */
+function pickWinner(candidates: AgentPersona[]): AgentPersona {
+  return [...candidates].sort((a, b) => {
+    const rankDelta = personaContextRank(b) - personaContextRank(a);
+    if (rankDelta !== 0) {
+      return rankDelta;
+    }
+    if (b.priority !== a.priority) {
+      return b.priority - a.priority;
+    }
+    return (a.name ?? '').localeCompare(b.name ?? '');
+  })[0];
+}
+
+function applyCeiling(
+  tools: string[],
+  availability?: PersonaAvailabilityGate | null,
+): string[] {
+  if (!availability?.toolCeiling) {
+    return [...tools];
+  }
+  const ceiling = new Set(availability.toolCeiling);
+  return tools.filter((tool) => ceiling.has(tool));
+}
+
+function isAvailable(availability?: PersonaAvailabilityGate | null): boolean {
+  return availability ? availability.status === 'active' : true;
+}
+
+function resolveMemoryScope(explicit: string, ctx: LayerContext): string {
+  if (explicit) {
+    return explicit;
+  }
+  if (ctx.manifestDefaults?.memoryScope) {
+    return ctx.manifestDefaults.memoryScope;
+  }
+  const contextSuffix = ctx.context.contextType
+    ? `:${ctx.context.contextType}${ctx.context.contextId ? `:${ctx.context.contextId}` : ''}`
+    : '';
+  return `${ctx.canonical}:${ctx.tenantId}${contextSuffix}`;
+}
+
+// Re-export the context applicability helper for consumers building their own
+// persona selection UIs without duplicating the semantics.
+export { personaAppliesToContext };

--- a/packages/personas/src/persona-resolver.ts
+++ b/packages/personas/src/persona-resolver.ts
@@ -162,7 +162,10 @@ export function availabilityFromResolvedAgent(
   if (toolPermissionPrefix) {
     toolCeiling = Object.entries(resolved.permissions ?? {})
       .filter(([id, granted]) => granted && id.startsWith(toolPermissionPrefix))
-      .map(([id]) => id.slice(toolPermissionPrefix.length));
+      .map(([id]) => id.slice(toolPermissionPrefix.length))
+      // Sort for a stable, order-independent ceiling regardless of how the
+      // permissions map was produced.
+      .sort();
   }
 
   return {

--- a/packages/personas/tsconfig.json
+++ b/packages/personas/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": ["node"],
+    "lib": ["ES2023"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/personas/vite.config.ts
+++ b/packages/personas/vite.config.ts
@@ -1,0 +1,3 @@
+import { createPackageConfig } from '../../vite.config.base.js';
+
+export default createPackageConfig('personas');

--- a/packages/personas/vitest.config.ts
+++ b/packages/personas/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import { smrtVitestPlugin } from '../vitest/src/index.ts';
+
+export default defineConfig({
+  plugins: [smrtVitestPlugin({ verbose: true })],
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 30000,
+    fileParallelism: false,
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1387,6 +1387,34 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  packages/personas:
+    dependencies:
+      '@happyvertical/smrt-agents':
+        specifier: workspace:*
+        version: link:../agents
+      '@happyvertical/smrt-core':
+        specifier: workspace:*
+        version: link:../core
+      '@happyvertical/smrt-tenancy':
+        specifier: workspace:*
+        version: link:../tenancy
+    devDependencies:
+      '@happyvertical/smrt-vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@types/node':
+        specifier: 24.13.2
+        version: 24.13.2
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.1.3
+        version: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+
   packages/places:
     dependencies:
       '@happyvertical/ai':


### PR DESCRIPTION
## Summary

L2 foundation of the learning-agents epic (#1885): a new
`@happyvertical/smrt-personas` leaf package delivering the `AgentPersona` model
and `PersonaResolver`. Foundation only — `ExecuteAsPrincipal`, feedback, the
reflection runner, and multi-instance routing are separate issues
(#1888–#1890).

## What's included

- **`AgentPersona`** — `@TenantScoped({ mode: 'required' })` on table
  `agent_personas`, unique on `(tenant_id, agent_class, name)` via
  `conflictColumns`. Fields: `agentClass` (canonical qualified type),
  `name`, optional `contextType`/`contextId`, `instructions`, `allowedTools`
  (JSON-as-string with `getAllowedTools()`/`setAllowedTools()`),
  `runAsUserId` (`@crossPackageRef → smrt-users:User`), optional
  `actsAsProfileId` (`@crossPackageRef → smrt-profiles:Profile`),
  `memoryScope`, `priority` (INTEGER), `enabled` (boolean).
- **`AgentPersonaCollection`** — `byTenantAndClass()` and `findActive()`
  (context + enabled filtering, priority ordering).
- **`PersonaResolver`** — `resolve(tenant, agentClass, context, options)`
  layers **manifest defaults → `TenantAgent` gate/ceiling → `AgentPersona`**.
  Tenant-hierarchy inheritance mirrors
  `TenantAgentCollection.resolveForTenant` (closer level shadows farther);
  within a level it selects by context specificity → priority → name, with a
  defined default fallback. `availabilityFromResolvedAgent()` bridges a
  `ResolvedAgentAvailability` into the ceiling gate.

## Package / release plumbing

- Added to the changeset `fixed` group (`.changeset/config.json`).
- Row added to the root `AGENTS.md` package table (Agents & Runtime).
- Package `AGENTS.md` expert doc + `CLAUDE.md` shim.
- No `vite.config.base.ts` change needed: `@happyvertical/*` is externalized by
  the existing regex and personas is not framework infra (so it correctly uses
  `smrtPlugin`); `skipSmrtPlugin` is only for `core/types/config/scanner/vitest/playground`.

## Dependencies (leaf, acyclic)

Runtime: `@happyvertical/smrt-core`, `-tenancy`, `-agents`. `runAsUserId` /
`actsAsProfileId` reference `smrt-users` / `smrt-profiles` via `@crossPackageRef`
string ids only (no package edge). No inter-`smrt-*` `peerDependencies`
(`check-no-smrt-peers` + `check-package-dag` pass — 57-package DAG).

## Tests (real in-memory SQLite via `createIsolatedTestDbFromManifest`)

31 tests, all passing:

- `agent-persona.test.ts` — CRUD; `(tenant_id, agent_class, name)` uniqueness
  (definitive `_insertOnly` collision); `@TenantScoped` isolation via the
  tenancy interceptor (one tenant can't read another's; two tenants can own a
  same-named persona); cross-package refs registered + round-trip; collection
  helpers.
- `persona-resolver.test.ts` — default fallback, explicit resolution, manifest
  layering, tenant-hierarchy inheritance (parent/grandparent, closer-wins,
  own-over-inherited), priority ordering, context specificity (exact >
  type-scoped > tenant-wide), enabled filtering, ceiling capping + availability
  gate, and the `availabilityFromResolvedAgent` bridge.

## Local verification

- `pnpm test` (personas): 31 passed
- `pnpm typecheck`: clean
- `pnpm build`: clean (manifest emits the 3-column unique index + both
  cross-package refs)
- `smrt dev:knowledge-check`: fresh (0 errors, 0 warnings)
- `check-no-smrt-peers`, `check-package-dag`, `verify:pack`: pass

Closes #1887
Part of #1885
