### PR TITLE
feat(sales): add CRM tracer package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -44,6 +44,7 @@
       "@happyvertical/smrt-projects",
       "@happyvertical/smrt-properties",
       "@happyvertical/smrt-reports",
+      "@happyvertical/smrt-sales",
       "@happyvertical/smrt-secrets",
       "@happyvertical/smrt-sites",
       "@happyvertical/smrt-subscriptions",

--- a/packages/sales/AGENTS.md
+++ b/packages/sales/AGENTS.md
@@ -1,0 +1,13 @@
+# @happyvertical/smrt-sales
+
+Tenant-scoped CRM primitives for lead acquisition, ownership, qualification, configurable pipelines, opportunities, activities, and merge/conversion audit trails.
+
+## Validation
+
+```bash
+pnpm --filter @happyvertical/smrt-sales test
+pnpm --filter @happyvertical/smrt-sales typecheck
+pnpm --filter @happyvertical/smrt-sales build
+```
+
+Lead acquisition and activity history are append-only. Lead conversion is idempotent by `leadId`; referral and commission policy belongs outside this package.

--- a/packages/sales/CLAUDE.md
+++ b/packages/sales/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/sales/ambient.d.ts
+++ b/packages/sales/ambient.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="svelte" />

--- a/packages/sales/package.json
+++ b/packages/sales/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@happyvertical/smrt-sales",
+  "version": "0.39.0",
+  "description": "Tenant-scoped CRM leads, opportunities, pipelines, activities, and reusable sales UI for SMRT",
+  "type": "module",
+  "smrtRawPrimitives": "strict",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist", "AGENTS.md", "CLAUDE.md"],
+  "exports": {
+    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
+    "./manifest": "./dist/manifest.json",
+    "./manifest.json": "./dist/manifest.json",
+    "./svelte": { "types": "./dist/svelte/index.d.ts", "svelte": "./dist/svelte/index.js", "import": "./dist/svelte/index.js" }
+  },
+  "scripts": {
+    "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
+    "build:watch": "vite build --mode library --watch",
+    "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
+    "clean": "rm -rf dist",
+    "prepack": "node ../../scripts/prepack-package.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
+  },
+  "dependencies": { "@happyvertical/smrt-core": "workspace:*", "@happyvertical/smrt-tenancy": "workspace:*", "@happyvertical/smrt-types": "workspace:*", "@happyvertical/smrt-ui": "workspace:*" },
+  "peerDependencies": { "svelte": "^5.56.4" },
+  "peerDependenciesMeta": { "svelte": { "optional": true } },
+  "devDependencies": {
+    "@happyvertical/smrt-vitest": "workspace:*", "@sveltejs/package": "^2.5.8", "@types/node": "24.13.2",
+    "svelte": "^5.56.4", "svelte-check": "^4.7.1", "typescript": "^5.9.3", "vite": "^8.1.3", "vitest": "^4.1.9"
+  },
+  "keywords": ["smrt", "sales", "crm", "pipeline", "multi-tenant"],
+  "author": "HappyVertical", "license": "MIT",
+  "publishConfig": { "registry": "https://registry.npmjs.org", "access": "public" },
+  "repository": { "type": "git", "url": "https://github.com/happyvertical/smrt.git", "directory": "packages/sales" }
+}

--- a/packages/sales/src/__smrt-register__.ts
+++ b/packages/sales/src/__smrt-register__.ts
@@ -1,0 +1,5 @@
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+
+ObjectRegistry.registerPackageManifest(
+  new URL('./manifest.json', import.meta.url),
+);

--- a/packages/sales/src/__tests__/sales-manifest.test.ts
+++ b/packages/sales/src/__tests__/sales-manifest.test.ts
@@ -1,0 +1,47 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+interface ManifestObject {
+  decoratorConfig?: {
+    api?: { writable?: string[] };
+    mcp?: boolean | { include?: string[] };
+  };
+}
+
+interface SalesManifest {
+  objects: Record<string, ManifestObject>;
+}
+
+async function salesManifest(): Promise<SalesManifest> {
+  const raw = await readFile(
+    new URL('../../dist/manifest.json', import.meta.url),
+    'utf8',
+  );
+  return JSON.parse(raw) as SalesManifest;
+}
+
+function objectByName(manifest: SalesManifest, name: string): ManifestObject {
+  const entry = Object.entries(manifest.objects).find(([key]) =>
+    key.endsWith(`:${name}`),
+  );
+  if (!entry) {
+    throw new Error(`Manifest object '${name}' not found`);
+  }
+  return entry[1];
+}
+
+describe('generated sales manifest mutation policy', () => {
+  it('keeps SalesActivity MCP operations append-only', async () => {
+    const activity = objectByName(await salesManifest(), 'SalesActivity');
+    expect(activity.decoratorConfig?.mcp).toEqual({
+      include: ['list', 'get', 'create'],
+    });
+  });
+
+  it('does not allow generated Lead writes to replace acquisition history', async () => {
+    const lead = objectByName(await salesManifest(), 'Lead');
+    const writable = lead.decoratorConfig?.api?.writable;
+    expect(writable).toBeDefined();
+    expect(writable).not.toContain('acquisitionHistory');
+  });
+});

--- a/packages/sales/src/__tests__/sales-manifest.test.ts
+++ b/packages/sales/src/__tests__/sales-manifest.test.ts
@@ -31,9 +31,12 @@ function objectByName(manifest: SalesManifest, name: string): ManifestObject {
 }
 
 describe('generated sales manifest mutation policy', () => {
-  it('keeps SalesActivity MCP operations append-only', async () => {
-    const activity = objectByName(await salesManifest(), 'SalesActivity');
-    expect(activity.decoratorConfig?.mcp).toEqual({
+  it.each([
+    'SalesActivity',
+    'LeadMerge',
+  ])('keeps %s MCP operations append-only', async (objectName) => {
+    const object = objectByName(await salesManifest(), objectName);
+    expect(object.decoratorConfig?.mcp).toEqual({
       include: ['list', 'get', 'create'],
     });
   });

--- a/packages/sales/src/__tests__/sales-models.test.ts
+++ b/packages/sales/src/__tests__/sales-models.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  Lead,
+  Opportunity,
+  PipelineStage,
+  SalesActivity,
+} from '../models/index.js';
+
+describe('sales models', () => {
+  it('preserves append-only acquisition history and returns defensive copies', () => {
+    const lead = new Lead({ tenantId: 'tenant-1', name: 'Ada' });
+    lead.recordAcquisition({
+      source: 'website',
+      occurredAt: '2026-07-01T00:00:00Z',
+      campaign: 'launch',
+    });
+    lead.recordAcquisition({
+      source: 'conference',
+      occurredAt: '2026-07-02T00:00:00Z',
+    });
+    const first = lead.getAcquisitionHistory();
+    const firstEvent = first[0];
+    expect(firstEvent).toBeDefined();
+    if (!firstEvent) throw new Error('Expected an acquisition event');
+    firstEvent.source = 'changed';
+    expect(lead.getAcquisitionHistory().map((event) => event.source)).toEqual([
+      'website',
+      'conference',
+    ]);
+  });
+
+  it('moves opportunities only within their configured pipeline and applies outcomes', () => {
+    const opportunity = new Opportunity({
+      tenantId: 'tenant-1',
+      pipelineId: 'pipeline-1',
+      stageId: 'new',
+      expectedValue: 1250.0,
+    });
+    const won = new PipelineStage({
+      tenantId: 'tenant-1',
+      pipelineId: 'pipeline-1',
+      key: 'closed_won',
+      terminal: true,
+      outcome: 'won',
+    });
+    won.id = 'won';
+    opportunity.moveTo(won);
+    expect(opportunity.outcome).toBe('won');
+    expect(opportunity.closedAt).toBeInstanceOf(Date);
+    const foreign = new PipelineStage({
+      tenantId: 'tenant-1',
+      pipelineId: 'pipeline-2',
+    });
+    foreign.id = 'foreign';
+    expect(() => opportunity.moveTo(foreign)).toThrow('different pipeline');
+  });
+
+  it('parses activity details without surfacing corrupt JSON', () => {
+    const activity = new SalesActivity({ details: '{broken' });
+    expect(activity.getDetails()).toEqual({});
+    activity.setDetails({ from: 'new', to: 'qualified' });
+    expect(activity.getDetails()).toEqual({ from: 'new', to: 'qualified' });
+  });
+});

--- a/packages/sales/src/__tests__/sales-models.test.ts
+++ b/packages/sales/src/__tests__/sales-models.test.ts
@@ -61,4 +61,16 @@ describe('sales models', () => {
     activity.setDetails({ from: 'new', to: 'qualified' });
     expect(activity.getDetails()).toEqual({ from: 'new', to: 'qualified' });
   });
+
+  it('rejects qualification after conversion or merge and normalizes merge ids', () => {
+    const converted = new Lead({ tenantId: 'tenant-1', status: 'converted' });
+    expect(() => converted.qualify()).toThrow(
+      'A converted lead cannot be qualified',
+    );
+
+    const merged = new Lead({ tenantId: 'tenant-1' });
+    merged.markMerged('  target-lead  ');
+    expect(merged.mergedIntoLeadId).toBe('target-lead');
+    expect(() => merged.qualify()).toThrow('A merged lead cannot be qualified');
+  });
 });

--- a/packages/sales/src/__tests__/sales-service.test.ts
+++ b/packages/sales/src/__tests__/sales-service.test.ts
@@ -155,6 +155,7 @@ describe('SalesService', () => {
       leadId: lead.id,
       pipelineId: 'pipeline-1',
       stageKey: 'qualified',
+      ownerId: 'rep-new',
     });
 
     expect(result).toEqual({
@@ -168,7 +169,10 @@ describe('SalesService', () => {
       expect.objectContaining({ _insertOnly: true }),
     );
     expect(lead.status).toBe('converted');
+    expect(lead.ownerId).toBe('rep-new');
     expect(lead.save).toHaveBeenCalledOnce();
+    expect(winner.ownerId).toBe('rep-new');
+    expect(winner.save).toHaveBeenCalledOnce();
     expect(createActivity).not.toHaveBeenCalled();
   });
 
@@ -188,6 +192,7 @@ describe('SalesService', () => {
       stageId: 'stage-qualified',
     });
     opportunity.id = 'opportunity-1';
+    opportunity.save = vi.fn(async () => opportunity);
     const stage = new PipelineStage({
       tenantId: 'tenant-1',
       pipelineId: 'pipeline-1',
@@ -214,6 +219,8 @@ describe('SalesService', () => {
     expect(lead.status).toBe('converted');
     expect(lead.ownerId).toBe('rep-new');
     expect(lead.save).toHaveBeenCalledOnce();
+    expect(opportunity.ownerId).toBe('rep-new');
+    expect(opportunity.save).toHaveBeenCalledOnce();
     expect(createActivity).not.toHaveBeenCalled();
   });
 

--- a/packages/sales/src/__tests__/sales-service.test.ts
+++ b/packages/sales/src/__tests__/sales-service.test.ts
@@ -164,8 +164,38 @@ describe('SalesService', () => {
       stageKey: 'qualified',
     });
     expect(getByLeadId).toHaveBeenCalledTimes(2);
+    expect(stores.opportunities.create).toHaveBeenCalledWith(
+      expect.objectContaining({ _insertOnly: true }),
+    );
     expect(lead.save).not.toHaveBeenCalled();
     expect(createActivity).not.toHaveBeenCalled();
+  });
+
+  it('requires an explicit stage when moving an opportunity', async () => {
+    const opportunity = new Opportunity({
+      tenantId: 'tenant-1',
+      pipelineId: 'pipeline-1',
+      stageId: 'stage-new',
+    });
+    opportunity.id = 'opportunity-1';
+    const stores = {
+      leads: {},
+      opportunities: { get: vi.fn(async () => opportunity) },
+      pipelines: {},
+      stages: { get: vi.fn(), findByKey: vi.fn() },
+      activities: { create: vi.fn() },
+      leadMerges: {},
+    } as unknown as SalesServiceOptions;
+
+    await expect(
+      new SalesService(stores).moveOpportunity({
+        opportunityId: opportunity.id,
+      }),
+    ).rejects.toThrow(
+      'A stage id or stage key is required to move an opportunity',
+    );
+    expect(stores.stages.get).not.toHaveBeenCalled();
+    expect(stores.stages.findByKey).not.toHaveBeenCalled();
   });
 
   it('rejects caller-supplied pipeline ids from a different tenant during conversion', async () => {

--- a/packages/sales/src/__tests__/sales-service.test.ts
+++ b/packages/sales/src/__tests__/sales-service.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  Lead,
+  LeadMerge,
+  Opportunity,
+  PipelineDefinition,
+  PipelineStage,
+  SalesActivity,
+} from '../models/index.js';
+import { SalesService, type SalesServiceOptions } from '../services/index.js';
+import { DEFAULT_PIPELINE_STAGE_DEFINITIONS } from '../types.js';
+
+describe('SalesService', () => {
+  it('filters default pipeline lookup and normalization by tenant id', async () => {
+    const tenantDefault = new PipelineDefinition({
+      tenantId: 'tenant-1',
+      key: 'default',
+      name: 'Tenant 1 Default',
+      isDefault: true,
+    });
+    tenantDefault.id = 'pipeline-1';
+    tenantDefault.save = vi.fn(async () => undefined);
+
+    const otherTenantDefault = new PipelineDefinition({
+      tenantId: 'tenant-2',
+      key: 'default',
+      name: 'Tenant 2 Default',
+      isDefault: true,
+    });
+    otherTenantDefault.id = 'pipeline-2';
+    otherTenantDefault.save = vi.fn(async () => undefined);
+
+    const stages: PipelineStage[] = [];
+    const stores = {
+      leads: {},
+      opportunities: {},
+      pipelines: {
+        getDefault: vi.fn(async (tenantId: string) =>
+          tenantId === 'tenant-1' ? tenantDefault : null,
+        ),
+        list: vi.fn(
+          async ({
+            where,
+          }: {
+            where?: { tenantId?: string; isDefault?: boolean };
+          } = {}) =>
+            [tenantDefault, otherTenantDefault].filter(
+              (pipeline) =>
+                (where?.tenantId === undefined ||
+                  pipeline.tenantId === where.tenantId) &&
+                (where?.isDefault === undefined ||
+                  pipeline.isDefault === where.isDefault),
+            ),
+        ),
+        create: vi.fn(),
+      },
+      stages: {
+        findByKey: vi.fn(
+          async (pipelineId: string, key: string) =>
+            stages.find(
+              (stage) => stage.pipelineId === pipelineId && stage.key === key,
+            ) ?? null,
+        ),
+        create: vi.fn(async (data) => {
+          const stage = new PipelineStage(data);
+          stage.id = `stage-${stages.length + 1}`;
+          stage.save = vi.fn(async () => undefined);
+          stages.push(stage);
+          return stage;
+        }),
+      },
+      activities: {},
+      leadMerges: {},
+    } as unknown as SalesServiceOptions;
+
+    const result = await new SalesService(stores).ensureDefaultPipeline(
+      'tenant-1',
+    );
+
+    expect(result.pipeline.id).toBe('pipeline-1');
+    expect(stores.pipelines.getDefault).toHaveBeenCalledWith('tenant-1');
+    expect(stores.pipelines.list).toHaveBeenCalledWith({
+      where: { tenantId: 'tenant-1', isDefault: true },
+    });
+    expect(otherTenantDefault.save).not.toHaveBeenCalled();
+    expect(stages).toHaveLength(DEFAULT_PIPELINE_STAGE_DEFINITIONS.length);
+  });
+
+  it('reloads and returns the winning opportunity after a duplicate-key race', async () => {
+    const lead = new Lead({
+      tenantId: 'tenant-1',
+      name: 'Ada',
+      ownerId: 'rep-1',
+      status: 'qualified',
+    });
+    lead.id = 'lead-1';
+    lead.save = vi.fn(async () => undefined);
+
+    const winner = new Opportunity({
+      tenantId: 'tenant-1',
+      leadId: lead.id,
+      pipelineId: 'pipeline-1',
+      stageId: 'stage-qualified',
+      ownerId: 'rep-1',
+      name: 'Ada opportunity',
+    });
+    winner.id = 'opportunity-1';
+    winner.save = vi.fn(async () => undefined);
+
+    const stage = new PipelineStage({
+      tenantId: 'tenant-1',
+      pipelineId: 'pipeline-1',
+      key: 'qualified',
+      name: 'Qualified',
+    });
+    stage.id = 'stage-qualified';
+
+    const getByLeadId = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(winner);
+    const createActivity = vi.fn();
+    const stores = {
+      leads: { get: vi.fn(async () => lead) },
+      opportunities: {
+        getByLeadId,
+        create: vi.fn(async () => {
+          throw {
+            code: 'VALIDATION_UNIQUE_CONSTRAINT',
+            message:
+              'duplicate key value violates unique constraint "sales_opportunities_tenant_id_lead_id_idx"',
+          };
+        }),
+      },
+      pipelines: {},
+      stages: {
+        findByKey: vi.fn(async () => stage),
+        get: vi.fn(async () => stage),
+      },
+      activities: { create: createActivity },
+      leadMerges: {},
+    } as unknown as SalesServiceOptions;
+
+    const result = await new SalesService(stores).convertLeadToOpportunity({
+      leadId: lead.id,
+      pipelineId: 'pipeline-1',
+      stageKey: 'qualified',
+    });
+
+    expect(result).toEqual({
+      opportunityId: 'opportunity-1',
+      leadId: 'lead-1',
+      created: false,
+      stageKey: 'qualified',
+    });
+    expect(getByLeadId).toHaveBeenCalledTimes(2);
+    expect(lead.save).not.toHaveBeenCalled();
+    expect(createActivity).not.toHaveBeenCalled();
+  });
+
+  it('preserves the full source opportunity snapshot and opportunity-only activities when merging leads', async () => {
+    const source = new Lead({
+      tenantId: 'tenant-1',
+      name: 'Source Lead',
+      email: 'source@example.com',
+      organization: 'Source Org',
+      ownerId: 'rep-1',
+      status: 'qualified',
+      qualificationSummary: 'Budget confirmed',
+      qualifiedAt: new Date('2026-07-01T10:00:00Z'),
+      qualifiedById: 'rep-2',
+    });
+    source.id = 'lead-source';
+    source.save = vi.fn(async () => undefined);
+    source.recordAcquisition({
+      source: 'webinar',
+      occurredAt: '2026-06-30T09:00:00Z',
+    });
+
+    const target = new Lead({
+      tenantId: 'tenant-1',
+      name: 'Target Lead',
+      email: 'target@example.com',
+      organization: 'Target Org',
+      status: 'new',
+    });
+    target.id = 'lead-target';
+    target.save = vi.fn(async () => undefined);
+
+    const opportunity = new Opportunity({
+      tenantId: 'tenant-1',
+      leadId: source.id,
+      pipelineId: 'pipeline-1',
+      stageId: 'stage-proposal',
+      ownerId: 'rep-1',
+      name: 'Source Opportunity',
+      expectedValue: 4200.0,
+      currency: 'CAD',
+      nextAction: 'Send proposal',
+      outcome: 'open',
+      lastStageChangeAt: new Date('2026-07-02T12:00:00Z'),
+    });
+    opportunity.id = 'opp-1';
+
+    const leadActivity = new SalesActivity({
+      tenantId: 'tenant-1',
+      leadId: source.id,
+      opportunityId: opportunity.id,
+      type: 'note',
+      actorId: 'rep-1',
+      summary: 'Initial qualification notes',
+      occurredAt: new Date('2026-07-01T11:00:00Z'),
+    });
+    leadActivity.id = 'activity-1';
+    leadActivity.setDetails({ channel: 'call' });
+
+    const opportunityOnlyActivity = new SalesActivity({
+      tenantId: 'tenant-1',
+      leadId: null,
+      opportunityId: opportunity.id,
+      type: 'meeting',
+      actorId: 'rep-3',
+      summary: 'Proposal walkthrough',
+      occurredAt: new Date('2026-07-03T15:00:00Z'),
+    });
+    opportunityOnlyActivity.id = 'activity-2';
+    opportunityOnlyActivity.setDetails({ attendees: 3 });
+
+    let savedMerge: LeadMerge | null = null;
+    const stores = {
+      leads: {
+        get: vi.fn(async ({ id }: { id: string }) =>
+          id === source.id ? source : target,
+        ),
+      },
+      opportunities: { getByLeadId: vi.fn(async () => opportunity) },
+      pipelines: {},
+      stages: {},
+      activities: {
+        forLead: vi.fn(async () => [leadActivity]),
+        forOpportunity: vi.fn(async () => [
+          leadActivity,
+          opportunityOnlyActivity,
+        ]),
+        create: vi.fn(async (data) => {
+          const activity = new SalesActivity(data);
+          activity.id = 'activity-merge';
+          activity.save = vi.fn(async () => undefined);
+          return activity;
+        }),
+      },
+      leadMerges: {
+        findBySourceLeadId: vi.fn(async () => null),
+        create: vi.fn(async (data) => {
+          const merge = new LeadMerge(data);
+          merge.id = 'merge-1';
+          merge.save = vi.fn(async () => undefined);
+          savedMerge = merge;
+          return merge;
+        }),
+      },
+    } as unknown as SalesServiceOptions;
+
+    const result = await new SalesService(stores).mergeLeads({
+      sourceLeadId: source.id,
+      targetLeadId: target.id,
+      actorId: 'rep-9',
+    });
+
+    expect(result).toEqual({
+      mergeId: 'merge-1',
+      sourceLeadId: 'lead-source',
+      targetLeadId: 'lead-target',
+      created: true,
+    });
+    const snapshot = savedMerge?.getSourceSnapshot();
+    expect(snapshot?.sourceOpportunityId).toBe('opp-1');
+    expect(snapshot?.sourceOpportunity).toEqual({
+      id: 'opp-1',
+      tenantId: 'tenant-1',
+      leadId: 'lead-source',
+      pipelineId: 'pipeline-1',
+      stageId: 'stage-proposal',
+      ownerId: 'rep-1',
+      name: 'Source Opportunity',
+      expectedValue: 4200,
+      currency: 'CAD',
+      nextAction: 'Send proposal',
+      outcome: 'open',
+      closedAt: null,
+      lastStageChangeAt: '2026-07-02T12:00:00.000Z',
+    });
+    expect(snapshot?.sourceActivities).toHaveLength(2);
+    expect(snapshot?.sourceActivities.map((activity) => activity.id)).toEqual([
+      'activity-1',
+      'activity-2',
+    ]);
+    expect(
+      snapshot?.sourceActivities.find(
+        (activity) => activity.id === 'activity-2',
+      ),
+    ).toMatchObject({
+      type: 'meeting',
+      summary: 'Proposal walkthrough',
+      opportunityId: 'opp-1',
+      details: { attendees: 3 },
+    });
+  });
+});

--- a/packages/sales/src/__tests__/sales-service.test.ts
+++ b/packages/sales/src/__tests__/sales-service.test.ts
@@ -167,7 +167,53 @@ describe('SalesService', () => {
     expect(stores.opportunities.create).toHaveBeenCalledWith(
       expect.objectContaining({ _insertOnly: true }),
     );
-    expect(lead.save).not.toHaveBeenCalled();
+    expect(lead.status).toBe('converted');
+    expect(lead.save).toHaveBeenCalledOnce();
+    expect(createActivity).not.toHaveBeenCalled();
+  });
+
+  it('reconciles lead conversion state when retrying an existing opportunity', async () => {
+    const lead = new Lead({
+      tenantId: 'tenant-1',
+      name: 'Ada',
+      ownerId: 'rep-old',
+      status: 'qualified',
+    });
+    lead.id = 'lead-1';
+    lead.save = vi.fn(async () => undefined);
+    const opportunity = new Opportunity({
+      tenantId: 'tenant-1',
+      leadId: lead.id,
+      pipelineId: 'pipeline-1',
+      stageId: 'stage-qualified',
+    });
+    opportunity.id = 'opportunity-1';
+    const stage = new PipelineStage({
+      tenantId: 'tenant-1',
+      pipelineId: 'pipeline-1',
+      key: 'qualified',
+      name: 'Qualified',
+    });
+    stage.id = 'stage-qualified';
+    const createActivity = vi.fn();
+    const stores = {
+      leads: { get: vi.fn(async () => lead) },
+      opportunities: { getByLeadId: vi.fn(async () => opportunity) },
+      pipelines: {},
+      stages: { get: vi.fn(async () => stage) },
+      activities: { create: createActivity },
+      leadMerges: {},
+    } as unknown as SalesServiceOptions;
+
+    const result = await new SalesService(stores).convertLeadToOpportunity({
+      leadId: lead.id,
+      ownerId: 'rep-new',
+    });
+
+    expect(result.created).toBe(false);
+    expect(lead.status).toBe('converted');
+    expect(lead.ownerId).toBe('rep-new');
+    expect(lead.save).toHaveBeenCalledOnce();
     expect(createActivity).not.toHaveBeenCalled();
   });
 

--- a/packages/sales/src/__tests__/sales-service.test.ts
+++ b/packages/sales/src/__tests__/sales-service.test.ts
@@ -115,6 +115,14 @@ describe('SalesService', () => {
     });
     stage.id = 'stage-qualified';
 
+    const pipeline = new PipelineDefinition({
+      tenantId: 'tenant-1',
+      key: 'default',
+      name: 'Default Pipeline',
+      isDefault: true,
+    });
+    pipeline.id = 'pipeline-1';
+
     const getByLeadId = vi
       .fn()
       .mockResolvedValueOnce(null)
@@ -132,7 +140,9 @@ describe('SalesService', () => {
           };
         }),
       },
-      pipelines: {},
+      pipelines: {
+        get: vi.fn(async () => pipeline),
+      },
       stages: {
         findByKey: vi.fn(async () => stage),
         get: vi.fn(async () => stage),
@@ -156,6 +166,138 @@ describe('SalesService', () => {
     expect(getByLeadId).toHaveBeenCalledTimes(2);
     expect(lead.save).not.toHaveBeenCalled();
     expect(createActivity).not.toHaveBeenCalled();
+  });
+
+  it('rejects caller-supplied pipeline ids from a different tenant during conversion', async () => {
+    const lead = new Lead({
+      tenantId: 'tenant-1',
+      name: 'Ada',
+      status: 'qualified',
+    });
+    lead.id = 'lead-1';
+
+    const foreignPipeline = new PipelineDefinition({
+      tenantId: 'tenant-2',
+      key: 'default',
+      name: 'Foreign Pipeline',
+      isDefault: true,
+    });
+    foreignPipeline.id = 'pipeline-foreign';
+
+    const stores = {
+      leads: { get: vi.fn(async () => lead) },
+      opportunities: {
+        getByLeadId: vi.fn(async () => null),
+        create: vi.fn(),
+      },
+      pipelines: {
+        get: vi.fn(async () => foreignPipeline),
+      },
+      stages: {
+        findByKey: vi.fn(),
+      },
+      activities: { create: vi.fn() },
+      leadMerges: {},
+    } as unknown as SalesServiceOptions;
+
+    await expect(
+      new SalesService(stores).convertLeadToOpportunity({
+        leadId: lead.id,
+        pipelineId: foreignPipeline.id,
+        stageKey: 'qualified',
+      }),
+    ).rejects.toThrow(
+      "Pipeline 'pipeline-foreign' does not belong to tenant 'tenant-1'",
+    );
+
+    expect(stores.stages.findByKey).not.toHaveBeenCalled();
+    expect(stores.opportunities.create).not.toHaveBeenCalled();
+  });
+
+  it('reloads the winning default pipeline and stage after duplicate-key bootstrap races', async () => {
+    const winnerPipeline = new PipelineDefinition({
+      tenantId: 'tenant-1',
+      key: 'default',
+      name: 'Default Sales Pipeline',
+      isDefault: true,
+    });
+    winnerPipeline.id = 'pipeline-1';
+    winnerPipeline.save = vi.fn(async () => undefined);
+
+    const seededStages = new Map<string, PipelineStage>();
+    const duplicateStageKeys = new Set(['new']);
+    let getDefaultCalls = 0;
+
+    const stores = {
+      leads: {},
+      opportunities: {},
+      pipelines: {
+        getDefault: vi.fn(async () => {
+          getDefaultCalls += 1;
+          return getDefaultCalls === 1 ? null : winnerPipeline;
+        }),
+        get: vi.fn(async ({ id }: { id: string }) =>
+          id === winnerPipeline.id ? winnerPipeline : null,
+        ),
+        list: vi.fn(async () => [winnerPipeline]),
+        create: vi.fn(async (data) => {
+          const pipeline = new PipelineDefinition(data);
+          pipeline.id = 'pipeline-racing';
+          pipeline.save = vi.fn(async () => {
+            throw {
+              code: '23505',
+              message:
+                'duplicate key value violates unique constraint "sales_pipelines_tenant_id_key_idx"',
+            };
+          });
+          return pipeline;
+        }),
+      },
+      stages: {
+        findByKey: vi.fn(async (pipelineId: string, key: string) => {
+          const stage = seededStages.get(`${pipelineId}:${key}`) ?? null;
+          return stage;
+        }),
+        create: vi.fn(async (data) => {
+          const stage = new PipelineStage(data);
+          stage.id = `stage-${data.key}`;
+          stage.save = vi.fn(async () => {
+            if (duplicateStageKeys.delete(data.key)) {
+              const winner = new PipelineStage(data);
+              winner.id = `winner-${data.key}`;
+              winner.save = vi.fn(async () => undefined);
+              seededStages.set(`${data.pipelineId}:${data.key}`, winner);
+              throw {
+                code: 'VALIDATION_UNIQUE_CONSTRAINT',
+                message:
+                  'duplicate key value violates unique constraint "sales_pipeline_stages_tenant_id_pipeline_id_key_idx"',
+              };
+            }
+            seededStages.set(`${data.pipelineId}:${data.key}`, stage);
+          });
+          return stage;
+        }),
+      },
+      activities: {},
+      leadMerges: {},
+    } as unknown as SalesServiceOptions;
+
+    const result = await new SalesService(stores).ensureDefaultPipeline(
+      'tenant-1',
+    );
+
+    expect(result.pipeline).toEqual({
+      id: 'pipeline-1',
+      key: 'default',
+      name: 'Default Sales Pipeline',
+    });
+    expect(result.stageIdsByKey.new).toBe('winner-new');
+    expect(result.stageIdsByKey.qualified).toBe('stage-qualified');
+    expect(Object.keys(result.stageIdsByKey)).toHaveLength(
+      DEFAULT_PIPELINE_STAGE_DEFINITIONS.length,
+    );
+    expect(stores.pipelines.getDefault).toHaveBeenCalledTimes(2);
+    expect(stores.stages.findByKey).toHaveBeenCalledWith('pipeline-1', 'new');
   });
 
   it('preserves the full source opportunity snapshot and opportunity-only activities when merging leads', async () => {

--- a/packages/sales/src/__tests__/svelte-surfaces.test.ts
+++ b/packages/sales/src/__tests__/svelte-surfaces.test.ts
@@ -1,0 +1,21 @@
+import { readFile } from 'node:fs/promises';
+import { compile } from 'svelte/compiler';
+import { describe, expect, it } from 'vitest';
+
+describe('reusable sales Svelte surfaces', () => {
+  for (const component of ['LeadList', 'OpportunityBoard', 'SalesDetail']) {
+    it(`compiles ${component} without warnings`, async () => {
+      const filename = new URL(
+        `../svelte/components/${component}.svelte`,
+        import.meta.url,
+      );
+      const source = await readFile(filename, 'utf8');
+      const result = compile(source, {
+        filename: filename.pathname,
+        generate: 'client',
+        modernAst: true,
+      });
+      expect(result.warnings).toEqual([]);
+    });
+  }
+});

--- a/packages/sales/src/collections/LeadCollection.ts
+++ b/packages/sales/src/collections/LeadCollection.ts
@@ -1,0 +1,24 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { Lead } from '../models/Lead.js';
+
+export class LeadCollection extends SmrtCollection<Lead> {
+  static readonly _itemClass = Lead;
+
+  async findByOwner(ownerId: string): Promise<Lead[]> {
+    return this.list({ where: { ownerId } });
+  }
+
+  async findByEmail(email: string): Promise<Lead[]> {
+    return this.list({ where: { email } });
+  }
+
+  async findActive(): Promise<Lead[]> {
+    return this.list({
+      where: { 'status in': ['new', 'qualified', 'converted'] },
+    });
+  }
+
+  async findMergedInto(targetLeadId: string): Promise<Lead[]> {
+    return this.list({ where: { mergedIntoLeadId: targetLeadId } });
+  }
+}

--- a/packages/sales/src/collections/LeadMergeCollection.ts
+++ b/packages/sales/src/collections/LeadMergeCollection.ts
@@ -1,0 +1,18 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { LeadMerge } from '../models/LeadMerge.js';
+
+export class LeadMergeCollection extends SmrtCollection<LeadMerge> {
+  static readonly _itemClass = LeadMerge;
+
+  async findBySourceLeadId(sourceLeadId: string): Promise<LeadMerge | null> {
+    const rows = await this.list({ where: { sourceLeadId } });
+    return rows[0] ?? null;
+  }
+
+  async forTargetLead(targetLeadId: string): Promise<LeadMerge[]> {
+    const rows = await this.list({ where: { targetLeadId } });
+    return rows.sort(
+      (left, right) => left.mergedAt.getTime() - right.mergedAt.getTime(),
+    );
+  }
+}

--- a/packages/sales/src/collections/OpportunityCollection.ts
+++ b/packages/sales/src/collections/OpportunityCollection.ts
@@ -1,0 +1,40 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { Opportunity } from '../models/Opportunity.js';
+
+function byStageChangeThenValue(rows: Opportunity[]): Opportunity[] {
+  return [...rows].sort((left, right) => {
+    const leftTime = left.lastStageChangeAt?.getTime() ?? 0;
+    const rightTime = right.lastStageChangeAt?.getTime() ?? 0;
+    if (leftTime !== rightTime) {
+      return rightTime - leftTime;
+    }
+    return right.expectedValue - left.expectedValue;
+  });
+}
+
+export class OpportunityCollection extends SmrtCollection<Opportunity> {
+  static readonly _itemClass = Opportunity;
+
+  async getByLeadId(leadId: string): Promise<Opportunity | null> {
+    const rows = await this.list({ where: { leadId } });
+    return rows[0] ?? null;
+  }
+
+  async byOwner(ownerId: string): Promise<Opportunity[]> {
+    return this.list({ where: { ownerId } });
+  }
+
+  async byStage(stageId: string): Promise<Opportunity[]> {
+    return byStageChangeThenValue(await this.list({ where: { stageId } }));
+  }
+
+  async byPipeline(pipelineId: string): Promise<Opportunity[]> {
+    return byStageChangeThenValue(await this.list({ where: { pipelineId } }));
+  }
+
+  async open(): Promise<Opportunity[]> {
+    return byStageChangeThenValue(
+      await this.list({ where: { outcome: 'open' } }),
+    );
+  }
+}

--- a/packages/sales/src/collections/PipelineDefinitionCollection.ts
+++ b/packages/sales/src/collections/PipelineDefinitionCollection.ts
@@ -1,0 +1,31 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { PipelineDefinition } from '../models/PipelineDefinition.js';
+
+export class PipelineDefinitionCollection extends SmrtCollection<PipelineDefinition> {
+  static readonly _itemClass = PipelineDefinition;
+
+  async findByKey(
+    key: string,
+    tenantId?: string,
+  ): Promise<PipelineDefinition | null> {
+    const where: Record<string, unknown> = { key };
+    if (tenantId !== undefined) {
+      where.tenantId = tenantId;
+    }
+    const rows = await this.list({ where });
+    return rows[0] ?? null;
+  }
+
+  async getDefault(tenantId?: string): Promise<PipelineDefinition | null> {
+    const explicitWhere: Record<string, unknown> = { isDefault: true };
+    if (tenantId !== undefined) {
+      explicitWhere.tenantId = tenantId;
+    }
+    const explicit = await this.list({ where: explicitWhere });
+    if (explicit[0]) {
+      return explicit[0];
+    }
+
+    return this.findByKey('default', tenantId);
+  }
+}

--- a/packages/sales/src/collections/PipelineStageCollection.ts
+++ b/packages/sales/src/collections/PipelineStageCollection.ts
@@ -1,0 +1,45 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { PipelineStage } from '../models/PipelineStage.js';
+import type { PipelineStageKey } from '../types.js';
+
+function sortStages(stages: PipelineStage[]): PipelineStage[] {
+  return [...stages].sort((left, right) => left.sortOrder - right.sortOrder);
+}
+
+export class PipelineStageCollection extends SmrtCollection<PipelineStage> {
+  static readonly _itemClass = PipelineStage;
+
+  async forPipeline(pipelineId: string): Promise<PipelineStage[]> {
+    return sortStages(await this.list({ where: { pipelineId } }));
+  }
+
+  async findByKey(
+    pipelineId: string,
+    key: PipelineStageKey,
+  ): Promise<PipelineStage | null> {
+    const rows = await this.list({ where: { pipelineId, key } });
+    return rows[0] ?? null;
+  }
+
+  async getNextStage(stage: PipelineStage): Promise<PipelineStage | null> {
+    const stages = await this.forPipeline(stage.pipelineId);
+    const currentIndex = stages.findIndex(
+      (candidate) => candidate.id === stage.id,
+    );
+    if (currentIndex < 0 || currentIndex + 1 >= stages.length) {
+      return null;
+    }
+    return stages[currentIndex + 1] ?? null;
+  }
+
+  async getPreviousStage(stage: PipelineStage): Promise<PipelineStage | null> {
+    const stages = await this.forPipeline(stage.pipelineId);
+    const currentIndex = stages.findIndex(
+      (candidate) => candidate.id === stage.id,
+    );
+    if (currentIndex <= 0) {
+      return null;
+    }
+    return stages[currentIndex - 1] ?? null;
+  }
+}

--- a/packages/sales/src/collections/SalesActivityCollection.ts
+++ b/packages/sales/src/collections/SalesActivityCollection.ts
@@ -1,0 +1,27 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { SalesActivity } from '../models/SalesActivity.js';
+
+function byOccurredAt(rows: SalesActivity[]): SalesActivity[] {
+  return [...rows].sort(
+    (left, right) => left.occurredAt.getTime() - right.occurredAt.getTime(),
+  );
+}
+
+export class SalesActivityCollection extends SmrtCollection<SalesActivity> {
+  static readonly _itemClass = SalesActivity;
+
+  async forLead(leadId: string): Promise<SalesActivity[]> {
+    return byOccurredAt(await this.list({ where: { leadId } }));
+  }
+
+  async forLeadIds(leadIds: string[]): Promise<SalesActivity[]> {
+    if (leadIds.length === 0) {
+      return [];
+    }
+    return byOccurredAt(await this.list({ where: { 'leadId in': leadIds } }));
+  }
+
+  async forOpportunity(opportunityId: string): Promise<SalesActivity[]> {
+    return byOccurredAt(await this.list({ where: { opportunityId } }));
+  }
+}

--- a/packages/sales/src/collections/index.ts
+++ b/packages/sales/src/collections/index.ts
@@ -1,0 +1,6 @@
+export { LeadCollection } from './LeadCollection.js';
+export { LeadMergeCollection } from './LeadMergeCollection.js';
+export { OpportunityCollection } from './OpportunityCollection.js';
+export { PipelineDefinitionCollection } from './PipelineDefinitionCollection.js';
+export { PipelineStageCollection } from './PipelineStageCollection.js';
+export { SalesActivityCollection } from './SalesActivityCollection.js';

--- a/packages/sales/src/index.ts
+++ b/packages/sales/src/index.ts
@@ -1,0 +1,50 @@
+import './__smrt-register__.js';
+
+export {
+  LeadCollection,
+  LeadMergeCollection,
+  OpportunityCollection,
+  PipelineDefinitionCollection,
+  PipelineStageCollection,
+  SalesActivityCollection,
+} from './collections/index.js';
+
+export {
+  Lead,
+  LeadMerge,
+  Opportunity,
+  PipelineDefinition,
+  PipelineStage,
+  SalesActivity,
+} from './models/index.js';
+
+export { SalesService, type SalesServiceOptions } from './services/index.js';
+
+export {
+  type AcquisitionEvent,
+  type ActivityDetails,
+  type ConvertLeadToOpportunityArgs,
+  type ConvertLeadToOpportunityResult,
+  type CreateLeadArgs,
+  DEFAULT_PIPELINE_STAGE_DEFINITIONS,
+  type DefaultPipelineStageDefinition,
+  type EnsureDefaultPipelineResult,
+  type LeadMergeOptions,
+  type LeadMergeSnapshot,
+  type LeadOptions,
+  type LeadStatus,
+  type MergeLeadArgs,
+  type MergeLeadResult,
+  type MoveOpportunityArgs,
+  type OpportunityOptions,
+  type OpportunityOutcome,
+  type PipelineDefinitionOptions,
+  type PipelineStageKey,
+  type PipelineStageOptions,
+  type QualifyLeadArgs,
+  type SalesActivityOptions,
+  type SalesActivitySnapshot,
+  type SalesActivityType,
+} from './types.js';
+
+export { SALES_MODULE_META, SALES_UI_SLOTS } from './ui.js';

--- a/packages/sales/src/models/Lead.ts
+++ b/packages/sales/src/models/Lead.ts
@@ -1,0 +1,100 @@
+import { crossPackageRef, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type { AcquisitionEvent, LeadOptions, LeadStatus } from '../types.js';
+
+function normalizeAcquisitionHistory(raw: string | null | undefined): string {
+  if (!raw) {
+    return '[]';
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? JSON.stringify(parsed) : '[]';
+  } catch {
+    return '[]';
+  }
+}
+
+@TenantScoped({ mode: 'required' })
+@smrt({ tableName: 'sales_leads', api: true, cli: true, mcp: true })
+export class Lead extends SmrtObject {
+  @tenantId()
+  tenantId: string = '';
+
+  name: string = '';
+  email: string = '';
+  organization: string = '';
+
+  @crossPackageRef('@happyvertical/smrt-users:User', { nullable: true })
+  ownerId: string | null = null;
+
+  status: LeadStatus = 'new';
+  qualificationSummary: string = '';
+  qualifiedAt: Date | null = null;
+
+  @crossPackageRef('@happyvertical/smrt-users:User', { nullable: true })
+  qualifiedById: string | null = null;
+
+  acquisitionHistory: string = '[]';
+  mergedIntoLeadId: string | null = null;
+
+  constructor(options: LeadOptions = {}) {
+    super(options);
+    Object.assign(this, options);
+    this.acquisitionHistory = normalizeAcquisitionHistory(
+      this.acquisitionHistory,
+    );
+  }
+
+  getAcquisitionHistory(): AcquisitionEvent[] {
+    try {
+      const value: unknown = JSON.parse(this.acquisitionHistory);
+      return Array.isArray(value)
+        ? (value as AcquisitionEvent[]).map((event) => ({ ...event }))
+        : [];
+    } catch {
+      return [];
+    }
+  }
+
+  recordAcquisition(event: AcquisitionEvent): void {
+    if (!event.source || !event.occurredAt) {
+      throw new Error(
+        'Acquisition events require source and occurredAt values',
+      );
+    }
+    this.acquisitionHistory = JSON.stringify([
+      ...this.getAcquisitionHistory(),
+      { ...event },
+    ]);
+  }
+
+  assign(ownerId: string): void {
+    const normalized = ownerId.trim();
+    if (!normalized) {
+      throw new Error('A sales representative id is required');
+    }
+    this.ownerId = normalized;
+  }
+
+  qualify(actorId?: string | null, summary?: string): void {
+    this.status = 'qualified';
+    this.qualifiedAt = new Date();
+    this.qualifiedById = actorId?.trim() || null;
+    if (summary !== undefined) {
+      this.qualificationSummary = summary;
+    }
+  }
+
+  markConverted(): void {
+    this.status = 'converted';
+  }
+
+  markMerged(targetLeadId: string): void {
+    if (!targetLeadId.trim()) {
+      throw new Error('A merge target lead id is required');
+    }
+    this.status = 'merged';
+    this.mergedIntoLeadId = targetLeadId;
+  }
+}

--- a/packages/sales/src/models/Lead.ts
+++ b/packages/sales/src/models/Lead.ts
@@ -78,6 +78,9 @@ export class Lead extends SmrtObject {
   }
 
   qualify(actorId?: string | null, summary?: string): void {
+    if (this.status === 'converted' || this.status === 'merged') {
+      throw new Error(`A ${this.status} lead cannot be qualified`);
+    }
     this.status = 'qualified';
     this.qualifiedAt = new Date();
     this.qualifiedById = actorId?.trim() || null;
@@ -91,10 +94,11 @@ export class Lead extends SmrtObject {
   }
 
   markMerged(targetLeadId: string): void {
-    if (!targetLeadId.trim()) {
+    const normalized = targetLeadId.trim();
+    if (!normalized) {
       throw new Error('A merge target lead id is required');
     }
     this.status = 'merged';
-    this.mergedIntoLeadId = targetLeadId;
+    this.mergedIntoLeadId = normalized;
   }
 }

--- a/packages/sales/src/models/Lead.ts
+++ b/packages/sales/src/models/Lead.ts
@@ -16,7 +16,24 @@ function normalizeAcquisitionHistory(raw: string | null | undefined): string {
 }
 
 @TenantScoped({ mode: 'required' })
-@smrt({ tableName: 'sales_leads', api: true, cli: true, mcp: true })
+@smrt({
+  tableName: 'sales_leads',
+  api: {
+    writable: [
+      'name',
+      'email',
+      'organization',
+      'ownerId',
+      'status',
+      'qualificationSummary',
+      'qualifiedAt',
+      'qualifiedById',
+      'mergedIntoLeadId',
+    ],
+  },
+  cli: true,
+  mcp: true,
+})
 export class Lead extends SmrtObject {
   @tenantId()
   tenantId: string = '';

--- a/packages/sales/src/models/LeadMerge.ts
+++ b/packages/sales/src/models/LeadMerge.ts
@@ -1,0 +1,47 @@
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type { LeadMergeOptions, LeadMergeSnapshot } from '../types.js';
+
+@TenantScoped({ mode: 'required' })
+@smrt({
+  tableName: 'sales_lead_merges',
+  api: { include: ['list', 'get', 'create'] },
+  cli: true,
+  mcp: true,
+  conflictColumns: ['tenant_id', 'source_lead_id'],
+})
+export class LeadMerge extends SmrtObject {
+  @tenantId()
+  tenantId: string = '';
+
+  @foreignKey('Lead') sourceLeadId: string = '';
+  @foreignKey('Lead') targetLeadId: string = '';
+
+  @crossPackageRef('@happyvertical/smrt-users:User', { nullable: true })
+  actorId: string | null = null;
+
+  sourceSnapshot: string = '{}';
+  mergedAt: Date = new Date();
+
+  constructor(options: LeadMergeOptions = {}) {
+    super(options);
+    Object.assign(this, options);
+  }
+
+  getSourceSnapshot(): LeadMergeSnapshot | null {
+    try {
+      return JSON.parse(this.sourceSnapshot) as LeadMergeSnapshot;
+    } catch {
+      return null;
+    }
+  }
+
+  setSourceSnapshot(snapshot: LeadMergeSnapshot): void {
+    this.sourceSnapshot = JSON.stringify(snapshot);
+  }
+}

--- a/packages/sales/src/models/LeadMerge.ts
+++ b/packages/sales/src/models/LeadMerge.ts
@@ -12,7 +12,7 @@ import type { LeadMergeOptions, LeadMergeSnapshot } from '../types.js';
   tableName: 'sales_lead_merges',
   api: { include: ['list', 'get', 'create'] },
   cli: true,
-  mcp: true,
+  mcp: { include: ['list', 'get', 'create'] },
   conflictColumns: ['tenant_id', 'source_lead_id'],
 })
 export class LeadMerge extends SmrtObject {

--- a/packages/sales/src/models/Opportunity.ts
+++ b/packages/sales/src/models/Opportunity.ts
@@ -1,0 +1,68 @@
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type { OpportunityOptions, OpportunityOutcome } from '../types.js';
+
+@TenantScoped({ mode: 'required' })
+@smrt({
+  tableName: 'sales_opportunities',
+  api: true,
+  cli: true,
+  mcp: true,
+  conflictColumns: ['tenant_id', 'lead_id'],
+})
+export class Opportunity extends SmrtObject {
+  @tenantId()
+  tenantId: string = '';
+
+  @foreignKey('Lead') leadId: string = '';
+  @foreignKey('PipelineDefinition') pipelineId: string = '';
+  @foreignKey('PipelineStage') stageId: string = '';
+
+  @crossPackageRef('@happyvertical/smrt-users:User', { nullable: true })
+  ownerId: string | null = null;
+
+  name: string = '';
+  expectedValue: number = 0.0;
+  currency: string = 'USD';
+  nextAction: string = '';
+  outcome: OpportunityOutcome = 'open';
+  closedAt: Date | null = null;
+  lastStageChangeAt: Date | null = null;
+
+  constructor(options: OpportunityOptions = {}) {
+    super(options);
+    Object.assign(this, options);
+  }
+
+  assign(ownerId: string): void {
+    const normalized = ownerId.trim();
+    if (!normalized) {
+      throw new Error('A sales representative id is required');
+    }
+    this.ownerId = normalized;
+  }
+
+  setExpectedValue(value: number): void {
+    if (!Number.isFinite(value) || value < 0) {
+      throw new Error('Expected value must be a non-negative number');
+    }
+    this.expectedValue = value;
+  }
+
+  moveTo(stage: PipelineStage): void {
+    if (!stage.id) throw new Error('Pipeline stage must be saved before use');
+    if (stage.pipelineId !== this.pipelineId)
+      throw new Error('Pipeline stage belongs to a different pipeline');
+    this.stageId = stage.id;
+    this.outcome = stage.outcome;
+    this.lastStageChangeAt = new Date();
+    this.closedAt = stage.terminal ? new Date() : null;
+  }
+}
+
+import type { PipelineStage } from './PipelineStage.js';

--- a/packages/sales/src/models/PipelineDefinition.ts
+++ b/packages/sales/src/models/PipelineDefinition.ts
@@ -1,0 +1,25 @@
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type { PipelineDefinitionOptions } from '../types.js';
+
+@TenantScoped({ mode: 'required' })
+@smrt({
+  tableName: 'sales_pipelines',
+  api: true,
+  cli: true,
+  mcp: true,
+  conflictColumns: ['tenant_id', 'key'],
+})
+export class PipelineDefinition extends SmrtObject {
+  @tenantId()
+  tenantId: string = '';
+  key: string = 'default';
+  name: string = 'Default Sales Pipeline';
+  description: string = '';
+  active: boolean = true;
+  isDefault: boolean = false;
+  constructor(options: PipelineDefinitionOptions = {}) {
+    super(options);
+    Object.assign(this, options);
+  }
+}

--- a/packages/sales/src/models/PipelineStage.ts
+++ b/packages/sales/src/models/PipelineStage.ts
@@ -1,0 +1,30 @@
+import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type {
+  OpportunityOutcome,
+  PipelineStageKey,
+  PipelineStageOptions,
+} from '../types.js';
+
+@TenantScoped({ mode: 'required' })
+@smrt({
+  tableName: 'sales_pipeline_stages',
+  api: true,
+  cli: true,
+  mcp: true,
+  conflictColumns: ['tenant_id', 'pipeline_id', 'key'],
+})
+export class PipelineStage extends SmrtObject {
+  @tenantId()
+  tenantId: string = '';
+  @foreignKey('PipelineDefinition') pipelineId: string = '';
+  key: PipelineStageKey = 'new';
+  name: string = 'New';
+  sortOrder: number = 0;
+  terminal: boolean = false;
+  outcome: OpportunityOutcome = 'open';
+  constructor(options: PipelineStageOptions = {}) {
+    super(options);
+    Object.assign(this, options);
+  }
+}

--- a/packages/sales/src/models/SalesActivity.ts
+++ b/packages/sales/src/models/SalesActivity.ts
@@ -1,0 +1,52 @@
+import {
+  crossPackageRef,
+  foreignKey,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type {
+  ActivityDetails,
+  SalesActivityOptions,
+  SalesActivityType,
+} from '../types.js';
+
+@TenantScoped({ mode: 'required' })
+@smrt({
+  tableName: 'sales_activities',
+  api: { include: ['list', 'get', 'create'] },
+  cli: true,
+  mcp: true,
+})
+export class SalesActivity extends SmrtObject {
+  @tenantId()
+  tenantId: string = '';
+
+  @foreignKey('Lead') leadId: string | null = null;
+  @foreignKey('Opportunity') opportunityId: string | null = null;
+  type: SalesActivityType = 'note';
+
+  @crossPackageRef('@happyvertical/smrt-users:User', { nullable: true })
+  actorId: string | null = null;
+
+  summary: string = '';
+  details: string = '{}';
+  occurredAt: Date = new Date();
+
+  constructor(options: SalesActivityOptions = {}) {
+    super(options);
+    Object.assign(this, options);
+  }
+
+  getDetails(): ActivityDetails {
+    try {
+      return JSON.parse(this.details) as ActivityDetails;
+    } catch {
+      return {};
+    }
+  }
+
+  setDetails(details: ActivityDetails): void {
+    this.details = JSON.stringify(details);
+  }
+}

--- a/packages/sales/src/models/SalesActivity.ts
+++ b/packages/sales/src/models/SalesActivity.ts
@@ -16,7 +16,7 @@ import type {
   tableName: 'sales_activities',
   api: { include: ['list', 'get', 'create'] },
   cli: true,
-  mcp: true,
+  mcp: { include: ['list', 'get', 'create'] },
 })
 export class SalesActivity extends SmrtObject {
   @tenantId()

--- a/packages/sales/src/models/index.ts
+++ b/packages/sales/src/models/index.ts
@@ -1,0 +1,6 @@
+export { Lead } from './Lead.js';
+export { LeadMerge } from './LeadMerge.js';
+export { Opportunity } from './Opportunity.js';
+export { PipelineDefinition } from './PipelineDefinition.js';
+export { PipelineStage } from './PipelineStage.js';
+export { SalesActivity } from './SalesActivity.js';

--- a/packages/sales/src/services/SalesService.ts
+++ b/packages/sales/src/services/SalesService.ts
@@ -143,6 +143,7 @@ export class SalesService {
     const existing = await this.opportunities.getByLeadId(lead.id ?? '');
     if (existing?.id) {
       await this.reconcileConvertedLead(lead, args.ownerId);
+      await this.reconcileOpportunityOwner(existing, args.ownerId);
       const currentStage = await this.requireStage(existing.stageId);
       return {
         opportunityId: existing.id,
@@ -182,6 +183,7 @@ export class SalesService {
       });
     if (!created) {
       await this.reconcileConvertedLead(lead, args.ownerId);
+      await this.reconcileOpportunityOwner(opportunity, args.ownerId);
       const currentStage = await this.requireStage(opportunity.stageId);
       return {
         opportunityId: opportunity.id ?? '',
@@ -517,6 +519,21 @@ export class SalesService {
       lead.assign(normalizedOwnerId);
     }
     await lead.save();
+  }
+
+  private async reconcileOpportunityOwner(
+    opportunity: Opportunity,
+    ownerId?: string | null,
+  ): Promise<void> {
+    const normalizedOwnerId = ownerId?.trim() || null;
+    if (
+      normalizedOwnerId === null ||
+      opportunity.ownerId === normalizedOwnerId
+    ) {
+      return;
+    }
+    opportunity.ownerId = normalizedOwnerId;
+    await opportunity.save();
   }
 
   private mergeTaggedAcquisition(

--- a/packages/sales/src/services/SalesService.ts
+++ b/packages/sales/src/services/SalesService.ts
@@ -107,16 +107,7 @@ export class SalesService {
   ): Promise<EnsureDefaultPipelineResult> {
     let pipeline = await this.pipelines.getDefault(tenantId);
     if (!pipeline) {
-      pipeline = await this.pipelines.create({
-        tenantId,
-        key: 'default',
-        name: 'Default Sales Pipeline',
-        description:
-          'Default lead qualification and opportunity progression pipeline',
-        active: true,
-        isDefault: true,
-      });
-      await pipeline.save();
+      pipeline = await this.createDefaultPipelineWithRaceHandling(tenantId);
     }
 
     await this.normalizeDefaultFlags(tenantId, pipeline);
@@ -160,17 +151,25 @@ export class SalesService {
       };
     }
 
-    const pipeline =
+    const pipelineId =
       args.pipelineId?.trim() ||
       (await this.ensureDefaultPipeline(lead.tenantId)).pipeline.id;
+    const pipeline = await this.requirePipelineForTenant(
+      pipelineId,
+      lead.tenantId,
+    );
     const stageKey = args.stageKey ?? 'qualified';
-    const stage = await this.resolveStage(pipeline, stageKey);
+    const stage = await this.resolveStageForTenant(
+      pipeline.id ?? '',
+      stageKey,
+      lead.tenantId,
+    );
 
     const { opportunity, created } =
       await this.createOpportunityWithRaceHandling({
         tenantId: lead.tenantId,
         leadId: lead.id ?? '',
-        pipelineId: pipeline,
+        pipelineId: pipeline.id ?? '',
         stageId: stage.id ?? '',
         ownerId: args.ownerId ?? lead.ownerId,
         name: args.name ?? this.defaultOpportunityName(lead),
@@ -225,10 +224,11 @@ export class SalesService {
     const opportunity = await this.requireOpportunity(args.opportunityId);
     const previousStageId = opportunity.stageId;
     const stage = args.stageId?.trim()
-      ? await this.requireStage(args.stageId)
-      : await this.resolveStage(
+      ? await this.requireStageForOpportunity(args.stageId, opportunity)
+      : await this.resolveStageForTenant(
           opportunity.pipelineId,
           args.stageKey ?? 'qualified',
+          opportunity.tenantId,
         );
 
     opportunity.moveTo(stage);
@@ -413,20 +413,72 @@ export class SalesService {
         definition.key,
       );
       if (!stage) {
-        stage = await this.stages.create({
-          tenantId: pipeline.tenantId,
-          pipelineId: pipeline.id ?? '',
-          key: definition.key,
-          name: definition.name,
-          sortOrder: definition.sortOrder,
-          terminal: definition.terminal,
-          outcome: definition.outcome,
-        });
-        await stage.save();
+        stage = await this.createPipelineStageWithRaceHandling(
+          pipeline,
+          definition,
+        );
       }
       stages.push(stage);
     }
     return stages.sort((left, right) => left.sortOrder - right.sortOrder);
+  }
+
+  private async createDefaultPipelineWithRaceHandling(
+    tenantId: string,
+  ): Promise<PipelineDefinition> {
+    try {
+      const pipeline = await this.pipelines.create({
+        tenantId,
+        key: 'default',
+        name: 'Default Sales Pipeline',
+        description:
+          'Default lead qualification and opportunity progression pipeline',
+        active: true,
+        isDefault: true,
+      });
+      await pipeline.save();
+      return pipeline;
+    } catch (error) {
+      if (!this.isDuplicateKeyError(error)) {
+        throw error;
+      }
+      const winner = await this.pipelines.getDefault(tenantId);
+      if (!winner) {
+        throw error;
+      }
+      return winner;
+    }
+  }
+
+  private async createPipelineStageWithRaceHandling(
+    pipeline: PipelineDefinition,
+    definition: DefaultPipelineStageDefinition,
+  ): Promise<PipelineStage> {
+    try {
+      const stage = await this.stages.create({
+        tenantId: pipeline.tenantId,
+        pipelineId: pipeline.id ?? '',
+        key: definition.key,
+        name: definition.name,
+        sortOrder: definition.sortOrder,
+        terminal: definition.terminal,
+        outcome: definition.outcome,
+      });
+      await stage.save();
+      return stage;
+    } catch (error) {
+      if (!this.isDuplicateKeyError(error)) {
+        throw error;
+      }
+      const winner = await this.stages.findByKey(
+        pipeline.id ?? '',
+        definition.key,
+      );
+      if (!winner) {
+        throw error;
+      }
+      return winner;
+    }
   }
 
   private defaultOpportunityName(lead: Lead): string {
@@ -528,14 +580,20 @@ export class SalesService {
     }
   }
 
-  private async resolveStage(
+  private async resolveStageForTenant(
     pipelineId: string,
     stageKey: PipelineStageKey,
+    tenantId: string,
   ): Promise<PipelineStage> {
     const stage = await this.stages.findByKey(pipelineId, stageKey);
     if (!stage) {
       throw new Error(
         `Pipeline stage '${stageKey}' was not found for pipeline '${pipelineId}'`,
+      );
+    }
+    if (stage.tenantId !== tenantId) {
+      throw new Error(
+        `Pipeline stage '${stage.id}' does not belong to tenant '${tenantId}'`,
       );
     }
     return stage;
@@ -557,6 +615,40 @@ export class SalesService {
       throw new Error(`Opportunity '${opportunityId}' not found`);
     }
     return opportunity;
+  }
+
+  private async requirePipelineForTenant(
+    pipelineId: string,
+    tenantId: string,
+  ): Promise<PipelineDefinition> {
+    const pipeline = await this.pipelines.get({ id: pipelineId });
+    if (!pipeline) {
+      throw new Error(`Pipeline '${pipelineId}' not found`);
+    }
+    if (pipeline.tenantId !== tenantId) {
+      throw new Error(
+        `Pipeline '${pipelineId}' does not belong to tenant '${tenantId}'`,
+      );
+    }
+    return pipeline;
+  }
+
+  private async requireStageForOpportunity(
+    stageId: string,
+    opportunity: Opportunity,
+  ): Promise<PipelineStage> {
+    const stage = await this.requireStage(stageId);
+    if (stage.tenantId !== opportunity.tenantId) {
+      throw new Error(
+        `Pipeline stage '${stageId}' does not belong to tenant '${opportunity.tenantId}'`,
+      );
+    }
+    if (stage.pipelineId !== opportunity.pipelineId) {
+      throw new Error(
+        `Pipeline stage '${stageId}' belongs to a different pipeline`,
+      );
+    }
+    return stage;
   }
 
   private async requireStage(stageId: string): Promise<PipelineStage> {

--- a/packages/sales/src/services/SalesService.ts
+++ b/packages/sales/src/services/SalesService.ts
@@ -142,6 +142,7 @@ export class SalesService {
 
     const existing = await this.opportunities.getByLeadId(lead.id ?? '');
     if (existing?.id) {
+      await this.reconcileConvertedLead(lead, args.ownerId);
       const currentStage = await this.requireStage(existing.stageId);
       return {
         opportunityId: existing.id,
@@ -180,6 +181,7 @@ export class SalesService {
         lastStageChangeAt: new Date(),
       });
     if (!created) {
+      await this.reconcileConvertedLead(lead, args.ownerId);
       const currentStage = await this.requireStage(opportunity.stageId);
       return {
         opportunityId: opportunity.id ?? '',
@@ -495,6 +497,26 @@ export class SalesService {
       return `${lead.name.trim()} opportunity`;
     }
     return 'New opportunity';
+  }
+
+  private async reconcileConvertedLead(
+    lead: Lead,
+    ownerId?: string | null,
+  ): Promise<void> {
+    const normalizedOwnerId = ownerId?.trim() || null;
+    const needsConversion = lead.status !== 'converted';
+    const needsOwnerUpdate =
+      normalizedOwnerId !== null && lead.ownerId !== normalizedOwnerId;
+    if (!needsConversion && !needsOwnerUpdate) {
+      return;
+    }
+    if (needsConversion) {
+      lead.markConverted();
+    }
+    if (needsOwnerUpdate && normalizedOwnerId) {
+      lead.assign(normalizedOwnerId);
+    }
+    await lead.save();
   }
 
   private mergeTaggedAcquisition(

--- a/packages/sales/src/services/SalesService.ts
+++ b/packages/sales/src/services/SalesService.ts
@@ -223,11 +223,17 @@ export class SalesService {
   async moveOpportunity(args: MoveOpportunityArgs): Promise<Opportunity> {
     const opportunity = await this.requireOpportunity(args.opportunityId);
     const previousStageId = opportunity.stageId;
+    const stageKey = args.stageKey?.trim();
+    if (!args.stageId?.trim() && !stageKey) {
+      throw new Error(
+        'A stage id or stage key is required to move an opportunity',
+      );
+    }
     const stage = args.stageId?.trim()
       ? await this.requireStageForOpportunity(args.stageId, opportunity)
       : await this.resolveStageForTenant(
           opportunity.pipelineId,
-          args.stageKey ?? 'qualified',
+          stageKey as PipelineStageKey,
           opportunity.tenantId,
         );
 
@@ -566,7 +572,10 @@ export class SalesService {
     lastStageChangeAt: Date;
   }): Promise<{ opportunity: Opportunity; created: boolean }> {
     try {
-      const opportunity = await this.opportunities.create(args);
+      const opportunity = await this.opportunities.create({
+        ...args,
+        _insertOnly: true,
+      });
       return { opportunity, created: true };
     } catch (error) {
       if (!this.isDuplicateKeyError(error)) {

--- a/packages/sales/src/services/SalesService.ts
+++ b/packages/sales/src/services/SalesService.ts
@@ -1,0 +1,600 @@
+import type { LeadCollection } from '../collections/LeadCollection.js';
+import type { LeadMergeCollection } from '../collections/LeadMergeCollection.js';
+import type { OpportunityCollection } from '../collections/OpportunityCollection.js';
+import type { PipelineDefinitionCollection } from '../collections/PipelineDefinitionCollection.js';
+import type { PipelineStageCollection } from '../collections/PipelineStageCollection.js';
+import type { SalesActivityCollection } from '../collections/SalesActivityCollection.js';
+import type { Lead } from '../models/Lead.js';
+import type { Opportunity } from '../models/Opportunity.js';
+import type { PipelineDefinition } from '../models/PipelineDefinition.js';
+import type { PipelineStage } from '../models/PipelineStage.js';
+import type {
+  AcquisitionEvent,
+  ConvertLeadToOpportunityArgs,
+  ConvertLeadToOpportunityResult,
+  CreateLeadArgs,
+  DefaultPipelineStageDefinition,
+  EnsureDefaultPipelineResult,
+  LeadMergeSnapshot,
+  MergeLeadArgs,
+  MergeLeadResult,
+  MoveOpportunityArgs,
+  PipelineStageKey,
+  QualifyLeadArgs,
+} from '../types.js';
+import { DEFAULT_PIPELINE_STAGE_DEFINITIONS } from '../types.js';
+
+export interface SalesServiceOptions {
+  leads: LeadCollection;
+  opportunities: OpportunityCollection;
+  pipelines: PipelineDefinitionCollection;
+  stages: PipelineStageCollection;
+  activities: SalesActivityCollection;
+  leadMerges: LeadMergeCollection;
+}
+
+export class SalesService {
+  private readonly leads: LeadCollection;
+  private readonly opportunities: OpportunityCollection;
+  private readonly pipelines: PipelineDefinitionCollection;
+  private readonly stages: PipelineStageCollection;
+  private readonly activities: SalesActivityCollection;
+  private readonly leadMerges: LeadMergeCollection;
+
+  constructor(options: SalesServiceOptions) {
+    this.leads = options.leads;
+    this.opportunities = options.opportunities;
+    this.pipelines = options.pipelines;
+    this.stages = options.stages;
+    this.activities = options.activities;
+    this.leadMerges = options.leadMerges;
+  }
+
+  async createLead(tenantId: string, data: CreateLeadArgs): Promise<Lead> {
+    const lead = await this.leads.create({
+      tenantId,
+      name: data.name,
+      email: data.email ?? '',
+      organization: data.organization ?? '',
+      ownerId: data.ownerId ?? null,
+      status: 'new',
+    });
+
+    if (data.acquisitionEvent) {
+      lead.recordAcquisition(data.acquisitionEvent);
+    }
+
+    await lead.save();
+
+    if (data.acquisitionEvent) {
+      await this.appendActivity({
+        tenantId,
+        leadId: lead.id ?? null,
+        type: 'note',
+        actorId: data.ownerId ?? null,
+        summary: `Lead captured from ${data.acquisitionEvent.source}`,
+        details: {
+          acquisitionEvent: data.acquisitionEvent,
+        },
+      });
+    }
+
+    return lead;
+  }
+
+  async qualifyLead(args: QualifyLeadArgs): Promise<Lead> {
+    const lead = await this.requireLead(args.leadId);
+    lead.qualify(args.actorId, args.summary);
+    await lead.save();
+    await this.appendActivity({
+      tenantId: lead.tenantId,
+      leadId: lead.id ?? null,
+      type: 'qualification',
+      actorId: args.actorId ?? null,
+      summary: args.summary?.trim()
+        ? `Lead qualified: ${args.summary.trim()}`
+        : 'Lead qualified',
+      details: {
+        qualifiedAt: lead.qualifiedAt?.toISOString() ?? null,
+        qualifiedById: lead.qualifiedById,
+      },
+    });
+    return lead;
+  }
+
+  async ensureDefaultPipeline(
+    tenantId: string,
+  ): Promise<EnsureDefaultPipelineResult> {
+    let pipeline = await this.pipelines.getDefault(tenantId);
+    if (!pipeline) {
+      pipeline = await this.pipelines.create({
+        tenantId,
+        key: 'default',
+        name: 'Default Sales Pipeline',
+        description:
+          'Default lead qualification and opportunity progression pipeline',
+        active: true,
+        isDefault: true,
+      });
+      await pipeline.save();
+    }
+
+    await this.normalizeDefaultFlags(tenantId, pipeline);
+    const stages = await this.ensurePipelineStages(
+      pipeline,
+      DEFAULT_PIPELINE_STAGE_DEFINITIONS,
+    );
+
+    return {
+      pipeline: {
+        id: pipeline.id ?? '',
+        key: pipeline.key,
+        name: pipeline.name,
+      },
+      stageIdsByKey: Object.fromEntries(
+        stages
+          .filter((stage) => stage.id)
+          .map((stage) => [stage.key, stage.id as string]),
+      ),
+    };
+  }
+
+  async convertLeadToOpportunity(
+    args: ConvertLeadToOpportunityArgs,
+  ): Promise<ConvertLeadToOpportunityResult> {
+    const lead = await this.requireLead(args.leadId);
+    if (lead.mergedIntoLeadId) {
+      throw new Error(
+        `Lead '${lead.id}' has been merged into '${lead.mergedIntoLeadId}'`,
+      );
+    }
+
+    const existing = await this.opportunities.getByLeadId(lead.id ?? '');
+    if (existing?.id) {
+      const currentStage = await this.requireStage(existing.stageId);
+      return {
+        opportunityId: existing.id,
+        leadId: lead.id ?? '',
+        created: false,
+        stageKey: currentStage.key,
+      };
+    }
+
+    const pipeline =
+      args.pipelineId?.trim() ||
+      (await this.ensureDefaultPipeline(lead.tenantId)).pipeline.id;
+    const stageKey = args.stageKey ?? 'qualified';
+    const stage = await this.resolveStage(pipeline, stageKey);
+
+    const { opportunity, created } =
+      await this.createOpportunityWithRaceHandling({
+        tenantId: lead.tenantId,
+        leadId: lead.id ?? '',
+        pipelineId: pipeline,
+        stageId: stage.id ?? '',
+        ownerId: args.ownerId ?? lead.ownerId,
+        name: args.name ?? this.defaultOpportunityName(lead),
+        expectedValue: args.expectedValue ?? 0.0,
+        currency: args.currency ?? 'USD',
+        nextAction: args.nextAction ?? '',
+        outcome: stage.outcome,
+        lastStageChangeAt: new Date(),
+      });
+    if (!created) {
+      const currentStage = await this.requireStage(opportunity.stageId);
+      return {
+        opportunityId: opportunity.id ?? '',
+        leadId: lead.id ?? '',
+        created: false,
+        stageKey: currentStage.key,
+      };
+    }
+    opportunity.moveTo(stage);
+    await opportunity.save();
+
+    lead.markConverted();
+    if (args.ownerId?.trim()) {
+      lead.assign(args.ownerId);
+    }
+    await lead.save();
+
+    await this.appendActivity({
+      tenantId: lead.tenantId,
+      leadId: lead.id ?? null,
+      opportunityId: opportunity.id ?? null,
+      type: 'conversion',
+      actorId: args.actorId ?? null,
+      summary: `Lead converted into opportunity at ${stage.name}`,
+      details: {
+        opportunityId: opportunity.id,
+        pipelineId: opportunity.pipelineId,
+        stageId: opportunity.stageId,
+        stageKey: stage.key,
+      },
+    });
+
+    return {
+      opportunityId: opportunity.id ?? '',
+      leadId: lead.id ?? '',
+      created: true,
+      stageKey: stage.key,
+    };
+  }
+
+  async moveOpportunity(args: MoveOpportunityArgs): Promise<Opportunity> {
+    const opportunity = await this.requireOpportunity(args.opportunityId);
+    const previousStageId = opportunity.stageId;
+    const stage = args.stageId?.trim()
+      ? await this.requireStage(args.stageId)
+      : await this.resolveStage(
+          opportunity.pipelineId,
+          args.stageKey ?? 'qualified',
+        );
+
+    opportunity.moveTo(stage);
+    if (args.nextAction !== undefined) {
+      opportunity.nextAction = args.nextAction;
+    }
+    await opportunity.save();
+
+    await this.appendActivity({
+      tenantId: opportunity.tenantId,
+      leadId: opportunity.leadId,
+      opportunityId: opportunity.id ?? null,
+      type: stage.terminal ? 'outcome' : 'stage_change',
+      actorId: args.actorId ?? null,
+      summary: stage.terminal
+        ? `Opportunity moved to ${stage.name}`
+        : `Opportunity advanced to ${stage.name}`,
+      details: {
+        fromStageId: previousStageId,
+        toStageId: stage.id,
+        stageKey: stage.key,
+        outcome: stage.outcome,
+        nextAction: opportunity.nextAction,
+      },
+    });
+
+    return opportunity;
+  }
+
+  async mergeLeads(args: MergeLeadArgs): Promise<MergeLeadResult> {
+    if (args.sourceLeadId === args.targetLeadId) {
+      throw new Error('A lead cannot be merged into itself');
+    }
+
+    const source = await this.requireLead(args.sourceLeadId);
+    const target = await this.requireLead(args.targetLeadId);
+    if (source.tenantId !== target.tenantId) {
+      throw new Error('Leads must belong to the same tenant to merge');
+    }
+
+    const existing = await this.leadMerges.findBySourceLeadId(source.id ?? '');
+    if (existing?.id) {
+      if (existing.targetLeadId !== target.id) {
+        throw new Error(
+          `Lead '${source.id}' has already been merged into '${existing.targetLeadId}'`,
+        );
+      }
+      return {
+        mergeId: existing.id,
+        sourceLeadId: source.id ?? '',
+        targetLeadId: target.id ?? '',
+        created: false,
+      };
+    }
+
+    const sourceOpportunity = await this.opportunities.getByLeadId(
+      source.id ?? '',
+    );
+    const sourceActivities = this.combineActivities(
+      await this.activities.forLead(source.id ?? ''),
+      sourceOpportunity?.id
+        ? await this.activities.forOpportunity(sourceOpportunity.id)
+        : [],
+    );
+    const snapshot: LeadMergeSnapshot = {
+      sourceLead: {
+        id: source.id ?? '',
+        tenantId: source.tenantId,
+        name: source.name,
+        email: source.email,
+        organization: source.organization,
+        ownerId: source.ownerId,
+        status: source.status,
+        qualificationSummary: source.qualificationSummary,
+        qualifiedAt: source.qualifiedAt?.toISOString() ?? null,
+        qualifiedById: source.qualifiedById,
+      },
+      sourceAcquisitionHistory: source.getAcquisitionHistory(),
+      sourceActivities: sourceActivities.map((activity) => ({
+        id: activity.id ?? '',
+        type: activity.type,
+        summary: activity.summary,
+        occurredAt: activity.occurredAt.toISOString(),
+        actorId: activity.actorId,
+        details: activity.getDetails(),
+        opportunityId: activity.opportunityId,
+      })),
+      sourceOpportunity: sourceOpportunity
+        ? {
+            id: sourceOpportunity.id ?? '',
+            tenantId: sourceOpportunity.tenantId,
+            leadId: sourceOpportunity.leadId,
+            pipelineId: sourceOpportunity.pipelineId,
+            stageId: sourceOpportunity.stageId,
+            ownerId: sourceOpportunity.ownerId,
+            name: sourceOpportunity.name,
+            expectedValue: sourceOpportunity.expectedValue,
+            currency: sourceOpportunity.currency,
+            nextAction: sourceOpportunity.nextAction,
+            outcome: sourceOpportunity.outcome,
+            closedAt: sourceOpportunity.closedAt?.toISOString() ?? null,
+            lastStageChangeAt:
+              sourceOpportunity.lastStageChangeAt?.toISOString() ?? null,
+          }
+        : null,
+      sourceOpportunityId: sourceOpportunity?.id ?? null,
+    };
+
+    for (const event of snapshot.sourceAcquisitionHistory) {
+      target.recordAcquisition(
+        this.mergeTaggedAcquisition(event, source.id ?? ''),
+      );
+    }
+    if (!target.ownerId && source.ownerId) {
+      target.ownerId = source.ownerId;
+    }
+    await target.save();
+
+    const merge = await this.leadMerges.create({
+      tenantId: target.tenantId,
+      sourceLeadId: source.id ?? '',
+      targetLeadId: target.id ?? '',
+      actorId: args.actorId ?? null,
+      mergedAt: new Date(),
+    });
+    merge.setSourceSnapshot(snapshot);
+    await merge.save();
+
+    source.markMerged(target.id ?? '');
+    await source.save();
+
+    await this.appendActivity({
+      tenantId: target.tenantId,
+      leadId: target.id ?? null,
+      type: 'merge',
+      actorId: args.actorId ?? null,
+      summary: `Merged duplicate lead ${source.name || source.email || source.id}`,
+      details: {
+        mergeId: merge.id,
+        sourceLeadId: source.id,
+        preservedActivityCount: snapshot.sourceActivities.length,
+        preservedAcquisitionCount: snapshot.sourceAcquisitionHistory.length,
+      },
+    });
+
+    return {
+      mergeId: merge.id ?? '',
+      sourceLeadId: source.id ?? '',
+      targetLeadId: target.id ?? '',
+      created: true,
+    };
+  }
+
+  private async normalizeDefaultFlags(
+    tenantId: string,
+    pipeline: PipelineDefinition,
+  ): Promise<void> {
+    const pipelines = await this.pipelines.list({
+      where: { tenantId, isDefault: true },
+    });
+    for (const candidate of pipelines) {
+      const shouldBeDefault = candidate.id === pipeline.id;
+      if (candidate.isDefault !== shouldBeDefault) {
+        candidate.isDefault = shouldBeDefault;
+        await candidate.save();
+      }
+    }
+    if (!pipeline.isDefault) {
+      pipeline.isDefault = true;
+      await pipeline.save();
+    }
+  }
+
+  private async ensurePipelineStages(
+    pipeline: PipelineDefinition,
+    defaults: readonly DefaultPipelineStageDefinition[],
+  ): Promise<PipelineStage[]> {
+    const stages: PipelineStage[] = [];
+    for (const definition of defaults) {
+      let stage = await this.stages.findByKey(
+        pipeline.id ?? '',
+        definition.key,
+      );
+      if (!stage) {
+        stage = await this.stages.create({
+          tenantId: pipeline.tenantId,
+          pipelineId: pipeline.id ?? '',
+          key: definition.key,
+          name: definition.name,
+          sortOrder: definition.sortOrder,
+          terminal: definition.terminal,
+          outcome: definition.outcome,
+        });
+        await stage.save();
+      }
+      stages.push(stage);
+    }
+    return stages.sort((left, right) => left.sortOrder - right.sortOrder);
+  }
+
+  private defaultOpportunityName(lead: Lead): string {
+    if (lead.organization.trim()) {
+      return `${lead.organization.trim()} opportunity`;
+    }
+    if (lead.name.trim()) {
+      return `${lead.name.trim()} opportunity`;
+    }
+    return 'New opportunity';
+  }
+
+  private mergeTaggedAcquisition(
+    event: AcquisitionEvent,
+    sourceLeadId: string,
+  ): AcquisitionEvent {
+    return {
+      ...event,
+      metadata: {
+        ...(event.metadata ?? {}),
+        mergedFromLeadId: sourceLeadId,
+      },
+    };
+  }
+
+  private combineActivities(
+    leadActivities: Awaited<ReturnType<SalesActivityCollection['forLead']>>,
+    opportunityActivities: Awaited<
+      ReturnType<SalesActivityCollection['forOpportunity']>
+    >,
+  ) {
+    const byIdentity = new Map<string, (typeof leadActivities)[number]>();
+    for (const activity of [...leadActivities, ...opportunityActivities]) {
+      const key =
+        activity.id ??
+        `${activity.type}:${activity.occurredAt.toISOString()}:${activity.summary}`;
+      if (!byIdentity.has(key)) {
+        byIdentity.set(key, activity);
+      }
+    }
+    return [...byIdentity.values()].sort(
+      (left, right) => left.occurredAt.getTime() - right.occurredAt.getTime(),
+    );
+  }
+
+  private async appendActivity(args: {
+    tenantId: string;
+    leadId: string | null;
+    opportunityId?: string | null;
+    type:
+      | 'note'
+      | 'qualification'
+      | 'conversion'
+      | 'merge'
+      | 'stage_change'
+      | 'outcome';
+    actorId: string | null;
+    summary: string;
+    details: Record<string, unknown>;
+  }): Promise<void> {
+    const activity = await this.activities.create({
+      tenantId: args.tenantId,
+      leadId: args.leadId,
+      opportunityId: args.opportunityId ?? null,
+      type: args.type,
+      actorId: args.actorId,
+      summary: args.summary,
+      occurredAt: new Date(),
+    });
+    activity.setDetails(args.details);
+    await activity.save();
+  }
+
+  private async createOpportunityWithRaceHandling(args: {
+    tenantId: string;
+    leadId: string;
+    pipelineId: string;
+    stageId: string;
+    ownerId: string | null;
+    name: string;
+    expectedValue: number;
+    currency: string;
+    nextAction: string;
+    outcome: Opportunity['outcome'];
+    lastStageChangeAt: Date;
+  }): Promise<{ opportunity: Opportunity; created: boolean }> {
+    try {
+      const opportunity = await this.opportunities.create(args);
+      return { opportunity, created: true };
+    } catch (error) {
+      if (!this.isDuplicateKeyError(error)) {
+        throw error;
+      }
+      const winner = await this.opportunities.getByLeadId(args.leadId);
+      if (!winner) {
+        throw error;
+      }
+      return { opportunity: winner, created: false };
+    }
+  }
+
+  private async resolveStage(
+    pipelineId: string,
+    stageKey: PipelineStageKey,
+  ): Promise<PipelineStage> {
+    const stage = await this.stages.findByKey(pipelineId, stageKey);
+    if (!stage) {
+      throw new Error(
+        `Pipeline stage '${stageKey}' was not found for pipeline '${pipelineId}'`,
+      );
+    }
+    return stage;
+  }
+
+  private async requireLead(leadId: string): Promise<Lead> {
+    const lead = await this.leads.get({ id: leadId });
+    if (!lead) {
+      throw new Error(`Lead '${leadId}' not found`);
+    }
+    return lead;
+  }
+
+  private async requireOpportunity(
+    opportunityId: string,
+  ): Promise<Opportunity> {
+    const opportunity = await this.opportunities.get({ id: opportunityId });
+    if (!opportunity) {
+      throw new Error(`Opportunity '${opportunityId}' not found`);
+    }
+    return opportunity;
+  }
+
+  private async requireStage(stageId: string): Promise<PipelineStage> {
+    const stage = await this.stages.get({ id: stageId });
+    if (!stage) {
+      throw new Error(`Pipeline stage '${stageId}' not found`);
+    }
+    return stage;
+  }
+
+  private isDuplicateKeyError(err: unknown): boolean {
+    const seen = new Set<unknown>();
+    let current: unknown = err;
+
+    while (current && typeof current === 'object' && !seen.has(current)) {
+      seen.add(current);
+      const value = current as {
+        code?: unknown;
+        message?: unknown;
+        cause?: unknown;
+      };
+      if (
+        value.code === '23505' ||
+        value.code === 'VALIDATION_UNIQUE_CONSTRAINT'
+      ) {
+        return true;
+      }
+      const message = typeof value.message === 'string' ? value.message : '';
+      if (
+        /duplicate key|unique.+violat|code=23505|SQLITE_CONSTRAINT.*UNIQUE/i.test(
+          message,
+        )
+      ) {
+        return true;
+      }
+      current = value.cause;
+    }
+
+    return false;
+  }
+}

--- a/packages/sales/src/services/index.ts
+++ b/packages/sales/src/services/index.ts
@@ -1,0 +1,1 @@
+export { SalesService, type SalesServiceOptions } from './SalesService.js';

--- a/packages/sales/src/svelte/components/LeadList.svelte
+++ b/packages/sales/src/svelte/components/LeadList.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+import { Button } from '@happyvertical/smrt-ui/ui';
+import type { SalesLeadListItem } from '../types.js';
+
+export interface Props {
+  leads: SalesLeadListItem[];
+  loading?: boolean;
+  emptyMessage?: string;
+  onselect?: (lead: SalesLeadListItem) => void;
+  onassign?: (lead: SalesLeadListItem) => void;
+  onqualify?: (lead: SalesLeadListItem) => void;
+}
+
+const {
+  leads,
+  loading = false,
+  emptyMessage = 'No leads in this queue.',
+  onselect,
+  onassign,
+  onqualify,
+}: Props = $props();
+
+function cardClass(status: string): string {
+  if (status === 'qualified') return 'lead-card lead-qualified';
+  if (status === 'converted') return 'lead-card lead-converted';
+  if (status === 'merged') return 'lead-card lead-merged';
+  return 'lead-card';
+}
+</script>
+
+<section class="lead-list" aria-label="Lead list">
+  {#if loading}
+    <p class="state-message">Loading leads...</p>
+  {:else if leads.length === 0}
+    <p class="state-message">{emptyMessage}</p>
+  {:else}
+    {#each leads as lead (lead.id)}
+      <article class={cardClass(lead.status)}>
+        <Button class="lead-main" type="button" onclick={() => onselect?.(lead)}>
+          <span class="lead-status">{lead.status}</span>
+          <strong>{lead.name}</strong>
+          {#if lead.organization}
+            <span>{lead.organization}</span>
+          {/if}
+          {#if lead.email}
+            <span class="secondary">{lead.email}</span>
+          {/if}
+          <span class="secondary">
+            {lead.ownerName ? `Assigned to ${lead.ownerName}` : 'Unassigned'}
+          </span>
+          {#if lead.qualificationSummary}
+            <span class="qualification">{lead.qualificationSummary}</span>
+          {/if}
+        </Button>
+        <div class="actions">
+          <Button type="button" class="action-button" onclick={() => onassign?.(lead)}>
+            Assign
+          </Button>
+          <Button
+            type="button"
+            class="action-button action-primary"
+            onclick={() => onqualify?.(lead)}
+            disabled={lead.status === 'qualified' || lead.status === 'converted'}
+          >
+            Qualify
+          </Button>
+        </div>
+      </article>
+    {/each}
+  {/if}
+</section>
+
+<style>
+  .lead-list {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .lead-card {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.75rem;
+    padding: 1rem;
+    border-radius: 1rem;
+    border: 1px solid color-mix(in srgb, #1d3557 14%, white);
+    background:
+      linear-gradient(140deg, rgba(248, 250, 252, 0.98), rgba(235, 241, 248, 0.88)),
+      radial-gradient(circle at top left, rgba(29, 53, 87, 0.12), transparent 55%);
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+  }
+
+  .lead-qualified {
+    border-color: rgba(56, 161, 105, 0.35);
+  }
+
+  .lead-converted {
+    border-color: rgba(37, 99, 235, 0.35);
+  }
+
+  .lead-merged {
+    opacity: 0.8;
+  }
+
+  .lead-main {
+    display: grid;
+    gap: 0.25rem;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    text-align: left;
+    cursor: pointer;
+    color: inherit;
+  }
+
+  .lead-status {
+    width: fit-content;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    background: rgba(29, 53, 87, 0.08);
+    color: #1d3557;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .secondary {
+    color: #52606d;
+    font-size: 0.92rem;
+  }
+
+  .qualification {
+    color: #0f766e;
+    font-size: 0.92rem;
+  }
+
+  .actions {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.5rem;
+  }
+
+  .action-button {
+    min-width: 7rem;
+    padding: 0.6rem 0.85rem;
+    border-radius: 999px;
+    border: 1px solid rgba(29, 53, 87, 0.18);
+    background: rgba(255, 255, 255, 0.78);
+    color: #1d3557;
+  }
+
+  .action-primary {
+    background: #1d3557;
+    color: white;
+  }
+
+  .state-message {
+    padding: 2rem 1rem;
+    border-radius: 1rem;
+    text-align: center;
+    color: #52606d;
+    background: rgba(241, 245, 249, 0.9);
+  }
+
+  @media (max-width: 720px) {
+    .lead-card {
+      grid-template-columns: 1fr;
+    }
+
+    .actions {
+      flex-direction: row;
+      justify-content: stretch;
+    }
+
+    .action-button {
+      flex: 1 1 auto;
+    }
+  }
+</style>

--- a/packages/sales/src/svelte/components/LeadList.svelte
+++ b/packages/sales/src/svelte/components/LeadList.svelte
@@ -60,7 +60,7 @@ function cardClass(status: string): string {
             type="button"
             class="action-button action-primary"
             onclick={() => onqualify?.(lead)}
-            disabled={lead.status === 'qualified' || lead.status === 'converted'}
+            disabled={lead.status !== 'new'}
           >
             Qualify
           </Button>

--- a/packages/sales/src/svelte/components/OpportunityBoard.svelte
+++ b/packages/sales/src/svelte/components/OpportunityBoard.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+import { Button } from '@happyvertical/smrt-ui/ui';
+import type {
+  SalesBoardOpportunity,
+  SalesPipelineStageView,
+} from '../types.js';
+
+export interface Props {
+  stages: SalesPipelineStageView[];
+  opportunities: SalesBoardOpportunity[];
+  onmove?: (
+    opportunity: SalesBoardOpportunity,
+    direction: 'previous' | 'next',
+  ) => void;
+}
+
+const { stages, opportunities, onmove }: Props = $props();
+
+const opportunitiesByStage = $derived(
+  Object.fromEntries(
+    stages.map((stage) => [
+      stage.id,
+      opportunities.filter((opportunity) => opportunity.stageId === stage.id),
+    ]),
+  ),
+);
+
+function formatCurrency(value: number, currency = 'USD'): string {
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+</script>
+
+<section class="board" aria-label="Opportunity board">
+  {#each stages as stage, index (stage.id)}
+    <section class="column">
+      <header class="column-header">
+        <div>
+          <strong>{stage.name}</strong>
+          <p>{stage.terminal ? `Outcome: ${stage.outcome ?? 'closed'}` : 'Open stage'}</p>
+        </div>
+        <span class="count">{(opportunitiesByStage[stage.id] ?? []).length}</span>
+      </header>
+
+      <div class="column-cards">
+        {#if (opportunitiesByStage[stage.id] ?? []).length === 0}
+          <p class="empty">No opportunities</p>
+        {:else}
+          {#each opportunitiesByStage[stage.id] ?? [] as opportunity (opportunity.id)}
+            <article class="card">
+              <div class="card-top">
+                <strong>{opportunity.name}</strong>
+                <span class="value">{formatCurrency(opportunity.expectedValue, opportunity.currency)}</span>
+              </div>
+              <p class="meta">
+                {opportunity.ownerName ?? 'Unassigned'} • {opportunity.nextAction || 'No next action'}
+              </p>
+              <div class="controls">
+                <Button
+                  type="button"
+                  class="move"
+                  onclick={() => onmove?.(opportunity, 'previous')}
+                  disabled={index === 0}
+                >
+                  Previous
+                </Button>
+                <Button
+                  type="button"
+                  class="move move-primary"
+                  onclick={() => onmove?.(opportunity, 'next')}
+                  disabled={index === stages.length - 1}
+                >
+                  Next
+                </Button>
+              </div>
+            </article>
+          {/each}
+        {/if}
+      </div>
+    </section>
+  {/each}
+</section>
+
+<style>
+  .board {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+    gap: 1rem;
+  }
+
+  .column {
+    display: grid;
+    gap: 0.9rem;
+    padding: 1rem;
+    border-radius: 1.2rem;
+    background:
+      linear-gradient(180deg, rgba(251, 252, 253, 0.98), rgba(235, 240, 245, 0.96)),
+      radial-gradient(circle at top, rgba(41, 128, 185, 0.12), transparent 60%);
+    border: 1px solid rgba(29, 53, 87, 0.12);
+    min-height: 20rem;
+  }
+
+  .column-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    align-items: flex-start;
+  }
+
+  .column-header p {
+    margin: 0.2rem 0 0;
+    color: #52606d;
+    font-size: 0.88rem;
+  }
+
+  .count {
+    min-width: 2rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 999px;
+    background: rgba(29, 53, 87, 0.08);
+    text-align: center;
+  }
+
+  .column-cards {
+    display: grid;
+    gap: 0.8rem;
+    align-content: start;
+  }
+
+  .card {
+    display: grid;
+    gap: 0.7rem;
+    padding: 0.95rem;
+    border-radius: 1rem;
+    background: rgba(255, 255, 255, 0.92);
+    border: 1px solid rgba(29, 53, 87, 0.12);
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+  }
+
+  .card-top {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    align-items: baseline;
+  }
+
+  .value {
+    color: #0f766e;
+    font-weight: 700;
+  }
+
+  .meta {
+    margin: 0;
+    color: #52606d;
+    font-size: 0.9rem;
+  }
+
+  .controls {
+    display: flex;
+    gap: 0.45rem;
+  }
+
+  :global(.move) {
+    flex: 1 1 auto;
+    padding: 0.55rem 0.7rem;
+    border-radius: 999px;
+    border: 1px solid rgba(29, 53, 87, 0.18);
+    background: rgba(255, 255, 255, 0.8);
+  }
+
+  :global(.move-primary) {
+    background: #2a9d8f;
+    border-color: #2a9d8f;
+    color: white;
+  }
+
+  .empty {
+    margin: 0;
+    padding: 1rem 0.25rem;
+    color: #64748b;
+    text-align: center;
+  }
+</style>

--- a/packages/sales/src/svelte/components/OpportunityBoard.svelte
+++ b/packages/sales/src/svelte/components/OpportunityBoard.svelte
@@ -163,7 +163,7 @@ function formatCurrency(value: number, currency = 'USD'): string {
     gap: 0.45rem;
   }
 
-  :global(.move) {
+  .board :global(.move) {
     flex: 1 1 auto;
     padding: 0.55rem 0.7rem;
     border-radius: 999px;
@@ -171,7 +171,7 @@ function formatCurrency(value: number, currency = 'USD'): string {
     background: rgba(255, 255, 255, 0.8);
   }
 
-  :global(.move-primary) {
+  .board :global(.move-primary) {
     background: #2a9d8f;
     border-color: #2a9d8f;
     color: white;

--- a/packages/sales/src/svelte/components/SalesDetail.svelte
+++ b/packages/sales/src/svelte/components/SalesDetail.svelte
@@ -62,7 +62,7 @@ function formatTime(item: SalesActivityView | { occurredAt: string }): string {
         type="button"
         class="primary"
         onclick={() => onqualify?.(record.lead.id)}
-        disabled={record.lead.status === 'qualified' || record.lead.status === 'converted'}
+        disabled={record.lead.status !== 'new'}
       >
         Qualify
       </Button>
@@ -70,6 +70,7 @@ function formatTime(item: SalesActivityView | { occurredAt: string }): string {
   </header>
 
   {#if record.opportunity}
+    {@const opportunityId = record.opportunity.id}
     <section class="card">
       <div class="card-head">
         <div>
@@ -84,7 +85,7 @@ function formatTime(item: SalesActivityView | { occurredAt: string }): string {
           <Button
             type="button"
             class={stage.id === record.opportunity.stageId ? 'active' : ''}
-            onclick={() => onmoveStage?.(record.opportunity?.id ?? '', stage.id)}
+            onclick={() => onmoveStage?.(opportunityId, stage.id)}
           >
             {stage.name}
           </Button>
@@ -199,7 +200,7 @@ function formatTime(item: SalesActivityView | { occurredAt: string }): string {
     flex-wrap: wrap;
   }
 
-  :global(button) {
+  .detail :global(button) {
     padding: 0.6rem 0.85rem;
     border-radius: 999px;
     border: 1px solid rgba(29, 53, 87, 0.16);
@@ -207,7 +208,7 @@ function formatTime(item: SalesActivityView | { occurredAt: string }): string {
     color: #1d3557;
   }
 
-  :global(button.primary),
+  .detail :global(button.primary),
   .stage-row :global(button.active) {
     background: #1d3557;
     color: white;

--- a/packages/sales/src/svelte/components/SalesDetail.svelte
+++ b/packages/sales/src/svelte/components/SalesDetail.svelte
@@ -1,0 +1,257 @@
+<script lang="ts">
+import { Button } from '@happyvertical/smrt-ui/ui';
+import type {
+  SalesActivityView,
+  SalesDetailRecord,
+  SalesPipelineStageView,
+} from '../types.js';
+
+export interface Props {
+  record: SalesDetailRecord;
+  stages?: SalesPipelineStageView[];
+  onassign?: (leadId: string) => void;
+  onqualify?: (leadId: string) => void;
+  onmoveStage?: (opportunityId: string, stageId: string) => void;
+}
+
+const {
+  record,
+  stages = [],
+  onassign,
+  onqualify,
+  onmoveStage,
+}: Props = $props();
+
+const activityItems = $derived(record.activities ?? []);
+const acquisitionItems = $derived(record.acquisitions ?? []);
+
+function formatCurrency(value: number, currency = 'USD'): string {
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function formatTime(item: SalesActivityView | { occurredAt: string }): string {
+  const value = new Date(item.occurredAt);
+  return Number.isNaN(value.getTime())
+    ? item.occurredAt
+    : value.toLocaleString();
+}
+</script>
+
+<section class="detail">
+  <header class="hero">
+    <div>
+      <span class="eyebrow">{record.lead.status}</span>
+      <h2>{record.lead.name}</h2>
+      <p>
+        {record.lead.organization || 'Independent buyer'}
+        {#if record.lead.email}
+          • {record.lead.email}
+        {/if}
+      </p>
+      <p class="owner">
+        {record.ownerName ? `Owned by ${record.ownerName}` : 'No owner assigned'}
+      </p>
+    </div>
+    <div class="hero-actions">
+      <Button type="button" onclick={() => onassign?.(record.lead.id)}>Assign</Button>
+      <Button
+        type="button"
+        class="primary"
+        onclick={() => onqualify?.(record.lead.id)}
+        disabled={record.lead.status === 'qualified' || record.lead.status === 'converted'}
+      >
+        Qualify
+      </Button>
+    </div>
+  </header>
+
+  {#if record.opportunity}
+    <section class="card">
+      <div class="card-head">
+        <div>
+          <h3>{record.opportunity.name}</h3>
+          <p>{record.opportunity.stageName}</p>
+        </div>
+        <strong>{formatCurrency(record.opportunity.expectedValue, record.opportunity.currency)}</strong>
+      </div>
+      <p class="next-action">{record.opportunity.nextAction || 'No next action captured yet.'}</p>
+      <div class="stage-row">
+        {#each stages as stage (stage.id)}
+          <Button
+            type="button"
+            class={stage.id === record.opportunity.stageId ? 'active' : ''}
+            onclick={() => onmoveStage?.(record.opportunity?.id ?? '', stage.id)}
+          >
+            {stage.name}
+          </Button>
+        {/each}
+      </div>
+      {#if record.opportunity.outcome && record.opportunity.outcome !== 'open'}
+        <p class="outcome">Outcome: {record.opportunity.outcome}</p>
+      {/if}
+    </section>
+  {/if}
+
+  <div class="grid">
+    <section class="card">
+      <h3>Acquisition</h3>
+      {#if acquisitionItems.length === 0}
+        <p class="muted">No acquisition history recorded.</p>
+      {:else}
+        <ul>
+          {#each acquisitionItems as item}
+            <li>
+              <strong>{item.source}</strong>
+              <span>{formatTime(item)}</span>
+              {#if item.campaign}
+                <span class="muted">{item.campaign}</span>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+
+    <section class="card">
+      <h3>Timeline</h3>
+      {#if activityItems.length === 0}
+        <p class="muted">No activity yet.</p>
+      {:else}
+        <ul>
+          {#each activityItems as item}
+            <li>
+              <strong>{item.summary}</strong>
+              <span>{formatTime(item)}</span>
+              {#if item.actorName}
+                <span class="muted">{item.actorName}</span>
+              {/if}
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+  </div>
+
+  {#if record.outcomes && record.outcomes.length > 0}
+    <section class="card">
+      <h3>Outcomes</h3>
+      <ul class="outcomes">
+        {#each record.outcomes as outcome}
+          <li>{outcome}</li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
+</section>
+
+<style>
+  .detail {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .hero,
+  .card {
+    padding: 1.15rem;
+    border-radius: 1.25rem;
+    border: 1px solid rgba(29, 53, 87, 0.12);
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(240, 244, 248, 0.96)),
+      radial-gradient(circle at top right, rgba(42, 157, 143, 0.16), transparent 52%);
+  }
+
+  .hero {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: start;
+  }
+
+  .eyebrow {
+    display: inline-block;
+    margin-bottom: 0.5rem;
+    color: #0f766e;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.74rem;
+  }
+
+  h2,
+  h3,
+  p,
+  ul {
+    margin: 0;
+  }
+
+  .owner,
+  .muted {
+    color: #64748b;
+  }
+
+  .hero-actions,
+  .stage-row {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  :global(button) {
+    padding: 0.6rem 0.85rem;
+    border-radius: 999px;
+    border: 1px solid rgba(29, 53, 87, 0.16);
+    background: rgba(255, 255, 255, 0.82);
+    color: #1d3557;
+  }
+
+  :global(button.primary),
+  .stage-row :global(button.active) {
+    background: #1d3557;
+    color: white;
+  }
+
+  .card-head {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: baseline;
+  }
+
+  .next-action,
+  .outcome {
+    margin-top: 0.75rem;
+    color: #334155;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    gap: 1rem;
+  }
+
+  ul {
+    display: grid;
+    gap: 0.75rem;
+    list-style: none;
+    padding: 0;
+    margin-top: 0.75rem;
+  }
+
+  li {
+    display: grid;
+    gap: 0.15rem;
+  }
+
+  .outcomes {
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  }
+
+  @media (max-width: 720px) {
+    .hero {
+      flex-direction: column;
+    }
+  }
+</style>

--- a/packages/sales/src/svelte/index.ts
+++ b/packages/sales/src/svelte/index.ts
@@ -1,0 +1,34 @@
+import { ModuleUIRegistry } from '@happyvertical/smrt-ui/registry';
+import type { ComponentProps } from 'svelte';
+import { SALES_MODULE_META } from '../ui.js';
+import LeadList from './components/LeadList.svelte';
+import OpportunityBoard from './components/OpportunityBoard.svelte';
+import SalesDetail from './components/SalesDetail.svelte';
+
+export { LeadList, OpportunityBoard, SalesDetail };
+
+export type LeadListProps = ComponentProps<typeof LeadList>;
+export type OpportunityBoardProps = ComponentProps<typeof OpportunityBoard>;
+export type SalesDetailProps = ComponentProps<typeof SalesDetail>;
+
+export type {
+  SalesAcquisitionView,
+  SalesActivityView,
+  SalesBoardOpportunity,
+  SalesDetailRecord,
+  SalesLeadListItem,
+  SalesPipelineStageView,
+} from './types.js';
+
+ModuleUIRegistry.registerModule(SALES_MODULE_META);
+ModuleUIRegistry.register('@happyvertical/smrt-sales', 'lead-list', LeadList);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-sales',
+  'opportunity-board',
+  OpportunityBoard,
+);
+ModuleUIRegistry.register(
+  '@happyvertical/smrt-sales',
+  'sales-detail',
+  SalesDetail,
+);

--- a/packages/sales/src/svelte/types.ts
+++ b/packages/sales/src/svelte/types.ts
@@ -1,0 +1,62 @@
+export interface SalesLeadListItem {
+  id: string;
+  name: string;
+  email?: string;
+  organization?: string;
+  ownerName?: string | null;
+  status: string;
+  qualificationSummary?: string;
+}
+
+export interface SalesPipelineStageView {
+  id: string;
+  key: string;
+  name: string;
+  terminal?: boolean;
+  outcome?: string;
+}
+
+export interface SalesBoardOpportunity {
+  id: string;
+  name: string;
+  ownerName?: string | null;
+  stageId: string;
+  stageKey?: string;
+  expectedValue: number;
+  currency?: string;
+  nextAction?: string;
+  outcome?: string;
+}
+
+export interface SalesActivityView {
+  id: string;
+  type: string;
+  summary: string;
+  occurredAt: string;
+  actorName?: string | null;
+}
+
+export interface SalesAcquisitionView {
+  source: string;
+  occurredAt: string;
+  campaign?: string;
+}
+
+export interface SalesDetailRecord {
+  lead: SalesLeadListItem;
+  ownerName?: string | null;
+  opportunity?: {
+    id: string;
+    name: string;
+    stageId: string;
+    stageName: string;
+    stageKey?: string;
+    expectedValue: number;
+    currency?: string;
+    nextAction?: string;
+    outcome?: string;
+  } | null;
+  acquisitions?: SalesAcquisitionView[];
+  activities?: SalesActivityView[];
+  outcomes?: string[];
+}

--- a/packages/sales/src/types.ts
+++ b/packages/sales/src/types.ts
@@ -1,0 +1,279 @@
+export type BuiltInPipelineStageKey =
+  | 'new'
+  | 'qualified'
+  | 'discovery'
+  | 'proposal'
+  | 'negotiation'
+  | 'closed_won'
+  | 'closed_lost';
+
+export type PipelineStageKey = BuiltInPipelineStageKey | (string & {});
+
+export const DEFAULT_PIPELINE_STAGE_DEFINITIONS = [
+  {
+    key: 'new',
+    name: 'New',
+    sortOrder: 0,
+    terminal: false,
+    outcome: 'open',
+  },
+  {
+    key: 'qualified',
+    name: 'Qualified',
+    sortOrder: 1,
+    terminal: false,
+    outcome: 'open',
+  },
+  {
+    key: 'discovery',
+    name: 'Discovery',
+    sortOrder: 2,
+    terminal: false,
+    outcome: 'open',
+  },
+  {
+    key: 'proposal',
+    name: 'Proposal',
+    sortOrder: 3,
+    terminal: false,
+    outcome: 'open',
+  },
+  {
+    key: 'negotiation',
+    name: 'Negotiation',
+    sortOrder: 4,
+    terminal: false,
+    outcome: 'open',
+  },
+  {
+    key: 'closed_won',
+    name: 'Closed Won',
+    sortOrder: 5,
+    terminal: true,
+    outcome: 'won',
+  },
+  {
+    key: 'closed_lost',
+    name: 'Closed Lost',
+    sortOrder: 6,
+    terminal: true,
+    outcome: 'lost',
+  },
+] as const satisfies readonly DefaultPipelineStageDefinition[];
+
+export type LeadStatus =
+  | 'new'
+  | 'qualified'
+  | 'converted'
+  | 'merged'
+  | 'disqualified';
+
+export type OpportunityOutcome = 'open' | 'won' | 'lost';
+
+export type SalesActivityType =
+  | 'note'
+  | 'email'
+  | 'call'
+  | 'meeting'
+  | 'stage_change'
+  | 'assignment'
+  | 'qualification'
+  | 'conversion'
+  | 'merge'
+  | 'outcome';
+
+export interface AcquisitionEvent {
+  source: string;
+  occurredAt: string;
+  campaign?: string;
+  externalId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ActivityDetails {
+  [key: string]: unknown;
+}
+
+export interface SalesActivitySnapshot {
+  id: string;
+  type: SalesActivityType;
+  summary: string;
+  occurredAt: string;
+  actorId: string | null;
+  details: ActivityDetails;
+  opportunityId?: string | null;
+}
+
+export interface OpportunitySnapshot {
+  id: string;
+  tenantId: string;
+  leadId: string;
+  pipelineId: string;
+  stageId: string;
+  ownerId: string | null;
+  name: string;
+  expectedValue: number;
+  currency: string;
+  nextAction: string;
+  outcome: OpportunityOutcome;
+  closedAt: string | null;
+  lastStageChangeAt: string | null;
+}
+
+export interface LeadMergeSnapshot {
+  sourceLead: {
+    id: string;
+    tenantId: string;
+    name: string;
+    email: string;
+    organization: string;
+    ownerId: string | null;
+    status: LeadStatus;
+    qualificationSummary: string;
+    qualifiedAt: string | null;
+    qualifiedById: string | null;
+  };
+  sourceAcquisitionHistory: AcquisitionEvent[];
+  sourceActivities: SalesActivitySnapshot[];
+  sourceOpportunity: OpportunitySnapshot | null;
+  sourceOpportunityId: string | null;
+}
+
+export interface DefaultPipelineStageDefinition {
+  key: PipelineStageKey;
+  name: string;
+  sortOrder: number;
+  terminal: boolean;
+  outcome: OpportunityOutcome;
+}
+
+export interface LeadOptions {
+  tenantId?: string;
+  name?: string;
+  email?: string;
+  organization?: string;
+  ownerId?: string | null;
+  status?: LeadStatus;
+  qualificationSummary?: string;
+  qualifiedAt?: Date | null;
+  qualifiedById?: string | null;
+  acquisitionHistory?: string;
+  mergedIntoLeadId?: string | null;
+}
+
+export interface PipelineDefinitionOptions {
+  tenantId?: string;
+  key?: string;
+  name?: string;
+  description?: string;
+  active?: boolean;
+  isDefault?: boolean;
+}
+
+export interface PipelineStageOptions {
+  tenantId?: string;
+  pipelineId?: string;
+  key?: PipelineStageKey;
+  name?: string;
+  sortOrder?: number;
+  terminal?: boolean;
+  outcome?: OpportunityOutcome;
+}
+
+export interface OpportunityOptions {
+  tenantId?: string;
+  leadId?: string;
+  pipelineId?: string;
+  stageId?: string;
+  ownerId?: string | null;
+  name?: string;
+  expectedValue?: number;
+  currency?: string;
+  nextAction?: string;
+  outcome?: OpportunityOutcome;
+  closedAt?: Date | null;
+  lastStageChangeAt?: Date | null;
+}
+
+export interface SalesActivityOptions {
+  tenantId?: string;
+  leadId?: string | null;
+  opportunityId?: string | null;
+  type?: SalesActivityType;
+  actorId?: string | null;
+  summary?: string;
+  details?: string;
+  occurredAt?: Date;
+}
+
+export interface LeadMergeOptions {
+  tenantId?: string;
+  sourceLeadId?: string;
+  targetLeadId?: string;
+  actorId?: string | null;
+  sourceSnapshot?: string;
+  mergedAt?: Date;
+}
+
+export interface EnsureDefaultPipelineResult {
+  pipeline: {
+    id: string;
+    key: string;
+    name: string;
+  };
+  stageIdsByKey: Record<string, string>;
+}
+
+export interface CreateLeadArgs {
+  name: string;
+  email?: string;
+  organization?: string;
+  ownerId?: string | null;
+  acquisitionEvent?: AcquisitionEvent;
+}
+
+export interface QualifyLeadArgs {
+  leadId: string;
+  actorId?: string | null;
+  summary?: string;
+}
+
+export interface ConvertLeadToOpportunityArgs {
+  leadId: string;
+  actorId?: string | null;
+  pipelineId?: string;
+  stageKey?: PipelineStageKey;
+  ownerId?: string | null;
+  name?: string;
+  expectedValue?: number;
+  currency?: string;
+  nextAction?: string;
+}
+
+export interface ConvertLeadToOpportunityResult {
+  opportunityId: string;
+  leadId: string;
+  created: boolean;
+  stageKey: PipelineStageKey;
+}
+
+export interface MoveOpportunityArgs {
+  opportunityId: string;
+  actorId?: string | null;
+  stageId?: string;
+  stageKey?: PipelineStageKey;
+  nextAction?: string;
+}
+
+export interface MergeLeadArgs {
+  sourceLeadId: string;
+  targetLeadId: string;
+  actorId?: string | null;
+}
+
+export interface MergeLeadResult {
+  mergeId: string;
+  sourceLeadId: string;
+  targetLeadId: string;
+  created: boolean;
+}

--- a/packages/sales/src/ui.ts
+++ b/packages/sales/src/ui.ts
@@ -1,0 +1,58 @@
+import type { ModuleUISlot, SmrtModuleMeta } from '@happyvertical/smrt-types';
+
+export const SALES_UI_SLOTS: Record<string, ModuleUISlot> = {
+  'lead-list': {
+    id: 'lead-list',
+    label: 'Lead List',
+    description:
+      'Lead queue with assignment and qualification actions for sales reps',
+    icon: 'users',
+    category: 'list',
+    order: 1,
+    propsInterface: 'LeadListProps',
+  },
+  'opportunity-board': {
+    id: 'opportunity-board',
+    label: 'Opportunity Board',
+    description:
+      'Pipeline board showing stage movement, value, next action, and outcomes',
+    icon: 'columns-3',
+    category: 'dashboard',
+    order: 2,
+    propsInterface: 'OpportunityBoardProps',
+  },
+  'sales-detail': {
+    id: 'sales-detail',
+    label: 'Sales Detail',
+    description:
+      'Detail surface for lead and opportunity history, activities, and outcomes',
+    icon: 'panel-right',
+    category: 'detail',
+    order: 3,
+    propsInterface: 'SalesDetailProps',
+  },
+};
+
+export const SALES_MODULE_META: SmrtModuleMeta = {
+  name: '@happyvertical/smrt-sales',
+  displayName: 'Sales',
+  description:
+    'Tenant-scoped CRM primitives for leads, opportunities, pipelines, and sales workflows',
+  uiSlots: SALES_UI_SLOTS,
+  models: [
+    'Lead',
+    'Opportunity',
+    'PipelineDefinition',
+    'PipelineStage',
+    'SalesActivity',
+    'LeadMerge',
+  ],
+  collections: [
+    'LeadCollection',
+    'OpportunityCollection',
+    'PipelineDefinitionCollection',
+    'PipelineStageCollection',
+    'SalesActivityCollection',
+    'LeadMergeCollection',
+  ],
+};

--- a/packages/sales/tsconfig.json
+++ b/packages/sales/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": { "composite": true, "outDir": "./dist", "rootDir": "./src", "tsBuildInfoFile": "./dist/.tsbuildinfo", "types": ["node"] },
+  "include": ["src/**/*"],
+  "exclude": ["src/svelte/**/*", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/sales/tsconfig.svelte.json
+++ b/packages/sales/tsconfig.svelte.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "rootDir": ".", "types": ["node", "svelte"] },
+  "include": ["src/**/*", "ambient.d.ts"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/sales/vite.config.ts
+++ b/packages/sales/vite.config.ts
@@ -1,0 +1,3 @@
+import { createPackageConfig } from '../../vite.config.base.js';
+
+export default createPackageConfig('sales', { svelte: 'svelte' });

--- a/packages/sales/vite.config.ts
+++ b/packages/sales/vite.config.ts
@@ -1,3 +1,6 @@
 import { createPackageConfig } from '../../vite.config.base.js';
 
-export default createPackageConfig('sales', { svelte: 'svelte' });
+export default createPackageConfig('sales', {
+  entries: ['ui'],
+  svelte: 'svelte',
+});

--- a/packages/sales/vitest.config.ts
+++ b/packages/sales/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+import { smrtVitestPlugin } from '../vitest/src/index.ts';
+
+export default defineConfig({
+  plugins: [smrtVitestPlugin({ verbose: true })],
+  test: { globals: true, environment: 'node', include: ['src/**/*.test.ts'], testTimeout: 60000, hookTimeout: 60000, fileParallelism: false, pool: 'forks', singleFork: true },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1825,6 +1825,46 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  packages/sales:
+    dependencies:
+      '@happyvertical/smrt-core':
+        specifier: workspace:*
+        version: link:../core
+      '@happyvertical/smrt-tenancy':
+        specifier: workspace:*
+        version: link:../tenancy
+      '@happyvertical/smrt-types':
+        specifier: workspace:*
+        version: link:../types
+      '@happyvertical/smrt-ui':
+        specifier: workspace:*
+        version: link:../smrt-ui
+    devDependencies:
+      '@happyvertical/smrt-vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@sveltejs/package':
+        specifier: ^2.5.8
+        version: 2.5.8(svelte@5.56.4)(typescript@5.9.3)
+      '@types/node':
+        specifier: 24.13.2
+        version: 24.13.2
+      svelte:
+        specifier: ^5.56.4
+        version: 5.56.4
+      svelte-check:
+        specifier: ^4.7.1
+        version: 4.7.1(picomatch@4.0.5)(svelte@5.56.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.1.3
+        version: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+
   packages/scanner:
     dependencies:
       fast-glob:


### PR DESCRIPTION
## Summary

- add tenant-scoped Lead, Opportunity, PipelineDefinition/Stage, SalesActivity, and LeadMerge contracts
- provide configurable default sales stages, idempotent/concurrency-safe conversion, tenant-safe stage movement, ownership, and duplicate-merge audit/history preservation
- expose generated REST, CLI, and MCP operations and reusable Svelte lead list, opportunity board, and detail surfaces
- add package, service, model, manifest, and Svelte compilation tests

## Validation

- `pnpm --filter @happyvertical/smrt-sales test` — 13 tests passed
- `pnpm --filter @happyvertical/smrt-sales typecheck` — passed; Svelte check reported 0 errors and 0 warnings
- `pnpm --filter @happyvertical/smrt-sales build` — passed; generated manifest contains 12 SMRT objects and emits the `ui` entry
- `pnpm --filter @happyvertical/smrt-sales verify:pack` — passed
- `pnpm exec biome check <changed files>` — passed
- `node scripts/check-raw-primitives.mjs` — passed
- pre-commit and pre-push hooks — passed

## Review cycle

- Addressed all 9 GitHub Copilot/Codex review threads, including strict-insert conversion race handling, invalid lead-state transitions, explicit stage selection, normalized merge IDs, and component-local CSS.
- All review threads are resolved on head `d14adb4bc1100b462af605ca7e75280d2f9fdeae`.
- Codex CLI remains unavailable because the configured ChatGPT account rejects `gpt-5.3-codex` as unsupported.
- Copilot CLI remains unavailable because no independent OAuth/fine-grained-token session is configured; the classic `ghp_` credential is rejected.
- Claude CLI fallback is unavailable because it has no authenticated session. Static security scan, targeted tests, typecheck/Svelte diagnostics, package build/pack verification, Biome, and repository hooks passed. A GitHub Codex re-review was requested on the current head.

Closes #1924
