### PR TITLE
ci: switch lifecycle workflow to diagnostic

### DIFF
--- a/.agents/project.yaml
+++ b/.agents/project.yaml
@@ -44,6 +44,6 @@
   },
   "runtime": {
     "agent_validation_workflow": ".github/workflows/on-pull-request.yml",
-    "agent_lifecycle_stage": "compatibility"
+    "agent_lifecycle_stage": "diagnostic"
   }
 }

--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: Pull request number to recheck after a claim-only transition
+        description: Pull request to recheck after released_at or another claim-only transition
         required: true
         type: number
 
@@ -19,27 +19,57 @@ permissions:
   statuses: read
   packages: read
 
+concurrency:
+  group: >-
+    agent-policy-diagnostic-${{
+      github.event.merge_group.head_sha ||
+      github.event.pull_request.number ||
+      inputs.pr_number ||
+      github.ref
+    }}
+  cancel-in-progress: true
+
 jobs:
   lifecycle:
-    name: lifecycle
+    name: lifecycle / diagnostic
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.0.6
       - name: Load pinned policy runtime
         env:
           POLICY_ARTIFACT: ${{ vars.AGENT_POLICY_ARTIFACT }}
+          POLICY_PUBLISHER_IDENTITY: ${{ vars.AGENT_POLICY_PUBLISHER_IDENTITY }}
         run: |
           case "$POLICY_ARTIFACT" in
-            ghcr.io/*@sha256:*) ;;
-            *) echo 'AGENT_POLICY_ARTIFACT must be an immutable GHCR digest' >&2; exit 1 ;;
+            ghcr.io/happyvertical/agent-policy@sha256:*) ;;
+            *) echo 'AGENT_POLICY_ARTIFACT must pin the trusted HappyVertical policy image by digest' >&2; exit 1 ;;
           esac
+          expected_publisher_identity_sha256=86a917ce537a9e923ce02103068c76eb72629247ab584f7d368ac238a0209857
+          publisher_identity_sha256=$(python3 -c 'import hashlib, os; print(hashlib.sha256(os.environ["POLICY_PUBLISHER_IDENTITY"].encode()).hexdigest())')
+          test "$publisher_identity_sha256" = "$expected_publisher_identity_sha256" || {
+            echo 'AGENT_POLICY_PUBLISHER_IDENTITY must match the exact protected-main publisher identity' >&2
+            exit 1
+          }
+          publisher_workflow="${POLICY_PUBLISHER_IDENTITY%@refs/heads/main}"
+          test "$publisher_workflow" != "$POLICY_PUBLISHER_IDENTITY" || {
+            echo 'AGENT_POLICY_PUBLISHER_IDENTITY must name the protected-main publisher workflow' >&2
+            exit 1
+          }
+          publisher_workflow_regexp=$(printf '%s' "$publisher_workflow" | sed 's/[][\.*^()+?{}|$]/\\&/g')
+          cosign verify "$POLICY_ARTIFACT" \
+            --certificate-identity-regexp "^${publisher_workflow_regexp}@refs/(heads/main|tags/agent-policy-v[0-9]+\.[0-9]+\.[0-9]+)$" \
+            --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
+          policy_download_dir="$RUNNER_TEMP/hv-policy-download"
           policy_dir="$RUNNER_TEMP/hv-policy"
-          rm -rf "$policy_dir"
-          mkdir -p "$policy_dir"
-          oras pull "$POLICY_ARTIFACT" -o "$policy_dir"
-          archive="$policy_dir/agent-policy.tar.gz"
+          rm -rf "$policy_download_dir" "$policy_dir"
+          mkdir -p "$policy_download_dir" "$policy_dir"
+          oras pull "$POLICY_ARTIFACT" -o "$policy_download_dir"
+          archive="$policy_download_dir/agent-policy.tar.gz"
           test -f "$archive" || { echo 'policy artifact is missing agent-policy.tar.gz' >&2; exit 1; }
           python3 - "$archive" <<'PY'
           import pathlib
@@ -53,17 +83,27 @@ jobs:
                       raise SystemExit(f"unsafe policy archive member: {member.name}")
           PY
           tar -xzf "$archive" -C "$policy_dir"
+          identity=$(python3 "$policy_dir/scripts/verify-policy-artifact" "$policy_dir")
+          echo "Loaded $identity from $POLICY_ARTIFACT"
           echo "HV_POLICY_DIR=$policy_dir" >> "$GITHUB_ENV"
+          echo "HV_POLICY_IDENTITY=$identity" >> "$GITHUB_ENV"
       - name: Validate lifecycle
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          POLICY_ARTIFACT: ${{ vars.AGENT_POLICY_ARTIFACT }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
           PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
           MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
         run: |
-          "$HV_POLICY_DIR/scripts/hv-agent-lifecycle-prs" | while IFS= read -r number; do
-            python3 "$HV_POLICY_DIR/scripts/hv-agent" check-pr "$number"
-          done
+          set -euo pipefail
+          numbers_file="$RUNNER_TEMP/hv-agent-lifecycle-prs"
+          "$HV_POLICY_DIR/scripts/hv-agent-lifecycle-prs" > "$numbers_file"
+          while IFS= read -r number; do
+            if ! python3 "$HV_POLICY_DIR/scripts/hv-agent" check-pr "$number"; then
+              echo "ERROR $HV_POLICY_IDENTITY from $POLICY_ARTIFACT rejected PR #$number; correct canonical claim/PR state, then rerun the organization-required workflow execution; a repository-local lifecycle-only dispatch is not protected merge authority and draft toggles are invalid" >&2
+              exit 1
+            fi
+          done < "$numbers_file"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,14 @@
-<!-- hv-managed-policy:start revision=1.0.0 sha256=187a3882b5ccee8fd505cdc269af51e01def463476d2f58a9a89daa1edfd12af -->
+<!-- hv-managed-policy:start revision=1.0.0 sha256=dc892d3db6b886d9a74b70e555b0017605d9ab88a5ea06540f5d2f45388f804b -->
 
 ## Shared development kernel
 
 - Be concise. Load detailed SOP skills only when the task triggers them.
 - Read the repository's `.agents/project.yaml` and nearest `AGENTS.md` files before work.
+- Use `implement` by default for accepted issue implementation. Apply explicit task, issue, and repository instructions as additions or scoped overrides without weakening this kernel.
 - Claim every accepted or queued implementation issue with `agent: implementation` and an `hv-agent-claim:v1` lease before editing. Never overlap another live claim.
-- A pull request is draft only while implementation is actively changing it under a live claim. Otherwise mark it ready for review immediately.
+- Intentional release reauthenticates the canonical payload owner, records immutable owner-attributed evidence on every exact PR head, then sets `released_at` and the evidence digest on the existing claim comment before labels, project state, or PR readiness change. Public session/comment identifiers are selectors, not mutation credentials. Only the current issue incarnation and latest implementation-label generation may authorize work; issue closure ends renewable authority and settles the selected cycle as `race-lost`. Any later push or reopen requires a new claimed review cycle. Never delete claim history, backfill a release, or create duplicate active claim comments.
+- Open pull requests only when reviewable and keep them ready for review. Never use draft status for implementation work; exactly one valid, unexpired claim from the PR session may coexist with a ready PR, while duplicate, expired, foreign-session, or mismatched claims are invalid.
+- Lifecycle-protected pull requests merge only through the managed merge queue so the synthetic merge commit rechecks current claim state. Merge-time validation requires a `review` release from the exact implementation cycle bound to the current PR head; never merge with a live, blocked, abandoned, expired, unbound, or stale release, or direct-merge using an earlier pull-request check.
 - Incomplete work remains ready with `status: blocked` and a concrete handoff. Review agents do not claim implementation.
 - Agents do not merge unless explicitly authorized in the current session.
 - Run documented validation and update affected docs before shipping.

--- a/packages/content/src/content-chat-prompts.test.ts
+++ b/packages/content/src/content-chat-prompts.test.ts
@@ -9,6 +9,11 @@ import {
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  GET as getContentChat,
+  POST as postContentChat,
+} from '$routes/api/v1/contents/[id]/chat/+server';
+import { POST as postContentChatThread } from '$routes/api/v1/contents/[id]/chat/threads/[threadId]/+server';
+import {
   contentChatSessionIsAuthorized,
   contentChatSessionMatchesContent,
   createContentEditorChatThread,
@@ -21,11 +26,6 @@ import {
   contentEditorSessionPrompt,
 } from './content-chat-prompts';
 import { Contents } from './contents';
-import {
-  GET as getContentChat,
-  POST as postContentChat,
-} from './routes/api/v1/contents/[id]/chat/+server';
-import { POST as postContentChatThread } from './routes/api/v1/contents/[id]/chat/threads/[threadId]/+server';
 
 let currentContents: Contents | undefined;
 const getAIMock = vi.fn();

--- a/packages/content/src/content-chat-prompts.test.ts
+++ b/packages/content/src/content-chat-prompts.test.ts
@@ -11,8 +11,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   GET as getContentChat,
   POST as postContentChat,
-} from '$routes/api/v1/contents/[id]/chat/+server';
-import { POST as postContentChatThread } from '$routes/api/v1/contents/[id]/chat/threads/[threadId]/+server';
+} from '$lib/../routes/api/v1/contents/[id]/chat/+server';
+import { POST as postContentChatThread } from '$lib/../routes/api/v1/contents/[id]/chat/threads/[threadId]/+server';
 import {
   contentChatSessionIsAuthorized,
   contentChatSessionMatchesContent,

--- a/packages/content/src/contents-api.test.ts
+++ b/packages/content/src/contents-api.test.ts
@@ -5,12 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   POST as createContent,
   GET as getList,
-} from '$routes/api/v1/contents/+server';
+} from '$lib/../routes/api/v1/contents/+server';
 import {
   DELETE as deleteContent,
   GET as getSingle,
   PUT as updateContent,
-} from '$routes/api/v1/contents/[id]/+server';
+} from '$lib/../routes/api/v1/contents/[id]/+server';
 import { Contents } from './contents';
 
 let currentContents: Contents | undefined;

--- a/packages/content/src/contents-api.test.ts
+++ b/packages/content/src/contents-api.test.ts
@@ -2,16 +2,16 @@ import { getTestDatabase } from '@happyvertical/smrt-core';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { syncSchema } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { Contents } from './contents';
 import {
   POST as createContent,
   GET as getList,
-} from './routes/api/v1/contents/+server';
+} from '$routes/api/v1/contents/+server';
 import {
   DELETE as deleteContent,
   GET as getSingle,
   PUT as updateContent,
-} from './routes/api/v1/contents/[id]/+server';
+} from '$routes/api/v1/contents/[id]/+server';
+import { Contents } from './contents';
 
 let currentContents: Contents | undefined;
 

--- a/packages/content/vitest.config.ts
+++ b/packages/content/vitest.config.ts
@@ -15,6 +15,12 @@ export default defineConfig({
         find: '$lib',
         replacement: resolve(__dirname, 'src/lib'),
       },
+      {
+        // Keep route tests on a filesystem alias; Svelte's Vite transform
+        // rewrites relative route imports to root-absolute `/src/...` IDs.
+        find: '$routes',
+        replacement: resolve(__dirname, 'src/routes'),
+      },
       ...viteWorkspaceAliases,
     ],
     conditions: ['browser'],

--- a/packages/content/vitest.config.ts
+++ b/packages/content/vitest.config.ts
@@ -15,12 +15,6 @@ export default defineConfig({
         find: '$lib',
         replacement: resolve(__dirname, 'src/lib'),
       },
-      {
-        // Keep route tests on a filesystem alias; Svelte's Vite transform
-        // rewrites relative route imports to root-absolute `/src/...` IDs.
-        find: '$routes',
-        replacement: resolve(__dirname, 'src/routes'),
-      },
       ...viteWorkspaceAliases,
     ],
     conditions: ['browser'],

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -2,16 +2,9 @@
 
 ORM, code generation, AI integration, and the DispatchBus. Everything else builds on this.
 
-## Key Classes
-
-| Class | File | Purpose |
-|-------|------|---------|
-| SmrtObject | `src/object.ts` | Base persistent object — save, delete, is(), do(), loadFromId/Slug |
-| SmrtCollection | `src/collection.ts` | CRUD collection — list, get, create, delete, getOrUpsert |
-| ObjectRegistry | `src/registry.ts` | Global singleton (globalThis) — class metadata, fields, STI chains, manifests |
-| DispatchBus | `src/dispatch/bus.ts` | Inter-agent messaging — emit, subscribe (persistent), process |
-| GlobalInterceptors | `src/interceptors.ts` | Plugin system — beforeList/Get/Save/Delete hooks (used by tenancy) |
-| LearningMemory | `src/learning/memory.ts` | Confidence-scored recall/capture over `_smrt_contexts` + embeddings (#1886) |
+Key surfaces are `SmrtObject`, `SmrtCollection`, `ObjectRegistry`,
+`DispatchBus`, `GlobalInterceptors`, and `LearningMemory`; the sections below
+document their invariants and source locations.
 
 ## SmrtObject Lifecycle
 
@@ -25,22 +18,12 @@ ORM, code generation, AI integration, and the DispatchBus. Everything else build
 
 ## LearningMemory (#1886)
 
-Confidence-scored, self-correcting memory over the existing `_smrt_contexts` (keyed recall) and `_smrt_embeddings` (semantic recall) substrate. Wires the reinforcement columns that ship on `_smrt_contexts` but were never written (`success_count`, `failure_count`, and a `last_used_at` that recall now refreshes). This is L1 of the tenant-learning-agents epic; the opt-in `Learning` trait in `@happyvertical/smrt-agents` composes it into the agent lifecycle.
-
-```typescript
-const memory = new LearningMemory({ db: obj.systemDb, ownerClass: 'InvoiceAgent', ownerId: obj.id, tenantId });
-
-// recall — union of keyed-context lookup + (optional) semantic search, confidence-filtered
-const [hit] = await memory.recall('parser/acme', { key: docUrl }); // or { query } with a wired semanticSearch
-const strategy = hit?.value ?? (await generate());
-
-// capture — reinforce the outcome
-await memory.capture({ scope: 'parser/acme', key: docUrl, value: strategy }, { success: ok });
-```
-
-- **`capture(episode, outcome)`**: success strengthens `confidence` toward 1.0 + increments `success_count`; failure decays toward `failureConfidence` (default 0.3) + increments `failure_count`. Defaults (`minConfidence` 0.7, `successConfidence` 0.9, `reinforcement` 0.5) mean a single failure drops a confident memory below the reuse floor. Seeds a new row when none exists and the episode carries a `value` (a failed first attempt is retained at low confidence for self-correction).
-- **`recall(scope, opts)`**: owner-scoped keyed lookup (thus tenant-isolated) filtered by the confidence floor, expiry, and optional time-decay, with hierarchical scope fallback; unions an injected `semanticSearch` arm when a `query` is given (tenant-scoped via its `where`). Refreshes `last_used_at` on returned rows.
-- Injected `semanticSearch` matches `SmrtCollection.semanticSearch`, so `LearningMemory` never reaches into a collection's internals.
+`LearningMemory` provides tenant-isolated, confidence-scored recall over
+`_smrt_contexts` plus optional injected semantic search. `capture()` reinforces
+successes and decays failures while updating outcome counters; `recall()`
+applies confidence, expiry, time-decay, and hierarchical-scope filters and
+refreshes `last_used_at`. Keep semantic search behind the
+`SmrtCollection.semanticSearch`-compatible injection boundary.
 
 ## SmrtCollection Query
 

--- a/turbo.json
+++ b/turbo.json
@@ -29,6 +29,7 @@
         "!src/lib/types/smrt-generated/**",
         "scripts/generate-manifest.js",
         "scripts/generate-smrt-types.js",
+        "AGENTS.md",
         "package.json",
         "tsconfig*.json"
       ],


### PR DESCRIPTION
Closes #2064

Switches the repository-local lifecycle workflow to diagnostic-only reporting now that organization-owned lifecycle authority is active. The managed merge queue remains authoritative. Also compacts redundant `packages/core` agent guidance so the full instruction chain stays below Codex’s 32 KiB limit, makes `AGENTS.md` an explicit Turbo input so domain knowledge cannot be restored from a stale cache, and resolves content route tests through SvelteKit’s canonical `$lib` alias so Vite cannot rewrite relative imports to invalid root-absolute `/src/...` paths. Parent rollout: happyvertical/have-config#193.

Validated with the canonical policy audit, actionlint, git diff --check, core/content package builds, full content tests (45 files; 302 passed, 6 skipped), knowledge freshness, and all repository pre-push workflow/architecture gates.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-20260718-smrt-2064-content-lib-alias-4cdb","issue":"https://github.com/happyvertical/smrt/issues/2064","policy_revision":"1.0.0","status":"complete","validation":["hv-agent audit","actionlint","git diff --check","core build","content build","content tests","knowledge check","pre-push gates"]}
```