### PR TITLE
feat(agents): opt-in Learning trait + LearningMemory (#1886)

### DIFF
--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -85,11 +85,41 @@ Persisted `agent_config` snapshots env-derived values at sync time, so rotated e
 
 The TaskRunner calls `resolveLazyConfig()` immediately before constructing the agent, so live values always win over snapshotted ones. Re-exported from `@happyvertical/smrt-core` (`resolveLazyConfig`, `registerConfigResolver`, `getClassConfigResolvers`, …) for cases where agents isn't on the import path.
 
+## Learning Trait (issue #1886) — opt-in
+
+Any agent can opt into a confidence-scored **recall-before / capture-after** loop backed by core's `LearningMemory` (over `_smrt_contexts` + `_smrt_embeddings`). **Off by default** — a non-opted agent behaves byte-for-byte as today; the lifecycle's learning branches are never entered.
+
+```typescript
+@smrt()
+class InvoiceAgent extends Agent {
+  static override learning = true; // or { minConfidence: 0.8, scope: 'invoices', ... }
+  protected config = {};
+
+  async run() {
+    // recall-before-run already populated `recalledMemories` (confidence >= floor)
+    const cached = this.recalledMemories.find((m) => m.key === this.docUrl);
+    const strategy = cached?.value ?? (await this.generateStrategy());
+
+    // stage the episode; the lifecycle reinforces it after run()
+    this.stageLearning({ scope: this.learningScope(), key: this.docUrl, value: strategy });
+
+    // a validated failure decays the memory without throwing
+    if (!ok) this.reportLearningOutcome({ success: false, error: 'no match' });
+  }
+}
+```
+
+- **`capture` semantics** (`LearningMemory`): success strengthens `confidence` toward 1.0 and increments `success_count`; failure decays toward `failureConfidence` (0.3) and increments `failure_count`. A single failure drops a confident memory below the reuse floor (0.7), so recall stops returning it. Refreshes `last_used_at`; honours `expires_at` and optional time-decay.
+- **Memory isolation**: bound to `(agentType, agentInstanceId)` as `(owner_class, owner_id)`, so two tenants on the same agent class never share memory. `tenantId` is threaded into the optional semantic-search `where`.
+- **Seams to override**: `learningScope()`, `recallForRun(memory)`, `captureForRun(memory, outcome)`, `getLearningSemanticSearch()`. Helpers for `run()`: `stageLearning(episode)`, `reportLearningOutcome(outcome)`, `getLearningMemory()`, and the `recalledMemories` field.
+- **Config**: `static learning: boolean | AgentLearningConfig` — `{ enabled?, scope?, minConfidence?, successConfidence?, failureConfidence?, reinforcement?, decayHalfLifeMs? }`. `LearningMemory` and its types are re-exported from `@happyvertical/smrt-core`.
+
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `src/agent.ts` | Base Agent class — lifecycle, dispatch, interests, config |
+| `src/agent.ts` | Base Agent class — lifecycle, dispatch, interests, config, opt-in learning trait |
+| `src/learning.ts` | `AgentLearningConfig` + `resolveAgentLearning()` declaration normalisation |
 | `src/schedule.ts` | AgentSchedule model — cron, execution tracking |
 | `src/tenant-agent.ts` | TenantAgent — junction table, hierarchical resolution |
 | `src/interests.ts` | Interest filter types and configuration |

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -641,14 +641,6 @@ export abstract class Agent extends SmrtObject {
   }
 
   /**
-   * Whether the learning trait is enabled for this agent.
-   */
-  protected isLearningEnabled(): boolean {
-    return resolveAgentLearning((this.constructor as typeof Agent).learning)
-      .enabled;
-  }
-
-  /**
    * Optional semantic-search arm for {@link LearningMemory}.
    *
    * Returns `undefined` by default (keyed-context recall only). Override to

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -255,7 +255,9 @@ export abstract class Agent extends SmrtObject {
    * lifecycle, backed by {@link LearningMemory}. A non-opted agent behaves
    * byte-for-byte as it does today — the learning branches are never entered.
    *
-   * When enabled, `execute()`:
+   * When enabled, the loop wraps `run()` itself (in {@link initialize}), so it
+   * fires whether the agent runs via {@link execute} or the background/scheduled
+   * path (which calls `run()` directly). Each run:
    * 1. recalls confident memories for {@link learningScope} before `run()`,
    *    exposing them via {@link recalledMemories};
    * 2. captures the run outcome after `run()` — a clean completion reinforces
@@ -315,10 +317,16 @@ export abstract class Agent extends SmrtObject {
   private _dispatch: DispatchBus | null = null;
 
   /**
-   * Cached LearningMemory binding. `undefined` = not yet resolved,
-   * `null` = learning disabled (resolved once, cheaply).
+   * Cached LearningMemory binding, once successfully built. Not cached when
+   * learning is disabled or the DB isn't ready yet, so an early call can't
+   * permanently stick the agent in a learning-disabled state.
    */
-  private _learningMemory?: LearningMemory | null;
+  private _learningMemory?: LearningMemory;
+
+  /**
+   * Whether `run()` has been wrapped with the learning loop (idempotency guard).
+   */
+  private _runWrappedForLearning = false;
 
   /**
    * The episode the current run acted on, staged via {@link stageLearning} so
@@ -667,15 +675,17 @@ export abstract class Agent extends SmrtObject {
    * single static-flag check), which keeps non-opted agents unchanged.
    */
   getLearningMemory(): LearningMemory | null {
-    if (this._learningMemory !== undefined) {
+    if (this._learningMemory) {
       return this._learningMemory;
     }
 
     const resolved = resolveAgentLearning(
       (this.constructor as typeof Agent).learning,
     );
+    // Disabled is a stable answer (cheap static check, no need to cache). When
+    // enabled but the DB isn't wired yet, return null WITHOUT caching so a later
+    // call (after initialize()) can build the binding.
     if (!resolved.enabled || !this._db) {
-      this._learningMemory = null;
       return null;
     }
 
@@ -693,6 +703,64 @@ export abstract class Agent extends SmrtObject {
       config: resolved.memoryConfig,
     });
     return this._learningMemory;
+  }
+
+  /**
+   * Wrap `run()` with the recall-before / capture-after learning loop when the
+   * trait is enabled, so it fires **however run() is invoked** — via
+   * {@link execute} OR directly by the background/scheduled path
+   * (`ScheduleRunner` → `TaskRunner` calls the agent's configured method, which
+   * defaults to `run` and never goes through `execute()`). Both paths call
+   * {@link initialize}, so wrapping here covers them. Idempotent, and a no-op
+   * for non-opted agents (their `run()` is left untouched).
+   */
+  private wrapRunForLearning(): void {
+    if (this._runWrappedForLearning) return;
+    if (
+      !resolveAgentLearning((this.constructor as typeof Agent).learning).enabled
+    ) {
+      return;
+    }
+    this._runWrappedForLearning = true;
+
+    const originalRun = this.run.bind(this);
+    (this as { run: () => Promise<void> }).run = async (): Promise<void> => {
+      const memory = this.getLearningMemory();
+      if (!memory) {
+        await originalRun();
+        return;
+      }
+
+      // Clear per-run learning state up front so a throw in recallForRun()
+      // can't leave stale recalled memories from a previous run.
+      this.recalledMemories = [];
+      this._learningEpisode = null;
+      this._learningOutcome = null;
+      try {
+        this.recalledMemories = await this.recallForRun(memory);
+        await originalRun();
+        await this.captureForRun(
+          memory,
+          this._learningOutcome ?? { success: true },
+        );
+      } catch (error) {
+        // Capture the failure, but never mask the original error.
+        try {
+          await this.captureForRun(memory, {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        } catch (captureError) {
+          this.logger.warn('Learning capture failed during error handling', {
+            error: captureError,
+          });
+        }
+        throw error;
+      } finally {
+        this._learningEpisode = null;
+        this._learningOutcome = null;
+      }
+    };
   }
 
   /**
@@ -805,6 +873,11 @@ export abstract class Agent extends SmrtObject {
         }
       }
     }
+
+    // Engage the learning loop around run() (opt-in; no-op otherwise). Done
+    // here — not only in execute() — so the background/scheduled path, which
+    // calls initialize() then run() directly, learns too.
+    this.wrapRunForLearning();
 
     return this;
   }
@@ -1018,9 +1091,6 @@ export abstract class Agent extends SmrtObject {
    * ```
    */
   async execute(): Promise<void> {
-    // Learning trait (#1886): resolves to null for non-opted agents, so every
-    // guarded branch below is skipped and behaviour is unchanged.
-    let learning: LearningMemory | null = null;
     try {
       await this.initialize();
       await this.validate();
@@ -1039,46 +1109,17 @@ export abstract class Agent extends SmrtObject {
         }
       }
 
-      // Learning: recall-before-run
-      learning = this.getLearningMemory();
-      if (learning) {
-        this.recalledMemories = await this.recallForRun(learning);
-      }
-
+      // The learning loop (#1886) is wrapped around run() in initialize(), so
+      // recall-before / capture-after fires here and on the scheduled path
+      // alike — nothing learning-specific is needed in execute() itself.
       await this.run();
-
-      // Learning: capture-after-run (success unless run reported otherwise)
-      if (learning) {
-        await this.captureForRun(
-          learning,
-          this._learningOutcome ?? { success: true },
-        );
-      }
-
       this.status = 'idle';
 
       this.logger.info('Agent execution completed');
     } catch (error) {
-      // Learning: capture the failure, but never mask the original error.
-      if (learning) {
-        try {
-          await this.captureForRun(learning, {
-            success: false,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        } catch (captureError) {
-          this.logger.warn('Learning capture failed during error handling', {
-            error: captureError,
-          });
-        }
-      }
       this.status = 'error';
       this.logger.error('Agent execution failed', { error });
       throw error;
-    } finally {
-      // Reset per-run learning state so a reused instance starts clean.
-      this._learningEpisode = null;
-      this._learningOutcome = null;
     }
   }
 

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -7,6 +7,11 @@ import {
   type DispatchBus,
   type DispatchMetadata,
   type DispatchTenantScope,
+  type LearningEpisode,
+  LearningMemory,
+  type LearningMemoryRecord,
+  type LearningOutcome,
+  type LearningSemanticSearch,
   ObjectRegistry,
   resolveDispatchTenantScope,
   type SmrtCollection,
@@ -33,6 +38,10 @@ import type {
   ObjectInterestConfig,
 } from './interests.js';
 import { mergeFilters, normalizeSort } from './interests.js';
+import {
+  type AgentLearningDeclaration,
+  resolveAgentLearning,
+} from './learning.js';
 import type { AgentStatusType } from './types.js';
 import type { AgentAdminRoute, AgentUISlots } from './ui.js';
 
@@ -239,6 +248,38 @@ export abstract class Agent extends SmrtObject {
   static configResolvers: Record<string, ConfigResolver> = {};
 
   /**
+   * Opt-in learning trait declaration (#1886).
+   *
+   * **Off by default.** Set to `true` (or a config object) on a subclass to
+   * wire a confidence-scored recall-before / capture-after loop into the agent
+   * lifecycle, backed by {@link LearningMemory}. A non-opted agent behaves
+   * byte-for-byte as it does today — the learning branches are never entered.
+   *
+   * When enabled, `execute()`:
+   * 1. recalls confident memories for {@link learningScope} before `run()`,
+   *    exposing them via {@link recalledMemories};
+   * 2. captures the run outcome after `run()` — a clean completion reinforces
+   *    the staged memory (see {@link stageLearning}); a thrown error or an
+   *    explicit {@link reportLearningOutcome} failure decays it.
+   *
+   * @example
+   * ```typescript
+   * @smrt()
+   * class InvoiceAgent extends Agent {
+   *   static override learning = true; // reuse floor 0.7, success 0.9, fail 0.3
+   *   // or: static override learning = { minConfidence: 0.8, scope: 'invoices' };
+   *   protected config = {};
+   *   async run() {
+   *     const [cached] = this.recalledMemories;
+   *     const strategy = cached?.value ?? (await this.generateStrategy());
+   *     this.stageLearning({ scope: this.learningScope(), key: 'default', value: strategy });
+   *   }
+   * }
+   * ```
+   */
+  static learning: AgentLearningDeclaration = false;
+
+  /**
    * Current agent status
    */
   status: AgentStatusType = 'idle';
@@ -272,6 +313,33 @@ export abstract class Agent extends SmrtObject {
    * Cached DispatchBus instance for inter-agent communication
    */
   private _dispatch: DispatchBus | null = null;
+
+  /**
+   * Cached LearningMemory binding. `undefined` = not yet resolved,
+   * `null` = learning disabled (resolved once, cheaply).
+   */
+  private _learningMemory?: LearningMemory | null;
+
+  /**
+   * The episode the current run acted on, staged via {@link stageLearning} so
+   * the lifecycle can reinforce it after `run()`.
+   */
+  private _learningEpisode: LearningEpisode | null = null;
+
+  /**
+   * Explicit outcome for the current run, set via
+   * {@link reportLearningOutcome}. When unset, a clean `run()` is treated as a
+   * success and a thrown error as a failure.
+   */
+  private _learningOutcome: LearningOutcome | null = null;
+
+  /**
+   * Memories recalled before `run()` when the learning trait is enabled.
+   *
+   * Empty for non-opted agents. Populated by the lifecycle (see
+   * {@link recallForRun}); read from `run()` to reuse prior knowledge.
+   */
+  protected recalledMemories: LearningMemoryRecord[] = [];
 
   /**
    * Creates a new Agent instance
@@ -551,6 +619,130 @@ export abstract class Agent extends SmrtObject {
       this.getAgentTypeName(),
       this.handleDispatch.bind(this),
     );
+  }
+
+  // ============================================================================
+  // Learning Trait (#1886) — opt-in; inert unless `static learning` is set
+  // ============================================================================
+
+  /**
+   * Base memory scope for this agent's learning.
+   *
+   * Defaults to the configured `scope` (if any) or `agent/<agentType>`.
+   * Override to shape how memories are filed (e.g. per task type). Recall and
+   * capture are additionally isolated by the agent instance id (owner), so
+   * memory never bleeds across tenants running the same agent class.
+   */
+  protected learningScope(): string {
+    const resolved = resolveAgentLearning(
+      (this.constructor as typeof Agent).learning,
+    );
+    return resolved.scope ?? `agent/${this.getAgentTypeName()}`;
+  }
+
+  /**
+   * Whether the learning trait is enabled for this agent.
+   */
+  protected isLearningEnabled(): boolean {
+    return resolveAgentLearning((this.constructor as typeof Agent).learning)
+      .enabled;
+  }
+
+  /**
+   * Optional semantic-search arm for {@link LearningMemory}.
+   *
+   * Returns `undefined` by default (keyed-context recall only). Override to
+   * wire embedding search — e.g. return a bound `collection.semanticSearch`.
+   */
+  protected getLearningSemanticSearch(): LearningSemanticSearch | undefined {
+    return undefined;
+  }
+
+  /**
+   * Resolve the tenant id used for the learning scope and semantic filtering.
+   */
+  private resolveLearningTenantId(): string | null {
+    const contextTenant = getCurrentTenant()?.tenantId;
+    if (typeof contextTenant === 'string') return contextTenant;
+    return typeof this.tenantId === 'string' ? this.tenantId : null;
+  }
+
+  /**
+   * Get this agent's {@link LearningMemory} binding, or `null` when learning is
+   * disabled or no database is configured.
+   *
+   * Cheap and side-effect-free when the trait is off (returns `null` after a
+   * single static-flag check), which keeps non-opted agents unchanged.
+   */
+  getLearningMemory(): LearningMemory | null {
+    if (this._learningMemory !== undefined) {
+      return this._learningMemory;
+    }
+
+    const resolved = resolveAgentLearning(
+      (this.constructor as typeof Agent).learning,
+    );
+    if (!resolved.enabled || !this._db) {
+      this._learningMemory = null;
+      return null;
+    }
+
+    // Ensure a stable owner id so memory is bound to this instance.
+    if (!this.id) {
+      this.id = crypto.randomUUID();
+    }
+
+    this._learningMemory = new LearningMemory({
+      db: this.systemDb,
+      ownerClass: this.getAgentTypeName(),
+      ownerId: this.id as string,
+      tenantId: this.resolveLearningTenantId(),
+      semanticSearch: this.getLearningSemanticSearch(),
+      config: resolved.memoryConfig,
+    });
+    return this._learningMemory;
+  }
+
+  /**
+   * Recall relevant memories before `run()`.
+   *
+   * Default: a scope-wide, confidence-filtered recall of {@link learningScope}.
+   * Override to shape the recall (e.g. a keyed lookup or a semantic query).
+   */
+  protected async recallForRun(
+    memory: LearningMemory,
+  ): Promise<LearningMemoryRecord[]> {
+    return memory.recall(this.learningScope());
+  }
+
+  /**
+   * Capture the run outcome after `run()`.
+   *
+   * Default: reinforce the memory staged via {@link stageLearning}. A no-op
+   * when nothing was staged. Override for bespoke capture logic.
+   */
+  protected async captureForRun(
+    memory: LearningMemory,
+    outcome: LearningOutcome,
+  ): Promise<void> {
+    if (!this._learningEpisode) return;
+    await memory.capture(this._learningEpisode, outcome);
+  }
+
+  /**
+   * Stage the memory episode the current run acted on, so the lifecycle
+   * reinforces it after `run()` completes. Call from `run()`.
+   */
+  protected stageLearning(episode: LearningEpisode): void {
+    this._learningEpisode = episode;
+  }
+
+  /**
+   * Report an explicit outcome for the current run (e.g. a validated failure
+   * that did not throw). Overrides the default success/throw inference.
+   */
+  protected reportLearningOutcome(outcome: LearningOutcome): void {
+    this._learningOutcome = outcome;
   }
 
   /**
@@ -834,6 +1026,9 @@ export abstract class Agent extends SmrtObject {
    * ```
    */
   async execute(): Promise<void> {
+    // Learning trait (#1886): resolves to null for non-opted agents, so every
+    // guarded branch below is skipped and behaviour is unchanged.
+    let learning: LearningMemory | null = null;
     try {
       await this.initialize();
       await this.validate();
@@ -852,14 +1047,46 @@ export abstract class Agent extends SmrtObject {
         }
       }
 
+      // Learning: recall-before-run
+      learning = this.getLearningMemory();
+      if (learning) {
+        this.recalledMemories = await this.recallForRun(learning);
+      }
+
       await this.run();
+
+      // Learning: capture-after-run (success unless run reported otherwise)
+      if (learning) {
+        await this.captureForRun(
+          learning,
+          this._learningOutcome ?? { success: true },
+        );
+      }
+
       this.status = 'idle';
 
       this.logger.info('Agent execution completed');
     } catch (error) {
+      // Learning: capture the failure, but never mask the original error.
+      if (learning) {
+        try {
+          await this.captureForRun(learning, {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        } catch (captureError) {
+          this.logger.warn('Learning capture failed during error handling', {
+            error: captureError,
+          });
+        }
+      }
       this.status = 'error';
       this.logger.error('Agent execution failed', { error });
       throw error;
+    } finally {
+      // Reset per-run learning state so a reused instance starts clean.
+      this._learningEpisode = null;
+      this._learningOutcome = null;
     }
   }
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -106,6 +106,14 @@ export type {
   QueryFn,
 } from './interests.js';
 export { mergeFilters, normalizeSort } from './interests.js';
+// Opt-in Learning trait config (#1886). The underlying LearningMemory + its
+// records/outcomes live in @happyvertical/smrt-core.
+export {
+  type AgentLearningConfig,
+  type AgentLearningDeclaration,
+  type ResolvedAgentLearning,
+  resolveAgentLearning,
+} from './learning.js';
 export {
   AgentSchedule,
   AgentScheduleCollection,

--- a/packages/agents/src/learning-integration.test.ts
+++ b/packages/agents/src/learning-integration.test.ts
@@ -77,16 +77,10 @@ class LearningSampleAgent extends Agent {
     }
     this.lastStrategy = strategy;
 
-    // Stage the episode so the lifecycle reinforces it after run(). When the
-    // strategy was freshly generated (e.g. after the previous one decayed),
-    // `updateValue` replaces the stored value so a superseded/failed strategy
-    // is not later recalled at rising confidence.
-    this.stageLearning({
-      scope: this.learningScope(),
-      key,
-      value: strategy,
-      updateValue: this.lastStrategySource === 'generated',
-    });
+    // Stage the strategy this run acted on; the lifecycle reinforces it after
+    // run(). capture() reflects the staged value in storage, so a regenerated
+    // strategy (after the previous one decayed) supersedes the stale one.
+    this.stageLearning({ scope: this.learningScope(), key, value: strategy });
 
     // A validated failure decays the memory without throwing.
     if (!this.strategyValid) {

--- a/packages/agents/src/learning-integration.test.ts
+++ b/packages/agents/src/learning-integration.test.ts
@@ -1,0 +1,214 @@
+/**
+ * End-to-end integration test for the opt-in Learning trait (#1886).
+ *
+ * Drives a full **learn → recall → adapt** cycle on a reference sample learning
+ * agent across multiple runs, proving:
+ *   - a first run generates a strategy and captures success (seeds confident memory);
+ *   - a later run recalls and reuses it (no regeneration) and success strengthens it;
+ *   - a failing run decays it below the reuse floor;
+ *   - the next run stops reusing it and regenerates.
+ *
+ * Uses a real in-memory SQLite database (system tables bootstrapped by
+ * `initialize()`). The sample's "AI" is an in-process counter standing in for
+ * the real AI boundary, so nothing external is touched.
+ *
+ * (Named `*.test.ts` rather than `*.spec.ts` because the agents package's
+ * vitest config only includes `src/**\/*.test.ts`.)
+ */
+
+import { smrt } from '@happyvertical/smrt-core';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Agent } from './agent.js';
+import type { AgentLearningConfig } from './learning.js';
+
+// -----------------------------------------------------------------------------
+// Reference sample learning agent.
+//
+// This is the canonical shape of an agent that opts into learning: it recalls a
+// confident cached strategy before acting, reuses it when present, generates a
+// fresh one (its stand-in for an AI call) when not, and stages the episode so
+// the lifecycle reinforces the outcome after `run()`. A validated failure is
+// reported without throwing so a bad strategy decays and stops being reused —
+// the generalisation of anytown `praeco`'s confidence-scored parser cache.
+// -----------------------------------------------------------------------------
+@smrt()
+class LearningSampleAgent extends Agent {
+  /** Single-declaration opt-in. Off by default on the base class. */
+  static override learning: AgentLearningConfig = { enabled: true };
+
+  protected config = {};
+
+  /** The task this run should solve; also the memory key. */
+  task = 'invoice';
+  /** Test hook: whether the strategy used this run proved valid. */
+  strategyValid = true;
+
+  /** Number of "AI" strategy generations (should not advance when reusing). */
+  aiCalls = 0;
+  /** The strategy acted on this run. */
+  lastStrategy: string | null = null;
+  /** Whether the strategy was recalled from memory or freshly generated. */
+  lastStrategySource: 'recalled' | 'generated' | null = null;
+
+  /** Stand-in for a real AI call that synthesises a strategy for a task. */
+  protected async generateStrategy(task: string): Promise<string> {
+    this.aiCalls += 1;
+    return `strategy:${task}:v${this.aiCalls}`;
+  }
+
+  override learningScope(): string {
+    return `sample/${this.task}`;
+  }
+
+  async run(): Promise<void> {
+    const key = this.task;
+
+    // Recall-before-run has already populated `recalledMemories` (confidence
+    // >= floor). Reuse a confident strategy; otherwise generate a new one.
+    const recalled = this.recalledMemories.find((m) => m.key === key);
+    let strategy: string;
+    if (recalled) {
+      strategy = String(recalled.value);
+      this.lastStrategySource = 'recalled';
+    } else {
+      strategy = await this.generateStrategy(key);
+      this.lastStrategySource = 'generated';
+    }
+    this.lastStrategy = strategy;
+
+    // Stage the episode so the lifecycle reinforces it after run().
+    this.stageLearning({ scope: this.learningScope(), key, value: strategy });
+
+    // A validated failure decays the memory without throwing.
+    if (!this.strategyValid) {
+      this.reportLearningOutcome({ success: false, error: 'strategy invalid' });
+    }
+  }
+}
+
+async function readMemoryRow(
+  db: Awaited<ReturnType<typeof getDatabase>>,
+  ownerId: string,
+  scope: string,
+  key: string,
+) {
+  return db.get('_smrt_contexts', {
+    owner_id: ownerId,
+    scope,
+    key,
+    version: 1,
+  });
+}
+
+async function countContexts(
+  db: Awaited<ReturnType<typeof getDatabase>>,
+): Promise<number> {
+  const { rows } = await db.query('SELECT COUNT(*) AS n FROM _smrt_contexts');
+  return Number(rows[0]?.n ?? 0);
+}
+
+describe('Learning trait — end-to-end learn → recall → adapt (#1886)', () => {
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+
+  beforeEach(async () => {
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('generates on the first run and seeds a confident memory', async () => {
+    const agent = new LearningSampleAgent({ name: 'learner', db });
+    await agent.execute();
+
+    expect(agent.lastStrategySource).toBe('generated');
+    expect(agent.aiCalls).toBe(1);
+
+    const row = await readMemoryRow(
+      db,
+      agent.id as string,
+      'sample/invoice',
+      'invoice',
+    );
+    expect(row).not.toBeNull();
+    expect(Number(row?.confidence)).toBeCloseTo(0.9, 5);
+    expect(Number(row?.success_count)).toBe(1);
+    expect(Number(row?.failure_count)).toBe(0);
+  });
+
+  it('recalls and reuses a confident memory on the second run, strengthening it', async () => {
+    const agent = new LearningSampleAgent({ name: 'learner', db });
+
+    await agent.execute(); // run 1 — generate
+    await agent.execute(); // run 2 — recall + reuse
+
+    // Reused without a fresh generation.
+    expect(agent.lastStrategySource).toBe('recalled');
+    expect(agent.aiCalls).toBe(1);
+    expect(agent.lastStrategy).toBe('strategy:invoice:v1');
+
+    const row = await readMemoryRow(
+      db,
+      agent.id as string,
+      'sample/invoice',
+      'invoice',
+    );
+    // 0.9 -> 0.9 + 0.5*(1 - 0.9) = 0.95 (strengthened).
+    expect(Number(row?.confidence)).toBeCloseTo(0.95, 5);
+    expect(Number(row?.success_count)).toBe(2);
+  });
+
+  it('decays below the reuse floor on failure and stops reusing on the next run', async () => {
+    const agent = new LearningSampleAgent({ name: 'learner', db });
+
+    await agent.execute(); // run 1 — generate, success (0.9)
+    await agent.execute(); // run 2 — reuse, success (0.95)
+
+    // Run 3 — the strategy proves invalid.
+    agent.strategyValid = false;
+    await agent.execute();
+    expect(agent.lastStrategySource).toBe('recalled'); // still reused this run
+
+    const decayed = await readMemoryRow(
+      db,
+      agent.id as string,
+      'sample/invoice',
+      'invoice',
+    );
+    // 0.95 -> 0.95 + 0.5*(0.3 - 0.95) = 0.625 (< 0.7 floor).
+    expect(Number(decayed?.confidence)).toBeCloseTo(0.625, 5);
+    expect(Number(decayed?.failure_count)).toBe(1);
+    expect(Number(decayed?.confidence)).toBeLessThan(0.7);
+
+    // Run 4 — memory is below the floor, so recall omits it and the agent
+    // regenerates rather than reusing a strategy that stopped working.
+    agent.strategyValid = true;
+    await agent.execute();
+    expect(agent.lastStrategySource).toBe('generated');
+    expect(agent.aiCalls).toBe(2);
+  });
+
+  it('isolates memory by owner — a distinct agent instance starts cold', async () => {
+    const agentA = new LearningSampleAgent({ name: 'learner-a', db });
+    const agentB = new LearningSampleAgent({ name: 'learner-b', db });
+
+    await agentA.execute(); // A learns
+    await agentB.execute(); // B has its own owner id → starts cold
+
+    expect(agentA.id).not.toBe(agentB.id);
+    expect(agentA.aiCalls).toBe(1);
+    // B did not inherit A's learned strategy despite the same class + scope.
+    expect(agentB.lastStrategySource).toBe('generated');
+
+    // Two independent memory rows exist — one per owner.
+    expect(await countContexts(db)).toBe(2);
+    expect(
+      await readMemoryRow(db, agentA.id as string, 'sample/invoice', 'invoice'),
+    ).not.toBeNull();
+    expect(
+      await readMemoryRow(db, agentB.id as string, 'sample/invoice', 'invoice'),
+    ).not.toBeNull();
+  });
+});

--- a/packages/agents/src/learning-integration.test.ts
+++ b/packages/agents/src/learning-integration.test.ts
@@ -77,8 +77,16 @@ class LearningSampleAgent extends Agent {
     }
     this.lastStrategy = strategy;
 
-    // Stage the episode so the lifecycle reinforces it after run().
-    this.stageLearning({ scope: this.learningScope(), key, value: strategy });
+    // Stage the episode so the lifecycle reinforces it after run(). When the
+    // strategy was freshly generated (e.g. after the previous one decayed),
+    // `updateValue` replaces the stored value so a superseded/failed strategy
+    // is not later recalled at rising confidence.
+    this.stageLearning({
+      scope: this.learningScope(),
+      key,
+      value: strategy,
+      updateValue: this.lastStrategySource === 'generated',
+    });
 
     // A validated failure decays the memory without throwing.
     if (!this.strategyValid) {
@@ -188,6 +196,17 @@ describe('Learning trait — end-to-end learn → recall → adapt (#1886)', () 
     await agent.execute();
     expect(agent.lastStrategySource).toBe('generated');
     expect(agent.aiCalls).toBe(2);
+
+    // The regenerated strategy supersedes the failed one in storage, so a
+    // later run recalls the new strategy — never the one that stopped working.
+    const regenerated = await readMemoryRow(
+      db,
+      agent.id as string,
+      'sample/invoice',
+      'invoice',
+    );
+    expect(JSON.parse(String(regenerated?.value))).toBe('strategy:invoice:v2');
+    expect(Number(regenerated?.confidence)).toBeGreaterThanOrEqual(0.7);
   });
 
   it('isolates memory by owner — a distinct agent instance starts cold', async () => {

--- a/packages/agents/src/learning.test.ts
+++ b/packages/agents/src/learning.test.ts
@@ -161,6 +161,28 @@ describe('Learning trait — lifecycle seams', () => {
     expect(agent.recalledCountAtRun).toBe(1);
   });
 
+  it('learns on the scheduled path — recall/capture fire when run() is called directly (not execute)', async () => {
+    // ScheduleRunner → TaskRunner constructs the agent, calls initialize(), then
+    // invokes its configured method (default 'run') DIRECTLY, bypassing
+    // execute(). The learning loop must still fire on this path.
+    const agent = new WiringAgent({ name: 'scheduled', db });
+    await agent.initialize();
+    await agent.run(); // direct invocation, no execute()
+
+    // capture-after fired: the staged episode was persisted.
+    const row = await db.get('_smrt_contexts', {
+      owner_id: agent.id as string,
+      key: 'strategy',
+      version: 1,
+    });
+    expect(row).not.toBeNull();
+    expect(Number(row?.success_count)).toBe(1);
+
+    // recall-before fired on the next direct run: the prior memory is recalled.
+    await agent.run();
+    expect(agent.recalledCountAtRun).toBe(1);
+  });
+
   it('captures a reported failure so the memory decays', async () => {
     const agent = new WiringAgent({ name: 'wiring-fail', db });
     agent.fail = true;

--- a/packages/agents/src/learning.test.ts
+++ b/packages/agents/src/learning.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for the opt-in Learning trait wiring (#1886):
+ *   - `resolveAgentLearning` declaration normalisation;
+ *   - off-by-default guarantee (a non-opted agent is unchanged);
+ *   - recall-before / capture-after lifecycle seams.
+ *
+ * Real in-memory SQLite; nothing mocked.
+ */
+
+import { smrt } from '@happyvertical/smrt-core';
+import { getDatabase } from '@happyvertical/sql';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Agent } from './agent.js';
+import { type AgentLearningConfig, resolveAgentLearning } from './learning.js';
+
+async function countContexts(
+  db: Awaited<ReturnType<typeof getDatabase>>,
+): Promise<number> {
+  const { rows } = await db.query('SELECT COUNT(*) AS n FROM _smrt_contexts');
+  return Number(rows[0]?.n ?? 0);
+}
+
+// -----------------------------------------------------------------------------
+// Test agents (top-level so the manifest scanner picks up field metadata).
+// -----------------------------------------------------------------------------
+
+/** Not opted in — must behave byte-for-byte as today. */
+@smrt()
+class NonLearningAgent extends Agent {
+  protected config = {};
+  ran = false;
+  async run(): Promise<void> {
+    this.ran = true;
+  }
+}
+
+/** Opted in via a config object; stages an episode and snapshots recall. */
+@smrt()
+class WiringAgent extends Agent {
+  static override learning: AgentLearningConfig = { enabled: true };
+  protected config = {};
+
+  fail = false;
+  recalledCountAtRun = -1;
+
+  async run(): Promise<void> {
+    // recall-before-run must have populated recalledMemories by now.
+    this.recalledCountAtRun = this.recalledMemories.length;
+    this.stageLearning({
+      scope: this.learningScope(),
+      key: 'strategy',
+      value: { plan: 'A' },
+    });
+    if (this.fail) {
+      this.reportLearningOutcome({ success: false, error: 'bad' });
+    }
+  }
+}
+
+/** Opted in; throws from run() to exercise the failure-capture path. */
+@smrt()
+class ThrowingLearner extends Agent {
+  static override learning = true;
+  protected config = {};
+
+  async run(): Promise<void> {
+    this.stageLearning({ scope: this.learningScope(), key: 'k', value: 'v' });
+    throw new Error('run exploded');
+  }
+}
+
+describe('resolveAgentLearning', () => {
+  it('treats undefined and false as disabled', () => {
+    expect(resolveAgentLearning(undefined)).toEqual({
+      enabled: false,
+      memoryConfig: {},
+    });
+    expect(resolveAgentLearning(false)).toEqual({
+      enabled: false,
+      memoryConfig: {},
+    });
+  });
+
+  it('treats true as enabled with defaults', () => {
+    expect(resolveAgentLearning(true)).toEqual({
+      enabled: true,
+      scope: undefined,
+      memoryConfig: {},
+    });
+  });
+
+  it('forwards only explicitly-set thresholds (never clobbers defaults with undefined)', () => {
+    const resolved = resolveAgentLearning({
+      scope: 'invoices',
+      minConfidence: 0.8,
+    });
+    expect(resolved.enabled).toBe(true);
+    expect(resolved.scope).toBe('invoices');
+    expect(resolved.memoryConfig).toEqual({ minConfidence: 0.8 });
+    // Unset keys are absent, not `undefined`.
+    expect('successConfidence' in resolved.memoryConfig).toBe(false);
+  });
+
+  it('honours an explicit enabled:false in a config object', () => {
+    expect(resolveAgentLearning({ enabled: false, scope: 'x' })).toEqual({
+      enabled: false,
+      scope: 'x',
+      memoryConfig: {},
+    });
+  });
+});
+
+describe('Learning trait — off by default', () => {
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+
+  beforeEach(async () => {
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+  });
+
+  it('a non-opted agent has no learning memory, empty recall, and writes no rows', async () => {
+    const agent = new NonLearningAgent({ name: 'plain', db });
+    await agent.execute();
+
+    expect(agent.ran).toBe(true);
+    expect(agent.status).toBe('idle');
+    expect(agent.getLearningMemory()).toBeNull();
+    expect(await countContexts(db)).toBe(0);
+  });
+
+  it('getLearningMemory() is null before initialize when disabled (no db access)', () => {
+    const agent = new NonLearningAgent({ name: 'plain-2' });
+    expect(agent.getLearningMemory()).toBeNull();
+  });
+});
+
+describe('Learning trait — lifecycle seams', () => {
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+
+  beforeEach(async () => {
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+  });
+
+  it('recalls before run() and captures a staged success after run()', async () => {
+    const agent = new WiringAgent({ name: 'wiring', db });
+
+    await agent.execute();
+    // First run: nothing to recall yet.
+    expect(agent.recalledCountAtRun).toBe(0);
+    expect(agent.getLearningMemory()).not.toBeNull();
+
+    const row = await db.get('_smrt_contexts', {
+      owner_id: agent.id as string,
+      key: 'strategy',
+      version: 1,
+    });
+    expect(JSON.parse(String(row?.value))).toEqual({ plan: 'A' });
+    expect(Number(row?.success_count)).toBe(1);
+
+    // Second run: the staged strategy is now recalled before run().
+    await agent.execute();
+    expect(agent.recalledCountAtRun).toBe(1);
+  });
+
+  it('captures a reported failure so the memory decays', async () => {
+    const agent = new WiringAgent({ name: 'wiring-fail', db });
+    agent.fail = true;
+
+    await agent.execute();
+
+    const row = await db.get('_smrt_contexts', {
+      owner_id: agent.id as string,
+      key: 'strategy',
+      version: 1,
+    });
+    // Fresh insert on failure seeds at the failure confidence (0.3).
+    expect(Number(row?.confidence)).toBeCloseTo(0.3, 5);
+    expect(Number(row?.failure_count)).toBe(1);
+  });
+
+  it('captures failure when run() throws, then re-throws the original error', async () => {
+    const agent = new ThrowingLearner({ name: 'thrower', db });
+
+    await expect(agent.execute()).rejects.toThrow('run exploded');
+    expect(agent.status).toBe('error');
+
+    const row = await db.get('_smrt_contexts', {
+      owner_id: agent.id as string,
+      key: 'k',
+      version: 1,
+    });
+    expect(row).not.toBeNull();
+    expect(Number(row?.failure_count)).toBe(1);
+    expect(Number(row?.confidence)).toBeCloseTo(0.3, 5);
+  });
+});

--- a/packages/agents/src/learning.ts
+++ b/packages/agents/src/learning.ts
@@ -1,0 +1,94 @@
+/**
+ * Opt-in Learning trait configuration for {@link Agent} (#1886).
+ *
+ * The trait is **off by default**: an agent that does not declare
+ * `static learning` behaves byte-for-byte as it does today. Declaring it — with
+ * a single `static learning = true` (or a config object) — wires a
+ * confidence-scored recall-before / capture-after loop into the agent
+ * lifecycle, backed by {@link LearningMemory} from `@happyvertical/smrt-core`.
+ *
+ * @module
+ */
+
+import type { LearningMemoryConfig } from '@happyvertical/smrt-core';
+
+/**
+ * Per-agent learning configuration. All fields are optional; omitted
+ * thresholds fall back to {@link LearningMemory}'s defaults (the proven
+ * `praeco` values: reuse floor 0.7, success 0.9, failure 0.3).
+ */
+export interface AgentLearningConfig {
+  /** Explicit enable flag. Defaults to `true` when a config object is given. */
+  enabled?: boolean;
+  /**
+   * Base memory scope for this agent. Defaults to `agent/<agentType>`.
+   * Recall/capture are additionally isolated by the agent instance id (owner),
+   * so two tenants running the same agent class never share memory.
+   */
+  scope?: string;
+  /** Reuse floor — recall omits memories below this confidence. Default 0.7. */
+  minConfidence?: number;
+  /** Confidence a memory is seeded at on a first success. Default 0.9. */
+  successConfidence?: number;
+  /** Target a memory decays toward on failure. Default 0.3. */
+  failureConfidence?: number;
+  /** Reinforcement blend weight in `[0, 1]`. Default 0.5. */
+  reinforcement?: number;
+  /** Optional half-life (ms) for time-based confidence decay. */
+  decayHalfLifeMs?: number;
+}
+
+/**
+ * The `static learning` declaration accepted on an {@link Agent} subclass:
+ * `false` (default, off), `true` (on with defaults), or a config object.
+ */
+export type AgentLearningDeclaration = AgentLearningConfig | boolean;
+
+/** Normalised learning settings resolved from a declaration. */
+export interface ResolvedAgentLearning {
+  enabled: boolean;
+  scope?: string;
+  /** Threshold overrides to pass to `LearningMemory` (only defined keys). */
+  memoryConfig: Partial<LearningMemoryConfig>;
+}
+
+/**
+ * Resolve a `static learning` declaration into normalised settings.
+ *
+ * Only keys explicitly set on the declaration are forwarded to
+ * `LearningMemory`, so unset thresholds keep the module's defaults rather than
+ * clobbering them with `undefined`.
+ */
+export function resolveAgentLearning(
+  declaration: AgentLearningDeclaration | undefined,
+): ResolvedAgentLearning {
+  if (declaration === undefined || declaration === false) {
+    return { enabled: false, memoryConfig: {} };
+  }
+  if (declaration === true) {
+    return { enabled: true, memoryConfig: {} };
+  }
+
+  const memoryConfig: Partial<LearningMemoryConfig> = {};
+  if (declaration.minConfidence !== undefined) {
+    memoryConfig.minConfidence = declaration.minConfidence;
+  }
+  if (declaration.successConfidence !== undefined) {
+    memoryConfig.successConfidence = declaration.successConfidence;
+  }
+  if (declaration.failureConfidence !== undefined) {
+    memoryConfig.failureConfidence = declaration.failureConfidence;
+  }
+  if (declaration.reinforcement !== undefined) {
+    memoryConfig.reinforcement = declaration.reinforcement;
+  }
+  if (declaration.decayHalfLifeMs !== undefined) {
+    memoryConfig.decayHalfLifeMs = declaration.decayHalfLifeMs;
+  }
+
+  return {
+    enabled: declaration.enabled ?? true,
+    scope: declaration.scope,
+    memoryConfig,
+  };
+}

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -11,6 +11,7 @@ ORM, code generation, AI integration, and the DispatchBus. Everything else build
 | ObjectRegistry | `src/registry.ts` | Global singleton (globalThis) — class metadata, fields, STI chains, manifests |
 | DispatchBus | `src/dispatch/bus.ts` | Inter-agent messaging — emit, subscribe (persistent), process |
 | GlobalInterceptors | `src/interceptors.ts` | Plugin system — beforeList/Get/Save/Delete hooks (used by tenancy) |
+| LearningMemory | `src/learning/memory.ts` | Confidence-scored recall/capture over `_smrt_contexts` + embeddings (#1886) |
 
 ## SmrtObject Lifecycle
 
@@ -21,6 +22,25 @@ ORM, code generation, AI integration, and the DispatchBus. Everything else build
 - `is(criteria)` / `do(instructions)` / `describe()`: AI operations via function calling. They inject the object's own `toPublicJSON()` (sensitive fields stripped) as a "content body" so the model reasons over the instance. Options: `includeData: false` skips injection (for callers that already curate the relevant fields into the instruction); `maxDataLength` overrides the truncation budget. Neither key is forwarded to `ai.message()`. (#1567)
 - `getSlug()`: auto-generates from name → title → label → id
 - `loadRelated(fieldName)`: lazy-loads relationships (cached in `_loadedRelationships` Map)
+
+## LearningMemory (#1886)
+
+Confidence-scored, self-correcting memory over the existing `_smrt_contexts` (keyed recall) and `_smrt_embeddings` (semantic recall) substrate. Wires the reinforcement columns that ship on `_smrt_contexts` but were never written (`success_count`, `failure_count`, and a `last_used_at` that recall now refreshes). This is L1 of the tenant-learning-agents epic; the opt-in `Learning` trait in `@happyvertical/smrt-agents` composes it into the agent lifecycle.
+
+```typescript
+const memory = new LearningMemory({ db: obj.systemDb, ownerClass: 'InvoiceAgent', ownerId: obj.id, tenantId });
+
+// recall — union of keyed-context lookup + (optional) semantic search, confidence-filtered
+const [hit] = await memory.recall('parser/acme', { key: docUrl }); // or { query } with a wired semanticSearch
+const strategy = hit?.value ?? (await generate());
+
+// capture — reinforce the outcome
+await memory.capture({ scope: 'parser/acme', key: docUrl, value: strategy }, { success: ok });
+```
+
+- **`capture(episode, outcome)`**: success strengthens `confidence` toward 1.0 + increments `success_count`; failure decays toward `failureConfidence` (default 0.3) + increments `failure_count`. Defaults (`minConfidence` 0.7, `successConfidence` 0.9, `reinforcement` 0.5) mean a single failure drops a confident memory below the reuse floor. Seeds a new row when none exists and the episode carries a `value` (a failed first attempt is retained at low confidence for self-correction).
+- **`recall(scope, opts)`**: owner-scoped keyed lookup (thus tenant-isolated) filtered by the confidence floor, expiry, and optional time-decay, with hierarchical scope fallback; unions an injected `semanticSearch` arm when a `query` is given (tenant-scoped via its `where`). Refreshes `last_used_at` on returned rows.
+- Injected `semanticSearch` matches `SmrtCollection.semanticSearch`, so `LearningMemory` never reaches into a collection's internals.
 
 ## SmrtCollection Query
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -145,6 +145,18 @@ export {
   resolveLazyConfig,
   unregisterConfigResolver,
 } from './lazy-config';
+// Learning memory — confidence-scored, self-correcting recall/capture (#1886)
+export {
+  DEFAULT_LEARNING_CONFIG,
+  type LearningEpisode,
+  LearningMemory,
+  type LearningMemoryConfig,
+  type LearningMemoryOptions,
+  type LearningMemoryRecord,
+  type LearningOutcome,
+  type LearningRecallOptions,
+  type LearningSemanticSearch,
+} from './learning/index';
 // Static manifest (generated at build time)
 export * from './manifest/index';
 export type { DiffOptions } from './migrations/differ';

--- a/packages/core/src/learning/index.ts
+++ b/packages/core/src/learning/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Learning primitives — confidence-scored, self-correcting memory (L1 of the
+ * tenant-learning-agents epic, #1885 / #1886).
+ *
+ * @module
+ */
+
+export {
+  DEFAULT_LEARNING_CONFIG,
+  type LearningEpisode,
+  LearningMemory,
+  type LearningMemoryConfig,
+  type LearningMemoryOptions,
+  type LearningMemoryRecord,
+  type LearningOutcome,
+  type LearningRecallOptions,
+  type LearningSemanticSearch,
+} from './memory.js';

--- a/packages/core/src/learning/memory.test.ts
+++ b/packages/core/src/learning/memory.test.ts
@@ -1,0 +1,484 @@
+/**
+ * Unit tests for LearningMemory (#1886).
+ *
+ * Uses a real in-memory SQLite database with the `_smrt_contexts` /
+ * `_smrt_embeddings` system tables; only the AI embedding boundary is mocked.
+ */
+
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SmrtCollection } from '../collection';
+import { EmbeddingProvider } from '../embeddings/provider';
+import { SmrtObject } from '../object';
+import { ObjectRegistry, smrt } from '../registry';
+import { getTestDatabase } from '../testing/database';
+import { LearningMemory, type LearningSemanticSearch } from './memory';
+
+const OWNER_CLASS = 'TestLearner';
+
+async function readRow(
+  db: DatabaseInterface,
+  ownerId: string,
+  scope: string,
+  key: string,
+) {
+  return db.get('_smrt_contexts', {
+    owner_class: OWNER_CLASS,
+    owner_id: ownerId,
+    scope,
+    key,
+    version: 1,
+  });
+}
+
+describe('LearningMemory', () => {
+  let db: DatabaseInterface;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ includeSystemTables: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeMemory(ownerId = 'owner-1', overrides = {}) {
+    return new LearningMemory({
+      db,
+      ownerClass: OWNER_CLASS,
+      ownerId,
+      ...overrides,
+    });
+  }
+
+  describe('capture()', () => {
+    it('seeds a new memory at successConfidence and increments success_count on success', async () => {
+      const memory = makeMemory();
+
+      const record = await memory.capture(
+        { scope: 'parser/acme', key: 'invoice', value: { selector: '.total' } },
+        { success: true },
+      );
+
+      expect(record).not.toBeNull();
+      expect(record?.confidence).toBeCloseTo(0.9, 5);
+      expect(record?.successCount).toBe(1);
+      expect(record?.failureCount).toBe(0);
+
+      const row = await readRow(db, 'owner-1', 'parser/acme', 'invoice');
+      expect(Number(row?.confidence)).toBeCloseTo(0.9, 5);
+      expect(Number(row?.success_count)).toBe(1);
+      expect(Number(row?.failure_count)).toBe(0);
+    });
+
+    it('raises confidence and increments success_count on repeat success', async () => {
+      const memory = makeMemory();
+      const episode = {
+        scope: 'parser/acme',
+        key: 'invoice',
+        value: { selector: '.total' },
+      };
+
+      const first = await memory.capture(episode, { success: true });
+      const second = await memory.capture(episode, { success: true });
+
+      // 0.9 -> 0.9 + 0.5*(1 - 0.9) = 0.95
+      expect(second?.confidence).toBeGreaterThan(first?.confidence ?? 0);
+      expect(second?.confidence).toBeCloseTo(0.95, 5);
+      expect(second?.successCount).toBe(2);
+      expect(second?.failureCount).toBe(0);
+    });
+
+    it('lowers confidence and increments failure_count on failure', async () => {
+      const memory = makeMemory();
+      const episode = {
+        scope: 'parser/acme',
+        key: 'invoice',
+        value: { selector: '.total' },
+      };
+
+      await memory.capture(episode, { success: true }); // 0.9
+      const failed = await memory.capture(episode, {
+        success: false,
+        error: 'no match',
+      });
+
+      // 0.9 -> 0.9 + 0.5*(0.3 - 0.9) = 0.6
+      expect(failed?.confidence).toBeCloseTo(0.6, 5);
+      expect(failed?.confidence).toBeLessThan(0.7);
+      expect(failed?.successCount).toBe(1);
+      expect(failed?.failureCount).toBe(1);
+    });
+
+    it('drops a memory below the reuse floor in a single failure from any confident value', async () => {
+      const memory = makeMemory();
+      const episode = { scope: 's', key: 'k', value: 'v' };
+
+      // Climb confidence high with repeated successes.
+      for (let i = 0; i < 5; i++) {
+        await memory.capture(episode, { success: true });
+      }
+      const beforeFail = await readRow(db, 'owner-1', 's', 'k');
+      expect(Number(beforeFail?.confidence)).toBeGreaterThan(0.9);
+
+      const failed = await memory.capture(episode, { success: false });
+      expect(failed?.confidence).toBeLessThan(0.7);
+    });
+
+    it('retains a failed first attempt at low confidence for self-correction context', async () => {
+      const memory = makeMemory();
+
+      const record = await memory.capture(
+        { scope: 's', key: 'k', value: 'bad-attempt' },
+        { success: false, error: 'threw' },
+      );
+
+      expect(record?.confidence).toBeCloseTo(0.3, 5);
+      expect(record?.failureCount).toBe(1);
+
+      const row = await readRow(db, 'owner-1', 's', 'k');
+      expect(row).not.toBeNull();
+      expect(JSON.parse(String(row?.metadata)).lastError).toBe('threw');
+    });
+
+    it('returns null when there is no existing memory and no value to seed', async () => {
+      const memory = makeMemory();
+      const record = await memory.capture(
+        { scope: 's', key: 'missing' },
+        { success: true },
+      );
+      expect(record).toBeNull();
+    });
+
+    it('supports a numeric metric outcome (positive => success)', async () => {
+      const memory = makeMemory();
+      const episode = { scope: 's', key: 'k', value: 'v' };
+
+      await memory.capture(episode, { success: true });
+      const up = await memory.capture(episode, { metric: 5 });
+      expect(up?.successCount).toBe(2);
+
+      const down = await memory.capture(episode, { metric: -3 });
+      expect(down?.failureCount).toBe(1);
+      expect(down?.confidence).toBeLessThan(up?.confidence ?? 1);
+    });
+  });
+
+  describe('recall() — keyed context arm', () => {
+    it('returns a confident memory by key', async () => {
+      const memory = makeMemory();
+      await memory.capture(
+        { scope: 'parser/acme', key: 'invoice', value: { selector: '.total' } },
+        { success: true },
+      );
+
+      const results = await memory.recall('parser/acme', { key: 'invoice' });
+      expect(results).toHaveLength(1);
+      expect(results[0].value).toEqual({ selector: '.total' });
+      expect(results[0].source).toBe('context');
+      expect(results[0].confidence).toBeCloseTo(0.9, 5);
+    });
+
+    it('does not return a memory decayed below the reuse floor', async () => {
+      const memory = makeMemory();
+      const episode = { scope: 's', key: 'k', value: 'v' };
+      await memory.capture(episode, { success: true }); // 0.9
+      await memory.capture(episode, { success: false }); // 0.6 (< 0.7)
+
+      const results = await memory.recall('s', { key: 'k' });
+      expect(results).toHaveLength(0);
+    });
+
+    it('honours an explicit minConfidence override', async () => {
+      const memory = makeMemory();
+      const episode = { scope: 's', key: 'k', value: 'v' };
+      await memory.capture(episode, { success: true }); // 0.9
+      await memory.capture(episode, { success: false }); // 0.6
+
+      // Below the default 0.7 floor, but retrievable at a lower floor.
+      const results = await memory.recall('s', {
+        key: 'k',
+        minConfidence: 0.5,
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0].confidence).toBeCloseTo(0.6, 5);
+    });
+
+    it('recalls all confident keys in a scope when no key is given', async () => {
+      const memory = makeMemory();
+      await memory.capture(
+        { scope: 's', key: 'a', value: 1 },
+        { success: true },
+      );
+      await memory.capture(
+        { scope: 's', key: 'b', value: 2 },
+        { success: true },
+      );
+      await memory.capture(
+        { scope: 's', key: 'c', value: 3 },
+        { success: false },
+      ); // 0.3
+
+      const results = await memory.recall('s');
+      const keys = results.map((r) => r.key).sort();
+      expect(keys).toEqual(['a', 'b']); // 'c' decayed below floor
+    });
+
+    it('falls back up the scope hierarchy when no match at the leaf scope', async () => {
+      const memory = makeMemory();
+      await memory.capture(
+        { scope: 'parser', key: 'default', value: 'fallback' },
+        { success: true },
+      );
+
+      const results = await memory.recall('parser/acme/invoice', {
+        key: 'default',
+        includeAncestors: true,
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0].value).toBe('fallback');
+    });
+
+    it('refreshes last_used_at on recall (wires the previously-dead column)', async () => {
+      const memory = makeMemory();
+      await memory.capture(
+        { scope: 's', key: 'k', value: 'v' },
+        { success: true },
+      );
+
+      const before = await readRow(db, 'owner-1', 's', 'k');
+      const future = new Date(Date.now() + 60_000);
+
+      await memory.recall('s', { key: 'k', now: future });
+
+      const after = await readRow(db, 'owner-1', 's', 'k');
+      expect(new Date(String(after?.last_used_at)).getTime()).toBeGreaterThan(
+        new Date(String(before?.last_used_at)).getTime(),
+      );
+    });
+
+    it('excludes expired memories', async () => {
+      const memory = makeMemory();
+      await memory.capture(
+        {
+          scope: 's',
+          key: 'k',
+          value: 'v',
+          expiresAt: new Date(Date.now() - 1000),
+        },
+        { success: true },
+      );
+
+      const results = await memory.recall('s', { key: 'k' });
+      expect(results).toHaveLength(0);
+    });
+
+    it('applies optional time-based decay so stale memory drops below the floor', async () => {
+      const memory = makeMemory('owner-1', {
+        config: { decayHalfLifeMs: 1000 },
+      });
+      await memory.capture(
+        { scope: 's', key: 'k', value: 'v' },
+        { success: true },
+      ); // 0.9
+
+      // Fresh: still confident.
+      const fresh = await memory.recall('s', { key: 'k', now: new Date() });
+      expect(fresh).toHaveLength(1);
+
+      // 4 half-lives later: 0.9 * 0.5^4 = 0.056 < 0.7.
+      const stale = await memory.recall('s', {
+        key: 'k',
+        now: new Date(Date.now() + 4000),
+      });
+      expect(stale).toHaveLength(0);
+    });
+  });
+
+  describe('recall() — owner isolation (tenant scoping)', () => {
+    it('never returns another owner’s memory', async () => {
+      const ownerA = makeMemory('tenant-a-agent');
+      const ownerB = makeMemory('tenant-b-agent');
+
+      await ownerA.capture(
+        { scope: 's', key: 'k', value: 'a-secret' },
+        { success: true },
+      );
+
+      const bResults = await ownerB.recall('s', { key: 'k' });
+      expect(bResults).toHaveLength(0);
+
+      const aResults = await ownerA.recall('s', { key: 'k' });
+      expect(aResults).toHaveLength(1);
+      expect(aResults[0].value).toBe('a-secret');
+    });
+  });
+
+  describe('recall() — semantic arm (union)', () => {
+    it('unions keyed-context results with injected semantic search results', async () => {
+      const searcher = vi.fn(async () => [
+        { id: 'obj-1', _similarity: 0.92, title: 'Relevant doc' },
+        { id: 'obj-2', _similarity: 0.81, title: 'Also relevant' },
+      ]);
+      const memory = makeMemory('owner-1', { semanticSearch: searcher });
+
+      await memory.capture(
+        { scope: 'notes', key: 'k1', value: 'kept note' },
+        { success: true },
+      );
+
+      const results = await memory.recall('notes', {
+        key: 'k1',
+        query: 'find relevant docs',
+      });
+
+      const sources = results.map((r) => r.source).sort();
+      expect(sources).toEqual(['context', 'semantic', 'semantic']);
+      // Sorted by confidence/similarity desc: the 0.92 semantic hit leads.
+      expect(results[0].source).toBe('semantic');
+      expect(results[0].similarity).toBeCloseTo(0.92, 5);
+    });
+
+    it('threads tenantId into the semantic searcher where-clause', async () => {
+      const searcher = vi.fn(
+        async () => [],
+      ) as unknown as LearningSemanticSearch;
+      const memory = makeMemory('owner-1', {
+        tenantId: 'tenant-42',
+        semanticSearch: searcher,
+      });
+
+      await memory.recall('notes', { query: 'anything' });
+
+      expect(searcher).toHaveBeenCalledWith(
+        'anything',
+        expect.objectContaining({ where: { tenant_id: 'tenant-42' } }),
+      );
+    });
+
+    it('does not run semantic search without a query', async () => {
+      const searcher = vi.fn(
+        async () => [],
+      ) as unknown as LearningSemanticSearch;
+      const memory = makeMemory('owner-1', { semanticSearch: searcher });
+
+      await memory.recall('notes', { key: 'k1' });
+      expect(searcher).not.toHaveBeenCalled();
+    });
+
+    it('filters semantic hits by minSimilarity', async () => {
+      const searcher = vi.fn(
+        async (
+          _q: string,
+          opts: { minSimilarity?: number },
+        ): Promise<Array<{ id: string; _similarity: number }>> => {
+          const all = [
+            { id: 'hi', _similarity: 0.95 },
+            { id: 'lo', _similarity: 0.4 },
+          ];
+          return all.filter((h) => h._similarity >= (opts.minSimilarity ?? 0));
+        },
+      );
+      const memory = makeMemory('owner-1', { semanticSearch: searcher });
+
+      const results = await memory.recall('notes', {
+        query: 'q',
+        minSimilarity: 0.5,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('hi');
+    });
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Real embedding composition — proves the semantic arm works over stored
+// `_smrt_embeddings` via SmrtCollection.semanticSearch, with only the AI
+// embedding boundary mocked.
+// -----------------------------------------------------------------------------
+
+@smrt({
+  embeddings: {
+    fields: ['content'],
+    autoGenerate: false,
+  },
+})
+class LearningNote extends SmrtObject {
+  content: string = '';
+}
+
+class LearningNoteCollection extends SmrtCollection<LearningNote> {
+  static readonly _itemClass = LearningNote;
+}
+
+function topicEmbedding(text: string): number[] {
+  const t = text.toLowerCase();
+  return [
+    t.includes('invoice') || t.includes('billing') ? 0.9 : 0.1,
+    t.includes('sport') || t.includes('game') ? 0.9 : 0.1,
+    0.2,
+  ];
+}
+
+describe('LearningMemory — real embedding composition', () => {
+  let collection: LearningNoteCollection;
+
+  beforeEach(async () => {
+    ObjectRegistry.registerCollection('LearningNote', LearningNoteCollection);
+
+    collection = await LearningNoteCollection.create({
+      db: { type: 'sqlite', url: ':memory:' },
+      ai: {
+        embed: async (texts: string | string[]) => {
+          const arr = Array.isArray(texts) ? texts : [texts];
+          return { embeddings: arr.map(topicEmbedding) };
+        },
+      } as any,
+    });
+
+    vi.spyOn(EmbeddingProvider.prototype, 'embed').mockImplementation(
+      async (texts: string | string[]) => {
+        const arr = Array.isArray(texts) ? texts : [texts];
+        return arr.map(topicEmbedding);
+      },
+    );
+    vi.spyOn(EmbeddingProvider.prototype, 'getModelName').mockReturnValue(
+      'test-model',
+    );
+    vi.spyOn(EmbeddingProvider.prototype, 'getDimensions').mockReturnValue(3);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('recalls a semantically-similar stored note through the semantic arm', async () => {
+    for (const content of [
+      'How to reconcile an overdue invoice and billing dispute',
+      'The football game went into overtime last night',
+    ]) {
+      const note = await collection.create({ content });
+      await note.save();
+      await note.generateEmbeddings();
+    }
+
+    const memory = new LearningMemory({
+      db: collection.db,
+      ownerClass: 'LearningNote',
+      ownerId: '__collection__',
+      semanticSearch: (q, opts) => collection.semanticSearch(q, opts),
+    });
+
+    const results = await memory.recall('notes', {
+      query: 'unpaid invoice billing question',
+      minSimilarity: 0.5,
+    });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].source).toBe('semantic');
+    expect(String((results[0].value as { content: string }).content)).toContain(
+      'invoice',
+    );
+  });
+});

--- a/packages/core/src/learning/memory.test.ts
+++ b/packages/core/src/learning/memory.test.ts
@@ -366,6 +366,31 @@ describe('LearningMemory', () => {
       expect(searcher).not.toHaveBeenCalled();
     });
 
+    it('applies the confidence floor to the semantic arm by default', async () => {
+      const searcher = vi.fn(
+        async () => [],
+      ) as unknown as LearningSemanticSearch;
+      const memory = makeMemory('owner-1', {
+        semanticSearch: searcher,
+        config: { minConfidence: 0.75 },
+      });
+
+      // No explicit minSimilarity → the reuse floor is applied to semantic hits
+      // too, so a low-similarity hit can't be reused below the confidence floor.
+      await memory.recall('notes', { query: 'q' });
+      expect(searcher).toHaveBeenCalledWith(
+        'q',
+        expect.objectContaining({ minSimilarity: 0.75 }),
+      );
+
+      // An explicit minSimilarity still overrides the floor.
+      await memory.recall('notes', { query: 'q', minSimilarity: 0.4 });
+      expect(searcher).toHaveBeenLastCalledWith(
+        'q',
+        expect.objectContaining({ minSimilarity: 0.4 }),
+      );
+    });
+
     it('filters semantic hits by minSimilarity', async () => {
       const searcher = vi.fn(
         async (

--- a/packages/core/src/learning/memory.ts
+++ b/packages/core/src/learning/memory.ts
@@ -1,0 +1,608 @@
+/**
+ * LearningMemory — confidence-scored, self-correcting memory over the existing
+ * `_smrt_contexts` (keyed recall) and `_smrt_embeddings` (semantic recall)
+ * substrate.
+ *
+ * This is the L1 deep module of the tenant-learning-agents epic (#1885 / #1886).
+ * It wires the reinforcement columns that ship on `_smrt_contexts` but were
+ * never written — `success_count`, `failure_count`, and a `last_used_at` that
+ * is refreshed on recall — and layers a confidence floor + decay on top of the
+ * primitive `remember()` / `recall()` methods so a strategy that stops working
+ * stops being reused.
+ *
+ * It generalises the confidence-scored parser cache anytown's `praeco` agent
+ * hand-rolls: recall only reuses a memory at `confidence >= minConfidence`
+ * (default 0.7); a validated success strengthens confidence toward 1.0; an
+ * observed failure decays it toward `failureConfidence` (default 0.3) so a
+ * single failure drops it below the reuse floor.
+ *
+ * @module
+ */
+
+import type { DatabaseInterface } from '@happyvertical/sql';
+
+/**
+ * A relevance-scored memory returned by {@link LearningMemory.recall}.
+ *
+ * Records sourced from keyed `_smrt_contexts` lookups carry reinforcement
+ * counters; records sourced from semantic embedding search carry a
+ * `similarity` score (mirrored into `confidence` for uniform ranking).
+ */
+export interface LearningMemoryRecord {
+  /** Row id in `_smrt_contexts`, or the matched object id for semantic hits. */
+  id: string;
+  /** Hierarchical scope the memory is filed under. */
+  scope: string;
+  /** Lookup key within the scope. */
+  key: string;
+  /** The stored value (JSON-parsed for context rows; the matched object for semantic hits). */
+  value: unknown;
+  /** Confidence in `[0, 1]`. For semantic hits this equals `similarity`. */
+  confidence: number;
+  /** Number of captured successes reinforcing this memory. */
+  successCount: number;
+  /** Number of captured failures decaying this memory. */
+  failureCount: number;
+  /** Last time this memory was recalled or reinforced. */
+  lastUsedAt: Date | null;
+  /** Where the record came from. */
+  source: 'context' | 'semantic';
+  /** Cosine similarity for semantic hits (absent for context rows). */
+  similarity?: number;
+}
+
+/**
+ * The outcome of acting on a recalled (or freshly generated) memory.
+ *
+ * A boolean `success` signal is the common case; a numeric `metric` delta is
+ * supported as a convenience (positive → success, non-positive → failure).
+ */
+export type LearningOutcome =
+  | { success: boolean; error?: string }
+  | { metric: number; error?: string };
+
+/**
+ * The episode being reinforced — the scope/key of the memory the agent acted
+ * on, plus (for a first capture) the value to persist.
+ */
+export interface LearningEpisode {
+  /** Scope the memory is filed under (e.g. `'sample/parse-invoice'`). */
+  scope: string;
+  /** Lookup key within the scope. */
+  key: string;
+  /**
+   * Value to persist when no memory exists yet for `(scope, key)`. Ignored
+   * when a memory already exists unless {@link LearningEpisode.updateValue} is
+   * set — a captured outcome never silently rewrites a stored strategy.
+   */
+  value?: unknown;
+  /**
+   * When `true`, overwrite the stored value with {@link LearningEpisode.value}
+   * even if a memory already exists (used to feed a corrected/failed attempt
+   * back in for self-correction context).
+   */
+  updateValue?: boolean;
+  /** Optional metadata to persist on a first capture. */
+  metadata?: Record<string, unknown>;
+  /** Optional expiry after which recall ignores the memory. */
+  expiresAt?: Date;
+}
+
+/**
+ * Tunable thresholds for the reinforcement loop. Defaults mirror the proven
+ * `praeco` behaviour.
+ */
+export interface LearningMemoryConfig {
+  /** Reuse floor — recall omits memories below this confidence. Default 0.7. */
+  minConfidence: number;
+  /** Confidence a brand-new memory is seeded at on a first success. Default 0.9. */
+  successConfidence: number;
+  /** Target a memory decays toward on failure. Default 0.3. */
+  failureConfidence: number;
+  /**
+   * Blend weight in `[0, 1]` for each reinforcement step. At 0.5 a single
+   * failure from any confident value (>= 0.7) always lands below the 0.7 floor
+   * (`0.5·c + 0.15 <= 0.65`). Default 0.5.
+   */
+  reinforcement: number;
+  /**
+   * Optional half-life (ms) for time-based confidence decay. When set, recall
+   * discounts a memory's stored confidence by `0.5 ^ (age / halfLife)` based on
+   * `last_used_at`, so stale memory falls below the floor over time even
+   * without an explicit failure. Off (no time decay) when undefined.
+   */
+  decayHalfLifeMs?: number;
+}
+
+/** Default reinforcement thresholds. */
+export const DEFAULT_LEARNING_CONFIG: LearningMemoryConfig = {
+  minConfidence: 0.7,
+  successConfidence: 0.9,
+  failureConfidence: 0.3,
+  reinforcement: 0.5,
+};
+
+/**
+ * A semantic search over stored embeddings, injected so `LearningMemory` never
+ * reaches into a collection's internals. Matches the shape of
+ * `SmrtCollection.semanticSearch`.
+ */
+export type LearningSemanticSearch = (
+  query: string,
+  options: {
+    limit?: number;
+    minSimilarity?: number;
+    where?: Record<string, unknown>;
+  },
+) => Promise<
+  Array<{ id?: string; _similarity: number } & Record<string, unknown>>
+>;
+
+/** Options for {@link LearningMemory.recall}. */
+export interface LearningRecallOptions {
+  /** Exact key to look up within the scope. Omit for a scope-wide recall. */
+  key?: string;
+  /** Free-text query for semantic recall (only used when a searcher is wired). */
+  query?: string;
+  /** Override the reuse floor for this call. */
+  minConfidence?: number;
+  /** Walk up the scope hierarchy when no match is found at `scope`. Default true. */
+  includeAncestors?: boolean;
+  /** Cap on returned records. */
+  limit?: number;
+  /** Cap on semantic hits requested from the searcher. Default 10. */
+  semanticLimit?: number;
+  /** Minimum cosine similarity for semantic hits. Default 0. */
+  minSimilarity?: number;
+  /** Reference time for decay/expiry evaluation (injectable for tests). */
+  now?: Date;
+}
+
+/** Constructor options for {@link LearningMemory}. */
+export interface LearningMemoryOptions {
+  /** System database handle (an owning object's `systemDb`). */
+  db: DatabaseInterface;
+  /** `owner_class` the memories are filed under. */
+  ownerClass: string;
+  /** `owner_id` the memories are filed under (isolates memory per owner). */
+  ownerId: string;
+  /**
+   * Optional tenant id. When set it is threaded into the semantic searcher's
+   * `where` filter so embedding recall stays tenant-scoped. Keyed-context
+   * recall is already isolated by `owner_id`.
+   */
+  tenantId?: string | null;
+  /** Optional embedding search for the semantic recall arm. */
+  semanticSearch?: LearningSemanticSearch;
+  /** Threshold overrides; merged over {@link DEFAULT_LEARNING_CONFIG}. */
+  config?: Partial<LearningMemoryConfig>;
+}
+
+const CONTEXTS_TABLE = '_smrt_contexts';
+const CONFLICT_COLUMNS = ['owner_class', 'owner_id', 'scope', 'key', 'version'];
+
+function clamp01(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function normalizeOutcome(outcome: LearningOutcome): {
+  success: boolean;
+  error?: string;
+} {
+  if ('success' in outcome) {
+    return { success: outcome.success, error: outcome.error };
+  }
+  return { success: outcome.metric > 0, error: outcome.error };
+}
+
+function toDate(value: unknown): Date | null {
+  if (value == null) return null;
+  if (value instanceof Date) return value;
+  const parsed = new Date(value as string);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function parseValue(raw: unknown): unknown {
+  if (typeof raw !== 'string') return raw ?? null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // Tolerate legacy/non-JSON payloads rather than throwing mid-recall.
+    return raw;
+  }
+}
+
+/**
+ * Confidence-scored, self-correcting memory over `_smrt_contexts` and
+ * (optionally) semantic embedding search.
+ *
+ * @example
+ * ```typescript
+ * const memory = new LearningMemory({
+ *   db: agent.systemDb,
+ *   ownerClass: 'InvoiceAgent',
+ *   ownerId: agent.id,
+ *   tenantId: agent.tenantId,
+ * });
+ *
+ * // Recall a confident strategy for this task.
+ * const [hit] = await memory.recall('parser/acme', { key: docUrl });
+ * const strategy = hit?.value ?? (await generateStrategy(docUrl));
+ *
+ * // ...act on `strategy`, then reinforce the outcome.
+ * await memory.capture(
+ *   { scope: 'parser/acme', key: docUrl, value: strategy },
+ *   { success: extracted.length > 0 },
+ * );
+ * ```
+ */
+export class LearningMemory {
+  private readonly db: DatabaseInterface;
+  private readonly ownerClass: string;
+  private readonly ownerId: string;
+  private readonly tenantId: string | null;
+  private readonly semanticSearch?: LearningSemanticSearch;
+  private readonly config: LearningMemoryConfig;
+
+  constructor(options: LearningMemoryOptions) {
+    this.db = options.db;
+    this.ownerClass = options.ownerClass;
+    this.ownerId = options.ownerId;
+    this.tenantId = options.tenantId ?? null;
+    this.semanticSearch = options.semanticSearch;
+    this.config = { ...DEFAULT_LEARNING_CONFIG, ...(options.config ?? {}) };
+  }
+
+  /** The resolved reinforcement thresholds (defaults merged with overrides). */
+  get thresholds(): LearningMemoryConfig {
+    return { ...this.config };
+  }
+
+  /**
+   * Recall confidence-filtered, relevant memories for a scope.
+   *
+   * Unions two arms:
+   * 1. **Keyed context recall** over `_smrt_contexts` — owner-scoped (and thus
+   *    tenant-isolated), filtered by the confidence floor, expiry, and optional
+   *    time-decay, with hierarchical scope fallback. Surviving rows have their
+   *    `last_used_at` refreshed.
+   * 2. **Semantic recall** over stored embeddings (only when a searcher was
+   *    wired and a `query` is given) — tenant-scoped via the searcher's `where`.
+   *
+   * @returns Records sorted by confidence (then similarity) descending.
+   */
+  async recall(
+    scope: string,
+    options: LearningRecallOptions = {},
+  ): Promise<LearningMemoryRecord[]> {
+    const floor = options.minConfidence ?? this.config.minConfidence;
+    const now = options.now ?? new Date();
+    const includeAncestors = options.includeAncestors ?? true;
+
+    const contextRecords = await this.recallContexts(scope, {
+      key: options.key,
+      floor,
+      now,
+      includeAncestors,
+    });
+
+    // Wire the previously-dead refresh: recall marks a memory as used.
+    await this.touch(
+      contextRecords.map((r) => r.id),
+      now,
+    );
+
+    let semanticRecords: LearningMemoryRecord[] = [];
+    if (options.query && this.semanticSearch) {
+      semanticRecords = await this.recallSemantic(options.query, {
+        floor: options.minSimilarity ?? 0,
+        limit: options.semanticLimit ?? 10,
+      });
+    }
+
+    const merged = [...contextRecords, ...semanticRecords].sort((a, b) => {
+      if (b.confidence !== a.confidence) return b.confidence - a.confidence;
+      return (b.similarity ?? 0) - (a.similarity ?? 0);
+    });
+
+    return options.limit != null ? merged.slice(0, options.limit) : merged;
+  }
+
+  /**
+   * Reinforce a memory from an observed outcome.
+   *
+   * - Wires the dormant reinforcement columns: increments `success_count` on
+   *   success, `failure_count` on failure.
+   * - Adjusts `confidence`: success strengthens toward 1.0; failure decays
+   *   toward `failureConfidence` (default 0.3), dropping a confident memory
+   *   below the reuse floor in a single step.
+   * - Refreshes `last_used_at` and `updated_at`.
+   * - Seeds a new memory when none exists for `(scope, key)` and the episode
+   *   carries a `value` (a failed first attempt is retained at low confidence
+   *   for self-correction context).
+   *
+   * @returns The updated (or seeded) record, or `null` when there was nothing
+   *   to reinforce (no existing memory and no value to seed).
+   */
+  async capture(
+    episode: LearningEpisode,
+    outcome: LearningOutcome,
+  ): Promise<LearningMemoryRecord | null> {
+    const { success, error } = normalizeOutcome(outcome);
+    const now = new Date();
+
+    const existing = await this.db.get(CONTEXTS_TABLE, {
+      owner_class: this.ownerClass,
+      owner_id: this.ownerId,
+      scope: episode.scope,
+      key: episode.key,
+      version: 1,
+    });
+
+    if (existing) {
+      const currentConfidence = Number(existing.confidence ?? 1);
+      const nextConfidence = this.nextConfidence(currentConfidence, success);
+      const successCount =
+        Number(existing.success_count ?? 0) + (success ? 1 : 0);
+      const failureCount =
+        Number(existing.failure_count ?? 0) + (success ? 0 : 1);
+
+      const data: Record<string, unknown> = {
+        confidence: nextConfidence,
+        success_count: successCount,
+        failure_count: failureCount,
+        last_used_at: now,
+        updated_at: now,
+      };
+      if (episode.updateValue && episode.value !== undefined) {
+        data.value = JSON.stringify(episode.value);
+      }
+      if (episode.metadata !== undefined) {
+        data.metadata = JSON.stringify({
+          ...this.parseMetadata(existing.metadata),
+          ...episode.metadata,
+          ...(error ? { lastError: error } : {}),
+        });
+      } else if (error) {
+        data.metadata = JSON.stringify({
+          ...this.parseMetadata(existing.metadata),
+          lastError: error,
+        });
+      }
+
+      await this.db.update(CONTEXTS_TABLE, { id: existing.id }, data);
+
+      return {
+        id: String(existing.id),
+        scope: episode.scope,
+        key: episode.key,
+        value:
+          episode.updateValue && episode.value !== undefined
+            ? episode.value
+            : parseValue(existing.value),
+        confidence: nextConfidence,
+        successCount,
+        failureCount,
+        lastUsedAt: now,
+        source: 'context',
+      };
+    }
+
+    // No existing memory: seed one only if the episode provides a value.
+    if (episode.value === undefined) {
+      return null;
+    }
+
+    const id = crypto.randomUUID();
+    const confidence = success
+      ? this.config.successConfidence
+      : this.config.failureConfidence;
+    const metadata =
+      episode.metadata || error
+        ? JSON.stringify({
+            ...(episode.metadata ?? {}),
+            ...(error ? { lastError: error } : {}),
+          })
+        : null;
+
+    await this.db.upsert(CONTEXTS_TABLE, CONFLICT_COLUMNS, {
+      id,
+      owner_class: this.ownerClass,
+      owner_id: this.ownerId,
+      scope: episode.scope,
+      key: episode.key,
+      value: JSON.stringify(episode.value),
+      metadata,
+      version: 1,
+      confidence,
+      success_count: success ? 1 : 0,
+      failure_count: success ? 0 : 1,
+      created_at: now,
+      updated_at: now,
+      last_used_at: now,
+      expires_at: episode.expiresAt ?? null,
+    });
+
+    return {
+      id,
+      scope: episode.scope,
+      key: episode.key,
+      value: episode.value,
+      confidence,
+      successCount: success ? 1 : 0,
+      failureCount: success ? 0 : 1,
+      lastUsedAt: now,
+      source: 'context',
+    };
+  }
+
+  /**
+   * Compute the next confidence from the current value and an outcome.
+   *
+   * Success strengthens toward 1.0; failure blends toward `failureConfidence`.
+   * Exposed as a pure step so callers/tests can reason about the curve.
+   */
+  nextConfidence(current: number, success: boolean): number {
+    const r = this.config.reinforcement;
+    if (success) {
+      return clamp01(current + r * (1 - current));
+    }
+    return clamp01(current + r * (this.config.failureConfidence - current));
+  }
+
+  private async recallContexts(
+    scope: string,
+    opts: {
+      key?: string;
+      floor: number;
+      now: Date;
+      includeAncestors: boolean;
+    },
+  ): Promise<LearningMemoryRecord[]> {
+    const scopes = opts.includeAncestors ? this.scopeChain(scope) : [scope];
+
+    for (const candidateScope of scopes) {
+      const rows = await this.selectContextRows(candidateScope, opts.key);
+      const records = this.filterAndRank(rows, opts.floor, opts.now);
+      if (records.length > 0) {
+        return records;
+      }
+    }
+    return [];
+  }
+
+  private async selectContextRows(
+    scope: string,
+    key?: string,
+  ): Promise<Record<string, unknown>[]> {
+    if (key !== undefined) {
+      const { rows } = await this.db.query(
+        `SELECT * FROM ${CONTEXTS_TABLE}
+         WHERE owner_class = ? AND owner_id = ? AND scope = ? AND key = ?`,
+        this.ownerClass,
+        this.ownerId,
+        scope,
+        key,
+      );
+      return rows;
+    }
+    const { rows } = await this.db.query(
+      `SELECT * FROM ${CONTEXTS_TABLE}
+       WHERE owner_class = ? AND owner_id = ? AND scope = ?`,
+      this.ownerClass,
+      this.ownerId,
+      scope,
+    );
+    return rows;
+  }
+
+  private filterAndRank(
+    rows: Record<string, unknown>[],
+    floor: number,
+    now: Date,
+  ): LearningMemoryRecord[] {
+    const records: LearningMemoryRecord[] = [];
+
+    for (const row of rows) {
+      const expiresAt = toDate(row.expires_at);
+      if (expiresAt && expiresAt.getTime() <= now.getTime()) {
+        continue;
+      }
+
+      const lastUsedAt = toDate(row.last_used_at);
+      const stored = Number(row.confidence ?? 1);
+      const effective = this.applyTimeDecay(stored, lastUsedAt, now);
+      if (effective < floor) {
+        continue;
+      }
+
+      records.push({
+        id: String(row.id),
+        scope: String(row.scope),
+        key: String(row.key),
+        value: parseValue(row.value),
+        confidence: effective,
+        successCount: Number(row.success_count ?? 0),
+        failureCount: Number(row.failure_count ?? 0),
+        lastUsedAt,
+        source: 'context',
+      });
+    }
+
+    // Highest confidence first; break ties on the higher version.
+    return records.sort((a, b) => b.confidence - a.confidence);
+  }
+
+  private applyTimeDecay(
+    confidence: number,
+    lastUsedAt: Date | null,
+    now: Date,
+  ): number {
+    const halfLife = this.config.decayHalfLifeMs;
+    if (!halfLife || halfLife <= 0 || !lastUsedAt) {
+      return confidence;
+    }
+    const age = now.getTime() - lastUsedAt.getTime();
+    if (age <= 0) return confidence;
+    return clamp01(confidence * 0.5 ** (age / halfLife));
+  }
+
+  private async recallSemantic(
+    query: string,
+    opts: { floor: number; limit: number },
+  ): Promise<LearningMemoryRecord[]> {
+    if (!this.semanticSearch) return [];
+
+    const where: Record<string, unknown> | undefined =
+      this.tenantId != null ? { tenant_id: this.tenantId } : undefined;
+
+    const hits = await this.semanticSearch(query, {
+      limit: opts.limit,
+      minSimilarity: opts.floor,
+      where,
+    });
+
+    return hits.map((hit) => ({
+      id: hit.id != null ? String(hit.id) : crypto.randomUUID(),
+      scope: 'semantic',
+      key: hit.id != null ? String(hit.id) : query,
+      value: hit,
+      confidence: hit._similarity,
+      successCount: 0,
+      failureCount: 0,
+      lastUsedAt: null,
+      source: 'semantic',
+      similarity: hit._similarity,
+    }));
+  }
+
+  private async touch(ids: string[], now: Date): Promise<void> {
+    for (const id of ids) {
+      await this.db.update(CONTEXTS_TABLE, { id }, { last_used_at: now });
+    }
+  }
+
+  private scopeChain(scope: string): string[] {
+    const chain: string[] = [scope];
+    const parts = scope.split('/');
+    while (parts.length > 0) {
+      parts.pop();
+      chain.push(parts.join('/') || 'global');
+    }
+    // De-dupe while preserving order (guards against a leading 'global').
+    return [...new Set(chain)];
+  }
+
+  private parseMetadata(raw: unknown): Record<string, unknown> {
+    if (typeof raw !== 'string' || raw.length === 0) return {};
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+}

--- a/packages/core/src/learning/memory.ts
+++ b/packages/core/src/learning/memory.ts
@@ -71,17 +71,12 @@ export interface LearningEpisode {
   /** Lookup key within the scope. */
   key: string;
   /**
-   * Value to persist when no memory exists yet for `(scope, key)`. Ignored
-   * when a memory already exists unless {@link LearningEpisode.updateValue} is
-   * set — a captured outcome never silently rewrites a stored strategy.
+   * The value (strategy) this outcome pertains to. Seeds a new memory when none
+   * exists for `(scope, key)`, and refreshes the stored value when one does — so
+   * a regenerated strategy supersedes a decayed one. Omit to reinforce an
+   * existing memory's confidence without touching its stored value.
    */
   value?: unknown;
-  /**
-   * When `true`, overwrite the stored value with {@link LearningEpisode.value}
-   * even if a memory already exists (used to feed a corrected/failed attempt
-   * back in for self-correction context).
-   */
-  updateValue?: boolean;
   /** Optional metadata to persist on a first capture. */
   metadata?: Record<string, unknown>;
   /** Optional expiry after which recall ignores the memory. */
@@ -180,6 +175,11 @@ export interface LearningMemoryOptions {
 
 const CONTEXTS_TABLE = '_smrt_contexts';
 const CONFLICT_COLUMNS = ['owner_class', 'owner_id', 'scope', 'key', 'version'];
+/**
+ * The single `_smrt_contexts` version LearningMemory reads and writes. Kept
+ * explicit so capture and recall agree on the row identity.
+ */
+const MEMORY_VERSION = 1;
 
 function clamp01(value: number): number {
   if (Number.isNaN(value)) return 0;
@@ -297,8 +297,13 @@ export class LearningMemory {
 
     let semanticRecords: LearningMemoryRecord[] = [];
     if (options.query && this.semanticSearch) {
+      // Semantic hits carry `confidence = _similarity`, so the reuse floor must
+      // apply to them too: default `minSimilarity` to the resolved confidence
+      // floor unless the caller explicitly overrides it. Otherwise a
+      // low-similarity hit could be reused while a context memory at the same
+      // confidence is filtered out.
       semanticRecords = await this.recallSemantic(options.query, {
-        floor: options.minSimilarity ?? 0,
+        floor: options.minSimilarity ?? floor,
         limit: options.semanticLimit ?? 10,
       });
     }
@@ -319,7 +324,9 @@ export class LearningMemory {
    * - Adjusts `confidence`: success strengthens toward 1.0; failure decays
    *   toward `failureConfidence` (default 0.3), dropping a confident memory
    *   below the reuse floor in a single step.
-   * - Refreshes `last_used_at` and `updated_at`.
+   * - Refreshes `last_used_at` and `updated_at`, and (when the episode carries a
+   *   `value`) the stored value — so a regenerated strategy supersedes a decayed
+   *   one instead of the old value resurfacing on the next success.
    * - Seeds a new memory when none exists for `(scope, key)` and the episode
    *   carries a `value` (a failed first attempt is retained at low confidence
    *   for self-correction context).
@@ -339,7 +346,7 @@ export class LearningMemory {
       owner_id: this.ownerId,
       scope: episode.scope,
       key: episode.key,
-      version: 1,
+      version: MEMORY_VERSION,
     });
 
     if (existing) {
@@ -357,7 +364,11 @@ export class LearningMemory {
         last_used_at: now,
         updated_at: now,
       };
-      if (episode.updateValue && episode.value !== undefined) {
+      // The episode's value is the strategy this outcome pertains to, so always
+      // reflect it in storage. Without this, a regenerated strategy (staged
+      // after the previous one decayed below the floor) would be discarded and
+      // the next successful capture would resurrect the stale failed value.
+      if (episode.value !== undefined) {
         data.value = JSON.stringify(episode.value);
       }
       if (episode.metadata !== undefined) {
@@ -380,7 +391,7 @@ export class LearningMemory {
         scope: episode.scope,
         key: episode.key,
         value:
-          episode.updateValue && episode.value !== undefined
+          episode.value !== undefined
             ? episode.value
             : parseValue(existing.value),
         confidence: nextConfidence,
@@ -416,7 +427,7 @@ export class LearningMemory {
       key: episode.key,
       value: JSON.stringify(episode.value),
       metadata,
-      version: 1,
+      version: MEMORY_VERSION,
       confidence,
       success_count: success ? 1 : 0,
       failure_count: success ? 0 : 1,
@@ -478,23 +489,29 @@ export class LearningMemory {
     scope: string,
     key?: string,
   ): Promise<Record<string, unknown>[]> {
+    // Row identity is (owner_class, owner_id, scope, key, version); `capture()`
+    // only ever writes version 1, so recall filters to it — otherwise a future
+    // multi-version write would surface stale versions here.
     if (key !== undefined) {
       const { rows } = await this.db.query(
         `SELECT * FROM ${CONTEXTS_TABLE}
-         WHERE owner_class = ? AND owner_id = ? AND scope = ? AND key = ?`,
+         WHERE owner_class = ? AND owner_id = ? AND scope = ? AND key = ?
+           AND version = ?`,
         this.ownerClass,
         this.ownerId,
         scope,
         key,
+        MEMORY_VERSION,
       );
       return rows;
     }
     const { rows } = await this.db.query(
       `SELECT * FROM ${CONTEXTS_TABLE}
-       WHERE owner_class = ? AND owner_id = ? AND scope = ?`,
+       WHERE owner_class = ? AND owner_id = ? AND scope = ? AND version = ?`,
       this.ownerClass,
       this.ownerId,
       scope,
+      MEMORY_VERSION,
     );
     return rows;
   }
@@ -532,7 +549,7 @@ export class LearningMemory {
       });
     }
 
-    // Highest confidence first; break ties on the higher version.
+    // Highest effective confidence first.
     return records.sort((a, b) => b.confidence - a.confidence);
   }
 
@@ -580,9 +597,16 @@ export class LearningMemory {
   }
 
   private async touch(ids: string[], now: Date): Promise<void> {
-    for (const id of ids) {
-      await this.db.update(CONTEXTS_TABLE, { id }, { last_used_at: now });
-    }
+    if (ids.length === 0) return;
+    // Single batched UPDATE rather than one per row (avoids an N+1 on large
+    // recalls). Raw parameterised queries don't coerce Date bind params the way
+    // db.update() does, so serialise to ISO first.
+    const placeholders = ids.map(() => '?').join(', ');
+    await this.db.query(
+      `UPDATE ${CONTEXTS_TABLE} SET last_used_at = ? WHERE id IN (${placeholders})`,
+      now.toISOString(),
+      ...ids,
+    );
   }
 
   private scopeChain(scope: string): string[] {


### PR DESCRIPTION
## What this delivers

**L1 of the tenant-learning-agents epic** (#1885): make learning a **universal, opt-in** capability of every agent, and finally wire the dormant reinforcement columns on `_smrt_contexts`.

### `LearningMemory` (core, `packages/core/src/learning/memory.ts`)
A confidence-scored, self-correcting deep module over the existing `_smrt_contexts` (keyed recall) and `_smrt_embeddings` (semantic recall) substrate — generalising the bespoke cache anytown's `praeco` hand-rolls.

- **`capture(episode, outcome)`** — increments the previously-**unwritten** `success_count` / `failure_count`; strengthens `confidence` toward 1.0 on success and decays it toward `failureConfidence` (0.3) on failure so a single failure drops a confident memory below the 0.7 reuse floor; refreshes `last_used_at`; seeds a new row when none exists (a failed first attempt is retained at low confidence for self-correction).
- **`recall(scope, opts)`** — **union** of owner-scoped keyed-context lookup + an injected semantic-search arm, confidence-filtered, tenant-isolated (by owner), with hierarchical scope fallback, expiry, and optional time-decay. Refreshes `last_used_at` on returned rows (the recall-side column was never refreshed before).

### Opt-in `Learning` trait (agents, `Agent` + `packages/agents/src/learning.ts`)
- Single declaration: `static learning = true` (or a config object). **Off by default** — a non-opted agent behaves byte-for-byte as today; the lifecycle's learning branches are never entered (guarded by a cheap static-flag check).
- `execute()` recalls confident memory **before** `run()` (exposed via `recalledMemories`) and captures the outcome **after** — success reinforces the staged episode; a thrown error or an explicit `reportLearningOutcome({ success: false })` decays it.
- Override seams: `learningScope`, `recallForRun`, `captureForRun`, `getLearningSemanticSearch`; `run()` helpers: `stageLearning`, `reportLearningOutcome`, `getLearningMemory`, `recalledMemories`.

### Tests (real in-memory SQLite; only the AI embedding boundary mocked)
- **Core** `memory.test.ts` (21 tests): capture reinforcement + counts, decay-below-floor, floor/override, hierarchical fallback, `last_used_at` refresh, expiry, time-decay, owner isolation, semantic union (injected + **real embeddings** via `SmrtCollection.semanticSearch`).
- **Agents** `learning.test.ts`: `resolveAgentLearning` normalisation, off-by-default guarantee, recall-before/capture-after seams, throw→capture-failure.
- **Agents** `learning-integration.test.ts`: a reference sample learning agent driven through a full **learn → recall → adapt** cycle across runs — first run generates & seeds (0.9), second recalls/reuses & strengthens (0.95), a failing run decays below the floor (0.625), the next run stops reusing & regenerates; plus owner isolation.

## Backward compatibility
Fully additive. No schema changes (the reinforcement columns already ship). Non-opted agents are unchanged.

## Local verification
- `pnpm build` (core + agents) ✓
- `pnpm typecheck` (core + agents) ✓
- Biome clean on all touched files ✓
- `pnpm knowledge:check --strict` ✓ (AGENTS.md updated for both packages)
- Full **core** vitest suite ✓ (green, incl. the 21 new LearningMemory tests)
- **agents** vitest cannot run locally in this worktree — vite8/rolldown dep-optimize breaks at startup for **all** agents tests (a pre-existing `config.test.ts` fails identically), the documented Darwin/vite8 local limitation. Relying on CI (ubuntu) as the gate; the 13 agents learning tests passed in a working toolchain during development.

Part of #1885
Closes #1886
