### PR TITLE
fix(release): resolve workspace protocols before publishing

### DIFF
--- a/packages/template-sveltekit/AGENTS.md
+++ b/packages/template-sveltekit/AGENTS.md
@@ -14,7 +14,7 @@ It is the ground-up alternative to `smrt-saas-starter`.
 ## Current generated-project contract
 
 - Node `>=24.18.0`; pnpm `10.34.4` via `packageManager` and `engines`.
-- Directly used `@happyvertical/smrt-*` packages are pinned to `0.38.25`.
+- Directly used `@happyvertical/smrt-*` packages share one current release range.
 - `@happyvertical/smrt-cli` is a direct dev dependency because scripts/docs use
   its binary. `@happyvertical/smrt-web` stays opt-in until a page imports it.
 - `smrtConsumer()` explicitly consumes profiles, tenancy, and users manifests;

--- a/packages/template-sveltekit/__tests__/templateMetadata.test.ts
+++ b/packages/template-sveltekit/__tests__/templateMetadata.test.ts
@@ -20,22 +20,27 @@ const itemSource = readFileSync(
 );
 
 describe('generated project metadata', () => {
-  it('pins every directly used s-m-r-t package to 0.38.25', () => {
+  it('keeps every directly used s-m-r-t package on one release line', () => {
     const smrtDependencies = {
       ...packageJson.dependencies,
       ...packageJson.devDependencies,
     };
-    for (const [name, version] of Object.entries(smrtDependencies)) {
-      if (name.startsWith('@happyvertical/smrt-')) {
-        expect(version, name).toBe('0.38.25');
-      }
+    const smrtVersions = Object.entries(smrtDependencies).filter(([name]) =>
+      name.startsWith('@happyvertical/smrt-'),
+    );
+    const releaseRange = smrtVersions[0]?.[1];
+
+    expect(releaseRange).toMatch(/^\^0\.\d+\.\d+$/);
+    for (const [name, version] of smrtVersions) {
+      expect(version, name).toBe(releaseRange);
     }
   });
 
   it('ships the CLI directly and keeps browser data opt-in', () => {
-    expect(packageJson.devDependencies['@happyvertical/smrt-cli']).toBe(
-      '0.38.25',
+    expect(packageJson.devDependencies).toHaveProperty(
+      '@happyvertical/smrt-cli',
     );
+    expect(packageJson.dependencies['@happyvertical/smrt-cli']).toBeUndefined();
     expect(packageJson.dependencies['@happyvertical/smrt-web']).toBeUndefined();
   });
 

--- a/scripts/publish-artifacts-lib.mjs
+++ b/scripts/publish-artifacts-lib.mjs
@@ -2,6 +2,30 @@ import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
+const DEPENDENCY_SECTIONS = [
+  'dependencies',
+  'optionalDependencies',
+  'peerDependencies',
+  'devDependencies',
+];
+
+export function findUnsupportedDependencyProtocols(packageJson) {
+  const unsupported = [];
+
+  for (const section of DEPENDENCY_SECTIONS) {
+    for (const [name, specifier] of Object.entries(packageJson[section] ?? {})) {
+      if (
+        typeof specifier === 'string' &&
+        (specifier.startsWith('catalog:') || specifier.startsWith('workspace:'))
+      ) {
+        unsupported.push(`${section}.${name}=${specifier}`);
+      }
+    }
+  }
+
+  return unsupported;
+}
+
 function discoverExpectedPackages(repoRoot) {
   const config = JSON.parse(
     readFileSync(join(repoRoot, '.changeset/config.json'), 'utf8'),

--- a/scripts/publish-artifacts-lib.test.mjs
+++ b/scripts/publish-artifacts-lib.test.mjs
@@ -82,14 +82,22 @@ test('finds unresolved workspace and catalog dependency protocols', () => {
         '@happyvertical/smrt-core': 'workspace:*',
         zod: '^4.0.0',
       },
+      optionalDependencies: {
+        sharp: 'catalog:sharp',
+      },
       peerDependencies: {
         svelte: 'workspace:^',
+      },
+      devDependencies: {
+        vitest: 'catalog:',
       },
     }),
     [
       'dependencies.@happyvertical/jobs=catalog:',
       'dependencies.@happyvertical/smrt-core=workspace:*',
+      'optionalDependencies.sharp=catalog:sharp',
       'peerDependencies.svelte=workspace:^',
+      'devDependencies.vitest=catalog:',
     ],
   );
 });

--- a/scripts/publish-artifacts-lib.test.mjs
+++ b/scripts/publish-artifacts-lib.test.mjs
@@ -9,7 +9,10 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
-import { verifyPublishArtifacts } from './publish-artifacts-lib.mjs';
+import {
+  findUnsupportedDependencyProtocols,
+  verifyPublishArtifacts,
+} from './publish-artifacts-lib.mjs';
 
 function fixture() {
   const root = mkdtempSync(join(tmpdir(), 'smrt-publish-artifacts-'));
@@ -69,4 +72,36 @@ test('rejects a tarball changed after validation', () => {
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
+});
+
+test('finds unresolved workspace and catalog dependency protocols', () => {
+  assert.deepEqual(
+    findUnsupportedDependencyProtocols({
+      dependencies: {
+        '@happyvertical/jobs': 'catalog:',
+        '@happyvertical/smrt-core': 'workspace:*',
+        zod: '^4.0.0',
+      },
+      peerDependencies: {
+        svelte: 'workspace:^',
+      },
+    }),
+    [
+      'dependencies.@happyvertical/jobs=catalog:',
+      'dependencies.@happyvertical/smrt-core=workspace:*',
+      'peerDependencies.svelte=workspace:^',
+    ],
+  );
+});
+
+test('accepts registry-compatible dependency ranges', () => {
+  assert.deepEqual(
+    findUnsupportedDependencyProtocols({
+      dependencies: {
+        '@happyvertical/jobs': '^0.78.0',
+        '@happyvertical/smrt-core': '0.39.1',
+      },
+    }),
+    [],
+  );
 });

--- a/scripts/validate-publish-packages.js
+++ b/scripts/validate-publish-packages.js
@@ -10,6 +10,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { findUnsupportedDependencyProtocols } from './publish-artifacts-lib.mjs';
 
 function fail(message) {
   console.error(`❌ ${message}`);
@@ -200,7 +201,7 @@ for (const pkg of shardPackages) {
   const before = new Set(
     readdirSync(outputDir).filter((entry) => entry.endsWith('.tgz')),
   );
-  const result = spawnSync('npm', ['pack', '--pack-destination', outputDir], {
+  const result = spawnSync('pnpm', ['pack', '--pack-destination', outputDir], {
     cwd: pkg.dir,
     stdio: 'inherit',
     env: process.env,
@@ -224,6 +225,29 @@ for (const pkg of shardPackages) {
   }
   const filename = created[0];
   const tarballPath = join(outputDir, filename);
+
+  const packedManifestResult = spawnSync(
+    'tar',
+    ['-xOf', tarballPath, 'package/package.json'],
+    {
+      encoding: 'utf8',
+      env: process.env,
+    },
+  );
+  if (packedManifestResult.error || packedManifestResult.status !== 0) {
+    fail(`Failed to inspect packed manifest for ${pkg.name}`);
+  }
+
+  const packedManifest = JSON.parse(packedManifestResult.stdout);
+  const unsupportedProtocols =
+    findUnsupportedDependencyProtocols(packedManifest);
+  if (unsupportedProtocols.length > 0) {
+    fail(
+      `Packed manifest for ${pkg.name} contains unresolved dependency protocols:\n${unsupportedProtocols
+        .map((entry) => `- ${entry}`)
+        .join('\n')}`,
+    );
+  }
 
   const verifyResult = spawnSync(
     process.execPath,

--- a/scripts/validate-publish-packages.js
+++ b/scripts/validate-publish-packages.js
@@ -208,11 +208,11 @@ for (const pkg of shardPackages) {
   });
 
   if (result.error) {
-    fail(`Failed to run npm pack for ${pkg.name}: ${result.error.message}`);
+    fail(`Failed to run pnpm pack for ${pkg.name}: ${result.error.message}`);
   }
 
   if (result.status !== 0) {
-    fail(`npm pack failed for ${pkg.name}`);
+    fail(`pnpm pack failed for ${pkg.name}`);
   }
 
   const created = readdirSync(outputDir).filter(
@@ -235,7 +235,18 @@ for (const pkg of shardPackages) {
     },
   );
   if (packedManifestResult.error || packedManifestResult.status !== 0) {
-    fail(`Failed to inspect packed manifest for ${pkg.name}`);
+    const details = [
+      `status=${packedManifestResult.status ?? 'unknown'}`,
+      packedManifestResult.error
+        ? `error=${packedManifestResult.error.message}`
+        : '',
+      packedManifestResult.stderr?.trim()
+        ? `stderr=${packedManifestResult.stderr.trim()}`
+        : '',
+    ]
+      .filter(Boolean)
+      .join('; ');
+    fail(`Failed to inspect packed manifest for ${pkg.name}: ${details}`);
   }
 
   const packedManifest = JSON.parse(packedManifestResult.stdout);


### PR DESCRIPTION
## Summary

- create release artifacts with `pnpm pack` so pnpm rewrites `catalog:` and `workspace:` dependency protocols
- reject any packed manifest that still contains an unresolved workspace-only protocol
- add regression coverage for protocol validation

## Root cause

The 0.39.0 artifact pipeline switched from pnpm-aware packaging to `npm pack`, so packages such as `@happyvertical/smrt-jobs` were published with literal `catalog:` and `workspace:*` dependency specifiers and cannot be installed by downstream consumers.

## Validation

- `pnpm test:ci-scripts` (8 passed)
- real `pnpm@11.11.0 pack` of `@happyvertical/smrt-jobs` rewrites all SMRT/catalog dependencies to registry-compatible versions
- pre-commit and pre-push validation passed