### PR TITLE
feat(marketing): add cross-channel campaign coordination

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -32,6 +32,7 @@
       "@happyvertical/smrt-languages",
       "@happyvertical/smrt-ledgers",
       "@happyvertical/smrt-manufacturing",
+      "@happyvertical/smrt-marketing",
       "@happyvertical/smrt-messages",
       "@happyvertical/smrt-mobile",
       "@happyvertical/smrt-mobile-contract",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ for package-specific architecture and validation.
 - Foundation: `core`, `config`, `types`, `scanner`, `tenancy`, `vitest`, `cli`.
 - Runtime: `agents`, `jobs`, `users`, `profiles`, `personas`.
 - Domain packages include content/media, commerce, events, places, facts, sites,
-  properties, tags, social, and secrets.
+  properties, tags, social, marketing, and secrets.
 - Client/tooling packages include `smrt-web`, `smrt-svelte`, mobile packages,
   templates, and `smrt-dev-mcp`. The private `bundle-gate` package is the CI
   consumer bundle reachability/size gate (#1980).

--- a/packages/marketing/AGENTS.md
+++ b/packages/marketing/AGENTS.md
@@ -1,0 +1,78 @@
+# @happyvertical/smrt-marketing
+
+Cross-channel campaign coordination for SMRT. This package owns Campaign
+identity, budgets, lifecycle, execution links, immutable performance evidence,
+computed pacing, and props-driven Svelte surfaces. It does not execute ads,
+publish social posts, send messages, or own sales attribution.
+
+## Validation
+
+Run `pnpm --filter @happyvertical/smrt-marketing test` and
+`pnpm --filter @happyvertical/smrt-marketing typecheck`; use `test:coverage`
+to exercise the model/service and component coverage configurations.
+Natural-key changes must also run
+`pnpm --filter @happyvertical/smrt-marketing test:postgres` when
+the disposable PostgreSQL harness is available. Use
+`pnpm --filter @happyvertical/smrt-marketing build` and `verify:pack` for
+publish-surface changes.
+
+## Models
+
+- **Campaign**: optional-tenant umbrella with stable natural key
+  `(tenant_id, campaign_key)`, open objective, integer-cent budget, currency,
+  schedule, guarded metadata helpers, and lifecycle
+  `draft → scheduled → active ↔ paused → completed → archived`. Raw saves are
+  protected by an authoritative prior-status re-read; use
+  `CampaignLifecycleService` for lifecycle writes.
+- **CampaignChannel**: one generic execution link per
+  `(campaign_id, channel_kind, channel_ref)`. `channelKind`/`channelRef` are
+  intentionally plain strings so ads, social, messages, content, events, and
+  referral programs remain peer packages. Allocation and schedule overrides
+  use integer cents and dates.
+- **CampaignMetricSnapshot**: immutable period evidence with a global
+  `dedupe_key` natural key. A snapshot always carries `campaignId`; a null
+  `campaignChannelId` means campaign-level rollup evidence. API/MCP/CLI expose
+  create/list/get only, and the save guard rejects hydrated edits, blind-id
+  overwrites, and natural-key overwrites. Programmatic deletion is rejected.
+
+Every model is `@TenantScoped({ mode: 'optional' })` with nullable `tenantId`.
+All generated surfaces are explicit; never omit `api`, `mcp`, or `cli` config.
+
+## Services
+
+- **CampaignLifecycleService** loads the current row before applying one legal
+  transition. Paused campaigns may resume; completed campaigns may only be
+  archived; archived campaigns are terminal.
+- **MetricIngestionService** validates required scope/source/period fields and
+  delegates to `getOrCreateByDedupeKey()`. A replay returns the original row
+  unchanged even if the replay payload differs.
+- **BudgetPacingService** computes campaign/channel pacing from snapshots and
+  never persists derived balances. For each exact reporting period, campaign
+  pacing prefers campaign rollups and otherwise sums channel snapshots,
+  preventing double counting without dropping channel-only periods. Status
+  uses a five-percent budget tolerance around schedule-derived expected spend.
+
+## Svelte
+
+`@happyvertical/smrt-marketing/svelte` exports `MarketingDashboard`,
+`CampaignList`, `CampaignDetail`, `ChannelMix`, and `BudgetPacing`, plus view
+interfaces and pure helpers. Components are props-only: no fetching, no model
+imports, no providers. Use Provider-free `smrt-ui` primitives, `--smrt-*`
+tokens, named `$props()` interfaces, and integer-cent inputs formatted only at
+render time.
+
+## Boundaries and gotchas
+
+- Runtime dependencies stay limited to `smrt-core`, `smrt-tenancy`, and
+  `smrt-ui`. Never statically import sibling domain packages.
+- Lead loop-closing is conventional: CRM stores `sourceKind: 'campaign'` and a
+  campaign key in `sourceId`; marketing does not import or mutate Lead.
+- Attribution math remains in sales/referrals. Marketing stores performance
+  evidence only.
+- Campaign rollups and channel snapshots may describe the same period. The
+  pacing service deliberately chooses one evidence level instead of summing
+  both.
+- Corrections append a new metric snapshot with a new dedupe key; never edit
+  persisted evidence.
+- Table names are global: `campaigns`, `campaign_channels`, and
+  `campaign_metric_snapshots`.

--- a/packages/marketing/AGENTS.md
+++ b/packages/marketing/AGENTS.md
@@ -31,9 +31,10 @@ publish-surface changes.
   use integer cents and dates.
 - **CampaignMetricSnapshot**: immutable period evidence with a global
   `dedupe_key` natural key. A snapshot always carries `campaignId`; a null
-  `campaignChannelId` means campaign-level rollup evidence. API/MCP/CLI expose
-  create/list/get only, and the save guard rejects hydrated edits, blind-id
-  overwrites, and natural-key overwrites. Programmatic deletion is rejected.
+  `campaignChannelId` means campaign-level rollup evidence; when present, the
+  channel must belong to that same campaign. API/MCP/CLI expose create/list/get
+  only, and the save guard rejects hydrated edits, blind-id overwrites, and
+  natural-key overwrites. Programmatic deletion is rejected.
 
 Every model is `@TenantScoped({ mode: 'optional' })` with nullable `tenantId`.
 All generated surfaces are explicit; never omit `api`, `mcp`, or `cli` config.

--- a/packages/marketing/CHANGELOG.md
+++ b/packages/marketing/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @happyvertical/smrt-marketing
+
+## 0.39.15
+
+### Minor Changes
+
+- Initial release with Campaign lifecycle, generic channel links, immutable
+  metric snapshot ingestion, computed budget pacing, and reusable Svelte
+  marketing surfaces.

--- a/packages/marketing/CLAUDE.md
+++ b/packages/marketing/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/marketing/README.md
+++ b/packages/marketing/README.md
@@ -52,6 +52,9 @@ await ingestion.ingest({
   dedupeKey: `${tenantId}:summer-demand-2026:ad-group-42:2026-07-01`,
 });
 
+// Channel-scoped evidence is accepted only when the channel belongs to the
+// supplied campaign. Reporting periods are required valid date-like values.
+
 const pacing = await BudgetPacingService.create({ db });
 console.log(await pacing.getCampaignPacing(campaign.id));
 ```

--- a/packages/marketing/README.md
+++ b/packages/marketing/README.md
@@ -1,0 +1,64 @@
+# @happyvertical/smrt-marketing
+
+Cross-channel Campaign models, immutable performance snapshots, computed
+budget pacing, and reusable Svelte marketing surfaces for SMRT.
+
+```bash
+pnpm add @happyvertical/smrt-marketing
+```
+
+```ts
+import {
+  BudgetPacingService,
+  CampaignChannelCollection,
+  CampaignCollection,
+  MetricIngestionService,
+} from '@happyvertical/smrt-marketing';
+
+const campaigns = await CampaignCollection.create({ db });
+const channels = await CampaignChannelCollection.create({ db });
+const campaign = await campaigns.create({
+  tenantId,
+  campaignKey: 'summer-demand-2026',
+  name: 'Summer demand 2026',
+  objective: 'demand_generation',
+  budgetCents: 200_000,
+  currency: 'CAD',
+});
+if (!campaign.id) throw new Error('Campaign did not persist');
+
+const adGroup = await channels.create({
+  tenantId,
+  campaignId: campaign.id,
+  channelKind: 'ad_group',
+  channelRef: 'ad-group-42',
+  allocatedBudgetCents: 150_000,
+});
+if (!adGroup.id) throw new Error('Campaign channel did not persist');
+
+const ingestion = await MetricIngestionService.create({ db });
+await ingestion.ingest({
+  tenantId,
+  campaignId: campaign.id,
+  campaignChannelId: adGroup.id,
+  periodStart: new Date('2026-07-01T00:00:00Z'),
+  periodEnd: new Date('2026-07-01T23:59:59Z'),
+  spendCents: 12_500,
+  impressions: 25_000,
+  clicks: 800,
+  conversions: 35,
+  leads: 20,
+  source: 'ad-platform',
+  dedupeKey: `${tenantId}:summer-demand-2026:ad-group-42:2026-07-01`,
+});
+
+const pacing = await BudgetPacingService.create({ db });
+console.log(await pacing.getCampaignPacing(campaign.id));
+```
+
+Svelte components are exported from `@happyvertical/smrt-marketing/svelte`.
+They are presentational and accept plain view models; consumers remain in
+control of fetching and mutations.
+
+See [AGENTS.md](./AGENTS.md) for lifecycle, evidence, and package-boundary
+invariants.

--- a/packages/marketing/ambient.d.ts
+++ b/packages/marketing/ambient.d.ts
@@ -1,0 +1,6 @@
+declare module '*.svelte' {
+  import type { Component } from 'svelte';
+
+  const component: Component<Record<string, any>>;
+  export default component;
+}

--- a/packages/marketing/package.json
+++ b/packages/marketing/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@happyvertical/smrt-marketing",
+  "version": "0.39.15",
+  "description": "Cross-channel campaign coordination, immutable performance evidence, budget pacing, and reusable Svelte marketing surfaces for SMRT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "CLAUDE.md",
+    "AGENTS.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./svelte": {
+      "types": "./dist/svelte/index.d.ts",
+      "svelte": "./dist/svelte/index.js",
+      "import": "./dist/svelte/index.js"
+    },
+    "./manifest": "./dist/manifest.json",
+    "./manifest.json": "./dist/manifest.json"
+  },
+  "scripts": {
+    "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
+    "build:watch": "vite build --mode library --watch",
+    "clean": "rm -rf dist",
+    "dev": "vite dev",
+    "prepack": "node ../../scripts/prepack-package.js",
+    "test": "vitest run && vitest run --config vitest.svelte.config.ts",
+    "test:coverage": "vitest run --coverage --coverage.reportsDirectory=coverage/models && vitest run --coverage --config vitest.svelte.config.ts --coverage.reportsDirectory=coverage/svelte",
+    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/__tests__/marketing.postgres.test.ts",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit -p tsconfig.json && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
+    "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
+  },
+  "dependencies": {
+    "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-tenancy": "workspace:*",
+    "@happyvertical/smrt-ui": "workspace:*"
+  },
+  "peerDependencies": {
+    "svelte": "^5.56.4"
+  },
+  "devDependencies": {
+    "@happyvertical/smrt-vitest": "workspace:*",
+    "@happyvertical/sql": "catalog:",
+    "@sveltejs/package": "^2.5.8",
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "@testing-library/svelte": "^5.4.2",
+    "@types/node": "24.13.2",
+    "jsdom": "^26.1.0",
+    "svelte": "^5.56.4",
+    "svelte-check": "^4.7.1",
+    "typescript": "^5.9.3",
+    "vite": "^8.1.3",
+    "vitest": "^4.1.9"
+  },
+  "smrtRawPrimitives": "strict",
+  "keywords": [
+    "smrt",
+    "marketing",
+    "campaigns",
+    "budget-pacing",
+    "multi-tenant"
+  ],
+  "author": "HappyVertical",
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/smrt.git",
+    "directory": "packages/marketing"
+  }
+}

--- a/packages/marketing/src/__smrt-register__.ts
+++ b/packages/marketing/src/__smrt-register__.ts
@@ -1,0 +1,5 @@
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+
+ObjectRegistry.registerPackageManifest(
+  new URL('./manifest.json', import.meta.url),
+);

--- a/packages/marketing/src/__tests__/campaign-lifecycle.test.ts
+++ b/packages/marketing/src/__tests__/campaign-lifecycle.test.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from 'node:crypto';
+import { getTestDatabase, ObjectRegistry } from '@happyvertical/smrt-core';
+import {
+  disableTenancy,
+  enableTenancy,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CampaignCollection } from '../collections/CampaignCollection.js';
+import { CampaignLifecycleService } from '../services/CampaignLifecycleService.js';
+import type { CampaignStatus } from '../types.js';
+import '../index.js';
+
+describe('Campaign model and lifecycle', () => {
+  let db: DatabaseInterface;
+  let campaigns: CampaignCollection;
+
+  beforeEach(async () => {
+    enableTenancy();
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    campaigns = await CampaignCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    disableTenancy();
+    await db?.close?.();
+  });
+
+  it('registers natural keys, integer money, and explicit surfaces', () => {
+    expect(ObjectRegistry.getConfig('Campaign').conflictColumns).toEqual([
+      'tenant_id',
+      'campaign_key',
+    ]);
+    expect(ObjectRegistry.getConfig('CampaignChannel').conflictColumns).toEqual(
+      ['campaign_id', 'channel_kind', 'channel_ref'],
+    );
+    expect(
+      ObjectRegistry.getConfig('CampaignMetricSnapshot').conflictColumns,
+    ).toEqual(['dedupe_key']);
+
+    for (const className of [
+      'Campaign',
+      'CampaignChannel',
+      'CampaignMetricSnapshot',
+    ]) {
+      const config = ObjectRegistry.getConfig(className);
+      expect(config.api).toBeDefined();
+      expect(config.mcp).toBeDefined();
+      expect(config.cli).toBeDefined();
+    }
+
+    const campaignSchema = ObjectRegistry.getSchema('Campaign');
+    const channelSchema = ObjectRegistry.getSchema('CampaignChannel');
+    const snapshotSchema = ObjectRegistry.getSchema('CampaignMetricSnapshot');
+    if (!campaignSchema || !channelSchema || !snapshotSchema) {
+      throw new Error('expected marketing schemas');
+    }
+    expect(campaignSchema.tableName).toBe('campaigns');
+    expect(campaignSchema.columns.budget_cents.type).toBe('INTEGER');
+    expect(channelSchema.tableName).toBe('campaign_channels');
+    expect(channelSchema.columns.allocated_budget_cents.type).toBe('INTEGER');
+    expect(snapshotSchema.tableName).toBe('campaign_metric_snapshots');
+    expect(snapshotSchema.columns.spend_cents.type).toBe('INTEGER');
+  });
+
+  it('runs the guarded lifecycle, including pause and resume', async () => {
+    const campaign = await campaigns.create({
+      campaignKey: 'summer-launch',
+      name: 'Summer launch',
+      startAt: new Date('2026-07-01T00:00:00Z'),
+      endAt: new Date('2026-07-31T23:59:59Z'),
+      budgetCents: 100_000,
+      currency: 'CAD',
+    });
+    const service = new CampaignLifecycleService(campaigns);
+    const id = campaign.id ?? '';
+
+    expect((await service.schedule(id)).status).toBe('scheduled');
+    expect((await service.activate(id)).status).toBe('active');
+    expect((await service.pause(id)).status).toBe('paused');
+    expect((await service.resume(id)).status).toBe('active');
+    expect((await service.complete(id)).status).toBe('completed');
+    expect((await service.archive(id)).status).toBe('archived');
+  });
+
+  it('scopes the same natural campaign key independently per tenant', async () => {
+    const tenantA = randomUUID();
+    const tenantB = randomUUID();
+
+    const firstA = await withTenant({ tenantId: tenantA }, () =>
+      campaigns.create({
+        campaignKey: 'shared-launch',
+        name: 'Tenant A launch',
+      }),
+    );
+    const firstB = await withTenant({ tenantId: tenantB }, () =>
+      campaigns.create({
+        campaignKey: 'shared-launch',
+        name: 'Tenant B launch',
+      }),
+    );
+    await withTenant({ tenantId: tenantA }, () =>
+      campaigns.create({
+        campaignKey: 'shared-launch',
+        name: 'Tenant A launch updated',
+      }),
+    );
+
+    expect(firstA.tenantId).toBe(tenantA);
+    expect(firstB.tenantId).toBe(tenantB);
+    expect(firstA.id).not.toBe(firstB.id);
+
+    const seenByA = await withTenant({ tenantId: tenantA }, () =>
+      campaigns.list({ where: { campaignKey: 'shared-launch' } }),
+    );
+    const seenByB = await withTenant({ tenantId: tenantB }, () =>
+      campaigns.list({ where: { campaignKey: 'shared-launch' } }),
+    );
+    expect(seenByA).toHaveLength(1);
+    expect(seenByA[0]?.name).toBe('Tenant A launch updated');
+    expect(seenByB).toHaveLength(1);
+    expect(seenByB[0]?.name).toBe('Tenant B launch');
+  });
+
+  it('rejects skipped, reversed, and blind-overwrite transitions', async () => {
+    await expect(
+      campaigns.create({
+        campaignKey: 'unknown-status',
+        name: 'Unknown status',
+        status: 'invented' as CampaignStatus,
+      }),
+    ).rejects.toThrow(/unknown status/);
+
+    const campaign = await campaigns.create({
+      campaignKey: 'guarded',
+      name: 'Guarded campaign',
+    });
+    campaign.status = 'active';
+    await expect(campaign.save()).rejects.toThrow(/illegal status transition/);
+
+    const service = new CampaignLifecycleService(campaigns);
+    await service.schedule(campaign.id ?? '');
+    await service.activate(campaign.id ?? '');
+    await service.complete(campaign.id ?? '');
+    await service.archive(campaign.id ?? '');
+
+    const loaded = await campaigns.get({ id: campaign.id });
+    if (!loaded) throw new Error('campaign not found');
+    loaded.status = 'draft';
+    await expect(loaded.save()).rejects.toThrow(/illegal status transition/);
+
+    await expect(
+      campaigns.create({
+        id: campaign.id,
+        _skipLoad: true,
+        campaignKey: 'guarded',
+        name: 'Blind overwrite',
+        status: 'draft',
+      }),
+    ).rejects.toThrow(/illegal status transition/);
+  });
+
+  it('round-trips guarded metadata and date values', async () => {
+    const campaign = await campaigns.create({
+      campaignKey: 'metadata',
+      name: 'Metadata campaign',
+      startAt: '2026-07-01T00:00:00Z',
+      endAt: '2026-08-01T00:00:00Z',
+    });
+    campaign.setMetadata({ audience: 'builders', nested: { region: 'west' } });
+    await campaign.save();
+
+    const loaded = await campaigns.get({ id: campaign.id });
+    expect(loaded?.startAt).toBeInstanceOf(Date);
+    expect(loaded?.endAt).toBeInstanceOf(Date);
+    expect(loaded?.getMetadata()).toEqual({
+      audience: 'builders',
+      nested: { region: 'west' },
+    });
+  });
+});

--- a/packages/marketing/src/__tests__/campaign-lifecycle.test.ts
+++ b/packages/marketing/src/__tests__/campaign-lifecycle.test.ts
@@ -159,6 +159,14 @@ describe('Campaign model and lifecycle', () => {
         status: 'draft',
       }),
     ).rejects.toThrow(/illegal status transition/);
+
+    await expect(
+      campaigns.create({
+        campaignKey: 'guarded',
+        name: 'Natural-key overwrite',
+        status: 'draft',
+      }),
+    ).rejects.toThrow(/illegal status transition/);
   });
 
   it('round-trips guarded metadata and date values', async () => {

--- a/packages/marketing/src/__tests__/epic-tracer.spec.ts
+++ b/packages/marketing/src/__tests__/epic-tracer.spec.ts
@@ -1,0 +1,118 @@
+import { getTestDatabase } from '@happyvertical/smrt-core';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { LeadCollection } from '../../../sales/src/crm/collections/LeadCollection.js';
+import {
+  CampaignChannelCollection,
+  CampaignCollection,
+  CampaignMetricSnapshotCollection,
+} from '../collections/index.js';
+import {
+  BudgetPacingService,
+  MetricIngestionService,
+} from '../services/index.js';
+
+describe('smrt-marketing epic tracer (#1988)', () => {
+  let db: DatabaseInterface;
+
+  beforeAll(async () => {
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+  });
+
+  afterAll(async () => {
+    await db?.close?.();
+  });
+
+  it('coordinates two channels, idempotent evidence, pacing, and Lead provenance', async () => {
+    const campaigns = await CampaignCollection.create({ db });
+    const channels = await CampaignChannelCollection.create({ db });
+    const snapshots = await CampaignMetricSnapshotCollection.create({ db });
+    const leads = await LeadCollection.create({ db });
+
+    const campaign = await campaigns.create({
+      campaignKey: 'summer-demand-2026',
+      name: 'Summer demand 2026',
+      objective: 'demand_generation',
+      status: 'active',
+      startAt: new Date('2026-07-01T00:00:00Z'),
+      endAt: new Date('2026-07-31T00:00:00Z'),
+      budgetCents: 200_000,
+      currency: 'CAD',
+    });
+    const adGroup = await channels.create({
+      campaignId: campaign.id ?? '',
+      channelKind: 'ad_group',
+      channelRef: 'ad-group-42',
+      allocatedBudgetCents: 150_000,
+      status: 'active',
+    });
+    const socialPost = await channels.create({
+      campaignId: campaign.id ?? '',
+      channelKind: 'social_post',
+      channelRef: 'social-post-84',
+      allocatedBudgetCents: 50_000,
+      status: 'active',
+    });
+    expect(
+      (await channels.findByCampaign(campaign.id ?? '')).map(
+        (row) => row.channelKind,
+      ),
+    ).toEqual(['ad_group', 'social_post']);
+
+    const ingestion = new MetricIngestionService(snapshots);
+    const adMetric = await ingestion.ingest({
+      campaignId: campaign.id ?? '',
+      campaignChannelId: adGroup.id ?? '',
+      periodStart: new Date('2026-07-01T00:00:00Z'),
+      periodEnd: new Date('2026-07-15T23:59:59Z'),
+      spendCents: 70_000,
+      impressions: 100_000,
+      clicks: 3_000,
+      conversions: 140,
+      leads: 90,
+      source: 'ad-platform',
+      dedupeKey: 'summer-demand-2026:ads:2026-07-15',
+    });
+    await ingestion.ingest({
+      campaignId: campaign.id ?? '',
+      campaignChannelId: socialPost.id ?? '',
+      periodStart: new Date('2026-07-01T00:00:00Z'),
+      periodEnd: new Date('2026-07-15T23:59:59Z'),
+      spendCents: 20_000,
+      impressions: 40_000,
+      clicks: 1_200,
+      conversions: 40,
+      leads: 25,
+      source: 'social-platform',
+      dedupeKey: 'summer-demand-2026:social:2026-07-15',
+    });
+    const replay = await ingestion.ingest({
+      campaignId: campaign.id ?? '',
+      campaignChannelId: adGroup.id ?? '',
+      periodStart: new Date('2026-07-01T00:00:00Z'),
+      periodEnd: new Date('2026-07-15T23:59:59Z'),
+      spendCents: 999_999,
+      source: 'ad-platform',
+      dedupeKey: 'summer-demand-2026:ads:2026-07-15',
+    });
+    expect(replay.created).toBe(false);
+    expect(replay.snapshot.id).toBe(adMetric.snapshot.id);
+
+    const pacing = new BudgetPacingService(campaigns, channels, snapshots);
+    const result = await pacing.getCampaignPacing(
+      campaign.id ?? '',
+      new Date('2026-07-16T00:00:00Z'),
+    );
+    expect(result.spendCents).toBe(90_000);
+    expect(result.budgetCents).toBe(200_000);
+
+    const lead = await leads.create({
+      name: 'Campaign-sourced prospect',
+      sourceKind: 'campaign',
+      sourceId: campaign.campaignKey,
+    });
+    expect(lead.sourceKind).toBe('campaign');
+    const traced = await campaigns.findByCampaignKey(lead.sourceId, null);
+    expect(traced?.id).toBe(campaign.id);
+  });
+});

--- a/packages/marketing/src/__tests__/marketing.postgres.test.ts
+++ b/packages/marketing/src/__tests__/marketing.postgres.test.ts
@@ -1,0 +1,88 @@
+import { randomUUID } from 'node:crypto';
+import {
+  createIsolatedTestDbFromManifest,
+  type IsolatedTestDbResult,
+  isPostgresAvailable,
+} from '@happyvertical/smrt-vitest';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  CampaignCollection,
+  CampaignMetricSnapshotCollection,
+} from '../collections/index.js';
+import { MetricIngestionService } from '../services/MetricIngestionService.js';
+
+const describePostgres = isPostgresAvailable() ? describe : describe.skip;
+
+describePostgres('marketing natural keys on PostgreSQL', () => {
+  let isolated: IsolatedTestDbResult | undefined;
+  let db: DatabaseInterface;
+  let campaigns: CampaignCollection;
+  let snapshots: CampaignMetricSnapshotCollection;
+
+  beforeEach(async () => {
+    isolated = await createIsolatedTestDbFromManifest({
+      includeObjects: ['Campaign', 'CampaignChannel', 'CampaignMetricSnapshot'],
+    });
+    db = isolated.db;
+    campaigns = await CampaignCollection.create({ db });
+    snapshots = await CampaignMetricSnapshotCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    await isolated?.cleanup();
+    isolated = undefined;
+  });
+
+  it('upserts the nullable-tenant campaign key and dedupes ingestion', async () => {
+    await campaigns.create({
+      campaignKey: 'postgres-global-campaign',
+      name: 'First name',
+    });
+    const second = await campaigns.create({
+      campaignKey: 'postgres-global-campaign',
+      name: 'Updated name',
+    });
+    expect(
+      await campaigns.list({
+        where: { campaignKey: 'postgres-global-campaign' },
+      }),
+    ).toHaveLength(1);
+
+    const tenantA = randomUUID();
+    const tenantB = randomUUID();
+    const tenantCampaignA = await campaigns.create({
+      tenantId: tenantA,
+      campaignKey: 'postgres-shared-campaign',
+      name: 'Tenant A campaign',
+    });
+    const tenantCampaignB = await campaigns.create({
+      tenantId: tenantB,
+      campaignKey: 'postgres-shared-campaign',
+      name: 'Tenant B campaign',
+    });
+    expect(tenantCampaignA.tenantId).toBe(tenantA);
+    expect(tenantCampaignB.tenantId).toBe(tenantB);
+    expect(
+      await campaigns.list({
+        where: { campaignKey: 'postgres-shared-campaign' },
+      }),
+    ).toHaveLength(2);
+
+    const ingestion = new MetricIngestionService(snapshots);
+    const input = {
+      campaignId: second.id ?? '',
+      periodStart: new Date('2026-07-01T00:00:00Z'),
+      periodEnd: new Date('2026-07-01T23:59:59Z'),
+      spendCents: 1_000,
+      source: 'postgres-test',
+      dedupeKey: 'postgres-global-campaign:2026-07-01',
+    };
+    const first = await ingestion.ingest(input);
+    const replay = await ingestion.ingest({ ...input, spendCents: 2_000 });
+    expect(first.created).toBe(true);
+    expect(replay.created).toBe(false);
+    expect(replay.snapshot.id).toBe(first.snapshot.id);
+    expect(replay.snapshot.spendCents).toBe(1_000);
+  });
+});

--- a/packages/marketing/src/__tests__/marketing.postgres.test.ts
+++ b/packages/marketing/src/__tests__/marketing.postgres.test.ts
@@ -48,6 +48,16 @@ describePostgres('marketing natural keys on PostgreSQL', () => {
         where: { campaignKey: 'postgres-global-campaign' },
       }),
     ).toHaveLength(1);
+    second.transitionTo('scheduled');
+    await second.save();
+    second.transitionTo('active');
+    await second.save();
+    await expect(
+      campaigns.create({
+        campaignKey: 'postgres-global-campaign',
+        name: 'Lifecycle bypass attempt',
+      }),
+    ).rejects.toThrow(/illegal status transition/);
 
     const tenantA = randomUUID();
     const tenantB = randomUUID();

--- a/packages/marketing/src/__tests__/metric-ingestion.test.ts
+++ b/packages/marketing/src/__tests__/metric-ingestion.test.ts
@@ -116,6 +116,57 @@ describe('metric ingestion and budget pacing', () => {
         periodStart: 'not-a-date',
       }),
     ).rejects.toThrow(/valid dates/);
+
+    await expect(
+      ingestion.ingest({
+        ...input,
+        dedupeKey: 'missing-period',
+        periodStart: null as unknown as Date,
+      }),
+    ).rejects.toThrow(/requires periodStart and periodEnd/);
+    await expect(
+      ingestion.ingest({
+        ...input,
+        dedupeKey: 'missing-period-end',
+        periodEnd: null as unknown as Date,
+      }),
+    ).rejects.toThrow(/requires periodStart and periodEnd/);
+
+    await expect(
+      snapshots.getOrCreateByDedupeKey({
+        ...input,
+        dedupeKey: 'null-period',
+        periodStart: null as unknown as Date,
+      }),
+    ).rejects.toThrow(/valid dates/);
+  });
+
+  it('rejects channel evidence attributed to a different campaign', async () => {
+    const campaignA = await campaigns.create({
+      campaignKey: 'channel-scope-a',
+      name: 'Channel scope A',
+    });
+    const campaignB = await campaigns.create({
+      campaignKey: 'channel-scope-b',
+      name: 'Channel scope B',
+    });
+    const channelB = await channels.create({
+      campaignId: campaignB.id ?? '',
+      channelKind: 'ad_group',
+      channelRef: 'campaign-b-ad-group',
+    });
+
+    const ingestion = new MetricIngestionService(snapshots);
+    await expect(
+      ingestion.ingest({
+        campaignId: campaignA.id ?? '',
+        campaignChannelId: channelB.id ?? '',
+        periodStart: new Date('2026-07-03T00:00:00Z'),
+        periodEnd: new Date('2026-07-03T23:59:59Z'),
+        source: 'channel-sync',
+        dedupeKey: 'mismatched-channel-campaign',
+      }),
+    ).rejects.toThrow(/does not belong to campaignId/);
   });
 
   it('uses campaign rollups when present and otherwise sums channel evidence', async () => {

--- a/packages/marketing/src/__tests__/metric-ingestion.test.ts
+++ b/packages/marketing/src/__tests__/metric-ingestion.test.ts
@@ -1,0 +1,203 @@
+import { getTestDatabase, ObjectRegistry } from '@happyvertical/smrt-core';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  CampaignChannelCollection,
+  CampaignCollection,
+  CampaignMetricSnapshotCollection,
+} from '../collections/index.js';
+import {
+  BudgetPacingService,
+  MetricIngestionService,
+} from '../services/index.js';
+import '../index.js';
+
+describe('metric ingestion and budget pacing', () => {
+  let db: DatabaseInterface;
+  let campaigns: CampaignCollection;
+  let channels: CampaignChannelCollection;
+  let snapshots: CampaignMetricSnapshotCollection;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    campaigns = await CampaignCollection.create({ db });
+    channels = await CampaignChannelCollection.create({ db });
+    snapshots = await CampaignMetricSnapshotCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    await db?.close?.();
+  });
+
+  it('keeps snapshot surfaces create-only on every generated door', () => {
+    const config = ObjectRegistry.getConfig('CampaignMetricSnapshot');
+    for (const door of [config.api, config.mcp, config.cli]) {
+      if (typeof door === 'boolean' || door === undefined) {
+        throw new Error('expected an explicit object surface');
+      }
+      expect(door.include).toContain('create');
+      expect(door.include).not.toContain('update');
+      expect(door.include).not.toContain('delete');
+    }
+  });
+
+  it('ingests idempotently and refuses every evidence rewrite path', async () => {
+    const campaign = await campaigns.create({
+      campaignKey: 'immutable-evidence',
+      name: 'Immutable evidence',
+    });
+    const ingestion = new MetricIngestionService(snapshots);
+    const input = {
+      campaignId: campaign.id ?? '',
+      periodStart: new Date('2026-07-01T00:00:00Z'),
+      periodEnd: new Date('2026-07-01T23:59:59Z'),
+      spendCents: 12_345,
+      impressions: 5_000,
+      clicks: 400,
+      conversions: 30,
+      leads: 20,
+      revenueCents: 75_000,
+      source: 'warehouse-rollup',
+      dedupeKey: 'immutable-evidence:2026-07-01',
+    };
+
+    const first = await ingestion.ingest(input);
+    expect(first.created).toBe(true);
+    const replay = await ingestion.ingest({ ...input, spendCents: 99_999 });
+    expect(replay.created).toBe(false);
+    expect(replay.snapshot.id).toBe(first.snapshot.id);
+    expect(replay.snapshot.spendCents).toBe(12_345);
+
+    first.snapshot.clicks = 999;
+    await expect(first.snapshot.save()).rejects.toThrow(/immutable evidence/);
+    await expect(first.snapshot.delete()).rejects.toThrow(/cannot be deleted/);
+
+    await expect(
+      snapshots.create({
+        ...input,
+        id: first.snapshot.id,
+        _skipLoad: true,
+        clicks: 777,
+      }),
+    ).rejects.toThrow(/immutable evidence/);
+
+    await expect(snapshots.create({ ...input, spendCents: 1 })).rejects.toThrow(
+      /idempotent ingestion/,
+    );
+  });
+
+  it('keeps concurrent retries insert-only and rejects invalid periods', async () => {
+    const campaign = await campaigns.create({
+      campaignKey: 'concurrent-evidence',
+      name: 'Concurrent evidence',
+    });
+    const ingestion = new MetricIngestionService(snapshots);
+    const input = {
+      campaignId: campaign.id ?? '',
+      periodStart: new Date('2026-07-02T00:00:00Z'),
+      periodEnd: new Date('2026-07-02T23:59:59Z'),
+      source: 'warehouse-rollup',
+      dedupeKey: 'concurrent-evidence:2026-07-02',
+    };
+
+    const results = await Promise.all([
+      ingestion.ingest({ ...input, spendCents: 1_000 }),
+      ingestion.ingest({ ...input, spendCents: 9_000 }),
+    ]);
+    expect(results.filter((result) => result.created)).toHaveLength(1);
+    expect(results[0].snapshot.id).toBe(results[1].snapshot.id);
+    const persisted = await snapshots.findByDedupeKey(input.dedupeKey);
+    expect(persisted?.spendCents).toBe(results[0].snapshot.spendCents);
+
+    await expect(
+      ingestion.ingest({
+        ...input,
+        dedupeKey: 'invalid-period',
+        periodStart: 'not-a-date',
+      }),
+    ).rejects.toThrow(/valid dates/);
+  });
+
+  it('uses campaign rollups when present and otherwise sums channel evidence', async () => {
+    const campaign = await campaigns.create({
+      campaignKey: 'pacing',
+      name: 'Pacing campaign',
+      status: 'active',
+      startAt: new Date('2026-07-01T00:00:00Z'),
+      endAt: new Date('2026-07-11T00:00:00Z'),
+      budgetCents: 100_000,
+      currency: 'CAD',
+    });
+    const ads = await channels.create({
+      campaignId: campaign.id ?? '',
+      channelKind: 'ad_group',
+      channelRef: 'ads-ag-1',
+      allocatedBudgetCents: 60_000,
+      status: 'active',
+    });
+    const social = await channels.create({
+      campaignId: campaign.id ?? '',
+      channelKind: 'social_post',
+      channelRef: 'social-post-1',
+      allocatedBudgetCents: 40_000,
+      status: 'active',
+    });
+    const ingestion = new MetricIngestionService(snapshots);
+    const period = {
+      periodStart: new Date('2026-07-01T00:00:00Z'),
+      periodEnd: new Date('2026-07-05T23:59:59Z'),
+      source: 'channel-sync',
+    };
+    await ingestion.ingest({
+      ...period,
+      campaignId: campaign.id ?? '',
+      campaignChannelId: ads.id ?? '',
+      spendCents: 20_000,
+      dedupeKey: 'pacing:ads:first-half',
+    });
+    await ingestion.ingest({
+      ...period,
+      campaignId: campaign.id ?? '',
+      campaignChannelId: social.id ?? '',
+      spendCents: 5_000,
+      dedupeKey: 'pacing:social:first-half',
+    });
+
+    const pacing = new BudgetPacingService(campaigns, channels, snapshots);
+    const at = new Date('2026-07-06T00:00:00Z');
+    const channelOnly = await pacing.getCampaignPacing(campaign.id ?? '', at);
+    expect(channelOnly.spendCents).toBe(25_000);
+    expect(channelOnly.expectedSpendCents).toBe(50_000);
+    expect(channelOnly.status).toBe('behind');
+    expect(channelOnly.usedCampaignRollups).toBe(false);
+
+    await ingestion.ingest({
+      ...period,
+      campaignId: campaign.id ?? '',
+      spendCents: 30_000,
+      dedupeKey: 'pacing:campaign:first-half',
+      source: 'campaign-rollup',
+    });
+    const rolledUp = await pacing.getCampaignPacing(campaign.id ?? '', at);
+    expect(rolledUp.spendCents).toBe(30_000);
+    expect(rolledUp.usedCampaignRollups).toBe(true);
+
+    await ingestion.ingest({
+      campaignId: campaign.id ?? '',
+      campaignChannelId: social.id ?? '',
+      periodStart: new Date('2026-07-06T00:00:00Z'),
+      periodEnd: new Date('2026-07-10T23:59:59Z'),
+      spendCents: 10_000,
+      source: 'channel-sync',
+      dedupeKey: 'pacing:social:second-half',
+    });
+    const mixedPeriods = await pacing.getCampaignPacing(campaign.id ?? '', at);
+    expect(mixedPeriods.spendCents).toBe(40_000);
+    expect(mixedPeriods.usedCampaignRollups).toBe(true);
+
+    const adsPacing = await pacing.getChannelPacing(ads.id ?? '', at);
+    expect(adsPacing.campaignChannelId).toBe(ads.id);
+    expect(adsPacing.spendCents).toBe(20_000);
+    expect(adsPacing.budgetCents).toBe(60_000);
+  });
+});

--- a/packages/marketing/src/collections/CampaignChannelCollection.ts
+++ b/packages/marketing/src/collections/CampaignChannelCollection.ts
@@ -1,0 +1,22 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { CampaignChannel } from '../models/CampaignChannel.js';
+
+export class CampaignChannelCollection extends SmrtCollection<CampaignChannel> {
+  static readonly _itemClass = CampaignChannel;
+
+  async findByCampaign(campaignId: string): Promise<CampaignChannel[]> {
+    return await this.list({
+      where: { campaignId },
+      orderBy: 'start_at ASC',
+    });
+  }
+
+  async findByExecutionRef(
+    channelKind: string,
+    channelRef: string,
+  ): Promise<CampaignChannel[]> {
+    return await this.list({ where: { channelKind, channelRef } });
+  }
+}
+
+export default CampaignChannelCollection;

--- a/packages/marketing/src/collections/CampaignCollection.ts
+++ b/packages/marketing/src/collections/CampaignCollection.ts
@@ -1,0 +1,27 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { Campaign } from '../models/Campaign.js';
+import type { CampaignStatus } from '../types.js';
+
+export class CampaignCollection extends SmrtCollection<Campaign> {
+  static readonly _itemClass = Campaign;
+
+  async findByCampaignKey(
+    campaignKey: string,
+    tenantId?: string | null,
+  ): Promise<Campaign | null> {
+    if (!campaignKey) return null;
+    const where: Record<string, unknown> = { campaignKey };
+    if (tenantId !== undefined) where.tenantId = tenantId;
+    const rows = await this.list({ where, limit: 1 });
+    return rows[0] ?? null;
+  }
+
+  async findByStatus(status: CampaignStatus): Promise<Campaign[]> {
+    return await this.list({
+      where: { status },
+      orderBy: 'start_at ASC',
+    });
+  }
+}
+
+export default CampaignCollection;

--- a/packages/marketing/src/collections/CampaignMetricSnapshotCollection.ts
+++ b/packages/marketing/src/collections/CampaignMetricSnapshotCollection.ts
@@ -25,14 +25,13 @@ export class CampaignMetricSnapshotCollection extends SmrtCollection<CampaignMet
     const existing = await this.findByDedupeKey(dedupeKey);
     if (existing) return { snapshot: existing, created: false };
 
-    const { periodStart, periodEnd, ...rest } = options;
     try {
       const snapshot = await this.create({
-        ...rest,
-        ...(periodStart !== undefined
-          ? { periodStart: new Date(periodStart) }
-          : {}),
-        ...(periodEnd !== undefined ? { periodEnd: new Date(periodEnd) } : {}),
+        ...options,
+        // Keep runtime values uncoerced so the model rejects null/invalid
+        // periods instead of allowing Date(null) to become the Unix epoch.
+        periodStart: options.periodStart as Date | undefined,
+        periodEnd: options.periodEnd as Date | undefined,
         _insertOnly: true,
       });
       return { snapshot, created: true };

--- a/packages/marketing/src/collections/CampaignMetricSnapshotCollection.ts
+++ b/packages/marketing/src/collections/CampaignMetricSnapshotCollection.ts
@@ -1,0 +1,66 @@
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { CampaignMetricSnapshot } from '../models/CampaignMetricSnapshot.js';
+import type { CampaignMetricSnapshotOptions } from '../types.js';
+
+export class CampaignMetricSnapshotCollection extends SmrtCollection<CampaignMetricSnapshot> {
+  static readonly _itemClass = CampaignMetricSnapshot;
+
+  async findByDedupeKey(
+    dedupeKey: string,
+  ): Promise<CampaignMetricSnapshot | null> {
+    if (!dedupeKey) return null;
+    const rows = await this.list({ where: { dedupeKey }, limit: 1 });
+    return rows[0] ?? null;
+  }
+
+  async getOrCreateByDedupeKey(
+    options: CampaignMetricSnapshotOptions,
+  ): Promise<{ snapshot: CampaignMetricSnapshot; created: boolean }> {
+    const dedupeKey = options.dedupeKey ?? '';
+    if (!dedupeKey) {
+      throw new Error(
+        'CampaignMetricSnapshotCollection.getOrCreateByDedupeKey requires a dedupeKey.',
+      );
+    }
+    const existing = await this.findByDedupeKey(dedupeKey);
+    if (existing) return { snapshot: existing, created: false };
+
+    const { periodStart, periodEnd, ...rest } = options;
+    try {
+      const snapshot = await this.create({
+        ...rest,
+        ...(periodStart !== undefined
+          ? { periodStart: new Date(periodStart) }
+          : {}),
+        ...(periodEnd !== undefined ? { periodEnd: new Date(periodEnd) } : {}),
+        _insertOnly: true,
+      });
+      return { snapshot, created: true };
+    } catch (error) {
+      // A concurrent ingest may have won the unique dedupe-key insert after
+      // our initial read. Re-read the immutable winner instead of allowing a
+      // natural-key upsert to replace its evidence in place.
+      const concurrent = await this.findByDedupeKey(dedupeKey);
+      if (concurrent) return { snapshot: concurrent, created: false };
+      throw error;
+    }
+  }
+
+  async findByCampaign(campaignId: string): Promise<CampaignMetricSnapshot[]> {
+    return await this.list({
+      where: { campaignId },
+      orderBy: 'period_start ASC',
+    });
+  }
+
+  async findByChannel(
+    campaignChannelId: string,
+  ): Promise<CampaignMetricSnapshot[]> {
+    return await this.list({
+      where: { campaignChannelId },
+      orderBy: 'period_start ASC',
+    });
+  }
+}
+
+export default CampaignMetricSnapshotCollection;

--- a/packages/marketing/src/collections/index.ts
+++ b/packages/marketing/src/collections/index.ts
@@ -1,0 +1,3 @@
+export * from './CampaignChannelCollection.js';
+export * from './CampaignCollection.js';
+export * from './CampaignMetricSnapshotCollection.js';

--- a/packages/marketing/src/index.ts
+++ b/packages/marketing/src/index.ts
@@ -1,0 +1,8 @@
+/** Campaign coordination, performance evidence, and budget pacing for SMRT. */
+
+import './__smrt-register__.js';
+
+export * from './collections/index.js';
+export * from './models/index.js';
+export * from './services/index.js';
+export * from './types.js';

--- a/packages/marketing/src/models/Campaign.ts
+++ b/packages/marketing/src/models/Campaign.ts
@@ -1,0 +1,177 @@
+/** Campaign identity, budget, schedule, and guarded lifecycle. */
+
+import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import {
+  CAMPAIGN_STATUSES,
+  type CampaignOptions,
+  type CampaignStatus,
+} from '../types.js';
+
+const CAMPAIGN_STATUS_TRANSITIONS: Record<CampaignStatus, CampaignStatus[]> = {
+  draft: ['scheduled'],
+  scheduled: ['active'],
+  active: ['paused', 'completed'],
+  paused: ['active', 'completed'],
+  completed: ['archived'],
+  archived: [],
+};
+
+const loadedCampaignStatus = new WeakMap<Campaign, CampaignStatus>();
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'campaigns',
+  conflictColumns: ['tenant_id', 'campaign_key'],
+  api: { include: ['list', 'get', 'create', 'update'] },
+  mcp: { include: ['list', 'get', 'create', 'update'] },
+  cli: { include: ['list', 'get', 'create', 'update'] },
+})
+export class Campaign extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  /** Stable caller-defined key used by CRM/referral systems. */
+  @field({ required: true })
+  campaignKey: string = '';
+
+  @field({ required: true })
+  name: string = '';
+
+  /** Open objective key such as `awareness` or `demand_generation`. */
+  objective: string = '';
+
+  status: CampaignStatus = 'draft';
+
+  startAt: Date | null = null;
+
+  endAt: Date | null = null;
+
+  /** Total campaign budget in integer cents. */
+  budgetCents: number = 0;
+
+  /** ISO 4217 currency for every campaign/channel amount. */
+  currency: string = 'USD';
+
+  metadata: string = '{}';
+
+  constructor(options: CampaignOptions = {}) {
+    super(options);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.campaignKey !== undefined)
+      this.campaignKey = options.campaignKey;
+    if (options.name !== undefined) this.name = options.name;
+    if (options.objective !== undefined) this.objective = options.objective;
+    if (options.status !== undefined) this.status = options.status;
+    if (options.startAt !== undefined)
+      this.startAt = Campaign.coerceDate(options.startAt);
+    if (options.endAt !== undefined)
+      this.endAt = Campaign.coerceDate(options.endAt);
+    if (options.budgetCents !== undefined)
+      this.budgetCents = options.budgetCents;
+    if (options.currency !== undefined) this.currency = options.currency;
+    if (options.metadata !== undefined) this.metadata = options.metadata;
+  }
+
+  override async initialize(): Promise<this> {
+    await super.initialize();
+    this.startAt = Campaign.coerceDate(this.startAt);
+    this.endAt = Campaign.coerceDate(this.endAt);
+    if (await this.isSaved()) {
+      loadedCampaignStatus.set(this, this.status);
+    }
+    return this;
+  }
+
+  override async save(): Promise<this> {
+    const prior = await this.resolvePriorStatus();
+    this.assertStatusTransition(prior);
+    this.assertSchedule();
+    const result = (await super.save()) as this;
+    loadedCampaignStatus.set(this, this.status);
+    return result;
+  }
+
+  /** Apply one legal transition in memory; callers choose the save boundary. */
+  transitionTo(next: CampaignStatus): this {
+    if (next === this.status) return this;
+    const allowed = CAMPAIGN_STATUS_TRANSITIONS[this.status] ?? [];
+    if (!allowed.includes(next)) {
+      throw new Error(
+        `Campaign ${this.campaignKey || this.id}: cannot transition ` +
+          `'${this.status}' → '${next}'.`,
+      );
+    }
+    this.status = next;
+    return this;
+  }
+
+  getMetadata(): Record<string, unknown> {
+    if (!this.metadata) return {};
+    try {
+      const parsed = JSON.parse(this.metadata) as unknown;
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+
+  setMetadata(metadata: Record<string, unknown>): void {
+    this.metadata = JSON.stringify(metadata ?? {});
+  }
+
+  private assertSchedule(): void {
+    if (
+      this.startAt &&
+      this.endAt &&
+      this.endAt.getTime() < this.startAt.getTime()
+    ) {
+      throw new Error('Campaign endAt must be on or after startAt.');
+    }
+    if (!Number.isInteger(this.budgetCents) || this.budgetCents < 0) {
+      throw new Error('Campaign budgetCents must be a non-negative integer.');
+    }
+  }
+
+  private async resolvePriorStatus(): Promise<CampaignStatus | undefined> {
+    if (this.id) {
+      try {
+        const row = await this.db.get(this.tableName, { id: this.id });
+        if (row && row.status != null) return row.status as CampaignStatus;
+      } catch {
+        // DB not ready / table absent; fall through to the hydrated state.
+      }
+    }
+    return loadedCampaignStatus.get(this);
+  }
+
+  private assertStatusTransition(prior: CampaignStatus | undefined): void {
+    if (!CAMPAIGN_STATUSES.includes(this.status)) {
+      throw new Error(
+        `Campaign ${this.campaignKey || this.id}: unknown status '${this.status}'.`,
+      );
+    }
+    if (prior === undefined || prior === this.status) return;
+    const allowed = CAMPAIGN_STATUS_TRANSITIONS[prior] ?? [];
+    if (!allowed.includes(this.status)) {
+      throw new Error(
+        `Campaign ${this.campaignKey || this.id}: illegal status transition ` +
+          `'${prior}' → '${this.status}'.`,
+      );
+    }
+  }
+
+  private static coerceDate(value: unknown): Date | null {
+    if (value == null) return null;
+    if (value instanceof Date) return value;
+    if (typeof value === 'number' || typeof value === 'string') {
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? null : date;
+    }
+    return null;
+  }
+}
+
+export default Campaign;

--- a/packages/marketing/src/models/Campaign.ts
+++ b/packages/marketing/src/models/Campaign.ts
@@ -144,6 +144,17 @@ export class Campaign extends SmrtObject {
         // DB not ready / table absent; fall through to the hydrated state.
       }
     }
+    if (this.campaignKey) {
+      try {
+        const row = await this.db.get(this.tableName, {
+          tenant_id: this.tenantId,
+          campaign_key: this.campaignKey,
+        });
+        if (row && row.status != null) return row.status as CampaignStatus;
+      } catch {
+        // DB not ready / table absent; fall through to the hydrated state.
+      }
+    }
     return loadedCampaignStatus.get(this);
   }
 

--- a/packages/marketing/src/models/CampaignChannel.ts
+++ b/packages/marketing/src/models/CampaignChannel.ts
@@ -1,0 +1,103 @@
+/** Generic links from a campaign to cross-package channel execution rows. */
+
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type {
+  CampaignChannelOptions,
+  CampaignChannelStatus,
+} from '../types.js';
+import { CAMPAIGN_CHANNEL_STATUSES } from '../types.js';
+import { Campaign } from './Campaign.js';
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'campaign_channels',
+  conflictColumns: ['campaign_id', 'channel_kind', 'channel_ref'],
+  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  mcp: { include: ['list', 'get', 'create', 'update'] },
+  cli: { include: ['list', 'get', 'create', 'update', 'delete'] },
+})
+export class CampaignChannel extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  @foreignKey(Campaign, { required: true })
+  campaignId: string = '';
+
+  /** Open kind vocabulary; recommended values live in CAMPAIGN_CHANNEL_KINDS. */
+  @field({ required: true })
+  channelKind: string = '';
+
+  /** Opaque identifier in the namespace named by channelKind. */
+  @field({ required: true })
+  channelRef: string = '';
+
+  allocatedBudgetCents: number = 0;
+
+  /** Optional execution-specific override of the Campaign start. */
+  startAt: Date | null = null;
+
+  /** Optional execution-specific override of the Campaign end. */
+  endAt: Date | null = null;
+
+  status: CampaignChannelStatus = 'planned';
+
+  constructor(options: CampaignChannelOptions = {}) {
+    super(options);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.campaignId !== undefined) this.campaignId = options.campaignId;
+    if (options.channelKind !== undefined)
+      this.channelKind = options.channelKind;
+    if (options.channelRef !== undefined) this.channelRef = options.channelRef;
+    if (options.allocatedBudgetCents !== undefined)
+      this.allocatedBudgetCents = options.allocatedBudgetCents;
+    if (options.startAt !== undefined)
+      this.startAt = CampaignChannel.coerceDate(options.startAt);
+    if (options.endAt !== undefined)
+      this.endAt = CampaignChannel.coerceDate(options.endAt);
+    if (options.status !== undefined) this.status = options.status;
+  }
+
+  override async initialize(): Promise<this> {
+    await super.initialize();
+    this.startAt = CampaignChannel.coerceDate(this.startAt);
+    this.endAt = CampaignChannel.coerceDate(this.endAt);
+    return this;
+  }
+
+  override async save(): Promise<this> {
+    if (!CAMPAIGN_CHANNEL_STATUSES.includes(this.status)) {
+      throw new Error(
+        `CampaignChannel ${this.channelRef || this.id}: unknown status '${this.status}'.`,
+      );
+    }
+    if (
+      !Number.isInteger(this.allocatedBudgetCents) ||
+      this.allocatedBudgetCents < 0
+    ) {
+      throw new Error(
+        'CampaignChannel allocatedBudgetCents must be a non-negative integer.',
+      );
+    }
+    if (
+      this.startAt &&
+      this.endAt &&
+      this.endAt.getTime() < this.startAt.getTime()
+    ) {
+      throw new Error('CampaignChannel endAt must be on or after startAt.');
+    }
+    return (await super.save()) as this;
+  }
+
+  private static coerceDate(value: unknown): Date | null {
+    if (value == null) return null;
+    if (value instanceof Date) return value;
+    if (typeof value === 'number' || typeof value === 'string') {
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? null : date;
+    }
+    return null;
+  }
+}
+
+export default CampaignChannel;

--- a/packages/marketing/src/models/CampaignMetricSnapshot.ts
+++ b/packages/marketing/src/models/CampaignMetricSnapshot.ts
@@ -95,6 +95,7 @@ export class CampaignMetricSnapshot extends SmrtObject {
 
   override async save(): Promise<this> {
     this.assertMetrics();
+    await this.assertChannelMatchesCampaign();
     const captured = persistedSnapshotState.get(this);
     if (captured !== undefined) {
       if (captured !== this.serializeState()) {
@@ -174,6 +175,19 @@ export class CampaignMetricSnapshot extends SmrtObject {
       (!Number.isInteger(this.revenueCents) || this.revenueCents < 0)
     ) {
       throw new Error('revenueCents must be null or a non-negative integer.');
+    }
+  }
+
+  private async assertChannelMatchesCampaign(): Promise<void> {
+    if (!this.campaignChannelId) return;
+    const channel = (await this.loadRelated(
+      'campaignChannelId',
+    )) as CampaignChannel;
+    if (channel.campaignId !== this.campaignId) {
+      throw new Error(
+        `CampaignMetricSnapshot campaignChannelId '${this.campaignChannelId}' ` +
+          `does not belong to campaignId '${this.campaignId}'.`,
+      );
     }
   }
 

--- a/packages/marketing/src/models/CampaignMetricSnapshot.ts
+++ b/packages/marketing/src/models/CampaignMetricSnapshot.ts
@@ -1,0 +1,210 @@
+/** Immutable period performance evidence for a campaign or campaign channel. */
+
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import type { CampaignMetricSnapshotOptions } from '../types.js';
+import { Campaign } from './Campaign.js';
+import { CampaignChannel } from './CampaignChannel.js';
+
+const persistedSnapshotState = new WeakMap<CampaignMetricSnapshot, string>();
+
+@TenantScoped({ mode: 'optional' })
+@smrt({
+  tableName: 'campaign_metric_snapshots',
+  conflictColumns: ['dedupe_key'],
+  api: { include: ['list', 'get', 'create'] },
+  mcp: { include: ['list', 'get', 'create'] },
+  cli: { include: ['list', 'get', 'create'] },
+})
+export class CampaignMetricSnapshot extends SmrtObject {
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  @foreignKey(Campaign, { required: true })
+  campaignId: string = '';
+
+  /** Null for campaign rollups; set for channel-scoped evidence. */
+  @foreignKey(CampaignChannel, { nullable: true })
+  campaignChannelId: string | null = null;
+
+  @field({ required: true })
+  periodStart: Date = new Date();
+
+  @field({ required: true })
+  periodEnd: Date = new Date();
+
+  spendCents: number = 0;
+
+  impressions: number = 0;
+
+  clicks: number = 0;
+
+  conversions: number = 0;
+
+  leads: number = 0;
+
+  @field({ type: 'integer', nullable: true })
+  revenueCents: number | null = null;
+
+  /** Ingestion source such as `google_ads`, `meta`, or `rollup_job`. */
+  @field({ required: true })
+  source: string = '';
+
+  @field({ required: true })
+  dedupeKey: string = '';
+
+  constructor(options: CampaignMetricSnapshotOptions = {}) {
+    super(options);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.campaignId !== undefined) this.campaignId = options.campaignId;
+    if (options.campaignChannelId !== undefined)
+      this.campaignChannelId = options.campaignChannelId;
+    if (options.periodStart !== undefined)
+      this.periodStart =
+        CampaignMetricSnapshot.coerceDate(options.periodStart) ??
+        new Date(Number.NaN);
+    if (options.periodEnd !== undefined)
+      this.periodEnd =
+        CampaignMetricSnapshot.coerceDate(options.periodEnd) ??
+        new Date(Number.NaN);
+    if (options.spendCents !== undefined) this.spendCents = options.spendCents;
+    if (options.impressions !== undefined)
+      this.impressions = options.impressions;
+    if (options.clicks !== undefined) this.clicks = options.clicks;
+    if (options.conversions !== undefined)
+      this.conversions = options.conversions;
+    if (options.leads !== undefined) this.leads = options.leads;
+    if (options.revenueCents !== undefined)
+      this.revenueCents = options.revenueCents;
+    if (options.source !== undefined) this.source = options.source;
+    if (options.dedupeKey !== undefined) this.dedupeKey = options.dedupeKey;
+  }
+
+  override async initialize(): Promise<this> {
+    await super.initialize();
+    this.periodStart =
+      CampaignMetricSnapshot.coerceDate(this.periodStart) ??
+      new Date(Number.NaN);
+    this.periodEnd =
+      CampaignMetricSnapshot.coerceDate(this.periodEnd) ?? new Date(Number.NaN);
+    if (this.isPersisted) {
+      persistedSnapshotState.set(this, this.serializeState());
+    }
+    return this;
+  }
+
+  override async save(): Promise<this> {
+    this.assertMetrics();
+    const captured = persistedSnapshotState.get(this);
+    if (captured !== undefined) {
+      if (captured !== this.serializeState()) {
+        throw new Error(
+          `CampaignMetricSnapshot ${this.id ?? '<new>'}: metric snapshots ` +
+            'are immutable evidence; ingest a correcting snapshot instead.',
+        );
+      }
+    } else if (this.id && (await this.isSaved())) {
+      throw new Error(
+        `CampaignMetricSnapshot ${this.id}: refusing to overwrite an existing ` +
+          'snapshot from a non-hydrated instance; snapshots are immutable evidence.',
+      );
+    } else if (this.dedupeKey) {
+      try {
+        const row = await this.db.get(this.tableName, {
+          dedupe_key: this.dedupeKey,
+        });
+        if (row && row.id !== this.id) {
+          throw new Error(
+            `CampaignMetricSnapshot (dedupeKey '${this.dedupeKey}'): a ` +
+              'snapshot with this dedupe key already exists; use ' +
+              'MetricIngestionService for idempotent ingestion.',
+          );
+        }
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes('idempotent ingestion')
+        ) {
+          throw error;
+        }
+        // DB not ready / table absent; there is no persisted row to protect.
+      }
+    }
+
+    const result = (await super.save()) as this;
+    persistedSnapshotState.set(this, this.serializeState());
+    return result;
+  }
+
+  override async delete(): Promise<void> {
+    throw new Error(
+      `CampaignMetricSnapshot ${this.id ?? '<new>'}: metric snapshots are ` +
+        'immutable evidence and cannot be deleted.',
+    );
+  }
+
+  private assertMetrics(): void {
+    if (
+      Number.isNaN(this.periodStart.getTime()) ||
+      Number.isNaN(this.periodEnd.getTime())
+    ) {
+      throw new Error(
+        'CampaignMetricSnapshot periodStart and periodEnd must be valid dates.',
+      );
+    }
+    if (this.periodEnd.getTime() < this.periodStart.getTime()) {
+      throw new Error(
+        'CampaignMetricSnapshot periodEnd must be on or after periodStart.',
+      );
+    }
+    const integerMetrics: Array<[string, number]> = [
+      ['spendCents', this.spendCents],
+      ['impressions', this.impressions],
+      ['clicks', this.clicks],
+      ['conversions', this.conversions],
+      ['leads', this.leads],
+    ];
+    for (const [name, value] of integerMetrics) {
+      if (!Number.isInteger(value) || value < 0) {
+        throw new Error(`${name} must be a non-negative integer.`);
+      }
+    }
+    if (
+      this.revenueCents !== null &&
+      (!Number.isInteger(this.revenueCents) || this.revenueCents < 0)
+    ) {
+      throw new Error('revenueCents must be null or a non-negative integer.');
+    }
+  }
+
+  private serializeState(): string {
+    return JSON.stringify({
+      tenantId: this.tenantId,
+      campaignId: this.campaignId,
+      campaignChannelId: this.campaignChannelId,
+      periodStart: this.periodStart.toISOString(),
+      periodEnd: this.periodEnd.toISOString(),
+      spendCents: this.spendCents,
+      impressions: this.impressions,
+      clicks: this.clicks,
+      conversions: this.conversions,
+      leads: this.leads,
+      revenueCents: this.revenueCents,
+      source: this.source,
+      dedupeKey: this.dedupeKey,
+    });
+  }
+
+  private static coerceDate(value: unknown): Date | null {
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime()) ? null : value;
+    }
+    if (typeof value === 'number' || typeof value === 'string') {
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? null : date;
+    }
+    return null;
+  }
+}
+
+export default CampaignMetricSnapshot;

--- a/packages/marketing/src/models/index.ts
+++ b/packages/marketing/src/models/index.ts
@@ -1,0 +1,3 @@
+export * from './Campaign.js';
+export * from './CampaignChannel.js';
+export * from './CampaignMetricSnapshot.js';

--- a/packages/marketing/src/services/BudgetPacingService.ts
+++ b/packages/marketing/src/services/BudgetPacingService.ts
@@ -1,0 +1,207 @@
+import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import {
+  CampaignChannelCollection,
+  CampaignCollection,
+  CampaignMetricSnapshotCollection,
+} from '../collections/index.js';
+import type { Campaign } from '../models/Campaign.js';
+import type { CampaignMetricSnapshot } from '../models/CampaignMetricSnapshot.js';
+import type { BudgetPacingResult, BudgetPacingStatus } from '../types.js';
+
+/** Computes spend-to-budget pacing from immutable snapshots; stores nothing. */
+export class BudgetPacingService {
+  constructor(
+    private readonly campaigns: CampaignCollection,
+    private readonly channels: CampaignChannelCollection,
+    private readonly snapshots: CampaignMetricSnapshotCollection,
+  ) {}
+
+  static async create(
+    classOptions: SmrtClassOptions = {},
+  ): Promise<BudgetPacingService> {
+    return new BudgetPacingService(
+      await CampaignCollection.create(classOptions),
+      await CampaignChannelCollection.create(classOptions),
+      await CampaignMetricSnapshotCollection.create(classOptions),
+    );
+  }
+
+  async getCampaignPacing(
+    campaignId: string,
+    at = new Date(),
+  ): Promise<BudgetPacingResult> {
+    const campaign = await this.campaigns.get({ id: campaignId });
+    if (!campaign) throw new Error(`Campaign '${campaignId}' was not found.`);
+
+    const all = await this.snapshots.findByCampaign(campaignId);
+    const rollups = all.filter((snapshot) => !snapshot.campaignChannelId);
+    const used = this.selectCampaignEvidence(all);
+    return this.calculate({
+      campaign,
+      snapshots: used,
+      budgetCents: campaign.budgetCents,
+      startAt: campaign.startAt,
+      endAt: campaign.endAt,
+      at,
+      usedCampaignRollups: rollups.length > 0,
+    });
+  }
+
+  async getChannelPacing(
+    campaignChannelId: string,
+    at = new Date(),
+  ): Promise<BudgetPacingResult> {
+    const channel = await this.channels.get({ id: campaignChannelId });
+    if (!channel) {
+      throw new Error(`CampaignChannel '${campaignChannelId}' was not found.`);
+    }
+    const campaign = await this.campaigns.get({ id: channel.campaignId });
+    if (!campaign) {
+      throw new Error(`Campaign '${channel.campaignId}' was not found.`);
+    }
+    const snapshots = await this.snapshots.findByChannel(campaignChannelId);
+    return {
+      ...this.calculate({
+        campaign,
+        snapshots,
+        budgetCents: channel.allocatedBudgetCents,
+        startAt: channel.startAt ?? campaign.startAt,
+        endAt: channel.endAt ?? campaign.endAt,
+        at,
+        usedCampaignRollups: false,
+      }),
+      campaignChannelId,
+    };
+  }
+
+  private calculate({
+    campaign,
+    snapshots,
+    budgetCents,
+    startAt,
+    endAt,
+    at,
+    usedCampaignRollups,
+  }: {
+    campaign: Campaign;
+    snapshots: CampaignMetricSnapshot[];
+    budgetCents: number;
+    startAt: Date | null;
+    endAt: Date | null;
+    at: Date;
+    usedCampaignRollups: boolean;
+  }): BudgetPacingResult {
+    const spendCents = snapshots.reduce(
+      (sum, snapshot) => sum + snapshot.spendCents,
+      0,
+    );
+    const elapsedFraction = this.elapsedFraction(startAt, endAt, at);
+    const expectedSpendCents =
+      elapsedFraction === null
+        ? null
+        : Math.round(budgetCents * elapsedFraction);
+    const varianceCents =
+      expectedSpendCents === null ? null : spendCents - expectedSpendCents;
+    const budgetFraction = budgetCents > 0 ? spendCents / budgetCents : null;
+
+    return {
+      campaignId: campaign.id ?? '',
+      currency: campaign.currency,
+      budgetCents,
+      spendCents,
+      remainingCents: budgetCents - spendCents,
+      expectedSpendCents,
+      varianceCents,
+      budgetFraction,
+      elapsedFraction,
+      status: this.pacingStatus({
+        campaign,
+        budgetCents,
+        spendCents,
+        elapsedFraction,
+        varianceCents,
+        startAt,
+        at,
+      }),
+      snapshotCount: snapshots.length,
+      usedCampaignRollups,
+    };
+  }
+
+  private pacingStatus({
+    campaign,
+    budgetCents,
+    spendCents,
+    elapsedFraction,
+    varianceCents,
+    startAt,
+    at,
+  }: {
+    campaign: Campaign;
+    budgetCents: number;
+    spendCents: number;
+    elapsedFraction: number | null;
+    varianceCents: number | null;
+    startAt: Date | null;
+    at: Date;
+  }): BudgetPacingStatus {
+    if (budgetCents <= 0) return 'unbudgeted';
+    if (spendCents > budgetCents) return 'over_budget';
+    if (startAt && at.getTime() < startAt.getTime()) {
+      return 'not_started';
+    }
+    if (
+      campaign.status === 'completed' ||
+      campaign.status === 'archived' ||
+      elapsedFraction === 1
+    ) {
+      return 'complete';
+    }
+    if (varianceCents === null) return 'on_track';
+
+    // A five-percent budget band avoids noisy status flips from minor timing
+    // differences between spend collection and scheduled pacing.
+    const toleranceCents = Math.max(1, Math.round(budgetCents * 0.05));
+    if (varianceCents > toleranceCents) return 'ahead';
+    if (varianceCents < -toleranceCents) return 'behind';
+    return 'on_track';
+  }
+
+  /**
+   * Prefer a campaign rollup for each exact reporting period, while retaining
+   * channel evidence for periods that do not yet have a rollup. This prevents
+   * double counting without dropping earlier/later channel-only periods.
+   */
+  private selectCampaignEvidence(
+    snapshots: CampaignMetricSnapshot[],
+  ): CampaignMetricSnapshot[] {
+    const rollupPeriods = new Set(
+      snapshots
+        .filter((snapshot) => !snapshot.campaignChannelId)
+        .map((snapshot) => this.periodKey(snapshot)),
+    );
+    return snapshots.filter(
+      (snapshot) =>
+        !snapshot.campaignChannelId ||
+        !rollupPeriods.has(this.periodKey(snapshot)),
+    );
+  }
+
+  private periodKey(snapshot: CampaignMetricSnapshot): string {
+    return `${snapshot.periodStart.toISOString()}:${snapshot.periodEnd.toISOString()}`;
+  }
+
+  private elapsedFraction(
+    startAt: Date | null,
+    endAt: Date | null,
+    at: Date,
+  ): number | null {
+    if (!startAt || !endAt) return null;
+    const start = startAt.getTime();
+    const end = endAt.getTime();
+    if (end <= start) return at.getTime() < start ? 0 : 1;
+    return Math.min(1, Math.max(0, (at.getTime() - start) / (end - start)));
+  }
+}
+
+export default BudgetPacingService;

--- a/packages/marketing/src/services/CampaignLifecycleService.ts
+++ b/packages/marketing/src/services/CampaignLifecycleService.ts
@@ -1,0 +1,54 @@
+import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import { CampaignCollection } from '../collections/CampaignCollection.js';
+import type { Campaign } from '../models/Campaign.js';
+import type { CampaignStatus } from '../types.js';
+
+/** Single authoritative write path for Campaign lifecycle changes. */
+export class CampaignLifecycleService {
+  constructor(private readonly campaigns: CampaignCollection) {}
+
+  static async create(
+    classOptions: SmrtClassOptions = {},
+  ): Promise<CampaignLifecycleService> {
+    return new CampaignLifecycleService(
+      await CampaignCollection.create(classOptions),
+    );
+  }
+
+  async transition(
+    campaignId: string,
+    next: CampaignStatus,
+  ): Promise<Campaign> {
+    const campaign = await this.campaigns.get({ id: campaignId });
+    if (!campaign) throw new Error(`Campaign '${campaignId}' was not found.`);
+    campaign.transitionTo(next);
+    await campaign.save();
+    return campaign;
+  }
+
+  async schedule(campaignId: string): Promise<Campaign> {
+    return await this.transition(campaignId, 'scheduled');
+  }
+
+  async activate(campaignId: string): Promise<Campaign> {
+    return await this.transition(campaignId, 'active');
+  }
+
+  async pause(campaignId: string): Promise<Campaign> {
+    return await this.transition(campaignId, 'paused');
+  }
+
+  async resume(campaignId: string): Promise<Campaign> {
+    return await this.transition(campaignId, 'active');
+  }
+
+  async complete(campaignId: string): Promise<Campaign> {
+    return await this.transition(campaignId, 'completed');
+  }
+
+  async archive(campaignId: string): Promise<Campaign> {
+    return await this.transition(campaignId, 'archived');
+  }
+}
+
+export default CampaignLifecycleService;

--- a/packages/marketing/src/services/MetricIngestionService.ts
+++ b/packages/marketing/src/services/MetricIngestionService.ts
@@ -1,0 +1,37 @@
+import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import { CampaignMetricSnapshotCollection } from '../collections/CampaignMetricSnapshotCollection.js';
+import type { CampaignMetricSnapshot } from '../models/CampaignMetricSnapshot.js';
+import type { CampaignMetricSnapshotOptions } from '../types.js';
+
+/** Idempotent, validation-first ingestion for immutable metric evidence. */
+export class MetricIngestionService {
+  constructor(private readonly snapshots: CampaignMetricSnapshotCollection) {}
+
+  static async create(
+    classOptions: SmrtClassOptions = {},
+  ): Promise<MetricIngestionService> {
+    return new MetricIngestionService(
+      await CampaignMetricSnapshotCollection.create(classOptions),
+    );
+  }
+
+  async ingest(
+    options: CampaignMetricSnapshotOptions,
+  ): Promise<{ snapshot: CampaignMetricSnapshot; created: boolean }> {
+    if (!options.campaignId) {
+      throw new Error('Metric ingestion requires campaignId.');
+    }
+    if (!options.source?.trim()) {
+      throw new Error('Metric ingestion requires source.');
+    }
+    if (!options.dedupeKey?.trim()) {
+      throw new Error('Metric ingestion requires dedupeKey.');
+    }
+    if (options.periodStart === undefined || options.periodEnd === undefined) {
+      throw new Error('Metric ingestion requires periodStart and periodEnd.');
+    }
+    return await this.snapshots.getOrCreateByDedupeKey(options);
+  }
+}
+
+export default MetricIngestionService;

--- a/packages/marketing/src/services/MetricIngestionService.ts
+++ b/packages/marketing/src/services/MetricIngestionService.ts
@@ -27,7 +27,7 @@ export class MetricIngestionService {
     if (!options.dedupeKey?.trim()) {
       throw new Error('Metric ingestion requires dedupeKey.');
     }
-    if (options.periodStart === undefined || options.periodEnd === undefined) {
+    if (options.periodStart == null || options.periodEnd == null) {
       throw new Error('Metric ingestion requires periodStart and periodEnd.');
     }
     return await this.snapshots.getOrCreateByDedupeKey(options);

--- a/packages/marketing/src/services/index.ts
+++ b/packages/marketing/src/services/index.ts
@@ -1,0 +1,3 @@
+export * from './BudgetPacingService.js';
+export * from './CampaignLifecycleService.js';
+export * from './MetricIngestionService.js';

--- a/packages/marketing/src/svelte/__tests__/components.test.ts
+++ b/packages/marketing/src/svelte/__tests__/components.test.ts
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import BudgetPacing from '../components/BudgetPacing.svelte';
+import CampaignDetail from '../components/CampaignDetail.svelte';
+import CampaignList from '../components/CampaignList.svelte';
+import ChannelMix from '../components/ChannelMix.svelte';
+import MarketingDashboard from '../components/MarketingDashboard.svelte';
+import type {
+  BudgetPacingView,
+  CampaignChannelView,
+  CampaignDetailView,
+  CampaignSummaryView,
+} from '../types.js';
+
+const campaign: CampaignSummaryView = {
+  id: 'campaign-1',
+  campaignKey: 'summer-launch',
+  name: 'Summer launch',
+  objective: 'lead_generation',
+  status: 'active',
+  startAt: '2026-07-01T00:00:00.000Z',
+  endAt: '2026-07-31T00:00:00.000Z',
+  budgetCents: 10_000,
+  currency: 'USD',
+  spendCents: 2_500,
+  impressions: 4_000,
+  clicks: 80,
+  conversions: 4,
+  leads: 12,
+  channelCount: 2,
+};
+
+const channels: CampaignChannelView[] = [
+  {
+    id: 'channel-social',
+    channelKind: 'social',
+    channelRef: 'social:post-1',
+    label: 'Social post',
+    status: 'active',
+    allocatedBudgetCents: 7_500,
+    spendCents: 2_000,
+    impressions: 3_000,
+    clicks: 60,
+    leads: 10,
+  },
+  {
+    id: 'channel-ad',
+    channelKind: 'ads',
+    channelRef: 'ads:campaign-1',
+    label: 'Paid campaign',
+    status: 'scheduled',
+    allocatedBudgetCents: 2_500,
+    spendCents: 500,
+    impressions: 1_000,
+    clicks: 20,
+    leads: 2,
+  },
+];
+
+describe('marketing Svelte surfaces', () => {
+  it('renders dashboard totals from public campaign props', () => {
+    render(MarketingDashboard, {
+      props: { campaigns: [campaign], locale: 'en-US' },
+    });
+
+    expect(screen.getByText('1 active')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('$25.00 spent')).toBeInTheDocument();
+    expect(screen.getByText('of $100.00 budget')).toBeInTheDocument();
+  });
+
+  it('renders campaign rows and reports selection through its callback', async () => {
+    const onSelect = vi.fn();
+    render(CampaignList, {
+      props: { campaigns: [campaign], locale: 'en-US', onSelect },
+    });
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByText('Summer launch')).toBeInTheDocument();
+    await fireEvent.click(screen.getByRole('button', { name: 'View' }));
+    expect(onSelect).toHaveBeenCalledWith('campaign-1');
+  });
+
+  it('renders campaign details and generic channel references', () => {
+    const detail: CampaignDetailView = {
+      ...campaign,
+      description: 'A cross-channel launch.',
+    };
+    render(CampaignDetail, {
+      props: { campaign: detail, channels, locale: 'en-US' },
+    });
+
+    expect(
+      screen.getByRole('heading', { name: 'Summer launch' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('A cross-channel launch.')).toBeInTheDocument();
+    expect(screen.getByText('Social post')).toBeInTheDocument();
+    expect(screen.getByText('social:post-1')).toBeInTheDocument();
+  });
+
+  it('renders channel mix percentages and cent-based spend', () => {
+    render(ChannelMix, {
+      props: { channels, currency: 'USD', locale: 'en-US' },
+    });
+
+    expect(
+      screen.getByRole('heading', { name: 'Channel mix' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('$20.00 spent')).toBeInTheDocument();
+    expect(screen.getByText('80% of mix')).toBeInTheDocument();
+    expect(screen.getByText('$5.00 spent')).toBeInTheDocument();
+    expect(screen.getByText('20% of mix')).toBeInTheDocument();
+  });
+
+  it('renders budget pacing state and formatted evidence', () => {
+    const pacing: BudgetPacingView = {
+      campaignId: campaign.id,
+      currency: 'USD',
+      budgetCents: 10_000,
+      spendCents: 4_000,
+      remainingCents: 6_000,
+      expectedSpendCents: 3_500,
+      varianceCents: 500,
+      budgetFraction: 0.4,
+      elapsedFraction: 0.35,
+      status: 'on_track',
+    };
+    render(BudgetPacing, { props: { pacing, locale: 'en-US' } });
+
+    expect(
+      screen.getByRole('heading', { name: 'Budget pacing' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('On track')).toBeInTheDocument();
+    expect(screen.getByText('$40.00 spent')).toBeInTheDocument();
+    expect(screen.getByText('40%')).toBeInTheDocument();
+    expect(screen.getByText('$60.00')).toBeInTheDocument();
+  });
+});

--- a/packages/marketing/src/svelte/__tests__/helpers.test.ts
+++ b/packages/marketing/src/svelte/__tests__/helpers.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calculateChannelMix,
+  campaignStatusBadgeVariant,
+  cappedBudgetProgress,
+  pacingStatusBadgeVariant,
+  summarizeMarketingDashboard,
+} from '../types.js';
+
+describe('marketing Svelte helpers', () => {
+  it('summarizes campaign metrics without mixing currencies', () => {
+    const summary = summarizeMarketingDashboard([
+      {
+        id: 'campaign-1',
+        campaignKey: 'one',
+        name: 'One',
+        status: 'active',
+        budgetCents: 100_000,
+        spendCents: 40_000,
+        currency: 'CAD',
+        channelCount: 2,
+        impressions: 10_000,
+        clicks: 500,
+        conversions: 20,
+        leads: 12,
+      },
+      {
+        id: 'campaign-2',
+        campaignKey: 'two',
+        name: 'Two',
+        status: 'completed',
+        budgetCents: 50_000,
+        spendCents: 45_000,
+        currency: 'CAD',
+        channelCount: 1,
+        leads: 5,
+      },
+      {
+        id: 'campaign-3',
+        campaignKey: 'three',
+        name: 'Three',
+        status: 'draft',
+        budgetCents: 80_000,
+        spendCents: 0,
+        currency: 'USD',
+      },
+    ]);
+
+    expect(summary.activeCampaignCount).toBe(1);
+    expect(summary.channelCount).toBe(3);
+    expect(summary.leads).toBe(17);
+    expect(summary.currencyTotals).toEqual([
+      { currency: 'CAD', budgetCents: 150_000, spendCents: 85_000 },
+      { currency: 'USD', budgetCents: 80_000, spendCents: 0 },
+    ]);
+  });
+
+  it('calculates channel spend and allocation fractions independently', () => {
+    const mix = calculateChannelMix([
+      {
+        id: 'ads',
+        channelKind: 'ad_group',
+        channelRef: 'ag-1',
+        status: 'active',
+        allocatedBudgetCents: 75_000,
+        spendCents: 30_000,
+      },
+      {
+        id: 'social',
+        channelKind: 'social_post',
+        channelRef: 'post-1',
+        status: 'active',
+        allocatedBudgetCents: 25_000,
+        spendCents: 10_000,
+      },
+    ]);
+    expect(mix[0]?.spendFraction).toBe(0.75);
+    expect(mix[0]?.allocationFraction).toBe(0.75);
+    expect(mix[1]?.spendFraction).toBe(0.25);
+  });
+
+  it('caps visual progress while preserving status semantics', () => {
+    expect(
+      cappedBudgetProgress({
+        campaignId: 'campaign-1',
+        currency: 'CAD',
+        budgetCents: 100,
+        spendCents: 125,
+        remainingCents: -25,
+        expectedSpendCents: 50,
+        varianceCents: 75,
+        budgetFraction: 1.25,
+        elapsedFraction: 0.5,
+        status: 'over_budget',
+      }),
+    ).toBe(1);
+    expect(pacingStatusBadgeVariant('over_budget')).toBe('error');
+    expect(pacingStatusBadgeVariant('on_track')).toBe('success');
+    expect(campaignStatusBadgeVariant('paused')).toBe('warning');
+  });
+});

--- a/packages/marketing/src/svelte/__tests__/helpers.test.ts
+++ b/packages/marketing/src/svelte/__tests__/helpers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { formatCents } from '../format.js';
 import {
   calculateChannelMix,
   campaignStatusBadgeVariant,
@@ -8,6 +9,13 @@ import {
 } from '../types.js';
 
 describe('marketing Svelte helpers', () => {
+  it('keeps currency formatting render-safe for invalid inputs', () => {
+    expect(formatCents(12_345, 'NOT_A_CODE', 'en-US')).toBe(
+      '123.45 NOT_A_CODE',
+    );
+    expect(formatCents(Number.NaN, 'USD', 'en-US')).toBe('—');
+  });
+
   it('summarizes campaign metrics without mixing currencies', () => {
     const summary = summarizeMarketingDashboard([
       {

--- a/packages/marketing/src/svelte/components/BudgetPacing.svelte
+++ b/packages/marketing/src/svelte/components/BudgetPacing.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+import { Progress } from '@happyvertical/smrt-ui/feedback';
+import { Badge, Card } from '@happyvertical/smrt-ui/ui';
+import { formatCents, formatPercent, humanizeKey } from '../format.js';
+import type { BudgetPacingView } from '../types.js';
+import { cappedBudgetProgress, pacingStatusBadgeVariant } from '../types.js';
+
+export interface Props {
+  pacing?: BudgetPacingView | null;
+  locale?: string;
+  label?: string;
+}
+
+let { pacing = null, locale, label = 'Budget pacing' }: Props = $props();
+const progress = $derived(pacing ? cappedBudgetProgress(pacing) : 0);
+</script>
+
+{#if !pacing}
+  <p class="empty">No budget pacing is available.</p>
+{:else}
+  <Card padding="sm" variant="outlined">
+    <section class="budget-pacing">
+      <header>
+        <h3>{label}</h3>
+        <Badge variant={pacingStatusBadgeVariant(pacing.status)} size="sm">
+          {humanizeKey(pacing.status)}
+        </Badge>
+      </header>
+
+      <div class="progress-label">
+        <span>{formatCents(pacing.spendCents, pacing.currency, locale)} spent</span>
+        <span>
+          {pacing.budgetFraction === null
+            ? 'No budget'
+            : formatPercent(pacing.budgetFraction, locale)}
+        </span>
+      </div>
+      <Progress value={progress} max={1} label={label} />
+
+      <dl class="facts">
+        <div>
+          <dt>Budget</dt>
+          <dd>{formatCents(pacing.budgetCents, pacing.currency, locale)}</dd>
+        </div>
+        <div>
+          <dt>Remaining</dt>
+          <dd class:negative={pacing.remainingCents < 0}>
+            {formatCents(pacing.remainingCents, pacing.currency, locale)}
+          </dd>
+        </div>
+        <div>
+          <dt>Expected by now</dt>
+          <dd>
+            {pacing.expectedSpendCents === null
+              ? '—'
+              : formatCents(pacing.expectedSpendCents, pacing.currency, locale)}
+          </dd>
+        </div>
+        <div>
+          <dt>Variance</dt>
+          <dd class:negative={(pacing.varianceCents ?? 0) > 0}>
+            {pacing.varianceCents === null
+              ? '—'
+              : formatCents(pacing.varianceCents, pacing.currency, locale)}
+          </dd>
+        </div>
+      </dl>
+    </section>
+  </Card>
+{/if}
+
+<style>
+  .budget-pacing {
+    display: flex;
+    flex-direction: column;
+    gap: var(--smrt-spacing-2);
+  }
+
+  header,
+  .progress-label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--smrt-spacing-3);
+  }
+
+  h3,
+  .empty {
+    margin: 0;
+  }
+
+  h3 {
+    color: var(--smrt-color-on-surface);
+    font: var(--smrt-typography-title-medium-font);
+  }
+
+  .empty,
+  .progress-label,
+  dt {
+    color: var(--smrt-color-on-surface-variant);
+  }
+
+  .empty {
+    font: var(--smrt-typography-body-medium-font);
+  }
+
+  .progress-label,
+  dt {
+    font: var(--smrt-typography-body-small-font);
+  }
+
+  .facts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+    gap: var(--smrt-spacing-3);
+    margin: var(--smrt-spacing-3) 0 0;
+  }
+
+  .facts dd {
+    margin: var(--smrt-spacing-1) 0 0;
+    color: var(--smrt-color-on-surface);
+    font: var(--smrt-typography-body-medium-font);
+    font-weight: var(--smrt-typography-weight-medium);
+  }
+
+  .facts dd.negative {
+    color: var(--smrt-color-error);
+  }
+</style>

--- a/packages/marketing/src/svelte/components/CampaignDetail.svelte
+++ b/packages/marketing/src/svelte/components/CampaignDetail.svelte
@@ -1,0 +1,208 @@
+<script lang="ts">
+import { Badge, Card } from '@happyvertical/smrt-ui/ui';
+import type { Snippet } from 'svelte';
+import {
+  formatCents,
+  formatDateRange,
+  formatNumber,
+  humanizeKey,
+} from '../format.js';
+import type { CampaignChannelView, CampaignDetailView } from '../types.js';
+import { campaignStatusBadgeVariant } from '../types.js';
+
+export interface Props {
+  campaign?: CampaignDetailView | null;
+  channels?: CampaignChannelView[];
+  locale?: string;
+  pacing?: Snippet;
+  channelMix?: Snippet;
+  children?: Snippet;
+}
+
+let {
+  campaign = null,
+  channels = [],
+  locale,
+  pacing,
+  channelMix,
+  children,
+}: Props = $props();
+</script>
+
+{#if !campaign}
+  <p class="empty">Select a campaign to see its details.</p>
+{:else}
+  <article class="campaign-detail">
+    <Card variant="outlined">
+      <header class="header">
+        <div>
+          <p class="eyebrow">{campaign.campaignKey}</p>
+          <h2>{campaign.name}</h2>
+          {#if campaign.description}<p class="description">{campaign.description}</p>{/if}
+        </div>
+        <Badge variant={campaignStatusBadgeVariant(campaign.status)}>
+          {humanizeKey(campaign.status)}
+        </Badge>
+      </header>
+
+      <dl class="facts">
+        <div>
+          <dt>Objective</dt>
+          <dd>{campaign.objective ? humanizeKey(campaign.objective) : '—'}</dd>
+        </div>
+        <div>
+          <dt>Schedule</dt>
+          <dd>{formatDateRange(campaign.startAt, campaign.endAt, locale)}</dd>
+        </div>
+        <div>
+          <dt>Budget</dt>
+          <dd>{formatCents(campaign.budgetCents, campaign.currency, locale)}</dd>
+        </div>
+        <div>
+          <dt>Spend</dt>
+          <dd>{formatCents(campaign.spendCents ?? 0, campaign.currency, locale)}</dd>
+        </div>
+        <div>
+          <dt>Impressions</dt>
+          <dd>{formatNumber(campaign.impressions ?? 0, locale)}</dd>
+        </div>
+        <div>
+          <dt>Leads</dt>
+          <dd>{formatNumber(campaign.leads ?? 0, locale)}</dd>
+        </div>
+      </dl>
+    </Card>
+
+    {#if channels.length > 0}
+      <Card padding="sm">
+        <section class="channels" aria-label="Campaign channels">
+          <h3>Executions</h3>
+          <ul>
+            {#each channels as channel (channel.id)}
+              <li>
+                <span>
+                  <span class="channel-name">{channel.label ?? humanizeKey(channel.channelKind)}</span>
+                  <span class="channel-ref">{channel.channelRef}</span>
+                </span>
+                <Badge variant={campaignStatusBadgeVariant(channel.status)} size="sm">
+                  {humanizeKey(channel.status)}
+                </Badge>
+              </li>
+            {/each}
+          </ul>
+        </section>
+      </Card>
+    {/if}
+
+    {#if pacing}<section aria-label="Budget pacing">{@render pacing()}</section>{/if}
+    {#if channelMix}<section aria-label="Channel mix">{@render channelMix()}</section>{/if}
+    {@render children?.()}
+  </article>
+{/if}
+
+<style>
+  .campaign-detail {
+    display: flex;
+    flex-direction: column;
+    gap: var(--smrt-spacing-4);
+  }
+
+  .empty,
+  .description,
+  .channel-ref {
+    color: var(--smrt-color-on-surface-variant);
+  }
+
+  .empty,
+  .description {
+    margin: 0;
+    font: var(--smrt-typography-body-medium-font);
+  }
+
+  .header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--smrt-spacing-4);
+  }
+
+  .eyebrow {
+    margin: 0;
+    color: var(--smrt-color-on-surface-variant);
+    font: var(--smrt-typography-label-medium-font);
+  }
+
+  h2,
+  h3 {
+    margin: 0;
+    color: var(--smrt-color-on-surface);
+  }
+
+  h2 {
+    font: var(--smrt-typography-headline-small-font);
+  }
+
+  h3 {
+    font: var(--smrt-typography-title-medium-font);
+  }
+
+  .description {
+    margin-top: var(--smrt-spacing-2);
+  }
+
+  .facts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    gap: var(--smrt-spacing-4);
+    margin: var(--smrt-spacing-5) 0 0;
+  }
+
+  .facts dt {
+    color: var(--smrt-color-on-surface-variant);
+    font: var(--smrt-typography-label-medium-font);
+  }
+
+  .facts dd {
+    margin: var(--smrt-spacing-1) 0 0;
+    color: var(--smrt-color-on-surface);
+    font: var(--smrt-typography-body-large-font);
+    font-weight: var(--smrt-typography-weight-medium);
+  }
+
+  .channels h3 {
+    margin-bottom: var(--smrt-spacing-3);
+  }
+
+  ul {
+    display: flex;
+    flex-direction: column;
+    gap: var(--smrt-spacing-2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--smrt-spacing-3);
+    padding-bottom: var(--smrt-spacing-2);
+    border-bottom: 1px solid var(--smrt-color-outline-variant);
+  }
+
+  .channel-name,
+  .channel-ref {
+    display: block;
+  }
+
+  .channel-name {
+    color: var(--smrt-color-on-surface);
+    font: var(--smrt-typography-body-medium-font);
+    font-weight: var(--smrt-typography-weight-medium);
+  }
+
+  .channel-ref {
+    font: var(--smrt-typography-body-small-font);
+  }
+</style>

--- a/packages/marketing/src/svelte/components/CampaignList.svelte
+++ b/packages/marketing/src/svelte/components/CampaignList.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+import { Badge, Button } from '@happyvertical/smrt-ui/ui';
+import { formatCents, formatDateRange, humanizeKey } from '../format.js';
+import type { CampaignSummaryView } from '../types.js';
+import { campaignStatusBadgeVariant } from '../types.js';
+
+export interface Props {
+  campaigns?: CampaignSummaryView[];
+  selectedCampaignId?: string;
+  locale?: string;
+  onSelect?: (campaignId: string) => void;
+}
+
+let { campaigns = [], selectedCampaignId, locale, onSelect }: Props = $props();
+</script>
+
+<div class="campaign-list">
+  {#if campaigns.length === 0}
+    <p class="empty">No campaigns yet.</p>
+  {:else}
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">Campaign</th>
+          <th scope="col">Status</th>
+          <th scope="col">Schedule</th>
+          <th scope="col" class="number">Spend / budget</th>
+          <th scope="col" class="number">Channels</th>
+          {#if onSelect}<th scope="col"><span class="visually-hidden">Actions</span></th>{/if}
+        </tr>
+      </thead>
+      <tbody>
+        {#each campaigns as campaign (campaign.id)}
+          <tr class:selected={campaign.id === selectedCampaignId}>
+            <td>
+              <span class="name">{campaign.name}</span>
+              <span class="secondary">{campaign.campaignKey}</span>
+              {#if campaign.objective}
+                <span class="secondary">{humanizeKey(campaign.objective)}</span>
+              {/if}
+            </td>
+            <td>
+              <Badge variant={campaignStatusBadgeVariant(campaign.status)} size="sm">
+                {humanizeKey(campaign.status)}
+              </Badge>
+            </td>
+            <td>{formatDateRange(campaign.startAt, campaign.endAt, locale)}</td>
+            <td class="number">
+              <span class="name">
+                {formatCents(campaign.spendCents ?? 0, campaign.currency, locale)}
+              </span>
+              <span class="secondary">
+                of {formatCents(campaign.budgetCents, campaign.currency, locale)}
+              </span>
+            </td>
+            <td class="number">{campaign.channelCount ?? 0}</td>
+            {#if onSelect}
+              <td class="action">
+                <Button
+                  variant={campaign.id === selectedCampaignId ? 'primary' : 'secondary'}
+                  size="sm"
+                  onclick={() => onSelect?.(campaign.id)}
+                >
+                  View
+                </Button>
+              </td>
+            {/if}
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</div>
+
+<style>
+  .campaign-list {
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  .empty {
+    margin: 0;
+    color: var(--smrt-color-on-surface-variant);
+    font: var(--smrt-typography-body-medium-font);
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    color: var(--smrt-color-on-surface);
+    font: var(--smrt-typography-body-medium-font);
+  }
+
+  th,
+  td {
+    padding: var(--smrt-spacing-3);
+    border-bottom: 1px solid var(--smrt-color-outline-variant);
+    text-align: left;
+    vertical-align: top;
+  }
+
+  th {
+    background: var(--smrt-color-surface-container);
+    font-weight: var(--smrt-typography-weight-semibold);
+    white-space: nowrap;
+  }
+
+  tr.selected td {
+    background: var(--smrt-color-primary-container);
+  }
+
+  .name,
+  .secondary {
+    display: block;
+  }
+
+  .name {
+    font-weight: var(--smrt-typography-weight-medium);
+  }
+
+  .secondary {
+    color: var(--smrt-color-on-surface-variant);
+    font: var(--smrt-typography-body-small-font);
+  }
+
+  .number,
+  .action {
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+</style>

--- a/packages/marketing/src/svelte/components/ChannelMix.svelte
+++ b/packages/marketing/src/svelte/components/ChannelMix.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+import { Progress } from '@happyvertical/smrt-ui/feedback';
+import { Badge, Card } from '@happyvertical/smrt-ui/ui';
+import {
+  formatCents,
+  formatNumber,
+  formatPercent,
+  humanizeKey,
+} from '../format.js';
+import type { CampaignChannelView } from '../types.js';
+import { calculateChannelMix, campaignStatusBadgeVariant } from '../types.js';
+
+export interface Props {
+  channels?: CampaignChannelView[];
+  currency?: string;
+  locale?: string;
+}
+
+let { channels = [], currency = 'USD', locale }: Props = $props();
+const mix = $derived(calculateChannelMix(channels));
+</script>
+
+<section class="channel-mix">
+  <h3>Channel mix</h3>
+  {#if mix.length === 0}
+    <p class="empty">No channel performance yet.</p>
+  {:else}
+    <div class="rows">
+      {#each mix as channel (channel.id)}
+        <Card padding="sm">
+          <div class="head">
+            <div>
+              <span class="name">{channel.label ?? humanizeKey(channel.channelKind)}</span>
+              <span class="secondary">{channel.channelRef}</span>
+            </div>
+            <Badge variant={campaignStatusBadgeVariant(channel.status)} size="sm">
+              {humanizeKey(channel.status)}
+            </Badge>
+          </div>
+          <div class="progress-label">
+            <span>{formatCents(channel.spendCents, currency, locale)} spent</span>
+            <span>{formatPercent(channel.spendFraction, locale)} of mix</span>
+          </div>
+          <Progress
+            value={channel.spendFraction}
+            max={1}
+            label={`${channel.label ?? channel.channelKind} spend share`}
+          />
+          <dl class="metrics">
+            <div><dt>Allocation</dt><dd>{formatCents(channel.allocatedBudgetCents, currency, locale)}</dd></div>
+            <div><dt>Impressions</dt><dd>{formatNumber(channel.impressions ?? 0, locale)}</dd></div>
+            <div><dt>Clicks</dt><dd>{formatNumber(channel.clicks ?? 0, locale)}</dd></div>
+            <div><dt>Leads</dt><dd>{formatNumber(channel.leads ?? 0, locale)}</dd></div>
+          </dl>
+        </Card>
+      {/each}
+    </div>
+  {/if}
+</section>
+
+<style>
+  .channel-mix,
+  .rows {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .channel-mix {
+    gap: var(--smrt-spacing-3);
+  }
+
+  .rows {
+    gap: var(--smrt-spacing-2);
+  }
+
+  h3,
+  .empty {
+    margin: 0;
+  }
+
+  h3 {
+    color: var(--smrt-color-on-surface);
+    font: var(--smrt-typography-title-medium-font);
+  }
+
+  .empty,
+  .secondary,
+  dt,
+  .progress-label {
+    color: var(--smrt-color-on-surface-variant);
+  }
+
+  .empty,
+  .name {
+    font: var(--smrt-typography-body-medium-font);
+  }
+
+  .head,
+  .progress-label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--smrt-spacing-3);
+  }
+
+  .name,
+  .secondary {
+    display: block;
+  }
+
+  .name {
+    color: var(--smrt-color-on-surface);
+    font-weight: var(--smrt-typography-weight-medium);
+  }
+
+  .secondary,
+  .progress-label,
+  dt {
+    font: var(--smrt-typography-body-small-font);
+  }
+
+  .progress-label {
+    margin: var(--smrt-spacing-3) 0 var(--smrt-spacing-1);
+  }
+
+  .metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+    gap: var(--smrt-spacing-3);
+    margin: var(--smrt-spacing-3) 0 0;
+  }
+
+  .metrics dd {
+    margin: var(--smrt-spacing-1) 0 0;
+    color: var(--smrt-color-on-surface);
+    font: var(--smrt-typography-body-medium-font);
+  }
+</style>

--- a/packages/marketing/src/svelte/components/MarketingDashboard.svelte
+++ b/packages/marketing/src/svelte/components/MarketingDashboard.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+import { Card } from '@happyvertical/smrt-ui/ui';
+import type { Snippet } from 'svelte';
+import { formatCents, formatNumber } from '../format.js';
+import type { CampaignSummaryView } from '../types.js';
+import { summarizeMarketingDashboard } from '../types.js';
+
+export interface Props {
+  campaigns?: CampaignSummaryView[];
+  locale?: string;
+  campaignList?: Snippet;
+  detail?: Snippet;
+  children?: Snippet;
+}
+
+let {
+  campaigns = [],
+  locale,
+  campaignList,
+  detail,
+  children,
+}: Props = $props();
+
+const summary = $derived(summarizeMarketingDashboard(campaigns));
+</script>
+
+<section class="marketing-dashboard">
+  <div class="tiles">
+    <Card padding="sm">
+      <dl class="tile">
+        <dt>Campaigns</dt>
+        <dd>{summary.activeCampaignCount} active</dd>
+        <dd class="secondary">{summary.campaignCount} total</dd>
+      </dl>
+    </Card>
+    <Card padding="sm">
+      <dl class="tile">
+        <dt>Channels</dt>
+        <dd>{summary.channelCount}</dd>
+        <dd class="secondary">linked executions</dd>
+      </dl>
+    </Card>
+    <Card padding="sm">
+      <dl class="tile">
+        <dt>Leads</dt>
+        <dd>{formatNumber(summary.leads, locale)}</dd>
+        <dd class="secondary">{formatNumber(summary.conversions, locale)} conversions</dd>
+      </dl>
+    </Card>
+    <Card padding="sm">
+      <dl class="tile">
+        <dt>Reach</dt>
+        <dd>{formatNumber(summary.impressions, locale)}</dd>
+        <dd class="secondary">{formatNumber(summary.clicks, locale)} clicks</dd>
+      </dl>
+    </Card>
+  </div>
+
+  {#if summary.currencyTotals.length > 0}
+    <Card padding="sm">
+      <div class="currency-totals">
+        {#each summary.currencyTotals as total (total.currency)}
+          <dl class="currency-total">
+            <dt>{total.currency}</dt>
+            <dd>{formatCents(total.spendCents, total.currency, locale)} spent</dd>
+            <dd class="secondary">
+              of {formatCents(total.budgetCents, total.currency, locale)} budget
+            </dd>
+          </dl>
+        {/each}
+      </div>
+    </Card>
+  {/if}
+
+  {#if campaignList}
+    <div class="surface">{@render campaignList()}</div>
+  {/if}
+  {#if detail}
+    <div class="surface">{@render detail()}</div>
+  {/if}
+  {@render children?.()}
+</section>
+
+<style>
+  .marketing-dashboard {
+    display: flex;
+    flex-direction: column;
+    gap: var(--smrt-spacing-4);
+  }
+
+  .tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    gap: var(--smrt-spacing-3);
+  }
+
+  .tile,
+  .currency-total {
+    margin: 0;
+  }
+
+  dt {
+    color: var(--smrt-color-on-surface-variant);
+    font: var(--smrt-typography-label-medium-font);
+    text-transform: uppercase;
+    letter-spacing: var(--smrt-typography-label-medium-tracking);
+  }
+
+  dd {
+    margin: var(--smrt-spacing-1) 0 0;
+    color: var(--smrt-color-on-surface);
+    font: var(--smrt-typography-title-medium-font);
+  }
+
+  .secondary {
+    color: var(--smrt-color-on-surface-variant);
+    font: var(--smrt-typography-body-small-font);
+  }
+
+  .currency-totals {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+    gap: var(--smrt-spacing-4);
+  }
+
+  .surface {
+    min-width: 0;
+  }
+</style>

--- a/packages/marketing/src/svelte/format.ts
+++ b/packages/marketing/src/svelte/format.ts
@@ -1,0 +1,45 @@
+import type { DateLike } from './types.js';
+
+export function formatCents(
+  cents: number,
+  currency: string,
+  locale?: string,
+): string {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+  }).format(cents / 100);
+}
+
+export function formatNumber(value: number, locale?: string): string {
+  return new Intl.NumberFormat(locale).format(value);
+}
+
+export function formatPercent(value: number, locale?: string): string {
+  return new Intl.NumberFormat(locale, {
+    style: 'percent',
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+export function formatDate(value: DateLike, locale?: string): string {
+  if (value == null) return '—';
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(date);
+}
+
+export function formatDateRange(
+  startAt: DateLike,
+  endAt: DateLike,
+  locale?: string,
+): string {
+  if (startAt == null && endAt == null) return 'No fixed schedule';
+  return `${formatDate(startAt, locale)} – ${formatDate(endAt, locale)}`;
+}
+
+export function humanizeKey(value: string): string {
+  return value
+    .replace(/[_-]+/g, ' ')
+    .replace(/^\w/, (letter) => letter.toUpperCase());
+}

--- a/packages/marketing/src/svelte/format.ts
+++ b/packages/marketing/src/svelte/format.ts
@@ -5,10 +5,17 @@ export function formatCents(
   currency: string,
   locale?: string,
 ): string {
-  return new Intl.NumberFormat(locale, {
-    style: 'currency',
-    currency,
-  }).format(cents / 100);
+  if (!Number.isFinite(cents)) return '—';
+  const sign = cents < 0 ? -1 : 1;
+  const major = (sign * Math.round(Math.abs(cents))) / 100;
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency,
+    }).format(major);
+  } catch {
+    return `${major.toFixed(2)} ${currency}`.trim();
+  }
 }
 
 export function formatNumber(value: number, locale?: string): string {

--- a/packages/marketing/src/svelte/index.ts
+++ b/packages/marketing/src/svelte/index.ts
@@ -1,0 +1,7 @@
+export { default as BudgetPacing } from './components/BudgetPacing.svelte';
+export { default as CampaignDetail } from './components/CampaignDetail.svelte';
+export { default as CampaignList } from './components/CampaignList.svelte';
+export { default as ChannelMix } from './components/ChannelMix.svelte';
+export { default as MarketingDashboard } from './components/MarketingDashboard.svelte';
+export * from './format.js';
+export * from './types.js';

--- a/packages/marketing/src/svelte/types.ts
+++ b/packages/marketing/src/svelte/types.ts
@@ -1,0 +1,186 @@
+export type MarketingBadgeVariant =
+  | 'default'
+  | 'primary'
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'info';
+
+export type DateLike = Date | string | number | null | undefined;
+
+export interface CampaignSummaryView {
+  id: string;
+  campaignKey: string;
+  name: string;
+  objective?: string;
+  status: string;
+  startAt?: DateLike;
+  endAt?: DateLike;
+  budgetCents: number;
+  currency: string;
+  spendCents?: number;
+  impressions?: number;
+  clicks?: number;
+  conversions?: number;
+  leads?: number;
+  channelCount?: number;
+}
+
+export interface CampaignDetailView extends CampaignSummaryView {
+  description?: string;
+}
+
+export interface CampaignChannelView {
+  id: string;
+  channelKind: string;
+  channelRef: string;
+  label?: string;
+  status: string;
+  allocatedBudgetCents: number;
+  spendCents: number;
+  impressions?: number;
+  clicks?: number;
+  conversions?: number;
+  leads?: number;
+}
+
+export interface BudgetPacingView {
+  campaignId: string;
+  campaignChannelId?: string;
+  currency: string;
+  budgetCents: number;
+  spendCents: number;
+  remainingCents: number;
+  expectedSpendCents: number | null;
+  varianceCents: number | null;
+  budgetFraction: number | null;
+  elapsedFraction: number | null;
+  status: string;
+}
+
+export interface CurrencyMarketingTotal {
+  currency: string;
+  budgetCents: number;
+  spendCents: number;
+}
+
+export interface MarketingDashboardSummary {
+  campaignCount: number;
+  activeCampaignCount: number;
+  channelCount: number;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  leads: number;
+  currencyTotals: CurrencyMarketingTotal[];
+}
+
+export interface ChannelMixEntry extends CampaignChannelView {
+  spendFraction: number;
+  allocationFraction: number;
+}
+
+export function campaignStatusBadgeVariant(
+  status: string,
+): MarketingBadgeVariant {
+  switch (status) {
+    case 'active':
+      return 'success';
+    case 'scheduled':
+      return 'info';
+    case 'paused':
+      return 'warning';
+    case 'completed':
+      return 'primary';
+    case 'archived':
+      return 'default';
+    default:
+      return 'default';
+  }
+}
+
+export function pacingStatusBadgeVariant(
+  status: string,
+): MarketingBadgeVariant {
+  switch (status) {
+    case 'on_track':
+    case 'complete':
+      return 'success';
+    case 'ahead':
+      return 'info';
+    case 'behind':
+    case 'not_started':
+      return 'warning';
+    case 'over_budget':
+      return 'error';
+    default:
+      return 'default';
+  }
+}
+
+export function summarizeMarketingDashboard(
+  campaigns: CampaignSummaryView[],
+): MarketingDashboardSummary {
+  const byCurrency = new Map<string, CurrencyMarketingTotal>();
+  let channelCount = 0;
+  let impressions = 0;
+  let clicks = 0;
+  let conversions = 0;
+  let leads = 0;
+
+  for (const campaign of campaigns) {
+    const currency = campaign.currency || 'USD';
+    const total = byCurrency.get(currency) ?? {
+      currency,
+      budgetCents: 0,
+      spendCents: 0,
+    };
+    total.budgetCents += campaign.budgetCents;
+    total.spendCents += campaign.spendCents ?? 0;
+    byCurrency.set(currency, total);
+    channelCount += campaign.channelCount ?? 0;
+    impressions += campaign.impressions ?? 0;
+    clicks += campaign.clicks ?? 0;
+    conversions += campaign.conversions ?? 0;
+    leads += campaign.leads ?? 0;
+  }
+
+  return {
+    campaignCount: campaigns.length,
+    activeCampaignCount: campaigns.filter(
+      (campaign) => campaign.status === 'active',
+    ).length,
+    channelCount,
+    impressions,
+    clicks,
+    conversions,
+    leads,
+    currencyTotals: [...byCurrency.values()].sort((a, b) =>
+      a.currency.localeCompare(b.currency),
+    ),
+  };
+}
+
+export function calculateChannelMix(
+  channels: CampaignChannelView[],
+): ChannelMixEntry[] {
+  const totalSpend = channels.reduce(
+    (sum, channel) => sum + channel.spendCents,
+    0,
+  );
+  const totalAllocation = channels.reduce(
+    (sum, channel) => sum + channel.allocatedBudgetCents,
+    0,
+  );
+  return channels.map((channel) => ({
+    ...channel,
+    spendFraction: totalSpend > 0 ? channel.spendCents / totalSpend : 0,
+    allocationFraction:
+      totalAllocation > 0 ? channel.allocatedBudgetCents / totalAllocation : 0,
+  }));
+}
+
+export function cappedBudgetProgress(pacing: BudgetPacingView): number {
+  if (pacing.budgetFraction === null) return 0;
+  return Math.max(0, Math.min(1, pacing.budgetFraction));
+}

--- a/packages/marketing/src/types.ts
+++ b/packages/marketing/src/types.ts
@@ -1,0 +1,103 @@
+/** Shared model and service contracts for @happyvertical/smrt-marketing. */
+
+import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
+
+export const CAMPAIGN_STATUSES = [
+  'draft',
+  'scheduled',
+  'active',
+  'paused',
+  'completed',
+  'archived',
+] as const;
+
+export type CampaignStatus = (typeof CAMPAIGN_STATUSES)[number];
+
+export const CAMPAIGN_CHANNEL_KINDS = [
+  'ad_group',
+  'social_post',
+  'message',
+  'content',
+  'event',
+  'referral_program',
+] as const;
+
+export type CampaignChannelKind =
+  | (typeof CAMPAIGN_CHANNEL_KINDS)[number]
+  | (string & {});
+
+export const CAMPAIGN_CHANNEL_STATUSES = [
+  'planned',
+  'scheduled',
+  'active',
+  'paused',
+  'completed',
+  'cancelled',
+] as const;
+
+export type CampaignChannelStatus = (typeof CAMPAIGN_CHANNEL_STATUSES)[number];
+
+export interface CampaignOptions extends SmrtObjectOptions {
+  tenantId?: string | null;
+  campaignKey?: string;
+  name?: string;
+  objective?: string;
+  status?: CampaignStatus;
+  startAt?: Date | string | number | null;
+  endAt?: Date | string | number | null;
+  budgetCents?: number;
+  currency?: string;
+  metadata?: string;
+}
+
+export interface CampaignChannelOptions extends SmrtObjectOptions {
+  tenantId?: string | null;
+  campaignId?: string;
+  channelKind?: CampaignChannelKind;
+  channelRef?: string;
+  allocatedBudgetCents?: number;
+  startAt?: Date | string | number | null;
+  endAt?: Date | string | number | null;
+  status?: CampaignChannelStatus;
+}
+
+export interface CampaignMetricSnapshotOptions extends SmrtObjectOptions {
+  tenantId?: string | null;
+  campaignId?: string;
+  campaignChannelId?: string | null;
+  periodStart?: Date | string | number;
+  periodEnd?: Date | string | number;
+  spendCents?: number;
+  impressions?: number;
+  clicks?: number;
+  conversions?: number;
+  leads?: number;
+  revenueCents?: number | null;
+  source?: string;
+  dedupeKey?: string;
+}
+
+export type BudgetPacingStatus =
+  | 'unbudgeted'
+  | 'not_started'
+  | 'behind'
+  | 'on_track'
+  | 'ahead'
+  | 'over_budget'
+  | 'complete';
+
+export interface BudgetPacingResult {
+  campaignId: string;
+  campaignChannelId?: string;
+  currency: string;
+  budgetCents: number;
+  spendCents: number;
+  remainingCents: number;
+  expectedSpendCents: number | null;
+  varianceCents: number | null;
+  budgetFraction: number | null;
+  elapsedFraction: number | null;
+  status: BudgetPacingStatus;
+  snapshotCount: number;
+  usedCampaignRollups: boolean;
+}

--- a/packages/marketing/tsconfig.build.json
+++ b/packages/marketing/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.package-build.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "exclude": [
+    "src/svelte/**/*",
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/marketing/tsconfig.json
+++ b/packages/marketing/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.ui-package.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": ".",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["ambient.d.ts", "src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/marketing/tsconfig.svelte.json
+++ b/packages/marketing/tsconfig.svelte.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.package-svelte.json",
+  "include": ["ambient.d.ts", "src/**/*.ts", "src/**/*.svelte"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/marketing/vite.config.ts
+++ b/packages/marketing/vite.config.ts
@@ -1,0 +1,3 @@
+import { createPackageConfig } from '../../vite.config.base.js';
+
+export default createPackageConfig('marketing', { svelte: 'svelte' });

--- a/packages/marketing/vitest.config.ts
+++ b/packages/marketing/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+import { smrtVitestPlugin } from '../vitest/src/index.ts';
+
+export default defineConfig({
+  plugins: [smrtVitestPlugin({ verbose: true })],
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
+    exclude: ['src/svelte/__tests__/components.test.ts'],
+    coverage: {
+      provider: 'v8',
+      exclude: ['**/__tests__/**', '**/*.{test,spec}.ts', '**/*.d.ts'],
+    },
+    testTimeout: 30000,
+    fileParallelism: false,
+    pool: 'forks',
+    singleFork: true,
+  },
+});

--- a/packages/marketing/vitest.svelte.config.ts
+++ b/packages/marketing/vitest.svelte.config.ts
@@ -1,0 +1,21 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [svelte()],
+  resolve: {
+    conditions: ['browser'],
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['@happyvertical/smrt-vitest/svelte-setup'],
+    include: ['src/svelte/__tests__/components.test.ts'],
+    coverage: {
+      provider: 'v8',
+      exclude: ['**/__tests__/**', '**/*.{test,spec}.ts', '**/*.d.ts'],
+    },
+    fileParallelism: false,
+    pool: 'forks',
+    singleFork: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1354,6 +1354,55 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  packages/marketing:
+    dependencies:
+      '@happyvertical/smrt-core':
+        specifier: workspace:*
+        version: link:../core
+      '@happyvertical/smrt-tenancy':
+        specifier: workspace:*
+        version: link:../tenancy
+      '@happyvertical/smrt-ui':
+        specifier: workspace:*
+        version: link:../smrt-ui
+    devDependencies:
+      '@happyvertical/smrt-vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@happyvertical/sql':
+        specifier: ^0.78.1
+        version: 0.78.1(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+      '@sveltejs/package':
+        specifier: ^2.5.8
+        version: 2.5.8(svelte@5.56.4)(typescript@5.9.3)
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.1.2
+        version: 7.1.2(svelte@5.56.4)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@testing-library/svelte':
+        specifier: ^5.4.2
+        version: 5.4.2(svelte@5.56.4)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@types/node':
+        specifier: 24.13.2
+        version: 24.13.2
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
+      svelte:
+        specifier: ^5.56.4
+        version: 5.56.4
+      svelte-check:
+        specifier: ^4.7.1
+        version: 4.7.1(picomatch@4.0.5)(svelte@5.56.4)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^8.1.3
+        version: 8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(happy-dom@20.10.6)(jsdom@26.1.0)(vite@8.1.3(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+
   packages/messages:
     dependencies:
       '@happyvertical/email':

--- a/scripts/check-color-literals.mjs
+++ b/scripts/check-color-literals.mjs
@@ -49,6 +49,7 @@ const STRICT_PACKAGES = new Set([
   'projects',
   'users',
   'messages',
+  'marketing',
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- add the installable `@happyvertical/smrt-marketing` package with tenant-aware Campaign identity, guarded lifecycle transitions, and generic cross-channel execution links
- add immutable, create-only metric evidence with strict-insert idempotency, concurrent retry protection, validation, and computed budget pacing
- add Provider-free Svelte dashboard, list/detail, channel-mix, and pacing surfaces with integer-cent formatting and real jsdom component coverage
- document the package boundary and publish generated manifests/knowledge without introducing sibling channel-domain dependencies

## Validation

- `pnpm --filter @happyvertical/smrt-marketing test` — 13 model/integration tests passed; 1 PostgreSQL-gated suite skipped locally in the default run
- `pnpm --filter @happyvertical/smrt-marketing test:coverage` — model/service and Svelte component coverage passed
- `pnpm --filter @happyvertical/smrt-marketing typecheck` — TypeScript and Svelte check passed with 0 errors/0 warnings
- `pnpm --filter @happyvertical/smrt-marketing test:postgres` — PostgreSQL 16 coverage passed
- `pnpm --filter @happyvertical/smrt-marketing build` and `verify:pack`
- root build, dependency cruise/DAG, standards, SDK alignment, audit policy, Biome, design-token/raw-primitive checks, and strict generated knowledge freshness
- bounded review cycle completed; actionable integrity, component-coverage, concurrency, and documentation findings addressed

## Slice evidence

- #1990: Campaign schema, tenant-scoped natural key, lifecycle service/save guard, generated REST/MCP/CLI surfaces, SQLite and PostgreSQL regressions
- #1991: generic `channelKind`/`channelRef` links and two-channel tracer with no ads/social runtime dependency
- #1992: immutable metric snapshots, strict-insert dedupe retries, validation, pacing, create-only generated doors, and PostgreSQL coverage
- #1993: five props-only Svelte surfaces, shared UI/tokens, cent formatting helpers, jsdom component tests, and Svelte diagnostics

Closes #1988
Closes #1990
Closes #1991
Closes #1992
Closes #1993

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-20260714-fd12-1988","issue":1988,"policy_revision":"1.0.0","status":"complete","validation":["marketing vitest and coverage","TypeScript and Svelte check","PostgreSQL 16","package build and packed exports","root build and policy checks","strict knowledge freshness","bounded review cycle"]}
```