### PR TITLE
fix(scanner): resolve @smrt() config spreads instead of dropping them

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -290,11 +290,25 @@ jobs:
       # through its package exports, which need a build — without this the
       # config fails to load, vitest emits no coverage, and the gate reports
       # "no coverage produced" as if the package were below its floor (#2103).
-      # setup-environment restores the build job's per-SHA Turbo cache, so this
-      # is a cache hit rather than a cold rebuild.
+      #
+      # In affected mode the `build` job is skipped (`build.if: mode == full`),
+      # so a full `pnpm run build` here would be a cold whole-workspace build.
+      # The gate only measures TOUCHED packages, so building `[BASE_SHA]...`
+      # (changed packages plus their dependency closure) is sufficient and much
+      # smaller — for a one-package change it selects ~22 of ~60 packages.
+      # Fall back to a full build when no PR base is available (full mode,
+      # merge_group), where the seeded Turbo cache makes it cheap anyway.
       - name: Build packages
-        run: pnpm run build
+        run: |
+          if [ -n "$BASE_SHA" ]; then
+            echo "Building affected closure from $BASE_SHA"
+            pnpm turbo run build --filter="[$BASE_SHA]..."
+          else
+            echo "No PR base available; building full workspace"
+            pnpm run build
+          fi
         env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Sweep S6 (#1411): per-tier line-coverage floors (T1 80 / T2 70 / T3 50)

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -291,24 +291,25 @@ jobs:
       # config fails to load, vitest emits no coverage, and the gate reports
       # "no coverage produced" as if the package were below its floor (#2103).
       #
-      # In affected mode the `build` job is skipped (`build.if: mode == full`),
-      # so a full `pnpm run build` here would be a cold whole-workspace build.
-      # The gate only measures TOUCHED packages, so building `[BASE_SHA]...`
-      # (changed packages plus their dependency closure) is sufficient and much
-      # smaller — for a one-package change it selects ~22 of ~60 packages.
-      # Fall back to a full build when no PR base is available (full mode,
-      # merge_group), where the seeded Turbo cache makes it cheap anyway.
+      # This MUST be a full build — a dependency-graph filter cannot work here.
+      # The packages that need `dist/` are pulled in by each package's
+      # vitest.config.ts via a RELATIVE path (`../vitest/src`), not by a
+      # package.json dependency, so Turbo's graph cannot see the relationship.
+      # packages/scanner is the clearest case: it declares no workspace
+      # dependencies at all, yet its vitest config transitively needs a built
+      # @happyvertical/smrt-core. `--filter="[$BASE_SHA]..."` therefore selects
+      # only scanner itself ("Running build in 2 packages"), core is never
+      # built, and the gate still reports "no coverage produced" — verified on
+      # PR #2102. Measured turbo selections from that base:
+      #   [sha]     -> 2 packages      ...[sha] -> 53 packages
+      #   [sha]...  -> 2 packages      scanner... -> 1 package
+      # setup-environment restores the build job's per-SHA Turbo cache, so in
+      # full mode this is a cache hit. In affected mode the `build` job is
+      # skipped (`build.if: mode == full`), so this can be a cold build; that
+      # cost is accepted because correctness of the gate comes first.
       - name: Build packages
-        run: |
-          if [ -n "$BASE_SHA" ]; then
-            echo "Building affected closure from $BASE_SHA"
-            pnpm turbo run build --filter="[$BASE_SHA]..."
-          else
-            echo "No PR base available; building full workspace"
-            pnpm run build
-          fi
+        run: pnpm run build
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Sweep S6 (#1411): per-tier line-coverage floors (T1 80 / T2 70 / T3 50)

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -284,6 +284,19 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           auth-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Build first so workspace `dist/` output exists before vitest loads each
+      # touched package's config. Packages whose vitest.config.ts pulls the SMRT
+      # plugin from source (`../vitest/src`) resolve `@happyvertical/smrt-core`
+      # through its package exports, which need a build — without this the
+      # config fails to load, vitest emits no coverage, and the gate reports
+      # "no coverage produced" as if the package were below its floor (#2103).
+      # setup-environment restores the build job's per-SHA Turbo cache, so this
+      # is a cache hit rather than a cold rebuild.
+      - name: Build packages
+        run: pnpm run build
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Sweep S6 (#1411): per-tier line-coverage floors (T1 80 / T2 70 / T3 50)
       # on the packages this PR touches. Blocks regressions below the floor
       # without forcing repo-wide uplift (that uplift is Wave 3). Floors + tier

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -158,4 +158,7 @@ emitDecoratorMetadata: true`.
 - **Smart cloning**: arrays/objects shallow-cloned in property init to prevent aliasing (Issue #22)
 - **Table verification cache**: `isTableVerified(dbUrl, tableName)` avoids redundant `tableExists()` calls
 - **Manifest required**: build-time AST scanning creates manifest. Without vitest plugin → "No field metadata"
+- **ManifestBuilder fails on scanner errors**: every production manifest path
+  must abort before adapting partial scan results. A syntax error or unresolved
+  `@smrt()` config spread cannot be allowed to emit a default-open manifest.
 - **Vite plugin loads scanner from `dist/` first**: `src/vite-plugin/import-build-aware.ts` prefers `dist/` when it exists on disk; it only falls back to `src/` on fresh clones. So if you edit `src/scanner/*.ts` or `src/schema/generator.ts` and want those edits reflected in consumer manifest generation, you must rebuild (`pnpm build` or have `pnpm dev` / `pnpm build:watch` running in core). This is intentional — sniffing `.ts` vs `.js` via `import.meta.url` was non-deterministic under tsx and broke 12–13 publishes (#1139).

--- a/packages/core/src/manifest/__tests__/generator-coverage.test.ts
+++ b/packages/core/src/manifest/__tests__/generator-coverage.test.ts
@@ -247,4 +247,27 @@ describe('ManifestBuilder coverage', () => {
       expect(obj.filePath).not.toContain('\\');
     }
   });
+
+  it('aborts instead of emitting a manifest from scan errors', async () => {
+    writeFileSync(
+      join(dir, 'src', 'unsafe.ts'),
+      `import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { IMPORTED_SURFACE } from './shared.js';
+
+@smrt({ ...IMPORTED_SURFACE })
+class Unsafe extends SmrtObject {}
+`,
+    );
+
+    const builder = new ManifestBuilder();
+    process.chdir(dir);
+
+    await expect(
+      builder.generate({
+        include: ['src/**/*.ts'],
+        outputDir: join(dir, 'out'),
+        generateTypeStub: false,
+      }),
+    ).rejects.toThrow(/Build aborted due to 1 scan error/);
+  });
 });

--- a/packages/core/src/manifest/generator.ts
+++ b/packages/core/src/manifest/generator.ts
@@ -278,6 +278,22 @@ export class ManifestBuilder {
     });
 
     const { results, resolved } = await scanner.scanAndResolve();
+    const scanErrors = results.errors.filter(
+      (diagnostic) => diagnostic.severity === 'error',
+    );
+    if (scanErrors.length > 0) {
+      const detail = scanErrors
+        .map((diagnostic) => {
+          const where = diagnostic.line
+            ? `${diagnostic.filePath}:${diagnostic.line}`
+            : diagnostic.filePath;
+          return `${where} — ${diagnostic.message}`;
+        })
+        .join('; ');
+      throw new Error(
+        `[smrt] Build aborted due to ${scanErrors.length} scan error(s): ${detail}`,
+      );
+    }
 
     // Read package.json for metadata
     let packageName: string | undefined;

--- a/packages/core/src/utils/scanner-module.ts
+++ b/packages/core/src/utils/scanner-module.ts
@@ -8,6 +8,7 @@ export interface OxcScannerLike {
         filePath: string;
         message: string;
         line?: number;
+        severity: 'error' | 'warning';
       }>;
     };
     resolved: unknown[];

--- a/packages/scanner/AGENTS.md
+++ b/packages/scanner/AGENTS.md
@@ -67,3 +67,12 @@ executes the source.
   unwrapped from their `UnaryExpression` before the check.
 - **Static property capture**: captures `uiSlots` and `adminRoutes` for agent
   manifest generation.
+- **`@smrt()` config spreads resolve only against same-file `const`s** (issue
+  #2100). `@smrt({ ...INTERNAL_SURFACE })` works when `INTERNAL_SURFACE` is a
+  module-scope `const` object literal in the same file (`as const` and
+  `export const` included); a constant may spread an earlier constant. Anything
+  else — an imported constant, a `let`, a function call, a spread inside an
+  include array — is reported as a `severity: 'error'` scan diagnostic, never
+  silently dropped. Silence would be unsafe: a dropped spread can remove
+  `api`/`mcp`/`cli`, and an ABSENT surface key means default-open full CRUD, so
+  a quiet drop turns a deliberate lockdown into a published surface.

--- a/packages/scanner/AGENTS.md
+++ b/packages/scanner/AGENTS.md
@@ -67,15 +67,19 @@ executes the source.
   unwrapped from their `UnaryExpression` before the check.
 - **Static property capture**: captures `uiSlots` and `adminRoutes` for agent
   manifest generation.
-- **`@smrt()` config spreads resolve only against same-file `const`s** (issue
+- **`@smrt()` config spreads resolve only against unescaped same-file `const`s** (issue
   #2100). `@smrt({ ...INTERNAL_SURFACE })` works when `INTERNAL_SURFACE` is a
   module-scope `const` object literal in the same file (`as const` and
   `export const` included); a constant may spread an earlier constant. Anything
-  else — an imported constant, a `let`, a function call, a spread inside an
-  include array — is reported as a `severity: 'error'` scan diagnostic, never
-  silently dropped. Silence would be unsafe: a dropped spread can remove
-  `api`/`mcp`/`cli`, and an ABSENT surface key means default-open full CRUD, so
-  a quiet drop turns a deliberate lockdown into a published surface.
+  else — an imported constant, a `let`, a function call, a computed non-literal
+  key, shorthand or non-literal value, mutation/alias/escape, or a spread inside
+  an include array — is reported as a `severity: 'error'` scan diagnostic,
+  never silently dropped. `const` prevents rebinding but not property mutation,
+  and object spread is shallow, so only binding-aware spread references whose
+  shared nested values remain safe through the decorator use are trusted.
+  Silence would be unsafe: a dropped spread can remove `api`/`mcp`/`cli`, and an
+  ABSENT surface key means default-open full CRUD, so a quiet drop turns a
+  deliberate lockdown into a published surface.
   A constant whose own initializer holds an unresolvable spread
   (`const CFG = { ...IMPORTED }`) is tracked as **tainted**: it still resolves,
   but its taint replays into the diagnostics of every decorator that spreads

--- a/packages/scanner/AGENTS.md
+++ b/packages/scanner/AGENTS.md
@@ -76,3 +76,8 @@ executes the source.
   silently dropped. Silence would be unsafe: a dropped spread can remove
   `api`/`mcp`/`cli`, and an ABSENT surface key means default-open full CRUD, so
   a quiet drop turns a deliberate lockdown into a published surface.
+  A constant whose own initializer holds an unresolvable spread
+  (`const CFG = { ...IMPORTED }`) is tracked as **tainted**: it still resolves,
+  but its taint replays into the diagnostics of every decorator that spreads
+  it, transitively through constant chains. Without that the silent drop simply
+  moves one level up. An unused tainted constant reports nothing.

--- a/packages/scanner/src/__tests__/decorator-config-spread.test.ts
+++ b/packages/scanner/src/__tests__/decorator-config-spread.test.ts
@@ -62,6 +62,30 @@ describe('@smrt() config spread resolution (#2100)', () => {
     expect(config).toMatchObject({ api: false, cli: false, mcp: false });
   });
 
+  it('resolves a spread through an angle-bracket const assertion', () => {
+    const { config, errors } = configOf(`
+      const INTERNAL_SURFACES = <const>{ api: false, cli: false, mcp: false };
+
+      @smrt({ ...INTERNAL_SURFACES })
+      class AssistanceRequest extends SmrtObject {}
+    `);
+
+    expect(errors).toHaveLength(0);
+    expect(config).toMatchObject({ api: false, cli: false, mcp: false });
+  });
+
+  it('unwraps assertions and parentheses around the decorator config', () => {
+    const { config, errors } = configOf(`
+      const INTERNAL_SURFACE = { api: false, mcp: false };
+
+      @smrt(({ ...INTERNAL_SURFACE, cli: false }) as const)
+      class Widget extends SmrtObject {}
+    `);
+
+    expect(errors).toHaveLength(0);
+    expect(config).toMatchObject({ api: false, cli: false, mcp: false });
+  });
+
   it('resolves a spread of an exported const', () => {
     const { config, errors } = configOf(`
       export const SHARED = { api: false, mcp: false };
@@ -144,6 +168,18 @@ describe('@smrt() config spread resolution (#2100)', () => {
     expect(config).toMatchObject({ api: false, mcp: false });
   });
 
+  it('resolves a computed literal property key', () => {
+    const { config, errors } = configOf(`
+      const INTERNAL_SURFACE = { api: true, ['api']: false };
+
+      @smrt({ ...INTERNAL_SURFACE })
+      class Widget extends SmrtObject {}
+    `);
+
+    expect(errors).toHaveLength(0);
+    expect(config?.api).toBe(false);
+  });
+
   describe('unresolvable spreads fail loud', () => {
     it('reports an imported constant as a scan error', () => {
       // Cross-file resolution is out of scope; the point is that it must not
@@ -194,6 +230,232 @@ describe('@smrt() config spread resolution (#2100)', () => {
       `);
 
       expect(errors).toHaveLength(1);
+    });
+
+    it('reports shorthand values instead of serializing identifier names', () => {
+      const { errors } = configOf(`
+        const api = false;
+        const CFG = { api };
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('api');
+    });
+
+    it('reports explicit identifier values instead of serializing their names', () => {
+      const { errors } = configOf(`
+        const CLOSED = false;
+        const CFG = { api: CLOSED };
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('CLOSED');
+    });
+
+    it('reports call-expression values instead of serializing source text', () => {
+      const { errors } = configOf(`
+        const CFG = { api: lockdown() };
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('lockdown()');
+    });
+
+    it('reports member-expression values instead of serializing source text', () => {
+      const { errors } = configOf(`
+        const CFG = { api: policy.closed };
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('policy.closed');
+    });
+
+    it('reports a computed non-literal property key', () => {
+      const { errors } = configOf(`
+        const key = 'api';
+        const CFG = { [key]: false };
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('[key]');
+    });
+
+    it('reports a config object that is mutated after declaration', () => {
+      const { errors } = configOf(`
+        const CFG = { api: true };
+        CFG.api = false;
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('CFG');
+    });
+
+    it('reports a config object that escapes through an alias', () => {
+      const { errors } = configOf(`
+        const CFG = { api: false };
+        const ALIAS = CFG;
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('CFG');
+    });
+
+    it('propagates a prior mutation through a derived constant', () => {
+      const { errors } = configOf(`
+        const BASE = { api: true };
+        BASE.api = false;
+        const CFG = { ...BASE };
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('BASE');
+    });
+
+    it('propagates a later nested mutation through a shallow object spread', () => {
+      const { errors } = configOf(`
+        const BASE = { api: { include: ['list', 'delete'] } };
+        const CFG = { ...BASE };
+        BASE.api.include.pop();
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('BASE');
+    });
+
+    it('propagates derived-object mutation back to shared nested dependencies', () => {
+      const { errors } = configOf(`
+        const CFG = { api: { include: ['list', 'delete'] } };
+        const ALIAS = { ...CFG };
+        ALIAS.api.include.pop();
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('ALIAS');
+    });
+
+    it('taints a nested-value spread that escapes inline', () => {
+      const { errors } = configOf(`
+        const CFG = { api: { include: ['list', 'delete'] } };
+        consume({ ...CFG });
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('CFG');
+    });
+
+    it('taints an escaping spread nested in another constant initializer', () => {
+      const { errors } = configOf(`
+        const CFG = { api: { include: ['list', 'delete'] } };
+        const ALIAS = { result: consume({ ...CFG }) };
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('CFG');
+    });
+
+    it('does not confuse a shadowed local binding with the module constant', () => {
+      const { config, errors } = configOf(`
+        const CFG = { api: false };
+        function inspect(CFG: string) {
+          return CFG;
+        }
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(0);
+      expect(config?.api).toBe(false);
+    });
+
+    it('ignores type-only references to the module constant', () => {
+      const { config, errors } = configOf(`
+        const CFG = { api: false };
+        type Surface = typeof CFG;
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(0);
+      expect(config?.api).toBe(false);
+    });
+
+    it('does not confuse a noncomputed member name with the module constant', () => {
+      const { config, errors } = configOf(`
+        const CFG = { api: false };
+        console.log(other.CFG);
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(0);
+      expect(config?.api).toBe(false);
+    });
+
+    it('does not taint a decorator for a later mutation', () => {
+      const { config, errors } = configOf(`
+        const CFG = { api: false };
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+
+        CFG.api = true;
+      `);
+
+      expect(errors).toHaveLength(0);
+      expect(config?.api).toBe(false);
+    });
+
+    it('retains later taint when a decorator spread shares nested values', () => {
+      const { errors } = configOf(`
+        const CFG = { api: { include: ['list', 'delete'] } };
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+
+        CFG.api.include.pop();
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('CFG');
     });
 
     // Without this, the silent-drop failure mode returns one level removed:

--- a/packages/scanner/src/__tests__/decorator-config-spread.test.ts
+++ b/packages/scanner/src/__tests__/decorator-config-spread.test.ts
@@ -195,6 +195,55 @@ describe('@smrt() config spread resolution (#2100)', () => {
 
       expect(errors).toHaveLength(1);
     });
+
+    // Without this, the silent-drop failure mode returns one level removed:
+    // the constant resolves to a PARTIAL object, the decorator spread of it
+    // succeeds, and nothing anywhere records that keys went missing.
+    it('reports when a spread constant was itself built from an unresolvable spread', () => {
+      const { errors } = configOf(`
+        import { IMPORTED } from './shared.js';
+
+        const CFG = { ...IMPORTED, mcp: false };
+
+        @smrt({ ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(errors[0].message).toContain('IMPORTED');
+    });
+
+    it('propagates taint transitively through a chain of constants', () => {
+      const { errors } = configOf(`
+        import { IMPORTED } from './shared.js';
+
+        const BASE = { ...IMPORTED };
+        const MIDDLE = { ...BASE, cli: false };
+        const FINAL = { ...MIDDLE };
+
+        @smrt({ ...FINAL })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+      expect(errors[0].message).toContain('IMPORTED');
+    });
+
+    it('stays quiet when a tainted constant is never used by a decorator', () => {
+      // The constant may exist for unrelated runtime purposes; only a decorator
+      // that actually depends on it has a manifest correctness problem.
+      const { config, errors } = configOf(`
+        import { IMPORTED } from './shared.js';
+
+        const UNUSED = { ...IMPORTED };
+
+        @smrt({ api: false, cli: false, mcp: false })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(0);
+      expect(config).toMatchObject({ api: false, cli: false, mcp: false });
+    });
   });
 
   it('does not let a spread carry prototype-pollution keys', () => {

--- a/packages/scanner/src/__tests__/decorator-config-spread.test.ts
+++ b/packages/scanner/src/__tests__/decorator-config-spread.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Regression tests for spread resolution in `@smrt()` decorator config.
+ *
+ * Root cause (issue #2100): the parser skipped `SpreadElement` when extracting
+ * the decorator config, so a class that declared its surface policy through a
+ * shared constant — `@smrt({ ...INTERNAL_SURFACE })` — had `api`/`cli`/`mcp`
+ * silently erased from the manifest. Because an ABSENT surface key means
+ * default-open full CRUD (only an explicit `false` closes it), that turned a
+ * deliberate lockdown into a published surface for every manifest-driven
+ * consumer (MCP discovery, codegen, cross-package registration).
+ *
+ * Two guarantees are covered here:
+ *  1. Module-scope `const` object literals in the same file ARE resolved.
+ *  2. Anything NOT statically resolvable is reported as a `severity: 'error'`
+ *     scan diagnostic rather than silently dropped — fail loud, never quiet.
+ *
+ * @see https://github.com/happyvertical/smrt/issues/2100
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseSource } from '../oxc-parser.js';
+
+const PREAMBLE = `import { SmrtObject, smrt } from '@happyvertical/smrt-core';`;
+
+function configOf(source: string) {
+  const result = parseSource(`${PREAMBLE}\n${source}`);
+  return {
+    config: result.classes[0]?.decoratorConfig,
+    errors: result.errors.filter((e) => e.severity === 'error'),
+  };
+}
+
+describe('@smrt() config spread resolution (#2100)', () => {
+  it('resolves a module-scope const spread into the config', () => {
+    const { config, errors } = configOf(`
+      const INTERNAL_SURFACE = { api: false, cli: false, mcp: false };
+
+      @smrt({ tableName: 'widgets', ...INTERNAL_SURFACE })
+      class Widget extends SmrtObject {}
+    `);
+
+    expect(errors).toHaveLength(0);
+    expect(config).toMatchObject({
+      tableName: 'widgets',
+      api: false,
+      cli: false,
+      mcp: false,
+    });
+  });
+
+  it('resolves a spread through an `as const` assertion', () => {
+    // packages/projects/src/models/delivery-control-plane.ts uses this exact
+    // shape — the `as const` wrapper must be transparent.
+    const { config, errors } = configOf(`
+      const INTERNAL_SURFACES = { api: false, cli: false, mcp: false } as const;
+
+      @smrt({ tableName: 'assistance_requests', ...INTERNAL_SURFACES })
+      class AssistanceRequest extends SmrtObject {}
+    `);
+
+    expect(errors).toHaveLength(0);
+    expect(config).toMatchObject({ api: false, cli: false, mcp: false });
+  });
+
+  it('resolves a spread of an exported const', () => {
+    const { config, errors } = configOf(`
+      export const SHARED = { api: false, mcp: false };
+
+      @smrt({ ...SHARED })
+      class Widget extends SmrtObject {}
+    `);
+
+    expect(errors).toHaveLength(0);
+    expect(config).toMatchObject({ api: false, mcp: false });
+  });
+
+  it('preserves nested object values from the spread constant', () => {
+    // packages/reports spreads a `cli` include-list; the nested object must
+    // survive intact, not collapse to a bare `true`.
+    const { config, errors } = configOf(`
+      const INTERNAL_SURFACE = {
+        api: false,
+        cli: { include: ['list', 'get'], skipApiCheck: true, http: false },
+        mcp: false,
+      };
+
+      @smrt({ tableName: '_smrt_report_runs', ...INTERNAL_SURFACE })
+      class SmrtReportRun extends SmrtObject {}
+    `);
+
+    expect(errors).toHaveLength(0);
+    expect(config).toMatchObject({
+      tableName: '_smrt_report_runs',
+      api: false,
+      mcp: false,
+      cli: { include: ['list', 'get'], skipApiCheck: true, http: false },
+    });
+  });
+
+  describe('precedence follows source order, matching runtime semantics', () => {
+    it('lets a spread override an earlier explicit key', () => {
+      const { config } = configOf(`
+        const CFG = { api: false };
+
+        @smrt({ api: true, ...CFG })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(config?.api).toBe(false);
+    });
+
+    it('lets an explicit key override an earlier spread', () => {
+      const { config } = configOf(`
+        const CFG = { api: false };
+
+        @smrt({ ...CFG, api: true })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(config?.api).toBe(true);
+    });
+  });
+
+  it('resolves a constant that itself spreads an earlier constant', () => {
+    const { config, errors } = configOf(`
+      const BASE = { api: false, mcp: false };
+      const EXTENDED = { ...BASE, cli: false };
+
+      @smrt({ ...EXTENDED })
+      class Widget extends SmrtObject {}
+    `);
+
+    expect(errors).toHaveLength(0);
+    expect(config).toMatchObject({ api: false, mcp: false, cli: false });
+  });
+
+  it('resolves an inline object spread', () => {
+    const { config, errors } = configOf(`
+      @smrt({ ...{ api: false }, mcp: false })
+      class Widget extends SmrtObject {}
+    `);
+
+    expect(errors).toHaveLength(0);
+    expect(config).toMatchObject({ api: false, mcp: false });
+  });
+
+  describe('unresolvable spreads fail loud', () => {
+    it('reports an imported constant as a scan error', () => {
+      // Cross-file resolution is out of scope; the point is that it must not
+      // silently vanish, because the dropped keys default to OPEN.
+      const { errors } = configOf(`
+        import { IMPORTED_SURFACE } from './shared.js';
+
+        @smrt({ ...IMPORTED_SURFACE })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('IMPORTED_SURFACE');
+      expect(errors[0].line).toBeGreaterThan(0);
+    });
+
+    it('does not treat `let` as a static constant', () => {
+      // A `let` binding could be reassigned between declaration and decorator
+      // evaluation, so resolving it would be unsound.
+      const { errors } = configOf(`
+        let MUTABLE = { api: false };
+
+        @smrt({ ...MUTABLE })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('MUTABLE');
+    });
+
+    it('reports a spread inside an include array', () => {
+      // Dropping an element silently shrinks an allowlist.
+      const { errors } = configOf(`
+        const BASE_ACTIONS = ['list', 'get'];
+
+        @smrt({ cli: { include: [...BASE_ACTIONS, 'archive'] } })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('BASE_ACTIONS');
+    });
+
+    it('reports a call-expression spread', () => {
+      const { errors } = configOf(`
+        @smrt({ ...buildSurface() })
+        class Widget extends SmrtObject {}
+      `);
+
+      expect(errors).toHaveLength(1);
+    });
+  });
+
+  it('does not let a spread carry prototype-pollution keys', () => {
+    const { config } = configOf(`
+      const EVIL = { __proto__: { polluted: true }, api: false };
+
+      @smrt({ ...EVIL })
+      class Widget extends SmrtObject {}
+    `);
+
+    expect(config).toMatchObject({ api: false });
+    expect(Object.hasOwn(config, '__proto__')).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('leaves a spread-free config unchanged', () => {
+    const { config, errors } = configOf(`
+      @smrt({ api: { include: ['list'] }, mcp: false })
+      class Widget extends SmrtObject {}
+    `);
+
+    expect(errors).toHaveLength(0);
+    expect(config).toMatchObject({
+      api: { include: ['list'] },
+      mcp: false,
+    });
+  });
+});

--- a/packages/scanner/src/oxc-parser.ts
+++ b/packages/scanner/src/oxc-parser.ts
@@ -166,7 +166,12 @@ interface VariableDeclarator extends BaseNode {
  * union is a hand-maintained subset — so it is unwrapped via {@link unwrapTypeAssertion}.
  */
 interface TSTypeAssertionExpression extends BaseNode {
-  type: 'TSAsExpression' | 'TSSatisfiesExpression' | 'TSNonNullExpression';
+  type:
+    | 'TSAsExpression'
+    | 'TSSatisfiesExpression'
+    | 'TSNonNullExpression'
+    | 'TSTypeAssertion'
+    | 'ParenthesizedExpression';
   expression: Expression;
 }
 
@@ -925,7 +930,9 @@ function unwrapTypeAssertion(node: Expression | null): Expression | null {
     if (
       type === 'TSAsExpression' ||
       type === 'TSSatisfiesExpression' ||
-      type === 'TSNonNullExpression'
+      type === 'TSNonNullExpression' ||
+      type === 'TSTypeAssertion' ||
+      type === 'ParenthesizedExpression'
     ) {
       current = (current as unknown as TSTypeAssertionExpression).expression;
       continue;
@@ -963,6 +970,11 @@ interface UnresolvedSpread {
 interface ModuleConstant {
   value: Record<string, unknown>;
   unresolved: UnresolvedSpread[];
+  unsafeReferences: UnresolvedSpread[];
+  dependencies: Array<{
+    name: string;
+    start?: number;
+  }>;
 }
 
 /**
@@ -974,6 +986,10 @@ interface DecoratorConfigContext {
   constants: Map<string, ModuleConstant>;
   /** Collector for spreads that could not be statically resolved. */
   unresolved: UnresolvedSpread[];
+  /** Constant spreads recorded while another module constant is extracted. */
+  dependencies?: ModuleConstant['dependencies'];
+  /** Require values to be statically literal for security-sensitive @smrt config. */
+  requireLiteralValues?: boolean;
 }
 
 /**
@@ -1033,15 +1049,410 @@ export function extractModuleObjectConstants(
       // when a decorator actually spreads it, and it propagates transitively
       // because spreading a tainted constant re-collects its taint below.
       const unresolved: UnresolvedSpread[] = [];
+      const dependencies: ModuleConstant['dependencies'] = [];
       const value = extractObjectLiteral(init, sourceText, {
         constants,
         unresolved,
+        dependencies,
+        requireLiteralValues: true,
       });
-      constants.set(name, { value, unresolved });
+      constants.set(name, {
+        value,
+        unresolved,
+        unsafeReferences: [],
+        dependencies,
+      });
     }
   }
 
+  taintUnsafeModuleConstantReferences(body, constants, sourceText);
+  propagateModuleConstantTaint(constants);
   return constants;
+}
+
+/**
+ * Conservatively taint shared config objects that escape their declaration or
+ * a spread expression.
+ *
+ * `const` prevents rebinding, not mutation: `const CFG = { api: true };
+ * CFG.api = false` is legal JavaScript. Snapshotting only the initializer would
+ * therefore make the manifest say open while the runtime decorator sees
+ * closed. A reference used as the direct argument of a spread is safe; any
+ * other reference (property access, aliasing, function argument, assignment)
+ * may mutate or escape the object, so decorators that later spread it fail
+ * loudly instead of trusting a stale snapshot.
+ */
+function taintUnsafeModuleConstantReferences(
+  body: Statement[],
+  constants: Map<string, ModuleConstant>,
+  sourceText: string,
+): void {
+  if (constants.size === 0) return;
+
+  const tainted = new Set<string>();
+
+  const visit = (
+    value: unknown,
+    ancestors: Array<Record<string, unknown>>,
+    shadowed: ReadonlySet<string>,
+  ): void => {
+    if (Array.isArray(value)) {
+      for (const entry of value) visit(entry, ancestors, shadowed);
+      return;
+    }
+    if (!value || typeof value !== 'object') return;
+
+    const node = value as Record<string, unknown>;
+    if (typeof node.type !== 'string') {
+      for (const child of Object.values(node))
+        visit(child, ancestors, shadowed);
+      return;
+    }
+
+    if (
+      node.type === 'Identifier' &&
+      typeof node.name === 'string' &&
+      constants.has(node.name) &&
+      !shadowed.has(node.name) &&
+      !isTypeOnlyReference(node, ancestors) &&
+      !isSafeModuleConstantReference(node, ancestors, constants)
+    ) {
+      const name = node.name;
+      if (!tainted.has(name)) {
+        tainted.add(name);
+        const unresolved = {
+          expression:
+            sliceSource(node as unknown as BaseNode, sourceText) ?? name,
+          start:
+            typeof node.start === 'number' ? (node.start as number) : undefined,
+        };
+        const constant = constants.get(name);
+        constant?.unsafeReferences.push(unresolved);
+        constant?.unresolved.push(unresolved);
+      }
+    }
+
+    const nextShadowed = createsLexicalScope(node)
+      ? new Set([...shadowed, ...collectScopeBindings(node)])
+      : shadowed;
+    const nextAncestors = [...ancestors, node];
+    for (const [key, child] of Object.entries(node)) {
+      if (key === 'loc' || key === 'range' || key === 'start' || key === 'end')
+        continue;
+      visit(child, nextAncestors, nextShadowed);
+    }
+  };
+
+  visit(body, [], new Set());
+}
+
+function createsLexicalScope(node: Record<string, unknown>): boolean {
+  return (
+    node.type === 'BlockStatement' ||
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'FunctionExpression' ||
+    node.type === 'ArrowFunctionExpression' ||
+    node.type === 'CatchClause' ||
+    node.type === 'ForStatement' ||
+    node.type === 'ForInStatement' ||
+    node.type === 'ForOfStatement' ||
+    node.type === 'ClassDeclaration' ||
+    node.type === 'ClassExpression'
+  );
+}
+
+function collectScopeBindings(node: Record<string, unknown>): Set<string> {
+  const bindings = new Set<string>();
+  const addPattern = (value: unknown): void => {
+    if (!value || typeof value !== 'object') return;
+    const pattern = value as Record<string, unknown>;
+    if (pattern.type === 'Identifier' && typeof pattern.name === 'string') {
+      bindings.add(pattern.name);
+      return;
+    }
+    if (pattern.type === 'RestElement') {
+      addPattern(pattern.argument);
+      return;
+    }
+    if (pattern.type === 'AssignmentPattern') {
+      addPattern(pattern.left);
+      return;
+    }
+    if (pattern.type === 'ArrayPattern' && Array.isArray(pattern.elements)) {
+      for (const element of pattern.elements) addPattern(element);
+      return;
+    }
+    if (pattern.type === 'ObjectPattern' && Array.isArray(pattern.properties)) {
+      for (const property of pattern.properties) {
+        if (!property || typeof property !== 'object') continue;
+        const propertyNode = property as Record<string, unknown>;
+        addPattern(
+          propertyNode.type === 'RestElement'
+            ? propertyNode.argument
+            : propertyNode.value,
+        );
+      }
+    }
+  };
+
+  if (
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'FunctionExpression' ||
+    node.type === 'ArrowFunctionExpression'
+  ) {
+    if (node.type !== 'ArrowFunctionExpression') addPattern(node.id);
+    if (Array.isArray(node.params)) {
+      for (const parameter of node.params) addPattern(parameter);
+    }
+    collectFunctionVarBindings(node.body, bindings);
+  } else if (node.type === 'CatchClause') {
+    addPattern(node.param);
+  } else if (
+    node.type === 'ForStatement' ||
+    node.type === 'ForInStatement' ||
+    node.type === 'ForOfStatement'
+  ) {
+    const declaration = node.type === 'ForStatement' ? node.init : node.left;
+    if (
+      declaration &&
+      typeof declaration === 'object' &&
+      (declaration as Record<string, unknown>).type === 'VariableDeclaration'
+    ) {
+      for (const declarator of (declaration as Record<string, unknown>)
+        .declarations as Array<Record<string, unknown>>) {
+        addPattern(declarator.id);
+      }
+    }
+  } else if (
+    (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') &&
+    node.id
+  ) {
+    addPattern(node.id);
+  }
+
+  if (node.type === 'BlockStatement' && Array.isArray(node.body)) {
+    for (const statement of node.body as Array<Record<string, unknown>>) {
+      const declaration =
+        statement.type === 'ExportNamedDeclaration'
+          ? (statement.declaration as Record<string, unknown> | undefined)
+          : statement;
+      if (declaration?.type === 'VariableDeclaration') {
+        for (const declarator of declaration.declarations as Array<
+          Record<string, unknown>
+        >) {
+          addPattern(declarator.id);
+        }
+      } else if (
+        declaration?.type === 'FunctionDeclaration' ||
+        declaration?.type === 'ClassDeclaration'
+      ) {
+        addPattern(declaration.id);
+      }
+    }
+  }
+
+  return bindings;
+}
+
+function collectFunctionVarBindings(
+  value: unknown,
+  bindings: Set<string>,
+): void {
+  if (Array.isArray(value)) {
+    for (const entry of value) collectFunctionVarBindings(entry, bindings);
+    return;
+  }
+  if (!value || typeof value !== 'object') return;
+  const node = value as Record<string, unknown>;
+  if (
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'FunctionExpression' ||
+    node.type === 'ArrowFunctionExpression'
+  ) {
+    return;
+  }
+  if (node.type === 'VariableDeclaration' && node.kind === 'var') {
+    for (const declarator of node.declarations as Array<
+      Record<string, unknown>
+    >) {
+      const id = declarator.id as Record<string, unknown> | undefined;
+      if (id?.type === 'Identifier' && typeof id.name === 'string') {
+        bindings.add(id.name);
+      }
+    }
+  }
+  for (const [key, child] of Object.entries(node)) {
+    if (key === 'loc' || key === 'range' || key === 'start' || key === 'end')
+      continue;
+    collectFunctionVarBindings(child, bindings);
+  }
+}
+
+function isTypeOnlyReference(
+  identifier: Record<string, unknown>,
+  ancestors: Array<Record<string, unknown>>,
+): boolean {
+  let child = identifier;
+  for (let index = ancestors.length - 1; index >= 0; index--) {
+    const parent = ancestors[index];
+    if (
+      (parent.type === 'TSAsExpression' ||
+        parent.type === 'TSSatisfiesExpression' ||
+        parent.type === 'TSNonNullExpression' ||
+        parent.type === 'TSTypeAssertion') &&
+      parent.expression === child
+    ) {
+      child = parent;
+      continue;
+    }
+    if (typeof parent.type === 'string' && parent.type.startsWith('TS')) {
+      return true;
+    }
+    break;
+  }
+  return false;
+}
+
+function propagateModuleConstantTaint(
+  constants: Map<string, ModuleConstant>,
+): void {
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const constant of constants.values()) {
+      for (const dependency of constant.dependencies) {
+        const source = constants.get(dependency.name);
+        if (!source) continue;
+        for (const unresolved of source.unresolved) {
+          if (
+            dependency.start !== undefined &&
+            unresolved.start !== undefined &&
+            unresolved.start > dependency.start &&
+            !hasNestedReferenceValue(source.value)
+          ) {
+            continue;
+          }
+          if (
+            !constant.unresolved.some(
+              (existing) =>
+                existing.expression === unresolved.expression &&
+                existing.start === unresolved.start,
+            )
+          ) {
+            constant.unresolved.push(unresolved);
+            changed = true;
+          }
+        }
+        if (hasNestedReferenceValue(source.value)) {
+          for (const unsafeReference of constant.unsafeReferences) {
+            const matchesUnsafeReference = (existing: UnresolvedSpread) =>
+              existing.expression === unsafeReference.expression &&
+              existing.start === unsafeReference.start;
+            if (!source.unresolved.some(matchesUnsafeReference)) {
+              source.unresolved.push(unsafeReference);
+              changed = true;
+            }
+            if (!source.unsafeReferences.some(matchesUnsafeReference)) {
+              source.unsafeReferences.push(unsafeReference);
+              changed = true;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+function hasNestedReferenceValue(value: Record<string, unknown>): boolean {
+  return Object.values(value).some(
+    (entry) => entry !== null && typeof entry === 'object',
+  );
+}
+
+function isSafeModuleConstantReference(
+  identifier: Record<string, unknown>,
+  ancestors: Array<Record<string, unknown>>,
+  constants: Map<string, ModuleConstant>,
+): boolean {
+  let child = identifier;
+
+  for (let index = ancestors.length - 1; index >= 0; index--) {
+    const parent = ancestors[index];
+
+    if (parent.type === 'VariableDeclarator' && parent.id === child) {
+      return true;
+    }
+
+    if (
+      parent.type === 'Property' &&
+      parent.key === child &&
+      parent.computed === false &&
+      parent.shorthand === false
+    ) {
+      return true;
+    }
+
+    if (
+      parent.type === 'MemberExpression' &&
+      parent.property === child &&
+      parent.computed === false
+    ) {
+      return true;
+    }
+
+    if (
+      (parent.type === 'TSAsExpression' ||
+        parent.type === 'TSSatisfiesExpression' ||
+        parent.type === 'TSNonNullExpression' ||
+        parent.type === 'TSTypeAssertion' ||
+        parent.type === 'ParenthesizedExpression') &&
+      parent.expression === child
+    ) {
+      child = parent;
+      continue;
+    }
+
+    if (parent.type === 'SpreadElement' && parent.argument === child) {
+      const name =
+        typeof identifier.name === 'string' ? identifier.name : undefined;
+      const constant = name ? constants.get(name) : undefined;
+      if (!constant || !hasNestedReferenceValue(constant.value)) return true;
+
+      const moduleConstantInitializer = [...constants.values()].some(
+        (candidate) =>
+          candidate.dependencies.some(
+            (dependency) =>
+              dependency.name === name && dependency.start === parent.start,
+          ),
+      );
+      if (moduleConstantInitializer) return true;
+
+      const smrtDecorator = ancestors.some((ancestor) => {
+        if (
+          ancestor.type !== 'Decorator' ||
+          !ancestor.expression ||
+          typeof ancestor.expression !== 'object'
+        ) {
+          return false;
+        }
+        const expression = ancestor.expression as Record<string, unknown>;
+        if (
+          expression.type !== 'CallExpression' ||
+          !expression.callee ||
+          typeof expression.callee !== 'object'
+        ) {
+          return false;
+        }
+        const callee = expression.callee as Record<string, unknown>;
+        return callee.type === 'Identifier' && callee.name === 'smrt';
+      });
+      return smrtDecorator;
+    }
+
+    return false;
+  }
+
+  return false;
 }
 
 /**
@@ -1070,9 +1481,10 @@ function reportUnresolvedSpreads(
         : getLineColumn(sourceText, spread.start);
     errors.push({
       message:
-        `Cannot statically resolve \`${spread.expression}\` in a @smrt() config. ` +
-        `Only module-scope \`const\` object literals in the same file can be spread. ` +
-        `Inline the keys, or move the constant into this file — an unresolved spread ` +
+        `Cannot statically resolve \`${spread.expression}\` while expanding a @smrt() config. ` +
+        `Only literal keys/values and unescaped module-scope \`const\` object literals ` +
+        `in the same file are supported. Inline the keys or remove the mutation/alias — ` +
+        `an unresolved expression ` +
         `would drop api/mcp/cli from the manifest, and an absent surface defaults to open.`,
       filePath,
       line: loc?.line,
@@ -1147,7 +1559,11 @@ function extractClassDeclaration(
   );
   const hasSmartDecorator = !!smrtDecorator;
   const smrtConfig = smrtDecorator
-    ? extractDecoratorConfig(smrtDecorator, sourceText, ctx)
+    ? extractDecoratorConfig(
+        smrtDecorator,
+        sourceText,
+        ctx ? { ...ctx, requireLiteralValues: true } : ctx,
+      )
     : null;
   const decoratorConfig =
     tenantScopedDecorator || reportDecorator
@@ -1249,8 +1665,8 @@ function extractDecoratorConfig(
   const expr = decorator.expression;
 
   if (expr.type === 'CallExpression' && expr.arguments.length > 0) {
-    const arg = expr.arguments[0];
-    if (arg.type === 'ObjectExpression') {
+    const arg = unwrapTypeAssertion(expr.arguments[0]);
+    if (arg?.type === 'ObjectExpression') {
       return extractObjectLiteral(arg, sourceText, ctx) as RawDecoratorConfig;
     }
   }
@@ -1290,6 +1706,12 @@ function extractObjectLiteral(
           : undefined);
 
       if (resolved) {
+        if (constant && ctx?.dependencies && argument?.type === 'Identifier') {
+          ctx.dependencies.push({
+            name: argument.name,
+            start: prop.start,
+          });
+        }
         for (const [key, value] of Object.entries(resolved)) {
           if (isSafeObjectKey(key)) {
             result[key] = value;
@@ -1298,8 +1720,16 @@ function extractObjectLiteral(
         // A tainted constant resolved to a PARTIAL object — replay the spreads
         // its own initializer could not resolve, or the drop would go unnoticed
         // here even though this site depends on the missing keys.
-        if (constant?.unresolved.length && ctx) {
-          ctx.unresolved.push(...constant.unresolved);
+        if (constant?.unresolved.length && ctx && !ctx.dependencies) {
+          ctx.unresolved.push(
+            ...constant.unresolved.filter(
+              (unresolved) =>
+                hasNestedReferenceValue(constant.value) ||
+                prop.start === undefined ||
+                unresolved.start === undefined ||
+                unresolved.start <= prop.start,
+            ),
+          );
         }
       } else if (ctx) {
         ctx.unresolved.push({
@@ -1310,8 +1740,19 @@ function extractObjectLiteral(
       continue;
     }
 
-    if (prop.type === 'Property' && !prop.computed) {
+    if (prop.type === 'Property') {
       const key = getPropertyKey(prop.key);
+      if (
+        prop.shorthand ||
+        (prop.computed &&
+          !(prop.key.type === 'Literal' && typeof prop.key.value === 'string'))
+      ) {
+        ctx?.unresolved.push({
+          expression: sliceSource(prop, sourceText) ?? '<unknown property>',
+          start: prop.start,
+        });
+        continue;
+      }
       // Skip prototype-pollution keys (__proto__/constructor/prototype) so a
       // decorator-config property of that name cannot mutate the metadata
       // object's prototype.
@@ -1345,6 +1786,11 @@ function extractValue(
   sourceText: string,
   ctx?: DecoratorConfigContext,
 ): unknown {
+  const unwrapped = unwrapTypeAssertion(node as Expression);
+  if (unwrapped && unwrapped !== node) {
+    return extractValue(unwrapped, sourceText, ctx);
+  }
+
   switch (node.type) {
     case 'Literal':
       return node.value;
@@ -1355,6 +1801,12 @@ function extractValue(
       if (node.name === 'null') return null;
       if (node.name === 'true') return true;
       if (node.name === 'false') return false;
+      if (ctx?.requireLiteralValues) {
+        ctx.unresolved.push({
+          expression: sliceSource(node, sourceText) ?? node.name,
+          start: node.start,
+        });
+      }
       return node.name; // Return as string for class references
 
     case 'ArrayExpression': {
@@ -1401,14 +1853,24 @@ function extractValue(
     case 'NewExpression': {
       // Return the raw source for complex expressions
       const src = sliceSource(node, sourceText);
-      if (src) return src;
+      if (src) {
+        if (ctx?.requireLiteralValues) {
+          ctx.unresolved.push({ expression: src, start: node.start });
+        }
+        return src;
+      }
       break;
     }
   }
 
   // For complex expressions, return raw source if available
   const rawSrc = sliceSource(node, sourceText);
-  if (rawSrc) return rawSrc;
+  if (rawSrc) {
+    if (ctx?.requireLiteralValues) {
+      ctx.unresolved.push({ expression: rawSrc, start: node.start });
+    }
+    return rawSrc;
+  }
 
   return undefined;
 }

--- a/packages/scanner/src/oxc-parser.ts
+++ b/packages/scanner/src/oxc-parser.ts
@@ -144,7 +144,31 @@ type Statement =
   | ExportDefaultDeclaration
   | ImportDeclaration
   | TSTypeAliasDeclaration
-  | TSEnumDeclaration;
+  | TSEnumDeclaration
+  | VariableDeclaration;
+
+interface VariableDeclaration extends BaseNode {
+  type: 'VariableDeclaration';
+  kind: 'const' | 'let' | 'var';
+  declarations: VariableDeclarator[];
+}
+
+interface VariableDeclarator extends BaseNode {
+  type: 'VariableDeclarator';
+  id: Identifier | Pattern;
+  init: Expression | null;
+}
+
+/**
+ * `expr as const` / `expr satisfies T`. OXC emits these wrappers around the
+ * initializer, so a `const CFG = {...} as const` would otherwise never be seen
+ * as an `ObjectExpression`. Not part of the {@link Expression} union — the
+ * union is a hand-maintained subset — so it is unwrapped via {@link unwrapTypeAssertion}.
+ */
+interface TSTypeAssertionExpression extends BaseNode {
+  type: 'TSAsExpression' | 'TSSatisfiesExpression' | 'TSNonNullExpression';
+  expression: Expression;
+}
 
 interface ClassDeclaration extends BaseNode {
   type: 'ClassDeclaration';
@@ -529,17 +553,23 @@ export function parseFile(filePath: string): FileScanResult {
       const importAliases = extractImportAliases(program.body);
       typeAliases = extractTypeAliases(program.body);
       smrtImports = extractSmrtImports(program.body);
+      const ctx: DecoratorConfigContext = {
+        constants: extractModuleObjectConstants(program.body, sourceText),
+        unresolved: [],
+      };
       for (const node of program.body) {
         const extracted = extractClassFromNode(
           node,
           filePath,
           sourceText,
           importAliases,
+          ctx,
         );
         if (extracted) {
           classes.push(extracted);
         }
       }
+      reportUnresolvedSpreads(ctx.unresolved, filePath, sourceText, errors);
     }
   } catch (error) {
     errors.push({
@@ -629,17 +659,23 @@ export function parseSource(
       const importAliases = extractImportAliases(program.body);
       typeAliases = extractTypeAliases(program.body);
       smrtImports = extractSmrtImports(program.body);
+      const ctx: DecoratorConfigContext = {
+        constants: extractModuleObjectConstants(program.body, sourceText),
+        unresolved: [],
+      };
       for (const node of program.body) {
         const extracted = extractClassFromNode(
           node,
           filename,
           sourceText,
           importAliases,
+          ctx,
         );
         if (extracted) {
           classes.push(extracted);
         }
       }
+      reportUnresolvedSpreads(ctx.unresolved, filename, sourceText, errors);
     }
   } catch (error) {
     errors.push({
@@ -876,6 +912,154 @@ export function extractTypeAliases(body: Statement[]): Record<string, string> {
 }
 
 /**
+ * Unwrap `as const` / `satisfies T` / `!` wrappers to reach the underlying
+ * expression. `const CFG = { api: false } as const` is the idiomatic way to
+ * declare a shared surface policy, so the wrapper must be transparent here or
+ * the object literal is never found.
+ */
+function unwrapTypeAssertion(node: Expression | null): Expression | null {
+  let current = node;
+  // Bounded: assertions can legally nest (`x as unknown as T`), but not deeply.
+  for (let depth = 0; current && depth < 8; depth++) {
+    const type = (current as unknown as TSTypeAssertionExpression).type;
+    if (
+      type === 'TSAsExpression' ||
+      type === 'TSSatisfiesExpression' ||
+      type === 'TSNonNullExpression'
+    ) {
+      current = (current as unknown as TSTypeAssertionExpression).expression;
+      continue;
+    }
+    return current;
+  }
+  return current;
+}
+
+/**
+ * A spread inside an `@smrt()` config that could not be resolved statically.
+ *
+ * Recorded rather than silently dropped: an unresolvable spread may carry
+ * `api`/`mcp`/`cli` keys, and because an absent surface key means *default
+ * open* (full CRUD), dropping it silently turns a deliberate lockdown into a
+ * public surface. See issue #2100.
+ */
+interface UnresolvedSpread {
+  /** Source text of the spread, e.g. `...IMPORTED_SURFACE`. */
+  expression: string;
+  /** Byte offset of the spread node, for line/column resolution. */
+  start?: number;
+}
+
+/**
+ * Context threaded through decorator-config extraction so object spreads can be
+ * resolved against module-scope constants, and unresolvable ones reported.
+ */
+interface DecoratorConfigContext {
+  /** Module-scope `const NAME = {...}` object literals, by identifier name. */
+  constants: Map<string, Record<string, unknown>>;
+  /** Collector for spreads that could not be statically resolved. */
+  unresolved: UnresolvedSpread[];
+}
+
+/**
+ * Collect module-scope `const NAME = { ... }` object literals so that
+ * `@smrt({ ...NAME })` can be resolved at scan time.
+ *
+ * Declaration order is honoured: a constant may spread an earlier constant, and
+ * each is extracted against the map built so far. Only `const` is considered —
+ * `let`/`var` could be reassigned between declaration and decorator evaluation,
+ * so treating them as static would be unsound.
+ *
+ * Imported constants are intentionally NOT resolved (that would require
+ * cross-file resolution); they surface as unresolved spreads and are reported
+ * as scan errors instead of being silently dropped.
+ *
+ * @param body - Top-level statement array from the OXC-parsed `Program` node.
+ * @param sourceText - Full source text, used for nested value reconstruction.
+ * @returns Map of constant name to its extracted object literal.
+ */
+export function extractModuleObjectConstants(
+  body: Statement[],
+  sourceText: string,
+): Map<string, Record<string, unknown>> {
+  const constants = new Map<string, Record<string, unknown>>();
+
+  for (const node of body) {
+    // Both `const X = {}` and `export const X = {}`.
+    const decl =
+      node.type === 'VariableDeclaration'
+        ? node
+        : node.type === 'ExportNamedDeclaration' &&
+            node.declaration?.type === 'VariableDeclaration'
+          ? (node.declaration as VariableDeclaration)
+          : null;
+
+    if (decl?.kind !== 'const') continue;
+
+    for (const declarator of decl.declarations) {
+      if (declarator.id?.type !== 'Identifier') continue;
+      const name = declarator.id.name;
+      if (!name || !isSafeObjectKey(name)) continue;
+
+      const init = unwrapTypeAssertion(declarator.init);
+      if (init?.type !== 'ObjectExpression') continue;
+
+      // Extract against the constants seen so far, so `const B = { ...A }`
+      // resolves. Unresolvable spreads inside a constant are dropped here
+      // rather than reported: the constant may never be used by a decorator,
+      // and any decorator that does spread it reports at the use site.
+      constants.set(
+        name,
+        extractObjectLiteral(init, sourceText, {
+          constants,
+          unresolved: [],
+        }),
+      );
+    }
+  }
+
+  return constants;
+}
+
+/**
+ * Turn unresolvable `@smrt()` config spreads into `severity: 'error'` scan
+ * diagnostics.
+ *
+ * Deliberately fail-loud rather than fail-quiet. A dropped spread may have
+ * carried `api`/`mcp`/`cli`, and an absent surface key means *default open* —
+ * so silently discarding one converts a deliberate lockdown into a published
+ * CRUD surface with no signal anywhere. Erroring matches the precedent in
+ * `verify-completeness.ts`, where scan errors short-circuit so a broken source
+ * can never masquerade as a complete manifest.
+ *
+ * @see https://github.com/happyvertical/smrt/issues/2100
+ */
+function reportUnresolvedSpreads(
+  unresolved: UnresolvedSpread[],
+  filePath: string,
+  sourceText: string,
+  errors: ScanError[],
+): void {
+  for (const spread of unresolved) {
+    const loc =
+      spread.start === undefined
+        ? undefined
+        : getLineColumn(sourceText, spread.start);
+    errors.push({
+      message:
+        `Cannot statically resolve \`${spread.expression}\` in a @smrt() config. ` +
+        `Only module-scope \`const\` object literals in the same file can be spread. ` +
+        `Inline the keys, or move the constant into this file — an unresolved spread ` +
+        `would drop api/mcp/cli from the manifest, and an absent surface defaults to open.`,
+      filePath,
+      line: loc?.line,
+      column: loc?.column,
+      severity: 'error',
+    });
+  }
+}
+
+/**
  * Extract class definition from an AST node
  */
 function extractClassFromNode(
@@ -883,6 +1067,7 @@ function extractClassFromNode(
   filePath: string,
   sourceText: string,
   importAliases: Map<string, string>,
+  ctx?: DecoratorConfigContext,
 ): RawClassDefinition | null {
   // Handle export declarations
   if (node.type === 'ExportNamedDeclaration' && node.declaration) {
@@ -891,6 +1076,7 @@ function extractClassFromNode(
       filePath,
       sourceText,
       importAliases,
+      ctx,
     );
   }
   if (node.type === 'ExportDefaultDeclaration' && node.declaration) {
@@ -899,12 +1085,19 @@ function extractClassFromNode(
       filePath,
       sourceText,
       importAliases,
+      ctx,
     );
   }
 
   // Handle class declaration
   if (node.type === 'ClassDeclaration') {
-    return extractClassDeclaration(node, filePath, sourceText, importAliases);
+    return extractClassDeclaration(
+      node,
+      filePath,
+      sourceText,
+      importAliases,
+      ctx,
+    );
   }
 
   return null;
@@ -918,6 +1111,7 @@ function extractClassDeclaration(
   filePath: string,
   sourceText: string,
   importAliases: Map<string, string>,
+  ctx?: DecoratorConfigContext,
 ): RawClassDefinition {
   const className = node.id?.name || 'AnonymousClass';
 
@@ -930,20 +1124,27 @@ function extractClassDeclaration(
   );
   const hasSmartDecorator = !!smrtDecorator;
   const smrtConfig = smrtDecorator
-    ? extractDecoratorConfig(smrtDecorator, sourceText)
+    ? extractDecoratorConfig(smrtDecorator, sourceText, ctx)
     : null;
   const decoratorConfig =
     tenantScopedDecorator || reportDecorator
       ? {
           ...(smrtConfig ?? {}),
           ...(reportDecorator
-            ? { report: extractDecoratorConfig(reportDecorator, sourceText) }
+            ? {
+                report: extractDecoratorConfig(
+                  reportDecorator,
+                  sourceText,
+                  ctx,
+                ),
+              }
             : {}),
           ...(tenantScopedDecorator
             ? {
                 tenantScoped: extractDecoratorConfig(
                   tenantScopedDecorator,
                   sourceText,
+                  ctx,
                 ),
               }
             : {}),
@@ -1020,13 +1221,14 @@ function isNamedDecorator(decorator: Decorator, name: string): boolean {
 function extractDecoratorConfig(
   decorator: Decorator,
   sourceText: string,
+  ctx?: DecoratorConfigContext,
 ): RawDecoratorConfig | null {
   const expr = decorator.expression;
 
   if (expr.type === 'CallExpression' && expr.arguments.length > 0) {
     const arg = expr.arguments[0];
     if (arg.type === 'ObjectExpression') {
-      return extractObjectLiteral(arg, sourceText) as RawDecoratorConfig;
+      return extractObjectLiteral(arg, sourceText, ctx) as RawDecoratorConfig;
     }
   }
 
@@ -1040,17 +1242,49 @@ function extractDecoratorConfig(
 function extractObjectLiteral(
   node: ObjectExpression,
   sourceText: string,
+  ctx?: DecoratorConfigContext,
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
+  // Iterate in source order so spread/property precedence matches runtime
+  // semantics: `{ api: true, ...CFG }` takes `api` from CFG, while
+  // `{ ...CFG, api: true }` overrides it.
   for (const prop of node.properties) {
+    if (prop.type === 'SpreadElement') {
+      // A spread that reaches the manifest as "absent" is indistinguishable
+      // from a surface the author never declared — and absent means default
+      // *open*. Resolve it, or record it for a scan error. Never drop it
+      // silently. See issue #2100.
+      const argument = unwrapTypeAssertion(prop.argument);
+      const resolved =
+        argument?.type === 'Identifier'
+          ? ctx?.constants.get(argument.name)
+          : argument?.type === 'ObjectExpression'
+            ? extractObjectLiteral(argument, sourceText, ctx)
+            : undefined;
+
+      if (resolved) {
+        for (const [key, value] of Object.entries(resolved)) {
+          if (isSafeObjectKey(key)) {
+            result[key] = value;
+          }
+        }
+      } else if (ctx) {
+        ctx.unresolved.push({
+          expression: sliceSource(prop, sourceText) ?? '...<unknown>',
+          start: prop.start,
+        });
+      }
+      continue;
+    }
+
     if (prop.type === 'Property' && !prop.computed) {
       const key = getPropertyKey(prop.key);
       // Skip prototype-pollution keys (__proto__/constructor/prototype) so a
       // decorator-config property of that name cannot mutate the metadata
       // object's prototype.
       if (key && isSafeObjectKey(key)) {
-        result[key] = extractValue(prop.value, sourceText);
+        result[key] = extractValue(prop.value, sourceText, ctx);
       }
     }
   }
@@ -1074,7 +1308,11 @@ function getPropertyKey(node: Expression): string | null {
 /**
  * Extract value from expression
  */
-function extractValue(node: Expression | Pattern, sourceText: string): unknown {
+function extractValue(
+  node: Expression | Pattern,
+  sourceText: string,
+  ctx?: DecoratorConfigContext,
+): unknown {
   switch (node.type) {
     case 'Literal':
       return node.value;
@@ -1087,7 +1325,23 @@ function extractValue(node: Expression | Pattern, sourceText: string): unknown {
       if (node.name === 'false') return false;
       return node.name; // Return as string for class references
 
-    case 'ArrayExpression':
+    case 'ArrayExpression': {
+      // Array spreads (e.g. `include: [...BASE_ACTIONS, 'archive']`) are not
+      // resolved, but must not vanish silently: a dropped element changes an
+      // include/exclude allowlist. Record for a scan error instead.
+      for (const el of node.elements) {
+        if (
+          el &&
+          typeof el === 'object' &&
+          el.type === 'SpreadElement' &&
+          ctx
+        ) {
+          ctx.unresolved.push({
+            expression: sliceSource(el, sourceText) ?? '...<unknown>',
+            start: el.start,
+          });
+        }
+      }
       return node.elements
         .filter(
           (el: Expression | SpreadElement | null): el is Expression =>
@@ -1096,10 +1350,11 @@ function extractValue(node: Expression | Pattern, sourceText: string): unknown {
             'type' in el &&
             el.type !== 'SpreadElement',
         )
-        .map((el: Expression) => extractValue(el, sourceText));
+        .map((el: Expression) => extractValue(el, sourceText, ctx));
+    }
 
     case 'ObjectExpression':
-      return extractObjectLiteral(node, sourceText);
+      return extractObjectLiteral(node, sourceText, ctx);
 
     case 'UnaryExpression':
       if (node.operator === '-' && node.argument?.type === 'Literal') {

--- a/packages/scanner/src/oxc-parser.ts
+++ b/packages/scanner/src/oxc-parser.ts
@@ -951,12 +951,27 @@ interface UnresolvedSpread {
 }
 
 /**
+ * A module-scope `const` object literal available for spread resolution.
+ *
+ * `unresolved` carries any spread inside the constant's OWN initializer that
+ * could not be resolved (e.g. `const CFG = { ...IMPORTED }`). Such a constant
+ * is "tainted": `value` is only a partial view of what it holds at runtime.
+ * Resolving a decorator spread against it silently would reintroduce the
+ * silent-drop failure mode one level removed, so the taint is replayed into the
+ * use site's diagnostics instead.
+ */
+interface ModuleConstant {
+  value: Record<string, unknown>;
+  unresolved: UnresolvedSpread[];
+}
+
+/**
  * Context threaded through decorator-config extraction so object spreads can be
  * resolved against module-scope constants, and unresolvable ones reported.
  */
 interface DecoratorConfigContext {
   /** Module-scope `const NAME = {...}` object literals, by identifier name. */
-  constants: Map<string, Record<string, unknown>>;
+  constants: Map<string, ModuleConstant>;
   /** Collector for spreads that could not be statically resolved. */
   unresolved: UnresolvedSpread[];
 }
@@ -974,15 +989,22 @@ interface DecoratorConfigContext {
  * cross-file resolution); they surface as unresolved spreads and are reported
  * as scan errors instead of being silently dropped.
  *
+ * A constant whose own initializer contains an unresolvable spread is recorded
+ * as TAINTED rather than dropped: its extracted value is only partial, so any
+ * decorator that spreads it replays the taint into its own diagnostics. Without
+ * that, `const CFG = { ...IMPORTED }` followed by `@smrt({ ...CFG })` would
+ * resolve cleanly against a partial object and report nothing — the exact
+ * silent-drop failure mode this guard exists to prevent, one level removed.
+ *
  * @param body - Top-level statement array from the OXC-parsed `Program` node.
  * @param sourceText - Full source text, used for nested value reconstruction.
- * @returns Map of constant name to its extracted object literal.
+ * @returns Map of constant name to its extracted value plus any taint.
  */
 export function extractModuleObjectConstants(
   body: Statement[],
   sourceText: string,
-): Map<string, Record<string, unknown>> {
-  const constants = new Map<string, Record<string, unknown>>();
+): Map<string, ModuleConstant> {
+  const constants = new Map<string, ModuleConstant>();
 
   for (const node of body) {
     // Both `const X = {}` and `export const X = {}`.
@@ -1005,16 +1027,17 @@ export function extractModuleObjectConstants(
       if (init?.type !== 'ObjectExpression') continue;
 
       // Extract against the constants seen so far, so `const B = { ...A }`
-      // resolves. Unresolvable spreads inside a constant are dropped here
-      // rather than reported: the constant may never be used by a decorator,
-      // and any decorator that does spread it reports at the use site.
-      constants.set(
-        name,
-        extractObjectLiteral(init, sourceText, {
-          constants,
-          unresolved: [],
-        }),
-      );
+      // resolves — and capture this constant's OWN unresolvable spreads as
+      // taint rather than discarding them. Nothing is reported here: an unused
+      // constant is not a manifest problem. The taint only becomes an error
+      // when a decorator actually spreads it, and it propagates transitively
+      // because spreading a tainted constant re-collects its taint below.
+      const unresolved: UnresolvedSpread[] = [];
+      const value = extractObjectLiteral(init, sourceText, {
+        constants,
+        unresolved,
+      });
+      constants.set(name, { value, unresolved });
     }
   }
 
@@ -1256,18 +1279,27 @@ function extractObjectLiteral(
       // *open*. Resolve it, or record it for a scan error. Never drop it
       // silently. See issue #2100.
       const argument = unwrapTypeAssertion(prop.argument);
-      const resolved =
+      const constant =
         argument?.type === 'Identifier'
           ? ctx?.constants.get(argument.name)
-          : argument?.type === 'ObjectExpression'
-            ? extractObjectLiteral(argument, sourceText, ctx)
-            : undefined;
+          : undefined;
+      const resolved =
+        constant?.value ??
+        (argument?.type === 'ObjectExpression'
+          ? extractObjectLiteral(argument, sourceText, ctx)
+          : undefined);
 
       if (resolved) {
         for (const [key, value] of Object.entries(resolved)) {
           if (isSafeObjectKey(key)) {
             result[key] = value;
           }
+        }
+        // A tainted constant resolved to a PARTIAL object — replay the spreads
+        // its own initializer could not resolve, or the drop would go unnoticed
+        // here even though this site depends on the missing keys.
+        if (constant?.unresolved.length && ctx) {
+          ctx.unresolved.push(...constant.unresolved);
         }
       } else if (ctx) {
         ctx.unresolved.push({


### PR DESCRIPTION
Fixes #2100.

> **Stack note:** this branch is rebased on #2104 and therefore includes its Coverage Gate workflow fix. The workflow hunk disappears once #2104 merges; targeting a non-`main` PR base would skip this repository's pull-request validation workflow.

## Problem

The OXC parser silently skipped `SpreadElement` entries in `@smrt()` config. A source-level lockdown such as `@smrt({ ...INTERNAL_SURFACE })` could therefore lose `api`/`cli`/`mcp` in the generated manifest. Since absent surface keys default open, manifest-driven consumers could publish CRUD that the source intended to disable.

## Fix

- Resolve same-file module-scope `const` object spreads, including exported/asserted constants, nested constants, computed literal keys, and source-order precedence.
- Fail closed on imported/reassignable spreads, nonliteral keys or values, shorthand, array spreads, mutation, aliasing, escape, and other expressions that cannot be reconstructed safely.
- Track bindings and use order so shadowed/type-only references do not taint the module constant and primitive-only post-spread mutations do not create false positives.
- Model JavaScript's shallow object-spread semantics: unsafe uses propagate forward and backward through nested-value dependency edges, including derived aliases and post-decorator mutation.
- Unwrap asserted/parenthesized decorator arguments.
- Make `ManifestBuilder` abort on scanner errors before adapting or writing a partial/default-open manifest.

## Verification

- `smrt-scanner`: 195 passed, typecheck and build clean.
- `smrt-core`: 3,145 passed (45 skipped); new ManifestBuilder fail-closed regression passes.
- `smrt-reports`: 18 passed.
- `smrt-projects`: 112 passed.
- `smrt-content`: 302 passed (6 skipped).
- Full monorepo build: 61/61 tasks.
- Biome, audit policy, and `smrt dev:knowledge-check`: clean.
- Review cycle: code, security, and test/correctness reviewers clean after the bounded fix/retest loop.

## Follow-ups

- #2099 — require every surface to be explicitly declared.
- #2101 — consider default-closed `@smrt()` surfaces.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019f9cb9-d908-7b32-96f1-e6b2edabb038","issue":2100,"policy_revision":"1.0.0","validation":["pnpm test (scanner 195, core 3145, reports 18, projects 112, content 302)","pnpm typecheck/build (scanner)","pnpm build (61/61)","biome ci","pnpm smrt dev:knowledge-check","pnpm audit:policy","review-cycle: code/security/tests clean"]}
```

<!-- ci-recheck: stale Agent Policy context -->
