### PR TITLE
fix(core): stabilize generated client collection keys

### DIFF
--- a/packages/core/src/vite-plugin/generated-client-integration.test.ts
+++ b/packages/core/src/vite-plugin/generated-client-integration.test.ts
@@ -20,7 +20,13 @@
  *   a BARE array for list, and snake_case `created_at` on the wire.
  */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -115,19 +121,71 @@ describe('generated client <-> generated server integration (#1794/#1796/#1797)'
     );
     writeFileSync(
       join(projectRoot, 'src', 'objects.ts'),
-      `import { SmrtObject } from '@happyvertical/smrt-core';
+      `import { SmrtCollection, SmrtObject } from '@happyvertical/smrt-core';
 
-@smrt({ api: { public: true } })
+@smrt({
+  api: {
+    public: true,
+    routes: {
+      findFeatured: { method: 'GET' },
+      invalidItemScope: { scope: 'item' },
+    },
+  },
+})
+export class GenClientProductCollection extends SmrtCollection<GenClientProduct> {
+  static readonly _itemClass = GenClientProduct;
+
+  async list(): Promise<GenClientProduct[]> {
+    return super.list();
+  }
+
+  async findFeatured(options: { category?: string } = {}): Promise<GenClientProduct[]> {
+    return this.list({ where: { featured: true, ...options } });
+  }
+
+  async search(filters: { term?: string } = {}): Promise<GenClientProduct[]> {
+    return this.list({ where: filters });
+  }
+
+  async invalidItemScope(): Promise<GenClientProduct[]> {
+    return this.list();
+  }
+}
+
+@smrt({
+  api: {
+    public: true,
+    routes: { invalidCollectionScope: { scope: 'collection' } },
+  },
+})
 export class GenClientProduct extends SmrtObject {
   name: string = '';
   price: number = 0;
+
+  async invalidCollectionScope(): Promise<GenClientProduct> {
+    return this;
+  }
+}
+
+@smrt({
+  api: {
+    public: true,
+    routes: { describe: { path: 'descriptions/[tone]' } },
+  },
+})
+export class ArtCollection extends SmrtObject {
+  async describe(tone: string): Promise<string> {
+    void tone;
+    return 'item model, not SmrtCollection';
+  }
 }
 `,
     );
 
     const plugin: any = smrtPlugin({
-      generateTypes: false,
+      generateTypes: true,
       include: ['src/**/*.ts'],
+      watch: false,
     });
     await plugin.configResolved?.call(plugin, {
       root: projectRoot,
@@ -135,6 +193,11 @@ export class GenClientProduct extends SmrtObject {
       plugins: [],
       build: {},
     } as any);
+    getHook(plugin, 'configureServer').call(plugin, {
+      config: { root: projectRoot },
+      middlewares: { use: vi.fn() },
+    });
+    await getHook(plugin, 'buildStart').call(plugin);
 
     const load = getHook(plugin, 'load').bind(plugin);
     const clientSource = (await load('\0smrt:client')) as string;
@@ -143,6 +206,30 @@ export class GenClientProduct extends SmrtObject {
     // inflection change surfaces as a readable failure rather than an
     // `undefined.list()` TypeError below.
     expect(clientSource).toContain('genclientproducts:');
+    expect(clientSource).toContain('genClientProductCollection:');
+    expect(clientSource.match(/\n {2}genclientproducts:/g)).toHaveLength(1);
+    expect(clientSource).toContain('findFeatured: (options)');
+    expect(clientSource).not.toContain('findFeatured: (id, options)');
+    expect(clientSource).not.toContain('list: (id, options)');
+    expect(clientSource).not.toContain('invalidItemScope: (');
+    expect(clientSource).not.toContain('invalidCollectionScope: (');
+    expect(clientSource).toContain('describe: (id, options)');
+    expect(clientSource).not.toContain('describe: (options)');
+    const declarationSource = readFileSync(
+      join(projectRoot, 'src', 'types', 'virtual-modules.d.ts'),
+      'utf-8',
+    );
+    expect(declarationSource).toContain(
+      'genClientProductCollection: Omit<CrudOperations<GenClientProductData>, "search"> & {',
+    );
+    expect(declarationSource).not.toContain('invalidItemScope(');
+    expect(declarationSource).not.toContain('invalidCollectionScope(');
+    expect(declarationSource).toContain(
+      'findFeatured(options?: Record<string, any>): Promise<any>;',
+    );
+    expect(declarationSource).toContain(
+      'describe(id: string, options: { tone: string }): Promise<any>;',
+    );
 
     // Evaluate the generated ESM the way a bundler would: write it to disk and
     // dynamic-import it. This exercises the ACTUAL emitted source, not a
@@ -212,6 +299,58 @@ export class GenClientProduct extends SmrtObject {
     // A 404 would have surfaced `{ error: "Object type '...' not found" }`,
     // which is NOT an array of products.
     expect(rows.some((r) => r.name === 'Widget')).toBe(true);
+  });
+
+  it('uses collection-scoped URLs and configured verbs for generated collection methods', async () => {
+    const collectionHandler = vi.fn(async (req: Request) => {
+      const url = new URL(req.url);
+      expect(url.pathname).toBe('/api/v1/genclientproducts/findFeatured');
+      expect(url.searchParams.get('category')).toBe('news');
+      expect(req.method).toBe('GET');
+      expect(await req.text()).toBe('');
+      return Response.json({
+        action: 'findFeatured',
+        result: [{ name: 'Featured widget' }],
+      });
+    });
+    stubFetchToServer(collectionHandler);
+
+    const client = createClient('/api/v1');
+    const collectionClient =
+      client.genClientProductCollection as typeof client.genClientProductCollection & {
+        findFeatured(options?: Record<string, unknown>): Promise<unknown>;
+      };
+    const result = await collectionClient.findFeatured({ category: 'news' });
+
+    expect(result).toEqual([{ name: 'Featured widget' }]);
+    expect(collectionHandler).toHaveBeenCalledOnce();
+  });
+
+  it('preserves custom collection search methods instead of masking them with the generic fetcher', async () => {
+    const collectionHandler = vi.fn(async (req: Request) => {
+      expect(new URL(req.url).pathname).toBe(
+        '/api/v1/genclientproducts/search',
+      );
+      expect(req.method).toBe('POST');
+      expect(await req.json()).toEqual({ filters: { term: 'widget' } });
+      return Response.json({
+        action: 'search',
+        result: [{ name: 'Widget' }],
+      });
+    });
+    stubFetchToServer(collectionHandler);
+
+    const client = createClient('/api/v1');
+    const collectionClient =
+      client.genClientProductCollection as typeof client.genClientProductCollection & {
+        search(options?: Record<string, unknown>): Promise<unknown>;
+      };
+    const result = await collectionClient.search({
+      filters: { term: 'widget' },
+    });
+
+    expect(result).toEqual([{ name: 'Widget' }]);
+    expect(collectionHandler).toHaveBeenCalledOnce();
   });
 
   it('#1797: list() returns a BARE array whose items carry snake_case created_at', async () => {

--- a/packages/core/src/vite-plugin/generated-client-integration.test.ts
+++ b/packages/core/src/vite-plugin/generated-client-integration.test.ts
@@ -179,6 +179,36 @@ export class ArtCollection extends SmrtObject {
     return 'item model, not SmrtCollection';
   }
 }
+
+@smrt({ api: { public: true } })
+export class Contents extends SmrtCollection<Content> {
+  async featured(): Promise<Content[]> {
+    return this.list();
+  }
+}
+
+@smrt({ api: { public: true } })
+export class Content extends SmrtObject {
+  async summarize(): Promise<string> {
+    return 'summary';
+  }
+}
+
+@smrt({ api: { public: true } })
+export class GenClientMessageCollection extends SmrtCollection<GenClientMessage> {}
+
+@smrt({ api: { public: true } })
+export class GenClientEmailCollection extends GenClientMessageCollection {
+  async findUnread(): Promise<GenClientEmail[]> {
+    return this.list();
+  }
+}
+
+@smrt({ api: { public: true } })
+export class GenClientMessage extends SmrtObject {}
+
+@smrt({ api: { public: true } })
+export class GenClientEmail extends GenClientMessage {}
 `,
     );
 
@@ -208,6 +238,8 @@ export class ArtCollection extends SmrtObject {
     expect(clientSource).toContain('genclientproducts:');
     expect(clientSource).toContain('genClientProductCollection:');
     expect(clientSource.match(/\n {2}genclientproducts:/g)).toHaveLength(1);
+    expect(clientSource.match(/\n {2}contents:/g)).toHaveLength(1);
+    expect(clientSource).toContain('contents2:');
     expect(clientSource).toContain('findFeatured: (options)');
     expect(clientSource).not.toContain('findFeatured: (id, options)');
     expect(clientSource).not.toContain('list: (id, options)');
@@ -215,6 +247,10 @@ export class ArtCollection extends SmrtObject {
     expect(clientSource).not.toContain('invalidCollectionScope: (');
     expect(clientSource).toContain('describe: (id, options)');
     expect(clientSource).not.toContain('describe: (options)');
+    expect(clientSource).toContain('featured: (options)');
+    expect(clientSource).toContain('summarize: (id, options)');
+    expect(clientSource).toContain('findUnread: (options)');
+    expect(clientSource).not.toContain('findUnread: (id, options)');
     const declarationSource = readFileSync(
       join(projectRoot, 'src', 'types', 'virtual-modules.d.ts'),
       'utf-8',
@@ -229,6 +265,15 @@ export class ArtCollection extends SmrtObject {
     );
     expect(declarationSource).toContain(
       'describe(id: string, options: { tone: string }): Promise<any>;',
+    );
+    expect(declarationSource).toContain(
+      'contents: CrudOperations<ContentData> & {\n      summarize(id: string, options?: Record<string, never>): Promise<any>;',
+    );
+    expect(declarationSource).toContain(
+      'contents2: CrudOperations<ContentData> & {\n      featured(options?: Record<string, never>): Promise<any>;',
+    );
+    expect(declarationSource).toContain(
+      'genClientEmailCollection: CrudOperations<GenClientEmailData> & {\n      findUnread(options?: Record<string, never>): Promise<any>;',
     );
 
     // Evaluate the generated ESM the way a bundler would: write it to disk and

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -30,6 +30,7 @@ import {
   buildWebCollectionDefinition,
   buildWebToolDescriptors,
   computeWebManifestHash,
+  isCollectionManifestClass,
   selectWebCollectionEntries,
 } from './web-collections.js';
 
@@ -1184,39 +1185,65 @@ const GENERATED_CLIENT_BASE_METHODS = new Set([
   'search',
 ]);
 
-function isCollectionManifestEntry(
+function findManifestObjectByName(
+  manifest: SmartObjectManifest,
+  name: string,
+): SmartObjectManifest['objects'][string] | undefined {
+  return Object.entries(manifest.objects).find(
+    ([manifestKey, candidate]) =>
+      manifestKey === name ||
+      candidate.qualifiedName === name ||
+      candidate.className === name,
+  )?.[1];
+}
+
+function resolveCollectionItemObject(
   obj: SmartObjectManifest['objects'][string],
-): boolean {
-  return obj.extends === 'SmrtCollection' || Boolean(obj.extendsTypeArg);
+  manifest: SmartObjectManifest,
+): SmartObjectManifest['objects'][string] | undefined {
+  const seen = new Set<string>();
+  let candidate: SmartObjectManifest['objects'][string] | undefined = obj;
+
+  while (candidate) {
+    if (candidate.extendsTypeArg) {
+      const itemObject = findManifestObjectByName(
+        manifest,
+        candidate.extendsTypeArg,
+      );
+      if (itemObject) return itemObject;
+    }
+
+    if (candidate.className.endsWith('Collection')) {
+      const conventionalItem = findManifestObjectByName(
+        manifest,
+        candidate.className.slice(0, -'Collection'.length),
+      );
+      if (conventionalItem) return conventionalItem;
+    }
+
+    const parentName = candidate.extendsQualified || candidate.extends;
+    if (!parentName || seen.has(parentName)) return undefined;
+    seen.add(parentName);
+    candidate = findManifestObjectByName(manifest, parentName);
+  }
+
+  return undefined;
 }
 
 function resolveApiClientDataInterfaceName(
   obj: SmartObjectManifest['objects'][string],
   manifest: SmartObjectManifest,
 ): string {
-  if (!isCollectionManifestEntry(obj)) {
+  if (!isCollectionManifestClass(manifest, obj)) {
     return `${obj.className}Data`;
   }
 
-  const itemClassName =
-    obj.extendsTypeArg ||
-    (obj.className.endsWith('Collection')
-      ? obj.className.slice(0, -'Collection'.length)
-      : undefined);
-  const itemObject = itemClassName
-    ? Object.entries(manifest.objects).find(
-        ([manifestKey, candidate]) =>
-          manifestKey === itemClassName ||
-          candidate.className === itemClassName,
-      )?.[1]
-    : undefined;
+  const itemObject = resolveCollectionItemObject(obj, manifest);
 
   return `${itemObject?.className || obj.className}Data`;
 }
 
-function uniqueApiClientEntries(
-  objects: Array<[string, SmartObjectManifest['objects'][string]]>,
-): Array<{
+function uniqueApiClientEntries(manifest: SmartObjectManifest): Array<{
   objectName: string;
   obj: SmartObjectManifest['objects'][string];
   clientKey: string;
@@ -1225,28 +1252,38 @@ function uniqueApiClientEntries(
     string,
     SmartObjectManifest['objects'][string]
   >();
+  const objects = Object.entries(manifest.objects);
 
   for (const [, obj] of objects) {
     const current = canonicalCollectionOwners.get(obj.collection);
     if (
       !current ||
-      (isCollectionManifestEntry(current) && !isCollectionManifestEntry(obj))
+      (isCollectionManifestClass(manifest, current) &&
+        !isCollectionManifestClass(manifest, obj))
     ) {
       canonicalCollectionOwners.set(obj.collection, obj);
     }
   }
 
+  // Secondary keys must never claim canonical REST collection keys, even when
+  // a collection class normalizes to the same spelling and is scanned first
+  // (for example Contents + Content -> "contents").
+  const reservedCanonicalKeys = new Set(canonicalCollectionOwners.keys());
   const usedKeys = new Set<string>();
 
   return objects.map(([objectName, obj]) => {
-    let clientKey =
-      canonicalCollectionOwners.get(obj.collection) === obj
-        ? obj.collection
-        : lowerFirst(obj.className);
+    const isCanonicalOwner =
+      canonicalCollectionOwners.get(obj.collection) === obj;
+    let clientKey = isCanonicalOwner
+      ? obj.collection
+      : lowerFirst(obj.className);
 
     const baseClientKey = clientKey;
     let suffix = 2;
-    while (usedKeys.has(clientKey)) {
+    while (
+      usedKeys.has(clientKey) ||
+      (!isCanonicalOwner && reservedCanonicalKeys.has(clientKey))
+    ) {
       clientKey = `${baseClientKey}${suffix}`;
       suffix += 1;
     }
@@ -1260,7 +1297,7 @@ function generateClientModule(
   manifest: SmartObjectManifest,
   options: { kebabRoutes?: boolean } = {},
 ): string {
-  const objects = uniqueApiClientEntries(Object.entries(manifest.objects));
+  const objects = uniqueApiClientEntries(manifest);
 
   const clientMethods = objects
     .map(({ obj, clientKey }) => {
@@ -1290,7 +1327,7 @@ function generateClientModule(
             method,
             apiConfig,
             { kebabRoutes: options.kebabRoutes },
-            isCollectionManifestEntry(obj)
+            isCollectionManifestClass(manifest, obj)
               ? 'collection'
               : method.isStatic
                 ? 'collection'
@@ -1731,9 +1768,7 @@ ${fields}
     // type surface matches what generateClientModule actually emits at
     // runtime — otherwise consumers see methods in autocomplete that are
     // undefined at runtime.
-    const apiClientInterface = uniqueApiClientEntries(
-      Object.entries(manifest.objects),
-    )
+    const apiClientInterface = uniqueApiClientEntries(manifest)
       .map(({ obj, clientKey }) => {
         const { methods = {} } = obj;
         const apiConfig = obj.decoratorConfig?.api;
@@ -1754,7 +1789,7 @@ ${fields}
               method,
               apiConfig,
               {},
-              isCollectionManifestEntry(obj)
+              isCollectionManifestClass(manifest, obj)
                 ? 'collection'
                 : method.isStatic
                   ? 'collection'

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -22,7 +22,7 @@ import { importBuildAwareModule } from './import-build-aware.js';
 import {
   findCliApiCoherenceViolations,
   generateSvelteKitRoutes,
-  methodNameToKebab,
+  resolveApiActionRouteConfig,
   resolveApiActionSet,
   validateCliIncludeAgainstApi,
 } from './sveltekit-generator.js';
@@ -1171,6 +1171,49 @@ function lowerFirst(value: string): string {
   return value ? value[0].toLowerCase() + value.slice(1) : value;
 }
 
+const GENERATED_CLIENT_CRUD_METHODS = new Set([
+  'list',
+  'get',
+  'create',
+  'update',
+  'delete',
+]);
+
+const GENERATED_CLIENT_BASE_METHODS = new Set([
+  ...GENERATED_CLIENT_CRUD_METHODS,
+  'search',
+]);
+
+function isCollectionManifestEntry(
+  obj: SmartObjectManifest['objects'][string],
+): boolean {
+  return obj.extends === 'SmrtCollection' || Boolean(obj.extendsTypeArg);
+}
+
+function resolveApiClientDataInterfaceName(
+  obj: SmartObjectManifest['objects'][string],
+  manifest: SmartObjectManifest,
+): string {
+  if (!isCollectionManifestEntry(obj)) {
+    return `${obj.className}Data`;
+  }
+
+  const itemClassName =
+    obj.extendsTypeArg ||
+    (obj.className.endsWith('Collection')
+      ? obj.className.slice(0, -'Collection'.length)
+      : undefined);
+  const itemObject = itemClassName
+    ? Object.entries(manifest.objects).find(
+        ([manifestKey, candidate]) =>
+          manifestKey === itemClassName ||
+          candidate.className === itemClassName,
+      )?.[1]
+    : undefined;
+
+  return `${itemObject?.className || obj.className}Data`;
+}
+
 function uniqueApiClientEntries(
   objects: Array<[string, SmartObjectManifest['objects'][string]]>,
 ): Array<{
@@ -1178,14 +1221,28 @@ function uniqueApiClientEntries(
   obj: SmartObjectManifest['objects'][string];
   clientKey: string;
 }> {
+  const canonicalCollectionOwners = new Map<
+    string,
+    SmartObjectManifest['objects'][string]
+  >();
+
+  for (const [, obj] of objects) {
+    const current = canonicalCollectionOwners.get(obj.collection);
+    if (
+      !current ||
+      (isCollectionManifestEntry(current) && !isCollectionManifestEntry(obj))
+    ) {
+      canonicalCollectionOwners.set(obj.collection, obj);
+    }
+  }
+
   const usedKeys = new Set<string>();
 
   return objects.map(([objectName, obj]) => {
-    let clientKey = obj.collection;
-
-    if (usedKeys.has(clientKey)) {
-      clientKey = lowerFirst(obj.className);
-    }
+    let clientKey =
+      canonicalCollectionOwners.get(obj.collection) === obj
+        ? obj.collection
+        : lowerFirst(obj.className);
 
     const baseClientKey = clientKey;
     let suffix = 2;
@@ -1215,43 +1272,52 @@ function generateClientModule(
       // preserve the existing client-type contract.)
       const exposedActions = resolveApiActionSet(obj);
       const apiConfig = obj.decoratorConfig?.api;
-      const apiRoutes: Record<string, { path?: string }> =
-        apiConfig && typeof apiConfig === 'object'
-          ? ((apiConfig as { routes?: Record<string, { path?: string }> })
-              .routes ?? {})
-          : {};
 
       const customMethods = Object.entries(methods).filter(
-        ([name, method]) => method.isPublic && exposedActions.has(name),
+        ([name, method]) =>
+          !GENERATED_CLIENT_CRUD_METHODS.has(name) &&
+          method.isPublic &&
+          exposedActions.has(name),
       );
 
-      // Resolve the URL segment for each custom method using the same priority
-      // the server does in normalizeCustomRoutePath: explicit api.routes[name].path
-      // override wins; else kebab-case when kebabRoutes is enabled; else source casing.
-      const segmentFor = (methodName: string): string => {
-        const overridePath = apiRoutes[methodName]?.path;
-        if (overridePath) {
-          const trimmed = overridePath
-            .split('/')
-            .map((s) => s.trim())
-            .filter(Boolean)
-            .join('/');
-          if (trimmed.length > 0) return trimmed;
-        }
-        return options.kebabRoutes ? methodNameToKebab(methodName) : methodName;
-      };
-
-      // Generate custom method implementations.
-      // Custom methods are instance methods: POST /{collection}/{id}/{urlSegment}.
-      // All fetchers reject on !response.ok (#1796) via __smrtFetchJson.
+      // Generate custom method implementations using the same route metadata
+      // as the SvelteKit server generator. All fetchers reject on !response.ok
+      // (#1796) via __smrtFetchJson.
       const customMethodImpls = customMethods
-        .map(([methodName, _method]) => {
-          const urlSegment = segmentFor(methodName);
-          return `    ${methodName}: (id, options) => __smrtFetchJson(basePath + '/${collection}/' + id + '/${urlSegment}', {
-      method: 'POST',
+        .map(([methodName, method]) => {
+          const routeConfig = resolveApiActionRouteConfig(
+            methodName,
+            method,
+            apiConfig,
+            { kebabRoutes: options.kebabRoutes },
+            isCollectionManifestEntry(obj)
+              ? 'collection'
+              : method.isStatic
+                ? 'collection'
+                : 'item',
+          );
+          const urlSegment = routeConfig.pathSegments.join('/');
+          const args =
+            routeConfig.scope === 'collection' ? 'options' : 'id, options';
+          const route =
+            routeConfig.scope === 'collection'
+              ? `basePath + '/${collection}/${urlSegment}'`
+              : `basePath + '/${collection}/' + id + '/${urlSegment}'`;
+          const actionUrl = `__smrtActionUrl(${route}, options, ${JSON.stringify(
+            routeConfig.pathParamNames,
+          )}, ${routeConfig.method === 'GET'})`;
+          const requestInit =
+            routeConfig.method === 'GET'
+              ? `{
+      method: 'GET',
+      headers: { 'Accept': 'application/json' }
+    }`
+              : `{
+      method: '${routeConfig.method}',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(options || {})
-    })`;
+    }`;
+          return `    ${methodName}: (${args}) => __smrtFetchActionResult(${actionUrl}, ${requestInit})`;
         })
         .join(',\n');
 
@@ -1300,6 +1366,51 @@ function generateClientModule(
 // This file is generated automatically - do not edit
 
 ${CLIENT_FETCH_RUNTIME}
+
+async function __smrtFetchActionResult(url, init) {
+  const body = await __smrtFetchJson(url, init);
+  return body &&
+    typeof body === 'object' &&
+    Object.prototype.hasOwnProperty.call(body, 'result')
+    ? body.result
+    : body;
+}
+
+function __smrtActionUrl(url, options, pathParamNames, includeQuery) {
+  const values = options && typeof options === 'object' ? options : {};
+  const pathParams = new Set(pathParamNames);
+  let resolvedUrl = url;
+  for (const name of pathParamNames) {
+    const value = values[name];
+    if (value === undefined || value === null) {
+      throw new Error('Missing generated client route parameter: ' + name);
+    }
+    resolvedUrl = resolvedUrl.replace(
+      '[' + name + ']',
+      encodeURIComponent(String(value)),
+    );
+  }
+
+  if (!includeQuery) return resolvedUrl;
+
+  const searchParams = new URLSearchParams();
+  for (const [name, value] of Object.entries(values)) {
+    if (pathParams.has(name) || value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) searchParams.append(name, String(item));
+      continue;
+    }
+    searchParams.append(
+      name,
+      value !== null && typeof value === 'object'
+        ? JSON.stringify(value)
+        : String(value),
+    );
+  }
+
+  const query = searchParams.toString();
+  return query ? resolvedUrl + '?' + query : resolvedUrl;
+}
 
 export function createClient(basePath = '/api/v1') {
   return {${clientMethods}
@@ -1624,32 +1735,87 @@ ${fields}
       Object.entries(manifest.objects),
     )
       .map(({ obj, clientKey }) => {
-        const { className, methods = {} } = obj;
-        const interfaceName = `${className}Data`;
+        const { methods = {} } = obj;
+        const apiConfig = obj.decoratorConfig?.api;
+        const interfaceName = resolveApiClientDataInterfaceName(obj, manifest);
         const exposedActions = resolveApiActionSet(obj);
         const customMethods = Object.entries(methods).filter(
-          ([name, method]) => method.isPublic && exposedActions.has(name),
+          ([name, method]) =>
+            !GENERATED_CLIENT_CRUD_METHODS.has(name) &&
+            method.isPublic &&
+            exposedActions.has(name),
         );
 
         // Generate custom method signatures
-        // Custom methods are instance methods requiring id as first parameter
         const customMethodSignatures = customMethods
           .map(([methodName, method]) => {
+            const routeConfig = resolveApiActionRouteConfig(
+              methodName,
+              method,
+              apiConfig,
+              {},
+              isCollectionManifestEntry(obj)
+                ? 'collection'
+                : method.isStatic
+                  ? 'collection'
+                  : 'item',
+            );
             const params = method.parameters || [];
-            const optionsSignature =
-              params.length > 0
-                ? `, options?: { ${params.map((p) => `${p.name}?: ${mapTypeScriptType(p.type)}`).join('; ')} }`
-                : '';
-            return `      ${methodName}(id: string${optionsSignature}): Promise<any>;`;
+            const pathParamNames = new Set(routeConfig.pathParamNames);
+            const hasSingleOptionsParameter =
+              params.length === 1 && params[0]?.name === 'options';
+            const requiredPathProperties = routeConfig.pathParamNames
+              .map((name) => `${name}: string`)
+              .join('; ');
+            let optionsType: string;
+            if (hasSingleOptionsParameter) {
+              const directOptionsType = mapTypeScriptType(params[0].type);
+              optionsType = requiredPathProperties
+                ? `${directOptionsType} & { ${requiredPathProperties} }`
+                : directOptionsType;
+            } else {
+              const parameterNames = new Set(params.map((param) => param.name));
+              const properties = params.map(
+                (param) =>
+                  `${param.name}${pathParamNames.has(param.name) ? '' : '?'}: ${mapTypeScriptType(param.type)}`,
+              );
+              for (const pathParamName of routeConfig.pathParamNames) {
+                if (!parameterNames.has(pathParamName)) {
+                  properties.push(`${pathParamName}: string`);
+                }
+              }
+              optionsType =
+                properties.length > 0
+                  ? `{ ${properties.join('; ')} }`
+                  : 'Record<string, never>';
+            }
+            const optionsParameter = `${routeConfig.pathParamNames.length > 0 ? 'options' : 'options?'}: ${optionsType}`;
+            const signature =
+              routeConfig.scope === 'collection'
+                ? optionsParameter
+                : `id: string, ${optionsParameter}`;
+            return `      ${methodName}(${signature}): Promise<any>;`;
           })
           .join('\n');
 
+        const overriddenBaseMethods = customMethods
+          .map(([methodName]) => methodName)
+          .filter((methodName) =>
+            GENERATED_CLIENT_BASE_METHODS.has(methodName),
+          );
+        const crudOperationsType =
+          overriddenBaseMethods.length > 0
+            ? `Omit<CrudOperations<${interfaceName}>, ${overriddenBaseMethods
+                .map((methodName) => JSON.stringify(methodName))
+                .join(' | ')}>`
+            : `CrudOperations<${interfaceName}>`;
+
         if (customMethods.length > 0) {
           // Object with custom methods: include both CRUD and custom methods
-          return `    ${clientKey}: CrudOperations<${interfaceName}> & {\n${customMethodSignatures}\n    };`;
+          return `    ${clientKey}: ${crudOperationsType} & {\n${customMethodSignatures}\n    };`;
         } else {
           // Standard CRUD operations only
-          return `    ${clientKey}: CrudOperations<${interfaceName}>;`;
+          return `    ${clientKey}: ${crudOperationsType};`;
         }
       })
       .join('\n');
@@ -1753,7 +1919,8 @@ declare module '@happyvertical/smrt-virt-routes' {
 // list/search, a bare object for get/create/update — with snake_case field
 // names (created_at, updated_at). These declarations match that shape (no
 // envelope, no camelCase). Fetchers reject on non-2xx with a SmrtClientError
-// (#1796). This is byte-identical to the prebuild declaration path.
+// (#1796). Shared CRUD wire types stay aligned with the prebuild declaration
+// path; Vite-only custom action declarations are layered onto them below.
 declare module '@happyvertical/smrt-virt-client' {
   /** Shape of a JSON error body carried by a rejected request (SmrtClientError.body). */
   export interface ApiError {

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -63,7 +63,7 @@ export interface SvelteKitOptions {
 const BIOME_LINE_WIDTH = 80;
 const STANDARD_API_ACTIONS = ['list', 'get', 'create', 'update', 'delete'];
 
-interface ResolvedApiActionRouteConfig {
+export interface ResolvedApiActionRouteConfig {
   scope: 'item' | 'collection';
   method: ApiHttpMethod;
   pathSegments: string[];
@@ -776,7 +776,7 @@ function extractRoutePathParamNames(pathSegments: string[]): string[] {
     .filter(Boolean);
 }
 
-function resolveApiActionRouteConfig(
+export function resolveApiActionRouteConfig(
   actionName: string,
   actionDef: { isStatic?: boolean },
   apiConfig: unknown,

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -135,7 +135,7 @@ function normalizeRelatedName(related: string): string {
  * carries no type argument of its own; without walking the extends chain it
  * would be mistaken for a model and claim its base model's REST collection.
  */
-function isWebCollectionClass(
+export function isCollectionManifestClass(
   manifest: SmartObjectManifest,
   obj: SmartObjectDefinition,
   seen: Set<string> = new Set(),
@@ -150,7 +150,7 @@ function isWebCollectionClass(
   if (!parentName || seen.has(parentName)) return false;
   seen.add(parentName);
   const parent = findByName(manifest, parentName);
-  return parent ? isWebCollectionClass(manifest, parent, seen) : false;
+  return parent ? isCollectionManifestClass(manifest, parent, seen) : false;
 }
 
 /**
@@ -192,7 +192,7 @@ function selectEntriesQualifiedBy(
   >();
 
   for (const obj of Object.values(manifest.objects)) {
-    if (isWebCollectionClass(manifest, obj)) continue;
+    if (isCollectionManifestClass(manifest, obj)) continue;
 
     const exposedActions = resolveApiActionSet(obj);
     if (!qualifies(exposedActions)) continue;


### PR DESCRIPTION
## Summary

- deterministically reserve shared plural client keys for item models
- emit collection custom clients under stable secondary keys with server-matched scope, path, and verb handling
- keep generated runtime and declarations aligned for custom search, item DTOs, path params, and action result envelopes
- add integration coverage for collection-first manifests and misconfiguration guards

## Root cause

When a `SmrtCollection` manifest entry was scanned before its item class, it could claim the shared plural client key. Its methods then overrode item CRUD/list behavior, and collection-scoped custom methods were emitted with item-scoped URLs and types.

## Validation

- full `@happyvertical/smrt-core` suite: 3,082 passed / 30 skipped
- focused generated-client integration: 6/6
- core typecheck and build
- root build: 58/58 tasks
- Biome on changed files
- strict knowledge check
- captured pre-PR AI review: 0 findings

## Note

The repo-wide pre-push Biome hook currently reports four errors in `packages/personas/src/index.ts` and `packages/users/src/index.ts`; both are unchanged from `origin/main`. The three files in this PR pass the same Biome check.