### PR TITLE
fix(profiles): make manifest registration classes importable

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -95,7 +95,11 @@ fixed shared database name or remove the wrapper from their package script.
 
 Each package is packed once. Pack shards verify that exact tarball and emit a
 schema-versioned manifest containing package name, version, filename, and
-SHA-256. The summary verifies complete package membership and uniform versions.
+SHA-256. Profiles validation additionally installs that exact tarball into an
+isolated consumer, runs the built CLI to generate `.smrt/register.js`, and
+imports the generated file so every manifest-advertised root import is proven
+against the publish artifact. The summary verifies complete package membership
+and uniform versions.
 The release job publishes those tarballs sequentially and safely skips versions
 already present on npm during a retry. The final publisher consumes only those
 prebuilt artifacts, so it skips a redundant workspace dependency install and

--- a/packages/profiles/AGENTS.md
+++ b/packages/profiles/AGENTS.md
@@ -118,4 +118,9 @@ import { smrtProfilesGenerateBioPrompt } from '@happyvertical/smrt-profiles';
   `Profile.emailKey`, derived by the shared TypeScript
   `normalizeIdentityEmail()` helper rather than adapter-specific SQL casing or
   trimming, and deliberately fail closed on duplicate normalized keys.
+- **Manifest objects must remain root-importable**: the non-API
+  `OidcProfileEmailReservation` model and collection are public root exports
+  because generated consumer registration imports every advertised manifest
+  symbol from `@happyvertical/smrt-profiles`. Release-pack validation imports
+  the actual generated register file from the packed tarball.
 - **Optional tenancy** on Profile; AuditLog allows super-admin bypass

--- a/packages/profiles/src/__tests__/manifest-public-exports.test.ts
+++ b/packages/profiles/src/__tests__/manifest-public-exports.test.ts
@@ -1,0 +1,51 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import * as profilesCollections from '../collections/index.js';
+import * as profilesPublicApi from '../index.js';
+import * as profilesModels from '../models/index.js';
+
+interface ManifestObjectDefinition {
+  collectionExportName?: string;
+  exportName?: string;
+  hasCollection?: boolean;
+  name?: string;
+  visibility?: string;
+}
+
+describe('profiles manifest public exports', () => {
+  it('exports every symbol used by generated consumer registration', async () => {
+    const manifest = JSON.parse(
+      await readFile(
+        new URL('../manifest/manifest.json', import.meta.url),
+        'utf8',
+      ),
+    ) as { objects: Record<string, ManifestObjectDefinition> };
+    const registrationExports = new Set<string>();
+
+    for (const [objectName, definition] of Object.entries(manifest.objects)) {
+      if (definition.visibility === 'test') continue;
+
+      registrationExports.add(
+        definition.exportName ?? definition.name ?? objectName,
+      );
+      if (definition.hasCollection && definition.collectionExportName) {
+        registrationExports.add(definition.collectionExportName);
+      }
+    }
+
+    const missingExports = [...registrationExports]
+      .filter((exportName) => !(exportName in profilesPublicApi))
+      .sort();
+
+    expect(missingExports).toEqual([]);
+  });
+
+  it('keeps the OIDC reservation exports in their domain barrels', () => {
+    expect(profilesModels.OidcProfileEmailReservation).toBe(
+      profilesPublicApi.OidcProfileEmailReservation,
+    );
+    expect(profilesCollections.OidcProfileEmailReservationCollection).toBe(
+      profilesPublicApi.OidcProfileEmailReservationCollection,
+    );
+  });
+});

--- a/packages/profiles/src/collections/index.ts
+++ b/packages/profiles/src/collections/index.ts
@@ -14,6 +14,7 @@ export {
   AmbiguousOidcIdentityError,
   OidcIdentityCollection,
 } from './OidcIdentityCollection';
+export { OidcProfileEmailReservationCollection } from './OidcProfileEmailReservationCollection';
 export { ProfileAssetCollection } from './ProfileAssetCollection';
 export {
   CanonicalPersonProfileError,

--- a/packages/profiles/src/index.ts
+++ b/packages/profiles/src/index.ts
@@ -69,6 +69,7 @@ export {
   AmbiguousOidcIdentityError,
   OidcIdentityCollection,
 } from './collections/OidcIdentityCollection';
+export { OidcProfileEmailReservationCollection } from './collections/OidcProfileEmailReservationCollection';
 export { ProfileAssetCollection } from './collections/ProfileAssetCollection';
 // Export collections
 export {
@@ -102,6 +103,8 @@ export type { NostrIdentityOptions } from './models/NostrIdentity';
 export { NostrIdentity } from './models/NostrIdentity';
 export type { OidcIdentityOptions } from './models/OidcIdentity';
 export { OidcIdentity } from './models/OidcIdentity';
+export type { OidcProfileEmailReservationOptions } from './models/OidcProfileEmailReservation';
+export { OidcProfileEmailReservation } from './models/OidcProfileEmailReservation';
 // Export model option types
 export type { ProfileOptions } from './models/Profile';
 export { Profile } from './models/Profile';

--- a/packages/profiles/src/models/OidcProfileEmailReservation.ts
+++ b/packages/profiles/src/models/OidcProfileEmailReservation.ts
@@ -6,7 +6,7 @@ import {
   smrt,
 } from '@happyvertical/smrt-core';
 
-interface OidcProfileEmailReservationOptions extends SmrtObjectOptions {
+export interface OidcProfileEmailReservationOptions extends SmrtObjectOptions {
   emailKey?: string;
   profileId?: string;
 }

--- a/packages/profiles/src/models/index.ts
+++ b/packages/profiles/src/models/index.ts
@@ -12,6 +12,10 @@ export {
 } from './MagicLinkToken';
 export { NostrIdentity, type NostrIdentityOptions } from './NostrIdentity';
 export { OidcIdentity, type OidcIdentityOptions } from './OidcIdentity';
+export {
+  OidcProfileEmailReservation,
+  type OidcProfileEmailReservationOptions,
+} from './OidcProfileEmailReservation';
 export { Profile } from './Profile';
 export { ProfileMetadata } from './ProfileMetadata';
 export { ProfileMetafield } from './ProfileMetafield';

--- a/scripts/validate-publish-packages.js
+++ b/scripts/validate-publish-packages.js
@@ -285,6 +285,34 @@ for (const pkg of shardPackages) {
     fail(`Packed export verification failed for ${pkg.name}`);
   }
 
+  if (pkg.name === '@happyvertical/smrt-profiles') {
+    const registerImportResult = spawnSync(
+      process.execPath,
+      [
+        join(repoRoot, 'scripts', 'verify-generated-register-import.mjs'),
+        '--package-dir',
+        pkg.dir,
+        '--tarball',
+        tarballPath,
+      ],
+      {
+        cwd: repoRoot,
+        stdio: 'inherit',
+        env: process.env,
+      },
+    );
+
+    if (registerImportResult.error) {
+      fail(
+        `Failed to verify generated registration for ${pkg.name}: ${registerImportResult.error.message}`,
+      );
+    }
+
+    if (registerImportResult.status !== 0) {
+      fail(`Generated registration verification failed for ${pkg.name}`);
+    }
+  }
+
   const packageJson = JSON.parse(
     readFileSync(join(pkg.dir, 'package.json'), 'utf8'),
   );

--- a/scripts/verify-generated-register-import.mjs
+++ b/scripts/verify-generated-register-import.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+function fail(message) {
+  console.error(`❌ ${message}`);
+  process.exit(1);
+}
+
+function readOptionValue(flagName) {
+  const args = process.argv.slice(2);
+  const index = args.indexOf(flagName);
+  if (index === -1 || !args[index + 1] || args[index + 1].startsWith('-')) {
+    fail(`Missing ${flagName}`);
+  }
+  return args[index + 1];
+}
+
+function resolveExportTarget(target) {
+  if (typeof target === 'string') return target;
+  if (!target || typeof target !== 'object') return undefined;
+
+  for (const condition of ['import', 'default', 'node']) {
+    const resolved = resolveExportTarget(target[condition]);
+    if (resolved) return resolved;
+  }
+  return undefined;
+}
+
+function commandFailure(result) {
+  return [result.stdout, result.stderr]
+    .filter((value) => typeof value === 'string' && value.trim())
+    .map((value) => value.trim())
+    .join('\n');
+}
+
+const repoRoot = process.cwd();
+const packageDir = resolve(readOptionValue('--package-dir'));
+const tarballPath = resolve(readOptionValue('--tarball'));
+const sourcePackageJson = JSON.parse(
+  readFileSync(join(packageDir, 'package.json'), 'utf8'),
+);
+const packageName = sourcePackageJson.name;
+const cliEntry = join(repoRoot, 'packages', 'cli', 'dist', 'index.js');
+
+if (!packageName) fail(`Package at ${packageDir} has no name`);
+if (!existsSync(tarballPath)) fail(`Tarball not found: ${tarballPath}`);
+if (!existsSync(cliEntry)) {
+  fail(`Built CLI entry not found: ${cliEntry}`);
+}
+
+const consumerDir = mkdtempSync(join(tmpdir(), 'smrt-register-pack-'));
+const cleanup = () => rmSync(consumerDir, { recursive: true, force: true });
+process.once('exit', cleanup);
+
+try {
+  const installedPackageDir = join(
+    consumerDir,
+    'node_modules',
+    ...packageName.split('/'),
+  );
+  mkdirSync(installedPackageDir, { recursive: true });
+
+  const extractResult = spawnSync(
+    'tar',
+    [
+      '-xzf',
+      tarballPath,
+      '--strip-components=1',
+      '-C',
+      installedPackageDir,
+    ],
+    { encoding: 'utf8', env: process.env },
+  );
+  if (extractResult.error || extractResult.status !== 0) {
+    fail(
+      `Failed to extract ${packageName}: ${extractResult.error?.message ?? commandFailure(extractResult)}`,
+    );
+  }
+
+  writeFileSync(
+    join(consumerDir, 'package.json'),
+    `${JSON.stringify({ name: 'smrt-release-pack-consumer', private: true, type: 'module' }, null, 2)}\n`,
+  );
+
+  const packedPackageJson = JSON.parse(
+    readFileSync(join(installedPackageDir, 'package.json'), 'utf8'),
+  );
+  const dependencyNames = new Set([
+    ...Object.keys(packedPackageJson.dependencies ?? {}),
+    ...Object.keys(packedPackageJson.optionalDependencies ?? {}),
+    ...Object.keys(packedPackageJson.peerDependencies ?? {}),
+  ]);
+  for (const dependencyName of dependencyNames) {
+    const sourceDependencyDir = join(
+      packageDir,
+      'node_modules',
+      ...dependencyName.split('/'),
+    );
+    if (!existsSync(sourceDependencyDir)) {
+      fail(
+        `Installed workspace dependency unavailable for ${packageName}: ${dependencyName}`,
+      );
+    }
+    const consumerDependencyDir = join(
+      consumerDir,
+      'node_modules',
+      ...dependencyName.split('/'),
+    );
+    mkdirSync(resolve(consumerDependencyDir, '..'), { recursive: true });
+    symlinkSync(realpathSync(sourceDependencyDir), consumerDependencyDir, 'dir');
+  }
+
+  const manifestTarget =
+    resolveExportTarget(packedPackageJson.exports?.['./manifest']) ??
+    resolveExportTarget(packedPackageJson.exports?.['./manifest.json']);
+  if (!manifestTarget) {
+    fail(`${packageName} does not publish a manifest export`);
+  }
+  const manifest = JSON.parse(
+    readFileSync(join(installedPackageDir, manifestTarget), 'utf8'),
+  );
+  const expectedRootExports = new Set();
+  for (const [objectName, definition] of Object.entries(
+    manifest.objects ?? {},
+  )) {
+    if (definition.visibility === 'test') continue;
+    expectedRootExports.add(
+      definition.exportName ?? definition.name ?? objectName,
+    );
+    if (definition.hasCollection && definition.collectionExportName) {
+      expectedRootExports.add(definition.collectionExportName);
+    }
+  }
+  if (expectedRootExports.size === 0) {
+    fail(`${packageName} manifest has no public exports`);
+  }
+
+  const rootTarget = resolveExportTarget(packedPackageJson.exports?.['.']);
+  if (!rootTarget) {
+    fail(`${packageName} does not publish a root import`);
+  }
+  const packedRoot = await import(
+    pathToFileURL(join(installedPackageDir, rootTarget)).href
+  );
+  const missingRootExports = [...expectedRootExports]
+    .filter((exportName) => !(exportName in packedRoot))
+    .sort();
+  if (missingRootExports.length > 0) {
+    fail(
+      `Packed root for ${packageName} omits manifest exports: ${missingRootExports.join(', ')}`,
+    );
+  }
+
+  const generateResult = spawnSync(
+    process.execPath,
+    [cliEntry, 'generate-register', '--output-path', '.smrt/register.js'],
+    {
+      cwd: consumerDir,
+      encoding: 'utf8',
+      env: process.env,
+    },
+  );
+  if (generateResult.error || generateResult.status !== 0) {
+    fail(
+      `Failed to generate consumer registration for ${packageName}: ${generateResult.error?.message ?? commandFailure(generateResult)}`,
+    );
+  }
+
+  const registerPath = join(consumerDir, '.smrt', 'register.js');
+  if (!existsSync(registerPath)) {
+    fail(`CLI did not generate ${registerPath}`);
+  }
+
+  const registerSource = readFileSync(registerPath, 'utf8');
+  const generatedImports = new Set();
+  const importPattern = /import\s*\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]/g;
+  for (const match of registerSource.matchAll(importPattern)) {
+    if (match[2] !== packageName) continue;
+    for (const importedName of match[1].split(',')) {
+      generatedImports.add(
+        importedName.trim().replace(/^type\s+/, '').split(/\s+as\s+/)[0],
+      );
+    }
+  }
+
+  if (generatedImports.size === 0) {
+    fail(`Generated registration did not import ${packageName}`);
+  }
+
+  const importResult = spawnSync(process.execPath, [registerPath], {
+    cwd: consumerDir,
+    encoding: 'utf8',
+    env: process.env,
+  });
+  if (importResult.error || importResult.status !== 0) {
+    fail(
+      `Generated consumer registration could not import ${packageName} from its packed artifact:\n${importResult.error?.message ?? commandFailure(importResult)}`,
+    );
+  }
+
+  console.log(
+    `✅ Verified ${expectedRootExports.size} packed manifest exports and imported generated consumer registration for ${packageName} (${generatedImports.size} imports)`,
+  );
+} finally {
+  process.removeListener('exit', cleanup);
+  cleanup();
+}


### PR DESCRIPTION
## Summary

- export `OidcProfileEmailReservation` and `OidcProfileEmailReservationCollection` from the supported Profiles root and domain barrels
- add a source-level invariant that every public Profiles manifest symbol remains root-importable
- extend release-pack validation to install the exact Profiles tarball in an isolated consumer, verify all 31 manifest exports, generate the real consumer register, and import it

The verifier reproduces the published `@happyvertical/smrt-profiles@0.39.16` failure with exactly the two missing reservation exports, then passes against the fixed packed artifact without a consumer shim.

Implementation claim: released for review after the ready PR was opened.

## Validation

- published 0.39.16 negative reproduction — expected rejection for the two missing exports
- Profiles suite — 16 files, 208 tests
- focused Profiles build and typecheck
- exact Profiles publish-pack shard — 31 manifest exports and 31 generated register imports
- `pnpm build` — 61/61 tasks
- `pnpm typecheck` — 118/118 tasks
- `pnpm test` — 119/119 tasks
- release CI script tests, standards, and package DAG
- Biome, format, lint, and git hooks
- `pnpm smrt dev:knowledge-check` — 0 errors, 0 warnings
- three-perspective review cycle — final roster clean

Closes #2013

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019f62a6-39e1-7201-807c-d3c4738d03d5","issue":"happyvertical/smrt#2013","policy_revision":"1.0.0","validation":["published 0.39.16 negative reproduction","profiles tests 208/208","profiles build and typecheck","exact publish-pack and generated register import 31/31","pnpm build 61/61","pnpm typecheck 118/118","pnpm test 119/119","release CI scripts","standards and package DAG","Biome and git hooks","knowledge-check 0 errors 0 warnings","review-cycle final roster clean"]}
```