### PR TITLE
fix: add auto-generated versions and resilient ToolsDock availability

### DIFF
--- a/packages/content/AGENTS.md
+++ b/packages/content/AGENTS.md
@@ -8,7 +8,7 @@ STI content management with governance workflows, contribution intake, AI review
 - **Article**, **ContentDocument**, **Mirror**: STI subclasses — all share `contents` table via `_meta_type`
 - **ContentReview**: AI review result tied to a governance policy. Fields: `contentId`, `policyKey`, `kind`, `status` (accepted/flagged/rejected), `findings`, `fingerprint`, `metadata`
 - **ContentCorrection**: Post-publication change record. Fields: `contentId`, `type` (correction/retraction/update/clarification), `summary`, `note`, `status`, `metadata`
-- **ContentVersion**: Content snapshot. Fields: `contentId`, `kind` (publication/manual), `versionNumber`, `summary`, `metadata` (includes `transparency` for publication versions)
+- **ContentVersion**: Content snapshot. Fields: `contentId`, `kind` (manual/draft/review/publication/correction/auto-generated), `versionNumber`, `summary`, `metadata` (includes `transparency` for publication versions)
 - **ContentReference**: Junction model for content-to-content links (`content_references` table). Nullable `targetVersion` pins a citation to a specific `ContentVersion.version` for drift detection.
 - **ContentGovernancePolicy**: Persisted review policy (key, label, kind, instructions)
 - **ContentGovernanceProfile**: Persisted review profile (key, label, requirements array)

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -192,6 +192,8 @@ const versions = await article.listVersions();
 await versions.restoreIntoContent(versionId);
 ```
 
+#### Migrating automated producers
+
 Automated producers should use `kind: 'auto-generated'` instead of encoding
 generation as `kind: 'draft'` plus `metadata.generated = 'auto'`. Keep
 source-specific metadata such as `metadata.source` when it provides useful

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -174,8 +174,15 @@ are created automatically when governed content is published.
 ```typescript
 // Manual version snapshot
 await article.mutateVersionAction({
-  kind: 'publication',
-  summary: 'Content published.',
+  kind: 'manual',
+  summary: 'Before the editorial rewrite.',
+});
+
+// Snapshot created by an ingestion or generation worker
+await article.mutateVersionAction({
+  kind: 'auto-generated',
+  summary: 'Planning asset extracted.',
+  metadata: { source: 'planning-asset-ingestion' },
 });
 
 // List version history
@@ -184,6 +191,11 @@ const versions = await article.listVersions();
 // Restore a previous version
 await versions.restoreIntoContent(versionId);
 ```
+
+Automated producers should use `kind: 'auto-generated'` instead of encoding
+generation as `kind: 'draft'` plus `metadata.generated = 'auto'`. Keep
+source-specific metadata such as `metadata.source` when it provides useful
+provenance.
 
 ### References & Drift Detection
 
@@ -503,7 +515,7 @@ thumbnail selection, and save payload behavior as the package editors.
 | `ContentReference` | Junction model for content-to-content links; nullable `targetVersion` pins citation-time `ContentVersion.version` for drift detection |
 | `ContentReview` | AI review result tied to a governance policy |
 | `ContentCorrection` | Post-publication correction record |
-| `ContentVersion` | Content snapshot with kind (`'publication'`, `'manual'`) and transparency metadata |
+| `ContentVersion` | Content snapshot with kind (`'manual'`, `'draft'`, `'review'`, `'publication'`, `'correction'`, or `'auto-generated'`) and transparency metadata |
 | `ContentContribution` | Held inbound submission with approval, rejection, withdrawal, and promotion actions |
 | `ContentContributions` | Contribution collection with web intake, email ingestion, inbox, and contributor views |
 | `ContentContributionType` | Persisted contribution-type override for app-defined intake rules and promotion mapping |
@@ -561,7 +573,7 @@ thumbnail selection, and save payload behavior as the package editors.
 | `ContentReviewResult` | AI review output with findings |
 | `ContentReviewFinding` | Individual issue from a review |
 | `ContentCorrectionType` | `'correction' \| 'retraction' \| 'update' \| 'clarification'` |
-| `ContentVersionKind` | `'publication' \| 'manual'` |
+| `ContentVersionKind` | `'manual' \| 'draft' \| 'review' \| 'publication' \| 'correction' \| 'auto-generated'` |
 | `ContentTransparencyData` | Full transparency report data shape |
 | `ContentPublishReadinessState` | Profile evaluation result |
 

--- a/packages/content/src/__tests__/content-version-kind.test.ts
+++ b/packages/content/src/__tests__/content-version-kind.test.ts
@@ -1,0 +1,103 @@
+import os from 'node:os';
+import path from 'node:path';
+import { getTestDatabase } from '@happyvertical/smrt-core';
+import { syncSchema } from '@happyvertical/sql';
+import { describe, expect, it } from 'vitest';
+import type { ContentVersionKind } from '../content-governance';
+import { ContentVersionCollection } from '../content-versions';
+import manifest from '../manifest/manifest.json';
+import { serializeContentVersion } from '../serialization';
+
+const CONTENT_VERSIONS_SCHEMA = `
+CREATE TABLE IF NOT EXISTS content_versions (
+  id TEXT PRIMARY KEY NOT NULL,
+  slug TEXT NOT NULL,
+  context TEXT NOT NULL DEFAULT '',
+  created_at DATETIME NOT NULL,
+  updated_at DATETIME NOT NULL,
+  content_id TEXT,
+  version INTEGER NOT NULL DEFAULT 1,
+  kind TEXT DEFAULT 'manual',
+  title TEXT,
+  description TEXT,
+  body TEXT,
+  status TEXT,
+  summary TEXT,
+  snapshot TEXT,
+  metadata TEXT,
+  tenant_id TEXT
+);
+CREATE INDEX IF NOT EXISTS content_versions_id_idx ON content_versions (id);
+CREATE UNIQUE INDEX IF NOT EXISTS content_versions_content_id_version_idx ON content_versions (content_id, version);
+`;
+
+describe('ContentVersionKind', () => {
+  it('persists, queries, updates, and serializes auto-generated versions', async () => {
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      url: `file:${path.join(os.tmpdir(), `smrt-content-version-${crypto.randomUUID()}.db`)}`,
+    });
+    await syncSchema({ db, schema: CONTENT_VERSIONS_SCHEMA });
+    const versions = await ContentVersionCollection.create({ db });
+    const kind: ContentVersionKind = 'auto-generated';
+
+    const created = await versions.create({
+      slug: 'generated-version-v1',
+      contentId: crypto.randomUUID(),
+      version: 1,
+      kind,
+      summary: 'Created by planning-asset ingestion',
+      snapshot: { title: 'Generated planning asset' },
+      metadata: { source: 'planning-asset-ingestion' },
+    });
+
+    expect(created.kind).toBe('auto-generated');
+
+    const queried = await versions.list({ where: { kind } });
+    expect(queried).toHaveLength(1);
+    expect(queried[0]?.kind).toBe('auto-generated');
+
+    const persisted = queried[0];
+    if (!persisted) throw new Error('Expected persisted content version');
+    persisted.kind = 'manual';
+    await persisted.save();
+    persisted.kind = kind;
+    persisted.summary = 'Generated snapshot retained';
+    await persisted.save();
+
+    const reloaded = await versions.get(created.id as string);
+    expect(reloaded).toMatchObject({
+      kind: 'auto-generated',
+      summary: 'Generated snapshot retained',
+    });
+    expect(serializeContentVersion(reloaded)).toMatchObject({
+      kind: 'auto-generated',
+      snapshot: { title: 'Generated planning asset' },
+      metadata: { source: 'planning-asset-ingestion' },
+    });
+  });
+
+  it('keeps generated persistence surfaces text-backed and compatible', () => {
+    const versionManifest = manifest.objects[
+      '@happyvertical/smrt-content:ContentVersion'
+    ] as {
+      fields: { kind: { type: string; default?: string } };
+      schema: {
+        ddl: string;
+        columns: { kind: { type: string; default?: string } };
+      };
+    };
+
+    expect(versionManifest.fields.kind).toMatchObject({
+      type: 'text',
+      default: 'manual',
+    });
+    expect(versionManifest.schema.columns.kind).toMatchObject({
+      type: 'TEXT',
+      default: 'manual',
+    });
+    expect(versionManifest.schema.ddl).toContain(
+      '"kind" TEXT DEFAULT \'manual\'',
+    );
+  });
+});

--- a/packages/content/src/__tests__/content-version-kind.test.ts
+++ b/packages/content/src/__tests__/content-version-kind.test.ts
@@ -37,44 +37,48 @@ describe('ContentVersionKind', () => {
       type: 'sqlite',
       url: `file:${path.join(os.tmpdir(), `smrt-content-version-${crypto.randomUUID()}.db`)}`,
     });
-    await syncSchema({ db, schema: CONTENT_VERSIONS_SCHEMA });
-    const versions = await ContentVersionCollection.create({ db });
-    const kind: ContentVersionKind = 'auto-generated';
+    try {
+      await syncSchema({ db, schema: CONTENT_VERSIONS_SCHEMA });
+      const versions = await ContentVersionCollection.create({ db });
+      const kind: ContentVersionKind = 'auto-generated';
 
-    const created = await versions.create({
-      slug: 'generated-version-v1',
-      contentId: crypto.randomUUID(),
-      version: 1,
-      kind,
-      summary: 'Created by planning-asset ingestion',
-      snapshot: { title: 'Generated planning asset' },
-      metadata: { source: 'planning-asset-ingestion' },
-    });
+      const created = await versions.create({
+        slug: 'generated-version-v1',
+        contentId: crypto.randomUUID(),
+        version: 1,
+        kind,
+        summary: 'Created by planning-asset ingestion',
+        snapshot: { title: 'Generated planning asset' },
+        metadata: { source: 'planning-asset-ingestion' },
+      });
 
-    expect(created.kind).toBe('auto-generated');
+      expect(created.kind).toBe('auto-generated');
 
-    const queried = await versions.list({ where: { kind } });
-    expect(queried).toHaveLength(1);
-    expect(queried[0]?.kind).toBe('auto-generated');
+      const queried = await versions.list({ where: { kind } });
+      expect(queried).toHaveLength(1);
+      expect(queried[0]?.kind).toBe('auto-generated');
 
-    const persisted = queried[0];
-    if (!persisted) throw new Error('Expected persisted content version');
-    persisted.kind = 'manual';
-    await persisted.save();
-    persisted.kind = kind;
-    persisted.summary = 'Generated snapshot retained';
-    await persisted.save();
+      const persisted = queried[0];
+      if (!persisted) throw new Error('Expected persisted content version');
+      persisted.kind = 'manual';
+      await persisted.save();
+      persisted.kind = kind;
+      persisted.summary = 'Generated snapshot retained';
+      await persisted.save();
 
-    const reloaded = await versions.get(created.id as string);
-    expect(reloaded).toMatchObject({
-      kind: 'auto-generated',
-      summary: 'Generated snapshot retained',
-    });
-    expect(serializeContentVersion(reloaded)).toMatchObject({
-      kind: 'auto-generated',
-      snapshot: { title: 'Generated planning asset' },
-      metadata: { source: 'planning-asset-ingestion' },
-    });
+      const reloaded = await versions.get(created.id as string);
+      expect(reloaded).toMatchObject({
+        kind: 'auto-generated',
+        summary: 'Generated snapshot retained',
+      });
+      expect(serializeContentVersion(reloaded)).toMatchObject({
+        kind: 'auto-generated',
+        snapshot: { title: 'Generated planning asset' },
+        metadata: { source: 'planning-asset-ingestion' },
+      });
+    } finally {
+      await db.close?.();
+    }
   });
 
   it('keeps generated persistence surfaces text-backed and compatible', () => {

--- a/packages/content/src/content-governance.ts
+++ b/packages/content/src/content-governance.ts
@@ -24,7 +24,8 @@ export type ContentVersionKind =
   | 'draft'
   | 'review'
   | 'publication'
-  | 'correction';
+  | 'correction'
+  | 'auto-generated';
 
 export type ContentCorrectionType = 'fact' | 'safety' | 'copy' | 'custom';
 

--- a/packages/content/src/mock-smrt-client.test.ts
+++ b/packages/content/src/mock-smrt-client.test.ts
@@ -277,7 +277,9 @@ describe('mock-smrt-client', () => {
       summary: 'Fix claim',
     });
     await client.contents.getVersions('content-1');
-    await client.contents.createVersion('content-1', { kind: 'manual' });
+    await client.contents.createVersion('content-1', {
+      kind: 'auto-generated',
+    });
     await client.contents.restoreVersion('content-1', 3);
     await client.contentGovernancePolicies.list();
     await client.contentGovernancePolicies.get('policy-1');
@@ -374,7 +376,7 @@ describe('mock-smrt-client', () => {
         {
           url: '/api/v1/contents/content-1/versions',
           method: 'POST',
-          body: { kind: 'manual' },
+          body: { kind: 'auto-generated' },
         },
         {
           url: '/api/v1/contents/content-1/versions',

--- a/packages/smrt-svelte/AGENTS.md
+++ b/packages/smrt-svelte/AGENTS.md
@@ -82,7 +82,8 @@ the top-of-stack, domain-aware pieces:
 | Forms (`/forms`) | `TextInput`, `Select`, `MoneyInput`, `DateTimeInput`, `Toggle`, `FileUpload`, `AddressInput`, + more (AI-wired inputs use the hooks/browser-ai here) |
 | Module | `ModulePanel` |
 | Settings (`/settings`) | `SettingsCatalog`, `paginateSettingsCatalog` |
-| Workspace (`/workspace`) | `WorkspaceShell`, `NavTree`, `Breadcrumbs`, `ToolsDock`, `RoleShell` |
+| Workspace (`/workspace`) | `AdminShell`, `ShellState`, `TenantNav`, focus tools, settings, activities, and system/app panels |
+| Legacy workspace (`/workspace/legacy`) | First-generation `ToolsDock` compatibility surface during AdminShell migration |
 
 ### Gap primitives & S10 consolidation (L3 #1422)
 
@@ -120,7 +121,8 @@ library. Which barrel for what:
 | `Modal`, `ConfirmDialog`, `LoadingOverlay`, `ProgressBar` | `@happyvertical/smrt-svelte/feedback` |
 | `Container`, `Grid`, `Header`, `Footer`, `PageHeader`, `EmptyState` | `@happyvertical/smrt-svelte/layout` |
 | Chat message bubble, reaction picker, typing indicator | `@happyvertical/smrt-svelte/chat` |
-| Admin shell, nav tree, breadcrumbs, tools dock | `@happyvertical/smrt-svelte/workspace` |
+| Admin shell, tenant navigation, focus tools, settings, and activities | `@happyvertical/smrt-svelte/workspace` |
+| First-generation ToolsDock during AdminShell migration | `@happyvertical/smrt-svelte/workspace/legacy` |
 | Server-paged settings search, selection, and list/detail layout | `@happyvertical/smrt-svelte/settings` |
 
 The package root re-exports `./ui`, `./forms`, etc., so `from
@@ -268,7 +270,9 @@ activities, tenant nav, app/system panels) from `workspace/admin-shell/`.
 The first-generation workspace family (`WorkspaceShell`, `RoleShell`,
 `NavTree`, `Breadcrumbs`, `ToolsDock`) remains in source as migration reference
 only. Do not re-export it from the public `./workspace` barrel just to preserve
-compatibility.
+compatibility. Applications that still need ToolsDock during migration may use
+the explicit `@happyvertical/smrt-svelte/workspace/legacy` subpath; keep legacy
+additions isolated there so the canonical workspace surface remains AdminShell.
 
 **Principles**:
 - SvelteKit-agnostic core — no `$app/state` or `$app/navigation` imports
@@ -349,3 +353,13 @@ Recommended pattern: in the consumer's `+server.ts` endpoint that backs
 unconditionally visible (back-compat). Anytown's hand-coded
 `apps/dashboard/src/lib/server/content-tool-dock.ts` is a candidate for
 migration in a follow-up.
+
+Legacy ToolsDock treats availability fetch failures as degraded presentation
+state: it preserves the current context's last successful tool IDs, labels,
+and badges. Before the first success, or after a context change, it falls back
+to registered-tool metadata so contextual values do not cross boundaries.
+Consumers can read `dock.availabilityError` to surface the current context's
+failure; a context change or later successful refresh clears the signal, and
+success applies the new snapshot.
+Availability is never an authorization boundary—server operations must still
+enforce permissions.

--- a/packages/smrt-svelte/README.md
+++ b/packages/smrt-svelte/README.md
@@ -156,9 +156,18 @@ scaffold adopts AdminShell as its default chrome exactly this way; copy its
 | `@happyvertical/smrt-ui/data` | DataTable, CollectionList/ContentList, CollectionToolbar |
 | `@happyvertical/smrt-svelte/registry` | ModuleUIRegistry for agent admin panels |
 | `@happyvertical/smrt-svelte/workspace` | AdminShell, ShellState, tenant nav, focus tools, settings, activities, and system/app panels |
+| `@happyvertical/smrt-svelte/workspace/legacy` | Opt-in ToolsDock compatibility surface for applications migrating to AdminShell |
 | `@happyvertical/smrt-svelte/browser-ai` | Browser AI client (STT/TTS/LLM adapters, capability detection) |
 | `@happyvertical/smrt-svelte/browser-ai/svelte` | Svelte AI components (VoiceInput, CapabilityGate, etc.) |
 | `@happyvertical/smrt-svelte/styles/tokens.css` | Design tokens CSS |
+
+Legacy ToolsDock availability is presentation-only, not authorization.
+`fetchAvailability` failures intentionally keep controls usable using the
+current context's last-known-good result, or registered-tool metadata after a
+context change. Every tool operation and server endpoint must independently
+enforce permissions. Consumers can surface current-context degraded state
+through `dock.availabilityError`; a context change or later valid refresh
+clears it.
 
 ### Components by Category
 

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -37,6 +37,12 @@
       "import": "./dist/components/workspace/index.js",
       "default": "./dist/components/workspace/index.js"
     },
+    "./workspace/legacy": {
+      "types": "./dist/components/workspace/legacy.d.ts",
+      "svelte": "./dist/components/workspace/legacy.js",
+      "import": "./dist/components/workspace/legacy.js",
+      "default": "./dist/components/workspace/legacy.js"
+    },
     "./workspace/server": {
       "types": "./dist/components/workspace/server/index.d.ts",
       "import": "./dist/components/workspace/server/index.js",

--- a/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/define-tools-dock.test.ts
@@ -86,6 +86,7 @@ describe('defineToolsDock', () => {
     expect(dock.activeTool).toBeNull();
     expect(dock.layout).toBe('rail');
     expect(dock.storageKey).toBeNull();
+    expect(dock.availabilityError).toBeNull();
     expect(dock.availableTools.map((t) => t.id)).toEqual(['chat', 'jobs']);
   });
 
@@ -243,6 +244,51 @@ describe('defineToolsDock', () => {
     expect(dock.availableTools.map((t) => t.id)).toEqual(['jobs']);
   });
 
+  it('drops stale fetchAvailability failures after a newer success', async () => {
+    let rejectFirst: ((reason: Error) => void) | null = null;
+    let resolveSecond: ((value: { id: string }[]) => void) | null = null;
+
+    const fetchAvailability = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ id: string }[]>((_resolve, reject) => {
+            rejectFirst = reject;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ id: string }[]>((resolve) => {
+            resolveSecond = resolve;
+          }),
+      );
+
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+        ],
+        fetchAvailability,
+      }),
+    );
+
+    dock.setContext({ type: 'A' });
+    dock.setContext({ type: 'B' });
+    resolveSecond?.([{ id: 'jobs' }]);
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+
+    rejectFirst?.(new Error('stale failure'));
+    await Promise.resolve();
+    await Promise.resolve();
+    flushSync();
+
+    expect(dock.availableTools.map((tool) => tool.id)).toEqual(['jobs']);
+    expect(dock.availabilityError).toBeNull();
+  });
+
   it('emit / on / unsubscribe', () => {
     const { dock } = track(
       mountDock({
@@ -375,9 +421,10 @@ describe('defineToolsDock', () => {
     expect(dock.availableTools[0].badge).toBeNull();
   });
 
-  it('handles synchronous throws from fetchAvailability without surfacing them', async () => {
+  it('preserves the registered fallback and exposes synchronous availability errors', async () => {
+    const failure = new Error('sync boom');
     const fetchAvailability = vi.fn(() => {
-      throw new Error('sync boom');
+      throw failure;
     });
 
     const { dock } = track(
@@ -393,10 +440,192 @@ describe('defineToolsDock', () => {
     // propagate out of setContext to the caller.
     expect(() => dock.setContext({ type: 'a' })).not.toThrow();
 
-    // The internal `.catch` applies an empty-availability result.
+    // The failure is exposed without replacing the safe initial fallback.
     await new Promise((r) => setTimeout(r, 0));
     flushSync();
-    expect(dock.availableTools).toEqual([]);
+    expect(dock.availableTools.map((tool) => tool.id)).toEqual(['chat']);
+    expect(dock.availabilityError).toBe(failure);
+
+    dock.open('chat');
+    flushSync();
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBe('chat');
+  });
+
+  it('exposes a consumable error for a reasonless rejection', async () => {
+    const fetchAvailability = vi.fn().mockRejectedValueOnce(undefined);
+
+    const { dock } = track(
+      mountDock({
+        tools: [{ id: 'chat', label: 'Chat', component: noopTool }],
+        fetchAvailability,
+      }),
+    );
+
+    dock.setContext({ type: 'route' });
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+
+    expect(dock.availableTools.map((tool) => tool.id)).toEqual(['chat']);
+    expect(dock.availabilityError).toBeInstanceOf(Error);
+    expect((dock.availabilityError as Error).message).toContain(
+      'without a reason',
+    );
+  });
+
+  it('preserves last-known-good availability and badges after a rejected refresh', async () => {
+    const failure = new Error('availability offline');
+    const fetchAvailability = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { id: 'chat', badge: 2 },
+        { id: 'jobs', badge: 7 },
+      ])
+      .mockRejectedValueOnce(failure);
+
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+        ],
+        fetchAvailability,
+      }),
+    );
+
+    dock.setContext({ type: 'route' });
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+    expect(dock.availableTools).toEqual([
+      { id: 'chat', label: 'Chat', badge: 2 },
+      { id: 'jobs', label: 'Jobs', badge: 7 },
+    ]);
+
+    dock.open('jobs');
+    dock.refreshAvailability();
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+
+    expect(dock.availabilityError).toBe(failure);
+    expect(dock.availableTools).toEqual([
+      { id: 'chat', label: 'Chat', badge: 2 },
+      { id: 'jobs', label: 'Jobs', badge: 7 },
+    ]);
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBe('jobs');
+
+    dock.toggle('jobs');
+    flushSync();
+    expect(dock.isOpen).toBe(false);
+    dock.toggle('jobs');
+    flushSync();
+    expect(dock.isOpen).toBe(true);
+    expect(dock.activeTool).toBe('jobs');
+  });
+
+  it('preserves last-known-good availability after malformed entries', async () => {
+    const fetchAvailability = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 'jobs', badge: 4 }])
+      .mockResolvedValueOnce([
+        { label: 'Missing id' },
+      ] as unknown as import('../types.js').AvailableTool[]);
+
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+        ],
+        fetchAvailability,
+      }),
+    );
+
+    dock.setContext({ type: 'route' });
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+    expect(dock.availableTools).toEqual([
+      { id: 'jobs', label: 'Jobs', badge: 4 },
+    ]);
+
+    dock.refreshAvailability();
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+
+    expect(dock.availableTools).toEqual([
+      { id: 'jobs', label: 'Jobs', badge: 4 },
+    ]);
+    expect(dock.availabilityError).toBeInstanceOf(TypeError);
+  });
+
+  it('resets contextual availability before a new-context failure', async () => {
+    const failure = new Error('tenant B unavailable');
+    const fetchAvailability = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: 'jobs', label: 'Tenant A jobs', badge: 9 }])
+      .mockRejectedValueOnce(failure);
+
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', badge: 1, component: noopTool },
+        ],
+        fetchAvailability,
+      }),
+    );
+
+    dock.setContext({ type: 'tenant-a' });
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+    expect(dock.availableTools).toEqual([
+      { id: 'jobs', label: 'Tenant A jobs', badge: 9 },
+    ]);
+
+    dock.setContext({ type: 'tenant-b' });
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+
+    expect(dock.availabilityError).toBe(failure);
+    expect(dock.availableTools).toEqual([
+      { id: 'chat', label: 'Chat', badge: null },
+      { id: 'jobs', label: 'Jobs', badge: 1 },
+    ]);
+  });
+
+  it('recovers after a later successful availability refresh', async () => {
+    const failure = new Error('temporary failure');
+    const fetchAvailability = vi
+      .fn()
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce([{ id: 'jobs', badge: 3 }]);
+
+    const { dock } = track(
+      mountDock({
+        tools: [
+          { id: 'chat', label: 'Chat', component: noopTool },
+          { id: 'jobs', label: 'Jobs', component: noopTool },
+        ],
+        fetchAvailability,
+      }),
+    );
+
+    dock.setContext({ type: 'route' });
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+    expect(dock.availabilityError).toBe(failure);
+    expect(dock.availableTools.map((tool) => tool.id)).toEqual([
+      'chat',
+      'jobs',
+    ]);
+
+    dock.refreshAvailability();
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+    expect(dock.availabilityError).toBeNull();
+    expect(dock.availableTools).toEqual([
+      { id: 'jobs', label: 'Jobs', badge: 3 },
+    ]);
   });
 
   describe('refreshAvailability()', () => {

--- a/packages/smrt-svelte/src/components/workspace/__tests__/legacy-index.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/legacy-index.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import * as legacyWorkspace from '../legacy.js';
+
+describe('legacy workspace barrel', () => {
+  it('exposes the opt-in ToolsDock compatibility surface', () => {
+    expect(legacyWorkspace.ToolsDock).toBeDefined();
+    expect(legacyWorkspace.defineToolsDock).toBeDefined();
+    expect(legacyWorkspace.useToolsDock).toBeDefined();
+  });
+});

--- a/packages/smrt-svelte/src/components/workspace/__tests__/render-tools-dock.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/render-tools-dock.test.ts
@@ -314,4 +314,28 @@ describe('<ToolsDock> rail layout', () => {
     const empty = target.querySelector('.tools-dock__empty');
     expect(empty?.textContent).toContain('No tools');
   });
+
+  it('keeps registered rail controls usable after an initial availability rejection', async () => {
+    const target = render({
+      tools: [{ id: 'chat', label: 'Chat' }],
+      fetchAvailability: async () => {
+        throw new Error('temporary availability failure');
+      },
+      setContextOnMount: { type: 'route' },
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+    flushSync();
+
+    const chatButton = target.querySelector<HTMLButtonElement>(
+      '.tools-dock__rail-button',
+    );
+    expect(chatButton).not.toBeNull();
+    chatButton?.click();
+    flushSync();
+    expect(chatButton?.getAttribute('aria-pressed')).toBe('true');
+    expect(
+      target.querySelector('.tools-dock__panel-header h3')?.textContent,
+    ).toBe('Chat');
+  });
 });

--- a/packages/smrt-svelte/src/components/workspace/legacy.ts
+++ b/packages/smrt-svelte/src/components/workspace/legacy.ts
@@ -1,0 +1,23 @@
+/**
+ * Explicit compatibility entry for the first-generation ToolsDock family.
+ *
+ * The canonical `@happyvertical/smrt-svelte/workspace` surface is AdminShell.
+ * Existing applications that still need ToolsDock while migrating can import
+ * this opt-in subpath without adding legacy components back to that barrel.
+ */
+
+export {
+  type DefineToolsDockOptions,
+  defineToolsDock,
+  TOOLS_DOCK_KEY,
+  type ToolsDockInstance,
+} from './tools-dock/define-tools-dock.svelte.js';
+export { default as ToolsDock } from './tools-dock/ToolsDock.svelte';
+export { tryUseToolsDock, useToolsDock } from './tools-dock/use-tools-dock.js';
+export type {
+  AvailableTool,
+  ToolDef,
+  ToolsDockApi,
+  ToolsDockContext,
+  ToolsDockEvents,
+} from './types.js';

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/define-tools-dock.svelte.ts
@@ -17,7 +17,7 @@
  * @example Register a dock and a tool
  * ```ts
  * // somewhere in a +layout.svelte:
- * import { defineToolsDock } from '@happyvertical/smrt-svelte/workspace';
+ * import { defineToolsDock } from '@happyvertical/smrt-svelte/workspace/legacy';
  * import ChatTool from './ChatTool.svelte';
  *
  * const dock = defineToolsDock({
@@ -80,13 +80,24 @@ export interface DefineToolsDockOptions<
   /** Registered tools. Order is preserved when rendering the activation rail/topbar. */
   tools: ToolDef[];
   /**
-   * Optional backend-driven gating callback. Returns the subset of tools that
-   * should be exposed for the current `context`. When omitted, every
-   * registered tool is treated as available.
+   * Optional backend-driven presentation-gating callback. Returns the subset
+   * of tools that should be exposed for the current `context`. When omitted,
+   * every registered tool is treated as available.
+   *
+   * This is not an authorization boundary. Failures intentionally keep the
+   * dock usable, so every tool operation and server endpoint must enforce its
+   * own permissions independently.
    *
    * The callback may return tool ids that aren't present in `tools` — these
    * are ignored. Conversely, tools missing from the callback's response are
    * hidden from the dock UI.
+   *
+   * A thrown error, rejected promise, or malformed response preserves the
+   * last-known-good availability for the current context and is exposed
+   * through `dock.availabilityError`. Before the first success, and whenever
+   * context changes, the fallback is the registered tool set with registered
+   * labels and badges. A later valid response clears the error and replaces
+   * availability normally.
    *
    * The `ctx` parameter is typed against the factory's `TData` / `TActions`
    * generics — narrow them at the factory site for typed access to
@@ -229,13 +240,39 @@ export function defineToolsDock<
   // reference equality and avoids the `state_proxy_equality_mismatch`
   // warning.
   let rawContextRef: ToolsDockContext | null = null;
-  let availableTools = $state<AvailableTool[]>(
-    registeredTools.map((t) => ({ id: t.id, label: t.label, badge: t.badge })),
-  );
+  let availableTools = $state<AvailableTool[]>(registeredAvailability());
+  let availabilityError = $state<unknown>(null);
 
   // Race-handle: each fetchAvailability call gets a token; only the most
   // recent token may apply its result.
   let availabilityToken = 0;
+
+  function registeredAvailability(): AvailableTool[] {
+    return registeredTools.map((tool) => ({
+      id: tool.id,
+      label: tool.label,
+      badge: tool.badge,
+    }));
+  }
+
+  function isAvailableTool(value: unknown): value is AvailableTool {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return false;
+    }
+    const candidate = value as Record<string, unknown>;
+    if (typeof candidate.id !== 'string' || candidate.id.trim().length === 0) {
+      return false;
+    }
+    if (candidate.label !== undefined && typeof candidate.label !== 'string') {
+      return false;
+    }
+    return (
+      candidate.badge === undefined ||
+      candidate.badge === null ||
+      typeof candidate.badge === 'string' ||
+      (typeof candidate.badge === 'number' && Number.isFinite(candidate.badge))
+    );
+  }
 
   /**
    * Set to `true` once the factory has finished wiring the instance. Used
@@ -431,13 +468,7 @@ export function defineToolsDock<
   function refreshAvailability(): void {
     if (!fetchAvailability) {
       // Static availability — every registered tool.
-      applyAvailability(
-        registeredTools.map((t) => ({
-          id: t.id,
-          label: t.label,
-          badge: t.badge,
-        })),
-      );
+      applyAvailability(registeredAvailability());
       return;
     }
     const token = ++availabilityToken;
@@ -459,12 +490,22 @@ export function defineToolsDock<
     void pending
       .then((result) => {
         if (token !== availabilityToken) return; // stale
-        applyAvailability(Array.isArray(result) ? result : []);
+        if (!Array.isArray(result) || !result.every(isAvailableTool)) {
+          availabilityError = new TypeError(
+            'fetchAvailability must resolve to valid AvailableTool entries',
+          );
+          return;
+        }
+        availabilityError = null;
+        applyAvailability(result);
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         if (token !== availabilityToken) return;
-        // On error, surface zero availability rather than stale state.
-        applyAvailability([]);
+        // Preserve the last-known-good snapshot. Before the first successful
+        // request this is the safe registered-tool fallback seeded above, so a
+        // transient backend failure never makes open()/toggle() inert.
+        availabilityError =
+          error ?? new Error('fetchAvailability rejected without a reason');
       });
   }
 
@@ -567,13 +608,19 @@ export function defineToolsDock<
     if (erased === rawContextRef) return;
     rawContextRef = erased;
     context = erased;
-    if (fetchAvailability) refreshAvailability();
+    if (fetchAvailability) {
+      // A successful snapshot can contain context-specific labels and badges.
+      // Reset those to registration metadata before fetching for a new
+      // context, so a failure cannot carry tenant/user details across it.
+      availabilityError = null;
+      applyAvailability(registeredAvailability());
+      refreshAvailability();
+    }
     // Emit AFTER kicking off availability refresh. The refresh is async and
     // may emit a second event later if it clears `activeTool` — that is
     // the intended behaviour (one event per observable state transition).
-    // `contextChanged: true` fires `'dock:context-changed'`; `stateChanged`
-    // stays false here because `setContext` itself doesn't touch isOpen/
-    // activeTool (the async availability refresh handles that).
+    // `contextChanged: true` fires `'dock:context-changed'`; any observable
+    // availability reset above emits its own legacy change event.
     emitChange({ stateChanged: false, contextChanged: true });
   }
 
@@ -587,6 +634,9 @@ export function defineToolsDock<
     },
     get availableTools() {
       return availableTools;
+    },
+    get availabilityError() {
+      return availabilityError;
     },
     // Internal `context` `$state` is typed as the default-generic shape so
     // the runtime store stays homogeneous. Cast at the public boundary —

--- a/packages/smrt-svelte/src/components/workspace/tools-dock/use-tools-dock.ts
+++ b/packages/smrt-svelte/src/components/workspace/tools-dock/use-tools-dock.ts
@@ -18,7 +18,7 @@
  * @example
  * ```svelte
  * <script lang="ts">
- *   import { useToolsDock } from '@happyvertical/smrt-svelte/workspace';
+ *   import { useToolsDock } from '@happyvertical/smrt-svelte/workspace/legacy';
  *   const dock = useToolsDock();
  * </script>
  *

--- a/packages/smrt-svelte/src/components/workspace/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/types.ts
@@ -112,7 +112,7 @@ export interface ToolDef {
    * ```svelte
    * <script lang="ts">
    *   import type { ToolsDockApi, ToolsDockContext } from
-   *     '@happyvertical/smrt-svelte/workspace';
+   *     '@happyvertical/smrt-svelte/workspace/legacy';
    *
    *   interface MyData { siteSlug: string; contentId: string }
    *   interface MyActions { triggerSave(): void }
@@ -358,6 +358,16 @@ export interface ToolsDockApi<
   readonly activeTool: string | null;
   readonly isOpen: boolean;
   readonly availableTools: ReadonlyArray<AvailableTool>;
+  /**
+   * The current context's latest `fetchAvailability` failure, or `null`
+   * before a failure, after a context change, and after the next successful
+   * refresh. A failure leaves `availableTools` on its last-known-good snapshot
+   * for the current context; a context change resets to registered-tool
+   * metadata before fetching so contextual labels and badges do not cross
+   * boundaries. Optional for structural compatibility with pre-existing
+   * `ToolsDockApi` adapters.
+   */
+  readonly availabilityError?: unknown;
   /**
    * The current dock context (route data, selection, etc.) as supplied via
    * `setContext()`. Typed against the factory's `<TData, TActions>` generics —


### PR DESCRIPTION
## Summary

- Add `auto-generated` to the public `ContentVersionKind` contract and verify create, update, query, SQLite persistence, PostgreSQL/text schema compatibility, serialization, mock-client use, docs, and generated knowledge surfaces.
- Make legacy ToolsDock availability failures preserve a safe current-context snapshot, expose a reactive error signal, reject malformed results, ignore stale outcomes, reset contextual labels/badges across context changes, and recover after later success.
- Publish the maintained compatibility surface at `@happyvertical/smrt-svelte/workspace/legacy` without restoring legacy symbols to the canonical AdminShell barrel.

## Coordinated patch release

This PR contains the two requested fixes in one repository release. Iceboxed Stepper issue #1996 is explicitly excluded.

Release automation should produce the next fixed-group patch (currently expected to be `0.39.12` if `main` does not advance first).

### Downstream migration

After adopting the coordinated release, `projects.happyvertical.com` can:

- replace `kind: 'draft'` plus `metadata.generated = 'auto'` with `kind: 'auto-generated'`;
- retain useful provenance such as `metadata.source = 'planning-asset-ingestion'`;
- backfill matching historical rows and remove the corresponding upstream-work entry;
- replace the static ToolsDock availability workaround with `fetchAvailability`, consume `dock.availabilityError`, and import the compatibility API from `@happyvertical/smrt-svelte/workspace/legacy` while migrating toward AdminShell.

ToolsDock availability is presentation-only; server operations must continue to authorize independently.

## Validation

- `pnpm --filter @happyvertical/smrt-content build`
- `pnpm --filter @happyvertical/smrt-content test` — 45 files, 302 passed, 6 skipped
- `pnpm --filter @happyvertical/smrt-content check`
- `pnpm --filter @happyvertical/smrt-content typecheck`
- `pnpm --filter @happyvertical/smrt-content verify:pack`
- `pnpm --filter @happyvertical/smrt-svelte build`
- `pnpm --filter @happyvertical/smrt-svelte test` — 54 files, 521 passed
- `pnpm --filter @happyvertical/smrt-svelte check`
- `pnpm --filter @happyvertical/smrt-svelte typecheck`
- `pnpm --filter @happyvertical/smrt-svelte verify:pack`
- `pnpm install`
- `pnpm build` — 60/60 tasks
- `pnpm test` — 117/117 tasks
- `pnpm typecheck` — 116/116 tasks
- `pnpm lint`
- `pnpm format`
- `pnpm smrt dev:knowledge-check` — 0 errors, 0 warnings
- `pnpm check:standards` — 60 packages, 0 violations
- `pnpm exec lefthook run pre-push`
- Full seven-lens review-cycle clean on committed diff `4384686f3e77959fa1af0e41bf766bcd53c9b196f337935e7bd022c8607f9d4a`

Closes #1995
Closes #1997

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "019f5c82-27b9-7e81-ba46-e5b51b9aae2d",
  "issue": "happyvertical/smrt#1995",
  "policy_revision": "1.0.0",
  "validation": [
    "content build/test/check/typecheck/verify:pack passed",
    "smrt-svelte build/test/check/typecheck/verify:pack passed",
    "pnpm install passed",
    "pnpm build passed (60/60)",
    "pnpm test passed (117/117)",
    "pnpm typecheck passed (116/116)",
    "pnpm lint and pnpm format passed",
    "pnpm smrt dev:knowledge-check passed (0 errors, 0 warnings)",
    "pnpm check:standards passed (60 packages, 0 violations)",
    "pnpm exec lefthook run pre-push passed",
    "seven-lens review-cycle clean at 4384686f3e77959fa1af0e41bf766bcd53c9b196f337935e7bd022c8607f9d4a"
  ]
}
```

