### PR TITLE
fix(mcp): repair generated-server config import, bump SDK to 1.30.0, add conformance CI (#2146)

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -318,6 +318,14 @@ jobs:
       - name: Check hardcoded UI strings
         run: node scripts/check-hardcoded-strings.mjs
 
+      # Bans removed/deprecated MCP 2026-07-28 protocol features (ping,
+      # logging/setLevel, roots list_changed, Roots/Sampling/Logging
+      # capabilities, Mcp-Session-Id, HTTP+SSE transport) across
+      # packages/*/src, generated runtime templates included (#2146).
+      # Node-only, no deps.
+      - name: Check MCP protocol hygiene
+        run: node scripts/check-mcp-protocol-hygiene.mjs
+
   dependency-audit:
     name: Dependency Vulnerability Audit
     if: >-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,9 @@ for package-specific architecture and validation.
   properties, tags, social, marketing, and secrets.
 - Client/tooling packages include `smrt-web`, `smrt-svelte`, mobile packages,
   templates, and `smrt-dev-mcp`. The private `bundle-gate` package is the CI
-  consumer bundle reachability/size gate (#1980).
+  consumer bundle reachability/size gate (#1980); the private
+  `mcp-conformance-fixture` package is the CI MCP conformance gate for the
+  generated runtime template (#2146).
 - Package versions are coordinated with changesets. Do not create changesets
   manually; release automation generates them on merge.
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Status legend:
 | [`smrt-dev-mcp`](./packages/smrt-dev-mcp/README.md) | Stable | Development MCP server and repository knowledge tools. |
 | [`smrt-app-mcp`](./packages/smrt-app-mcp/README.md) | Preview | App-runtime MCP server and transport adapters. |
 | [`smrt-bundle-gate`](./packages/bundle-gate/README.md) | Internal | Consumer bundle reachability and size regression gate. |
+| [`smrt-mcp-conformance-fixture`](./packages/mcp-conformance-fixture/README.md) | Internal | MCP conformance gate for the generated Tier-1 runtime server template. |
 
 ### Agents, identity, and operations
 

--- a/docs/content/api/core/index.md
+++ b/docs/content/api/core/index.md
@@ -324,7 +324,7 @@ export default {
   plugins: [
     smrtPlugin({
       include: ['src/**/*.ts'],
-      exclude: ['**/*.test.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', '**/__tests__/**'],
       generateTypes: true,
       hmr: true
     })

--- a/docs/content/core.md
+++ b/docs/content/core.md
@@ -652,7 +652,7 @@ export default {
   plugins: [
     smrtPlugin({
       include: ['src/**/*.ts'],
-      exclude: ['**/*.test.ts'],
+      exclude: ['**/*.test.ts', '**/*.spec.ts', '**/__tests__/**'],
       generateTypes: true,
       hmr: true
     })

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -205,6 +205,20 @@ pre-push:
         <input>/<textarea>/<select>/<form> → @happyvertical/smrt-svelte.
         Run: node scripts/check-raw-primitives.mjs
 
+    mcp-protocol-hygiene:
+      # Bans removed/deprecated MCP 2026-07-28 protocol features (ping,
+      # logging/setLevel, roots list_changed, Roots/Sampling/Logging
+      # capabilities, Mcp-Session-Id, HTTP+SSE transport) in packages/*/src,
+      # generated runtime templates included (#2146).
+      run: node scripts/check-mcp-protocol-hygiene.mjs
+      fail_text: |
+        ❌ Removed/deprecated MCP protocol feature reintroduced!
+
+        The MCP 2026-07-28 spec removed ping, logging/setLevel, roots
+        list_changed, and Mcp-Session-Id, and deprecated the Roots/Sampling/
+        Logging capabilities and the HTTP+SSE transport.
+        Run: pnpm check:mcp-protocol-hygiene
+
     svelte-tokens:
       # Repo-wide: every consumed --smrt-* token must be emitted by a theme path
       # (or defined inline). Catches dangling/malformed refs in any package.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "check:no-smrt-peers": "node scripts/check-no-smrt-peers.mjs",
     "check:package-dag": "node scripts/check-package-dag.mjs",
     "check:mcp-config": "node scripts/check-mcp-config.mjs",
+    "check:mcp-protocol-hygiene": "node scripts/check-mcp-protocol-hygiene.mjs",
     "check:agents-chain": "node scripts/check-agents-chain.mjs",
     "knowledge:check": "tsx scripts/check-knowledge.ts",
     "changeset": "changeset",

--- a/packages/app-cli/package.json
+++ b/packages/app-cli/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@happyvertical/smrt-users": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.25.2"
+    "@modelcontextprotocol/sdk": "^1.30.0"
   },
   "devDependencies": {
     "@happyvertical/smrt-core": "workspace:*",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -393,7 +393,7 @@ export const initCommands: Record<string, CLICommand> = {
        sveltekit(),
        smrtPlugin({
          include: ['src/lib/objects/**/*.ts'],
-         exclude: ['**/*.test.ts'],
+         exclude: ['**/*.test.ts', '**/*.spec.ts', '**/__tests__/**'],
          generateTypes: true,
          svelteKit: {
            enabled: true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -159,7 +159,7 @@
     "@happyvertical/smrt-types": "workspace:*",
     "@happyvertical/sql": "catalog:",
     "@happyvertical/utils": "catalog:",
-    "@modelcontextprotocol/sdk": "^1.25.2",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@oxc-project/runtime": "^0.138.0",
     "cheerio": "^1.2.0",
     "fast-glob": "3.3.3",

--- a/packages/core/src/generators/mcp-integration.spec.ts
+++ b/packages/core/src/generators/mcp-integration.spec.ts
@@ -287,9 +287,9 @@ describe('MCPGenerator - Integration Tests', () => {
 
       // Verify @happyvertical/smrt-config usage
       expect(content).toContain(
-        "import { config } from '@happyvertical/smrt-config'",
+        "import { loadConfig } from '@happyvertical/smrt-config'",
       );
-      expect(content).toContain('await config.load()');
+      expect(content).toContain('await loadConfig()');
       expect(content).toContain('appConfig?.ai || {}');
 
       // Verify ObjectRegistry integration

--- a/packages/core/src/generators/mcp-modular.test.ts
+++ b/packages/core/src/generators/mcp-modular.test.ts
@@ -71,9 +71,9 @@ describe('MCPGenerator - Modular Generation', () => {
 
       const content = await readFile(outputPath, 'utf-8');
       expect(content).toContain(
-        "import { config } from '@happyvertical/smrt-config'",
+        "import { loadConfig } from '@happyvertical/smrt-config'",
       );
-      expect(content).toContain('await config.load()');
+      expect(content).toContain('await loadConfig()');
       expect(content).toContain('appConfig?.ai || {}');
       expect(content).not.toContain('loadEnvConfig'); // Old approach
     });

--- a/packages/core/src/generators/mcp-runtime-template.ts
+++ b/packages/core/src/generators/mcp-runtime-template.ts
@@ -241,7 +241,7 @@ import {
   type ListToolsRequest,
 } from '@modelcontextprotocol/sdk/types.js';
 import { ObjectRegistry } from '@happyvertical/smrt-core';
-import { config } from '@happyvertical/smrt-config';
+import { loadConfig } from '@happyvertical/smrt-config';
 ${hasTenantScoped ? "import { enableTenancy, runTenantScopedEntryPoint } from '@happyvertical/smrt-tenancy';\n" : ''}
 // Server configuration
 const SERVER_NAME = ${JSON.stringify(name)};
@@ -349,7 +349,7 @@ ${
     : ''
 }
     // Load configuration from environment and .smrt.config files
-    const appConfig = await config.load();
+    const appConfig = await loadConfig();
     const aiConfig = appConfig?.ai || {};
 
     if (DEBUG) {

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -1603,7 +1603,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { config } from '@happyvertical/smrt-config';
+import { loadConfig } from '@happyvertical/smrt-config';
 import { getDatabase } from '@happyvertical/sql';
 import { getAI } from '@happyvertical/ai';
 
@@ -1622,7 +1622,7 @@ async function main() {
     }
 
     // Load configuration from environment and .smrt.config files
-    const appConfig = await config.load();
+    const appConfig = await loadConfig();
     const aiConfig = appConfig?.ai || {};
 
     // Create MCP server

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -198,10 +198,26 @@ export function generateInlineRegisterModule(
   ].join('\n');
 }
 
+/**
+ * Default exclude globs for the build-time manifest scan. Test-located
+ * `@smrt()` classes must never reach a published `dist/manifest.json` /
+ * `dist/smrt-knowledge.json` — downstream manifest discovery would treat
+ * them as real package objects (#2146). Mirrors the scanner package's
+ * `DEFAULT_IGNORE_PATTERNS` for test paths; the smrt-vitest plugin
+ * intentionally scans WITH test files so fixture classes keep field
+ * metadata during tests.
+ */
+export const DEFAULT_SCAN_EXCLUDE = [
+  '**/*.test.ts',
+  '**/*.spec.ts',
+  '**/__tests__/**',
+  '**/node_modules/**',
+];
+
 export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
   const {
     include = ['src/**/*.ts', 'src/**/*.js'],
-    exclude = ['**/*.test.ts', '**/*.spec.ts', '**/node_modules/**'],
+    exclude = DEFAULT_SCAN_EXCLUDE,
     hmr = true,
     watch = true,
     generateTypes = true,

--- a/packages/core/src/vite-plugin/scan-exclude.test.ts
+++ b/packages/core/src/vite-plugin/scan-exclude.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Regression guard for the build-time manifest scan excludes (#2146).
+ *
+ * `@smrt()` classes declared in test files must never reach a published
+ * `dist/manifest.json`: the smrt-app-mcp conformance fixtures leaked into
+ * the production manifest as phantom package objects because the plugin's
+ * default exclude list had drifted from the scanner package's defaults and
+ * missed `__tests__` directories (test FILES were excluded, plain fixture
+ * modules inside `__tests__/` were not).
+ */
+import { minimatch } from 'minimatch';
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_SCAN_EXCLUDE } from './index.js';
+
+function isExcluded(path: string): boolean {
+  return DEFAULT_SCAN_EXCLUDE.some((pattern) =>
+    minimatch(path, pattern, { dot: true }),
+  );
+}
+
+describe('DEFAULT_SCAN_EXCLUDE (build-time manifest scan)', () => {
+  it('excludes every test-file shape that can declare @smrt() classes', () => {
+    expect(isExcluded('src/registry.test.ts')).toBe(true);
+    expect(isExcluded('src/generators/mcp-protocol.spec.ts')).toBe(true);
+    expect(isExcluded('src/__tests__/mcp-conformance-fixture-objects.ts')).toBe(
+      true,
+    );
+    expect(isExcluded('src/__tests__/fixtures/registry-test-classes.ts')).toBe(
+      true,
+    );
+    expect(isExcluded('node_modules/pkg/src/model.ts')).toBe(true);
+  });
+
+  it('keeps production sources in scan scope', () => {
+    expect(isExcluded('src/models/article.ts')).toBe(false);
+    expect(isExcluded('src/testing/database.ts')).toBe(false);
+    expect(isExcluded('src/index.ts')).toBe(false);
+  });
+});

--- a/packages/mcp-conformance-fixture/.gitignore
+++ b/packages/mcp-conformance-fixture/.gitignore
@@ -1,0 +1,1 @@
+.generated-tmp/

--- a/packages/mcp-conformance-fixture/AGENTS.md
+++ b/packages/mcp-conformance-fixture/AGENTS.md
@@ -1,0 +1,41 @@
+# @happyvertical/smrt-mcp-conformance-fixture
+
+Private CI gate: runs the official `@modelcontextprotocol/conformance` suite
+against a server generated from the Tier-1 runtime template
+(`packages/core/src/generators/mcp-runtime-template.ts`). Never published.
+
+## How it works
+
+1. `src/fixture-objects.ts` registers two plain `@smrt()` objects with
+   explicit `api`/`mcp`/`cli` config.
+2. The spec calls `MCPGenerator.generateServer()` to bake a real single-file
+   stdio server into `.generated-tmp/` (gitignored), then runs it via `tsx` —
+   exactly the artifact downstream apps ship.
+3. The conformance CLI only tests HTTP servers, so a per-request forwarder
+   mirrors the generated server's `serverInfo`/capabilities onto a stateless
+   `StreamableHTTPServerTransport`, proxying `tools/list` and `tools/call`
+   through one stdio SDK `Client`. Results pass through verbatim; only the
+   transport envelope is the forwarder's.
+4. `conformance-baseline.yml` is the expected-failure baseline: unexpected
+   failures fail CI, and so do stale entries (a baselined scenario that
+   starts passing).
+
+Sibling conformance harnesses: `packages/smrt-dev-mcp` (real server over
+HTTP directly) and `packages/smrt-app-mcp` (HTTP tool API composed with the
+app-cli stdio bridge).
+
+## Gotchas
+
+- **Requires built workspace deps**: the spawned server imports
+  `@happyvertical/smrt-core` / `smrt-config` package exports (dist). Run
+  `npx turbo build --filter=@happyvertical/smrt-core...` in a fresh worktree
+  first.
+- **The generated server never touches a database here**: conformance
+  scenarios only call suite fixture tool names, and generated tool bodies
+  connect lazily per call — so no schema bootstrap is needed.
+- **Do not hand-edit `.generated-tmp/`**: it is regenerated every run and
+  removed on cleanup.
+- The template intentionally stays stdio-only (#1540 trust boundary); a
+  native spec-compliant HTTP endpoint is #2147's scope. When the template
+  moves to the MCP SDK v2 line, bump `SPEC_VERSION` here to `2026-07-28` and
+  re-derive the baseline.

--- a/packages/mcp-conformance-fixture/CLAUDE.md
+++ b/packages/mcp-conformance-fixture/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/mcp-conformance-fixture/README.md
+++ b/packages/mcp-conformance-fixture/README.md
@@ -1,0 +1,11 @@
+# @happyvertical/smrt-mcp-conformance-fixture
+
+Private CI gate that generates a Tier-1 MCP server from the runtime template
+and runs the official MCP conformance suite against it. See
+[AGENTS.md](./AGENTS.md) for the mechanism and gotchas.
+
+```bash
+pnpm --filter @happyvertical/smrt-mcp-conformance-fixture test
+```
+
+Not published to npm.

--- a/packages/mcp-conformance-fixture/conformance-baseline.yml
+++ b/packages/mcp-conformance-fixture/conformance-baseline.yml
@@ -1,0 +1,40 @@
+# Expected-failure baseline for the generated-template conformance run in
+# src/generated-server-conformance.spec.ts (#2146). Every entry is a scenario
+# a generated tools-only Tier-1 server cannot pass at spec revision
+# 2025-11-25: the template declares only the `tools` capability, and the
+# tools-call fixtures require suite-defined tool names (test_image_content,
+# …) no product server implements. Unexpected failures and stale entries
+# (a baselined scenario that starts passing) both fail CI. Re-derive when the
+# template gains capabilities (#2145 children) or moves to SDK v2 /
+# spec 2026-07-28.
+server:
+  # SEP-1699 concurrent POST SSE streams assume the stateful session
+  # lifecycle; against the stateless per-request harness the scenario
+  # alternates between skipping (0 checks, tolerated) and failing.
+  - server-sse-multiple-streams
+  # Capabilities the generated template does not declare (tools only).
+  - logging-set-level
+  - completion-complete
+  - resources-list
+  - resources-read-text
+  - resources-read-binary
+  - resources-templates-read
+  - resources-subscribe
+  - resources-unsubscribe
+  - prompts-list
+  - prompts-get-simple
+  - prompts-get-with-args
+  - prompts-get-embedded-resource
+  - prompts-get-with-image
+  # Suite fixture tools (test_image_content, test_audio_content, …).
+  - tools-call-image
+  - tools-call-audio
+  - tools-call-embedded-resource
+  - tools-call-mixed-content
+  - tools-call-with-logging
+  - tools-call-with-progress
+  # Server-initiated sampling/elicitation fixtures.
+  - tools-call-sampling
+  - tools-call-elicitation
+  - elicitation-sep1034-defaults
+  - elicitation-sep1330-enums

--- a/packages/mcp-conformance-fixture/package.json
+++ b/packages/mcp-conformance-fixture/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@happyvertical/smrt-mcp-conformance-fixture",
+  "version": "0.0.0",
+  "description": "MCP conformance gate for the generated Tier-1 runtime server template",
+  "type": "module",
+  "private": true,
+  "author": "HappyVertical",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/smrt.git",
+    "directory": "packages/mcp-conformance-fixture"
+  },
+  "files": [
+    "dist",
+    "CLAUDE.md",
+    "AGENTS.md"
+  ],
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@happyvertical/smrt-config": "workspace:*",
+    "@happyvertical/smrt-core": "workspace:*",
+    "@modelcontextprotocol/conformance": "0.2.0-alpha.10",
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "@types/node": "24.13.2",
+    "typescript": "5.9.3",
+    "vite": "8.1.4",
+    "vitest": "4.1.10"
+  }
+}

--- a/packages/mcp-conformance-fixture/src/fixture-objects.ts
+++ b/packages/mcp-conformance-fixture/src/fixture-objects.ts
@@ -1,0 +1,39 @@
+/**
+ * Fixture `@smrt()` objects for the generated-template conformance run.
+ *
+ * Two plain objects (no tenancy, no cross-package refs) so the generated
+ * Tier-1 server exercises the default template path: static TOOLS baked at
+ * generation time, stdio transport, no tenant gate imports. Explicit
+ * `api`/`mcp`/`cli` config — an omitted config means full CRUD (#1400).
+ */
+import { SmrtCollection, SmrtObject, smrt } from '@happyvertical/smrt-core';
+
+@smrt({
+  api: false,
+  cli: false,
+  mcp: { include: ['list', 'get'] },
+})
+export class ConformanceWidget extends SmrtObject {
+  name = '';
+  description = '';
+  count = 0;
+}
+
+export class ConformanceWidgetCollection extends SmrtCollection<ConformanceWidget> {
+  static readonly _itemClass = ConformanceWidget;
+}
+
+@smrt({
+  api: false,
+  cli: false,
+  mcp: { include: ['list', 'get', 'create'] },
+})
+export class ConformanceGadget extends SmrtObject {
+  name = '';
+  label = '';
+  price = 0.0;
+}
+
+export class ConformanceGadgetCollection extends SmrtCollection<ConformanceGadget> {
+  static readonly _itemClass = ConformanceGadget;
+}

--- a/packages/mcp-conformance-fixture/src/generated-server-conformance.spec.ts
+++ b/packages/mcp-conformance-fixture/src/generated-server-conformance.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * Official MCP conformance suite against a generated Tier-1 runtime server
+ * (#2146).
+ *
+ * The spec generates a real server from `MCPGenerator` (the same
+ * `mcp-runtime-template.ts` bootstrap every downstream app bakes), runs it as
+ * the stdio process it ships as, and bridges it to the HTTP-only conformance
+ * CLI through a thin forwarder: one SDK `Client` connected to the generated
+ * server over stdio, mirrored per-request onto a stateless
+ * `StreamableHTTPServerTransport`. tools/list, tools/call, and every result
+ * shape the generated server produces pass through the forwarder verbatim;
+ * only the transport envelope (initialize response assembly, ping) is the
+ * forwarder's own — the generated template stays stdio-only by design
+ * (#1540 documents its trust boundary; a native HTTP endpoint is #2147).
+ *
+ * `conformance-baseline.yml` lists scenarios that cannot pass for a
+ * generated tools-only server (suite fixture tools, undeclared optional
+ * capabilities). Unexpected failures AND stale baseline entries both fail.
+ */
+import { spawn } from 'node:child_process';
+import { mkdir, rm } from 'node:fs/promises';
+import { createServer as createHttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { MCPGenerator } from '@happyvertical/smrt-core/generators/mcp';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import './fixture-objects.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(__dirname, '..');
+const repoRoot = resolve(packageRoot, '..', '..');
+const tsxBin = join(repoRoot, 'node_modules', '.bin', 'tsx');
+const conformanceBin = join(packageRoot, 'node_modules', '.bin', 'conformance');
+const baselinePath = join(packageRoot, 'conformance-baseline.yml');
+const generatedDir = join(packageRoot, '.generated-tmp');
+const generatedServerPath = join(generatedDir, 'index.ts');
+
+const SPEC_VERSION = '2025-11-25';
+
+let stdioClient: Client;
+let stdioTransport: StdioClientTransport;
+let httpServer: ReturnType<typeof createHttpServer>;
+let mcpUrl: string;
+let allowedHosts: string[] = [];
+
+beforeAll(async () => {
+  // 1. Generate the Tier-1 server from the registered fixture objects using
+  //    the exact template downstream builds consume.
+  await rm(generatedDir, { force: true, recursive: true });
+  await mkdir(generatedDir, { recursive: true });
+  const generator = new MCPGenerator(
+    {
+      name: 'smrt-conformance-fixture',
+      version: '0.0.0',
+      description: 'Generated-template conformance fixture server',
+    },
+    { user: { id: 'conformance-fixture' } },
+  );
+  await generator.generateServer({ outputPath: generatedServerPath });
+
+  // 2. Run the generated server exactly as shipped: a stdio process.
+  stdioTransport = new StdioClientTransport({
+    command: tsxBin,
+    args: [generatedServerPath],
+    cwd: packageRoot,
+    stderr: 'pipe',
+  });
+  stdioClient = new Client(
+    { name: 'conformance-forwarder', version: '0.0.0' },
+    { capabilities: {} },
+  );
+  await stdioClient.connect(stdioTransport);
+
+  const remoteInfo = stdioClient.getServerVersion();
+  const remoteCapabilities = stdioClient.getServerCapabilities();
+  if (!remoteInfo || !remoteCapabilities) {
+    throw new Error('generated server did not report serverInfo/capabilities');
+  }
+
+  // 3. Mirror the generated server per-request onto the HTTP transport the
+  //    conformance CLI requires, forwarding through the single stdio client.
+  httpServer = createHttpServer(async (req, res) => {
+    try {
+      const forwarder = new Server(
+        { name: remoteInfo.name, version: remoteInfo.version },
+        { capabilities: remoteCapabilities },
+      );
+      forwarder.setRequestHandler(ListToolsRequestSchema, async () =>
+        stdioClient.listTools(),
+      );
+      forwarder.setRequestHandler(CallToolRequestSchema, async (request) =>
+        stdioClient.callTool({
+          name: request.params.name,
+          arguments: request.params.arguments,
+        }),
+      );
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableDnsRebindingProtection: true,
+        allowedHosts,
+      });
+      // Keep-alive safe: 'finish' covers normal completion, 'close' covers
+      // aborted connections; the guard makes double-invocation harmless.
+      let cleanedUp = false;
+      const cleanup = () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        void transport.close();
+        void forwarder.close();
+      };
+      res.on('finish', cleanup);
+      res.on('close', cleanup);
+      await forwarder.connect(transport);
+      await transport.handleRequest(req, res);
+    } catch (error) {
+      console.error('[generated-conformance] request error', error);
+      if (!res.headersSent) {
+        res.writeHead(500).end();
+      }
+    }
+  });
+  await new Promise<void>((resolveListen) => {
+    httpServer.listen(0, '127.0.0.1', resolveListen);
+  });
+  const { port } = httpServer.address() as AddressInfo;
+  mcpUrl = `http://127.0.0.1:${port}/mcp`;
+  allowedHosts = [`127.0.0.1:${port}`, `localhost:${port}`];
+});
+
+afterAll(async () => {
+  await stdioClient?.close();
+  await stdioTransport?.close();
+  if (httpServer) {
+    await new Promise<void>((resolveClose, rejectClose) => {
+      httpServer.close((error) =>
+        error ? rejectClose(error) : resolveClose(),
+      );
+    });
+  }
+  if (process.env.MCP_CONFORMANCE_KEEP_GENERATED !== 'true') {
+    await rm(generatedDir, { force: true, recursive: true });
+  }
+});
+
+describe('generated Tier-1 template MCP conformance', () => {
+  // Direct stdio lifecycle coverage of the REAL generated process — the
+  // forwarder below never handles these: `client.connect()` in beforeAll
+  // already performed the initialize handshake against the generated
+  // server, and these assertions pin the identity, capabilities, listing,
+  // and tools/call error contract it answered with.
+  it('serves the MCP lifecycle directly over stdio', async () => {
+    expect(stdioClient.getServerVersion()).toMatchObject({
+      name: 'smrt-conformance-fixture',
+      version: '0.0.0',
+    });
+    const capabilities = stdioClient.getServerCapabilities();
+    expect(capabilities?.tools).toBeDefined();
+
+    const { tools } = await stdioClient.listTools();
+    const names = tools.map((tool) => tool.name);
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'conformancewidget_list',
+        'conformancewidget_get',
+        'conformancegadget_list',
+        'conformancegadget_get',
+        'conformancegadget_create',
+      ]),
+    );
+    for (const tool of tools) {
+      expect(tool.description).toBeTruthy();
+      expect(tool.inputSchema).toMatchObject({ type: 'object' });
+    }
+
+    // tools/call against the real generated switch: unknown tools must come
+    // back as an in-band isError text result, not a protocol failure.
+    const errorResult = await stdioClient.callTool({
+      name: 'test_simple_text',
+      arguments: {},
+    });
+    expect(errorResult.isError).toBe(true);
+    const [first] = errorResult.content as Array<{
+      type: string;
+      text?: string;
+    }>;
+    expect(first?.type).toBe('text');
+    expect(first?.text).toContain('Unknown tool');
+  });
+
+  it(`passes the official conformance suite at ${SPEC_VERSION} (baseline-checked)`, async () => {
+    const result = await new Promise<{ code: number | null; output: string }>(
+      (resolveRun, rejectRun) => {
+        const child = spawn(
+          conformanceBin,
+          [
+            'server',
+            '--url',
+            mcpUrl,
+            '--spec-version',
+            SPEC_VERSION,
+            '--expected-failures',
+            baselinePath,
+          ],
+          { cwd: packageRoot, env: process.env },
+        );
+        let output = '';
+        child.stdout.on('data', (chunk) => {
+          output += String(chunk);
+        });
+        child.stderr.on('data', (chunk) => {
+          output += String(chunk);
+        });
+        child.on('error', rejectRun);
+        child.on('close', (code) => resolveRun({ code, output }));
+      },
+    );
+
+    expect(
+      result.code,
+      `conformance suite reported unexpected results:\n${result.output}`,
+    ).toBe(0);
+  }, 240_000);
+});

--- a/packages/mcp-conformance-fixture/tsconfig.json
+++ b/packages/mcp-conformance-fixture/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.package-typecheck.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", ".generated-tmp"]
+}

--- a/packages/mcp-conformance-fixture/vitest.config.ts
+++ b/packages/mcp-conformance-fixture/vitest.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.{test,spec}.ts'],
-    testTimeout: 15000,
+    // The conformance spec generates a server, spawns it over stdio, and runs
+    // the official suite against a forwarding HTTP harness.
+    testTimeout: 300_000,
+    hookTimeout: 120_000,
+    fileParallelism: false,
   },
 });

--- a/packages/smrt-app-mcp/AGENTS.md
+++ b/packages/smrt-app-mcp/AGENTS.md
@@ -20,3 +20,4 @@ Application-scoped MCP server wrapper for SMRT apps.
 - Public tool patterns are still constrained by read-only detection.
 - Workflow assertions run before generated tool dispatch and should be deterministic.
 - This package is runtime app infrastructure, not the development MCP. Use `@happyvertical/smrt-dev-mcp` for agentic development knowledge, review, and architecture tooling.
+- The HTTP surface here is a custom GET/POST tool API, not an MCP protocol transport; real MCP clients connect through the `@happyvertical/smrt-app-cli` stdio bridge today. `src/__tests__/mcp-conformance.spec.ts` runs the official MCP conformance suite against that full composition (`conformance-baseline.yml` holds expected failures; stale entries fail too). A native stateless Streamable HTTP endpoint is #2147.

--- a/packages/smrt-app-mcp/conformance-baseline.yml
+++ b/packages/smrt-app-mcp/conformance-baseline.yml
@@ -1,0 +1,39 @@
+# Expected-failure baseline for the bridge-composition conformance run in
+# src/__tests__/mcp-conformance.spec.ts (#2146). Every entry is a scenario
+# the tools-only bridge composition cannot pass at spec revision 2025-11-25:
+# the bridge declares only the `tools` capability, and the tools-call
+# fixtures require suite-defined tool names (test_image_content, …) no
+# product server implements. Unexpected failures and stale entries (a
+# baselined scenario that starts passing) both fail CI. Re-derive when the
+# native stateless Streamable HTTP endpoint lands (#2147).
+server:
+  # SEP-1699 concurrent POST SSE streams assume the stateful session
+  # lifecycle; against the stateless per-request harness the scenario
+  # alternates between skipping (0 checks, tolerated) and failing.
+  - server-sse-multiple-streams
+  # Capabilities the bridge composition does not declare (tools only).
+  - logging-set-level
+  - completion-complete
+  - resources-list
+  - resources-read-text
+  - resources-read-binary
+  - resources-templates-read
+  - resources-subscribe
+  - resources-unsubscribe
+  - prompts-list
+  - prompts-get-simple
+  - prompts-get-with-args
+  - prompts-get-embedded-resource
+  - prompts-get-with-image
+  # Suite fixture tools (test_image_content, test_audio_content, …).
+  - tools-call-image
+  - tools-call-audio
+  - tools-call-embedded-resource
+  - tools-call-mixed-content
+  - tools-call-with-logging
+  - tools-call-with-progress
+  # Server-initiated sampling/elicitation fixtures.
+  - tools-call-sampling
+  - tools-call-elicitation
+  - elicitation-sep1034-defaults
+  - elicitation-sep1330-enums

--- a/packages/smrt-app-mcp/package.json
+++ b/packages/smrt-app-mcp/package.json
@@ -56,9 +56,11 @@
   "author": "HappyVertical",
   "dependencies": {
     "@happyvertical/smrt-core": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.25.2"
+    "@modelcontextprotocol/sdk": "^1.30.0"
   },
   "devDependencies": {
+    "@happyvertical/smrt-app-cli": "workspace:*",
+    "@modelcontextprotocol/conformance": "0.2.0-alpha.10",
     "@types/node": "24.13.2",
     "typescript": "5.9.3",
     "vite": "8.1.4",

--- a/packages/smrt-app-mcp/src/__tests__/mcp-conformance-fixture-objects.ts
+++ b/packages/smrt-app-mcp/src/__tests__/mcp-conformance-fixture-objects.ts
@@ -1,0 +1,37 @@
+/**
+ * Registered `@smrt()` fixture objects for the conformance composition spec.
+ * Explicit `api`/`mcp`/`cli` config — an omitted config means full CRUD
+ * (#1400). Kept in their own module so the decorator side effects run once
+ * per test process.
+ */
+import { SmrtCollection, SmrtObject, smrt } from '@happyvertical/smrt-core';
+
+@smrt({
+  api: false,
+  cli: false,
+  mcp: { include: ['list', 'get'] },
+})
+export class AppMcpConformanceItem extends SmrtObject {
+  name = '';
+  summary = '';
+  quantity = 0;
+}
+
+export class AppMcpConformanceItemCollection extends SmrtCollection<AppMcpConformanceItem> {
+  static readonly _itemClass = AppMcpConformanceItem;
+}
+
+@smrt({
+  api: false,
+  cli: false,
+  mcp: { include: ['list', 'get', 'create'] },
+})
+export class AppMcpConformanceOrder extends SmrtObject {
+  name = '';
+  status = '';
+  total = 0.0;
+}
+
+export class AppMcpConformanceOrderCollection extends SmrtCollection<AppMcpConformanceOrder> {
+  static readonly _itemClass = AppMcpConformanceOrder;
+}

--- a/packages/smrt-app-mcp/src/__tests__/mcp-conformance.spec.ts
+++ b/packages/smrt-app-mcp/src/__tests__/mcp-conformance.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * Official MCP conformance suite against the downstream app MCP path (#2146).
+ *
+ * smrt-app-mcp's shipped surface is an HTTP tool API (`mountMcpToolsRoute` /
+ * `mountMcpCallRoute`), not an MCP protocol transport — real MCP clients
+ * reach a smrt app today through the `@happyvertical/smrt-app-cli` stdio
+ * bridge. This spec conformance-tests that full composition end to end:
+ *
+ *   conformance CLI → Streamable HTTP harness → bridge `Server`
+ *     → fetch → app-mcp route mounts → `createMcpAppServer` → MCPGenerator
+ *
+ * Everything in that chain is production code over real registered `@smrt()`
+ * fixture objects; only the HTTP mounting of the bridge's `Server` (instead
+ * of stdio) belongs to the harness. A native spec-compliant stateless
+ * Streamable HTTP endpoint for smrt-app-mcp is #2147; when it lands, point
+ * this spec (or its successor) at that endpoint directly and re-derive the
+ * baseline.
+ *
+ * `conformance-baseline.yml` semantics match the sibling harnesses
+ * (packages/smrt-dev-mcp, packages/mcp-conformance-fixture): unexpected
+ * failures and stale baseline entries both fail CI.
+ */
+import { spawn } from 'node:child_process';
+import type { IncomingMessage } from 'node:http';
+import { createServer as createHttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createMcpStdioBridge } from '@happyvertical/smrt-app-cli';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createMcpAppServer } from '../server.js';
+import { mountMcpCallRoute, mountMcpToolsRoute } from '../sveltekit.js';
+import './mcp-conformance-fixture-objects.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(__dirname, '..', '..');
+const conformanceBin = join(packageRoot, 'node_modules', '.bin', 'conformance');
+const baselinePath = join(packageRoot, 'conformance-baseline.yml');
+
+const SPEC_VERSION = '2025-11-25';
+const ENV_PREFIX = 'SMRT_APP_MCP_CONFORMANCE';
+
+async function readBody(req: IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks);
+}
+
+let appHttpServer: ReturnType<typeof createHttpServer>;
+let mcpHttpServer: ReturnType<typeof createHttpServer>;
+let mcpUrl: string;
+let allowedHosts: string[] = [];
+
+beforeAll(async () => {
+  // 1. A real app tool API: createMcpAppServer over the registered fixture
+  //    objects, mounted exactly as a SvelteKit app would mount it. The
+  //    synthetic event carries an authenticated user, matching a bridge
+  //    session with a stored token.
+  const appServer = createMcpAppServer({
+    smrtOptions: () => ({}),
+    serverInfo: { name: 'smrt-app-mcp-conformance', version: '0.0.0' },
+    allowedClassNames: ['AppMcpConformanceItem', 'AppMcpConformanceOrder'],
+  });
+  const toolsRoute = mountMcpToolsRoute(appServer);
+  const callRoute = mountMcpCallRoute(appServer);
+
+  appHttpServer = createHttpServer(async (req, res) => {
+    try {
+      const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
+      const body = req.method === 'GET' ? undefined : await readBody(req);
+      const event = {
+        locals: { user: { id: 'conformance-user' } },
+        request: new Request(url, {
+          method: req.method,
+          headers: req.headers as Record<string, string>,
+          body: body && body.length > 0 ? body : undefined,
+        }),
+        url,
+      };
+      let response: Response;
+      if (url.pathname === '/api/mcp/tools' && req.method === 'GET') {
+        response = await toolsRoute(event);
+      } else if (url.pathname === '/api/mcp/call' && req.method === 'POST') {
+        response = await callRoute(event);
+      } else {
+        response = new Response('not found', { status: 404 });
+      }
+      res.writeHead(
+        response.status,
+        Object.fromEntries(response.headers.entries()),
+      );
+      res.end(Buffer.from(await response.arrayBuffer()));
+    } catch (error) {
+      console.error('[app-mcp-conformance] app route error', error);
+      if (!res.headersSent) {
+        res.writeHead(500).end();
+      }
+    }
+  });
+  await new Promise<void>((resolveListen) => {
+    appHttpServer.listen(0, '127.0.0.1', resolveListen);
+  });
+  const appPort = (appHttpServer.address() as AddressInfo).port;
+  process.env[`${ENV_PREFIX}_SERVER_URL`] = `http://127.0.0.1:${appPort}`;
+  // Point the CLI config at a path that never exists so developer machines'
+  // ~/.config state cannot leak into the run.
+  process.env[`${ENV_PREFIX}_CLI_CONFIG`] = join(
+    packageRoot,
+    '.mcp-conformance-no-config.json',
+  );
+
+  // 2. The bridge's MCP Server, mounted per-request on the stateless
+  //    Streamable HTTP transport the conformance CLI requires.
+  mcpHttpServer = createHttpServer(async (req, res) => {
+    try {
+      const { server } = createMcpStdioBridge({
+        envPrefix: ENV_PREFIX,
+        serverInfo: { name: 'smrt-app-mcp-conformance', version: '0.0.0' },
+      });
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableDnsRebindingProtection: true,
+        allowedHosts,
+      });
+      // Keep-alive safe: 'finish' covers normal completion, 'close' covers
+      // aborted connections; the guard makes double-invocation harmless.
+      let cleanedUp = false;
+      const cleanup = () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        void transport.close();
+        void server.close();
+      };
+      res.on('finish', cleanup);
+      res.on('close', cleanup);
+      await server.connect(transport);
+      await transport.handleRequest(req, res);
+    } catch (error) {
+      console.error('[app-mcp-conformance] harness error', error);
+      if (!res.headersSent) {
+        res.writeHead(500).end();
+      }
+    }
+  });
+  await new Promise<void>((resolveListen) => {
+    mcpHttpServer.listen(0, '127.0.0.1', resolveListen);
+  });
+  const { port } = mcpHttpServer.address() as AddressInfo;
+  mcpUrl = `http://127.0.0.1:${port}/mcp`;
+  allowedHosts = [`127.0.0.1:${port}`, `localhost:${port}`];
+});
+
+afterAll(async () => {
+  delete process.env[`${ENV_PREFIX}_SERVER_URL`];
+  delete process.env[`${ENV_PREFIX}_CLI_CONFIG`];
+  for (const server of [mcpHttpServer, appHttpServer]) {
+    if (!server) continue;
+    await new Promise<void>((resolveClose, rejectClose) => {
+      server.close((error) => (error ? rejectClose(error) : resolveClose()));
+    });
+  }
+});
+
+describe('smrt-app-mcp × app-cli bridge MCP conformance', () => {
+  it(`passes the official conformance suite at ${SPEC_VERSION} (baseline-checked)`, async () => {
+    const result = await new Promise<{ code: number | null; output: string }>(
+      (resolveRun, rejectRun) => {
+        const child = spawn(
+          conformanceBin,
+          [
+            'server',
+            '--url',
+            mcpUrl,
+            '--spec-version',
+            SPEC_VERSION,
+            '--expected-failures',
+            baselinePath,
+          ],
+          { cwd: packageRoot, env: process.env },
+        );
+        let output = '';
+        child.stdout.on('data', (chunk) => {
+          output += String(chunk);
+        });
+        child.stderr.on('data', (chunk) => {
+          output += String(chunk);
+        });
+        child.on('error', rejectRun);
+        child.on('close', (code) => resolveRun({ code, output }));
+      },
+    );
+
+    expect(
+      result.code,
+      `conformance suite reported unexpected results:\n${result.output}`,
+    ).toBe(0);
+  }, 240_000);
+});

--- a/packages/smrt-dev-mcp/AGENTS.md
+++ b/packages/smrt-dev-mcp/AGENTS.md
@@ -94,7 +94,12 @@ launcher or a small wrapper script with an absolute Node path.
 
 ## Key Files
 
-- `src/index.ts` — MCP server setup, tool registration
+- `src/index.ts` — MCP server setup, tool registration; `createServer()` builds
+  the transport-less server `main()` connects to stdio
+- `src/mcp-conformance.spec.ts` — official MCP conformance suite over a
+  stateless Streamable HTTP harness; `conformance-baseline.yml` lists the
+  expected failures (fixture-tool and undeclared-capability scenarios), and
+  the CLI fails on unexpected failures AND on stale baseline entries (#2146)
 - `src/knowledge/index.ts` — deterministic SMRT, SDK, and downstream domain knowledge discovery; workspace-glob expansion, provenance, coverage, and diagnostics
 - `src/agent-skills.ts` — bundled skill registry and file loader
 - `agent-skills/smrt-code-review/SKILL.md` — downstream SMRT review procedure

--- a/packages/smrt-dev-mcp/conformance-baseline.yml
+++ b/packages/smrt-dev-mcp/conformance-baseline.yml
@@ -1,0 +1,44 @@
+# Expected-failure baseline for the official MCP conformance suite run in
+# src/mcp-conformance.spec.ts (#2146). Every entry is a scenario that cannot
+# pass for a product server at spec revision 2025-11-25: it either requires
+# the suite's fixture tools/prompts/resources (test_simple_text, fixture
+# prompt names, test:// URIs), or an optional capability (logging,
+# completions, subscriptions, sampling, elicitation) smrt-dev-mcp
+# intentionally does not declare. The conformance CLI fails on any scenario
+# NOT listed here that fails, and on any scenario listed here that passes
+# (stale baseline), so regressions and silent fixes both break CI. Remove
+# entries as capabilities land (#2145 children).
+server:
+  # SEP-1699 concurrent POST SSE streams assume the stateful session
+  # lifecycle; against this stateless per-request harness the scenario
+  # alternates between skipping (0 checks) and failing, so it is baselined
+  # (a baselined scenario that skips is tolerated, one that fully passes
+  # flags the entry as stale).
+  - server-sse-multiple-streams
+  # Optional capabilities smrt-dev-mcp does not declare.
+  - logging-set-level
+  - completion-complete
+  - resources-subscribe
+  - resources-unsubscribe
+  # Suite fixture tools (test_image_content, test_audio_content, …) that a
+  # product server does not implement.
+  - tools-call-image
+  - tools-call-audio
+  - tools-call-embedded-resource
+  - tools-call-mixed-content
+  - tools-call-with-logging
+  - tools-call-with-progress
+  # Server-initiated sampling/elicitation fixtures — requires Sampling and
+  # Elicitation client-capability flows the server does not initiate.
+  - tools-call-sampling
+  - tools-call-elicitation
+  - elicitation-sep1034-defaults
+  - elicitation-sep1330-enums
+  # Suite fixture resources/prompts (test:// URIs, fixture prompt names).
+  - resources-read-text
+  - resources-read-binary
+  - resources-templates-read
+  - prompts-get-simple
+  - prompts-get-with-args
+  - prompts-get-embedded-resource
+  - prompts-get-with-image

--- a/packages/smrt-dev-mcp/package.json
+++ b/packages/smrt-dev-mcp/package.json
@@ -54,9 +54,10 @@
     "@happyvertical/smrt-core": "workspace:*",
     "@happyvertical/smrt-scanner": "workspace:*",
     "@happyvertical/smrt-types": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.25.2"
+    "@modelcontextprotocol/sdk": "^1.30.0"
   },
   "devDependencies": {
+    "@modelcontextprotocol/conformance": "0.2.0-alpha.10",
     "@types/node": "24.13.2",
     "typescript": "5.9.3",
     "vite": "8.1.4",

--- a/packages/smrt-dev-mcp/src/index.ts
+++ b/packages/smrt-dev-mcp/src/index.ts
@@ -486,11 +486,13 @@ export const TOOLS = [
   },
 ];
 
-async function main() {
-  if (DEBUG) {
-    console.error(`[${SERVER_NAME}] Starting server v${SERVER_VERSION}`);
-  }
-
+/**
+ * Build the smrt-dev-mcp Server with every tool, prompt, and resource handler
+ * registered but no transport connected. `main()` connects it to stdio; the
+ * MCP conformance spec connects the same construction to a Streamable HTTP
+ * transport so the official suite can exercise it.
+ */
+export function createServer(): Server {
   const server = new Server(
     {
       name: SERVER_NAME,
@@ -961,6 +963,16 @@ async function main() {
       };
     }
   });
+
+  return server;
+}
+
+async function main() {
+  if (DEBUG) {
+    console.error(`[${SERVER_NAME}] Starting server v${SERVER_VERSION}`);
+  }
+
+  const server = createServer();
 
   // Setup stdio transport
   const transport = new StdioServerTransport();

--- a/packages/smrt-dev-mcp/src/mcp-conformance.spec.ts
+++ b/packages/smrt-dev-mcp/src/mcp-conformance.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Official MCP conformance suite against the smrt-dev-mcp server (#2146).
+ *
+ * The conformance CLI tests servers over Streamable HTTP, so this spec mounts
+ * the exact `createServer()` construction `main()` ships over a stateless
+ * `StreamableHTTPServerTransport` (fresh server + transport per request — the
+ * SDK's documented stateless pattern) and runs the pinned
+ * `@modelcontextprotocol/conformance` CLI against it at the spec revision the
+ * current SDK line implements (2025-11-25).
+ *
+ * `conformance-baseline.yml` lists the scenarios that cannot pass for a
+ * product server: they require the suite's fixture tools/prompts/resources
+ * (`test_simple_text`, …) or optional capabilities (logging, completions,
+ * subscriptions) smrt-dev-mcp intentionally does not declare. The CLI exits
+ * non-zero on any unexpected failure AND on stale baseline entries, so both
+ * regressions and silent fixes surface here. Sibling harnesses:
+ * packages/mcp-conformance-fixture (generated Tier-1 template server) and
+ * packages/smrt-app-mcp (HTTP tool API composed with the app-cli bridge).
+ */
+import { spawn } from 'node:child_process';
+import { createServer as createHttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createServer } from './index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(__dirname, '..');
+const conformanceBin = join(packageRoot, 'node_modules', '.bin', 'conformance');
+const baselinePath = join(packageRoot, 'conformance-baseline.yml');
+
+const SPEC_VERSION = '2025-11-25';
+
+let httpServer: ReturnType<typeof createHttpServer>;
+let mcpUrl: string;
+let allowedHosts: string[] = [];
+
+beforeAll(async () => {
+  httpServer = createHttpServer(async (req, res) => {
+    try {
+      const server = createServer();
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableDnsRebindingProtection: true,
+        allowedHosts,
+      });
+      // Keep-alive safe: 'finish' covers normal completion, 'close' covers
+      // aborted connections; the guard makes double-invocation harmless.
+      let cleanedUp = false;
+      const cleanup = () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        void transport.close();
+        void server.close();
+      };
+      res.on('finish', cleanup);
+      res.on('close', cleanup);
+      await server.connect(transport);
+      await transport.handleRequest(req, res);
+    } catch (error) {
+      console.error('[mcp-conformance] request error', error);
+      if (!res.headersSent) {
+        res.writeHead(500).end();
+      }
+    }
+  });
+  await new Promise<void>((resolveListen) => {
+    httpServer.listen(0, '127.0.0.1', resolveListen);
+  });
+  const { port } = httpServer.address() as AddressInfo;
+  mcpUrl = `http://127.0.0.1:${port}/mcp`;
+  allowedHosts = [`127.0.0.1:${port}`, `localhost:${port}`];
+});
+
+afterAll(async () => {
+  if (!httpServer) return;
+  await new Promise<void>((resolveClose, rejectClose) => {
+    httpServer.close((error) => (error ? rejectClose(error) : resolveClose()));
+  });
+});
+
+describe('smrt-dev-mcp MCP conformance', () => {
+  it(`passes the official conformance suite at ${SPEC_VERSION} (baseline-checked)`, async () => {
+    const result = await new Promise<{ code: number | null; output: string }>(
+      (resolveRun, rejectRun) => {
+        const child = spawn(
+          conformanceBin,
+          [
+            'server',
+            '--url',
+            mcpUrl,
+            '--spec-version',
+            SPEC_VERSION,
+            '--expected-failures',
+            baselinePath,
+          ],
+          { cwd: packageRoot, env: process.env },
+        );
+        let output = '';
+        child.stdout.on('data', (chunk) => {
+          output += String(chunk);
+        });
+        child.stderr.on('data', (chunk) => {
+          output += String(chunk);
+        });
+        child.on('error', rejectRun);
+        child.on('close', (code) => resolveRun({ code, output }));
+      },
+    );
+
+    expect(
+      result.code,
+      `conformance suite reported unexpected results:\n${result.output}`,
+    ).toBe(0);
+  }, 240_000);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,7 +215,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -345,8 +345,8 @@ importers:
         specifier: workspace:*
         version: link:../users
       '@modelcontextprotocol/sdk':
-        specifier: ^1.25.2
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        specifier: ^1.30.0
+        version: 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
     devDependencies:
       '@happyvertical/smrt-core':
         specifier: workspace:*
@@ -371,7 +371,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -515,7 +515,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/smrt-agents':
         specifier: workspace:*
         version: link:../agents
@@ -585,7 +585,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -723,10 +723,10 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/documents':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -741,10 +741,10 @@ importers:
         version: 0.84.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/ocr':
         specifier: ^0.60.55
-        version: 0.60.55(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
+        version: 0.60.55(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/pdf':
         specifier: ^0.65.3
-        version: 0.65.3(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
+        version: 0.65.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/smrt-assets':
         specifier: workspace:*
         version: link:../assets
@@ -835,7 +835,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -861,8 +861,8 @@ importers:
         specifier: ^0.84.0
         version: 0.84.0
       '@modelcontextprotocol/sdk':
-        specifier: ^1.25.2
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        specifier: ^1.30.0
+        version: 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@oxc-project/runtime':
         specifier: ^0.138.0
         version: 0.138.0
@@ -917,7 +917,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -987,7 +987,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -1058,7 +1058,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -1092,7 +1092,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/images':
         specifier: ^0.84.0
         version: 0.84.0(jimp@1.6.1)(sharp@0.35.3(@types/node@24.13.2))
@@ -1254,7 +1254,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/logger':
         specifier: ^0.84.0
         version: 0.84.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
@@ -1413,6 +1413,33 @@ importers:
         specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@26.1.0)(vite@8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  packages/mcp-conformance-fixture:
+    devDependencies:
+      '@happyvertical/smrt-config':
+        specifier: workspace:*
+        version: link:../config
+      '@happyvertical/smrt-core':
+        specifier: workspace:*
+        version: link:../core
+      '@modelcontextprotocol/conformance':
+        specifier: 0.2.0-alpha.10
+        version: 0.2.0-alpha.10(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.30.0
+        version: 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@types/node':
+        specifier: 24.13.2
+        version: 24.13.2
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 8.1.4
+        version: 8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+
   packages/messages:
     dependencies:
       '@happyvertical/email':
@@ -1542,7 +1569,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/cache':
         specifier: ^0.84.0
         version: 0.84.0(@opentelemetry/api@1.9.1)
@@ -1594,7 +1621,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -1679,7 +1706,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -1737,7 +1764,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/logger':
         specifier: ^0.84.0
         version: 0.84.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
@@ -2064,9 +2091,15 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@modelcontextprotocol/sdk':
-        specifier: ^1.25.2
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        specifier: ^1.30.0
+        version: 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
     devDependencies:
+      '@happyvertical/smrt-app-cli':
+        specifier: workspace:*
+        version: link:../app-cli
+      '@modelcontextprotocol/conformance':
+        specifier: 0.2.0-alpha.10
+        version: 0.2.0-alpha.10(@cfworker/json-schema@4.1.1)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -2092,9 +2125,12 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@modelcontextprotocol/sdk':
-        specifier: ^1.25.2
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+        specifier: ^1.30.0
+        version: 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
     devDependencies:
+      '@modelcontextprotocol/conformance':
+        specifier: 0.2.0-alpha.10
+        version: 0.2.0-alpha.10(@cfworker/json-schema@4.1.1)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -2504,7 +2540,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -4303,8 +4339,12 @@ packages:
   '@mlc-ai/web-llm@0.2.84':
     resolution: {integrity: sha512-hrOWzK4/nGNmgoRKT8pgVmZZ2oEPpbblIWQOwpqNyvK2dysHw3KVB1gNJOuRcQfKOPhucEhX1NJzXzgMDnwSCQ==}
 
-  '@modelcontextprotocol/sdk@1.27.1':
-    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+  '@modelcontextprotocol/conformance@0.2.0-alpha.10':
+    resolution: {integrity: sha512-0V/HZDdWHcg6j0zVBzBsXcPZ571IVi6umKgTpnBhtTx/jm/LONmGF6cIWL2k4Xjyps0OiHV6B37nj2s0pUg0nQ==}
+    hasBin: true
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -4453,6 +4493,58 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.6':
+    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.3':
+    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@6.0.0':
+    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.11':
+    resolution: {integrity: sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/rest@22.0.1':
+    resolution: {integrity: sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
   '@openpgp/web-stream-tools@0.3.1':
     resolution: {integrity: sha512-EV+VQ4Dr8b+JmlGnc74FLgx7EhLyydOr4j6s6Hp+2scQh6sLQMs2h+1oEYUIslXcQPicWKG5ZQx+/dua0dgPWA==}
@@ -6058,6 +6150,9 @@ packages:
   bech32@2.0.0:
     resolution: {integrity: sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==}
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -6727,8 +6822,8 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -7445,6 +7540,9 @@ packages:
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  json-with-bigint@3.5.10:
+    resolution: {integrity: sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -9167,6 +9265,9 @@ packages:
 
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -10929,14 +11030,14 @@ snapshots:
       - supports-color
     optional: true
 
-  '@google/genai@1.50.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))':
+  '@google/genai@1.50.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))':
     dependencies:
       google-auth-library: 10.7.0
       p-retry: 4.6.2
       protobufjs: 7.6.5
       ws: 8.21.0
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -10988,11 +11089,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@happyvertical/ai@0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+  '@happyvertical/ai@0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1034.0
-      '@google/genai': 1.50.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))
+      '@google/genai': 1.50.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))
       '@happyvertical/utils': 0.84.0
       openai: 6.34.0(ws@8.21.0)(zod@4.3.6)
     transitivePeerDependencies:
@@ -11013,11 +11114,11 @@ snapshots:
       - '@node-rs/xxhash'
       - '@opentelemetry/api'
 
-  '@happyvertical/documents@0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)':
+  '@happyvertical/documents@0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)':
     dependencies:
       '@happyvertical/files': 0.84.0
-      '@happyvertical/ocr': 0.60.55(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
-      '@happyvertical/pdf': 0.65.3(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
+      '@happyvertical/ocr': 0.60.55(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
+      '@happyvertical/pdf': 0.65.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/spider': 1.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)
       '@happyvertical/utils': 0.84.0
       uuid: 13.0.2
@@ -11132,10 +11233,10 @@ snapshots:
       - debug
       - supports-color
 
-  '@happyvertical/ocr@0.60.55(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)':
+  '@happyvertical/ocr@0.60.55(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)':
     dependencies:
       '@gutenye/ocr-node': 1.4.8(@types/node@24.13.2)
-      '@happyvertical/ai': 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@happyvertical/ai': 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/utils': 0.84.0
       jpeg-js: 0.4.4
       pngjs: 7.0.0
@@ -11150,9 +11251,9 @@ snapshots:
       - ws
       - zod
 
-  '@happyvertical/pdf@0.65.3(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)':
+  '@happyvertical/pdf@0.65.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)':
     dependencies:
-      '@happyvertical/ocr': 0.60.55(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
+      '@happyvertical/ocr': 0.60.55(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/utils': 0.84.0
       '@napi-rs/canvas': 0.1.99
       marked: 14.1.4
@@ -11781,7 +11882,22 @@ snapshots:
     dependencies:
       loglevel: 1.9.2
 
-  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+  '@modelcontextprotocol/conformance@0.2.0-alpha.10(@cfworker/json-schema@4.1.1)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@octokit/rest': 22.0.1
+      commander: 14.0.3
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      jose: 6.2.3
+      undici: 7.28.0
+      yaml: 2.9.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.27)
       ajv: 8.18.0
@@ -11790,7 +11906,7 @@ snapshots:
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
       hono: 4.12.27
@@ -11900,6 +12016,69 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.6':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.3
+      '@octokit/request': 10.0.11
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.3':
+    dependencies:
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.3':
+    dependencies:
+      '@octokit/request': 10.0.11
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/types': 16.0.0
+
+  '@octokit/request-error@7.1.0':
+    dependencies:
+      '@octokit/types': 16.0.0
+
+  '@octokit/request@10.0.11':
+    dependencies:
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      content-type: 2.0.0
+      json-with-bigint: 3.5.10
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@22.0.1':
+    dependencies:
+      '@octokit/core': 7.0.6
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.6)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
 
   '@openpgp/web-stream-tools@0.3.1(@types/node@24.13.2)(typescript@5.9.3)':
     optionalDependencies:
@@ -13271,6 +13450,8 @@ snapshots:
 
   bech32@2.0.0: {}
 
+  before-after-hook@4.0.0: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -13968,11 +14149,11 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  eventsource-parser@3.0.6: {}
+  eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.0
 
   exif-parser@0.1.12: {}
 
@@ -14942,6 +15123,8 @@ snapshots:
   json-schema-typed@8.0.2: {}
 
   json-stringify-safe@5.0.1: {}
+
+  json-with-bigint@3.5.10: {}
 
   json5@2.2.3: {}
 
@@ -16719,6 +16902,8 @@ snapshots:
     dependencies:
       pako: 0.2.9
       tiny-inflate: 1.0.3
+
+  universal-user-agent@7.0.3: {}
 
   universalify@0.1.2: {}
 

--- a/scripts/check-mcp-protocol-hygiene.mjs
+++ b/scripts/check-mcp-protocol-hygiene.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * MCP protocol hygiene gate (#2146, epic #2145).
+ *
+ * The MCP 2026-07-28 spec removes `ping`, `logging/setLevel`, and
+ * `notifications/roots/list_changed`, deprecates the Roots / Sampling /
+ * Logging capabilities and the HTTP+SSE transport, drops the
+ * `Mcp-Session-Id` header (sessions are gone), and remaps resource-not-found
+ * from `-32002` to `-32602`. The 2026-07-29 exposure audit found ZERO usage
+ * of any of these across SMRT's MCP surfaces — this gate keeps it that way
+ * while the SDK line migrates (v1.30.0 interim → v2 scoped packages).
+ *
+ * Scans `packages/<pkg>/src` TypeScript/JavaScript/Svelte sources (generated
+ * runtime templates live there too, so baked-in template output is covered).
+ * A finding fails CI. For a genuinely required exception (e.g. a
+ * compatibility shim during the v2 migration), annotate the line before it:
+ *
+ *   // mcp-protocol-hygiene-allow: <reason>
+ *
+ * Run: `node scripts/check-mcp-protocol-hygiene.mjs` or
+ * `pnpm check:mcp-protocol-hygiene`.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+const PACKAGES_DIR = join(ROOT, 'packages');
+const ALLOW_ANNOTATION = 'mcp-protocol-hygiene-allow:';
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.mts', '.cts', '.js', '.mjs', '.cjs', '.svelte']);
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.generated-tmp', '.smrt']);
+
+/**
+ * Substring tokens. Each entry: [token, reason]. Tokens are chosen to be
+ * SDK/wire-level identifiers that do not occur in ordinary application code.
+ */
+const BANNED_TOKENS = [
+  // Removed request: ping (SDK answers it protocol-side in the v1 line; the
+  // 2026-07-28 revision removes it entirely).
+  ['PingRequestSchema', 'ping was removed in MCP 2026-07-28'],
+  // Removed: logging/setLevel and the Logging capability (deprecated).
+  ['logging/setLevel', 'logging/setLevel was removed in MCP 2026-07-28'],
+  ['SetLevelRequestSchema', 'logging/setLevel was removed in MCP 2026-07-28'],
+  ['setLoggingLevel', 'logging/setLevel was removed in MCP 2026-07-28'],
+  ['sendLoggingMessage', 'the Logging capability is deprecated (per-request _meta log level replaces it)'],
+  ['LoggingMessageNotificationSchema', 'the Logging capability is deprecated'],
+  // Removed: notifications/roots/list_changed and the Roots capability
+  // (deprecated). 'roots/list' also covers the roots/list request.
+  ['notifications/roots/list_changed', 'notifications/roots/list_changed was removed in MCP 2026-07-28'],
+  ['RootsListChangedNotificationSchema', 'notifications/roots/list_changed was removed in MCP 2026-07-28'],
+  ['sendRootsListChanged', 'notifications/roots/list_changed was removed in MCP 2026-07-28'],
+  ['ListRootsRequestSchema', 'the Roots capability is deprecated (12-month window from 2026-07-28)'],
+  ['roots/list', 'the Roots capability is deprecated (12-month window from 2026-07-28)'],
+  // Deprecated: server-initiated Sampling (replaced by MRTR input_required).
+  ['sampling/createMessage', 'the Sampling capability is deprecated (MRTR replaces server-initiated requests)'],
+  ['CreateMessageRequestSchema', 'the Sampling capability is deprecated'],
+  ['CreateMessageResultSchema', 'the Sampling capability is deprecated'],
+  // Removed: sessions. State crosses calls via server-minted handles.
+  // HTTP header names are case-insensitive and Node lowercases incoming
+  // headers, so this token is matched case-insensitively below.
+  ['mcp-session-id', 'Mcp-Session-Id was removed in MCP 2026-07-28 (stateless protocol)', { caseInsensitive: true }],
+  // Deprecated transport: HTTP+SSE (12-month window). Streamable HTTP replaces it.
+  ['SSEServerTransport', 'the HTTP+SSE transport is deprecated; use Streamable HTTP'],
+  ['SSEClientTransport', 'the HTTP+SSE transport is deprecated; use Streamable HTTP'],
+  // Remapped error code: resource-not-found -32002 becomes -32602; the
+  // -32020..-32099 range is reserved for the spec.
+  ['-32002', 'resource-not-found is -32602 in MCP 2026-07-28 (-32002 is retired)'],
+];
+
+/**
+ * Regex rules for shapes a plain token cannot express safely.
+ * Each entry: [regex, reason]. Applied per line.
+ */
+const BANNED_PATTERNS = [
+  // Explicit .ping() calls on MCP client/server objects.
+  [/\b(?:client|server|mcp[A-Za-z0-9_]*)\s*\.\s*ping\s*\(/, 'ping was removed in MCP 2026-07-28'],
+];
+
+/**
+ * Capability-declaration heuristic: inside files that touch the MCP SDK,
+ * flag `roots:`, `sampling:`, or `logging:` keys that open an object literal
+ * (the capability-map idiom). Ordinary app config (`logging: true`) does not
+ * match, and non-SDK files are never scanned by this rule.
+ */
+const CAPABILITY_PATTERN = /\b(roots|sampling|logging)\s*:\s*\{/;
+
+function isLineAllowed(lines, index) {
+  const previous = index > 0 ? lines[index - 1] : '';
+  return (
+    lines[index].includes(ALLOW_ANNOTATION) ||
+    previous.includes(ALLOW_ANNOTATION)
+  );
+}
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    const stats = statSync(full);
+    if (stats.isDirectory()) {
+      yield* walk(full);
+    } else if (SOURCE_EXTENSIONS.has(full.slice(full.lastIndexOf('.')))) {
+      yield full;
+    }
+  }
+}
+
+const findings = [];
+
+for (const pkg of readdirSync(PACKAGES_DIR)) {
+  const srcDir = join(PACKAGES_DIR, pkg, 'src');
+  let srcStats;
+  try {
+    srcStats = statSync(srcDir);
+  } catch {
+    continue;
+  }
+  if (!srcStats.isDirectory()) continue;
+
+  for (const file of walk(srcDir)) {
+    const content = readFileSync(file, 'utf8');
+    const lines = content.split('\n');
+    const touchesSdk = content.includes('@modelcontextprotocol');
+
+    lines.forEach((line, index) => {
+      if (line.includes(ALLOW_ANNOTATION)) return;
+
+      for (const [token, reason, tokenOptions] of BANNED_TOKENS) {
+        const haystack = tokenOptions?.caseInsensitive
+          ? line.toLowerCase()
+          : line;
+        if (haystack.includes(token) && !isLineAllowed(lines, index)) {
+          findings.push({ file, line: index + 1, token, reason });
+        }
+      }
+      for (const [pattern, reason] of BANNED_PATTERNS) {
+        if (pattern.test(line) && !isLineAllowed(lines, index)) {
+          findings.push({ file, line: index + 1, token: line.trim().slice(0, 80), reason });
+        }
+      }
+      if (touchesSdk) {
+        const capability = line.match(CAPABILITY_PATTERN);
+        if (capability && !isLineAllowed(lines, index)) {
+          findings.push({
+            file,
+            line: index + 1,
+            token: `${capability[1]}: {`,
+            reason: `the ${capability[1]} capability is deprecated in MCP 2026-07-28`,
+          });
+        }
+      }
+    });
+  }
+}
+
+if (findings.length > 0) {
+  console.error('❌ MCP protocol hygiene violations (removed/deprecated 2026-07-28 features):\n');
+  for (const finding of findings) {
+    console.error(
+      `  ${relative(ROOT, finding.file)}:${finding.line} — "${finding.token}"\n    ${finding.reason}`,
+    );
+  }
+  console.error(
+    `\n${findings.length} violation(s). If one is a deliberate compatibility shim, annotate the line above it with:\n  // ${ALLOW_ANNOTATION} <reason>`,
+  );
+  process.exit(1);
+}
+
+console.log('✅ MCP protocol hygiene: no removed/deprecated 2026-07-28 protocol features in packages/*/src.');

--- a/turbo.json
+++ b/turbo.json
@@ -112,7 +112,8 @@
         "**/*.spec.ts",
         "package.json",
         "vitest.config.ts",
-        "vitest.config.js"
+        "vitest.config.js",
+        "conformance-baseline.yml"
       ],
       "outputs": [
         "coverage/**"

--- a/vite.config.base.ts
+++ b/vite.config.base.ts
@@ -428,7 +428,11 @@ export function createPackageConfig(
           ? [
               smrtPlugin({
                 include: ['src/**/*.ts'],
-                exclude: ['**/*.test.ts', '**/*.spec.ts'],
+                // Keep in sync with DEFAULT_SCAN_EXCLUDE in
+                // packages/core/src/vite-plugin/index.ts: test-located
+                // @smrt() classes must never reach a published
+                // dist/manifest.json as phantom package objects (#2146).
+                exclude: ['**/*.test.ts', '**/*.spec.ts', '**/__tests__/**'],
                 generateTypes: true,
                 hmr: false, // Disable HMR for library builds
               }),


### PR DESCRIPTION
<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-2146-resume-20260801","issue":"2146","policy_revision":"1.0.0","status":"complete","head_sha":"339d300a1cd9ee121d764387fa8620f64d54eeda","validation":["Node 24.18.0; pnpm test (120 tasks)","pnpm build (61 tasks)","pnpm typecheck (119 tasks)","pnpm lint","pnpm format","pnpm smrt dev:knowledge-check","pnpm audit:policy","exact MCP package test/typecheck/conformance and hygiene"]}

Closes #2146. Parent: #2145.

## Recovery

This recovery rebases the prior implementation on `origin/main` while preserving the generated-server conformance rail and its documented SDK v1.30.0 interim boundary. The sole rebase conflict was `packages/smrt-dev-mcp/AGENTS.md`; its resolution retains both current main knowledge guidance and this issue's `createServer`/conformance documentation.

## Delivered

- MCP SDK compatibility baseline and scoped import migration prerequisites.
- Generated-server conformance fixture and transport coverage for dev MCP, app MCP, and the app CLI bridge.
- Deterministic `createServer()` discovery/result semantics and documentation for the executable contract.

## Exact-head validation

All checks ran against `339d300a1cd9ee121d764387fa8620f64d54eeda` using Node 24.18.0:

- Targeted tests: core (3,167 passed), dev-mcp (123), app-mcp (23), app-cli (86), fixture conformance (2).
- Targeted typechecks: core, dev-mcp, app-mcp, app-cli, and fixture.
- Root `pnpm test` (120/120 tasks), `pnpm build` (61/61), and `pnpm typecheck` (119/119).
- `pnpm lint`, `pnpm format`, `pnpm smrt dev:knowledge-check`, `pnpm audit:policy`, and protocol hygiene.

## Independent review

- Code review: CLEAR / APPROVE; no material findings.
- Lifecycle gate review: recovery implementation accepted; final release is contingent on this exact remote head, green checks, no unresolved threads, and the required quiet window.
