### PR TITLE
fix(cli): scope forced schema migrations

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -8,6 +8,7 @@ Developer CLI with lazy-loaded commands, manifest discovery, and class introspec
 smrt introspect              # Discover SMRT objects in project
 smrt db:status               # Pending schema changes + failed migration classification
 smrt db:migrate              # Apply migrations
+smrt db:migrate --force-migration <exact-id> # Force one generated migration only
 smrt db:migrate-uuid         # Convert schema-declared UUID text columns after data remap
 smrt db:diff                 # Show schema differences without generating migration files
 smrt db:rollback             # Rollback migrations

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,6 +26,7 @@ pnpm add -D @happyvertical/smrt-cli
 |---------|------------|
 | `smrt db:status` | Show pending schema changes and classify failed migration history |
 | `smrt db:migrate` | Apply pending migrations |
+| `smrt db:migrate --force-migration <exact-id>` | Force one generated migration while preserving guards for every other migration in the batch |
 | `smrt db:migrate-uuid` | Convert schema-declared UUID text columns to native PostgreSQL uuid after data has been remapped |
 | `smrt db:diff` | Show schema differences without generating migration files |
 | `smrt db:rollback` | Rollback last migration |
@@ -34,6 +35,13 @@ pnpm add -D @happyvertical/smrt-cli
 File-backed SQL/TypeScript migration generation is not supported. SMRT schema
 migrations are manifest-driven; model schema with SMRT objects and apply changes
 with `smrt db:migrate`.
+
+Use `--force-migration <exact-id>` for a known checksum, failed, or interrupted
+migration that is safe to retry. The selector is an exact generated migration
+ID, and unrelated checksum, failed, and running records remain fail-closed even
+when the atomic batch reconciles live schema drift. Global `--force` remains
+available for backward compatibility but intentionally overrides guards for the
+whole pending batch.
 
 ### Code Generation
 

--- a/packages/cli/src/commands/__tests__/db-migrate-atomic.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-atomic.test.ts
@@ -20,6 +20,7 @@ const {
   const migrationApplyAllOptions: Array<{
     atomic?: boolean;
     force?: boolean;
+    forceMigrations?: readonly string[];
     postgresSafe?: boolean;
     reconcile?: boolean;
   }> = [];
@@ -52,6 +53,7 @@ const {
       options: {
         atomic?: boolean;
         force?: boolean;
+        forceMigrations?: readonly string[];
         onProgress?: (result: any) => void;
         postgresSafe?: boolean;
         reconcile?: boolean;
@@ -60,6 +62,7 @@ const {
       migrationApplyAllOptions.push({
         atomic: options.atomic,
         force: options.force,
+        forceMigrations: options.forceMigrations,
         postgresSafe: options.postgresSafe,
         reconcile: options.reconcile,
       });
@@ -277,6 +280,7 @@ describe('db:migrate atomic schema execution', () => {
       {
         atomic: true,
         force: false,
+        forceMigrations: undefined,
         postgresSafe: false,
         reconcile: true,
       },
@@ -291,6 +295,24 @@ describe('db:migrate atomic schema execution', () => {
       'add_column_contents_second_column: synthetic failure',
     );
     expect(stderr).toContain('successful steps shown above');
+  }, 15_000);
+
+  it('passes an exact force target into the atomic migration batch', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { utilityCommands } = await import('../utilities.js');
+
+    await utilityCommands['db:migrate'].handler([], {
+      'force-migration': 'add_column_contents_first_column',
+    });
+
+    expect(migrationApplyAllOptions[0]).toMatchObject({
+      atomic: true,
+      force: false,
+      forceMigrations: ['add_column_contents_first_column'],
+      postgresSafe: false,
+      reconcile: true,
+    });
   }, 15_000);
 
   it('warns when postgres-safe index operations are folded into the atomic batch', async () => {

--- a/packages/cli/src/commands/__tests__/utilities.test.ts
+++ b/packages/cli/src/commands/__tests__/utilities.test.ts
@@ -110,6 +110,21 @@ describe('utilities', () => {
     );
   });
 
+  it('exposes exact generated-migration force without weakening the global default', () => {
+    const migrateOptions = utilityCommands['db:migrate'].options;
+
+    expect(migrateOptions?.force).toMatchObject({
+      type: 'boolean',
+      default: false,
+    });
+    expect(migrateOptions?.['force-migration']).toMatchObject({
+      type: 'string',
+    });
+    expect(migrateOptions?.['force-migration'].description).toContain(
+      'exact ID',
+    );
+  });
+
   it('doctor reports missing consumer registrations for projects with external SMRT dependencies', async () => {
     const projectDir = await mkdtemp(
       resolve(process.cwd(), '.tmp-smrt-doctor-'),

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -191,6 +191,7 @@ interface DbMigrateOptions {
   'dry-run'?: boolean;
   'postgres-safe'?: boolean;
   force?: boolean;
+  'force-migration'?: string;
   'repair-data'?: boolean;
   'upgrade-sti'?: boolean;
   'drop-indexes'?: boolean;
@@ -1065,6 +1066,11 @@ export default testManifest;
           'Force re-apply even if already applied (skip checksum validation)',
         default: false,
       },
+      'force-migration': {
+        type: 'string',
+        description:
+          'Force only the generated migration with this exact ID; all other migration guards remain enabled',
+      },
       'repair-data': {
         type: 'boolean',
         description:
@@ -1534,6 +1540,9 @@ export default testManifest;
               atomic: true,
               postgresSafe: false,
               force: options.force ?? false,
+              forceMigrations: options['force-migration']
+                ? [options['force-migration']]
+                : undefined,
               // The diff was computed from the live schema moments earlier, so
               // missing columns/indexes must be repaired even if a previous
               // synthetic migration record says "completed".

--- a/packages/core/src/migrations/__tests__/tracker.test.ts
+++ b/packages/core/src/migrations/__tests__/tracker.test.ts
@@ -160,6 +160,67 @@ describe('MigrationTracker', () => {
       expect(result.error).toContain('checksum mismatch');
     });
 
+    it('should force only migration IDs explicitly selected by the caller', async () => {
+      const selectedV1: MigrationDefinition = {
+        id: '0001_selected',
+        description: 'Selected migration',
+        version: '1.0.0',
+        up: ['CREATE TABLE selected (id TEXT PRIMARY KEY);'],
+        down: ['DROP TABLE selected;'],
+      };
+      const guardedV1: MigrationDefinition = {
+        id: '0002_guarded',
+        description: 'Guarded migration',
+        version: '1.0.0',
+        up: ['CREATE TABLE guarded (id TEXT PRIMARY KEY);'],
+        down: ['DROP TABLE guarded;'],
+      };
+
+      await tracker.apply(selectedV1);
+      await tracker.apply(guardedV1);
+
+      const selectedResult = await tracker.apply(
+        {
+          ...selectedV1,
+          up: ['CREATE TABLE IF NOT EXISTS selected (id TEXT);'],
+        },
+        { forceMigrations: ['0001_selected'] },
+      );
+      const guardedResult = await tracker.apply(
+        { ...guardedV1, up: ['CREATE TABLE IF NOT EXISTS guarded (id TEXT);'] },
+        { forceMigrations: ['0001_selected'] },
+      );
+
+      expect(selectedResult.success).toBe(true);
+      expect(selectedResult.applied).toBe(true);
+      expect(guardedResult.success).toBe(false);
+      expect(guardedResult.error).toContain('checksum mismatch');
+    });
+
+    it('should not reconcile an unrelated failed migration during scoped force', async () => {
+      const failed: MigrationDefinition = {
+        id: '0001_failed_guarded',
+        description: 'Guarded failed migration',
+        version: '1.0.0',
+        up: ['INVALID SQL'],
+        down: [],
+      };
+
+      const first = await tracker.apply(failed);
+      expect(first.success).toBe(false);
+
+      const retry = await tracker.apply(
+        { ...failed, up: ['CREATE TABLE guarded_retry (id TEXT);'] },
+        {
+          reconcile: true,
+          forceMigrations: ['0002_selected'],
+        },
+      );
+
+      expect(retry.success).toBe(false);
+      expect(retry.error).toContain('previously failed');
+    });
+
     it('should still block checksum mismatches during reconcile', async () => {
       const migration1: MigrationDefinition = {
         id: '0001_create_users',
@@ -471,6 +532,31 @@ describe('MigrationTracker', () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain('currently running or was interrupted');
       expect(result.error).toContain('--force');
+    });
+
+    it('should block an unrelated running migration during scoped force', async () => {
+      await db.query(
+        `INSERT INTO _smrt_schema_migrations (id, name, version, checksum, status, attempts, is_reversible, batch)
+         VALUES ('scoped-stuck-id', '0001_scoped_stuck', '1.0.0', 'abc123', 'running', 1, 0, 1)`,
+      );
+
+      const result = await tracker.apply(
+        {
+          id: '0001_scoped_stuck',
+          description: 'Scoped stuck migration',
+          version: '1.0.0',
+          up: ['SELECT 1;'],
+          down: [],
+        },
+        {
+          reconcile: true,
+          forceMigrations: ['0002_selected'],
+        },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('currently running or was interrupted');
+      expect(result.error).toContain('--force-migration 0001_scoped_stuck');
     });
 
     it('should allow re-applying rolled back migration without --force', async () => {

--- a/packages/core/src/migrations/tracker.ts
+++ b/packages/core/src/migrations/tracker.ts
@@ -324,6 +324,10 @@ export class MigrationTracker {
     await this.initialize();
     const startTime = Date.now();
     const checksum = computeChecksum(definition.up);
+    const force = Boolean(
+      options.force || options.forceMigrations?.includes(definition.id),
+    );
+    const hasScopedForce = Boolean(options.forceMigrations?.length);
 
     // Check if migration record already exists
     const existing = await this.getMigration(definition.id);
@@ -332,7 +336,7 @@ export class MigrationTracker {
       // Handle based on existing status
       switch (existing.status) {
         case 'completed':
-          if (!options.force && existing.checksum !== checksum) {
+          if (!force && existing.checksum !== checksum) {
             return {
               success: false,
               applied: false,
@@ -340,11 +344,11 @@ export class MigrationTracker {
               name: definition.id,
               checksum,
               execution_time_ms: 0,
-              error: `Migration ${definition.id} checksum mismatch. Was already applied with different checksum. Use --force to override.`,
+              error: `Migration ${definition.id} checksum mismatch. Was already applied with different checksum. Use --force-migration ${definition.id} to override only this migration, or --force to override the whole batch.`,
             };
           }
 
-          if (!options.force && !options.reconcile) {
+          if (!force && !options.reconcile) {
             // Already applied, skip
             return {
               success: true,
@@ -358,7 +362,7 @@ export class MigrationTracker {
           break;
 
         case 'failed':
-          if (!options.force && !options.reconcile) {
+          if (!force && (!options.reconcile || hasScopedForce)) {
             return {
               success: false,
               applied: false,
@@ -366,14 +370,14 @@ export class MigrationTracker {
               name: definition.id,
               checksum,
               execution_time_ms: 0,
-              error: `Migration ${definition.id} previously failed: ${existing.error_message || 'Unknown error'}. Use --force to retry.`,
+              error: `Migration ${definition.id} previously failed: ${existing.error_message || 'Unknown error'}. Use --force-migration ${definition.id} to retry only this migration, or --force to retry the whole batch.`,
             };
           }
           // Will retry below
           break;
 
         case 'running':
-          if (!options.force) {
+          if (!force) {
             return {
               success: false,
               applied: false,
@@ -381,7 +385,7 @@ export class MigrationTracker {
               name: definition.id,
               checksum,
               execution_time_ms: 0,
-              error: `Migration ${definition.id} is currently running or was interrupted. Use --force to retry if the previous run crashed.`,
+              error: `Migration ${definition.id} is currently running or was interrupted. If the previous run crashed, use --force-migration ${definition.id} to retry only this migration, or --force to retry the whole batch.`,
             };
           }
           // Will retry below

--- a/packages/core/src/migrations/types.ts
+++ b/packages/core/src/migrations/types.ts
@@ -133,6 +133,12 @@ export interface ApplyMigrationsOptions {
   /** Force application even if checksums don't match */
   force?: boolean;
   /**
+   * Force only the migration definitions whose exact IDs appear in this list.
+   * Other definitions retain the checksum, failed, and running guards even
+   * when the batch also enables reconciliation.
+   */
+  forceMigrations?: readonly string[];
+  /**
    * Reconcile migration history with live schema drift.
    *
    * When true, the tracker may re-run a migration if the caller has already


### PR DESCRIPTION
## Summary

- add `smrt db:migrate --force-migration <exact-id>`
- preserve checksum, failed, and running guards for every unrelated migration, including reconcile batches
- keep global `--force` compatible while steering recovery diagnostics to the scoped option
- document and test exact-target atomic behavior

## Validation

- affected dependency build: 19/19 packages
- focused core/CLI tests: 46/46
- core and CLI typechecks
- Biome + diff checks
- full pre-push policy/knowledge/workflow checks
- bounded migration-safety and API/maintainability review: clean

Closes #2042

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex-desktop",
  "session": "019f6bb6-eff5-7681-85e5-e718b301d51b",
  "issue": "happyvertical/smrt#2042",
  "policy_revision": "1.0.0",
  "validation": [
    "affected dependency build 19/19",
    "focused core and CLI tests 46/46",
    "core and CLI typechecks",
    "Biome and diff checks",
    "full pre-push policy, knowledge, and workflow checks",
    "bounded migration-safety and API maintainability reviews clean"
  ]
}
```