### PR TITLE
fix(users): harden OIDC profile provisioning

### DIFF
--- a/packages/core/src/__tests__/issue-343-external-sti-manifest-loading.test.ts
+++ b/packages/core/src/__tests__/issue-343-external-sti-manifest-loading.test.ts
@@ -175,9 +175,9 @@ describe('Issue #343: External Package STI Classes Manifest Loading', () => {
       expect(personDef.decoratorConfig?.tableStrategy).toBe('sti');
 
       // As of v0.17: Manifest includes inherited fields inline (build-time merging)
-      // Person now has 10 fields from Profile in the manifest
+      // Person now has 11 fields from Profile in the manifest
       // (includes tenantId, created_at, updated_at from SmrtObject base)
-      expect(Object.keys(personDef.fields || {}).length).toBe(10);
+      expect(Object.keys(personDef.fields || {}).length).toBe(11);
     }
 
     // Verify Profile is in the manifest (the STI base)
@@ -274,9 +274,9 @@ describe('Issue #343: External Package STI Classes Manifest Loading', () => {
     console.log('Person fields:', Array.from(fields.keys()));
     console.log('Person fields count:', fields.size);
 
-    // FIXED: Person now has 10 fields because manifest includes inherited fields
+    // FIXED: Person now has 11 fields because manifest includes inherited fields
     // (includes tenantId, created_at, updated_at from SmrtObject base)
-    expect(fields.size).toBe(10); // Exactly 10 inherited fields from Profile
+    expect(fields.size).toBe(11); // Exactly 11 inherited fields from Profile
 
     // Check specific fields from Profile (inherited at build time)
     expect(fields.has('created_at')).toBe(true);
@@ -284,6 +284,7 @@ describe('Issue #343: External Package STI Classes Manifest Loading', () => {
     expect(fields.has('tenantId')).toBe(true);
     expect(fields.has('typeId')).toBe(true);
     expect(fields.has('email')).toBe(true);
+    expect(fields.has('emailKey')).toBe(true);
     expect(fields.has('name')).toBe(true);
     expect(fields.has('description')).toBe(true);
     expect(fields.has('metadata')).toBe(true);

--- a/packages/core/src/migrations/backfill-tracker.spec.ts
+++ b/packages/core/src/migrations/backfill-tracker.spec.ts
@@ -1,6 +1,12 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { type DatabaseInterface, getDatabase } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { BackfillTracker } from './backfill-tracker.js';
+import {
+  BackfillTableUnavailableError,
+  BackfillTracker,
+} from './backfill-tracker.js';
 
 describe('BackfillTracker', () => {
   let db: DatabaseInterface;
@@ -167,6 +173,135 @@ describe('BackfillTracker', () => {
     db.query = originalQuery as typeof db.query;
   });
 
+  it('shares initialization across tracker instances for one database client', async () => {
+    let createCalls = 0;
+    const originalQuery = db.query.bind(db);
+    db.query = ((sql: string, ...args: unknown[]) => {
+      if (sql.includes('CREATE TABLE') && sql.includes('_smrt_backfills')) {
+        createCalls += 1;
+      }
+      return originalQuery(sql as unknown as string, ...(args as []));
+    }) as unknown as typeof db.query;
+
+    await Promise.all([
+      new BackfillTracker({ db }).initialize(),
+      new BackfillTracker({ db }).initialize(),
+      new BackfillTracker({ db }).initialize(),
+    ]);
+
+    expect(createCalls).toBe(1);
+    db.query = originalQuery as typeof db.query;
+  });
+
+  it('does not cache transaction-local DDL that is later rolled back', async () => {
+    const transaction = db.transaction;
+    if (!transaction)
+      throw new Error('SQLite test database requires transaction().');
+
+    await expect(
+      transaction.call(db, async (tx) => {
+        await new BackfillTracker({ db: tx }).initialize();
+        throw new Error('roll back tracker initialization');
+      }),
+    ).rejects.toThrow('roll back tracker initialization');
+
+    const freshTracker = new BackfillTracker({ db });
+    await expect(freshTracker.isApplied('after-rollback')).resolves.toBe(false);
+  });
+
+  it('skips transaction DDL after inheriting durable root initialization', async () => {
+    await tracker.recordApplied('root-ready');
+    const transaction = db.transaction;
+    if (!transaction)
+      throw new Error('SQLite test database requires transaction().');
+
+    await transaction.call(db, async (tx) => {
+      let transactionCreates = 0;
+      const observedTx = new Proxy(tx, {
+        get(target, property, receiver) {
+          if (property === 'query') {
+            return async (sql: string, ...params: unknown[]) => {
+              if (
+                sql.includes('CREATE TABLE') &&
+                sql.includes('_smrt_backfills')
+              ) {
+                transactionCreates += 1;
+              }
+              return target.query(sql, ...params);
+            };
+          }
+          const value = Reflect.get(target, property, receiver);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+      BackfillTracker.inheritInitialization(observedTx, db);
+
+      await expect(
+        new BackfillTracker({ db: observedTx }).isApplied('root-ready'),
+      ).resolves.toBe(true);
+      expect(transactionCreates).toBe(0);
+    });
+  });
+
+  it('does not reuse initialization across fresh clients with the same URL', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'smrt-backfill-tracker-'));
+    const url = join(directory, 'tracker.sqlite');
+    const firstDb = await getDatabase({
+      type: 'sqlite',
+      url,
+      dbid: 'backfill-same-url-first',
+    });
+    let secondDb: DatabaseInterface | undefined;
+
+    try {
+      await new BackfillTracker({ db: firstDb }).initialize();
+      await firstDb.query('DROP TABLE _smrt_backfills');
+      await closeDatabase(firstDb);
+
+      secondDb = await getDatabase({
+        type: 'sqlite',
+        url,
+        dbid: 'backfill-same-url-second',
+      });
+      await expect(
+        new BackfillTracker({ db: secondDb }).isApplied('fresh-client'),
+      ).resolves.toBe(false);
+    } finally {
+      await closeDatabase(secondDb);
+      await closeDatabase(firstDb);
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it('reinitializes after the table is dropped on the same client', async () => {
+    await tracker.initialize();
+    await db.query('DROP TABLE _smrt_backfills');
+
+    await tracker.initialize();
+    await expect(
+      new BackfillTracker({ db }).isApplied('same-client-reset'),
+    ).resolves.toBe(false);
+  });
+
+  it('invalidates the root cache when an inherited transaction finds the table missing', async () => {
+    await tracker.initialize();
+    await db.query('DROP TABLE _smrt_backfills');
+    const transaction = db.transaction;
+    if (!transaction)
+      throw new Error('SQLite test database requires transaction().');
+
+    await expect(
+      transaction.call(db, async (tx) => {
+        BackfillTracker.inheritInitialization(tx, db);
+        return new BackfillTracker({ db: tx }).isApplied('missing-in-tx');
+      }),
+    ).rejects.toBeInstanceOf(BackfillTableUnavailableError);
+
+    await expect(
+      new BackfillTracker({ db }).isApplied('root-recovers'),
+    ).resolves.toBe(false);
+  });
+
   it('initialize allows retry after a failed CREATE TABLE', async () => {
     let attempts = 0;
     const originalQuery = db.query.bind(db);
@@ -192,3 +327,14 @@ describe('BackfillTracker', () => {
     db.query = originalQuery as typeof db.query;
   });
 });
+
+async function closeDatabase(
+  database: DatabaseInterface | undefined,
+): Promise<void> {
+  const close = (
+    database as
+      | (DatabaseInterface & { close?: () => Promise<void> })
+      | undefined
+  )?.close;
+  if (close) await close.call(database).catch(() => undefined);
+}

--- a/packages/core/src/migrations/backfill-tracker.ts
+++ b/packages/core/src/migrations/backfill-tracker.ts
@@ -26,16 +26,27 @@ export interface BackfillRecord {
   packageName: string | null;
 }
 
+/**
+ * A tracker query proved that its inherited root initialization is stale.
+ *
+ * Transaction coordinators must roll back the current transaction, refresh
+ * the root tracker outside that transaction, and retry with a fresh handle.
+ */
+export class BackfillTableUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super('The shared _smrt_backfills table is unavailable.', { cause });
+    this.name = 'BackfillTableUnavailableError';
+  }
+}
+
+// Only root adapters can establish a durable shared initialization. A tracker
+// created around a transaction handle may have its DDL rolled back later, so
+// transaction-local successes must never poison this cache.
+const initializationByObject = new WeakMap<object, Promise<void>>();
+const inheritedInitializationByHandle = new WeakMap<object, object>();
+
 export class BackfillTracker {
   private readonly db: DatabaseInterface;
-  /**
-   * Memoized initialization promise. Storing the promise (rather than a
-   * `boolean` flag set after the DDL completes) makes `initialize()` safe
-   * under concurrency: multiple parallel callers all `await` the same
-   * in-flight promise instead of independently re-running the DDL. On
-   * error the slot is cleared so the next caller retries — a transient
-   * failure doesn't permanently poison the instance.
-   */
   private initializePromise: Promise<void> | null = null;
 
   constructor(options: BackfillTrackerOptions) {
@@ -43,10 +54,79 @@ export class BackfillTracker {
   }
 
   /**
+   * Mark a transaction handle as inheriting a table initialized durably by its
+   * root adapter. Framework transaction coordinators use this after root DDL
+   * commits so transaction-local trackers can skip redundant `CREATE TABLE`.
+   */
+  static inheritInitialization(
+    db: DatabaseInterface,
+    rootDb: DatabaseInterface,
+  ): void {
+    inheritedInitializationByHandle.set(
+      db as object,
+      databaseTargetIdentity(rootDb),
+    );
+  }
+
+  /**
+   * Suppress lazy DDL on a caller-owned transaction.
+   *
+   * Marker reads may proceed when the table already exists. A missing table
+   * raises `BackfillTableUnavailableError` so the caller can fail closed or
+   * retry with a root adapter.
+   */
+  static requireExistingTable(db: DatabaseInterface): void {
+    inheritedInitializationByHandle.set(
+      db as object,
+      databaseTargetIdentity(db),
+    );
+  }
+
+  /** Forget a root initialization after a schema lifecycle reset. */
+  static invalidateInitialization(db: DatabaseInterface): void {
+    deleteSharedInitialization(databaseTargetIdentity(db));
+  }
+
+  /**
    * Create the `_smrt_backfills` table if it doesn't already exist.
    * Safe to call repeatedly and concurrently.
    */
   async initialize(): Promise<void> {
+    if (inheritedInitializationByHandle.has(this.db as object)) {
+      return;
+    }
+
+    const target = databaseTargetIdentity(this.db);
+    const existing = getSharedInitialization(target);
+    if (existing) {
+      await existing;
+      if (!isRootDatabase(this.db)) return;
+      try {
+        await this.db.query('SELECT 1 FROM _smrt_backfills LIMIT 1');
+        return;
+      } catch (error) {
+        if (!isMissingBackfillTableError(error)) throw error;
+        if (getSharedInitialization(target) === existing) {
+          deleteSharedInitialization(target);
+        }
+        return this.initialize();
+      }
+    }
+
+    if (isRootDatabase(this.db)) {
+      const initialization = this.db
+        .query(CREATE_SMRT_BACKFILLS_TABLE)
+        .then(() => undefined)
+        .catch((error) => {
+          if (getSharedInitialization(target) === initialization) {
+            deleteSharedInitialization(target);
+          }
+          throw error;
+        });
+      setSharedInitialization(target, initialization);
+      return initialization;
+    }
+
     if (!this.initializePromise) {
       this.initializePromise = this.db
         .query(CREATE_SMRT_BACKFILLS_TABLE)
@@ -61,8 +141,7 @@ export class BackfillTracker {
 
   /** Has the backfill named `name` already run? */
   async isApplied(name: string): Promise<boolean> {
-    await this.initialize();
-    const result = await this.db.query(
+    const result = await this.queryBackfillTable(
       'SELECT 1 FROM _smrt_backfills WHERE name = ? LIMIT 1',
       name,
     );
@@ -78,8 +157,7 @@ export class BackfillTracker {
     name: string,
     options: { description?: string; packageName?: string } = {},
   ): Promise<void> {
-    await this.initialize();
-    await this.db.query(
+    await this.queryBackfillTable(
       `INSERT INTO _smrt_backfills (name, description, package_name)
        VALUES (?, ?, ?)
        ON CONFLICT (name) DO NOTHING`,
@@ -134,8 +212,7 @@ export class BackfillTracker {
 
   /** List every recorded backfill, oldest first. */
   async listApplied(): Promise<BackfillRecord[]> {
-    await this.initialize();
-    const result = await this.db.query(
+    const result = await this.queryBackfillTable(
       'SELECT name, applied_at, description, package_name FROM _smrt_backfills ORDER BY applied_at ASC, name ASC',
     );
     return result.rows.map((row) => ({
@@ -145,6 +222,95 @@ export class BackfillTracker {
       packageName: row.package_name == null ? null : String(row.package_name),
     }));
   }
+
+  private async queryBackfillTable(sql: string, ...params: unknown[]) {
+    await this.initialize();
+    try {
+      return await this.db.query(sql, ...params);
+    } catch (error) {
+      if (!isMissingBackfillTableError(error)) throw error;
+      const inheritedRoot = inheritedInitializationByHandle.get(
+        this.db as object,
+      );
+      this.resetInitialization(inheritedRoot);
+      if (inheritedRoot) throw new BackfillTableUnavailableError(error);
+      await this.initialize();
+      return this.db.query(sql, ...params);
+    }
+  }
+
+  private resetInitialization(inheritedRoot?: object): void {
+    this.initializePromise = null;
+    inheritedInitializationByHandle.delete(this.db as object);
+    deleteSharedInitialization(databaseTargetIdentity(this.db));
+    if (inheritedRoot) deleteSharedInitialization(inheritedRoot);
+  }
+}
+
+function databaseTargetIdentity(db: DatabaseInterface): object {
+  const client = db.client;
+  return client !== null &&
+    (typeof client === 'object' || typeof client === 'function')
+    ? client
+    : db;
+}
+
+function isRootDatabase(db: DatabaseInterface): boolean {
+  return typeof db.beginTransaction === 'function';
+}
+
+function getSharedInitialization(target: object): Promise<void> | undefined {
+  return initializationByObject.get(target);
+}
+
+function setSharedInitialization(
+  target: object,
+  initialization: Promise<void>,
+): void {
+  initializationByObject.set(target, initialization);
+}
+
+function deleteSharedInitialization(target: object): void {
+  initializationByObject.delete(target);
+}
+
+function isMissingBackfillTableError(error: unknown): boolean {
+  const pending: unknown[] = [error];
+  const seen = new Set<unknown>();
+  const missingPattern =
+    /(?:no such table|does not exist|doesn't exist|unknown table|not found)/iu;
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (typeof current === 'string') {
+      if (current.includes('_smrt_backfills') && missingPattern.test(current)) {
+        return true;
+      }
+      continue;
+    }
+    if (!current || typeof current !== 'object' || seen.has(current)) continue;
+    seen.add(current);
+    if (
+      current instanceof Error &&
+      current.message.includes('_smrt_backfills') &&
+      missingPattern.test(current.message)
+    ) {
+      return true;
+    }
+    const details = current as {
+      cause?: unknown;
+      context?: unknown;
+      details?: unknown;
+      originalError?: unknown;
+    };
+    pending.push(
+      details.cause,
+      details.context,
+      details.details,
+      details.originalError,
+    );
+    if (current instanceof AggregateError) pending.push(...current.errors);
+  }
+  return false;
 }
 
 /**

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -12,6 +12,7 @@
 // Backfill tracking (data corrections, not schema migrations)
 export {
   type BackfillRecord,
+  BackfillTableUnavailableError,
   BackfillTracker,
   type BackfillTrackerOptions,
 } from './backfill-tracker.js';

--- a/packages/profiles/AGENTS.md
+++ b/packages/profiles/AGENTS.md
@@ -4,7 +4,7 @@ Central identity system with multi-auth, relationships, controlled metadata, and
 
 ## Models
 
-- **Profile** (STI base → Bot, Organization, Person): email (globally unique), `typeId` FK to ProfileType, plus a `metadata` `@oneToMany('ProfileMetadata')` relationship for controlled per-profile values.
+- **Profile** (STI base → Bot, Organization, Person): email (globally unique exact value), readonly indexed `emailKey` derived with `normalizeIdentityEmail()` for adapter-independent identity lookup, `typeId` FK to ProfileType, plus a `metadata` `@oneToMany('ProfileMetadata')` relationship for controlled per-profile values.
 - **ProfileAsset**: dedicated owned-asset join in `profile_assets` with `relationship` and `sortOrder`.
 - **ProfileRelationship**: bidirectional — creating one auto-creates reciprocal inverse. `contextProfileId` for tertiary relationships. `ProfileRelationshipTerm` tracks start/end dates.
 - **ProfileMetafield**: controlled vocabulary with `validationSchema`. **ProfileMetadata**: per-profile values linked to metafields.
@@ -15,7 +15,7 @@ Central identity system with multi-auth, relationships, controlled metadata, and
 | Model | Pattern |
 |-------|---------|
 | NostrIdentity | Encrypted keypair (AES-256-GCM). Requires `SERVER_MASTER_SECRET` env var for decryption. NIP-05 address generation. |
-| OidcIdentity | Multiple issuers (Keycloak/Google/GitHub). Lookup by `issuer + subject` pair. `findOrCreate()` for first login. |
+| OidcIdentity | Multiple issuers (Keycloak/Google/GitHub). Lookup by `issuer + subject` pair. Transactional provisioning derives the readonly nullable unique `identityKey` and backfills legacy rows. |
 | ApiKey | SHA-256 hashed. **Plaintext returned once only** on `generate()`. `keyPrefix` for identification. Scope-based with expiry. |
 | MagicLinkToken | One-time token with expiry for passwordless auth. |
 
@@ -24,7 +24,19 @@ Central identity system with multi-auth, relationships, controlled metadata, and
 Auth helpers in `src/auth/` build profiles from external identity claims:
 
 - `resolveIdentity()` — top-level dispatcher that returns/creates a Profile from Nostr signatures, OIDC claims, magic link tokens, or API keys.
-- `createProfileFromOidc(claims, provider)` — creates `Profile` + `OidcIdentity` for first-time OIDC sign-in.
+- `createProfileFromOidc(claims, provider, options)` — creates `Profile` + `OidcIdentity` for first-time OIDC sign-in using a transaction-capable root database in `options.db`.
+- `ProfileCollection.findUniqueGlobalPersonByEmail(email)` — supported
+  verified-identity lookup; fails closed on tenant-scoped, non-Person, or
+  duplicate case-insensitive matches.
+- `ProfileCollection.requireCanonicalGlobalPerson(profileId, email?)` —
+  validates an application-selected Profile against the same canonical global
+  Person invariant.
+- `ProfileCollection.reserveCanonicalIdentityEmail(profileId, email?)` —
+  validates and synchronizes the private unique
+  `oidc_profile_email_reservations.email_key` used as the database arbiter for
+  concurrent external-identity provisioning. Omitting `email` uses the
+  Profile's stored address, moving or removing an existing reservation as the
+  canonical Profile changes.
 - `createProfileFromNostr(email, nostrData)` — creates `Profile` + `NostrIdentity` for Nostr-authenticated users.
 
 ## Key Methods
@@ -48,6 +60,52 @@ import { smrtProfilesGenerateBioPrompt } from '@happyvertical/smrt-profiles';
 
 - **SERVER_MASTER_SECRET required** for Nostr private key decryption — centralized key management
 - **API key never returned again**: `ApiKey.generate()` returns plaintext once; only `keyPrefix` visible later
-- **OIDC unique per issuer+subject**: same subject from different issuers = different identities
-- **Email unique across all profiles**: DB-level unique constraint, not per-tenant
+- **OIDC unique per issuer+subject**: same subject from different issuers =
+  different identities. Both claims are opaque and case-sensitive; preserve
+  exact whitespace after using trim only to reject blank values.
+- **OIDC identity mutations are trusted-only**: generated REST, MCP, and CLI
+  surfaces are read-only. Link or update identities through transactional
+  provisioning APIs so callers cannot rebind issuer/subject authority to an
+  arbitrary Profile. Deprecated `OidcIdentity.findOrCreate()` preserves only
+  transaction-safe exact-link reuse and refuses to create new links;
+  `OidcIdentityCollection.linkToProfile()` and `Profile.linkOidcIdentity()`
+  delegate to that same non-creating compatibility path.
+- **Apply schema migrations for identity race keys**: run `smrt db:status`,
+  `smrt db:migrate`, then `smrt db:status` before deploying. Transactional OIDC
+  provisioning populates `OidcIdentity.identityKey` and
+  `oidc_profile_email_reservations`; legacy rows reserve an address only after
+  safe validation. Stop/upgrade old Profile writers, then run the public,
+  transactional and idempotent `backfillProfileEmailKeys(db)` from one deploy
+  process. Verified-email provisioning and public email-key lookup require the
+  standard `_smrt_backfills` readiness marker and fail closed immediately when
+  it is absent. This keeps table scans in the explicit deploy step; runtime
+  reads use the indexed key and validate only returned candidates.
+- **Public OIDC provisioning requires transactions**:
+  `createProfileFromOidc()` owns a root transaction or uses a savepoint on an
+  already-bound handle. Root adapters must expose `beginTransaction`;
+  transaction-only handles are ambiguous and fail closed. Pass the root
+  database for adapters without nested savepoints, including DuckDB;
+  provisioning fails before durable writes if neither path is safe. Trusted
+  framework packages use the private
+  `@happyvertical/smrt-profiles/internal/oidc-provisioning` subpath instead of
+  duplicating adapter probing, locking, or retry policy, and supply both exact
+  issuer/subject and normalized-email lock keys in deterministic order. The
+  coordinator additionally serializes all SQLite/DuckDB provisioning
+  transactions per database URL because those adapters cannot overlap
+  unrelated root transactions safely and retries bounded PostgreSQL
+  deadlock/serialization failures. New OIDC Profiles use per-profile,
+  non-semantic slugs so duplicate display names never invoke natural-key upsert.
+  Caller-owned transactions never execute `_smrt_backfills` DDL; the table must
+  already exist or the caller must retry with the root database.
+- **Profile-only OIDC linking fails closed on existing email matches**:
+  `createProfileFromOidc()` preserves exact issuer/subject reuse, but profiles
+  cannot prove whether a User owns a same-email Profile. New identities therefore
+  never attach to an existing email match through this helper. Use
+  `UserCollection.getOrCreateFromOidc()` for owner-aware verified-email reuse and
+  its supported transaction-bound resolver hook.
+- **Email storage and identity matching differ**: `Profile.email` has an
+  exact-value DB constraint. Identity boundaries query readonly indexed
+  `Profile.emailKey`, derived by the shared TypeScript
+  `normalizeIdentityEmail()` helper rather than adapter-specific SQL casing or
+  trimming, and deliberately fail closed on duplicate normalized keys.
 - **Optional tenancy** on Profile; AuditLog allows super-admin bypass

--- a/packages/profiles/AGENTS.md
+++ b/packages/profiles/AGENTS.md
@@ -95,12 +95,18 @@ import { smrtProfilesGenerateBioPrompt } from '@happyvertical/smrt-profiles';
   unrelated root transactions safely and retries bounded PostgreSQL
   deadlock/serialization failures. New OIDC Profiles use per-profile,
   non-semantic slugs so duplicate display names never invoke natural-key upsert.
-  Caller-owned transactions never execute `_smrt_backfills` DDL; the table must
-  already exist or the caller must retry with the root database.
+  Caller-owned transactions never execute `_smrt_backfills` DDL; paths that
+  perform canonical email lookup or reservation require the table to already
+  exist or the caller must retry with the root database. Exact issuer/subject
+  reuse skips the email-key readiness-marker lookup, but root coordination still
+  initializes the shared tracker table. Caller-owned exact reuse does not
+  consult the tracker and therefore does not require that table.
 - **Profile-only OIDC linking fails closed on existing email matches**:
-  `createProfileFromOidc()` preserves exact issuer/subject reuse, but profiles
-  cannot prove whether a User owns a same-email Profile. New identities therefore
-  never attach to an existing email match through this helper. Use
+  `createProfileFromOidc()` preserves exact issuer/subject reuse, including
+  legacy tenant-scoped and non-Person links, but profiles cannot prove whether a
+  User owns a same-email Profile. New identities therefore never attach to an
+  existing email match through this helper; User/session provisioning still
+  rejects unsafe linked Profiles before creating authentication state. Use
   `UserCollection.getOrCreateFromOidc()` for owner-aware verified-email reuse and
   its supported transaction-bound resolver hook.
 - **Email storage and identity matching differ**: `Profile.email` has an

--- a/packages/profiles/README.md
+++ b/packages/profiles/README.md
@@ -145,8 +145,10 @@ Existing installations must stop or upgrade legacy Profile writers, run
 this version to add the identity keys and private email-reservation table. Then
 run `backfillProfileEmailKeys(db)` once from a single deploy process before
 enabling verified-email provisioning. The transaction-safe backfill is
-idempotent; provisioning fails closed with `email_key_backfill_required` while
-the standard `_smrt_backfills` readiness marker is absent.
+idempotent; canonical email lookup and reservation fail closed with
+`email_key_backfill_required` while the standard `_smrt_backfills` readiness
+marker is absent. Exact issuer/subject reuse does not depend on email-key
+readiness because it does not perform email-based linking.
 The identity-boundary helpers use the readiness guard and indexed key. The
 general-purpose `ProfileCollection.findByEmail()` retains its compatible legacy
 lookup behavior and is not suitable for identity linking. Only the explicit
@@ -155,16 +157,22 @@ runtime identity lookups use the indexed key and validate returned candidates.
 `createProfileFromOidc()` requires a transaction-capable database. Pass the
 root database, which must expose `beginTransaction`, and SMRT owns the
 transaction; an already transaction-bound handle is supported through a
-savepoint when `_smrt_backfills` already exists. Provisioning never attempts
-tracker DDL on a caller-owned transaction; if the table is absent, pass the
-root database so SMRT can initialize it outside the transaction. A handle
-exposing only `transaction()` is ambiguous and fails closed. For adapters
-without nested savepoint support, including DuckDB, pass
+savepoint. Paths that perform canonical email lookup or reservation require
+`_smrt_backfills` to exist first. Provisioning never attempts tracker DDL on
+a caller-owned transaction; for those paths, if the table is absent, pass the
+root database so SMRT can initialize it outside the transaction. Exact
+issuer/subject reuse skips the email-key readiness-marker lookup, but root
+coordination still initializes the shared tracker table. Caller-owned exact
+reuse does not consult the tracker and therefore does not require that table.
+A handle exposing only `transaction()` is ambiguous and fails closed. For
+adapters without nested savepoint support, including DuckDB, pass
 the root database rather than calling the helper inside an outer transaction.
 Provisioning fails before durable writes when neither safe path is available.
-The Profile-only helper preserves exact issuer/subject reuse but never attaches
-a new identity to an existing email match because this package cannot prove
-whether a User owns that Profile. Use
+The Profile-only helper preserves exact issuer/subject reuse, including legacy
+links to tenant-scoped or non-Person Profiles, but never attaches a new identity
+to an existing email match because this package cannot prove whether a User owns
+that Profile. User/session provisioning still rejects those unsafe linked
+Profiles before creating authentication state. Use
 `UserCollection.getOrCreateFromOidc()` from `@happyvertical/smrt-users` for
 owner-aware verified-email reuse and the supported pre-provision resolver hook.
 

--- a/packages/profiles/README.md
+++ b/packages/profiles/README.md
@@ -5,69 +5,46 @@ Central identity system with multi-auth (Nostr/OIDC/API keys/magic links), relat
 ## Installation
 
 ```bash
-pnpm add @happyvertical/smrt-profiles
+pnpm add @happyvertical/smrt-profiles @happyvertical/sql
 ```
 
 ## Usage
 
 ```typescript
 import {
-  Profile,
-  ProfileCollection,
-  OidcIdentity,
-  OidcIdentityCollection,
-  ApiKey,
-  ApiKeyCollection,
-  NostrIdentity,
-  generateNostrKeypair,
+  backfillProfileEmailKeys,
   createProfileFromOidc,
 } from '@happyvertical/smrt-profiles';
+import { getDatabase } from '@happyvertical/sql';
 
-// Create a profile
-const profile = new Profile({
-  name: 'Alice Johnson',
-  email: 'alice@example.com',
-});
-await profile.save();
+// Connect after applying schema migrations.
+const persistence = { type: 'sqlite' as const, url: 'file:profiles.db' };
+// Mark migrated Profile email keys ready before enabling OIDC provisioning.
+const db = await getDatabase(persistence);
+await backfillProfileEmailKeys(db);
 
-// OIDC identity (Keycloak/Google/GitHub)
-const oidcProfile = await createProfileFromOidc({
-  issuer: 'https://accounts.google.com',
-  subject: 'abc123',
-  email: 'alice@example.com',
-  name: 'Alice Johnson',
-});
-
-// Nostr identity (encrypted keypair, requires SERVER_MASTER_SECRET)
-const keypair = generateNostrKeypair();
-const nostr = new NostrIdentity({
-  profileId: profile.id,
-  pubkey: keypair.pubkey,
-});
-await nostr.save();
-
-// API key (plaintext returned once only)
-const { key, apiKey } = await ApiKey.generate({
-  profileId: profile.id,
-  scope: 'read:profiles',
-  expiresAt: new Date('2025-12-31'),
-});
-// key = plaintext (store now), apiKey.keyPrefix = visible identifier
-
-// Relationships (auto-creates reciprocal inverse)
-const bob = new Profile({ name: 'Bob Smith', email: 'bob@example.com' });
-await bob.save();
-await profile.addRelationship(bob, 'friend');
-const friends = await profile.getRelationships({ direction: 'from' });
+// Provision a new OIDC Profile or reuse its exact issuer/subject link.
+const { profile, oidcIdentity, created } = await createProfileFromOidc(
+  {
+    iss: 'https://accounts.google.com',
+    sub: 'abc123',
+    email: 'olivia@example.com',
+    email_verified: true,
+    name: 'Olivia Smith',
+  },
+  'google',
+  { db },
+);
 ```
 
 ### Owned assets
 
 ```typescript
 import { AssetCollection } from '@happyvertical/smrt-assets';
+import { ProfileCollection } from '@happyvertical/smrt-profiles';
 
-const profiles = await ProfileCollection.create();
-const assets = await AssetCollection.create();
+const profiles = await ProfileCollection.create({ db });
+const assets = await AssetCollection.create({ db });
 
 const headshot = await assets.create({
   name: 'alice-headshot.jpg',
@@ -128,6 +105,69 @@ const galleryAssets = await profiles.getAssets(profile.id!, 'gallery');
 | `NostrIdentityCollection` | Nostr identity lookup (includes NIP-05) |
 | `OidcIdentityCollection` | OIDC identity lookup |
 
+`ProfileCollection.findUniqueGlobalPersonByEmail(email)` is the supported
+verified-identity lookup. It reads across tenant scopes and returns a Profile
+only when the case-insensitive email has exactly one match and that row is a
+global `Person`; tenant-scoped, non-Person, and duplicate matches throw a
+`CanonicalPersonProfileError`. Matching uses readonly, indexed
+`Profile.emailKey`, derived with the exported TypeScript
+`normalizeIdentityEmail()` helper so Unicode casing and whitespace behave the
+same on every database adapter. Use
+`requireCanonicalGlobalPerson(profileId, email?)` to validate an
+application-selected Profile against the same invariant. When `email` is
+omitted, the helper validates uniqueness using the Profile's current stored
+email. `reserveCanonicalIdentityEmail(profileId, email)` additionally claims
+the normalized address in the private
+`oidc_profile_email_reservations` table. Omit `email` to synchronize the
+reservation from the Profile's current stored email; changing the address moves
+the reservation, and clearing it removes the reservation. Legacy simple
+`Person` STI discriminators remain valid and are handled by core's normal
+upgrade path.
+
+`OidcIdentity.identityKey` stores a nullable, unique issuer/subject natural key
+for transaction-safe first-login races. The model derives it from issuer and
+subject on every save, so callers cannot desynchronize it. New links populate
+it and legacy rows backfill it when reused. Issuer and subject are opaque,
+case-sensitive OIDC identifiers: surrounding whitespace is preserved and is
+part of the key; trimming is used only to reject an all-whitespace claim. The
+generated REST, MCP, and CLI surfaces are read-only because identity mutation
+is an authentication authority change; trusted callers link identities through
+the transactional provisioning APIs. The legacy
+`OidcIdentity.findOrCreate()` method is deprecated: it transactionally reuses
+one exact safe issuer/subject link for compatibility but refuses to create a
+new authentication link. Use `createProfileFromOidc()` or the users package's
+owner-aware provisioning API for creation. The deprecated
+`OidcIdentityCollection.linkToProfile()` and `Profile.linkOidcIdentity()`
+helpers delegate to the same exact-reuse-only path and cannot plant or rebind a
+link.
+Existing installations must stop or upgrade legacy Profile writers, run
+`smrt db:status`, `smrt db:migrate`, and then `smrt db:status` before deploying
+this version to add the identity keys and private email-reservation table. Then
+run `backfillProfileEmailKeys(db)` once from a single deploy process before
+enabling verified-email provisioning. The transaction-safe backfill is
+idempotent; provisioning fails closed with `email_key_backfill_required` while
+the standard `_smrt_backfills` readiness marker is absent.
+The identity-boundary helpers use the readiness guard and indexed key. The
+general-purpose `ProfileCollection.findByEmail()` retains its compatible legacy
+lookup behavior and is not suitable for identity linking. Only the explicit
+deploy-time backfill scans the Profile table and records readiness; guarded
+runtime identity lookups use the indexed key and validate returned candidates.
+`createProfileFromOidc()` requires a transaction-capable database. Pass the
+root database, which must expose `beginTransaction`, and SMRT owns the
+transaction; an already transaction-bound handle is supported through a
+savepoint when `_smrt_backfills` already exists. Provisioning never attempts
+tracker DDL on a caller-owned transaction; if the table is absent, pass the
+root database so SMRT can initialize it outside the transaction. A handle
+exposing only `transaction()` is ambiguous and fails closed. For adapters
+without nested savepoint support, including DuckDB, pass
+the root database rather than calling the helper inside an outer transaction.
+Provisioning fails before durable writes when neither safe path is available.
+The Profile-only helper preserves exact issuer/subject reuse but never attaches
+a new identity to an existing email match because this package cannot prove
+whether a User owns that Profile. Use
+`UserCollection.getOrCreateFromOidc()` from `@happyvertical/smrt-users` for
+owner-aware verified-email reuse and the supported pre-provision resolver hook.
+
 `Profile` and `ProfileCollection` both expose `getAssets()`, `addAsset()`, and
 `removeAsset()` helpers backed by `profile_assets`. Typical relationships are
 `avatar`, `gallery`, and `attachment`.
@@ -137,7 +177,10 @@ const galleryAssets = await profiles.getAssets(profile.id!, 'gallery');
 | Export | Description |
 |--------|------------|
 | `resolveIdentity` | Resolve profile from any auth method |
-| `createProfileFromOidc` | Create profile + OIDC identity in one call |
+| `createProfileFromOidc` | Create a Profile + OIDC identity or reuse an exact issuer/subject link; existing email matches fail closed |
+| `normalizeIdentityEmail` | Adapter-independent Unicode/whitespace email canonicalizer used by identity keys |
+| `backfillProfileEmailKeys` | Transactionally populate normalized keys for migrated Profiles |
+| `PROFILE_EMAIL_KEY_BACKFILL_NAME` | Durable readiness-marker name recorded by the Profile email-key backfill |
 | `createProfileFromNostr` | Create profile + Nostr identity in one call |
 | `createAuthEvent` | Create a Nostr auth event |
 | `verifyAuthEvent` | Verify a Nostr auth event signature |
@@ -161,7 +204,7 @@ const galleryAssets = await profiles.getAssets(profile.id!, 'gallery');
 
 ### Key Types
 
-`ProfileOptions`, `ProfileTypeOptions`, `ProfileMetadataOptions`, `ProfileMetafieldOptions`, `ProfileRelationshipOptions`, `ProfileRelationshipTypeOptions`, `ProfileRelationshipTermOptions`, `OidcIdentityOptions`, `NostrIdentityOptions`, `ApiKeyOptions`, `GenerateKeyResult`, `MagicLinkTokenOptions`, `GenerateTokenResult`, `AuditLogOptions`, `AuditSource`, `AuthContext`, `ResolveIdentityResult`, `InitiateResult`, `VerifyResult`, `MagicLinkConfig`, `MagicLinkService`, `Nip05HandlerConfig`, `Nip05HandlerResult`, `Nip05Request`, `Nip05Response`, `NostrEvent`, `NostrKeypair`, `EncryptedKey`, `ValidationSchema`, `ValidatorFunction`, `ReciprocalHandler`
+`ProfileOptions`, `ProfileTypeOptions`, `ProfileMetadataOptions`, `ProfileMetafieldOptions`, `ProfileRelationshipOptions`, `ProfileRelationshipTypeOptions`, `ProfileRelationshipTermOptions`, `OidcIdentityOptions`, `CanonicalPersonProfileErrorCode`, `NostrIdentityOptions`, `ApiKeyOptions`, `GenerateKeyResult`, `MagicLinkTokenOptions`, `GenerateTokenResult`, `AuditLogOptions`, `AuditSource`, `AuthContext`, `ResolveIdentityResult`, `InitiateResult`, `VerifyResult`, `MagicLinkConfig`, `MagicLinkService`, `Nip05HandlerConfig`, `Nip05HandlerResult`, `Nip05Request`, `Nip05Response`, `NostrEvent`, `NostrKeypair`, `EncryptedKey`, `ValidationSchema`, `ValidatorFunction`, `ReciprocalHandler`
 
 ## Dependencies
 

--- a/packages/profiles/package.json
+++ b/packages/profiles/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/utils.d.ts",
       "import": "./dist/utils.js"
     },
+    "./internal/oidc-provisioning": {
+      "types": "./dist/oidc-provisioning.d.ts",
+      "import": "./dist/internal/oidc-provisioning.js"
+    },
     "./manifest": "./dist/manifest.json",
     "./manifest.json": "./dist/manifest.json"
   },

--- a/packages/profiles/src/__tests__/oidc-account-linking.test.ts
+++ b/packages/profiles/src/__tests__/oidc-account-linking.test.ts
@@ -258,7 +258,24 @@ describe('OIDC Account Linking', () => {
         await database.close?.();
       }
 
-      const reused = await OidcIdentity.findOrCreate(created.profile, {
+      const exactReuse = await createProfileFromOidc(
+        {
+          ...claims,
+          email: 'legacy-organization-updated@example.com',
+        },
+        'legacy',
+        { db },
+      );
+
+      expect(exactReuse.created).toBe(false);
+      expect(exactReuse.profile.id).toBe(created.profile.id);
+      expect(exactReuse.oidcIdentity.id).toBe(created.oidcIdentity.id);
+      expect(exactReuse.profile.tenantId).toBe('legacy-tenant');
+      expect(exactReuse.profile._meta_type).toBe(
+        '@happyvertical/smrt-profiles:Organization',
+      );
+
+      const reused = await OidcIdentity.findOrCreate(exactReuse.profile, {
         email: 'legacy-organization-updated@example.com',
         issuer: claims.iss,
         provider: 'legacy',

--- a/packages/profiles/src/__tests__/oidc-account-linking.test.ts
+++ b/packages/profiles/src/__tests__/oidc-account-linking.test.ts
@@ -2,18 +2,116 @@
  * Tests for OIDC account linking functionality
  *
  * Tests the createProfileFromOidc function which handles:
- * - Creating new profiles from OIDC claims
- * - Linking multiple OIDC identities to the same profile by email
- * - Security: only linking when email_verified is true
+ * - Creating new Profiles from OIDC claims
+ * - Reusing an exact issuer/subject identity link
+ * - Failing closed on existing email matches that require owner-aware reuse
  */
 
+import { randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+import { type DatabaseInterface, getDatabase } from '@happyvertical/sql';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { createProfileFromOidc } from '../auth/resolveIdentity.js';
+import { createProfileFromOidc } from '../auth/index.js';
 import { OidcIdentityCollection } from '../collections/OidcIdentityCollection.js';
 import { ProfileCollection } from '../collections/ProfileCollection.js';
 import { ProfileTypeCollection } from '../collections/ProfileTypeCollection.js';
+import { isOidcProvisioningRaceConflict } from '../internal/oidc-provisioning.js';
+import { backfillProfileEmailKeys } from '../migrations/backfillProfileEmailKeys.js';
+import { OidcIdentity } from '../models/OidcIdentity.js';
+
+describe('OIDC identity generated authority surface', () => {
+  it('exposes no generated REST or MCP mutations', () => {
+    const registered = ObjectRegistry.getClassInPackage(
+      '@happyvertical/smrt-profiles',
+      'OidcIdentity',
+    );
+    expect(registered, 'OidcIdentity must be registered').toBeTruthy();
+
+    const config = (
+      registered as {
+        config: {
+          api?: { include?: string[] };
+          mcp?: { include?: string[] };
+        };
+      }
+    ).config;
+    for (const surface of [config.api, config.mcp]) {
+      expect(surface?.include).toEqual(['list', 'get']);
+      expect(surface?.include).not.toContain('create');
+      expect(surface?.include).not.toContain('update');
+      expect(surface?.include).not.toContain('delete');
+    }
+  });
+
+  it('keeps the checked-in manifest read-only and includes race arbiters', async () => {
+    const manifest = JSON.parse(
+      await readFile(
+        new URL('../manifest/manifest.json', import.meta.url),
+        'utf8',
+      ),
+    ) as {
+      objects: Record<
+        string,
+        {
+          decoratorConfig?: {
+            api?: false | { include?: string[] };
+            cli?: false | { include?: string[] };
+            mcp?: false | { include?: string[] };
+          };
+          fields?: Record<
+            string,
+            { _meta?: { unique?: boolean }; readonly?: boolean }
+          >;
+          filePath?: string;
+        }
+      >;
+    };
+    const identity =
+      manifest.objects['@happyvertical/smrt-profiles:OidcIdentity'];
+    const reservation =
+      manifest.objects[
+        '@happyvertical/smrt-profiles:OidcProfileEmailReservation'
+      ];
+
+    expect(identity?.decoratorConfig?.api).toEqual({
+      include: ['list', 'get'],
+    });
+    expect(identity?.decoratorConfig?.mcp).toEqual({
+      include: ['list', 'get'],
+    });
+    expect(identity?.decoratorConfig?.cli).toEqual({
+      include: ['list', 'get'],
+    });
+    expect(identity?.fields?.identityKey?._meta?.unique).toBe(true);
+    expect(identity?.fields?.identityKey?.readonly).toBe(true);
+    expect(reservation).toBeDefined();
+    expect(reservation?.decoratorConfig?.api).toBe(false);
+    expect(reservation?.decoratorConfig?.mcp).toBe(false);
+    expect(reservation?.decoratorConfig?.cli).toBe(false);
+    expect(reservation?.fields?.profileId?._meta?.unique).toBe(true);
+    expect(reservation?.fields?.emailKey?._meta?.unique).toBe(true);
+    expect(reservation?.fields?.emailKey?.readonly).toBe(true);
+    for (const object of Object.values(manifest.objects)) {
+      expect(object.filePath).toBeDefined();
+      expect(isAbsolute(object.filePath ?? '')).toBe(false);
+      expect(object.filePath).not.toContain('\\');
+      expect(object.filePath).toMatch(/^packages\/profiles\/src\//u);
+    }
+  });
+
+  it('classifies stateful extension patterns deterministically', () => {
+    const pattern = /custom_oidc_race/gu;
+    const error = new Error('custom_oidc_race');
+    const options = { messagePatterns: [pattern] };
+
+    expect(isOidcProvisioningRaceConflict(error, options)).toBe(true);
+    expect(isOidcProvisioningRaceConflict(error, options)).toBe(true);
+    expect(pattern.lastIndex).toBe(0);
+  });
+});
 
 describe('OIDC Account Linking', () => {
   let dbUrl: string;
@@ -34,6 +132,8 @@ describe('OIDC Account Linking', () => {
       description: 'Individual person',
     });
     await personType.save();
+    const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+    await backfillProfileEmailKeys(db);
   });
 
   describe('createProfileFromOidc', () => {
@@ -56,6 +156,32 @@ describe('OIDC Account Linking', () => {
       expect(profile.name).toBe('Alice Johnson');
       expect(oidcIdentity.subject).toBe('google-user-123');
       expect(oidcIdentity.issuer).toBe('https://accounts.google.com');
+    });
+
+    it('accepts the database string shortcut', async () => {
+      const stringDbUrl = `file:${join(
+        tmpdir(),
+        `test-oidc-string-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
+      )}`;
+      await ProfileTypeCollection.create({
+        persistence: { type: 'sqlite', url: stringDbUrl },
+      });
+      const stringDb = await getDatabase({ type: 'sqlite', url: stringDbUrl });
+      await backfillProfileEmailKeys(stringDb);
+      const result = await createProfileFromOidc(
+        {
+          sub: 'string-db-user',
+          iss: 'https://accounts.example.com',
+          email: 'string-db@example.com',
+          email_verified: true,
+          name: 'String Database User',
+        },
+        'example',
+        { db: stringDbUrl },
+      );
+
+      expect(result.created).toBe(true);
+      expect(result.profile.email).toBe('string-db@example.com');
     });
 
     it('should return existing profile for same OIDC identity', async () => {
@@ -82,7 +208,135 @@ describe('OIDC Account Linking', () => {
       expect(second.oidcIdentity.id).toBe(first.oidcIdentity.id);
     });
 
-    it('should link different providers with same verified email to same profile', async () => {
+    it('keeps deprecated findOrCreate compatible only for an exact safe identity', async () => {
+      const claims = {
+        sub: 'legacy-exact-subject',
+        iss: 'https://legacy.example.com',
+        email: 'legacy-exact@example.com',
+        email_verified: true,
+      };
+      const created = await createProfileFromOidc(claims, 'legacy', {
+        db: { type: 'sqlite', url: dbUrl },
+      });
+
+      const identity = await OidcIdentity.findOrCreate(created.profile, {
+        email: claims.email,
+        issuer: claims.iss,
+        provider: 'legacy',
+        subject: claims.sub,
+      });
+
+      expect(identity.id).toBe(created.oidcIdentity.id);
+      const identities = await (
+        await OidcIdentityCollection.create({
+          persistence: { type: 'sqlite', url: dbUrl },
+        })
+      ).list({});
+      expect(identities).toHaveLength(1);
+    });
+
+    it('preserves an exact legacy link to a tenant-scoped non-Person Profile', async () => {
+      const db = { type: 'sqlite' as const, url: dbUrl };
+      const claims = {
+        sub: 'legacy-organization-subject',
+        iss: 'https://legacy.example.com',
+        email: 'legacy-organization@example.com',
+        email_verified: true,
+      };
+      const created = await createProfileFromOidc(claims, 'legacy', { db });
+      const database = await getDatabase(db);
+      try {
+        await database.query(
+          `UPDATE profiles
+             SET tenant_id = ?, _meta_type = ?
+           WHERE id = ?`,
+          'legacy-tenant',
+          '@happyvertical/smrt-profiles:Organization',
+          created.profile.id,
+        );
+      } finally {
+        await database.close?.();
+      }
+
+      const reused = await OidcIdentity.findOrCreate(created.profile, {
+        email: 'legacy-organization-updated@example.com',
+        issuer: claims.iss,
+        provider: 'legacy',
+        subject: claims.sub,
+      });
+
+      expect(reused.id).toBe(created.oidcIdentity.id);
+      expect(reused.email).toBe('legacy-organization-updated@example.com');
+      expect(reused.identityKey).toBe(
+        '["https://legacy.example.com","legacy-organization-subject"]',
+      );
+    });
+
+    it('deprecated findOrCreate refuses to create a new authentication link', async () => {
+      const created = await createProfileFromOidc(
+        {
+          sub: 'legacy-removed-subject',
+          iss: 'https://legacy.example.com',
+          email: 'legacy-removed@example.com',
+          email_verified: true,
+        },
+        'legacy',
+        { db: { type: 'sqlite', url: dbUrl } },
+      );
+      await created.oidcIdentity.delete();
+
+      await expect(
+        OidcIdentity.findOrCreate(
+          created.profile,
+          {
+            email: created.profile.email,
+            issuer: 'https://legacy.example.com',
+            provider: 'legacy',
+            subject: 'legacy-new-subject',
+          },
+          { db: { type: 'sqlite', url: dbUrl } },
+        ),
+      ).rejects.toThrow('no longer creates authentication links');
+
+      const identities = await (
+        await OidcIdentityCollection.create({
+          persistence: { type: 'sqlite', url: dbUrl },
+        })
+      ).list({});
+      expect(identities).toHaveLength(0);
+    });
+
+    it('preserves the exact opaque issuer and subject claims', async () => {
+      const first = await createProfileFromOidc(
+        {
+          sub: 'opaque-subject',
+          iss: 'https://issuer.example.com',
+          email: 'opaque-first@example.com',
+          email_verified: true,
+        },
+        'example',
+        { db: { type: 'sqlite', url: dbUrl } },
+      );
+      const second = await createProfileFromOidc(
+        {
+          sub: ' opaque-subject',
+          iss: 'https://issuer.example.com',
+          email: 'opaque-second@example.com',
+          email_verified: true,
+        },
+        'example',
+        { db: { type: 'sqlite', url: dbUrl } },
+      );
+
+      expect(second.profile.id).not.toBe(first.profile.id);
+      expect(second.oidcIdentity.id).not.toBe(first.oidcIdentity.id);
+      expect(second.oidcIdentity.subject).toBe(' opaque-subject');
+      expect(second.oidcIdentity.identityKey).toBe(
+        '["https://issuer.example.com"," opaque-subject"]',
+      );
+    });
+
+    it('fails closed before Profile-only cross-provider email linking', async () => {
       const email = 'carol@example.com';
 
       // First login with Google
@@ -100,45 +354,39 @@ describe('OIDC Account Linking', () => {
       expect(googleLogin.created).toBe(true);
 
       // Second login with GitHub (same email)
-      const githubLogin = await createProfileFromOidc(
-        {
-          sub: '98765',
-          iss: 'https://github.com',
-          email,
-          email_verified: true,
-          name: 'Carol Davis',
-        },
-        'github',
-        { db: { type: 'sqlite', url: dbUrl } },
-      );
+      await expect(
+        createProfileFromOidc(
+          {
+            sub: '98765',
+            iss: 'https://github.com',
+            email,
+            email_verified: true,
+            name: 'Carol Davis',
+          },
+          'github',
+          { db: { type: 'sqlite', url: dbUrl } },
+        ),
+      ).rejects.toThrow('cannot prove that Profile is unowned');
 
-      // Should link to same profile, not create new one
-      expect(githubLogin.created).toBe(false);
-      expect(githubLogin.profile.id).toBe(googleLogin.profile.id);
-
-      // But should have different OIDC identities
-      expect(githubLogin.oidcIdentity.id).not.toBe(googleLogin.oidcIdentity.id);
-      expect(githubLogin.oidcIdentity.issuer).toBe('https://github.com');
       expect(googleLogin.oidcIdentity.issuer).toBe(
         'https://accounts.google.com',
       );
 
-      // Verify both identities exist and link to same profile
+      // The original exact identity remains unchanged and no new link is
+      // persisted. Owner-aware linking belongs to smrt-users.
       const identityCollection = await OidcIdentityCollection.create({
         persistence: { type: 'sqlite', url: dbUrl },
       });
       const identities = await identityCollection.list({});
-      expect(identities.length).toBe(2);
-      expect(
-        identities.every((i) => i.profileId === googleLogin.profile.id),
-      ).toBe(true);
+      expect(identities).toHaveLength(1);
+      expect(identities[0].profileId).toBe(googleLogin.profile.id);
     });
 
     it('should NOT link accounts when email is not verified', async () => {
       const email = 'dave@example.com';
 
       // First login with verified email
-      const firstLogin = await createProfileFromOidc(
+      await createProfileFromOidc(
         {
           sub: 'provider1-dave',
           iss: 'https://provider1.com',
@@ -149,31 +397,27 @@ describe('OIDC Account Linking', () => {
         'provider1',
         { db: { type: 'sqlite', url: dbUrl } },
       );
-      expect(firstLogin.created).toBe(true);
-
       // Second login with UNVERIFIED email (should NOT link)
-      const secondLogin = await createProfileFromOidc(
-        {
-          sub: 'provider2-dave',
-          iss: 'https://provider2.com',
-          email,
-          email_verified: false, // Not verified!
-          name: 'Dave Wilson',
-        },
-        'provider2',
-        { db: { type: 'sqlite', url: dbUrl } },
-      );
-
-      // Should create a new profile, not link to existing
-      expect(secondLogin.created).toBe(true);
-      expect(secondLogin.profile.id).not.toBe(firstLogin.profile.id);
+      await expect(
+        createProfileFromOidc(
+          {
+            sub: 'provider2-dave',
+            iss: 'https://provider2.com',
+            email,
+            email_verified: false,
+            name: 'Dave Wilson',
+          },
+          'provider2',
+          { db: { type: 'sqlite', url: dbUrl } },
+        ),
+      ).rejects.toThrow('not verified');
     });
 
     it('should NOT link accounts when email_verified is undefined', async () => {
       const email = 'eve@example.com';
 
       // First login with verified email
-      const firstLogin = await createProfileFromOidc(
+      await createProfileFromOidc(
         {
           sub: 'provider1-eve',
           iss: 'https://provider1.com',
@@ -186,21 +430,18 @@ describe('OIDC Account Linking', () => {
       );
 
       // Second login without email_verified claim
-      const secondLogin = await createProfileFromOidc(
-        {
-          sub: 'provider2-eve',
-          iss: 'https://provider2.com',
-          email,
-          // email_verified is undefined
-          name: 'Eve Brown',
-        },
-        'provider2',
-        { db: { type: 'sqlite', url: dbUrl } },
-      );
-
-      // Should create a new profile, not link
-      expect(secondLogin.created).toBe(true);
-      expect(secondLogin.profile.id).not.toBe(firstLogin.profile.id);
+      await expect(
+        createProfileFromOidc(
+          {
+            sub: 'provider2-eve',
+            iss: 'https://provider2.com',
+            email,
+            name: 'Eve Brown',
+          },
+          'provider2',
+          { db: { type: 'sqlite', url: dbUrl } },
+        ),
+      ).rejects.toThrow('not verified');
     });
 
     it('should create separate profiles for different emails', async () => {
@@ -249,6 +490,331 @@ describe('OIDC Account Linking', () => {
       expect(profile.id).toBeDefined();
       expect(profile.name).toBe('Anon User');
     });
+
+    it('converges concurrent first login on one Profile and identity', async () => {
+      const concurrentClaims = {
+        sub: 'concurrent-profile-subject',
+        iss: 'https://auth.example.com',
+        email: 'concurrent-profile@example.com',
+        email_verified: true,
+        name: 'Concurrent Profile',
+      };
+
+      const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+      try {
+        const [first, second] = await Promise.all([
+          createProfileFromOidc(concurrentClaims, 'example', { db }),
+          createProfileFromOidc(concurrentClaims, 'example', { db }),
+        ]);
+
+        expect(second.profile.id).toBe(first.profile.id);
+        expect(second.oidcIdentity.id).toBe(first.oidcIdentity.id);
+      } finally {
+        await db.close?.();
+      }
+    });
+
+    it('preserves unrelated same-name Profiles on one SQLite root handle', async () => {
+      const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+      const sharedClaims = {
+        iss: 'https://auth.example.com',
+        email_verified: true,
+        name: 'Shared Display Name',
+      };
+
+      try {
+        const [first, second] = await Promise.all([
+          createProfileFromOidc(
+            {
+              ...sharedClaims,
+              email: 'same-name-first@example.com',
+              sub: 'same-name-first',
+            },
+            'example',
+            { db },
+          ),
+          createProfileFromOidc(
+            {
+              ...sharedClaims,
+              email: 'same-name-second@example.com',
+              sub: 'same-name-second',
+            },
+            'example',
+            { db },
+          ),
+        ]);
+
+        expect(second.profile.id).not.toBe(first.profile.id);
+        expect(second.oidcIdentity.id).not.toBe(first.oidcIdentity.id);
+        await expect(countRows(db, 'profiles')).resolves.toBe(2);
+        await expect(countRows(db, 'oidc_identities')).resolves.toBe(2);
+      } finally {
+        await db.close?.();
+      }
+    });
+
+    it('converges first login across independent SQLite connections', async () => {
+      const firstDb = await getDatabase({
+        type: 'sqlite',
+        url: dbUrl,
+        dbid: `oidc-profile-sqlite-first-${randomUUID()}`,
+      });
+      const secondDb = await getDatabase({
+        type: 'sqlite',
+        url: dbUrl,
+        dbid: `oidc-profile-sqlite-second-${randomUUID()}`,
+      });
+      let activeLookups = 0;
+      let maxActiveLookups = 0;
+      const observeLookup = async () => {
+        activeLookups += 1;
+        maxActiveLookups = Math.max(maxActiveLookups, activeLookups);
+        await new Promise<void>((resolve) => setTimeout(resolve, 25));
+        activeLookups -= 1;
+      };
+      const concurrentClaims = {
+        sub: 'independent-profile-subject',
+        iss: 'https://auth.example.com',
+        email: 'independent-profile@example.com',
+        email_verified: true,
+        name: 'Independent Profile',
+      };
+
+      try {
+        const [first, second] = await Promise.all([
+          createProfileFromOidc(concurrentClaims, 'example', {
+            db: withIdentityLookupObserver(firstDb, observeLookup),
+          }),
+          createProfileFromOidc(concurrentClaims, 'example', {
+            db: withIdentityLookupObserver(secondDb, observeLookup),
+          }),
+        ]);
+
+        expect(maxActiveLookups).toBe(1);
+        expect(second.profile.id).toBe(first.profile.id);
+        expect(second.oidcIdentity.id).toBe(first.oidcIdentity.id);
+        await expect(countRows(firstDb, 'profiles')).resolves.toBe(1);
+        await expect(countRows(firstDb, 'oidc_identities')).resolves.toBe(1);
+        await expect(
+          countRows(firstDb, 'oidc_profile_email_reservations'),
+        ).resolves.toBe(1);
+      } finally {
+        await Promise.all([firstDb.close?.(), secondDb.close?.()]);
+      }
+    });
+
+    it('serializes one issuer/subject with different emails across independent DuckDB handles', async () => {
+      const db = await getDatabase({ type: 'duckdb', url: ':memory:' });
+      await ProfileTypeCollection.create({ db });
+      await backfillProfileEmailKeys(db);
+      let activeLookups = 0;
+      let maxActiveLookups = 0;
+      const observeLookup = async () => {
+        activeLookups += 1;
+        maxActiveLookups = Math.max(maxActiveLookups, activeLookups);
+        await new Promise<void>((resolve) => setTimeout(resolve, 25));
+        activeLookups -= 1;
+      };
+      const firstDb = withIdentityLookupObserver(db, observeLookup);
+      const secondDb = withIdentityLookupObserver(db, observeLookup);
+      const sharedClaims = {
+        sub: 'duckdb-shared-profile-subject',
+        iss: 'https://auth.example.com',
+        email_verified: true,
+        name: 'DuckDB Shared Profile',
+      };
+
+      try {
+        const [first, second] = await Promise.all([
+          createProfileFromOidc(
+            { ...sharedClaims, email: 'duckdb-profile-first@example.com' },
+            'example',
+            { db: firstDb },
+          ),
+          createProfileFromOidc(
+            { ...sharedClaims, email: 'duckdb-profile-second@example.com' },
+            'example',
+            { db: secondDb },
+          ),
+        ]);
+
+        expect(maxActiveLookups).toBe(1);
+        expect(second.profile.id).toBe(first.profile.id);
+        expect(second.oidcIdentity.id).toBe(first.oidcIdentity.id);
+        await expect(countRows(firstDb, 'profiles')).resolves.toBe(1);
+        await expect(countRows(firstDb, 'oidc_identities')).resolves.toBe(1);
+      } finally {
+        await db.close?.();
+      }
+    });
+
+    it('fails closed on an ambiguous callback-only root adapter', async () => {
+      const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+      const callbackOnlyRoot = new Proxy(db, {
+        get(target, property, receiver) {
+          if (property === 'beginTransaction') return undefined;
+          if (property === 'query') {
+            return async (sql: string, ...params: unknown[]) => {
+              if (/^SAVEPOINT\b/iu.test(sql)) {
+                throw new Error(
+                  'SAVEPOINT can only be used in transaction blocks',
+                );
+              }
+              return target.query(sql, ...params);
+            };
+          }
+          const value = Reflect.get(target, property, receiver);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+
+      try {
+        await expect(
+          createProfileFromOidc(
+            {
+              sub: 'callback-only-profile-subject',
+              iss: 'https://auth.example.com',
+              email: 'callback-only-profile@example.com',
+              email_verified: true,
+            },
+            'example',
+            { db: callbackOnlyRoot },
+          ),
+        ).rejects.toThrow('root database');
+      } finally {
+        await db.close?.();
+      }
+    });
+
+    it('fails closed on a DuckDB manual transaction without corrupting it', async () => {
+      const db = await getDatabase({ type: 'duckdb', url: ':memory:' });
+      if (!db.beginTransaction) {
+        throw new Error('Expected DuckDB manual transaction support.');
+      }
+      const tx = await db.beginTransaction();
+      try {
+        await expect(
+          createProfileFromOidc(
+            {
+              sub: 'duckdb-manual-profile',
+              iss: 'https://auth.example.com',
+              email: 'duckdb-manual-profile@example.com',
+              email_verified: true,
+            },
+            'example',
+            { db: tx },
+          ),
+        ).rejects.toThrow('root database');
+
+        expect(tx.isActive()).toBe(true);
+        await tx.query('CREATE TABLE profile_outer_probe (id INTEGER)');
+        await tx.query('INSERT INTO profile_outer_probe VALUES (1)');
+        const result = await tx.query(
+          'SELECT count(*) AS count FROM profile_outer_probe',
+        );
+        expect(Number(result.rows[0]?.count)).toBe(1);
+      } finally {
+        if (tx.isActive()) await tx.rollback();
+        await db.close?.();
+      }
+    });
+
+    it('fails closed on a DuckDB callback transaction without corrupting it', async () => {
+      const db = await getDatabase({ type: 'duckdb', url: ':memory:' });
+      if (!db.transaction) {
+        throw new Error('Expected DuckDB callback transaction support.');
+      }
+      try {
+        await db.transaction(async (tx) => {
+          await expect(
+            createProfileFromOidc(
+              {
+                sub: 'duckdb-callback-profile',
+                iss: 'https://auth.example.com',
+                email: 'duckdb-callback-profile@example.com',
+                email_verified: true,
+              },
+              'example',
+              { db: tx },
+            ),
+          ).rejects.toThrow('root database');
+
+          await tx.query('CREATE TABLE profile_callback_probe (id INTEGER)');
+          await tx.query('INSERT INTO profile_callback_probe VALUES (1)');
+          const result = await tx.query(
+            'SELECT count(*) AS count FROM profile_callback_probe',
+          );
+          expect(Number(result.rows[0]?.count)).toBe(1);
+        });
+      } finally {
+        await db.close?.();
+      }
+    });
+
+    it('does not retry an unrelated unique constraint', async () => {
+      const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+      let transactionAttempts = 0;
+      const failingDb = new Proxy(db, {
+        get(target, property, receiver) {
+          if (property === 'transaction') {
+            return async <T>(
+              callback: (tx: typeof db) => Promise<T>,
+            ): Promise<T> => {
+              transactionAttempts += 1;
+              if (!target.transaction) {
+                throw new Error('Expected a transaction-capable database.');
+              }
+              return target.transaction(async (tx) =>
+                callback(
+                  new Proxy(tx, {
+                    get(txTarget, txProperty, txReceiver) {
+                      if (txProperty === 'query') {
+                        return async (sql: string, ...params: unknown[]) => {
+                          if (/oidc_identities/iu.test(sql)) {
+                            throw new Error(
+                              'UNIQUE constraint failed: unrelated.slug',
+                            );
+                          }
+                          return txTarget.query(sql, ...params);
+                        };
+                      }
+                      const value = Reflect.get(
+                        txTarget,
+                        txProperty,
+                        txReceiver,
+                      );
+                      return typeof value === 'function'
+                        ? value.bind(txTarget)
+                        : value;
+                    },
+                  }),
+                ),
+              );
+            };
+          }
+          const value = Reflect.get(target, property, receiver);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+
+      try {
+        await expect(
+          createProfileFromOidc(
+            {
+              sub: 'unrelated-constraint-subject',
+              iss: 'https://auth.example.com',
+              email: 'unrelated-constraint@example.com',
+              email_verified: true,
+            },
+            'example',
+            { db: failingDb },
+          ),
+        ).rejects.toThrow('unrelated.slug');
+        expect(transactionAttempts).toBe(1);
+      } finally {
+        await db.close?.();
+      }
+    });
   });
 
   describe('ProfileCollection.findByEmail', () => {
@@ -276,6 +842,39 @@ describe('OIDC Account Linking', () => {
       expect(found?.email).toBe('test@example.com');
     });
 
+    it('keeps general email lookup compatible before the identity backfill', async () => {
+      const created = await createProfileFromOidc(
+        {
+          sub: 'legacy-find-user',
+          iss: 'https://auth.example.com',
+          email: 'legacy-find@example.com',
+          email_verified: true,
+        },
+        'example',
+        { db: { type: 'sqlite', url: dbUrl } },
+      );
+      const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+      await db.query(
+        'UPDATE profiles SET email_key = NULL WHERE id = ?',
+        created.profile.id,
+      );
+      await db.query(
+        `DELETE FROM _smrt_backfills
+         WHERE name = '@happyvertical/smrt-profiles:profile-email-keys:v1'`,
+      );
+      const collection = await ProfileCollection.create({ db });
+
+      await expect(
+        collection.findByEmail('legacy-find@example.com'),
+      ).resolves.toMatchObject({ id: created.profile.id });
+      await expect(backfillProfileEmailKeys(db)).resolves.toEqual({
+        updated: 1,
+      });
+      await expect(
+        collection.findByEmail('legacy-find@example.com'),
+      ).resolves.toMatchObject({ id: created.profile.id });
+    });
+
     it('should return null for non-existent email', async () => {
       const collection = await ProfileCollection.create({
         persistence: { type: 'sqlite', url: dbUrl },
@@ -286,3 +885,41 @@ describe('OIDC Account Linking', () => {
     });
   });
 });
+
+function withIdentityLookupObserver(
+  db: DatabaseInterface,
+  observe: () => Promise<void>,
+): DatabaseInterface {
+  const wrap = (database: DatabaseInterface): DatabaseInterface =>
+    new Proxy(database, {
+      get(target, property, receiver) {
+        if (property === 'query') {
+          return async (sql: string, ...params: unknown[]) => {
+            const result = await target.query(sql, ...params);
+            if (/from\s+["`]?oidc_identities["`]?/iu.test(sql)) {
+              await observe();
+            }
+            return result;
+          };
+        }
+        if (property === 'transaction') {
+          const transaction = target.transaction;
+          if (!transaction) return undefined;
+          return async <T>(
+            callback: (tx: DatabaseInterface) => Promise<T>,
+          ): Promise<T> => transaction.call(target, (tx) => callback(wrap(tx)));
+        }
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+  return wrap(db);
+}
+
+async function countRows(
+  db: DatabaseInterface,
+  table: 'oidc_identities' | 'oidc_profile_email_reservations' | 'profiles',
+): Promise<number> {
+  const result = await db.query(`SELECT count(*) AS count FROM ${table}`);
+  return Number(result.rows[0]?.count ?? 0);
+}

--- a/packages/profiles/src/__tests__/profile-collection.test.ts
+++ b/packages/profiles/src/__tests__/profile-collection.test.ts
@@ -142,21 +142,21 @@ describe('Profile model misc methods', () => {
     expect(await Profile.searchByEmail('x@example.com')).toBeNull();
   });
 
-  it('links and reads OIDC identities through the profile model', async () => {
+  it('refuses to plant a new OIDC identity through the profile model', async () => {
     const { mkProfile } = await setup(dbUrl);
     const profile = await mkProfile('Olive');
 
-    const identity = await profile.linkOidcIdentity({
-      provider: 'github',
-      issuer: 'https://github.com',
-      subject: 'gh-123',
-      email: 'olive@example.com',
-    });
-    expect(identity.profileId).toBe(profile.id);
+    await expect(
+      profile.linkOidcIdentity({
+        provider: 'github',
+        issuer: 'https://github.com',
+        subject: 'gh-123',
+        email: 'olive@example.com',
+      }),
+    ).rejects.toThrow('no longer creates authentication links');
 
     const identities = await profile.getOidcIdentities();
-    expect(identities).toHaveLength(1);
-    expect(identities[0].subject).toBe('gh-123');
+    expect(identities).toHaveLength(0);
   });
 
   it('links and reads Nostr identities through the profile model', async () => {

--- a/packages/profiles/src/__tests__/profile-email-key-backfill.test.ts
+++ b/packages/profiles/src/__tests__/profile-email-key-backfill.test.ts
@@ -1,0 +1,130 @@
+import { randomUUID } from 'node:crypto';
+import { type DatabaseInterface, getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { backfillProfileEmailKeys } from '../migrations/backfillProfileEmailKeys.js';
+
+describe('backfillProfileEmailKeys', () => {
+  let db: DatabaseInterface;
+
+  beforeEach(async () => {
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    await db.query(
+      `CREATE TABLE profiles (
+        id TEXT PRIMARY KEY NOT NULL,
+        email TEXT,
+        email_key TEXT
+      )`,
+    );
+  });
+
+  afterEach(async () => {
+    await db.close?.();
+  });
+
+  it('uses application Unicode and whitespace normalization idempotently', async () => {
+    const profileId = randomUUID();
+    const blankProfileId = randomUUID();
+    await db.query(
+      `INSERT INTO profiles (id, email, email_key)
+       VALUES (?, ?, NULL), (?, ?, NULL)`,
+      profileId,
+      '\tÜser@Example.com\t',
+      blankProfileId,
+      '\t',
+    );
+
+    await expect(backfillProfileEmailKeys(db)).resolves.toEqual({ updated: 1 });
+    const result = await db.query(
+      'SELECT id, email_key FROM profiles ORDER BY id',
+    );
+    const keys = new Map(
+      result.rows.map((row) => [String(row.id), row.email_key]),
+    );
+    expect(keys.get(profileId)).toBe('üser@example.com');
+    expect(keys.get(blankProfileId)).toBeNull();
+    await expect(readBackfillMarker(db)).resolves.toBe(true);
+    await expect(backfillProfileEmailKeys(db)).resolves.toEqual({ updated: 0 });
+  });
+
+  it('rolls back every key and the readiness marker when an update fails', async () => {
+    const firstId = await seedLegacyProfile(db, 'first@example.com');
+    const secondId = await seedLegacyProfile(db, 'second@example.com');
+    const transaction = db.transaction;
+    if (!transaction)
+      throw new Error('SQLite test database requires transaction().');
+    const failingDb = new Proxy(db, {
+      get(target, property, receiver) {
+        if (property !== 'transaction') {
+          const value = Reflect.get(target, property, receiver);
+          return typeof value === 'function' ? value.bind(target) : value;
+        }
+        return async <T>(
+          callback: (tx: DatabaseInterface) => Promise<T>,
+        ): Promise<T> =>
+          transaction.call(target, async (tx) => {
+            let updates = 0;
+            const failingTx = new Proxy(tx, {
+              get(txTarget, txProperty, txReceiver) {
+                if (txProperty !== 'query') {
+                  const value = Reflect.get(txTarget, txProperty, txReceiver);
+                  return typeof value === 'function'
+                    ? value.bind(txTarget)
+                    : value;
+                }
+                return async (sql: string, ...params: unknown[]) => {
+                  if (sql.startsWith('UPDATE profiles')) {
+                    updates += 1;
+                    if (updates === 2) {
+                      throw new Error('forced profile backfill update failure');
+                    }
+                  }
+                  return txTarget.query(sql, ...params);
+                };
+              },
+            });
+            return callback(failingTx);
+          });
+      },
+    }) as DatabaseInterface;
+
+    await expect(backfillProfileEmailKeys(failingDb)).rejects.toThrow(
+      'forced profile backfill update failure',
+    );
+    await expect(readEmailKey(db, firstId)).resolves.toBeNull();
+    await expect(readEmailKey(db, secondId)).resolves.toBeNull();
+    await expect(readBackfillMarker(db)).resolves.toBe(false);
+  });
+});
+
+async function seedLegacyProfile(
+  db: DatabaseInterface,
+  email: string,
+): Promise<string> {
+  const id = randomUUID();
+  await db.query(
+    'INSERT INTO profiles (id, email, email_key) VALUES (?, ?, NULL)',
+    id,
+    email,
+  );
+  return id;
+}
+
+async function readEmailKey(
+  db: DatabaseInterface,
+  profileId: string,
+): Promise<string | null> {
+  const result = await db.query(
+    'SELECT email_key FROM profiles WHERE id = ?',
+    profileId,
+  );
+  const value = result.rows[0]?.email_key;
+  return value == null ? null : String(value);
+}
+
+async function readBackfillMarker(db: DatabaseInterface): Promise<boolean> {
+  const result = await db.query(
+    `SELECT 1 FROM _smrt_backfills
+     WHERE name = '@happyvertical/smrt-profiles:profile-email-keys:v1'`,
+  );
+  return result.rows.length === 1;
+}

--- a/packages/profiles/src/__tests__/profiles-tenant-isolation.test.ts
+++ b/packages/profiles/src/__tests__/profiles-tenant-isolation.test.ts
@@ -105,4 +105,18 @@ describe('profiles tenant isolation (#1600)', () => {
       ),
     ).toEqual(['g-profile', 't2-profile']);
   });
+
+  it('ProfileTypeCollection.getOrCreateBySlug preserves tenant auto-population', async () => {
+    const types = await ProfileTypeCollection.create({ db });
+    const created = await withTenant({ tenantId: 'tenant-1' }, () =>
+      types.getOrCreateBySlug('tenant-person', { name: 'Tenant Person' }),
+    );
+
+    expect(created.tenantId).toBe('tenant-1');
+    const stored = await db.query(
+      'SELECT tenant_id FROM profile_types WHERE id = ?',
+      created.id,
+    );
+    expect(stored.rows[0]?.tenant_id).toBe('tenant-1');
+  });
 });

--- a/packages/profiles/src/__tests__/resolve-identity.test.ts
+++ b/packages/profiles/src/__tests__/resolve-identity.test.ts
@@ -10,9 +10,11 @@
 import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { getDatabase } from '@happyvertical/sql';
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   ApiKey,
+  backfillProfileEmailKeys,
   createAuthEvent,
   createProfileFromNostr,
   createProfileFromOidc,
@@ -50,8 +52,11 @@ async function createProfile(dbUrl: string, email: string) {
 describe('resolveIdentity', () => {
   let dbUrl: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     dbUrl = getTestDbUrl('resolve-identity');
+    const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+    await ProfileCollection.create({ db });
+    await backfillProfileEmailKeys(db);
   });
 
   it('resolves via API key', async () => {
@@ -88,6 +93,56 @@ describe('resolveIdentity', () => {
     expect(result.source).toBe('oidc');
     expect(result.profile?.id).toBe(profile.id);
     expect(result.oidcIdentity?.lastUsedAt).toBeInstanceOf(Date);
+  });
+
+  it('fails closed on duplicate legacy issuer-subject mappings', async () => {
+    const db = { type: 'sqlite' as const, url: dbUrl };
+    const first = await createProfileFromOidc(
+      {
+        sub: 'legacy-first',
+        iss: 'https://legacy-first.example.com',
+        email: `legacy-first-${randomUUID()}@example.com`,
+        email_verified: true,
+      },
+      'legacy',
+      { db },
+    );
+    const second = await createProfileFromOidc(
+      {
+        sub: 'legacy-second',
+        iss: 'https://legacy-second.example.com',
+        email: `legacy-second-${randomUUID()}@example.com`,
+        email_verified: true,
+      },
+      'legacy',
+      { db },
+    );
+    const database = await getDatabase(db);
+    try {
+      await database.query(
+        `UPDATE oidc_identities
+           SET issuer = ?, subject = ?, identity_key = NULL
+         WHERE id IN (?, ?)`,
+        'https://duplicate.example.com',
+        'duplicate-subject',
+        first.oidcIdentity.id,
+        second.oidcIdentity.id,
+      );
+
+      await expect(
+        resolveIdentity({
+          oidcSession: {
+            iss: 'https://duplicate.example.com',
+            sub: 'duplicate-subject',
+          },
+          db,
+        }),
+      ).rejects.toThrow(
+        'Multiple OIDC identities match the same issuer and subject.',
+      );
+    } finally {
+      await database.close?.();
+    }
   });
 
   it('resolves via a Nostr signed auth event', async () => {
@@ -217,27 +272,37 @@ describe('createProfileFromNostr', () => {
 describe('OidcIdentity model and collection', () => {
   let dbUrl: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     dbUrl = getTestDbUrl('oidc-identity');
+    const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+    await ProfileCollection.create({ db });
+    await backfillProfileEmailKeys(db);
   });
 
-  it('links, finds, updates, and unlinks OIDC identities', async () => {
-    const { db, profile } = await createProfile(
-      dbUrl,
-      `oidc-coll-${randomUUID()}@example.com`,
+  it('reuses, finds, updates, and unlinks exact OIDC identities', async () => {
+    const db = { type: 'sqlite' as const, url: dbUrl };
+    const created = await createProfileFromOidc(
+      {
+        email: `oidc-coll-${randomUUID()}@example.com`,
+        email_verified: true,
+        iss: 'https://accounts.google.com',
+        sub: 'google-1',
+      },
+      'google',
+      { db },
     );
     const identities = await OidcIdentityCollection.create({ db });
 
-    const identity = await identities.linkToProfile(profile, {
+    const identity = await identities.linkToProfile(created.profile, {
       provider: 'google',
       issuer: 'https://accounts.google.com',
       subject: 'google-1',
       email: 'g@example.com',
     });
-    expect(identity.profileId).toBe(profile.id);
+    expect(identity.profileId).toBe(created.profile.id);
 
     // Re-linking the same issuer+subject updates rather than duplicates.
-    const relinked = await identities.linkToProfile(profile, {
+    const relinked = await identities.linkToProfile(created.profile, {
       provider: 'google',
       issuer: 'https://accounts.google.com',
       subject: 'google-1',
@@ -246,9 +311,9 @@ describe('OidcIdentity model and collection', () => {
     expect(relinked.id).toBe(identity.id);
     expect(relinked.email).toBe('updated@example.com');
 
-    expect(await identities.findByProfile(profile.id as string)).toHaveLength(
-      1,
-    );
+    expect(
+      await identities.findByProfile(created.profile.id as string),
+    ).toHaveLength(1);
     expect(await identities.findByProvider('google')).toHaveLength(1);
     expect(
       (
@@ -262,18 +327,18 @@ describe('OidcIdentity model and collection', () => {
     // recordUsage bumps lastUsedAt.
     await identity.recordUsage();
     expect(identity.lastUsedAt).toBeInstanceOf(Date);
-    expect((await identity.getProfile())?.id).toBe(profile.id);
+    expect((await identity.getProfile())?.id).toBe(created.profile.id);
 
     expect(
       await identities.unlinkFromProfile(
-        profile.id as string,
+        created.profile.id as string,
         'https://accounts.google.com',
         'google-1',
       ),
     ).toBe(true);
     expect(
       await identities.unlinkFromProfile(
-        profile.id as string,
+        created.profile.id as string,
         'https://accounts.google.com',
         'missing',
       ),

--- a/packages/profiles/src/auth/index.ts
+++ b/packages/profiles/src/auth/index.ts
@@ -22,6 +22,7 @@ export {
   type Nip05Request,
   parseNip05Identifier,
 } from './nip05Handler';
+export { normalizeIdentityEmail } from './normalizeIdentityEmail';
 // Nostr crypto utilities
 export {
   computeEventId,

--- a/packages/profiles/src/auth/normalizeIdentityEmail.ts
+++ b/packages/profiles/src/auth/normalizeIdentityEmail.ts
@@ -1,0 +1,13 @@
+/**
+ * Canonicalize an email used as an external identity key.
+ *
+ * Keep this in application code: SQL `trim()` and `lower()` have
+ * adapter-specific whitespace and Unicode behavior.
+ */
+export function normalizeIdentityEmail(email: string): string {
+  const normalized = email.trim().toLowerCase();
+  if (!normalized) {
+    throw new Error('Identity email normalization requires a non-blank email.');
+  }
+  return normalized;
+}

--- a/packages/profiles/src/auth/oidcProvisioningCoordinator.ts
+++ b/packages/profiles/src/auth/oidcProvisioningCoordinator.ts
@@ -1,0 +1,479 @@
+import { ValidationError } from '@happyvertical/smrt-core';
+import {
+  BackfillTableUnavailableError,
+  BackfillTracker,
+} from '@happyvertical/smrt-core/migrations';
+import type { getDatabase } from '@happyvertical/sql';
+
+type DatabaseInterface = Awaited<ReturnType<typeof getDatabase>>;
+
+const provisioningLocks = new Map<
+  string | object,
+  Map<string, Promise<void>>
+>();
+const sqliteRetryLocks = new Map<string | object, Promise<void>>();
+let savepointSequence = 0;
+
+const OIDC_RACE_FIELD_NAMES = new Set([
+  'email_key',
+  'emailKey',
+  'identity_key',
+  'identityKey',
+  'profile_id',
+  'profileId',
+]);
+const OIDC_RACE_MESSAGE_PATTERNS = [
+  /oidc_identities[._].*identity_key/iu,
+  /oidc_identities_identity_key/iu,
+  /oidc_profile_email_reservations[._].*(?:email_key|profile_id)/iu,
+  /profile_types_slug_context_meta_type/iu,
+];
+
+class OidcRaceArbiterConflict extends Error {
+  constructor(cause: unknown) {
+    super('An OIDC provisioning race arbiter reported a unique conflict.', {
+      cause,
+    });
+    this.name = 'OidcRaceArbiterConflict';
+  }
+}
+
+class SavepointUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super('OIDC provisioning could not start a transaction savepoint.', {
+      cause,
+    });
+    this.name = 'SavepointUnavailableError';
+  }
+}
+
+/** Shared transaction and concurrency policy for OIDC provisioning. */
+export interface OidcProvisioningCoordinatorOptions<T> {
+  /** Root or transaction-bound database used for every provisioning write. */
+  db: DatabaseInterface;
+  /**
+   * Stable keys used for local serialization. Supply both the exact
+   * issuer/subject key and normalized email when available.
+   */
+  lockKeys: readonly string[];
+  /** Package-specific durable race-arbiter classifier. */
+  isRaceConflict: (error: unknown) => boolean;
+  /** Package-specific transaction failure mapping. */
+  createTransactionError: (message: string, cause?: unknown) => Error;
+  /** Package-specific terminal concurrency failure mapping. */
+  createConcurrencyError: (cause?: unknown) => Error;
+  /** Provision atomically using the supplied transaction-bound handle. */
+  provision: (tx: DatabaseInterface) => Promise<T>;
+  /**
+   * Rehydrate root-owned results after commit so models do not retain a
+   * released transaction client. Omit for non-model results.
+   */
+  rebindRootResult?: (result: T, rootDb: DatabaseInterface) => Promise<T>;
+}
+
+/**
+ * Coordinate one OIDC provisioning operation across adapters.
+ *
+ * Root adapters must expose `beginTransaction`. Already-bound adapters must
+ * support savepoints. An adapter that exposes only `transaction()` is
+ * intentionally ambiguous and fails closed instead of risking a nested
+ * transaction that could roll back its caller's work.
+ */
+export async function coordinateOidcProvisioning<T>(
+  options: OidcProvisioningCoordinatorOptions<T>,
+): Promise<T> {
+  // Establish the shared backfill table outside the provisioning transaction.
+  // Transaction-bound callers are handled below via savepoints and must not
+  // leak DDL into their caller's transaction.
+  const rootBackfillTableReady =
+    typeof options.db.beginTransaction === 'function';
+  if (rootBackfillTableReady) {
+    await new BackfillTracker({ db: options.db }).initialize();
+  }
+  return withProvisioningLocks(options.db, options.lockKeys, async () => {
+    const result = await retryProvisioning(options, () =>
+      withProvisioningTransaction(
+        options.db,
+        (tx) => {
+          // Marker reads inside provisioning transactions must never run DDL.
+          // Root callers inherit a verified durable initialization; already-
+          // bound callers may read an existing table but fail closed if it is
+          // absent because no root handle is available for safe recovery.
+          if (rootBackfillTableReady) {
+            BackfillTracker.inheritInitialization(tx, options.db);
+          } else {
+            BackfillTracker.requireExistingTable(tx);
+          }
+          return options.provision(tx);
+        },
+        options.createTransactionError,
+      ),
+    );
+    return rootBackfillTableReady && options.rebindRootResult
+      ? options.rebindRootResult(result, options.db)
+      : result;
+  });
+}
+
+async function withProvisioningLocks<T>(
+  db: DatabaseInterface,
+  lockKeys: readonly string[],
+  callback: () => Promise<T>,
+): Promise<T> {
+  // SQLite and DuckDB root handles cannot safely overlap transactions, even
+  // when the identities are unrelated. Their database-scoped adapter lock is
+  // acquired before the narrower identity/email locks shared across handles.
+  const keys = [
+    ...new Set([
+      ...(!isPostgresDatabase(db) || typeof db.beginTransaction !== 'function'
+        ? ['adapter-transaction']
+        : []),
+      ...lockKeys,
+    ]),
+  ].sort();
+  const acquire = (index: number): Promise<T> =>
+    index >= keys.length
+      ? callback()
+      : withProvisioningLock(db, keys[index], () => acquire(index + 1));
+  return acquire(0);
+}
+
+/** Detect an adapter error caused by an aborted transaction. */
+export function isOidcAbortedTransactionError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+    if (
+      /current transaction is aborted|transaction.*aborted/iu.test(
+        current.message,
+      )
+    ) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+export interface OidcProvisioningRaceClassifierOptions {
+  /** Package-specific database constraint messages. */
+  messagePatterns?: readonly RegExp[];
+}
+
+function testRaceMessagePattern(pattern: RegExp, message: string): boolean {
+  // Callers may supply stateful global/sticky expressions. Do not let a prior
+  // classification change the result of the next provisioning attempt.
+  pattern.lastIndex = 0;
+  try {
+    return pattern.test(message);
+  } finally {
+    pattern.lastIndex = 0;
+  }
+}
+
+/** Classify only the durable constraints used to converge OIDC retries. */
+export function isOidcProvisioningRaceConflict(
+  error: unknown,
+  options: OidcProvisioningRaceClassifierOptions = {},
+): boolean {
+  if (isOidcAbortedTransactionError(error)) return true;
+  const pending: unknown[] = [error];
+  const seen = new Set<unknown>();
+  const messagePatterns = [
+    ...OIDC_RACE_MESSAGE_PATTERNS,
+    ...(options.messagePatterns ?? []),
+  ];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current || typeof current !== 'object' || seen.has(current)) continue;
+    seen.add(current);
+    if (current instanceof OidcRaceArbiterConflict) return true;
+    if (
+      current instanceof Error &&
+      current.name === 'CanonicalPersonProfileError' &&
+      (current as Error & { code?: unknown }).code === 'reservation_conflict'
+    ) {
+      return true;
+    }
+    if (
+      current instanceof ValidationError &&
+      current.code === 'VALIDATION_UNIQUE_CONSTRAINT' &&
+      OIDC_RACE_FIELD_NAMES.has(String(current.details?.fieldName ?? ''))
+    ) {
+      return true;
+    }
+    if (
+      current instanceof Error &&
+      messagePatterns.some((pattern) =>
+        testRaceMessagePattern(pattern, current.message),
+      )
+    ) {
+      return true;
+    }
+    const details = current as {
+      cause?: unknown;
+      context?: unknown;
+      details?: unknown;
+      originalError?: unknown;
+    };
+    pending.push(
+      details.cause,
+      details.context,
+      details.details,
+      details.originalError,
+    );
+    if (current instanceof AggregateError) pending.push(...current.errors);
+  }
+  return false;
+}
+
+/** Wrap a known OIDC arbiter write so only its unique failure is retryable. */
+export async function saveOidcRaceArbiter<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (
+      (error instanceof ValidationError &&
+        error.code === 'VALIDATION_UNIQUE_CONSTRAINT') ||
+      isOidcAbortedTransactionError(error)
+    ) {
+      throw new OidcRaceArbiterConflict(error);
+    }
+    throw error;
+  }
+}
+
+async function withProvisioningLock<T>(
+  db: DatabaseInterface,
+  lockKey: string,
+  callback: () => Promise<T>,
+): Promise<T> {
+  // Non-Postgres handles for the same URL share a local lock. Durable unique
+  // keys remain the cross-process and PostgreSQL race arbiters.
+  const databaseKey = getDatabaseLockKey(db);
+  const locks = provisioningLocks.get(databaseKey) ?? new Map();
+  provisioningLocks.set(databaseKey, locks);
+  const previous = locks.get(lockKey) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = previous.then(() => current);
+  locks.set(lockKey, queued);
+  await previous;
+  try {
+    return await callback();
+  } finally {
+    release();
+    if (locks.get(lockKey) === queued) locks.delete(lockKey);
+    if (locks.size === 0) provisioningLocks.delete(databaseKey);
+  }
+}
+
+function getDatabaseLockKey(db: DatabaseInterface): string | object {
+  const url = db.url;
+  if (
+    isPostgresDatabase(db) &&
+    typeof db.beginTransaction !== 'function' &&
+    db.client !== null &&
+    (typeof db.client === 'object' || typeof db.client === 'function')
+  ) {
+    return db.client;
+  }
+  return url && !isPostgresDatabase(db) ? url : (db as object);
+}
+
+function isPostgresDatabase(db: DatabaseInterface): boolean {
+  return /^postgres(?:ql)?:/iu.test(db.url ?? '');
+}
+
+async function retryProvisioning<T>(
+  options: OidcProvisioningCoordinatorOptions<T>,
+  callback: () => Promise<T>,
+): Promise<T> {
+  let serializeSqliteRetry = false;
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    try {
+      return await (serializeSqliteRetry
+        ? withSqliteRetryLock(options.db, callback)
+        : callback());
+    } catch (error) {
+      if (error instanceof BackfillTableUnavailableError) {
+        if (typeof options.db.beginTransaction === 'function' && attempt < 7) {
+          BackfillTracker.invalidateInitialization(options.db);
+          await new BackfillTracker({ db: options.db }).initialize();
+          continue;
+        }
+        throw options.createTransactionError(
+          'Transaction-bound OIDC provisioning requires an existing _smrt_backfills table; pass the root database so SMRT can initialize it safely.',
+          error,
+        );
+      }
+      const sqliteBusy = isSqliteBusyError(error);
+      const postgresTransactionRetry = isPostgresTransactionRetryError(error);
+      const raceConflict = options.isRaceConflict(error);
+      if (!sqliteBusy && !postgresTransactionRetry && !raceConflict)
+        throw error;
+      if (sqliteBusy && attempt < 7) {
+        serializeSqliteRetry = true;
+        await waitForRetry(Math.min(100 * 2 ** attempt, 1_000));
+        continue;
+      }
+      if (postgresTransactionRetry && attempt < 7) {
+        await waitForRetry(Math.min(25 * 2 ** attempt, 500));
+        continue;
+      }
+      if (raceConflict && attempt === 0) continue;
+      throw options.createConcurrencyError(error);
+    }
+  }
+  throw options.createConcurrencyError();
+}
+
+function isPostgresTransactionRetryError(error: unknown): boolean {
+  const pending: unknown[] = [error];
+  const seen = new Set<unknown>();
+  const messagePattern =
+    /deadlock detected|could not serialize access|serialization failure/iu;
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (!current || typeof current !== 'object' || seen.has(current)) continue;
+    seen.add(current);
+    const details = current as {
+      cause?: unknown;
+      code?: unknown;
+      context?: unknown;
+      originalError?: unknown;
+    };
+    if (details.code === '40P01' || details.code === '40001') return true;
+    if (current instanceof Error && messagePattern.test(current.message)) {
+      return true;
+    }
+    pending.push(details.cause, details.context, details.originalError);
+    if (current instanceof AggregateError) pending.push(...current.errors);
+  }
+  return false;
+}
+
+async function withSqliteRetryLock<T>(
+  db: DatabaseInterface,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const key = db.url || (db as object);
+  const previous = sqliteRetryLocks.get(key) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = previous.then(() => current);
+  sqliteRetryLocks.set(key, queued);
+  await previous;
+  try {
+    return await callback();
+  } finally {
+    release();
+    if (sqliteRetryLocks.get(key) === queued) sqliteRetryLocks.delete(key);
+  }
+}
+
+function isSqliteBusyError(error: unknown): boolean {
+  const pending: unknown[] = [error];
+  const seen = new Set<unknown>();
+  const busyPattern =
+    /SQLITE_(?:BUSY|LOCKED)|database(?: table)? is locked|cannot (?:commit transaction|release savepoint) - SQL statements in progress/iu;
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (typeof current === 'string') {
+      if (busyPattern.test(current)) return true;
+      continue;
+    }
+    if (!current || typeof current !== 'object' || seen.has(current)) continue;
+    seen.add(current);
+    if (current instanceof Error) {
+      if (busyPattern.test(current.message)) return true;
+      pending.push((current as { cause?: unknown }).cause);
+      if (current instanceof AggregateError) pending.push(...current.errors);
+    }
+    const details = current as {
+      context?: unknown;
+      details?: unknown;
+      originalError?: unknown;
+    };
+    pending.push(details.context, details.details, details.originalError);
+  }
+  return false;
+}
+
+async function waitForRetry(milliseconds: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function withProvisioningTransaction<T>(
+  db: DatabaseInterface,
+  callback: (tx: DatabaseInterface) => Promise<T>,
+  createTransactionError: (message: string, cause?: unknown) => Error,
+): Promise<T> {
+  if (typeof db.beginTransaction === 'function') {
+    if (db.transaction) return db.transaction((tx) => callback(tx));
+    const tx = await db.beginTransaction();
+    try {
+      const result = await callback(tx);
+      await tx.commit();
+      return result;
+    } catch (error) {
+      try {
+        if (tx.isActive()) await tx.rollback();
+      } catch (rollbackError) {
+        throw createTransactionError(
+          'OIDC provisioning could not roll back its root transaction.',
+          new AggregateError([error, rollbackError]),
+        );
+      }
+      throw error;
+    }
+  }
+
+  try {
+    return await withSavepoint(db, () => callback(db), createTransactionError);
+  } catch (error) {
+    if (!(error instanceof SavepointUnavailableError)) throw error;
+    throw createTransactionError(
+      'OIDC provisioning requires a root database or a transaction handle that supports savepoints.',
+      error.cause,
+    );
+  }
+}
+
+async function withSavepoint<T>(
+  db: DatabaseInterface,
+  callback: () => Promise<T>,
+  createTransactionError: (message: string, cause?: unknown) => Error,
+): Promise<T> {
+  savepointSequence = (savepointSequence + 1) % Number.MAX_SAFE_INTEGER;
+  const savepoint = `smrt_oidc_${savepointSequence.toString(36)}`;
+  try {
+    await db.query(`SAVEPOINT ${savepoint}`);
+  } catch (error) {
+    throw new SavepointUnavailableError(error);
+  }
+
+  try {
+    const result = await callback();
+    await db.query(`RELEASE SAVEPOINT ${savepoint}`);
+    return result;
+  } catch (error) {
+    try {
+      await db.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+      await db.query(`RELEASE SAVEPOINT ${savepoint}`);
+    } catch (rollbackError) {
+      throw createTransactionError(
+        'OIDC provisioning could not roll back its transaction savepoint.',
+        new AggregateError([error, rollbackError]),
+      );
+    }
+    throw error;
+  }
+}

--- a/packages/profiles/src/auth/oidcProvisioningPrimitives.ts
+++ b/packages/profiles/src/auth/oidcProvisioningPrimitives.ts
@@ -1,0 +1,83 @@
+import type { getDatabase } from '@happyvertical/sql';
+import { ProfileCollection } from '../collections/ProfileCollection';
+import { ProfileTypeCollection } from '../collections/ProfileTypeCollection';
+import { OidcIdentity } from '../models/OidcIdentity';
+import type { Profile } from '../models/Profile';
+import { Person } from '../models/ProfileTypes';
+import { saveOidcRaceArbiter } from './oidcProvisioningCoordinator';
+
+type DatabaseInterface = Awaited<ReturnType<typeof getDatabase>>;
+
+export interface OidcProvisioningPersonInput {
+  email?: string;
+  name?: string;
+  preferredUsername?: string;
+  subject: string;
+}
+
+export interface OidcProvisioningIdentityInput {
+  email?: string;
+  issuer: string;
+  profileId: string;
+  provider: string;
+  subject: string;
+}
+
+/** Create and reserve a fresh global Person inside the caller's transaction. */
+export async function createOidcProvisioningPerson(
+  db: DatabaseInterface,
+  input: OidcProvisioningPersonInput,
+): Promise<Profile> {
+  const typeCollection = await ProfileTypeCollection.create({ db });
+  const personType = await typeCollection.getOrCreateGlobalBySlug('person', {
+    name: 'Person',
+    description: 'Individual person profile',
+  });
+  const typeId = requireProvisioningId(personType.id, 'Person ProfileType');
+  let profile: Profile = new Person({
+    db,
+    // OIDC display names are not identity keys. A per-profile slug keeps
+    // SMRT's natural-key upsert from replacing an unrelated Person.
+    slug: `oidc-${crypto.randomUUID()}`,
+    tenantId: null,
+    typeId,
+    email: input.email ?? '',
+    name: input.name || input.preferredUsername || input.subject,
+  });
+  await profile.initialize();
+  await saveOidcRaceArbiter(() => profile.save());
+
+  if (input.email) {
+    const profiles = await ProfileCollection.create({ db });
+    profile = await profiles.reserveCanonicalIdentityEmail(
+      requireProvisioningId(profile.id, 'Created Profile'),
+      input.email,
+    );
+  }
+  return profile;
+}
+
+/** Insert the identity after the caller proves Profile ownership. */
+export async function insertOidcProvisioningIdentity(
+  db: DatabaseInterface,
+  input: OidcProvisioningIdentityInput,
+): Promise<OidcIdentity> {
+  const identity = new OidcIdentity({
+    db,
+    email: input.email ?? '',
+    issuer: input.issuer,
+    profileId: input.profileId,
+    provider: input.provider,
+    subject: input.subject,
+  });
+  await identity.initialize();
+  await saveOidcRaceArbiter(() => identity.save());
+  return identity;
+}
+
+function requireProvisioningId(value: unknown, label: string): string {
+  if (typeof value !== 'string' || !value) {
+    throw new Error(`${label} did not produce an id.`);
+  }
+  return value;
+}

--- a/packages/profiles/src/auth/resolveIdentity.ts
+++ b/packages/profiles/src/auth/resolveIdentity.ts
@@ -291,9 +291,10 @@ async function findProfileByExternalId(
  * 3. Otherwise, create new profile + identity
  *
  * Security considerations:
- * - Existing issuer/subject links always keep their canonical Profile and
- *   refresh the cached identity email. An unverified address cannot reuse an
- *   existing email match.
+ * - Existing issuer/subject links always keep their already-linked Profile,
+ *   including legacy tenant-scoped or non-Person Profiles, and refresh the
+ *   cached identity email. This exact-link compatibility does not perform
+ *   email-based canonical reuse.
  * - New identities never attach to an existing email match through this
  *   Profile-only helper because Profile ownership belongs to the users package.
  *   Use `UserCollection.getOrCreateFromOidc()` for owner-aware verified-email
@@ -448,26 +449,26 @@ async function provisionOidcProfile(
   const { OidcIdentityCollection } = await import(
     '../collections/OidcIdentityCollection'
   );
-  const { ProfileCollection } = await import(
-    '../collections/ProfileCollection'
-  );
   const identityCollection = await OidcIdentityCollection.create(options);
   const existingIdentity = await identityCollection.findBySubject(
     claims.iss,
     claims.sub,
   );
-  const profileCollection = await ProfileCollection.create(options);
   if (existingIdentity) {
-    const profileId = requireOidcProfileId(existingIdentity.profileId);
-    let profile =
-      await profileCollection.requireCanonicalGlobalPerson(profileId);
-    profile = await profileCollection.reserveCanonicalIdentityEmail(profileId);
+    const profile = await existingIdentity.getProfile();
+    if (!profile) {
+      throw new Error('The exact OIDC identity has no linked Profile.');
+    }
     if (claims.email) existingIdentity.email = claims.email;
     existingIdentity.lastUsedAt = new Date();
     await existingIdentity.save();
     return { profile, oidcIdentity: existingIdentity, created: false };
   }
 
+  const { ProfileCollection } = await import(
+    '../collections/ProfileCollection'
+  );
+  const profileCollection = await ProfileCollection.create(options);
   if (claims.email) {
     const collision = await profileCollection.findUniqueGlobalPersonByEmail(
       claims.email,

--- a/packages/profiles/src/auth/resolveIdentity.ts
+++ b/packages/profiles/src/auth/resolveIdentity.ts
@@ -11,12 +11,26 @@
  * 4. Actor header (CI pass-through) → Profile lookup
  */
 
-import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
+import {
+  resolveDatabase,
+  type SmrtObjectOptions,
+} from '@happyvertical/smrt-core';
+import { withSystemContext } from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
 import { ApiKey } from '../models/ApiKey';
 import { NostrIdentity } from '../models/NostrIdentity';
 import { OidcIdentity } from '../models/OidcIdentity';
 import type { Profile } from '../models/Profile';
+import { normalizeIdentityEmail } from './normalizeIdentityEmail';
 import { type NostrEvent, verifyAuthEvent } from './nostrCrypto';
+import {
+  coordinateOidcProvisioning,
+  isOidcProvisioningRaceConflict,
+} from './oidcProvisioningCoordinator';
+import {
+  createOidcProvisioningPerson,
+  insertOidcProvisioningIdentity,
+} from './oidcProvisioningPrimitives';
 
 /**
  * Context provided to resolveIdentity
@@ -270,23 +284,20 @@ async function findProfileByExternalId(
 /**
  * Create a profile from OIDC claims if it doesn't exist
  *
- * Supports email-based account linking: if a user signs in with Google
- * and later with GitHub using the same email, they get the same profile.
- *
  * Resolution order:
  * 1. If OIDC identity (iss + sub) already exists → return linked profile
- * 2. If verified email provided, check if profile with same email exists → link new identity
+ * 2. If the email matches an existing Profile, fail closed because this
+ *    package cannot prove whether a User owns it
  * 3. Otherwise, create new profile + identity
  *
  * Security considerations:
- * - Email-based linking only occurs when `email_verified` is true. This prevents
- *   attackers from claiming unverified emails to hijack accounts.
- * - Linking is automatic and irreversible through this API. Multiple OIDC
- *   identities from different providers sharing the same verified email will
- *   be associated to the same Profile.
- * - If an OIDC provider does not supply an email, or the email changes later,
- *   existing links are not automatically updated. New sign-ins without an email
- *   or with a different email may result in a new Profile being created.
+ * - Existing issuer/subject links always keep their canonical Profile and
+ *   refresh the cached identity email. An unverified address cannot reuse an
+ *   existing email match.
+ * - New identities never attach to an existing email match through this
+ *   Profile-only helper because Profile ownership belongs to the users package.
+ *   Use `UserCollection.getOrCreateFromOidc()` for owner-aware verified-email
+ *   reuse and its supported pre-provision resolver hook.
  * - This function trusts the OIDC provider to assert correct email_verified status.
  *   Only use with trusted providers.
  *
@@ -307,108 +318,267 @@ export async function createProfileFromOidc(
   provider: string,
   options: SmrtObjectOptions,
 ): Promise<{ profile: Profile; oidcIdentity: OidcIdentity; created: boolean }> {
-  // 1. If OIDC identity already exists for this issuer+subject, return linked profile
-  const existingIdentity = await OidcIdentity.findBySubject(
+  return coordinateProfileOidcProvisioning(claims, provider, options);
+}
+
+/**
+ * @internal Transactionally reuse one exact legacy issuer/subject link.
+ *
+ * This path cannot create or rebind authority. It intentionally preserves
+ * existing tenant-scoped and non-Person Profile links; canonical global Person
+ * validation remains mandatory for every path that creates a User/session.
+ */
+export async function reuseExistingOidcIdentityForProfile(
+  profileId: string,
+  claims: {
+    sub: string;
+    iss: string;
+    email?: string;
+    email_verified?: boolean;
+    name?: string;
+    preferred_username?: string;
+  },
+  provider: string,
+  options: SmrtObjectOptions,
+): Promise<{ profile: Profile; oidcIdentity: OidcIdentity; created: false }> {
+  const normalizedClaims = normalizeOidcProfileClaims(claims);
+  const db = await resolveOidcProfileDatabase(options.db);
+  return coordinateOidcProvisioning({
+    db,
+    lockKeys: [
+      `identity:${OidcIdentity.buildIdentityKey(
+        normalizedClaims.iss,
+        normalizedClaims.sub,
+      )}`,
+    ],
+    isRaceConflict: isOidcProvisioningRaceConflict,
+    createTransactionError: (message, cause) =>
+      new Error(message, cause === undefined ? undefined : { cause }),
+    createConcurrencyError: (cause) =>
+      new Error(
+        'Concurrent exact OIDC identity reuse did not converge.',
+        cause === undefined ? undefined : { cause },
+      ),
+    rebindRootResult: rebindOidcProfileResult,
+    provision: (tx) =>
+      withSystemContext(async () => {
+        const { OidcIdentityCollection } = await import(
+          '../collections/OidcIdentityCollection'
+        );
+        const identity = await (
+          await OidcIdentityCollection.create({ db: tx })
+        ).findBySubject(normalizedClaims.iss, normalizedClaims.sub);
+        if (!identity) {
+          throw new Error(
+            'OidcIdentity.findOrCreate() no longer creates authentication links; use UserCollection.getOrCreateFromOidc() or createProfileFromOidc().',
+          );
+        }
+        if (identity.profileId !== profileId) {
+          throw new Error(
+            `OIDC identity ${normalizedClaims.iss} subject ${normalizedClaims.sub} belongs to a different Profile.`,
+          );
+        }
+        const profile = await identity.getProfile();
+        if (!profile) {
+          throw new Error('The exact OIDC identity has no linked Profile.');
+        }
+        identity.provider = provider;
+        if (normalizedClaims.email) identity.email = normalizedClaims.email;
+        identity.lastUsedAt = new Date();
+        await identity.save();
+        return { profile, oidcIdentity: identity, created: false as const };
+      }),
+  });
+}
+
+async function coordinateProfileOidcProvisioning(
+  claims: {
+    sub: string;
+    iss: string;
+    email?: string;
+    email_verified?: boolean;
+    name?: string;
+    preferred_username?: string;
+  },
+  provider: string,
+  options: SmrtObjectOptions,
+): Promise<{ profile: Profile; oidcIdentity: OidcIdentity; created: boolean }> {
+  const normalizedClaims = normalizeOidcProfileClaims(claims);
+  const db = await resolveOidcProfileDatabase(options.db);
+  return coordinateOidcProvisioning({
+    db,
+    lockKeys: [
+      `identity:${OidcIdentity.buildIdentityKey(
+        normalizedClaims.iss,
+        normalizedClaims.sub,
+      )}`,
+      ...(normalizedClaims.email ? [`email:${normalizedClaims.email}`] : []),
+    ],
+    isRaceConflict: isOidcProvisioningRaceConflict,
+    createTransactionError: (message, cause) =>
+      new Error(message, cause === undefined ? undefined : { cause }),
+    createConcurrencyError: (cause) =>
+      new Error(
+        'Concurrent OIDC Profile provisioning did not converge.',
+        cause === undefined ? undefined : { cause },
+      ),
+    rebindRootResult: rebindOidcProfileResult,
+    provision: (tx) =>
+      withSystemContext(() =>
+        provisionOidcProfile(normalizedClaims, provider, {
+          ...options,
+          db: tx,
+        }),
+      ),
+  });
+}
+
+async function provisionOidcProfile(
+  claims: {
+    sub: string;
+    iss: string;
+    email?: string;
+    email_verified?: boolean;
+    name?: string;
+    preferred_username?: string;
+  },
+  provider: string,
+  options: SmrtObjectOptions & { db: DatabaseInterface },
+): Promise<{ profile: Profile; oidcIdentity: OidcIdentity; created: boolean }> {
+  const { OidcIdentityCollection } = await import(
+    '../collections/OidcIdentityCollection'
+  );
+  const { ProfileCollection } = await import(
+    '../collections/ProfileCollection'
+  );
+  const identityCollection = await OidcIdentityCollection.create(options);
+  const existingIdentity = await identityCollection.findBySubject(
     claims.iss,
     claims.sub,
-    options,
   );
-
+  const profileCollection = await ProfileCollection.create(options);
   if (existingIdentity) {
-    const profile = await existingIdentity.getProfile();
-    if (profile) {
-      // Update identity with latest claims
-      if (claims.email) existingIdentity.email = claims.email;
-      existingIdentity.lastUsedAt = new Date();
-      await existingIdentity.save();
-
-      return {
-        profile,
-        oidcIdentity: existingIdentity,
-        created: false,
-      };
-    }
+    const profileId = requireOidcProfileId(existingIdentity.profileId);
+    let profile =
+      await profileCollection.requireCanonicalGlobalPerson(profileId);
+    profile = await profileCollection.reserveCanonicalIdentityEmail(profileId);
+    if (claims.email) existingIdentity.email = claims.email;
+    existingIdentity.lastUsedAt = new Date();
+    await existingIdentity.save();
+    return { profile, oidcIdentity: existingIdentity, created: false };
   }
 
-  // 2. Email-based account linking: only link if email is verified (security)
-  if (claims.email && claims.email_verified) {
-    const { ProfileCollection } = await import(
-      '../collections/ProfileCollection'
+  if (claims.email) {
+    const collision = await profileCollection.findUniqueGlobalPersonByEmail(
+      claims.email,
     );
-
-    const profileCollection = await ProfileCollection.create(options);
-    const existingProfile = await profileCollection.findByEmail(claims.email);
-
-    if (existingProfile) {
-      // Link new OIDC identity to existing profile (email-based linking)
-      const oidcIdentity = await OidcIdentity.findOrCreate(
-        existingProfile,
-        {
-          provider,
-          issuer: claims.iss,
-          subject: claims.sub,
-          email: claims.email,
-        },
-        options,
+    if (collision) {
+      if (claims.email_verified !== true) {
+        throw new Error(
+          `OIDC email ${claims.email} is not verified and already belongs to a Profile.`,
+        );
+      }
+      throw new Error(
+        `OIDC email ${claims.email} already belongs to a Profile; createProfileFromOidc() cannot prove that Profile is unowned. Use UserCollection.getOrCreateFromOidc() for owner-aware linking.`,
       );
-
-      return {
-        profile: existingProfile,
-        oidcIdentity,
-        created: false,
-      };
     }
   }
 
-  // 3. Create new profile
-  const { Person } = await import('../models/ProfileTypes');
-  const { ProfileTypeCollection } = await import(
-    '../collections/ProfileTypeCollection'
-  );
-
-  // Get or create the 'person' type
-  const typeCollection = await ProfileTypeCollection.create(options);
-  let personType = await typeCollection.getBySlug('person');
-
-  if (!personType) {
-    // Create the person type if it doesn't exist
-    const { ProfileType } = await import('../models/ProfileType');
-    personType = new ProfileType({
-      ...options,
-      slug: 'person',
-      name: 'Person',
-      description: 'Individual person profile',
-    });
-    await personType.initialize();
-    await personType.save();
-  }
-
-  const profile = new Person({
-    ...options,
-    typeId: personType.id as string,
-    email: claims.email || '',
-    name: claims.name || claims.preferred_username || claims.sub,
+  const profile = await createOidcProvisioningPerson(options.db, {
+    email: claims.email ?? '',
+    name: claims.name,
+    preferredUsername: claims.preferred_username,
+    subject: claims.sub,
   });
-  await profile.initialize();
-  await profile.save();
+  const oidcIdentity = await insertOidcProvisioningIdentity(options.db, {
+    email: claims.email,
+    issuer: claims.iss,
+    profileId: requireOidcProfileId(profile.id),
+    provider,
+    subject: claims.sub,
+  });
+  return { profile, oidcIdentity, created: true };
+}
 
-  // Link OIDC identity
-  const oidcIdentity = await OidcIdentity.findOrCreate(
-    profile,
-    {
-      provider,
-      issuer: claims.iss,
-      subject: claims.sub,
-      email: claims.email,
-    },
-    options,
+async function rebindOidcProfileResult<
+  T extends {
+    profile: Profile;
+    oidcIdentity: OidcIdentity;
+    created: boolean;
+  },
+>(result: T, rootDb: DatabaseInterface): Promise<T> {
+  const { OidcIdentityCollection } = await import(
+    '../collections/OidcIdentityCollection'
   );
+  const { ProfileCollection } = await import(
+    '../collections/ProfileCollection'
+  );
+  const profileId = requireOidcProfileId(result.profile.id);
+  const identityId = requireOidcProfileId(result.oidcIdentity.id);
+  const [profile, oidcIdentity] = await withSystemContext(async () => {
+    const profiles = await ProfileCollection.create({ db: rootDb });
+    const identities = await OidcIdentityCollection.create({ db: rootDb });
+    return Promise.all([
+      profiles.get({ id: profileId }),
+      identities.get({ id: identityId }),
+    ]);
+  });
+  if (!profile || !oidcIdentity) {
+    throw new Error(
+      'Committed OIDC Profile provisioning result was not found.',
+    );
+  }
+  return { ...result, profile, oidcIdentity };
+}
 
+function normalizeOidcProfileClaims(claims: {
+  sub: string;
+  iss: string;
+  email?: string;
+  email_verified?: boolean;
+  name?: string;
+  preferred_username?: string;
+}) {
+  const sub = claims?.sub;
+  const iss = claims?.iss;
+  if (
+    typeof sub !== 'string' ||
+    sub.trim().length === 0 ||
+    typeof iss !== 'string' ||
+    iss.trim().length === 0
+  ) {
+    throw new Error(
+      'Invalid OIDC claims: both "sub" and "iss" must be non-empty strings.',
+    );
+  }
+  const suppliedEmail = claims.email;
   return {
-    profile,
-    oidcIdentity,
-    created: true,
+    ...claims,
+    sub,
+    iss,
+    email:
+      typeof suppliedEmail === 'string' && suppliedEmail.trim()
+        ? normalizeIdentityEmail(suppliedEmail)
+        : undefined,
   };
+}
+
+function requireOidcProfileId(value: unknown): string {
+  if (typeof value !== 'string' || !value) {
+    throw new Error('OIDC Profile provisioning did not produce an id.');
+  }
+  return value;
+}
+
+async function resolveOidcProfileDatabase(
+  db: SmrtObjectOptions['db'],
+): Promise<DatabaseInterface> {
+  if (!db) {
+    throw new Error(
+      'OIDC Profile provisioning requires an initialized database.',
+    );
+  }
+  return resolveDatabase(db as Parameters<typeof resolveDatabase>[0]);
 }
 
 /**
@@ -437,7 +607,7 @@ export async function createProfileFromNostr(
   nostrIdentity: NostrIdentity;
   created: boolean;
 }> {
-  const normalizedEmail = email.toLowerCase();
+  const normalizedEmail = normalizeIdentityEmail(email);
 
   // Check if Nostr identity already exists
   const existingIdentity = await NostrIdentity.findByEmail(

--- a/packages/profiles/src/collections/OidcIdentityCollection.ts
+++ b/packages/profiles/src/collections/OidcIdentityCollection.ts
@@ -6,6 +6,17 @@ import { SmrtCollection } from '@happyvertical/smrt-core';
 import { OidcIdentity } from '../models/OidcIdentity';
 import type { Profile } from '../models/Profile';
 
+/** More than one legacy row maps the same opaque OIDC issuer and subject. */
+export class AmbiguousOidcIdentityError extends Error {
+  constructor(
+    readonly issuer: string,
+    readonly subject: string,
+  ) {
+    super('Multiple OIDC identities match the same issuer and subject.');
+    this.name = 'AmbiguousOidcIdentityError';
+  }
+}
+
 export class OidcIdentityCollection extends SmrtCollection<OidcIdentity> {
   static readonly _itemClass = OidcIdentity;
 
@@ -25,9 +36,14 @@ export class OidcIdentityCollection extends SmrtCollection<OidcIdentity> {
     issuer: string,
     subject: string,
   ): Promise<OidcIdentity | null> {
-    return await this.findOne({
+    const matches = await this.list({
       where: { issuer, subject },
+      limit: 2,
     });
+    if (matches.length > 1) {
+      throw new AmbiguousOidcIdentityError(issuer, subject);
+    }
+    return matches[0] ?? null;
   }
 
   /**
@@ -40,7 +56,11 @@ export class OidcIdentityCollection extends SmrtCollection<OidcIdentity> {
   }
 
   /**
-   * Link a new OIDC identity to a profile
+   * Reuse an existing exact OIDC identity for its unchanged Profile.
+   *
+   * @deprecated New authentication links require the owner-aware,
+   * transactional provisioning APIs. This compatibility helper may refresh a
+   * legacy Profile type, but refuses to create or rebind authority.
    */
   async linkToProfile(
     profile: Profile,
@@ -51,31 +71,7 @@ export class OidcIdentityCollection extends SmrtCollection<OidcIdentity> {
       email?: string;
     },
   ): Promise<OidcIdentity> {
-    // Check if already exists
-    const existing = await this.findBySubject(
-      oidcData.issuer,
-      oidcData.subject,
-    );
-    if (existing) {
-      // Update and return existing
-      existing.lastUsedAt = new Date();
-      if (oidcData.email) existing.email = oidcData.email;
-      await existing.save();
-      return existing;
-    }
-
-    // Create new
-    const identity = new OidcIdentity({
-      ...this.options,
-      profileId: profile.id as string,
-      provider: oidcData.provider,
-      issuer: oidcData.issuer,
-      subject: oidcData.subject,
-      email: oidcData.email || '',
-    });
-    await identity.initialize();
-    await identity.save();
-    return identity;
+    return OidcIdentity.findOrCreate(profile, oidcData, this.options);
   }
 
   /**

--- a/packages/profiles/src/collections/OidcProfileEmailReservationCollection.ts
+++ b/packages/profiles/src/collections/OidcProfileEmailReservationCollection.ts
@@ -1,0 +1,7 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { OidcProfileEmailReservation } from '../models/OidcProfileEmailReservation';
+
+/** Internal collection for canonical OIDC email reservations. */
+export class OidcProfileEmailReservationCollection extends SmrtCollection<OidcProfileEmailReservation> {
+  static readonly _itemClass = OidcProfileEmailReservation;
+}

--- a/packages/profiles/src/collections/ProfileCollection.ts
+++ b/packages/profiles/src/collections/ProfileCollection.ts
@@ -10,12 +10,59 @@ import {
   getOwnedAssetsFromCollection,
   removeOwnedAssetFromCollection,
 } from '@happyvertical/smrt-assets';
-import { SmrtCollection } from '@happyvertical/smrt-core';
-import { queryGlobal, queryWithGlobals } from '@happyvertical/smrt-tenancy';
+import { SmrtCollection, ValidationError } from '@happyvertical/smrt-core';
+import { BackfillTracker } from '@happyvertical/smrt-core/migrations';
+import {
+  queryGlobal,
+  queryWithGlobals,
+  withSystemContext,
+} from '@happyvertical/smrt-tenancy';
+import type { getDatabase } from '@happyvertical/sql';
+import { normalizeIdentityEmail } from '../auth/normalizeIdentityEmail';
+import { isOidcAbortedTransactionError } from '../auth/oidcProvisioningCoordinator';
+import { PROFILE_EMAIL_KEY_BACKFILL_NAME } from '../migrations/backfillProfileEmailKeys.js';
+import { OidcProfileEmailReservation } from '../models/OidcProfileEmailReservation';
 import { Profile } from '../models/Profile';
+import { OidcProfileEmailReservationCollection } from './OidcProfileEmailReservationCollection';
+
+const PERSON_META_TYPES = new Set([
+  '@happyvertical/smrt-profiles:Person',
+  'Person',
+]);
+
+type DatabaseInterface = Awaited<ReturnType<typeof getDatabase>>;
+
+export type CanonicalPersonProfileErrorCode =
+  | 'ambiguous_email'
+  | 'email_key_backfill_required'
+  | 'email_mismatch'
+  | 'missing_profile'
+  | 'non_person'
+  | 'reservation_conflict'
+  | 'tenant_scoped';
+
+/** A Profile cannot safely represent one global human identity. */
+export class CanonicalPersonProfileError extends Error {
+  constructor(
+    readonly code: CanonicalPersonProfileErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'CanonicalPersonProfileError';
+  }
+}
+
+interface CanonicalProfileRow extends Record<string, unknown> {
+  _meta_type?: unknown;
+  email?: unknown;
+  email_key?: unknown;
+  id?: unknown;
+  tenant_id?: unknown;
+}
 
 export class ProfileCollection extends SmrtCollection<Profile> {
   static readonly _itemClass = Profile;
+  private emailKeysReadyPromise: Promise<void> | null = null;
 
   /**
    * Find a profile by email address
@@ -24,12 +71,174 @@ export class ProfileCollection extends SmrtCollection<Profile> {
    * @returns The matching profile or null
    */
   async findByEmail(email: string): Promise<Profile | null> {
-    const normalizedEmail = email.toLowerCase();
+    const normalizedEmail = normalizeIdentityEmail(email);
     const profiles = await this.list({
       where: { email: normalizedEmail },
       limit: 1,
     });
-    return profiles.length > 0 ? profiles[0] : null;
+    return profiles[0] ?? null;
+  }
+
+  /**
+   * Resolve one unambiguous global Person by normalized email.
+   *
+   * Unlike `findByEmail()`, this identity-boundary helper deliberately reads
+   * across tenant scopes and fails closed when any matching row is
+   * tenant-scoped, is not a Person STI row, or when more than one row matches
+   * case-insensitively. It is intended for verified external identities.
+   */
+  async findUniqueGlobalPersonByEmail(email: string): Promise<Profile | null> {
+    const normalizedEmail = normalizeIdentityEmail(email);
+    const rows = await this.loadCanonicalEmailRows(normalizedEmail);
+
+    if (rows.length === 0) return null;
+    this.assertCanonicalRows(rows, normalizedEmail);
+    return this.requireHydratedProfile(readRequiredString(rows[0], 'id'));
+  }
+
+  /**
+   * Validate and hydrate a supplied canonical Profile.
+   *
+   * The Profile must be the sole case-insensitive match for its stored email.
+   * When `email` is provided, that address must also match the stored email.
+   */
+  async requireCanonicalGlobalPerson(
+    profileId: string,
+    email?: string,
+  ): Promise<Profile> {
+    const db = this.requireDatabase();
+    await this.ensureEmailKeysReady();
+    const result = await withSystemContext(() =>
+      db.query(
+        `SELECT id, tenant_id, _meta_type, email, email_key
+         FROM profiles
+         WHERE id = ?
+         LIMIT 1`,
+        profileId,
+      ),
+    );
+    const row = result.rows[0] as CanonicalProfileRow | undefined;
+
+    if (!row) {
+      throw new CanonicalPersonProfileError(
+        'missing_profile',
+        `Profile ${profileId} does not exist.`,
+      );
+    }
+
+    this.assertRowEmailKeyCurrent(row);
+    this.assertCanonicalRows([row]);
+
+    const storedEmail = readString(row, 'email');
+    const normalizedEmail =
+      email !== undefined
+        ? normalizeIdentityEmail(email)
+        : storedEmail
+          ? normalizeIdentityEmail(storedEmail)
+          : undefined;
+    if (normalizedEmail !== undefined) {
+      const matches = await this.loadCanonicalEmailRows(normalizedEmail);
+      this.assertCanonicalRows(matches, normalizedEmail);
+      if (
+        matches.length !== 1 ||
+        readRequiredString(matches[0], 'id') !== profileId
+      ) {
+        throw new CanonicalPersonProfileError(
+          'email_mismatch',
+          `Profile ${profileId} is not the unique global Person for ${normalizedEmail}.`,
+        );
+      }
+    }
+
+    return this.requireHydratedProfile(profileId);
+  }
+
+  /**
+   * Reserve the normalized email for a previously validated canonical Person.
+   *
+   * The unique stored key turns a concurrent OIDC first-login race into a
+   * retryable database conflict. Legacy Profiles remain unaffected until an
+   * identity boundary safely claims them.
+   */
+  async reserveCanonicalIdentityEmail(
+    profileId: string,
+    email?: string,
+  ): Promise<Profile> {
+    const profile = await this.requireCanonicalGlobalPerson(profileId, email);
+    const normalizedEmail =
+      email !== undefined
+        ? normalizeIdentityEmail(email)
+        : profile.email?.trim()
+          ? normalizeIdentityEmail(profile.email)
+          : null;
+    const db = this.requireDatabase();
+    const reservations = await OidcProfileEmailReservationCollection.create({
+      db,
+    });
+    const byProfile = await reservations.list({
+      where: { profileId },
+      limit: 2,
+    });
+    if (byProfile.length > 1) {
+      throw new CanonicalPersonProfileError(
+        'ambiguous_email',
+        `Multiple canonical identity reservations exist for Profile ${profileId}.`,
+      );
+    }
+    if (normalizedEmail === null) {
+      await byProfile[0]?.delete();
+      return profile;
+    }
+
+    const byEmail = await reservations.list({
+      where: { emailKey: normalizedEmail },
+      limit: 2,
+    });
+    const activeEmailReservations: typeof byEmail = [];
+    for (const reservation of byEmail) {
+      if (
+        reservation.profileId !== profileId &&
+        (await this.isStaleEmailReservation(reservation, normalizedEmail))
+      ) {
+        await reservation.delete();
+      } else {
+        activeEmailReservations.push(reservation);
+      }
+    }
+    const conflictingEmail = activeEmailReservations.find(
+      (reservation) => reservation.profileId !== profileId,
+    );
+    if (conflictingEmail) {
+      throw new CanonicalPersonProfileError(
+        'reservation_conflict',
+        `${normalizedEmail} is already reserved for a different canonical Person.`,
+      );
+    }
+    if (activeEmailReservations.length > 1) {
+      throw new CanonicalPersonProfileError(
+        'ambiguous_email',
+        `Multiple canonical identity reservations exist for ${normalizedEmail}.`,
+      );
+    }
+
+    const existing = byProfile[0];
+    if (existing) {
+      if (existing.emailKey !== normalizedEmail) {
+        existing.emailKey = normalizedEmail;
+        await saveIdentityEmailReservation(existing, normalizedEmail);
+      }
+      return profile;
+    }
+    if (!activeEmailReservations[0]) {
+      const reservation = new OidcProfileEmailReservation({
+        db,
+        emailKey: normalizedEmail,
+        profileId,
+      });
+      await reservation.initialize();
+      await saveIdentityEmailReservation(reservation, normalizedEmail);
+    }
+    return profile;
   }
 
   /**
@@ -51,6 +260,136 @@ export class ProfileCollection extends SmrtCollection<Profile> {
     }
 
     return filtered;
+  }
+
+  private requireDatabase(): DatabaseInterface {
+    const db = this.options.db;
+    if (!db || typeof db !== 'object' || !('query' in db)) {
+      throw new Error(
+        'Canonical Profile identity resolution requires an initialized database.',
+      );
+    }
+    return db as DatabaseInterface;
+  }
+
+  private async loadCanonicalEmailRows(
+    normalizedEmail: string,
+  ): Promise<CanonicalProfileRow[]> {
+    const db = this.requireDatabase();
+    await this.ensureEmailKeysReady();
+    const result = await withSystemContext(async () => {
+      return db.query(
+        `SELECT id, tenant_id, _meta_type, email, email_key
+         FROM profiles
+         WHERE email_key = ?
+         ORDER BY created_at ASC, id ASC
+         LIMIT 2`,
+        normalizedEmail,
+      );
+    });
+    const rows = result.rows as CanonicalProfileRow[];
+    for (const row of rows) this.assertRowEmailKeyCurrent(row, normalizedEmail);
+    return rows;
+  }
+
+  /** Require the deploy-time backfill marker before indexed identity reads. */
+  private async ensureEmailKeysReady(): Promise<void> {
+    if (!this.emailKeysReadyPromise) {
+      this.emailKeysReadyPromise = this.checkEmailKeysReady().catch((error) => {
+        this.emailKeysReadyPromise = null;
+        throw error;
+      });
+    }
+    return this.emailKeysReadyPromise;
+  }
+
+  private async checkEmailKeysReady(): Promise<void> {
+    const db = this.requireDatabase();
+    if (
+      await new BackfillTracker({ db }).isApplied(
+        PROFILE_EMAIL_KEY_BACKFILL_NAME,
+      )
+    )
+      return;
+    throw new CanonicalPersonProfileError(
+      'email_key_backfill_required',
+      'Profile identity email keys are not marked ready; run backfillProfileEmailKeys() before identity lookup.',
+    );
+  }
+
+  private async isStaleEmailReservation(
+    reservation: OidcProfileEmailReservation,
+    reservedEmail: string,
+  ): Promise<boolean> {
+    const profileId = reservation.profileId;
+    if (!profileId) return true;
+    const result = await this.requireDatabase().query(
+      'SELECT email FROM profiles WHERE id = ? LIMIT 1',
+      profileId,
+    );
+    const row = result.rows[0] as CanonicalProfileRow | undefined;
+    if (!row) return true;
+    const email = readString(row, 'email');
+    return !email?.trim() || normalizeIdentityEmail(email) !== reservedEmail;
+  }
+
+  private assertRowEmailKeyCurrent(
+    row: CanonicalProfileRow,
+    normalizedEmail?: string,
+  ): void {
+    const email = readString(row, 'email') ?? '';
+    const expectedKey = email.trim() ? normalizeIdentityEmail(email) : null;
+    const storedKey = readString(row, 'email_key') ?? null;
+    if (
+      storedKey !== expectedKey ||
+      (normalizedEmail !== undefined && expectedKey !== normalizedEmail)
+    ) {
+      throw new CanonicalPersonProfileError(
+        'email_key_backfill_required',
+        `Profile ${String(row.id ?? '<unknown>')} has a missing or stale identity email key; run backfillProfileEmailKeys() before identity lookup.`,
+      );
+    }
+  }
+
+  private assertCanonicalRows(
+    rows: CanonicalProfileRow[],
+    normalizedEmail?: string,
+  ): void {
+    const tenantScoped = rows.find((row) => readString(row, 'tenant_id'));
+    if (tenantScoped) {
+      throw new CanonicalPersonProfileError(
+        'tenant_scoped',
+        `Profile ${readRequiredString(tenantScoped, 'id')} for ${normalizedEmail ?? 'the supplied identity'} is tenant-scoped.`,
+      );
+    }
+
+    const nonPerson = rows.find(
+      (row) => !PERSON_META_TYPES.has(readString(row, '_meta_type') ?? ''),
+    );
+    if (nonPerson) {
+      throw new CanonicalPersonProfileError(
+        'non_person',
+        `Profile ${readRequiredString(nonPerson, 'id')} for ${normalizedEmail ?? 'the supplied identity'} is not a Person.`,
+      );
+    }
+
+    if (rows.length > 1) {
+      throw new CanonicalPersonProfileError(
+        'ambiguous_email',
+        `Multiple Profiles use ${normalizedEmail ?? 'the supplied identity email'}.`,
+      );
+    }
+  }
+
+  private async requireHydratedProfile(profileId: string): Promise<Profile> {
+    const profile = await withSystemContext(() => this.get({ id: profileId }));
+    if (!profile) {
+      throw new CanonicalPersonProfileError(
+        'missing_profile',
+        `Profile ${profileId} could not be hydrated.`,
+      );
+    }
+    return profile;
   }
 
   /**
@@ -225,4 +564,38 @@ export class ProfileCollection extends SmrtCollection<Profile> {
   async findWithGlobals(tenantId: string): Promise<Profile[]> {
     return queryWithGlobals<Profile>(this, tenantId, 'Profile.findWithGlobals');
   }
+}
+
+async function saveIdentityEmailReservation(
+  reservation: OidcProfileEmailReservation,
+  normalizedEmail: string,
+): Promise<void> {
+  try {
+    await reservation.save();
+  } catch (error) {
+    if (
+      (error instanceof ValidationError &&
+        error.code === 'VALIDATION_UNIQUE_CONSTRAINT') ||
+      isOidcAbortedTransactionError(error)
+    ) {
+      throw new CanonicalPersonProfileError(
+        'reservation_conflict',
+        `${normalizedEmail} was concurrently reserved for another canonical Person.`,
+      );
+    }
+    throw error;
+  }
+}
+
+function readString(row: Record<string, unknown>, key: string): string | null {
+  const value = row[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function readRequiredString(row: Record<string, unknown>, key: string): string {
+  const value = readString(row, key);
+  if (!value) {
+    throw new Error(`Canonical Profile identity row is missing ${key}.`);
+  }
+  return value;
 }

--- a/packages/profiles/src/collections/ProfileTypeCollection.ts
+++ b/packages/profiles/src/collections/ProfileTypeCollection.ts
@@ -5,6 +5,7 @@
  */
 
 import { SmrtCollection } from '@happyvertical/smrt-core';
+import { isSystemContext } from '@happyvertical/smrt-tenancy';
 import { ProfileType } from '../models/ProfileType';
 
 export class ProfileTypeCollection extends SmrtCollection<ProfileType> {
@@ -37,5 +38,61 @@ export class ProfileTypeCollection extends SmrtCollection<ProfileType> {
     const profileType = await this.create({ slug, ...defaults });
     await profileType.save();
     return profileType;
+  }
+
+  /**
+   * Atomically create or load a global ProfileType from trusted system code.
+   *
+   * This intentionally bypasses tenant auto-population and therefore refuses
+   * to run outside an explicit `withSystemContext()` boundary.
+   */
+  async getOrCreateGlobalBySlug(
+    slug: string,
+    defaults: { name: string; description?: string },
+  ): Promise<ProfileType> {
+    if (!isSystemContext()) {
+      throw new Error(
+        'Global ProfileType creation requires an explicit system context.',
+      );
+    }
+
+    const existing = await this.loadGlobalBySlug(slug);
+    if (existing) return existing;
+
+    // A plain SMRT create is an upsert and may replace the winning row's id
+    // when two first-login transactions race. Keep the canonical id stable by
+    // using a cross-adapter insert-if-absent and then hydrating the winner.
+    await this.db.query(
+      `INSERT INTO profile_types
+        (id, slug, context, _meta_type, tenant_id, name, description)
+       VALUES (?, ?, '', '@happyvertical/smrt-profiles:ProfileType', NULL, ?, ?)
+       ON CONFLICT (slug, context, _meta_type) DO NOTHING`,
+      crypto.randomUUID(),
+      slug,
+      defaults.name,
+      defaults.description ?? null,
+    );
+    const profileType = await this.loadGlobalBySlug(slug);
+    if (!profileType) {
+      throw new Error(
+        `Global ProfileType '${slug}' could not be created or loaded.`,
+      );
+    }
+    return profileType;
+  }
+
+  private async loadGlobalBySlug(slug: string): Promise<ProfileType | null> {
+    const result = await this.db.query(
+      `SELECT id
+       FROM profile_types
+       WHERE slug = ?
+         AND context = ''
+         AND _meta_type = '@happyvertical/smrt-profiles:ProfileType'
+         AND tenant_id IS NULL
+       LIMIT 1`,
+      slug,
+    );
+    const id = result.rows[0]?.id;
+    return typeof id === 'string' ? this.get({ id }) : null;
   }
 }

--- a/packages/profiles/src/collections/index.ts
+++ b/packages/profiles/src/collections/index.ts
@@ -10,9 +10,16 @@ export {
   type Nip05Response,
   NostrIdentityCollection,
 } from './NostrIdentityCollection';
-export { OidcIdentityCollection } from './OidcIdentityCollection';
+export {
+  AmbiguousOidcIdentityError,
+  OidcIdentityCollection,
+} from './OidcIdentityCollection';
 export { ProfileAssetCollection } from './ProfileAssetCollection';
-export { ProfileCollection } from './ProfileCollection';
+export {
+  CanonicalPersonProfileError,
+  type CanonicalPersonProfileErrorCode,
+  ProfileCollection,
+} from './ProfileCollection';
 export { ProfileMetadataCollection } from './ProfileMetadataCollection';
 export { ProfileMetafieldCollection } from './ProfileMetafieldCollection';
 export { ProfileRelationshipCollection } from './ProfileRelationshipCollection';

--- a/packages/profiles/src/index.ts
+++ b/packages/profiles/src/index.ts
@@ -44,6 +44,7 @@ export {
   type Nip05Request,
   type NostrEvent,
   type NostrKeypair,
+  normalizeIdentityEmail,
   npubToPubkey,
   nsecToPrivkey,
   parseNip05Identifier,
@@ -56,7 +57,6 @@ export {
   verifyAuthEvent,
   verifyNostrSignature,
 } from './auth';
-
 // Auth-related collections
 export { ApiKeyCollection } from './collections/ApiKeyCollection';
 export { AuditLogCollection } from './collections/AuditLogCollection';
@@ -65,16 +65,29 @@ export {
   type Nip05Response,
   NostrIdentityCollection,
 } from './collections/NostrIdentityCollection';
-export { OidcIdentityCollection } from './collections/OidcIdentityCollection';
+export {
+  AmbiguousOidcIdentityError,
+  OidcIdentityCollection,
+} from './collections/OidcIdentityCollection';
 export { ProfileAssetCollection } from './collections/ProfileAssetCollection';
 // Export collections
-export { ProfileCollection } from './collections/ProfileCollection';
+export {
+  CanonicalPersonProfileError,
+  type CanonicalPersonProfileErrorCode,
+  ProfileCollection,
+} from './collections/ProfileCollection';
 export { ProfileMetadataCollection } from './collections/ProfileMetadataCollection';
 export { ProfileMetafieldCollection } from './collections/ProfileMetafieldCollection';
 export { ProfileRelationshipCollection } from './collections/ProfileRelationshipCollection';
 export { ProfileRelationshipTermCollection } from './collections/ProfileRelationshipTermCollection';
 export { ProfileRelationshipTypeCollection } from './collections/ProfileRelationshipTypeCollection';
 export { ProfileTypeCollection } from './collections/ProfileTypeCollection';
+// Deploy-time data migrations
+export {
+  type BackfillProfileEmailKeysResult,
+  backfillProfileEmailKeys,
+  PROFILE_EMAIL_KEY_BACKFILL_NAME,
+} from './migrations/backfillProfileEmailKeys.js';
 export type { ApiKeyOptions, GenerateKeyResult } from './models/ApiKey';
 // Auth-related models
 export { ApiKey } from './models/ApiKey';

--- a/packages/profiles/src/internal/oidc-provisioning.ts
+++ b/packages/profiles/src/internal/oidc-provisioning.ts
@@ -1,0 +1,44 @@
+import type { getDatabase } from '@happyvertical/sql';
+
+export {
+  coordinateOidcProvisioning,
+  isOidcAbortedTransactionError,
+  isOidcProvisioningRaceConflict,
+  type OidcProvisioningCoordinatorOptions,
+  type OidcProvisioningRaceClassifierOptions,
+  saveOidcRaceArbiter,
+} from '../auth/oidcProvisioningCoordinator.js';
+
+import {
+  createOidcProvisioningPerson as createPerson,
+  insertOidcProvisioningIdentity as insertIdentity,
+  type OidcProvisioningIdentityInput,
+  type OidcProvisioningPersonInput,
+} from '../auth/oidcProvisioningPrimitives';
+
+type DatabaseInterface = Awaited<ReturnType<typeof getDatabase>>;
+
+export type { OidcProvisioningIdentityInput, OidcProvisioningPersonInput };
+
+/**
+ * Trusted integration surface for framework packages participating in the
+ * owner-aware OIDC provisioning transaction.
+ *
+ * Application code should use UserCollection.getOrCreateFromOidc() instead.
+ * The generic result avoids duplicating nominal SMRT model declarations across
+ * package entry bundles; trusted callers bind it to the root package model.
+ */
+export async function createOidcProvisioningPerson<TProfile>(
+  db: DatabaseInterface,
+  input: OidcProvisioningPersonInput,
+): Promise<TProfile> {
+  return (await createPerson(db, input)) as TProfile;
+}
+
+/** Trusted integration insert after the caller proves Profile ownership. */
+export async function insertOidcProvisioningIdentity<TIdentity>(
+  db: DatabaseInterface,
+  input: OidcProvisioningIdentityInput,
+): Promise<TIdentity> {
+  return (await insertIdentity(db, input)) as TIdentity;
+}

--- a/packages/profiles/src/manifest/manifest.json
+++ b/packages/profiles/src/manifest/manifest.json
@@ -1,14 +1,14 @@
 {
   "version": "1.0.0",
-  "timestamp": 1780379238701,
+  "timestamp": 1784000192728,
   "packageName": "@happyvertical/smrt-profiles",
-  "packageVersion": "0.25.8",
+  "packageVersion": "0.39.12",
   "objects": {
     "@happyvertical/smrt-profiles:ApiKeyCollection": {
       "name": "apikeycollection",
       "className": "ApiKeyCollection",
       "qualifiedName": "@happyvertical/smrt-profiles:ApiKeyCollection",
-      "collection": "apikeies",
+      "collection": "apikeys",
       "filePath": "packages/profiles/src/collections/ApiKeyCollection.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {},
@@ -139,8 +139,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -178,7 +178,7 @@
             "unique": true
           }
         ],
-        "version": "0cb00ee9"
+        "version": "a8704e4a"
       }
     },
     "@happyvertical/smrt-profiles:AuditLogCollection": {
@@ -332,8 +332,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -371,7 +371,7 @@
             "unique": true
           }
         ],
-        "version": "4db3924e"
+        "version": "8934683a"
       }
     },
     "@happyvertical/smrt-profiles:MagicLinkTokenCollection": {
@@ -552,8 +552,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -591,7 +591,7 @@
             "unique": true
           }
         ],
-        "version": "e406b402"
+        "version": "1276befb"
       }
     },
     "@happyvertical/smrt-profiles:NostrIdentityCollection": {
@@ -788,8 +788,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -827,7 +827,7 @@
             "unique": true
           }
         ],
-        "version": "cb131355"
+        "version": "042a84e0"
       }
     },
     "@happyvertical/smrt-profiles:OidcIdentityCollection": {
@@ -944,8 +944,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -983,7 +983,72 @@
             "unique": true
           }
         ],
-        "version": "fd355bfc"
+        "version": "38013ce3"
+      }
+    },
+    "@happyvertical/smrt-profiles:OidcProfileEmailReservationCollection": {
+      "name": "oidcprofileemailreservationcollection",
+      "className": "OidcProfileEmailReservationCollection",
+      "qualifiedName": "@happyvertical/smrt-profiles:OidcProfileEmailReservationCollection",
+      "collection": "oidcprofileemailreservations",
+      "filePath": "packages/profiles/src/collections/OidcProfileEmailReservationCollection.ts",
+      "packageName": "@happyvertical/smrt-profiles",
+      "fields": {},
+      "methods": {},
+      "decoratorConfig": {
+        "tableName": "oidc_profile_email_reservations"
+      },
+      "extends": "SmrtCollection",
+      "extendsTypeArg": "OidcProfileEmailReservation",
+      "exportName": "OidcProfileEmailReservationCollection",
+      "collectionExportName": "OidcProfileEmailReservationCollectionCollection",
+      "schema": {
+        "tableName": "oidc_profile_email_reservations",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"oidc_profile_email_reservations\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "referenceKind": "id",
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          }
+        },
+        "indexes": [
+          {
+            "name": "oidc_profile_email_reservations_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "oidc_profile_email_reservations_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "2c5044ab"
       }
     },
     "@happyvertical/smrt-profiles:ProfileAssetCollection": {
@@ -1196,8 +1261,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -1235,7 +1300,7 @@
             "unique": true
           }
         ],
-        "version": "919e91b5"
+        "version": "e6aeda33"
       }
     },
     "@happyvertical/smrt-profiles:ProfileCollection": {
@@ -1258,6 +1323,58 @@
             }
           ],
           "returnType": "Promise<Profile | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "findUniqueGlobalPersonByEmail": {
+          "name": "findUniqueGlobalPersonByEmail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "email",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<Profile | null>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "requireCanonicalGlobalPerson": {
+          "name": "requireCanonicalGlobalPerson",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "email",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Profile>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "reserveCanonicalIdentityEmail": {
+          "name": "reserveCanonicalIdentityEmail",
+          "async": true,
+          "parameters": [
+            {
+              "name": "profileId",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "email",
+              "type": "string",
+              "optional": true
+            }
+          ],
+          "returnType": "Promise<Profile>",
           "isStatic": false,
           "isPublic": true
         },
@@ -1285,7 +1402,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<Map<string, Record<string, any>>>",
+          "returnType": "Promise<Map<string, Record<string, string>>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -1463,8 +1580,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -1502,7 +1619,7 @@
             "unique": true
           }
         ],
-        "version": "5ff9ed7e"
+        "version": "324ffa91"
       }
     },
     "@happyvertical/smrt-profiles:ProfileMetadataCollection": {
@@ -1538,7 +1655,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<Record<string, any>>",
+          "returnType": "Promise<Record<string, string>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -1574,8 +1691,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -1613,7 +1730,7 @@
             "unique": true
           }
         ],
-        "version": "e19c06c6"
+        "version": "388f4e8b"
       }
     },
     "@happyvertical/smrt-profiles:ProfileMetafieldCollection": {
@@ -1671,8 +1788,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -1710,7 +1827,7 @@
             "unique": true
           }
         ],
-        "version": "d50afde1"
+        "version": "50171869"
       }
     },
     "@happyvertical/smrt-profiles:ProfileRelationshipCollection": {
@@ -1816,8 +1933,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -1855,7 +1972,7 @@
             "unique": true
           }
         ],
-        "version": "c2512065"
+        "version": "27e5548a"
       }
     },
     "@happyvertical/smrt-profiles:ProfileRelationshipTermCollection": {
@@ -1922,8 +2039,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -1961,7 +2078,7 @@
             "unique": true
           }
         ],
-        "version": "0b826567"
+        "version": "5905c22e"
       }
     },
     "@happyvertical/smrt-profiles:ProfileRelationshipTypeCollection": {
@@ -2035,8 +2152,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -2074,7 +2191,7 @@
             "unique": true
           }
         ],
-        "version": "65243ce8"
+        "version": "f2c054a3"
       }
     },
     "@happyvertical/smrt-profiles:ProfileTypeCollection": {
@@ -2118,6 +2235,25 @@
           "returnType": "Promise<ProfileType>",
           "isStatic": false,
           "isPublic": true
+        },
+        "getOrCreateGlobalBySlug": {
+          "name": "getOrCreateGlobalBySlug",
+          "async": true,
+          "parameters": [
+            {
+              "name": "slug",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "defaults",
+              "type": "object",
+              "optional": false
+            }
+          ],
+          "returnType": "Promise<ProfileType>",
+          "isStatic": false,
+          "isPublic": true
         }
       },
       "decoratorConfig": {},
@@ -2132,8 +2268,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -2171,14 +2307,14 @@
             "unique": true
           }
         ],
-        "version": "e0c2639e"
+        "version": "b169ded1"
       }
     },
     "@happyvertical/smrt-profiles:ApiKey": {
       "name": "apikey",
       "className": "ApiKey",
       "qualifiedName": "@happyvertical/smrt-profiles:ApiKey",
-      "collection": "apikeies",
+      "collection": "apikeys",
       "filePath": "packages/profiles/src/models/ApiKey.ts",
       "packageName": "@happyvertical/smrt-profiles",
       "fields": {
@@ -2343,7 +2479,8 @@
             "get",
             "create",
             "revoke"
-          ]
+          ],
+          "skipApiCheck": true
         }
       },
       "extends": "SmrtObject",
@@ -2363,8 +2500,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -2387,9 +2524,9 @@
           },
           "profile_id": {
             "type": "UUID",
+            "referenceKind": "foreignKey",
             "notNull": true,
-            "unique": false,
-            "referenceKind": "foreignKey"
+            "unique": false
           },
           "key_hash": {
             "type": "TEXT",
@@ -2447,7 +2584,7 @@
             "unique": true
           }
         ],
-        "version": "8a5e44ea"
+        "version": "675b5c1a"
       }
     },
     "@happyvertical/smrt-profiles:AuditLog": {
@@ -2460,7 +2597,21 @@
       "fields": {
         "tenantId": {
           "type": "text",
-          "required": false
+          "required": false,
+          "_meta": {
+            "sqlType": "UUID",
+            "nullable": true,
+            "__tenancy": {
+              "isTenantIdField": true,
+              "autoFilter": true,
+              "required": false,
+              "autoPopulate": true,
+              "nullable": true,
+              "mode": "optional",
+              "field": "tenantId",
+              "allowSuperAdminBypass": true
+            }
+          }
         },
         "profileId": {
           "type": "foreignKey",
@@ -2562,6 +2713,10 @@
           "include": [
             "list"
           ]
+        },
+        "tenantScoped": {
+          "mode": "optional",
+          "allowSuperAdminBypass": true
         }
       },
       "extends": "SmrtObject",
@@ -2581,8 +2736,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -2605,15 +2760,15 @@
           },
           "tenant_id": {
             "type": "UUID",
+            "referenceKind": "tenantId",
             "notNull": false,
-            "unique": false,
-            "referenceKind": "tenantId"
+            "unique": false
           },
           "profile_id": {
             "type": "UUID",
+            "referenceKind": "foreignKey",
             "notNull": true,
-            "unique": false,
-            "referenceKind": "foreignKey"
+            "unique": false
           },
           "action": {
             "type": "TEXT",
@@ -2647,9 +2802,9 @@
           },
           "on_behalf_of_id": {
             "type": "UUID",
+            "referenceKind": "foreignKey",
             "notNull": false,
-            "unique": false,
-            "referenceKind": "foreignKey"
+            "unique": false
           }
         },
         "indexes": [
@@ -2668,7 +2823,7 @@
             "unique": true
           }
         ],
-        "version": "11439cb2"
+        "version": "42bf3450"
       }
     },
     "@happyvertical/smrt-profiles:MagicLinkToken": {
@@ -2857,8 +3012,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -2881,9 +3036,9 @@
           },
           "nostr_identity_id": {
             "type": "UUID",
+            "referenceKind": "foreignKey",
             "notNull": true,
-            "unique": false,
-            "referenceKind": "foreignKey"
+            "unique": false
           },
           "token_hash": {
             "type": "TEXT",
@@ -2930,7 +3085,7 @@
             "unique": true
           }
         ],
-        "version": "18deb8e3"
+        "version": "fc26af5c"
       }
     },
     "@happyvertical/smrt-profiles:NostrIdentity": {
@@ -3159,8 +3314,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -3183,9 +3338,9 @@
           },
           "profile_id": {
             "type": "UUID",
+            "referenceKind": "foreignKey",
             "notNull": true,
-            "unique": false,
-            "referenceKind": "foreignKey"
+            "unique": false
           },
           "pubkey": {
             "type": "TEXT",
@@ -3250,7 +3405,7 @@
             "unique": true
           }
         ],
-        "version": "964d72ef"
+        "version": "b5de7c6f"
       }
     },
     "@happyvertical/smrt-profiles:OidcIdentity": {
@@ -3272,26 +3427,43 @@
         "provider": {
           "type": "text",
           "required": false,
-          "default": ""
+          "_meta": {}
         },
         "issuer": {
           "type": "text",
           "required": false,
-          "default": ""
+          "_meta": {
+            "indexed": true
+          }
         },
         "subject": {
           "type": "text",
           "required": false,
-          "default": ""
+          "_meta": {
+            "indexed": true
+          }
+        },
+        "identityKey": {
+          "type": "text",
+          "required": false,
+          "_meta": {
+            "nullable": true,
+            "unique": true,
+            "readonly": true
+          },
+          "readonly": true
         },
         "email": {
           "type": "text",
           "required": false,
-          "default": ""
+          "_meta": {}
         },
         "lastUsedAt": {
           "type": "datetime",
-          "required": false
+          "required": false,
+          "_meta": {
+            "nullable": true
+          }
         }
       },
       "methods": {
@@ -3325,6 +3497,33 @@
           ],
           "returnType": "Promise<OidcIdentity | null>",
           "isStatic": true,
+          "isPublic": true
+        },
+        "buildIdentityKey": {
+          "name": "buildIdentityKey",
+          "async": false,
+          "parameters": [
+            {
+              "name": "issuer",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "subject",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "string",
+          "isStatic": true,
+          "isPublic": true
+        },
+        "save": {
+          "name": "save",
+          "async": true,
+          "parameters": [],
+          "returnType": "Promise",
+          "isStatic": false,
           "isPublic": true
         },
         "findOrCreate": {
@@ -3363,8 +3562,9 @@
       "decoratorConfig": {
         "tableName": "oidc_identities",
         "api": {
-          "exclude": [
-            "delete"
+          "include": [
+            "list",
+            "get"
           ]
         },
         "mcp": {
@@ -3392,13 +3592,13 @@
       ],
       "schema": {
         "tableName": "oidc_identities",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"oidc_identities\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" UUID NOT NULL,\n  \"provider\" TEXT DEFAULT '',\n  \"issuer\" TEXT DEFAULT '',\n  \"subject\" TEXT DEFAULT '',\n  \"email\" TEXT DEFAULT '',\n  \"last_used_at\" TIMESTAMP\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"oidc_identities\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" UUID NOT NULL,\n  \"provider\" TEXT,\n  \"issuer\" TEXT,\n  \"subject\" TEXT,\n  \"identity_key\" TEXT UNIQUE,\n  \"email\" TEXT,\n  \"last_used_at\" TIMESTAMP\n);",
         "columns": {
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -3421,33 +3621,34 @@
           },
           "profile_id": {
             "type": "UUID",
+            "referenceKind": "foreignKey",
             "notNull": true,
-            "unique": false,
-            "referenceKind": "foreignKey"
+            "unique": false
           },
           "provider": {
             "type": "TEXT",
             "notNull": false,
-            "unique": false,
-            "default": ""
+            "unique": false
           },
           "issuer": {
             "type": "TEXT",
             "notNull": false,
-            "unique": false,
-            "default": ""
+            "unique": false
           },
           "subject": {
             "type": "TEXT",
             "notNull": false,
-            "unique": false,
-            "default": ""
+            "unique": false
+          },
+          "identity_key": {
+            "type": "TEXT",
+            "notNull": false,
+            "unique": true
           },
           "email": {
             "type": "TEXT",
             "notNull": false,
-            "unique": false,
-            "default": ""
+            "unique": false
           },
           "last_used_at": {
             "type": "TIMESTAMP",
@@ -3469,9 +3670,131 @@
               "context"
             ],
             "unique": true
+          },
+          {
+            "name": "oidc_identities_issuer_idx",
+            "columns": [
+              "issuer"
+            ]
+          },
+          {
+            "name": "oidc_identities_subject_idx",
+            "columns": [
+              "subject"
+            ]
           }
         ],
-        "version": "7bfcab24"
+        "version": "0686d3f4"
+      }
+    },
+    "@happyvertical/smrt-profiles:OidcProfileEmailReservation": {
+      "name": "oidcprofileemailreservation",
+      "className": "OidcProfileEmailReservation",
+      "qualifiedName": "@happyvertical/smrt-profiles:OidcProfileEmailReservation",
+      "collection": "oidcprofileemailreservations",
+      "filePath": "packages/profiles/src/models/OidcProfileEmailReservation.ts",
+      "packageName": "@happyvertical/smrt-profiles",
+      "fields": {
+        "profileId": {
+          "type": "foreignKey",
+          "required": true,
+          "related": "Profile",
+          "_meta": {
+            "required": true,
+            "unique": true
+          }
+        },
+        "emailKey": {
+          "type": "text",
+          "required": true,
+          "_meta": {
+            "required": true,
+            "unique": true,
+            "readonly": true
+          },
+          "readonly": true
+        }
+      },
+      "methods": {},
+      "decoratorConfig": {
+        "tableName": "oidc_profile_email_reservations",
+        "api": false,
+        "mcp": false,
+        "cli": false
+      },
+      "extends": "SmrtObject",
+      "exportName": "OidcProfileEmailReservation",
+      "collectionExportName": "OidcProfileEmailReservationCollection",
+      "validationRules": [
+        {
+          "field": "profileId",
+          "rule": "required",
+          "fieldType": "foreignKey"
+        },
+        {
+          "field": "emailKey",
+          "rule": "required",
+          "fieldType": "text"
+        }
+      ],
+      "schema": {
+        "tableName": "oidc_profile_email_reservations",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"oidc_profile_email_reservations\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"profile_id\" UUID NOT NULL UNIQUE,\n  \"email_key\" TEXT NOT NULL UNIQUE\n);",
+        "columns": {
+          "id": {
+            "type": "UUID",
+            "primaryKey": true,
+            "referenceKind": "id",
+            "notNull": true
+          },
+          "slug": {
+            "type": "TEXT",
+            "notNull": true
+          },
+          "context": {
+            "type": "TEXT",
+            "notNull": true,
+            "default": ""
+          },
+          "created_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "updated_at": {
+            "type": "TIMESTAMP",
+            "notNull": true,
+            "default": "current_timestamp"
+          },
+          "profile_id": {
+            "type": "UUID",
+            "referenceKind": "foreignKey",
+            "notNull": true,
+            "unique": true
+          },
+          "email_key": {
+            "type": "TEXT",
+            "notNull": true,
+            "unique": true
+          }
+        },
+        "indexes": [
+          {
+            "name": "oidc_profile_email_reservations_id_idx",
+            "columns": [
+              "id"
+            ]
+          },
+          {
+            "name": "oidc_profile_email_reservations_slug_context_idx",
+            "columns": [
+              "slug",
+              "context"
+            ],
+            "unique": true
+          }
+        ],
+        "version": "311f2b6f"
       }
     },
     "@happyvertical/smrt-profiles:Profile": {
@@ -3492,7 +3815,21 @@
         },
         "tenantId": {
           "type": "text",
-          "required": false
+          "required": false,
+          "_meta": {
+            "sqlType": "UUID",
+            "nullable": true,
+            "__tenancy": {
+              "isTenantIdField": true,
+              "autoFilter": true,
+              "required": false,
+              "autoPopulate": true,
+              "nullable": true,
+              "mode": "optional",
+              "field": "tenantId",
+              "allowSuperAdminBypass": false
+            }
+          }
         },
         "typeId": {
           "type": "foreignKey",
@@ -3508,6 +3845,16 @@
           "_meta": {
             "unique": true
           }
+        },
+        "emailKey": {
+          "type": "text",
+          "required": false,
+          "_meta": {
+            "nullable": true,
+            "indexed": true,
+            "readonly": true
+          },
+          "readonly": true
         },
         "name": {
           "type": "text",
@@ -3596,6 +3943,22 @@
           "isStatic": false,
           "isPublic": true
         },
+        "markAsPersisted": {
+          "name": "markAsPersisted",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "requireInsertOnSave": {
+          "name": "requireInsertOnSave",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "initialize": {
           "name": "initialize",
           "async": true,
@@ -3610,7 +3973,7 @@
           "parameters": [
             {
               "name": "data",
-              "type": "any",
+              "type": "Record<string>",
               "optional": false
             }
           ],
@@ -3622,7 +3985,7 @@
           "name": "getFields",
           "async": true,
           "parameters": [],
-          "returnType": "any",
+          "returnType": "Promise<any>",
           "isStatic": false,
           "isPublic": true
         },
@@ -3638,6 +4001,20 @@
           "name": "toPlainObject",
           "async": false,
           "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPublicJSON": {
+          "name": "toPublicJSON",
+          "async": false,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "PublicJsonOptions",
+              "optional": true
+            }
+          ],
           "returnType": "Record<string>",
           "isStatic": false,
           "isPublic": true
@@ -3678,8 +4055,22 @@
           "name": "save",
           "async": true,
           "parameters": [],
-          "returnType": "any",
+          "returnType": "Promise",
           "isStatic": false,
+          "isPublic": true
+        },
+        "classifyConstraintError": {
+          "name": "classifyConstraintError",
+          "async": false,
+          "parameters": [
+            {
+              "name": "message",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "'unique' | 'not_null' | null",
+          "isStatic": true,
           "isPublic": true
         },
         "loadFromId": {
@@ -3709,7 +4100,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -3728,7 +4119,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -3742,7 +4133,7 @@
           "parameters": [
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -3772,6 +4163,25 @@
           "isStatic": false,
           "isPublic": true
         },
+        "_setLoadedRelationship": {
+          "name": "_setLoadedRelationship",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "loadRelated": {
           "name": "loadRelated",
           "async": true,
@@ -3780,6 +4190,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -3794,6 +4209,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any[]>",
@@ -3808,6 +4228,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -3860,7 +4285,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any | null>",
+          "returnType": "Promise",
           "isStatic": false,
           "isPublic": true
         },
@@ -3874,7 +4299,7 @@
               "optional": true
             }
           ],
-          "returnType": "Promise<Map<string, any>>",
+          "returnType": "Promise<Map<string>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -4000,7 +4425,7 @@
           "name": "getMetadata",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<Record<string, any>>",
+          "returnType": "Promise<Record<string, string>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -4010,7 +4435,7 @@
           "parameters": [
             {
               "name": "metadata",
-              "type": "Record<string, any>",
+              "type": "Record<string>",
               "optional": false
             }
           ],
@@ -4253,7 +4678,7 @@
           "name": "getApiKeys",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<ApiKey[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -4261,7 +4686,7 @@
           "name": "getActiveApiKeys",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<ApiKey[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -4275,7 +4700,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<object>",
+          "returnType": "Promise<GenerateKeyResult>",
           "isStatic": false,
           "isPublic": true
         },
@@ -4283,7 +4708,7 @@
           "name": "getOidcIdentities",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<OidcIdentity[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -4297,7 +4722,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any>",
+          "returnType": "Promise<OidcIdentity>",
           "isStatic": false,
           "isPublic": true
         },
@@ -4305,7 +4730,7 @@
           "name": "getNostrIdentities",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<NostrIdentity[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -4319,7 +4744,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any>",
+          "returnType": "Promise<NostrIdentity>",
           "isStatic": false,
           "isPublic": true
         },
@@ -4333,7 +4758,7 @@
               "optional": true
             }
           ],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<AuditLog[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -4347,7 +4772,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any>",
+          "returnType": "Promise<AuditLog>",
           "isStatic": false,
           "isPublic": true
         }
@@ -4371,7 +4796,10 @@
             "update"
           ]
         },
-        "cli": true
+        "cli": true,
+        "tenantScoped": {
+          "mode": "optional"
+        }
       },
       "extends": "SmrtObject",
       "exportName": "Profile",
@@ -4390,13 +4818,13 @@
       ],
       "schema": {
         "tableName": "profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" UUID,\n  \"type_id\" UUID,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" UUID,\n  \"type_id\" UUID,\n  \"email\" TEXT,\n  \"email_key\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -4427,15 +4855,19 @@
           },
           "tenant_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "tenantId"
+            "referenceKind": "tenantId",
+            "notNull": false
           },
           "type_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "foreignKey"
+            "referenceKind": "foreignKey",
+            "notNull": false
           },
           "email": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "email_key": {
             "type": "TEXT",
             "notNull": false
           },
@@ -4470,9 +4902,15 @@
             "columns": [
               "_meta_type"
             ]
+          },
+          {
+            "name": "profiles_email_key_idx",
+            "columns": [
+              "email_key"
+            ]
           }
         ],
-        "version": "dab71e12"
+        "version": "6f91abae"
       }
     },
     "@happyvertical/smrt-profiles:ProfileAsset": {
@@ -4485,7 +4923,21 @@
       "fields": {
         "tenantId": {
           "type": "text",
-          "required": false
+          "required": false,
+          "_meta": {
+            "sqlType": "UUID",
+            "nullable": true,
+            "__tenancy": {
+              "isTenantIdField": true,
+              "autoFilter": true,
+              "required": false,
+              "autoPopulate": true,
+              "nullable": true,
+              "mode": "optional",
+              "field": "tenantId",
+              "allowSuperAdminBypass": false
+            }
+          }
         },
         "profileId": {
           "type": "foreignKey",
@@ -4523,7 +4975,10 @@
         ],
         "api": false,
         "mcp": false,
-        "cli": false
+        "cli": false,
+        "tenantScoped": {
+          "mode": "optional"
+        }
       },
       "extends": "SmrtObject",
       "exportName": "ProfileAsset",
@@ -4557,8 +5012,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -4581,21 +5036,21 @@
           },
           "tenant_id": {
             "type": "UUID",
+            "referenceKind": "tenantId",
             "notNull": false,
-            "unique": false,
-            "referenceKind": "tenantId"
+            "unique": false
           },
           "profile_id": {
             "type": "UUID",
+            "referenceKind": "foreignKey",
             "notNull": true,
-            "unique": false,
-            "referenceKind": "foreignKey"
+            "unique": false
           },
           "asset_id": {
             "type": "UUID",
+            "referenceKind": "crossPackageRef",
             "notNull": true,
-            "unique": false,
-            "referenceKind": "crossPackageRef"
+            "unique": false
           },
           "relationship": {
             "type": "TEXT",
@@ -4626,7 +5081,7 @@
             "unique": true
           }
         ],
-        "version": "784ce134"
+        "version": "251cd922"
       }
     },
     "@happyvertical/smrt-profiles:ProfileMetadata": {
@@ -4647,7 +5102,21 @@
         },
         "tenantId": {
           "type": "text",
-          "required": false
+          "required": false,
+          "_meta": {
+            "sqlType": "UUID",
+            "nullable": true,
+            "__tenancy": {
+              "isTenantIdField": true,
+              "autoFilter": true,
+              "required": false,
+              "autoPopulate": true,
+              "nullable": true,
+              "mode": "optional",
+              "field": "tenantId",
+              "allowSuperAdminBypass": false
+            }
+          }
         },
         "profileId": {
           "type": "foreignKey",
@@ -4727,6 +5196,22 @@
           "isStatic": false,
           "isPublic": true
         },
+        "markAsPersisted": {
+          "name": "markAsPersisted",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "requireInsertOnSave": {
+          "name": "requireInsertOnSave",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "initialize": {
           "name": "initialize",
           "async": true,
@@ -4741,7 +5226,7 @@
           "parameters": [
             {
               "name": "data",
-              "type": "any",
+              "type": "Record<string>",
               "optional": false
             }
           ],
@@ -4753,7 +5238,7 @@
           "name": "getFields",
           "async": true,
           "parameters": [],
-          "returnType": "any",
+          "returnType": "Promise<any>",
           "isStatic": false,
           "isPublic": true
         },
@@ -4769,6 +5254,20 @@
           "name": "toPlainObject",
           "async": false,
           "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPublicJSON": {
+          "name": "toPublicJSON",
+          "async": false,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "PublicJsonOptions",
+              "optional": true
+            }
+          ],
           "returnType": "Record<string>",
           "isStatic": false,
           "isPublic": true
@@ -4813,6 +5312,20 @@
           "isStatic": false,
           "isPublic": true
         },
+        "classifyConstraintError": {
+          "name": "classifyConstraintError",
+          "async": false,
+          "parameters": [
+            {
+              "name": "message",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "'unique' | 'not_null' | null",
+          "isStatic": true,
+          "isPublic": true
+        },
         "loadFromId": {
           "name": "loadFromId",
           "async": true,
@@ -4840,7 +5353,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -4859,7 +5372,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -4873,7 +5386,7 @@
           "parameters": [
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -4903,6 +5416,25 @@
           "isStatic": false,
           "isPublic": true
         },
+        "_setLoadedRelationship": {
+          "name": "_setLoadedRelationship",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "loadRelated": {
           "name": "loadRelated",
           "async": true,
@@ -4911,6 +5443,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -4925,6 +5462,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any[]>",
@@ -4939,6 +5481,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -4991,7 +5538,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any | null>",
+          "returnType": "Promise",
           "isStatic": false,
           "isPublic": true
         },
@@ -5005,7 +5552,7 @@
               "optional": true
             }
           ],
-          "returnType": "Promise<Map<string, any>>",
+          "returnType": "Promise<Map<string>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -5120,7 +5667,10 @@
             "get"
           ]
         },
-        "cli": true
+        "cli": true,
+        "tenantScoped": {
+          "mode": "optional"
+        }
       },
       "extends": "SmrtObject",
       "exportName": "ProfileMetadata",
@@ -5149,8 +5699,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -5181,18 +5731,18 @@
           },
           "tenant_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "tenantId"
+            "referenceKind": "tenantId",
+            "notNull": false
           },
           "profile_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "foreignKey"
+            "referenceKind": "foreignKey",
+            "notNull": false
           },
           "metafield_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "foreignKey"
+            "referenceKind": "foreignKey",
+            "notNull": false
           },
           "value": {
             "type": "TEXT",
@@ -5223,7 +5773,7 @@
             ]
           }
         ],
-        "version": "b33758b8"
+        "version": "d4570a13"
       }
     },
     "@happyvertical/smrt-profiles:ProfileMetafield": {
@@ -5244,7 +5794,21 @@
         },
         "tenantId": {
           "type": "text",
-          "required": false
+          "required": false,
+          "_meta": {
+            "sqlType": "UUID",
+            "nullable": true,
+            "__tenancy": {
+              "isTenantIdField": true,
+              "autoFilter": true,
+              "required": false,
+              "autoPopulate": true,
+              "nullable": true,
+              "mode": "optional",
+              "field": "tenantId",
+              "allowSuperAdminBypass": false
+            }
+          }
         },
         "name": {
           "type": "text",
@@ -5260,8 +5824,7 @@
         },
         "validation": {
           "type": "json",
-          "required": false,
-          "default": {}
+          "required": false
         }
       },
       "methods": {
@@ -5317,6 +5880,22 @@
           "isStatic": false,
           "isPublic": true
         },
+        "markAsPersisted": {
+          "name": "markAsPersisted",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "requireInsertOnSave": {
+          "name": "requireInsertOnSave",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "initialize": {
           "name": "initialize",
           "async": true,
@@ -5331,7 +5910,7 @@
           "parameters": [
             {
               "name": "data",
-              "type": "any",
+              "type": "Record<string>",
               "optional": false
             }
           ],
@@ -5343,7 +5922,7 @@
           "name": "getFields",
           "async": true,
           "parameters": [],
-          "returnType": "any",
+          "returnType": "Promise<any>",
           "isStatic": false,
           "isPublic": true
         },
@@ -5359,6 +5938,20 @@
           "name": "toPlainObject",
           "async": false,
           "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPublicJSON": {
+          "name": "toPublicJSON",
+          "async": false,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "PublicJsonOptions",
+              "optional": true
+            }
+          ],
           "returnType": "Record<string>",
           "isStatic": false,
           "isPublic": true
@@ -5403,6 +5996,20 @@
           "isStatic": false,
           "isPublic": true
         },
+        "classifyConstraintError": {
+          "name": "classifyConstraintError",
+          "async": false,
+          "parameters": [
+            {
+              "name": "message",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "'unique' | 'not_null' | null",
+          "isStatic": true,
+          "isPublic": true
+        },
         "loadFromId": {
           "name": "loadFromId",
           "async": true,
@@ -5430,7 +6037,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -5449,7 +6056,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -5463,7 +6070,7 @@
           "parameters": [
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -5493,6 +6100,25 @@
           "isStatic": false,
           "isPublic": true
         },
+        "_setLoadedRelationship": {
+          "name": "_setLoadedRelationship",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "loadRelated": {
           "name": "loadRelated",
           "async": true,
@@ -5501,6 +6127,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -5515,6 +6146,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any[]>",
@@ -5529,6 +6165,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -5581,7 +6222,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any | null>",
+          "returnType": "Promise",
           "isStatic": false,
           "isPublic": true
         },
@@ -5595,7 +6236,7 @@
               "optional": true
             }
           ],
-          "returnType": "Promise<Map<string, any>>",
+          "returnType": "Promise<Map<string>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -5754,7 +6395,10 @@
             "get"
           ]
         },
-        "cli": true
+        "cli": true,
+        "tenantScoped": {
+          "mode": "optional"
+        }
       },
       "extends": "SmrtObject",
       "exportName": "ProfileMetafield",
@@ -5768,13 +6412,13 @@
       ],
       "schema": {
         "tableName": "profile_metafields",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metafields\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" UUID,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT,\n  \"validation\" JSON DEFAULT '{}'\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profile_metafields\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" UUID,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT,\n  \"validation\" JSON\n);",
         "columns": {
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -5805,8 +6449,8 @@
           },
           "tenant_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "tenantId"
+            "referenceKind": "tenantId",
+            "notNull": false
           },
           "name": {
             "type": "TEXT",
@@ -5819,8 +6463,7 @@
           },
           "validation": {
             "type": "JSON",
-            "notNull": false,
-            "default": {}
+            "notNull": false
           }
         },
         "indexes": [
@@ -5846,7 +6489,7 @@
             ]
           }
         ],
-        "version": "e6b89f44"
+        "version": "afe420df"
       }
     },
     "@happyvertical/smrt-profiles:ProfileRelationship": {
@@ -5867,7 +6510,21 @@
         },
         "tenantId": {
           "type": "text",
-          "required": false
+          "required": false,
+          "_meta": {
+            "sqlType": "UUID",
+            "nullable": true,
+            "__tenancy": {
+              "isTenantIdField": true,
+              "autoFilter": true,
+              "required": false,
+              "autoPopulate": true,
+              "nullable": true,
+              "mode": "optional",
+              "field": "tenantId",
+              "allowSuperAdminBypass": false
+            }
+          }
         },
         "fromProfileId": {
           "type": "foreignKey",
@@ -5957,6 +6614,22 @@
           "isStatic": false,
           "isPublic": true
         },
+        "markAsPersisted": {
+          "name": "markAsPersisted",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "requireInsertOnSave": {
+          "name": "requireInsertOnSave",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "initialize": {
           "name": "initialize",
           "async": true,
@@ -5971,7 +6644,7 @@
           "parameters": [
             {
               "name": "data",
-              "type": "any",
+              "type": "Record<string>",
               "optional": false
             }
           ],
@@ -5983,7 +6656,7 @@
           "name": "getFields",
           "async": true,
           "parameters": [],
-          "returnType": "any",
+          "returnType": "Promise<any>",
           "isStatic": false,
           "isPublic": true
         },
@@ -5999,6 +6672,20 @@
           "name": "toPlainObject",
           "async": false,
           "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPublicJSON": {
+          "name": "toPublicJSON",
+          "async": false,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "PublicJsonOptions",
+              "optional": true
+            }
+          ],
           "returnType": "Record<string>",
           "isStatic": false,
           "isPublic": true
@@ -6043,6 +6730,20 @@
           "isStatic": false,
           "isPublic": true
         },
+        "classifyConstraintError": {
+          "name": "classifyConstraintError",
+          "async": false,
+          "parameters": [
+            {
+              "name": "message",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "'unique' | 'not_null' | null",
+          "isStatic": true,
+          "isPublic": true
+        },
         "loadFromId": {
           "name": "loadFromId",
           "async": true,
@@ -6070,7 +6771,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -6089,7 +6790,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -6103,7 +6804,7 @@
           "parameters": [
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -6133,6 +6834,25 @@
           "isStatic": false,
           "isPublic": true
         },
+        "_setLoadedRelationship": {
+          "name": "_setLoadedRelationship",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "loadRelated": {
           "name": "loadRelated",
           "async": true,
@@ -6141,6 +6861,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -6155,6 +6880,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any[]>",
@@ -6169,6 +6899,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -6221,7 +6956,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any | null>",
+          "returnType": "Promise",
           "isStatic": false,
           "isPublic": true
         },
@@ -6235,7 +6970,7 @@
               "optional": true
             }
           ],
-          "returnType": "Promise<Map<string, any>>",
+          "returnType": "Promise<Map<string>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -6390,7 +7125,10 @@
             "get"
           ]
         },
-        "cli": true
+        "cli": true,
+        "tenantScoped": {
+          "mode": "optional"
+        }
       },
       "extends": "SmrtObject",
       "exportName": "ProfileRelationship",
@@ -6419,8 +7157,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -6451,28 +7189,28 @@
           },
           "tenant_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "tenantId"
+            "referenceKind": "tenantId",
+            "notNull": false
           },
           "from_profile_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "foreignKey"
+            "referenceKind": "foreignKey",
+            "notNull": false
           },
           "to_profile_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "foreignKey"
+            "referenceKind": "foreignKey",
+            "notNull": false
           },
           "type_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "foreignKey"
+            "referenceKind": "foreignKey",
+            "notNull": false
           },
           "context_profile_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "foreignKey"
+            "referenceKind": "foreignKey",
+            "notNull": false
           }
         },
         "indexes": [
@@ -6498,7 +7236,7 @@
             ]
           }
         ],
-        "version": "27104553"
+        "version": "8a5a4b64"
       }
     },
     "@happyvertical/smrt-profiles:ProfileRelationshipTerm": {
@@ -6590,6 +7328,22 @@
           "isStatic": false,
           "isPublic": true
         },
+        "markAsPersisted": {
+          "name": "markAsPersisted",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "requireInsertOnSave": {
+          "name": "requireInsertOnSave",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "initialize": {
           "name": "initialize",
           "async": true,
@@ -6604,7 +7358,7 @@
           "parameters": [
             {
               "name": "data",
-              "type": "any",
+              "type": "Record<string>",
               "optional": false
             }
           ],
@@ -6616,7 +7370,7 @@
           "name": "getFields",
           "async": true,
           "parameters": [],
-          "returnType": "any",
+          "returnType": "Promise<any>",
           "isStatic": false,
           "isPublic": true
         },
@@ -6632,6 +7386,20 @@
           "name": "toPlainObject",
           "async": false,
           "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPublicJSON": {
+          "name": "toPublicJSON",
+          "async": false,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "PublicJsonOptions",
+              "optional": true
+            }
+          ],
           "returnType": "Record<string>",
           "isStatic": false,
           "isPublic": true
@@ -6676,6 +7444,20 @@
           "isStatic": false,
           "isPublic": true
         },
+        "classifyConstraintError": {
+          "name": "classifyConstraintError",
+          "async": false,
+          "parameters": [
+            {
+              "name": "message",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "'unique' | 'not_null' | null",
+          "isStatic": true,
+          "isPublic": true
+        },
         "loadFromId": {
           "name": "loadFromId",
           "async": true,
@@ -6703,7 +7485,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -6722,7 +7504,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -6736,7 +7518,7 @@
           "parameters": [
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -6766,6 +7548,25 @@
           "isStatic": false,
           "isPublic": true
         },
+        "_setLoadedRelationship": {
+          "name": "_setLoadedRelationship",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "loadRelated": {
           "name": "loadRelated",
           "async": true,
@@ -6774,6 +7575,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -6788,6 +7594,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any[]>",
@@ -6802,6 +7613,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -6854,7 +7670,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any | null>",
+          "returnType": "Promise",
           "isStatic": false,
           "isPublic": true
         },
@@ -6868,7 +7684,7 @@
               "optional": true
             }
           ],
-          "returnType": "Promise<Map<string, any>>",
+          "returnType": "Promise<Map<string>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -7021,8 +7837,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -7053,8 +7869,8 @@
           },
           "relationship_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "foreignKey"
+            "referenceKind": "foreignKey",
+            "notNull": false
           },
           "started_at": {
             "type": "TIMESTAMP",
@@ -7088,7 +7904,7 @@
             ]
           }
         ],
-        "version": "5f5314f3"
+        "version": "643f97d0"
       }
     },
     "@happyvertical/smrt-profiles:ProfileRelationshipType": {
@@ -7174,6 +7990,22 @@
           "isStatic": false,
           "isPublic": true
         },
+        "markAsPersisted": {
+          "name": "markAsPersisted",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "requireInsertOnSave": {
+          "name": "requireInsertOnSave",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "initialize": {
           "name": "initialize",
           "async": true,
@@ -7188,7 +8020,7 @@
           "parameters": [
             {
               "name": "data",
-              "type": "any",
+              "type": "Record<string>",
               "optional": false
             }
           ],
@@ -7200,7 +8032,7 @@
           "name": "getFields",
           "async": true,
           "parameters": [],
-          "returnType": "any",
+          "returnType": "Promise<any>",
           "isStatic": false,
           "isPublic": true
         },
@@ -7216,6 +8048,20 @@
           "name": "toPlainObject",
           "async": false,
           "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPublicJSON": {
+          "name": "toPublicJSON",
+          "async": false,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "PublicJsonOptions",
+              "optional": true
+            }
+          ],
           "returnType": "Record<string>",
           "isStatic": false,
           "isPublic": true
@@ -7260,6 +8106,20 @@
           "isStatic": false,
           "isPublic": true
         },
+        "classifyConstraintError": {
+          "name": "classifyConstraintError",
+          "async": false,
+          "parameters": [
+            {
+              "name": "message",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "'unique' | 'not_null' | null",
+          "isStatic": true,
+          "isPublic": true
+        },
         "loadFromId": {
           "name": "loadFromId",
           "async": true,
@@ -7287,7 +8147,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -7306,7 +8166,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -7320,7 +8180,7 @@
           "parameters": [
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -7350,6 +8210,25 @@
           "isStatic": false,
           "isPublic": true
         },
+        "_setLoadedRelationship": {
+          "name": "_setLoadedRelationship",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "loadRelated": {
           "name": "loadRelated",
           "async": true,
@@ -7358,6 +8237,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -7372,6 +8256,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any[]>",
@@ -7386,6 +8275,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -7438,7 +8332,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any | null>",
+          "returnType": "Promise",
           "isStatic": false,
           "isPublic": true
         },
@@ -7452,7 +8346,7 @@
               "optional": true
             }
           ],
-          "returnType": "Promise<Map<string, any>>",
+          "returnType": "Promise<Map<string>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -7630,8 +8524,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -7694,7 +8588,7 @@
             ]
           }
         ],
-        "version": "0d5e7b48"
+        "version": "719fe0d9"
       }
     },
     "@happyvertical/smrt-profiles:ProfileType": {
@@ -7715,7 +8609,21 @@
         },
         "tenantId": {
           "type": "text",
-          "required": false
+          "required": false,
+          "_meta": {
+            "sqlType": "UUID",
+            "nullable": true,
+            "__tenancy": {
+              "isTenantIdField": true,
+              "autoFilter": true,
+              "required": false,
+              "autoPopulate": true,
+              "nullable": true,
+              "mode": "optional",
+              "field": "tenantId",
+              "allowSuperAdminBypass": false
+            }
+          }
         },
         "name": {
           "type": "text",
@@ -7783,6 +8691,22 @@
           "isStatic": false,
           "isPublic": true
         },
+        "markAsPersisted": {
+          "name": "markAsPersisted",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "requireInsertOnSave": {
+          "name": "requireInsertOnSave",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "initialize": {
           "name": "initialize",
           "async": true,
@@ -7797,7 +8721,7 @@
           "parameters": [
             {
               "name": "data",
-              "type": "any",
+              "type": "Record<string>",
               "optional": false
             }
           ],
@@ -7809,7 +8733,7 @@
           "name": "getFields",
           "async": true,
           "parameters": [],
-          "returnType": "any",
+          "returnType": "Promise<any>",
           "isStatic": false,
           "isPublic": true
         },
@@ -7825,6 +8749,20 @@
           "name": "toPlainObject",
           "async": false,
           "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPublicJSON": {
+          "name": "toPublicJSON",
+          "async": false,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "PublicJsonOptions",
+              "optional": true
+            }
+          ],
           "returnType": "Record<string>",
           "isStatic": false,
           "isPublic": true
@@ -7869,6 +8807,20 @@
           "isStatic": false,
           "isPublic": true
         },
+        "classifyConstraintError": {
+          "name": "classifyConstraintError",
+          "async": false,
+          "parameters": [
+            {
+              "name": "message",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "'unique' | 'not_null' | null",
+          "isStatic": true,
+          "isPublic": true
+        },
         "loadFromId": {
           "name": "loadFromId",
           "async": true,
@@ -7896,7 +8848,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -7915,7 +8867,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -7929,7 +8881,7 @@
           "parameters": [
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -7959,6 +8911,25 @@
           "isStatic": false,
           "isPublic": true
         },
+        "_setLoadedRelationship": {
+          "name": "_setLoadedRelationship",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "loadRelated": {
           "name": "loadRelated",
           "async": true,
@@ -7967,6 +8938,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -7981,6 +8957,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any[]>",
@@ -7995,6 +8976,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -8047,7 +9033,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any | null>",
+          "returnType": "Promise",
           "isStatic": false,
           "isPublic": true
         },
@@ -8061,7 +9047,7 @@
               "optional": true
             }
           ],
-          "returnType": "Promise<Map<string, any>>",
+          "returnType": "Promise<Map<string>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -8173,7 +9159,10 @@
             "get"
           ]
         },
-        "cli": true
+        "cli": true,
+        "tenantScoped": {
+          "mode": "optional"
+        }
       },
       "extends": "SmrtObject",
       "exportName": "ProfileType",
@@ -8192,8 +9181,8 @@
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -8224,8 +9213,8 @@
           },
           "tenant_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "tenantId"
+            "referenceKind": "tenantId",
+            "notNull": false
           },
           "name": {
             "type": "TEXT",
@@ -8260,7 +9249,7 @@
             ]
           }
         ],
-        "version": "dd5baf19"
+        "version": "0fb37aeb"
       }
     },
     "@happyvertical/smrt-profiles:Person": {
@@ -8281,7 +9270,18 @@
         },
         "tenantId": {
           "type": "text",
-          "required": false
+          "required": false,
+          "_meta": {
+            "sqlType": "UUID",
+            "nullable": true,
+            "__tenancy": {
+              "isTenantIdField": true,
+              "autoFilter": true,
+              "required": false,
+              "autoPopulate": true,
+              "nullable": true
+            }
+          }
         },
         "typeId": {
           "type": "foreignKey",
@@ -8297,6 +9297,16 @@
           "_meta": {
             "unique": true
           }
+        },
+        "emailKey": {
+          "type": "text",
+          "required": false,
+          "_meta": {
+            "nullable": true,
+            "indexed": true,
+            "readonly": true
+          },
+          "readonly": true
         },
         "name": {
           "type": "text",
@@ -8385,6 +9395,22 @@
           "isStatic": false,
           "isPublic": true
         },
+        "markAsPersisted": {
+          "name": "markAsPersisted",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "requireInsertOnSave": {
+          "name": "requireInsertOnSave",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "initialize": {
           "name": "initialize",
           "async": true,
@@ -8399,7 +9425,7 @@
           "parameters": [
             {
               "name": "data",
-              "type": "any",
+              "type": "Record<string>",
               "optional": false
             }
           ],
@@ -8411,7 +9437,7 @@
           "name": "getFields",
           "async": true,
           "parameters": [],
-          "returnType": "any",
+          "returnType": "Promise<any>",
           "isStatic": false,
           "isPublic": true
         },
@@ -8427,6 +9453,20 @@
           "name": "toPlainObject",
           "async": false,
           "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPublicJSON": {
+          "name": "toPublicJSON",
+          "async": false,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "PublicJsonOptions",
+              "optional": true
+            }
+          ],
           "returnType": "Record<string>",
           "isStatic": false,
           "isPublic": true
@@ -8471,6 +9511,20 @@
           "isStatic": false,
           "isPublic": true
         },
+        "classifyConstraintError": {
+          "name": "classifyConstraintError",
+          "async": false,
+          "parameters": [
+            {
+              "name": "message",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "'unique' | 'not_null' | null",
+          "isStatic": true,
+          "isPublic": true
+        },
         "loadFromId": {
           "name": "loadFromId",
           "async": true,
@@ -8498,7 +9552,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -8517,7 +9571,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -8531,7 +9585,7 @@
           "parameters": [
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -8561,6 +9615,25 @@
           "isStatic": false,
           "isPublic": true
         },
+        "_setLoadedRelationship": {
+          "name": "_setLoadedRelationship",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "loadRelated": {
           "name": "loadRelated",
           "async": true,
@@ -8569,6 +9642,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -8583,6 +9661,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any[]>",
@@ -8597,6 +9680,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -8649,7 +9737,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any | null>",
+          "returnType": "Promise",
           "isStatic": false,
           "isPublic": true
         },
@@ -8663,7 +9751,7 @@
               "optional": true
             }
           ],
-          "returnType": "Promise<Map<string, any>>",
+          "returnType": "Promise<Map<string>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -8789,7 +9877,7 @@
           "name": "getMetadata",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<Record<string, any>>",
+          "returnType": "Promise<Record<string, string>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -8799,7 +9887,7 @@
           "parameters": [
             {
               "name": "metadata",
-              "type": "Record<string, any>",
+              "type": "Record<string>",
               "optional": false
             }
           ],
@@ -9042,7 +10130,7 @@
           "name": "getApiKeys",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<ApiKey[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -9050,7 +10138,7 @@
           "name": "getActiveApiKeys",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<ApiKey[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -9064,7 +10152,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<object>",
+          "returnType": "Promise<GenerateKeyResult>",
           "isStatic": false,
           "isPublic": true
         },
@@ -9072,7 +10160,7 @@
           "name": "getOidcIdentities",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<OidcIdentity[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -9086,7 +10174,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any>",
+          "returnType": "Promise<OidcIdentity>",
           "isStatic": false,
           "isPublic": true
         },
@@ -9094,7 +10182,7 @@
           "name": "getNostrIdentities",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<NostrIdentity[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -9108,7 +10196,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any>",
+          "returnType": "Promise<NostrIdentity>",
           "isStatic": false,
           "isPublic": true
         },
@@ -9122,7 +10210,7 @@
               "optional": true
             }
           ],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<AuditLog[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -9136,7 +10224,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any>",
+          "returnType": "Promise<AuditLog>",
           "isStatic": false,
           "isPublic": true
         }
@@ -9162,13 +10250,13 @@
       ],
       "schema": {
         "tableName": "profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" UUID,\n  \"type_id\" UUID,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" UUID,\n  \"type_id\" UUID,\n  \"email\" TEXT,\n  \"email_key\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -9199,15 +10287,19 @@
           },
           "tenant_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "tenantId"
+            "referenceKind": "tenantId",
+            "notNull": false
           },
           "type_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "foreignKey"
+            "referenceKind": "foreignKey",
+            "notNull": false
           },
           "email": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "email_key": {
             "type": "TEXT",
             "notNull": false
           },
@@ -9242,9 +10334,15 @@
             "columns": [
               "_meta_type"
             ]
+          },
+          {
+            "name": "profiles_email_key_idx",
+            "columns": [
+              "email_key"
+            ]
           }
         ],
-        "version": "119055e0"
+        "version": "23f35a07"
       }
     },
     "@happyvertical/smrt-profiles:Organization": {
@@ -9265,7 +10363,18 @@
         },
         "tenantId": {
           "type": "text",
-          "required": false
+          "required": false,
+          "_meta": {
+            "sqlType": "UUID",
+            "nullable": true,
+            "__tenancy": {
+              "isTenantIdField": true,
+              "autoFilter": true,
+              "required": false,
+              "autoPopulate": true,
+              "nullable": true
+            }
+          }
         },
         "typeId": {
           "type": "foreignKey",
@@ -9281,6 +10390,16 @@
           "_meta": {
             "unique": true
           }
+        },
+        "emailKey": {
+          "type": "text",
+          "required": false,
+          "_meta": {
+            "nullable": true,
+            "indexed": true,
+            "readonly": true
+          },
+          "readonly": true
         },
         "name": {
           "type": "text",
@@ -9369,6 +10488,22 @@
           "isStatic": false,
           "isPublic": true
         },
+        "markAsPersisted": {
+          "name": "markAsPersisted",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "requireInsertOnSave": {
+          "name": "requireInsertOnSave",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "initialize": {
           "name": "initialize",
           "async": true,
@@ -9383,7 +10518,7 @@
           "parameters": [
             {
               "name": "data",
-              "type": "any",
+              "type": "Record<string>",
               "optional": false
             }
           ],
@@ -9395,7 +10530,7 @@
           "name": "getFields",
           "async": true,
           "parameters": [],
-          "returnType": "any",
+          "returnType": "Promise<any>",
           "isStatic": false,
           "isPublic": true
         },
@@ -9411,6 +10546,20 @@
           "name": "toPlainObject",
           "async": false,
           "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPublicJSON": {
+          "name": "toPublicJSON",
+          "async": false,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "PublicJsonOptions",
+              "optional": true
+            }
+          ],
           "returnType": "Record<string>",
           "isStatic": false,
           "isPublic": true
@@ -9455,6 +10604,20 @@
           "isStatic": false,
           "isPublic": true
         },
+        "classifyConstraintError": {
+          "name": "classifyConstraintError",
+          "async": false,
+          "parameters": [
+            {
+              "name": "message",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "'unique' | 'not_null' | null",
+          "isStatic": true,
+          "isPublic": true
+        },
         "loadFromId": {
           "name": "loadFromId",
           "async": true,
@@ -9482,7 +10645,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -9501,7 +10664,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -9515,7 +10678,7 @@
           "parameters": [
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -9545,6 +10708,25 @@
           "isStatic": false,
           "isPublic": true
         },
+        "_setLoadedRelationship": {
+          "name": "_setLoadedRelationship",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "loadRelated": {
           "name": "loadRelated",
           "async": true,
@@ -9553,6 +10735,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -9567,6 +10754,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any[]>",
@@ -9581,6 +10773,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -9633,7 +10830,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any | null>",
+          "returnType": "Promise",
           "isStatic": false,
           "isPublic": true
         },
@@ -9647,7 +10844,7 @@
               "optional": true
             }
           ],
-          "returnType": "Promise<Map<string, any>>",
+          "returnType": "Promise<Map<string>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -9773,7 +10970,7 @@
           "name": "getMetadata",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<Record<string, any>>",
+          "returnType": "Promise<Record<string, string>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -9783,7 +10980,7 @@
           "parameters": [
             {
               "name": "metadata",
-              "type": "Record<string, any>",
+              "type": "Record<string>",
               "optional": false
             }
           ],
@@ -10026,7 +11223,7 @@
           "name": "getApiKeys",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<ApiKey[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -10034,7 +11231,7 @@
           "name": "getActiveApiKeys",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<ApiKey[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -10048,7 +11245,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<object>",
+          "returnType": "Promise<GenerateKeyResult>",
           "isStatic": false,
           "isPublic": true
         },
@@ -10056,7 +11253,7 @@
           "name": "getOidcIdentities",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<OidcIdentity[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -10070,7 +11267,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any>",
+          "returnType": "Promise<OidcIdentity>",
           "isStatic": false,
           "isPublic": true
         },
@@ -10078,7 +11275,7 @@
           "name": "getNostrIdentities",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<NostrIdentity[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -10092,7 +11289,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any>",
+          "returnType": "Promise<NostrIdentity>",
           "isStatic": false,
           "isPublic": true
         },
@@ -10106,7 +11303,7 @@
               "optional": true
             }
           ],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<AuditLog[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -10120,7 +11317,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any>",
+          "returnType": "Promise<AuditLog>",
           "isStatic": false,
           "isPublic": true
         }
@@ -10146,13 +11343,13 @@
       ],
       "schema": {
         "tableName": "profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" UUID,\n  \"type_id\" UUID,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" UUID,\n  \"type_id\" UUID,\n  \"email\" TEXT,\n  \"email_key\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -10183,15 +11380,19 @@
           },
           "tenant_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "tenantId"
+            "referenceKind": "tenantId",
+            "notNull": false
           },
           "type_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "foreignKey"
+            "referenceKind": "foreignKey",
+            "notNull": false
           },
           "email": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "email_key": {
             "type": "TEXT",
             "notNull": false
           },
@@ -10226,9 +11427,15 @@
             "columns": [
               "_meta_type"
             ]
+          },
+          {
+            "name": "profiles_email_key_idx",
+            "columns": [
+              "email_key"
+            ]
           }
         ],
-        "version": "1dbcdde7"
+        "version": "144faf5c"
       }
     },
     "@happyvertical/smrt-profiles:Bot": {
@@ -10249,7 +11456,18 @@
         },
         "tenantId": {
           "type": "text",
-          "required": false
+          "required": false,
+          "_meta": {
+            "sqlType": "UUID",
+            "nullable": true,
+            "__tenancy": {
+              "isTenantIdField": true,
+              "autoFilter": true,
+              "required": false,
+              "autoPopulate": true,
+              "nullable": true
+            }
+          }
         },
         "typeId": {
           "type": "foreignKey",
@@ -10265,6 +11483,16 @@
           "_meta": {
             "unique": true
           }
+        },
+        "emailKey": {
+          "type": "text",
+          "required": false,
+          "_meta": {
+            "nullable": true,
+            "indexed": true,
+            "readonly": true
+          },
+          "readonly": true
         },
         "name": {
           "type": "text",
@@ -10353,6 +11581,22 @@
           "isStatic": false,
           "isPublic": true
         },
+        "markAsPersisted": {
+          "name": "markAsPersisted",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "requireInsertOnSave": {
+          "name": "requireInsertOnSave",
+          "async": false,
+          "parameters": [],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "initialize": {
           "name": "initialize",
           "async": true,
@@ -10367,7 +11611,7 @@
           "parameters": [
             {
               "name": "data",
-              "type": "any",
+              "type": "Record<string>",
               "optional": false
             }
           ],
@@ -10379,7 +11623,7 @@
           "name": "getFields",
           "async": true,
           "parameters": [],
-          "returnType": "any",
+          "returnType": "Promise<any>",
           "isStatic": false,
           "isPublic": true
         },
@@ -10395,6 +11639,20 @@
           "name": "toPlainObject",
           "async": false,
           "parameters": [],
+          "returnType": "Record<string>",
+          "isStatic": false,
+          "isPublic": true
+        },
+        "toPublicJSON": {
+          "name": "toPublicJSON",
+          "async": false,
+          "parameters": [
+            {
+              "name": "options",
+              "type": "PublicJsonOptions",
+              "optional": true
+            }
+          ],
           "returnType": "Record<string>",
           "isStatic": false,
           "isPublic": true
@@ -10439,6 +11697,20 @@
           "isStatic": false,
           "isPublic": true
         },
+        "classifyConstraintError": {
+          "name": "classifyConstraintError",
+          "async": false,
+          "parameters": [
+            {
+              "name": "message",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "'unique' | 'not_null' | null",
+          "isStatic": true,
+          "isPublic": true
+        },
         "loadFromId": {
           "name": "loadFromId",
           "async": true,
@@ -10466,7 +11738,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -10485,7 +11757,7 @@
             },
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -10499,7 +11771,7 @@
           "parameters": [
             {
               "name": "options",
-              "type": "any",
+              "type": "AiOperationOptions",
               "optional": true
             }
           ],
@@ -10529,6 +11801,25 @@
           "isStatic": false,
           "isPublic": true
         },
+        "_setLoadedRelationship": {
+          "name": "_setLoadedRelationship",
+          "async": false,
+          "parameters": [
+            {
+              "name": "fieldName",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "value",
+              "type": "any",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "isStatic": false,
+          "isPublic": true
+        },
         "loadRelated": {
           "name": "loadRelated",
           "async": true,
@@ -10537,6 +11828,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -10551,6 +11847,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any[]>",
@@ -10565,6 +11866,11 @@
               "name": "fieldName",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "opts",
+              "type": "LoadRelatedOptions",
+              "optional": true
             }
           ],
           "returnType": "Promise<any>",
@@ -10617,7 +11923,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any | null>",
+          "returnType": "Promise",
           "isStatic": false,
           "isPublic": true
         },
@@ -10631,7 +11937,7 @@
               "optional": true
             }
           ],
-          "returnType": "Promise<Map<string, any>>",
+          "returnType": "Promise<Map<string>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -10757,7 +12063,7 @@
           "name": "getMetadata",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<Record<string, any>>",
+          "returnType": "Promise<Record<string, string>>",
           "isStatic": false,
           "isPublic": true
         },
@@ -10767,7 +12073,7 @@
           "parameters": [
             {
               "name": "metadata",
-              "type": "Record<string, any>",
+              "type": "Record<string>",
               "optional": false
             }
           ],
@@ -11010,7 +12316,7 @@
           "name": "getApiKeys",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<ApiKey[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -11018,7 +12324,7 @@
           "name": "getActiveApiKeys",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<ApiKey[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -11032,7 +12338,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<object>",
+          "returnType": "Promise<GenerateKeyResult>",
           "isStatic": false,
           "isPublic": true
         },
@@ -11040,7 +12346,7 @@
           "name": "getOidcIdentities",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<OidcIdentity[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -11054,7 +12360,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any>",
+          "returnType": "Promise<OidcIdentity>",
           "isStatic": false,
           "isPublic": true
         },
@@ -11062,7 +12368,7 @@
           "name": "getNostrIdentities",
           "async": true,
           "parameters": [],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<NostrIdentity[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -11076,7 +12382,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any>",
+          "returnType": "Promise<NostrIdentity>",
           "isStatic": false,
           "isPublic": true
         },
@@ -11090,7 +12396,7 @@
               "optional": true
             }
           ],
-          "returnType": "Promise<any[]>",
+          "returnType": "Promise<AuditLog[]>",
           "isStatic": false,
           "isPublic": true
         },
@@ -11104,7 +12410,7 @@
               "optional": false
             }
           ],
-          "returnType": "Promise<any>",
+          "returnType": "Promise<AuditLog>",
           "isStatic": false,
           "isPublic": true
         }
@@ -11130,13 +12436,13 @@
       ],
       "schema": {
         "tableName": "profiles",
-        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" UUID,\n  \"type_id\" UUID,\n  \"email\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
+        "ddl": "CREATE TABLE IF NOT EXISTS \"profiles\" (\n  \"id\" UUID PRIMARY KEY NOT NULL,\n  \"slug\" TEXT NOT NULL,\n  \"context\" TEXT NOT NULL DEFAULT '',\n  \"_meta_type\" TEXT NOT NULL,\n  \"_meta_data\" JSON,\n  \"created_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"updated_at\" TIMESTAMP NOT NULL DEFAULT current_timestamp,\n  \"tenant_id\" UUID,\n  \"type_id\" UUID,\n  \"email\" TEXT,\n  \"email_key\" TEXT,\n  \"name\" TEXT DEFAULT '',\n  \"description\" TEXT\n);",
         "columns": {
           "id": {
             "type": "UUID",
             "primaryKey": true,
-            "notNull": true,
-            "referenceKind": "id"
+            "referenceKind": "id",
+            "notNull": true
           },
           "slug": {
             "type": "TEXT",
@@ -11167,15 +12473,19 @@
           },
           "tenant_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "tenantId"
+            "referenceKind": "tenantId",
+            "notNull": false
           },
           "type_id": {
             "type": "UUID",
-            "notNull": false,
-            "referenceKind": "foreignKey"
+            "referenceKind": "foreignKey",
+            "notNull": false
           },
           "email": {
+            "type": "TEXT",
+            "notNull": false
+          },
+          "email_key": {
             "type": "TEXT",
             "notNull": false
           },
@@ -11210,9 +12520,15 @@
             "columns": [
               "_meta_type"
             ]
+          },
+          {
+            "name": "profiles_email_key_idx",
+            "columns": [
+              "email_key"
+            ]
           }
         ],
-        "version": "8ebc0e80"
+        "version": "38738f31"
       }
     }
   },

--- a/packages/profiles/src/migrations/backfillProfileEmailKeys.ts
+++ b/packages/profiles/src/migrations/backfillProfileEmailKeys.ts
@@ -1,0 +1,72 @@
+import { BackfillTracker } from '@happyvertical/smrt-core/migrations';
+import type { getDatabase } from '@happyvertical/sql';
+import { normalizeIdentityEmail } from '../auth/normalizeIdentityEmail.js';
+
+type DatabaseInterface = Awaited<ReturnType<typeof getDatabase>>;
+
+export const PROFILE_EMAIL_KEY_BACKFILL_NAME =
+  '@happyvertical/smrt-profiles:profile-email-keys:v1';
+
+export interface BackfillProfileEmailKeysResult {
+  updated: number;
+}
+
+/**
+ * Populate adapter-independent Profile email keys after the schema migration.
+ *
+ * Run this from one deploy process after legacy writers are stopped or
+ * upgraded. Every read and update runs in one transaction, and repeats are a
+ * no-op.
+ */
+export async function backfillProfileEmailKeys(
+  db: DatabaseInterface,
+): Promise<BackfillProfileEmailKeysResult> {
+  if (!db.transaction) {
+    throw new Error(
+      'Profile email-key backfill requires a root database with transaction().',
+    );
+  }
+
+  const tracker = new BackfillTracker({ db });
+  await tracker.initialize();
+
+  return db.transaction(async (tx) => {
+    BackfillTracker.inheritInitialization(tx, db);
+    const result = await tx.query(
+      'SELECT id, email, email_key FROM profiles ORDER BY id',
+    );
+    const updates: Array<{ emailKey: string | null; id: string }> = [];
+
+    for (const row of result.rows) {
+      const id = typeof row.id === 'string' ? row.id : '';
+      if (!id) {
+        throw new Error(
+          'Profile email-key backfill found a row without an id.',
+        );
+      }
+      const email = typeof row.email === 'string' ? row.email : '';
+      const emailKey = email.trim() ? normalizeIdentityEmail(email) : null;
+      const storedKey =
+        typeof row.email_key === 'string' ? row.email_key : null;
+      if (storedKey !== emailKey) updates.push({ emailKey, id });
+    }
+
+    for (const update of updates) {
+      await tx.query(
+        'UPDATE profiles SET email_key = ? WHERE id = ?',
+        update.emailKey,
+        update.id,
+      );
+    }
+
+    await new BackfillTracker({ db: tx }).recordApplied(
+      PROFILE_EMAIL_KEY_BACKFILL_NAME,
+      {
+        description: 'Canonical Profile identity email keys are current.',
+        packageName: '@happyvertical/smrt-profiles',
+      },
+    );
+
+    return { updated: updates.length };
+  });
+}

--- a/packages/profiles/src/models/OidcIdentity.ts
+++ b/packages/profiles/src/models/OidcIdentity.ts
@@ -25,7 +25,10 @@ export interface OidcIdentityOptions extends SmrtObjectOptions {
 
 @smrt({
   tableName: 'oidc_identities',
-  api: { exclude: ['delete'] },
+  // Identity linking is an authentication authority change. Generated routes
+  // authenticate callers but do not authorize Profile ownership, so mutations
+  // must stay behind the trusted provisioning APIs below.
+  api: { include: ['list', 'get'] },
   mcp: { include: ['list', 'get'] },
   cli: { include: ['list', 'get'] },
 })
@@ -45,14 +48,24 @@ export class OidcIdentity extends SmrtObject {
   /**
    * OIDC issuer URL (e.g., https://keycloak.example.com/realms/bmp)
    */
-  @field({ type: 'text' })
+  @field({ type: 'text', indexed: true })
   issuer: string = '';
 
   /**
    * OIDC subject claim - unique identifier from the provider
    */
-  @field({ type: 'text' })
+  @field({ type: 'text', indexed: true })
   subject: string = '';
+
+  /**
+   * Stable issuer+subject key used as the database race arbiter.
+   *
+   * Nullable for legacy rows; every newly linked or reused identity backfills
+   * it. A separate unique constraint makes concurrent first login fail with a
+   * retryable conflict instead of creating two identities.
+   */
+  @field({ type: 'text', nullable: true, unique: true, readonly: true })
+  identityKey: string | null = null;
 
   /**
    * Cached email from the IdP (for display/lookup)
@@ -95,13 +108,30 @@ export class OidcIdentity extends SmrtObject {
       '../collections/OidcIdentityCollection'
     );
     const collection = await OidcIdentityCollection.create(options);
-    return await collection.findOne({
-      where: { issuer, subject },
-    });
+    return await collection.findBySubject(issuer, subject);
+  }
+
+  /** Build the collision-free natural key for one OIDC issuer subject. */
+  static buildIdentityKey(issuer: string, subject: string): string {
+    return JSON.stringify([issuer, subject]);
+  }
+
+  /** Keep the durable key derived from its natural-key source fields. */
+  override async save(): Promise<this> {
+    this.identityKey =
+      this.issuer.trim() && this.subject.trim()
+        ? OidcIdentity.buildIdentityKey(this.issuer, this.subject)
+        : null;
+    return super.save();
   }
 
   /**
-   * Find or create identity for a profile
+   * Reuse an existing exact identity for its unchanged Profile.
+   *
+   * @deprecated Authentication links must be created through transactional
+   * provisioning. This compatibility method only refreshes a unique mapping
+   * that already belongs to the supplied Profile, including legacy Profile
+   * types, and deliberately refuses to create or rebind authority.
    */
   static async findOrCreate(
     profile: Profile,
@@ -113,32 +143,29 @@ export class OidcIdentity extends SmrtObject {
     },
     options: SmrtObjectOptions = {},
   ): Promise<OidcIdentity> {
-    const existing = await OidcIdentity.findBySubject(
-      oidcData.issuer,
-      oidcData.subject,
-      options,
-    );
-
-    if (existing) {
-      // Update last used
-      existing.lastUsedAt = new Date();
-      if (oidcData.email) existing.email = oidcData.email;
-      await existing.save();
-      return existing;
+    const profileId = profile.id;
+    if (typeof profileId !== 'string' || !profileId) {
+      throw new Error('OidcIdentity.findOrCreate() requires a saved Profile.');
     }
-
-    // Create new
-    const identity = new OidcIdentity({
-      ...options,
-      profileId: profile.id as string,
-      provider: oidcData.provider,
-      issuer: oidcData.issuer,
-      subject: oidcData.subject,
-      email: oidcData.email || '',
-    });
-    await identity.initialize();
-    await identity.save();
-    return identity;
+    const { reuseExistingOidcIdentityForProfile } = await import(
+      '../auth/resolveIdentity'
+    );
+    const profileOptions = profile.options ?? {};
+    const result = await reuseExistingOidcIdentityForProfile(
+      profileId,
+      {
+        email: oidcData.email,
+        iss: oidcData.issuer,
+        sub: oidcData.subject,
+      },
+      oidcData.provider,
+      {
+        ...profileOptions,
+        ...options,
+        db: options.db ?? profileOptions.db,
+      },
+    );
+    return result.oidcIdentity;
   }
 
   /**

--- a/packages/profiles/src/models/OidcProfileEmailReservation.ts
+++ b/packages/profiles/src/models/OidcProfileEmailReservation.ts
@@ -1,0 +1,33 @@
+import {
+  field,
+  foreignKey,
+  SmrtObject,
+  type SmrtObjectOptions,
+  smrt,
+} from '@happyvertical/smrt-core';
+
+interface OidcProfileEmailReservationOptions extends SmrtObjectOptions {
+  emailKey?: string;
+  profileId?: string;
+}
+
+/** Private database arbiter for canonical OIDC email provisioning races. */
+@smrt({
+  tableName: 'oidc_profile_email_reservations',
+  api: false,
+  mcp: false,
+  cli: false,
+})
+export class OidcProfileEmailReservation extends SmrtObject {
+  @foreignKey('Profile', { required: true, unique: true })
+  profileId?: string;
+
+  @field({ type: 'text', required: true, unique: true, readonly: true })
+  emailKey: string = '';
+
+  constructor(options: OidcProfileEmailReservationOptions = {}) {
+    super(options);
+    if (options.profileId !== undefined) this.profileId = options.profileId;
+    if (options.emailKey !== undefined) this.emailKey = options.emailKey;
+  }
+}

--- a/packages/profiles/src/models/Profile.ts
+++ b/packages/profiles/src/models/Profile.ts
@@ -22,6 +22,7 @@ import {
 } from '@happyvertical/smrt-core';
 import { resolvePrompt } from '@happyvertical/smrt-prompts';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import { normalizeIdentityEmail } from '../auth/normalizeIdentityEmail';
 import {
   promptMessageOptions,
   smrtProfilesGenerateBioPrompt,
@@ -60,6 +61,10 @@ export class Profile extends SmrtObject {
   @field({ unique: true })
   email?: string; // Optional email address
 
+  /** Adapter-independent identity lookup key derived from email on save. */
+  @field({ type: 'text', nullable: true, indexed: true, readonly: true })
+  emailKey: string | null = null;
+
   @field({ required: true })
   name: string = ''; // Display name
 
@@ -87,6 +92,14 @@ export class Profile extends SmrtObject {
     if (options.name) this.name = options.name;
     if (options.description !== undefined)
       this.description = options.description;
+  }
+
+  /** Keep the durable identity key derived from the public email field. */
+  override async save(): Promise<this> {
+    this.emailKey = this.email?.trim()
+      ? normalizeIdentityEmail(this.email)
+      : null;
+    return super.save();
   }
 
   /**
@@ -681,10 +694,13 @@ export class Profile extends SmrtObject {
   }
 
   /**
-   * Link a new OIDC identity to this profile
+   * Reuse an existing exact OIDC identity for this unchanged Profile.
    *
    * @param oidcData - OIDC provider data
    * @returns The linked OIDC identity record
+   * @deprecated New authentication links require owner-aware transactional
+   * provisioning. This compatibility helper may refresh a legacy Profile
+   * type, but refuses to create or rebind authority.
    */
   async linkOidcIdentity(oidcData: {
     provider: string;

--- a/packages/profiles/vite.config.ts
+++ b/packages/profiles/vite.config.ts
@@ -1,5 +1,11 @@
 import { createPackageConfig } from '../../vite.config.base.js';
 
 export default createPackageConfig('profiles', {
-  entries: ['utils'],
+  entries: [
+    'utils',
+    {
+      name: 'internal/oidc-provisioning',
+      source: 'src/internal/oidc-provisioning.ts',
+    },
+  ],
 });

--- a/packages/users/AGENTS.md
+++ b/packages/users/AGENTS.md
@@ -257,9 +257,12 @@ the package root).
   claim source; verification is never borrowed across sources.
   Resolver reads/writes use the supplied `db`, and the hook must be idempotent
   because a concurrent unique-key conflict can retry it. `undefined` chooses
-  the secure default, `null` rejects, and a supplied Profile is still validated
-  as the unique, unowned global Person for the verified email. The hook receives
-  a separate frozen claims snapshot; internal retry and persistence state is not
+  the secure default and `null` rejects, including exact issuer/subject reuse.
+  For a new identity, a supplied Profile is still validated as the unique,
+  unowned global Person for the verified email. For an exact existing identity,
+  it must be the already-linked Profile and cannot rebind identity authority;
+  stable-link owner and canonical-Person checks still apply. The hook receives a
+  separate frozen claims snapshot; internal retry and persistence state is not
   exposed for mutation.
 - **OIDC first login is atomic.** The Profile, `OidcIdentity`, and User are one
   transaction. The database arbiters are `OidcIdentity.identityKey`,

--- a/packages/users/AGENTS.md
+++ b/packages/users/AGENTS.md
@@ -6,7 +6,7 @@ Multi-tenant user management with RBAC, hierarchical tenants, session handling, 
 
 | Model | Key Pattern |
 |-------|-------------|
-| User | Auth identity. `profileId` is plain string (not FK) to smrt-profiles. Email auto-lowercased. |
+| User | Auth identity. `profileId` is a unique cross-package reference to smrt-profiles (one User per non-null Profile). Email auto-lowercased; readonly nullable unique `emailKey` is derived on save for durable normalized uniqueness. |
 | AccessRequest | "Request access / waitlist" record captured before a `User` exists. CLOSED generated surface (`api`/`mcp`/`cli` = `[]`) — all access via `AccessRequestService`. Email normalized + indexed; JSON `requestContext` (NOT `context` — reserved for slug scoping). |
 | Tenant | **STI** + hierarchical parent-child. `hierarchyPath` (materialized path), `hierarchyLevel`. Max depth 10. |
 | Session | Server-side. Secure UUID. TTL in **seconds** (not ms). Status auto-updates to EXPIRED on access. |
@@ -240,6 +240,58 @@ the package root).
   refuses to provision a user when the IdP explicitly returns
   `email_verified: false` (opt out with `{ allowUnverifiedEmail: true }`). An
   absent claim makes no assertion and is not enforced.
+- **Verified-email Profile reuse is fail-closed.** Default provisioning reuses
+  only one unowned, global `Person`. Tenant-scoped, non-Person, duplicate-email,
+  and already-owned matches fail before User/session creation. An existing
+  issuer/subject link without a User must still be the unique global Person for
+  the current verified claim email; once owned, the stable issuer/subject link
+  reuses its canonical Person and owner.
+  Issuer and subject are opaque, case-sensitive identifiers; preserve their
+  exact value and use trim only to reject blank claims.
+- **`resolveProfile` is the application reconciliation boundary.** The
+  SvelteKit handlers, `OidcLoginService`, and `getOrCreateFromOidc` accept the
+  same hook inside the provisioning transaction. The service/handler path
+  supplies protocol-validated claims; direct collection callers must validate
+  and trust their claim source before calling `getOrCreateFromOidc`.
+  Token/userinfo merging keeps `email` and `email_verified` paired to the same
+  claim source; verification is never borrowed across sources.
+  Resolver reads/writes use the supplied `db`, and the hook must be idempotent
+  because a concurrent unique-key conflict can retry it. `undefined` chooses
+  the secure default, `null` rejects, and a supplied Profile is still validated
+  as the unique, unowned global Person for the verified email. The hook receives
+  a separate frozen claims snapshot; internal retry and persistence state is not
+  exposed for mutation.
+- **OIDC first login is atomic.** The Profile, `OidcIdentity`, and User are one
+  transaction. The database arbiters are `OidcIdentity.identityKey`,
+  private `oidc_profile_email_reservations.email_key`, `User.emailKey`, and the
+  unique `User.profileId`; local callbacks acquire exact issuer/subject and normalized
+  email locks in deterministic order so changed email claims also serialize.
+  SQLite and DuckDB callbacks additionally serialize transactions per database
+  URL because one adapter cannot safely overlap unrelated root transactions;
+  PostgreSQL deadlock and serialization errors use a bounded transaction retry.
+  Newly provisioned Profiles use non-semantic per-profile slugs so equal IdP
+  display names cannot trigger a natural-key upsert;
+  run
+  `smrt db:status`, `smrt db:migrate`, then `smrt db:status` before deployment.
+  Stop or upgrade old writers first. Before migration, group
+  non-null `users.profile_id` values, then reconcile duplicates. After
+  migration, run public `backfillProfileEmailKeys(db)` followed by
+  `backfillUserEmailKeys(db)` from one deploy process. Both use the shared
+  TypeScript `normalizeIdentityEmail()` implementation transactionally and are
+  idempotent; the User backfill fails before writes if normalized duplicates
+  remain. Every OIDC path requires the Profile email-key readiness marker;
+  creating a User or checking User email uniqueness additionally requires the
+  User marker. A stable issuer/subject with an existing owning User skips only
+  the User email-key lookup and marker. Full scans remain in the explicit deploy
+  step; guarded runtime paths use indexed keys and validate only returned
+  candidates. Multiple null links remain valid.
+  Legacy race keys backfill only after canonical validation. Pass a root
+  database on adapters such as DuckDB that cannot create nested savepoints.
+  Root adapters must expose `beginTransaction`; transaction-only handles are
+  ambiguous and fail closed before provisioning writes. Caller-owned
+  transactions never run `_smrt_backfills` DDL and require that table to
+  already exist; use the root database when initialization or recovery is
+  needed.
 
 ## Gotchas
 

--- a/packages/users/README.md
+++ b/packages/users/README.md
@@ -374,6 +374,133 @@ can pass `transactionCookieSecret` to the route helpers. On success it creates
 or reuses a SMRT `Profile`, links an `OidcIdentity`, creates or reuses a `User`,
 records `lastLoginAt`, and sets the standard SMRT session cookie.
 
+Verified-email provisioning is fail-closed. The default resolver reuses a
+Profile only when exactly one case-insensitive email match exists and that row
+is an unowned, global `Person`. A tenant-scoped Profile, a non-`Person` STI row,
+duplicate email matches, or a Profile already owned by another `User` rejects
+the callback before User or session creation. An existing OIDC issuer/subject
+link without a User must still identify the unique global `Person` for the
+current verified claim email. Once a User owns it, the stable issuer/subject
+link continues to select its canonical global `Person` and existing User.
+
+Canonical Profile failures use `CanonicalPersonProfileError` from
+`@happyvertical/smrt-profiles`, with codes `ambiguous_email`, `email_mismatch`,
+`email_key_backfill_required`, `missing_profile`, `non_person`,
+`reservation_conflict`, or `tenant_scoped`.
+User ownership/provisioning failures use `OidcProvisioningError`, with codes
+`ambiguous_identity`, `concurrency_conflict`, `profile_owned`, `rejected`,
+`transaction_required`, `user_email_backfill_required`, or
+`user_email_conflict`. `completeOidcLogin()` rejects with the full error. The
+ready-made callback handler passes that error to a configured `failureRedirect`
+callback; without one it returns a generic 401 and does not expose account,
+resolver, or database details to the browser.
+
+Applications that already own an identity-reconciliation policy can provide a
+`resolveProfile` hook without replacing transaction cookies, token exchange,
+claim verification, or session creation:
+
+```typescript
+// src/routes/auth/[provider]/callback/+server.ts
+import { createOidcCallbackHandler } from '@happyvertical/smrt-users/sveltekit';
+
+export const GET = createOidcCallbackHandler({
+  db: { type: 'postgres', url: process.env.DATABASE_URL! },
+  resolveProfile: async ({ claims, db }) => {
+    // All reads and writes must use this transaction-bound `db` handle.
+    const profile = await resolveApplicationIdentity({ claims, db });
+
+    // undefined: use SMRT's secure default
+    // null: reject this login
+    // Profile: select an application-reconciled canonical global Person
+    return profile;
+  },
+  successRedirect: '/dashboard',
+});
+```
+
+The service and SvelteKit handler run the hook after protocol claim validation
+and inside the same provisioning transaction as OIDC identity and User
+creation. Direct `UserCollection.getOrCreateFromOidc()` callers must first
+validate and trust their supplied claims. The hook may run again after a
+concurrent unique-key conflict, so it must be idempotent. A supplied Profile is
+still validated as the unique global `Person` for a verified email; resolver
+reuse is rejected unless `email_verified` is exactly `true`, and an
+already-owned Profile is always rejected for a new issuer/subject link. The
+resolver receives a separate frozen claims snapshot; retry locks, identity
+lookups, and persistence retain SMRT's immutable internal snapshot.
+
+When userinfo supplies a missing email, its `email_verified` value travels with
+that email as one source-bound pair. SMRT never borrows a verification flag
+from the ID token for a userinfo address, or from userinfo for an ID-token
+address.
+
+The concurrency guarantee uses four database arbiters: nullable unique
+`OidcIdentity.identityKey`, private unique
+`oidc_profile_email_reservations.email_key`, nullable unique `User.emailKey`,
+and unique `User.profileId`. `User.emailKey` is derived from the trimmed,
+lowercase email on every save, preventing independent database connections from
+creating ambiguous User rows for the same address. Profile and User keys share
+the exported TypeScript `normalizeIdentityEmail()` implementation; identity
+lookups never depend on adapter-specific SQL `lower()` or `trim()` behavior.
+Before trusting those keys, identity lookup verifies that every stored key
+on a returned candidate still equals the application-normalized source email.
+Every OIDC path validates or synchronizes its canonical Profile and therefore
+requires the Profile email-key readiness marker. Creating a User or checking
+User email uniqueness additionally requires the User email-key marker. A stable
+issuer/subject that already has an owning User skips only the User email-key
+lookup and marker. Full table validation stays in the explicit backfill, while
+guarded runtime paths use only indexed candidate rows.
+In-process callbacks also acquire the exact issuer/subject and normalized email
+locks in deterministic order, including when the same subject presents changed
+email claims on independent database handles. SQLite and DuckDB also acquire a
+database-URL transaction lock because one adapter cannot safely overlap
+unrelated root transactions; PostgreSQL deadlock and serialization failures use
+a bounded transaction retry. New OIDC Profiles use non-semantic unique slugs,
+so equal IdP display names cannot overwrite one another through SMRT's
+natural-key upsert.
+Existing installations must run `smrt db:status`, `smrt db:migrate`, then
+`smrt db:status` before deploying this users version; legacy identities reserve
+an address only after the Profile passes canonical validation, and existing
+issuer/subject reuse synchronizes that reservation with the Profile's current
+stored email. Stop or upgrade old Profile and User writers before migration.
+Before migration, find duplicate ownership links:
+
+```sql
+SELECT profile_id, COUNT(*) AS user_count
+FROM users
+WHERE profile_id IS NOT NULL
+GROUP BY profile_id
+HAVING COUNT(*) > 1;
+```
+
+Reconcile every result before applying the unique Profile constraint; legacy
+empty-string Profile placeholders should be normalized to `NULL`. Multiple
+`NULL` links remain valid. After the schema migration, populate both durable
+keys from a single deploy process:
+
+```typescript
+import { backfillProfileEmailKeys } from '@happyvertical/smrt-profiles';
+import { backfillUserEmailKeys } from '@happyvertical/smrt-users';
+
+await backfillProfileEmailKeys(database);
+await backfillUserEmailKeys(database);
+```
+
+The supported backfills are transactional and idempotent. The User backfill
+fails without changing rows if legacy emails are still ambiguous; reconcile
+the reported normalized keys and rerun it. All OIDC paths require the Profile
+marker; paths that create a User or arbitrate User email uniqueness also require
+the User marker. Run both before enabling OIDC provisioning. Pass the
+root database to provisioning on adapters such as DuckDB that do not support
+nested savepoints; root adapters must expose `beginTransaction`. A handle
+exposing only `transaction()` is ambiguous and fails closed before resolver
+writes rather than risking a nested transaction that could roll back
+caller-owned work. A transaction-bound handle reads an existing
+`_smrt_backfills` table but never attempts tracker DDL; pass the root database
+when initialization or recovery is needed. OIDC `iss` and `sub` are preserved as exact opaque,
+case-sensitive identifiers (trim is used only to reject blank claims), so
+whitespace-distinct subjects never reuse one another.
+
 With `postgresRls: true`, SMRT opens a request-scoped Postgres transaction,
 loads the session, resolves permissions, and sets session variables used by the
 generated RLS helpers:
@@ -447,7 +574,7 @@ TenantService supports three modes: `flexible` (no auto-create), `personal` (aut
 
 | Export | Description |
 |--------|-------------|
-| `User` | Auth identity. Email auto-lowercased. `profileId` links to smrt-profiles (plain string). |
+| `User` | Auth identity. Email auto-lowercased. `profileId` is a unique cross-package Profile reference (one User per non-null Profile). |
 | `Tenant` | Organizational boundary. STI. Hierarchical via `parentTenantId`/`hierarchyPath`. |
 | `Role` | Permission template. `tenantId = null` for system roles. `isSystem` blocks deletion. |
 | `Permission` | Named capability. Slug format: `resource.action`. |
@@ -480,6 +607,9 @@ TenantService supports three modes: `flexible` (no auto-create), `personal` (aut
 | `generatePostgresPermissionSql()`, `applyPostgresPermissionPolicies()` | Preview or apply Postgres RLS helper functions and table policies. |
 | `SessionService` | High-level session management. `createSession()`, `loadSessionContext()`, `destroySession()`. |
 | `OidcLoginService` | Generic OIDC authorization-code login with PKCE for Kanidm, Dex, and other standards-compliant providers. |
+| `backfillUserEmailKeys` | Idempotently populate durable normalized-email keys after migrating legacy Users; fails closed on duplicates. |
+| `OidcProfileResolver` | Transaction-bound pre-provision hook for application identity reconciliation. |
+| `NormalizedOidcClaims` | Frozen resolver claims with required normalized `email`. |
 | `withSessionPermissionContext()` | Loads a session, optionally enters tenancy context, and exposes a request-scoped database/permission context. |
 | `getCurrentSessionPermissionContext()`, `getRequestScopedDatabase()` | Read the active request/session context inside app code. |
 | `TenantService` | Policy-driven tenant lifecycle. `ensureTenantForUser()`, `createTenantWithOwnership()`. |

--- a/packages/users/README.md
+++ b/packages/users/README.md
@@ -422,12 +422,15 @@ The service and SvelteKit handler run the hook after protocol claim validation
 and inside the same provisioning transaction as OIDC identity and User
 creation. Direct `UserCollection.getOrCreateFromOidc()` callers must first
 validate and trust their supplied claims. The hook may run again after a
-concurrent unique-key conflict, so it must be idempotent. A supplied Profile is
-still validated as the unique global `Person` for a verified email; resolver
-reuse is rejected unless `email_verified` is exactly `true`, and an
-already-owned Profile is always rejected for a new issuer/subject link. The
-resolver receives a separate frozen claims snapshot; retry locks, identity
-lookups, and persistence retain SMRT's immutable internal snapshot.
+concurrent unique-key conflict, so it must be idempotent. For a new
+issuer/subject, a supplied Profile is still validated as the unique, unowned
+global `Person` for a verified email; resolver reuse is rejected unless
+`email_verified` is exactly `true`. For an exact existing issuer/subject,
+`null` still rejects login, a supplied Profile must be the already-linked
+Profile and cannot rebind it, and stable-link owner/canonical-Person checks
+still apply. The resolver receives a separate frozen claims snapshot; retry
+locks, identity lookups, and persistence retain SMRT's immutable internal
+snapshot.
 
 When userinfo supplies a missing email, its `email_verified` value travels with
 that email as one source-bound pair. SMRT never borrows a verification flag

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -39,7 +39,7 @@
     "dev": "npm run build:watch",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
-    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/__tests__/permission-postgres-rls.test.ts src/__tests__/principal-permission-context-postgres.test.ts",
+    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/__tests__/permission-postgres-rls.test.ts src/__tests__/principal-permission-context-postgres.test.ts src/__tests__/oidc-provisioning-postgres.test.ts",
     "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
@@ -61,11 +61,11 @@
     "@happyvertical/smrt-tenancy": "workspace:*",
     "@happyvertical/smrt-types": "workspace:*",
     "@happyvertical/smrt-ui": "workspace:*",
+    "@happyvertical/sql": "catalog:",
     "jose": "^6.2.3"
   },
   "devDependencies": {
     "@happyvertical/smrt-vitest": "workspace:*",
-    "@happyvertical/sql": "catalog:",
     "@sveltejs/package": "^2.5.8",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@types/node": "24.13.2",

--- a/packages/users/src/__tests__/helpers/oidc-test-server.ts
+++ b/packages/users/src/__tests__/helpers/oidc-test-server.ts
@@ -13,12 +13,20 @@ import {
   type Server,
   type ServerResponse,
 } from 'node:http';
+import {
+  BackfillTracker,
+  type DatabaseInterface,
+} from '@happyvertical/smrt-core/migrations';
+import { PROFILE_EMAIL_KEY_BACKFILL_NAME } from '@happyvertical/smrt-profiles';
 import { exportJWK, generateKeyPair, SignJWT } from 'jose';
+import { USER_EMAIL_KEY_BACKFILL_NAME } from '../../migrations/backfillUserEmailKeys.js';
 
 export interface OidcTestServerOptions {
   audience?: string | string[];
   authorizedParty?: string;
+  idTokenEmailVerified?: boolean;
   includeEmailInIdToken?: boolean;
+  userInfoEmailVerified?: boolean;
 }
 
 export interface OidcTestServer {
@@ -36,6 +44,13 @@ export interface OidcTestServer {
  * and sessions. Extend with further DDL per suite as needed.
  */
 export const OIDC_USERS_TEST_SCHEMA = `
+CREATE TABLE IF NOT EXISTS "_smrt_backfills" (
+  "name" TEXT PRIMARY KEY NOT NULL,
+  "applied_at" TIMESTAMP DEFAULT current_timestamp,
+  "description" TEXT,
+  "package_name" TEXT
+);
+
 CREATE TABLE IF NOT EXISTS "profile_types" (
   "id" TEXT PRIMARY KEY NOT NULL,
   "slug" TEXT NOT NULL,
@@ -62,11 +77,26 @@ CREATE TABLE IF NOT EXISTS "profiles" (
   "tenant_id" TEXT,
   "type_id" TEXT,
   "email" TEXT,
+  "email_key" TEXT,
   "name" TEXT DEFAULT '',
   "description" TEXT
 );
 CREATE UNIQUE INDEX IF NOT EXISTS "profiles_slug_context_meta_type_idx" ON "profiles" ("slug", "context", "_meta_type");
 CREATE INDEX IF NOT EXISTS "profiles_meta_type_idx" ON "profiles" ("_meta_type");
+CREATE INDEX IF NOT EXISTS "profiles_email_key_idx" ON "profiles" ("email_key");
+
+CREATE TABLE IF NOT EXISTS "oidc_profile_email_reservations" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "slug" TEXT NOT NULL,
+  "context" TEXT NOT NULL DEFAULT '',
+  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "profile_id" TEXT NOT NULL,
+  "email_key" TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "oidc_profile_email_reservations_slug_context_idx" ON "oidc_profile_email_reservations" ("slug", "context");
+CREATE UNIQUE INDEX IF NOT EXISTS "oidc_profile_email_reservations_profile_id_idx" ON "oidc_profile_email_reservations" ("profile_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "oidc_profile_email_reservations_email_key_idx" ON "oidc_profile_email_reservations" ("email_key");
 
 CREATE TABLE IF NOT EXISTS "oidc_identities" (
   "id" TEXT PRIMARY KEY NOT NULL,
@@ -74,14 +104,16 @@ CREATE TABLE IF NOT EXISTS "oidc_identities" (
   "context" TEXT NOT NULL DEFAULT '',
   "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
   "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  "profile_id" TEXT,
+  "profile_id" TEXT NOT NULL,
   "provider" TEXT DEFAULT '',
   "issuer" TEXT DEFAULT '',
   "subject" TEXT DEFAULT '',
+  "identity_key" TEXT,
   "email" TEXT DEFAULT '',
   "last_used_at" TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS "oidc_identities_slug_context_idx" ON "oidc_identities" ("slug", "context");
+CREATE UNIQUE INDEX IF NOT EXISTS "oidc_identities_identity_key_idx" ON "oidc_identities" ("identity_key");
 
 CREATE TABLE IF NOT EXISTS "users" (
   "id" TEXT PRIMARY KEY NOT NULL,
@@ -91,10 +123,13 @@ CREATE TABLE IF NOT EXISTS "users" (
   "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
   "profile_id" TEXT DEFAULT '',
   "email" TEXT DEFAULT '',
+  "email_key" TEXT,
   "status" TEXT,
   "last_login_at" TIMESTAMP
 );
 CREATE UNIQUE INDEX IF NOT EXISTS "users_slug_context_idx" ON "users" ("slug", "context");
+CREATE UNIQUE INDEX IF NOT EXISTS "users_profile_id_idx" ON "users" ("profile_id");
+CREATE UNIQUE INDEX IF NOT EXISTS "users_email_key_idx" ON "users" ("email_key");
 
 CREATE TABLE IF NOT EXISTS "sessions" (
   "id" TEXT PRIMARY KEY NOT NULL,
@@ -113,6 +148,21 @@ CREATE TABLE IF NOT EXISTS "sessions" (
 );
 CREATE UNIQUE INDEX IF NOT EXISTS "sessions_slug_context_idx" ON "sessions" ("slug", "context");
 `;
+
+/** Mark a freshly-created, empty test schema ready for indexed OIDC reads. */
+export async function prepareOidcEmailKeyBackfills(
+  db: DatabaseInterface,
+): Promise<void> {
+  const tracker = new BackfillTracker({ db });
+  await tracker.recordApplied(PROFILE_EMAIL_KEY_BACKFILL_NAME, {
+    description: 'Canonical Profile identity email keys are current.',
+    packageName: '@happyvertical/smrt-profiles',
+  });
+  await tracker.recordApplied(USER_EMAIL_KEY_BACKFILL_NAME, {
+    description: 'Canonical User identity email keys are current.',
+    packageName: '@happyvertical/smrt-users',
+  });
+}
 
 const activeServers = new Set<Server>();
 
@@ -203,9 +253,11 @@ export async function startOidcServer(
       };
       if (options.includeEmailInIdToken !== false) {
         idTokenClaims.email = 'dex.user@example.com';
-        idTokenClaims.email_verified = true;
+        idTokenClaims.email_verified = options.idTokenEmailVerified ?? true;
         idTokenClaims.name = 'Dex User';
         idTokenClaims.preferred_username = 'dex-user';
+      } else if (options.idTokenEmailVerified !== undefined) {
+        idTokenClaims.email_verified = options.idTokenEmailVerified;
       }
       if (options.authorizedParty) {
         idTokenClaims.azp = options.authorizedParty;
@@ -235,7 +287,7 @@ export async function startOidcServer(
       });
       sendJson(response, 200, {
         email: 'dex.user@example.com',
-        email_verified: true,
+        email_verified: options.userInfoEmailVerified ?? true,
         name: 'Dex User',
         preferred_username: 'dex-user',
         sub: 'dex-user-123',

--- a/packages/users/src/__tests__/mobile-auth-handlers.test.ts
+++ b/packages/users/src/__tests__/mobile-auth-handlers.test.ts
@@ -33,6 +33,7 @@ import {
   closeAllOidcServers,
   OIDC_USERS_TEST_SCHEMA,
   type OidcTestServer,
+  prepareOidcEmailKeyBackfills,
   startOidcServer,
 } from './helpers/oidc-test-server.js';
 
@@ -939,6 +940,7 @@ describe('mobile auth default user provisioning', () => {
     const { getDatabase, syncSchema } = await import('@happyvertical/sql');
     const handle = await getDatabase(db);
     await syncSchema({ db: handle, schema: OIDC_USERS_TEST_SCHEMA });
+    await prepareOidcEmailKeyBackfills(handle);
     server = await startOidcServer();
   });
 

--- a/packages/users/src/__tests__/oidc-login-service.test.ts
+++ b/packages/users/src/__tests__/oidc-login-service.test.ts
@@ -1,4 +1,6 @@
+import { randomUUID } from 'node:crypto';
 import { clearCache, setConfig } from '@happyvertical/smrt-config';
+import { ProfileCollection } from '@happyvertical/smrt-profiles';
 import {
   createIsolatedTestDb,
   type IsolatedTestDbResult,
@@ -18,11 +20,16 @@ import {
 import {
   closeAllOidcServers,
   OIDC_USERS_TEST_SCHEMA,
+  prepareOidcEmailKeyBackfills,
   startOidcServer,
 } from './helpers/oidc-test-server.js';
 
 async function createOidcTestDb(): Promise<IsolatedTestDbResult> {
-  return createIsolatedTestDb({ schema: OIDC_USERS_TEST_SCHEMA });
+  const isolated = await createIsolatedTestDb({
+    schema: OIDC_USERS_TEST_SCHEMA,
+  });
+  await prepareOidcEmailKeyBackfills(isolated.db);
+  return isolated;
 }
 
 function toFetchUrl(input: Parameters<typeof fetch>[0]): string {
@@ -203,7 +210,7 @@ describe('OidcLoginService', () => {
     });
 
     expect(response.status).toBe(401);
-    await expect(response.text()).resolves.toContain('signature');
+    await expect(response.text()).resolves.toBe('OIDC login failed.');
     expect(jar.has('smrt_oidc_dex')).toBe(false);
   });
 
@@ -308,6 +315,184 @@ describe('OidcLoginService', () => {
     expect(fetchUrls).toContain(`${server.issuer}/jwks`);
   });
 
+  it('runs a pre-provision resolver inside the stock token-exchange flow', async () => {
+    const server = await startOidcServer();
+    cleanup.push(server.close);
+    const isolated = await createOidcTestDb();
+    cleanup.push(isolated.cleanup);
+    const { db } = isolated;
+    const profileId = randomUUID();
+    await db.query(
+      `INSERT INTO profiles
+        (id, slug, context, _meta_type, tenant_id, email, email_key, name)
+       VALUES (?, ?, '', '@happyvertical/smrt-profiles:Person', NULL, ?, ?, 'Existing Person')`,
+      profileId,
+      `profile-${profileId}`,
+      'dex.user@example.com',
+      'dex.user@example.com',
+    );
+
+    const options: Parameters<typeof beginOidcLogin>[1] = {
+      db,
+      provider: 'dex',
+      providers: {
+        dex: {
+          clientId: 'smrt-client',
+          clientSecret: 'secret',
+          issuer: server.issuer,
+          kind: 'dex' as const,
+          redirectUri: `${server.issuer}/auth/dex/callback`,
+        },
+      },
+      resolveProfile: async ({ db: tx }) => {
+        const profiles = await ProfileCollection.create({ db: tx });
+        return profiles.get({ id: profileId });
+      },
+    };
+    const { cookies, jar } = createCookieJar();
+    const loginUrl = new URL(
+      `${server.issuer}/auth/dex/login?returnTo=/dashboard`,
+    );
+    const { transaction } = await beginOidcLogin(
+      {
+        cookies,
+        params: { provider: 'dex' },
+        request: new Request(loginUrl),
+        url: loginUrl,
+      },
+      options,
+    );
+    server.setNonce(transaction.nonce);
+    const callbackUrl = new URL(`${server.issuer}/auth/dex/callback`);
+    callbackUrl.searchParams.set('code', 'authorization-code');
+    callbackUrl.searchParams.set('state', transaction.state);
+    const handler = createOidcCallbackHandler(options);
+
+    const response = await handler({
+      cookies,
+      getClientAddress: () => '127.0.0.1',
+      params: { provider: 'dex' },
+      request: new Request(callbackUrl),
+      url: callbackUrl,
+    });
+
+    expect(response.status, await response.clone().text()).toBe(303);
+    expect(response.headers.get('location')).toBe('/dashboard');
+    expect(jar.has('sid')).toBe(true);
+    await expect(countRows(db, 'users')).resolves.toBe(1);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(1);
+    await expect(countRows(db, 'sessions')).resolves.toBe(1);
+  });
+
+  it('fails before User and session creation on a Profile-only collision', async () => {
+    const server = await startOidcServer();
+    cleanup.push(server.close);
+    const isolated = await createOidcTestDb();
+    cleanup.push(isolated.cleanup);
+    const { db } = isolated;
+    const profileId = randomUUID();
+    await db.query(
+      `INSERT INTO profiles
+        (id, slug, context, _meta_type, tenant_id, email, email_key, name)
+       VALUES (?, ?, '', '@happyvertical/smrt-profiles:Organization', NULL, ?, ?, 'Collision')`,
+      profileId,
+      `profile-${profileId}`,
+      'dex.user@example.com',
+      'dex.user@example.com',
+    );
+
+    const service = new OidcLoginService({
+      db,
+      provider: {
+        clientId: 'smrt-client',
+        issuer: server.issuer,
+        kind: 'dex',
+        redirectUri: `${server.issuer}/auth/dex/callback`,
+        tokenEndpointAuthMethod: 'none',
+      },
+      providerName: 'dex',
+    });
+    const transaction = service.createTransaction('/dashboard');
+    server.setNonce(transaction.nonce);
+    const callbackUrl = new URL(`${server.issuer}/auth/dex/callback`);
+    callbackUrl.searchParams.set('code', 'authorization-code');
+    callbackUrl.searchParams.set('state', transaction.state);
+    const { cookies } = createCookieJar({
+      smrt_oidc_dex: encodeOidcTransaction(transaction),
+    });
+    const handler = createOidcCallbackHandler({
+      db,
+      provider: 'dex',
+      providers: {
+        dex: {
+          clientId: 'smrt-client',
+          issuer: server.issuer,
+          kind: 'dex',
+          redirectUri: `${server.issuer}/auth/dex/callback`,
+          tokenEndpointAuthMethod: 'none',
+        },
+      },
+    });
+
+    const response = await handler({
+      cookies,
+      getClientAddress: () => '127.0.0.1',
+      params: { provider: 'dex' },
+      request: new Request(callbackUrl),
+      url: callbackUrl,
+    });
+
+    expect(response.status).toBe(401);
+    const failureBody = await response.text();
+    expect(failureBody).toBe('OIDC login failed.');
+    expect(failureBody).not.toContain('dex.user@example.com');
+    expect(failureBody).not.toContain(profileId);
+    expect(failureBody).not.toContain('Organization');
+    await expect(countRows(db, 'users')).resolves.toBe(0);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(0);
+    await expect(countRows(db, 'sessions')).resolves.toBe(0);
+
+    const resolverTransaction = service.createTransaction('/dashboard');
+    server.setNonce(resolverTransaction.nonce);
+    callbackUrl.searchParams.set('state', resolverTransaction.state);
+    const { cookies: resolverCookies } = createCookieJar({
+      smrt_oidc_dex: encodeOidcTransaction(resolverTransaction),
+    });
+    const internalResolverMessage = `resolver-secret:${profileId}:dex.user@example.com`;
+    const resolverHandler = createOidcCallbackHandler({
+      db,
+      provider: 'dex',
+      providers: {
+        dex: {
+          clientId: 'smrt-client',
+          issuer: server.issuer,
+          kind: 'dex',
+          redirectUri: `${server.issuer}/auth/dex/callback`,
+          tokenEndpointAuthMethod: 'none',
+        },
+      },
+      resolveProfile: () => {
+        throw new Error(internalResolverMessage);
+      },
+    });
+
+    const resolverResponse = await resolverHandler({
+      cookies: resolverCookies,
+      getClientAddress: () => '127.0.0.1',
+      params: { provider: 'dex' },
+      request: new Request(callbackUrl),
+      url: callbackUrl,
+    });
+    const resolverFailureBody = await resolverResponse.text();
+    expect(resolverResponse.status).toBe(401);
+    expect(resolverFailureBody).toBe('OIDC login failed.');
+    expect(resolverFailureBody).not.toContain(internalResolverMessage);
+    expect(resolverFailureBody).not.toContain(profileId);
+    expect(resolverFailureBody).not.toContain('dex.user@example.com');
+    await expect(countRows(db, 'users')).resolves.toBe(0);
+    await expect(countRows(db, 'sessions')).resolves.toBe(0);
+  });
+
   it('form-encodes client credentials for client_secret_basic token requests', async () => {
     const clientId = 'smrt client:dev@local';
     const clientSecret = 's:e+c ret ü';
@@ -381,6 +566,36 @@ describe('OidcLoginService', () => {
     expect(server.userinfoRequests[0]?.authorization).toBe(
       'Bearer access-token',
     );
+  });
+
+  it('does not borrow ID-token verification for a userinfo email', async () => {
+    const server = await startOidcServer({
+      idTokenEmailVerified: true,
+      includeEmailInIdToken: false,
+      userInfoEmailVerified: false,
+    });
+    cleanup.push(server.close);
+    const service = new OidcLoginService({
+      db: { type: 'sqlite', url: ':memory:' },
+      provider: {
+        clientId: 'smrt-client',
+        clientSecret: 'secret',
+        issuer: server.issuer,
+        kind: 'dex',
+        redirectUri: `${server.issuer}/auth/dex/callback`,
+      },
+      providerName: 'dex',
+    });
+    const transaction = service.createTransaction('/dashboard');
+    server.setNonce(transaction.nonce);
+    const callbackUrl = new URL(`${server.issuer}/auth/dex/callback`);
+    callbackUrl.searchParams.set('code', 'authorization-code');
+    callbackUrl.searchParams.set('state', transaction.state);
+
+    const result = await service.exchangeCallback(callbackUrl, transaction);
+
+    expect(result.claims.email).toBe('dex.user@example.com');
+    expect(result.claims.email_verified).toBe(false);
   });
 
   it('rejects multi-audience ID tokens with a mismatched authorized party', async () => {
@@ -468,3 +683,11 @@ describe('OidcLoginService', () => {
     expect(jar.has('smrt_oidc_dex')).toBe(false);
   });
 });
+
+async function countRows(
+  db: IsolatedTestDbResult['db'],
+  table: 'oidc_identities' | 'sessions' | 'users',
+): Promise<number> {
+  const result = await db.query(`SELECT count(*) AS count FROM ${table}`);
+  return Number(result.rows[0]?.count ?? 0);
+}

--- a/packages/users/src/__tests__/oidc-provisioning-postgres.test.ts
+++ b/packages/users/src/__tests__/oidc-provisioning-postgres.test.ts
@@ -1,0 +1,890 @@
+import { randomUUID } from 'node:crypto';
+import {
+  backfillProfileEmailKeys,
+  createProfileFromOidc,
+} from '@happyvertical/smrt-profiles';
+import {
+  getTestDbConfig,
+  isPostgresAvailable,
+} from '@happyvertical/smrt-vitest';
+import { type DatabaseInterface, getDatabase } from '@happyvertical/sql';
+import { afterEach, describe, expect, it } from 'vitest';
+import { UserCollection } from '../collections/UserCollection.js';
+import { backfillUserEmailKeys } from '../migrations/backfillUserEmailKeys.js';
+import {
+  OIDC_USERS_TEST_SCHEMA,
+  prepareOidcEmailKeyBackfills,
+} from './helpers/oidc-test-server.js';
+
+const describePostgres = isPostgresAvailable() ? describe : describe.skip;
+
+describePostgres('Postgres OIDC provisioning concurrency', () => {
+  let adminDb: DatabaseInterface | undefined;
+  let schemaName: string | undefined;
+  const connections: DatabaseInterface[] = [];
+
+  afterEach(async () => {
+    await Promise.all(connections.splice(0).map(closeDatabase));
+    if (adminDb && schemaName) {
+      await adminDb.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`);
+    }
+    await closeDatabase(adminDb);
+    adminDb = undefined;
+    schemaName = undefined;
+  });
+
+  it('converges independent first-login transactions on one identity and User', async () => {
+    const fixture = await createFixture();
+    await seedPersonType(fixture.rootDb);
+
+    const firstDb = await getDatabase({
+      ...fixture.config,
+      dbid: `oidc-first-${Date.now()}`,
+    });
+    const secondDb = await getDatabase({
+      ...fixture.config,
+      dbid: `oidc-second-${Date.now()}`,
+    });
+    await Promise.all([
+      setSearchPath(firstDb, fixture.schemaName),
+      setSearchPath(secondDb, fixture.schemaName),
+    ]);
+    connections.push(firstDb, secondDb);
+    const firstUsers = await UserCollection.create({ db: firstDb });
+    const secondUsers = await UserCollection.create({ db: secondDb });
+
+    let arrivals = 0;
+    let release!: () => void;
+    const bothLookupsComplete = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const barrier = async () => {
+      arrivals += 1;
+      if (arrivals === 2) release();
+      await bothLookupsComplete;
+      return undefined;
+    };
+    const claims = {
+      email: 'postgres-concurrent@example.com',
+      email_verified: true,
+      iss: 'https://issuer.example.com',
+      name: 'Concurrent Postgres User',
+      sub: 'postgres-concurrent-subject',
+    };
+
+    const [first, second] = await Promise.all([
+      firstUsers.getOrCreateFromOidc(claims, 'dex', {
+        resolveProfile: barrier,
+      }),
+      secondUsers.getOrCreateFromOidc(claims, 'dex', {
+        resolveProfile: barrier,
+      }),
+    ]);
+
+    expect(second.profile.id).toBe(first.profile.id);
+    expect(second.user.id).toBe(first.user.id);
+    expect(second.oidcIdentity.id).toBe(first.oidcIdentity.id);
+    first.user.recordLogin();
+    await expect(first.user.save()).resolves.toBe(first.user);
+    await expect(first.profile.getOidcIdentities()).resolves.toHaveLength(1);
+    await expect(first.oidcIdentity.recordUsage()).resolves.toBeUndefined();
+    await expect(countRows(firstDb, 'profiles')).resolves.toBe(1);
+    await expect(countRows(firstDb, 'users')).resolves.toBe(1);
+    await expect(countRows(firstDb, 'oidc_identities')).resolves.toBe(1);
+    await expect(
+      countRows(firstDb, 'oidc_profile_email_reservations'),
+    ).resolves.toBe(1);
+  });
+
+  it('reinvokes an idempotent resolver after a durable-arbiter retry', async () => {
+    const fixture = await createFixture();
+    await seedPersonType(fixture.rootDb);
+
+    const rootDb = await getDatabase({
+      ...fixture.config,
+      dbid: `oidc-retry-${Date.now()}`,
+    });
+    await setSearchPath(rootDb, fixture.schemaName);
+    connections.push(rootDb);
+    let injectedConflicts = 0;
+    const retryingDb = withFirstIdentityArbiterConflict(rootDb, () => {
+      injectedConflicts += 1;
+    });
+    const users = await UserCollection.create({ db: retryingDb });
+    let resolverCalls = 0;
+    const resolver = async () => {
+      resolverCalls += 1;
+      return undefined;
+    };
+
+    const result = await users.getOrCreateFromOidc(
+      {
+        email: 'postgres-retry@example.com',
+        email_verified: true,
+        iss: 'https://issuer.example.com',
+        sub: 'postgres-retry-subject',
+      },
+      'dex',
+      { resolveProfile: resolver },
+    );
+
+    expect(injectedConflicts).toBe(1);
+    expect(resolverCalls).toBe(2);
+    expect(result.created).toBe(true);
+    await expect(countRows(rootDb, 'profiles')).resolves.toBe(1);
+    await expect(countRows(rootDb, 'users')).resolves.toBe(1);
+    await expect(countRows(rootDb, 'oidc_identities')).resolves.toBe(1);
+    await expect(
+      countRows(rootDb, 'oidc_profile_email_reservations'),
+    ).resolves.toBe(1);
+  });
+
+  it('allows only one subject to claim a verified email across independent transactions', async () => {
+    const fixture = await createFixture();
+    await seedPersonType(fixture.rootDb);
+
+    const firstDb = await getDatabase({
+      ...fixture.config,
+      dbid: `oidc-owner-first-${Date.now()}`,
+    });
+    const secondDb = await getDatabase({
+      ...fixture.config,
+      dbid: `oidc-owner-second-${Date.now()}`,
+    });
+    await Promise.all([
+      setSearchPath(firstDb, fixture.schemaName),
+      setSearchPath(secondDb, fixture.schemaName),
+    ]);
+    connections.push(firstDb, secondDb);
+    const firstUsers = await UserCollection.create({ db: firstDb });
+    const secondUsers = await UserCollection.create({ db: secondDb });
+    const synchronizeLookup = createBarrier(2);
+    const commonClaims = {
+      email: 'postgres-owned-race@example.com',
+      email_verified: true,
+      iss: 'https://issuer.example.com',
+      name: 'Competing Postgres User',
+    };
+
+    const results = await Promise.allSettled([
+      firstUsers.getOrCreateFromOidc(
+        { ...commonClaims, sub: 'postgres-owner-subject-one' },
+        'dex',
+        { resolveProfile: synchronizeLookup },
+      ),
+      secondUsers.getOrCreateFromOidc(
+        { ...commonClaims, sub: 'postgres-owner-subject-two' },
+        'dex',
+        { resolveProfile: synchronizeLookup },
+      ),
+    ]);
+
+    expect(
+      results.filter((result) => result.status === 'fulfilled'),
+    ).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toEqual([
+      expect.objectContaining({
+        reason: expect.objectContaining({ code: 'profile_owned' }),
+      }),
+    ]);
+    await expect(countRows(firstDb, 'profiles')).resolves.toBe(1);
+    await expect(countRows(firstDb, 'users')).resolves.toBe(1);
+    await expect(countRows(firstDb, 'oidc_identities')).resolves.toBe(1);
+    await expect(
+      countRows(firstDb, 'oidc_profile_email_reservations'),
+    ).resolves.toBe(1);
+  });
+
+  it('rejects existing identities without Users when the claim email changes', async () => {
+    const fixture = await createFixture();
+    await seedPersonType(fixture.rootDb);
+    await seedExistingIdentity(fixture.rootDb, {
+      email: 'stored-first@example.com',
+      subject: 'existing-first-subject',
+    });
+    await seedExistingIdentity(fixture.rootDb, {
+      email: 'stored-second@example.com',
+      subject: 'existing-second-subject',
+    });
+
+    const firstDb = await getDatabase({
+      ...fixture.config,
+      dbid: `oidc-existing-email-first-${Date.now()}`,
+    });
+    const secondDb = await getDatabase({
+      ...fixture.config,
+      dbid: `oidc-existing-email-second-${Date.now()}`,
+    });
+    await Promise.all([
+      setSearchPath(firstDb, fixture.schemaName),
+      setSearchPath(secondDb, fixture.schemaName),
+    ]);
+    connections.push(firstDb, secondDb);
+    const firstUsers = await UserCollection.create({ db: firstDb });
+    const secondUsers = await UserCollection.create({ db: secondDb });
+    const commonClaims = {
+      email: 'shared-new@example.com',
+      email_verified: true,
+      iss: 'https://issuer.example.com',
+      name: 'Existing Identity User',
+    };
+
+    const results = await Promise.allSettled([
+      firstUsers.getOrCreateFromOidc(
+        { ...commonClaims, sub: 'existing-first-subject' },
+        'dex',
+      ),
+      secondUsers.getOrCreateFromOidc(
+        { ...commonClaims, sub: 'existing-second-subject' },
+        'dex',
+      ),
+    ]);
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        reason: expect.objectContaining({ code: 'email_mismatch' }),
+        status: 'rejected',
+      }),
+      expect.objectContaining({
+        reason: expect.objectContaining({ code: 'email_mismatch' }),
+        status: 'rejected',
+      }),
+    ]);
+    await expect(countRows(firstDb, 'profiles')).resolves.toBe(2);
+    await expect(countRows(firstDb, 'users')).resolves.toBe(0);
+    await expect(countRows(firstDb, 'oidc_identities')).resolves.toBe(2);
+    await expect(
+      countRows(firstDb, 'oidc_profile_email_reservations'),
+    ).resolves.toBe(2);
+  });
+
+  it('retries a deadlock while reconciling concurrently swapped reservations', async () => {
+    const fixture = await createFixture();
+    await seedPersonType(fixture.rootDb);
+    const firstProfileId = await seedExistingIdentity(fixture.rootDb, {
+      email: 'swap-first@example.com',
+      subject: 'postgres-swap-first-subject',
+    });
+    const secondProfileId = await seedExistingIdentity(fixture.rootDb, {
+      email: 'swap-second@example.com',
+      subject: 'postgres-swap-second-subject',
+    });
+    await fixture.rootDb.query(
+      'UPDATE profiles SET email = ?, email_key = ? WHERE id = ?',
+      'swap-second@example.com',
+      'swap-second@example.com',
+      firstProfileId,
+    );
+    await fixture.rootDb.query(
+      'UPDATE profiles SET email = ?, email_key = ? WHERE id = ?',
+      'swap-first@example.com',
+      'swap-first@example.com',
+      secondProfileId,
+    );
+
+    const firstDb = await getDatabase({
+      ...fixture.config,
+      dbid: `oidc-swap-first-${Date.now()}`,
+    });
+    const secondDb = await getDatabase({
+      ...fixture.config,
+      dbid: `oidc-swap-second-${Date.now()}`,
+    });
+    await Promise.all([
+      setSearchPath(firstDb, fixture.schemaName),
+      setSearchPath(secondDb, fixture.schemaName),
+    ]);
+    connections.push(firstDb, secondDb);
+    const synchronizeDeletes = createBarrier(2);
+    const firstUsers = await UserCollection.create({
+      db: withReservationDeleteBarrier(firstDb, synchronizeDeletes),
+    });
+    const secondUsers = await UserCollection.create({
+      db: withReservationDeleteBarrier(secondDb, synchronizeDeletes),
+    });
+
+    const [first, second] = await Promise.all([
+      firstUsers.getOrCreateFromOidc(
+        {
+          email: 'swap-second@example.com',
+          email_verified: true,
+          iss: 'https://issuer.example.com',
+          sub: 'postgres-swap-first-subject',
+        },
+        'dex',
+      ),
+      secondUsers.getOrCreateFromOidc(
+        {
+          email: 'swap-first@example.com',
+          email_verified: true,
+          iss: 'https://issuer.example.com',
+          sub: 'postgres-swap-second-subject',
+        },
+        'dex',
+      ),
+    ]);
+
+    expect(first.profile.id).toBe(firstProfileId);
+    expect(second.profile.id).toBe(secondProfileId);
+    await expect(countRows(firstDb, 'users')).resolves.toBe(2);
+    const reservations = await firstDb.query(
+      'SELECT profile_id, email_key FROM oidc_profile_email_reservations ORDER BY email_key',
+    );
+    expect(reservations.rows).toEqual([
+      { profile_id: secondProfileId, email_key: 'swap-first@example.com' },
+      { profile_id: firstProfileId, email_key: 'swap-second@example.com' },
+    ]);
+  });
+
+  it('enforces normalized User email uniqueness across independent connections', async () => {
+    const fixture = await createFixture();
+    const firstDb = await getDatabase({
+      ...fixture.config,
+      dbid: `user-email-first-${Date.now()}`,
+    });
+    const secondDb = await getDatabase({
+      ...fixture.config,
+      dbid: `user-email-second-${Date.now()}`,
+    });
+    await Promise.all([
+      setSearchPath(firstDb, fixture.schemaName),
+      setSearchPath(secondDb, fixture.schemaName),
+    ]);
+    connections.push(firstDb, secondDb);
+    const synchronizeUpsert = createBarrier(2);
+    const firstUsers = await UserCollection.create({
+      db: withUserUpsertBarrier(firstDb, synchronizeUpsert),
+    });
+    const secondUsers = await UserCollection.create({
+      db: withUserUpsertBarrier(secondDb, synchronizeUpsert),
+    });
+
+    const results = await Promise.allSettled([
+      firstUsers.create({
+        email: ' Shared-New@Example.com ',
+        profileId: randomUUID(),
+      }),
+      secondUsers.create({
+        email: 'shared-new@example.com',
+        profileId: randomUUID(),
+      }),
+    ]);
+
+    expect(
+      results.filter((result) => result.status === 'fulfilled'),
+    ).toHaveLength(1);
+    expect(
+      results.filter((result) => result.status === 'rejected'),
+    ).toHaveLength(1);
+    await expect(countRows(firstDb, 'users')).resolves.toBe(1);
+    const storedUsers = await firstDb.query(
+      'SELECT email, email_key FROM users',
+    );
+    expect(storedUsers.rows).toEqual([
+      {
+        email: 'shared-new@example.com',
+        email_key: 'shared-new@example.com',
+      },
+    ]);
+  });
+
+  it('serializes unrelated provisions on one transaction-bound client', async () => {
+    const fixture = await createFixture();
+    await seedPersonType(fixture.rootDb);
+    if (!fixture.rootDb.beginTransaction) {
+      throw new Error('Expected PostgreSQL manual transaction support.');
+    }
+    const tx = await fixture.rootDb.beginTransaction();
+    let trackerDdl = 0;
+    const observeTrackerDdl = (sql: string) => {
+      if (/create\s+table[\s\S]*_smrt_backfills/iu.test(sql)) trackerDdl += 1;
+    };
+
+    try {
+      const firstUsers = await UserCollection.create({
+        db: proxyDatabaseHandle(tx, observeTrackerDdl),
+      });
+      const secondUsers = await UserCollection.create({
+        db: proxyDatabaseHandle(tx, observeTrackerDdl),
+      });
+      const [first, second] = await Promise.all([
+        firstUsers.getOrCreateFromOidc(
+          {
+            email: 'outer-first@example.com',
+            email_verified: true,
+            iss: 'https://issuer.example.com',
+            sub: 'outer-first-subject',
+          },
+          'dex',
+        ),
+        secondUsers.getOrCreateFromOidc(
+          {
+            email: 'outer-second@example.com',
+            email_verified: true,
+            iss: 'https://issuer.example.com',
+            sub: 'outer-second-subject',
+          },
+          'dex',
+        ),
+      ]);
+
+      expect(second.profile.id).not.toBe(first.profile.id);
+      await expect(countRows(tx, 'users')).resolves.toBe(2);
+      await expect(tx.query('SELECT 1 AS usable')).resolves.toMatchObject({
+        rows: [{ usable: 1 }],
+      });
+      expect(tx.isActive()).toBe(true);
+      expect(trackerDdl).toBe(0);
+    } finally {
+      if (tx.isActive()) await tx.rollback();
+    }
+  });
+
+  it('reinitializes dropped backfill state on the same root before provisioning', async () => {
+    const fixture = await createFixture();
+    await seedPersonType(fixture.rootDb);
+    await fixture.rootDb.query('DROP TABLE _smrt_backfills');
+
+    await expect(backfillProfileEmailKeys(fixture.rootDb)).resolves.toEqual({
+      updated: 0,
+    });
+    await expect(backfillUserEmailKeys(fixture.rootDb)).resolves.toEqual({
+      updated: 0,
+    });
+
+    const users = await UserCollection.create({ db: fixture.rootDb });
+    const result = await users.getOrCreateFromOidc(
+      {
+        email: 'postgres-reinitialized@example.com',
+        email_verified: true,
+        iss: 'https://issuer.example.com',
+        sub: 'postgres-reinitialized-subject',
+      },
+      'dex',
+    );
+
+    expect(result.created).toBe(true);
+    await expect(countRows(fixture.rootDb, 'users')).resolves.toBe(1);
+  });
+
+  it('converges public Profile helper calls across independent transactions', async () => {
+    const fixture = await createFixture();
+    await seedPersonType(fixture.rootDb);
+
+    const firstDb = await getDatabase({
+      ...fixture.config,
+      dbid: `oidc-profile-first-${Date.now()}`,
+    });
+    const secondDb = await getDatabase({
+      ...fixture.config,
+      dbid: `oidc-profile-second-${Date.now()}`,
+    });
+    await Promise.all([
+      setSearchPath(firstDb, fixture.schemaName),
+      setSearchPath(secondDb, fixture.schemaName),
+    ]);
+    connections.push(firstDb, secondDb);
+    const synchronizeLookup = createBarrier(2);
+    const claims = {
+      email: 'postgres-profile-concurrent@example.com',
+      email_verified: true,
+      iss: 'https://issuer.example.com',
+      name: 'Concurrent Postgres Profile',
+      sub: 'postgres-profile-concurrent-subject',
+    };
+
+    const [first, second] = await Promise.all([
+      createProfileFromOidc(claims, 'dex', {
+        db: withIdentityLookupBarrier(firstDb, synchronizeLookup),
+      }),
+      createProfileFromOidc(claims, 'dex', {
+        db: withIdentityLookupBarrier(secondDb, synchronizeLookup),
+      }),
+    ]);
+
+    expect(second.profile.id).toBe(first.profile.id);
+    expect(second.oidcIdentity.id).toBe(first.oidcIdentity.id);
+    await expect(first.profile.getOidcIdentities()).resolves.toHaveLength(1);
+    await expect(first.oidcIdentity.recordUsage()).resolves.toBeUndefined();
+    await expect(countRows(firstDb, 'profiles')).resolves.toBe(1);
+    await expect(countRows(firstDb, 'oidc_identities')).resolves.toBe(1);
+    await expect(
+      countRows(firstDb, 'oidc_profile_email_reservations'),
+    ).resolves.toBe(1);
+  });
+
+  it('creates one stable Person type during unseeded independent logins', async () => {
+    const fixture = await createFixture();
+
+    const firstDb = await getDatabase({
+      ...fixture.config,
+      dbid: `oidc-unseeded-first-${Date.now()}`,
+    });
+    const secondDb = await getDatabase({
+      ...fixture.config,
+      dbid: `oidc-unseeded-second-${Date.now()}`,
+    });
+    await Promise.all([
+      setSearchPath(firstDb, fixture.schemaName),
+      setSearchPath(secondDb, fixture.schemaName),
+    ]);
+    connections.push(firstDb, secondDb);
+    const firstUsers = await UserCollection.create({ db: firstDb });
+    const secondUsers = await UserCollection.create({ db: secondDb });
+    const synchronizeLookup = createBarrier(2);
+
+    const [first, second] = await Promise.all([
+      firstUsers.getOrCreateFromOidc(
+        {
+          email: 'unseeded-first@example.com',
+          email_verified: true,
+          iss: 'https://issuer.example.com',
+          sub: 'unseeded-first-subject',
+        },
+        'dex',
+        { resolveProfile: synchronizeLookup },
+      ),
+      secondUsers.getOrCreateFromOidc(
+        {
+          email: 'unseeded-second@example.com',
+          email_verified: true,
+          iss: 'https://issuer.example.com',
+          sub: 'unseeded-second-subject',
+        },
+        'dex',
+        { resolveProfile: synchronizeLookup },
+      ),
+    ]);
+
+    expect(second.profile.typeId).toBe(first.profile.typeId);
+    await expect(countRows(firstDb, 'profiles')).resolves.toBe(2);
+    await expect(countRows(firstDb, 'users')).resolves.toBe(2);
+    await expect(countRows(firstDb, 'oidc_identities')).resolves.toBe(2);
+    await expect(
+      countRows(firstDb, 'oidc_profile_email_reservations'),
+    ).resolves.toBe(2);
+    const personTypes = await firstDb.query(
+      "SELECT id FROM profile_types WHERE slug = 'person'",
+    );
+    expect(personTypes.rows).toHaveLength(1);
+    expect(personTypes.rows[0]?.id).toBe(first.profile.typeId);
+  });
+
+  async function createFixture(): Promise<{
+    config: {
+      __smrtSkipVitestSchemaPreparation: true;
+      type: 'postgres';
+      url: string;
+    };
+    rootDb: DatabaseInterface;
+    schemaName: string;
+  }> {
+    const baseConfig = getTestDbConfig();
+    if (baseConfig.type !== 'postgres') {
+      throw new Error('Expected a Postgres test database.');
+    }
+    schemaName = `oidc_${randomUUID().replaceAll('-', '')}`;
+    adminDb = await getDatabase({
+      ...baseConfig,
+      dbid: `oidc-admin-${schemaName}`,
+    });
+    await adminDb.query(`CREATE SCHEMA "${schemaName}"`);
+    const url = new URL(baseConfig.url);
+    url.searchParams.set('options', `-csearch_path=${schemaName}`);
+    const config = {
+      __smrtSkipVitestSchemaPreparation: true as const,
+      type: 'postgres' as const,
+      url: url.toString(),
+    };
+    const rootDb = await getDatabase({
+      ...config,
+      dbid: `oidc-root-${schemaName}`,
+    });
+    connections.push(rootDb);
+    await setSearchPath(rootDb, schemaName);
+    await executeSchema(rootDb, OIDC_USERS_TEST_SCHEMA);
+    await prepareOidcEmailKeyBackfills(rootDb);
+    return { config, rootDb, schemaName };
+  }
+});
+
+async function setSearchPath(
+  db: DatabaseInterface,
+  schemaName: string,
+): Promise<void> {
+  await db.query(`SET search_path TO "${schemaName}"`);
+}
+
+async function executeSchema(
+  db: DatabaseInterface,
+  schema: string,
+): Promise<void> {
+  for (const statement of schema.split(';').map((part) => part.trim())) {
+    if (statement) await db.query(statement);
+  }
+}
+
+async function countRows(
+  db: DatabaseInterface,
+  table:
+    | 'oidc_identities'
+    | 'oidc_profile_email_reservations'
+    | 'profiles'
+    | 'users',
+): Promise<number> {
+  const result = await db.query(`SELECT count(*) AS count FROM ${table}`);
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+async function seedPersonType(db: DatabaseInterface): Promise<void> {
+  const id = randomUUID();
+  await db.query(
+    `INSERT INTO profile_types
+      (id, slug, context, _meta_type, name, description)
+     VALUES (?, 'person', '', '@happyvertical/smrt-profiles:ProfileType', 'Person', 'Individual person profile')
+     ON CONFLICT (slug, context, _meta_type) DO NOTHING`,
+    id,
+  );
+}
+
+async function seedExistingIdentity(
+  db: DatabaseInterface,
+  options: { email: string; subject: string },
+): Promise<string> {
+  const profileId = randomUUID();
+  const identityId = randomUUID();
+  await db.query(
+    `INSERT INTO profiles
+      (id, slug, context, _meta_type, tenant_id, email, email_key, name)
+     VALUES (?, ?, '', '@happyvertical/smrt-profiles:Person', NULL, ?, ?, 'Existing Person')`,
+    profileId,
+    `profile-${profileId}`,
+    options.email,
+    options.email.trim().toLowerCase(),
+  );
+  await db.query(
+    `INSERT INTO oidc_identities
+      (id, slug, context, profile_id, provider, issuer, subject, identity_key, email)
+     VALUES (?, ?, '', ?, 'dex', 'https://issuer.example.com', ?, ?, ?)`,
+    identityId,
+    `identity-${identityId}`,
+    profileId,
+    options.subject,
+    JSON.stringify(['https://issuer.example.com', options.subject]),
+    options.email,
+  );
+  const reservationId = randomUUID();
+  await db.query(
+    `INSERT INTO oidc_profile_email_reservations
+      (id, slug, context, profile_id, email_key)
+     VALUES (?, ?, '', ?, ?)`,
+    reservationId,
+    `reservation-${reservationId}`,
+    profileId,
+    options.email,
+  );
+  return profileId;
+}
+
+function createBarrier(parties: number): () => Promise<undefined> {
+  let arrivals = 0;
+  let release!: () => void;
+  const ready = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return async () => {
+    if (arrivals >= parties) return undefined;
+    arrivals += 1;
+    if (arrivals === parties) release();
+    await ready;
+    return undefined;
+  };
+}
+
+function withIdentityLookupBarrier(
+  db: DatabaseInterface,
+  synchronize: () => Promise<void>,
+): DatabaseInterface {
+  return withQueryBarrier(
+    db,
+    synchronize,
+    /from\s+["`]?oidc_identities["`]?/iu,
+  );
+}
+
+function withFirstIdentityArbiterConflict(
+  db: DatabaseInterface,
+  onConflict: () => void,
+): DatabaseInterface {
+  const transaction = db.transaction;
+  if (!transaction) {
+    throw new Error('Expected a transaction-capable database.');
+  }
+  let injected = false;
+  return new Proxy(db, {
+    get(target, property, receiver) {
+      if (property === 'transaction') {
+        return async <T>(
+          callback: (tx: DatabaseInterface) => Promise<T>,
+        ): Promise<T> =>
+          transaction.call(target, (tx) =>
+            callback(
+              new Proxy(tx, {
+                get(txTarget, txProperty, txReceiver) {
+                  if (txProperty === 'upsert') {
+                    return async (
+                      ...args: Parameters<DatabaseInterface['upsert']>
+                    ) => {
+                      if (!injected && args[0] === 'oidc_identities') {
+                        injected = true;
+                        onConflict();
+                        throw new Error(
+                          'duplicate key violates unique constraint "oidc_identities_identity_key_idx"',
+                        );
+                      }
+                      return txTarget.upsert(...args);
+                    };
+                  }
+                  const value = Reflect.get(txTarget, txProperty, txReceiver);
+                  return typeof value === 'function'
+                    ? value.bind(txTarget)
+                    : value;
+                },
+              }),
+            ),
+          );
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
+function proxyDatabaseHandle(
+  db: DatabaseInterface,
+  observeQuery?: (sql: string) => void,
+): DatabaseInterface {
+  return new Proxy(db, {
+    get(target, property, receiver) {
+      if (property === 'query') {
+        return async (sql: string, ...params: unknown[]) => {
+          observeQuery?.(sql);
+          return target.query(sql, ...params);
+        };
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
+function withUserUpsertBarrier(
+  db: DatabaseInterface,
+  synchronize: () => Promise<void>,
+): DatabaseInterface {
+  return new Proxy(db, {
+    get(target, property, receiver) {
+      if (property === 'upsert') {
+        return async (...args: Parameters<DatabaseInterface['upsert']>) => {
+          if (args[0] === 'users') await synchronize();
+          return target.upsert(...args);
+        };
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
+function withReservationDeleteBarrier(
+  db: DatabaseInterface,
+  synchronize: () => Promise<void>,
+): DatabaseInterface {
+  return new Proxy(db, {
+    get(target, property, receiver) {
+      if (property === 'transaction') {
+        return async <T>(
+          callback: (tx: DatabaseInterface) => Promise<T>,
+        ): Promise<T> => {
+          if (!target.transaction) {
+            throw new Error('Expected a transaction-capable database.');
+          }
+          return target.transaction((tx) =>
+            callback(
+              new Proxy(tx, {
+                get(txTarget, txProperty, txReceiver) {
+                  if (txProperty === 'delete') {
+                    return async (
+                      ...args: Parameters<DatabaseInterface['delete']>
+                    ) => {
+                      const result = await txTarget.delete(...args);
+                      if (args[0] === 'oidc_profile_email_reservations') {
+                        await synchronize();
+                      }
+                      return result;
+                    };
+                  }
+                  const value = Reflect.get(txTarget, txProperty, txReceiver);
+                  return typeof value === 'function'
+                    ? value.bind(txTarget)
+                    : value;
+                },
+              }),
+            ),
+          );
+        };
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
+function withQueryBarrier(
+  db: DatabaseInterface,
+  synchronize: () => Promise<void>,
+  queryPattern: RegExp,
+): DatabaseInterface {
+  return new Proxy(db, {
+    get(target, property, receiver) {
+      if (property === 'transaction') {
+        return async <T>(
+          callback: (tx: DatabaseInterface) => Promise<T>,
+        ): Promise<T> => {
+          if (!target.transaction) {
+            throw new Error('Expected a transaction-capable database.');
+          }
+          return target.transaction(async (tx) => {
+            const synchronizedTx = new Proxy(tx, {
+              get(txTarget, txProperty, txReceiver) {
+                if (txProperty === 'query') {
+                  return async (sql: string, ...params: unknown[]) => {
+                    const result = await txTarget.query(sql, ...params);
+                    if (queryPattern.test(sql)) {
+                      await synchronize();
+                    }
+                    return result;
+                  };
+                }
+                const value = Reflect.get(txTarget, txProperty, txReceiver);
+                return typeof value === 'function'
+                  ? value.bind(txTarget)
+                  : value;
+              },
+            });
+            return callback(synchronizedTx);
+          });
+        };
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
+async function closeDatabase(db: DatabaseInterface | undefined): Promise<void> {
+  if (!db) return;
+  const close = (db as DatabaseInterface & { close?: () => Promise<void> })
+    .close;
+  if (close) await close.call(db);
+}

--- a/packages/users/src/__tests__/oidc-provisioning-safety.test.ts
+++ b/packages/users/src/__tests__/oidc-provisioning-safety.test.ts
@@ -445,7 +445,9 @@ describe('safe OIDC provisioning', () => {
         }),
       ]);
 
-      expect(resolverCalls).toBe(1);
+      // Each callback crosses the application rejection boundary, including
+      // the serialized callback that observes the winner's exact identity.
+      expect(resolverCalls).toBe(2);
       expect(maxActiveResolvers).toBe(1);
       expect(second.profile.id).toBe(first.profile.id);
       expect(second.user.id).toBe(first.user.id);
@@ -613,6 +615,77 @@ describe('safe OIDC provisioning', () => {
     await expect(countRows(db, 'profiles')).resolves.toBe(1);
     await expect(countRows(db, 'users')).resolves.toBe(1);
     await expect(countRows(db, 'oidc_identities')).resolves.toBe(1);
+  });
+
+  it('runs the resolver before exact identity reuse and rejects without User or session creation', async () => {
+    const profileId = await seedProfile(db, {
+      email: 'resolver-returning@example.com',
+    });
+    await seedIdentity(db, profileId, {
+      email: 'resolver-returning@example.com',
+      subject: 'resolver-returning-subject',
+    });
+    let resolverCalls = 0;
+
+    await expect(
+      users.getOrCreateFromOidc(
+        claims({
+          email: 'resolver-returning@example.com',
+          sub: 'resolver-returning-subject',
+        }),
+        'dex',
+        {
+          resolveProfile: ({ claims: resolvedClaims }) => {
+            resolverCalls += 1;
+            expect(resolvedClaims.sub).toBe('resolver-returning-subject');
+            return null;
+          },
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'rejected' });
+
+    expect(resolverCalls).toBe(1);
+    await expect(countRows(db, 'profiles')).resolves.toBe(1);
+    await expect(countRows(db, 'users')).resolves.toBe(0);
+    await expect(countRows(db, 'sessions')).resolves.toBe(0);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(1);
+  });
+
+  it('prevents the resolver from rebinding an exact OIDC identity', async () => {
+    const linkedProfileId = await seedProfile(db, {
+      email: 'resolver-linked@example.com',
+    });
+    const otherProfileId = await seedProfile(db, {
+      email: 'resolver-other@example.com',
+    });
+    await seedIdentity(db, linkedProfileId, {
+      email: 'resolver-linked@example.com',
+      subject: 'resolver-rebind-subject',
+    });
+
+    await expect(
+      users.getOrCreateFromOidc(
+        claims({
+          email: 'resolver-linked@example.com',
+          sub: 'resolver-rebind-subject',
+        }),
+        'dex',
+        {
+          resolveProfile: async ({ db: tx }) =>
+            (await ProfileCollection.create({ db: tx })).get({
+              id: otherProfileId,
+            }),
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'rejected' });
+
+    const identities = await db.query(
+      'SELECT profile_id FROM oidc_identities WHERE subject = ?',
+      'resolver-rebind-subject',
+    );
+    expect(identities.rows).toEqual([{ profile_id: linkedProfileId }]);
+    await expect(countRows(db, 'users')).resolves.toBe(0);
+    await expect(countRows(db, 'sessions')).resolves.toBe(0);
   });
 
   it('preserves the exact opaque issuer and subject claims', async () => {

--- a/packages/users/src/__tests__/oidc-provisioning-safety.test.ts
+++ b/packages/users/src/__tests__/oidc-provisioning-safety.test.ts
@@ -1,0 +1,1311 @@
+import { randomUUID } from 'node:crypto';
+import type { DatabaseInterface } from '@happyvertical/smrt-core/migrations';
+import {
+  createProfileFromOidc,
+  normalizeIdentityEmail,
+  OidcIdentityCollection,
+  ProfileCollection,
+} from '@happyvertical/smrt-profiles';
+import {
+  createIsolatedTestDb,
+  type IsolatedTestDbResult,
+} from '@happyvertical/smrt-vitest';
+import { getDatabase, syncSchema } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  type OidcClaims,
+  type OidcProvisioningError,
+  UserCollection,
+} from '../collections/UserCollection.js';
+import {
+  OIDC_USERS_TEST_SCHEMA,
+  prepareOidcEmailKeyBackfills,
+} from './helpers/oidc-test-server.js';
+
+const PERSON_META_TYPE = '@happyvertical/smrt-profiles:Person';
+const ORGANIZATION_META_TYPE = '@happyvertical/smrt-profiles:Organization';
+
+describe('safe OIDC provisioning', () => {
+  let isolated: IsolatedTestDbResult;
+  let db: DatabaseInterface;
+  let users: UserCollection;
+
+  beforeEach(async () => {
+    isolated = await createIsolatedTestDb({ schema: OIDC_USERS_TEST_SCHEMA });
+    db = isolated.db;
+    await prepareOidcEmailKeyBackfills(db);
+    users = await UserCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    await isolated.cleanup();
+  });
+
+  it('reuses one unowned global Person for a verified email', async () => {
+    const profileId = await seedProfile(db, {
+      email: ' Safe@Example.com ',
+    });
+
+    const result = await users.getOrCreateFromOidc(
+      claims({ email: ' SAFE@example.com ' }),
+      'dex',
+    );
+
+    expect(result.created).toBe(false);
+    expect(result.profile.id).toBe(profileId);
+    expect(result.user.profileId).toBe(profileId);
+    await expect(countRows(db, 'profiles')).resolves.toBe(1);
+    await expect(countRows(db, 'users')).resolves.toBe(1);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(1);
+  });
+
+  it('fails closed on a tenant-scoped Profile-only email collision', async () => {
+    await seedProfile(db, {
+      email: '\tÜser@Example.com\t',
+      tenantId: randomUUID(),
+    });
+
+    await expect(
+      users.getOrCreateFromOidc(claims({ email: 'üser@example.com' }), 'dex'),
+    ).rejects.toMatchObject({ code: 'tenant_scoped' });
+    await expectNoProvisioningWrites(db);
+  });
+
+  it('fails closed on a non-Person Profile-only email collision', async () => {
+    await seedProfile(db, {
+      email: '\tÜser@Example.com\t',
+      metaType: ORGANIZATION_META_TYPE,
+    });
+
+    await expect(
+      users.getOrCreateFromOidc(claims({ email: 'üser@example.com' }), 'dex'),
+    ).rejects.toMatchObject({ code: 'non_person' });
+    await expectNoProvisioningWrites(db);
+  });
+
+  it('fails closed when duplicate Profiles share the verified email', async () => {
+    await seedProfile(db, { email: '\tÜser@Example.com\t' });
+    await seedProfile(db, { email: 'üser@example.com' });
+
+    await expect(
+      users.getOrCreateFromOidc(claims({ email: 'ÜSER@example.com' }), 'dex'),
+    ).rejects.toMatchObject({ code: 'ambiguous_email' });
+    await expectNoProvisioningWrites(db, 2);
+  });
+
+  it('fails closed when the matching Person already belongs to a User', async () => {
+    const profileId = await seedProfile(db, {
+      email: 'collision@example.com',
+    });
+    await seedUser(db, profileId, 'collision@example.com');
+
+    await expect(users.getOrCreateFromOidc(claims(), 'dex')).rejects.toEqual(
+      expect.objectContaining<Partial<OidcProvisioningError>>({
+        code: 'profile_owned',
+      }),
+    );
+    await expect(countRows(db, 'users')).resolves.toBe(1);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(0);
+    await expect(
+      countRows(db, 'oidc_profile_email_reservations'),
+    ).resolves.toBe(0);
+  });
+
+  it('prevents the Profile-only helper from planting an identity on an owned Profile', async () => {
+    const profileId = await seedProfile(db, {
+      email: 'profile-helper-owned@example.com',
+    });
+    await seedUser(db, profileId, 'profile-helper-owned@example.com');
+
+    await expect(
+      createProfileFromOidc(
+        {
+          email: 'profile-helper-owned@example.com',
+          email_verified: true,
+          iss: 'https://new-issuer.example.com',
+          sub: 'new-subject',
+        },
+        'new-provider',
+        { db },
+      ),
+    ).rejects.toThrow('cannot prove that Profile is unowned');
+
+    await expect(countRows(db, 'profiles')).resolves.toBe(1);
+    await expect(countRows(db, 'users')).resolves.toBe(1);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(0);
+    await expect(
+      countRows(db, 'oidc_profile_email_reservations'),
+    ).resolves.toBe(0);
+  });
+
+  it('prevents legacy Profile link helpers from planting an identity on an owned Profile', async () => {
+    const profileId = await seedProfile(db, {
+      email: 'legacy-link-owned@example.com',
+    });
+    await seedUser(db, profileId, 'legacy-link-owned@example.com');
+    const profiles = await ProfileCollection.create({ db });
+    const profile = await profiles.get({ id: profileId });
+    if (!profile) throw new Error('Expected seeded Profile.');
+    const oidcData = {
+      email: 'legacy-link-owned@example.com',
+      issuer: 'https://attacker.example.com',
+      provider: 'attacker',
+      subject: 'attacker-subject',
+    };
+
+    await expect(profile.linkOidcIdentity(oidcData)).rejects.toThrow(
+      'no longer creates authentication links',
+    );
+    const identities = await OidcIdentityCollection.create({ db });
+    await expect(identities.linkToProfile(profile, oidcData)).rejects.toThrow(
+      'no longer creates authentication links',
+    );
+
+    await expect(countRows(db, 'users')).resolves.toBe(1);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(0);
+  });
+
+  it('fails closed on a Unicode and whitespace-equivalent User-only collision', async () => {
+    const existingProfileId = await seedProfile(db, {
+      email: 'different@example.com',
+    });
+    await seedUser(db, existingProfileId, '\tÜser@Example.com\t');
+
+    await expect(
+      users.getOrCreateFromOidc(claims({ email: 'üser@example.com' }), 'dex'),
+    ).rejects.toMatchObject({ code: 'user_email_conflict' });
+
+    await expect(countRows(db, 'profiles')).resolves.toBe(1);
+    await expect(countRows(db, 'users')).resolves.toBe(1);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(0);
+  });
+
+  it('fails closed until legacy Profile email keys are backfilled', async () => {
+    const profileId = await seedProfile(db, {
+      email: 'legacy-profile@example.com',
+    });
+    await db.query(
+      'UPDATE profiles SET email_key = NULL WHERE id = ?',
+      profileId,
+    );
+    await deleteBackfillMarker(
+      db,
+      '@happyvertical/smrt-profiles:profile-email-keys:v1',
+    );
+
+    await expect(
+      users.getOrCreateFromOidc(
+        claims({ email: 'new-profile@example.com' }),
+        'dex',
+      ),
+    ).rejects.toMatchObject({ code: 'email_key_backfill_required' });
+
+    await expectNoProvisioningWrites(db, 1);
+  });
+
+  it('fails closed when a Profile identity email key is stale', async () => {
+    const profileId = await seedProfile(db, {
+      email: 'different-profile@example.com',
+    });
+    await db.query(
+      'UPDATE profiles SET email_key = ? WHERE id = ?',
+      'collision@example.com',
+      profileId,
+    );
+
+    await expect(
+      users.getOrCreateFromOidc(claims(), 'dex'),
+    ).rejects.toMatchObject({ code: 'email_key_backfill_required' });
+
+    await expectNoProvisioningWrites(db, 1);
+  });
+
+  it('rolls back provisioning until legacy User email keys are backfilled', async () => {
+    const profileId = await seedProfile(db, {
+      email: 'legacy-user@example.com',
+    });
+    const userId = await seedUser(db, profileId, 'legacy-user@example.com');
+    await db.query('UPDATE users SET email_key = NULL WHERE id = ?', userId);
+    await deleteBackfillMarker(
+      db,
+      '@happyvertical/smrt-users:user-email-keys:v1',
+    );
+
+    await expect(
+      users.getOrCreateFromOidc(
+        claims({ email: 'new-user@example.com' }),
+        'dex',
+      ),
+    ).rejects.toMatchObject({ code: 'user_email_backfill_required' });
+
+    await expect(countRows(db, 'profiles')).resolves.toBe(1);
+    await expect(countRows(db, 'users')).resolves.toBe(1);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(0);
+    await expect(
+      countRows(db, 'oidc_profile_email_reservations'),
+    ).resolves.toBe(0);
+  });
+
+  it('rolls back provisioning when a User email key is stale', async () => {
+    const profileId = await seedProfile(db, {
+      email: 'different-profile@example.com',
+    });
+    const userId = await seedUser(db, profileId, 'collision@example.com');
+    await db.query(
+      'UPDATE users SET email_key = ? WHERE id = ?',
+      'stale@example.com',
+      userId,
+    );
+
+    await expect(
+      users.getOrCreateFromOidc(claims({ email: 'stale@example.com' }), 'dex'),
+    ).rejects.toMatchObject({ code: 'user_email_backfill_required' });
+
+    await expect(countRows(db, 'profiles')).resolves.toBe(1);
+    await expect(countRows(db, 'users')).resolves.toBe(1);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(0);
+    await expect(
+      countRows(db, 'oidc_profile_email_reservations'),
+    ).resolves.toBe(0);
+  });
+
+  it.each([
+    ['tenant-scoped', 'tenant_scoped'],
+    ['non-Person', 'non_person'],
+    ['duplicate', 'ambiguous_email'],
+    ['different canonical Person', 'email_mismatch'],
+  ] as const)('fails closed when an existing identity without a User presents a %s Profile collision', async (scenario, expectedCode) => {
+    const profileId = await seedProfile(db, {
+      email: `original-${scenario.replaceAll(' ', '-')}@example.com`,
+    });
+    const subject = `existing-no-owner-${scenario.replaceAll(' ', '-')}`;
+    await seedIdentity(db, profileId, {
+      email: `original-${scenario.replaceAll(' ', '-')}@example.com`,
+      subject,
+    });
+    await seedProfile(db, {
+      email: 'claimed-collision@example.com',
+      metaType: scenario === 'non-Person' ? ORGANIZATION_META_TYPE : undefined,
+      tenantId: scenario === 'tenant-scoped' ? randomUUID() : undefined,
+    });
+    if (scenario === 'duplicate') {
+      await seedProfile(db, { email: ' Claimed-Collision@Example.com ' });
+    }
+
+    await expect(
+      users.getOrCreateFromOidc(
+        claims({ email: 'claimed-collision@example.com', sub: subject }),
+        'dex',
+      ),
+    ).rejects.toMatchObject({ code: expectedCode });
+
+    await expect(countRows(db, 'profiles')).resolves.toBe(
+      scenario === 'duplicate' ? 3 : 2,
+    );
+    await expect(countRows(db, 'users')).resolves.toBe(0);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(1);
+    await expect(
+      countRows(db, 'oidc_profile_email_reservations'),
+    ).resolves.toBe(0);
+  });
+
+  it.each([
+    ['tenant-scoped', 'tenant_scoped'],
+    ['non-Person', 'non_person'],
+  ] as const)('fails closed when the exact issuer and subject links directly to a %s Profile', async (scenario, expectedCode) => {
+    const email = `unsafe-${scenario.toLowerCase()}@example.com`;
+    const subject = `unsafe-linked-${scenario.toLowerCase()}`;
+    const profileId = await seedProfile(db, {
+      email,
+      metaType: scenario === 'non-Person' ? ORGANIZATION_META_TYPE : undefined,
+      tenantId: scenario === 'tenant-scoped' ? randomUUID() : undefined,
+    });
+    await seedIdentity(db, profileId, { email, subject });
+
+    await expect(
+      users.getOrCreateFromOidc(claims({ email, sub: subject }), 'dex'),
+    ).rejects.toMatchObject({ code: expectedCode });
+
+    await expect(countRows(db, 'profiles')).resolves.toBe(1);
+    await expect(countRows(db, 'users')).resolves.toBe(0);
+    await expect(countRows(db, 'sessions')).resolves.toBe(0);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(1);
+    await expect(
+      countRows(db, 'oidc_profile_email_reservations'),
+    ).resolves.toBe(0);
+  });
+
+  it('converges concurrent first-login callbacks on one identity and User', async () => {
+    await isolated.db.rollback();
+    db = isolated.baseDb;
+    await prepareOidcEmailKeyBackfills(db);
+    users = await UserCollection.create({ db });
+    const oidcClaims = claims({
+      email: 'concurrent@example.com',
+      sub: 'concurrent-subject',
+    });
+
+    const [first, second] = await Promise.all([
+      users.getOrCreateFromOidc(oidcClaims, 'dex'),
+      users.getOrCreateFromOidc(oidcClaims, 'dex'),
+    ]);
+
+    expect(second.profile.id).toBe(first.profile.id);
+    expect(second.user.id).toBe(first.user.id);
+    expect(second.oidcIdentity.id).toBe(first.oidcIdentity.id);
+    await expect(countRows(db, 'profiles')).resolves.toBe(1);
+    await expect(countRows(db, 'users')).resolves.toBe(1);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(1);
+  });
+
+  it('serializes unrelated first logins on one SQLite root handle', async () => {
+    await isolated.db.rollback();
+    db = isolated.baseDb;
+    await prepareOidcEmailKeyBackfills(db);
+    users = await UserCollection.create({ db });
+    let activeResolvers = 0;
+    let maxActiveResolvers = 0;
+    const observeResolver = async () => {
+      activeResolvers += 1;
+      maxActiveResolvers = Math.max(maxActiveResolvers, activeResolvers);
+      await new Promise<void>((resolve) => setTimeout(resolve, 25));
+      activeResolvers -= 1;
+      return undefined;
+    };
+
+    const [first, second] = await Promise.all([
+      users.getOrCreateFromOidc(
+        claims({
+          email: 'sqlite-unrelated-first@example.com',
+          sub: 'sqlite-unrelated-first',
+        }),
+        'dex',
+        { resolveProfile: observeResolver },
+      ),
+      users.getOrCreateFromOidc(
+        claims({
+          email: 'sqlite-unrelated-second@example.com',
+          sub: 'sqlite-unrelated-second',
+        }),
+        'dex',
+        { resolveProfile: observeResolver },
+      ),
+    ]);
+
+    expect(maxActiveResolvers).toBe(1);
+    expect(second.profile.id).not.toBe(first.profile.id);
+    expect(second.user.id).not.toBe(first.user.id);
+    await expect(countRows(db, 'profiles')).resolves.toBe(2);
+    await expect(countRows(db, 'users')).resolves.toBe(2);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(2);
+  });
+
+  it('converges first login across independent SQLite connections', async () => {
+    await isolated.db.rollback();
+    db = isolated.baseDb;
+    await prepareOidcEmailKeyBackfills(db);
+    const databaseUrl = db.url;
+    if (!databaseUrl) throw new Error('Expected a file-backed SQLite URL.');
+    const firstDb = (await getDatabase({
+      type: 'sqlite',
+      url: databaseUrl,
+      dbid: `oidc-sqlite-first-${randomUUID()}`,
+    })) as DatabaseInterface;
+    const secondDb = (await getDatabase({
+      type: 'sqlite',
+      url: databaseUrl,
+      dbid: `oidc-sqlite-second-${randomUUID()}`,
+    })) as DatabaseInterface;
+
+    try {
+      const firstUsers = await UserCollection.create({ db: firstDb });
+      const secondUsers = await UserCollection.create({ db: secondDb });
+      let activeResolvers = 0;
+      let maxActiveResolvers = 0;
+      let resolverCalls = 0;
+      const observeResolver = async () => {
+        resolverCalls += 1;
+        activeResolvers += 1;
+        maxActiveResolvers = Math.max(maxActiveResolvers, activeResolvers);
+        await new Promise<void>((resolve) => setTimeout(resolve, 25));
+        activeResolvers -= 1;
+        return undefined;
+      };
+      const concurrentClaims = claims({
+        email: 'independent-sqlite@example.com',
+        sub: 'independent-sqlite-subject',
+      });
+
+      const [first, second] = await Promise.all([
+        firstUsers.getOrCreateFromOidc(concurrentClaims, 'dex', {
+          resolveProfile: observeResolver,
+        }),
+        secondUsers.getOrCreateFromOidc(concurrentClaims, 'dex', {
+          resolveProfile: observeResolver,
+        }),
+      ]);
+
+      expect(resolverCalls).toBe(1);
+      expect(maxActiveResolvers).toBe(1);
+      expect(second.profile.id).toBe(first.profile.id);
+      expect(second.user.id).toBe(first.user.id);
+      expect(second.oidcIdentity.id).toBe(first.oidcIdentity.id);
+      await expect(countRows(firstDb, 'profiles')).resolves.toBe(1);
+      await expect(countRows(firstDb, 'users')).resolves.toBe(1);
+      await expect(countRows(firstDb, 'oidc_identities')).resolves.toBe(1);
+      await expect(
+        countRows(firstDb, 'oidc_profile_email_reservations'),
+      ).resolves.toBe(1);
+    } finally {
+      await Promise.all([closeDatabase(firstDb), closeDatabase(secondDb)]);
+    }
+  });
+
+  it('serializes one issuer/subject with different emails across independent DuckDB handles', async () => {
+    await isolated.db.rollback();
+    db = isolated.baseDb;
+    const duckDb = (await getDatabase({
+      type: 'duckdb',
+      url: ':memory:',
+    })) as DatabaseInterface;
+    await syncSchema({ db: duckDb, schema: OIDC_USERS_TEST_SCHEMA });
+    await prepareOidcEmailKeyBackfills(duckDb);
+    const firstDb = independentDatabaseHandle(duckDb);
+    const secondDb = independentDatabaseHandle(duckDb);
+    let activeResolvers = 0;
+    let maxActiveResolvers = 0;
+    const observeResolver = async () => {
+      activeResolvers += 1;
+      maxActiveResolvers = Math.max(maxActiveResolvers, activeResolvers);
+      await new Promise<void>((resolve) => setTimeout(resolve, 25));
+      activeResolvers -= 1;
+      return undefined;
+    };
+
+    try {
+      const firstUsers = await UserCollection.create({ db: firstDb });
+      const secondUsers = await UserCollection.create({ db: secondDb });
+      const [first, second] = await Promise.all([
+        firstUsers.getOrCreateFromOidc(
+          claims({
+            email: 'duckdb-user-first@example.com',
+            sub: 'duckdb-shared-user-subject',
+          }),
+          'dex',
+          { resolveProfile: observeResolver },
+        ),
+        secondUsers.getOrCreateFromOidc(
+          claims({
+            email: 'duckdb-user-second@example.com',
+            sub: 'duckdb-shared-user-subject',
+          }),
+          'dex',
+          { resolveProfile: observeResolver },
+        ),
+      ]);
+
+      expect(maxActiveResolvers).toBe(1);
+      expect(second.profile.id).toBe(first.profile.id);
+      expect(second.user.id).toBe(first.user.id);
+      expect(second.oidcIdentity.id).toBe(first.oidcIdentity.id);
+      await expect(countRows(firstDb, 'profiles')).resolves.toBe(1);
+      await expect(countRows(firstDb, 'users')).resolves.toBe(1);
+      await expect(countRows(firstDb, 'oidc_identities')).resolves.toBe(1);
+    } finally {
+      await closeDatabase(duckDb);
+    }
+  });
+
+  it('serializes unrelated first logins on one DuckDB root handle', async () => {
+    const duckDb = (await getDatabase({
+      type: 'duckdb',
+      url: ':memory:',
+    })) as DatabaseInterface;
+    await syncSchema({ db: duckDb, schema: OIDC_USERS_TEST_SCHEMA });
+    await prepareOidcEmailKeyBackfills(duckDb);
+    const duckUsers = await UserCollection.create({ db: duckDb });
+    let activeResolvers = 0;
+    let maxActiveResolvers = 0;
+    const observeResolver = async () => {
+      activeResolvers += 1;
+      maxActiveResolvers = Math.max(maxActiveResolvers, activeResolvers);
+      await new Promise<void>((resolve) => setTimeout(resolve, 25));
+      activeResolvers -= 1;
+      return undefined;
+    };
+
+    try {
+      const [first, second] = await Promise.all([
+        duckUsers.getOrCreateFromOidc(
+          claims({
+            email: 'duckdb-unrelated-first@example.com',
+            sub: 'duckdb-unrelated-first',
+          }),
+          'dex',
+          { resolveProfile: observeResolver },
+        ),
+        duckUsers.getOrCreateFromOidc(
+          claims({
+            email: 'duckdb-unrelated-second@example.com',
+            sub: 'duckdb-unrelated-second',
+          }),
+          'dex',
+          { resolveProfile: observeResolver },
+        ),
+      ]);
+
+      expect(maxActiveResolvers).toBe(1);
+      expect(second.profile.id).not.toBe(first.profile.id);
+      expect(second.user.id).not.toBe(first.user.id);
+      await expect(countRows(duckDb, 'profiles')).resolves.toBe(2);
+      await expect(countRows(duckDb, 'users')).resolves.toBe(2);
+      await expect(countRows(duckDb, 'oidc_identities')).resolves.toBe(2);
+    } finally {
+      await closeDatabase(duckDb);
+    }
+  });
+
+  it('rejects concurrent distinct subjects competing for one verified email', async () => {
+    await isolated.db.rollback();
+    db = isolated.baseDb;
+    await prepareOidcEmailKeyBackfills(db);
+    users = await UserCollection.create({ db });
+
+    const results = await Promise.allSettled([
+      users.getOrCreateFromOidc(
+        claims({ email: 'shared@example.com', sub: 'subject-one' }),
+        'dex',
+      ),
+      users.getOrCreateFromOidc(
+        claims({ email: 'shared@example.com', sub: 'subject-two' }),
+        'dex',
+      ),
+    ]);
+
+    expect(
+      results.filter((result) => result.status === 'fulfilled'),
+    ).toHaveLength(1);
+    expect(results.filter((result) => result.status === 'rejected')).toEqual([
+      expect.objectContaining({
+        reason: expect.objectContaining({ code: 'profile_owned' }),
+      }),
+    ]);
+    await expect(countRows(db, 'profiles')).resolves.toBe(1);
+    await expect(countRows(db, 'users')).resolves.toBe(1);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(1);
+  });
+
+  it('preserves issuer and subject reuse for an existing safe identity', async () => {
+    const oidcClaims = claims({
+      email: 'returning@example.com',
+      sub: 'returning-subject',
+    });
+    const first = await users.getOrCreateFromOidc(oidcClaims, 'dex');
+    const second = await users.getOrCreateFromOidc(
+      { ...oidcClaims, name: 'Updated display name' },
+      'dex',
+    );
+
+    expect(second.created).toBe(false);
+    expect(second.profile.id).toBe(first.profile.id);
+    expect(second.user.id).toBe(first.user.id);
+    expect(second.oidcIdentity.id).toBe(first.oidcIdentity.id);
+    await expect(countRows(db, 'profiles')).resolves.toBe(1);
+    await expect(countRows(db, 'users')).resolves.toBe(1);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(1);
+  });
+
+  it('preserves the exact opaque issuer and subject claims', async () => {
+    const first = await users.getOrCreateFromOidc(
+      claims({
+        email: 'opaque-first@example.com',
+        sub: 'opaque-subject',
+      }),
+      'dex',
+    );
+    const second = await users.getOrCreateFromOidc(
+      claims({
+        email: 'opaque-second@example.com',
+        sub: ' opaque-subject',
+      }),
+      'dex',
+    );
+
+    expect(second.user.id).not.toBe(first.user.id);
+    expect(second.profile.id).not.toBe(first.profile.id);
+    expect(second.oidcIdentity.id).not.toBe(first.oidcIdentity.id);
+    expect(second.oidcIdentity.subject).toBe(' opaque-subject');
+    expect(second.oidcIdentity.identityKey).toBe(
+      '["https://issuer.example.com"," opaque-subject"]',
+    );
+    await expect(countRows(db, 'users')).resolves.toBe(2);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(2);
+  });
+
+  it('backfills a legacy null identity key during issuer and subject reuse', async () => {
+    const profileId = await seedProfile(db, {
+      email: 'legacy@example.com',
+    });
+    const userId = await seedUser(db, profileId, 'legacy@example.com');
+    const identityId = await seedIdentity(db, profileId, {
+      email: 'legacy@example.com',
+      subject: 'legacy-subject',
+    });
+
+    const result = await users.getOrCreateFromOidc(
+      claims({ email: 'legacy@example.com', sub: 'legacy-subject' }),
+      'dex',
+    );
+
+    expect(result.profile.id).toBe(profileId);
+    expect(result.user.id).toBe(userId);
+    expect(result.oidcIdentity.id).toBe(identityId);
+    expect(result.oidcIdentity.identityKey).toBe(
+      '["https://issuer.example.com","legacy-subject"]',
+    );
+  });
+
+  it('reuses an existing safe identity with a legacy Person discriminator', async () => {
+    const profileId = await seedProfile(db, {
+      email: 'legacy-person@example.com',
+      metaType: 'Person',
+    });
+    const userId = await seedUser(db, profileId, 'legacy-person@example.com');
+    await seedIdentity(db, profileId, {
+      email: 'legacy-person@example.com',
+      subject: 'legacy-person-subject',
+    });
+
+    const result = await users.getOrCreateFromOidc(
+      claims({
+        email: 'legacy-person@example.com',
+        sub: 'legacy-person-subject',
+      }),
+      'dex',
+    );
+
+    expect(result.profile.id).toBe(profileId);
+    expect(result.user.id).toBe(userId);
+    await expect(countRows(db, 'profiles')).resolves.toBe(1);
+  });
+
+  it('uses the current Profile email instead of a stale identity cache', async () => {
+    const first = await users.getOrCreateFromOidc(
+      claims({ email: 'old@example.com', sub: 'renamed-subject' }),
+      'dex',
+    );
+    await db.query(
+      'UPDATE profiles SET email = ?, email_key = ? WHERE id = ?',
+      'new@example.com',
+      'new@example.com',
+      first.profile.id,
+    );
+
+    const second = await users.getOrCreateFromOidc(
+      claims({ email: 'new@example.com', sub: 'renamed-subject' }),
+      'dex',
+    );
+
+    expect(second.profile.id).toBe(first.profile.id);
+    expect(second.user.id).toBe(first.user.id);
+    expect(second.oidcIdentity.email).toBe('new@example.com');
+
+    const reservation = await db.query(
+      'SELECT email_key FROM oidc_profile_email_reservations WHERE profile_id = ?',
+      first.profile.id,
+    );
+    expect(reservation.rows).toEqual([{ email_key: 'new@example.com' }]);
+
+    const releasedProfileId = await seedProfile(db, {
+      email: 'old@example.com',
+    });
+    const profiles = await ProfileCollection.create({ db });
+    await expect(
+      profiles.reserveCanonicalIdentityEmail(
+        releasedProfileId,
+        'old@example.com',
+      ),
+    ).resolves.toMatchObject({ id: releasedProfileId });
+  });
+
+  it('removes a stale reservation when the canonical Profile email is cleared', async () => {
+    const first = await users.getOrCreateFromOidc(
+      claims({ email: 'clear@example.com', sub: 'clear-subject' }),
+      'dex',
+    );
+    await db.query(
+      'UPDATE profiles SET email = NULL, email_key = NULL WHERE id = ?',
+      first.profile.id,
+    );
+
+    await users.getOrCreateFromOidc(
+      claims({ email: 'claim-cache@example.com', sub: 'clear-subject' }),
+      'dex',
+    );
+
+    await expect(
+      countRows(db, 'oidc_profile_email_reservations'),
+    ).resolves.toBe(0);
+  });
+
+  it('reconciles swapped stale reservations for existing issuer subjects', async () => {
+    const first = await users.getOrCreateFromOidc(
+      claims({ email: 'swap-first@example.com', sub: 'swap-first-subject' }),
+      'dex',
+    );
+    const second = await users.getOrCreateFromOidc(
+      claims({ email: 'swap-second@example.com', sub: 'swap-second-subject' }),
+      'dex',
+    );
+    await db.query(
+      'UPDATE profiles SET email = ?, email_key = ? WHERE id = ?',
+      'swap-second@example.com',
+      'swap-second@example.com',
+      first.profile.id,
+    );
+    await db.query(
+      'UPDATE profiles SET email = ?, email_key = ? WHERE id = ?',
+      'swap-first@example.com',
+      'swap-first@example.com',
+      second.profile.id,
+    );
+
+    const firstReuse = await users.getOrCreateFromOidc(
+      claims({ email: 'swap-second@example.com', sub: 'swap-first-subject' }),
+      'dex',
+    );
+    const secondReuse = await users.getOrCreateFromOidc(
+      claims({ email: 'swap-first@example.com', sub: 'swap-second-subject' }),
+      'dex',
+    );
+
+    expect(firstReuse.profile.id).toBe(first.profile.id);
+    expect(secondReuse.profile.id).toBe(second.profile.id);
+    const reservations = await db.query(
+      'SELECT profile_id, email_key FROM oidc_profile_email_reservations ORDER BY email_key',
+    );
+    expect(reservations.rows).toEqual([
+      { profile_id: second.profile.id, email_key: 'swap-first@example.com' },
+      { profile_id: first.profile.id, email_key: 'swap-second@example.com' },
+    ]);
+  });
+
+  it('rejects an owned canonical Person supplied by a resolver', async () => {
+    const profileId = await seedProfile(db, {
+      email: 'owned@example.com',
+    });
+    await seedUser(db, profileId, 'owned@example.com');
+    let resolverCalls = 0;
+
+    await expect(
+      users.getOrCreateFromOidc(
+        claims({ email: 'owned@example.com', sub: 'linked-subject' }),
+        'dex',
+        {
+          resolveProfile: async ({ claims: resolvedClaims, db: tx }) => {
+            resolverCalls += 1;
+            expect(resolvedClaims.email).toBe('owned@example.com');
+            const profiles = await ProfileCollection.create({ db: tx });
+            return profiles.get({ id: profileId });
+          },
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'profile_owned' });
+
+    expect(resolverCalls).toBe(1);
+    await expect(countRows(db, 'users')).resolves.toBe(1);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(0);
+    await expect(
+      countRows(db, 'oidc_profile_email_reservations'),
+    ).resolves.toBe(0);
+  });
+
+  it('keeps resolver claims immutable at the authenticated identity boundary', async () => {
+    const victimProfileId = await seedProfile(db, {
+      email: 'victim@example.com',
+    });
+    const victimUserId = await seedUser(
+      db,
+      victimProfileId,
+      'victim@example.com',
+    );
+    await seedIdentity(db, victimProfileId, {
+      email: 'victim@example.com',
+      issuer: 'https://victim-issuer.example.com',
+      subject: 'victim-subject',
+    });
+
+    const result = await users.getOrCreateFromOidc(
+      claims({
+        email: 'attacker@example.com',
+        email_verified: false,
+        sub: 'attacker-subject',
+      }),
+      'dex',
+      {
+        allowUnverifiedEmail: true,
+        resolveProfile: ({ claims: resolverClaims }) => {
+          expect(Object.isFrozen(resolverClaims)).toBe(true);
+          expect(
+            Reflect.set(
+              resolverClaims,
+              'iss',
+              'https://victim-issuer.example.com',
+            ),
+          ).toBe(false);
+          expect(Reflect.set(resolverClaims, 'sub', 'victim-subject')).toBe(
+            false,
+          );
+          expect(
+            Reflect.set(resolverClaims, 'email', 'victim@example.com'),
+          ).toBe(false);
+          expect(Reflect.set(resolverClaims, 'email_verified', true)).toBe(
+            false,
+          );
+          return undefined;
+        },
+      },
+    );
+
+    expect(result.user.id).not.toBe(victimUserId);
+    expect(result.profile.id).not.toBe(victimProfileId);
+    expect(result.oidcIdentity.subject).toBe('attacker-subject');
+    expect(result.oidcIdentity.email).toBe('attacker@example.com');
+    await expect(countRows(db, 'users')).resolves.toBe(2);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(2);
+  });
+
+  it('rejects resolver reuse when the OIDC email is not verified', async () => {
+    const profileId = await seedProfile(db, {
+      email: 'unverified@example.com',
+    });
+
+    await expect(
+      users.getOrCreateFromOidc(
+        claims({
+          email: 'unverified@example.com',
+          email_verified: false,
+          sub: 'unverified-resolver-subject',
+        }),
+        'dex',
+        {
+          allowUnverifiedEmail: true,
+          resolveProfile: async ({ db: tx }) =>
+            (await ProfileCollection.create({ db: tx })).get({ id: profileId }),
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'rejected' });
+
+    await expectNoProvisioningWrites(db);
+  });
+
+  it.each([
+    ['tenant-scoped', 'tenant_scoped'],
+    ['non-Person', 'non_person'],
+    ['duplicate-email', 'ambiguous_email'],
+    ['mismatched-email', 'email_mismatch'],
+  ] as const)('rejects a resolver-supplied %s Profile before provisioning', async (scenario, expectedCode) => {
+    const profileId = await seedProfile(db, {
+      email:
+        scenario === 'mismatched-email'
+          ? 'other@example.com'
+          : 'collision@example.com',
+      metaType: scenario === 'non-Person' ? ORGANIZATION_META_TYPE : undefined,
+      tenantId: scenario === 'tenant-scoped' ? randomUUID() : undefined,
+    });
+    if (scenario === 'duplicate-email') {
+      await seedProfile(db, { email: 'Collision@Example.com' });
+    }
+
+    await expect(
+      users.getOrCreateFromOidc(claims(), 'dex', {
+        resolveProfile: async ({ db: tx }) =>
+          (await ProfileCollection.create({ db: tx })).get({ id: profileId }),
+      }),
+    ).rejects.toMatchObject({ code: expectedCode });
+
+    await expectNoProvisioningWrites(
+      db,
+      scenario === 'duplicate-email' ? 2 : 1,
+    );
+  });
+
+  it('rolls back all provisioning when the application resolver rejects login', async () => {
+    const attemptedUserId = randomUUID();
+    await expect(
+      users.getOrCreateFromOidc(claims(), 'dex', {
+        resolveProfile: async ({ db: tx }) => {
+          await tx.query(
+            `INSERT INTO users
+              (id, slug, context, profile_id, email, email_key, status)
+             VALUES (?, ?, '', '', 'partial@example.com', 'partial@example.com', 'active')`,
+            attemptedUserId,
+            `partial-${attemptedUserId}`,
+          );
+          return null;
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'rejected' });
+
+    await expectNoProvisioningWrites(db, 0);
+  });
+
+  it('rolls back with a standard transaction callback handle', async () => {
+    await isolated.db.rollback();
+    db = isolated.baseDb;
+    await prepareOidcEmailKeyBackfills(db);
+    const transaction = db.transaction;
+    if (!transaction) {
+      throw new Error('Expected a transaction-capable database.');
+    }
+
+    await expect(
+      transaction.call(db, async (tx) => {
+        const transactionUsers = await UserCollection.create({ db: tx });
+        await transactionUsers.getOrCreateFromOidc(
+          claims({ email: 'outer-rollback@example.com' }),
+          'dex',
+        );
+        throw new Error('force outer rollback');
+      }),
+    ).rejects.toThrow('force outer rollback');
+
+    await expectNoProvisioningWrites(db, 0);
+  });
+
+  it('does not repeat backfill table DDL inside a root-owned provisioning transaction', async () => {
+    await isolated.db.rollback();
+    db = isolated.baseDb;
+    await prepareOidcEmailKeyBackfills(db);
+    let transactionCreates = 0;
+    const observedDb = withTransactionBackfillCreateObserver(db, () => {
+      transactionCreates += 1;
+    });
+    const rootUsers = await UserCollection.create({ db: observedDb });
+
+    await rootUsers.getOrCreateFromOidc(
+      claims({ email: 'root-ddl@example.com', sub: 'root-ddl-subject' }),
+      'dex',
+    );
+
+    expect(transactionCreates).toBe(0);
+  });
+
+  it('fails closed on an ambiguous callback-only root adapter', async () => {
+    await isolated.db.rollback();
+    db = isolated.baseDb;
+    await prepareOidcEmailKeyBackfills(db);
+    const callbackOnlyRoot = new Proxy(db, {
+      get(target, property, receiver) {
+        if (property === 'beginTransaction') return undefined;
+        if (property === 'query') {
+          return async (sql: string, ...params: unknown[]) => {
+            if (/^SAVEPOINT\b/iu.test(sql)) {
+              throw new Error(
+                'SAVEPOINT can only be used in transaction blocks',
+              );
+            }
+            return target.query(sql, ...params);
+          };
+        }
+        const value = Reflect.get(target, property, receiver);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+    const callbackUsers = await UserCollection.create({
+      db: callbackOnlyRoot,
+    });
+
+    await expect(
+      callbackUsers.getOrCreateFromOidc(
+        claims({ email: 'callback-only-root@example.com' }),
+        'dex',
+      ),
+    ).rejects.toMatchObject({ code: 'transaction_required' });
+    await expectNoProvisioningWrites(db, 0);
+  });
+
+  it('fails closed on a DuckDB manual transaction without corrupting it', async () => {
+    const duckDb = (await getDatabase({
+      type: 'duckdb',
+      url: ':memory:',
+    })) as DatabaseInterface;
+    if (!duckDb.beginTransaction) {
+      throw new Error('Expected DuckDB manual transaction support.');
+    }
+    const tx = await duckDb.beginTransaction();
+    try {
+      const transactionUsers = await UserCollection.create({ db: tx });
+      await expect(
+        transactionUsers.getOrCreateFromOidc(
+          claims({ email: 'duckdb-manual-user@example.com' }),
+          'dex',
+        ),
+      ).rejects.toMatchObject({ code: 'transaction_required' });
+
+      expect(tx.isActive()).toBe(true);
+      await tx.query('CREATE TABLE user_outer_probe (id INTEGER)');
+      await tx.query('INSERT INTO user_outer_probe VALUES (1)');
+      const result = await tx.query(
+        'SELECT count(*) AS count FROM user_outer_probe',
+      );
+      expect(Number(result.rows[0]?.count)).toBe(1);
+    } finally {
+      if (tx.isActive()) await tx.rollback();
+      await closeDatabase(duckDb);
+    }
+  });
+
+  it('fails closed on a DuckDB callback transaction without corrupting it', async () => {
+    const duckDb = (await getDatabase({
+      type: 'duckdb',
+      url: ':memory:',
+    })) as DatabaseInterface;
+    if (!duckDb.transaction) {
+      throw new Error('Expected DuckDB callback transaction support.');
+    }
+    try {
+      await duckDb.transaction(async (tx) => {
+        const transactionUsers = await UserCollection.create({ db: tx });
+        await expect(
+          transactionUsers.getOrCreateFromOidc(
+            claims({ email: 'duckdb-callback-user@example.com' }),
+            'dex',
+          ),
+        ).rejects.toMatchObject({ code: 'transaction_required' });
+
+        await tx.query('CREATE TABLE user_callback_probe (id INTEGER)');
+        await tx.query('INSERT INTO user_callback_probe VALUES (1)');
+        const result = await tx.query(
+          'SELECT count(*) AS count FROM user_callback_probe',
+        );
+        expect(Number(result.rows[0]?.count)).toBe(1);
+      });
+    } finally {
+      await closeDatabase(duckDb);
+    }
+  });
+
+  it('rolls back resolver writes when provisioning owns the root transaction', async () => {
+    await isolated.db.rollback();
+    db = isolated.baseDb;
+    await prepareOidcEmailKeyBackfills(db);
+    users = await UserCollection.create({ db });
+    const attemptedUserId = randomUUID();
+
+    await expect(
+      users.getOrCreateFromOidc(
+        claims({ email: 'root-rejection@example.com' }),
+        'dex',
+        {
+          resolveProfile: async ({ db: tx }) => {
+            await tx.query(
+              `INSERT INTO users
+                (id, slug, context, profile_id, email, email_key, status)
+               VALUES (?, ?, '', '', 'partial@example.com', 'partial@example.com', 'active')`,
+              attemptedUserId,
+              `partial-${attemptedUserId}`,
+            );
+            return null;
+          },
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'rejected' });
+
+    await expectNoProvisioningWrites(db, 0);
+  });
+
+  it('does not retry an unrelated resolver unique constraint', async () => {
+    const profileId = await seedProfile(db, { email: 'seed@example.com' });
+    const userId = await seedUser(db, profileId, 'seed@example.com');
+    const seeded = await users.get({ id: userId });
+    let resolverCalls = 0;
+
+    await expect(
+      users.getOrCreateFromOidc(
+        claims({ email: 'unrelated@example.com' }),
+        'dex',
+        {
+          resolveProfile: async ({ db: tx }) => {
+            resolverCalls += 1;
+            await tx.query(
+              `INSERT INTO users
+                (id, slug, context, profile_id, email, email_key, status)
+               VALUES (?, ?, '', ?, 'other@example.com', 'other@example.com', 'active')`,
+              randomUUID(),
+              seeded?.slug,
+              randomUUID(),
+            );
+            return undefined;
+          },
+        },
+      ),
+    ).rejects.toThrow();
+
+    expect(resolverCalls).toBe(1);
+    await expect(countRows(db, 'oidc_identities')).resolves.toBe(0);
+  });
+});
+
+function claims(overrides: Partial<OidcClaims> = {}): OidcClaims {
+  return {
+    email: 'collision@example.com',
+    email_verified: true,
+    iss: 'https://issuer.example.com',
+    name: 'OIDC User',
+    sub: 'oidc-subject',
+    ...overrides,
+  };
+}
+
+async function seedProfile(
+  db: DatabaseInterface,
+  options: {
+    email: string;
+    metaType?: string;
+    tenantId?: string | null;
+  },
+): Promise<string> {
+  const id = randomUUID();
+  await db.query(
+    `INSERT INTO profiles
+      (id, slug, context, _meta_type, tenant_id, email, email_key, name)
+     VALUES (?, ?, '', ?, ?, ?, ?, 'Seed Profile')`,
+    id,
+    `seed-${id}`,
+    options.metaType ?? PERSON_META_TYPE,
+    options.tenantId ?? null,
+    options.email,
+    normalizeIdentityEmail(options.email),
+  );
+  return id;
+}
+
+async function seedUser(
+  db: DatabaseInterface,
+  profileId: string,
+  email: string,
+): Promise<string> {
+  const id = randomUUID();
+  await db.query(
+    `INSERT INTO users
+      (id, slug, context, profile_id, email, email_key, status)
+     VALUES (?, ?, '', ?, ?, ?, 'active')`,
+    id,
+    `seed-${id}`,
+    profileId,
+    email,
+    normalizeIdentityEmail(email),
+  );
+  return id;
+}
+
+async function seedIdentity(
+  db: DatabaseInterface,
+  profileId: string,
+  options: { email: string; issuer?: string; subject: string },
+): Promise<string> {
+  const id = randomUUID();
+  await db.query(
+    `INSERT INTO oidc_identities
+      (id, slug, context, profile_id, provider, issuer, subject, identity_key, email)
+     VALUES (?, ?, '', ?, 'dex', ?, ?, NULL, ?)`,
+    id,
+    `seed-${id}`,
+    profileId,
+    options.issuer ?? 'https://issuer.example.com',
+    options.subject,
+    options.email,
+  );
+  return id;
+}
+
+async function countRows(
+  db: DatabaseInterface,
+  table:
+    | 'oidc_identities'
+    | 'oidc_profile_email_reservations'
+    | 'profiles'
+    | 'sessions'
+    | 'users',
+): Promise<number> {
+  const result = await db.query(`SELECT count(*) AS count FROM ${table}`);
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+async function deleteBackfillMarker(
+  db: DatabaseInterface,
+  name: string,
+): Promise<void> {
+  await db.query('DELETE FROM _smrt_backfills WHERE name = ?', name);
+}
+
+async function expectNoProvisioningWrites(
+  db: DatabaseInterface,
+  expectedProfiles = 1,
+): Promise<void> {
+  await expect(countRows(db, 'profiles')).resolves.toBe(expectedProfiles);
+  await expect(countRows(db, 'users')).resolves.toBe(0);
+  await expect(countRows(db, 'sessions')).resolves.toBe(0);
+  await expect(countRows(db, 'oidc_identities')).resolves.toBe(0);
+  await expect(countRows(db, 'oidc_profile_email_reservations')).resolves.toBe(
+    0,
+  );
+}
+
+async function closeDatabase(db: DatabaseInterface): Promise<void> {
+  await db.close?.();
+}
+
+function independentDatabaseHandle(db: DatabaseInterface): DatabaseInterface {
+  return new Proxy(db, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
+function withTransactionBackfillCreateObserver(
+  db: DatabaseInterface,
+  onCreate: () => void,
+): DatabaseInterface {
+  return new Proxy(db, {
+    get(target, property, receiver) {
+      if (property === 'transaction') {
+        return async <T>(
+          callback: (tx: DatabaseInterface) => Promise<T>,
+        ): Promise<T> => {
+          if (!target.transaction) {
+            throw new Error('Expected a transaction-capable database.');
+          }
+          return target.transaction((tx) =>
+            callback(
+              new Proxy(tx, {
+                get(txTarget, txProperty, txReceiver) {
+                  if (txProperty === 'query') {
+                    return async (sql: string, ...params: unknown[]) => {
+                      if (
+                        sql.includes('CREATE TABLE') &&
+                        sql.includes('_smrt_backfills')
+                      ) {
+                        onCreate();
+                      }
+                      return txTarget.query(sql, ...params);
+                    };
+                  }
+                  const value = Reflect.get(txTarget, txProperty, txReceiver);
+                  return typeof value === 'function'
+                    ? value.bind(txTarget)
+                    : value;
+                },
+              }),
+            ),
+          );
+        };
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}

--- a/packages/users/src/__tests__/security-audit-1400.test.ts
+++ b/packages/users/src/__tests__/security-audit-1400.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { existsSync, rmSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ObjectRegistry } from '@happyvertical/smrt-core';
@@ -34,6 +35,10 @@ import {
   TenantCollection,
   UserCollection,
 } from '../index.js';
+import {
+  OIDC_USERS_TEST_SCHEMA,
+  prepareOidcEmailKeyBackfills,
+} from './helpers/oidc-test-server.js';
 
 // ---------------------------------------------------------------------------
 // 1. RBAC / identity generated CRUD lockdown (#1400)
@@ -127,6 +132,30 @@ describe('RBAC/identity generated CRUD lockdown (#1400)', () => {
       (membership as { config: SurfaceConfig }).config,
     );
     expect(api).toEqual(['list', 'get']);
+  });
+
+  it('keeps the generated User ownership and email arbiters unique', async () => {
+    const manifest = JSON.parse(
+      await readFile(
+        new URL('../../.smrt/manifest.json', import.meta.url),
+        'utf8',
+      ),
+    ) as {
+      objects: Record<
+        string,
+        {
+          fields?: Record<
+            string,
+            { _meta?: { unique?: boolean }; readonly?: boolean }
+          >;
+        }
+      >;
+    };
+    const user = manifest.objects['@happyvertical/smrt-users:User'];
+
+    expect(user?.fields?.profileId?._meta?.unique).toBe(true);
+    expect(user?.fields?.emailKey?._meta?.unique).toBe(true);
+    expect(user?.fields?.emailKey?.readonly).toBe(true);
   });
 });
 
@@ -326,72 +355,13 @@ describe('deleteExpired atomic cleanup (#1400)', () => {
 // 4. OIDC email_verified enforcement (#1400)
 // ---------------------------------------------------------------------------
 
-const PROFILE_SCHEMA = `
-CREATE TABLE IF NOT EXISTS "profile_types" (
-  "id" TEXT PRIMARY KEY NOT NULL,
-  "slug" TEXT NOT NULL,
-  "context" TEXT NOT NULL DEFAULT '',
-  "_meta_type" TEXT NOT NULL,
-  "_meta_data" JSON,
-  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  "tenant_id" TEXT,
-  "name" TEXT DEFAULT '',
-  "description" TEXT
-);
-CREATE UNIQUE INDEX IF NOT EXISTS "profile_types_slug_context_meta_type_idx" ON "profile_types" ("slug", "context", "_meta_type");
-
-CREATE TABLE IF NOT EXISTS "profiles" (
-  "id" TEXT PRIMARY KEY NOT NULL,
-  "slug" TEXT NOT NULL,
-  "context" TEXT NOT NULL DEFAULT '',
-  "_meta_type" TEXT NOT NULL,
-  "_meta_data" JSON,
-  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  "tenant_id" TEXT,
-  "type_id" TEXT,
-  "email" TEXT,
-  "name" TEXT DEFAULT '',
-  "description" TEXT
-);
-CREATE UNIQUE INDEX IF NOT EXISTS "profiles_slug_context_meta_type_idx" ON "profiles" ("slug", "context", "_meta_type");
-
-CREATE TABLE IF NOT EXISTS "oidc_identities" (
-  "id" TEXT PRIMARY KEY NOT NULL,
-  "slug" TEXT NOT NULL,
-  "context" TEXT NOT NULL DEFAULT '',
-  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  "profile_id" TEXT,
-  "provider" TEXT DEFAULT '',
-  "issuer" TEXT DEFAULT '',
-  "subject" TEXT DEFAULT '',
-  "email" TEXT DEFAULT '',
-  "last_used_at" TIMESTAMP
-);
-CREATE UNIQUE INDEX IF NOT EXISTS "oidc_identities_slug_context_idx" ON "oidc_identities" ("slug", "context");
-
-CREATE TABLE IF NOT EXISTS "users" (
-  "id" TEXT PRIMARY KEY NOT NULL,
-  "slug" TEXT NOT NULL,
-  "context" TEXT NOT NULL DEFAULT '',
-  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
-  "profile_id" TEXT DEFAULT '',
-  "email" TEXT DEFAULT '',
-  "status" TEXT,
-  "last_login_at" TIMESTAMP
-);
-CREATE UNIQUE INDEX IF NOT EXISTS "users_slug_context_idx" ON "users" ("slug", "context");
-`;
-
 describe('OIDC email_verified enforcement (#1400)', () => {
   let isolated: IsolatedTestDbResult;
   let users: UserCollection;
 
   beforeEach(async () => {
-    isolated = await createIsolatedTestDb({ schema: PROFILE_SCHEMA });
+    isolated = await createIsolatedTestDb({ schema: OIDC_USERS_TEST_SCHEMA });
+    await prepareOidcEmailKeyBackfills(isolated.db);
     users = await UserCollection.create({ db: isolated.db });
   });
 

--- a/packages/users/src/__tests__/user-email-key-backfill.test.ts
+++ b/packages/users/src/__tests__/user-email-key-backfill.test.ts
@@ -1,0 +1,156 @@
+import { randomUUID } from 'node:crypto';
+import type { DatabaseInterface } from '@happyvertical/smrt-core/migrations';
+import { getDatabase, syncSchema } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  backfillUserEmailKeys,
+  UserEmailKeyBackfillError,
+} from '../migrations/backfillUserEmailKeys.js';
+import { OIDC_USERS_TEST_SCHEMA } from './helpers/oidc-test-server.js';
+
+describe('backfillUserEmailKeys', () => {
+  let db: DatabaseInterface;
+
+  beforeEach(async () => {
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    await syncSchema({ db, schema: OIDC_USERS_TEST_SCHEMA });
+  });
+
+  afterEach(async () => {
+    await db.close?.();
+  });
+
+  it('normalizes a migrated legacy User and is idempotent', async () => {
+    const userId = await seedLegacyUser(db, '\tÜser@Example.com\t');
+    const blankUserId = await seedLegacyUser(db, '\t');
+
+    await expect(backfillUserEmailKeys(db)).resolves.toEqual({ updated: 1 });
+    await expect(readEmailKey(db, userId)).resolves.toBe('üser@example.com');
+    await expect(readEmailKey(db, blankUserId)).resolves.toBeNull();
+    await expect(readBackfillMarker(db)).resolves.toBe(true);
+    await expect(backfillUserEmailKeys(db)).resolves.toEqual({ updated: 0 });
+  });
+
+  it('fails before changing rows when legacy emails normalize to a duplicate', async () => {
+    const firstId = await seedLegacyUser(db, '\tÜser@Example.com\t');
+    const secondId = await seedLegacyUser(db, 'üser@example.com');
+
+    const error = await backfillUserEmailKeys(db).catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(UserEmailKeyBackfillError);
+    expect(error).toMatchObject({
+      code: 'duplicate_email',
+      duplicates: [{ emailKey: 'üser@example.com', userCount: 2 }],
+    });
+    await expect(readEmailKey(db, firstId)).resolves.toBeNull();
+    await expect(readEmailKey(db, secondId)).resolves.toBeNull();
+    await expect(readBackfillMarker(db)).resolves.toBe(false);
+  });
+
+  it('repairs swapped stale keys without a transient uniqueness failure', async () => {
+    const firstId = await seedLegacyUser(db, 'first@example.com');
+    const secondId = await seedLegacyUser(db, 'second@example.com');
+    await db.query(
+      'UPDATE users SET email_key = ? WHERE id = ?',
+      'second@example.com',
+      firstId,
+    );
+    await db.query(
+      'UPDATE users SET email_key = ? WHERE id = ?',
+      'first@example.com',
+      secondId,
+    );
+
+    await expect(backfillUserEmailKeys(db)).resolves.toEqual({ updated: 2 });
+    await expect(readEmailKey(db, firstId)).resolves.toBe('first@example.com');
+    await expect(readEmailKey(db, secondId)).resolves.toBe(
+      'second@example.com',
+    );
+  });
+
+  it('rolls back every key and the readiness marker when an update fails', async () => {
+    const firstId = await seedLegacyUser(db, 'first@example.com');
+    const secondId = await seedLegacyUser(db, 'second@example.com');
+    const transaction = db.transaction;
+    if (!transaction)
+      throw new Error('SQLite test database requires transaction().');
+    const failingDb = new Proxy(db, {
+      get(target, property, receiver) {
+        if (property !== 'transaction') {
+          const value = Reflect.get(target, property, receiver);
+          return typeof value === 'function' ? value.bind(target) : value;
+        }
+        return async <T>(
+          callback: (tx: DatabaseInterface) => Promise<T>,
+        ): Promise<T> =>
+          transaction.call(target, async (tx) => {
+            let updates = 0;
+            const failingTx = new Proxy(tx, {
+              get(txTarget, txProperty, txReceiver) {
+                if (txProperty !== 'query') {
+                  const value = Reflect.get(txTarget, txProperty, txReceiver);
+                  return typeof value === 'function'
+                    ? value.bind(txTarget)
+                    : value;
+                }
+                return async (sql: string, ...params: unknown[]) => {
+                  if (sql.startsWith('UPDATE users')) {
+                    updates += 1;
+                    if (updates === 2) {
+                      throw new Error('forced backfill update failure');
+                    }
+                  }
+                  return txTarget.query(sql, ...params);
+                };
+              },
+            });
+            return callback(failingTx);
+          });
+      },
+    }) as DatabaseInterface;
+
+    await expect(backfillUserEmailKeys(failingDb)).rejects.toThrow(
+      'forced backfill update failure',
+    );
+    await expect(readEmailKey(db, firstId)).resolves.toBeNull();
+    await expect(readEmailKey(db, secondId)).resolves.toBeNull();
+    await expect(readBackfillMarker(db)).resolves.toBe(false);
+  });
+});
+
+async function seedLegacyUser(
+  db: DatabaseInterface,
+  email: string,
+): Promise<string> {
+  const id = randomUUID();
+  await db.query(
+    `INSERT INTO users
+      (id, slug, context, profile_id, email, email_key, status)
+     VALUES (?, ?, '', ?, ?, NULL, 'active')`,
+    id,
+    `legacy-${id}`,
+    randomUUID(),
+    email,
+  );
+  return id;
+}
+
+async function readEmailKey(
+  db: DatabaseInterface,
+  userId: string,
+): Promise<string | null> {
+  const result = await db.query(
+    'SELECT email_key FROM users WHERE id = ?',
+    userId,
+  );
+  const value = result.rows[0]?.email_key;
+  return value == null ? null : String(value);
+}
+
+async function readBackfillMarker(db: DatabaseInterface): Promise<boolean> {
+  const result = await db.query(
+    `SELECT 1 FROM _smrt_backfills
+     WHERE name = '@happyvertical/smrt-users:user-email-keys:v1'`,
+  );
+  return result.rows.length === 1;
+}

--- a/packages/users/src/collections/UserCollection.ts
+++ b/packages/users/src/collections/UserCollection.ts
@@ -4,9 +4,28 @@
  */
 
 import { SmrtCollection } from '@happyvertical/smrt-core';
-import type { OidcIdentity, Profile } from '@happyvertical/smrt-profiles';
+import { BackfillTracker } from '@happyvertical/smrt-core/migrations';
+import {
+  AmbiguousOidcIdentityError,
+  normalizeIdentityEmail,
+  OidcIdentity,
+  OidcIdentityCollection,
+  type Profile,
+} from '@happyvertical/smrt-profiles';
+import {
+  coordinateOidcProvisioning,
+  createOidcProvisioningPerson,
+  insertOidcProvisioningIdentity,
+  isOidcProvisioningRaceConflict,
+  saveOidcRaceArbiter,
+} from '@happyvertical/smrt-profiles/internal/oidc-provisioning';
+import { withSystemContext } from '@happyvertical/smrt-tenancy';
+import type { getDatabase } from '@happyvertical/sql';
+import { USER_EMAIL_KEY_BACKFILL_NAME } from '../migrations/backfillUserEmailKeys.js';
 import { User } from '../models/User.js';
 import { UserStatus } from '../types/index.js';
+
+type DatabaseInterface = Awaited<ReturnType<typeof getDatabase>>;
 
 /**
  * OIDC claims used for identity resolution
@@ -26,6 +45,9 @@ export interface OidcClaims {
   preferred_username?: string;
 }
 
+/** OIDC claims after the provisioning boundary validates and normalizes email. */
+export type NormalizedOidcClaims = Readonly<OidcClaims & { email: string }>;
+
 /**
  * Result of OIDC identity resolution
  */
@@ -38,6 +60,55 @@ export interface OidcIdentityResult {
   oidcIdentity: OidcIdentity;
   /** Whether the profile was newly created */
   created: boolean;
+}
+
+/** Context passed after OIDC claims are validated and before provisioning. */
+export interface OidcProfileResolverContext {
+  /** Transaction-bound database; use this for every resolver read/write. */
+  db: DatabaseInterface;
+  /**
+   * Frozen normalized claim snapshot. OidcLoginService supplies
+   * protocol-validated claims; direct collection callers must provide claims
+   * from a trusted boundary.
+   */
+  claims: NormalizedOidcClaims;
+  /** Configured provider key. */
+  provider: string;
+  /** Transaction-bound User collection. */
+  users: UserCollection;
+}
+
+/**
+ * Resolve a consumer-owned canonical Profile before User/session creation.
+ *
+ * Return `undefined` for the secure default, `null` to reject login, or a
+ * Profile to select it explicitly. A supplied Profile is still required to be
+ * the unique, unowned global Person for the verified email. The hook may be
+ * retried after a concurrent unique-key race and must therefore be idempotent.
+ */
+export type OidcProfileResolver = (
+  context: OidcProfileResolverContext,
+) => Profile | null | undefined | Promise<Profile | null | undefined>;
+
+export type OidcProvisioningErrorCode =
+  | 'ambiguous_identity'
+  | 'concurrency_conflict'
+  | 'profile_owned'
+  | 'rejected'
+  | 'transaction_required'
+  | 'user_email_backfill_required'
+  | 'user_email_conflict';
+
+/** Fail-closed OIDC identity provisioning error. */
+export class OidcProvisioningError extends Error {
+  constructor(
+    readonly code: OidcProvisioningErrorCode,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+    this.name = 'OidcProvisioningError';
+  }
 }
 
 /**
@@ -54,6 +125,13 @@ export interface GetOrCreateFromOidcOptions {
    * assertion, so it cannot be enforced.
    */
   allowUnverifiedEmail?: boolean;
+  /**
+   * Optional application resolver invoked inside the provisioning transaction
+   * after token/claim validation and before OIDC identity, User, or session
+   * creation. Return a canonical Profile, `null` to reject, or `undefined` to
+   * use SMRT's secure default.
+   */
+  resolveProfile?: OidcProfileResolver;
 }
 
 /**
@@ -61,6 +139,7 @@ export interface GetOrCreateFromOidcOptions {
  */
 export class UserCollection extends SmrtCollection<User> {
   static readonly _itemClass = User;
+  private userEmailKeysReadyPromise: Promise<void> | null = null;
 
   /**
    * Find user by email address
@@ -139,9 +218,18 @@ export class UserCollection extends SmrtCollection<User> {
    * 2. Link OidcIdentity to the Profile
    * 3. Find or create User linked to the Profile
    *
-   * @param claims - OIDC token claims (sub, iss, email, name)
+   * Direct callers must supply claims from a trusted, already validated token
+   * boundary. OidcLoginService performs discovery, token exchange, issuer and
+   * subject validation, and verified-email source pairing before calling this
+   * collection method.
+   *
+   * @param claims - Trusted OIDC token claims (sub, iss, email, name)
    * @param provider - Provider name (e.g., 'kanidm', 'keycloak', 'google')
-   * @param options - Optional settings (recordLogin)
+   * @param options - Login recording, unverified-email compatibility, and an
+   * application Profile resolver. The resolver runs inside the provisioning
+   * transaction before identity/User creation, may be retried, and must be
+   * idempotent. Its returned Profile is still checked as the unique, global,
+   * unowned Person for the verified normalized email.
    * @returns User, Profile, OidcIdentity, and whether profile was created
    *
    * @example
@@ -169,20 +257,28 @@ export class UserCollection extends SmrtCollection<User> {
     options?: GetOrCreateFromOidcOptions,
   ): Promise<OidcIdentityResult> {
     // Validate required OIDC claims at runtime
-    const sub = claims?.sub?.trim();
-    const iss = claims?.iss?.trim();
-    if (!sub || !iss) {
+    const sub = claims?.sub;
+    const iss = claims?.iss;
+    if (
+      typeof sub !== 'string' ||
+      sub.trim().length === 0 ||
+      typeof iss !== 'string' ||
+      iss.trim().length === 0
+    ) {
       throw new Error(
         'Invalid OIDC claims: both "sub" and "iss" must be non-empty strings.',
       );
     }
 
-    // Email is required for user creation
-    if (!claims.email) {
+    // Email is required for user creation and is canonicalized before any
+    // resolver or persistence operation.
+    const suppliedEmail = claims.email;
+    if (typeof suppliedEmail !== 'string' || !suppliedEmail.trim()) {
       throw new Error(
         'OIDC claims missing required "email" for user creation.',
       );
     }
+    const email = normalizeIdentityEmail(suppliedEmail);
 
     // #1400: refuse an email the IdP explicitly marked unverified. Only an
     // explicit `email_verified === false` hard-fails; an absent claim makes no
@@ -194,46 +290,389 @@ export class UserCollection extends SmrtCollection<User> {
       );
     }
 
-    // Dynamic import to avoid circular dependency between smrt-users and smrt-profiles.
-    // Both packages need to reference each other's types, so we defer the import.
-    const { createProfileFromOidc } = await import(
-      '@happyvertical/smrt-profiles'
-    );
+    const normalizedClaims: NormalizedOidcClaims = Object.freeze({
+      ...claims,
+      sub,
+      iss,
+      email,
+    });
+    const db = this.requireProvisioningDatabase();
+    return coordinateOidcProvisioning({
+      db,
+      lockKeys: [
+        `identity:${OidcIdentity.buildIdentityKey(iss, sub)}`,
+        `email:${email}`,
+      ],
+      isRaceConflict: isUserOidcRaceConflict,
+      createTransactionError: (message, cause) =>
+        new OidcProvisioningError('transaction_required', message, {
+          cause,
+        }),
+      createConcurrencyError: (cause) =>
+        new OidcProvisioningError(
+          'concurrency_conflict',
+          'Concurrent OIDC provisioning did not converge on one identity.',
+          { cause },
+        ),
+      rebindRootResult: (result, rootDb) =>
+        this.rebindOidcProvisioningResult(result, rootDb),
+      provision: (tx) =>
+        withSystemContext(async () => {
+          const users =
+            tx === db ? this : await UserCollection.create({ db: tx });
+          return users.provisionOidcIdentity(
+            normalizedClaims,
+            provider,
+            options,
+            tx,
+          );
+        }),
+    });
+  }
 
-    // Get database options from this collection
-    const dbOptions = { db: this.options.db };
+  private requireProvisioningDatabase(): DatabaseInterface {
+    const db = this.options.db;
+    if (!db || typeof db !== 'object' || !('query' in db)) {
+      throw new OidcProvisioningError(
+        'transaction_required',
+        'OIDC provisioning requires an initialized database.',
+      );
+    }
+    return db as DatabaseInterface;
+  }
 
-    // Create or find profile with linked OIDC identity
-    const { profile, oidcIdentity, created } = await createProfileFromOidc(
+  private async provisionOidcIdentity(
+    claims: NormalizedOidcClaims,
+    provider: string,
+    options: GetOrCreateFromOidcOptions | undefined,
+    db: DatabaseInterface,
+  ): Promise<OidcIdentityResult> {
+    const { ProfileCollection } = await import('@happyvertical/smrt-profiles');
+    const profileCollection = await ProfileCollection.create({ db });
+    const identityCollection = await OidcIdentityCollection.create({ db });
+    const existingIdentity = await this.findUniqueOidcIdentity(
+      identityCollection,
       claims,
-      provider,
-      dbOptions,
     );
+    if (existingIdentity) {
+      const profileId = requireId(
+        existingIdentity.profileId,
+        'OIDC identity Profile',
+      );
+      const owners = await this.findProfileOwners(profileId);
+      if (owners.length > 1) {
+        throw new OidcProvisioningError(
+          'profile_owned',
+          `Profile ${profileId} belongs to multiple Users.`,
+        );
+      }
+      const profile = await profileCollection.reserveCanonicalIdentityEmail(
+        profileId,
+        owners[0] ? undefined : claims.email,
+      );
 
-    const shouldRecordLogin = options?.recordLogin !== false;
-
-    // Get or create user for this profile. SmrtCollection.create() persists, so
-    // pass lastLoginAt during creation to avoid an extra first-login write.
-    const existingUser = await this.findByProfile(profile.id as string);
-    const user =
-      existingUser ??
-      (await this.create({
-        email: claims.email,
-        ...(shouldRecordLogin ? { lastLoginAt: new Date() } : {}),
-        profileId: profile.id as string,
-        status: UserStatus.ACTIVE,
-      }));
-
-    if (existingUser && shouldRecordLogin) {
-      existingUser.recordLogin();
-      await existingUser.save();
+      const user = await this.finishUserProvisioning(
+        profile,
+        owners[0],
+        claims.email,
+        options,
+      );
+      existingIdentity.email = claims.email;
+      existingIdentity.lastUsedAt = new Date();
+      await existingIdentity.save();
+      return {
+        user,
+        profile,
+        oidcIdentity: existingIdentity,
+        created: false,
+      };
     }
 
-    return {
-      user,
+    const resolvedProfile = options?.resolveProfile
+      ? await options.resolveProfile({
+          // Never expose the internal snapshot used for retry locks and
+          // persistence. A frozen copy keeps an application resolver from
+          // changing the authenticated identity across attempts.
+          claims: Object.freeze({ ...claims }),
+          db,
+          provider,
+          users: this,
+        })
+      : undefined;
+    if (resolvedProfile === null) {
+      throw new OidcProvisioningError(
+        'rejected',
+        'OIDC provisioning was rejected by the application resolver.',
+      );
+    }
+
+    let profile: Profile | null | undefined = resolvedProfile;
+    let created = false;
+
+    if (profile) {
+      if (claims.email_verified !== true) {
+        throw new OidcProvisioningError(
+          'rejected',
+          'An application resolver cannot reuse a Profile without a verified OIDC email.',
+        );
+      }
+      profile = await profileCollection.reserveCanonicalIdentityEmail(
+        requireId(profile.id, 'Resolved Profile'),
+        claims.email,
+      );
+    } else if (claims.email_verified === true) {
+      profile = await profileCollection.findUniqueGlobalPersonByEmail(
+        claims.email,
+      );
+      if (profile) {
+        profile = await profileCollection.reserveCanonicalIdentityEmail(
+          requireId(profile.id, 'Matched Profile'),
+          claims.email,
+        );
+      }
+    } else {
+      // Never link an unverified/unspecified email to an existing identity.
+      const collision = await profileCollection.findUniqueGlobalPersonByEmail(
+        claims.email,
+      );
+      if (collision) {
+        throw new OidcProvisioningError(
+          'rejected',
+          `OIDC email ${claims.email} is not verified and already belongs to a Profile.`,
+        );
+      }
+    }
+
+    if (!profile) {
+      profile = await createOidcProvisioningPerson<Profile>(db, {
+        email: claims.email,
+        name: claims.name,
+        preferredUsername: claims.preferred_username,
+        subject: claims.sub,
+      });
+      created = true;
+    }
+
+    const profileId = requireId(profile.id, 'OIDC Profile');
+    const owners = await this.findProfileOwners(profileId);
+    if (owners.length > 0) {
+      // A concurrent first login can commit the exact issuer+subject mapping
+      // after this transaction's initial identity lookup but before its
+      // profile ownership check. Re-read the durable identity arbiter before
+      // rejecting the now-owned Profile so the same identity converges while
+      // every different identity still fails closed.
+      const concurrentIdentity = await this.findUniqueOidcIdentity(
+        identityCollection,
+        claims,
+      );
+      if (owners.length === 1 && concurrentIdentity?.profileId === profileId) {
+        const user = await this.finishUserProvisioning(
+          profile,
+          owners[0],
+          claims.email,
+          options,
+        );
+        concurrentIdentity.email = claims.email;
+        concurrentIdentity.lastUsedAt = new Date();
+        await concurrentIdentity.save();
+        return {
+          user,
+          profile,
+          oidcIdentity: concurrentIdentity,
+          created: false,
+        };
+      }
+      throw new OidcProvisioningError(
+        'profile_owned',
+        `Profile ${profileId} already belongs to another User.`,
+      );
+    }
+
+    // Initial lookup already proved this issuer+subject absent. Insert only:
+    // a concurrent winner must surface the unique identity-key conflict so the
+    // whole transaction rolls back and retries against the committed winner.
+    const oidcIdentity = await insertOidcProvisioningIdentity<OidcIdentity>(
+      db,
+      {
+        email: claims.email,
+        issuer: claims.iss,
+        profileId,
+        provider,
+        subject: claims.sub,
+      },
+    );
+    const user = await this.finishUserProvisioning(
       profile,
-      oidcIdentity,
-      created,
-    };
+      undefined,
+      claims.email,
+      options,
+    );
+
+    return { user, profile, oidcIdentity, created };
   }
+
+  private async findProfileOwners(profileId: string): Promise<User[]> {
+    return this.list({ where: { profileId }, limit: 2 });
+  }
+
+  private async rebindOidcProvisioningResult(
+    result: OidcIdentityResult,
+    rootDb: DatabaseInterface,
+  ): Promise<OidcIdentityResult> {
+    const profileId = requireId(result.profile.id, 'OIDC Profile');
+    const identityId = requireId(result.oidcIdentity.id, 'OIDC identity');
+    const userId = requireId(result.user.id, 'OIDC User');
+    return withSystemContext(async () => {
+      const { ProfileCollection } = await import(
+        '@happyvertical/smrt-profiles'
+      );
+      const users = await UserCollection.create({ db: rootDb });
+      const profiles = await ProfileCollection.create({ db: rootDb });
+      const identities = await OidcIdentityCollection.create({ db: rootDb });
+      const [user, profile, oidcIdentity] = await Promise.all([
+        users.get({ id: userId }),
+        profiles.get({ id: profileId }),
+        identities.get({ id: identityId }),
+      ]);
+      if (!user || !profile || !oidcIdentity) {
+        throw new OidcProvisioningError(
+          'concurrency_conflict',
+          'Committed OIDC provisioning result was not found.',
+        );
+      }
+      return { ...result, user, profile, oidcIdentity };
+    });
+  }
+
+  private async findUniqueOidcIdentity(
+    identities: OidcIdentityCollection,
+    claims: Pick<NormalizedOidcClaims, 'iss' | 'sub'>,
+  ): Promise<OidcIdentity | undefined> {
+    try {
+      return (
+        (await identities.findBySubject(claims.iss, claims.sub)) ?? undefined
+      );
+    } catch (error) {
+      if (error instanceof AmbiguousOidcIdentityError) {
+        throw new OidcProvisioningError(
+          'ambiguous_identity',
+          `Multiple OIDC identities exist for ${claims.iss} subject ${claims.sub}.`,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+  }
+
+  private async finishUserProvisioning(
+    profile: Profile,
+    existingOwner: User | undefined,
+    email: string,
+    options: GetOrCreateFromOidcOptions | undefined,
+  ): Promise<User> {
+    const shouldRecordLogin = options?.recordLogin !== false;
+    if (existingOwner) {
+      if (shouldRecordLogin) {
+        existingOwner.recordLogin();
+        await existingOwner.save();
+      }
+      return existingOwner;
+    }
+
+    const emailUsers = await this.findUsersByNormalizedEmail(email);
+    if (emailUsers.length > 0) {
+      throw new OidcProvisioningError(
+        'user_email_conflict',
+        `A User already exists for ${email} without the selected Profile.`,
+      );
+    }
+
+    return saveOidcRaceArbiter(() =>
+      this.create({
+        email,
+        ...(shouldRecordLogin ? { lastLoginAt: new Date() } : {}),
+        profileId: requireId(profile.id, 'OIDC Profile'),
+        status: UserStatus.ACTIVE,
+      }),
+    );
+  }
+
+  private async findUsersByNormalizedEmail(email: string): Promise<User[]> {
+    const db = this.requireProvisioningDatabase();
+    await this.ensureUserEmailKeysReady(db);
+    const result = await db.query(
+      `SELECT id, email, email_key
+       FROM users
+       WHERE email_key = ?
+       ORDER BY created_at ASC, id ASC
+       LIMIT 2`,
+      email,
+    );
+    for (const row of result.rows) {
+      this.assertUserEmailKeyCurrent(row, email);
+    }
+    const users = await Promise.all(
+      result.rows.map((row) =>
+        typeof row.id === 'string' ? this.get({ id: row.id }) : null,
+      ),
+    );
+    return users.filter((user): user is User => user !== null);
+  }
+
+  /** Require the deploy-time backfill marker before indexed identity reads. */
+  private async ensureUserEmailKeysReady(db: DatabaseInterface): Promise<void> {
+    if (!this.userEmailKeysReadyPromise) {
+      this.userEmailKeysReadyPromise = this.checkUserEmailKeysReady(db).catch(
+        (error) => {
+          this.userEmailKeysReadyPromise = null;
+          throw error;
+        },
+      );
+    }
+    return this.userEmailKeysReadyPromise;
+  }
+
+  private async checkUserEmailKeysReady(db: DatabaseInterface): Promise<void> {
+    if (
+      await new BackfillTracker({ db }).isApplied(USER_EMAIL_KEY_BACKFILL_NAME)
+    )
+      return;
+    throw new OidcProvisioningError(
+      'user_email_backfill_required',
+      'User email keys are not marked ready; run backfillUserEmailKeys() before OIDC provisioning.',
+    );
+  }
+
+  private assertUserEmailKeyCurrent(
+    row: Record<string, unknown>,
+    normalizedEmail?: string,
+  ): void {
+    const storedEmail = typeof row.email === 'string' ? row.email : '';
+    const expectedKey = storedEmail.trim()
+      ? normalizeIdentityEmail(storedEmail)
+      : null;
+    const storedKey = typeof row.email_key === 'string' ? row.email_key : null;
+    if (
+      storedKey !== expectedKey ||
+      (normalizedEmail !== undefined && expectedKey !== normalizedEmail)
+    ) {
+      throw new OidcProvisioningError(
+        'user_email_backfill_required',
+        `User ${String(row.id ?? '<unknown>')} has a missing or stale email key; run backfillUserEmailKeys() before OIDC provisioning.`,
+      );
+    }
+  }
+}
+
+function requireId(value: unknown, label: string): string {
+  if (typeof value !== 'string' || !value) {
+    throw new Error(`${label} did not produce an id.`);
+  }
+  return value;
+}
+
+function isUserOidcRaceConflict(error: unknown): boolean {
+  return isOidcProvisioningRaceConflict(error, {
+    messagePatterns: [/users[._].*profile_id|users_profile_id/iu],
+  });
 }

--- a/packages/users/src/collections/UserCollection.ts
+++ b/packages/users/src/collections/UserCollection.ts
@@ -82,9 +82,13 @@ export interface OidcProfileResolverContext {
  * Resolve a consumer-owned canonical Profile before User/session creation.
  *
  * Return `undefined` for the secure default, `null` to reject login, or a
- * Profile to select it explicitly. A supplied Profile is still required to be
- * the unique, unowned global Person for the verified email. The hook may be
- * retried after a concurrent unique-key race and must therefore be idempotent.
+ * Profile to select it explicitly. For a new issuer/subject, a supplied Profile
+ * is still required to be the unique, unowned global Person for the verified
+ * email. For an exact existing issuer/subject, `null` still rejects login and a
+ * supplied Profile must be the already-linked Profile; the hook cannot rebind
+ * identity authority. Stable-link owner and canonical-Person checks still
+ * apply. The hook may be retried after a concurrent unique-key race and must
+ * therefore be idempotent.
  */
 export type OidcProfileResolver = (
   context: OidcProfileResolverContext,
@@ -227,9 +231,11 @@ export class UserCollection extends SmrtCollection<User> {
    * @param provider - Provider name (e.g., 'kanidm', 'keycloak', 'google')
    * @param options - Login recording, unverified-email compatibility, and an
    * application Profile resolver. The resolver runs inside the provisioning
-   * transaction before identity/User creation, may be retried, and must be
-   * idempotent. Its returned Profile is still checked as the unique, global,
-   * unowned Person for the verified normalized email.
+   * transaction before provisioning returns, may be retried, and must be
+   * idempotent. For a new identity, its returned Profile is still checked as
+   * the unique, global, unowned Person for the verified normalized email. For
+   * an exact existing identity, it may only confirm the already-linked Profile
+   * and cannot rebind it.
    * @returns User, Profile, OidcIdentity, and whether profile was created
    *
    * @example
@@ -354,11 +360,38 @@ export class UserCollection extends SmrtCollection<User> {
       identityCollection,
       claims,
     );
+    const resolvedProfile = options?.resolveProfile
+      ? await options.resolveProfile({
+          // Never expose the internal snapshot used for retry locks and
+          // persistence. A frozen copy keeps an application resolver from
+          // changing the authenticated identity across attempts.
+          claims: Object.freeze({ ...claims }),
+          db,
+          provider,
+          users: this,
+        })
+      : undefined;
+    if (resolvedProfile === null) {
+      throw new OidcProvisioningError(
+        'rejected',
+        'OIDC provisioning was rejected by the application resolver.',
+      );
+    }
+
     if (existingIdentity) {
       const profileId = requireId(
         existingIdentity.profileId,
         'OIDC identity Profile',
       );
+      if (
+        resolvedProfile &&
+        requireId(resolvedProfile.id, 'Resolved Profile') !== profileId
+      ) {
+        throw new OidcProvisioningError(
+          'rejected',
+          'An application resolver cannot rebind an existing OIDC identity.',
+        );
+      }
       const owners = await this.findProfileOwners(profileId);
       if (owners.length > 1) {
         throw new OidcProvisioningError(
@@ -386,24 +419,6 @@ export class UserCollection extends SmrtCollection<User> {
         oidcIdentity: existingIdentity,
         created: false,
       };
-    }
-
-    const resolvedProfile = options?.resolveProfile
-      ? await options.resolveProfile({
-          // Never expose the internal snapshot used for retry locks and
-          // persistence. A frozen copy keeps an application resolver from
-          // changing the authenticated identity across attempts.
-          claims: Object.freeze({ ...claims }),
-          db,
-          provider,
-          users: this,
-        })
-      : undefined;
-    if (resolvedProfile === null) {
-      throw new OidcProvisioningError(
-        'rejected',
-        'OIDC provisioning was rejected by the application resolver.',
-      );
     }
 
     let profile: Profile | null | undefined = resolvedProfile;

--- a/packages/users/src/collections/index.ts
+++ b/packages/users/src/collections/index.ts
@@ -53,7 +53,12 @@ export {
 // Core collections
 export {
   type GetOrCreateFromOidcOptions,
+  type NormalizedOidcClaims,
   type OidcClaims,
   type OidcIdentityResult,
+  type OidcProfileResolver,
+  type OidcProfileResolverContext,
+  OidcProvisioningError,
+  type OidcProvisioningErrorCode,
   UserCollection,
 } from './UserCollection.js';

--- a/packages/users/src/index.ts
+++ b/packages/users/src/index.ts
@@ -73,8 +73,13 @@ export {
   MagicLinkTokenCollection,
   MembershipCollection,
   MembershipOverrideCollection,
+  type NormalizedOidcClaims,
   type OidcClaims,
   type OidcIdentityResult,
+  type OidcProfileResolver,
+  type OidcProfileResolverContext,
+  OidcProvisioningError,
+  type OidcProvisioningErrorCode,
   PermissionCollection,
   RoleCollection,
   RolePermissionCollection,
@@ -92,6 +97,14 @@ export {
   UsersCliAuthRequestCollection,
   UsersMagicLinkTokenCollection,
 } from './collections/index.js';
+// Deploy-time data migrations
+export {
+  type BackfillUserEmailKeysResult,
+  backfillUserEmailKeys,
+  type DuplicateUserEmailKey,
+  UserEmailKeyBackfillError,
+  type UserEmailKeyBackfillErrorCode,
+} from './migrations/backfillUserEmailKeys.js';
 // Models
 export {
   AccessRequest,

--- a/packages/users/src/migrations/backfillUserEmailKeys.ts
+++ b/packages/users/src/migrations/backfillUserEmailKeys.ts
@@ -1,0 +1,119 @@
+import { BackfillTracker } from '@happyvertical/smrt-core/migrations';
+import { normalizeIdentityEmail } from '@happyvertical/smrt-profiles';
+import type { getDatabase } from '@happyvertical/sql';
+
+type DatabaseInterface = Awaited<ReturnType<typeof getDatabase>>;
+
+export const USER_EMAIL_KEY_BACKFILL_NAME =
+  '@happyvertical/smrt-users:user-email-keys:v1';
+
+export interface DuplicateUserEmailKey {
+  emailKey: string;
+  userCount: number;
+}
+
+export interface BackfillUserEmailKeysResult {
+  updated: number;
+}
+
+export type UserEmailKeyBackfillErrorCode =
+  | 'duplicate_email'
+  | 'transaction_required';
+
+/**
+ * Raised before any rows are changed when legacy User emails are ambiguous.
+ */
+export class UserEmailKeyBackfillError extends Error {
+  constructor(
+    readonly code: UserEmailKeyBackfillErrorCode,
+    message: string,
+    readonly duplicates: DuplicateUserEmailKey[] = [],
+  ) {
+    super(message);
+    this.name = 'UserEmailKeyBackfillError';
+  }
+}
+
+/**
+ * Populate the durable normalized-email key for Users created before the
+ * `emailKey` field existed.
+ *
+ * Apply the schema migration first, stop or upgrade legacy writers, then call
+ * this once from a single deploy process. The operation is idempotent. It
+ * fails before changing any rows when two non-blank emails normalize to the
+ * same key, so operators can reconcile those Users explicitly.
+ */
+export async function backfillUserEmailKeys(
+  db: DatabaseInterface,
+): Promise<BackfillUserEmailKeysResult> {
+  if (!db.transaction) {
+    throw new UserEmailKeyBackfillError(
+      'transaction_required',
+      'User email-key backfill requires a root database with transaction().',
+    );
+  }
+
+  const tracker = new BackfillTracker({ db });
+  await tracker.initialize();
+
+  return db.transaction(async (tx) => {
+    BackfillTracker.inheritInitialization(tx, db);
+    const result = await tx.query(
+      'SELECT id, email, email_key FROM users ORDER BY id',
+    );
+    const counts = new Map<string, number>();
+    const updates: Array<{ emailKey: string | null; id: string }> = [];
+
+    for (const row of result.rows) {
+      const id = typeof row.id === 'string' ? row.id : '';
+      if (!id) {
+        throw new Error('User email-key backfill found a row without an id.');
+      }
+      const email = typeof row.email === 'string' ? row.email : '';
+      const emailKey = email.trim() ? normalizeIdentityEmail(email) : null;
+      if (emailKey) counts.set(emailKey, (counts.get(emailKey) ?? 0) + 1);
+      const storedKey =
+        typeof row.email_key === 'string' ? row.email_key : null;
+      if (storedKey !== emailKey) updates.push({ emailKey, id });
+    }
+
+    const duplicates = [...counts.entries()]
+      .filter(([, userCount]) => userCount > 1)
+      .map(([emailKey, userCount]) => ({ emailKey, userCount }))
+      .sort((left, right) => left.emailKey.localeCompare(right.emailKey));
+    if (duplicates.length > 0) {
+      throw new UserEmailKeyBackfillError(
+        'duplicate_email',
+        'Cannot backfill User.emailKey because legacy User emails contain normalized duplicates.',
+        duplicates,
+      );
+    }
+
+    // Clear every changing key first. This avoids transient unique-index
+    // conflicts for valid final states such as two legacy rows whose stale
+    // keys were swapped.
+    for (const update of updates) {
+      await tx.query(
+        'UPDATE users SET email_key = NULL WHERE id = ?',
+        update.id,
+      );
+    }
+    for (const update of updates) {
+      await tx.query(
+        'UPDATE users SET email_key = ? WHERE id = ?',
+        update.emailKey,
+        update.id,
+      );
+    }
+
+    await new BackfillTracker({ db: tx }).recordApplied(
+      USER_EMAIL_KEY_BACKFILL_NAME,
+      {
+        description: 'Canonical User email keys are current.',
+        packageName: '@happyvertical/smrt-users',
+      },
+    );
+
+    return { updated: updates.length };
+  });
+}

--- a/packages/users/src/models/User.ts
+++ b/packages/users/src/models/User.ts
@@ -10,6 +10,7 @@ import {
   type SmrtObjectOptions,
   smrt,
 } from '@happyvertical/smrt-core';
+import { normalizeIdentityEmail } from '@happyvertical/smrt-profiles';
 import type { User as UserContract } from '@happyvertical/smrt-types';
 import { UserStatus } from '../types/index.js';
 
@@ -46,7 +47,7 @@ export function isValidEmail(email: string): boolean {
  */
 export function normalizeEmail(email: string): string {
   if (!email || typeof email !== 'string') return '';
-  return email.trim().toLowerCase();
+  return email.trim() ? normalizeIdentityEmail(email) : '';
 }
 
 /**
@@ -76,13 +77,17 @@ export class User extends SmrtObject implements UserContract {
   /**
    * Foreign key to smrt-profiles Profile (cross-package)
    */
-  @crossPackageRef('@happyvertical/smrt-profiles:Profile')
+  @crossPackageRef('@happyvertical/smrt-profiles:Profile', { unique: true })
   profileId: string = '';
 
   /**
    * User's email address (unique, used for lookup)
    */
   email: string = '';
+
+  /** Durable normalized key for cross-connection email uniqueness. */
+  @field({ type: 'text', nullable: true, unique: true, readonly: true })
+  emailKey: string | null = null;
 
   /**
    * User account status
@@ -138,5 +143,12 @@ export class User extends SmrtObject implements UserContract {
    */
   recordLogin(): void {
     this.lastLoginAt = new Date();
+  }
+
+  /** Keep the durable email key derived from the public email field. */
+  override async save(): Promise<this> {
+    this.email = normalizeEmail(this.email);
+    this.emailKey = this.email || null;
+    return super.save();
   }
 }

--- a/packages/users/src/services/OidcLoginService.ts
+++ b/packages/users/src/services/OidcLoginService.ts
@@ -21,6 +21,7 @@ import {
 import {
   type OidcClaims,
   type OidcIdentityResult,
+  type OidcProfileResolver,
   UserCollection,
 } from '../collections/UserCollection.js';
 
@@ -143,6 +144,11 @@ export interface OidcLoginServiceOptions extends SmrtClassOptions {
   clockTolerance?: number | string;
   /** Provider metadata cache TTL in milliseconds. Defaults to 5 minutes. */
   metadataCacheTtlMs?: number;
+  /**
+   * Application Profile resolver invoked after claims validation and before
+   * OIDC identity, User, or session creation.
+   */
+  resolveProfile?: OidcProfileResolver;
 }
 
 export class OidcLoginError extends Error {
@@ -311,11 +317,16 @@ function mergeClaims(
     throw new OidcLoginError('OIDC userinfo subject does not match ID token.');
   }
 
+  const useIdTokenEmail = idTokenClaims.email !== undefined;
   return {
     ...idTokenClaims,
-    email: idTokenClaims.email ?? userInfoClaims.email,
-    email_verified:
-      idTokenClaims.email_verified ?? userInfoClaims.email_verified,
+    // Email verification is meaningful only for the email asserted by the
+    // same source. Never borrow an ID-token verification flag for a userinfo
+    // address (or vice versa).
+    email: useIdTokenEmail ? idTokenClaims.email : userInfoClaims.email,
+    email_verified: useIdTokenEmail
+      ? idTokenClaims.email_verified
+      : userInfoClaims.email_verified,
     name: idTokenClaims.name ?? userInfoClaims.name,
     preferred_username:
       idTokenClaims.preferred_username ?? userInfoClaims.preferred_username,
@@ -452,6 +463,7 @@ export class OidcLoginService {
   private readonly clockTolerance: number | string;
   private readonly fetchImpl: typeof fetch;
   private readonly metadataCacheTtlMs: number;
+  private readonly resolveProfile?: OidcProfileResolver;
   private metadataFetchedAt = 0;
   private metadataPromise?: Promise<OidcProviderMetadata>;
   private remoteJwks?: JWTVerifyGetKey;
@@ -465,6 +477,7 @@ export class OidcLoginService {
       metadataCacheTtlMs,
       provider,
       providerName,
+      resolveProfile,
       ...classOptions
     } = options;
 
@@ -479,6 +492,7 @@ export class OidcLoginService {
     this.fetchImpl = ensureFetch(fetchOverride);
     this.metadataCacheTtlMs =
       metadataCacheTtlMs ?? DEFAULT_METADATA_CACHE_TTL_MS;
+    this.resolveProfile = resolveProfile;
     this.provider = {
       ...provider,
       issuer: normalizeIssuer(provider.issuer),
@@ -610,7 +624,9 @@ export class OidcLoginService {
       transaction,
     );
     const users = await UserCollection.create(this.classOptions);
-    const result = await users.getOrCreateFromOidc(claims, this.providerName);
+    const result = await users.getOrCreateFromOidc(claims, this.providerName, {
+      resolveProfile: this.resolveProfile,
+    });
 
     return {
       ...result,

--- a/packages/users/src/sveltekit/index.ts
+++ b/packages/users/src/sveltekit/index.ts
@@ -27,6 +27,7 @@ import '../__smrt-register__.js';
 
 import { createLogger } from '@happyvertical/logger';
 import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import type { OidcProfileResolver } from '../collections/UserCollection.js';
 import { DEFAULT_SESSION_TTL } from '../models/Session.js';
 import {
   decodeOidcTransaction,
@@ -51,6 +52,11 @@ import {
   type TerminalAuthServiceOptions,
 } from '../services/TerminalAuthService.js';
 
+export type {
+  NormalizedOidcClaims,
+  OidcProfileResolver,
+  OidcProfileResolverContext,
+} from '../collections/UserCollection.js';
 export {
   MobileAuthError,
   type MobileAuthErrorCode,
@@ -196,6 +202,12 @@ export interface OidcSvelteKitOptions
   sessionTtl?: number;
   /** Optional tenant to bind to the session. */
   tenantId?: OidcStringResolver<string | null | undefined>;
+  /**
+   * Resolve or reject the canonical Profile after validated claims and before
+   * User/session creation. The resolver runs inside the provisioning
+   * transaction and may be retried after a concurrent unique-key race.
+   */
+  resolveProfile?: OidcProfileResolver;
   /** Redirect target after successful callback. */
   successRedirect?: OidcStringResolver<string>;
   /** Redirect target after failed callback. If omitted, failures return 401. */
@@ -780,9 +792,11 @@ function redirectResponse(location: string | URL): Response {
   });
 }
 
-function failureResponse(error: unknown): Response {
-  const message = error instanceof Error ? error.message : 'OIDC login failed.';
-  return new Response(message, {
+function failureResponse(_error: unknown): Response {
+  // The callback is unauthenticated. Provisioning and resolver errors can
+  // contain emails, Profile IDs, tenancy state, or database details; expose
+  // the full Error only through the server-side failureRedirect callback.
+  return new Response('OIDC login failed.', {
     status: 401,
     headers: {
       'content-type': 'text/plain; charset=utf-8',

--- a/packages/vitest/src/__tests__/workspace-aliases.test.ts
+++ b/packages/vitest/src/__tests__/workspace-aliases.test.ts
@@ -30,6 +30,12 @@ describe('getWorkspaceViteAliases', () => {
     );
   });
 
+  it('aliases the trusted profiles OIDC integration subpath to source', () => {
+    expect(
+      byFind.get('@happyvertical/smrt-profiles/internal/oidc-provisioning'),
+    ).toMatch(/packages\/profiles\/src\/internal\/oidc-provisioning\.ts$/);
+  });
+
   it('aliases the S11 component-test harness subpaths (smrt-vitest special-case)', () => {
     expect(byFind.get('@happyvertical/smrt-vitest/svelte')).toMatch(
       /src\/svelte\.ts$/,

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -275,6 +275,13 @@ export function getWorkspaceViteAliases(
       `${packageName}/internal/agent-runtime`,
       join(packageRoot, 'src/internal/agent-runtime.ts'),
     );
+    // smrt-profiles exposes trusted OIDC primitives only to framework package
+    // integrations, outside its application-facing root entry.
+    addAliasIfPresent(
+      aliases,
+      `${packageName}/internal/oidc-provisioning`,
+      join(packageRoot, 'src/internal/oidc-provisioning.ts'),
+    );
 
     if (packageName === '@happyvertical/smrt-core') {
       addAliasIfPresent(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2587,6 +2587,9 @@ importers:
       '@happyvertical/smrt-ui':
         specifier: workspace:*
         version: link:../smrt-ui
+      '@happyvertical/sql':
+        specifier: ^0.78.1
+        version: 0.78.1(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -2594,9 +2597,6 @@ importers:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest
-      '@happyvertical/sql':
-        specifier: ^0.78.1
-        version: 0.78.1(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@sveltejs/package':
         specifier: ^2.5.8
         version: 2.5.8(svelte@5.56.4)(typescript@5.9.3)


### PR DESCRIPTION
## Summary

- harden verified-email OIDC provisioning so it reuses only one unambiguous, unowned, global `Person`
- fail closed on tenant-scoped, non-`Person`, duplicate-email, already-owned, and Profile-only collisions before creating a `User` or session
- make first-login provisioning transaction-safe and idempotent across SQLite and PostgreSQL while preserving exact issuer/subject reuse
- expose a supported pre-provision profile resolver through `UserCollection`, `OidcLoginService`, and the SvelteKit integration without exposing protocol or session internals
- add durable email/identity reservation arbiters, readiness-checked backfills, focused regressions, public API documentation, and generated manifest updates

## Migration and release

Apply the generated schema changes, then run `backfillProfileEmailKeys(db)` followed by `backfillUserEmailKeys(db)` before enabling OIDC provisioning against existing data. Both backfills fail closed on collisions and record readiness only after a successful transaction.

Per the SMRT release policy, this PR does not add a manual changeset or edit package versions. Merge-time release automation will version the affected fixed release group.

## Validation

- `pnpm build` — 60/60 tasks
- `pnpm test` — full repository pass
- `pnpm typecheck` — 116/116 tasks
- `pnpm lint` and `pnpm format` — repository entry points pass (no configured Turbo tasks)
- `pnpm smrt dev:knowledge-check` — fresh, 0 errors / 0 warnings
- `pnpm --filter @happyvertical/smrt-users test:postgres` — 3 files / 19 tests
- focused Profiles tests — 28/28
- focused Users safety, security, and backfill tests — 73/73
- package export verification for Profiles and Users
- fresh 0.39.14 tarball consumer — strict TypeScript and runtime imports pass
- changed-file Biome check — clean except 19 pre-existing warnings in `security-audit-1400.test.ts`
- full seven-lens review cycle — correctness, maintainability, security, product behavior, tests, docs, and local consistency clean

Closes #1998

<!-- hv-agent-run:v1 -->
```json
{"issue":1998,"linked_issue":1998,"policy_revision":"1.0.0","runtime":"codex","schema":"hv-agent-run:v1","session":"019f5cda-1958-77f2-855a-0b9e971b3505","validation":["pnpm build","pnpm test","pnpm typecheck","pnpm lint","pnpm format","pnpm smrt dev:knowledge-check","smrt-users PostgreSQL integration: 19/19","profiles focused: 28/28","users focused: 73/73","packed exports and isolated consumer","review-cycle full roster: clean"]}
```
