### PR TITLE
feat(chat): add voice dev workbench

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
       "@happyvertical/projects": "^0.78.0",
       "@happyvertical/repos": "^0.78.0",
       "@happyvertical/secrets": "^0.78.0",
+      "@happyvertical/speech": "^0.78.0",
       "@happyvertical/spider": "^1.1.10",
       "@happyvertical/sql": "^0.78.0",
       "@happyvertical/utils": "^0.78.0",

--- a/packages/chat/AGENTS.md
+++ b/packages/chat/AGENTS.md
@@ -2,11 +2,26 @@
 
 Chat rooms, threads, and agent sessions with app-controlled tool whitelisting.
 
+## Dev Server
+
+`pnpm --dir packages/chat dev` runs a package-local SvelteKit workbench. The root
+route is an interactive chat surface with a dev-only `/api/dev-chat` endpoint:
+it uses `@happyvertical/ai` when local provider credentials are present and
+falls back to a deterministic local assistant otherwise. `/previews` hosts the
+shared component playground entries from `src/svelte/playground.ts`.
+
+The root workbench also has a dev-only voice conversation mode. It reads voice
+gateway connection details through `/api/dev-voice/config`, streams browser mic
+audio to `WS /ws/voice` as PCM16 mono, appends gateway transcripts/responses to
+the chat, and plays returned TTS audio. Exposing
+`SMRT_CHAT_DEV_VOICE_GATEWAY_TOKEN` to the browser requires
+`SMRT_CHAT_DEV_VOICE_GATEWAY_EXPOSE_TOKEN=true`; keep that local-only.
+
 ## Models
 
-Internal models — all mutations go through the membership/owner-checked `ChatService` (S5 #1392). EVERY `@smrt()` model in this package (ChatRoom, ChatMessage, ChatParticipant, ChatThread, ChatReaction, AgentSession) has a READ-ONLY generated REST/MCP surface (`list`/`get` only); `create`/`update`/`delete` are intentionally NOT generated so the raw collection routes cannot skip the service-layer authorization. A structural regression test enumerates the registry to assert no chat model exposes a mutating op.
+Internal models — all mutations go through the membership/owner-checked `ChatService` (S5 #1392) or the voice adapter's binding-checked flow. EVERY `@smrt()` model in this package (ChatRoom, ChatMessage, ChatParticipant, ChatThread, ChatReaction, AgentSession, VoiceSession) has a READ-ONLY generated REST/MCP surface (`list`/`get` only); `create`/`update`/`delete` are intentionally NOT generated so the raw collection routes cannot skip the service-layer authorization. A structural regression test enumerates the registry to assert no chat model exposes a mutating op.
 
-`ChatService` is a CLOSED FACADE (S5 #1392). The raw collections (`rooms`, `messages`, `participants`, `threads`, `agentSessions`, `reactions`) are ES `#private` fields — they are NOT on the public `ChatService` type and the package index does NOT export the collection classes, so a consumer cannot do `chat.messages.create({senderProfileId, role})` / `new ChatParticipantCollection(...)` to mutate around the authorization. The security-sensitive internals (`#writeMessage`, `#emitAgentReply`, `#enrollParticipant`, `#loadActiveSession`, `#requireActiveMembership`, `#requireRoomAdmin`, `#extractToolName`) are ES `#private` too, so they are unreachable at runtime — TypeScript `private` alone is erased and would leave them callable on the prototype. The agent-reply bridge is a `Symbol`-keyed static (not the old enumerable `_runAgentReply`), reachable only by the module-local `sendAgentReply` that holds the non-exported symbol.
+`ChatService` is a CLOSED FACADE (S5 #1392). The raw collections (`rooms`, `messages`, `participants`, `threads`, `agentSessions`, `reactions`, `voiceSessions`) are ES `#private` fields — they are NOT on the public `ChatService` type and the package index does NOT export the collection classes, so a consumer cannot do `chat.messages.create({senderProfileId, role})` / `new ChatParticipantCollection(...)` to mutate around the authorization. The security-sensitive internals (`#writeMessage`, `#emitAgentReply`, `#enrollParticipant`, `#loadActiveSession`, `#requireActiveMembership`, `#requireRoomAdmin`, `#extractToolName`) are ES `#private` too, so they are unreachable at runtime — TypeScript `private` alone is erased and would leave them callable on the prototype. The agent-reply bridge is a `Symbol`-keyed static (not the old enumerable `_runAgentReply`), reachable only by the module-local `sendAgentReply` that holds the non-exported symbol.
 
 - **ChatRoom**: `roomType` (public/private/dm/agent), `status`, `topic`, `maxParticipants`, `lastMessageAt`. Tenant-scoped (required).
 - **ChatMessage**: shared by users + agents. `role` (user/assistant/system/tool), `messageType` (text/system/action/file/tool_call/tool_result), `toolCallData` JSON. Unified model — no separate agent message type. Tenant-scoped (required).
@@ -14,6 +29,7 @@ Internal models — all mutations go through the membership/owner-checked `ChatS
 - **ChatThread**: `rootMessageId`, `isResolved`, `messageCount`. Created via `ChatService.startThread()` (member-checked). Tenant-scoped (required).
 - **ChatReaction**: `messageId`, `profileId`, `emoji`. Added/removed via `ChatService.addReaction()`/`removeReaction()` (member-checked, self-keyed). Tenant-scoped (required).
 - **AgentSession**: `agentId` (string ref, not FK), `allowedTools` (JSON string array), `sessionContext` (JSON), `systemPrompt`, limits (`maxTokens`/`maxMessages`/`expiresAt`). Optional tenancy.
+- **VoiceSession**: short-lived voice-gateway binding over `(tenant, actorProfileId, personaId, room/thread/agentSession)` plus a persona snapshot, gateway `session_id`, expiry, replay tracking, and metadata. Tenant-scoped (required). Generated surface is read-only; creation and turns go through `createVoiceChatSession()` / `handleVoiceGatewayTurn()`.
 
 ## ChatService
 
@@ -33,6 +49,12 @@ The "chat with your learning agent" surface — the real agentic runtime for `Ag
 - **`runPersonaConversationTurn(options)`** (`persona-conversation.ts`) — binds a conversation to an `AgentPersona`/`ResolvedPersona`: runs as its principal (`runAsUserId`), offers only its `allowedTools`, speaks its instructions (`resolvePersonaInstructions`, layering approved learned directives), and injects its **recalled learning memory** (`personaLearningMemory`, isolated per `memoryScope`) into the system prompt. `bindPersonaToSession()` mirrors the persona's `allowedTools`/instructions onto the `AgentSession` so the chat authoring gate agrees with the loop's offer gate. Authors the reply (and each executed tool) via the internal `sendAgentReply` bridge.
 - **Agent orchestration** (L3, #1892) — the loop accepts non-manifest **`extraTools`** (`PrincipalTool[]`, from `@happyvertical/smrt-agents`), gated by the *same* fail-closed allow-list. The standard **`invoke-agent`** tool (`createInvokeAgentTool`, slug `agents.invoke`) lets a conversational agent delegate to a **worker agent under its own principal** — the worker runs via `executeAsPrincipal` as the originating user (never its own authority), the principal is immutable along the chain, and its completion is surfaced back into the conversation. `runPersonaConversationTurn` filters `extraTools` by the persona's `allowedTools` (offer gate); the tool's `execute` re-asserts `assertToolAllowed` (execution gate). See `@happyvertical/smrt-agents` for the delegation envelope + transports.
 - **Chat feedback capture** (`chat-feedback.ts`) — `captureChatFeedback()` + `acceptAppliedChange`/`rejectAppliedChange`/`correctResponse`/`rateResponse`/`thumbsUp`/`thumbsDown` write a `Feedback` row (personas) carrying the conversation's **correlation-id**, and (by default) reinforce the persona's learning memory (`reinforceFromFeedback`). So an in-chat reject decays a strategy below the reuse floor and it stops being recalled; a correction supersedes its stored value.
+
+## Voice Gateway Turns (#1910)
+
+Voice is an input mode for the existing persona chat harness, not a separate chat runtime. `createVoiceChatSession()` creates a short-lived `VoiceSession` for an authenticated actor/profile, binding tenant, persona, agent session, room, and optional thread. `handleVoiceGatewayTurn()` resolves that binding from `metadata.voiceSessionId`, checks the gateway's `session_id` and any supplied tenant/profile/persona/session/thread metadata against the server-side binding, persists the transcript through `ChatService.sendAgentUserMessage()`, runs `runPersonaConversationTurn()`, stamps voice/correlation metadata onto the persisted user/assistant/tool messages, records the gateway `turn_id`, and returns the gateway response contract. The Fetch-compatible `createVoiceGatewayTurnHandler()` adds the coarse gateway bearer-token check.
+
+The gateway bearer token proves only "this request came from the gateway"; it never authorizes the end user. The short-lived `VoiceSession` binding is the user/session proof, and untrusted gateway metadata must be validated against that binding before any chat write or tool loop. Tool execution remains fail-closed through the persona allow-list mirrored onto `AgentSession` by `bindPersonaToSession()`.
 
 ## Gotchas
 

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -10,6 +10,30 @@ pnpm add @happyvertical/smrt-chat
 
 ## Usage
 
+### Local dev server
+
+Run the chat package workbench directly:
+
+```bash
+pnpm --dir packages/chat dev
+```
+
+The root route opens an interactive chat surface backed by
+`src/routes/api/dev-chat/+server.ts`. If `SMRT_CHAT_DEV_PROVIDER` /
+`SMRT_CHAT_DEV_API_KEY` or standard provider credentials such as
+`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `GEMINI_API_KEY` are available, the
+assistant turn goes through `@happyvertical/ai`; otherwise it uses a
+deterministic local fallback. Component previews are available at `/previews`.
+
+The workbench also has a local-only voice conversation mode. It reads
+`SMRT_CHAT_DEV_VOICE_GATEWAY_HTTP_URL` and
+`SMRT_CHAT_DEV_VOICE_GATEWAY_WS_URL`, fetches gateway targets from
+`/api/dev-voice/config`, streams browser microphone audio to `WS /ws/voice` as
+PCM16 mono at 16 kHz, appends gateway transcripts/responses to the chat, and
+plays returned TTS audio. If the gateway requires a bearer token, set
+`SMRT_CHAT_DEV_VOICE_GATEWAY_TOKEN`; browser WebSocket testing also requires
+`SMRT_CHAT_DEV_VOICE_GATEWAY_EXPOSE_TOKEN=true`, so use this only for local dev.
+
 ### Rooms and messages
 
 ```typescript
@@ -104,6 +128,93 @@ if (session.isActive()) {
 }
 ```
 
+### Voice gateway turns
+
+`smrt-chat` can expose a gateway-facing turn target for browser voice input.
+The browser receives only a short-lived SMRT voice session binding; the
+gateway-to-SMRT service bearer token stays server-side.
+
+```typescript
+import {
+  createVoiceChatSession,
+  createVoiceGatewayTurnHandler,
+} from '@happyvertical/smrt-chat';
+
+// Authenticated app route: bind the speaking profile to a persona and an
+// existing or newly-created agent session.
+const voice = await createVoiceChatSession({
+  chatService: chat,
+  db,
+  tenantId: locals.tenantId,
+  actorProfileId: locals.profileId,
+  actorUserId: locals.userId,
+  persona: resolvedPersona,
+  agentSessionId: session.id, // omit to create/reuse an agent session
+  ttlSeconds: 600,
+});
+
+// Return voice.gatewaySessionId + voice.metadata to the browser/gateway. Do not
+// return the gateway service token.
+
+// Gateway target route: configure the deployed voice gateway HTTP target to
+// POST here with Authorization: Bearer <SMRT_VOICE_GATEWAY_TOKEN>.
+export const POST = ({ request }) =>
+  createVoiceGatewayTurnHandler({
+    chatService: chat,
+    db,
+    ai,
+    gatewayToken: process.env.SMRT_VOICE_GATEWAY_TOKEN ?? '',
+  })(request);
+```
+
+The gateway sends the transcribed text turn:
+
+```json
+{
+  "session_id": "gateway-or-smrt-stable-session-id",
+  "turn_id": "gateway-generated-turn-id",
+  "target": "smrt:chat",
+  "actor": "optional-display-name",
+  "text": "transcribed user utterance",
+  "metadata": {
+    "tenantId": "tenant uuid",
+    "actorProfileId": "profile id",
+    "chatRoomId": "room id",
+    "threadId": "optional thread id",
+    "agentSessionId": "agent session id",
+    "personaId": "persona id",
+    "voiceSessionId": "SMRT-issued voice session id",
+    "source": "voice-gateway"
+  }
+}
+```
+
+SMRT validates `metadata.voiceSessionId` against its server-side binding, then
+checks any supplied tenant/profile/persona/session/thread ids against that
+binding instead of trusting the gateway metadata. A valid turn is persisted as a
+normal user chat message, routed through `runPersonaConversationTurn()`, and the
+assistant reply is persisted as a normal assistant message. The response is:
+
+```json
+{
+  "session_id": "same session_id",
+  "turn_id": "same turn_id",
+  "text": "assistant response text",
+  "metadata": {
+    "tenantId": "tenant id",
+    "chatRoomId": "room id",
+    "threadId": null,
+    "agentSessionId": "agent session id",
+    "userMessageId": "persisted transcript message id",
+    "assistantMessageId": "persisted assistant message id",
+    "personaId": "persona id",
+    "correlationId": "feedback correlation id",
+    "voiceSessionId": "SMRT-issued voice session id",
+    "source": "voice-gateway"
+  }
+}
+```
+
 ### Direct messages
 
 ```typescript
@@ -129,10 +240,15 @@ const dmRoom = await chat.getOrCreateDM({
 | `ChatThread` | Threaded conversation linked to a root message, with resolve/reopen lifecycle |
 | `ChatReaction` | Emoji reaction on a message |
 | `AgentSession` | AI agent session with `allowedTools` (JSON string array), `sessionContext` for multi-turn memory, `systemPrompt`, and usage limits (`maxTokens`/`maxMessages`/`expiresAt`) |
+| `VoiceSession` | Short-lived voice gateway binding over a tenant, actor profile, persona, and agent session |
 
-### Collections
+### Internal collections
 
-| Export | Description |
+Raw collection classes are not exported from the package index. They are listed
+here as implementation details; application code should use `ChatService` and
+the voice helpers.
+
+| Internal class | Description |
 |--------|------------|
 | `ChatRoomCollection` | Room queries, `findOrCreateDM()` |
 | `ChatMessageCollection` | Message queries and search filters |
@@ -140,16 +256,20 @@ const dmRoom = await chat.getOrCreateDM({
 | `ChatThreadCollection` | Thread queries |
 | `ChatReactionCollection` | Reaction queries |
 | `AgentSessionCollection` | Session queries, `findActiveSession()`, `findOrCreate()` |
+| `VoiceSessionCollection` | Voice session binding queries and stale-expiry helper |
 
 ### Services
 
 | Export | Description |
 |--------|------------|
 | `ChatService` | Facade: `createRoom()`, `sendMessage()`, `startThread()`, `addParticipant()`, `removeParticipant()`, `updateRoom()`, `addReaction()`, `removeReaction()`, `getOrCreateDM()`, `createAgentSession()`, `sendAgentUserMessage()`, `getRoomMessages()`, `getRoomForMember()`, `updateAgentSessionConfig()`. Every write takes a server-supplied `actorProfileId`. The agent-authored reply path (`sendAgentReply`) is intentionally NOT on this facade or the package index — it is an internal function in `services/ChatService.ts` for the trusted in-process agent runtime only (S5 #1392). |
+| `createVoiceChatSession()` | Creates a short-lived voice binding for an authenticated actor and persona, optionally against an existing agent session |
+| `handleVoiceGatewayTurn()` | Lower-level gateway turn adapter for non-Fetch hosts |
+| `createVoiceGatewayTurnHandler()` | Fetch-compatible HTTP handler for the gateway target endpoint |
 
 ### Types
 
-`ChatRoomType`, `ChatRoomStatus`, `ChatRoomOptions`, `ChatMessageType`, `ChatMessageRole`, `ChatMessageOptions`, `ChatMessageSearchFilters`, `ChatParticipantRole`, `ChatParticipantStatus`, `ChatParticipantOptions`, `OnlineStatus`, `ChatThreadOptions`, `ChatReactionOptions`, `AgentSessionStatus`, `AgentSessionOptions`
+`ChatRoomType`, `ChatRoomStatus`, `ChatRoomOptions`, `ChatMessageType`, `ChatMessageRole`, `ChatMessageOptions`, `ChatMessageSearchFilters`, `ChatParticipantRole`, `ChatParticipantStatus`, `ChatParticipantOptions`, `OnlineStatus`, `ChatThreadOptions`, `ChatReactionOptions`, `AgentSessionStatus`, `AgentSessionOptions`, `VoiceSessionStatus`, `VoiceSessionOptions`, `VoiceGatewayTurnPayload`, `VoiceGatewayTurnResponse`
 
 ### Constants
 

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -37,14 +37,14 @@
     "AGENTS.md"
   ],
   "scripts": {
-    "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
+    "build": "SMRT_PACKAGE_BUILD=1 vite build --mode library && SMRT_PACKAGE_BUILD=1 svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
     "build:watch": "vite build --mode library --watch",
     "clean": "rm -rf dist",
-    "dev": "npm run build:watch",
+    "dev": "vite dev",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
-    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
-    "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "svelte-kit sync && tsc -p tsconfig.typecheck.json && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.kit.json",
+    "check": "svelte-kit sync && pnpm exec svelte-check --tsconfig ./tsconfig.kit.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "keywords": [
@@ -86,8 +86,10 @@
     }
   },
   "devDependencies": {
+    "@happyvertical/smrt-playground": "workspace:*",
     "@happyvertical/smrt-profiles": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",
+    "@sveltejs/kit": "^2.69.1",
     "@sveltejs/package": "^2.5.8",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@types/node": "24.13.2",

--- a/packages/chat/src/__tests__/chat-security.test.ts
+++ b/packages/chat/src/__tests__/chat-security.test.ts
@@ -796,6 +796,7 @@ describe('chat security (S5 #1392)', () => {
       '@happyvertical/smrt-chat:ChatThread',
       '@happyvertical/smrt-chat:ChatReaction',
       '@happyvertical/smrt-chat:AgentSession',
+      '@happyvertical/smrt-chat:VoiceSession',
     ];
 
     for (const qualifiedName of internals) {
@@ -1296,6 +1297,7 @@ describe('chat security (S5 #1392)', () => {
         'threads',
         'agentSessions',
         'reactions',
+        'voiceSessions',
       ];
       for (const prop of collectionProps) {
         const value = (svc as unknown as Record<string, unknown>)[prop];
@@ -1319,6 +1321,7 @@ describe('chat security (S5 #1392)', () => {
         'ChatThreadCollection',
         'AgentSessionCollection',
         'ChatReactionCollection',
+        'VoiceSessionCollection',
       ]) {
         expect(index[exportName]).toBeUndefined();
       }

--- a/packages/chat/src/__tests__/chat-security.test.ts
+++ b/packages/chat/src/__tests__/chat-security.test.ts
@@ -796,6 +796,7 @@ describe('chat security (S5 #1392)', () => {
       '@happyvertical/smrt-chat:ChatThread',
       '@happyvertical/smrt-chat:ChatReaction',
       '@happyvertical/smrt-chat:AgentSession',
+      '@happyvertical/smrt-chat:VoiceGatewayTurn',
       '@happyvertical/smrt-chat:VoiceSession',
     ];
 
@@ -1321,6 +1322,7 @@ describe('chat security (S5 #1392)', () => {
         'ChatThreadCollection',
         'AgentSessionCollection',
         'ChatReactionCollection',
+        'VoiceGatewayTurnCollection',
         'VoiceSessionCollection',
       ]) {
         expect(index[exportName]).toBeUndefined();

--- a/packages/chat/src/__tests__/raw-collections.ts
+++ b/packages/chat/src/__tests__/raw-collections.ts
@@ -21,6 +21,7 @@ import type { ChatParticipantCollection } from '../collections/ChatParticipantCo
 import type { ChatReactionCollection } from '../collections/ChatReactionCollection.js';
 import type { ChatRoomCollection } from '../collections/ChatRoomCollection.js';
 import type { ChatThreadCollection } from '../collections/ChatThreadCollection.js';
+import type { VoiceSessionCollection } from '../collections/VoiceSessionCollection.js';
 
 export interface RawChatCollections {
   rooms: ChatRoomCollection;
@@ -29,6 +30,7 @@ export interface RawChatCollections {
   threads: ChatThreadCollection;
   agentSessions: AgentSessionCollection;
   reactions: ChatReactionCollection;
+  voiceSessions: VoiceSessionCollection;
 }
 
 /**
@@ -62,5 +64,17 @@ export async function getRawChatCollections(
     '@happyvertical/smrt-chat:ChatReaction',
     options,
   )) as ChatReactionCollection;
-  return { rooms, messages, participants, threads, agentSessions, reactions };
+  const voiceSessions = (await ObjectRegistry.getCollection(
+    '@happyvertical/smrt-chat:VoiceSession',
+    options,
+  )) as VoiceSessionCollection;
+  return {
+    rooms,
+    messages,
+    participants,
+    threads,
+    agentSessions,
+    reactions,
+    voiceSessions,
+  };
 }

--- a/packages/chat/src/app.html
+++ b/packages/chat/src/app.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>

--- a/packages/chat/src/collections/VoiceGatewayTurnCollection.ts
+++ b/packages/chat/src/collections/VoiceGatewayTurnCollection.ts
@@ -1,0 +1,20 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { VoiceGatewayTurn } from '../models/VoiceGatewayTurn.js';
+
+export class VoiceGatewayTurnCollection extends SmrtCollection<VoiceGatewayTurn> {
+  static readonly _itemClass = VoiceGatewayTurn;
+
+  async reserveTurn(input: {
+    tenantId: string;
+    voiceSessionId: string;
+    gatewaySessionId: string;
+    gatewayTurnId: string;
+    target: string;
+  }): Promise<VoiceGatewayTurn> {
+    return this.create({
+      ...input,
+      status: 'processing',
+      _insertOnly: true,
+    });
+  }
+}

--- a/packages/chat/src/collections/VoiceSessionCollection.ts
+++ b/packages/chat/src/collections/VoiceSessionCollection.ts
@@ -1,0 +1,35 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { VoiceSession } from '../models/VoiceSession.js';
+
+export class VoiceSessionCollection extends SmrtCollection<VoiceSession> {
+  static readonly _itemClass = VoiceSession;
+
+  async getActiveById(
+    id: string,
+    target = 'smrt:chat',
+  ): Promise<VoiceSession | null> {
+    const session = await this.get({ id, target });
+    if (!session?.isActive()) return null;
+    return session;
+  }
+
+  async expireStale(
+    olderThan: Date = new Date(),
+    scope?: { tenantId?: string; target?: string },
+  ): Promise<number> {
+    const where: Record<string, unknown> = {
+      status: 'active',
+      'expiresAt <': olderThan,
+    };
+    if (scope?.tenantId !== undefined) where.tenantId = scope.tenantId;
+    if (scope?.target !== undefined) where.target = scope.target;
+
+    const stale = await this.list({ where });
+    let expired = 0;
+    for (const session of stale) {
+      await session.expire();
+      expired++;
+    }
+    return expired;
+  }
+}

--- a/packages/chat/src/collections/index.ts
+++ b/packages/chat/src/collections/index.ts
@@ -4,4 +4,5 @@ export { ChatParticipantCollection } from './ChatParticipantCollection.js';
 export { ChatReactionCollection } from './ChatReactionCollection.js';
 export { ChatRoomCollection } from './ChatRoomCollection.js';
 export { ChatThreadCollection } from './ChatThreadCollection.js';
+export { VoiceGatewayTurnCollection } from './VoiceGatewayTurnCollection.js';
 export { VoiceSessionCollection } from './VoiceSessionCollection.js';

--- a/packages/chat/src/collections/index.ts
+++ b/packages/chat/src/collections/index.ts
@@ -4,3 +4,4 @@ export { ChatParticipantCollection } from './ChatParticipantCollection.js';
 export { ChatReactionCollection } from './ChatReactionCollection.js';
 export { ChatRoomCollection } from './ChatRoomCollection.js';
 export { ChatThreadCollection } from './ChatThreadCollection.js';
+export { VoiceSessionCollection } from './VoiceSessionCollection.js';

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -79,6 +79,7 @@ export {
   ChatReaction,
   ChatRoom,
   ChatThread,
+  VoiceGatewayTurn,
   VoiceSession,
 } from './models/index.js';
 export {
@@ -130,6 +131,8 @@ export type {
   ChatRoomType,
   ChatThreadOptions,
   OnlineStatus,
+  VoiceGatewayTurnOptions,
+  VoiceGatewayTurnStatus,
   VoiceSessionOptions,
   VoiceSessionStatus,
 } from './types.js';
@@ -143,6 +146,7 @@ export {
   createVoiceGatewayTurnHandler,
   type HandleVoiceGatewayTurnOptions,
   handleVoiceGatewayTurn,
+  MAX_VOICE_GATEWAY_TEXT_LENGTH,
   SMRT_CHAT_VOICE_TARGET,
   type VoiceChatSessionCreationResult,
   VoiceGatewayBadRequestError,

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -79,8 +79,10 @@ export {
   ChatReaction,
   ChatRoom,
   ChatThread,
+  VoiceSession,
 } from './models/index.js';
 export {
+  type AuthoredConversationMessages,
   type BindPersonaToSessionOptions,
   bindPersonaToSession,
   type ConversationPersona,
@@ -111,7 +113,6 @@ export {
   type ToolLoopResult,
   type ToolLoopStopReason,
 } from './tool-loop.js';
-
 // Types
 export type {
   AgentSessionOptions,
@@ -129,7 +130,30 @@ export type {
   ChatRoomType,
   ChatThreadOptions,
   OnlineStatus,
+  VoiceSessionOptions,
+  VoiceSessionStatus,
 } from './types.js';
 
 // UI metadata (no Svelte dependency - import ./svelte for components)
 export { CHAT_MODULE_META, CHAT_UI_SLOTS } from './ui.js';
+export {
+  assertVoiceGatewayBearer,
+  type CreateVoiceChatSessionOptions,
+  createVoiceChatSession,
+  createVoiceGatewayTurnHandler,
+  type HandleVoiceGatewayTurnOptions,
+  handleVoiceGatewayTurn,
+  SMRT_CHAT_VOICE_TARGET,
+  type VoiceChatSessionCreationResult,
+  VoiceGatewayBadRequestError,
+  VoiceGatewayError,
+  VoiceGatewayReplayError,
+  type VoiceGatewayTurnHandlerOptions,
+  type VoiceGatewayTurnMetadata,
+  type VoiceGatewayTurnPayload,
+  type VoiceGatewayTurnResponse,
+  type VoiceGatewayTurnResponseMetadata,
+  VoiceGatewayUnauthorizedError,
+  VoiceSessionExpiredError,
+  VoiceSessionRejectedError,
+} from './voice.js';

--- a/packages/chat/src/models/VoiceGatewayTurn.ts
+++ b/packages/chat/src/models/VoiceGatewayTurn.ts
@@ -1,0 +1,73 @@
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type {
+  VoiceGatewayTurnOptions,
+  VoiceGatewayTurnStatus,
+} from '../types.js';
+
+/**
+ * Durable reservation for a gateway turn. The natural key makes `turn_id`
+ * replay checks concurrency-safe before transcript messages are written.
+ */
+@TenantScoped({ mode: 'required' })
+@smrt({
+  tableName: 'voice_gateway_turns',
+  conflictColumns: ['voice_session_id', 'gateway_turn_id'],
+  api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+  cli: false,
+})
+export class VoiceGatewayTurn extends SmrtObject {
+  @tenantId()
+  tenantId: string = '';
+
+  @foreignKey('VoiceSession', { required: true })
+  voiceSessionId: string = '';
+
+  @field({ required: true })
+  gatewaySessionId: string = '';
+
+  @field({ required: true })
+  gatewayTurnId: string = '';
+
+  @field({ required: true })
+  target: string = 'smrt:chat';
+
+  @field({ required: true })
+  status: VoiceGatewayTurnStatus = 'processing';
+
+  @field()
+  completedAt: Date | null = null;
+
+  @field()
+  failedAt: Date | null = null;
+
+  constructor(options: VoiceGatewayTurnOptions = {}) {
+    super(options);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.voiceSessionId !== undefined)
+      this.voiceSessionId = options.voiceSessionId;
+    if (options.gatewaySessionId !== undefined)
+      this.gatewaySessionId = options.gatewaySessionId;
+    if (options.gatewayTurnId !== undefined)
+      this.gatewayTurnId = options.gatewayTurnId;
+    if (options.target !== undefined) this.target = options.target;
+    if (options.status !== undefined) this.status = options.status;
+    if (options.completedAt !== undefined)
+      this.completedAt = options.completedAt;
+    if (options.failedAt !== undefined) this.failedAt = options.failedAt;
+  }
+
+  async complete(now: Date = new Date()): Promise<void> {
+    this.status = 'completed';
+    this.completedAt = now;
+    this.failedAt = null;
+    await this.save();
+  }
+
+  async fail(now: Date = new Date()): Promise<void> {
+    this.status = 'failed';
+    this.failedAt = now;
+    await this.save();
+  }
+}

--- a/packages/chat/src/models/VoiceSession.ts
+++ b/packages/chat/src/models/VoiceSession.ts
@@ -1,0 +1,182 @@
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type { ConversationPersona } from '../persona-conversation.js';
+import type { VoiceSessionOptions, VoiceSessionStatus } from '../types.js';
+
+/**
+ * Short-lived binding proving a voice gateway turn belongs to an authenticated
+ * SMRT actor, persona, and chat session. Internal model: creation and turn
+ * handling must go through the voice adapter, never raw generated mutations.
+ */
+@TenantScoped({ mode: 'required' })
+@smrt({
+  tableName: 'voice_sessions',
+  api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+  cli: true,
+})
+export class VoiceSession extends SmrtObject {
+  @tenantId()
+  tenantId: string = '';
+
+  /** Stable session id the gateway places in the top-level `session_id`. */
+  @field({ required: true })
+  gatewaySessionId: string = '';
+
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { required: true })
+  actorProfileId: string = '';
+
+  @crossPackageRef('@happyvertical/smrt-users:User', { nullable: true })
+  actorUserId: string | null = null;
+
+  @crossPackageRef('@happyvertical/smrt-personas:AgentPersona', {
+    required: true,
+  })
+  personaId: string = '';
+
+  @foreignKey('AgentSession', { required: true })
+  agentSessionId: string = '';
+
+  @foreignKey('ChatRoom', { required: true })
+  chatRoomId: string = '';
+
+  @foreignKey('ChatThread')
+  threadId: string | null = null;
+
+  @field({ required: true })
+  target: string = 'smrt:chat';
+
+  @field({ required: true })
+  status: VoiceSessionStatus = 'active';
+
+  @field({ required: true })
+  expiresAt: Date = new Date(Date.now() + 10 * 60 * 1000);
+
+  @field()
+  lastTurnAt: Date | null = null;
+
+  @field()
+  lastGatewayTurnId: string | null = null;
+
+  @field()
+  personaSnapshot: string = '{}';
+
+  @field()
+  metadata: string = '{}';
+
+  @field()
+  processedTurnIds: string = '[]';
+
+  constructor(options: VoiceSessionOptions = {}) {
+    super(options);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.gatewaySessionId !== undefined)
+      this.gatewaySessionId = options.gatewaySessionId;
+    if (options.actorProfileId !== undefined)
+      this.actorProfileId = options.actorProfileId;
+    if (options.actorUserId !== undefined)
+      this.actorUserId = options.actorUserId;
+    if (options.personaId !== undefined) this.personaId = options.personaId;
+    if (options.agentSessionId !== undefined)
+      this.agentSessionId = options.agentSessionId;
+    if (options.chatRoomId !== undefined) this.chatRoomId = options.chatRoomId;
+    if (options.threadId !== undefined) this.threadId = options.threadId;
+    if (options.target !== undefined) this.target = options.target;
+    if (options.status !== undefined) this.status = options.status;
+    if (options.expiresAt !== undefined) this.expiresAt = options.expiresAt;
+    if (options.lastTurnAt !== undefined) this.lastTurnAt = options.lastTurnAt;
+    if (options.lastGatewayTurnId !== undefined)
+      this.lastGatewayTurnId = options.lastGatewayTurnId;
+    if (options.personaSnapshot !== undefined)
+      this.personaSnapshot =
+        typeof options.personaSnapshot === 'string'
+          ? options.personaSnapshot
+          : JSON.stringify(options.personaSnapshot);
+    if (options.metadata !== undefined)
+      this.metadata =
+        typeof options.metadata === 'string'
+          ? options.metadata
+          : JSON.stringify(options.metadata);
+    if (options.processedTurnIds !== undefined)
+      this.processedTurnIds =
+        typeof options.processedTurnIds === 'string'
+          ? options.processedTurnIds
+          : JSON.stringify(options.processedTurnIds);
+  }
+
+  isActive(now: Date = new Date()): boolean {
+    return this.status === 'active' && now < this.expiresAt;
+  }
+
+  isExpired(now: Date = new Date()): boolean {
+    return now >= this.expiresAt;
+  }
+
+  async expire(): Promise<void> {
+    this.status = 'expired';
+    await this.save();
+  }
+
+  async revoke(): Promise<void> {
+    this.status = 'revoked';
+    await this.save();
+  }
+
+  getPersonaSnapshot(): ConversationPersona {
+    try {
+      return JSON.parse(this.personaSnapshot) as ConversationPersona;
+    } catch {
+      return {
+        id: this.personaId,
+        tenantId: this.tenantId,
+        runAsUserId: '',
+        allowedTools: [],
+      };
+    }
+  }
+
+  setPersonaSnapshot(persona: ConversationPersona): void {
+    this.personaSnapshot = JSON.stringify(persona);
+  }
+
+  getMetadata(): Record<string, unknown> {
+    try {
+      return JSON.parse(this.metadata);
+    } catch {
+      return {};
+    }
+  }
+
+  setMetadata(metadata: Record<string, unknown>): void {
+    this.metadata = JSON.stringify(metadata);
+  }
+
+  getProcessedTurnIds(): string[] {
+    try {
+      const parsed = JSON.parse(this.processedTurnIds);
+      return Array.isArray(parsed)
+        ? parsed.filter((id): id is string => typeof id === 'string')
+        : [];
+    } catch {
+      return [];
+    }
+  }
+
+  hasProcessedTurn(turnId: string): boolean {
+    return this.getProcessedTurnIds().includes(turnId);
+  }
+
+  recordGatewayTurn(turnId: string, maxRememberedTurns = 50): void {
+    const ids = this.getProcessedTurnIds().filter((id) => id !== turnId);
+    ids.push(turnId);
+    this.processedTurnIds = JSON.stringify(ids.slice(-maxRememberedTurns));
+    this.lastGatewayTurnId = turnId;
+    this.lastTurnAt = new Date();
+  }
+}

--- a/packages/chat/src/models/index.ts
+++ b/packages/chat/src/models/index.ts
@@ -4,4 +4,5 @@ export { ChatParticipant } from './ChatParticipant.js';
 export { ChatReaction } from './ChatReaction.js';
 export { ChatRoom } from './ChatRoom.js';
 export { ChatThread } from './ChatThread.js';
+export { VoiceGatewayTurn } from './VoiceGatewayTurn.js';
 export { VoiceSession } from './VoiceSession.js';

--- a/packages/chat/src/models/index.ts
+++ b/packages/chat/src/models/index.ts
@@ -4,3 +4,4 @@ export { ChatParticipant } from './ChatParticipant.js';
 export { ChatReaction } from './ChatReaction.js';
 export { ChatRoom } from './ChatRoom.js';
 export { ChatThread } from './ChatThread.js';
+export { VoiceSession } from './VoiceSession.js';

--- a/packages/chat/src/persona-conversation.test.ts
+++ b/packages/chat/src/persona-conversation.test.ts
@@ -17,7 +17,12 @@ import type {
   ChatOptions,
 } from '@happyvertical/ai';
 import type { PrincipalAuditEntry } from '@happyvertical/smrt-agents';
-import { ObjectRegistry, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  field,
+  ObjectRegistry,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { personaLearningMemory } from '@happyvertical/smrt-personas';
 import {
   MembershipCollection,
@@ -46,6 +51,8 @@ import { toolFunctionName } from './tool-loop.js';
 })
 class ConvNote extends SmrtObject {
   tenantId: string | null = null;
+
+  @field()
   title = '';
 }
 void ConvNote;

--- a/packages/chat/src/persona-conversation.ts
+++ b/packages/chat/src/persona-conversation.ts
@@ -35,6 +35,7 @@ import {
 } from '@happyvertical/smrt-personas';
 import { getDatabase } from '@happyvertical/sql';
 import type { AgentSession } from './models/AgentSession.js';
+import type { ChatMessage } from './models/ChatMessage.js';
 import {
   buildManifestToolCatalog,
   type ManifestTool,
@@ -294,6 +295,14 @@ export interface PersonaConversationTurnResult {
   recalled: LearningMemoryRecord[];
   /** The system prompt assembled for the turn. */
   systemPrompt: string;
+  /** Persisted messages authored by this turn when a chat service was supplied. */
+  authoredMessages?: AuthoredConversationMessages;
+}
+
+/** Persisted assistant/tool messages emitted for a persona turn. */
+export interface AuthoredConversationMessages {
+  toolMessages: ChatMessage[];
+  assistantMessage: ChatMessage | null;
 }
 
 function assembleSystemPrompt(
@@ -388,8 +397,9 @@ export async function runPersonaConversationTurn(
     audit: options.audit,
   });
 
+  let authoredMessages: AuthoredConversationMessages | undefined;
   if (options.chatService && options.session?.id) {
-    await authorConversationReply({
+    authoredMessages = await authorConversationReply({
       chatService: options.chatService,
       session: options.session,
       tenantId,
@@ -398,7 +408,7 @@ export async function runPersonaConversationTurn(
     });
   }
 
-  return { result, correlationId, recalled, systemPrompt };
+  return { result, correlationId, recalled, systemPrompt, authoredMessages };
 }
 
 /**
@@ -466,13 +476,14 @@ async function authorConversationReply(input: {
   tenantId: string;
   threadId: string | null;
   result: ToolLoopResult;
-}): Promise<void> {
+}): Promise<AuthoredConversationMessages> {
   const { sendAgentReply } = await import('./services/ChatService.js');
+  const toolMessages: ChatMessage[] = [];
   for (const invocation of input.result.invocations) {
     if (!invocation.ok) {
       continue;
     }
-    await sendAgentReply(input.chatService, {
+    const message = await sendAgentReply(input.chatService, {
       tenantId: input.tenantId,
       agentSessionId: input.session.id as string,
       threadId: input.threadId,
@@ -481,12 +492,14 @@ async function authorConversationReply(input: {
       messageType: 'tool_result',
       toolCallData: { name: invocation.slug, args: invocation.args },
     });
+    toolMessages.push(message);
   }
-  await sendAgentReply(input.chatService, {
+  const assistantMessage = await sendAgentReply(input.chatService, {
     tenantId: input.tenantId,
     agentSessionId: input.session.id as string,
     threadId: input.threadId,
     content: input.result.content,
     kind: 'assistant',
   });
+  return { toolMessages, assistantMessage };
 }

--- a/packages/chat/src/routes/+page.svelte
+++ b/packages/chat/src/routes/+page.svelte
@@ -51,6 +51,26 @@ interface VoiceControlFrame {
 
 const currentProfileId = 'profile-dev-user';
 const assistantProfileId = 'agent-dev-assistant';
+const VOICE_CAPTURE_WORKLET_NAME = 'smrt-voice-capture';
+const VOICE_CAPTURE_WORKLET_SOURCE = `
+class SmrtVoiceCaptureProcessor extends AudioWorkletProcessor {
+  process(inputs, outputs) {
+    const output = outputs[0] && outputs[0][0];
+    if (output) output.fill(0);
+
+    const input = inputs[0] && inputs[0][0];
+    if (input) {
+      const copy = new Float32Array(input.length);
+      copy.set(input);
+      this.port.postMessage(copy, [copy.buffer]);
+    }
+
+    return true;
+  }
+}
+
+registerProcessor('${VOICE_CAPTURE_WORKLET_NAME}', SmrtVoiceCaptureProcessor);
+`;
 
 const seedRooms: ChatRoomData[] = [
   {
@@ -160,7 +180,7 @@ let voiceSocket: WebSocket | null = null;
 let voiceStream: MediaStream | null = null;
 let voiceAudioContext: AudioContext | null = null;
 let voiceSource: MediaStreamAudioSourceNode | null = null;
-let voiceProcessor: ScriptProcessorNode | null = null;
+let voiceProcessor: AudioWorkletNode | null = null;
 let activeVoiceAudio: HTMLAudioElement | null = null;
 let activeVoiceAudioUrl: string | null = null;
 
@@ -414,6 +434,50 @@ function downsampleToPcm16(
   return output.buffer;
 }
 
+async function createVoiceCaptureProcessor(
+  audioContext: AudioContext,
+  config: DevVoiceConfig,
+  socket: WebSocket,
+): Promise<AudioWorkletNode> {
+  if (!audioContext.audioWorklet) {
+    throw new Error('This browser does not support AudioWorklet capture.');
+  }
+
+  const workletUrl = URL.createObjectURL(
+    new Blob([VOICE_CAPTURE_WORKLET_SOURCE], { type: 'text/javascript' }),
+  );
+  try {
+    await audioContext.audioWorklet.addModule(workletUrl);
+  } finally {
+    URL.revokeObjectURL(workletUrl);
+  }
+
+  const processor = new AudioWorkletNode(
+    audioContext,
+    VOICE_CAPTURE_WORKLET_NAME,
+    {
+      channelCount: 1,
+      channelCountMode: 'explicit',
+      numberOfInputs: 1,
+      numberOfOutputs: 1,
+    },
+  );
+
+  processor.port.onmessage = (event: MessageEvent<Float32Array>) => {
+    if (socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    const pcm = downsampleToPcm16(
+      event.data,
+      audioContext.sampleRate,
+      config.sampleRate,
+    );
+    socket.send(pcm);
+  };
+
+  return processor;
+}
+
 function stopActiveVoiceAudio() {
   if (activeVoiceAudio) {
     activeVoiceAudio.pause();
@@ -531,6 +595,7 @@ function handleVoiceSocketMessage(
 }
 
 function cleanupVoiceCapture() {
+  voiceProcessor?.port.close();
   voiceProcessor?.disconnect();
   voiceProcessor = null;
   voiceSource?.disconnect();
@@ -585,28 +650,20 @@ async function startVoiceConversation() {
     const audioContext = new AudioContext();
     await audioContext.resume();
     const source = audioContext.createMediaStreamSource(stream);
-    const processor = audioContext.createScriptProcessor(4096, 1, 1);
     const socket = new WebSocket(voiceSocketUrl(config));
 
     voiceStream = stream;
     voiceAudioContext = audioContext;
     voiceSource = source;
-    voiceProcessor = processor;
     voiceSocket = socket;
     socket.binaryType = 'arraybuffer';
 
-    processor.onaudioprocess = (event) => {
-      event.outputBuffer.getChannelData(0).fill(0);
-      if (socket.readyState !== WebSocket.OPEN) {
-        return;
-      }
-      const pcm = downsampleToPcm16(
-        event.inputBuffer.getChannelData(0),
-        audioContext.sampleRate,
-        config.sampleRate,
-      );
-      socket.send(pcm);
-    };
+    const processor = await createVoiceCaptureProcessor(
+      audioContext,
+      config,
+      socket,
+    );
+    voiceProcessor = processor;
 
     source.connect(processor);
     processor.connect(audioContext.destination);

--- a/packages/chat/src/routes/+page.svelte
+++ b/packages/chat/src/routes/+page.svelte
@@ -1,0 +1,1095 @@
+<script lang="ts">
+import { Select } from '@happyvertical/smrt-ui/forms';
+import {
+  ColorSchemeToggle,
+  ThemeProvider,
+} from '@happyvertical/smrt-ui/themes';
+import { Button } from '@happyvertical/smrt-ui/ui';
+import { onMount } from 'svelte';
+import ChatLayout from '../svelte/components/layout/ChatLayout.svelte';
+import RoomHeader from '../svelte/components/layout/RoomHeader.svelte';
+import MessageInput from '../svelte/components/messages/MessageInput.svelte';
+import MessageList from '../svelte/components/messages/MessageList.svelte';
+import type { ChatMessageData, ChatRoomData } from '../svelte/types.js';
+
+type DevChatMode = 'ai' | 'local';
+type WorkbenchMode = 'text' | 'voice';
+
+interface DevChatResponse {
+  mode: DevChatMode;
+  provider?: string;
+  model?: string;
+  content: string;
+  configured: boolean;
+  warning?: string;
+}
+
+interface DevVoiceConfig {
+  configured: boolean;
+  httpUrl: string;
+  wsUrl: string;
+  token?: string;
+  tokenConfigured: boolean;
+  tokenExposed: boolean;
+  defaultTarget: string;
+  sampleRate: number;
+  targets: Record<string, Record<string, unknown>>;
+  warning?: string;
+}
+
+interface VoiceControlFrame {
+  type?: string;
+  session_id?: string;
+  target?: string;
+  text?: string;
+  turn_id?: string;
+  content_type?: string;
+  bytes?: number;
+  reason?: string;
+  error?: string;
+}
+
+const currentProfileId = 'profile-dev-user';
+const assistantProfileId = 'agent-dev-assistant';
+
+const seedRooms: ChatRoomData[] = [
+  {
+    id: 'room-agent-lab',
+    name: 'Agent Lab',
+    description: 'Local agent chat workbench',
+    roomType: 'agent',
+    topic: 'Credential-backed chat when AI environment variables are present',
+    participantCount: 2,
+    unreadCount: 0,
+    isPinned: true,
+  },
+  {
+    id: 'room-product',
+    name: 'Product',
+    description: 'Package conversation fixture',
+    roomType: 'public',
+    topic: 'Chat package behavior and UI states',
+    participantCount: 5,
+    unreadCount: 0,
+  },
+  {
+    id: 'room-direct',
+    name: 'Taylor Rowan',
+    description: 'Direct message fixture',
+    roomType: 'dm',
+    topic: '',
+    participantCount: 2,
+    unreadCount: 0,
+  },
+];
+
+const seedMessages: Record<string, ChatMessageData[]> = {
+  'room-agent-lab': [
+    {
+      id: 'seed-agent-1',
+      roomId: 'room-agent-lab',
+      senderProfileId: assistantProfileId,
+      senderName: 'Dev Assistant',
+      content:
+        'The chat workbench is online. Send a message to exercise the package components and local dev endpoint.',
+      messageType: 'text',
+      role: 'assistant',
+      isEdited: false,
+      isDeleted: false,
+      reactions: [],
+      attachments: [],
+      createdAt: new Date(Date.now() - 1000 * 60 * 8).toISOString(),
+    },
+  ],
+  'room-product': [
+    {
+      id: 'seed-product-1',
+      roomId: 'room-product',
+      senderProfileId: 'profile-taylor',
+      senderName: 'Taylor Rowan',
+      content:
+        'The route should make the message list, room list, and composer easy to test together.',
+      messageType: 'text',
+      role: 'user',
+      isEdited: false,
+      isDeleted: false,
+      reactions: [{ emoji: 'ok', count: 1, reacted: false, profileIds: [] }],
+      attachments: [],
+      createdAt: new Date(Date.now() - 1000 * 60 * 15).toISOString(),
+    },
+  ],
+  'room-direct': [
+    {
+      id: 'seed-direct-1',
+      roomId: 'room-direct',
+      senderProfileId: 'profile-taylor',
+      senderName: 'Taylor Rowan',
+      content: 'Can you sanity-check the compact chat state on mobile too?',
+      messageType: 'text',
+      role: 'user',
+      isEdited: false,
+      isDeleted: false,
+      reactions: [],
+      attachments: [],
+      createdAt: new Date(Date.now() - 1000 * 60 * 35).toISOString(),
+    },
+  ],
+};
+
+let currentRoomId = $state('room-agent-lab');
+let messagesByRoom = $state<Record<string, ChatMessageData[]>>({
+  ...seedMessages,
+});
+let pendingRoomId = $state<string | null>(null);
+let statusText = $state('Local endpoint ready');
+let backendMode = $state<DevChatMode>('local');
+let backendDetail = $state('No AI response yet');
+let warning = $state<string | null>(null);
+let workbenchMode = $state<WorkbenchMode>('text');
+let voiceConfig = $state<DevVoiceConfig | null>(null);
+let voiceConfigLoaded = $state(false);
+let voiceTarget = $state('echo');
+let voiceSessionId = $state<string | null>(null);
+let voiceConnected = $state(false);
+let voiceStatus = $state('Voice gateway not loaded');
+let voiceTurnState = $state('Idle');
+let voiceTranscript = $state('No voice transcript yet');
+let voiceWarning = $state<string | null>(null);
+
+let voiceSocket: WebSocket | null = null;
+let voiceStream: MediaStream | null = null;
+let voiceAudioContext: AudioContext | null = null;
+let voiceSource: MediaStreamAudioSourceNode | null = null;
+let voiceProcessor: ScriptProcessorNode | null = null;
+let activeVoiceAudio: HTMLAudioElement | null = null;
+let activeVoiceAudioUrl: string | null = null;
+
+const messages = $derived(messagesByRoom[currentRoomId] ?? []);
+const pending = $derived(pendingRoomId === currentRoomId);
+const voiceTargetNames = $derived(Object.keys(voiceConfig?.targets ?? {}));
+const rooms = $derived(
+  seedRooms.map((room) => {
+    const roomMessages = messagesByRoom[room.id] ?? [];
+    const lastMessage = roomMessages.at(-1);
+
+    return {
+      ...room,
+      lastMessage,
+      lastMessageAt: lastMessage?.createdAt ?? room.lastMessageAt ?? null,
+      unreadCount: room.id === currentRoomId ? 0 : room.unreadCount,
+    };
+  }),
+);
+const currentRoom = $derived(
+  rooms.find((room) => room.id === currentRoomId) ?? rooms[0],
+);
+const totalMessages = $derived(
+  Object.values(messagesByRoom).reduce(
+    (total, roomMessages) => total + roomMessages.length,
+    0,
+  ),
+);
+
+function createMessageId(prefix: string) {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function appendMessage(roomId: string, message: ChatMessageData) {
+  messagesByRoom = {
+    ...messagesByRoom,
+    [roomId]: [...(messagesByRoom[roomId] ?? []), message],
+  };
+}
+
+function createUserMessage(roomId: string, content: string): ChatMessageData {
+  return {
+    id: createMessageId('user'),
+    roomId,
+    senderProfileId: currentProfileId,
+    senderName: 'You',
+    content,
+    messageType: 'text',
+    role: 'user',
+    isEdited: false,
+    isDeleted: false,
+    reactions: [],
+    attachments: [],
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function chatHistoryFor(roomId: string, nextMessage: ChatMessageData) {
+  return [...(messagesByRoom[roomId] ?? []), nextMessage].map((message) => ({
+    role: message.role,
+    content: message.content,
+  }));
+}
+
+function appendAssistantMessage(
+  roomId: string,
+  content: string,
+  role: ChatMessageData['role'] = 'assistant',
+) {
+  appendMessage(roomId, {
+    id: createMessageId(role === 'system' ? 'system' : 'assistant'),
+    roomId,
+    senderProfileId: role === 'system' ? 'system' : assistantProfileId,
+    senderName: role === 'system' ? 'System' : 'Dev Assistant',
+    content,
+    messageType: role === 'system' ? 'system' : 'text',
+    role,
+    isEdited: false,
+    isDeleted: false,
+    reactions: [],
+    attachments: [],
+    createdAt: new Date().toISOString(),
+  });
+}
+
+async function requestAssistantReply(
+  roomId: string,
+  userMessage: ChatMessageData,
+) {
+  pendingRoomId = roomId;
+  statusText = 'Assistant replying';
+  warning = null;
+
+  try {
+    const response = await fetch('/api/dev-chat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        messages: chatHistoryFor(roomId, userMessage),
+      }),
+    });
+    const result = (await response.json()) as DevChatResponse;
+
+    if (!response.ok) {
+      throw new Error(result.content || 'Dev chat request failed.');
+    }
+
+    backendMode = result.mode;
+    backendDetail =
+      result.mode === 'ai'
+        ? [result.provider, result.model].filter(Boolean).join(' / ') ||
+          'AI provider'
+        : result.configured
+          ? 'AI configured, fallback response'
+          : 'Local fallback';
+    statusText =
+      result.mode === 'ai' ? 'AI response received' : 'Local response received';
+    warning = result.warning ?? null;
+    appendAssistantMessage(roomId, result.content);
+  } catch (error) {
+    statusText = 'Request failed';
+    backendMode = 'local';
+    backendDetail = 'Error state';
+    warning =
+      error instanceof Error ? error.message : 'Dev chat request failed.';
+    appendAssistantMessage(
+      roomId,
+      error instanceof Error ? error.message : 'Dev chat request failed.',
+      'system',
+    );
+  } finally {
+    pendingRoomId = null;
+  }
+}
+
+function sendMessage(content: string) {
+  const roomId = currentRoomId;
+  const room = currentRoom;
+  const userMessage = createUserMessage(roomId, content);
+
+  appendMessage(roomId, userMessage);
+
+  if (room.roomType === 'agent') {
+    void requestAssistantReply(roomId, userMessage);
+    return;
+  }
+
+  statusText = 'Message appended';
+  backendDetail = 'No assistant in this room';
+}
+
+function handleComposerSend(content: string) {
+  if (workbenchMode === 'voice') {
+    sendVoiceTextTurn(content);
+    return;
+  }
+
+  sendMessage(content);
+}
+
+function resetConversation() {
+  void stopVoiceConversation();
+  messagesByRoom = { ...seedMessages };
+  currentRoomId = 'room-agent-lab';
+  pendingRoomId = null;
+  statusText = 'Local endpoint ready';
+  backendMode = 'local';
+  backendDetail = 'No AI response yet';
+  warning = null;
+  voiceTurnState = 'Idle';
+  voiceTranscript = 'No voice transcript yet';
+  voiceWarning = null;
+}
+
+function setWorkbenchMode(mode: WorkbenchMode) {
+  workbenchMode = mode;
+  if (mode === 'voice' && !voiceConfigLoaded) {
+    void loadVoiceConfig();
+  }
+  if (mode === 'text') {
+    void stopVoiceConversation();
+  }
+}
+
+async function loadVoiceConfig() {
+  voiceConfigLoaded = false;
+  voiceStatus = 'Loading voice gateway';
+  voiceWarning = null;
+
+  try {
+    const response = await fetch('/api/dev-voice/config');
+    const config = (await response.json()) as DevVoiceConfig;
+    voiceConfig = config;
+    voiceConfigLoaded = true;
+    voiceWarning = config.warning ?? null;
+
+    const targetNames = Object.keys(config.targets ?? {});
+    if (!targetNames.includes(voiceTarget)) {
+      voiceTarget = targetNames.includes(config.defaultTarget)
+        ? config.defaultTarget
+        : targetNames[0] || config.defaultTarget || 'echo';
+    }
+
+    if (!config.configured) {
+      voiceStatus = 'Voice gateway not configured';
+    } else if (config.tokenConfigured && !config.tokenExposed) {
+      voiceStatus = 'Voice token is server-side only';
+    } else {
+      voiceStatus = 'Voice gateway ready';
+    }
+  } catch (error) {
+    voiceConfigLoaded = true;
+    voiceStatus = 'Voice config failed';
+    voiceWarning =
+      error instanceof Error ? error.message : 'Voice config request failed.';
+  }
+}
+
+function voiceSocketUrl(config: DevVoiceConfig): string {
+  const url = new URL(config.wsUrl);
+  if (config.token) {
+    url.searchParams.set('token', config.token);
+  }
+  return url.toString();
+}
+
+function downsampleToPcm16(
+  input: Float32Array,
+  inputSampleRate: number,
+  outputSampleRate: number,
+): ArrayBuffer {
+  const ratio = inputSampleRate / outputSampleRate;
+  const length = Math.max(1, Math.floor(input.length / ratio));
+  const output = new Int16Array(length);
+
+  for (let outputIndex = 0; outputIndex < length; outputIndex += 1) {
+    const start = Math.floor(outputIndex * ratio);
+    const end = Math.min(input.length, Math.floor((outputIndex + 1) * ratio));
+    let total = 0;
+    let count = 0;
+
+    for (let inputIndex = start; inputIndex < end; inputIndex += 1) {
+      total += input[inputIndex] ?? 0;
+      count += 1;
+    }
+
+    const sample = Math.max(-1, Math.min(1, count ? total / count : 0));
+    output[outputIndex] = sample < 0 ? sample * 0x8000 : sample * 0x7fff;
+  }
+
+  return output.buffer;
+}
+
+function stopActiveVoiceAudio() {
+  if (activeVoiceAudio) {
+    activeVoiceAudio.pause();
+    activeVoiceAudio.src = '';
+    activeVoiceAudio = null;
+  }
+  if (activeVoiceAudioUrl) {
+    URL.revokeObjectURL(activeVoiceAudioUrl);
+    activeVoiceAudioUrl = null;
+  }
+}
+
+async function playVoiceAudio(data: ArrayBuffer | Blob) {
+  stopActiveVoiceAudio();
+  const blob =
+    data instanceof Blob ? data : new Blob([data], { type: 'audio/wav' });
+  const url = URL.createObjectURL(blob);
+  const audio = new Audio(url);
+
+  activeVoiceAudio = audio;
+  activeVoiceAudioUrl = url;
+  audio.onended = stopActiveVoiceAudio;
+  audio.onerror = () => {
+    voiceWarning = 'Voice audio playback failed.';
+    stopActiveVoiceAudio();
+  };
+
+  try {
+    await audio.play();
+  } catch (error) {
+    voiceWarning =
+      error instanceof Error ? error.message : 'Voice audio playback failed.';
+  }
+}
+
+function handleVoiceControlFrame(frame: VoiceControlFrame) {
+  switch (frame.type) {
+    case 'ready':
+      voiceSessionId = frame.session_id ?? voiceSessionId;
+      voiceStatus = 'Voice socket ready';
+      break;
+    case 'started':
+      voiceConnected = true;
+      voiceSessionId = frame.session_id ?? voiceSessionId;
+      voiceTarget = frame.target ?? voiceTarget;
+      voiceStatus = 'Listening';
+      voiceTurnState = 'Listening';
+      break;
+    case 'transcribing':
+      voiceStatus = 'Transcribing';
+      voiceTurnState = frame.reason
+        ? `Transcribing (${frame.reason})`
+        : 'Transcribing';
+      break;
+    case 'transcript':
+      if (frame.text) {
+        voiceTranscript = frame.text;
+        appendMessage(
+          currentRoomId,
+          createUserMessage(currentRoomId, frame.text),
+        );
+      }
+      voiceStatus = 'Transcript received';
+      voiceTurnState = 'Waiting for response';
+      break;
+    case 'response_text':
+      if (frame.text) {
+        appendAssistantMessage(currentRoomId, frame.text);
+      }
+      backendMode = 'ai';
+      backendDetail = `Voice gateway / ${voiceTarget}`;
+      statusText = 'Voice response received';
+      voiceStatus = 'Response received';
+      voiceTurnState = 'Synthesizing audio';
+      break;
+    case 'audio':
+      voiceStatus = 'Playing voice response';
+      voiceTurnState =
+        typeof frame.bytes === 'number'
+          ? `Playing ${Math.round(frame.bytes / 1024)} KB audio`
+          : 'Playing audio';
+      break;
+    case 'done':
+      voiceStatus = 'Listening';
+      voiceTurnState = 'Listening';
+      break;
+    case 'clear_buffer':
+      stopActiveVoiceAudio();
+      voiceStatus = 'Barge-in detected';
+      voiceTurnState = 'Listening';
+      break;
+    case 'error':
+      voiceWarning = frame.error ?? 'Voice gateway error.';
+      voiceStatus = 'Voice error';
+      voiceTurnState = 'Error';
+      break;
+    default:
+      break;
+  }
+}
+
+function handleVoiceSocketMessage(
+  event: MessageEvent<string | ArrayBuffer | Blob>,
+) {
+  if (typeof event.data === 'string') {
+    try {
+      handleVoiceControlFrame(JSON.parse(event.data) as VoiceControlFrame);
+    } catch {
+      voiceWarning = 'Voice gateway sent invalid JSON.';
+    }
+    return;
+  }
+
+  void playVoiceAudio(event.data);
+}
+
+function cleanupVoiceCapture() {
+  voiceProcessor?.disconnect();
+  voiceProcessor = null;
+  voiceSource?.disconnect();
+  voiceSource = null;
+  voiceStream?.getTracks().forEach((track) => {
+    track.stop();
+  });
+  voiceStream = null;
+
+  if (voiceAudioContext && voiceAudioContext.state !== 'closed') {
+    void voiceAudioContext.close();
+  }
+  voiceAudioContext = null;
+}
+
+async function startVoiceConversation() {
+  if (voiceConnected) return;
+  if (!voiceConfigLoaded) {
+    await loadVoiceConfig();
+  }
+
+  const config = voiceConfig;
+  if (!config?.configured) {
+    voiceWarning = 'Voice gateway is not configured.';
+    voiceStatus = 'Voice gateway not configured';
+    return;
+  }
+  if (config.tokenConfigured && !config.tokenExposed) {
+    voiceWarning =
+      'Voice gateway token is not exposed to the local browser dev route.';
+    voiceStatus = 'Voice token unavailable';
+    return;
+  }
+  if (!navigator.mediaDevices?.getUserMedia) {
+    voiceWarning = 'This browser does not support microphone capture.';
+    voiceStatus = 'Microphone unavailable';
+    return;
+  }
+
+  voiceWarning = null;
+  voiceStatus = 'Opening microphone';
+
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        autoGainControl: true,
+        channelCount: 1,
+        echoCancellation: true,
+        noiseSuppression: true,
+      },
+    });
+    const audioContext = new AudioContext();
+    await audioContext.resume();
+    const source = audioContext.createMediaStreamSource(stream);
+    const processor = audioContext.createScriptProcessor(4096, 1, 1);
+    const socket = new WebSocket(voiceSocketUrl(config));
+
+    voiceStream = stream;
+    voiceAudioContext = audioContext;
+    voiceSource = source;
+    voiceProcessor = processor;
+    voiceSocket = socket;
+    socket.binaryType = 'arraybuffer';
+
+    processor.onaudioprocess = (event) => {
+      event.outputBuffer.getChannelData(0).fill(0);
+      if (socket.readyState !== WebSocket.OPEN) {
+        return;
+      }
+      const pcm = downsampleToPcm16(
+        event.inputBuffer.getChannelData(0),
+        audioContext.sampleRate,
+        config.sampleRate,
+      );
+      socket.send(pcm);
+    };
+
+    source.connect(processor);
+    processor.connect(audioContext.destination);
+
+    socket.onmessage = handleVoiceSocketMessage;
+    socket.onclose = () => {
+      voiceConnected = false;
+      voiceStatus = 'Voice disconnected';
+      voiceTurnState = 'Idle';
+      cleanupVoiceCapture();
+    };
+    socket.onerror = () => {
+      voiceWarning = 'Voice socket connection failed.';
+      voiceStatus = 'Voice socket failed';
+    };
+    socket.onopen = () => {
+      socket.send(
+        JSON.stringify({
+          type: 'start',
+          target: voiceTarget,
+          session_id: voiceSessionId ?? undefined,
+          actor: 'chat-dev',
+          audio: { sample_rate: config.sampleRate, encoding: 'pcm_s16le' },
+        }),
+      );
+      voiceConnected = true;
+      voiceStatus = 'Starting voice session';
+      voiceTurnState = 'Listening';
+    };
+  } catch (error) {
+    cleanupVoiceCapture();
+    voiceSocket?.close();
+    voiceSocket = null;
+    voiceConnected = false;
+    voiceStatus = 'Voice start failed';
+    voiceWarning =
+      error instanceof Error ? error.message : 'Voice conversation failed.';
+  }
+}
+
+async function stopVoiceConversation() {
+  stopActiveVoiceAudio();
+  if (voiceSocket?.readyState === WebSocket.OPEN) {
+    voiceSocket.send(JSON.stringify({ type: 'stop' }));
+  }
+  voiceSocket?.close();
+  voiceSocket = null;
+  cleanupVoiceCapture();
+  voiceConnected = false;
+  voiceStatus = voiceConfigLoaded
+    ? 'Voice stopped'
+    : 'Voice gateway not loaded';
+  voiceTurnState = 'Idle';
+}
+
+function sendVoiceTextTurn(content: string) {
+  if (!voiceSocket || voiceSocket.readyState !== WebSocket.OPEN) {
+    voiceWarning = 'Start voice conversation before sending a voice turn.';
+    voiceStatus = 'Voice is not connected';
+    return;
+  }
+
+  appendMessage(currentRoomId, createUserMessage(currentRoomId, content));
+  voiceSocket.send(JSON.stringify({ type: 'text_turn', text: content }));
+  voiceTranscript = content;
+  voiceStatus = 'Voice text turn sent';
+  voiceTurnState = 'Waiting for response';
+}
+
+onMount(() => {
+  void loadVoiceConfig();
+  return () => {
+    void stopVoiceConversation();
+  };
+});
+</script>
+
+<svelte:head>
+  <title>Chat Dev</title>
+</svelte:head>
+
+<ThemeProvider colorScheme="system" persist={true}>
+  <div class="chat-dev">
+    <header class="topbar">
+      <div class="title-block">
+        <p class="eyebrow">@happyvertical/smrt-chat</p>
+        <h1>Chat Dev</h1>
+      </div>
+
+      <nav class="topbar__actions" aria-label="Chat dev navigation">
+        <div class="mode-toggle" role="group" aria-label="Input mode">
+          <Button
+            variant="ghost"
+            size="sm"
+            type="button"
+            class={workbenchMode === 'text' ? 'mode-button active' : 'mode-button'}
+            aria-pressed={workbenchMode === 'text'}
+            onclick={() => setWorkbenchMode('text')}
+          >
+            Text
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            type="button"
+            class={workbenchMode === 'voice' ? 'mode-button active' : 'mode-button'}
+            aria-pressed={workbenchMode === 'voice'}
+            onclick={() => setWorkbenchMode('voice')}
+          >
+            Voice
+          </Button>
+        </div>
+        <a class="preview-link" href="/previews">Previews</a>
+        <Button variant="ghost" size="sm" type="button" onclick={resetConversation}>
+          Reset
+        </Button>
+        <ColorSchemeToggle />
+      </nav>
+    </header>
+
+    <main class="workspace">
+      <section class="chat-frame" aria-label="Chat workbench">
+        <ChatLayout
+          {rooms}
+          {currentRoomId}
+          {currentProfileId}
+          onselectroom={(roomId) => (currentRoomId = roomId)}
+        >
+          <RoomHeader room={currentRoom} participantCount={currentRoom.participantCount} />
+          <div class="transcript">
+            <MessageList
+              {messages}
+              {currentProfileId}
+              onreply={() => undefined}
+              onreact={() => undefined}
+            />
+            {#if pending}
+              <div class="typing-row" role="status">Assistant is replying...</div>
+            {/if}
+            {#if workbenchMode === 'voice' && voiceConnected}
+              <div class="typing-row" role="status">{voiceTurnState}</div>
+            {/if}
+          </div>
+          <MessageInput
+            onsend={handleComposerSend}
+            disabled={Boolean(pendingRoomId) || (workbenchMode === 'voice' && !voiceConnected)}
+            placeholder={workbenchMode === 'voice' ? 'Send a typed voice turn' : currentRoom.roomType === 'agent' ? 'Message the dev assistant' : 'Message this room'}
+          />
+        </ChatLayout>
+      </section>
+
+      <aside class="status-panel" aria-label="Dev chat status">
+        <div class="status-row">
+          <span class="status-label">Input</span>
+          <strong>{workbenchMode === 'voice' ? 'Voice conversation' : 'Text chat'}</strong>
+        </div>
+        <div class="status-row">
+          <span class="status-label">Mode</span>
+          <strong>{backendMode === 'ai' ? 'AI' : 'Local'}</strong>
+        </div>
+        <div class="status-row">
+          <span class="status-label">Backend</span>
+          <strong>{backendDetail}</strong>
+        </div>
+        <div class="status-row">
+          <span class="status-label">Status</span>
+          <strong>{statusText}</strong>
+        </div>
+        <div class="status-row">
+          <span class="status-label">Messages</span>
+          <strong>{totalMessages}</strong>
+        </div>
+
+        {#if workbenchMode === 'voice'}
+          <section class="voice-panel" aria-label="Voice conversation controls">
+            <label class="voice-field">
+              <span class="status-label">Voice target</span>
+              <Select bind:value={voiceTarget} disabled={voiceConnected} class="voice-select">
+                {#each voiceTargetNames as target (target)}
+                  <option value={target}>{target}</option>
+                {/each}
+              </Select>
+            </label>
+
+            <div class="voice-actions">
+              {#if voiceConnected}
+                <Button variant="danger" size="sm" type="button" class="voice-button" onclick={stopVoiceConversation}>
+                  Stop
+                </Button>
+              {:else}
+                <Button variant="primary" size="sm" type="button" class="voice-button" onclick={startVoiceConversation}>
+                  Start
+                </Button>
+              {/if}
+              <Button variant="secondary" size="sm" type="button" class="voice-button" onclick={loadVoiceConfig} disabled={voiceConnected}>
+                Reload
+              </Button>
+            </div>
+
+            <div class="voice-readout">
+              <span class:active={voiceConnected} aria-hidden="true"></span>
+              <strong>{voiceStatus}</strong>
+            </div>
+
+            <div class="voice-meta">
+              <span class="status-label">Session</span>
+              <strong>{voiceSessionId ?? 'Not started'}</strong>
+            </div>
+            <div class="voice-meta">
+              <span class="status-label">Transcript</span>
+              <strong>{voiceTranscript}</strong>
+            </div>
+
+            {#if voiceWarning}
+              <p class="warning">{voiceWarning}</p>
+            {/if}
+          </section>
+        {/if}
+
+        {#if warning}
+          <p class="warning">{warning}</p>
+        {/if}
+      </aside>
+    </main>
+  </div>
+</ThemeProvider>
+
+<style>
+  :global(body) {
+    margin: 0;
+    min-height: 100vh;
+  }
+
+  :global(a) {
+    color: inherit;
+  }
+
+  .chat-dev {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    min-height: 100vh;
+    background: var(--smrt-color-background);
+    color: var(--smrt-color-on-background);
+    font-family: var(--smrt-font-family);
+  }
+
+  .topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.8rem 1rem;
+    border-bottom: 1px solid var(--smrt-color-outline-variant);
+    background: var(--smrt-color-surface);
+    color: var(--smrt-color-on-surface);
+  }
+
+  .title-block {
+    min-width: 0;
+  }
+
+  .eyebrow {
+    margin: 0 0 0.15rem;
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    color: var(--smrt-color-on-surface-variant);
+  }
+
+  h1 {
+    margin: 0;
+    font-size: var(--smrt-typography-title-medium-size, 1rem);
+    line-height: var(--smrt-typography-title-medium-line-height, 1.5);
+    letter-spacing: 0;
+  }
+
+  .topbar__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .mode-toggle {
+    display: inline-flex;
+    padding: 0.16rem;
+    border: 1px solid var(--smrt-color-outline-variant);
+    border-radius: var(--smrt-radius-md, 8px);
+    background: var(--smrt-color-surface-container-high);
+  }
+
+  .mode-toggle :global(.mode-button) {
+    min-height: 2rem;
+    padding: 0 0.68rem;
+    border: 0;
+    border-radius: var(--smrt-radius-sm, 4px);
+    background: transparent;
+    color: var(--smrt-color-on-surface-variant);
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-bold, 700);
+  }
+
+  .mode-toggle :global(.mode-button.active) {
+    background: var(--smrt-color-primary);
+    color: var(--smrt-color-on-primary);
+  }
+
+  .preview-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2rem;
+    padding: 0 0.7rem;
+    border: 1px solid var(--smrt-color-outline-variant);
+    border-radius: var(--smrt-radius-md, 8px);
+    background: var(--smrt-color-surface-container-lowest);
+    color: var(--smrt-color-on-surface);
+    text-decoration: none;
+    font-size: var(--smrt-typography-label-large-size, 0.875rem);
+    font-weight: var(--smrt-typography-weight-semibold, 600);
+  }
+
+  .preview-link:hover {
+    background: var(--smrt-color-surface-container-low);
+  }
+
+  .workspace {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 17rem;
+    gap: 1rem;
+    min-height: 0;
+    padding: 1rem;
+  }
+
+  .chat-frame {
+    min-width: 0;
+    min-height: 32rem;
+    height: calc(100vh - 5.1rem);
+    overflow: hidden;
+    border: 1px solid var(--smrt-color-outline-variant);
+    border-radius: var(--smrt-radius-md, 8px);
+    background: var(--smrt-color-surface);
+  }
+
+  .transcript {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+    flex-direction: column;
+    background: var(--smrt-color-surface-container-low);
+  }
+
+  .typing-row {
+    margin: 0 1rem 0.75rem;
+    padding: 0.55rem 0.7rem;
+    align-self: flex-start;
+    border: 1px solid var(--smrt-color-outline-variant);
+    border-radius: var(--smrt-radius-md, 8px);
+    background: var(--smrt-color-surface);
+    color: var(--smrt-color-on-surface-variant);
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
+  }
+
+  .status-panel {
+    display: grid;
+    align-content: start;
+    gap: 0.75rem;
+    height: max-content;
+    padding: 0.9rem;
+    border: 1px solid var(--smrt-color-outline-variant);
+    border-radius: var(--smrt-radius-md, 8px);
+    background: var(--smrt-color-surface);
+    color: var(--smrt-color-on-surface);
+  }
+
+  .status-row {
+    display: grid;
+    gap: 0.2rem;
+    padding-bottom: 0.65rem;
+    border-bottom: 1px solid var(--smrt-color-outline-variant);
+  }
+
+  .status-row:last-of-type {
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
+
+  .status-label {
+    font-size: var(--smrt-typography-label-medium-size, 0.75rem);
+    color: var(--smrt-color-on-surface-variant);
+  }
+
+  .status-panel strong {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    font-size: var(--smrt-typography-body-medium-size, 0.875rem);
+  }
+
+  .voice-panel {
+    display: grid;
+    gap: 0.75rem;
+    padding-top: 0.15rem;
+  }
+
+  .voice-field {
+    display: grid;
+    gap: 0.35rem;
+  }
+
+  .voice-field :global(.voice-select) {
+    min-height: 2.2rem;
+    background-color: var(--smrt-color-surface-container-lowest);
+  }
+
+  .voice-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.55rem;
+  }
+
+  .voice-actions :global(.voice-button) {
+    width: 100%;
+    min-height: 2rem;
+  }
+
+  .voice-readout {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+  }
+
+  .voice-readout span {
+    width: 0.6rem;
+    height: 0.6rem;
+    flex: 0 0 auto;
+    border-radius: var(--smrt-radius-full, 9999px);
+    background: var(--smrt-color-outline);
+  }
+
+  .voice-readout span.active {
+    background: var(--smrt-color-success);
+  }
+
+  .voice-meta {
+    display: grid;
+    gap: 0.2rem;
+  }
+
+  .warning {
+    margin: 0;
+    padding: 0.7rem;
+    border: 1px solid var(--smrt-color-warning);
+    border-radius: var(--smrt-radius-md, 8px);
+    background: var(--smrt-color-warning-container);
+    color: var(--smrt-color-on-warning-container);
+    font-size: var(--smrt-typography-body-small-size, 0.75rem);
+    line-height: 1.45;
+  }
+
+  @media (max-width: 820px) {
+    .workspace {
+      grid-template-columns: 1fr;
+    }
+
+    .chat-frame {
+      height: 36rem;
+    }
+  }
+
+  @media (max-width: 600px) {
+    .topbar {
+      align-items: flex-start;
+    }
+
+    .topbar__actions {
+      max-width: 12rem;
+    }
+
+    .workspace {
+      padding: 0.75rem;
+    }
+
+    .chat-frame {
+      height: 34rem;
+      min-height: 28rem;
+    }
+  }
+</style>

--- a/packages/chat/src/routes/api/dev-chat/+server.ts
+++ b/packages/chat/src/routes/api/dev-chat/+server.ts
@@ -1,0 +1,233 @@
+import type { AIMessage, ChatOptions } from '@happyvertical/ai';
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+const MAX_MESSAGES = 24;
+const MAX_CONTENT_LENGTH = 8_000;
+const DEFAULT_MAX_TOKENS = 700;
+
+type DevChatMode = 'ai' | 'local';
+
+interface DevChatRequest {
+  messages?: Array<{
+    role?: unknown;
+    content?: unknown;
+  }>;
+  model?: unknown;
+  temperature?: unknown;
+}
+
+interface DevAIConfig {
+  provider: string;
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+}
+
+function nonEmpty(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function env(name: string): string | undefined {
+  return nonEmpty(process.env[name]);
+}
+
+function apiKeyForProvider(provider: string): string | undefined {
+  const normalized = provider.toLowerCase();
+  const direct =
+    env('SMRT_CHAT_DEV_API_KEY') ||
+    env('SMRT_AI_API_KEY') ||
+    env('HAVE_AI_API_KEY');
+
+  if (direct) {
+    return direct;
+  }
+
+  if (normalized === 'anthropic') return env('ANTHROPIC_API_KEY');
+  if (normalized === 'gemini') return env('GEMINI_API_KEY');
+  if (normalized === 'openai') return env('OPENAI_API_KEY');
+  return undefined;
+}
+
+function resolveDevAIConfig(requestedModel?: string): DevAIConfig | null {
+  const explicitProvider =
+    env('SMRT_CHAT_DEV_PROVIDER') ||
+    env('SMRT_AI_PROVIDER') ||
+    env('HAVE_AI_PROVIDER');
+  const provider =
+    explicitProvider ||
+    (env('OPENAI_API_KEY')
+      ? 'openai'
+      : env('ANTHROPIC_API_KEY')
+        ? 'anthropic'
+        : env('GEMINI_API_KEY')
+          ? 'gemini'
+          : undefined);
+
+  if (!provider) {
+    return null;
+  }
+
+  return {
+    provider,
+    apiKey: apiKeyForProvider(provider),
+    baseUrl:
+      env('SMRT_CHAT_DEV_BASE_URL') ||
+      env('SMRT_AI_BASE_URL') ||
+      env('HAVE_AI_BASE_URL'),
+    model:
+      requestedModel ||
+      env('SMRT_CHAT_DEV_MODEL') ||
+      env('SMRT_AI_MODEL') ||
+      env('HAVE_AI_MODEL'),
+  };
+}
+
+function normalizeMessages(messages: DevChatRequest['messages']): AIMessage[] {
+  if (!Array.isArray(messages)) {
+    return [];
+  }
+
+  return messages.slice(-MAX_MESSAGES).flatMap((message): AIMessage[] => {
+    const role = message.role;
+    if (
+      role !== 'system' &&
+      role !== 'user' &&
+      role !== 'assistant' &&
+      role !== 'tool' &&
+      role !== 'function'
+    ) {
+      return [];
+    }
+
+    const content = nonEmpty(message.content);
+    if (!content) {
+      return [];
+    }
+
+    return [
+      {
+        role,
+        content: content.slice(0, MAX_CONTENT_LENGTH),
+      },
+    ];
+  });
+}
+
+function latestUserMessage(messages: AIMessage[]): string {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role === 'user' && typeof message.content === 'string') {
+      return message.content;
+    }
+  }
+
+  return '';
+}
+
+function localReply(messages: AIMessage[]): string {
+  const latest = latestUserMessage(messages);
+  const trimmed =
+    latest.length > 180 ? `${latest.slice(0, 177).trimEnd()}...` : latest;
+
+  if (!trimmed) {
+    return 'Local dev chat is ready.';
+  }
+
+  return `Local dev reply received: "${trimmed}"`;
+}
+
+function buildChatOptions(
+  aiConfig: DevAIConfig,
+  body: DevChatRequest,
+): ChatOptions {
+  const options: ChatOptions = {
+    maxTokens: DEFAULT_MAX_TOKENS,
+    temperature: typeof body.temperature === 'number' ? body.temperature : 0.4,
+  };
+
+  if (aiConfig.model) {
+    options.model = aiConfig.model;
+  }
+
+  return options;
+}
+
+async function runAIChat(
+  aiConfig: DevAIConfig,
+  messages: AIMessage[],
+  body: DevChatRequest,
+): Promise<{ content: string; model?: string }> {
+  const { getAI } = await import('@happyvertical/ai');
+  const ai = await getAI({
+    type: aiConfig.provider,
+    provider: aiConfig.provider,
+    apiKey: aiConfig.apiKey,
+    baseUrl: aiConfig.baseUrl,
+    defaultModel: aiConfig.model,
+  } as never);
+  const response = await ai.chat(messages, buildChatOptions(aiConfig, body));
+
+  return {
+    content: response.content || localReply(messages),
+    model: response.model || aiConfig.model,
+  };
+}
+
+export const POST: RequestHandler = async ({ request }) => {
+  const body = (await request.json().catch(() => ({}))) as DevChatRequest;
+  const messages = normalizeMessages(body.messages);
+  const requestedModel = nonEmpty(body.model);
+  const aiConfig = resolveDevAIConfig(requestedModel);
+  const seededMessages: AIMessage[] = [
+    {
+      role: 'system',
+      content:
+        'You are the local @happyvertical/smrt-chat dev assistant. Keep replies concise and useful for testing chat UI behavior.',
+    },
+    ...messages,
+  ];
+
+  if (!messages.some((message) => message.role === 'user')) {
+    return json(
+      {
+        mode: 'local' satisfies DevChatMode,
+        content: localReply(messages),
+        configured: Boolean(aiConfig),
+      },
+      { status: 400 },
+    );
+  }
+
+  if (aiConfig) {
+    try {
+      const result = await runAIChat(aiConfig, seededMessages, body);
+      return json({
+        mode: 'ai' satisfies DevChatMode,
+        provider: aiConfig.provider,
+        model: result.model,
+        content: result.content,
+        configured: true,
+      });
+    } catch (error) {
+      return json({
+        mode: 'local' satisfies DevChatMode,
+        provider: aiConfig.provider,
+        model: aiConfig.model,
+        content: localReply(messages),
+        configured: true,
+        warning:
+          error instanceof Error
+            ? `AI request failed: ${error.message}`
+            : 'AI request failed.',
+      });
+    }
+  }
+
+  return json({
+    mode: 'local' satisfies DevChatMode,
+    content: localReply(messages),
+    configured: false,
+  });
+};

--- a/packages/chat/src/routes/api/dev-voice/config/+server.ts
+++ b/packages/chat/src/routes/api/dev-voice/config/+server.ts
@@ -1,0 +1,86 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+
+const DEFAULT_SAMPLE_RATE = 16_000;
+const DEFAULT_GATEWAY_HTTP_URL = 'http://voice-gateway.tail8e7e73.ts.net:8080';
+
+function nonEmpty(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function env(name: string): string | undefined {
+  return nonEmpty(process.env[name]);
+}
+
+function boolEnv(name: string): boolean {
+  const value = env(name)?.toLowerCase();
+  return value === '1' || value === 'true' || value === 'yes';
+}
+
+function httpToWebSocketUrl(httpUrl: string): string {
+  const parsed = new URL(httpUrl);
+  parsed.protocol = parsed.protocol === 'https:' ? 'wss:' : 'ws:';
+  parsed.pathname = '/ws/voice';
+  parsed.search = '';
+  return parsed.toString();
+}
+
+function authHeaders(token: string | undefined): HeadersInit {
+  return token ? { authorization: `Bearer ${token}` } : {};
+}
+
+export const GET: RequestHandler = async ({ fetch }) => {
+  const httpUrl =
+    env('SMRT_CHAT_DEV_VOICE_GATEWAY_HTTP_URL') ||
+    env('VOICE_GATEWAY_BASE_URL') ||
+    DEFAULT_GATEWAY_HTTP_URL;
+  const wsUrl =
+    env('SMRT_CHAT_DEV_VOICE_GATEWAY_WS_URL') || httpToWebSocketUrl(httpUrl);
+  const token =
+    env('SMRT_CHAT_DEV_VOICE_GATEWAY_TOKEN') || env('VOICE_GATEWAY_API_TOKEN');
+  const exposeToken = boolEnv('SMRT_CHAT_DEV_VOICE_GATEWAY_EXPOSE_TOKEN');
+  const defaultTarget = env('SMRT_CHAT_DEV_VOICE_GATEWAY_TARGET') || 'echo';
+
+  let targets: Record<string, Record<string, unknown>> = {
+    [defaultTarget]: { adapter: 'configured' },
+  };
+  let warning: string | undefined;
+
+  try {
+    const response = await fetch(`${httpUrl.replace(/\/$/, '')}/v1/targets`, {
+      headers: authHeaders(token),
+    });
+    const body = (await response.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
+
+    if (!response.ok) {
+      warning =
+        typeof body.detail === 'string'
+          ? body.detail
+          : `Voice gateway target lookup failed with ${response.status}.`;
+    } else if (body.targets && typeof body.targets === 'object') {
+      targets = body.targets as Record<string, Record<string, unknown>>;
+    }
+  } catch (error) {
+    warning =
+      error instanceof Error
+        ? `Voice gateway target lookup failed: ${error.message}`
+        : 'Voice gateway target lookup failed.';
+  }
+
+  return json({
+    configured: Boolean(httpUrl && wsUrl),
+    httpUrl,
+    wsUrl,
+    token: exposeToken ? token : undefined,
+    tokenConfigured: Boolean(token),
+    tokenExposed: exposeToken && Boolean(token),
+    defaultTarget,
+    sampleRate: DEFAULT_SAMPLE_RATE,
+    targets,
+    warning,
+  });
+};

--- a/packages/chat/src/routes/api/dev-voice/config/+server.ts
+++ b/packages/chat/src/routes/api/dev-voice/config/+server.ts
@@ -1,7 +1,7 @@
 import { json, type RequestHandler } from '@sveltejs/kit';
 
 const DEFAULT_SAMPLE_RATE = 16_000;
-const DEFAULT_GATEWAY_HTTP_URL = 'http://voice-gateway.tail8e7e73.ts.net:8080';
+const DEFAULT_GATEWAY_HTTP_URL = 'http://127.0.0.1:8080';
 
 function nonEmpty(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim().length > 0

--- a/packages/chat/src/routes/previews/+page.svelte
+++ b/packages/chat/src/routes/previews/+page.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+import { PlaygroundHost } from '@happyvertical/smrt-playground/svelte';
+import chatPlayground from '../../playground.js';
+
+const modules = [chatPlayground];
+</script>
+
+<PlaygroundHost
+  title="Chat Previews"
+  subtitle="Component previews for @happyvertical/smrt-chat."
+  {modules}
+/>

--- a/packages/chat/src/services/ChatService.ts
+++ b/packages/chat/src/services/ChatService.ts
@@ -8,6 +8,7 @@ import { ChatParticipantCollection } from '../collections/ChatParticipantCollect
 import { ChatReactionCollection } from '../collections/ChatReactionCollection.js';
 import { ChatRoomCollection } from '../collections/ChatRoomCollection.js';
 import { ChatThreadCollection } from '../collections/ChatThreadCollection.js';
+import { VoiceSessionCollection } from '../collections/VoiceSessionCollection.js';
 import type { AgentSession } from '../models/AgentSession.js';
 import type { ChatMessage } from '../models/ChatMessage.js';
 import type { ChatThread } from '../models/ChatThread.js';
@@ -97,6 +98,7 @@ export class ChatService {
   readonly #threads: ChatThreadCollection;
   readonly #agentSessions: AgentSessionCollection;
   readonly #reactions: ChatReactionCollection;
+  readonly #voiceSessions: VoiceSessionCollection;
 
   private constructor(
     rooms: ChatRoomCollection,
@@ -105,6 +107,7 @@ export class ChatService {
     threads: ChatThreadCollection,
     agentSessions: AgentSessionCollection,
     reactions: ChatReactionCollection,
+    voiceSessions: VoiceSessionCollection,
   ) {
     this.#rooms = rooms;
     this.#messages = messages;
@@ -112,6 +115,7 @@ export class ChatService {
     this.#threads = threads;
     this.#agentSessions = agentSessions;
     this.#reactions = reactions;
+    this.#voiceSessions = voiceSessions;
   }
 
   static async create(options: SmrtObjectOptions): Promise<ChatService> {
@@ -139,6 +143,10 @@ export class ChatService {
       '@happyvertical/smrt-chat:ChatReaction',
       ChatReactionCollection,
     );
+    ObjectRegistry.registerCollection(
+      '@happyvertical/smrt-chat:VoiceSession',
+      VoiceSessionCollection,
+    );
 
     const rooms = (await ObjectRegistry.getCollection(
       '@happyvertical/smrt-chat:ChatRoom',
@@ -164,6 +172,10 @@ export class ChatService {
       '@happyvertical/smrt-chat:ChatReaction',
       options,
     )) as ChatReactionCollection;
+    const voiceSessions = (await ObjectRegistry.getCollection(
+      '@happyvertical/smrt-chat:VoiceSession',
+      options,
+    )) as VoiceSessionCollection;
 
     return new ChatService(
       rooms,
@@ -172,6 +184,7 @@ export class ChatService {
       threads,
       agentSessions,
       reactions,
+      voiceSessions,
     );
   }
 
@@ -183,6 +196,7 @@ export class ChatService {
     await this.#threads.initialize();
     await this.#agentSessions.initialize();
     await this.#reactions.initialize();
+    await this.#voiceSessions.initialize();
   }
 
   /**

--- a/packages/chat/src/svelte/components/layout/ChatLayout.svelte
+++ b/packages/chat/src/svelte/components/layout/ChatLayout.svelte
@@ -146,11 +146,15 @@ function handlePointerUp() {
   }
 
   @media (max-width: 600px) {
+    .chat-layout {
+      flex-direction: column;
+    }
+
     .chat-layout__sidebar {
       width: 100% !important;
-      position: absolute;
-      inset: 0;
-      z-index: 10;
+      max-height: 14rem;
+      border-right: 0;
+      border-bottom: 1px solid var(--smrt-color-outline-variant, #c4c6d0);
     }
 
     .chat-layout__resize-handle {

--- a/packages/chat/src/svelte/components/messages/MessageInput.svelte
+++ b/packages/chat/src/svelte/components/messages/MessageInput.svelte
@@ -5,7 +5,6 @@
  */
 import { Textarea } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
-import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../../i18n.messages.js';
 
 const { t } = useI18n();
@@ -69,16 +68,15 @@ function handleInput(event: Event) {
         <span class="message-input__reply-text">{replyTo.content}</span>
       </div>
       {#if oncancelreply}
-        <Button
-          variant="ghost"
-          size="sm"
+        <!-- raw-primitive-allow: compact icon-only composer control; uses the component's local button geometry and avoids wrapper event forwarding in the dev-server browser path -->
+        <button
           class="message-input__reply-close"
           type="button"
           onclick={oncancelreply}
           aria-label={t(M['chat.message_input.cancel_reply'])}
         >
           <svg viewBox="0 0 16 16" width="14" height="14"><path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" /></svg>
-        </Button>
+        </button>
       {/if}
     </div>
   {/if}
@@ -94,8 +92,8 @@ function handleInput(event: Event) {
       oninput={handleInput}
       aria-label={t(M['chat.message_input.input_label'])}
     />
-    <Button
-      variant="ghost"
+    <!-- raw-primitive-allow: compact icon-only composer submit control; native button is required so pointer clicks and Enter-submit share the same local handler in package dev servers -->
+    <button
       class="message-input__send"
       type="button"
       onclick={handleSend}
@@ -112,7 +110,7 @@ function handleInput(event: Event) {
           stroke-linejoin="round"
         />
       </svg>
-    </Button>
+    </button>
   </div>
 </div>
 
@@ -162,18 +160,22 @@ function handleInput(event: Event) {
     text-overflow: ellipsis;
   }
 
-  /* :global() pierces into the Button child's rendered <button> (see #1589). */
-  .message-input__reply :global(.message-input__reply-close) {
+  .message-input__reply-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     width: 24px;
     height: 24px;
     padding: 0;
+    border: 0;
     border-radius: var(--smrt-radius-small, 0.25rem);
     background: transparent;
     color: var(--smrt-color-on-surface-variant, #43474e);
+    cursor: pointer;
     flex-shrink: 0;
   }
 
-  .message-input__reply :global(.message-input__reply-close:hover) {
+  .message-input__reply-close:hover {
     background: var(--smrt-color-surface-container-high, #e1e3e8);
   }
 
@@ -195,24 +197,29 @@ function handleInput(event: Event) {
     overflow-y: auto;
   }
 
-  /* :global() pierces into the Button child's rendered <button> (see #1589). */
-  .message-input__bar :global(.message-input__send) {
+  .message-input__send {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     width: 36px;
     height: 36px;
     padding: 0;
+    border: 0;
     border-radius: var(--smrt-radius-full, 9999px);
     background: var(--smrt-color-primary, #005ac1);
     color: var(--smrt-color-on-primary, #ffffff);
+    cursor: pointer;
     flex-shrink: 0;
     transition: background var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);
   }
 
-  .message-input__bar :global(.message-input__send:hover:not(:disabled)) {
+  .message-input__send:hover:not(:disabled) {
     background: color-mix(in srgb, var(--smrt-color-primary, #005ac1) 85%, var(--smrt-color-shadow, #000));
   }
 
-  .message-input__bar :global(.message-input__send:disabled) {
+  .message-input__send:disabled {
     background: var(--smrt-color-surface-container-high, #e1e3e8);
     color: var(--smrt-color-outline, #74777f);
+    cursor: default;
   }
 </style>

--- a/packages/chat/src/tool-loop.test.ts
+++ b/packages/chat/src/tool-loop.test.ts
@@ -21,7 +21,12 @@ import type {
   AIResponse,
   ChatOptions,
 } from '@happyvertical/ai';
-import { ObjectRegistry, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  field,
+  ObjectRegistry,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import {
   MembershipCollection,
   PermissionCollection,
@@ -51,7 +56,11 @@ import {
 })
 class ToolLoopNote extends SmrtObject {
   tenantId: string | null = null;
+
+  @field()
   title = '';
+
+  @field()
   body = '';
 
   /** A public custom action → a `tool_loop_notes.archive` catalog tool. */

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -16,6 +16,7 @@ export type ChatMessageType =
   | 'tool_result';
 export type ChatMessageRole = 'user' | 'assistant' | 'system' | 'tool';
 export type AgentSessionStatus = 'active' | 'closed' | 'expired';
+export type VoiceSessionStatus = 'active' | 'expired' | 'revoked';
 
 // ---- Options Interfaces ----
 
@@ -101,6 +102,25 @@ export interface AgentSessionOptions extends SmrtObjectOptions {
   lastMessageAt?: Date | null;
   expiresAt?: Date | null;
   closedAt?: Date | null;
+}
+
+export interface VoiceSessionOptions extends SmrtObjectOptions {
+  tenantId?: string;
+  gatewaySessionId?: string;
+  actorProfileId?: string;
+  actorUserId?: string | null;
+  personaId?: string;
+  agentSessionId?: string;
+  chatRoomId?: string;
+  threadId?: string | null;
+  target?: string;
+  status?: VoiceSessionStatus;
+  expiresAt?: Date;
+  lastTurnAt?: Date | null;
+  lastGatewayTurnId?: string | null;
+  personaSnapshot?: Record<string, unknown> | string;
+  metadata?: Record<string, unknown> | string;
+  processedTurnIds?: string[] | string;
 }
 
 // ---- Search / Filter types ----

--- a/packages/chat/src/types.ts
+++ b/packages/chat/src/types.ts
@@ -17,6 +17,7 @@ export type ChatMessageType =
 export type ChatMessageRole = 'user' | 'assistant' | 'system' | 'tool';
 export type AgentSessionStatus = 'active' | 'closed' | 'expired';
 export type VoiceSessionStatus = 'active' | 'expired' | 'revoked';
+export type VoiceGatewayTurnStatus = 'processing' | 'completed' | 'failed';
 
 // ---- Options Interfaces ----
 
@@ -121,6 +122,17 @@ export interface VoiceSessionOptions extends SmrtObjectOptions {
   personaSnapshot?: Record<string, unknown> | string;
   metadata?: Record<string, unknown> | string;
   processedTurnIds?: string[] | string;
+}
+
+export interface VoiceGatewayTurnOptions extends SmrtObjectOptions {
+  tenantId?: string;
+  voiceSessionId?: string;
+  gatewaySessionId?: string;
+  gatewayTurnId?: string;
+  target?: string;
+  status?: VoiceGatewayTurnStatus;
+  completedAt?: Date | null;
+  failedAt?: Date | null;
 }
 
 // ---- Search / Filter types ----

--- a/packages/chat/src/ui.ts
+++ b/packages/chat/src/ui.ts
@@ -78,6 +78,7 @@ export const CHAT_MODULE_META: SmrtModuleMeta = {
     'ChatParticipant',
     'ChatReaction',
     'AgentSession',
+    'VoiceSession',
   ],
   collections: [
     'ChatRoomCollection',
@@ -86,5 +87,6 @@ export const CHAT_MODULE_META: SmrtModuleMeta = {
     'ChatParticipantCollection',
     'ChatReactionCollection',
     'AgentSessionCollection',
+    'VoiceSessionCollection',
   ],
 };

--- a/packages/chat/src/voice.test.ts
+++ b/packages/chat/src/voice.test.ts
@@ -27,7 +27,10 @@ import {
   createVoiceChatSession,
   createVoiceGatewayTurnHandler,
   handleVoiceGatewayTurn,
+  MAX_VOICE_GATEWAY_TEXT_LENGTH,
   SMRT_CHAT_VOICE_TARGET,
+  VoiceGatewayBadRequestError,
+  VoiceGatewayReplayError,
   type VoiceGatewayTurnPayload,
   VoiceSessionExpiredError,
   VoiceSessionRejectedError,
@@ -304,6 +307,113 @@ describe('voice gateway chat integration', () => {
       limit: 10,
     });
     expect(messages).toHaveLength(0);
+  });
+
+  it('rejects oversized gateway text before creating chat messages', async () => {
+    const voiceSession = await createVoiceChatSession({
+      chatService: chat,
+      db,
+      tenantId,
+      actorProfileId: 'speaker-profile',
+      persona,
+      ttlSeconds: 60,
+    });
+    const { ai } = makeAI(() => textResponse('should not run'));
+
+    await expect(
+      handleVoiceGatewayTurn({
+        chatService: chat,
+        db,
+        ai,
+        payload: payloadFor(voiceSession, {
+          text: 'x'.repeat(MAX_VOICE_GATEWAY_TEXT_LENGTH + 1),
+        }),
+        recall: false,
+      }),
+    ).rejects.toBeInstanceOf(VoiceGatewayBadRequestError);
+
+    const messages = await chat.getRoomMessages({
+      roomId: voiceSession.chatRoomId,
+      actorProfileId: 'speaker-profile',
+      tenantId,
+      limit: 10,
+    });
+    expect(messages).toHaveLength(0);
+  });
+
+  it('rejects an invalid persona snapshot before creating chat messages', async () => {
+    const voiceSession = await createVoiceChatSession({
+      chatService: chat,
+      db,
+      tenantId,
+      actorProfileId: 'speaker-profile',
+      persona,
+      ttlSeconds: 60,
+    });
+    voiceSession.voiceSession.setPersonaSnapshot({
+      ...persona,
+      runAsUserId: '',
+    });
+    await voiceSession.voiceSession.save();
+    const { ai } = makeAI(() => textResponse('should not run'));
+
+    await expect(
+      handleVoiceGatewayTurn({
+        chatService: chat,
+        db,
+        ai,
+        payload: payloadFor(voiceSession),
+        recall: false,
+      }),
+    ).rejects.toBeInstanceOf(VoiceSessionRejectedError);
+
+    const messages = await chat.getRoomMessages({
+      roomId: voiceSession.chatRoomId,
+      actorProfileId: 'speaker-profile',
+      tenantId,
+      limit: 10,
+    });
+    expect(messages).toHaveLength(0);
+  });
+
+  it('rejects duplicate gateway turn ids with one persisted transcript', async () => {
+    const voiceSession = await createVoiceChatSession({
+      chatService: chat,
+      db,
+      tenantId,
+      actorProfileId: 'speaker-profile',
+      persona,
+      ttlSeconds: 60,
+    });
+    const { ai } = makeAI(() => textResponse('I heard you.'));
+    const payload = payloadFor(voiceSession);
+
+    await handleVoiceGatewayTurn({
+      chatService: chat,
+      db,
+      ai,
+      payload,
+      recall: false,
+    });
+
+    await expect(
+      handleVoiceGatewayTurn({
+        chatService: chat,
+        db,
+        ai,
+        payload,
+        recall: false,
+      }),
+    ).rejects.toBeInstanceOf(VoiceGatewayReplayError);
+
+    const messages = await chat.getRoomMessages({
+      roomId: voiceSession.chatRoomId,
+      actorProfileId: 'speaker-profile',
+      tenantId,
+      limit: 10,
+    });
+    expect(messages.filter((m) => m.role === 'user')).toHaveLength(1);
+    expect(messages.filter((m) => m.role === 'assistant')).toHaveLength(1);
   });
 
   it('rejects an invalid gateway bearer token through the HTTP handler', async () => {

--- a/packages/chat/src/voice.test.ts
+++ b/packages/chat/src/voice.test.ts
@@ -1,0 +1,387 @@
+import { existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  AIInterface,
+  AIMessage,
+  AIResponse,
+  ChatOptions,
+} from '@happyvertical/ai';
+import {
+  field,
+  ObjectRegistry,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import {
+  MembershipCollection,
+  RoleCollection,
+  TenantCollection,
+  UserCollection,
+} from '@happyvertical/smrt-users';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ConversationPersona } from './persona-conversation.js';
+import { ChatService } from './services/index.js';
+import {
+  createVoiceChatSession,
+  createVoiceGatewayTurnHandler,
+  handleVoiceGatewayTurn,
+  SMRT_CHAT_VOICE_TARGET,
+  type VoiceGatewayTurnPayload,
+  VoiceSessionExpiredError,
+  VoiceSessionRejectedError,
+} from './voice.js';
+
+@smrt({
+  api: { include: ['list', 'get', 'create', 'delete'] },
+  collection: 'voice_notes',
+  tableName: 'voice_notes',
+  tenantScoped: { field: 'tenantId', mode: 'optional' },
+})
+class VoiceNote extends SmrtObject {
+  tenantId: string | null = null;
+
+  @field()
+  title = '';
+}
+void VoiceNote;
+
+interface Captured {
+  messages: AIMessage[];
+  options: ChatOptions | undefined;
+}
+
+function makeAI(
+  handler: (
+    call: number,
+    offered: boolean,
+    messages: AIMessage[],
+    options?: ChatOptions,
+  ) => AIResponse,
+): {
+  ai: AIInterface;
+  captured: Captured[];
+} {
+  const captured: Captured[] = [];
+  const ai = {
+    async chat(messages: AIMessage[], options?: ChatOptions) {
+      const offered =
+        Array.isArray(options?.tools) &&
+        options.tools.length > 0 &&
+        options.toolChoice !== 'none';
+      captured.push({ messages, options });
+      return handler(captured.length - 1, offered, messages, options);
+    },
+  } as unknown as AIInterface;
+  return { ai, captured };
+}
+
+function textResponse(content: string): AIResponse {
+  return { content, finishReason: 'stop' } as AIResponse;
+}
+
+function toolCall(name: string, args: Record<string, unknown>): AIResponse {
+  return {
+    content: '',
+    finishReason: 'tool_calls',
+    toolCalls: [
+      {
+        id: `tc_${Math.random().toString(36).slice(2)}`,
+        type: 'function',
+        function: { name, arguments: JSON.stringify(args) },
+      },
+    ],
+  };
+}
+
+describe('voice gateway chat integration', () => {
+  let dbPath: string;
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+  let chat: ChatService;
+  let tenantId: string;
+  let runAsUserId: string;
+  let persona: ConversationPersona;
+
+  beforeEach(async () => {
+    dbPath = join(
+      tmpdir(),
+      `smrt-chat-voice-${Date.now()}-${Math.random()}.db`,
+    );
+    db = await getDatabase({ type: 'sqlite', url: dbPath });
+
+    const users = await UserCollection.create({ db });
+    const tenants = await TenantCollection.create({ db });
+    const roles = await RoleCollection.create({ db });
+    const memberships = await MembershipCollection.create({ db });
+
+    const user = await users.create({ email: 'voice-persona@example.com' });
+    await user.save();
+    const tenant = await tenants.create({ name: 'Voice Org' });
+    await tenant.save();
+    const role = await roles.create({ name: 'Voice Persona' });
+    await role.save();
+    await (
+      await memberships.create({
+        userId: user.id,
+        tenantId: tenant.id,
+        roleId: role.id,
+      })
+    ).save();
+
+    tenantId = tenant.id as string;
+    runAsUserId = user.id as string;
+    persona = {
+      id: 'persona-voice',
+      tenantId,
+      agentClass: '@happyvertical/smrt-agents:Praeco',
+      runAsUserId,
+      actsAsProfileId: 'voice-agent-profile',
+      allowedTools: [],
+      instructions: 'Answer voice chat turns plainly.',
+      memoryScope: `voice:${tenantId}`,
+    };
+
+    chat = await ChatService.create({ db });
+    await chat.initialize();
+  });
+
+  afterEach(() => {
+    if (existsSync(dbPath)) {
+      try {
+        rmSync(dbPath, { force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+
+  function payloadFor(
+    session: Awaited<ReturnType<typeof createVoiceChatSession>>,
+    overrides: Partial<VoiceGatewayTurnPayload> = {},
+  ): VoiceGatewayTurnPayload {
+    return {
+      session_id: session.gatewaySessionId,
+      turn_id: 'turn-1',
+      target: SMRT_CHAT_VOICE_TARGET,
+      actor: 'Speaker',
+      text: 'hello from voice',
+      metadata: {
+        ...session.metadata,
+        source: 'voice-gateway',
+      },
+      ...overrides,
+    };
+  }
+
+  it('persists a gateway transcript and persona response as normal chat messages', async () => {
+    const voiceSession = await createVoiceChatSession({
+      chatService: chat,
+      db,
+      tenantId,
+      actorProfileId: 'speaker-profile',
+      actorUserId: 'speaker-user',
+      persona,
+      ttlSeconds: 60,
+    });
+    const { ai } = makeAI(() => textResponse('I heard you.'));
+
+    const response = await handleVoiceGatewayTurn({
+      chatService: chat,
+      db,
+      ai,
+      payload: payloadFor(voiceSession),
+      recall: false,
+    });
+
+    expect(response).toMatchObject({
+      session_id: voiceSession.gatewaySessionId,
+      turn_id: 'turn-1',
+      text: 'I heard you.',
+      metadata: {
+        tenantId,
+        chatRoomId: voiceSession.chatRoomId,
+        agentSessionId: voiceSession.agentSessionId,
+        personaId: 'persona-voice',
+        voiceSessionId: voiceSession.voiceSessionId,
+      },
+    });
+    expect(response.metadata.userMessageId).toBeTruthy();
+    expect(response.metadata.assistantMessageId).toBeTruthy();
+    expect(response.metadata.correlationId).toBeTruthy();
+
+    const messages = await chat.getRoomMessages({
+      roomId: voiceSession.chatRoomId,
+      actorProfileId: 'speaker-profile',
+      tenantId,
+      limit: 10,
+    });
+    const transcript = messages.find((m) => m.role === 'user');
+    const assistant = messages.find((m) => m.role === 'assistant');
+
+    expect(transcript?.content).toBe('hello from voice');
+    expect(transcript?.agentSessionId).toBe(voiceSession.agentSessionId);
+    expect(transcript?.getMetadata()).toMatchObject({
+      source: 'voice-gateway',
+      voiceSessionId: voiceSession.voiceSessionId,
+      gatewayTurnId: 'turn-1',
+      voiceRole: 'transcript',
+      correlationId: response.metadata.correlationId,
+    });
+
+    expect(assistant?.content).toBe('I heard you.');
+    expect(assistant?.agentSessionId).toBe(voiceSession.agentSessionId);
+    expect(assistant?.getMetadata()).toMatchObject({
+      source: 'voice-gateway',
+      voiceSessionId: voiceSession.voiceSessionId,
+      gatewayTurnId: 'turn-1',
+      voiceRole: 'assistant',
+      correlationId: response.metadata.correlationId,
+    });
+  });
+
+  it('rejects an expired voice session before creating chat messages', async () => {
+    const voiceSession = await createVoiceChatSession({
+      chatService: chat,
+      db,
+      tenantId,
+      actorProfileId: 'speaker-profile',
+      persona,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    const { ai } = makeAI(() => textResponse('should not run'));
+
+    await expect(
+      handleVoiceGatewayTurn({
+        chatService: chat,
+        db,
+        ai,
+        payload: payloadFor(voiceSession),
+        recall: false,
+      }),
+    ).rejects.toBeInstanceOf(VoiceSessionExpiredError);
+
+    const messages = await chat.getRoomMessages({
+      roomId: voiceSession.chatRoomId,
+      actorProfileId: 'speaker-profile',
+      tenantId,
+      limit: 10,
+    });
+    expect(messages).toHaveLength(0);
+  });
+
+  it('rejects gateway metadata that conflicts with the server-side tenant binding', async () => {
+    const voiceSession = await createVoiceChatSession({
+      chatService: chat,
+      db,
+      tenantId,
+      actorProfileId: 'speaker-profile',
+      persona,
+      ttlSeconds: 60,
+    });
+    const { ai } = makeAI(() => textResponse('should not run'));
+
+    await expect(
+      handleVoiceGatewayTurn({
+        chatService: chat,
+        db,
+        ai,
+        payload: payloadFor(voiceSession, {
+          metadata: {
+            ...voiceSession.metadata,
+            tenantId: 'other-tenant',
+            source: 'voice-gateway',
+          },
+        }),
+        recall: false,
+      }),
+    ).rejects.toBeInstanceOf(VoiceSessionRejectedError);
+
+    const messages = await chat.getRoomMessages({
+      roomId: voiceSession.chatRoomId,
+      actorProfileId: 'speaker-profile',
+      tenantId,
+      limit: 10,
+    });
+    expect(messages).toHaveLength(0);
+  });
+
+  it('rejects an invalid gateway bearer token through the HTTP handler', async () => {
+    const voiceSession = await createVoiceChatSession({
+      chatService: chat,
+      db,
+      tenantId,
+      actorProfileId: 'speaker-profile',
+      persona,
+      ttlSeconds: 60,
+    });
+    const { ai } = makeAI(() => textResponse('should not run'));
+    const handler = createVoiceGatewayTurnHandler({
+      chatService: chat,
+      db,
+      ai,
+      gatewayToken: 'correct-token',
+      recall: false,
+    });
+
+    const response = await handler(
+      new Request('http://localhost/api/voice/smrt-chat/turn', {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer wrong-token',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(payloadFor(voiceSession)),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    const messages = await chat.getRoomMessages({
+      roomId: voiceSession.chatRoomId,
+      actorProfileId: 'speaker-profile',
+      tenantId,
+      limit: 10,
+    });
+    expect(messages).toHaveLength(0);
+  });
+
+  it('keeps persona tool allow-list enforcement on voice turns', async () => {
+    persona = { ...persona, allowedTools: ['voice_notes.read'] };
+    const notes = await ObjectRegistry.getCollection('VoiceNote', { db });
+    const note = await notes.create({ tenantId, title: 'Keep this note' });
+    await note.save();
+
+    const voiceSession = await createVoiceChatSession({
+      chatService: chat,
+      db,
+      tenantId,
+      actorProfileId: 'speaker-profile',
+      persona,
+      ttlSeconds: 60,
+    });
+    const { ai } = makeAI((call, offered) =>
+      call === 0 && offered
+        ? toolCall('voice_notes.delete', { id: note.id })
+        : textResponse('I cannot delete that.'),
+    );
+
+    const response = await handleVoiceGatewayTurn({
+      chatService: chat,
+      db,
+      ai,
+      payload: payloadFor(voiceSession),
+      recall: false,
+    });
+
+    expect(response.text).toBe('I cannot delete that.');
+    expect(await notes.get({ id: note.id })).toBeTruthy();
+
+    const messages = await chat.getRoomMessages({
+      roomId: voiceSession.chatRoomId,
+      actorProfileId: 'speaker-profile',
+      tenantId,
+      limit: 10,
+    });
+    expect(messages.filter((m) => m.role === 'tool')).toHaveLength(0);
+  });
+});

--- a/packages/chat/src/voice.ts
+++ b/packages/chat/src/voice.ts
@@ -1,0 +1,715 @@
+import type { AIInterface, AIMessage } from '@happyvertical/ai';
+import type { PrincipalAuditSink } from '@happyvertical/smrt-agents';
+import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import { VoiceSessionCollection } from './collections/VoiceSessionCollection.js';
+import type { ChatMessage } from './models/ChatMessage.js';
+import type { VoiceSession } from './models/VoiceSession.js';
+import {
+  bindPersonaToSession,
+  type ConversationPersona,
+  type PersonaRecallOptions,
+  runPersonaConversationTurn,
+} from './persona-conversation.js';
+import type { ChatService } from './services/index.js';
+
+export const SMRT_CHAT_VOICE_TARGET = 'smrt:chat';
+const DEFAULT_VOICE_SESSION_TTL_SECONDS = 10 * 60;
+const DEFAULT_HISTORY_LIMIT = 24;
+
+export interface VoiceGatewayTurnMetadata {
+  tenantId?: string;
+  actorProfileId?: string;
+  chatRoomId?: string;
+  threadId?: string;
+  agentSessionId?: string;
+  personaId?: string;
+  voiceSessionId?: string;
+  source?: string;
+  [key: string]: unknown;
+}
+
+export interface VoiceGatewayTurnPayload {
+  session_id: string;
+  turn_id: string;
+  target: string;
+  actor?: string;
+  text: string;
+  metadata?: VoiceGatewayTurnMetadata;
+}
+
+export interface VoiceGatewayTurnResponseMetadata {
+  tenantId: string;
+  chatRoomId: string;
+  threadId: string | null;
+  agentSessionId: string;
+  userMessageId: string;
+  assistantMessageId: string | null;
+  personaId: string;
+  correlationId: string;
+  voiceSessionId: string;
+  source: string;
+}
+
+export interface VoiceGatewayTurnResponse {
+  session_id: string;
+  turn_id: string;
+  text: string;
+  metadata: VoiceGatewayTurnResponseMetadata;
+}
+
+export interface CreateVoiceChatSessionOptions {
+  chatService: ChatService;
+  db: SmrtClassOptions['db'];
+  tenantId: string;
+  actorProfileId: string;
+  actorUserId?: string | null;
+  persona: ConversationPersona;
+  /** Existing agent session to bind voice to. Omit to create/reuse one. */
+  agentSessionId?: string;
+  /** Agent profile/session author id when creating a new agent session. */
+  agentId?: string;
+  /** Optional existing thread within the bound session room. */
+  threadId?: string | null;
+  /** Stable gateway-level `session_id`. Generated when omitted. */
+  gatewaySessionId?: string;
+  /** Subject key forwarded to ChatService.createAgentSession(). */
+  sessionKey?: string | null;
+  /** Voice binding TTL. Ignored when `expiresAt` is supplied. */
+  ttlSeconds?: number;
+  expiresAt?: Date;
+  metadata?: Record<string, unknown>;
+  target?: string;
+  maxTokens?: number;
+  maxMessages?: number;
+  instructions?: string;
+}
+
+export interface VoiceChatSessionCreationResult {
+  voiceSession: VoiceSession;
+  voiceSessionId: string;
+  gatewaySessionId: string;
+  expiresAt: Date;
+  tenantId: string;
+  actorProfileId: string;
+  personaId: string;
+  agentSessionId: string;
+  chatRoomId: string;
+  threadId: string | null;
+  metadata: VoiceGatewayTurnMetadata;
+}
+
+export interface HandleVoiceGatewayTurnOptions {
+  chatService: ChatService;
+  db: SmrtClassOptions['db'];
+  ai: AIInterface;
+  payload: VoiceGatewayTurnPayload;
+  now?: Date;
+  historyLimit?: number;
+  recall?: PersonaRecallOptions | false;
+  model?: string;
+  temperature?: number;
+  maxTokens?: number;
+  maxSteps?: number;
+  postgresRls?: boolean;
+  audit?: PrincipalAuditSink;
+}
+
+export interface VoiceGatewayTurnHandlerOptions
+  extends Omit<HandleVoiceGatewayTurnOptions, 'payload'> {
+  gatewayToken: string | (() => string | Promise<string>);
+}
+
+export class VoiceGatewayError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(message: string, status: number, code: string) {
+    super(message);
+    this.name = 'VoiceGatewayError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export class VoiceGatewayBadRequestError extends VoiceGatewayError {
+  constructor(message: string) {
+    super(message, 400, 'voice_gateway_bad_request');
+    this.name = 'VoiceGatewayBadRequestError';
+  }
+}
+
+export class VoiceGatewayUnauthorizedError extends VoiceGatewayError {
+  constructor(message = 'Voice gateway authorization failed') {
+    super(message, 401, 'voice_gateway_unauthorized');
+    this.name = 'VoiceGatewayUnauthorizedError';
+  }
+}
+
+export class VoiceSessionRejectedError extends VoiceGatewayError {
+  constructor(message: string) {
+    super(message, 403, 'voice_session_rejected');
+    this.name = 'VoiceSessionRejectedError';
+  }
+}
+
+export class VoiceSessionExpiredError extends VoiceGatewayError {
+  constructor(message = 'Voice session is expired') {
+    super(message, 410, 'voice_session_expired');
+    this.name = 'VoiceSessionExpiredError';
+  }
+}
+
+export class VoiceGatewayReplayError extends VoiceGatewayError {
+  constructor(message = 'Voice gateway turn has already been processed') {
+    super(message, 409, 'voice_gateway_replay');
+    this.name = 'VoiceGatewayReplayError';
+  }
+}
+
+export async function createVoiceChatSession(
+  options: CreateVoiceChatSessionOptions,
+): Promise<VoiceChatSessionCreationResult> {
+  const target = options.target ?? SMRT_CHAT_VOICE_TARGET;
+  const personaId = requireNonEmptyString(
+    options.persona.id,
+    'createVoiceChatSession requires a persisted persona id',
+  );
+  if (
+    options.persona.tenantId !== null &&
+    options.persona.tenantId !== options.tenantId
+  ) {
+    throw new VoiceSessionRejectedError(
+      'Persona tenant does not match the voice session tenant',
+    );
+  }
+
+  const persona: ConversationPersona = {
+    ...options.persona,
+    id: personaId,
+    tenantId: options.tenantId,
+  };
+
+  let agentSession = options.agentSessionId
+    ? await options.chatService.getAgentSession({
+        agentSessionId: options.agentSessionId,
+        tenantId: options.tenantId,
+      })
+    : null;
+
+  if (options.agentSessionId) {
+    if (!agentSession) {
+      throw new VoiceSessionRejectedError('Agent session not found');
+    }
+    assertAgentSessionMatchesActor(agentSession, options.actorProfileId);
+    assertActiveAgentSession(agentSession);
+  } else {
+    const agentId =
+      options.agentId ??
+      persona.actsAsProfileId ??
+      persona.id ??
+      persona.agentClass;
+    if (!agentId) {
+      throw new VoiceGatewayBadRequestError(
+        'createVoiceChatSession requires agentId when the persona has no acting profile or id',
+      );
+    }
+    const created = await options.chatService.createAgentSession({
+      tenantId: options.tenantId,
+      agentId,
+      actorProfileId: options.actorProfileId,
+      allowedTools: persona.allowedTools,
+      systemPrompt: options.instructions ?? persona.instructions,
+      maxTokens: options.maxTokens,
+      maxMessages: options.maxMessages,
+      sessionKey: options.sessionKey,
+    });
+    agentSession = created.session;
+  }
+
+  const boundSession = await bindPersonaToSession({
+    chatService: options.chatService,
+    session: agentSession,
+    actorProfileId: options.actorProfileId,
+    tenantId: options.tenantId,
+    persona,
+    instructions: options.instructions,
+    db: options.db,
+  });
+  assertActiveAgentSession(boundSession);
+
+  const chatRoomId = requireNonEmptyString(
+    boundSession.chatRoomId,
+    'Agent session has no chat room',
+  );
+  await options.chatService.getRoomForMember(
+    chatRoomId,
+    options.actorProfileId,
+    options.tenantId,
+  );
+
+  const threadId = options.threadId ?? null;
+  if (threadId) {
+    const thread = await options.chatService.getThread({
+      threadId,
+      tenantId: options.tenantId,
+    });
+    if (!thread || thread.roomId !== chatRoomId) {
+      throw new VoiceSessionRejectedError(
+        'threadId does not belong to the bound agent session room',
+      );
+    }
+  }
+
+  const voiceSessions = await VoiceSessionCollection.create({ db: options.db });
+  const gatewaySessionId = options.gatewaySessionId ?? crypto.randomUUID();
+  const expiresAt =
+    options.expiresAt ??
+    new Date(
+      Date.now() +
+        (options.ttlSeconds ?? DEFAULT_VOICE_SESSION_TTL_SECONDS) * 1000,
+    );
+
+  const voiceSession = await voiceSessions.create({
+    tenantId: options.tenantId,
+    gatewaySessionId,
+    actorProfileId: options.actorProfileId,
+    actorUserId: options.actorUserId ?? null,
+    personaId,
+    agentSessionId: boundSession.id as string,
+    chatRoomId,
+    threadId,
+    target,
+    status: 'active',
+    expiresAt,
+    personaSnapshot: JSON.stringify(persona),
+    metadata: JSON.stringify(options.metadata ?? {}),
+  });
+
+  const voiceSessionId = voiceSession.id as string;
+  return {
+    voiceSession,
+    voiceSessionId,
+    gatewaySessionId,
+    expiresAt,
+    tenantId: options.tenantId,
+    actorProfileId: options.actorProfileId,
+    personaId,
+    agentSessionId: boundSession.id as string,
+    chatRoomId,
+    threadId,
+    metadata: {
+      tenantId: options.tenantId,
+      actorProfileId: options.actorProfileId,
+      chatRoomId,
+      threadId: threadId ?? undefined,
+      agentSessionId: boundSession.id as string,
+      personaId,
+      voiceSessionId,
+      source: 'smrt-chat',
+    },
+  };
+}
+
+export async function handleVoiceGatewayTurn(
+  options: HandleVoiceGatewayTurnOptions,
+): Promise<VoiceGatewayTurnResponse> {
+  const payload = normalizeGatewayPayload(options.payload);
+  const metadata = payload.metadata ?? {};
+  const voiceSessionId = requireNonEmptyString(
+    metadata.voiceSessionId,
+    'Voice gateway payload metadata.voiceSessionId is required',
+  );
+
+  const voiceSessions = await VoiceSessionCollection.create({ db: options.db });
+  const voiceSession = await voiceSessions.get({
+    id: voiceSessionId,
+    target: payload.target,
+  });
+  if (!voiceSession) {
+    throw new VoiceSessionRejectedError('Voice session not found');
+  }
+  if (voiceSession.isExpired(options.now)) {
+    if (voiceSession.status === 'active') {
+      await voiceSession.expire();
+    }
+    throw new VoiceSessionExpiredError();
+  }
+  if (!voiceSession.isActive(options.now)) {
+    throw new VoiceSessionRejectedError('Voice session is not active');
+  }
+  if (voiceSession.hasProcessedTurn(payload.turn_id)) {
+    throw new VoiceGatewayReplayError();
+  }
+
+  validateGatewayPayloadAgainstBinding(payload, voiceSession);
+
+  const agentSession = await options.chatService.getAgentSession({
+    agentSessionId: voiceSession.agentSessionId,
+    tenantId: voiceSession.tenantId,
+  });
+  if (!agentSession) {
+    throw new VoiceSessionRejectedError('Bound agent session not found');
+  }
+  assertAgentSessionMatchesActor(agentSession, voiceSession.actorProfileId);
+  assertActiveAgentSession(agentSession);
+  if (agentSession.chatRoomId !== voiceSession.chatRoomId) {
+    throw new VoiceSessionRejectedError(
+      'Bound agent session no longer belongs to the voice session room',
+    );
+  }
+
+  if (voiceSession.threadId) {
+    const thread = await options.chatService.getThread({
+      threadId: voiceSession.threadId,
+      tenantId: voiceSession.tenantId,
+    });
+    if (!thread || thread.roomId !== voiceSession.chatRoomId) {
+      throw new VoiceSessionRejectedError(
+        'Bound thread no longer belongs to the voice session room',
+      );
+    }
+  }
+
+  const history = await loadConversationHistory({
+    chatService: options.chatService,
+    tenantId: voiceSession.tenantId,
+    actorProfileId: voiceSession.actorProfileId,
+    roomId: voiceSession.chatRoomId,
+    threadId: voiceSession.threadId,
+    limit: options.historyLimit ?? DEFAULT_HISTORY_LIMIT,
+  });
+  const correlationId = crypto.randomUUID();
+  const commonMetadata = {
+    source: 'voice-gateway',
+    target: payload.target,
+    voiceSessionId,
+    gatewaySessionId: payload.session_id,
+    gatewayTurnId: payload.turn_id,
+    correlationId,
+  };
+
+  const userMessage = await options.chatService.sendAgentUserMessage({
+    tenantId: voiceSession.tenantId,
+    agentSessionId: voiceSession.agentSessionId,
+    actorProfileId: voiceSession.actorProfileId,
+    content: payload.text,
+  });
+  await mergeAndSaveMetadata(userMessage, {
+    ...commonMetadata,
+    voiceRole: 'transcript',
+  });
+
+  const turn = await runPersonaConversationTurn({
+    ai: options.ai,
+    db: options.db,
+    persona: voiceSession.getPersonaSnapshot(),
+    tenantId: voiceSession.tenantId,
+    userMessage: payload.text,
+    history,
+    chatService: options.chatService,
+    session: agentSession,
+    threadId: voiceSession.threadId,
+    recall: options.recall,
+    model: options.model,
+    temperature: options.temperature,
+    maxTokens: options.maxTokens,
+    maxSteps: options.maxSteps,
+    postgresRls: options.postgresRls,
+    audit: options.audit,
+    onBehalfOfUserId: voiceSession.actorUserId ?? undefined,
+    correlationId,
+  });
+
+  for (const toolMessage of turn.authoredMessages?.toolMessages ?? []) {
+    await mergeAndSaveMetadata(toolMessage, {
+      ...commonMetadata,
+      voiceRole: 'tool',
+    });
+  }
+  const assistantMessage = turn.authoredMessages?.assistantMessage ?? null;
+  if (assistantMessage) {
+    await mergeAndSaveMetadata(assistantMessage, {
+      ...commonMetadata,
+      voiceRole: 'assistant',
+    });
+  }
+
+  voiceSession.recordGatewayTurn(payload.turn_id);
+  await voiceSession.save();
+
+  return {
+    session_id: payload.session_id,
+    turn_id: payload.turn_id,
+    text: turn.result.content,
+    metadata: {
+      tenantId: voiceSession.tenantId,
+      chatRoomId: voiceSession.chatRoomId,
+      threadId: voiceSession.threadId,
+      agentSessionId: voiceSession.agentSessionId,
+      userMessageId: userMessage.id as string,
+      assistantMessageId: (assistantMessage?.id as string | undefined) ?? null,
+      personaId: voiceSession.personaId,
+      correlationId: turn.correlationId,
+      voiceSessionId,
+      source: 'voice-gateway',
+    },
+  };
+}
+
+export function createVoiceGatewayTurnHandler(
+  options: VoiceGatewayTurnHandlerOptions,
+): (request: Request) => Promise<Response> {
+  return async (request: Request): Promise<Response> => {
+    try {
+      if (request.method !== 'POST') {
+        return jsonResponse({ error: 'Method not allowed' }, 405);
+      }
+      await assertVoiceGatewayBearer(
+        request.headers,
+        await resolveGatewayToken(options.gatewayToken),
+      );
+      const payload = normalizeGatewayPayload(await request.json());
+      const response = await handleVoiceGatewayTurn({ ...options, payload });
+      return jsonResponse(response, 200);
+    } catch (error) {
+      const status = error instanceof VoiceGatewayError ? error.status : 500;
+      const message =
+        error instanceof Error ? error.message : 'Voice gateway turn failed';
+      const code =
+        error instanceof VoiceGatewayError ? error.code : 'voice_gateway_error';
+      return jsonResponse({ error: message, code }, status);
+    }
+  };
+}
+
+export async function assertVoiceGatewayBearer(
+  headers: Headers,
+  expectedToken: string,
+): Promise<void> {
+  if (!expectedToken) {
+    throw new VoiceGatewayUnauthorizedError(
+      'Voice gateway token is not configured',
+    );
+  }
+  const authorization = headers.get('authorization') ?? '';
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  const actual = match?.[1] ?? '';
+  if (!constantTimeEquals(actual, expectedToken)) {
+    throw new VoiceGatewayUnauthorizedError();
+  }
+}
+
+async function resolveGatewayToken(
+  token: string | (() => string | Promise<string>),
+): Promise<string> {
+  return typeof token === 'function' ? token() : token;
+}
+
+function normalizeGatewayPayload(input: unknown): VoiceGatewayTurnPayload {
+  if (!isRecord(input)) {
+    throw new VoiceGatewayBadRequestError('Voice gateway payload must be JSON');
+  }
+  const sessionId = requireNonEmptyString(
+    input.session_id,
+    'Voice gateway payload session_id is required',
+  );
+  const turnId = requireNonEmptyString(
+    input.turn_id,
+    'Voice gateway payload turn_id is required',
+  );
+  const target = requireNonEmptyString(
+    input.target,
+    'Voice gateway payload target is required',
+  );
+  if (target !== SMRT_CHAT_VOICE_TARGET) {
+    throw new VoiceGatewayBadRequestError(
+      `Unsupported voice gateway target '${target}'`,
+    );
+  }
+  const text = requireNonEmptyString(
+    input.text,
+    'Voice gateway payload text is required',
+  );
+  const metadata = input.metadata;
+  if (metadata !== undefined && !isRecord(metadata)) {
+    throw new VoiceGatewayBadRequestError(
+      'Voice gateway payload metadata must be an object',
+    );
+  }
+
+  return {
+    session_id: sessionId,
+    turn_id: turnId,
+    target,
+    actor:
+      typeof input.actor === 'string' && input.actor.length > 0
+        ? input.actor
+        : undefined,
+    text,
+    metadata: metadata as VoiceGatewayTurnMetadata | undefined,
+  };
+}
+
+function validateGatewayPayloadAgainstBinding(
+  payload: VoiceGatewayTurnPayload,
+  voiceSession: VoiceSession,
+): void {
+  if (payload.session_id !== voiceSession.gatewaySessionId) {
+    throw new VoiceSessionRejectedError(
+      'Gateway session_id does not match the voice session binding',
+    );
+  }
+  const metadata = payload.metadata ?? {};
+  assertMetadataMatches(
+    metadata,
+    'tenantId',
+    voiceSession.tenantId,
+    'tenantId does not match the voice session binding',
+  );
+  assertMetadataMatches(
+    metadata,
+    'actorProfileId',
+    voiceSession.actorProfileId,
+    'actorProfileId does not match the voice session binding',
+  );
+  assertMetadataMatches(
+    metadata,
+    'chatRoomId',
+    voiceSession.chatRoomId,
+    'chatRoomId does not match the voice session binding',
+  );
+  assertMetadataMatches(
+    metadata,
+    'threadId',
+    voiceSession.threadId,
+    'threadId does not match the voice session binding',
+  );
+  assertMetadataMatches(
+    metadata,
+    'agentSessionId',
+    voiceSession.agentSessionId,
+    'agentSessionId does not match the voice session binding',
+  );
+  assertMetadataMatches(
+    metadata,
+    'personaId',
+    voiceSession.personaId,
+    'personaId does not match the voice session binding',
+  );
+}
+
+function assertMetadataMatches(
+  metadata: VoiceGatewayTurnMetadata,
+  key: keyof VoiceGatewayTurnMetadata,
+  expected: string | null,
+  message: string,
+): void {
+  const actual = metadata[key];
+  if (actual === undefined || actual === null || actual === '') {
+    return;
+  }
+  if (typeof actual !== 'string' || actual !== expected) {
+    throw new VoiceSessionRejectedError(message);
+  }
+}
+
+function assertAgentSessionMatchesActor(
+  session: { participantProfileId: string },
+  actorProfileId: string,
+): void {
+  if (session.participantProfileId !== actorProfileId) {
+    throw new VoiceSessionRejectedError(
+      'Agent session participant does not match the voice session actor',
+    );
+  }
+}
+
+function assertActiveAgentSession(session: {
+  isActive: () => boolean;
+  chatRoomId: string | null;
+}): void {
+  if (!session.isActive()) {
+    throw new VoiceSessionRejectedError('Agent session is not active');
+  }
+  if (!session.chatRoomId) {
+    throw new VoiceSessionRejectedError('Agent session has no chat room');
+  }
+}
+
+async function loadConversationHistory(input: {
+  chatService: ChatService;
+  tenantId: string;
+  actorProfileId: string;
+  roomId: string;
+  threadId: string | null;
+  limit: number;
+}): Promise<AIMessage[]> {
+  const messages = input.threadId
+    ? await input.chatService.getThreadMessages({
+        threadId: input.threadId,
+        actorProfileId: input.actorProfileId,
+        tenantId: input.tenantId,
+        limit: input.limit,
+      })
+    : (
+        await input.chatService.getRoomMessages({
+          roomId: input.roomId,
+          actorProfileId: input.actorProfileId,
+          tenantId: input.tenantId,
+          limit: input.limit,
+        })
+      ).reverse();
+
+  return messages
+    .map(chatMessageToAIMessage)
+    .filter((message): message is AIMessage => message !== null);
+}
+
+function chatMessageToAIMessage(message: ChatMessage): AIMessage | null {
+  if (
+    message.role !== 'user' &&
+    message.role !== 'assistant' &&
+    message.role !== 'system'
+  ) {
+    return null;
+  }
+  return { role: message.role, content: message.content } as AIMessage;
+}
+
+async function mergeAndSaveMetadata(
+  message: ChatMessage,
+  metadata: Record<string, unknown>,
+): Promise<void> {
+  message.setMetadata({ ...message.getMetadata(), ...metadata });
+  await message.save();
+}
+
+function requireNonEmptyString(value: unknown, message: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new VoiceGatewayBadRequestError(message);
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function constantTimeEquals(actual: string, expected: string): boolean {
+  let diff = actual.length ^ expected.length;
+  const length = Math.max(actual.length, expected.length);
+  for (let index = 0; index < length; index++) {
+    const actualCode = index < actual.length ? actual.charCodeAt(index) : 0;
+    const expectedCode =
+      index < expected.length ? expected.charCodeAt(index) : 0;
+    diff |= actualCode ^ expectedCode;
+  }
+  return diff === 0;
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/packages/chat/src/voice.ts
+++ b/packages/chat/src/voice.ts
@@ -1,8 +1,13 @@
 import type { AIInterface, AIMessage } from '@happyvertical/ai';
 import type { PrincipalAuditSink } from '@happyvertical/smrt-agents';
-import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import {
+  type SmrtClassOptions,
+  ValidationError,
+} from '@happyvertical/smrt-core';
+import { VoiceGatewayTurnCollection } from './collections/VoiceGatewayTurnCollection.js';
 import { VoiceSessionCollection } from './collections/VoiceSessionCollection.js';
 import type { ChatMessage } from './models/ChatMessage.js';
+import type { VoiceGatewayTurn } from './models/VoiceGatewayTurn.js';
 import type { VoiceSession } from './models/VoiceSession.js';
 import {
   bindPersonaToSession,
@@ -13,6 +18,7 @@ import {
 import type { ChatService } from './services/index.js';
 
 export const SMRT_CHAT_VOICE_TARGET = 'smrt:chat';
+export const MAX_VOICE_GATEWAY_TEXT_LENGTH = 12_000;
 const DEFAULT_VOICE_SESSION_TTL_SECONDS = 10 * 60;
 const DEFAULT_HISTORY_LIMIT = 24;
 
@@ -342,6 +348,7 @@ export async function handleVoiceGatewayTurn(
   }
 
   validateGatewayPayloadAgainstBinding(payload, voiceSession);
+  const persona = requireVoiceSessionPersona(voiceSession);
 
   const agentSession = await options.chatService.getAgentSession({
     agentSessionId: voiceSession.agentSessionId,
@@ -370,90 +377,103 @@ export async function handleVoiceGatewayTurn(
     }
   }
 
-  const history = await loadConversationHistory({
-    chatService: options.chatService,
-    tenantId: voiceSession.tenantId,
-    actorProfileId: voiceSession.actorProfileId,
-    roomId: voiceSession.chatRoomId,
-    threadId: voiceSession.threadId,
-    limit: options.historyLimit ?? DEFAULT_HISTORY_LIMIT,
-  });
-  const correlationId = crypto.randomUUID();
-  const commonMetadata = {
-    source: 'voice-gateway',
-    target: payload.target,
-    voiceSessionId,
-    gatewaySessionId: payload.session_id,
-    gatewayTurnId: payload.turn_id,
-    correlationId,
-  };
+  const gatewayTurn = await reserveVoiceGatewayTurn(
+    options.db,
+    voiceSession,
+    payload,
+  );
 
-  const userMessage = await options.chatService.sendAgentUserMessage({
-    tenantId: voiceSession.tenantId,
-    agentSessionId: voiceSession.agentSessionId,
-    actorProfileId: voiceSession.actorProfileId,
-    content: payload.text,
-  });
-  await mergeAndSaveMetadata(userMessage, {
-    ...commonMetadata,
-    voiceRole: 'transcript',
-  });
-
-  const turn = await runPersonaConversationTurn({
-    ai: options.ai,
-    db: options.db,
-    persona: voiceSession.getPersonaSnapshot(),
-    tenantId: voiceSession.tenantId,
-    userMessage: payload.text,
-    history,
-    chatService: options.chatService,
-    session: agentSession,
-    threadId: voiceSession.threadId,
-    recall: options.recall,
-    model: options.model,
-    temperature: options.temperature,
-    maxTokens: options.maxTokens,
-    maxSteps: options.maxSteps,
-    postgresRls: options.postgresRls,
-    audit: options.audit,
-    onBehalfOfUserId: voiceSession.actorUserId ?? undefined,
-    correlationId,
-  });
-
-  for (const toolMessage of turn.authoredMessages?.toolMessages ?? []) {
-    await mergeAndSaveMetadata(toolMessage, {
-      ...commonMetadata,
-      voiceRole: 'tool',
-    });
-  }
-  const assistantMessage = turn.authoredMessages?.assistantMessage ?? null;
-  if (assistantMessage) {
-    await mergeAndSaveMetadata(assistantMessage, {
-      ...commonMetadata,
-      voiceRole: 'assistant',
-    });
-  }
-
-  voiceSession.recordGatewayTurn(payload.turn_id);
-  await voiceSession.save();
-
-  return {
-    session_id: payload.session_id,
-    turn_id: payload.turn_id,
-    text: turn.result.content,
-    metadata: {
+  try {
+    const history = await loadConversationHistory({
+      chatService: options.chatService,
       tenantId: voiceSession.tenantId,
-      chatRoomId: voiceSession.chatRoomId,
+      actorProfileId: voiceSession.actorProfileId,
+      roomId: voiceSession.chatRoomId,
       threadId: voiceSession.threadId,
-      agentSessionId: voiceSession.agentSessionId,
-      userMessageId: userMessage.id as string,
-      assistantMessageId: (assistantMessage?.id as string | undefined) ?? null,
-      personaId: voiceSession.personaId,
-      correlationId: turn.correlationId,
-      voiceSessionId,
+      limit: options.historyLimit ?? DEFAULT_HISTORY_LIMIT,
+    });
+    const correlationId = crypto.randomUUID();
+    const commonMetadata = {
       source: 'voice-gateway',
-    },
-  };
+      target: payload.target,
+      voiceSessionId,
+      gatewaySessionId: payload.session_id,
+      gatewayTurnId: payload.turn_id,
+      correlationId,
+    };
+
+    const userMessage = await options.chatService.sendAgentUserMessage({
+      tenantId: voiceSession.tenantId,
+      agentSessionId: voiceSession.agentSessionId,
+      actorProfileId: voiceSession.actorProfileId,
+      content: payload.text,
+    });
+    await mergeAndSaveMetadata(userMessage, {
+      ...commonMetadata,
+      voiceRole: 'transcript',
+    });
+
+    const turn = await runPersonaConversationTurn({
+      ai: options.ai,
+      db: options.db,
+      persona,
+      tenantId: voiceSession.tenantId,
+      userMessage: payload.text,
+      history,
+      chatService: options.chatService,
+      session: agentSession,
+      threadId: voiceSession.threadId,
+      recall: options.recall,
+      model: options.model,
+      temperature: options.temperature,
+      maxTokens: options.maxTokens,
+      maxSteps: options.maxSteps,
+      postgresRls: options.postgresRls,
+      audit: options.audit,
+      onBehalfOfUserId: voiceSession.actorUserId ?? undefined,
+      correlationId,
+    });
+
+    for (const toolMessage of turn.authoredMessages?.toolMessages ?? []) {
+      await mergeAndSaveMetadata(toolMessage, {
+        ...commonMetadata,
+        voiceRole: 'tool',
+      });
+    }
+    const assistantMessage = turn.authoredMessages?.assistantMessage ?? null;
+    if (assistantMessage) {
+      await mergeAndSaveMetadata(assistantMessage, {
+        ...commonMetadata,
+        voiceRole: 'assistant',
+      });
+    }
+
+    voiceSession.recordGatewayTurn(payload.turn_id);
+    await voiceSession.save();
+    await gatewayTurn.complete();
+
+    return {
+      session_id: payload.session_id,
+      turn_id: payload.turn_id,
+      text: turn.result.content,
+      metadata: {
+        tenantId: voiceSession.tenantId,
+        chatRoomId: voiceSession.chatRoomId,
+        threadId: voiceSession.threadId,
+        agentSessionId: voiceSession.agentSessionId,
+        userMessageId: userMessage.id as string,
+        assistantMessageId:
+          (assistantMessage?.id as string | undefined) ?? null,
+        personaId: voiceSession.personaId,
+        correlationId: turn.correlationId,
+        voiceSessionId,
+        source: 'voice-gateway',
+      },
+    };
+  } catch (error) {
+    await markVoiceGatewayTurnFailed(gatewayTurn);
+    throw error;
+  }
 }
 
 export function createVoiceGatewayTurnHandler(
@@ -530,6 +550,11 @@ function normalizeGatewayPayload(input: unknown): VoiceGatewayTurnPayload {
     input.text,
     'Voice gateway payload text is required',
   );
+  if (text.length > MAX_VOICE_GATEWAY_TEXT_LENGTH) {
+    throw new VoiceGatewayBadRequestError(
+      `Voice gateway payload text must be ${MAX_VOICE_GATEWAY_TEXT_LENGTH} characters or fewer`,
+    );
+  }
   const metadata = input.metadata;
   if (metadata !== undefined && !isRecord(metadata)) {
     throw new VoiceGatewayBadRequestError(
@@ -595,6 +620,77 @@ function validateGatewayPayloadAgainstBinding(
     'personaId',
     voiceSession.personaId,
     'personaId does not match the voice session binding',
+  );
+}
+
+function requireVoiceSessionPersona(
+  voiceSession: VoiceSession,
+): ConversationPersona {
+  const persona = voiceSession.getPersonaSnapshot();
+  if (!hasNonEmptyString(persona.id)) {
+    throw new VoiceSessionRejectedError(
+      'Voice session persona snapshot has no persona id',
+    );
+  }
+  if (persona.id !== voiceSession.personaId) {
+    throw new VoiceSessionRejectedError(
+      'Voice session persona snapshot does not match the voice session persona',
+    );
+  }
+  if (persona.tenantId !== voiceSession.tenantId) {
+    throw new VoiceSessionRejectedError(
+      'Voice session persona snapshot tenant does not match the voice session tenant',
+    );
+  }
+  if (!hasNonEmptyString(persona.runAsUserId)) {
+    throw new VoiceSessionRejectedError(
+      'Voice session persona snapshot has no runnable user',
+    );
+  }
+  if (!Array.isArray(persona.allowedTools)) {
+    throw new VoiceSessionRejectedError(
+      'Voice session persona snapshot has an invalid tool allow-list',
+    );
+  }
+  return persona;
+}
+
+async function reserveVoiceGatewayTurn(
+  db: SmrtClassOptions['db'],
+  voiceSession: VoiceSession,
+  payload: VoiceGatewayTurnPayload,
+): Promise<VoiceGatewayTurn> {
+  const gatewayTurns = await VoiceGatewayTurnCollection.create({ db });
+  try {
+    return await gatewayTurns.reserveTurn({
+      tenantId: voiceSession.tenantId,
+      voiceSessionId: voiceSession.id as string,
+      gatewaySessionId: payload.session_id,
+      gatewayTurnId: payload.turn_id,
+      target: payload.target,
+    });
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      throw new VoiceGatewayReplayError();
+    }
+    throw error;
+  }
+}
+
+async function markVoiceGatewayTurnFailed(
+  gatewayTurn: VoiceGatewayTurn,
+): Promise<void> {
+  try {
+    await gatewayTurn.fail();
+  } catch {
+    // Preserve the original turn failure for the gateway response.
+  }
+}
+
+function isUniqueConstraintError(error: unknown): boolean {
+  return (
+    error instanceof ValidationError &&
+    error.code === 'VALIDATION_UNIQUE_CONSTRAINT'
   );
 }
 
@@ -689,6 +785,10 @@ function requireNonEmptyString(value: unknown, message: string): string {
     throw new VoiceGatewayBadRequestError(message);
   }
   return value;
+}
+
+function hasNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/chat/svelte.config.js
+++ b/packages/chat/svelte.config.js
@@ -1,0 +1,14 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import { svelteKitWorkspaceAliases } from './workspace-aliases.js';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  preprocess: vitePreprocess(),
+  kit: {
+    outDir: '.svelte-kit',
+    alias:
+      process.env.SMRT_PACKAGE_BUILD === '1' ? {} : svelteKitWorkspaceAliases,
+  },
+};
+
+export default config;

--- a/packages/chat/tsconfig.kit.json
+++ b/packages/chat/tsconfig.kit.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "lib": ["ES2023", "DOM"],
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": false,
+    "resolveJsonModule": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "*.config.ts",
+    "*.config.js",
+    "svelte.config.js",
+    "workspace-aliases.js"
+  ]
+}

--- a/packages/chat/tsconfig.typecheck.json
+++ b/packages/chat/tsconfig.typecheck.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.package-typecheck.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "src/svelte/**/*",
+    "src/routes/**/*",
+    "src/playground.ts"
+  ]
+}

--- a/packages/chat/vite.config.ts
+++ b/packages/chat/vite.config.ts
@@ -1,13 +1,47 @@
-import { createPackageConfig } from '../../vite.config.base.js';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+import {
+  viteWorkspaceAliases,
+  workspaceAliasPackageNames,
+} from './workspace-aliases.js';
 
-export default createPackageConfig('chat', {
-  entries: [
-    'ui',
-    'playground',
-    // Internal agent-runtime surface (S5 #1392): emitted under a dedicated
-    // subpath, NOT folded into the package index, so only trusted in-process
-    // agent runtimes opt into `sendAgentReply`.
-    { name: 'internal/agent-runtime', source: 'src/internal/agent-runtime.ts' },
-  ],
-  svelte: 'svelte',
+export default defineConfig(async ({ command, mode }) => {
+  const isPackageBuild =
+    mode === 'library' || process.env.SMRT_PACKAGE_BUILD === '1';
+
+  if (isPackageBuild) {
+    const { createPackageConfig } = await import('../../vite.config.base.js');
+    const config = createPackageConfig('chat', {
+      entries: [
+        'ui',
+        'playground',
+        // Internal agent-runtime surface (S5 #1392): emitted under a dedicated
+        // subpath, NOT folded into the package index, so only trusted in-process
+        // agent runtimes opt into `sendAgentReply`.
+        {
+          name: 'internal/agent-runtime',
+          source: 'src/internal/agent-runtime.ts',
+        },
+      ],
+      svelte: 'svelte',
+      dtsExclude: ['src/routes/**/*', 'src/app.html'],
+    });
+
+    return typeof config === 'function'
+      ? await config({ command, mode })
+      : config;
+  }
+
+  return {
+    resolve: {
+      alias: viteWorkspaceAliases,
+    },
+    optimizeDeps: {
+      exclude: workspaceAliasPackageNames,
+    },
+    ssr: {
+      noExternal: workspaceAliasPackageNames,
+    },
+    plugins: [sveltekit()],
+  };
 });

--- a/packages/chat/workspace-aliases.d.ts
+++ b/packages/chat/workspace-aliases.d.ts
@@ -1,0 +1,6 @@
+export declare const workspaceAliasPackageNames: string[];
+export declare const svelteKitWorkspaceAliases: Record<string, string>;
+export declare const viteWorkspaceAliases: Array<{
+  find: string;
+  replacement: string;
+}>;

--- a/packages/chat/workspace-aliases.js
+++ b/packages/chat/workspace-aliases.js
@@ -1,0 +1,46 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const workspaceAliasEntries = [
+  ['@happyvertical/smrt-chat', './src/index.ts'],
+  ['@happyvertical/smrt-chat/svelte', './src/svelte/index.ts'],
+  ['@happyvertical/smrt-playground', '../smrt-playground/src/index.ts'],
+  [
+    '@happyvertical/smrt-playground/svelte',
+    '../smrt-playground/src/svelte/index.ts',
+  ],
+  ['@happyvertical/smrt-ui', '../smrt-ui/src/index.ts'],
+  ['@happyvertical/smrt-ui/chat', '../smrt-ui/src/components/chat/index.ts'],
+  [
+    '@happyvertical/smrt-ui/feedback',
+    '../smrt-ui/src/components/feedback/index.ts',
+  ],
+  ['@happyvertical/smrt-ui/forms', '../smrt-ui/src/components/forms/index.ts'],
+  ['@happyvertical/smrt-ui/i18n', '../smrt-ui/src/i18n/index.ts'],
+  ['@happyvertical/smrt-ui/registry', '../smrt-ui/src/registry/index.ts'],
+  ['@happyvertical/smrt-ui/themes', '../smrt-ui/src/themes/index.ts'],
+  ['@happyvertical/smrt-ui/ui', '../smrt-ui/src/components/ui/index.ts'],
+];
+
+function getSortedWorkspaceAliasEntries() {
+  return [...workspaceAliasEntries].sort(
+    ([left], [right]) => right.length - left.length,
+  );
+}
+
+export const workspaceAliasPackageNames = workspaceAliasEntries.map(
+  ([packageName]) => packageName,
+);
+
+export const svelteKitWorkspaceAliases = Object.fromEntries(
+  getSortedWorkspaceAliasEntries(),
+);
+
+export const viteWorkspaceAliases = getSortedWorkspaceAliasEntries().map(
+  ([packageName, relativePath]) => ({
+    find: packageName,
+    replacement: resolve(__dirname, relativePath),
+  }),
+);

--- a/packages/smrt-playground/src/svelte/PlaygroundHost.svelte
+++ b/packages/smrt-playground/src/svelte/PlaygroundHost.svelte
@@ -353,15 +353,6 @@ function selectEntry(entry: ResolvedSmrtPlaygroundEntry) {
 <style>
   :global(body) {
     margin: 0;
-    font-family:
-      "IBM Plex Sans",
-      "Inter",
-      system-ui,
-      sans-serif;
-    background:
-      radial-gradient(circle at top left, rgba(30, 96, 145, 0.16), transparent 28rem),
-      linear-gradient(180deg, #f4f7fb 0%, #eef2f8 100%);
-    color: #0f1722;
     min-height: 100vh;
   }
 
@@ -369,6 +360,9 @@ function selectEntry(entry: ResolvedSmrtPlaygroundEntry) {
     display: grid;
     grid-template-columns: 20rem minmax(0, 1fr);
     min-height: 100vh;
+    background: var(--smrt-color-background);
+    color: var(--smrt-color-on-background);
+    font-family: var(--smrt-font-family);
   }
 
   .sidebar {
@@ -376,9 +370,9 @@ function selectEntry(entry: ResolvedSmrtPlaygroundEntry) {
     align-content: start;
     gap: 1.25rem;
     padding: 1.5rem;
-    background: rgba(7, 15, 26, 0.92);
-    color: #ecf2ff;
-    border-right: 1px solid rgba(255, 255, 255, 0.08);
+    border-right: 1px solid var(--smrt-color-outline-variant);
+    background: var(--smrt-color-surface-container);
+    color: var(--smrt-color-on-surface);
     backdrop-filter: blur(18px);
   }
 
@@ -404,7 +398,7 @@ function selectEntry(entry: ResolvedSmrtPlaygroundEntry) {
     font-size: 0.75rem;
     letter-spacing: 0.12em;
     text-transform: uppercase;
-    color: #6aa4ff;
+    color: var(--smrt-color-primary);
   }
 
   .sidebar__header p:last-child,
@@ -432,17 +426,22 @@ function selectEntry(entry: ResolvedSmrtPlaygroundEntry) {
 
   .search span {
     font-size: 0.82rem;
-    color: rgba(236, 242, 255, 0.72);
+    color: var(--smrt-color-on-surface-variant);
   }
 
   .search input {
     width: 100%;
     box-sizing: border-box;
-    border: 1px solid rgba(255, 255, 255, 0.16);
+    border: 1px solid var(--smrt-color-outline-variant);
     border-radius: 0.9rem;
-    background: rgba(255, 255, 255, 0.08);
-    color: inherit;
+    background: var(--smrt-color-surface-container-lowest);
+    color: var(--smrt-color-on-surface);
     padding: 0.8rem 0.95rem;
+  }
+
+  .search input::placeholder {
+    color: var(--smrt-color-on-surface-variant);
+    opacity: 0.72;
   }
 
   .module-list button,
@@ -466,15 +465,16 @@ function selectEntry(entry: ResolvedSmrtPlaygroundEntry) {
   }
 
   .module-list button {
-    background: rgba(255, 255, 255, 0.06);
-    color: inherit;
+    background: var(--smrt-color-surface-container-low);
+    color: var(--smrt-color-on-surface);
     border: 1px solid transparent;
   }
 
   .module-list button.selected,
   .module-list button:hover {
-    background: rgba(106, 164, 255, 0.14);
-    border-color: rgba(106, 164, 255, 0.34);
+    border-color: var(--smrt-color-primary);
+    background: var(--smrt-color-primary-container);
+    color: var(--smrt-color-on-primary-container);
   }
 
   .module-list button span,
@@ -494,16 +494,19 @@ function selectEntry(entry: ResolvedSmrtPlaygroundEntry) {
   }
 
   .entry-list button {
-    background: rgba(255, 255, 255, 0.72);
-    border: 1px solid rgba(15, 23, 34, 0.08);
-    box-shadow: 0 18px 45px rgba(15, 23, 34, 0.05);
+    border: 1px solid var(--smrt-color-outline-variant);
+    background: var(--smrt-color-surface);
+    color: var(--smrt-color-on-surface);
+    box-shadow: 0 18px 45px color-mix(in srgb, var(--smrt-color-shadow) 5%, transparent);
   }
 
   .entry-list button.selected,
   .entry-list button:hover {
     transform: translateY(-1px);
-    border-color: rgba(14, 93, 224, 0.25);
-    box-shadow: 0 18px 45px rgba(14, 93, 224, 0.12);
+    border-color: var(--smrt-color-primary);
+    background: var(--smrt-color-primary-container);
+    color: var(--smrt-color-on-primary-container);
+    box-shadow: 0 18px 45px color-mix(in srgb, var(--smrt-color-primary) 14%, transparent);
   }
 
   .mode-pills {
@@ -522,17 +525,18 @@ function selectEntry(entry: ResolvedSmrtPlaygroundEntry) {
   }
 
   .mode-pills span {
-    background: rgba(14, 93, 224, 0.08);
-    color: #0e5de0;
+    background: var(--smrt-color-primary-container);
+    color: var(--smrt-color-on-primary-container);
   }
 
   .preview-panel,
   .empty-card {
     padding: 1.1rem;
     border-radius: 1.25rem;
-    background: rgba(255, 255, 255, 0.82);
-    border: 1px solid rgba(15, 23, 34, 0.08);
-    box-shadow: 0 24px 60px rgba(15, 23, 34, 0.08);
+    border: 1px solid var(--smrt-color-outline-variant);
+    background: var(--smrt-color-surface);
+    color: var(--smrt-color-on-surface);
+    box-shadow: 0 24px 60px color-mix(in srgb, var(--smrt-color-shadow) 8%, transparent);
     backdrop-filter: blur(18px);
   }
 
@@ -549,26 +553,24 @@ function selectEntry(entry: ResolvedSmrtPlaygroundEntry) {
     gap: 0.45rem;
     padding: 0.2rem;
     border-radius: 999px;
-    background: #e6edf9;
+    background: var(--smrt-color-surface-container-high);
   }
 
   .mode-toggle button {
     background: transparent;
-    color: #36527b;
+    color: var(--smrt-color-on-surface-variant);
   }
 
   .mode-toggle button.active {
-    background: #0e5de0;
-    color: white;
+    background: var(--smrt-color-primary);
+    color: var(--smrt-color-on-primary);
   }
 
   .preview-stage {
     padding: 1rem;
     border-radius: 1rem;
-    background:
-      linear-gradient(180deg, rgba(255, 255, 255, 0.84), rgba(245, 248, 252, 0.94)),
-      radial-gradient(circle at top, rgba(106, 164, 255, 0.12), transparent 28rem);
-    border: 1px solid rgba(15, 23, 34, 0.06);
+    border: 1px solid var(--smrt-color-outline-variant);
+    background: var(--smrt-color-surface-container-lowest);
     overflow: auto;
     min-height: 24rem;
   }

--- a/packages/smrt-ui/src/components/ui/Button.svelte
+++ b/packages/smrt-ui/src/components/ui/Button.svelte
@@ -96,6 +96,17 @@ const linkProps = $derived(() => {
     ),
   ) as HTMLAnchorAttributes;
 });
+
+function handleClick(event: MouseEvent) {
+  if (isDisabled) {
+    event.preventDefault();
+    return;
+  }
+
+  onclick?.(
+    event as Parameters<NonNullable<HTMLButtonAttributes['onclick']>>[0],
+  );
+}
 </script>
 
 {#if isLink}
@@ -111,7 +122,7 @@ const linkProps = $derived(() => {
     tabindex={isDisabled ? -1 : undefined}
     aria-disabled={isDisabled}
     aria-busy={loading}
-    onclick={onclick as HTMLAnchorAttributes['onclick']}
+    onclick={handleClick as HTMLAnchorAttributes['onclick']}
     {...linkProps()}
   >
     {#if loading}
@@ -129,7 +140,7 @@ const linkProps = $derived(() => {
     class="button {variant} {size} {className}"
     class:full-width={fullWidth}
     class:loading
-    {onclick}
+    onclick={handleClick}
     {...rest}
   >
     {#if loading}

--- a/packages/smrt-ui/src/components/ui/Button.svelte
+++ b/packages/smrt-ui/src/components/ui/Button.svelte
@@ -100,6 +100,7 @@ const linkProps = $derived(() => {
 function handleClick(event: MouseEvent) {
   if (isDisabled) {
     event.preventDefault();
+    event.stopPropagation();
     return;
   }
 

--- a/packages/voice/AGENTS.md
+++ b/packages/voice/AGENTS.md
@@ -10,7 +10,7 @@ TTS voice profiles with two creation modes: AI design or audio cloning. Word-lev
 
 ## Gotchas
 
-- **Default provider hardcoded**: 'qwen3-tts' — no provider abstraction layer
+- **Runtime providers live in `@happyvertical/speech`**: this package persists voice profiles, samples, and outputs. Use `VoiceProfile.toSpeechVoice()` and `VoiceOutput.fromSynthesizedSpeech()` at the adapter boundary.
 - **Sample minimum not enforced in constructor**: 3-sec minimum documented but not validated on create
 - **WordTiming from external provider**: framework doesn't generate timings — populated by TTS service
 - **Status transitions not enforced**: can manually set status without triggering generation workflow

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -65,6 +65,36 @@ const output = new VoiceOutput({
 output.getWordAtTime(0.7); // { word: 'evening', start: 0.6, end: 1.0 }
 ```
 
+### Runtime speech adapters
+
+`@happyvertical/smrt-voice` stores voice domain records. Runtime STT/TTS provider
+calls are owned by `@happyvertical/speech`.
+
+```typescript
+import { getSpeech } from '@happyvertical/speech';
+import { VoiceOutput, VoiceProfile } from '@happyvertical/smrt-voice';
+
+const speech = await getSpeech({
+  synthesizer: {
+    type: 'qwen3-tts',
+    baseUrl: 'http://qwen3-tts.qwen3-tts.svc.cluster.local',
+  },
+});
+
+const profile = await VoiceProfile.find('voice-123');
+const spoken = await speech.synthesize({
+  text: 'Welcome to the evening news.',
+  voice: profile.toSpeechVoice(),
+});
+
+const output = VoiceOutput.fromSynthesizedSpeech({
+  sourceText: 'Welcome to the evening news.',
+  voiceProfileId: profile.id,
+  audioAssetId: 'asset-created-by-your-asset-store',
+  speech: spoken,
+});
+```
+
 ## API
 
 ### Models
@@ -84,6 +114,7 @@ output.getWordAtTime(0.7); // { word: 'evening', start: 0.6, end: 1.0 }
 | `SampleQuality` | Audio quality rating: `low`, `medium`, `high` |
 | `WordTiming` | Per-word timing entry: `{ word, start, end }` (seconds) |
 | `VoiceOutputMetadata` | Audio metadata: sampleRate, format, channels, bitDepth, provider, model |
+| `SpeechVoice`, `SynthesizedSpeech`, `TranscriptResult` | Runtime contracts re-exported from `@happyvertical/speech` |
 | `VoiceProfileOptions` | Profile creation options |
 | `VoiceSampleOptions` | Sample creation options |
 | `VoiceOutputOptions` | Output creation options |
@@ -92,10 +123,12 @@ output.getWordAtTime(0.7); // { word: 'evening', start: 0.6, end: 1.0 }
 
 - `VoiceProfile.isCloned` / `isDesigned` -- which creation mode is active
 - `VoiceProfile.isReady` -- status equals `ready`
+- `VoiceProfile.toSpeechVoice()` -- runtime voice contract for `@happyvertical/speech`
 - `VoiceSample.meetsMinDuration` -- duration >= 3 seconds
 - `VoiceSample.isSuitableForCloning` -- meets min duration AND quality != low
 - `VoiceOutput.wordCount` / `wordsPerSecond` -- computed from sourceText and duration
 - `VoiceOutput.getWordAtTime(seconds)` -- look up word being spoken at a timestamp
+- `VoiceOutput.fromSynthesizedSpeech()` -- normalize speech adapter output metadata/timings
 
 ## Dependencies
 
@@ -104,3 +137,4 @@ output.getWordAtTime(0.7); // { word: 'evening', start: 0.6, end: 1.0 }
 - `@happyvertical/smrt-config` -- configuration loading
 - `@happyvertical/smrt-content` -- content models (VoiceOutput extends Content)
 - `@happyvertical/smrt-tenancy` -- multi-tenant scoping
+- `@happyvertical/speech` -- runtime STT/TTS adapter contracts

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -41,6 +41,7 @@
     "@happyvertical/smrt-content": "workspace:*",
     "@happyvertical/smrt-core": "workspace:*",
     "@happyvertical/smrt-tenancy": "workspace:*",
+    "@happyvertical/speech": "catalog:",
     "@happyvertical/utils": "catalog:"
   },
   "devDependencies": {

--- a/packages/voice/src/__tests__/speech-contract.test.ts
+++ b/packages/voice/src/__tests__/speech-contract.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  metadataFromSynthesizedSpeech,
+  type SynthesizedSpeech,
+  VoiceOutput,
+  VoiceProfile,
+  wordTimingsFromSpeech,
+} from '../index.js';
+
+describe('speech adapter contract mapping', () => {
+  it('converts a voice profile into a provider-neutral speech voice', () => {
+    const profile = new VoiceProfile({
+      name: 'Anchor',
+      language: 'en-US',
+      provider: 'qwen3-tts',
+      defaultSpeed: 1.15,
+      defaultPitch: 2,
+      voiceData: {
+        providerVoiceId: 'vivian',
+        voicePrompt: 'encoded-prompt',
+        stableKey: 'tenant-anchor',
+      },
+    });
+
+    const voice = profile.toSpeechVoice();
+
+    expect(voice).toMatchObject({
+      name: 'Anchor',
+      language: 'en-US',
+      speakerId: 'vivian',
+      prompt: 'encoded-prompt',
+      metadata: {
+        provider: 'qwen3-tts',
+        stableKey: 'tenant-anchor',
+        defaultSpeed: 1.15,
+        defaultPitch: 2,
+      },
+    });
+  });
+
+  it('normalizes speech word timings onto the persisted SMRT shape', () => {
+    expect(
+      wordTimingsFromSpeech([
+        {
+          word: 'hello',
+          startSeconds: 0.1,
+          endSeconds: 0.4,
+          confidence: 0.93,
+          speakerId: 'speaker-a',
+        },
+      ]),
+    ).toEqual([
+      {
+        word: 'hello',
+        start: 0.1,
+        end: 0.4,
+        confidence: 0.93,
+        speakerId: 'speaker-a',
+      },
+    ]);
+  });
+
+  it('creates VoiceOutput metadata from synthesized speech without storing audio bytes', () => {
+    const speech: SynthesizedSpeech = {
+      audio: new Uint8Array([1, 2, 3, 4]).buffer,
+      contentType: 'audio/wav',
+      sampleRate: 24_000,
+      channels: 1,
+      durationSeconds: 0.8,
+      provider: 'qwen3-tts',
+      model: 'Qwen/Qwen3-TTS-12Hz-1.7B-Base',
+      words: [{ word: 'hello', startSeconds: 0, endSeconds: 0.5 }],
+    };
+
+    expect(metadataFromSynthesizedSpeech(speech)).toMatchObject({
+      contentType: 'audio/wav',
+      fileSize: 4,
+      format: 'wav',
+      sampleRate: 24_000,
+      channels: 1,
+      provider: 'qwen3-tts',
+      model: 'Qwen/Qwen3-TTS-12Hz-1.7B-Base',
+    });
+
+    const output = VoiceOutput.fromSynthesizedSpeech({
+      speech,
+      sourceText: 'hello',
+      voiceProfileId: 'voice-1',
+      audioAssetId: 'asset-1',
+    });
+
+    expect(output.duration).toBe(0.8);
+    expect(output.wordTimings).toEqual([{ word: 'hello', start: 0, end: 0.5 }]);
+    expect(output.audioMetadata).toMatchObject({
+      contentType: 'audio/wav',
+      fileSize: 4,
+      provider: 'qwen3-tts',
+    });
+  });
+});

--- a/packages/voice/src/index.ts
+++ b/packages/voice/src/index.ts
@@ -38,11 +38,31 @@
 // module loads below. See __smrt-register__.ts for issue #1132 context.
 import './__smrt-register__.js';
 
+export type {
+  AudioInput,
+  Speech,
+  SpeechAdapterAvailability,
+  SpeechSynthesizer,
+  SpeechSynthesizerType,
+  SpeechVoice,
+  SpeechVoiceInput,
+  SynthesisRequest,
+  SynthesizedSpeech,
+  Transcriber,
+  TranscriberType,
+  TranscriptionRequest,
+  TranscriptResult,
+  TranscriptSegment,
+  WordTiming as SpeechWordTiming,
+} from '@happyvertical/speech';
 export {
+  metadataFromSynthesizedSpeech,
   VoiceOutput,
+  type VoiceOutputFromSynthesizedSpeechOptions,
   type VoiceOutputMetadata,
   type VoiceOutputOptions,
   type WordTiming,
+  wordTimingsFromSpeech,
 } from './voice-output.js';
 // Models
 export {

--- a/packages/voice/src/voice-output.ts
+++ b/packages/voice/src/voice-output.ts
@@ -8,6 +8,10 @@
 import { Content, type ContentOptions } from '@happyvertical/smrt-content';
 import { crossPackageRef, foreignKey, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped } from '@happyvertical/smrt-tenancy';
+import type {
+  WordTiming as SpeechWordTiming,
+  SynthesizedSpeech,
+} from '@happyvertical/speech';
 import { VoiceProfile } from './voice-profile.js';
 
 /**
@@ -28,6 +32,16 @@ export interface WordTiming {
    * End time in seconds
    */
   end: number;
+
+  /**
+   * Provider confidence score, when available
+   */
+  confidence?: number;
+
+  /**
+   * Speaker identifier, when diarization is available
+   */
+  speakerId?: string;
 }
 
 /**
@@ -43,6 +57,11 @@ export interface VoiceOutputMetadata {
    * Audio format (e.g., 'wav', 'mp3', 'ogg')
    */
   format?: string;
+
+  /**
+   * MIME type returned by the speech provider
+   */
+  contentType?: string;
 
   /**
    * Number of audio channels
@@ -113,6 +132,17 @@ export interface VoiceOutputOptions extends ContentOptions {
    * Audio metadata
    */
   audioMetadata?: VoiceOutputMetadata;
+}
+
+/**
+ * Create a VoiceOutput from a runtime @happyvertical/speech synthesis result.
+ */
+export interface VoiceOutputFromSynthesizedSpeechOptions
+  extends VoiceOutputOptions {
+  /**
+   * Runtime synthesis result from @happyvertical/speech.
+   */
+  speech: SynthesizedSpeech;
 }
 
 /**
@@ -242,4 +272,62 @@ export class VoiceOutput extends Content {
       null
     );
   }
+
+  /**
+   * Build a persisted output model from a provider-neutral speech result.
+   *
+   * The binary audio remains in the caller-owned asset pipeline; this helper
+   * only normalizes metadata and timing fields onto the SMRT model.
+   */
+  static fromSynthesizedSpeech(
+    options: VoiceOutputFromSynthesizedSpeechOptions,
+  ): VoiceOutput {
+    const { speech, audioMetadata, duration, wordTimings, ...rest } = options;
+    return new VoiceOutput({
+      ...rest,
+      duration: duration ?? speech.durationSeconds ?? 0,
+      wordTimings: wordTimings ?? wordTimingsFromSpeech(speech.words),
+      audioMetadata: {
+        ...metadataFromSynthesizedSpeech(speech),
+        ...audioMetadata,
+      },
+    });
+  }
+}
+
+export function wordTimingsFromSpeech(
+  words: readonly SpeechWordTiming[] | null | undefined,
+): WordTiming[] | null {
+  if (!words || words.length === 0) {
+    return null;
+  }
+  return words.map((word) => ({
+    word: word.word,
+    start: word.startSeconds,
+    end: word.endSeconds,
+    confidence: word.confidence,
+    speakerId: word.speakerId,
+  }));
+}
+
+export function metadataFromSynthesizedSpeech(
+  speech: SynthesizedSpeech,
+): VoiceOutputMetadata {
+  return {
+    sampleRate: speech.sampleRate,
+    format: speech.format ?? formatFromContentType(speech.contentType),
+    contentType: speech.contentType,
+    channels: speech.channels,
+    fileSize: speech.audio.byteLength,
+    provider: speech.provider,
+    model: speech.model,
+  };
+}
+
+function formatFromContentType(contentType: string): string | undefined {
+  const normalized = contentType.split(';', 1)[0]?.trim().toLowerCase();
+  if (!normalized?.startsWith('audio/')) {
+    return undefined;
+  }
+  return normalized.slice('audio/'.length);
 }

--- a/packages/voice/src/voice-profile.ts
+++ b/packages/voice/src/voice-profile.ts
@@ -9,6 +9,7 @@
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
 import { crossPackageRef, SmrtObject, smrt } from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type { SpeechVoice } from '@happyvertical/speech';
 
 /**
  * Voice profile status
@@ -271,4 +272,43 @@ export class VoiceProfile extends SmrtObject {
   get isGlobal(): boolean {
     return this.tenantId === null;
   }
+
+  /**
+   * Convert this persisted profile into the runtime voice shape consumed by
+   * @happyvertical/speech adapters.
+   */
+  toSpeechVoice(): SpeechVoice {
+    const voiceData = isRecord(this.voiceData) ? this.voiceData : {};
+    const prompt =
+      stringValue(voiceData.prompt) ?? stringValue(voiceData.voicePrompt);
+    const speakerId =
+      stringValue(voiceData.speakerId) ??
+      stringValue(voiceData.speaker) ??
+      stringValue(voiceData.providerVoiceId);
+
+    return {
+      id:
+        stringValue(voiceData.id) ??
+        stringValue(voiceData.voiceId) ??
+        stringValue(this.id),
+      name: this.name || undefined,
+      language: this.language || undefined,
+      speakerId,
+      prompt,
+      metadata: {
+        ...voiceData,
+        provider: this.provider,
+        defaultSpeed: this.defaultSpeed,
+        defaultPitch: this.defaultPitch,
+      },
+    };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,7 @@ overrides:
   '@happyvertical/projects': ^0.78.0
   '@happyvertical/repos': ^0.78.0
   '@happyvertical/secrets': ^0.78.0
+  '@happyvertical/speech': ^0.78.0
   '@happyvertical/spider': ^1.1.10
   '@happyvertical/sql': ^0.78.0
   '@happyvertical/utils': ^0.78.0
@@ -512,12 +513,18 @@ importers:
         specifier: ^0.78.0
         version: 0.78.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
     devDependencies:
+      '@happyvertical/smrt-playground':
+        specifier: workspace:*
+        version: link:../smrt-playground
       '@happyvertical/smrt-profiles':
         specifier: workspace:*
         version: link:../profiles
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest
+      '@sveltejs/kit':
+        specifier: ^2.69.1
+        version: 2.69.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)))(svelte@5.56.4)(typescript@5.9.3)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
       '@sveltejs/package':
         specifier: ^2.5.8
         version: 2.5.8(svelte@5.56.4)(typescript@5.9.3)
@@ -2590,6 +2597,9 @@ importers:
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy
+      '@happyvertical/speech':
+        specifier: ^0.78.0
+        version: 0.78.0
       '@happyvertical/utils':
         specifier: ^0.78.0
         version: 0.78.0
@@ -3612,6 +3622,9 @@ packages:
   '@happyvertical/secrets@0.78.0':
     resolution: {integrity: sha512-RTAaNJiYyLDkygJVVTaRJInRJTWkKtSIf6FbsNAIvCWOQSsemTqlOEcZEi4NK3paBxI47CX/+efA7BoDzrylAw==}
     hasBin: true
+
+  '@happyvertical/speech@0.78.0':
+    resolution: {integrity: sha512-X81v7sbmDVpqj1KdRkj8deXrJ4Y92AHmMlnGbIjReerLwHNa4d/1C4kie2VloFdv6+rYVQtjtdvgPq0VUCipsA==}
 
   '@happyvertical/spider@1.1.10':
     resolution: {integrity: sha512-m3kFQdAhbsUUei5D3uSR6xXqC075pAYk+1ATOJwE+mBfDQZgMm7iaGP3cAj+N9UR+cJX2KesHS3gd+k7mm/cCw==}
@@ -11426,6 +11439,8 @@ snapshots:
       - encoding
       - pg-native
       - utf-8-validate
+
+  '@happyvertical/speech@0.78.0': {}
 
   '@happyvertical/spider@1.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,27 @@ packages:
   - 'packages/*'
   - 'packages/smrt-playground/host'
 
+minimumReleaseAgeExclude:
+  - '@happyvertical/ai@0.78.0'
+  - '@happyvertical/cache@0.78.0'
+  - '@happyvertical/documents@0.78.0'
+  - '@happyvertical/email@0.78.0'
+  - '@happyvertical/encryption@0.78.0'
+  - '@happyvertical/files@0.78.0'
+  - '@happyvertical/geo@0.78.0'
+  - '@happyvertical/graphql@0.78.0'
+  - '@happyvertical/images@0.78.0'
+  - '@happyvertical/jobs@0.78.0'
+  - '@happyvertical/json@0.78.0'
+  - '@happyvertical/logger@0.78.0'
+  - '@happyvertical/messages@0.78.0'
+  - '@happyvertical/projects@0.78.0'
+  - '@happyvertical/repos@0.78.0'
+  - '@happyvertical/secrets@0.78.0'
+  - '@happyvertical/speech@0.78.0'
+  - '@happyvertical/sql@0.78.0'
+  - '@happyvertical/utils@0.78.0'
+
 catalog:
   '@aws-sdk/client-sqs': ^3.1079.0
   '@google-cloud/tasks': ^6.2.3
@@ -22,6 +43,7 @@ catalog:
   '@happyvertical/projects': ^0.78.0
   '@happyvertical/repos': ^0.78.0
   '@happyvertical/secrets': ^0.78.0
+  '@happyvertical/speech': ^0.78.0
   '@happyvertical/spider': ^1.1.10
   '@happyvertical/sql': ^0.78.0
   '@happyvertical/utils': ^0.78.0
@@ -30,5 +52,3 @@ catalog:
   bullmq: ^5.79.2
   jimp: ^1.6.1
   sharp: ^0.35.3
-
-


### PR DESCRIPTION
## Summary
- Adds a SvelteKit-backed `@happyvertical/smrt-chat` dev server with text and voice workbench routes.
- Adds short-lived voice session bindings and gateway turn handling for persona-backed chat conversations.
- Wires `@happyvertical/smrt-voice` to `@happyvertical/speech@0.78.0` runtime contracts with conversion helpers.
- Cleans up theme consistency in the playground/dev surfaces and fixes disabled button click handling.

Closes #1910

## Validation
- `corepack pnpm --dir packages/chat typecheck`
- `corepack pnpm --dir packages/chat test`
- `corepack pnpm --dir packages/chat build`
- `corepack pnpm --dir packages/voice typecheck`
- `corepack pnpm --dir packages/voice test`
- `corepack pnpm --dir packages/voice build`
- `corepack pnpm exec biome check $(git diff --name-only --diff-filter=ACM) $(git ls-files --others --exclude-standard)`
- `git diff --check`
- local dev server on `http://127.0.0.1:5561/`
- typed WebSocket voice smoke test against `hermes:happyvertical`: ready/start/response_text/audio/done

## Notes
- Adds a narrow `minimumReleaseAgeExclude` for `@happyvertical/speech@0.78.0`, the first-party package published for this integration.
- Live cluster voice testing currently uses a temporary qwen TTS compatibility adapter and STT-only `studio-server` config; those runtime changes are not part of this SMRT PR.
