### PR TITLE
fix(ci): expose isolated database to libpq clients

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -73,7 +73,8 @@ Packages opt in with a `test:postgres` script. The wrapper obtains the
 disposable URL from `CI_POSTGRES_BASE_URL` or the read-only file named by
 `CI_POSTGRES_BASE_URL_FILE`, creates a uniquely named database, exports all
 supported PostgreSQL test URL variables plus libpq's `PG*` connection
-variables, and drops the database afterward. IAC
+variables, including supported URI query parameters, and drops the database
+afterward. IAC
 stores the same credential in SOPS-encrypted Secrets in the database and runner
 namespaces; the node runner mounts only the URL copy. It has no production
 database secret access.

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -72,7 +72,8 @@ and documentation deployment remain on main.
 Packages opt in with a `test:postgres` script. The wrapper obtains the
 disposable URL from `CI_POSTGRES_BASE_URL` or the read-only file named by
 `CI_POSTGRES_BASE_URL_FILE`, creates a uniquely named database, exports all
-supported PostgreSQL test URL variables, and drops the database afterward. IAC
+supported PostgreSQL test URL variables plus libpq's `PG*` connection
+variables, and drops the database afterward. IAC
 stores the same credential in SOPS-encrypted Secrets in the database and runner
 namespaces; the node runner mounts only the URL copy. It has no production
 database secret access.

--- a/scripts/run-with-ci-postgres.mjs
+++ b/scripts/run-with-ci-postgres.mjs
@@ -6,6 +6,43 @@ import { pathToFileURL } from 'node:url';
 
 const DEFAULT_URL_FILE = '/var/run/ci-services/postgres/url';
 
+const LIBPQ_PARAMETER_ENV = {
+  application_name: 'PGAPPNAME',
+  channel_binding: 'PGCHANNELBINDING',
+  client_encoding: 'PGCLIENTENCODING',
+  connect_timeout: 'PGCONNECT_TIMEOUT',
+  dbname: 'PGDATABASE',
+  gssencmode: 'PGGSSENCMODE',
+  gsslib: 'PGGSSLIB',
+  host: 'PGHOST',
+  hostaddr: 'PGHOSTADDR',
+  keepalives: 'PGKEEPALIVES',
+  keepalives_count: 'PGKEEPALIVESCOUNT',
+  keepalives_idle: 'PGKEEPALIVESIDLE',
+  keepalives_interval: 'PGKEEPALIVESINTERVAL',
+  krbsrvname: 'PGKRBSRVNAME',
+  load_balance_hosts: 'PGLOADBALANCEHOSTS',
+  options: 'PGOPTIONS',
+  passfile: 'PGPASSFILE',
+  password: 'PGPASSWORD',
+  port: 'PGPORT',
+  requirepeer: 'PGREQUIREPEER',
+  service: 'PGSERVICE',
+  servicefile: 'PGSERVICEFILE',
+  sslcert: 'PGSSLCERT',
+  sslcrl: 'PGSSLCRL',
+  sslcrldir: 'PGSSLCRLDIR',
+  sslkey: 'PGSSLKEY',
+  ssl_max_protocol_version: 'PGSSLMAXPROTOCOLVERSION',
+  ssl_min_protocol_version: 'PGSSLMINPROTOCOLVERSION',
+  sslmode: 'PGSSLMODE',
+  sslrootcert: 'PGSSLROOTCERT',
+  sslsni: 'PGSSLSNI',
+  target_session_attrs: 'PGTARGETSESSIONATTRS',
+  tcp_user_timeout: 'PGTCPUSER_TIMEOUT',
+  user: 'PGUSER',
+};
+
 export function createDatabaseName({
   epoch = Math.floor(Date.now() / 1000),
   runId = process.env.GITHUB_RUN_ID || 'local',
@@ -28,17 +65,26 @@ export function databaseUrl(baseUrl, databaseName) {
 
 export function databaseEnvironment(testUrl, environment = process.env) {
   const url = new URL(testUrl);
+  const libpqEnvironment = {
+    PGHOST: url.hostname,
+    PGPORT: url.port || '5432',
+    PGUSER: decodeURIComponent(url.username),
+    PGPASSWORD: decodeURIComponent(url.password),
+    PGDATABASE: decodeURIComponent(url.pathname.replace(/^\//, '')),
+  };
+
+  for (const [parameter, value] of url.searchParams) {
+    const environmentName = LIBPQ_PARAMETER_ENV[parameter];
+    if (environmentName) libpqEnvironment[environmentName] = value;
+  }
+
   return {
     ...environment,
     DATABASE_URL: testUrl,
     TEST_DB_URL: testUrl,
     TEST_DB_ADAPTER: 'postgres',
     SMRT_TEST_POSTGRES_URL: testUrl,
-    PGHOST: url.hostname,
-    PGPORT: url.port || '5432',
-    PGUSER: decodeURIComponent(url.username),
-    PGPASSWORD: decodeURIComponent(url.password),
-    PGDATABASE: decodeURIComponent(url.pathname.replace(/^\//, '')),
+    ...libpqEnvironment,
   };
 }
 

--- a/scripts/run-with-ci-postgres.mjs
+++ b/scripts/run-with-ci-postgres.mjs
@@ -26,6 +26,22 @@ export function databaseUrl(baseUrl, databaseName) {
   return url.toString();
 }
 
+export function databaseEnvironment(testUrl, environment = process.env) {
+  const url = new URL(testUrl);
+  return {
+    ...environment,
+    DATABASE_URL: testUrl,
+    TEST_DB_URL: testUrl,
+    TEST_DB_ADAPTER: 'postgres',
+    SMRT_TEST_POSTGRES_URL: testUrl,
+    PGHOST: url.hostname,
+    PGPORT: url.port || '5432',
+    PGUSER: decodeURIComponent(url.username),
+    PGPASSWORD: decodeURIComponent(url.password),
+    PGDATABASE: decodeURIComponent(url.pathname.replace(/^\//, '')),
+  };
+}
+
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     stdio: 'inherit',
@@ -91,13 +107,7 @@ export async function main(argv = process.argv.slice(2)) {
     }
 
     const status = run(command, args, {
-      env: {
-        ...process.env,
-        DATABASE_URL: testUrl,
-        TEST_DB_URL: testUrl,
-        TEST_DB_ADAPTER: 'postgres',
-        SMRT_TEST_POSTGRES_URL: testUrl,
-      },
+      env: databaseEnvironment(testUrl),
     });
     return status;
   } finally {

--- a/scripts/run-with-ci-postgres.test.mjs
+++ b/scripts/run-with-ci-postgres.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
   createDatabaseName,
+  databaseEnvironment,
   databaseUrl,
 } from './run-with-ci-postgres.mjs';
 
@@ -30,4 +31,24 @@ test('replaces only the database path in a PostgreSQL URL', () => {
     ),
     'postgresql://ci_runner:secret@ci-postgres-rw.ci-services:5432/smrt_ci_1_2_3_core_4?sslmode=require',
   );
+});
+
+test('exports the isolated URL for SMRT and libpq clients', () => {
+  const url =
+    'postgresql://ci_runner:secret%20value@ci-postgres-rw:5433/smrt_ci_1';
+  const environment = databaseEnvironment(url, {
+    KEEP_ME: 'yes',
+    PGDATABASE: 'old-database',
+  });
+
+  assert.equal(environment.KEEP_ME, 'yes');
+  assert.equal(environment.DATABASE_URL, url);
+  assert.equal(environment.TEST_DB_URL, url);
+  assert.equal(environment.TEST_DB_ADAPTER, 'postgres');
+  assert.equal(environment.SMRT_TEST_POSTGRES_URL, url);
+  assert.equal(environment.PGHOST, 'ci-postgres-rw');
+  assert.equal(environment.PGPORT, '5433');
+  assert.equal(environment.PGUSER, 'ci_runner');
+  assert.equal(environment.PGPASSWORD, 'secret value');
+  assert.equal(environment.PGDATABASE, 'smrt_ci_1');
 });

--- a/scripts/run-with-ci-postgres.test.mjs
+++ b/scripts/run-with-ci-postgres.test.mjs
@@ -35,7 +35,8 @@ test('replaces only the database path in a PostgreSQL URL', () => {
 
 test('exports the isolated URL for SMRT and libpq clients', () => {
   const url =
-    'postgresql://ci_runner:secret%20value@ci-postgres-rw:5433/smrt_ci_1';
+    'postgresql://ci_runner:secret%20value@authority-host:5433/smrt_ci_1' +
+    '?host=query-host&port=6543&sslmode=verify-full&application_name=smrt%20ci';
   const environment = databaseEnvironment(url, {
     KEEP_ME: 'yes',
     PGDATABASE: 'old-database',
@@ -46,9 +47,11 @@ test('exports the isolated URL for SMRT and libpq clients', () => {
   assert.equal(environment.TEST_DB_URL, url);
   assert.equal(environment.TEST_DB_ADAPTER, 'postgres');
   assert.equal(environment.SMRT_TEST_POSTGRES_URL, url);
-  assert.equal(environment.PGHOST, 'ci-postgres-rw');
-  assert.equal(environment.PGPORT, '5433');
+  assert.equal(environment.PGHOST, 'query-host');
+  assert.equal(environment.PGPORT, '6543');
   assert.equal(environment.PGUSER, 'ci_runner');
   assert.equal(environment.PGPASSWORD, 'secret value');
   assert.equal(environment.PGDATABASE, 'smrt_ci_1');
+  assert.equal(environment.PGSSLMODE, 'verify-full');
+  assert.equal(environment.PGAPPNAME, 'smrt ci');
 });


### PR DESCRIPTION
## Summary

- export the disposable test database through libpq's standard `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, and `PGDATABASE` variables
- preserve the existing SMRT PostgreSQL URL variables
- add regression coverage for URL parsing and document the libpq interface

## Why

The node-runner shadow workflow created the isolated database correctly, but bare `psql` ignored the URI stored in `PGDATABASE` and fell back to a local Unix socket. Splitting the isolated URL into libpq's standard variables makes CLI clients use the same per-run database as SMRT tests.

## Validation

- `node --test scripts/run-with-ci-postgres.test.mjs`
- `pnpm knowledge:check --changed --strict --format markdown`
- repository pre-commit and pre-push hooks
- [node-runner shadow validation](https://github.com/happyvertical/smrt/actions/runs/29136416607): Node 24.18.0, pnpm 11.11.0, no Docker socket/privileged sidecar, same-filesystem hardlinks, disposable PostgreSQL create/query/drop