### PR TITLE
feat(mobile): close Phase 7 foundation gaps

### DIFF
--- a/docs/content/adr/0001-kmp-mobile-foundation-extraction-plan.md
+++ b/docs/content/adr/0001-kmp-mobile-foundation-extraction-plan.md
@@ -71,8 +71,12 @@ Locked with the framework owner (issue #1737 has the full record):
    (server-brokered PKCE on smrt-users OIDC/session infra; verified). Owner
    decision: **SMRT ships the server side in this epic** — Phase 3.5
    (#1748), reusable handlers in `smrt-users`.
-6. **Toolchain** — Kotlin 2.2.21 / AGP 8.13.1 / compileSdk 36 / minSdk 26 /
-   JVM 21 / iOS 17.0 (reporter-proven set, amaru catalog structure).
+6. **Toolchain** — Kotlin 2.4.0 / AGP 9.2.1 / Gradle 9.6.1 / compileSdk 36 /
+   minSdk 26 / JVM 21 / iOS 17.0. Updated 2026-07-09 after the shipped
+   packages advanced beyond the original reporter-proven pins (#1897).
+   AGP 9 consumers use built-in Kotlin (no `org.jetbrains.kotlin.android`) and
+   request `TargetJvmEnvironment.ANDROID` for resolvable configurations so
+   transitive KMP dependencies select Android variants.
 
 ## Phase 1 — `smrt-mobile` skeleton
 

--- a/docs/content/architecture/mobile-upload-contract.md
+++ b/docs/content/architecture/mobile-upload-contract.md
@@ -28,6 +28,19 @@ The shared KMP client (`MobileApiClient.submitMultipart`, Phase 4) sends:
 - `Idempotency-Key: <queue entry id>` when the upload is re-sent by the
   durable write queue.
 
+## Durable client payload
+
+Queue an encoded `EvidenceMultipartUpload`, not a `QueueHttpRequest.Multipart`:
+the durable payload stores fields and `EvidenceAssetRef` metadata, while the
+request type contains in-memory bytes. In the suspend `HttpQueueSender`
+entry mapper, decode the payload and call
+`toQueueHttpRequest(EvidenceByteSource { asset -> ... })`. The platform byte
+source reads `asset.localUri` or `asset.relativePath` when connectivity returns
+and the queue flushes, so retries carry the actual media without duplicating
+it in the SQLDelight queue row. Use `AndroidEvidenceByteSource` on Android or
+`FoundationEvidenceByteSource` on iOS; the latter bulk-copies Foundation data
+into Kotlin memory instead of crossing the Swift bridge once per byte.
+
 ## Dedup semantics (`clientCaptureId` / `Idempotency-Key`)
 
 Retries are NORMAL: the mobile queue re-POSTs after dropped connections and
@@ -106,6 +119,7 @@ is fail-closed (#1822).
   rejects larger bodies with an opaque 413 BEFORE your handler executes —
   deployments must raise it to at least the app's max upload size, and that
   size should stay modest precisely because of the buffering.
-- The Phase-4 client buffers each part as a `ByteArray` (photo-scale).
+- The Phase-4 client loads and buffers each part as a `ByteArray` at flush
+  time (photo-scale); the durable row stores only evidence metadata.
   Streamed multipart is tracked in #1871 — do not size this contract for
   video until it lands.

--- a/packages/smrt-android/AGENTS.md
+++ b/packages/smrt-android/AGENTS.md
@@ -46,7 +46,9 @@ publishing deferred, consumers are local-fs).
   `AndroidEvidenceCaptureAdapter` (`EvidenceCapturePlatformAdapter`;
   drive-to-completion `captureOrPickPhoto` — full-res `TakePicture` into a
   library-shipped `FileProvider` URI, or the system photo picker — app-private
-  storage, sha256 pin, `LocationManager` geo sidecar; #1880). The evidence
+  storage, sha256 pin, `LocationManager` geo sidecar; #1880), and
+  `AndroidEvidenceByteSource`, which resolves file/content URIs on
+  `Dispatchers.IO` when durable multipart entries flush (#1896). The evidence
   FileProvider (`SmrtEvidenceFileProvider`) ships in the library manifest with a
   `${applicationId}.evidence.files` authority (per-consumer via manifest merge,
   overridable via the constructor + `tools:replace`).

--- a/packages/smrt-android/README.md
+++ b/packages/smrt-android/README.md
@@ -14,14 +14,47 @@ Publishing is deferred; consumers use Gradle composite builds:
 
 ```kotlin
 // settings.gradle.kts
-includeBuild("<path-to-smrt>/packages/smrt-mobile")
-includeBuild("<path-to-smrt>/packages/smrt-android")
+val smrtFoundationDir = providers.gradleProperty("smrtFoundationDir")
+    .orElse(providers.environmentVariable("SMRT_FOUNDATION_DIR"))
+    .orElse("../smrt")
+    .get()
+val smrtFoundation = file(smrtFoundationDir)
+
+includeBuild(smrtFoundation.resolve("packages/smrt-mobile"))
+includeBuild(smrtFoundation.resolve("packages/smrt-android"))
 
 // module build.gradle.kts
 dependencies {
     implementation("com.happyvertical.smrt:smrt-android")
 }
 ```
+
+CI should check out `happyvertical/smrt` at a pinned release tag and set
+`SMRT_FOUNDATION_DIR` to that checkout. Private cross-organization checkouts
+need a GitHub App token or fine-grained PAT with repository read access; see
+the complete workflow in [`smrt-mobile`'s README](../smrt-mobile/README.md).
+
+AGP 9 provides built-in Kotlin, so consumers must not apply
+`org.jetbrains.kotlin.android`. AGP 9 may otherwise select standard JVM
+variants for transitive KMP dependencies; Android modules consuming this
+foundation should explicitly request the Android JVM environment:
+
+```kotlin
+import org.gradle.api.attributes.java.TargetJvmEnvironment
+
+configurations.configureEach {
+    if (isCanBeResolved) {
+        attributes.attribute(
+            TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
+            objects.named(TargetJvmEnvironment.ANDROID),
+        )
+    }
+}
+```
+
+For durable media queues, pass `AndroidEvidenceByteSource(context)` to
+`EvidenceMultipartUpload.toQueueHttpRequest(...)`; it reads file and content
+URIs on `Dispatchers.IO` when the queue flushes.
 
 ## Development
 

--- a/packages/smrt-android/library/src/main/kotlin/com/happyvertical/smrt/android/platform/AndroidEvidenceByteSource.kt
+++ b/packages/smrt-android/library/src/main/kotlin/com/happyvertical/smrt/android/platform/AndroidEvidenceByteSource.kt
@@ -38,6 +38,15 @@ class AndroidEvidenceByteSource(
         require(asset.relativePath.isNotBlank()) {
             "Evidence asset ${asset.assetId} has no readable local file location"
         }
-        return baseDirectory.resolve(asset.relativePath)
+        return resolveEvidenceRelativeFile(baseDirectory, asset.relativePath)
     }
+}
+
+internal fun resolveEvidenceRelativeFile(baseDirectory: File, relativePath: String): File {
+    val canonicalBase = baseDirectory.canonicalFile
+    val candidate = canonicalBase.resolve(relativePath).canonicalFile
+    require(candidate.toPath().startsWith(canonicalBase.toPath())) {
+        "Evidence relative path escapes the configured base directory"
+    }
+    return candidate
 }

--- a/packages/smrt-android/library/src/main/kotlin/com/happyvertical/smrt/android/platform/AndroidEvidenceByteSource.kt
+++ b/packages/smrt-android/library/src/main/kotlin/com/happyvertical/smrt/android/platform/AndroidEvidenceByteSource.kt
@@ -1,0 +1,43 @@
+package com.happyvertical.smrt.android.platform
+
+import android.content.Context
+import android.net.Uri
+import com.happyvertical.smrt.mobile.evidence.EvidenceAssetRef
+import com.happyvertical.smrt.mobile.evidence.EvidenceByteSource
+import java.io.File
+import java.net.URI
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/** Loads app-private evidence bytes when a durable multipart entry flushes. */
+class AndroidEvidenceByteSource(
+    context: Context,
+    private val baseDirectory: File = context.filesDir,
+) : EvidenceByteSource {
+    private val contentResolver = context.applicationContext.contentResolver
+
+    override suspend fun readBytes(asset: EvidenceAssetRef): ByteArray =
+        withContext(Dispatchers.IO) {
+            when (val scheme = runCatching { URI(asset.localUri).scheme?.lowercase() }.getOrNull()) {
+                null -> resolveLocalFile(asset).readBytes()
+                "file" -> File(URI(asset.localUri)).readBytes()
+                "content", "android.resource" -> contentResolver
+                    .openInputStream(Uri.parse(asset.localUri))
+                    ?.buffered()
+                    ?.use { it.readBytes() }
+                    ?: error("Unable to open evidence URI ${asset.localUri}")
+                else -> error("Unsupported evidence URI scheme: $scheme")
+            }
+        }
+
+    private fun resolveLocalFile(asset: EvidenceAssetRef): File {
+        if (asset.localUri.isNotBlank()) {
+            val direct = File(asset.localUri)
+            if (direct.isAbsolute) return direct
+        }
+        require(asset.relativePath.isNotBlank()) {
+            "Evidence asset ${asset.assetId} has no readable local file location"
+        }
+        return baseDirectory.resolve(asset.relativePath)
+    }
+}

--- a/packages/smrt-android/library/src/test/kotlin/com/happyvertical/smrt/android/platform/EvidenceCaptureMappingTest.kt
+++ b/packages/smrt-android/library/src/test/kotlin/com/happyvertical/smrt/android/platform/EvidenceCaptureMappingTest.kt
@@ -5,8 +5,10 @@ import com.happyvertical.smrt.mobile.evidence.EvidenceAssetStorageState
 import com.happyvertical.smrt.mobile.evidence.EvidenceCaptureRequest
 import com.happyvertical.smrt.mobile.evidence.EvidenceCaptureSource
 import com.happyvertical.smrt.mobile.evidence.EvidencePermissionStatus
+import kotlin.io.path.createTempDirectory
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -18,6 +20,22 @@ import kotlinx.datetime.Instant
  * drive itself needs an Activity + on-device UI and is exercised by the sample.
  */
 class EvidenceCaptureMappingTest {
+    @Test
+    fun relativeEvidenceFileMustStayWithinBaseDirectory() {
+        val baseDirectory = createTempDirectory("smrt-evidence").toFile()
+        try {
+            assertEquals(
+                baseDirectory.resolve("evidence/asset.jpg").canonicalFile,
+                resolveEvidenceRelativeFile(baseDirectory, "evidence/asset.jpg"),
+            )
+            assertFailsWith<IllegalArgumentException> {
+                resolveEvidenceRelativeFile(baseDirectory, "../outside.jpg")
+            }
+        } finally {
+            baseDirectory.deleteRecursively()
+        }
+    }
+
     @Test
     fun captureSegmentTakesFirstNonBlankContextIdBySortedKey() {
         assertEquals(

--- a/packages/smrt-android/scripts/validate-android.mjs
+++ b/packages/smrt-android/scripts/validate-android.mjs
@@ -127,6 +127,14 @@ const SPEC = [
     ],
   },
   {
+    path: `${LIB_ROOT}/platform/AndroidEvidenceByteSource.kt`,
+    mustContain: [
+      'class AndroidEvidenceByteSource(',
+      ': EvidenceByteSource',
+      'withContext(Dispatchers.IO)',
+    ],
+  },
+  {
     path: `${LIB_ROOT}/platform/SmrtEvidenceFileProvider.kt`,
     mustContain: ['class SmrtEvidenceFileProvider : FileProvider('],
   },

--- a/packages/smrt-ios/AGENTS.md
+++ b/packages/smrt-ios/AGENTS.md
@@ -28,6 +28,9 @@ point for the KMP framework, so there are no duplicate static symbols.
   Values are **identical to smrt-android's `MobileTheme.kt`** — one design system.
 - `Sources/SmrtIos/Shell/MobileShellScaffold.swift` — the tab shell bound to
   smrt-mobile's shared `MobileShellState` (not an unbound `TabView`), + `MobileTabHeader`.
+- `Sources/SmrtIos/State/MobileObservableState.swift` — the `ObservableObject`
+  bridge for exported `MobileStateHolder` instances. It owns and closes the
+  Kotlin observation subscription and publishes updates on the main actor.
 - `Sources/SmrtIos/Platform/` — the adapters, each conforming to a smrt-mobile
   exported seam: `CryptoKitSha256Hasher` (`Sha256Hasher`), `KeychainAuthStorage`
   (`AuthStorage`), `WebAuthSessionLauncher` (`ExternalAuthLauncher`),
@@ -40,7 +43,10 @@ point for the KMP framework, so there are no duplicate static symbols.
   presents `UIImagePickerController`/`PHPickerViewController`, bridges the
   delegate into `async`, copies into `Documents/Evidence/` with
   security-scoped-resource handling, CryptoKit sha256 pin, `CLLocationManager`
-  geo sidecar; simulator falls back to the photo picker; #1880).
+  geo sidecar; simulator falls back to the photo picker; #1880), plus
+  `FoundationEvidenceByteSource`, which loads those app-private files at queue
+  flush time and uses `SmrtMobileIos.byteArray(NSData)` for one native bulk copy
+  into Kotlin memory (#1896).
 - `Sample/SmrtIosSample/` — the demo app proving real shared logic (durable pack
   store + write-queue, adapters, evidence capture, theme/shell). Never published.
 - `Tests/SmrtIosTests/` — XCTest over the pure seam-vocabulary mappings.

--- a/packages/smrt-ios/README.md
+++ b/packages/smrt-ios/README.md
@@ -2,8 +2,9 @@
 
 The SwiftUI half of the SMRT mobile foundation (ADR 0001, epic #1745, Phase 6
 issue #1743): `MobileTheme` design tokens, a tab shell scaffold bound to
-smrt-mobile's shared `MobileShellState`, and native platform adapters — all
-**consuming the exported `SmrtMobile` KMP framework** from
+smrt-mobile's shared `MobileShellState`, a SwiftUI observation bridge for
+shared KMP presenters, and native platform adapters -- all **consuming the
+exported `SmrtMobile` KMP framework** from
 `packages/smrt-mobile`.
 
 ## Consuming (local filesystem, per the Phase 0 decision)
@@ -17,6 +18,14 @@ follow-up.
 
 The reusable foundation is `Sources/SmrtIos` (Swift module `SmrtIos`); apps
 `import SmrtMobile` (shared logic) and `import SmrtIos` (theme/shell/adapters).
+Wrap a presenter's exported `MobileStateHolder` in
+`MobileObservableState(holder:)`, retain it as a SwiftUI `@StateObject`, and
+render its published `value`.
+
+Use `FoundationEvidenceByteSource` when converting a queued
+`EvidenceMultipartUpload` at flush time. It resolves app-private files and
+bulk-copies `Data` into Kotlin memory through `SmrtMobileIos`, avoiding an
+element-by-element Swift bridge.
 
 ## Development
 

--- a/packages/smrt-ios/Sources/SmrtIos/Platform/FoundationEvidenceByteSource.swift
+++ b/packages/smrt-ios/Sources/SmrtIos/Platform/FoundationEvidenceByteSource.swift
@@ -1,0 +1,43 @@
+import Foundation
+import SmrtMobile
+
+/// Loads app-private evidence files when a durable multipart queue entry flushes.
+/// Conversion to `KotlinByteArray` uses a native bulk copy in `SmrtMobileIos`.
+public final class FoundationEvidenceByteSource: NSObject, EvidenceByteSource {
+    private let baseDirectory: URL
+
+    public init(baseDirectory: URL? = nil) {
+        self.baseDirectory = baseDirectory
+            ?? FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        super.init()
+    }
+
+    public func readBytes(asset: EvidenceAssetRef) async throws -> KotlinByteArray {
+        let data = try Data(contentsOf: try fileURL(for: asset), options: .mappedIfSafe)
+        return SmrtMobileIos.shared.byteArray(data: data)
+    }
+
+    private func fileURL(for asset: EvidenceAssetRef) throws -> URL {
+        if let url = URL(string: asset.localUri), url.isFileURL {
+            return url
+        }
+        if asset.localUri.hasPrefix("/") {
+            return URL(fileURLWithPath: asset.localUri)
+        }
+        guard !asset.relativePath.isEmpty else {
+            throw FoundationEvidenceByteSourceError.missingFileLocation(assetId: asset.assetId)
+        }
+        return baseDirectory.appendingPathComponent(asset.relativePath)
+    }
+}
+
+public enum FoundationEvidenceByteSourceError: LocalizedError {
+    case missingFileLocation(assetId: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .missingFileLocation(assetId):
+            return "Evidence asset \(assetId) has no readable local file location."
+        }
+    }
+}

--- a/packages/smrt-ios/Sources/SmrtIos/Platform/FoundationEvidenceByteSource.swift
+++ b/packages/smrt-ios/Sources/SmrtIos/Platform/FoundationEvidenceByteSource.swift
@@ -4,6 +4,12 @@ import SmrtMobile
 /// Loads app-private evidence files when a durable multipart queue entry flushes.
 /// Conversion to `KotlinByteArray` uses a native bulk copy in `SmrtMobileIos`.
 public final class FoundationEvidenceByteSource: NSObject, EvidenceByteSource {
+    private static let ioQueue = DispatchQueue(
+        label: "com.happyvertical.smrt.evidence-byte-source",
+        qos: .utility,
+        attributes: .concurrent
+    )
+
     private let baseDirectory: URL
 
     public init(baseDirectory: URL? = nil) {
@@ -13,31 +19,65 @@ public final class FoundationEvidenceByteSource: NSObject, EvidenceByteSource {
     }
 
     public func readBytes(asset: EvidenceAssetRef) async throws -> KotlinByteArray {
-        let data = try Data(contentsOf: try fileURL(for: asset), options: .mappedIfSafe)
-        return SmrtMobileIos.shared.byteArray(data: data)
+        let assetId = asset.assetId
+        let localUri = asset.localUri
+        let relativePath = asset.relativePath
+        let baseDirectory = baseDirectory
+        return try await withCheckedThrowingContinuation { continuation in
+            Self.ioQueue.async {
+                do {
+                    let fileURL = try Self.fileURL(
+                        assetId: assetId,
+                        localUri: localUri,
+                        relativePath: relativePath,
+                        baseDirectory: baseDirectory
+                    )
+                    let data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
+                    continuation.resume(returning: SmrtMobileIos.shared.byteArray(data: data))
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
     }
 
-    private func fileURL(for asset: EvidenceAssetRef) throws -> URL {
-        if let url = URL(string: asset.localUri), url.isFileURL {
+    private static func fileURL(
+        assetId: String,
+        localUri: String,
+        relativePath: String,
+        baseDirectory: URL
+    ) throws -> URL {
+        if let url = URL(string: localUri), url.isFileURL {
             return url
         }
-        if asset.localUri.hasPrefix("/") {
-            return URL(fileURLWithPath: asset.localUri)
+        if localUri.hasPrefix("/") {
+            return URL(fileURLWithPath: localUri)
         }
-        guard !asset.relativePath.isEmpty else {
-            throw FoundationEvidenceByteSourceError.missingFileLocation(assetId: asset.assetId)
+        guard !relativePath.isEmpty else {
+            throw FoundationEvidenceByteSourceError.missingFileLocation(assetId: assetId)
         }
-        return baseDirectory.appendingPathComponent(asset.relativePath)
+        let canonicalBase = baseDirectory.standardizedFileURL.resolvingSymlinksInPath()
+        let candidate = canonicalBase
+            .appendingPathComponent(relativePath)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        guard candidate.pathComponents.starts(with: canonicalBase.pathComponents) else {
+            throw FoundationEvidenceByteSourceError.pathOutsideBaseDirectory(assetId: assetId)
+        }
+        return candidate
     }
 }
 
 public enum FoundationEvidenceByteSourceError: LocalizedError {
     case missingFileLocation(assetId: String)
+    case pathOutsideBaseDirectory(assetId: String)
 
     public var errorDescription: String? {
         switch self {
         case let .missingFileLocation(assetId):
             return "Evidence asset \(assetId) has no readable local file location."
+        case let .pathOutsideBaseDirectory(assetId):
+            return "Evidence asset \(assetId) resolves outside the configured base directory."
         }
     }
 }

--- a/packages/smrt-ios/Sources/SmrtIos/State/MobileObservableState.swift
+++ b/packages/smrt-ios/Sources/SmrtIos/State/MobileObservableState.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import SmrtMobile
+
+/// SwiftUI observation bridge for a shared KMP `MobileStateHolder`.
+///
+/// Shared presenters expose their holder from Kotlin. SwiftUI owns this adapter
+/// as a `@StateObject`/`@ObservedObject` and reads `value`; the adapter closes
+/// the Kotlin subscription when it deinitializes.
+@MainActor
+public final class MobileObservableState<State: AnyObject>: ObservableObject {
+    private let holder: MobileStateHolder<State>
+    private var observer: MobileObservableStateObserver<State>?
+    private var subscription: MobileStateSubscription?
+
+    @Published public private(set) var value: State
+
+    public init(holder: MobileStateHolder<State>, emitCurrent: Bool = true) {
+        self.holder = holder
+        self.value = holder.value
+
+        let observer = MobileObservableStateObserver<State> { [weak self] next in
+            self?.value = next
+        }
+        self.observer = observer
+        self.subscription = holder.observe(observer: observer, emitCurrent: emitCurrent)
+    }
+
+    public func refreshFromHolder() {
+        value = holder.value
+    }
+
+    public func close() {
+        subscription?.close()
+        subscription = nil
+        observer = nil
+    }
+
+    deinit {
+        subscription?.close()
+    }
+}
+
+private final class MobileObservableStateObserver<State: AnyObject>: NSObject, MobileStateObserver {
+    private let publish: @MainActor (State) -> Void
+
+    init(publish: @escaping @MainActor (State) -> Void) {
+        self.publish = publish
+    }
+
+    func onState(value: Any?) {
+        guard let state = value as? State else { return }
+        Task { @MainActor in
+            self.publish(state)
+        }
+    }
+}

--- a/packages/smrt-ios/Tests/SmrtIosTests/EvidenceCaptureMappingTests.swift
+++ b/packages/smrt-ios/Tests/SmrtIosTests/EvidenceCaptureMappingTests.swift
@@ -47,6 +47,41 @@ final class EvidenceCaptureMappingTests: XCTestCase {
         )
     }
 
+    func testFoundationEvidenceByteSourceRejectsRelativePathOutsideBaseDirectory() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let directory = root.appendingPathComponent("evidence", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let asset = EvidenceAssetRef(
+            assetId: "asset-outside",
+            localUri: "",
+            fileName: "outside.jpg",
+            contentType: "image/jpeg",
+            sizeBytes: nil,
+            sha256: "",
+            captureSource: EvidenceCaptureSource.shared.NATIVE_PICKER,
+            originalUri: "",
+            storageRoot: "app_private",
+            relativePath: "../outside.jpg",
+            storageState: EvidenceAssetStorageState.shared.STORED_OFFLINE,
+            offlineSafe: true,
+            persistedAt: nil
+        )
+
+        do {
+            _ = try await FoundationEvidenceByteSource(baseDirectory: directory)
+                .readBytes(asset: asset)
+            XCTFail("Expected traversal outside the base directory to be rejected")
+        } catch let error as FoundationEvidenceByteSourceError {
+            guard case let .pathOutsideBaseDirectory(assetId) = error else {
+                return XCTFail("Unexpected evidence byte-source error: \(error)")
+            }
+            XCTAssertEqual(assetId, "asset-outside")
+        }
+    }
+
     func testCaptureSegmentPicksFirstNonBlankBySortedKey() {
         XCTAssertEqual(
             IOSEvidenceCaptureAdapter.evidenceCaptureSegment(

--- a/packages/smrt-ios/Tests/SmrtIosTests/EvidenceCaptureMappingTests.swift
+++ b/packages/smrt-ios/Tests/SmrtIosTests/EvidenceCaptureMappingTests.swift
@@ -12,6 +12,41 @@ import SmrtMobile
 /// drive itself needs an on-device UI and is verified by the sample app.
 final class EvidenceCaptureMappingTests: XCTestCase {
 
+    func testFoundationEvidenceByteSourceBulkLoadsLocalFile() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let file = directory.appendingPathComponent("asset.jpg")
+        let expected = Data("bulk-evidence-bytes".utf8)
+        try expected.write(to: file)
+        let asset = EvidenceAssetRef(
+            assetId: "asset-1",
+            localUri: file.absoluteString,
+            fileName: file.lastPathComponent,
+            contentType: "image/jpeg",
+            sizeBytes: KotlinLong(longLong: Int64(expected.count)),
+            sha256: "",
+            captureSource: EvidenceCaptureSource.shared.NATIVE_PICKER,
+            originalUri: "",
+            storageRoot: "app_private",
+            relativePath: file.lastPathComponent,
+            storageState: EvidenceAssetStorageState.shared.STORED_OFFLINE,
+            offlineSafe: true,
+            persistedAt: nil
+        )
+
+        let bytes = try await FoundationEvidenceByteSource(baseDirectory: directory)
+            .readBytes(asset: asset)
+
+        XCTAssertEqual(bytes.size, Int32(expected.count))
+        XCTAssertEqual(
+            Data((0..<bytes.size).map { UInt8(bitPattern: bytes.get(index: $0)) }),
+            expected
+        )
+    }
+
     func testCaptureSegmentPicksFirstNonBlankBySortedKey() {
         XCTAssertEqual(
             IOSEvidenceCaptureAdapter.evidenceCaptureSegment(

--- a/packages/smrt-ios/scripts/validate-ios.mjs
+++ b/packages/smrt-ios/scripts/validate-ios.mjs
@@ -56,6 +56,15 @@ const SPEC = [
     path: `${SRC}/Shell/MobileShellScaffold.swift`,
     mustContain: ['struct MobileShellScaffold', 'MobileShellState', 'struct MobileTabHeader'],
   },
+  {
+    path: `${SRC}/State/MobileObservableState.swift`,
+    mustContain: [
+      'final class MobileObservableState',
+      'MobileStateHolder',
+      'MobileStateObserver',
+      'MobileStateSubscription',
+    ],
+  },
   { path: `${PLATFORM}/CryptoKitSha256Hasher.swift`, mustContain: [', Sha256Hasher', 'CryptoKit'] },
   {
     path: `${PLATFORM}/KeychainAuthStorage.swift`,
@@ -90,6 +99,10 @@ const SPEC = [
       'startAccessingSecurityScopedResource',
       'PHPickerViewController',
     ],
+  },
+  {
+    path: `${PLATFORM}/FoundationEvidenceByteSource.swift`,
+    mustContain: [', EvidenceByteSource', 'Data(contentsOf:', 'SmrtMobileIos.shared.byteArray'],
   },
   {
     path: `${SAMPLE}/SmrtIosSampleApp.swift`,

--- a/packages/smrt-mobile-contract/src/emit-framework.ts
+++ b/packages/smrt-mobile-contract/src/emit-framework.ts
@@ -105,8 +105,10 @@ import kotlinx.serialization.json.JsonObject
  *
  * The server owns the OIDC/PKCE exchange: \`auth/start\` returns the
  * authorization URL plus the \`state\`/\`codeVerifier\` the client must persist
- * and echo back on \`auth/complete\`. Reference implementation: anytown
- * dashboard; SMRT-shipped handlers are tracked in issue #1748.
+ * and echo back on \`auth/complete\`. SMRT ships the SvelteKit handlers in
+ * @happyvertical/smrt-users (issue #1748). App-defined session bootstrap data
+ * belongs under MobileSessionBootstrap.extras; unknown top-level fields are
+ * outside this contract and are ignored by the Kotlin client.
  */
 
 @Serializable

--- a/packages/smrt-mobile-contract/src/framework-types.ts
+++ b/packages/smrt-mobile-contract/src/framework-types.ts
@@ -4,8 +4,8 @@
  * These are the SAME shapes the framework Kotlin contract ships to mobile
  * clients (`MOBILE_AUTH_CONTRACT_KT` in `emit-framework.ts`, checked into
  * `@happyvertical/smrt-mobile` as `MobileAuthContract.kt`). Server-side
- * implementations — the reusable SvelteKit handlers in
- * `@happyvertical/smrt-users` (issue #1748) — import them from here so the
+ * implementations -- the reusable SvelteKit handlers in
+ * `@happyvertical/smrt-users` (issue #1748) -- import them from here so the
  * wire contract has one owning package on both sides.
  *
  * Two sync guarantees keep the three representations locked together:
@@ -129,9 +129,11 @@ export interface MobileAuthSession {
 }
 
 /**
- * Response of `GET /api/mobile/session` — the app-boot payload for a stored
- * bearer. `extras` is an app-defined JSON object escape hatch (must remain a
- * JSON object; the Kotlin side decodes it as `JsonObject`).
+ * Response of `GET /api/mobile/session` -- the app-boot payload for a stored
+ * bearer. `extras` is the only app-defined extension point and must remain a
+ * JSON object (the Kotlin side decodes it as `JsonObject`). App-domain fields
+ * placed at the top level are outside the contract and are ignored by the
+ * Kotlin decoder.
  */
 export interface MobileSessionBootstrap {
   user: MobileUserSummary;

--- a/packages/smrt-mobile/AGENTS.md
+++ b/packages/smrt-mobile/AGENTS.md
@@ -7,7 +7,7 @@ non-TypeScript package in the monorepo. Design: **ADR 0001**
 
 **Status: Phases 1–5 complete** — the shared-logic core. Present: framework
 contract types, pack i18n resolver, pack integrity/snapshot model,
-evidence-capture model, shell state, the **durable SQLDelight write-queue +
+evidence-capture model, shared presenter state, shell state, the **durable SQLDelight write-queue +
 pack store** (Phase 2, #1739), the **PKCE auth/session module** (Phase 3,
 #1740), the **shared Ktor client** (Phase 4, #1741) implementing the
 `AuthTransport`/`QueueSender` seams, and the **barcode/speech/LLM/device
@@ -44,7 +44,9 @@ consumers use Gradle `includeBuild`).
   engines; tests use MockEngine). Bearer on every authenticated request;
   multipart evidence upload; `Idempotency-Key` from the queue entry id;
   401 → `UnauthorizedHandler` (wire to `MobileSessionManager.onUnauthorized`)
-  then `AuthUnauthorizedException`. `HttpQueueSender` maps HTTP outcomes to
+  then `AuthUnauthorizedException`. `HttpQueueSender`'s entry mapper is
+  suspend so platform byte sources can load queued evidence at flush time.
+  It maps HTTP outcomes to
   the queue's `SendOutcome` semantics **for the hand-written `/api/mobile`
   single-item endpoints only** (4xx permanent except 408/429; the handlers
   dedupe on `Idempotency-Key`). Framework-model writes need the planned
@@ -85,8 +87,13 @@ consumers use Gradle `includeBuild`).
   smrt-android / smrt-ios (Phases 5–6).
 - `src/commonMain/kotlin/.../evidence/` — evidence asset refs (SHA-256
   pins), geo **sidecar** metadata (never EXIF — recompression strips it),
-  permission state, `EvidenceCapturePlatformAdapter` seam. Domain identity
-  travels in `contextIds` so the model stays trade-neutral.
+  permission state, `EvidenceCapturePlatformAdapter` seam, and
+  `EvidenceMultipartUpload`/`EvidenceByteSource` for durable uploads that
+  resolve file bytes at flush time. Domain identity travels in `contextIds`
+  so the model stays trade-neutral.
+- `src/commonMain/kotlin/.../state/` — `MobileStateHolder` and
+  `MobileStatePresenter` expose shared `StateFlow` state to Compose and the
+  smrt-ios SwiftUI observation adapter.
 - `src/commonMain/kotlin/.../shell/` — `MobileShellState` manual-tab nav
   state (no androidx.navigation); apps provide the tab list.
 - `src/commonMain/kotlin/.../platform/` — adapter seams: `Sha256Hasher`,
@@ -112,7 +119,9 @@ without an Android SDK.
   the iOS evidence adapter needs for `persistedAt`/`capturedAt`; #1880). These
   build Kotlin/Native types Swift cannot instantiate itself (`NativeSqliteDriver`,
   the Ktor `Darwin` engine, `Instant`); smrt-android, being Kotlin, builds its
-  own. This is the only `iosMain` code — everything else is `commonMain`.
+  own. `byteArray(NSData)` gives smrt-ios evidence loading one native bulk copy
+  instead of per-byte Objective-C bridging. This is the only `iosMain` code —
+  everything else is `commonMain`.
 
 ## Commands
 

--- a/packages/smrt-mobile/README.md
+++ b/packages/smrt-mobile/README.md
@@ -1,9 +1,10 @@
 # @happyvertical/smrt-mobile
 
 Kotlin Multiplatform shared mobile foundation for SMRT apps: offline pack
-model + integrity, pack i18n resolution, evidence-capture model, app-shell
-state, and platform adapter contracts. Android consumes the module directly;
-iOS consumes the exported `SmrtMobile` framework.
+model + integrity, pack i18n resolution, durable evidence uploads, shared
+presenter state, app-shell state, and platform adapter contracts. Android
+consumes the module directly; iOS consumes the exported `SmrtMobile`
+framework.
 
 Design and rationale: [ADR 0001](../../docs/content/adr/0001-kmp-mobile-foundation.md)
 and its [extraction plan](../../docs/content/adr/0001-kmp-mobile-foundation-extraction-plan.md).
@@ -31,11 +32,11 @@ Codegen companion: [`@happyvertical/smrt-mobile-contract`](../smrt-mobile-contra
 5. **Server contract** — `/api/mobile` (server-brokered PKCE, session
    bootstrap, multipart upload with `clientCaptureId`/`Idempotency-Key`
    dedup) is part of the foundation: SMRT ships reusable handlers in
-   `smrt-users` (issue #1748); anytown's dashboard is the reference
-   implementation until then.
-6. **Toolchain** — Kotlin 2.2.21 / AGP 8.13.1 / compileSdk 36 / minSdk 26 /
-   JVM 21 / iOS deployment target 17.0 (reporter-proven set, amaru catalog
-   structure).
+   `smrt-users` (issue #1748); app-owned bootstrap data is nested under the
+   contract's `extras` field.
+6. **Toolchain** — Kotlin 2.4.0 / AGP 9.2.1 / Gradle 9.6.1 / compileSdk 36 /
+   minSdk 26 / JVM 21 / iOS deployment target 17.0. The Compose package pins
+   Compose BOM 2026.06.01 and Activity Compose 1.13.0.
 
 ## Building
 
@@ -47,7 +48,7 @@ pnpm validate:shell     # structure checks (what CI runs on every PR)
 ```
 
 Toolchain requirements: run Gradle on a JDK between 17 and 24 (the module's
-language/toolchain level is 21 — `jvmToolchain(21)`); Gradle 8.14.4 ships via
+language/toolchain level is 21 -- `jvmToolchain(21)`); Gradle 9.6.1 ships via
 the checked-in wrapper, so always invoke `./gradlew`. `androidTarget` needs an
 Android SDK (`ANDROID_HOME`); the `jvm` target exists precisely so common
 logic tests run without one. iOS targets require a macOS host with Xcode.
@@ -55,16 +56,75 @@ logic tests run without one. iOS targets require a macOS host with Xcode.
 ## Consuming (v0, local filesystem)
 
 Distribution is deferred (decision 2). Android/KMP consumers use a Gradle
-composite build from a sibling checkout:
+composite build. Resolve the SMRT checkout from a Gradle property first, an
+environment variable second, and a sibling checkout as the local default:
 
 ```kotlin
 // settings.gradle.kts of the consuming app
-includeBuild("../smrt/packages/smrt-mobile")
+val smrtFoundationDir = providers.gradleProperty("smrtFoundationDir")
+    .orElse(providers.environmentVariable("SMRT_FOUNDATION_DIR"))
+    .orElse("../smrt")
+    .get()
+val smrtFoundation = file(smrtFoundationDir)
+
+includeBuild(smrtFoundation.resolve("packages/smrt-mobile"))
+// Include this only when consuming the Compose package.
+includeBuild(smrtFoundation.resolve("packages/smrt-android"))
 ```
 
-then depend on `com.happyvertical.smrt:smrt-mobile`. iOS apps link the
-`SmrtMobile` static framework produced by the iOS targets (wired end-to-end
-in Phase 6, #1743).
+Then depend on `com.happyvertical.smrt:smrt-mobile` and, when needed,
+`com.happyvertical.smrt:smrt-android`. Do not hard-code workstation-absolute
+paths in a consuming repository. AGP 9 provides built-in Kotlin, so Android
+consumers must not apply `org.jetbrains.kotlin.android`; they must also request
+`TargetJvmEnvironment.ANDROID` on resolvable configurations. The complete
+snippet is in [`smrt-android`'s README](../smrt-android/README.md).
+
+CI checks out both repositories and points Gradle at the foundation checkout:
+
+```yaml
+- uses: actions/checkout@v4
+- uses: actions/checkout@v4
+  with:
+    repository: happyvertical/smrt
+    ref: ${{ vars.SMRT_FOUNDATION_REF }} # Set to an immutable release tag.
+    path: smrt-foundation
+    token: ${{ secrets.FOUNDATION_REPO_TOKEN }}
+- run: ./gradlew test
+  env:
+    SMRT_FOUNDATION_DIR: ${{ github.workspace }}/smrt-foundation
+```
+
+For a private cross-organization checkout, `FOUNDATION_REPO_TOKEN` must be a
+GitHub App token or fine-grained PAT with read access to `happyvertical/smrt`.
+Set the `SMRT_FOUNDATION_REF` repository variable to the exact release tag the
+consumer has validated.
+iOS apps link the `SmrtMobile` static framework produced by the iOS targets
+(wired end-to-end in Phase 6, #1743).
+
+## Shared presenter state
+
+Put cross-platform orchestration in a KMP presenter derived from
+`MobileStatePresenter<T>`. Compose collects `presenter.state` as a normal
+`StateFlow`; SwiftUI owns a `MobileObservableState(holder:)` from `SmrtIos`
+and reads its published `value`. Close presenters when their owning scope is
+destroyed, and call `close()` on an adapter when observation must end early.
+
+## Durable evidence multipart
+
+Queue an encoded `EvidenceMultipartUpload`, which stores form fields and
+`EvidenceAssetRef` metadata without copying media bytes into the SQLDelight
+row. Decode it inside the suspend `HttpQueueSender` mapper and call
+`toQueueHttpRequest(EvidenceByteSource { ... })`; the platform byte source
+loads each local file when the queue actually flushes. `smrt-android` ships
+`AndroidEvidenceByteSource`; `smrt-ios` ships `FoundationEvidenceByteSource`,
+whose Kotlin/Native bridge uses one bulk copy rather than per-byte calls.
+
+## Session bootstrap extensions
+
+App-domain bootstrap payloads belong inside `MobileSessionBootstrap.extras`.
+Configure them with `createMobileAuthHandlers({ buildExtras })` on the server.
+Unknown top-level fields such as `dashboard` are outside the contract and are
+ignored by the Kotlin decoder, so they cannot be used as an extension point.
 
 ## Layout
 
@@ -74,7 +134,10 @@ in Phase 6, #1743).
   `pnpm --filter @happyvertical/smrt-mobile-contract generate:framework`.
 - `.../i18n/` — `PackTextResolver` (requested → fallback → source locale).
 - `.../packs/` — pack snapshot identity + SHA-256 integrity seal.
-- `.../evidence/` — evidence asset refs, geo sidecar, capture adapter seam.
+- `.../evidence/` — evidence asset refs, geo sidecar, capture adapter seam,
+  and durable multipart payload/byte-source helpers.
+- `.../state/` — shared `StateFlow` holder and presenter base for Compose and
+  SwiftUI observation.
 - `.../shell/` — `MobileShellState` manual-tab navigation state.
 - `.../platform/` — platform seams (`Sha256Hasher`).
 
@@ -85,11 +148,12 @@ in Phase 6, #1743).
   attempt cap, `uploading → pending` crash recovery, idempotency keys.
 - Phase 3 (#1740) — **landed**: PKCE/OIDC session module (`MobileSessionManager`)
   with platform browser/deep-link/secure-storage seams.
-- Phase 3.5 (#1748): `/api/mobile` server handlers in `smrt-users`.
+- Phase 3.5 (#1748) — **landed**: `/api/mobile` server handlers in
+  `smrt-users`.
 - Phase 4 (#1741) — **landed**: shared Ktor client (`MobileApiClient` +
   `HttpQueueSender`): bearer everywhere, multipart with idempotency keys,
   401 hook, queue flush end-to-end.
-- Phases 5–6 (#1742/#1743): `smrt-android` (Compose) and `smrt-ios` (SwiftUI +
-  real KMP framework wiring).
+- Phases 5–6 (#1742/#1743) — **landed**: `smrt-android` (Compose) and
+  `smrt-ios` (SwiftUI + real KMP framework wiring).
 - Phase 7 (#1744): rebuild amaru FieldOps and anytown reporter on the
   foundation — the trade-neutrality acceptance test.

--- a/packages/smrt-mobile/scripts/validate-shell.mjs
+++ b/packages/smrt-mobile/scripts/validate-shell.mjs
@@ -105,7 +105,7 @@ const SPEC = [
   },
   {
     path: `${KOTLIN_ROOT}/network/HttpQueueSender.kt`,
-    mustContain: ['class HttpQueueSender(', 'SendOutcome.Unauthorized'],
+    mustContain: ['class HttpQueueSender(', 'suspend (QueueEntry) -> QueueHttpRequest', 'SendOutcome.Unauthorized'],
   },
   {
     path: `${KOTLIN_ROOT}/i18n/PackTextResolver.kt`,
@@ -135,8 +135,25 @@ const SPEC = [
     ],
   },
   {
+    path: `${KOTLIN_ROOT}/evidence/EvidenceMultipartUpload.kt`,
+    mustContain: [
+      'fun interface EvidenceByteSource',
+      'data class EvidenceMultipartUpload(',
+      'toQueueHttpRequest',
+    ],
+  },
+  {
     path: `${KOTLIN_ROOT}/shell/MobileShell.kt`,
     mustContain: ['data class MobileShellState('],
+  },
+  {
+    path: `${KOTLIN_ROOT}/state/MobileStateHolder.kt`,
+    mustContain: [
+      'class MobileStateHolder',
+      'StateFlow',
+      'fun observe(',
+      'abstract class MobileStatePresenter',
+    ],
   },
   {
     path: `${KOTLIN_ROOT}/platform/Hashing.kt`,
@@ -170,6 +187,7 @@ const SPEC = [
       'NativeSqliteDriver',
       'fun createDatabase(',
       'fun instantFromEpochMillis(',
+      'fun byteArray(data: NSData)',
     ],
   },
   {
@@ -189,6 +207,7 @@ const SPEC = [
   { path: `${TEST_ROOT}/packs/PackIntegrityCheckTest.kt` },
   { path: `${TEST_ROOT}/shell/MobileShellStateTest.kt` },
   { path: `${TEST_ROOT}/evidence/EvidenceCaptureTest.kt` },
+  { path: `${TEST_ROOT}/state/MobileStateHolderTest.kt` },
   { path: `${TEST_ROOT}/platform/PlatformSeamsTest.kt` },
   { path: `${JVM_TEST_ROOT}/sync/DurableWriteQueueTest.kt` },
   { path: `${JVM_TEST_ROOT}/packs/DurableOfflinePackStoreTest.kt` },

--- a/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/contract/MobileAuthContract.kt
+++ b/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/contract/MobileAuthContract.kt
@@ -11,8 +11,10 @@ import kotlinx.serialization.json.JsonObject
  *
  * The server owns the OIDC/PKCE exchange: `auth/start` returns the
  * authorization URL plus the `state`/`codeVerifier` the client must persist
- * and echo back on `auth/complete`. Reference implementation: anytown
- * dashboard; SMRT-shipped handlers are tracked in issue #1748.
+ * and echo back on `auth/complete`. SMRT ships the SvelteKit handlers in
+ * @happyvertical/smrt-users (issue #1748). App-defined session bootstrap data
+ * belongs under MobileSessionBootstrap.extras; unknown top-level fields are
+ * outside this contract and are ignored by the Kotlin client.
  */
 
 @Serializable

--- a/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/evidence/EvidenceMultipartUpload.kt
+++ b/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/evidence/EvidenceMultipartUpload.kt
@@ -1,0 +1,57 @@
+package com.happyvertical.smrt.mobile.evidence
+
+import com.happyvertical.smrt.mobile.network.MobileUploadPart
+import com.happyvertical.smrt.mobile.network.QueueHttpRequest
+import kotlinx.serialization.Serializable
+
+/**
+ * Platform seam for loading captured evidence bytes at queue-flush time.
+ *
+ * Implementations should use the platform's efficient whole-file read for
+ * [EvidenceAssetRef.localUri] or [EvidenceAssetRef.relativePath]. This avoids
+ * storing media bytes in the durable queue row while still letting
+ * `HttpQueueSender` build multipart requests when connectivity returns.
+ */
+fun interface EvidenceByteSource {
+    suspend fun readBytes(asset: EvidenceAssetRef): ByteArray
+}
+
+@Serializable
+data class EvidenceMultipartAsset(
+    val asset: EvidenceAssetRef,
+    val fieldName: String = "file",
+)
+
+/**
+ * Serializable queue payload for a durable evidence/media multipart upload.
+ * Apps store this as a queue entry payload, then decode it in the sender mapper
+ * and call [toQueueHttpRequest] with their platform byte source.
+ */
+@Serializable
+data class EvidenceMultipartUpload(
+    val path: String,
+    val fields: Map<String, String> = emptyMap(),
+    val assets: List<EvidenceMultipartAsset> = emptyList(),
+) {
+    suspend fun toQueueHttpRequest(byteSource: EvidenceByteSource): QueueHttpRequest.Multipart =
+        QueueHttpRequest.Multipart(
+            path = path,
+            fields = fields,
+            files = assets.map { part ->
+                part.asset.toMobileUploadPart(
+                    fieldName = part.fieldName,
+                    bytes = byteSource.readBytes(part.asset),
+                )
+            },
+        )
+}
+
+fun EvidenceAssetRef.toMobileUploadPart(
+    bytes: ByteArray,
+    fieldName: String = "file",
+): MobileUploadPart = MobileUploadPart(
+    fileName = fileName,
+    contentType = contentType,
+    bytes = bytes,
+    fieldName = fieldName,
+)

--- a/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/evidence/EvidenceMultipartUpload.kt
+++ b/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/evidence/EvidenceMultipartUpload.kt
@@ -33,17 +33,22 @@ data class EvidenceMultipartUpload(
     val fields: Map<String, String> = emptyMap(),
     val assets: List<EvidenceMultipartAsset> = emptyList(),
 ) {
-    suspend fun toQueueHttpRequest(byteSource: EvidenceByteSource): QueueHttpRequest.Multipart =
-        QueueHttpRequest.Multipart(
-            path = path,
-            fields = fields,
-            files = assets.map { part ->
+    suspend fun toQueueHttpRequest(byteSource: EvidenceByteSource): QueueHttpRequest.Multipart {
+        val files = mutableListOf<MobileUploadPart>()
+        for (part in assets) {
+            files.add(
                 part.asset.toMobileUploadPart(
                     fieldName = part.fieldName,
                     bytes = byteSource.readBytes(part.asset),
                 )
-            },
+            )
+        }
+        return QueueHttpRequest.Multipart(
+            path = path,
+            fields = fields,
+            files = files,
         )
+    }
 }
 
 fun EvidenceAssetRef.toMobileUploadPart(

--- a/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/network/HttpQueueSender.kt
+++ b/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/network/HttpQueueSender.kt
@@ -48,7 +48,7 @@ sealed interface QueueHttpRequest {
  */
 class HttpQueueSender(
     private val client: MobileApiClient,
-    private val requestForEntry: (QueueEntry) -> QueueHttpRequest,
+    private val requestForEntry: suspend (QueueEntry) -> QueueHttpRequest,
 ) : QueueSender {
     override suspend fun send(entry: QueueEntry): SendOutcome {
         val response = try {

--- a/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/state/MobileStateHolder.kt
+++ b/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/state/MobileStateHolder.kt
@@ -1,0 +1,119 @@
+package com.happyvertical.smrt.mobile.state
+
+import kotlin.concurrent.Volatile
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Shared presenter state holder for apps that move orchestration into KMP.
+ *
+ * Compose can collect [state] directly. SwiftUI should observe this through the
+ * smrt-ios adapter, which uses [observe] instead of requiring each app to learn
+ * Kotlin/Native Flow collection details.
+ */
+open class MobileStateHolder<T : Any>(
+    initialState: T,
+    coroutineContext: CoroutineContext = Dispatchers.Default,
+) {
+    private val rootJob = SupervisorJob(coroutineContext[Job])
+    private val scope = CoroutineScope(coroutineContext + rootJob)
+    private val mutableState = MutableStateFlow(initialState)
+
+    @Volatile
+    private var closed = false
+
+    val state: StateFlow<T> = mutableState.asStateFlow()
+
+    val value: T
+        get() = mutableState.value
+
+    fun set(next: T): T {
+        ensureOpen()
+        mutableState.value = next
+        return next
+    }
+
+    fun update(reducer: (T) -> T): T {
+        ensureOpen()
+        var updated = value
+        mutableState.update { current ->
+            reducer(current).also { updated = it }
+        }
+        return updated
+    }
+
+    fun observe(
+        observer: MobileStateObserver,
+        emitCurrent: Boolean = true,
+    ): MobileStateSubscription {
+        ensureOpen()
+        val flow = if (emitCurrent) state else state.drop(1)
+        val job = scope.launch {
+            flow.collect { next -> observer.onState(next) }
+        }
+        return MobileStateSubscription(job)
+    }
+
+    open fun close() {
+        if (closed) return
+        closed = true
+        scope.cancel()
+    }
+
+    private fun ensureOpen() {
+        check(!closed && rootJob.isActive) { "MobileStateHolder is closed" }
+    }
+}
+
+/**
+ * Type-erased observer for Kotlin/Native export. The smrt-ios adapter casts the
+ * received value to the Swift generic state type before publishing it.
+ */
+fun interface MobileStateObserver {
+    fun onState(value: Any?)
+}
+
+class MobileStateSubscription internal constructor(private val job: Job) {
+    val isActive: Boolean
+        get() = job.isActive
+
+    fun close() {
+        job.cancel()
+    }
+}
+
+/**
+ * Base class for shared presenters/view-models. Apps put orchestration methods
+ * on subclasses and expose [holder] to platform UI.
+ */
+abstract class MobileStatePresenter<T : Any>(
+    initialState: T,
+    coroutineContext: CoroutineContext = Dispatchers.Default,
+) {
+    val holder: MobileStateHolder<T> = MobileStateHolder(initialState, coroutineContext)
+
+    val state: StateFlow<T>
+        get() = holder.state
+
+    val value: T
+        get() = holder.value
+
+    protected fun setState(next: T): T = holder.set(next)
+
+    protected fun updateState(reducer: (T) -> T): T = holder.update(reducer)
+
+    open fun close() {
+        holder.close()
+    }
+}

--- a/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/state/MobileStateHolder.kt
+++ b/packages/smrt-mobile/src/commonMain/kotlin/com/happyvertical/smrt/mobile/state/MobileStateHolder.kt
@@ -3,6 +3,7 @@ package com.happyvertical.smrt.mobile.state
 import kotlin.concurrent.Volatile
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -59,7 +60,7 @@ open class MobileStateHolder<T : Any>(
     ): MobileStateSubscription {
         ensureOpen()
         val flow = if (emitCurrent) state else state.drop(1)
-        val job = scope.launch {
+        val job = scope.launch(start = CoroutineStart.UNDISPATCHED) {
             flow.collect { next -> observer.onState(next) }
         }
         return MobileStateSubscription(job)

--- a/packages/smrt-mobile/src/commonTest/kotlin/com/happyvertical/smrt/mobile/evidence/EvidenceCaptureTest.kt
+++ b/packages/smrt-mobile/src/commonTest/kotlin/com/happyvertical/smrt/mobile/evidence/EvidenceCaptureTest.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
 
 class EvidenceCaptureTest {
     @Test
@@ -63,5 +64,34 @@ class EvidenceCaptureTest {
 
         assertEquals("p-1", request.contextIds["projectId"])
         assertEquals(EvidenceCaptureSource.CAMERA, request.preferredSource)
+    }
+
+    @Test
+    fun multipartUploadLoadsEvidenceBytesAtFlushTime() = runTest {
+        val asset = EvidenceAssetRef(
+            assetId = "asset-1",
+            localUri = "file:///data/evidence/asset-1.jpg",
+            fileName = "asset-1.jpg",
+            contentType = "image/jpeg",
+            sha256 = "deadbeef",
+        )
+        val upload = EvidenceMultipartUpload(
+            path = "captures",
+            fields = mapOf("clientCaptureId" to "capture-1"),
+            assets = listOf(EvidenceMultipartAsset(asset, fieldName = "photo")),
+        )
+
+        val request = upload.toQueueHttpRequest(
+            EvidenceByteSource { requested ->
+                assertEquals(asset.localUri, requested.localUri)
+                "image-bytes".encodeToByteArray()
+            },
+        )
+
+        assertEquals("captures", request.path)
+        assertEquals("capture-1", request.fields["clientCaptureId"])
+        assertEquals("photo", request.files.single().fieldName)
+        assertEquals("asset-1.jpg", request.files.single().fileName)
+        assertTrue(request.files.single().bytes.contentEquals("image-bytes".encodeToByteArray()))
     }
 }

--- a/packages/smrt-mobile/src/commonTest/kotlin/com/happyvertical/smrt/mobile/state/MobileStateHolderTest.kt
+++ b/packages/smrt-mobile/src/commonTest/kotlin/com/happyvertical/smrt/mobile/state/MobileStateHolderTest.kt
@@ -53,6 +53,21 @@ class MobileStateHolderTest {
     }
 
     @Test
+    fun skipInitialObservationDoesNotDropImmediateUpdate() = runTest {
+        val holder = MobileStateHolder("initial", StandardTestDispatcher(testScheduler))
+        val seen = mutableListOf<String>()
+
+        holder.observe(
+            MobileStateObserver { value -> seen.add(value as String) },
+            emitCurrent = false,
+        )
+        holder.set("next")
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(listOf("next"), seen)
+    }
+
+    @Test
     fun parentCancellationStopsObservation() = runTest {
         val parent = Job()
         val holder = MobileStateHolder(

--- a/packages/smrt-mobile/src/commonTest/kotlin/com/happyvertical/smrt/mobile/state/MobileStateHolderTest.kt
+++ b/packages/smrt-mobile/src/commonTest/kotlin/com/happyvertical/smrt/mobile/state/MobileStateHolderTest.kt
@@ -1,0 +1,86 @@
+package com.happyvertical.smrt.mobile.state
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+class MobileStateHolderTest {
+    @Test
+    fun observesCurrentStateAndUpdates() = runTest {
+        val holder = MobileStateHolder(0, StandardTestDispatcher(testScheduler))
+        val seen = mutableListOf<Int>()
+
+        val subscription = holder.observe(
+            MobileStateObserver { value -> seen.add(value as Int) },
+        )
+        testScheduler.advanceUntilIdle()
+
+        holder.set(1)
+        testScheduler.advanceUntilIdle()
+        holder.update { current -> current + 1 }
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(listOf(0, 1, 2), seen)
+        assertTrue(subscription.isActive)
+
+        subscription.close()
+        holder.set(3)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(listOf(0, 1, 2), seen)
+        assertFalse(subscription.isActive)
+    }
+
+    @Test
+    fun canSkipInitialEmission() = runTest {
+        val holder = MobileStateHolder("initial", StandardTestDispatcher(testScheduler))
+        val seen = mutableListOf<String>()
+
+        holder.observe(
+            MobileStateObserver { value -> seen.add(value as String) },
+            emitCurrent = false,
+        )
+        testScheduler.advanceUntilIdle()
+        holder.set("next")
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(listOf("next"), seen)
+    }
+
+    @Test
+    fun parentCancellationStopsObservation() = runTest {
+        val parent = Job()
+        val holder = MobileStateHolder(
+            0,
+            StandardTestDispatcher(testScheduler) + parent,
+        )
+        val subscription = holder.observe(MobileStateObserver {})
+        testScheduler.advanceUntilIdle()
+
+        parent.cancel()
+        testScheduler.advanceUntilIdle()
+
+        assertFalse(subscription.isActive)
+        assertFailsWith<IllegalStateException> { holder.set(1) }
+    }
+
+    @Test
+    fun presenterSubclassesMutateSharedState() {
+        val presenter = CounterPresenter()
+
+        assertEquals(1, presenter.increment())
+        assertEquals(1, presenter.value)
+
+        presenter.close()
+        assertFailsWith<IllegalStateException> { presenter.increment() }
+    }
+
+    private class CounterPresenter : MobileStatePresenter<Int>(0) {
+        fun increment(): Int = updateState { current -> current + 1 }
+    }
+}

--- a/packages/smrt-mobile/src/iosMain/kotlin/com/happyvertical/smrt/mobile/platform/SmrtMobileIos.kt
+++ b/packages/smrt-mobile/src/iosMain/kotlin/com/happyvertical/smrt/mobile/platform/SmrtMobileIos.kt
@@ -9,7 +9,12 @@ import com.happyvertical.smrt.mobile.network.UnauthorizedHandler
 import com.happyvertical.smrt.mobile.packs.DurableOfflinePackStore
 import com.happyvertical.smrt.mobile.sync.DurableWriteQueue
 import io.ktor.client.engine.darwin.Darwin
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
 import kotlinx.datetime.Instant
+import platform.Foundation.NSData
+import platform.posix.memcpy
 
 /**
  * iOS platform factories the exported `SmrtMobile` framework hands to Swift
@@ -85,6 +90,25 @@ object SmrtMobileIos {
      */
     fun instantFromEpochMillis(epochMillis: Long): Instant =
         Instant.fromEpochMilliseconds(epochMillis)
+
+    /**
+     * Copies Foundation data into a Kotlin byte array with one native memcpy.
+     * Swift evidence byte sources use this instead of setting KotlinByteArray
+     * one element at a time across the Objective-C bridge.
+     */
+    @OptIn(ExperimentalForeignApi::class)
+    fun byteArray(data: NSData): ByteArray {
+        require(data.length <= Int.MAX_VALUE.toULong()) {
+            "Evidence file is too large for an in-memory multipart request"
+        }
+        val result = ByteArray(data.length.toInt())
+        if (result.isNotEmpty()) {
+            result.usePinned { pinned ->
+                memcpy(pinned.addressOf(0), data.bytes, data.length)
+            }
+        }
+        return result
+    }
 
     const val DEFAULT_DATABASE_NAME: String = "smrt_mobile.db"
 }

--- a/packages/smrt-mobile/src/jvmTest/kotlin/com/happyvertical/smrt/mobile/network/QueueFlushIntegrationTest.kt
+++ b/packages/smrt-mobile/src/jvmTest/kotlin/com/happyvertical/smrt/mobile/network/QueueFlushIntegrationTest.kt
@@ -2,15 +2,22 @@ package com.happyvertical.smrt.mobile.network
 
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.happyvertical.smrt.mobile.db.SmrtMobileDatabase
+import com.happyvertical.smrt.mobile.evidence.EvidenceAssetRef
+import com.happyvertical.smrt.mobile.evidence.EvidenceByteSource
+import com.happyvertical.smrt.mobile.evidence.EvidenceMultipartAsset
+import com.happyvertical.smrt.mobile.evidence.EvidenceMultipartUpload
 import com.happyvertical.smrt.mobile.sync.DurableWriteQueue
 import com.happyvertical.smrt.mobile.sync.NewQueueEntry
 import com.happyvertical.smrt.mobile.sync.QueueEntryState
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -27,7 +34,10 @@ class QueueFlushIntegrationTest {
         return DurableWriteQueue(SmrtMobileDatabase(driver))
     }
 
-    private fun sender(engine: MockEngine): HttpQueueSender {
+    private fun sender(
+        engine: MockEngine,
+        byteSource: EvidenceByteSource = EvidenceByteSource { "img".encodeToByteArray() },
+    ): HttpQueueSender {
         val client = MobileApiClient(
             engine = engine,
             config = MobileApiConfig(baseUrl = "https://app.example.com"),
@@ -35,17 +45,8 @@ class QueueFlushIntegrationTest {
         )
         return HttpQueueSender(client) { entry ->
             if (entry.kind == "evidence") {
-                QueueHttpRequest.Multipart(
-                    path = "contributions",
-                    fields = mapOf("eventId" to "event-1"),
-                    files = listOf(
-                        MobileUploadPart(
-                            fileName = "asset.jpg",
-                            contentType = "image/jpeg",
-                            bytes = "img".encodeToByteArray(),
-                        ),
-                    ),
-                )
+                Json.decodeFromString<EvidenceMultipartUpload>(entry.payload)
+                    .toQueueHttpRequest(byteSource)
             } else {
                 QueueHttpRequest.JsonPost("plays")
             }
@@ -58,10 +59,32 @@ class QueueFlushIntegrationTest {
             respond("""{"id":"c1"}""", HttpStatusCode.Created, headersOf(HttpHeaders.ContentType, "application/json"))
         }
         val queue = newQueue()
+        val asset = EvidenceAssetRef(
+            assetId = "asset-1",
+            localUri = "file:///data/evidence/asset.jpg",
+            fileName = "asset.jpg",
+            contentType = "image/jpeg",
+        )
+        val evidencePayload = Json.encodeToString(
+            EvidenceMultipartUpload(
+                path = "contributions",
+                fields = mapOf("eventId" to "event-1"),
+                assets = listOf(EvidenceMultipartAsset(asset)),
+            ),
+        )
+        var loadedAssetId: String? = null
         queue.enqueue(NewQueueEntry(id = "e1", kind = "play", payload = """{"statKey":"goal"}"""))
-        queue.enqueue(NewQueueEntry(id = "e2", kind = "evidence", payload = """{"eventId":"event-1"}"""))
+        queue.enqueue(NewQueueEntry(id = "e2", kind = "evidence", payload = evidencePayload))
 
-        val summary = queue.flush(sender(engine))
+        val summary = queue.flush(
+            sender(
+                engine,
+                EvidenceByteSource { requested ->
+                    loadedAssetId = requested.assetId
+                    "bytes-loaded-at-flush".encodeToByteArray()
+                },
+            ),
+        )
 
         assertEquals(2, summary.sent)
         assertTrue(queue.all().isEmpty())
@@ -71,6 +94,10 @@ class QueueFlushIntegrationTest {
         assertTrue(
             engine.requestHistory[1].body.contentType.toString().startsWith("multipart/form-data"),
         )
+        assertEquals("asset-1", loadedAssetId)
+        val multipartBody = engine.requestHistory[1].body.toByteArray().decodeToString()
+        assertTrue(multipartBody.contains("filename=\"asset.jpg\""))
+        assertTrue(multipartBody.contains("bytes-loaded-at-flush"))
     }
 
     @Test

--- a/packages/users/AGENTS.md
+++ b/packages/users/AGENTS.md
@@ -180,6 +180,9 @@ the package root).
 - **Hooks**: `resolveUser` (invite-gating; default provisions via
   `getOrCreateFromOidc`), `resolveTenantId`, `buildExtras` (bootstrap
   `extras`; model JSON must use `toPublicJSON({ permissions })` — #1822).
+  `buildExtras` is the only app-domain bootstrap extension point. Never emit
+  app fields such as `dashboard` at the response top level: they are outside
+  `MobileSessionBootstrap` and the Kotlin decoder ignores them.
 - **Guard** wraps `withSessionPermissionContext`, so
   `assertOperationPermission`, tenancy context, and Postgres RLS all see the
   bearer caller; `OperationPermissionError` maps to 403 with a

--- a/packages/users/README.md
+++ b/packages/users/README.md
@@ -495,7 +495,16 @@ TenantService supports three modes: `flexible` (no auto-create), `personal` (aut
 | `switchSessionTenant` | Change tenant context for current session |
 | `beginOidcLogin`, `completeOidcLogin` | Low-level SvelteKit helpers for custom OIDC login routes |
 | `createOidcLoginHandler`, `createOidcCallbackHandler` | Ready-to-use SvelteKit route handlers for OIDC login and callback |
+| `createMobileAuthHandlers` | Mountable `/api/mobile` PKCE, bearer session, bootstrap, logout, and route-guard handlers |
+| `resolveMobileUploadDedupKey` | Resolves `clientCaptureId` with `Idempotency-Key` fallback for app-owned multipart routes |
 | `SessionLocals` | Type for `event.locals` (extend in `app.d.ts`) |
+
+`createMobileAuthHandlers({ buildExtras })` places app-domain bootstrap data
+under `MobileSessionBootstrap.extras`. Do not add app fields at the response
+top level: they are outside the shared contract and the Kotlin client ignores
+unknown top-level keys. Multipart ingestion remains app-owned; follow
+[`mobile-upload-contract.md`](../../docs/content/architecture/mobile-upload-contract.md)
+for authentication, deduplication, and status semantics.
 
 ### Types & Constants
 


### PR DESCRIPTION
## Summary

- add a lifecycle-aware shared KMP presenter/state holder and a SwiftUI `ObservableObject` bridge
- add a durable evidence multipart payload plus Android/iOS byte sources, including bulk Kotlin/Native copying on iOS
- make `HttpQueueSender` entry mapping suspend so evidence bytes load at queue flush time
- document cross-repository composite builds, the `MobileSessionBootstrap.extras` extension contract, and the shipped Kotlin/AGP/Gradle toolchain

## Why

The Phase 7 acceptance work exposed a cluster of related adoption gaps: orchestration state still had to be duplicated per platform, durable queue rows could not reconstruct multipart media efficiently, external repositories lacked a stable source-consumption recipe, and the session/toolchain documentation no longer matched the shipped contract.

These changes keep downstream reporter/amaru migration out of scope while making the shared foundation sufficient for that migration.

## Impact

Compose can observe shared presenter `StateFlow` directly, while SwiftUI uses `MobileObservableState`. Durable evidence entries retain only serializable file references and load bytes when flushing. External consumers get a CI-safe composite-build recipe, and server authors have one documented bootstrap extension point under `extras`.

## Validation

- `./gradlew jvmTest --console=plain` (`smrt-mobile`)
- full Android Gradle build, unit tests, and lint (JDK 21 / SDK 36)
- `pnpm --filter @happyvertical/smrt-ios validate:ios:native` (framework link, Swift typecheck, simulator build, 19 XCTest cases)
- `pnpm --filter @happyvertical/smrt-mobile-contract build`
- 37 `smrt-mobile-contract` tests
- 35 `smrt-users` mobile auth-handler tests
- structural package validators and strict knowledge freshness

Closes #1893
Closes #1894
Closes #1895
Closes #1896
Closes #1897