### PR TITLE
Adopt the shared agent development policy

### DIFF
--- a/.agents/project.yaml
+++ b/.agents/project.yaml
@@ -1,0 +1,39 @@
+{
+  "schema": "https://happyvertical.com/schemas/agent-project/v1",
+  "policy": {
+    "profile": "happyvertical",
+    "revision": "1.0.0"
+  },
+  "tracker": {
+    "provider": "github",
+    "repository": "happyvertical/smrt",
+    "project_url": "https://github.com/orgs/happyvertical/projects/7"
+  },
+  "labels": {
+    "claim": "agent: implementation",
+    "blocked": "status: blocked",
+    "dispatch": {
+      "claude": "dispatch: claude",
+      "codex": "dispatch: codex",
+      "hermes": "dispatch: hermes"
+    }
+  },
+  "memory": {
+    "provider": "hindsight",
+    "bank": "repo-happyvertical-smrt",
+    "package_tags": []
+  },
+  "instructions": {
+    "canonical": "AGENTS.md",
+    "adapters": [
+      "claude",
+      "gemini",
+      "copilot"
+    ]
+  },
+  "skills": {
+    "paths": [
+      ".agents/skills"
+    ]
+  }
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Generated adapter
+
+Follow `/AGENTS.md` as canonical repository instructions.

--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -2,7 +2,7 @@ name: Agent Policy
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
+    types: [opened, edited, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -26,11 +26,14 @@ jobs:
             ghcr.io/*@sha256:*) ;;
             *) echo 'AGENT_POLICY_ARTIFACT must be an immutable GHCR digest' >&2; exit 1 ;;
           esac
-          mkdir -p .hv-policy
-          oras pull "$POLICY_ARTIFACT" -o .hv-policy
-          tar -xzf .hv-policy/agent-policy.tar.gz -C .hv-policy
+          policy_dir="$RUNNER_TEMP/hv-policy"
+          rm -rf "$policy_dir"
+          mkdir -p "$policy_dir"
+          oras pull "$POLICY_ARTIFACT" -o "$policy_dir"
+          tar -xzf "$policy_dir/agent-policy.tar.gz" -C "$policy_dir"
+          echo "HV_POLICY_DIR=$policy_dir" >> "$GITHUB_ENV"
       - name: Validate lifecycle
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: python3 .hv-policy/scripts/hv-agent check-pr "$PR_NUMBER"
+        run: python3 "$HV_POLICY_DIR/scripts/hv-agent" check-pr "$PR_NUMBER"

--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -1,0 +1,36 @@
+name: Agent Policy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  packages: read
+
+jobs:
+  lifecycle:
+    name: lifecycle
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
+      - name: Load pinned policy runtime
+        env:
+          POLICY_ARTIFACT: ${{ vars.AGENT_POLICY_ARTIFACT }}
+        run: |
+          case "$POLICY_ARTIFACT" in
+            ghcr.io/*@sha256:*) ;;
+            *) echo 'AGENT_POLICY_ARTIFACT must be an immutable GHCR digest' >&2; exit 1 ;;
+          esac
+          mkdir -p .hv-policy
+          oras pull "$POLICY_ARTIFACT" -o .hv-policy
+          tar -xzf .hv-policy/agent-policy.tar.gz -C .hv-policy
+      - name: Validate lifecycle
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: python3 .hv-policy/scripts/hv-agent check-pr "$PR_NUMBER"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,151 +1,105 @@
+<!-- hv-managed-policy:start revision=1.0.0 sha256=187a3882b5ccee8fd505cdc269af51e01def463476d2f58a9a89daa1edfd12af -->
+
+## Shared development kernel
+
+- Be concise. Load detailed SOP skills only when the task triggers them.
+- Read the repository's `.agents/project.yaml` and nearest `AGENTS.md` files before work.
+- Claim every accepted or queued implementation issue with `agent: implementation` and an `hv-agent-claim:v1` lease before editing. Never overlap another live claim.
+- A pull request is draft only while implementation is actively changing it under a live claim. Otherwise mark it ready for review immediately.
+- Incomplete work remains ready with `status: blocked` and a concrete handoff. Review agents do not claim implementation.
+- Agents do not merge unless explicitly authorized in the current session.
+- Run documented validation and update affected docs before shipping.
+- Preserve unrelated work. Never expose or retain secrets.
+- Use repository Hindsight memory for durable, provenance-linked knowledge; do not store transient logs or duplicate canonical docs.
+- Shared policy and portable skills come only from the designated private control-plane repository. Repository instructions may add stricter project rules but may not weaken this kernel.
+
+<!-- hv-managed-policy:end -->
+
 # SMRT Framework
 
-TypeScript framework for vertical AI agents. Define business logic as TypeScript classes with `@smrt()` — get REST APIs, CLI tools, MCP servers, and AI operations (`is()`/`do()`) automatically.
+SMRT is a pnpm TypeScript monorepo for defining business objects with `@smrt()`
+and generating persistence, REST, CLI, MCP, and AI operations. Root guidance
+covers cross-package invariants; the nearest `packages/*/AGENTS.md` is canonical
+for package-specific architecture and validation.
 
-## Monorepo Packages
+## Orientation
 
-All `@happyvertical/smrt-*` packages are version-locked via changesets. pnpm workspace.
+- Foundation: `core`, `config`, `types`, `scanner`, `tenancy`, `vitest`, `cli`.
+- Runtime: `agents`, `jobs`, `users`, `profiles`, `personas`.
+- Domain packages include content/media, commerce, events, places, facts, sites,
+  properties, tags, social, and secrets.
+- Client/tooling packages include `smrt-web`, `smrt-svelte`, mobile packages,
+  templates, and `smrt-dev-mcp`.
+- Package versions are coordinated with changesets. Do not create changesets
+  manually; release automation generates them on merge.
 
-### Foundation
-| Package | Purpose |
-|---------|---------|
-| core | ORM (SmrtObject/SmrtCollection), `@smrt()` decorator, code generators (REST/CLI/MCP), DispatchBus, STI, object context memory (`remember`/`recall`) + semantic search |
-| config | cosmiconfig loader, secret sanitization, SSG export |
-| cli | Developer CLI: `smrt db:*`, `smrt docs:agents`, `smrt dev:knowledge-*`, introspection, code generation |
-| types | Shared TypeScript types/enums — zero runtime code |
-| vitest | Test plugin: auto-manifest generation, cross-package class loading, DB isolation |
-| scanner | oxc-parser AST scanner for class/field metadata extraction |
-| tenancy | Multi-tenancy: AsyncLocalStorage context, auto-filtering interceptors, adapters |
-
-### Agents & Runtime
-| Package | Purpose |
-|---------|---------|
-| agents | Agent lifecycle, DispatchBus inter-agent messaging, interests-based discovery, scheduling |
-| jobs | Background execution: TaskRunner, ScheduleRunner, fluent JobBuilder, `withBackgroundJobs()` |
-| users | Auth/RBAC: 4-level permission cascade, hierarchical tenants, sessions, SvelteKit hooks; manifest-derived per-operation permissions + Postgres RLS |
-| profiles | Identity: multi-auth (Nostr/OIDC/API keys/magic links), relationships, audit logging, owned asset joins via `profile_assets` |
-| personas | Tenant-owned, context-scoped `AgentPersona` + `PersonaResolver` (layers over `smrt-agents` `TenantAgent` availability/ceiling gate); persona learning loop — `Feedback` reinforcement, scheduled `ReflectionRunner` → pending `DirectiveProposal`, HITL activation gated by the `personas.activate-directive` permission split |
-
-### Content & Media
-| Package | Purpose |
-|---------|---------|
-| content | STI content types (Article/Document/Mirror), thumbnails (3 strategies), content-owned asset joins via `content_assets`, versioned snapshots with citation-time reference pinning for drift detection |
-| messages | Multi-channel messaging: Email/Twitter/Slack as STI hierarchy, credential encryption |
-| chat | Chat rooms (public/private/DM/agent), threads, agent sessions with tool whitelisting |
-| assets | Provider-agnostic asset management, versioning, generic/provenance `AssetAssociation` links |
-| images | Image ops: AI categorization, editing, cross-package STI extending Asset |
-| video | Video production: Character/Performer/Scene, ComfyUI workflows, frame-based durations |
-| voice | TTS voice profiles, cloning from samples, word timings for lip-sync |
-
-### Business
-| Package | Purpose |
-|---------|---------|
-| commerce | Customer/Vendor, Contract (5 STI types), Invoice with ledger integration, Fulfillment |
-| products | Product catalog — reference template for triple-consumption (npm/federation/standalone) with owned asset joins via `product_assets` |
-| ads | Ad delivery: priority waterfall, weighted A/B variations, immutable event tracking |
-| sales | Modular sales: CRM (Lead/Opportunity/Pipeline), referrals with versioned attribution policies + immutable term snapshots, neutral commissions core (Earner, CommissionPlan, Commission, CommissionPayout — integer cents), reusable Svelte surfaces; subpaths `/crm`, `/referrals`, `/commissions`, `/svelte` |
-| affiliates | DEPRECATED compatibility shim over `smrt-sales` — re-exports legacy Partner/Commission/Payout names with no persistence of its own; see `packages/affiliates/MIGRATION.md` |
-| ledgers | Double-entry accounting, balance enforcement (EPSILON=0.01), journal lifecycle |
-| analytics | GA4/Plausible: properties, data streams, server-side events, AI-powered reports |
-| reports | Materialized aggregate read models: report decorators, portable aggregate specs, rebuild refresh |
-| subscriptions | Tenant subscription plans, feature grants, usage thresholds, and entitlement resolution |
-| support | AI-first Support Cases: chat/email intake to canonical cases (create-or-join dedup), guarded lifecycle + reopen history, Automated Support Response with lossless Human Handoff, Project-qualified routing, Service Target clocks with timed escalation, generic ServiceTimeEntry with separated SupportCharge/SupportCompensation snapshots |
-
-### Domain
-| Package | Purpose |
-|---------|---------|
-| events | Infinite-nesting event hierarchy, series, participant roles/placements, owned asset joins via `event_assets` |
-| places | Hierarchical places, geocoding via `lookupOrCreate()`, Haversine proximity search, owned asset joins via `place_assets` |
-| facts | Knowledge base: semantic dedup (3-zone reconciliation), evolution chains, confidence |
-| sites | Site lifecycle management, agent bindings with priority ordering |
-| properties | Digital properties with hierarchical zones for content/ad placement |
-| tags | Hierarchical tagging: context-scoped slugs, multi-language aliases |
-| social | Social media OAuth (YouTube/Threads/X/Bluesky), post scheduling |
-| secrets | Envelope encryption (AMK→TDEK→secret), key rotation, audit logging |
-
-### Mobile
-| Package | Purpose |
-|---------|---------|
-| smrt-mobile | KMP shared mobile foundation (offline packs + durable SQLDelight write-queue, evidence, i18n, shell state, PKCE auth/session, Ktor client, platform seams incl. barcode/speech/on-device-LLM) — first non-TS package, Gradle behind a package.json wrapper (ADR 0001) |
-| smrt-android | Android Compose foundation: MobileTheme design tokens, bottom-tab shell bound to MobileShellState, native adapters (ML Kit barcode, speech, Gemini Nano, device capabilities, SQLDelight driver, Keystore auth storage) — consumes smrt-mobile via Gradle composite build |
-| smrt-ios | SwiftUI foundation: MobileTheme design tokens, tab shell bound to MobileShellState, native adapters (VisionKit barcode, Speech, Foundation Models on-device LLM, device capabilities, SQLDelight native driver, Keychain auth storage, ASWebAuthenticationSession launcher) — consumes the exported SmrtMobile KMP framework via XcodeGen |
-| smrt-mobile-contract | TS codegen: SMRT manifest + allowlist → Kotlin/Swift mobile DTOs + smrt-mobile's generated framework contract |
-
-### Tooling
-| Package | Purpose |
-|---------|---------|
-| smrt-web | Browser client data runtime (web twin of smrt-mobile): manifest-generated collections over the generated REST surface with SWR reads, request dedup, optimistic mutations; wraps the client-data engine (TanStack DB) behind SMRT-owned types so it never leaks |
-| smrt-svelte | Svelte 5: Provider, browser AI (STT/TTS/LLM) with warm cache, theme system |
-| smrt-dev-mcp | Tier 2 dev MCP: code generation, project introspection, deterministic knowledge reflection, review/architecture context bundles, bundled agent skills |
-| gnode | Federation library — stubs only, not implemented |
-| template-sveltekit | Base SvelteKit scaffold with SMRT integration |
-| template-site-static-json | Community news site scaffold with Praeco/Caelus |
-
-## Commands
+## Setup and validation
 
 ```bash
-pnpm install && npm run build   # Setup (~8s first build, ~80ms cached via turborepo)
-npm run dev                     # Watch mode
-npm test                        # Vitest — smrtVitestPlugin() required in config
-npm run typecheck               # TypeScript checking
-npm run lint                    # Biome
-npm run format                  # Biome
+pnpm install
+pnpm build
+pnpm test
+pnpm typecheck
+pnpm lint
+pnpm format
+pnpm dev:knowledge-check
 ```
 
-## Conventions
+Use the narrowest package command first, then the relevant root checks. The
+SMRT Vitest plugin is required for manifest generation and database isolation.
+When editing scanner or schema-generator code, rebuild `packages/core` because
+the Vite plugin consumes deterministic `dist/` artifacts.
 
-- **0 vs 0.0**: `count: number = 0` → INTEGER. `price: number = 0.0` → DECIMAL
-- **Never override toJSON()** — use `transformJSON()` (toJSON handles STI + meta fields)
-- **Same-package FKs**: use `@foreignKey(Target)` so relationships, schema, includes, and `loadRelated()` are registered.
-- **Cross-package FKs**: use `@crossPackageRef('@happyvertical/smrt-package:Class')`; it registers runtime relationships without emitting circular DDL constraints.
-- **System tables**: prefixed `_smrt_` (jobs, dispatch, schedules, migrations)
-- **Conflict columns**: set `conflictColumns` in `@smrt()` for junction/upsert tables
-- **Junction collections**: extend `SmrtJunction`; use `byLeft()` / `byRight()` and options-object `attach()` / `detach()`.
-- **Hierarchies**: extend `SmrtHierarchical` only for true `parentId` trees; use package-specific names for chains/DAGs like fact evolution or asset derivation.
-- **Polymorphic links**: extend `SmrtPolymorphicAssociation` for generic/provenance links that target `(metaType, metaId, role)`.
-- **Asset ownership joins**: base/domain-owned asset relationships belong on noun join tables like `content_assets`, `profile_assets`, `event_assets`, `place_assets`, and `product_assets`; use `asset_associations` only for generic/provenance links
-- **STI discriminator**: qualified names — `@happyvertical/smrt-content:Article`
-- **UUID storage**: `id` and declared FK columns are native `uuid` on PostgreSQL/DuckDB and `TEXT` on SQLite.
-- **Tenant relationship loads**: `loadRelated()` / `loadRelatedMany()` enforce tenant isolation unless `{ allowCrossTenant: true }` is explicit.
-- **Tenant scoping**: most domain models use `@TenantScoped({ mode: 'optional' })` + nullable tenantId
-- **JSON fields**: store as string, provide `getX()`/`setX()` helpers with graceful parse error handling
-- **No private reach-ins**: do not cast into underscored internals like `_db`, `_tableName`, or registry-private state from outside the owning class. If a public API is missing, add one upstream instead of reaching through a private implementation detail.
-- **Changesets**: auto-generated on merge to main. Don't run `npx changeset` manually
+## Core model invariants
 
-## SDK Dependencies
+- Numeric defaults carry schema meaning: `0` maps to integer and `0.0` to decimal.
+- Never override `toJSON()`; extend serialization through `transformJSON()`.
+- Same-package foreign keys use `@foreignKey(Target)`; cross-package references
+  use `@crossPackageRef('@happyvertical/smrt-package:Class')`.
+- System tables use `_smrt_` prefixes. Junctions extend `SmrtJunction`; true
+  `parentId` trees extend `SmrtHierarchical`; generic/provenance links extend
+  `SmrtPolymorphicAssociation`.
+- STI discriminators are qualified names such as
+  `@happyvertical/smrt-content:Article`.
+- UUID identifiers and foreign keys remain native UUID on PostgreSQL/DuckDB and
+  text on SQLite. Fix invalid values or casts at owning boundaries; never weaken
+  UUID columns to text.
+- Tenant-scoped relationship loads enforce isolation. Cross-tenant reads require
+  an explicit, reviewed `allowCrossTenant` path.
+- Do not reach into underscored/private registry, database, collection, or table
+  state. Add a public API in the owning package.
+- Asset ownership uses noun-specific join tables; reserve generic asset
+  associations for provenance or polymorphic links.
 
-From [@happyvertical/sdk](https://github.com/happyvertical/sdk): `@happyvertical/ai`, `@happyvertical/sql`, `@happyvertical/files`, `@happyvertical/utils`, `@happyvertical/cache`, `@happyvertical/documents`, `@happyvertical/email`, `@happyvertical/encryption`, `@happyvertical/geo`, `@happyvertical/images`, `@happyvertical/jobs`, `@happyvertical/json`, `@happyvertical/logger`, `@happyvertical/messages`, `@happyvertical/ocr`, `@happyvertical/pdf`, `@happyvertical/projects`, `@happyvertical/repos`, `@happyvertical/secrets`, and `@happyvertical/spider`.
+## Generated knowledge
 
-## Downstream Doc Generation
+- Root and package `AGENTS.md` files are canonical expert documentation.
+- `CLAUDE.md` is only an `@AGENTS.md` adapter.
+- `smrt docs:agents` generates downstream `.agents/smrt-framework.md` snapshots.
+- `smrt dev:knowledge-index` prints the deterministic SMRT + SDK knowledge graph.
+- `smrt dev:knowledge-check` validates docs, manifests, package files, and
+  relationship facts. CI and Lefthook run strict freshness checks.
+- Use `smrt knowledge:review-context` and
+  `smrt knowledge:architecture-context` with the narrowest scope/package.
+- Runtime manifests stay runtime-focused; `.smrt/smrt-knowledge.json` and
+  `dist/smrt-knowledge.json` are the agent/developer contract.
 
-`smrt docs:agents` generates `.agents/smrt-framework.md` for consumer projects by concatenating installed package `AGENTS.md` files with version tables. `smrt docs:claude` remains a deprecated compatibility alias that writes `.claude/smrt-framework.md`. Code: `packages/cli/src/commands/docs-claude.ts`.
+## Frequent hazards
 
-## Agent Knowledge
+- Restart Vitest after adding decorated classes; manifests are generated at
+  startup.
+- `ObjectRegistry` uses a `globalThis` singleton so it survives HMR.
+- Runtime verifies schema but does not create application tables; use explicit
+  migrations/tooling.
+- Vite 8 decorators require the repository's documented Oxc legacy decorator
+  configuration; do not restore obsolete Vite 7 workarounds.
+- Svelte subpath packages must run `svelte-check`, not only `tsc`.
+- Avoid complex inline intersected generics in Svelte `$props()`; use named
+  interfaces to prevent recursive type evaluation.
+- JSON fields are stored as strings and should expose guarded get/set helpers.
 
-- `AGENTS.md` is canonical for root and package expert docs.
-- `CLAUDE.md` files are one-line Claude Code shims containing only `@AGENTS.md`.
-- Harnesses that do not resolve Claude Code `@AGENTS.md` shims should read
-  `AGENTS.md` directly.
-- `smrt dev:knowledge-index` prints the deterministic SMRT + HappyVertical SDK knowledge graph.
-- `smrt dev:knowledge-check` validates agent-doc freshness, stale references, package docs, package `files` entries, and relationship-aware manifest facts. Use `--format markdown` for human hook output and `--format json` for scripts.
-- Downstream apps/packages generate `.smrt/smrt-knowledge.json` for local
-  development and `dist/smrt-knowledge.json` for published package artifacts.
-  `manifest.json` remains runtime-focused; `smrt-knowledge.json` is the
-  agent/developer contract.
-- `smrt knowledge:review-context` and `smrt knowledge:architecture-context`
-  build domain-scoped prompt bundles. Use `--scope project|local|package|sdk`
-  and `--package <name>` to narrow context.
-- Lefthook runs deterministic knowledge freshness locally: changed-file strict checks on pre-commit and full strict checks on pre-push. CI runs the full strict check as a blocking PR gate (the `Knowledge Freshness` job, sweep S5 #1376). Model-assisted audits are never required in hooks or CI.
-- `smrt-dev-mcp` exposes the same knowledge through `reflect-knowledge`, `reflect-domain-knowledge`, `check-knowledge-freshness`, `check-domain-knowledge`, `build-review-context`, `build-domain-review-context`, `smrt-review`, `build-architecture-context`, `build-domain-architecture-context`, and `smrt-architecture`.
-- `smrt-dev-mcp` also ships harness-agnostic skills. Downstream agents can call `get-agent-skill` with `name: "smrt-code-review"` to fetch the portable review procedure before using `smrt-review` on a project diff.
+## Pull requests
 
-## Gotchas
-
-- **Vitest plugin required**: without `smrtVitestPlugin()` in vitest.config.ts → "No field metadata" errors
-- **Vite decorators**: under Vite 8 set `oxc: { decorator: { legacy: true, emitDecoratorMetadata: true } }` in `vite.config.ts` (see `packages/template-sveltekit/template/vite.config.ts`) — the oxc transform ignores the pre-Vite-8 `esbuild.tsconfigRaw` / tsconfig `experimentalDecorators` through SvelteKit's `extends` chain, so that recipe throws `SyntaxError: Invalid or unexpected token` on the first SSR request. Consumers pinned on vite<8 still need the legacy `esbuild.tsconfigRaw` form.
-- **Manifest is build-time**: generated once at vitest startup — restart after adding new `@smrt()` classes
-- **ObjectRegistry on globalThis**: singleton via `globalThis.__smrtRegistry*` — survives HMR
-- **No runtime schema creation**: application tables must be prepared explicitly via migrations/tooling; runtime only verifies and fails clearly
-- **Svelte typechecking**: packages with `/svelte` subpaths must run `svelte-check` in `typecheck` after `tsc`; `tsc` alone treats `.svelte` imports as ambient `Component<any>`.
-- **TypeScript & Svelte 5 Performance**: Avoid using inline intersected generic types (like `Asset & { id: string }`) in component `$props()`. It causes infinite-loop-like recursion during type evaluation. Export an explicit interface (e.g., `interface PersistedAsset extends Asset { id: string }`) instead.
-- **Editing `packages/core/src/scanner/*` or `src/schema/generator.ts` requires a rebuild**: the vite-plugin loads these modules from `dist/` deterministically (sniffing `.ts`/`.js` via `import.meta.url` was non-deterministic under tsx and repeatedly broke publishes — see #1139). Run `pnpm build` in core, or keep `pnpm dev` / `pnpm build:watch` running, otherwise consumers won't see your scanner/generator edits reflected in their manifests.
+Keep changes package-focused, use conventional commits, run knowledge freshness,
+and make the PR ready when implementation stops. Agents never merge without an
+explicit session instruction.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ pnpm test
 pnpm typecheck
 pnpm lint
 pnpm format
-pnpm dev:knowledge-check
+pnpm smrt dev:knowledge-check
 ```
 
 Use the narrowest package command first, then the relevant root checks. The

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,3 @@
+# Generated adapter
+
+Read and follow `AGENTS.md`; it is canonical.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "changeset:publish": "changeset publish",
     "version": "node scripts/check-version-limit.js && changeset version",
     "release": "pnpm run build && node scripts/publish-sequential.js",
-    "smrt": "pnpm --filter @happyvertical/smrt-core cli",
+    "smrt": "pnpm --filter @happyvertical/smrt-cli cli",
     "docs:site": "pnpm --dir docs start",
     "docs:site:build": "pnpm --dir docs build",
     "docs:site:dev": "pnpm --dir docs dev",


### PR DESCRIPTION
## Summary

Curates the oversized root guidance while preserving package-level expert docs, adds the repository contract and adapters, and introduces the digest-gated lifecycle check.

## Release gate

Ready for review, but blocked until have-config PR #28 publishes the signed public policy artifact and `AGENT_POLICY_ARTIFACT` is set to its immutable digest. The lifecycle workflow fails closed until then.

## Validation

- strict knowledge freshness
- SMRT standards
- full pre-push hooks
- policy audit

Closes #1960

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-wave3-smrt","issue":"happyvertical/smrt#1960","policy_revision":"1.0.0","validation":["strict knowledge freshness","SMRT standards","full pre-push hooks","policy audit"]}
```