### PR TITLE
feat(cli): force multiple exact migrations atomically

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -8,7 +8,7 @@ Developer CLI with lazy-loaded commands, manifest discovery, and class introspec
 smrt introspect              # Discover SMRT objects in project
 smrt db:status               # Pending schema changes + failed migration classification
 smrt db:migrate              # Apply migrations
-smrt db:migrate --force-migration <exact-id> # Force one generated migration only
+smrt db:migrate --force-migration <exact-id> [--force-migration <exact-id>...] # Force exact generated migrations in one atomic batch
 smrt db:migrate-uuid         # Convert schema-declared UUID text columns after data remap
 smrt db:diff                 # Show schema differences without generating migration files
 smrt db:rollback             # Rollback migrations

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -26,7 +26,7 @@ pnpm add -D @happyvertical/smrt-cli
 |---------|------------|
 | `smrt db:status` | Show pending schema changes and classify failed migration history |
 | `smrt db:migrate` | Apply pending migrations |
-| `smrt db:migrate --force-migration <exact-id>` | Force one generated migration while preserving guards for every other migration in the batch |
+| `smrt db:migrate --force-migration <exact-id> [--force-migration <exact-id>...]` | Force one or more exact generated migrations in one atomic batch while preserving every other guard |
 | `smrt db:migrate-uuid` | Convert schema-declared UUID text columns to native PostgreSQL uuid after data has been remapped |
 | `smrt db:diff` | Show schema differences without generating migration files |
 | `smrt db:rollback` | Rollback last migration |
@@ -37,11 +37,23 @@ migrations are manifest-driven; model schema with SMRT objects and apply changes
 with `smrt db:migrate`.
 
 Use `--force-migration <exact-id>` for a known checksum, failed, or interrupted
-migration that is safe to retry. The selector is an exact generated migration
-ID, and unrelated checksum, failed, and running records remain fail-closed even
-when the atomic batch reconciles live schema drift. Global `--force` remains
-available for backward compatibility but intentionally overrides guards for the
-whole pending batch.
+migration that is safe to retry. Repeat the flag to recover multiple verified
+IDs in the same atomic invocation:
+
+```bash
+smrt db:migrate \
+  --force-migration create_table_commissions \
+  --force-migration create_table_referral_links
+```
+
+Each selector must be one exact generated migration ID. Comma-separated lists,
+wildcards, empty values, and combining exact selectors with global `--force`
+are rejected, as are IDs absent from the current generated migration batch.
+Duplicate exact IDs are normalized to one selection. Unrelated checksum,
+failed, and running records remain fail-closed even when the atomic batch
+reconciles live schema drift. Global `--force` remains available by itself for
+backward compatibility but intentionally overrides guards for the whole pending
+batch.
 
 ### Code Generation
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "clean": "rm -rf dist",
     "dev": "npm run build:watch",
     "test": "vitest run",
-    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/commands/__tests__/db-migrate-uuid.test.ts",
+    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/commands/__tests__/db-migrate-uuid.test.ts src/commands/__tests__/db-migrate-force-postgres.test.ts",
     "test:watch": "vitest",
     "typecheck": "tsc -p tsconfig.typecheck.json",
     "cli": "tsx src/index.ts"

--- a/packages/cli/src/cli-generator.ts
+++ b/packages/cli/src/cli-generator.ts
@@ -169,8 +169,91 @@ interface CliMethodDefinition {
   }>;
 }
 
-// Re-export Command as CLICommand for backward compatibility
-export type CLICommand = Command;
+export interface CLIOptionConfig extends OptionConfig {
+  /** Collect every occurrence of this string option in argv order. */
+  multiple?: boolean;
+}
+
+// Preserve the shared Command contract while allowing SMRT commands to opt a
+// string option into repeatable parsing. @happyvertical/utils currently keeps
+// only the final occurrence, so the local wrapper below restores the complete
+// argv selection for explicitly repeatable options.
+export interface CLICommand extends Omit<Command, 'options'> {
+  options?: Record<string, CLIOptionConfig>;
+}
+
+function collectRepeatableOptionValues(
+  argv: string[],
+  optionName: string,
+): string[] {
+  const flag = `--${optionName}`;
+  const inlinePrefix = `${flag}=`;
+  const values: string[] = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+
+    if (token === '--') {
+      break;
+    }
+
+    if (token.startsWith(inlinePrefix)) {
+      values.push(token.slice(inlinePrefix.length));
+      continue;
+    }
+
+    if (token !== flag) {
+      continue;
+    }
+
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('-')) {
+      throw new Error(`Option ${flag} requires a value`);
+    }
+
+    values.push(value);
+    index += 1;
+  }
+
+  return values;
+}
+
+/**
+ * Parse one command while preserving every occurrence of options marked
+ * `multiple`. Non-repeatable options retain the shared SDK parser behavior.
+ */
+export function parseCliCommandArgs(
+  argv: string[],
+  commands: CLICommand[],
+  builtInCommands: Record<string, CLICommand> = {},
+): ParsedArgs {
+  const parsed = parseCliArgs(argv, commands, builtInCommands);
+  const command = parsed.command
+    ? (builtInCommands[parsed.command] ??
+      commands.find(
+        (candidate) =>
+          candidate.name === parsed.command ||
+          candidate.aliases?.includes(parsed.command as string),
+      ))
+    : undefined;
+
+  if (!command?.options) {
+    return parsed;
+  }
+
+  for (const [name, option] of Object.entries(command.options)) {
+    if (!option.multiple) {
+      continue;
+    }
+
+    const values = collectRepeatableOptionValues(argv, name);
+    if (values.length > 0) {
+      parsed.options[name] = values;
+    }
+  }
+
+  return parsed;
+}
 
 // Re-export ParsedArgs from utils
 export type { ParsedArgs } from '@happyvertical/utils';
@@ -453,7 +536,7 @@ export class CLIGenerator {
       const processedArgv = this.preprocessObjectCommands(argv, commands);
 
       // Parse args first without built-in commands to avoid loading them unnecessarily
-      const parsed = parseCliArgs(processedArgv, commands, {});
+      const parsed = parseCliCommandArgs(processedArgv, commands, {});
       await this.executeCommand(parsed, commands, processedArgv);
     };
   }
@@ -1182,7 +1265,7 @@ export class CLIGenerator {
 
       // Re-parse options for built-in command since they weren't in initial parse
       // The initial parseCliArgs only has object commands, not built-in commands
-      const reParsed = parseCliArgs(processedArgv, [builtInCommand], {});
+      const reParsed = parseCliCommandArgs(processedArgv, [builtInCommand], {});
 
       try {
         await builtInCommand.handler(reParsed.args, reParsed.options);

--- a/packages/cli/src/commands/__tests__/db-migrate-atomic.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-atomic.test.ts
@@ -315,6 +315,47 @@ describe('db:migrate atomic schema execution', () => {
     });
   }, 15_000);
 
+  it('passes multiple exact force targets into one atomic migration batch', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { utilityCommands } = await import('../utilities.js');
+
+    await utilityCommands['db:migrate'].handler([], {
+      'force-migration': [
+        'add_column_contents_first_column',
+        'add_column_contents_second_column',
+      ],
+    });
+
+    expect(migrationApplyAllOptions).toHaveLength(1);
+    expect(migrationApplyAllOptions[0]).toMatchObject({
+      atomic: true,
+      force: false,
+      forceMigrations: [
+        'add_column_contents_first_column',
+        'add_column_contents_second_column',
+      ],
+      postgresSafe: false,
+      reconcile: true,
+    });
+  }, 15_000);
+
+  it('rejects an exact force target outside the current generated batch', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { utilityCommands } = await import('../utilities.js');
+
+    await utilityCommands['db:migrate'].handler([], {
+      'force-migration': ['add_column_contents_missing_column'],
+    });
+
+    expect(migrationApplyAllOptions).toEqual([]);
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy.mock.calls.flat().join('\n')).toContain(
+      'add_column_contents_missing_column',
+    );
+  }, 15_000);
+
   it('warns when postgres-safe index operations are folded into the atomic batch', async () => {
     compareMock.mockResolvedValue({
       added_tables: [],

--- a/packages/cli/src/commands/__tests__/db-migrate-force-postgres.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-force-postgres.test.ts
@@ -1,0 +1,321 @@
+import { clearCache, setConfig } from '@happyvertical/smrt-config';
+import {
+  ObjectRegistry,
+  type SchemaDefinition,
+} from '@happyvertical/smrt-core';
+import { MigrationTracker } from '@happyvertical/smrt-core/migrations';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseCliCommandArgs } from '../../cli-generator.js';
+import { utilityCommands } from '../utilities.js';
+
+vi.mock('../../discovery/index.js', () => ({
+  autoDiscoverAndLoad: vi.fn(async () => ({
+    discovered: [
+      {
+        path: '/tmp/multiple-force-migrations/.smrt/manifest.json',
+        source: 'project',
+        objectCount: 3,
+      },
+    ],
+    totalObjects: 3,
+  })),
+}));
+
+const hasPostgres = Boolean(process.env.DATABASE_URL);
+const describePostgres = hasPostgres ? describe : describe.skip;
+
+describePostgres(
+  'db:migrate multiple exact checksum recovery (real PostgreSQL)',
+  () => {
+    const suffix = `${process.pid}_${Math.random().toString(36).slice(2, 8)}`;
+    const commissions = `fm_commissions_${suffix}`;
+    const referralLinks = `fm_referral_links_${suffix}`;
+    const unrelated = `fm_unrelated_${suffix}`;
+    const allTables = [commissions, referralLinks, unrelated];
+    const registrySpies: Array<ReturnType<typeof vi.spyOn>> = [];
+
+    function migrationId(tableName: string): string {
+      return `create_table_${tableName}`;
+    }
+
+    function legacyTable(tableName: string): string {
+      return `${tableName}_legacy`;
+    }
+
+    function schema(tableName: string): SchemaDefinition {
+      return {
+        tableName,
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          value: { type: 'TEXT' },
+        },
+        indexes: [],
+        triggers: [],
+        foreignKeys: [],
+        version: 'multiple-force-test',
+        dependencies: [],
+      };
+    }
+
+    async function freshDb(): Promise<any> {
+      return getDatabase({
+        type: 'postgres',
+        url: process.env.DATABASE_URL as string,
+      });
+    }
+
+    async function tableExists(tableName: string): Promise<boolean> {
+      const db = await freshDb();
+      const result = await db.query(
+        `SELECT 1
+           FROM information_schema.tables
+          WHERE table_schema = 'public' AND table_name = $1`,
+        tableName,
+      );
+      return result.rows.length > 0;
+    }
+
+    async function history(tableNames: string[]): Promise<
+      Array<{
+        name: string;
+        checksum: string;
+        attempts: number;
+        status: string;
+      }>
+    > {
+      const db = await freshDb();
+      const result = await db.query(
+        `SELECT name, checksum, attempts, status
+           FROM _smrt_schema_migrations
+          WHERE name = ANY($1::text[])
+          ORDER BY name`,
+        tableNames.map(migrationId),
+      );
+      return result.rows as Array<{
+        name: string;
+        checksum: string;
+        attempts: number;
+        status: string;
+      }>;
+    }
+
+    function installManifest(tableNames: string[]): void {
+      const schemas = Object.fromEntries(
+        tableNames.map((tableName) => [tableName, schema(tableName)]),
+      );
+      const classNames = tableNames.map((tableName) => `Test_${tableName}`);
+      const tableByClass = new Map(
+        classNames.map((className, index) => [className, tableNames[index]]),
+      );
+
+      registrySpies.push(
+        vi
+          .spyOn(ObjectRegistry, 'getInitializationOrder')
+          .mockReturnValue(classNames),
+        vi
+          .spyOn(ObjectRegistry, 'getAllSchemasAsDefinitions')
+          .mockReturnValue(schemas),
+        vi
+          .spyOn(ObjectRegistry, 'getTableName')
+          .mockImplementation(
+            (className: string) => tableByClass.get(className) ?? className,
+          ),
+      );
+    }
+
+    async function prepareRenamedHistory(
+      tableNames: string[],
+    ): Promise<Map<string, string>> {
+      const db = await freshDb();
+      const tracker = new MigrationTracker({ db });
+      const results = await tracker.applyAll(
+        tableNames.map((tableName) => ({
+          id: migrationId(tableName),
+          description: `Legacy create ${tableName}`,
+          version: '0.40.8',
+          // Deliberately differs byte-for-byte from the current generated DDL
+          // while creating the same legacy table shape.
+          up: [`CREATE TABLE "${tableName}" (id text PRIMARY KEY, value text)`],
+          down: [`DROP TABLE IF EXISTS "${tableName}"`],
+        })),
+        { atomic: true },
+      );
+      expect(results.every((result) => result.success)).toBe(true);
+
+      for (const tableName of tableNames) {
+        await db.query(
+          `ALTER TABLE "${tableName}" RENAME TO "${legacyTable(tableName)}"`,
+        );
+      }
+
+      return new Map(
+        (await history(tableNames)).map((row) => [row.name, row.checksum]),
+      );
+    }
+
+    async function runMigrate(argv: string[]): Promise<{
+      stdout: string;
+      stderr: string;
+      exitCode: number | undefined;
+    }> {
+      const command = utilityCommands['db:migrate'];
+      const parsed = parseCliCommandArgs(argv, [command]);
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      process.exitCode = undefined;
+      await command.handler(parsed.args, parsed.options);
+      const result = {
+        stdout: logSpy.mock.calls.flat().join('\n'),
+        stderr: errorSpy.mock.calls.flat().join('\n'),
+        exitCode: process.exitCode,
+      };
+      process.exitCode = undefined;
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+      return result;
+    }
+
+    beforeEach(async () => {
+      clearCache();
+      setConfig({
+        packages: {
+          cli: {
+            database: {
+              type: 'postgres',
+              url: process.env.DATABASE_URL,
+            },
+          },
+        },
+      } as any);
+
+      const db = await freshDb();
+      for (const tableName of allTables) {
+        await db.query(`DROP TABLE IF EXISTS "${tableName}" CASCADE`);
+        await db.query(
+          `DROP TABLE IF EXISTS "${legacyTable(tableName)}" CASCADE`,
+        );
+      }
+      await new MigrationTracker({ db }).initialize();
+      await db.query(
+        `DELETE FROM _smrt_schema_migrations
+          WHERE name = ANY($1::text[])`,
+        allTables.map(migrationId),
+      );
+    });
+
+    afterEach(async () => {
+      for (const spy of registrySpies.splice(0)) {
+        spy.mockRestore();
+      }
+      try {
+        const db = await freshDb();
+        for (const tableName of allTables) {
+          await db.query(`DROP TABLE IF EXISTS "${tableName}" CASCADE`);
+          await db.query(
+            `DROP TABLE IF EXISTS "${legacyTable(tableName)}" CASCADE`,
+          );
+        }
+        await db.query(
+          `DELETE FROM _smrt_schema_migrations
+            WHERE name = ANY($1::text[])`,
+          allTables.map(migrationId),
+        );
+      } finally {
+        clearCache();
+        process.exitCode = undefined;
+        vi.restoreAllMocks();
+      }
+    });
+
+    it('recovers two renamed-table histories in one CLI batch, applies data, and reruns cleanly', async () => {
+      const targets = [commissions, referralLinks];
+      installManifest(targets);
+      const staleChecksums = await prepareRenamedHistory(targets);
+
+      const migrate = await runMigrate([
+        'db:migrate',
+        '--force-migration',
+        migrationId(commissions),
+        '--force-migration',
+        migrationId(referralLinks),
+      ]);
+
+      expect(migrate.exitCode).toBeUndefined();
+      expect(await tableExists(commissions)).toBe(true);
+      expect(await tableExists(referralLinks)).toBe(true);
+      expect(await tableExists(legacyTable(commissions))).toBe(true);
+      expect(await tableExists(legacyTable(referralLinks))).toBe(true);
+
+      const recoveredHistory = await history(targets);
+      expect(recoveredHistory).toHaveLength(2);
+      for (const row of recoveredHistory) {
+        expect(row.status).toBe('completed');
+        expect(row.attempts).toBe(2);
+        expect(row.checksum).not.toBe(staleChecksums.get(row.name));
+      }
+
+      // Downstream apply phase: data is written only after both schema targets
+      // exist. A subsequent unforced CLI rerun must preserve it and stay clean.
+      const db = await freshDb();
+      await db.query(
+        `INSERT INTO "${commissions}" (id, value) VALUES ($1, $2)`,
+        'commission-1',
+        'applied',
+      );
+      await db.query(
+        `INSERT INTO "${referralLinks}" (id, value) VALUES ($1, $2)`,
+        'referral-link-1',
+        'applied',
+      );
+
+      const rerun = await runMigrate(['db:migrate']);
+      expect(rerun.exitCode).toBeUndefined();
+      expect(rerun.stdout).toContain('Database schema is up to date');
+
+      const commissionRows = await (await freshDb()).query(
+        `SELECT id, value FROM "${commissions}"`,
+      );
+      const referralRows = await (await freshDb()).query(
+        `SELECT id, value FROM "${referralLinks}"`,
+      );
+      expect(commissionRows.rows).toEqual([
+        { id: 'commission-1', value: 'applied' },
+      ]);
+      expect(referralRows.rows).toEqual([
+        { id: 'referral-link-1', value: 'applied' },
+      ]);
+    }, 60_000);
+
+    it('keeps an unrelated checksum guard enforced and rolls back the selected targets', async () => {
+      installManifest(allTables);
+      const staleChecksums = await prepareRenamedHistory(allTables);
+
+      const migrate = await runMigrate([
+        'db:migrate',
+        '--force-migration',
+        migrationId(commissions),
+        '--force-migration',
+        migrationId(referralLinks),
+      ]);
+
+      expect(migrate.exitCode).toBe(1);
+      expect(migrate.stderr).toContain(migrationId(unrelated));
+      expect(migrate.stderr).toContain('checksum mismatch');
+
+      for (const tableName of allTables) {
+        expect(await tableExists(tableName)).toBe(false);
+        expect(await tableExists(legacyTable(tableName))).toBe(true);
+      }
+
+      const guardedHistory = await history(allTables);
+      expect(guardedHistory).toHaveLength(3);
+      for (const row of guardedHistory) {
+        expect(row.status).toBe('completed');
+        expect(row.attempts).toBe(1);
+        expect(row.checksum).toBe(staleChecksums.get(row.name));
+      }
+    }, 60_000);
+  },
+);

--- a/packages/cli/src/commands/__tests__/utilities.test.ts
+++ b/packages/cli/src/commands/__tests__/utilities.test.ts
@@ -2,7 +2,13 @@ import { spawnSync } from 'node:child_process';
 import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { resolveVitestEntrypoint, utilityCommands } from '../utilities.js';
+import { parseCliCommandArgs } from '../../cli-generator.js';
+import {
+  assertForceMigrationTargetsExist,
+  resolveForceMigrationSelection,
+  resolveVitestEntrypoint,
+  utilityCommands,
+} from '../utilities.js';
 
 vi.mock('node:child_process', () => ({
   spawnSync: vi.fn(() => ({
@@ -119,10 +125,101 @@ describe('utilities', () => {
     });
     expect(migrateOptions?.['force-migration']).toMatchObject({
       type: 'string',
+      multiple: true,
     });
     expect(migrateOptions?.['force-migration'].description).toContain(
-      'exact ID',
+      'repeat for multiple IDs',
     );
+  });
+
+  it('parses repeated exact migration flags in argv order', () => {
+    const migrate = utilityCommands['db:migrate'];
+    const parsed = parseCliCommandArgs(
+      [
+        'db:migrate',
+        '--force-migration',
+        'create_table_commissions',
+        '--force-migration=create_table_referral_links',
+      ],
+      [migrate],
+    );
+
+    expect(parsed.options['force-migration']).toEqual([
+      'create_table_commissions',
+      'create_table_referral_links',
+    ]);
+  });
+
+  it('preserves the existing single exact migration flag', () => {
+    const migrate = utilityCommands['db:migrate'];
+    const parsed = parseCliCommandArgs(
+      ['db:migrate', '--force-migration', 'create_table_commissions'],
+      [migrate],
+    );
+
+    expect(parsed.options['force-migration']).toEqual([
+      'create_table_commissions',
+    ]);
+    expect(
+      resolveForceMigrationSelection(false, parsed.options['force-migration']),
+    ).toEqual({
+      force: false,
+      forceMigrations: ['create_table_commissions'],
+    });
+  });
+
+  it('normalizes duplicate exact IDs and rejects ambiguous or broad selectors', () => {
+    expect(
+      resolveForceMigrationSelection(false, [
+        ' create_table_commissions ',
+        'create_table_referral_links',
+        'create_table_commissions',
+      ]),
+    ).toEqual({
+      force: false,
+      forceMigrations: [
+        'create_table_commissions',
+        'create_table_referral_links',
+      ],
+    });
+
+    expect(() => resolveForceMigrationSelection(false, '')).toThrow(
+      /cannot be empty/,
+    );
+    expect(() => resolveForceMigrationSelection(false, 'first,second')).toThrow(
+      /Comma-separated/,
+    );
+    expect(() => resolveForceMigrationSelection(false, '*')).toThrow(
+      /wildcard/,
+    );
+    expect(() => resolveForceMigrationSelection(true, ['first'])).toThrow(
+      /Do not combine --force/,
+    );
+  });
+
+  it('requires every exact selector to exist in the current generated batch', () => {
+    expect(() =>
+      assertForceMigrationTargetsExist(
+        ['create_table_commissions', 'create_table_missing'],
+        ['create_table_commissions', 'create_table_referral_links'],
+      ),
+    ).toThrow(/create_table_missing/);
+
+    expect(() =>
+      assertForceMigrationTargetsExist(
+        ['create_table_commissions', 'create_table_referral_links'],
+        ['create_table_commissions', 'create_table_referral_links'],
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects a repeated migration flag without a value', () => {
+    expect(() =>
+      parseCliCommandArgs(
+        ['db:migrate', '--force-migration', '--verbose'],
+        [utilityCommands['db:migrate']],
+      ),
+    ).toThrow(/requires a value/);
   });
 
   it('doctor reports missing consumer registrations for projects with external SMRT dependencies', async () => {

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -191,7 +191,7 @@ interface DbMigrateOptions {
   'dry-run'?: boolean;
   'postgres-safe'?: boolean;
   force?: boolean;
-  'force-migration'?: string;
+  'force-migration'?: string | readonly string[];
   'repair-data'?: boolean;
   'upgrade-sti'?: boolean;
   'drop-indexes'?: boolean;
@@ -200,6 +200,99 @@ interface DbMigrateOptions {
 
 interface DoctorOptions {
   fix?: boolean;
+}
+
+export interface ForceMigrationSelection {
+  force: boolean;
+  forceMigrations?: readonly string[];
+}
+
+/**
+ * Normalize exact migration selectors from the public single/repeated CLI
+ * forms. List and wildcard syntax are deliberately rejected: every selected
+ * migration must be named by its own exact flag.
+ */
+export function resolveForceMigrationSelection(
+  force: boolean | undefined,
+  value: unknown,
+): ForceMigrationSelection {
+  const globalForce = Boolean(force);
+
+  if (value === undefined) {
+    return { force: globalForce };
+  }
+
+  const rawValues = Array.isArray(value) ? value : [value];
+  const forceMigrations: string[] = [];
+  const seen = new Set<string>();
+
+  for (const rawValue of rawValues) {
+    if (typeof rawValue !== 'string') {
+      throw new Error(
+        '--force-migration requires an exact generated migration ID',
+      );
+    }
+
+    const migrationId = rawValue.trim();
+    if (migrationId.length === 0) {
+      throw new Error('--force-migration cannot be empty');
+    }
+    if (migrationId.includes(',')) {
+      throw new Error(
+        'Comma-separated --force-migration lists are not supported; repeat the flag for each exact ID',
+      );
+    }
+    if (/\s/u.test(migrationId)) {
+      throw new Error(
+        `Invalid --force-migration ID "${migrationId}": exact IDs cannot contain whitespace`,
+      );
+    }
+    if (/[*?[\]{}]/u.test(migrationId)) {
+      throw new Error(
+        `Invalid --force-migration ID "${migrationId}": wildcard selectors are not supported`,
+      );
+    }
+    if (migrationId.startsWith('-')) {
+      throw new Error(
+        `Invalid --force-migration ID "${migrationId}": expected an exact generated migration ID`,
+      );
+    }
+
+    if (!seen.has(migrationId)) {
+      seen.add(migrationId);
+      forceMigrations.push(migrationId);
+    }
+  }
+
+  if (forceMigrations.length === 0) {
+    throw new Error('--force-migration requires at least one exact ID');
+  }
+  if (globalForce) {
+    throw new Error(
+      'Do not combine --force with --force-migration; choose global forcing or exact migration IDs',
+    );
+  }
+
+  return { force: false, forceMigrations };
+}
+
+export function assertForceMigrationTargetsExist(
+  forceMigrations: readonly string[] | undefined,
+  generatedMigrationIds: Iterable<string>,
+): void {
+  if (!forceMigrations?.length) {
+    return;
+  }
+
+  const generated = new Set(generatedMigrationIds);
+  const unknown = forceMigrations.filter(
+    (migrationId) => !generated.has(migrationId),
+  );
+  if (unknown.length > 0) {
+    throw new Error(
+      `--force-migration target${unknown.length === 1 ? '' : 's'} not found in the current generated migration batch: ${unknown.join(', ')}`,
+    );
+  }
 }
 
 /**
@@ -1069,7 +1162,8 @@ export default testManifest;
       'force-migration': {
         type: 'string',
         description:
-          'Force only the generated migration with this exact ID; all other migration guards remain enabled',
+          'Force one generated migration by exact ID; repeat for multiple IDs while all other guards remain enabled',
+        multiple: true,
       },
       'repair-data': {
         type: 'boolean',
@@ -1101,6 +1195,11 @@ export default testManifest;
       let db: DatabaseInterface | undefined;
 
       try {
+        const forceSelection = resolveForceMigrationSelection(
+          options.force,
+          options['force-migration'],
+        );
+
         // 1. Load CLI config
         const { getPackageConfig } = await import('@happyvertical/smrt-config');
         const { DEFAULT_CLI_CONFIG } = await import('../config.js');
@@ -1317,6 +1416,16 @@ export default testManifest;
         );
         migrations.push(...partitionedChanges.migrations);
         manualInterventions.push(...partitionedChanges.manualInterventions);
+
+        assertForceMigrationTargetsExist(forceSelection.forceMigrations, [
+          ...diff.added_tables.map(
+            (schema) => `create_table_${schema.tableName}`,
+          ),
+          ...migrations.flatMap((migration) => {
+            const migrationName = getSyntheticMigrationNameForAction(migration);
+            return migrationName ? [migrationName] : [];
+          }),
+        ]);
 
         console.log();
 
@@ -1539,10 +1648,8 @@ export default testManifest;
             const results = await tracker.applyAll(migrationDefs, {
               atomic: true,
               postgresSafe: false,
-              force: options.force ?? false,
-              forceMigrations: options['force-migration']
-                ? [options['force-migration']]
-                : undefined,
+              force: forceSelection.force,
+              forceMigrations: forceSelection.forceMigrations,
               // The diff was computed from the live schema moments earlier, so
               // missing columns/indexes must be repaired even if a previous
               // synthetic migration record says "completed".


### PR DESCRIPTION
## Summary

- add an explicitly repeatable CLI option contract so `db:migrate` accepts multiple exact `--force-migration` flags in argv order
- normalize and validate every selector, reject empty, ambiguous, wildcard, unknown, or mixed global-force input, and pass the full set to one atomic migration invocation
- add unit/atomic coverage plus a real PostgreSQL prepare → CLI migrate → apply → clean rerun regression for two simultaneous checksum/history recoveries, including rollback when an unrelated checksum guard fails
- document the supported repeated-flag syntax and include the regression in the CLI PostgreSQL test surface

## Validation

- focused CLI parser and migration tests: 18 passed
- full CLI tests: 789 passed, 6 skipped
- CLI PostgreSQL tests: 17 passed
- CLI coverage gate: 89.77% lines, T1 floor 80%
- CLI typecheck, build, packed exports verification
- frozen install, SDK version alignment, standards, dependency DAG/policy checks, dependency audit
- root build, test, typecheck, lint, format-check
- strict SMRT knowledge checks and MCP config check
- gitleaks: no leaks
- bounded three-perspective review cycle: clean

Closes #2057

Unblocks [anytown/anytown.ai#716](https://github.com/anytown/anytown.ai/issues/716) and [anytown/anytown.ai#730](https://github.com/anytown/anytown.ai/pull/730).

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "019f72f3-3fac-76a0-b74b-ad0b2c284597",
  "issue": 2057,
  "linked_issue": 2057,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "focused CLI and PostgreSQL migration tests",
    "full CLI and root validation",
    "strict knowledge freshness",
    "bounded review cycle"
  ]
}
