### PR TITLE
fix: migrate generation 5 lifecycle

### DIFF
--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -16,6 +16,7 @@ permissions:
   contents: read
   issues: read
   pull-requests: read
+  statuses: read
   packages: read
 
 jobs:
@@ -58,6 +59,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
           PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
           MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -76,6 +76,7 @@ jobs:
           # injection hardening guidelines.
           BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref }}
         run: |
+          BASE_REF="${BASE_REF#refs/heads/}"
           git fetch origin "$BASE_REF" --depth=200
           FROM_SHA=$(git merge-base "origin/$BASE_REF" HEAD)
           echo "Linting commits from $FROM_SHA to HEAD"
@@ -201,6 +202,7 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref }}
         run: |
+          BASE_REF="${BASE_REF#refs/heads/}"
           git fetch origin "$BASE_REF" --depth=200
           FROM_SHA=$(git merge-base "origin/$BASE_REF" HEAD)
           echo "Scanning commits $FROM_SHA..HEAD for secrets"

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -74,7 +74,7 @@ jobs:
           # Reading it into an env var keeps the shell substitution
           # out of the ${{ ... }} layer to satisfy the workflow-
           # injection hardening guidelines.
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref }}
         run: |
           git fetch origin "$BASE_REF" --depth=200
           FROM_SHA=$(git merge-base "origin/$BASE_REF" HEAD)
@@ -199,7 +199,7 @@ jobs:
       # secret out of the workflow logs. Allowlist: .gitleaks.toml.
       - name: Scan PR commits for secrets
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref }}
         run: |
           git fetch origin "$BASE_REF" --depth=200
           FROM_SHA=$(git merge-base "origin/$BASE_REF" HEAD)


### PR DESCRIPTION
Closes #2061.

Adds the generation-5 lifecycle capability repair (`statuses: read` and explicit event action) after the signed artifact pin. `CI_MERGE_QUEUE_ENABLED=true` is set so merge groups run the full gate while `on-merge-main` continues to own changeset versioning and publication. No SMRT package behavior changes. Parent rollout: happyvertical/have-config#193.

Validated by the canonical policy audit, actionlint, git diff --check, core build, knowledge freshness, and all repository pre-push workflow/architecture gates.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-20260718-smrt-2061-baseref-normalize-4cdb","issue":"https://github.com/happyvertical/smrt/issues/2061","policy_revision":"1.0.0","validation":["hv-agent audit","actionlint","git diff --check","core build","knowledge check","pre-push gates"]}
```