### PR TITLE
fix(ci): recover release state and preflight ref push

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -111,17 +111,20 @@ retains a 45-minute recovery window for sequential registry writes. Registry
 reads prefer fresh metadata, and post-publish verification retries six times
 with bounded exponential backoff so temporary npm propagation or stale negative
 cache entries do not strand the release before its Git refs are written. After
-publication, it supplies the release App credential directly to Git instead of
-relying on checkout's path-conditional credential include (ARC workspaces may
-resolve through a symlink). The release commit and tag are pushed atomically, so
-GitHub cannot record only one of the two refs.
+creating the release commit and tag locally, it resets inherited Git
+authentication, supplies the release App credential directly, and dry-runs the
+exact atomic ref push before publication. The publisher checkout does not
+persist its own credential, preventing duplicate `Authorization` headers when
+ARC workspaces resolve through different paths. After publication, the release
+commit and tag are pushed atomically, so GitHub cannot record only one ref.
 
 If an interrupted run publishes only part of a lockstep version, a later main
 commit must not fill in the remaining packages under that same version: the
 artifacts would come from different source trees. Keep the npm collision guard,
 apply the interrupted run's exact generated version patch to reserve that
 version in Git, and let the next merge publish the complete package set at a new
-version.
+version. The version patch is retained for 30 days so this recovery remains
+available after the short-lived build and package artifacts expire.
 
 Documentation installs as an isolated workspace under `docs/`. Its pnpm build
 policy explicitly allows the `core-js` and `sharp` install scripts required by

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -205,7 +205,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: publish-release-version-patch
-          retention-days: 1
+          # Keep the exact recovery patch long enough to reconcile an npm
+          # publish that succeeds before a later Git ref update fails.
+          retention-days: 30
           if-no-files-found: error
           path: release-version.patch
 
@@ -303,6 +305,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          # push-release-refs supplies the release App credential explicitly.
+          # Persisting checkout auth can send duplicate Authorization headers.
+          persist-credentials: false
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Download release version patch
@@ -388,6 +393,12 @@ jobs:
             git add "${release_files[@]}"
           fi
           git commit -m "chore(release): v$RELEASE_VERSION [skip ci]"
+          git tag -f "v$RELEASE_VERSION"
+
+          # Exercise the same authenticated atomic push before npm publication
+          # makes the release irreversible. This catches credential and remote
+          # ref failures without updating either main or the release tag.
+          RELEASE_PUSH_DRY_RUN=true node scripts/push-release-refs.mjs
 
           if [ "$PUBLISH_MODE" = "artifacts" ]; then
             node scripts/publish-validated-artifacts.mjs publish-pack-output
@@ -406,7 +417,6 @@ jobs:
             exit 1
           fi
 
-          git tag -f "v$RELEASE_VERSION"
           # Skip developer hooks in CI. Release builds can generate source
           # artifacts, and those hooks should not block the automation push
           # after the equivalent safety checks have already run above.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "smrt framework for building vertical AI agents",
   "author": "Will Griffin <willgriffin@gmail.com>",
   "type": "module",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "files": [
     "AGENTS.md",
     "CLAUDE.md"

--- a/packages/ads/CHANGELOG.md
+++ b/packages/ads/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-ads
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/ads/package.json
+++ b/packages/ads/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ads",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Advertising delivery and tracking models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/affiliates/CHANGELOG.md
+++ b/packages/affiliates/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-affiliates
 
+## 0.40.6
+
+### Patch Changes
+
+- @happyvertical/smrt-sales@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/affiliates/package.json
+++ b/packages/affiliates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-affiliates",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "DEPRECATED compatibility shim over @happyvertical/smrt-sales — re-exports the legacy Partner/Commission/Payout names. See MIGRATION.md.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agents/CHANGELOG.md
+++ b/packages/agents/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-agents
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-secrets@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-users@0.40.6
+  - @happyvertical/smrt-config@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-agents",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "type": "module",
   "smrtRawPrimitives": "strict",
   "description": "Agent framework for building autonomous actors in the SMRT ecosystem",

--- a/packages/analytics/CHANGELOG.md
+++ b/packages/analytics/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-analytics
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-prompts@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-analytics",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Analytics integration models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/app-cli/CHANGELOG.md
+++ b/packages/app-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-app-cli
 
+## 0.40.6
+
+### Patch Changes
+
+- @happyvertical/smrt-users@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/app-cli/package.json
+++ b/packages/app-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-app-cli",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Reusable CLI factory for SMRT apps — branded `<name> <resource> <command>` CLI + stdio MCP bridge with decorator-driven resource discovery",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/assets-ergot/CHANGELOG.md
+++ b/packages/assets-ergot/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-assets-ergot
 
+## 0.40.6
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/assets-ergot/package.json
+++ b/packages/assets-ergot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-assets-ergot",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Ergot-backed processing, search, and workflow adapter for SMRT assets",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/assets-local/CHANGELOG.md
+++ b/packages/assets-local/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-assets-local
 
+## 0.40.6
+
+### Patch Changes
+
+- @happyvertical/smrt-assets@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/assets-local/package.json
+++ b/packages/assets-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-assets-local",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Local image metadata and variant processor for SMRT assets",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/assets/CHANGELOG.md
+++ b/packages/assets/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-assets
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-tags@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/assets/package.json
+++ b/packages/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-assets",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Asset management system with versioning, metadata, and AI-powered operations for SMRT framework",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/chat/CHANGELOG.md
+++ b/packages/chat/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-chat
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-agents@0.40.6
+  - @happyvertical/smrt-personas@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-users@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-chat",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Chat rooms, DMs, threads, and agent conversations for the SMRT framework",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-cli
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-agents@0.40.6
+  - @happyvertical/smrt-dev-mcp@0.40.6
+  - @happyvertical/smrt-config@0.40.6
+  - @happyvertical/smrt-playground@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-cli",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Developer CLI for SMRT framework - introspection, testing, and project management",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/commerce/CHANGELOG.md
+++ b/packages/commerce/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-commerce
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-ledgers@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-commerce",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Commerce models for the SMRT framework - contracts, fulfillments, payments",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-config
 
+## 0.40.6
+
+### Patch Changes
+
+- @happyvertical/smrt-types@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-config",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "type": "module",
   "description": "Centralized configuration management for SMRT modules",
   "author": "HappyVertical",

--- a/packages/content/CHANGELOG.md
+++ b/packages/content/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @happyvertical/smrt-content
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-assets@0.40.6
+  - @happyvertical/smrt-chat@0.40.6
+  - @happyvertical/smrt-facts@0.40.6
+  - @happyvertical/smrt-images@0.40.6
+  - @happyvertical/smrt-messages@0.40.6
+  - @happyvertical/smrt-profiles@0.40.6
+  - @happyvertical/smrt-prompts@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-content",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Content processing module for SMRT framework - handles documents, web content, and media",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @happyvertical/smrt-core
 
+## 0.40.6
+
+### Patch Changes
+
+- ### Features
+
+  - browser SSE client for the streaming chat route (/client subpath) (chat)
+
+  ### Bug Fixes
+
+  - enforce client contract locks + release the stream on settled turns (chat)
+  - support prepared non-Debian runners (ci)
+
+  ### Other Changes
+
+  - ci: use shared Linux runner pool
+  - @happyvertical/smrt-config@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+  - @happyvertical/smrt-scanner@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-core",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Core AI agent framework with standardized collections, object-relational mapping, and code generators",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/events/CHANGELOG.md
+++ b/packages/events/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-events
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-assets@0.40.6
+  - @happyvertical/smrt-places@0.40.6
+  - @happyvertical/smrt-profiles@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-events",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Hierarchical event management with participant tracking and SMRT framework support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/facts/CHANGELOG.md
+++ b/packages/facts/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-facts
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-prompts@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/facts/package.json
+++ b/packages/facts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-facts",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Distributed memory and knowledge management with provenance tracking for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/features/CHANGELOG.md
+++ b/packages/features/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-features
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-features",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Code-first feature flags and tenant-aware overrides for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gnode/CHANGELOG.md
+++ b/packages/gnode/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-gnode
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/gnode/package.json
+++ b/packages/gnode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-gnode",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "SMRT federation library for building federated local knowledge bases (gnodes)",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/images/CHANGELOG.md
+++ b/packages/images/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-images
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-assets@0.40.6
+  - @happyvertical/smrt-prompts@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/images/package.json
+++ b/packages/images/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-images",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Image asset management with AI-powered categorization, search, editing, and metadata extraction for SMRT framework",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/inventory/CHANGELOG.md
+++ b/packages/inventory/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-inventory
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-inventory",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Multi-location stock tracking for the SMRT framework — Sku, InventoryLocation, StockLevel, StockMovement, and a stock-mutation service",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/jobs/CHANGELOG.md
+++ b/packages/jobs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-jobs
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-config@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-jobs",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Background job processing for SMRT objects with persistence and scheduling",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/languages/CHANGELOG.md
+++ b/packages/languages/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-languages
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-features@0.40.6
+  - @happyvertical/smrt-jobs@0.40.6
+  - @happyvertical/smrt-prompts@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-config@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/languages/package.json
+++ b/packages/languages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-languages",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Code-first language strings with config + tenant overrides and AI auto-translation for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ledgers/CHANGELOG.md
+++ b/packages/ledgers/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-ledgers
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-prompts@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/ledgers/package.json
+++ b/packages/ledgers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ledgers",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Double-entry accounting ledger for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/manufacturing/CHANGELOG.md
+++ b/packages/manufacturing/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-manufacturing
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-inventory@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/manufacturing/package.json
+++ b/packages/manufacturing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-manufacturing",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Bills of materials, cost rollup, and production-order operations for the SMRT framework — strictly industry-neutral",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/marketing/CHANGELOG.md
+++ b/packages/marketing/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-marketing
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/marketing/package.json
+++ b/packages/marketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-marketing",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Cross-channel campaign coordination, immutable performance evidence, budget pacing, and reusable Svelte marketing surfaces for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/messages/CHANGELOG.md
+++ b/packages/messages/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @happyvertical/smrt-messages
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-secrets@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-users@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-messages",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Unified multi-channel messaging with STI-based hierarchies",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/personas/CHANGELOG.md
+++ b/packages/personas/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-personas
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-agents@0.40.6
+  - @happyvertical/smrt-messages@0.40.6
+  - @happyvertical/smrt-prompts@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-users@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/personas/package.json
+++ b/packages/personas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-personas",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Tenant-owned, context-scoped agent personas and resolution for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/places/CHANGELOG.md
+++ b/packages/places/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-places
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-assets@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/places/package.json
+++ b/packages/places/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-places",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Hierarchical place management with geo integration and SMRT framework support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/products/CHANGELOG.md
+++ b/packages/products/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-products
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-assets@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-svelte@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+  - @happyvertical/smrt-scanner@0.40.6
+  - @happyvertical/smrt-web@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/products/package.json
+++ b/packages/products/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-products",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "SMRT products module: triple-purpose microservice template for standalone apps, federated modules, and NPM libraries",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/profiles/CHANGELOG.md
+++ b/packages/profiles/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-profiles
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-assets@0.40.6
+  - @happyvertical/smrt-prompts@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/profiles/package.json
+++ b/packages/profiles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-profiles",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Profile management system with relationships, metadata, and reciprocal associations for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/projects/CHANGELOG.md
+++ b/packages/projects/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-projects
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-prompts@0.40.6
+  - @happyvertical/smrt-subscriptions@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-config@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-projects",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Provider-agnostic project management models (Issues, PRs, Repositories, Projects) for SMRT framework",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/prompts/CHANGELOG.md
+++ b/packages/prompts/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-prompts
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-config@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-prompts",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Typed prompt registry, override resolution, and tenant-aware prompt settings for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/properties/CHANGELOG.md
+++ b/packages/properties/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-properties
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-prompts@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/properties/package.json
+++ b/packages/properties/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-properties",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Digital property and zone management models for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/reports/CHANGELOG.md
+++ b/packages/reports/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-reports
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-jobs@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-reports",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Materialized aggregate report models for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sales/CHANGELOG.md
+++ b/packages/sales/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @happyvertical/smrt-sales
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-assets@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/sales/package.json
+++ b/packages/sales/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-sales",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Modular sales for the SMRT framework: agreement execution, CRM, referral intake, neutral commissions, and reusable Svelte surfaces",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/scanner/CHANGELOG.md
+++ b/packages/scanner/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-scanner
 
+## 0.40.6
+
 ## 0.40.5
 
 ## 0.40.4

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-scanner",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "High-performance TypeScript scanner using OXC for SMRT manifest generation",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/secrets/CHANGELOG.md
+++ b/packages/secrets/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-secrets
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/secrets/package.json
+++ b/packages/secrets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-secrets",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Per-tenant secret management with envelope encryption for SMRT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sites/CHANGELOG.md
+++ b/packages/sites/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-sites
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/sites/package.json
+++ b/packages/sites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-sites",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Site lifecycle management for multi-tenant SMRT networks",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-android/CHANGELOG.md
+++ b/packages/smrt-android/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-android
 
+## 0.40.6
+
 ## 0.40.5
 
 ## 0.40.4

--- a/packages/smrt-android/package.json
+++ b/packages/smrt-android/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-android",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Android Compose foundation for SMRT mobile apps: MobileTheme design tokens, the bottom-tab shell scaffold bound to smrt-mobile's MobileShellState, and the native platform adapters (ML Kit barcode, speech transcription, Gemini Nano on-device LLM, device capabilities, SQLDelight driver, Keystore auth storage, Custom Tabs auth launcher)",
   "author": "HappyVertical",
   "license": "MIT",

--- a/packages/smrt-app-mcp/CHANGELOG.md
+++ b/packages/smrt-app-mcp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-app-mcp
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/smrt-app-mcp/package.json
+++ b/packages/smrt-app-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-app-mcp",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "App-runtime MCP server scaffolding for SMRT apps — `createMcpAppServer` plus transport adapters (SvelteKit today) for exposing a SMRT app's MCP surface over HTTP.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-dev-mcp/CHANGELOG.md
+++ b/packages/smrt-dev-mcp/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-dev-mcp
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+  - @happyvertical/smrt-scanner@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/smrt-dev-mcp/package.json
+++ b/packages/smrt-dev-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-dev-mcp",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Development MCP server for SMRT framework knowledge, review context, architecture context, and code generation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-ios/CHANGELOG.md
+++ b/packages/smrt-ios/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-ios
 
+## 0.40.6
+
 ## 0.40.5
 
 ## 0.40.4

--- a/packages/smrt-ios/package.json
+++ b/packages/smrt-ios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ios",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "SwiftUI foundation for SMRT mobile apps: MobileTheme design tokens, the tab shell scaffold bound to smrt-mobile's MobileShellState, and the native platform adapters (VisionKit barcode, Speech transcription, Foundation Models on-device LLM, device capabilities, SQLDelight native driver, Keychain auth storage, ASWebAuthenticationSession auth launcher) — actually consuming the exported SmrtMobile KMP framework",
   "author": "HappyVertical",
   "license": "MIT",

--- a/packages/smrt-mobile-contract/CHANGELOG.md
+++ b/packages/smrt-mobile-contract/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-mobile-contract
 
+## 0.40.6
+
 ## 0.40.5
 
 ## 0.40.4

--- a/packages/smrt-mobile-contract/package.json
+++ b/packages/smrt-mobile-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-mobile-contract",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "SMRT mobile contract codegen: manifest + allowlist → mobile-contract.json → Kotlin/Swift DTOs, plus the generated framework contract for @happyvertical/smrt-mobile",
   "author": "HappyVertical",
   "license": "MIT",

--- a/packages/smrt-mobile/CHANGELOG.md
+++ b/packages/smrt-mobile/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-mobile
 
+## 0.40.6
+
 ## 0.40.5
 
 ## 0.40.4

--- a/packages/smrt-mobile/package.json
+++ b/packages/smrt-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-mobile",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Kotlin Multiplatform shared mobile foundation for SMRT apps: durable SQLDelight offline write-queue, offline pack store + integrity, evidence capture model, pack i18n resolver, shell state, and platform adapter contracts (auth and networking land in later phases)",
   "author": "HappyVertical",
   "license": "MIT",

--- a/packages/smrt-playground/CHANGELOG.md
+++ b/packages/smrt-playground/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-playground
 
+## 0.40.6
+
+### Patch Changes
+
+- @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/smrt-playground/package.json
+++ b/packages/smrt-playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-playground",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Shared playground discovery, runtime, and host components for SMRT UI packages",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-svelte/CHANGELOG.md
+++ b/packages/smrt-svelte/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-svelte
 
+## 0.40.6
+
+### Patch Changes
+
+- @happyvertical/smrt-languages@0.40.6
+- @happyvertical/smrt-types@0.40.6
+- @happyvertical/smrt-ui@0.40.6
+- @happyvertical/smrt-web@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-svelte",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Svelte 5 components for SMRT user management - auth, users, tenants, roles, permissions, groups",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/smrt-ui/CHANGELOG.md
+++ b/packages/smrt-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @happyvertical/smrt-ui
 
+## 0.40.6
+
+### Patch Changes
+
+- @happyvertical/smrt-types@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/smrt-ui/package.json
+++ b/packages/smrt-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-ui",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Domain-agnostic Svelte 5 UI runtime for SMRT: primitives, i18n client, theme system, and module UI registry",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/smrt-web/CHANGELOG.md
+++ b/packages/smrt-web/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-web
 
+## 0.40.6
+
 ## 0.40.5
 
 ## 0.40.4

--- a/packages/smrt-web/package.json
+++ b/packages/smrt-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-web",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "SMRT browser client data runtime: typed collection factory wrapping the client-data engine over generated REST clients",
   "author": "HappyVertical",
   "type": "module",

--- a/packages/social/CHANGELOG.md
+++ b/packages/social/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-social
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-content@0.40.6
+  - @happyvertical/smrt-secrets@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-video@0.40.6
+  - @happyvertical/smrt-config@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/social/package.json
+++ b/packages/social/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-social",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "type": "module",
   "smrtRawPrimitives": "strict",
   "description": "Social media account management for multi-platform publishing in the SMRT ecosystem",

--- a/packages/subscriptions/CHANGELOG.md
+++ b/packages/subscriptions/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-subscriptions
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/subscriptions/package.json
+++ b/packages/subscriptions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-subscriptions",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Tenant subscriptions, entitlement resolution, usage thresholds, and subscription UI for SMRT",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/support/CHANGELOG.md
+++ b/packages/support/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @happyvertical/smrt-support
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-chat@0.40.6
+  - @happyvertical/smrt-jobs@0.40.6
+  - @happyvertical/smrt-messages@0.40.6
+  - @happyvertical/smrt-projects@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-users@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-support",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "AI-first Support Cases: channel-neutral intake, lifecycle, routing, service targets, and service time for the SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tags/CHANGELOG.md
+++ b/packages/tags/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-tags
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-tags",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Reusable tagging system with hierarchies, contexts, and multi-language support for SMRT framework",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/template-site-static-json/CHANGELOG.md
+++ b/packages/template-site-static-json/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @happyvertical/smrt-template-site-static-json
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-config@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/template-site-static-json/package.json
+++ b/packages/template-site-static-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-template-site-static-json",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Static community site template with JSON data storage and SMRT framework",
   "type": "module",
   "main": "index.js",

--- a/packages/template-site-static-json/template.config.js
+++ b/packages/template-site-static-json/template.config.js
@@ -23,13 +23,13 @@ export default {
   // the scaffolder injects the entries below at generation time, so this file is
   // the single source of truth for dependency versions.
   dependencies: {
-    '@happyvertical/smrt-core': '^0.40.5',
-    '@happyvertical/smrt-config': '^0.40.5',
-    '@happyvertical/smrt-ui': '^0.40.5',
-    '@happyvertical/smrt-content': '^0.40.5',
-    '@happyvertical/smrt-events': '^0.40.5',
-    '@happyvertical/smrt-places': '^0.40.5',
-    '@happyvertical/smrt-profiles': '^0.40.5',
+    '@happyvertical/smrt-core': '^0.40.6',
+    '@happyvertical/smrt-config': '^0.40.6',
+    '@happyvertical/smrt-ui': '^0.40.6',
+    '@happyvertical/smrt-content': '^0.40.6',
+    '@happyvertical/smrt-events': '^0.40.6',
+    '@happyvertical/smrt-places': '^0.40.6',
+    '@happyvertical/smrt-profiles': '^0.40.6',
     '@happyvertical/caelus': '^0.1.385',
   },
 

--- a/packages/template-sveltekit/CHANGELOG.md
+++ b/packages/template-sveltekit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-template-sveltekit
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/template-sveltekit/package.json
+++ b/packages/template-sveltekit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-template-sveltekit",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Minimal SvelteKit project template with s-m-r-t framework integration",
   "type": "module",
   "main": "index.js",

--- a/packages/template-sveltekit/template.config.js
+++ b/packages/template-sveltekit/template.config.js
@@ -19,16 +19,16 @@ export default {
 
   // Dependencies to add to generated project
   dependencies: {
-    '@happyvertical/smrt-core': '^0.40.5',
-    '@happyvertical/smrt-profiles': '^0.40.5',
-    '@happyvertical/smrt-svelte': '^0.40.5',
-    '@happyvertical/smrt-tenancy': '^0.40.5',
-    '@happyvertical/smrt-ui': '^0.40.5',
-    '@happyvertical/smrt-users': '^0.40.5',
+    '@happyvertical/smrt-core': '^0.40.6',
+    '@happyvertical/smrt-profiles': '^0.40.6',
+    '@happyvertical/smrt-svelte': '^0.40.6',
+    '@happyvertical/smrt-tenancy': '^0.40.6',
+    '@happyvertical/smrt-ui': '^0.40.6',
+    '@happyvertical/smrt-users': '^0.40.6',
   },
 
   devDependencies: {
-    '@happyvertical/smrt-cli': '^0.40.5',
+    '@happyvertical/smrt-cli': '^0.40.6',
     '@sveltejs/adapter-auto': '^7.0.1',
     '@sveltejs/kit': '^2.69.2',
     '@sveltejs/vite-plugin-svelte': '^7.2.0',

--- a/packages/template-sveltekit/template/package.json
+++ b/packages/template-sveltekit/template/package.json
@@ -25,14 +25,14 @@
     "svelte-check": "^4.7.2",
     "typescript": "^6.0.3",
     "vite": "^8.1.4",
-    "@happyvertical/smrt-cli": "^0.40.5"
+    "@happyvertical/smrt-cli": "^0.40.6"
   },
   "dependencies": {
-    "@happyvertical/smrt-core": "^0.40.5",
-    "@happyvertical/smrt-profiles": "^0.40.5",
-    "@happyvertical/smrt-svelte": "^0.40.5",
-    "@happyvertical/smrt-tenancy": "^0.40.5",
-    "@happyvertical/smrt-ui": "^0.40.5",
-    "@happyvertical/smrt-users": "^0.40.5"
+    "@happyvertical/smrt-core": "^0.40.6",
+    "@happyvertical/smrt-profiles": "^0.40.6",
+    "@happyvertical/smrt-svelte": "^0.40.6",
+    "@happyvertical/smrt-tenancy": "^0.40.6",
+    "@happyvertical/smrt-ui": "^0.40.6",
+    "@happyvertical/smrt-users": "^0.40.6"
   }
 }

--- a/packages/tenancy/CHANGELOG.md
+++ b/packages/tenancy/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @happyvertical/smrt-tenancy
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/tenancy/package.json
+++ b/packages/tenancy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-tenancy",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Production-ready multi-tenancy framework for SMRT with automatic tenant isolation and enforcement",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @happyvertical/smrt-types
 
+## 0.40.6
+
 ## 0.40.5
 
 ## 0.40.4

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-types",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Shared type definitions for the HAVE SDK",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/users/CHANGELOG.md
+++ b/packages/users/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-users
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-profiles@0.40.6
+  - @happyvertical/smrt-mobile-contract@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-config@0.40.6
+  - @happyvertical/smrt-types@0.40.6
+  - @happyvertical/smrt-ui@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-users",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Multi-tenant user management for the SMRT framework - users, tenants, roles, permissions, groups",
   "type": "module",
   "smrtRawPrimitives": "strict",

--- a/packages/video/CHANGELOG.md
+++ b/packages/video/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @happyvertical/smrt-video
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-assets@0.40.6
+  - @happyvertical/smrt-content@0.40.6
+  - @happyvertical/smrt-profiles@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-voice@0.40.6
+  - @happyvertical/smrt-config@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/video/package.json
+++ b/packages/video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-video",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "type": "module",
   "description": "Video content management for AI-powered video production in the SMRT ecosystem",
   "author": "HappyVertical",

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @happyvertical/smrt-vitest
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-vitest",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "description": "Vitest plugin for automatic cross-package manifest loading in SMRT tests",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/voice/CHANGELOG.md
+++ b/packages/voice/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @happyvertical/smrt-voice
 
+## 0.40.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @happyvertical/smrt-core@0.40.6
+  - @happyvertical/smrt-assets@0.40.6
+  - @happyvertical/smrt-content@0.40.6
+  - @happyvertical/smrt-tenancy@0.40.6
+  - @happyvertical/smrt-config@0.40.6
+
 ## 0.40.5
 
 ### Patch Changes

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@happyvertical/smrt-voice",
-  "version": "0.40.5",
+  "version": "0.40.6",
   "type": "module",
   "description": "Voice profile management for AI-powered voice synthesis and cloning in the SMRT ecosystem",
   "author": "HappyVertical",

--- a/scripts/push-release-refs.mjs
+++ b/scripts/push-release-refs.mjs
@@ -31,6 +31,7 @@ function runGit(args, { env, label, spawn }) {
 
 export function pushReleaseRefs({
   baseBranch = process.env.RELEASE_BASE_BRANCH ?? 'main',
+  dryRun = process.env.RELEASE_PUSH_DRY_RUN === 'true',
   githubToken = process.env.RELEASE_GITHUB_TOKEN,
   releaseVersion = process.env.RELEASE_VERSION,
   spawn = spawnSync,
@@ -51,25 +52,38 @@ export function pushReleaseRefs({
   ).toString('base64')}`;
   const gitEnv = {
     ...process.env,
-    GIT_CONFIG_COUNT: '1',
+    // An empty extraHeader resets values inherited from checkout or global
+    // Git config before the release App credential is added. GitHub rejects
+    // requests containing multiple Authorization headers with HTTP 400.
+    GIT_CONFIG_COUNT: '2',
     GIT_CONFIG_KEY_0: 'http.https://github.com/.extraheader',
-    GIT_CONFIG_VALUE_0: authHeader,
+    GIT_CONFIG_VALUE_0: '',
+    GIT_CONFIG_KEY_1: 'http.https://github.com/.extraheader',
+    GIT_CONFIG_VALUE_1: authHeader,
     GIT_TERMINAL_PROMPT: '0',
   };
   const tag = `v${releaseVersion}`;
+  const pushArgs = ['push'];
+
+  if (dryRun) {
+    pushArgs.push('--dry-run');
+  }
+
+  pushArgs.push(
+    '--no-verify',
+    '--atomic',
+    'origin',
+    `HEAD:refs/heads/${baseBranch}`,
+    `refs/tags/${tag}:refs/tags/${tag}`,
+  );
 
   runGit(
-    [
-      'push',
-      '--no-verify',
-      '--atomic',
-      'origin',
-      `HEAD:refs/heads/${baseBranch}`,
-      `refs/tags/${tag}:refs/tags/${tag}`,
-    ],
+    pushArgs,
     {
       env: gitEnv,
-      label: `Failed to atomically push release ${tag} to ${baseBranch}`,
+      label: dryRun
+        ? `Failed to preflight release ${tag} push to ${baseBranch}`
+        : `Failed to atomically push release ${tag} to ${baseBranch}`,
       spawn,
     },
   );

--- a/scripts/push-release-refs.test.mjs
+++ b/scripts/push-release-refs.test.mjs
@@ -3,7 +3,7 @@ import test from 'node:test';
 
 import { pushReleaseRefs } from './push-release-refs.mjs';
 
-test('supplies GitHub authentication directly to the atomic release push', () => {
+test('resets inherited authentication before the atomic release push', () => {
   const calls = [];
   const spawn = (command, args, options) => {
     calls.push({ command, args, options });
@@ -33,18 +33,54 @@ test('supplies GitHub authentication directly to the atomic release push', () =>
   );
 
   for (const { options } of calls) {
-    assert.equal(options.env.GIT_CONFIG_COUNT, '1');
+    assert.equal(options.env.GIT_CONFIG_COUNT, '2');
     assert.equal(
       options.env.GIT_CONFIG_KEY_0,
       'http.https://github.com/.extraheader',
     );
+    assert.equal(options.env.GIT_CONFIG_VALUE_0, '');
     assert.equal(
-      options.env.GIT_CONFIG_VALUE_0,
+      options.env.GIT_CONFIG_KEY_1,
+      'http.https://github.com/.extraheader',
+    );
+    assert.equal(
+      options.env.GIT_CONFIG_VALUE_1,
       `AUTHORIZATION: basic ${Buffer.from(
         'x-access-token:installation-token',
       ).toString('base64')}`,
     );
   }
+});
+
+test('can preflight the exact atomic push without updating refs', () => {
+  const calls = [];
+
+  pushReleaseRefs({
+    baseBranch: 'main',
+    dryRun: true,
+    githubToken: 'installation-token',
+    releaseVersion: '0.40.7',
+    spawn: (command, args, options) => {
+      calls.push({ command, args, options });
+      return { status: 0, stderr: '', stdout: '' };
+    },
+  });
+
+  assert.deepEqual(
+    calls.map(({ command, args }) => [command, ...args]),
+    [
+      [
+        'git',
+        'push',
+        '--dry-run',
+        '--no-verify',
+        '--atomic',
+        'origin',
+        'HEAD:refs/heads/main',
+        'refs/tags/v0.40.7:refs/tags/v0.40.7',
+      ],
+    ],
+  );
 });
 
 test('fails before pushing when the GitHub App token is missing', () => {


### PR DESCRIPTION
## Summary

- reserve the already-published `0.40.6` package version in Git using the exact reconstructed release patch from the interrupted publisher
- prevent duplicate GitHub `Authorization` headers by disabling checkout persistence and resetting inherited Git extraheaders
- preflight the exact authenticated atomic branch/tag push before npm publication
- retain generated release recovery patches for 30 days and document the recovery path

## Root cause

Run 29453809823 published all `0.40.6` npm artifacts, then its atomic Git ref push received HTTP 400. The checkout credential and the explicit release credential could both be sent as `Authorization` headers. Run 29548630985 subsequently failed correctly because its guard found `0.40.6` already present on npm.

A non-mutating probe reproduced GitHub returning 401 for one dummy authorization header and 400 for duplicate authorization headers.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm test` (119/119 tasks)
- `pnpm typecheck` and forced manifest-refresh typecheck (118/118 tasks)
- `pnpm exec biome ci --diagnostic-level=error .`
- `pnpm lint`
- `pnpm format`
- `node --test scripts/push-release-refs.test.mjs`
- `pnpm exec vitest run scripts/guard-release-publish.test.js`
- `actionlint .github/workflows/publish.yml`
- `pnpm knowledge:check --changed --strict --format markdown`
- `pnpm run check:mcp-config`
- authenticated `git push --dry-run --atomic` with an injected inherited header; no remote refs created

Closes #2040

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex-desktop","session":"019f6e24-88c4-7db2-8a5a-9be7b142b10d","linked_issue":2040,"policy_revision":"1.0.0","validation_summary":"build, full tests, typecheck, formatting, knowledge freshness, workflow validation, focused release tests, and live non-mutating atomic push preflight passed"}
```