### PR TITLE
feat(cli): gate PostgreSQL timestamp conversion

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -55,6 +55,26 @@ reconciles live schema drift. Global `--force` remains available by itself for
 backward compatibility but intentionally overrides guards for the whole pending
 batch.
 
+### Audited PostgreSQL timestamp conversion
+
+`timestamp without time zone` values do not carry enough information for SMRT
+to infer their original instant. After auditing every historical writer,
+database default, trigger, and raw SQL path, an operator may confirm that the
+legacy values are UTC wall times and include the exact opt-in:
+
+```bash
+smrt db:migrate --postgres-timestamp-legacy-timezone UTC
+```
+
+The option has no default and rejects every value other than `UTC`. On
+PostgreSQL, it allows the manifest-owned timestamp columns to be converted to
+`timestamptz` with `USING column AT TIME ZONE 'UTC'`, preserving the proven UTC
+instants. It is not safe for a database with any local-time writer; use an
+application-owned, provenance-aware migration in that case. Rehearse against a
+restored clone and keep a verified backup because type upgrades have no
+automatic down migration. `--dry-run` previews the same conversion without
+writing it.
+
 ### Code Generation
 
 | Command | Description |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -72,8 +72,9 @@ PostgreSQL, it allows the manifest-owned timestamp columns to be converted to
 instants. It is not safe for a database with any local-time writer; use an
 application-owned, provenance-aware migration in that case. Rehearse against a
 restored clone and keep a verified backup because type upgrades have no
-automatic down migration. `--dry-run` previews the same conversion without
-writing it.
+automatic down migration. `smrt db:diff --postgres-timestamp-legacy-timezone
+UTC` and `smrt db:migrate --dry-run --postgres-timestamp-legacy-timezone UTC`
+both preview the same conversion without writing it.
 
 ### Code Generation
 

--- a/packages/cli/src/commands/__tests__/db-diff.test.ts
+++ b/packages/cli/src/commands/__tests__/db-diff.test.ts
@@ -115,6 +115,15 @@ describe('db:diff (real SQLite + real SchemaComparer)', () => {
     exitSpy.mockRestore();
   });
 
+  it('refuses an unproven PostgreSQL timestamp timezone before opening the database', async () => {
+    await dbDiffCommand.handler([], {
+      'postgres-timestamp-legacy-timezone': 'America/Edmonton',
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(errorOutput()).toContain('must be exactly UTC');
+  });
+
   it('exits when no manifests are discovered', async () => {
     autoDiscoverAndLoadMock.mockResolvedValue({
       discovered: [],

--- a/packages/cli/src/commands/__tests__/utilities-handlers.test.ts
+++ b/packages/cli/src/commands/__tests__/utilities-handlers.test.ts
@@ -40,6 +40,7 @@ const h = vi.hoisted(() => {
     trackerApplyAll: vi.fn(async () => []),
     ensureSchema: vi.fn(async () => {}),
     generateSchema: vi.fn(async () => 'CREATE TABLE t ()'),
+    schemaComparerOptions: vi.fn(),
     schemaCompare: vi.fn(async () => ({ added_tables: [], changes: [] })),
     manifestGenerate: vi.fn(async () => ({
       objects: { '@app:Article': {} },
@@ -66,6 +67,7 @@ const {
   trackerApplyAll,
   ensureSchema,
   generateSchema,
+  schemaComparerOptions,
   schemaCompare,
   manifestGenerate,
   discoverBaseClasses,
@@ -87,6 +89,10 @@ function migratableDb(overrides: Record<string, unknown> = {}) {
 vi.mock('@happyvertical/smrt-core', () => ({
   ObjectRegistry: h.registry,
   SchemaComparer: class {
+    constructor(_db: unknown, options?: unknown) {
+      h.schemaComparerOptions(options);
+    }
+
     compare = (...a: unknown[]) => h.schemaCompare(...a);
   },
   generateDDLForEngine: vi.fn(() => ({
@@ -437,6 +443,29 @@ describe('utility command handlers', () => {
 
     await utilityCommands['db:migrate'].handler([], { verbose: true });
     expect(logged()).toContain('Database schema is up to date');
+  });
+
+  it('db:migrate forwards only the exact UTC timestamp confirmation to the schema comparer', async () => {
+    configureMigrate();
+
+    await utilityCommands['db:migrate'].handler([], {
+      'postgres-timestamp-legacy-timezone': 'UTC',
+    });
+
+    expect(schemaComparerOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        postgresTimestampMigration: { legacyTimezone: 'UTC' },
+      }),
+    );
+  });
+
+  it('db:migrate rejects non-UTC timestamp conversion provenance', async () => {
+    await utilityCommands['db:migrate'].handler([], {
+      'postgres-timestamp-legacy-timezone': 'America/Edmonton',
+    });
+
+    expect(errored()).toContain('must be exactly UTC');
+    expect(process.exitCode).toBe(1);
   });
 
   it('db:migrate previews changes in --dry-run mode', async () => {

--- a/packages/cli/src/commands/__tests__/utilities.test.ts
+++ b/packages/cli/src/commands/__tests__/utilities.test.ts
@@ -6,6 +6,7 @@ import { parseCliCommandArgs } from '../../cli-generator.js';
 import {
   assertForceMigrationTargetsExist,
   resolveForceMigrationSelection,
+  resolvePostgresTimestampMigration,
   resolveVitestEntrypoint,
   utilityCommands,
 } from '../utilities.js';
@@ -130,6 +131,39 @@ describe('utilities', () => {
     expect(migrateOptions?.['force-migration'].description).toContain(
       'repeat for multiple IDs',
     );
+  });
+
+  it('requires an exact UTC confirmation before enabling PostgreSQL timestamp conversion', () => {
+    const migrateOptions = utilityCommands['db:migrate'].options;
+
+    expect(
+      migrateOptions?.['postgres-timestamp-legacy-timezone'],
+    ).toMatchObject({
+      type: 'string',
+    });
+    expect(
+      migrateOptions?.['postgres-timestamp-legacy-timezone'].description,
+    ).toContain('Exact value required: UTC');
+    expect(resolvePostgresTimestampMigration(undefined)).toBeUndefined();
+    expect(resolvePostgresTimestampMigration('UTC')).toEqual({
+      legacyTimezone: 'UTC',
+    });
+    expect(() => resolvePostgresTimestampMigration('America/Edmonton')).toThrow(
+      /exactly UTC/,
+    );
+    expect(() => resolvePostgresTimestampMigration('UTC ')).toThrow(
+      /exactly UTC/,
+    );
+  });
+
+  it('parses the PostgreSQL timestamp confirmation without a default opt-in', () => {
+    const migrate = utilityCommands['db:migrate'];
+    const parsed = parseCliCommandArgs(
+      ['db:migrate', '--postgres-timestamp-legacy-timezone', 'UTC'],
+      [migrate],
+    );
+
+    expect(parsed.options['postgres-timestamp-legacy-timezone']).toBe('UTC');
   });
 
   it('parses repeated exact migration flags in argv order', () => {

--- a/packages/cli/src/commands/__tests__/utilities.test.ts
+++ b/packages/cli/src/commands/__tests__/utilities.test.ts
@@ -166,6 +166,19 @@ describe('utilities', () => {
     expect(parsed.options['postgres-timestamp-legacy-timezone']).toBe('UTC');
   });
 
+  it('offers the same exact PostgreSQL timestamp confirmation to db:diff', () => {
+    const diff = utilityCommands['db:diff'];
+    const parsed = parseCliCommandArgs(
+      ['db:diff', '--postgres-timestamp-legacy-timezone', 'UTC'],
+      [diff],
+    );
+
+    expect(diff.options?.['postgres-timestamp-legacy-timezone']).toMatchObject({
+      type: 'string',
+    });
+    expect(parsed.options['postgres-timestamp-legacy-timezone']).toBe('UTC');
+  });
+
   it('parses repeated exact migration flags in argv order', () => {
     const migrate = utilityCommands['db:migrate'];
     const parsed = parseCliCommandArgs(

--- a/packages/cli/src/commands/db-diff.ts
+++ b/packages/cli/src/commands/db-diff.ts
@@ -9,6 +9,7 @@ import type { DatabaseInterface } from '@happyvertical/sql';
 import type { CLICommand } from '../cli-generator.js';
 import { autoDiscoverAndLoad } from '../discovery/index.js';
 import { closeDatabaseConnection } from './db-command-utils.js';
+import { resolvePostgresTimestampMigration } from './postgres-timestamp-migration.js';
 
 const UNSUPPORTED_GENERATE_MESSAGE =
   'File-backed SMRT migrations are not supported. SMRT schema migrations are manifest-driven; update @smrt object definitions and run smrt db:migrate.';
@@ -25,6 +26,7 @@ interface DbDiffOptions {
   json?: boolean;
   verbose?: boolean;
   'drop-indexes'?: boolean;
+  'postgres-timestamp-legacy-timezone'?: string;
 }
 
 export const dbDiffCommand: CLICommand = {
@@ -77,11 +79,19 @@ export const dbDiffCommand: CLICommand = {
         'Include orphan-index drops in the diff (indexes in DB but not in the manifest, excluding *_pkey/*_key implicit-from-constraint indexes). Off by default for safety.',
       default: false,
     },
+    'postgres-timestamp-legacy-timezone': {
+      type: 'string',
+      description:
+        'Confirm that legacy PostgreSQL timestamp-without-time-zone values are UTC wall times before previewing their conversion to timestamptz. Exact value required: UTC; omitted by default.',
+    },
   },
   handler: async (_args: string[], options: DbDiffOptions) => {
     let db: DatabaseInterface | undefined;
 
     try {
+      const postgresTimestampMigration = resolvePostgresTimestampMigration(
+        options['postgres-timestamp-legacy-timezone'],
+      );
       const unsupportedFileOptions = (
         ['generate', 'name', 'format', 'with-down', 'output'] as const
       ).filter(
@@ -180,6 +190,7 @@ export const dbDiffCommand: CLICommand = {
         includeDroppedTables: false,
         includeDroppedColumns: false,
         includeDroppedIndexes: Boolean(options['drop-indexes']),
+        postgresTimestampMigration,
       });
 
       const diff = await comparer.compare(schemaDefinitions);

--- a/packages/cli/src/commands/postgres-timestamp-migration.ts
+++ b/packages/cli/src/commands/postgres-timestamp-migration.ts
@@ -1,0 +1,22 @@
+/**
+ * Fail-closed confirmation shared by PostgreSQL schema preview and migration.
+ *
+ * A `timestamp without time zone` value cannot establish its own original
+ * instant. Callers must therefore make the same explicit UTC provenance
+ * confirmation whether they are previewing or applying the conversion.
+ */
+export function resolvePostgresTimestampMigration(
+  legacyTimezone: string | undefined,
+): { legacyTimezone: 'UTC' } | undefined {
+  if (legacyTimezone === undefined) {
+    return undefined;
+  }
+
+  if (legacyTimezone !== 'UTC') {
+    throw new Error(
+      '--postgres-timestamp-legacy-timezone must be exactly UTC; refusing to infer the offset of legacy PostgreSQL timestamps',
+    );
+  }
+
+  return { legacyTimezone: 'UTC' };
+}

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -44,6 +44,7 @@ import { dbRollbackCommand } from './db-rollback.js';
 import { dbStatusCommand } from './db-status.js';
 import { devKnowledgeCommands } from './dev-knowledge.js';
 import { exportCommand } from './export.js';
+import { resolvePostgresTimestampMigration } from './postgres-timestamp-migration.js';
 import {
   runRuntimeCheckSafely,
   runtimeCheckCommand,
@@ -213,21 +214,7 @@ export interface ForceMigrationSelection {
  * reinterpret legacy PostgreSQL timestamp-without-time-zone values as UTC
  * instants. Omitting the option intentionally leaves the type drift manual.
  */
-export function resolvePostgresTimestampMigration(
-  legacyTimezone: string | undefined,
-): { legacyTimezone: 'UTC' } | undefined {
-  if (legacyTimezone === undefined) {
-    return undefined;
-  }
-
-  if (legacyTimezone !== 'UTC') {
-    throw new Error(
-      '--postgres-timestamp-legacy-timezone must be exactly UTC; refusing to infer the offset of legacy PostgreSQL timestamps',
-    );
-  }
-
-  return { legacyTimezone: 'UTC' };
-}
+export { resolvePostgresTimestampMigration } from './postgres-timestamp-migration.js';
 
 /**
  * Normalize exact migration selectors from the public single/repeated CLI

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -190,6 +190,7 @@ interface DbValidateOptions {
 interface DbMigrateOptions {
   'dry-run'?: boolean;
   'postgres-safe'?: boolean;
+  'postgres-timestamp-legacy-timezone'?: string;
   force?: boolean;
   'force-migration'?: string | readonly string[];
   'repair-data'?: boolean;
@@ -205,6 +206,27 @@ interface DoctorOptions {
 export interface ForceMigrationSelection {
   force: boolean;
   forceMigrations?: readonly string[];
+}
+
+/**
+ * Require the explicit provenance confirmation before the schema comparer may
+ * reinterpret legacy PostgreSQL timestamp-without-time-zone values as UTC
+ * instants. Omitting the option intentionally leaves the type drift manual.
+ */
+export function resolvePostgresTimestampMigration(
+  legacyTimezone: string | undefined,
+): { legacyTimezone: 'UTC' } | undefined {
+  if (legacyTimezone === undefined) {
+    return undefined;
+  }
+
+  if (legacyTimezone !== 'UTC') {
+    throw new Error(
+      '--postgres-timestamp-legacy-timezone must be exactly UTC; refusing to infer the offset of legacy PostgreSQL timestamps',
+    );
+  }
+
+  return { legacyTimezone: 'UTC' };
 }
 
 /**
@@ -1153,6 +1175,11 @@ export default testManifest;
           'Use PostgreSQL-safe operations (CONCURRENTLY for indexes, lock_timeout)',
         default: false,
       },
+      'postgres-timestamp-legacy-timezone': {
+        type: 'string',
+        description:
+          'Confirm that legacy PostgreSQL timestamp-without-time-zone values are UTC wall times before converting them to timestamptz. Exact value required: UTC; omitted by default.',
+      },
       force: {
         type: 'boolean',
         description:
@@ -1198,6 +1225,9 @@ export default testManifest;
         const forceSelection = resolveForceMigrationSelection(
           options.force,
           options['force-migration'],
+        );
+        const postgresTimestampMigration = resolvePostgresTimestampMigration(
+          options['postgres-timestamp-legacy-timezone'],
         );
 
         // 1. Load CLI config
@@ -1378,6 +1408,7 @@ export default testManifest;
         // --drop-indexes for safety.
         const comparer = new SchemaComparer(db, {
           includeDroppedIndexes: Boolean(options['drop-indexes']),
+          postgresTimestampMigration,
         });
         const diff = await comparer.compare(manifestSchemas);
 


### PR DESCRIPTION
## Summary

- add a fail-closed `--postgres-timestamp-legacy-timezone UTC` confirmation to both `smrt db:migrate` and `smrt db:diff`
- forward one shared, exact UTC confirmation to `SchemaComparer`, so the diff remains an honest preview of the migration path
- document the no-write preview and cover parsing plus unproven-timezone refusal

Fixes #2095

## Validation

- `pnpm --filter @happyvertical/smrt-cli... build`
- `pnpm --filter @happyvertical/smrt-cli exec vitest run src/commands/__tests__/utilities.test.ts src/commands/__tests__/db-diff.test.ts`
- `pnpm --filter @happyvertical/smrt-cli typecheck`
- `pnpm exec biome check packages/cli/src/commands/postgres-timestamp-migration.ts packages/cli/src/commands/db-diff.ts packages/cli/src/commands/utilities.ts packages/cli/src/commands/__tests__/utilities.test.ts packages/cli/src/commands/__tests__/db-diff.test.ts packages/cli/README.md`

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-smrt-2096-steward-20260725","issue":2095,"linked_issue":2095,"policy_revision":"1.0.0","status":"in_progress","validation":["Node 24.18.0 dependency build","CLI timestamp option tests","CLI typecheck","Biome"]}
```
