### PR TITLE
fix(ci): raise full-suite typecheck timeout

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -132,7 +132,7 @@ jobs:
     needs: build
     if: inputs.mode == 'full'
     runs-on: arc-happyvertical
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- raise the full-suite Typecheck ceiling from 15 to 25 minutes
- preserve runner routing, commands, dependencies, and required-result aggregation
- unblock merge-group validation for #2157 after its otherwise-green run hit the old ceiling

Closes #2159.

## Validation

- `yamllint .github/workflows/test-suite.yml`
- `actionlint .github/workflows/test-suite.yml`
- `git diff --check`
- strict changed-scope and full knowledge freshness
- complete pre-commit and pre-push policy hooks
- independent review-cycle: clean, no material findings

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-2159-typecheck-timeout-019fabf1","policy_revision":"1.0.0","issue":2159,"status":"in_progress","head_sha":"6e70e41bee8b43eab5f70b5be1a1ac07bd30a2d0","validation":["yamllint","actionlint","git diff --check","strict knowledge freshness","pre-commit hooks","pre-push hooks","review-cycle clean"]}
```