### PR TITLE
fix(ci): extend full-suite typecheck timeout

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -132,7 +132,7 @@ jobs:
     needs: build
     if: inputs.mode == 'full'
     runs-on: arc-happyvertical
-    timeout-minutes: 25
+    timeout-minutes: 45
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- raise the full-suite Typecheck job timeout from 25 to 45 minutes
- preserve the existing brokered ARC runner and all validation steps
- unblock PR #2157, whose merge-group Typecheck job 90823956445 was terminated exactly at the 25-minute ceiling after roughly 23 minutes of typechecking plus setup

Closes #2159.

## Validation

- `yamllint .github/workflows/test-suite.yml`
- `actionlint .github/workflows/test-suite.yml`
- `git diff --check`
- `pnpm knowledge:check --changed --strict --format markdown`
- pre-commit and pre-push hooks
- independent review-cycle: clean

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-2159-typecheck-timeout-45-019fabf1","policy_revision":"1.0.0","issue":2159,"status":"in_progress","head_sha":"6c416bfb50ad4fcdc5aa42514adefce55b32d5c4","validation":["yamllint","actionlint","git diff --check","strict changed knowledge freshness","pre-commit hooks","pre-push hooks","review-cycle clean"]}
```