### PR TITLE
perf(vitest): reuse SQLite schema templates

### DIFF
--- a/packages/vitest/AGENTS.md
+++ b/packages/vitest/AGENTS.md
@@ -48,6 +48,13 @@ same `retry` policy inline in their own `vitest.config.ts`.
 
 **DB adapter auto-detection**: `DATABASE_URL` set → PostgreSQL; otherwise → SQLite temp files.
 
+For local file-backed SQLite, identical schemas are prepared once per Vitest
+process and cloned from an immutable schema-only template for later databases.
+The cache key is the full generated DDL, concurrent first callers share one
+build, and every test still receives its own database file and transaction.
+Existing non-empty database files are never replaced. PostgreSQL, DuckDB, JSON,
+remote libSQL, and in-memory SQLite retain their normal preparation paths.
+
 ```typescript
 let db, cleanup;
 beforeEach(async () => {
@@ -103,6 +110,7 @@ Pattern: render → assert role/name/state → drive with user-event → prove a
 
 - `src/index.ts` — Vite plugin, manifest generation, workspace aliases, all exports
 - `src/setup.ts` — globalThis isolation setup file
+- `src/sqlite-schema-template.ts` — process-local immutable SQLite schema templates
 - `src/svelte-setup.ts` — Svelte component-test setup (jest-dom, cleanup, dialog polyfill)
 - `src/svelte.ts` — component-test surface (Testing Library + a11y, one import)
 - `src/a11y.ts` — `expectNoA11yViolations` (axe-core)

--- a/packages/vitest/src/__tests__/test-db-schema-template.test.ts
+++ b/packages/vitest/src/__tests__/test-db-schema-template.test.ts
@@ -1,0 +1,123 @@
+import { randomUUID } from 'node:crypto';
+import { syncSchema } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createIsolatedTestDb } from '../test-db.js';
+
+vi.mock('@happyvertical/sql', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@happyvertical/sql')>();
+
+  return {
+    ...actual,
+    syncSchema: vi.fn(actual.syncSchema),
+  };
+});
+
+const originalDatabaseUrl = process.env.DATABASE_URL;
+const originalTestDbAdapter = process.env.TEST_DB_ADAPTER;
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+describe('SQLite isolated test database schema templates', () => {
+  beforeEach(() => {
+    delete process.env.DATABASE_URL;
+    process.env.TEST_DB_ADAPTER = 'sqlite';
+    vi.mocked(syncSchema).mockClear();
+  });
+
+  afterEach(() => {
+    restoreEnv('DATABASE_URL', originalDatabaseUrl);
+    restoreEnv('TEST_DB_ADAPTER', originalTestDbAdapter);
+  });
+
+  it('builds identical schema once while returning isolated databases', async () => {
+    const suffix = randomUUID().replaceAll('-', '');
+    const tableName = `schema_template_${suffix}`;
+    const schema = `CREATE TABLE "${tableName}" ("id" TEXT PRIMARY KEY, "value" TEXT);`;
+
+    const first = await createIsolatedTestDb({ schema, prefix: 'template-a' });
+    try {
+      await first.db.insert(tableName, { id: 'first', value: 'persisted' });
+      expect(await first.db.list(tableName, {})).toHaveLength(1);
+    } finally {
+      await first.cleanup();
+    }
+
+    const second = await createIsolatedTestDb({
+      schema,
+      prefix: 'template-b',
+    });
+    try {
+      expect(await second.db.list(tableName, {})).toHaveLength(0);
+    } finally {
+      await second.cleanup();
+    }
+
+    expect(syncSchema).toHaveBeenCalledTimes(1);
+  });
+
+  it('coordinates concurrent template creation for the same schema', async () => {
+    const suffix = randomUUID().replaceAll('-', '');
+    const tableName = `schema_template_concurrent_${suffix}`;
+    const schema = `CREATE TABLE "${tableName}" ("id" TEXT PRIMARY KEY, "value" TEXT);`;
+
+    const databases = await Promise.all(
+      Array.from({ length: 4 }, (_, index) =>
+        createIsolatedTestDb({
+          schema,
+          prefix: `template-concurrent-${index}`,
+        }),
+      ),
+    );
+
+    try {
+      expect(new Set(databases.map(({ config }) => config.url)).size).toBe(4);
+
+      await Promise.all(
+        databases.map(async ({ db }, index) => {
+          await db.insert(tableName, {
+            id: `database-${index}`,
+            value: `value-${index}`,
+          });
+          expect(await db.list(tableName, {})).toEqual([
+            expect.objectContaining({ id: `database-${index}` }),
+          ]);
+        }),
+      );
+    } finally {
+      await Promise.all(databases.map(({ cleanup }) => cleanup()));
+    }
+
+    expect(syncSchema).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses separate templates when schema content differs', async () => {
+    const suffix = randomUUID().replaceAll('-', '');
+    const firstTable = `schema_template_first_${suffix}`;
+    const secondTable = `schema_template_second_${suffix}`;
+
+    const first = await createIsolatedTestDb({
+      schema: `CREATE TABLE "${firstTable}" ("id" TEXT PRIMARY KEY);`,
+      prefix: 'template-first-schema',
+    });
+    const second = await createIsolatedTestDb({
+      schema: `CREATE TABLE "${secondTable}" ("id" TEXT PRIMARY KEY);`,
+      prefix: 'template-second-schema',
+    });
+
+    try {
+      expect(await first.db.list(firstTable, {})).toEqual([]);
+      expect(await second.db.list(secondTable, {})).toEqual([]);
+    } finally {
+      await Promise.all([first.cleanup(), second.cleanup()]);
+    }
+
+    expect(syncSchema).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/vitest/src/setup.ts
+++ b/packages/vitest/src/setup.ts
@@ -23,6 +23,10 @@ import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type { SchemaDefinition } from '@happyvertical/smrt-core';
 import { afterAll, beforeAll, vi } from 'vitest';
+import {
+  getDatabaseFromSqliteSchemaTemplate,
+  getLocalSqliteFilePath,
+} from './sqlite-schema-template.js';
 
 // Type alias for any to avoid conflicts with smrt-core's globalThis declarations
 type CacheState = unknown;
@@ -236,27 +240,45 @@ vi.mock('@happyvertical/sql', async () => {
         return actual.getDatabase(options);
       }
 
-      const db = await actual.getDatabase(options);
+      const canUseSqliteSchemaTemplate = Boolean(
+        options &&
+          typeof options === 'object' &&
+          !('query' in options) &&
+          getLocalSqliteFilePath(options as { type?: string; url?: string }),
+      );
+      let db: Awaited<ReturnType<typeof actual.getDatabase>> | undefined =
+        canUseSqliteSchemaTemplate
+          ? undefined
+          : await actual.getDatabase(options);
       let schemaSqlBatches: string[] = [];
 
       try {
         const smrtCore = await loadSmrtCoreModule();
-        schemaSqlBatches = buildSchemaSqlBatches(
-          smrtCore,
-          db as { url?: string; exportTable?: unknown },
-          options,
-        );
+        if (canUseSqliteSchemaTemplate) {
+          const dbConfig = options as { url?: string };
+          schemaSqlBatches = buildSchemaSqlBatches(
+            smrtCore,
+            { url: dbConfig.url },
+            options,
+          );
+        } else {
+          db ??= await actual.getDatabase(options);
+          schemaSqlBatches = buildSchemaSqlBatches(
+            smrtCore,
+            db as { url?: string; exportTable?: unknown },
+            options,
+          );
+        }
       } catch {
-        return db;
+        return db ?? actual.getDatabase(options);
       }
 
       const schemaSql = schemaSqlBatches.filter(Boolean).join('\n-- smrt --\n');
       if (!schemaSql) {
-        return db;
+        return db ?? actual.getDatabase(options);
       }
 
-      const dbObject = db as object;
-      if (preparedSchemasByDb.get(dbObject) === schemaSql) {
+      if (db && preparedSchemasByDb.get(db as object) === schemaSql) {
         return db;
       }
 
@@ -265,17 +287,38 @@ vi.mock('@happyvertical/sql', async () => {
         preparationKey &&
         preparedSchemasByConfig.get(preparationKey) === schemaSql
       ) {
-        preparedSchemasByDb.set(dbObject, schemaSql);
+        db ??= await actual.getDatabase(options);
+        preparedSchemasByDb.set(db as object, schemaSql);
         return db;
       }
 
-      for (const schemaBatch of schemaSqlBatches) {
-        if (!schemaBatch) {
-          continue;
+      const prepareSchema = async (
+        database: Awaited<ReturnType<typeof actual.getDatabase>>,
+      ): Promise<void> => {
+        for (const schemaBatch of schemaSqlBatches) {
+          if (!schemaBatch) {
+            continue;
+          }
+          await actual.syncSchema({ db: database, schema: schemaBatch });
         }
-        await actual.syncSchema({ db, schema: schemaBatch });
+      };
+
+      if (canUseSqliteSchemaTemplate) {
+        db = await getDatabaseFromSqliteSchemaTemplate({
+          cacheKey: `automatic-schema\0${schemaSql}`,
+          databaseOptions: options as Record<string, unknown> & {
+            url?: string;
+          },
+          getDatabase: (databaseOptions) =>
+            actual.getDatabase(databaseOptions as VitestDatabaseOptions),
+          prepare: prepareSchema,
+        });
+      } else {
+        db ??= await actual.getDatabase(options);
+        await prepareSchema(db);
       }
-      preparedSchemasByDb.set(dbObject, schemaSql);
+
+      preparedSchemasByDb.set(db as object, schemaSql);
       if (preparationKey) {
         preparedSchemasByConfig.set(preparationKey, schemaSql);
       }

--- a/packages/vitest/src/sqlite-schema-template.ts
+++ b/packages/vitest/src/sqlite-schema-template.ts
@@ -1,0 +1,195 @@
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface SqliteSchemaTemplateState {
+  directory: string;
+  templates: Map<string, Promise<string>>;
+}
+
+interface SqliteSchemaTemplateDatabase {
+  query: (sql: string, ...values: unknown[]) => Promise<unknown>;
+  close?: () => Promise<void>;
+}
+
+interface SqliteSchemaTemplateOptions<
+  Database extends SqliteSchemaTemplateDatabase,
+> {
+  cacheKey: string;
+  databaseOptions: Record<string, unknown> & { url?: string };
+  getDatabase: (
+    options: Record<string, unknown> & { url?: string },
+  ) => Promise<Database>;
+  prepare: (database: Database) => Promise<void>;
+}
+
+type GlobalWithSqliteSchemaTemplates = typeof globalThis & {
+  __smrtVitestSqliteSchemaTemplates?: SqliteSchemaTemplateState;
+};
+
+function removeSqliteFiles(path: string): void {
+  rmSync(path, { force: true });
+  rmSync(`${path}-wal`, { force: true });
+  rmSync(`${path}-shm`, { force: true });
+}
+
+function getSqliteSchemaTemplateState(): SqliteSchemaTemplateState {
+  const globalState = globalThis as GlobalWithSqliteSchemaTemplates;
+  const existing = globalState.__smrtVitestSqliteSchemaTemplates;
+  if (existing) {
+    return existing;
+  }
+
+  const directory = join(
+    tmpdir(),
+    `smrt-vitest-schema-templates-${process.pid}-${randomUUID().slice(0, 8)}`,
+  );
+  mkdirSync(directory, { recursive: true });
+
+  const state: SqliteSchemaTemplateState = {
+    directory,
+    templates: new Map(),
+  };
+  globalState.__smrtVitestSqliteSchemaTemplates = state;
+
+  process.once('exit', () => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  return state;
+}
+
+/** Resolve a local SQLite URL to the file copied from a schema template. */
+export function getLocalSqliteFilePath(
+  options: { type?: string; url?: string } | undefined,
+): string | undefined {
+  if (!options?.url || (options.type && options.type !== 'sqlite')) {
+    return undefined;
+  }
+
+  const { url } = options;
+  if (
+    url === ':memory:' ||
+    url === 'memory' ||
+    url === 'file::memory:' ||
+    url.startsWith('http://') ||
+    url.startsWith('https://') ||
+    url.startsWith('libsql://')
+  ) {
+    return undefined;
+  }
+
+  if (url.startsWith('file:')) {
+    try {
+      return fileURLToPath(url);
+    } catch {
+      return undefined;
+    }
+  }
+
+  return isAbsolute(url) ? url : resolve(url);
+}
+
+/**
+ * Open a fresh local SQLite database using an immutable schema-only template.
+ *
+ * The first caller prepares its own target database and snapshots it with
+ * `VACUUM INTO`. Concurrent and later callers copy that snapshot before
+ * opening their independent connection. Existing database files are never
+ * replaced; they retain the normal additive schema-preparation path.
+ */
+export async function getDatabaseFromSqliteSchemaTemplate<
+  Database extends SqliteSchemaTemplateDatabase,
+>({
+  cacheKey,
+  databaseOptions,
+  getDatabase,
+  prepare,
+}: SqliteSchemaTemplateOptions<Database>): Promise<Database> {
+  const targetPath = getLocalSqliteFilePath(databaseOptions);
+  if (!targetPath) {
+    const database = await getDatabase(databaseOptions);
+    await prepare(database);
+    return database;
+  }
+
+  // Never replace a fixture or a database already populated by this test.
+  if (existsSync(targetPath) && statSync(targetPath).size > 0) {
+    const database = await getDatabase(databaseOptions);
+    await prepare(database);
+    return database;
+  }
+
+  const state = getSqliteSchemaTemplateState();
+  const templateHash = createHash('sha256')
+    .update('smrt-vitest-sqlite-template-v1\0')
+    .update(cacheKey)
+    .digest('hex');
+  const templatePath = join(state.directory, `${templateHash}.db`);
+  let templatePromise = state.templates.get(templateHash);
+
+  if (templatePromise || existsSync(templatePath)) {
+    if (!templatePromise) {
+      templatePromise = Promise.resolve(templatePath);
+      state.templates.set(templateHash, templatePromise);
+    }
+    await templatePromise;
+
+    try {
+      copyFileSync(templatePath, targetPath);
+      return await getDatabase(databaseOptions);
+    } catch (error) {
+      removeSqliteFiles(targetPath);
+      throw error;
+    }
+  }
+
+  let resolveTemplate!: (path: string) => void;
+  let rejectTemplate!: (error: unknown) => void;
+  templatePromise = new Promise<string>((resolvePromise, rejectPromise) => {
+    resolveTemplate = resolvePromise;
+    rejectTemplate = rejectPromise;
+  });
+  // The builder rethrows failures itself; this prevents an unhandled rejection
+  // when no concurrent caller is awaiting the same schema.
+  void templatePromise.catch(() => {});
+  state.templates.set(templateHash, templatePromise);
+
+  const snapshotPath = join(state.directory, `${randomUUID()}.snapshot.db`);
+  let database: Database | undefined;
+
+  try {
+    database = await getDatabase(databaseOptions);
+    await prepare(database);
+
+    // Public SQL API only: VACUUM INTO captures committed schema from a live
+    // SQLite/WAL connection without reaching into the adapter's raw client.
+    await database.query('VACUUM INTO ?', snapshotPath);
+    renameSync(snapshotPath, templatePath);
+    resolveTemplate(templatePath);
+    return database;
+  } catch (error) {
+    rejectTemplate(error);
+    if (state.templates.get(templateHash) === templatePromise) {
+      state.templates.delete(templateHash);
+    }
+    try {
+      await database?.close?.();
+    } catch {
+      // Best effort: older SQLite adapters do not expose close().
+    }
+    removeSqliteFiles(targetPath);
+    throw error;
+  } finally {
+    removeSqliteFiles(snapshotPath);
+  }
+}

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -42,6 +42,7 @@ import { join } from 'node:path';
 // `createIsolatedTestDbFromManifest({ includeObjects: [...] })` were still
 // misclassified as table-bearing and lost their FK/junction columns.
 import { isSmrtCollectionExtendsName } from '@happyvertical/smrt-core';
+import { getDatabaseFromSqliteSchemaTemplate } from './sqlite-schema-template.js';
 import type {
   DatabaseInterfaceWithTransaction,
   TransactionHandle,
@@ -52,6 +53,12 @@ type VitestDatabaseConnectionOptions = Parameters<
 >[0] & {
   __smrtSkipVitestSchemaPreparation?: boolean;
 };
+
+function removeSqliteFiles(url: string): void {
+  rmSync(url, { force: true });
+  rmSync(`${url}-wal`, { force: true });
+  rmSync(`${url}-shm`, { force: true });
+}
 
 // ============================================================================
 // Manifest Types (minimal to avoid circular dependency with smrt-core)
@@ -281,10 +288,7 @@ export async function createTestDb(prefix = 'smrt-test'): Promise<{
       // Small delay to allow any pending writes
       await new Promise((resolve) => setTimeout(resolve, 50));
       try {
-        rmSync(config.url, { force: true });
-        // Also remove -wal and -shm files if they exist
-        rmSync(`${config.url}-wal`, { force: true });
-        rmSync(`${config.url}-shm`, { force: true });
+        removeSqliteFiles(config.url);
       } catch {
         // Ignore cleanup errors
       }
@@ -402,6 +406,10 @@ export interface IsolatedTestDbResult {
  * receive their own temp database file (SQLite) or an independent
  * transaction (PostgreSQL).
  *
+ * File-backed SQLite schemas are prepared once per process, snapshotted, and
+ * copied into each later database. The template contains schema only; test
+ * data remains isolated in the per-test transaction and database file.
+ *
  * Requires `@happyvertical/sql` with `beginTransaction()` support
  * (SDK PR #722).  Throws if the adapter does not implement it.
  *
@@ -459,13 +467,27 @@ export async function createIsolatedTestDb(
 
   // Create the base database connection
   // Cast to extended interface that includes beginTransaction (from SDK #722)
-  const baseDb = (await getDatabase({
-    ...config,
-    __smrtSkipVitestSchemaPreparation: true,
-  } as VitestDatabaseConnectionOptions)) as DatabaseInterfaceWithTransaction;
+  const baseDb =
+    schema && config.type === 'sqlite' && config.url !== ':memory:'
+      ? await getDatabaseFromSqliteSchemaTemplate({
+          cacheKey: `isolated-test-db\0${schema}`,
+          databaseOptions: {
+            ...config,
+            __smrtSkipVitestSchemaPreparation: true,
+          },
+          getDatabase: async (databaseOptions) =>
+            (await getDatabase(
+              databaseOptions as VitestDatabaseConnectionOptions,
+            )) as DatabaseInterfaceWithTransaction,
+          prepare: (database) => syncSchema({ db: database, schema }),
+        })
+      : ((await getDatabase({
+          ...config,
+          __smrtSkipVitestSchemaPreparation: true,
+        } as VitestDatabaseConnectionOptions)) as DatabaseInterfaceWithTransaction);
 
   // Sync schema if provided (must be done before transaction for DDL)
-  if (schema) {
+  if (schema && config.type !== 'sqlite') {
     await syncSchema({ db: baseDb, schema });
   }
 
@@ -515,9 +537,7 @@ export async function createIsolatedTestDb(
     ) {
       await new Promise((resolve) => setTimeout(resolve, 50));
       try {
-        rmSync(config.url, { force: true });
-        rmSync(`${config.url}-wal`, { force: true });
-        rmSync(`${config.url}-shm`, { force: true });
+        removeSqliteFiles(config.url);
       } catch {
         // Ignore cleanup errors
       }


### PR DESCRIPTION
## Summary

- prepare each unique local file-backed SQLite schema once per Vitest process
- snapshot the prepared database with `VACUUM INTO` and clone that immutable template for subsequent isolated databases
- share concurrent first-time builds while preserving a distinct database file and transaction for every test
- leave PostgreSQL, DuckDB, JSON, remote libSQL, in-memory SQLite, and existing non-empty files on their prior preparation paths
- document the behavior and add sequential, concurrent, isolation, and distinct-schema regression coverage

## Why

Package tests repeatedly ran the same SQLite DDL for every fresh test database. A representative profiles test created 12 databases and executed 22 schema batches for each one, producing 264 `syncSchema` starts.

With this change it executes those 22 batches once and clones the result for the remaining databases: **264 → 22 syncs (91.7% fewer)**. A synthetic core-sized schema (351 tables, 1,053 indexes, six databases) improved from **3,185 ms to 915 ms (3.48×)**.

During review, the fast path was narrowed explicitly to local SQLite after an initialization-order regression exposed that JSON adapters must retain their existing sequence.

## Validation

- `@happyvertical/smrt-vitest`: 45/45 tests, typecheck, build
- full `@happyvertical/smrt-core`: 3,083 passed, 30 skipped
- JSON adapter regression set: 16/16
- `@happyvertical/smrt-profiles`: 168/168; measured test 12/12 with 22 schema syncs
- `@happyvertical/smrt-users`: 341 passed, 9 skipped
- `@happyvertical/smrt-analytics`: 293 passed, 31 skipped
- repository-wide Biome, knowledge freshness, package DAG, workflow validation, and all pre-push checks
