### PR TITLE
fix(jobs): hydrate object-bound jobs by persisted id

### DIFF
--- a/packages/jobs/AGENTS.md
+++ b/packages/jobs/AGENTS.md
@@ -25,7 +25,8 @@ Polling-based execution engine. Config: `concurrency` (5), `pollInterval` (1s), 
 3. Claim sets `status='running'`, `workerId=<incarnation key>`, heartbeat/start timestamps, and increments `attempts`
 4. Resolves class via `ObjectRegistry.getClass(objectType)`. Object-bound jobs
    pass `objectId` to the constructor and let `initialize()` perform the single
-   canonical hydration; jobs without `objectId` construct a static-like instance
+   canonical hydration. Runner-owned `db`, `id`, and hydration options cannot be
+   overridden by agent config; jobs without `objectId` construct a static-like instance
 5. **Internal args**: `_agentConfig` and `_scheduleId` stripped from args before calling method
 6. Calls the requested method on the initialized instance
 7. Terminal/retry writes are **conditional** (`WHERE worker_id=? AND status='running'`) so a recovered row is never stomped

--- a/packages/jobs/AGENTS.md
+++ b/packages/jobs/AGENTS.md
@@ -26,7 +26,8 @@ Polling-based execution engine. Config: `concurrency` (5), `pollInterval` (1s), 
 4. Resolves class via `ObjectRegistry.getClass(objectType)`. Object-bound jobs
    pass `objectId` to the constructor and let `initialize()` perform the single
    canonical hydration. Runner-owned `db`, `id`, and hydration options cannot be
-   overridden by agent config; jobs without `objectId` construct a static-like instance
+   overridden by agent config; missing persisted targets fail before method
+   dispatch. Jobs without `objectId` construct a static-like instance
 5. **Internal args**: `_agentConfig` and `_scheduleId` stripped from args before calling method
 6. Calls the requested method on the initialized instance
 7. Terminal/retry writes are **conditional** (`WHERE worker_id=? AND status='running'`) so a recovered row is never stomped

--- a/packages/jobs/AGENTS.md
+++ b/packages/jobs/AGENTS.md
@@ -23,11 +23,14 @@ Polling-based execution engine. Config: `concurrency` (5), `pollInterval` (1s), 
 1. `start()` calls `assertReady()` (fail fast if `_smrt_workers` unmigrated), registers a seeded `SmrtWorker` lease, and adds its worker key to the process-global live set — all **before** polling
 2. Polls `claimReady()` to atomically claim pending jobs (`runAt <= NOW`, ordered by `priority DESC, runAt ASC, created_at ASC, id ASC`)
 3. Claim sets `status='running'`, `workerId=<incarnation key>`, heartbeat/start timestamps, and increments `attempts`
-4. Resolves class via `ObjectRegistry.getClass(objectType)`, creates instance, calls method
+4. Resolves class via `ObjectRegistry.getClass(objectType)`. Object-bound jobs
+   pass `objectId` to the constructor and let `initialize()` perform the single
+   canonical hydration; jobs without `objectId` construct a static-like instance
 5. **Internal args**: `_agentConfig` and `_scheduleId` stripped from args before calling method
-6. Terminal/retry writes are **conditional** (`WHERE worker_id=? AND status='running'`) so a recovered row is never stomped
-7. Retry: uses strategy from `@happyvertical/jobs`, schedules future `runAt` on failure
-8. Events: `job:started`, `job:completed`, `job:failed`, `job:retrying`, `runner:started/stopped`
+6. Calls the requested method on the initialized instance
+7. Terminal/retry writes are **conditional** (`WHERE worker_id=? AND status='running'`) so a recovered row is never stomped
+8. Retry: uses strategy from `@happyvertical/jobs`, schedules future `runAt` on failure
+9. Events: `job:started`, `job:completed`, `job:failed`, `job:retrying`, `runner:started/stopped`
 
 A rejection from `processJob` can never escape the poll loop: the caller attaches `.catch(e => emit('runner:error', e))` and the error path (`handleJobError`) is itself try/caught, so a failure-path write that rejects is surfaced as a `runner:error` event instead of crashing the worker with an unhandled rejection.
 

--- a/packages/jobs/src/__tests__/object-job-hydration.test.ts
+++ b/packages/jobs/src/__tests__/object-job-hydration.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression for #2038: object-bound jobs must hydrate the persisted target
+ * before invoking its method. This exercises the real persistent queue and
+ * polling runner rather than calling TaskRunner internals directly.
+ */
+import {
+  field,
+  getTestDatabase,
+  ObjectRegistry,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { afterEach, describe, expect, it } from 'vitest';
+import { backgroundEligible } from '../background-policy.js';
+import { createTaskRunner } from '../runner.js';
+import { SmrtJobCollection } from '../smrt-job.js';
+
+interface ProbeResult {
+  id: string | null | undefined;
+  label: string;
+  processedMarker: string;
+}
+
+@smrt()
+class ObjectJobHydrationProbe extends SmrtObject {
+  @field({ type: 'text', required: true })
+  label: string = '';
+
+  @field({ type: 'text' })
+  processedMarker: string = '';
+
+  private readonly agentMarker: string;
+
+  constructor(options: Record<string, unknown> = {}) {
+    super(options as never);
+    this.agentMarker = String(options.agentMarker ?? 'missing-agent-config');
+  }
+
+  @backgroundEligible()
+  async process(args: { suffix: string }): Promise<ProbeResult> {
+    this.processedMarker = `${this.label}:${args.suffix}:${this.agentMarker}`;
+    await this.save();
+
+    return {
+      id: this.id,
+      label: this.label,
+      processedMarker: this.processedMarker,
+    };
+  }
+}
+
+function canonicalProbeType(): string {
+  return (
+    ObjectRegistry.getClass('ObjectJobHydrationProbe')?.qualifiedName ||
+    'ObjectJobHydrationProbe'
+  );
+}
+
+afterEach(() => {
+  ObjectRegistry.clearCollectionCache?.();
+});
+
+describe('TaskRunner object-bound job hydration (#2038)', () => {
+  it('hydrates the exact persisted row and invokes its method with agent config', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+
+    const target = await new ObjectJobHydrationProbe({
+      db,
+      label: 'target-row',
+    }).initialize();
+    await target.save();
+
+    const other = await new ObjectJobHydrationProbe({
+      db,
+      label: 'other-row',
+    }).initialize();
+    await other.save();
+
+    const targetId = target.id;
+    const otherId = other.id;
+    if (!targetId || !otherId) {
+      throw new Error('persisted probes must have IDs');
+    }
+
+    const jobs = await SmrtJobCollection.create({ db });
+    const job = await jobs.create({
+      objectType: canonicalProbeType(),
+      objectId: targetId,
+      method: 'process',
+      args: {
+        suffix: 'ran',
+        _agentConfig: { agentMarker: 'resolved-config' },
+      },
+      maxAttempts: 1,
+    });
+    await job.save();
+
+    const runner = createTaskRunner({ concurrency: 1, pollInterval: 10 });
+    await runner.initialize(db);
+
+    const completion = new Promise<{ result?: ProbeResult }>(
+      (resolve, reject) => {
+        runner.once('job:completed', (_completedJob, result) =>
+          resolve(result as { result?: ProbeResult }),
+        );
+        runner.once('job:failed', (_failedJob, error) => reject(error));
+        runner.once('runner:error', reject);
+      },
+    );
+
+    await runner.start();
+    try {
+      const { result } = await completion;
+      expect(result).toEqual({
+        id: targetId,
+        label: 'target-row',
+        processedMarker: 'target-row:ran:resolved-config',
+      });
+    } finally {
+      await runner.stop();
+    }
+
+    const hydratedTarget = await new ObjectJobHydrationProbe({
+      db,
+      id: targetId,
+    }).initialize();
+    const hydratedOther = await new ObjectJobHydrationProbe({
+      db,
+      id: otherId,
+    }).initialize();
+
+    expect(hydratedTarget.processedMarker).toBe(
+      'target-row:ran:resolved-config',
+    );
+    expect(hydratedOther.processedMarker).toBe('');
+  });
+});

--- a/packages/jobs/src/__tests__/object-job-hydration.test.ts
+++ b/packages/jobs/src/__tests__/object-job-hydration.test.ts
@@ -23,6 +23,8 @@ interface ProbeResult {
 
 @smrt()
 class ObjectJobHydrationProbe extends SmrtObject {
+  static invocationIds: string[] = [];
+
   @field({ type: 'text', required: true })
   label: string = '';
 
@@ -38,6 +40,7 @@ class ObjectJobHydrationProbe extends SmrtObject {
 
   @backgroundEligible()
   async process(args: { suffix: string }): Promise<ProbeResult> {
+    ObjectJobHydrationProbe.invocationIds.push(this.id ?? 'missing-id');
     this.processedMarker = `${this.label}:${args.suffix}:${this.agentMarker}`;
     await this.save();
 
@@ -57,6 +60,7 @@ function canonicalProbeType(): string {
 }
 
 afterEach(() => {
+  ObjectJobHydrationProbe.invocationIds.length = 0;
   ObjectRegistry.clearCollectionCache?.();
 });
 
@@ -138,5 +142,54 @@ describe('TaskRunner object-bound job hydration (#2038)', () => {
       'target-row:ran:resolved-config',
     );
     expect(hydratedOther.processedMarker).toBe('');
+  });
+
+  it('fails a stale object-bound job before invoking its method', async () => {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+
+    const target = await new ObjectJobHydrationProbe({
+      db,
+      label: 'deleted-row',
+    }).initialize();
+    await target.save();
+
+    const targetId = target.id;
+    if (!targetId) {
+      throw new Error('persisted probe must have an ID');
+    }
+    await target.delete();
+
+    const jobs = await SmrtJobCollection.create({ db });
+    const job = await jobs.create({
+      objectType: canonicalProbeType(),
+      objectId: targetId,
+      method: 'process',
+      args: { suffix: 'must-not-run' },
+      maxAttempts: 1,
+    });
+    await job.save();
+
+    const runner = createTaskRunner({ concurrency: 1, pollInterval: 10 });
+    await runner.initialize(db);
+
+    const failure = new Promise<Error>((resolve, reject) => {
+      runner.once('job:failed', (_failedJob, error) => resolve(error));
+      runner.once('job:completed', () =>
+        reject(new Error('stale object-bound job unexpectedly completed')),
+      );
+      runner.once('runner:error', reject);
+    });
+
+    await runner.start();
+    try {
+      const error = await failure;
+      expect(error.message).toBe(
+        `Object-bound job target not found: ${canonicalProbeType()}#${targetId}`,
+      );
+    } finally {
+      await runner.stop();
+    }
+
+    expect(ObjectJobHydrationProbe.invocationIds).toEqual([]);
   });
 });

--- a/packages/jobs/src/__tests__/object-job-hydration.test.ts
+++ b/packages/jobs/src/__tests__/object-job-hydration.test.ts
@@ -89,7 +89,12 @@ describe('TaskRunner object-bound job hydration (#2038)', () => {
       method: 'process',
       args: {
         suffix: 'ran',
-        _agentConfig: { agentMarker: 'resolved-config' },
+        _agentConfig: {
+          agentMarker: 'resolved-config',
+          db: ':memory:',
+          id: otherId,
+          _skipLoad: true,
+        },
       },
       maxAttempts: 1,
     });

--- a/packages/jobs/src/runner.ts
+++ b/packages/jobs/src/runner.ts
@@ -582,12 +582,20 @@ export class TaskRunner extends EventEmitter {
       let instance: SmrtObject;
 
       if (job.objectId) {
+        // Agent configuration belongs to the registered class, but it must not
+        // override the runner-controlled persistence target or disable the
+        // canonical hydration.
+        const objectAgentConfig = { ...agentConfig };
+        delete objectAgentConfig.db;
+        delete objectAgentConfig.id;
+        delete objectAgentConfig._skipLoad;
+
         // initialize() performs the canonical hydration when the persisted ID
         // is supplied to the constructor.
         instance = new ObjectClass({
           db: this.db,
           id: job.objectId,
-          ...agentConfig,
+          ...objectAgentConfig,
         });
         await instance.initialize();
       } else {

--- a/packages/jobs/src/runner.ts
+++ b/packages/jobs/src/runner.ts
@@ -598,6 +598,12 @@ export class TaskRunner extends EventEmitter {
           ...objectAgentConfig,
         });
         await instance.initialize();
+
+        if (!instance.isPersisted) {
+          throw new Error(
+            `Object-bound job target not found: ${job.objectType}#${job.objectId}`,
+          );
+        }
       } else {
         // Create new instance for static-like methods
         instance = new ObjectClass({ db: this.db, ...agentConfig });

--- a/packages/jobs/src/runner.ts
+++ b/packages/jobs/src/runner.ts
@@ -582,12 +582,14 @@ export class TaskRunner extends EventEmitter {
       let instance: SmrtObject;
 
       if (job.objectId) {
-        // Load existing object
-        instance = new ObjectClass({ db: this.db, ...agentConfig });
+        // initialize() performs the canonical hydration when the persisted ID
+        // is supplied to the constructor.
+        instance = new ObjectClass({
+          db: this.db,
+          id: job.objectId,
+          ...agentConfig,
+        });
         await instance.initialize();
-        await (
-          instance as SmrtObject & { loadFromId(id: string): Promise<void> }
-        ).loadFromId(job.objectId);
       } else {
         // Create new instance for static-like methods
         instance = new ObjectClass({ db: this.db, ...agentConfig });


### PR DESCRIPTION
## Summary

- construct object-bound TaskRunner targets with the persisted `objectId` plus resolved agent config
- prevent resolved agent config from overriding runner-owned `db`, `id`, or `_skipLoad` hydration options
- fail object-bound jobs whose persisted target was deleted before method dispatch
- let `initialize()` perform the single canonical hydration and remove the invalid `loadFromId(job.objectId)` call
- add a persisted external-behavior regression through the real queue and polling runner that proves the exact row is hydrated and invoked
- document the object-bound execution lifecycle

## Regression evidence

Before the runtime fix, the new regression failed on current `main` with `ValidationError: Required field 'id' is missing for ObjectJobHydrationProbe`. It passes with this change, verifies that a second persisted row remains untouched, and proves reserved config keys cannot redirect or skip hydration. A second persisted queue/runner case proves a deleted target fails without invoking its handler.

## Validation

- `pnpm --filter @happyvertical/smrt-jobs test` — 17 files, 110 tests passed
- `pnpm --filter @happyvertical/smrt-jobs typecheck`
- `pnpm --filter @happyvertical/smrt-jobs build`
- `pnpm exec biome ci --diagnostic-level=error .` — 2,837 files clean
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm run check:mcp-config`
- `pnpm knowledge:check --strict --format markdown`
- review-cycle final full roster — clean

## Downstream provenance

This unblocks happyvertical/projects.happyvertical.com#159, where the real `SupportServiceTarget` worker proof exposed the object-bound hydration defect. The downstream application is not modified here.

Fixes #2038

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex-desktop",
  "session": "019f6d28-cad4-71b3-95ab-eb47889a3740",
  "issue": "happyvertical/smrt#2038",
  "policy_revision": "1.0.0",
  "validation": [
    "pre-fix persisted queue/runner regression failed with required-id ValidationError",
    "pnpm --filter @happyvertical/smrt-jobs test",
    "pnpm --filter @happyvertical/smrt-jobs typecheck",
    "pnpm --filter @happyvertical/smrt-jobs build",
    "pnpm exec biome ci --diagnostic-level=error .",
    "pnpm typecheck",
    "pnpm test",
    "pnpm build",
    "pnpm run check:mcp-config",
    "pnpm knowledge:check --strict --format markdown",
    "review-cycle final full roster clean"
  ]
}
```