### PR TITLE
feat(personas): persona learning & adaptation loop with HITL gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ All `@happyvertical/smrt-*` packages are version-locked via changesets. pnpm wor
 | jobs | Background execution: TaskRunner, ScheduleRunner, fluent JobBuilder, `withBackgroundJobs()` |
 | users | Auth/RBAC: 4-level permission cascade, hierarchical tenants, sessions, SvelteKit hooks |
 | profiles | Identity: multi-auth (Nostr/OIDC/API keys/magic links), relationships, audit logging, owned asset joins via `profile_assets` |
-| personas | Tenant-owned, context-scoped `AgentPersona` + `PersonaResolver`; layers over `smrt-agents` `TenantAgent` (availability/ceiling gate) with tenant-hierarchy inheritance and priority ordering |
+| personas | Tenant-owned, context-scoped `AgentPersona` + `PersonaResolver` (layers over `smrt-agents` `TenantAgent` availability/ceiling gate); persona learning loop — `Feedback` reinforcement, scheduled `ReflectionRunner` → pending `DirectiveProposal`, HITL activation gated by the `personas.activate-directive` permission split |
 
 ### Content & Media
 | Package | Purpose |

--- a/packages/personas/AGENTS.md
+++ b/packages/personas/AGENTS.md
@@ -5,10 +5,13 @@ Tenant-owned, context-scoped agent personas and their resolution. Layers over
 *how* an agent behaves for a given tenant and context (its `TenantAgent` binding
 decides *whether* it runs and caps its capabilities).
 
-This is the L2 foundation of the "learning agents" epic (#1885). Foundation
-only: `AgentPersona` + `PersonaResolver`. `ExecuteAsPrincipal`, feedback, the
-reflection runner, and multi-instance routing are separate issues
-(#1888/#1889/#1890).
+This is the L2 layer of the "learning agents" epic (#1885). It carries both the
+persona foundation (`AgentPersona` + `PersonaResolver`) and the **persona
+learning & adaptation loop** (#1889): feedback → confidence-scored reinforcement
+→ a scheduled reflection runner that emits pending directive proposals → a
+permission-gated approval surface that activates an approved rewrite as a
+tenant/persona-scoped prompt override. `ExecuteAsPrincipal` and multi-instance
+routing remain separate issues (#1888/#1890).
 
 ## Models
 
@@ -33,6 +36,67 @@ reflection runner, and multi-instance routing are separate issues
   - `priority` — integer; higher wins among personas that apply at the same
     tenant level.
   - `enabled` — boolean; only enabled personas are resolved.
+
+- **Feedback** (`@TenantScoped({ mode: 'optional' })`, table `agent_feedback`):
+  one reinforcement signal against a persona and the learning episode it judges.
+  Human signals (`accept` / `reject` / `correction` / `rating`) and autonomous
+  signals (`outcome` / `metric`) each carry a required **`correlationId`** (+
+  optional `correlationType`) back to the AI call / dispatch / job. `scope` /
+  `key` name the `LearningMemory` episode; `toLearningOutcome()` maps the signal
+  onto a `LearningOutcome` (feeds reinforcement, #1886). `FeedbackCollection`:
+  `forPersona`, `forScope`, `byCorrelation`.
+
+- **DirectiveProposal** (`@TenantScoped({ mode: 'required' })`, table
+  `directive_proposals`): a pending, human-reviewable proposed edit to a
+  persona's `instructions`. Read-only generated surface (`api`/`cli`/`mcp` =
+  `list`/`get`) — writes go through the gated approval service, not CRUD. Key
+  fields: `promptKey`, `proposedInstructions`, `currentInstructions` (diff),
+  `rationale`, `evidence` (JSON: episode + feedback ids), `status`
+  (`pending`/`approved`/`rejected`/`superseded`), `fingerprint` (dedup so a
+  rejected rewrite is never re-surfaced), `proposedBy`, `reviewedBy` /
+  `reviewedAt` / `activatedOverrideId`. `DirectiveProposalCollection`:
+  `pending(...)` (the review queue), `findByFingerprint(...)`.
+
+## Learning loop (#1889)
+
+- **Persona instructions via prompt overrides** (`persona-prompt.ts`): a
+  persona's instructions apply through a per-persona registered prompt key
+  (`persona.<id>.instructions`, neutral empty base template) plus a
+  tenant-scoped `prompt_override`. Two personas of the same tenant/class resolve
+  different instructions without colliding on the override `(key, context)`
+  identity. `ensurePersonaInstructionsPrompt` (idempotent registration,
+  `editable` configurable), `applyPersonaInstructions` /
+  `upsertPromptTemplateOverride` (write the override — flows through
+  `PromptOverride.save()` → `validatePromptOverride`, so a non-editable template
+  is refused), `resolvePersonaInstructions`.
+- **Memory scoping** (`persona-memory.ts`): `personaLearningMemory` routes a
+  `LearningMemory` by the persona's `memoryScope` (used as `owner_id`), so
+  personas learn independently. `reinforceFromFeedback` applies a `Feedback`
+  signal to memory as automatic, confidence-only reinforcement (ungated).
+- **ReflectionRunner** (`reflection-runner.ts`): a schedulable pass that, under
+  the autonomous reflection principal (which **lacks**
+  `personas.activate-directive`), reinforces recent feedback, consolidates
+  episodes + feedback via an injected `reflect` boundary (the AI call, mocked in
+  tests), and records a **pending** `DirectiveProposal` (deduped by fingerprint).
+  It cannot activate anything.
+- **The gate = a permission split** (`directive-principal.ts`,
+  `directive-approval.ts`): activating a directive is the permissioned operation
+  `personas.activate-directive` (contributed to the manifest permission catalog
+  via `registerPermissionDefinitions`). `DirectiveApprovalService.approve` /
+  `reject` first `assertCanActivate(principal)`; approval writes the
+  persona-scoped override and records an `accept` signal, rejection records a
+  `reject` signal and closes the proposal. A `DirectivePrincipal` is built from
+  granted slugs (`principalFromPermissions`) or a `PermissionResolver`
+  (`resolveDirectivePrincipal`).
+
+## Svelte UI
+
+`@happyvertical/smrt-personas/svelte` ships a minimal, presentational
+`DirectiveReviewQueue` component (Svelte 5): it lists pending proposals with a
+current-vs-proposed diff and Approve/Reject actions, delegating to `onApprove`
+(optionally with reviewer-edited text) / `onReject` callbacks a host wires to
+the gated `DirectiveApprovalService`. Built with `svelte-package`; Svelte tests
+run in CI only.
 
 ## Collection
 
@@ -69,10 +133,16 @@ per-tenant interceptor context (same expectation as `resolveForTenant`).
 Leaf package (acyclic by construction — nothing depends back on it):
 
 - Runtime: `@happyvertical/smrt-core`, `@happyvertical/smrt-tenancy`,
-  `@happyvertical/smrt-agents` (the `TenantAgent` type it bridges).
+  `@happyvertical/smrt-agents` (the `TenantAgent` type it bridges),
+  `@happyvertical/smrt-prompts` (persona instructions via `PromptOverride` +
+  `resolvePrompt`), `@happyvertical/smrt-users` (the permission catalog slug +
+  `PermissionResolver` principal), and `@happyvertical/sql` (`DatabaseInterface`
+  type). These edges are all acyclic (none of those packages depend on personas).
+- Svelte peer + `@happyvertical/smrt-ui` for the optional `./svelte` review-queue
+  component.
 - `runAsUserId` / `actsAsProfileId` reference `@happyvertical/smrt-users` and
-  `@happyvertical/smrt-profiles` via `@crossPackageRef` string ids only — no
-  package edge (keeps the DAG minimal). No inter-`smrt-*` `peerDependencies`.
+  `@happyvertical/smrt-profiles` via `@crossPackageRef` string ids only. No
+  inter-`smrt-*` `peerDependencies`.
 
 ## Gotchas
 
@@ -83,3 +153,15 @@ Leaf package (acyclic by construction — nothing depends back on it):
   read through the helpers, so it never auto-hydrates to an object.
 - **Resolver runs outside strict tenant context** — it deliberately crosses
   tenants to walk the hierarchy.
+- **The gate is the permission split, not a bespoke check** — the reflection
+  principal simply lacks `personas.activate-directive`, so it can only propose;
+  everything privileged in `DirectiveApprovalService` calls `assertCanActivate`
+  first. Instruction rewrites are gated; confidence-only reinforcement is not.
+- **Persona instructions live in the override layer, not the base prompt** — the
+  per-persona prompt key registers a neutral empty template, so re-registration
+  stays idempotent as instructions change; the tenant-scoped override carries the
+  actual text. Activation still honours `validatePromptOverride` editability.
+- **Directive dedup is by fingerprint across all statuses** — the runner skips a
+  proposal whose `(personaId, promptKey, proposedInstructions)` fingerprint
+  already exists (pending, approved, or rejected), so a rejected rewrite is never
+  re-surfaced.

--- a/packages/personas/ambient.d.ts
+++ b/packages/personas/ambient.d.ts
@@ -1,0 +1,6 @@
+declare module '*.svelte' {
+  import type { Component } from 'svelte';
+
+  const component: Component<Record<string, any>>;
+  export default component;
+}

--- a/packages/personas/package.json
+++ b/packages/personas/package.json
@@ -15,28 +15,44 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./svelte": {
+      "types": "./dist/svelte/index.d.ts",
+      "svelte": "./dist/svelte/index.js",
+      "import": "./dist/svelte/index.js"
+    },
     "./manifest": "./dist/manifest.json",
     "./manifest.json": "./dist/manifest.json"
   },
   "scripts": {
-    "build": "vite build --mode library",
+    "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
     "build:watch": "vite build --mode library --watch",
     "clean": "rm -rf dist",
     "dev": "vite dev",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "dependencies": {
     "@happyvertical/smrt-agents": "workspace:*",
     "@happyvertical/smrt-core": "workspace:*",
-    "@happyvertical/smrt-tenancy": "workspace:*"
+    "@happyvertical/smrt-prompts": "workspace:*",
+    "@happyvertical/smrt-tenancy": "workspace:*",
+    "@happyvertical/smrt-ui": "workspace:*",
+    "@happyvertical/smrt-users": "workspace:*",
+    "@happyvertical/sql": "catalog:"
+  },
+  "peerDependencies": {
+    "svelte": "^5.56.4"
   },
   "devDependencies": {
     "@happyvertical/smrt-vitest": "workspace:*",
+    "@sveltejs/package": "^2.5.8",
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@types/node": "24.13.2",
+    "svelte": "^5.56.4",
+    "svelte-check": "^4.7.1",
     "typescript": "^5.9.3",
     "vite": "^8.1.3",
     "vitest": "^4.1.9"

--- a/packages/personas/src/directive-approval.ts
+++ b/packages/personas/src/directive-approval.ts
@@ -1,0 +1,235 @@
+/**
+ * DirectiveApprovalService — the human-in-the-loop gate (#1889).
+ *
+ * The review queue's write side. A reviewer who holds the
+ * `personas.activate-directive` permission can **approve** (optionally editing
+ * the text), or **reject**, a pending {@link DirectiveProposal}:
+ *
+ *   - **approve** activates the persona-scoped `prompt_override` (through
+ *     `PromptOverride.save()`, so a non-editable prompt template is refused by
+ *     `validatePromptOverride`) and records an `accept` signal.
+ *   - **reject** records a `reject` signal and closes the proposal so the
+ *     reflection runner never re-surfaces the same rewrite (it dedups on
+ *     fingerprint against non-pending proposals too).
+ *
+ * The gate is purely the permission check: an actor lacking the slug — the
+ * autonomous reflection principal included — is denied before anything is
+ * written. Confidence-only reinforcement is unaffected; it never passes here.
+ *
+ * @module
+ */
+
+import type { PromptOverride } from '@happyvertical/smrt-prompts';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import {
+  ACTIVATE_DIRECTIVE_PERMISSION,
+  type DirectivePrincipal,
+} from './directive-principal.js';
+import {
+  DirectiveProposal,
+  DirectiveProposalCollection,
+} from './directive-proposal.js';
+import { type Feedback, FeedbackCollection } from './feedback.js';
+import { upsertPromptTemplateOverride } from './persona-prompt.js';
+
+/** Raised when a principal without the activation permission attempts to review. */
+export class DirectiveActivationDeniedError extends Error {
+  constructor(
+    message = `Principal lacks the '${ACTIVATE_DIRECTIVE_PERMISSION}' permission required to review persona directives`,
+  ) {
+    super(message);
+    this.name = 'DirectiveActivationDeniedError';
+  }
+}
+
+/** Raised when a review is attempted on a proposal that is not pending. */
+export class DirectiveNotPendingError extends Error {
+  constructor(status: string) {
+    super(`Directive proposal is not pending (status: ${status})`);
+    this.name = 'DirectiveNotPendingError';
+  }
+}
+
+/** Options for {@link DirectiveApprovalService}. */
+export interface DirectiveApprovalServiceOptions {
+  db: DatabaseInterface;
+  proposals?: DirectiveProposalCollection;
+  feedback?: FeedbackCollection;
+}
+
+/** Result of approving a proposal. */
+export interface DirectiveApprovalResult {
+  proposal: DirectiveProposal;
+  /** The activated persona-scoped override. */
+  override: PromptOverride;
+  /** The recorded `accept` signal. */
+  signal: Feedback;
+}
+
+/** Result of rejecting a proposal. */
+export interface DirectiveRejectionResult {
+  proposal: DirectiveProposal;
+  /** The recorded `reject` signal. */
+  signal: Feedback;
+}
+
+/** A proposal reference: the row, or its id. */
+export type ProposalRef = DirectiveProposal | string;
+
+/**
+ * The permission-gated review surface for persona directives.
+ */
+export class DirectiveApprovalService {
+  private readonly db: DatabaseInterface;
+  private proposals?: DirectiveProposalCollection;
+  private feedback?: FeedbackCollection;
+
+  constructor(options: DirectiveApprovalServiceOptions) {
+    this.db = options.db;
+    this.proposals = options.proposals;
+    this.feedback = options.feedback;
+  }
+
+  /**
+   * Assert a principal is authorised to review directives. The single gate:
+   * everything privileged in this service calls it first.
+   *
+   * @throws {DirectiveActivationDeniedError} when the principal lacks the slug.
+   */
+  assertCanActivate(principal: DirectivePrincipal): void {
+    if (!principal.can(ACTIVATE_DIRECTIVE_PERMISSION)) {
+      throw new DirectiveActivationDeniedError();
+    }
+  }
+
+  /**
+   * Approve a pending proposal: activate the persona-scoped override and record
+   * an `accept` signal. Pass `editedInstructions` to activate a revised text
+   * (the proposal keeps the model's original as its audit record; the override
+   * holds what was activated).
+   *
+   * @throws {DirectiveActivationDeniedError} when the principal lacks the slug.
+   * @throws {DirectiveNotPendingError} when the proposal is already reviewed.
+   */
+  async approve(
+    ref: ProposalRef,
+    principal: DirectivePrincipal,
+    options: { note?: string; editedInstructions?: string } = {},
+  ): Promise<DirectiveApprovalResult> {
+    this.assertCanActivate(principal);
+    const proposal = await this.loadPending(ref);
+
+    const template =
+      options.editedInstructions ?? proposal.proposedInstructions;
+
+    // Activation is exactly writing the persona-scoped override. This flows
+    // through PromptOverride.save() → validatePromptOverride, so a non-editable
+    // template is refused here (the error propagates to the reviewer).
+    const override = await upsertPromptTemplateOverride({
+      db: this.db,
+      key: proposal.promptKey,
+      tenantId: proposal.tenantId,
+      template,
+    });
+
+    proposal.status = 'approved';
+    proposal.reviewedBy = principal.id ?? null;
+    proposal.reviewedAt = new Date();
+    proposal.reviewNote = options.note ?? null;
+    proposal.activatedOverrideId = override.id ?? null;
+    await proposal.save();
+
+    const signal = await this.recordSignal(proposal, 'accept', principal, {
+      note: options.note,
+      edited: options.editedInstructions !== undefined,
+    });
+
+    return { proposal, override, signal };
+  }
+
+  /**
+   * Reject a pending proposal: record a `reject` signal and close it so it is
+   * never re-surfaced.
+   *
+   * @throws {DirectiveActivationDeniedError} when the principal lacks the slug.
+   * @throws {DirectiveNotPendingError} when the proposal is already reviewed.
+   */
+  async reject(
+    ref: ProposalRef,
+    principal: DirectivePrincipal,
+    options: { note?: string } = {},
+  ): Promise<DirectiveRejectionResult> {
+    this.assertCanActivate(principal);
+    const proposal = await this.loadPending(ref);
+
+    proposal.status = 'rejected';
+    proposal.reviewedBy = principal.id ?? null;
+    proposal.reviewedAt = new Date();
+    proposal.reviewNote = options.note ?? null;
+    await proposal.save();
+
+    const signal = await this.recordSignal(proposal, 'reject', principal, {
+      note: options.note,
+    });
+
+    return { proposal, signal };
+  }
+
+  private async loadPending(ref: ProposalRef): Promise<DirectiveProposal> {
+    const proposal =
+      ref instanceof DirectiveProposal ? ref : await this.getProposal(ref);
+    if (!proposal) {
+      throw new Error(`Directive proposal not found: ${String(ref)}`);
+    }
+    if (proposal.status !== 'pending') {
+      throw new DirectiveNotPendingError(proposal.status);
+    }
+    return proposal;
+  }
+
+  private async getProposal(id: string): Promise<DirectiveProposal | null> {
+    const proposals = await this.proposalsCollection();
+    return proposals.get({ id });
+  }
+
+  private async recordSignal(
+    proposal: DirectiveProposal,
+    signalType: 'accept' | 'reject',
+    principal: DirectivePrincipal,
+    options: { note?: string; edited?: boolean } = {},
+  ): Promise<Feedback> {
+    const feedback = await this.feedbackCollection();
+    return feedback.create({
+      tenantId: proposal.tenantId,
+      personaId: proposal.personaId,
+      agentClass: proposal.agentClass,
+      memoryScope: '',
+      scope: 'persona/directive',
+      key: proposal.id ?? '',
+      signalType,
+      source: 'human',
+      // The correlation-id ties the signal back to the reviewed proposal.
+      correlationId: proposal.id ?? '',
+      correlationType: 'directive_proposal',
+      actorId: principal.id ?? null,
+      comment: options.note ?? null,
+      metadata: JSON.stringify({ edited: options.edited ?? false }),
+    });
+  }
+
+  private async proposalsCollection(): Promise<DirectiveProposalCollection> {
+    if (!this.proposals) {
+      this.proposals = await DirectiveProposalCollection.create({
+        db: this.db,
+      });
+    }
+    return this.proposals;
+  }
+
+  private async feedbackCollection(): Promise<FeedbackCollection> {
+    if (!this.feedback) {
+      this.feedback = await FeedbackCollection.create({ db: this.db });
+    }
+    return this.feedback;
+  }
+}

--- a/packages/personas/src/directive-approval.ts
+++ b/packages/personas/src/directive-approval.ts
@@ -21,6 +21,7 @@
 
 import type { PromptOverride } from '@happyvertical/smrt-prompts';
 import type { DatabaseInterface } from '@happyvertical/sql';
+import { AgentPersonaCollection } from './agent-persona.js';
 import {
   ACTIVATE_DIRECTIVE_PERMISSION,
   type DirectivePrincipal,
@@ -55,6 +56,7 @@ export interface DirectiveApprovalServiceOptions {
   db: DatabaseInterface;
   proposals?: DirectiveProposalCollection;
   feedback?: FeedbackCollection;
+  personas?: AgentPersonaCollection;
 }
 
 /** Result of approving a proposal. */
@@ -83,11 +85,13 @@ export class DirectiveApprovalService {
   private readonly db: DatabaseInterface;
   private proposals?: DirectiveProposalCollection;
   private feedback?: FeedbackCollection;
+  private personas?: AgentPersonaCollection;
 
   constructor(options: DirectiveApprovalServiceOptions) {
     this.db = options.db;
     this.proposals = options.proposals;
     this.feedback = options.feedback;
+    this.personas = options.personas;
   }
 
   /**
@@ -99,6 +103,28 @@ export class DirectiveApprovalService {
   assertCanActivate(principal: DirectivePrincipal): void {
     if (!principal.can(ACTIVATE_DIRECTIVE_PERMISSION)) {
       throw new DirectiveActivationDeniedError();
+    }
+  }
+
+  /**
+   * Assert a principal may review a specific proposal: its resolved tenant, when
+   * bound, must match the proposal's tenant. Permissions are resolved per
+   * tenant, so holding the slug in one tenant must not authorise activating
+   * another tenant's directive.
+   *
+   * @throws {DirectiveActivationDeniedError} on a cross-tenant attempt.
+   */
+  private assertTenantMatch(
+    principal: DirectivePrincipal,
+    proposal: DirectiveProposal,
+  ): void {
+    if (
+      principal.tenantId !== undefined &&
+      principal.tenantId !== proposal.tenantId
+    ) {
+      throw new DirectiveActivationDeniedError(
+        `Principal (tenant '${principal.tenantId}') cannot review a directive for tenant '${proposal.tenantId}'`,
+      );
     }
   }
 
@@ -118,6 +144,7 @@ export class DirectiveApprovalService {
   ): Promise<DirectiveApprovalResult> {
     this.assertCanActivate(principal);
     const proposal = await this.loadPending(ref);
+    this.assertTenantMatch(principal, proposal);
 
     const template =
       options.editedInstructions ?? proposal.proposedInstructions;
@@ -131,6 +158,13 @@ export class DirectiveApprovalService {
       tenantId: proposal.tenantId,
       template,
     });
+
+    // Keep the persona's own `instructions` field in sync with the activated
+    // text, so the field-based `PersonaResolver.resolve()` path reflects the
+    // approved directive too — not only the prompt-override path. Best effort:
+    // the override is the authoritative application; a missing persona (e.g.
+    // deleted) does not fail the activation.
+    await this.syncPersonaInstructions(proposal.personaId, template);
 
     proposal.status = 'approved';
     proposal.reviewedBy = principal.id ?? null;
@@ -161,6 +195,7 @@ export class DirectiveApprovalService {
   ): Promise<DirectiveRejectionResult> {
     this.assertCanActivate(principal);
     const proposal = await this.loadPending(ref);
+    this.assertTenantMatch(principal, proposal);
 
     proposal.status = 'rejected';
     proposal.reviewedBy = principal.id ?? null;
@@ -215,6 +250,26 @@ export class DirectiveApprovalService {
       comment: options.note ?? null,
       metadata: JSON.stringify({ edited: options.edited ?? false }),
     });
+  }
+
+  private async syncPersonaInstructions(
+    personaId: string,
+    instructions: string,
+  ): Promise<void> {
+    const personas = await this.personasCollection();
+    const persona = await personas.get({ id: personaId });
+    if (!persona) {
+      return;
+    }
+    persona.instructions = instructions;
+    await persona.save();
+  }
+
+  private async personasCollection(): Promise<AgentPersonaCollection> {
+    if (!this.personas) {
+      this.personas = await AgentPersonaCollection.create({ db: this.db });
+    }
+    return this.personas;
   }
 
   private async proposalsCollection(): Promise<DirectiveProposalCollection> {

--- a/packages/personas/src/directive-principal.ts
+++ b/packages/personas/src/directive-principal.ts
@@ -1,0 +1,104 @@
+/**
+ * The permission split that gates persona directive activation (#1889).
+ *
+ * **The gate is the permission system, not a bespoke subsystem.** Activating a
+ * directive — writing/enabling the persona-scoped `prompt_override` — is a
+ * permissioned operation guarded by the `personas.activate-directive` slug. The
+ * autonomous reflection principal runs *without* that permission, so it can only
+ * propose; a human who holds it approves / edits / rejects. Confidence-only
+ * reinforcement stays automatic; only instruction rewrites are gated.
+ *
+ * This module contributes the slug to the manifest-derived permission catalog
+ * (via `registerPermissionDefinitions`) and provides a small
+ * {@link DirectivePrincipal} abstraction over "which permission slugs does this
+ * actor hold". In production the principal is built from a
+ * `PermissionResolver.resolvePermissions()` result; tests inject one directly.
+ *
+ * @module
+ */
+
+import {
+  type PermissionDefinition,
+  type PermissionResolver,
+  registerPermissionDefinitions,
+} from '@happyvertical/smrt-users';
+
+/** The permission slug that authorises activating a persona directive. */
+export const ACTIVATE_DIRECTIVE_PERMISSION = 'personas.activate-directive';
+
+/** Catalog definition contributed for {@link ACTIVATE_DIRECTIVE_PERMISSION}. */
+export const DIRECTIVE_ACTIVATION_PERMISSION_DEF: PermissionDefinition = {
+  slug: ACTIVATE_DIRECTIVE_PERMISSION,
+  category: 'personas',
+  name: 'Activate Persona Directive',
+  description:
+    "Approve, edit, or reject a proposed edit to a persona's instructions and activate the persona-scoped prompt override",
+};
+
+/**
+ * An actor whose authority is expressed as a set of held permission slugs.
+ *
+ * Deliberately minimal so the gate depends only on the permission model, not on
+ * any particular resolver or session machinery.
+ */
+export interface DirectivePrincipal {
+  /** Optional stable id (recorded as the reviewer on approve/reject). */
+  readonly id?: string;
+  /** Whether this actor holds the given permission slug. */
+  can(slug: string): boolean;
+}
+
+/**
+ * Build a {@link DirectivePrincipal} from an explicit set of granted slugs.
+ */
+export function principalFromPermissions(
+  permissions: Iterable<string>,
+  options: { id?: string } = {},
+): DirectivePrincipal {
+  const granted = new Set(permissions);
+  return {
+    id: options.id,
+    can: (slug: string) => granted.has(slug),
+  };
+}
+
+/**
+ * Build a {@link DirectivePrincipal} for a user in a tenant by resolving their
+ * effective permissions through the RBAC {@link PermissionResolver} — the
+ * production wiring that makes the gate concretely the permission system.
+ */
+export async function resolveDirectivePrincipal(options: {
+  resolver: PermissionResolver;
+  userId: string;
+  tenantId: string;
+}): Promise<DirectivePrincipal> {
+  const { permissions } = await options.resolver.resolvePermissions(
+    options.userId,
+    options.tenantId,
+  );
+  return principalFromPermissions(permissions, { id: options.userId });
+}
+
+let personaPermissionsRegistered = false;
+
+/**
+ * Register the persona directive-activation permission into the runtime catalog.
+ *
+ * @returns An unregister function (primarily for tests).
+ */
+export function registerPersonaPermissions(): () => void {
+  return registerPermissionDefinitions([DIRECTIVE_ACTIVATION_PERMISSION_DEF]);
+}
+
+/**
+ * Register the persona permissions once per process. Called as a side effect
+ * from the package entry so the slug is present in the permission catalog for
+ * any consumer that imports `@happyvertical/smrt-personas`.
+ */
+export function ensurePersonaPermissionsRegistered(): void {
+  if (personaPermissionsRegistered) {
+    return;
+  }
+  personaPermissionsRegistered = true;
+  registerPersonaPermissions();
+}

--- a/packages/personas/src/directive-principal.ts
+++ b/packages/personas/src/directive-principal.ts
@@ -44,6 +44,15 @@ export const DIRECTIVE_ACTIVATION_PERMISSION_DEF: PermissionDefinition = {
 export interface DirectivePrincipal {
   /** Optional stable id (recorded as the reviewer on approve/reject). */
   readonly id?: string;
+  /**
+   * The tenant this principal's authority was resolved for. Permissions are
+   * resolved per tenant (`PermissionResolver.resolvePermissions(userId, tenantId)`),
+   * so a principal authorised in one tenant must not activate another tenant's
+   * directive. When set, the approval service enforces
+   * `principal.tenantId === proposal.tenantId`. `undefined` skips the check
+   * (e.g. a system/global actor or a hand-built principal).
+   */
+  readonly tenantId?: string;
   /** Whether this actor holds the given permission slug. */
   can(slug: string): boolean;
 }
@@ -53,11 +62,12 @@ export interface DirectivePrincipal {
  */
 export function principalFromPermissions(
   permissions: Iterable<string>,
-  options: { id?: string } = {},
+  options: { id?: string; tenantId?: string } = {},
 ): DirectivePrincipal {
   const granted = new Set(permissions);
   return {
     id: options.id,
+    tenantId: options.tenantId,
     can: (slug: string) => granted.has(slug),
   };
 }
@@ -76,7 +86,12 @@ export async function resolveDirectivePrincipal(options: {
     options.userId,
     options.tenantId,
   );
-  return principalFromPermissions(permissions, { id: options.userId });
+  // Carry the resolved tenant so the approval service can refuse a directive
+  // from a different tenant (permissions were resolved for this tenant only).
+  return principalFromPermissions(permissions, {
+    id: options.userId,
+    tenantId: options.tenantId,
+  });
 }
 
 let personaPermissionsRegistered = false;

--- a/packages/personas/src/directive-proposal.ts
+++ b/packages/personas/src/directive-proposal.ts
@@ -1,0 +1,227 @@
+/**
+ * DirectiveProposal — a pending, human-reviewable edit to a persona's
+ * instructions (#1889).
+ *
+ * The autonomous {@link ReflectionRunner} consolidates recent episodes and
+ * {@link Feedback} into candidate rewrites of a persona's instructions and
+ * records each as a pending `DirectiveProposal` (rationale + evidence). A
+ * proposal is inert data: it changes nothing until a human who holds the
+ * `personas.activate-directive` permission approves it through the review
+ * queue, at which point the persona-scoped `prompt_override` is written.
+ *
+ * The reflection principal deliberately lacks that permission, so it can only
+ * *propose* — the permission split is the gate. See {@link DirectiveApprovalService}.
+ *
+ * @module
+ */
+
+import {
+  field,
+  foreignKey,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+
+/**
+ * Lifecycle status of a proposal:
+ *
+ * - `pending` — awaiting review; surfaced in the queue.
+ * - `approved` — a reviewer activated it; the override was written.
+ * - `rejected` — a reviewer declined it; recorded as a signal and never
+ *   re-surfaced (the runner dedups against it by fingerprint).
+ * - `superseded` — a newer proposal replaced it before review.
+ */
+export type DirectiveProposalStatus =
+  | 'pending'
+  | 'approved'
+  | 'rejected'
+  | 'superseded';
+
+/**
+ * Structured evidence backing a proposal — the ids of the learning episodes and
+ * feedback signals the reflection consolidated. Pure references so the proposal
+ * stays auditable without duplicating payloads.
+ */
+export interface DirectiveEvidence {
+  /** `_smrt_contexts` row ids of the episodes considered. */
+  episodeIds?: string[];
+  /** {@link Feedback} row ids considered. */
+  feedbackIds?: string[];
+  /** Free-form supporting notes (e.g. counts, aggregate metrics). */
+  notes?: string[];
+  [key: string]: unknown;
+}
+
+/**
+ * A stable content fingerprint for `(personaId, promptKey, proposedInstructions)`.
+ *
+ * Used to dedup proposals so an already-reviewed rewrite — in particular a
+ * rejected one — is never re-surfaced. Pure FNV-1a so it needs no crypto import
+ * and stays identical across Node and browser bundles.
+ */
+export function computeDirectiveFingerprint(
+  personaId: string,
+  promptKey: string,
+  proposedInstructions: string,
+): string {
+  const input = `${personaId} ${promptKey} ${proposedInstructions}`;
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    // FNV prime multiply, kept in 32-bit unsigned space.
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+}
+
+function parseEvidence(raw: unknown): DirectiveEvidence {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return raw && typeof raw === 'object' ? (raw as DirectiveEvidence) : {};
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as DirectiveEvidence)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * A pending, human-reviewable proposed edit to a persona's instructions.
+ */
+@TenantScoped({ mode: 'required' })
+@smrt({
+  tableName: 'directive_proposals',
+  // Read-only generated surface: activation/rejection go through the
+  // permission-gated DirectiveApprovalService, not generated CRUD writes.
+  api: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+})
+export class DirectiveProposal extends SmrtObject {
+  /** Owning tenant (required — proposals always target a tenant's persona). */
+  @tenantId()
+  tenantId: string = '';
+
+  /** The persona whose instructions this proposal would rewrite. */
+  @foreignKey('AgentPersona', { required: true })
+  personaId: string = '';
+
+  /** Canonical agent class the persona configures (denormalised for queries). */
+  @field({ type: 'text' })
+  agentClass: string = '';
+
+  /**
+   * The registered prompt key whose template the persona's instructions map to.
+   * Activation writes/updates the tenant-scoped override for this key.
+   */
+  @field({ type: 'text' })
+  promptKey: string = '';
+
+  /** The proposed replacement instructions (the new prompt template). */
+  @field({ type: 'text' })
+  proposedInstructions: string = '';
+
+  /** Snapshot of the instructions at proposal time (for a review diff). */
+  @field({ type: 'text' })
+  currentInstructions: string = '';
+
+  /** Model-authored explanation for the proposed change. */
+  @field({ type: 'text' })
+  rationale: string = '';
+
+  /** Structured evidence, stored as a JSON string (see {@link getEvidence}). */
+  @field({ type: 'text' })
+  evidence: string = '{}';
+
+  /** Lifecycle status. */
+  @field({ type: 'text' })
+  status: DirectiveProposalStatus = 'pending';
+
+  /**
+   * Content fingerprint for dedup / not-re-surfacing. Set from
+   * {@link computeDirectiveFingerprint} at creation time.
+   */
+  @field({ type: 'text' })
+  fingerprint: string = '';
+
+  /** Aggregate confidence in the proposal, in `[0, 1]`. */
+  confidence: number = 0.0;
+
+  /** Id of the principal (autonomous reflection actor) that proposed it. */
+  @field({ type: 'text' })
+  proposedBy: string = '';
+
+  /** The reviewer (user id) that approved/rejected it, once reviewed. */
+  @field({ type: 'text', nullable: true })
+  reviewedBy: string | null = null;
+
+  /** When the proposal was reviewed. */
+  @field({ type: 'datetime', nullable: true })
+  reviewedAt: Date | null = null;
+
+  /** Reviewer note attached on approve/reject. */
+  @field({ type: 'text', nullable: true })
+  reviewNote: string | null = null;
+
+  /** The `prompt_override` id written on activation (`null` until approved). */
+  @field({ type: 'text', nullable: true })
+  activatedOverrideId: string | null = null;
+
+  /** Parse {@link evidence}, tolerating malformed JSON. */
+  getEvidence(): DirectiveEvidence {
+    return parseEvidence(this.evidence);
+  }
+
+  /** Replace {@link evidence}. */
+  setEvidence(value: DirectiveEvidence): void {
+    this.evidence = JSON.stringify(value ?? {});
+  }
+
+  /** Whether the proposal is still awaiting review. */
+  isPending(): boolean {
+    return this.status === 'pending';
+  }
+}
+
+/**
+ * Collection for {@link DirectiveProposal} rows — the review queue.
+ */
+export class DirectiveProposalCollection extends SmrtCollection<DirectiveProposal> {
+  static readonly _itemClass = DirectiveProposal;
+
+  /**
+   * The review queue: pending proposals, oldest first. Optionally scoped to a
+   * persona.
+   */
+  async pending(
+    options: { personaId?: string; limit?: number } = {},
+  ): Promise<DirectiveProposal[]> {
+    const where: Record<string, unknown> = { status: 'pending' };
+    if (options.personaId) {
+      where.personaId = options.personaId;
+    }
+    return this.list({
+      where,
+      orderBy: 'created_at ASC',
+      limit: options.limit,
+    });
+  }
+
+  /**
+   * Existing proposals for a persona carrying a given fingerprint, in any
+   * status — used to avoid re-surfacing an already-seen (e.g. rejected) rewrite.
+   */
+  async findByFingerprint(
+    personaId: string,
+    fingerprint: string,
+  ): Promise<DirectiveProposal[]> {
+    return this.list({ where: { personaId, fingerprint } });
+  }
+}
+
+export default DirectiveProposal;

--- a/packages/personas/src/feedback.test.ts
+++ b/packages/personas/src/feedback.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the Feedback model and feedback → reinforcement path (#1889).
+ *
+ * Covers the signal taxonomy (human vs autonomous), the correlation-id, the
+ * mapping onto a LearningOutcome, and that a signal actually adjusts a persona's
+ * confidence-scored memory. Uses real in-memory SQLite with the `_smrt_contexts`
+ * system table; nothing external is touched.
+ */
+
+import { getTestDatabase, type LearningMemory } from '@happyvertical/smrt-core';
+import { disableTenancy } from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Feedback, FeedbackCollection, feedbackSourceFor } from './feedback.js';
+import {
+  personaLearningMemory,
+  reinforceFromFeedback,
+} from './persona-memory.js';
+
+function makeSignal(fields: Partial<Feedback>): Feedback {
+  const feedback = new Feedback();
+  Object.assign(feedback, fields);
+  return feedback;
+}
+
+describe('Feedback', () => {
+  let db: DatabaseInterface;
+
+  beforeEach(async () => {
+    // Force a known, tenancy-off state for this file (single-fork process).
+    disableTenancy();
+    db = await getTestDatabase({ classes: ['Feedback'] });
+  });
+
+  afterEach(async () => {
+    if (typeof (db as { close?: () => Promise<void> }).close === 'function') {
+      await (db as { close: () => Promise<void> }).close();
+    }
+  });
+
+  describe('signal taxonomy', () => {
+    it('classifies human vs autonomous signal types', () => {
+      expect(feedbackSourceFor('accept')).toBe('human');
+      expect(feedbackSourceFor('reject')).toBe('human');
+      expect(feedbackSourceFor('correction')).toBe('human');
+      expect(feedbackSourceFor('rating')).toBe('human');
+      expect(feedbackSourceFor('outcome')).toBe('autonomous');
+      expect(feedbackSourceFor('metric')).toBe('autonomous');
+    });
+
+    it('maps signal types onto learning outcomes', () => {
+      expect(makeSignal({ signalType: 'accept' }).toLearningOutcome()).toEqual({
+        success: true,
+      });
+      expect(
+        makeSignal({ signalType: 'reject' }).toLearningOutcome(),
+      ).toMatchObject({ success: false });
+      expect(
+        makeSignal({
+          signalType: 'outcome',
+          success: true,
+        }).toLearningOutcome(),
+      ).toEqual({ success: true });
+      expect(
+        makeSignal({ signalType: 'metric', metric: 5 }).toLearningOutcome(),
+      ).toEqual({ metric: 5 });
+      // A 1–5 star rating with neutral 3: a 5 reinforces, a 2 decays.
+      expect(
+        makeSignal({ signalType: 'rating', rating: 5 }).toLearningOutcome({
+          ratingNeutral: 3,
+        }),
+      ).toEqual({ metric: 2 });
+      expect(
+        makeSignal({ signalType: 'rating', rating: 2 }).toLearningOutcome({
+          ratingNeutral: 3,
+        }),
+      ).toEqual({ metric: -1 });
+      // Signals with no value carry no reinforcement.
+      expect(
+        makeSignal({ signalType: 'outcome' }).toLearningOutcome(),
+      ).toBeNull();
+    });
+  });
+
+  describe('persistence', () => {
+    it('round-trips a signal with its correlation-id', async () => {
+      const feedback = await FeedbackCollection.create({ db });
+      const created = await feedback.create({
+        tenantId: 'tenant-a',
+        personaId: 'persona-1',
+        agentClass: '@happyvertical/smrt-agents:Praeco',
+        memoryScope: 'praeco:support',
+        scope: 'parser/acme',
+        key: 'invoice',
+        signalType: 'outcome',
+        source: 'autonomous',
+        correlationId: 'ai-call-42',
+        correlationType: 'ai_call',
+        success: true,
+      });
+
+      const loaded = await feedback.get({ id: created.id as string });
+      expect(loaded?.correlationId).toBe('ai-call-42');
+      expect(loaded?.correlationType).toBe('ai_call');
+      expect(loaded?.signalType).toBe('outcome');
+      expect(loaded?.success).toBe(true);
+
+      const byCorrelation = await feedback.byCorrelation('ai-call-42');
+      expect(byCorrelation).toHaveLength(1);
+      expect(byCorrelation[0].key).toBe('invoice');
+    });
+  });
+
+  describe('reinforcement', () => {
+    let memory: LearningMemory;
+
+    beforeEach(() => {
+      memory = personaLearningMemory({
+        db,
+        persona: {
+          id: 'persona-1',
+          memoryScope: 'praeco:support',
+          agentClass: 'Praeco',
+          tenantId: 'tenant-a',
+        },
+      });
+    });
+
+    it('decays a confident memory when an outcome signal reports failure', async () => {
+      const episode = { scope: 'parser/acme', key: 'invoice', value: 'v1' };
+      await memory.capture(episode, { success: true }); // seeds at 0.9
+
+      const signal = makeSignal({
+        signalType: 'outcome',
+        source: 'autonomous',
+        scope: 'parser/acme',
+        key: 'invoice',
+        correlationId: 'job-7',
+        success: false,
+      });
+      const record = await reinforceFromFeedback(memory, signal);
+
+      // 0.9 -> 0.9 + 0.5*(0.3 - 0.9) = 0.6 (below the 0.7 reuse floor).
+      expect(record?.confidence).toBeCloseTo(0.6, 5);
+      expect(record?.failureCount).toBe(1);
+    });
+
+    it('strengthens a memory when a human accept signal is applied', async () => {
+      const episode = { scope: 'parser/acme', key: 'invoice', value: 'v1' };
+      await memory.capture(episode, { success: true }); // 0.9
+
+      const signal = makeSignal({
+        signalType: 'accept',
+        source: 'human',
+        scope: 'parser/acme',
+        key: 'invoice',
+        correlationId: 'dispatch-3',
+        actorId: 'user-1',
+      });
+      const record = await reinforceFromFeedback(memory, signal);
+
+      // 0.9 -> 0.9 + 0.5*(1 - 0.9) = 0.95.
+      expect(record?.confidence).toBeCloseTo(0.95, 5);
+      expect(record?.successCount).toBe(2);
+    });
+
+    it('supersedes the stored strategy from a correction signal', async () => {
+      const episode = { scope: 'parser/acme', key: 'invoice', value: 'old' };
+      await memory.capture(episode, { success: true });
+
+      const signal = makeSignal({
+        signalType: 'correction',
+        source: 'human',
+        scope: 'parser/acme',
+        key: 'invoice',
+        correlationId: 'ai-call-9',
+        correction: 'new-strategy',
+      });
+      const record = await reinforceFromFeedback(memory, signal);
+
+      // Correction decays confidence but replaces the stored value.
+      expect(record?.value).toBe('new-strategy');
+      expect(record?.failureCount).toBe(1);
+    });
+  });
+});

--- a/packages/personas/src/feedback.ts
+++ b/packages/personas/src/feedback.ts
@@ -180,6 +180,15 @@ export class Feedback extends SmrtObject {
   @field({ type: 'text' })
   metadata: string = '{}';
 
+  /**
+   * When this signal was applied to memory as reinforcement. `null` until a
+   * reflection pass consumes it. Gates exactly-once reinforcement so a scheduled
+   * runner never re-applies the same signal (which would amplify a single
+   * accept/reject into many outcomes).
+   */
+  @field({ type: 'datetime', nullable: true })
+  reinforcedAt: Date | null = null;
+
   /** Whether this is a human-authored signal. */
   isHuman(): boolean {
     return this.source === 'human';

--- a/packages/personas/src/feedback.ts
+++ b/packages/personas/src/feedback.ts
@@ -1,0 +1,287 @@
+/**
+ * Feedback — reinforcement signals for a persona's learning loop (#1889).
+ *
+ * A `Feedback` row captures one reinforcement signal against a persona and the
+ * `LearningMemory` episode it pertains to. Two families of signal are modelled:
+ *
+ *   - **Human signals** — `accept` / `reject` / `correction` / `rating`: an
+ *     operator's judgement on an agent's behaviour.
+ *   - **Autonomous signals** — `outcome` / `metric`: a machine-observed result
+ *     (a boolean success or a numeric measurement) captured without a human.
+ *
+ * Every signal carries a **correlation-id** back to the thing it judges — the
+ * AI call, dispatch, or job whose result prompted the feedback — so a signal
+ * can always be traced to its cause. Signals feed the confidence-scored
+ * reinforcement in {@link LearningMemory} (#1886) via {@link toLearningOutcome}:
+ * this is the automatic, confidence-only half of the loop. The gated half —
+ * rewriting a persona's instructions — lives in the directive-proposal flow.
+ *
+ * @module
+ */
+
+import {
+  field,
+  foreignKey,
+  type LearningOutcome,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+
+/**
+ * The kind of reinforcement signal a {@link Feedback} row carries.
+ *
+ * `accept` / `reject` / `correction` / `rating` are human judgements;
+ * `outcome` / `metric` are machine-observed autonomous signals.
+ */
+export type FeedbackSignalType =
+  | 'accept'
+  | 'reject'
+  | 'correction'
+  | 'rating'
+  | 'outcome'
+  | 'metric';
+
+/** Whether a signal originated from a person or an autonomous observation. */
+export type FeedbackSource = 'human' | 'autonomous';
+
+/** The human-authored signal types. */
+export const HUMAN_SIGNAL_TYPES: readonly FeedbackSignalType[] = [
+  'accept',
+  'reject',
+  'correction',
+  'rating',
+];
+
+/**
+ * Return the natural source for a signal type: the human judgement types are
+ * `'human'`; `outcome` / `metric` are `'autonomous'`.
+ */
+export function feedbackSourceFor(signal: FeedbackSignalType): FeedbackSource {
+  return HUMAN_SIGNAL_TYPES.includes(signal) ? 'human' : 'autonomous';
+}
+
+/** Options for {@link Feedback.toLearningOutcome}. */
+export interface FeedbackOutcomeOptions {
+  /**
+   * The neutral point of a `rating` scale. A rating strictly above the neutral
+   * reinforces as a success; at or below it decays as a failure. Default `0`
+   * (any positive rating is a success), matching {@link LearningOutcome}'s
+   * metric convention. Pass e.g. `3` for a 1–5 star scale.
+   */
+  ratingNeutral?: number;
+}
+
+function parseJsonObject(raw: unknown): Record<string, unknown> {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return raw && typeof raw === 'object'
+      ? (raw as Record<string, unknown>)
+      : {};
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * A single reinforcement signal against a persona and a learning episode.
+ */
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'agent_feedback',
+  api: { include: ['list', 'get', 'create'] },
+  cli: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+})
+export class Feedback extends SmrtObject {
+  /** Owning tenant (optional — autonomous signals may be tenant-less). */
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  /** The persona this signal judges. */
+  @foreignKey('AgentPersona', { required: true })
+  personaId: string = '';
+
+  /** Canonical agent class the persona configures (denormalised for queries). */
+  @field({ type: 'text' })
+  agentClass: string = '';
+
+  /**
+   * Memory scope the signal reinforces — the partition key routing it to the
+   * right {@link LearningMemory} so different personas reinforce independently.
+   */
+  @field({ type: 'text' })
+  memoryScope: string = '';
+
+  /** Learning episode scope this signal pertains to (`LearningEpisode.scope`). */
+  @field({ type: 'text' })
+  scope: string = '';
+
+  /** Learning episode key this signal pertains to (`LearningEpisode.key`). */
+  @field({ type: 'text' })
+  key: string = '';
+
+  /** The kind of signal (see {@link FeedbackSignalType}). */
+  @field({ type: 'text' })
+  signalType: FeedbackSignalType = 'outcome';
+
+  /** Whether the signal is human or autonomous. */
+  @field({ type: 'text' })
+  source: FeedbackSource = 'autonomous';
+
+  /**
+   * Correlation-id back to the thing this signal judges — the AI call,
+   * dispatch, or job id. Required so a signal is always traceable to its cause.
+   */
+  @field({ type: 'text', required: true })
+  correlationId: string = '';
+
+  /**
+   * What kind of thing {@link correlationId} names (e.g. `'ai_call'`,
+   * `'dispatch'`, `'job'`). `null` when the namespace is implicit.
+   */
+  @field({ type: 'text', nullable: true })
+  correlationType: string | null = null;
+
+  /** Numeric rating for a `rating` signal (scale is caller-defined). */
+  @field({ type: 'decimal', nullable: true })
+  rating: number | null = null;
+
+  /** Observed measurement for a `metric` signal. */
+  @field({ type: 'decimal', nullable: true })
+  metric: number | null = null;
+
+  /** Observed boolean result for an `outcome` signal. */
+  @field({ type: 'boolean', nullable: true })
+  success: boolean | null = null;
+
+  /**
+   * Corrected instructions/value for a `correction` signal — the human-supplied
+   * replacement that should supersede the strategy that was judged wrong.
+   */
+  @field({ type: 'text', nullable: true })
+  correction: string | null = null;
+
+  /** Freeform note attached to the signal. */
+  @field({ type: 'text', nullable: true })
+  comment: string | null = null;
+
+  /** The user id that authored a human signal (`null` for autonomous). */
+  @field({ type: 'text', nullable: true })
+  actorId: string | null = null;
+
+  /** Arbitrary structured metadata, stored as a JSON string. */
+  @field({ type: 'text' })
+  metadata: string = '{}';
+
+  /** Whether this is a human-authored signal. */
+  isHuman(): boolean {
+    return this.source === 'human';
+  }
+
+  /** Parse {@link metadata}, tolerating malformed JSON. */
+  getMetadata(): Record<string, unknown> {
+    return parseJsonObject(this.metadata);
+  }
+
+  /** Replace {@link metadata}. */
+  setMetadata(value: Record<string, unknown>): void {
+    this.metadata = JSON.stringify(value ?? {});
+  }
+
+  /** Shallow-merge into {@link metadata}. */
+  updateMetadata(patch: Record<string, unknown>): void {
+    this.setMetadata({ ...this.getMetadata(), ...patch });
+  }
+
+  /**
+   * The strategy value a `correction` signal should persist into memory, so a
+   * regenerated (corrected) strategy supersedes the one that was judged wrong.
+   * `undefined` for non-correction signals (reinforce confidence only).
+   */
+  getCorrectionValue(): string | undefined {
+    return this.signalType === 'correction' && this.correction != null
+      ? this.correction
+      : undefined;
+  }
+
+  /**
+   * Map this signal onto a {@link LearningOutcome} for reinforcement, or `null`
+   * when the signal carries no reinforcement value:
+   *
+   * - `accept` → success; `reject` / `correction` → failure.
+   * - `outcome` → the recorded boolean `success`.
+   * - `metric` → the recorded `metric` (positive → success).
+   * - `rating` → `{ metric: rating - ratingNeutral }`.
+   */
+  toLearningOutcome(
+    options: FeedbackOutcomeOptions = {},
+  ): LearningOutcome | null {
+    switch (this.signalType) {
+      case 'accept':
+        return { success: true };
+      case 'reject':
+      case 'correction':
+        return { success: false, error: this.comment ?? undefined };
+      case 'outcome':
+        return this.success == null ? null : { success: this.success };
+      case 'metric':
+        return this.metric == null ? null : { metric: this.metric };
+      case 'rating': {
+        if (this.rating == null) {
+          return null;
+        }
+        return { metric: this.rating - (options.ratingNeutral ?? 0) };
+      }
+      default:
+        return null;
+    }
+  }
+}
+
+/**
+ * Collection for {@link Feedback} rows.
+ */
+export class FeedbackCollection extends SmrtCollection<Feedback> {
+  static readonly _itemClass = Feedback;
+
+  /** All signals for a persona, newest first. */
+  async forPersona(
+    personaId: string,
+    options: { limit?: number } = {},
+  ): Promise<Feedback[]> {
+    return this.list({
+      where: { personaId },
+      orderBy: 'created_at DESC',
+      limit: options.limit,
+    });
+  }
+
+  /** All signals filed under a memory scope, newest first. */
+  async forScope(
+    memoryScope: string,
+    options: { limit?: number } = {},
+  ): Promise<Feedback[]> {
+    return this.list({
+      where: { memoryScope },
+      orderBy: 'created_at DESC',
+      limit: options.limit,
+    });
+  }
+
+  /** Every signal correlated to a given AI call / dispatch / job id. */
+  async byCorrelation(correlationId: string): Promise<Feedback[]> {
+    return this.list({
+      where: { correlationId },
+      orderBy: 'created_at DESC',
+    });
+  }
+}
+
+export default Feedback;

--- a/packages/personas/src/index.ts
+++ b/packages/personas/src/index.ts
@@ -5,6 +5,12 @@
  * `@happyvertical/smrt-agents`' `TenantAgent` availability/ceiling gate to
  * decide how an agent should behave for a given tenant and context.
  *
+ * Also home to the persona **learning & adaptation loop** (#1889): feedback
+ * signals feed confidence-scored reinforcement, a scheduled reflection runner
+ * consolidates episodes + feedback into pending directive proposals, and a
+ * permission-gated approval service (the `personas.activate-directive` split)
+ * activates an approved rewrite as a tenant/persona-scoped prompt override.
+ *
  * @packageDocumentation
  */
 
@@ -12,6 +18,8 @@
 // downstream. Must come first so the side effect runs ahead of the class
 // module loads below. See __smrt-register__.ts for issue #1132 context.
 import './__smrt-register__.js';
+
+import { ensurePersonaPermissionsRegistered } from './directive-principal.js';
 
 export {
   AgentPersona,
@@ -21,6 +29,54 @@ export {
   personaContextRank,
 } from './agent-persona.js';
 export {
+  DirectiveActivationDeniedError,
+  type DirectiveApprovalResult,
+  DirectiveApprovalService,
+  type DirectiveApprovalServiceOptions,
+  DirectiveNotPendingError,
+  type DirectiveRejectionResult,
+  type ProposalRef,
+} from './directive-approval.js';
+export {
+  ACTIVATE_DIRECTIVE_PERMISSION,
+  DIRECTIVE_ACTIVATION_PERMISSION_DEF,
+  type DirectivePrincipal,
+  ensurePersonaPermissionsRegistered,
+  principalFromPermissions,
+  registerPersonaPermissions,
+  resolveDirectivePrincipal,
+} from './directive-principal.js';
+export {
+  computeDirectiveFingerprint,
+  type DirectiveEvidence,
+  DirectiveProposal,
+  DirectiveProposalCollection,
+  type DirectiveProposalStatus,
+} from './directive-proposal.js';
+export {
+  Feedback,
+  FeedbackCollection,
+  type FeedbackOutcomeOptions,
+  type FeedbackSignalType,
+  type FeedbackSource,
+  feedbackSourceFor,
+  HUMAN_SIGNAL_TYPES,
+} from './feedback.js';
+export {
+  type PersonaMemoryLike,
+  personaLearningMemory,
+  personaMemoryScope,
+  reinforceFromFeedback,
+} from './persona-memory.js';
+export {
+  applyPersonaInstructions,
+  ensurePersonaInstructionsPrompt,
+  type PersonaLike,
+  personaInstructionsPromptKey,
+  resolvePersonaInstructions,
+  upsertPromptTemplateOverride,
+} from './persona-prompt.js';
+export {
   availabilityFromResolvedAgent,
   type ManifestPersonaDefaults,
   type PersonaAvailabilityGate,
@@ -29,3 +85,18 @@ export {
   type ResolvedPersona,
   type ResolvePersonaOptions,
 } from './persona-resolver.js';
+export {
+  type DirectiveDraft,
+  type DirectiveReflector,
+  type ReflectionInput,
+  type ReflectionPersona,
+  type ReflectionPersonaInput,
+  ReflectionRunner,
+  type ReflectionRunnerOptions,
+  type ReflectionRunOptions,
+  type ReflectionRunResult,
+} from './reflection-runner.js';
+
+// Contribute the persona directive-activation permission to the runtime catalog
+// on import, so any consumer of this package sees the gate's slug.
+ensurePersonaPermissionsRegistered();

--- a/packages/personas/src/persona-learning-loop.test.ts
+++ b/packages/personas/src/persona-learning-loop.test.ts
@@ -205,6 +205,13 @@ describe('persona learning & adaptation loop (#1889)', () => {
     expect(proposal.getEvidence().feedbackIds?.length).toBeGreaterThan(0);
     expect(proposal.proposedBy).toBe('reflection-bot');
 
+    // `confidence` round-trips from the DB (plain `= 0.0` persists as decimal).
+    const queueForConfidence = await DirectiveProposalCollection.create({ db });
+    const reloaded = await queueForConfidence.get({
+      id: proposal.id as string,
+    });
+    expect(reloaded?.confidence).toBeCloseTo(0.82, 5);
+
     const approval = new DirectiveApprovalService({ db });
 
     // The reflection principal lacks the permission → it can only propose.
@@ -226,6 +233,11 @@ describe('persona learning & adaptation loop (#1889)', () => {
     expect(await resolvePersonaInstructions({ persona, db })).toBe(
       'Be terse and cite sources.',
     );
+
+    // The persona's own `instructions` field is synced too, so the field-based
+    // PersonaResolver path reflects the approved directive (not just the override).
+    const refreshed = await personas.get({ id: persona.id as string });
+    expect(refreshed?.instructions).toBe('Be terse and cite sources.');
 
     // The approval was recorded as a human accept signal correlated to the proposal.
     const signals = await feedback.byCorrelation(proposal.id as string);
@@ -339,5 +351,116 @@ describe('persona learning & adaptation loop (#1889)', () => {
     // Nothing was activated: the proposal remains pending.
     const queue = await DirectiveProposalCollection.create({ db });
     expect(await queue.pending()).toHaveLength(1);
+  });
+
+  it('refuses a reviewer whose resolved tenant differs from the proposal', async () => {
+    // A persona (and its proposal) in tenant-b.
+    const persona = await personas.create({
+      tenantId: 'tenant-b',
+      agentClass: AGENT,
+      name: 'OtherTenant',
+      instructions: 'Base.',
+      runAsUserId: 'user-runas',
+      memoryScope: 'praeco:other',
+    });
+    await applyPersonaInstructions({ persona, db });
+    const reflect: DirectiveReflector = async () => ({
+      instructions: 'Cross-tenant rewrite.',
+      rationale: 'r',
+      confidence: 0.6,
+    });
+    const runner = new ReflectionRunner({
+      db,
+      principal: reflectionPrincipal,
+      reflect,
+    });
+    const { proposals } = await runner.run({
+      persona,
+      memory: personaLearningMemory({ db, persona }),
+    });
+    expect(proposals[0].tenantId).toBe('tenant-b');
+
+    // A reviewer authorised for tenant-a — holds the slug, wrong tenant.
+    const tenantAReviewer = principalFromPermissions(
+      [ACTIVATE_DIRECTIVE_PERMISSION],
+      { id: 'reviewer-a', tenantId: 'tenant-a' },
+    );
+    const approval = new DirectiveApprovalService({ db });
+    await expect(
+      approval.approve(proposals[0], tenantAReviewer),
+    ).rejects.toBeInstanceOf(DirectiveActivationDeniedError);
+
+    // A reviewer authorised for tenant-b can activate it.
+    const tenantBReviewer = principalFromPermissions(
+      [ACTIVATE_DIRECTIVE_PERMISSION],
+      { id: 'reviewer-b', tenantId: 'tenant-b' },
+    );
+    const { override } = await approval.approve(proposals[0], tenantBReviewer);
+    expect(override.template).toBe('Cross-tenant rewrite.');
+  });
+
+  it('applies a feedback signal to memory exactly once across repeated runs', async () => {
+    const persona = await createPersona('Once', 'Base.', 'praeco:once');
+    await applyPersonaInstructions({ persona, db });
+
+    const memory = personaLearningMemory({ db, persona });
+    // Seed a confident memory the feedback will decay.
+    await memory.capture(
+      { scope: 'task', key: 'k', value: 'strategy' },
+      { success: true },
+    ); // 0.9
+
+    const feedback = await FeedbackCollection.create({ db });
+    await feedback.create({
+      tenantId: TENANT,
+      personaId: persona.id,
+      agentClass: AGENT,
+      memoryScope: personaMemoryScope(persona),
+      scope: 'task',
+      key: 'k',
+      signalType: 'outcome',
+      source: 'autonomous',
+      correlationId: 'job-1',
+      success: false,
+    });
+
+    // Reflector proposes nothing so the run is reinforcement-only.
+    const runner = new ReflectionRunner({
+      db,
+      principal: reflectionPrincipal,
+      reflect: async () => null,
+    });
+
+    const first = await runner.run({ persona, memory });
+    expect(first.reinforced).toBe(1);
+    const afterFirst = await memory.recall('task', {
+      key: 'k',
+      minConfidence: 0,
+    });
+    // 0.9 -> 0.6 after one failure.
+    expect(afterFirst[0].confidence).toBeCloseTo(0.6, 5);
+    expect(afterFirst[0].failureCount).toBe(1);
+
+    // A second run must NOT re-apply the already-consumed signal.
+    const second = await runner.run({ persona, memory });
+    expect(second.reinforced).toBe(0);
+    const afterSecond = await memory.recall('task', {
+      key: 'k',
+      minConfidence: 0,
+    });
+    expect(afterSecond[0].confidence).toBeCloseTo(0.6, 5);
+    expect(afterSecond[0].failureCount).toBe(1);
+  });
+
+  it('rejects a conflicting editability re-registration for a persona prompt', async () => {
+    const persona = await createPersona('Editability', 'Base.', 'praeco:edit2');
+    // First registration: template editable (the default).
+    ensurePersonaInstructionsPrompt(persona);
+    // A later attempt to lock the same key must fail loudly, not be ignored.
+    expect(() =>
+      ensurePersonaInstructionsPrompt(persona, {
+        editable: { template: false },
+      }),
+    ).toThrow(/different definition/);
   });
 });

--- a/packages/personas/src/persona-learning-loop.test.ts
+++ b/packages/personas/src/persona-learning-loop.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Integration tests for the persona learning & adaptation loop (#1889).
+ *
+ * Exercises every acceptance criterion end-to-end against real in-memory SQLite
+ * (only the reflection/AI boundary is a stub):
+ *
+ *   - two personas of one agent class behave differently (instructions applied
+ *     via tenant/persona-scoped prompt overrides) and learn in separate memory
+ *     scopes;
+ *   - the ReflectionRunner emits pending directive proposals it CANNOT activate
+ *     (its principal lacks `personas.activate-directive`);
+ *   - a human holding that permission approves — activating the persona-scoped
+ *     override — while a rejection is recorded as a signal and never re-surfaced;
+ *   - a non-editable prompt template cannot be overridden (`validatePromptOverride`).
+ */
+
+import { getTestDatabase } from '@happyvertical/smrt-core';
+import { clearPromptCache, PromptRegistry } from '@happyvertical/smrt-prompts';
+import { disableTenancy } from '@happyvertical/smrt-tenancy';
+import { PermissionCatalogService } from '@happyvertical/smrt-users';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { type AgentPersona, AgentPersonaCollection } from './agent-persona.js';
+import {
+  DirectiveActivationDeniedError,
+  DirectiveApprovalService,
+} from './directive-approval.js';
+import {
+  ACTIVATE_DIRECTIVE_PERMISSION,
+  type DirectivePrincipal,
+  ensurePersonaPermissionsRegistered,
+  principalFromPermissions,
+} from './directive-principal.js';
+import { DirectiveProposalCollection } from './directive-proposal.js';
+import { FeedbackCollection } from './feedback.js';
+import { personaLearningMemory, personaMemoryScope } from './persona-memory.js';
+import {
+  applyPersonaInstructions,
+  ensurePersonaInstructionsPrompt,
+  resolvePersonaInstructions,
+} from './persona-prompt.js';
+import type { DirectiveReflector } from './reflection-runner.js';
+import { ReflectionRunner } from './reflection-runner.js';
+
+const TENANT = 'tenant-a';
+const AGENT = '@happyvertical/smrt-agents:Praeco';
+
+const CLASSES = [
+  'AgentPersona',
+  'Feedback',
+  'DirectiveProposal',
+  'PromptOverride',
+];
+
+describe('persona learning & adaptation loop (#1889)', () => {
+  let db: DatabaseInterface;
+  let personas: AgentPersonaCollection;
+  let reflectionPrincipal: DirectivePrincipal;
+  let humanPrincipal: DirectivePrincipal;
+
+  beforeEach(async () => {
+    disableTenancy();
+    PromptRegistry.clear();
+    clearPromptCache();
+    ensurePersonaPermissionsRegistered();
+    db = await getTestDatabase({ classes: CLASSES });
+    personas = await AgentPersonaCollection.create({ db });
+    // The autonomous reflection principal holds NO permissions.
+    reflectionPrincipal = principalFromPermissions([], {
+      id: 'reflection-bot',
+    });
+    // The reviewer holds the activation permission.
+    humanPrincipal = principalFromPermissions([ACTIVATE_DIRECTIVE_PERMISSION], {
+      id: 'reviewer-1',
+    });
+  });
+
+  afterEach(async () => {
+    PromptRegistry.clear();
+    clearPromptCache();
+    if (typeof (db as { close?: () => Promise<void> }).close === 'function') {
+      await (db as { close: () => Promise<void> }).close();
+    }
+  });
+
+  async function createPersona(
+    name: string,
+    instructions: string,
+    memoryScope: string,
+  ): Promise<AgentPersona> {
+    return personas.create({
+      tenantId: TENANT,
+      agentClass: AGENT,
+      name,
+      instructions,
+      runAsUserId: 'user-runas',
+      memoryScope,
+    });
+  }
+
+  it('applies two personas differently via prompt overrides and isolates their memory', async () => {
+    const terse = await createPersona('Terse', 'Be terse.', 'praeco:terse');
+    const verbose = await createPersona(
+      'Verbose',
+      'Be verbose and thorough.',
+      'praeco:verbose',
+    );
+
+    await applyPersonaInstructions({ persona: terse, db });
+    await applyPersonaInstructions({ persona: verbose, db });
+
+    // Behaviour: the same agent class resolves different instructions per persona.
+    expect(await resolvePersonaInstructions({ persona: terse, db })).toBe(
+      'Be terse.',
+    );
+    expect(await resolvePersonaInstructions({ persona: verbose, db })).toBe(
+      'Be verbose and thorough.',
+    );
+
+    // Memory: each persona's memoryScope routes an isolated partition.
+    expect(personaMemoryScope(terse)).not.toBe(personaMemoryScope(verbose));
+    const terseMem = personaLearningMemory({ db, persona: terse });
+    const verboseMem = personaLearningMemory({ db, persona: verbose });
+
+    await terseMem.capture(
+      { scope: 'task', key: 'k', value: 'terse-strategy' },
+      { success: true },
+    );
+    await verboseMem.capture(
+      { scope: 'task', key: 'k', value: 'verbose-strategy' },
+      { success: true },
+    );
+
+    const terseRecall = await terseMem.recall('task', { key: 'k' });
+    const verboseRecall = await verboseMem.recall('task', { key: 'k' });
+    expect(terseRecall.map((r) => r.value)).toEqual(['terse-strategy']);
+    expect(verboseRecall.map((r) => r.value)).toEqual(['verbose-strategy']);
+  });
+
+  it('registers the activation permission in the manifest-derived catalog', () => {
+    const catalog = PermissionCatalogService.create({}).getCatalog();
+    const slugs = catalog.permissions.map((p) => p.slug);
+    expect(slugs).toContain(ACTIVATE_DIRECTIVE_PERMISSION);
+  });
+
+  it('proposes but cannot activate under the reflection principal; a human with the permission activates', async () => {
+    const persona = await createPersona(
+      'Learner',
+      'Base instructions.',
+      'praeco:learner',
+    );
+    await applyPersonaInstructions({ persona, db });
+
+    const memory = personaLearningMemory({ db, persona });
+    // A failing episode is captured as evidence of a strategy that stopped working.
+    await memory.capture(
+      { scope: 'task', key: 'k1', value: 'failing-strategy' },
+      { success: false },
+    );
+
+    // A human reject signal against that episode, carrying a correlation-id.
+    const feedback = await FeedbackCollection.create({ db });
+    await feedback.create({
+      tenantId: TENANT,
+      personaId: persona.id,
+      agentClass: AGENT,
+      memoryScope: personaMemoryScope(persona),
+      scope: 'task',
+      key: 'k1',
+      signalType: 'reject',
+      source: 'human',
+      correlationId: 'ai-call-1',
+      correlationType: 'ai_call',
+      actorId: 'user-2',
+    });
+
+    const reflect: DirectiveReflector = async (input) => {
+      // The reflector sees the current instructions, episodes, and feedback.
+      expect(input.currentInstructions).toBe('Base instructions.');
+      expect(input.feedback.length).toBeGreaterThan(0);
+      return {
+        instructions: 'Be terse and cite sources.',
+        rationale:
+          'Recent rejections indicate over-verbosity; tighten the directive.',
+        confidence: 0.82,
+      };
+    };
+
+    const runner = new ReflectionRunner({
+      db,
+      principal: reflectionPrincipal,
+      reflect,
+    });
+    const result = await runner.run({
+      persona,
+      memory,
+      episodeScope: 'task',
+    });
+
+    expect(result.proposals).toHaveLength(1);
+    const proposal = result.proposals[0];
+    expect(proposal.status).toBe('pending');
+    expect(proposal.proposedInstructions).toBe('Be terse and cite sources.');
+    expect(proposal.rationale).toContain('tighten');
+    expect(proposal.getEvidence().feedbackIds?.length).toBeGreaterThan(0);
+    expect(proposal.proposedBy).toBe('reflection-bot');
+
+    const approval = new DirectiveApprovalService({ db });
+
+    // The reflection principal lacks the permission → it can only propose.
+    await expect(
+      approval.approve(proposal, reflectionPrincipal),
+    ).rejects.toBeInstanceOf(DirectiveActivationDeniedError);
+
+    // The proposal is untouched by the denied attempt.
+    const queue = await DirectiveProposalCollection.create({ db });
+    expect(await queue.pending()).toHaveLength(1);
+
+    // A human holding the permission activates it.
+    const { override } = await approval.approve(proposal, humanPrincipal, {
+      note: 'Approved.',
+    });
+    expect(override.template).toBe('Be terse and cite sources.');
+
+    // The persona-scoped override now drives the resolved instructions.
+    expect(await resolvePersonaInstructions({ persona, db })).toBe(
+      'Be terse and cite sources.',
+    );
+
+    // The approval was recorded as a human accept signal correlated to the proposal.
+    const signals = await feedback.byCorrelation(proposal.id as string);
+    expect(
+      signals.some((s) => s.signalType === 'accept' && s.source === 'human'),
+    ).toBe(true);
+
+    // The queue is now empty (the proposal is approved, not pending).
+    expect(await queue.pending()).toHaveLength(0);
+  });
+
+  it('supports an edited approval that activates the reviewer-revised text', async () => {
+    const persona = await createPersona('Editable', 'Start.', 'praeco:edit');
+    await applyPersonaInstructions({ persona, db });
+
+    const reflect: DirectiveReflector = async () => ({
+      instructions: 'Model proposal.',
+      rationale: 'because',
+      confidence: 0.6,
+    });
+    const runner = new ReflectionRunner({
+      db,
+      principal: reflectionPrincipal,
+      reflect,
+    });
+    const { proposals } = await runner.run({
+      persona,
+      memory: personaLearningMemory({ db, persona }),
+    });
+
+    const approval = new DirectiveApprovalService({ db });
+    const { override } = await approval.approve(proposals[0], humanPrincipal, {
+      editedInstructions: 'Reviewer-revised directive.',
+    });
+
+    expect(override.template).toBe('Reviewer-revised directive.');
+    expect(await resolvePersonaInstructions({ persona, db })).toBe(
+      'Reviewer-revised directive.',
+    );
+  });
+
+  it('records a rejection as a signal and never re-surfaces the same proposal', async () => {
+    const persona = await createPersona('Rejected', 'Base.', 'praeco:reject');
+    await applyPersonaInstructions({ persona, db });
+
+    const reflect: DirectiveReflector = async () => ({
+      instructions: 'Rewrite candidate.',
+      rationale: 'candidate rationale',
+      confidence: 0.7,
+    });
+    const runner = new ReflectionRunner({
+      db,
+      principal: reflectionPrincipal,
+      reflect,
+    });
+    const memory = personaLearningMemory({ db, persona });
+
+    const first = await runner.run({ persona, memory });
+    expect(first.proposals).toHaveLength(1);
+    const proposal = first.proposals[0];
+
+    const approval = new DirectiveApprovalService({ db });
+    const { proposal: rejected, signal } = await approval.reject(
+      proposal,
+      humanPrincipal,
+      { note: 'Not appropriate.' },
+    );
+    expect(rejected.status).toBe('rejected');
+    expect(signal.signalType).toBe('reject');
+    expect(signal.correlationId).toBe(proposal.id);
+
+    // Re-running produces the identical candidate → deduped, not re-surfaced.
+    const second = await runner.run({ persona, memory });
+    expect(second.proposals).toHaveLength(0);
+    expect(second.skipped).toBe(1);
+
+    const queue = await DirectiveProposalCollection.create({ db });
+    expect(
+      await queue.pending({ personaId: persona.id ?? undefined }),
+    ).toHaveLength(0);
+  });
+
+  it('cannot override a non-editable prompt template', async () => {
+    const persona = await createPersona('Locked', 'Base.', 'praeco:locked');
+    // Lock the persona's instructions template against overrides.
+    ensurePersonaInstructionsPrompt(persona, { editable: { template: false } });
+
+    const reflect: DirectiveReflector = async () => ({
+      instructions: 'Attempted rewrite.',
+      rationale: 'x',
+      confidence: 0.5,
+    });
+    const runner = new ReflectionRunner({
+      db,
+      principal: reflectionPrincipal,
+      reflect,
+    });
+    const { proposals } = await runner.run({
+      persona,
+      memory: personaLearningMemory({ db, persona }),
+    });
+    expect(proposals).toHaveLength(1);
+
+    // The reviewer holds the permission, but the prompt field is non-editable,
+    // so activation is refused by validatePromptOverride.
+    const approval = new DirectiveApprovalService({ db });
+    await expect(
+      approval.approve(proposals[0], humanPrincipal),
+    ).rejects.toThrow(/does not allow template overrides/);
+
+    // Nothing was activated: the proposal remains pending.
+    const queue = await DirectiveProposalCollection.create({ db });
+    expect(await queue.pending()).toHaveLength(1);
+  });
+});

--- a/packages/personas/src/persona-memory.ts
+++ b/packages/personas/src/persona-memory.ts
@@ -1,0 +1,110 @@
+/**
+ * Persona-scoped learning memory routing (#1889).
+ *
+ * A persona's `memoryScope` routes {@link LearningMemory} so different personas
+ * of the same agent class learn independently. The scope becomes the memory
+ * partition (`owner_id`), so two personas never share confidence-scored
+ * strategies even when they run the identical agent class over the same tenant.
+ *
+ * The other direction of the loop — turning a {@link Feedback} signal into a
+ * confidence adjustment — is {@link reinforceFromFeedback}: the automatic,
+ * confidence-only reinforcement that stays ungated (only instruction rewrites
+ * are gated).
+ *
+ * @module
+ */
+
+import {
+  LearningMemory,
+  type LearningMemoryConfig,
+  type LearningMemoryRecord,
+  type LearningSemanticSearch,
+} from '@happyvertical/smrt-core';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import type { Feedback, FeedbackOutcomeOptions } from './feedback.js';
+
+/** The minimal persona shape the memory router needs. */
+export interface PersonaMemoryLike {
+  id?: string | null;
+  memoryScope?: string;
+  agentClass?: string;
+  tenantId?: string | null;
+}
+
+/**
+ * The effective memory partition key for a persona: its explicit `memoryScope`,
+ * or a stable `persona:<id>` fallback when none is set.
+ *
+ * @throws if neither a `memoryScope` nor an id is available.
+ */
+export function personaMemoryScope(persona: PersonaMemoryLike): string {
+  const explicit = persona.memoryScope?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  if (persona.id) {
+    return `persona:${persona.id}`;
+  }
+  throw new Error(
+    'personaMemoryScope requires a persona with a memoryScope or an id',
+  );
+}
+
+/**
+ * Build a {@link LearningMemory} partitioned to a persona's memory scope.
+ *
+ * The persona's `memoryScope` is used as the memory `owner_id`, so recall and
+ * capture are isolated per persona. `owner_class` defaults to the persona's
+ * agent class (falling back to `'AgentPersona'`).
+ */
+export function personaLearningMemory(options: {
+  db: DatabaseInterface;
+  persona: PersonaMemoryLike;
+  ownerClass?: string;
+  tenantId?: string | null;
+  semanticSearch?: LearningSemanticSearch;
+  config?: Partial<LearningMemoryConfig>;
+}): LearningMemory {
+  const ownerClass =
+    options.ownerClass ??
+    (options.persona.agentClass?.trim() || 'AgentPersona');
+  return new LearningMemory({
+    db: options.db,
+    ownerClass,
+    ownerId: personaMemoryScope(options.persona),
+    tenantId: options.tenantId ?? options.persona.tenantId ?? null,
+    semanticSearch: options.semanticSearch,
+    config: options.config,
+  });
+}
+
+/**
+ * Apply a single {@link Feedback} signal to a persona's memory as
+ * confidence-only reinforcement.
+ *
+ * Maps the signal onto a `LearningOutcome` and captures it against the episode
+ * the signal names (`feedback.scope` / `feedback.key`). A `correction` signal
+ * additionally supersedes the stored strategy with the corrected value.
+ *
+ * @returns The updated/seeded memory record, or `null` when the signal carries
+ *   no reinforcement value (or there was nothing to reinforce).
+ */
+export async function reinforceFromFeedback(
+  memory: LearningMemory,
+  feedback: Feedback,
+  options: FeedbackOutcomeOptions = {},
+): Promise<LearningMemoryRecord | null> {
+  const outcome = feedback.toLearningOutcome(options);
+  if (!outcome) {
+    return null;
+  }
+  const value = feedback.getCorrectionValue();
+  return memory.capture(
+    {
+      scope: feedback.scope,
+      key: feedback.key,
+      ...(value !== undefined ? { value } : {}),
+    },
+    outcome,
+  );
+}

--- a/packages/personas/src/persona-prompt.ts
+++ b/packages/personas/src/persona-prompt.ts
@@ -1,0 +1,171 @@
+/**
+ * Persona ↔ prompt-override binding (#1889).
+ *
+ * A persona's `instructions` are applied to the running agent through a
+ * **tenant/persona-scoped `prompt_override`**, not by mutating the agent's code
+ * default. Each persona owns a dedicated, per-persona prompt key registered at
+ * runtime with a neutral empty base template; the persona's actual instructions
+ * live entirely in the override layer. Because the key is unique per persona,
+ * two personas of the same tenant and agent class resolve to different
+ * instructions without colliding on the `(key, context)` override identity.
+ *
+ * Activating a directive (see {@link DirectiveApprovalService}) is exactly the
+ * act of writing/updating this override — and it flows through
+ * `PromptOverride.save()`, so `validatePromptOverride` still forbids overriding
+ * a non-editable prompt field.
+ *
+ * @module
+ */
+
+import {
+  definePrompt,
+  type PromptDefinition,
+  type PromptEditableConfig,
+  type PromptOverride,
+  PromptOverrideCollection,
+  PromptRegistry,
+  resolvePrompt,
+} from '@happyvertical/smrt-prompts';
+import type { DatabaseInterface } from '@happyvertical/sql';
+
+/** The minimal persona shape these helpers need. */
+export interface PersonaLike {
+  id?: string | null;
+  tenantId?: string | null;
+  instructions?: string;
+}
+
+/**
+ * The registered prompt key a persona's instructions map to.
+ *
+ * @throws if the persona has no id (an unsaved persona has no stable key).
+ */
+export function personaInstructionsPromptKey(persona: PersonaLike): string {
+  const id = persona.id;
+  if (!id) {
+    throw new Error(
+      'personaInstructionsPromptKey requires a persisted persona (missing id)',
+    );
+  }
+  return `persona.${id}.instructions`;
+}
+
+/** Default editability for a persona instructions prompt: template-only. */
+const DEFAULT_PERSONA_EDITABLE: PromptEditableConfig = {
+  template: true,
+  profile: false,
+  model: false,
+  params: false,
+};
+
+/**
+ * Idempotently register the per-persona instructions prompt.
+ *
+ * The base template is always the empty string and the editability is fixed, so
+ * repeated calls register an identical definition (the registry is idempotent
+ * for matching definitions). The persona's real instructions are supplied by
+ * the override layer, never by the base template — that keeps re-registration
+ * stable even as instructions change.
+ *
+ * Pass `editable` to model a prompt whose template is locked; activation of a
+ * proposal against such a key is then rejected by `validatePromptOverride`.
+ */
+export function ensurePersonaInstructionsPrompt(
+  persona: PersonaLike,
+  options: { editable?: Partial<PromptEditableConfig> } = {},
+): PromptDefinition {
+  const key = personaInstructionsPromptKey(persona);
+  const existing = PromptRegistry.get(key);
+  if (existing) {
+    return existing;
+  }
+  return definePrompt({
+    key,
+    template: '',
+    editable: { ...DEFAULT_PERSONA_EDITABLE, ...(options.editable ?? {}) },
+  });
+}
+
+/**
+ * Upsert a scoped `prompt_override` template for a registered prompt key.
+ *
+ * Loads the existing app/tenant override (by `tenantId`), updates its template,
+ * or creates a new one. Always flows through `PromptOverride.save()`, so
+ * `validatePromptOverride` still forbids overriding a non-editable template.
+ *
+ * The prompt key must already be registered (via
+ * {@link ensurePersonaInstructionsPrompt} or `definePrompt`); this helper does
+ * not register it, so it never silently relaxes a locked prompt's editability.
+ *
+ * @returns The persisted override.
+ */
+export async function upsertPromptTemplateOverride(options: {
+  db: DatabaseInterface;
+  key: string;
+  tenantId: string | null;
+  template: string;
+}): Promise<PromptOverride> {
+  const { db, key, tenantId, template } = options;
+  const overrides = await PromptOverrideCollection.create({ db });
+  const existing =
+    tenantId != null
+      ? await overrides.getTenantOverride(key, tenantId)
+      : await overrides.getAppOverride(key);
+
+  if (existing) {
+    existing.template = template;
+    await existing.save();
+    return existing;
+  }
+
+  return overrides.create({ key, tenantId, template });
+}
+
+/**
+ * Write (or update) the tenant-scoped `prompt_override` that carries a persona's
+ * instructions.
+ *
+ * Ensures the per-persona prompt key is registered, then upserts the override
+ * template to `instructions ?? persona.instructions`. Flows through
+ * `PromptOverride.save()`, so a non-editable template throws.
+ *
+ * @returns The persisted override.
+ */
+export async function applyPersonaInstructions(options: {
+  persona: PersonaLike;
+  db: DatabaseInterface;
+  instructions?: string;
+  editable?: Partial<PromptEditableConfig>;
+}): Promise<PromptOverride> {
+  const { persona, db } = options;
+  ensurePersonaInstructionsPrompt(persona, { editable: options.editable });
+  return upsertPromptTemplateOverride({
+    db,
+    key: personaInstructionsPromptKey(persona),
+    tenantId: persona.tenantId ?? null,
+    template: options.instructions ?? persona.instructions ?? '',
+  });
+}
+
+/**
+ * Resolve a persona's effective instructions through the prompt system —
+ * layering code default → config → app override → tenant (persona) override.
+ *
+ * @returns The rendered instructions text (empty string when nothing overrides
+ *   the neutral base template).
+ */
+export async function resolvePersonaInstructions(options: {
+  persona: PersonaLike;
+  db: DatabaseInterface;
+  variables?: Record<string, unknown>;
+}): Promise<string> {
+  const { persona, db } = options;
+  ensurePersonaInstructionsPrompt(persona);
+  const key = personaInstructionsPromptKey(persona);
+  const resolved = await resolvePrompt(key, {
+    db,
+    tenantId: persona.tenantId ?? null,
+    variables: options.variables,
+  });
+  return resolved.text;
+}

--- a/packages/personas/src/persona-prompt.ts
+++ b/packages/personas/src/persona-prompt.ts
@@ -76,7 +76,11 @@ export function ensurePersonaInstructionsPrompt(
 ): PromptDefinition {
   const key = personaInstructionsPromptKey(persona);
   const existing = PromptRegistry.get(key);
-  if (existing) {
+  // Fast path only when the caller does not assert a specific editability. When
+  // `editable` IS given, always go through definePrompt so a conflicting
+  // re-registration (e.g. trying to lock `template: false` over an already
+  // editable key) is rejected loudly rather than silently ignored.
+  if (existing && options.editable === undefined) {
     return existing;
   }
   return definePrompt({

--- a/packages/personas/src/reflection-runner.ts
+++ b/packages/personas/src/reflection-runner.ts
@@ -1,0 +1,314 @@
+/**
+ * ReflectionRunner — the scheduled consolidation step of the learning loop (#1889).
+ *
+ * Runs under the **autonomous reflection principal**, which deliberately lacks
+ * the `personas.activate-directive` permission. For a persona it:
+ *
+ *   1. Applies recent {@link Feedback} to the persona's {@link LearningMemory}
+ *      as automatic, confidence-only reinforcement (ungated).
+ *   2. Consolidates the resulting episodes + feedback and asks an injected
+ *      reflector (the AI boundary, mocked in tests) for a candidate rewrite of
+ *      the persona's instructions.
+ *   3. Records that rewrite as a **pending** {@link DirectiveProposal} with
+ *      rationale + evidence — deduped by fingerprint so an already-seen (e.g.
+ *      rejected) rewrite is never re-surfaced.
+ *
+ * It cannot activate anything: writing the persona override is gated by the
+ * permission its principal does not hold. That split is the whole gate.
+ *
+ * The runner is transport-agnostic; schedule it through an `AgentSchedule` /
+ * background job by calling {@link run} on a cadence.
+ *
+ * @module
+ */
+
+import type {
+  LearningMemory,
+  LearningMemoryRecord,
+} from '@happyvertical/smrt-core';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import type { DirectivePrincipal } from './directive-principal.js';
+import {
+  computeDirectiveFingerprint,
+  type DirectiveProposal,
+  DirectiveProposalCollection,
+} from './directive-proposal.js';
+import { type Feedback, FeedbackCollection } from './feedback.js';
+import { reinforceFromFeedback } from './persona-memory.js';
+import {
+  ensurePersonaInstructionsPrompt,
+  personaInstructionsPromptKey,
+  resolvePersonaInstructions,
+} from './persona-prompt.js';
+
+/** The (normalised) persona shape handed to the reflector. */
+export interface ReflectionPersona {
+  id: string;
+  tenantId: string;
+  agentClass?: string;
+  name?: string;
+  instructions?: string;
+  memoryScope?: string;
+}
+
+/**
+ * The persona a run consolidates over — accepts a persisted `AgentPersona`
+ * directly (its `id` / `tenantId` are validated at run time).
+ */
+export interface ReflectionPersonaInput {
+  id?: string | null;
+  tenantId?: string | null;
+  agentClass?: string;
+  name?: string;
+  instructions?: string;
+  memoryScope?: string;
+}
+
+/** The consolidated input handed to the reflector (the AI boundary). */
+export interface ReflectionInput {
+  persona: ReflectionPersona;
+  /** The persona's current effective instructions (resolved via prompts). */
+  currentInstructions: string;
+  /** Recent episodes for the persona's memory scope. */
+  episodes: LearningMemoryRecord[];
+  /** Recent feedback signals for the persona. */
+  feedback: Feedback[];
+}
+
+/** A candidate rewrite returned by the reflector. */
+export interface DirectiveDraft {
+  /** Proposed replacement instructions. */
+  instructions: string;
+  /** Model-authored explanation. */
+  rationale: string;
+  /** Optional aggregate confidence in `[0, 1]`. */
+  confidence?: number;
+}
+
+/**
+ * The reflection boundary: consolidate episodes + feedback into a proposed
+ * instruction rewrite, or `null` to propose nothing. Injected so the AI call is
+ * the only thing mocked in tests.
+ */
+export type DirectiveReflector = (
+  input: ReflectionInput,
+) => Promise<DirectiveDraft | null> | DirectiveDraft | null;
+
+/** Options for {@link ReflectionRunner}. */
+export interface ReflectionRunnerOptions {
+  db: DatabaseInterface;
+  /** The autonomous principal — must NOT hold `personas.activate-directive`. */
+  principal: DirectivePrincipal;
+  /** The reflection boundary (AI call), injected. */
+  reflect: DirectiveReflector;
+  proposals?: DirectiveProposalCollection;
+  feedback?: FeedbackCollection;
+  /** Clock, injectable for deterministic lookback in tests. */
+  now?: () => Date;
+}
+
+/** Options for a single {@link ReflectionRunner.run} pass over one persona. */
+export interface ReflectionRunOptions {
+  persona: ReflectionPersonaInput;
+  /** The persona-scoped learning memory (see `personaLearningMemory`). */
+  memory: LearningMemory;
+  /** Episode scope to recall for evidence. Omit to skip episode gathering. */
+  episodeScope?: string;
+  /** Only consider feedback newer than this many ms ago. */
+  lookbackMs?: number;
+  /** Cap on feedback rows considered. Default 50. */
+  feedbackLimit?: number;
+  /** Neutral point for `rating` signals during reinforcement. Default 0. */
+  ratingNeutral?: number;
+  /** Override the target prompt key (default the persona instructions key). */
+  promptKey?: string;
+}
+
+/** Result of a {@link ReflectionRunner.run} pass. */
+export interface ReflectionRunResult {
+  /** Newly created pending proposals (0 or 1). */
+  proposals: DirectiveProposal[];
+  /** Number of feedback signals that adjusted memory reinforcement. */
+  reinforced: number;
+  /** Number of candidate rewrites suppressed (deduped / no-op). */
+  skipped: number;
+}
+
+function normalizePersona(input: ReflectionPersonaInput): ReflectionPersona {
+  if (!input.id) {
+    throw new Error(
+      'ReflectionRunner.run requires a persisted persona (missing id)',
+    );
+  }
+  if (!input.tenantId) {
+    throw new Error(
+      'ReflectionRunner.run requires a tenant-scoped persona (missing tenantId)',
+    );
+  }
+  return {
+    id: input.id,
+    tenantId: input.tenantId,
+    agentClass: input.agentClass,
+    name: input.name,
+    instructions: input.instructions,
+    memoryScope: input.memoryScope,
+  };
+}
+
+function meanConfidence(episodes: LearningMemoryRecord[]): number {
+  if (episodes.length === 0) {
+    return 0.5;
+  }
+  const sum = episodes.reduce((acc, e) => acc + e.confidence, 0);
+  return sum / episodes.length;
+}
+
+/**
+ * Consolidates feedback + episodes into pending directive proposals under a
+ * principal that cannot activate them.
+ */
+export class ReflectionRunner {
+  private readonly db: DatabaseInterface;
+  private readonly reflect: DirectiveReflector;
+  private readonly now: () => Date;
+  private readonly _principal: DirectivePrincipal;
+  private proposalsCol?: DirectiveProposalCollection;
+  private feedbackCol?: FeedbackCollection;
+
+  constructor(options: ReflectionRunnerOptions) {
+    this.db = options.db;
+    this._principal = options.principal;
+    this.reflect = options.reflect;
+    this.now = options.now ?? (() => new Date());
+    this.proposalsCol = options.proposals;
+    this.feedbackCol = options.feedback;
+  }
+
+  /**
+   * The autonomous principal this runner acts as. Exposed so callers can prove
+   * it cannot activate a proposal (it lacks `personas.activate-directive`).
+   */
+  get principal(): DirectivePrincipal {
+    return this._principal;
+  }
+
+  /**
+   * Run one reflection pass for a persona.
+   */
+  async run(options: ReflectionRunOptions): Promise<ReflectionRunResult> {
+    const { memory } = options;
+    const persona = normalizePersona(options.persona);
+    const feedbackCol = await this.feedbackCollection();
+
+    // 1. Recent feedback for the persona (optionally windowed).
+    const feedbackLimit = options.feedbackLimit ?? 50;
+    let feedback = await feedbackCol.forPersona(persona.id, {
+      limit: feedbackLimit,
+    });
+    if (options.lookbackMs != null) {
+      const cutoff = this.now().getTime() - options.lookbackMs;
+      feedback = feedback.filter((f) => {
+        const created = f.created_at ? new Date(f.created_at).getTime() : 0;
+        return created >= cutoff;
+      });
+    }
+
+    // 2. Automatic, confidence-only reinforcement from episode-level feedback.
+    //    Directive review signals (accept/reject of a proposal) are excluded —
+    //    they judge a proposal, not a strategy episode.
+    let reinforced = 0;
+    for (const signal of feedback) {
+      if (signal.correlationType === 'directive_proposal') {
+        continue;
+      }
+      const record = await reinforceFromFeedback(memory, signal, {
+        ratingNeutral: options.ratingNeutral,
+      });
+      if (record) {
+        reinforced += 1;
+      }
+    }
+
+    // 3. Gather episodes as evidence (all confidences, including decayed ones).
+    const episodes = options.episodeScope
+      ? await memory.recall(options.episodeScope, {
+          minConfidence: 0,
+          includeAncestors: true,
+        })
+      : [];
+
+    // 4. Resolve the persona's current instructions, then ask the reflector.
+    ensurePersonaInstructionsPrompt(persona);
+    const currentInstructions = await resolvePersonaInstructions({
+      persona,
+      db: this.db,
+    });
+
+    const draft = await this.reflect({
+      persona,
+      currentInstructions,
+      episodes,
+      feedback,
+    });
+
+    if (!draft || draft.instructions.trim() === currentInstructions.trim()) {
+      // Nothing to propose, or a no-op rewrite.
+      return { proposals: [], reinforced, skipped: draft ? 1 : 0 };
+    }
+
+    // 5. Dedup by fingerprint so an already-seen (e.g. rejected) rewrite is
+    //    never re-surfaced.
+    const promptKey =
+      options.promptKey ?? personaInstructionsPromptKey(persona);
+    const fingerprint = computeDirectiveFingerprint(
+      persona.id,
+      promptKey,
+      draft.instructions,
+    );
+    const proposals = await this.proposalsCollection();
+    const existing = await proposals.findByFingerprint(persona.id, fingerprint);
+    if (existing.length > 0) {
+      return { proposals: [], reinforced, skipped: 1 };
+    }
+
+    // 6. Record the pending proposal (rationale + evidence). It is inert until a
+    //    permissioned human activates it.
+    const proposal = await proposals.create({
+      tenantId: persona.tenantId,
+      personaId: persona.id,
+      agentClass: persona.agentClass ?? '',
+      promptKey,
+      proposedInstructions: draft.instructions,
+      currentInstructions,
+      rationale: draft.rationale,
+      status: 'pending',
+      fingerprint,
+      confidence: draft.confidence ?? meanConfidence(episodes),
+      proposedBy: this._principal.id ?? 'reflection',
+      evidence: JSON.stringify({
+        episodeIds: episodes.map((e) => e.id),
+        feedbackIds: feedback
+          .map((f) => f.id)
+          .filter((id): id is string => Boolean(id)),
+      }),
+    });
+
+    return { proposals: [proposal], reinforced, skipped: 0 };
+  }
+
+  private async proposalsCollection(): Promise<DirectiveProposalCollection> {
+    if (!this.proposalsCol) {
+      this.proposalsCol = await DirectiveProposalCollection.create({
+        db: this.db,
+      });
+    }
+    return this.proposalsCol;
+  }
+
+  private async feedbackCollection(): Promise<FeedbackCollection> {
+    if (!this.feedbackCol) {
+      this.feedbackCol = await FeedbackCollection.create({ db: this.db });
+    }
+    return this.feedbackCol;
+  }
+}

--- a/packages/personas/src/reflection-runner.ts
+++ b/packages/personas/src/reflection-runner.ts
@@ -213,20 +213,27 @@ export class ReflectionRunner {
       });
     }
 
-    // 2. Automatic, confidence-only reinforcement from episode-level feedback.
-    //    Directive review signals (accept/reject of a proposal) are excluded —
-    //    they judge a proposal, not a strategy episode.
+    // 2. Automatic, confidence-only reinforcement — applied EXACTLY ONCE per
+    //    signal. A signal already consumed (`reinforcedAt` set) is skipped, so a
+    //    scheduled runner never re-applies it and amplifies one accept/reject
+    //    into many outcomes. Directive review signals (accept/reject of a
+    //    proposal) judge a proposal, not an episode, so they are marked consumed
+    //    without reinforcing.
     let reinforced = 0;
     for (const signal of feedback) {
-      if (signal.correlationType === 'directive_proposal') {
+      if (signal.reinforcedAt) {
         continue;
       }
-      const record = await reinforceFromFeedback(memory, signal, {
-        ratingNeutral: options.ratingNeutral,
-      });
-      if (record) {
-        reinforced += 1;
+      if (signal.correlationType !== 'directive_proposal') {
+        const record = await reinforceFromFeedback(memory, signal, {
+          ratingNeutral: options.ratingNeutral,
+        });
+        if (record) {
+          reinforced += 1;
+        }
       }
+      signal.reinforcedAt = this.now();
+      await signal.save();
     }
 
     // 3. Gather episodes as evidence (all confidences, including decayed ones).

--- a/packages/personas/src/svelte/components/DirectiveReviewQueue.svelte
+++ b/packages/personas/src/svelte/components/DirectiveReviewQueue.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+/**
+ * DirectiveReviewQueue — the minimal human-in-the-loop surface for the persona
+ * learning loop (#1889).
+ *
+ * Renders pending {@link DirectiveProposalView}s with their rationale and a
+ * current-vs-proposed diff, and lets a reviewer approve (optionally editing the
+ * proposed text) or reject. It is purely presentational — approval/rejection are
+ * delegated to the `onApprove` / `onReject` callbacks, which a host wires to the
+ * permission-gated `DirectiveApprovalService`.
+ */
+import { Textarea } from '@happyvertical/smrt-ui/forms';
+import { Badge, Button, Card } from '@happyvertical/smrt-ui/ui';
+import type { DirectiveProposalView } from '../types.js';
+import { confidencePercent, statusBadgeVariant } from '../types.js';
+
+export interface Props {
+  /** Proposals to review (typically the pending queue). */
+  proposals?: DirectiveProposalView[];
+  /** Disable actions while a review is in flight. */
+  busy?: boolean;
+  /** Approve a proposal, optionally with reviewer-edited instructions. */
+  onApprove?: (id: string, editedInstructions?: string) => void;
+  /** Reject a proposal. */
+  onReject?: (id: string) => void;
+}
+
+const { proposals = [], busy = false, onApprove, onReject }: Props = $props();
+
+// Reviewer edits, keyed by proposal id.
+let edits = $state<Record<string, string>>({});
+
+function draftFor(proposal: DirectiveProposalView): string {
+  return edits[proposal.id] ?? proposal.proposedInstructions;
+}
+
+function onEdit(id: string, value: string): void {
+  edits = { ...edits, [id]: value };
+}
+
+function approve(proposal: DirectiveProposalView): void {
+  const edited = edits[proposal.id];
+  const changed =
+    edited !== undefined && edited !== proposal.proposedInstructions;
+  onApprove?.(proposal.id, changed ? edited : undefined);
+}
+</script>
+
+<section class="directive-review-queue">
+  {#if proposals.length === 0}
+    <p class="dq-empty">No directive proposals awaiting review.</p>
+  {:else}
+    {#each proposals as proposal (proposal.id)}
+      {@const locked = busy || proposal.status !== 'pending'}
+      <Card variant="outlined">
+        <div class="dq-head">
+          <span class="dq-title">
+            {proposal.personaName ?? proposal.agentClass ?? 'Persona directive'}
+          </span>
+          <span class="dq-badges">
+            {#if proposal.confidence != null}
+              <Badge variant="info" size="sm">
+                {confidencePercent(proposal.confidence)} confidence
+              </Badge>
+            {/if}
+            <Badge variant={statusBadgeVariant(proposal.status)} size="sm">
+              {proposal.status}
+            </Badge>
+          </span>
+        </div>
+
+        <p class="dq-rationale">{proposal.rationale}</p>
+
+        <div class="dq-diff">
+          <div class="dq-col">
+            <h4 class="dq-col-title">Current</h4>
+            <pre class="dq-pre">{proposal.currentInstructions || '(none)'}</pre>
+          </div>
+          <div class="dq-col">
+            <h4 class="dq-col-title">Proposed</h4>
+            <Textarea
+              value={draftFor(proposal)}
+              rows={5}
+              disabled={locked}
+              oninput={(event) =>
+                onEdit(
+                  proposal.id,
+                  (event.currentTarget as HTMLTextAreaElement).value,
+                )}
+            />
+          </div>
+        </div>
+
+        <div class="dq-actions">
+          <Button
+            variant="primary"
+            size="sm"
+            disabled={locked}
+            onclick={() => approve(proposal)}
+          >
+            Approve
+          </Button>
+          <Button
+            variant="danger"
+            size="sm"
+            disabled={locked}
+            onclick={() => onReject?.(proposal.id)}
+          >
+            Reject
+          </Button>
+        </div>
+      </Card>
+    {/each}
+  {/if}
+</section>
+
+<style>
+  .directive-review-queue {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .dq-empty {
+    color: var(--color-text-muted, #6b7280);
+    font-style: italic;
+  }
+
+  .dq-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .dq-title {
+    font-weight: 600;
+  }
+
+  .dq-badges {
+    display: inline-flex;
+    gap: 0.375rem;
+  }
+
+  .dq-rationale {
+    margin: 0 0 0.75rem;
+  }
+
+  .dq-diff {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+  }
+
+  @media (max-width: 640px) {
+    .dq-diff {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .dq-col-title {
+    margin: 0 0 0.25rem;
+    font-size: 0.8125rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted, #6b7280);
+  }
+
+  .dq-pre {
+    margin: 0;
+    padding: 0.5rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+    background: var(--color-surface-muted, #f3f4f6);
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+  }
+
+  .dq-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+  }
+</style>

--- a/packages/personas/src/svelte/index.ts
+++ b/packages/personas/src/svelte/index.ts
@@ -1,0 +1,26 @@
+/**
+ * @happyvertical/smrt-personas/svelte
+ *
+ * Optional Svelte 5 UI for the persona learning loop (#1889): a minimal
+ * directive review queue. Presentational only — approval/rejection are
+ * delegated to callbacks a host wires to the permission-gated
+ * `DirectiveApprovalService`.
+ *
+ * @packageDocumentation
+ */
+
+import type { ComponentProps } from 'svelte';
+import DirectiveReviewQueue from './components/DirectiveReviewQueue.svelte';
+
+export { DirectiveReviewQueue };
+export type DirectiveReviewQueueProps = ComponentProps<
+  typeof DirectiveReviewQueue
+>;
+
+export {
+  confidencePercent,
+  type DirectiveProposalView,
+  type DirectiveReviewStatus,
+  statusBadgeVariant,
+  toDirectiveProposalView,
+} from './types.js';

--- a/packages/personas/src/svelte/types.ts
+++ b/packages/personas/src/svelte/types.ts
@@ -1,0 +1,80 @@
+/**
+ * Presentational types for the directive review-queue UI (#1889).
+ *
+ * Kept free of the `@smrt()` model classes so the Svelte bundle stays a thin
+ * presentation layer — consumers map their {@link DirectiveProposal} rows to
+ * {@link DirectiveProposalView} via {@link toDirectiveProposalView}.
+ *
+ * @module
+ */
+
+/** The proposal lifecycle statuses the queue renders. */
+export type DirectiveReviewStatus =
+  | 'pending'
+  | 'approved'
+  | 'rejected'
+  | 'superseded';
+
+/** A plain, render-ready view of a directive proposal. */
+export interface DirectiveProposalView {
+  /** Proposal id. */
+  id: string;
+  /** Persona display name, if known. */
+  personaName?: string;
+  /** Canonical agent class the persona configures. */
+  agentClass?: string;
+  /** Lifecycle status. */
+  status: DirectiveReviewStatus;
+  /** Model-authored rationale for the change. */
+  rationale: string;
+  /** Current instructions (for the review diff). */
+  currentInstructions: string;
+  /** Proposed replacement instructions. */
+  proposedInstructions: string;
+  /** Aggregate confidence in `[0, 1]`, if known. */
+  confidence?: number;
+}
+
+/** Map a proposal-shaped record onto a render-ready view. */
+export function toDirectiveProposalView(proposal: {
+  id?: string | null;
+  status?: string;
+  rationale?: string;
+  currentInstructions?: string;
+  proposedInstructions?: string;
+  confidence?: number;
+  agentClass?: string;
+  personaName?: string;
+}): DirectiveProposalView {
+  return {
+    id: proposal.id ?? '',
+    personaName: proposal.personaName,
+    agentClass: proposal.agentClass,
+    status: (proposal.status as DirectiveReviewStatus) ?? 'pending',
+    rationale: proposal.rationale ?? '',
+    currentInstructions: proposal.currentInstructions ?? '',
+    proposedInstructions: proposal.proposedInstructions ?? '',
+    confidence: proposal.confidence,
+  };
+}
+
+/** Badge variant for a proposal status (matches `@happyvertical/smrt-ui`). */
+export function statusBadgeVariant(
+  status: DirectiveReviewStatus,
+): 'default' | 'success' | 'warning' | 'error' {
+  switch (status) {
+    case 'approved':
+      return 'success';
+    case 'rejected':
+      return 'error';
+    case 'pending':
+      return 'warning';
+    default:
+      return 'default';
+  }
+}
+
+/** Format a `[0, 1]` confidence as a rounded percentage string. */
+export function confidencePercent(confidence: number): string {
+  return `${Math.round(confidence * 100)}%`;
+}

--- a/packages/personas/tsconfig.build.json
+++ b/packages/personas/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.package-build.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "exclude": [
+    "src/svelte/**/*",
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/personas/tsconfig.json
+++ b/packages/personas/tsconfig.json
@@ -1,13 +1,12 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.ui-package.json",
   "compilerOptions": {
     "composite": true,
     "outDir": "./dist",
     "rootDir": "./src",
-    "tsBuildInfoFile": "./dist/.tsbuildinfo",
-    "types": ["node"],
-    "lib": ["ES2023"]
+    "baseUrl": ".",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "include": ["ambient.d.ts", "src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
 }

--- a/packages/personas/tsconfig.svelte.json
+++ b/packages/personas/tsconfig.svelte.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.package-svelte.json",
+  "include": ["ambient.d.ts", "src/**/*.ts", "src/**/*.svelte"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/personas/vite.config.ts
+++ b/packages/personas/vite.config.ts
@@ -1,3 +1,5 @@
 import { createPackageConfig } from '../../vite.config.base.js';
 
-export default createPackageConfig('personas');
+export default createPackageConfig('personas', {
+  svelte: 'svelte',
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1395,16 +1395,40 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
+      '@happyvertical/smrt-prompts':
+        specifier: workspace:*
+        version: link:../prompts
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy
+      '@happyvertical/smrt-ui':
+        specifier: workspace:*
+        version: link:../smrt-ui
+      '@happyvertical/smrt-users':
+        specifier: workspace:*
+        version: link:../users
+      '@happyvertical/sql':
+        specifier: ^0.77.0
+        version: 0.77.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest
+      '@sveltejs/package':
+        specifier: ^2.5.8
+        version: 2.5.8(svelte@5.56.4)(typescript@5.9.3)
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.1.2
+        version: 7.1.2(svelte@5.56.4)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
+      svelte:
+        specifier: ^5.56.4
+        version: 5.56.4
+      svelte-check:
+        specifier: ^4.7.1
+        version: 4.7.1(picomatch@4.0.5)(svelte@5.56.4)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Slice

L2 persona **learning & adaptation loop** with a human-in-the-loop approval gate, on top of the merged `AgentPersona` (#1887) + `LearningMemory` / `Learning` trait (#1886) foundation. Design defaults are locked: human approval is required for all behaviour changes, the surface is a review queue, auto-proposals are limited to instructions text, and there is a single approver.

### What it builds (all in `packages/personas`)

- **Behaviour + memory scoping** — a persona's `instructions` apply through a per-persona registered prompt key + a tenant-scoped `prompt_override` (`persona-prompt.ts`); `memoryScope` routes `LearningMemory` (via `owner_id`) so different personas learn independently (`persona-memory.ts`).
- **`Feedback`** (`agent_feedback`) — human `accept`/`reject`/`correction`/`rating` and autonomous `outcome`/`metric` signals, each with a required **correlation-id** back to the AI call / dispatch / job. `toLearningOutcome()` feeds the confidence-scored reinforcement from #1886; `reinforceFromFeedback()` applies it (automatic, ungated).
- **`ReflectionRunner`** (schedulable) — runs under the autonomous reflection principal, reinforces recent feedback, then consolidates episodes + feedback via an injected `reflect` boundary (the AI call) into pending **`DirectiveProposal`** rows (`directive_proposals`) with rationale + evidence, deduped by fingerprint.
- **The gate = a permission split** — activating a directive requires the `personas.activate-directive` slug (contributed to the manifest permission catalog via `registerPermissionDefinitions`). The reflection principal **lacks** it and can only propose. `DirectiveApprovalService.approve`/`reject` calls `assertCanActivate` first; approval writes the persona-scoped override through `PromptOverride.save()`, so `validatePromptOverride` still refuses a non-editable template. A rejection is recorded as a signal and the same proposal is never re-surfaced. Confidence-only reinforcement stays automatic.
- **Minimal review-queue UI** — `@happyvertical/smrt-personas/svelte` `DirectiveReviewQueue` (presentational Svelte 5): pending proposals with a current-vs-proposed diff and Approve/Reject, delegating to callbacks a host wires to the gated service.

### Tests

Real in-memory SQLite; only the AI/reflection boundary is stubbed. Covers every acceptance criterion: two personas behave differently and learn in separate memory scopes; `Feedback` (human + outcome) carries a correlation-id and adjusts reinforcement; the runner emits pending proposals it cannot activate (its principal lacks the slug); a human holding the slug activates one; a rejection is recorded and not re-surfaced; a non-editable prompt template cannot be overridden; the slug is present in the catalog. 43 tests pass.

### Notes

- New acyclic package edges: `personas → smrt-prompts`, `→ smrt-users`, `→ smrt-ui` (Svelte only), `→ @happyvertical/sql`. DAG + no-smrt-peer guardrails pass.
- Svelte-package tests can't run locally on Darwin/vite8; the UI is built (`svelte-package`) and typechecked locally, and relies on CI for the Svelte runtime.
- This wave runs in parallel with #1888 / #1890, which also touch `packages/personas` + `packages/agents`; additions are kept modular. **Governance surface — do not merge without review.**

Closes #1889
Part of #1885
