### PR TITLE
fix(ci): stabilize optimized validation

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -18,7 +18,10 @@ If the remote cache is unavailable, Turbo performs a cold build.
 
 The pnpm store and runner workspace must remain on the same node-local
 filesystem so pnpm can hardlink packages. Do not restore the RAM-backed split
-mounts without measuring runner memory and install latency.
+mounts without measuring runner memory and install latency. The shared setup
+action also points `TMPDIR` at the workspace-backed runner temp directory so
+SQLite fixtures and other temporary test files bypass the container overlay
+filesystem.
 
 ## Pull requests and merge groups
 

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -21,7 +21,8 @@ filesystem so pnpm can hardlink packages. Do not restore the RAM-backed split
 mounts without measuring runner memory and install latency. The shared setup
 action also points `TMPDIR` at the workspace-backed runner temp directory so
 SQLite fixtures and other temporary test files bypass the container overlay
-filesystem.
+filesystem. ARC runners can provide `CI_TEST_TMPDIR` to route those files to a
+bounded, test-only tmpfs; other runners retain the workspace-backed fallback.
 
 ## Pull requests and merge groups
 

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -49,6 +49,13 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Configure runner temp directory
+      shell: bash
+      run: |
+        mkdir -p "$RUNNER_TEMP"
+        echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
+        echo "Using workspace-backed runner temp directory at $RUNNER_TEMP"
+
     # Check if Node.js is already installed with the required version (custom ARC runner)
     - name: Check Node.js version
       id: node-check

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -52,9 +52,10 @@ runs:
     - name: Configure runner temp directory
       shell: bash
       run: |
-        mkdir -p "$RUNNER_TEMP"
-        echo "TMPDIR=$RUNNER_TEMP" >> "$GITHUB_ENV"
-        echo "Using workspace-backed runner temp directory at $RUNNER_TEMP"
+        temp_dir="${CI_TEST_TMPDIR:-$RUNNER_TEMP}"
+        mkdir -p "$temp_dir"
+        echo "TMPDIR=$temp_dir" >> "$GITHUB_ENV"
+        echo "Using runner temp directory at $temp_dir"
 
     # Check if Node.js is already installed with the required version (custom ARC runner)
     - name: Check Node.js version

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -289,7 +289,10 @@ jobs:
     needs: build
     if: inputs.mode == 'full'
     runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
-    timeout-minutes: 15
+    # A remote-cache outage can add several minutes of cold setup and build
+    # time. Match the package-shard ceiling so cache misses cannot cancel an
+    # otherwise healthy core suite.
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       max-parallel: 2

--- a/packages/ads/vitest.config.ts
+++ b/packages/ads/vitest.config.ts
@@ -11,10 +11,6 @@ export default defineConfig({
     hookTimeout: 30000, // Allow longer setup time in CI
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/affiliates/vitest.config.ts
+++ b/packages/affiliates/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/agents/vitest.config.ts
+++ b/packages/agents/vitest.config.ts
@@ -24,10 +24,6 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/assets-ergot/vitest.config.ts
+++ b/packages/assets-ergot/vitest.config.ts
@@ -29,10 +29,6 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/assets-local/vitest.config.ts
+++ b/packages/assets-local/vitest.config.ts
@@ -29,10 +29,6 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/assets/vitest.config.ts
+++ b/packages/assets/vitest.config.ts
@@ -24,10 +24,6 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/chat/vitest.config.ts
+++ b/packages/chat/vitest.config.ts
@@ -25,11 +25,7 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/commerce/vitest.config.ts
+++ b/packages/commerce/vitest.config.ts
@@ -12,11 +12,7 @@ export default defineConfig({
     fileParallelism: false,
     // Use single-threaded pool to avoid database contention
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/config/vitest.config.ts
+++ b/packages/config/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/core/src/__tests__/issue-1758-change-feed.test.ts
+++ b/packages/core/src/__tests__/issue-1758-change-feed.test.ts
@@ -21,7 +21,7 @@
  */
 
 import type { DatabaseInterface } from '@happyvertical/sql';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   appendChange,
   bumpChangeFeed,
@@ -567,6 +567,37 @@ describe('change feed spine (issue #1758)', () => {
       expect(page.cursor).toBe(1);
       expect(page.resyncRequired).toBe(true);
       expect(page.resyncCursor).toBe(5);
+    });
+  });
+
+  describe('append allocation', () => {
+    it('retries SDK-wrapped Postgres unique violations', async () => {
+      const wrappedUniqueViolation = Object.assign(
+        new Error('Failed to execute raw query'),
+        {
+          code: 'DATABASE_ERROR',
+          context: {
+            originalError:
+              'duplicate key value violates unique constraint "_smrt_changes_pkey", code=23505, detail=Key (seq)=(1) already exists.',
+          },
+        },
+      );
+      const query = vi
+        .fn()
+        .mockRejectedValueOnce(wrappedUniqueViolation)
+        .mockResolvedValueOnce({ rows: [{ seq: 1 }] });
+      const postgresDb = {
+        url: 'postgresql://ci.invalid/smrt',
+        query,
+      } as unknown as DatabaseInterface;
+
+      await expect(
+        appendChange(postgresDb, {
+          table: 'products',
+          rowId: 'product-1',
+        }),
+      ).resolves.toBe(1);
+      expect(query).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/core/src/change-feed.ts
+++ b/packages/core/src/change-feed.ts
@@ -281,8 +281,41 @@ function getQueryRows(result: unknown): Record<string, unknown>[] {
 }
 
 function isUniqueViolation(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error ?? '');
+  const signals: string[] = [];
+  const pending: unknown[] = [error];
+  const seen = new Set<object>();
+
+  while (pending.length > 0 && seen.size < 5) {
+    const candidate = pending.shift();
+    if (typeof candidate === 'string') {
+      signals.push(candidate);
+      continue;
+    }
+    if (!candidate || typeof candidate !== 'object' || seen.has(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+
+    const shaped = candidate as {
+      cause?: unknown;
+      code?: unknown;
+      context?: unknown;
+      message?: unknown;
+    };
+    if (typeof shaped.message === 'string') signals.push(shaped.message);
+    if (typeof shaped.code === 'string') signals.push(shaped.code);
+    if (shaped.cause !== undefined) pending.push(shaped.cause);
+
+    if (shaped.context && typeof shaped.context === 'object') {
+      const originalError = (shaped.context as { originalError?: unknown })
+        .originalError;
+      if (originalError !== undefined) pending.push(originalError);
+    }
+  }
+
+  const message = signals.join(', ');
   return (
+    /\b23505\b/.test(message) ||
     /unique constraint/i.test(message) ||
     /duplicate key/i.test(message) ||
     /primary key constraint/i.test(message) ||

--- a/packages/events/vitest.config.ts
+++ b/packages/events/vitest.config.ts
@@ -13,10 +13,6 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/facts/vitest.config.ts
+++ b/packages/facts/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/features/vitest.config.ts
+++ b/packages/features/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 60000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/gnode/vitest.config.ts
+++ b/packages/gnode/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/images/vitest.config.ts
+++ b/packages/images/vitest.config.ts
@@ -27,11 +27,7 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
     coverage: {
       // Exclude @smrt/core-generated code from the coverage denominator: the
       // SvelteKit route handlers (gitignored, "Auto-generated … DO NOT EDIT")

--- a/packages/inventory/vitest.config.ts
+++ b/packages/inventory/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/jobs/vitest.config.ts
+++ b/packages/jobs/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/languages/vitest.config.ts
+++ b/packages/languages/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/ledgers/vitest.config.ts
+++ b/packages/ledgers/vitest.config.ts
@@ -13,11 +13,7 @@ export default defineConfig({
     fileParallelism: false,
     // Use single-threaded pool to avoid database contention
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/manufacturing/vitest.config.ts
+++ b/packages/manufacturing/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/personas/vitest.config.ts
+++ b/packages/personas/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/places/vitest.config.ts
+++ b/packages/places/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/profiles/vitest.config.ts
+++ b/packages/profiles/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/projects/vitest.config.ts
+++ b/packages/projects/vitest.config.ts
@@ -25,11 +25,7 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/prompts/vitest.config.ts
+++ b/packages/prompts/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/properties/vitest.config.ts
+++ b/packages/properties/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/reports/vitest.config.ts
+++ b/packages/reports/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/scanner/vitest.config.ts
+++ b/packages/scanner/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/secrets/vitest.config.ts
+++ b/packages/secrets/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/sites/vitest.config.ts
+++ b/packages/sites/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/smrt-dev-mcp/vitest.config.ts
+++ b/packages/smrt-dev-mcp/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/smrt-mobile-contract/package.json
+++ b/packages/smrt-mobile-contract/package.json
@@ -33,6 +33,7 @@
     "prepack": "node ../../scripts/prepack-package.js"
   },
   "devDependencies": {
+    "@happyvertical/smrt-core": "workspace:*",
     "@types/node": "24.13.2",
     "typescript": "^5.9.3",
     "vite": "8.1.3",

--- a/packages/smrt-mobile-contract/vitest.config.ts
+++ b/packages/smrt-mobile-contract/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/smrt-svelte/vitest.config.ts
+++ b/packages/smrt-svelte/vitest.config.ts
@@ -60,10 +60,6 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/smrt-ui/vitest.config.ts
+++ b/packages/smrt-ui/vitest.config.ts
@@ -27,10 +27,6 @@ export default defineConfig({
     hookTimeout: 60000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/social/vitest.config.ts
+++ b/packages/social/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/subscriptions/vitest.config.ts
+++ b/packages/subscriptions/vitest.config.ts
@@ -11,10 +11,6 @@ export default defineConfig({
     hookTimeout: 60000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/tags/vitest.config.ts
+++ b/packages/tags/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/tenancy/vitest.config.ts
+++ b/packages/tenancy/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/types/vitest.config.ts
+++ b/packages/types/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -39,7 +39,7 @@
     "dev": "npm run build:watch",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
-    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run",
+    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/__tests__/permission-postgres-rls.test.ts src/__tests__/principal-permission-context-postgres.test.ts",
     "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."

--- a/packages/users/src/__tests__/permission-postgres-rls.test.ts
+++ b/packages/users/src/__tests__/permission-postgres-rls.test.ts
@@ -43,6 +43,29 @@ async function closeDatabase(database: unknown): Promise<void> {
   }
 }
 
+async function seedWithSystemContext(
+  db: DatabaseInterface,
+  sql: string,
+  ...values: unknown[]
+): Promise<void> {
+  const factory = db as DatabaseInterface & {
+    beginTransaction?: () => Promise<TransactionHandle>;
+  };
+  if (!factory.beginTransaction) {
+    throw new Error('Postgres test database does not support transactions.');
+  }
+
+  const tx = await factory.beginTransaction();
+  try {
+    await tx.query("SELECT set_config('smrt.system_context', 'true', true)");
+    await tx.query(sql, ...values);
+    await tx.commit();
+  } catch (error) {
+    if (tx.isActive()) await tx.rollback();
+    throw error;
+  }
+}
+
 async function setSessionContext(
   tx: TransactionHandle,
   permissions: string[],
@@ -95,7 +118,8 @@ describePostgres('Postgres permission RLS', () => {
     tenantCId = randomUUID();
 
     await adminDb.query('TRUNCATE TABLE public.permission_rls_records');
-    await adminDb.query(
+    await seedWithSystemContext(
+      adminDb,
       `INSERT INTO public.permission_rls_records
         (id, slug, context, tenant_id, title)
       VALUES

--- a/packages/users/src/__tests__/permission-postgres-rls.test.ts
+++ b/packages/users/src/__tests__/permission-postgres-rls.test.ts
@@ -70,6 +70,11 @@ describePostgres('Postgres permission RLS', () => {
   let isolated: IsolatedTestDbResult | undefined;
   let adminDb: DatabaseInterface | undefined;
   let roleName = '';
+  let rowAId = '';
+  let rowBId = '';
+  let tenantAId = '';
+  let tenantBId = '';
+  let tenantCId = '';
 
   beforeEach(async () => {
     isolated = await createIsolatedTestDbFromManifest();
@@ -83,30 +88,44 @@ describePostgres('Postgres permission RLS', () => {
       url: isolated.config.url,
     });
 
-    roleName = `smrt_users_rls_${randomUUID().replaceAll('-', '_')}`;
+    rowAId = randomUUID();
+    rowBId = randomUUID();
+    tenantAId = randomUUID();
+    tenantBId = randomUUID();
+    tenantCId = randomUUID();
 
     await adminDb.query('TRUNCATE TABLE public.permission_rls_records');
     await adminDb.query(
-      [
-        'INSERT INTO public.permission_rls_records',
-        '  (id, slug, context, tenant_id, title)',
-        'VALUES',
-        "  ('row-a', 'row-a', '', 'tenant-a', 'Tenant A'),",
-        "  ('row-b', 'row-b', '', 'tenant-b', 'Tenant B')",
-      ].join('\n'),
+      `INSERT INTO public.permission_rls_records
+        (id, slug, context, tenant_id, title)
+      VALUES
+        ($1, 'row-a', '', $2, 'Tenant A'),
+        ($3, 'row-b', '', $4, 'Tenant B')`,
+      rowAId,
+      tenantAId,
+      rowBId,
+      tenantBId,
     );
 
     await applyPostgresPermissionPolicies({
       db: { type: 'postgres', url: isolated.config.url },
     });
 
-    await adminDb.query(
-      `CREATE ROLE "${roleName}" LOGIN PASSWORD 'postgres' NOSUPERUSER NOBYPASSRLS`,
-    );
-    await adminDb.query(`GRANT USAGE ON SCHEMA public TO "${roleName}"`);
-    await adminDb.query(
-      `GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.permission_rls_records TO "${roleName}"`,
-    );
+    const currentRole = rowsOf(
+      await adminDb.query(
+        'SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user',
+      ),
+    )[0];
+    if (currentRole?.rolsuper === true || currentRole?.rolbypassrls === true) {
+      roleName = `smrt_users_rls_${randomUUID().replaceAll('-', '_')}`;
+      await adminDb.query(
+        `CREATE ROLE "${roleName}" LOGIN PASSWORD 'postgres' NOSUPERUSER NOBYPASSRLS`,
+      );
+      await adminDb.query(`GRANT USAGE ON SCHEMA public TO "${roleName}"`);
+      await adminDb.query(
+        `GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.permission_rls_records TO "${roleName}"`,
+      );
+    }
   });
 
   afterEach(async () => {
@@ -156,7 +175,7 @@ describePostgres('Postgres permission RLS', () => {
 
     const tx = await transactionFactory.beginTransaction();
     try {
-      await tx.query(`SET ROLE "${roleName}"`);
+      if (roleName) await tx.query(`SET ROLE "${roleName}"`);
       await setSessionContext(tx, permissions, tenantId, options);
       await fn(tx);
     } finally {
@@ -169,18 +188,18 @@ describePostgres('Postgres permission RLS', () => {
   it('enforces read visibility by tenant and permission', async () => {
     await withRoleTransaction(
       ['permission_rls_records.read'],
-      'tenant-a',
+      tenantAId,
       async (tx) => {
         const result = await tx.query(
-          'SELECT id FROM public.permission_rls_records ORDER BY id',
+          'SELECT id FROM public.permission_rls_records ORDER BY slug',
         );
-        expect(rowsOf(result).map((row) => row.id)).toEqual(['row-a']);
+        expect(rowsOf(result).map((row) => row.id)).toEqual([rowAId]);
       },
     );
 
     await withRoleTransaction(
       ['permission_rls_records.read'],
-      'tenant-c',
+      tenantCId,
       async (tx) => {
         const result = await tx.query(
           'SELECT id FROM public.permission_rls_records ORDER BY id',
@@ -189,7 +208,7 @@ describePostgres('Postgres permission RLS', () => {
       },
     );
 
-    await withRoleTransaction([], 'tenant-a', async (tx) => {
+    await withRoleTransaction([], tenantAId, async (tx) => {
       const result = await tx.query(
         'SELECT id FROM public.permission_rls_records ORDER BY id',
       );
@@ -198,26 +217,28 @@ describePostgres('Postgres permission RLS', () => {
   });
 
   it('enforces insert, update, delete, and bypass semantics', async () => {
+    const rowCId = randomUUID();
+    const rowDId = randomUUID();
     await withRoleTransaction(
       ['permission_rls_records.create'],
-      'tenant-a',
+      tenantAId,
       async (tx) => {
         const inserted = await tx.query(
-          [
-            'INSERT INTO public.permission_rls_records',
-            '  (id, slug, context, tenant_id, title)',
-            "VALUES ('row-c', 'row-c', '', 'tenant-a', 'Tenant C')",
-          ].join('\n'),
+          `INSERT INTO public.permission_rls_records
+            (id, slug, context, tenant_id, title)
+          VALUES ($1, 'row-c', '', $2, 'Tenant C')`,
+          rowCId,
+          tenantAId,
         );
         expect(rowCountOf(inserted)).toBe(1);
 
         await expect(
           tx.query(
-            [
-              'INSERT INTO public.permission_rls_records',
-              '  (id, slug, context, tenant_id, title)',
-              "VALUES ('row-d', 'row-d', '', 'tenant-b', 'Tenant D')",
-            ].join('\n'),
+            `INSERT INTO public.permission_rls_records
+              (id, slug, context, tenant_id, title)
+            VALUES ($1, 'row-d', '', $2, 'Tenant D')`,
+            rowDId,
+            tenantBId,
           ),
         ).rejects.toThrow(/row-level security/i);
       },
@@ -225,23 +246,21 @@ describePostgres('Postgres permission RLS', () => {
 
     await withRoleTransaction(
       ['permission_rls_records.read', 'permission_rls_records.update'],
-      'tenant-a',
+      tenantAId,
       async (tx) => {
         const updated = await tx.query(
-          [
-            'UPDATE public.permission_rls_records',
-            "SET title = 'Tenant A Updated'",
-            "WHERE id = 'row-a'",
-          ].join('\n'),
+          `UPDATE public.permission_rls_records
+          SET title = 'Tenant A Updated'
+          WHERE id = $1`,
+          rowAId,
         );
         expect(rowCountOf(updated)).toBe(1);
 
         const blocked = await tx.query(
-          [
-            'UPDATE public.permission_rls_records',
-            "SET title = 'Tenant B Updated'",
-            "WHERE id = 'row-b'",
-          ].join('\n'),
+          `UPDATE public.permission_rls_records
+          SET title = 'Tenant B Updated'
+          WHERE id = $1`,
+          rowBId,
         );
         expect(rowCountOf(blocked)).toBe(0);
       },
@@ -249,21 +268,17 @@ describePostgres('Postgres permission RLS', () => {
 
     await withRoleTransaction(
       ['permission_rls_records.read', 'permission_rls_records.delete'],
-      'tenant-a',
+      tenantAId,
       async (tx) => {
         const deleted = await tx.query(
-          [
-            'DELETE FROM public.permission_rls_records',
-            "WHERE id = 'row-a'",
-          ].join('\n'),
+          'DELETE FROM public.permission_rls_records WHERE id = $1',
+          rowAId,
         );
         expect(rowCountOf(deleted)).toBe(1);
 
         const blocked = await tx.query(
-          [
-            'DELETE FROM public.permission_rls_records',
-            "WHERE id = 'row-b'",
-          ].join('\n'),
+          'DELETE FROM public.permission_rls_records WHERE id = $1',
+          rowBId,
         );
         expect(rowCountOf(blocked)).toBe(0);
       },
@@ -271,12 +286,12 @@ describePostgres('Postgres permission RLS', () => {
 
     await withRoleTransaction(
       [],
-      'tenant-a',
+      tenantAId,
       async (tx) => {
         const result = await tx.query(
-          'SELECT id FROM public.permission_rls_records ORDER BY id',
+          'SELECT id FROM public.permission_rls_records ORDER BY slug',
         );
-        expect(rowsOf(result).map((row) => row.id)).toEqual(['row-a', 'row-b']);
+        expect(rowsOf(result).map((row) => row.id)).toEqual([rowAId, rowBId]);
       },
       {
         superAdminBypass: true,
@@ -285,17 +300,18 @@ describePostgres('Postgres permission RLS', () => {
 
     await withRoleTransaction(
       [],
-      'tenant-a',
+      tenantAId,
       async (tx) => {
+        const systemRowId = randomUUID();
         const inserted = await tx.query(
-          [
-            'INSERT INTO public.permission_rls_records',
-            '  (id, slug, context, tenant_id, title)',
-            "VALUES ('row-system', 'row-system', '', 'tenant-b', 'System Insert')",
-            'RETURNING id',
-          ].join('\n'),
+          `INSERT INTO public.permission_rls_records
+            (id, slug, context, tenant_id, title)
+          VALUES ($1, 'row-system', '', $2, 'System Insert')
+          RETURNING id`,
+          systemRowId,
+          tenantBId,
         );
-        expect(rowsOf(inserted).map((row) => row.id)).toEqual(['row-system']);
+        expect(rowsOf(inserted).map((row) => row.id)).toEqual([systemRowId]);
       },
       {
         systemContext: true,
@@ -335,28 +351,29 @@ describePostgres('Postgres permission RLS', () => {
       db: { type: 'postgres', url: isolated?.config.url },
     });
 
-    await withRoleTransaction(['audits.inspect'], 'tenant-a', async (tx) => {
+    await withRoleTransaction(['audits.inspect'], tenantAId, async (tx) => {
       const selected = await tx.query(
         'SELECT id FROM public.permission_rls_records ORDER BY id',
       );
-      expect(rowsOf(selected).map((row) => row.id)).toEqual(['row-a']);
+      expect(rowsOf(selected).map((row) => row.id)).toEqual([rowAId]);
 
+      const auditRowId = randomUUID();
       const inserted = await tx.query(
-        [
-          'INSERT INTO public.permission_rls_records',
-          '  (id, slug, context, tenant_id, title)',
-          "VALUES ('row-audit', 'row-audit', '', 'tenant-a', 'Audit Insert')",
-        ].join('\n'),
+        `INSERT INTO public.permission_rls_records
+          (id, slug, context, tenant_id, title)
+        VALUES ($1, 'row-audit', '', $2, 'Audit Insert')`,
+        auditRowId,
+        tenantAId,
       );
       expect(rowCountOf(inserted)).toBe(1);
 
       await expect(
         tx.query(
-          [
-            'INSERT INTO public.permission_rls_records',
-            '  (id, slug, context, tenant_id, title)',
-            "VALUES ('row-audit-blocked', 'row-audit-blocked', '', 'tenant-b', 'Blocked Insert')",
-          ].join('\n'),
+          `INSERT INTO public.permission_rls_records
+            (id, slug, context, tenant_id, title)
+          VALUES ($1, 'row-audit-blocked', '', $2, 'Blocked Insert')`,
+          randomUUID(),
+          tenantBId,
         ),
       ).rejects.toThrow(/row-level security/i);
     });

--- a/packages/users/src/__tests__/principal-permission-context-postgres.test.ts
+++ b/packages/users/src/__tests__/principal-permission-context-postgres.test.ts
@@ -75,6 +75,29 @@ async function closeDatabase(database: unknown): Promise<void> {
   }
 }
 
+async function seedWithSystemContext(
+  db: DatabaseInterface,
+  sql: string,
+  ...values: unknown[]
+): Promise<void> {
+  const factory = db as DatabaseInterface & {
+    beginTransaction?: () => Promise<TransactionHandle>;
+  };
+  if (!factory.beginTransaction) {
+    throw new Error('Postgres test database does not support transactions.');
+  }
+
+  const tx = await factory.beginTransaction();
+  try {
+    await tx.query("SELECT set_config('smrt.system_context', 'true', true)");
+    await tx.query(sql, ...values);
+    await tx.commit();
+  } catch (error) {
+    if (tx.isActive()) await tx.rollback();
+    throw error;
+  }
+}
+
 describePostgres('withPrincipalPermissionContext + Postgres RLS', () => {
   let isolated: IsolatedTestDbResult | undefined;
   let adminDb: DatabaseInterface | undefined;
@@ -144,7 +167,8 @@ describePostgres('withPrincipalPermissionContext + Postgres RLS', () => {
     rowBId = randomUUID();
 
     // One record per tenant; the principal is bound to tenant A only.
-    await adminDb.query(
+    await seedWithSystemContext(
+      adminDb,
       `INSERT INTO public.principal_rls_records
         (id, slug, context, tenant_id, title)
       VALUES

--- a/packages/users/src/__tests__/principal-permission-context-postgres.test.ts
+++ b/packages/users/src/__tests__/principal-permission-context-postgres.test.ts
@@ -10,12 +10,13 @@
  * - a cross-tenant read is denied,
  * - a live role change reflects on the next resolve.
  *
- * RLS only bites for a non-superuser, NOBYPASSRLS role, so — exactly like the
- * existing `permission-postgres-rls.test.ts` — enforcement is exercised under
- * `SET ROLE` inside a transaction. The permission set fed onto that session is
- * the real {@link PermissionResolver} output (the same live cascade
- * `withPrincipalPermissionContext` runs), and a companion test proves the
- * wrapper itself publishes that principal onto a real Postgres session.
+ * RLS only bites for a non-superuser, NOBYPASSRLS role. The dedicated CI role
+ * already has those properties and the policies FORCE RLS for the table owner;
+ * local superuser databases use a temporary `SET ROLE` target instead. The
+ * permission set fed onto that session is the real {@link PermissionResolver}
+ * output (the same live cascade `withPrincipalPermissionContext` runs), and a
+ * companion test proves the wrapper itself publishes that principal onto a
+ * real Postgres session.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -84,6 +85,8 @@ describePostgres('withPrincipalPermissionContext + Postgres RLS', () => {
   let tenantBId = '';
   let roleId = '';
   let readPermissionId = '';
+  let rowAId = '';
+  let rowBId = '';
 
   beforeEach(async () => {
     isolated = await createIsolatedTestDbFromManifest();
@@ -137,27 +140,39 @@ describePostgres('withPrincipalPermissionContext + Postgres RLS', () => {
     roleId = role.id as string;
     readPermissionId = readPermission.id as string;
 
+    rowAId = randomUUID();
+    rowBId = randomUUID();
+
     // One record per tenant; the principal is bound to tenant A only.
     await adminDb.query(
-      [
-        'INSERT INTO public.principal_rls_records',
-        '  (id, slug, context, tenant_id, title)',
-        'VALUES',
-        `  ('row-a', 'row-a', '', '${tenantAId}', 'Tenant A'),`,
-        `  ('row-b', 'row-b', '', '${tenantBId}', 'Tenant B')`,
-      ].join('\n'),
+      `INSERT INTO public.principal_rls_records
+        (id, slug, context, tenant_id, title)
+      VALUES
+        ($1, 'row-a', '', $2, 'Tenant A'),
+        ($3, 'row-b', '', $4, 'Tenant B')`,
+      rowAId,
+      tenantAId,
+      rowBId,
+      tenantBId,
     );
 
     await applyPostgresPermissionPolicies(options);
 
-    roleName = `smrt_principal_rls_${randomUUID().replaceAll('-', '_')}`;
-    await adminDb.query(
-      `CREATE ROLE "${roleName}" LOGIN PASSWORD 'postgres' NOSUPERUSER NOBYPASSRLS`,
-    );
-    await adminDb.query(`GRANT USAGE ON SCHEMA public TO "${roleName}"`);
-    await adminDb.query(
-      `GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.principal_rls_records TO "${roleName}"`,
-    );
+    const currentRole = rowsOf(
+      await adminDb.query(
+        'SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user',
+      ),
+    )[0];
+    if (currentRole?.rolsuper === true || currentRole?.rolbypassrls === true) {
+      roleName = `smrt_principal_rls_${randomUUID().replaceAll('-', '_')}`;
+      await adminDb.query(
+        `CREATE ROLE "${roleName}" LOGIN PASSWORD 'postgres' NOSUPERUSER NOBYPASSRLS`,
+      );
+      await adminDb.query(`GRANT USAGE ON SCHEMA public TO "${roleName}"`);
+      await adminDb.query(
+        `GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.principal_rls_records TO "${roleName}"`,
+      );
+    }
   });
 
   afterEach(async () => {
@@ -210,7 +225,7 @@ describePostgres('withPrincipalPermissionContext + Postgres RLS', () => {
     }
     const tx = await factory.beginTransaction();
     try {
-      await tx.query(`SET ROLE "${roleName}"`);
+      if (roleName) await tx.query(`SET ROLE "${roleName}"`);
       await tx.query("SELECT set_config('smrt.tenant_id', $1, true)", tenantId);
       await tx.query("SELECT set_config('smrt.user_id', $1, true)", userId);
       await tx.query("SELECT set_config('smrt.session_id', $1, true)", '');
@@ -239,9 +254,9 @@ describePostgres('withPrincipalPermissionContext + Postgres RLS', () => {
       const result = await tx.query(
         'SELECT id FROM public.principal_rls_records ORDER BY id',
       );
-      // row-a (tenant A) is visible; row-b (tenant B) is filtered — cross-tenant
-      // denied.
-      expect(rowsOf(result).map((row) => row.id)).toEqual(['row-a']);
+      // The tenant A row is visible; the tenant B row is filtered —
+      // cross-tenant denied.
+      expect(rowsOf(result).map((row) => row.id)).toEqual([rowAId]);
     });
   });
 
@@ -251,11 +266,11 @@ describePostgres('withPrincipalPermissionContext + Postgres RLS', () => {
     await underResolvedPrincipal(tenantAId, async (tx) => {
       await expect(
         tx.query(
-          [
-            'INSERT INTO public.principal_rls_records',
-            '  (id, slug, context, tenant_id, title)',
-            `VALUES ('row-c', 'row-c', '', '${tenantAId}', 'Tenant C')`,
-          ].join('\n'),
+          `INSERT INTO public.principal_rls_records
+            (id, slug, context, tenant_id, title)
+          VALUES ($1, 'row-c', '', $2, 'Tenant C')`,
+          randomUUID(),
+          tenantAId,
         ),
       ).rejects.toThrow(/row-level security/i);
     });
@@ -267,7 +282,7 @@ describePostgres('withPrincipalPermissionContext + Postgres RLS', () => {
       const result = await tx.query(
         'SELECT id FROM public.principal_rls_records ORDER BY id',
       );
-      expect(rowsOf(result).map((row) => row.id)).toEqual(['row-a']);
+      expect(rowsOf(result).map((row) => row.id)).toEqual([rowAId]);
     });
 
     // Revoke the read permission from the role at the data layer.

--- a/packages/users/vitest.config.ts
+++ b/packages/users/vitest.config.ts
@@ -27,11 +27,7 @@ export default defineConfig({
     fileParallelism: false,
     // Use single-threaded pool to avoid database contention
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/video/vitest.config.ts
+++ b/packages/video/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/packages/vitest/vitest.config.ts
+++ b/packages/vitest/vitest.config.ts
@@ -15,6 +15,14 @@ export default defineConfig({
     environment: 'node',
     testTimeout: 30000,
     hookTimeout: 30000,
+    // This package cannot consume smrtVitestPlugin's injected retry policy
+    // while testing the plugin itself. Match core and CLI so transient CI-only
+    // timing failures retry without changing local behavior.
+    retry: /^\d+$/.test(process.env.SMRT_VITEST_RETRY ?? '')
+      ? Number.parseInt(process.env.SMRT_VITEST_RETRY as string, 10)
+      : process.env.CI
+        ? 2
+        : 0,
     // Disable parallelism to avoid race conditions with process.chdir() in tests
     fileParallelism: false,
     coverage: {

--- a/packages/voice/vitest.config.ts
+++ b/packages/voice/vitest.config.ts
@@ -10,10 +10,6 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    singleFork: true,
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1985,6 +1985,9 @@ importers:
 
   packages/smrt-mobile-contract:
     devDependencies:
+      '@happyvertical/smrt-core':
+        specifier: workspace:*
+        version: link:../core
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,8 @@
     "biome.json"
   ],
   "globalPassThroughEnv": [
-    "PUBLISH_PACK_OUTPUT_DIR"
+    "PUBLISH_PACK_OUTPUT_DIR",
+    "TMPDIR"
   ],
   "tasks": {
     "generate": {


### PR DESCRIPTION
## What changed

- Recognizes PostgreSQL SQLSTATE 23505 through wrapped SDK database errors, with a regression test for the observed CI error shape.
- Keeps the users PostgreSQL lane focused on its two RLS suites, uses native UUID fixtures, and seeds FORCE-RLS fixtures through the least-privileged CI path.
- Allows cold core-shard setup enough time to complete while retaining bounded job timeouts.
- Declares the mobile-contract package dependency on core so filtered Turbo runs build the required closure.
- Applies the existing bounded CI retry policy to the smrt-vitest package itself.
- Migrates 41 package configs from removed Vitest 3 poolOptions to the Vitest 4 top-level singleFork option.
- Passes `TMPDIR` through Turbo and routes temporary SQLite files away from the container overlay; ARC runners can select the bounded tmpfs supplied by IAC PR #923.

## Why

The optimized workflows exposed real cold-cache and PostgreSQL correctness issues, then repeatedly stalled package jobs while the runners were mostly idle. The stalled runs emitted Vitest 4 warnings that poolOptions had been removed, so Vitest ignored the intended isolation setting.

Follow-up instrumentation found the larger runtime tail: SQLite-heavy tests were writing to the container overlay and failing with `SQLITE_IOERR_FSTAT`. Moving them to workspace ext4 removed some failures and cut analytics from a failed 11m14s shard to a successful 5m34s shard, but inventory still spent 5–10 seconds per schema-heavy test. IAC PR #923 now provides a capped test-only tmpfs; this PR consumes it without moving workspaces or package stores back into RAM.

PostgreSQL remains useful: its shadow lane caught wrapped conflict handling, UUID fixture, privilege, and FORCE-RLS problems that SQLite did not. The dedicated lane passed all four registered packages in 4m40s.

## Validation

- Wrapped-conflict red/green regression passes.
- Full core suite passed locally: 261 files and 3,083 tests, with normal gated skips.
- Dedicated PostgreSQL shadow run passed core, CLI, users, and analytics in 4m40s: https://github.com/happyvertical/smrt/actions/runs/29107102362
- Forced Turbo reproduction across six representative packages completed 23 tasks in 57s at concurrency two, with no removed-option warning.
- All 53 package Vitest configs load successfully.
- Inventory and analytics pass locally with a passed-through custom temp directory: 13 Turbo tasks in 41.8s.
- Live diagnostics confirmed `TMPDIR` reaches Vitest and SQLite database files move beneath the selected runner temp directory.
- Strict knowledge freshness, formatting, package DAG, workflow validation, and secret checks pass.

## Rollout dependency

Merge and reconcile IAC PR #923 before rerunning this PR. The next acceptance run must show runner `CI_TEST_TMPDIR=/home/runner/_test-tmp`, inventory/core free of `SQLITE_IOERR_FSTAT`, and no 10–15 second SQLite setup timeouts. Keep the node-runner and merge-queue repository flags disabled until that run passes.

No changeset: repository policy auto-generates release changesets on merge.