### PR TITLE
feat(ui): theme hardening, SSR-safe subscription components, AdminShell rail fixes

### DIFF
--- a/packages/content/src/content-chat-prompts.test.ts
+++ b/packages/content/src/content-chat-prompts.test.ts
@@ -9,11 +9,6 @@ import {
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  GET as getContentChat,
-  POST as postContentChat,
-} from '$lib/../routes/api/v1/contents/[id]/chat/+server';
-import { POST as postContentChatThread } from '$lib/../routes/api/v1/contents/[id]/chat/threads/[threadId]/+server';
-import {
   contentChatSessionIsAuthorized,
   contentChatSessionMatchesContent,
   createContentEditorChatThread,
@@ -26,6 +21,11 @@ import {
   contentEditorSessionPrompt,
 } from './content-chat-prompts';
 import { Contents } from './contents';
+import {
+  GET as getContentChat,
+  POST as postContentChat,
+} from './routes/api/v1/contents/[id]/chat/+server';
+import { POST as postContentChatThread } from './routes/api/v1/contents/[id]/chat/threads/[threadId]/+server';
 
 let currentContents: Contents | undefined;
 const getAIMock = vi.fn();

--- a/packages/content/src/contents-api.test.ts
+++ b/packages/content/src/contents-api.test.ts
@@ -2,16 +2,16 @@ import { getTestDatabase } from '@happyvertical/smrt-core';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { syncSchema } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Contents } from './contents';
 import {
   POST as createContent,
   GET as getList,
-} from '$lib/../routes/api/v1/contents/+server';
+} from './routes/api/v1/contents/+server';
 import {
   DELETE as deleteContent,
   GET as getSingle,
   PUT as updateContent,
-} from '$lib/../routes/api/v1/contents/[id]/+server';
-import { Contents } from './contents';
+} from './routes/api/v1/contents/[id]/+server';
 
 let currentContents: Contents | undefined;
 

--- a/packages/smrt-svelte/src/components/forms/CheckboxInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/CheckboxInput.svelte
@@ -113,6 +113,7 @@ function handleChange(e: Event) {
 <style>
   .smrt-checkbox-field {
     display: inline-flex;
+    min-width: 0;
     align-items: center;
     gap: var(--smrt-spacing-2, 8px);
     cursor: pointer;

--- a/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
@@ -437,6 +437,9 @@ function handleNativeChange(e: Event) {
 
   .smrt-input {
     flex: 1;
+    box-sizing: border-box;
+    min-width: 0;
+    width: 100%;
     padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     font-size: var(--smrt-typography-body-large-size, 1rem);
     border: 1px solid var(--smrt-color-outline-variant, #d1d5db);

--- a/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
@@ -413,6 +413,8 @@ function handleNativeChange(e: Event) {
   .smrt-datetime {
     display: flex;
     flex-direction: column;
+    width: 100%;
+    min-width: 0;
     gap: var(--smrt-spacing-1, 4px);
     position: relative;
   }

--- a/packages/smrt-svelte/src/components/forms/NumberInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/NumberInput.svelte
@@ -260,6 +260,9 @@ function handleInput(e: Event) {
 
   .smrt-input {
     flex: 1;
+    box-sizing: border-box;
+    min-width: 0;
+    width: 100%;
     padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     font-size: var(--smrt-typography-body-large-size, 1rem);
     border: 1px solid var(--smrt-color-outline-variant, #d1d5db);

--- a/packages/smrt-svelte/src/components/forms/NumberInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/NumberInput.svelte
@@ -237,6 +237,8 @@ function handleInput(e: Event) {
   .smrt-number {
     display: flex;
     flex-direction: column;
+    width: 100%;
+    min-width: 0;
     gap: var(--smrt-spacing-1, 4px);
   }
 

--- a/packages/smrt-svelte/src/components/forms/SelectInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/SelectInput.svelte
@@ -150,7 +150,7 @@ function handleChange(e: Event) {
     display: flex;
     flex-direction: column;
     width: 100%;
-    min-width: 240px;
+    min-width: 0;
   }
 
   .container {

--- a/packages/smrt-svelte/src/components/forms/TextInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/TextInput.svelte
@@ -321,7 +321,7 @@ function handleInput(e: Event) {
     display: flex;
     flex-direction: column;
     width: 100%;
-    min-width: 240px;
+    min-width: 0;
   }
 
   .container {

--- a/packages/smrt-svelte/src/components/forms/TextareaInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/TextareaInput.svelte
@@ -290,6 +290,7 @@ function handleInput(e: Event) {
     display: flex;
     flex-direction: column;
     width: 100%;
+    min-width: 0;
   }
 
   .container {

--- a/packages/smrt-svelte/src/components/forms/__tests__/DateTimeInput.behavior.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/DateTimeInput.behavior.test.ts
@@ -33,8 +33,22 @@ vi.mock('../../../hooks/useSTT.svelte.js', () => ({
 }));
 
 import DateTimeInput from '../DateTimeInput.svelte';
+import dateTimeInputSource from '../DateTimeInput.svelte?raw';
 
 describe('DateTimeInput — behavior', () => {
+  it('allows its native input to shrink inside a narrow form track', () => {
+    const { container } = render(DateTimeInput, {
+      props: { name: 'when', label: 'When' },
+    });
+    container.style.width = '80px';
+    const input = screen.getByLabelText('When');
+
+    expect(input).toHaveClass('smrt-input');
+    expect(dateTimeInputSource).toMatch(
+      /\.smrt-input\s*\{[^}]*box-sizing:\s*border-box;[^}]*min-width:\s*0;[^}]*width:\s*100%;/,
+    );
+  });
+
   it('renders a datetime-local input when includeTime is true (default)', () => {
     render(DateTimeInput, { props: { name: 'when', label: 'When' } });
     expect(screen.getByLabelText('When')).toHaveAttribute(

--- a/packages/smrt-svelte/src/components/forms/__tests__/NumberInput.behavior.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/NumberInput.behavior.test.ts
@@ -22,6 +22,7 @@ vi.mock('../../../hooks/useAppState.svelte.js', () => ({
 }));
 
 import NumberInput from '../NumberInput.svelte';
+import numberInputSource from '../NumberInput.svelte?raw';
 
 describe('NumberInput — typing & parsing', () => {
   it('fires onchange with the parsed number as the user types', async () => {
@@ -129,6 +130,19 @@ describe('NumberInput — range validation', () => {
 });
 
 describe('NumberInput — attributes', () => {
+  it('allows its native input to shrink inside a narrow form track', () => {
+    const { container } = render(NumberInput, {
+      props: { name: 'amount', label: 'Amount' },
+    });
+    container.style.width = '80px';
+    const input = screen.getByLabelText('Amount');
+
+    expect(input).toHaveClass('smrt-input');
+    expect(numberInputSource).toMatch(
+      /\.smrt-input\s*\{[^}]*box-sizing:\s*border-box;[^}]*min-width:\s*0;[^}]*width:\s*100%;/,
+    );
+  });
+
   it('forwards min, max, and step onto the input', () => {
     render(NumberInput, {
       props: { name: 'age', label: 'Age', min: 1, max: 100, step: 5 },

--- a/packages/smrt-svelte/src/components/workspace/__tests__/AdminShell.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/AdminShell.test.ts
@@ -257,4 +257,55 @@ describe('AdminShell', () => {
       unmount(component);
     }
   });
+
+  it('collapses corner tracks when no corner snippets are mounted', () => {
+    const component = mount(AdminShell, {
+      target: container,
+      props: {
+        title: 'Ops',
+        children: textSnippet('main work'),
+      },
+    });
+
+    try {
+      const topEdge = container.querySelector(
+        '.smrt-admin-shell__edge--top',
+      ) as HTMLElement;
+      const band = container.querySelector(
+        '.smrt-admin-shell__band--top',
+      ) as HTMLElement;
+      expect(topEdge.style.getPropertyValue('--edge-columns').trim()).toBe(
+        'minmax(0, 1fr)',
+      );
+      expect(band.style.getPropertyValue('--band-column').trim()).toBe('1');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('reserves corner tracks only for mounted corner snippets', () => {
+    const component = mount(AdminShell, {
+      target: container,
+      props: {
+        title: 'Ops',
+        topLeftCorner: textSnippet('corner'),
+        children: textSnippet('main work'),
+      },
+    });
+
+    try {
+      const topEdge = container.querySelector(
+        '.smrt-admin-shell__edge--top',
+      ) as HTMLElement;
+      const band = container.querySelector(
+        '.smrt-admin-shell__band--top',
+      ) as HTMLElement;
+      const columns = topEdge.style.getPropertyValue('--edge-columns');
+      expect(columns).toContain('--smrt-admin-shell-left-collapsed');
+      expect(columns).not.toContain('--smrt-admin-shell-right-collapsed');
+      expect(band.style.getPropertyValue('--band-column').trim()).toBe('2');
+    } finally {
+      unmount(component);
+    }
+  });
 });

--- a/packages/smrt-svelte/src/components/workspace/__tests__/AdminShell.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/AdminShell.test.ts
@@ -283,6 +283,43 @@ describe('AdminShell', () => {
     }
   });
 
+  it('renders a default focus rail from registered tools when no focusRail snippet is given', async () => {
+    const state = createShellState();
+    state.registerFocusTool({ id: 'chat', label: 'Chat' });
+    state.registerFocusTool({ id: 'files', label: 'Files' });
+    const component = mount(AdminShell, {
+      target: container,
+      props: { state, children: textSnippet('main work') },
+    });
+
+    try {
+      const buttons = container.querySelectorAll(
+        '.smrt-admin-shell__focus-tool',
+      );
+      expect(buttons.length).toBe(2);
+      expect(buttons[0].getAttribute('aria-label')).toBe('Chat');
+
+      // Clicking a tool opens the panel; clicking the active one closes it.
+      (buttons[0] as HTMLButtonElement).click();
+      const { tick } = await import('svelte');
+      await tick();
+      expect(
+        container
+          .querySelector('.smrt-admin-shell__edge--right')
+          ?.getAttribute('data-state'),
+      ).toBe('expanded');
+      (buttons[0] as HTMLButtonElement).click();
+      await tick();
+      expect(
+        container
+          .querySelector('.smrt-admin-shell__edge--right')
+          ?.getAttribute('data-state'),
+      ).toBe('collapsed');
+    } finally {
+      unmount(component);
+    }
+  });
+
   it('reserves corner tracks only for mounted corner snippets', () => {
     const component = mount(AdminShell, {
       target: container,

--- a/packages/smrt-svelte/src/components/workspace/__tests__/AdminShell.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/AdminShell.test.ts
@@ -275,9 +275,9 @@ describe('AdminShell', () => {
         '.smrt-admin-shell__band--top',
       ) as HTMLElement;
       expect(topEdge.style.getPropertyValue('--edge-columns').trim()).toBe(
-        'minmax(0, 1fr)',
+        '0px minmax(0, 1fr) 0px',
       );
-      expect(band.style.getPropertyValue('--band-column').trim()).toBe('1');
+      expect(band.style.getPropertyValue('--band-column').trim()).toBe('2');
     } finally {
       unmount(component);
     }
@@ -341,6 +341,36 @@ describe('AdminShell', () => {
       expect(columns).toContain('--smrt-admin-shell-left-collapsed');
       expect(columns).not.toContain('--smrt-admin-shell-right-collapsed');
       expect(band.style.getPropertyValue('--band-column').trim()).toBe('2');
+    } finally {
+      unmount(component);
+    }
+  });
+
+  it('keeps a right-only corner in the explicit third grid track', () => {
+    const component = mount(AdminShell, {
+      target: container,
+      props: {
+        title: 'Ops',
+        topRightCorner: textSnippet('right corner'),
+        children: textSnippet('main work'),
+      },
+    });
+
+    try {
+      const topEdge = container.querySelector(
+        '.smrt-admin-shell__edge--top',
+      ) as HTMLElement;
+      const band = container.querySelector(
+        '.smrt-admin-shell__band--top',
+      ) as HTMLElement;
+      const columns = topEdge.style.getPropertyValue('--edge-columns').trim();
+      expect(columns).toBe(
+        '0px minmax(0, 1fr) var(--smrt-admin-shell-right-collapsed)',
+      );
+      expect(band.style.getPropertyValue('--band-column').trim()).toBe('2');
+      expect(
+        container.querySelector('.smrt-admin-shell__corner--top-right'),
+      ).not.toBeNull();
     } finally {
       unmount(component);
     }

--- a/packages/smrt-svelte/src/components/workspace/__tests__/admin-shell-state.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/admin-shell-state.test.ts
@@ -182,6 +182,30 @@ describe('ShellState', () => {
     }
   });
 
+  it('re-opening the active focus tool collapses the right panel', () => {
+    const shell = createShellState();
+    shell.registerFocusTool({ id: 'chat', label: 'Chat' });
+
+    shell.openFocusTool('chat');
+    expect(shell.panels.right).toBe('expanded');
+    expect(shell.activeFocusToolId).toBe('chat');
+
+    // Second click on the active tool closes the dock.
+    shell.openFocusTool('chat');
+    expect(shell.panels.right).toBe('collapsed');
+    expect(shell.activeFocusToolId).toBe('chat');
+
+    // Third click re-opens it.
+    shell.openFocusTool('chat');
+    expect(shell.panels.right).toBe('expanded');
+
+    // Switching tools never collapses.
+    shell.registerFocusTool({ id: 'files', label: 'Files' });
+    shell.openFocusTool('files');
+    expect(shell.panels.right).toBe('expanded');
+    expect(shell.activeFocusToolId).toBe('files');
+  });
+
   it('does not leak panel state reads into consumer effects', () => {
     const shell = createShellState();
     const harness = mountMutationEffect(shell, (state) => {

--- a/packages/smrt-svelte/src/components/workspace/__tests__/admin-shell-state.test.ts
+++ b/packages/smrt-svelte/src/components/workspace/__tests__/admin-shell-state.test.ts
@@ -182,7 +182,7 @@ describe('ShellState', () => {
     }
   });
 
-  it('re-opening the active focus tool collapses the right panel', () => {
+  it('keeps imperative open idempotent and toggles only through toggleFocusTool', () => {
     const shell = createShellState();
     shell.registerFocusTool({ id: 'chat', label: 'Chat' });
 
@@ -190,13 +190,15 @@ describe('ShellState', () => {
     expect(shell.panels.right).toBe('expanded');
     expect(shell.activeFocusToolId).toBe('chat');
 
-    // Second click on the active tool closes the dock.
+    // Imperative callers can safely ensure that a tool is open.
     shell.openFocusTool('chat');
-    expect(shell.panels.right).toBe('collapsed');
+    expect(shell.panels.right).toBe('expanded');
     expect(shell.activeFocusToolId).toBe('chat');
 
-    // Third click re-opens it.
-    shell.openFocusTool('chat');
+    // Rail clicks use the explicit toggle operation.
+    shell.toggleFocusTool('chat');
+    expect(shell.panels.right).toBe('collapsed');
+    shell.toggleFocusTool('chat');
     expect(shell.panels.right).toBe('expanded');
 
     // Switching tools never collapses.

--- a/packages/smrt-svelte/src/components/workspace/admin-shell/AdminShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/admin-shell/AdminShell.svelte
@@ -386,6 +386,35 @@ function buildLayoutStyle(shell: ModuleShellState): string {
       <div class="smrt-admin-shell__rail">
         {#if focusRail}
           {@render focusRail()}
+        {:else if shell.focusTools.length > 0}
+          <nav class="smrt-admin-shell__focus-rail" aria-label="Focus tools">
+            {#each shell.focusTools as tool (tool.id)}
+              <!-- raw-primitive-allow: shell chrome toggle, not a content button -->
+              <button
+                type="button"
+                class="smrt-admin-shell__focus-tool"
+                class:active={shell.activeFocusToolId ===
+                  tool.id && edgeExpanded('right')}
+                aria-pressed={shell.activeFocusToolId ===
+                  tool.id && edgeExpanded('right')}
+                aria-label={tool.label}
+                title={tool.label}
+                onclick={() => shell.openFocusTool(tool.id)}
+              >
+                {#if tool.icon}
+                  <tool.icon />
+                {:else}
+                  <span aria-hidden="true">{tool.label.charAt(0)}</span>
+                {/if}
+                {#if tool.badge != null}
+                  <span class="smrt-admin-shell__focus-tool-badge">
+                    {tool.badge}
+                  </span>
+                {/if}
+              </button>
+            {/each}
+          </nav>
+          {@render edgeToggle('right')}
         {:else}
           {@render edgeToggle('right')}
         {/if}
@@ -613,6 +642,49 @@ function buildLayoutStyle(shell: ModuleShellState): string {
     block-size: 100%;
     overflow: auto;
     padding: var(--smrt-spacing-3);
+  }
+
+  .smrt-admin-shell__focus-rail {
+    display: grid;
+    /* Center tracks, not just items: buttons may be wider than the
+       collapsed strip's content box (see ToolsDock). */
+    justify-content: center;
+    justify-items: center;
+    gap: var(--smrt-spacing-2, 0.5rem);
+  }
+
+  .smrt-admin-shell__focus-tool {
+    position: relative;
+    display: grid;
+    place-items: center;
+    width: 2.35rem;
+    height: 2.35rem;
+    border: 1px solid transparent;
+    border-radius: var(--smrt-radius-md, 8px);
+    background: transparent;
+    color: var(--smrt-color-on-surface-variant);
+    cursor: pointer;
+    font: inherit;
+  }
+
+  .smrt-admin-shell__focus-tool:hover,
+  .smrt-admin-shell__focus-tool.active {
+    color: var(--smrt-color-primary);
+    border-color: var(--smrt-color-primary);
+    background: var(--smrt-color-surface-container-high);
+  }
+
+  .smrt-admin-shell__focus-tool-badge {
+    position: absolute;
+    inset-block-start: -0.25rem;
+    inset-inline-end: -0.25rem;
+    min-width: 1rem;
+    border-radius: var(--smrt-radius-full, 9999px);
+    background: var(--smrt-color-error);
+    color: var(--smrt-color-on-error);
+    font-size: var(--smrt-typography-label-small-size, 0.625rem);
+    line-height: 1rem;
+    text-align: center;
   }
 
   .smrt-admin-shell__edge--left[data-state='expanded']

--- a/packages/smrt-svelte/src/components/workspace/admin-shell/AdminShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/admin-shell/AdminShell.svelte
@@ -636,6 +636,7 @@ function buildLayoutStyle(shell: ModuleShellState): string {
   }
 
   .smrt-admin-shell__rail {
+    box-sizing: border-box;
     min-width: 0;
     min-height: 0;
     block-size: 100%;
@@ -719,6 +720,7 @@ function buildLayoutStyle(shell: ModuleShellState): string {
   }
 
   .smrt-admin-shell__panel {
+    box-sizing: border-box;
     min-width: 0;
     min-height: 0;
     block-size: 100%;

--- a/packages/smrt-svelte/src/components/workspace/admin-shell/AdminShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/admin-shell/AdminShell.svelte
@@ -163,10 +163,7 @@ function buildLayoutStyle(shell: ModuleShellState): string {
   function edgeColumns(left: unknown, right: unknown): string {
     const l = 'var(--smrt-admin-shell-left-collapsed)';
     const r = 'var(--smrt-admin-shell-right-collapsed)';
-    if (left && right) return `${l} minmax(0, 1fr) ${r}`;
-    if (left) return `${l} minmax(0, 1fr)`;
-    if (right) return `minmax(0, 1fr) ${r}`;
-    return 'minmax(0, 1fr)';
+    return `${left ? l : '0px'} minmax(0, 1fr) ${right ? r : '0px'}`;
   }
 
   const topEdgeColumns = $derived(edgeColumns(topLeftCorner, topRightCorner));
@@ -299,7 +296,7 @@ function buildLayoutStyle(shell: ModuleShellState): string {
       {/if}
       <div
         class="smrt-admin-shell__band smrt-admin-shell__band--top"
-        style:--band-column={topLeftCorner ? 2 : 1}
+        style:--band-column={2}
       >
         {#if appBar}
           {@render appBar()}
@@ -399,7 +396,7 @@ function buildLayoutStyle(shell: ModuleShellState): string {
                   tool.id && edgeExpanded('right')}
                 aria-label={tool.label}
                 title={tool.label}
-                onclick={() => shell.openFocusTool(tool.id)}
+                onclick={() => shell.toggleFocusTool(tool.id)}
               >
                 {#if tool.icon}
                   <tool.icon />
@@ -443,7 +440,7 @@ function buildLayoutStyle(shell: ModuleShellState): string {
       {/if}
       <div
         class="smrt-admin-shell__band smrt-admin-shell__band--bottom"
-        style:--band-column={bottomLeftCorner ? 2 : 1}
+        style:--band-column={2}
       >
         {#if systemBar}
           {@render systemBar()}

--- a/packages/smrt-svelte/src/components/workspace/admin-shell/AdminShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/admin-shell/AdminShell.svelte
@@ -414,7 +414,6 @@ function buildLayoutStyle(shell: ModuleShellState): string {
               </button>
             {/each}
           </nav>
-          {@render edgeToggle('right')}
         {:else}
           {@render edgeToggle('right')}
         {/if}

--- a/packages/smrt-svelte/src/components/workspace/admin-shell/AdminShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/admin-shell/AdminShell.svelte
@@ -157,6 +157,23 @@ function buildLayoutStyle(shell: ModuleShellState): string {
 
   const layoutStyle = $derived(buildLayoutStyle(shell));
 
+  // Top/bottom edges reserve grid tracks for corner snippets. When a corner
+  // isn't mounted its track must collapse, otherwise the band is squeezed
+  // between phantom tracks sized by the collapsed panel widths.
+  function edgeColumns(left: unknown, right: unknown): string {
+    const l = 'var(--smrt-admin-shell-left-collapsed)';
+    const r = 'var(--smrt-admin-shell-right-collapsed)';
+    if (left && right) return `${l} minmax(0, 1fr) ${r}`;
+    if (left) return `${l} minmax(0, 1fr)`;
+    if (right) return `minmax(0, 1fr) ${r}`;
+    return 'minmax(0, 1fr)';
+  }
+
+  const topEdgeColumns = $derived(edgeColumns(topLeftCorner, topRightCorner));
+  const bottomEdgeColumns = $derived(
+    edgeColumns(bottomLeftCorner, bottomRightCorner),
+  );
+
   function panelState(edge: PanelEdge) {
     return shell.panels[edge];
   }
@@ -273,13 +290,17 @@ function buildLayoutStyle(shell: ModuleShellState): string {
       class="smrt-admin-shell__edge smrt-admin-shell__edge--top"
       data-state={panelState('top')}
       data-presentation={shell.config.panels.top.presentation}
+      style:--edge-columns={topEdgeColumns}
     >
       {#if topLeftCorner}
         <div class="smrt-admin-shell__corner smrt-admin-shell__corner--top-left">
           {@render topLeftCorner()}
         </div>
       {/if}
-      <div class="smrt-admin-shell__band smrt-admin-shell__band--top">
+      <div
+        class="smrt-admin-shell__band smrt-admin-shell__band--top"
+        style:--band-column={topLeftCorner ? 2 : 1}
+      >
         {#if appBar}
           {@render appBar()}
         {:else}
@@ -385,13 +406,17 @@ function buildLayoutStyle(shell: ModuleShellState): string {
       class="smrt-admin-shell__edge smrt-admin-shell__edge--bottom"
       data-state={panelState('bottom')}
       data-presentation={shell.config.panels.bottom.presentation}
+      style:--edge-columns={bottomEdgeColumns}
     >
       {#if bottomLeftCorner}
         <div class="smrt-admin-shell__corner smrt-admin-shell__corner--bottom-left">
           {@render bottomLeftCorner()}
         </div>
       {/if}
-      <div class="smrt-admin-shell__band smrt-admin-shell__band--bottom">
+      <div
+        class="smrt-admin-shell__band smrt-admin-shell__band--bottom"
+        style:--band-column={bottomLeftCorner ? 2 : 1}
+      >
         {#if systemBar}
           {@render systemBar()}
         {:else}
@@ -499,9 +524,11 @@ function buildLayoutStyle(shell: ModuleShellState): string {
     grid-column: 1 / -1;
     grid-row: 1;
     display: grid;
-    grid-template-columns:
+    grid-template-columns: var(
+      --edge-columns,
       var(--smrt-admin-shell-left-collapsed) minmax(0, 1fr)
-      var(--smrt-admin-shell-right-collapsed);
+        var(--smrt-admin-shell-right-collapsed)
+    );
     border-block-end: 1px solid var(--smrt-color-outline-variant);
     z-index: 30;
   }
@@ -531,9 +558,11 @@ function buildLayoutStyle(shell: ModuleShellState): string {
     grid-column: 1 / -1;
     grid-row: 3;
     display: grid;
-    grid-template-columns:
+    grid-template-columns: var(
+      --edge-columns,
       var(--smrt-admin-shell-left-collapsed) minmax(0, 1fr)
-      var(--smrt-admin-shell-right-collapsed);
+        var(--smrt-admin-shell-right-collapsed)
+    );
     border-block-start: 1px solid var(--smrt-color-outline-variant);
     z-index: 30;
   }
@@ -558,7 +587,7 @@ function buildLayoutStyle(shell: ModuleShellState): string {
 
   .smrt-admin-shell__band--top,
   .smrt-admin-shell__band--bottom {
-    grid-column: 2;
+    grid-column: var(--band-column, 2);
   }
 
   .smrt-admin-shell__brand {

--- a/packages/smrt-svelte/src/components/workspace/admin-shell/AdminShell.svelte
+++ b/packages/smrt-svelte/src/components/workspace/admin-shell/AdminShell.svelte
@@ -387,7 +387,7 @@ function buildLayoutStyle(shell: ModuleShellState): string {
         {#if focusRail}
           {@render focusRail()}
         {:else if shell.focusTools.length > 0}
-          <nav class="smrt-admin-shell__focus-rail" aria-label="Focus tools">
+          <nav class="smrt-admin-shell__focus-rail" aria-label={t(M['ui.admin_shell.focus_tools'])}>
             {#each shell.focusTools as tool (tool.id)}
               <!-- raw-primitive-allow: shell chrome toggle, not a content button -->
               <button

--- a/packages/smrt-svelte/src/components/workspace/admin-shell/state.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/admin-shell/state.svelte.ts
@@ -183,19 +183,23 @@ export class ShellState {
   openFocusTool(id: string): void {
     untrack(() => {
       if (!this.focusTools.some((tool) => tool.id === id)) return;
-      // Re-clicking the active tool collapses the panel (rail-dock
-      // convention, e.g. VS Code's activity bar) — without this there is no
-      // pointer affordance to close the dock, which traps mobile users.
-      if (this.activeFocusToolId === id && this.panels.right === 'expanded') {
-        this.collapsePanel('right');
-        return;
-      }
       this.activeFocusToolId = id;
       this.settings = mergeShellSettingsDelta(this.settings, {
         activeFocusToolId: id,
       });
       this.expandPanel('right');
       void this.persistSettings();
+    });
+  }
+
+  toggleFocusTool(id: string): void {
+    untrack(() => {
+      if (!this.focusTools.some((tool) => tool.id === id)) return;
+      if (this.activeFocusToolId === id && this.panels.right === 'expanded') {
+        this.collapsePanel('right');
+        return;
+      }
+      this.openFocusTool(id);
     });
   }
 

--- a/packages/smrt-svelte/src/components/workspace/admin-shell/state.svelte.ts
+++ b/packages/smrt-svelte/src/components/workspace/admin-shell/state.svelte.ts
@@ -183,6 +183,13 @@ export class ShellState {
   openFocusTool(id: string): void {
     untrack(() => {
       if (!this.focusTools.some((tool) => tool.id === id)) return;
+      // Re-clicking the active tool collapses the panel (rail-dock
+      // convention, e.g. VS Code's activity bar) — without this there is no
+      // pointer affordance to close the dock, which traps mobile users.
+      if (this.activeFocusToolId === id && this.panels.right === 'expanded') {
+        this.collapsePanel('right');
+        return;
+      }
       this.activeFocusToolId = id;
       this.settings = mergeShellSettingsDelta(this.settings, {
         activeFocusToolId: id,

--- a/packages/smrt-svelte/src/components/workspace/admin-shell/types.ts
+++ b/packages/smrt-svelte/src/components/workspace/admin-shell/types.ts
@@ -81,6 +81,8 @@ export interface ShellFocusTool {
   description?: string;
   order?: number;
   badge?: number | string | null;
+  /** Optional icon component rendered by the default focus rail. */
+  icon?: Component | null;
   component?: Component | null;
   render?: Snippet<[{ tool: ShellFocusTool }]>;
   scopeId?: string;

--- a/packages/smrt-svelte/src/i18n/strings.workspace.ts
+++ b/packages/smrt-svelte/src/i18n/strings.workspace.ts
@@ -38,6 +38,7 @@ export const M = defineMessages({
 
   // components/workspace/admin-shell/*
   'ui.admin_shell.no_focus_tools': 'No focus tools',
+  'ui.admin_shell.focus_tools': 'Focus tools',
   'ui.admin_shell.no_app_panel': 'No app panel',
   'ui.admin_shell.no_system_panel': 'No system panel',
   'ui.admin_shell.shell_shortcuts': 'Shell shortcuts',

--- a/packages/smrt-ui/src/themes/ThemeProvider.svelte
+++ b/packages/smrt-ui/src/themes/ThemeProvider.svelte
@@ -24,6 +24,12 @@ interface Props {
   borderRadius?: ThemeConfig['borderRadius'];
   /** Custom CSS variable overrides */
   overrides?: Record<string, string>;
+  /**
+   * Paint the theme's background/color/font onto the wrapper. Set false when
+   * the host app owns its surface palette and only wants the CSS variables +
+   * scheme context — avoids specificity-fighting `.smrt-theme-root`.
+   */
+  paintSurface?: boolean;
   /** Persist preferences to localStorage */
   persist?: boolean;
   /** Storage key for persistence */
@@ -38,6 +44,7 @@ let {
   primaryColor,
   borderRadius = defaultThemeConfig.borderRadius,
   overrides = {},
+  paintSurface = true,
   persist = defaultThemeConfig.persist,
   storageKey = defaultThemeConfig.storageKey,
   children,
@@ -285,6 +292,7 @@ $effect(() => {
 <div
   class="smrt-theme-root"
   class:dark={isDark}
+  class:no-paint={!paintSurface}
   class:smrt-theme-glass={config.preset === 'glass'}
   style={styleString}
   data-theme={config.preset}
@@ -301,6 +309,12 @@ $effect(() => {
     color: var(--smrt-color-on-background);
     background-color: var(--smrt-color-background);
     font-family: var(--smrt-font-family);
+  }
+
+  .smrt-theme-root.no-paint {
+    color: inherit;
+    background-color: transparent;
+    font-family: inherit;
   }
 
   /* Glass theme specific base styles */

--- a/packages/smrt-ui/src/themes/ThemeProvider.svelte
+++ b/packages/smrt-ui/src/themes/ThemeProvider.svelte
@@ -221,23 +221,51 @@ $effect(() => {
   }
 });
 
-// Sync props to state
-$effect(() => {
-  config.preset = preset;
-});
+// Sync props to state — but only on actual prop changes. config is seeded
+// from the initial props above and onMount applies persisted preferences, so
+// re-asserting the initial prop values here would clobber the persisted
+// choice ($effect order vs onMount is not a safe thing to rely on).
+let prevPreset = untrack(() => preset);
+let prevColorScheme = untrack(() => colorScheme);
+let prevPrimaryColor = untrack(() => primaryColor);
+let prevBorderRadius = untrack(() => borderRadius);
 
 $effect(() => {
-  config.colorScheme = colorScheme;
-});
-
-$effect(() => {
-  if (primaryColor !== undefined) {
-    config.primaryColor = primaryColor;
+  if (preset !== prevPreset) {
+    prevPreset = preset;
+    untrack(() => {
+      config.preset = preset;
+    });
   }
 });
 
 $effect(() => {
-  config.borderRadius = borderRadius;
+  if (colorScheme !== prevColorScheme) {
+    prevColorScheme = colorScheme;
+    untrack(() => {
+      config.colorScheme = colorScheme;
+    });
+  }
+});
+
+$effect(() => {
+  if (primaryColor !== prevPrimaryColor) {
+    prevPrimaryColor = primaryColor;
+    untrack(() => {
+      if (primaryColor !== undefined) {
+        config.primaryColor = primaryColor;
+      }
+    });
+  }
+});
+
+$effect(() => {
+  if (borderRadius !== prevBorderRadius) {
+    prevBorderRadius = borderRadius;
+    untrack(() => {
+      config.borderRadius = borderRadius;
+    });
+  }
 });
 
 // Sync overrides prop to state

--- a/packages/smrt-ui/src/themes/ThemeProvider.svelte
+++ b/packages/smrt-ui/src/themes/ThemeProvider.svelte
@@ -3,7 +3,7 @@ import type { Snippet } from 'svelte';
 import { onMount, untrack } from 'svelte';
 import { setThemeContext, type ThemeContext } from './context.svelte.js';
 import { generateThemeVariables } from './css-generator.js';
-import { getTheme } from './registry.js';
+import { getTheme, isValidPreset } from './registry.js';
 import type {
   ColorScheme,
   Theme,
@@ -108,7 +108,15 @@ const cssVariables = $derived.by(() => {
 // Convert to style string
 const styleString = $derived.by(() => {
   return Object.entries(cssVariables)
-    .map(([key, value]) => `${key}: ${value}`)
+    .map(([key, value]) => {
+      const isExplicitOverride =
+        Object.hasOwn(config.overrides ?? {}, key) ||
+        (key === '--smrt-color-primary' && config.primaryColor);
+      const bootstrapKey = key.replace(/^--smrt-/, '--smrt-bootstrap-');
+      return `${key}: ${
+        isExplicitOverride ? value : `var(${bootstrapKey}, ${value})`
+      }`;
+    })
     .join('; ');
 });
 
@@ -165,10 +173,32 @@ function loadPersistedConfig(): void {
   try {
     const stored = localStorage.getItem(config.storageKey!);
     if (stored) {
-      const data = JSON.parse(stored);
-      if (data.preset) config.preset = data.preset;
-      if (data.colorScheme) config.colorScheme = data.colorScheme;
-      if (data.borderRadius) config.borderRadius = data.borderRadius;
+      const data = JSON.parse(stored) as unknown;
+      if (!data || typeof data !== 'object') return;
+      const persisted = data as Record<string, unknown>;
+      if (
+        typeof persisted.preset === 'string' &&
+        isValidPreset(persisted.preset)
+      ) {
+        config.preset = persisted.preset;
+      }
+      if (
+        persisted.colorScheme === 'light' ||
+        persisted.colorScheme === 'dark' ||
+        persisted.colorScheme === 'system'
+      ) {
+        config.colorScheme = persisted.colorScheme;
+      }
+      if (
+        persisted.borderRadius === 'none' ||
+        persisted.borderRadius === 'sm' ||
+        persisted.borderRadius === 'md' ||
+        persisted.borderRadius === 'lg' ||
+        persisted.borderRadius === 'xl' ||
+        persisted.borderRadius === 'full'
+      ) {
+        config.borderRadius = persisted.borderRadius;
+      }
     }
   } catch {
     // Ignore storage errors (e.g., corrupted data, JSON parse errors)
@@ -225,6 +255,21 @@ $effect(() => {
 
     // Color scheme for browser UI
     html.style.colorScheme = resolvedScheme;
+  }
+});
+
+// The pre-paint aliases only bridge SSR to the hydrated provider. Remove them
+// after the provider has applied the persisted config so later runtime theme
+// changes use the component's reactive variables normally.
+$effect(() => {
+  if (typeof document !== 'undefined' && mounted) {
+    const html = document.documentElement;
+    for (const property of Array.from(html.style)) {
+      if (property.startsWith('--smrt-bootstrap-')) {
+        html.style.removeProperty(property);
+      }
+    }
+    html.removeAttribute('data-smrt-theme-bootstrap');
   }
 });
 

--- a/packages/smrt-ui/src/themes/__tests__/theme-provider.test.ts
+++ b/packages/smrt-ui/src/themes/__tests__/theme-provider.test.ts
@@ -86,4 +86,17 @@ describe('ThemeProvider persistence', () => {
       );
     });
   });
+
+  it('paints the surface by default and opts out via paintSurface=false', async () => {
+    mockSystemDark(false);
+
+    const { container, rerender } = render(ThemeProvider, {
+      props: { children: child() },
+    });
+    const root = container.querySelector('.smrt-theme-root');
+    expect(root).not.toHaveClass('no-paint');
+
+    await rerender({ paintSurface: false, children: child() });
+    expect(root).toHaveClass('no-paint');
+  });
 });

--- a/packages/smrt-ui/src/themes/__tests__/theme-provider.test.ts
+++ b/packages/smrt-ui/src/themes/__tests__/theme-provider.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Regression tests for ThemeProvider persistence behavior.
+ *
+ * Bug: the prop-sync `$effect`s re-asserted the `colorScheme`/`preset` props on
+ * every mount, clobbering the persisted localStorage preference loaded in
+ * `onMount` — a toggled light/dark choice snapped back to the prop (typically
+ * "system") on reload. Fixed by only syncing props on actual prop changes.
+ */
+import { render, waitFor } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ThemeProvider from '../ThemeProvider.svelte';
+
+function child() {
+  return createRawSnippet(() => ({ render: () => '<span>child</span>' }));
+}
+
+function mockSystemDark(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+describe('ThemeProvider persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.removeAttribute('data-color-scheme');
+  });
+
+  it('keeps the persisted color scheme instead of clobbering it with the prop', async () => {
+    localStorage.setItem(
+      'smrt-theme',
+      JSON.stringify({ colorScheme: 'light' }),
+    );
+    mockSystemDark(true); // system is dark; stored choice is light
+
+    render(ThemeProvider, {
+      props: { colorScheme: 'system', children: child() },
+    });
+
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute('data-color-scheme')).toBe(
+        'light',
+      );
+    });
+    // The stored preference must survive too (not rewritten to the prop value)
+    expect(JSON.parse(localStorage.getItem('smrt-theme')!)).toMatchObject({
+      colorScheme: 'light',
+    });
+  });
+
+  it('falls back to the system scheme when nothing is persisted', async () => {
+    mockSystemDark(true);
+
+    render(ThemeProvider, {
+      props: { colorScheme: 'system', children: child() },
+    });
+
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute('data-color-scheme')).toBe(
+        'dark',
+      );
+    });
+  });
+
+  it('still applies prop changes after mount', async () => {
+    mockSystemDark(false);
+
+    const { rerender } = render(ThemeProvider, {
+      props: { colorScheme: 'system', children: child() },
+    });
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute('data-color-scheme')).toBe(
+        'light',
+      );
+    });
+
+    await rerender({ colorScheme: 'dark', children: child() });
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute('data-color-scheme')).toBe(
+        'dark',
+      );
+    });
+  });
+});

--- a/packages/smrt-ui/src/themes/__tests__/theme-provider.test.ts
+++ b/packages/smrt-ui/src/themes/__tests__/theme-provider.test.ts
@@ -99,4 +99,52 @@ describe('ThemeProvider persistence', () => {
     await rerender({ paintSurface: false, children: child() });
     expect(root).toHaveClass('no-paint');
   });
+
+  it('ignores invalid persisted theme values instead of breaking hydration', async () => {
+    localStorage.setItem(
+      'smrt-theme',
+      JSON.stringify({
+        preset: 'not-a-theme',
+        colorScheme: 'sepia',
+        borderRadius: 'enormous',
+      }),
+    );
+    mockSystemDark(false);
+
+    render(ThemeProvider, {
+      props: {
+        preset: 'material',
+        colorScheme: 'system',
+        children: child(),
+      },
+    });
+
+    await waitFor(() => {
+      expect(document.documentElement.getAttribute('data-theme')).toBe(
+        'material',
+      );
+      expect(document.documentElement.getAttribute('data-color-scheme')).toBe(
+        'light',
+      );
+    });
+  });
+
+  it('emits bootstrap-aware SSR variable fallbacks', () => {
+    mockSystemDark(false);
+    const { container } = render(ThemeProvider, {
+      props: { children: child() },
+    });
+    const style =
+      container.querySelector('.smrt-theme-root')?.getAttribute('style') ?? '';
+    const bootstrapBackground = [
+      '--smrt',
+      'bootstrap',
+      'color',
+      'background',
+    ].join('-');
+
+    expect(style).toContain(
+      `--smrt-color-background: var(${bootstrapBackground},`,
+    );
+  });
 });

--- a/packages/smrt-ui/src/themes/__tests__/theme-script.test.ts
+++ b/packages/smrt-ui/src/themes/__tests__/theme-script.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for the themeScript() pre-paint bootstrap generator. The generated
+ * script must mirror ThemeProvider's persistence resolution so apps stop
+ * hand-duplicating it in app.html.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { themeScript } from '../theme-script.js';
+
+function mockSystemDark(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+  })) as unknown as typeof window.matchMedia;
+}
+
+function run(script: string) {
+  // biome-ignore lint/security/noGlobalEval: the browser evals this inline bootstrap; testing that is the point
+  (0, eval)(script);
+}
+
+describe('themeScript', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.removeAttribute('data-color-scheme');
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('resolves system preference when nothing is stored', () => {
+    mockSystemDark(true);
+    run(themeScript({ preset: 'material' }));
+    expect(document.documentElement.getAttribute('data-theme')).toBe(
+      'material',
+    );
+    expect(document.documentElement.getAttribute('data-color-scheme')).toBe(
+      'dark',
+    );
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('honours a stored scheme and preset over system and defaults', () => {
+    mockSystemDark(true);
+    localStorage.setItem(
+      'smrt-theme',
+      JSON.stringify({ preset: 'studio', colorScheme: 'light' }),
+    );
+    run(themeScript({ preset: 'material' }));
+    expect(document.documentElement.getAttribute('data-theme')).toBe('studio');
+    expect(document.documentElement.getAttribute('data-color-scheme')).toBe(
+      'light',
+    );
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  it('uses the custom storageKey', () => {
+    mockSystemDark(false);
+    localStorage.setItem('my-theme', JSON.stringify({ colorScheme: 'dark' }));
+    run(themeScript({ storageKey: 'my-theme' }));
+    expect(document.documentElement.getAttribute('data-color-scheme')).toBe(
+      'dark',
+    );
+  });
+
+  it('tolerates a raw (non-JSON) stored scheme', () => {
+    mockSystemDark(false);
+    localStorage.setItem('smrt-theme', 'dark');
+    run(themeScript());
+    expect(document.documentElement.getAttribute('data-color-scheme')).toBe(
+      'dark',
+    );
+  });
+});

--- a/packages/smrt-ui/src/themes/__tests__/theme-script.test.ts
+++ b/packages/smrt-ui/src/themes/__tests__/theme-script.test.ts
@@ -4,6 +4,9 @@
  * hand-duplicating it in app.html.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTheme, registerTheme } from '../create-theme.js';
+import { generateThemeVariables } from '../css-generator.js';
+import { studioTheme } from '../studio/index.js';
 import { themeScript } from '../theme-script.js';
 
 function mockSystemDark(matches: boolean) {
@@ -20,10 +23,17 @@ function run(script: string) {
 
 describe('themeScript', () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     localStorage.clear();
     document.documentElement.removeAttribute('data-theme');
     document.documentElement.removeAttribute('data-color-scheme');
+    document.documentElement.removeAttribute('data-smrt-theme-bootstrap');
     document.documentElement.classList.remove('dark');
+    for (const property of Array.from(document.documentElement.style)) {
+      if (property.startsWith('--smrt-bootstrap-')) {
+        document.documentElement.style.removeProperty(property);
+      }
+    }
   });
 
   it('resolves system preference when nothing is stored', () => {
@@ -50,6 +60,13 @@ describe('themeScript', () => {
       'light',
     );
     expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(
+      document.documentElement.style.getPropertyValue(
+        '--smrt-bootstrap-color-background',
+      ),
+    ).toBe(
+      generateThemeVariables(studioTheme, false)['--smrt-color-background'],
+    );
   });
 
   it('uses the custom storageKey', () => {
@@ -61,12 +78,107 @@ describe('themeScript', () => {
     );
   });
 
-  it('tolerates a raw (non-JSON) stored scheme', () => {
+  it('does not read stored preferences when persistence is disabled', () => {
     mockSystemDark(false);
-    localStorage.setItem('smrt-theme', 'dark');
+    localStorage.setItem(
+      'smrt-theme',
+      JSON.stringify({ preset: 'studio', colorScheme: 'dark' }),
+    );
+    run(
+      themeScript({
+        persist: false,
+        preset: 'material',
+        defaultColorScheme: 'light',
+      }),
+    );
+    expect(document.documentElement.getAttribute('data-theme')).toBe(
+      'material',
+    );
+    expect(document.documentElement.getAttribute('data-color-scheme')).toBe(
+      'light',
+    );
+  });
+
+  it('ignores a raw (non-JSON) stored value like ThemeProvider', () => {
+    mockSystemDark(true);
+    localStorage.setItem('smrt-theme', 'light');
     run(themeScript());
     expect(document.documentElement.getAttribute('data-color-scheme')).toBe(
       'dark',
     );
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('ignores invalid persisted enum values', () => {
+    mockSystemDark(false);
+    localStorage.setItem(
+      'smrt-theme',
+      JSON.stringify({
+        preset: 'not-a-theme',
+        colorScheme: 'sepia',
+      }),
+    );
+    run(themeScript({ preset: 'material', defaultColorScheme: 'light' }));
+    expect(document.documentElement.getAttribute('data-theme')).toBe(
+      'material',
+    );
+    expect(document.documentElement.getAttribute('data-color-scheme')).toBe(
+      'light',
+    );
+  });
+
+  it('bootstraps a registered custom theme from persistence', () => {
+    const brandTheme = createTheme({
+      id: 'bootstrap-test-brand',
+      name: 'Bootstrap Test Brand',
+      light: { primary: '#336699', background: '#fefefe' },
+      dark: { primary: '#99ccff', background: '#101820' },
+    });
+    registerTheme(brandTheme);
+    mockSystemDark(false);
+    localStorage.setItem(
+      'smrt-theme',
+      JSON.stringify({
+        preset: 'bootstrap-test-brand',
+        colorScheme: 'dark',
+      }),
+    );
+
+    run(themeScript());
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe(
+      'bootstrap-test-brand',
+    );
+    expect(
+      document.documentElement.style.getPropertyValue(
+        '--smrt-bootstrap-color-background',
+      ),
+    ).toBe(generateThemeVariables(brandTheme, true)['--smrt-color-background']);
+  });
+
+  it('still applies the fallback when localStorage access throws', () => {
+    mockSystemDark(true);
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('denied', 'SecurityError');
+    });
+
+    run(themeScript({ preset: 'studio' }));
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('studio');
+    expect(document.documentElement.getAttribute('data-color-scheme')).toBe(
+      'dark',
+    );
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  it('escapes executable inline-script terminators and separators', () => {
+    const script = themeScript({
+      storageKey: '</script><script>alert(1)</script>\u2028\u2029',
+    });
+
+    expect(script.toLowerCase()).not.toContain('</script');
+    expect(script).not.toContain('\u2028');
+    expect(script).not.toContain('\u2029');
+    expect(script).toContain('\\u003c/script>');
   });
 });

--- a/packages/smrt-ui/src/themes/index.ts
+++ b/packages/smrt-ui/src/themes/index.ts
@@ -69,6 +69,8 @@ export { smrtTheme } from './smrt/index.js';
 export { studioTheme } from './studio/index.js';
 // Main components
 export { default as ThemeProvider } from './ThemeProvider.svelte';
+// Pre-paint bootstrap script
+export { type ThemeScriptOptions, themeScript } from './theme-script.js';
 // Types
 export type {
   BorderRadius,

--- a/packages/smrt-ui/src/themes/theme-script.ts
+++ b/packages/smrt-ui/src/themes/theme-script.ts
@@ -1,0 +1,49 @@
+/**
+ * Pre-paint theme bootstrap script generator.
+ *
+ * ThemeProvider resolves the persisted/system color scheme only after mount,
+ * so apps without a pre-paint script flash the wrong scheme on load. Apps used
+ * to hand-duplicate the provider's storage logic in `app.html`; this helper
+ * generates that script from the same config so the two never drift.
+ *
+ * Usage (root layout — SSR renders `svelte:head` into the initial HTML, so the
+ * script runs before first paint):
+ *
+ * ```svelte
+ * <script lang="ts">
+ *   import { themeScript } from '@happyvertical/smrt-ui/themes';
+ * </script>
+ *
+ * <svelte:head>
+ *   {@html `<script>${themeScript({ preset: 'studio' })}</script>`}
+ * </svelte:head>
+ * ```
+ */
+import type { ColorScheme, ThemePreset } from './types.js';
+import { defaultThemeConfig } from './types.js';
+
+export interface ThemeScriptOptions {
+  /** Preset to stamp as `data-theme` when nothing is persisted. */
+  preset?: ThemePreset;
+  /** localStorage key — must match ThemeProvider's `storageKey`. */
+  storageKey?: string;
+  /** Fallback scheme when storage holds no value. Default: 'system'. */
+  defaultColorScheme?: ColorScheme;
+}
+
+/**
+ * Returns the JS body (no `<script>` tags) of a pre-paint bootstrap that
+ * mirrors ThemeProvider's persistence: reads the stored config, resolves
+ * 'system' via matchMedia, then stamps `data-theme`, `data-color-scheme`,
+ * the `dark` class, and `color-scheme` style on <html>.
+ */
+export function themeScript(options: ThemeScriptOptions = {}): string {
+  const preset = options.preset ?? defaultThemeConfig.preset;
+  const storageKey = options.storageKey ?? defaultThemeConfig.storageKey;
+  const fallback = options.defaultColorScheme ?? 'system';
+
+  // Keep this dependency-free and ES5-ish: it runs inline in every browser
+  // before any framework code. Must stay in sync with
+  // ThemeProvider.svelte's loadPersistedConfig()/resolvedScheme.
+  return `(function(){try{var scheme=${JSON.stringify(fallback)};var preset=${JSON.stringify(preset)};var raw=localStorage.getItem(${JSON.stringify(storageKey)});if(raw){try{var data=JSON.parse(raw);if(data.colorScheme)scheme=data.colorScheme;if(data.preset)preset=data.preset;}catch(_){scheme=raw;}}if(scheme==='system'){scheme=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';}var el=document.documentElement;el.setAttribute('data-theme',preset);el.setAttribute('data-color-scheme',scheme);el.classList.toggle('dark',scheme==='dark');el.style.colorScheme=scheme;}catch(_){}})();`;
+}

--- a/packages/smrt-ui/src/themes/theme-script.ts
+++ b/packages/smrt-ui/src/themes/theme-script.ts
@@ -19,31 +19,77 @@
  * </svelte:head>
  * ```
  */
+
+import { generateThemeVariables } from './css-generator.js';
+import { getTheme, getThemeOptions } from './registry.js';
 import type { ColorScheme, ThemePreset } from './types.js';
 import { defaultThemeConfig } from './types.js';
 
 export interface ThemeScriptOptions {
   /** Preset to stamp as `data-theme` when nothing is persisted. */
   preset?: ThemePreset;
+  /** Read persisted preferences. Must match ThemeProvider's `persist` prop. */
+  persist?: boolean;
   /** localStorage key — must match ThemeProvider's `storageKey`. */
   storageKey?: string;
   /** Fallback scheme when storage holds no value. Default: 'system'. */
   defaultColorScheme?: ColorScheme;
 }
 
+function inlineJSON(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+function bootstrapVariableName(variable: string): string {
+  return variable.replace(/^--smrt-/, '--smrt-bootstrap-');
+}
+
 /**
  * Returns the JS body (no `<script>` tags) of a pre-paint bootstrap that
  * mirrors ThemeProvider's persistence: reads the stored config, resolves
  * 'system' via matchMedia, then stamps `data-theme`, `data-color-scheme`,
- * the `dark` class, and `color-scheme` style on <html>.
+ * the `dark` class, and `color-scheme` style on <html>. It also sets temporary
+ * bootstrap variables consumed by ThemeProvider's SSR inline fallbacks, so the
+ * persisted preset/scheme wins before hydration rather than only changing
+ * attributes around an already-painted default wrapper.
  */
 export function themeScript(options: ThemeScriptOptions = {}): string {
-  const preset = options.preset ?? defaultThemeConfig.preset;
+  const presetNames = getThemeOptions().map(({ value }) => value);
+  const requestedPreset = options.preset ?? defaultThemeConfig.preset;
+  const preset = presetNames.includes(requestedPreset)
+    ? requestedPreset
+    : defaultThemeConfig.preset;
+  const persist = options.persist ?? defaultThemeConfig.persist;
   const storageKey = options.storageKey ?? defaultThemeConfig.storageKey;
-  const fallback = options.defaultColorScheme ?? 'system';
+  const requestedFallback =
+    options.defaultColorScheme ?? defaultThemeConfig.colorScheme;
+  const fallback: ColorScheme = ['light', 'dark', 'system'].includes(
+    requestedFallback,
+  )
+    ? requestedFallback
+    : defaultThemeConfig.colorScheme;
+
+  const variableNames = Array.from(
+    new Set(
+      presetNames.flatMap((name) => [
+        ...Object.keys(generateThemeVariables(getTheme(name), false)),
+        ...Object.keys(generateThemeVariables(getTheme(name), true)),
+      ]),
+    ),
+  );
+  const bootstrapNames = variableNames.map(bootstrapVariableName);
+  const variableRows = presetNames.flatMap((name) =>
+    [false, true].map((dark) => {
+      const variables = generateThemeVariables(getTheme(name), dark);
+      return variableNames.map((variable) => variables[variable] ?? '');
+    }),
+  );
 
   // Keep this dependency-free and ES5-ish: it runs inline in every browser
   // before any framework code. Must stay in sync with
   // ThemeProvider.svelte's loadPersistedConfig()/resolvedScheme.
-  return `(function(){try{var scheme=${JSON.stringify(fallback)};var preset=${JSON.stringify(preset)};var raw=localStorage.getItem(${JSON.stringify(storageKey)});if(raw){try{var data=JSON.parse(raw);if(data.colorScheme)scheme=data.colorScheme;if(data.preset)preset=data.preset;}catch(_){scheme=raw;}}if(scheme==='system'){scheme=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';}var el=document.documentElement;el.setAttribute('data-theme',preset);el.setAttribute('data-color-scheme',scheme);el.classList.toggle('dark',scheme==='dark');el.style.colorScheme=scheme;}catch(_){}})();`;
+  return `(function(){try{var presets=${inlineJSON(presetNames)};var names=${inlineJSON(bootstrapNames)};var rows=${inlineJSON(variableRows)};var scheme=${inlineJSON(fallback)};var preset=${inlineJSON(preset)};${persist ? `try{var raw=localStorage.getItem(${inlineJSON(storageKey)});if(raw){var data=JSON.parse(raw);if(data&&typeof data==='object'){if(data.colorScheme==='light'||data.colorScheme==='dark'||data.colorScheme==='system')scheme=data.colorScheme;if(typeof data.preset==='string'&&presets.indexOf(data.preset)!==-1)preset=data.preset;}}}catch(_){}` : ''}if(scheme==='system'){scheme=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';}var el=document.documentElement;el.setAttribute('data-theme',preset);el.setAttribute('data-color-scheme',scheme);el.setAttribute('data-smrt-theme-bootstrap','');el.classList.toggle('dark',scheme==='dark');el.style.colorScheme=scheme;var row=rows[presets.indexOf(preset)*2+(scheme==='dark'?1:0)];for(var i=0;i<names.length;i++){if(row[i])el.style.setProperty(names[i],row[i]);}}catch(_){}})();`;
 }

--- a/packages/subscriptions/src/svelte/PlanPicker.svelte
+++ b/packages/subscriptions/src/svelte/PlanPicker.svelte
@@ -3,9 +3,14 @@
  * Serializable plan shape accepted by PlanPicker. `SubscriptionPlan` model
  * instances satisfy it structurally, but it can also be plain data returned
  * from a SvelteKit `load` — models lose their methods across serialization,
- * so components must not *require* them. Either `featureKeys` (array) or
- * `getFeatureKeys()` (method) provides the feature count.
+ * so components must not *require* them. `featureKeys` is accepted as an
+ * explicit view-model field; `features` supports the framework's normal
+ * serialized model shape; and model instances can still use getFeatureKeys().
  */
+type SerializedFeatureGrant =
+  | string
+  | { featureKey?: string; enabled?: boolean };
+
 export interface PlanPickerPlan {
   id?: string;
   planKey: string;
@@ -15,11 +20,32 @@ export interface PlanPickerPlan {
   currency: string;
   billingInterval: string;
   featureKeys?: string[];
+  features?: string | SerializedFeatureGrant[];
   getFeatureKeys?: () => string[];
 }
 
 function featureCount(plan: PlanPickerPlan): number {
-  return plan.featureKeys?.length ?? plan.getFeatureKeys?.().length ?? 0;
+  if (plan.featureKeys) return plan.featureKeys.length;
+  if (plan.getFeatureKeys) return plan.getFeatureKeys().length;
+
+  try {
+    const features =
+      typeof plan.features === 'string'
+        ? (JSON.parse(plan.features) as unknown)
+        : plan.features;
+    if (!Array.isArray(features)) return 0;
+    return features.filter(
+      (feature) =>
+        typeof feature === 'string' ||
+        (feature !== null &&
+          typeof feature === 'object' &&
+          'featureKey' in feature &&
+          typeof feature.featureKey === 'string' &&
+          feature.enabled !== false),
+    ).length;
+  } catch {
+    return 0;
+  }
 }
 
 let {
@@ -34,7 +60,7 @@ let {
 </script>
 
 <div class="smrt-plan-picker">
-  {#each plans as plan (plan.id)}
+  {#each plans as plan (plan.planKey)}
     <!-- raw-primitive-allow: pressable selection card (aria-pressed toggle with multi-line plan summary), not a standard action button -->
     <button
       aria-pressed={plan.planKey === selectedPlanKey}

--- a/packages/subscriptions/src/svelte/PlanPicker.svelte
+++ b/packages/subscriptions/src/svelte/PlanPicker.svelte
@@ -1,14 +1,35 @@
 <script lang="ts">
-import type { SubscriptionPlan } from '../models/SubscriptionPlan.js';
+/**
+ * Serializable plan shape accepted by PlanPicker. `SubscriptionPlan` model
+ * instances satisfy it structurally, but it can also be plain data returned
+ * from a SvelteKit `load` — models lose their methods across serialization,
+ * so components must not *require* them. Either `featureKeys` (array) or
+ * `getFeatureKeys()` (method) provides the feature count.
+ */
+export interface PlanPickerPlan {
+  id?: string;
+  planKey: string;
+  name: string;
+  description?: string | null;
+  priceAmount: number;
+  currency: string;
+  billingInterval: string;
+  featureKeys?: string[];
+  getFeatureKeys?: () => string[];
+}
+
+function featureCount(plan: PlanPickerPlan): number {
+  return plan.featureKeys?.length ?? plan.getFeatureKeys?.().length ?? 0;
+}
 
 let {
   plans = [],
   selectedPlanKey = null,
   onSelect,
 }: {
-  plans?: SubscriptionPlan[];
+  plans?: PlanPickerPlan[];
   selectedPlanKey?: string | null;
-  onSelect?: (plan: SubscriptionPlan) => void;
+  onSelect?: (plan: PlanPickerPlan) => void;
 } = $props();
 </script>
 
@@ -34,7 +55,7 @@ let {
         <span class="smrt-plan-picker__description">{plan.description}</span>
       {/if}
       <span class="smrt-plan-picker__features">
-        {plan.getFeatureKeys().length} features
+        {featureCount(plan)} features
       </span>
     </button>
   {/each}

--- a/packages/subscriptions/src/svelte/PlanPicker.test.ts
+++ b/packages/subscriptions/src/svelte/PlanPicker.test.ts
@@ -1,0 +1,71 @@
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+import { SubscriptionPlan } from '../models/SubscriptionPlan.js';
+import PlanPicker, { type PlanPickerPlan } from './PlanPicker.svelte';
+import planPickerSource from './PlanPicker.svelte?raw';
+
+describe('PlanPicker', () => {
+  it('keys serialized id-less plans by planKey', () => {
+    const plans: PlanPickerPlan[] = [
+      {
+        planKey: 'starter',
+        name: 'Starter',
+        priceAmount: 0,
+        currency: 'USD',
+        billingInterval: 'month',
+      },
+      {
+        planKey: 'pro',
+        name: 'Pro',
+        priceAmount: 10,
+        currency: 'USD',
+        billingInterval: 'month',
+      },
+    ];
+
+    const { body } = render(PlanPicker, {
+      props: { plans },
+    });
+
+    expect(body.match(/smrt-plan-picker__plan/g)).toHaveLength(2);
+    expect(planPickerSource).toContain('{#each plans as plan (plan.planKey)}');
+  });
+
+  it('counts enabled features from the normal model serialization shape', () => {
+    const plan = new SubscriptionPlan({
+      planKey: 'pro',
+      name: 'Pro',
+      priceAmount: 10,
+      currency: 'USD',
+      billingInterval: 'month',
+      features: JSON.stringify([
+        'smrt:chat',
+        { featureKey: 'smrt:projects', enabled: true },
+        { featureKey: 'smrt:disabled', enabled: false },
+      ]),
+    });
+    const serialized = plan.toJSON() as unknown as PlanPickerPlan;
+
+    const { body } = render(PlanPicker, {
+      props: { plans: [serialized] },
+    });
+
+    expect(body).toContain('2 features');
+  });
+
+  it('treats malformed serialized feature JSON as empty', () => {
+    const plan: PlanPickerPlan = {
+      planKey: 'broken',
+      name: 'Broken',
+      priceAmount: 0,
+      currency: 'USD',
+      billingInterval: 'month',
+      features: '{bad json',
+    };
+    const { body } = render(PlanPicker, {
+      props: { plans: [plan] },
+    });
+
+    expect(body).toContain('0 features');
+  });
+});

--- a/packages/subscriptions/src/svelte/SubscriptionSummary.svelte
+++ b/packages/subscriptions/src/svelte/SubscriptionSummary.svelte
@@ -5,11 +5,27 @@ import { M } from './i18n.js';
 
 let {
   resolution = null,
+  periodEnd = null,
+  periodDisposition = 'unknown',
 }: {
   resolution?: EntitlementResolution | null;
+  /** ISO date string (or null) for the current billing period end. */
+  periodEnd?: string | null;
+  /** How to describe `periodEnd`: renews / ends / perpetual / unknown. */
+  periodDisposition?: 'perpetual' | 'renews' | 'ends' | 'unknown';
 } = $props();
 
 const { t } = useI18n();
+
+const periodLabel = $derived(
+  periodDisposition === 'perpetual'
+    ? t(M['subscriptions.summary.no_expiration'])
+    : periodDisposition === 'renews' && periodEnd
+      ? `${t(M['subscriptions.summary.renews'])} ${new Date(periodEnd).toLocaleDateString()}`
+      : periodDisposition === 'ends' && periodEnd
+        ? `${t(M['subscriptions.summary.ends'])} ${new Date(periodEnd).toLocaleDateString()}`
+        : null,
+);
 </script>
 
 <section class="smrt-subscription-summary">
@@ -30,6 +46,12 @@ const { t } = useI18n();
       <dt>Thresholds</dt>
       <dd>{resolution?.thresholds.length ?? 0}</dd>
     </div>
+    {#if periodLabel}
+      <div>
+        <dt>{t(M['subscriptions.summary.period'])}</dt>
+        <dd>{periodLabel}</dd>
+      </div>
+    {/if}
   </dl>
 </section>
 

--- a/packages/subscriptions/src/svelte/SubscriptionSummary.svelte
+++ b/packages/subscriptions/src/svelte/SubscriptionSummary.svelte
@@ -2,28 +2,46 @@
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import type { EntitlementResolution } from '../types.js';
 import { M } from './i18n.js';
+import { formatPeriodDate } from './subscription-summary.js';
 
 let {
   resolution = null,
   periodEnd = null,
   periodDisposition = 'unknown',
+  periodDateLocale,
+  periodTimeZone = 'UTC',
 }: {
   resolution?: EntitlementResolution | null;
   /** ISO date string (or null) for the current billing period end. */
   periodEnd?: string | null;
   /** How to describe `periodEnd`: renews / ends / perpetual / unknown. */
   periodDisposition?: 'perpetual' | 'renews' | 'ends' | 'unknown';
+  /** Stable locale override for the billing date. Defaults to the i18n locale. */
+  periodDateLocale?: string;
+  /** Billing timezone used by both SSR and hydration. Defaults to UTC. */
+  periodTimeZone?: string;
 } = $props();
 
-const { t } = useI18n();
+const i18n = useI18n();
+const { t } = i18n;
+
+const formattedPeriodEnd = $derived(
+  periodEnd
+    ? formatPeriodDate(
+        periodEnd,
+        periodDateLocale ?? i18n.locale,
+        periodTimeZone,
+      )
+    : null,
+);
 
 const periodLabel = $derived(
   periodDisposition === 'perpetual'
     ? t(M['subscriptions.summary.no_expiration'])
-    : periodDisposition === 'renews' && periodEnd
-      ? `${t(M['subscriptions.summary.renews'])} ${new Date(periodEnd).toLocaleDateString()}`
-      : periodDisposition === 'ends' && periodEnd
-        ? `${t(M['subscriptions.summary.ends'])} ${new Date(periodEnd).toLocaleDateString()}`
+    : periodDisposition === 'renews' && formattedPeriodEnd
+      ? `${t(M['subscriptions.summary.renews'])} ${formattedPeriodEnd}`
+      : periodDisposition === 'ends' && formattedPeriodEnd
+        ? `${t(M['subscriptions.summary.ends'])} ${formattedPeriodEnd}`
         : null,
 );
 </script>

--- a/packages/subscriptions/src/svelte/SubscriptionSummary.test.ts
+++ b/packages/subscriptions/src/svelte/SubscriptionSummary.test.ts
@@ -1,0 +1,40 @@
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+import SubscriptionSummary from './SubscriptionSummary.svelte';
+
+describe('SubscriptionSummary', () => {
+  it('renders period dates with a deterministic locale and timezone', () => {
+    const { body } = render(SubscriptionSummary, {
+      props: {
+        periodDisposition: 'renews',
+        periodEnd: '2026-07-01T00:00:00Z',
+      },
+    });
+
+    expect(body).toContain('Jul 1, 2026');
+  });
+
+  it('honours an explicit billing timezone', () => {
+    const { body } = render(SubscriptionSummary, {
+      props: {
+        periodDisposition: 'ends',
+        periodEnd: '2026-07-01T00:00:00Z',
+        periodTimeZone: 'America/Edmonton',
+      },
+    });
+
+    expect(body).toContain('Jun 30, 2026');
+  });
+
+  it('does not render an invalid billing date', () => {
+    const { body } = render(SubscriptionSummary, {
+      props: {
+        periodDisposition: 'renews',
+        periodEnd: 'not-a-date',
+      },
+    });
+
+    expect(body).not.toContain('Invalid Date');
+    expect(body).not.toContain('Period');
+  });
+});

--- a/packages/subscriptions/src/svelte/i18n.ts
+++ b/packages/subscriptions/src/svelte/i18n.ts
@@ -7,5 +7,9 @@ import { defineMessages } from '@happyvertical/smrt-ui/i18n';
 export const M = defineMessages({
   'subscriptions.commercial.overview_label': 'Commercial usage overview',
   'subscriptions.summary.current_plan': 'Current plan',
+  'subscriptions.summary.ends': 'Ends',
   'subscriptions.summary.no_active_plan': 'No active plan',
+  'subscriptions.summary.no_expiration': 'No expiration',
+  'subscriptions.summary.period': 'Billing period',
+  'subscriptions.summary.renews': 'Renews',
 });

--- a/packages/subscriptions/src/svelte/index.ts
+++ b/packages/subscriptions/src/svelte/index.ts
@@ -1,5 +1,6 @@
 export type { CommercialMetricView } from './CommercialOverview.svelte';
 export { default as CommercialOverview } from './CommercialOverview.svelte';
+export type { PlanPickerPlan } from './PlanPicker.svelte';
 export { default as PlanPicker } from './PlanPicker.svelte';
 export { default as SubscriptionSummary } from './SubscriptionSummary.svelte';
 export { default as UsageThresholds } from './UsageThresholds.svelte';

--- a/packages/subscriptions/src/svelte/index.ts
+++ b/packages/subscriptions/src/svelte/index.ts
@@ -3,4 +3,5 @@ export { default as CommercialOverview } from './CommercialOverview.svelte';
 export type { PlanPickerPlan } from './PlanPicker.svelte';
 export { default as PlanPicker } from './PlanPicker.svelte';
 export { default as SubscriptionSummary } from './SubscriptionSummary.svelte';
+export { formatPeriodDate } from './subscription-summary.js';
 export { default as UsageThresholds } from './UsageThresholds.svelte';

--- a/packages/subscriptions/src/svelte/subscription-summary.ts
+++ b/packages/subscriptions/src/svelte/subscription-summary.ts
@@ -1,0 +1,17 @@
+export function formatPeriodDate(
+  value: string,
+  locale = 'en-US',
+  timeZone = 'UTC',
+): string | null {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      dateStyle: 'medium',
+      timeZone,
+    }).format(date);
+  } catch {
+    return null;
+  }
+}

--- a/packages/subscriptions/vitest.config.ts
+++ b/packages/subscriptions/vitest.config.ts
@@ -1,8 +1,9 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'vitest/config';
 import { smrtVitestPlugin } from '../vitest/src/index.ts';
 
 export default defineConfig({
-  plugins: [smrtVitestPlugin({ verbose: true })],
+  plugins: [smrtVitestPlugin({ verbose: true }), svelte()],
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
## Summary

Upstreams the recurring theme, shell, form-layout, and subscription UI fixes that consuming apps had been carrying locally. The branch is rebased onto current `main`; stale policy/dependency cleanup commits were dropped because `main` already contains their successors.

Fixes #2114.

### smrt-ui themes

- ThemeProvider preserves persisted preset/scheme state, validates stored enum values, and supports `paintSurface={false}`.
- `themeScript()` provides an inline-safe pre-paint bootstrap that mirrors ThemeProvider, handles blocked/corrupt storage, supports registered custom themes, and bridges the provider's SSR variables until hydration.
- The bootstrap escapes script terminators and Unicode separators before use through `{@html}`.

### smrt-svelte shell and forms

- AdminShell supplies a default registered-tool focus rail, localized accessibility text, stable three-track corner layout, and self-contained rail/panel box sizing.
- Imperative `openFocusTool()` remains idempotent; rail clicks use the separate toggle operation.
- Number/date-time native inputs now shrink correctly in narrow tracks; the other form controls no longer impose hard minimum widths.

### subscriptions

- PlanPicker accepts live models or serialized DTOs, keys by required `planKey`, and reads the normal serialized `features` representation safely.
- SubscriptionSummary accepts period disposition/end data and formats billing dates deterministically with the active i18n locale and an explicit UTC-default timezone.

## Review fixes

- Addressed both Copilot threads by ignoring raw non-JSON persistence consistently in the bootstrap and provider.
- Closed independent review findings for inline-script injection, invalid persisted themes, custom-theme first paint, duplicate plan keys, serialized feature counts, right-only corner tracks, focus-tool semantics, native-input overflow, storage access failures, and SSR date determinism.

## Validation

- smrt-ui full suite: 489 tests passed before the final custom-theme regression; 15/15 focused theme tests pass at the final head.
- smrt-svelte full suite passed; 51/51 focused shell/form tests pass at the final head.
- subscriptions full suite: 83/83 tests passed.
- `svelte-check`: 0 errors and 0 warnings in all three affected packages.
- Affected package builds and full 62-package root build passed.
- `pnpm audit:policy`, strict changed knowledge check, format, token, primitive, color, spacing, radius, typography, elevation, package-DAG, and workflow gates passed.
- Two independent review-cycle passes ended CLEAN.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019f9cb9-d908-7b32-96f1-e6b2edabb038","issue":2114,"policy_revision":"1.0.0","validation":["smrt-ui tests passed; final focused theme tests 15/15","smrt-svelte tests passed; focused shell/form tests 51/51","subscriptions tests 83/83","affected svelte-check: 0 errors and 0 warnings","affected builds and full root build passed","pnpm audit:policy passed","strict changed knowledge freshness passed","pre-push repository gates passed","review-cycle: clean"]}
```