### PR TITLE
fix(release): reconcile v0.39.3 and authenticate ref push

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -97,7 +97,11 @@ Each package is packed once. Pack shards verify that exact tarball and emit a
 schema-versioned manifest containing package name, version, filename, and
 SHA-256. The summary verifies complete package membership and uniform versions.
 The release job publishes those tarballs sequentially and safely skips versions
-already present on npm during a retry.
+already present on npm during a retry. After publication, it supplies the
+release App credential directly to Git instead of relying on checkout's
+path-conditional credential include (ARC workspaces may resolve through a
+symlink). The release commit and tag are pushed atomically, so GitHub cannot
+record only one of the two refs.
 
 The manual `publish-mode=changesets` option is an emergency fallback for the
 first two successful artifact-based releases. Remove the option after both

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -368,9 +368,11 @@ jobs:
         env:
           CI: true
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          RELEASE_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           PREVIOUS_VERSION: ${{ needs.prepare-release.outputs.previous-version }}
+          RELEASE_BASE_BRANCH: main
           RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
           PUBLISH_MODE: ${{ inputs.publish-mode || 'artifacts' }}
         run: |
@@ -405,8 +407,11 @@ jobs:
           # Skip developer hooks in CI. Release builds can generate source
           # artifacts, and those hooks should not block the automation push
           # after the equivalent safety checks have already run above.
-          git push --no-verify -f origin "v$RELEASE_VERSION"
-          git push --no-verify origin main
+          # Supply auth directly to Git for these writes. On ARC runners the
+          # workspace can resolve through a symlink into the pnpm store, so the
+          # path-conditional credentials installed by actions/checkout do not
+          # match the repository's real gitdir even though public fetches work.
+          node scripts/push-release-refs.mjs
 
           RELEASE_NOTES="## Published Packages"$'\n\n'
           RELEASE_NOTES="${RELEASE_NOTES}All packages published to"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "smrt framework for building vertical AI agents",
   "author": "Will Griffin <willgriffin@gmail.com>",
   "type": "module",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "files": [
     "AGENTS.md",
     "CLAUDE.md"

--- a/packages/ads/CHANGELOG.md
+++ b/packages/ads/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-ads
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/ads/package.json
+++ b/packages/ads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ads",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Advertising delivery and tracking models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/affiliates/CHANGELOG.md
+++ b/packages/affiliates/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-affiliates
 
+## 0.39.3
+
+### Patch Changes
+
+- @happyvertical/smrt-sales@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/affiliates/package.json
+++ b/packages/affiliates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-affiliates",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "DEPRECATED compatibility shim over @happyvertical/smrt-sales — re-exports the legacy Partner/Commission/Payout names. See MIGRATION.md.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/CHANGELOG.md
+++ b/packages/agents/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-agents
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-secrets@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-users@0.39.3
+  - @happyvertical/smrt-config@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-agents",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "type": "module",
   "smrtRawPrimitives": "strict",
   "description": "Agent framework for building autonomous actors in the SMRT ecosystem",

--- a/packages/analytics/CHANGELOG.md
+++ b/packages/analytics/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-analytics
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-prompts@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-analytics",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Analytics integration models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/app-cli/CHANGELOG.md
+++ b/packages/app-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-app-cli
 
+## 0.39.3
+
+### Patch Changes
+
+- @happyvertical/smrt-users@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/app-cli/package.json
+++ b/packages/app-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-app-cli",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Reusable CLI factory for SMRT apps — branded `<name> <resource> <command>` CLI + stdio MCP bridge with decorator-driven resource discovery",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/assets-ergot/CHANGELOG.md
+++ b/packages/assets-ergot/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-assets-ergot
 
+## 0.39.3
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/assets-ergot/package.json
+++ b/packages/assets-ergot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-assets-ergot",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Ergot-backed processing, search, and workflow adapter for SMRT assets",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/assets-local/CHANGELOG.md
+++ b/packages/assets-local/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-assets-local
 
+## 0.39.3
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/assets-local/package.json
+++ b/packages/assets-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-assets-local",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Local image metadata and variant processor for SMRT assets",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-assets
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-tags@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-assets",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Asset management system with versioning, metadata, and AI-powered operations for SMRT framework",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/chat/CHANGELOG.md
+++ b/packages/chat/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-chat
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-agents@0.39.3
+  - @happyvertical/smrt-personas@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-users@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-chat",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Chat rooms, DMs, threads, and agent conversations for the SMRT framework",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-cli
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-agents@0.39.3
+  - @happyvertical/smrt-dev-mcp@0.39.3
+  - @happyvertical/smrt-config@0.39.3
+  - @happyvertical/smrt-playground@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-cli",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Developer CLI for SMRT framework - introspection, testing, and project management",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/commerce/CHANGELOG.md
+++ b/packages/commerce/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-commerce
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-ledgers@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-commerce",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Commerce models for the SMRT framework - contracts, fulfillments, payments",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-config
 
+## 0.39.3
+
+### Patch Changes
+
+- @happyvertical/smrt-types@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-config",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "type": "module",
   "description": "Centralized configuration management for SMRT modules",
   "author": "HappyVertical",

--- a/packages/content/CHANGELOG.md
+++ b/packages/content/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @happyvertical/smrt-content
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-assets@0.39.3
+  - @happyvertical/smrt-chat@0.39.3
+  - @happyvertical/smrt-facts@0.39.3
+  - @happyvertical/smrt-images@0.39.3
+  - @happyvertical/smrt-messages@0.39.3
+  - @happyvertical/smrt-profiles@0.39.3
+  - @happyvertical/smrt-prompts@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-content",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Content processing module for SMRT framework - handles documents, web content, and media",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @happyvertical/smrt-core
 
+## 0.39.3
+
+### Patch Changes
+
+- ### Features
+
+  - add smrt-sales — modular CRM, referrals, commissions, Svelte (#1945) (sales)
+  - smrt-support — AI-first Support Cases, routing, targets, and service time (epic #1934) (#1943) (support)
+
+  ### Bug Fixes
+
+  - expose isolated database to libpq clients (#1946) (ci)
+  - support Vite 7 consumers (#1942) (playground)
+
+  ### Other Changes
+
+  - chore: reconcile v0.39.2 repository state (#1947) (release)
+  - chore: add Vite peer release note (#1944) (playground)
+  - perf: reuse generated manifests (#1939) (ci)
+  - perf: reuse SQLite schema templates (#1937) (vitest)
+  - @happyvertical/smrt-config@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+  - @happyvertical/smrt-scanner@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-core",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Core AI agent framework with standardized collections, object-relational mapping, and code generators",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/events/CHANGELOG.md
+++ b/packages/events/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-events
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-assets@0.39.3
+  - @happyvertical/smrt-places@0.39.3
+  - @happyvertical/smrt-profiles@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-events",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Hierarchical event management with participant tracking and SMRT framework support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/facts/CHANGELOG.md
+++ b/packages/facts/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-facts
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-prompts@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/facts/package.json
+++ b/packages/facts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-facts",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Distributed memory and knowledge management with provenance tracking for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/features/CHANGELOG.md
+++ b/packages/features/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-features
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-features",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Code-first feature flags and tenant-aware overrides for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gnode/CHANGELOG.md
+++ b/packages/gnode/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-gnode
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/gnode/package.json
+++ b/packages/gnode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-gnode",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "SMRT federation library for building federated local knowledge bases (gnodes)",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/images/CHANGELOG.md
+++ b/packages/images/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-images
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-assets@0.39.3
+  - @happyvertical/smrt-prompts@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-images",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Image asset management with AI-powered categorization, search, editing, and metadata extraction for SMRT framework",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/inventory/CHANGELOG.md
+++ b/packages/inventory/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-inventory
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-inventory",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Multi-location stock tracking for the SMRT framework — Sku, InventoryLocation, StockLevel, StockMovement, and a stock-mutation service",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/jobs/CHANGELOG.md
+++ b/packages/jobs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-jobs
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-config@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-jobs",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Background job processing for SMRT objects with persistence and scheduling",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/languages/CHANGELOG.md
+++ b/packages/languages/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-languages
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-features@0.39.3
+  - @happyvertical/smrt-jobs@0.39.3
+  - @happyvertical/smrt-prompts@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-config@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-languages",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Code-first language strings with config + tenant overrides and AI auto-translation for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ledgers/CHANGELOG.md
+++ b/packages/ledgers/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-ledgers
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-prompts@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/ledgers/package.json
+++ b/packages/ledgers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ledgers",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Double-entry accounting ledger for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/manufacturing/CHANGELOG.md
+++ b/packages/manufacturing/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-manufacturing
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-inventory@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/manufacturing/package.json
+++ b/packages/manufacturing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-manufacturing",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Bills of materials, cost rollup, and production-order operations for the SMRT framework — strictly industry-neutral",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/messages/CHANGELOG.md
+++ b/packages/messages/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-messages
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-secrets@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-messages",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Unified multi-channel messaging with STI-based hierarchies",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/personas/CHANGELOG.md
+++ b/packages/personas/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-personas
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-agents@0.39.3
+  - @happyvertical/smrt-prompts@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-users@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/personas/package.json
+++ b/packages/personas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-personas",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Tenant-owned, context-scoped agent personas and resolution for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/places/CHANGELOG.md
+++ b/packages/places/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-places
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-assets@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/places/package.json
+++ b/packages/places/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-places",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Hierarchical place management with geo integration and SMRT framework support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/products/CHANGELOG.md
+++ b/packages/products/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-products
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-assets@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-svelte@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+  - @happyvertical/smrt-scanner@0.39.3
+  - @happyvertical/smrt-web@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-products",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "SMRT products module: triple-purpose microservice template for standalone apps, federated modules, and NPM libraries",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/profiles/CHANGELOG.md
+++ b/packages/profiles/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-profiles
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-assets@0.39.3
+  - @happyvertical/smrt-prompts@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/profiles/package.json
+++ b/packages/profiles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-profiles",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Profile management system with relationships, metadata, and reciprocal associations for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/projects/CHANGELOG.md
+++ b/packages/projects/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-projects
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-prompts@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-config@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-projects",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Provider-agnostic project management models (Issues, PRs, Repositories, Projects) for SMRT framework",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/prompts/CHANGELOG.md
+++ b/packages/prompts/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-prompts
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-config@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-prompts",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Typed prompt registry, override resolution, and tenant-aware prompt settings for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/properties/CHANGELOG.md
+++ b/packages/properties/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-properties
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-prompts@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-properties",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Digital property and zone management models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/reports/CHANGELOG.md
+++ b/packages/reports/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-reports
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-jobs@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-reports",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Materialized aggregate report models for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sales/CHANGELOG.md
+++ b/packages/sales/CHANGELOG.md
@@ -1,9 +1,17 @@
 # @happyvertical/smrt-sales
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes
 
 - Initial release of the modular sales package with CRM, referral attribution,
   commissions, payouts, and reusable Svelte surfaces.
-

--- a/packages/sales/package.json
+++ b/packages/sales/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-sales",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Modular sales for the SMRT framework: CRM (Leads, Opportunities, Pipelines), referral intake with versioned attribution policies, neutral commissions with snapshots and payouts, and reusable Svelte surfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/scanner/CHANGELOG.md
+++ b/packages/scanner/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-scanner
 
+## 0.39.3
+
 ## 0.39.2
 
 ## 0.39.1

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-scanner",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "High-performance TypeScript scanner using OXC for SMRT manifest generation",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/secrets/CHANGELOG.md
+++ b/packages/secrets/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-secrets
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-secrets",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Per-tenant secret management with envelope encryption for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sites/CHANGELOG.md
+++ b/packages/sites/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-sites
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-sites",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Site lifecycle management for multi-tenant SMRT networks",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-android/CHANGELOG.md
+++ b/packages/smrt-android/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-android
 
+## 0.39.3
+
 ## 0.39.2
 
 ## 0.39.1

--- a/packages/smrt-android/package.json
+++ b/packages/smrt-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-android",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Android Compose foundation for SMRT mobile apps: MobileTheme design tokens, the bottom-tab shell scaffold bound to smrt-mobile's MobileShellState, and the native platform adapters (ML Kit barcode, speech transcription, Gemini Nano on-device LLM, device capabilities, SQLDelight driver, Keystore auth storage, Custom Tabs auth launcher)",
   "author": "HappyVertical",
   "license": "MIT",

--- a/packages/smrt-app-mcp/CHANGELOG.md
+++ b/packages/smrt-app-mcp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-app-mcp
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/smrt-app-mcp/package.json
+++ b/packages/smrt-app-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-app-mcp",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "App-runtime MCP server scaffolding for SMRT apps — `createMcpAppServer` plus transport adapters (SvelteKit today) for exposing a SMRT app's MCP surface over HTTP.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-dev-mcp/CHANGELOG.md
+++ b/packages/smrt-dev-mcp/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-dev-mcp
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+  - @happyvertical/smrt-scanner@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/smrt-dev-mcp/package.json
+++ b/packages/smrt-dev-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-dev-mcp",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Development MCP server for SMRT framework knowledge, review context, architecture context, and code generation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-ios/CHANGELOG.md
+++ b/packages/smrt-ios/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-ios
 
+## 0.39.3
+
 ## 0.39.2
 
 ## 0.39.1

--- a/packages/smrt-ios/package.json
+++ b/packages/smrt-ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ios",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "SwiftUI foundation for SMRT mobile apps: MobileTheme design tokens, the tab shell scaffold bound to smrt-mobile's MobileShellState, and the native platform adapters (VisionKit barcode, Speech transcription, Foundation Models on-device LLM, device capabilities, SQLDelight native driver, Keychain auth storage, ASWebAuthenticationSession auth launcher) — actually consuming the exported SmrtMobile KMP framework",
   "author": "HappyVertical",
   "license": "MIT",

--- a/packages/smrt-mobile-contract/CHANGELOG.md
+++ b/packages/smrt-mobile-contract/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-mobile-contract
 
+## 0.39.3
+
 ## 0.39.2
 
 ## 0.39.1

--- a/packages/smrt-mobile-contract/package.json
+++ b/packages/smrt-mobile-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-mobile-contract",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "SMRT mobile contract codegen: manifest + allowlist → mobile-contract.json → Kotlin/Swift DTOs, plus the generated framework contract for @happyvertical/smrt-mobile",
   "author": "HappyVertical",
   "license": "MIT",

--- a/packages/smrt-mobile/CHANGELOG.md
+++ b/packages/smrt-mobile/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-mobile
 
+## 0.39.3
+
 ## 0.39.2
 
 ## 0.39.1

--- a/packages/smrt-mobile/package.json
+++ b/packages/smrt-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-mobile",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Kotlin Multiplatform shared mobile foundation for SMRT apps: durable SQLDelight offline write-queue, offline pack store + integrity, evidence capture model, pack i18n resolver, shell state, and platform adapter contracts (auth and networking land in later phases)",
   "author": "HappyVertical",
   "license": "MIT",

--- a/packages/smrt-playground/CHANGELOG.md
+++ b/packages/smrt-playground/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-playground
 
+## 0.39.3
+
+### Patch Changes
+
+- @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/smrt-playground/package.json
+++ b/packages/smrt-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-playground",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Shared playground discovery, runtime, and host components for SMRT UI packages",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-svelte/CHANGELOG.md
+++ b/packages/smrt-svelte/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-svelte
 
+## 0.39.3
+
+### Patch Changes
+
+- @happyvertical/smrt-languages@0.39.3
+- @happyvertical/smrt-types@0.39.3
+- @happyvertical/smrt-ui@0.39.3
+- @happyvertical/smrt-web@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-svelte",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Svelte 5 components for SMRT user management - auth, users, tenants, roles, permissions, groups",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/smrt-ui/CHANGELOG.md
+++ b/packages/smrt-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-ui
 
+## 0.39.3
+
+### Patch Changes
+
+- @happyvertical/smrt-types@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/smrt-ui/package.json
+++ b/packages/smrt-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ui",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Domain-agnostic Svelte 5 UI runtime for SMRT: primitives, i18n client, theme system, and module UI registry",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-web/CHANGELOG.md
+++ b/packages/smrt-web/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-web
 
+## 0.39.3
+
 ## 0.39.2
 
 ## 0.39.1

--- a/packages/smrt-web/package.json
+++ b/packages/smrt-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-web",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "SMRT browser client data runtime: typed collection factory wrapping the client-data engine over generated REST clients",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/social/CHANGELOG.md
+++ b/packages/social/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-social
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-content@0.39.3
+  - @happyvertical/smrt-secrets@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-video@0.39.3
+  - @happyvertical/smrt-config@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-social",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "type": "module",
   "smrtRawPrimitives": "strict",
   "description": "Social media account management for multi-platform publishing in the SMRT ecosystem",

--- a/packages/subscriptions/CHANGELOG.md
+++ b/packages/subscriptions/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-subscriptions
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/subscriptions/package.json
+++ b/packages/subscriptions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-subscriptions",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Tenant subscriptions, entitlement resolution, usage thresholds, and subscription UI for SMRT",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/support/CHANGELOG.md
+++ b/packages/support/CHANGELOG.md
@@ -1,9 +1,21 @@
 # @happyvertical/smrt-support
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-chat@0.39.3
+  - @happyvertical/smrt-jobs@0.39.3
+  - @happyvertical/smrt-messages@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-users@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes
 
 - Initial release of AI-first support cases with channel-neutral intake,
   lifecycle routing, service targets, and service-time tracking.
-

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-support",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "AI-first Support Cases: channel-neutral intake, lifecycle, routing, service targets, and service time for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tags/CHANGELOG.md
+++ b/packages/tags/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-tags
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-tags",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Reusable tagging system with hierarchies, contexts, and multi-language support for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/template-site-static-json/CHANGELOG.md
+++ b/packages/template-site-static-json/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-template-site-static-json
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-config@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/template-site-static-json/package.json
+++ b/packages/template-site-static-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-template-site-static-json",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Static community site template with JSON data storage and SMRT framework",
   "type": "module",
   "main": "index.js",

--- a/packages/template-site-static-json/template.config.js
+++ b/packages/template-site-static-json/template.config.js
@@ -23,13 +23,13 @@ export default {
   // the scaffolder injects the entries below at generation time, so this file is
   // the single source of truth for dependency versions.
   dependencies: {
-    '@happyvertical/smrt-core': '^0.39.2',
-    '@happyvertical/smrt-config': '^0.39.2',
-    '@happyvertical/smrt-ui': '^0.39.2',
-    '@happyvertical/smrt-content': '^0.39.2',
-    '@happyvertical/smrt-events': '^0.39.2',
-    '@happyvertical/smrt-places': '^0.39.2',
-    '@happyvertical/smrt-profiles': '^0.39.2',
+    '@happyvertical/smrt-core': '^0.39.3',
+    '@happyvertical/smrt-config': '^0.39.3',
+    '@happyvertical/smrt-ui': '^0.39.3',
+    '@happyvertical/smrt-content': '^0.39.3',
+    '@happyvertical/smrt-events': '^0.39.3',
+    '@happyvertical/smrt-places': '^0.39.3',
+    '@happyvertical/smrt-profiles': '^0.39.3',
     '@happyvertical/caelus': '^0.1.385',
   },
 

--- a/packages/template-sveltekit/CHANGELOG.md
+++ b/packages/template-sveltekit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-template-sveltekit
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/template-sveltekit/package.json
+++ b/packages/template-sveltekit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-template-sveltekit",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Minimal SvelteKit project template with s-m-r-t framework integration",
   "type": "module",
   "main": "index.js",

--- a/packages/template-sveltekit/template.config.js
+++ b/packages/template-sveltekit/template.config.js
@@ -19,16 +19,16 @@ export default {
 
   // Dependencies to add to generated project
   dependencies: {
-    '@happyvertical/smrt-core': '^0.39.2',
-    '@happyvertical/smrt-profiles': '^0.39.2',
-    '@happyvertical/smrt-svelte': '^0.39.2',
-    '@happyvertical/smrt-tenancy': '^0.39.2',
-    '@happyvertical/smrt-ui': '^0.39.2',
-    '@happyvertical/smrt-users': '^0.39.2',
+    '@happyvertical/smrt-core': '^0.39.3',
+    '@happyvertical/smrt-profiles': '^0.39.3',
+    '@happyvertical/smrt-svelte': '^0.39.3',
+    '@happyvertical/smrt-tenancy': '^0.39.3',
+    '@happyvertical/smrt-ui': '^0.39.3',
+    '@happyvertical/smrt-users': '^0.39.3',
   },
 
   devDependencies: {
-    '@happyvertical/smrt-cli': '^0.39.2',
+    '@happyvertical/smrt-cli': '^0.39.3',
     '@sveltejs/adapter-auto': '^7.0.1',
     '@sveltejs/kit': '^2.69.2',
     '@sveltejs/vite-plugin-svelte': '^7.2.0',

--- a/packages/template-sveltekit/template/package.json
+++ b/packages/template-sveltekit/template/package.json
@@ -25,14 +25,14 @@
     "svelte-check": "^4.7.2",
     "typescript": "^6.0.3",
     "vite": "^8.1.4",
-    "@happyvertical/smrt-cli": "^0.39.2"
+    "@happyvertical/smrt-cli": "^0.39.3"
   },
   "dependencies": {
-    "@happyvertical/smrt-core": "^0.39.2",
-    "@happyvertical/smrt-profiles": "^0.39.2",
-    "@happyvertical/smrt-svelte": "^0.39.2",
-    "@happyvertical/smrt-tenancy": "^0.39.2",
-    "@happyvertical/smrt-ui": "^0.39.2",
-    "@happyvertical/smrt-users": "^0.39.2"
+    "@happyvertical/smrt-core": "^0.39.3",
+    "@happyvertical/smrt-profiles": "^0.39.3",
+    "@happyvertical/smrt-svelte": "^0.39.3",
+    "@happyvertical/smrt-tenancy": "^0.39.3",
+    "@happyvertical/smrt-ui": "^0.39.3",
+    "@happyvertical/smrt-users": "^0.39.3"
   }
 }

--- a/packages/tenancy/CHANGELOG.md
+++ b/packages/tenancy/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-tenancy
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/tenancy/package.json
+++ b/packages/tenancy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-tenancy",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Production-ready multi-tenancy framework for SMRT with automatic tenant isolation and enforcement",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-types
 
+## 0.39.3
+
 ## 0.39.2
 
 ## 0.39.1

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-types",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Shared type definitions for the HAVE SDK",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/users/CHANGELOG.md
+++ b/packages/users/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-users
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-profiles@0.39.3
+  - @happyvertical/smrt-mobile-contract@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-config@0.39.3
+  - @happyvertical/smrt-types@0.39.3
+  - @happyvertical/smrt-ui@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-users",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Multi-tenant user management for the SMRT framework - users, tenants, roles, permissions, groups",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/video/CHANGELOG.md
+++ b/packages/video/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-video
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-assets@0.39.3
+  - @happyvertical/smrt-content@0.39.3
+  - @happyvertical/smrt-profiles@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-voice@0.39.3
+  - @happyvertical/smrt-config@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-video",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "type": "module",
   "description": "Video content management for AI-powered video production in the SMRT ecosystem",
   "author": "HappyVertical",

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-vitest
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-vitest",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "description": "Vitest plugin for automatic cross-package manifest loading in SMRT tests",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/voice/CHANGELOG.md
+++ b/packages/voice/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-voice
 
+## 0.39.3
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.39.3
+  - @happyvertical/smrt-assets@0.39.3
+  - @happyvertical/smrt-content@0.39.3
+  - @happyvertical/smrt-tenancy@0.39.3
+  - @happyvertical/smrt-config@0.39.3
+
 ## 0.39.2
 
 ### Patch Changes

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-voice",
-  "version": "0.39.2",
+  "version": "0.39.3",
   "type": "module",
   "description": "Voice profile management for AI-powered voice synthesis and cloning in the SMRT ecosystem",
   "author": "HappyVertical",

--- a/scripts/push-release-refs.mjs
+++ b/scripts/push-release-refs.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function requireCleanRefPart(value, label) {
+  if (!value || !/^[A-Za-z0-9._/-]+$/.test(value)) {
+    fail(`${label} contains unsupported characters: ${JSON.stringify(value)}`);
+  }
+}
+
+function runGit(args, { env, label, spawn }) {
+  const result = spawn('git', args, {
+    encoding: 'utf8',
+    env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (result.error) {
+    fail(`${label}: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    fail(`${label}:\n${result.stderr || result.stdout}`);
+  }
+}
+
+export function pushReleaseRefs({
+  baseBranch = process.env.RELEASE_BASE_BRANCH ?? 'main',
+  githubToken = process.env.RELEASE_GITHUB_TOKEN,
+  releaseVersion = process.env.RELEASE_VERSION,
+  spawn = spawnSync,
+} = {}) {
+  requireCleanRefPart(baseBranch, 'Release base branch');
+  requireCleanRefPart(releaseVersion, 'Release version');
+
+  if (!githubToken) {
+    fail('RELEASE_GITHUB_TOKEN is required to push release refs');
+  }
+
+  const authHeader = `AUTHORIZATION: basic ${Buffer.from(
+    `x-access-token:${githubToken}`,
+  ).toString('base64')}`;
+  const gitEnv = {
+    ...process.env,
+    GIT_CONFIG_COUNT: '1',
+    GIT_CONFIG_KEY_0: 'http.https://github.com/.extraheader',
+    GIT_CONFIG_VALUE_0: authHeader,
+    GIT_TERMINAL_PROMPT: '0',
+  };
+  const tag = `v${releaseVersion}`;
+
+  runGit(
+    [
+      'push',
+      '--no-verify',
+      '--atomic',
+      'origin',
+      `HEAD:refs/heads/${baseBranch}`,
+      `refs/tags/${tag}:refs/tags/${tag}`,
+    ],
+    {
+      env: gitEnv,
+      label: `Failed to atomically push release ${tag} to ${baseBranch}`,
+      spawn,
+    },
+  );
+}
+
+const isCli =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isCli) {
+  try {
+    pushReleaseRefs();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/push-release-refs.mjs
+++ b/scripts/push-release-refs.mjs
@@ -35,6 +35,10 @@ export function pushReleaseRefs({
   releaseVersion = process.env.RELEASE_VERSION,
   spawn = spawnSync,
 } = {}) {
+  if (!releaseVersion) {
+    fail('RELEASE_VERSION is required to push release refs');
+  }
+
   requireCleanRefPart(baseBranch, 'Release base branch');
   requireCleanRefPart(releaseVersion, 'Release version');
 

--- a/scripts/push-release-refs.test.mjs
+++ b/scripts/push-release-refs.test.mjs
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import { pushReleaseRefs } from './push-release-refs.mjs';
 
-test('supplies GitHub authentication directly to both release pushes', () => {
+test('supplies GitHub authentication directly to the atomic release push', () => {
   const calls = [];
   const spawn = (command, args, options) => {
     calls.push({ command, args, options });
@@ -57,6 +57,18 @@ test('fails before pushing when the GitHub App token is missing', () => {
         spawn: () => assert.fail('git must not run without authentication'),
       }),
     /RELEASE_GITHUB_TOKEN is required/,
+  );
+});
+
+test('fails before pushing when the release version is missing', () => {
+  assert.throws(
+    () =>
+      pushReleaseRefs({
+        githubToken: 'installation-token',
+        releaseVersion: '',
+        spawn: () => assert.fail('git must not run without a release version'),
+      }),
+    /RELEASE_VERSION is required/,
   );
 });
 

--- a/scripts/push-release-refs.test.mjs
+++ b/scripts/push-release-refs.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { pushReleaseRefs } from './push-release-refs.mjs';
+
+test('supplies GitHub authentication directly to both release pushes', () => {
+  const calls = [];
+  const spawn = (command, args, options) => {
+    calls.push({ command, args, options });
+    return { status: 0, stderr: '', stdout: '' };
+  };
+
+  pushReleaseRefs({
+    baseBranch: 'main',
+    githubToken: 'installation-token',
+    releaseVersion: '0.39.3',
+    spawn,
+  });
+
+  assert.deepEqual(
+    calls.map(({ command, args }) => [command, ...args]),
+    [
+      [
+        'git',
+        'push',
+        '--no-verify',
+        '--atomic',
+        'origin',
+        'HEAD:refs/heads/main',
+        'refs/tags/v0.39.3:refs/tags/v0.39.3',
+      ],
+    ],
+  );
+
+  for (const { options } of calls) {
+    assert.equal(options.env.GIT_CONFIG_COUNT, '1');
+    assert.equal(
+      options.env.GIT_CONFIG_KEY_0,
+      'http.https://github.com/.extraheader',
+    );
+    assert.equal(
+      options.env.GIT_CONFIG_VALUE_0,
+      `AUTHORIZATION: basic ${Buffer.from(
+        'x-access-token:installation-token',
+      ).toString('base64')}`,
+    );
+  }
+});
+
+test('fails before pushing when the GitHub App token is missing', () => {
+  assert.throws(
+    () =>
+      pushReleaseRefs({
+        baseBranch: 'main',
+        githubToken: '',
+        releaseVersion: '0.39.3',
+        spawn: () => assert.fail('git must not run without authentication'),
+      }),
+    /RELEASE_GITHUB_TOKEN is required/,
+  );
+});
+
+test('reports an atomic push failure without attempting a second write', () => {
+  let calls = 0;
+
+  assert.throws(
+    () =>
+      pushReleaseRefs({
+        baseBranch: 'main',
+        githubToken: 'installation-token',
+        releaseVersion: '0.39.3',
+        spawn: () => {
+          calls += 1;
+          return { status: 128, stderr: 'authentication failed', stdout: '' };
+        },
+      }),
+    /Failed to atomically push release v0.39.3 to main/,
+  );
+
+  assert.equal(calls, 1);
+});


### PR DESCRIPTION
## Summary

- apply the exact version patch produced and validated by failed release run 29159374773
- record the already-published 0.39.3 package versions and changelogs in git
- supply the release GitHub App credential directly to Git on ARC runners
- push the release commit and tag as one atomic ref transaction

## Root cause

The ARC node runner resolves the checkout workspace through a symlink into the pnpm store. `actions/checkout@v7` persisted its HTTP credential through a gitdir path condition based on the visible workspace path, but Git resolved the repository through the real pnpm-store path. Public fetches succeeded without authentication and masked the mismatch; the first authenticated tag push failed with exit 128 after all 56 npm artifacts had already published.

## Impact

Main is reconciled to the npm-published 0.39.3 state. Future releases no longer depend on checkout's path-conditional credential include for Git writes, and GitHub cannot receive only the release tag or only the release commit.

## Validation

- recovered package/changelog diff SHA-256 matches the failed run artifact: `ce347646a924db610bf79ee3aae99b100f2aa664e56f8b55a4310896907323bd`
- all 60 workspace build tasks passed
- all 12 CI script tests passed, including authenticated atomic push regression coverage
- strict knowledge freshness passed
- full pre-commit and pre-push hooks passed
- `actionlint .github/workflows/publish.yml`
- `git diff --check`
