### PR TITLE
fix(core): align client generation and timestamp migrations

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -182,7 +182,7 @@ jobs:
     needs: affected-scope
     if: inputs.mode == 'affected'
     runs-on: arc-happyvertical
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -67,14 +67,17 @@ smrt db:migrate --postgres-timestamp-legacy-timezone UTC
 ```
 
 The option has no default and rejects every value other than `UTC`. On
-PostgreSQL, it allows the manifest-owned timestamp columns to be converted to
-`timestamptz` with `USING column AT TIME ZONE 'UTC'`, preserving the proven UTC
-instants. It is not safe for a database with any local-time writer; use an
-application-owned, provenance-aware migration in that case. Rehearse against a
-restored clone and keep a verified backup because type upgrades have no
-automatic down migration. `smrt db:diff --postgres-timestamp-legacy-timezone
-UTC` and `smrt db:migrate --dry-run --postgres-timestamp-legacy-timezone UTC`
-both preview the same conversion without writing it.
+PostgreSQL, `db:migrate` first converts framework-owned `_smrt_*` timestamp
+columns before migration-tracker bootstrap, then converts manifest-owned
+columns to `timestamptz` with `USING column AT TIME ZONE 'UTC'`. This preserves
+the proven UTC instants. It is not safe for a database with any local-time
+writer; use an application-owned, provenance-aware migration in that case.
+Rehearse against a restored clone and keep a verified backup because type
+upgrades have no automatic down migration. `smrt db:diff
+--postgres-timestamp-legacy-timezone UTC` previews manifest-owned changes;
+`smrt db:migrate --dry-run --postgres-timestamp-legacy-timezone UTC` also
+queries and prints the read-only `_smrt_*` conversion plan without initializing
+the tracker or writing to the database.
 
 ### Code Generation
 

--- a/packages/cli/src/commands/__tests__/utilities-handlers.test.ts
+++ b/packages/cli/src/commands/__tests__/utilities-handlers.test.ts
@@ -42,6 +42,8 @@ const h = vi.hoisted(() => {
     generateSchema: vi.fn(async () => 'CREATE TABLE t ()'),
     schemaComparerOptions: vi.fn(),
     schemaCompare: vi.fn(async () => ({ added_tables: [], changes: [] })),
+    migratePostgresSystemTimestamps: vi.fn(async () => {}),
+    planPostgresSystemTimestampMigrations: vi.fn(async () => []),
     manifestGenerate: vi.fn(async () => ({
       objects: { '@app:Article': {} },
     })),
@@ -69,6 +71,9 @@ const {
   generateSchema,
   schemaComparerOptions,
   schemaCompare,
+  migratePostgresSystemTimestamps,
+  planPostgresSystemTimestampMigrations,
+  trackerInitialize,
   manifestGenerate,
   discoverBaseClasses,
   rlQuestion,
@@ -100,6 +105,10 @@ vi.mock('@happyvertical/smrt-core', () => ({
     indexes: [],
     triggers: [],
   })),
+  migratePostgresSystemTimestamps: (...args: unknown[]) =>
+    h.migratePostgresSystemTimestamps(...args),
+  planPostgresSystemTimestampMigrations: (...args: unknown[]) =>
+    h.planPostgresSystemTimestampMigrations(...args),
   isQualifiedName: vi.fn((s: string) => s.includes(':')),
   getClassName: vi.fn((s: string) => (s.includes(':') ? s.split(':')[1] : s)),
 }));
@@ -211,6 +220,7 @@ describe('utility command handlers', () => {
     });
     getDatabase.mockResolvedValue({ close: vi.fn() });
     schemaCompare.mockResolvedValue({ added_tables: [], changes: [] });
+    planPostgresSystemTimestampMigrations.mockResolvedValue([]);
     trackerApplyAll.mockResolvedValue([]);
   });
 
@@ -445,13 +455,21 @@ describe('utility command handlers', () => {
     expect(logged()).toContain('Database schema is up to date');
   });
 
-  it('db:migrate forwards only the exact UTC timestamp confirmation to the schema comparer', async () => {
+  it('db:migrate upgrades SMRT system timestamps before tracker bootstrap and forwards the exact UTC confirmation', async () => {
     configureMigrate();
 
     await utilityCommands['db:migrate'].handler([], {
       'postgres-timestamp-legacy-timezone': 'UTC',
     });
 
+    expect(migratePostgresSystemTimestamps).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.any(Function) }),
+      { legacyTimezone: 'UTC' },
+      'sqlite',
+    );
+    expect(
+      migratePostgresSystemTimestamps.mock.invocationCallOrder[0],
+    ).toBeLessThan(trackerInitialize.mock.invocationCallOrder[0]);
     expect(schemaComparerOptions).toHaveBeenCalledWith(
       expect.objectContaining({
         postgresTimestampMigration: { legacyTimezone: 'UTC' },
@@ -466,6 +484,47 @@ describe('utility command handlers', () => {
 
     expect(errored()).toContain('must be exactly UTC');
     expect(process.exitCode).toBe(1);
+  });
+
+  it('db:migrate keeps UTC timestamp preview strictly read-only', async () => {
+    configureMigrate();
+    planPostgresSystemTimestampMigrations.mockResolvedValue([
+      {
+        kind: 'column',
+        tableName: '_smrt_changes',
+        columnName: 'created_at',
+        sql: `ALTER TABLE "_smrt_changes" ALTER COLUMN "created_at" TYPE TIMESTAMPTZ USING "created_at" AT TIME ZONE 'UTC'`,
+      },
+      {
+        kind: 'change-feed-function',
+        tableName: '_smrt_changes',
+        sql: 'DROP FUNCTION legacy();\nCREATE FUNCTION current() RETURNS void AS $$ BEGIN END $$;',
+      },
+    ]);
+
+    await utilityCommands['db:migrate'].handler([], {
+      'dry-run': true,
+      'postgres-timestamp-legacy-timezone': 'UTC',
+    });
+
+    expect(migratePostgresSystemTimestamps).not.toHaveBeenCalled();
+    expect(trackerInitialize).not.toHaveBeenCalled();
+    expect(planPostgresSystemTimestampMigrations).toHaveBeenCalledWith(
+      expect.objectContaining({ query: expect.any(Function) }),
+      { legacyTimezone: 'UTC' },
+      'sqlite',
+    );
+    expect(schemaComparerOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        postgresTimestampMigration: { legacyTimezone: 'UTC' },
+      }),
+    );
+    expect(logged()).toContain('_smrt_changes.created_at');
+    expect(logged()).toContain(
+      `ALTER TABLE "_smrt_changes" ALTER COLUMN "created_at" TYPE TIMESTAMPTZ`,
+    );
+    expect(logged()).not.toContain('$$;;');
+    expect(logged()).not.toContain('Database schema is up to date');
   });
 
   it('db:migrate previews changes in --dry-run mode', async () => {

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -12,7 +12,9 @@ import { fileURLToPath } from 'node:url';
 import {
   generateDDLForEngine,
   isQualifiedName,
+  migratePostgresSystemTimestamps,
   ObjectRegistry,
+  planPostgresSystemTimestampMigrations,
   SchemaComparer,
 } from '@happyvertical/smrt-core';
 import type {
@@ -1216,6 +1218,7 @@ export default testManifest;
         const postgresTimestampMigration = resolvePostgresTimestampMigration(
           options['postgres-timestamp-legacy-timezone'],
         );
+        const isDryRun = options['dry-run'] ?? false;
 
         // 1. Load CLI config
         const { getPackageConfig } = await import('@happyvertical/smrt-config');
@@ -1345,6 +1348,26 @@ export default testManifest;
           `✓ Connected to ${formatDatabaseDisplayUrl(dbType, dbUrl)}\n`,
         );
 
+        // MigrationTracker bootstraps framework-owned tables and deliberately
+        // rejects legacy timezone-naive system columns. Apply the same
+        // explicit UTC confirmation to those tables first so the documented
+        // one-shot PostgreSQL migration path can reach schema comparison.
+        const systemTimestampPreview =
+          postgresTimestampMigration && isDryRun
+            ? await planPostgresSystemTimestampMigrations(
+                db,
+                postgresTimestampMigration,
+                dbType,
+              )
+            : [];
+        if (postgresTimestampMigration && !isDryRun) {
+          await migratePostgresSystemTimestamps(
+            db,
+            postgresTimestampMigration,
+            dbType,
+          );
+        }
+
         // 7.5. Initialize MigrationTracker for tracking applied migrations
         const { MigrationTracker, shortChecksum } = await import(
           '@happyvertical/smrt-core/migrations'
@@ -1354,11 +1377,17 @@ export default testManifest;
           db,
           useConcurrentIndexes: options['postgres-safe'] ?? false,
         });
-        await tracker.initialize();
+        if (!isDryRun) {
+          await tracker.initialize();
+        }
 
         if (options.verbose) {
           const engine = tracker.getEngine();
-          console.log(`Migration tracker initialized (engine: ${engine})`);
+          console.log(
+            isDryRun
+              ? `Migration tracker preview configured (engine: ${engine})`
+              : `Migration tracker initialized (engine: ${engine})`,
+          );
           if (options['postgres-safe'] && engine === 'postgres') {
             console.log(
               'PostgreSQL-safe mode enabled (CONCURRENTLY, lock_timeout)',
@@ -1372,7 +1401,6 @@ export default testManifest;
         const migrations: MigrationAction[] = [];
         const manualInterventions: MigrationAction[] = [];
         const tableErrorCount = 0;
-        const isDryRun = options['dry-run'] ?? false;
         const applySchemaMigrations = shouldApplySchemaMigrations({
           dryRun: isDryRun,
         });
@@ -1473,7 +1501,8 @@ export default testManifest;
         const schemaUpToDate =
           migrations.length === 0 &&
           manualInterventions.length === 0 &&
-          !tablesCreated;
+          !tablesCreated &&
+          systemTimestampPreview.length === 0;
 
         // 11. Preview or execute migrations
         // Note: SQL statements come from SchemaComparer via change.sql
@@ -1491,6 +1520,20 @@ export default testManifest;
             );
           } else {
             console.log('📋 Migration Preview (not executed):\n');
+
+            if (systemTimestampPreview.length > 0) {
+              console.log(
+                `  🕰️  SMRT system timestamp columns to convert: ${systemTimestampPreview.length}`,
+              );
+              for (const migration of systemTimestampPreview) {
+                console.log(
+                  migration.kind === 'column'
+                    ? `     ${migration.tableName}.${migration.columnName}`
+                    : '     _smrt_changes append function signature',
+                );
+              }
+              console.log();
+            }
 
             const columnMigrations = migrations.filter(
               (m) => m.type === 'add_column',
@@ -1532,6 +1575,12 @@ export default testManifest;
             }
 
             console.log('  SQL Statements:\n');
+            for (const migration of systemTimestampPreview) {
+              const terminator = migration.sql.trimEnd().endsWith(';')
+                ? ''
+                : ';';
+              console.log(`    ${migration.sql}${terminator}`);
+            }
             for (const m of migrations) {
               const sqlStatements = m.sqlStatements ?? (m.sql ? [m.sql] : []);
               for (const sql of sqlStatements) {

--- a/packages/core/src/__tests__/system-table-compatibility.test.ts
+++ b/packages/core/src/__tests__/system-table-compatibility.test.ts
@@ -7,6 +7,7 @@ import {
   ensureJobEventsSystemTableCompatibility,
   ensureJobsSystemTableCompatibility,
   migratePostgresSystemTimestamps,
+  planPostgresSystemTimestampMigrations,
 } from '../system/compatibility';
 import { getSystemTableDDL, SMRT_SCHEMA_VERSION } from '../system/schema';
 
@@ -555,7 +556,91 @@ describe('system table compatibility', () => {
     expect(migration).toContain(
       'DROP FUNCTION IF EXISTS _smrt_append_change(text,text,text,text,timestamp without time zone)',
     );
+    expect(migration).toContain(
+      "IF to_regprocedure('_smrt_append_change(text,text,text,text,timestamp without time zone)') IS NOT NULL THEN",
+    );
     expect(migration).toContain('p_created_at TIMESTAMPTZ');
+  });
+
+  it('plans legacy PostgreSQL system timestamp conversions without mutating', async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [{ timezone: 'UTC', legacy_change_feed_function_exists: true }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { table_name: '_smrt_dispatch', column_name: 'created_at' },
+          { table_name: '_smrt_jobs', column_name: 'run_at' },
+        ],
+      });
+
+    const plan = await planPostgresSystemTimestampMigrations(
+      { url: 'postgresql://localhost/test', query } as any,
+      { legacyTimezone: 'UTC' },
+      'postgres',
+    );
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(plan).toEqual([
+      {
+        kind: 'column',
+        tableName: '_smrt_dispatch',
+        columnName: 'created_at',
+        sql: `ALTER TABLE "_smrt_dispatch" ALTER COLUMN "created_at" TYPE TIMESTAMPTZ USING "created_at" AT TIME ZONE 'UTC'`,
+      },
+      {
+        kind: 'column',
+        tableName: '_smrt_jobs',
+        columnName: 'run_at',
+        sql: `ALTER TABLE "_smrt_jobs" ALTER COLUMN "run_at" TYPE TIMESTAMPTZ USING "run_at" AT TIME ZONE 'UTC'`,
+      },
+      expect.objectContaining({
+        kind: 'change-feed-function',
+        tableName: '_smrt_changes',
+        sql: expect.stringContaining(
+          'DROP FUNCTION IF EXISTS _smrt_append_change',
+        ),
+      }),
+    ]);
+  });
+
+  it('does not re-plan an already-removed legacy change-feed helper', async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [{ timezone: 'UTC', legacy_change_feed_function_exists: false }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(
+      planPostgresSystemTimestampMigrations(
+        { url: 'postgresql://localhost/test', query } as any,
+        { legacyTimezone: 'UTC' },
+        'postgres',
+      ),
+    ).resolves.toEqual([]);
+    expect(String(query.mock.calls[0]?.[0])).toContain('to_regprocedure');
+  });
+
+  it('refuses to preview the system timestamp migration outside a UTC session', async () => {
+    const query = vi.fn(async () => ({
+      rows: [
+        {
+          timezone: 'America/Edmonton',
+          legacy_change_feed_function_exists: false,
+        },
+      ],
+    }));
+
+    await expect(
+      planPostgresSystemTimestampMigrations(
+        { url: 'postgresql://localhost/test', query } as any,
+        { legacyTimezone: 'UTC' },
+        'postgres',
+      ),
+    ).rejects.toThrow('outside a UTC PostgreSQL session');
+    expect(query).toHaveBeenCalledTimes(1);
   });
 
   it('refuses to stamp a partial PostgreSQL system schema with legacy timestamps', async () => {

--- a/packages/core/src/consumer-plugin/index.ts
+++ b/packages/core/src/consumer-plugin/index.ts
@@ -6,9 +6,9 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { Plugin } from 'vite';
-import { CLIENT_FETCH_RUNTIME } from '../generated-client-runtime.js';
 import { generateDeclarations } from '../prebuild/index.js';
 import type { SmartObjectManifest } from '../scanner/types.js';
+import { generateClientModule } from '../vite-plugin/generated-client.js';
 
 /**
  * Loosely-typed view of an object definition as carried by an external
@@ -71,6 +71,11 @@ export interface SmrtConsumerOptions {
   projectRoot?: string;
   /** SvelteKit integration mode */
   svelteKit?: boolean;
+  /**
+   * Apply kebab-case to generated custom-method URL segments. This must match
+   * the producer plugin's `svelteKit.kebabRoutes` setting.
+   */
+  kebabRoutes?: boolean;
   /** Use static types only (for federation builds) */
   staticTypes?: boolean;
   /** Disable file scanning */
@@ -102,6 +107,7 @@ export function smrtConsumer(options: SmrtConsumerOptions = {}): Plugin {
     typesDir = 'src/types/smrt-generated',
     projectRoot = process.cwd(),
     disableScanning = false,
+    kebabRoutes = false,
   } = options;
 
   let smrtPackages: string[] = [];
@@ -176,7 +182,7 @@ export function smrtConsumer(options: SmrtConsumerOptions = {}): Plugin {
           return generateFallbackRoutesModule();
 
         case 'smrt-consumer:client':
-          return generateFallbackClientModule(typeManifest);
+          return generateFallbackClientModule(typeManifest, { kebabRoutes });
 
         case 'smrt-consumer:mcp':
           return generateFallbackMcpModule();
@@ -684,7 +690,10 @@ export default setupRoutes;
 `;
 }
 
-function generateFallbackClientModule(manifest: ConsumerManifest): string {
+function generateFallbackClientModule(
+  manifest: ConsumerManifest,
+  options: { kebabRoutes?: boolean } = {},
+): string {
   const objects = Object.entries(manifest?.objects || {});
   if (objects.length === 0) {
     return `
@@ -697,49 +706,9 @@ export default createClient;
 `;
   }
 
-  // Generate basic client from manifest.
-  //
-  // Object keys are QUOTED via JSON.stringify (#1795): a manifest key can be a
-  // package-qualified name like `@happyvertical/smrt-assets:AssetAssociation`,
-  // which is not a valid bare object-literal key and produced a build-breaking
-  // syntax error in the emitted module. Fetchers reject on !response.ok (#1796)
-  // via the shared __smrtFetchJson/__smrtFetchOk runtime.
-  const clientMethods = objects
-    .map(([name, obj]) => {
-      const { collection } = obj;
-      return `
-  ${JSON.stringify(name)}: {
-    list: () => __smrtFetchJson(basePath + '/${collection}', { method: 'GET' }),
-    get: (id) => __smrtFetchJson(basePath + '/${collection}/' + id, { method: 'GET' }),
-    create: (data) => __smrtFetchJson(basePath + '/${collection}', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data)
-    }),
-    update: (id, data) => __smrtFetchJson(basePath + '/${collection}/' + id, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data)
-    }),
-    delete: (id) => __smrtFetchOk(basePath + '/${collection}/' + id, {
-      method: 'DELETE'
-    }),
-    search: (query) => __smrtFetchJson(basePath + '/${collection}/search?q=' + encodeURIComponent(query), { method: 'GET' })
-  }`;
-    })
-    .join(',');
-
-  return `
-// Auto-generated API client from SMRT consumer
-
-${CLIENT_FETCH_RUNTIME}
-
-export function createClient(basePath = '/api/v1') {
-  return {${clientMethods}
-  };
-}
-export default createClient;
-`;
+  return generateClientModule(manifest as unknown as SmartObjectManifest, {
+    kebabRoutes: options.kebabRoutes,
+  });
 }
 
 function generateFallbackMcpModule(): string {

--- a/packages/core/src/consumer-plugin/load-resolve.test.ts
+++ b/packages/core/src/consumer-plugin/load-resolve.test.ts
@@ -197,6 +197,35 @@ describe('smrtConsumer load with a populated manifest', () => {
             methods: {},
             decoratorConfig: {},
           },
+          AuditEvent: {
+            className: 'AuditEvent',
+            collection: 'audit-events',
+            fields: {},
+            methods: {},
+            decoratorConfig: {},
+          },
+          HiddenWidget: {
+            className: 'HiddenWidget',
+            collection: 'hiddenWidgets',
+            fields: {},
+            methods: {},
+            decoratorConfig: { api: false },
+          },
+          Report: {
+            className: 'Report',
+            collection: 'reports',
+            fields: {},
+            methods: {
+              revealSecret: {
+                name: 'revealSecret',
+                parameters: [],
+                returnType: 'string',
+                isPublic: true,
+                isStatic: false,
+              },
+            },
+            decoratorConfig: { api: { include: ['get', 'revealSecret'] } },
+          },
         },
       }),
     );
@@ -215,17 +244,52 @@ describe('smrtConsumer load with a populated manifest', () => {
     const plugin = await pluginWithObjects();
     const load = getHook(plugin, 'load');
 
-    const client = await load.call({}, '\0smrt-consumer:client');
-    // Object keys are quoted (#1795), so a simple name appears as "Widget":.
-    expect(client).toContain('"Widget":');
+    const client = (await load.call({}, '\0smrt-consumer:client')) as string;
+    expect(client).toContain('"widgets":');
     expect(client).toContain("'/widgets'");
-    // The fallback emits every CRUD verb the declared CrudOperations promises,
-    // including search — otherwise the @smrt/client d.ts would advertise a
-    // method the runtime object lacks (TypeError at call time).
     expect(client).toContain('search:');
+    expect(client).toContain('"reports":');
+    expect(client).toContain('revealSecret:');
+    expect(client).toContain('"audit-events":');
+    expect(client).not.toContain('hiddenWidgets');
+
+    const dataUri = `data:text/javascript,${encodeURIComponent(client)}`;
+    const mod = await import(dataUri);
+    const api = mod.createClient('/api/v1');
+    expect(Object.keys(api)).toEqual(['audit-events', 'reports', 'widgets']);
+    expect(Object.keys(api.reports).sort()).toEqual(['get', 'revealSecret']);
+    expect(api['audit-events']).toBeDefined();
+    expect(Object.keys(api.widgets).sort()).toEqual([
+      'create',
+      'delete',
+      'get',
+      'list',
+      'search',
+      'update',
+    ]);
 
     const types = await load.call({}, '\0smrt-consumer:types');
     expect(types).toContain('export interface WidgetData');
+  });
+
+  it('applies the configured kebabRoutes policy to consumer custom methods', async () => {
+    const plugin = smrtConsumer({
+      packages: ['@acme/widgets'],
+      generateTypes: false,
+      projectRoot,
+      disableScanning: true,
+      kebabRoutes: true,
+    });
+
+    // Reuse the package fixture populated by the helper, then initialize this
+    // plugin with the route policy used by the producer SvelteKit generator.
+    await pluginWithObjects();
+    await plugin.buildStart?.call({} as any);
+    const load = getHook(plugin, 'load');
+    const client = (await load.call({}, '\0smrt-consumer:client')) as string;
+
+    expect(client).toContain("'/reports/' + id + '/reveal-secret'");
+    expect(client).not.toContain("'/reports/' + id + '/revealSecret'");
   });
 
   it('emits SYNTACTICALLY VALID client code for a package-qualified manifest key (#1795)', async () => {
@@ -275,17 +339,18 @@ describe('smrtConsumer load with a populated manifest', () => {
     const load = getHook(plugin, 'load');
     const client = (await load.call({}, '\0smrt-consumer:client')) as string;
 
-    // The qualified key is present and QUOTED.
-    expect(client).toContain('"@acme/assets:AssetAssociation":');
+    // Runtime keys use the same stable collection key as declarations.
+    expect(client).toContain('"asset_associations":');
+    expect(client).not.toContain('@acme/assets:AssetAssociation');
 
     // The emitted module must be syntactically valid: import it as a data URI.
     // A pre-fix unquoted key throws SyntaxError here.
     const dataUri = `data:text/javascript,${encodeURIComponent(client)}`;
     const mod = await import(dataUri);
     expect(typeof mod.createClient).toBe('function');
-    // The client exposes the qualified key as a collection accessor.
+    // The client exposes the stable collection key as its accessor.
     const api = mod.createClient('/api/v1');
-    const accessor = api['@acme/assets:AssetAssociation'];
+    const accessor = api.asset_associations;
     expect(accessor).toBeDefined();
     // Every CRUD verb the declared CrudOperations promises is present.
     for (const verb of [

--- a/packages/core/src/prebuild/index.test.ts
+++ b/packages/core/src/prebuild/index.test.ts
@@ -17,6 +17,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import ts from 'typescript';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SmartObjectManifest } from '../scanner/types.js';
 import { generateDeclarations, generateDeclarationsFromCLI } from './index.js';
@@ -170,8 +171,8 @@ describe('generateDeclarations', () => {
     const clientDecl = readFileSync(join(outDir, 'smrt-client.d.ts'), 'utf-8');
     expect(clientDecl).toContain("declare module '@smrt/client'");
     // Client interface derives CRUD operations keyed by unique collection name.
-    expect(clientDecl).toContain('articles: CrudOperations<ArticleData>;');
-    expect(clientDecl).toContain('authors: CrudOperations<AuthorData>;');
+    expect(clientDecl).toContain('"articles": CrudOperations<ArticleData>;');
+    expect(clientDecl).toContain('"authors": CrudOperations<AuthorData>;');
 
     const typesDecl = readFileSync(join(outDir, 'smrt-types.d.ts'), 'utf-8');
     expect(typesDecl).toContain("declare module '@smrt/types'");
@@ -179,6 +180,49 @@ describe('generateDeclarations', () => {
     expect(typesDecl).toContain(
       "export type ArticleData = import('./smrt-objects').ArticleData;",
     );
+  });
+
+  it('quotes non-identifier collection keys in client and web declarations', async () => {
+    const manifest = buildManifest();
+    manifest.objects.AuditEvent = {
+      className: 'AuditEvent',
+      collection: 'audit-events',
+      fields: {},
+      methods: {},
+      decoratorConfig: {},
+    } as any;
+
+    await generateDeclarations({
+      manifest,
+      outDir,
+      includeVirtualModules: true,
+      includeObjectTypes: true,
+    });
+
+    const clientDecl = readFileSync(join(outDir, 'smrt-client.d.ts'), 'utf-8');
+    const webDecl = readFileSync(join(outDir, 'smrt-web.d.ts'), 'utf-8');
+    expect(clientDecl).toContain(
+      '"audit-events": CrudOperations<AuditEventData>;',
+    );
+    expect(webDecl).toContain('"audit-events": SmrtWebCollectionDefinition<');
+
+    const sourceFile = ts.createSourceFile(
+      'generated-virtual-modules.d.ts',
+      `${clientDecl}\n${webDecl}`,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const diagnostics = (
+      sourceFile as ts.SourceFile & {
+        parseDiagnostics: readonly ts.Diagnostic[];
+      }
+    ).parseDiagnostics;
+    expect(
+      diagnostics.filter(
+        (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+      ),
+    ).toEqual([]);
   });
 
   it('types canonical collection endpoints from populated models regardless of manifest order', async () => {
@@ -209,16 +253,66 @@ describe('generateDeclarations', () => {
 
     expect(collectionFirstClient).toBe(modelFirstClient);
     expect(collectionFirstClient).toContain(
-      'agreementExecutions: CrudOperations<AgreementExecutionData>;',
+      '"agreementExecutions": CrudOperations<AgreementExecutionData>;',
     );
     expect(collectionFirstClient).toContain(
-      'agreementExecutionCollection: CrudOperations<AgreementExecutionData>;',
+      '"agreementExecutionCollection": CrudOperations<AgreementExecutionData>;',
     );
     expect(collectionFirstClient).not.toContain(
-      'agreementExecutions: CrudOperations<AgreementExecutionCollectionData>;',
+      '"agreementExecutions": CrudOperations<AgreementExecutionCollectionData>;',
     );
     expect(objectTypes).toMatch(
       /export interface AgreementExecutionData \{[\s\S]*status: string;[\s\S]*amount: number;[\s\S]*\}/,
+    );
+  });
+
+  it('declares a hidden item companion as custom-only without phantom CRUD', async () => {
+    const manifest = {
+      version: '1.0.0',
+      timestamp: 1,
+      objects: {
+        Secret: {
+          className: 'Secret',
+          collection: 'secrets',
+          extends: 'SmrtObject',
+          fields: { value: { type: 'text' } },
+          methods: {},
+          decoratorConfig: { api: false },
+        },
+        SecretCollection: {
+          className: 'SecretCollection',
+          collection: 'secrets',
+          extends: 'SmrtCollection',
+          extendsTypeArg: 'Secret',
+          fields: {},
+          methods: {
+            reveal: {
+              name: 'reveal',
+              async: true,
+              parameters: [{ name: 'token', type: 'text' }],
+              returnType: 'string',
+              isStatic: false,
+              isPublic: true,
+            },
+          },
+          decoratorConfig: {
+            api: { routes: { reveal: { path: 'reveal/[token]' } } },
+          },
+        },
+      },
+    } as SmartObjectManifest;
+
+    await generateDeclarations({ manifest, outDir });
+    const clientDeclaration = readFileSync(
+      join(outDir, 'smrt-client.d.ts'),
+      'utf-8',
+    );
+
+    expect(clientDeclaration).toContain(
+      '"secrets": {\n      reveal(options: { token: string }): Promise<any>;\n    };',
+    );
+    expect(clientDeclaration).not.toContain(
+      '"secrets": CrudOperations<SecretData>',
     );
   });
 

--- a/packages/core/src/prebuild/index.ts
+++ b/packages/core/src/prebuild/index.ts
@@ -6,7 +6,11 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { SmartObjectManifest } from '../scanner/types';
-import { selectApiClientEntries } from '../vite-plugin/api-client-entries.js';
+import {
+  renderApiClientCrudType,
+  renderApiClientCustomMethodParameters,
+  selectApiClientEntries,
+} from '../vite-plugin/api-client-entries.js';
 import { selectWebCollectionEntries } from '../vite-plugin/web-collections.js';
 
 export interface PrebuildOptions {
@@ -164,16 +168,37 @@ declare module '@smrt/manifest' {
 
   // Generate client module declaration
   const apiClientInterface = selectApiClientEntries(manifest)
-    .map(({ clientKey, dataInterfaceName }) => {
-      return `    ${clientKey}: CrudOperations<${dataInterfaceName}>;`;
+    .map(({ clientKey, dataInterfaceName, crudMethods, customMethods }) => {
+      const overriddenMethods = customMethods.map(({ name }) => name);
+      const crudType = renderApiClientCrudType(
+        dataInterfaceName,
+        crudMethods,
+        overriddenMethods,
+      );
+      const customSignatures = customMethods
+        .map(
+          (method) =>
+            `      ${method.name}(${renderApiClientCustomMethodParameters(
+              method,
+              mapFieldTypeToTypeScript,
+            )}): Promise<any>;`,
+        )
+        .join('\n');
+
+      if (customSignatures) {
+        const intersection = crudType ? `${crudType} & ` : '';
+        return `    ${JSON.stringify(clientKey)}: ${intersection}{\n${customSignatures}\n    };`;
+      }
+
+      return `    ${JSON.stringify(clientKey)}: ${crudType ?? 'Record<string, never>'};`;
     })
     .join('\n');
 
   // Wire-shape policy (#1797): the server returns BARE JSON — a bare array for
   // list/search, a bare object for get/create/update — with snake_case field
-  // names (created_at, updated_at). These declarations match that shape (no
-  // envelope, no camelCase) and are byte-identical to the vite-plugin client
-  // declaration. Fetchers reject on non-2xx with a SmrtClientError (#1796).
+  // names (created_at, updated_at). These physical declarations share client
+  // entry selection and method-signature rendering with the Vite declaration.
+  // Fetchers reject on non-2xx with a SmrtClientError (#1796).
   const clientDeclaration = `/**
  * Auto-generated API client module declaration
  */
@@ -281,7 +306,7 @@ ${objectImports}
   const webCollectionEntries = selectWebCollectionEntries(manifest)
     .map(
       ({ collection, obj }) =>
-        `    ${collection}: SmrtWebCollectionDefinition<import('./smrt-objects').${obj.className}Data>;`,
+        `    ${JSON.stringify(collection)}: SmrtWebCollectionDefinition<import('./smrt-objects').${obj.className}Data>;`,
     )
     .join('\n');
 

--- a/packages/core/src/system/compatibility.ts
+++ b/packages/core/src/system/compatibility.ts
@@ -107,6 +107,90 @@ export interface PostgresSystemTimestampMigrationConfirmation {
   legacyTimezone: 'UTC';
 }
 
+export interface PostgresSystemTimestampMigrationPlan {
+  kind: 'column' | 'change-feed-function';
+  tableName: string;
+  columnName?: string;
+  sql: string;
+}
+
+function quotePostgresIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+/**
+ * Read-only plan for the framework-owned timestamp conversion. This is kept
+ * separate from the atomic mutator so CLI dry-runs can report every ALTER
+ * without bootstrapping or changing framework tables.
+ */
+export async function planPostgresSystemTimestampMigrations(
+  db: DatabaseInterface,
+  confirmation: PostgresSystemTimestampMigrationConfirmation,
+  typeHint?: string,
+): Promise<PostgresSystemTimestampMigrationPlan[]> {
+  if (getDatabaseEngine(db, typeHint) !== 'postgres') return [];
+  if (confirmation.legacyTimezone !== 'UTC') {
+    throw new Error(
+      'Legacy SMRT system timestamp migration requires an explicit UTC provenance confirmation',
+    );
+  }
+
+  const sessionRows = getQueryRows(
+    await db.query(`
+      SELECT
+        current_setting('TimeZone') AS timezone,
+        to_regprocedure('${LEGACY_POSTGRES_CHANGE_FEED_APPEND_FUNCTION_IDENTITY}')
+          IS NOT NULL AS legacy_change_feed_function_exists
+    `),
+  );
+  const session = sessionRows[0] ?? {};
+  const timezone = String(session.timezone ?? '').toUpperCase();
+  if (!['UTC', 'ETC/UTC', 'GMT'].includes(timezone)) {
+    throw new Error(
+      `Refusing to preview legacy SMRT timestamp migration outside a UTC PostgreSQL session (current TimeZone: ${String(session.timezone ?? 'unknown')})`,
+    );
+  }
+
+  const rows = getQueryRows(
+    await db.query(`
+      SELECT table_name, column_name
+      FROM information_schema.columns
+      WHERE table_schema = current_schema()
+        AND table_name LIKE '\\_smrt\\_%' ESCAPE '\\'
+        AND data_type = 'timestamp without time zone'
+      ORDER BY table_name, ordinal_position
+    `),
+  );
+
+  const plans: PostgresSystemTimestampMigrationPlan[] = rows.map((row) => {
+    const tableName = String(row.table_name);
+    const columnName = String(row.column_name);
+    const table = quotePostgresIdentifier(tableName);
+    const column = quotePostgresIdentifier(columnName);
+    return {
+      kind: 'column',
+      tableName,
+      columnName,
+      sql: `ALTER TABLE ${table} ALTER COLUMN ${column} TYPE TIMESTAMPTZ USING ${column} AT TIME ZONE 'UTC'`,
+    };
+  });
+
+  if (
+    session.legacy_change_feed_function_exists === true ||
+    session.legacy_change_feed_function_exists === 't' ||
+    session.legacy_change_feed_function_exists === 'true' ||
+    session.legacy_change_feed_function_exists === 1
+  ) {
+    plans.push({
+      kind: 'change-feed-function',
+      tableName: '_smrt_changes',
+      sql: `DROP FUNCTION IF EXISTS ${LEGACY_POSTGRES_CHANGE_FEED_APPEND_FUNCTION_IDENTITY};\n${CREATE_POSTGRES_CHANGE_FEED_APPEND_FUNCTION.trim()}`,
+    });
+  }
+
+  return plans;
+}
+
 /**
  * Fail closed when framework-owned PostgreSQL tables still contain legacy
  * timezone-naive timestamps. Call this before recording the current system
@@ -180,7 +264,7 @@ export async function migratePostgresSystemTimestamps(
           target.column_name
         );
       END LOOP;
-      IF to_regclass('_smrt_changes') IS NOT NULL THEN
+      IF to_regprocedure('${LEGACY_POSTGRES_CHANGE_FEED_APPEND_FUNCTION_IDENTITY}') IS NOT NULL THEN
         DROP FUNCTION IF EXISTS ${LEGACY_POSTGRES_CHANGE_FEED_APPEND_FUNCTION_IDENTITY};
         EXECUTE $smrt_change_feed_ddl$
 ${CREATE_POSTGRES_CHANGE_FEED_APPEND_FUNCTION.trim()}

--- a/packages/core/src/vite-plugin/api-client-entries.test.ts
+++ b/packages/core/src/vite-plugin/api-client-entries.test.ts
@@ -3,7 +3,10 @@ import type {
   SmartObjectDefinition,
   SmartObjectManifest,
 } from '../scanner/types.js';
-import { selectApiClientEntries } from './api-client-entries.js';
+import {
+  type ApiClientCrudMethod,
+  selectApiClientEntries,
+} from './api-client-entries.js';
 
 const agreementExecutionCollection = {
   className: 'AgreementExecutionCollection',
@@ -112,6 +115,237 @@ describe('selectApiClientEntries', () => {
     ]);
   });
 
+  it('excludes api:false objects without changing canonical ownership or client keys', () => {
+    const manifest = buildManifest(false);
+    manifest.objects.HiddenAgreementExecution = {
+      className: 'HiddenAgreementExecution',
+      collection: 'agreementExecutions',
+      extends: 'SmrtObject',
+      fields: { secret: { type: 'text', required: true } },
+      methods: {},
+      decoratorConfig: { api: false },
+    } as SmartObjectDefinition;
+    manifest.objects.InternalCheckpoint = {
+      className: 'InternalCheckpoint',
+      collection: 'internalCheckpoints',
+      extends: 'SmrtObject',
+      fields: { cursor: { type: 'text', required: true } },
+      methods: {},
+      decoratorConfig: { api: false },
+    } as SmartObjectDefinition;
+
+    expect(
+      selectApiClientEntries(manifest).map(({ clientKey, obj }) => [
+        clientKey,
+        obj.className,
+      ]),
+    ).toEqual([
+      ['agreementExecutions', 'AgreementExecution'],
+      ['agreementExecutionCollection', 'AgreementExecutionCollection'],
+      ['contents', 'Content'],
+      ['contents2', 'Contents'],
+    ]);
+  });
+
+  it('keeps only routed companion collection methods when its item model has api:false', () => {
+    const hiddenModel = {
+      className: 'Secret',
+      collection: 'secrets',
+      extends: 'SmrtObject',
+      fields: { value: { type: 'text', required: true } },
+      methods: {},
+      decoratorConfig: { api: false },
+    } as SmartObjectDefinition;
+    const implicitCollection = {
+      className: 'SecretCollection',
+      collection: 'secrets',
+      extends: 'SmrtCollection',
+      extendsTypeArg: 'Secret',
+      fields: {},
+      methods: {},
+      decoratorConfig: {},
+    } as SmartObjectDefinition;
+
+    const implicitManifest = {
+      version: '1.0.0',
+      timestamp: 1,
+      objects: {
+        Secret: hiddenModel,
+        SecretCollection: implicitCollection,
+      },
+    } satisfies SmartObjectManifest;
+
+    expect(selectApiClientEntries(implicitManifest)).toEqual([]);
+
+    const customOnlyEntries = selectApiClientEntries({
+      ...implicitManifest,
+      objects: {
+        ...implicitManifest.objects,
+        SecretCollection: {
+          ...implicitCollection,
+          methods: {
+            reveal: {
+              name: 'reveal',
+              async: true,
+              parameters: [],
+              returnType: 'string',
+              isStatic: false,
+              isPublic: true,
+            },
+          },
+        },
+      },
+    });
+    expect(
+      customOnlyEntries.map(({ clientKey, obj }) => [clientKey, obj.className]),
+    ).toEqual([['secrets', 'SecretCollection']]);
+    expect(customOnlyEntries[0]).toMatchObject({
+      crudMethods: [],
+      customMethods: [{ name: 'reveal', scope: 'collection' }],
+    });
+
+    expect(
+      selectApiClientEntries({
+        ...implicitManifest,
+        objects: {
+          ...implicitManifest.objects,
+          SecretCollection: {
+            ...implicitCollection,
+            methods: {
+              reveal: {
+                name: 'reveal',
+                async: true,
+                parameters: [],
+                returnType: 'string',
+                isStatic: false,
+                isPublic: true,
+              },
+            },
+            decoratorConfig: {
+              api: {
+                routes: {
+                  reveal: { scope: 'item' },
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).toEqual([]);
+
+    expect(
+      selectApiClientEntries({
+        ...implicitManifest,
+        objects: {
+          ...implicitManifest.objects,
+          SecretCollection: {
+            ...implicitCollection,
+            decoratorConfig: { api: true },
+          },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it('prefers an inherited generic item over a subclass naming collision', () => {
+    const manifest = {
+      version: '1.0.0',
+      timestamp: 1,
+      objects: {
+        Widget: {
+          className: 'Widget',
+          collection: 'widgets',
+          extends: 'SmrtObject',
+          fields: {},
+          methods: {},
+          decoratorConfig: { api: false },
+        },
+        SpecialWidget: {
+          className: 'SpecialWidget',
+          collection: 'specialWidgets',
+          extends: 'SmrtObject',
+          fields: {},
+          methods: {},
+          decoratorConfig: { api: false },
+        },
+        WidgetCollection: {
+          className: 'WidgetCollection',
+          collection: 'widgets',
+          extends: 'SmrtCollection',
+          extendsTypeArg: 'Widget',
+          fields: {},
+          methods: {},
+          decoratorConfig: { api: false },
+        },
+        SpecialWidgetCollection: {
+          className: 'SpecialWidgetCollection',
+          collection: 'widgets',
+          extends: 'WidgetCollection',
+          fields: {},
+          methods: {
+            restoreSpecial: {
+              name: 'restoreSpecial',
+              async: true,
+              parameters: [],
+              returnType: 'Widget[]',
+              isStatic: false,
+              isPublic: true,
+            },
+          },
+          decoratorConfig: {
+            api: { include: ['restoreSpecial'] },
+          },
+        },
+      },
+    } satisfies SmartObjectManifest;
+
+    const entry = selectApiClientEntries(manifest).find(
+      ({ obj }) => obj.className === 'SpecialWidgetCollection',
+    );
+    expect(entry).toMatchObject({
+      clientKey: 'widgets',
+      dataInterfaceName: 'WidgetData',
+      customMethods: [{ name: 'restoreSpecial', scope: 'collection' }],
+    });
+  });
+
+  it('carries the exact standard action set for partial and custom-only APIs', () => {
+    const manifest = buildManifest(false);
+    manifest.objects.AgreementExecution = {
+      ...agreementExecution,
+      methods: {
+        reveal: {
+          name: 'reveal',
+          async: true,
+          parameters: [],
+          returnType: 'string',
+          isStatic: false,
+          isPublic: true,
+        },
+      },
+      decoratorConfig: {
+        api: {
+          include: ['get', 'update', 'reveal'],
+          exclude: ['update'],
+        },
+      },
+    };
+
+    const entries = selectApiClientEntries(manifest).filter(
+      ({ obj }) => obj.collection === 'agreementExecutions',
+    );
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      clientKey: 'agreementExecutions',
+      crudMethods: ['get'],
+      customMethods: [{ name: 'reveal', scope: 'item' }],
+    });
+    expect(entries[1]).toMatchObject({
+      clientKey: 'agreementExecutionCollection',
+      crudMethods: ['get'],
+    });
+  });
+
   it('uses a transitive canonical rank for mixed STI and unrelated models', () => {
     const entries: Array<[string, SmartObjectDefinition]> = [
       [
@@ -166,6 +400,49 @@ describe('selectApiClientEntries', () => {
         ['mOther', 'MOther'],
       ]);
     }
+  });
+
+  it('matches CRUD aliases to the route files actually emitted for a shared collection', () => {
+    const base = {
+      className: 'RecordBase',
+      collection: 'records',
+      extends: 'SmrtObject',
+      fields: { base: { type: 'text' } },
+      methods: {},
+      decoratorConfig: {
+        tableStrategy: 'sti',
+        api: { include: ['list', 'get', 'create'] },
+      },
+    } as SmartObjectDefinition;
+    const child = {
+      className: 'RecordChild',
+      collection: 'records',
+      extends: 'RecordBase',
+      fields: { child: { type: 'text' } },
+      methods: {},
+      decoratorConfig: { api: { include: ['get', 'update'] } },
+    } as SmartObjectDefinition;
+
+    const summarize = (
+      objects: Record<string, SmartObjectDefinition>,
+    ): Array<[string, ApiClientCrudMethod[]]> =>
+      selectApiClientEntries({
+        version: '1.0.0',
+        timestamp: 1,
+        objects,
+      }).map(({ clientKey, crudMethods }) => [clientKey, crudMethods]);
+
+    // Base writes the collection file; the later child replaces the item file.
+    expect(summarize({ RecordBase: base, RecordChild: child })).toEqual([
+      ['records', ['list', 'get', 'create', 'update']],
+      ['recordChild', ['list', 'get', 'create', 'update']],
+    ]);
+
+    // Reversing manifest order makes the base the final writer of both files.
+    expect(summarize({ RecordChild: child, RecordBase: base })).toEqual([
+      ['records', ['list', 'get', 'create']],
+      ['recordChild', ['list', 'get', 'create']],
+    ]);
   });
 
   it('resolves duplicate simple parent names deterministically across packages', () => {

--- a/packages/core/src/vite-plugin/api-client-entries.ts
+++ b/packages/core/src/vite-plugin/api-client-entries.ts
@@ -11,10 +11,20 @@ import type {
   SmartObjectDefinition,
   SmartObjectManifest,
 } from '../scanner/types.js';
+import { resolveApiActionRouteConfig } from './sveltekit-generator.js';
 import {
   findManifestObjectByName,
   isCollectionManifestClass,
+  resolveCollectionItemObject,
 } from './web-collections.js';
+
+export type ApiClientCrudMethod =
+  | 'list'
+  | 'get'
+  | 'create'
+  | 'update'
+  | 'delete'
+  | 'search';
 
 export interface ApiClientEntry {
   /** Original key in manifest.objects. */
@@ -25,6 +35,82 @@ export interface ApiClientEntry {
   clientKey: string;
   /** Row-payload interface used by CRUD methods for this entry. */
   dataInterfaceName: string;
+  /** Standard client operations whose server routes are actually emitted. */
+  crudMethods: ApiClientCrudMethod[];
+  /** Custom methods whose routes are actually emitted by the server. */
+  customMethods: Array<{
+    name: string;
+    scope: 'item' | 'collection';
+    pathParamNames: string[];
+    parameters: Array<{
+      name: string;
+      type: string;
+      optional?: boolean;
+      default?: unknown;
+    }>;
+  }>;
+}
+
+export function renderApiClientCrudType(
+  dataInterfaceName: string,
+  crudMethods: ApiClientCrudMethod[],
+  overriddenMethods: string[] = [],
+): string | undefined {
+  const overridden = new Set(overriddenMethods);
+  const methods = crudMethods.filter((method) => !overridden.has(method));
+  if (methods.length === 0) return undefined;
+  if (
+    methods.length === 6 &&
+    methods.every(
+      (method, index) => method === [...STANDARD_API_ACTIONS, 'search'][index],
+    )
+  ) {
+    return `CrudOperations<${dataInterfaceName}>`;
+  }
+  return `Pick<CrudOperations<${dataInterfaceName}>, ${methods
+    .map((method) => JSON.stringify(method))
+    .join(' | ')}>`;
+}
+
+export function renderApiClientCustomMethodParameters(
+  method: ApiClientEntry['customMethods'][number],
+  mapType: (type: string) => string,
+): string {
+  const pathParamNames = new Set(method.pathParamNames);
+  const params = method.parameters;
+  const hasSingleOptionsParameter =
+    params.length === 1 && params[0]?.name === 'options';
+  const requiredPathProperties = method.pathParamNames
+    .map((name) => `${name}: string`)
+    .join('; ');
+  let optionsType: string;
+
+  if (hasSingleOptionsParameter) {
+    const directOptionsType = mapType(params[0].type);
+    optionsType = requiredPathProperties
+      ? `${directOptionsType} & { ${requiredPathProperties} }`
+      : directOptionsType;
+  } else {
+    const parameterNames = new Set(params.map((param) => param.name));
+    const properties = params.map(
+      (param) =>
+        `${param.name}${pathParamNames.has(param.name) ? '' : '?'}: ${mapType(param.type)}`,
+    );
+    for (const pathParamName of method.pathParamNames) {
+      if (!parameterNames.has(pathParamName)) {
+        properties.push(`${pathParamName}: string`);
+      }
+    }
+    optionsType =
+      properties.length > 0
+        ? `{ ${properties.join('; ')} }`
+        : 'Record<string, never>';
+  }
+
+  const optionsParameter = `${method.pathParamNames.length > 0 ? 'options' : 'options?'}: ${optionsType}`;
+  return method.scope === 'collection'
+    ? optionsParameter
+    : `id: string, ${optionsParameter}`;
 }
 
 interface ManifestCandidate {
@@ -78,39 +164,180 @@ function isAncestorOf(
   return false;
 }
 
-function resolveCollectionItemObject(
+const STANDARD_API_ACTIONS = [
+  'list',
+  'get',
+  'create',
+  'update',
+  'delete',
+] as const;
+const STANDARD_API_ACTION_SET = new Set<string>(STANDARD_API_ACTIONS);
+
+function resolveGeneratedClientCustomMethods(
+  obj: SmartObjectDefinition,
+  manifest: SmartObjectManifest,
+): ApiClientEntry['customMethods'] {
+  const apiConfig = obj.decoratorConfig?.api;
+  if (apiConfig === false) return [];
+
+  const config =
+    typeof apiConfig === 'object' && apiConfig !== null ? apiConfig : undefined;
+  const included = Array.isArray(config?.include) ? config.include : undefined;
+  const excluded = Array.isArray(config?.exclude) ? config.exclude : undefined;
+  const isCollection = isCollectionManifestClass(manifest, obj);
+
+  return Object.entries(obj.methods ?? {}).flatMap(([name, method]) => {
+    if (STANDARD_API_ACTION_SET.has(name) || !method.isPublic) return [];
+    if (included && !included.includes(name)) return [];
+    if (excluded?.includes(name)) return [];
+
+    const scope =
+      config?.routes?.[name]?.scope ??
+      (isCollection || method.isStatic ? 'collection' : 'item');
+    if (isCollection && scope !== 'collection') return [];
+    if (!isCollection && scope === 'collection' && !method.isStatic) return [];
+
+    const routeConfig = resolveApiActionRouteConfig(
+      name,
+      method,
+      apiConfig,
+      {},
+      isCollection ? 'collection' : method.isStatic ? 'collection' : 'item',
+    );
+
+    return [
+      {
+        name,
+        scope,
+        pathParamNames: routeConfig.pathParamNames,
+        parameters: method.parameters ?? [],
+      },
+    ];
+  });
+}
+
+function resolveCrudObject(
   obj: SmartObjectDefinition,
   manifest: SmartObjectManifest,
 ): SmartObjectDefinition | undefined {
-  const seen = new Set<string>();
-  let candidate: SmartObjectDefinition | undefined = obj;
+  if (!isCollectionManifestClass(manifest, obj)) return obj;
 
-  while (candidate) {
-    if (candidate.extendsTypeArg) {
-      const itemObject = findManifestObjectByName(
-        manifest,
-        candidate.extendsTypeArg,
-        candidate,
-      );
-      if (itemObject) return itemObject;
-    }
+  const itemObject = resolveCollectionItemObject(manifest, obj);
+  if (itemObject) return itemObject;
 
-    if (candidate.className.endsWith('Collection')) {
-      const conventionalItem = findManifestObjectByName(
-        manifest,
-        candidate.className.slice(0, -'Collection'.length),
-        candidate,
-      );
-      if (conventionalItem) return conventionalItem;
-    }
+  // A non-conventional collection can still share an endpoint with a model.
+  return Object.values(manifest.objects)
+    .filter(
+      (candidate) =>
+        candidate.collection === obj.collection &&
+        !isCollectionManifestClass(manifest, candidate),
+    )
+    .sort((left, right) =>
+      compareText(
+        left.qualifiedName ?? left.className,
+        right.qualifiedName ?? right.className,
+      ),
+    )[0];
+}
 
-    const parentName = candidate.extendsQualified || candidate.extends;
-    if (!parentName || seen.has(parentName)) return undefined;
-    seen.add(parentName);
-    candidate = findManifestObjectByName(manifest, parentName, candidate);
+function resolveGeneratedClientCrudMethods(
+  obj: SmartObjectDefinition,
+  manifest: SmartObjectManifest,
+): ApiClientCrudMethod[] {
+  const crudObject = resolveCrudObject(obj, manifest);
+  const apiConfig = crudObject?.decoratorConfig?.api;
+  if (!crudObject || apiConfig === false) return [];
+
+  if (apiConfig === true || apiConfig === undefined) {
+    return [...STANDARD_API_ACTIONS, 'search'];
+  }
+  if (typeof apiConfig !== 'object' || apiConfig === null) {
+    return [...STANDARD_API_ACTIONS, 'search'];
   }
 
-  return undefined;
+  const included = Array.isArray(apiConfig.include)
+    ? apiConfig.include
+    : undefined;
+  const excluded = Array.isArray(apiConfig.exclude) ? apiConfig.exclude : [];
+  const standardMethods = (
+    included
+      ? STANDARD_API_ACTIONS.filter((action) => included.includes(action))
+      : [...STANDARD_API_ACTIONS]
+  ).filter((action) => !excluded.includes(action));
+
+  // Preserve the historical search convenience only for an unbounded API
+  // config. Explicit include lists are fail-closed; a real custom search
+  // method is carried separately by resolveGeneratedClientCustomMethods().
+  const includeSearch = !included && !excluded.includes('search');
+  return includeSearch ? [...standardMethods, 'search'] : standardMethods;
+}
+
+/**
+ * Resolve the CRUD surface that the generated route files actually expose for
+ * one shared collection endpoint.
+ *
+ * Route generation processes manifest objects in insertion order. Collection
+ * and item handlers live in separate files, and the last model that emits each
+ * file replaces the earlier file. Mirror that behavior here so every client
+ * alias for a shared endpoint has the same, real action set.
+ */
+function resolveGeneratedEndpointCrudMethods(
+  collection: string,
+  manifest: SmartObjectManifest,
+): ApiClientCrudMethod[] {
+  let collectionMethods: ApiClientCrudMethod[] = [];
+  let itemMethods: ApiClientCrudMethod[] = [];
+
+  for (const obj of Object.values(manifest.objects)) {
+    if (
+      obj.collection !== collection ||
+      isCollectionManifestClass(manifest, obj)
+    ) {
+      continue;
+    }
+
+    const methods = resolveGeneratedClientCrudMethods(obj, manifest);
+    const emittedCollectionMethods = methods.filter((method) =>
+      ['list', 'create', 'search'].includes(method),
+    );
+    const emittedItemMethods = methods.filter((method) =>
+      ['get', 'update', 'delete'].includes(method),
+    );
+
+    // generateRoutesForObject only writes a route file when that file has at
+    // least one standard handler. A custom-only object leaves an earlier CRUD
+    // file intact rather than replacing it with an empty file.
+    if (
+      emittedCollectionMethods.some(
+        (method) => method === 'list' || method === 'create',
+      )
+    ) {
+      collectionMethods = emittedCollectionMethods;
+    }
+    if (emittedItemMethods.length > 0) {
+      itemMethods = emittedItemMethods;
+    }
+  }
+
+  const emitted = new Set([...collectionMethods, ...itemMethods]);
+  const orderedMethods: ApiClientCrudMethod[] = [
+    ...STANDARD_API_ACTIONS,
+    'search',
+  ];
+  return orderedMethods.filter((method) => emitted.has(method));
+}
+
+function exposesApiClientSurface(
+  obj: SmartObjectDefinition,
+  manifest: SmartObjectManifest,
+): boolean {
+  if (obj.decoratorConfig?.api === false) return false;
+  if (resolveGeneratedClientCrudMethods(obj, manifest).length > 0) return true;
+
+  // A disabled item has no CRUD routes. Keep its companion collection only
+  // when the collection itself contributes a custom route that the SvelteKit
+  // generator will actually emit.
+  return resolveGeneratedClientCustomMethods(obj, manifest).length > 0;
 }
 
 function resolveDataInterfaceName(
@@ -121,7 +348,7 @@ function resolveDataInterfaceName(
     return `${obj.className}Data`;
   }
 
-  const itemObject = resolveCollectionItemObject(obj, manifest);
+  const itemObject = resolveCollectionItemObject(manifest, obj);
   return `${itemObject?.className || obj.className}Data`;
 }
 
@@ -183,8 +410,8 @@ function selectCanonicalOwner(
   }
 
   return [...group].sort((left, right) => {
-    const leftHasItem = resolveCollectionItemObject(left.obj, manifest);
-    const rightHasItem = resolveCollectionItemObject(right.obj, manifest);
+    const leftHasItem = resolveCollectionItemObject(manifest, left.obj);
+    const rightHasItem = resolveCollectionItemObject(manifest, right.obj);
     if (Boolean(leftHasItem) !== Boolean(rightHasItem)) {
       return leftHasItem ? -1 : 1;
     }
@@ -200,9 +427,9 @@ function selectCanonicalOwner(
 export function selectApiClientEntries(
   manifest: SmartObjectManifest,
 ): ApiClientEntry[] {
-  const candidates = Object.entries(manifest.objects).map(
-    ([objectName, obj]): ManifestCandidate => ({ objectName, obj }),
-  );
+  const candidates = Object.entries(manifest.objects)
+    .filter(([, obj]) => exposesApiClientSurface(obj, manifest))
+    .map(([objectName, obj]): ManifestCandidate => ({ objectName, obj }));
   const candidatesByCollection = new Map<string, ManifestCandidate[]>();
 
   for (const candidate of candidates) {
@@ -264,6 +491,11 @@ export function selectApiClientEntries(
       obj,
       clientKey,
       dataInterfaceName: resolveDataInterfaceName(obj, manifest),
+      crudMethods: resolveGeneratedEndpointCrudMethods(
+        obj.collection,
+        manifest,
+      ),
+      customMethods: resolveGeneratedClientCustomMethods(obj, manifest),
     };
   });
 }

--- a/packages/core/src/vite-plugin/generated-client-integration.test.ts
+++ b/packages/core/src/vite-plugin/generated-client-integration.test.ts
@@ -44,8 +44,9 @@ import { field } from '../decorators';
 import { APIGenerator } from '../generators/rest';
 import { SmrtObject } from '../object';
 import { ObjectRegistry, smrt } from '../registry';
+import type { SmartObjectManifest } from '../scanner/types.js';
 import { getTestDatabase } from '../testing/database';
-import { smrtPlugin } from './index.js';
+import { generateTypeDeclarationFile, smrtPlugin } from './index.js';
 
 // A collection whose canonical segment is already plural
 // (`GenClientProduct` -> `genclientproducts`). The generated client emits GET
@@ -212,6 +213,27 @@ export class GenClientMessage extends SmrtObject {}
 
 @smrt({ api: { public: true } })
 export class GenClientEmail extends GenClientMessage {}
+
+@smrt({ api: { public: true } })
+export class GenClientSecretCollection extends SmrtCollection<GenClientSecret> {
+  async reveal(): Promise<string> {
+    return 'revealed';
+  }
+}
+
+@smrt({ api: false })
+export class GenClientSecret extends SmrtObject {
+  @field({ type: 'text' })
+  value: string = '';
+}
+
+@smrt({ api: { public: true, include: ['get', 'ping'] } })
+export class GenClientReadonly extends SmrtObject {
+  async ping(): Promise<string> {
+    return 'pong';
+  }
+}
+
 `,
     );
 
@@ -238,11 +260,11 @@ export class GenClientEmail extends GenClientMessage {}
     // pluralizes to `genclientproducts`; assert that here so a future
     // inflection change surfaces as a readable failure rather than an
     // `undefined.list()` TypeError below.
-    expect(clientSource).toContain('genclientproducts:');
-    expect(clientSource).toContain('genClientProductCollection:');
-    expect(clientSource.match(/\n {2}genclientproducts:/g)).toHaveLength(1);
-    expect(clientSource.match(/\n {2}contents:/g)).toHaveLength(1);
-    expect(clientSource).toContain('contents2:');
+    expect(clientSource).toContain('"genclientproducts":');
+    expect(clientSource).toContain('"genClientProductCollection":');
+    expect(clientSource.match(/\n {2}"genclientproducts":/g)).toHaveLength(1);
+    expect(clientSource.match(/\n {2}"contents":/g)).toHaveLength(1);
+    expect(clientSource).toContain('"contents2":');
     expect(clientSource).toContain('findFeatured: (options)');
     expect(clientSource).not.toContain('findFeatured: (id, options)');
     expect(clientSource).not.toContain('list: (id, options)');
@@ -254,18 +276,33 @@ export class GenClientEmail extends GenClientMessage {}
     expect(clientSource).toContain('summarize: (id, options)');
     expect(clientSource).toContain('findUnread: (options)');
     expect(clientSource).not.toContain('findUnread: (id, options)');
+    const customOnlyClientSource = clientSource.match(
+      /\n {2}"genclientsecrets": \{([\s\S]*?)\n {2}\}/,
+    )?.[1];
+    expect(customOnlyClientSource).toContain('reveal: (options)');
+    expect(customOnlyClientSource).not.toMatch(
+      /\b(list|get|create|update|delete|search):/,
+    );
+    const partialClientSource = clientSource.match(
+      /\n {2}"genclientreadonlies": \{([\s\S]*?)\n {2}\}/,
+    )?.[1];
+    expect(partialClientSource).toContain('get: (id)');
+    expect(partialClientSource).toContain('ping: (id, options)');
+    expect(partialClientSource).not.toMatch(
+      /\b(list|create|update|delete|search):/,
+    );
     const declarationSource = readFileSync(
       join(projectRoot, 'src', 'types', 'virtual-modules.d.ts'),
       'utf-8',
     );
     expect(declarationSource).toContain(
-      'genclientproducts: CrudOperations<GenClientProductData>;',
+      '"genclientproducts": CrudOperations<GenClientProductData>;',
     );
     expect(declarationSource).not.toContain(
-      'genclientproducts: CrudOperations<GenClientProductCollectionData>;',
+      '"genclientproducts": CrudOperations<GenClientProductCollectionData>;',
     );
     expect(declarationSource).toContain(
-      'genClientProductCollection: Omit<CrudOperations<GenClientProductData>, "search"> & {',
+      '"genClientProductCollection": Pick<CrudOperations<GenClientProductData>, "list" | "get" | "create" | "update" | "delete"> & {',
     );
     expect(declarationSource).toMatch(
       /export interface GenClientProductData \{[\s\S]*?name: string;[\s\S]*?price: number;[\s\S]*?\n {2}\}/,
@@ -279,13 +316,22 @@ export class GenClientEmail extends GenClientMessage {}
       'describe(id: string, options: { tone: string }): Promise<any>;',
     );
     expect(declarationSource).toContain(
-      'contents: CrudOperations<ContentData> & {\n      summarize(id: string, options?: Record<string, never>): Promise<any>;',
+      '"contents": CrudOperations<ContentData> & {\n      summarize(id: string, options?: Record<string, never>): Promise<any>;',
     );
     expect(declarationSource).toContain(
-      'contents2: CrudOperations<ContentData> & {\n      featured(options?: Record<string, never>): Promise<any>;',
+      '"contents2": CrudOperations<ContentData> & {\n      featured(options?: Record<string, never>): Promise<any>;',
     );
     expect(declarationSource).toContain(
-      'genClientEmailCollection: CrudOperations<GenClientEmailData> & {\n      findUnread(options?: Record<string, never>): Promise<any>;',
+      '"genClientEmailCollection": CrudOperations<GenClientMessageData> & {\n      findUnread(options?: Record<string, never>): Promise<any>;',
+    );
+    expect(declarationSource).toContain(
+      '"genclientsecrets": {\n      reveal(options?: Record<string, never>): Promise<any>;\n    };',
+    );
+    expect(declarationSource).not.toContain(
+      '"genclientsecrets": CrudOperations<GenClientSecretData>',
+    );
+    expect(declarationSource).toContain(
+      '"genclientreadonlies": Pick<CrudOperations<GenClientReadonlyData>, "get"> & {\n      ping(id: string, options?: Record<string, never>): Promise<any>;',
     );
 
     // Evaluate the generated ESM the way a bundler would: write it to disk and
@@ -296,6 +342,7 @@ export class GenClientEmail extends GenClientMessage {}
     writeFileSync(clientModulePath, clientSource, 'utf-8');
     const mod = await import(pathToFileURL(clientModulePath).href);
     createClient = mod.createClient;
+    expect(Object.keys(createClient().genclientsecrets)).toEqual(['reveal']);
 
     // Real in-memory SQLite collection + generated server. No registerCollection
     // on the APIGenerator — force the auto-discovery path.
@@ -314,6 +361,39 @@ export class GenClientEmail extends GenClientMessage {}
     if (projectRoot) rmSync(projectRoot, { recursive: true, force: true });
     if (clientModuleDir)
       rmSync(clientModuleDir, { recursive: true, force: true });
+  });
+
+  it('quotes non-identifier keys in Vite client and web declarations', async () => {
+    const declarationRoot = mkdtempSync(join(tmpdir(), 'smrt-vite-types-'));
+    try {
+      const manifest: SmartObjectManifest = {
+        version: '1.0.0',
+        timestamp: 1,
+        objects: {
+          AuditEvent: {
+            className: 'AuditEvent',
+            collection: 'audit-events',
+            fields: {},
+            methods: {},
+            decoratorConfig: {},
+          },
+        },
+      };
+
+      await generateTypeDeclarationFile(manifest, declarationRoot, 'types');
+      const declarationSource = readFileSync(
+        join(declarationRoot, 'types', 'virtual-modules.d.ts'),
+        'utf-8',
+      );
+      expect(declarationSource).toContain(
+        '"audit-events": CrudOperations<AuditEventData>;',
+      );
+      expect(declarationSource).toContain(
+        '"audit-events": SmrtWebCollectionDefinition<',
+      );
+    } finally {
+      rmSync(declarationRoot, { force: true, recursive: true });
+    }
   });
 
   afterEach(() => {

--- a/packages/core/src/vite-plugin/generated-client.ts
+++ b/packages/core/src/vite-plugin/generated-client.ts
@@ -1,0 +1,198 @@
+/**
+ * Shared runtime generator for producer and consumer `@smrt/client` modules.
+ *
+ * Keep runtime values on the same manifest-derived contract as physical and
+ * virtual declarations. In particular, disabled objects, partial CRUD
+ * allowlists, stable collection keys, and custom route signatures must not
+ * diverge between the two plugin entry points.
+ */
+
+import { CLIENT_FETCH_RUNTIME } from '../generated-client-runtime.js';
+import type { SmartObjectManifest } from '../scanner/types.js';
+import { selectApiClientEntries } from './api-client-entries.js';
+import { resolveApiActionRouteConfig } from './sveltekit-generator.js';
+import { isCollectionManifestClass } from './web-collections.js';
+
+export const GENERATED_CLIENT_CRUD_METHODS = new Set([
+  'list',
+  'get',
+  'create',
+  'update',
+  'delete',
+]);
+
+export const GENERATED_CLIENT_BASE_METHODS = new Set([
+  ...GENERATED_CLIENT_CRUD_METHODS,
+  'search',
+]);
+
+export function generateClientModule(
+  manifest: SmartObjectManifest,
+  options: { kebabRoutes?: boolean } = {},
+): string {
+  const objects = selectApiClientEntries(manifest);
+
+  const clientMethods = objects
+    .map(({ obj, clientKey, crudMethods, customMethods: exposedMethods }) => {
+      const { collection, methods = {} } = obj;
+
+      const exposedActionNames = new Set(
+        exposedMethods.map((method) => method.name),
+      );
+      const apiConfig = obj.decoratorConfig?.api;
+      const customMethods = Object.entries(methods).filter(
+        ([name, method]) =>
+          !GENERATED_CLIENT_CRUD_METHODS.has(name) &&
+          method.isPublic &&
+          exposedActionNames.has(name),
+      );
+
+      const customMethodImpls = customMethods
+        .map(([methodName, method]) => {
+          const routeConfig = resolveApiActionRouteConfig(
+            methodName,
+            method,
+            apiConfig,
+            { kebabRoutes: options.kebabRoutes },
+            isCollectionManifestClass(manifest, obj)
+              ? 'collection'
+              : method.isStatic
+                ? 'collection'
+                : 'item',
+          );
+          const urlSegment = routeConfig.pathSegments.join('/');
+          const args =
+            routeConfig.scope === 'collection' ? 'options' : 'id, options';
+          const route =
+            routeConfig.scope === 'collection'
+              ? `basePath + '/${collection}/${urlSegment}'`
+              : `basePath + '/${collection}/' + id + '/${urlSegment}'`;
+          const actionUrl = `__smrtActionUrl(${route}, options, ${JSON.stringify(
+            routeConfig.pathParamNames,
+          )}, ${routeConfig.method === 'GET'})`;
+          const requestInit =
+            routeConfig.method === 'GET'
+              ? `{
+      method: 'GET',
+      headers: { 'Accept': 'application/json' }
+    }`
+              : `{
+      method: '${routeConfig.method}',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(options || {})
+    }`;
+          return `    ${methodName}: (${args}) => __smrtFetchActionResult(${actionUrl}, ${requestInit})`;
+        })
+        .join(',\n');
+
+      const enabledCrudMethods = new Set(crudMethods);
+      const crudMethodImpls = [
+        enabledCrudMethods.has('list')
+          ? `    list: (params) => __smrtFetchJson(basePath + '/${collection}', {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' }
+    })`
+          : '',
+        enabledCrudMethods.has('get')
+          ? `    get: (id) => __smrtFetchJson(basePath + '/${collection}/' + id, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' }
+    })`
+          : '',
+        enabledCrudMethods.has('create')
+          ? `    create: (data) => __smrtFetchJson(basePath + '/${collection}', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    })`
+          : '',
+        enabledCrudMethods.has('update')
+          ? `    update: (id, data) => __smrtFetchJson(basePath + '/${collection}/' + id, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    })`
+          : '',
+        enabledCrudMethods.has('delete')
+          ? `    delete: (id) => __smrtFetchOk(basePath + '/${collection}/' + id, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' }
+    })`
+          : '',
+        enabledCrudMethods.has('search')
+          ? `    search: (query) => __smrtFetchJson(basePath + '/${collection}/search?q=' + encodeURIComponent(query), {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' }
+    })`
+          : '',
+      ].filter(Boolean);
+      const methodBlocks = [...crudMethodImpls, customMethodImpls].filter(
+        Boolean,
+      );
+
+      return `
+  ${JSON.stringify(clientKey)}: {
+${methodBlocks.join(',\n')}
+  }`;
+    })
+    .join(',');
+
+  return `
+// Auto-generated API client from SMRT objects
+// This file is generated automatically - do not edit
+
+${CLIENT_FETCH_RUNTIME}
+
+async function __smrtFetchActionResult(url, init) {
+  const body = await __smrtFetchJson(url, init);
+  return body &&
+    typeof body === 'object' &&
+    Object.prototype.hasOwnProperty.call(body, 'result')
+    ? body.result
+    : body;
+}
+
+function __smrtActionUrl(url, options, pathParamNames, includeQuery) {
+  const values = options && typeof options === 'object' ? options : {};
+  const pathParams = new Set(pathParamNames);
+  let resolvedUrl = url;
+  for (const name of pathParamNames) {
+    const value = values[name];
+    if (value === undefined || value === null) {
+      throw new Error('Missing generated client route parameter: ' + name);
+    }
+    resolvedUrl = resolvedUrl.replace(
+      '[' + name + ']',
+      encodeURIComponent(String(value)),
+    );
+  }
+
+  if (!includeQuery) return resolvedUrl;
+
+  const searchParams = new URLSearchParams();
+  for (const [name, value] of Object.entries(values)) {
+    if (pathParams.has(name) || value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) searchParams.append(name, String(item));
+      continue;
+    }
+    searchParams.append(
+      name,
+      value !== null && typeof value === 'object'
+        ? JSON.stringify(value)
+        : String(value),
+    );
+  }
+
+  const query = searchParams.toString();
+  return query ? resolvedUrl + '?' + query : resolvedUrl;
+}
+
+export function createClient(basePath = '/api/v1') {
+  return {${clientMethods}
+  };
+}
+
+export { createClient as default };
+`;
+}

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -11,27 +11,32 @@ import type {
   DomainKnowledgeManifest,
 } from '@happyvertical/smrt-types';
 import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite';
-import { CLIENT_FETCH_RUNTIME } from '../generated-client-runtime.js';
 import { buildDomainKnowledgeManifest } from '../knowledge.js';
 import { discoverSmrtPackages } from '../manifest/discover-smrt-packages.js';
 import type { SmartObjectManifest } from '../scanner/types';
 import type { SchemaDefinition } from '../schema/types.js';
 import { importWorkspaceModule } from '../utils/import-workspace-module.js';
 import type { ScannerModule } from '../utils/scanner-module.js';
-import { selectApiClientEntries } from './api-client-entries.js';
+import {
+  renderApiClientCrudType,
+  renderApiClientCustomMethodParameters,
+  selectApiClientEntries,
+} from './api-client-entries.js';
+import {
+  GENERATED_CLIENT_BASE_METHODS,
+  GENERATED_CLIENT_CRUD_METHODS,
+  generateClientModule,
+} from './generated-client.js';
 import { importBuildAwareModule } from './import-build-aware.js';
 import {
   findCliApiCoherenceViolations,
   generateSvelteKitRoutes,
-  resolveApiActionRouteConfig,
-  resolveApiActionSet,
   validateCliIncludeAgainstApi,
 } from './sveltekit-generator.js';
 import {
   buildWebCollectionDefinition,
   buildWebToolDescriptors,
   computeWebManifestHash,
-  isCollectionManifestClass,
   selectWebCollectionEntries,
 } from './web-collections.js';
 
@@ -1189,184 +1194,6 @@ export { setupRoutes as default };
   }
 }
 
-const GENERATED_CLIENT_CRUD_METHODS = new Set([
-  'list',
-  'get',
-  'create',
-  'update',
-  'delete',
-]);
-
-const GENERATED_CLIENT_BASE_METHODS = new Set([
-  ...GENERATED_CLIENT_CRUD_METHODS,
-  'search',
-]);
-
-function generateClientModule(
-  manifest: SmartObjectManifest,
-  options: { kebabRoutes?: boolean } = {},
-): string {
-  const objects = selectApiClientEntries(manifest);
-
-  const clientMethods = objects
-    .map(({ obj, clientKey }) => {
-      const { collection, methods = {} } = obj;
-
-      // Honor api include/exclude + scope/static skip rules for custom methods,
-      // so the client only emits proxies for methods that actually have routes
-      // emitted by the server. (Custom only — CRUD is left unconditional to
-      // preserve the existing client-type contract.)
-      const exposedActions = resolveApiActionSet(obj);
-      const apiConfig = obj.decoratorConfig?.api;
-
-      const customMethods = Object.entries(methods).filter(
-        ([name, method]) =>
-          !GENERATED_CLIENT_CRUD_METHODS.has(name) &&
-          method.isPublic &&
-          exposedActions.has(name),
-      );
-
-      // Generate custom method implementations using the same route metadata
-      // as the SvelteKit server generator. All fetchers reject on !response.ok
-      // (#1796) via __smrtFetchJson.
-      const customMethodImpls = customMethods
-        .map(([methodName, method]) => {
-          const routeConfig = resolveApiActionRouteConfig(
-            methodName,
-            method,
-            apiConfig,
-            { kebabRoutes: options.kebabRoutes },
-            isCollectionManifestClass(manifest, obj)
-              ? 'collection'
-              : method.isStatic
-                ? 'collection'
-                : 'item',
-          );
-          const urlSegment = routeConfig.pathSegments.join('/');
-          const args =
-            routeConfig.scope === 'collection' ? 'options' : 'id, options';
-          const route =
-            routeConfig.scope === 'collection'
-              ? `basePath + '/${collection}/${urlSegment}'`
-              : `basePath + '/${collection}/' + id + '/${urlSegment}'`;
-          const actionUrl = `__smrtActionUrl(${route}, options, ${JSON.stringify(
-            routeConfig.pathParamNames,
-          )}, ${routeConfig.method === 'GET'})`;
-          const requestInit =
-            routeConfig.method === 'GET'
-              ? `{
-      method: 'GET',
-      headers: { 'Accept': 'application/json' }
-    }`
-              : `{
-      method: '${routeConfig.method}',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(options || {})
-    }`;
-          return `    ${methodName}: (${args}) => __smrtFetchActionResult(${actionUrl}, ${requestInit})`;
-        })
-        .join(',\n');
-
-      const customMethodsBlock =
-        customMethods.length > 0 ? `,\n${customMethodImpls}` : '';
-
-      return `
-  ${clientKey}: {
-    list: (params) => __smrtFetchJson(basePath + '/${collection}', {
-      method: 'GET',
-      headers: { 'Content-Type': 'application/json' }
-    }),
-
-    get: (id) => __smrtFetchJson(basePath + '/${collection}/' + id, {
-      method: 'GET',
-      headers: { 'Content-Type': 'application/json' }
-    }),
-
-    create: (data) => __smrtFetchJson(basePath + '/${collection}', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data)
-    }),
-
-    update: (id, data) => __smrtFetchJson(basePath + '/${collection}/' + id, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data)
-    }),
-
-    delete: (id) => __smrtFetchOk(basePath + '/${collection}/' + id, {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' }
-    }),
-
-    search: (query) => __smrtFetchJson(basePath + '/${collection}/search?q=' + encodeURIComponent(query), {
-      method: 'GET',
-      headers: { 'Content-Type': 'application/json' }
-    })${customMethodsBlock}
-  }`;
-    })
-    .join(',');
-
-  return `
-// Auto-generated API client from SMRT objects
-// This file is generated automatically - do not edit
-
-${CLIENT_FETCH_RUNTIME}
-
-async function __smrtFetchActionResult(url, init) {
-  const body = await __smrtFetchJson(url, init);
-  return body &&
-    typeof body === 'object' &&
-    Object.prototype.hasOwnProperty.call(body, 'result')
-    ? body.result
-    : body;
-}
-
-function __smrtActionUrl(url, options, pathParamNames, includeQuery) {
-  const values = options && typeof options === 'object' ? options : {};
-  const pathParams = new Set(pathParamNames);
-  let resolvedUrl = url;
-  for (const name of pathParamNames) {
-    const value = values[name];
-    if (value === undefined || value === null) {
-      throw new Error('Missing generated client route parameter: ' + name);
-    }
-    resolvedUrl = resolvedUrl.replace(
-      '[' + name + ']',
-      encodeURIComponent(String(value)),
-    );
-  }
-
-  if (!includeQuery) return resolvedUrl;
-
-  const searchParams = new URLSearchParams();
-  for (const [name, value] of Object.entries(values)) {
-    if (pathParams.has(name) || value === undefined) continue;
-    if (Array.isArray(value)) {
-      for (const item of value) searchParams.append(name, String(item));
-      continue;
-    }
-    searchParams.append(
-      name,
-      value !== null && typeof value === 'object'
-        ? JSON.stringify(value)
-        : String(value),
-    );
-  }
-
-  const query = searchParams.toString();
-  return query ? resolvedUrl + '?' + query : resolvedUrl;
-}
-
-export function createClient(basePath = '/api/v1') {
-  return {${clientMethods}
-  };
-}
-
-export { createClient as default };
-`;
-}
-
 /**
  * Generate the virtual web-collection definition module
  * (`@happyvertical/smrt-virt-web`, #1761).
@@ -1629,7 +1456,7 @@ export { manifest as default };
  * Generate TypeScript declaration file for virtual modules
  * This eliminates the need for manual type maintenance
  */
-async function generateTypeDeclarationFile(
+export async function generateTypeDeclarationFile(
   manifest: SmartObjectManifest,
   projectRoot: string,
   typeDeclarationsPath: string,
@@ -1678,90 +1505,62 @@ ${fields}
     // runtime — otherwise consumers see methods in autocomplete that are
     // undefined at runtime.
     const apiClientInterface = selectApiClientEntries(manifest)
-      .map(({ obj, clientKey, dataInterfaceName }) => {
-        const { methods = {} } = obj;
-        const apiConfig = obj.decoratorConfig?.api;
-        const interfaceName = dataInterfaceName;
-        const exposedActions = resolveApiActionSet(obj);
-        const customMethods = Object.entries(methods).filter(
-          ([name, method]) =>
-            !GENERATED_CLIENT_CRUD_METHODS.has(name) &&
-            method.isPublic &&
-            exposedActions.has(name),
-        );
-
-        // Generate custom method signatures
-        const customMethodSignatures = customMethods
-          .map(([methodName, method]) => {
-            const routeConfig = resolveApiActionRouteConfig(
-              methodName,
-              method,
-              apiConfig,
-              {},
-              isCollectionManifestClass(manifest, obj)
-                ? 'collection'
-                : method.isStatic
-                  ? 'collection'
-                  : 'item',
-            );
-            const params = method.parameters || [];
-            const pathParamNames = new Set(routeConfig.pathParamNames);
-            const hasSingleOptionsParameter =
-              params.length === 1 && params[0]?.name === 'options';
-            const requiredPathProperties = routeConfig.pathParamNames
-              .map((name) => `${name}: string`)
-              .join('; ');
-            let optionsType: string;
-            if (hasSingleOptionsParameter) {
-              const directOptionsType = mapTypeScriptType(params[0].type);
-              optionsType = requiredPathProperties
-                ? `${directOptionsType} & { ${requiredPathProperties} }`
-                : directOptionsType;
-            } else {
-              const parameterNames = new Set(params.map((param) => param.name));
-              const properties = params.map(
-                (param) =>
-                  `${param.name}${pathParamNames.has(param.name) ? '' : '?'}: ${mapTypeScriptType(param.type)}`,
-              );
-              for (const pathParamName of routeConfig.pathParamNames) {
-                if (!parameterNames.has(pathParamName)) {
-                  properties.push(`${pathParamName}: string`);
-                }
-              }
-              optionsType =
-                properties.length > 0
-                  ? `{ ${properties.join('; ')} }`
-                  : 'Record<string, never>';
-            }
-            const optionsParameter = `${routeConfig.pathParamNames.length > 0 ? 'options' : 'options?'}: ${optionsType}`;
-            const signature =
-              routeConfig.scope === 'collection'
-                ? optionsParameter
-                : `id: string, ${optionsParameter}`;
-            return `      ${methodName}(${signature}): Promise<any>;`;
-          })
-          .join('\n');
-
-        const overriddenBaseMethods = customMethods
-          .map(([methodName]) => methodName)
-          .filter((methodName) =>
-            GENERATED_CLIENT_BASE_METHODS.has(methodName),
+      .map(
+        ({
+          obj,
+          clientKey,
+          dataInterfaceName,
+          crudMethods,
+          customMethods: exposedMethods,
+        }) => {
+          const { methods = {} } = obj;
+          const interfaceName = dataInterfaceName;
+          const exposedActionNames = new Set(
+            exposedMethods.map((method) => method.name),
           );
-        const crudOperationsType =
-          overriddenBaseMethods.length > 0
-            ? `Omit<CrudOperations<${interfaceName}>, ${overriddenBaseMethods
-                .map((methodName) => JSON.stringify(methodName))
-                .join(' | ')}>`
-            : `CrudOperations<${interfaceName}>`;
+          const customMethods = Object.entries(methods).filter(
+            ([name, method]) =>
+              !GENERATED_CLIENT_CRUD_METHODS.has(name) &&
+              method.isPublic &&
+              exposedActionNames.has(name),
+          );
 
-        if (customMethods.length > 0) {
-          // Object with custom methods: include both CRUD and custom methods
-          return `    ${clientKey}: ${crudOperationsType} & {\n${customMethodSignatures}\n    };`;
-        } else {
-          // Standard CRUD operations only
-          return `    ${clientKey}: ${crudOperationsType};`;
-        }
-      })
+          // Generate custom method signatures
+          const customMethodSignatures = customMethods
+            .map(([methodName]) => {
+              const exposedMethod = exposedMethods.find(
+                ({ name }) => name === methodName,
+              );
+              if (!exposedMethod) return '';
+              const signature = renderApiClientCustomMethodParameters(
+                exposedMethod,
+                mapTypeScriptType,
+              );
+              return `      ${methodName}(${signature}): Promise<any>;`;
+            })
+            .join('\n');
+
+          const overriddenBaseMethods = customMethods
+            .map(([methodName]) => methodName)
+            .filter((methodName) =>
+              GENERATED_CLIENT_BASE_METHODS.has(methodName),
+            );
+          const crudOperationsType = renderApiClientCrudType(
+            interfaceName,
+            crudMethods,
+            overriddenBaseMethods,
+          );
+
+          if (customMethods.length > 0) {
+            const intersection = crudOperationsType
+              ? `${crudOperationsType} & `
+              : '';
+            return `    ${JSON.stringify(clientKey)}: ${intersection}{\n${customMethodSignatures}\n    };`;
+          }
+
+          return `    ${JSON.stringify(clientKey)}: ${crudOperationsType ?? 'Record<string, never>'};`;
+        },
+      )
       .join('\n');
 
     // Typed web collection definitions (#1761): one entry per REST collection,
@@ -1772,7 +1571,7 @@ ${fields}
     const webCollectionInterface = selectWebCollectionEntries(manifest)
       .map(
         ({ collection, obj }) =>
-          `    ${collection}: SmrtWebCollectionDefinition<import('@happyvertical/smrt-virt-types').${obj.className}Data>;`,
+          `    ${JSON.stringify(collection)}: SmrtWebCollectionDefinition<import('@happyvertical/smrt-virt-types').${obj.className}Data>;`,
       )
       .join('\n');
 

--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -145,6 +145,174 @@ describe('SvelteKit Route Generator', () => {
       expect(configContent).toContain('requestScopedDb ?? config.db');
     });
 
+    it('does not let transitive collection subclasses emit model CRUD routes', async () => {
+      const manifest: SmartObjectManifest = {
+        objects: {
+          Widget: {
+            className: 'Widget',
+            collection: 'widgets',
+            extends: 'SmrtObject',
+            fields: {},
+            methods: {},
+            decoratorConfig: { api: false },
+          },
+          WidgetCollection: {
+            className: 'WidgetCollection',
+            collection: 'widgets',
+            extends: 'SmrtCollection',
+            extendsTypeArg: 'Widget',
+            fields: {},
+            methods: {},
+            decoratorConfig: { api: false },
+          },
+          SpecialWidget: {
+            className: 'SpecialWidget',
+            collection: 'specialWidgets',
+            extends: 'SmrtObject',
+            fields: {},
+            methods: {},
+            decoratorConfig: { api: false },
+          },
+          SpecialWidgetCollection: {
+            className: 'SpecialWidgetCollection',
+            collection: 'widgets',
+            extends: 'WidgetCollection',
+            fields: {},
+            methods: {},
+            decoratorConfig: {},
+          },
+        },
+      };
+
+      await generateSvelteKitRoutes(projectRoot, manifest, {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+        configPath: 'src/lib/server',
+      });
+
+      const generatedWidgetRoutes = vi
+        .mocked(writeFileSync)
+        .mock.calls.filter(([filePath]) =>
+          String(filePath).includes('/src/routes/api/widgets/'),
+        );
+      expect(generatedWidgetRoutes).toEqual([]);
+    });
+
+    it('resolves an inherited collection item type for custom routes', async () => {
+      const manifest: SmartObjectManifest = {
+        objects: {
+          Widget: {
+            className: 'Widget',
+            collection: 'widgets',
+            extends: 'SmrtObject',
+            fields: {},
+            methods: {},
+            decoratorConfig: { api: false },
+          },
+          WidgetCollection: {
+            className: 'WidgetCollection',
+            collection: 'widgets',
+            extends: 'SmrtCollection',
+            extendsTypeArg: 'Widget',
+            fields: {},
+            methods: {},
+            decoratorConfig: { api: false },
+          },
+          SpecialWidget: {
+            className: 'SpecialWidget',
+            collection: 'specialWidgets',
+            extends: 'SmrtObject',
+            fields: {},
+            methods: {},
+            decoratorConfig: { api: false },
+          },
+          SpecialWidgetCollection: {
+            className: 'SpecialWidgetCollection',
+            collection: 'widgets',
+            extends: 'WidgetCollection',
+            fields: {},
+            methods: {
+              restoreSpecial: {
+                name: 'restoreSpecial',
+                parameters: [],
+                returnType: 'Promise<any>',
+                isPublic: true,
+                isStatic: false,
+              },
+            },
+            decoratorConfig: {
+              api: { include: ['restoreSpecial'] },
+            },
+          },
+        },
+      };
+
+      await generateSvelteKitRoutes(projectRoot, manifest, {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+        configPath: 'src/lib/server',
+      });
+
+      const route = vi
+        .mocked(writeFileSync)
+        .mock.calls.find(([filePath]) =>
+          String(filePath).includes(
+            '/src/routes/api/widgets/restoreSpecial/+server.ts',
+          ),
+        );
+      expect(route).toBeDefined();
+      const content = route?.[1] as string;
+      expectGetCollectionCall(content, 'Widget', 'Widget');
+      expect(content).not.toContain("getCollection('SpecialWidget')");
+    });
+
+    it('keeps an inherited item type name when a partial manifest omits the item', async () => {
+      const manifest: SmartObjectManifest = {
+        objects: {
+          WidgetCollection: {
+            className: 'WidgetCollection',
+            collection: 'widgets',
+            extends: 'SmrtCollection',
+            extendsTypeArg: 'Widget',
+            fields: {},
+            methods: {
+              restoreSpecial: {
+                name: 'restoreSpecial',
+                parameters: [],
+                returnType: 'Promise<any>',
+                isPublic: true,
+                isStatic: false,
+              },
+            },
+            decoratorConfig: {
+              api: { include: ['restoreSpecial'] },
+            },
+          },
+        },
+      };
+
+      await generateSvelteKitRoutes(projectRoot, manifest, {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+        configPath: 'src/lib/server',
+      });
+
+      const route = vi
+        .mocked(writeFileSync)
+        .mock.calls.find(([filePath]) =>
+          String(filePath).includes(
+            '/src/routes/api/widgets/restoreSpecial/+server.ts',
+          ),
+        );
+      expect(route).toBeDefined();
+      const content = route?.[1] as string;
+      expect(content).toContain("    'Widget',");
+      expect(content).not.toContain("'WidgetCollection'");
+    });
+
     it('should skip config generation when file already exists', async () => {
       vi.mocked(existsSync).mockReturnValue(true);
 
@@ -2301,6 +2469,101 @@ describe('SvelteKit Route Generator', () => {
       ).toEqual(['listSpecial']);
       expect(findCliApiCoherenceViolations(manifest)).toEqual([
         { className: 'DocCollection', unreachable: ['misconfigured'] },
+      ]);
+    });
+
+    it('does not claim CRUD routes for collection classes', () => {
+      const manifest: SmartObjectManifest = {
+        objects: {
+          DocCollection: {
+            className: 'DocCollection',
+            collection: 'docs',
+            fields: {},
+            extends: 'SmrtCollection',
+            extendsTypeArg: 'Doc',
+            methods: {},
+            decoratorConfig: {
+              api: true,
+              cli: { include: ['list'] },
+            },
+          },
+        },
+      };
+
+      expect(
+        Array.from(
+          resolveApiActionSet(manifest.objects.DocCollection, manifest),
+        ),
+      ).toEqual([]);
+      expect(findCliApiCoherenceViolations(manifest)).toEqual([
+        { className: 'DocCollection', unreachable: ['list'] },
+      ]);
+    });
+
+    it('uses manifest ancestry for transitive collection CLI/API coherence', () => {
+      const manifest: SmartObjectManifest = {
+        objects: {
+          Doc: {
+            className: 'Doc',
+            collection: 'docs',
+            fields: {},
+            methods: {},
+            decoratorConfig: { api: false },
+          },
+          DocCollection: {
+            className: 'DocCollection',
+            collection: 'docs',
+            fields: {},
+            extends: 'SmrtCollection',
+            extendsTypeArg: 'Doc',
+            methods: {},
+            decoratorConfig: { api: false },
+          },
+          SpecialDocCollection: {
+            className: 'SpecialDocCollection',
+            collection: 'docs',
+            fields: {},
+            extends: 'DocCollection',
+            methods: {
+              collectionAction: {
+                name: 'collectionAction',
+                parameters: [],
+                returnType: 'Promise<any>',
+                isPublic: true,
+                isStatic: false,
+              },
+              itemAction: {
+                name: 'itemAction',
+                parameters: [],
+                returnType: 'Promise<any>',
+                isPublic: true,
+                isStatic: false,
+              },
+            },
+            decoratorConfig: {
+              api: {
+                include: ['collectionAction', 'itemAction'],
+                routes: {
+                  collectionAction: { scope: 'collection' },
+                  itemAction: { scope: 'item' },
+                },
+              },
+              cli: { include: ['collectionAction', 'itemAction'] },
+            },
+          },
+        },
+      };
+
+      expect(
+        Array.from(
+          resolveApiActionSet(manifest.objects.SpecialDocCollection, manifest),
+        ),
+      ).toEqual(['collectionAction']);
+      expect(findCliApiCoherenceViolations(manifest)).toEqual([
+        {
+          className: 'SpecialDocCollection',
+          unreachable: ['itemAction'],
+        },
       ]);
     });
   });

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -29,7 +29,12 @@ import { generateChangesRoute } from './changes-route.js';
 import { generateEventsRoute } from './events-route.js';
 import { AUTO_GENERATED_ROUTE_HEADER } from './route-header.js';
 import { generateSyncApplyRoute } from './sync-apply-route.js';
-import { computeWebManifestHash } from './web-collections.js';
+import {
+  computeWebManifestHash,
+  isCollectionManifestClass,
+  resolveCollectionItemObject,
+  resolveCollectionItemTypeName,
+} from './web-collections.js';
 
 export interface SvelteKitOptions {
   enabled: boolean;
@@ -1072,22 +1077,15 @@ function findItemClassRegistryKey(
   objectDef: SmartObjectDefinition,
   manifest: SmartObjectManifest,
 ): string {
-  const itemClassName =
-    objectDef.extendsTypeArg ||
-    (className.endsWith('Collection')
-      ? className.slice(0, -'Collection'.length)
-      : undefined);
-
-  if (!itemClassName) {
-    return className;
+  const itemObject = resolveCollectionItemObject(manifest, objectDef);
+  if (!itemObject) {
+    return resolveCollectionItemTypeName(manifest, objectDef) || className;
   }
 
   const manifestMatch = Object.entries(manifest.objects).find(
-    ([manifestKey, candidate]) =>
-      manifestKey === itemClassName || candidate.className === itemClassName,
+    ([, manifestObject]) => manifestObject === itemObject,
   );
-
-  return manifestMatch?.[0] || itemClassName;
+  return manifestMatch?.[0] || itemObject.className;
 }
 
 function groupCustomActionRoutes(
@@ -1139,7 +1137,7 @@ export async function generateSvelteKitRoutes(
   let generatedCount = 0;
   let skippedCollections = 0;
   for (const [className, objectDef] of Object.entries(manifest.objects)) {
-    if (isCollectionClass(objectDef)) {
+    if (isCollectionManifestClass(manifest, objectDef)) {
       const generatedCollectionRoutes = await generateCollectionRoutesForObject(
         projectRoot,
         className,
@@ -1322,7 +1320,7 @@ async function generateRegistrationFile(
         hasCollectionImport: false,
       };
 
-      if (isCollectionClass(objectDef)) {
+      if (isCollectionManifestClass(manifest, objectDef)) {
         packageEntry.hasCollectionImport = true;
       } else {
         packageEntry.classNames.push(className);
@@ -1362,7 +1360,7 @@ async function generateRegistrationFile(
       );
     }
 
-    if (isCollectionClass(objectDef)) {
+    if (isCollectionManifestClass(manifest, objectDef)) {
       localSideEffectImports.add(importPath);
       continue;
     }
@@ -1412,7 +1410,7 @@ async function generateRegistrationFile(
   const imports = [packageImports, localImports].filter(Boolean).join('\n');
   const registrations = Object.entries(manifest.objects)
     .map(([className, objectDef]) => {
-      if (isCollectionClass(objectDef)) {
+      if (isCollectionManifestClass(manifest, objectDef)) {
         // Importing the collection class is enough to trigger its decorator.
         // Explicit package-qualified re-registration only applies to object
         // classes, because ObjectRegistry.register() is object-only.
@@ -1898,12 +1896,17 @@ function shouldIncludeInApi(actionName: string, apiConfig: unknown): boolean {
  */
 export function resolveApiActionSet(
   objectDef: SmartObjectDefinition,
+  manifest?: SmartObjectManifest,
 ): Set<string> {
   const apiConfig = objectDef.decoratorConfig?.api;
   if (apiConfig === false) return new Set();
 
-  const actions = new Set<string>(resolveStandardCrudActions(apiConfig));
-  const objectIsCollectionClass = isCollectionClass(objectDef);
+  const objectIsCollectionClass = manifest
+    ? isCollectionManifestClass(manifest, objectDef)
+    : isCollectionClass(objectDef);
+  const actions = objectIsCollectionClass
+    ? new Set<string>()
+    : new Set<string>(resolveStandardCrudActions(apiConfig));
   const config = getApiConfigObject(apiConfig);
 
   // Custom (non-CRUD, public) methods. We mirror BOTH the include/exclude
@@ -1978,7 +1981,7 @@ export function findCliApiCoherenceViolations(
     );
     if (effectiveCliCommands.length === 0) continue;
 
-    const apiActionSet = resolveApiActionSet(objectDef);
+    const apiActionSet = resolveApiActionSet(objectDef, manifest);
     const unreachable = effectiveCliCommands.filter(
       (action: string) => !apiActionSet.has(action),
     );

--- a/packages/core/src/vite-plugin/sync-apply-route.test.ts
+++ b/packages/core/src/vite-plugin/sync-apply-route.test.ts
@@ -112,6 +112,14 @@ describe('collectSyncApplyTargets', () => {
           extends: 'SmrtCollection',
           extendsTypeArg: 'Product',
         },
+        SpecialProductCollection: {
+          className: 'SpecialProductCollection',
+          collection: 'products',
+          fields: {},
+          methods: {},
+          decoratorConfig: { api: true },
+          extends: 'ProductCollection',
+        },
       }),
     );
     expect(targets).toHaveLength(0);

--- a/packages/core/src/vite-plugin/sync-apply-route.ts
+++ b/packages/core/src/vite-plugin/sync-apply-route.ts
@@ -25,6 +25,7 @@ import type {
 } from '../scanner/types';
 import { AUTO_GENERATED_ROUTE_HEADER } from './route-header.js';
 import type { SvelteKitOptions } from './sveltekit-generator.js';
+import { isCollectionManifestClass } from './web-collections.js';
 
 const MUTATING_ACTIONS = ['create', 'update', 'delete'] as const;
 
@@ -113,11 +114,6 @@ function getApiWritableAllowlist(apiConfig: unknown): string[] | null {
   return Array.isArray(config?.writable) ? config.writable : null;
 }
 
-/** Mirror of sveltekit-generator.ts `isCollectionClass`. */
-function isCollectionClass(objectDef: SmartObjectDefinition): boolean {
-  return objectDef.extends === 'SmrtCollection' || !!objectDef.extendsTypeArg;
-}
-
 /**
  * Collect the syncable targets from a manifest: non-collection objects whose
  * API config is enabled and exposes at least one mutating action.
@@ -128,7 +124,7 @@ export function collectSyncApplyTargets(
   const targets: SyncTargetSpec[] = [];
 
   for (const [className, objectDef] of Object.entries(manifest.objects)) {
-    if (isCollectionClass(objectDef)) continue;
+    if (isCollectionManifestClass(manifest, objectDef)) continue;
 
     const apiConfig = objectDef.decoratorConfig?.api;
     if (apiConfig === false) continue;

--- a/packages/core/src/vite-plugin/web-collections.test.ts
+++ b/packages/core/src/vite-plugin/web-collections.test.ts
@@ -21,6 +21,9 @@ import {
   buildWebRelationships,
   buildWebToolDescriptors,
   computeWebManifestHash,
+  isCollectionManifestClass,
+  resolveCollectionItemObject,
+  resolveCollectionItemTypeName,
   selectWebCollectionEntries,
 } from './web-collections.js';
 
@@ -52,6 +55,113 @@ function manifest(...objects: SmartObjectDefinition[]): SmartObjectManifest {
     ),
   } as SmartObjectManifest;
 }
+
+describe('collection item ancestry', () => {
+  const baseWidget = obj({
+    className: 'Widget',
+    collection: 'widgets',
+    packageName: '@base/pkg',
+    qualifiedName: '@base/pkg:Widget',
+  });
+  const childWidget = obj({
+    className: 'Widget',
+    collection: 'childWidgets',
+    packageName: '@child/pkg',
+    qualifiedName: '@child/pkg:Widget',
+  });
+  const baseCollection = obj({
+    className: 'WidgetCollection',
+    collection: 'widgets',
+    packageName: '@base/pkg',
+    qualifiedName: '@base/pkg:WidgetCollection',
+    extends: 'SmrtCollection',
+    extendsTypeArg: 'Widget',
+  });
+  const childCollection = obj({
+    className: 'SpecialWidgetCollection',
+    collection: 'widgets',
+    packageName: '@child/pkg',
+    qualifiedName: '@child/pkg:SpecialWidgetCollection',
+    extends: 'WidgetCollection',
+    extendsQualified: '@base/pkg:WidgetCollection',
+  });
+
+  it('resolves an inherited generic in the package that declared it', () => {
+    const crossPackageManifest = manifest(
+      childWidget,
+      childCollection,
+      baseCollection,
+      baseWidget,
+    );
+
+    expect(
+      resolveCollectionItemObject(crossPackageManifest, childCollection),
+    ).toBe(baseWidget);
+    expect(
+      resolveCollectionItemTypeName(crossPackageManifest, childCollection),
+    ).toBe('Widget');
+  });
+
+  it('keeps a qualified generic reference when a partial manifest omits its item', () => {
+    const partialManifest = manifest(
+      childWidget,
+      childCollection,
+      baseCollection,
+    );
+
+    expect(
+      resolveCollectionItemObject(partialManifest, childCollection),
+    ).toBeUndefined();
+    expect(
+      resolveCollectionItemTypeName(partialManifest, childCollection),
+    ).toBe('@base/pkg:Widget');
+  });
+
+  it('uses qualified manifest keys when legacy object bodies omit package identity', () => {
+    const child = obj({
+      className: 'SpecialDocCollection',
+      collection: 'docs',
+      extends: 'DocCollection',
+      qualifiedName: '@z/base:SpecialDocCollection',
+    });
+    const realParent = obj({
+      className: 'DocCollection',
+      collection: 'docs',
+      extends: 'SmrtCollection',
+      extendsTypeArg: 'Doc',
+      qualifiedName: '@z/base:DocCollection',
+    });
+    const collidingParent = obj({
+      className: 'DocCollection',
+      collection: 'unrelated',
+      extends: 'SmrtObject',
+      qualifiedName: '@a/other:DocCollection',
+    });
+    const realItem = obj({
+      className: 'Doc',
+      collection: 'docs',
+      qualifiedName: '@z/base:Doc',
+    });
+    for (const candidate of [child, realParent, collidingParent, realItem]) {
+      candidate.qualifiedName = undefined;
+      candidate.packageName = undefined;
+    }
+    const legacyManifest = {
+      version: '1.0.0',
+      timestamp: 0,
+      objects: {
+        '@z/base:SpecialDocCollection': child,
+        '@z/base:DocCollection': realParent,
+        '@z/base:Doc': realItem,
+        '@a/other:DocCollection': collidingParent,
+      },
+    } as SmartObjectManifest;
+
+    expect(isCollectionManifestClass(legacyManifest, child)).toBe(true);
+    expect(resolveCollectionItemTypeName(legacyManifest, child)).toBe('Doc');
+    expect(resolveCollectionItemObject(legacyManifest, child)).toBe(realItem);
+  });
+});
 
 describe('buildWebToolDescriptors', () => {
   const field = (f: Partial<FieldDefinition>): FieldDefinition =>

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -114,6 +114,7 @@ interface ManifestObjectIndex {
   byExactName: Map<string, SmartObjectDefinition>;
   byPackageAndClass: Map<string, SmartObjectDefinition>;
   bySimpleName: Map<string, SmartObjectDefinition>;
+  packageByObject: WeakMap<SmartObjectDefinition, string>;
 }
 
 const manifestObjectIndexes = new WeakMap<
@@ -142,6 +143,7 @@ function getManifestObjectIndex(
     byExactName: new Map(),
     byPackageAndClass: new Map(),
     bySimpleName: new Map(),
+    packageByObject: new WeakMap(),
   };
 
   for (const [manifestKey, candidate] of entries) {
@@ -160,6 +162,9 @@ function getManifestObjectIndex(
 
     const packageName = manifestObjectPackage(manifestKey, candidate);
     if (packageName) {
+      if (!index.packageByObject.has(candidate)) {
+        index.packageByObject.set(candidate, packageName);
+      }
       const packageKey = packageAndClassKey(packageName, candidate.className);
       if (!index.byPackageAndClass.has(packageKey)) {
         index.byPackageAndClass.set(packageKey, candidate);
@@ -169,6 +174,16 @@ function getManifestObjectIndex(
 
   manifestObjectIndexes.set(manifest.objects, index);
   return index;
+}
+
+function indexedManifestObjectPackage(
+  manifest: SmartObjectManifest,
+  obj: SmartObjectDefinition,
+): string | undefined {
+  const index = getManifestObjectIndex(manifest);
+  return (
+    index.packageByObject.get(obj) || manifestObjectPackage(undefined, obj)
+  );
 }
 
 /**
@@ -189,7 +204,7 @@ export function findManifestObjectByName(
   if (exact) return exact;
 
   const ownerPackage = owner
-    ? manifestObjectPackage(undefined, owner)
+    ? indexedManifestObjectPackage(manifest, owner)
     : undefined;
   const packageLocal = ownerPackage
     ? index.byPackageAndClass.get(packageAndClassKey(ownerPackage, name))
@@ -245,6 +260,113 @@ export function isCollectionManifestClass(
   seen.add(parentName);
   const parent = findManifestObjectByName(manifest, parentName, obj);
   return parent ? isCollectionManifestClass(manifest, parent, seen) : false;
+}
+
+/**
+ * Resolve the row model carried by a collection class.
+ *
+ * An explicit generic on any ancestor is authoritative. Conventional
+ * `FooCollection` → `Foo` lookup is only a fallback after the full ancestry
+ * has been checked, so an unrelated `SpecialFoo` cannot override an inherited
+ * `FooCollection<Foo>` contract.
+ */
+function collectionAncestry(
+  manifest: SmartObjectManifest,
+  obj: SmartObjectDefinition,
+): SmartObjectDefinition[] {
+  const ancestry: SmartObjectDefinition[] = [];
+  const seen = new Set<string>();
+  let candidate: SmartObjectDefinition | undefined = obj;
+
+  while (candidate) {
+    ancestry.push(candidate);
+    const parentName = candidate.extendsQualified || candidate.extends;
+    if (!parentName || seen.has(parentName)) break;
+    seen.add(parentName);
+    candidate = findManifestObjectByName(manifest, parentName, candidate);
+  }
+  return ancestry;
+}
+
+/**
+ * Resolve the authoritative collection item type name even when a partial
+ * manifest omits the item definition itself.
+ */
+interface CollectionItemReference {
+  name: string;
+  owner: SmartObjectDefinition;
+  object?: SmartObjectDefinition;
+}
+
+function resolveCollectionItemCandidate(
+  manifest: SmartObjectManifest,
+  name: string,
+  owner: SmartObjectDefinition,
+): CollectionItemReference {
+  const object = findManifestObjectByName(manifest, name, owner);
+  const ownerPackage = indexedManifestObjectPackage(manifest, owner);
+
+  if (!name.includes(':') && ownerPackage) {
+    const objectPackage = object
+      ? indexedManifestObjectPackage(manifest, object)
+      : undefined;
+    if (objectPackage !== ownerPackage) {
+      return {
+        name: `${ownerPackage}:${name}`,
+        owner,
+      };
+    }
+  }
+
+  return { name, owner, object };
+}
+
+function resolveCollectionItemReference(
+  manifest: SmartObjectManifest,
+  obj: SmartObjectDefinition,
+): CollectionItemReference | undefined {
+  const ancestry = collectionAncestry(manifest, obj);
+  for (const collectionClass of ancestry) {
+    if (collectionClass.extendsTypeArg) {
+      return resolveCollectionItemCandidate(
+        manifest,
+        collectionClass.extendsTypeArg,
+        collectionClass,
+      );
+    }
+  }
+
+  let fallback: CollectionItemReference | undefined;
+  for (const collectionClass of ancestry) {
+    if (!collectionClass.className.endsWith('Collection')) continue;
+    const conventionalName = collectionClass.className.slice(
+      0,
+      -'Collection'.length,
+    );
+    const candidate = resolveCollectionItemCandidate(
+      manifest,
+      conventionalName,
+      collectionClass,
+    );
+    if (candidate.object) return candidate;
+    fallback ??= candidate;
+  }
+
+  return fallback;
+}
+
+export function resolveCollectionItemTypeName(
+  manifest: SmartObjectManifest,
+  obj: SmartObjectDefinition,
+): string | undefined {
+  return resolveCollectionItemReference(manifest, obj)?.name;
+}
+
+export function resolveCollectionItemObject(
+  manifest: SmartObjectManifest,
+  obj: SmartObjectDefinition,
+): SmartObjectDefinition | undefined {
+  return resolveCollectionItemReference(manifest, obj)?.object;
 }
 
 /**

--- a/packages/jobs/src/forge-projection.ts
+++ b/packages/jobs/src/forge-projection.ts
@@ -222,6 +222,11 @@ export interface ClaimForgeDeliveryOptions {
  * is the sole cross-tenant worker scan and returns the captured tenant so the
  * runtime can restore it before normalization or projection.
  */
+@smrt({
+  api: false,
+  cli: false,
+  mcp: false,
+})
 export class ForgeDeliveryCollection extends SmrtCollection<ForgeDelivery> {
   static readonly _itemClass = ForgeDelivery;
 


### PR DESCRIPTION
## Summary

- make generated clients omit `api: false` objects and carry the exact server-emitted CRUD/custom action set across runtime, Vite, prebuild, inherited collections, and qualified cross-package manifests
- keep required custom-route path parameters aligned in both declaration paths and explicitly suppress the internal forge delivery collection
- add an audited PostgreSQL UTC migration path for framework `_smrt_*` timestamps before migration-tracker bootstrap, including a strictly read-only dry-run plan
- let the unchanged affected dependency-closure validation finish by raising its reproduced 30-minute ceiling to 45 minutes

## Restored snapshot rehearsal

Rehearsed against restored production- and development-shaped PostgreSQL snapshots in an isolated `postgres:18-alpine` container; no live database was touched.

- explicit UTC migration completed atomically on both snapshots (420 schema changes each)
- the normal migration command immediately afterward reported the schema up to date on both snapshots
- manifest-owned and current SMRT system timestamps converted to `timestamptz`
- remaining legacy timestamp columns were confined to obsolete, unreferenced tables

## Validation

- core full suite: 264 files passed, 3,165 tests passed, 45 skipped
- final focused core suite: 8 files, 173 tests passed
- CLI full suite: 55 files passed, 799 tests passed, 6 skipped
- jobs full suite: 18 files passed, 119 tests passed
- core, CLI, and jobs typechecks passed
- core and dependency-aware jobs builds passed
- knowledge freshness, repository standards, dependency policy audit, formatting, workflow validation, and `git diff --check` passed
- four-reviewer final review cycle: CLEAN

Closes #2132
Closes #2134
Closes #2136

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-2132-ergot-upgrade-20260729","issue":"2132","policy_revision":"1.0.0","status":"complete","validation":["restored production and development snapshot migrations plus normal idempotent follow-up","core CLI and jobs full suites","core CLI and jobs typechecks and builds","knowledge standards formatting workflow and policy checks","four-reviewer final CLEAN cycle"]}
