### PR TITLE
fix(cli): version type-upgrade migration identities

### DIFF
--- a/packages/cli/src/commands/__tests__/db-migrate-actions-names.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-actions-names.test.ts
@@ -131,15 +131,17 @@ describe('getSyntheticMigrationNameForAction', () => {
     ).toBeNull();
   });
 
-  it('names a type_upgrade action and returns null without a column', () => {
+  it('fingerprints a type_upgrade action and returns null without a column', () => {
     expect(
       getSyntheticMigrationNameForAction({
         type: 'type_upgrade',
         tableName: 'widgets',
         className: 'Widget',
         column: { name: 'status', type: 'TEXT' },
+        mismatch: { actual: 'INTEGER', expected: 'TEXT' },
+        sql: 'ALTER TABLE widgets ALTER COLUMN status TYPE TEXT',
       } as any),
-    ).toBe('type_upgrade_widgets_status');
+    ).toMatch(/^type_upgrade_widgets_status_[0-9a-f]{8}$/);
     expect(
       getSyntheticMigrationNameForAction({
         type: 'type_upgrade',
@@ -224,14 +226,44 @@ describe('getSyntheticMigrationNameForChange', () => {
     ).toBeNull();
   });
 
-  it('names a type_upgrade change and returns null for unknown types', () => {
+  it('fingerprints type upgrades by source, target, and conversion SQL', () => {
+    const originalConversion = {
+      type: 'type_upgrade' as const,
+      table: 'ad_events',
+      name: 'created_at',
+      column: { type: 'TIMESTAMP' },
+      mismatch: { actual: 'TEXT', expected: 'TIMESTAMP' },
+      sql: 'ALTER TABLE ad_events ALTER COLUMN created_at TYPE TIMESTAMP USING created_at::timestamp',
+    };
+    const utcConversion = {
+      ...originalConversion,
+      column: { type: 'TIMESTAMPTZ' },
+      mismatch: { actual: 'TIMESTAMP', expected: 'TIMESTAMPTZ' },
+      sql: "ALTER TABLE ad_events ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC'",
+    };
+
+    const originalId = getSyntheticMigrationNameForChange(originalConversion);
+    const utcId = getSyntheticMigrationNameForChange(utcConversion);
+
+    expect(originalId).toMatch(
+      /^type_upgrade_ad_events_created_at_[0-9a-f]{8}$/,
+    );
+    expect(utcId).toMatch(/^type_upgrade_ad_events_created_at_[0-9a-f]{8}$/);
+    expect(utcId).not.toBe(originalId);
+    expect(utcId).not.toBe('type_upgrade_ad_events_created_at');
     expect(
-      getSyntheticMigrationNameForChange({
+      getSyntheticMigrationNameForAction({
         type: 'type_upgrade',
-        table: 'widgets',
-        name: 'status',
-      } as any),
-    ).toBe('type_upgrade_widgets_status');
+        tableName: utcConversion.table,
+        className: 'AdEvent',
+        column: { name: utcConversion.name, ...utcConversion.column },
+        mismatch: { column: utcConversion.name, ...utcConversion.mismatch },
+        sql: utcConversion.sql,
+      }),
+    ).toBe(utcId);
+  });
+
+  it('returns null for unknown types', () => {
     expect(
       getSyntheticMigrationNameForChange({
         type: 'drop_table',

--- a/packages/cli/src/commands/__tests__/db-migrate-actions-names.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-actions-names.test.ts
@@ -3,6 +3,7 @@ import {
   classifyTypeUpgradeSql,
   getSyntheticMigrationNameForAction,
   getSyntheticMigrationNameForChange,
+  getSyntheticMigrationNamesForChange,
   getUnresolvedGeneratedMigrationNames,
   partitionSchemaChanges,
 } from '../db-migrate-actions.js';
@@ -261,6 +262,22 @@ describe('getSyntheticMigrationNameForChange', () => {
         sql: utcConversion.sql,
       }),
     ).toBe(utcId);
+  });
+
+  it('keeps the legacy bare type-upgrade id as a status-only alias', () => {
+    const change = {
+      type: 'type_upgrade' as const,
+      table: 'ad_events',
+      name: 'created_at',
+      column: { type: 'TIMESTAMPTZ' },
+      mismatch: { actual: 'TIMESTAMP', expected: 'TIMESTAMPTZ' },
+      sql: "ALTER TABLE ad_events ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC'",
+    };
+
+    expect(getSyntheticMigrationNamesForChange(change)).toEqual([
+      getSyntheticMigrationNameForChange(change),
+      'type_upgrade_ad_events_created_at',
+    ]);
   });
 
   it('returns null for unknown types', () => {

--- a/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  getSyntheticMigrationNameForChange,
   getUnresolvedGeneratedMigrationNames,
   partitionSchemaChanges,
   shouldApplySchemaMigrations,
@@ -283,6 +284,14 @@ describe('shouldApplySchemaMigrations', () => {
 
 describe('failed migration classification', () => {
   it('tracks current unresolved generated repairs separately from superseded failures', () => {
+    const typeUpgrade = {
+      type: 'type_upgrade' as const,
+      table: 'contents',
+      name: 'status',
+      sql: 'ALTER TABLE contents ALTER COLUMN status TYPE JSONB USING status::jsonb',
+    };
+    const typeUpgradeName = getSyntheticMigrationNameForChange(typeUpgrade);
+    if (!typeUpgradeName) throw new Error('expected type-upgrade migration id');
     const unresolvedNames = getUnresolvedGeneratedMigrationNames([
       {
         type: 'add_column',
@@ -290,12 +299,7 @@ describe('failed migration classification', () => {
         name: 'script_text',
         column: { type: 'TEXT' },
       },
-      {
-        type: 'type_upgrade',
-        table: 'contents',
-        name: 'status',
-        sql: 'ALTER TABLE contents ALTER COLUMN status TYPE JSONB USING status::jsonb',
-      },
+      typeUpgrade,
     ]);
 
     expect(
@@ -310,7 +314,7 @@ describe('failed migration classification', () => {
             error_message: 'index already exists',
           },
           {
-            name: 'type_upgrade_contents_status',
+            name: typeUpgradeName,
             error_message: 'cannot cast',
           },
         ],
@@ -326,7 +330,7 @@ describe('failed migration classification', () => {
           errorMessage: 'column missing',
         },
         {
-          name: 'type_upgrade_contents_status',
+          name: typeUpgradeName,
           classification: 'unresolved',
           recommendation:
             'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed generated schema repair no longer appears as unresolved.',

--- a/packages/cli/src/commands/__tests__/db-status.test.ts
+++ b/packages/cli/src/commands/__tests__/db-status.test.ts
@@ -453,7 +453,7 @@ describe('db:status', () => {
     });
   });
 
-  it('keeps failed migrations actionable when the live diff still requires them', async () => {
+  it('keeps legacy failed type upgrades actionable when the live diff still requires them', async () => {
     const typeUpgrade = {
       type: 'type_upgrade' as const,
       table: '_smrt_agent_schedules',
@@ -471,7 +471,7 @@ describe('db:status', () => {
     getHistoryMock.mockResolvedValue([
       {
         id: 'failed-2',
-        name: typeUpgradeName,
+        name: 'type_upgrade__smrt_agent_schedules_agent_config',
         version: '1.0.0',
         checksum: 'def',
         applied_checksum: null,
@@ -499,7 +499,7 @@ describe('db:status', () => {
     );
     expect(parsed.migrations.failed.actionRequired).toBe(1);
     expect(parsed.migrations.failed.details[0]).toMatchObject({
-      name: typeUpgradeName,
+      name: 'type_upgrade__smrt_agent_schedules_agent_config',
       resolution: 'action_required',
       kind: 'type_upgrade',
     });

--- a/packages/cli/src/commands/__tests__/db-status.test.ts
+++ b/packages/cli/src/commands/__tests__/db-status.test.ts
@@ -71,6 +71,7 @@ vi.mock('@happyvertical/smrt-core/migrations', () => ({
   MigrationTracker: MigrationTrackerMock,
 }));
 
+import { getSyntheticMigrationNameForChange } from '../db-migrate-actions.js';
 import {
   checkTenantIdUuidPreconditions,
   dbStatusCommand,
@@ -453,23 +454,24 @@ describe('db:status', () => {
   });
 
   it('keeps failed migrations actionable when the live diff still requires them', async () => {
+    const typeUpgrade = {
+      type: 'type_upgrade' as const,
+      table: '_smrt_agent_schedules',
+      name: 'agent_config',
+      sql: 'ALTER TABLE _smrt_agent_schedules ALTER COLUMN agent_config TYPE JSONB USING agent_config::jsonb',
+    };
+    const typeUpgradeName = getSyntheticMigrationNameForChange(typeUpgrade);
+    if (!typeUpgradeName) throw new Error('expected type-upgrade migration id');
     compareMock.mockResolvedValue({
       added_tables: [],
       dropped_tables: [],
       has_changes: true,
-      changes: [
-        {
-          type: 'type_upgrade',
-          table: '_smrt_agent_schedules',
-          name: 'agent_config',
-          sql: 'ALTER TABLE _smrt_agent_schedules ALTER COLUMN agent_config TYPE JSONB USING agent_config::jsonb',
-        },
-      ],
+      changes: [typeUpgrade],
     });
     getHistoryMock.mockResolvedValue([
       {
         id: 'failed-2',
-        name: 'type_upgrade__smrt_agent_schedules_agent_config',
+        name: typeUpgradeName,
         version: '1.0.0',
         checksum: 'def',
         applied_checksum: null,
@@ -497,7 +499,7 @@ describe('db:status', () => {
     );
     expect(parsed.migrations.failed.actionRequired).toBe(1);
     expect(parsed.migrations.failed.details[0]).toMatchObject({
-      name: 'type_upgrade__smrt_agent_schedules_agent_config',
+      name: typeUpgradeName,
       resolution: 'action_required',
       kind: 'type_upgrade',
     });
@@ -520,6 +522,14 @@ describe('db:status', () => {
   });
 
   it('classifies failed additive migrations against current live drift', async () => {
+    const typeUpgrade = {
+      type: 'type_upgrade' as const,
+      table: 'contents',
+      name: 'status',
+      sql: 'ALTER TABLE contents ALTER COLUMN status TYPE JSONB USING status::jsonb',
+    };
+    const typeUpgradeName = getSyntheticMigrationNameForChange(typeUpgrade);
+    if (!typeUpgradeName) throw new Error('expected type-upgrade migration id');
     compareMock.mockResolvedValue({
       added_tables: [],
       dropped_tables: [],
@@ -531,12 +541,7 @@ describe('db:status', () => {
           name: 'script_text',
           column: { type: 'TEXT' },
         },
-        {
-          type: 'type_upgrade',
-          table: 'contents',
-          name: 'status',
-          sql: 'ALTER TABLE contents ALTER COLUMN status TYPE JSONB USING status::jsonb',
-        },
+        typeUpgrade,
       ],
     });
     getHistoryMock.mockResolvedValue([
@@ -549,7 +554,7 @@ describe('db:status', () => {
         error_message: 'index already exists',
       },
       {
-        name: 'type_upgrade_contents_status',
+        name: typeUpgradeName,
         error_message: 'cannot cast',
       },
     ]);
@@ -571,7 +576,7 @@ describe('db:status', () => {
           errorMessage: 'column missing',
         },
         {
-          name: 'type_upgrade_contents_status',
+          name: typeUpgradeName,
           classification: 'unresolved',
           recommendation:
             'Run `smrt db:migrate` to reconcile the live schema, then confirm this failed generated schema repair no longer appears as unresolved.',

--- a/packages/cli/src/commands/__tests__/utilities-handlers.test.ts
+++ b/packages/cli/src/commands/__tests__/utilities-handlers.test.ts
@@ -895,6 +895,18 @@ describe('utility command handlers', () => {
 
     await utilityCommands['db:migrate'].handler([], { verbose: true });
     expect(trackerApplyAll).toHaveBeenCalled();
+    const definitions = trackerApplyAll.mock.calls[0]?.[0] as Array<{
+      id: string;
+    }>;
+    expect(definitions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.stringMatching(
+            /^type_upgrade_contents_count_[0-9a-f]{8}$/,
+          ),
+        }),
+      ]),
+    );
     expect(logged()).toContain('Successfully applied');
   });
 

--- a/packages/cli/src/commands/db-migrate-actions.ts
+++ b/packages/cli/src/commands/db-migrate-actions.ts
@@ -137,6 +137,37 @@ function sqlShapeFingerprint(action: {
   return createHash('sha256').update(normalized).digest('hex').slice(0, 8);
 }
 
+/**
+ * Keep type-upgrade tracker identities tied to the specific conversion, not
+ * merely the table and column. A column may legitimately undergo multiple
+ * upgrades over its lifetime; reusing the old bare id would make
+ * MigrationTracker compare different SQL checksums against applied history.
+ *
+ * Include the differ's source/target types as well as the normalized SQL
+ * shape. The type data keeps fallback identities meaningful when SQL is not
+ * available, while the SQL fingerprint distinguishes conversions with the
+ * same endpoints but different semantics (for example a UTC interpretation).
+ */
+function typeUpgradeFingerprint(action: {
+  sql?: string;
+  sqlStatements?: string[];
+  column?: { type: string };
+  mismatch?: { expected: string; actual: string };
+}): string {
+  const source = action.mismatch?.actual ?? '';
+  const target = action.mismatch?.expected ?? action.column?.type ?? '';
+  const conversion = sqlShapeFingerprint(action);
+
+  if (!source && !target && !conversion) {
+    return '';
+  }
+
+  return createHash('sha256')
+    .update(`source:${source};target:${target};conversion:${conversion}`)
+    .digest('hex')
+    .slice(0, 8);
+}
+
 export function classifyTypeUpgradeSql(sql?: string): TypeUpgradeExecutionKind {
   const trimmed = sql?.trim();
 
@@ -186,10 +217,15 @@ export function getSyntheticMigrationNameForAction(
         : `drop_index_${action.indexName}`;
     }
 
-    case 'type_upgrade':
-      return action.column
-        ? `type_upgrade_${action.tableName}_${action.column.name}`
-        : null;
+    case 'type_upgrade': {
+      if (!action.column) return null;
+      // Issue #2111: conversions for the same column must never reuse an
+      // applied tracker id with different SQL/checksum.
+      const fingerprint = typeUpgradeFingerprint(action);
+      return fingerprint
+        ? `type_upgrade_${action.tableName}_${action.column.name}_${fingerprint}`
+        : `type_upgrade_${action.tableName}_${action.column.name}`;
+    }
 
     default:
       return null;
@@ -227,8 +263,13 @@ export function getSyntheticMigrationNameForChange(
         : `drop_index_${change.name}`;
     }
 
-    case 'type_upgrade':
-      return change.name ? `type_upgrade_${change.table}_${change.name}` : null;
+    case 'type_upgrade': {
+      if (!change.name) return null;
+      const fingerprint = typeUpgradeFingerprint(change);
+      return fingerprint
+        ? `type_upgrade_${change.table}_${change.name}_${fingerprint}`
+        : `type_upgrade_${change.table}_${change.name}`;
+    }
 
     default:
       return null;

--- a/packages/cli/src/commands/db-migrate-actions.ts
+++ b/packages/cli/src/commands/db-migrate-actions.ts
@@ -276,6 +276,32 @@ export function getSyntheticMigrationNameForChange(
   }
 }
 
+/**
+ * Return every tracker name that can represent the current schema change.
+ *
+ * New type upgrades use a fingerprinted id, but releases before #2111 wrote
+ * failures under the bare table-and-column id. Keep that old id as a
+ * classification alias only: execution always uses the fingerprinted id, so
+ * no applied migration record is rewritten or reused for a new conversion.
+ */
+export function getSyntheticMigrationNamesForChange(
+  change: SchemaChangeLike,
+): string[] {
+  const migrationName = getSyntheticMigrationNameForChange(change);
+  if (!migrationName) {
+    return [];
+  }
+
+  if (change.type === 'type_upgrade' && change.name) {
+    const legacyName = `type_upgrade_${change.table}_${change.name}`;
+    return migrationName === legacyName
+      ? [migrationName]
+      : [migrationName, legacyName];
+  }
+
+  return [migrationName];
+}
+
 export function shouldFailDbMigrate(state: DbMigrateFailureState): boolean {
   return (
     (state.tableErrorCount ?? 0) > 0 ||
@@ -331,8 +357,7 @@ export function getUnresolvedGeneratedMigrationNames(
       continue;
     }
 
-    const migrationName = getSyntheticMigrationNameForChange(change);
-    if (migrationName) {
+    for (const migrationName of getSyntheticMigrationNamesForChange(change)) {
       names.add(migrationName);
     }
   }

--- a/packages/cli/src/commands/migration-failure-analysis.ts
+++ b/packages/cli/src/commands/migration-failure-analysis.ts
@@ -5,7 +5,7 @@ import type {
 } from '@happyvertical/smrt-core/migrations';
 import {
   classifyTypeUpgradeSql,
-  getSyntheticMigrationNameForChange,
+  getSyntheticMigrationNamesForChange,
 } from './db-migrate-actions.js';
 
 export type FailedMigrationResolution =
@@ -21,16 +21,14 @@ export interface FailedMigrationAssessment {
   errorMessage: string | null;
 }
 
-function getActionableGeneratedMigrationName(
-  change: SchemaChange,
-): string | null {
+function getActionableGeneratedMigrationNames(change: SchemaChange): string[] {
   if (change.type === 'type_upgrade' && change.name) {
     if (classifyTypeUpgradeSql(change.sql) === 'noop') {
-      return null;
+      return [];
     }
   }
 
-  return getSyntheticMigrationNameForChange(change);
+  return getSyntheticMigrationNamesForChange(change);
 }
 
 export function getActionableFailedMigrationNames(
@@ -39,8 +37,7 @@ export function getActionableFailedMigrationNames(
   const names = new Set<string>();
 
   for (const change of diff.changes) {
-    const name = getActionableGeneratedMigrationName(change);
-    if (name) {
+    for (const name of getActionableGeneratedMigrationNames(change)) {
       names.add(name);
     }
   }


### PR DESCRIPTION
## Summary
- Version generated type-upgrade IDs by source, target, and conversion SQL shape.
- Preserve previously applied migration records by assigning subsequent conversions a distinct ID.
- Keep historic bare IDs as status-only aliases so failed legacy migrations remain actionable.
- Cover identity derivation, db:migrate definitions, and status classification.

## Validation
- `pnpm build`
- `pnpm --filter @happyvertical/smrt-cli test` (798 passed, 6 skipped)
- `pnpm --filter @happyvertical/smrt-cli typecheck`
- `pnpm exec biome ci --diagnostic-level=error` on changed files
- `pnpm knowledge:check --changed --strict --format markdown`

Closes #2111

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019f5220-6b88-7a32-964d-79e43d9a7e67","issue":"2111","policy_revision":"1.0.0","validation":["pnpm build","pnpm --filter @happyvertical/smrt-cli test: 798 passed, 6 skipped","pnpm --filter @happyvertical/smrt-cli typecheck","biome changed-files check","knowledge freshness check"]}
```