### PR TITLE
feat(agents): opt-in multi-instance agents + persona durable instances (#1890)

### DIFF
--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -114,11 +114,27 @@ class InvoiceAgent extends Agent {
 - **Seams to override**: `learningScope()`, `recallForRun(memory)`, `captureForRun(memory, outcome)`, `getLearningSemanticSearch()`. Helpers for `run()`: `stageLearning(episode)`, `reportLearningOutcome(outcome)`, `getLearningMemory()`, and the `recalledMemories` field.
 - **Config**: `static learning: boolean | AgentLearningConfig` — `{ enabled?, scope?, minConfidence?, successConfidence?, failureConfidence?, reinforcement?, decayHalfLifeMs? }`. `LearningMemory` and its types are re-exported from `@happyvertical/smrt-core`.
 
+## Multi-Instance Agents (issue #1890) — opt-in
+
+`static multiInstance = false` by default: a class is a **singleton** (the N=1 case) and is byte-for-byte unchanged — one dispatch subscriber keyed by the agent type, one memory scope, class-wide interests. Set `static multiInstance = true` to run N durable instances (personas, from `@happyvertical/smrt-personas`) of one class per tenant, each independent.
+
+The framework provides only the per-instance **identity**; a package scopes its own dispatch/interests to the instance's config by overriding the seams.
+
+- **`AgentOptions.instanceKey`** — the durable per-instance key (typically the persona id). Honored **only** when `multiInstance` is true, so passing it to a non-opted agent is a no-op.
+- **`getInstanceKey()`** → the key, or `null` for a singleton (opt-in off, or no key).
+- **`getDispatchSubscriber()`** → `` `${agentType}#${key}` `` for a multi-instance agent, the bare `agentType` for a singleton. Used everywhere the agent subscribes/seeds/processes, so each instance has its own subscription rows and pending-dispatch queue — two instances never compete for or double-process each other's dispatches. Composed by the exported `instanceScopedSubscriber(agentType, key)`.
+- **`learningScope()`** — suffixed with `#<key>` for a multi-instance agent, so instances learn independently (singleton scope unchanged).
+- **Seams to override** (both default to singleton behavior):
+  - `resolveSignalSubscriptions()` — derive **instance-scoped** signal types from the instance config so an emit meant for one instance only matches its subscription.
+  - `instanceInterestFilter()` — an `ObjectFilter` AND-merged (as the base layer) into every `interesting()` query so instances partition the objects they process.
+
+The **`default` persona reuses the singleton identity** (a `null` key), which is what makes the singleton→multi upgrade non-destructive — see `@happyvertical/smrt-personas` (`personaInstanceKey`, `upgradeSingletonToDefaultPersona`).
+
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `src/agent.ts` | Base Agent class — lifecycle, dispatch, interests, config, opt-in learning trait |
+| `src/agent.ts` | Base Agent class — lifecycle, dispatch, interests, config, opt-in learning trait, multi-instance identity |
 | `src/learning.ts` | `AgentLearningConfig` + `resolveAgentLearning()` declaration normalisation |
 | `src/schedule.ts` | AgentSchedule model — cron, execution tracking |
 | `src/tenant-agent.ts` | TenantAgent — junction table, hierarchical resolution |

--- a/packages/agents/src/agent.ts
+++ b/packages/agents/src/agent.ts
@@ -27,6 +27,7 @@ import {
 import { type AgentAIOptions, resolveAgentAIOptions } from './ai-config.js';
 import { AgentConfig } from './config.js';
 import {
+  instanceScopedSubscriber,
   getAgentClassName as resolveAgentClassName,
   getAgentTypeName as resolveAgentTypeName,
 } from './identity.js';
@@ -35,6 +36,7 @@ import type {
   InterestFilter,
   InterestOptions,
   InterestResult,
+  ObjectFilter,
   ObjectInterestConfig,
 } from './interests.js';
 import { mergeFilters, normalizeSort } from './interests.js';
@@ -72,6 +74,19 @@ export interface AgentOptions
    * shutdown itself; the first handler to finish exits the process.
    */
   manageProcessSignals?: boolean;
+
+  /**
+   * Durable per-instance key for multi-instance agents (#1890).
+   *
+   * Only honored when the agent class opts into multi-instance
+   * (`static multiInstance = true`); a singleton agent (the default) ignores it,
+   * so passing a key can never change a non-opted agent's behavior. When honored
+   * it becomes the per-instance dispatch subscriber suffix and memory partition
+   * (see {@link Agent.getDispatchSubscriber} / {@link Agent.learningScope}) so N
+   * instances of one class run independently. Typically the persona id from
+   * `@happyvertical/smrt-personas` (a persona is a durable instance).
+   */
+  instanceKey?: string | null;
 }
 
 /**
@@ -282,6 +297,27 @@ export abstract class Agent extends SmrtObject {
   static learning: AgentLearningDeclaration = false;
 
   /**
+   * Opt into multiple durable instances of this agent class per tenant (#1890).
+   *
+   * **Off by default** — a non-opted class is a **singleton** (the N=1 case) and
+   * behaves byte-for-byte as it does today: one dispatch subscriber keyed by the
+   * agent type, one memory scope, class-wide interests. Setting this to `true`
+   * lets N configured instances (personas, from `@happyvertical/smrt-personas`)
+   * run independently: each is constructed with its own {@link AgentOptions.instanceKey},
+   * which the framework folds into a per-instance dispatch subscriber
+   * ({@link getDispatchSubscriber}), memory partition ({@link learningScope}),
+   * and interest/subscription scoping seams ({@link instanceInterestFilter} /
+   * {@link resolveSignalSubscriptions}) so two instances never double-process
+   * each other's dispatches or interests.
+   *
+   * The framework provides the per-instance *identity*; a package scopes its own
+   * dispatch/interests to the instance's config by overriding the seams. The
+   * `default` persona reuses the singleton identity (null key), which makes the
+   * singleton→multi upgrade non-destructive.
+   */
+  static multiInstance: boolean = false;
+
+  /**
    * Current agent status
    */
   status: AgentStatusType = 'idle';
@@ -385,6 +421,81 @@ export abstract class Agent extends SmrtObject {
    */
   protected getAgentClassName(): string {
     return resolveAgentClassName(this.getAgentTypeName());
+  }
+
+  // ============================================================================
+  // Multi-instance identity (#1890) — opt-in; singleton (null key) by default
+  // ============================================================================
+
+  /**
+   * Whether this agent class opted into multiple durable instances per tenant.
+   */
+  protected isMultiInstance(): boolean {
+    return (this.constructor as typeof Agent).multiInstance === true;
+  }
+
+  /**
+   * The durable per-instance key for this agent, or `null` for a singleton.
+   *
+   * Returns `null` unless the class opts in (`static multiInstance = true`) AND a
+   * non-empty {@link AgentOptions.instanceKey} was supplied — so a non-opted
+   * agent is always singleton-identified even if a key is passed. This is the
+   * anchor the framework folds into the dispatch subscriber, memory scope, and
+   * scoping seams below.
+   */
+  getInstanceKey(): string | null {
+    if (!this.isMultiInstance()) {
+      return null;
+    }
+    const key = (this.options as AgentOptions).instanceKey;
+    return typeof key === 'string' && key.length > 0 ? key : null;
+  }
+
+  /**
+   * Canonical dispatch subscriber identity for this agent.
+   *
+   * A singleton (no instance key) is the bare agent type — **unchanged** from the
+   * class-keyed behavior. A multi-instance agent is `` `${agentType}#${key}` ``,
+   * giving each instance its own subscription rows and its own pending-dispatch
+   * queue so instances don't compete for or double-process each other's
+   * dispatches. Used everywhere the agent subscribes, seeds, and processes.
+   */
+  getDispatchSubscriber(): string {
+    return instanceScopedSubscriber(
+      this.getAgentTypeName(),
+      this.getInstanceKey(),
+    );
+  }
+
+  /**
+   * The signal types this instance should seed as dispatch subscriptions.
+   *
+   * Defaults to the class's static {@link Agent.signalSubscriptions} unchanged.
+   * A multi-instance package overrides this to derive **instance-scoped** signal
+   * types from the persona/instance config (e.g. append the instance key or a
+   * routing dimension), so an emit meant for one instance only matches that
+   * instance's subscription and the other never processes it.
+   */
+  protected resolveSignalSubscriptions(): string[] {
+    return (this.constructor as typeof Agent).signalSubscriptions;
+  }
+
+  /**
+   * An optional filter AND-merged (as the base layer) into every
+   * {@link interesting} query for this instance.
+   *
+   * `undefined` by default (no scoping — singleton behavior unchanged). A
+   * multi-instance package overrides it to return an instance-discriminating
+   * filter derived from the persona/instance config, so two instances of one
+   * class partition the objects they process and never double-handle the same
+   * row. Global and per-object interest filters layer on top (and win on key
+   * collision), so choose a dedicated discriminator key here.
+   *
+   * Applies to the standard filter path; custom `query` interest filters own
+   * their SQL and should incorporate {@link getInstanceKey} themselves.
+   */
+  protected instanceInterestFilter(): ObjectFilter | undefined {
+    return undefined;
   }
 
   /**
@@ -624,7 +735,7 @@ export abstract class Agent extends SmrtObject {
   async processDispatches(): Promise<number> {
     const dispatch = await this.getDispatch();
     return dispatch.process(
-      this.getAgentTypeName(),
+      this.getDispatchSubscriber(),
       this.handleDispatch.bind(this),
     );
   }
@@ -645,7 +756,11 @@ export abstract class Agent extends SmrtObject {
     const resolved = resolveAgentLearning(
       (this.constructor as typeof Agent).learning,
     );
-    return resolved.scope ?? `agent/${this.getAgentTypeName()}`;
+    const base = resolved.scope ?? `agent/${this.getAgentTypeName()}`;
+    // Partition memory per durable instance so two multi-instance personas learn
+    // independently. Null key (singleton) leaves the scope unchanged.
+    const instanceKey = this.getInstanceKey();
+    return instanceKey ? `${base}#${instanceKey}` : base;
   }
 
   /**
@@ -858,9 +973,9 @@ export abstract class Agent extends SmrtObject {
       const dispatch = await this.getDispatch();
       await this.migrateLegacyDispatchSubscriptions(dispatch);
 
-      const subs = (this.constructor as typeof Agent).signalSubscriptions;
+      const subs = this.resolveSignalSubscriptions();
       if (subs.length > 0) {
-        const subscriber = this.getAgentTypeName();
+        const subscriber = this.getDispatchSubscriber();
         const existing = await dispatch.listSubscriptions(subscriber);
         const existingTypes = new Set(existing.map((s) => s.signalType));
         for (const signalType of subs) {
@@ -1100,7 +1215,9 @@ export abstract class Agent extends SmrtObject {
       // Auto-process pending dispatches for agents with signal subscriptions
       if (this._db) {
         const dispatch = await this.getDispatch();
-        const subs = await dispatch.listSubscriptions(this.getAgentTypeName());
+        const subs = await dispatch.listSubscriptions(
+          this.getDispatchSubscriber(),
+        );
         if (subs.length > 0) {
           const count = await this.processDispatches();
           if (count > 0) {
@@ -1382,8 +1499,14 @@ export abstract class Agent extends SmrtObject {
       return items;
     }
 
-    // Standard filter path - uses collection.list() with SDK filters
-    const mergedFilter = mergeFilters(this.interests?.filter, filter.filter);
+    // Standard filter path - uses collection.list() with SDK filters.
+    // Layer the per-instance scope (#1890) as the base so multi-instance agents
+    // partition what they process; the global then per-object filters layer on
+    // top (winning on key collision). Undefined for singletons → unchanged.
+    const mergedFilter = mergeFilters(
+      mergeFilters(this.instanceInterestFilter(), this.interests?.filter),
+      filter.filter,
+    );
 
     const queryOptions: {
       where?: Record<string, unknown>;

--- a/packages/agents/src/identity.ts
+++ b/packages/agents/src/identity.ts
@@ -30,3 +30,23 @@ export function getAgentTypeAliases(name: string): string[] {
     new Set([getAgentTypeName(name), getAgentClassName(name)].filter(Boolean)),
   );
 }
+
+/**
+ * Compose a per-instance dispatch subscriber identity from an agent type and an
+ * optional instance key (#1890).
+ *
+ * Multiple durable instances of one agent class each need their own subscriber
+ * name so their dispatch subscriptions and pending dispatches never collide —
+ * that is what keeps two instances from double-processing each other's work.
+ *
+ * Returns the bare `agentType` when `instanceKey` is nullish/empty, so a
+ * **singleton** agent's subscriber is byte-for-byte unchanged (the N=1 default).
+ * When a key is present the identity is `` `${agentType}#${instanceKey}` `` — a
+ * stable, reversible composition (the type never contains `#`).
+ */
+export function instanceScopedSubscriber(
+  agentType: string,
+  instanceKey?: string | null,
+): string {
+  return instanceKey ? `${agentType}#${instanceKey}` : agentType;
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -94,6 +94,10 @@ export {
   resolveAgentAIOptions,
 } from './ai-config.js';
 export { AgentConfig, AgentConfigCollection } from './config.js';
+// Per-instance dispatch subscriber composition (#1890). Exported so
+// `@happyvertical/smrt-personas` can derive the same identity for a persona
+// without reconstructing an agent.
+export { instanceScopedSubscriber } from './identity.js';
 export type {
   AgentWithInterestsOptions,
   AsyncQualifierFn,

--- a/packages/agents/src/multi-instance.test.ts
+++ b/packages/agents/src/multi-instance.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Multi-instance agents (#1890) — framework primitives.
+ *
+ * Proves the opt-in per-instance identity the framework provides:
+ *   - a **singleton** (non-opted) agent is byte-for-byte unchanged — it ignores
+ *     any `instanceKey`, keeps the bare class-keyed dispatch subscriber, an
+ *     un-suffixed memory scope, and no interest scoping (the N=1 default);
+ *   - two **multi-instance** instances of one class run independently — distinct
+ *     dispatch subscribers so an emit for one instance is never processed by the
+ *     other, partitioned interests so they don't double-handle the same rows, and
+ *     separate memory scopes.
+ *
+ * The package scopes its own dispatch/interests to the instance's config by
+ * overriding the framework seams (`resolveSignalSubscriptions`,
+ * `instanceInterestFilter`); these reference agents stand in for that.
+ *
+ * Real in-memory SQLite throughout; nothing external is touched.
+ */
+
+import {
+  getTestDatabase,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { getDatabase } from '@happyvertical/sql';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { Agent, type AgentOptions } from './agent.js';
+import type { ObjectFilter } from './interests.js';
+import type { AgentLearningConfig } from './learning.js';
+
+// -----------------------------------------------------------------------------
+// Reference agents
+// -----------------------------------------------------------------------------
+
+/** A plain singleton agent — does NOT opt into multi-instance. */
+@smrt()
+class SoloAgent extends Agent {
+  protected config = {};
+
+  static override signalSubscriptions: string[] = ['ping'];
+
+  handled = 0;
+
+  async handleDispatch(): Promise<void> {
+    this.handled += 1;
+  }
+
+  async run(): Promise<void> {}
+}
+
+/**
+ * A multi-instance worker. It scopes its seeded subscription to its own instance
+ * key so an emit targeted at one instance's signal type only matches that
+ * instance's subscription — the package scoping dispatch by the instance config.
+ */
+@smrt()
+class MultiWorker extends Agent {
+  protected config = {};
+
+  static override multiInstance = true;
+  static override signalSubscriptions: string[] = ['task.assigned'];
+
+  handled: Array<Record<string, unknown>> = [];
+
+  protected override resolveSignalSubscriptions(): string[] {
+    const key = this.getInstanceKey();
+    return (this.constructor as typeof MultiWorker).signalSubscriptions.map(
+      (type) => (key ? `${type}.${key}` : type),
+    );
+  }
+
+  async handleDispatch(payload: unknown): Promise<void> {
+    this.handled.push(payload as Record<string, unknown>);
+  }
+
+  async run(): Promise<void> {}
+}
+
+/** A registered object the scanners query. */
+@smrt()
+class Ticket extends SmrtObject {
+  title: string = '';
+  category: string = '';
+}
+
+class TicketCollection extends SmrtCollection<Ticket> {
+  static readonly _itemClass = Ticket;
+}
+
+/**
+ * A multi-instance scanner that partitions the tickets it processes by its
+ * instance key via the `instanceInterestFilter` seam.
+ */
+@smrt()
+class MultiScanner extends Agent {
+  protected config = {};
+
+  static override multiInstance = true;
+
+  constructor(options: AgentOptions = {}) {
+    super({
+      ...options,
+      interests: { objects: { Ticket: { sort: 'created_at DESC' } } },
+    });
+  }
+
+  protected override instanceInterestFilter(): ObjectFilter | undefined {
+    const key = this.getInstanceKey();
+    return key ? { category: key } : undefined;
+  }
+
+  async run(): Promise<void> {}
+}
+
+/** A multi-instance learning agent — proves per-instance memory partitioning. */
+@smrt()
+class MultiLearner extends Agent {
+  static override multiInstance = true;
+  static override learning: AgentLearningConfig = { enabled: true };
+
+  protected config = {};
+
+  aiCalls = 0;
+
+  async run(): Promise<void> {
+    const recalled = this.recalledMemories.find((m) => m.key === 'strategy');
+    if (!recalled) {
+      this.aiCalls += 1;
+    }
+    this.stageLearning({
+      scope: this.learningScope(),
+      key: 'strategy',
+      value: recalled ? String(recalled.value) : `v${this.aiCalls}`,
+    });
+  }
+
+  // Expose the protected scope for assertions.
+  publicLearningScope(): string {
+    return this.learningScope();
+  }
+}
+
+describe('Multi-instance agents (#1890)', () => {
+  describe('singleton (non-opted) regression', () => {
+    it('ignores instanceKey and keeps the bare class-keyed identity', () => {
+      const a = new SoloAgent({ name: 'solo-a', instanceKey: 'ignored-a' });
+      const b = new SoloAgent({ name: 'solo-b', instanceKey: 'ignored-b' });
+
+      // Opt-in is off → no instance key, even though one was passed.
+      expect(a.getInstanceKey()).toBeNull();
+      expect(b.getInstanceKey()).toBeNull();
+
+      // Both share the same class-keyed subscriber (no `#suffix`).
+      expect(a.getDispatchSubscriber()).toBe(b.getDispatchSubscriber());
+      expect(a.getDispatchSubscriber()).not.toContain('#');
+    });
+
+    it('seeds subscriptions under the class-keyed subscriber (unchanged)', async () => {
+      const db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+      const agent = new SoloAgent({ name: 'solo-sub', db, instanceKey: 'x' });
+      await agent.initialize();
+
+      const bus = await agent.getDispatch();
+      const scoped = await bus.listSubscriptions(
+        `${agent.getDispatchSubscriber()}#x`,
+      );
+      const classKeyed = await bus.listSubscriptions(
+        agent.getDispatchSubscriber(),
+      );
+
+      // Nothing was seeded under a per-instance name; all under the bare type.
+      expect(scoped).toHaveLength(0);
+      expect(classKeyed.map((s) => s.signalType)).toEqual(['ping']);
+    });
+  });
+
+  describe('per-instance dispatch identity', () => {
+    it('gives each instance a distinct, key-suffixed subscriber', () => {
+      const support = new MultiWorker({ name: 'w1', instanceKey: 'support' });
+      const sales = new MultiWorker({ name: 'w2', instanceKey: 'sales' });
+
+      expect(support.getInstanceKey()).toBe('support');
+      expect(support.getDispatchSubscriber()).not.toBe(
+        sales.getDispatchSubscriber(),
+      );
+      expect(support.getDispatchSubscriber().endsWith('#support')).toBe(true);
+      expect(sales.getDispatchSubscriber().endsWith('#sales')).toBe(true);
+    });
+
+    it('does not cross-process: an emit for one instance is not handled by the other', async () => {
+      const db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+      const support = new MultiWorker({
+        name: 'w-support',
+        db,
+        instanceKey: 'support',
+      });
+      const sales = new MultiWorker({
+        name: 'w-sales',
+        db,
+        instanceKey: 'sales',
+      });
+
+      await support.initialize();
+      await sales.initialize();
+
+      const bus = await support.getDispatch();
+      // Package routes this signal to the "support" instance.
+      await bus.emit('task.assigned.support', { id: 't1' }, { source: 'test' });
+
+      await support.execute();
+      await sales.execute();
+
+      expect(support.handled).toHaveLength(1);
+      expect(support.handled[0]).toEqual({ id: 't1' });
+      // The sales instance never saw the support task.
+      expect(sales.handled).toHaveLength(0);
+    });
+  });
+
+  describe('per-instance interest scoping', () => {
+    let db: Awaited<ReturnType<typeof getTestDatabase>>;
+    let tickets: TicketCollection;
+
+    beforeAll(async () => {
+      db = await getTestDatabase();
+      tickets = await TicketCollection.create({ db });
+      await (await tickets.create({ title: 'S1', category: 'support' })).save();
+      await (await tickets.create({ title: 'S2', category: 'support' })).save();
+      await (await tickets.create({ title: 'X1', category: 'sales' })).save();
+    });
+
+    it('partitions the objects each instance processes by its config', async () => {
+      const support = new MultiScanner({
+        name: 's-support',
+        db,
+        instanceKey: 'support',
+      });
+      const sales = new MultiScanner({
+        name: 's-sales',
+        db,
+        instanceKey: 'sales',
+      });
+      await support.initialize();
+      await sales.initialize();
+
+      const supportItems = await support.interesting();
+      const salesItems = await sales.interesting();
+
+      expect(supportItems).toHaveLength(2);
+      expect(
+        supportItems.every((i) => (i.data as Ticket).category === 'support'),
+      ).toBe(true);
+
+      expect(salesItems).toHaveLength(1);
+      expect((salesItems[0].data as Ticket).category).toBe('sales');
+    });
+  });
+
+  describe('per-instance memory scope', () => {
+    it('partitions learning memory by instance and starts each cold', async () => {
+      const db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+      const support = new MultiLearner({
+        name: 'l-support',
+        db,
+        instanceKey: 'support',
+      });
+      const sales = new MultiLearner({
+        name: 'l-sales',
+        db,
+        instanceKey: 'sales',
+      });
+
+      // Distinct, key-suffixed memory scopes.
+      expect(support.publicLearningScope()).not.toBe(
+        sales.publicLearningScope(),
+      );
+      expect(support.publicLearningScope().endsWith('#support')).toBe(true);
+
+      await support.execute(); // support learns
+      await sales.execute(); // sales starts cold — own scope + own owner id
+
+      // Each generated its own strategy independently (no cross-pollination).
+      expect(support.aiCalls).toBe(1);
+      expect(sales.aiCalls).toBe(1);
+
+      // support reuses its own memory on a second run (no new generation).
+      await support.execute();
+      expect(support.aiCalls).toBe(1);
+    });
+  });
+});

--- a/packages/personas/AGENTS.md
+++ b/packages/personas/AGENTS.md
@@ -5,10 +5,10 @@ Tenant-owned, context-scoped agent personas and their resolution. Layers over
 *how* an agent behaves for a given tenant and context (its `TenantAgent` binding
 decides *whether* it runs and caps its capabilities).
 
-This is the L2 foundation of the "learning agents" epic (#1885). Foundation
-only: `AgentPersona` + `PersonaResolver`. `ExecuteAsPrincipal`, feedback, the
-reflection runner, and multi-instance routing are separate issues
-(#1888/#1889/#1890).
+This is the L2 foundation of the "learning agents" epic (#1885): `AgentPersona` +
+`PersonaResolver`, plus the persona-as-durable-instance helpers (#1890, below).
+`ExecuteAsPrincipal`, feedback, and the reflection runner are separate issues
+(#1888/#1889).
 
 ## Models
 
@@ -64,12 +64,38 @@ Because the walk reads personas across tenants, `resolve()` is intended for a
 system/admin path where cross-tenant reads are allowed — not inside a strict
 per-tenant interceptor context (same expectation as `resolveForTenant`).
 
+## Persona as Durable Instance (#1890)
+
+A persona is a **durable instance** of an agent class — N per tenant, each
+independently scheduled, memory-scoped, and permission-scoped. `persona-instance.ts`
+wires that to the `@happyvertical/smrt-agents` multi-instance primitives (which are
+per-package opt-in via `static multiInstance`, singleton by default):
+
+- **Identity** — `personaInstanceKey(persona)` returns the persona id, or `null`
+  for the `default` persona (`DEFAULT_PERSONA_NAME`). A `null` key reuses the
+  **singleton** runtime identity (class-keyed dispatch subscriber + un-suffixed
+  memory scope). `agentOptionsForPersona(persona)` projects `{ instanceKey,
+  tenantId }` to spread into the agent constructor.
+- **Scheduling** — `schedulePersonaInstance(schedules, persona, { cron, … })`
+  creates an `AgentSchedule` bound to the instance: `agentId` = the instance key
+  (`null` for the default → runs the singleton), `agentType` = the persona class.
+- **Admin** — `buildPersonaInstanceAdmin(personas, { tenantId, agentClass,
+  manifest })` renders the class's `uiSlots`/`adminRoutes` **once per instance**
+  (with the per-instance dispatch subscriber); `addPersonaInstance()` /
+  `removePersonaInstance(personaId)` are the add/remove affordances.
+- **Non-destructive upgrade** — `upgradeSingletonToDefaultPersona(personas, {
+  tenantId, agentClass, runAsUserId, … })` maps an existing singleton to a single
+  `default` persona. It's null-keyed, so the running agent's dispatch subscriber,
+  memory, and config are untouched; idempotent (a second call returns the
+  existing default with `created: false` and never overwrites it).
+
 ## Dependencies
 
 Leaf package (acyclic by construction — nothing depends back on it):
 
 - Runtime: `@happyvertical/smrt-core`, `@happyvertical/smrt-tenancy`,
-  `@happyvertical/smrt-agents` (the `TenantAgent` type it bridges).
+  `@happyvertical/smrt-agents` (the `TenantAgent` type it bridges, plus the
+  `AgentSchedule`/multi-instance surface `persona-instance.ts` builds on).
 - `runAsUserId` / `actsAsProfileId` reference `@happyvertical/smrt-users` and
   `@happyvertical/smrt-profiles` via `@crossPackageRef` string ids only — no
   package edge (keeps the DAG minimal). No inter-`smrt-*` `peerDependencies`.

--- a/packages/personas/AGENTS.md
+++ b/packages/personas/AGENTS.md
@@ -77,8 +77,12 @@ per-package opt-in via `static multiInstance`, singleton by default):
   memory scope). `agentOptionsForPersona(persona)` projects `{ instanceKey,
   tenantId }` to spread into the agent constructor.
 - **Scheduling** — `schedulePersonaInstance(schedules, persona, { cron, … })`
-  creates an `AgentSchedule` bound to the instance: `agentId` = the instance key
-  (`null` for the default → runs the singleton), `agentType` = the persona class.
+  creates an `AgentSchedule` for the instance. The instance key rides in
+  `agentConfig` (which the scheduler spreads into the agent constructor →
+  `AgentOptions.instanceKey`); `agentId` is left **null** on purpose, because the
+  scheduler copies `agentId`→`SmrtJob.objectId` and the `TaskRunner`
+  `loadFromId()`s it against the agent's STI table — a persona id is not a row
+  there. The default persona carries no key → runs the singleton.
 - **Admin** — `buildPersonaInstanceAdmin(personas, { tenantId, agentClass,
   manifest })` renders the class's `uiSlots`/`adminRoutes` **once per instance**
   (with the per-instance dispatch subscriber); `addPersonaInstance()` /

--- a/packages/personas/src/index.ts
+++ b/packages/personas/src/index.ts
@@ -21,6 +21,25 @@ export {
   personaContextRank,
 } from './agent-persona.js';
 export {
+  type AddPersonaInstanceOptions,
+  addPersonaInstance,
+  agentOptionsForPersona,
+  type BuildPersonaInstanceAdminOptions,
+  buildPersonaInstanceAdmin,
+  DEFAULT_PERSONA_NAME,
+  isDefaultPersona,
+  type PersonaAgentOptions,
+  type PersonaInstanceAdminView,
+  type PersonaInstanceView,
+  personaInstanceKey,
+  removePersonaInstance,
+  type SchedulePersonaInstanceOptions,
+  schedulePersonaInstance,
+  type UpgradeSingletonOptions,
+  type UpgradeSingletonResult,
+  upgradeSingletonToDefaultPersona,
+} from './persona-instance.js';
+export {
   availabilityFromResolvedAgent,
   type ManifestPersonaDefaults,
   type PersonaAvailabilityGate,

--- a/packages/personas/src/persona-instance.test.ts
+++ b/packages/personas/src/persona-instance.test.ts
@@ -131,7 +131,7 @@ describe('persona-as-instance (#1890)', () => {
   });
 
   describe('schedulePersonaInstance', () => {
-    it('binds an AgentSchedule to a non-default instance via agentId', async () => {
+    it('carries the instance key in agentConfig (not agentId, which loadFromId-s the STI table)', async () => {
       const schedules = await AgentScheduleCollection.create({ db });
       const persona = await addPersonaInstance(personas, {
         tenantId: 'tenant-a',
@@ -144,14 +144,18 @@ describe('persona-as-instance (#1890)', () => {
         cron: '0 2 * * *',
       });
 
-      expect(schedule.agentId).toBe(persona.id);
+      // agentId stays null so the runner constructs a fresh instance instead of
+      // loadFromId-ing the persona id against the agents STI table; the identity
+      // reaches AgentOptions.instanceKey via agentConfig.
+      expect(schedule.agentId).toBeNull();
+      expect(schedule.agentConfig.instanceKey).toBe(persona.id);
       expect(schedule.agentType).toBe(PRAECO);
       expect(schedule.tenantId).toBe('tenant-a');
       expect(schedule.cron).toBe('0 2 * * *');
       expect(schedule.enabled).toBe(true);
     });
 
-    it('schedules the default instance as the singleton (null agentId)', async () => {
+    it('schedules the default instance as the singleton (no instance key)', async () => {
       const schedules = await AgentScheduleCollection.create({ db });
       const { persona } = await upgradeSingletonToDefaultPersona(personas, {
         tenantId: 'tenant-a',
@@ -163,7 +167,25 @@ describe('persona-as-instance (#1890)', () => {
         cron: '*/5 * * * *',
       });
       expect(schedule.agentId).toBeNull();
+      expect(schedule.agentConfig.instanceKey).toBeUndefined();
       expect(schedule.agentType).toBe(PRAECO);
+    });
+
+    it('preserves caller agentConfig alongside the instance key', async () => {
+      const schedules = await AgentScheduleCollection.create({ db });
+      const persona = await addPersonaInstance(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        name: 'Support',
+        runAsUserId: 'user-1',
+      });
+
+      const schedule = await schedulePersonaInstance(schedules, persona, {
+        cron: '0 2 * * *',
+        agentConfig: { region: 'eu' },
+      });
+      expect(schedule.agentConfig.region).toBe('eu');
+      expect(schedule.agentConfig.instanceKey).toBe(persona.id);
     });
 
     it('supports many independent schedules for one class', async () => {
@@ -188,7 +210,7 @@ describe('persona-as-instance (#1890)', () => {
         cron: '0 2 * * *',
       });
 
-      expect(s1.agentId).not.toBe(s2.agentId);
+      expect(s1.agentConfig.instanceKey).not.toBe(s2.agentConfig.instanceKey);
       const forClass = await schedules.listByAgentType(PRAECO);
       expect(forClass).toHaveLength(2);
     });

--- a/packages/personas/src/persona-instance.test.ts
+++ b/packages/personas/src/persona-instance.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Tests for the persona-as-durable-instance helpers (#1890).
+ *
+ * Covers per-instance identity + independent config, per-instance scheduling
+ * (an `AgentSchedule` bound to the persona), the instance-aware admin surface
+ * (class panels rendered per instance, add/remove), and the non-destructive
+ * singleton→default-persona upgrade.
+ *
+ * Resolution/admin helpers read across the tenant (admin path), so — like
+ * `persona-resolver.test.ts` — these run with the tenancy interceptor disabled
+ * and seed `tenantId` explicitly. Real in-memory SQLite from the generated
+ * manifest.
+ */
+
+import {
+  AgentScheduleCollection,
+  instanceScopedSubscriber,
+} from '@happyvertical/smrt-agents';
+import { getTestDatabase } from '@happyvertical/smrt-core';
+import { disableTenancy } from '@happyvertical/smrt-tenancy';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { AgentPersonaCollection } from './agent-persona.js';
+import {
+  addPersonaInstance,
+  agentOptionsForPersona,
+  buildPersonaInstanceAdmin,
+  DEFAULT_PERSONA_NAME,
+  isDefaultPersona,
+  personaInstanceKey,
+  removePersonaInstance,
+  schedulePersonaInstance,
+  upgradeSingletonToDefaultPersona,
+} from './persona-instance.js';
+
+const PRAECO = '@happyvertical/smrt-agents:Praeco';
+
+const MANIFEST = {
+  uiSlots: {
+    sources: { id: 'sources', label: 'Sources', order: 1 },
+    settings: { id: 'settings', label: 'Settings', order: 2 },
+  },
+  adminRoutes: [{ path: 'sources', component: 'SourcesPanel' }],
+};
+
+describe('persona-as-instance (#1890)', () => {
+  // getTestDatabase() creates schemas for every registered class — including the
+  // cross-package AgentSchedule the scheduling helper persists into — from the
+  // same DDL as production. Resolution/admin helpers read across the tenant, so
+  // tenancy enforcement is disabled and tenantId is seeded explicitly.
+  let db: Awaited<ReturnType<typeof getTestDatabase>>;
+  let personas: AgentPersonaCollection;
+
+  beforeEach(async () => {
+    disableTenancy();
+    db = await getTestDatabase();
+    personas = await AgentPersonaCollection.create({ db });
+  });
+
+  describe('personaInstanceKey / identity', () => {
+    it('maps the default persona to the singleton identity (null key)', async () => {
+      const persona = await addPersonaInstance(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        name: DEFAULT_PERSONA_NAME,
+        runAsUserId: 'user-1',
+      });
+      expect(isDefaultPersona(persona)).toBe(true);
+      expect(personaInstanceKey(persona)).toBeNull();
+      expect(agentOptionsForPersona(persona)).toEqual({
+        instanceKey: null,
+        tenantId: 'tenant-a',
+      });
+      // Null key → the class-keyed dispatch subscriber (unchanged singleton).
+      expect(
+        instanceScopedSubscriber(PRAECO, personaInstanceKey(persona)),
+      ).toBe(PRAECO);
+    });
+
+    it('maps a non-default persona to its id and a distinct subscriber', async () => {
+      const persona = await addPersonaInstance(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        name: 'Support',
+        runAsUserId: 'user-1',
+      });
+      expect(personaInstanceKey(persona)).toBe(persona.id);
+      expect(
+        instanceScopedSubscriber(PRAECO, personaInstanceKey(persona)),
+      ).toBe(`${PRAECO}#${persona.id}`);
+    });
+
+    it('two instances of one class have independent config + distinct identity', async () => {
+      const support = await addPersonaInstance(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        name: 'Support',
+        runAsUserId: 'user-support',
+        instructions: 'Be terse.',
+        allowedTools: ['search'],
+        memoryScope: 'm-support',
+      });
+      const sales = await addPersonaInstance(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        name: 'Sales',
+        runAsUserId: 'user-sales',
+        instructions: 'Be warm.',
+        allowedTools: ['summarize'],
+        memoryScope: 'm-sales',
+      });
+
+      // Independent config.
+      expect(support.instructions).not.toBe(sales.instructions);
+      expect(support.getAllowedTools()).toEqual(['search']);
+      expect(sales.getAllowedTools()).toEqual(['summarize']);
+      expect(support.memoryScope).not.toBe(sales.memoryScope);
+      expect(support.runAsUserId).not.toBe(sales.runAsUserId);
+
+      // Distinct per-instance dispatch identities → no cross-processing.
+      expect(personaInstanceKey(support)).not.toBe(personaInstanceKey(sales));
+      expect(
+        instanceScopedSubscriber(PRAECO, personaInstanceKey(support)),
+      ).not.toBe(instanceScopedSubscriber(PRAECO, personaInstanceKey(sales)));
+    });
+
+    it('refuses to key an unsaved non-default persona', () => {
+      expect(() =>
+        personaInstanceKey({ name: 'Support', id: undefined }),
+      ).toThrow(/must be saved/);
+    });
+  });
+
+  describe('schedulePersonaInstance', () => {
+    it('binds an AgentSchedule to a non-default instance via agentId', async () => {
+      const schedules = await AgentScheduleCollection.create({ db });
+      const persona = await addPersonaInstance(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        name: 'Support',
+        runAsUserId: 'user-1',
+      });
+
+      const schedule = await schedulePersonaInstance(schedules, persona, {
+        cron: '0 2 * * *',
+      });
+
+      expect(schedule.agentId).toBe(persona.id);
+      expect(schedule.agentType).toBe(PRAECO);
+      expect(schedule.tenantId).toBe('tenant-a');
+      expect(schedule.cron).toBe('0 2 * * *');
+      expect(schedule.enabled).toBe(true);
+    });
+
+    it('schedules the default instance as the singleton (null agentId)', async () => {
+      const schedules = await AgentScheduleCollection.create({ db });
+      const { persona } = await upgradeSingletonToDefaultPersona(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        runAsUserId: 'user-1',
+      });
+
+      const schedule = await schedulePersonaInstance(schedules, persona, {
+        cron: '*/5 * * * *',
+      });
+      expect(schedule.agentId).toBeNull();
+      expect(schedule.agentType).toBe(PRAECO);
+    });
+
+    it('supports many independent schedules for one class', async () => {
+      const schedules = await AgentScheduleCollection.create({ db });
+      const support = await addPersonaInstance(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        name: 'Support',
+        runAsUserId: 'u1',
+      });
+      const sales = await addPersonaInstance(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        name: 'Sales',
+        runAsUserId: 'u2',
+      });
+
+      const s1 = await schedulePersonaInstance(schedules, support, {
+        cron: '0 1 * * *',
+      });
+      const s2 = await schedulePersonaInstance(schedules, sales, {
+        cron: '0 2 * * *',
+      });
+
+      expect(s1.agentId).not.toBe(s2.agentId);
+      const forClass = await schedules.listByAgentType(PRAECO);
+      expect(forClass).toHaveLength(2);
+    });
+  });
+
+  describe('buildPersonaInstanceAdmin — instance-aware admin', () => {
+    it('renders the class panels per instance with add/remove', async () => {
+      await addPersonaInstance(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        name: 'Support',
+        runAsUserId: 'u1',
+        priority: 5,
+      });
+      await addPersonaInstance(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        name: 'Sales',
+        runAsUserId: 'u2',
+      });
+
+      const admin = await buildPersonaInstanceAdmin(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        manifest: MANIFEST,
+      });
+
+      expect(admin.agentClass).toBe(PRAECO);
+      expect(admin.canAddInstance).toBe(true);
+      expect(admin.instances).toHaveLength(2);
+      // Priority-ordered (Support priority 5 before Sales priority 0).
+      expect(admin.instances.map((i) => i.name)).toEqual(['Support', 'Sales']);
+      // Each instance carries the class's uiSlots + adminRoutes.
+      for (const instance of admin.instances) {
+        expect(Object.keys(instance.slots)).toEqual(['sources', 'settings']);
+        expect(instance.adminRoutes).toEqual(MANIFEST.adminRoutes);
+        expect(instance.dispatchSubscriber).toBe(
+          `${PRAECO}#${instance.personaId}`,
+        );
+      }
+
+      // Add affordance → a third instance.
+      const added = await addPersonaInstance(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        name: 'Ops',
+        runAsUserId: 'u3',
+      });
+      const afterAdd = await buildPersonaInstanceAdmin(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        manifest: MANIFEST,
+      });
+      expect(afterAdd.instances).toHaveLength(3);
+
+      // Remove affordance → back to two, others untouched.
+      const removed = await removePersonaInstance(personas, added.id as string);
+      expect(removed).toBe(true);
+      const afterRemove = await buildPersonaInstanceAdmin(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        manifest: MANIFEST,
+      });
+      expect(afterRemove.instances.map((i) => i.name).sort()).toEqual([
+        'Sales',
+        'Support',
+      ]);
+    });
+
+    it('renders the default instance with the singleton (class-keyed) subscriber', async () => {
+      await upgradeSingletonToDefaultPersona(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        runAsUserId: 'u1',
+      });
+
+      const admin = await buildPersonaInstanceAdmin(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        manifest: MANIFEST,
+      });
+      const def = admin.instances.find((i) => i.isDefault);
+      expect(def).toBeDefined();
+      expect(def?.instanceKey).toBeNull();
+      expect(def?.dispatchSubscriber).toBe(PRAECO);
+    });
+
+    it('returns no instances (empty, addable) when none are configured', async () => {
+      const admin = await buildPersonaInstanceAdmin(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+      });
+      expect(admin.instances).toEqual([]);
+      expect(admin.canAddInstance).toBe(true);
+    });
+  });
+
+  describe('upgradeSingletonToDefaultPersona — non-destructive', () => {
+    it('maps the existing singleton to a single default persona', async () => {
+      const result = await upgradeSingletonToDefaultPersona(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        runAsUserId: 'user-1',
+        instructions: 'legacy behavior',
+      });
+
+      expect(result.created).toBe(true);
+      expect(result.persona.name).toBe(DEFAULT_PERSONA_NAME);
+      expect(result.instanceKey).toBeNull();
+      // Maps to the singleton runtime identity — unchanged.
+      expect(personaInstanceKey(result.persona)).toBeNull();
+
+      const all = await personas.byTenantAndClass('tenant-a', PRAECO);
+      expect(all.filter(isDefaultPersona)).toHaveLength(1);
+    });
+
+    it('is idempotent and does not overwrite the existing default', async () => {
+      const first = await upgradeSingletonToDefaultPersona(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        runAsUserId: 'user-1',
+        instructions: 'legacy behavior',
+      });
+
+      // A second upgrade with different config must not clobber the first.
+      const second = await upgradeSingletonToDefaultPersona(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        runAsUserId: 'user-2',
+        instructions: 'DIFFERENT',
+      });
+
+      expect(second.created).toBe(false);
+      expect(second.persona.id).toBe(first.persona.id);
+      expect(second.persona.instructions).toBe('legacy behavior');
+
+      const all = await personas.byTenantAndClass('tenant-a', PRAECO);
+      expect(all.filter(isDefaultPersona)).toHaveLength(1);
+    });
+
+    it('leaves other instances untouched when upgrading', async () => {
+      const support = await addPersonaInstance(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        name: 'Support',
+        runAsUserId: 'u1',
+        instructions: 'terse',
+      });
+
+      await upgradeSingletonToDefaultPersona(personas, {
+        tenantId: 'tenant-a',
+        agentClass: PRAECO,
+        runAsUserId: 'user-1',
+      });
+
+      const reloaded = await personas.get({ id: support.id as string });
+      expect(reloaded?.instructions).toBe('terse');
+      const all = await personas.byTenantAndClass('tenant-a', PRAECO);
+      expect(all).toHaveLength(2);
+    });
+  });
+});

--- a/packages/personas/src/persona-instance.ts
+++ b/packages/personas/src/persona-instance.ts
@@ -12,7 +12,8 @@
  *   `default` persona reuses the **singleton** identity (a `null` key), which is
  *   what makes the singleton→multi upgrade non-destructive.
  * - **Scheduling** — {@link schedulePersonaInstance} binds an `AgentSchedule` to
- *   a persona instance (the schedule already carries `agentId`).
+ *   a persona instance, routing the instance key through `agentConfig` so it
+ *   reaches the constructed agent as `AgentOptions.instanceKey`.
  * - **Admin** — {@link buildPersonaInstanceAdmin} renders the agent class's
  *   `uiSlots`/`adminRoutes` once per instance, with {@link addPersonaInstance} /
  *   {@link removePersonaInstance} affordances.
@@ -130,11 +131,19 @@ export interface SchedulePersonaInstanceOptions {
 /**
  * Create an `AgentSchedule` bound to a persona **instance**.
  *
- * The schedule's `agentType` is the persona's agent class and its `agentId` is
- * the persona instance key ({@link personaInstanceKey}) — `null` for the default
- * (so it runs the singleton), the persona id otherwise (so the runtime
- * constructs that specific instance). This is the per-instance scheduling the
- * issue calls for: many schedules for one class, one per instance.
+ * The schedule's `agentType` is the persona's agent class. The persona instance
+ * key ({@link personaInstanceKey}) must reach the constructed agent as
+ * `AgentOptions.instanceKey`, so it is carried in `agentConfig` — which the
+ * scheduler (`smrt-jobs`) spreads into the agent constructor options — and
+ * `agentId` is left **null**.
+ *
+ * This is deliberate: the scheduler copies `AgentSchedule.agentId` to
+ * `SmrtJob.objectId`, and the `TaskRunner` `loadFromId()`s a non-null
+ * `objectId` against the agent's STI table. A persona id lives in
+ * `agent_personas`, not that table, so putting it in `agentId` would fail to
+ * load (or load the wrong row). Leaving `agentId` null makes the runner
+ * construct a fresh instance and pick up `instanceKey` from `agentConfig`. The
+ * default persona (null key) carries no key → runs the singleton.
  *
  * @param schedules - The `AgentScheduleCollection` to create into.
  * @param persona - The persona instance to schedule (must be saved).
@@ -146,14 +155,20 @@ export async function schedulePersonaInstance(
   options: SchedulePersonaInstanceOptions,
 ): Promise<AgentSchedule> {
   const instanceKey = personaInstanceKey(persona);
+  const agentConfig: Record<string, unknown> = {
+    ...(options.agentConfig ?? {}),
+  };
+  if (instanceKey) {
+    agentConfig.instanceKey = instanceKey;
+  }
   const schedule = await schedules.create({
     tenantId: persona.tenantId,
     agentType: persona.agentClass,
-    agentId: instanceKey,
+    agentId: null,
     cron: options.cron,
     timezone: options.timezone ?? 'UTC',
     method: options.method ?? 'run',
-    agentConfig: options.agentConfig ?? {},
+    agentConfig,
     methodArgs: options.methodArgs ?? {},
     enabled: options.enabled ?? true,
   });

--- a/packages/personas/src/persona-instance.ts
+++ b/packages/personas/src/persona-instance.ts
@@ -1,0 +1,428 @@
+/**
+ * Persona-as-durable-instance helpers (#1890).
+ *
+ * Treats an {@link AgentPersona} as a **durable instance** of an agent class:
+ * N configured instances per tenant, each independently scheduled, memory-scoped,
+ * and permission-scoped. This module wires that instance concept to the
+ * `@happyvertical/smrt-agents` runtime:
+ *
+ * - **Identity** — {@link personaInstanceKey} / {@link agentOptionsForPersona}
+ *   map a persona to the `AgentOptions.instanceKey` the framework folds into a
+ *   per-instance dispatch subscriber, memory scope, and interest scope. The
+ *   `default` persona reuses the **singleton** identity (a `null` key), which is
+ *   what makes the singleton→multi upgrade non-destructive.
+ * - **Scheduling** — {@link schedulePersonaInstance} binds an `AgentSchedule` to
+ *   a persona instance (the schedule already carries `agentId`).
+ * - **Admin** — {@link buildPersonaInstanceAdmin} renders the agent class's
+ *   `uiSlots`/`adminRoutes` once per instance, with {@link addPersonaInstance} /
+ *   {@link removePersonaInstance} affordances.
+ * - **Upgrade** — {@link upgradeSingletonToDefaultPersona} maps an existing
+ *   singleton to a single `default` persona without touching its data.
+ *
+ * Multi-instance is a per-package opt-in on the agent class
+ * (`static multiInstance = true`); these helpers manage the persona rows that
+ * back it. A singleton (non-opted) agent needs none of this and is unchanged.
+ */
+
+import {
+  type AgentAdminRoute,
+  type AgentManifestInfo,
+  type AgentSchedule,
+  type AgentScheduleCollection,
+  type AgentUISlots,
+  instanceScopedSubscriber,
+} from '@happyvertical/smrt-agents';
+import {
+  type AgentPersona,
+  type AgentPersonaCollection,
+  canonicalAgentClass,
+} from './agent-persona.js';
+
+/**
+ * The reserved persona name for the singleton/default instance.
+ *
+ * Matches the `PersonaResolver` default-fallback name so the concept is
+ * consistent across the package. A persona with this name is the tenant's
+ * singleton identity: it maps to a `null` instance key (see
+ * {@link personaInstanceKey}), reusing the class-keyed dispatch subscriber and
+ * un-suffixed memory scope an un-upgraded agent already uses.
+ */
+export const DEFAULT_PERSONA_NAME = 'default';
+
+/**
+ * The durable per-instance key for a persona, or `null` for the singleton.
+ *
+ * - The `default` persona → `null`: it *is* the singleton identity, so an agent
+ *   run as it keeps the class-keyed dispatch subscriber and un-suffixed memory
+ *   scope. This is why upgrading a singleton to a default persona changes no
+ *   runtime identity (non-destructive).
+ * - Any other persona → its `id`: a distinct, stable instance key the framework
+ *   folds into a per-instance subscriber/memory/interest scope.
+ *
+ * @throws Error if a non-default persona has no `id` (it must be saved first —
+ *   an unsaved non-default persona would masquerade as the singleton).
+ */
+export function personaInstanceKey(
+  persona: Pick<AgentPersona, 'name' | 'id'>,
+): string | null {
+  if (persona.name === DEFAULT_PERSONA_NAME) {
+    return null;
+  }
+  if (!persona.id) {
+    throw new Error(
+      'personaInstanceKey: a non-default persona must be saved (have an id) ' +
+        'before it can act as a durable instance',
+    );
+  }
+  return persona.id;
+}
+
+/**
+ * Whether a persona is the singleton/default instance.
+ */
+export function isDefaultPersona(persona: Pick<AgentPersona, 'name'>): boolean {
+  return persona.name === DEFAULT_PERSONA_NAME;
+}
+
+/**
+ * The subset of `AgentOptions` a runtime spreads to construct an agent as this
+ * persona instance. Kept structural (no agents runtime import needed by the
+ * caller) — spread into `new AgentClass({ ...agentOptionsForPersona(p), db })`.
+ */
+export interface PersonaAgentOptions {
+  /** Per-instance key — `null` for the default (singleton) persona. */
+  instanceKey: string | null;
+  /** The tenant the persona belongs to. */
+  tenantId: string;
+}
+
+/**
+ * Project a persona into the agent construction options that give the agent its
+ * per-instance identity.
+ */
+export function agentOptionsForPersona(
+  persona: AgentPersona,
+): PersonaAgentOptions {
+  return {
+    instanceKey: personaInstanceKey(persona),
+    tenantId: persona.tenantId,
+  };
+}
+
+/**
+ * Options for {@link schedulePersonaInstance}.
+ */
+export interface SchedulePersonaInstanceOptions {
+  /** Cron expression (5-field). */
+  cron: string;
+  /** Timezone label (default `'UTC'`). */
+  timezone?: string;
+  /** Agent method to invoke (default `'run'`). */
+  method?: string;
+  /** Config passed to the agent on each run. */
+  agentConfig?: Record<string, unknown>;
+  /** Arguments passed to the method. */
+  methodArgs?: Record<string, unknown>;
+  /** Whether the schedule starts enabled (default `true`). */
+  enabled?: boolean;
+}
+
+/**
+ * Create an `AgentSchedule` bound to a persona **instance**.
+ *
+ * The schedule's `agentType` is the persona's agent class and its `agentId` is
+ * the persona instance key ({@link personaInstanceKey}) — `null` for the default
+ * (so it runs the singleton), the persona id otherwise (so the runtime
+ * constructs that specific instance). This is the per-instance scheduling the
+ * issue calls for: many schedules for one class, one per instance.
+ *
+ * @param schedules - The `AgentScheduleCollection` to create into.
+ * @param persona - The persona instance to schedule (must be saved).
+ * @param options - Cron and run settings.
+ */
+export async function schedulePersonaInstance(
+  schedules: AgentScheduleCollection,
+  persona: AgentPersona,
+  options: SchedulePersonaInstanceOptions,
+): Promise<AgentSchedule> {
+  const instanceKey = personaInstanceKey(persona);
+  const schedule = await schedules.create({
+    tenantId: persona.tenantId,
+    agentType: persona.agentClass,
+    agentId: instanceKey,
+    cron: options.cron,
+    timezone: options.timezone ?? 'UTC',
+    method: options.method ?? 'run',
+    agentConfig: options.agentConfig ?? {},
+    methodArgs: options.methodArgs ?? {},
+    enabled: options.enabled ?? true,
+  });
+  await schedule.save();
+  return schedule;
+}
+
+/**
+ * One instance's row in the instance-aware admin surface.
+ *
+ * Carries the agent class's admin surface (`slots` / `adminRoutes`) rendered for
+ * THIS instance, plus the resolved per-instance dispatch subscriber so the admin
+ * can show how the instance is routed.
+ */
+export interface PersonaInstanceView {
+  /** The persona id backing this instance. */
+  personaId: string;
+  /** Persona (instance) name. */
+  name: string;
+  /** Per-instance key — `null` for the default (singleton). */
+  instanceKey: string | null;
+  /** Whether this is the default (singleton) instance. */
+  isDefault: boolean;
+  /** Whether the instance is enabled. */
+  enabled: boolean;
+  /** Resolution priority. */
+  priority: number;
+  /** Context scoping (if any). */
+  contextType: string | null;
+  contextId: string | null;
+  /** The principal the instance runs as. */
+  runAsUserId: string;
+  /** Optional acting bot identity. */
+  actsAsProfileId: string | null;
+  /** The per-instance dispatch subscriber identity. */
+  dispatchSubscriber: string;
+  /** The agent class's UI slots, rendered for this instance. */
+  slots: AgentUISlots;
+  /** The agent class's admin routes, rendered for this instance. */
+  adminRoutes: AgentAdminRoute[];
+}
+
+/**
+ * The instance-aware admin surface for one `(tenant, agentClass)` pair.
+ */
+export interface PersonaInstanceAdminView {
+  /** Canonical agent class the surface is for. */
+  agentClass: string;
+  /** Tenant the surface is for. */
+  tenantId: string;
+  /** One entry per configured instance (persona), priority-ordered. */
+  instances: PersonaInstanceView[];
+  /** Whether new instances may be added (always true for the persona model). */
+  canAddInstance: boolean;
+}
+
+/**
+ * Options for {@link buildPersonaInstanceAdmin}.
+ */
+export interface BuildPersonaInstanceAdminOptions {
+  /** Tenant to render the surface for. */
+  tenantId: string;
+  /** Agent class (canonicalized internally). */
+  agentClass: string;
+  /**
+   * The agent class's manifest surface. Its `uiSlots` / `adminRoutes` are
+   * rendered once per instance. Optional — omit to render instances with empty
+   * panels (e.g. a class that declares none).
+   */
+  manifest?: Pick<AgentManifestInfo, 'uiSlots' | 'adminRoutes'>;
+}
+
+/**
+ * Build the instance-aware admin surface: one panel set per configured instance.
+ *
+ * Lists the tenant's persona instances for the class and renders the class's
+ * `uiSlots`/`adminRoutes` for each, so an admin sees N instances (not one class
+ * panel) with add/remove affordances. The default (singleton) instance appears
+ * with `instanceKey: null` and the class-keyed subscriber.
+ *
+ * @param personas - Persona collection to read instances from.
+ * @param options - Tenant, class, and the class manifest to render per instance.
+ */
+export async function buildPersonaInstanceAdmin(
+  personas: AgentPersonaCollection,
+  options: BuildPersonaInstanceAdminOptions,
+): Promise<PersonaInstanceAdminView> {
+  const canonical = canonicalAgentClass(options.agentClass);
+  const slots = options.manifest?.uiSlots ?? {};
+  const adminRoutes = options.manifest?.adminRoutes ?? [];
+
+  const rows = await personas.byTenantAndClass(options.tenantId, canonical);
+
+  const instances: PersonaInstanceView[] = rows.map((persona) => {
+    const instanceKey = personaInstanceKey(persona);
+    return {
+      personaId: persona.id as string,
+      name: persona.name,
+      instanceKey,
+      isDefault: isDefaultPersona(persona),
+      enabled: persona.enabled,
+      priority: persona.priority,
+      contextType: persona.contextType,
+      contextId: persona.contextId,
+      runAsUserId: persona.runAsUserId,
+      actsAsProfileId: persona.actsAsProfileId,
+      dispatchSubscriber: instanceScopedSubscriber(canonical, instanceKey),
+      slots,
+      adminRoutes,
+    };
+  });
+
+  return {
+    agentClass: canonical,
+    tenantId: options.tenantId,
+    instances,
+    canAddInstance: true,
+  };
+}
+
+/**
+ * Options for {@link addPersonaInstance}.
+ */
+export interface AddPersonaInstanceOptions {
+  tenantId: string;
+  agentClass: string;
+  /** Instance name (unique per `(tenant, agentClass)`). */
+  name: string;
+  /** The principal the instance runs as (required by `AgentPersona`). */
+  runAsUserId: string;
+  instructions?: string;
+  allowedTools?: string[];
+  contextType?: string | null;
+  contextId?: string | null;
+  priority?: number;
+  memoryScope?: string;
+  actsAsProfileId?: string | null;
+  enabled?: boolean;
+}
+
+/**
+ * Add a new instance (persona) — the "add" admin affordance.
+ *
+ * Creates and saves an `AgentPersona`, canonicalizing the agent class so it
+ * lines up with `TenantAgent`. The `(tenant_id, agent_class, name)` unique
+ * constraint rejects a duplicate name.
+ */
+export async function addPersonaInstance(
+  personas: AgentPersonaCollection,
+  options: AddPersonaInstanceOptions,
+): Promise<AgentPersona> {
+  const persona = await personas.create({
+    tenantId: options.tenantId,
+    agentClass: canonicalAgentClass(options.agentClass),
+    name: options.name,
+    instructions: options.instructions ?? '',
+    contextType: options.contextType ?? null,
+    contextId: options.contextId ?? null,
+    priority: options.priority ?? 0,
+    enabled: options.enabled ?? true,
+    runAsUserId: options.runAsUserId,
+    actsAsProfileId: options.actsAsProfileId ?? null,
+    memoryScope: options.memoryScope ?? '',
+  });
+  if (options.allowedTools) {
+    persona.setAllowedTools(options.allowedTools);
+  }
+  await persona.save();
+  return persona;
+}
+
+/**
+ * Remove an instance (persona) by id — the "remove" admin affordance.
+ *
+ * Deletes only the named instance; other instances of the class are untouched.
+ * A no-op (returns `false`) when the persona does not exist.
+ *
+ * @returns `true` if a persona was removed, `false` if none matched the id.
+ */
+export async function removePersonaInstance(
+  personas: AgentPersonaCollection,
+  personaId: string,
+): Promise<boolean> {
+  const persona = await personas.get({ id: personaId });
+  if (!persona) {
+    return false;
+  }
+  await persona.delete();
+  return true;
+}
+
+/**
+ * Options for {@link upgradeSingletonToDefaultPersona}.
+ */
+export interface UpgradeSingletonOptions {
+  tenantId: string;
+  agentClass: string;
+  /** The principal the default persona runs as (required by `AgentPersona`). */
+  runAsUserId: string;
+  /** Instructions to seed the default persona with (from existing config). */
+  instructions?: string;
+  /** Tools to seed (from existing config). */
+  allowedTools?: string[];
+  /**
+   * Memory scope for the default persona. Leave empty (default) to let the
+   * resolver derive it — for the default (null-keyed) instance the derived
+   * scope equals the singleton's existing `agent/<type>` scope, so existing
+   * learned memory is preserved untouched.
+   */
+  memoryScope?: string;
+  actsAsProfileId?: string | null;
+}
+
+/**
+ * The result of a singleton→multi upgrade.
+ */
+export interface UpgradeSingletonResult {
+  /** The default persona representing the existing singleton instance. */
+  persona: AgentPersona;
+  /** `true` if it was created now, `false` if a default persona already existed. */
+  created: boolean;
+  /**
+   * The instance key for the default persona — always `null`, i.e. it maps to
+   * the existing singleton runtime identity (same dispatch subscriber + memory
+   * scope), which is what makes the upgrade non-destructive.
+   */
+  instanceKey: null;
+}
+
+/**
+ * Non-destructively upgrade a singleton agent to the multi-instance model by
+ * mapping the existing instance to a single `default` persona.
+ *
+ * The default persona is null-keyed, so it *reuses the singleton's exact runtime
+ * identity* — the class-keyed dispatch subscriber and the un-suffixed
+ * `agent/<type>` memory scope. Nothing about the running agent, its config, its
+ * dispatch subscriptions, or its learned memory changes; a persona row is simply
+ * added so further instances can now be created alongside it.
+ *
+ * Idempotent: if a `default` persona already exists for the pair it is returned
+ * with `created: false` and nothing is duplicated.
+ *
+ * @param personas - Persona collection to read/create into.
+ * @param options - Tenant, class, and the principal + config to seed.
+ */
+export async function upgradeSingletonToDefaultPersona(
+  personas: AgentPersonaCollection,
+  options: UpgradeSingletonOptions,
+): Promise<UpgradeSingletonResult> {
+  const canonical = canonicalAgentClass(options.agentClass);
+
+  const existing = await personas.byTenantAndClass(options.tenantId, canonical);
+  const existingDefault = existing.find(isDefaultPersona);
+  if (existingDefault) {
+    return { persona: existingDefault, created: false, instanceKey: null };
+  }
+
+  const persona = await addPersonaInstance(personas, {
+    tenantId: options.tenantId,
+    agentClass: canonical,
+    name: DEFAULT_PERSONA_NAME,
+    runAsUserId: options.runAsUserId,
+    instructions: options.instructions,
+    allowedTools: options.allowedTools,
+    memoryScope: options.memoryScope,
+    actsAsProfileId: options.actsAsProfileId,
+    priority: 0,
+    enabled: true,
+  });
+
+  return { persona, created: true, instanceKey: null };
+}


### PR DESCRIPTION
## Slice

L2 of the learning-agents epic: **multiple named instances of one agent class per tenant** — a persona is a durable instance, each independently scheduled / memory-scoped / permission-scoped, with per-instance routing. Multi-instance is a **per-package opt-in**; **singleton is the default and the N=1 case**, byte-for-byte unchanged.

### Framework primitives — `@happyvertical/smrt-agents` (`src/agent.ts`)
- `static multiInstance = false` opt-in on `Agent`.
- `AgentOptions.instanceKey` + `getInstanceKey()` — returns `null` unless the class opts in, so a non-opted agent ignores any key passed to it.
- `getDispatchSubscriber()` — the bare agent type for a singleton, `` `${agentType}#${key}` `` for a multi-instance agent. Wired into subscription seeding, `processDispatches()`, and `execute()` so each instance owns its subscription rows and pending-dispatch queue → instances never cross-process dispatches. Exported helper `instanceScopedSubscriber()`.
- `resolveSignalSubscriptions()` + `instanceInterestFilter()` — seams a package overrides to scope its dispatch/interests by the instance config.
- `learningScope()` — suffixed with `#<key>` per instance so instances learn independently.

### Persona-as-instance — `@happyvertical/smrt-personas` (`src/persona-instance.ts`)
- `personaInstanceKey()` / `agentOptionsForPersona()` — the **`default` persona reuses the singleton identity** (null key), which makes the upgrade non-destructive.
- `schedulePersonaInstance()` — `AgentSchedule` bound to the instance via `agentId`.
- `buildPersonaInstanceAdmin()` + `addPersonaInstance()` / `removePersonaInstance()` — render the class's `uiSlots`/`adminRoutes` **per instance**, with add/remove affordances.
- `upgradeSingletonToDefaultPersona()` — non-destructive, idempotent singleton→default-persona mapping.

### Tests (real in-memory SQLite)
- `packages/agents/src/multi-instance.test.ts` — two instances have distinct dispatch subscribers and an emit for one is **not** processed by the other; partitioned interests; per-instance memory scopes; **singleton regression** (a non-opted agent ignores `instanceKey`, keeps the class-keyed subscriber and un-suffixed scope).
- `packages/personas/src/persona-instance.test.ts` — per-instance identity + independent config; per-instance scheduling; instance-aware admin (class panels per instance, add/remove); **non-destructive, idempotent** upgrade to a single default persona.

### Notes for review
- Non-opted agents are unchanged by construction: `getDispatchSubscriber()` ≡ `getAgentTypeName()` and `learningScope()`/`instanceInterestFilter()` are identity when `multiInstance` is off.
- Runs in parallel with #1888/#1889 (which also touch these packages). Additions are modular — one new file per package plus additive edits; expect only trivial index/AGENTS.md merge reconciliation.

Local: agents node suite 206 passed (19 files); personas 44 passed (3 files); `tsc` + `svelte-check` clean for both; `pnpm build` green; knowledge-freshness check green. The agents package's full Vitest run (its Svelte plugin) is CI-gated locally (known vite8/rolldown block); no Svelte files were touched.

Closes #1890
Part of #1885
