### PR TITLE
docs: link SaaS starter and normalize branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ The documentation build discovers package READMEs from workspace `package.json` 
 ## Related projects
 
 - [HappyVertical SDK](https://github.com/happyvertical/sdk) — infrastructure packages used by s-m-r-t.
-- [Praeco](https://github.com/happyvertical/praeco) — a production application built on s-m-r-t.
+- [s-m-r-t SaaS starter](https://github.com/happyvertical/smrt-saas-starter) — reference application, demo, and template baseline.
 
 ## License
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -57,7 +57,7 @@ batch.
 
 ### Audited PostgreSQL timestamp conversion
 
-`timestamp without time zone` values do not carry enough information for SMRT
+`timestamp without time zone` values do not carry enough information for s-m-r-t
 to infer their original instant. After auditing every historical writer,
 database default, trigger, and raw SQL path, an operator may confirm that the
 legacy values are UTC wall times and include the exact opt-in:
@@ -155,7 +155,7 @@ Custom methods on s-m-r-t objects are auto-discovered from manifests. Method par
 ## Usage
 
 ```bash
-# Discover what SMRT objects are available
+# Discover what s-m-r-t objects are available
 smrt introspect
 
 # Generate an MCP server


### PR DESCRIPTION
## Summary

- replace the public Related projects link to private Praeco with the canonical `happyvertical/smrt-saas-starter` reference application, demo, and template baseline
- restore the CLI package README’s required `s-m-r-t` spelling, which a newly merged package-doc section had regressed

## Validation

- unauthenticated `https://github.com/happyvertical/smrt-saas-starter` returns HTTP 200
- `pnpm check:readmes` — 62 workspace packages, complete catalog, local links, s-m-r-t branding, and quick start
- `pnpm test:ci-scripts` — 32/32 passed
- `pnpm --filter @happyvertical/smrt-core build`
- `pnpm knowledge:check --changed --strict --format markdown`
- `hv-agent audit`
- pre-commit and pre-push hooks
- one-reviewer docs cycle: no material findings

Closes #2089

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-steward-2090-rebase-20260725","issue":"https://github.com/happyvertical/smrt/issues/2089","policy_revision":"1.0.0","status":"complete","validation":["public SaaS starter HTTP 200","README contract","32 CI-script tests","core build and strict knowledge freshness","policy audit","pre-commit and pre-push gates","one-reviewer docs cycle clean"]}
```
