### PR TITLE
fix(core): serialize collection hydration

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -42,6 +42,11 @@ composes with `where`, `orderBy`, `limit`, and `offset`; `beforeList`
 interceptors still run. It is for column-backed fields only and cannot combine
 with `include`/relationship eager loading.
 
+`list()` and `query()` hydrate model instances serially in result order because
+an `initialize()` hook may query through the same transaction-bound PostgreSQL
+client. Keep this serialization invariant; use `select` when callers need plain
+rows without model hydration.
+
 **WHERE operators**: `=`, `>`, `<`, `>=`, `<=`, `!=`, `in`, `not in`, `like`, `is null`, `is not null`. Arrays auto-detect `IN`. Dot notation for JSON paths: `metadata.userId`.
 
 STI child collections auto-filter by `_meta_type`.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -173,7 +173,7 @@
     "generate": "node scripts/generate-manifest.js",
     "generate:test": "node scripts/generate-test-manifest.js",
     "test": "node scripts/generate-test-manifest.js && vitest run",
-    "test:postgres": "node scripts/generate-test-manifest.js && node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/__tests__/change-feed-concurrency.optional.test.ts src/__tests__/issue-2069-postgres-date-instant.optional.test.ts",
+    "test:postgres": "node scripts/generate-test-manifest.js && NODE_OPTIONS=--trace-deprecation node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/__tests__/change-feed-concurrency.optional.test.ts src/__tests__/issue-2069-postgres-date-instant.optional.test.ts src/__tests__/issue-2070-postgres-hydration.optional.test.ts",
     "test:integration": "TEST_INTEGRATION=1 vitest run src/__tests__/full-registry-integration.test.ts src/__tests__/manifest-no-leak.test.ts",
     "test:watch": "node scripts/generate-test-manifest.js && vitest",
     "build": "node scripts/generate-manifest.js && node scripts/generate-test-manifest.js && vite build && cp -r src/vite-plugin/templates dist/vite-plugin/ && cp -r scripts dist/ && cp src/manifest/static-manifest.json dist/manifest.json && cp src/manifest/smrt-knowledge.json dist/smrt-knowledge.json",

--- a/packages/core/src/__tests__/issue-2070-postgres-hydration.optional.test.ts
+++ b/packages/core/src/__tests__/issue-2070-postgres-hydration.optional.test.ts
@@ -1,0 +1,116 @@
+/**
+ * PostgreSQL transaction hydration contract for issue #2070.
+ *
+ * Runs only in the dedicated disposable PostgreSQL shard with
+ * NODE_OPTIONS=--trace-deprecation so pg's concurrent-query warning is fatal
+ * to the assertion below rather than being hidden in test output.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { getDatabase } from '@happyvertical/sql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection.js';
+import { field } from '../decorators/index.js';
+import { SmrtObject } from '../object.js';
+import { ObjectRegistry, smrt } from '../registry.js';
+import { getDDLStrategy } from '../schema/ddl/index.js';
+
+const pgUrl = process.env.SMRT_TEST_POSTGRES_URL;
+const TABLE = 'issue_2070_postgres_hydration_probes';
+
+@smrt({ tableName: 'issue_2070_postgres_hydration_probes' })
+class Issue2070PostgresHydrationProbe extends SmrtObject {
+  @field()
+  position: number = 0;
+
+  override async initialize(): Promise<this> {
+    await super.initialize();
+    if (this.isPersisted && this.id) {
+      await this.db.get(this.tableName, { id: this.id });
+    }
+    return this;
+  }
+}
+
+class Issue2070PostgresHydrationProbeCollection extends SmrtCollection<Issue2070PostgresHydrationProbe> {
+  static readonly _itemClass = Issue2070PostgresHydrationProbe;
+}
+
+const postgresDescribe = pgUrl ? describe.sequential : describe.skip;
+
+postgresDescribe('PostgreSQL transaction hydration (#2070)', () => {
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+
+  beforeAll(async () => {
+    db = await getDatabase({
+      type: 'postgres',
+      url: pgUrl,
+      dbid: `smrt-test-hydration-${randomUUID()}`,
+    } as Parameters<typeof getDatabase>[0]);
+
+    await db.query(`DROP TABLE IF EXISTS "${TABLE}"`);
+    const registration = ObjectRegistry.getClassByConstructor(
+      Issue2070PostgresHydrationProbe,
+    );
+    const className =
+      registration?.qualifiedName ||
+      registration?.name ||
+      Issue2070PostgresHydrationProbe.name;
+    const schema = ObjectRegistry.getSchema(className);
+    const ddl = ObjectRegistry.getSchemaDDL(className, 'postgres');
+    if (!schema || !ddl) throw new Error(`Missing schema for ${className}`);
+    await db.query(ddl);
+    for (const indexSql of getDDLStrategy('postgres').generateIndexes(schema)) {
+      await db.query(indexSql);
+    }
+  });
+
+  afterAll(async () => {
+    try {
+      await db?.query(`DROP TABLE IF EXISTS "${TABLE}"`);
+    } finally {
+      await db?.close?.();
+    }
+  });
+
+  it('does not overlap initialize() queries on one transaction client', async () => {
+    await db.query(`TRUNCATE TABLE "${TABLE}"`);
+
+    const warnings: Error[] = [];
+    const captureWarning = (warning: Error): void => {
+      if (
+        /client\.query\(\).*already executing a query/i.test(warning.message)
+      ) {
+        warnings.push(warning);
+      }
+    };
+    process.on('warning', captureWarning);
+
+    try {
+      await db.transaction(async (tx) => {
+        const probes = await Issue2070PostgresHydrationProbeCollection.create({
+          db: tx,
+        });
+        for (const position of [1, 2, 3]) {
+          const id = randomUUID();
+          await tx.insert(TABLE, {
+            id,
+            slug: id,
+            context: '',
+            created_at: new Date(),
+            updated_at: new Date(),
+            position,
+          });
+        }
+
+        const rows = await probes.list({ orderBy: 'position ASC' });
+        expect(rows.map((row) => row.position)).toEqual([1, 2, 3]);
+      });
+
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(warnings).toEqual([]);
+    } finally {
+      process.off('warning', captureWarning);
+    }
+  });
+});

--- a/packages/core/src/__tests__/issue-2070-serialized-hydration.test.ts
+++ b/packages/core/src/__tests__/issue-2070-serialized-hydration.test.ts
@@ -1,0 +1,88 @@
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection.js';
+import { field } from '../decorators/index.js';
+import { SmrtObject } from '../object.js';
+import { smrt } from '../registry.js';
+import { getTestDatabase } from '../testing/database.js';
+
+let activeInitializers = 0;
+let maximumActiveInitializers = 0;
+let initializationOrder: number[] = [];
+
+@smrt({ tableName: 'issue_2070_hydration_probes' })
+class Issue2070HydrationProbe extends SmrtObject {
+  @field()
+  position: number = 0;
+
+  override async initialize(): Promise<this> {
+    await super.initialize();
+    if (!this.isPersisted || !this.id) return this;
+
+    activeInitializers += 1;
+    maximumActiveInitializers = Math.max(
+      maximumActiveInitializers,
+      activeInitializers,
+    );
+    initializationOrder.push(this.position);
+
+    try {
+      // Keep the initialization query in flight long enough for parallel row
+      // hydration to overlap deterministically on the same database adapter.
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      await this.db.get(this.tableName, { id: this.id });
+    } finally {
+      activeInitializers -= 1;
+    }
+
+    return this;
+  }
+}
+
+class Issue2070HydrationProbeCollection extends SmrtCollection<Issue2070HydrationProbe> {
+  static readonly _itemClass = Issue2070HydrationProbe;
+}
+
+function resetInitializationEvidence(): void {
+  activeInitializers = 0;
+  maximumActiveInitializers = 0;
+  initializationOrder = [];
+}
+
+describe('Issue #2070: collection hydration serializes model initialization', () => {
+  let db: DatabaseInterface;
+  let probes: Issue2070HydrationProbeCollection;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ classes: ['Issue2070HydrationProbe'] });
+    probes = await Issue2070HydrationProbeCollection.create({ db });
+
+    for (const position of [1, 2, 3]) {
+      await probes.create({ position });
+    }
+
+    resetInitializationEvidence();
+  });
+
+  afterEach(async () => {
+    await db?.close?.();
+  });
+
+  it('serializes list() hydration and preserves selected row order', async () => {
+    const rows = await probes.list({ orderBy: 'position ASC' });
+
+    expect(rows.map((row) => row.position)).toEqual([1, 2, 3]);
+    expect(initializationOrder).toEqual([1, 2, 3]);
+    expect(maximumActiveInitializers).toBe(1);
+  });
+
+  it('serializes query() hydration and preserves selected row order', async () => {
+    const rows = await probes.query(
+      `SELECT * FROM ${probes.tableName} ORDER BY position DESC`,
+    );
+
+    expect(rows.map((row) => row.position)).toEqual([3, 2, 1]);
+    expect(initializationOrder).toEqual([3, 2, 1]);
+    expect(maximumActiveInitializers).toBe(1);
+  });
+});

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -1568,9 +1568,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
 
     // STI: Hydrate instances polymorphically based on _meta_type
     // Reuse tableStrategy and isSTI from earlier in the function
-    const instances = await Promise.all(
-      rows.map((item) => this.hydrateResultRow(item, fields, isSTI)),
-    );
+    const instances = await this.hydrateResultRows(rows, fields, isSTI);
 
     // Eager load specified relationships
     if (interceptedOptions.include && interceptedOptions.include.length > 0) {
@@ -2704,9 +2702,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     );
     const isSTI = tableStrategy === 'sti';
 
-    const instances = await Promise.all(
-      result.rows.map((row) => this.hydrateResultRow(row, fields, isSTI)),
-    );
+    const instances = await this.hydrateResultRows(result.rows, fields, isSTI);
 
     // Execute afterQuery interceptors
     return await GlobalInterceptors.executeAfterQuery(
@@ -2760,6 +2756,27 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     }
 
     return instance;
+  }
+
+  /**
+   * Hydrate rows in result order.
+   *
+   * A model's initialize() hook may query through the collection database.
+   * PostgreSQL transaction adapters bind every query to one pg client, which
+   * cannot execute overlapping client.query() calls once pg 9 removes its
+   * deprecated per-client queue. Serial hydration therefore protects every
+   * model hook without relying on driver queuing and preserves row order.
+   */
+  private async hydrateResultRows(
+    rows: Record<string, unknown>[],
+    fields: Record<string, CollectionFieldDefinition>,
+    isSTI: boolean,
+  ): Promise<ModelType[]> {
+    const instances: ModelType[] = [];
+    for (const row of rows) {
+      instances.push(await this.hydrateResultRow(row, fields, isSTI));
+    }
+    return instances;
   }
 
   /**


### PR DESCRIPTION
## Summary

- hydrate `SmrtCollection.list()` and raw `query()` results serially in selected row order
- prevent model `initialize()` hooks from overlapping queries on one transaction-bound PostgreSQL client
- add deterministic concurrency coverage and a real PostgreSQL warning regression shard
- document the collection hydration invariant and the non-hydrating `select` path

## Validation

- `pnpm --dir packages/core test` — 3,136 passed, 45 skipped
- targeted list/query hydration matrix — 45 passed
- disposable PostgreSQL 16 matrix — 16 passed with `NODE_OPTIONS=--trace-deprecation`
- `pnpm typecheck` — 118/118 tasks
- `pnpm build` — 61/61 tasks
- core package dry-run, standards, package DAG, no-SMRT-peers, MCP config, knowledge freshness, formatting, secret scan
- bounded correctness, PostgreSQL-test, and ship reviews — clean

Closes #2070
Unblocks happyvertical/suasor#205, happyvertical/suasor#206, happyvertical/suasor#207, and anytown/anytown.ai#706.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019f78b5-02b9-7781-98c5-78374943a162","issue":2070,"linked_issue":2070,"policy_revision":"1.0.0","status":"complete","validation":["core tests: 3136 passed, 45 skipped","targeted hydration matrix: 45 passed","PostgreSQL 16 matrix: 16 passed with trace-deprecation","root typecheck: 118/118","root build: 61/61","package dry-run and repository policy checks passed","bounded review cycle clean"]}
```
