### PR TITLE
ci: broker trusted SMRT CI

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -1,7 +1,7 @@
 # Continuous integration architecture
 
 SMRT uses hosted runners for lightweight static and control-plane checks and
-the shared `ci-linux-x64` pool for general builds, tests, and publishing. The
+the shared `arc-happyvertical` broker pool for general builds, tests, and publishing. The
 internal Turborepo server is the build-output cache; GitHub Actions cache
 archives are deliberately not used for `.turbo/cache`. If the remote cache is
 unavailable, Turbo performs a cold build.
@@ -22,13 +22,23 @@ never prevent the tests from running.
 
 ## Runner selection
 
-- `ci-linux-x64` is the default selector for general Linux work. It combines
-  ARC capacity with allowlisted PXE hosts using one workflow-facing label.
+- `arc-happyvertical` is the default selector for general Linux work. It is the
+  workflow-facing broker alias; only runner-pool policy chooses its backing
+  capacity.
 - `arc-happyvertical-node` is reserved for the runner-image smoke test and
   PostgreSQL shadow validation. Those jobs depend on its cluster-local database
   URL mount and intentionally do not join the general pool.
 - Lightweight lifecycle, policy, aggregation, stale-management, and mobile
   jobs remain GitHub-hosted when they do not benefit from a self-hosted cache.
+
+The PR caller uses `pull_request_target`, so GitHub loads runner selection from
+the trusted base branch rather than contributor-controlled merge YAML. It passes
+a PR head SHA to reusable general-CI workflows only when the head repository
+equals `github.repository`; merge-group and trusted push workflows use the
+broker normally. External fork PRs keep a base-revision hosted control-plane
+check, while the self-hosted validation and publish-dry-run calls are skipped
+and `Required CI` rejects the run. Broker admission must also deny those fork
+events before making a reservation.
 
 The retired `CI_NODE_RUNNER_ENABLED` switch no longer controls job placement
 and can be removed from the repository after this workflow migration is live.
@@ -59,7 +69,7 @@ representative code-changing PR run.
 
 After that canary run:
 
-1. Verify the `ci-linux-x64` ARC/PXE canary and one representative SMRT run.
+1. Verify the `arc-happyvertical` broker canary and one representative SMRT run.
 2. Set `CI_POSTGRES_ENABLED=true` after the disposable cluster and runner URL
    mount pass the manual shadow workflow.
 3. Set `CI_MERGE_QUEUE_ENABLED=true`.
@@ -142,9 +152,10 @@ p95 exceeds 45 seconds, runner memory exceeds 8 GiB, required contexts vanish,
 or retries/failures increase. Target setup p50 below 30 seconds, queue p95 below
 two minutes, and at least 30% fewer self-hosted runner-minutes per PR.
 
-Rollback runner placement by restoring general jobs to
-`arc-happyvertical-node`. Merge-queue rollout can be reversed independently by
-clearing `CI_MERGE_QUEUE_ENABLED`, restoring the previous required status list,
-and removing the merge-queue rule. PostgreSQL can be removed from the required
-aggregator without altering SQLite coverage. The artifact publisher can
-temporarily fall back to Changesets through manual dispatch.
+Runner placement remains brokered through `arc-happyvertical`; change backing
+capacity only in runner-pool policy, not workflow labels. Merge-queue rollout
+can be reversed independently by clearing `CI_MERGE_QUEUE_ENABLED`, restoring
+the previous required status list, and removing the merge-queue rule.
+PostgreSQL can be removed from the required aggregator without altering SQLite
+coverage. The artifact publisher can temporarily fall back to Changesets
+through manual dispatch.

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,6 @@
 self-hosted-runner:
   labels:
-    - ci-linux-x64
+    - arc-happyvertical
     - arc-happyvertical-node
 
 config-variables: null

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -1,7 +1,9 @@
 name: Pull Request Validation
 
 on:
-  pull_request:
+  # This event always loads workflow YAML from the trusted base branch, so an
+  # external fork cannot modify runner selection in its merge commit.
+  pull_request_target:
     branches: [main]
     types: [opened, synchronize, reopened]
   merge_group:
@@ -13,7 +15,7 @@ concurrency:
       github.event.merge_group.head_sha ||
       github.ref
     }}-${{
-      github.event_name == 'pull_request' &&
+      github.event_name == 'pull_request_target' &&
       !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       !(github.event.action == 'edited' && github.event.changes.base != null) &&
       'lifecycle' ||
@@ -23,6 +25,11 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  # Only same-repository PRs check out their head. External forks retain the
+  # base revision; their reusable self-hosted workflows are skipped below.
+  CHECKOUT_REF: >-
+    ${{ github.event.pull_request.head.repo.full_name == github.repository &&
+    github.event.pull_request.head.sha || github.sha }}
 
 permissions:
   contents: read
@@ -36,7 +43,7 @@ jobs:
     name: Validate Conventional Commits
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: ubuntu-latest
 
@@ -44,6 +51,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
 
       # We deliberately don't use wagoid/commitlint-github-action here.
@@ -69,7 +77,7 @@ jobs:
 
       - name: Validate commit messages
         env:
-          # GITHUB_BASE_REF is set by GitHub for pull_request events
+          # GITHUB_BASE_REF is set by GitHub for pull_request_target events
           # and always carries a branch name (GitHub-validated).
           # Reading it into an env var keeps the shell substitution
           # out of the ${{ ... }} layer to satisfy the workflow-
@@ -87,12 +95,14 @@ jobs:
     name: Validate Workflow Files
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Get changed workflow files
         id: changed-files
@@ -161,12 +171,14 @@ jobs:
     name: Check SDK Version Alignment
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Verify SDK packages use same version
         run: bash scripts/check-sdk-versions.sh
@@ -175,7 +187,7 @@ jobs:
     name: Secret Scan (gitleaks)
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: ubuntu-latest
     steps:
@@ -183,6 +195,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
 
       - name: Install gitleaks
@@ -213,12 +226,14 @@ jobs:
     name: Check Monorepo Standards
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       # Pin Node to the version declared in package.json engines so that
       # `import.meta.dirname` (Node 20.11+) and other modern features used by
@@ -307,13 +322,15 @@ jobs:
     name: Dependency Vulnerability Audit
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -346,11 +363,13 @@ jobs:
     name: Validate Changes
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     uses: ./.github/workflows/test-suite.yml
     with:
       mode: ${{ github.event_name == 'merge_group' && 'full' || (vars.CI_MERGE_QUEUE_ENABLED == 'true' && 'affected' || 'full') }}
+      checkout_ref: ${{ github.event.pull_request.head.sha || github.sha }}
     permissions:
       contents: read
       packages: read
@@ -359,9 +378,12 @@ jobs:
     name: Publish Dry Run
     if: >-
       github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
+      (github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     uses: ./.github/workflows/publish-dry-run.yml
+    with:
+      checkout_ref: ${{ github.event.pull_request.head.sha || github.sha }}
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -2,11 +2,18 @@ name: Publish Dry Run
 
 on:
   workflow_call:
+    inputs:
+      checkout_ref:
+        description: 'Trusted caller-selected revision to validate'
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
   PUBLISH_PACK_SHARD_COUNT: '2'
+  CHECKOUT_REF: ${{ inputs.checkout_ref || github.sha }}
 
 permissions:
   contents: read
@@ -15,7 +22,7 @@ permissions:
 jobs:
   prepare-publish:
     name: Prepare Publish Validation
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     outputs:
       should-validate: ${{ steps.prepare.outputs.should_validate }}
@@ -24,6 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
 
       - name: Setup Environment
@@ -134,7 +142,7 @@ jobs:
   validate-publish-shards:
     needs: prepare-publish
     if: needs.prepare-publish.outputs.should-validate == 'true'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -150,6 +158,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           # Preparation already produced the versioned workspace artifact.
           # Pack shards only need workflow actions and scripts from this ref;
           # fetching full history here can exhaust the 20-minute ARC timeout.
@@ -197,13 +206,15 @@ jobs:
       - prepare-publish
       - validate-publish-shards
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 5
 
     steps:
       - name: Checkout repository
         if: needs.prepare-publish.outputs.should-validate == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Download verified package artifacts
         if: needs.prepare-publish.outputs.should-validate == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ permissions:
 jobs:
   prepare-release:
     name: Prepare Release
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 20
     outputs:
       previous-version: ${{ steps.prepare.outputs.previous_version }}
@@ -223,7 +223,7 @@ jobs:
   validate-release-shards:
     needs: prepare-release
     if: needs.prepare-release.outputs.should-publish == 'true'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -286,7 +286,7 @@ jobs:
     if: |
       needs.prepare-release.outputs.should-publish == 'true' &&
       needs.validate-release-shards.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 45
     concurrency:
       group: release-publish-${{ github.repository }}-${{ github.ref }}
@@ -445,7 +445,7 @@ jobs:
 
   deploy-docs:
     name: Deploy Documentation
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -8,20 +8,28 @@ on:
         required: false
         type: string
         default: full
+      checkout_ref:
+        description: 'Trusted caller-selected revision to validate'
+        required: false
+        type: string
+        default: ''
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  CHECKOUT_REF: ${{ inputs.checkout_ref || github.sha }}
 
 jobs:
   affected-scope:
     name: Detect Affected Validation Scope
     if: inputs.mode == 'affected'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     outputs:
       knowledge: ${{ steps.filter.outputs.knowledge }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Detect knowledge-sensitive changes
         id: filter
@@ -43,13 +51,14 @@ jobs:
   build:
     name: Build
     if: inputs.mode == 'full'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 15
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           # Changesets needs complete commit/tag history, but not historical
           # file contents. Avoid transferring every old blob on ARC runners.
           fetch-depth: 0
@@ -122,12 +131,14 @@ jobs:
     name: Typecheck
     needs: build
     if: inputs.mode == 'full'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 15
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -149,12 +160,14 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 10
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -168,12 +181,13 @@ jobs:
     name: Affected Build, Typecheck, and Tests
     needs: affected-scope
     if: inputs.mode == 'affected'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
 
       - name: Setup environment
@@ -201,11 +215,13 @@ jobs:
     name: Affected Knowledge Freshness
     needs: affected-scope
     if: inputs.mode == 'affected' && needs.affected-scope.outputs.knowledge == 'true'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -230,12 +246,14 @@ jobs:
     name: Knowledge Freshness
     needs: build
     if: inputs.mode == 'full'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 10
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -269,7 +287,7 @@ jobs:
     name: Coverage Gate
     needs: build
     if: always() && (inputs.mode == 'affected' || needs.build.result == 'success')
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 25
 
     steps:
@@ -278,6 +296,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
 
       - name: Setup environment
@@ -330,7 +349,7 @@ jobs:
   test-core:
     needs: build
     if: inputs.mode == 'full'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     # A remote-cache outage can add several minutes of cold setup and build
     # time. Match the package-shard ceiling so cache misses cannot cancel an
     # otherwise healthy core suite.
@@ -344,6 +363,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -385,12 +406,14 @@ jobs:
     name: Test Integration
     needs: build
     if: inputs.mode == 'full'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     timeout-minutes: 10
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -419,7 +442,7 @@ jobs:
   test-packages:
     needs: build
     if: inputs.mode == 'full'
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     # Each shard runs ~1/3 of package tests and lets Turbo build only their
     # dependency closures. Keep the wider timeout for runner-pool contention.
     timeout-minutes: 25
@@ -432,6 +455,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
 
       - name: Setup environment
         uses: ./.github/actions/setup-environment
@@ -472,7 +497,7 @@ jobs:
   test-packages-result:
     name: Test Packages
     needs: test-packages
-    runs-on: ubuntu-latest
+    runs-on: arc-happyvertical
     if: always() && inputs.mode == 'full'
     steps:
       - name: Verify all Test Packages shards passed


### PR DESCRIPTION
## Summary

- Routes trusted portable CI through the provider-neutral `arc-happyvertical` broker alias.
- Uses trusted-base `pull_request_target` handling so only same-repository PR heads reach reusable self-hosted validation.
- Skips external-fork broker calls before assignment and documents the separate broker-admission denial.

## Rebase and re-validation (2026-07-28)

Rebased onto `main` (`36d48d9c6`). No content change; the original diff applied cleanly.

The first lifecycle run on 2026-07-26T23:40Z was rejected by policy generation 13 with
`validation workflow top-level on.pull_request mapping is missing`. That rejection is obsolete:
`fix(lifecycle): admit trusted-base public validation` landed in the policy source at
2026-07-26T23:58Z — 18 minutes later — and generation 16 now models this exact pattern as a
first-class "trusted-base validation workflow".

Re-validated against the current policy source:

- `validation_workflow_trigger_errors` → clean (composite entry point; covers the trusted-base
  gate, check contexts, and matrix rules).
- `validation_workflow_base_errors` → clean.
- The workflow matches `TRUSTED_BASE_CHECKOUT_REF`, `TRUSTED_BASE_HOSTED_GATE`,
  `TRUSTED_BASE_SELF_HOSTED_GATE`, and `TRUSTED_BASE_REUSABLE_REF` exactly.
- `actionlint` clean on all changed workflows; `yamllint` reports only line-length warnings that
  already exist on `main`.

Broker readiness confirmed: `arc-happyvertical` is served by the `brokered-general-linux-x64`
runner group, which allows public repositories, lists `happyvertical/smrt` on its explicit
allowlist, and currently has three online runners (two Patdown JIT, one Landgraf).

Precedent: `happyvertical/sdk` landed the identical transition in
happyvertical/sdk#1149 and passes lifecycle today with `pull_request_target` plus
`arc-happyvertical`.

### Expected: no `Required CI` run on this PR

Switching the validation trigger means neither event can produce a validation run for this PR —
`pull_request` reads the head (which no longer subscribes) and `pull_request_target` reads the
base (which does not yet subscribe). `Required CI` therefore stays unreported until this merges.
happyvertical/sdk#1149 hit the same condition and merged on lifecycle plus release evidence;
the `Repository CI / required` ruleset carries an Integration bypass actor for exactly this case.

## Validation

- `actionlint` and `yamllint` for changed workflows
- workflow checkout/guard assertions
- policy trigger/base checkers run against the current policy source
- runner-group admission verified against the live org configuration

Closes #2123

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"claude-2123-trusted-broker-ci-454569","issue":2123,"policy_revision":"1.0.0","validation":"actionlint, yamllint, policy trigger/base checkers against current source, runner-group admission verified"}
```
