### PR TITLE
fix(sales): resolve global commission plans in PostgreSQL

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -418,6 +418,7 @@ jobs:
               - 'packages/analytics/**'
               - 'packages/cli/**'
               - 'packages/core/**'
+              - 'packages/sales/**'
               - 'packages/users/**'
               - 'packages/vitest/**'
               - 'scripts/run-with-ci-postgres.mjs'

--- a/packages/sales/AGENTS.md
+++ b/packages/sales/AGENTS.md
@@ -9,6 +9,10 @@ Modular sales: CRM (Leads, Opportunities, Pipelines), referral intake with versi
 
 The root export re-exports every TS module. Internal module dependency order is `crm → commissions` and `referrals → commissions` (by string references only); `commissions` never imports from `crm`/`referrals` and never assumes advertising, Referral, Lead, or Opportunity semantics.
 
+## Validation
+
+Run `pnpm --filter @happyvertical/smrt-sales test` and `pnpm --filter @happyvertical/smrt-sales typecheck` for package changes. PostgreSQL-sensitive changes must also run `pnpm --filter @happyvertical/smrt-sales test:postgres`; the command uses the repository's disposable PostgreSQL harness and is registered in the PostgreSQL CI shard.
+
 ## Roles vs. money
 
 Referrers and Sales Representatives are **distinct roles** and stay that way. Both connect to money through one neutral financial account:

--- a/packages/sales/package.json
+++ b/packages/sales/package.json
@@ -42,6 +42,7 @@
     "dev": "vite dev",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
+    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/commissions/__tests__/commission-plan.postgres.test.ts",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit -p tsconfig.json && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."

--- a/packages/sales/src/commissions/__tests__/commission-plan.postgres.test.ts
+++ b/packages/sales/src/commissions/__tests__/commission-plan.postgres.test.ts
@@ -1,0 +1,93 @@
+/**
+ * PostgreSQL regression coverage for global CommissionPlan resolution (#1982).
+ *
+ * The row is inserted independently through SQL, then hydrated through the
+ * public collection API. This covers the production migration path that does
+ * not have an in-memory model instance available to the resolver.
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  createIsolatedTestDbFromManifest,
+  type IsolatedTestDbResult,
+  isPostgresAvailable,
+} from '@happyvertical/smrt-vitest';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CommissionPlanCollection } from '../collections/CommissionPlanCollection.js';
+
+const describePostgres = isPostgresAvailable() ? describe : describe.skip;
+
+describePostgres('CommissionPlan PostgreSQL global resolution (#1982)', () => {
+  let isolated: IsolatedTestDbResult | undefined;
+  let db: DatabaseInterface;
+  let plans: CommissionPlanCollection;
+
+  beforeEach(async () => {
+    isolated = await createIsolatedTestDbFromManifest({
+      includeObjects: ['CommissionPlan'],
+    });
+    if (isolated.config.type !== 'postgres') {
+      throw new Error('Expected a PostgreSQL test database.');
+    }
+    db = isolated.db;
+    plans = await CommissionPlanCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    await isolated?.cleanup();
+    isolated = undefined;
+  });
+
+  async function insertGlobalPlan({
+    id = randomUUID(),
+    version,
+    effectiveFrom,
+  }: {
+    id?: string;
+    version: number;
+    effectiveFrom: Date;
+  }): Promise<string> {
+    await db.query(
+      `INSERT INTO commission_plans (
+        id, slug, context, tenant_id, plan_key, version,
+        name, description, status, effective_from, currency, components, metadata
+      ) VALUES (
+        $1, $2, '', NULL, 'postgres-global-plan', $3,
+        'PostgreSQL global plan', '', 'active', $4, 'CAD', '[]', '{}'
+      )`,
+      id,
+      `postgres-global-plan-v${version}`,
+      version,
+      effectiveFrom,
+    );
+    return id;
+  }
+
+  it('hydrates and resolves a separately persisted global row', async () => {
+    const governingId = await insertGlobalPlan({
+      version: 1,
+      effectiveFrom: new Date('2026-07-01T00:00:00Z'),
+    });
+    await insertGlobalPlan({
+      version: 2,
+      effectiveFrom: new Date('2026-08-01T00:00:00Z'),
+    });
+
+    const beforeAmendment = await plans.latestActiveByKey(
+      'postgres-global-plan',
+      new Date('2026-07-15T00:00:00Z'),
+      null,
+    );
+    expect(beforeAmendment?.id).toBe(governingId);
+    expect(beforeAmendment?.tenantId).toBeNull();
+    expect(beforeAmendment?.version).toBe(1);
+
+    const afterAmendment = await plans.latestActiveByKey(
+      'postgres-global-plan',
+      new Date('2026-08-01T00:00:00Z'),
+      null,
+    );
+    expect(afterAmendment?.version).toBe(2);
+  });
+});

--- a/packages/sales/src/commissions/__tests__/commission-plan.test.ts
+++ b/packages/sales/src/commissions/__tests__/commission-plan.test.ts
@@ -315,6 +315,15 @@ describe('CommissionPlan', () => {
     const forC = await plans.latestActiveByKey('lane-plan', now, 'tenant-c');
     expect(forC?.version).toBe(3);
     expect(forC?.tenantId).toBeNull();
+
+    // An exact tenant lane still wins even when a higher global version exists.
+    const forAWithGlobal = await plans.latestActiveByKey(
+      'lane-plan',
+      now,
+      'tenant-a',
+    );
+    expect(forAWithGlobal?.version).toBe(1);
+    expect(forAWithGlobal?.tenantId).toBe('tenant-a');
   });
 
   it('refuses a fresh create onto an existing plan version (codex P1)', async () => {

--- a/packages/sales/src/commissions/__tests__/commission-plan.test.ts
+++ b/packages/sales/src/commissions/__tests__/commission-plan.test.ts
@@ -6,6 +6,11 @@
  */
 
 import { getTestDatabase } from '@happyvertical/smrt-core';
+import {
+  disableTenancy,
+  enableTenancy,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { CommissionPlanCollection } from '../collections/CommissionPlanCollection.js';
@@ -324,6 +329,23 @@ describe('CommissionPlan', () => {
     );
     expect(forAWithGlobal?.version).toBe(1);
     expect(forAWithGlobal?.tenantId).toBe('tenant-a');
+  });
+
+  it('rejects an explicit cross-tenant plan lookup', async () => {
+    enableTenancy();
+    try {
+      await expect(
+        withTenant({ tenantId: 'tenant-a' }, () =>
+          plans.latestActiveByKey(
+            'lane-plan',
+            new Date('2026-07-01T00:00:00Z'),
+            'tenant-b',
+          ),
+        ),
+      ).rejects.toThrow(/Tenant isolation violation/);
+    } finally {
+      disableTenancy();
+    }
   });
 
   it('refuses a fresh create onto an existing plan version (codex P1)', async () => {

--- a/packages/sales/src/commissions/collections/CommissionPlanCollection.ts
+++ b/packages/sales/src/commissions/collections/CommissionPlanCollection.ts
@@ -8,7 +8,7 @@
  */
 
 import { SmrtCollection } from '@happyvertical/smrt-core';
-import { queryGlobal, queryWithGlobals } from '@happyvertical/smrt-tenancy';
+import { assertTenantReadAllowed } from '@happyvertical/smrt-tenancy';
 import {
   CommissionPlan,
   validateCommissionPlanComponents,
@@ -65,39 +65,54 @@ export class CommissionPlanCollection extends SmrtCollection<CommissionPlan> {
     at: Date = new Date(),
     tenantId?: string | null,
   ): Promise<CommissionPlan | null> {
-    const results =
-      tenantId === undefined
-        ? await this.list({
-            where: { planKey, status: 'active' },
-            orderBy: 'version DESC',
-          })
-        : (tenantId === null
-            ? await queryGlobal<CommissionPlan>(this)
-            : await queryWithGlobals<CommissionPlan>(
-                this,
-                tenantId,
-                'CommissionPlanCollection.latestActiveByKey',
-              )
-          )
-            .filter(
-              (plan) => plan.planKey === planKey && plan.status === 'active',
-            )
-            .sort((a, b) => b.version - a.version);
-    const inEffect = results.filter(
-      (plan) => plan.effectiveFrom === null || plan.effectiveFrom <= at,
-    );
     if (tenantId === undefined) {
       // No explicit scope: ambient tenant scoping (when present) applies.
-      return inEffect[0] ?? null;
+      const results = await this.list({
+        where: { planKey, status: 'active' },
+        orderBy: 'version DESC',
+      });
+      return (
+        results.find(
+          (plan) => plan.effectiveFrom === null || plan.effectiveFrom <= at,
+        ) ?? null
+      );
     }
+
     // Explicit scope (system/background paths run without ambient tenant
     // context): the tenant's own versions form their own key-space; global
     // (NULL-tenant) versions are the fallback. Never another tenant's.
-    return (
-      inEffect.find((plan) => plan.tenantId === tenantId) ??
-      inEffect.find((plan) => plan.tenantId === null) ??
-      null
+    const atIso = at.toISOString();
+    if (tenantId === null) {
+      const results = await this.query(
+        `SELECT * FROM ${this.tableName}
+         WHERE tenant_id IS NULL
+           AND plan_key = ?
+           AND status = ?
+           AND (effective_from IS NULL OR effective_from <= ?)
+         ORDER BY version DESC
+         LIMIT 1`,
+        [planKey, 'active', atIso],
+        { allowRawOnTenantScoped: true },
+      );
+      return results[0] ?? null;
+    }
+
+    assertTenantReadAllowed(
+      tenantId,
+      'CommissionPlanCollection.latestActiveByKey',
     );
+    const results = await this.query(
+      `SELECT * FROM ${this.tableName}
+       WHERE (tenant_id = ? OR tenant_id IS NULL)
+         AND plan_key = ?
+         AND status = ?
+         AND (effective_from IS NULL OR effective_from <= ?)
+       ORDER BY CASE WHEN tenant_id = ? THEN 0 ELSE 1 END, version DESC
+       LIMIT 1`,
+      [tenantId, planKey, 'active', atIso, tenantId],
+      { allowRawOnTenantScoped: true },
+    );
+    return results[0] ?? null;
   }
 
   /**

--- a/packages/sales/src/commissions/collections/CommissionPlanCollection.ts
+++ b/packages/sales/src/commissions/collections/CommissionPlanCollection.ts
@@ -8,6 +8,7 @@
  */
 
 import { SmrtCollection } from '@happyvertical/smrt-core';
+import { queryGlobal, queryWithGlobals } from '@happyvertical/smrt-tenancy';
 import {
   CommissionPlan,
   validateCommissionPlanComponents,
@@ -64,10 +65,24 @@ export class CommissionPlanCollection extends SmrtCollection<CommissionPlan> {
     at: Date = new Date(),
     tenantId?: string | null,
   ): Promise<CommissionPlan | null> {
-    const results = await this.list({
-      where: { planKey, status: 'active' },
-      orderBy: 'version DESC',
-    });
+    const results =
+      tenantId === undefined
+        ? await this.list({
+            where: { planKey, status: 'active' },
+            orderBy: 'version DESC',
+          })
+        : (tenantId === null
+            ? await queryGlobal<CommissionPlan>(this)
+            : await queryWithGlobals<CommissionPlan>(
+                this,
+                tenantId,
+                'CommissionPlanCollection.latestActiveByKey',
+              )
+          )
+            .filter(
+              (plan) => plan.planKey === planKey && plan.status === 'active',
+            )
+            .sort((a, b) => b.version - a.version);
     const inEffect = results.filter(
       (plan) => plan.effectiveFrom === null || plan.effectiveFrom <= at,
     );


### PR DESCRIPTION
## Summary

- route explicit global and tenant-with-global commission plan lookups through the shared tenancy query helpers
- preserve exact-tenant precedence while excluding other tenants and future-dated versions
- add a real PostgreSQL hydration regression and register sales in the PostgreSQL CI shard

Closes #1982

## Validation

- `pnpm --filter @happyvertical/smrt-sales test:postgres`
- `pnpm --filter @happyvertical/smrt-sales test`
- `pnpm --filter @happyvertical/smrt-sales typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm typecheck`
- `pnpm test:ci-scripts`
- `pnpm knowledge:check --changed --strict --format markdown`
- `actionlint .github/workflows/on-pull-request.yml`
- `git diff --check`

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"4f4e04c9-3521-4be2-91c0-2a60eb9880c8","issue":"https://github.com/happyvertical/smrt/issues/1982","policy_revision":"1.0.0","validation":["real PostgreSQL regression","sales tests","sales typecheck","root build","root test","root typecheck","actionlint","CI script tests","knowledge freshness","git diff --check"]}