### PR TITLE
ci: use the shared Linux runner pool

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -1,9 +1,10 @@
 # Continuous integration architecture
 
-SMRT uses hosted runners for static checks and HappyVertical ARC runners for
-builds and tests. The internal Turborepo server is the build-output cache;
-GitHub Actions cache archives are deliberately not used for `.turbo/cache`.
-If the remote cache is unavailable, Turbo performs a cold build.
+SMRT uses hosted runners for lightweight static and control-plane checks and
+the shared `ci-linux-x64` pool for general builds, tests, and publishing. The
+internal Turborepo server is the build-output cache; GitHub Actions cache
+archives are deliberately not used for `.turbo/cache`. If the remote cache is
+unavailable, Turbo performs a cold build.
 
 ## Manifest generation
 
@@ -21,22 +22,25 @@ never prevent the tests from running.
 
 ## Runner selection
 
-- `arc-happyvertical-node` is the normal Node.js runner. It has exact Node and
-  pnpm versions, native build dependencies, and a PostgreSQL client. It has no
-  Docker daemon or privileged sidecar.
-- `arc-happyvertical` is the compatibility runner for workflows that require
-  Docker or deployment tooling.
-- SMRT jobs select the node runner when the repository variable
-  `CI_NODE_RUNNER_ENABLED` is `true`; otherwise they use the compatibility
-  runner. PostgreSQL shadow validation always targets the node runner.
+- `ci-linux-x64` is the default selector for general Linux work. It combines
+  ARC capacity with allowlisted PXE hosts using one workflow-facing label.
+- `arc-happyvertical-node` is reserved for the runner-image smoke test and
+  PostgreSQL shadow validation. Those jobs depend on its cluster-local database
+  URL mount and intentionally do not join the general pool.
+- Lightweight lifecycle, policy, aggregation, stale-management, and mobile
+  jobs remain GitHub-hosted when they do not benefit from a self-hosted cache.
+
+The retired `CI_NODE_RUNNER_ENABLED` switch no longer controls job placement
+and can be removed from the repository after this workflow migration is live.
 
 The pnpm store and runner workspace must remain on the same node-local
-filesystem so pnpm can hardlink packages. Do not restore the RAM-backed split
+filesystem so pnpm can hardlink packages. Do not restore RAM-backed split
 mounts without measuring runner memory and install latency. The shared setup
 action also points `TMPDIR` at the workspace-backed runner temp directory so
 SQLite fixtures and other temporary test files bypass the container overlay
-filesystem. ARC runners can provide `CI_TEST_TMPDIR` to route those files to a
-bounded, test-only tmpfs; other runners retain the workspace-backed fallback.
+filesystem. Self-hosted runners can provide `CI_TEST_TMPDIR` to route those
+files to a bounded, test-only tmpfs; other runners retain the workspace-backed
+fallback.
 
 ## Pull requests and merge groups
 
@@ -55,7 +59,7 @@ representative code-changing PR run.
 
 After that canary run:
 
-1. Set `CI_NODE_RUNNER_ENABLED=true` and verify one non-required/shadow run.
+1. Verify the `ci-linux-x64` ARC/PXE canary and one representative SMRT run.
 2. Set `CI_POSTGRES_ENABLED=true` after the disposable cluster and runner URL
    mount pass the manual shadow workflow.
 3. Set `CI_MERGE_QUEUE_ENABLED=true`.
@@ -135,8 +139,9 @@ p95 exceeds 45 seconds, runner memory exceeds 8 GiB, required contexts vanish,
 or retries/failures increase. Target setup p50 below 30 seconds, queue p95 below
 two minutes, and at least 30% fewer self-hosted runner-minutes per PR.
 
-Rollback by clearing the three repository variables, restoring the previous
-required status list, and removing the merge-queue rule. PostgreSQL can be
-removed from the required aggregator without altering SQLite coverage. The
-artifact publisher can temporarily fall back to Changesets through manual
-dispatch.
+Rollback runner placement by restoring general jobs to
+`arc-happyvertical-node`. Merge-queue rollout can be reversed independently by
+clearing `CI_MERGE_QUEUE_ENABLED`, restoring the previous required status list,
+and removing the merge-queue rule. PostgreSQL can be removed from the required
+aggregator without altering SQLite coverage. The artifact publisher can
+temporarily fall back to Changesets through manual dispatch.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,6 @@
 self-hosted-runner:
   labels:
-    - arc-happyvertical
+    - ci-linux-x64
     - arc-happyvertical-node
 
 config-variables: null

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -225,20 +225,29 @@ runs:
         restore-keys: |
           ${{ runner.os }}-playwright-
 
-    # Check if ONNX deps are already installed (custom ARC runner)
+    # Check if ONNX deps are already installed or supplied by the runner image.
     - name: Install system dependencies for ONNX Runtime
       shell: bash
       run: |
-        # Skip if already installed (custom ARC runner image)
-        # Check for dpkg first (only available on Debian-based systems)
+        if [ "${CI_ONNX_DEPS_READY:-}" = "true" ]; then
+          echo "✓ ONNX Runtime dependencies are supplied by the runner image, skipping"
+          exit 0
+        fi
+
+        # Check for dpkg first (only available on Debian-based systems).
         if command -v dpkg >/dev/null 2>&1; then
           if dpkg -l | grep -q libprotobuf-dev && dpkg -l | grep -q build-essential; then
             echo "✓ ONNX Runtime deps already installed, skipping"
             exit 0
           fi
-        else
-          echo "dpkg not found, skipping installed-package check"
         fi
+
+        if ! command -v sudo >/dev/null 2>&1 || ! command -v apt-get >/dev/null 2>&1; then
+          echo "::error::Runner must supply ONNX dependencies with" \
+            "CI_ONNX_DEPS_READY=true or provide both sudo and apt-get"
+          exit 1
+        fi
+
         echo "Installing ONNX Runtime system dependencies..."
         sudo apt-get update && sudo apt-get install -y \
           libstdc++6 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -31,7 +31,7 @@ jobs:
   cancel-pr-checks:
     name: Cancel PR Validation Checks
     if: github.event_name == 'push' && vars.CI_MERGE_QUEUE_ENABLED != 'true'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   prepare-publish:
     name: Prepare Publish Validation
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     timeout-minutes: 30
     outputs:
       should-validate: ${{ steps.prepare.outputs.should_validate }}
@@ -135,7 +135,7 @@ jobs:
     name: Pack Validation (Shard ${{ matrix.shard-label }})
     needs: prepare-publish
     if: needs.prepare-publish.outputs.should-validate == 'true'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ permissions:
 jobs:
   prepare-release:
     name: Prepare Release
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     timeout-minutes: 20
     outputs:
       previous-version: ${{ steps.prepare.outputs.previous_version }}
@@ -222,7 +222,7 @@ jobs:
     name: Release Pack Validation (Shard ${{ matrix.shard-label }})
     needs: prepare-release
     if: needs.prepare-release.outputs.should-publish == 'true'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -285,7 +285,7 @@ jobs:
     if: |
       needs.prepare-release.outputs.should-publish == 'true' &&
       needs.validate-release-shards.result == 'success'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     timeout-minutes: 45
     concurrency:
       group: release-publish-${{ github.repository }}-${{ github.ref }}
@@ -436,7 +436,7 @@ jobs:
 
   deploy-docs:
     name: Deploy Documentation
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: arc-happyvertical
+    runs-on: ubuntu-latest
     steps:
       - name: Mark stale issues and PRs
         uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -43,7 +43,7 @@ jobs:
   build:
     name: Build
     if: inputs.mode == 'full'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     timeout-minutes: 15
 
     steps:
@@ -122,7 +122,7 @@ jobs:
     name: Typecheck
     needs: build
     if: inputs.mode == 'full'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     timeout-minutes: 15
 
     steps:
@@ -168,7 +168,7 @@ jobs:
     name: Affected Build, Typecheck, and Tests
     needs: affected-scope
     if: inputs.mode == 'affected'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -196,7 +196,7 @@ jobs:
     name: Affected Knowledge Freshness
     needs: affected-scope
     if: inputs.mode == 'affected' && needs.affected-scope.outputs.knowledge == 'true'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     timeout-minutes: 15
     steps:
       - name: Checkout repository
@@ -225,7 +225,7 @@ jobs:
     name: Knowledge Freshness
     needs: build
     if: inputs.mode == 'full'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     timeout-minutes: 10
 
     steps:
@@ -264,7 +264,7 @@ jobs:
     name: Coverage Gate
     needs: build
     if: always() && (inputs.mode == 'affected' || needs.build.result == 'success')
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     timeout-minutes: 25
 
     steps:
@@ -298,7 +298,7 @@ jobs:
     name: Test Core (${{ matrix.shard }})
     needs: build
     if: inputs.mode == 'full'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     # A remote-cache outage can add several minutes of cold setup and build
     # time. Match the package-shard ceiling so cache misses cannot cancel an
     # otherwise healthy core suite.
@@ -353,7 +353,7 @@ jobs:
     name: Test Integration
     needs: build
     if: inputs.mode == 'full'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     timeout-minutes: 10
 
     steps:
@@ -388,7 +388,7 @@ jobs:
     name: Test Packages (${{ matrix.shard }})
     needs: build
     if: inputs.mode == 'full'
-    runs-on: ${{ vars.CI_NODE_RUNNER_ENABLED == 'true' && 'arc-happyvertical-node' || 'arc-happyvertical' }}
+    runs-on: ci-linux-x64
     # Each shard runs ~1/3 of package tests and lets Turbo build only their
     # dependency closures. Keep the wider timeout for runner-pool contention.
     timeout-minutes: 25


### PR DESCRIPTION
Closes #2031

## Summary

- route 16 build, test, package-validation, release, and docs jobs through the shared `ci-linux-x64` selector
- keep PostgreSQL shadow validation and the node-image smoke test on `arc-happyvertical-node` because they depend on that specialized runner contract
- move lightweight merge-control and stale-management jobs to GitHub-hosted runners
- retire workflow dependence on `CI_NODE_RUNNER_ENABLED` and document the new runner split and rollback path

This PR intentionally depends on happyvertical/iac#996 making `ci-linux-x64` live. Existing specialized PostgreSQL and mobile execution paths are unchanged.

## Validation

- `actionlint` on all changed workflows
- `yamllint` on all changed workflows (pre-existing line-length warnings only)
- `pnpm knowledge:check --changed --strict --format markdown`
- repository pre-commit hooks
- repository pre-push hooks, including all-workflow validation
- `git diff --check`

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-2031-smrt-ci-linux-x64-20260715",
  "issue": "happyvertical/smrt#2031",
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "changed workflows actionlint and yamllint",
    "SMRT knowledge freshness strict",
    "repository pre-commit hooks",
    "repository pre-push hooks including all-workflow validation",
    "commit diff check"
  ]
}
```
