### PR TITLE
fix(cli): support aggregated consumer manifests

### DIFF
--- a/.changeset/calm-runtime-manifests.md
+++ b/.changeset/calm-runtime-manifests.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/smrt-cli': patch
+---
+
+Preserve object package ownership when loading aggregated consumer manifests so runtime checks validate only project-owned objects without reporting dependency collisions.

--- a/.changeset/calm-runtime-manifests.md
+++ b/.changeset/calm-runtime-manifests.md
@@ -1,5 +1,0 @@
----
-'@happyvertical/smrt-cli': patch
----
-
-Preserve object package ownership when loading aggregated consumer manifests so runtime checks validate only project-owned objects without reporting dependency collisions.

--- a/packages/cli/src/__tests__/runtime-check.test.ts
+++ b/packages/cli/src/__tests__/runtime-check.test.ts
@@ -97,9 +97,10 @@ async function createLoosePackage(
 async function createProject(
   projectRoot: string,
   manifest: SmartObjectManifest,
+  packageName = 'runtime-check-fixture',
 ): Promise<void> {
   await writeJson(resolve(projectRoot, 'package.json'), {
-    name: 'runtime-check-fixture',
+    name: packageName,
     private: true,
     type: 'module',
     dependencies: {
@@ -267,6 +268,169 @@ describe('runRuntimeCheck', () => {
       (finding) => finding.severity === 'error',
     );
 
+    expect(errors, errors.map((finding) => finding.message).join('\n')).toEqual(
+      [],
+    );
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'pass',
+          code: 'runtime-check-passed',
+        }),
+      ]),
+    );
+  });
+
+  it('accepts external-only aggregate manifests without hydrating dependency entries as local', async () => {
+    const projectRoot = await mkdtemp(
+      resolve(process.cwd(), '.tmp-runtime-check-'),
+    );
+    tempDirs.push(projectRoot);
+
+    const family = (packageName: string, childName: string) => ({
+      [`${packageName}:FixtureProfile`]: {
+        className: 'FixtureProfile',
+        qualifiedName: `${packageName}:FixtureProfile`,
+        packageName,
+        collection: 'profiles',
+        fields: { displayName: { type: 'text' as const, required: false } },
+      },
+      [`${packageName}:${childName}`]: {
+        className: childName,
+        qualifiedName: `${packageName}:${childName}`,
+        packageName,
+        collection: 'profiles',
+        extends: 'FixtureProfile',
+        fields: { role: { type: 'text' as const, required: false } },
+      },
+    });
+    const familyA = family('@fixture/profiles-a', 'FixtureStaffProfile');
+    const familyB = family('@fixture/profiles-b', 'FixtureMemberProfile');
+
+    await createExternalPackage(projectRoot, '@fixture/profiles-a', {
+      version: '1.0.0',
+      timestamp: Date.now(),
+      packageName: '@fixture/profiles-a',
+      objects: familyA,
+    });
+    await createExternalPackage(projectRoot, '@fixture/profiles-b', {
+      version: '1.0.0',
+      timestamp: Date.now(),
+      packageName: '@fixture/profiles-b',
+      objects: familyB,
+    });
+
+    await createProject(projectRoot, {
+      version: '1.0.0',
+      timestamp: Date.now(),
+      smrtDependencies: ['@fixture/profiles-a', '@fixture/profiles-b'],
+      objects: { ...familyA, ...familyB },
+    });
+    await createRegisterFile(projectRoot);
+
+    process.chdir(projectRoot);
+    const result = await runRuntimeCheck(projectRoot);
+    const errors = result.findings.filter(
+      (finding) => finding.severity === 'error',
+    );
+
+    expect(errors, errors.map((finding) => finding.message).join('\n')).toEqual(
+      [],
+    );
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'pass',
+          code: 'runtime-check-passed',
+        }),
+      ]),
+    );
+  });
+
+  it('retains containerless local entries identified by the project package name', async () => {
+    const projectRoot = await mkdtemp(
+      resolve(process.cwd(), '.tmp-runtime-check-'),
+    );
+    tempDirs.push(projectRoot);
+
+    await createExternalPackage(projectRoot, '@fixture/widgets', {
+      version: '1.0.0',
+      timestamp: Date.now(),
+      packageName: '@fixture/widgets',
+      objects: {
+        '@fixture/widgets:Widget': {
+          className: 'Widget',
+          qualifiedName: '@fixture/widgets:Widget',
+          packageName: '@fixture/widgets',
+          collection: 'widgets',
+          fields: { externalName: { type: 'text', required: false } },
+        },
+      },
+    });
+
+    await createProject(
+      projectRoot,
+      {
+        version: '1.0.0',
+        timestamp: Date.now(),
+        smrtDependencies: ['@fixture/widgets'],
+        objects: {
+          '@test/app:Widget': {
+            className: 'Widget',
+            qualifiedName: '@test/app:Widget',
+            packageName: '@test/app',
+            collection: 'widgets',
+            fields: { localName: { type: 'text', required: false } },
+          },
+        },
+      },
+      '@test/app',
+    );
+    await createRegisterFile(projectRoot);
+
+    process.chdir(projectRoot);
+    const result = await runRuntimeCheck(projectRoot);
+
+    expect(result.projectPackageName).toBe('@test/app');
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'warning',
+          code: 'duplicate-short-name',
+        }),
+      ]),
+    );
+  });
+
+  it('hydrates unqualified local entries with the inferred project package owner', async () => {
+    const projectRoot = await mkdtemp(
+      resolve(process.cwd(), '.tmp-runtime-check-'),
+    );
+    tempDirs.push(projectRoot);
+
+    await createProject(
+      projectRoot,
+      {
+        version: '1.0.0',
+        timestamp: Date.now(),
+        objects: {
+          Widget: {
+            className: 'Widget',
+            collection: 'widgets',
+            fields: { title: { type: 'text', required: true } },
+          },
+        },
+      },
+      '@test/app',
+    );
+
+    process.chdir(projectRoot);
+    const result = await runRuntimeCheck(projectRoot);
+    const errors = result.findings.filter(
+      (finding) => finding.severity === 'error',
+    );
+
+    expect(result.projectPackageName).toBe('@test/app');
     expect(errors, errors.map((finding) => finding.message).join('\n')).toEqual(
       [],
     );

--- a/packages/cli/src/__tests__/runtime-check.test.ts
+++ b/packages/cli/src/__tests__/runtime-check.test.ts
@@ -214,6 +214,72 @@ describe('runRuntimeCheck', () => {
     ).toBe(false);
   });
 
+  it('accepts aggregated consumer manifests without treating dependency entries as local', async () => {
+    const projectRoot = await mkdtemp(
+      resolve(process.cwd(), '.tmp-runtime-check-'),
+    );
+    tempDirs.push(projectRoot);
+
+    const externalDefinition = {
+      className: 'FixtureProfile',
+      qualifiedName: '@fixture/profiles:FixtureProfile',
+      packageName: '@fixture/profiles',
+      collection: 'profiles',
+      fields: {
+        displayName: { type: 'text', required: false },
+        isActive: { type: 'boolean', required: false },
+      },
+    } as const;
+
+    await createExternalPackage(projectRoot, '@fixture/profiles', {
+      version: '1.0.0',
+      timestamp: Date.now(),
+      packageName: '@fixture/profiles',
+      objects: {
+        '@fixture/profiles:FixtureProfile': externalDefinition,
+      },
+    });
+
+    await createProject(projectRoot, {
+      version: '1.0.0',
+      timestamp: Date.now(),
+      packageName: '@test/app',
+      smrtDependencies: ['@fixture/profiles'],
+      objects: {
+        '@test/app:FixtureStaffProfile': {
+          className: 'FixtureStaffProfile',
+          qualifiedName: '@test/app:FixtureStaffProfile',
+          packageName: '@test/app',
+          collection: 'profiles',
+          extends: 'FixtureProfile',
+          fields: {
+            role: { type: 'text', required: false },
+          },
+        },
+        '@fixture/profiles:FixtureProfile': externalDefinition,
+      },
+    });
+    await createRegisterFile(projectRoot);
+
+    process.chdir(projectRoot);
+    const result = await runRuntimeCheck(projectRoot);
+    const errors = result.findings.filter(
+      (finding) => finding.severity === 'error',
+    );
+
+    expect(errors, errors.map((finding) => finding.message).join('\n')).toEqual(
+      [],
+    );
+    expect(result.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: 'pass',
+          code: 'runtime-check-passed',
+        }),
+      ]),
+    );
+  });
+
   it('does not require generated registrations for empty dependency manifests', async () => {
     const projectRoot = await mkdtemp(
       resolve(process.cwd(), '.tmp-runtime-check-'),

--- a/packages/cli/src/discovery/index.ts
+++ b/packages/cli/src/discovery/index.ts
@@ -8,4 +8,5 @@ export {
   discoverManifests,
   loadManifest,
   loadManifestFile,
+  resolveManifestEntryPackageName,
 } from './manifest-discovery.js';

--- a/packages/cli/src/discovery/manifest-discovery.ts
+++ b/packages/cli/src/discovery/manifest-discovery.ts
@@ -11,7 +11,10 @@ import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { createLogger } from '@happyvertical/logger';
 import type { SmartObjectDefinition } from '@happyvertical/smrt-core';
-import { ObjectRegistry } from '@happyvertical/smrt-core';
+import {
+  getPackageFromQualifiedName,
+  ObjectRegistry,
+} from '@happyvertical/smrt-core';
 import glob from 'fast-glob';
 
 const logger = createLogger({ level: 'info' });
@@ -37,6 +40,21 @@ export interface LoadedManifestFile {
   version?: string;
   smrtDependencies?: unknown;
   [key: string]: unknown;
+}
+
+export function resolveManifestEntryPackageName(
+  name: string,
+  definition: SmartObjectDefinition,
+  fallback?: string,
+): string | undefined {
+  return (
+    definition.packageName ||
+    (definition.qualifiedName
+      ? getPackageFromQualifiedName(definition.qualifiedName)
+      : undefined) ||
+    getPackageFromQualifiedName(name) ||
+    fallback
+  );
 }
 
 /**
@@ -315,11 +333,13 @@ export async function loadManifest(manifestPath: string): Promise<void> {
   for (const [name, objectDef] of Object.entries(manifest.objects)) {
     // Manifest entries are loaded from JSON as `unknown`; at this boundary they
     // are the runtime SmartObjectDefinition shape the registry expects.
-    ObjectRegistry.registerFromManifest(
+    const definition = objectDef as SmartObjectDefinition;
+    const packageName = resolveManifestEntryPackageName(
       name,
-      objectDef as SmartObjectDefinition,
+      definition,
       manifest.packageName,
     );
+    ObjectRegistry.registerFromManifest(name, definition, packageName);
   }
 }
 

--- a/packages/cli/src/discovery/manifest-discovery.ts
+++ b/packages/cli/src/discovery/manifest-discovery.ts
@@ -47,14 +47,14 @@ export function resolveManifestEntryPackageName(
   definition: SmartObjectDefinition,
   fallback?: string,
 ): string | undefined {
-  // Only explicit entry provenance or a qualified manifest key may override
-  // the containing manifest. A qualifiedName is also an identity value that
-  // runtime:check validates, so it must not let a malformed local entry
-  // reclassify itself as external when the container already has an owner.
+  // Only explicit entry provenance may override the containing manifest.
+  // Qualified keys and qualifiedName are identity values that runtime:check
+  // validates, so neither may let a malformed local entry reclassify itself
+  // as external when the container already has an owner.
   return (
     definition.packageName ||
-    getPackageFromQualifiedName(name) ||
     fallback ||
+    getPackageFromQualifiedName(name) ||
     (definition.qualifiedName
       ? getPackageFromQualifiedName(definition.qualifiedName)
       : undefined)

--- a/packages/cli/src/discovery/manifest-discovery.ts
+++ b/packages/cli/src/discovery/manifest-discovery.ts
@@ -47,13 +47,17 @@ export function resolveManifestEntryPackageName(
   definition: SmartObjectDefinition,
   fallback?: string,
 ): string | undefined {
+  // Only explicit entry provenance or a qualified manifest key may override
+  // the containing manifest. A qualifiedName is also an identity value that
+  // runtime:check validates, so it must not let a malformed local entry
+  // reclassify itself as external when the container already has an owner.
   return (
     definition.packageName ||
+    getPackageFromQualifiedName(name) ||
+    fallback ||
     (definition.qualifiedName
       ? getPackageFromQualifiedName(definition.qualifiedName)
-      : undefined) ||
-    getPackageFromQualifiedName(name) ||
-    fallback
+      : undefined)
   );
 }
 

--- a/packages/cli/src/runtime-check.test.ts
+++ b/packages/cli/src/runtime-check.test.ts
@@ -107,6 +107,23 @@ describe('runRuntimeCheck', () => {
     expect(findCodes(result.findings)).toContain('manifest-key-mismatch');
   });
 
+  it('flags a manifest-key mismatch when a qualified key disagrees with the container package', async () => {
+    writeManifest(tempDir, {
+      version: '1.0.0',
+      packageName: '@app/example',
+      objects: {
+        '@other/pkg:Widget': {
+          className: 'Widget',
+          fields: { id: { type: 'text' } },
+        },
+      },
+    });
+
+    const result = await runRuntimeCheck(tempDir);
+
+    expect(findCodes(result.findings)).toContain('manifest-key-mismatch');
+  });
+
   it('warns when a class is missing package identity', async () => {
     writeManifest(tempDir, {
       version: '1.0.0',

--- a/packages/cli/src/runtime-check.ts
+++ b/packages/cli/src/runtime-check.ts
@@ -17,6 +17,7 @@ import {
   type DiscoveredManifest,
   discoverManifests,
   loadManifestFile,
+  resolveManifestEntryPackageName,
 } from './discovery/index.js';
 
 type RuntimeCheckSeverity = 'error' | 'warning' | 'pass';
@@ -165,11 +166,34 @@ function flattenManifestEntries(
   );
 
   return Object.entries(manifest.objects || {}).map(([key, objectDef]) => ({
-    manifestPackageName,
+    manifestPackageName: resolveManifestEntryPackageName(
+      key,
+      objectDef as SmartObjectDefinition,
+      manifestPackageName,
+    ),
     manifestSource: source,
     key,
     definition: objectDef as SmartObjectDefinition,
   }));
+}
+
+function getOwnedProjectManifest(
+  manifest: SmartObjectManifest,
+): SmartObjectManifest {
+  const packageName = manifest.packageName;
+  if (!packageName) {
+    return manifest;
+  }
+
+  const objects = Object.fromEntries(
+    Object.entries(manifest.objects || {}).filter(
+      ([key, definition]) =>
+        resolveManifestEntryPackageName(key, definition, packageName) ===
+        packageName,
+    ),
+  );
+
+  return { ...manifest, objects };
 }
 
 function findProjectManifest(
@@ -379,7 +403,7 @@ function registerDependencyManifests(
       ObjectRegistry.registerFromManifest(
         name,
         objectDef,
-        manifest.packageName,
+        resolveManifestEntryPackageName(name, objectDef, manifest.packageName),
       );
     }
   }
@@ -868,6 +892,7 @@ export async function runRuntimeCheck(
   const projectManifest = (await loadManifestFile(
     projectManifestInfo.path,
   )) as unknown as SmartObjectManifest;
+  const ownedProjectManifest = getOwnedProjectManifest(projectManifest);
   const dependencyManifests = await loadDependencyManifests(
     projectManifest,
     projectRoot,
@@ -915,8 +940,12 @@ export async function runRuntimeCheck(
     };
   }
   registerDependencyManifests(dependencyManifests);
-  await checkRuntimeHydration(projectManifest, dependencyManifests, findings);
-  checkShadowing(projectManifest, dependencyManifests, findings);
+  await checkRuntimeHydration(
+    ownedProjectManifest,
+    dependencyManifests,
+    findings,
+  );
+  checkShadowing(ownedProjectManifest, dependencyManifests, findings);
 
   if (!findings.some((finding) => finding.severity === 'error')) {
     addFinding(

--- a/packages/cli/src/runtime-check.ts
+++ b/packages/cli/src/runtime-check.ts
@@ -107,6 +107,24 @@ function getManifestPackageName(
   return manifest.packageName || fallback;
 }
 
+function readProjectPackageName(projectRoot: string): string | undefined {
+  const packageJsonPath = resolve(projectRoot, 'package.json');
+  if (!existsSync(packageJsonPath)) {
+    return undefined;
+  }
+
+  try {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
+      name?: unknown;
+    };
+    return typeof packageJson.name === 'string' && packageJson.name
+      ? packageJson.name
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function getEntryClassName(
   key: string,
   definition: SmartObjectDefinition,
@@ -179,8 +197,9 @@ function flattenManifestEntries(
 
 function getOwnedProjectManifest(
   manifest: SmartObjectManifest,
+  fallbackPackageName?: string,
 ): SmartObjectManifest {
-  const packageName = manifest.packageName;
+  const packageName = getManifestPackageName(manifest, fallbackPackageName);
   if (!packageName) {
     return manifest;
   }
@@ -193,7 +212,7 @@ function getOwnedProjectManifest(
     ),
   );
 
-  return { ...manifest, objects };
+  return { ...manifest, packageName, objects };
 }
 
 function findProjectManifest(
@@ -395,17 +414,21 @@ async function loadDependencyManifests(
   return Array.from(loaded.values(), (entry) => entry.manifest);
 }
 
+function registerManifestEntries(manifest: SmartObjectManifest): void {
+  for (const [name, objectDef] of Object.entries(manifest.objects || {})) {
+    ObjectRegistry.registerFromManifest(
+      name,
+      objectDef,
+      resolveManifestEntryPackageName(name, objectDef, manifest.packageName),
+    );
+  }
+}
+
 function registerDependencyManifests(
   dependencyManifests: SmartObjectManifest[],
 ): void {
   for (const manifest of dependencyManifests) {
-    for (const [name, objectDef] of Object.entries(manifest.objects || {})) {
-      ObjectRegistry.registerFromManifest(
-        name,
-        objectDef,
-        resolveManifestEntryPackageName(name, objectDef, manifest.packageName),
-      );
-    }
+    registerManifestEntries(manifest);
   }
 }
 
@@ -892,7 +915,14 @@ export async function runRuntimeCheck(
   const projectManifest = (await loadManifestFile(
     projectManifestInfo.path,
   )) as unknown as SmartObjectManifest;
-  const ownedProjectManifest = getOwnedProjectManifest(projectManifest);
+  const projectPackageName = getManifestPackageName(
+    projectManifest,
+    readProjectPackageName(projectRoot),
+  );
+  const ownedProjectManifest = getOwnedProjectManifest(
+    projectManifest,
+    projectPackageName,
+  );
   const dependencyManifests = await loadDependencyManifests(
     projectManifest,
     projectRoot,
@@ -906,11 +936,7 @@ export async function runRuntimeCheck(
   );
 
   const allEntries = [
-    ...flattenManifestEntries(
-      projectManifest,
-      'project',
-      projectManifest.packageName,
-    ),
+    ...flattenManifestEntries(projectManifest, 'project', projectPackageName),
     ...dependencyManifests.flatMap((manifest) =>
       flattenManifestEntries(manifest, 'dependency', manifest.packageName),
     ),
@@ -934,10 +960,13 @@ export async function runRuntimeCheck(
     return {
       projectRoot,
       projectManifestPath: projectManifestInfo.path,
-      projectPackageName: projectManifest.packageName,
+      projectPackageName,
       discoveredManifestCount: discovered.length,
       findings,
     };
+  }
+  if (!projectManifest.packageName && projectPackageName) {
+    registerManifestEntries(ownedProjectManifest);
   }
   registerDependencyManifests(dependencyManifests);
   await checkRuntimeHydration(
@@ -959,7 +988,7 @@ export async function runRuntimeCheck(
   return {
     projectRoot,
     projectManifestPath: projectManifestInfo.path,
-    projectPackageName: projectManifest.packageName,
+    projectPackageName,
     discoveredManifestCount: discovered.length,
     findings,
   };


### PR DESCRIPTION
## Summary

- preserve each aggregate manifest entry's defining package during discovery, runtime validation, and dependency registration
- restrict project hydration and shadow checks to objects actually owned by the project package
- support manifests without a top-level owner: external-only aggregates remain external, while legacy local entries inherit the project's package.json identity
- preserve container identity when an entry lacks explicit per-entry provenance, so malformed qualified names and keys still fail validation
- add regressions for mixed, external-only, and legacy containerless consumer manifests

## Root cause

The consumer plugin intentionally writes an aggregate `.smrt/manifest.json` for runtime and code generation. `runtime:check` treated every object in that file as project-owned, then loaded the same dependency manifests separately. Clean consumer builds consequently reported false package-identity mismatches, ambiguous inheritance, shadowing, and registry collisions.

## Review

A three-perspective review cycle covered manifest correctness, runtime behavior/testing, and compatibility/maintainability. Review caught three ownership edge cases: malformed qualified names and keys must not self-reclassify local entries, and external-only aggregates without a container owner must not hydrate dependency entries as local. The implementation gives explicit per-entry `packageName` precedence, retains container ownership otherwise, and uses qualified keys/names only when no container identity exists. When the container is ownerless, the project package name is used only as a compatibility fallback for local entries; explicitly owned dependencies remain excluded, and unqualified legacy locals are registered under that inferred owner. Every finding has an end-to-end regression, and the complete reviewer roster returned clean on the final diff.

## Validation

- `pnpm build`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm smrt dev:knowledge-check`
- full CLI suite: 779 passed, 4 skipped
- focused runtime-check and manifest-discovery suites: 37 passed
- CLI typecheck, targeted Biome check, and `git diff --check`
- pre-commit and pre-push hooks
- three-reviewer final pass clean

No manual changeset is included; repository release automation generates it on merge.

Closes #1989

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019f5bee-ab73-7c33-acce-d59946cf5e9f","issue":"https://github.com/happyvertical/smrt/issues/1989","policy_revision":"1.0.0","validation":["root build","root test","root typecheck","root lint","root format","knowledge freshness","CLI suite: 779 passed, 4 skipped","focused runtime-check and manifest-discovery: 37 passed","CLI typecheck","Biome and git diff checks","pre-commit and pre-push hooks","three-reviewer final pass clean"]}
