### PR TITLE
fix(ci): serialize affected validation around generated routes

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -185,12 +185,17 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           auth-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Some SvelteKit package tasks generate tracked routes and restore the
+      # original tree during cleanup. Running typecheck and test together lets
+      # one task remove those routes while the other is importing them.
       - name: Run affected dependency closures
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_ENV: test
-        run: pnpm turbo run typecheck test --filter="...[$BASE_SHA]" --concurrency=2
+        run: |
+          pnpm turbo run typecheck --filter="...[$BASE_SHA]" --concurrency=2
+          pnpm turbo run test --filter="...[$BASE_SHA]" --concurrency=2
 
   affected-knowledge:
     name: Affected Knowledge Freshness

--- a/packages/content/src/contents-api.test.ts
+++ b/packages/content/src/contents-api.test.ts
@@ -2,16 +2,16 @@ import { getTestDatabase } from '@happyvertical/smrt-core';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { syncSchema } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Contents } from './contents';
 import {
   POST as createContent,
   GET as getList,
-} from '$lib/../routes/api/v1/contents/+server';
+} from './routes/api/v1/contents/+server';
 import {
   DELETE as deleteContent,
   GET as getSingle,
   PUT as updateContent,
-} from '$lib/../routes/api/v1/contents/[id]/+server';
-import { Contents } from './contents';
+} from './routes/api/v1/contents/[id]/+server';
 
 let currentContents: Contents | undefined;
 


### PR DESCRIPTION
## Summary

- run affected typechecks to completion before starting affected tests
- use package-relative imports for the content API's generated route modules
- document why those phases must not overlap

## Root cause

The affected job invoked `turbo run typecheck test` in one concurrent graph. SMRT/SvelteKit package tasks generate tracked route modules and restore/remove them during cleanup, so a package's typecheck cleanup could delete a route while that package's Vitest process was importing it. This produced the repeated missing-module failures on otherwise valid PRs.

## Validation

- `pnpm build` — 61/61 tasks passed
- affected typecheck phase — 30/30 Turbo tasks passed
- affected test phase — 30/30 Turbo tasks passed
- `@happyvertical/smrt-content` — 45/45 files, 302 passed, 6 skipped
- content typecheck, build, and `verify:pack` passed
- workflow `actionlint` and `yamllint` passed
- `pnpm audit:policy` passed
- frozen install passed
- strict knowledge freshness passed
- pre-commit and pre-push repository gates passed
- review-cycle: clean

Fixes #2119

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019f9cb9-d908-7b32-96f1-e6b2edabb038","issue":2119,"policy_revision":"1.0.0","validation":["pnpm build: 61/61 tasks passed","affected typecheck: 30/30 tasks passed","affected test: 30/30 tasks passed","smrt-content: 45 files, 302 passed, 6 skipped","content typecheck/build/verify:pack passed","actionlint and yamllint passed","pnpm audit:policy passed","pnpm install --frozen-lockfile passed","knowledge freshness passed","pre-commit and pre-push gates passed","review-cycle: clean"]}
```