### PR TITLE
feat(agents): ExecuteAsPrincipal — run agent work as a persona's bound user

### DIFF
--- a/packages/agents/src/execute-as-principal.test.ts
+++ b/packages/agents/src/execute-as-principal.test.ts
@@ -1,0 +1,240 @@
+/**
+ * executeAsPrincipal — logic tests on real in-memory SQLite.
+ *
+ * These prove the door-agnostic pieces that do not need Postgres: the principal
+ * context is published, the persona tool ceiling is enforced, the RLS-off
+ * catalog seam denies un-permitted operations, and actions audit as
+ * on-behalf-of the originating user. Postgres RLS enforcement of the same
+ * permission set is proven by
+ * `@happyvertical/smrt-users`'s `principal-permission-context-postgres.test.ts`.
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Logger } from '@happyvertical/logger';
+import {
+  MembershipCollection,
+  OperationPermissionError,
+  PermissionCollection,
+  RoleCollection,
+  RolePermissionCollection,
+  registerPermissionDefinitions,
+  TenantCollection,
+  UserCollection,
+} from '@happyvertical/smrt-users';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  executeAsPrincipal,
+  type PrincipalAuditEntry,
+  PrincipalToolNotAllowedError,
+} from './execute-as-principal.js';
+
+describe('executeAsPrincipal', () => {
+  let dbPath: string;
+  let db: { type: 'sqlite'; url: string };
+  let unregister: (() => void) | undefined;
+  let userId: string;
+  let tenantId: string;
+  let roleId: string;
+  let rolePermissions: RolePermissionCollection;
+  let permissions: PermissionCollection;
+
+  beforeEach(async () => {
+    dbPath = join(
+      tmpdir(),
+      `smrt-exec-principal-${Date.now()}-${Math.random()}.db`,
+    );
+    db = { type: 'sqlite', url: dbPath };
+    const options = { db };
+
+    // Catalog slugs the tool/exec seam asserts against.
+    unregister = registerPermissionDefinitions([
+      { slug: 'widgets.read' },
+      { slug: 'widgets.create' },
+    ]);
+
+    const users = await UserCollection.create(options);
+    const tenants = await TenantCollection.create(options);
+    const roles = await RoleCollection.create(options);
+    permissions = await PermissionCollection.create(options);
+    rolePermissions = await RolePermissionCollection.create(options);
+    const memberships = await MembershipCollection.create(options);
+
+    const user = await users.create({ email: 'principal@example.com' });
+    await user.save();
+    const tenant = await tenants.create({ name: 'Principal Org' });
+    await tenant.save();
+    const role = await roles.create({ name: 'Widget Reader' });
+    await role.save();
+    await (
+      await memberships.create({
+        userId: user.id,
+        tenantId: tenant.id,
+        roleId: role.id,
+      })
+    ).save();
+
+    userId = user.id as string;
+    tenantId = tenant.id as string;
+    roleId = role.id as string;
+
+    await grant('widgets.read');
+  });
+
+  afterEach(() => {
+    unregister?.();
+    unregister = undefined;
+    vi.restoreAllMocks();
+    if (existsSync(dbPath)) {
+      try {
+        rmSync(dbPath, { force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+
+  async function grant(slug: string): Promise<void> {
+    const permission = await permissions.create({ slug, name: slug });
+    await permission.save();
+    await rolePermissions.addPermission(roleId, permission.id as string);
+  }
+
+  it('runs the body inside a context built from the bound principal', async () => {
+    const seen = await executeAsPrincipal(
+      {
+        db,
+        principal: { runAsUserId: userId, tenantId },
+        audit: () => {},
+      },
+      async (run) => {
+        expect(run.context.userId).toBe(userId);
+        expect(run.context.tenantId).toBe(tenantId);
+        expect(run.context.session).toBeNull();
+        expect(run.context.superAdminBypass).toBe(false);
+        expect(run.context.systemContext).toBe(false);
+        expect(run.permissions).toContain('widgets.read');
+        return run.permissions;
+      },
+    );
+    expect(seen).toContain('widgets.read');
+  });
+
+  it('enforces the persona tool ceiling (allowedTools)', async () => {
+    await executeAsPrincipal(
+      {
+        db,
+        principal: { runAsUserId: userId, tenantId, allowedTools: ['publish'] },
+        audit: () => {},
+      },
+      async (run) => {
+        expect(run.isToolAllowed('publish')).toBe(true);
+        expect(run.isToolAllowed('delete')).toBe(false);
+        expect(() => run.assertToolAllowed('publish')).not.toThrow();
+        expect(() => run.assertToolAllowed('delete')).toThrow(
+          PrincipalToolNotAllowedError,
+        );
+      },
+    );
+  });
+
+  it('treats an undefined tool ceiling as "no ceiling" (all tools pass)', async () => {
+    await executeAsPrincipal(
+      { db, principal: { runAsUserId: userId, tenantId }, audit: () => {} },
+      async (run) => {
+        expect(run.isToolAllowed('anything')).toBe(true);
+        expect(() => run.assertToolAllowed('anything')).not.toThrow();
+      },
+    );
+  });
+
+  it('asserts the catalog permission for a (collection, action) at the RLS-off seam', async () => {
+    await executeAsPrincipal(
+      { db, principal: { runAsUserId: userId, tenantId }, audit: () => {} },
+      async (run) => {
+        const permitted = await run.assertOperation('widgets', 'read');
+        expect(permitted.allowed).toBe(true);
+
+        await expect(run.assertOperation('widgets', 'create')).rejects.toThrow(
+          OperationPermissionError,
+        );
+      },
+    );
+  });
+
+  it('reflects live role changes on the next execution', async () => {
+    await executeAsPrincipal(
+      { db, principal: { runAsUserId: userId, tenantId }, audit: () => {} },
+      async (run) => {
+        await expect(run.assertOperation('widgets', 'create')).rejects.toThrow(
+          OperationPermissionError,
+        );
+      },
+    );
+
+    await grant('widgets.create');
+
+    await executeAsPrincipal(
+      { db, principal: { runAsUserId: userId, tenantId }, audit: () => {} },
+      async (run) => {
+        const permitted = await run.assertOperation('widgets', 'create');
+        expect(permitted.allowed).toBe(true);
+      },
+    );
+  });
+
+  it('audits the action as on-behalf-of the originating user', async () => {
+    const entries: PrincipalAuditEntry[] = [];
+    await executeAsPrincipal(
+      {
+        db,
+        principal: { runAsUserId: userId, tenantId, actsAsProfileId: 'bot-1' },
+        onBehalfOfUserId: 'originator-9',
+        agentClass: '@happyvertical/smrt-agents:Widgeteer',
+        action: 'agent.run',
+        audit: (entry) => {
+          entries.push(entry);
+        },
+      },
+      async () => {},
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      action: 'agent.run',
+      actorUserId: userId,
+      onBehalfOfUserId: 'originator-9',
+      tenantId,
+      agentClass: '@happyvertical/smrt-agents:Widgeteer',
+      actsAsProfileId: 'bot-1',
+    });
+  });
+
+  it('falls back to the injected logger when no audit sink is provided', async () => {
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    await executeAsPrincipal(
+      {
+        db,
+        principal: { runAsUserId: userId, tenantId },
+        onBehalfOfUserId: 'originator-9',
+        logger: logger as unknown as Logger,
+      },
+      async () => {},
+    );
+
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      'agent action executed on behalf of originating user',
+      expect.objectContaining({
+        actorUserId: userId,
+        onBehalfOfUserId: 'originator-9',
+      }),
+    );
+  });
+});

--- a/packages/agents/src/execute-as-principal.test.ts
+++ b/packages/agents/src/execute-as-principal.test.ts
@@ -139,12 +139,32 @@ describe('executeAsPrincipal', () => {
     );
   });
 
-  it('treats an undefined tool ceiling as "no ceiling" (all tools pass)', async () => {
+  it('fails closed when no tool allow-list is provided (permits NOTHING)', async () => {
     await executeAsPrincipal(
       { db, principal: { runAsUserId: userId, tenantId }, audit: () => {} },
       async (run) => {
-        expect(run.isToolAllowed('anything')).toBe(true);
-        expect(() => run.assertToolAllowed('anything')).not.toThrow();
+        expect(run.allowedTools).toEqual([]);
+        expect(run.isToolAllowed('anything')).toBe(false);
+        expect(() => run.assertToolAllowed('anything')).toThrow(
+          PrincipalToolNotAllowedError,
+        );
+      },
+    );
+  });
+
+  it('fails closed for an empty allow-list and for empty/blank tool names', async () => {
+    await executeAsPrincipal(
+      {
+        db,
+        principal: { runAsUserId: userId, tenantId, allowedTools: [] },
+        audit: () => {},
+      },
+      async (run) => {
+        expect(run.isToolAllowed('publish')).toBe(false);
+        expect(run.isToolAllowed('')).toBe(false);
+        expect(() => run.assertToolAllowed('publish')).toThrow(
+          PrincipalToolNotAllowedError,
+        );
       },
     );
   });
@@ -180,6 +200,53 @@ describe('executeAsPrincipal', () => {
       async (run) => {
         const permitted = await run.assertOperation('widgets', 'create');
         expect(permitted.allowed).toBe(true);
+      },
+    );
+  });
+
+  it('enforces the published snapshot within a run — a mid-run grant is not honored', async () => {
+    await executeAsPrincipal(
+      { db, principal: { runAsUserId: userId, tenantId }, audit: () => {} },
+      async (run) => {
+        // Snapshot holds widgets.read but not widgets.create.
+        expect((await run.assertOperation('widgets', 'read')).allowed).toBe(
+          true,
+        );
+        await expect(run.assertOperation('widgets', 'create')).rejects.toThrow(
+          OperationPermissionError,
+        );
+
+        // Granting widgets.create DURING the run must NOT change the authority
+        // bound — the seam authorizes against the published snapshot, matching
+        // what Postgres RLS enforces for the same context (adapter-independent).
+        await grant('widgets.create');
+        await expect(run.assertOperation('widgets', 'create')).rejects.toThrow(
+          OperationPermissionError,
+        );
+      },
+    );
+  });
+
+  it('honors a reduced pre-resolved permission set consistently at the seam', async () => {
+    await grant('widgets.create');
+    // Live RBAC now grants both read and create, but the caller narrows the
+    // published set to read-only; the RLS-off seam must enforce that narrower
+    // snapshot, not the broader live set.
+    await executeAsPrincipal(
+      {
+        db,
+        principal: { runAsUserId: userId, tenantId },
+        permissions: ['widgets.read'],
+        audit: () => {},
+      },
+      async (run) => {
+        expect(run.permissions).toEqual(['widgets.read']);
+        expect((await run.assertOperation('widgets', 'read')).allowed).toBe(
+          true,
+        );
+        await expect(run.assertOperation('widgets', 'create')).rejects.toThrow(
+          OperationPermissionError,
+        );
       },
     );
   });

--- a/packages/agents/src/execute-as-principal.ts
+++ b/packages/agents/src/execute-as-principal.ts
@@ -54,9 +54,12 @@ export interface PrincipalBinding {
   /** Tenant the principal acts within. */
   tenantId: string | null;
   /**
-   * Tool identifiers the persona may invoke (already capped by the agent-class
-   * ceiling). `undefined` means "no tool ceiling declared" — every tool passes.
-   * An empty array means "no tools permitted".
+   * The persona's tool allow-list (already capped by the agent-class ceiling).
+   * This is a **fail-closed** whitelist, mirroring
+   * `@happyvertical/smrt-chat`'s `AgentSession.isToolAllowed()` (S5 #1392): an
+   * absent (`undefined`) or empty allow-list permits **NO** tools, never all of
+   * them, so forgetting to pass it can only tighten authority. Resolved personas
+   * always provide a concrete `string[]`.
    */
   allowedTools?: string[];
   /** Optional acting `Bot` profile id, recorded in the audit entry. */
@@ -151,19 +154,27 @@ export class PrincipalToolNotAllowedError extends Error {
 export interface PrincipalRun {
   /** The published session-permission runtime context for the principal. */
   context: SessionPermissionRuntimeContext;
-  /** The principal's live-resolved permission slugs. */
+  /** The principal's published (snapshot) permission slugs. */
   permissions: string[];
-  /** The persona's tool ceiling (`undefined` when no ceiling was declared). */
-  allowedTools: string[] | undefined;
-  /** Whether `tool` is within the persona's `allowedTools`. */
+  /**
+   * The effective, fail-closed tool allow-list — always a concrete array (an
+   * absent binding allow-list normalizes to `[]`, i.e. no tools).
+   */
+  allowedTools: string[];
+  /**
+   * Whether `tool` is within the fail-closed allow-list. An empty allow-list,
+   * or an empty/non-string tool name, permits nothing.
+   */
   isToolAllowed(tool: string): boolean;
   /** Throw {@link PrincipalToolNotAllowedError} unless `tool` is allowed. */
   assertToolAllowed(tool: string): void;
   /**
    * Assert the principal holds the catalog permission for `(collection,
-   * action)`. This is the door-agnostic teeth for the RLS-off adapters — it
-   * re-resolves the principal live and throws `OperationPermissionError` on
-   * denial. Under Postgres RLS it is a redundant (but harmless) second gate.
+   * action)`, authorizing against the **published** principal set
+   * (`context.permissionSet`) — the same snapshot the RLS session enforces — so
+   * the bound is adapter-independent. This is the door-agnostic teeth for the
+   * RLS-off adapters; under Postgres RLS it is a redundant (but harmless)
+   * second gate. Throws `OperationPermissionError` on denial.
    */
   assertOperation(
     collection: OperationPermissionCollectionInput,
@@ -235,12 +246,16 @@ export async function executeAsPrincipal<T>(
     ...smrtOptions
   } = options;
 
-  const {
-    runAsUserId,
-    tenantId,
-    allowedTools,
-    actsAsProfileId = null,
-  } = principal;
+  const { runAsUserId, tenantId, actsAsProfileId = null } = principal;
+
+  // Fail-closed tool allow-list (mirrors chat's AgentSession, S5 #1392): an
+  // absent or non-array binding allow-list normalizes to `[]` — no tools — so a
+  // missing ceiling can only tighten authority, never open it up.
+  const toolWhitelist = Array.isArray(principal.allowedTools)
+    ? principal.allowedTools
+    : [];
+  const isToolAllowed = (tool: string): boolean =>
+    typeof tool === 'string' && tool.length > 0 && toolWhitelist.includes(tool);
 
   await emitAudit(
     {
@@ -270,12 +285,10 @@ export async function executeAsPrincipal<T>(
       const run: PrincipalRun = {
         context,
         permissions: context.permissions,
-        allowedTools,
-        isToolAllowed(tool: string): boolean {
-          return allowedTools == null || allowedTools.includes(tool);
-        },
+        allowedTools: toolWhitelist,
+        isToolAllowed,
         assertToolAllowed(tool: string): void {
-          if (allowedTools != null && !allowedTools.includes(tool)) {
+          if (!isToolAllowed(tool)) {
             throw new PrincipalToolNotAllowedError(tool);
           }
         },
@@ -289,6 +302,10 @@ export async function executeAsPrincipal<T>(
             ...extraOptions,
             collection,
             action: operationAction,
+            // Authorize against the PUBLISHED principal set (the same snapshot
+            // Postgres RLS enforces for this context), not a fresh live
+            // re-resolve — keeps the RLS-off gate adapter-independent.
+            permissionSet: context.permissionSet,
           });
         },
       };

--- a/packages/agents/src/execute-as-principal.ts
+++ b/packages/agents/src/execute-as-principal.ts
@@ -1,0 +1,298 @@
+/**
+ * ExecuteAsPrincipal — run an agent's work AS its persona's bound user.
+ *
+ * This is deliberately NOT a new authorization layer. It reuses the framework's
+ * existing principal-context machinery:
+ *
+ * - {@link withPrincipalPermissionContext} resolves the bound user's *live*
+ *   permission set (the standard {@link PermissionResolver} cascade) and
+ *   publishes `(smrt.user_id, smrt.tenant_id, smrt.permissions[])` onto the DB
+ *   session. With Postgres RLS enabled, the manifest-derived policies then bound
+ *   every query the agent makes per-`(table, action)` and per-tenant — through
+ *   any door (in-process "side door", REST, MCP), with no per-call re-checking.
+ *
+ * - Because RLS is Postgres-only and opt-in, the exec/tool seam must ALSO assert
+ *   the catalog permission for the `(collection, action)` when RLS is off
+ *   (SQLite/dev). {@link PrincipalRun.assertOperation} wraps
+ *   `assertOperationPermission` for exactly that, so the authority bound holds
+ *   on every adapter.
+ *
+ * The effective authority of an agent action is therefore:
+ *
+ *   bound-user RBAC  ∩  agent-class capability ceiling  ∩  persona allowedTools
+ *
+ * where the RBAC half is enforced at the data layer (RLS) or the catalog seam
+ * (`assertOperation`), and the tool half is enforced by
+ * {@link PrincipalRun.assertToolAllowed} against `allowedTools` — which a
+ * resolved persona has already intersected with the `TenantAgent` ceiling.
+ *
+ * Actions audit as on-behalf-of the originating user (see {@link PrincipalAuditEntry}).
+ *
+ * @packageDocumentation
+ */
+
+import { createLogger, type Logger } from '@happyvertical/logger';
+import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import {
+  assertOperationPermission,
+  type OperationPermissionCollectionInput,
+  type OperationPermissionDecision,
+  type PermissionResolver,
+  type SessionPermissionRuntimeContext,
+  withPrincipalPermissionContext,
+} from '@happyvertical/smrt-users';
+
+/**
+ * The bound principal an agent runs as. A resolved persona structurally
+ * satisfies this once its optional `runAsUserId` has been narrowed to a
+ * concrete id — `allowedTools` on a `ResolvedPersona` is already the persona's
+ * tools intersected with the `TenantAgent` capability ceiling.
+ */
+export interface PrincipalBinding {
+  /** The user whose live permissions bound this execution. Required. */
+  runAsUserId: string;
+  /** Tenant the principal acts within. */
+  tenantId: string | null;
+  /**
+   * Tool identifiers the persona may invoke (already capped by the agent-class
+   * ceiling). `undefined` means "no tool ceiling declared" — every tool passes.
+   * An empty array means "no tools permitted".
+   */
+  allowedTools?: string[];
+  /** Optional acting `Bot` profile id, recorded in the audit entry. */
+  actsAsProfileId?: string | null;
+}
+
+/**
+ * A single audit record describing an agent action performed by the bound
+ * principal (`actorUserId`) on behalf of the originating user
+ * (`onBehalfOfUserId`).
+ */
+export interface PrincipalAuditEntry {
+  /** Action label, e.g. `'agent.run'`. */
+  action: string;
+  /** The persona's bound user the work ran as. */
+  actorUserId: string;
+  /** The user who triggered the agent, if known. */
+  onBehalfOfUserId: string | null;
+  /** Tenant the action ran within. */
+  tenantId: string | null;
+  /** Canonical agent class, when the caller supplies it. */
+  agentClass?: string;
+  /** Acting profile id, when the persona sets one. */
+  actsAsProfileId?: string | null;
+  /** Free-form additional context. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Sink that records a {@link PrincipalAuditEntry}. Provide one to persist audit
+ * rows (e.g. via `AuditLog.record`); when omitted, the entry is emitted as a
+ * structured log line.
+ */
+export type PrincipalAuditSink = (
+  entry: PrincipalAuditEntry,
+) => void | Promise<void>;
+
+/**
+ * Options for {@link executeAsPrincipal}.
+ */
+export interface ExecuteAsPrincipalOptions extends SmrtClassOptions {
+  /** The bound principal to run as. */
+  principal: PrincipalBinding;
+  /** The originating user the action is performed on behalf of (for audit). */
+  onBehalfOfUserId?: string | null;
+  /** Canonical agent class, recorded in the audit entry. */
+  agentClass?: string;
+  /** Audit action label. Defaults to `'agent.run'`. */
+  action?: string;
+  /** Extra audit metadata merged into the emitted entry. */
+  auditMetadata?: Record<string, unknown>;
+  /**
+   * Pre-resolved permission slugs. When omitted, the principal's permissions
+   * are resolved live so role changes reflect on the next execution.
+   */
+  permissions?: string[];
+  /** Reuse an initialized resolver across executions. */
+  resolver?: PermissionResolver;
+  /** Opt into Postgres RLS transaction wrapping (defaults to package config). */
+  postgresRls?: boolean;
+  /**
+   * Enter tenant context so tenant auto-filtering applies on every adapter.
+   * Defaults to `true` whenever the principal has a tenant.
+   */
+  enterTenantContext?: boolean;
+  /** Audit sink. Defaults to a structured log line. */
+  audit?: PrincipalAuditSink;
+  /** Logger used for the default audit sink. */
+  logger?: Logger;
+}
+
+/**
+ * Thrown when the persona attempts a tool outside its `allowedTools`.
+ */
+export class PrincipalToolNotAllowedError extends Error {
+  readonly tool: string;
+  readonly status = 403;
+
+  constructor(tool: string) {
+    super(`Tool '${tool}' is not permitted for this persona.`);
+    this.name = 'PrincipalToolNotAllowedError';
+    this.tool = tool;
+  }
+}
+
+/**
+ * The handle passed to the {@link executeAsPrincipal} body. Its
+ * session-permission {@link context} is already published for the principal, so
+ * data operations are bounded by RLS on Postgres. The assertions enforce the
+ * remaining two authority dimensions.
+ */
+export interface PrincipalRun {
+  /** The published session-permission runtime context for the principal. */
+  context: SessionPermissionRuntimeContext;
+  /** The principal's live-resolved permission slugs. */
+  permissions: string[];
+  /** The persona's tool ceiling (`undefined` when no ceiling was declared). */
+  allowedTools: string[] | undefined;
+  /** Whether `tool` is within the persona's `allowedTools`. */
+  isToolAllowed(tool: string): boolean;
+  /** Throw {@link PrincipalToolNotAllowedError} unless `tool` is allowed. */
+  assertToolAllowed(tool: string): void;
+  /**
+   * Assert the principal holds the catalog permission for `(collection,
+   * action)`. This is the door-agnostic teeth for the RLS-off adapters — it
+   * re-resolves the principal live and throws `OperationPermissionError` on
+   * denial. Under Postgres RLS it is a redundant (but harmless) second gate.
+   */
+  assertOperation(
+    collection: OperationPermissionCollectionInput,
+    action: string,
+    extraOptions?: SmrtClassOptions,
+  ): Promise<OperationPermissionDecision>;
+}
+
+async function emitAudit(
+  entry: PrincipalAuditEntry,
+  audit: PrincipalAuditSink | undefined,
+  logger: Logger | undefined,
+): Promise<void> {
+  if (audit) {
+    await audit(entry);
+    return;
+  }
+  const log = logger ?? createLogger({ level: 'info' });
+  log.info('agent action executed on behalf of originating user', {
+    ...entry,
+  });
+}
+
+/**
+ * Run `fn` AS the persona's bound principal.
+ *
+ * Resolves the bound user's live permissions, publishes them onto the DB
+ * session (so Postgres RLS bounds every query per-`(table, action)`), emits an
+ * on-behalf-of audit entry, and hands `fn` a {@link PrincipalRun} whose
+ * assertions enforce the persona tool ceiling and the RLS-off catalog gate.
+ *
+ * @example
+ * ```typescript
+ * await executeAsPrincipal(
+ *   {
+ *     db,
+ *     principal: {
+ *       runAsUserId: persona.runAsUserId,
+ *       tenantId: persona.tenantId,
+ *       allowedTools: persona.allowedTools,
+ *     },
+ *     onBehalfOfUserId: triggeringUserId,
+ *     agentClass: persona.agentClass,
+ *   },
+ *   async (run) => {
+ *     run.assertToolAllowed('articles.publish');
+ *     await run.assertOperation('articles', 'update');
+ *     await agent.run();
+ *   },
+ * );
+ * ```
+ */
+export async function executeAsPrincipal<T>(
+  options: ExecuteAsPrincipalOptions,
+  fn: (run: PrincipalRun) => Promise<T>,
+): Promise<T> {
+  const {
+    principal,
+    onBehalfOfUserId = null,
+    agentClass,
+    action = 'agent.run',
+    auditMetadata,
+    permissions,
+    resolver,
+    postgresRls,
+    enterTenantContext,
+    audit,
+    logger,
+    ...smrtOptions
+  } = options;
+
+  const {
+    runAsUserId,
+    tenantId,
+    allowedTools,
+    actsAsProfileId = null,
+  } = principal;
+
+  await emitAudit(
+    {
+      action,
+      actorUserId: runAsUserId,
+      onBehalfOfUserId,
+      tenantId,
+      agentClass,
+      actsAsProfileId,
+      metadata: auditMetadata,
+    },
+    audit,
+    logger,
+  );
+
+  return withPrincipalPermissionContext(
+    {
+      ...smrtOptions,
+      userId: runAsUserId,
+      tenantId,
+      permissions,
+      resolver,
+      postgresRls,
+      enterTenantContext: enterTenantContext ?? tenantId !== null,
+    },
+    async (context) => {
+      const run: PrincipalRun = {
+        context,
+        permissions: context.permissions,
+        allowedTools,
+        isToolAllowed(tool: string): boolean {
+          return allowedTools == null || allowedTools.includes(tool);
+        },
+        assertToolAllowed(tool: string): void {
+          if (allowedTools != null && !allowedTools.includes(tool)) {
+            throw new PrincipalToolNotAllowedError(tool);
+          }
+        },
+        async assertOperation(
+          collection: OperationPermissionCollectionInput,
+          operationAction: string,
+          extraOptions?: SmrtClassOptions,
+        ): Promise<OperationPermissionDecision> {
+          return assertOperationPermission({
+            ...smrtOptions,
+            ...extraOptions,
+            collection,
+            action: operationAction,
+          });
+        },
+      };
+      return fn(run);
+    },
+  );
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -94,6 +94,15 @@ export {
   resolveAgentAIOptions,
 } from './ai-config.js';
 export { AgentConfig, AgentConfigCollection } from './config.js';
+export {
+  type ExecuteAsPrincipalOptions,
+  executeAsPrincipal,
+  type PrincipalAuditEntry,
+  type PrincipalAuditSink,
+  type PrincipalBinding,
+  type PrincipalRun,
+  PrincipalToolNotAllowedError,
+} from './execute-as-principal.js';
 export type {
   AgentWithInterestsOptions,
   AsyncQualifierFn,

--- a/packages/users/src/__tests__/operation-permission.test.ts
+++ b/packages/users/src/__tests__/operation-permission.test.ts
@@ -168,6 +168,51 @@ describe('operation permission guards', () => {
     );
   });
 
+  it('authorizes against an explicit permissionSet instead of re-resolving live RBAC', async () => {
+    // Live RBAC grants update for this actor.
+    const holder = await createActor(['operation_permission_records.update']);
+
+    // In-set → allowed (no live resolve needed).
+    const allowed = await assertOperationPermission({
+      ...options,
+      action: 'update',
+      collection: 'operation_permission_records',
+      tenantId: holder.tenant.id,
+      userId: holder.user.id,
+      permissionSet: new Set(['operation_permission_records.update']),
+    });
+    expect(allowed).toMatchObject({
+      allowed: true,
+      reason: 'permission_granted',
+    });
+
+    // Not in the (empty) published set → DENIED, even though live RBAC grants
+    // it. The published snapshot is authoritative, so an RLS-off gate matches
+    // what the RLS session would enforce for the same context.
+    await expect(
+      assertOperationPermission({
+        ...options,
+        action: 'update',
+        collection: 'operation_permission_records',
+        tenantId: holder.tenant.id,
+        userId: holder.user.id,
+        permissionSet: new Set<string>(),
+      }),
+    ).rejects.toThrow(OperationPermissionError);
+
+    // A readonly array is accepted too.
+    await expect(
+      assertOperationPermission({
+        ...options,
+        action: 'update',
+        collection: 'operation_permission_records',
+        tenantId: holder.tenant.id,
+        userId: holder.user.id,
+        permissionSet: [] as readonly string[],
+      }),
+    ).rejects.toThrow(OperationPermissionError);
+  });
+
   it('allows holders and denies non-holders fail-closed', async () => {
     const holder = await createActor(['operation_permission_records.update']);
     const nonHolder = await createActor([]);

--- a/packages/users/src/__tests__/principal-permission-context-postgres.test.ts
+++ b/packages/users/src/__tests__/principal-permission-context-postgres.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Real-Postgres RLS proof for withPrincipalPermissionContext (issue #1888).
+ *
+ * Gated on DATABASE_URL (`isPostgresAvailable()`), so CI's Postgres shard runs
+ * it and it skips cleanly elsewhere. It proves that a principal's LIVE-resolved
+ * permissions bound Postgres RLS per-`(table, action)` and per-tenant:
+ *
+ * - a permitted op succeeds,
+ * - an un-permitted op is DENIED by the database,
+ * - a cross-tenant read is denied,
+ * - a live role change reflects on the next resolve.
+ *
+ * RLS only bites for a non-superuser, NOBYPASSRLS role, so — exactly like the
+ * existing `permission-postgres-rls.test.ts` — enforcement is exercised under
+ * `SET ROLE` inside a transaction. The permission set fed onto that session is
+ * the real {@link PermissionResolver} output (the same live cascade
+ * `withPrincipalPermissionContext` runs), and a companion test proves the
+ * wrapper itself publishes that principal onto a real Postgres session.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { clearCache } from '@happyvertical/smrt-config';
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  createIsolatedTestDbFromManifest,
+  type IsolatedTestDbResult,
+  isPostgresAvailable,
+  type TransactionHandle,
+} from '@happyvertical/smrt-vitest';
+import { type DatabaseInterface, getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { MembershipCollection } from '../collections/MembershipCollection.js';
+import { PermissionCollection } from '../collections/PermissionCollection.js';
+import { RoleCollection } from '../collections/RoleCollection.js';
+import { RolePermissionCollection } from '../collections/RolePermissionCollection.js';
+import { TenantCollection } from '../collections/TenantCollection.js';
+import { UserCollection } from '../collections/UserCollection.js';
+import { applyPostgresPermissionPolicies } from '../services/index.js';
+import { PermissionResolver } from '../services/PermissionResolver.js';
+import {
+  getCurrentSessionPermissionContext,
+  withPrincipalPermissionContext,
+} from '../services/SessionPermissionContext.js';
+
+@smrt({
+  api: { include: ['list', 'create', 'update', 'delete'] },
+  collection: 'principal_rls_records',
+  tableName: 'principal_rls_records',
+  tenantScoped: { field: 'tenantId', mode: 'required' },
+})
+class PrincipalRlsRecord extends SmrtObject {
+  tenantId: string = '';
+  title: string = '';
+}
+
+const describePostgres = isPostgresAvailable() ? describe : describe.skip;
+
+function rowsOf(result: unknown): Array<Record<string, unknown>> {
+  return ((result as { rows?: Array<Record<string, unknown>> }).rows ?? []).map(
+    (row) => ({ ...row }),
+  );
+}
+
+function rowCountOf(result: unknown): number {
+  return (result as { rowCount?: number }).rowCount ?? 0;
+}
+
+async function closeDatabase(database: unknown): Promise<void> {
+  if (
+    database &&
+    typeof (database as { close?: () => Promise<void> }).close === 'function'
+  ) {
+    await (database as { close: () => Promise<void> }).close();
+  }
+}
+
+describePostgres('withPrincipalPermissionContext + Postgres RLS', () => {
+  let isolated: IsolatedTestDbResult | undefined;
+  let adminDb: DatabaseInterface | undefined;
+  let url = '';
+  let roleName = '';
+  let userId = '';
+  let tenantAId = '';
+  let tenantBId = '';
+  let roleId = '';
+  let readPermissionId = '';
+
+  beforeEach(async () => {
+    isolated = await createIsolatedTestDbFromManifest();
+    if (isolated.config.type !== 'postgres') {
+      throw new Error('Expected a Postgres test database.');
+    }
+    url = isolated.config.url;
+    const options = { db: { type: 'postgres' as const, url } };
+
+    adminDb = await getDatabase({ type: 'postgres', url });
+    await adminDb.query('TRUNCATE TABLE public.principal_rls_records');
+
+    // Seed RBAC via the real collections so column shapes/ids are correct.
+    const users = await UserCollection.create(options);
+    const tenants = await TenantCollection.create(options);
+    const roles = await RoleCollection.create(options);
+    const permissions = await PermissionCollection.create(options);
+    const rolePermissions = await RolePermissionCollection.create(options);
+    const memberships = await MembershipCollection.create(options);
+
+    const user = await users.create({
+      email: `principal-${randomUUID()}@example.com`,
+    });
+    await user.save();
+    const tenantA = await tenants.create({ name: 'Principal Tenant A' });
+    await tenantA.save();
+    const tenantB = await tenants.create({ name: 'Principal Tenant B' });
+    await tenantB.save();
+    const role = await roles.create({ name: 'Principal Reader' });
+    await role.save();
+    const readPermission = await permissions.create({
+      slug: 'principal_rls_records.read',
+      name: 'Read Principal Records',
+    });
+    await readPermission.save();
+    await rolePermissions.addPermission(
+      role.id as string,
+      readPermission.id as string,
+    );
+    await (
+      await memberships.create({
+        userId: user.id,
+        tenantId: tenantA.id,
+        roleId: role.id,
+      })
+    ).save();
+
+    userId = user.id as string;
+    tenantAId = tenantA.id as string;
+    tenantBId = tenantB.id as string;
+    roleId = role.id as string;
+    readPermissionId = readPermission.id as string;
+
+    // One record per tenant; the principal is bound to tenant A only.
+    await adminDb.query(
+      [
+        'INSERT INTO public.principal_rls_records',
+        '  (id, slug, context, tenant_id, title)',
+        'VALUES',
+        `  ('row-a', 'row-a', '', '${tenantAId}', 'Tenant A'),`,
+        `  ('row-b', 'row-b', '', '${tenantBId}', 'Tenant B')`,
+      ].join('\n'),
+    );
+
+    await applyPostgresPermissionPolicies(options);
+
+    roleName = `smrt_principal_rls_${randomUUID().replaceAll('-', '_')}`;
+    await adminDb.query(
+      `CREATE ROLE "${roleName}" LOGIN PASSWORD 'postgres' NOSUPERUSER NOBYPASSRLS`,
+    );
+    await adminDb.query(`GRANT USAGE ON SCHEMA public TO "${roleName}"`);
+    await adminDb.query(
+      `GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.principal_rls_records TO "${roleName}"`,
+    );
+  });
+
+  afterEach(async () => {
+    if (adminDb) {
+      try {
+        await adminDb.query('TRUNCATE TABLE public.principal_rls_records');
+      } catch {
+        // best-effort cleanup against a shared test database
+      }
+      if (roleName) {
+        try {
+          await adminDb.query(`DROP ROLE IF EXISTS "${roleName}"`);
+        } catch {
+          // best-effort cleanup
+        }
+      }
+    }
+    roleName = '';
+    await closeDatabase(adminDb);
+    adminDb = undefined;
+    clearCache();
+    if (isolated) {
+      await isolated.cleanup();
+      isolated = undefined;
+    }
+  });
+
+  /**
+   * Resolve the principal's LIVE permissions (exactly as
+   * withPrincipalPermissionContext does) and run `fn` under a NOBYPASSRLS role
+   * with that resolved set published onto the DB session — so RLS actually
+   * bites (the app connection in these tests is a superuser that would
+   * otherwise bypass RLS).
+   */
+  async function underResolvedPrincipal(
+    tenantId: string,
+    fn: (tx: TransactionHandle) => Promise<void>,
+  ): Promise<void> {
+    const resolver = await PermissionResolver.create({
+      db: { type: 'postgres', url },
+    });
+    const resolved = await resolver.resolvePermissions(userId, tenantId);
+    const permissions = Array.from(resolved.permissions);
+
+    const factory = adminDb as DatabaseInterface & {
+      beginTransaction?: () => Promise<TransactionHandle>;
+    };
+    if (!factory?.beginTransaction) {
+      throw new Error('Role database does not support beginTransaction().');
+    }
+    const tx = await factory.beginTransaction();
+    try {
+      await tx.query(`SET ROLE "${roleName}"`);
+      await tx.query("SELECT set_config('smrt.tenant_id', $1, true)", tenantId);
+      await tx.query("SELECT set_config('smrt.user_id', $1, true)", userId);
+      await tx.query("SELECT set_config('smrt.session_id', $1, true)", '');
+      await tx.query(
+        "SELECT set_config('smrt.permissions', $1, true)",
+        JSON.stringify(permissions),
+      );
+      await tx.query(
+        "SELECT set_config('smrt.super_admin_bypass', $1, true)",
+        'false',
+      );
+      await tx.query(
+        "SELECT set_config('smrt.system_context', $1, true)",
+        'false',
+      );
+      await fn(tx);
+    } finally {
+      if (tx.isActive()) {
+        await tx.rollback();
+      }
+    }
+  }
+
+  it('bounds a permitted read to the principal tenant and denies cross-tenant rows', async () => {
+    await underResolvedPrincipal(tenantAId, async (tx) => {
+      const result = await tx.query(
+        'SELECT id FROM public.principal_rls_records ORDER BY id',
+      );
+      // row-a (tenant A) is visible; row-b (tenant B) is filtered — cross-tenant
+      // denied.
+      expect(rowsOf(result).map((row) => row.id)).toEqual(['row-a']);
+    });
+  });
+
+  it('denies an un-permitted operation at the database', async () => {
+    // The principal holds only `principal_rls_records.read`, so INSERT (which
+    // requires `.create`) is rejected by the RLS policy.
+    await underResolvedPrincipal(tenantAId, async (tx) => {
+      await expect(
+        tx.query(
+          [
+            'INSERT INTO public.principal_rls_records',
+            '  (id, slug, context, tenant_id, title)',
+            `VALUES ('row-c', 'row-c', '', '${tenantAId}', 'Tenant C')`,
+          ].join('\n'),
+        ),
+      ).rejects.toThrow(/row-level security/i);
+    });
+  });
+
+  it('reflects a live role change on the next resolve', async () => {
+    // Before: the principal can read its tenant's row.
+    await underResolvedPrincipal(tenantAId, async (tx) => {
+      const result = await tx.query(
+        'SELECT id FROM public.principal_rls_records ORDER BY id',
+      );
+      expect(rowsOf(result).map((row) => row.id)).toEqual(['row-a']);
+    });
+
+    // Revoke the read permission from the role at the data layer.
+    await (adminDb as DatabaseInterface).query(
+      'DELETE FROM public.role_permissions WHERE role_id = $1 AND permission_id = $2',
+      roleId,
+      readPermissionId,
+    );
+
+    // After: the next resolve returns an empty set, so RLS filters every row.
+    await underResolvedPrincipal(tenantAId, async (tx) => {
+      const result = await tx.query(
+        'SELECT id FROM public.principal_rls_records ORDER BY id',
+      );
+      expect(rowsOf(result)).toHaveLength(0);
+    });
+  });
+
+  it('publishes the live-resolved principal onto the Postgres session', async () => {
+    await withPrincipalPermissionContext(
+      {
+        db: { type: 'postgres', url },
+        userId,
+        tenantId: tenantAId,
+        postgresRls: true,
+      },
+      async (context) => {
+        expect(context.postgresRls).toBe(true);
+        expect(context.userId).toBe(userId);
+        expect(context.tenantId).toBe(tenantAId);
+        expect(context.superAdminBypass).toBe(false);
+        expect(context.systemContext).toBe(false);
+        expect(context.permissions).toContain('principal_rls_records.read');
+        expect(getCurrentSessionPermissionContext()?.userId).toBe(userId);
+
+        // The principal is published onto the actual DB session that RLS reads.
+        const publishedPermissions = await context.database.query(
+          "SELECT current_setting('smrt.permissions', true) AS value",
+        );
+        expect(
+          JSON.parse(rowsOf(publishedPermissions)[0]?.value as string),
+        ).toContain('principal_rls_records.read');
+
+        const publishedUser = await context.database.query(
+          "SELECT current_setting('smrt.user_id', true) AS value",
+        );
+        expect(rowsOf(publishedUser)[0]?.value).toBe(userId);
+
+        const publishedBypass = await context.database.query(
+          "SELECT current_setting('smrt.super_admin_bypass', true) AS value",
+        );
+        expect(rowsOf(publishedBypass)[0]?.value).toBe('false');
+      },
+    );
+  });
+
+  it('publishes an empty permission set for a tenant the principal has no membership in', async () => {
+    // Tenant B: no membership, so the resolved set is empty (fail closed).
+    await withPrincipalPermissionContext(
+      {
+        db: { type: 'postgres', url },
+        userId,
+        tenantId: tenantBId,
+        postgresRls: true,
+      },
+      async (context) => {
+        expect(context.permissions).toEqual([]);
+        const published = await context.database.query(
+          "SELECT current_setting('smrt.permissions', true) AS value",
+        );
+        expect(rowsOf(published)[0]?.value).toBe('[]');
+      },
+    );
+
+    // And under RLS that empty set filters every row in tenant B.
+    await underResolvedPrincipal(tenantBId, async (tx) => {
+      const result = await tx.query(
+        'SELECT id FROM public.principal_rls_records ORDER BY id',
+      );
+      expect(rowsOf(result)).toHaveLength(0);
+    });
+  });
+});

--- a/packages/users/src/__tests__/principal-permission-context.test.ts
+++ b/packages/users/src/__tests__/principal-permission-context.test.ts
@@ -1,0 +1,253 @@
+/**
+ * withPrincipalPermissionContext — logic tests on real in-memory SQLite plus a
+ * focused mock proving the Postgres session-variable publication.
+ *
+ * The real-Postgres RLS enforcement proof lives in
+ * `principal-permission-context-postgres.test.ts` (gated on DATABASE_URL).
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MembershipCollection } from '../collections/MembershipCollection.js';
+import { PermissionCollection } from '../collections/PermissionCollection.js';
+import { RoleCollection } from '../collections/RoleCollection.js';
+import { RolePermissionCollection } from '../collections/RolePermissionCollection.js';
+import { TenantCollection } from '../collections/TenantCollection.js';
+import { UserCollection } from '../collections/UserCollection.js';
+import { PermissionResolver } from '../services/PermissionResolver.js';
+import {
+  getCurrentSessionPermissionContext,
+  withPrincipalPermissionContext,
+} from '../services/SessionPermissionContext.js';
+import { SessionService } from '../services/SessionService.js';
+
+describe('withPrincipalPermissionContext (SQLite logic)', () => {
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = join(
+      tmpdir(),
+      `smrt-principal-ctx-${Date.now()}-${Math.random()}.db`,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (existsSync(dbPath)) {
+      try {
+        rmSync(dbPath, { force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+
+  async function seed(): Promise<{
+    userId: string;
+    tenantId: string;
+    roleId: string;
+    grant: (slug: string) => Promise<void>;
+  }> {
+    const options = { db: { type: 'sqlite' as const, url: dbPath } };
+    const users = await UserCollection.create(options);
+    const tenants = await TenantCollection.create(options);
+    const roles = await RoleCollection.create(options);
+    const permissions = await PermissionCollection.create(options);
+    const rolePermissions = await RolePermissionCollection.create(options);
+    const memberships = await MembershipCollection.create(options);
+
+    const user = await users.create({ email: 'principal@example.com' });
+    await user.save();
+    const tenant = await tenants.create({ name: 'Principal Org' });
+    await tenant.save();
+    const role = await roles.create({ name: 'Reader' });
+    await role.save();
+    const membership = await memberships.create({
+      userId: user.id,
+      tenantId: tenant.id,
+      roleId: role.id,
+    });
+    await membership.save();
+
+    const grant = async (slug: string): Promise<void> => {
+      const permission = await permissions.create({ slug, name: slug });
+      await permission.save();
+      await rolePermissions.addPermission(
+        role.id as string,
+        permission.id as string,
+      );
+    };
+
+    return {
+      userId: user.id as string,
+      tenantId: tenant.id as string,
+      roleId: role.id as string,
+      grant,
+    };
+  }
+
+  it('publishes the bound principal and its live-resolved permissions into the context', async () => {
+    const { userId, tenantId, grant } = await seed();
+    await grant('articles.read');
+
+    const seenInside = await withPrincipalPermissionContext(
+      { db: { type: 'sqlite', url: dbPath }, userId, tenantId },
+      async (context) => {
+        // The ALS store exposes the same context to any downstream code.
+        expect(getCurrentSessionPermissionContext()?.userId).toBe(userId);
+        expect(context.userId).toBe(userId);
+        expect(context.tenantId).toBe(tenantId);
+        expect(context.session).toBeNull();
+        expect(context.sessionId).toBeNull();
+        // A principal run never bypasses.
+        expect(context.superAdminBypass).toBe(false);
+        expect(context.systemContext).toBe(false);
+        expect(context.permissions).toContain('articles.read');
+        expect(context.permissionSet.has('articles.read')).toBe(true);
+        return context.permissions;
+      },
+    );
+
+    expect(seenInside).toEqual(['articles.read']);
+  });
+
+  it('re-resolves live so role changes reflect on the next execution', async () => {
+    const { userId, tenantId, grant } = await seed();
+    await grant('articles.read');
+
+    await withPrincipalPermissionContext(
+      { db: { type: 'sqlite', url: dbPath }, userId, tenantId },
+      async (context) => {
+        expect(context.permissions).toContain('articles.read');
+        expect(context.permissions).not.toContain('articles.publish');
+      },
+    );
+
+    // Grant a new permission to the same role between executions.
+    await grant('articles.publish');
+
+    await withPrincipalPermissionContext(
+      { db: { type: 'sqlite', url: dbPath }, userId, tenantId },
+      async (context) => {
+        expect(context.permissions).toContain('articles.read');
+        expect(context.permissions).toContain('articles.publish');
+      },
+    );
+  });
+
+  it('honors an explicit pre-resolved permission set without querying the resolver', async () => {
+    const { userId, tenantId, grant } = await seed();
+    await grant('articles.read');
+    const resolveSpy = vi.spyOn(
+      PermissionResolver.prototype,
+      'resolvePermissions',
+    );
+
+    await withPrincipalPermissionContext(
+      {
+        db: { type: 'sqlite', url: dbPath },
+        userId,
+        tenantId,
+        permissions: ['articles.override'],
+      },
+      async (context) => {
+        expect(context.permissions).toEqual(['articles.override']);
+      },
+    );
+
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+
+  it('fails closed to no permissions when the principal has no tenant', async () => {
+    const { userId } = await seed();
+
+    await withPrincipalPermissionContext(
+      { db: { type: 'sqlite', url: dbPath }, userId, tenantId: null },
+      async (context) => {
+        expect(context.permissions).toEqual([]);
+        expect(context.tenantId).toBeNull();
+      },
+    );
+  });
+});
+
+describe('withPrincipalPermissionContext (Postgres session publication)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('publishes the resolved principal onto the DB session, never bypassing', async () => {
+    const transaction = {
+      commit: vi.fn().mockResolvedValue(undefined),
+      isActive: vi.fn().mockReturnValue(true),
+      query: vi.fn().mockResolvedValue(undefined),
+      rollback: vi.fn().mockResolvedValue(undefined),
+      url: 'postgres://transaction-db',
+    };
+    const baseDb = {
+      beginTransaction: vi.fn().mockResolvedValue(transaction),
+      query: vi.fn().mockResolvedValue(undefined),
+      url: 'postgres://base-db',
+    };
+    const fakeSessionService = {
+      getDatabase: () => baseDb,
+    } as unknown as SessionService;
+    vi.spyOn(SessionService, 'create').mockResolvedValue(fakeSessionService);
+
+    const resolvePermissions = vi.fn().mockResolvedValue({
+      permissions: new Set(['articles.read', 'articles.update']),
+    });
+    vi.spyOn(PermissionResolver, 'create').mockResolvedValue({
+      resolvePermissions,
+    } as unknown as PermissionResolver);
+
+    const resolved = await withPrincipalPermissionContext(
+      {
+        db: { type: 'postgres', url: 'postgres://base-db' },
+        postgresRls: true,
+        userId: 'user-1',
+        tenantId: 'tenant-1',
+      },
+      async (context) => context.permissions,
+    );
+
+    expect(resolved).toEqual(['articles.read', 'articles.update']);
+    // Live resolution used the standard cascade for the exact principal.
+    expect(resolvePermissions).toHaveBeenCalledWith('user-1', 'tenant-1', {});
+
+    expect(baseDb.beginTransaction).toHaveBeenCalledTimes(1);
+    expect(transaction.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("set_config('smrt.tenant_id'"),
+      'tenant-1',
+    );
+    expect(transaction.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("set_config('smrt.user_id'"),
+      'user-1',
+    );
+    expect(transaction.query).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining("set_config('smrt.session_id'"),
+      '',
+    );
+    expect(transaction.query).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining("set_config('smrt.permissions'"),
+      JSON.stringify(['articles.read', 'articles.update']),
+    );
+    expect(transaction.query).toHaveBeenNthCalledWith(
+      5,
+      expect.stringContaining("set_config('smrt.super_admin_bypass'"),
+      'false',
+    );
+    expect(transaction.query).toHaveBeenNthCalledWith(
+      6,
+      expect.stringContaining("set_config('smrt.system_context'"),
+      'false',
+    );
+    expect(transaction.commit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/users/src/__tests__/principal-permission-context.test.ts
+++ b/packages/users/src/__tests__/principal-permission-context.test.ts
@@ -160,6 +160,32 @@ describe('withPrincipalPermissionContext (SQLite logic)', () => {
     expect(resolveSpy).not.toHaveBeenCalled();
   });
 
+  it('honors an explicit EMPTY permission set as zero permissions, not "resolve live"', async () => {
+    const { userId, tenantId, grant } = await seed();
+    await grant('articles.read');
+    const resolveSpy = vi.spyOn(
+      PermissionResolver.prototype,
+      'resolvePermissions',
+    );
+
+    // `[]` is truthy but must be honored as "run with ZERO permissions" (a
+    // truthy test would fail open by resolving live).
+    await withPrincipalPermissionContext(
+      {
+        db: { type: 'sqlite', url: dbPath },
+        userId,
+        tenantId,
+        permissions: [],
+      },
+      async (context) => {
+        expect(context.permissions).toEqual([]);
+        expect(context.permissionSet.size).toBe(0);
+      },
+    );
+
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+
   it('fails closed to no permissions when the principal has no tenant', async () => {
     const { userId } = await seed();
 

--- a/packages/users/src/index.ts
+++ b/packages/users/src/index.ts
@@ -216,6 +216,7 @@ export {
   type PostgresPermissionPolicyReportItem,
   type PostgresPermissionPolicyTarget,
   type ResolvedOidcProviderConfig,
+  type PrincipalPermissionRuntimeOptions,
   readMobileBearerToken,
   registerPermissionDefinitions,
   resolveOidcProviderConfig,
@@ -236,6 +237,7 @@ export {
   type UsersConfig,
   type UsersOidcConfig,
   validateMobileRedirectUri,
+  withPrincipalPermissionContext,
   withSessionPermissionContext,
 } from './services/index.js';
 

--- a/packages/users/src/services/OperationPermissionService.ts
+++ b/packages/users/src/services/OperationPermissionService.ts
@@ -60,6 +60,16 @@ export interface OperationPermissionOptions
   resolver?: PermissionResolver;
   tenantId?: string | null;
   userId?: string | null;
+  /**
+   * When provided, authorize against THIS exact permission set instead of
+   * re-resolving live RBAC. Pass the published principal set
+   * (`context.permissionSet`) so an RLS-off catalog gate enforces the same
+   * snapshot authority the RLS-on session published — keeping the authority
+   * bound adapter-independent. Without it a mid-run role grant, or a reduced
+   * pre-resolved `permissions` set, could let SQLite/dev allow an operation the
+   * Postgres RLS path for the same principal context would deny.
+   */
+  permissionSet?: ReadonlySet<string> | readonly string[];
 }
 
 export class OperationPermissionError extends Error {
@@ -188,6 +198,18 @@ export async function checkOperationPermission(
   const tenantId = options.tenantId ?? sessionContext?.tenantId ?? null;
   if (!userId || !tenantId) {
     return deny(permission, 'missing_principal');
+  }
+
+  // Explicit set wins over a live re-resolve: authorize against the exact
+  // published principal set so the gate matches what an RLS session enforces
+  // for the same context (adapter-independent, snapshot-consistent).
+  if (options.permissionSet !== undefined) {
+    const granted = Array.isArray(options.permissionSet)
+      ? options.permissionSet.includes(permission)
+      : (options.permissionSet as ReadonlySet<string>).has(permission);
+    return granted
+      ? allow(permission, 'permission_granted')
+      : deny(permission, 'permission_denied');
   }
 
   try {

--- a/packages/users/src/services/SessionPermissionContext.ts
+++ b/packages/users/src/services/SessionPermissionContext.ts
@@ -420,9 +420,12 @@ export async function withPrincipalPermissionContext<T>(
   const baseDatabase = sessionService.getDatabase() as QueryableDatabase;
 
   // Resolve the bound principal's LIVE permission set unless the caller passed
-  // one explicitly. A missing tenant resolves to no permissions (fail closed).
+  // one explicitly. Distinguish "not provided" (`undefined` → resolve live)
+  // from "explicitly empty" (`[]` → run with ZERO permissions): a truthy test
+  // would treat an intentional empty set as "not provided" and fail open. A
+  // missing tenant likewise resolves to no permissions (fail closed).
   let permissions: string[];
-  if (providedPermissions) {
+  if (providedPermissions !== undefined) {
     permissions = providedPermissions;
   } else if (tenantId) {
     const resolver =

--- a/packages/users/src/services/SessionPermissionContext.ts
+++ b/packages/users/src/services/SessionPermissionContext.ts
@@ -7,6 +7,8 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { getPackageConfig } from '@happyvertical/smrt-config';
 import type { SmrtClassOptions } from '@happyvertical/smrt-core';
 import type { DatabaseInterface } from '@happyvertical/sql';
+import type { Membership } from '../models/Membership.js';
+import { PermissionResolver } from './PermissionResolver.js';
 import {
   type SessionContext,
   SessionService,
@@ -47,6 +49,55 @@ export interface SessionPermissionRuntimeOptions extends SmrtClassOptions {
   superAdminBypass?: boolean;
   systemContext?: boolean;
 }
+
+/**
+ * Options for {@link withPrincipalPermissionContext}.
+ *
+ * Where {@link SessionPermissionRuntimeOptions} sources the principal from a
+ * loaded session, this sources it directly from a `(userId, tenantId)` pair —
+ * used to run work AS a bound principal (e.g. an agent persona's `runAsUserId`)
+ * with that principal's *live* resolved permissions.
+ */
+export interface PrincipalPermissionRuntimeOptions extends SmrtClassOptions {
+  /** Enter tenant context so tenant auto-filtering applies on every adapter. */
+  enterTenantContext?: boolean;
+  /**
+   * Raw membership row for the `(userId, tenantId)` pair, forwarded to
+   * {@link PermissionResolver.resolvePermissions}. Only consulted when
+   * `permissions` is not supplied. Pass `null` to assert "no direct membership"
+   * (enabling opt-in ancestor inheritance); leave `undefined` to let the
+   * resolver look it up.
+   */
+  membership?: Membership | null;
+  /**
+   * Pre-resolved permission slugs. When omitted, the principal's permissions
+   * are resolved LIVE via {@link PermissionResolver.resolvePermissions} so role
+   * changes reflect on the next call.
+   */
+  permissions?: string[];
+  /** Opt into Postgres RLS transaction wrapping (defaults to package config). */
+  postgresRls?: boolean;
+  /** Reuse an initialized resolver instead of creating one per call. */
+  resolver?: PermissionResolver;
+  /** Tenant the principal acts within. `null` resolves to no permissions. */
+  tenantId: string | null;
+  /** The user whose live permissions bound this execution. */
+  userId: string;
+}
+
+/**
+ * The controls shared by both permission-context entry points that influence
+ * transaction wrapping and tenant-context entry.
+ */
+interface PermissionRuntimeControls {
+  enterTenantContext?: boolean;
+  postgresRls?: boolean;
+  systemContext?: boolean;
+}
+
+type PermissionRuntimeDatabaseConfig =
+  | SmrtClassOptions['db']
+  | SmrtClassOptions['persistence'];
 
 declare global {
   // eslint-disable-next-line no-var
@@ -136,11 +187,11 @@ function isModuleNotFoundError(error: unknown): boolean {
 }
 
 async function runWithOptionalTenantContext<T>(
-  options: SessionPermissionRuntimeOptions,
+  controls: PermissionRuntimeControls,
   context: SessionPermissionRuntimeContext,
   fn: () => Promise<T>,
 ): Promise<T> {
-  if (options.systemContext) {
+  if (controls.systemContext) {
     try {
       const tenancy = await import('@happyvertical/smrt-tenancy');
       return await tenancy.withSystemContext(fn);
@@ -152,7 +203,7 @@ async function runWithOptionalTenantContext<T>(
     }
   }
 
-  if (!options.enterTenantContext || !context.tenantId) {
+  if (!controls.enterTenantContext || !context.tenantId) {
     return await fn();
   }
 
@@ -174,6 +225,97 @@ async function runWithOptionalTenantContext<T>(
       return await fn();
     }
     throw error;
+  }
+}
+
+/**
+ * Shared runtime: given an already-resolved principal `spec` and the base
+ * database, optionally open a Postgres RLS transaction, publish the principal
+ * onto the DB session (`set_config(..., is_local=true)`), and run `fn` inside
+ * the request-scoped ALS store (and optional tenant context).
+ *
+ * Both {@link withSessionPermissionContext} (principal from a loaded session)
+ * and {@link withPrincipalPermissionContext} (principal from a `userId` +
+ * live-resolved permissions) funnel through here, so the transaction lifecycle
+ * and the exact DB-session publication stay identical no matter which door the
+ * principal entered through.
+ */
+async function runWithinPermissionRuntime<T>(
+  controls: PermissionRuntimeControls,
+  configuredDb: PermissionRuntimeDatabaseConfig,
+  baseDatabase: QueryableDatabase,
+  spec: {
+    permissions: string[];
+    membership: SessionContext['membership'];
+    session: SessionContext | null;
+    sessionId: string | null;
+    superAdminBypass: boolean;
+    systemContext: boolean;
+    tenantId: string | null;
+    user: SessionContext['user'] | null;
+    userId: string | null;
+  },
+  fn: (context: SessionPermissionRuntimeContext) => Promise<T>,
+): Promise<T> {
+  const config = getPackageConfig<{
+    permissions?: { postgres?: { enabled?: boolean } };
+  }>('users', {});
+  const usePostgresRls =
+    (controls.postgresRls ?? config.permissions?.postgres?.enabled ?? false) &&
+    isProbablyPostgres(configuredDb, baseDatabase);
+
+  let transaction: TransactionDatabase | undefined;
+  let rolledBack = false;
+  if (usePostgresRls) {
+    if (!baseDatabase.beginTransaction) {
+      throw new Error(
+        'Postgres RLS requires a database adapter that supports beginTransaction().',
+      );
+    }
+    transaction = await baseDatabase.beginTransaction();
+  }
+
+  const runtimeContext: SessionPermissionRuntimeContext = {
+    database: transaction ?? baseDatabase,
+    permissions: spec.permissions,
+    permissionSet: new Set(spec.permissions),
+    membership: spec.membership,
+    postgresRls: usePostgresRls,
+    session: spec.session,
+    sessionId: spec.sessionId,
+    superAdminBypass: spec.superAdminBypass,
+    systemContext: spec.systemContext,
+    tenantId: spec.tenantId,
+    user: spec.user,
+    userId: spec.userId,
+  };
+
+  try {
+    if (transaction) {
+      await setPostgresSessionVariables(transaction, runtimeContext);
+    }
+
+    return await requestPermissionContextStorage.run(runtimeContext, async () =>
+      runWithOptionalTenantContext(controls, runtimeContext, () =>
+        fn(runtimeContext),
+      ),
+    );
+  } catch (error) {
+    if (transaction) {
+      const active = transaction.isActive ? transaction.isActive() : true;
+      if (active) {
+        rolledBack = true;
+        await transaction.rollback();
+      }
+    }
+    throw error;
+  } finally {
+    if (transaction && !rolledBack) {
+      const active = transaction.isActive ? transaction.isActive() : true;
+      if (active) {
+        await transaction.commit();
+      }
+    }
   }
 }
 
@@ -202,66 +344,121 @@ export async function withSessionPermissionContext<T>(
     options.sessionId === undefined || options.sessionId === null
       ? null
       : await sessionService.loadSessionContext(options.sessionId);
-  const permissionSet = new Set(session?.permissions ?? []);
   const baseDatabase = sessionService.getDatabase() as QueryableDatabase;
-  const config = getPackageConfig<{
-    permissions?: { postgres?: { enabled?: boolean } };
-  }>('users', {});
-  const usePostgresRls =
-    (options.postgresRls ?? config.permissions?.postgres?.enabled ?? false) &&
-    isProbablyPostgres(configuredDb, baseDatabase);
 
-  let transaction: TransactionDatabase | undefined;
-  let rolledBack = false;
-  if (usePostgresRls) {
-    if (!baseDatabase.beginTransaction) {
-      throw new Error(
-        'Postgres RLS requires a database adapter that supports beginTransaction().',
-      );
-    }
-    transaction = await baseDatabase.beginTransaction();
-  }
+  return runWithinPermissionRuntime(
+    {
+      enterTenantContext: options.enterTenantContext,
+      postgresRls: options.postgresRls,
+      systemContext: options.systemContext,
+    },
+    configuredDb,
+    baseDatabase,
+    {
+      permissions: session?.permissions ?? [],
+      membership: session?.membership ?? null,
+      session,
+      sessionId: session?.sessionId ?? null,
+      superAdminBypass: options.superAdminBypass ?? false,
+      systemContext: options.systemContext ?? false,
+      tenantId: session?.tenantId ?? null,
+      user: session?.user ?? null,
+      userId: session?.user.id ?? null,
+    },
+    fn,
+  );
+}
 
-  const runtimeContext: SessionPermissionRuntimeContext = {
-    database: transaction ?? baseDatabase,
-    permissions: session?.permissions ?? [],
-    permissionSet,
-    membership: session?.membership ?? null,
-    postgresRls: usePostgresRls,
-    session,
-    sessionId: session?.sessionId ?? null,
-    superAdminBypass: options.superAdminBypass ?? false,
-    systemContext: options.systemContext ?? false,
-    tenantId: session?.tenantId ?? null,
-    user: session?.user ?? null,
-    userId: session?.user.id ?? null,
-  };
+/**
+ * Run `fn` AS a bound principal — a `(userId, tenantId)` pair rather than a
+ * session — inside a session-permission context carrying that principal's
+ * **live** resolved permissions.
+ *
+ * This is the door-agnostic mechanism behind "execute as principal": it does
+ * NOT introduce a new authorization layer. It resolves the principal's
+ * permissions through the standard {@link PermissionResolver} cascade (unless
+ * the caller passes a pre-resolved set) and publishes `(smrt.user_id,
+ * smrt.tenant_id, smrt.permissions[])` onto the DB session exactly like
+ * {@link withSessionPermissionContext}, so the manifest-derived Postgres RLS
+ * policies bound every query on that session per-`(table, action)`.
+ *
+ * A principal run never bypasses: `super_admin_bypass` and `system_context`
+ * are always published as `false`. Resolution runs on the base connection
+ * BEFORE any RLS transaction opens (identical ordering to session loading), so
+ * the trusted cascade is never bounded by the not-yet-published principal.
+ *
+ * With RLS off (SQLite/dev) the same permission set is still resolved and
+ * carried, but the DB has no per-operation teeth — callers relying on this on a
+ * non-Postgres adapter must additionally assert the catalog permission for the
+ * `(collection, action)` at their tool/exec seam (see
+ * `assertOperationPermission`).
+ */
+export async function withPrincipalPermissionContext<T>(
+  options: PrincipalPermissionRuntimeOptions,
+  fn: (context: SessionPermissionRuntimeContext) => Promise<T>,
+): Promise<T> {
+  const {
+    enterTenantContext: _enterTenantContext,
+    membership,
+    permissions: providedPermissions,
+    postgresRls: _postgresRls,
+    resolver: providedResolver,
+    tenantId,
+    userId,
+    ...serviceOptions
+  } = options;
 
-  try {
-    if (transaction) {
-      await setPostgresSessionVariables(transaction, runtimeContext);
-    }
+  // Reuse SessionService purely as the blessed database accessor — no session
+  // is loaded on this path; the principal comes straight from (userId,
+  // tenantId).
+  const sessionService = await SessionService.create({
+    ...serviceOptions,
+  } as SessionServiceOptions);
+  const configuredDb =
+    (serviceOptions as SessionServiceOptions).db ??
+    (serviceOptions as SessionServiceOptions).persistence;
+  const baseDatabase = sessionService.getDatabase() as QueryableDatabase;
 
-    return await requestPermissionContextStorage.run(runtimeContext, async () =>
-      runWithOptionalTenantContext(options, runtimeContext, () =>
-        fn(runtimeContext),
-      ),
+  // Resolve the bound principal's LIVE permission set unless the caller passed
+  // one explicitly. A missing tenant resolves to no permissions (fail closed).
+  let permissions: string[];
+  if (providedPermissions) {
+    permissions = providedPermissions;
+  } else if (tenantId) {
+    const resolver =
+      providedResolver ??
+      (await PermissionResolver.create({
+        ...serviceOptions,
+      } as SmrtClassOptions));
+    const resolved = await resolver.resolvePermissions(
+      userId,
+      tenantId,
+      membership === undefined ? {} : { membership },
     );
-  } catch (error) {
-    if (transaction) {
-      const active = transaction.isActive ? transaction.isActive() : true;
-      if (active) {
-        rolledBack = true;
-        await transaction.rollback();
-      }
-    }
-    throw error;
-  } finally {
-    if (transaction && !rolledBack) {
-      const active = transaction.isActive ? transaction.isActive() : true;
-      if (active) {
-        await transaction.commit();
-      }
-    }
+    permissions = Array.from(resolved.permissions);
+  } else {
+    permissions = [];
   }
+
+  return runWithinPermissionRuntime(
+    {
+      enterTenantContext: options.enterTenantContext,
+      postgresRls: options.postgresRls,
+      systemContext: false,
+    },
+    configuredDb,
+    baseDatabase,
+    {
+      permissions,
+      membership: null,
+      session: null,
+      sessionId: null,
+      superAdminBypass: false,
+      systemContext: false,
+      tenantId: tenantId ?? null,
+      user: null,
+      userId,
+    },
+    fn,
+  );
 }

--- a/packages/users/src/services/index.ts
+++ b/packages/users/src/services/index.ts
@@ -111,8 +111,10 @@ export {
 export {
   getCurrentSessionPermissionContext,
   getRequestScopedDatabase,
+  type PrincipalPermissionRuntimeOptions,
   type SessionPermissionRuntimeContext,
   type SessionPermissionRuntimeOptions,
+  withPrincipalPermissionContext,
   withSessionPermissionContext,
 } from './SessionPermissionContext.js';
 export {


### PR DESCRIPTION
## Slice

**L2: ExecuteAsPrincipal** — run an agent's work AS its persona's bound user, by REUSING the framework's existing principal-context machinery. This is **not** a new authorization layer.

### `@happyvertical/smrt-users` — `withPrincipalPermissionContext`
A sibling to `withSessionPermissionContext` whose principal comes from a `(userId, tenantId)` pair rather than a loaded session. It:
- resolves the bound user's **live** permission set via the standard `PermissionResolver` cascade (or accepts a pre-resolved set),
- publishes `(smrt.user_id, smrt.tenant_id, smrt.permissions[])` onto the DB session with `set_config(..., is_local=true)` — byte-identical to the session path — so the manifest-derived Postgres **RLS policies** bound every query per-`(table, action)` and per-tenant, through any door,
- **never bypasses**: `super_admin_bypass` / `system_context` are always published `false`,
- resolves on the base connection **before** the RLS transaction opens (same ordering as session loading), so the trusted cascade is never bounded by the not-yet-published principal.

Both entry points now funnel through one shared `runWithinPermissionRuntime` helper, so the DB-session publication and transaction lifecycle stay identical.

### `@happyvertical/smrt-agents` — `executeAsPrincipal`
Wraps `withPrincipalPermissionContext` and hands the body a `PrincipalRun` that enforces the remaining two authority dimensions:
- `assertToolAllowed(tool)` against the persona's `allowedTools` (already `ceiling ∩ persona` from `PersonaResolver`),
- `assertOperation(collection, action)` → `assertOperationPermission` — the door-agnostic **RLS-off catalog seam** (defense-in-depth on SQLite/dev; a harmless redundant gate under Postgres RLS),
- audits every action as **on-behalf-of** the originating user through a pluggable sink (default: structured log line; consumers can persist `AuditLog` rows).

**Effective authority = bound-user RBAC ∩ agent-class ceiling ∩ persona `allowedTools`.**

## Acceptance criteria
- [x] Agent work runs inside a session-permission context built from the persona's bound user; `smrt.permissions` / `smrt.tenant_id` reflect that principal; enforcement stays live.
- [x] Postgres RLS bounds an action per-`(table, action)` + tenant — real-Postgres integration test: permitted succeeds, un-permitted denied by the DB, cross-tenant denied.
- [x] RLS off (SQLite): the tool/exec seam asserts the catalog permission for `(collection, action)`; tenant filtering still applies (`enterTenantContext`).
- [x] Effective authority = bound-user RBAC ∩ agent-class ceiling ∩ persona `allowedTools`.
- [x] Actions audit as on-behalf-of the originating user.

## Tests
- Real in-memory SQLite logic tests in both packages (`principal-permission-context.test.ts`, `execute-as-principal.test.ts`) plus a mock proving the exact Postgres `set_config` publication.
- **Real-Postgres RLS integration test** `principal-permission-context-postgres.test.ts` — gated on `DATABASE_URL` (`isPostgresAvailable()`) so CI's Postgres shard runs it and it skips cleanly elsewhere. It drives the permission set through the real `PermissionResolver` under a `NOBYPASSRLS` role (the proven `SET ROLE` harness) to prove permitted / DB-denied / cross-tenant-denied / live-role-change, and separately asserts `withPrincipalPermissionContext` publishes the live-resolved principal onto a real Postgres session.

> Note: the Darwin + Vite 8 + `svelte()` plugin combination blocks these packages' Vitest suites locally (known repo limitation — CI is the gate). Logic was validated locally end-to-end against the built `dist` via a throwaway `tsx` script (all checks passed); `pnpm typecheck`, `pnpm build`, Biome, and `knowledge:check --strict` all pass locally.

Closes #1888
Part of #1885
