### PR TITLE
fix: restore consumer-safe package boundaries for chat, personas, and messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,8 @@ for package-specific architecture and validation.
 - Domain packages include content/media, commerce, events, places, facts, sites,
   properties, tags, social, and secrets.
 - Client/tooling packages include `smrt-web`, `smrt-svelte`, mobile packages,
-  templates, and `smrt-dev-mcp`.
+  templates, and `smrt-dev-mcp`. The private `bundle-gate` package is the CI
+  consumer bundle reachability/size gate (#1980).
 - Package versions are coordinated with changesets. Do not create changesets
   manually; release automation generates them on merge.
 

--- a/packages/assets/AGENTS.md
+++ b/packages/assets/AGENTS.md
@@ -71,6 +71,7 @@ Registered slots: `asset-manager` (admin), `asset-grid` / `asset-list` (list), `
 
 ## Gotchas
 
+- **Files SDK is a lazy boundary (#1979)**: `AssetStore` loads `@happyvertical/files` through `src/files-runtime.ts` (bundler-invisible), because smrt-assets is reachable from provider-neutral consumer graphs via profiles. Node/tsx/vite-dev runtimes resolve it on first file operation; fully-bundled deployments import `@happyvertical/smrt-assets/filesystem` at startup. Never import the files SDK statically from modules reachable from `src/index.ts`.
 - **Version history manual**: `findVersions()` chaining required — no ORM shortcut
 - **Tag management uses raw SQL**: `asset_tags` is a join table, not an SMRT model
 - **Folder tree traversal**: via `SmrtHierarchical` (`getParent`/`getChildren`/`getAncestors`/`getDescendants`/`getHierarchy`/`moveTo`); `FolderCollection.getTree(rootId?)` and `getPath(folderId)` wrap these for convenience

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -16,6 +16,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./filesystem": {
+      "types": "./dist/filesystem.d.ts",
+      "import": "./dist/filesystem.js"
+    },
     "./ui": {
       "types": "./dist/ui.d.ts",
       "import": "./dist/ui.js"

--- a/packages/assets/src/asset-store.ts
+++ b/packages/assets/src/asset-store.ts
@@ -7,14 +7,15 @@
  * Supports provider-agnostic storage (local, S3, etc.) via @happyvertical/files.
  */
 
-import {
-  FileNotFoundError,
-  type FilesystemInterface,
-  type GetFilesystemOptions,
-  getFilesystem,
+import type {
+  FilesystemInterface,
+  GetFilesystemOptions,
 } from '@happyvertical/files';
 import type { Asset } from './asset';
 import type { AssetCollection } from './assets';
+// The files SDK is loaded through the lazy boundary in files-runtime.ts so it
+// never enters provider-neutral consumer bundles (#1977/#1979).
+import { getFilesystemLazy, isFileNotFoundError } from './files-runtime.js';
 
 /**
  * MIME type to file extension mapping
@@ -200,7 +201,7 @@ export class AssetStore {
    * Must be called before any file operations.
    */
   async initialize(): Promise<this> {
-    this.fs = await getFilesystem(this.fsOptions);
+    this.fs = await getFilesystemLazy(this.fsOptions);
     this.fsCache.set(this.providerCacheKey(this.fsOptions), this.fs);
     return this;
   }
@@ -226,7 +227,7 @@ export class AssetStore {
     const cached = this.fsCache.get(key);
     if (cached) return cached;
 
-    const filesystem = await getFilesystem(providerOptions);
+    const filesystem = await getFilesystemLazy(providerOptions);
     this.fsCache.set(key, filesystem);
     return filesystem;
   }
@@ -527,7 +528,7 @@ export class AssetStore {
       try {
         await target.filesystem.delete(target.path);
       } catch (err) {
-        if (!(err instanceof FileNotFoundError)) {
+        if (!isFileNotFoundError(err)) {
           throw err;
         }
         // File may not exist on disk — still delete the record

--- a/packages/assets/src/files-runtime.test.ts
+++ b/packages/assets/src/files-runtime.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Lazy files-SDK boundary for AssetStore (#1979).
+ *
+ * smrt-assets is reachable from provider-neutral consumer graphs, so the
+ * files SDK must load lazily (or via the explicit filesystem entry) instead
+ * of a static import.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+async function loadFresh() {
+  vi.resetModules();
+  return import('./files-runtime.js');
+}
+
+describe('files-runtime boundary', () => {
+  it('uses a registered files module without runtime resolution', async () => {
+    const runtime = await loadFresh();
+    const filesystem = { read: vi.fn() };
+    const getFilesystem = vi.fn(async () => filesystem as never);
+    runtime.registerFilesModule({ getFilesystem } as never);
+
+    const resolved = await runtime.getFilesystemLazy({
+      type: 'local',
+      basePath: '.',
+    } as never);
+
+    expect(resolved).toBe(filesystem);
+    expect(getFilesystem).toHaveBeenCalledWith({
+      type: 'local',
+      basePath: '.',
+    });
+  });
+
+  it('falls back to runtime resolution of @happyvertical/files', async () => {
+    const runtime = await loadFresh();
+    const filesystem = await runtime.getFilesystemLazy({
+      type: 'local',
+      basePath: '.',
+    } as never);
+    expect(filesystem).toBeDefined();
+  });
+
+  it('the explicit filesystem entry registers the real SDK module', async () => {
+    vi.resetModules();
+    const runtime = await import('./files-runtime.js');
+    await import('./filesystem.js');
+    const filesystem = await runtime.getFilesystemLazy({
+      type: 'local',
+      basePath: '.',
+    } as never);
+    expect(filesystem).toBeDefined();
+  });
+
+  it('recognizes FileNotFoundError from the loaded module and by name', async () => {
+    const runtime = await loadFresh();
+    class FileNotFoundError extends Error {
+      constructor() {
+        super('missing');
+        this.name = 'FileNotFoundError';
+      }
+    }
+    runtime.registerFilesModule({
+      getFilesystem: async () => ({}) as never,
+      FileNotFoundError,
+    } as never);
+
+    expect(runtime.isFileNotFoundError(new FileNotFoundError())).toBe(true);
+
+    const foreign = new Error('missing elsewhere');
+    foreign.name = 'FileNotFoundError';
+    expect(runtime.isFileNotFoundError(foreign)).toBe(true);
+
+    expect(runtime.isFileNotFoundError(new Error('other'))).toBe(false);
+    expect(runtime.isFileNotFoundError(undefined)).toBe(false);
+  });
+});

--- a/packages/assets/src/files-runtime.ts
+++ b/packages/assets/src/files-runtime.ts
@@ -1,0 +1,59 @@
+/**
+ * Lazy boundary to `@happyvertical/files` (#1977/#1979).
+ *
+ * The files SDK statically imports @aws-sdk/client-s3 and reaches googleapis
+ * from its root, and smrt-assets is reachable from provider-neutral consumer
+ * graphs (profiles → assets), so AssetStore must not import it eagerly.
+ *
+ *  - Runtimes with node_modules (Node, tsx, vite dev, externalized SSR) load
+ *    the SDK on first file operation via a bundler-invisible import.
+ *  - Fully-bundled deployments opt in explicitly with
+ *    `import '@happyvertical/smrt-assets/filesystem'` at server startup.
+ */
+import type {
+  FilesystemInterface,
+  GetFilesystemOptions,
+} from '@happyvertical/files';
+import { importOptionalDependency } from '@happyvertical/smrt-core';
+
+type FilesModule = typeof import('@happyvertical/files');
+
+let filesModule: FilesModule | undefined;
+
+/**
+ * Registers the statically-imported files SDK module. Called by the
+ * `@happyvertical/smrt-assets/filesystem` entry point.
+ */
+export function registerFilesModule(mod: FilesModule): void {
+  filesModule = mod;
+}
+
+async function loadFilesModule(): Promise<FilesModule> {
+  if (!filesModule) {
+    filesModule = (await importOptionalDependency(
+      '@happyvertical/files',
+      "Import '@happyvertical/smrt-assets/filesystem' during server startup to enable asset file storage in bundled builds.",
+    )) as FilesModule;
+  }
+  return filesModule;
+}
+
+/** Lazy equivalent of the files SDK's `getFilesystem`. */
+export async function getFilesystemLazy(
+  options: GetFilesystemOptions,
+): Promise<FilesystemInterface> {
+  const mod = await loadFilesModule();
+  return mod.getFilesystem(options);
+}
+
+/**
+ * True when `error` is the files SDK's FileNotFoundError. Uses the loaded
+ * module's class when available and falls back to an `error.name` check so
+ * resolver-injected filesystems built against another SDK copy still match.
+ */
+export function isFileNotFoundError(error: unknown): boolean {
+  if (filesModule && error instanceof filesModule.FileNotFoundError) {
+    return true;
+  }
+  return error instanceof Error && error.name === 'FileNotFoundError';
+}

--- a/packages/assets/src/filesystem.ts
+++ b/packages/assets/src/filesystem.ts
@@ -2,10 +2,13 @@
  * Explicit filesystem enablement entry point for smrt-assets.
  *
  * Importing this module statically links `@happyvertical/files` and registers
- * it with AssetStore's lazy boundary, restoring asset file storage in
- * fully-bundled deployments (where the runtime fallback in files-runtime
- * cannot resolve node_modules). Provider-neutral consumers must NOT import
- * this — it deliberately makes the files SDK (S3/googleapis) reachable.
+ * it with AssetStore's lazy boundary AND core's global optional-dependency
+ * registry (so every importOptionalDependency('@happyvertical/files') caller
+ * — e.g. smrt-messages Attachment.readContent — is satisfied too). This
+ * restores asset file storage in fully-bundled deployments where the runtime
+ * fallback in files-runtime cannot resolve node_modules. Provider-neutral
+ * consumers must NOT import this — it deliberately makes the files SDK
+ * (S3/googleapis) reachable.
  *
  * @example
  * ```ts
@@ -14,8 +17,10 @@
  * ```
  */
 import * as files from '@happyvertical/files';
+import { registerOptionalDependency } from '@happyvertical/smrt-core';
 import { registerFilesModule } from './files-runtime.js';
 
+registerOptionalDependency('@happyvertical/files', files);
 registerFilesModule(files);
 
 export { FileNotFoundError, getFilesystem } from '@happyvertical/files';

--- a/packages/assets/src/filesystem.ts
+++ b/packages/assets/src/filesystem.ts
@@ -1,0 +1,21 @@
+/**
+ * Explicit filesystem enablement entry point for smrt-assets.
+ *
+ * Importing this module statically links `@happyvertical/files` and registers
+ * it with AssetStore's lazy boundary, restoring asset file storage in
+ * fully-bundled deployments (where the runtime fallback in files-runtime
+ * cannot resolve node_modules). Provider-neutral consumers must NOT import
+ * this — it deliberately makes the files SDK (S3/googleapis) reachable.
+ *
+ * @example
+ * ```ts
+ * // hooks.server.ts / server bootstrap
+ * import '@happyvertical/smrt-assets/filesystem';
+ * ```
+ */
+import * as files from '@happyvertical/files';
+import { registerFilesModule } from './files-runtime.js';
+
+registerFilesModule(files);
+
+export { FileNotFoundError, getFilesystem } from '@happyvertical/files';

--- a/packages/assets/src/index.ts
+++ b/packages/assets/src/index.ts
@@ -81,6 +81,11 @@ export {
   type ProviderOptions,
   type StoreOptions,
 } from './asset-store';
+export {
+  getFilesystemLazy,
+  isFileNotFoundError,
+  registerFilesModule,
+} from './files-runtime';
 export { AssetType } from './asset-type';
 export { AssetTypeCollection } from './asset-types';
 export { AssetCollection } from './assets';

--- a/packages/assets/src/index.ts
+++ b/packages/assets/src/index.ts
@@ -81,14 +81,14 @@ export {
   type ProviderOptions,
   type StoreOptions,
 } from './asset-store';
+export { AssetType } from './asset-type';
+export { AssetTypeCollection } from './asset-types';
+export { AssetCollection } from './assets';
 export {
   getFilesystemLazy,
   isFileNotFoundError,
   registerFilesModule,
 } from './files-runtime';
-export { AssetType } from './asset-type';
-export { AssetTypeCollection } from './asset-types';
-export { AssetCollection } from './assets';
 export { Folder } from './folder';
 export { FolderCollection } from './folders';
 export {

--- a/packages/assets/vite.config.ts
+++ b/packages/assets/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig(async ({ mode }) => {
     // Delegate to the shared package config which handles entry points,
     // externals, dts generation, and svelte-package exclusion.
     const config = createPackageConfig('assets', {
-      entries: ['ui', 'playground'],
+      entries: ['ui', 'playground', 'filesystem'],
       svelte: 'svelte',
       dtsExclude: ['src/routes/**/*'],
       // Fail the build on TS errors in dts generation so type-only bugs

--- a/packages/bundle-gate/AGENTS.md
+++ b/packages/bundle-gate/AGENTS.md
@@ -1,0 +1,48 @@
+# @happyvertical/smrt-bundle-gate
+
+Private (unpublished) consumer bundle reachability and size regression gate
+(#1978/#1980). Rebuilds the downstream SvelteKit-consumer viewpoint — SSR
+`vite build` with `ssr.noExternal: true` over the **dist** surface of
+chat/personas/messages — and fails CI when messaging-provider SDKs become
+reachable from provider-neutral imports or when output exceeds the size
+budget.
+
+## What it protects
+
+The 0.39.7 regression: `smrt-chat → smrt-personas → smrt-messages` made
+googleapis/nodemailer/@slack/web-api (via the `@happyvertical/email`,
+`@happyvertical/messages`, and `@happyvertical/files` SDK wrappers) reachable
+from ordinary chat consumers, growing a downstream server build from ~18 MB to
+~109 MB and exhausting a 4 GB Node heap. Bundlers follow statically-analyzable
+dynamic imports, and SvelteKit production server builds bundle every
+dependency not listed in `ssr.external` — "lazy at runtime" is not "absent
+from the bundle".
+
+## How it works
+
+`src/__tests__/consumer-boundary.spec.ts`:
+
+- **Neutral fixture** (`fixtures/consumer-neutral.ts`) imports the three
+  package roots — what app code and the smrtConsumer-generated
+  `.smrt/register.js` import. A `resolveId` guard records every attempted
+  resolution of a forbidden provider module with its importer, then
+  externalizes it, so a regression reports **all** offending edges without
+  bundling ~200 MB of SDK code. Assertions: zero forbidden resolutions, zero
+  forbidden modules in emitted chunks, output within the size budgets.
+- **Explicit fixture** (`fixtures/consumer-with-providers.ts`) imports
+  `@happyvertical/smrt-messages/providers/all` and asserts the SDK wrappers
+  ARE reachable again — providers stay available to consumers that opt in.
+
+The specs build from **dist** via package export maps (no workspace src
+aliases), so run `pnpm build` for chat/personas/messages first; in CI turbo's
+`test` task already depends on `^build`.
+
+## Ownership and budget updates
+
+The gate belongs to whoever changes chat/personas/messages/core/assets
+package boundaries. Budget rules live in the spec header: if the gate fails
+on FORBIDDEN modules, fix the import edge (never the budget); if it fails on
+size after a legitimate feature, rerun, read the printed `[bundle-gate]`
+report line, and set the budget to ~1.5–2× the new measured size in the same
+PR with an explanation. Forbidden-module additions (new heavyweight provider
+SDKs) go in `FORBIDDEN_PROVIDER_MODULES` with a comment.

--- a/packages/bundle-gate/CLAUDE.md
+++ b/packages/bundle-gate/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/bundle-gate/package.json
+++ b/packages/bundle-gate/package.json
@@ -4,7 +4,14 @@
   "description": "Consumer bundle reachability and size regression gate for SMRT packages",
   "type": "module",
   "private": true,
+  "author": "HappyVertical",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/smrt.git",
+    "directory": "packages/bundle-gate"
+  },
   "files": [
+    "dist",
     "CLAUDE.md",
     "AGENTS.md"
   ],

--- a/packages/bundle-gate/package.json
+++ b/packages/bundle-gate/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@happyvertical/smrt-bundle-gate",
+  "version": "0.0.0",
+  "description": "Consumer bundle reachability and size regression gate for SMRT packages",
+  "type": "module",
+  "private": true,
+  "files": [
+    "CLAUDE.md",
+    "AGENTS.md"
+  ],
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@happyvertical/smrt-chat": "workspace:*",
+    "@happyvertical/smrt-messages": "workspace:*",
+    "@happyvertical/smrt-personas": "workspace:*",
+    "@types/node": "24.13.2",
+    "typescript": "^5.9.3",
+    "vite": "^8.1.3",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/bundle-gate/src/__tests__/consumer-boundary.spec.ts
+++ b/packages/bundle-gate/src/__tests__/consumer-boundary.spec.ts
@@ -43,7 +43,7 @@
  * instead fails on FORBIDDEN modules, do not touch the budget — a provider
  * SDK became reachable and the reported import chain is the bug.
  */
-import { mkdtemp, readdir, rm, stat } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/packages/bundle-gate/src/__tests__/consumer-boundary.spec.ts
+++ b/packages/bundle-gate/src/__tests__/consumer-boundary.spec.ts
@@ -1,0 +1,273 @@
+/**
+ * Consumer bundle reachability and size regression gate (#1978/#1980).
+ *
+ * The SMRT 0.39.7 release made heavyweight messaging-provider SDKs
+ * (googleapis, nodemailer, imapflow, mailparser, @slack/web-api, and the
+ * @happyvertical/email//messages/files SDK wrappers around them) reachable
+ * from provider-neutral chat/persona imports:
+ *
+ *   app → smrt-chat → smrt-personas → smrt-messages (root barrel)
+ *       → EmailAccount.createClient() / SlackSender.send() / TweetSender.send()
+ *       → await import('@happyvertical/email' | '@happyvertical/messages')
+ *
+ * SvelteKit's production server build bundles every dependency by default
+ * (ssr.noExternal semantics — only `ssr.external` opts out), and Rollup
+ * follows statically-analyzable dynamic imports, so "lazy at runtime" still
+ * meant ~90 MB of provider SDK code in downstream server output and a
+ * 4 GB heap exhaustion while writing the chunk + sourcemap (Ergot rehearsal:
+ * server output 18 MB → 109 MB, largest chunk 31.6 MB).
+ *
+ * This gate rebuilds that consumer viewpoint deterministically:
+ *
+ *  - It bundles fixture entries with `vite build` in SSR mode with
+ *    `ssr.noExternal: true`, resolving the workspace packages through their
+ *    package.json export maps (dist output — the same files npm consumers
+ *    get). Run `pnpm build` for chat/personas/messages before this test;
+ *    in CI turbo's `test` task already depends on `^build`.
+ *  - A resolveId guard records every attempt to resolve a forbidden provider
+ *    module together with its importer, then externalizes it so a regression
+ *    reports every offending edge instead of spending minutes (and gigabytes)
+ *    bundling provider SDKs.
+ *  - The provider-neutral fixture must resolve zero forbidden modules and
+ *    stay under a coarse size budget. The explicit-provider fixture must
+ *    still reach the SDK wrappers, proving providers remain available.
+ *
+ * ## Updating the size budgets intentionally
+ *
+ * The budgets are coarse ceilings, not golden numbers — ordinary chunk
+ * rearrangement or bundler patch releases should never trip them. If a
+ * legitimate feature grows the neutral surface, rerun this spec, read the
+ * "[bundle-gate]" report line it prints, and raise the budget to roughly
+ * 1.5× the new measured size in the same change that grows the surface,
+ * with a sentence in the PR description explaining the growth. If the gate
+ * instead fails on FORBIDDEN modules, do not touch the budget — a provider
+ * SDK became reachable and the reported import chain is the bug.
+ */
+import { mkdtemp, readdir, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build, type Plugin, type Rollup } from 'vite';
+import { describe, expect, it } from 'vitest';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixture = (name: string) => path.resolve(here, 'fixtures', name);
+
+/**
+ * Messaging-provider SDKs (and their SDK wrappers) that must never be
+ * reachable from a provider-neutral consumer surface. Matched against raw
+ * import specifiers and resolved module ids.
+ */
+const FORBIDDEN_PROVIDER_MODULES = [
+  // SDK wrappers whose roots statically import the heavy vendors.
+  '@happyvertical/email',
+  '@happyvertical/messages',
+  '@happyvertical/files',
+  // The heavy vendors themselves, in case a future edge skips the wrappers.
+  // 'google-auth-library' is deliberately NOT listed: the @happyvertical/ai
+  // stack reaches it through @google/genai (a small auth client, pre-existing
+  // since before 0.39.x) — the messaging regression marker is googleapis.
+  'googleapis',
+  'nodemailer',
+  'imapflow',
+  'mailparser',
+  'node-pop3',
+  '@slack/web-api',
+  '@aws-sdk/client-s3',
+];
+
+/**
+ * Native/driver modules a real deployment keeps external (SvelteKit consumers
+ * list these in `ssr.external`, e.g. sharp/resvg in Ergot). Kept external here
+ * so the fixture builds match deployment reality and stay CI-fast.
+ */
+const RUNTIME_EXTERNAL = [
+  'better-sqlite3',
+  'pg',
+  'pg-native',
+  'pg-query-stream',
+  'duckdb',
+  '@duckdb/node-api',
+  '@duckdb/node-bindings',
+  'sharp',
+  'bufferutil',
+  'utf-8-validate',
+];
+
+/**
+ * Coarse ceilings — see "Updating the size budgets intentionally" above.
+ * Measured 2026-07-12 after the #1979 boundary repair: 12.55 MB total,
+ * 7.44 MB largest chunk. Budgets sit at ~2× measured; any single messaging
+ * provider SDK regression adds ≥20 MB and blows straight through them.
+ */
+const NEUTRAL_TOTAL_OUTPUT_BUDGET_BYTES = 25 * 1024 * 1024;
+const NEUTRAL_LARGEST_CHUNK_BUDGET_BYTES = 15 * 1024 * 1024;
+
+interface ForbiddenHits {
+  /** forbidden specifier/id → importers that requested it */
+  map: Map<string, Set<string>>;
+}
+
+function matchForbidden(id: string): string | undefined {
+  return FORBIDDEN_PROVIDER_MODULES.find(
+    (name) =>
+      id === name ||
+      id.startsWith(`${name}/`) ||
+      id.includes(`/node_modules/${name}/`),
+  );
+}
+
+/**
+ * Records every resolution attempt for a forbidden module and externalizes it,
+ * so a regressed graph reports all offending edges without bundling ~200 MB of
+ * provider SDK code (the failure mode that exhausted a 4 GB heap downstream).
+ */
+function providerBoundaryGuard(hits: ForbiddenHits): Plugin {
+  return {
+    name: 'smrt-provider-boundary-guard',
+    enforce: 'pre',
+    resolveId(source, importer) {
+      if (!matchForbidden(source)) return null;
+      const importers = hits.map.get(source) ?? new Set<string>();
+      if (importer) importers.add(importer);
+      hits.map.set(source, importers);
+      return { id: source, external: true };
+    },
+  };
+}
+
+function formatHits(hits: ForbiddenHits): string {
+  return [...hits.map.entries()]
+    .map(
+      ([specifier, importers]) =>
+        `${specifier}\n${[...importers].map((i) => `    imported by ${i}`).join('\n')}`,
+    )
+    .join('\n');
+}
+
+interface FixtureBuildResult {
+  hits: ForbiddenHits;
+  /** Module ids that ended up inside emitted chunks. */
+  bundledModuleIds: string[];
+  totalBytes: number;
+  largestChunk: { fileName: string; bytes: number };
+  chunkCount: number;
+}
+
+async function buildConsumerFixture(
+  entryFile: string,
+): Promise<FixtureBuildResult> {
+  const outDir = await mkdtemp(path.join(tmpdir(), 'smrt-bundle-gate-'));
+  const hits: ForbiddenHits = { map: new Map() };
+  try {
+    const result = (await build({
+      configFile: false,
+      logLevel: 'error',
+      plugins: [providerBoundaryGuard(hits)],
+      build: {
+        ssr: true,
+        outDir,
+        emptyOutDir: true,
+        minify: false,
+        sourcemap: false,
+        target: 'node20',
+        rollupOptions: {
+          input: { server: entryFile },
+        },
+      },
+      ssr: {
+        // SvelteKit adapter parity: production server builds bundle every
+        // dependency unless explicitly listed in ssr.external.
+        noExternal: true,
+        external: RUNTIME_EXTERNAL,
+      },
+    })) as Rollup.RollupOutput;
+
+    const chunks = result.output.filter(
+      (item): item is Rollup.OutputChunk => item.type === 'chunk',
+    );
+    const bundledModuleIds = chunks.flatMap((chunk) =>
+      Object.keys(chunk.modules),
+    );
+    let totalBytes = 0;
+    let largestChunk = { fileName: '<none>', bytes: 0 };
+    for (const item of result.output) {
+      const bytes =
+        item.type === 'chunk'
+          ? Buffer.byteLength(item.code)
+          : typeof item.source === 'string'
+            ? Buffer.byteLength(item.source)
+            : item.source.byteLength;
+      totalBytes += bytes;
+      if (item.type === 'chunk' && bytes > largestChunk.bytes) {
+        largestChunk = { fileName: item.fileName, bytes };
+      }
+    }
+    return {
+      hits,
+      bundledModuleIds,
+      totalBytes,
+      largestChunk,
+      chunkCount: chunks.length,
+    };
+  } finally {
+    await rm(outDir, { recursive: true, force: true });
+  }
+}
+
+const megabytes = (bytes: number) => `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+
+describe('consumer bundle boundary (#1978/#1980)', () => {
+  it('provider-neutral chat/persona/message imports never reach messaging-provider SDKs and stay within budget', async () => {
+    const result = await buildConsumerFixture(fixture('consumer-neutral.ts'));
+
+    // Reachability contract: no forbidden module may even be *resolved* from
+    // the provider-neutral graph. On failure the message lists each forbidden
+    // specifier with the modules that imported it.
+    expect(
+      formatHits(result.hits),
+      'forbidden messaging-provider modules became reachable from the provider-neutral consumer surface',
+    ).toBe('');
+
+    // Belt and braces: nothing forbidden made it into an emitted chunk either.
+    const bundledForbidden = result.bundledModuleIds.filter(matchForbidden);
+    expect(bundledForbidden).toEqual([]);
+
+    // CI visibility + budget. Coarse on purpose; see header for update rules.
+    console.log(
+      `[bundle-gate] neutral server output: total ${megabytes(result.totalBytes)}` +
+        ` across ${result.chunkCount} chunks; largest chunk ${result.largestChunk.fileName}` +
+        ` at ${megabytes(result.largestChunk.bytes)}` +
+        ` (budgets: total ${megabytes(NEUTRAL_TOTAL_OUTPUT_BUDGET_BYTES)},` +
+        ` largest ${megabytes(NEUTRAL_LARGEST_CHUNK_BUDGET_BYTES)})`,
+    );
+    expect(
+      result.totalBytes,
+      `total server output ${megabytes(result.totalBytes)} exceeded the ${megabytes(
+        NEUTRAL_TOTAL_OUTPUT_BUDGET_BYTES,
+      )} budget — if this growth is intentional, follow the budget-update instructions in this spec's header`,
+    ).toBeLessThan(NEUTRAL_TOTAL_OUTPUT_BUDGET_BYTES);
+    expect(
+      result.largestChunk.bytes,
+      `largest chunk ${result.largestChunk.fileName} (${megabytes(
+        result.largestChunk.bytes,
+      )}) exceeded the ${megabytes(NEUTRAL_LARGEST_CHUNK_BUDGET_BYTES)} budget`,
+    ).toBeLessThan(NEUTRAL_LARGEST_CHUNK_BUDGET_BYTES);
+  });
+
+  it('explicit provider entry points still make the provider SDK wrappers reachable', async () => {
+    const result = await buildConsumerFixture(
+      fixture('consumer-with-providers.ts'),
+    );
+
+    const reached = [...result.hits.map.keys()];
+    expect(
+      reached.some((id) => matchForbidden(id) === '@happyvertical/email'),
+      `expected '@happyvertical/smrt-messages/providers/all' to make @happyvertical/email reachable; reached: ${reached.join(', ') || '<nothing>'}`,
+    ).toBe(true);
+    expect(
+      reached.some((id) => matchForbidden(id) === '@happyvertical/messages'),
+      `expected '@happyvertical/smrt-messages/providers/all' to make @happyvertical/messages reachable; reached: ${reached.join(', ') || '<nothing>'}`,
+    ).toBe(true);
+  });
+});

--- a/packages/bundle-gate/src/__tests__/fixtures/consumer-neutral.ts
+++ b/packages/bundle-gate/src/__tests__/fixtures/consumer-neutral.ts
@@ -1,0 +1,15 @@
+/**
+ * Provider-neutral consumer surface.
+ *
+ * This mirrors what an ordinary downstream chat/persona application makes
+ * reachable in its server bundle: the package roots, exactly as imported by
+ * app code and by the `.smrt/register.js` file the smrtConsumer plugin
+ * generates for model registration.
+ *
+ * Nothing here selects or configures a messaging provider, so no messaging
+ * provider SDK (googleapis, nodemailer, @slack/web-api, ...) may become
+ * reachable from these imports. See consumer-boundary.spec.ts.
+ */
+import '@happyvertical/smrt-chat';
+import '@happyvertical/smrt-messages';
+import '@happyvertical/smrt-personas';

--- a/packages/bundle-gate/src/__tests__/fixtures/consumer-with-providers.ts
+++ b/packages/bundle-gate/src/__tests__/fixtures/consumer-with-providers.ts
@@ -1,0 +1,9 @@
+/**
+ * Explicit-provider consumer surface.
+ *
+ * A consumer that wants functional messaging providers opts in by importing
+ * the provider entry points. That import — and only that import — is allowed
+ * to make the provider SDKs reachable in the server bundle.
+ */
+import '@happyvertical/smrt-chat';
+import '@happyvertical/smrt-messages/providers/all';

--- a/packages/bundle-gate/tsconfig.json
+++ b/packages/bundle-gate/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.package-typecheck.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*", "vitest.config.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/bundle-gate/vitest.config.ts
+++ b/packages/bundle-gate/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+// Intentionally NOT using smrtVitestPlugin: this package never instantiates
+// SmrtObject classes. Its specs drive programmatic `vite build` runs against
+// the *published dist surface* of chat/personas/messages, so the workspace
+// src aliases and manifest bootstrap the plugin provides would only distort
+// the consumer's viewpoint.
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/__tests__/**/*.spec.ts'],
+    // Each spec performs a full SSR bundle of the consumer surface.
+    testTimeout: 300_000,
+    hookTimeout: 60_000,
+    fileParallelism: false,
+  },
+});

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -182,6 +182,7 @@ emitDecoratorMetadata: true`.
 
 ## Gotchas
 
+- **Filesystem support is a lazy boundary (#1979)**: `SmrtClass` acquires `options.fs` adapters via `createFilesystemAdapter()` (`src/filesystem-loader.ts`), never a static `@happyvertical/files` import — the files SDK statically pulls @aws-sdk/client-s3 and reaches googleapis, and a static edge here would land it in every downstream SSR bundle. Node/tsx/vite-dev runtimes resolve it on first use; fully-bundled deployments import `@happyvertical/smrt-core/filesystem` at startup. Use `importOptionalDependency()` (`src/lazy-external.ts`) for any similar optional heavyweight dependency.
 - **Never override toJSON()** — handles STI discriminator + meta field extraction. Use `transformJSON()`
 - **Property init order**: TypeScript initializers run first, then `initialize()` applies option values (options win)
 - **No runtime schema creation**: application tables must be prepared explicitly via migrations/tooling; runtime only verifies and fails clearly

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,11 @@
       "import": "./dist/utils.js",
       "default": "./dist/utils.js"
     },
+    "./filesystem": {
+      "types": "./dist/filesystem.d.ts",
+      "import": "./dist/filesystem.js",
+      "default": "./dist/filesystem.js"
+    },
     "./schema/utils": {
       "types": "./dist/schema/utils.d.ts",
       "import": "./dist/schema/utils.js",

--- a/packages/core/src/class.ts
+++ b/packages/core/src/class.ts
@@ -1,7 +1,9 @@
 import type { AIClientOptions } from '@happyvertical/ai';
 import { type AIClient, getAI } from '@happyvertical/ai';
-import type { FilesystemAdapterOptions } from '@happyvertical/files';
-import { FilesystemAdapter } from '@happyvertical/files';
+import type {
+  FilesystemAdapter,
+  FilesystemAdapterOptions,
+} from '@happyvertical/files';
 import { createLogger, type LoggerConfig } from '@happyvertical/logger';
 import type {
   AiTokenUsage,
@@ -34,6 +36,7 @@ import type {
 } from './config.js';
 import { config } from './config.js';
 import type { DatabaseConfig } from './database.js';
+import { createFilesystemAdapter } from './filesystem-loader.js';
 import { detectEngine } from './schema/ddl/index.js';
 import { SignalBus } from './signals/bus.js';
 import {
@@ -645,7 +648,10 @@ export class SmrtClass {
     if (!this._runtimeServicesInitPromise) {
       this._runtimeServicesInitPromise = (async () => {
         if (this.options.fs && !this._fs) {
-          this._fs = await FilesystemAdapter.create(this.options.fs);
+          // Acquired through the boundary in filesystem-loader.ts so the
+          // @happyvertical/files SDK (S3/googleapis) never enters
+          // provider-neutral consumer bundles (#1977/#1979).
+          this._fs = await createFilesystemAdapter(this.options.fs);
         }
 
         // Initialize AI client with environment variable support

--- a/packages/core/src/filesystem-loader.test.ts
+++ b/packages/core/src/filesystem-loader.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Filesystem adapter boundary (#1979).
+ *
+ * SmrtClass acquires filesystem support through this loader instead of a
+ * static @happyvertical/files import so the files SDK (S3/googleapis) never
+ * enters provider-neutral consumer bundles. Module-level factory state is
+ * reset per test via vi.resetModules() + dynamic import.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function loadFresh() {
+  vi.resetModules();
+  return import('./filesystem-loader.js');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createFilesystemAdapter', () => {
+  it('uses a registered factory without touching the files SDK', async () => {
+    const loader = await loadFresh();
+    const adapter = { read: vi.fn() };
+    const factory = vi.fn(async () => adapter as never);
+
+    loader.registerFilesystemAdapterFactory(factory);
+    const created = await loader.createFilesystemAdapter({
+      type: 'local',
+    } as never);
+
+    expect(created).toBe(adapter);
+    expect(factory).toHaveBeenCalledWith({ type: 'local' });
+  });
+
+  it('falls back to a runtime-resolved @happyvertical/files import when no factory is registered', async () => {
+    const loader = await loadFresh();
+    // Workspace runtimes resolve the SDK from node_modules — the behavior
+    // ordinary Node/tsx/vite-dev consumers rely on with zero configuration.
+    const adapter = await loader.createFilesystemAdapter({
+      type: 'local',
+      basePath: '.',
+    } as never);
+    expect(adapter).toBeDefined();
+  });
+
+  it('the explicit filesystem entry registers the SDK-backed factory', async () => {
+    vi.resetModules();
+    const loader = await import('./filesystem-loader.js');
+    const spy = vi.fn();
+    loader.registerFilesystemAdapterFactory(async (options) => {
+      spy(options);
+      return { registered: true } as never;
+    });
+    // The entry registers its own SDK-backed factory; last registration
+    // wins, so the spy factory above must no longer be consulted.
+    await import('./filesystem.js');
+    const adapter = await loader.createFilesystemAdapter({
+      type: 'local',
+      basePath: '.',
+    } as never);
+    expect(spy).not.toHaveBeenCalled();
+    expect(adapter).toBeDefined();
+  });
+});

--- a/packages/core/src/filesystem-loader.test.ts
+++ b/packages/core/src/filesystem-loader.test.ts
@@ -18,6 +18,37 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+describe('importOptionalDependency registration (bundled-runtime opt-in)', () => {
+  it('serves a module registered on the global registry without runtime resolution', async () => {
+    vi.resetModules();
+    const lazy = await import('./lazy-external.js');
+    const fake = { marker: 'registered-module' };
+    lazy.registerOptionalDependency('@happyvertical/fake-optional', fake);
+
+    // Module-fresh import instance must still see the registration —
+    // the registry lives on globalThis, so ANY package's entry point
+    // satisfies EVERY package's lazy import of the same specifier.
+    vi.resetModules();
+    const secondInstance = await import('./lazy-external.js');
+    const resolved = await secondInstance.importOptionalDependency(
+      '@happyvertical/fake-optional',
+      'unused hint',
+    );
+    expect(resolved).toBe(fake);
+  });
+
+  it('throws the enablement hint when unregistered and unresolvable', async () => {
+    vi.resetModules();
+    const lazy = await import('./lazy-external.js');
+    await expect(
+      lazy.importOptionalDependency(
+        '@happyvertical/does-not-exist-anywhere',
+        "Import 'some/entry' to enable it.",
+      ),
+    ).rejects.toThrow(/Import 'some\/entry' to enable it\./);
+  });
+});
+
 describe('createFilesystemAdapter', () => {
   it('uses a registered factory without touching the files SDK', async () => {
     const loader = await loadFresh();

--- a/packages/core/src/filesystem-loader.ts
+++ b/packages/core/src/filesystem-loader.ts
@@ -1,0 +1,56 @@
+/**
+ * Filesystem adapter acquisition boundary.
+ *
+ * `@happyvertical/files` statically imports @aws-sdk/client-s3 and reaches
+ * googleapis from its root, so SmrtClass must not import it eagerly — that
+ * single edge put the whole files SDK into every downstream SSR bundle
+ * (#1977/#1978). Filesystem support is acquired here instead:
+ *
+ *  - Runtimes with node_modules (Node, tsx, vite dev, externalized SSR) work
+ *    unchanged: the adapter is loaded on first use via a bundler-invisible
+ *    import.
+ *  - Fully-bundled deployments opt in explicitly with
+ *    `import '@happyvertical/smrt-core/filesystem'` at server startup, which
+ *    registers the statically-imported adapter factory.
+ */
+import type {
+  FilesystemAdapter,
+  FilesystemAdapterOptions,
+} from '@happyvertical/files';
+import { importOptionalDependency } from './lazy-external.js';
+
+export type FilesystemAdapterFactory = (
+  options: FilesystemAdapterOptions,
+) => Promise<FilesystemAdapter>;
+
+let factory: FilesystemAdapterFactory | undefined;
+
+/**
+ * Registers the factory used to satisfy `fs` options on SmrtClass instances.
+ * Called by the `@happyvertical/smrt-core/filesystem` entry point; hosts with
+ * a custom adapter can call it directly. The last registration wins.
+ */
+export function registerFilesystemAdapterFactory(
+  create: FilesystemAdapterFactory,
+): void {
+  factory = create;
+}
+
+/**
+ * Creates a filesystem adapter for SmrtClass `fs` options, using the
+ * registered factory or falling back to a runtime-resolved
+ * `@happyvertical/files` import.
+ */
+export async function createFilesystemAdapter(
+  options: FilesystemAdapterOptions,
+): Promise<FilesystemAdapter> {
+  if (!factory) {
+    const mod = (await importOptionalDependency(
+      '@happyvertical/files',
+      "Import '@happyvertical/smrt-core/filesystem' during server startup (or call registerFilesystemAdapterFactory) to enable filesystem support in bundled builds.",
+    )) as typeof import('@happyvertical/files');
+    const adapter = mod.FilesystemAdapter;
+    factory = (fsOptions) => adapter.create(fsOptions);
+  }
+  return factory(options);
+}

--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -1,0 +1,24 @@
+/**
+ * Explicit filesystem enablement entry point.
+ *
+ * Importing this module statically links `@happyvertical/files` and registers
+ * its adapter factory with SmrtClass, restoring filesystem support in
+ * fully-bundled deployments (where the runtime fallback in filesystem-loader
+ * cannot resolve node_modules). Provider-neutral consumers must NOT import
+ * this — it deliberately makes the files SDK (S3/googleapis) reachable.
+ *
+ * @example
+ * ```ts
+ * // hooks.server.ts / server bootstrap
+ * import '@happyvertical/smrt-core/filesystem';
+ * ```
+ */
+import { FilesystemAdapter } from '@happyvertical/files';
+import { registerFilesystemAdapterFactory } from './filesystem-loader.js';
+
+registerFilesystemAdapterFactory((options) =>
+  FilesystemAdapter.create(options),
+);
+
+export { registerFilesystemAdapterFactory } from './filesystem-loader.js';
+export { FilesystemAdapter };

--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -2,9 +2,11 @@
  * Explicit filesystem enablement entry point.
  *
  * Importing this module statically links `@happyvertical/files` and registers
- * its adapter factory with SmrtClass, restoring filesystem support in
- * fully-bundled deployments (where the runtime fallback in filesystem-loader
- * cannot resolve node_modules). Provider-neutral consumers must NOT import
+ * it for the whole optional-dependency boundary: the SmrtClass adapter
+ * factory AND every importOptionalDependency('@happyvertical/files') call in
+ * any smrt package (e.g. smrt-messages Attachment.readContent). This restores
+ * filesystem support in fully-bundled deployments where the runtime fallback
+ * cannot resolve node_modules. Provider-neutral consumers must NOT import
  * this — it deliberately makes the files SDK (S3/googleapis) reachable.
  *
  * @example
@@ -13,12 +15,16 @@
  * import '@happyvertical/smrt-core/filesystem';
  * ```
  */
+import * as files from '@happyvertical/files';
 import { FilesystemAdapter } from '@happyvertical/files';
 import { registerFilesystemAdapterFactory } from './filesystem-loader.js';
+import { registerOptionalDependency } from './lazy-external.js';
 
+registerOptionalDependency('@happyvertical/files', files);
 registerFilesystemAdapterFactory((options) =>
   FilesystemAdapter.create(options),
 );
 
 export { registerFilesystemAdapterFactory } from './filesystem-loader.js';
+export { registerOptionalDependency } from './lazy-external.js';
 export { FilesystemAdapter };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,6 +117,13 @@ export * from './dispatch/index';
 // Embeddings support (semantic search)
 export * from './embeddings/index';
 export * from './errors';
+// Filesystem boundary (keeps @happyvertical/files out of neutral bundles)
+export {
+  createFilesystemAdapter,
+  type FilesystemAdapterFactory,
+  registerFilesystemAdapterFactory,
+} from './filesystem-loader';
+export { importOptionalDependency } from './lazy-external';
 // Code generators (tree-shakeable)
 export * from './generators/index';
 export { type HierarchyView, SmrtHierarchical } from './hierarchical';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -123,7 +123,6 @@ export {
   type FilesystemAdapterFactory,
   registerFilesystemAdapterFactory,
 } from './filesystem-loader';
-export { importOptionalDependency } from './lazy-external';
 // Code generators (tree-shakeable)
 export * from './generators/index';
 export { type HierarchyView, SmrtHierarchical } from './hierarchical';
@@ -152,6 +151,7 @@ export {
   resolveLazyConfig,
   unregisterConfigResolver,
 } from './lazy-config';
+export { importOptionalDependency } from './lazy-external';
 // Learning memory — confidence-scored, self-correcting recall/capture (#1886)
 export {
   DEFAULT_LEARNING_CONFIG,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -151,7 +151,10 @@ export {
   resolveLazyConfig,
   unregisterConfigResolver,
 } from './lazy-config';
-export { importOptionalDependency } from './lazy-external';
+export {
+  importOptionalDependency,
+  registerOptionalDependency,
+} from './lazy-external';
 // Learning memory — confidence-scored, self-correcting recall/capture (#1886)
 export {
   DEFAULT_LEARNING_CONFIG,

--- a/packages/core/src/lazy-external.ts
+++ b/packages/core/src/lazy-external.ts
@@ -9,16 +9,46 @@
  * function argument keeps the import expression non-analyzable, so the
  * dependency stays out of consumer bundles entirely and is resolved from
  * node_modules at runtime instead.
+ *
+ * Fully-bundled deployments (no node_modules at runtime) opt back in through
+ * an explicit entry point that statically imports the dependency and calls
+ * registerOptionalDependency() — the registry lives on globalThis, so ANY
+ * package's entry point satisfies EVERY package's lazy import of the same
+ * specifier.
  */
+
+const OPTIONAL_DEPS_KEY = Symbol.for('smrt.optional-dependencies');
+
+function registeredModules(): Map<string, unknown> {
+  const root = globalThis as typeof globalThis & {
+    [OPTIONAL_DEPS_KEY]?: Map<string, unknown>;
+  };
+  root[OPTIONAL_DEPS_KEY] ??= new Map();
+  return root[OPTIONAL_DEPS_KEY];
+}
+
+/**
+ * Registers a statically-imported module as the resolution for `specifier`,
+ * making importOptionalDependency() work in fully-bundled deployments.
+ * Called by explicit entry points such as `@happyvertical/smrt-core/filesystem`
+ * and `@happyvertical/smrt-assets/filesystem`. The last registration wins.
+ */
+export function registerOptionalDependency(
+  specifier: string,
+  module: unknown,
+): void {
+  registeredModules().set(specifier, module);
+}
 
 /**
  * Imports `specifier` without creating a statically-analyzable module edge.
  *
- * Resolution follows the runtime module graph, so this succeeds wherever the
- * calling package's own dependencies are installed (Node, tsx, vite dev,
- * externalized SSR). In a fully-bundled deployment that ships no
- * node_modules, resolution fails and the error tells the operator which
- * explicit entry point restores the capability.
+ * Resolution order: a module registered via registerOptionalDependency()
+ * wins; otherwise the specifier resolves through the runtime module graph,
+ * which succeeds wherever the calling package's own dependencies are
+ * installed (Node, tsx, vite dev, externalized SSR). In a fully-bundled
+ * deployment with neither, the error names the explicit entry point that
+ * restores the capability.
  *
  * @param specifier - Bare module specifier of the optional dependency
  * @param enableHint - One sentence naming the explicit entry point (or
@@ -28,6 +58,8 @@ export async function importOptionalDependency(
   specifier: string,
   enableHint: string,
 ): Promise<unknown> {
+  const registered = registeredModules().get(specifier);
+  if (registered !== undefined) return registered;
   try {
     return await import(/* @vite-ignore */ specifier);
   } catch (cause) {

--- a/packages/core/src/lazy-external.ts
+++ b/packages/core/src/lazy-external.ts
@@ -1,0 +1,39 @@
+/**
+ * Bundler-invisible loading of optional heavyweight dependencies.
+ *
+ * Rollup/Rolldown/esbuild follow `import('literal')` even inside rarely-called
+ * methods, so a "lazy at runtime" provider import still lands in downstream
+ * server bundles — SvelteKit production builds bundle every dependency unless
+ * it is listed in `ssr.external` (#1977/#1978: ~90 MB of googleapis/nodemailer
+ * reached ordinary chat consumers this way). Passing the specifier through a
+ * function argument keeps the import expression non-analyzable, so the
+ * dependency stays out of consumer bundles entirely and is resolved from
+ * node_modules at runtime instead.
+ */
+
+/**
+ * Imports `specifier` without creating a statically-analyzable module edge.
+ *
+ * Resolution follows the runtime module graph, so this succeeds wherever the
+ * calling package's own dependencies are installed (Node, tsx, vite dev,
+ * externalized SSR). In a fully-bundled deployment that ships no
+ * node_modules, resolution fails and the error tells the operator which
+ * explicit entry point restores the capability.
+ *
+ * @param specifier - Bare module specifier of the optional dependency
+ * @param enableHint - One sentence naming the explicit entry point (or
+ *   registration call) that makes the capability available in bundled builds
+ */
+export async function importOptionalDependency(
+  specifier: string,
+  enableHint: string,
+): Promise<unknown> {
+  try {
+    return await import(/* @vite-ignore */ specifier);
+  } catch (cause) {
+    throw new Error(
+      `Optional dependency '${specifier}' is not available in this runtime or build. ${enableHint}`,
+      { cause },
+    );
+  }
+}

--- a/packages/messages/AGENTS.md
+++ b/packages/messages/AGENTS.md
@@ -43,6 +43,33 @@ directly. Credential descriptor schemas contain field definitions, never values.
 
 `message.send()`: resolves account → creates provider sender → updates sendStatus. Retry support with `maxRetries` budget.
 
+## Provider entry points (bundle boundary, #1979)
+
+The package root is provider-neutral: models, collections, services,
+permissions, and the provider registry carry **zero provider-SDK weight**.
+Provider SDK wrappers (`@happyvertical/email`, `@happyvertical/messages`) are
+reachable only through explicit entry points, imported once at server startup:
+
+```ts
+import '@happyvertical/smrt-messages/providers/email';   // smtp/imap/pop3/gmail
+import '@happyvertical/smrt-messages/providers/slack';
+import '@happyvertical/smrt-messages/providers/twitter';
+import '@happyvertical/smrt-messages/providers/all';     // all of the above
+```
+
+- Without the matching entry, `EmailAccount.createClient()` (send + mailbox
+  sync) throws an actionable error and `SlackSender`/`TweetSender` return a
+  failure result naming the entry to import. Telegram and Zulip are
+  fetch-based and always work from the root.
+- Builtin registry definitions stay metadata-only (setup fields for UIs); the
+  entries upgrade them with `createEmailClient`/`createMessageClient`/
+  `createSender` hooks. Never import a provider SDK from any module reachable
+  from `src/index.ts` — the consumer bundle gate (`packages/bundle-gate`)
+  fails CI when one becomes reachable.
+- `Attachment.readContent()` loads `@happyvertical/files` through core's
+  `importOptionalDependency` boundary and keeps its null-on-failure contract
+  in builds where the SDK is absent.
+
 ## Gotchas
 
 - **STI `_meta_type`**: qualified format `@happyvertical/smrt-messages:Email`

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -18,6 +18,22 @@
     },
     "./manifest": "./dist/manifest.json",
     "./manifest.json": "./dist/manifest.json",
+    "./providers/email": {
+      "types": "./dist/providers/email.d.ts",
+      "import": "./dist/providers/email.js"
+    },
+    "./providers/slack": {
+      "types": "./dist/providers/slack.d.ts",
+      "import": "./dist/providers/slack.js"
+    },
+    "./providers/twitter": {
+      "types": "./dist/providers/twitter.d.ts",
+      "import": "./dist/providers/twitter.js"
+    },
+    "./providers/all": {
+      "types": "./dist/providers/all.d.ts",
+      "import": "./dist/providers/all.js"
+    },
     "./ui": {
       "types": "./dist/ui.d.ts",
       "import": "./dist/ui.js"
@@ -32,6 +48,12 @@
       "import": "./dist/svelte/index.js"
     }
   },
+  "sideEffects": [
+    "./dist/index.js",
+    "./dist/__smrt-register__.js",
+    "./dist/providers/*.js",
+    "./dist/chunks/*.js"
+  ],
   "scripts": {
     "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
     "build:watch": "vite build --mode library --watch",
@@ -46,7 +68,6 @@
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
   "dependencies": {
-    "@happyvertical/ai": "catalog:",
     "@happyvertical/email": "catalog:",
     "@happyvertical/files": "catalog:",
     "@happyvertical/logger": "catalog:",

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -52,7 +52,8 @@
     "./dist/index.js",
     "./dist/__smrt-register__.js",
     "./dist/providers/*.js",
-    "./dist/chunks/*.js"
+    "./dist/chunks/*.js",
+    "./dist/svelte/index.js"
   ],
   "scripts": {
     "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",

--- a/packages/messages/src/__tests__/account-message-extended.test.ts
+++ b/packages/messages/src/__tests__/account-message-extended.test.ts
@@ -7,8 +7,9 @@
  * orchestration (status transitions).
  *
  * Mocking policy: only the external SDK transport getMessageClient() from
- * '@happyvertical/messages' is mocked (used indirectly via SlackSender during
- * Message.send). All models/collections/DB are real.
+ * '@happyvertical/messages' is mocked (reached through the explicit Slack
+ * provider entry via SlackSender during Message.send, #1979). All
+ * models/collections/DB are real.
  */
 
 import { getTestDatabase } from '@happyvertical/smrt-core';
@@ -31,6 +32,10 @@ import { Attachment } from '../models/Attachment';
 import { Message } from '../models/Message';
 import { SlackAccount } from '../models/SlackAccount';
 import { SlackMessage } from '../models/SlackMessage';
+// Explicit provider entry registers the Slack SDK transport on the provider
+// registry — the same opt-in production servers perform (#1979). Its dynamic
+// SDK import resolves to the vi.mock above.
+import '../providers/slack';
 
 let db: DatabaseInterface;
 

--- a/packages/messages/src/__tests__/provider-entries.test.ts
+++ b/packages/messages/src/__tests__/provider-entries.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Explicit provider entry points (#1979).
+ *
+ * Provider-neutral consumers must get actionable errors instead of provider
+ * SDK weight; importing a provider entry must restore full functionality.
+ * The SDK boundary ('@happyvertical/email') is mocked per testing policy —
+ * everything else (registry, models, entry modules) is real.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getEmailClientMock = vi.fn(async () => ({
+  connect: vi.fn(async () => undefined),
+  isConnected: () => true,
+}));
+
+vi.mock('@happyvertical/email', () => ({
+  getEmailClient: (...args: unknown[]) => getEmailClientMock(...args),
+}));
+
+import { EmailAccount } from '../models/EmailAccount';
+import {
+  ensureBuiltinMessagingProvidersRegistered,
+  getMessagingProvider,
+  listMessagingProviders,
+} from '../providers';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('builtin provider registry stays metadata-only', () => {
+  it('registers smtp/gmail without any client implementation', () => {
+    ensureBuiltinMessagingProvidersRegistered();
+    for (const id of ['smtp', 'gmail']) {
+      const definition = getMessagingProvider(id);
+      expect(definition, `builtin '${id}' definition`).toBeDefined();
+      expect(definition?.createEmailClient).toBeUndefined();
+      expect(definition?.createSender).toBeUndefined();
+    }
+  });
+
+  it('keeps fetch-based zulip/telegram senders functional from the root', () => {
+    ensureBuiltinMessagingProvidersRegistered();
+    expect(getMessagingProvider('zulip')?.createSender).toBeTypeOf('function');
+    expect(getMessagingProvider('telegram')?.createSender).toBeTypeOf(
+      'function',
+    );
+  });
+});
+
+describe('EmailAccount.createClient without the email provider entry', () => {
+  it('rejects with guidance naming the explicit entry point', async () => {
+    ensureBuiltinMessagingProvidersRegistered();
+    // Fresh worker per test file: providers/email has not been imported here.
+    expect(getMessagingProvider('smtp')?.createEmailClient).toBeUndefined();
+
+    const account = new EmailAccount({ email: 'me@example.com' });
+    account.providerType = 'smtp';
+
+    await expect(account.createClient()).rejects.toThrow(
+      /smrt-messages\/providers\/email/,
+    );
+    expect(getEmailClientMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('importing providers/email enables the email client boundary', () => {
+  it('registers createEmailClient on every email provider and routes createClient through it', async () => {
+    await import('../providers/email');
+
+    for (const id of ['smtp', 'imap', 'pop3', 'gmail']) {
+      expect(
+        getMessagingProvider(id)?.createEmailClient,
+        `createEmailClient on '${id}'`,
+      ).toBeTypeOf('function');
+    }
+
+    const account = new EmailAccount({ email: 'me@example.com' });
+    account.providerType = 'smtp';
+    vi.spyOn(account, 'getConfiguration').mockReturnValue({
+      email: 'me@example.com',
+      host: 'mail.example.com',
+      port: 587,
+    });
+    vi.spyOn(account, 'getCredentials').mockResolvedValue({
+      username: 'user',
+      password: 'secret',
+    });
+
+    const client = await account.createClient();
+
+    expect(client.isConnected()).toBe(true);
+    expect(getEmailClientMock).toHaveBeenCalledTimes(1);
+    expect(getEmailClientMock).toHaveBeenCalledWith({
+      type: 'smtp',
+      host: 'mail.example.com',
+      port: 587,
+      username: 'user',
+      password: 'secret',
+    });
+  });
+
+  it('keeps provider definitions serializable for setup UIs (functions stripped)', async () => {
+    await import('../providers/email');
+    const serialized = listMessagingProviders({ includeUnavailable: true }).map(
+      ({
+        createSender: _createSender,
+        createEmailClient: _createEmailClient,
+        createMessageClient: _createMessageClient,
+        ...provider
+      }) => provider,
+    );
+    for (const provider of serialized) {
+      expect(JSON.parse(JSON.stringify(provider))).toEqual(provider);
+    }
+  });
+});

--- a/packages/messages/src/__tests__/provider-entries.test.ts
+++ b/packages/messages/src/__tests__/provider-entries.test.ts
@@ -121,6 +121,29 @@ describe('importing providers/email enables the email client boundary', () => {
     ).toBeTypeOf('function');
   });
 
+  it('Attachment.readContent() honors a files module registered via the core optional-dependency registry', async () => {
+    const { registerOptionalDependency } = await import(
+      '@happyvertical/smrt-core'
+    );
+    const read = vi.fn(async () => Buffer.from('attachment-bytes'));
+    registerOptionalDependency('@happyvertical/files', {
+      getFilesystem: async () => ({ read }),
+    });
+    try {
+      const { Attachment } = await import('../models/Attachment');
+      const attachment = new Attachment({});
+      attachment.filePath = '/stored/file.bin';
+
+      const content = await attachment.readContent();
+
+      expect(content?.toString()).toBe('attachment-bytes');
+      expect(read).toHaveBeenCalledWith('/stored/file.bin');
+    } finally {
+      // Restore runtime resolution for any later test in this worker.
+      registerOptionalDependency('@happyvertical/files', undefined);
+    }
+  });
+
   it('keeps provider definitions serializable for setup UIs (functions stripped)', async () => {
     await import('../providers/email');
     const serialized = listMessagingProviders({ includeUnavailable: true }).map(

--- a/packages/messages/src/__tests__/provider-entries.test.ts
+++ b/packages/messages/src/__tests__/provider-entries.test.ts
@@ -101,6 +101,26 @@ describe('importing providers/email enables the email client boundary', () => {
     });
   });
 
+  it('survives a second module instance re-running builtin registration (HMR/dual-identity)', async () => {
+    await import('../providers/email');
+    expect(getMessagingProvider('smtp')?.createEmailClient).toBeTypeOf(
+      'function',
+    );
+
+    // The registry lives on globalThis while the builtin flag is
+    // module-scoped: a fresh module instance (HMR reload, src/dist dual
+    // identity) re-runs ensureBuiltin... against the shared registry. Builtins
+    // must gap-fill, never clobber the entry-registered client hooks.
+    vi.resetModules();
+    const secondInstance = await import('../providers');
+    secondInstance.ensureBuiltinMessagingProvidersRegistered();
+
+    expect(
+      secondInstance.getMessagingProvider('smtp')?.createEmailClient,
+      'entry-registered hook survived the second builtin registration',
+    ).toBeTypeOf('function');
+  });
+
   it('keeps provider definitions serializable for setup UIs (functions stripped)', async () => {
     await import('../providers/email');
     const serialized = listMessagingProviders({ includeUnavailable: true }).map(

--- a/packages/messages/src/__tests__/senders-extended.test.ts
+++ b/packages/messages/src/__tests__/senders-extended.test.ts
@@ -4,7 +4,9 @@
  *
  * Mocking policy: only the EXTERNAL transport is mocked.
  *  - EmailSender takes an injected EmailClient — we pass a fake client.
- *  - SlackSender / TweetSender dynamically import getMessageClient() from the
+ *  - SlackSender / TweetSender resolve their transport from the messaging
+ *    provider registry, populated here by the explicit provider entry points
+ *    (#1979). Those entries dynamically import getMessageClient() from the
  *    SDK package '@happyvertical/messages'; that single external boundary is
  *    mocked with vi.mock. Accounts/messages are real model instances.
  *
@@ -34,6 +36,11 @@ import { SlackAccount } from '../models/SlackAccount';
 import { SlackMessage } from '../models/SlackMessage';
 import { Tweet } from '../models/Tweet';
 import { TwitterAccount } from '../models/TwitterAccount';
+// Explicit provider entries register the SDK transports on the provider
+// registry — the same opt-in production servers perform (#1979). Their
+// dynamic SDK import resolves to the vi.mock above.
+import '../providers/slack';
+import '../providers/twitter';
 import { EmailSender } from '../senders/EmailSender';
 import { SlackSender } from '../senders/SlackSender';
 import { TweetSender } from '../senders/TweetSender';

--- a/packages/messages/src/models/Attachment.ts
+++ b/packages/messages/src/models/Attachment.ts
@@ -4,7 +4,12 @@
  * Uses messageId instead of emailId for cross-type support.
  */
 
-import { foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  foreignKey,
+  importOptionalDependency,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
 import type { AttachmentOptions } from '../types';
 
@@ -117,12 +122,19 @@ export class Attachment extends SmrtObject {
 
   /**
    * Read file content (if stored externally)
+   *
+   * The files SDK is loaded through core's bundler-invisible optional-import
+   * boundary so it never enters provider-neutral consumer bundles (#1979).
+   * Absence of the SDK at runtime degrades to the existing null contract.
    */
   async readContent(): Promise<Buffer | null> {
     if (!this.filePath) return null;
 
     try {
-      const { getFilesystem } = await import('@happyvertical/files');
+      const { getFilesystem } = (await importOptionalDependency(
+        '@happyvertical/files',
+        "Import '@happyvertical/smrt-assets/filesystem' or resolve @happyvertical/files at runtime to read externally-stored attachments.",
+      )) as typeof import('@happyvertical/files');
       const files = await getFilesystem({ type: 'local' });
       const data = await files.read(this.filePath);
       return data instanceof Buffer ? data : Buffer.from(data);

--- a/packages/messages/src/models/Attachment.ts
+++ b/packages/messages/src/models/Attachment.ts
@@ -133,7 +133,7 @@ export class Attachment extends SmrtObject {
     try {
       const { getFilesystem } = (await importOptionalDependency(
         '@happyvertical/files',
-        "Import '@happyvertical/smrt-assets/filesystem' or resolve @happyvertical/files at runtime to read externally-stored attachments.",
+        "Import '@happyvertical/smrt-core/filesystem' (or '@happyvertical/smrt-assets/filesystem') during server startup to read externally-stored attachments in bundled builds.",
       )) as typeof import('@happyvertical/files');
       const files = await getFilesystem({ type: 'local' });
       const data = await files.read(this.filePath);

--- a/packages/messages/src/models/EmailAccount.ts
+++ b/packages/messages/src/models/EmailAccount.ts
@@ -65,16 +65,33 @@ export class EmailAccount extends Account {
   /**
    * Create an EmailClient from stored settings
    * Retrieves credentials from smrt-secrets if credentialSecretId is set
+   *
+   * The client factory comes from the messaging provider registry rather than
+   * a direct `@happyvertical/email` import so the email SDK
+   * (googleapis/nodemailer) never becomes reachable from provider-neutral
+   * consumer bundles (#1979). Server code that uses email accounts must
+   * import '@happyvertical/smrt-messages/providers/email' (or
+   * '/providers/all') once during startup.
    */
   async createClient() {
-    const { getEmailClient } = await import('@happyvertical/email');
+    const { getMessagingProvider } = await import('../providers.js');
+    const createEmailClient = getMessagingProvider(
+      this.providerType,
+    )?.createEmailClient;
+    if (!createEmailClient) {
+      throw new Error(
+        `Email provider '${this.providerType}' has no client implementation registered. ` +
+          "Import '@happyvertical/smrt-messages/providers/email' (or '/providers/all') " +
+          'during server startup to enable outbound email and mailbox sync.',
+      );
+    }
     const settings: Record<string, unknown> = {
       ...this.getConfiguration(),
       ...((await this.getCredentials()) ?? {}),
     };
     delete settings.email;
 
-    return await getEmailClient({
+    return await createEmailClient({
       type: this.providerType as ProviderType,
       ...settings,
     } as GetEmailClientOptions);

--- a/packages/messages/src/providers.ts
+++ b/packages/messages/src/providers.ts
@@ -97,6 +97,23 @@ export function listMessagingProviders(
 
 let builtinsRegistered = false;
 
+/**
+ * Registers a builtin definition only when its id is still absent.
+ *
+ * The registry lives on globalThis (survives HMR and duplicate module
+ * instances) while the `builtinsRegistered` flag is module-scoped, so a
+ * second module instance re-runs this function against a registry that may
+ * already hold upgraded definitions — e.g. the functional client hooks
+ * registered by the explicit `providers/*` entry points (#1979). Builtins
+ * therefore only fill gaps; they never overwrite an existing definition.
+ */
+function registerBuiltinMessagingProvider(
+  provider: MessagingProviderDefinition,
+): void {
+  if (registry().has(provider.id)) return;
+  registerMessagingProvider(provider);
+}
+
 export function ensureBuiltinMessagingProvidersRegistered(): void {
   if (builtinsRegistered) return;
   builtinsRegistered = true;
@@ -124,7 +141,7 @@ export function ensureBuiltinMessagingProvidersRegistered(): void {
   ];
 
   for (const id of ['smtp', 'imap', 'pop3'] as const) {
-    registerMessagingProvider({
+    registerBuiltinMessagingProvider({
       id,
       label: id.toUpperCase(),
       channel: 'email',
@@ -137,7 +154,7 @@ export function ensureBuiltinMessagingProvidersRegistered(): void {
     });
   }
 
-  registerMessagingProvider({
+  registerBuiltinMessagingProvider({
     id: 'gmail',
     label: 'Gmail',
     channel: 'email',
@@ -169,7 +186,7 @@ export function ensureBuiltinMessagingProvidersRegistered(): void {
     endpointFields: emailEndpoint,
   });
 
-  registerMessagingProvider({
+  registerBuiltinMessagingProvider({
     id: 'zulip',
     label: 'Zulip',
     channel: 'zulip',
@@ -203,7 +220,7 @@ export function ensureBuiltinMessagingProvidersRegistered(): void {
     createSender: async (account) => new ZulipSender(account),
   });
 
-  registerMessagingProvider({
+  registerBuiltinMessagingProvider({
     id: 'telegram',
     label: 'Telegram',
     channel: 'telegram',
@@ -219,7 +236,7 @@ export function ensureBuiltinMessagingProvidersRegistered(): void {
     createSender: async (account) => new TelegramSender(account),
   });
 
-  registerMessagingProvider({
+  registerBuiltinMessagingProvider({
     id: 'sms',
     label: 'SMS (provider required)',
     channel: 'sms',

--- a/packages/messages/src/providers.ts
+++ b/packages/messages/src/providers.ts
@@ -1,7 +1,12 @@
+import type { EmailClient, GetEmailClientOptions } from '@happyvertical/email';
 import type { Account } from './models/Account.js';
 import { TelegramSender } from './senders/TelegramSender.js';
 import { ZulipSender } from './senders/ZulipSender.js';
-import type { MessageSenderInterface, MessagingChannel } from './types.js';
+import type {
+  MessageClientFactory,
+  MessageSenderInterface,
+  MessagingChannel,
+} from './types.js';
 
 export type MessagingProviderFieldType =
   | 'string'
@@ -32,7 +37,30 @@ export interface MessagingProviderDefinition {
   credentialFields: MessagingProviderField[];
   endpointFields: MessagingProviderField[];
   createSender?: (account: Account) => Promise<MessageSenderInterface>;
+  /**
+   * Creates the SDK email client for this provider. Absent on the builtin
+   * metadata-only definitions — registered by the explicit
+   * `@happyvertical/smrt-messages/providers/email` entry point so the
+   * @happyvertical/email SDK (googleapis/nodemailer) never enters
+   * provider-neutral consumer bundles (#1979).
+   */
+  createEmailClient?: (options: GetEmailClientOptions) => Promise<EmailClient>;
+  /**
+   * Creates the SDK message client (Slack, Twitter, …) for this provider.
+   * Registered by the matching `@happyvertical/smrt-messages/providers/*`
+   * entry point; absent until that entry is imported.
+   */
+  createMessageClient?: MessageClientFactory;
 }
+
+/**
+ * Function-valued definition keys. Stripped by MessagingSettingsService before
+ * definitions are serialized to setup UIs.
+ */
+export type MessagingProviderFunctionKey =
+  | 'createSender'
+  | 'createEmailClient'
+  | 'createMessageClient';
 
 const REGISTRY_KEY = Symbol.for('smrt.messaging.providers');
 

--- a/packages/messages/src/providers/all.ts
+++ b/packages/messages/src/providers/all.ts
@@ -1,0 +1,17 @@
+/**
+ * Convenience entry point enabling every built-in messaging provider (#1979).
+ *
+ * Importing this module registers the email, Slack, and Twitter transports —
+ * the explicit opt-in that makes their SDKs part of the consumer's bundle
+ * contract. Telegram and Zulip are fetch-based and always functional from the
+ * package root without any provider entry.
+ *
+ * @example
+ * ```ts
+ * // hooks.server.ts / server bootstrap
+ * import '@happyvertical/smrt-messages/providers/all';
+ * ```
+ */
+export { ensureEmailMessagingProvider } from './email.js';
+export { ensureSlackMessagingProvider } from './slack.js';
+export { ensureTwitterMessagingProvider } from './twitter.js';

--- a/packages/messages/src/providers/email.ts
+++ b/packages/messages/src/providers/email.ts
@@ -1,0 +1,51 @@
+/**
+ * Explicit email provider entry point (#1979).
+ *
+ * Importing this module upgrades the builtin metadata-only email provider
+ * definitions (smtp, imap, pop3, gmail) with a functional
+ * `createEmailClient` backed by `@happyvertical/email`. Until a server
+ * imports it, provider-neutral consumers carry zero email-SDK weight
+ * (googleapis, nodemailer, imapflow, mailparser) and
+ * `EmailAccount.createClient()` fails with an actionable error.
+ *
+ * The SDK itself is still loaded on first client construction, so importing
+ * this entry keeps server startup cheap while making the dependency an
+ * explicit part of the consumer's bundle contract.
+ *
+ * @example
+ * ```ts
+ * // hooks.server.ts / server bootstrap
+ * import '@happyvertical/smrt-messages/providers/email';
+ * ```
+ */
+import type { GetEmailClientOptions } from '@happyvertical/email';
+import {
+  ensureBuiltinMessagingProvidersRegistered,
+  getMessagingProvider,
+  registerMessagingProvider,
+} from '../providers.js';
+
+const EMAIL_PROVIDER_IDS = ['smtp', 'imap', 'pop3', 'gmail'] as const;
+
+let registered = false;
+
+/** Idempotently registers the email client factory on the email providers. */
+export function ensureEmailMessagingProvider(): void {
+  if (registered) return;
+  registered = true;
+
+  ensureBuiltinMessagingProvidersRegistered();
+  for (const id of EMAIL_PROVIDER_IDS) {
+    const definition = getMessagingProvider(id);
+    if (!definition) continue;
+    registerMessagingProvider({
+      ...definition,
+      createEmailClient: async (options: GetEmailClientOptions) => {
+        const { getEmailClient } = await import('@happyvertical/email');
+        return getEmailClient(options);
+      },
+    });
+  }
+}
+
+ensureEmailMessagingProvider();

--- a/packages/messages/src/providers/slack.ts
+++ b/packages/messages/src/providers/slack.ts
@@ -1,0 +1,66 @@
+/**
+ * Explicit Slack provider entry point (#1979).
+ *
+ * Importing this module registers the Slack messaging provider with a
+ * functional transport backed by `@happyvertical/messages` (@slack/web-api).
+ * Until a server imports it, provider-neutral consumers carry zero Slack-SDK
+ * weight and `SlackSender.send()` returns an actionable failure result.
+ *
+ * @example
+ * ```ts
+ * // hooks.server.ts / server bootstrap
+ * import '@happyvertical/smrt-messages/providers/slack';
+ * ```
+ */
+import type { GetMessageClientOptions } from '@happyvertical/messages';
+import type { SlackAccount } from '../models/SlackAccount.js';
+import {
+  ensureBuiltinMessagingProvidersRegistered,
+  registerMessagingProvider,
+} from '../providers.js';
+import type { MessagingTransportClient } from '../types.js';
+
+let registered = false;
+
+/** Idempotently registers the Slack provider with its SDK transport. */
+export function ensureSlackMessagingProvider(): void {
+  if (registered) return;
+  registered = true;
+
+  ensureBuiltinMessagingProvidersRegistered();
+  registerMessagingProvider({
+    id: 'slack',
+    label: 'Slack',
+    channel: 'slack',
+    available: true,
+    configurationFields: [],
+    credentialFields: [
+      {
+        id: 'botToken',
+        label: 'Bot token',
+        type: 'password',
+        required: true,
+      },
+    ],
+    endpointFields: [
+      {
+        id: 'channelId',
+        label: 'Channel ID',
+        type: 'string',
+        required: true,
+      },
+    ],
+    createSender: async (account) => {
+      const { SlackSender } = await import('../senders/SlackSender.js');
+      return new SlackSender(account as SlackAccount);
+    },
+    createMessageClient: async (config) => {
+      const { getMessageClient } = await import('@happyvertical/messages');
+      return (await getMessageClient(
+        config as unknown as GetMessageClientOptions,
+      )) as unknown as MessagingTransportClient;
+    },
+  });
+}
+
+ensureSlackMessagingProvider();

--- a/packages/messages/src/providers/twitter.ts
+++ b/packages/messages/src/providers/twitter.ts
@@ -1,0 +1,72 @@
+/**
+ * Explicit Twitter provider entry point (#1979).
+ *
+ * Importing this module registers the Twitter messaging provider with a
+ * functional transport backed by `@happyvertical/messages`. Until a server
+ * imports it, provider-neutral consumers carry zero Twitter-SDK weight and
+ * `TweetSender.send()` returns an actionable failure result.
+ *
+ * @example
+ * ```ts
+ * // hooks.server.ts / server bootstrap
+ * import '@happyvertical/smrt-messages/providers/twitter';
+ * ```
+ */
+import type { GetMessageClientOptions } from '@happyvertical/messages';
+import type { TwitterAccount } from '../models/TwitterAccount.js';
+import {
+  ensureBuiltinMessagingProvidersRegistered,
+  registerMessagingProvider,
+} from '../providers.js';
+import type { MessagingTransportClient } from '../types.js';
+
+let registered = false;
+
+/** Idempotently registers the Twitter provider with its SDK transport. */
+export function ensureTwitterMessagingProvider(): void {
+  if (registered) return;
+  registered = true;
+
+  ensureBuiltinMessagingProvidersRegistered();
+  registerMessagingProvider({
+    id: 'twitter',
+    label: 'Twitter / X',
+    channel: 'twitter',
+    available: true,
+    configurationFields: [],
+    credentialFields: [
+      { id: 'apiKey', label: 'API key', type: 'password', required: true },
+      {
+        id: 'apiSecret',
+        label: 'API secret',
+        type: 'password',
+        required: true,
+      },
+      {
+        id: 'accessToken',
+        label: 'Access token',
+        type: 'password',
+        required: true,
+      },
+      {
+        id: 'accessSecret',
+        label: 'Access token secret',
+        type: 'password',
+        required: true,
+      },
+    ],
+    endpointFields: [],
+    createSender: async (account) => {
+      const { TweetSender } = await import('../senders/TweetSender.js');
+      return new TweetSender(account as TwitterAccount);
+    },
+    createMessageClient: async (config) => {
+      const { getMessageClient } = await import('@happyvertical/messages');
+      return (await getMessageClient(
+        config as unknown as GetMessageClientOptions,
+      )) as unknown as MessagingTransportClient;
+    },
+  });
+}
+
+ensureTwitterMessagingProvider();

--- a/packages/messages/src/senders/SlackSender.ts
+++ b/packages/messages/src/senders/SlackSender.ts
@@ -1,10 +1,18 @@
 /**
  * SlackSender — sends Slack messages via the SDK MessageClient
+ *
+ * The SDK transport comes from the messaging provider registry (populated by
+ * `@happyvertical/smrt-messages/providers/slack`) or constructor injection —
+ * never a direct `@happyvertical/messages` import, which would drag the SDK
+ * (and transitively googleapis/nodemailer via its email wrapper) into
+ * provider-neutral consumer bundles (#1979).
  */
 
 import type { SlackAccount } from '../models/SlackAccount';
 import type { SlackMessage } from '../models/SlackMessage';
+import { getMessagingProvider } from '../providers.js';
 import type {
+  MessageClientFactory,
   MessageSenderInterface,
   MessageSendResult,
   SendMessageOptions,
@@ -13,9 +21,14 @@ import type {
 export class SlackSender implements MessageSenderInterface {
   readonly providerType = 'slack';
   private account: SlackAccount;
+  private createMessageClient?: MessageClientFactory;
 
-  constructor(account: SlackAccount) {
+  constructor(
+    account: SlackAccount,
+    createMessageClient?: MessageClientFactory,
+  ) {
     this.account = account;
+    this.createMessageClient = createMessageClient;
   }
 
   isReady(): boolean {
@@ -26,7 +39,17 @@ export class SlackSender implements MessageSenderInterface {
     message: SlackMessage,
     _options?: SendMessageOptions,
   ): Promise<MessageSendResult> {
-    const { getMessageClient } = await import('@happyvertical/messages');
+    const createMessageClient =
+      this.createMessageClient ??
+      getMessagingProvider(this.providerType)?.createMessageClient;
+    if (!createMessageClient) {
+      return {
+        success: false,
+        error:
+          "Slack provider has no transport registered. Import '@happyvertical/smrt-messages/providers/slack' (or '/providers/all') during server startup.",
+        sentAt: new Date(),
+      };
+    }
 
     const credentials = await this.account.getCredentials();
     if (!credentials?.botToken) {
@@ -37,7 +60,7 @@ export class SlackSender implements MessageSenderInterface {
       };
     }
 
-    const client = await getMessageClient({
+    const client = await createMessageClient({
       type: 'slack',
       botToken: credentials.botToken as string,
     });
@@ -62,7 +85,7 @@ export class SlackSender implements MessageSenderInterface {
         success: result.success,
         providerMessageId: result.messageId,
         providerResponse: result.providerResponse,
-        sentAt: result.timestamp,
+        sentAt: result.timestamp ?? new Date(),
       };
     } catch (error) {
       return {

--- a/packages/messages/src/senders/TweetSender.ts
+++ b/packages/messages/src/senders/TweetSender.ts
@@ -1,10 +1,18 @@
 /**
  * TweetSender — sends tweets via the SDK MessageClient
+ *
+ * The SDK transport comes from the messaging provider registry (populated by
+ * `@happyvertical/smrt-messages/providers/twitter`) or constructor injection —
+ * never a direct `@happyvertical/messages` import, which would drag the SDK
+ * (and transitively googleapis/nodemailer via its email wrapper) into
+ * provider-neutral consumer bundles (#1979).
  */
 
 import type { Tweet } from '../models/Tweet';
 import type { TwitterAccount } from '../models/TwitterAccount';
+import { getMessagingProvider } from '../providers.js';
 import type {
+  MessageClientFactory,
   MessageSenderInterface,
   MessageSendResult,
   SendMessageOptions,
@@ -13,9 +21,14 @@ import type {
 export class TweetSender implements MessageSenderInterface {
   readonly providerType = 'twitter';
   private account: TwitterAccount;
+  private createMessageClient?: MessageClientFactory;
 
-  constructor(account: TwitterAccount) {
+  constructor(
+    account: TwitterAccount,
+    createMessageClient?: MessageClientFactory,
+  ) {
     this.account = account;
+    this.createMessageClient = createMessageClient;
   }
 
   isReady(): boolean {
@@ -26,7 +39,17 @@ export class TweetSender implements MessageSenderInterface {
     message: Tweet,
     _options?: SendMessageOptions,
   ): Promise<MessageSendResult> {
-    const { getMessageClient } = await import('@happyvertical/messages');
+    const createMessageClient =
+      this.createMessageClient ??
+      getMessagingProvider(this.providerType)?.createMessageClient;
+    if (!createMessageClient) {
+      return {
+        success: false,
+        error:
+          "Twitter provider has no transport registered. Import '@happyvertical/smrt-messages/providers/twitter' (or '/providers/all') during server startup.",
+        sentAt: new Date(),
+      };
+    }
 
     const credentials = await this.account.getCredentials();
     if (
@@ -42,7 +65,7 @@ export class TweetSender implements MessageSenderInterface {
       };
     }
 
-    const client = await getMessageClient({
+    const client = await createMessageClient({
       type: 'twitter',
       apiKey: credentials.apiKey as string,
       apiSecret: credentials.apiSecret as string,
@@ -68,7 +91,7 @@ export class TweetSender implements MessageSenderInterface {
         success: result.success,
         providerMessageId: result.messageId,
         providerResponse: result.providerResponse,
-        sentAt: result.timestamp,
+        sentAt: result.timestamp ?? new Date(),
       };
     } catch (error) {
       return {

--- a/packages/messages/src/services/MessagingSettingsService.ts
+++ b/packages/messages/src/services/MessagingSettingsService.ts
@@ -20,6 +20,7 @@ import {
   listMessagingProviders,
   type MessagingProviderDefinition,
   type MessagingProviderField,
+  type MessagingProviderFunctionKey,
 } from '../providers.js';
 import type { MessagingChannel } from '../types.js';
 
@@ -86,12 +87,19 @@ export class MessagingSettingsService {
 
   getProviderDefinitions(options: { includeUnavailable?: boolean } = {}) {
     return listMessagingProviders(options).map(
-      ({ createSender: _, ...provider }) => provider,
+      ({
+        createSender: _createSender,
+        createEmailClient: _createEmailClient,
+        createMessageClient: _createMessageClient,
+        ...provider
+      }) => provider,
     );
   }
 
   async list(personaId: string): Promise<{
-    providers: Array<Omit<MessagingProviderDefinition, 'createSender'>>;
+    providers: Array<
+      Omit<MessagingProviderDefinition, MessagingProviderFunctionKey>
+    >;
     accounts: MessagingAccountView[];
     endpoints: MessagingEndpointView[];
     routes: PersonaMessageRoute[];

--- a/packages/messages/src/types.ts
+++ b/packages/messages/src/types.ts
@@ -88,6 +88,40 @@ export interface MessageSendResult {
 }
 
 // ─────────────────────────────────────────────────────────────────────────
+// Provider transport factories (#1979)
+// ─────────────────────────────────────────────────────────────────────────
+//
+// Structural view of the SDK message clients used by senders. Kept structural
+// (rather than typed against @happyvertical/messages) so the provider-neutral
+// package surface carries no reference to the SDK wrappers whose roots import
+// googleapis/nodemailer/@slack/web-api. Concrete factories are registered on
+// MessagingProviderDefinition by the explicit provider entry points
+// (`@happyvertical/smrt-messages/providers/*`).
+
+/** Result shape returned by SDK message-client `send()` implementations. */
+export interface MessagingTransportSendResult {
+  success: boolean;
+  messageId?: string;
+  providerResponse?: Record<string, unknown>;
+  timestamp?: Date;
+}
+
+/** Minimal structural contract of an SDK message client (Slack, Twitter, …). */
+export interface MessagingTransportClient {
+  connect(): Promise<unknown>;
+  disconnect(): Promise<unknown>;
+  send(
+    message: Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ): Promise<MessagingTransportSendResult>;
+}
+
+/** Creates a connected-capable SDK message client for a provider config. */
+export type MessageClientFactory = (
+  config: { type: string } & Record<string, unknown>,
+) => Promise<MessagingTransportClient>;
+
+// ─────────────────────────────────────────────────────────────────────────
 // Discriminator Types
 // ─────────────────────────────────────────────────────────────────────────
 

--- a/packages/messages/vite.config.ts
+++ b/packages/messages/vite.config.ts
@@ -1,6 +1,15 @@
 import { createPackageConfig } from '../../vite.config.base.js';
 
 export default createPackageConfig('messages', {
-  entries: ['ui', 'playground'],
+  entries: [
+    'ui',
+    'playground',
+    // Explicit provider entry points (#1979): the only modules allowed to
+    // reference the provider SDK wrappers (@happyvertical/email//messages).
+    { name: 'providers/email', source: 'src/providers/email.ts' },
+    { name: 'providers/slack', source: 'src/providers/slack.ts' },
+    { name: 'providers/twitter', source: 'src/providers/twitter.ts' },
+    { name: 'providers/all', source: 'src/providers/all.ts' },
+  ],
   svelte: 'svelte',
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,30 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  packages/bundle-gate:
+    devDependencies:
+      '@happyvertical/smrt-chat':
+        specifier: workspace:*
+        version: link:../chat
+      '@happyvertical/smrt-messages':
+        specifier: workspace:*
+        version: link:../messages
+      '@happyvertical/smrt-personas':
+        specifier: workspace:*
+        version: link:../personas
+      '@types/node':
+        specifier: 24.13.2
+        version: 24.13.2
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.1.3
+        version: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+
   packages/chat:
     dependencies:
       '@happyvertical/ai':
@@ -1332,9 +1356,6 @@ importers:
 
   packages/messages:
     dependencies:
-      '@happyvertical/ai':
-        specifier: ^0.78.0
-        version: 0.78.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/email':
         specifier: ^0.78.0
         version: 0.78.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))


### PR DESCRIPTION
## Summary

Epic #1977: an ordinary (provider-neutral) SMRT chat consumer must not bundle heavyweight messaging-provider SDKs. The Ergot 0.39.7 rehearsal showed googleapis + nodemailer landing in a 31.6 MB server chunk (server output 18 MB → 109 MB) and a 4 GB heap exhaustion.

Root cause: bundlers follow statically-analyzable dynamic imports, and SvelteKit production server builds bundle every dependency not listed in `ssr.external` — so the `await import('@happyvertical/email')`-style "lazy" edges inside root-exported models/senders were bundle-eager. Full import-graph evidence is posted on #1978.

### Boundary repair (#1979)

- **smrt-messages** — root stays fully importable and API-compatible with **zero provider-SDK reachability**. Registry definitions stay metadata-only; new explicit entries `@happyvertical/smrt-messages/providers/{email,slack,twitter,all}` register the functional `createEmailClient`/`createMessageClient`/`createSender` hooks. Without the entry, `EmailAccount.createClient()` throws an actionable enablement error and `SlackSender`/`TweetSender` return an actionable failure result. Telegram/Zulip (fetch-based) keep working from the root. Accurate `sideEffects` metadata; dropped unused `@happyvertical/ai` dep.
- **smrt-core** — `SmrtClass` no longer statically imports `@happyvertical/files` (which statically pulls @aws-sdk/client-s3 and reaches googleapis@144); `options.fs` resolves through a lazy boundary + `@happyvertical/smrt-core/filesystem` entry. Adds reusable `importOptionalDependency()`.
- **smrt-assets** — `AssetStore` loads the files SDK lazily + `@happyvertical/smrt-assets/filesystem` entry (assets is reachable from neutral graphs via profiles).
- **chat/personas** — no source changes needed once the roots they reach are provider-free.

Unbundled runtimes (Node, tsx, vite dev, externalized SSR) keep working with **zero code changes** — the lazy boundaries resolve from node_modules on first use. Only fully-bundled deployments that want a provider must add the explicit entry import at server startup.

### Permanent regression gate (#1980)

`packages/bundle-gate` (private): SSR `vite build` with `ssr.noExternal: true` over the **dist** surface.

- Neutral fixture: zero forbidden provider modules resolvable (guard reports every offending edge with importers on failure), zero in emitted chunks, coarse size budget.
- Explicit fixture: `providers/all` makes the SDK wrappers reachable again; runtime tests in messages prove the wiring.
- **Fails against the pre-repair tree** with exactly the documented edges; passes post-repair.

### Measurements

| | 0.39.7 behavior | after repair |
|---|---|---|
| Fixture neutral SSR output | forbidden edges (email/messages/files SDKs → googleapis 195 MB unpacked, nodemailer, @slack/web-api, S3) | **12.55 MB / 84 chunks, largest 7.44 MB**, normal heap |
| Ergot server output (baseline from epic) | ~109 MB, 31.6 MB chunk, 8 GB heap workaround | to verify in #1981 after release |

### Validation

- Full suites green: core (3095), messages (267), assets (126), personas (63), chat (236), content (300), profiles (168); bundle-gate 2/2
- Typecheck green across touched packages; biome clean on the diff; `verify:pack` green for core/assets/messages (new entries present in packed export maps)
- `pnpm smrt dev:knowledge-check`: 0 errors, 0 warnings
- Dist runtime driven as a real consumer: neutral root errors actionably; entry imports register hooks

Closes #1978
Closes #1979
Closes #1980
Refs #1977

### Release note for #1981

Consumers using messaging providers in **fully-bundled** deployments must add the matching `import '@happyvertical/smrt-messages/providers/…'` (and `@happyvertical/smrt-{core,assets}/filesystem` if they use `options.fs`/AssetStore there) at server startup. All other usage is unchanged.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude-code","session":"e2abb678-72a6-4fd8-81b1-56d7c1cadfa2","issue":"happyvertical/smrt#1979","policy_revision":"1.0.0","validation":["package suites: core 3095 / messages 267 / assets 126 / personas 63 / chat 236 / content 300 / profiles 168","bundle-gate neutral+explicit fixtures","turbo typecheck (touched packages)","biome check on diff","pnpm smrt dev:knowledge-check (0 errors)","verify:pack core/assets/messages","dist consumer runtime smoke"]}
```
