### PR TITLE
feat(vitest): normalize vite 8 rolldown/oxc defaults for consumers

### DIFF
--- a/packages/vitest/AGENTS.md
+++ b/packages/vitest/AGENTS.md
@@ -24,6 +24,30 @@ Without the plugin → "unregistered class" / "No field metadata found" errors.
 4. Registers all classes in ObjectRegistry
 5. Watch mode caveat: manifest only generated at startup — restart vitest after adding new classes/fields
 
+## Vite 8 (rolldown/oxc) normalization (#2017)
+
+The plugin's `config` hook normalizes three vite 8 behaviors so consumers
+don't carry per-repo workarounds (evidence: anytown.ai#707,
+willgriffin.dev#220):
+
+1. `esbuild.tsconfigRaw` is ignored on vite 8 → injects
+   `oxc.decorator = { legacy: true, emitDecoratorMetadata: true }` (+ the
+   `oxc.tsconfig.compilerOptions` mirror) so `@smrt()` legacy decorators
+   still transform.
+2. oxc elides type-position-only imports by default, silently dropping
+   side-effect model imports (SMRT object registration) in test files outside
+   the tsconfig `include` → injects
+   `oxc.typescript = { onlyRemoveTypeImports: true }`.
+3. Rolldown prefix-matches string alias `find`s, mangling unaliased subpath
+   imports (`@org/pkg/sub` → `src/index.ts/sub`) → workspace aliases are
+   anchored exact-match RegExps; unaliased subpaths fall through to the
+   exports map. `aliasFilter` drops entries entirely.
+
+Overrides: any `oxc` field the consumer sets is never injected
+(`resolveOxcDefaults`); `oxc: false` suppresses everything. Keys are inert on
+esbuild-based vite ≤ 7. Build-only vite configs that don't list the plugin
+still need their own `oxc.decorator` on vite 8.
+
 ## CI retry (flaky-test resilience)
 
 The plugin injects `test.retry` into every consuming package's config: **2 in CI

--- a/packages/vitest/README.md
+++ b/packages/vitest/README.md
@@ -35,6 +35,49 @@ Without this plugin, tests fail with `"No field metadata found"` or `"unregister
 | `packages` | `string[]` | `[]` | Additional packages beyond auto-discovered |
 | `verbose` | `boolean` | `false` | Enable detailed logging |
 | `root` | `string` | `process.cwd()` | Root directory |
+| `setupFile` | `string` | package setup entry | Override the setup file injected into Vitest projects |
+| `aliasFilter` | `(entry) => boolean` | keep all | Drop auto-generated workspace alias entries (receives the raw string `find` and `replacement`) |
+
+### Vite 8 (rolldown/oxc) Normalization
+
+Vite 8 replaced esbuild with rolldown/oxc, which changed three behaviors that
+break SMRT projects. The plugin normalizes all three so consuming apps don't
+need per-repo workarounds (evidence: anytown.ai#707, willgriffin.dev#220):
+
+1. **`esbuild.tsconfigRaw` is ignored** — legacy `@smrt()` decorators reach
+   the bundle untransformed. The plugin injects
+   `oxc.decorator = { legacy: true, emitDecoratorMetadata: true }` (plus the
+   matching `oxc.tsconfig.compilerOptions` mirror).
+2. **oxc elides type-position side-effect imports by default** — test files
+   usually sit outside the tsconfig `include`, so a repo-wide
+   `verbatimModuleSyntax` never reaches them and side-effect model imports
+   (SMRT object registration) are silently dropped. The plugin injects
+   `oxc.typescript = { onlyRemoveTypeImports: true }`.
+3. **Rolldown prefix-matches string alias `find`s** — a bare workspace alias
+   like `@org/pkg` → `src/index.ts` mangles unaliased subpath imports
+   (`@org/pkg/sub` → `src/index.ts/sub`). Workspace aliases are emitted as
+   anchored exact-match RegExps, so unaliased subpaths fall through to the
+   package exports map; use `aliasFilter` to drop entries entirely.
+
+   > **Breaking change for direct `getWorkspaceViteAliases()` consumers:**
+   > each entry's `find` is now an anchored `RegExp`, not a `string` (the
+   > returned array is still ordered most-specific first, and the new second
+   > `options` parameter is optional). Code that used `find` as a string —
+   > e.g. a `Map` key or an equality filter — should match with
+   > `entry.find.test('<specifier>')` instead. Filters passed via
+   > `aliasFilter` (or the helper's `options.filter`) are unaffected: they
+   > receive the raw string `find` before anchoring. Plugin-only consumers
+   > need no changes.
+
+All defaults are override-able: any `oxc` field you set in your own config is
+never injected (explicit consumer values always win, and sibling fields still
+deep-merge), and `oxc: false` suppresses injection entirely. The `oxc` keys
+are inert on esbuild-based vite ≤ 7.
+
+Note: the plugin only reaches configs that include it (vitest configs and any
+vite config listing it in `plugins`). An app's separate build-only
+`vite.config.ts` without the plugin still needs its own `oxc.decorator`
+settings on vite 8.
 
 ### Watch Mode Note
 

--- a/packages/vitest/src/__tests__/plugin-config.test.ts
+++ b/packages/vitest/src/__tests__/plugin-config.test.ts
@@ -81,15 +81,17 @@ describe('smrtVitestPlugin config', () => {
     const config = plugin.config?.(userConfig as any);
 
     expect(config).toMatchObject({
-      resolve: {
-        alias: expect.arrayContaining([
-          expect.objectContaining({ find: '@happyvertical/smrt-core' }),
-        ]),
-      },
       test: {
         setupFiles: ['existing-root-setup', defaultSetupFile],
       },
     });
+    expect(
+      (config as any).resolve.alias.some(
+        (entry: { find: RegExp }) =>
+          entry.find instanceof RegExp &&
+          entry.find.test('@happyvertical/smrt-core'),
+      ),
+    ).toBe(true);
 
     expect(userConfig).toMatchObject({
       test: {
@@ -180,15 +182,17 @@ describe('smrtVitestPlugin config', () => {
     const config = plugin.config?.(userConfig as any);
 
     expect(config).toMatchObject({
-      resolve: {
-        alias: expect.arrayContaining([
-          expect.objectContaining({ find: '@happyvertical/smrt-core' }),
-        ]),
-      },
       test: {
         setupFiles: [defaultSetupFile],
       },
     });
+    expect(
+      (config as any).resolve.alias.some(
+        (entry: { find: RegExp }) =>
+          entry.find instanceof RegExp &&
+          entry.find.test('@happyvertical/smrt-core'),
+      ),
+    ).toBe(true);
 
     expect(userConfig).toMatchObject({
       test: {
@@ -201,6 +205,88 @@ describe('smrtVitestPlugin config', () => {
         ],
       },
     });
+  });
+
+  it('injects the vite 8 oxc defaults when the consumer sets none (#2017)', () => {
+    const config = smrtVitestPlugin().config?.({ test: {} } as any);
+
+    expect((config as any).oxc).toEqual({
+      decorator: { legacy: true, emitDecoratorMetadata: true },
+      tsconfig: {
+        compilerOptions: {
+          experimentalDecorators: true,
+          emitDecoratorMetadata: true,
+        },
+      },
+      typescript: { onlyRemoveTypeImports: true },
+    });
+  });
+
+  it('never overrides consumer-configured oxc fields (#2017)', () => {
+    // Explicit decorator config: the decorator default (and its tsconfig
+    // mirror) is suppressed; the typescript default still applies.
+    const decoratorOwned = smrtVitestPlugin().config?.({
+      oxc: { decorator: { legacy: false } },
+      test: {},
+    } as any);
+    expect((decoratorOwned as any).oxc).toEqual({
+      typescript: { onlyRemoveTypeImports: true },
+    });
+
+    // Explicit onlyRemoveTypeImports: the typescript default is suppressed.
+    const typescriptOwned = smrtVitestPlugin().config?.({
+      oxc: { typescript: { onlyRemoveTypeImports: false } },
+      test: {},
+    } as any);
+    expect((typescriptOwned as any).oxc).toEqual({
+      decorator: { legacy: true, emitDecoratorMetadata: true },
+      tsconfig: {
+        compilerOptions: {
+          experimentalDecorators: true,
+          emitDecoratorMetadata: true,
+        },
+      },
+    });
+
+    // Other typescript options without the flag still receive the default
+    // (vite deep-merges, so the consumer's fields survive).
+    const typescriptPartial = smrtVitestPlugin().config?.({
+      oxc: { typescript: { allowNamespaces: true } },
+      test: {},
+    } as any);
+    expect((typescriptPartial as any).oxc).toMatchObject({
+      typescript: { onlyRemoveTypeImports: true },
+    });
+
+    // `oxc: false` disables the transform entirely — nothing is injected
+    // (undefined is dropped by vite's config merge).
+    const disabled = smrtVitestPlugin().config?.({
+      oxc: false,
+      test: {},
+    } as any);
+    expect((disabled as any).oxc).toBeUndefined();
+  });
+
+  it('drops workspace aliases rejected by aliasFilter (#2017)', () => {
+    const config = smrtVitestPlugin({
+      aliasFilter: (entry) => entry.find !== '@happyvertical/smrt-core',
+    }).config?.({ test: {} } as any);
+
+    const alias = (config as any).resolve.alias as Array<{ find: RegExp }>;
+    expect(
+      alias.some(
+        (entry) =>
+          entry.find instanceof RegExp &&
+          entry.find.test('@happyvertical/smrt-core'),
+      ),
+    ).toBe(false);
+    expect(
+      alias.some(
+        (entry) =>
+          entry.find instanceof RegExp &&
+          entry.find.test('@happyvertical/smrt-core/testing'),
+      ),
+    ).toBe(true);
   });
 
   it('registers classes from the local manifest during configResolved', async () => {

--- a/packages/vitest/src/__tests__/workspace-aliases.test.ts
+++ b/packages/vitest/src/__tests__/workspace-aliases.test.ts
@@ -4,6 +4,10 @@
  * source entries so tests resolve workspace code without a build. Exercised
  * against the real repo workspace. Includes the S11 (#1416) component-test
  * harness special-case for smrt-vitest.
+ *
+ * Entries are emitted with anchored RegExp `find`s so an alias only matches
+ * its exact specifier — rolldown (vite 8) prefix-matches string finds, which
+ * mangled unaliased subpath imports downstream (anytown.ai#707).
  */
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -12,38 +16,39 @@ import { getWorkspaceViteAliases } from '../index.js';
 // packages/vitest/src/__tests__ → repo root
 const repoRoot = resolve(__dirname, '../../../..');
 const aliases = getWorkspaceViteAliases(repoRoot);
-const byFind = new Map(aliases.map((entry) => [entry.find, entry.replacement]));
+const replacementFor = (specifier: string) =>
+  aliases.find((entry) => entry.find.test(specifier))?.replacement;
 
 describe('getWorkspaceViteAliases', () => {
   it('aliases each workspace package root to its source entry', () => {
-    expect(byFind.get('@happyvertical/smrt-core')).toMatch(
+    expect(replacementFor('@happyvertical/smrt-core')).toMatch(
       /packages\/core\/src\/index\.ts$/,
     );
-    expect(byFind.get('@happyvertical/smrt-vitest')).toMatch(
+    expect(replacementFor('@happyvertical/smrt-vitest')).toMatch(
       /packages\/vitest\/src\/index\.ts$/,
     );
   });
 
   it('aliases known package subpaths to source (e.g. smrt-core/testing)', () => {
-    expect(byFind.get('@happyvertical/smrt-core/testing')).toMatch(
+    expect(replacementFor('@happyvertical/smrt-core/testing')).toMatch(
       /src\/testing\.ts$/,
     );
   });
 
   it('aliases the trusted profiles OIDC integration subpath to source', () => {
     expect(
-      byFind.get('@happyvertical/smrt-profiles/internal/oidc-provisioning'),
+      replacementFor('@happyvertical/smrt-profiles/internal/oidc-provisioning'),
     ).toMatch(/packages\/profiles\/src\/internal\/oidc-provisioning\.ts$/);
   });
 
   it('aliases the S11 component-test harness subpaths (smrt-vitest special-case)', () => {
-    expect(byFind.get('@happyvertical/smrt-vitest/svelte')).toMatch(
+    expect(replacementFor('@happyvertical/smrt-vitest/svelte')).toMatch(
       /src\/svelte\.ts$/,
     );
-    expect(byFind.get('@happyvertical/smrt-vitest/svelte-setup')).toMatch(
+    expect(replacementFor('@happyvertical/smrt-vitest/svelte-setup')).toMatch(
       /src\/svelte-setup\.ts$/,
     );
-    expect(byFind.get('@happyvertical/smrt-vitest/a11y')).toMatch(
+    expect(replacementFor('@happyvertical/smrt-vitest/a11y')).toMatch(
       /src\/a11y\.ts$/,
     );
   });
@@ -53,29 +58,65 @@ describe('getWorkspaceViteAliases', () => {
     // not the generic `${pkg}/ui` → `src/ui.ts` convention). /forms is the
     // relocated Provider-free form primitives — without it, consumer tests that
     // render a migrated form component fail to resolve the import.
-    expect(byFind.get('@happyvertical/smrt-ui/forms')).toMatch(
+    expect(replacementFor('@happyvertical/smrt-ui/forms')).toMatch(
       /src\/components\/forms\/index\.ts$/,
     );
-    expect(byFind.get('@happyvertical/smrt-ui/ui')).toMatch(
+    expect(replacementFor('@happyvertical/smrt-ui/ui')).toMatch(
       /src\/components\/ui\/index\.ts$/,
     );
-    expect(byFind.get('@happyvertical/smrt-ui/chat')).toMatch(
+    expect(replacementFor('@happyvertical/smrt-ui/chat')).toMatch(
       /src\/components\/chat\/index\.ts$/,
     );
   });
 
-  it('sorts entries most-specific first so subpaths win over the bare-package root', () => {
-    const lengths = aliases.map((entry) => entry.find.length);
+  it('emits anchored exact-match finds so unaliased subpaths fall through (#2017)', () => {
+    // Rolldown (vite 8) prefix-matches string finds: the bare-package alias
+    // would turn `@happyvertical/smrt-core/not-an-aliased-subpath` into
+    // `.../src/index.ts/not-an-aliased-subpath`. Anchored finds must not
+    // match, so the specifier resolves through the package exports map.
+    expect(
+      replacementFor('@happyvertical/smrt-core/not-an-aliased-subpath'),
+    ).toBeUndefined();
+
+    for (const { find } of aliases) {
+      expect(find).toBeInstanceOf(RegExp);
+      expect(find.source.startsWith('^')).toBe(true);
+      expect(find.source.endsWith('$')).toBe(true);
+    }
+  });
+
+  it('sorts entries most-specific first so subpaths precede the bare-package root', () => {
+    // Recover the raw specifier from the anchored source (strip ^…$, unescape)
+    // — ordering is by raw specifier length, not escaped regex length.
+    const rawFind = (find: RegExp) =>
+      find.source.slice(1, -1).replace(/\\(.)/g, '$1');
+    const lengths = aliases.map((entry) => rawFind(entry.find).length);
     expect(lengths).toEqual([...lengths].sort((a, b) => b - a));
 
-    const svelteIdx = aliases.findIndex(
-      (entry) => entry.find === '@happyvertical/smrt-vitest/svelte',
+    const svelteIdx = aliases.findIndex((entry) =>
+      entry.find.test('@happyvertical/smrt-vitest/svelte'),
     );
-    const rootIdx = aliases.findIndex(
-      (entry) => entry.find === '@happyvertical/smrt-vitest',
+    const rootIdx = aliases.findIndex((entry) =>
+      entry.find.test('@happyvertical/smrt-vitest'),
     );
     expect(svelteIdx).toBeGreaterThanOrEqual(0);
     expect(svelteIdx).toBeLessThan(rootIdx);
+  });
+
+  it('drops entries rejected by the filter option, keeping the rest (#2017)', () => {
+    const filtered = getWorkspaceViteAliases(repoRoot, {
+      filter: (entry) => entry.find !== '@happyvertical/smrt-core',
+    });
+    const filteredReplacementFor = (specifier: string) =>
+      filtered.find((entry) => entry.find.test(specifier))?.replacement;
+
+    expect(filteredReplacementFor('@happyvertical/smrt-core')).toBeUndefined();
+    expect(filteredReplacementFor('@happyvertical/smrt-core/testing')).toMatch(
+      /src\/testing\.ts$/,
+    );
+    expect(filteredReplacementFor('@happyvertical/smrt-vitest')).toMatch(
+      /packages\/vitest\/src\/index\.ts$/,
+    );
   });
 
   it('only emits aliases whose source target exists', () => {

--- a/packages/vitest/src/index.ts
+++ b/packages/vitest/src/index.ts
@@ -104,6 +104,16 @@ export interface SmrtVitestPluginOptions {
    * at a local source file while still using the same plugin API.
    */
   setupFile?: string;
+
+  /**
+   * Filter applied to the auto-generated workspace alias entries before they
+   * are injected into `resolve.alias`. Receives the raw string `find` and its
+   * `replacement`; return `false` to drop the entry — e.g. to force a package
+   * to resolve through its published exports map instead of workspace source.
+   *
+   * @default undefined — every generated entry is kept
+   */
+  aliasFilter?: (entry: { find: string; replacement: string }) => boolean;
 }
 
 function resolveDefaultSetupFile(): string {
@@ -124,6 +134,34 @@ type ViteAliasEntry = {
   find: string;
   replacement: string;
 };
+
+/**
+ * Workspace alias entry as injected into Vite. `find` is an anchored RegExp
+ * so an alias can only match its exact specifier: rolldown (vite 8) treats a
+ * plain-string `find` as a prefix match, so a bare package alias like
+ * `@org/pkg` → `src/index.ts` would mangle an unaliased subpath import
+ * (`@org/pkg/sub` → `src/index.ts/sub`). Known subpaths get their own
+ * entries; everything else falls through to the package exports map.
+ */
+export type WorkspaceViteAlias = {
+  find: RegExp;
+  replacement: string;
+};
+
+/**
+ * Options for {@link getWorkspaceViteAliases}.
+ */
+export interface WorkspaceViteAliasOptions {
+  /**
+   * Drop generated entries by returning `false`. Receives the raw string
+   * `find` (package name or package subpath) and its `replacement` path.
+   */
+  filter?: (entry: ViteAliasEntry) => boolean;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 function findWorkspaceRoot(startDir: string): string | null {
   let current = startDir;
@@ -223,7 +261,8 @@ function addAliasIfPresent(
 
 export function getWorkspaceViteAliases(
   root = process.cwd(),
-): ViteAliasEntry[] {
+  options: WorkspaceViteAliasOptions = {},
+): WorkspaceViteAlias[] {
   const packageRoots = readWorkspacePackageRoots(root);
   const aliases: ViteAliasEntry[] = [];
 
@@ -389,8 +428,8 @@ export function getWorkspaceViteAliases(
     if (packageName === '@happyvertical/smrt-vitest') {
       // Shared Svelte component-test harness (S11 #1416). Flat `src/*.ts` files,
       // so the generic `/svelte` → `src/svelte/index.ts` convention misses them;
-      // map the exact subpaths. The length-desc sort below makes these win over
-      // the bare-package root alias.
+      // map the exact subpaths (every emitted alias matches exactly, so the
+      // bare-package root alias can never shadow these).
       addAliasIfPresent(
         aliases,
         '@happyvertical/smrt-vitest/svelte',
@@ -507,7 +546,18 @@ export function getWorkspaceViteAliases(
     }
   }
 
-  return aliases.sort((left, right) => right.find.length - left.find.length);
+  const { filter } = options;
+  const kept = filter ? aliases.filter((entry) => filter(entry)) : aliases;
+
+  return kept
+    .sort((left, right) => right.find.length - left.find.length)
+    .map(({ find, replacement }) => ({
+      // Anchored exact match — see WorkspaceViteAlias. Without the anchors,
+      // rolldown prefix-matches string finds and mangles unaliased subpath
+      // imports (e.g. `@anytown/deploy/deploy/pipeline`, anytown.ai#707).
+      find: new RegExp(`^${escapeRegExp(find)}$`),
+      replacement,
+    }));
 }
 
 function normalizeAliasEntries(
@@ -896,6 +946,73 @@ async function generateLocalManifest(
 type RetryConfig = number | { count?: number; delay?: number };
 
 /**
+ * Build the `oxc` transform defaults injected into the consumer config.
+ *
+ * Vite 8 (rolldown) transforms TypeScript with oxc and ignores the old
+ * `esbuild.tsconfigRaw` escape hatch, which breaks SMRT projects in two ways
+ * (evidence: anytown.ai#707, willgriffin.dev#220):
+ *
+ * - `@smrt()` legacy decorators reach the bundle untransformed unless
+ *   `oxc.decorator.legacy` is enabled;
+ * - oxc elides imports that are only referenced in type positions, silently
+ *   dropping side-effect model imports (SMRT object registration) in test
+ *   files that sit outside the tsconfig `include`, unless
+ *   `oxc.typescript.onlyRemoveTypeImports` is enabled.
+ *
+ * Every field the consumer configured themselves is left alone — a default is
+ * only injected when the consumer has not set that field, so explicit
+ * consumer values always win (vite deep-merges the rest). `oxc: false`
+ * disables the oxc transform entirely and suppresses all injection. The keys
+ * are inert on esbuild-based vite ≤ 7.
+ */
+function resolveOxcDefaults(
+  userOxc: unknown,
+): Record<string, unknown> | undefined {
+  if (
+    userOxc !== undefined &&
+    (typeof userOxc !== 'object' || userOxc === null)
+  ) {
+    return undefined;
+  }
+
+  const user = (userOxc ?? {}) as {
+    decorator?: unknown;
+    tsconfig?: unknown;
+    typescript?: unknown;
+  };
+
+  const defaults: Record<string, unknown> = {};
+
+  if (user.decorator === undefined) {
+    defaults.decorator = {
+      legacy: true,
+      emitDecoratorMetadata: true,
+    };
+    // The tsconfig compiler-option mirror only makes sense alongside the
+    // decorator default — a consumer overriding `decorator` owns both.
+    if (user.tsconfig === undefined) {
+      defaults.tsconfig = {
+        compilerOptions: {
+          experimentalDecorators: true,
+          emitDecoratorMetadata: true,
+        },
+      };
+    }
+  }
+
+  const typescriptConfigured =
+    user.typescript !== undefined &&
+    (typeof user.typescript !== 'object' ||
+      user.typescript === null ||
+      'onlyRemoveTypeImports' in user.typescript);
+  if (!typescriptConfigured) {
+    defaults.typescript = { onlyRemoveTypeImports: true };
+  }
+
+  return Object.keys(defaults).length > 0 ? defaults : undefined;
+}
+
+/**
  * Resolve the per-test `retry` injected into the vitest config.
  *
  * Precedence: `SMRT_VITEST_RETRY` (a digits-only, non-negative integer) wins;
@@ -972,11 +1089,14 @@ export function smrtVitestPlugin(
     root = process.cwd(),
     generateManifest = true,
     setupFile = resolveDefaultSetupFile(),
+    aliasFilter,
   } = options;
 
   let manifestsLoaded = false;
   const setupFileId = setupFile;
-  const workspaceAliases = getWorkspaceViteAliases(root);
+  const workspaceAliases = getWorkspaceViteAliases(root, {
+    filter: aliasFilter,
+  });
 
   const ensureSetupFiles = (value: string | string[] | undefined): string[] => {
     const setupFiles = Array.isArray(value) ? [...value] : value ? [value] : [];
@@ -1027,18 +1147,11 @@ export function smrtVitestPlugin(
       const alias = normalizeAliasEntries(resolveConfig?.alias);
 
       return {
-        oxc: {
-          decorator: {
-            legacy: true,
-            emitDecoratorMetadata: true,
-          },
-          tsconfig: {
-            compilerOptions: {
-              experimentalDecorators: true,
-              emitDecoratorMetadata: true,
-            },
-          },
-        },
+        // Vite 8 (rolldown/oxc) defaults — legacy @smrt() decorators and
+        // type-import elision (see resolveOxcDefaults). Fields the consumer
+        // configured are never injected; `undefined` is dropped by vite's
+        // config merge, so this key vanishes when there is nothing to add.
+        oxc: resolveOxcDefaults((userConfig as { oxc?: unknown }).oxc),
         resolve: {
           alias: [...workspaceAliases, ...alias],
         },


### PR DESCRIPTION
## Summary

Upstreams the three vite 8 (rolldown/oxc) workarounds that SMRT-consuming apps currently carry locally (evidence: anytown/anytown.ai#707, willgriffin/willgriffin.dev#220) into `@happyvertical/smrt-vitest`, so every consumer gets them from `smrtVitestPlugin()` automatically:

- **Legacy decorators / type-import elision defaults are now consumer-overridable and complete** — the plugin's `config` hook injects `oxc.decorator = { legacy: true, emitDecoratorMetadata: true }` (with its `oxc.tsconfig.compilerOptions` mirror) and, newly, `oxc.typescript = { onlyRemoveTypeImports: true }` so oxc stops eliding type-position side-effect imports that perform SMRT object registration. Injection is per-field: anything the consumer set themselves is never touched, and `oxc: false` suppresses everything (`resolveOxcDefaults`). The previous decorator block was injected unconditionally and could clobber explicit consumer values.
- **Workspace aliases can no longer mangle subpath imports** — `getWorkspaceViteAliases()` now emits anchored exact-match `RegExp` finds instead of plain strings, because rolldown prefix-matches string finds and turned `@anytown/deploy/deploy/pipeline` into `packages/deploy/src/index.ts/deploy/pipeline`. Unaliased subpaths now fall through to the package exports map. A new `aliasFilter` plugin option (and `filter` on the helper) lets consumers drop generated entries without monkey-patching the plugin's `config` hook, which is what anytown's dashboard does today.
- **README and package AGENTS.md document exactly which vite 8 behaviors are normalized**, the override story, and the boundary that build-only vite configs without the plugin still need their own `oxc.decorator` settings.

No manual changeset: this repo auto-generates changesets from conventional commits.

Implementation claim: released for review after the ready PR was opened.

## Validation

- focused `@happyvertical/smrt-vitest` suite — 5 files, 51 tests, including new coverage for oxc default injection and per-field overrides, anchored exact-match aliases, and `aliasFilter`
- `pnpm build` — 61/61 tasks
- `pnpm typecheck` — 118/118 tasks
- `pnpm test` — full suite, 119/119 tasks green against the final source (a first pass had one transient failure that did not reproduce on the full re-run, consistent with the repo's documented CI-timing flake class)
- `npx biome ci --diagnostic-level=error .` — clean, 2817 files
- `pnpm knowledge:check --strict --format markdown` — 0 errors, 0 warnings
- lefthook pre-commit and pre-push gates — format, secret-scan, commitlint, standards checks, knowledge freshness

Closes #2017

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"eb978fd3-d324-4b9d-9b96-efc7e19e64e2","issue":"happyvertical/smrt#2017","policy_revision":"1.0.0","validation":["smrt-vitest suite 51/51 (new oxc/alias coverage)", "pnpm build 61/61", "pnpm typecheck 118/118", "pnpm test 119/119 on final source (one non-reproducing transient in first pass)", "biome ci clean 2817 files", "knowledge:check --strict 0 errors 0 warnings", "lefthook pre-commit and pre-push gates"]}
```
