### PR TITLE
fix(playground): support Vite 7 consumers

### DIFF
--- a/packages/smrt-playground/package.json
+++ b/packages/smrt-playground/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "svelte": "^5.56.4",
-    "vite": "^8.1.3"
+    "vite": "^7.3.1 || ^8.1.3"
   },
   "peerDependenciesMeta": {
     "svelte": {

--- a/packages/smrt-playground/package.json
+++ b/packages/smrt-playground/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "svelte": "^5.56.4",
-    "vite": "^7.3.1 || ^8.1.3"
+    "vite": "^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {
     "svelte": {


### PR DESCRIPTION
## Summary
- widen the optional `vite` peer range to support Vite 7 and Vite 8
- keep the package build toolchain on Vite 8

This lets existing consumers upgrade to SMRT 0.39.x without an unrelated Vite/Vitest migration. The playground plugin only uses `normalizePath` and the stable `Plugin` type, both available in Vite 7.

## Validation
- `pnpm --filter @happyvertical/smrt-playground test`
- `pnpm --filter @happyvertical/smrt-ui build`
- `pnpm --filter @happyvertical/smrt-playground typecheck`
- `pnpm --filter @happyvertical/smrt-playground build`
- `pnpm --filter @happyvertical/smrt-playground verify:pack`
- `pnpm knowledge:check --changed --strict --format markdown`