### PR TITLE
feat(support): smrt-support — AI-first Support Cases, routing, targets, and service time (epic #1934)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -47,6 +47,7 @@
       "@happyvertical/smrt-secrets",
       "@happyvertical/smrt-sites",
       "@happyvertical/smrt-subscriptions",
+      "@happyvertical/smrt-support",
       "@happyvertical/smrt-tags",
       "@happyvertical/smrt-tenancy",
       "@happyvertical/smrt-template-site-static-json",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ All `@happyvertical/smrt-*` packages are version-locked via changesets. pnpm wor
 | analytics | GA4/Plausible: properties, data streams, server-side events, AI-powered reports |
 | reports | Materialized aggregate read models: report decorators, portable aggregate specs, rebuild refresh |
 | subscriptions | Tenant subscription plans, feature grants, usage thresholds, and entitlement resolution |
+| support | AI-first Support Cases: chat/email intake to canonical cases (create-or-join dedup), guarded lifecycle + reopen history, Automated Support Response with lossless Human Handoff, Project-qualified routing, Service Target clocks with timed escalation, generic ServiceTimeEntry with separated SupportCharge/SupportCompensation snapshots |
 
 ### Domain
 | Package | Purpose |

--- a/packages/support/AGENTS.md
+++ b/packages/support/AGENTS.md
@@ -137,6 +137,44 @@ generated CRUD.
   observer keyed on the `ChatMessage`/`Email` class names that never throws
   into the source package's save path. Join semantics: open case → join;
   resolved → reopen; closed → new case.
+- **SupportAiWorkflow** — the Automated Support Response (FR-28a):
+  `processIntake`/`processCase` run acknowledge → classify → answer →
+  resolve under the resolved `SupportPolicy` (conservative defaults), each
+  phase writing a `SupportAiRun` + `ai_run` case event. AI calls go through
+  the injected `SupportAiBoundary` (default uses `supportCase.do()` with
+  defensive JSON parsing that fails toward the human); knowledge comes from
+  the pluggable `SupportKnowledgeProvider` (default no-op). Classification
+  never overwrites human triage; email answers are drafted
+  (`metadata.draft`) unless the policy allows sending. Handoff triggers —
+  `client_request`, `low_confidence`, `high_severity`, `sensitive`,
+  `failed_resolution`, `policy` (attempt budget) — are always active.
+- **HumanHandoffService** — the lossless Human Handoff (FR-28b):
+  `handoff` assembles the full context package (case state + compact
+  timeline + AI runs) into the `handoff` event, stamps
+  `metadata.activeHandoff` for the no-repeat guarantee (repeat triggers are
+  deduped events), routes through the injected `assignSpecialist` seam
+  (#1929's routing service plugs in; default queues `new` cases to
+  `triaged`), and `releaseHandoff` clears the flag.
+- **ServiceTargetEngine** — Service Target clocks (FR-30/31):
+  `startTargetsForCase` derives per-severity clocks from the case's
+  `planSnapshot` (live plan fallback) with due times computed in covered
+  time (`coverage-calendar.ts`: timezone-aware weekly windows + holidays;
+  empty coverage = 24×7) and schedules one-shot `_smrt_jobs` escalation jobs
+  at `dueAt`; `onInteractionRecorded` satisfies acknowledgement/response and
+  recurs `update` cycles; `onCaseTransition` pauses/resumes clocks only when
+  the plan's `pauseStatuses` say so (recomputing remaining covered minutes)
+  and settles targets on resolve. Breach → `SupportServiceTarget.
+  checkAndEscalate` (background-eligible, at-least-once-safe) marks the
+  breach and escalates through the plan's policy steps (notify/reassign,
+  delayed follow-up levels), transitioning the case to `escalated`.
+- **SupportRoutingService** — explainable ranked routing (FR-30):
+  `rankSpecialists` hard-filters on active status, effective Project
+  Support Qualification, workload cap, and availability windows (specialist
+  timezone), then scores preferred-specialist, qualification level, on-call,
+  workload headroom, and language (weights in `ROUTING_WEIGHTS`; every
+  factor recorded so ineligible specialists show why); `autoAssign` writes
+  the assignment with its rationale; `reassign` is gated by
+  `support.reassign-case` and refuses cross-tenant principals.
 - **ServiceTimeEntryService** — the ONE recording contract for all four
   entry sources (FR-40): `record` validates duration (explicit or derived
   from the period; `timer` needs both bounds), participant coherence
@@ -166,11 +204,14 @@ or a `PermissionResolver`.
 
 `@happyvertical/smrt-support/svelte` ships presentational Svelte 5 surfaces:
 `CaseQueue` (priority/status/assignment/channel at a glance, `onselect`),
-`CaseDetail` (header, meta, linked work, merged timeline), and
-`TimeEntryApprovalQueue` (date/hours/description/worker/status/amount with
+`CaseDetail` (header, meta, linked work, merged timeline), `TargetList`
+(Service Target clocks with due/paused/satisfied/breached badges),
+`RoutingRationale` (ranked specialists with eligibility + factor chips and
+an optional reassign action), and `TimeEntryApprovalQueue`
+(date/hours/description/worker/status/amount with
 approve/reject-with-reason actions on submitted rows). Hosts adapt models
-with `toSupportCaseView` / `toCaseTimelineItemView` /
-`toSupportTimeEntryView` — the time-entry view's first eight fields
+with `toSupportCaseView` / `toCaseTimelineItemView` / `toServiceTargetView`
+/ `toSupportTimeEntryView` — the time-entry view's first eight fields
 deliberately match `smrt-projects`' presentation `TimeEntry` contract.
 Components use `smrt-ui` primitives (`smrtRawPrimitives: "strict"`).
 

--- a/packages/support/AGENTS.md
+++ b/packages/support/AGENTS.md
@@ -137,6 +137,22 @@ generated CRUD.
   observer keyed on the `ChatMessage`/`Email` class names that never throws
   into the source package's save path. Join semantics: open case → join;
   resolved → reopen; closed → new case.
+- **ServiceTimeEntryService** — the ONE recording contract for all four
+  entry sources (FR-40): `record` validates duration (explicit or derived
+  from the period; `timer` needs both bounds), participant coherence
+  (`human` → `participantProfileId`, `agent` → `agentRef`), and the work
+  context (case and/or work ref; case entries copy the tenant and append a
+  `time_recorded` event); `submit` stamps the submitter.
+- **TimeEntryApprovalService** — the approval gate and only writer of the
+  commercial snapshots (FR-36): `approve` resolves the governing terms (case
+  `planSnapshot` first, live plan fallback, zero-rate default), gates by
+  policy path (`automatic`/`threshold`/`operator`/`client`; operator paths
+  behind `support.approve-time-entry`; cross-tenant principals refused), then
+  derives the `SupportCharge` (included time first, then overage/on-call) and
+  `SupportCompensation` (effective-dated plan) rows; `reject` and `correct`
+  (supersede + linked fresh draft via `correctionOfId`) round out the
+  lifecycle. Case events carry the charge amount only — compensation never
+  leaks case-side.
 
 ## Permissions
 
@@ -149,10 +165,14 @@ or a `PermissionResolver`.
 ## Svelte UI
 
 `@happyvertical/smrt-support/svelte` ships presentational Svelte 5 surfaces:
-`CaseQueue` (priority/status/assignment/channel at a glance, `onselect`) and
-`CaseDetail` (header, meta, linked work, merged timeline). Hosts adapt models
-with `toSupportCaseView` / `toCaseTimelineItemView`. Components use
-`smrt-ui` primitives (`smrtRawPrimitives: "strict"`).
+`CaseQueue` (priority/status/assignment/channel at a glance, `onselect`),
+`CaseDetail` (header, meta, linked work, merged timeline), and
+`TimeEntryApprovalQueue` (date/hours/description/worker/status/amount with
+approve/reject-with-reason actions on submitted rows). Hosts adapt models
+with `toSupportCaseView` / `toCaseTimelineItemView` /
+`toSupportTimeEntryView` — the time-entry view's first eight fields
+deliberately match `smrt-projects`' presentation `TimeEntry` contract.
+Components use `smrt-ui` primitives (`smrtRawPrimitives: "strict"`).
 
 ## Dependencies
 

--- a/packages/support/AGENTS.md
+++ b/packages/support/AGENTS.md
@@ -1,0 +1,193 @@
+# @happyvertical/smrt-support
+
+AI-first Support Cases for the SMRT framework (epic #1934). Every inbound
+support interaction — chat message or email — creates or joins one canonical,
+tenant-scoped **Support Case**; channels stay transports, never separate
+systems of record. The package owns the case lifecycle, channel intake, the
+Automated Support Response workflow with lossless **Human Handoff**,
+Project-qualified routing, **Service Target** clocks with timed escalation,
+and auditable **Service Time Entries** whose client charges and provider
+compensation stay separate.
+
+**Boundary (FR-29a):** Support owns tickets, interactions, routing, and
+service targets. Delivery Operations owns repository work — a **Delivery
+Handoff** links a case to a Development Work Item (e.g.
+`@happyvertical/smrt-projects:Issue`) via a `SupportWorkLink` without ever
+driving its execution; the delivery side reports status echoes back.
+
+## Models
+
+Case-side models are **internal**: generated API/CLI/MCP surfaces are
+read-only (`list`/`get`) and every write goes through the service facades
+(the `smrt-chat` `ChatService` idiom). Configuration models expose full
+generated CRUD.
+
+### Case core (#1926)
+
+- **SupportCase** (`support_cases`) — canonical ticket: `caseNumber`,
+  `subject`, `status` (`new → triaged → assigned → in_progress →
+  waiting_on_client|escalated → resolved → closed`, guarded at save time via
+  the WeakMap + authoritative-DB-read idiom from S5 #1390), `priority`,
+  `severity` (plan-defined key), `category`, `sensitive`, `channelKind`,
+  `clientProfileId`/`openedByProfileId` (crossPackageRef → Profile),
+  `projectId` (app-defined string — deliberately not an FK), `bindingId`,
+  `threadKey` (create-or-join dedup key), `planId` + `planSnapshot` (terms
+  frozen at apply time), assignment fields, response stamps
+  (`acknowledgedAt`, `firstRespondedAt`), `humanRequestedAt`, resolution
+  fields, `reopenCount`/`lastReopenedAt`, `aiEnabled`.
+- **SupportInteraction** (`support_interactions`,
+  `conflictColumns: ['source_key']`) — channel-neutral transport record:
+  `direction` (`inbound`/`outbound`/`internal`), `channelKind`, `actorKind`
+  (`client`/`specialist`/`agent`/`system`), denormalized `body`, and the
+  qualified `sourceType`/`sourceId` + globally unique `sourceKey`
+  (`chat:<messageId>`, `email:<emailId>`, `manual:<uuid>`) that makes
+  re-ingestion idempotent.
+- **SupportCaseEvent** (`support_case_events`) — append-only audit trail
+  (transitions, assignments, AI runs, handoffs, escalations, target state,
+  work links, reopens). Together with interactions this is the complete
+  context a Human Handoff transfers.
+- **SupportChannelBinding** (`support_channel_bindings`,
+  `conflictColumns: ['target_type','target_id']`) — marks a container as a
+  support intake channel: `bindingKind` (`chat_room`/`email_account`),
+  qualified `targetType` + `targetId`, default client/project/plan,
+  `selfAddresses` (email direction heuristic). Unbound containers are never
+  touched.
+- **SupportWorkLink** (`support_work_links`) — Support/Development Work Item
+  links with a read-only `status` echo.
+
+### AI workflow (#1928)
+
+- **SupportPolicy** (`support_policies`) — what the AI may do without a
+  human: `autoAcknowledge`/`autoClassify`/`autoAnswer` (on by default),
+  `autoTroubleshoot`/`autoResolve` (off by default),
+  `autoResolveMaxSeverity`, `confidenceThreshold`, `maxAutoAttempts`,
+  `sensitiveCategories`, `allowedTools`, `autoSendEmailReplies` (off —
+  email replies are drafted, not sent). Resolution is most-specific-wins on
+  `(planId, projectId)`; no row → `DEFAULT_SUPPORT_POLICY` (conservative).
+- **SupportAiRun** (`support_ai_runs`) — append-only audit of each phase
+  (`acknowledge`/`classify`/`answer`/`troubleshoot`/`resolve`) with
+  `confidence`, classification output, knowledge refs, tool calls, outcome
+  (`completed`/`skipped`/`failed`/`handed_off`), and `correlationId`.
+
+### Routing, targets, escalation (#1929)
+
+- **SupportSpecialist** (`support_specialists`) — specialist role record on a
+  Profile (the commerce `Customer` role-record idiom): `languages`,
+  `timezone`, `maxConcurrentCases`, `onCallPriority`, status.
+- **SupportQualification** (`support_qualifications`) — effective-dated
+  Project Support Qualification (`trainee`/`qualified`/`expert`).
+- **SupportAvailability** (`support_availability_windows`) — weekly windows
+  plus `on_call`/`time_off` spans.
+- **SupportPlan** (`support_plans`, `conflictColumns:
+  ['tenant_id','plan_key']`) — the Managed Support Plan: coverage calendar +
+  holidays + timezone, channels, severity definitions, per-severity
+  acknowledgement/response/update/resolution target minutes, `pauseStatuses`
+  (clocks pause only when the plan says so), escalation policy steps,
+  availability fee, `includedMinutes`, `overageHourlyRate`,
+  `onCallHourlyRate`, time-approval policy, optional
+  `subscriptionPlanKey` binding (string, not a dependency).
+  `snapshotTerms()` feeds `SupportCase.planSnapshot`.
+- **SupportServiceTarget** (`support_service_targets`,
+  `conflictColumns: ['case_id','target_type','cycle']`) — one clock per
+  target type (update clocks recur via `cycle`), with pause accounting and
+  `escalationJobId` (the one-shot `_smrt_jobs` row scheduled at `dueAt`,
+  cancelled on satisfy).
+- **SupportEscalation** (`support_escalations`) — the audit record of one
+  escalation firing.
+- **SupportCompensationPlan** (`support_compensation_plans`) —
+  effective-dated Support Specialist earning terms; specialist-specific plan
+  wins over the tenant default at the work instant. Deliberately separate
+  from `SupportPlan` (client pricing) so margin stays measurable.
+
+### Service time (#1930)
+
+- **ServiceTimeEntry** (`service_time_entries`) — auditable Professional
+  Service duration: work-context-generic (`caseId` and/or polymorphic
+  `workRefType`/`workRefId`), delivering Participant (`participantKind`
+  `human`/`agent` + `participantProfileId`/`agentRef`), `source`
+  (`timer`/`manual`/`import`/`agent` — one shared validation/audit
+  contract), evidence JSON, and lifecycle `draft → submitted →
+  approved|rejected`, `approved → corrected` only. **Approved entries are
+  immutable**: the work-defining fields are frozen at save time (the
+  `LicenseSale` WeakMap-freeze idiom, backed by an authoritative DB-row
+  comparison); disputes create explicit corrections via `correctionOfId`.
+- **SupportCharge** / **SupportCompensation** (`support_charges` /
+  `support_compensations`, one per time entry) — derived commercial
+  snapshots: client amount from the Managed Support Plan (included-time
+  consumption then metered overage) vs provider amount from the Support
+  Compensation Plan, each with a frozen `rateSnapshot`. Margin = charge −
+  compensation, computed by readers; settlement/invoicing composes at the
+  app/accounting boundary (#1925) and is out of scope here.
+
+## Services
+
+- **SupportCaseService** — the closed write facade: `openCase`,
+  `recordInteraction` (idempotent on `sourceKey`; stamps
+  `acknowledgedAt`/`firstRespondedAt`; inbound un-parks
+  `waiting_on_client`), `transition`, `assign`, `resolve`, `close`,
+  `reopen` (preserves prior resolution in the reopen event), `requestHuman`,
+  `linkWork`/`recordWorkStatus` (Delivery Handoff), `recordEvent`,
+  `getTimeline` (merged interactions + events).
+- **SupportIntakeService** — create-or-join intake for both channels:
+  `ingestChatMessage` (bound `ChatRoom`; `chat:<roomId>[:<threadId>]` thread
+  keys; only `role: 'user'` messages), `ingestEmail` (bound `EmailAccount`;
+  RFC-thread joins via `inReplyTo`; `selfAddresses` skip; unresolved senders
+  park the case with `metadata.unresolvedClient`), plus
+  `registerSupportIntake()` — an opt-in `GlobalInterceptors.afterSave`
+  observer keyed on the `ChatMessage`/`Email` class names that never throws
+  into the source package's save path. Join semantics: open case → join;
+  resolved → reopen; closed → new case.
+
+## Permissions
+
+Contributed to the runtime catalog on import (the
+`personas.activate-directive` pattern): `support.reassign-case`,
+`support.approve-time-entry`, `support.manage-plans`. Privileged service
+operations take a `SupportPrincipal` (`can(slug)`), built from explicit slugs
+or a `PermissionResolver`.
+
+## Svelte UI
+
+`@happyvertical/smrt-support/svelte` ships presentational Svelte 5 surfaces:
+`CaseQueue` (priority/status/assignment/channel at a glance, `onselect`) and
+`CaseDetail` (header, meta, linked work, merged timeline). Hosts adapt models
+with `toSupportCaseView` / `toCaseTimelineItemView`. Components use
+`smrt-ui` primitives (`smrtRawPrimitives: "strict"`).
+
+## Dependencies
+
+Leaf package (nothing depends back on it): `smrt-core`, `smrt-tenancy`,
+`smrt-chat`, `smrt-messages`, `smrt-jobs`, `smrt-users`, `smrt-ui`,
+`@happyvertical/logger`, `@happyvertical/sql`. Profile / smrt-projects /
+subscriptions references are `@crossPackageRef` string ids or plain string
+keys only — no package edge. No inter-`smrt-*` `peerDependencies`.
+
+## Validation
+
+```sh
+pnpm --filter @happyvertical/smrt-support test
+pnpm --filter @happyvertical/smrt-support typecheck
+pnpm --filter @happyvertical/smrt-support build
+```
+
+## Gotchas
+
+- **Writes go through the facades** — the case-side generated routes are
+  read-only on purpose; `create`/`update` on them is not a bug to "fix".
+- **`projectId` is an app-defined string** — the consuming app owns the
+  Project concept; don't turn it into an FK or a crossPackageRef to
+  `smrt-projects:Project` (that class is a provider board, not a client
+  initiative).
+- **`SupportCase.threadKey` + `SupportInteraction.sourceKey` carry intake
+  correctness** — `sourceKey` is globally unique (`conflictColumns`), so
+  replayed transport rows are no-ops; new manual interactions must use a
+  fresh `manual:<uuid>` key.
+- **High-volume models avoid the inherited `name` field** (`subject`,
+  `displayName`, …) so the default `(slug, context, _meta_type)` unique index
+  falls back to id-derived slugs; named config models carry
+  `conflictColumns` instead (which replaces that index).
+- **Approved time entries never change** — corrections are new rows linked
+  by `correctionOfId`; the original flips to `corrected` with its snapshot
+  intact.
+- **Plan edits never rewrite history** — cases keep `planSnapshot`, charges
+  and compensation keep `rateSnapshot`.

--- a/packages/support/AGENTS.md
+++ b/packages/support/AGENTS.md
@@ -19,8 +19,11 @@ driving its execution; the delivery side reports status echoes back.
 
 Case-side models are **internal**: generated API/CLI/MCP surfaces are
 read-only (`list`/`get`) and every write goes through the service facades
-(the `smrt-chat` `ChatService` idiom). Configuration models expose full
-generated CRUD.
+(the `smrt-chat` `ChatService` idiom). Operational configuration models
+(bindings, policies, specialists, qualifications, availability) expose full
+generated CRUD; **commercial terms** (`SupportPlan`,
+`SupportCompensationPlan`) are read-only too — their writes flow through the
+`support.manage-plans`-gated `SupportPlanAdminService`.
 
 ### Case core (#1926)
 
@@ -167,6 +170,10 @@ generated CRUD.
   checkAndEscalate` (background-eligible, at-least-once-safe) marks the
   breach and escalates through the plan's policy steps (notify/reassign,
   delayed follow-up levels), transitioning the case to `escalated`.
+- **SupportPlanAdminService** — the permission-gated write surface for
+  commercial terms: create/update/archive for Managed Support Plans and
+  Support Compensation Plans, every act behind `support.manage-plans` with
+  cross-tenant writes refused (generated CRUD on both models is read-only).
 - **SupportRoutingService** — explainable ranked routing (FR-30):
   `rankSpecialists` hard-filters on active status, effective Project
   Support Qualification, workload cap, and availability windows (specialist

--- a/packages/support/AGENTS.md
+++ b/packages/support/AGENTS.md
@@ -259,3 +259,12 @@ pnpm --filter @happyvertical/smrt-support build
   intact.
 - **Plan edits never rewrite history** — cases keep `planSnapshot`, charges
   and compensation keep `rateSnapshot`.
+- **Create-or-join and included-time consumption serialize in-process** —
+  `SupportIntakeService` (per conversation key) and
+  `TimeEntryApprovalService` (per case) use a `KeyedMutex`, which covers the
+  single-app-process deployment these paths run in. Multi-replica
+  deployments must serialize at the app layer (route a conversation's
+  intake / a case's approvals through one worker, or add an app-level
+  claim) — the framework exposes no cross-adapter transaction primitive at
+  this seam. Escalation is additionally idempotent per `(target, level)`,
+  so at-least-once job redelivery never stacks duplicate escalations.

--- a/packages/support/CLAUDE.md
+++ b/packages/support/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/support/ambient.d.ts
+++ b/packages/support/ambient.d.ts
@@ -1,0 +1,6 @@
+declare module '*.svelte' {
+  import type { Component } from 'svelte';
+
+  const component: Component<Record<string, any>>;
+  export default component;
+}

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-support",
-  "version": "0.38.26",
+  "version": "0.39.1",
   "description": "AI-first Support Cases: channel-neutral intake, lifecycle, routing, service targets, and service time for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -1,0 +1,87 @@
+{
+  "name": "@happyvertical/smrt-support",
+  "version": "0.38.26",
+  "description": "AI-first Support Cases: channel-neutral intake, lifecycle, routing, service targets, and service time for the SMRT framework",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "smrtRawPrimitives": "strict",
+  "files": [
+    "dist",
+    "CLAUDE.md",
+    "AGENTS.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./svelte": {
+      "types": "./dist/svelte/index.d.ts",
+      "svelte": "./dist/svelte/index.js",
+      "import": "./dist/svelte/index.js"
+    },
+    "./manifest": "./dist/manifest.json",
+    "./manifest.json": "./dist/manifest.json"
+  },
+  "scripts": {
+    "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
+    "build:watch": "vite build --mode library --watch",
+    "clean": "rm -rf dist",
+    "dev": "vite dev",
+    "prepack": "node ../../scripts/prepack-package.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit -p tsconfig.json && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
+    "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
+  },
+  "dependencies": {
+    "@happyvertical/logger": "catalog:",
+    "@happyvertical/smrt-chat": "workspace:*",
+    "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-jobs": "workspace:*",
+    "@happyvertical/smrt-messages": "workspace:*",
+    "@happyvertical/smrt-tenancy": "workspace:*",
+    "@happyvertical/smrt-ui": "workspace:*",
+    "@happyvertical/smrt-users": "workspace:*",
+    "@happyvertical/sql": "catalog:"
+  },
+  "peerDependencies": {
+    "svelte": "^5.56.4"
+  },
+  "peerDependenciesMeta": {
+    "svelte": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@happyvertical/smrt-vitest": "workspace:*",
+    "@sveltejs/package": "^2.5.8",
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "@types/node": "24.13.2",
+    "svelte": "^5.56.4",
+    "svelte-check": "^4.7.1",
+    "typescript": "^5.9.3",
+    "vite": "^8.1.3",
+    "vitest": "^4.1.9"
+  },
+  "keywords": [
+    "smrt",
+    "support",
+    "tickets",
+    "service-desk",
+    "sla",
+    "multi-tenant"
+  ],
+  "author": "HappyVertical",
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/smrt.git",
+    "directory": "packages/support"
+  }
+}

--- a/packages/support/src/__smrt-register__.ts
+++ b/packages/support/src/__smrt-register__.ts
@@ -1,0 +1,5 @@
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+
+ObjectRegistry.registerPackageManifest(
+  new URL('./manifest.json', import.meta.url),
+);

--- a/packages/support/src/generated-surface.test.ts
+++ b/packages/support/src/generated-surface.test.ts
@@ -44,6 +44,10 @@ const READ_ONLY_MODELS = [
   'ServiceTimeEntry',
   'SupportCharge',
   'SupportCompensation',
+  // Commercial terms write only through the `support.manage-plans`-gated
+  // SupportPlanAdminService — never via generated CRUD.
+  'SupportPlan',
+  'SupportCompensationPlan',
 ];
 
 const FULL_CRUD_MODELS = [
@@ -52,8 +56,6 @@ const FULL_CRUD_MODELS = [
   'SupportSpecialist',
   'SupportQualification',
   'SupportAvailability',
-  'SupportPlan',
-  'SupportCompensationPlan',
 ];
 
 describe('generated surfaces', () => {

--- a/packages/support/src/generated-surface.test.ts
+++ b/packages/support/src/generated-surface.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Generated-surface configuration tests (#1926): the case-side models expose
+ * read-only generated API/CLI/MCP (writes go through the closed service
+ * facade), configuration models expose full CRUD, and the intake dedup /
+ * uniqueness contracts are carried by `conflictColumns` exactly as shipped.
+ */
+
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+import { describe, expect, it } from 'vitest';
+// Import the package entry so every model registers.
+import {
+  SERVICE_TIME_ENTRY_STATUS_TRANSITIONS,
+  SUPPORT_CASE_STATUS_TRANSITIONS,
+} from './index.js';
+
+type SurfaceConfig = {
+  include?: string[];
+};
+
+function smrtConfigOf(className: string): {
+  api?: SurfaceConfig | boolean;
+  mcp?: SurfaceConfig | boolean;
+  cli?: SurfaceConfig | boolean;
+  conflictColumns?: string[];
+} {
+  const metadata = ObjectRegistry.getObjectMetadata(className);
+  expect(metadata, `expected ${className} in the ObjectRegistry`).toBeTruthy();
+  return (metadata?.config ?? {}) as ReturnType<typeof smrtConfigOf>;
+}
+
+function includeList(surface: SurfaceConfig | boolean | undefined): string[] {
+  if (!surface || surface === true) return [];
+  return surface.include ?? [];
+}
+
+const READ_ONLY_MODELS = [
+  'SupportCase',
+  'SupportInteraction',
+  'SupportCaseEvent',
+  'SupportWorkLink',
+  'SupportAiRun',
+  'SupportServiceTarget',
+  'SupportEscalation',
+  'ServiceTimeEntry',
+  'SupportCharge',
+  'SupportCompensation',
+];
+
+const FULL_CRUD_MODELS = [
+  'SupportChannelBinding',
+  'SupportPolicy',
+  'SupportSpecialist',
+  'SupportQualification',
+  'SupportAvailability',
+  'SupportPlan',
+  'SupportCompensationPlan',
+];
+
+describe('generated surfaces', () => {
+  it('keeps every case-side model read-only on API, CLI, and MCP', () => {
+    for (const className of READ_ONLY_MODELS) {
+      const config = smrtConfigOf(className);
+      for (const surface of ['api', 'mcp', 'cli'] as const) {
+        const ops = includeList(config[surface]);
+        expect(ops, `${className}.${surface}`).toEqual(['list', 'get']);
+      }
+    }
+  });
+
+  it('exposes full CRUD APIs on configuration models', () => {
+    for (const className of FULL_CRUD_MODELS) {
+      const config = smrtConfigOf(className);
+      expect(includeList(config.api), `${className}.api`).toEqual([
+        'list',
+        'get',
+        'create',
+        'update',
+        'delete',
+      ]);
+      // Non-API surfaces stay read-only even for config models.
+      expect(includeList(config.mcp), `${className}.mcp`).toEqual([
+        'list',
+        'get',
+      ]);
+    }
+  });
+
+  it('carries the intake and uniqueness contracts in conflictColumns', () => {
+    expect(smrtConfigOf('SupportInteraction').conflictColumns).toEqual([
+      'source_key',
+    ]);
+    expect(smrtConfigOf('SupportChannelBinding').conflictColumns).toEqual([
+      'target_type',
+      'target_id',
+    ]);
+    expect(smrtConfigOf('SupportPlan').conflictColumns).toEqual([
+      'tenant_id',
+      'plan_key',
+    ]);
+    expect(smrtConfigOf('SupportSpecialist').conflictColumns).toEqual([
+      'tenant_id',
+      'profile_id',
+    ]);
+    expect(smrtConfigOf('SupportQualification').conflictColumns).toEqual([
+      'specialist_id',
+      'project_id',
+    ]);
+    expect(smrtConfigOf('SupportServiceTarget').conflictColumns).toEqual([
+      'case_id',
+      'target_type',
+      'cycle',
+    ]);
+    expect(smrtConfigOf('SupportCharge').conflictColumns).toEqual([
+      'time_entry_id',
+    ]);
+    expect(smrtConfigOf('SupportCompensation').conflictColumns).toEqual([
+      'time_entry_id',
+    ]);
+  });
+
+  it('publishes coherent lifecycle maps', () => {
+    // Every transition target is itself a known status.
+    for (const [from, targets] of Object.entries(
+      SUPPORT_CASE_STATUS_TRANSITIONS,
+    )) {
+      for (const to of targets) {
+        expect(
+          SUPPORT_CASE_STATUS_TRANSITIONS[to],
+          `case ${from} → ${to}`,
+        ).toBeDefined();
+      }
+    }
+    for (const [from, targets] of Object.entries(
+      SERVICE_TIME_ENTRY_STATUS_TRANSITIONS,
+    )) {
+      for (const to of targets) {
+        expect(
+          SERVICE_TIME_ENTRY_STATUS_TRANSITIONS[to],
+          `time entry ${from} → ${to}`,
+        ).toBeDefined();
+      }
+    }
+    // Approved entries only exit through explicit correction.
+    expect(SERVICE_TIME_ENTRY_STATUS_TRANSITIONS.approved).toEqual([
+      'corrected',
+    ]);
+    expect(SERVICE_TIME_ENTRY_STATUS_TRANSITIONS.corrected).toEqual([]);
+  });
+});

--- a/packages/support/src/index.ts
+++ b/packages/support/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * @happyvertical/smrt-support
+ *
+ * AI-first Support Cases for the SMRT framework (epic #1934): channel-neutral
+ * Support Cases over chat and email transports, the standard case lifecycle
+ * with reopen history, immediate AI assistance with lossless Human Handoff,
+ * Project-qualified routing, Service Targets with timed escalation, and
+ * auditable Service Time Entries with separated client charges and provider
+ * compensation.
+ *
+ * Boundary: Support owns tickets, interactions, routing, and service targets.
+ * Delivery Operations owns repository work — a Delivery Handoff links a case
+ * to a Development Work Item without driving its execution.
+ *
+ * @packageDocumentation
+ */
+
+// Self-register this package's manifest before any @smrt() decorator fires
+// downstream. Must come first so the side effect runs ahead of the class
+// module loads below (issue #1132 context in __smrt-register__.ts).
+import './__smrt-register__.js';
+
+import { ensureSupportPermissionsRegistered } from './permissions.js';
+
+export * from './models/index.js';
+export {
+  APPROVE_TIME_ENTRY_PERMISSION,
+  ensureSupportPermissionsRegistered,
+  MANAGE_PLANS_PERMISSION,
+  REASSIGN_CASE_PERMISSION,
+  registerSupportPermissions,
+  SUPPORT_PERMISSION_DEFS,
+  type SupportPrincipal,
+  supportPrincipalFromPermissions,
+} from './permissions.js';
+export * from './services/index.js';
+export * from './types.js';
+
+// Contribute the support permission slugs to the runtime catalog on import,
+// so any consumer of this package sees the gates' slugs.
+ensureSupportPermissionsRegistered();

--- a/packages/support/src/models/index.ts
+++ b/packages/support/src/models/index.ts
@@ -42,6 +42,7 @@ export {
   SupportPolicyCollection,
 } from './support-policy.js';
 export {
+  type CheckAndEscalateResult,
   SupportEscalation,
   SupportEscalationCollection,
   SupportServiceTarget,

--- a/packages/support/src/models/index.ts
+++ b/packages/support/src/models/index.ts
@@ -1,0 +1,67 @@
+/**
+ * Model barrel for `@happyvertical/smrt-support`.
+ */
+
+export {
+  ServiceTimeEntry,
+  ServiceTimeEntryCollection,
+} from './service-time-entry.js';
+export {
+  SupportAiRun,
+  SupportAiRunCollection,
+} from './support-ai-run.js';
+export {
+  generateCaseNumber,
+  SupportCase,
+  SupportCaseCollection,
+} from './support-case.js';
+export {
+  SupportCaseEvent,
+  SupportCaseEventCollection,
+} from './support-case-event.js';
+export {
+  SupportChannelBinding,
+  SupportChannelBindingCollection,
+} from './support-channel-binding.js';
+export {
+  SupportCompensationPlan,
+  SupportCompensationPlanCollection,
+} from './support-compensation-plan.js';
+export {
+  SupportInteraction,
+  SupportInteractionCollection,
+} from './support-interaction.js';
+export {
+  DEFAULT_TARGET_MINUTES,
+  SupportPlan,
+  SupportPlanCollection,
+} from './support-plan.js';
+export {
+  DEFAULT_SUPPORT_POLICY,
+  SupportPolicy,
+  SupportPolicyCollection,
+} from './support-policy.js';
+export {
+  SupportEscalation,
+  SupportEscalationCollection,
+  SupportServiceTarget,
+  SupportServiceTargetCollection,
+} from './support-service-target.js';
+export {
+  SupportCharge,
+  SupportChargeCollection,
+  SupportCompensation,
+  SupportCompensationCollection,
+} from './support-settlement.js';
+export {
+  SupportAvailability,
+  SupportAvailabilityCollection,
+  SupportQualification,
+  SupportQualificationCollection,
+  SupportSpecialist,
+  SupportSpecialistCollection,
+} from './support-specialist.js';
+export {
+  SupportWorkLink,
+  SupportWorkLinkCollection,
+} from './support-work-link.js';

--- a/packages/support/src/models/service-time-entry.ts
+++ b/packages/support/src/models/service-time-entry.ts
@@ -1,0 +1,329 @@
+/**
+ * ServiceTimeEntry — an auditable duration of Professional Service attributed
+ * to its work context and delivering Participant (FR-34/FR-40, issue #1930).
+ *
+ * Work-context-generic by design: a Support Case is one context
+ * (`caseId`), but planning and development work attach through the
+ * polymorphic `workRefType`/`workRefId` pair, so this model can graduate to
+ * the shared Professional Services boundary without a migration.
+ *
+ * Timer, manual, imported, and automatic agent entries share this one
+ * validation and audit contract. Duration and work evidence stay separate
+ * from money: client pricing derives from the Managed Support Plan and
+ * provider earnings from the Support Compensation Plan at approval time (see
+ * `TimeEntryApprovalService`), each into its own immutable snapshot row.
+ *
+ * **Immutability**: once a row is `approved`, its work-defining fields
+ * (duration, period, description, evidence, context, participant, source)
+ * are frozen — enforced at save time via the WeakMap-snapshot idiom
+ * (`commerce LicenseSale` precedent). Disputes create explicit corrections
+ * (`correctionOfId` chain); the original flips to `corrected` but its
+ * snapshot never changes.
+ */
+
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import {
+  parseJsonField,
+  SERVICE_TIME_ENTRY_STATUS_TRANSITIONS,
+  type ServiceTimeEntrySource,
+  type ServiceTimeEntryStatus,
+  type SupportParticipantKind,
+  type TimeEntryEvidence,
+} from '../types.js';
+
+/** Fields frozen once an entry reaches `approved`. */
+const FROZEN_FIELDS = [
+  'caseId',
+  'workRefType',
+  'workRefId',
+  'specialistId',
+  'participantKind',
+  'participantProfileId',
+  'agentRef',
+  'source',
+  'description',
+  'startedAt',
+  'endedAt',
+  'durationSeconds',
+  'evidence',
+] as const;
+
+/** Serialized frozen-field snapshot captured at/after approval. */
+const approvedSnapshot = new WeakMap<ServiceTimeEntry, string>();
+
+/** Status each persisted row was loaded with (transition guard). */
+const loadedEntryStatus = new WeakMap<
+  ServiceTimeEntry,
+  ServiceTimeEntryStatus
+>();
+
+/**
+ * Normalize one frozen-field value so in-memory and raw-DB-row views compare
+ * equal across adapters (SQLite returns dates as strings, numbers sometimes
+ * as strings; empty string and null both mean "unset" for nullable refs).
+ */
+function normalizeFrozenValue(key: string, value: unknown): unknown {
+  if (value === undefined || value === null || value === '') {
+    return key === 'durationSeconds' ? 0 : null;
+  }
+  if (key === 'startedAt' || key === 'endedAt') {
+    const date = value instanceof Date ? value : new Date(String(value));
+    return Number.isNaN(date.getTime()) ? String(value) : date.toISOString();
+  }
+  if (key === 'durationSeconds') {
+    return Number(value);
+  }
+  return value;
+}
+
+function serializeFrozenView(view: Record<string, unknown>): string {
+  const normalized: Record<string, unknown> = {};
+  for (const key of FROZEN_FIELDS) {
+    normalized[key] = normalizeFrozenValue(key, view[key]);
+  }
+  return JSON.stringify(normalized);
+}
+
+function serializeFrozenFields(entry: ServiceTimeEntry): string {
+  const view: Record<string, unknown> = {};
+  for (const key of FROZEN_FIELDS) {
+    view[key] = (entry as unknown as Record<string, unknown>)[key];
+  }
+  return serializeFrozenView(view);
+}
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'service_time_entries',
+  api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+})
+export class ServiceTimeEntry extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  /** Support Case context, when the work was support (Support Time Entry). */
+  @foreignKey('SupportCase')
+  caseId: string | null = null;
+
+  /**
+   * Polymorphic work context for non-case work (planning sessions,
+   * development work items): a qualified class name + id. Either `caseId` or
+   * a work ref (or both) should identify the context.
+   */
+  @field({ type: 'text', nullable: true })
+  workRefType: string | null = null;
+
+  @field({ type: 'text', nullable: true })
+  workRefId: string | null = null;
+
+  /** Specialist role record, when the deliverer is a Support Specialist. */
+  @foreignKey('SupportSpecialist')
+  specialistId: string | null = null;
+
+  /** Whether a human or a software agent delivered the work. */
+  @field({ type: 'text' })
+  participantKind: SupportParticipantKind = 'human';
+
+  /** Delivering human Participant (Person profile), when human. */
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { nullable: true })
+  participantProfileId: string | null = null;
+
+  /** Delivering agent identity (persona/agent ref), when agent. */
+  @field({ type: 'text' })
+  agentRef: string = '';
+
+  @field({ type: 'text' })
+  source: ServiceTimeEntrySource = 'manual';
+
+  @field({ type: 'text' })
+  description: string = '';
+
+  /** Work period bounds (informational; `durationSeconds` is authoritative). */
+  startedAt: Date | null = null;
+
+  endedAt: Date | null = null;
+
+  /** Authoritative worked duration in seconds. */
+  durationSeconds: number = 0;
+
+  /** Work evidence: JSON array of {@link TimeEntryEvidence}. */
+  @field({ type: 'text' })
+  evidence: string = '[]';
+
+  @field({ type: 'text' })
+  status: ServiceTimeEntryStatus = 'draft';
+
+  submittedAt: Date | null = null;
+
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { nullable: true })
+  submittedByProfileId: string | null = null;
+
+  approvedAt: Date | null = null;
+
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { nullable: true })
+  approvedByProfileId: string | null = null;
+
+  /** Which approval path accepted the entry (FR-36). */
+  @field({ type: 'text' })
+  approvalPath: string = '';
+
+  rejectedAt: Date | null = null;
+
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { nullable: true })
+  rejectedByProfileId: string | null = null;
+
+  @field({ type: 'text' })
+  rejectionReason: string = '';
+
+  /** The approved entry this one explicitly corrects, when a correction. */
+  @foreignKey('ServiceTimeEntry')
+  correctionOfId: string | null = null;
+
+  @field({ type: 'text' })
+  metadata: string = '{}';
+
+  getEvidence(): TimeEntryEvidence[] {
+    const parsed = parseJsonField<TimeEntryEvidence[]>(this.evidence, []);
+    return Array.isArray(parsed) ? parsed : [];
+  }
+
+  setEvidence(items: TimeEntryEvidence[]): void {
+    this.evidence = JSON.stringify(items ?? []);
+  }
+
+  getMetadata(): Record<string, unknown> {
+    return parseJsonField(this.metadata, {});
+  }
+
+  setMetadata(value: Record<string, unknown>): void {
+    this.metadata = JSON.stringify(value ?? {});
+  }
+
+  /** Worked duration in decimal hours (UI convenience). */
+  durationHours(): number {
+    return this.durationSeconds / 3600;
+  }
+
+  override async initialize(): Promise<this> {
+    await super.initialize();
+    if (await this.isSaved()) {
+      loadedEntryStatus.set(this, this.status);
+      if (this.status === 'approved' || this.status === 'corrected') {
+        approvedSnapshot.set(this, serializeFrozenFields(this));
+      }
+    }
+    return this;
+  }
+
+  override async save(): Promise<this> {
+    const prior = await this.resolvePriorState();
+    this.assertStatusTransition(prior?.status);
+    this.assertApprovedImmutable(prior);
+    const result = (await super.save()) as this;
+    loadedEntryStatus.set(this, this.status);
+    if (this.status === 'approved' || this.status === 'corrected') {
+      approvedSnapshot.set(this, serializeFrozenFields(this));
+    }
+    return result;
+  }
+
+  protected assertStatusTransition(
+    prior: ServiceTimeEntryStatus | undefined,
+  ): void {
+    if (prior === undefined) return;
+    if (prior === this.status) return;
+    const allowed = SERVICE_TIME_ENTRY_STATUS_TRANSITIONS[prior] ?? [];
+    if (!allowed.includes(this.status)) {
+      throw new Error(
+        `ServiceTimeEntry ${this.id}: illegal status transition ` +
+          `'${prior}' → '${this.status}'.`,
+      );
+    }
+  }
+
+  /**
+   * Once approved, the work-defining fields are immutable — compare against
+   * the authoritative persisted row (not just the WeakMap), so an upsert via
+   * `create({ id, _skipLoad: true })` cannot bypass the freeze.
+   */
+  protected assertApprovedImmutable(
+    prior:
+      | { status: ServiceTimeEntryStatus; frozen: string | null }
+      | undefined,
+  ): void {
+    if (!prior) return;
+    if (prior.status !== 'approved' && prior.status !== 'corrected') return;
+    const persisted = prior.frozen ?? approvedSnapshot.get(this) ?? null;
+    if (persisted === null) return;
+    const current = serializeFrozenFields(this);
+    if (current !== persisted) {
+      throw new Error(
+        `ServiceTimeEntry ${this.id}: approved entries are immutable — ` +
+          'create an explicit correction instead of editing the approved record.',
+      );
+    }
+  }
+
+  /** Authoritative prior state read from the DB row (S5 #1390 idiom). */
+  protected async resolvePriorState(): Promise<
+    { status: ServiceTimeEntryStatus; frozen: string | null } | undefined
+  > {
+    if (this.id) {
+      try {
+        const row = await this.db.get(this.tableName, { id: this.id });
+        if (row && row.status != null) {
+          const status = row.status as ServiceTimeEntryStatus;
+          let frozen: string | null = null;
+          if (status === 'approved' || status === 'corrected') {
+            const view: Record<string, unknown> = {};
+            for (const key of FROZEN_FIELDS) {
+              const column = key.replace(
+                /[A-Z]/g,
+                (c) => `_${c.toLowerCase()}`,
+              );
+              view[key] = row[column];
+            }
+            frozen = serializeFrozenView(view);
+          }
+          return { status, frozen };
+        }
+      } catch {
+        // DB not ready / table absent — fall through to in-memory record.
+      }
+    }
+    const status = loadedEntryStatus.get(this);
+    if (status === undefined) return undefined;
+    return { status, frozen: approvedSnapshot.get(this) ?? null };
+  }
+}
+
+export class ServiceTimeEntryCollection extends SmrtCollection<ServiceTimeEntry> {
+  static readonly _itemClass = ServiceTimeEntry;
+
+  async forCase(caseId: string): Promise<ServiceTimeEntry[]> {
+    return this.list({ where: { caseId }, orderBy: 'created_at ASC' });
+  }
+
+  async forSpecialist(specialistId: string): Promise<ServiceTimeEntry[]> {
+    return this.list({ where: { specialistId }, orderBy: 'created_at ASC' });
+  }
+
+  async pendingApproval(): Promise<ServiceTimeEntry[]> {
+    return this.list({
+      where: { status: 'submitted' },
+      orderBy: 'submitted_at ASC',
+    });
+  }
+}
+
+export default ServiceTimeEntry;

--- a/packages/support/src/models/support-ai-run.ts
+++ b/packages/support/src/models/support-ai-run.ts
@@ -1,0 +1,126 @@
+/**
+ * SupportAiRun — the auditable record of one Automated Support Response phase
+ * (FR-28a): what the AI attempted (acknowledge / classify / answer /
+ * troubleshoot / resolve), with confidence, classification output, knowledge
+ * references, attempted tool calls, and outcome. This is the "prior automated
+ * work" a Human Handoff transfers losslessly (FR-28b).
+ *
+ * Append-only: generated surface is `list`/`get`; the workflow writes each
+ * run once and never rewrites history.
+ */
+
+import {
+  field,
+  foreignKey,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import {
+  parseJsonField,
+  type SupportAiRunOutcome,
+  type SupportAiRunPhase,
+} from '../types.js';
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_ai_runs',
+  api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+})
+export class SupportAiRun extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  @foreignKey('SupportCase', { required: true })
+  caseId: string = '';
+
+  /** Inbound interaction that triggered this run, when applicable. */
+  @foreignKey('SupportInteraction')
+  interactionId: string | null = null;
+
+  @field({ type: 'text' })
+  phase: SupportAiRunPhase = 'acknowledge';
+
+  @field({ type: 'text' })
+  outcome: SupportAiRunOutcome = 'completed';
+
+  /**
+   * Model-reported confidence in [0, 1] for answer/classify/resolve phases;
+   * null when the phase has no confidence semantics (e.g. acknowledge).
+   */
+  @field({ type: 'decimal', nullable: true })
+  confidence: number | null = null;
+
+  /** Classification output JSON: severity, category, sentiment, sensitive. */
+  @field({ type: 'text' })
+  classification: string = '{}';
+
+  /** Outbound interaction holding the posted/drafted response, if any. */
+  @foreignKey('SupportInteraction')
+  responseInteractionId: string | null = null;
+
+  /** Knowledge sources consulted (JSON array of `{kind, ref, label?}`). */
+  @field({ type: 'text' })
+  knowledgeRefs: string = '[]';
+
+  /** Tool calls attempted during troubleshooting (JSON array). */
+  @field({ type: 'text' })
+  toolCalls: string = '[]';
+
+  /** Error detail when `outcome === 'failed'`. */
+  @field({ type: 'text' })
+  error: string = '';
+
+  /** Correlation id tying this run to AI-call telemetry / feedback signals. */
+  @field({ type: 'text' })
+  correlationId: string = '';
+
+  /** Model identifier used, when known. */
+  @field({ type: 'text' })
+  model: string = '';
+
+  startedAt: Date = new Date();
+
+  completedAt: Date | null = null;
+
+  @field({ type: 'text' })
+  metadata: string = '{}';
+
+  getClassification(): Record<string, unknown> {
+    return parseJsonField(this.classification, {});
+  }
+
+  setClassification(value: Record<string, unknown>): void {
+    this.classification = JSON.stringify(value ?? {});
+  }
+
+  getKnowledgeRefs(): Array<Record<string, unknown>> {
+    return parseJsonField(this.knowledgeRefs, []);
+  }
+
+  setKnowledgeRefs(refs: Array<Record<string, unknown>>): void {
+    this.knowledgeRefs = JSON.stringify(refs ?? []);
+  }
+
+  getToolCalls(): Array<Record<string, unknown>> {
+    return parseJsonField(this.toolCalls, []);
+  }
+
+  setToolCalls(calls: Array<Record<string, unknown>>): void {
+    this.toolCalls = JSON.stringify(calls ?? []);
+  }
+}
+
+export class SupportAiRunCollection extends SmrtCollection<SupportAiRun> {
+  static readonly _itemClass = SupportAiRun;
+
+  /** All AI runs for a case, oldest first. */
+  async forCase(caseId: string): Promise<SupportAiRun[]> {
+    return this.list({ where: { caseId }, orderBy: 'started_at ASC' });
+  }
+}
+
+export default SupportAiRun;

--- a/packages/support/src/models/support-case-event.ts
+++ b/packages/support/src/models/support-case-event.ts
@@ -1,0 +1,85 @@
+/**
+ * SupportCaseEvent — append-only audit trail for a Support Case: creations,
+ * transitions, assignments, AI runs, handoffs, escalations, target state
+ * changes, work links, and reopens. Together with interactions this is the
+ * "complete Case context" a Human Handoff transfers (FR-28b) and the reopen
+ * history FR-29b preserves.
+ *
+ * Events are immutable: the generated surface is `list`/`get` only and the
+ * service never updates an event after writing it.
+ */
+
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import {
+  parseJsonField,
+  type SupportActorKind,
+  type SupportCaseEventType,
+} from '../types.js';
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_case_events',
+  api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+})
+export class SupportCaseEvent extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  @foreignKey('SupportCase', { required: true })
+  caseId: string = '';
+
+  @field({ type: 'text' })
+  eventType: SupportCaseEventType = 'note';
+
+  @field({ type: 'text' })
+  actorKind: SupportActorKind = 'system';
+
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { nullable: true })
+  actorProfileId: string | null = null;
+
+  occurredAt: Date = new Date();
+
+  /** One-line human-readable summary for the case timeline. */
+  @field({ type: 'text' })
+  summary: string = '';
+
+  /** Structured event payload (transition from/to, rationale, evidence, …). */
+  @field({ type: 'text' })
+  payload: string = '{}';
+
+  getPayload(): Record<string, unknown> {
+    return parseJsonField(this.payload, {});
+  }
+
+  setPayload(value: Record<string, unknown>): void {
+    this.payload = JSON.stringify(value ?? {});
+  }
+}
+
+export class SupportCaseEventCollection extends SmrtCollection<SupportCaseEvent> {
+  static readonly _itemClass = SupportCaseEvent;
+
+  /** All events for a case, oldest first. */
+  async forCase(
+    caseId: string,
+    options: { eventType?: SupportCaseEventType } = {},
+  ): Promise<SupportCaseEvent[]> {
+    const where: Record<string, unknown> = { caseId };
+    if (options.eventType !== undefined) {
+      where.eventType = options.eventType;
+    }
+    return this.list({ where, orderBy: 'occurred_at ASC' });
+  }
+}
+
+export default SupportCaseEvent;

--- a/packages/support/src/models/support-case.test.ts
+++ b/packages/support/src/models/support-case.test.ts
@@ -1,0 +1,195 @@
+/**
+ * SupportCase model tests (#1926): the guarded lifecycle state machine,
+ * reopen bookkeeping fields, case numbering, and tenant isolation via the
+ * tenancy interceptor.
+ *
+ * Real in-memory SQLite from the generated manifest — the transition guard
+ * and unique indexes are exactly what ships.
+ */
+
+import {
+  disableTenancy,
+  enableTenancy,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  generateCaseNumber,
+  SupportCase,
+  SupportCaseCollection,
+} from './support-case.js';
+
+describe('SupportCase', () => {
+  let ctx: Awaited<ReturnType<typeof createIsolatedTestDbFromManifest>>;
+  let cases: SupportCaseCollection;
+
+  beforeEach(async () => {
+    ctx = await createIsolatedTestDbFromManifest({
+      includeObjects: ['SupportCase'],
+    });
+    cases = await SupportCaseCollection.create({ db: ctx.db });
+  });
+
+  afterEach(async () => {
+    disableTenancy();
+    await ctx.cleanup();
+  });
+
+  describe('lifecycle transitions', () => {
+    it('walks the standard path new → triaged → assigned → in_progress → resolved → closed', async () => {
+      const supportCase = await cases.create({
+        caseNumber: generateCaseNumber(),
+        subject: 'Login broken',
+        status: 'new',
+      });
+
+      for (const next of [
+        'triaged',
+        'assigned',
+        'in_progress',
+        'resolved',
+        'closed',
+      ] as const) {
+        supportCase.status = next;
+        await supportCase.save();
+        expect(supportCase.status).toBe(next);
+      }
+    });
+
+    it('rejects an illegal status flip done via raw field assignment', async () => {
+      const supportCase = await cases.create({
+        caseNumber: generateCaseNumber(),
+        subject: 'Billing question',
+        status: 'new',
+      });
+      supportCase.status = 'closed';
+      await supportCase.save();
+
+      supportCase.status = 'resolved';
+      await expect(supportCase.save()).rejects.toThrow(
+        /illegal status transition 'closed' → 'resolved'/,
+      );
+    });
+
+    it('rejects an illegal flip on an un-hydrated _skipLoad upsert (S5 #1390 idiom)', async () => {
+      const supportCase = await cases.create({
+        caseNumber: generateCaseNumber(),
+        subject: 'Feature request',
+        status: 'closed',
+      });
+
+      // Fresh instance carrying the existing id via the _skipLoad upsert path
+      // — its WeakMap entry is absent, so only the authoritative DB read can
+      // catch the illegal closed → resolved flip.
+      await expect(
+        cases.create({
+          id: supportCase.id,
+          caseNumber: supportCase.caseNumber,
+          subject: supportCase.subject,
+          status: 'resolved',
+          _skipLoad: true,
+        } as never),
+      ).rejects.toThrow(/illegal status transition 'closed' → 'resolved'/);
+
+      const reloaded = await cases.get({ id: supportCase.id });
+      expect(reloaded?.status).toBe('closed');
+    });
+
+    it('supports reopening from resolved and from closed', async () => {
+      const supportCase = await cases.create({
+        caseNumber: generateCaseNumber(),
+        subject: 'Recurring issue',
+        status: 'resolved',
+      });
+      supportCase.status = 'triaged';
+      await supportCase.save();
+      expect(supportCase.status).toBe('triaged');
+
+      supportCase.status = 'closed';
+      await supportCase.save();
+      supportCase.status = 'in_progress';
+      await supportCase.save();
+      expect(supportCase.status).toBe('in_progress');
+    });
+  });
+
+  describe('helpers', () => {
+    it('reports open vs terminal states', async () => {
+      const supportCase = new SupportCase({ db: ctx.db });
+      supportCase.status = 'in_progress';
+      expect(supportCase.isOpen()).toBe(true);
+      supportCase.status = 'closed';
+      expect(supportCase.isOpen()).toBe(false);
+    });
+
+    it('generates distinct, prefixed case numbers', () => {
+      const a = generateCaseNumber();
+      const b = generateCaseNumber();
+      expect(a).toMatch(/^SUP-/);
+      expect(a).not.toBe(b);
+    });
+
+    it('round-trips metadata and plan snapshots through the JSON helpers', async () => {
+      const supportCase = await cases.create({
+        caseNumber: generateCaseNumber(),
+        subject: 'meta',
+      });
+      supportCase.updateMetadata({ unresolvedClient: true });
+      supportCase.setPlanSnapshot({ planKey: 'gold' });
+      await supportCase.save();
+
+      const reloaded = await cases.get({ id: supportCase.id });
+      expect(reloaded?.getMetadata()).toEqual({ unresolvedClient: true });
+      expect(reloaded?.getPlanSnapshot()).toEqual({ planKey: 'gold' });
+    });
+  });
+
+  describe('tenant isolation', () => {
+    it('scopes queue reads to the active tenant', async () => {
+      enableTenancy();
+      await withTenant({ tenantId: 'tenant-a' }, async () => {
+        await cases.create({
+          tenantId: 'tenant-a',
+          caseNumber: generateCaseNumber(),
+          subject: 'A case',
+        });
+      });
+      await withTenant({ tenantId: 'tenant-b' }, async () => {
+        await cases.create({
+          tenantId: 'tenant-b',
+          caseNumber: generateCaseNumber(),
+          subject: 'B case',
+        });
+      });
+
+      await withTenant({ tenantId: 'tenant-a' }, async () => {
+        const visible = await cases.findQueue({ openOnly: true });
+        expect(visible).toHaveLength(1);
+        expect(visible[0]?.subject).toBe('A case');
+      });
+    });
+  });
+
+  describe('queue and thread lookups', () => {
+    it('finds the open case for a thread key but never a closed one', async () => {
+      const open = await cases.create({
+        caseNumber: generateCaseNumber(),
+        subject: 'open one',
+        threadKey: 'chat:room-1',
+        status: 'in_progress',
+      });
+      await cases.create({
+        caseNumber: generateCaseNumber(),
+        subject: 'closed one',
+        threadKey: 'chat:room-2',
+        status: 'closed',
+      });
+
+      expect((await cases.findOpenByThreadKey('chat:room-1'))?.id).toBe(
+        open.id,
+      );
+      expect(await cases.findOpenByThreadKey('chat:room-2')).toBeNull();
+    });
+  });
+});

--- a/packages/support/src/models/support-case.ts
+++ b/packages/support/src/models/support-case.ts
@@ -1,0 +1,328 @@
+/**
+ * SupportCase — the canonical, tenant-scoped record of a client support
+ * request (FR-28/FR-29): one Case per request across every channel, carrying
+ * priority, severity, plan snapshot, lifecycle state, assignment, resolution,
+ * and reopen history.
+ *
+ * Internal model — writes go through {@link SupportCaseService} (closed-facade
+ * idiom, mirroring `smrt-chat`'s `ChatService`). The generated CRUD surface is
+ * read-only (`list`/`get`); the save-time transition guard below additionally
+ * rejects illegal status flips done via raw field assignment.
+ */
+
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import {
+  OPEN_SUPPORT_CASE_STATUSES,
+  parseJsonField,
+  SUPPORT_CASE_STATUS_TRANSITIONS,
+  type SupportCaseStatus,
+} from '../types.js';
+
+/**
+ * Status each persisted row was loaded with, for the save-time transition
+ * guard. WeakMap (not a column) so it never round-trips through the DB.
+ */
+const loadedCaseStatus = new WeakMap<SupportCase, SupportCaseStatus>();
+
+/** Generate a short human-facing case number (unique enough per tenant). */
+export function generateCaseNumber(now: Date = new Date()): string {
+  const stamp = now.getTime().toString(36).toUpperCase();
+  const rand = Math.random().toString(36).slice(2, 6).toUpperCase();
+  return `SUP-${stamp}-${rand}`;
+}
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_cases',
+  api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+})
+export class SupportCase extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  /** Human-facing case reference (e.g. `SUP-…`), generated at open time. */
+  @field({ type: 'text' })
+  caseNumber: string = '';
+
+  /** Short client-facing summary of the request. */
+  @field({ type: 'text' })
+  subject: string = '';
+
+  /** Initial request text (the first inbound interaction's body). */
+  @field({ type: 'text' })
+  description: string = '';
+
+  @field({ type: 'text' })
+  status: SupportCaseStatus = 'new';
+
+  /** Queue ordering priority: `low` | `normal` | `high` | `urgent`. */
+  @field({ type: 'text' })
+  priority: string = 'normal';
+
+  /**
+   * Severity key resolved against the plan's severity definitions (e.g.
+   * `sev1`…`sev4`). Empty until triage/classification assigns one.
+   */
+  @field({ type: 'text' })
+  severity: string = '';
+
+  /** Classification category (AI- or human-assigned). Free vocabulary. */
+  @field({ type: 'text' })
+  category: string = '';
+
+  /** Whether the subject matter was flagged sensitive (handoff trigger). */
+  @field({ type: 'boolean' })
+  sensitive: boolean = false;
+
+  /** Origin transport kind (`chat` | `email` | …). */
+  @field({ type: 'text' })
+  channelKind: string = '';
+
+  /**
+   * The Client this Case belongs to (FR-29) — a `Person` or `Organization`
+   * Profile. Nullable so unmatched inbound email can park a Case for triage;
+   * intake marks those with `metadata.unresolvedClient`.
+   */
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { nullable: true })
+  clientProfileId: string | null = null;
+
+  /** The person who opened the request, when distinct from the Client. */
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { nullable: true })
+  openedByProfileId: string | null = null;
+
+  /**
+   * App-defined Project reference (a client initiative, not a repo board).
+   * Deliberately a plain string — the consuming app owns the Project concept.
+   */
+  @field({ type: 'text', nullable: true })
+  projectId: string | null = null;
+
+  /** Channel binding that created this case, when intake-created. */
+  @foreignKey('SupportChannelBinding')
+  bindingId: string | null = null;
+
+  /**
+   * Deterministic conversation key used by create-or-join intake dedup
+   * (e.g. `chat:<roomId>[:<threadId>]` or `email:<rfc-message-id>`).
+   */
+  @field({ type: 'text' })
+  threadKey: string = '';
+
+  /** Managed Support Plan governing this case, when one applies. */
+  @foreignKey('SupportPlan')
+  planId: string | null = null;
+
+  /**
+   * JSON snapshot of the plan terms captured when the plan was applied, so
+   * later plan edits never rewrite the terms a case was handled under.
+   * Read through {@link getPlanSnapshot}.
+   */
+  @field({ type: 'text' })
+  planSnapshot: string = '{}';
+
+  @foreignKey('SupportSpecialist')
+  assignedSpecialistId: string | null = null;
+
+  assignedAt: Date | null = null;
+
+  /** Client/plan preferred specialist considered first by routing (FR-30). */
+  @foreignKey('SupportSpecialist')
+  preferredSpecialistId: string | null = null;
+
+  /** Current escalation level (0 = never escalated). */
+  escalationLevel: number = 0;
+
+  escalatedAt: Date | null = null;
+
+  /** First outbound acknowledgement of any kind (starts as `null`). */
+  acknowledgedAt: Date | null = null;
+
+  /** First substantive outbound response (specialist or agent). */
+  firstRespondedAt: Date | null = null;
+
+  /** Set when the client explicitly requested a human (FR-28b). */
+  humanRequestedAt: Date | null = null;
+
+  resolvedAt: Date | null = null;
+
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { nullable: true })
+  resolvedByProfileId: string | null = null;
+
+  /** How the case was resolved: `automated` | `human` | `delivery`. */
+  @field({ type: 'text' })
+  resolutionKind: string = '';
+
+  @field({ type: 'text' })
+  resolutionSummary: string = '';
+
+  closedAt: Date | null = null;
+
+  /** Times this case was reopened; prior resolutions live in case events. */
+  reopenCount: number = 0;
+
+  lastReopenedAt: Date | null = null;
+
+  /** Per-case escape hatch: disable the AI workflow for this case only. */
+  @field({ type: 'boolean' })
+  aiEnabled: boolean = true;
+
+  @field({ type: 'text' })
+  metadata: string = '{}';
+
+  /** Whether the case is in an open (not resolved/closed) state. */
+  isOpen(): boolean {
+    return OPEN_SUPPORT_CASE_STATUSES.includes(this.status);
+  }
+
+  getMetadata(): Record<string, unknown> {
+    return parseJsonField(this.metadata, {});
+  }
+
+  setMetadata(value: Record<string, unknown>): void {
+    this.metadata = JSON.stringify(value ?? {});
+  }
+
+  updateMetadata(patch: Record<string, unknown>): void {
+    this.setMetadata({ ...this.getMetadata(), ...patch });
+  }
+
+  getPlanSnapshot(): Record<string, unknown> {
+    return parseJsonField(this.planSnapshot, {});
+  }
+
+  setPlanSnapshot(value: Record<string, unknown>): void {
+    this.planSnapshot = JSON.stringify(value ?? {});
+  }
+
+  /**
+   * Capture the status the row was loaded with so the save-time guard can
+   * reject illegal flips made via raw field assignment.
+   */
+  override async initialize(): Promise<this> {
+    await super.initialize();
+    if (await this.isSaved()) {
+      loadedCaseStatus.set(this, this.status);
+    }
+    return this;
+  }
+
+  /** Validate the status transition before persisting, then save. */
+  override async save(): Promise<this> {
+    const prior = await this.resolvePriorStatus();
+    this.assertStatusTransition(prior);
+    const result = (await super.save()) as this;
+    loadedCaseStatus.set(this, this.status);
+    return result;
+  }
+
+  protected assertStatusTransition(prior: SupportCaseStatus | undefined): void {
+    if (prior === undefined) return; // new row — any starting status
+    if (prior === this.status) return; // no-op re-save
+    const allowed = SUPPORT_CASE_STATUS_TRANSITIONS[prior] ?? [];
+    if (!allowed.includes(this.status)) {
+      throw new Error(
+        `SupportCase ${this.caseNumber || this.id}: illegal status transition ` +
+          `'${prior}' → '${this.status}'.`,
+      );
+    }
+  }
+
+  /**
+   * Resolve the AUTHORITATIVE prior status. The WeakMap only covers rows
+   * hydrated through {@link initialize}; a `create({ id, _skipLoad: true })`
+   * upsert would otherwise look brand-new and skip the guard, so when the
+   * instance carries an id, read the persisted row directly (S5 #1390 idiom).
+   */
+  protected async resolvePriorStatus(): Promise<SupportCaseStatus | undefined> {
+    if (this.id) {
+      try {
+        const row = await this.db.get(this.tableName, { id: this.id });
+        if (row && row.status != null) {
+          return row.status as SupportCaseStatus;
+        }
+      } catch {
+        // DB not ready / table absent — fall through to the in-memory record.
+      }
+    }
+    return loadedCaseStatus.get(this);
+  }
+}
+
+export class SupportCaseCollection extends SmrtCollection<SupportCase> {
+  static readonly _itemClass = SupportCase;
+
+  /**
+   * Find the open case an inbound interaction should join, by conversation
+   * key (create-or-join dedup, FR-28). Returns the most recently updated open
+   * case for the key, or `null` when a new case should be created.
+   */
+  async findOpenByThreadKey(
+    threadKey: string,
+    options: { bindingId?: string | null } = {},
+  ): Promise<SupportCase | null> {
+    const where: Record<string, unknown> = {
+      threadKey,
+      'status in': OPEN_SUPPORT_CASE_STATUSES,
+    };
+    if (options.bindingId !== undefined && options.bindingId !== null) {
+      where.bindingId = options.bindingId;
+    }
+    const matches = await this.list({
+      where,
+      orderBy: 'updated_at DESC',
+      limit: 1,
+    });
+    return matches[0] ?? null;
+  }
+
+  /** Queue listing with common filters, newest first. */
+  async findQueue(
+    options: {
+      status?: SupportCaseStatus | SupportCaseStatus[];
+      assignedSpecialistId?: string | null;
+      clientProfileId?: string;
+      projectId?: string;
+      openOnly?: boolean;
+      limit?: number;
+      offset?: number;
+    } = {},
+  ): Promise<SupportCase[]> {
+    const where: Record<string, unknown> = {};
+    if (options.status !== undefined) {
+      if (Array.isArray(options.status)) {
+        where['status in'] = options.status;
+      } else {
+        where.status = options.status;
+      }
+    } else if (options.openOnly) {
+      where['status in'] = OPEN_SUPPORT_CASE_STATUSES;
+    }
+    if (options.assignedSpecialistId !== undefined) {
+      where.assignedSpecialistId = options.assignedSpecialistId;
+    }
+    if (options.clientProfileId !== undefined) {
+      where.clientProfileId = options.clientProfileId;
+    }
+    if (options.projectId !== undefined) {
+      where.projectId = options.projectId;
+    }
+    return this.list({
+      where,
+      orderBy: 'updated_at DESC',
+      limit: options.limit ?? 50,
+      offset: options.offset ?? 0,
+    });
+  }
+}
+
+export default SupportCase;

--- a/packages/support/src/models/support-channel-binding.ts
+++ b/packages/support/src/models/support-channel-binding.ts
@@ -1,0 +1,127 @@
+/**
+ * SupportChannelBinding — marks a transport container (a chat room, an email
+ * account) as a Managed Support intake channel. Inbound activity on a bound
+ * container creates-or-joins Support Cases; unbound containers are never
+ * touched, so ordinary chat rooms and mailboxes stay out of the support
+ * system.
+ *
+ * Bindings are configuration (operator-managed), so unlike the case-side
+ * models they expose full generated CRUD.
+ */
+
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import {
+  parseJsonField,
+  parseStringArrayField,
+  type SupportBindingKind,
+  type SupportChannelKind,
+} from '../types.js';
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_channel_bindings',
+  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+  conflictColumns: ['target_type', 'target_id'],
+})
+export class SupportChannelBinding extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  /** Operator-facing binding name (inherited `name` is the display label). */
+  name: string = '';
+
+  @field({ type: 'text' })
+  bindingKind: SupportBindingKind = 'chat_room';
+
+  /** Channel kind interactions from this binding are recorded as. */
+  @field({ type: 'text' })
+  channelKind: SupportChannelKind = 'chat';
+
+  /**
+   * Qualified class of the bound container, e.g.
+   * `@happyvertical/smrt-chat:ChatRoom` or
+   * `@happyvertical/smrt-messages:EmailAccount`.
+   */
+  @field({ type: 'text' })
+  targetType: string = '';
+
+  /** Id of the bound container row. */
+  @field({ type: 'text' })
+  targetId: string = '';
+
+  /**
+   * Default Client for cases created from this binding (e.g. a dedicated
+   * client support room). When null, intake resolves the client from the
+   * interaction author (chat) or sender lookup (email).
+   */
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { nullable: true })
+  clientProfileId: string | null = null;
+
+  /** Default app-defined Project reference for cases from this binding. */
+  @field({ type: 'text', nullable: true })
+  projectId: string | null = null;
+
+  /** Managed Support Plan applied to cases created from this binding. */
+  @foreignKey('SupportPlan')
+  planId: string | null = null;
+
+  @field({ type: 'boolean' })
+  enabled: boolean = true;
+
+  /**
+   * Addresses belonging to the provider side of an email binding — inbound
+   * sync skips messages sent FROM these (they are our own outbound mail).
+   * JSON array of e-mail addresses, matched case-insensitively.
+   */
+  @field({ type: 'text' })
+  selfAddresses: string = '[]';
+
+  @field({ type: 'text' })
+  metadata: string = '{}';
+
+  getSelfAddresses(): string[] {
+    return parseStringArrayField(this.selfAddresses).map((address) =>
+      address.toLowerCase(),
+    );
+  }
+
+  setSelfAddresses(addresses: string[]): void {
+    this.selfAddresses = JSON.stringify(addresses ?? []);
+  }
+
+  getMetadata(): Record<string, unknown> {
+    return parseJsonField(this.metadata, {});
+  }
+
+  setMetadata(value: Record<string, unknown>): void {
+    this.metadata = JSON.stringify(value ?? {});
+  }
+}
+
+export class SupportChannelBindingCollection extends SmrtCollection<SupportChannelBinding> {
+  static readonly _itemClass = SupportChannelBinding;
+
+  /** Find the enabled binding for a transport container, if any. */
+  async findForTarget(
+    targetType: string,
+    targetId: string,
+  ): Promise<SupportChannelBinding | null> {
+    const matches = await this.list({
+      where: { targetType, targetId, enabled: true },
+      limit: 1,
+    });
+    return matches[0] ?? null;
+  }
+}
+
+export default SupportChannelBinding;

--- a/packages/support/src/models/support-compensation-plan.ts
+++ b/packages/support/src/models/support-compensation-plan.ts
@@ -1,0 +1,107 @@
+/**
+ * SupportCompensationPlan — the provider-facing **Support Compensation Plan**
+ * (FR-32/FR-35): the effective-dated terms under which a Support Specialist
+ * earns for delivered support time. Deliberately separate from
+ * {@link SupportPlan} (client pricing) so margin stays measurable and client
+ * terms never leak provider terms.
+ *
+ * Resolution: the specialist-specific plan effective at the work instant
+ * wins; otherwise the tenant default (`specialistId` null) effective at that
+ * instant applies.
+ */
+
+import {
+  field,
+  foreignKey,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import { parseJsonField } from '../types.js';
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_compensation_plans',
+  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+  conflictColumns: ['tenant_id', 'specialist_id', 'effective_from'],
+})
+export class SupportCompensationPlan extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  /** Specialist this plan compensates; null = tenant default plan. */
+  @foreignKey('SupportSpecialist')
+  specialistId: string | null = null;
+
+  /** Display name (inherited `name`; uniqueness comes from conflictColumns). */
+  name: string = '';
+
+  /** Hourly earning rate for delivered support time. */
+  hourlyRate: number = 0.0;
+
+  @field({ type: 'text' })
+  currency: string = 'USD';
+
+  /** Effective-dating: null bounds mean open-ended. */
+  effectiveFrom: Date | null = null;
+
+  effectiveTo: Date | null = null;
+
+  /** `active` | `archived`. */
+  @field({ type: 'text' })
+  status: string = 'active';
+
+  /** Additional agreement terms (JSON object; free-form, snapshotted). */
+  @field({ type: 'text' })
+  terms: string = '{}';
+
+  getTerms(): Record<string, unknown> {
+    return parseJsonField(this.terms, {});
+  }
+
+  setTerms(value: Record<string, unknown>): void {
+    this.terms = JSON.stringify(value ?? {});
+  }
+
+  /** Whether the plan is effective at the given instant. */
+  isEffectiveAt(at: Date = new Date()): boolean {
+    if (this.status !== 'active') return false;
+    if (this.effectiveFrom && at < this.effectiveFrom) return false;
+    if (this.effectiveTo && at >= this.effectiveTo) return false;
+    return true;
+  }
+}
+
+export class SupportCompensationPlanCollection extends SmrtCollection<SupportCompensationPlan> {
+  static readonly _itemClass = SupportCompensationPlan;
+
+  /**
+   * Resolve the plan compensating a specialist at a work instant:
+   * specialist-specific first, then the tenant default. Ties (overlapping
+   * effective ranges) prefer the latest `effectiveFrom`.
+   */
+  async resolveForSpecialist(
+    specialistId: string,
+    at: Date = new Date(),
+  ): Promise<SupportCompensationPlan | null> {
+    const candidates = await this.list({
+      where: { status: 'active' },
+    });
+    const effective = candidates.filter((plan) => plan.isEffectiveAt(at));
+    const pick = (plans: SupportCompensationPlan[]) =>
+      plans.sort(
+        (a, b) =>
+          (b.effectiveFrom?.getTime() ?? 0) - (a.effectiveFrom?.getTime() ?? 0),
+      )[0] ?? null;
+    const specific = pick(
+      effective.filter((plan) => plan.specialistId === specialistId),
+    );
+    if (specific) return specific;
+    return pick(effective.filter((plan) => plan.specialistId === null));
+  }
+}
+
+export default SupportCompensationPlan;

--- a/packages/support/src/models/support-compensation-plan.ts
+++ b/packages/support/src/models/support-compensation-plan.ts
@@ -20,10 +20,13 @@ import {
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import { parseJsonField } from '../types.js';
 
+// Provider earning terms are written only through the
+// `support.manage-plans`-gated `SupportPlanAdminService`; the generated
+// surface stays read-only (see SupportPlan for the rationale).
 @TenantScoped({ mode: 'optional' })
 @smrt({
   tableName: 'support_compensation_plans',
-  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  api: { include: ['list', 'get'] },
   mcp: { include: ['list', 'get'] },
   cli: { include: ['list', 'get'] },
   conflictColumns: ['tenant_id', 'specialist_id', 'effective_from'],

--- a/packages/support/src/models/support-compensation-plan.ts
+++ b/packages/support/src/models/support-compensation-plan.ts
@@ -81,21 +81,42 @@ export class SupportCompensationPlanCollection extends SmrtCollection<SupportCom
   /**
    * Resolve the plan compensating a specialist at a work instant:
    * specialist-specific first, then the tenant default. Ties (overlapping
-   * effective ranges) prefer the latest `effectiveFrom`.
+   * effective ranges) prefer an exact tenant match over a global
+   * (NULL-tenant) plan, then the latest `effectiveFrom`.
+   *
+   * Pass `options.tenantId` (the work's tenant) whenever resolution may run
+   * without an ambient tenant context (system/job paths list across
+   * tenants): candidates are then limited to that tenant's plans plus
+   * global NULL-tenant plans, so another tenant's default can never price
+   * this tenant's work.
    */
   async resolveForSpecialist(
     specialistId: string,
     at: Date = new Date(),
+    options: { tenantId?: string | null } = {},
   ): Promise<SupportCompensationPlan | null> {
     const candidates = await this.list({
       where: { status: 'active' },
     });
-    const effective = candidates.filter((plan) => plan.isEffectiveAt(at));
+    const tenantId = options.tenantId;
+    const effective = candidates.filter(
+      (plan) =>
+        plan.isEffectiveAt(at) &&
+        (tenantId === undefined ||
+          plan.tenantId === null ||
+          plan.tenantId === tenantId),
+    );
     const pick = (plans: SupportCompensationPlan[]) =>
-      plans.sort(
-        (a, b) =>
-          (b.effectiveFrom?.getTime() ?? 0) - (a.effectiveFrom?.getTime() ?? 0),
-      )[0] ?? null;
+      plans.sort((a, b) => {
+        if (tenantId !== undefined) {
+          const aExact = a.tenantId === tenantId ? 1 : 0;
+          const bExact = b.tenantId === tenantId ? 1 : 0;
+          if (aExact !== bExact) return bExact - aExact;
+        }
+        return (
+          (b.effectiveFrom?.getTime() ?? 0) - (a.effectiveFrom?.getTime() ?? 0)
+        );
+      })[0] ?? null;
     const specific = pick(
       effective.filter((plan) => plan.specialistId === specialistId),
     );

--- a/packages/support/src/models/support-interaction.ts
+++ b/packages/support/src/models/support-interaction.ts
@@ -81,6 +81,14 @@ export class SupportInteraction extends SmrtObject {
   @field({ type: 'text' })
   sourceKey: string = '';
 
+  /**
+   * RFC 822 Message-ID for email interactions — a first-class column so
+   * reply threading (`In-Reply-To` joins) is a keyed lookup instead of a
+   * bounded metadata scan. Empty for non-email interactions.
+   */
+  @field({ type: 'text' })
+  rfcMessageId: string = '';
+
   @field({ type: 'text' })
   metadata: string = '{}';
 
@@ -107,6 +115,17 @@ export class SupportInteractionCollection extends SmrtCollection<SupportInteract
   /** Look up an interaction by its idempotency key. */
   async bySourceKey(sourceKey: string): Promise<SupportInteraction | null> {
     const matches = await this.list({ where: { sourceKey }, limit: 1 });
+    return matches[0] ?? null;
+  }
+
+  /** Keyed lookup of an email interaction by its RFC 822 Message-ID. */
+  async byRfcMessageId(
+    rfcMessageId: string,
+  ): Promise<SupportInteraction | null> {
+    if (!rfcMessageId) {
+      return null;
+    }
+    const matches = await this.list({ where: { rfcMessageId }, limit: 1 });
     return matches[0] ?? null;
   }
 }

--- a/packages/support/src/models/support-interaction.ts
+++ b/packages/support/src/models/support-interaction.ts
@@ -1,0 +1,114 @@
+/**
+ * SupportInteraction — a channel-neutral transport record attached to a
+ * Support Case (FR-28/FR-29): one row per message/chat/email/voice exchange,
+ * preserving chronology and transport metadata. The channel row (a
+ * `ChatMessage`, an `Email`, …) stays in its own package; this row links it
+ * via a qualified `sourceType`/`sourceId` pair and a globally unique
+ * `sourceKey` so re-ingesting the same transport record is idempotent.
+ *
+ * Internal model — writes go through {@link SupportCaseService}. Generated
+ * surface is read-only.
+ */
+
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import {
+  parseJsonField,
+  type SupportActorKind,
+  type SupportChannelKind,
+  type SupportInteractionDirection,
+} from '../types.js';
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_interactions',
+  api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+  conflictColumns: ['source_key'],
+})
+export class SupportInteraction extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  @foreignKey('SupportCase', { required: true })
+  caseId: string = '';
+
+  @field({ type: 'text' })
+  direction: SupportInteractionDirection = 'inbound';
+
+  @field({ type: 'text' })
+  channelKind: SupportChannelKind = 'chat';
+
+  @field({ type: 'text' })
+  actorKind: SupportActorKind = 'client';
+
+  /** Author identity when known (client contact, specialist, bot profile). */
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { nullable: true })
+  authorProfileId: string | null = null;
+
+  /** When the exchange happened on its channel (not when it was ingested). */
+  occurredAt: Date = new Date();
+
+  /** Denormalized text body for the case timeline (source stays canonical). */
+  @field({ type: 'text' })
+  body: string = '';
+
+  /**
+   * Qualified class of the source transport record, e.g.
+   * `@happyvertical/smrt-chat:ChatMessage` or
+   * `@happyvertical/smrt-messages:Email`. Null for manual notes.
+   */
+  @field({ type: 'text', nullable: true })
+  sourceType: string | null = null;
+
+  /** Id of the source transport record. Null for manual notes. */
+  @field({ type: 'text', nullable: true })
+  sourceId: string | null = null;
+
+  /**
+   * Globally unique idempotency key for intake dedup (`conflictColumns`):
+   * `chat:<messageId>`, `email:<emailId>`, or `manual:<uuid>` for
+   * service-authored notes.
+   */
+  @field({ type: 'text' })
+  sourceKey: string = '';
+
+  @field({ type: 'text' })
+  metadata: string = '{}';
+
+  getMetadata(): Record<string, unknown> {
+    return parseJsonField(this.metadata, {});
+  }
+
+  setMetadata(value: Record<string, unknown>): void {
+    this.metadata = JSON.stringify(value ?? {});
+  }
+}
+
+export class SupportInteractionCollection extends SmrtCollection<SupportInteraction> {
+  static readonly _itemClass = SupportInteraction;
+
+  /** All interactions for a case in channel chronology (oldest first). */
+  async forCase(caseId: string): Promise<SupportInteraction[]> {
+    return this.list({
+      where: { caseId },
+      orderBy: 'occurred_at ASC',
+    });
+  }
+
+  /** Look up an interaction by its idempotency key. */
+  async bySourceKey(sourceKey: string): Promise<SupportInteraction | null> {
+    const matches = await this.list({ where: { sourceKey }, limit: 1 });
+    return matches[0] ?? null;
+  }
+}
+
+export default SupportInteraction;

--- a/packages/support/src/models/support-plan.ts
+++ b/packages/support/src/models/support-plan.ts
@@ -43,10 +43,14 @@ export const DEFAULT_TARGET_MINUTES: ServiceTargetMinutes = {
   resolutionMinutes: null,
 };
 
+// Commercial terms are written only through the `support.manage-plans`-gated
+// `SupportPlanAdminService` — the generated surface stays read-only so an
+// authenticated caller cannot rewrite pricing/service terms via CRUD routes
+// (`create` would even upsert over `conflictColumns`).
 @TenantScoped({ mode: 'optional' })
 @smrt({
   tableName: 'support_plans',
-  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  api: { include: ['list', 'get'] },
   mcp: { include: ['list', 'get'] },
   cli: { include: ['list', 'get'] },
   conflictColumns: ['tenant_id', 'plan_key'],

--- a/packages/support/src/models/support-plan.ts
+++ b/packages/support/src/models/support-plan.ts
@@ -1,0 +1,275 @@
+/**
+ * SupportPlan — the client-facing **Managed Support Plan** (FR-31): coverage
+ * hours and channels, severity definitions, acknowledgement / response /
+ * update / resolution Service Targets, pause rules, escalation policy, an
+ * availability fee, included support time, and metered overage pricing.
+ *
+ * Pure hourly support is a plan with zero availability fee and zero included
+ * minutes. A Service Target here is an operational objective — it becomes a
+ * contractual Service Level Agreement only in the governing agreement, which
+ * is out of this package's scope.
+ *
+ * Client pricing lives here; Support Specialist earnings live in the separate
+ * {@link SupportCompensationPlan} — the two are never merged (FR-32/FR-35).
+ *
+ * `subscriptionPlanKey` optionally binds the plan to a
+ * `@happyvertical/smrt-subscriptions` plan by its natural key for entitlement
+ * checks — a string reference, deliberately not a package dependency.
+ */
+
+import {
+  field,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import {
+  type CoverageWindow,
+  DEFAULT_SEVERITY_DEFINITIONS,
+  type EscalationStep,
+  parseJsonField,
+  parseStringArrayField,
+  type ServiceTargetMinutes,
+  type SeverityDefinition,
+  type TimeApprovalPolicy,
+} from '../types.js';
+
+/** Default target minutes applied when a plan omits a severity's targets. */
+export const DEFAULT_TARGET_MINUTES: ServiceTargetMinutes = {
+  acknowledgementMinutes: 60,
+  responseMinutes: 240,
+  updateMinutes: null,
+  resolutionMinutes: null,
+};
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_plans',
+  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+  conflictColumns: ['tenant_id', 'plan_key'],
+})
+export class SupportPlan extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  /** Natural key, unique per tenant (`conflictColumns`). */
+  @field({ type: 'text' })
+  planKey: string = '';
+
+  /** Display name (inherited `name` field). */
+  name: string = '';
+
+  @field({ type: 'text' })
+  description: string = '';
+
+  /** `draft` | `active` | `archived`. */
+  @field({ type: 'text' })
+  status: string = 'active';
+
+  /** Channels this plan covers (JSON array of channel kinds). */
+  @field({ type: 'text' })
+  channels: string = '["chat","email"]';
+
+  /** IANA timezone the coverage calendar is expressed in. */
+  @field({ type: 'text' })
+  timezone: string = 'UTC';
+
+  /**
+   * Coverage calendar: JSON array of {@link CoverageWindow}. Empty array
+   * means 24×7 coverage (clocks always run).
+   */
+  @field({ type: 'text' })
+  coverage: string = '[]';
+
+  /** Holiday dates excluded from coverage (JSON array of `YYYY-MM-DD`). */
+  @field({ type: 'text' })
+  holidays: string = '[]';
+
+  /**
+   * Severity vocabulary for this plan: JSON map of severity key →
+   * {@link SeverityDefinition}. Empty object falls back to
+   * `DEFAULT_SEVERITY_DEFINITIONS`.
+   */
+  @field({ type: 'text' })
+  severityDefinitions: string = '{}';
+
+  /**
+   * Service Targets per severity: JSON map of severity key →
+   * {@link ServiceTargetMinutes}. Missing severities fall back to
+   * `DEFAULT_TARGET_MINUTES`; explicit `null` minutes disable that clock.
+   */
+  @field({ type: 'text' })
+  targets: string = '{}';
+
+  /**
+   * Case statuses that pause Service Target clocks (FR-29b: waiting periods
+   * pause clocks only when the plan says so). JSON array of statuses.
+   */
+  @field({ type: 'text' })
+  pauseStatuses: string = '["waiting_on_client"]';
+
+  /** Escalation policy: JSON array of {@link EscalationStep}, level order. */
+  @field({ type: 'text' })
+  escalationPolicy: string = '[]';
+
+  /** Recurring availability/retainer fee (0.0 = pure hourly support). */
+  availabilityFeeAmount: number = 0.0;
+
+  @field({ type: 'text' })
+  currency: string = 'USD';
+
+  /** Included support minutes per period (0 = none included). */
+  includedMinutes: number = 0;
+
+  /** Metered hourly rate for time beyond the included minutes. */
+  overageHourlyRate: number = 0.0;
+
+  /** Premium hourly rate for on-call work (0.0 = use overage rate). */
+  onCallHourlyRate: number = 0.0;
+
+  /**
+   * Time-entry approval policy for work under this plan (FR-36): JSON
+   * {@link TimeApprovalPolicy}. Empty object = operator approval.
+   */
+  @field({ type: 'text' })
+  timeApprovalPolicy: string = '{}';
+
+  /** Optional `@happyvertical/smrt-subscriptions` plan natural key binding. */
+  @field({ type: 'text' })
+  subscriptionPlanKey: string = '';
+
+  @field({ type: 'text' })
+  metadata: string = '{}';
+
+  getChannels(): string[] {
+    return parseStringArrayField(this.channels);
+  }
+
+  setChannels(channels: string[]): void {
+    this.channels = JSON.stringify(channels ?? []);
+  }
+
+  getCoverage(): CoverageWindow[] {
+    const parsed = parseJsonField<CoverageWindow[]>(this.coverage, []);
+    return Array.isArray(parsed) ? parsed : [];
+  }
+
+  setCoverage(windows: CoverageWindow[]): void {
+    this.coverage = JSON.stringify(windows ?? []);
+  }
+
+  getHolidays(): string[] {
+    return parseStringArrayField(this.holidays);
+  }
+
+  setHolidays(dates: string[]): void {
+    this.holidays = JSON.stringify(dates ?? []);
+  }
+
+  getSeverityDefinitions(): Record<string, SeverityDefinition> {
+    const parsed = parseJsonField<Record<string, SeverityDefinition>>(
+      this.severityDefinitions,
+      {},
+    );
+    return Object.keys(parsed).length > 0
+      ? parsed
+      : { ...DEFAULT_SEVERITY_DEFINITIONS };
+  }
+
+  setSeverityDefinitions(defs: Record<string, SeverityDefinition>): void {
+    this.severityDefinitions = JSON.stringify(defs ?? {});
+  }
+
+  getTargets(): Record<string, Partial<ServiceTargetMinutes>> {
+    return parseJsonField(this.targets, {});
+  }
+
+  setTargets(targets: Record<string, Partial<ServiceTargetMinutes>>): void {
+    this.targets = JSON.stringify(targets ?? {});
+  }
+
+  /** Effective target minutes for a severity, with defaults applied. */
+  targetsForSeverity(severity: string): ServiceTargetMinutes {
+    const configured = this.getTargets()[severity] ?? {};
+    return { ...DEFAULT_TARGET_MINUTES, ...configured };
+  }
+
+  getPauseStatuses(): string[] {
+    return parseStringArrayField(this.pauseStatuses);
+  }
+
+  setPauseStatuses(statuses: string[]): void {
+    this.pauseStatuses = JSON.stringify(statuses ?? []);
+  }
+
+  getEscalationPolicy(): EscalationStep[] {
+    const parsed = parseJsonField<EscalationStep[]>(this.escalationPolicy, []);
+    return Array.isArray(parsed) ? parsed : [];
+  }
+
+  setEscalationPolicy(steps: EscalationStep[]): void {
+    this.escalationPolicy = JSON.stringify(steps ?? []);
+  }
+
+  getTimeApprovalPolicy(): TimeApprovalPolicy {
+    const parsed = parseJsonField<Partial<TimeApprovalPolicy>>(
+      this.timeApprovalPolicy,
+      {},
+    );
+    return { mode: 'operator', ...parsed };
+  }
+
+  setTimeApprovalPolicy(policy: TimeApprovalPolicy): void {
+    this.timeApprovalPolicy = JSON.stringify(policy ?? {});
+  }
+
+  getMetadata(): Record<string, unknown> {
+    return parseJsonField(this.metadata, {});
+  }
+
+  setMetadata(value: Record<string, unknown>): void {
+    this.metadata = JSON.stringify(value ?? {});
+  }
+
+  /**
+   * The plan terms captured onto a case at apply time (`planSnapshot`), so
+   * later plan edits never rewrite the terms a case was handled under.
+   */
+  snapshotTerms(): Record<string, unknown> {
+    return {
+      planId: this.id,
+      planKey: this.planKey,
+      name: this.name,
+      timezone: this.timezone,
+      channels: this.getChannels(),
+      coverage: this.getCoverage(),
+      holidays: this.getHolidays(),
+      severityDefinitions: this.getSeverityDefinitions(),
+      targets: this.getTargets(),
+      pauseStatuses: this.getPauseStatuses(),
+      escalationPolicy: this.getEscalationPolicy(),
+      availabilityFeeAmount: this.availabilityFeeAmount,
+      currency: this.currency,
+      includedMinutes: this.includedMinutes,
+      overageHourlyRate: this.overageHourlyRate,
+      onCallHourlyRate: this.onCallHourlyRate,
+      timeApprovalPolicy: this.getTimeApprovalPolicy(),
+      subscriptionPlanKey: this.subscriptionPlanKey,
+      capturedAt: new Date().toISOString(),
+    };
+  }
+}
+
+export class SupportPlanCollection extends SmrtCollection<SupportPlan> {
+  static readonly _itemClass = SupportPlan;
+
+  async byPlanKey(planKey: string): Promise<SupportPlan | null> {
+    const matches = await this.list({ where: { planKey }, limit: 1 });
+    return matches[0] ?? null;
+  }
+}
+
+export default SupportPlan;

--- a/packages/support/src/models/support-policy.ts
+++ b/packages/support/src/models/support-policy.ts
@@ -1,0 +1,181 @@
+/**
+ * SupportPolicy — governs what the AI support workflow may do without a human
+ * (FR-28a/FR-28b): which phases run automatically, whether low-risk
+ * resolutions may complete autonomously, the confidence floor, sensitive
+ * categories, and the tool whitelist for troubleshooting.
+ *
+ * Resolution is most-specific-wins per case: `(planId, projectId)` exact →
+ * `planId` → `projectId` → tenant default (both null) → the package's
+ * conservative built-in defaults (see `DEFAULT_SUPPORT_POLICY`). Policies are
+ * operator configuration, so they expose full generated CRUD.
+ */
+
+import {
+  field,
+  foreignKey,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import { parseJsonField, parseStringArrayField } from '../types.js';
+
+/**
+ * Conservative defaults applied when no SupportPolicy row matches: the AI
+ * acknowledges, classifies, and answers, but never closes a case or executes
+ * tools until a policy explicitly enables it. Handoff triggers are always
+ * active regardless of policy.
+ */
+export const DEFAULT_SUPPORT_POLICY = {
+  autoAcknowledge: true,
+  autoClassify: true,
+  autoAnswer: true,
+  autoTroubleshoot: false,
+  autoResolve: false,
+  autoResolveMaxSeverity: '',
+  confidenceThreshold: 0.7,
+  maxAutoAttempts: 1,
+  autoSendEmailReplies: false,
+  sensitiveCategories: [] as string[],
+  allowedTools: [] as string[],
+} as const;
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_policies',
+  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+  conflictColumns: ['tenant_id', 'name'],
+})
+export class SupportPolicy extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  /** Policy name, unique per tenant (`conflictColumns`). */
+  name: string = '';
+
+  /** Scope: applies to cases under this plan (null = any plan). */
+  @foreignKey('SupportPlan')
+  planId: string | null = null;
+
+  /** Scope: applies to cases for this app-defined project (null = any). */
+  @field({ type: 'text', nullable: true })
+  projectId: string | null = null;
+
+  @field({ type: 'boolean' })
+  enabled: boolean = true;
+
+  /** Immediately acknowledge new inbound cases. */
+  @field({ type: 'boolean' })
+  autoAcknowledge: boolean = true;
+
+  /** Classify severity/category/sensitivity on intake. */
+  @field({ type: 'boolean' })
+  autoClassify: boolean = true;
+
+  /** Post an automated answer using scoped knowledge. */
+  @field({ type: 'boolean' })
+  autoAnswer: boolean = true;
+
+  /** Run tool-executing troubleshooting (gated OFF by default). */
+  @field({ type: 'boolean' })
+  autoTroubleshoot: boolean = false;
+
+  /** Allow the AI to resolve (close out) low-risk cases (OFF by default). */
+  @field({ type: 'boolean' })
+  autoResolve: boolean = false;
+
+  /**
+   * Highest severity the AI may auto-resolve (e.g. `sev4` = questions only).
+   * Empty means "no severity is eligible" even when `autoResolve` is true.
+   */
+  @field({ type: 'text' })
+  autoResolveMaxSeverity: string = '';
+
+  /**
+   * Confidence floor for automated answers/resolutions; below it the workflow
+   * triggers a `low_confidence` Human Handoff.
+   */
+  confidenceThreshold: number = 0.7;
+
+  /** Max automated resolution attempts before a `failed_resolution` handoff. */
+  maxAutoAttempts: number = 1;
+
+  /** Whether automated email replies may be sent (vs drafted) — OFF default. */
+  @field({ type: 'boolean' })
+  autoSendEmailReplies: boolean = false;
+
+  /**
+   * Categories considered sensitive: classification into one of these always
+   * triggers a Human Handoff (FR-28b). JSON array of category keys.
+   */
+  @field({ type: 'text' })
+  sensitiveCategories: string = '[]';
+
+  /** Tool ids the troubleshooting phase may execute. JSON array, fail-closed. */
+  @field({ type: 'text' })
+  allowedTools: string = '[]';
+
+  @field({ type: 'text' })
+  metadata: string = '{}';
+
+  getSensitiveCategories(): string[] {
+    return parseStringArrayField(this.sensitiveCategories);
+  }
+
+  setSensitiveCategories(categories: string[]): void {
+    this.sensitiveCategories = JSON.stringify(categories ?? []);
+  }
+
+  getAllowedTools(): string[] {
+    return parseStringArrayField(this.allowedTools);
+  }
+
+  setAllowedTools(tools: string[]): void {
+    this.allowedTools = JSON.stringify(tools ?? []);
+  }
+
+  getMetadata(): Record<string, unknown> {
+    return parseJsonField(this.metadata, {});
+  }
+
+  setMetadata(value: Record<string, unknown>): void {
+    this.metadata = JSON.stringify(value ?? {});
+  }
+
+  /** Specificity rank for resolution: exact scope wins over partial. */
+  scopeRank(): number {
+    let rank = 0;
+    if (this.planId) rank += 2;
+    if (this.projectId) rank += 1;
+    return rank;
+  }
+}
+
+export class SupportPolicyCollection extends SmrtCollection<SupportPolicy> {
+  static readonly _itemClass = SupportPolicy;
+
+  /**
+   * Resolve the effective policy for a case scope, most-specific-wins.
+   * Returns `null` when no enabled policy matches (callers then apply
+   * {@link DEFAULT_SUPPORT_POLICY}).
+   */
+  async resolveForScope(options: {
+    planId?: string | null;
+    projectId?: string | null;
+  }): Promise<SupportPolicy | null> {
+    const policies = await this.list({ where: { enabled: true } });
+    const planId = options.planId ?? null;
+    const projectId = options.projectId ?? null;
+    const applicable = policies.filter((policy) => {
+      if (policy.planId && policy.planId !== planId) return false;
+      if (policy.projectId && policy.projectId !== projectId) return false;
+      return true;
+    });
+    applicable.sort((a, b) => b.scopeRank() - a.scopeRank());
+    return applicable[0] ?? null;
+  }
+}
+
+export default SupportPolicy;

--- a/packages/support/src/models/support-service-target.ts
+++ b/packages/support/src/models/support-service-target.ts
@@ -1,0 +1,188 @@
+/**
+ * Service Target clocks and escalations (FR-30/FR-31).
+ *
+ * - **SupportServiceTarget** — one acknowledgement/response/update/resolution
+ *   clock on a case, derived from the applicable plan's targets, coverage
+ *   calendar, and pause rules. `escalationJobId` holds the one-shot
+ *   `_smrt_jobs` row scheduled at `dueAt` so satisfying the target can cancel
+ *   the pending escalation.
+ * - **SupportEscalation** — the auditable record of one escalation firing
+ *   (target breach, target risk, manual, or AI-triggered).
+ *
+ * Both are written by the target engine / case service only; generated
+ * surfaces are read-only.
+ */
+
+import {
+  field,
+  foreignKey,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import {
+  parseJsonField,
+  parseStringArrayField,
+  type ServiceTargetStatus,
+  type ServiceTargetType,
+  type SupportEscalationReason,
+} from '../types.js';
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_service_targets',
+  api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+  conflictColumns: ['case_id', 'target_type', 'cycle'],
+})
+export class SupportServiceTarget extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  @foreignKey('SupportCase', { required: true })
+  caseId: string = '';
+
+  @field({ type: 'text' })
+  targetType: ServiceTargetType = 'acknowledgement';
+
+  /**
+   * Recurrence cycle for repeating clocks (`update` restarts after each
+   * update). One-shot clocks stay at cycle 0.
+   */
+  cycle: number = 0;
+
+  /** Severity key the minutes were derived from (audit). */
+  @field({ type: 'text' })
+  severity: string = '';
+
+  /** Configured clock length in covered minutes. */
+  baseMinutes: number = 0;
+
+  /** When the clock started running. */
+  startedAt: Date = new Date();
+
+  /** Current deadline, in wall-clock time (recomputed on pause/resume). */
+  dueAt: Date = new Date();
+
+  @field({ type: 'text' })
+  status: ServiceTargetStatus = 'pending';
+
+  /** Set while the clock is paused (plan pause rules). */
+  pausedAt: Date | null = null;
+
+  /** Accumulated paused time, excluded from the clock. */
+  pausedTotalSeconds: number = 0;
+
+  satisfiedAt: Date | null = null;
+
+  breachedAt: Date | null = null;
+
+  cancelledAt: Date | null = null;
+
+  /** One-shot `_smrt_jobs` id scheduled for `dueAt` (cancel on satisfy). */
+  @field({ type: 'text' })
+  escalationJobId: string = '';
+
+  @field({ type: 'text' })
+  metadata: string = '{}';
+
+  getMetadata(): Record<string, unknown> {
+    return parseJsonField(this.metadata, {});
+  }
+
+  setMetadata(value: Record<string, unknown>): void {
+    this.metadata = JSON.stringify(value ?? {});
+  }
+
+  isRunning(): boolean {
+    return this.status === 'pending';
+  }
+}
+
+export class SupportServiceTargetCollection extends SmrtCollection<SupportServiceTarget> {
+  static readonly _itemClass = SupportServiceTarget;
+
+  async forCase(caseId: string): Promise<SupportServiceTarget[]> {
+    return this.list({ where: { caseId }, orderBy: 'created_at ASC' });
+  }
+
+  /** Active clock of a type on a case (highest cycle wins). */
+  async activeTarget(
+    caseId: string,
+    targetType: ServiceTargetType,
+  ): Promise<SupportServiceTarget | null> {
+    const matches = await this.list({
+      where: { caseId, targetType, 'status in': ['pending', 'paused'] },
+      orderBy: 'cycle DESC',
+      limit: 1,
+    });
+    return matches[0] ?? null;
+  }
+}
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_escalations',
+  api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+})
+export class SupportEscalation extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  @foreignKey('SupportCase', { required: true })
+  caseId: string = '';
+
+  /** Escalation level applied (1-based, follows the plan's policy steps). */
+  level: number = 1;
+
+  @field({ type: 'text' })
+  reason: SupportEscalationReason = 'target_breach';
+
+  /** Breached/at-risk target that triggered this, when applicable. */
+  @foreignKey('SupportServiceTarget')
+  targetId: string | null = null;
+
+  @field({ type: 'text' })
+  targetType: string = '';
+
+  /** Escalation action taken: `notify` | `reassign`. */
+  @field({ type: 'text' })
+  action: string = 'notify';
+
+  @foreignKey('SupportSpecialist')
+  fromSpecialistId: string | null = null;
+
+  @foreignKey('SupportSpecialist')
+  toSpecialistId: string | null = null;
+
+  /** Profiles notified (JSON array of profile ids). */
+  @field({ type: 'text' })
+  notifiedProfileIds: string = '[]';
+
+  occurredAt: Date = new Date();
+
+  @field({ type: 'text' })
+  note: string = '';
+
+  getNotifiedProfileIds(): string[] {
+    return parseStringArrayField(this.notifiedProfileIds);
+  }
+
+  setNotifiedProfileIds(ids: string[]): void {
+    this.notifiedProfileIds = JSON.stringify(ids ?? []);
+  }
+}
+
+export class SupportEscalationCollection extends SmrtCollection<SupportEscalation> {
+  static readonly _itemClass = SupportEscalation;
+
+  async forCase(caseId: string): Promise<SupportEscalation[]> {
+    return this.list({ where: { caseId }, orderBy: 'occurred_at ASC' });
+  }
+}
+
+export default SupportServiceTarget;

--- a/packages/support/src/models/support-service-target.ts
+++ b/packages/support/src/models/support-service-target.ts
@@ -20,6 +20,7 @@ import {
   SmrtObject,
   smrt,
 } from '@happyvertical/smrt-core';
+import { backgroundEligible } from '@happyvertical/smrt-jobs';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import {
   parseJsonField,
@@ -28,6 +29,11 @@ import {
   type ServiceTargetType,
   type SupportEscalationReason,
 } from '../types.js';
+
+/** Outcome of one {@link SupportServiceTarget.checkAndEscalate} delivery. */
+export interface CheckAndEscalateResult {
+  outcome: 'breached' | 'escalated' | 'rescheduled' | 'noop' | 'missing';
+}
 
 @TenantScoped({ mode: 'optional' })
 @smrt({
@@ -98,6 +104,77 @@ export class SupportServiceTarget extends SmrtObject {
 
   isRunning(): boolean {
     return this.status === 'pending';
+  }
+
+  /**
+   * One-shot escalation job entry point, delivered at-least-once by the
+   * jobs runner at `dueAt` (and again for delayed policy steps). Reloads its
+   * own persisted state first, so stale deliveries are harmless:
+   *
+   * - not `pending` and no due pending-escalation marker → no-op (already
+   *   satisfied/cancelled/paused, or an already-breached clock without a due
+   *   follow-up step);
+   * - `pending` with `dueAt` in the future → no-op (the clock was
+   *   rescheduled after this job was enqueued);
+   * - `pending` and overdue → mark breached and escalate through the plan's
+   *   escalation policy;
+   * - `breached` with a due pending-escalation marker → continue with the
+   *   next policy step.
+   *
+   * The engine is imported dynamically to avoid a static model → service
+   * cycle. `args.at` (ISO string or `Date`) pins "now" for deterministic
+   * tests; the runner passes no args, so production uses wall-clock time.
+   */
+  @backgroundEligible()
+  async checkAndEscalate(
+    args?: Record<string, unknown>,
+    _context?: unknown,
+  ): Promise<CheckAndEscalateResult> {
+    const rawAt = args?.at;
+    const at =
+      rawAt instanceof Date
+        ? rawAt
+        : typeof rawAt === 'string' && !Number.isNaN(new Date(rawAt).getTime())
+          ? new Date(rawAt)
+          : new Date();
+
+    if (!this.id) {
+      return { outcome: 'missing' };
+    }
+    // Load fresh, authoritative state — the enqueued row may be stale.
+    const targets = await SupportServiceTargetCollection.create({
+      db: this.db,
+    });
+    const fresh = await targets.get({ id: this.id });
+    if (!fresh) {
+      return { outcome: 'missing' };
+    }
+
+    if (fresh.status === 'pending') {
+      if (fresh.dueAt.getTime() > at.getTime()) {
+        return { outcome: 'rescheduled' };
+      }
+      fresh.breachedAt = at;
+      fresh.status = 'breached';
+      await fresh.save();
+      const { ServiceTargetEngine } = await import(
+        '../services/service-target-engine.js'
+      );
+      const engine = await ServiceTargetEngine.create({ db: this.db });
+      await engine.escalateForBreach(fresh, { at });
+      return { outcome: 'breached' };
+    }
+
+    if (fresh.status === 'breached') {
+      const { ServiceTargetEngine } = await import(
+        '../services/service-target-engine.js'
+      );
+      const engine = await ServiceTargetEngine.create({ db: this.db });
+      const continued = await engine.continueEscalation(fresh, at);
+      return { outcome: continued ? 'escalated' : 'noop' };
+    }
+
+    return { outcome: 'noop' };
   }
 }
 

--- a/packages/support/src/models/support-settlement.ts
+++ b/packages/support/src/models/support-settlement.ts
@@ -1,0 +1,168 @@
+/**
+ * Derived commercial snapshots for approved Service Time Entries
+ * (FR-32/FR-35, issue #1930). Two deliberately separate rows per entry:
+ *
+ * - **SupportCharge** — what the Client owes, derived from the Managed
+ *   Support Plan (included-time consumption, then metered overage).
+ * - **SupportCompensation** — what the delivering Participant earns, derived
+ *   from the Support Compensation Plan.
+ *
+ * Margin = charge − compensation, computed by readers; the two records are
+ * never merged so client pricing can't leak provider terms. Rows snapshot the
+ * rate terms at derivation time (`rateSnapshot`) — later plan edits never
+ * rewrite them; corrections void/supersede and re-derive from the correcting
+ * entry. Settlement (invoicing, ledger posting) is out of scope here and
+ * composes at the app/accounting boundary (#1925).
+ *
+ * Append-only surfaces: `list`/`get` generated routes only; writes go through
+ * `TimeEntryApprovalService`.
+ */
+
+import {
+  field,
+  foreignKey,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import { parseJsonField, type SupportSettlementStatus } from '../types.js';
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_charges',
+  api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+  conflictColumns: ['time_entry_id'],
+})
+export class SupportCharge extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  @foreignKey('ServiceTimeEntry', { required: true })
+  timeEntryId: string = '';
+
+  @foreignKey('SupportCase')
+  caseId: string | null = null;
+
+  /** Plan the pricing derived from (null = no plan; zero-amount charge). */
+  @foreignKey('SupportPlan')
+  planId: string | null = null;
+
+  /** Client charge amount for the billable time. */
+  amount: number = 0.0;
+
+  @field({ type: 'text' })
+  currency: string = 'USD';
+
+  /** Seconds priced at the metered rate (after included-time consumption). */
+  billableSeconds: number = 0;
+
+  /** Seconds absorbed by the plan's included support time. */
+  includedSecondsApplied: number = 0;
+
+  /**
+   * JSON snapshot of the pricing terms used: hourly rate, rate source
+   * (`overage` | `on_call` | `none`), plan key, included-time state,
+   * derivation timestamp. Never rewritten by later plan edits.
+   */
+  @field({ type: 'text' })
+  rateSnapshot: string = '{}';
+
+  @field({ type: 'text' })
+  status: SupportSettlementStatus = 'pending';
+
+  finalizedAt: Date | null = null;
+
+  @field({ type: 'text' })
+  metadata: string = '{}';
+
+  getRateSnapshot(): Record<string, unknown> {
+    return parseJsonField(this.rateSnapshot, {});
+  }
+
+  setRateSnapshot(value: Record<string, unknown>): void {
+    this.rateSnapshot = JSON.stringify(value ?? {});
+  }
+}
+
+export class SupportChargeCollection extends SmrtCollection<SupportCharge> {
+  static readonly _itemClass = SupportCharge;
+
+  async forTimeEntry(timeEntryId: string): Promise<SupportCharge | null> {
+    const matches = await this.list({ where: { timeEntryId }, limit: 1 });
+    return matches[0] ?? null;
+  }
+
+  async forCase(caseId: string): Promise<SupportCharge[]> {
+    return this.list({ where: { caseId }, orderBy: 'created_at ASC' });
+  }
+}
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_compensations',
+  api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+  conflictColumns: ['time_entry_id'],
+})
+export class SupportCompensation extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  @foreignKey('ServiceTimeEntry', { required: true })
+  timeEntryId: string = '';
+
+  @foreignKey('SupportSpecialist')
+  specialistId: string | null = null;
+
+  /** Compensation plan the earning derived from (null = no plan resolved). */
+  @foreignKey('SupportCompensationPlan')
+  compensationPlanId: string | null = null;
+
+  /** Provider earning amount for the payable time. */
+  amount: number = 0.0;
+
+  @field({ type: 'text' })
+  currency: string = 'USD';
+
+  /** Seconds compensated. */
+  payableSeconds: number = 0;
+
+  /** JSON snapshot of the earning terms used at derivation time. */
+  @field({ type: 'text' })
+  rateSnapshot: string = '{}';
+
+  @field({ type: 'text' })
+  status: SupportSettlementStatus = 'pending';
+
+  finalizedAt: Date | null = null;
+
+  @field({ type: 'text' })
+  metadata: string = '{}';
+
+  getRateSnapshot(): Record<string, unknown> {
+    return parseJsonField(this.rateSnapshot, {});
+  }
+
+  setRateSnapshot(value: Record<string, unknown>): void {
+    this.rateSnapshot = JSON.stringify(value ?? {});
+  }
+}
+
+export class SupportCompensationCollection extends SmrtCollection<SupportCompensation> {
+  static readonly _itemClass = SupportCompensation;
+
+  async forTimeEntry(timeEntryId: string): Promise<SupportCompensation | null> {
+    const matches = await this.list({ where: { timeEntryId }, limit: 1 });
+    return matches[0] ?? null;
+  }
+
+  async forSpecialist(specialistId: string): Promise<SupportCompensation[]> {
+    return this.list({ where: { specialistId }, orderBy: 'created_at ASC' });
+  }
+}
+
+export default SupportCharge;

--- a/packages/support/src/models/support-specialist.ts
+++ b/packages/support/src/models/support-specialist.ts
@@ -1,0 +1,208 @@
+/**
+ * Support Specialist models (FR-30): the specialist role record layered on a
+ * Profile (the `commerce Customer` role-record idiom), per-project
+ * qualifications, and availability/on-call windows.
+ *
+ * - **SupportSpecialist** — a Participant qualified to handle first-tier
+ *   support; workload cap, languages, and timezone drive routing.
+ * - **SupportQualification** — recognition that a specialist is trained and
+ *   approved for a specific app-defined project (effective-dated).
+ * - **SupportAvailability** — weekly working windows, on-call spans, and
+ *   time-off exceptions used by routing and coverage checks.
+ *
+ * These are operator configuration surfaces, so they expose generated CRUD.
+ */
+
+import {
+  crossPackageRef,
+  field,
+  foreignKey,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import {
+  parseJsonField,
+  parseStringArrayField,
+  type SupportAvailabilityKind,
+  type SupportQualificationLevel,
+  type SupportSpecialistStatus,
+} from '../types.js';
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_specialists',
+  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+  conflictColumns: ['tenant_id', 'profile_id'],
+})
+export class SupportSpecialist extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  /** The Participant (Person profile) this specialist role belongs to. */
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { required: true })
+  profileId: string = '';
+
+  /** Display name for queues/routing rationale (denormalized from Profile). */
+  @field({ type: 'text' })
+  displayName: string = '';
+
+  @field({ type: 'text' })
+  status: SupportSpecialistStatus = 'active';
+
+  /** Languages the specialist supports (JSON array of BCP-47-ish codes). */
+  @field({ type: 'text' })
+  languages: string = '["en"]';
+
+  /** IANA timezone the weekly availability windows are expressed in. */
+  @field({ type: 'text' })
+  timezone: string = 'UTC';
+
+  /** Routing workload cap: open cases beyond this exclude the specialist. */
+  maxConcurrentCases: number = 10;
+
+  /** Tie-break priority for on-call ranking (higher = preferred). */
+  onCallPriority: number = 0;
+
+  @field({ type: 'text' })
+  notes: string = '';
+
+  @field({ type: 'text' })
+  metadata: string = '{}';
+
+  getLanguages(): string[] {
+    return parseStringArrayField(this.languages);
+  }
+
+  setLanguages(languages: string[]): void {
+    this.languages = JSON.stringify(languages ?? []);
+  }
+
+  getMetadata(): Record<string, unknown> {
+    return parseJsonField(this.metadata, {});
+  }
+
+  setMetadata(value: Record<string, unknown>): void {
+    this.metadata = JSON.stringify(value ?? {});
+  }
+
+  isActive(): boolean {
+    return this.status === 'active';
+  }
+}
+
+export class SupportSpecialistCollection extends SmrtCollection<SupportSpecialist> {
+  static readonly _itemClass = SupportSpecialist;
+
+  async findActive(): Promise<SupportSpecialist[]> {
+    return this.list({ where: { status: 'active' } });
+  }
+
+  async byProfile(profileId: string): Promise<SupportSpecialist | null> {
+    const matches = await this.list({ where: { profileId }, limit: 1 });
+    return matches[0] ?? null;
+  }
+}
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_qualifications',
+  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+  conflictColumns: ['specialist_id', 'project_id'],
+})
+export class SupportQualification extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  @foreignKey('SupportSpecialist', { required: true })
+  specialistId: string = '';
+
+  /** App-defined Project this qualification covers. */
+  @field({ type: 'text' })
+  projectId: string = '';
+
+  @field({ type: 'text' })
+  level: SupportQualificationLevel = 'qualified';
+
+  /** Effective-dating: null bounds mean open-ended. */
+  effectiveFrom: Date | null = null;
+
+  effectiveTo: Date | null = null;
+
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { nullable: true })
+  grantedByProfileId: string | null = null;
+
+  @field({ type: 'text' })
+  notes: string = '';
+
+  /** Whether the qualification is effective at the given instant. */
+  isEffectiveAt(at: Date = new Date()): boolean {
+    if (this.effectiveFrom && at < this.effectiveFrom) return false;
+    if (this.effectiveTo && at >= this.effectiveTo) return false;
+    return true;
+  }
+}
+
+export class SupportQualificationCollection extends SmrtCollection<SupportQualification> {
+  static readonly _itemClass = SupportQualification;
+
+  async forSpecialist(specialistId: string): Promise<SupportQualification[]> {
+    return this.list({ where: { specialistId } });
+  }
+
+  async forProject(projectId: string): Promise<SupportQualification[]> {
+    return this.list({ where: { projectId } });
+  }
+}
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_availability_windows',
+  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+})
+export class SupportAvailability extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  @foreignKey('SupportSpecialist', { required: true })
+  specialistId: string = '';
+
+  @field({ type: 'text' })
+  kind: SupportAvailabilityKind = 'weekly';
+
+  /** Weekly windows: 0 = Sunday … 6 = Saturday. Null for span kinds. */
+  @field({ type: 'integer', nullable: true })
+  weekday: number | null = null;
+
+  /** Weekly windows: minutes from midnight, inclusive start. */
+  startMinute: number = 0;
+
+  /** Weekly windows: minutes from midnight, exclusive end. */
+  endMinute: number = 0;
+
+  /** Span kinds (`on_call`, `time_off`): absolute start. */
+  startsAt: Date | null = null;
+
+  /** Span kinds (`on_call`, `time_off`): absolute end. */
+  endsAt: Date | null = null;
+
+  @field({ type: 'text' })
+  notes: string = '';
+}
+
+export class SupportAvailabilityCollection extends SmrtCollection<SupportAvailability> {
+  static readonly _itemClass = SupportAvailability;
+
+  async forSpecialist(specialistId: string): Promise<SupportAvailability[]> {
+    return this.list({ where: { specialistId } });
+  }
+}
+
+export default SupportSpecialist;

--- a/packages/support/src/models/support-work-link.ts
+++ b/packages/support/src/models/support-work-link.ts
@@ -1,0 +1,88 @@
+/**
+ * SupportWorkLink — links a Support Case to separately tracked internal work
+ * (FR-29/FR-29a): a **Support Work Item** on the operational board, or a
+ * **Development Work Item** created through a Delivery Handoff.
+ *
+ * Boundary: Support owns the Case and this link; Delivery Operations owns the
+ * linked work's execution (agents, previews, merges, deployments). The
+ * `status` field here is a read-only echo the delivery side reports back —
+ * this package never drives the linked item's lifecycle. Targets are
+ * addressed by qualified type + id (e.g. `@happyvertical/smrt-projects:Issue`)
+ * so no runtime dependency on the owning package is needed.
+ */
+
+import {
+  field,
+  foreignKey,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import { parseJsonField, type SupportWorkLinkKind } from '../types.js';
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'support_work_links',
+  api: { include: ['list', 'get'] },
+  mcp: { include: ['list', 'get'] },
+  cli: { include: ['list', 'get'] },
+  conflictColumns: ['case_id', 'target_type', 'target_id'],
+})
+export class SupportWorkLink extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  @foreignKey('SupportCase', { required: true })
+  caseId: string = '';
+
+  @field({ type: 'text' })
+  linkKind: SupportWorkLinkKind = 'support_work_item';
+
+  /**
+   * Qualified class of the linked work item, e.g.
+   * `@happyvertical/smrt-projects:Issue`.
+   */
+  @field({ type: 'text' })
+  targetType: string = '';
+
+  @field({ type: 'text' })
+  targetId: string = '';
+
+  /** Display label for the case timeline (e.g. `repo#123: fix login`). */
+  @field({ type: 'text' })
+  targetLabel: string = '';
+
+  @field({ type: 'text' })
+  externalUrl: string = '';
+
+  /**
+   * Status echo reported back from the owning domain (`open`,
+   * `in_progress`, `done`, …). Informational only.
+   */
+  @field({ type: 'text' })
+  status: string = 'open';
+
+  lastStatusAt: Date | null = null;
+
+  @field({ type: 'text' })
+  metadata: string = '{}';
+
+  getMetadata(): Record<string, unknown> {
+    return parseJsonField(this.metadata, {});
+  }
+
+  setMetadata(value: Record<string, unknown>): void {
+    this.metadata = JSON.stringify(value ?? {});
+  }
+}
+
+export class SupportWorkLinkCollection extends SmrtCollection<SupportWorkLink> {
+  static readonly _itemClass = SupportWorkLink;
+
+  async forCase(caseId: string): Promise<SupportWorkLink[]> {
+    return this.list({ where: { caseId }, orderBy: 'created_at ASC' });
+  }
+}
+
+export default SupportWorkLink;

--- a/packages/support/src/permissions.ts
+++ b/packages/support/src/permissions.ts
@@ -1,0 +1,93 @@
+/**
+ * Custom permission slugs contributed by `@happyvertical/smrt-support` to the
+ * runtime permission catalog (the `personas.activate-directive` pattern).
+ *
+ * The privileged operations are permission splits, not bespoke checks:
+ * - `support.reassign-case` — manual reassignment despite routing (FR-30).
+ * - `support.approve-time-entry` — accept a Service Time Entry and derive its
+ *   commercial snapshots (FR-36) via the operator path.
+ * - `support.manage-plans` — administer Managed Support Plans and Support
+ *   Compensation Plans.
+ */
+
+import {
+  type PermissionDefinition,
+  registerPermissionDefinitions,
+} from '@happyvertical/smrt-users';
+
+/** Authorizes manual case reassignment overriding automatic routing. */
+export const REASSIGN_CASE_PERMISSION = 'support.reassign-case';
+
+/** Authorizes operator approval/rejection of Service Time Entries. */
+export const APPROVE_TIME_ENTRY_PERMISSION = 'support.approve-time-entry';
+
+/** Authorizes plan administration (support + compensation plans). */
+export const MANAGE_PLANS_PERMISSION = 'support.manage-plans';
+
+export const SUPPORT_PERMISSION_DEFS: PermissionDefinition[] = [
+  {
+    slug: REASSIGN_CASE_PERMISSION,
+    category: 'support',
+    name: 'Reassign Support Case',
+    description:
+      'Manually reassign a Support Case to a specialist, overriding automatic routing',
+  },
+  {
+    slug: APPROVE_TIME_ENTRY_PERMISSION,
+    category: 'support',
+    name: 'Approve Service Time Entry',
+    description:
+      'Approve or reject submitted Service Time Entries and finalize their charge/compensation snapshots',
+  },
+  {
+    slug: MANAGE_PLANS_PERMISSION,
+    category: 'support',
+    name: 'Manage Support Plans',
+    description:
+      'Create and edit Managed Support Plans and Support Compensation Plans',
+  },
+];
+
+/**
+ * An actor whose authority is expressed as held permission slugs. Minimal on
+ * purpose — the gate depends on the permission model only (personas idiom).
+ */
+export interface SupportPrincipal {
+  /** Stable id recorded as the acting reviewer/assigner. */
+  readonly id?: string;
+  /** Tenant the authority was resolved for (cross-tenant acts are refused). */
+  readonly tenantId?: string;
+  can(slug: string): boolean;
+}
+
+/** Build a {@link SupportPrincipal} from explicit granted slugs. */
+export function supportPrincipalFromPermissions(
+  permissions: Iterable<string>,
+  options: { id?: string; tenantId?: string } = {},
+): SupportPrincipal {
+  const granted = new Set(permissions);
+  return {
+    id: options.id,
+    tenantId: options.tenantId,
+    can: (slug: string) => granted.has(slug),
+  };
+}
+
+let supportPermissionsRegistered = false;
+
+/** Register the support permissions (returns an unregister fn for tests). */
+export function registerSupportPermissions(): () => void {
+  return registerPermissionDefinitions(SUPPORT_PERMISSION_DEFS);
+}
+
+/**
+ * Register the support permissions once per process. Called as a package
+ * entry side effect so any consumer sees the slugs in the catalog.
+ */
+export function ensureSupportPermissionsRegistered(): void {
+  if (supportPermissionsRegistered) {
+    return;
+  }
+  supportPermissionsRegistered = true;
+  registerSupportPermissions();
+}

--- a/packages/support/src/services/coverage-calendar.test.ts
+++ b/packages/support/src/services/coverage-calendar.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Coverage-calendar math tests (#1929): deterministic business-time
+ * arithmetic — 24×7 fast path, business-hours windows, holiday skips,
+ * timezone wall-clock evaluation, and the add/measure symmetry the Service
+ * Target clocks rely on.
+ *
+ * Fixed instants throughout (2026-01-05 is a Monday).
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { CoverageCalendar } from './coverage-calendar.js';
+import {
+  addCoveredMinutes,
+  coveredMinutesBetween,
+  MAX_COVERAGE_SCAN_DAYS,
+  zonedParts,
+} from './coverage-calendar.js';
+
+const ALWAYS: CoverageCalendar = { windows: [], holidays: [], timezone: 'UTC' };
+
+/** Mon–Fri 09:00–17:00 UTC. */
+const BUSINESS_HOURS: CoverageCalendar = {
+  windows: [1, 2, 3, 4, 5].map((weekday) => ({
+    weekday,
+    startMinute: 9 * 60,
+    endMinute: 17 * 60,
+  })),
+  holidays: [],
+  timezone: 'UTC',
+};
+
+describe('zonedParts', () => {
+  it('projects a UTC instant onto a timezone wall clock (0 = Sunday)', () => {
+    const parts = zonedParts(
+      new Date('2026-01-05T14:00:00Z'),
+      'America/New_York',
+    );
+    expect(parts.weekday).toBe(1); // Monday
+    expect(parts.minuteOfDay).toBe(9 * 60); // 09:00 EST
+    expect(parts.dateKey).toBe('2026-01-05');
+  });
+
+  it('crosses the date line relative to UTC when the zone is behind', () => {
+    const parts = zonedParts(
+      new Date('2026-01-05T02:00:00Z'),
+      'America/New_York',
+    );
+    expect(parts.dateKey).toBe('2026-01-04'); // still Sunday evening in NY
+    expect(parts.weekday).toBe(0);
+    expect(parts.minuteOfDay).toBe(21 * 60);
+  });
+});
+
+describe('addCoveredMinutes', () => {
+  it('is plain wall-clock arithmetic on an empty 24×7 calendar', () => {
+    const from = new Date('2026-01-05T10:00:00Z');
+    expect(addCoveredMinutes(ALWAYS, from, 90).toISOString()).toBe(
+      '2026-01-05T11:30:00.000Z',
+    );
+  });
+
+  it('carries a Friday-afternoon clock over the weekend to Monday morning', () => {
+    // Friday 2026-01-09 16:30 + 60 covered minutes: 30 min remain on Friday,
+    // the other 30 land after Monday 09:00.
+    const from = new Date('2026-01-09T16:30:00Z');
+    expect(addCoveredMinutes(BUSINESS_HOURS, from, 60).toISOString()).toBe(
+      '2026-01-12T09:30:00.000Z',
+    );
+  });
+
+  it('skips holidays entirely', () => {
+    const withHoliday: CoverageCalendar = {
+      ...BUSINESS_HOURS,
+      holidays: ['2026-01-12'],
+    };
+    const from = new Date('2026-01-09T16:30:00Z');
+    expect(addCoveredMinutes(withHoliday, from, 60).toISOString()).toBe(
+      '2026-01-13T09:30:00.000Z',
+    );
+  });
+
+  it('excludes holidays under 24×7 coverage too', () => {
+    const alwaysButHoliday: CoverageCalendar = {
+      windows: [],
+      holidays: ['2026-01-12'],
+      timezone: 'UTC',
+    };
+    // Sunday 12:00 + 24h of coverage: 12h on Sunday, Monday skipped, the
+    // remaining 12h complete on Tuesday at noon.
+    const from = new Date('2026-01-11T12:00:00Z');
+    expect(
+      addCoveredMinutes(alwaysButHoliday, from, 24 * 60).toISOString(),
+    ).toBe('2026-01-13T12:00:00.000Z');
+  });
+
+  it('evaluates windows in the calendar timezone from a UTC instant', () => {
+    const newYork: CoverageCalendar = {
+      windows: [{ weekday: 1, startMinute: 9 * 60, endMinute: 17 * 60 }],
+      holidays: [],
+      timezone: 'America/New_York',
+    };
+    // Monday 13:00 UTC is 08:00 EST — before coverage opens. The clock only
+    // starts at 09:00 EST (14:00 UTC) and 60 covered minutes end 15:00 UTC.
+    const from = new Date('2026-01-05T13:00:00Z');
+    expect(addCoveredMinutes(newYork, from, 60).toISOString()).toBe(
+      '2026-01-05T15:00:00.000Z',
+    );
+  });
+
+  it('returns the start instant for zero or negative minutes', () => {
+    const from = new Date('2026-01-05T10:00:00Z');
+    expect(addCoveredMinutes(BUSINESS_HOURS, from, 0).getTime()).toBe(
+      from.getTime(),
+    );
+  });
+
+  it(`throws a descriptive error after ${MAX_COVERAGE_SCAN_DAYS} uncovered days`, () => {
+    const empty: CoverageCalendar = {
+      windows: [{ weekday: 1, startMinute: 0, endMinute: 0 }],
+      holidays: [],
+      timezone: 'UTC',
+    };
+    expect(() =>
+      addCoveredMinutes(empty, new Date('2026-01-05T10:00:00Z'), 30),
+    ).toThrow(/no coverage found within 400 days/);
+  });
+});
+
+describe('coveredMinutesBetween', () => {
+  it('measures plain elapsed minutes on an empty 24×7 calendar', () => {
+    expect(
+      coveredMinutesBetween(
+        ALWAYS,
+        new Date('2026-01-05T10:00:00Z'),
+        new Date('2026-01-05T11:30:00Z'),
+      ),
+    ).toBe(90);
+  });
+
+  it('returns zero for inverted or empty ranges', () => {
+    const at = new Date('2026-01-05T10:00:00Z');
+    expect(coveredMinutesBetween(BUSINESS_HOURS, at, at)).toBe(0);
+    expect(
+      coveredMinutesBetween(
+        BUSINESS_HOURS,
+        at,
+        new Date('2026-01-05T09:00:00Z'),
+      ),
+    ).toBe(0);
+  });
+
+  it('only counts covered time across a weekend', () => {
+    // Friday 16:30 → Monday 09:30 spans 30 covered Friday minutes and 30
+    // covered Monday minutes.
+    expect(
+      coveredMinutesBetween(
+        BUSINESS_HOURS,
+        new Date('2026-01-09T16:30:00Z'),
+        new Date('2026-01-12T09:30:00Z'),
+      ),
+    ).toBe(60);
+  });
+
+  it('is symmetric with addCoveredMinutes', () => {
+    const cases: Array<{
+      calendar: CoverageCalendar;
+      from: Date;
+      minutes: number;
+    }> = [
+      {
+        calendar: BUSINESS_HOURS,
+        from: new Date('2026-01-09T16:30:00Z'),
+        minutes: 60,
+      },
+      {
+        calendar: BUSINESS_HOURS,
+        from: new Date('2026-01-07T10:00:00Z'),
+        minutes: 120,
+      },
+      {
+        calendar: { ...BUSINESS_HOURS, holidays: ['2026-01-08'] },
+        from: new Date('2026-01-07T16:00:00Z'),
+        minutes: 180,
+      },
+      {
+        calendar: {
+          windows: [{ weekday: 1, startMinute: 9 * 60, endMinute: 17 * 60 }],
+          holidays: [],
+          timezone: 'America/New_York',
+        },
+        from: new Date('2026-01-05T13:00:00Z'),
+        minutes: 45,
+      },
+    ];
+    for (const { calendar, from, minutes } of cases) {
+      const due = addCoveredMinutes(calendar, from, minutes);
+      expect(coveredMinutesBetween(calendar, from, due)).toBeCloseTo(
+        minutes,
+        6,
+      );
+    }
+  });
+});

--- a/packages/support/src/services/coverage-calendar.ts
+++ b/packages/support/src/services/coverage-calendar.ts
@@ -1,0 +1,342 @@
+/**
+ * Coverage-calendar math for Service Target clocks (FR-30/FR-31): pure,
+ * deterministic business-time arithmetic over a Managed Support Plan's
+ * coverage windows, holidays, and IANA timezone.
+ *
+ * Semantics:
+ * - An empty `windows` array means 24×7 coverage; with no holidays either,
+ *   covered time is plain wall-clock time (the fast path).
+ * - Holidays (`YYYY-MM-DD` in the calendar's timezone) exclude whole days
+ *   from coverage, including under 24×7 coverage.
+ * - All functions take explicit instants — no `Date.now()` inside — so the
+ *   engine and its tests stay deterministic.
+ *
+ * Timezone handling uses `Intl.DateTimeFormat#formatToParts` only (no date
+ * library): {@link zonedParts} projects a UTC instant onto the calendar
+ * timezone's wall clock, and an iterative inverse converts wall-clock day
+ * positions back to UTC instants. DST transition days therefore keep exact
+ * window boundaries; a window boundary falling inside a nonexistent
+ * spring-forward hour lands on the later real instant so clocks never gain
+ * time.
+ */
+
+import type { CoverageWindow } from '../types.js';
+
+/** The coverage terms a Service Target clock runs against. */
+export interface CoverageCalendar {
+  /** Weekly coverage windows; empty means 24×7 coverage. */
+  windows: CoverageWindow[];
+  /** Holiday dates excluded from coverage (`YYYY-MM-DD`). */
+  holidays: string[];
+  /** IANA timezone the windows and holidays are expressed in. */
+  timezone: string;
+}
+
+/** Wall-clock projection of a UTC instant in a target timezone. */
+export interface ZonedParts {
+  /** Calendar year in the target timezone. */
+  year: number;
+  /** Calendar month in the target timezone (1–12). */
+  month: number;
+  /** Calendar day of month in the target timezone (1–31). */
+  day: number;
+  /** 0 = Sunday … 6 = Saturday (matches {@link CoverageWindow} docs). */
+  weekday: number;
+  /** Minutes from local midnight (0–1439). */
+  minuteOfDay: number;
+  /** `YYYY-MM-DD` date key in the target timezone (holiday comparisons). */
+  dateKey: string;
+}
+
+/**
+ * Hard ceiling on how many calendar days {@link addCoveredMinutes} will walk
+ * forward looking for coverage before failing loudly (a plan whose calendar
+ * never covers anything would otherwise loop forever).
+ */
+export const MAX_COVERAGE_SCAN_DAYS = 400;
+
+const MINUTE_MS = 60_000;
+const DAY_MS = 86_400_000;
+const MINUTES_PER_DAY = 1_440;
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  Sun: 0,
+  Mon: 1,
+  Tue: 2,
+  Wed: 3,
+  Thu: 4,
+  Fri: 5,
+  Sat: 6,
+};
+
+/** One `Intl.DateTimeFormat` per timezone — construction is expensive. */
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getFormatter(timeZone: string): Intl.DateTimeFormat {
+  const cached = formatterCache.get(timeZone);
+  if (cached) {
+    return cached;
+  }
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hourCycle: 'h23',
+    weekday: 'short',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  formatterCache.set(timeZone, formatter);
+  return formatter;
+}
+
+/**
+ * Project a UTC instant onto a timezone's wall clock via
+ * `Intl.DateTimeFormat#formatToParts`. Throws a `RangeError` for an invalid
+ * IANA timezone name (surfacing plan misconfiguration immediately).
+ */
+export function zonedParts(date: Date, timeZone: string): ZonedParts {
+  const parts = getFormatter(timeZone).formatToParts(date);
+  const byType: Record<string, string> = {};
+  for (const part of parts) {
+    byType[part.type] = part.value;
+  }
+  const year = Number(byType.year);
+  const month = Number(byType.month);
+  const day = Number(byType.day);
+  const hour = Number(byType.hour) % 24;
+  const minute = Number(byType.minute);
+  return {
+    year,
+    month,
+    day,
+    weekday: WEEKDAY_INDEX[byType.weekday ?? ''] ?? 0,
+    minuteOfDay: hour * 60 + minute,
+    dateKey: `${byType.year}-${byType.month}-${byType.day}`,
+  };
+}
+
+/** Wall-clock milliseconds since the UTC epoch, as if the zone were UTC. */
+function wallClockMs(parts: ZonedParts): number {
+  return (
+    Date.UTC(parts.year, parts.month - 1, parts.day) +
+    parts.minuteOfDay * MINUTE_MS
+  );
+}
+
+/**
+ * Convert a wall-clock position (`year`/`month`/`day` + minutes from local
+ * midnight) in `timeZone` to the UTC instant it names. Converges in one or
+ * two steps for real wall times; a nonexistent spring-forward time lands on
+ * the later real instant (clocks never gain covered time).
+ */
+function wallTimeToUtcMs(
+  year: number,
+  month: number,
+  day: number,
+  minuteOfDay: number,
+  timeZone: string,
+): number {
+  const targetWallMs = Date.UTC(year, month - 1, day) + minuteOfDay * MINUTE_MS;
+  let guessMs = targetWallMs;
+  for (let i = 0; i < 4; i++) {
+    const wallMs = wallClockMs(zonedParts(new Date(guessMs), timeZone));
+    if (wallMs === targetWallMs) {
+      return guessMs;
+    }
+    guessMs += targetWallMs - wallMs;
+  }
+  // Nonexistent wall time (DST gap): step onto the later real instant.
+  const finalWallMs = wallClockMs(zonedParts(new Date(guessMs), timeZone));
+  if (finalWallMs < targetWallMs) {
+    guessMs += targetWallMs - finalWallMs;
+  }
+  return guessMs;
+}
+
+/** A covered span of real time within one calendar day, in UTC ms. */
+interface CoveredSpan {
+  startMs: number;
+  endMs: number;
+}
+
+/** Clamp, sort, and merge a day's window minutes into disjoint spans. */
+function normalizeWindowMinutes(
+  windows: Array<Pick<CoverageWindow, 'startMinute' | 'endMinute'>>,
+): Array<{ startMinute: number; endMinute: number }> {
+  const clamped = windows
+    .map((window) => ({
+      startMinute: Math.max(0, Math.min(window.startMinute, MINUTES_PER_DAY)),
+      endMinute: Math.max(0, Math.min(window.endMinute, MINUTES_PER_DAY)),
+    }))
+    .filter((window) => window.endMinute > window.startMinute)
+    .sort((a, b) => a.startMinute - b.startMinute);
+
+  const merged: Array<{ startMinute: number; endMinute: number }> = [];
+  for (const window of clamped) {
+    const last = merged[merged.length - 1];
+    if (last && window.startMinute <= last.endMinute) {
+      last.endMinute = Math.max(last.endMinute, window.endMinute);
+    } else {
+      merged.push({ ...window });
+    }
+  }
+  return merged;
+}
+
+/**
+ * The covered spans of one calendar day (identified by its wall-clock
+ * year/month/day in the calendar timezone), as UTC instants.
+ */
+function coveredSpansForDay(
+  calendar: CoverageCalendar,
+  parts: ZonedParts,
+): CoveredSpan[] {
+  if (calendar.holidays.includes(parts.dateKey)) {
+    return [];
+  }
+  // The civil weekday of a Y-M-D is timezone-independent.
+  const weekday = new Date(
+    Date.UTC(parts.year, parts.month - 1, parts.day),
+  ).getUTCDay();
+  const dayWindows =
+    calendar.windows.length === 0
+      ? [{ startMinute: 0, endMinute: MINUTES_PER_DAY }]
+      : calendar.windows.filter((window) => window.weekday === weekday);
+
+  return normalizeWindowMinutes(dayWindows).map((window) => ({
+    startMs: wallTimeToUtcMs(
+      parts.year,
+      parts.month,
+      parts.day,
+      window.startMinute,
+      calendar.timezone,
+    ),
+    endMs: wallTimeToUtcMs(
+      parts.year,
+      parts.month,
+      parts.day,
+      window.endMinute,
+      calendar.timezone,
+    ),
+  }));
+}
+
+/** UTC instant of the calendar timezone's next local midnight after `parts`. */
+function nextZoneMidnightMs(
+  calendar: CoverageCalendar,
+  parts: ZonedParts,
+): number {
+  const nextDate = new Date(
+    Date.UTC(parts.year, parts.month - 1, parts.day) + DAY_MS,
+  );
+  return wallTimeToUtcMs(
+    nextDate.getUTCFullYear(),
+    nextDate.getUTCMonth() + 1,
+    nextDate.getUTCDate(),
+    0,
+    calendar.timezone,
+  );
+}
+
+function isAlwaysCovered(calendar: CoverageCalendar): boolean {
+  return calendar.windows.length === 0 && calendar.holidays.length === 0;
+}
+
+/**
+ * Covered minutes between two instants (fractional; `0` when `to <= from`).
+ *
+ * Walks forward day by day through the calendar timezone, summing the overlap
+ * of `[from, to)` with each day's covered spans.
+ */
+export function coveredMinutesBetween(
+  calendar: CoverageCalendar,
+  from: Date,
+  to: Date,
+): number {
+  const fromMs = from.getTime();
+  const toMs = to.getTime();
+  if (toMs <= fromMs) {
+    return 0;
+  }
+  if (isAlwaysCovered(calendar)) {
+    return (toMs - fromMs) / MINUTE_MS;
+  }
+
+  let totalMs = 0;
+  let cursorMs = fromMs;
+  while (cursorMs < toMs) {
+    const parts = zonedParts(new Date(cursorMs), calendar.timezone);
+    for (const span of coveredSpansForDay(calendar, parts)) {
+      const start = Math.max(span.startMs, cursorMs);
+      const end = Math.min(span.endMs, toMs);
+      if (end > start) {
+        totalMs += end - start;
+      }
+    }
+    const nextMidnightMs = nextZoneMidnightMs(calendar, parts);
+    if (nextMidnightMs <= cursorMs) {
+      throw new Error(
+        `coveredMinutesBetween: calendar for timezone '${calendar.timezone}' ` +
+          'failed to advance past ' +
+          new Date(cursorMs).toISOString(),
+      );
+    }
+    cursorMs = nextMidnightMs;
+  }
+  return totalMs / MINUTE_MS;
+}
+
+/**
+ * The instant at which `minutes` of covered time have elapsed from `from` —
+ * the Service Target due-time computation. Walks forward day by day through
+ * coverage windows, skipping holidays; throws a descriptive error after
+ * {@link MAX_COVERAGE_SCAN_DAYS} days without accumulating enough coverage
+ * (an effectively-empty calendar).
+ */
+export function addCoveredMinutes(
+  calendar: CoverageCalendar,
+  from: Date,
+  minutes: number,
+): Date {
+  if (minutes <= 0) {
+    return new Date(from.getTime());
+  }
+  if (isAlwaysCovered(calendar)) {
+    return new Date(from.getTime() + minutes * MINUTE_MS);
+  }
+
+  let remainingMs = minutes * MINUTE_MS;
+  let cursorMs = from.getTime();
+  for (let dayScan = 0; dayScan <= MAX_COVERAGE_SCAN_DAYS; dayScan++) {
+    const parts = zonedParts(new Date(cursorMs), calendar.timezone);
+    for (const span of coveredSpansForDay(calendar, parts)) {
+      const start = Math.max(span.startMs, cursorMs);
+      if (span.endMs <= start) {
+        continue;
+      }
+      const spanMs = span.endMs - start;
+      if (spanMs >= remainingMs) {
+        return new Date(start + remainingMs);
+      }
+      remainingMs -= spanMs;
+    }
+    const nextMidnightMs = nextZoneMidnightMs(calendar, parts);
+    if (nextMidnightMs <= cursorMs) {
+      throw new Error(
+        `addCoveredMinutes: calendar for timezone '${calendar.timezone}' ` +
+          'failed to advance past ' +
+          new Date(cursorMs).toISOString(),
+      );
+    }
+    cursorMs = nextMidnightMs;
+  }
+  throw new Error(
+    `addCoveredMinutes: no coverage found within ${MAX_COVERAGE_SCAN_DAYS} ` +
+      `days after ${from.toISOString()} for ${minutes} covered minute(s) — ` +
+      'the coverage calendar appears to never cover any time ' +
+      `(windows: ${JSON.stringify(calendar.windows)}, ` +
+      `holidays: ${calendar.holidays.length}, timezone: '${calendar.timezone}').`,
+  );
+}

--- a/packages/support/src/services/human-handoff-service.test.ts
+++ b/packages/support/src/services/human-handoff-service.test.ts
@@ -1,0 +1,266 @@
+/**
+ * HumanHandoffService tests (#1928): the lossless Human Handoff — the full
+ * context package (case state + merged timeline + AI runs) travels with the
+ * handoff so the Client never repeats themselves, the routing seam records
+ * assignments with rationale, unrouted cases queue for triage, and the
+ * no-repeat guarantee dedupes triggers until released.
+ */
+
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  type HandoffContextPackage,
+  HumanHandoffService,
+} from './human-handoff-service.js';
+import {
+  type SupportAiBoundary,
+  SupportAiWorkflow,
+} from './support-ai-workflow.js';
+import { SupportCaseService } from './support-case-service.js';
+
+const MODEL_NAMES = [
+  'SupportCase',
+  'SupportInteraction',
+  'SupportCaseEvent',
+  'SupportWorkLink',
+  'SupportPlan',
+  'SupportPolicy',
+  'SupportAiRun',
+];
+
+describe('HumanHandoffService', () => {
+  let ctx: Awaited<ReturnType<typeof createIsolatedTestDbFromManifest>>;
+  let caseService: SupportCaseService;
+
+  beforeEach(async () => {
+    ctx = await createIsolatedTestDbFromManifest({
+      includeObjects: MODEL_NAMES,
+    });
+    caseService = await SupportCaseService.create({ db: ctx.db });
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  function openCase(overrides: Record<string, unknown> = {}) {
+    return caseService.openCase({
+      subject: 'Checkout intermittently fails',
+      description: 'Roughly one in ten checkouts errors out.',
+      channelKind: 'chat',
+      clientProfileId: 'client-1',
+      projectId: 'project-9',
+      ...overrides,
+    });
+  }
+
+  it('transfers the complete case context: state, timeline, and AI runs', async () => {
+    const plan = await caseService.plans.create({
+      planKey: 'gold',
+      name: 'Gold',
+    });
+    const boundary: SupportAiBoundary = {
+      classify: () =>
+        Promise.resolve({
+          severity: 'sev3',
+          category: 'performance',
+          sensitive: false,
+          confidence: 0.8,
+        }),
+      answer: () =>
+        Promise.resolve({
+          reply: 'Retry with the cache disabled.',
+          confidence: 0.9,
+          proposedResolution: false,
+        }),
+    };
+    const workflow = await SupportAiWorkflow.create({ db: ctx.db, boundary });
+    const supportCase = await workflow.caseService.openCase({
+      subject: 'Checkout intermittently fails',
+      description: 'Roughly one in ten checkouts errors out.',
+      channelKind: 'chat',
+      clientProfileId: 'client-1',
+      projectId: 'project-9',
+      planId: plan.id,
+    });
+    await workflow.caseService.recordInteraction(supportCase, {
+      direction: 'inbound',
+      channelKind: 'chat',
+      actorKind: 'client',
+      body: 'Roughly one in ten checkouts errors out.',
+      sourceKey: 'chat:msg-1',
+    });
+    await workflow.processCase(supportCase.id ?? '');
+
+    const handoffs = await HumanHandoffService.create({ db: ctx.db });
+    const result = await handoffs.handoff(supportCase.id ?? '', {
+      trigger: 'manual',
+      note: 'operator escalation',
+    });
+    expect(result.alreadyActive).toBe(false);
+
+    const events = await caseService.events.forCase(supportCase.id ?? '', {
+      eventType: 'handoff',
+    });
+    expect(events).toHaveLength(1);
+    const payload = events[0]?.getPayload() as {
+      trigger: string;
+      note: string | null;
+      contextPackage: HandoffContextPackage;
+    };
+    expect(payload.trigger).toBe('manual');
+    expect(payload.note).toBe('operator escalation');
+
+    const pkg = payload.contextPackage;
+    expect(pkg.caseNumber).toBe(supportCase.caseNumber);
+    expect(pkg.subject).toBe('Checkout intermittently fails');
+    expect(pkg.status).toBe('new');
+    expect(pkg.severity).toBe('sev3');
+    expect(pkg.category).toBe('performance');
+    expect(pkg.clientProfileId).toBe('client-1');
+    expect(pkg.projectId).toBe('project-9');
+    expect(pkg.planId).toBe(plan.id);
+
+    // The client's own words travel with the handoff (FR-28b).
+    expect(
+      pkg.timeline.some(
+        (item) =>
+          item.kind === 'interaction' &&
+          item.body === 'Roughly one in ten checkouts errors out.',
+      ),
+    ).toBe(true);
+    expect(pkg.timeline.some((item) => item.kind === 'event')).toBe(true);
+    expect(pkg.timeline.every((item) => item.occurredAt.length > 0)).toBe(true);
+
+    // Every prior automated-work run is included.
+    expect(pkg.aiRuns).toHaveLength(5);
+    expect(
+      pkg.aiRuns.some(
+        (run) =>
+          run.phase === 'classify' &&
+          (run.classification as { severity?: string }).severity === 'sev3',
+      ),
+    ).toBe(true);
+    expect(
+      pkg.aiRuns.some(
+        (run) => run.phase === 'answer' && run.confidence === 0.9,
+      ),
+    ).toBe(true);
+
+    // buildContextPackage is directly consumable by apps.
+    const direct = await handoffs.buildContextPackage(supportCase.id ?? '');
+    expect(direct.caseNumber).toBe(pkg.caseNumber);
+    expect(direct.aiRuns).toHaveLength(5);
+
+    // The unrouted handoff queued the case for a human.
+    expect(result.supportCase.status).toBe('triaged');
+  });
+
+  it('routes through the assignSpecialist seam and records the rationale', async () => {
+    const calls: Array<{ caseId: string | null; trigger: string }> = [];
+    const handoffs = await HumanHandoffService.create({
+      db: ctx.db,
+      assignSpecialist: (supportCase, context) => {
+        calls.push({
+          caseId: supportCase.id ?? null,
+          trigger: context.trigger,
+        });
+        return Promise.resolve({
+          specialistId: 'spec-77',
+          rationale: { score: 0.92 },
+        });
+      },
+    });
+    const supportCase = await openCase();
+
+    const result = await handoffs.handoff(supportCase, {
+      trigger: 'high_severity',
+    });
+
+    expect(calls).toEqual([
+      { caseId: supportCase.id, trigger: 'high_severity' },
+    ]);
+    expect(result.supportCase.assignedSpecialistId).toBe('spec-77');
+    expect(result.supportCase.status).toBe('assigned');
+
+    const assignments = await caseService.events.forCase(supportCase.id ?? '', {
+      eventType: 'assignment',
+    });
+    expect(assignments).toHaveLength(1);
+    expect(assignments[0]?.getPayload()).toMatchObject({
+      specialistId: 'spec-77',
+      rationale: { score: 0.92 },
+    });
+  });
+
+  it('queues the case for triage when no routing seam is configured', async () => {
+    const handoffs = await HumanHandoffService.create({ db: ctx.db });
+    const supportCase = await openCase();
+
+    await handoffs.handoff(supportCase, { trigger: 'low_confidence' });
+
+    expect(supportCase.status).toBe('triaged');
+    expect(supportCase.assignedSpecialistId).toBeNull();
+    const transitions = await caseService.events.forCase(supportCase.id ?? '', {
+      eventType: 'transition',
+    });
+    expect(transitions).toHaveLength(1);
+    expect(transitions[0]?.getPayload()).toMatchObject({
+      from: 'new',
+      to: 'triaged',
+      reason: 'human handoff queued',
+    });
+  });
+
+  it('dedupes repeat handoffs while active and allows a new one after release', async () => {
+    const handoffs = await HumanHandoffService.create({ db: ctx.db });
+    const supportCase = await openCase();
+
+    const first = await handoffs.handoff(supportCase, {
+      trigger: 'low_confidence',
+    });
+    expect(first.alreadyActive).toBe(false);
+
+    const repeat = await handoffs.handoff(supportCase, {
+      trigger: 'high_severity',
+    });
+    expect(repeat.alreadyActive).toBe(true);
+
+    await handoffs.releaseHandoff(supportCase);
+    const afterRelease = await handoffs.handoff(supportCase, {
+      trigger: 'manual',
+    });
+    expect(afterRelease.alreadyActive).toBe(false);
+
+    const payloads = (
+      await caseService.events.forCase(supportCase.id ?? '', {
+        eventType: 'handoff',
+      })
+    ).map((event) => event.getPayload());
+    expect(payloads).toHaveLength(3);
+    const deduped = payloads.filter((payload) => payload.deduped === true);
+    expect(deduped).toHaveLength(1);
+    expect(deduped[0]?.trigger).toBe('high_severity');
+  });
+
+  it('stamps the client human request on client_request triggers', async () => {
+    const handoffs = await HumanHandoffService.create({ db: ctx.db });
+    const supportCase = await openCase();
+
+    await handoffs.handoff(supportCase, {
+      trigger: 'client_request',
+      requestedByProfileId: 'client-1',
+      note: 'please, a person',
+    });
+
+    expect(supportCase.humanRequestedAt).toBeInstanceOf(Date);
+    const requests = await caseService.events.forCase(supportCase.id ?? '', {
+      eventType: 'human_requested',
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.actorProfileId).toBe('client-1');
+    expect(requests[0]?.getPayload()).toMatchObject({
+      note: 'please, a person',
+    });
+  });
+});

--- a/packages/support/src/services/human-handoff-service.ts
+++ b/packages/support/src/services/human-handoff-service.ts
@@ -1,0 +1,311 @@
+/**
+ * HumanHandoffService — the lossless Human Handoff (FR-28b, issue #1928).
+ * Whatever pulls the trigger (an explicit client request, low answer
+ * confidence, a sensitive classification, high severity, failed automation,
+ * a policy cap, or a manual escalation), the handoff transfers the FULL case
+ * context — current state, the merged interaction/event timeline, and every
+ * prior {@link SupportAiRun} — so the Client never repeats themselves and the
+ * Support Specialist starts with the complete history.
+ *
+ * A no-repeat guarantee keeps at most one handoff active per case
+ * (`metadata.activeHandoff`): repeat triggers while one is pending only
+ * append a deduped audit event. Routing is a seam — the #1929 routing
+ * service plugs in via `assignSpecialist`; without it the case is queued for
+ * manual pickup (`new` → `triaged`).
+ */
+
+import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
+import {
+  type SupportAiRun,
+  SupportAiRunCollection,
+} from '../models/support-ai-run.js';
+import type { SupportCase } from '../models/support-case.js';
+import type { HumanHandoffTrigger } from '../types.js';
+import {
+  type CaseTimelineItem,
+  SupportCaseService,
+} from './support-case-service.js';
+
+/** One compact timeline entry inside a {@link HandoffContextPackage}. */
+export interface HandoffTimelineItem {
+  kind: 'interaction' | 'event';
+  /** ISO-8601 timestamp (the package is embedded in a JSON event payload). */
+  occurredAt: string;
+  actorKind: string;
+  summary: string;
+  /** Interaction body — the Client's own words travel with the handoff. */
+  body?: string;
+}
+
+/** One compact AI-run entry inside a {@link HandoffContextPackage}. */
+export interface HandoffAiRunSummary {
+  phase: string;
+  outcome: string;
+  confidence: number | null;
+  classification: Record<string, unknown>;
+  error: string | null;
+}
+
+/**
+ * The lossless context a Human Handoff transfers (FR-28b): the case's current
+ * state plus the merged timeline and every prior automated-work audit row.
+ * This is what the assigned Support Specialist receives — the Client never
+ * repeats themselves.
+ */
+export interface HandoffContextPackage {
+  caseNumber: string;
+  subject: string;
+  status: string;
+  severity: string;
+  category: string;
+  clientProfileId: string | null;
+  projectId: string | null;
+  planId: string | null;
+  timeline: HandoffTimelineItem[];
+  aiRuns: HandoffAiRunSummary[];
+}
+
+/**
+ * The routing seam (#1929): pick the Support Specialist for a handed-off
+ * case. Return `null` to leave the case in the queue for manual assignment.
+ */
+export type SpecialistRouter = (
+  supportCase: SupportCase,
+  context: { trigger: HumanHandoffTrigger },
+) => Promise<{
+  specialistId: string;
+  rationale?: Record<string, unknown>;
+} | null>;
+
+/** Options for {@link HumanHandoffService.create}. */
+export interface HumanHandoffServiceOptions extends SmrtObjectOptions {
+  /** Routing seam; omitted → handed-off cases queue for manual assignment. */
+  assignSpecialist?: SpecialistRouter;
+}
+
+/** Input for one {@link HumanHandoffService.handoff} call. */
+export interface HumanHandoffInput {
+  trigger: HumanHandoffTrigger;
+  /** Free-form context for the audit event (why the trigger fired). */
+  note?: string;
+  /** The requesting Client profile, for `client_request` triggers. */
+  requestedByProfileId?: string | null;
+}
+
+/** Result of one {@link HumanHandoffService.handoff} call. */
+export interface HumanHandoffResult {
+  supportCase: SupportCase;
+  /** True when an earlier handoff was still active (no-repeat guarantee). */
+  alreadyActive: boolean;
+}
+
+/**
+ * The Human Handoff engine. Construct with {@link HumanHandoffService.create}.
+ */
+export class HumanHandoffService {
+  readonly caseService: SupportCaseService;
+  readonly aiRuns: SupportAiRunCollection;
+  private readonly assignSpecialist?: SpecialistRouter;
+
+  protected constructor(deps: {
+    caseService: SupportCaseService;
+    aiRuns: SupportAiRunCollection;
+    assignSpecialist?: SpecialistRouter;
+  }) {
+    this.caseService = deps.caseService;
+    this.aiRuns = deps.aiRuns;
+    this.assignSpecialist = deps.assignSpecialist;
+  }
+
+  static async create(
+    options: HumanHandoffServiceOptions,
+  ): Promise<HumanHandoffService> {
+    const [caseService, aiRuns] = await Promise.all([
+      SupportCaseService.create(options),
+      SupportAiRunCollection.create(options),
+    ]);
+    return new HumanHandoffService({
+      caseService,
+      aiRuns,
+      assignSpecialist: options.assignSpecialist,
+    });
+  }
+
+  /**
+   * Assemble the lossless context package for a case: current state, the
+   * merged interaction/event timeline, and every prior AI run (FR-28b).
+   */
+  async buildContextPackage(caseId: string): Promise<HandoffContextPackage> {
+    const supportCase = await this.caseService.getCase(caseId);
+    const [timeline, runs] = await Promise.all([
+      this.caseService.getTimeline(caseId),
+      this.aiRuns.forCase(caseId),
+    ]);
+    return {
+      caseNumber: supportCase.caseNumber,
+      subject: supportCase.subject,
+      status: supportCase.status,
+      severity: supportCase.severity,
+      category: supportCase.category,
+      clientProfileId: supportCase.clientProfileId,
+      projectId: supportCase.projectId,
+      planId: supportCase.planId,
+      timeline: timeline.map((item) => compactTimelineItem(item)),
+      aiRuns: runs.map((run) => compactAiRun(run)),
+    };
+  }
+
+  /**
+   * Hand the case to a human: enforce the no-repeat guarantee, stamp
+   * `metadata.activeHandoff`, record the `handoff` audit event carrying the
+   * full context package, then route via the `assignSpecialist` seam (or
+   * queue the case as `triaged` when unrouted).
+   */
+  async handoff(
+    caseRef: SupportCase | string,
+    input: HumanHandoffInput,
+  ): Promise<HumanHandoffResult> {
+    const supportCase =
+      typeof caseRef === 'string'
+        ? await this.caseService.getCase(caseRef)
+        : caseRef;
+    const caseId = this.caseIdOf(supportCase);
+
+    // No-repeat guarantee: while one handoff is pending, repeat triggers only
+    // append a deduped audit event — assignment never runs twice.
+    if (this.isHandoffActive(supportCase)) {
+      await this.caseService.recordEvent(supportCase, 'handoff', {
+        actorKind: 'system',
+        summary: `Human handoff (${input.trigger}) deduped — one already active`,
+        payload: { trigger: input.trigger, deduped: true },
+      });
+      return { supportCase, alreadyActive: true };
+    }
+
+    supportCase.updateMetadata({
+      activeHandoff: { trigger: input.trigger, at: new Date().toISOString() },
+    });
+    await supportCase.save();
+
+    if (input.trigger === 'client_request') {
+      await this.caseService.requestHuman(supportCase, {
+        byProfileId: input.requestedByProfileId ?? null,
+        note: input.note,
+      });
+    }
+
+    const contextPackage = await this.buildContextPackage(caseId);
+    await this.caseService.recordEvent(supportCase, 'handoff', {
+      actorKind: 'system',
+      summary: `Human handoff triggered (${input.trigger})`,
+      payload: {
+        trigger: input.trigger,
+        note: input.note ?? null,
+        contextPackage,
+      },
+    });
+
+    let routed: Awaited<ReturnType<SpecialistRouter>> = null;
+    if (this.assignSpecialist) {
+      routed = await this.assignSpecialist(supportCase, {
+        trigger: input.trigger,
+      });
+    }
+    if (routed) {
+      await this.caseService.assign(supportCase, {
+        actorKind: 'system',
+        specialistId: routed.specialistId,
+        rationale: routed.rationale,
+      });
+    } else if (supportCase.status === 'new') {
+      await this.caseService.transition(supportCase, 'triaged', {
+        actorKind: 'system',
+        reason: 'human handoff queued',
+      });
+    }
+
+    return { supportCase, alreadyActive: false };
+  }
+
+  /**
+   * Clear the active-handoff flag so a later trigger can hand off again.
+   * Apps call this when the handoff concludes (assignment accepted or the
+   * case resolves); a resolve-then-reopen also invalidates the flag
+   * automatically inside {@link handoff}.
+   */
+  async releaseHandoff(caseRef: SupportCase | string): Promise<SupportCase> {
+    const supportCase =
+      typeof caseRef === 'string'
+        ? await this.caseService.getCase(caseRef)
+        : caseRef;
+    if (supportCase.getMetadata().activeHandoff) {
+      supportCase.updateMetadata({ activeHandoff: null });
+      await supportCase.save();
+    }
+    return supportCase;
+  }
+
+  /**
+   * Whether a handoff is still pending on the case. A flag survives only
+   * while the case stays open; a resolve-and-reopen since the flag was set
+   * makes it stale (the new conversation may hand off afresh).
+   */
+  private isHandoffActive(supportCase: SupportCase): boolean {
+    const active = supportCase.getMetadata().activeHandoff;
+    if (!active || typeof active !== 'object') {
+      return false;
+    }
+    if (!supportCase.isOpen()) {
+      return false;
+    }
+    const at = Date.parse(String((active as Record<string, unknown>).at ?? ''));
+    if (
+      Number.isFinite(at) &&
+      supportCase.lastReopenedAt &&
+      supportCase.lastReopenedAt.getTime() > at
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  /** The persisted id of a saved case. */
+  private caseIdOf(supportCase: SupportCase): string {
+    if (!supportCase.id) {
+      throw new Error('SupportCase has no id — was it saved?');
+    }
+    return supportCase.id;
+  }
+}
+
+/** Compact one merged-timeline item for the context package. */
+function compactTimelineItem(item: CaseTimelineItem): HandoffTimelineItem {
+  if (item.kind === 'interaction' && item.interaction) {
+    return {
+      kind: 'interaction',
+      occurredAt: item.occurredAt.toISOString(),
+      actorKind: item.interaction.actorKind,
+      summary: `${item.interaction.direction} ${item.interaction.channelKind}`,
+      body: item.interaction.body,
+    };
+  }
+  return {
+    kind: 'event',
+    occurredAt: item.occurredAt.toISOString(),
+    actorKind: item.event?.actorKind ?? 'system',
+    summary: item.event?.summary ?? '',
+  };
+}
+
+/** Compact one AI run for the context package. */
+function compactAiRun(run: SupportAiRun): HandoffAiRunSummary {
+  return {
+    phase: run.phase,
+    outcome: run.outcome,
+    confidence: run.confidence,
+    classification: run.getClassification(),
+    error: run.error || null,
+  };
+}
+
+export default HumanHandoffService;

--- a/packages/support/src/services/index.ts
+++ b/packages/support/src/services/index.ts
@@ -3,6 +3,14 @@
  */
 
 export {
+  addCoveredMinutes,
+  type CoverageCalendar,
+  coveredMinutesBetween,
+  MAX_COVERAGE_SCAN_DAYS,
+  type ZonedParts,
+  zonedParts,
+} from './coverage-calendar.js';
+export {
   type HandoffAiRunSummary,
   type HandoffContextPackage,
   type HandoffTimelineItem,
@@ -12,6 +20,14 @@ export {
   type HumanHandoffServiceOptions,
   type SpecialistRouter,
 } from './human-handoff-service.js';
+export {
+  DEFAULT_SEVERITY_KEY,
+  ESCALATION_JOB_PRIORITY,
+  type ResolvedTargetPlanTerms,
+  ServiceTargetEngine,
+  type ServiceTargetEngineOptions,
+  SUPPORT_JOB_QUEUE,
+} from './service-target-engine.js';
 export {
   type RecordServiceTimeEntryInput,
   ServiceTimeEntryService,
@@ -51,6 +67,14 @@ export {
   type SupportIntakeOptions,
   SupportIntakeService,
 } from './support-intake-service.js';
+export {
+  type AutoAssignResult,
+  type RankedSpecialist,
+  ReassignDeniedError,
+  ROUTING_WEIGHTS,
+  SupportRoutingService,
+  type SupportRoutingServiceOptions,
+} from './support-routing-service.js';
 export {
   type ApproveTimeEntryInput,
   type ApproveTimeEntryResult,

--- a/packages/support/src/services/index.ts
+++ b/packages/support/src/services/index.ts
@@ -20,6 +20,7 @@ export {
   type HumanHandoffServiceOptions,
   type SpecialistRouter,
 } from './human-handoff-service.js';
+export { KeyedMutex } from './keyed-mutex.js';
 export {
   DEFAULT_SEVERITY_KEY,
   ESCALATION_JOB_PRIORITY,
@@ -67,6 +68,11 @@ export {
   type SupportIntakeOptions,
   SupportIntakeService,
 } from './support-intake-service.js';
+export {
+  type PlanAdminActor,
+  PlanAdminDeniedError,
+  SupportPlanAdminService,
+} from './support-plan-admin-service.js';
 export {
   type AutoAssignResult,
   type RankedSpecialist,

--- a/packages/support/src/services/index.ts
+++ b/packages/support/src/services/index.ts
@@ -3,6 +3,29 @@
  */
 
 export {
+  type HandoffAiRunSummary,
+  type HandoffContextPackage,
+  type HandoffTimelineItem,
+  type HumanHandoffInput,
+  type HumanHandoffResult,
+  HumanHandoffService,
+  type HumanHandoffServiceOptions,
+  type SpecialistRouter,
+} from './human-handoff-service.js';
+export {
+  createDefaultAiBoundary,
+  createNoopKnowledgeProvider,
+  type KnowledgeSnippet,
+  type SupportAiAnswerResult,
+  type SupportAiBoundary,
+  type SupportAiClassifyResult,
+  SupportAiWorkflow,
+  type SupportAiWorkflowOptions,
+  type SupportHandoffNotice,
+  type SupportKnowledgeProvider,
+  severityRank,
+} from './support-ai-workflow.js';
+export {
   type CaseActor,
   type CaseTimelineItem,
   type OpenCaseInput,

--- a/packages/support/src/services/index.ts
+++ b/packages/support/src/services/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Service barrel for `@happyvertical/smrt-support`.
+ */
+
+export {
+  type CaseActor,
+  type CaseTimelineItem,
+  type OpenCaseInput,
+  type RecordInteractionInput,
+  SupportCaseService,
+} from './support-case-service.js';
+export {
+  CHAT_MESSAGE_SOURCE_TYPE,
+  CHAT_ROOM_TARGET_TYPE,
+  EMAIL_ACCOUNT_TARGET_TYPE,
+  EMAIL_SOURCE_TYPE,
+  type InboundChatMessage,
+  type InboundEmail,
+  type IntakeResult,
+  registerSupportIntake,
+  SUPPORT_INTAKE_INTERCEPTOR,
+  type SupportIntakeOptions,
+  SupportIntakeService,
+} from './support-intake-service.js';

--- a/packages/support/src/services/index.ts
+++ b/packages/support/src/services/index.ts
@@ -13,6 +13,12 @@ export {
   type SpecialistRouter,
 } from './human-handoff-service.js';
 export {
+  type RecordServiceTimeEntryInput,
+  ServiceTimeEntryService,
+  type ServiceTimeEntryServiceOptions,
+  type SubmitServiceTimeEntryInput,
+} from './service-time-entry-service.js';
+export {
   createDefaultAiBoundary,
   createNoopKnowledgeProvider,
   type KnowledgeSnippet,
@@ -45,3 +51,14 @@ export {
   type SupportIntakeOptions,
   SupportIntakeService,
 } from './support-intake-service.js';
+export {
+  type ApproveTimeEntryInput,
+  type ApproveTimeEntryResult,
+  type CorrectTimeEntryInput,
+  type CorrectTimeEntryResult,
+  type RejectTimeEntryInput,
+  type ResolvedPlanTerms,
+  TimeEntryApprovalDeniedError,
+  TimeEntryApprovalService,
+  type TimeEntryApprovalServiceOptions,
+} from './time-entry-approval-service.js';

--- a/packages/support/src/services/keyed-mutex.ts
+++ b/packages/support/src/services/keyed-mutex.ts
@@ -1,0 +1,41 @@
+/**
+ * KeyedMutex — serialize async work per key within one process.
+ *
+ * Used where a read-then-write decision must not interleave for the same
+ * logical resource: intake's create-or-join per conversation key, and
+ * included-time consumption per case during time-entry approval. Keys chain
+ * promises, so concurrent callers for the same key run strictly in arrival
+ * order while different keys stay fully parallel; entries clean up when the
+ * last waiter finishes.
+ *
+ * Scope: in-process only. It covers the deployment shape these paths run in
+ * (one app process owns intake interceptors / approval actions); multi-
+ * replica deployments serialize at the app layer (sticky routing or a
+ * DB-level claim), which composes above these seams.
+ */
+export class KeyedMutex {
+  private readonly tails = new Map<string, Promise<unknown>>();
+
+  /** Run `fn` exclusively for `key`, after every earlier holder of it. */
+  async run<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.tails.get(key) ?? Promise.resolve();
+    // Chain regardless of the predecessor's outcome — a failed holder must
+    // not poison the queue behind it.
+    const turn = previous.then(fn, fn);
+    // Track completion (success or failure) so cleanup always runs.
+    const settled = turn.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.tails.set(key, settled);
+    try {
+      return await turn;
+    } finally {
+      if (this.tails.get(key) === settled) {
+        this.tails.delete(key);
+      }
+    }
+  }
+}
+
+export default KeyedMutex;

--- a/packages/support/src/services/service-target-engine.test.ts
+++ b/packages/support/src/services/service-target-engine.test.ts
@@ -1,0 +1,614 @@
+/**
+ * ServiceTargetEngine tests (#1929): plan-snapshot clock creation with real
+ * one-shot `_smrt_jobs` escalation rows, idempotent starts, satisfy-on-reply
+ * with job cancellation, update-cycle recurrence, plan-governed pause/resume
+ * (FR-29b), resolution settlement, and breach escalation through the plan's
+ * policy steps (notify → delayed reassign).
+ *
+ * Real in-memory SQLite throughout — the `_smrt_jobs` table is created from
+ * the runtime registry (the smrt-vitest plugin loads the jobs package
+ * manifest cross-package) inside the isolated transaction, since the local
+ * manifest file only carries this package's objects.
+ */
+
+import { getTestDatabase } from '@happyvertical/smrt-core';
+import { SmrtJobCollection } from '@happyvertical/smrt-jobs';
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { SupportCase } from '../models/support-case.js';
+import type { SupportPlan } from '../models/support-plan.js';
+import {
+  SupportEscalationCollection,
+  type SupportServiceTarget,
+  SupportServiceTargetCollection,
+} from '../models/support-service-target.js';
+import {
+  SupportAvailabilityCollection,
+  SupportSpecialistCollection,
+} from '../models/support-specialist.js';
+import type { EscalationStep } from '../types.js';
+import { ServiceTargetEngine } from './service-target-engine.js';
+import { SupportCaseService } from './support-case-service.js';
+
+const MODEL_NAMES = [
+  'SupportCase',
+  'SupportInteraction',
+  'SupportCaseEvent',
+  'SupportWorkLink',
+  'SupportPlan',
+  'SupportServiceTarget',
+  'SupportEscalation',
+  'SupportSpecialist',
+  'SupportQualification',
+  'SupportAvailability',
+  'SmrtJob',
+];
+
+// Fixed instants — 2026-01-05 is a Monday.
+const T0 = new Date('2026-01-05T10:00:00Z');
+const at = (isoTime: string): Date => new Date(`2026-01-05T${isoTime}Z`);
+
+describe('ServiceTargetEngine', () => {
+  let ctx: Awaited<ReturnType<typeof createIsolatedTestDbFromManifest>>;
+  let service: SupportCaseService;
+  let engine: ServiceTargetEngine;
+  let targets: SupportServiceTargetCollection;
+  let escalations: SupportEscalationCollection;
+  let jobs: SmrtJobCollection;
+
+  beforeEach(async () => {
+    ctx = await createIsolatedTestDbFromManifest({
+      includeObjects: MODEL_NAMES,
+    });
+    // `SmrtJob` lives in `@happyvertical/smrt-jobs`, outside this package's
+    // manifest file — create its `_smrt_jobs` table from the runtime
+    // registry inside the isolated transaction.
+    await getTestDatabase({
+      db: ctx.db as unknown as DatabaseInterface,
+      classes: ['SmrtJob'],
+      includeSystemTables: false,
+    });
+    service = await SupportCaseService.create({ db: ctx.db });
+    engine = await ServiceTargetEngine.create({
+      db: ctx.db,
+      caseService: service,
+    });
+    targets = await SupportServiceTargetCollection.create({ db: ctx.db });
+    escalations = await SupportEscalationCollection.create({ db: ctx.db });
+    jobs = await SmrtJobCollection.create({ db: ctx.db });
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  async function makePlan(
+    overrides: Partial<{
+      pauseStatuses: string[];
+      escalationPolicy: EscalationStep[];
+      updateMinutes: number | null;
+    }> = {},
+  ): Promise<SupportPlan> {
+    return service.plans.create({
+      planKey: `plan-${crypto.randomUUID().slice(0, 8)}`,
+      name: 'Gold',
+      timezone: 'UTC',
+      coverage: '[]',
+      holidays: '[]',
+      targets: JSON.stringify({
+        sev2: {
+          acknowledgementMinutes: 30,
+          responseMinutes: 120,
+          updateMinutes: overrides.updateMinutes ?? 60,
+          resolutionMinutes: 480,
+        },
+      }),
+      pauseStatuses: JSON.stringify(
+        overrides.pauseStatuses ?? ['waiting_on_client'],
+      ),
+      escalationPolicy: JSON.stringify(overrides.escalationPolicy ?? []),
+    });
+  }
+
+  async function openPlannedCase(
+    plan: SupportPlan,
+    input: Record<string, unknown> = {},
+  ): Promise<SupportCase> {
+    return service.openCase({
+      subject: 'Dashboard is slow',
+      severity: 'sev2',
+      planId: plan.id,
+      ...input,
+    });
+  }
+
+  async function reloadTarget(id: string): Promise<SupportServiceTarget> {
+    const found = await targets.get({ id });
+    if (!found) throw new Error(`target not found: ${id}`);
+    return found;
+  }
+
+  function byType(
+    list: SupportServiceTarget[],
+    targetType: string,
+  ): SupportServiceTarget {
+    const found = list.find((target) => target.targetType === targetType);
+    if (!found) throw new Error(`no ${targetType} target in ${list.length}`);
+    return found;
+  }
+
+  describe('startTargetsForCase', () => {
+    it('creates one clock per configured target type from the plan snapshot, with real pending jobs at dueAt', async () => {
+      const plan = await makePlan();
+      const supportCase = await openPlannedCase(plan);
+      const created = await engine.startTargetsForCase(supportCase, { at: T0 });
+
+      expect(created.map((t) => t.targetType).sort()).toEqual([
+        'acknowledgement',
+        'resolution',
+        'response',
+        'update',
+      ]);
+      const ack = byType(created, 'acknowledgement');
+      expect(ack.status).toBe('pending');
+      expect(ack.cycle).toBe(0);
+      expect(ack.severity).toBe('sev2');
+      expect(ack.baseMinutes).toBe(30);
+      expect(ack.startedAt.toISOString()).toBe(T0.toISOString());
+      expect(ack.dueAt.toISOString()).toBe(at('10:30:00').toISOString());
+      expect(byType(created, 'response').dueAt.toISOString()).toBe(
+        at('12:00:00').toISOString(),
+      );
+      expect(byType(created, 'update').dueAt.toISOString()).toBe(
+        at('11:00:00').toISOString(),
+      );
+      expect(byType(created, 'resolution').dueAt.toISOString()).toBe(
+        at('18:00:00').toISOString(),
+      );
+
+      // Real one-shot _smrt_jobs rows, linked via escalationJobId.
+      for (const target of created) {
+        expect(target.escalationJobId).toBeTruthy();
+        const job = await jobs.get({ id: target.escalationJobId });
+        expect(job).not.toBeNull();
+        expect(job?.status).toBe('pending');
+        expect(job?.queue).toBe('support');
+        expect(job?.objectType).toBe('SupportServiceTarget');
+        expect(job?.objectId).toBe(target.id);
+        expect(job?.method).toBe('checkAndEscalate');
+        expect(job?.priority).toBe(75);
+        expect(job?.runAt.toISOString()).toBe(target.dueAt.toISOString());
+      }
+
+      const events = await service.events.forCase(supportCase.id ?? '', {
+        eventType: 'target_scheduled',
+      });
+      expect(events).toHaveLength(4);
+    });
+
+    it('is idempotent while clocks are active', async () => {
+      const plan = await makePlan();
+      const supportCase = await openPlannedCase(plan);
+      await engine.startTargetsForCase(supportCase, { at: T0 });
+      const second = await engine.startTargetsForCase(supportCase, {
+        at: at('10:05:00'),
+      });
+
+      expect(second).toHaveLength(0);
+      expect(await targets.forCase(supportCase.id ?? '')).toHaveLength(4);
+    });
+
+    it('uses default target minutes when the case has no plan', async () => {
+      const supportCase = await service.openCase({ subject: 'No plan' });
+      const created = await engine.startTargetsForCase(supportCase, { at: T0 });
+
+      // DEFAULT_TARGET_MINUTES: acknowledgement 60, response 240, no update,
+      // no resolution.
+      expect(created.map((t) => t.targetType).sort()).toEqual([
+        'acknowledgement',
+        'response',
+      ]);
+      expect(byType(created, 'acknowledgement').dueAt.toISOString()).toBe(
+        at('11:00:00').toISOString(),
+      );
+    });
+
+    it('skips job rows when scheduleJobs is disabled', async () => {
+      const quietEngine = await ServiceTargetEngine.create({
+        db: ctx.db,
+        caseService: service,
+        scheduleJobs: false,
+      });
+      const plan = await makePlan();
+      const supportCase = await openPlannedCase(plan);
+      const created = await quietEngine.startTargetsForCase(supportCase, {
+        at: T0,
+      });
+
+      expect(created.length).toBeGreaterThan(0);
+      expect(created.every((t) => t.escalationJobId === '')).toBe(true);
+      expect(await jobs.listByStatus('pending')).toHaveLength(0);
+    });
+  });
+
+  describe('onInteractionRecorded', () => {
+    it('satisfies acknowledgement and response on the first outbound reply and cancels their jobs', async () => {
+      const plan = await makePlan();
+      const supportCase = await openPlannedCase(plan);
+      const created = await engine.startTargetsForCase(supportCase, { at: T0 });
+      const ackJobId = byType(created, 'acknowledgement').escalationJobId;
+      const responseJobId = byType(created, 'response').escalationJobId;
+
+      const interaction = await service.recordInteraction(supportCase, {
+        direction: 'outbound',
+        channelKind: 'chat',
+        actorKind: 'specialist',
+        body: 'Looking into it now.',
+        occurredAt: at('10:10:00'),
+      });
+      await engine.onInteractionRecorded(supportCase, interaction);
+
+      const ack = await reloadTarget(
+        byType(created, 'acknowledgement').id ?? '',
+      );
+      const response = await reloadTarget(byType(created, 'response').id ?? '');
+      expect(ack.status).toBe('satisfied');
+      expect(ack.satisfiedAt?.toISOString()).toBe(at('10:10:00').toISOString());
+      expect(response.status).toBe('satisfied');
+
+      expect((await jobs.get({ id: ackJobId }))?.status).toBe('cancelled');
+      expect((await jobs.get({ id: responseJobId }))?.status).toBe('cancelled');
+
+      const satisfiedEvents = await service.events.forCase(
+        supportCase.id ?? '',
+        { eventType: 'target_satisfied' },
+      );
+      expect(satisfiedEvents.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('rolls the update clock to the next cycle from the interaction instant', async () => {
+      const plan = await makePlan();
+      const supportCase = await openPlannedCase(plan);
+      const created = await engine.startTargetsForCase(supportCase, { at: T0 });
+      const cycleZero = byType(created, 'update');
+
+      const interaction = await service.recordInteraction(supportCase, {
+        direction: 'outbound',
+        channelKind: 'chat',
+        actorKind: 'agent',
+        body: 'Status update: mitigation in progress.',
+        occurredAt: at('10:40:00'),
+      });
+      await engine.onInteractionRecorded(supportCase, interaction);
+
+      expect((await reloadTarget(cycleZero.id ?? '')).status).toBe('satisfied');
+      const next = await targets.activeTarget(supportCase.id ?? '', 'update');
+      expect(next).not.toBeNull();
+      expect(next?.cycle).toBe(1);
+      expect(next?.startedAt.toISOString()).toBe(at('10:40:00').toISOString());
+      expect(next?.dueAt.toISOString()).toBe(at('11:40:00').toISOString());
+      const nextJob = await jobs.get({ id: next?.escalationJobId ?? '' });
+      expect(nextJob?.status).toBe('pending');
+      expect(nextJob?.runAt.toISOString()).toBe(at('11:40:00').toISOString());
+    });
+
+    it('never satisfies clocks from inbound client interactions', async () => {
+      const plan = await makePlan();
+      const supportCase = await openPlannedCase(plan);
+      const created = await engine.startTargetsForCase(supportCase, { at: T0 });
+
+      const inbound = await service.recordInteraction(supportCase, {
+        direction: 'inbound',
+        channelKind: 'chat',
+        actorKind: 'client',
+        body: 'Any update?',
+        occurredAt: at('10:20:00'),
+      });
+      await engine.onInteractionRecorded(supportCase, inbound);
+
+      const ack = await reloadTarget(
+        byType(created, 'acknowledgement').id ?? '',
+      );
+      expect(ack.status).toBe('pending');
+    });
+  });
+
+  describe('onCaseTransition — pause and resume (FR-29b)', () => {
+    it('pauses pending clocks entering a plan pause status and resumes with the remaining covered minutes', async () => {
+      const plan = await makePlan();
+      const supportCase = await openPlannedCase(plan);
+      const created = await engine.startTargetsForCase(supportCase, { at: T0 });
+      const ack = byType(created, 'acknowledgement');
+      const firstJobId = ack.escalationJobId;
+
+      await service.transition(supportCase, 'in_progress', {
+        actorKind: 'specialist',
+      });
+      await service.transition(supportCase, 'waiting_on_client', {
+        actorKind: 'specialist',
+      });
+      await engine.onCaseTransition(
+        supportCase,
+        'in_progress',
+        'waiting_on_client',
+        { at: at('10:15:00') },
+      );
+
+      const paused = await reloadTarget(ack.id ?? '');
+      expect(paused.status).toBe('paused');
+      expect(paused.pausedAt?.toISOString()).toBe(at('10:15:00').toISOString());
+      expect(paused.getMetadata().consumedMinutes).toBe(15);
+      expect((await jobs.get({ id: firstJobId }))?.status).toBe('cancelled');
+
+      await service.transition(supportCase, 'in_progress', {
+        actorKind: 'specialist',
+      });
+      await engine.onCaseTransition(
+        supportCase,
+        'waiting_on_client',
+        'in_progress',
+        { at: at('11:00:00') },
+      );
+
+      const resumed = await reloadTarget(ack.id ?? '');
+      expect(resumed.status).toBe('pending');
+      expect(resumed.pausedAt).toBeNull();
+      expect(resumed.pausedTotalSeconds).toBe(45 * 60);
+      // 30 base − 15 consumed = 15 covered minutes left from 11:00.
+      expect(resumed.dueAt.toISOString()).toBe(at('11:15:00').toISOString());
+      expect(resumed.escalationJobId).not.toBe(firstJobId);
+      const freshJob = await jobs.get({ id: resumed.escalationJobId });
+      expect(freshJob?.status).toBe('pending');
+      expect(freshJob?.runAt.toISOString()).toBe(at('11:15:00').toISOString());
+
+      const caseId = supportCase.id ?? '';
+      expect(
+        await service.events.forCase(caseId, { eventType: 'target_paused' }),
+      ).not.toHaveLength(0);
+      expect(
+        await service.events.forCase(caseId, { eventType: 'target_resumed' }),
+      ).not.toHaveLength(0);
+    });
+
+    it('does NOT pause clocks when the plan does not list the status (FR-29b)', async () => {
+      const plan = await makePlan({ pauseStatuses: [] });
+      const supportCase = await openPlannedCase(plan);
+      const created = await engine.startTargetsForCase(supportCase, { at: T0 });
+      const ack = byType(created, 'acknowledgement');
+
+      await service.transition(supportCase, 'in_progress', {
+        actorKind: 'specialist',
+      });
+      await service.transition(supportCase, 'waiting_on_client', {
+        actorKind: 'specialist',
+      });
+      await engine.onCaseTransition(
+        supportCase,
+        'in_progress',
+        'waiting_on_client',
+        { at: at('10:15:00') },
+      );
+
+      const untouched = await reloadTarget(ack.id ?? '');
+      expect(untouched.status).toBe('pending');
+      expect(untouched.dueAt.toISOString()).toBe(at('10:30:00').toISOString());
+      expect((await jobs.get({ id: ack.escalationJobId }))?.status).toBe(
+        'pending',
+      );
+    });
+  });
+
+  describe('onCaseTransition — resolution and reopen', () => {
+    it('satisfies the resolution clock and cancels the rest on resolve', async () => {
+      const plan = await makePlan();
+      const supportCase = await openPlannedCase(plan);
+      const created = await engine.startTargetsForCase(supportCase, { at: T0 });
+
+      await service.resolve(supportCase, {
+        actorKind: 'specialist',
+        summary: 'Rebuilt the index.',
+      });
+      await engine.onCaseTransition(supportCase, 'new', 'resolved', {
+        at: at('12:00:00'),
+      });
+
+      const resolution = await reloadTarget(
+        byType(created, 'resolution').id ?? '',
+      );
+      expect(resolution.status).toBe('satisfied');
+      for (const targetType of ['acknowledgement', 'response', 'update']) {
+        const target = await reloadTarget(byType(created, targetType).id ?? '');
+        expect(target.status).toBe('cancelled');
+        expect(target.cancelledAt?.toISOString()).toBe(
+          at('12:00:00').toISOString(),
+        );
+        expect((await jobs.get({ id: target.escalationJobId }))?.status).toBe(
+          'cancelled',
+        );
+      }
+    });
+
+    it('starts fresh clocks on the next cycle when a case reopens', async () => {
+      const plan = await makePlan();
+      const supportCase = await openPlannedCase(plan);
+      await engine.startTargetsForCase(supportCase, { at: T0 });
+      await service.resolve(supportCase, {
+        actorKind: 'specialist',
+        summary: 'Done.',
+      });
+      await engine.onCaseTransition(supportCase, 'new', 'resolved', {
+        at: at('12:00:00'),
+      });
+
+      await service.reopen(supportCase, { actorKind: 'client' });
+      await engine.onCaseTransition(supportCase, 'resolved', 'triaged', {
+        at: at('13:00:00'),
+      });
+
+      const ack = await targets.activeTarget(
+        supportCase.id ?? '',
+        'acknowledgement',
+      );
+      expect(ack).not.toBeNull();
+      expect(ack?.cycle).toBe(1);
+      expect(ack?.startedAt.toISOString()).toBe(at('13:00:00').toISOString());
+      expect(ack?.dueAt.toISOString()).toBe(at('13:30:00').toISOString());
+      expect(await targets.forCase(supportCase.id ?? '')).toHaveLength(8);
+    });
+  });
+
+  describe('checkAndEscalate', () => {
+    const POLICY: EscalationStep[] = [
+      { level: 1, action: 'notify', notifyProfileIds: ['profile-lead'] },
+      { level: 2, action: 'reassign', delayMinutes: 30 },
+    ];
+
+    async function breachedSetup(): Promise<{
+      supportCase: SupportCase;
+      ack: SupportServiceTarget;
+    }> {
+      const plan = await makePlan({ escalationPolicy: POLICY });
+      const supportCase = await openPlannedCase(plan);
+      const created = await engine.startTargetsForCase(supportCase, { at: T0 });
+      return { supportCase, ack: byType(created, 'acknowledgement') };
+    }
+
+    it('marks an overdue pending clock breached, escalates level 1, and schedules the delayed level-2 step', async () => {
+      const { supportCase, ack } = await breachedSetup();
+
+      const result = await ack.checkAndEscalate({ at: at('11:00:00') });
+      expect(result.outcome).toBe('breached');
+
+      const breached = await reloadTarget(ack.id ?? '');
+      expect(breached.status).toBe('breached');
+      expect(breached.breachedAt?.toISOString()).toBe(
+        at('11:00:00').toISOString(),
+      );
+
+      const rows = await escalations.forCase(supportCase.id ?? '');
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.level).toBe(1);
+      expect(rows[0]?.reason).toBe('target_breach');
+      expect(rows[0]?.action).toBe('notify');
+      expect(rows[0]?.targetId).toBe(ack.id);
+      expect(rows[0]?.targetType).toBe('acknowledgement');
+      expect(rows[0]?.getNotifiedProfileIds()).toEqual(['profile-lead']);
+
+      const reloaded = await service.getCase(supportCase.id ?? '');
+      expect(reloaded.escalationLevel).toBe(1);
+      expect(reloaded.escalatedAt?.toISOString()).toBe(
+        at('11:00:00').toISOString(),
+      );
+      expect(reloaded.status).toBe('escalated');
+
+      const caseId = supportCase.id ?? '';
+      expect(
+        await service.events.forCase(caseId, { eventType: 'target_breached' }),
+      ).toHaveLength(1);
+      expect(
+        await service.events.forCase(caseId, { eventType: 'escalation' }),
+      ).toHaveLength(1);
+
+      // The level-2 follow-up job: same target/method, 30 wall-clock minutes
+      // later, with the pending level recorded on the target.
+      const pending = await jobs.listByStatus('pending');
+      const followUp = pending.find(
+        (job) =>
+          job.objectId === ack.id &&
+          job.runAt.toISOString() === at('11:30:00').toISOString(),
+      );
+      expect(followUp).toBeTruthy();
+      expect(breached.getMetadata().pendingEscalationLevel).toBe(2);
+    });
+
+    it('is idempotent on satisfied targets and on breached targets before the follow-up is due', async () => {
+      const { supportCase, ack } = await breachedSetup();
+
+      await ack.checkAndEscalate({ at: at('11:00:00') });
+      // Redelivery (at-least-once) before the level-2 delay elapses: no-op.
+      const redelivery = await ack.checkAndEscalate({ at: at('11:05:00') });
+      expect(redelivery.outcome).toBe('noop');
+      expect(await escalations.forCase(supportCase.id ?? '')).toHaveLength(1);
+      expect(
+        (await service.getCase(supportCase.id ?? '')).escalationLevel,
+      ).toBe(1);
+
+      // Satisfied clocks never escalate. (Reload the case: the escalation
+      // above transitioned the persisted row to 'escalated'.)
+      const escalatedCase = await service.getCase(supportCase.id ?? '');
+      const created = await targets.forCase(supportCase.id ?? '');
+      const response = byType(created, 'response');
+      const interaction = await service.recordInteraction(escalatedCase, {
+        direction: 'outbound',
+        channelKind: 'chat',
+        actorKind: 'specialist',
+        body: 'Answered.',
+        occurredAt: at('11:10:00'),
+      });
+      await engine.onInteractionRecorded(escalatedCase, interaction);
+      const satisfiedResult = await response.checkAndEscalate({
+        at: at('12:30:00'),
+      });
+      expect(satisfiedResult.outcome).toBe('noop');
+      expect(await escalations.forCase(supportCase.id ?? '')).toHaveLength(1);
+    });
+
+    it('no-ops when the clock was rescheduled to a later dueAt', async () => {
+      const { ack } = await breachedSetup();
+      const result = await ack.checkAndEscalate({ at: at('10:15:00') });
+      expect(result.outcome).toBe('rescheduled');
+      expect((await reloadTarget(ack.id ?? '')).status).toBe('pending');
+    });
+
+    it('level-2 reassign moves the case to the next eligible specialist, excluding the current assignee', async () => {
+      const specialists = await SupportSpecialistCollection.create({
+        db: ctx.db,
+      });
+      const availabilities = await SupportAvailabilityCollection.create({
+        db: ctx.db,
+      });
+
+      const current = await specialists.create({
+        profileId: 'profile-current',
+        displayName: 'Current Carol',
+        timezone: 'UTC',
+      });
+      const backup = await specialists.create({
+        profileId: 'profile-backup',
+        displayName: 'Backup Bob',
+        timezone: 'UTC',
+      });
+      for (const specialist of [current, backup]) {
+        await availabilities.create({
+          specialistId: specialist.id,
+          kind: 'weekly',
+          weekday: 1,
+          startMinute: 0,
+          endMinute: 1440,
+        });
+      }
+
+      const { supportCase, ack } = await breachedSetup();
+      await service.assign(supportCase, {
+        actorKind: 'system',
+        specialistId: current.id ?? '',
+      });
+
+      await ack.checkAndEscalate({ at: at('11:00:00') });
+      const followUp = await ack.checkAndEscalate({ at: at('11:30:00') });
+      expect(followUp.outcome).toBe('escalated');
+
+      const rows = await escalations.forCase(supportCase.id ?? '');
+      expect(rows).toHaveLength(2);
+      const level2 = rows.find((row) => row.level === 2);
+      expect(level2?.action).toBe('reassign');
+      expect(level2?.fromSpecialistId).toBe(current.id);
+      expect(level2?.toSpecialistId).toBe(backup.id);
+
+      const reloaded = await service.getCase(supportCase.id ?? '');
+      expect(reloaded.escalationLevel).toBe(2);
+      expect(reloaded.assignedSpecialistId).toBe(backup.id);
+    });
+  });
+});

--- a/packages/support/src/services/service-target-engine.test.ts
+++ b/packages/support/src/services/service-target-engine.test.ts
@@ -293,6 +293,48 @@ describe('ServiceTargetEngine', () => {
       expect(nextJob?.runAt.toISOString()).toBe(at('11:40:00').toISOString());
     });
 
+    it('a templated acknowledgement satisfies only the acknowledgement clock', async () => {
+      const plan = await makePlan();
+      const supportCase = await openPlannedCase(plan);
+      const created = await engine.startTargetsForCase(supportCase, { at: T0 });
+      const updateZero = byType(created, 'update');
+
+      // The AI workflow marks its instant receipt with
+      // `metadata.acknowledgement` — it must not satisfy response/update
+      // clocks (that would neuter response Service Targets on AI cases).
+      const ackInteraction = await service.recordInteraction(supportCase, {
+        direction: 'outbound',
+        channelKind: 'chat',
+        actorKind: 'agent',
+        body: 'Thanks — case opened, on it.',
+        occurredAt: at('10:01:00'),
+        metadata: { acknowledgement: true },
+      });
+      await engine.onInteractionRecorded(supportCase, ackInteraction);
+
+      expect(
+        (await reloadTarget(byType(created, 'acknowledgement').id ?? ''))
+          .status,
+      ).toBe('satisfied');
+      expect(
+        (await reloadTarget(byType(created, 'response').id ?? '')).status,
+      ).toBe('pending');
+      expect((await reloadTarget(updateZero.id ?? '')).status).toBe('pending');
+
+      // The substantive answer then satisfies the response clock.
+      const answer = await service.recordInteraction(supportCase, {
+        direction: 'outbound',
+        channelKind: 'chat',
+        actorKind: 'agent',
+        body: 'Here is the fix: …',
+        occurredAt: at('10:15:00'),
+      });
+      await engine.onInteractionRecorded(supportCase, answer);
+      expect(
+        (await reloadTarget(byType(created, 'response').id ?? '')).status,
+      ).toBe('satisfied');
+    });
+
     it('never satisfies clocks from inbound client interactions', async () => {
       const plan = await makePlan();
       const supportCase = await openPlannedCase(plan);

--- a/packages/support/src/services/service-target-engine.test.ts
+++ b/packages/support/src/services/service-target-engine.test.ts
@@ -516,6 +516,22 @@ describe('ServiceTargetEngine', () => {
       return { supportCase, ack: byType(created, 'acknowledgement') };
     }
 
+    it('escalates once per (target, level) under duplicate redelivery', async () => {
+      const { supportCase, ack } = await breachedSetup();
+
+      // At-least-once jobs redeliver: a stale instance that still believes
+      // the clock is pending, plus a straight re-run, must not stack
+      // duplicate level-1 escalations (codex review round 3, PR #1943).
+      const stale = await reloadTarget(ack.id ?? '');
+      await ack.checkAndEscalate({ at: at('11:00:00') });
+      await stale.checkAndEscalate({ at: at('11:00:00') });
+      await ack.checkAndEscalate({ at: at('11:00:05') });
+
+      const rows = await escalations.forCase(supportCase.id ?? '');
+      const levelOnes = rows.filter((row) => row.level === 1);
+      expect(levelOnes).toHaveLength(1);
+    });
+
     it('marks an overdue pending clock breached, escalates level 1, and schedules the delayed level-2 step', async () => {
       const { supportCase, ack } = await breachedSetup();
 

--- a/packages/support/src/services/service-target-engine.ts
+++ b/packages/support/src/services/service-target-engine.ts
@@ -457,7 +457,20 @@ export class ServiceTargetEngine {
     const at = interaction.occurredAt ?? new Date();
     const satisfied: SupportServiceTarget[] = [];
 
-    for (const targetType of ['acknowledgement', 'response'] as const) {
+    // Drafts (`metadata.draft`) were never delivered — they satisfy nothing.
+    const interactionMeta = interaction.getMetadata();
+    if (interactionMeta.draft === true) {
+      return [];
+    }
+    // A templated receipt (`metadata.acknowledgement`) satisfies only the
+    // acknowledgement clock; response/update clocks wait for a substantive
+    // reply — otherwise the instant AI ack would neuter response targets.
+    const ackOnly = interactionMeta.acknowledgement === true;
+    const satisfiableTypes = ackOnly
+      ? (['acknowledgement'] as const)
+      : (['acknowledgement', 'response'] as const);
+
+    for (const targetType of satisfiableTypes) {
       const target = await this.targets.activeTarget(caseId, targetType);
       if (target) {
         await this.satisfyTarget(supportCase, target, at);
@@ -465,7 +478,9 @@ export class ServiceTargetEngine {
       }
     }
 
-    const update = await this.targets.activeTarget(caseId, 'update');
+    const update = ackOnly
+      ? null
+      : await this.targets.activeTarget(caseId, 'update');
     if (update) {
       await this.satisfyTarget(supportCase, update, at);
       satisfied.push(update);

--- a/packages/support/src/services/service-target-engine.ts
+++ b/packages/support/src/services/service-target-engine.ts
@@ -1,0 +1,826 @@
+/**
+ * ServiceTargetEngine — Service Target clocks with timed escalation
+ * (FR-30/FR-31).
+ *
+ * Owns the full clock lifecycle on a case:
+ * - **start** — one clock per configured target type from the case's plan
+ *   terms (the frozen `planSnapshot` wins over the live plan; sensible
+ *   defaults with no plan), `dueAt` computed in *covered* time through the
+ *   plan's coverage calendar, plus a one-shot `_smrt_jobs` row
+ *   (`SupportServiceTarget.checkAndEscalate`) scheduled at `dueAt`;
+ * - **satisfy** — outbound specialist/agent interactions satisfy the
+ *   acknowledgement/response clocks and roll the recurring update clock to
+ *   its next cycle; satisfied clocks cancel their escalation job;
+ * - **pause/resume** — case statuses listed in the plan's `pauseStatuses`
+ *   freeze clocks (FR-29b: waiting periods pause clocks *only when the plan
+ *   says so*); resume recomputes `dueAt` from the remaining covered minutes
+ *   and enqueues a fresh job;
+ * - **resolve/reopen** — resolution satisfies the resolution clock and
+ *   cancels the rest; reopening starts fresh clocks on a new cycle;
+ * - **breach** — an overdue clock is marked breached and escalated through
+ *   the plan's escalation policy (notify or reassign via
+ *   {@link SupportRoutingService}), with optional delayed follow-up steps.
+ *
+ * The engine is invoked by the application around
+ * {@link SupportCaseService} calls; it deliberately takes explicit `at`
+ * instants so behavior is deterministic and testable.
+ */
+
+import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
+import { type SmrtJob, SmrtJobCollection } from '@happyvertical/smrt-jobs';
+import type { SupportCase } from '../models/support-case.js';
+import type { SupportInteraction } from '../models/support-interaction.js';
+import { DEFAULT_TARGET_MINUTES } from '../models/support-plan.js';
+import {
+  SupportEscalationCollection,
+  type SupportServiceTarget,
+  SupportServiceTargetCollection,
+} from '../models/support-service-target.js';
+import {
+  type EscalationStep,
+  OPEN_SUPPORT_CASE_STATUSES,
+  type ServiceTargetMinutes,
+  type ServiceTargetType,
+  type SupportCaseStatus,
+} from '../types.js';
+import {
+  addCoveredMinutes,
+  type CoverageCalendar,
+  coveredMinutesBetween,
+} from './coverage-calendar.js';
+import { SupportCaseService } from './support-case-service.js';
+import { SupportRoutingService } from './support-routing-service.js';
+
+/** Queue name for support escalation jobs. */
+export const SUPPORT_JOB_QUEUE = 'support';
+
+/** Priority for escalation jobs (`high` — breaches are time-critical). */
+export const ESCALATION_JOB_PRIORITY = 75;
+
+/** Severity assumed when a case has not been assigned one yet. */
+export const DEFAULT_SEVERITY_KEY = 'sev3';
+
+/** Case statuses that pause clocks when the plan doesn't say otherwise. */
+const DEFAULT_PAUSE_STATUSES = ['waiting_on_client'];
+
+const MINUTE_MS = 60_000;
+
+/** Clock target types in start order. */
+const TARGET_TYPES: ServiceTargetType[] = [
+  'acknowledgement',
+  'response',
+  'update',
+  'resolution',
+];
+
+/** The plan terms a case's clocks run against (snapshot-first). */
+export interface ResolvedTargetPlanTerms {
+  calendar: CoverageCalendar;
+  pauseStatuses: string[];
+  escalationPolicy: EscalationStep[];
+  targetsForSeverity(severity: string): ServiceTargetMinutes;
+}
+
+/** Options for {@link ServiceTargetEngine.create}. */
+export interface ServiceTargetEngineOptions extends SmrtObjectOptions {
+  /** Share an existing case service (and its collections) with the engine. */
+  caseService?: SupportCaseService;
+  /**
+   * Whether to enqueue real `_smrt_jobs` escalation rows (default `true`).
+   * Disable only where a jobs table is unavailable by design.
+   */
+  scheduleJobs?: boolean;
+}
+
+function targetMinutesFor(
+  minutes: ServiceTargetMinutes,
+  targetType: ServiceTargetType,
+): number | null {
+  switch (targetType) {
+    case 'acknowledgement':
+      return minutes.acknowledgementMinutes;
+    case 'response':
+      return minutes.responseMinutes;
+    case 'update':
+      return minutes.updateMinutes;
+    case 'resolution':
+      return minutes.resolutionMinutes;
+    default:
+      return null;
+  }
+}
+
+function asStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  return value.filter((entry): entry is string => typeof entry === 'string');
+}
+
+function asFiniteNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function parseIsoDate(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+  if (typeof value === 'string' && value) {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return null;
+}
+
+/**
+ * The clock engine. Construct with {@link ServiceTargetEngine.create}.
+ */
+export class ServiceTargetEngine {
+  readonly caseService: SupportCaseService;
+  readonly targets: SupportServiceTargetCollection;
+  readonly escalations: SupportEscalationCollection;
+  readonly jobs: SmrtJobCollection;
+  readonly scheduleJobs: boolean;
+
+  private readonly options: SmrtObjectOptions;
+  private routing?: SupportRoutingService;
+
+  protected constructor(deps: {
+    options: SmrtObjectOptions;
+    caseService: SupportCaseService;
+    targets: SupportServiceTargetCollection;
+    escalations: SupportEscalationCollection;
+    jobs: SmrtJobCollection;
+    scheduleJobs: boolean;
+  }) {
+    this.options = deps.options;
+    this.caseService = deps.caseService;
+    this.targets = deps.targets;
+    this.escalations = deps.escalations;
+    this.jobs = deps.jobs;
+    this.scheduleJobs = deps.scheduleJobs;
+  }
+
+  static async create(
+    options: ServiceTargetEngineOptions,
+  ): Promise<ServiceTargetEngine> {
+    const { caseService, scheduleJobs, ...smrtOptions } = options;
+    const [service, targets, escalations, jobs] = await Promise.all([
+      caseService ?? SupportCaseService.create(smrtOptions),
+      SupportServiceTargetCollection.create(smrtOptions),
+      SupportEscalationCollection.create(smrtOptions),
+      SmrtJobCollection.create(smrtOptions),
+    ]);
+    return new ServiceTargetEngine({
+      options: smrtOptions,
+      caseService: service,
+      targets,
+      escalations,
+      jobs,
+      scheduleJobs: scheduleJobs ?? true,
+    });
+  }
+
+  private async resolveCase(
+    caseRef: SupportCase | string,
+  ): Promise<SupportCase> {
+    return typeof caseRef === 'string'
+      ? this.caseService.getCase(caseRef)
+      : caseRef;
+  }
+
+  private requireId(entity: { id?: string | null }, label: string): string {
+    if (!entity.id) {
+      throw new Error(`${label} has no id — was it saved?`);
+    }
+    return entity.id;
+  }
+
+  private async getRoutingService(): Promise<SupportRoutingService> {
+    if (!this.routing) {
+      this.routing = await SupportRoutingService.create({
+        ...this.options,
+        caseService: this.caseService,
+      });
+    }
+    return this.routing;
+  }
+
+  /**
+   * Resolve the plan terms governing a case's clocks: the frozen
+   * `planSnapshot` when present, else the loaded plan, else conservative
+   * defaults (24×7 calendar, default target minutes, pause on
+   * `waiting_on_client`, empty escalation policy).
+   */
+  async resolvePlanTerms(supportCase: SupportCase): Promise<ResolvedTargetPlanTerms> {
+    const snapshot = supportCase.getPlanSnapshot();
+    if (Object.keys(snapshot).length > 0) {
+      const coverage = Array.isArray(snapshot.coverage)
+        ? (snapshot.coverage as CoverageCalendar['windows'])
+        : [];
+      const calendar: CoverageCalendar = {
+        windows: coverage,
+        holidays: asStringArray(snapshot.holidays) ?? [],
+        timezone:
+          typeof snapshot.timezone === 'string' && snapshot.timezone
+            ? snapshot.timezone
+            : 'UTC',
+      };
+      const targets =
+        snapshot.targets && typeof snapshot.targets === 'object'
+          ? (snapshot.targets as Record<string, Partial<ServiceTargetMinutes>>)
+          : {};
+      return {
+        calendar,
+        // An explicit (even empty) snapshot list is authoritative — FR-29b:
+        // clocks pause only when the plan says so.
+        pauseStatuses:
+          asStringArray(snapshot.pauseStatuses) ?? DEFAULT_PAUSE_STATUSES,
+        escalationPolicy: Array.isArray(snapshot.escalationPolicy)
+          ? (snapshot.escalationPolicy as EscalationStep[])
+          : [],
+        targetsForSeverity: (severity: string) => ({
+          ...DEFAULT_TARGET_MINUTES,
+          ...(targets[severity] ?? {}),
+        }),
+      };
+    }
+
+    if (supportCase.planId) {
+      const plan = await this.caseService.plans.get({ id: supportCase.planId });
+      if (plan) {
+        return {
+          calendar: {
+            windows: plan.getCoverage(),
+            holidays: plan.getHolidays(),
+            timezone: plan.timezone || 'UTC',
+          },
+          pauseStatuses: plan.getPauseStatuses(),
+          escalationPolicy: plan.getEscalationPolicy(),
+          targetsForSeverity: (severity: string) =>
+            plan.targetsForSeverity(severity),
+        };
+      }
+    }
+
+    return {
+      calendar: { windows: [], holidays: [], timezone: 'UTC' },
+      pauseStatuses: [...DEFAULT_PAUSE_STATUSES],
+      escalationPolicy: [],
+      targetsForSeverity: () => ({ ...DEFAULT_TARGET_MINUTES }),
+    };
+  }
+
+  /**
+   * Start the case's Service Target clocks (idempotent: target types that
+   * already have an active clock are skipped). One clock per non-null
+   * configured minutes for the case severity — the `update` clock only when
+   * the plan configures `updateMinutes`. A first start creates cycle 0;
+   * starting again after clocks settled (e.g. a reopen) creates the next
+   * cycle, preserving the settled rows.
+   */
+  async startTargetsForCase(
+    caseRef: SupportCase | string,
+    opts: { at?: Date } = {},
+  ): Promise<SupportServiceTarget[]> {
+    const supportCase = await this.resolveCase(caseRef);
+    return this.startTargets(supportCase, opts.at ?? new Date());
+  }
+
+  private async startTargets(
+    supportCase: SupportCase,
+    at: Date,
+  ): Promise<SupportServiceTarget[]> {
+    const caseId = this.requireId(supportCase, 'SupportCase');
+    const terms = await this.resolvePlanTerms(supportCase);
+    const severity = supportCase.severity || DEFAULT_SEVERITY_KEY;
+    const minutes = terms.targetsForSeverity(severity);
+    const existing = await this.targets.forCase(caseId);
+
+    const created: SupportServiceTarget[] = [];
+    for (const targetType of TARGET_TYPES) {
+      const baseMinutes = targetMinutesFor(minutes, targetType);
+      if (baseMinutes === null) {
+        continue;
+      }
+      const active = await this.targets.activeTarget(caseId, targetType);
+      if (active) {
+        continue;
+      }
+      // Next cycle above any prior (settled) row of this type — first start
+      // is cycle 0; a reopen starts the next cycle. Never reuse a settled
+      // row's cycle: `(case_id, target_type, cycle)` are conflict columns,
+      // so an equal-cycle create would upsert over the historical row.
+      const prior = existing.filter(
+        (target) => target.targetType === targetType,
+      );
+      const cycle =
+        prior.length > 0
+          ? Math.max(...prior.map((target) => target.cycle)) + 1
+          : 0;
+      created.push(
+        await this.startTarget(supportCase, terms, {
+          targetType,
+          cycle,
+          severity,
+          baseMinutes,
+          at,
+        }),
+      );
+    }
+    return created;
+  }
+
+  private async startTarget(
+    supportCase: SupportCase,
+    terms: ResolvedTargetPlanTerms,
+    input: {
+      targetType: ServiceTargetType;
+      cycle: number;
+      severity: string;
+      baseMinutes: number;
+      at: Date;
+    },
+  ): Promise<SupportServiceTarget> {
+    const dueAt = addCoveredMinutes(
+      terms.calendar,
+      input.at,
+      input.baseMinutes,
+    );
+    const target = await this.targets.create({
+      tenantId: supportCase.tenantId,
+      caseId: this.requireId(supportCase, 'SupportCase'),
+      targetType: input.targetType,
+      cycle: input.cycle,
+      severity: input.severity,
+      baseMinutes: input.baseMinutes,
+      startedAt: input.at,
+      dueAt,
+      status: 'pending',
+      metadata: JSON.stringify({ consumedMinutes: 0 }),
+    });
+    await this.scheduleEscalationJob(target, dueAt);
+    await this.caseService.recordEvent(supportCase, 'target_scheduled', {
+      actorKind: 'system',
+      occurredAt: input.at,
+      summary: `${input.targetType} target scheduled (cycle ${input.cycle}, due ${dueAt.toISOString()})`,
+      payload: {
+        targetId: target.id,
+        targetType: input.targetType,
+        cycle: input.cycle,
+        severity: input.severity,
+        baseMinutes: input.baseMinutes,
+        dueAt: dueAt.toISOString(),
+      },
+    });
+    return target;
+  }
+
+  /**
+   * Enqueue the one-shot escalation job for a clock at `runAt` and record
+   * its id on the target (`escalationJobId`) so satisfying can cancel it.
+   */
+  private async scheduleEscalationJob(
+    target: SupportServiceTarget,
+    runAt: Date,
+  ): Promise<void> {
+    if (!this.scheduleJobs) {
+      return;
+    }
+    const job = await this.jobs.enqueueJob(
+      {
+        tenantId: target.tenantId ?? null,
+        queue: SUPPORT_JOB_QUEUE,
+        objectType: 'SupportServiceTarget',
+        objectId: this.requireId(target, 'SupportServiceTarget'),
+        method: 'checkAndEscalate',
+        args: {},
+        runAt,
+        priority: ESCALATION_JOB_PRIORITY,
+      },
+      // Trusted internal caller: escalation jobs carry clock correctness, so
+      // they must not be dropped by the per-tenant creation cap. Their count
+      // is bounded by the tenant's active clocks.
+      { tenantJobCap: 0 },
+    );
+    target.escalationJobId = job.id ?? '';
+    await target.save();
+  }
+
+  /**
+   * Cancel a clock's pending escalation job, tolerating jobs that already
+   * ran, were cancelled, or are missing (at-least-once semantics).
+   */
+  private async cancelEscalationJob(
+    target: SupportServiceTarget,
+  ): Promise<void> {
+    if (!target.escalationJobId) {
+      return;
+    }
+    try {
+      const job: SmrtJob | null = await this.jobs.get({
+        id: target.escalationJobId,
+      });
+      if (job && (job.status === 'pending' || job.status === 'running')) {
+        await job.cancel();
+      }
+    } catch {
+      // Already terminal or missing — the target state is authoritative.
+    }
+  }
+
+  /**
+   * React to a recorded interaction. Outbound specialist/agent interactions
+   * satisfy the acknowledgement clock (first outbound of any kind), the
+   * response clock (first substantive outbound — the same trigger), and the
+   * active update-cycle clock (which then restarts at the next cycle from
+   * the interaction instant). Inbound client interactions never satisfy
+   * clocks.
+   */
+  async onInteractionRecorded(
+    caseRef: SupportCase | string,
+    interaction: SupportInteraction,
+  ): Promise<SupportServiceTarget[]> {
+    if (interaction.direction !== 'outbound') {
+      return [];
+    }
+    if (
+      interaction.actorKind !== 'specialist' &&
+      interaction.actorKind !== 'agent'
+    ) {
+      return [];
+    }
+    const supportCase = await this.resolveCase(caseRef);
+    const caseId = this.requireId(supportCase, 'SupportCase');
+    const at = interaction.occurredAt ?? new Date();
+    const satisfied: SupportServiceTarget[] = [];
+
+    for (const targetType of ['acknowledgement', 'response'] as const) {
+      const target = await this.targets.activeTarget(caseId, targetType);
+      if (target) {
+        await this.satisfyTarget(supportCase, target, at);
+        satisfied.push(target);
+      }
+    }
+
+    const update = await this.targets.activeTarget(caseId, 'update');
+    if (update) {
+      await this.satisfyTarget(supportCase, update, at);
+      satisfied.push(update);
+      const terms = await this.resolvePlanTerms(supportCase);
+      const severity = supportCase.severity || DEFAULT_SEVERITY_KEY;
+      const updateMinutes = terms.targetsForSeverity(severity).updateMinutes;
+      if (updateMinutes !== null) {
+        await this.startTarget(supportCase, terms, {
+          targetType: 'update',
+          cycle: update.cycle + 1,
+          severity,
+          baseMinutes: updateMinutes,
+          at,
+        });
+      }
+    }
+
+    return satisfied;
+  }
+
+  private async satisfyTarget(
+    supportCase: SupportCase,
+    target: SupportServiceTarget,
+    at: Date,
+  ): Promise<void> {
+    if (target.pausedAt) {
+      target.pausedTotalSeconds += Math.max(
+        0,
+        Math.round((at.getTime() - target.pausedAt.getTime()) / 1000),
+      );
+      target.pausedAt = null;
+    }
+    target.status = 'satisfied';
+    target.satisfiedAt = at;
+    await target.save();
+    await this.cancelEscalationJob(target);
+    await this.caseService.recordEvent(supportCase, 'target_satisfied', {
+      actorKind: 'system',
+      occurredAt: at,
+      summary: `${target.targetType} target satisfied`,
+      payload: {
+        targetId: target.id,
+        targetType: target.targetType,
+        cycle: target.cycle,
+      },
+    });
+  }
+
+  /**
+   * React to a case lifecycle transition:
+   * - to `resolved` — satisfy the resolution clock, cancel every other
+   *   active clock (and its job);
+   * - to `closed` — cancel all remaining active clocks;
+   * - reopen (`resolved`/`closed` → an open status) — start fresh clocks on
+   *   the next cycle for every type;
+   * - entering a plan pause status — freeze pending clocks (FR-29b: only
+   *   when the plan says so);
+   * - leaving a pause status — resume paused clocks with `dueAt` recomputed
+   *   from the remaining covered minutes and a fresh escalation job.
+   */
+  async onCaseTransition(
+    caseRef: SupportCase | string,
+    from: SupportCaseStatus,
+    to: SupportCaseStatus,
+    opts: { at?: Date } = {},
+  ): Promise<void> {
+    const supportCase = await this.resolveCase(caseRef);
+    const at = opts.at ?? new Date();
+
+    if (to === 'resolved' || to === 'closed') {
+      await this.settleTargetsForTerminal(supportCase, to, at);
+      return;
+    }
+
+    const reopened =
+      (from === 'resolved' || from === 'closed') &&
+      OPEN_SUPPORT_CASE_STATUSES.includes(to);
+    if (reopened) {
+      await this.startTargets(supportCase, at);
+      return;
+    }
+
+    const terms = await this.resolvePlanTerms(supportCase);
+    const wasPaused = terms.pauseStatuses.includes(from);
+    const nowPaused = terms.pauseStatuses.includes(to);
+    if (!wasPaused && nowPaused) {
+      await this.pauseTargets(supportCase, terms, at);
+    } else if (wasPaused && !nowPaused) {
+      await this.resumeTargets(supportCase, terms, at);
+    }
+  }
+
+  private async settleTargetsForTerminal(
+    supportCase: SupportCase,
+    to: 'resolved' | 'closed',
+    at: Date,
+  ): Promise<void> {
+    const caseId = this.requireId(supportCase, 'SupportCase');
+    if (to === 'resolved') {
+      const resolution = await this.targets.activeTarget(caseId, 'resolution');
+      if (resolution) {
+        await this.satisfyTarget(supportCase, resolution, at);
+      }
+    }
+    const remaining = await this.targets.list({
+      where: { caseId, 'status in': ['pending', 'paused'] },
+    });
+    for (const target of remaining) {
+      if (target.pausedAt) {
+        target.pausedTotalSeconds += Math.max(
+          0,
+          Math.round((at.getTime() - target.pausedAt.getTime()) / 1000),
+        );
+        target.pausedAt = null;
+      }
+      target.status = 'cancelled';
+      target.cancelledAt = at;
+      await target.save();
+      await this.cancelEscalationJob(target);
+    }
+  }
+
+  private async pauseTargets(
+    supportCase: SupportCase,
+    terms: ResolvedTargetPlanTerms,
+    at: Date,
+  ): Promise<void> {
+    const caseId = this.requireId(supportCase, 'SupportCase');
+    const pending = await this.targets.list({
+      where: { caseId, status: 'pending' },
+    });
+    for (const target of pending) {
+      const meta = target.getMetadata();
+      // Covered minutes consumed by the segment that just ended (since the
+      // last resume, or the clock start), accumulated across segments so
+      // resume can compute the remaining covered minutes exactly.
+      const segmentStart = parseIsoDate(meta.lastResumedAt) ?? target.startedAt;
+      const consumedMinutes =
+        asFiniteNumber(meta.consumedMinutes) +
+        coveredMinutesBetween(terms.calendar, segmentStart, at);
+      target.setMetadata({ ...meta, consumedMinutes });
+      target.pausedAt = at;
+      target.status = 'paused';
+      await target.save();
+      await this.cancelEscalationJob(target);
+      await this.caseService.recordEvent(supportCase, 'target_paused', {
+        actorKind: 'system',
+        occurredAt: at,
+        summary: `${target.targetType} target paused`,
+        payload: {
+          targetId: target.id,
+          targetType: target.targetType,
+          cycle: target.cycle,
+          consumedMinutes,
+        },
+      });
+    }
+  }
+
+  private async resumeTargets(
+    supportCase: SupportCase,
+    terms: ResolvedTargetPlanTerms,
+    at: Date,
+  ): Promise<void> {
+    const caseId = this.requireId(supportCase, 'SupportCase');
+    const paused = await this.targets.list({
+      where: { caseId, status: 'paused' },
+    });
+    for (const target of paused) {
+      const meta = target.getMetadata();
+      const remainingMinutes = Math.max(
+        target.baseMinutes - asFiniteNumber(meta.consumedMinutes),
+        0,
+      );
+      if (target.pausedAt) {
+        target.pausedTotalSeconds += Math.max(
+          0,
+          Math.round((at.getTime() - target.pausedAt.getTime()) / 1000),
+        );
+      }
+      target.pausedAt = null;
+      target.status = 'pending';
+      const dueAt = addCoveredMinutes(terms.calendar, at, remainingMinutes);
+      target.dueAt = dueAt;
+      target.setMetadata({ ...meta, lastResumedAt: at.toISOString() });
+      await target.save();
+      await this.scheduleEscalationJob(target, dueAt);
+      await this.caseService.recordEvent(supportCase, 'target_resumed', {
+        actorKind: 'system',
+        occurredAt: at,
+        summary: `${target.targetType} target resumed (due ${dueAt.toISOString()})`,
+        payload: {
+          targetId: target.id,
+          targetType: target.targetType,
+          cycle: target.cycle,
+          remainingMinutes,
+          dueAt: dueAt.toISOString(),
+        },
+      });
+    }
+  }
+
+  /**
+   * Escalate a breached clock through the plan's escalation policy: write
+   * the {@link SupportEscalation} audit row, apply the step action
+   * (`notify` records the profiles to notify; `reassign` routes to the next
+   * eligible specialist, excluding the current assignee), bump the case
+   * escalation level, transition the case to `escalated` (unless already
+   * resolved/closed), and schedule the next policy step when it declares a
+   * `delayMinutes`.
+   */
+  async escalateForBreach(
+    target: SupportServiceTarget,
+    opts: { at?: Date } = {},
+  ): Promise<void> {
+    const at = opts.at ?? target.breachedAt ?? new Date();
+    const supportCase = await this.caseService.getCase(target.caseId);
+    const terms = await this.resolvePlanTerms(supportCase);
+    const level = supportCase.escalationLevel + 1;
+    const step: EscalationStep = terms.escalationPolicy[level - 1] ?? {
+      level,
+      action: 'notify',
+    };
+
+    const escalation = await this.escalations.create({
+      tenantId: supportCase.tenantId,
+      caseId: this.requireId(supportCase, 'SupportCase'),
+      level,
+      reason: 'target_breach',
+      targetId: target.id,
+      targetType: target.targetType,
+      action: step.action,
+      fromSpecialistId: supportCase.assignedSpecialistId,
+      notifiedProfileIds: JSON.stringify(step.notifyProfileIds ?? []),
+      occurredAt: at,
+    });
+
+    let reassignedTo: string | null = null;
+    if (step.action === 'reassign') {
+      const routing = await this.getRoutingService();
+      const exclude = supportCase.assignedSpecialistId
+        ? [supportCase.assignedSpecialistId]
+        : [];
+      const result = await routing.autoAssign(supportCase, {
+        at,
+        exclude,
+        actorKind: 'system',
+      });
+      if (result.assigned && result.specialistId) {
+        reassignedTo = result.specialistId;
+        escalation.toSpecialistId = result.specialistId;
+        await escalation.save();
+      }
+    }
+
+    supportCase.escalationLevel = level;
+    supportCase.escalatedAt = at;
+    const terminal =
+      supportCase.status === 'resolved' || supportCase.status === 'closed';
+    if (!terminal && supportCase.status !== 'escalated') {
+      await this.caseService.transition(supportCase, 'escalated', {
+        actorKind: 'system',
+        reason: `${target.targetType} target breached`,
+      });
+    } else {
+      await supportCase.save();
+    }
+
+    await this.caseService.recordEvent(supportCase, 'target_breached', {
+      actorKind: 'system',
+      occurredAt: at,
+      summary: `${target.targetType} target breached`,
+      payload: {
+        targetId: target.id,
+        targetType: target.targetType,
+        cycle: target.cycle,
+        dueAt: target.dueAt.toISOString(),
+      },
+    });
+    await this.caseService.recordEvent(supportCase, 'escalation', {
+      actorKind: 'system',
+      occurredAt: at,
+      summary: `Escalated to level ${level} (${step.action})`,
+      payload: {
+        escalationId: escalation.id,
+        level,
+        action: step.action,
+        targetId: target.id,
+        targetType: target.targetType,
+        notifiedProfileIds: step.notifyProfileIds ?? [],
+        reassignedTo,
+      },
+    });
+
+    // Delayed follow-up: the next policy step (when it declares a delay)
+    // re-fires checkAndEscalate on the same target at `at + delay` wall
+    // time; the pending level marker gates the breached-target branch.
+    const next = terms.escalationPolicy[level];
+    if (next && next.delayMinutes != null && next.delayMinutes >= 0) {
+      const runAt = new Date(at.getTime() + next.delayMinutes * MINUTE_MS);
+      const meta = target.getMetadata();
+      target.setMetadata({
+        ...meta,
+        pendingEscalationLevel: next.level,
+        pendingEscalationAt: runAt.toISOString(),
+      });
+      await target.save();
+      if (this.scheduleJobs) {
+        await this.jobs.enqueueJob(
+          {
+            tenantId: target.tenantId ?? null,
+            queue: SUPPORT_JOB_QUEUE,
+            objectType: 'SupportServiceTarget',
+            objectId: this.requireId(target, 'SupportServiceTarget'),
+            method: 'checkAndEscalate',
+            args: {},
+            runAt,
+            priority: ESCALATION_JOB_PRIORITY,
+          },
+          { tenantJobCap: 0 },
+        );
+      }
+    }
+  }
+
+  /**
+   * Continue a delayed escalation on an already-breached clock: consumes the
+   * pending-level marker and escalates the next policy step, unless the case
+   * has since left its open states.
+   */
+  async continueEscalation(
+    target: SupportServiceTarget,
+    at: Date,
+  ): Promise<boolean> {
+    const meta = target.getMetadata();
+    const pendingAt = parseIsoDate(meta.pendingEscalationAt);
+    if (meta.pendingEscalationLevel == null || pendingAt === null) {
+      return false;
+    }
+    if (at.getTime() < pendingAt.getTime()) {
+      return false;
+    }
+    const {
+      pendingEscalationLevel: _level,
+      pendingEscalationAt: _at,
+      ...rest
+    } = meta;
+    target.setMetadata(rest);
+    await target.save();
+
+    const supportCase = await this.caseService.getCase(target.caseId);
+    if (!supportCase.isOpen()) {
+      return false;
+    }
+    await this.escalateForBreach(target, { at });
+    return true;
+  }
+}
+
+export default ServiceTargetEngine;

--- a/packages/support/src/services/service-target-engine.ts
+++ b/packages/support/src/services/service-target-engine.ts
@@ -705,6 +705,17 @@ export class ServiceTargetEngine {
       action: 'notify',
     };
 
+    // Escalation is idempotent per (target, level): at-least-once job
+    // delivery (or a concurrent duplicate claim) must not stack duplicate
+    // escalation records, notifications, or reassignments.
+    const already = await this.escalations.list({
+      where: { targetId: target.id, level },
+      limit: 1,
+    });
+    if (already.length > 0) {
+      return;
+    }
+
     const escalation = await this.escalations.create({
       tenantId: supportCase.tenantId,
       caseId: this.requireId(supportCase, 'SupportCase'),

--- a/packages/support/src/services/service-target-engine.ts
+++ b/packages/support/src/services/service-target-engine.ts
@@ -212,7 +212,9 @@ export class ServiceTargetEngine {
    * defaults (24×7 calendar, default target minutes, pause on
    * `waiting_on_client`, empty escalation policy).
    */
-  async resolvePlanTerms(supportCase: SupportCase): Promise<ResolvedTargetPlanTerms> {
+  async resolvePlanTerms(
+    supportCase: SupportCase,
+  ): Promise<ResolvedTargetPlanTerms> {
     const snapshot = supportCase.getPlanSnapshot();
     if (Object.keys(snapshot).length > 0) {
       const coverage = Array.isArray(snapshot.coverage)

--- a/packages/support/src/services/service-time-entry-service.test.ts
+++ b/packages/support/src/services/service-time-entry-service.test.ts
@@ -238,13 +238,26 @@ describe('ServiceTimeEntryService', () => {
 
     const explicit = await service.record({
       caseId: supportCase.id,
-      tenantId: 'tenant-override',
+      tenantId: 'tenant-1',
       participantKind: 'human',
       participantProfileId: 'profile-1',
       source: 'manual',
       durationSeconds: 600,
     });
-    expect(explicit.tenantId).toBe('tenant-override');
+    expect(explicit.tenantId).toBe('tenant-1');
+
+    // A disagreeing explicit tenant would be a cross-tenant reference onto
+    // another tenant's case — refused (copilot review, PR #1943).
+    await expect(
+      service.record({
+        caseId: supportCase.id,
+        tenantId: 'tenant-other',
+        participantKind: 'human',
+        participantProfileId: 'profile-1',
+        source: 'manual',
+        durationSeconds: 600,
+      }),
+    ).rejects.toThrow(/does not match the case's tenant/);
   });
 
   it('round-trips work evidence', async () => {

--- a/packages/support/src/services/service-time-entry-service.test.ts
+++ b/packages/support/src/services/service-time-entry-service.test.ts
@@ -1,0 +1,327 @@
+/**
+ * ServiceTimeEntryService tests (#1930): the ONE recording contract shared by
+ * timer, manual, imported, and agent entries — duration/participant/context
+ * validation, tenant copy from the case, evidence round-trips, the
+ * `time_recorded` audit event, and the submit flow.
+ */
+
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ServiceTimeEntryService } from './service-time-entry-service.js';
+import { SupportCaseService } from './support-case-service.js';
+
+const MODEL_NAMES = [
+  'SupportCase',
+  'SupportInteraction',
+  'SupportCaseEvent',
+  'SupportWorkLink',
+  'SupportPlan',
+  'SupportSpecialist',
+  'SupportCompensationPlan',
+  'ServiceTimeEntry',
+  'SupportCharge',
+  'SupportCompensation',
+];
+
+const STARTED_AT = new Date('2026-07-01T10:00:00.000Z');
+const ENDED_AT = new Date('2026-07-01T11:30:00.000Z');
+
+describe('ServiceTimeEntryService', () => {
+  let ctx: Awaited<ReturnType<typeof createIsolatedTestDbFromManifest>>;
+  let caseService: SupportCaseService;
+  let service: ServiceTimeEntryService;
+
+  beforeEach(async () => {
+    ctx = await createIsolatedTestDbFromManifest({
+      includeObjects: MODEL_NAMES,
+    });
+    caseService = await SupportCaseService.create({ db: ctx.db });
+    service = await ServiceTimeEntryService.create({
+      db: ctx.db,
+      caseService,
+    });
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  describe('one contract across all four sources', () => {
+    it('timer entries require both bounds and derive the duration', async () => {
+      const supportCase = await caseService.openCase({ subject: 'timer' });
+
+      await expect(
+        service.record({
+          caseId: supportCase.id,
+          participantKind: 'human',
+          participantProfileId: 'profile-1',
+          source: 'timer',
+          startedAt: STARTED_AT,
+        }),
+      ).rejects.toThrow(/'timer' requires both startedAt and endedAt/);
+
+      const entry = await service.record({
+        caseId: supportCase.id,
+        participantKind: 'human',
+        participantProfileId: 'profile-1',
+        source: 'timer',
+        description: 'debugged the login loop',
+        startedAt: STARTED_AT,
+        endedAt: ENDED_AT,
+      });
+      expect(entry.status).toBe('draft');
+      expect(entry.durationSeconds).toBe(5400);
+      expect(entry.source).toBe('timer');
+    });
+
+    it('manual entries take an explicit duration without bounds', async () => {
+      const supportCase = await caseService.openCase({ subject: 'manual' });
+      const entry = await service.record({
+        caseId: supportCase.id,
+        participantKind: 'human',
+        participantProfileId: 'profile-1',
+        source: 'manual',
+        description: 'pairing session',
+        durationSeconds: 1800,
+      });
+      expect(entry.durationSeconds).toBe(1800);
+      expect(entry.startedAt).toBeNull();
+    });
+
+    it('imported entries pass the same gate as first-party ones', async () => {
+      const supportCase = await caseService.openCase({ subject: 'import' });
+      const entry = await service.record({
+        caseId: supportCase.id,
+        participantKind: 'human',
+        participantProfileId: 'profile-1',
+        source: 'import',
+        description: 'imported from legacy tracker',
+        durationSeconds: 900,
+      });
+      expect(entry.source).toBe('import');
+
+      await expect(
+        service.record({
+          caseId: supportCase.id,
+          participantKind: 'human',
+          participantProfileId: 'profile-1',
+          source: 'import',
+          durationSeconds: 0,
+        }),
+      ).rejects.toThrow(/durationSeconds must be greater than zero/);
+    });
+
+    it('agent entries require an agentRef; humans require a profile', async () => {
+      const supportCase = await caseService.openCase({ subject: 'actors' });
+
+      await expect(
+        service.record({
+          caseId: supportCase.id,
+          participantKind: 'agent',
+          source: 'agent',
+          durationSeconds: 600,
+        }),
+      ).rejects.toThrow(/'agent' requires agentRef/);
+
+      await expect(
+        service.record({
+          caseId: supportCase.id,
+          participantKind: 'human',
+          source: 'manual',
+          durationSeconds: 600,
+        }),
+      ).rejects.toThrow(/'human' requires participantProfileId/);
+
+      const entry = await service.record({
+        caseId: supportCase.id,
+        participantKind: 'agent',
+        agentRef: 'persona:support-triage',
+        source: 'agent',
+        description: 'automated triage session',
+        durationSeconds: 600,
+      });
+      expect(entry.participantKind).toBe('agent');
+      expect(entry.agentRef).toBe('persona:support-triage');
+    });
+  });
+
+  describe('validation failures', () => {
+    it('rejects entries with no duration at all', async () => {
+      const supportCase = await caseService.openCase({ subject: 'no dur' });
+      await expect(
+        service.record({
+          caseId: supportCase.id,
+          participantKind: 'human',
+          participantProfileId: 'profile-1',
+          source: 'manual',
+        }),
+      ).rejects.toThrow(/a duration is required/);
+    });
+
+    it('rejects a period that ends before it starts', async () => {
+      const supportCase = await caseService.openCase({ subject: 'backwards' });
+      await expect(
+        service.record({
+          caseId: supportCase.id,
+          participantKind: 'human',
+          participantProfileId: 'profile-1',
+          source: 'timer',
+          startedAt: ENDED_AT,
+          endedAt: STARTED_AT,
+        }),
+      ).rejects.toThrow(/startedAt must be before endedAt/);
+    });
+
+    it('rejects entries with no work context', async () => {
+      await expect(
+        service.record({
+          participantKind: 'human',
+          participantProfileId: 'profile-1',
+          source: 'manual',
+          durationSeconds: 600,
+        }),
+      ).rejects.toThrow(/a work context is required/);
+    });
+
+    it('rejects a half-specified work ref', async () => {
+      await expect(
+        service.record({
+          workRefType: '@happyvertical/smrt-projects:Issue',
+          participantKind: 'human',
+          participantProfileId: 'profile-1',
+          source: 'manual',
+          durationSeconds: 600,
+        }),
+      ).rejects.toThrow(/workRefType and workRefId must be provided together/);
+    });
+
+    it('rejects a missing case', async () => {
+      await expect(
+        service.record({
+          caseId: 'no-such-case',
+          participantKind: 'human',
+          participantProfileId: 'profile-1',
+          source: 'manual',
+          durationSeconds: 600,
+        }),
+      ).rejects.toThrow(/SupportCase not found/);
+    });
+  });
+
+  it('accepts a pure work-ref context without a case (no case event)', async () => {
+    const entry = await service.record({
+      workRefType: '@happyvertical/smrt-projects:Issue',
+      workRefId: 'issue-42',
+      participantKind: 'human',
+      participantProfileId: 'profile-1',
+      source: 'manual',
+      description: 'planning session',
+      durationSeconds: 1200,
+    });
+    expect(entry.caseId).toBeNull();
+    expect(entry.workRefId).toBe('issue-42');
+  });
+
+  it('copies the tenant from the case unless explicitly provided', async () => {
+    const supportCase = await caseService.openCase({
+      subject: 'tenant copy',
+      tenantId: 'tenant-1',
+    });
+    const copied = await service.record({
+      caseId: supportCase.id,
+      participantKind: 'human',
+      participantProfileId: 'profile-1',
+      source: 'manual',
+      durationSeconds: 600,
+    });
+    expect(copied.tenantId).toBe('tenant-1');
+
+    const explicit = await service.record({
+      caseId: supportCase.id,
+      tenantId: 'tenant-override',
+      participantKind: 'human',
+      participantProfileId: 'profile-1',
+      source: 'manual',
+      durationSeconds: 600,
+    });
+    expect(explicit.tenantId).toBe('tenant-override');
+  });
+
+  it('round-trips work evidence', async () => {
+    const supportCase = await caseService.openCase({ subject: 'evidence' });
+    const evidence = [
+      { kind: 'commit', ref: 'abc123', label: 'fix: login loop' },
+      { kind: 'chat_message', ref: 'msg-9' },
+    ];
+    const entry = await service.record({
+      caseId: supportCase.id,
+      participantKind: 'human',
+      participantProfileId: 'profile-1',
+      source: 'manual',
+      durationSeconds: 600,
+      evidence,
+    });
+
+    const reloaded = await service.getEntry(entry.id ?? '');
+    expect(reloaded.getEvidence()).toEqual(evidence);
+  });
+
+  it('writes a time_recorded case event with the audit payload', async () => {
+    const supportCase = await caseService.openCase({ subject: 'audited' });
+    const entry = await service.record({
+      caseId: supportCase.id,
+      participantKind: 'agent',
+      agentRef: 'persona:support',
+      source: 'agent',
+      durationSeconds: 900,
+    });
+
+    const events = await caseService.events.forCase(supportCase.id ?? '', {
+      eventType: 'time_recorded',
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]?.actorKind).toBe('agent');
+    expect(events[0]?.getPayload()).toMatchObject({
+      timeEntryId: entry.id,
+      durationSeconds: 900,
+      source: 'agent',
+      participantKind: 'agent',
+    });
+  });
+
+  describe('submit', () => {
+    it('moves a draft to submitted with submitter stamps', async () => {
+      const supportCase = await caseService.openCase({ subject: 'submit' });
+      const entry = await service.record({
+        caseId: supportCase.id,
+        participantKind: 'human',
+        participantProfileId: 'profile-1',
+        source: 'manual',
+        durationSeconds: 600,
+      });
+
+      const submitted = await service.submit(entry, {
+        byProfileId: 'profile-1',
+      });
+      expect(submitted.status).toBe('submitted');
+      expect(submitted.submittedAt).toBeInstanceOf(Date);
+      expect(submitted.submittedByProfileId).toBe('profile-1');
+    });
+
+    it('refuses to submit an already-submitted entry', async () => {
+      const supportCase = await caseService.openCase({ subject: 'resubmit' });
+      const entry = await service.record({
+        caseId: supportCase.id,
+        participantKind: 'human',
+        participantProfileId: 'profile-1',
+        source: 'manual',
+        durationSeconds: 600,
+      });
+      await service.submit(entry);
+
+      await expect(service.submit(entry.id ?? '')).rejects.toThrow(
+        /only 'draft' or 'rejected' entries can be submitted/,
+      );
+    });
+  });
+});

--- a/packages/support/src/services/service-time-entry-service.ts
+++ b/packages/support/src/services/service-time-entry-service.ts
@@ -1,0 +1,237 @@
+/**
+ * ServiceTimeEntryService — the shared recording contract for Service Time
+ * Entries (FR-40, issue #1930): timer, manual, imported, and automatic agent
+ * entries all pass ONE validation and audit gate, so no source can smuggle in
+ * an incoherent duration, participant, or work context.
+ *
+ * Recording is deliberately money-free: entries capture the work (duration,
+ * period, evidence, participant, context) and land as `draft`; pricing and
+ * earnings derive later, at approval time, in `TimeEntryApprovalService`.
+ * Case-attached entries append a `time_recorded` audit event so the case
+ * timeline shows the work as it happens.
+ */
+
+import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
+import {
+  type ServiceTimeEntry,
+  ServiceTimeEntryCollection,
+} from '../models/service-time-entry.js';
+import type { SupportCase } from '../models/support-case.js';
+import type {
+  ServiceTimeEntrySource,
+  SupportParticipantKind,
+  TimeEntryEvidence,
+} from '../types.js';
+import { SupportCaseService } from './support-case-service.js';
+
+/** Options for {@link ServiceTimeEntryService.create}. */
+export interface ServiceTimeEntryServiceOptions extends SmrtObjectOptions {
+  /** Share an existing case facade (otherwise one is created internally). */
+  caseService?: SupportCaseService;
+}
+
+/** Input for {@link ServiceTimeEntryService.record} — all four sources. */
+export interface RecordServiceTimeEntryInput {
+  tenantId?: string | null;
+  /** Support Case context (either this or the work ref pair is required). */
+  caseId?: string | null;
+  /** Polymorphic work context: qualified class name + id, together. */
+  workRefType?: string | null;
+  workRefId?: string | null;
+  /** Specialist role record, when the deliverer is a Support Specialist. */
+  specialistId?: string | null;
+  participantKind: SupportParticipantKind;
+  /** Delivering human Participant — required when `participantKind: 'human'`. */
+  participantProfileId?: string | null;
+  /** Delivering agent identity — required when `participantKind: 'agent'`. */
+  agentRef?: string;
+  source: ServiceTimeEntrySource;
+  description?: string;
+  startedAt?: Date;
+  endedAt?: Date;
+  /** Explicit duration; derived from `endedAt − startedAt` when omitted. */
+  durationSeconds?: number;
+  evidence?: TimeEntryEvidence[];
+  metadata?: Record<string, unknown>;
+}
+
+/** Input for {@link ServiceTimeEntryService.submit}. */
+export interface SubmitServiceTimeEntryInput {
+  byProfileId?: string | null;
+}
+
+/**
+ * The write facade for recording and submitting Service Time Entries.
+ * Construct with {@link ServiceTimeEntryService.create}.
+ */
+export class ServiceTimeEntryService {
+  readonly entries: ServiceTimeEntryCollection;
+  readonly caseService: SupportCaseService;
+
+  protected constructor(collections: {
+    entries: ServiceTimeEntryCollection;
+    caseService: SupportCaseService;
+  }) {
+    this.entries = collections.entries;
+    this.caseService = collections.caseService;
+  }
+
+  static async create(
+    options: ServiceTimeEntryServiceOptions,
+  ): Promise<ServiceTimeEntryService> {
+    const caseService =
+      options.caseService ?? (await SupportCaseService.create(options));
+    const entries = await ServiceTimeEntryCollection.create(options);
+    return new ServiceTimeEntryService({ entries, caseService });
+  }
+
+  /** Load an entry or throw a descriptive error. */
+  async getEntry(
+    entryRef: ServiceTimeEntry | string,
+  ): Promise<ServiceTimeEntry> {
+    if (typeof entryRef !== 'string') {
+      return entryRef;
+    }
+    const found = await this.entries.get({ id: entryRef });
+    if (!found) {
+      throw new Error(`ServiceTimeEntry not found: ${entryRef}`);
+    }
+    return found;
+  }
+
+  /**
+   * Record one Service Time Entry as a `draft`. One validation contract for
+   * all four sources (FR-40):
+   *
+   * - a work context is required: `caseId` and/or the `workRefType`/`workRefId`
+   *   pair (a case-attached entry copies the case's tenant unless given);
+   * - the participant must be coherent: `human` needs `participantProfileId`,
+   *   `agent` needs `agentRef`;
+   * - `timer` entries need both period bounds; every entry needs a positive
+   *   duration — explicit `durationSeconds` or derived `endedAt − startedAt`.
+   *
+   * Case-attached entries append a `time_recorded` audit event.
+   */
+  async record(input: RecordServiceTimeEntryInput): Promise<ServiceTimeEntry> {
+    const hasWorkRef = Boolean(input.workRefType) || Boolean(input.workRefId);
+    if (hasWorkRef && !(input.workRefType && input.workRefId)) {
+      throw new Error(
+        'ServiceTimeEntry: workRefType and workRefId must be provided together.',
+      );
+    }
+    if (!input.caseId && !hasWorkRef) {
+      throw new Error(
+        'ServiceTimeEntry: a work context is required — provide caseId or the workRefType/workRefId pair.',
+      );
+    }
+
+    if (input.participantKind === 'human' && !input.participantProfileId) {
+      throw new Error(
+        "ServiceTimeEntry: participantKind 'human' requires participantProfileId (the delivering Participant).",
+      );
+    }
+    if (input.participantKind === 'agent' && !input.agentRef) {
+      throw new Error(
+        "ServiceTimeEntry: participantKind 'agent' requires agentRef (the delivering agent identity).",
+      );
+    }
+
+    if (input.source === 'timer' && !(input.startedAt && input.endedAt)) {
+      throw new Error(
+        "ServiceTimeEntry: source 'timer' requires both startedAt and endedAt.",
+      );
+    }
+    if (
+      input.startedAt &&
+      input.endedAt &&
+      input.startedAt.getTime() >= input.endedAt.getTime()
+    ) {
+      throw new Error('ServiceTimeEntry: startedAt must be before endedAt.');
+    }
+
+    const durationSeconds =
+      input.durationSeconds ??
+      (input.startedAt && input.endedAt
+        ? Math.round(
+            (input.endedAt.getTime() - input.startedAt.getTime()) / 1000,
+          )
+        : undefined);
+    if (durationSeconds === undefined) {
+      throw new Error(
+        'ServiceTimeEntry: a duration is required — provide durationSeconds or both startedAt and endedAt.',
+      );
+    }
+    if (!(durationSeconds > 0)) {
+      throw new Error(
+        `ServiceTimeEntry: durationSeconds must be greater than zero (got ${durationSeconds}).`,
+      );
+    }
+
+    let tenantId = input.tenantId ?? null;
+    let supportCase: SupportCase | null = null;
+    if (input.caseId) {
+      supportCase = await this.caseService.getCase(input.caseId);
+      if (input.tenantId === undefined) {
+        tenantId = supportCase.tenantId;
+      }
+    }
+
+    const entry = await this.entries.create({
+      tenantId,
+      caseId: input.caseId ?? null,
+      workRefType: input.workRefType ?? null,
+      workRefId: input.workRefId ?? null,
+      specialistId: input.specialistId ?? null,
+      participantKind: input.participantKind,
+      participantProfileId: input.participantProfileId ?? null,
+      agentRef: input.agentRef ?? '',
+      source: input.source,
+      description: input.description ?? '',
+      startedAt: input.startedAt ?? null,
+      endedAt: input.endedAt ?? null,
+      durationSeconds,
+      evidence: JSON.stringify(input.evidence ?? []),
+      status: 'draft',
+      metadata: JSON.stringify(input.metadata ?? {}),
+    });
+
+    if (supportCase) {
+      await this.caseService.recordEvent(supportCase, 'time_recorded', {
+        actorKind: input.participantKind === 'agent' ? 'agent' : 'specialist',
+        actorProfileId: input.participantProfileId ?? null,
+        summary: `Time recorded: ${(durationSeconds / 3600).toFixed(2)}h (${input.source})`,
+        payload: {
+          timeEntryId: entry.id,
+          durationSeconds,
+          source: input.source,
+          participantKind: input.participantKind,
+        },
+      });
+    }
+
+    return entry;
+  }
+
+  /**
+   * Submit a `draft` (or resubmit a `rejected`) entry for approval, stamping
+   * the submitter. Approval itself is `TimeEntryApprovalService`'s job.
+   */
+  async submit(
+    entryRef: ServiceTimeEntry | string,
+    input: SubmitServiceTimeEntryInput = {},
+  ): Promise<ServiceTimeEntry> {
+    const entry = await this.getEntry(entryRef);
+    if (entry.status !== 'draft' && entry.status !== 'rejected') {
+      throw new Error(
+        `ServiceTimeEntry ${entry.id}: only 'draft' or 'rejected' entries can be submitted (status is '${entry.status}').`,
+      );
+    }
+    entry.status = 'submitted';
+    entry.submittedAt = new Date();
+    entry.submittedByProfileId = input.byProfileId ?? null;
+    await entry.save();
+    return entry;
+  }
+}
+
+export default ServiceTimeEntryService;

--- a/packages/support/src/services/service-time-entry-service.ts
+++ b/packages/support/src/services/service-time-entry-service.ts
@@ -173,6 +173,12 @@ export class ServiceTimeEntryService {
       supportCase = await this.caseService.getCase(input.caseId);
       if (input.tenantId === undefined) {
         tenantId = supportCase.tenantId;
+      } else if ((input.tenantId ?? null) !== supportCase.tenantId) {
+        // An explicit tenant must agree with the case — otherwise the entry
+        // would be a cross-tenant reference onto another tenant's case.
+        throw new Error(
+          `ServiceTimeEntry: tenantId '${input.tenantId}' does not match the case's tenant '${supportCase.tenantId}'.`,
+        );
       }
     }
 

--- a/packages/support/src/services/support-ai-workflow.test.ts
+++ b/packages/support/src/services/support-ai-workflow.test.ts
@@ -484,6 +484,14 @@ describe('SupportAiWorkflow', () => {
     );
     expect(draftAnswer?.getMetadata().draft).toBe(true);
 
+    // Undelivered drafts stamp nothing — the client never saw them (codex
+    // P1, PR #1943).
+    const draftedReloaded = await workflow.caseService.getCase(
+      drafted.id ?? '',
+    );
+    expect(draftedReloaded.acknowledgedAt).toBeNull();
+    expect(draftedReloaded.firstRespondedAt).toBeNull();
+
     await workflow.policies.create({
       name: 'send-email-replies',
       autoSendEmailReplies: true,
@@ -497,6 +505,59 @@ describe('SupportAiWorkflow', () => {
       (item) => item.sourceKey.startsWith('ai:answer:'),
     );
     expect(sentAnswer?.getMetadata().draft).toBe(false);
+  });
+
+  it('never auto-resolves from an unsent email draft', async () => {
+    const { workflow } = await createWorkflow({
+      classify: { severity: 'sev4', confidence: 0.95 },
+      answer: { confidence: 0.95, proposedResolution: true },
+    });
+    await workflow.policies.create({
+      name: 'resolve-but-draft',
+      autoResolve: true,
+      autoResolveMaxSeverity: 'sev3',
+      // autoSendEmailReplies stays false — the answer is only a draft.
+    });
+    const supportCase = await openCase(workflow, { channelKind: 'email' });
+    const runs = await workflow.processCase(supportCase.id ?? '');
+
+    const resolveRun = runs.find((run) => run.phase === 'resolve');
+    expect(resolveRun?.outcome).toBe('skipped');
+    const reloaded = await workflow.caseService.getCase(supportCase.id ?? '');
+    expect(reloaded.status).not.toBe('resolved');
+
+    // The same policy over a chat case resolves autonomously — the gate is
+    // specifically the undelivered draft.
+    const chatCase = await openCase(workflow, {
+      subject: 'chat twin',
+      channelKind: 'chat',
+    });
+    await workflow.processCase(chatCase.id ?? '');
+    const chatReloaded = await workflow.caseService.getCase(chatCase.id ?? '');
+    expect(chatReloaded.status).toBe('resolved');
+  });
+
+  it('counts low-confidence answers toward maxAutoAttempts', async () => {
+    const { workflow, answerCalls } = await createWorkflow({
+      answer: { confidence: 0.1 },
+    });
+    await workflow.policies.create({
+      name: 'one-shot-low',
+      maxAutoAttempts: 1,
+    });
+    const supportCase = await openCase(workflow);
+
+    const first = await workflow.processCase(supportCase.id ?? '');
+    expect(first.find((run) => run.phase === 'answer')?.outcome).toBe(
+      'handed_off',
+    );
+
+    // The boundary was consumed by the low-confidence attempt — a second
+    // pass must not spin another answer (codex P2, PR #1943).
+    const second = await workflow.processCase(supportCase.id ?? '');
+    const secondAnswer = second.find((run) => run.phase === 'answer');
+    expect(secondAnswer?.outcome).toBe('skipped');
+    expect(answerCalls).toHaveLength(1);
   });
 
   it('never overwrites human triage during classification', async () => {

--- a/packages/support/src/services/support-ai-workflow.test.ts
+++ b/packages/support/src/services/support-ai-workflow.test.ts
@@ -1,0 +1,544 @@
+/**
+ * SupportAiWorkflow tests (#1928): the Automated Support Response pass —
+ * auditable per-phase runs, conservative defaults, policy-gated autonomous
+ * resolution, and every Human Handoff trigger (low confidence, sensitivity,
+ * high severity, explicit client request, boundary failure, attempt caps)
+ * with the no-repeat guarantee. Only the AI boundary and the knowledge
+ * provider are mocked — they model the external AI calls.
+ */
+
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  type KnowledgeSnippet,
+  type SupportAiAnswerResult,
+  type SupportAiBoundary,
+  type SupportAiClassifyResult,
+  SupportAiWorkflow,
+  type SupportKnowledgeProvider,
+  severityRank,
+} from './support-ai-workflow.js';
+import type { OpenCaseInput } from './support-case-service.js';
+
+const MODEL_NAMES = [
+  'SupportCase',
+  'SupportInteraction',
+  'SupportCaseEvent',
+  'SupportWorkLink',
+  'SupportPlan',
+  'SupportPolicy',
+  'SupportAiRun',
+];
+
+interface BoundaryScript {
+  classify?: Partial<SupportAiClassifyResult>;
+  answer?: Partial<SupportAiAnswerResult>;
+  classifyError?: Error;
+  answerError?: Error;
+}
+
+const DEFAULT_REPLY = 'Clearing the CDN cache resolves the 500 errors.';
+
+function createBoundary(script: BoundaryScript = {}) {
+  const classifyCalls: Array<{
+    subject: string;
+    body: string;
+    severityKeys: string[];
+    sensitiveCategories: string[];
+  }> = [];
+  const answerCalls: Array<{
+    subject: string;
+    body: string;
+    knowledge: KnowledgeSnippet[];
+    caseSummary: string;
+  }> = [];
+  const boundary: SupportAiBoundary = {
+    classify(input) {
+      classifyCalls.push(input);
+      if (script.classifyError) {
+        return Promise.reject(script.classifyError);
+      }
+      return Promise.resolve({
+        severity: 'sev4',
+        category: 'question',
+        sensitive: false,
+        confidence: 0.9,
+        ...script.classify,
+      });
+    },
+    answer(input) {
+      answerCalls.push(input);
+      if (script.answerError) {
+        return Promise.reject(script.answerError);
+      }
+      return Promise.resolve({
+        reply: DEFAULT_REPLY,
+        confidence: 0.9,
+        proposedResolution: false,
+        ...script.answer,
+      });
+    },
+  };
+  return { boundary, classifyCalls, answerCalls };
+}
+
+describe('SupportAiWorkflow', () => {
+  let ctx: Awaited<ReturnType<typeof createIsolatedTestDbFromManifest>>;
+
+  beforeEach(async () => {
+    ctx = await createIsolatedTestDbFromManifest({
+      includeObjects: MODEL_NAMES,
+    });
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  async function createWorkflow(
+    script: BoundaryScript = {},
+    extras: { knowledge?: KnowledgeSnippet[] } = {},
+  ) {
+    const { boundary, classifyCalls, answerCalls } = createBoundary(script);
+    const knowledge: SupportKnowledgeProvider = {
+      retrieve: () => Promise.resolve(extras.knowledge ?? []),
+    };
+    const workflow = await SupportAiWorkflow.create({
+      db: ctx.db,
+      boundary,
+      knowledge,
+    });
+    return { workflow, classifyCalls, answerCalls };
+  }
+
+  function openCase(
+    workflow: SupportAiWorkflow,
+    overrides: Partial<OpenCaseInput> = {},
+  ) {
+    return workflow.caseService.openCase({
+      subject: 'Dashboard shows 500 errors',
+      description: 'Every page load returns a 500 since this morning.',
+      channelKind: 'chat',
+      clientProfileId: 'client-1',
+      ...overrides,
+    });
+  }
+
+  async function outboundFor(workflow: SupportAiWorkflow, caseId: string) {
+    const interactions =
+      await workflow.caseService.interactions.forCase(caseId);
+    return interactions.filter((item) => item.direction === 'outbound');
+  }
+
+  async function handoffPayloads(workflow: SupportAiWorkflow, caseId: string) {
+    const events = await workflow.caseService.events.forCase(caseId, {
+      eventType: 'handoff',
+    });
+    return events.map((event) => event.getPayload());
+  }
+
+  it('records an auditable Automated Support Response on intake', async () => {
+    const snippets: KnowledgeSnippet[] = [
+      {
+        kind: 'fact',
+        ref: 'fact-42',
+        label: 'CDN KB',
+        content: 'Clearing the CDN cache fixes stale 500s.',
+      },
+    ];
+    const { workflow, answerCalls } = await createWorkflow(
+      { classify: { severity: 'sev3', category: 'availability' } },
+      { knowledge: snippets },
+    );
+    const supportCase = await openCase(workflow);
+    const interaction = await workflow.caseService.recordInteraction(
+      supportCase,
+      {
+        direction: 'inbound',
+        channelKind: 'chat',
+        actorKind: 'client',
+        body: 'Every page load returns a 500 since this morning.',
+        sourceKey: 'chat:msg-1',
+      },
+    );
+
+    const runs = await workflow.processIntake({
+      outcome: 'created',
+      supportCase,
+      interaction,
+    });
+
+    expect(runs.map((run) => `${run.phase}:${run.outcome}`)).toEqual([
+      'acknowledge:completed',
+      'classify:completed',
+      'answer:completed',
+      'troubleshoot:skipped',
+      'resolve:skipped',
+    ]);
+
+    // The acknowledgement and the answer are real outbound interactions.
+    const outbound = await outboundFor(workflow, supportCase.id ?? '');
+    expect(outbound).toHaveLength(2);
+    const ack = outbound.find((item) => item.sourceKey.startsWith('ai:ack:'));
+    const answer = outbound.find((item) =>
+      item.sourceKey.startsWith('ai:answer:'),
+    );
+    expect(ack?.body).toContain(supportCase.caseNumber);
+    expect(ack?.actorKind).toBe('agent');
+    expect(answer?.body).toBe(DEFAULT_REPLY);
+    expect(answer?.actorKind).toBe('agent');
+
+    // Each run is auditable: correlation ids, confidence, knowledge refs.
+    const answerRun = runs[2];
+    expect(answerRun?.confidence).toBeCloseTo(0.9);
+    expect(answerRun?.getKnowledgeRefs()).toMatchObject([
+      { kind: 'fact', ref: 'fact-42' },
+    ]);
+    expect(answerRun?.responseInteractionId).toBe(answer?.id);
+    expect(runs.every((run) => (run.correlationId ?? '').length > 0)).toBe(
+      true,
+    );
+    expect(runs.every((run) => run.interactionId === interaction.id)).toBe(
+      true,
+    );
+    const classifyRun = runs[1];
+    expect(classifyRun?.getClassification()).toMatchObject({
+      severity: 'sev3',
+      category: 'availability',
+      sensitive: false,
+    });
+
+    // The boundary saw the retrieved knowledge and the case summary.
+    expect(answerCalls).toHaveLength(1);
+    expect(answerCalls[0]?.knowledge).toEqual(snippets);
+    expect(answerCalls[0]?.caseSummary).toContain(supportCase.caseNumber);
+
+    // The classification landed on the case; the ack stamped the clock.
+    const reloaded = await workflow.caseService.getCase(supportCase.id ?? '');
+    expect(reloaded.severity).toBe('sev3');
+    expect(reloaded.category).toBe('availability');
+    expect(reloaded.acknowledgedAt).toBeInstanceOf(Date);
+
+    // The case audit trail carries one ai_run event per phase.
+    const aiRunEvents = await workflow.caseService.events.forCase(
+      supportCase.id ?? '',
+      { eventType: 'ai_run' },
+    );
+    expect(aiRunEvents).toHaveLength(5);
+  });
+
+  it('keeps conservative defaults: no policy row never resolves a case', async () => {
+    // Even a would-be-resolving answer stays advisory without a policy row.
+    const { workflow } = await createWorkflow({
+      answer: { confidence: 0.99, proposedResolution: true },
+    });
+    const supportCase = await openCase(workflow);
+
+    const runs = await workflow.processCase(supportCase.id ?? '');
+
+    expect(runs.map((run) => `${run.phase}:${run.outcome}`)).toEqual([
+      'acknowledge:completed',
+      'classify:completed',
+      'answer:completed',
+      'troubleshoot:skipped',
+      'resolve:skipped',
+    ]);
+    const reloaded = await workflow.caseService.getCase(supportCase.id ?? '');
+    expect(reloaded.status).toBe('new');
+    expect(reloaded.resolvedAt).toBeNull();
+    expect(reloaded.resolutionKind).toBe('');
+  });
+
+  it('resolves autonomously when the policy allows it', async () => {
+    const { workflow } = await createWorkflow({
+      classify: { severity: 'sev4', confidence: 0.95 },
+      answer: { confidence: 0.95, proposedResolution: true },
+    });
+    await workflow.policies.create({
+      name: 'auto-resolve-low-risk',
+      autoResolve: true,
+      autoResolveMaxSeverity: 'sev3',
+      confidenceThreshold: 0.7,
+    });
+    const supportCase = await openCase(workflow);
+
+    const runs = await workflow.processCase(supportCase.id ?? '');
+
+    expect(runs[4]?.phase).toBe('resolve');
+    expect(runs[4]?.outcome).toBe('completed');
+    const reloaded = await workflow.caseService.getCase(supportCase.id ?? '');
+    expect(reloaded.status).toBe('resolved');
+    expect(reloaded.resolutionKind).toBe('automated');
+    expect(reloaded.resolutionSummary).toBe(DEFAULT_REPLY);
+  });
+
+  it('hands off low-confidence answers without posting them', async () => {
+    const { workflow } = await createWorkflow({
+      answer: { confidence: 0.3 },
+    });
+    const supportCase = await openCase(workflow);
+
+    const runs = await workflow.processCase(supportCase.id ?? '');
+
+    const answerRun = runs.find((run) => run.phase === 'answer');
+    expect(answerRun?.outcome).toBe('handed_off');
+    expect(answerRun?.confidence).toBeCloseTo(0.3);
+
+    // Only the acknowledgement went out — never the low-confidence reply.
+    const outbound = await outboundFor(workflow, supportCase.id ?? '');
+    expect(outbound).toHaveLength(1);
+    expect(outbound[0]?.sourceKey.startsWith('ai:ack:')).toBe(true);
+
+    // The handoff event carries the prior automated work (FR-28b).
+    const payloads = await handoffPayloads(workflow, supportCase.id ?? '');
+    const handoff = payloads.find(
+      (payload) => payload.trigger === 'low_confidence',
+    );
+    expect(handoff).toBeDefined();
+    const pkg = handoff?.contextPackage as {
+      aiRuns: Array<{ phase: string; outcome: string }>;
+    };
+    expect(
+      pkg.aiRuns.some(
+        (run) => run.phase === 'answer' && run.outcome === 'handed_off',
+      ),
+    ).toBe(true);
+    expect(pkg.aiRuns.some((run) => run.phase === 'classify')).toBe(true);
+  });
+
+  it('hands off sensitive classifications and never resolves them', async () => {
+    const { workflow, answerCalls } = await createWorkflow({
+      classify: {
+        severity: 'sev4',
+        category: 'billing-dispute',
+        sensitive: true,
+      },
+      answer: { confidence: 0.95, proposedResolution: true },
+    });
+    await workflow.policies.create({
+      name: 'permissive',
+      autoResolve: true,
+      autoResolveMaxSeverity: 'sev4',
+    });
+    const supportCase = await openCase(workflow);
+
+    const runs = await workflow.processCase(supportCase.id ?? '');
+
+    // Sensitivity stops autonomous answering — the boundary is never asked.
+    expect(answerCalls).toHaveLength(0);
+    expect(runs.find((run) => run.phase === 'answer')?.outcome).toBe(
+      'handed_off',
+    );
+    expect(runs.find((run) => run.phase === 'resolve')?.outcome).toBe(
+      'skipped',
+    );
+
+    const payloads = await handoffPayloads(workflow, supportCase.id ?? '');
+    expect(payloads.some((payload) => payload.trigger === 'sensitive')).toBe(
+      true,
+    );
+    const reloaded = await workflow.caseService.getCase(supportCase.id ?? '');
+    expect(reloaded.sensitive).toBe(true);
+    expect(reloaded.status).not.toBe('resolved');
+  });
+
+  it('routes a human on high severity while still answering (FR-28a)', async () => {
+    const { workflow } = await createWorkflow({
+      classify: { severity: 'sev1' },
+    });
+    const supportCase = await openCase(workflow);
+
+    const runs = await workflow.processCase(supportCase.id ?? '');
+
+    const payloads = await handoffPayloads(workflow, supportCase.id ?? '');
+    expect(
+      payloads.some(
+        (payload) =>
+          payload.trigger === 'high_severity' && payload.deduped !== true,
+      ),
+    ).toBe(true);
+
+    // The confident answer still went out in parallel.
+    expect(runs.find((run) => run.phase === 'answer')?.outcome).toBe(
+      'completed',
+    );
+    const outbound = await outboundFor(workflow, supportCase.id ?? '');
+    expect(
+      outbound.some((item) => item.sourceKey.startsWith('ai:answer:')),
+    ).toBe(true);
+
+    // Without a routing seam the case queues for a human.
+    const reloaded = await workflow.caseService.getCase(supportCase.id ?? '');
+    expect(reloaded.status).toBe('triaged');
+  });
+
+  it('honours an explicit human request exactly once across passes', async () => {
+    const { workflow, answerCalls } = await createWorkflow({
+      answer: { confidence: 0.95, proposedResolution: true },
+    });
+    await workflow.policies.create({
+      name: 'permissive',
+      autoResolve: true,
+      autoResolveMaxSeverity: 'sev4',
+    });
+    const supportCase = await openCase(workflow);
+    await workflow.caseService.requestHuman(supportCase, {
+      byProfileId: 'client-1',
+    });
+
+    const first = await workflow.processCase(supportCase.id ?? '');
+    expect(first.find((run) => run.phase === 'answer')?.outcome).toBe(
+      'handed_off',
+    );
+    expect(first.find((run) => run.phase === 'resolve')?.outcome).toBe(
+      'skipped',
+    );
+    expect(answerCalls).toHaveLength(0);
+
+    const second = await workflow.processCase(supportCase.id ?? '');
+    expect(second.find((run) => run.phase === 'answer')?.outcome).toBe(
+      'handed_off',
+    );
+
+    // The client_request handoff fired exactly once; the repeat deduped.
+    const payloads = (
+      await handoffPayloads(workflow, supportCase.id ?? '')
+    ).filter((payload) => payload.trigger === 'client_request');
+    expect(payloads.filter((payload) => payload.deduped !== true)).toHaveLength(
+      1,
+    );
+    expect(payloads.filter((payload) => payload.deduped === true)).toHaveLength(
+      1,
+    );
+
+    const reloaded = await workflow.caseService.getCase(supportCase.id ?? '');
+    expect(reloaded.status).not.toBe('resolved');
+  });
+
+  it('audits boundary failures and hands off failed automation', async () => {
+    const { workflow } = await createWorkflow({
+      classifyError: new Error('model exploded'),
+    });
+    const supportCase = await openCase(workflow);
+
+    const runs = await workflow.processCase(supportCase.id ?? '');
+
+    expect(runs.map((run) => `${run.phase}:${run.outcome}`)).toEqual([
+      'acknowledge:completed',
+      'classify:failed',
+    ]);
+    expect(runs[1]?.error).toContain('model exploded');
+    const payloads = await handoffPayloads(workflow, supportCase.id ?? '');
+    expect(
+      payloads.some((payload) => payload.trigger === 'failed_resolution'),
+    ).toBe(true);
+
+    // An answer-phase throw is audited the same way.
+    const { workflow: failing } = await createWorkflow({
+      answerError: new Error('answer melted'),
+    });
+    const other = await openCase(failing, { subject: 'Another outage' });
+    const otherRuns = await failing.processCase(other.id ?? '');
+    expect(otherRuns.map((run) => `${run.phase}:${run.outcome}`)).toEqual([
+      'acknowledge:completed',
+      'classify:completed',
+      'answer:failed',
+    ]);
+    expect(otherRuns[2]?.error).toContain('answer melted');
+    const otherPayloads = await handoffPayloads(failing, other.id ?? '');
+    expect(
+      otherPayloads.some((payload) => payload.trigger === 'failed_resolution'),
+    ).toBe(true);
+  });
+
+  it('stops answering once maxAutoAttempts is exhausted', async () => {
+    const { workflow, answerCalls } = await createWorkflow();
+    await workflow.policies.create({ name: 'one-shot', maxAutoAttempts: 1 });
+    const supportCase = await openCase(workflow);
+
+    await workflow.processCase(supportCase.id ?? '');
+    const second = await workflow.processCase(supportCase.id ?? '');
+
+    expect(second.map((run) => `${run.phase}:${run.outcome}`)).toEqual([
+      'acknowledge:skipped',
+      'classify:completed',
+      'answer:skipped',
+      'troubleshoot:skipped',
+      'resolve:skipped',
+    ]);
+    expect(answerCalls).toHaveLength(1);
+    const answers = (await outboundFor(workflow, supportCase.id ?? '')).filter(
+      (item) => item.sourceKey.startsWith('ai:answer:'),
+    );
+    expect(answers).toHaveLength(1);
+    const payloads = await handoffPayloads(workflow, supportCase.id ?? '');
+    expect(payloads.some((payload) => payload.trigger === 'policy')).toBe(true);
+  });
+
+  it('drafts email replies unless the policy allows sending', async () => {
+    const { workflow } = await createWorkflow();
+    const drafted = await openCase(workflow, { channelKind: 'email' });
+    await workflow.processCase(drafted.id ?? '');
+    const draftAnswer = (await outboundFor(workflow, drafted.id ?? '')).find(
+      (item) => item.sourceKey.startsWith('ai:answer:'),
+    );
+    expect(draftAnswer?.getMetadata().draft).toBe(true);
+
+    await workflow.policies.create({
+      name: 'send-email-replies',
+      autoSendEmailReplies: true,
+    });
+    const sent = await openCase(workflow, {
+      subject: 'Another email issue',
+      channelKind: 'email',
+    });
+    await workflow.processCase(sent.id ?? '');
+    const sentAnswer = (await outboundFor(workflow, sent.id ?? '')).find(
+      (item) => item.sourceKey.startsWith('ai:answer:'),
+    );
+    expect(sentAnswer?.getMetadata().draft).toBe(false);
+  });
+
+  it('never overwrites human triage during classification', async () => {
+    const { workflow } = await createWorkflow({
+      classify: { severity: 'sev4', category: 'billing' },
+    });
+    const supportCase = await openCase(workflow);
+    supportCase.severity = 'sev2'; // human triage before the AI pass
+    await supportCase.save();
+
+    await workflow.processCase(supportCase.id ?? '');
+
+    const reloaded = await workflow.caseService.getCase(supportCase.id ?? '');
+    expect(reloaded.severity).toBe('sev2');
+    // Empty fields are still filled in.
+    expect(reloaded.category).toBe('billing');
+  });
+
+  it('does nothing when the case opts out of AI or is no longer open', async () => {
+    const { workflow, classifyCalls } = await createWorkflow();
+
+    const optedOut = await openCase(workflow);
+    optedOut.aiEnabled = false;
+    await optedOut.save();
+    expect(await workflow.processCase(optedOut.id ?? '')).toEqual([]);
+
+    const resolved = await openCase(workflow, { subject: 'Already handled' });
+    await workflow.caseService.resolve(resolved, {
+      actorKind: 'specialist',
+      summary: 'done',
+    });
+    expect(await workflow.processCase(resolved.id ?? '')).toEqual([]);
+
+    expect(classifyCalls).toHaveLength(0);
+    expect(await workflow.aiRuns.forCase(optedOut.id ?? '')).toEqual([]);
+  });
+
+  it('ranks severity keys by numeric suffix and fails closed otherwise', () => {
+    expect(severityRank('sev1')).toBe(1);
+    expect(severityRank('sev4')).toBe(4);
+    expect(Number.isNaN(severityRank(''))).toBe(true);
+    expect(Number.isNaN(severityRank('critical'))).toBe(true);
+    expect(Number.isNaN(severityRank(null))).toBe(true);
+  });
+});

--- a/packages/support/src/services/support-ai-workflow.ts
+++ b/packages/support/src/services/support-ai-workflow.ts
@@ -470,7 +470,10 @@ export class SupportAiWorkflow {
               metadata: { attempt: attemptNumber, draft },
             }),
           );
-          answerPosted = true;
+          // A drafted email was never delivered to the client — it must not
+          // count as a posted answer, so autonomous resolution stays gated
+          // until the reply actually goes out (codex P1, PR #1943).
+          answerPosted = !draft;
         } else {
           runs.push(
             await this.writeRun(supportCase, {
@@ -568,12 +571,21 @@ export class SupportAiWorkflow {
       });
     }
     const caseId = this.caseIdOf(supportCase);
+    // Email receipts are drafts unless the policy sends automated mail — an
+    // undelivered receipt must not stamp `acknowledgedAt` or satisfy the
+    // acknowledgement Service Target.
+    const draft =
+      supportCase.channelKind === 'email' && !policy.autoSendEmailReplies;
     const interaction = await this.caseService.recordInteraction(supportCase, {
       direction: 'outbound',
       channelKind: (supportCase.channelKind || 'chat') as SupportChannelKind,
       actorKind: 'agent',
       body: `Thanks for reaching out — we've opened case ${supportCase.caseNumber} and are looking into it now.`,
       sourceKey: `ai:ack:${caseId}`,
+      // A templated receipt is an acknowledgement only — it must not satisfy
+      // response Service Targets or stamp `firstRespondedAt` (the substantive
+      // answer does that).
+      metadata: { acknowledgement: true, draft },
     });
     return this.writeRun(supportCase, {
       phase: 'acknowledge',
@@ -655,13 +667,15 @@ export class SupportAiWorkflow {
     };
   }
 
-  /** Prior boundary-consuming answer attempts (completed or failed). */
+  /**
+   * Prior boundary-consuming answer attempts. Low-confidence answers consume
+   * the boundary too (`handed_off`), so they count toward the attempt budget
+   * — only `skipped` runs (which never called the boundary) are free.
+   */
   private async countAnswerAttempts(caseId: string): Promise<number> {
     const runs = await this.aiRuns.forCase(caseId);
     return runs.filter(
-      (run) =>
-        run.phase === 'answer' &&
-        (run.outcome === 'completed' || run.outcome === 'failed'),
+      (run) => run.phase === 'answer' && run.outcome !== 'skipped',
     ).length;
   }
 

--- a/packages/support/src/services/support-ai-workflow.ts
+++ b/packages/support/src/services/support-ai-workflow.ts
@@ -1,0 +1,924 @@
+/**
+ * SupportAiWorkflow — the Automated Support Response pipeline (FR-28a, issue
+ * #1928): on intake a case is immediately acknowledged, classified, and
+ * answered from scoped knowledge; only when the resolved {@link SupportPolicy}
+ * explicitly allows it may the workflow resolve a low-risk case autonomously.
+ * Every phase — run or skipped — writes an append-only {@link SupportAiRun}
+ * audit row, and every risk signal (client request, low confidence,
+ * sensitivity, high severity, boundary failure, attempt cap) routes through
+ * {@link HumanHandoffService} so a Support Specialist takes over with the
+ * complete context (FR-28b).
+ *
+ * The AI call is an injected {@link SupportAiBoundary} and knowledge
+ * retrieval an injected {@link SupportKnowledgeProvider} (the `smrt-personas`
+ * `ReflectionRunner` injected-boundary idiom) — tests mock only these seams,
+ * and the package stays dependency-free: apps plug `smrt-facts` /
+ * `smrt-content`-backed providers.
+ */
+
+import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
+import {
+  type SupportAiRun,
+  SupportAiRunCollection,
+} from '../models/support-ai-run.js';
+import type { SupportCase } from '../models/support-case.js';
+import { SupportInteractionCollection } from '../models/support-interaction.js';
+import {
+  DEFAULT_SUPPORT_POLICY,
+  SupportPolicyCollection,
+} from '../models/support-policy.js';
+import {
+  DEFAULT_SEVERITY_DEFINITIONS,
+  type HumanHandoffTrigger,
+  type SupportAiRunOutcome,
+  type SupportAiRunPhase,
+  type SupportChannelKind,
+} from '../types.js';
+import { HumanHandoffService } from './human-handoff-service.js';
+import { SupportCaseService } from './support-case-service.js';
+import type { IntakeResult } from './support-intake-service.js';
+
+/** One knowledge source consulted while drafting an automated answer. */
+export interface KnowledgeSnippet {
+  /** Source kind, e.g. `fact`, `article`, `document`. */
+  kind: string;
+  /** Source reference (id, slug, or URL) for the audit trail. */
+  ref: string;
+  label?: string;
+  content: string;
+}
+
+/** Classification returned by {@link SupportAiBoundary.classify}. */
+export interface SupportAiClassifyResult {
+  /** One of the offered severity keys, or `''` when undetermined. */
+  severity: string;
+  /** Short free-vocabulary category, or `''` when undetermined. */
+  category: string;
+  /** Whether the matter is sensitive (always triggers a Human Handoff). */
+  sensitive: boolean;
+  /** Confidence in `[0, 1]`. */
+  confidence: number;
+  /** Model identifier, when the boundary knows it. */
+  model?: string;
+}
+
+/** Draft answer returned by {@link SupportAiBoundary.answer}. */
+export interface SupportAiAnswerResult {
+  reply: string;
+  /** Confidence in `[0, 1]`; below the policy threshold → Human Handoff. */
+  confidence: number;
+  /** Whether the reply would fully resolve the request (FR-28a). */
+  proposedResolution: boolean;
+  /** Model identifier, when the boundary knows it. */
+  model?: string;
+}
+
+/**
+ * THE AI seam: the only thing tests mock. The default implementation
+ * ({@link createDefaultAiBoundary}) delegates to the case's own `do()` AI
+ * operation from `smrt-core`.
+ */
+export interface SupportAiBoundary {
+  classify(input: {
+    subject: string;
+    body: string;
+    severityKeys: string[];
+    sensitiveCategories: string[];
+  }): Promise<SupportAiClassifyResult>;
+  answer(input: {
+    subject: string;
+    body: string;
+    knowledge: KnowledgeSnippet[];
+    caseSummary: string;
+  }): Promise<SupportAiAnswerResult>;
+}
+
+/**
+ * The knowledge seam: retrieve the snippets an automated answer may cite.
+ * The default provider returns nothing, keeping this package dependency-free
+ * — apps plug `smrt-facts` / `smrt-content`-backed providers.
+ */
+export interface SupportKnowledgeProvider {
+  retrieve(input: {
+    subject: string;
+    body: string;
+    projectId: string | null;
+    tenantId: string | null;
+  }): Promise<KnowledgeSnippet[]>;
+}
+
+/** Notification passed to `onHandoff` after each handoff attempt. */
+export interface SupportHandoffNotice {
+  supportCase: SupportCase;
+  trigger: HumanHandoffTrigger;
+  /** True when the no-repeat guarantee deduped this trigger. */
+  alreadyActive: boolean;
+}
+
+/** Options for {@link SupportAiWorkflow.create}. */
+export interface SupportAiWorkflowOptions extends SmrtObjectOptions {
+  /** The AI seam; omitted → {@link createDefaultAiBoundary} per case. */
+  boundary?: SupportAiBoundary;
+  /** The knowledge seam; omitted → a no-op provider. */
+  knowledge?: SupportKnowledgeProvider;
+  /** Handoff engine to share; omitted → one is created lazily. */
+  handoffService?: HumanHandoffService;
+  /** Called after every handoff attempt (app notification seam). */
+  onHandoff?: (notice: SupportHandoffNotice) => Promise<void>;
+}
+
+/** The resolved policy shape a pass runs under (row or built-in defaults). */
+interface EffectiveSupportPolicy {
+  policyId: string | null;
+  autoAcknowledge: boolean;
+  autoClassify: boolean;
+  autoAnswer: boolean;
+  autoTroubleshoot: boolean;
+  autoResolve: boolean;
+  autoResolveMaxSeverity: string;
+  confidenceThreshold: number;
+  maxAutoAttempts: number;
+  autoSendEmailReplies: boolean;
+  sensitiveCategories: string[];
+  allowedTools: string[];
+}
+
+/** Severity ranks at or below this are `high_severity` handoff triggers. */
+const HIGH_SEVERITY_MAX_RANK = 2;
+
+/**
+ * Numeric rank of a severity key by its numeric suffix (`sev1` → 1; lower is
+ * more severe). Returns `NaN` for keys without a numeric suffix, which makes
+ * every comparison false — auto-resolution fails closed and the
+ * high-severity trigger stays quiet for unknown vocabularies.
+ */
+export function severityRank(severityKey: string | null | undefined): number {
+  const match = /(\d+)\s*$/.exec((severityKey ?? '').trim());
+  return match ? Number.parseInt(match[1] ?? '', 10) : Number.NaN;
+}
+
+/**
+ * The Automated Support Response pipeline. Construct with
+ * {@link SupportAiWorkflow.create}; wire {@link processIntake} into
+ * `SupportIntakeService`'s `onCaseIntake` hook.
+ */
+export class SupportAiWorkflow {
+  readonly caseService: SupportCaseService;
+  readonly policies: SupportPolicyCollection;
+  readonly aiRuns: SupportAiRunCollection;
+  readonly interactions: SupportInteractionCollection;
+  readonly handoffs: HumanHandoffService;
+  private readonly boundary: SupportAiBoundary | null;
+  private readonly knowledge: SupportKnowledgeProvider;
+  private readonly onHandoff?: (notice: SupportHandoffNotice) => Promise<void>;
+
+  protected constructor(deps: {
+    caseService: SupportCaseService;
+    policies: SupportPolicyCollection;
+    aiRuns: SupportAiRunCollection;
+    interactions: SupportInteractionCollection;
+    handoffs: HumanHandoffService;
+    boundary: SupportAiBoundary | null;
+    knowledge: SupportKnowledgeProvider;
+    onHandoff?: (notice: SupportHandoffNotice) => Promise<void>;
+  }) {
+    this.caseService = deps.caseService;
+    this.policies = deps.policies;
+    this.aiRuns = deps.aiRuns;
+    this.interactions = deps.interactions;
+    this.handoffs = deps.handoffs;
+    this.boundary = deps.boundary;
+    this.knowledge = deps.knowledge;
+    this.onHandoff = deps.onHandoff;
+  }
+
+  static async create(
+    options: SupportAiWorkflowOptions,
+  ): Promise<SupportAiWorkflow> {
+    const [caseService, policies, aiRuns, interactions, handoffs] =
+      await Promise.all([
+        SupportCaseService.create(options),
+        SupportPolicyCollection.create(options),
+        SupportAiRunCollection.create(options),
+        SupportInteractionCollection.create(options),
+        options.handoffService
+          ? Promise.resolve(options.handoffService)
+          : HumanHandoffService.create(options),
+      ]);
+    return new SupportAiWorkflow({
+      caseService,
+      policies,
+      aiRuns,
+      interactions,
+      handoffs,
+      boundary: options.boundary ?? null,
+      knowledge: options.knowledge ?? createNoopKnowledgeProvider(),
+      onHandoff: options.onHandoff,
+    });
+  }
+
+  /**
+   * Entry point for `SupportIntakeService.onCaseIntake`: run one automated
+   * pass over the case an inbound interaction created or joined.
+   */
+  async processIntake(result: IntakeResult): Promise<SupportAiRun[]> {
+    const caseId = result.supportCase?.id;
+    if (!caseId || result.outcome === 'skipped') {
+      return [];
+    }
+    return this.processCase(caseId, {
+      interactionId: result.interaction?.id ?? null,
+    });
+  }
+
+  /**
+   * Run one Automated Support Response pass over a case: acknowledge →
+   * classify → answer → troubleshoot → resolve, each gated by the resolved
+   * policy and audited as a {@link SupportAiRun}. Cases with `aiEnabled`
+   * off, or no longer open, are left untouched.
+   */
+  async processCase(
+    caseId: string,
+    opts: { interactionId?: string | null } = {},
+  ): Promise<SupportAiRun[]> {
+    const supportCase = await this.caseService.getCase(caseId);
+    if (supportCase.aiEnabled === false || !supportCase.isOpen()) {
+      return [];
+    }
+
+    const policy = await this.resolveEffectivePolicy(supportCase);
+    const boundary =
+      this.boundary ?? createDefaultAiBoundary(() => supportCase);
+    const interactionId = opts.interactionId ?? null;
+    const body = await this.requestBodyOf(supportCase, interactionId);
+    const runs: SupportAiRun[] = [];
+
+    // Phase: acknowledge (FR-28a — the client hears back immediately).
+    runs.push(await this.runAcknowledge(supportCase, policy, interactionId));
+
+    // Phase: classify (severity / category / sensitivity triage).
+    if (!policy.autoClassify) {
+      runs.push(
+        await this.writeRun(supportCase, {
+          phase: 'classify',
+          outcome: 'skipped',
+          interactionId,
+          metadata: { reason: 'policy-disabled' },
+        }),
+      );
+    } else {
+      const startedAt = new Date();
+      let classification: SupportAiClassifyResult;
+      try {
+        classification = await boundary.classify({
+          subject: supportCase.subject,
+          body,
+          severityKeys: this.severityKeysOf(supportCase),
+          sensitiveCategories: policy.sensitiveCategories,
+        });
+      } catch (error) {
+        runs.push(
+          await this.writeRun(supportCase, {
+            phase: 'classify',
+            outcome: 'failed',
+            interactionId,
+            startedAt,
+            error: errorMessage(error),
+          }),
+        );
+        await this.triggerHandoff(
+          supportCase,
+          'failed_resolution',
+          `AI classification failed: ${errorMessage(error)}`,
+        );
+        return runs;
+      }
+      const classifiedSensitive =
+        classification.sensitive ||
+        (classification.category !== '' &&
+          policy.sensitiveCategories.includes(classification.category));
+      // Persist triage only into empty fields — a human's triage is never
+      // overwritten by the model.
+      let caseDirty = false;
+      if (!supportCase.severity && classification.severity) {
+        supportCase.severity = classification.severity;
+        caseDirty = true;
+      }
+      if (!supportCase.category && classification.category) {
+        supportCase.category = classification.category;
+        caseDirty = true;
+      }
+      if (!supportCase.sensitive && classifiedSensitive) {
+        supportCase.sensitive = true;
+        caseDirty = true;
+      }
+      if (caseDirty) {
+        await supportCase.save();
+      }
+      runs.push(
+        await this.writeRun(supportCase, {
+          phase: 'classify',
+          outcome: 'completed',
+          interactionId,
+          startedAt,
+          confidence: classification.confidence,
+          classification: {
+            severity: classification.severity,
+            category: classification.category,
+            sensitive: classifiedSensitive,
+            confidence: classification.confidence,
+          },
+          model: classification.model,
+        }),
+      );
+    }
+
+    // Always-on triggers (FR-28b): sensitivity stops autonomous answering;
+    // high severity routes a human while answering continues in parallel.
+    const sensitive = supportCase.sensitive;
+    if (sensitive) {
+      await this.triggerHandoff(
+        supportCase,
+        'sensitive',
+        'Case involves a sensitive matter',
+      );
+    }
+    const rank = severityRank(supportCase.severity);
+    if (Number.isFinite(rank) && rank <= HIGH_SEVERITY_MAX_RANK) {
+      await this.triggerHandoff(
+        supportCase,
+        'high_severity',
+        `Severity ${supportCase.severity} requires a Support Specialist`,
+      );
+    }
+
+    // Phase: answer (knowledge-grounded reply above the confidence floor).
+    let answer: SupportAiAnswerResult | null = null;
+    let answerPosted = false;
+    if (!policy.autoAnswer) {
+      runs.push(
+        await this.writeRun(supportCase, {
+          phase: 'answer',
+          outcome: 'skipped',
+          interactionId,
+          metadata: { reason: 'policy-disabled' },
+        }),
+      );
+    } else if (sensitive) {
+      runs.push(
+        await this.writeRun(supportCase, {
+          phase: 'answer',
+          outcome: 'handed_off',
+          interactionId,
+          metadata: { reason: 'sensitive' },
+        }),
+      );
+    } else if (supportCase.humanRequestedAt) {
+      runs.push(
+        await this.writeRun(supportCase, {
+          phase: 'answer',
+          outcome: 'handed_off',
+          interactionId,
+          metadata: { reason: 'human-requested' },
+        }),
+      );
+      await this.triggerHandoff(
+        supportCase,
+        'client_request',
+        'Client explicitly requested a human',
+      );
+    } else {
+      const priorAttempts = await this.countAnswerAttempts(caseId);
+      if (priorAttempts >= policy.maxAutoAttempts) {
+        runs.push(
+          await this.writeRun(supportCase, {
+            phase: 'answer',
+            outcome: 'skipped',
+            interactionId,
+            metadata: {
+              reason: 'max-attempts',
+              attempts: priorAttempts,
+              maxAutoAttempts: policy.maxAutoAttempts,
+            },
+          }),
+        );
+        await this.triggerHandoff(
+          supportCase,
+          'policy',
+          `Automated answer attempts exhausted (${priorAttempts}/${policy.maxAutoAttempts})`,
+        );
+      } else {
+        const startedAt = new Date();
+        let snippets: KnowledgeSnippet[] = [];
+        try {
+          snippets = await this.knowledge.retrieve({
+            subject: supportCase.subject,
+            body,
+            projectId: supportCase.projectId,
+            tenantId: supportCase.tenantId,
+          });
+          answer = await boundary.answer({
+            subject: supportCase.subject,
+            body,
+            knowledge: snippets,
+            caseSummary: this.caseSummaryOf(supportCase),
+          });
+        } catch (error) {
+          runs.push(
+            await this.writeRun(supportCase, {
+              phase: 'answer',
+              outcome: 'failed',
+              interactionId,
+              startedAt,
+              knowledgeRefs: snippets,
+              error: errorMessage(error),
+            }),
+          );
+          await this.triggerHandoff(
+            supportCase,
+            'failed_resolution',
+            `AI answer failed: ${errorMessage(error)}`,
+          );
+          return runs;
+        }
+        if (answer.confidence >= policy.confidenceThreshold) {
+          const attemptNumber = priorAttempts + 1;
+          const draft =
+            supportCase.channelKind === 'email' && !policy.autoSendEmailReplies;
+          const interaction = await this.caseService.recordInteraction(
+            supportCase,
+            {
+              direction: 'outbound',
+              channelKind: (supportCase.channelKind ||
+                'chat') as SupportChannelKind,
+              actorKind: 'agent',
+              body: answer.reply,
+              sourceKey: `ai:answer:${caseId}:${attemptNumber}`,
+              metadata: { draft },
+            },
+          );
+          runs.push(
+            await this.writeRun(supportCase, {
+              phase: 'answer',
+              outcome: 'completed',
+              interactionId,
+              startedAt,
+              confidence: answer.confidence,
+              knowledgeRefs: snippets,
+              responseInteractionId: interaction.id ?? null,
+              model: answer.model,
+              metadata: { attempt: attemptNumber, draft },
+            }),
+          );
+          answerPosted = true;
+        } else {
+          runs.push(
+            await this.writeRun(supportCase, {
+              phase: 'answer',
+              outcome: 'handed_off',
+              interactionId,
+              startedAt,
+              confidence: answer.confidence,
+              knowledgeRefs: snippets,
+              model: answer.model,
+              // The unsent draft travels in the audit metadata so the
+              // Specialist still sees the automated work (FR-28b).
+              metadata: { reason: 'low-confidence', unsentReply: answer.reply },
+            }),
+          );
+          await this.triggerHandoff(
+            supportCase,
+            'low_confidence',
+            `Answer confidence ${answer.confidence} below threshold ${policy.confidenceThreshold}`,
+          );
+        }
+      }
+    }
+
+    // Phase: troubleshoot — tool execution ships behind `allowedTools` in a
+    // later slice; #1928 always records the gate decision.
+    runs.push(
+      await this.writeRun(supportCase, {
+        phase: 'troubleshoot',
+        outcome: 'skipped',
+        interactionId,
+        metadata: {
+          reason: policy.autoTroubleshoot
+            ? 'not-implemented'
+            : 'policy-disabled',
+        },
+      }),
+    );
+
+    // Phase: resolve — autonomous only when the policy explicitly allows it
+    // and every risk gate passes.
+    const skipReason = this.resolveSkipReason(supportCase, policy, {
+      answer,
+      answerPosted,
+      sensitive,
+    });
+    if (skipReason !== null || !answer) {
+      runs.push(
+        await this.writeRun(supportCase, {
+          phase: 'resolve',
+          outcome: 'skipped',
+          interactionId,
+          metadata: { reason: skipReason ?? 'no-answer' },
+        }),
+      );
+    } else {
+      await this.caseService.resolve(supportCase, {
+        actorKind: 'agent',
+        summary: answer.reply,
+        resolutionKind: 'automated',
+      });
+      runs.push(
+        await this.writeRun(supportCase, {
+          phase: 'resolve',
+          outcome: 'completed',
+          interactionId,
+          confidence: answer.confidence,
+        }),
+      );
+    }
+
+    return runs;
+  }
+
+  /** Acknowledge phase: post the templated receipt once per case. */
+  private async runAcknowledge(
+    supportCase: SupportCase,
+    policy: EffectiveSupportPolicy,
+    interactionId: string | null,
+  ): Promise<SupportAiRun> {
+    if (!policy.autoAcknowledge) {
+      return this.writeRun(supportCase, {
+        phase: 'acknowledge',
+        outcome: 'skipped',
+        interactionId,
+        metadata: { reason: 'policy-disabled' },
+      });
+    }
+    if (supportCase.acknowledgedAt) {
+      return this.writeRun(supportCase, {
+        phase: 'acknowledge',
+        outcome: 'skipped',
+        interactionId,
+        metadata: { reason: 'already-acknowledged' },
+      });
+    }
+    const caseId = this.caseIdOf(supportCase);
+    const interaction = await this.caseService.recordInteraction(supportCase, {
+      direction: 'outbound',
+      channelKind: (supportCase.channelKind || 'chat') as SupportChannelKind,
+      actorKind: 'agent',
+      body: `Thanks for reaching out — we've opened case ${supportCase.caseNumber} and are looking into it now.`,
+      sourceKey: `ai:ack:${caseId}`,
+    });
+    return this.writeRun(supportCase, {
+      phase: 'acknowledge',
+      outcome: 'completed',
+      interactionId,
+      responseInteractionId: interaction.id ?? null,
+    });
+  }
+
+  /** Why autonomous resolution must not run, or `null` when it may. */
+  private resolveSkipReason(
+    supportCase: SupportCase,
+    policy: EffectiveSupportPolicy,
+    outcome: {
+      answer: SupportAiAnswerResult | null;
+      answerPosted: boolean;
+      sensitive: boolean;
+    },
+  ): string | null {
+    if (!policy.autoResolve) {
+      return 'policy-disabled';
+    }
+    const caseRank = severityRank(supportCase.severity);
+    const maxRank = severityRank(policy.autoResolveMaxSeverity);
+    if (
+      !Number.isFinite(caseRank) ||
+      !Number.isFinite(maxRank) ||
+      caseRank < maxRank
+    ) {
+      return 'severity-ineligible';
+    }
+    if (!outcome.answerPosted || !outcome.answer) {
+      return 'no-answer';
+    }
+    if (outcome.answer.confidence < policy.confidenceThreshold) {
+      return 'low-confidence';
+    }
+    if (!outcome.answer.proposedResolution) {
+      return 'no-proposed-resolution';
+    }
+    if (outcome.sensitive) {
+      return 'sensitive';
+    }
+    if (supportCase.humanRequestedAt) {
+      return 'human-requested';
+    }
+    return null;
+  }
+
+  /** Resolve the governing policy: matching row, else built-in defaults. */
+  private async resolveEffectivePolicy(
+    supportCase: SupportCase,
+  ): Promise<EffectiveSupportPolicy> {
+    const policy = await this.policies.resolveForScope({
+      planId: supportCase.planId,
+      projectId: supportCase.projectId,
+    });
+    if (!policy) {
+      return {
+        policyId: null,
+        ...DEFAULT_SUPPORT_POLICY,
+        sensitiveCategories: [...DEFAULT_SUPPORT_POLICY.sensitiveCategories],
+        allowedTools: [...DEFAULT_SUPPORT_POLICY.allowedTools],
+      };
+    }
+    return {
+      policyId: policy.id ?? null,
+      autoAcknowledge: policy.autoAcknowledge,
+      autoClassify: policy.autoClassify,
+      autoAnswer: policy.autoAnswer,
+      autoTroubleshoot: policy.autoTroubleshoot,
+      autoResolve: policy.autoResolve,
+      autoResolveMaxSeverity: policy.autoResolveMaxSeverity,
+      confidenceThreshold: policy.confidenceThreshold,
+      maxAutoAttempts: policy.maxAutoAttempts,
+      autoSendEmailReplies: policy.autoSendEmailReplies,
+      sensitiveCategories: policy.getSensitiveCategories(),
+      allowedTools: policy.getAllowedTools(),
+    };
+  }
+
+  /** Prior boundary-consuming answer attempts (completed or failed). */
+  private async countAnswerAttempts(caseId: string): Promise<number> {
+    const runs = await this.aiRuns.forCase(caseId);
+    return runs.filter(
+      (run) =>
+        run.phase === 'answer' &&
+        (run.outcome === 'completed' || run.outcome === 'failed'),
+    ).length;
+  }
+
+  /** The request text a pass reasons over: triggering interaction, else the
+   * case description. */
+  private async requestBodyOf(
+    supportCase: SupportCase,
+    interactionId: string | null,
+  ): Promise<string> {
+    if (interactionId) {
+      const interaction = await this.interactions.get({ id: interactionId });
+      if (interaction?.body) {
+        return interaction.body;
+      }
+    }
+    return supportCase.description;
+  }
+
+  /** Severity vocabulary: the case's plan snapshot, else the defaults. */
+  private severityKeysOf(supportCase: SupportCase): string[] {
+    const defs = supportCase.getPlanSnapshot().severityDefinitions;
+    if (defs && typeof defs === 'object' && !Array.isArray(defs)) {
+      const keys = Object.keys(defs as Record<string, unknown>);
+      if (keys.length > 0) {
+        return keys;
+      }
+    }
+    return Object.keys(DEFAULT_SEVERITY_DEFINITIONS);
+  }
+
+  /** One-line case summary handed to the answer boundary. */
+  private caseSummaryOf(supportCase: SupportCase): string {
+    const parts = [
+      `Case ${supportCase.caseNumber}`,
+      `status ${supportCase.status}`,
+    ];
+    if (supportCase.severity) {
+      parts.push(`severity ${supportCase.severity}`);
+    }
+    if (supportCase.category) {
+      parts.push(`category ${supportCase.category}`);
+    }
+    return `${parts.join(', ')} — ${supportCase.subject}`;
+  }
+
+  /** Route a trigger through the handoff engine and notify the app seam. */
+  private async triggerHandoff(
+    supportCase: SupportCase,
+    trigger: HumanHandoffTrigger,
+    note: string,
+  ): Promise<void> {
+    const { alreadyActive } = await this.handoffs.handoff(supportCase, {
+      trigger,
+      note,
+    });
+    if (this.onHandoff) {
+      await this.onHandoff({ supportCase, trigger, alreadyActive });
+    }
+  }
+
+  /** Append one audit run plus its `ai_run` case event. */
+  private async writeRun(
+    supportCase: SupportCase,
+    input: {
+      phase: SupportAiRunPhase;
+      outcome: SupportAiRunOutcome;
+      interactionId?: string | null;
+      confidence?: number | null;
+      classification?: Record<string, unknown>;
+      responseInteractionId?: string | null;
+      knowledgeRefs?: KnowledgeSnippet[];
+      error?: string;
+      model?: string;
+      startedAt?: Date;
+      metadata?: Record<string, unknown>;
+    },
+  ): Promise<SupportAiRun> {
+    const run = await this.aiRuns.create({
+      tenantId: supportCase.tenantId,
+      caseId: this.caseIdOf(supportCase),
+      interactionId: input.interactionId ?? null,
+      phase: input.phase,
+      outcome: input.outcome,
+      confidence: input.confidence ?? null,
+      classification: JSON.stringify(input.classification ?? {}),
+      responseInteractionId: input.responseInteractionId ?? null,
+      knowledgeRefs: JSON.stringify(input.knowledgeRefs ?? []),
+      error: input.error ?? '',
+      correlationId: crypto.randomUUID(),
+      model: input.model ?? '',
+      startedAt: input.startedAt ?? new Date(),
+      completedAt: new Date(),
+      metadata: JSON.stringify(input.metadata ?? {}),
+    });
+    await this.caseService.recordEvent(supportCase, 'ai_run', {
+      actorKind: 'agent',
+      summary: `AI ${input.phase} → ${input.outcome}`,
+      payload: {
+        runId: run.id,
+        phase: input.phase,
+        outcome: input.outcome,
+        confidence: input.confidence ?? null,
+      },
+    });
+    return run;
+  }
+
+  /** The persisted id of a saved case. */
+  private caseIdOf(supportCase: SupportCase): string {
+    if (!supportCase.id) {
+      throw new Error('SupportCase has no id — was it saved?');
+    }
+    return supportCase.id;
+  }
+}
+
+/**
+ * The default knowledge provider: retrieves nothing. Keeps the package
+ * dependency-free; apps supply providers backed by `smrt-facts`,
+ * `smrt-content`, or their own corpus.
+ */
+export function createNoopKnowledgeProvider(): SupportKnowledgeProvider {
+  return {
+    retrieve: () => Promise.resolve([]),
+  };
+}
+
+/**
+ * The default AI boundary: delegates to the case's own `do()` AI operation
+ * (smrt-core) asking for strict JSON, parsed defensively — a malformed
+ * classification comes back sensitive with zero confidence, failing toward
+ * the human.
+ */
+export function createDefaultAiBoundary(
+  getCase: () => SupportCase,
+): SupportAiBoundary {
+  return {
+    async classify(input) {
+      const raw = String(await getCase().do(buildClassifyInstructions(input)));
+      const parsed = extractJsonObject(raw);
+      if (!parsed) {
+        return { severity: '', category: '', sensitive: true, confidence: 0 };
+      }
+      return {
+        severity: typeof parsed.severity === 'string' ? parsed.severity : '',
+        category: typeof parsed.category === 'string' ? parsed.category : '',
+        sensitive: parsed.sensitive === true,
+        confidence: clampConfidence(parsed.confidence),
+      };
+    },
+    async answer(input) {
+      const raw = String(await getCase().do(buildAnswerInstructions(input)));
+      const parsed = extractJsonObject(raw);
+      if (!parsed || typeof parsed.reply !== 'string' || !parsed.reply.trim()) {
+        return { reply: '', confidence: 0, proposedResolution: false };
+      }
+      return {
+        reply: parsed.reply,
+        confidence: clampConfidence(parsed.confidence),
+        proposedResolution: parsed.proposedResolution === true,
+      };
+    },
+  };
+}
+
+/** Build the strict-JSON classification instructions for `do()`. */
+function buildClassifyInstructions(input: {
+  subject: string;
+  body: string;
+  severityKeys: string[];
+  sensitiveCategories: string[];
+}): string {
+  const sensitiveList =
+    input.sensitiveCategories.length > 0
+      ? input.sensitiveCategories.join(', ')
+      : '(none configured)';
+  return [
+    'You are triaging a client support request.',
+    `Severity keys, most severe first: ${input.severityKeys.join(', ')}.`,
+    `Sensitive categories: ${sensitiveList}.`,
+    `Subject: ${input.subject}`,
+    'Request:',
+    input.body,
+    '',
+    'Respond with ONLY a strict JSON object:',
+    '{"severity": "<one severity key>", "category": "<short-kebab-case>",',
+    '"sensitive": <true when the matter touches a sensitive category, legal',
+    'or security exposure, or personal data>, "confidence": <number 0..1>}',
+  ].join('\n');
+}
+
+/** Build the strict-JSON answer instructions for `do()`. */
+function buildAnswerInstructions(input: {
+  subject: string;
+  body: string;
+  knowledge: KnowledgeSnippet[];
+  caseSummary: string;
+}): string {
+  const knowledgeBlock =
+    input.knowledge.length > 0
+      ? input.knowledge
+          .map(
+            (snippet) =>
+              `- [${snippet.kind}:${snippet.ref}]${
+                snippet.label ? ` ${snippet.label}:` : ''
+              } ${snippet.content}`,
+          )
+          .join('\n')
+      : '(no knowledge available)';
+  return [
+    'You are drafting a support reply grounded ONLY in the knowledge below.',
+    `Context: ${input.caseSummary}`,
+    `Subject: ${input.subject}`,
+    'Request:',
+    input.body,
+    'Knowledge:',
+    knowledgeBlock,
+    '',
+    'Respond with ONLY a strict JSON object:',
+    '{"reply": "<the reply to send>", "confidence": <number 0..1>,',
+    '"proposedResolution": <true when the reply fully resolves the request>}',
+  ].join('\n');
+}
+
+/** Best-effort strict-JSON extraction from a raw model response. */
+function extractJsonObject(raw: string): Record<string, unknown> | null {
+  const text = raw.trim();
+  const candidates = [text];
+  const embedded = /\{[\s\S]*\}/.exec(text);
+  if (embedded && embedded[0] !== text) {
+    candidates.push(embedded[0]);
+  }
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return null;
+}
+
+/** Clamp a model-reported confidence into `[0, 1]` (non-numbers → 0). */
+function clampConfidence(value: unknown): number {
+  const num = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(num)) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, num));
+}
+
+/** Normalise an unknown thrown value into an audit-friendly message. */
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export default SupportAiWorkflow;

--- a/packages/support/src/services/support-case-service.test.ts
+++ b/packages/support/src/services/support-case-service.test.ts
@@ -64,6 +64,18 @@ describe('SupportCaseService', () => {
         planId: foreignPlan.id,
       }),
     ).rejects.toThrow(/cannot govern a case in tenant/);
+    // The rejected open never persisted a partial case.
+    expect(await service.cases.findQueue({})).toHaveLength(0);
+
+    // A dangling plan id is refused up front too — no case row with an
+    // unresolvable plan reference.
+    await expect(
+      service.openCase({
+        subject: 'dangling plan',
+        planId: 'no-such-plan',
+      }),
+    ).rejects.toThrow(/SupportPlan not found/);
+    expect(await service.cases.findQueue({})).toHaveLength(0);
 
     const supportCase = await service.openCase({
       subject: 'no plan yet',

--- a/packages/support/src/services/support-case-service.test.ts
+++ b/packages/support/src/services/support-case-service.test.ts
@@ -49,6 +49,55 @@ describe('SupportCaseService', () => {
     expect(events[0]?.eventType).toBe('created');
   });
 
+  it("refuses another tenant's plan on open and on apply", async () => {
+    const foreignPlan = await service.plans.create({
+      tenantId: 'tenant-b',
+      planKey: 'foreign',
+      name: 'Foreign',
+      overageHourlyRate: 500.0,
+    });
+
+    await expect(
+      service.openCase({
+        subject: 'wrong plan',
+        tenantId: 'tenant-a',
+        planId: foreignPlan.id,
+      }),
+    ).rejects.toThrow(/cannot govern a case in tenant/);
+
+    const supportCase = await service.openCase({
+      subject: 'no plan yet',
+      tenantId: 'tenant-a',
+    });
+    await expect(service.applyPlan(supportCase, foreignPlan)).rejects.toThrow(
+      /cannot govern a case in tenant/,
+    );
+
+    // Global NULL-tenant template plans apply anywhere.
+    const globalPlan = await service.plans.create({
+      planKey: 'global',
+      name: 'Global',
+    });
+    await service.applyPlan(supportCase, globalPlan);
+    expect(supportCase.planId).toBe(globalPlan.id);
+  });
+
+  it('refuses to reopen a case that is not terminal', async () => {
+    const supportCase = await service.openCase({ subject: 'still open' });
+    await expect(
+      service.reopen(supportCase, { actorKind: 'client' }),
+    ).rejects.toThrow(/only resolved or closed cases can be reopened/);
+    expect(supportCase.reopenCount).toBe(0);
+
+    await service.resolve(supportCase, {
+      actorKind: 'specialist',
+      summary: 'done',
+    });
+    await expect(
+      service.reopen(supportCase, { actorKind: 'client', to: 'closed' }),
+    ).rejects.toThrow(/must land in an active status/);
+  });
+
   it('captures the plan snapshot when opening under a plan', async () => {
     const plan = await service.plans.create({
       planKey: 'gold',

--- a/packages/support/src/services/support-case-service.test.ts
+++ b/packages/support/src/services/support-case-service.test.ts
@@ -1,0 +1,275 @@
+/**
+ * SupportCaseService tests (#1926): the closed write facade — case opening
+ * with plan snapshots, interaction recording (idempotent, response stamps,
+ * waiting-on-client unpark), guarded transitions with audit events,
+ * assignment, resolution, reopen history, work links, and the merged
+ * timeline.
+ */
+
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SupportCaseService } from './support-case-service.js';
+
+const MODEL_NAMES = [
+  'SupportCase',
+  'SupportInteraction',
+  'SupportCaseEvent',
+  'SupportWorkLink',
+  'SupportPlan',
+];
+
+describe('SupportCaseService', () => {
+  let ctx: Awaited<ReturnType<typeof createIsolatedTestDbFromManifest>>;
+  let service: SupportCaseService;
+
+  beforeEach(async () => {
+    ctx = await createIsolatedTestDbFromManifest({
+      includeObjects: MODEL_NAMES,
+    });
+    service = await SupportCaseService.create({ db: ctx.db });
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  it('opens a case with a created event and a case number', async () => {
+    const supportCase = await service.openCase({
+      subject: 'Cannot log in',
+      description: 'Password reset loops forever',
+      clientProfileId: 'profile-client-1',
+      channelKind: 'chat',
+    });
+
+    expect(supportCase.caseNumber).toMatch(/^SUP-/);
+    expect(supportCase.status).toBe('new');
+
+    const events = await service.events.forCase(supportCase.id ?? '');
+    expect(events).toHaveLength(1);
+    expect(events[0]?.eventType).toBe('created');
+  });
+
+  it('captures the plan snapshot when opening under a plan', async () => {
+    const plan = await service.plans.create({
+      planKey: 'gold',
+      name: 'Gold',
+      includedMinutes: 600,
+      overageHourlyRate: 150.0,
+    });
+    const supportCase = await service.openCase({
+      subject: 'Slow dashboard',
+      planId: plan.id,
+    });
+
+    expect(supportCase.planId).toBe(plan.id);
+    const snapshot = supportCase.getPlanSnapshot();
+    expect(snapshot.planKey).toBe('gold');
+    expect(snapshot.overageHourlyRate).toBe(150);
+
+    const events = await service.events.forCase(supportCase.id ?? '');
+    expect(events.map((event) => event.eventType)).toContain('plan_applied');
+  });
+
+  describe('recordInteraction', () => {
+    it('is idempotent on sourceKey', async () => {
+      const supportCase = await service.openCase({ subject: 'dup test' });
+      const first = await service.recordInteraction(supportCase, {
+        direction: 'inbound',
+        channelKind: 'chat',
+        actorKind: 'client',
+        body: 'hello',
+        sourceKey: 'chat:msg-1',
+      });
+      const second = await service.recordInteraction(supportCase, {
+        direction: 'inbound',
+        channelKind: 'chat',
+        actorKind: 'client',
+        body: 'hello again (same transport row)',
+        sourceKey: 'chat:msg-1',
+      });
+
+      expect(second.id).toBe(first.id);
+      const all = await service.interactions.forCase(supportCase.id ?? '');
+      expect(all).toHaveLength(1);
+    });
+
+    it('stamps acknowledgedAt and firstRespondedAt on the first outbound reply', async () => {
+      const supportCase = await service.openCase({ subject: 'stamps' });
+      expect(supportCase.acknowledgedAt).toBeNull();
+
+      await service.recordInteraction(supportCase, {
+        direction: 'outbound',
+        channelKind: 'chat',
+        actorKind: 'agent',
+        body: 'On it!',
+      });
+
+      expect(supportCase.acknowledgedAt).toBeInstanceOf(Date);
+      expect(supportCase.firstRespondedAt).toBeInstanceOf(Date);
+    });
+
+    it('moves a waiting_on_client case back to in_progress on inbound', async () => {
+      const supportCase = await service.openCase({ subject: 'unpark' });
+      await service.transition(supportCase, 'in_progress', {
+        actorKind: 'specialist',
+      });
+      await service.transition(supportCase, 'waiting_on_client', {
+        actorKind: 'specialist',
+      });
+
+      await service.recordInteraction(supportCase, {
+        direction: 'inbound',
+        channelKind: 'chat',
+        actorKind: 'client',
+        body: 'here is the info you asked for',
+      });
+
+      expect(supportCase.status).toBe('in_progress');
+    });
+  });
+
+  it('records transition audit events with from/to', async () => {
+    const supportCase = await service.openCase({ subject: 'audit' });
+    await service.transition(supportCase, 'triaged', {
+      actorKind: 'specialist',
+      actorProfileId: 'profile-spec-1',
+      reason: 'triage sweep',
+    });
+
+    const events = await service.events.forCase(supportCase.id ?? '', {
+      eventType: 'transition',
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]?.getPayload()).toMatchObject({
+      from: 'new',
+      to: 'triaged',
+      reason: 'triage sweep',
+    });
+  });
+
+  it('assigns and reassigns with rationale, flipping new/triaged to assigned', async () => {
+    const supportCase = await service.openCase({ subject: 'assign' });
+    await service.assign(supportCase, {
+      actorKind: 'system',
+      specialistId: 'spec-1',
+      rationale: { score: 0.9 },
+    });
+    expect(supportCase.status).toBe('assigned');
+    expect(supportCase.assignedSpecialistId).toBe('spec-1');
+
+    await service.assign(supportCase, {
+      actorKind: 'specialist',
+      actorProfileId: 'manager-1',
+      specialistId: 'spec-2',
+    });
+    expect(supportCase.assignedSpecialistId).toBe('spec-2');
+
+    const events = await service.events.forCase(supportCase.id ?? '', {
+      eventType: 'assignment',
+    });
+    expect(events).toHaveLength(2);
+    expect(events[1]?.getPayload()).toMatchObject({
+      specialistId: 'spec-2',
+      previousSpecialistId: 'spec-1',
+    });
+  });
+
+  it('resolves, closes, and reopens preserving the prior resolution in history', async () => {
+    const supportCase = await service.openCase({ subject: 'lifecycle' });
+    await service.resolve(supportCase, {
+      actorKind: 'specialist',
+      actorProfileId: 'spec-1',
+      summary: 'Cleared the cache',
+      resolutionKind: 'human',
+    });
+    expect(supportCase.status).toBe('resolved');
+    expect(supportCase.resolutionSummary).toBe('Cleared the cache');
+
+    await service.close(supportCase, { actorKind: 'system' });
+    expect(supportCase.status).toBe('closed');
+    expect(supportCase.closedAt).toBeInstanceOf(Date);
+
+    await service.reopen(supportCase, {
+      actorKind: 'client',
+      reason: 'It broke again',
+    });
+    expect(supportCase.status).toBe('triaged');
+    expect(supportCase.reopenCount).toBe(1);
+    expect(supportCase.resolvedAt).toBeNull();
+    expect(supportCase.resolutionSummary).toBe('');
+
+    const reopenEvents = await service.events.forCase(supportCase.id ?? '', {
+      eventType: 'reopened',
+    });
+    expect(reopenEvents).toHaveLength(1);
+    const payload = reopenEvents[0]?.getPayload() as {
+      priorResolution: { resolutionSummary: string };
+    };
+    expect(payload.priorResolution.resolutionSummary).toBe('Cleared the cache');
+  });
+
+  it('records a client human request once and audits every ask', async () => {
+    const supportCase = await service.openCase({ subject: 'human please' });
+    await service.requestHuman(supportCase, { byProfileId: 'client-1' });
+    const stamped = supportCase.humanRequestedAt;
+    expect(stamped).toBeInstanceOf(Date);
+
+    await service.requestHuman(supportCase, { byProfileId: 'client-1' });
+    expect(supportCase.humanRequestedAt).toEqual(stamped);
+
+    const events = await service.events.forCase(supportCase.id ?? '', {
+      eventType: 'human_requested',
+    });
+    expect(events).toHaveLength(2);
+  });
+
+  it('links delivery work and records status echoes without driving execution', async () => {
+    const supportCase = await service.openCase({ subject: 'bug fix needed' });
+    const link = await service.linkWork(supportCase, {
+      actorKind: 'specialist',
+      linkKind: 'development_work_item',
+      targetType: '@happyvertical/smrt-projects:Issue',
+      targetId: 'issue-42',
+      targetLabel: 'web#42: fix login',
+      externalUrl: 'https://github.com/acme/web/issues/42',
+    });
+    expect(link.linkKind).toBe('development_work_item');
+
+    await service.recordWorkStatus(link.id ?? '', {
+      status: 'done',
+      note: 'deployed in v1.2.3',
+    });
+    const reloaded = await service.workLinks.get({ id: link.id });
+    expect(reloaded?.status).toBe('done');
+    expect(reloaded?.lastStatusAt).toBeInstanceOf(Date);
+
+    const events = await service.events.forCase(supportCase.id ?? '', {
+      eventType: 'work_linked',
+    });
+    expect(events).toHaveLength(2);
+  });
+
+  it('merges interactions and events into one chronological timeline', async () => {
+    const supportCase = await service.openCase({ subject: 'timeline' });
+    await service.recordInteraction(supportCase, {
+      direction: 'inbound',
+      channelKind: 'chat',
+      actorKind: 'client',
+      body: 'first message',
+      occurredAt: new Date(Date.now() - 60_000),
+    });
+    await service.transition(supportCase, 'triaged', { actorKind: 'system' });
+
+    const timeline = await service.getTimeline(supportCase.id ?? '');
+    expect(timeline.length).toBeGreaterThanOrEqual(4);
+    for (let i = 1; i < timeline.length; i++) {
+      const current = timeline[i];
+      const previous = timeline[i - 1];
+      expect(current?.occurredAt.getTime()).toBeGreaterThanOrEqual(
+        previous?.occurredAt.getTime() ?? 0,
+      );
+    }
+    expect(timeline.some((item) => item.kind === 'interaction')).toBe(true);
+    expect(timeline.some((item) => item.kind === 'event')).toBe(true);
+  });
+});

--- a/packages/support/src/services/support-case-service.test.ts
+++ b/packages/support/src/services/support-case-service.test.ts
@@ -108,6 +108,28 @@ describe('SupportCaseService', () => {
       expect(supportCase.firstRespondedAt).toBeInstanceOf(Date);
     });
 
+    it('an acknowledgement-marked receipt stamps acknowledgedAt but not firstRespondedAt', async () => {
+      const supportCase = await service.openCase({ subject: 'ack only' });
+
+      await service.recordInteraction(supportCase, {
+        direction: 'outbound',
+        channelKind: 'chat',
+        actorKind: 'agent',
+        body: 'Thanks — case opened.',
+        metadata: { acknowledgement: true },
+      });
+      expect(supportCase.acknowledgedAt).toBeInstanceOf(Date);
+      expect(supportCase.firstRespondedAt).toBeNull();
+
+      await service.recordInteraction(supportCase, {
+        direction: 'outbound',
+        channelKind: 'chat',
+        actorKind: 'agent',
+        body: 'Here is the actual answer.',
+      });
+      expect(supportCase.firstRespondedAt).toBeInstanceOf(Date);
+    });
+
     it('moves a waiting_on_client case back to in_progress on inbound', async () => {
       const supportCase = await service.openCase({ subject: 'unpark' });
       await service.transition(supportCase, 'in_progress', {

--- a/packages/support/src/services/support-case-service.ts
+++ b/packages/support/src/services/support-case-service.ts
@@ -146,6 +146,22 @@ export class SupportCaseService {
    * and writes the `created` audit event.
    */
   async openCase(input: OpenCaseInput): Promise<SupportCase> {
+    // Resolve and validate the plan BEFORE the insert — a dangling id or a
+    // foreign tenant's plan must never persist onto a case, even partially.
+    let plan: SupportPlan | null = null;
+    if (input.planId) {
+      plan = await this.plans.get({ id: input.planId });
+      if (!plan) {
+        throw new Error(`SupportPlan not found: ${input.planId}`);
+      }
+      if (plan.tenantId && plan.tenantId !== (input.tenantId ?? null)) {
+        throw new Error(
+          `SupportPlan '${plan.planKey || plan.id}' belongs to tenant '${plan.tenantId}' ` +
+            `and cannot govern a case in tenant '${input.tenantId ?? null}'.`,
+        );
+      }
+    }
+
     const supportCase = await this.cases.create({
       tenantId: input.tenantId ?? null,
       caseNumber: generateCaseNumber(),
@@ -160,18 +176,13 @@ export class SupportCaseService {
       projectId: input.projectId ?? null,
       bindingId: input.bindingId ?? null,
       threadKey: input.threadKey ?? '',
-      planId: input.planId ?? null,
+      planId: null,
       preferredSpecialistId: input.preferredSpecialistId ?? null,
       metadata: JSON.stringify(input.metadata ?? {}),
     });
 
-    if (input.planId) {
-      const plan = await this.plans.get({ id: input.planId });
-      if (plan) {
-        // applyPlan validates the tenant boundary; a foreign plan aborts the
-        // open so no case persists with another tenant's terms.
-        await this.applyPlan(supportCase, plan);
-      }
+    if (plan) {
+      await this.applyPlan(supportCase, plan);
     }
 
     await this.recordEvent(supportCase, 'created', {

--- a/packages/support/src/services/support-case-service.ts
+++ b/packages/support/src/services/support-case-service.ts
@@ -1,0 +1,561 @@
+/**
+ * SupportCaseService — the closed write facade for Support Cases (the
+ * `smrt-chat` `ChatService` idiom): case creation, interaction recording,
+ * lifecycle transitions, assignment, resolution, reopening, human requests,
+ * and work links all flow through here so the audit trail
+ * ({@link SupportCaseEvent}) and the lifecycle guard stay coherent. The
+ * generated CRUD surface on the case-side models is read-only.
+ */
+
+import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
+import {
+  generateCaseNumber,
+  type SupportCase,
+  SupportCaseCollection,
+} from '../models/support-case.js';
+import {
+  type SupportCaseEvent,
+  SupportCaseEventCollection,
+} from '../models/support-case-event.js';
+import {
+  type SupportInteraction,
+  SupportInteractionCollection,
+} from '../models/support-interaction.js';
+import {
+  type SupportPlan,
+  SupportPlanCollection,
+} from '../models/support-plan.js';
+import {
+  type SupportWorkLink,
+  SupportWorkLinkCollection,
+} from '../models/support-work-link.js';
+import type {
+  SupportActorKind,
+  SupportCaseEventType,
+  SupportCaseStatus,
+  SupportChannelKind,
+  SupportInteractionDirection,
+  SupportWorkLinkKind,
+} from '../types.js';
+
+export interface OpenCaseInput {
+  tenantId?: string | null;
+  subject: string;
+  description?: string;
+  priority?: string;
+  severity?: string;
+  channelKind?: SupportChannelKind | '';
+  clientProfileId?: string | null;
+  openedByProfileId?: string | null;
+  projectId?: string | null;
+  bindingId?: string | null;
+  threadKey?: string;
+  planId?: string | null;
+  preferredSpecialistId?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RecordInteractionInput {
+  direction: SupportInteractionDirection;
+  channelKind: SupportChannelKind;
+  actorKind: SupportActorKind;
+  authorProfileId?: string | null;
+  body: string;
+  occurredAt?: Date;
+  sourceType?: string | null;
+  sourceId?: string | null;
+  /** Idempotency key; generated (`manual:<uuid>`) when omitted. */
+  sourceKey?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CaseActor {
+  actorKind: SupportActorKind;
+  actorProfileId?: string | null;
+}
+
+export interface CaseTimelineItem {
+  kind: 'interaction' | 'event';
+  occurredAt: Date;
+  interaction?: SupportInteraction;
+  event?: SupportCaseEvent;
+}
+
+/**
+ * The write facade. Construct with {@link SupportCaseService.create}.
+ */
+export class SupportCaseService {
+  readonly cases: SupportCaseCollection;
+  readonly interactions: SupportInteractionCollection;
+  readonly events: SupportCaseEventCollection;
+  readonly workLinks: SupportWorkLinkCollection;
+  readonly plans: SupportPlanCollection;
+
+  protected constructor(collections: {
+    cases: SupportCaseCollection;
+    interactions: SupportInteractionCollection;
+    events: SupportCaseEventCollection;
+    workLinks: SupportWorkLinkCollection;
+    plans: SupportPlanCollection;
+  }) {
+    this.cases = collections.cases;
+    this.interactions = collections.interactions;
+    this.events = collections.events;
+    this.workLinks = collections.workLinks;
+    this.plans = collections.plans;
+  }
+
+  static async create(options: SmrtObjectOptions): Promise<SupportCaseService> {
+    const [cases, interactions, events, workLinks, plans] = await Promise.all([
+      SupportCaseCollection.create(options),
+      SupportInteractionCollection.create(options),
+      SupportCaseEventCollection.create(options),
+      SupportWorkLinkCollection.create(options),
+      SupportPlanCollection.create(options),
+    ]);
+    return new SupportCaseService({
+      cases,
+      interactions,
+      events,
+      workLinks,
+      plans,
+    });
+  }
+
+  /** Load a case or throw a descriptive error. */
+  async getCase(caseId: string): Promise<SupportCase> {
+    const found = await this.cases.get({ id: caseId });
+    if (!found) {
+      throw new Error(`SupportCase not found: ${caseId}`);
+    }
+    return found;
+  }
+
+  /** The persisted id of a saved case (all facade entry points save first). */
+  private caseIdOf(supportCase: SupportCase): string {
+    if (!supportCase.id) {
+      throw new Error('SupportCase has no id — was it saved?');
+    }
+    return supportCase.id;
+  }
+
+  /**
+   * Open a new Support Case. Applies the plan snapshot when a plan is given
+   * and writes the `created` audit event.
+   */
+  async openCase(input: OpenCaseInput): Promise<SupportCase> {
+    const supportCase = await this.cases.create({
+      tenantId: input.tenantId ?? null,
+      caseNumber: generateCaseNumber(),
+      subject: input.subject,
+      description: input.description ?? '',
+      status: 'new' as SupportCaseStatus,
+      priority: input.priority ?? 'normal',
+      severity: input.severity ?? '',
+      channelKind: input.channelKind ?? '',
+      clientProfileId: input.clientProfileId ?? null,
+      openedByProfileId: input.openedByProfileId ?? null,
+      projectId: input.projectId ?? null,
+      bindingId: input.bindingId ?? null,
+      threadKey: input.threadKey ?? '',
+      planId: input.planId ?? null,
+      preferredSpecialistId: input.preferredSpecialistId ?? null,
+      metadata: JSON.stringify(input.metadata ?? {}),
+    });
+
+    if (input.planId) {
+      const plan = await this.plans.get({ id: input.planId });
+      if (plan) {
+        await this.applyPlan(supportCase, plan);
+      }
+    }
+
+    await this.recordEvent(supportCase, 'created', {
+      actorKind: 'system',
+      summary: `Case ${supportCase.caseNumber} opened`,
+      payload: {
+        channelKind: supportCase.channelKind,
+        clientProfileId: supportCase.clientProfileId,
+        projectId: supportCase.projectId,
+      },
+    });
+
+    return supportCase;
+  }
+
+  /**
+   * Capture the plan terms onto the case (`planSnapshot`) so later plan edits
+   * never rewrite what this case was handled under.
+   */
+  async applyPlan(supportCase: SupportCase, plan: SupportPlan): Promise<void> {
+    supportCase.planId = plan.id ?? null;
+    supportCase.setPlanSnapshot(plan.snapshotTerms());
+    await supportCase.save();
+    await this.recordEvent(supportCase, 'plan_applied', {
+      actorKind: 'system',
+      summary: `Plan '${plan.name || plan.planKey}' applied`,
+      payload: { planId: plan.id, planKey: plan.planKey },
+    });
+  }
+
+  /**
+   * Record a channel interaction on a case (idempotent on `sourceKey`).
+   * Inbound client activity un-parks `waiting_on_client` cases; the first
+   * outbound reply stamps `acknowledgedAt`/`firstRespondedAt`.
+   */
+  async recordInteraction(
+    caseRef: SupportCase | string,
+    input: RecordInteractionInput,
+  ): Promise<SupportInteraction> {
+    const supportCase =
+      typeof caseRef === 'string' ? await this.getCase(caseRef) : caseRef;
+
+    const sourceKey = input.sourceKey ?? `manual:${crypto.randomUUID()}`;
+    const existing = await this.interactions.bySourceKey(sourceKey);
+    if (existing) {
+      return existing;
+    }
+
+    const interaction = await this.interactions.create({
+      tenantId: supportCase.tenantId,
+      caseId: this.caseIdOf(supportCase),
+      direction: input.direction,
+      channelKind: input.channelKind,
+      actorKind: input.actorKind,
+      authorProfileId: input.authorProfileId ?? null,
+      occurredAt: input.occurredAt ?? new Date(),
+      body: input.body,
+      sourceType: input.sourceType ?? null,
+      sourceId: input.sourceId ?? null,
+      sourceKey,
+      metadata: JSON.stringify(input.metadata ?? {}),
+    });
+
+    let caseDirty = false;
+    if (input.direction === 'outbound') {
+      if (!supportCase.acknowledgedAt) {
+        supportCase.acknowledgedAt = interaction.occurredAt;
+        caseDirty = true;
+      }
+      if (
+        !supportCase.firstRespondedAt &&
+        (input.actorKind === 'specialist' || input.actorKind === 'agent')
+      ) {
+        supportCase.firstRespondedAt = interaction.occurredAt;
+        caseDirty = true;
+      }
+    }
+    if (
+      input.direction === 'inbound' &&
+      supportCase.status === 'waiting_on_client'
+    ) {
+      supportCase.status = 'in_progress';
+      caseDirty = true;
+    }
+    if (caseDirty) {
+      await supportCase.save();
+    }
+
+    await this.recordEvent(supportCase, 'interaction', {
+      actorKind: input.actorKind,
+      actorProfileId: input.authorProfileId ?? null,
+      summary:
+        input.direction === 'inbound'
+          ? `Inbound ${input.channelKind} interaction`
+          : `${input.direction} ${input.channelKind} interaction`,
+      payload: { interactionId: interaction.id, direction: input.direction },
+    });
+
+    return interaction;
+  }
+
+  /** Transition a case's lifecycle status (guarded by the model). */
+  async transition(
+    caseRef: SupportCase | string,
+    to: SupportCaseStatus,
+    actor: CaseActor & { reason?: string },
+  ): Promise<SupportCase> {
+    const supportCase =
+      typeof caseRef === 'string' ? await this.getCase(caseRef) : caseRef;
+    const from = supportCase.status;
+    if (from === to) {
+      return supportCase;
+    }
+    supportCase.status = to;
+    await supportCase.save();
+    await this.recordEvent(supportCase, 'transition', {
+      actorKind: actor.actorKind,
+      actorProfileId: actor.actorProfileId ?? null,
+      summary: `Status ${from} → ${to}`,
+      payload: { from, to, reason: actor.reason ?? null },
+    });
+    return supportCase;
+  }
+
+  /** Assign (or reassign) a case to a specialist. */
+  async assign(
+    caseRef: SupportCase | string,
+    input: CaseActor & {
+      specialistId: string;
+      rationale?: Record<string, unknown>;
+    },
+  ): Promise<SupportCase> {
+    const supportCase =
+      typeof caseRef === 'string' ? await this.getCase(caseRef) : caseRef;
+    const previousSpecialistId = supportCase.assignedSpecialistId;
+    supportCase.assignedSpecialistId = input.specialistId;
+    supportCase.assignedAt = new Date();
+    if (supportCase.status === 'new' || supportCase.status === 'triaged') {
+      supportCase.status = 'assigned';
+    }
+    await supportCase.save();
+    await this.recordEvent(supportCase, 'assignment', {
+      actorKind: input.actorKind,
+      actorProfileId: input.actorProfileId ?? null,
+      summary: previousSpecialistId ? 'Case reassigned' : 'Case assigned',
+      payload: {
+        specialistId: input.specialistId,
+        previousSpecialistId,
+        rationale: input.rationale ?? null,
+      },
+    });
+    return supportCase;
+  }
+
+  /** Resolve a case with a resolution summary. */
+  async resolve(
+    caseRef: SupportCase | string,
+    input: CaseActor & {
+      summary: string;
+      resolutionKind?: 'automated' | 'human' | 'delivery';
+    },
+  ): Promise<SupportCase> {
+    const supportCase =
+      typeof caseRef === 'string' ? await this.getCase(caseRef) : caseRef;
+    const from = supportCase.status;
+    supportCase.status = 'resolved';
+    supportCase.resolvedAt = new Date();
+    supportCase.resolvedByProfileId = input.actorProfileId ?? null;
+    supportCase.resolutionKind = input.resolutionKind ?? 'human';
+    supportCase.resolutionSummary = input.summary;
+    await supportCase.save();
+    await this.recordEvent(supportCase, 'transition', {
+      actorKind: input.actorKind,
+      actorProfileId: input.actorProfileId ?? null,
+      summary: `Status ${from} → resolved`,
+      payload: {
+        from,
+        to: 'resolved',
+        resolutionKind: supportCase.resolutionKind,
+        resolutionSummary: input.summary,
+      },
+    });
+    return supportCase;
+  }
+
+  /** Close a resolved case. */
+  async close(
+    caseRef: SupportCase | string,
+    actor: CaseActor & { reason?: string },
+  ): Promise<SupportCase> {
+    const supportCase =
+      typeof caseRef === 'string' ? await this.getCase(caseRef) : caseRef;
+    supportCase.closedAt = new Date();
+    return this.transition(supportCase, 'closed', actor);
+  }
+
+  /**
+   * Reopen a resolved/closed case, preserving the prior resolution in the
+   * reopen event (FR-29b) and bumping `reopenCount`.
+   */
+  async reopen(
+    caseRef: SupportCase | string,
+    actor: CaseActor & { reason?: string; to?: SupportCaseStatus },
+  ): Promise<SupportCase> {
+    const supportCase =
+      typeof caseRef === 'string' ? await this.getCase(caseRef) : caseRef;
+    const priorResolution = {
+      resolvedAt: supportCase.resolvedAt?.toISOString() ?? null,
+      resolvedByProfileId: supportCase.resolvedByProfileId,
+      resolutionKind: supportCase.resolutionKind,
+      resolutionSummary: supportCase.resolutionSummary,
+      closedAt: supportCase.closedAt?.toISOString() ?? null,
+      reopenIndex: supportCase.reopenCount + 1,
+    };
+    const from = supportCase.status;
+    supportCase.status = actor.to ?? 'triaged';
+    supportCase.reopenCount += 1;
+    supportCase.lastReopenedAt = new Date();
+    supportCase.resolvedAt = null;
+    supportCase.resolvedByProfileId = null;
+    supportCase.resolutionKind = '';
+    supportCase.resolutionSummary = '';
+    supportCase.closedAt = null;
+    await supportCase.save();
+    await this.recordEvent(supportCase, 'reopened', {
+      actorKind: actor.actorKind,
+      actorProfileId: actor.actorProfileId ?? null,
+      summary: `Case reopened (from ${from})`,
+      payload: {
+        from,
+        to: supportCase.status,
+        reason: actor.reason ?? null,
+        priorResolution,
+      },
+    });
+    return supportCase;
+  }
+
+  /**
+   * Record that the Client explicitly requested a human (FR-28b). The actual
+   * handoff (routing + context transfer) is performed by the handoff service;
+   * this stamps the request and its audit event.
+   */
+  async requestHuman(
+    caseRef: SupportCase | string,
+    input: { byProfileId?: string | null; note?: string },
+  ): Promise<SupportCase> {
+    const supportCase =
+      typeof caseRef === 'string' ? await this.getCase(caseRef) : caseRef;
+    if (!supportCase.humanRequestedAt) {
+      supportCase.humanRequestedAt = new Date();
+      await supportCase.save();
+    }
+    await this.recordEvent(supportCase, 'human_requested', {
+      actorKind: 'client',
+      actorProfileId: input.byProfileId ?? null,
+      summary: 'Client requested a human',
+      payload: { note: input.note ?? null },
+    });
+    return supportCase;
+  }
+
+  /**
+   * Link separately tracked work to the case (Support Work Item or a
+   * Delivery Handoff's Development Work Item). Support keeps the Case as the
+   * canonical client record; the linked item's execution belongs to its
+   * owning domain (FR-29a).
+   */
+  async linkWork(
+    caseRef: SupportCase | string,
+    input: CaseActor & {
+      linkKind: SupportWorkLinkKind;
+      targetType: string;
+      targetId: string;
+      targetLabel?: string;
+      externalUrl?: string;
+      metadata?: Record<string, unknown>;
+    },
+  ): Promise<SupportWorkLink> {
+    const supportCase =
+      typeof caseRef === 'string' ? await this.getCase(caseRef) : caseRef;
+    const link = await this.workLinks.create({
+      tenantId: supportCase.tenantId,
+      caseId: this.caseIdOf(supportCase),
+      linkKind: input.linkKind,
+      targetType: input.targetType,
+      targetId: input.targetId,
+      targetLabel: input.targetLabel ?? '',
+      externalUrl: input.externalUrl ?? '',
+      metadata: JSON.stringify(input.metadata ?? {}),
+    });
+    await this.recordEvent(supportCase, 'work_linked', {
+      actorKind: input.actorKind,
+      actorProfileId: input.actorProfileId ?? null,
+      summary:
+        input.linkKind === 'development_work_item'
+          ? `Delivery Handoff → ${input.targetLabel || input.targetId}`
+          : `Support work item linked: ${input.targetLabel || input.targetId}`,
+      payload: {
+        linkId: link.id,
+        linkKind: input.linkKind,
+        targetType: input.targetType,
+        targetId: input.targetId,
+      },
+    });
+    return link;
+  }
+
+  /**
+   * Record a status echo reported back from the domain owning a linked work
+   * item (Delivery Operations reports progress; Support never drives it).
+   */
+  async recordWorkStatus(
+    linkId: string,
+    input: { status: string; note?: string },
+  ): Promise<SupportWorkLink> {
+    const link = await this.workLinks.get({ id: linkId });
+    if (!link) {
+      throw new Error(`SupportWorkLink not found: ${linkId}`);
+    }
+    link.status = input.status;
+    link.lastStatusAt = new Date();
+    await link.save();
+    const supportCase = await this.getCase(link.caseId);
+    await this.recordEvent(supportCase, 'work_linked', {
+      actorKind: 'system',
+      summary: `Linked work '${link.targetLabel || link.targetId}' → ${input.status}`,
+      payload: {
+        linkId: link.id,
+        status: input.status,
+        note: input.note ?? null,
+      },
+    });
+    return link;
+  }
+
+  /** Append an audit event to a case. */
+  async recordEvent(
+    caseRef: SupportCase | string,
+    eventType: SupportCaseEventType,
+    input: {
+      actorKind: SupportActorKind;
+      actorProfileId?: string | null;
+      summary: string;
+      payload?: Record<string, unknown>;
+      occurredAt?: Date;
+    },
+  ): Promise<SupportCaseEvent> {
+    const supportCase =
+      typeof caseRef === 'string' ? await this.getCase(caseRef) : caseRef;
+    return this.events.create({
+      tenantId: supportCase.tenantId,
+      caseId: this.caseIdOf(supportCase),
+      eventType,
+      actorKind: input.actorKind,
+      actorProfileId: input.actorProfileId ?? null,
+      occurredAt: input.occurredAt ?? new Date(),
+      summary: input.summary,
+      payload: JSON.stringify(input.payload ?? {}),
+    });
+  }
+
+  /**
+   * The merged case timeline: interactions and audit events in one
+   * chronological stream (the queue/detail UI's data shape, and the context
+   * package a Human Handoff transfers).
+   */
+  async getTimeline(caseId: string): Promise<CaseTimelineItem[]> {
+    const [interactions, events] = await Promise.all([
+      this.interactions.forCase(caseId),
+      this.events.forCase(caseId),
+    ]);
+    const items: CaseTimelineItem[] = [
+      ...interactions.map((interaction) => ({
+        kind: 'interaction' as const,
+        occurredAt: interaction.occurredAt,
+        interaction,
+      })),
+      ...events.map((event) => ({
+        kind: 'event' as const,
+        occurredAt: event.occurredAt,
+        event,
+      })),
+    ];
+    return items.sort(
+      (a, b) => a.occurredAt.getTime() - b.occurredAt.getTime(),
+    );
+  }
+}
+
+export default SupportCaseService;

--- a/packages/support/src/services/support-case-service.ts
+++ b/packages/support/src/services/support-case-service.ts
@@ -168,6 +168,8 @@ export class SupportCaseService {
     if (input.planId) {
       const plan = await this.plans.get({ id: input.planId });
       if (plan) {
+        // applyPlan validates the tenant boundary; a foreign plan aborts the
+        // open so no case persists with another tenant's terms.
         await this.applyPlan(supportCase, plan);
       }
     }
@@ -187,9 +189,18 @@ export class SupportCaseService {
 
   /**
    * Capture the plan terms onto the case (`planSnapshot`) so later plan edits
-   * never rewrite what this case was handled under.
+   * never rewrite what this case was handled under. A tenant-owned plan only
+   * applies to that tenant's cases (global NULL-tenant template plans apply
+   * anywhere) — a foreign plan would snapshot another tenant's pricing,
+   * approval, and escalation terms.
    */
   async applyPlan(supportCase: SupportCase, plan: SupportPlan): Promise<void> {
+    if (plan.tenantId && plan.tenantId !== supportCase.tenantId) {
+      throw new Error(
+        `SupportPlan '${plan.planKey || plan.id}' belongs to tenant '${plan.tenantId}' ` +
+          `and cannot govern a case in tenant '${supportCase.tenantId}'.`,
+      );
+    }
     supportCase.planId = plan.id ?? null;
     supportCase.setPlanSnapshot(plan.snapshotTerms());
     await supportCase.save();
@@ -382,6 +393,20 @@ export class SupportCaseService {
   ): Promise<SupportCase> {
     const supportCase =
       typeof caseRef === 'string' ? await this.getCase(caseRef) : caseRef;
+    // Only terminal cases reopen, and only into an active state — anything
+    // else would corrupt the reopen history for a case that never closed.
+    if (supportCase.status !== 'resolved' && supportCase.status !== 'closed') {
+      throw new Error(
+        `SupportCase ${supportCase.caseNumber || supportCase.id}: only ` +
+          `resolved or closed cases can be reopened (status is '${supportCase.status}').`,
+      );
+    }
+    const to = actor.to ?? 'triaged';
+    if (to === 'resolved' || to === 'closed') {
+      throw new Error(
+        `SupportCase: a reopen must land in an active status (got '${to}').`,
+      );
+    }
     const priorResolution = {
       resolvedAt: supportCase.resolvedAt?.toISOString() ?? null,
       resolvedByProfileId: supportCase.resolvedByProfileId,
@@ -391,7 +416,7 @@ export class SupportCaseService {
       reopenIndex: supportCase.reopenCount + 1,
     };
     const from = supportCase.status;
-    supportCase.status = actor.to ?? 'triaged';
+    supportCase.status = to;
     supportCase.reopenCount += 1;
     supportCase.lastReopenedAt = new Date();
     supportCase.resolvedAt = null;

--- a/packages/support/src/services/support-case-service.ts
+++ b/packages/support/src/services/support-case-service.ts
@@ -66,6 +66,8 @@ export interface RecordInteractionInput {
   sourceId?: string | null;
   /** Idempotency key; generated (`manual:<uuid>`) when omitted. */
   sourceKey?: string;
+  /** RFC 822 Message-ID for email interactions (keyed reply threading). */
+  rfcMessageId?: string;
   metadata?: Record<string, unknown>;
 }
 
@@ -228,18 +230,24 @@ export class SupportCaseService {
       sourceType: input.sourceType ?? null,
       sourceId: input.sourceId ?? null,
       sourceKey,
+      rfcMessageId: input.rfcMessageId ?? '',
       metadata: JSON.stringify(input.metadata ?? {}),
     });
 
     let caseDirty = false;
-    if (input.direction === 'outbound') {
+    // Drafts (metadata.draft) were never delivered to the client — they
+    // stamp nothing.
+    if (input.direction === 'outbound' && input.metadata?.draft !== true) {
       if (!supportCase.acknowledgedAt) {
         supportCase.acknowledgedAt = interaction.occurredAt;
         caseDirty = true;
       }
+      // Templated receipts (metadata.acknowledgement) acknowledge but are
+      // not the substantive first response.
       if (
         !supportCase.firstRespondedAt &&
-        (input.actorKind === 'specialist' || input.actorKind === 'agent')
+        (input.actorKind === 'specialist' || input.actorKind === 'agent') &&
+        input.metadata?.acknowledgement !== true
       ) {
         supportCase.firstRespondedAt = interaction.occurredAt;
         caseDirty = true;

--- a/packages/support/src/services/support-intake-service.test.ts
+++ b/packages/support/src/services/support-intake-service.test.ts
@@ -217,6 +217,16 @@ describe('SupportIntakeService', () => {
       });
       expect(reply.outcome).toBe('joined');
       expect(reply.supportCase?.id).toBe(first.supportCase?.id);
+
+      // Threading rides a first-class keyed column, not a bounded metadata
+      // scan (codex P2, PR #1943) — the Message-ID is persisted and
+      // queryable directly.
+      expect(first.interaction?.rfcMessageId).toBe('<m1@client.test>');
+      const parent =
+        await intake.caseService.interactions.byRfcMessageId(
+          '<m1@client.test>',
+        );
+      expect(parent?.id).toBe(first.interaction?.id);
     });
 
     it('skips mail sent from the binding self addresses', async () => {

--- a/packages/support/src/services/support-intake-service.test.ts
+++ b/packages/support/src/services/support-intake-service.test.ts
@@ -1,0 +1,316 @@
+/**
+ * SupportIntakeService tests (#1926): deterministic create-or-join over both
+ * wired channels — chat rooms and email accounts — plus the opt-in ambient
+ * interceptor. Covers binding gates, idempotent re-ingestion, thread joins,
+ * reopen-on-resolved, self-address skips, and unresolved-client parking.
+ */
+
+import {
+  createInterceptorContext,
+  GlobalInterceptors,
+} from '@happyvertical/smrt-core';
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  registerSupportIntake,
+  SupportIntakeService,
+} from './support-intake-service.js';
+
+const MODEL_NAMES = [
+  'SupportCase',
+  'SupportInteraction',
+  'SupportCaseEvent',
+  'SupportWorkLink',
+  'SupportPlan',
+  'SupportChannelBinding',
+];
+
+describe('SupportIntakeService', () => {
+  let ctx: Awaited<ReturnType<typeof createIsolatedTestDbFromManifest>>;
+  let intake: SupportIntakeService;
+
+  beforeEach(async () => {
+    ctx = await createIsolatedTestDbFromManifest({
+      includeObjects: MODEL_NAMES,
+    });
+    intake = await SupportIntakeService.create({ db: ctx.db });
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  describe('chat intake', () => {
+    async function bindRoom(roomId = 'room-1') {
+      return intake.bindings.create({
+        name: `binding ${roomId}`,
+        bindingKind: 'chat_room',
+        channelKind: 'chat',
+        targetType: '@happyvertical/smrt-chat:ChatRoom',
+        targetId: roomId,
+        clientProfileId: 'client-org-1',
+        projectId: 'project-1',
+      });
+    }
+
+    it('creates a case from the first message and joins subsequent ones', async () => {
+      await bindRoom();
+      const first = await intake.ingestChatMessage({
+        messageId: 'msg-1',
+        roomId: 'room-1',
+        senderProfileId: 'person-1',
+        content: 'The site is down!',
+      });
+      expect(first.outcome).toBe('created');
+      expect(first.supportCase?.subject).toBe('The site is down!');
+      expect(first.supportCase?.clientProfileId).toBe('client-org-1');
+      expect(first.supportCase?.projectId).toBe('project-1');
+      expect(first.supportCase?.channelKind).toBe('chat');
+
+      const second = await intake.ingestChatMessage({
+        messageId: 'msg-2',
+        roomId: 'room-1',
+        senderProfileId: 'person-1',
+        content: 'Any update?',
+      });
+      expect(second.outcome).toBe('joined');
+      expect(second.supportCase?.id).toBe(first.supportCase?.id);
+
+      const interactions = await intake.caseService.interactions.forCase(
+        first.supportCase?.id ?? '',
+      );
+      expect(interactions).toHaveLength(2);
+    });
+
+    it('is idempotent when the same message is ingested twice', async () => {
+      await bindRoom();
+      await intake.ingestChatMessage({
+        messageId: 'msg-1',
+        roomId: 'room-1',
+        senderProfileId: 'person-1',
+        content: 'hello',
+      });
+      const replay = await intake.ingestChatMessage({
+        messageId: 'msg-1',
+        roomId: 'room-1',
+        senderProfileId: 'person-1',
+        content: 'hello',
+      });
+      expect(replay.outcome).toBe('joined');
+      expect(replay.reason).toBe('duplicate-source');
+
+      const cases = await intake.caseService.cases.findQueue({});
+      expect(cases).toHaveLength(1);
+      const interactions = await intake.caseService.interactions.forCase(
+        cases[0]?.id ?? '',
+      );
+      expect(interactions).toHaveLength(1);
+    });
+
+    it('opens distinct cases per thread within one room', async () => {
+      await bindRoom();
+      const main = await intake.ingestChatMessage({
+        messageId: 'msg-1',
+        roomId: 'room-1',
+        senderProfileId: 'person-1',
+        content: 'main conversation',
+      });
+      const threaded = await intake.ingestChatMessage({
+        messageId: 'msg-2',
+        roomId: 'room-1',
+        threadId: 'thread-9',
+        senderProfileId: 'person-1',
+        content: 'separate thread topic',
+      });
+      expect(threaded.outcome).toBe('created');
+      expect(threaded.supportCase?.id).not.toBe(main.supportCase?.id);
+    });
+
+    it('skips unbound rooms and non-user roles', async () => {
+      await bindRoom('room-1');
+      const unbound = await intake.ingestChatMessage({
+        messageId: 'msg-1',
+        roomId: 'room-unbound',
+        senderProfileId: 'person-1',
+        content: 'not support',
+      });
+      expect(unbound.outcome).toBe('skipped');
+      expect(unbound.reason).toBe('no-binding');
+
+      const agentReply = await intake.ingestChatMessage({
+        messageId: 'msg-2',
+        roomId: 'room-1',
+        senderProfileId: 'bot-1',
+        role: 'assistant',
+        content: 'I am the agent replying',
+      });
+      expect(agentReply.outcome).toBe('skipped');
+      expect(agentReply.reason).toBe('role:assistant');
+    });
+
+    it('reopens a resolved case when the client writes again', async () => {
+      await bindRoom();
+      const first = await intake.ingestChatMessage({
+        messageId: 'msg-1',
+        roomId: 'room-1',
+        senderProfileId: 'person-1',
+        content: 'issue!',
+      });
+      expect(first.supportCase).toBeDefined();
+      await intake.caseService.resolve(first.supportCase?.id ?? '', {
+        actorKind: 'specialist',
+        summary: 'fixed',
+      });
+
+      const again = await intake.ingestChatMessage({
+        messageId: 'msg-2',
+        roomId: 'room-1',
+        senderProfileId: 'person-1',
+        content: 'it broke again',
+      });
+      expect(again.outcome).toBe('reopened');
+      expect(again.supportCase?.id).toBe(first.supportCase?.id);
+      expect(again.supportCase?.reopenCount).toBe(1);
+      // Reopened cases land back in triage; the new inbound interaction is
+      // already attached below it in the timeline.
+      expect(again.supportCase?.status).toBe('triaged');
+    });
+  });
+
+  describe('email intake', () => {
+    async function bindAccount(accountId = 'acct-1') {
+      const binding = await intake.bindings.create({
+        name: `mailbox ${accountId}`,
+        bindingKind: 'email_account',
+        channelKind: 'email',
+        targetType: '@happyvertical/smrt-messages:EmailAccount',
+        targetId: accountId,
+      });
+      binding.setSelfAddresses(['support@acme.test']);
+      await binding.save();
+      return binding;
+    }
+
+    it('creates a case from a new email and joins the RFC thread on reply', async () => {
+      await bindAccount();
+      const first = await intake.ingestEmail({
+        emailId: 'email-1',
+        accountId: 'acct-1',
+        fromAddress: 'customer@client.test',
+        fromName: 'Customer',
+        subject: 'Invoice discrepancy',
+        body: 'Our invoice looks wrong.',
+        rfcMessageId: '<m1@client.test>',
+      });
+      expect(first.outcome).toBe('created');
+      expect(first.supportCase?.subject).toBe('Invoice discrepancy');
+      expect(first.supportCase?.channelKind).toBe('email');
+
+      const reply = await intake.ingestEmail({
+        emailId: 'email-2',
+        accountId: 'acct-1',
+        fromAddress: 'customer@client.test',
+        subject: 'Re: Invoice discrepancy',
+        body: 'Adding more detail.',
+        rfcMessageId: '<m2@client.test>',
+        inReplyTo: '<m1@client.test>',
+      });
+      expect(reply.outcome).toBe('joined');
+      expect(reply.supportCase?.id).toBe(first.supportCase?.id);
+    });
+
+    it('skips mail sent from the binding self addresses', async () => {
+      await bindAccount();
+      const outbound = await intake.ingestEmail({
+        emailId: 'email-1',
+        accountId: 'acct-1',
+        fromAddress: 'Support@Acme.test',
+        subject: 'Re: your ticket',
+        body: 'our own reply synced back in',
+      });
+      expect(outbound.outcome).toBe('skipped');
+      expect(outbound.reason).toBe('self-address');
+    });
+
+    it('parks unresolved senders for triage and uses the resolver when given', async () => {
+      await bindAccount();
+      const parked = await intake.ingestEmail({
+        emailId: 'email-1',
+        accountId: 'acct-1',
+        fromAddress: 'stranger@nowhere.test',
+        subject: 'help',
+        body: 'who am I?',
+      });
+      expect(parked.outcome).toBe('created');
+      expect(parked.supportCase?.clientProfileId).toBeNull();
+      expect(parked.supportCase?.getMetadata()).toMatchObject({
+        unresolvedClient: true,
+        fromAddress: 'stranger@nowhere.test',
+      });
+
+      const resolving = await SupportIntakeService.create({
+        db: ctx.db,
+        resolveClientProfileId: async ({ email }) =>
+          email === 'known@client.test' ? 'profile-known' : null,
+      });
+      const resolved = await resolving.ingestEmail({
+        emailId: 'email-2',
+        accountId: 'acct-1',
+        fromAddress: 'known@client.test',
+        subject: 'hi',
+        body: 'known sender',
+      });
+      expect(resolved.supportCase?.clientProfileId).toBe('profile-known');
+      expect(resolved.supportCase?.getMetadata()).toEqual({});
+    });
+  });
+
+  describe('ambient interceptor', () => {
+    it('feeds ChatMessage saves through intake and never throws into the save path', async () => {
+      await intake.bindings.create({
+        name: 'room binding',
+        bindingKind: 'chat_room',
+        channelKind: 'chat',
+        targetType: '@happyvertical/smrt-chat:ChatRoom',
+        targetId: 'room-1',
+      });
+
+      const unregister = registerSupportIntake(intake);
+      try {
+        // Simulate the source package's saved instance: the interceptor keys
+        // off the constructor name and reads the transport fields.
+        class ChatMessage {
+          id = 'msg-77';
+          roomId = 'room-1';
+          threadId = null;
+          senderProfileId = 'person-9';
+          role = 'user';
+          content = 'ambient hello';
+          tenantId = null;
+          isDeleted = false;
+        }
+        await GlobalInterceptors.executeAfterSave(
+          new ChatMessage() as never,
+          createInterceptorContext('ChatMessage', 'save'),
+        );
+
+        const cases = await intake.caseService.cases.findQueue({});
+        expect(cases).toHaveLength(1);
+        expect(cases[0]?.subject).toBe('ambient hello');
+
+        // A model the interceptor does not understand passes through silently.
+        class SomethingElse {
+          id = 'x';
+        }
+        await expect(
+          GlobalInterceptors.executeAfterSave(
+            new SomethingElse() as never,
+            createInterceptorContext('SomethingElse', 'save'),
+          ),
+        ).resolves.toBeUndefined();
+      } finally {
+        unregister();
+      }
+    });
+  });
+});

--- a/packages/support/src/services/support-intake-service.test.ts
+++ b/packages/support/src/services/support-intake-service.test.ts
@@ -107,6 +107,36 @@ describe('SupportIntakeService', () => {
       expect(interactions).toHaveLength(1);
     });
 
+    it('keeps one canonical case under concurrent first messages', async () => {
+      await bindRoom();
+      // Two DIFFERENT messages race intake for a brand-new conversation —
+      // without per-conversation serialization both would observe "no open
+      // case" and split the conversation (codex review round 2, PR #1943).
+      const [a, b] = await Promise.all([
+        intake.ingestChatMessage({
+          messageId: 'race-1',
+          roomId: 'room-1',
+          senderProfileId: 'person-1',
+          content: 'first racer',
+        }),
+        intake.ingestChatMessage({
+          messageId: 'race-2',
+          roomId: 'room-1',
+          senderProfileId: 'person-1',
+          content: 'second racer',
+        }),
+      ]);
+
+      expect(a.supportCase?.id).toBe(b.supportCase?.id);
+      expect([a.outcome, b.outcome].sort()).toEqual(['created', 'joined']);
+      const cases = await intake.caseService.cases.findQueue({});
+      expect(cases).toHaveLength(1);
+      const interactions = await intake.caseService.interactions.forCase(
+        cases[0]?.id ?? '',
+      );
+      expect(interactions).toHaveLength(2);
+    });
+
     it('opens distinct cases per thread within one room', async () => {
       await bindRoom();
       const main = await intake.ingestChatMessage({

--- a/packages/support/src/services/support-intake-service.ts
+++ b/packages/support/src/services/support-intake-service.ts
@@ -238,6 +238,7 @@ export class SupportIntakeService {
       occurredAt: input.occurredAt,
       sourceType: EMAIL_SOURCE_TYPE,
       sourceId: input.emailId,
+      rfcMessageId: input.rfcMessageId ?? null,
       caseMetadata: unresolvedClient
         ? { unresolvedClient: true, fromAddress: input.fromAddress }
         : undefined,
@@ -264,6 +265,7 @@ export class SupportIntakeService {
     occurredAt?: Date;
     sourceType: string;
     sourceId: string;
+    rfcMessageId?: string | null;
     caseMetadata?: Record<string, unknown>;
     interactionMetadata?: Record<string, unknown>;
   }): Promise<IntakeResult> {
@@ -334,6 +336,7 @@ export class SupportIntakeService {
       sourceType: input.sourceType,
       sourceId: input.sourceId,
       sourceKey: input.sourceKey,
+      rfcMessageId: input.rfcMessageId ?? '',
       metadata: input.interactionMetadata,
     });
 
@@ -368,19 +371,9 @@ export class SupportIntakeService {
   private async findInteractionByRfcMessageId(
     rfcMessageId: string,
   ): Promise<SupportInteraction | null> {
-    // rfcMessageId lives in interaction metadata; scan recent email
-    // interactions (metadata is a JSON text column, so filter in memory).
-    const candidates = await this.caseService.interactions.list({
-      where: { sourceType: EMAIL_SOURCE_TYPE },
-      orderBy: 'occurred_at DESC',
-      limit: 500,
-    });
-    return (
-      candidates.find(
-        (interaction) =>
-          (interaction.getMetadata().rfcMessageId ?? null) === rfcMessageId,
-      ) ?? null
-    );
+    // Keyed lookup on the first-class column — reply threading must not
+    // depend on how much traffic arrived since the parent message.
+    return this.caseService.interactions.byRfcMessageId(rfcMessageId);
   }
 }
 

--- a/packages/support/src/services/support-intake-service.ts
+++ b/packages/support/src/services/support-intake-service.ts
@@ -29,6 +29,7 @@ import {
   SupportChannelBindingCollection,
 } from '../models/support-channel-binding.js';
 import type { SupportInteraction } from '../models/support-interaction.js';
+import { KeyedMutex } from './keyed-mutex.js';
 import { SupportCaseService } from './support-case-service.js';
 
 /** Qualified source types intake understands. */
@@ -95,6 +96,7 @@ export class SupportIntakeService {
   readonly caseService: SupportCaseService;
   readonly bindings: SupportChannelBindingCollection;
   private readonly options: SupportIntakeOptions;
+  private readonly conversationMutex = new KeyedMutex();
 
   protected constructor(
     caseService: SupportCaseService,
@@ -253,6 +255,33 @@ export class SupportIntakeService {
 
   /** The shared create-or-join core (deterministic per conversation key). */
   private async createOrJoin(input: {
+    binding: SupportChannelBinding;
+    threadKey: string;
+    sourceKey: string;
+    tenantId: string | null;
+    subject: string;
+    body: string;
+    clientProfileId: string | null;
+    openedByProfileId: string | null;
+    authorProfileId: string | null;
+    occurredAt?: Date;
+    sourceType: string;
+    sourceId: string;
+    rfcMessageId?: string | null;
+    caseMetadata?: Record<string, unknown>;
+    interactionMetadata?: Record<string, unknown>;
+  }): Promise<IntakeResult> {
+    // Serialize per conversation: two concurrent first messages for the same
+    // room/thread must not both observe "no open case" and split one
+    // conversation across duplicate canonical cases (their source keys
+    // differ, so row uniqueness alone cannot catch this).
+    const conversationKey = `${input.binding.id ?? ''}:${input.threadKey}`;
+    return this.conversationMutex.run(conversationKey, () =>
+      this.createOrJoinExclusive(input),
+    );
+  }
+
+  private async createOrJoinExclusive(input: {
     binding: SupportChannelBinding;
     threadKey: string;
     sourceKey: string;

--- a/packages/support/src/services/support-intake-service.ts
+++ b/packages/support/src/services/support-intake-service.ts
@@ -1,0 +1,466 @@
+/**
+ * SupportIntakeService — channel intake: every inbound interaction on a bound
+ * transport container deterministically creates or joins one canonical
+ * Support Case (FR-28, issue #1926).
+ *
+ * Channels are transports, not systems of record: the ChatMessage / Email row
+ * stays canonical in its package; intake links it as a
+ * {@link SupportInteraction} (idempotent on `sourceKey`) and drives the
+ * create-or-join decision by conversation key:
+ *
+ * - chat: `chat:<roomId>[:<threadId>]` — a bound room is one client
+ *   conversation; threads open distinct cases.
+ * - email: the RFC thread — a reply (`inReplyTo`) joins the case holding the
+ *   referenced message; otherwise the message id starts a new thread key.
+ *
+ * Join semantics: open case → join; resolved case → reopen + join (the client
+ * replied to a "resolved" conversation); closed case → a fresh case.
+ *
+ * Intake never throws into the source package's save path — the opt-in
+ * interceptor (`registerSupportIntake`) swallows and logs intake errors.
+ */
+
+import { createLogger } from '@happyvertical/logger';
+import type { SmrtObject, SmrtObjectOptions } from '@happyvertical/smrt-core';
+import { GlobalInterceptors } from '@happyvertical/smrt-core';
+import type { SupportCase } from '../models/support-case.js';
+import {
+  type SupportChannelBinding,
+  SupportChannelBindingCollection,
+} from '../models/support-channel-binding.js';
+import type { SupportInteraction } from '../models/support-interaction.js';
+import { SupportCaseService } from './support-case-service.js';
+
+/** Qualified source types intake understands. */
+export const CHAT_MESSAGE_SOURCE_TYPE = '@happyvertical/smrt-chat:ChatMessage';
+export const CHAT_ROOM_TARGET_TYPE = '@happyvertical/smrt-chat:ChatRoom';
+export const EMAIL_SOURCE_TYPE = '@happyvertical/smrt-messages:Email';
+export const EMAIL_ACCOUNT_TARGET_TYPE =
+  '@happyvertical/smrt-messages:EmailAccount';
+
+export interface InboundChatMessage {
+  messageId: string;
+  roomId: string;
+  threadId?: string | null;
+  senderProfileId: string;
+  /** Chat role; only `user` messages are client inbound. */
+  role?: string;
+  content: string;
+  tenantId?: string | null;
+  occurredAt?: Date;
+}
+
+export interface InboundEmail {
+  emailId: string;
+  accountId: string;
+  fromAddress: string;
+  fromName?: string;
+  subject?: string;
+  body: string;
+  /** RFC 822 Message-ID of this email. */
+  rfcMessageId?: string | null;
+  /** RFC 822 Message-ID this email replies to. */
+  inReplyTo?: string | null;
+  tenantId?: string | null;
+  occurredAt?: Date;
+}
+
+export interface IntakeResult {
+  outcome: 'created' | 'joined' | 'reopened' | 'skipped';
+  reason?: string;
+  supportCase?: SupportCase;
+  interaction?: SupportInteraction;
+  binding?: SupportChannelBinding;
+}
+
+export interface SupportIntakeOptions extends SmrtObjectOptions {
+  /**
+   * Resolve the Client profile for an inbound email sender. When omitted and
+   * the binding has no default client, the case is parked with
+   * `metadata.unresolvedClient = true` for operator triage.
+   */
+  resolveClientProfileId?: (input: {
+    email: string;
+    name?: string;
+    tenantId?: string | null;
+  }) => Promise<string | null>;
+  /**
+   * Called after intake creates or updates a case — the AI workflow and the
+   * target engine attach here without a hard dependency cycle.
+   */
+  onCaseIntake?: (result: IntakeResult) => Promise<void>;
+}
+
+export class SupportIntakeService {
+  readonly caseService: SupportCaseService;
+  readonly bindings: SupportChannelBindingCollection;
+  private readonly options: SupportIntakeOptions;
+
+  protected constructor(
+    caseService: SupportCaseService,
+    bindings: SupportChannelBindingCollection,
+    options: SupportIntakeOptions,
+  ) {
+    this.caseService = caseService;
+    this.bindings = bindings;
+    this.options = options;
+  }
+
+  static async create(
+    options: SupportIntakeOptions,
+  ): Promise<SupportIntakeService> {
+    const [caseService, bindings] = await Promise.all([
+      SupportCaseService.create(options),
+      SupportChannelBindingCollection.create(options),
+    ]);
+    return new SupportIntakeService(caseService, bindings, options);
+  }
+
+  /** Conversation key for a chat room/thread. */
+  static chatThreadKey(roomId: string, threadId?: string | null): string {
+    return threadId ? `chat:${roomId}:${threadId}` : `chat:${roomId}`;
+  }
+
+  /** Idempotency key for a chat message. */
+  static chatSourceKey(messageId: string): string {
+    return `chat:${messageId}`;
+  }
+
+  /** Idempotency key for an email. */
+  static emailSourceKey(emailId: string): string {
+    return `email:${emailId}`;
+  }
+
+  /**
+   * Ingest one inbound chat message from a bound room: create-or-join the
+   * conversation's case and record the interaction.
+   */
+  async ingestChatMessage(input: InboundChatMessage): Promise<IntakeResult> {
+    if (input.role && input.role !== 'user') {
+      return { outcome: 'skipped', reason: `role:${input.role}` };
+    }
+    const binding = await this.bindings.findForTarget(
+      CHAT_ROOM_TARGET_TYPE,
+      input.roomId,
+    );
+    if (!binding) {
+      return { outcome: 'skipped', reason: 'no-binding' };
+    }
+
+    const threadKey = SupportIntakeService.chatThreadKey(
+      input.roomId,
+      input.threadId,
+    );
+    const sourceKey = SupportIntakeService.chatSourceKey(input.messageId);
+    const clientProfileId = binding.clientProfileId ?? input.senderProfileId;
+
+    return this.createOrJoin({
+      binding,
+      threadKey,
+      sourceKey,
+      tenantId: input.tenantId ?? binding.tenantId ?? null,
+      subject: truncateSubject(input.content),
+      body: input.content,
+      clientProfileId,
+      openedByProfileId: input.senderProfileId,
+      authorProfileId: input.senderProfileId,
+      occurredAt: input.occurredAt,
+      sourceType: CHAT_MESSAGE_SOURCE_TYPE,
+      sourceId: input.messageId,
+      interactionMetadata: {
+        roomId: input.roomId,
+        threadId: input.threadId ?? null,
+      },
+    });
+  }
+
+  /**
+   * Ingest one inbound email from a bound account: joins the RFC thread's
+   * case when `inReplyTo` references a known interaction, else creates a new
+   * case keyed by the message id. Mail sent FROM the binding's own addresses
+   * is skipped (our outbound side of the conversation).
+   */
+  async ingestEmail(input: InboundEmail): Promise<IntakeResult> {
+    const binding = await this.bindings.findForTarget(
+      EMAIL_ACCOUNT_TARGET_TYPE,
+      input.accountId,
+    );
+    if (!binding) {
+      return { outcome: 'skipped', reason: 'no-binding' };
+    }
+    const from = input.fromAddress.trim().toLowerCase();
+    if (binding.getSelfAddresses().includes(from)) {
+      return { outcome: 'skipped', reason: 'self-address' };
+    }
+
+    const sourceKey = SupportIntakeService.emailSourceKey(input.emailId);
+
+    // A reply joins the case that holds the referenced message.
+    let threadKey: string | null = null;
+    if (input.inReplyTo) {
+      const parent = await this.findInteractionByRfcMessageId(input.inReplyTo);
+      if (parent) {
+        const parentCase = await this.caseService.cases.get({
+          id: parent.caseId,
+        });
+        if (parentCase) {
+          threadKey = parentCase.threadKey;
+        }
+      }
+    }
+    if (!threadKey) {
+      threadKey = `email:${input.rfcMessageId || input.emailId}`;
+    }
+
+    let clientProfileId = binding.clientProfileId ?? null;
+    let unresolvedClient = false;
+    if (!clientProfileId && this.options.resolveClientProfileId) {
+      clientProfileId = await this.options.resolveClientProfileId({
+        email: input.fromAddress,
+        name: input.fromName,
+        tenantId: input.tenantId ?? binding.tenantId ?? null,
+      });
+    }
+    if (!clientProfileId) {
+      unresolvedClient = true;
+    }
+
+    return this.createOrJoin({
+      binding,
+      threadKey,
+      sourceKey,
+      tenantId: input.tenantId ?? binding.tenantId ?? null,
+      subject: input.subject?.trim() || truncateSubject(input.body),
+      body: input.body,
+      clientProfileId,
+      openedByProfileId: clientProfileId,
+      authorProfileId: clientProfileId,
+      occurredAt: input.occurredAt,
+      sourceType: EMAIL_SOURCE_TYPE,
+      sourceId: input.emailId,
+      caseMetadata: unresolvedClient
+        ? { unresolvedClient: true, fromAddress: input.fromAddress }
+        : undefined,
+      interactionMetadata: {
+        fromAddress: input.fromAddress,
+        fromName: input.fromName ?? null,
+        rfcMessageId: input.rfcMessageId ?? null,
+        inReplyTo: input.inReplyTo ?? null,
+      },
+    });
+  }
+
+  /** The shared create-or-join core (deterministic per conversation key). */
+  private async createOrJoin(input: {
+    binding: SupportChannelBinding;
+    threadKey: string;
+    sourceKey: string;
+    tenantId: string | null;
+    subject: string;
+    body: string;
+    clientProfileId: string | null;
+    openedByProfileId: string | null;
+    authorProfileId: string | null;
+    occurredAt?: Date;
+    sourceType: string;
+    sourceId: string;
+    caseMetadata?: Record<string, unknown>;
+    interactionMetadata?: Record<string, unknown>;
+  }): Promise<IntakeResult> {
+    const { binding } = input;
+
+    // Idempotency: the same transport record never produces two interactions.
+    const existing = await this.caseService.interactions.bySourceKey(
+      input.sourceKey,
+    );
+    if (existing) {
+      const supportCase = await this.caseService.cases.get({
+        id: existing.caseId,
+      });
+      return {
+        outcome: 'joined',
+        reason: 'duplicate-source',
+        supportCase: supportCase ?? undefined,
+        interaction: existing,
+        binding,
+      };
+    }
+
+    let outcome: IntakeResult['outcome'];
+    let supportCase = await this.caseService.cases.findOpenByThreadKey(
+      input.threadKey,
+      { bindingId: binding.id },
+    );
+
+    if (supportCase) {
+      outcome = 'joined';
+    } else {
+      const resolved = await this.findResolvedByThreadKey(
+        input.threadKey,
+        binding.id ?? null,
+      );
+      if (resolved) {
+        supportCase = await this.caseService.reopen(resolved, {
+          actorKind: 'client',
+          actorProfileId: input.authorProfileId,
+          reason: 'new inbound interaction on resolved case',
+        });
+        outcome = 'reopened';
+      } else {
+        supportCase = await this.caseService.openCase({
+          tenantId: input.tenantId,
+          subject: input.subject,
+          description: input.body,
+          channelKind: binding.channelKind,
+          clientProfileId: input.clientProfileId,
+          openedByProfileId: input.openedByProfileId,
+          projectId: binding.projectId ?? null,
+          bindingId: binding.id ?? null,
+          threadKey: input.threadKey,
+          planId: binding.planId ?? null,
+          metadata: input.caseMetadata,
+        });
+        outcome = 'created';
+      }
+    }
+
+    const interaction = await this.caseService.recordInteraction(supportCase, {
+      direction: 'inbound',
+      channelKind: binding.channelKind,
+      actorKind: 'client',
+      authorProfileId: input.authorProfileId,
+      body: input.body,
+      occurredAt: input.occurredAt,
+      sourceType: input.sourceType,
+      sourceId: input.sourceId,
+      sourceKey: input.sourceKey,
+      metadata: input.interactionMetadata,
+    });
+
+    const result: IntakeResult = {
+      outcome,
+      supportCase,
+      interaction,
+      binding,
+    };
+    if (this.options.onCaseIntake) {
+      await this.options.onCaseIntake(result);
+    }
+    return result;
+  }
+
+  private async findResolvedByThreadKey(
+    threadKey: string,
+    bindingId: string | null,
+  ): Promise<SupportCase | null> {
+    const where: Record<string, unknown> = { threadKey, status: 'resolved' };
+    if (bindingId) {
+      where.bindingId = bindingId;
+    }
+    const matches = await this.caseService.cases.list({
+      where,
+      orderBy: 'updated_at DESC',
+      limit: 1,
+    });
+    return matches[0] ?? null;
+  }
+
+  private async findInteractionByRfcMessageId(
+    rfcMessageId: string,
+  ): Promise<SupportInteraction | null> {
+    // rfcMessageId lives in interaction metadata; scan recent email
+    // interactions (metadata is a JSON text column, so filter in memory).
+    const candidates = await this.caseService.interactions.list({
+      where: { sourceType: EMAIL_SOURCE_TYPE },
+      orderBy: 'occurred_at DESC',
+      limit: 500,
+    });
+    return (
+      candidates.find(
+        (interaction) =>
+          (interaction.getMetadata().rfcMessageId ?? null) === rfcMessageId,
+      ) ?? null
+    );
+  }
+}
+
+function truncateSubject(body: string, max = 120): string {
+  const firstLine = (body ?? '').split('\n', 1)[0]?.trim() ?? '';
+  if (firstLine.length <= max) {
+    return firstLine || '(no subject)';
+  }
+  return `${firstLine.slice(0, max - 1)}…`;
+}
+
+/** Interceptor name used for registration/unregistration. */
+export const SUPPORT_INTAKE_INTERCEPTOR = 'smrt-support:intake';
+
+/**
+ * Opt-in ambient intake: observe saves of `ChatMessage` and `Email` rows via
+ * core `GlobalInterceptors` and feed them through the intake service. Only
+ * containers with an enabled {@link SupportChannelBinding} produce cases;
+ * everything else passes through untouched. Errors are logged, never thrown —
+ * intake must not break the source package's save path.
+ *
+ * @returns An unregister function.
+ */
+export function registerSupportIntake(
+  intake: SupportIntakeService,
+  options: { onError?: (error: unknown, instance: SmrtObject) => void } = {},
+): () => void {
+  const handleError = (error: unknown, instance: SmrtObject) => {
+    if (options.onError) {
+      options.onError(error, instance);
+      return;
+    }
+    // Lazy logger: created on first failure, never at module scope (a
+    // module-scope createLogger reads process.env and breaks browser builds).
+    createLogger(true).error('[smrt-support] intake failed', { error });
+  };
+
+  GlobalInterceptors.register({
+    name: SUPPORT_INTAKE_INTERCEPTOR,
+    async afterSave(instance) {
+      const record = instance as unknown as Record<string, unknown>;
+      try {
+        const className = instance.constructor?.name;
+        if (className === 'ChatMessage') {
+          // Only freshly created user messages are inbound client activity.
+          if (record.isDeleted === true) return;
+          await intake.ingestChatMessage({
+            messageId: String(record.id ?? ''),
+            roomId: String(record.roomId ?? ''),
+            threadId: (record.threadId as string | null) ?? null,
+            senderProfileId: String(record.senderProfileId ?? ''),
+            role: (record.role as string | undefined) ?? 'user',
+            content: String(record.content ?? ''),
+            tenantId: (record.tenantId as string | null) ?? null,
+            occurredAt:
+              record.created_at instanceof Date ? record.created_at : undefined,
+          });
+        } else if (className === 'Email') {
+          await intake.ingestEmail({
+            emailId: String(record.id ?? ''),
+            accountId: String(record.accountId ?? ''),
+            fromAddress: String(record.fromAddress ?? ''),
+            fromName: (record.fromName as string | undefined) ?? undefined,
+            subject: (record.subject as string | undefined) ?? undefined,
+            body: String(record.textBody ?? record.body ?? ''),
+            rfcMessageId: (record.messageId as string | null) ?? null,
+            inReplyTo: (record.inReplyTo as string | null) ?? null,
+            tenantId: (record.tenantId as string | null) ?? null,
+            occurredAt: record.date instanceof Date ? record.date : undefined,
+          });
+        }
+      } catch (error) {
+        handleError(error, instance);
+      }
+    },
+  });
+
+  return () => {
+    GlobalInterceptors.unregister(SUPPORT_INTAKE_INTERCEPTOR);
+  };
+}
+
+export default SupportIntakeService;

--- a/packages/support/src/services/support-plan-admin-service.test.ts
+++ b/packages/support/src/services/support-plan-admin-service.test.ts
@@ -1,0 +1,118 @@
+/**
+ * SupportPlanAdminService tests: the `support.manage-plans` permission split
+ * gates every commercial-terms write (Managed Support Plans and Support
+ * Compensation Plans), with cross-tenant writes refused (codex review round
+ * 2, PR #1943 — generated CRUD on both models is read-only).
+ */
+
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  MANAGE_PLANS_PERMISSION,
+  supportPrincipalFromPermissions,
+} from '../permissions.js';
+import {
+  PlanAdminDeniedError,
+  SupportPlanAdminService,
+} from './support-plan-admin-service.js';
+
+const MODEL_NAMES = ['SupportPlan', 'SupportCompensationPlan'];
+
+const manager = (tenantId?: string) =>
+  supportPrincipalFromPermissions([MANAGE_PLANS_PERMISSION], {
+    id: 'profile-ops',
+    tenantId,
+  });
+const member = () =>
+  supportPrincipalFromPermissions([], { id: 'profile-member' });
+
+describe('SupportPlanAdminService', () => {
+  let ctx: Awaited<ReturnType<typeof createIsolatedTestDbFromManifest>>;
+  let admin: SupportPlanAdminService;
+
+  beforeEach(async () => {
+    ctx = await createIsolatedTestDbFromManifest({
+      includeObjects: MODEL_NAMES,
+    });
+    admin = await SupportPlanAdminService.create({ db: ctx.db });
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  it('denies every plan write without the manage-plans split', async () => {
+    await expect(
+      admin.savePlan({
+        principal: member(),
+        fields: { planKey: 'gold', name: 'Gold' },
+      }),
+    ).rejects.toThrow(PlanAdminDeniedError);
+    await expect(
+      admin.saveCompensationPlan({
+        principal: member(),
+        fields: { name: 'Rates', hourlyRate: 45.0 },
+      }),
+    ).rejects.toThrow(PlanAdminDeniedError);
+  });
+
+  it('creates, updates, and archives plans for a holder of the split', async () => {
+    const plan = await admin.savePlan({
+      principal: manager(),
+      fields: {
+        planKey: 'gold',
+        name: 'Gold',
+        includedMinutes: 600,
+        overageHourlyRate: 150.0,
+      },
+    });
+    expect(plan.planKey).toBe('gold');
+
+    const updated = await admin.updatePlan(plan.id ?? '', {
+      principal: manager(),
+      fields: { overageHourlyRate: 175.0 },
+    });
+    expect(updated.overageHourlyRate).toBe(175);
+
+    const archived = await admin.archivePlan(plan.id ?? '', {
+      principal: manager(),
+    });
+    expect(archived.status).toBe('archived');
+  });
+
+  it('manages compensation plans through the same gate', async () => {
+    const comp = await admin.saveCompensationPlan({
+      principal: manager(),
+      fields: {
+        name: 'Specialist rates',
+        hourlyRate: 45.0,
+        effectiveFrom: new Date('2026-01-01T00:00:00Z'),
+      },
+    });
+    expect(comp.hourlyRate).toBe(45);
+
+    const archived = await admin.archiveCompensationPlan(comp.id ?? '', {
+      principal: manager(),
+    });
+    expect(archived.status).toBe('archived');
+  });
+
+  it('refuses cross-tenant plan writes even for a holder', async () => {
+    const plan = await admin.savePlan({
+      principal: manager('tenant-a'),
+      fields: { tenantId: 'tenant-a', planKey: 'a-plan', name: 'A' },
+    });
+    await expect(
+      admin.updatePlan(plan.id ?? '', {
+        principal: manager('tenant-b'),
+        fields: { overageHourlyRate: 999.0 },
+      }),
+    ).rejects.toThrow(/tenant/);
+    await expect(
+      admin.savePlan({
+        principal: manager('tenant-b'),
+        fields: { tenantId: 'tenant-a', planKey: 'forged', name: 'F' },
+      }),
+    ).rejects.toThrow(/tenant/);
+  });
+});

--- a/packages/support/src/services/support-plan-admin-service.ts
+++ b/packages/support/src/services/support-plan-admin-service.ts
@@ -1,0 +1,168 @@
+/**
+ * SupportPlanAdminService — the permission-gated write surface for
+ * commercial terms: Managed Support Plans (client pricing/service terms) and
+ * Support Compensation Plans (provider earning terms).
+ *
+ * The `support.manage-plans` split is the gate (the
+ * `personas.activate-directive` idiom): the generated CRUD routes on both
+ * models are read-only, so every plan write flows through here, carries an
+ * accountable principal, and refuses cross-tenant acts. Plan history stays
+ * safe regardless — cases snapshot plan terms at apply time and settlements
+ * snapshot rates at approval time — but only holders of the split may shape
+ * future terms.
+ */
+
+import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
+import {
+  type SupportCompensationPlan,
+  SupportCompensationPlanCollection,
+} from '../models/support-compensation-plan.js';
+import {
+  type SupportPlan,
+  SupportPlanCollection,
+} from '../models/support-plan.js';
+import {
+  MANAGE_PLANS_PERMISSION,
+  type SupportPrincipal,
+} from '../permissions.js';
+
+/** Thrown when a plan write is attempted without the manage-plans split. */
+export class PlanAdminDeniedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PlanAdminDeniedError';
+  }
+}
+
+export interface PlanAdminActor {
+  principal: SupportPrincipal;
+}
+
+export class SupportPlanAdminService {
+  readonly plans: SupportPlanCollection;
+  readonly compensationPlans: SupportCompensationPlanCollection;
+
+  protected constructor(collections: {
+    plans: SupportPlanCollection;
+    compensationPlans: SupportCompensationPlanCollection;
+  }) {
+    this.plans = collections.plans;
+    this.compensationPlans = collections.compensationPlans;
+  }
+
+  static async create(
+    options: SmrtObjectOptions,
+  ): Promise<SupportPlanAdminService> {
+    const [plans, compensationPlans] = await Promise.all([
+      SupportPlanCollection.create(options),
+      SupportCompensationPlanCollection.create(options),
+    ]);
+    return new SupportPlanAdminService({ plans, compensationPlans });
+  }
+
+  /** Create (or overwrite via natural key) a Managed Support Plan. */
+  async savePlan(
+    input: PlanAdminActor & { fields: Record<string, unknown> },
+  ): Promise<SupportPlan> {
+    this.assertManager(input.principal, 'writing a Managed Support Plan');
+    this.assertTenant(
+      input.principal,
+      (input.fields.tenantId as string | null | undefined) ?? null,
+    );
+    return this.plans.create(input.fields);
+  }
+
+  /** Update an existing Managed Support Plan's fields. */
+  async updatePlan(
+    planId: string,
+    input: PlanAdminActor & { fields: Record<string, unknown> },
+  ): Promise<SupportPlan> {
+    this.assertManager(input.principal, 'updating a Managed Support Plan');
+    const plan = await this.plans.get({ id: planId });
+    if (!plan) {
+      throw new Error(`SupportPlan not found: ${planId}`);
+    }
+    this.assertTenant(input.principal, plan.tenantId);
+    Object.assign(plan, input.fields);
+    await plan.save();
+    return plan;
+  }
+
+  /** Archive a Managed Support Plan (soft retirement; history untouched). */
+  async archivePlan(
+    planId: string,
+    input: PlanAdminActor,
+  ): Promise<SupportPlan> {
+    return this.updatePlan(planId, {
+      principal: input.principal,
+      fields: { status: 'archived' },
+    });
+  }
+
+  /** Create a Support Compensation Plan (effective-dated earning terms). */
+  async saveCompensationPlan(
+    input: PlanAdminActor & { fields: Record<string, unknown> },
+  ): Promise<SupportCompensationPlan> {
+    this.assertManager(input.principal, 'writing a Support Compensation Plan');
+    this.assertTenant(
+      input.principal,
+      (input.fields.tenantId as string | null | undefined) ?? null,
+    );
+    return this.compensationPlans.create(input.fields);
+  }
+
+  /** Update an existing Support Compensation Plan's fields. */
+  async updateCompensationPlan(
+    planId: string,
+    input: PlanAdminActor & { fields: Record<string, unknown> },
+  ): Promise<SupportCompensationPlan> {
+    this.assertManager(input.principal, 'updating a Support Compensation Plan');
+    const plan = await this.compensationPlans.get({ id: planId });
+    if (!plan) {
+      throw new Error(`SupportCompensationPlan not found: ${planId}`);
+    }
+    this.assertTenant(input.principal, plan.tenantId);
+    Object.assign(plan, input.fields);
+    await plan.save();
+    return plan;
+  }
+
+  /** Archive a Support Compensation Plan. */
+  async archiveCompensationPlan(
+    planId: string,
+    input: PlanAdminActor,
+  ): Promise<SupportCompensationPlan> {
+    return this.updateCompensationPlan(planId, {
+      principal: input.principal,
+      fields: { status: 'archived' },
+    });
+  }
+
+  protected assertManager(
+    principal: SupportPrincipal | undefined,
+    act: string,
+  ): void {
+    if (!principal?.can(MANAGE_PLANS_PERMISSION)) {
+      throw new PlanAdminDeniedError(
+        `Denied ${act}: principal lacks '${MANAGE_PLANS_PERMISSION}'.`,
+      );
+    }
+  }
+
+  /** Cross-tenant plan writes are refused when both sides carry a tenant. */
+  protected assertTenant(
+    principal: SupportPrincipal,
+    planTenantId: string | null,
+  ): void {
+    if (!principal.tenantId || !planTenantId) {
+      return;
+    }
+    if (principal.tenantId !== planTenantId) {
+      throw new PlanAdminDeniedError(
+        `Denied: principal tenant '${principal.tenantId}' does not match the plan tenant '${planTenantId}'.`,
+      );
+    }
+  }
+}
+
+export default SupportPlanAdminService;

--- a/packages/support/src/services/support-routing-service.test.ts
+++ b/packages/support/src/services/support-routing-service.test.ts
@@ -114,6 +114,23 @@ describe('SupportRoutingService', () => {
   }
 
   describe('rankSpecialists', () => {
+    it('hard-filters specialists from another tenant with the factor visible', async () => {
+      const foreign = await makeSpecialist({ tenantId: 'tenant-x' });
+      const local = await makeSpecialist({ tenantId: 'tenant-b' });
+      await allDayWeekly(foreign);
+      await allDayWeekly(local);
+      const supportCase = await openCase({ tenantId: 'tenant-b' });
+
+      const ranked = await routing.rankSpecialists(supportCase, { at: AT });
+      const foreignRank = ranked.find(
+        (item) => item.specialistId === foreign.id,
+      );
+      const localRank = ranked.find((item) => item.specialistId === local.id);
+      expect(foreignRank?.eligible).toBe(false);
+      expect(foreignRank?.factors.tenantMismatch).toBe(true);
+      expect(localRank?.eligible).toBe(true);
+    });
+
     it('hard-filters on an effective project qualification, keeping the failing factor visible', async () => {
       const qualified = await makeSpecialist();
       const unqualified = await makeSpecialist();
@@ -385,6 +402,31 @@ describe('SupportRoutingService', () => {
           ),
         }),
       ).rejects.toThrow(/tenant/);
+    });
+
+    it('refuses a specialist from another tenant and unknown specialist ids', async () => {
+      const foreign = await makeSpecialist({ tenantId: 'tenant-x' });
+      const supportCase = await openCase({ tenantId: 'tenant-b' });
+      const principal = supportPrincipalFromPermissions(
+        [REASSIGN_CASE_PERMISSION],
+        { id: 'profile-lead', tenantId: 'tenant-b' },
+      );
+
+      // An authorized in-tenant caller must not be able to assign (and
+      // audit) a foreign tenant's specialist (codex review, PR #1943).
+      await expect(
+        routing.reassign(supportCase, {
+          specialistId: foreign.id ?? '',
+          principal,
+        }),
+      ).rejects.toThrow(/specialist tenant does not match/);
+
+      await expect(
+        routing.reassign(supportCase, {
+          specialistId: 'no-such-specialist',
+          principal,
+        }),
+      ).rejects.toThrow(/unknown specialist/);
     });
 
     it('reassigns with a manual rationale when authorized', async () => {

--- a/packages/support/src/services/support-routing-service.test.ts
+++ b/packages/support/src/services/support-routing-service.test.ts
@@ -1,0 +1,418 @@
+/**
+ * SupportRoutingService tests (#1929): explainable ranked routing — the
+ * project-qualification hard filter with effective dating, workload caps,
+ * availability in the specialist's own timezone (weekly windows, on-call
+ * spans, time-off exclusions), preference and language scoring, deterministic
+ * ordering, auto-assignment rationale, and the permission-gated manual
+ * reassignment override with its cross-tenant guard.
+ */
+
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { SupportCase } from '../models/support-case.js';
+import type {
+  SupportAvailability,
+  SupportAvailabilityCollection,
+  SupportQualificationCollection,
+  SupportSpecialist,
+  SupportSpecialistCollection,
+} from '../models/support-specialist.js';
+import {
+  REASSIGN_CASE_PERMISSION,
+  supportPrincipalFromPermissions,
+} from '../permissions.js';
+import { SupportCaseService } from './support-case-service.js';
+import {
+  ReassignDeniedError,
+  SupportRoutingService,
+} from './support-routing-service.js';
+
+const MODEL_NAMES = [
+  'SupportCase',
+  'SupportInteraction',
+  'SupportCaseEvent',
+  'SupportWorkLink',
+  'SupportPlan',
+  'SupportSpecialist',
+  'SupportQualification',
+  'SupportAvailability',
+];
+
+// Monday 2026-01-05 14:00 UTC — 09:00 in America/New_York.
+const AT = new Date('2026-01-05T14:00:00Z');
+
+describe('SupportRoutingService', () => {
+  let ctx: Awaited<ReturnType<typeof createIsolatedTestDbFromManifest>>;
+  let service: SupportCaseService;
+  let routing: SupportRoutingService;
+  let specialists: SupportSpecialistCollection;
+  let qualifications: SupportQualificationCollection;
+  let availabilities: SupportAvailabilityCollection;
+  let specialistSeq = 0;
+
+  beforeEach(async () => {
+    ctx = await createIsolatedTestDbFromManifest({
+      includeObjects: MODEL_NAMES,
+    });
+    service = await SupportCaseService.create({ db: ctx.db });
+    routing = await SupportRoutingService.create({
+      db: ctx.db,
+      caseService: service,
+    });
+    specialists = routing.specialists;
+    qualifications = routing.qualifications;
+    availabilities = routing.availabilities;
+    specialistSeq = 0;
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  async function makeSpecialist(
+    overrides: Partial<Record<string, unknown>> = {},
+  ): Promise<SupportSpecialist> {
+    specialistSeq += 1;
+    return specialists.create({
+      profileId: `profile-${specialistSeq}`,
+      displayName: `Specialist ${specialistSeq}`,
+      status: 'active',
+      timezone: 'UTC',
+      maxConcurrentCases: 5,
+      languages: '["en"]',
+      ...overrides,
+    });
+  }
+
+  async function allDayWeekly(
+    specialist: SupportSpecialist,
+  ): Promise<SupportAvailability> {
+    return availabilities.create({
+      specialistId: specialist.id,
+      kind: 'weekly',
+      weekday: 1, // AT is a Monday
+      startMinute: 0,
+      endMinute: 1440,
+    });
+  }
+
+  async function openCase(
+    input: Record<string, unknown> = {},
+  ): Promise<SupportCase> {
+    return service.openCase({ subject: 'Broken widget', ...input });
+  }
+
+  function entryFor(
+    ranking: Awaited<ReturnType<SupportRoutingService['rankSpecialists']>>,
+    specialist: SupportSpecialist,
+  ) {
+    const entry = ranking.find(
+      (candidate) => candidate.specialistId === specialist.id,
+    );
+    if (!entry) throw new Error(`specialist missing from ranking`);
+    return entry;
+  }
+
+  describe('rankSpecialists', () => {
+    it('hard-filters on an effective project qualification, keeping the failing factor visible', async () => {
+      const qualified = await makeSpecialist();
+      const unqualified = await makeSpecialist();
+      const expired = await makeSpecialist();
+      for (const specialist of [qualified, unqualified, expired]) {
+        await allDayWeekly(specialist);
+      }
+      await qualifications.create({
+        specialistId: qualified.id,
+        projectId: 'proj-1',
+        level: 'qualified',
+      });
+      await qualifications.create({
+        specialistId: expired.id,
+        projectId: 'proj-1',
+        level: 'expert',
+        effectiveTo: new Date('2025-12-31T00:00:00Z'),
+      });
+
+      const supportCase = await openCase({ projectId: 'proj-1' });
+      const ranking = await routing.rankSpecialists(supportCase, { at: AT });
+
+      const winner = entryFor(ranking, qualified);
+      expect(winner.eligible).toBe(true);
+      expect(winner.factors.projectQualification).toBe('qualified');
+
+      const missing = entryFor(ranking, unqualified);
+      expect(missing.eligible).toBe(false);
+      expect(missing.factors.projectQualification).toBe('none');
+
+      const lapsed = entryFor(ranking, expired);
+      expect(lapsed.eligible).toBe(false);
+      expect(lapsed.factors.projectQualification).toBe('expired');
+    });
+
+    it('excludes specialists at their workload cap, with the open-case factor', async () => {
+      const busy = await makeSpecialist({ maxConcurrentCases: 1 });
+      const free = await makeSpecialist();
+      await allDayWeekly(busy);
+      await allDayWeekly(free);
+      const otherCase = await openCase();
+      await service.assign(otherCase, {
+        actorKind: 'system',
+        specialistId: busy.id ?? '',
+      });
+
+      const ranking = await routing.rankSpecialists(await openCase(), {
+        at: AT,
+      });
+
+      const overloaded = entryFor(ranking, busy);
+      expect(overloaded.eligible).toBe(false);
+      expect(overloaded.factors.workloadExceeded).toBe(true);
+      expect(overloaded.factors.openCases).toBe(1);
+      expect(entryFor(ranking, free).eligible).toBe(true);
+    });
+
+    it('evaluates weekly windows in the specialist timezone', async () => {
+      const newYorker = await makeSpecialist({ timezone: 'America/New_York' });
+      await availabilities.create({
+        specialistId: newYorker.id,
+        kind: 'weekly',
+        weekday: 1,
+        startMinute: 9 * 60,
+        endMinute: 17 * 60,
+      });
+      const supportCase = await openCase();
+
+      // 14:00 UTC = 09:00 New York — inside the window.
+      const inside = await routing.rankSpecialists(supportCase, { at: AT });
+      expect(entryFor(inside, newYorker).eligible).toBe(true);
+      expect(entryFor(inside, newYorker).factors.weeklyAvailable).toBe(true);
+
+      // 13:00 UTC = 08:00 New York — before the window opens.
+      const outside = await routing.rankSpecialists(supportCase, {
+        at: new Date('2026-01-05T13:00:00Z'),
+      });
+      expect(entryFor(outside, newYorker).eligible).toBe(false);
+      expect(entryFor(outside, newYorker).factors.weeklyAvailable).toBe(false);
+    });
+
+    it('includes active on-call spans and excludes time-off spans', async () => {
+      const onCall = await makeSpecialist();
+      await availabilities.create({
+        specialistId: onCall.id,
+        kind: 'on_call',
+        startsAt: new Date('2026-01-05T00:00:00Z'),
+        endsAt: new Date('2026-01-06T00:00:00Z'),
+      });
+      const away = await makeSpecialist();
+      await allDayWeekly(away);
+      await availabilities.create({
+        specialistId: away.id,
+        kind: 'time_off',
+        startsAt: new Date('2026-01-04T00:00:00Z'),
+        endsAt: new Date('2026-01-07T00:00:00Z'),
+      });
+
+      const ranking = await routing.rankSpecialists(await openCase(), {
+        at: AT,
+      });
+
+      const reachable = entryFor(ranking, onCall);
+      expect(reachable.eligible).toBe(true);
+      expect(reachable.factors.onCall).toBe(true);
+
+      const excluded = entryFor(ranking, away);
+      expect(excluded.eligible).toBe(false);
+      expect(excluded.factors.timeOff).toBe(true);
+    });
+
+    it('marks inactive specialists ineligible with the status factor', async () => {
+      const inactive = await makeSpecialist({ status: 'inactive' });
+      await allDayWeekly(inactive);
+
+      const ranking = await routing.rankSpecialists(await openCase(), {
+        at: AT,
+      });
+      const entry = entryFor(ranking, inactive);
+      expect(entry.eligible).toBe(false);
+      expect(entry.factors.status).toBe('inactive');
+    });
+
+    it('ranks the preferred specialist above a better-qualified alternative', async () => {
+      const preferred = await makeSpecialist();
+      const expert = await makeSpecialist();
+      await allDayWeekly(preferred);
+      await allDayWeekly(expert);
+      await qualifications.create({
+        specialistId: preferred.id,
+        projectId: 'proj-1',
+        level: 'trainee',
+      });
+      await qualifications.create({
+        specialistId: expert.id,
+        projectId: 'proj-1',
+        level: 'expert',
+      });
+
+      const supportCase = await openCase({
+        projectId: 'proj-1',
+        preferredSpecialistId: preferred.id,
+      });
+      const ranking = await routing.rankSpecialists(supportCase, { at: AT });
+
+      expect(ranking[0]?.specialistId).toBe(preferred.id);
+      expect(ranking[0]?.factors.preferred).toBe(true);
+      expect(ranking[0]?.score).toBeGreaterThan(
+        entryFor(ranking, expert).score,
+      );
+    });
+
+    it('applies the language bonus from case metadata', async () => {
+      const francophone = await makeSpecialist({
+        languages: '["en","fr"]',
+      });
+      const anglophone = await makeSpecialist();
+      await allDayWeekly(francophone);
+      await allDayWeekly(anglophone);
+
+      const supportCase = await openCase({ metadata: { language: 'fr' } });
+      const ranking = await routing.rankSpecialists(supportCase, { at: AT });
+
+      const bonus = entryFor(ranking, francophone);
+      expect(bonus.factors.languageMatch).toBe(true);
+      expect(bonus.score).toBe(entryFor(ranking, anglophone).score + 10);
+      expect(ranking[0]?.specialistId).toBe(francophone.id);
+    });
+
+    it('orders deterministically: score, then display name', async () => {
+      const bravo = await makeSpecialist({ displayName: 'Bravo' });
+      const alpha = await makeSpecialist({ displayName: 'Alpha' });
+      await allDayWeekly(bravo);
+      await allDayWeekly(alpha);
+
+      const ranking = await routing.rankSpecialists(await openCase(), {
+        at: AT,
+      });
+      expect(ranking.map((entry) => entry.displayName)).toEqual([
+        'Alpha',
+        'Bravo',
+      ]);
+    });
+  });
+
+  describe('autoAssign', () => {
+    it('assigns the top eligible specialist with an explainable rationale', async () => {
+      const winner = await makeSpecialist({ onCallPriority: 2 });
+      const runnerUp = await makeSpecialist();
+      await allDayWeekly(winner);
+      await allDayWeekly(runnerUp);
+
+      const supportCase = await openCase();
+      const result = await routing.autoAssign(supportCase, { at: AT });
+
+      expect(result.assigned).toBe(true);
+      expect(result.specialistId).toBe(winner.id);
+
+      const reloaded = await service.getCase(supportCase.id ?? '');
+      expect(reloaded.assignedSpecialistId).toBe(winner.id);
+      expect(reloaded.status).toBe('assigned');
+
+      const events = await service.events.forCase(supportCase.id ?? '', {
+        eventType: 'assignment',
+      });
+      expect(events).toHaveLength(1);
+      const payload = events[0]?.getPayload() as {
+        specialistId?: string;
+        rationale?: {
+          factors?: Record<string, unknown>;
+          ranking?: Array<{ specialistId: string }>;
+        };
+      };
+      expect(payload.specialistId).toBe(winner.id);
+      expect(payload.rationale?.factors?.weeklyAvailable).toBe(true);
+      expect(payload.rationale?.ranking?.length).toBeLessThanOrEqual(3);
+      expect(payload.rationale?.ranking?.[0]?.specialistId).toBe(winner.id);
+    });
+
+    it('records an unrouted note and returns assigned:false when nobody is eligible', async () => {
+      const unavailable = await makeSpecialist(); // no availability windows
+
+      const supportCase = await openCase();
+      const result = await routing.autoAssign(supportCase, { at: AT });
+
+      expect(result.assigned).toBe(false);
+      expect(result.specialistId).toBeUndefined();
+      expect(
+        result.ranking.some((e) => e.specialistId === unavailable.id),
+      ).toBe(true);
+
+      const reloaded = await service.getCase(supportCase.id ?? '');
+      expect(reloaded.assignedSpecialistId).toBeNull();
+
+      const notes = await service.events.forCase(supportCase.id ?? '', {
+        eventType: 'note',
+      });
+      expect(notes).toHaveLength(1);
+      const payload = notes[0]?.getPayload() as {
+        unrouted?: boolean;
+        ranking?: unknown[];
+      };
+      expect(payload.unrouted).toBe(true);
+      expect(Array.isArray(payload.ranking)).toBe(true);
+    });
+  });
+
+  describe('reassign', () => {
+    it('denies principals without the reassign permission', async () => {
+      const specialist = await makeSpecialist();
+      const supportCase = await openCase();
+      await expect(
+        routing.reassign(supportCase, {
+          specialistId: specialist.id ?? '',
+          principal: supportPrincipalFromPermissions([]),
+        }),
+      ).rejects.toThrow(ReassignDeniedError);
+    });
+
+    it('denies cross-tenant reassignment even with the permission', async () => {
+      const specialist = await makeSpecialist();
+      const supportCase = await openCase({ tenantId: 'tenant-b' });
+      await expect(
+        routing.reassign(supportCase, {
+          specialistId: specialist.id ?? '',
+          principal: supportPrincipalFromPermissions(
+            [REASSIGN_CASE_PERMISSION],
+            { id: 'profile-lead', tenantId: 'tenant-a' },
+          ),
+        }),
+      ).rejects.toThrow(/tenant/);
+    });
+
+    it('reassigns with a manual rationale when authorized', async () => {
+      const specialist = await makeSpecialist();
+      const supportCase = await openCase();
+
+      const updated = await routing.reassign(supportCase, {
+        specialistId: specialist.id ?? '',
+        principal: supportPrincipalFromPermissions([REASSIGN_CASE_PERMISSION], {
+          id: 'profile-lead',
+        }),
+        note: 'Client asked for their usual contact.',
+      });
+
+      expect(updated.assignedSpecialistId).toBe(specialist.id);
+      const events = await service.events.forCase(supportCase.id ?? '', {
+        eventType: 'assignment',
+      });
+      expect(events).toHaveLength(1);
+      expect(events[0]?.actorKind).toBe('specialist');
+      expect(events[0]?.actorProfileId).toBe('profile-lead');
+      const payload = events[0]?.getPayload() as {
+        rationale?: { manual?: boolean; note?: string };
+      };
+      expect(payload.rationale?.manual).toBe(true);
+      expect(payload.rationale?.note).toBe(
+        'Client asked for their usual contact.',
+      );
+    });
+  });
+});

--- a/packages/support/src/services/support-routing-service.ts
+++ b/packages/support/src/services/support-routing-service.ts
@@ -232,6 +232,18 @@ export class SupportRoutingService {
       eligible = false;
     }
 
+    // Tenant boundary (hard filter): a case never routes to another
+    // tenant's specialist, even when ranking runs without an ambient
+    // tenant context (system/job paths list across tenants).
+    if (
+      specialist.tenantId &&
+      supportCase.tenantId &&
+      specialist.tenantId !== supportCase.tenantId
+    ) {
+      factors.tenantMismatch = true;
+      eligible = false;
+    }
+
     if (excluded.has(specialistId)) {
       factors.excluded = true;
       eligible = false;
@@ -410,6 +422,24 @@ export class SupportRoutingService {
     ) {
       throw new ReassignDeniedError(
         'Reassignment denied: principal tenant does not match the case tenant.',
+      );
+    }
+    // The target must be a real specialist in the case's tenant — an
+    // authorized caller must not be able to assign (and audit) a foreign
+    // tenant's specialist onto this case.
+    const specialist = await this.specialists.get({ id: input.specialistId });
+    if (!specialist) {
+      throw new ReassignDeniedError(
+        `Reassignment denied: unknown specialist '${input.specialistId}'.`,
+      );
+    }
+    if (
+      specialist.tenantId &&
+      supportCase.tenantId &&
+      specialist.tenantId !== supportCase.tenantId
+    ) {
+      throw new ReassignDeniedError(
+        'Reassignment denied: specialist tenant does not match the case tenant.',
       );
     }
     return this.caseService.assign(supportCase, {

--- a/packages/support/src/services/support-routing-service.ts
+++ b/packages/support/src/services/support-routing-service.ts
@@ -1,0 +1,424 @@
+/**
+ * SupportRoutingService — Project-qualified Support Case routing (FR-30).
+ *
+ * Ranks Support Specialists for a case with an **explainable** score: every
+ * hard eligibility check (active status, effective Project Support
+ * Qualification, workload cap, availability) is recorded as a factor on the
+ * ranked entry, so the queue UI can show *why* someone was or wasn't chosen.
+ * Ineligible specialists stay in the returned ranking (`eligible: false`)
+ * for that rationale display.
+ *
+ * `autoAssign` writes the assignment through {@link SupportCaseService} with
+ * the ranking rationale in the audit event; `reassign` is the manual
+ * override, gated by the `support.reassign-case` permission split and a
+ * cross-tenant guard.
+ */
+
+import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
+import type { SupportCase } from '../models/support-case.js';
+import type { SupportAvailability } from '../models/support-specialist.js';
+import {
+  SupportAvailabilityCollection,
+  SupportQualificationCollection,
+  type SupportSpecialist,
+  SupportSpecialistCollection,
+} from '../models/support-specialist.js';
+import {
+  REASSIGN_CASE_PERMISSION,
+  type SupportPrincipal,
+} from '../permissions.js';
+import type { SupportActorKind, SupportQualificationLevel } from '../types.js';
+import { zonedParts } from './coverage-calendar.js';
+import { SupportCaseService } from './support-case-service.js';
+
+/**
+ * Named scoring weights, so the ranking is auditable against the code.
+ * Factors carry the raw signals; the score composes them with these weights.
+ */
+export const ROUTING_WEIGHTS = {
+  /** Case/plan preferred specialist (FR-30) — considered first. */
+  PREFERRED_SPECIALIST: 100,
+  /** Effective `expert` Project Support Qualification. */
+  QUALIFICATION_EXPERT: 30,
+  /** Effective `qualified` Project Support Qualification. */
+  QUALIFICATION_QUALIFIED: 20,
+  /** Effective `trainee` Project Support Qualification. */
+  QUALIFICATION_TRAINEE: 5,
+  /** An active on-call span at the routing instant. */
+  ON_CALL: 25,
+  /** A weekly availability window covering the routing instant. */
+  WEEKLY_AVAILABLE: 15,
+  /** Maximum workload-headroom bonus (scaled by free capacity). */
+  WORKLOAD_HEADROOM_MAX: 10,
+  /** Case language ∈ specialist languages. */
+  LANGUAGE_MATCH: 10,
+} as const;
+
+const QUALIFICATION_WEIGHTS: Record<SupportQualificationLevel, number> = {
+  expert: ROUTING_WEIGHTS.QUALIFICATION_EXPERT,
+  qualified: ROUTING_WEIGHTS.QUALIFICATION_QUALIFIED,
+  trainee: ROUTING_WEIGHTS.QUALIFICATION_TRAINEE,
+};
+
+/** Strongest-first ordering for picking the effective qualification level. */
+const QUALIFICATION_RANK: Record<SupportQualificationLevel, number> = {
+  expert: 3,
+  qualified: 2,
+  trainee: 1,
+};
+
+/** One specialist's routing evaluation for a case. */
+export interface RankedSpecialist {
+  specialistId: string;
+  displayName: string;
+  score: number;
+  /** Whether every hard eligibility filter passed. */
+  eligible: boolean;
+  /** The raw signals behind the score/eligibility (rationale display). */
+  factors: Record<string, number | string | boolean>;
+}
+
+/** Result of an {@link SupportRoutingService.autoAssign} attempt. */
+export interface AutoAssignResult {
+  assigned: boolean;
+  specialistId?: string;
+  ranking: RankedSpecialist[];
+}
+
+/** Thrown when a manual reassignment is refused (permission or tenant). */
+export class ReassignDeniedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ReassignDeniedError';
+  }
+}
+
+/** Options for {@link SupportRoutingService.create}. */
+export interface SupportRoutingServiceOptions extends SmrtObjectOptions {
+  /** Share an existing case service (and its collections) with the router. */
+  caseService?: SupportCaseService;
+}
+
+/** Compact ranking rows embedded in assignment rationale payloads. */
+function compactRanking(
+  ranking: RankedSpecialist[],
+  limit: number,
+): Array<
+  Pick<RankedSpecialist, 'specialistId' | 'displayName' | 'score' | 'eligible'>
+> {
+  return ranking.slice(0, limit).map((entry) => ({
+    specialistId: entry.specialistId,
+    displayName: entry.displayName,
+    score: entry.score,
+    eligible: entry.eligible,
+  }));
+}
+
+/** Whether an absolute availability span covers the instant. */
+function spanActiveAt(window: SupportAvailability, at: Date): boolean {
+  if (!window.startsAt) {
+    return false; // A span without a start never activates.
+  }
+  if (window.startsAt.getTime() > at.getTime()) {
+    return false;
+  }
+  return window.endsAt === null || at.getTime() < window.endsAt.getTime();
+}
+
+/**
+ * The routing engine. Construct with {@link SupportRoutingService.create}.
+ */
+export class SupportRoutingService {
+  readonly caseService: SupportCaseService;
+  readonly specialists: SupportSpecialistCollection;
+  readonly qualifications: SupportQualificationCollection;
+  readonly availabilities: SupportAvailabilityCollection;
+
+  protected constructor(collections: {
+    caseService: SupportCaseService;
+    specialists: SupportSpecialistCollection;
+    qualifications: SupportQualificationCollection;
+    availabilities: SupportAvailabilityCollection;
+  }) {
+    this.caseService = collections.caseService;
+    this.specialists = collections.specialists;
+    this.qualifications = collections.qualifications;
+    this.availabilities = collections.availabilities;
+  }
+
+  static async create(
+    options: SupportRoutingServiceOptions,
+  ): Promise<SupportRoutingService> {
+    const { caseService, ...smrtOptions } = options;
+    const [service, specialists, qualifications, availabilities] =
+      await Promise.all([
+        caseService ?? SupportCaseService.create(smrtOptions),
+        SupportSpecialistCollection.create(smrtOptions),
+        SupportQualificationCollection.create(smrtOptions),
+        SupportAvailabilityCollection.create(smrtOptions),
+      ]);
+    return new SupportRoutingService({
+      caseService: service,
+      specialists,
+      qualifications,
+      availabilities,
+    });
+  }
+
+  private async resolveCase(
+    caseRef: SupportCase | string,
+  ): Promise<SupportCase> {
+    return typeof caseRef === 'string'
+      ? this.caseService.getCase(caseRef)
+      : caseRef;
+  }
+
+  /**
+   * Rank every Support Specialist for a case at an instant.
+   *
+   * Hard eligibility filters — each recorded as a factor:
+   * - `status` must be `active`;
+   * - when the case carries a `projectId`, an *effective* Project Support
+   *   Qualification for that project (`projectQualification` is the level,
+   *   or `'expired'`/`'none'` on failure);
+   * - open assigned cases below `maxConcurrentCases` (`openCases`,
+   *   `workloadExceeded`);
+   * - available at `at`: a weekly window in the specialist's own timezone or
+   *   an active on-call span, and not inside a time-off span
+   *   (`weeklyAvailable`, `onCall`, `timeOff`).
+   *
+   * Ineligible specialists are returned too (`eligible: false`) so the UI
+   * can show the failing factor. Sorted by score descending, then display
+   * name, then id.
+   */
+  async rankSpecialists(
+    caseRef: SupportCase | string,
+    opts: { at?: Date; exclude?: string[] } = {},
+  ): Promise<RankedSpecialist[]> {
+    const supportCase = await this.resolveCase(caseRef);
+    const at = opts.at ?? new Date();
+    const excluded = new Set(opts.exclude ?? []);
+
+    const specialists = await this.specialists.list({});
+    const ranked: RankedSpecialist[] = [];
+
+    for (const specialist of specialists) {
+      ranked.push(
+        await this.evaluateSpecialist(supportCase, specialist, at, excluded),
+      );
+    }
+
+    return ranked.sort(
+      (a, b) =>
+        b.score - a.score ||
+        a.displayName.localeCompare(b.displayName) ||
+        a.specialistId.localeCompare(b.specialistId),
+    );
+  }
+
+  private async evaluateSpecialist(
+    supportCase: SupportCase,
+    specialist: SupportSpecialist,
+    at: Date,
+    excluded: Set<string>,
+  ): Promise<RankedSpecialist> {
+    const specialistId = specialist.id ?? '';
+    const factors: Record<string, number | string | boolean> = {};
+    let eligible = true;
+    let score = 0;
+
+    factors.status = specialist.status;
+    if (!specialist.isActive()) {
+      eligible = false;
+    }
+
+    if (excluded.has(specialistId)) {
+      factors.excluded = true;
+      eligible = false;
+    }
+
+    // Project Support Qualification (hard filter when the case has a project).
+    if (supportCase.projectId) {
+      const qualifications = (
+        await this.qualifications.forSpecialist(specialistId)
+      ).filter((q) => q.projectId === supportCase.projectId);
+      const effective = qualifications.filter((q) => q.isEffectiveAt(at));
+      if (effective.length > 0) {
+        const level = effective
+          .map((q) => q.level)
+          .sort((a, b) => QUALIFICATION_RANK[b] - QUALIFICATION_RANK[a])[0];
+        factors.projectQualification = level;
+        score += QUALIFICATION_WEIGHTS[level];
+      } else {
+        factors.projectQualification =
+          qualifications.length > 0 ? 'expired' : 'none';
+        eligible = false;
+      }
+    }
+
+    // Workload cap.
+    const openCases = await this.caseService.cases.findQueue({
+      assignedSpecialistId: specialistId,
+      openOnly: true,
+      limit: 1000,
+    });
+    factors.openCases = openCases.length;
+    factors.maxConcurrentCases = specialist.maxConcurrentCases;
+    if (openCases.length >= specialist.maxConcurrentCases) {
+      factors.workloadExceeded = true;
+      eligible = false;
+    } else if (specialist.maxConcurrentCases > 0) {
+      score += Math.round(
+        (ROUTING_WEIGHTS.WORKLOAD_HEADROOM_MAX *
+          (specialist.maxConcurrentCases - openCases.length)) /
+          specialist.maxConcurrentCases,
+      );
+    }
+
+    // Availability at `at`, in the specialist's own timezone.
+    const windows = await this.availabilities.forSpecialist(specialistId);
+    const wall = zonedParts(at, specialist.timezone || 'UTC');
+    const weeklyAvailable = windows.some(
+      (window) =>
+        window.kind === 'weekly' &&
+        window.weekday === wall.weekday &&
+        wall.minuteOfDay >= window.startMinute &&
+        wall.minuteOfDay < window.endMinute,
+    );
+    const onCall = windows.some(
+      (window) => window.kind === 'on_call' && spanActiveAt(window, at),
+    );
+    const timeOff = windows.some(
+      (window) => window.kind === 'time_off' && spanActiveAt(window, at),
+    );
+    factors.weeklyAvailable = weeklyAvailable;
+    factors.onCall = onCall;
+    factors.timeOff = timeOff;
+    if (timeOff || (!weeklyAvailable && !onCall)) {
+      eligible = false;
+    }
+    if (onCall) {
+      score += ROUTING_WEIGHTS.ON_CALL;
+    }
+    if (weeklyAvailable) {
+      score += ROUTING_WEIGHTS.WEEKLY_AVAILABLE;
+    }
+
+    // Soft preferences.
+    if (
+      supportCase.preferredSpecialistId &&
+      supportCase.preferredSpecialistId === specialistId
+    ) {
+      factors.preferred = true;
+      score += ROUTING_WEIGHTS.PREFERRED_SPECIALIST;
+    }
+
+    const language = supportCase.getMetadata().language;
+    if (
+      typeof language === 'string' &&
+      language.length > 0 &&
+      specialist.getLanguages().includes(language)
+    ) {
+      factors.languageMatch = true;
+      score += ROUTING_WEIGHTS.LANGUAGE_MATCH;
+    }
+
+    // Final tie-break: on-call priority added directly.
+    if (specialist.onCallPriority !== 0) {
+      factors.onCallPriority = specialist.onCallPriority;
+      score += specialist.onCallPriority;
+    }
+
+    return {
+      specialistId,
+      displayName: specialist.displayName || specialistId,
+      score,
+      eligible,
+      factors,
+    };
+  }
+
+  /**
+   * Assign the top eligible ranked specialist, recording the rationale
+   * (winning factors plus the compact top of the ranking) on the assignment
+   * event. When no one is eligible, records an unrouted `note` event with
+   * the full ranking and returns `assigned: false`.
+   */
+  async autoAssign(
+    caseRef: SupportCase | string,
+    opts: {
+      at?: Date;
+      exclude?: string[];
+      actorKind?: SupportActorKind;
+    } = {},
+  ): Promise<AutoAssignResult> {
+    const supportCase = await this.resolveCase(caseRef);
+    const ranking = await this.rankSpecialists(supportCase, {
+      at: opts.at,
+      exclude: opts.exclude,
+    });
+    const top = ranking.find((entry) => entry.eligible);
+
+    if (!top) {
+      await this.caseService.recordEvent(supportCase, 'note', {
+        actorKind: opts.actorKind ?? 'system',
+        occurredAt: opts.at,
+        summary: 'Routing found no eligible specialist',
+        payload: {
+          unrouted: true,
+          ranking: compactRanking(ranking, ranking.length),
+        },
+      });
+      return { assigned: false, ranking };
+    }
+
+    await this.caseService.assign(supportCase, {
+      actorKind: opts.actorKind ?? 'system',
+      specialistId: top.specialistId,
+      rationale: {
+        factors: top.factors,
+        ranking: compactRanking(ranking, 3),
+      },
+    });
+    return { assigned: true, specialistId: top.specialistId, ranking };
+  }
+
+  /**
+   * Manual reassignment override (FR-30). Requires the
+   * `support.reassign-case` permission split on the acting principal and
+   * refuses cross-tenant acts; the assignment event carries
+   * `{ manual: true, note }` as its rationale.
+   */
+  async reassign(
+    caseRef: SupportCase | string,
+    input: {
+      specialistId: string;
+      principal: SupportPrincipal;
+      note?: string;
+    },
+  ): Promise<SupportCase> {
+    if (!input.principal.can(REASSIGN_CASE_PERMISSION)) {
+      throw new ReassignDeniedError(
+        `Reassignment denied: principal lacks '${REASSIGN_CASE_PERMISSION}'.`,
+      );
+    }
+    const supportCase = await this.resolveCase(caseRef);
+    if (
+      input.principal.tenantId &&
+      supportCase.tenantId &&
+      input.principal.tenantId !== supportCase.tenantId
+    ) {
+      throw new ReassignDeniedError(
+        'Reassignment denied: principal tenant does not match the case tenant.',
+      );
+    }
+    return this.caseService.assign(supportCase, {
+      actorKind: 'specialist',
+      actorProfileId: input.principal.id ?? null,
+      specialistId: input.specialistId,
+      rationale: { manual: true, note: input.note ?? null },
+    });
+  }
+}
+
+export default SupportRoutingService;

--- a/packages/support/src/services/time-entry-approval-service.test.ts
+++ b/packages/support/src/services/time-entry-approval-service.test.ts
@@ -411,7 +411,97 @@ describe('TimeEntryApprovalService', () => {
     });
   });
 
+  describe('approval retryability (partial-failure recovery)', () => {
+    it('re-approving after a partial settlement write refreshes the same rows without double-counting', async () => {
+      const plan = await planWith(
+        { mode: 'automatic' },
+        { includedMinutes: 60, overageHourlyRate: 120.0 },
+      );
+      const supportCase = await caseUnder(plan);
+      const entry = await submittedEntry(supportCase.id ?? '', {
+        durationSeconds: 5400, // 60 included + 30 metered
+      });
+
+      // Simulate the failure mode codex flagged (P1, PR #1943): a prior
+      // approval attempt wrote the settlement rows but died before the
+      // entry flipped to 'approved' — the entry is still 'submitted' with a
+      // stale charge row present.
+      await approvalService.charges.create({
+        tenantId: entry.tenantId,
+        timeEntryId: entry.id ?? '',
+        caseId: entry.caseId,
+        planId: plan.id,
+        amount: 999,
+        currency: 'USD',
+        billableSeconds: 5400,
+        includedSecondsApplied: 3600,
+        rateSnapshot: JSON.stringify({ stale: true }),
+        status: 'final',
+        finalizedAt: APPROVE_AT,
+      });
+
+      const result = await approvalService.approve(entry.id ?? '', {
+        at: APPROVE_AT,
+      });
+      expect(result.entry.status).toBe('approved');
+      // The retry refreshed the SAME row: correct amount, no self
+      // double-count of the included allowance, and still exactly one
+      // charge + one compensation for the entry.
+      expect(result.charge.amount).toBeCloseTo(60.0, 2);
+      expect(result.charge.includedSecondsApplied).toBe(3600);
+      expect(result.charge.getRateSnapshot()).toMatchObject({
+        includedSecondsBefore: 3600,
+      });
+      const charges = await approvalService.charges.forCase(
+        supportCase.id ?? '',
+      );
+      expect(charges).toHaveLength(1);
+      const compensation = await approvalService.compensations.forTimeEntry(
+        entry.id ?? '',
+      );
+      expect(compensation).not.toBeNull();
+    });
+  });
+
   describe('corrections', () => {
+    it('releases the corrected charge’s included time back to the case', async () => {
+      const plan = await planWith(
+        { mode: 'automatic' },
+        { includedMinutes: 60, overageHourlyRate: 120.0 },
+      );
+      const supportCase = await caseUnder(plan);
+
+      // A 60-minute entry consumes the whole included allowance.
+      const entry = await submittedEntry(supportCase.id ?? '', {
+        durationSeconds: 3600,
+      });
+      const approved = await approvalService.approve(entry.id ?? '', {
+        at: APPROVE_AT,
+      });
+      expect(approved.charge.amount).toBeCloseTo(0, 2);
+      expect(approved.charge.includedSecondsApplied).toBe(3600);
+
+      // Correcting it down to 30 minutes releases the allowance — the
+      // replacement must consume included time again, not bill overage
+      // (codex P1, PR #1943).
+      const { correction } = await approvalService.correct(entry.id ?? '', {
+        principal: operator(),
+        patch: { durationSeconds: 1800 },
+        note: 'over-recorded',
+      });
+      await entryService.submit(correction, {
+        byProfileId: 'profile-worker-1',
+      });
+      const reApproved = await approvalService.approve(correction.id ?? '', {
+        at: APPROVE_AT,
+      });
+      expect(reApproved.charge.includedSecondsApplied).toBe(1800);
+      expect(reApproved.charge.amount).toBeCloseTo(0, 2);
+      expect(reApproved.charge.getRateSnapshot()).toMatchObject({
+        includedSecondsBefore: 3600,
+      });
+    });
+
     it('supersedes the original and re-derives fresh snapshots from the patch', async () => {
       const plan = await planWith(
         { mode: 'automatic' },

--- a/packages/support/src/services/time-entry-approval-service.test.ts
+++ b/packages/support/src/services/time-entry-approval-service.test.ts
@@ -447,6 +447,38 @@ describe('TimeEntryApprovalService', () => {
     });
   });
 
+  describe('concurrent approvals', () => {
+    it('never over-consumes included time when two approvals race on one case', async () => {
+      const plan = await planWith(
+        { mode: 'automatic' },
+        { includedMinutes: 60, overageHourlyRate: 120.0 },
+      );
+      const supportCase = await caseUnder(plan);
+      const first = await submittedEntry(supportCase.id ?? '', {
+        durationSeconds: 3600,
+      });
+      const second = await submittedEntry(supportCase.id ?? '', {
+        durationSeconds: 3600,
+      });
+
+      // Both 60-minute entries race a 60-minute allowance: exactly one may
+      // consume it; the other bills the full hour (codex review round 2,
+      // PR #1943 — approvals serialize per case).
+      const [a, b] = await Promise.all([
+        approvalService.approve(first.id ?? '', { at: APPROVE_AT }),
+        approvalService.approve(second.id ?? '', { at: APPROVE_AT }),
+      ]);
+
+      const amounts = [a.charge.amount, b.charge.amount].sort((x, y) => x - y);
+      expect(amounts[0]).toBeCloseTo(0, 2);
+      expect(amounts[1]).toBeCloseTo(120.0, 2);
+      const consumed =
+        (a.charge.includedSecondsApplied ?? 0) +
+        (b.charge.includedSecondsApplied ?? 0);
+      expect(consumed).toBe(3600);
+    });
+  });
+
   describe('approval retryability (partial-failure recovery)', () => {
     it('re-approving after a partial settlement write refreshes the same rows without double-counting', async () => {
       const plan = await planWith(

--- a/packages/support/src/services/time-entry-approval-service.test.ts
+++ b/packages/support/src/services/time-entry-approval-service.test.ts
@@ -335,6 +335,42 @@ describe('TimeEntryApprovalService', () => {
       expect(compensation.getRateSnapshot()).not.toHaveProperty('margin');
     });
 
+    it("never prices work with another tenant's default plan", async () => {
+      // A foreign tenant's default plan exists and is newer/richer.
+      await approvalService.compensationPlans.create({
+        tenantId: 'tenant-other',
+        specialistId: null,
+        name: 'Foreign default',
+        hourlyRate: 500.0,
+        effectiveFrom: new Date('2026-01-02T00:00:00.000Z'),
+      });
+      await approvalService.compensationPlans.create({
+        tenantId: 'tenant-1',
+        specialistId: null,
+        name: 'Own default',
+        hourlyRate: 30.0,
+        effectiveFrom: new Date('2026-01-01T00:00:00.000Z'),
+      });
+
+      const plan = await planWith(
+        { mode: 'automatic' },
+        { overageHourlyRate: 120.0 },
+      );
+      const supportCase = await caseUnder(plan, { tenantId: 'tenant-1' });
+      const entry = await submittedEntry(supportCase.id ?? '', {
+        specialistId: 'spec-1',
+        durationSeconds: 3600,
+      });
+
+      const { compensation } = await approvalService.approve(entry.id ?? '', {
+        at: APPROVE_AT,
+      });
+      // Resolution is scoped to the entry's tenant (codex review, PR
+      // #1943): the foreign default never applies.
+      expect(compensation.amount).toBeCloseTo(30.0, 2);
+      expect(compensation.getRateSnapshot()).toMatchObject({ hourlyRate: 30 });
+    });
+
     it('falls back to the tenant default when the specific plan has expired', async () => {
       await approvalService.compensationPlans.create({
         specialistId: 'spec-1',

--- a/packages/support/src/services/time-entry-approval-service.test.ts
+++ b/packages/support/src/services/time-entry-approval-service.test.ts
@@ -1,0 +1,629 @@
+/**
+ * TimeEntryApprovalService tests — the heart of issue #1930's acceptance
+ * criteria: the four approval paths gated by `support.approve-time-entry`,
+ * charge derivation from the Managed Support Plan (included time first, then
+ * metered overage) vs compensation derivation from the effective-dated
+ * Support Compensation Plan, immutable approved snapshots, explicit
+ * corrections, plan-edit isolation via the case's `planSnapshot`, and the
+ * tenant guard.
+ */
+
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ServiceTimeEntry } from '../models/service-time-entry.js';
+import type { SupportCase } from '../models/support-case.js';
+import type { SupportPlan } from '../models/support-plan.js';
+import {
+  APPROVE_TIME_ENTRY_PERMISSION,
+  supportPrincipalFromPermissions,
+} from '../permissions.js';
+import type { TimeApprovalPolicy } from '../types.js';
+import { ServiceTimeEntryService } from './service-time-entry-service.js';
+import { SupportCaseService } from './support-case-service.js';
+import {
+  TimeEntryApprovalDeniedError,
+  TimeEntryApprovalService,
+} from './time-entry-approval-service.js';
+
+const MODEL_NAMES = [
+  'SupportCase',
+  'SupportInteraction',
+  'SupportCaseEvent',
+  'SupportWorkLink',
+  'SupportPlan',
+  'SupportSpecialist',
+  'SupportCompensationPlan',
+  'ServiceTimeEntry',
+  'SupportCharge',
+  'SupportCompensation',
+];
+
+const APPROVE_AT = new Date('2026-07-01T12:00:00.000Z');
+const WORK_ENDED_AT = new Date('2026-07-01T11:00:00.000Z');
+
+const operator = (extra: { id?: string; tenantId?: string } = {}) =>
+  supportPrincipalFromPermissions([APPROVE_TIME_ENTRY_PERMISSION], {
+    id: 'operator-1',
+    ...extra,
+  });
+
+describe('TimeEntryApprovalService', () => {
+  let ctx: Awaited<ReturnType<typeof createIsolatedTestDbFromManifest>>;
+  let caseService: SupportCaseService;
+  let entryService: ServiceTimeEntryService;
+  let approvalService: TimeEntryApprovalService;
+
+  beforeEach(async () => {
+    ctx = await createIsolatedTestDbFromManifest({
+      includeObjects: MODEL_NAMES,
+    });
+    caseService = await SupportCaseService.create({ db: ctx.db });
+    entryService = await ServiceTimeEntryService.create({
+      db: ctx.db,
+      caseService,
+    });
+    approvalService = await TimeEntryApprovalService.create({
+      db: ctx.db,
+      caseService,
+    });
+  });
+
+  afterEach(async () => {
+    await ctx.cleanup();
+  });
+
+  async function planWith(
+    policy: TimeApprovalPolicy,
+    fields: Record<string, unknown> = {},
+  ): Promise<SupportPlan> {
+    return caseService.plans.create({
+      planKey: 'managed',
+      name: 'Managed',
+      timeApprovalPolicy: JSON.stringify(policy),
+      ...fields,
+    });
+  }
+
+  async function caseUnder(
+    plan: SupportPlan | null,
+    fields: Record<string, unknown> = {},
+  ): Promise<SupportCase> {
+    return caseService.openCase({
+      subject: 'time-approval case',
+      planId: plan?.id ?? null,
+      ...fields,
+    });
+  }
+
+  async function submittedEntry(
+    caseId: string,
+    overrides: Record<string, unknown> = {},
+  ): Promise<ServiceTimeEntry> {
+    const entry = await entryService.record({
+      caseId,
+      participantKind: 'human',
+      participantProfileId: 'profile-worker-1',
+      source: 'manual',
+      description: 'debugging',
+      durationSeconds: 3600,
+      endedAt: WORK_ENDED_AT,
+      ...overrides,
+    });
+    return entryService.submit(entry, { byProfileId: 'profile-worker-1' });
+  }
+
+  describe('approval paths (FR-36)', () => {
+    it('approves under-threshold entries automatically, with no principal', async () => {
+      const plan = await planWith(
+        { mode: 'automatic' },
+        { overageHourlyRate: 100.0 },
+      );
+      const supportCase = await caseUnder(plan);
+      const entry = await submittedEntry(supportCase.id ?? '', {
+        durationSeconds: 1800,
+      });
+
+      const result = await approvalService.approve(entry, { at: APPROVE_AT });
+
+      expect(result.path).toBe('automatic');
+      expect(result.entry.status).toBe('approved');
+      expect(result.entry.approvedAt).toEqual(APPROVE_AT);
+      expect(result.entry.approvedByProfileId).toBeNull();
+      expect(result.entry.approvalPath).toBe('automatic');
+    });
+
+    it('escalates over-threshold automatic entries to an operator', async () => {
+      const plan = await planWith(
+        { mode: 'automatic', thresholdMinutes: 60 },
+        { overageHourlyRate: 100.0 },
+      );
+      const supportCase = await caseUnder(plan);
+      const entry = await submittedEntry(supportCase.id ?? '', {
+        durationSeconds: 7200,
+      });
+
+      await expect(
+        approvalService.approve(entry.id ?? '', { at: APPROVE_AT }),
+      ).rejects.toThrow(TimeEntryApprovalDeniedError);
+
+      const result = await approvalService.approve(entry.id ?? '', {
+        principal: operator(),
+        at: APPROVE_AT,
+      });
+      expect(result.path).toBe('threshold');
+      expect(result.entry.approvedByProfileId).toBe('operator-1');
+    });
+
+    it('gates the operator path on the approve-time-entry split', async () => {
+      const plan = await planWith({ mode: 'operator' });
+      const supportCase = await caseUnder(plan);
+      const entry = await submittedEntry(supportCase.id ?? '');
+
+      await expect(
+        approvalService.approve(entry.id ?? '', { at: APPROVE_AT }),
+      ).rejects.toThrow(TimeEntryApprovalDeniedError);
+      await expect(
+        approvalService.approve(entry.id ?? '', {
+          principal: supportPrincipalFromPermissions([], { id: 'nobody' }),
+          at: APPROVE_AT,
+        }),
+      ).rejects.toThrow(/operator approval requires/);
+
+      const result = await approvalService.approve(entry.id ?? '', {
+        principal: operator(),
+        at: APPROVE_AT,
+      });
+      expect(result.path).toBe('operator');
+    });
+
+    it('lets the case client approve under client mode, with the operator split as override', async () => {
+      const plan = await planWith({ mode: 'client' });
+      const supportCase = await caseUnder(plan, {
+        clientProfileId: 'client-1',
+      });
+
+      const first = await submittedEntry(supportCase.id ?? '');
+      const asClient = await approvalService.approve(first.id ?? '', {
+        principal: supportPrincipalFromPermissions([], { id: 'client-1' }),
+        at: APPROVE_AT,
+      });
+      expect(asClient.path).toBe('client');
+
+      const second = await submittedEntry(supportCase.id ?? '');
+      await expect(
+        approvalService.approve(second.id ?? '', {
+          principal: supportPrincipalFromPermissions([], { id: 'stranger' }),
+          at: APPROVE_AT,
+        }),
+      ).rejects.toThrow(TimeEntryApprovalDeniedError);
+
+      const asOperator = await approvalService.approve(second.id ?? '', {
+        principal: operator(),
+        at: APPROVE_AT,
+      });
+      expect(asOperator.path).toBe('client');
+    });
+  });
+
+  describe('charge derivation (Managed Support Plan side)', () => {
+    it('consumes included time first, then meters the overage per case', async () => {
+      const plan = await planWith(
+        { mode: 'automatic' },
+        { includedMinutes: 60, overageHourlyRate: 120.0 },
+      );
+      const supportCase = await caseUnder(plan);
+
+      // 90 minutes: 60 included + 30 metered → 0.5h × 120 = 60.00
+      const first = await submittedEntry(supportCase.id ?? '', {
+        durationSeconds: 5400,
+      });
+      const firstResult = await approvalService.approve(first.id ?? '', {
+        at: APPROVE_AT,
+      });
+      expect(firstResult.charge.amount).toBeCloseTo(60.0, 2);
+      expect(firstResult.charge.includedSecondsApplied).toBe(3600);
+      expect(firstResult.charge.billableSeconds).toBe(5400);
+      expect(firstResult.charge.status).toBe('final');
+      expect(firstResult.charge.finalizedAt).toEqual(APPROVE_AT);
+      expect(firstResult.charge.getRateSnapshot()).toMatchObject({
+        hourlyRate: 120,
+        rateSource: 'overage',
+        planKey: 'managed',
+        includedMinutes: 60,
+        includedSecondsBefore: 3600,
+        includedSecondsApplied: 3600,
+        derivedAt: APPROVE_AT.toISOString(),
+      });
+
+      // Second 60-minute entry on the SAME case: nothing left included.
+      const second = await submittedEntry(supportCase.id ?? '', {
+        durationSeconds: 3600,
+      });
+      const secondResult = await approvalService.approve(second.id ?? '', {
+        at: APPROVE_AT,
+      });
+      expect(secondResult.charge.amount).toBeCloseTo(120.0, 2);
+      expect(secondResult.charge.includedSecondsApplied).toBe(0);
+      expect(secondResult.charge.getRateSnapshot()).toMatchObject({
+        includedSecondsBefore: 0,
+        includedSecondsApplied: 0,
+      });
+    });
+
+    it('prices a zero-rate plan at 0 with rateSource none', async () => {
+      const plan = await planWith(
+        { mode: 'automatic' },
+        { includedMinutes: 0, overageHourlyRate: 0.0 },
+      );
+      const supportCase = await caseUnder(plan);
+      const entry = await submittedEntry(supportCase.id ?? '');
+
+      const { charge } = await approvalService.approve(entry.id ?? '', {
+        at: APPROVE_AT,
+      });
+      expect(charge.amount).toBe(0);
+      expect(charge.getRateSnapshot()).toMatchObject({ rateSource: 'none' });
+    });
+
+    it('uses the on-call rate for entries flagged onCall', async () => {
+      const plan = await planWith(
+        { mode: 'automatic' },
+        { overageHourlyRate: 120.0, onCallHourlyRate: 200.0 },
+      );
+      const supportCase = await caseUnder(plan);
+      const entry = await submittedEntry(supportCase.id ?? '', {
+        metadata: { onCall: true },
+      });
+
+      const { charge } = await approvalService.approve(entry.id ?? '', {
+        at: APPROVE_AT,
+      });
+      expect(charge.amount).toBeCloseTo(200.0, 2);
+      expect(charge.getRateSnapshot()).toMatchObject({
+        hourlyRate: 200,
+        rateSource: 'on_call',
+      });
+    });
+  });
+
+  describe('compensation derivation (Support Compensation Plan side)', () => {
+    it('prefers the specialist-specific plan over the tenant default', async () => {
+      await approvalService.compensationPlans.create({
+        specialistId: 'spec-1',
+        name: 'Specific',
+        hourlyRate: 45.0,
+        effectiveFrom: new Date('2026-01-01T00:00:00.000Z'),
+      });
+      await approvalService.compensationPlans.create({
+        specialistId: null,
+        name: 'Default',
+        hourlyRate: 30.0,
+        effectiveFrom: new Date('2026-01-01T00:00:00.000Z'),
+      });
+
+      const plan = await planWith(
+        { mode: 'automatic' },
+        { overageHourlyRate: 120.0 },
+      );
+      const supportCase = await caseUnder(plan);
+      const entry = await submittedEntry(supportCase.id ?? '', {
+        specialistId: 'spec-1',
+        durationSeconds: 7200,
+      });
+
+      const { charge, compensation } = await approvalService.approve(
+        entry.id ?? '',
+        { at: APPROVE_AT },
+      );
+      expect(compensation.amount).toBeCloseTo(90.0, 2);
+      expect(compensation.payableSeconds).toBe(7200);
+      expect(compensation.status).toBe('final');
+      expect(compensation.getRateSnapshot()).toMatchObject({
+        hourlyRate: 45,
+        derivedAt: APPROVE_AT.toISOString(),
+      });
+
+      // Margin stays computable by readers and is NEVER stored — the two
+      // sides live in separate tables with no margin column anywhere.
+      expect(charge.amount - compensation.amount).toBeCloseTo(150.0, 2);
+      expect(charge.tableName).toBe('support_charges');
+      expect(compensation.tableName).toBe('support_compensations');
+      expect(charge.tableName).not.toBe(compensation.tableName);
+      expect(Object.keys(charge.toJSON())).not.toContain('margin');
+      expect(Object.keys(compensation.toJSON())).not.toContain('margin');
+      expect(charge.getRateSnapshot()).not.toHaveProperty('margin');
+      expect(compensation.getRateSnapshot()).not.toHaveProperty('margin');
+    });
+
+    it('falls back to the tenant default when the specific plan has expired', async () => {
+      await approvalService.compensationPlans.create({
+        specialistId: 'spec-1',
+        name: 'Expired specific',
+        hourlyRate: 45.0,
+        effectiveFrom: new Date('2026-01-01T00:00:00.000Z'),
+        effectiveTo: new Date('2026-06-01T00:00:00.000Z'),
+      });
+      await approvalService.compensationPlans.create({
+        specialistId: null,
+        name: 'Default',
+        hourlyRate: 30.0,
+        effectiveFrom: new Date('2026-01-01T00:00:00.000Z'),
+      });
+
+      const plan = await planWith({ mode: 'automatic' });
+      const supportCase = await caseUnder(plan);
+      // Work instant (endedAt 2026-07-01) is past the specific plan's window.
+      const entry = await submittedEntry(supportCase.id ?? '', {
+        specialistId: 'spec-1',
+        durationSeconds: 7200,
+      });
+
+      const { compensation } = await approvalService.approve(entry.id ?? '', {
+        at: APPROVE_AT,
+      });
+      expect(compensation.amount).toBeCloseTo(60.0, 2);
+      expect(compensation.getRateSnapshot()).toMatchObject({ hourlyRate: 30 });
+    });
+
+    it('settles a zero compensation when no specialist delivered the work', async () => {
+      const plan = await planWith(
+        { mode: 'automatic' },
+        { overageHourlyRate: 120.0 },
+      );
+      const supportCase = await caseUnder(plan);
+      const entry = await submittedEntry(supportCase.id ?? '');
+
+      const { compensation } = await approvalService.approve(entry.id ?? '', {
+        at: APPROVE_AT,
+      });
+      expect(compensation.amount).toBe(0);
+      expect(compensation.compensationPlanId).toBeNull();
+      expect(compensation.getRateSnapshot()).toMatchObject({
+        rateSource: 'none',
+      });
+    });
+  });
+
+  describe('immutability of approved entries', () => {
+    it('freezes the work-defining fields and refuses a second approval', async () => {
+      const plan = await planWith(
+        { mode: 'automatic' },
+        { overageHourlyRate: 100.0 },
+      );
+      const supportCase = await caseUnder(plan);
+      const entry = await submittedEntry(supportCase.id ?? '');
+      await approvalService.approve(entry.id ?? '', { at: APPROVE_AT });
+
+      const approved = await approvalService.getEntry(entry.id ?? '');
+      approved.durationSeconds = 999_999;
+      await expect(approved.save()).rejects.toThrow(/immutable/);
+
+      const evidenceTamper = await approvalService.getEntry(entry.id ?? '');
+      evidenceTamper.setEvidence([{ kind: 'note', ref: 'fabricated' }]);
+      await expect(evidenceTamper.save()).rejects.toThrow(/immutable/);
+
+      await expect(
+        approvalService.approve(entry.id ?? '', {
+          principal: operator(),
+          at: APPROVE_AT,
+        }),
+      ).rejects.toThrow(/only 'submitted' entries can be approved/);
+    });
+  });
+
+  describe('corrections', () => {
+    it('supersedes the original and re-derives fresh snapshots from the patch', async () => {
+      const plan = await planWith(
+        { mode: 'automatic' },
+        { includedMinutes: 0, overageHourlyRate: 100.0 },
+      );
+      const supportCase = await caseUnder(plan);
+      const entry = await submittedEntry(supportCase.id ?? '', {
+        durationSeconds: 3600,
+      });
+      const approvedResult = await approvalService.approve(entry.id ?? '', {
+        at: APPROVE_AT,
+      });
+      expect(approvedResult.charge.amount).toBeCloseTo(100.0, 2);
+      const originalChargeSnapshot = approvedResult.charge.getRateSnapshot();
+
+      const { original, correction } = await approvalService.correct(
+        entry.id ?? '',
+        {
+          principal: operator(),
+          patch: { durationSeconds: 5400 },
+          note: 'client disputed the hour count',
+        },
+      );
+
+      // The original flipped to corrected with its frozen fields intact.
+      expect(original.status).toBe('corrected');
+      const reloadedOriginal = await approvalService.getEntry(entry.id ?? '');
+      expect(reloadedOriginal.status).toBe('corrected');
+      expect(reloadedOriginal.durationSeconds).toBe(3600);
+      expect(reloadedOriginal.approvedAt).toEqual(APPROVE_AT);
+
+      // And it stays frozen: editing its duration still refuses to save.
+      reloadedOriginal.durationSeconds = 4000;
+      await expect(reloadedOriginal.save()).rejects.toThrow(/immutable/);
+
+      // Its settlement rows are marked corrected, snapshots untouched.
+      const originalCharge = await approvalService.charges.forTimeEntry(
+        entry.id ?? '',
+      );
+      const originalCompensation =
+        await approvalService.compensations.forTimeEntry(entry.id ?? '');
+      expect(originalCharge?.status).toBe('corrected');
+      expect(originalCompensation?.status).toBe('corrected');
+      expect(originalCharge?.amount).toBeCloseTo(100.0, 2);
+      expect(originalCharge?.getRateSnapshot()).toEqual(originalChargeSnapshot);
+
+      // The correction is a linked draft carrying the patch.
+      expect(correction.status).toBe('draft');
+      expect(correction.correctionOfId).toBe(entry.id);
+      expect(correction.durationSeconds).toBe(5400);
+      expect(correction.caseId).toBe(supportCase.id);
+      expect(correction.getMetadata()).toMatchObject({
+        correctionNote: 'client disputed the hour count',
+      });
+
+      // It flows submit → approve normally into fresh final snapshots.
+      await entryService.submit(correction, {
+        byProfileId: 'profile-worker-1',
+      });
+      const CORRECT_AT = new Date('2026-07-02T09:00:00.000Z');
+      const corrected = await approvalService.approve(correction.id ?? '', {
+        at: CORRECT_AT,
+      });
+      expect(corrected.charge.amount).toBeCloseTo(150.0, 2);
+      expect(corrected.charge.status).toBe('final');
+      expect(corrected.charge.getRateSnapshot().derivedAt).toBe(
+        CORRECT_AT.toISOString(),
+      );
+
+      // The original's snapshot never moved.
+      const originalChargeAfter = await approvalService.charges.forTimeEntry(
+        entry.id ?? '',
+      );
+      expect(originalChargeAfter?.amount).toBeCloseTo(100.0, 2);
+      expect(originalChargeAfter?.getRateSnapshot()).toEqual(
+        originalChargeSnapshot,
+      );
+    });
+
+    it('requires the operator split and an approved original', async () => {
+      const plan = await planWith(
+        { mode: 'automatic' },
+        { overageHourlyRate: 100.0 },
+      );
+      const supportCase = await caseUnder(plan);
+      const entry = await submittedEntry(supportCase.id ?? '');
+
+      await expect(
+        approvalService.correct(entry.id ?? '', {
+          principal: operator(),
+          patch: { durationSeconds: 1200 },
+        }),
+      ).rejects.toThrow(/only 'approved' entries can be corrected/);
+
+      await approvalService.approve(entry.id ?? '', { at: APPROVE_AT });
+      await expect(
+        approvalService.correct(entry.id ?? '', {
+          principal: supportPrincipalFromPermissions([], { id: 'nobody' }),
+          patch: { durationSeconds: 1200 },
+        }),
+      ).rejects.toThrow(TimeEntryApprovalDeniedError);
+    });
+  });
+
+  it('derives from the case planSnapshot even after the live plan is edited', async () => {
+    const plan = await planWith(
+      { mode: 'automatic' },
+      { includedMinutes: 0, overageHourlyRate: 100.0 },
+    );
+    const supportCase = await caseUnder(plan);
+
+    const first = await submittedEntry(supportCase.id ?? '');
+    const firstResult = await approvalService.approve(first.id ?? '', {
+      at: APPROVE_AT,
+    });
+    expect(firstResult.charge.amount).toBeCloseTo(100.0, 2);
+
+    // Edit the live plan AFTER the case captured its snapshot.
+    plan.overageHourlyRate = 500.0;
+    await plan.save();
+
+    const second = await submittedEntry(supportCase.id ?? '');
+    const secondResult = await approvalService.approve(second.id ?? '', {
+      at: APPROVE_AT,
+    });
+    // History never rewritten: still the snapshot's 100/h, not the live 500/h.
+    expect(secondResult.charge.amount).toBeCloseTo(100.0, 2);
+    expect(secondResult.charge.getRateSnapshot()).toMatchObject({
+      hourlyRate: 100,
+    });
+  });
+
+  it('denies a principal from another tenant', async () => {
+    const plan = await planWith({ mode: 'operator' });
+    const supportCase = await caseUnder(plan, { tenantId: 'tenant-1' });
+    const entry = await submittedEntry(supportCase.id ?? '');
+    expect(entry.tenantId).toBe('tenant-1');
+
+    await expect(
+      approvalService.approve(entry.id ?? '', {
+        principal: operator({ tenantId: 'tenant-2' }),
+        at: APPROVE_AT,
+      }),
+    ).rejects.toThrow(/does not match the entry's tenant/);
+
+    const result = await approvalService.approve(entry.id ?? '', {
+      principal: operator({ tenantId: 'tenant-1' }),
+      at: APPROVE_AT,
+    });
+    expect(result.path).toBe('operator');
+  });
+
+  describe('reject', () => {
+    it('rejects a submitted entry with a reason under the operator split', async () => {
+      const plan = await planWith({ mode: 'operator' });
+      const supportCase = await caseUnder(plan);
+      const entry = await submittedEntry(supportCase.id ?? '');
+
+      await expect(
+        approvalService.reject(entry.id ?? '', {
+          principal: supportPrincipalFromPermissions([], { id: 'nobody' }),
+          reason: 'not billable',
+        }),
+      ).rejects.toThrow(TimeEntryApprovalDeniedError);
+
+      const rejected = await approvalService.reject(entry.id ?? '', {
+        principal: operator(),
+        reason: 'duplicate of an earlier entry',
+      });
+      expect(rejected.status).toBe('rejected');
+      expect(rejected.rejectedAt).toBeInstanceOf(Date);
+      expect(rejected.rejectedByProfileId).toBe('operator-1');
+      expect(rejected.rejectionReason).toBe('duplicate of an earlier entry');
+    });
+  });
+
+  it('records a case event carrying the charge amount and never the compensation', async () => {
+    await approvalService.compensationPlans.create({
+      specialistId: 'spec-1',
+      name: 'Comp',
+      hourlyRate: 45.0,
+    });
+    const plan = await planWith(
+      { mode: 'automatic' },
+      { overageHourlyRate: 120.0 },
+    );
+    const supportCase = await caseUnder(plan);
+    const entry = await submittedEntry(supportCase.id ?? '', {
+      specialistId: 'spec-1',
+    });
+
+    const { charge, compensation, path } = await approvalService.approve(
+      entry.id ?? '',
+      { at: APPROVE_AT },
+    );
+    expect(compensation.amount).toBeCloseTo(45.0, 2);
+
+    const events = await caseService.events.forCase(supportCase.id ?? '', {
+      eventType: 'time_recorded',
+    });
+    const approvalEvent = events.find(
+      (event) => (event.getPayload() as { approved?: boolean }).approved,
+    );
+    expect(approvalEvent).toBeDefined();
+    expect(approvalEvent?.getPayload()).toEqual({
+      approved: true,
+      path,
+      timeEntryId: entry.id,
+      chargeAmount: charge.amount,
+    });
+    expect(JSON.stringify(approvalEvent?.getPayload())).not.toContain(
+      'compensation',
+    );
+  });
+});

--- a/packages/support/src/services/time-entry-approval-service.ts
+++ b/packages/support/src/services/time-entry-approval-service.ts
@@ -297,15 +297,12 @@ export class TimeEntryApprovalService {
       supportCase,
     );
 
-    // Set every approval field BEFORE the save — the model's freeze engages
-    // the moment the row persists as 'approved'.
-    entry.approvedAt = at;
-    entry.approvedByProfileId = principal?.id ?? null;
-    entry.approvalPath = path;
-    entry.status = 'approved';
-    await entry.save();
-
-    const charge = await this.charges.create({
+    // Settlement rows are written BEFORE the entry flips to 'approved' so a
+    // transient failure leaves the entry 'submitted' and the whole approval
+    // retryable (codex P1, PR #1943): both writes are upserts keyed on the
+    // entry (one charge/compensation per entry), the consumption query above
+    // excludes the entry's own row, and the status flip lands last.
+    const charge = await this.upsertChargeRow(entry, {
       tenantId: entry.tenantId,
       timeEntryId: entry.id ?? '',
       caseId: entry.caseId,
@@ -330,6 +327,14 @@ export class TimeEntryApprovalService {
     });
 
     const compensation = await this.deriveCompensation(entry, at);
+
+    // Set every approval field BEFORE the save — the model's freeze engages
+    // the moment the row persists as 'approved'.
+    entry.approvedAt = at;
+    entry.approvedByProfileId = principal?.id ?? null;
+    entry.approvalPath = path;
+    entry.status = 'approved';
+    await entry.save();
 
     if (supportCase) {
       // Case-visible audit carries the client-side amount ONLY — provider
@@ -541,8 +546,16 @@ export class TimeEntryApprovalService {
     let includedSecondsBefore = 0;
     if (entry.caseId && terms.includedMinutes > 0) {
       const existing = await this.charges.forCase(entry.caseId);
+      // Only live charges consume included time: `corrected`/`voided` rows
+      // release their allowance back to the case (codex P1, PR #1943), and
+      // the entry's own row is excluded so an approval retry after a partial
+      // failure never double-counts itself.
       const consumed = existing
-        .filter((charge) => charge.status !== 'voided')
+        .filter(
+          (charge) =>
+            (charge.status === 'final' || charge.status === 'pending') &&
+            charge.timeEntryId !== entry.id,
+        )
         .reduce((sum, charge) => sum + (charge.includedSecondsApplied ?? 0), 0);
       includedSecondsBefore = Math.max(
         0,
@@ -588,7 +601,7 @@ export class TimeEntryApprovalService {
     const payableSeconds = entry.durationSeconds;
 
     if (!plan) {
-      return this.compensations.create({
+      return this.upsertCompensationRow(entry, {
         tenantId: entry.tenantId,
         timeEntryId: entry.id ?? '',
         specialistId: entry.specialistId,
@@ -606,7 +619,7 @@ export class TimeEntryApprovalService {
     }
 
     const amount = roundMoney((payableSeconds / 3600) * plan.hourlyRate);
-    return this.compensations.create({
+    return this.upsertCompensationRow(entry, {
       tenantId: entry.tenantId,
       timeEntryId: entry.id ?? '',
       specialistId: entry.specialistId,
@@ -625,6 +638,42 @@ export class TimeEntryApprovalService {
       status: 'final',
       finalizedAt: at,
     });
+  }
+
+  /**
+   * Idempotent write of the entry's single charge row: an approval retry
+   * after a partial failure refreshes the existing row instead of colliding
+   * on the `time_entry_id` unique key.
+   */
+  protected async upsertChargeRow(
+    entry: ServiceTimeEntry,
+    fields: Record<string, unknown>,
+  ): Promise<SupportCharge> {
+    const existing = entry.id
+      ? await this.charges.forTimeEntry(entry.id)
+      : null;
+    if (!existing) {
+      return this.charges.create(fields);
+    }
+    Object.assign(existing, fields);
+    await existing.save();
+    return existing;
+  }
+
+  /** Idempotent write of the entry's single compensation row (see above). */
+  protected async upsertCompensationRow(
+    entry: ServiceTimeEntry,
+    fields: Record<string, unknown>,
+  ): Promise<SupportCompensation> {
+    const existing = entry.id
+      ? await this.compensations.forTimeEntry(entry.id)
+      : null;
+    if (!existing) {
+      return this.compensations.create(fields);
+    }
+    Object.assign(existing, fields);
+    await existing.save();
+    return existing;
   }
 
   /** Cross-tenant acts are refused when both sides carry a tenant. */

--- a/packages/support/src/services/time-entry-approval-service.ts
+++ b/packages/support/src/services/time-entry-approval-service.ts
@@ -52,6 +52,7 @@ import type {
   TimeEntryApprovalPath,
   TimeEntryEvidence,
 } from '../types.js';
+import { KeyedMutex } from './keyed-mutex.js';
 import { SupportCaseService } from './support-case-service.js';
 
 /** Thrown when an approval-path or tenant gate refuses the acting principal. */
@@ -151,6 +152,7 @@ export class TimeEntryApprovalService {
   readonly compensations: SupportCompensationCollection;
   readonly compensationPlans: SupportCompensationPlanCollection;
   readonly caseService: SupportCaseService;
+  private readonly approvalMutex = new KeyedMutex();
 
   protected constructor(collections: {
     entries: ServiceTimeEntryCollection;
@@ -275,6 +277,19 @@ export class TimeEntryApprovalService {
     input: ApproveTimeEntryInput = {},
   ): Promise<ApproveTimeEntryResult> {
     const entry = await this.getEntry(entryRef);
+    // Serialize per work context: concurrent approvals against the same case
+    // must not each read the same remaining included allowance and both
+    // consume it (over-granting included time / under-billing overage).
+    const lockKey = entry.caseId ?? `entry:${entry.id ?? ''}`;
+    return this.approvalMutex.run(lockKey, () =>
+      this.approveExclusive(entry, input),
+    );
+  }
+
+  private async approveExclusive(
+    entry: ServiceTimeEntry,
+    input: ApproveTimeEntryInput,
+  ): Promise<ApproveTimeEntryResult> {
     if (entry.status !== 'submitted') {
       throw new Error(
         `ServiceTimeEntry ${entry.id}: only 'submitted' entries can be approved (status is '${entry.status}').`,

--- a/packages/support/src/services/time-entry-approval-service.ts
+++ b/packages/support/src/services/time-entry-approval-service.ts
@@ -596,6 +596,10 @@ export class TimeEntryApprovalService {
       ? await this.compensationPlans.resolveForSpecialist(
           entry.specialistId,
           entry.endedAt ?? at,
+          // Scope defaults to the entry's tenant — approval may run without
+          // an ambient tenant context, and another tenant's default plan
+          // must never price this tenant's work.
+          { tenantId: entry.tenantId ?? null },
         )
       : null;
     const payableSeconds = entry.durationSeconds;

--- a/packages/support/src/services/time-entry-approval-service.ts
+++ b/packages/support/src/services/time-entry-approval-service.ts
@@ -1,0 +1,658 @@
+/**
+ * TimeEntryApprovalService — the approval gate for Service Time Entries and
+ * the ONLY writer of their commercial snapshots (FR-36/FR-32/FR-35, issue
+ * #1930).
+ *
+ * Approval paths come from the governing Managed Support Plan's
+ * `timeApprovalPolicy`: `automatic` (no principal needed under the
+ * thresholds), `threshold` (an over-threshold automatic entry needs an
+ * operator), `operator` (the `support.approve-time-entry` split), and
+ * `client` (the case's Client, with the operator split as override).
+ *
+ * On approval two deliberately separate rows derive per entry:
+ *
+ * - **SupportCharge** — client side, from the Managed Support Plan only:
+ *   included time consumes first (per case; period windows arrive with usage
+ *   pricing #1925), the remainder meters at the overage (or on-call) rate.
+ *   Rate math uses the CASE's `planSnapshot` when present so later plan edits
+ *   never change history.
+ * - **SupportCompensation** — provider side, from the effective-dated Support
+ *   Compensation Plan only.
+ *
+ * Margin (charge − compensation) stays computable by readers and is NEVER
+ * stored; case-visible audit events carry the charge amount only, never the
+ * compensation. Approved entries freeze (model-enforced); disputes flow
+ * through {@link TimeEntryApprovalService.correct}, which supersedes the
+ * original and re-derives fresh snapshots from the correcting entry.
+ */
+
+import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
+import {
+  type ServiceTimeEntry,
+  ServiceTimeEntryCollection,
+} from '../models/service-time-entry.js';
+import type { SupportCase } from '../models/support-case.js';
+import {
+  type SupportCompensationPlan,
+  SupportCompensationPlanCollection,
+} from '../models/support-compensation-plan.js';
+import type { SupportPlan } from '../models/support-plan.js';
+import {
+  type SupportCharge,
+  SupportChargeCollection,
+  type SupportCompensation,
+  SupportCompensationCollection,
+} from '../models/support-settlement.js';
+import {
+  APPROVE_TIME_ENTRY_PERMISSION,
+  type SupportPrincipal,
+} from '../permissions.js';
+import type {
+  TimeApprovalPolicy,
+  TimeEntryApprovalPath,
+  TimeEntryEvidence,
+} from '../types.js';
+import { SupportCaseService } from './support-case-service.js';
+
+/** Thrown when an approval-path or tenant gate refuses the acting principal. */
+export class TimeEntryApprovalDeniedError extends Error {
+  constructor(reason: string) {
+    super(`Time entry approval denied: ${reason}`);
+    this.name = 'TimeEntryApprovalDeniedError';
+  }
+}
+
+/** Options for {@link TimeEntryApprovalService.create}. */
+export interface TimeEntryApprovalServiceOptions extends SmrtObjectOptions {
+  /** Share an existing case facade (otherwise one is created internally). */
+  caseService?: SupportCaseService;
+}
+
+/**
+ * The plan terms governing one entry's approval and pricing, resolved from
+ * the case's frozen `planSnapshot` first, then the live plan row, else
+ * zero-rate defaults (operator approval, nothing charged).
+ */
+export interface ResolvedPlanTerms {
+  policy: TimeApprovalPolicy;
+  currency: string;
+  includedMinutes: number;
+  overageHourlyRate: number;
+  onCallHourlyRate: number;
+  planId: string | null;
+  planKey: string;
+}
+
+/** Input for {@link TimeEntryApprovalService.approve}. */
+export interface ApproveTimeEntryInput {
+  /** Acting principal; optional only for the `automatic` path. */
+  principal?: SupportPrincipal;
+  note?: string;
+  /** Approval instant (defaults to now); also the derivation timestamp. */
+  at?: Date;
+}
+
+/** Result of {@link TimeEntryApprovalService.approve}. */
+export interface ApproveTimeEntryResult {
+  entry: ServiceTimeEntry;
+  charge: SupportCharge;
+  compensation: SupportCompensation;
+  path: TimeEntryApprovalPath;
+}
+
+/** Input for {@link TimeEntryApprovalService.reject}. */
+export interface RejectTimeEntryInput {
+  principal: SupportPrincipal;
+  reason: string;
+}
+
+/** Input for {@link TimeEntryApprovalService.correct}. */
+export interface CorrectTimeEntryInput {
+  principal: SupportPrincipal;
+  patch: Partial<{
+    durationSeconds: number;
+    startedAt: Date;
+    endedAt: Date;
+    description: string;
+    evidence: TimeEntryEvidence[];
+  }>;
+  note?: string;
+}
+
+/** Result of {@link TimeEntryApprovalService.correct}. */
+export interface CorrectTimeEntryResult {
+  /** The superseded entry, now `corrected` with its snapshot intact. */
+  original: ServiceTimeEntry;
+  /** The new `draft` entry carrying the patch (flows submit → approve). */
+  correction: ServiceTimeEntry;
+}
+
+/** Charge math derived from the plan terms before any row is written. */
+interface ChargeDerivation {
+  billableSeconds: number;
+  includedSecondsBefore: number;
+  includedSecondsApplied: number;
+  hourlyRate: number;
+  rateSource: 'overage' | 'on_call' | 'none';
+  amount: number;
+}
+
+/** Round a currency amount to 2 decimals. */
+function roundMoney(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+/**
+ * The approval gate. Construct with {@link TimeEntryApprovalService.create}.
+ */
+export class TimeEntryApprovalService {
+  readonly entries: ServiceTimeEntryCollection;
+  readonly charges: SupportChargeCollection;
+  readonly compensations: SupportCompensationCollection;
+  readonly compensationPlans: SupportCompensationPlanCollection;
+  readonly caseService: SupportCaseService;
+
+  protected constructor(collections: {
+    entries: ServiceTimeEntryCollection;
+    charges: SupportChargeCollection;
+    compensations: SupportCompensationCollection;
+    compensationPlans: SupportCompensationPlanCollection;
+    caseService: SupportCaseService;
+  }) {
+    this.entries = collections.entries;
+    this.charges = collections.charges;
+    this.compensations = collections.compensations;
+    this.compensationPlans = collections.compensationPlans;
+    this.caseService = collections.caseService;
+  }
+
+  static async create(
+    options: TimeEntryApprovalServiceOptions,
+  ): Promise<TimeEntryApprovalService> {
+    const caseService =
+      options.caseService ?? (await SupportCaseService.create(options));
+    const [entries, charges, compensations, compensationPlans] =
+      await Promise.all([
+        ServiceTimeEntryCollection.create(options),
+        SupportChargeCollection.create(options),
+        SupportCompensationCollection.create(options),
+        SupportCompensationPlanCollection.create(options),
+      ]);
+    return new TimeEntryApprovalService({
+      entries,
+      charges,
+      compensations,
+      compensationPlans,
+      caseService,
+    });
+  }
+
+  /** Load an entry or throw a descriptive error. */
+  async getEntry(
+    entryRef: ServiceTimeEntry | string,
+  ): Promise<ServiceTimeEntry> {
+    if (typeof entryRef !== 'string') {
+      return entryRef;
+    }
+    const found = await this.entries.get({ id: entryRef });
+    if (!found) {
+      throw new Error(`ServiceTimeEntry not found: ${entryRef}`);
+    }
+    return found;
+  }
+
+  /**
+   * Resolve the plan terms governing an entry: the case's frozen
+   * `planSnapshot` wins field-by-field (history never rewritten by plan
+   * edits), the live plan row fills gaps, and with no case or plan at all the
+   * terms fall back to zero rates under operator approval.
+   */
+  async resolvePlanTerms(
+    entry: ServiceTimeEntry,
+    supportCase?: SupportCase | null,
+  ): Promise<ResolvedPlanTerms> {
+    const zeroRate: ResolvedPlanTerms = {
+      policy: { mode: 'operator' },
+      currency: 'USD',
+      includedMinutes: 0,
+      overageHourlyRate: 0,
+      onCallHourlyRate: 0,
+      planId: null,
+      planKey: '',
+    };
+    if (!entry.caseId) {
+      return zeroRate;
+    }
+    const owningCase =
+      supportCase ?? (await this.caseService.getCase(entry.caseId));
+    const snapshot = owningCase.getPlanSnapshot();
+    const plan: SupportPlan | null = owningCase.planId
+      ? await this.caseService.plans.get({ id: owningCase.planId })
+      : null;
+    if (Object.keys(snapshot).length === 0 && !plan) {
+      return zeroRate;
+    }
+
+    const num = (snapshotValue: unknown, planValue: number | undefined) =>
+      typeof snapshotValue === 'number' ? snapshotValue : (planValue ?? 0);
+    const policySource =
+      snapshot.timeApprovalPolicy &&
+      typeof snapshot.timeApprovalPolicy === 'object'
+        ? (snapshot.timeApprovalPolicy as Partial<TimeApprovalPolicy>)
+        : plan?.getTimeApprovalPolicy();
+
+    return {
+      policy: { mode: 'operator', ...(policySource ?? {}) },
+      currency:
+        typeof snapshot.currency === 'string' && snapshot.currency
+          ? snapshot.currency
+          : (plan?.currency ?? 'USD'),
+      includedMinutes: num(snapshot.includedMinutes, plan?.includedMinutes),
+      overageHourlyRate: num(
+        snapshot.overageHourlyRate,
+        plan?.overageHourlyRate,
+      ),
+      onCallHourlyRate: num(snapshot.onCallHourlyRate, plan?.onCallHourlyRate),
+      planId:
+        typeof snapshot.planId === 'string' && snapshot.planId
+          ? snapshot.planId
+          : (plan?.id ?? null),
+      planKey:
+        typeof snapshot.planKey === 'string'
+          ? snapshot.planKey
+          : (plan?.planKey ?? ''),
+    };
+  }
+
+  /**
+   * Approve a `submitted` entry: gate the acting principal by the plan's
+   * approval policy, freeze the entry, and derive its charge and compensation
+   * snapshots. Throws {@link TimeEntryApprovalDeniedError} when the gate
+   * refuses.
+   */
+  async approve(
+    entryRef: ServiceTimeEntry | string,
+    input: ApproveTimeEntryInput = {},
+  ): Promise<ApproveTimeEntryResult> {
+    const entry = await this.getEntry(entryRef);
+    if (entry.status !== 'submitted') {
+      throw new Error(
+        `ServiceTimeEntry ${entry.id}: only 'submitted' entries can be approved (status is '${entry.status}').`,
+      );
+    }
+    const at = input.at ?? new Date();
+    const principal = input.principal;
+    this.assertTenantMatch(entry, principal);
+
+    const supportCase = entry.caseId
+      ? await this.caseService.getCase(entry.caseId)
+      : null;
+    const terms = await this.resolvePlanTerms(entry, supportCase);
+    const derivation = await this.deriveCharge(entry, terms);
+    const path = this.determinePath(
+      entry,
+      terms.policy,
+      derivation.amount,
+      principal,
+      supportCase,
+    );
+
+    // Set every approval field BEFORE the save — the model's freeze engages
+    // the moment the row persists as 'approved'.
+    entry.approvedAt = at;
+    entry.approvedByProfileId = principal?.id ?? null;
+    entry.approvalPath = path;
+    entry.status = 'approved';
+    await entry.save();
+
+    const charge = await this.charges.create({
+      tenantId: entry.tenantId,
+      timeEntryId: entry.id ?? '',
+      caseId: entry.caseId,
+      planId: terms.planId,
+      amount: derivation.amount,
+      currency: terms.currency,
+      billableSeconds: derivation.billableSeconds,
+      includedSecondsApplied: derivation.includedSecondsApplied,
+      rateSnapshot: JSON.stringify({
+        hourlyRate: derivation.hourlyRate,
+        rateSource: derivation.rateSource,
+        planId: terms.planId,
+        planKey: terms.planKey,
+        includedMinutes: terms.includedMinutes,
+        includedSecondsBefore: derivation.includedSecondsBefore,
+        includedSecondsApplied: derivation.includedSecondsApplied,
+        derivedAt: at.toISOString(),
+        scope: 'per-case (period accounting arrives with usage pricing #1925)',
+      }),
+      status: 'final',
+      finalizedAt: at,
+    });
+
+    const compensation = await this.deriveCompensation(entry, at);
+
+    if (supportCase) {
+      // Case-visible audit carries the client-side amount ONLY — provider
+      // compensation never leaks into a case event; it is queryable through
+      // its own read model.
+      await this.caseService.recordEvent(supportCase, 'time_recorded', {
+        actorKind:
+          path === 'client' ? 'client' : principal ? 'specialist' : 'system',
+        actorProfileId: principal?.id ?? null,
+        summary: `Time entry approved (${path})`,
+        payload: {
+          approved: true,
+          path,
+          timeEntryId: entry.id ?? '',
+          chargeAmount: charge.amount,
+        },
+        occurredAt: at,
+      });
+    }
+
+    return { entry, charge, compensation, path };
+  }
+
+  /**
+   * Reject a `submitted` entry with a reason (requires the
+   * `support.approve-time-entry` split).
+   */
+  async reject(
+    entryRef: ServiceTimeEntry | string,
+    input: RejectTimeEntryInput,
+  ): Promise<ServiceTimeEntry> {
+    const entry = await this.getEntry(entryRef);
+    if (entry.status !== 'submitted') {
+      throw new Error(
+        `ServiceTimeEntry ${entry.id}: only 'submitted' entries can be rejected (status is '${entry.status}').`,
+      );
+    }
+    if (!input.reason?.trim()) {
+      throw new Error('ServiceTimeEntry: a rejection reason is required.');
+    }
+    this.assertTenantMatch(entry, input.principal);
+    this.assertOperator(input.principal, 'rejecting a time entry');
+
+    entry.rejectedAt = new Date();
+    entry.rejectedByProfileId = input.principal.id ?? null;
+    entry.rejectionReason = input.reason;
+    entry.status = 'rejected';
+    await entry.save();
+    return entry;
+  }
+
+  /**
+   * Correct an `approved` entry (requires the `support.approve-time-entry`
+   * split): a NEW `draft` entry copies the original's context, participant,
+   * and source with the patch applied and links back via `correctionOfId`;
+   * the original flips to `corrected` with its frozen fields and snapshots
+   * untouched, and its charge/compensation rows are marked `corrected`. The
+   * correction then flows submit → approve normally, deriving fresh
+   * snapshots.
+   */
+  async correct(
+    entryRef: ServiceTimeEntry | string,
+    input: CorrectTimeEntryInput,
+  ): Promise<CorrectTimeEntryResult> {
+    const original = await this.getEntry(entryRef);
+    if (original.status !== 'approved') {
+      throw new Error(
+        `ServiceTimeEntry ${original.id}: only 'approved' entries can be corrected (status is '${original.status}').`,
+      );
+    }
+    this.assertTenantMatch(original, input.principal);
+    this.assertOperator(input.principal, 'correcting an approved time entry');
+
+    const patch = input.patch ?? {};
+    const startedAt =
+      patch.startedAt !== undefined ? patch.startedAt : original.startedAt;
+    const endedAt =
+      patch.endedAt !== undefined ? patch.endedAt : original.endedAt;
+    const durationSeconds = patch.durationSeconds ?? original.durationSeconds;
+    if (!(durationSeconds > 0)) {
+      throw new Error(
+        `ServiceTimeEntry: correction durationSeconds must be greater than zero (got ${durationSeconds}).`,
+      );
+    }
+    if (startedAt && endedAt && startedAt.getTime() >= endedAt.getTime()) {
+      throw new Error(
+        'ServiceTimeEntry: correction startedAt must be before endedAt.',
+      );
+    }
+
+    const correction = await this.entries.create({
+      tenantId: original.tenantId,
+      caseId: original.caseId,
+      workRefType: original.workRefType,
+      workRefId: original.workRefId,
+      specialistId: original.specialistId,
+      participantKind: original.participantKind,
+      participantProfileId: original.participantProfileId,
+      agentRef: original.agentRef,
+      source: original.source,
+      description: patch.description ?? original.description,
+      startedAt,
+      endedAt,
+      durationSeconds,
+      evidence:
+        patch.evidence !== undefined
+          ? JSON.stringify(patch.evidence)
+          : original.evidence,
+      status: 'draft',
+      correctionOfId: original.id,
+      metadata: JSON.stringify({
+        ...original.getMetadata(),
+        correctionNote: input.note ?? null,
+      }),
+    });
+
+    // Only the status flips — the frozen work-defining fields stay intact
+    // (the model allows exactly this approved → corrected exit).
+    original.status = 'corrected';
+    await original.save();
+
+    const originalId = original.id ?? '';
+    const [charge, compensation] = await Promise.all([
+      this.charges.forTimeEntry(originalId),
+      this.compensations.forTimeEntry(originalId),
+    ]);
+    if (charge) {
+      charge.status = 'corrected';
+      await charge.save();
+    }
+    if (compensation) {
+      compensation.status = 'corrected';
+      await compensation.save();
+    }
+
+    return { original, correction };
+  }
+
+  /**
+   * Determine the approval path for an entry under a policy, or throw
+   * {@link TimeEntryApprovalDeniedError} when the acting principal does not
+   * satisfy it.
+   */
+  protected determinePath(
+    entry: ServiceTimeEntry,
+    policy: TimeApprovalPolicy,
+    chargeAmount: number,
+    principal: SupportPrincipal | undefined,
+    supportCase: SupportCase | null,
+  ): TimeEntryApprovalPath {
+    const isOperator = principal?.can(APPROVE_TIME_ENTRY_PERMISSION) ?? false;
+
+    if (policy.mode === 'automatic') {
+      const minutes = entry.durationSeconds / 60;
+      const overMinutes =
+        policy.thresholdMinutes !== undefined &&
+        minutes > policy.thresholdMinutes;
+      const overAmount =
+        policy.thresholdAmount !== undefined &&
+        chargeAmount > policy.thresholdAmount;
+      if (!overMinutes && !overAmount) {
+        return 'automatic';
+      }
+      if (!isOperator) {
+        throw new TimeEntryApprovalDeniedError(
+          `the entry exceeds the automatic-approval ${overMinutes ? 'duration' : 'amount'} threshold and requires an operator holding '${APPROVE_TIME_ENTRY_PERMISSION}'.`,
+        );
+      }
+      return 'threshold';
+    }
+
+    if (policy.mode === 'client') {
+      if (!principal) {
+        throw new TimeEntryApprovalDeniedError(
+          'client approval requires an acting principal.',
+        );
+      }
+      const clientProfileId = supportCase?.clientProfileId ?? null;
+      if (clientProfileId && principal.id === clientProfileId) {
+        return 'client';
+      }
+      if (isOperator) {
+        return 'client';
+      }
+      throw new TimeEntryApprovalDeniedError(
+        `client approval requires the case's Client${clientProfileId ? ` (${clientProfileId})` : ''} or an operator holding '${APPROVE_TIME_ENTRY_PERMISSION}'.`,
+      );
+    }
+
+    // 'operator' — the default mode, including zero-rate fallback terms.
+    if (!isOperator) {
+      throw new TimeEntryApprovalDeniedError(
+        `operator approval requires '${APPROVE_TIME_ENTRY_PERMISSION}'.`,
+      );
+    }
+    return 'operator';
+  }
+
+  /**
+   * Charge math from the Managed Support Plan terms: remaining included time
+   * (per case — period windows are #1925's scope) absorbs first, the
+   * remainder meters at the overage (or on-call) hourly rate.
+   */
+  protected async deriveCharge(
+    entry: ServiceTimeEntry,
+    terms: ResolvedPlanTerms,
+  ): Promise<ChargeDerivation> {
+    const billableSeconds = entry.durationSeconds;
+    let includedSecondsBefore = 0;
+    if (entry.caseId && terms.includedMinutes > 0) {
+      const existing = await this.charges.forCase(entry.caseId);
+      const consumed = existing
+        .filter((charge) => charge.status !== 'voided')
+        .reduce((sum, charge) => sum + (charge.includedSecondsApplied ?? 0), 0);
+      includedSecondsBefore = Math.max(
+        0,
+        terms.includedMinutes * 60 - consumed,
+      );
+    }
+    const includedSecondsApplied = Math.min(
+      includedSecondsBefore,
+      billableSeconds,
+    );
+    const onCall = Boolean(entry.getMetadata().onCall);
+    const hourlyRate = onCall
+      ? terms.onCallHourlyRate || terms.overageHourlyRate
+      : terms.overageHourlyRate;
+    const amount = roundMoney(
+      ((billableSeconds - includedSecondsApplied) / 3600) * hourlyRate,
+    );
+    return {
+      billableSeconds,
+      includedSecondsBefore,
+      includedSecondsApplied,
+      hourlyRate,
+      rateSource: onCall ? 'on_call' : hourlyRate > 0 ? 'overage' : 'none',
+      amount,
+    };
+  }
+
+  /**
+   * Provider earning from the Support Compensation Plan effective at the work
+   * instant (`endedAt`, falling back to the approval instant). No specialist
+   * or no plan resolves to a zero-amount row so the entry still settles.
+   */
+  protected async deriveCompensation(
+    entry: ServiceTimeEntry,
+    at: Date,
+  ): Promise<SupportCompensation> {
+    const plan: SupportCompensationPlan | null = entry.specialistId
+      ? await this.compensationPlans.resolveForSpecialist(
+          entry.specialistId,
+          entry.endedAt ?? at,
+        )
+      : null;
+    const payableSeconds = entry.durationSeconds;
+
+    if (!plan) {
+      return this.compensations.create({
+        tenantId: entry.tenantId,
+        timeEntryId: entry.id ?? '',
+        specialistId: entry.specialistId,
+        compensationPlanId: null,
+        amount: 0,
+        currency: 'USD',
+        payableSeconds,
+        rateSnapshot: JSON.stringify({
+          rateSource: 'none',
+          derivedAt: at.toISOString(),
+        }),
+        status: 'final',
+        finalizedAt: at,
+      });
+    }
+
+    const amount = roundMoney((payableSeconds / 3600) * plan.hourlyRate);
+    return this.compensations.create({
+      tenantId: entry.tenantId,
+      timeEntryId: entry.id ?? '',
+      specialistId: entry.specialistId,
+      compensationPlanId: plan.id,
+      amount,
+      currency: plan.currency,
+      payableSeconds,
+      rateSnapshot: JSON.stringify({
+        hourlyRate: plan.hourlyRate,
+        currency: plan.currency,
+        planId: plan.id,
+        effectiveFrom: plan.effectiveFrom?.toISOString() ?? null,
+        effectiveTo: plan.effectiveTo?.toISOString() ?? null,
+        derivedAt: at.toISOString(),
+      }),
+      status: 'final',
+      finalizedAt: at,
+    });
+  }
+
+  /** Cross-tenant acts are refused when both sides carry a tenant. */
+  protected assertTenantMatch(
+    entry: ServiceTimeEntry,
+    principal: SupportPrincipal | undefined,
+  ): void {
+    if (!principal?.tenantId || !entry.tenantId) {
+      return;
+    }
+    if (principal.tenantId !== entry.tenantId) {
+      throw new TimeEntryApprovalDeniedError(
+        `principal tenant '${principal.tenantId}' does not match the entry's tenant '${entry.tenantId}'.`,
+      );
+    }
+  }
+
+  /** Require the operator permission split for a privileged act. */
+  protected assertOperator(
+    principal: SupportPrincipal | undefined,
+    act: string,
+  ): void {
+    if (!principal?.can(APPROVE_TIME_ENTRY_PERMISSION)) {
+      throw new TimeEntryApprovalDeniedError(
+        `${act} requires '${APPROVE_TIME_ENTRY_PERMISSION}'.`,
+      );
+    }
+  }
+}
+
+export default TimeEntryApprovalService;

--- a/packages/support/src/svelte/components/CaseDetail.svelte
+++ b/packages/support/src/svelte/components/CaseDetail.svelte
@@ -1,0 +1,277 @@
+<script lang="ts">
+/**
+ * CaseDetail — reusable Support Case detail surface (issue #1926): header
+ * with priority/status/assignment, resolution, linked work, and the merged
+ * interaction + audit timeline. Presentational: the host loads the case view
+ * and timeline (see `toSupportCaseView` / `toCaseTimelineItemView`).
+ */
+
+import { StatusBadge } from '@happyvertical/smrt-ui';
+import {
+  type CaseTimelineItemView,
+  caseStatusBadgeKey,
+  humanizeStatus,
+  priorityBadgeKey,
+  type SupportCaseView,
+  type SupportWorkLinkView,
+} from '../types.js';
+
+export interface CaseDetailProps {
+  caseView: SupportCaseView;
+  timeline?: CaseTimelineItemView[];
+  workLinks?: SupportWorkLinkView[];
+}
+
+const { caseView, timeline = [], workLinks = [] }: CaseDetailProps = $props();
+
+function formatWhen(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+</script>
+
+<article class="case-detail">
+  <header class="case-detail-header">
+    <p class="case-detail-number">{caseView.caseNumber}</p>
+    <h2 class="case-detail-subject">{caseView.subject}</h2>
+    <div class="case-detail-badges">
+      <StatusBadge
+        status={priorityBadgeKey(caseView.priority)}
+        label={caseView.priority}
+        size="sm"
+      />
+      <StatusBadge
+        status={caseStatusBadgeKey(caseView.status)}
+        label={humanizeStatus(caseView.status)}
+        size="sm"
+      />
+      {#if caseView.severity}
+        <span class="case-detail-severity">{caseView.severity}</span>
+      {/if}
+      {#if caseView.reopenCount > 0}
+        <span class="case-detail-reopens">
+          reopened ×{caseView.reopenCount}
+        </span>
+      {/if}
+    </div>
+  </header>
+
+  <dl class="case-detail-meta">
+    <div>
+      <dt>Assigned</dt>
+      <dd>
+        {caseView.assignedSpecialistName ??
+          (caseView.assignedSpecialistId ? 'assigned' : 'unassigned')}
+      </dd>
+    </div>
+    {#if caseView.channelKind}
+      <div>
+        <dt>Channel</dt>
+        <dd>{caseView.channelKind}</dd>
+      </div>
+    {/if}
+    {#if caseView.projectId}
+      <div>
+        <dt>Project</dt>
+        <dd>{caseView.projectId}</dd>
+      </div>
+    {/if}
+  </dl>
+
+  {#if caseView.resolutionSummary}
+    <section class="case-detail-resolution" aria-label="Resolution">
+      <h3>Resolution</h3>
+      <p>{caseView.resolutionSummary}</p>
+    </section>
+  {/if}
+
+  {#if workLinks.length > 0}
+    <section class="case-detail-work" aria-label="Linked work">
+      <h3>Linked work</h3>
+      <ul>
+        {#each workLinks as link (link.id)}
+          <li>
+            <span class="case-detail-work-kind">
+              {link.linkKind === 'development_work_item'
+                ? 'delivery'
+                : 'support'}
+            </span>
+            {#if link.externalUrl}
+              <a href={link.externalUrl} target="_blank" rel="noreferrer">
+                {link.targetLabel || link.externalUrl}
+              </a>
+            {:else}
+              <span>{link.targetLabel}</span>
+            {/if}
+            <StatusBadge status="pending" label={link.status} size="sm" />
+          </li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
+
+  <section class="case-detail-timeline" aria-label="Case history">
+    <h3>History</h3>
+    {#if timeline.length === 0}
+      <p class="case-detail-empty">No activity yet</p>
+    {:else}
+      <ol>
+        {#each timeline as item, index (index)}
+          <li class="timeline-item" data-kind={item.kind}>
+            <div class="timeline-item-head">
+              <span class="timeline-actor">{item.actorKind}</span>
+              <span class="timeline-summary">
+                {item.kind === 'event'
+                  ? item.summary
+                  : humanizeStatus(item.summary)}
+              </span>
+              <time datetime={item.occurredAt}>
+                {formatWhen(item.occurredAt)}
+              </time>
+            </div>
+            {#if item.body}
+              <p class="timeline-body">{item.body}</p>
+            {/if}
+          </li>
+        {/each}
+      </ol>
+    {/if}
+  </section>
+</article>
+
+<style>
+  .case-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .case-detail-number {
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--smrt-color-on-surface-variant, inherit);
+  }
+
+  .case-detail-subject {
+    margin: 0.125rem 0 0.5rem;
+    font-size: 1.25rem;
+  }
+
+  .case-detail-badges {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .case-detail-severity,
+  .case-detail-reopens {
+    font-size: 0.75rem;
+    color: var(--smrt-color-on-surface-variant, inherit);
+  }
+
+  .case-detail-meta {
+    display: flex;
+    gap: 1.5rem;
+    margin: 0;
+    flex-wrap: wrap;
+  }
+
+  .case-detail-meta dt {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--smrt-color-on-surface-variant, inherit);
+  }
+
+  .case-detail-meta dd {
+    margin: 0;
+  }
+
+  .case-detail-resolution h3,
+  .case-detail-work h3,
+  .case-detail-timeline h3 {
+    margin: 0 0 0.5rem;
+    font-size: 0.875rem;
+  }
+
+  .case-detail-work ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .case-detail-work li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .case-detail-work-kind {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--smrt-color-on-surface-variant, inherit);
+  }
+
+  .case-detail-timeline ol {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+  }
+
+  .timeline-item {
+    border-left: 2px solid var(--smrt-color-outline-variant, currentColor);
+    padding-left: 0.75rem;
+  }
+
+  .timeline-item[data-kind='interaction'] {
+    border-left-color: var(--smrt-color-primary, currentColor);
+  }
+
+  .timeline-item-head {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .timeline-actor {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--smrt-color-on-surface-variant, inherit);
+  }
+
+  .timeline-summary {
+    font-weight: 500;
+  }
+
+  .timeline-item time {
+    font-size: 0.75rem;
+    color: var(--smrt-color-on-surface-variant, inherit);
+    margin-left: auto;
+  }
+
+  .timeline-body {
+    margin: 0.25rem 0 0;
+    white-space: pre-wrap;
+  }
+
+  .case-detail-empty {
+    color: var(--smrt-color-on-surface-variant, inherit);
+  }
+</style>

--- a/packages/support/src/svelte/components/CaseQueue.svelte
+++ b/packages/support/src/svelte/components/CaseQueue.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+/**
+ * CaseQueue — reusable Support Case queue list (issue #1926): priority,
+ * status, assignment, and channel at a glance. Presentational: the host
+ * fetches `SupportCaseView[]` (see `toSupportCaseView`) and wires `onselect`.
+ */
+
+import { Button, StatusBadge } from '@happyvertical/smrt-ui';
+import {
+  caseStatusBadgeKey,
+  humanizeStatus,
+  priorityBadgeKey,
+  type SupportCaseView,
+} from '../types.js';
+
+export interface CaseQueueProps {
+  cases: SupportCaseView[];
+  onselect?: (caseId: string) => void;
+  emptyMessage?: string;
+  /** Show the assigned-specialist column (default true). */
+  showAssignee?: boolean;
+}
+
+const {
+  cases,
+  onselect,
+  emptyMessage = 'No support cases',
+  showAssignee = true,
+}: CaseQueueProps = $props();
+
+function formatUpdated(iso: string | null): string {
+  if (!iso) return '';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+</script>
+
+{#if cases.length === 0}
+  <p class="case-queue-empty">{emptyMessage}</p>
+{:else}
+  <ul class="case-queue">
+    {#each cases as item (item.id)}
+      <li class="case-queue-row">
+        <Button
+          variant="ghost"
+          fullWidth
+          onclick={() => onselect?.(item.id)}
+          aria-label={`Open case ${item.caseNumber}: ${item.subject}`}
+        >
+          <span class="case-queue-line">
+            <span class="case-queue-main">
+              <span class="case-queue-number">{item.caseNumber}</span>
+              <span class="case-queue-subject">{item.subject}</span>
+            </span>
+            <span class="case-queue-meta">
+              <StatusBadge
+                status={priorityBadgeKey(item.priority)}
+                label={item.priority}
+                size="sm"
+              />
+              <StatusBadge
+                status={caseStatusBadgeKey(item.status)}
+                label={humanizeStatus(item.status)}
+                size="sm"
+              />
+              {#if item.channelKind}
+                <span class="case-queue-channel">{item.channelKind}</span>
+              {/if}
+              {#if showAssignee}
+                <span class="case-queue-assignee">
+                  {item.assignedSpecialistName ??
+                    (item.assignedSpecialistId ? 'assigned' : 'unassigned')}
+                </span>
+              {/if}
+              <span class="case-queue-updated">
+                {formatUpdated(item.updatedAt)}
+              </span>
+            </span>
+          </span>
+        </Button>
+      </li>
+    {/each}
+  </ul>
+{/if}
+
+<style>
+  .case-queue {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .case-queue-line {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    text-align: left;
+  }
+
+  .case-queue-main {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .case-queue-number {
+    font-size: 0.75rem;
+    color: var(--smrt-color-on-surface-variant, inherit);
+  }
+
+  .case-queue-subject {
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .case-queue-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+
+  .case-queue-channel,
+  .case-queue-assignee,
+  .case-queue-updated {
+    font-size: 0.75rem;
+    color: var(--smrt-color-on-surface-variant, inherit);
+  }
+
+  .case-queue-empty {
+    color: var(--smrt-color-on-surface-variant, inherit);
+    padding: 1rem 0;
+  }
+</style>

--- a/packages/support/src/svelte/components/RoutingRationale.svelte
+++ b/packages/support/src/svelte/components/RoutingRationale.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+/**
+ * RoutingRationale — the explainable routing ranking for a case (issue
+ * #1929): each specialist's score, eligibility, and the factor signals
+ * behind them, with an optional manual-reassign action per row.
+ * Presentational: the host runs `SupportRoutingService.rankSpecialists`
+ * (and gates reassignment with `support.reassign-case`).
+ */
+
+import { Button, StatusBadge } from '@happyvertical/smrt-ui';
+import type { RankedSpecialistView } from '../types.js';
+
+export interface RoutingRationaleProps {
+  ranking: RankedSpecialistView[];
+  /** When provided, each row shows a reassign action. */
+  onreassign?: (specialistId: string) => void;
+  emptyMessage?: string;
+}
+
+const {
+  ranking,
+  onreassign,
+  emptyMessage = 'No specialists to rank',
+}: RoutingRationaleProps = $props();
+
+function factorChips(
+  factors: Record<string, number | string | boolean>,
+): string[] {
+  return Object.entries(factors).map(([key, value]) =>
+    value === true ? key : `${key}: ${value}`,
+  );
+}
+</script>
+
+{#if ranking.length === 0}
+  <p class="routing-rationale-empty">{emptyMessage}</p>
+{:else}
+  <ul class="routing-rationale">
+    {#each ranking as entry (entry.specialistId)}
+      <li class="routing-rationale-row">
+        <span class="routing-rationale-main">
+          <span class="routing-rationale-head">
+            <span class="routing-rationale-name">{entry.displayName}</span>
+            <span class="routing-rationale-score">score {entry.score}</span>
+            <StatusBadge
+              status={entry.eligible ? 'success' : 'inactive'}
+              label={entry.eligible ? 'eligible' : 'ineligible'}
+              size="sm"
+            />
+          </span>
+          <span class="routing-rationale-factors">
+            {#each factorChips(entry.factors) as chip (chip)}
+              <span class="routing-rationale-factor">{chip}</span>
+            {/each}
+          </span>
+        </span>
+        {#if onreassign}
+          <Button
+            variant="secondary"
+            size="sm"
+            onclick={() => onreassign?.(entry.specialistId)}
+            aria-label={`Reassign to ${entry.displayName}`}
+          >
+            Reassign
+          </Button>
+        {/if}
+      </li>
+    {/each}
+  </ul>
+{/if}
+
+<style>
+  .routing-rationale {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .routing-rationale-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .routing-rationale-main {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+  }
+
+  .routing-rationale-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .routing-rationale-name {
+    font-weight: 500;
+  }
+
+  .routing-rationale-score {
+    font-size: 0.75rem;
+    color: var(--smrt-color-on-surface-variant, inherit);
+  }
+
+  .routing-rationale-factors {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+
+  .routing-rationale-factor {
+    font-size: 0.6875rem;
+    padding: 0.0625rem 0.375rem;
+    border-radius: 0.5rem;
+    background: var(--smrt-color-surface-container-highest, transparent);
+    color: var(--smrt-color-on-surface-variant, inherit);
+    border: 1px solid var(--smrt-color-outline-variant, currentColor);
+  }
+
+  .routing-rationale-empty {
+    color: var(--smrt-color-on-surface-variant, inherit);
+    padding: 1rem 0;
+  }
+</style>

--- a/packages/support/src/svelte/components/TargetList.svelte
+++ b/packages/support/src/svelte/components/TargetList.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+/**
+ * TargetList — Service Target clocks on a case at a glance (issue #1929):
+ * target type, due time, clock status, and a paused indicator per row.
+ * Presentational: the host loads targets and adapts them with
+ * `toServiceTargetView`.
+ */
+
+import { StatusBadge } from '@happyvertical/smrt-ui';
+import {
+  humanizeStatus,
+  type ServiceTargetView,
+  targetStatusBadgeKey,
+} from '../types.js';
+
+export interface TargetListProps {
+  targets: ServiceTargetView[];
+  emptyMessage?: string;
+}
+
+const { targets, emptyMessage = 'No service targets' }: TargetListProps =
+  $props();
+
+function formatDue(iso: string | null): string {
+  if (!iso) return '';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+</script>
+
+{#if targets.length === 0}
+  <p class="target-list-empty">{emptyMessage}</p>
+{:else}
+  <ul class="target-list">
+    {#each targets as target (target.id)}
+      <li class="target-list-row">
+        <span class="target-list-main">
+          <span class="target-list-type">
+            {humanizeStatus(target.targetType)}
+            {#if target.cycle > 0}
+              <span class="target-list-cycle">cycle {target.cycle}</span>
+            {/if}
+          </span>
+          {#if target.dueAt}
+            <span class="target-list-due">due {formatDue(target.dueAt)}</span>
+          {/if}
+        </span>
+        <span class="target-list-meta">
+          {#if target.paused}
+            <span class="target-list-paused">paused</span>
+          {/if}
+          <StatusBadge
+            status={targetStatusBadgeKey(target.status)}
+            label={humanizeStatus(target.status)}
+            size="sm"
+          />
+        </span>
+      </li>
+    {/each}
+  </ul>
+{/if}
+
+<style>
+  .target-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .target-list-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .target-list-main {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .target-list-type {
+    font-weight: 500;
+    text-transform: capitalize;
+  }
+
+  .target-list-cycle {
+    font-size: 0.75rem;
+    font-weight: 400;
+    text-transform: none;
+    color: var(--smrt-color-on-surface-variant, inherit);
+    margin-left: 0.375rem;
+  }
+
+  .target-list-due,
+  .target-list-paused {
+    font-size: 0.75rem;
+    color: var(--smrt-color-on-surface-variant, inherit);
+  }
+
+  .target-list-paused {
+    font-style: italic;
+  }
+
+  .target-list-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+
+  .target-list-empty {
+    color: var(--smrt-color-on-surface-variant, inherit);
+    padding: 1rem 0;
+  }
+</style>

--- a/packages/support/src/svelte/components/TimeEntryApprovalQueue.svelte
+++ b/packages/support/src/svelte/components/TimeEntryApprovalQueue.svelte
@@ -1,0 +1,226 @@
+<script lang="ts">
+/**
+ * TimeEntryApprovalQueue — reusable Service Time Entry review list (issue
+ * #1930): date, hours, description, worker, status, and the client charge
+ * amount at a glance, with approve/reject actions on `submitted` rows.
+ * Presentational: the host loads entries through `TimeEntryApprovalService`
+ * / `ServiceTimeEntryCollection`, adapts them with `toSupportTimeEntryView`,
+ * and wires `onapprove` / `onreject` to the approval service.
+ */
+
+import { Button, StatusBadge } from '@happyvertical/smrt-ui';
+import { Input } from '@happyvertical/smrt-ui/forms';
+import {
+  humanizeStatus,
+  type SupportTimeEntryView,
+  timeEntryStatusBadgeKey,
+} from '../types.js';
+
+export interface TimeEntryApprovalQueueProps {
+  entries: SupportTimeEntryView[];
+  onapprove?: (id: string) => void;
+  onreject?: (id: string, reason: string) => void;
+  emptyMessage?: string;
+}
+
+const {
+  entries,
+  onapprove,
+  onreject,
+  emptyMessage = 'No time entries',
+}: TimeEntryApprovalQueueProps = $props();
+
+/** The entry currently collecting a rejection reason (one at a time). */
+let rejectingId = $state<string | null>(null);
+let rejectReason = $state('');
+
+function beginReject(id: string): void {
+  rejectingId = id;
+  rejectReason = '';
+}
+
+function cancelReject(): void {
+  rejectingId = null;
+  rejectReason = '';
+}
+
+function confirmReject(id: string): void {
+  const reason = rejectReason.trim();
+  if (!reason) return;
+  onreject?.(id, reason);
+  cancelReject();
+}
+
+function formatHours(hours: number): string {
+  return `${hours.toFixed(1)}h`;
+}
+
+function formatAmount(amount: number): string {
+  return amount.toFixed(2);
+}
+</script>
+
+{#if entries.length === 0}
+  <p class="time-approval-empty">{emptyMessage}</p>
+{:else}
+  <ul class="time-approval-queue">
+    {#each entries as entry (entry.id)}
+      <li class="time-approval-row">
+        <div class="time-approval-line">
+          <span class="time-approval-date">{entry.date}</span>
+          <span class="time-approval-main">
+            <span class="time-approval-description">{entry.description}</span>
+            {#if entry.workerName}
+              <span class="time-approval-worker">{entry.workerName}</span>
+            {/if}
+          </span>
+          <span class="time-approval-meta">
+            <span class="time-approval-hours">{formatHours(entry.hours)}</span>
+            <StatusBadge
+              status={timeEntryStatusBadgeKey(entry.status)}
+              label={humanizeStatus(entry.status)}
+              size="sm"
+            />
+            {#if entry.amount !== undefined}
+              <span class="time-approval-amount">
+                {formatAmount(entry.amount)}
+              </span>
+            {/if}
+          </span>
+        </div>
+        {#if entry.status === 'submitted'}
+          <div class="time-approval-actions">
+            {#if rejectingId === entry.id}
+              <Input
+                bind:value={rejectReason}
+                placeholder="Rejection reason"
+                aria-label={`Rejection reason for: ${entry.description}`}
+              />
+              <Button
+                variant="danger"
+                size="sm"
+                disabled={rejectReason.trim().length === 0}
+                onclick={() => confirmReject(entry.id)}
+                aria-label={`Confirm rejection of: ${entry.description}`}
+              >
+                Confirm reject
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onclick={cancelReject}
+                aria-label={`Cancel rejecting: ${entry.description}`}
+              >
+                Cancel
+              </Button>
+            {:else}
+              <Button
+                variant="primary"
+                size="sm"
+                onclick={() => onapprove?.(entry.id)}
+                aria-label={`Approve time entry: ${entry.description}`}
+              >
+                Approve
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onclick={() => beginReject(entry.id)}
+                aria-label={`Reject time entry: ${entry.description}`}
+              >
+                Reject
+              </Button>
+            {/if}
+          </div>
+        {/if}
+      </li>
+    {/each}
+  </ul>
+{/if}
+
+<style>
+  .time-approval-queue {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .time-approval-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+    padding: 0.5rem 0.25rem;
+    border-bottom: 1px solid var(--smrt-color-outline-variant, transparent);
+  }
+
+  .time-approval-row:last-child {
+    border-bottom: none;
+  }
+
+  .time-approval-line {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    text-align: left;
+  }
+
+  .time-approval-date {
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    color: var(--smrt-color-on-surface-variant, inherit);
+  }
+
+  .time-approval-main {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .time-approval-description {
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .time-approval-worker {
+    font-size: 0.75rem;
+    color: var(--smrt-color-on-surface-variant, inherit);
+  }
+
+  .time-approval-meta {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+
+  .time-approval-hours {
+    font-weight: 500;
+    color: var(--smrt-color-primary, inherit);
+  }
+
+  .time-approval-amount {
+    font-variant-numeric: tabular-nums;
+    font-weight: 500;
+  }
+
+  .time-approval-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    justify-content: flex-end;
+  }
+
+  .time-approval-empty {
+    color: var(--smrt-color-on-surface-variant, inherit);
+    padding: 1rem 0;
+  }
+</style>

--- a/packages/support/src/svelte/components/__tests__/CaseDetail.test.ts
+++ b/packages/support/src/svelte/components/__tests__/CaseDetail.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for CaseDetail via the shared S11 harness (#1416).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it } from 'vitest';
+import type {
+  CaseTimelineItemView,
+  SupportCaseView,
+  SupportWorkLinkView,
+} from '../../types.js';
+import CaseDetail from '../CaseDetail.svelte';
+
+const caseView: SupportCaseView = {
+  id: 'case-1',
+  caseNumber: 'SUP-9',
+  subject: 'Checkout errors under load',
+  status: 'escalated',
+  priority: 'urgent',
+  severity: 'sev1',
+  channelKind: 'email',
+  clientProfileId: 'client-1',
+  projectId: 'shop-rebuild',
+  assignedSpecialistId: 'spec-2',
+  assignedSpecialistName: 'Grace',
+  reopenCount: 1,
+  createdAt: '2026-07-01T09:00:00.000Z',
+  updatedAt: '2026-07-03T16:00:00.000Z',
+  resolutionSummary: '',
+};
+
+const timeline: CaseTimelineItemView[] = [
+  {
+    kind: 'interaction',
+    occurredAt: '2026-07-01T09:00:00.000Z',
+    actorKind: 'client',
+    summary: 'inbound email',
+    body: 'Checkout is failing for many users.',
+    direction: 'inbound',
+    channelKind: 'email',
+    eventType: null,
+  },
+  {
+    kind: 'event',
+    occurredAt: '2026-07-01T09:05:00.000Z',
+    actorKind: 'system',
+    summary: 'Status new → triaged',
+    body: '',
+    direction: null,
+    channelKind: null,
+    eventType: 'transition',
+  },
+];
+
+const workLinks: SupportWorkLinkView[] = [
+  {
+    id: 'link-1',
+    linkKind: 'development_work_item',
+    targetLabel: 'shop#101: fix checkout race',
+    externalUrl: 'https://github.com/acme/shop/issues/101',
+    status: 'in_progress',
+  },
+];
+
+describe('CaseDetail', () => {
+  it('renders header, meta, linked work, and the merged timeline', async () => {
+    const { container } = render(CaseDetail, {
+      props: { caseView, timeline, workLinks },
+    });
+
+    expect(screen.getByText('SUP-9')).toBeInTheDocument();
+    expect(screen.getByText('Checkout errors under load')).toBeInTheDocument();
+    expect(screen.getByText('escalated')).toBeInTheDocument();
+    expect(screen.getByText('reopened ×1')).toBeInTheDocument();
+    expect(screen.getByText('Grace')).toBeInTheDocument();
+    expect(screen.getByText('shop-rebuild')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', { name: 'shop#101: fix checkout race' }),
+    ).toHaveAttribute('href', 'https://github.com/acme/shop/issues/101');
+
+    expect(
+      screen.getByText('Checkout is failing for many users.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Status new → triaged')).toBeInTheDocument();
+
+    await expectNoA11yViolations(container);
+  });
+
+  it('shows the empty history state and resolution when present', () => {
+    render(CaseDetail, {
+      props: {
+        caseView: {
+          ...caseView,
+          status: 'resolved',
+          resolutionSummary: 'Scaled the checkout workers.',
+        },
+        timeline: [],
+      },
+    });
+    expect(screen.getByText('No activity yet')).toBeInTheDocument();
+    expect(
+      screen.getByText('Scaled the checkout workers.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/support/src/svelte/components/__tests__/CaseQueue.test.ts
+++ b/packages/support/src/svelte/components/__tests__/CaseQueue.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for CaseQueue via the shared S11 harness (#1416).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import type { SupportCaseView } from '../../types.js';
+import CaseQueue from '../CaseQueue.svelte';
+
+function caseView(overrides: Partial<SupportCaseView> = {}): SupportCaseView {
+  return {
+    id: 'case-1',
+    caseNumber: 'SUP-1',
+    subject: 'Login is broken',
+    status: 'in_progress',
+    priority: 'high',
+    severity: 'sev2',
+    channelKind: 'chat',
+    clientProfileId: 'client-1',
+    projectId: 'project-1',
+    assignedSpecialistId: 'spec-1',
+    assignedSpecialistName: 'Ada',
+    reopenCount: 0,
+    createdAt: '2026-07-01T10:00:00.000Z',
+    updatedAt: '2026-07-02T11:30:00.000Z',
+    resolutionSummary: '',
+    ...overrides,
+  };
+}
+
+describe('CaseQueue', () => {
+  it('renders case number, subject, badges, and assignee', async () => {
+    const { container } = render(CaseQueue, {
+      props: { cases: [caseView()] },
+    });
+    expect(screen.getByText('SUP-1')).toBeInTheDocument();
+    expect(screen.getByText('Login is broken')).toBeInTheDocument();
+    expect(screen.getByText('high')).toBeInTheDocument();
+    expect(screen.getByText('in progress')).toBeInTheDocument();
+    expect(screen.getByText('Ada')).toBeInTheDocument();
+    await expectNoA11yViolations(container);
+  });
+
+  it('invokes onselect with the case id', async () => {
+    const onselect = vi.fn();
+    render(CaseQueue, { props: { cases: [caseView()], onselect } });
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'Open case SUP-1: Login is broken',
+      }),
+    );
+    expect(onselect).toHaveBeenCalledWith('case-1');
+  });
+
+  it('shows the empty message when there are no cases', () => {
+    render(CaseQueue, {
+      props: { cases: [], emptyMessage: 'Queue is clear' },
+    });
+    expect(screen.getByText('Queue is clear')).toBeInTheDocument();
+  });
+
+  it('falls back to unassigned when no specialist is set', () => {
+    render(CaseQueue, {
+      props: {
+        cases: [
+          caseView({
+            assignedSpecialistId: null,
+            assignedSpecialistName: null,
+          }),
+        ],
+      },
+    });
+    expect(screen.getByText('unassigned')).toBeInTheDocument();
+  });
+});

--- a/packages/support/src/svelte/components/__tests__/RoutingRationale.test.ts
+++ b/packages/support/src/svelte/components/__tests__/RoutingRationale.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for RoutingRationale via the shared S11 harness (#1416).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import type { RankedSpecialistView } from '../../types.js';
+import RoutingRationale from '../RoutingRationale.svelte';
+
+function rankedView(
+  overrides: Partial<RankedSpecialistView> = {},
+): RankedSpecialistView {
+  return {
+    specialistId: 'spec-1',
+    displayName: 'Ada Lovelace',
+    score: 45,
+    eligible: true,
+    factors: {
+      status: 'active',
+      projectQualification: 'expert',
+      weeklyAvailable: true,
+      openCases: 2,
+    },
+    ...overrides,
+  };
+}
+
+describe('RoutingRationale', () => {
+  it('renders name, score, eligibility, and factor chips', async () => {
+    const { container } = render(RoutingRationale, {
+      props: {
+        ranking: [
+          rankedView(),
+          rankedView({
+            specialistId: 'spec-2',
+            displayName: 'Grace Hopper',
+            score: 0,
+            eligible: false,
+            factors: { status: 'active', projectQualification: 'none' },
+          }),
+        ],
+      },
+    });
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+    expect(screen.getByText('score 45')).toBeInTheDocument();
+    expect(screen.getByText('eligible')).toBeInTheDocument();
+    expect(screen.getByText('ineligible')).toBeInTheDocument();
+    // Boolean-true factors render as bare chips; others as key: value.
+    expect(screen.getByText('weeklyAvailable')).toBeInTheDocument();
+    expect(
+      screen.getByText('projectQualification: expert'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('projectQualification: none')).toBeInTheDocument();
+    expect(screen.getByText('openCases: 2')).toBeInTheDocument();
+    await expectNoA11yViolations(container);
+  });
+
+  it('fires onreassign with the specialist id', async () => {
+    const onreassign = vi.fn();
+    const { container } = render(RoutingRationale, {
+      props: { ranking: [rankedView()], onreassign },
+    });
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Reassign to Ada Lovelace' }),
+    );
+    expect(onreassign).toHaveBeenCalledWith('spec-1');
+    await expectNoA11yViolations(container);
+  });
+
+  it('renders no reassign action without an onreassign handler', () => {
+    render(RoutingRationale, { props: { ranking: [rankedView()] } });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty message for an empty ranking', () => {
+    render(RoutingRationale, {
+      props: { ranking: [], emptyMessage: 'Nobody to rank' },
+    });
+    expect(screen.getByText('Nobody to rank')).toBeInTheDocument();
+  });
+});

--- a/packages/support/src/svelte/components/__tests__/TargetList.test.ts
+++ b/packages/support/src/svelte/components/__tests__/TargetList.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for TargetList via the shared S11 harness (#1416).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it } from 'vitest';
+import type { ServiceTargetView } from '../../types.js';
+import TargetList from '../TargetList.svelte';
+
+function targetView(
+  overrides: Partial<ServiceTargetView> = {},
+): ServiceTargetView {
+  return {
+    id: 'target-1',
+    targetType: 'acknowledgement',
+    cycle: 0,
+    status: 'pending',
+    severity: 'sev2',
+    baseMinutes: 30,
+    startedAt: '2026-01-05T10:00:00.000Z',
+    dueAt: '2026-01-05T10:30:00.000Z',
+    satisfiedAt: null,
+    breachedAt: null,
+    paused: false,
+    ...overrides,
+  };
+}
+
+describe('TargetList', () => {
+  it('renders target type, due time, and status badge', async () => {
+    const { container } = render(TargetList, {
+      props: {
+        targets: [
+          targetView(),
+          targetView({
+            id: 'target-2',
+            targetType: 'resolution',
+            status: 'satisfied',
+            satisfiedAt: '2026-01-05T11:00:00.000Z',
+          }),
+        ],
+      },
+    });
+    expect(screen.getByText('acknowledgement')).toBeInTheDocument();
+    expect(screen.getByText('resolution')).toBeInTheDocument();
+    expect(screen.getAllByText(/due /)).toHaveLength(2);
+    expect(screen.getByText('pending')).toBeInTheDocument();
+    expect(screen.getByText('satisfied')).toBeInTheDocument();
+    await expectNoA11yViolations(container);
+  });
+
+  it('shows the paused indicator and the recurrence cycle', async () => {
+    const { container } = render(TargetList, {
+      props: {
+        targets: [
+          targetView({
+            id: 'target-3',
+            targetType: 'update',
+            status: 'paused',
+            paused: true,
+            cycle: 2,
+          }),
+        ],
+      },
+    });
+    expect(
+      screen.getByText('paused', { selector: '.target-list-paused' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('cycle 2')).toBeInTheDocument();
+    await expectNoA11yViolations(container);
+  });
+
+  it('renders a breached clock with the error badge label', () => {
+    render(TargetList, {
+      props: {
+        targets: [
+          targetView({
+            id: 'target-4',
+            status: 'breached',
+            breachedAt: '2026-01-05T11:00:00.000Z',
+          }),
+        ],
+      },
+    });
+    expect(screen.getByText('breached')).toBeInTheDocument();
+  });
+
+  it('shows the empty message when there are no targets', () => {
+    render(TargetList, {
+      props: { targets: [], emptyMessage: 'No clocks running' },
+    });
+    expect(screen.getByText('No clocks running')).toBeInTheDocument();
+  });
+});

--- a/packages/support/src/svelte/components/__tests__/TimeEntryApprovalQueue.test.ts
+++ b/packages/support/src/svelte/components/__tests__/TimeEntryApprovalQueue.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+/**
+ * Component coverage for TimeEntryApprovalQueue via the shared S11 harness
+ * (#1416): rendering, the approve/reject callbacks (reject collects a
+ * reason first), and accessibility.
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import type { SupportTimeEntryView } from '../../types.js';
+import TimeEntryApprovalQueue from '../TimeEntryApprovalQueue.svelte';
+
+function entryView(
+  overrides: Partial<SupportTimeEntryView> = {},
+): SupportTimeEntryView {
+  return {
+    id: 'te-1',
+    date: '2026-07-01',
+    hours: 1.5,
+    description: 'Debugged the login loop',
+    status: 'submitted',
+    amount: 180,
+    workerName: 'Ada',
+    hourlyRate: 120,
+    source: 'timer',
+    participantKind: 'human',
+    caseId: 'case-1',
+    ...overrides,
+  };
+}
+
+describe('TimeEntryApprovalQueue', () => {
+  it('renders date, hours, description, worker, status, and amount', async () => {
+    const { container } = render(TimeEntryApprovalQueue, {
+      props: { entries: [entryView()] },
+    });
+    expect(screen.getByText('2026-07-01')).toBeInTheDocument();
+    expect(screen.getByText('1.5h')).toBeInTheDocument();
+    expect(screen.getByText('Debugged the login loop')).toBeInTheDocument();
+    expect(screen.getByText('Ada')).toBeInTheDocument();
+    expect(screen.getByText('submitted')).toBeInTheDocument();
+    expect(screen.getByText('180.00')).toBeInTheDocument();
+    await expectNoA11yViolations(container);
+  });
+
+  it('omits the amount when no charge has derived yet', () => {
+    render(TimeEntryApprovalQueue, {
+      props: { entries: [entryView({ amount: undefined })] },
+    });
+    expect(screen.queryByText('180.00')).not.toBeInTheDocument();
+  });
+
+  it('invokes onapprove with the entry id', async () => {
+    const onapprove = vi.fn();
+    render(TimeEntryApprovalQueue, {
+      props: { entries: [entryView()], onapprove },
+    });
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'Approve time entry: Debugged the login loop',
+      }),
+    );
+    expect(onapprove).toHaveBeenCalledWith('te-1');
+  });
+
+  it('collects a reason before invoking onreject', async () => {
+    const onreject = vi.fn();
+    const { container } = render(TimeEntryApprovalQueue, {
+      props: { entries: [entryView()], onreject },
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'Reject time entry: Debugged the login loop',
+      }),
+    );
+    const confirmButton = screen.getByRole('button', {
+      name: 'Confirm rejection of: Debugged the login loop',
+    });
+    expect(confirmButton).toBeDisabled();
+
+    await userEvent.type(
+      screen.getByRole('textbox', {
+        name: 'Rejection reason for: Debugged the login loop',
+      }),
+      'duplicate entry',
+    );
+    await expectNoA11yViolations(container);
+    await userEvent.click(confirmButton);
+    expect(onreject).toHaveBeenCalledWith('te-1', 'duplicate entry');
+  });
+
+  it('cancelling a rejection restores the actions without firing onreject', async () => {
+    const onreject = vi.fn();
+    render(TimeEntryApprovalQueue, {
+      props: { entries: [entryView()], onreject },
+    });
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'Reject time entry: Debugged the login loop',
+      }),
+    );
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'Cancel rejecting: Debugged the login loop',
+      }),
+    );
+    expect(onreject).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole('button', {
+        name: 'Approve time entry: Debugged the login loop',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows no actions on rows that are not submitted', () => {
+    render(TimeEntryApprovalQueue, {
+      props: {
+        entries: [entryView({ id: 'te-2', status: 'approved' })],
+        onapprove: vi.fn(),
+      },
+    });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('shows the empty message when there are no entries', () => {
+    render(TimeEntryApprovalQueue, {
+      props: { entries: [], emptyMessage: 'Nothing awaiting review' },
+    });
+    expect(screen.getByText('Nothing awaiting review')).toBeInTheDocument();
+  });
+});

--- a/packages/support/src/svelte/index.ts
+++ b/packages/support/src/svelte/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @happyvertical/smrt-support/svelte
+ *
+ * Reusable Svelte 5 surfaces for Managed Support (issue #1926): a case queue
+ * and a case detail view. Presentational only — hosts load data through the
+ * package services and adapt models with the exported view mappers.
+ *
+ * @packageDocumentation
+ */
+
+import type { ComponentProps } from 'svelte';
+import CaseDetail from './components/CaseDetail.svelte';
+import CaseQueue from './components/CaseQueue.svelte';
+
+export { CaseDetail, CaseQueue };
+export type CaseQueueProps = ComponentProps<typeof CaseQueue>;
+export type CaseDetailProps = ComponentProps<typeof CaseDetail>;
+
+export {
+  type CaseTimelineItemView,
+  caseStatusBadgeKey,
+  humanizeStatus,
+  priorityBadgeKey,
+  type SupportCaseView,
+  type SupportWorkLinkView,
+  toCaseTimelineItemView,
+  toSupportCaseView,
+} from './types.js';

--- a/packages/support/src/svelte/index.ts
+++ b/packages/support/src/svelte/index.ts
@@ -1,10 +1,11 @@
 /**
  * @happyvertical/smrt-support/svelte
  *
- * Reusable Svelte 5 surfaces for Managed Support (issues #1926/#1930): a case
- * queue, a case detail view, and a time-entry approval queue. Presentational
- * only — hosts load data through the package services and adapt models with
- * the exported view mappers.
+ * Reusable Svelte 5 surfaces for Managed Support: a case queue and case
+ * detail view (issue #1926), Service Target clocks and the explainable
+ * routing ranking (issue #1929), and a time-entry approval queue (issue
+ * #1930). Presentational only — hosts load data through the package services
+ * and adapt models with the exported view mappers.
  *
  * @packageDocumentation
  */
@@ -12,11 +13,21 @@
 import type { ComponentProps } from 'svelte';
 import CaseDetail from './components/CaseDetail.svelte';
 import CaseQueue from './components/CaseQueue.svelte';
+import RoutingRationale from './components/RoutingRationale.svelte';
+import TargetList from './components/TargetList.svelte';
 import TimeEntryApprovalQueue from './components/TimeEntryApprovalQueue.svelte';
 
-export { CaseDetail, CaseQueue, TimeEntryApprovalQueue };
+export {
+  CaseDetail,
+  CaseQueue,
+  RoutingRationale,
+  TargetList,
+  TimeEntryApprovalQueue,
+};
 export type CaseQueueProps = ComponentProps<typeof CaseQueue>;
 export type CaseDetailProps = ComponentProps<typeof CaseDetail>;
+export type TargetListProps = ComponentProps<typeof TargetList>;
+export type RoutingRationaleProps = ComponentProps<typeof RoutingRationale>;
 export type TimeEntryApprovalQueueProps = ComponentProps<
   typeof TimeEntryApprovalQueue
 >;
@@ -26,11 +37,15 @@ export {
   caseStatusBadgeKey,
   humanizeStatus,
   priorityBadgeKey,
+  type RankedSpecialistView,
+  type ServiceTargetView,
   type SupportCaseView,
   type SupportTimeEntryView,
   type SupportWorkLinkView,
+  targetStatusBadgeKey,
   timeEntryStatusBadgeKey,
   toCaseTimelineItemView,
+  toServiceTargetView,
   toSupportCaseView,
   toSupportTimeEntryView,
 } from './types.js';

--- a/packages/support/src/svelte/index.ts
+++ b/packages/support/src/svelte/index.ts
@@ -1,9 +1,10 @@
 /**
  * @happyvertical/smrt-support/svelte
  *
- * Reusable Svelte 5 surfaces for Managed Support (issue #1926): a case queue
- * and a case detail view. Presentational only — hosts load data through the
- * package services and adapt models with the exported view mappers.
+ * Reusable Svelte 5 surfaces for Managed Support (issues #1926/#1930): a case
+ * queue, a case detail view, and a time-entry approval queue. Presentational
+ * only — hosts load data through the package services and adapt models with
+ * the exported view mappers.
  *
  * @packageDocumentation
  */
@@ -11,10 +12,14 @@
 import type { ComponentProps } from 'svelte';
 import CaseDetail from './components/CaseDetail.svelte';
 import CaseQueue from './components/CaseQueue.svelte';
+import TimeEntryApprovalQueue from './components/TimeEntryApprovalQueue.svelte';
 
-export { CaseDetail, CaseQueue };
+export { CaseDetail, CaseQueue, TimeEntryApprovalQueue };
 export type CaseQueueProps = ComponentProps<typeof CaseQueue>;
 export type CaseDetailProps = ComponentProps<typeof CaseDetail>;
+export type TimeEntryApprovalQueueProps = ComponentProps<
+  typeof TimeEntryApprovalQueue
+>;
 
 export {
   type CaseTimelineItemView,
@@ -22,7 +27,10 @@ export {
   humanizeStatus,
   priorityBadgeKey,
   type SupportCaseView,
+  type SupportTimeEntryView,
   type SupportWorkLinkView,
+  timeEntryStatusBadgeKey,
   toCaseTimelineItemView,
   toSupportCaseView,
+  toSupportTimeEntryView,
 } from './types.js';

--- a/packages/support/src/svelte/types.ts
+++ b/packages/support/src/svelte/types.ts
@@ -7,9 +7,11 @@
  * intersections) keep Svelte 5 prop type evaluation cheap.
  */
 
+import type { ServiceTimeEntry } from '../models/service-time-entry.js';
 import type { SupportCase } from '../models/support-case.js';
 import type { SupportCaseEvent } from '../models/support-case-event.js';
 import type { SupportInteraction } from '../models/support-interaction.js';
+import type { SupportCharge } from '../models/support-settlement.js';
 import type { CaseTimelineItem } from '../services/support-case-service.js';
 
 export interface SupportCaseView {
@@ -47,6 +49,31 @@ export interface SupportWorkLinkView {
   targetLabel: string;
   externalUrl: string;
   status: string;
+}
+
+/**
+ * View shape for a Service Time Entry in approval/review surfaces. The first
+ * eight fields deliberately match `smrt-projects`' presentation `TimeEntry`
+ * contract (`packages/projects/src/svelte/utils.ts`) — smrt-support promotes
+ * that presentation-only shape into persisted models, so hosts can reuse
+ * either package's time surfaces over the same view rows.
+ */
+export interface SupportTimeEntryView {
+  id: string;
+  /** ISO date part (`YYYY-MM-DD`) of the work period start. */
+  date: string;
+  /** Worked duration in decimal hours, rounded to 2 decimals. */
+  hours: number;
+  description: string;
+  status: string;
+  /** Client charge amount, when a derived {@link SupportCharge} is supplied. */
+  amount?: number;
+  workerName?: string;
+  /** Hourly rate from the charge's frozen `rateSnapshot`, when supplied. */
+  hourlyRate?: number;
+  source: string;
+  participantKind: string;
+  caseId: string | null;
 }
 
 function toIso(value: Date | string | null | undefined): string | null {
@@ -152,4 +179,53 @@ export function priorityBadgeKey(priority: string): string {
 /** Human-readable label for a snake_case status value. */
 export function humanizeStatus(value: string): string {
   return (value ?? '').replace(/_/g, ' ');
+}
+
+/** Adapt a ServiceTimeEntry model (plus its optional charge) to the view. */
+export function toSupportTimeEntryView(
+  entry: ServiceTimeEntry,
+  opts: { charge?: SupportCharge | null; workerName?: string | null } = {},
+): SupportTimeEntryView {
+  const startIso = toIso(
+    entry.startedAt ?? (entry.created_at as Date | string | undefined) ?? null,
+  );
+  const view: SupportTimeEntryView = {
+    id: entry.id ?? '',
+    date: startIso ? startIso.slice(0, 10) : '',
+    hours: Math.round((entry.durationSeconds / 3600) * 100) / 100,
+    description: entry.description,
+    status: entry.status,
+    source: entry.source,
+    participantKind: entry.participantKind,
+    caseId: entry.caseId,
+  };
+  if (opts.charge) {
+    view.amount = opts.charge.amount;
+    const hourlyRate = opts.charge.getRateSnapshot().hourlyRate;
+    if (typeof hourlyRate === 'number') {
+      view.hourlyRate = hourlyRate;
+    }
+  }
+  if (opts.workerName) {
+    view.workerName = opts.workerName;
+  }
+  return view;
+}
+
+/** Map a time-entry status onto `StatusBadge` default color-scheme keys. */
+export function timeEntryStatusBadgeKey(status: string): string {
+  switch (status) {
+    case 'draft':
+      return 'inactive';
+    case 'submitted':
+      return 'pending';
+    case 'approved':
+      return 'success';
+    case 'rejected':
+      return 'error';
+    case 'corrected':
+      return 'warning';
+    default:
+      return 'pending';
+  }
 }

--- a/packages/support/src/svelte/types.ts
+++ b/packages/support/src/svelte/types.ts
@@ -11,6 +11,7 @@ import type { ServiceTimeEntry } from '../models/service-time-entry.js';
 import type { SupportCase } from '../models/support-case.js';
 import type { SupportCaseEvent } from '../models/support-case-event.js';
 import type { SupportInteraction } from '../models/support-interaction.js';
+import type { SupportServiceTarget } from '../models/support-service-target.js';
 import type { SupportCharge } from '../models/support-settlement.js';
 import type { CaseTimelineItem } from '../services/support-case-service.js';
 
@@ -228,4 +229,73 @@ export function timeEntryStatusBadgeKey(status: string): string {
     default:
       return 'pending';
   }
+}
+
+/** Serializable Service Target clock view for `TargetList` (#1929). */
+export interface ServiceTargetView {
+  id: string;
+  targetType: string;
+  cycle: number;
+  status: string;
+  severity: string;
+  baseMinutes: number;
+  startedAt: string | null;
+  dueAt: string | null;
+  satisfiedAt: string | null;
+  breachedAt: string | null;
+  /** Whether the clock is currently frozen by the plan's pause rules. */
+  paused: boolean;
+}
+
+/** Adapt a SupportServiceTarget model to the `TargetList` view shape. */
+export function toServiceTargetView(
+  target: SupportServiceTarget,
+): ServiceTargetView {
+  return {
+    id: target.id ?? '',
+    targetType: target.targetType,
+    cycle: target.cycle,
+    status: target.status,
+    severity: target.severity,
+    baseMinutes: target.baseMinutes,
+    startedAt: toIso(target.startedAt),
+    dueAt: toIso(target.dueAt),
+    satisfiedAt: toIso(target.satisfiedAt),
+    breachedAt: toIso(target.breachedAt),
+    paused: target.status === 'paused',
+  };
+}
+
+/**
+ * Map a Service Target status onto smrt-ui `StatusBadge` default
+ * color-scheme keys: running/paused clocks read as attention-colored,
+ * satisfied as success, breached as error.
+ */
+export function targetStatusBadgeKey(status: string): string {
+  switch (status) {
+    case 'pending':
+      return 'pending';
+    case 'paused':
+      return 'warning';
+    case 'satisfied':
+      return 'success';
+    case 'breached':
+      return 'error';
+    case 'cancelled':
+      return 'inactive';
+    default:
+      return 'pending';
+  }
+}
+
+/**
+ * Serializable ranked-specialist view for `RoutingRationale` (#1929) —
+ * mirrors the routing service's `RankedSpecialist` result shape.
+ */
+export interface RankedSpecialistView {
+  specialistId: string;
+  displayName: string;
+  score: number;
+  eligible: boolean;
+  factors: Record<string, number | string | boolean>;
 }

--- a/packages/support/src/svelte/types.ts
+++ b/packages/support/src/svelte/types.ts
@@ -1,0 +1,155 @@
+/**
+ * Serializable view types for the support Svelte surfaces.
+ *
+ * Components take plain view objects (not model instances) so hosts can pass
+ * data across the server/client boundary; `toSupportCaseView` /
+ * `toCaseTimelineItemView` adapt the models. Explicit interfaces (not inline
+ * intersections) keep Svelte 5 prop type evaluation cheap.
+ */
+
+import type { SupportCase } from '../models/support-case.js';
+import type { SupportCaseEvent } from '../models/support-case-event.js';
+import type { SupportInteraction } from '../models/support-interaction.js';
+import type { CaseTimelineItem } from '../services/support-case-service.js';
+
+export interface SupportCaseView {
+  id: string;
+  caseNumber: string;
+  subject: string;
+  status: string;
+  priority: string;
+  severity: string;
+  channelKind: string;
+  clientProfileId: string | null;
+  projectId: string | null;
+  assignedSpecialistId: string | null;
+  assignedSpecialistName: string | null;
+  reopenCount: number;
+  createdAt: string | null;
+  updatedAt: string | null;
+  resolutionSummary: string;
+}
+
+export interface CaseTimelineItemView {
+  kind: 'interaction' | 'event';
+  occurredAt: string;
+  actorKind: string;
+  summary: string;
+  body: string;
+  direction: string | null;
+  channelKind: string | null;
+  eventType: string | null;
+}
+
+export interface SupportWorkLinkView {
+  id: string;
+  linkKind: string;
+  targetLabel: string;
+  externalUrl: string;
+  status: string;
+}
+
+function toIso(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+/** Adapt a SupportCase model to the queue/detail view shape. */
+export function toSupportCaseView(
+  supportCase: SupportCase,
+  options: { assignedSpecialistName?: string | null } = {},
+): SupportCaseView {
+  return {
+    id: supportCase.id ?? '',
+    caseNumber: supportCase.caseNumber,
+    subject: supportCase.subject,
+    status: supportCase.status,
+    priority: supportCase.priority,
+    severity: supportCase.severity,
+    channelKind: supportCase.channelKind,
+    clientProfileId: supportCase.clientProfileId,
+    projectId: supportCase.projectId,
+    assignedSpecialistId: supportCase.assignedSpecialistId,
+    assignedSpecialistName: options.assignedSpecialistName ?? null,
+    reopenCount: supportCase.reopenCount,
+    createdAt: toIso(supportCase.created_at as Date | undefined),
+    updatedAt: toIso(supportCase.updated_at as Date | undefined),
+    resolutionSummary: supportCase.resolutionSummary,
+  };
+}
+
+/** Adapt one merged timeline item (interaction or event) to its view. */
+export function toCaseTimelineItemView(
+  item: CaseTimelineItem,
+): CaseTimelineItemView {
+  if (item.kind === 'interaction' && item.interaction) {
+    const interaction = item.interaction as SupportInteraction;
+    return {
+      kind: 'interaction',
+      occurredAt: toIso(interaction.occurredAt) ?? '',
+      actorKind: interaction.actorKind,
+      summary: `${interaction.direction} ${interaction.channelKind}`,
+      body: interaction.body,
+      direction: interaction.direction,
+      channelKind: interaction.channelKind,
+      eventType: null,
+    };
+  }
+  const event = item.event as SupportCaseEvent;
+  return {
+    kind: 'event',
+    occurredAt: toIso(event.occurredAt) ?? '',
+    actorKind: event.actorKind,
+    summary: event.summary,
+    body: '',
+    direction: null,
+    channelKind: null,
+    eventType: event.eventType,
+  };
+}
+
+/**
+ * Map a case status onto smrt-ui `StatusBadge`'s default color-scheme keys
+ * (`active` | `inactive` | `pending` | `error` | `success` | `warning`); pass
+ * the real status as the badge `label`.
+ */
+export function caseStatusBadgeKey(status: string): string {
+  switch (status) {
+    case 'new':
+    case 'triaged':
+      return 'pending';
+    case 'assigned':
+    case 'in_progress':
+      return 'active';
+    case 'waiting_on_client':
+      return 'warning';
+    case 'escalated':
+      return 'error';
+    case 'resolved':
+      return 'success';
+    case 'closed':
+      return 'inactive';
+    default:
+      return 'pending';
+  }
+}
+
+/** Map a case priority onto `StatusBadge` default color-scheme keys. */
+export function priorityBadgeKey(priority: string): string {
+  switch (priority) {
+    case 'urgent':
+      return 'error';
+    case 'high':
+      return 'warning';
+    case 'low':
+      return 'inactive';
+    default:
+      return 'active';
+  }
+}
+
+/** Human-readable label for a snake_case status value. */
+export function humanizeStatus(value: string): string {
+  return (value ?? '').replace(/_/g, ' ');
+}

--- a/packages/support/src/types.ts
+++ b/packages/support/src/types.ts
@@ -1,0 +1,332 @@
+/**
+ * Shared types, enums, and lifecycle maps for `@happyvertical/smrt-support`.
+ *
+ * Domain language follows the HappyVertical support glossary: a **Support
+ * Case** is the canonical record of a client support request; **Support
+ * Interactions** are channel transports attached to it; **Service Targets**
+ * are operational clocks (not contractual SLAs); a **Managed Support Plan**
+ * carries the client-facing terms while a **Support Compensation Plan**
+ * carries the provider-facing terms — the two are never merged.
+ */
+
+/** Support Case lifecycle states (FR-29b). */
+export type SupportCaseStatus =
+  | 'new'
+  | 'triaged'
+  | 'assigned'
+  | 'in_progress'
+  | 'waiting_on_client'
+  | 'escalated'
+  | 'resolved'
+  | 'closed';
+
+/**
+ * Legal Support Case status transitions, enforced at save time by
+ * {@link SupportCase} (S5 guarded-lifecycle idiom — raw mass-assignment on a
+ * generated route cannot skip states). Reopening (`resolved`/`closed` back to
+ * an active state) is legal here; the reopen bookkeeping (count, history
+ * event) is layered by `SupportCaseService.reopen()`.
+ */
+export const SUPPORT_CASE_STATUS_TRANSITIONS: Record<
+  SupportCaseStatus,
+  SupportCaseStatus[]
+> = {
+  new: [
+    'triaged',
+    'assigned',
+    'in_progress',
+    'waiting_on_client',
+    'escalated',
+    'resolved',
+    'closed',
+  ],
+  triaged: [
+    'assigned',
+    'in_progress',
+    'waiting_on_client',
+    'escalated',
+    'resolved',
+    'closed',
+  ],
+  assigned: [
+    'triaged',
+    'in_progress',
+    'waiting_on_client',
+    'escalated',
+    'resolved',
+    'closed',
+  ],
+  in_progress: [
+    'assigned',
+    'waiting_on_client',
+    'escalated',
+    'resolved',
+    'closed',
+  ],
+  waiting_on_client: [
+    'assigned',
+    'in_progress',
+    'escalated',
+    'resolved',
+    'closed',
+  ],
+  escalated: [
+    'assigned',
+    'in_progress',
+    'waiting_on_client',
+    'resolved',
+    'closed',
+  ],
+  resolved: ['closed', 'in_progress', 'triaged'],
+  closed: ['triaged', 'in_progress'],
+};
+
+/** Case statuses considered "open" for create-or-join intake dedup. */
+export const OPEN_SUPPORT_CASE_STATUSES: SupportCaseStatus[] = [
+  'new',
+  'triaged',
+  'assigned',
+  'in_progress',
+  'waiting_on_client',
+  'escalated',
+];
+
+/** Client-facing priority (ordering/urgency inside a queue). */
+export type SupportCasePriority = 'low' | 'normal' | 'high' | 'urgent';
+
+/** Transport kind a Support Interaction arrived through. */
+export type SupportChannelKind =
+  | 'chat'
+  | 'email'
+  | 'phone'
+  | 'voice'
+  | 'web'
+  | 'api';
+
+/** Direction of a Support Interaction relative to the Client. */
+export type SupportInteractionDirection = 'inbound' | 'outbound' | 'internal';
+
+/** Who performed an interaction or case event. */
+export type SupportActorKind = 'client' | 'specialist' | 'agent' | 'system';
+
+/** Append-only case audit event types. */
+export type SupportCaseEventType =
+  | 'created'
+  | 'interaction'
+  | 'transition'
+  | 'assignment'
+  | 'ai_run'
+  | 'handoff'
+  | 'human_requested'
+  | 'escalation'
+  | 'target_scheduled'
+  | 'target_satisfied'
+  | 'target_breached'
+  | 'target_paused'
+  | 'target_resumed'
+  | 'work_linked'
+  | 'reopened'
+  | 'plan_applied'
+  | 'time_recorded'
+  | 'note';
+
+/** What kind of transport container a channel binding points at. */
+export type SupportBindingKind = 'chat_room' | 'email_account';
+
+/** Operational Work Item link kinds carried by a {@link SupportWorkLink}. */
+export type SupportWorkLinkKind = 'support_work_item' | 'development_work_item';
+
+/** Service Target clock types (FR-30/FR-31). */
+export type ServiceTargetType =
+  | 'acknowledgement'
+  | 'response'
+  | 'update'
+  | 'resolution';
+
+/** Service Target clock states. */
+export type ServiceTargetStatus =
+  | 'pending'
+  | 'paused'
+  | 'satisfied'
+  | 'breached'
+  | 'cancelled';
+
+/** Why a case was escalated. */
+export type SupportEscalationReason =
+  | 'target_breach'
+  | 'target_risk'
+  | 'manual'
+  | 'ai_trigger';
+
+/** AI support workflow phases (FR-28a). */
+export type SupportAiRunPhase =
+  | 'acknowledge'
+  | 'classify'
+  | 'answer'
+  | 'troubleshoot'
+  | 'resolve';
+
+/** Terminal outcome of one AI workflow phase run. */
+export type SupportAiRunOutcome =
+  | 'completed'
+  | 'skipped'
+  | 'failed'
+  | 'handed_off';
+
+/** What triggered a Human Handoff (FR-28b). */
+export type HumanHandoffTrigger =
+  | 'client_request'
+  | 'low_confidence'
+  | 'high_severity'
+  | 'sensitive'
+  | 'failed_resolution'
+  | 'target_risk'
+  | 'policy'
+  | 'manual';
+
+/** Service Time Entry lifecycle (FR-36). */
+export type ServiceTimeEntryStatus =
+  | 'draft'
+  | 'submitted'
+  | 'approved'
+  | 'rejected'
+  | 'corrected';
+
+/**
+ * Legal Service Time Entry status transitions. `approved → corrected` is the
+ * only exit from `approved` and is reachable exclusively through the explicit
+ * correction path (the approved snapshot itself stays frozen).
+ */
+export const SERVICE_TIME_ENTRY_STATUS_TRANSITIONS: Record<
+  ServiceTimeEntryStatus,
+  ServiceTimeEntryStatus[]
+> = {
+  draft: ['submitted', 'rejected'],
+  submitted: ['approved', 'rejected', 'draft'],
+  approved: ['corrected'],
+  rejected: ['draft', 'submitted'],
+  corrected: [],
+};
+
+/** How a Service Time Entry was produced (FR-40). */
+export type ServiceTimeEntrySource = 'timer' | 'manual' | 'import' | 'agent';
+
+/** Who/what delivered the work behind a Service Time Entry. */
+export type SupportParticipantKind = 'human' | 'agent';
+
+/** Which approval path accepted a Service Time Entry (FR-36). */
+export type TimeEntryApprovalPath =
+  | 'automatic'
+  | 'operator'
+  | 'client'
+  | 'threshold';
+
+/** Derived commercial snapshot lifecycle (charges and compensation). */
+export type SupportSettlementStatus =
+  | 'pending'
+  | 'final'
+  | 'corrected'
+  | 'voided';
+
+/** Support Specialist availability window kinds. */
+export type SupportAvailabilityKind = 'weekly' | 'on_call' | 'time_off';
+
+/** Support Specialist activation state. */
+export type SupportSpecialistStatus = 'active' | 'inactive';
+
+/** Project Support Qualification levels. */
+export type SupportQualificationLevel = 'trainee' | 'qualified' | 'expert';
+
+/** A weekly coverage window in a plan's coverage calendar. */
+export interface CoverageWindow {
+  /** 0 = Sunday … 6 = Saturday (JS `Date#getDay` convention). */
+  weekday: number;
+  /** Minutes from midnight, inclusive start. */
+  startMinute: number;
+  /** Minutes from midnight, exclusive end. */
+  endMinute: number;
+}
+
+/** Per-severity Service Target minutes; `null` disables that clock. */
+export interface ServiceTargetMinutes {
+  acknowledgementMinutes: number | null;
+  responseMinutes: number | null;
+  updateMinutes: number | null;
+  resolutionMinutes: number | null;
+}
+
+/** One step of a plan's escalation policy, applied in `level` order. */
+export interface EscalationStep {
+  level: number;
+  action: 'notify' | 'reassign';
+  /** Profile ids to notify (recorded on the escalation; delivery is app-side). */
+  notifyProfileIds?: string[];
+  /** Minutes after the previous step before this one fires (0 = immediately). */
+  delayMinutes?: number;
+}
+
+/** A severity definition entry in a plan (key → labels). */
+export interface SeverityDefinition {
+  label: string;
+  description?: string;
+}
+
+/**
+ * Default severity vocabulary used when a plan doesn't define its own.
+ * `sev1` is the most severe.
+ */
+export const DEFAULT_SEVERITY_DEFINITIONS: Record<string, SeverityDefinition> =
+  {
+    sev1: { label: 'Critical', description: 'Service down or unusable' },
+    sev2: { label: 'Major', description: 'Significant degradation' },
+    sev3: { label: 'Minor', description: 'Limited impact' },
+    sev4: { label: 'Question', description: 'Question or request' },
+  };
+
+/** Time-entry approval policy carried by a Managed Support Plan (FR-36). */
+export interface TimeApprovalPolicy {
+  /** Base path when no threshold applies. */
+  mode: 'automatic' | 'operator' | 'client';
+  /** Entries longer than this require review even under `automatic`. */
+  thresholdMinutes?: number;
+  /** Entries pricing above this amount require review even under `automatic`. */
+  thresholdAmount?: number;
+}
+
+/** One piece of work evidence attached to a Service Time Entry. */
+export interface TimeEntryEvidence {
+  kind: string;
+  ref: string;
+  label?: string;
+}
+
+/**
+ * Parse a JSON value stored as text, returning the fallback on malformed
+ * input (never throws — stored JSON may predate schema changes).
+ */
+export function parseJsonField<T>(
+  raw: string | null | undefined,
+  fallback: T,
+): T {
+  if (!raw) {
+    return fallback;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    // Hydrated `type: 'json'`-less text columns always come back as strings,
+    // but be tolerant of a caller passing an already-parsed object through.
+    return (parsed ?? fallback) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+/** Parse a JSON array-of-strings field, tolerating malformed input. */
+export function parseStringArrayField(
+  raw: string | null | undefined,
+): string[] {
+  const parsed = parseJsonField<unknown>(raw, []);
+  return Array.isArray(parsed)
+    ? parsed.filter((value): value is string => typeof value === 'string')
+    : [];
+}

--- a/packages/support/src/types.ts
+++ b/packages/support/src/types.ts
@@ -302,19 +302,21 @@ export interface TimeEntryEvidence {
 
 /**
  * Parse a JSON value stored as text, returning the fallback on malformed
- * input (never throws — stored JSON may predate schema changes).
+ * input (never throws — stored JSON may predate schema changes). Accepts an
+ * already-parsed value (e.g. a `type: 'json'` column that hydrated as an
+ * object) and hands it back unchanged.
  */
-export function parseJsonField<T>(
-  raw: string | null | undefined,
-  fallback: T,
-): T {
+export function parseJsonField<T>(raw: unknown, fallback: T): T {
   if (!raw) {
     return fallback;
   }
+  // Text columns hydrate as strings; a non-string here means the caller
+  // already holds a parsed value — hand it back rather than throwing.
+  if (typeof raw !== 'string') {
+    return raw as T;
+  }
   try {
     const parsed = JSON.parse(raw);
-    // Hydrated `type: 'json'`-less text columns always come back as strings,
-    // but be tolerant of a caller passing an already-parsed object through.
     return (parsed ?? fallback) as T;
   } catch {
     return fallback;

--- a/packages/support/tsconfig.build.json
+++ b/packages/support/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.package-build.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "exclude": [
+    "src/svelte/**/*",
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/support/tsconfig.json
+++ b/packages/support/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.ui-package.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": ".",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["ambient.d.ts", "src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/support/tsconfig.svelte.json
+++ b/packages/support/tsconfig.svelte.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.package-svelte.json",
+  "include": ["ambient.d.ts", "src/**/*.ts", "src/**/*.svelte"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/support/vite.config.ts
+++ b/packages/support/vite.config.ts
@@ -1,0 +1,5 @@
+import { createPackageConfig } from '../../vite.config.base.js';
+
+export default createPackageConfig('support', {
+  svelte: 'svelte',
+});

--- a/packages/support/vitest.config.ts
+++ b/packages/support/vitest.config.ts
@@ -1,0 +1,30 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vitest/config';
+import {
+  smrtVitestPlugin,
+  smrtVitestSetupPath,
+} from '../../vitest.workspace.js';
+
+export default defineConfig({
+  plugins: [svelte(), smrtVitestPlugin({ setupFile: smrtVitestSetupPath })],
+  // The smrt-vitest plugin auto-applies the workspace package→src aliases in
+  // its config() hook; only the browser resolve conditions are needed here so
+  // Svelte component tests resolve the client runtime.
+  resolve: {
+    conditions: ['browser'],
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.ts'],
+    // Manifest setup + the shared Svelte component-test harness (S11 #1416).
+    // The harness only activates under a DOM; component tests opt in with
+    // `// @vitest-environment jsdom`.
+    setupFiles: [smrtVitestSetupPath, '@happyvertical/smrt-vitest/svelte-setup'],
+    testTimeout: 30000,
+    hookTimeout: 30000,
+    fileParallelism: false,
+    pool: 'forks',
+    singleFork: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2307,6 +2307,64 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  packages/support:
+    dependencies:
+      '@happyvertical/logger':
+        specifier: ^0.78.0
+        version: 0.78.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+      '@happyvertical/smrt-chat':
+        specifier: workspace:*
+        version: link:../chat
+      '@happyvertical/smrt-core':
+        specifier: workspace:*
+        version: link:../core
+      '@happyvertical/smrt-jobs':
+        specifier: workspace:*
+        version: link:../jobs
+      '@happyvertical/smrt-messages':
+        specifier: workspace:*
+        version: link:../messages
+      '@happyvertical/smrt-tenancy':
+        specifier: workspace:*
+        version: link:../tenancy
+      '@happyvertical/smrt-ui':
+        specifier: workspace:*
+        version: link:../smrt-ui
+      '@happyvertical/smrt-users':
+        specifier: workspace:*
+        version: link:../users
+      '@happyvertical/sql':
+        specifier: ^0.78.0
+        version: 0.78.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+    devDependencies:
+      '@happyvertical/smrt-vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@sveltejs/package':
+        specifier: ^2.5.8
+        version: 2.5.8(svelte@5.56.4)(typescript@5.9.3)
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.1.2
+        version: 7.1.2(svelte@5.56.4)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@types/node':
+        specifier: 24.13.2
+        version: 24.13.2
+      svelte:
+        specifier: ^5.56.4
+        version: 5.56.4
+      svelte-check:
+        specifier: ^4.7.1
+        version: 4.7.1(picomatch@4.0.5)(svelte@5.56.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.1.3
+        version: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+
   packages/tags:
     dependencies:
       '@happyvertical/ai':


### PR DESCRIPTION
## Summary

New package **`@happyvertical/smrt-support`** — AI-first Support Cases for the SMRT framework, shipping epic #1934 end-to-end as one integration PR:

- Closes #1926 (Support Case lifecycle from one inbound channel to reusable UI)
- Closes #1928 (Immediate AI resolution with optional lossless Human Handoff)
- Closes #1929 (Project-qualified routing, service targets, and timed escalation)
- Closes #1930 (Persist Support Time, separate client charges from provider compensation)
- Closes #1934 (the epic)

Consumer roadmap: happyvertical/projects.happyvertical.com#111. Cross-cutting usage pricing (#1925) is explicitly out of scope — settlement/invoicing composes later at the accounting boundary; this package persists the evidence and the derived snapshots.

## What's in the package

**Case core (#1926).** Every inbound interaction on a *bound* transport container creates or joins one canonical, tenant-scoped `SupportCase` (channels stay transports, never systems of record). Both channels are fully wired: chat rooms (`chat:<roomId>[:<threadId>]` conversation keys, `role: 'user'` only) and email accounts (RFC-thread joins via `inReplyTo`, self-address skip, unresolved senders parked with `metadata.unresolvedClient`). Intake is idempotent (`SupportInteraction.sourceKey` unique), deterministic (open → join, resolved → reopen, closed → new case), and available as an opt-in `GlobalInterceptors.afterSave` observer that never throws into the source package's save path. The lifecycle `new → triaged → assigned → in_progress → waiting_on_client|escalated → resolved → closed` is guarded at save time (WeakMap + authoritative-DB-read idiom from S5 #1390) with reopen history preserved in append-only `SupportCaseEvent`s. Writes go through the closed `SupportCaseService` facade (chat's `ChatService` idiom); generated API/CLI/MCP surfaces on case-side models are read-only.

**AI workflow (#1928).** `SupportAiWorkflow` runs acknowledge → classify → answer → resolve under a resolved `SupportPolicy` with **conservative defaults** (ack/classify/answer on; tool-executing troubleshooting and auto-resolve off until enabled; email replies drafted, not sent). AI calls go through an injected `SupportAiBoundary` (default uses `SmrtObject.do()` with defensive JSON parsing that fails toward the human); knowledge is a pluggable `SupportKnowledgeProvider`. Every phase writes an auditable `SupportAiRun` (confidence, classification, knowledge refs, outcome, correlation id). Handoff triggers are always active — client request, low confidence, high severity, sensitive category, failed resolution, attempt budget — and `HumanHandoffService` transfers the complete context package (case state + timeline + prior automated work) with a no-repeat guarantee and a routing seam.

**Routing, targets, escalation (#1929).** `SupportRoutingService` produces explainable ranked assignments (hard filters: active status, effective Project Support Qualification, workload cap, availability windows in the specialist's timezone; scored factors: preferred specialist, qualification level, on-call, workload headroom, language — every factor recorded, ineligible specialists show why). Manual reassignment is gated by the new `support.reassign-case` permission. `ServiceTargetEngine` derives acknowledgement/response/update/resolution clocks from the case's frozen `planSnapshot`, computes due times in covered time (timezone-aware coverage calendars + holidays; empty = 24×7), pauses clocks **only when the plan's pause rules say so** (FR-29b), and schedules one-shot `_smrt_jobs` escalation jobs at `dueAt` that are cancelled on satisfy. Breach escalates through the plan's policy steps (notify/reassign, delayed follow-up levels) via an at-least-once-safe `checkAndEscalate` job method.

**Service time (#1930).** `ServiceTimeEntry` is work-context-generic (case and/or polymorphic work ref) so planning/development adopt it later without migration; timer, manual, imported, and automatic agent entries share one validation/audit contract. Approval paths — automatic, operator (gated by `support.approve-time-entry`), client, and threshold-triggered — produce **immutable approved snapshots** (LicenseSale WeakMap-freeze idiom backed by an authoritative DB-row comparison); disputes create explicit corrections (`correctionOfId` chain). Approval derives two deliberately separate rows per entry: `SupportCharge` (Managed Support Plan: included time first, then metered overage / on-call rate) and `SupportCompensation` (effective-dated Support Compensation Plan) — margin is computable, never stored, and compensation never leaks into case-side events. Plan edits never rewrite history (`planSnapshot` / `rateSnapshot`). The Svelte time-entry view stays prop-compatible with smrt-projects' presentation `TimeEntry` contract it promotes.

**Boundary (FR-29a).** Support owns tickets, interactions, routing, and service targets. Delivery Operations owns repository work: a Delivery Handoff links a case to a Development Work Item (e.g. `@happyvertical/smrt-projects:Issue`) via `SupportWorkLink` — status echoes flow back; execution never lives here.

**Reusable UI.** `@happyvertical/smrt-support/svelte`: `CaseQueue`, `CaseDetail`, `TargetList`, `RoutingRationale`, `TimeEntryApprovalQueue` — presentational Svelte 5 on smrt-ui primitives (`smrtRawPrimitives: "strict"`), with serializable view mappers.

## Integration & conventions

- 17 `@smrt()` models, closed-facade services, `@crossPackageRef` string links only (Profile, smrt-projects Issue, subscriptions plan key) — dependency graph stays a DAG; no inter-smrt peerDeps.
- New permission slugs contributed on import (personas pattern): `support.reassign-case`, `support.approve-time-entry`, `support.manage-plans`.
- Root wiring: `.changeset/config.json` fixed group + root `AGENTS.md` row. No vite.config.base or tsconfig overrides needed (`packages/support` matches the wildcards).
- Package version aligned to the 0.39.1 fixed group.

## Tests

145 tests across 16 files, all green locally (real in-memory SQLite from the generated manifest; real `_smrt_jobs` rows; only the AI boundary/knowledge provider are injected): lifecycle + illegal-transition + upsert-forgery guards, tenant isolation, chat/email create-or-join determinism + idempotent re-ingestion + reopen semantics, generated-surface config assertions, AI workflow autonomy/handoff matrix (11 scenarios), handoff context completeness, coverage-calendar math (business hours, weekends, holidays, timezones), target scheduling/pause/resume/breach/escalation with real job rows, explainable routing + permission gates, the full approval-path matrix, included-time→overage charge math, effective-dated compensation resolution, approved-snapshot immutability + corrections, plan-edit isolation, and jsdom + axe a11y coverage for all five components.

`pnpm build` (all 59 tasks), `pnpm typecheck` (tsc + svelte-check 0/0), Biome clean, `check-package-dag` / `check-no-smrt-peers` / `check-raw-primitives` / `dev:knowledge-check --strict` all green.
