### PR TITLE
test(users): codify OIDC provisioning decision matrix

### DIFF
--- a/packages/profiles/AGENTS.md
+++ b/packages/profiles/AGENTS.md
@@ -102,6 +102,10 @@ import { smrtProfilesGenerateBioPrompt } from '@happyvertical/smrt-profiles';
   initializes the shared tracker table. Caller-owned exact reuse does not
   consult the tracker and therefore does not require that table.
 - **Profile-only OIDC linking fails closed on existing email matches**:
+  the typed canonical scenario contract is
+  `src/testing/oidcProvisioningDecisionMatrix.ts`, executed by both Profiles
+  and Users tests; keep public docs pointed at it instead of adding a second
+  behavioral table.
   `createProfileFromOidc()` preserves exact issuer/subject reuse, including
   legacy tenant-scoped and non-Person links, but profiles cannot prove whether a
   User owns a same-email Profile. New identities therefore never attach to an

--- a/packages/profiles/README.md
+++ b/packages/profiles/README.md
@@ -168,13 +168,14 @@ A handle exposing only `transaction()` is ambiguous and fails closed. For
 adapters without nested savepoint support, including DuckDB, pass
 the root database rather than calling the helper inside an outer transaction.
 Provisioning fails before durable writes when neither safe path is available.
-The Profile-only helper preserves exact issuer/subject reuse, including legacy
-links to tenant-scoped or non-Person Profiles, but never attaches a new identity
-to an existing email match because this package cannot prove whether a User owns
-that Profile. User/session provisioning still rejects those unsafe linked
-Profiles before creating authentication state. Use
-`UserCollection.getOrCreateFromOidc()` from `@happyvertical/smrt-users` for
-owner-aware verified-email reuse and the supported pre-provision resolver hook.
+The typed [OIDC provisioning decision matrix](./src/testing/oidcProvisioningDecisionMatrix.ts)
+is the canonical package-by-package behavior contract. It records exact reuse,
+new identity and resolver outcomes, readiness, retries, adapter support, public
+errors, and permitted row creation; the Profiles and Users suites execute its
+applicable rows directly. In particular, Profile-only exact reuse preserves an
+established legacy link because it creates no User/session authentication state,
+while `UserCollection.getOrCreateFromOidc()` remains owner-aware and fail-closed.
+Use the Users API for verified-email reuse and application reconciliation.
 
 `Profile` and `ProfileCollection` both expose `getAssets()`, `addAsset()`, and
 `removeAsset()` helpers backed by `profile_assets`. Typical relationships are

--- a/packages/profiles/src/__tests__/oidc-account-linking.test.ts
+++ b/packages/profiles/src/__tests__/oidc-account-linking.test.ts
@@ -1127,7 +1127,7 @@ async function runProfileMatrixScenario(
   expect(expected.resolverCalls).toBe(0);
   const profileIds = values.map((value) => value.profile.id);
   if (expected.selectedProfile === 'concurrent_winner') {
-    expect(new Set(profileIds)).toHaveLength(1);
+    expect(new Set(profileIds).size).toBe(1);
   } else if (expected.selectedProfile === 'exact_identity_profile') {
     expect(profileIds.every((id) => id === identityProfileId)).toBe(true);
     expect(values.every((value) => value.oidcIdentity.id === identityId)).toBe(

--- a/packages/profiles/src/__tests__/oidc-account-linking.test.ts
+++ b/packages/profiles/src/__tests__/oidc-account-linking.test.ts
@@ -12,7 +12,11 @@ import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
 import { ObjectRegistry } from '@happyvertical/smrt-core';
-import { type DatabaseInterface, getDatabase } from '@happyvertical/sql';
+import {
+  type DatabaseInterface,
+  getDatabase,
+  syncSchema,
+} from '@happyvertical/sql';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createProfileFromOidc } from '../auth/index.js';
 import { OidcIdentityCollection } from '../collections/OidcIdentityCollection.js';
@@ -21,6 +25,52 @@ import { ProfileTypeCollection } from '../collections/ProfileTypeCollection.js';
 import { isOidcProvisioningRaceConflict } from '../internal/oidc-provisioning.js';
 import { backfillProfileEmailKeys } from '../migrations/backfillProfileEmailKeys.js';
 import { OidcIdentity } from '../models/OidcIdentity.js';
+import {
+  getOidcProvisioningDecisionScenario,
+  OIDC_PROVISIONING_DECISION_MATRIX,
+  type OidcProvisioningScenario,
+  type OidcProvisioningSurfaceExpectation,
+} from '../testing/oidcProvisioningDecisionMatrix.js';
+
+const PROFILE_MATRIX_SCENARIOS: readonly OidcProvisioningScenario[] =
+  OIDC_PROVISIONING_DECISION_MATRIX.filter(
+    (scenario) =>
+      scenario.adapters.sqlite.status === 'required' &&
+      scenario.expectations.profiles !== undefined,
+  );
+
+const OIDC_PROFILES_DUCKDB_TEST_SCHEMA = `
+CREATE TABLE IF NOT EXISTS "profiles" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "slug" TEXT NOT NULL,
+  "context" TEXT NOT NULL DEFAULT '',
+  "_meta_type" TEXT NOT NULL,
+  "_meta_data" JSON,
+  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "tenant_id" TEXT,
+  "type_id" TEXT,
+  "email" TEXT,
+  "email_key" TEXT,
+  "name" TEXT DEFAULT '',
+  "description" TEXT
+);
+
+CREATE TABLE IF NOT EXISTS "oidc_identities" (
+  "id" TEXT PRIMARY KEY NOT NULL,
+  "slug" TEXT NOT NULL,
+  "context" TEXT NOT NULL DEFAULT '',
+  "created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "updated_at" TIMESTAMP NOT NULL DEFAULT current_timestamp,
+  "profile_id" TEXT NOT NULL,
+  "provider" TEXT DEFAULT '',
+  "issuer" TEXT DEFAULT '',
+  "subject" TEXT DEFAULT '',
+  "identity_key" TEXT,
+  "email" TEXT DEFAULT '',
+  "last_used_at" TIMESTAMP
+);
+`;
 
 describe('OIDC identity generated authority surface', () => {
   it('exposes no generated REST or MCP mutations', () => {
@@ -134,6 +184,17 @@ describe('OIDC Account Linking', () => {
     await personType.save();
     const db = await getDatabase({ type: 'sqlite', url: dbUrl });
     await backfillProfileEmailKeys(db);
+  });
+
+  describe('executable decision matrix (SQLite)', () => {
+    it.each(PROFILE_MATRIX_SCENARIOS)('$id — $title', async (scenario) => {
+      const db = await getDatabase({ type: 'sqlite', url: dbUrl });
+      try {
+        await runProfileMatrixScenario(db, scenario);
+      } finally {
+        await db.close?.();
+      }
+    });
   });
 
   describe('createProfileFromOidc', () => {
@@ -703,14 +764,18 @@ describe('OIDC Account Linking', () => {
       }
     });
 
-    it('fails closed on a DuckDB manual transaction without corrupting it', async () => {
+    it.each([
+      getOidcProvisioningDecisionScenario('duckdb-caller-owned-transaction'),
+    ])('$id — $title (Profiles manual transaction)', async (scenario) => {
       const db = await getDatabase({ type: 'duckdb', url: ':memory:' });
+      await syncSchema({ db, schema: OIDC_PROFILES_DUCKDB_TEST_SCHEMA });
+      const before = await profileMatrixRowCounts(db);
       if (!db.beginTransaction) {
         throw new Error('Expected DuckDB manual transaction support.');
       }
       const tx = await db.beginTransaction();
       try {
-        await expect(
+        await expectProfileMatrixRejection(
           createProfileFromOidc(
             {
               sub: 'duckdb-manual-profile',
@@ -721,7 +786,14 @@ describe('OIDC Account Linking', () => {
             'example',
             { db: tx },
           ),
-        ).rejects.toThrow('root database');
+          scenario.expectations.profiles?.publicError ?? null,
+        );
+
+        await expectProfileMatrixRowDelta(
+          tx,
+          before,
+          scenario.expectations.profiles,
+        );
 
         expect(tx.isActive()).toBe(true);
         await tx.query('CREATE TABLE profile_outer_probe (id INTEGER)');
@@ -736,14 +808,18 @@ describe('OIDC Account Linking', () => {
       }
     });
 
-    it('fails closed on a DuckDB callback transaction without corrupting it', async () => {
+    it.each([
+      getOidcProvisioningDecisionScenario('duckdb-caller-owned-transaction'),
+    ])('$id — $title (Profiles callback transaction)', async (scenario) => {
       const db = await getDatabase({ type: 'duckdb', url: ':memory:' });
+      await syncSchema({ db, schema: OIDC_PROFILES_DUCKDB_TEST_SCHEMA });
+      const before = await profileMatrixRowCounts(db);
       if (!db.transaction) {
         throw new Error('Expected DuckDB callback transaction support.');
       }
       try {
         await db.transaction(async (tx) => {
-          await expect(
+          await expectProfileMatrixRejection(
             createProfileFromOidc(
               {
                 sub: 'duckdb-callback-profile',
@@ -754,7 +830,14 @@ describe('OIDC Account Linking', () => {
               'example',
               { db: tx },
             ),
-          ).rejects.toThrow('root database');
+            scenario.expectations.profiles?.publicError ?? null,
+          );
+
+          await expectProfileMatrixRowDelta(
+            tx,
+            before,
+            scenario.expectations.profiles,
+          );
 
           await tx.query('CREATE TABLE profile_callback_probe (id INTEGER)');
           await tx.query('INSERT INTO profile_callback_probe VALUES (1)');
@@ -902,6 +985,338 @@ describe('OIDC Account Linking', () => {
     });
   });
 });
+
+interface ProfileMatrixResult {
+  created: boolean;
+  profile: { id?: string };
+  oidcIdentity: { id?: string };
+}
+
+async function runProfileMatrixScenario(
+  db: DatabaseInterface,
+  scenario: OidcProvisioningScenario,
+): Promise<void> {
+  const expected = scenario.expectations.profiles;
+  if (!expected) {
+    throw new Error(`Missing Profiles expectation for ${scenario.id}`);
+  }
+
+  const email = 'matrix@example.com';
+  const subject = `matrix-${scenario.id}`;
+  let identityProfileId: string | undefined;
+  let identityId: string | undefined;
+  let emailProfileId: string | undefined;
+
+  if (scenario.identity === 'exact_missing_profile') {
+    identityId = await seedProfileMatrixIdentity(
+      db,
+      randomUUID(),
+      email,
+      subject,
+      false,
+    );
+  } else if (scenario.identity !== 'none') {
+    const identityEmail =
+      scenario.email === 'different_global_person'
+        ? 'linked-matrix@example.com'
+        : email;
+    identityProfileId = await seedProfileMatrixProfile(db, {
+      email: identityEmail,
+      metaType:
+        scenario.identity === 'exact_legacy_non_person_profile'
+          ? '@happyvertical/smrt-profiles:Organization'
+          : undefined,
+      tenantId:
+        scenario.identity === 'exact_legacy_tenant_profile'
+          ? randomUUID()
+          : undefined,
+    });
+    const legacyIdentity =
+      scenario.identity.startsWith('exact_legacy_') ||
+      scenario.identity === 'exact_ambiguous_legacy_links';
+    identityId = await seedProfileMatrixIdentity(
+      db,
+      identityProfileId,
+      identityEmail,
+      subject,
+      legacyIdentity,
+    );
+    if (scenario.identity === 'exact_ambiguous_legacy_links') {
+      const duplicateProfileId = await seedProfileMatrixProfile(db, {
+        email: identityEmail,
+      });
+      await seedProfileMatrixIdentity(
+        db,
+        duplicateProfileId,
+        identityEmail,
+        subject,
+        true,
+      );
+    }
+    if (scenario.email === 'different_global_person') {
+      emailProfileId = await seedProfileMatrixProfile(db, { email });
+    }
+  } else if (
+    scenario.email === 'one_unowned_global_person' ||
+    scenario.email === 'tenant_scoped_collision' ||
+    scenario.email === 'non_person_collision' ||
+    scenario.email === 'duplicate_normalized_profiles'
+  ) {
+    emailProfileId = await seedProfileMatrixProfile(db, {
+      email,
+      metaType:
+        scenario.email === 'non_person_collision'
+          ? '@happyvertical/smrt-profiles:Organization'
+          : undefined,
+      tenantId:
+        scenario.email === 'tenant_scoped_collision' ? randomUUID() : undefined,
+    });
+    if (scenario.email === 'duplicate_normalized_profiles') {
+      await seedProfileMatrixProfile(db, { email: ' MATRIX@example.com ' });
+    }
+  }
+
+  if (expected.readiness === 'none') {
+    await db.query(
+      `DELETE FROM _smrt_backfills
+       WHERE name = ?`,
+      '@happyvertical/smrt-profiles:profile-email-keys:v1',
+    );
+  }
+
+  const before = await profileMatrixRowCounts(db);
+  const identityBindingsBefore = await profileMatrixIdentityBindings(
+    db,
+    subject,
+  );
+  const claims = {
+    email: scenario.email === 'missing' ? undefined : email,
+    email_verified:
+      scenario.verification === 'claim_missing'
+        ? undefined
+        : scenario.verification === 'verified',
+    iss: 'https://issuer.example.com',
+    name: 'Matrix Profile',
+    sub: subject,
+  };
+  const invoke = (database: DatabaseInterface = db) =>
+    createProfileFromOidc(claims, 'matrix', { db: database });
+  const values: ProfileMatrixResult[] = [];
+  const errors: unknown[] = [];
+
+  if (scenario.execution === 'concurrent_winner_and_observer') {
+    collectProfileMatrixSettled(
+      await Promise.allSettled([invoke(), invoke()]),
+      values,
+      errors,
+    );
+  } else if (scenario.execution === 'caller_owned_transaction') {
+    const transaction = db.transaction;
+    if (!transaction) throw new Error('SQLite matrix requires transaction().');
+    await collectProfileMatrixPromise(
+      transaction.call(db, (tx) => invoke(tx)),
+      values,
+      errors,
+    );
+  } else {
+    await collectProfileMatrixPromise(invoke(), values, errors);
+  }
+
+  expectProfileMatrixOutcome(expected, values, errors);
+  expectProfileMatrixCreatedResult(expected, values);
+  expect(expected.resolverCalls).toBe(0);
+  const profileIds = values.map((value) => value.profile.id);
+  if (expected.selectedProfile === 'concurrent_winner') {
+    expect(new Set(profileIds)).toHaveLength(1);
+  } else if (expected.selectedProfile === 'exact_identity_profile') {
+    expect(profileIds.every((id) => id === identityProfileId)).toBe(true);
+    expect(values.every((value) => value.oidcIdentity.id === identityId)).toBe(
+      true,
+    );
+  } else if (expected.selectedProfile === 'new_profile') {
+    expect(profileIds.every((id) => typeof id === 'string')).toBe(true);
+    expect(profileIds).not.toContain(emailProfileId);
+  }
+
+  await expectProfileMatrixRowDelta(db, before, expected);
+  if (scenario.identity !== 'none' && !expected.rebindAllowed) {
+    await expect(profileMatrixIdentityBindings(db, subject)).resolves.toEqual(
+      identityBindingsBefore,
+    );
+  }
+}
+
+async function seedProfileMatrixProfile(
+  db: DatabaseInterface,
+  options: { email: string; metaType?: string; tenantId?: string },
+): Promise<string> {
+  const id = randomUUID();
+  await db.query(
+    `INSERT INTO profiles
+      (id, slug, context, _meta_type, tenant_id, email, email_key, name)
+     VALUES (?, ?, '', ?, ?, ?, ?, 'Matrix Profile')`,
+    id,
+    `matrix-${id}`,
+    options.metaType ?? '@happyvertical/smrt-profiles:Person',
+    options.tenantId ?? null,
+    options.email,
+    options.email.trim().toLowerCase(),
+  );
+  return id;
+}
+
+async function seedProfileMatrixIdentity(
+  db: DatabaseInterface,
+  profileId: string,
+  email: string,
+  subject: string,
+  legacy: boolean,
+): Promise<string> {
+  const id = randomUUID();
+  await db.query(
+    `INSERT INTO oidc_identities
+      (id, slug, context, profile_id, provider, issuer, subject, identity_key, email)
+     VALUES (?, ?, '', ?, 'matrix', 'https://issuer.example.com', ?, ?, ?)`,
+    id,
+    `matrix-${id}`,
+    profileId,
+    subject,
+    legacy ? null : JSON.stringify(['https://issuer.example.com', subject]),
+    email,
+  );
+  return id;
+}
+
+async function profileMatrixIdentityBindings(
+  db: DatabaseInterface,
+  subject: string,
+): Promise<Array<{ id: string; profileId: string }>> {
+  const result = await db.query(
+    `SELECT id, profile_id
+     FROM oidc_identities
+     WHERE issuer = ? AND subject = ?
+     ORDER BY id`,
+    'https://issuer.example.com',
+    subject,
+  );
+  return result.rows.map((row) => ({
+    id: String(row.id),
+    profileId: String(row.profile_id),
+  }));
+}
+
+async function profileMatrixRowCounts(
+  db: DatabaseInterface,
+): Promise<{ profile: number; oidcIdentity: number }> {
+  const [profile, oidcIdentity] = await Promise.all([
+    countRows(db, 'profiles'),
+    countRows(db, 'oidc_identities'),
+  ]);
+  return { profile, oidcIdentity };
+}
+
+async function expectProfileMatrixRowDelta(
+  db: DatabaseInterface,
+  before: { profile: number; oidcIdentity: number },
+  expected: OidcProvisioningSurfaceExpectation | undefined,
+): Promise<void> {
+  if (!expected) throw new Error('Missing Profiles matrix expectation.');
+  const after = await profileMatrixRowCounts(db);
+  expect({
+    profile: after.profile - before.profile,
+    oidcIdentity: after.oidcIdentity - before.oidcIdentity,
+    user: 0,
+    session: 0,
+  }).toEqual(expected.createdRows);
+}
+
+async function collectProfileMatrixPromise(
+  promise: Promise<ProfileMatrixResult>,
+  values: ProfileMatrixResult[],
+  errors: unknown[],
+): Promise<void> {
+  try {
+    values.push(await promise);
+  } catch (error) {
+    errors.push(error);
+  }
+}
+
+function collectProfileMatrixSettled(
+  results: PromiseSettledResult<ProfileMatrixResult>[],
+  values: ProfileMatrixResult[],
+  errors: unknown[],
+): void {
+  for (const result of results) {
+    if (result.status === 'fulfilled') values.push(result.value);
+    else errors.push(result.reason);
+  }
+}
+
+function expectProfileMatrixOutcome(
+  expected: OidcProvisioningSurfaceExpectation,
+  values: ProfileMatrixResult[],
+  errors: unknown[],
+): void {
+  if (expected.outcome === 'success') {
+    expect(values.length).toBeGreaterThan(0);
+    expect(errors).toHaveLength(0);
+  } else {
+    expect(values).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+  }
+  for (const error of errors) {
+    expectProfileMatrixPublicError(error, expected.publicError);
+  }
+}
+
+function expectProfileMatrixCreatedResult(
+  expected: OidcProvisioningSurfaceExpectation,
+  values: ProfileMatrixResult[],
+): void {
+  const created = values.map((value) => value.created);
+  if (expected.resultCreated === 'none') expect(created).toHaveLength(0);
+  else if (expected.resultCreated === 'created') {
+    expect(created.every(Boolean)).toBe(true);
+  } else if (expected.resultCreated === 'reused') {
+    expect(created.every((value) => !value)).toBe(true);
+  } else {
+    expect(created).toContain(true);
+    expect(created).toContain(false);
+  }
+}
+
+function expectProfileMatrixPublicError(
+  error: unknown,
+  publicError: OidcProvisioningSurfaceExpectation['publicError'],
+): void {
+  expect(publicError).not.toBeNull();
+  if (!publicError) return;
+  if ('code' in publicError) {
+    expect(error).toEqual(expect.objectContaining({ code: publicError.code }));
+  } else if ('name' in publicError) {
+    expect(error).toEqual(expect.objectContaining({ name: publicError.name }));
+  } else {
+    expect(error).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining(publicError.messageIncludes),
+      }),
+    );
+  }
+}
+
+async function expectProfileMatrixRejection(
+  promise: Promise<unknown>,
+  publicError: OidcProvisioningSurfaceExpectation['publicError'],
+): Promise<void> {
+  try {
+    await promise;
+  } catch (error) {
+    expectProfileMatrixPublicError(error, publicError);
+    return;
+  }
+  throw new Error('Expected OIDC Profile provisioning to reject.');
+}
 
 function withIdentityLookupObserver(
   db: DatabaseInterface,

--- a/packages/profiles/src/testing/oidcProvisioningDecisionMatrix.ts
+++ b/packages/profiles/src/testing/oidcProvisioningDecisionMatrix.ts
@@ -1,0 +1,912 @@
+/**
+ * Canonical executable contract for Profile and User OIDC provisioning.
+ *
+ * The Profiles and Users suites execute the applicable rows directly. Public
+ * documentation links here instead of maintaining a second behavioral table.
+ */
+
+export type OidcProvisioningIdentityState =
+  | 'none'
+  | 'exact_global_person'
+  | 'exact_legacy_tenant_profile'
+  | 'exact_legacy_non_person_profile'
+  | 'exact_ambiguous_legacy_links'
+  | 'exact_missing_profile';
+
+export type OidcProvisioningEmailState =
+  | 'missing'
+  | 'no_match'
+  | 'one_unowned_global_person'
+  | 'tenant_scoped_collision'
+  | 'non_person_collision'
+  | 'duplicate_normalized_profiles'
+  | 'already_owned_global_person'
+  | 'different_global_person';
+
+export type OidcProvisioningVerificationState =
+  | 'verified'
+  | 'unverified'
+  | 'claim_missing';
+
+export type OidcProvisioningResolverResult =
+  | 'absent'
+  | 'undefined'
+  | 'null'
+  | 'same_profile'
+  | 'different_profile'
+  | 'owned_profile'
+  | 'throws';
+
+export type OidcProvisioningExecutionState =
+  | 'first_callback'
+  | 'exact_subsequent_callback'
+  | 'concurrent_winner_and_observer'
+  | 'concurrent_email_competitors'
+  | 'durable_arbiter_retry'
+  | 'caller_owned_transaction'
+  | 'root_transaction_rollback'
+  | 'duckdb_caller_owned_transaction';
+
+export type OidcProvisioningPublicErrorCode =
+  | 'ambiguous_email'
+  | 'ambiguous_identity'
+  | 'email_key_backfill_required'
+  | 'missing_profile'
+  | 'non_person'
+  | 'profile_owned'
+  | 'rejected'
+  | 'tenant_scoped'
+  | 'transaction_required'
+  | 'user_email_backfill_required'
+  | null;
+
+export type OidcProvisioningPublicError =
+  | { code: Exclude<OidcProvisioningPublicErrorCode, null> }
+  | { messageIncludes: string }
+  | { name: string }
+  | null;
+
+export type OidcProvisioningSelectedProfile =
+  | 'new_profile'
+  | 'email_match'
+  | 'exact_identity_profile'
+  | 'resolver_profile'
+  | 'concurrent_winner'
+  | null;
+
+export type OidcProvisioningReadiness =
+  | 'none'
+  | 'profile_email_keys'
+  | 'profile_and_user_email_keys';
+
+export interface OidcProvisioningCreatedRows {
+  profile: number;
+  oidcIdentity: number;
+  user: number;
+  session: number;
+}
+
+export interface OidcProvisioningSurfaceExpectation {
+  outcome: 'success' | 'rejected' | 'mixed';
+  publicError: OidcProvisioningPublicError;
+  selectedProfile: OidcProvisioningSelectedProfile;
+  resolverCalls: number | 'at_least_2';
+  /** Exact issuer/subject authority is never rebindable. */
+  rebindAllowed: false;
+  /** Backfill marker state installed by the runner for this surface. */
+  readiness: OidcProvisioningReadiness;
+  retry: 'none' | 'once_after_race';
+  resultCreated: 'created' | 'reused' | 'created_and_reused' | 'none';
+  createdRows: OidcProvisioningCreatedRows;
+}
+
+export type OidcProvisioningAdapterStatus =
+  | 'required'
+  | 'sqlite_parity'
+  | 'root_serialized'
+  | 'not_applicable'
+  | 'unsupported';
+
+export interface OidcProvisioningAdapterExpectation {
+  status: OidcProvisioningAdapterStatus;
+  invariant?: string;
+}
+
+export interface OidcProvisioningScenario {
+  id: string;
+  title: string;
+  identity: OidcProvisioningIdentityState;
+  email: OidcProvisioningEmailState;
+  verification: OidcProvisioningVerificationState;
+  resolver: OidcProvisioningResolverResult;
+  execution: OidcProvisioningExecutionState;
+  adapters: {
+    sqlite: OidcProvisioningAdapterExpectation;
+    postgres: OidcProvisioningAdapterExpectation;
+    duckdb: OidcProvisioningAdapterExpectation;
+  };
+  expectations: {
+    profiles?: OidcProvisioningSurfaceExpectation;
+    users?: OidcProvisioningSurfaceExpectation;
+  };
+}
+
+const ROOT_ADAPTERS = {
+  sqlite: { status: 'required' },
+  postgres: { status: 'sqlite_parity' },
+  duckdb: {
+    status: 'root_serialized',
+    invariant:
+      'DuckDB provisioning is supported through a root database and is serialized per database URL.',
+  },
+} as const satisfies OidcProvisioningScenario['adapters'];
+
+const POSTGRES_SENSITIVE_ADAPTERS = {
+  sqlite: { status: 'required' },
+  postgres: { status: 'required' },
+  duckdb: {
+    status: 'root_serialized',
+    invariant:
+      'DuckDB uses root-handle serialization instead of overlapping independent transactions.',
+  },
+} as const satisfies OidcProvisioningScenario['adapters'];
+
+const CALLER_TRANSACTION_ADAPTERS = {
+  sqlite: { status: 'required' },
+  postgres: { status: 'required' },
+  duckdb: {
+    status: 'unsupported',
+    invariant:
+      'DuckDB transaction handles do not support the savepoint contract; pass the root database.',
+  },
+} as const satisfies OidcProvisioningScenario['adapters'];
+
+const DUCKDB_CALLER_TRANSACTION_ADAPTERS = {
+  sqlite: { status: 'not_applicable' },
+  postgres: { status: 'not_applicable' },
+  duckdb: {
+    status: 'required',
+    invariant:
+      'DuckDB transaction handles fail closed before provisioning writes and leave the caller transaction usable.',
+  },
+} as const satisfies OidcProvisioningScenario['adapters'];
+
+const noRows = (): OidcProvisioningCreatedRows => ({
+  profile: 0,
+  oidcIdentity: 0,
+  user: 0,
+  session: 0,
+});
+
+function expectation(
+  overrides: Partial<OidcProvisioningSurfaceExpectation> = {},
+): OidcProvisioningSurfaceExpectation {
+  const expectation: OidcProvisioningSurfaceExpectation = {
+    outcome: 'success',
+    publicError: null,
+    selectedProfile: 'new_profile',
+    resolverCalls: 0,
+    rebindAllowed: false,
+    readiness: 'none',
+    retry: 'none',
+    resultCreated: 'created',
+    createdRows: noRows(),
+    ...overrides,
+  };
+  if (
+    overrides.resultCreated === undefined &&
+    expectation.outcome === 'rejected'
+  ) {
+    expectation.resultCreated = 'none';
+  }
+  return expectation;
+}
+
+/**
+ * Typed scenario table consumed by both package suites.
+ *
+ * Row counts are deltas from the declared fixture state. A rejected row always
+ * declares zero User and session creation; the runners assert every delta.
+ */
+export const OIDC_PROVISIONING_DECISION_MATRIX = [
+  {
+    id: 'new-verified-no-match',
+    title: 'verified first callback creates a new canonical identity',
+    identity: 'none',
+    email: 'no_match',
+    verification: 'verified',
+    resolver: 'absent',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        readiness: 'profile_email_keys',
+        createdRows: { ...noRows(), profile: 1, oidcIdentity: 1 },
+      }),
+      users: expectation({
+        readiness: 'profile_and_user_email_keys',
+        createdRows: {
+          profile: 1,
+          oidcIdentity: 1,
+          user: 1,
+          session: 0,
+        },
+      }),
+    },
+  },
+  {
+    id: 'new-missing-email',
+    title:
+      'Profile-only provisioning allows a missing email while Users reject',
+    identity: 'none',
+    email: 'missing',
+    verification: 'claim_missing',
+    resolver: 'absent',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        createdRows: { ...noRows(), profile: 1, oidcIdentity: 1 },
+      }),
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { messageIncludes: 'missing required "email"' },
+        selectedProfile: null,
+      }),
+    },
+  },
+  {
+    id: 'new-unverified-no-match',
+    title:
+      'Profile-only provisioning isolates an unverified email while Users reject',
+    identity: 'none',
+    email: 'no_match',
+    verification: 'unverified',
+    resolver: 'absent',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        readiness: 'profile_email_keys',
+        createdRows: { ...noRows(), profile: 1, oidcIdentity: 1 },
+      }),
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { messageIncludes: 'unverified email' },
+        selectedProfile: null,
+      }),
+    },
+  },
+  {
+    id: 'new-unverified-email-match',
+    title: 'an unverified email never reuses an existing Profile',
+    identity: 'none',
+    email: 'one_unowned_global_person',
+    verification: 'unverified',
+    resolver: 'absent',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        outcome: 'rejected',
+        publicError: { messageIncludes: 'not verified' },
+        selectedProfile: null,
+        readiness: 'profile_email_keys',
+      }),
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { messageIncludes: 'unverified email' },
+        selectedProfile: null,
+      }),
+    },
+  },
+  {
+    id: 'new-verified-email-match',
+    title: 'only owner-aware User provisioning may reuse a safe email match',
+    identity: 'none',
+    email: 'one_unowned_global_person',
+    verification: 'verified',
+    resolver: 'absent',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        outcome: 'rejected',
+        publicError: {
+          messageIncludes: 'cannot prove that Profile is unowned',
+        },
+        selectedProfile: null,
+        readiness: 'profile_email_keys',
+      }),
+      users: expectation({
+        selectedProfile: 'email_match',
+        readiness: 'profile_and_user_email_keys',
+        resultCreated: 'reused',
+        createdRows: { ...noRows(), oidcIdentity: 1, user: 1 },
+      }),
+    },
+  },
+  {
+    id: 'new-verified-tenant-collision',
+    title: 'tenant-scoped email collisions fail closed',
+    identity: 'none',
+    email: 'tenant_scoped_collision',
+    verification: 'verified',
+    resolver: 'absent',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'tenant_scoped' },
+        selectedProfile: null,
+        readiness: 'profile_email_keys',
+      }),
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'tenant_scoped' },
+        selectedProfile: null,
+        readiness: 'profile_email_keys',
+      }),
+    },
+  },
+  {
+    id: 'new-verified-non-person-collision',
+    title: 'non-Person email collisions fail closed',
+    identity: 'none',
+    email: 'non_person_collision',
+    verification: 'verified',
+    resolver: 'absent',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'non_person' },
+        selectedProfile: null,
+        readiness: 'profile_email_keys',
+      }),
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'non_person' },
+        selectedProfile: null,
+        readiness: 'profile_email_keys',
+      }),
+    },
+  },
+  {
+    id: 'new-verified-duplicate-email',
+    title: 'duplicate normalized Profile emails fail closed',
+    identity: 'none',
+    email: 'duplicate_normalized_profiles',
+    verification: 'verified',
+    resolver: 'absent',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'ambiguous_email' },
+        selectedProfile: null,
+        readiness: 'profile_email_keys',
+      }),
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'ambiguous_email' },
+        selectedProfile: null,
+        readiness: 'profile_email_keys',
+      }),
+    },
+  },
+  {
+    id: 'new-verified-owned-profile',
+    title: 'an already-owned email match cannot acquire another identity',
+    identity: 'none',
+    email: 'already_owned_global_person',
+    verification: 'verified',
+    resolver: 'absent',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'profile_owned' },
+        selectedProfile: null,
+        readiness: 'profile_email_keys',
+      }),
+    },
+  },
+  {
+    id: 'exact-safe-owned',
+    title: 'an exact safe identity reuses its canonical Profile and User',
+    identity: 'exact_global_person',
+    email: 'already_owned_global_person',
+    verification: 'verified',
+    resolver: 'absent',
+    execution: 'exact_subsequent_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        selectedProfile: 'exact_identity_profile',
+        resultCreated: 'reused',
+      }),
+      users: expectation({
+        selectedProfile: 'exact_identity_profile',
+        readiness: 'profile_email_keys',
+        resultCreated: 'reused',
+      }),
+    },
+  },
+  {
+    id: 'exact-safe-unowned',
+    title: 'an exact safe identity without an owner may create one User',
+    identity: 'exact_global_person',
+    email: 'one_unowned_global_person',
+    verification: 'verified',
+    resolver: 'absent',
+    execution: 'exact_subsequent_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        selectedProfile: 'exact_identity_profile',
+        resultCreated: 'reused',
+      }),
+      users: expectation({
+        selectedProfile: 'exact_identity_profile',
+        readiness: 'profile_and_user_email_keys',
+        resultCreated: 'reused',
+        createdRows: { ...noRows(), user: 1 },
+      }),
+    },
+  },
+  {
+    id: 'exact-legacy-tenant-profile',
+    title: 'Profile-only legacy exact reuse succeeds while Users fail closed',
+    identity: 'exact_legacy_tenant_profile',
+    email: 'tenant_scoped_collision',
+    verification: 'verified',
+    resolver: 'absent',
+    execution: 'exact_subsequent_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        selectedProfile: 'exact_identity_profile',
+        resultCreated: 'reused',
+      }),
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'tenant_scoped' },
+        selectedProfile: null,
+        readiness: 'profile_email_keys',
+      }),
+    },
+  },
+  {
+    id: 'exact-legacy-non-person-profile',
+    title:
+      'Profile-only non-Person exact reuse succeeds while Users fail closed',
+    identity: 'exact_legacy_non_person_profile',
+    email: 'non_person_collision',
+    verification: 'verified',
+    resolver: 'absent',
+    execution: 'exact_subsequent_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        selectedProfile: 'exact_identity_profile',
+        resultCreated: 'reused',
+      }),
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'non_person' },
+        selectedProfile: null,
+        readiness: 'profile_email_keys',
+      }),
+    },
+  },
+  {
+    id: 'exact-ambiguous-legacy-links',
+    title: 'ambiguous legacy exact identities fail closed',
+    identity: 'exact_ambiguous_legacy_links',
+    email: 'one_unowned_global_person',
+    verification: 'verified',
+    resolver: 'absent',
+    execution: 'exact_subsequent_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        outcome: 'rejected',
+        publicError: { name: 'AmbiguousOidcIdentityError' },
+        selectedProfile: null,
+      }),
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'ambiguous_identity' },
+        selectedProfile: null,
+      }),
+    },
+  },
+  {
+    id: 'exact-missing-profile',
+    title: 'an exact identity with a missing Profile fails closed',
+    identity: 'exact_missing_profile',
+    email: 'no_match',
+    verification: 'verified',
+    resolver: 'absent',
+    execution: 'exact_subsequent_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        outcome: 'rejected',
+        publicError: {
+          messageIncludes: 'provisioning result was not found',
+        },
+        selectedProfile: null,
+      }),
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'missing_profile' },
+        selectedProfile: null,
+        readiness: 'profile_email_keys',
+      }),
+    },
+  },
+  {
+    id: 'resolver-undefined-new',
+    title: 'undefined resolver output selects the secure default',
+    identity: 'none',
+    email: 'no_match',
+    verification: 'verified',
+    resolver: 'undefined',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      users: expectation({
+        resolverCalls: 1,
+        readiness: 'profile_and_user_email_keys',
+        createdRows: {
+          profile: 1,
+          oidcIdentity: 1,
+          user: 1,
+          session: 0,
+        },
+      }),
+    },
+  },
+  {
+    id: 'resolver-null-new',
+    title: 'null resolver output rejects before provisioning',
+    identity: 'none',
+    email: 'no_match',
+    verification: 'verified',
+    resolver: 'null',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'rejected' },
+        selectedProfile: null,
+        resolverCalls: 1,
+      }),
+    },
+  },
+  {
+    id: 'resolver-same-new',
+    title:
+      'a resolver may select the same safe canonical Profile for a new identity',
+    identity: 'none',
+    email: 'one_unowned_global_person',
+    verification: 'verified',
+    resolver: 'same_profile',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      users: expectation({
+        selectedProfile: 'resolver_profile',
+        resolverCalls: 1,
+        readiness: 'profile_and_user_email_keys',
+        resultCreated: 'reused',
+        createdRows: { ...noRows(), oidcIdentity: 1, user: 1 },
+      }),
+    },
+  },
+  {
+    id: 'resolver-owned-new',
+    title: 'a resolver-selected owned Profile fails closed',
+    identity: 'none',
+    email: 'already_owned_global_person',
+    verification: 'verified',
+    resolver: 'owned_profile',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'profile_owned' },
+        selectedProfile: null,
+        resolverCalls: 1,
+        readiness: 'profile_email_keys',
+      }),
+    },
+  },
+  {
+    id: 'resolver-same-exact',
+    title: 'a resolver may confirm but not rebind an exact identity',
+    identity: 'exact_global_person',
+    email: 'already_owned_global_person',
+    verification: 'verified',
+    resolver: 'same_profile',
+    execution: 'exact_subsequent_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      users: expectation({
+        selectedProfile: 'exact_identity_profile',
+        resolverCalls: 1,
+        readiness: 'profile_email_keys',
+        resultCreated: 'reused',
+      }),
+    },
+  },
+  {
+    id: 'resolver-different-exact',
+    title: 'a resolver cannot rebind an exact identity to a different Profile',
+    identity: 'exact_global_person',
+    email: 'different_global_person',
+    verification: 'verified',
+    resolver: 'different_profile',
+    execution: 'exact_subsequent_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'rejected' },
+        selectedProfile: null,
+        resolverCalls: 1,
+      }),
+    },
+  },
+  {
+    id: 'resolver-null-exact',
+    title: 'null resolver output rejects exact identity reuse',
+    identity: 'exact_global_person',
+    email: 'already_owned_global_person',
+    verification: 'verified',
+    resolver: 'null',
+    execution: 'exact_subsequent_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'rejected' },
+        selectedProfile: null,
+        resolverCalls: 1,
+      }),
+    },
+  },
+  {
+    id: 'resolver-throws-new',
+    title: 'resolver exceptions roll back without authentication state',
+    identity: 'none',
+    email: 'no_match',
+    verification: 'verified',
+    resolver: 'throws',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { messageIncludes: 'matrix resolver failure' },
+        selectedProfile: null,
+        resolverCalls: 1,
+      }),
+    },
+  },
+  {
+    id: 'profile-readiness-missing',
+    title: 'email-based lookup fails until Profile email keys are ready',
+    identity: 'none',
+    email: 'one_unowned_global_person',
+    verification: 'verified',
+    resolver: 'absent',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'email_key_backfill_required' },
+        selectedProfile: null,
+      }),
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'email_key_backfill_required' },
+        selectedProfile: null,
+      }),
+    },
+  },
+  {
+    id: 'user-readiness-missing',
+    title: 'User creation fails until User email keys are ready',
+    identity: 'none',
+    email: 'no_match',
+    verification: 'verified',
+    resolver: 'absent',
+    execution: 'first_callback',
+    adapters: ROOT_ADAPTERS,
+    expectations: {
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'user_email_backfill_required' },
+        selectedProfile: null,
+        readiness: 'profile_email_keys',
+      }),
+    },
+  },
+  {
+    id: 'concurrent-winner-and-observer',
+    title: 'both concurrent callbacks run policy and converge on the winner',
+    identity: 'none',
+    email: 'no_match',
+    verification: 'verified',
+    resolver: 'undefined',
+    execution: 'concurrent_winner_and_observer',
+    adapters: POSTGRES_SENSITIVE_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        selectedProfile: 'concurrent_winner',
+        readiness: 'profile_email_keys',
+        resultCreated: 'created_and_reused',
+        createdRows: { ...noRows(), profile: 1, oidcIdentity: 1 },
+      }),
+      users: expectation({
+        selectedProfile: 'concurrent_winner',
+        resolverCalls: 'at_least_2',
+        readiness: 'profile_and_user_email_keys',
+        resultCreated: 'created_and_reused',
+        createdRows: {
+          profile: 1,
+          oidcIdentity: 1,
+          user: 1,
+          session: 0,
+        },
+      }),
+    },
+  },
+  {
+    id: 'concurrent-email-competitors',
+    title: 'only one concurrent subject may claim a verified email',
+    identity: 'none',
+    email: 'no_match',
+    verification: 'verified',
+    resolver: 'undefined',
+    execution: 'concurrent_email_competitors',
+    adapters: POSTGRES_SENSITIVE_ADAPTERS,
+    expectations: {
+      users: expectation({
+        outcome: 'mixed',
+        publicError: { code: 'profile_owned' },
+        selectedProfile: 'concurrent_winner',
+        resolverCalls: 'at_least_2',
+        readiness: 'profile_and_user_email_keys',
+        createdRows: {
+          profile: 1,
+          oidcIdentity: 1,
+          user: 1,
+          session: 0,
+        },
+      }),
+    },
+  },
+  {
+    id: 'resolver-durable-arbiter-retry',
+    title: 'a durable race retry invokes the idempotent resolver again',
+    identity: 'none',
+    email: 'no_match',
+    verification: 'verified',
+    resolver: 'undefined',
+    execution: 'durable_arbiter_retry',
+    adapters: POSTGRES_SENSITIVE_ADAPTERS,
+    expectations: {
+      users: expectation({
+        resolverCalls: 2,
+        readiness: 'profile_and_user_email_keys',
+        retry: 'once_after_race',
+        createdRows: {
+          profile: 1,
+          oidcIdentity: 1,
+          user: 1,
+          session: 0,
+        },
+      }),
+    },
+  },
+  {
+    id: 'caller-owned-transaction',
+    title: 'caller-owned transactions use a savepoint where supported',
+    identity: 'none',
+    email: 'no_match',
+    verification: 'verified',
+    resolver: 'undefined',
+    execution: 'caller_owned_transaction',
+    adapters: CALLER_TRANSACTION_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        readiness: 'profile_email_keys',
+        createdRows: { ...noRows(), profile: 1, oidcIdentity: 1 },
+      }),
+      users: expectation({
+        resolverCalls: 1,
+        readiness: 'profile_and_user_email_keys',
+        createdRows: {
+          profile: 1,
+          oidcIdentity: 1,
+          user: 1,
+          session: 0,
+        },
+      }),
+    },
+  },
+  {
+    id: 'root-transaction-resolver-rollback',
+    title: 'root coordination rolls resolver rejection back atomically',
+    identity: 'none',
+    email: 'no_match',
+    verification: 'verified',
+    resolver: 'null',
+    execution: 'root_transaction_rollback',
+    adapters: POSTGRES_SENSITIVE_ADAPTERS,
+    expectations: {
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'rejected' },
+        selectedProfile: null,
+        resolverCalls: 1,
+      }),
+    },
+  },
+  {
+    id: 'duckdb-caller-owned-transaction',
+    title: 'DuckDB caller-owned transactions fail closed and remain usable',
+    identity: 'none',
+    email: 'no_match',
+    verification: 'verified',
+    resolver: 'absent',
+    execution: 'duckdb_caller_owned_transaction',
+    adapters: DUCKDB_CALLER_TRANSACTION_ADAPTERS,
+    expectations: {
+      profiles: expectation({
+        outcome: 'rejected',
+        publicError: { messageIncludes: 'root database' },
+        selectedProfile: null,
+      }),
+      users: expectation({
+        outcome: 'rejected',
+        publicError: { code: 'transaction_required' },
+        selectedProfile: null,
+      }),
+    },
+  },
+] as const satisfies readonly OidcProvisioningScenario[];
+
+export type OidcProvisioningDecisionScenario =
+  (typeof OIDC_PROVISIONING_DECISION_MATRIX)[number];
+
+export function getOidcProvisioningDecisionScenario(
+  id: OidcProvisioningDecisionScenario['id'],
+): OidcProvisioningDecisionScenario {
+  const scenario = OIDC_PROVISIONING_DECISION_MATRIX.find(
+    (candidate) => candidate.id === id,
+  );
+  if (!scenario) throw new Error(`Unknown OIDC provisioning scenario: ${id}`);
+  return scenario;
+}
+
+export function getOidcProvisioningPublicErrorCode(
+  expectation: OidcProvisioningSurfaceExpectation | undefined,
+): Exclude<OidcProvisioningPublicErrorCode, null> {
+  const publicError = expectation?.publicError;
+  if (!publicError || !('code' in publicError)) {
+    throw new Error('The OIDC provisioning scenario has no public error code.');
+  }
+  return publicError.code;
+}

--- a/packages/users/AGENTS.md
+++ b/packages/users/AGENTS.md
@@ -240,8 +240,12 @@ the package root).
   refuses to provision a user when the IdP explicitly returns
   `email_verified: false` (opt out with `{ allowUnverifiedEmail: true }`). An
   absent claim makes no assertion and is not enforced.
-- **Verified-email Profile reuse is fail-closed.** Default provisioning reuses
-  only one unowned, global `Person`. Tenant-scoped, non-Person, duplicate-email,
+- **Verified-email Profile reuse is fail-closed.** The typed canonical scenarios
+  live in
+  `packages/profiles/src/testing/oidcProvisioningDecisionMatrix.ts`; both
+  package suites execute that matrix and public docs reference it rather than
+  maintaining another behavioral table. Default provisioning reuses only one
+  unowned, global `Person`. Tenant-scoped, non-Person, duplicate-email,
   and already-owned matches fail before User/session creation. An existing
   issuer/subject link without a User must still be the unique global Person for
   the current verified claim email; once owned, the stable issuer/subject link

--- a/packages/users/README.md
+++ b/packages/users/README.md
@@ -374,14 +374,15 @@ can pass `transactionCookieSecret` to the route helpers. On success it creates
 or reuses a SMRT `Profile`, links an `OidcIdentity`, creates or reuses a `User`,
 records `lastLoginAt`, and sets the standard SMRT session cookie.
 
-Verified-email provisioning is fail-closed. The default resolver reuses a
-Profile only when exactly one case-insensitive email match exists and that row
-is an unowned, global `Person`. A tenant-scoped Profile, a non-`Person` STI row,
-duplicate email matches, or a Profile already owned by another `User` rejects
-the callback before User or session creation. An existing OIDC issuer/subject
-link without a User must still identify the unique global `Person` for the
-current verified claim email. Once a User owns it, the stable issuer/subject
-link continues to select its canonical global `Person` and existing User.
+The typed [OIDC provisioning decision matrix](../profiles/src/testing/oidcProvisioningDecisionMatrix.ts)
+is the canonical behavior contract shared with Profiles. Its executable rows
+declare exact reuse and new-identity outcomes, resolver invocation and
+rebinding, ownership/collision failures, readiness, retries, adapter support,
+public errors, and permitted Profile/OIDC identity/User/session creation. For a
+new identity, the Users path is deliberately fail-closed before User or session
+creation unless the selected Profile is the one safe, unowned global `Person`
+allowed by that matrix. An exact issuer/subject link may instead continue to
+its already-owned canonical global `Person`, but it cannot be rebound.
 
 Canonical Profile failures use `CanonicalPersonProfileError` from
 `@happyvertical/smrt-profiles`, with codes `ambiguous_email`, `email_mismatch`,

--- a/packages/users/src/__tests__/oidc-provisioning-postgres.test.ts
+++ b/packages/users/src/__tests__/oidc-provisioning-postgres.test.ts
@@ -544,7 +544,8 @@ describePostgres('Postgres OIDC provisioning concurrency', () => {
     await seedPersonType(fixture.rootDb);
     await fixture.rootDb.query(
       'DELETE FROM _smrt_backfills WHERE name IN (?, ?)',
-      [PROFILE_EMAIL_KEY_BACKFILL_NAME, USER_EMAIL_KEY_BACKFILL_NAME],
+      PROFILE_EMAIL_KEY_BACKFILL_NAME,
+      USER_EMAIL_KEY_BACKFILL_NAME,
     );
     const users = await UserCollection.create({ db: fixture.rootDb });
     let resolverCalls = 0;

--- a/packages/users/src/__tests__/oidc-provisioning-postgres.test.ts
+++ b/packages/users/src/__tests__/oidc-provisioning-postgres.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import {
   backfillProfileEmailKeys,
   createProfileFromOidc,
+  PROFILE_EMAIL_KEY_BACKFILL_NAME,
 } from '@happyvertical/smrt-profiles';
 import {
   getTestDbConfig,
@@ -9,14 +10,43 @@ import {
 } from '@happyvertical/smrt-vitest';
 import { type DatabaseInterface, getDatabase } from '@happyvertical/sql';
 import { afterEach, describe, expect, it } from 'vitest';
+import {
+  getOidcProvisioningDecisionScenario,
+  getOidcProvisioningPublicErrorCode,
+  OIDC_PROVISIONING_DECISION_MATRIX,
+} from '../../../profiles/src/testing/oidcProvisioningDecisionMatrix.js';
 import { UserCollection } from '../collections/UserCollection.js';
-import { backfillUserEmailKeys } from '../migrations/backfillUserEmailKeys.js';
+import {
+  backfillUserEmailKeys,
+  USER_EMAIL_KEY_BACKFILL_NAME,
+} from '../migrations/backfillUserEmailKeys.js';
 import {
   OIDC_USERS_TEST_SCHEMA,
   prepareOidcEmailKeyBackfills,
 } from './helpers/oidc-test-server.js';
 
 const describePostgres = isPostgresAvailable() ? describe : describe.skip;
+const POSTGRES_USER_MATRIX_IDS = OIDC_PROVISIONING_DECISION_MATRIX.filter(
+  (scenario) =>
+    scenario.adapters.postgres.status === 'required' &&
+    scenario.expectations.users !== undefined,
+).map((scenario) => scenario.id);
+const EXECUTED_POSTGRES_USER_MATRIX_IDS = [
+  'concurrent-winner-and-observer',
+  'concurrent-email-competitors',
+  'resolver-durable-arbiter-retry',
+  'caller-owned-transaction',
+  'root-transaction-resolver-rollback',
+] as const;
+const POSTGRES_PROFILE_MATRIX_IDS = OIDC_PROVISIONING_DECISION_MATRIX.filter(
+  (scenario) =>
+    scenario.adapters.postgres.status === 'required' &&
+    scenario.expectations.profiles !== undefined,
+).map((scenario) => scenario.id);
+const EXECUTED_POSTGRES_PROFILE_MATRIX_IDS = [
+  'concurrent-winner-and-observer',
+  'caller-owned-transaction',
+] as const;
 
 describePostgres('Postgres OIDC provisioning concurrency', () => {
   let adminDb: DatabaseInterface | undefined;
@@ -33,7 +63,18 @@ describePostgres('Postgres OIDC provisioning concurrency', () => {
     schemaName = undefined;
   });
 
-  it('converges independent first-login transactions on one identity and User', async () => {
+  it('executes every PostgreSQL-required matrix row for each applicable surface', () => {
+    expect([...EXECUTED_POSTGRES_USER_MATRIX_IDS].sort()).toEqual(
+      [...POSTGRES_USER_MATRIX_IDS].sort(),
+    );
+    expect([...EXECUTED_POSTGRES_PROFILE_MATRIX_IDS].sort()).toEqual(
+      [...POSTGRES_PROFILE_MATRIX_IDS].sort(),
+    );
+  });
+
+  it.each([
+    getOidcProvisioningDecisionScenario('concurrent-winner-and-observer'),
+  ])('$id — $title (Users)', async (scenario) => {
     const fixture = await createFixture();
     await seedPersonType(fixture.rootDb);
 
@@ -81,6 +122,7 @@ describePostgres('Postgres OIDC provisioning concurrency', () => {
       }),
     ]);
 
+    expect(arrivals).toBeGreaterThanOrEqual(2);
     expect(second.profile.id).toBe(first.profile.id);
     expect(second.user.id).toBe(first.user.id);
     expect(second.oidcIdentity.id).toBe(first.oidcIdentity.id);
@@ -96,7 +138,9 @@ describePostgres('Postgres OIDC provisioning concurrency', () => {
     ).resolves.toBe(1);
   });
 
-  it('reinvokes an idempotent resolver after a durable-arbiter retry', async () => {
+  it.each([
+    getOidcProvisioningDecisionScenario('resolver-durable-arbiter-retry'),
+  ])('$id — $title (Users)', async (scenario) => {
     const fixture = await createFixture();
     await seedPersonType(fixture.rootDb);
 
@@ -129,7 +173,7 @@ describePostgres('Postgres OIDC provisioning concurrency', () => {
     );
 
     expect(injectedConflicts).toBe(1);
-    expect(resolverCalls).toBe(2);
+    expect(resolverCalls).toBe(scenario.expectations.users?.resolverCalls);
     expect(result.created).toBe(true);
     await expect(countRows(rootDb, 'profiles')).resolves.toBe(1);
     await expect(countRows(rootDb, 'users')).resolves.toBe(1);
@@ -139,7 +183,9 @@ describePostgres('Postgres OIDC provisioning concurrency', () => {
     ).resolves.toBe(1);
   });
 
-  it('allows only one subject to claim a verified email across independent transactions', async () => {
+  it.each([
+    getOidcProvisioningDecisionScenario('concurrent-email-competitors'),
+  ])('$id — $title (Users)', async (scenario) => {
     const fixture = await createFixture();
     await seedPersonType(fixture.rootDb);
 
@@ -184,7 +230,9 @@ describePostgres('Postgres OIDC provisioning concurrency', () => {
     ).toHaveLength(1);
     expect(results.filter((result) => result.status === 'rejected')).toEqual([
       expect.objectContaining({
-        reason: expect.objectContaining({ code: 'profile_owned' }),
+        reason: expect.objectContaining({
+          code: getOidcProvisioningPublicErrorCode(scenario.expectations.users),
+        }),
       }),
     ]);
     await expect(countRows(firstDb, 'profiles')).resolves.toBe(1);
@@ -388,7 +436,9 @@ describePostgres('Postgres OIDC provisioning concurrency', () => {
     ]);
   });
 
-  it('serializes unrelated provisions on one transaction-bound client', async () => {
+  it.each([
+    getOidcProvisioningDecisionScenario('caller-owned-transaction'),
+  ])('$id — $title (Users)', async (scenario) => {
     const fixture = await createFixture();
     await seedPersonType(fixture.rootDb);
     if (!fixture.rootDb.beginTransaction) {
@@ -396,8 +446,13 @@ describePostgres('Postgres OIDC provisioning concurrency', () => {
     }
     const tx = await fixture.rootDb.beginTransaction();
     let trackerDdl = 0;
+    let resolverCalls = 0;
     const observeTrackerDdl = (sql: string) => {
       if (/create\s+table[\s\S]*_smrt_backfills/iu.test(sql)) trackerDdl += 1;
+    };
+    const resolver = async () => {
+      resolverCalls += 1;
+      return undefined;
     };
 
     try {
@@ -416,6 +471,7 @@ describePostgres('Postgres OIDC provisioning concurrency', () => {
             sub: 'outer-first-subject',
           },
           'dex',
+          { resolveProfile: resolver },
         ),
         secondUsers.getOrCreateFromOidc(
           {
@@ -425,6 +481,7 @@ describePostgres('Postgres OIDC provisioning concurrency', () => {
             sub: 'outer-second-subject',
           },
           'dex',
+          { resolveProfile: resolver },
         ),
       ]);
 
@@ -435,9 +492,98 @@ describePostgres('Postgres OIDC provisioning concurrency', () => {
       });
       expect(tx.isActive()).toBe(true);
       expect(trackerDdl).toBe(0);
+      expect(resolverCalls).toBe(
+        (scenario.expectations.users?.resolverCalls ?? 0) * 2,
+      );
+      expect(await countRows(tx, 'users')).toBe(
+        (scenario.expectations.users?.createdRows.user ?? 0) * 2,
+      );
     } finally {
       if (tx.isActive()) await tx.rollback();
     }
+  });
+
+  it.each([
+    getOidcProvisioningDecisionScenario('caller-owned-transaction'),
+  ])('$id — $title (Profiles)', async (scenario) => {
+    const fixture = await createFixture();
+    await seedPersonType(fixture.rootDb);
+    if (!fixture.rootDb.beginTransaction) {
+      throw new Error('Expected PostgreSQL manual transaction support.');
+    }
+    const tx = await fixture.rootDb.beginTransaction();
+    try {
+      const result = await createProfileFromOidc(
+        {
+          email: 'postgres-profile-caller@example.com',
+          email_verified: true,
+          iss: 'https://issuer.example.com',
+          sub: 'postgres-profile-caller-subject',
+        },
+        'dex',
+        { db: tx },
+      );
+
+      expect(result.created).toBe(true);
+      expect(tx.isActive()).toBe(true);
+      await expect(countRows(tx, 'profiles')).resolves.toBe(
+        scenario.expectations.profiles?.createdRows.profile,
+      );
+      await expect(countRows(tx, 'oidc_identities')).resolves.toBe(
+        scenario.expectations.profiles?.createdRows.oidcIdentity,
+      );
+    } finally {
+      if (tx.isActive()) await tx.rollback();
+    }
+  });
+
+  it.each([
+    getOidcProvisioningDecisionScenario('root-transaction-resolver-rollback'),
+  ])('$id — $title (Users)', async (scenario) => {
+    const fixture = await createFixture();
+    await seedPersonType(fixture.rootDb);
+    await fixture.rootDb.query(
+      'DELETE FROM _smrt_backfills WHERE name IN (?, ?)',
+      [PROFILE_EMAIL_KEY_BACKFILL_NAME, USER_EMAIL_KEY_BACKFILL_NAME],
+    );
+    const users = await UserCollection.create({ db: fixture.rootDb });
+    let resolverCalls = 0;
+    const probeProfileId = randomUUID();
+
+    await expect(
+      users.getOrCreateFromOidc(
+        {
+          email: 'postgres-root-rollback@example.com',
+          email_verified: true,
+          iss: 'https://issuer.example.com',
+          sub: 'postgres-root-rollback-subject',
+        },
+        'dex',
+        {
+          resolveProfile: async ({ db: tx }) => {
+            resolverCalls += 1;
+            await tx.query(
+              `INSERT INTO profiles
+                (id, slug, context, _meta_type, tenant_id, email, email_key, name)
+               VALUES (?, ?, '', '@happyvertical/smrt-profiles:Person', NULL, ?, ?, 'Rollback Probe')`,
+              probeProfileId,
+              `rollback-probe-${probeProfileId}`,
+              'rollback-probe@example.com',
+              'rollback-probe@example.com',
+            );
+            return null;
+          },
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: getOidcProvisioningPublicErrorCode(scenario.expectations.users),
+    });
+
+    expect(resolverCalls).toBe(scenario.expectations.users?.resolverCalls);
+    await expect(countRows(fixture.rootDb, 'profiles')).resolves.toBe(0);
+    await expect(countRows(fixture.rootDb, 'oidc_identities')).resolves.toBe(0);
+    await expect(countRows(fixture.rootDb, 'users')).resolves.toBe(0);
+    await expect(countRows(fixture.rootDb, 'sessions')).resolves.toBe(0);
   });
 
   it('reinitializes dropped backfill state on the same root before provisioning', async () => {
@@ -467,7 +613,9 @@ describePostgres('Postgres OIDC provisioning concurrency', () => {
     await expect(countRows(fixture.rootDb, 'users')).resolves.toBe(1);
   });
 
-  it('converges public Profile helper calls across independent transactions', async () => {
+  it.each([
+    getOidcProvisioningDecisionScenario('concurrent-winner-and-observer'),
+  ])('$id — $title (Profiles)', async (scenario) => {
     const fixture = await createFixture();
     await seedPersonType(fixture.rootDb);
 
@@ -511,6 +659,7 @@ describePostgres('Postgres OIDC provisioning concurrency', () => {
     await expect(
       countRows(firstDb, 'oidc_profile_email_reservations'),
     ).resolves.toBe(1);
+    expect(scenario.expectations.profiles?.createdRows.profile).toBe(1);
   });
 
   it('creates one stable Person type during unseeded independent logins', async () => {
@@ -630,6 +779,7 @@ async function countRows(
     | 'oidc_identities'
     | 'oidc_profile_email_reservations'
     | 'profiles'
+    | 'sessions'
     | 'users',
 ): Promise<number> {
   const result = await db.query(`SELECT count(*) AS count FROM ${table}`);

--- a/packages/users/src/__tests__/oidc-provisioning-safety.test.ts
+++ b/packages/users/src/__tests__/oidc-provisioning-safety.test.ts
@@ -13,6 +13,13 @@ import {
 import { getDatabase, syncSchema } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  getOidcProvisioningDecisionScenario,
+  getOidcProvisioningPublicErrorCode,
+  OIDC_PROVISIONING_DECISION_MATRIX,
+  type OidcProvisioningScenario,
+  type OidcProvisioningSurfaceExpectation,
+} from '../../../profiles/src/testing/oidcProvisioningDecisionMatrix.js';
+import {
   type OidcClaims,
   type OidcProvisioningError,
   UserCollection,
@@ -24,6 +31,12 @@ import {
 
 const PERSON_META_TYPE = '@happyvertical/smrt-profiles:Person';
 const ORGANIZATION_META_TYPE = '@happyvertical/smrt-profiles:Organization';
+const USER_MATRIX_SCENARIOS: readonly OidcProvisioningScenario[] =
+  OIDC_PROVISIONING_DECISION_MATRIX.filter(
+    (scenario) =>
+      scenario.adapters.sqlite.status === 'required' &&
+      scenario.expectations.users !== undefined,
+  );
 
 describe('safe OIDC provisioning', () => {
   let isolated: IsolatedTestDbResult;
@@ -39,6 +52,25 @@ describe('safe OIDC provisioning', () => {
 
   afterEach(async () => {
     await isolated.cleanup();
+  });
+
+  describe('executable decision matrix (SQLite)', () => {
+    it.each(USER_MATRIX_SCENARIOS)('$id — $title', async (scenario) => {
+      if (
+        scenario.execution === 'concurrent_winner_and_observer' ||
+        scenario.execution === 'concurrent_email_competitors' ||
+        scenario.execution === 'durable_arbiter_retry' ||
+        scenario.execution === 'caller_owned_transaction' ||
+        scenario.execution === 'root_transaction_rollback'
+      ) {
+        await isolated.db.rollback();
+        db = isolated.baseDb;
+        await prepareOidcEmailKeyBackfills(db);
+        users = await UserCollection.create({ db });
+      }
+
+      await runUserMatrixScenario({ db, scenario, users });
+    });
   });
 
   it('reuses one unowned global Person for a verified email', async () => {
@@ -1098,11 +1130,15 @@ describe('safe OIDC provisioning', () => {
     await expectNoProvisioningWrites(db, 0);
   });
 
-  it('fails closed on a DuckDB manual transaction without corrupting it', async () => {
+  it.each([
+    getOidcProvisioningDecisionScenario('duckdb-caller-owned-transaction'),
+  ])('$id — $title (Users manual transaction)', async (scenario) => {
     const duckDb = (await getDatabase({
       type: 'duckdb',
       url: ':memory:',
     })) as DatabaseInterface;
+    await syncSchema({ db: duckDb, schema: OIDC_USERS_TEST_SCHEMA });
+    const before = await provisioningRowCounts(duckDb);
     if (!duckDb.beginTransaction) {
       throw new Error('Expected DuckDB manual transaction support.');
     }
@@ -1114,7 +1150,11 @@ describe('safe OIDC provisioning', () => {
           claims({ email: 'duckdb-manual-user@example.com' }),
           'dex',
         ),
-      ).rejects.toMatchObject({ code: 'transaction_required' });
+      ).rejects.toMatchObject({
+        code: getOidcProvisioningPublicErrorCode(scenario.expectations.users),
+      });
+
+      await expectUserMatrixRowDelta(tx, before, scenario.expectations.users);
 
       expect(tx.isActive()).toBe(true);
       await tx.query('CREATE TABLE user_outer_probe (id INTEGER)');
@@ -1129,11 +1169,15 @@ describe('safe OIDC provisioning', () => {
     }
   });
 
-  it('fails closed on a DuckDB callback transaction without corrupting it', async () => {
+  it.each([
+    getOidcProvisioningDecisionScenario('duckdb-caller-owned-transaction'),
+  ])('$id — $title (Users callback transaction)', async (scenario) => {
     const duckDb = (await getDatabase({
       type: 'duckdb',
       url: ':memory:',
     })) as DatabaseInterface;
+    await syncSchema({ db: duckDb, schema: OIDC_USERS_TEST_SCHEMA });
+    const before = await provisioningRowCounts(duckDb);
     if (!duckDb.transaction) {
       throw new Error('Expected DuckDB callback transaction support.');
     }
@@ -1145,7 +1189,11 @@ describe('safe OIDC provisioning', () => {
             claims({ email: 'duckdb-callback-user@example.com' }),
             'dex',
           ),
-        ).rejects.toMatchObject({ code: 'transaction_required' });
+        ).rejects.toMatchObject({
+          code: getOidcProvisioningPublicErrorCode(scenario.expectations.users),
+        });
+
+        await expectUserMatrixRowDelta(tx, before, scenario.expectations.users);
 
         await tx.query('CREATE TABLE user_callback_probe (id INTEGER)');
         await tx.query('INSERT INTO user_callback_probe VALUES (1)');
@@ -1157,35 +1205,6 @@ describe('safe OIDC provisioning', () => {
     } finally {
       await closeDatabase(duckDb);
     }
-  });
-
-  it('rolls back resolver writes when provisioning owns the root transaction', async () => {
-    await isolated.db.rollback();
-    db = isolated.baseDb;
-    await prepareOidcEmailKeyBackfills(db);
-    users = await UserCollection.create({ db });
-    const attemptedUserId = randomUUID();
-
-    await expect(
-      users.getOrCreateFromOidc(
-        claims({ email: 'root-rejection@example.com' }),
-        'dex',
-        {
-          resolveProfile: async ({ db: tx }) => {
-            await tx.query(
-              `INSERT INTO users
-                (id, slug, context, profile_id, email, email_key, status)
-               VALUES (?, ?, '', '', 'partial@example.com', 'partial@example.com', 'active')`,
-              attemptedUserId,
-              `partial-${attemptedUserId}`,
-            );
-            return null;
-          },
-        },
-      ),
-    ).rejects.toMatchObject({ code: 'rejected' });
-
-    await expectNoProvisioningWrites(db, 0);
   });
 
   it('does not retry an unrelated resolver unique constraint', async () => {
@@ -1219,6 +1238,468 @@ describe('safe OIDC provisioning', () => {
     await expect(countRows(db, 'oidc_identities')).resolves.toBe(0);
   });
 });
+
+interface UserMatrixRunOptions {
+  db: DatabaseInterface;
+  scenario: OidcProvisioningScenario;
+  users: UserCollection;
+}
+
+interface UserMatrixResult {
+  created: boolean;
+  profile: { id?: string };
+  user: { id?: string };
+  oidcIdentity: { id?: string };
+}
+
+interface ProvisioningRowCounts {
+  profile: number;
+  oidcIdentity: number;
+  user: number;
+  session: number;
+}
+
+async function runUserMatrixScenario({
+  db,
+  scenario,
+  users,
+}: UserMatrixRunOptions): Promise<void> {
+  const expected = scenario.expectations.users;
+  if (!expected)
+    throw new Error(`Missing Users expectation for ${scenario.id}`);
+
+  const email = 'matrix@example.com';
+  const subject = `matrix-${scenario.id}`;
+  let identityProfileId: string | undefined;
+  let identityId: string | undefined;
+  let emailProfileId: string | undefined;
+  let resolverProfileId: string | undefined;
+
+  if (scenario.identity === 'exact_missing_profile') {
+    identityId = await seedIdentity(db, randomUUID(), {
+      email,
+      identityKey: JSON.stringify(['https://issuer.example.com', subject]),
+      subject,
+    });
+  } else if (scenario.identity !== 'none') {
+    const identityEmail =
+      scenario.email === 'different_global_person'
+        ? 'linked-matrix@example.com'
+        : email;
+    identityProfileId = await seedProfile(db, {
+      email: identityEmail,
+      metaType:
+        scenario.identity === 'exact_legacy_non_person_profile'
+          ? ORGANIZATION_META_TYPE
+          : undefined,
+      tenantId:
+        scenario.identity === 'exact_legacy_tenant_profile'
+          ? randomUUID()
+          : undefined,
+    });
+    const legacyIdentity =
+      scenario.identity.startsWith('exact_legacy_') ||
+      scenario.identity === 'exact_ambiguous_legacy_links';
+    identityId = await seedIdentity(db, identityProfileId, {
+      email: identityEmail,
+      identityKey: legacyIdentity
+        ? null
+        : JSON.stringify(['https://issuer.example.com', subject]),
+      subject,
+    });
+    if (scenario.identity === 'exact_ambiguous_legacy_links') {
+      const duplicateProfileId = await seedProfile(db, {
+        email: identityEmail,
+      });
+      await seedIdentity(db, duplicateProfileId, {
+        email: identityEmail,
+        identityKey: null,
+        subject,
+      });
+    }
+    if (scenario.email === 'already_owned_global_person') {
+      await seedUser(db, identityProfileId, email);
+    }
+    if (scenario.email === 'different_global_person') {
+      emailProfileId = await seedProfile(db, { email });
+    }
+  }
+
+  if (scenario.identity === 'none') {
+    if (
+      scenario.email === 'one_unowned_global_person' ||
+      scenario.email === 'already_owned_global_person' ||
+      scenario.email === 'tenant_scoped_collision' ||
+      scenario.email === 'non_person_collision' ||
+      scenario.email === 'duplicate_normalized_profiles'
+    ) {
+      emailProfileId = await seedProfile(db, {
+        email,
+        metaType:
+          scenario.email === 'non_person_collision'
+            ? ORGANIZATION_META_TYPE
+            : undefined,
+        tenantId:
+          scenario.email === 'tenant_scoped_collision'
+            ? randomUUID()
+            : undefined,
+      });
+      if (scenario.email === 'duplicate_normalized_profiles') {
+        await seedProfile(db, { email: ' MATRIX@example.com ' });
+      }
+      if (scenario.email === 'already_owned_global_person') {
+        await seedUser(db, emailProfileId, email);
+      }
+    }
+  }
+
+  if (scenario.resolver === 'different_profile') {
+    resolverProfileId =
+      emailProfileId ??
+      (await seedProfile(db, { email: 'different-matrix@example.com' }));
+  } else if (scenario.resolver === 'same_profile') {
+    resolverProfileId = identityProfileId ?? emailProfileId;
+  } else if (scenario.resolver === 'owned_profile') {
+    resolverProfileId = emailProfileId;
+  }
+
+  if (expected.readiness === 'none') {
+    await deleteBackfillMarker(
+      db,
+      '@happyvertical/smrt-profiles:profile-email-keys:v1',
+    );
+  }
+  if (expected.readiness !== 'profile_and_user_email_keys') {
+    await deleteBackfillMarker(
+      db,
+      '@happyvertical/smrt-users:user-email-keys:v1',
+    );
+  }
+
+  const before = await provisioningRowCounts(db);
+  const identityBindingsBefore = await userMatrixIdentityBindings(db, subject);
+  let resolverCalls = 0;
+  const resolveProfile =
+    scenario.resolver === 'absent'
+      ? undefined
+      : async ({ db: resolverDb }: { db: DatabaseInterface }) => {
+          resolverCalls += 1;
+          if (scenario.execution === 'root_transaction_rollback') {
+            const probeProfileId = randomUUID();
+            await resolverDb.query(
+              `INSERT INTO profiles
+                (id, slug, context, _meta_type, tenant_id, email, email_key, name)
+               VALUES (?, ?, '', '@happyvertical/smrt-profiles:Person', NULL, ?, ?, 'Rollback Probe')`,
+              probeProfileId,
+              `rollback-probe-${probeProfileId}`,
+              'rollback-probe@example.com',
+              'rollback-probe@example.com',
+            );
+            return null;
+          }
+          if (scenario.resolver === 'undefined') return undefined;
+          if (scenario.resolver === 'null') return null;
+          if (scenario.resolver === 'throws') {
+            throw new Error('matrix resolver failure');
+          }
+          const profileId = resolverProfileId;
+          if (!profileId) {
+            throw new Error(`Scenario ${scenario.id} has no resolver Profile.`);
+          }
+          return (await ProfileCollection.create({ db: resolverDb })).get({
+            id: profileId,
+          });
+        };
+  const oidcClaims = claims({
+    email: scenario.email === 'missing' ? undefined : email,
+    email_verified:
+      scenario.verification === 'claim_missing'
+        ? undefined
+        : scenario.verification === 'verified',
+    sub: subject,
+  });
+  if (scenario.email === 'missing') delete oidcClaims.email;
+  if (scenario.verification === 'claim_missing') {
+    delete oidcClaims.email_verified;
+  }
+
+  const values: UserMatrixResult[] = [];
+  const errors: unknown[] = [];
+  const invoke = (collection = users, claimsOverride = oidcClaims) =>
+    collection.getOrCreateFromOidc(claimsOverride, 'dex', {
+      ...(resolveProfile ? { resolveProfile } : {}),
+    });
+
+  if (scenario.execution === 'concurrent_winner_and_observer') {
+    collectSettled(
+      await Promise.allSettled([invoke(), invoke()]),
+      values,
+      errors,
+    );
+  } else if (scenario.execution === 'concurrent_email_competitors') {
+    collectSettled(
+      await Promise.allSettled([
+        invoke(users, { ...oidcClaims, sub: `${subject}-first` }),
+        invoke(users, { ...oidcClaims, sub: `${subject}-second` }),
+      ]),
+      values,
+      errors,
+    );
+  } else if (scenario.execution === 'durable_arbiter_retry') {
+    const retryingUsers = await UserCollection.create({
+      db: withFirstMatrixIdentityConflict(db),
+    });
+    await collectPromise(invoke(retryingUsers), values, errors);
+  } else if (scenario.execution === 'caller_owned_transaction') {
+    const transaction = db.transaction;
+    if (!transaction) throw new Error('SQLite matrix requires transaction().');
+    await collectPromise(
+      transaction.call(db, async (tx) =>
+        invoke(await UserCollection.create({ db: tx })),
+      ),
+      values,
+      errors,
+    );
+  } else {
+    await collectPromise(invoke(), values, errors);
+  }
+
+  expectMatrixOutcome(expected, values, errors);
+  expectMatrixCreatedResult(expected, values);
+  expectMatrixResolverCalls(resolverCalls, expected.resolverCalls);
+  expectMatrixRetryContract(scenario, expected, resolverCalls);
+  assertSelectedProfile({
+    emailProfileId,
+    expected,
+    identityProfileId,
+    resolverProfileId,
+    values,
+  });
+  if (expected.selectedProfile === 'exact_identity_profile') {
+    expect(values.every((value) => value.oidcIdentity.id === identityId)).toBe(
+      true,
+    );
+  }
+
+  await expectUserMatrixRowDelta(db, before, expected);
+  if (scenario.identity !== 'none' && !expected.rebindAllowed) {
+    await expect(userMatrixIdentityBindings(db, subject)).resolves.toEqual(
+      identityBindingsBefore,
+    );
+  }
+}
+
+async function collectPromise(
+  promise: Promise<UserMatrixResult>,
+  values: UserMatrixResult[],
+  errors: unknown[],
+): Promise<void> {
+  try {
+    values.push(await promise);
+  } catch (error) {
+    errors.push(error);
+  }
+}
+
+function collectSettled(
+  results: PromiseSettledResult<UserMatrixResult>[],
+  values: UserMatrixResult[],
+  errors: unknown[],
+): void {
+  for (const result of results) {
+    if (result.status === 'fulfilled') values.push(result.value);
+    else errors.push(result.reason);
+  }
+}
+
+function expectMatrixOutcome(
+  expected: OidcProvisioningSurfaceExpectation,
+  values: UserMatrixResult[],
+  errors: unknown[],
+): void {
+  if (expected.outcome === 'success') {
+    expect(values.length).toBeGreaterThan(0);
+    expect(errors).toHaveLength(0);
+  } else if (expected.outcome === 'rejected') {
+    expect(values).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+  } else {
+    expect(values).toHaveLength(1);
+    expect(errors).toHaveLength(1);
+  }
+  for (const error of errors) {
+    expectMatrixPublicError(error, expected.publicError);
+  }
+}
+
+function expectMatrixCreatedResult(
+  expected: OidcProvisioningSurfaceExpectation,
+  values: UserMatrixResult[],
+): void {
+  const created = values.map((value) => value.created);
+  if (expected.resultCreated === 'none') expect(created).toHaveLength(0);
+  else if (expected.resultCreated === 'created') {
+    expect(created.every(Boolean)).toBe(true);
+  } else if (expected.resultCreated === 'reused') {
+    expect(created.every((value) => !value)).toBe(true);
+  } else {
+    expect(created).toContain(true);
+    expect(created).toContain(false);
+  }
+}
+
+function expectMatrixResolverCalls(
+  actual: number,
+  expected: OidcProvisioningSurfaceExpectation['resolverCalls'],
+): void {
+  if (expected === 'at_least_2') expect(actual).toBeGreaterThanOrEqual(2);
+  else expect(actual).toBe(expected);
+}
+
+function expectMatrixRetryContract(
+  scenario: OidcProvisioningScenario,
+  expected: OidcProvisioningSurfaceExpectation,
+  resolverCalls: number,
+): void {
+  if (expected.retry === 'once_after_race') {
+    expect([
+      'concurrent_winner_and_observer',
+      'durable_arbiter_retry',
+    ]).toContain(scenario.execution);
+    expect(resolverCalls).toBeGreaterThanOrEqual(2);
+  } else if (scenario.execution === 'durable_arbiter_retry') {
+    throw new Error(`${scenario.id} must declare its resolver retry contract.`);
+  }
+}
+
+function expectMatrixPublicError(
+  error: unknown,
+  publicError: OidcProvisioningSurfaceExpectation['publicError'],
+): void {
+  expect(publicError).not.toBeNull();
+  if (!publicError) return;
+  if ('code' in publicError) {
+    expect(error).toEqual(expect.objectContaining({ code: publicError.code }));
+  } else if ('name' in publicError) {
+    expect(error).toEqual(expect.objectContaining({ name: publicError.name }));
+  } else {
+    expect(error).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining(publicError.messageIncludes),
+      }),
+    );
+  }
+}
+
+function assertSelectedProfile(options: {
+  emailProfileId?: string;
+  expected: OidcProvisioningSurfaceExpectation;
+  identityProfileId?: string;
+  resolverProfileId?: string;
+  values: UserMatrixResult[];
+}): void {
+  const { expected, values } = options;
+  if (expected.selectedProfile === null) return;
+  const profileIds = values.map((value) => value.profile.id);
+  if (expected.selectedProfile === 'concurrent_winner') {
+    expect(new Set(profileIds)).toHaveLength(1);
+    return;
+  }
+  const expectedId =
+    expected.selectedProfile === 'email_match'
+      ? options.emailProfileId
+      : expected.selectedProfile === 'exact_identity_profile'
+        ? options.identityProfileId
+        : expected.selectedProfile === 'resolver_profile'
+          ? options.resolverProfileId
+          : undefined;
+  if (expected.selectedProfile === 'new_profile') {
+    expect(profileIds.every((id) => typeof id === 'string')).toBe(true);
+    expect(profileIds).not.toContain(options.emailProfileId);
+    expect(profileIds).not.toContain(options.identityProfileId);
+    return;
+  }
+  expect(expectedId).toBeDefined();
+  expect(profileIds.every((id) => id === expectedId)).toBe(true);
+}
+
+async function provisioningRowCounts(
+  db: DatabaseInterface,
+): Promise<ProvisioningRowCounts> {
+  const [profile, oidcIdentity, user, session] = await Promise.all([
+    countRows(db, 'profiles'),
+    countRows(db, 'oidc_identities'),
+    countRows(db, 'users'),
+    countRows(db, 'sessions'),
+  ]);
+  return { profile, oidcIdentity, user, session };
+}
+
+function rowCountDelta(
+  before: ProvisioningRowCounts,
+  after: ProvisioningRowCounts,
+): ProvisioningRowCounts {
+  return {
+    profile: after.profile - before.profile,
+    oidcIdentity: after.oidcIdentity - before.oidcIdentity,
+    user: after.user - before.user,
+    session: after.session - before.session,
+  };
+}
+
+async function expectUserMatrixRowDelta(
+  db: DatabaseInterface,
+  before: ProvisioningRowCounts,
+  expected: OidcProvisioningSurfaceExpectation | undefined,
+): Promise<void> {
+  if (!expected) throw new Error('Missing Users matrix expectation.');
+  const after = await provisioningRowCounts(db);
+  expect(rowCountDelta(before, after)).toEqual(expected.createdRows);
+}
+
+function withFirstMatrixIdentityConflict(
+  db: DatabaseInterface,
+): DatabaseInterface {
+  const transaction = db.transaction;
+  if (!transaction) throw new Error('SQLite matrix requires transaction().');
+  let injected = false;
+  return new Proxy(db, {
+    get(target, property, receiver) {
+      if (property === 'transaction') {
+        return async <T>(
+          callback: (tx: DatabaseInterface) => Promise<T>,
+        ): Promise<T> =>
+          transaction.call(target, (tx) =>
+            callback(
+              new Proxy(tx, {
+                get(txTarget, txProperty, txReceiver) {
+                  if (txProperty === 'upsert') {
+                    return async (
+                      ...args: Parameters<DatabaseInterface['upsert']>
+                    ) => {
+                      if (!injected && args[0] === 'oidc_identities') {
+                        injected = true;
+                        throw new Error(
+                          'UNIQUE constraint failed: oidc_identities.identity_key',
+                        );
+                      }
+                      return txTarget.upsert(...args);
+                    };
+                  }
+                  const value = Reflect.get(txTarget, txProperty, txReceiver);
+                  return typeof value === 'function'
+                    ? value.bind(txTarget)
+                    : value;
+                },
+              }),
+            ),
+          );
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
 
 function claims(overrides: Partial<OidcClaims> = {}): OidcClaims {
   return {
@@ -1276,21 +1757,45 @@ async function seedUser(
 async function seedIdentity(
   db: DatabaseInterface,
   profileId: string,
-  options: { email: string; issuer?: string; subject: string },
+  options: {
+    email: string;
+    identityKey?: string | null;
+    issuer?: string;
+    subject: string;
+  },
 ): Promise<string> {
   const id = randomUUID();
   await db.query(
     `INSERT INTO oidc_identities
       (id, slug, context, profile_id, provider, issuer, subject, identity_key, email)
-     VALUES (?, ?, '', ?, 'dex', ?, ?, NULL, ?)`,
+     VALUES (?, ?, '', ?, 'dex', ?, ?, ?, ?)`,
     id,
     `seed-${id}`,
     profileId,
     options.issuer ?? 'https://issuer.example.com',
     options.subject,
+    options.identityKey ?? null,
     options.email,
   );
   return id;
+}
+
+async function userMatrixIdentityBindings(
+  db: DatabaseInterface,
+  subject: string,
+): Promise<Array<{ id: string; profileId: string }>> {
+  const result = await db.query(
+    `SELECT id, profile_id
+     FROM oidc_identities
+     WHERE issuer = ? AND subject = ?
+     ORDER BY id`,
+    'https://issuer.example.com',
+    subject,
+  );
+  return result.rows.map((row) => ({
+    id: String(row.id),
+    profileId: String(row.profile_id),
+  }));
 }
 
 async function countRows(


### PR DESCRIPTION
## Summary

- add a typed, executable OIDC provisioning decision matrix shared directly by the Profiles and Users test suites
- cover exact reuse, new provisioning, resolver outcomes, ownership and collision states, readiness, retries, root/caller transactions, and concurrency across SQLite, PostgreSQL, and DuckDB adapter contracts
- preserve the Profile-only legacy exact-reuse exception while asserting Users/session fail-closed behavior, public errors, resolver calls, rebinding restrictions, and zero rejected-path writes
- link public Profiles and Users documentation to the canonical matrix instead of maintaining a contradictory prose table

This contract work builds on the OIDC provisioning surface from #1998, delivered by merged PR #2005.

## Release policy

No manual changeset or package version edit is included; merge-time release automation remains authoritative.

## Validation

- `pnpm build` — full repository pass
- `pnpm test` — full repository pass
- `pnpm typecheck` — full repository pass, including Users `svelte-check` with 0 errors / 0 warnings
- `pnpm lint` and `pnpm format` — repository entry points pass
- `pnpm smrt dev:knowledge-check --strict` and `pnpm knowledge:check --strict --format markdown` — 0 errors / 0 warnings
- focused Profiles matrix suite — 43/43
- focused Users matrix/safety suite — 77/77
- PostgreSQL-sensitive OIDC provisioning suite — 13/13
- pre-commit and pre-push policy hooks — pass
- review-cycle full correctness, coverage, and maintainability roster — clean

Closes #2006

<!-- hv-agent-run:v1 -->
```json
{"issue":2006,"linked_issue":2006,"policy_revision":"1.0.0","runtime":"codex","schema":"hv-agent-run:v1","session":"019f6195-54cc-75b0-a0ce-56b62eb262cf","validation":["pnpm build","pnpm test","pnpm typecheck","pnpm lint","pnpm format","pnpm smrt dev:knowledge-check --strict","pnpm knowledge:check --strict --format markdown","profiles focused: 43/43","users focused: 77/77","users PostgreSQL OIDC provisioning: 13/13","pre-commit and pre-push hooks","review-cycle full roster: clean"]}
```
