### PR TITLE
fix(ci): raise cold-build validation ceilings

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -52,7 +52,7 @@ jobs:
     name: Build
     if: inputs.mode == 'full'
     runs-on: arc-happyvertical
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - name: Checkout repository
@@ -216,7 +216,7 @@ jobs:
     needs: affected-scope
     if: inputs.mode == 'affected' && needs.affected-scope.outputs.knowledge == 'true'
     runs-on: arc-happyvertical
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -247,7 +247,7 @@ jobs:
     needs: build
     if: inputs.mode == 'full'
     runs-on: arc-happyvertical
-    timeout-minutes: 10
+    timeout-minutes: 25
 
     steps:
       - name: Checkout repository
@@ -288,7 +288,7 @@ jobs:
     needs: build
     if: always() && (inputs.mode == 'affected' || needs.build.result == 'success')
     runs-on: arc-happyvertical
-    timeout-minutes: 25
+    timeout-minutes: 45
 
     steps:
       # fetch-depth: 0 so the gate can diff against the PR base to find the
@@ -407,7 +407,7 @@ jobs:
     needs: build
     if: inputs.mode == 'full'
     runs-on: arc-happyvertical
-    timeout-minutes: 10
+    timeout-minutes: 35
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- raise only the five validation ceilings whose jobs perform cold full-workspace builds on brokered ARC runners
- keep job dependencies, conditions, runner labels, commands, and required-result aggregation unchanged
- bootstrap these base-branch workflow limits separately so pull_request_target validation can exercise the generation-20 policy PR under the corrected ceilings

Superseded by #2141, which merged the same timeout changes. This PR does not close #2144; that issue remains scoped to video Vitest worker serialization.

## Validation

- exact head `0aa67bb`
- `actionlint .github/workflows/test-suite.yml`
- full pre-push workflow validation
- strict changed-scope and full knowledge freshness
- commitlint and diff hygiene

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-gen20-timeout-019fabf1","policy_revision":"1.0.0","issue":null,"status":"superseded","head_sha":"0aa67bb4ba002f85341f75f794cfd424fc56e624","validation":["superseded by merged PR #2141"]}
```