### PR TITLE
fix(cli): preserve aggregate manifest identities

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -16,7 +16,7 @@ jobs:
   prepare-publish:
     name: Prepare Publish Validation
     runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
-    timeout-minutes: 20
+    timeout-minutes: 30
     outputs:
       should-validate: ${{ steps.prepare.outputs.should_validate }}
 

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -33,6 +33,7 @@ migrations are manifest-driven through registered objects and project manifests.
 
 - **Lazy command loading**: commands loaded on-demand via dynamic import (~100ms overhead on first use)
 - **Manifest discovery**: auto-finds `.smrt/manifest.json` + scans `node_modules/@happyvertical/smrt-*`
+- **Aggregate manifest identity**: preload and schema discovery resolve package ownership per entry (`definition.packageName` before the container), so dependency objects retain their qualified registrations
 - **Class loading order**: config.entryPoint → package.json exports['.'] → package.json main → `./dist/index.js`
 - **Object method exposure**: custom methods on SMRT objects auto-become CLI commands
 

--- a/packages/cli/src/__tests__/cli-generator-aggregate-manifest.test.ts
+++ b/packages/cli/src/__tests__/cli-generator-aggregate-manifest.test.ts
@@ -1,0 +1,135 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CLIGenerator } from '../cli-generator.js';
+import { loadManifest } from '../discovery/manifest-discovery.js';
+
+const { loadLocalTestManifestSyncMock } = vi.hoisted(() => ({
+  loadLocalTestManifestSyncMock: vi.fn(),
+}));
+
+vi.mock('@happyvertical/smrt-core/manifest', () => ({
+  loadLocalTestManifestSync: loadLocalTestManifestSyncMock,
+}));
+
+describe('CLIGenerator aggregate manifest preload', () => {
+  let tempDir: string;
+
+  const qualifiedName =
+    '@happyvertical/smrt-content:ContentFeedSource' as const;
+  const externalDefinition = {
+    className: 'ContentFeedSource',
+    qualifiedName,
+    packageName: '@happyvertical/smrt-content',
+    filePath: '/build/smrt-content/src/content-feed-source.ts',
+    fields: {
+      tenantId: {
+        type: 'text' as const,
+        required: false,
+        _meta: {
+          sqlType: 'UUID',
+          __tenancy: {
+            isTenantIdField: true,
+            mode: 'optional' as const,
+          },
+        },
+      },
+      feedUrl: {
+        type: 'text' as const,
+        required: true,
+      },
+    },
+    decoratorConfig: {
+      tableName: 'content_feed_sources',
+      tenantScoped: { mode: 'optional' as const },
+    },
+    schema: {
+      tableName: 'content_feed_sources',
+      ddl: '',
+      columns: {
+        tenant_id: {
+          type: 'UUID' as const,
+          referenceKind: 'tenantId' as const,
+        },
+        feed_url: { type: 'TEXT' as const, notNull: true },
+      },
+      indexes: [],
+      version: 'fixture',
+    },
+  };
+
+  beforeEach(async () => {
+    ObjectRegistry.clear();
+    tempDir = await mkdtemp(join(tmpdir(), 'smrt-cli-aggregate-test-'));
+    loadLocalTestManifestSyncMock.mockReturnValue({
+      packageName: '@test/app',
+      objects: {
+        '@test/app:LocalObject': {
+          className: 'LocalObject',
+          qualifiedName: '@test/app:LocalObject',
+          packageName: '@test/app',
+        },
+        [qualifiedName]: externalDefinition,
+      },
+    });
+  });
+
+  afterEach(async () => {
+    ObjectRegistry.clear();
+    loadLocalTestManifestSyncMock.mockReset();
+    vi.restoreAllMocks();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('preserves external qualified identity and metadata after duplicate discovery', async () => {
+    const cli = new CLIGenerator({ prompt: false, colors: false });
+    const internalCli = cli as unknown as {
+      ensureManifestLoaded(): Promise<void>;
+      tryLoadUserClasses(): Promise<void>;
+    };
+    vi.spyOn(internalCli, 'tryLoadUserClasses').mockResolvedValue(undefined);
+
+    await internalCli.ensureManifestLoaded();
+
+    const preloaded = ObjectRegistry.getClassByQualifiedName(qualifiedName);
+    expect(preloaded).toBeDefined();
+    expect(preloaded?.packageName).toBe('@happyvertical/smrt-content');
+    expect(preloaded?.qualifiedName).toBe(qualifiedName);
+    expect(preloaded?.fields.get('tenantId')?._meta).toMatchObject({
+      sqlType: 'UUID',
+      __tenancy: {
+        isTenantIdField: true,
+        mode: 'optional',
+      },
+    });
+
+    const packageDir = join(
+      tempDir,
+      'node_modules',
+      '@happyvertical',
+      'content',
+    );
+    await mkdir(packageDir, { recursive: true });
+    const packageManifestPath = join(packageDir, 'manifest.json');
+    await writeFile(
+      packageManifestPath,
+      JSON.stringify({
+        packageName: '@happyvertical/smrt-content',
+        objects: { [qualifiedName]: externalDefinition },
+      }),
+    );
+
+    await loadManifest(packageManifestPath);
+
+    const rediscovered = ObjectRegistry.getClassByQualifiedName(qualifiedName);
+    expect(rediscovered).toBe(preloaded);
+    expect(rediscovered?.fields.get('tenantId')?._meta).toEqual(
+      preloaded?.fields.get('tenantId')?._meta,
+    );
+    expect(
+      ObjectRegistry.getClassByQualifiedName('@test/app:ContentFeedSource'),
+    ).toBeUndefined();
+  });
+});

--- a/packages/cli/src/cli-generator.ts
+++ b/packages/cli/src/cli-generator.ts
@@ -24,6 +24,7 @@ import {
   type ParsedArgs,
   parseCliArgs,
 } from '@happyvertical/utils';
+import { resolveManifestEntryPackageName } from './discovery/manifest-identity.js';
 
 // Read version from package.json (ESM-compatible)
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -562,7 +563,11 @@ export class CLIGenerator {
         ObjectRegistry.registerFromManifest(
           name,
           objectDef,
-          manifest.packageName,
+          resolveManifestEntryPackageName(
+            name,
+            objectDef,
+            manifest.packageName,
+          ),
         );
       }
     }

--- a/packages/cli/src/discovery/index.ts
+++ b/packages/cli/src/discovery/index.ts
@@ -8,5 +8,5 @@ export {
   discoverManifests,
   loadManifest,
   loadManifestFile,
-  resolveManifestEntryPackageName,
 } from './manifest-discovery.js';
+export { resolveManifestEntryPackageName } from './manifest-identity.js';

--- a/packages/cli/src/discovery/manifest-discovery.ts
+++ b/packages/cli/src/discovery/manifest-discovery.ts
@@ -11,11 +11,9 @@ import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { createLogger } from '@happyvertical/logger';
 import type { SmartObjectDefinition } from '@happyvertical/smrt-core';
-import {
-  getPackageFromQualifiedName,
-  ObjectRegistry,
-} from '@happyvertical/smrt-core';
+import { ObjectRegistry } from '@happyvertical/smrt-core';
 import glob from 'fast-glob';
+import { resolveManifestEntryPackageName } from './manifest-identity.js';
 
 const logger = createLogger({ level: 'info' });
 
@@ -40,25 +38,6 @@ export interface LoadedManifestFile {
   version?: string;
   smrtDependencies?: unknown;
   [key: string]: unknown;
-}
-
-export function resolveManifestEntryPackageName(
-  name: string,
-  definition: SmartObjectDefinition,
-  fallback?: string,
-): string | undefined {
-  // Only explicit entry provenance may override the containing manifest.
-  // Qualified keys and qualifiedName are identity values that runtime:check
-  // validates, so neither may let a malformed local entry reclassify itself
-  // as external when the container already has an owner.
-  return (
-    definition.packageName ||
-    fallback ||
-    getPackageFromQualifiedName(name) ||
-    (definition.qualifiedName
-      ? getPackageFromQualifiedName(definition.qualifiedName)
-      : undefined)
-  );
 }
 
 /**

--- a/packages/cli/src/discovery/manifest-identity.ts
+++ b/packages/cli/src/discovery/manifest-identity.ts
@@ -1,0 +1,28 @@
+import type { SmartObjectDefinition } from '@happyvertical/smrt-core';
+import { getPackageFromQualifiedName } from '@happyvertical/smrt-core';
+
+/**
+ * Resolve the package that owns one manifest entry.
+ *
+ * Aggregate consumer manifests contain dependency entries alongside local
+ * objects. Entry-level provenance must win over the containing manifest so
+ * those dependencies retain their qualified registry identities.
+ */
+export function resolveManifestEntryPackageName(
+  name: string,
+  definition: SmartObjectDefinition,
+  fallback?: string,
+): string | undefined {
+  // Only explicit entry provenance may override the containing manifest.
+  // Qualified keys and qualifiedName are identity values that runtime:check
+  // validates, so neither may let a malformed local entry reclassify itself
+  // as external when the container already has an owner.
+  return (
+    definition.packageName ||
+    fallback ||
+    getPackageFromQualifiedName(name) ||
+    (definition.qualifiedName
+      ? getPackageFromQualifiedName(definition.qualifiedName)
+      : undefined)
+  );
+}


### PR DESCRIPTION
## Summary

- preserve entry-level package ownership when the CLI preloads aggregate consumer manifests
- share the same ownership resolver with dependency-manifest discovery so duplicates cannot replace or strand qualified registrations
- cover external qualified identity, UUID/tenancy field metadata, and duplicate dependency loading with a regression test
- allow publish preparation up to 30 minutes for its forced clean 60-package build

## Validation

- `pnpm --filter @happyvertical/smrt-cli test` — 55 files, 780 passed, 4 skipped
- `pnpm --filter @happyvertical/smrt-cli typecheck`
- `pnpm --filter @happyvertical/smrt-cli build`
- `pnpm exec biome ci --diagnostic-level=error` on changed TypeScript files
- `yamllint .github/workflows/publish-dry-run.yml`
- `actionlint .github/workflows/publish-dry-run.yml`
- `pnpm smrt dev:knowledge-check` — 0 errors, 0 warnings
- exact Anytown aggregate artifact replay: `db:migrate`, `db:status`, and `db:diff` all resolve 570 objects; live schema contract passed
- pre-commit and pre-push repository hooks passed

Closes #2000

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-6289-2000-timeout-20260713",
  "issue": "happyvertical/smrt#2000",
  "policy_revision": "1.0.0",
  "validation": [
    "CLI tests passed: 780 passed, 4 skipped",
    "CLI typecheck and build passed",
    "Biome passed on changed TypeScript files",
    "yamllint and actionlint passed for publish-dry-run workflow",
    "SMRT knowledge freshness passed with 0 errors and 0 warnings",
    "exact Anytown artifact passed db:migrate, db:status, db:diff, and schema contract",
    "pre-commit and pre-push repository hooks passed"
  ]
}
```
