### PR TITLE
chore(release): reconcile v0.39.2 repository state

### DIFF
--- a/.changeset/quick-vite-consumers.md
+++ b/.changeset/quick-vite-consumers.md
@@ -1,5 +1,0 @@
----
-'@happyvertical/smrt-playground': patch
----
-
-Allow consumers to use SMRT Playground with stable Vite 7 or Vite 8 releases.

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -412,10 +412,18 @@ jobs:
       # round-robins by name), keeping per-runner load low so transient
       # resource-pressure timing flakes stay rare.
       - name: Run package tests (shard ${{ matrix.shard }}, excluding core)
-        run: node scripts/test-packages-shard.mjs '${{ matrix.shard }}' | xargs -r pnpm turbo run test --concurrency=2
+        # SQLite-heavy suites can emit tens of thousands of successful log
+        # lines. Buffer only failed task output so ARC runners retain a healthy
+        # log stream while otherwise-green tests keep running.
+        run: >-
+          node scripts/test-packages-shard.mjs '${{ matrix.shard }}'
+          | xargs -r pnpm turbo run test --concurrency=2 --output-logs=errors-only
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_ENV: test
+          # The node runner exposes all 32 host CPUs. Cap each of the two
+          # concurrent Turbo tasks so Vitest cannot fan out to dozens of workers.
+          VITEST_MAX_WORKERS: '2'
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -412,12 +412,9 @@ jobs:
       # round-robins by name), keeping per-runner load low so transient
       # resource-pressure timing flakes stay rare.
       - name: Run package tests (shard ${{ matrix.shard }}, excluding core)
-        # SQLite-heavy suites can emit tens of thousands of successful log
-        # lines. Buffer only failed task output so ARC runners retain a healthy
-        # log stream while otherwise-green tests keep running.
         run: >-
           node scripts/test-packages-shard.mjs '${{ matrix.shard }}'
-          | xargs -r pnpm turbo run test --concurrency=2 --output-logs=errors-only
+          | xargs -r pnpm turbo run test --concurrency=2
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_ENV: test

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "smrt framework for building vertical AI agents",
   "author": "Will Griffin <willgriffin@gmail.com>",
   "type": "module",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "files": [
     "AGENTS.md",
     "CLAUDE.md"

--- a/packages/ads/CHANGELOG.md
+++ b/packages/ads/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-ads
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/ads/package.json
+++ b/packages/ads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ads",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Advertising delivery and tracking models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/affiliates/CHANGELOG.md
+++ b/packages/affiliates/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-affiliates
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-sales@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/affiliates/package.json
+++ b/packages/affiliates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-affiliates",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "DEPRECATED compatibility shim over @happyvertical/smrt-sales — re-exports the legacy Partner/Commission/Payout names. See MIGRATION.md.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/CHANGELOG.md
+++ b/packages/agents/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-agents
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-config@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-secrets@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+- @happyvertical/smrt-users@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-agents",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "type": "module",
   "smrtRawPrimitives": "strict",
   "description": "Agent framework for building autonomous actors in the SMRT ecosystem",

--- a/packages/analytics/CHANGELOG.md
+++ b/packages/analytics/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-analytics
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-prompts@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-analytics",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Analytics integration models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/app-cli/CHANGELOG.md
+++ b/packages/app-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-app-cli
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-users@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/app-cli/package.json
+++ b/packages/app-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-app-cli",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Reusable CLI factory for SMRT apps — branded `<name> <resource> <command>` CLI + stdio MCP bridge with decorator-driven resource discovery",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/assets-ergot/CHANGELOG.md
+++ b/packages/assets-ergot/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-assets-ergot
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/assets-ergot/package.json
+++ b/packages/assets-ergot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-assets-ergot",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Ergot-backed processing, search, and workflow adapter for SMRT assets",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/assets-local/CHANGELOG.md
+++ b/packages/assets-local/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-assets-local
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/assets-local/package.json
+++ b/packages/assets-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-assets-local",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Local image metadata and variant processor for SMRT assets",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-assets
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-tags@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-assets",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Asset management system with versioning, metadata, and AI-powered operations for SMRT framework",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/chat/CHANGELOG.md
+++ b/packages/chat/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-chat
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-agents@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-personas@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+- @happyvertical/smrt-users@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-chat",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Chat rooms, DMs, threads, and agent conversations for the SMRT framework",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-cli
 
+## 0.39.2
+
+### Patch Changes
+
+- Updated dependencies [c80ac05]
+  - @happyvertical/smrt-playground@0.39.2
+  - @happyvertical/smrt-agents@0.39.2
+  - @happyvertical/smrt-config@0.39.2
+  - @happyvertical/smrt-core@0.39.2
+  - @happyvertical/smrt-dev-mcp@0.39.2
+  - @happyvertical/smrt-types@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-cli",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Developer CLI for SMRT framework - introspection, testing, and project management",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/commerce/CHANGELOG.md
+++ b/packages/commerce/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-commerce
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-ledgers@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-commerce",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Commerce models for the SMRT framework - contracts, fulfillments, payments",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-config
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-types@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-config",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "type": "module",
   "description": "Centralized configuration management for SMRT modules",
   "author": "HappyVertical",

--- a/packages/content/CHANGELOG.md
+++ b/packages/content/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @happyvertical/smrt-content
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.39.2
+- @happyvertical/smrt-chat@0.39.2
+- @happyvertical/smrt-images@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-facts@0.39.2
+- @happyvertical/smrt-messages@0.39.2
+- @happyvertical/smrt-profiles@0.39.2
+- @happyvertical/smrt-prompts@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-content",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Content processing module for SMRT framework - handles documents, web content, and media",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-core
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-config@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-scanner@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-core",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Core AI agent framework with standardized collections, object-relational mapping, and code generators",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/events/CHANGELOG.md
+++ b/packages/events/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-events
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-places@0.39.2
+- @happyvertical/smrt-profiles@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-events",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Hierarchical event management with participant tracking and SMRT framework support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/facts/CHANGELOG.md
+++ b/packages/facts/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-facts
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-prompts@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/facts/package.json
+++ b/packages/facts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-facts",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Distributed memory and knowledge management with provenance tracking for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/features/CHANGELOG.md
+++ b/packages/features/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-features
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-features",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Code-first feature flags and tenant-aware overrides for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gnode/CHANGELOG.md
+++ b/packages/gnode/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-gnode
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/gnode/package.json
+++ b/packages/gnode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-gnode",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "SMRT federation library for building federated local knowledge bases (gnodes)",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/images/CHANGELOG.md
+++ b/packages/images/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-images
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-prompts@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-images",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Image asset management with AI-powered categorization, search, editing, and metadata extraction for SMRT framework",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/inventory/CHANGELOG.md
+++ b/packages/inventory/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-inventory
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-inventory",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Multi-location stock tracking for the SMRT framework — Sku, InventoryLocation, StockLevel, StockMovement, and a stock-mutation service",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/jobs/CHANGELOG.md
+++ b/packages/jobs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-jobs
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-config@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-jobs",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Background job processing for SMRT objects with persistence and scheduling",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/languages/CHANGELOG.md
+++ b/packages/languages/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-languages
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-features@0.39.2
+- @happyvertical/smrt-config@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-jobs@0.39.2
+- @happyvertical/smrt-prompts@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-languages",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Code-first language strings with config + tenant overrides and AI auto-translation for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ledgers/CHANGELOG.md
+++ b/packages/ledgers/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-ledgers
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-prompts@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/ledgers/package.json
+++ b/packages/ledgers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ledgers",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Double-entry accounting ledger for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/manufacturing/CHANGELOG.md
+++ b/packages/manufacturing/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-manufacturing
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-inventory@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/manufacturing/package.json
+++ b/packages/manufacturing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-manufacturing",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Bills of materials, cost rollup, and production-order operations for the SMRT framework — strictly industry-neutral",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/messages/CHANGELOG.md
+++ b/packages/messages/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-messages
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-secrets@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-messages",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Unified multi-channel messaging with STI-based hierarchies",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/personas/CHANGELOG.md
+++ b/packages/personas/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-personas
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-agents@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-prompts@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+- @happyvertical/smrt-users@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/personas/package.json
+++ b/packages/personas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-personas",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Tenant-owned, context-scoped agent personas and resolution for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/places/CHANGELOG.md
+++ b/packages/places/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-places
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/places/package.json
+++ b/packages/places/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-places",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Hierarchical place management with geo integration and SMRT framework support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/products/CHANGELOG.md
+++ b/packages/products/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-products
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+- @happyvertical/smrt-svelte@0.39.2
+- @happyvertical/smrt-scanner@0.39.2
+- @happyvertical/smrt-web@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-products",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "SMRT products module: triple-purpose microservice template for standalone apps, federated modules, and NPM libraries",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/profiles/CHANGELOG.md
+++ b/packages/profiles/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-profiles
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-prompts@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/profiles/package.json
+++ b/packages/profiles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-profiles",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Profile management system with relationships, metadata, and reciprocal associations for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/projects/CHANGELOG.md
+++ b/packages/projects/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-projects
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-config@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-prompts@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-projects",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Provider-agnostic project management models (Issues, PRs, Repositories, Projects) for SMRT framework",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/prompts/CHANGELOG.md
+++ b/packages/prompts/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-prompts
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-config@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-prompts",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Typed prompt registry, override resolution, and tenant-aware prompt settings for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/properties/CHANGELOG.md
+++ b/packages/properties/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-properties
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-prompts@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-properties",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Digital property and zone management models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/reports/CHANGELOG.md
+++ b/packages/reports/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-reports
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-jobs@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-reports",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Materialized aggregate report models for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sales/CHANGELOG.md
+++ b/packages/sales/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @happyvertical/smrt-sales
+
+## 0.39.2
+
+### Patch Changes
+
+- Initial release of the modular sales package with CRM, referral attribution,
+  commissions, payouts, and reusable Svelte surfaces.
+

--- a/packages/sales/package.json
+++ b/packages/sales/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-sales",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Modular sales for the SMRT framework: CRM (Leads, Opportunities, Pipelines), referral intake with versioned attribution policies, neutral commissions with snapshots and payouts, and reusable Svelte surfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/scanner/CHANGELOG.md
+++ b/packages/scanner/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-scanner
 
+## 0.39.2
+
 ## 0.39.1
 
 ## 1.0.0

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-scanner",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "High-performance TypeScript scanner using OXC for SMRT manifest generation",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/secrets/CHANGELOG.md
+++ b/packages/secrets/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-secrets
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-secrets",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Per-tenant secret management with envelope encryption for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sites/CHANGELOG.md
+++ b/packages/sites/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-sites
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-sites",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Site lifecycle management for multi-tenant SMRT networks",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-android/CHANGELOG.md
+++ b/packages/smrt-android/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-android
 
+## 0.39.2
+
 ## 0.39.1
 
 ## 1.0.0

--- a/packages/smrt-android/package.json
+++ b/packages/smrt-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-android",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Android Compose foundation for SMRT mobile apps: MobileTheme design tokens, the bottom-tab shell scaffold bound to smrt-mobile's MobileShellState, and the native platform adapters (ML Kit barcode, speech transcription, Gemini Nano on-device LLM, device capabilities, SQLDelight driver, Keystore auth storage, Custom Tabs auth launcher)",
   "author": "HappyVertical",
   "license": "MIT",

--- a/packages/smrt-app-mcp/CHANGELOG.md
+++ b/packages/smrt-app-mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-app-mcp
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/smrt-app-mcp/package.json
+++ b/packages/smrt-app-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-app-mcp",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "App-runtime MCP server scaffolding for SMRT apps — `createMcpAppServer` plus transport adapters (SvelteKit today) for exposing a SMRT app's MCP surface over HTTP.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-dev-mcp/CHANGELOG.md
+++ b/packages/smrt-dev-mcp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-dev-mcp
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-scanner@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/smrt-dev-mcp/package.json
+++ b/packages/smrt-dev-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-dev-mcp",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Development MCP server for SMRT framework knowledge, review context, architecture context, and code generation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-ios/CHANGELOG.md
+++ b/packages/smrt-ios/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-ios
 
+## 0.39.2
+
 ## 0.39.1
 
 ## 1.0.0

--- a/packages/smrt-ios/package.json
+++ b/packages/smrt-ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ios",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "SwiftUI foundation for SMRT mobile apps: MobileTheme design tokens, the tab shell scaffold bound to smrt-mobile's MobileShellState, and the native platform adapters (VisionKit barcode, Speech transcription, Foundation Models on-device LLM, device capabilities, SQLDelight native driver, Keychain auth storage, ASWebAuthenticationSession auth launcher) — actually consuming the exported SmrtMobile KMP framework",
   "author": "HappyVertical",
   "license": "MIT",

--- a/packages/smrt-mobile-contract/CHANGELOG.md
+++ b/packages/smrt-mobile-contract/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-mobile-contract
 
+## 0.39.2
+
 ## 0.39.1
 
 ## 1.0.0

--- a/packages/smrt-mobile-contract/package.json
+++ b/packages/smrt-mobile-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-mobile-contract",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "SMRT mobile contract codegen: manifest + allowlist → mobile-contract.json → Kotlin/Swift DTOs, plus the generated framework contract for @happyvertical/smrt-mobile",
   "author": "HappyVertical",
   "license": "MIT",

--- a/packages/smrt-mobile/CHANGELOG.md
+++ b/packages/smrt-mobile/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-mobile
 
+## 0.39.2
+
 ## 0.39.1
 
 ## 1.0.0

--- a/packages/smrt-mobile/package.json
+++ b/packages/smrt-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-mobile",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Kotlin Multiplatform shared mobile foundation for SMRT apps: durable SQLDelight offline write-queue, offline pack store + integrity, evidence capture model, pack i18n resolver, shell state, and platform adapter contracts (auth and networking land in later phases)",
   "author": "HappyVertical",
   "license": "MIT",

--- a/packages/smrt-playground/CHANGELOG.md
+++ b/packages/smrt-playground/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-playground
 
+## 0.39.2
+
+### Patch Changes
+
+- c80ac05: Allow consumers to use SMRT Playground with stable Vite 7 or Vite 8 releases.
+  - @happyvertical/smrt-ui@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/smrt-playground/package.json
+++ b/packages/smrt-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-playground",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Shared playground discovery, runtime, and host components for SMRT UI packages",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-svelte/CHANGELOG.md
+++ b/packages/smrt-svelte/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-svelte
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-languages@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+- @happyvertical/smrt-web@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-svelte",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Svelte 5 components for SMRT user management - auth, users, tenants, roles, permissions, groups",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/smrt-ui/CHANGELOG.md
+++ b/packages/smrt-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-ui
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-types@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/smrt-ui/package.json
+++ b/packages/smrt-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ui",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Domain-agnostic Svelte 5 UI runtime for SMRT: primitives, i18n client, theme system, and module UI registry",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-web/CHANGELOG.md
+++ b/packages/smrt-web/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-web
 
+## 0.39.2
+
 ## 0.39.1
 
 ## 1.0.0

--- a/packages/smrt-web/package.json
+++ b/packages/smrt-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-web",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "SMRT browser client data runtime: typed collection factory wrapping the client-data engine over generated REST clients",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/social/CHANGELOG.md
+++ b/packages/social/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-social
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-content@0.39.2
+- @happyvertical/smrt-config@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-secrets@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+- @happyvertical/smrt-video@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-social",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "type": "module",
   "smrtRawPrimitives": "strict",
   "description": "Social media account management for multi-platform publishing in the SMRT ecosystem",

--- a/packages/subscriptions/CHANGELOG.md
+++ b/packages/subscriptions/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-subscriptions
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/subscriptions/package.json
+++ b/packages/subscriptions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-subscriptions",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Tenant subscriptions, entitlement resolution, usage thresholds, and subscription UI for SMRT",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/support/CHANGELOG.md
+++ b/packages/support/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @happyvertical/smrt-support
+
+## 0.39.2
+
+### Patch Changes
+
+- Initial release of AI-first support cases with channel-neutral intake,
+  lifecycle routing, service targets, and service-time tracking.
+

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-support",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "AI-first Support Cases: channel-neutral intake, lifecycle, routing, service targets, and service time for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tags/CHANGELOG.md
+++ b/packages/tags/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-tags
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-tags",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Reusable tagging system with hierarchies, contexts, and multi-language support for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/template-site-static-json/CHANGELOG.md
+++ b/packages/template-site-static-json/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-template-site-static-json
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-config@0.39.2
+- @happyvertical/smrt-core@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/template-site-static-json/package.json
+++ b/packages/template-site-static-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-template-site-static-json",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Static community site template with JSON data storage and SMRT framework",
   "type": "module",
   "main": "index.js",

--- a/packages/template-site-static-json/template.config.js
+++ b/packages/template-site-static-json/template.config.js
@@ -23,13 +23,13 @@ export default {
   // the scaffolder injects the entries below at generation time, so this file is
   // the single source of truth for dependency versions.
   dependencies: {
-    '@happyvertical/smrt-core': '^0.39.1',
-    '@happyvertical/smrt-config': '^0.39.1',
-    '@happyvertical/smrt-ui': '^0.39.1',
-    '@happyvertical/smrt-content': '^0.39.1',
-    '@happyvertical/smrt-events': '^0.39.1',
-    '@happyvertical/smrt-places': '^0.39.1',
-    '@happyvertical/smrt-profiles': '^0.39.1',
+    '@happyvertical/smrt-core': '^0.39.2',
+    '@happyvertical/smrt-config': '^0.39.2',
+    '@happyvertical/smrt-ui': '^0.39.2',
+    '@happyvertical/smrt-content': '^0.39.2',
+    '@happyvertical/smrt-events': '^0.39.2',
+    '@happyvertical/smrt-places': '^0.39.2',
+    '@happyvertical/smrt-profiles': '^0.39.2',
     '@happyvertical/caelus': '^0.1.385',
   },
 

--- a/packages/template-sveltekit/CHANGELOG.md
+++ b/packages/template-sveltekit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-template-sveltekit
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/template-sveltekit/package.json
+++ b/packages/template-sveltekit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-template-sveltekit",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Minimal SvelteKit project template with s-m-r-t framework integration",
   "type": "module",
   "main": "index.js",

--- a/packages/template-sveltekit/template.config.js
+++ b/packages/template-sveltekit/template.config.js
@@ -19,16 +19,16 @@ export default {
 
   // Dependencies to add to generated project
   dependencies: {
-    '@happyvertical/smrt-core': '^0.39.1',
-    '@happyvertical/smrt-profiles': '^0.39.1',
-    '@happyvertical/smrt-svelte': '^0.39.1',
-    '@happyvertical/smrt-tenancy': '^0.39.1',
-    '@happyvertical/smrt-ui': '^0.39.1',
-    '@happyvertical/smrt-users': '^0.39.1',
+    '@happyvertical/smrt-core': '^0.39.2',
+    '@happyvertical/smrt-profiles': '^0.39.2',
+    '@happyvertical/smrt-svelte': '^0.39.2',
+    '@happyvertical/smrt-tenancy': '^0.39.2',
+    '@happyvertical/smrt-ui': '^0.39.2',
+    '@happyvertical/smrt-users': '^0.39.2',
   },
 
   devDependencies: {
-    '@happyvertical/smrt-cli': '^0.39.1',
+    '@happyvertical/smrt-cli': '^0.39.2',
     '@sveltejs/adapter-auto': '^7.0.1',
     '@sveltejs/kit': '^2.69.2',
     '@sveltejs/vite-plugin-svelte': '^7.2.0',

--- a/packages/template-sveltekit/template/package.json
+++ b/packages/template-sveltekit/template/package.json
@@ -25,14 +25,14 @@
     "svelte-check": "^4.7.2",
     "typescript": "^6.0.3",
     "vite": "^8.1.4",
-    "@happyvertical/smrt-cli": "^0.39.1"
+    "@happyvertical/smrt-cli": "^0.39.2"
   },
   "dependencies": {
-    "@happyvertical/smrt-core": "^0.39.1",
-    "@happyvertical/smrt-profiles": "^0.39.1",
-    "@happyvertical/smrt-svelte": "^0.39.1",
-    "@happyvertical/smrt-tenancy": "^0.39.1",
-    "@happyvertical/smrt-ui": "^0.39.1",
-    "@happyvertical/smrt-users": "^0.39.1"
+    "@happyvertical/smrt-core": "^0.39.2",
+    "@happyvertical/smrt-profiles": "^0.39.2",
+    "@happyvertical/smrt-svelte": "^0.39.2",
+    "@happyvertical/smrt-tenancy": "^0.39.2",
+    "@happyvertical/smrt-ui": "^0.39.2",
+    "@happyvertical/smrt-users": "^0.39.2"
   }
 }

--- a/packages/tenancy/CHANGELOG.md
+++ b/packages/tenancy/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-tenancy
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/tenancy/package.json
+++ b/packages/tenancy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-tenancy",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Production-ready multi-tenancy framework for SMRT with automatic tenant isolation and enforcement",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-types
 
+## 0.39.2
+
 ## 0.39.1
 
 ## 1.0.0

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-types",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Shared type definitions for the HAVE SDK",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/users/CHANGELOG.md
+++ b/packages/users/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-users
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-config@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-mobile-contract@0.39.2
+- @happyvertical/smrt-profiles@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-types@0.39.2
+- @happyvertical/smrt-ui@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-users",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Multi-tenant user management for the SMRT framework - users, tenants, roles, permissions, groups",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/video/CHANGELOG.md
+++ b/packages/video/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-video
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.39.2
+- @happyvertical/smrt-content@0.39.2
+- @happyvertical/smrt-config@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-profiles@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+- @happyvertical/smrt-voice@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-video",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "type": "module",
   "description": "Video content management for AI-powered video production in the SMRT ecosystem",
   "author": "HappyVertical",

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-vitest
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-core@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-vitest",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Vitest plugin for automatic cross-package manifest loading in SMRT tests",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/voice/CHANGELOG.md
+++ b/packages/voice/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-voice
 
+## 0.39.2
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.39.2
+- @happyvertical/smrt-content@0.39.2
+- @happyvertical/smrt-config@0.39.2
+- @happyvertical/smrt-core@0.39.2
+- @happyvertical/smrt-tenancy@0.39.2
+
 ## 0.39.1
 
 ### Patch Changes

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-voice",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "type": "module",
   "description": "Voice profile management for AI-powered voice synthesis and cloning in the SMRT ecosystem",
   "author": "HappyVertical",

--- a/turbo.json
+++ b/turbo.json
@@ -100,6 +100,10 @@
         "generate:test",
         "@happyvertical/smrt-core#build"
       ],
+      "env": [
+        "NODE_ENV",
+        "VITEST_MAX_WORKERS"
+      ],
       "inputs": [
         "src/**",
         "test/**",


### PR DESCRIPTION
## Summary

- apply the exact version patch produced and validated by failed release run 29139090084
- record the already-published 0.39.2 package versions and changelogs in git
- consume the release changeset so the next release advances to 0.39.3 instead of colliding with npm

## Context

The 0.39.2 artifact publisher completed irreversible npm publishes, then failed before pushing the version commit and tag. Main therefore remained at 0.39.1 even though the registry is at 0.39.2. The newly added smrt-sales package was not published in that run; advancing repository state allows it to publish with the next fixed-group release.

## Validation

- recovered diff is byte-for-byte identical to publish-release-version-patch from run 29139090084
- all 59 SMRT workspace packages resolve to version 0.39.2
- git diff --check
- full pre-commit and pre-push hooks
- knowledge freshness check