### PR TITLE
Align the lifecycle policy workflow

### DIFF
--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -3,6 +3,12 @@ name: Agent Policy
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to recheck after a claim-only transition
+        required: true
+        type: number
 
 permissions:
   contents: read
@@ -30,10 +36,23 @@ jobs:
           rm -rf "$policy_dir"
           mkdir -p "$policy_dir"
           oras pull "$POLICY_ARTIFACT" -o "$policy_dir"
-          tar -xzf "$policy_dir/agent-policy.tar.gz" -C "$policy_dir"
+          archive="$policy_dir/agent-policy.tar.gz"
+          test -f "$archive" || { echo 'policy artifact is missing agent-policy.tar.gz' >&2; exit 1; }
+          python3 - "$archive" <<'PY'
+          import pathlib
+          import sys
+          import tarfile
+
+          with tarfile.open(sys.argv[1], "r:gz") as archive:
+              for member in archive.getmembers():
+                  path = pathlib.PurePosixPath(member.name)
+                  if path.is_absolute() or ".." in path.parts or member.issym() or member.islnk():
+                      raise SystemExit(f"unsafe policy archive member: {member.name}")
+          PY
+          tar -xzf "$archive" -C "$policy_dir"
           echo "HV_POLICY_DIR=$policy_dir" >> "$GITHUB_ENV"
       - name: Validate lifecycle
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
         run: python3 "$HV_POLICY_DIR/scripts/hv-agent" check-pr "$PR_NUMBER"


### PR DESCRIPTION
## Summary

Aligns this repository's Agent Policy workflow with the canonical control-plane template before the next signed policy artifact is activated.

The workflow uses the organization-level immutable artifact variable, fails closed on invalid references, and validates archive members before extraction.

## Validation

- have-config policy audit
- byte-for-byte canonical template comparison
- actionlint

Closes #1969

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"align-smrt-workflow","issue":"happyvertical/smrt#1969","policy_revision":"1.0.0","validation":["policy audit","canonical template comparison","actionlint"]}
```

