### PR TITLE
chore(ci): standardize job timeouts on 45 minutes for arc-happyvertical

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -31,8 +31,11 @@ never prevent the tests from running.
   and then queues until it times out rather than failing. `.github/actionlint.yaml`
   omits the label so lint rejects it instead. If a node capability lane is ever
   activated again it needs a fresh, served label.
-- Lightweight lifecycle, policy, aggregation, stale-management, and mobile
-  jobs remain GitHub-hosted when they do not benefit from a self-hosted cache.
+- Lightweight lifecycle, policy, stale-management, and mobile jobs remain
+  GitHub-hosted when they do not benefit from a self-hosted cache. Aggregation
+  is not uniform: `required-ci` is hosted, but `test-packages-result` runs on
+  `arc-happyvertical` even though it only reads `needs.*.result`. It is capped
+  at the standard rather than moved, because it backs a required status.
 
 The PR caller uses `pull_request_target`, so GitHub loads runner selection from
 the trusted base branch rather than contributor-controlled merge YAML. It passes
@@ -43,8 +46,9 @@ check, while the self-hosted validation and publish-dry-run calls are skipped
 and `Required CI` rejects the run. Broker admission must also deny those fork
 events before making a reservation.
 
-The retired `CI_NODE_RUNNER_ENABLED` switch no longer controls job placement
-and can be removed from the repository after this workflow migration is live.
+`CI_NODE_RUNNER_ENABLED` is gone from this tree — nothing reads it, and the
+migration it was conditioned on is live. If the repository still defines the
+variable it is inert and can be deleted.
 
 The pnpm store and runner workspace must remain on the same node-local
 filesystem so pnpm can hardlink packages. Do not restore RAM-backed split
@@ -54,6 +58,58 @@ SQLite fixtures and other temporary test files bypass the container overlay
 filesystem. Self-hosted runners can provide `CI_TEST_TMPDIR` to route those
 files to a bounded, test-only tmpfs; other runners retain the workspace-backed
 fallback.
+
+## Job timeouts
+
+Validation jobs on `arc-happyvertical` use `timeout-minutes: 45`. The value
+is a standard, not a per-job estimate: the previous spread ran from 5 to 45,
+mostly unexplained, and the low end was close to the pool's own queue wait
+(p90 1483-1933s measured over 180 jobs, against a median execution of 39-50s).
+A ceiling near that scale is fragile — it leaves nothing for a cold Turbo cache
+or a slow checkout, and it invites cancelling healthy work.
+
+`timeout-minutes` is measured from the moment a job starts executing, not from
+when it is queued, so this ceiling does not govern queue wait and raising it
+does not fix a job that is requeued while waiting. That behaviour is tracked
+separately in happyvertical/iac#1282. Do not treat a change here as a fix for
+requeueing.
+
+These jobs deliberately sit below the standard, with the reason recorded next
+to the setting or here:
+
+- GitHub-hosted jobs that set a timeout (`dependency-audit` at 10,
+  `mobile.yml`'s two Linux Gradle jobs at 30). Hosted runners never enter the
+  self-hosted queue, so the fragility above does not apply and their values can
+  track observed runtime.
+- `required-ci`, which only reads `needs.*.result`. It finishes in seconds, so
+  failing fast is correct for a job that just reports other jobs' results.
+
+`postgres-tests` is at the standard 45. #2164 retired the unserved
+`arc-happyvertical-node` label, deleted the `node-runner-smoke` workflow that
+ran only there, and moved this job onto the general `arc-happyvertical` pool —
+the pool the 45 was measured on — so the standard applies to it for the same
+reason it applies to every other job there. Its earlier 30 was inherited from a
+label whose scale set was quiesced to zero runners, where `timeout-minutes`
+never governed anything.
+
+`publish-release` is at the standard 45 but that value is load-bearing
+independently of it: 45 is the documented sequential-registry recovery window
+below, and `scripts/publish-workflow-policy.test.mjs` asserts the exact number.
+Moving the standard later does not by itself license moving that job.
+
+Two related constraints are deliberately not per-job settings:
+
+- Several GitHub-hosted jobs set no `timeout-minutes` at all and inherit
+  GitHub's 360-minute default. That is a separate gap from this standard; it is
+  not a licence to leave a self-hosted job uncapped.
+- A merge queue configured with a 60-minute timeout measures wall time, which
+  includes queue wait; a chain of 45-minute jobs can exceed it. Tune the queue
+  timeout at the queue, not by shrinking job ceilings back toward the queue
+  wait.
+
+`agent-policy.yml` is synced from the shared policy source rather than authored
+here; its timeout belongs to the policy control plane, so it is not changed in
+this repository.
 
 ## Pull requests and merge groups
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   build:
     runs-on: arc-happyvertical
-    timeout-minutes: 20
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -46,6 +46,10 @@ jobs:
   gradle-linux:
     name: Gradle build + KMP unit tests
     runs-on: ubuntu-latest
+    # Deliberately below the 45-minute standard. Every job in this workflow is
+    # GitHub-hosted, so none of them sit in the self-hosted queue that makes a
+    # low ceiling fragile on `arc-happyvertical`. These values are calibrated
+    # to observed Gradle runtime and act as hang guards.
     timeout-minutes: 30
     steps:
       - name: Checkout
@@ -70,6 +74,7 @@ jobs:
   gradle-android:
     name: smrt-android library + sample
     runs-on: ubuntu-latest
+    # Deliberately below the 45-minute standard; see `gradle-linux`.
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -325,6 +325,11 @@ jobs:
       (github.event_name == 'pull_request_target' &&
       contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: ubuntu-latest
+    # Deliberately below the 45-minute standard: this is GitHub-hosted, so it
+    # is not exposed to the self-hosted queue wait that makes low ceilings
+    # fragile there. Setup plus the audit and its policy check are bounded work
+    # against the registry, so ten minutes is a hang guard against an
+    # unresponsive registry rather than a capacity budget.
     timeout-minutes: 10
     steps:
       - name: Checkout PR branch
@@ -401,6 +406,11 @@ jobs:
       - test
       - publish-dry-run
     runs-on: ubuntu-latest
+    # Deliberately below the 45-minute standard. This aggregator does no
+    # checkout and no work beyond reading `needs.*.result`, and it is
+    # GitHub-hosted, so it never waits in the self-hosted queue. It runs in
+    # seconds; if it has not finished in five minutes it is stuck, and failing
+    # fast is correct for a job that only reports other jobs' results.
     timeout-minutes: 5
     steps:
       - name: Require full validation success

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -18,7 +18,7 @@ jobs:
     name: Registered PostgreSQL Suites
     if: github.event_name == 'workflow_dispatch' || vars.CI_POSTGRES_ENABLED == 'true'
     runs-on: arc-happyvertical
-    timeout-minutes: 30
+    timeout-minutes: 45
     # The general lane does not mount the cluster-local database URL that
     # arc-happyvertical-node provided, so the suite brings its own PostgreSQL.
     # CI_POSTGRES_BASE_URL keeps scripts/run-with-ci-postgres.mjs on its managed

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -23,7 +23,7 @@ jobs:
   prepare-publish:
     name: Prepare Publish Validation
     runs-on: arc-happyvertical
-    timeout-minutes: 30
+    timeout-minutes: 45
     outputs:
       should-validate: ${{ steps.prepare.outputs.should_validate }}
 
@@ -143,7 +143,7 @@ jobs:
     needs: prepare-publish
     if: needs.prepare-publish.outputs.should-validate == 'true'
     runs-on: arc-happyvertical
-    timeout-minutes: 20
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -159,9 +159,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ env.CHECKOUT_REF }}
-          # Preparation already produced the versioned workspace artifact.
-          # Pack shards only need workflow actions and scripts from this ref;
-          # fetching full history here can exhaust the 20-minute ARC timeout.
+          # Preparation already produced the versioned workspace artifact, so
+          # pack shards only need workflow actions and scripts from this ref.
+          # This was originally a workaround for a 20-minute job ceiling that
+          # a full-history fetch could exhaust; that ceiling is now 45 minutes
+          # (see .github/CI.md, "Job timeouts"), but the shallow fetch stays on
+          # its own merits — full history is work this job never reads.
           fetch-depth: 1
 
       - name: Restore versioned workspace and build outputs
@@ -207,7 +210,7 @@ jobs:
       - validate-publish-shards
     if: always()
     runs-on: arc-happyvertical
-    timeout-minutes: 5
+    timeout-minutes: 45
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
   prepare-release:
     name: Prepare Release
     runs-on: arc-happyvertical
-    timeout-minutes: 20
+    timeout-minutes: 45
     outputs:
       previous-version: ${{ steps.prepare.outputs.previous_version }}
       should-publish: ${{ steps.prepare.outputs.should_publish }}
@@ -224,7 +224,7 @@ jobs:
     needs: prepare-release
     if: needs.prepare-release.outputs.should-publish == 'true'
     runs-on: arc-happyvertical
-    timeout-minutes: 20
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -446,7 +446,7 @@ jobs:
   deploy-docs:
     name: Deploy Documentation
     runs-on: arc-happyvertical
-    timeout-minutes: 15
+    timeout-minutes: 45
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -23,6 +23,7 @@ jobs:
     name: Detect Affected Validation Scope
     if: inputs.mode == 'affected'
     runs-on: arc-happyvertical
+    timeout-minutes: 45
     outputs:
       knowledge: ${{ steps.filter.outputs.knowledge }}
     steps:
@@ -52,7 +53,7 @@ jobs:
     name: Build
     if: inputs.mode == 'full'
     runs-on: arc-happyvertical
-    timeout-minutes: 25
+    timeout-minutes: 45
 
     steps:
       - name: Checkout repository
@@ -161,7 +162,7 @@ jobs:
   lint:
     name: Lint
     runs-on: arc-happyvertical
-    timeout-minutes: 10
+    timeout-minutes: 45
 
     steps:
       - name: Checkout repository
@@ -216,7 +217,7 @@ jobs:
     needs: affected-scope
     if: inputs.mode == 'affected' && needs.affected-scope.outputs.knowledge == 'true'
     runs-on: arc-happyvertical
-    timeout-minutes: 25
+    timeout-minutes: 45
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -247,7 +248,7 @@ jobs:
     needs: build
     if: inputs.mode == 'full'
     runs-on: arc-happyvertical
-    timeout-minutes: 25
+    timeout-minutes: 45
 
     steps:
       - name: Checkout repository
@@ -351,9 +352,9 @@ jobs:
     if: inputs.mode == 'full'
     runs-on: arc-happyvertical
     # A remote-cache outage can add several minutes of cold setup and build
-    # time. Match the package-shard ceiling so cache misses cannot cancel an
-    # otherwise healthy core suite.
-    timeout-minutes: 25
+    # time, so this shard stays on the standard ceiling rather than a tighter
+    # one; cache misses must not cancel an otherwise healthy core suite.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -407,7 +408,7 @@ jobs:
     needs: build
     if: inputs.mode == 'full'
     runs-on: arc-happyvertical
-    timeout-minutes: 35
+    timeout-minutes: 45
 
     steps:
       - name: Checkout repository
@@ -444,8 +445,9 @@ jobs:
     if: inputs.mode == 'full'
     runs-on: arc-happyvertical
     # Each shard runs ~1/3 of package tests and lets Turbo build only their
-    # dependency closures. Keep the wider timeout for runner-pool contention.
-    timeout-minutes: 25
+    # dependency closures. Runner-pool contention still applies, so this keeps
+    # the standard ceiling rather than a shard-specific one.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -515,6 +517,7 @@ jobs:
     needs: test-packages
     runs-on: arc-happyvertical
     if: always() && inputs.mode == 'full'
+    timeout-minutes: 45
     steps:
       - name: Verify all Test Packages shards passed
         run: |


### PR DESCRIPTION
## Summary

`timeout-minutes` across this repository's workflows ranged from 5 to 45 with mostly no stated reasoning. This sets **45 minutes as the standard for every job on `arc-happyvertical`**, and keeps a lower value only where a short ceiling is a real safety property — each with the reason stated next to the setting or in `.github/CI.md`.

The discriminator turned out to be the **runner**, not the job. Queue wait is a property of `arc-happyvertical` (p90 1483-1933s against a median execution of 39-50s), so a 10- or 20-minute ceiling there has no headroom for a cold Turbo cache or a slow checkout. GitHub-hosted jobs never enter that queue, so their values are left alone.

This is less a new practice than the end of a reactive one: #2160 and #2161 each raised a single timeout after it bit.

## This is hygiene, NOT the requeue fix

`timeout-minutes` is measured from when a job **starts executing**, not from when it is queued. Raising it therefore **cannot** fix a job being requeued while it waits. The 25-minute requeue seen on #2154 is tracked in **happyvertical/iac#1282** and is not addressed here. These values are raised because the spread is arbitrary and the low end is fragile — not on the assumption that it resolves the requeue. `.github/CI.md` states this inline so the next reader does not draw the wrong conclusion.

## Rebased onto #2164 (now merged)

#2164 landed while this PR was open and changed the ground under one section of it. This branch has been rebased onto that merged state. What #2164 did:

- **deleted** `.github/workflows/node-runner-smoke.yml`;
- **retired** the `arc-happyvertical-node` label (nothing registers it; `.github/actionlint.yaml` omits it so lint rejects it);
- **moved** `postgres-tests`' `postgres` job onto `runs-on: arc-happyvertical`.

That resolves the one question this PR previously deferred. An earlier revision here raised `postgres-tests` from 30 to 45 and then reverted it, because the job sat on a scale set quiesced to `minRunners`/`maxRunners` 0 — so `timeout-minutes` governed nothing, and a ceiling derived from the general pool's queue wait did not transfer to a different label. **Both halves of that reasoning have now evaporated**: the job runs on `arc-happyvertical`, which is the exact pool the 45 was measured on. Raising it is completing this issue's own scope, not adding to it.

The stale `.github/CI.md` paragraph that described two jobs on `arc-happyvertical-node` in future tense has been rewritten to present-tense current reality, and the `node-runner-smoke` exception is **deleted outright** — the workflow no longer exists, so an exception documenting it is dead text. The "Runner selection" section needed no change from this PR: #2164 already rewrote it to say the label is retired and must not be selected.

### Two further statements corrected in the same section

A full audit of `.github/CI.md` against the tree at this head turned up two more statements that the same retirement made false. Both are in "Runner selection", both are corrected here:

- **`CI_NODE_RUNNER_ENABLED`** was described in future tense as removable "after this workflow migration is live". The migration has landed, and the variable appears **nowhere in the tree** — that line was its only mention. Now stated in present tense: nothing reads it, and if the repository still defines it, it is inert.
- **"aggregation ... jobs remain GitHub-hosted"** is not uniformly true: `test-packages-result` runs on `arc-happyvertical` despite only reading `needs.*.result`. Recorded rather than moved — it backs a required status, and relocating a job between pools is a different change from capping one.

### Audit findings deliberately left alone

The same audit found five pre-existing inaccuracies with no connection to timeouts or to #2164, all predating this PR. They are **not** fixed here — they need a judgement call about PostgreSQL lane intent and merge-queue rollout state that does not belong in a timeout change:

1. "affected PostgreSQL coverage" in the merge-queue rollout list — `on-pull-request.yml` references no PostgreSQL job at all.
2. "Scheduled and PR PostgreSQL lanes" — there is no PR-triggered PostgreSQL lane; `postgres-tests.yml` is `workflow_call`/`workflow_dispatch`/`schedule` only, and its sole caller is dispatch-only.
3. "PostgreSQL can be removed from the required aggregator" — `required-ci`'s `needs` list has no PostgreSQL entry to remove.
4. The `publish-mode=changesets` fallback is still framed as removable "after the first two successful artifact-based releases"; at least eight releases have completed since.
5. Rollout step 1 (verify the broker canary) is written as pending, but brokering landed in #2124.

## Relationship to #2166

This PR is **independent** and targets `main`. It contains only the timeout commit.

It briefly targeted #2166's branch (`claude/concurrency-groups`), because that PR also edits `mobile.yml`. That was rebased away: an agent-authored PR cannot pass the lifecycle check from a non-default base, because GitHub only registers a closing-issue reference when a PR targets the default branch — so `Closes #2163` never registered and `Required CI` never ran. Rebasing onto `main` fixes both and keeps the two PRs from entangling.

Both PRs edit `mobile.yml`, but in different places: #2166 changes the top-level `concurrency:` block, this one adds a comment above `timeout-minutes` inside two jobs. They should auto-merge in either order. **If whichever lands second hits a conflict, keep both changes** — #2166's `concurrency:` block *and* the timeout value/comment here. No `concurrency:` block is touched by this PR.

## Rationale table

Re-derived from the tree at this PR's head, not carried over from an earlier revision.

### Raised to the standard (`arc-happyvertical`)

| File | Job | Old | New |
|---|---|---|---|
| build.yml | `build` | 20 | 45 |
| postgres-tests.yml | `postgres` | 30 | 45 |
| publish-dry-run.yml | `prepare-publish` | 30 | 45 |
| publish-dry-run.yml | `validate-publish-shards` | 20 | 45 |
| publish-dry-run.yml | `publish-dry-run-summary` | 5 | 45 |
| publish.yml | `prepare-release` | 20 | 45 |
| publish.yml | `validate-release-shards` | 20 | 45 |
| publish.yml | `deploy-docs` | 15 | 45 |
| test-suite.yml | `build` | 25 | 45 |
| test-suite.yml | `lint` | 10 | 45 |
| test-suite.yml | `affected-knowledge` | 25 | 45 |
| test-suite.yml | `knowledge` | 25 | 45 |
| test-suite.yml | `test-core` | 25 | 45 |
| test-suite.yml | `test-integration` | 35 | 45 |
| test-suite.yml | `test-packages` | 25 | 45 |

`postgres-tests.yml`'s `postgres` is the entry added by the #2164 rebase; its "old" 30 is the value #2164 left it at when it moved the job onto the general pool.

### Capped for the first time — found during review, worse than anything in the issue

| File | Job | Old | New | Rationale |
|---|---|---|---|---|
| test-suite.yml | `affected-scope` | **unset (360)** | 45 | On `arc-happyvertical` with no ceiling at all, inheriting GitHub's 360-minute default. Becomes the PR-path entry point once `CI_MERGE_QUEUE_ENABLED` flips. |
| test-suite.yml | `test-packages-result` | **unset (360)** | 45 | Same. It backs the required "Test Packages" status, so a hang could hold a merge-group slot for six hours. |

These two were not in the issue's list. They were the widest values in the tree, not the narrowest.

### Kept below the standard, with stated rationale

| File | Job | Value | Rationale |
|---|---|---|---|
| on-pull-request.yml | `required-ci` | 5 | GitHub-hosted aggregator; no checkout, reads only `needs.*.result`. Runs in seconds — if it has not finished in five minutes it is stuck, and failing fast is correct. |
| on-pull-request.yml | `dependency-audit` | 10 | GitHub-hosted. Setup plus `pnpm audit` and its policy check are bounded registry work; 10 minutes is a hang guard against an unresponsive registry, not a capacity budget. |
| mobile.yml | `gradle-linux` | 30 | GitHub-hosted; never enters the self-hosted queue. Calibrated to observed Gradle runtime. |
| mobile.yml | `gradle-android` | 30 | Same. |

Already at 45 and untouched: `publish-release`, `typecheck`, `affected-validation`, `coverage-gate`, `gradle-macos`, `xcode-ios`.

**Every `arc-happyvertical` job in the tree is now at 45** — 21 of them, verified by re-scanning `.github/workflows/` at this head rather than trusting this table. No self-hosted job sits below the standard and none is uncapped.

### Comments reconciled rather than left contradicting the new value

- `publish-dry-run.yml` — the `fetch-depth: 1` note justified itself by a "20-minute ARC timeout" that no longer exists. The shallow fetch is still correct on its own merits (the shard reads the workspace from the artifact, never full history), so the workaround stays and the reasoning is restated.
- `test-suite.yml` `test-core` — "Match the package-shard ceiling" (then 25).
- `test-suite.yml` `test-packages` — "Keep the wider timeout for runner-pool contention" (then 25).

## Validation

Re-run at this head, after the rebase onto merged #2164:

- **actionlint 1.7.12** — exit 0, no output, whole `.github/workflows/` tree.
- **yamllint 1.37.1** — 8 `line-length` warnings, **identical in count and location to the same run against `origin/main`** (8 vs 8), so this diff introduces none.
- **`node scripts/publish-workflow-policy.test.mjs`** — 1 pass, 0 fail. It pins `publish-release` at exactly 45; that job is unchanged.
- **lefthook pre-commit** — `validate-workflows` green ("✅ All workflow files validated"), plus `secret-scan` and `forbidden-artifacts`; `commit-msg`/`commitlint` green.
- **Self-hosted timeout sweep** — every job with `runs-on: arc-happyvertical` re-derived from the tree: 21 jobs, all at 45, none unset.

One caveat, stated plainly rather than omitted: **`pnpm knowledge:check --changed --strict` fails locally at this head**, with 42 `stale-domain-knowledge` errors. It is unrelated to this diff. `.smrt/` is gitignored, so those `smrt-knowledge.json` files are untracked local build artifacts; the rebase pulled in the `chore(release): v0.40.37` commit, which rewrote every `packages/*/package.json`, and the check compares that timestamp against locally generated artifacts. It reproduces **identically (42 errors) with this PR's edits stashed**, and this diff touches only `.github/` — no `package.json` and no package source. CI regenerates knowledge from scratch and scopes the job to affected packages, which is why `Validate Changes / Knowledge Freshness` reports `skipping` on this PR.

## Out of scope

- **`agent-policy.yml` (`timeout-minutes: 10`)** — not hand-edited. It is synced from the shared policy source and pulls a cosign-verified artifact at runtime; hand-edits drift from the control plane and are rejected by `check-pr`. It is also `ubuntu-latest`, so the queue-wait argument does not apply. If that value should change, it belongs upstream in the policy control plane.
- **Eight GitHub-hosted jobs still set no `timeout-minutes` at all**, inheriting GitHub's 360-minute default: `validate-commits`, `validate-workflows`, `check-sdk-versions`, `secret-scan` and `check-standards` (all `on-pull-request.yml`), plus `on-merge-main.yml`'s `cancel-pr-checks`, `on-demand-validation.yml`'s `postgres-scope`, and `stale-issues.yml`'s `stale`. Recorded in `.github/CI.md` so it is not lost. Scoped out deliberately: adding hang guards to hosted jobs that never had one is a different change from standardizing an existing spread, and none of them sit in the self-hosted queue this issue is about. The two *self-hosted* jobs in the same state were in scope and are fixed above.
- **Footnote on `required-ci`** — its rationale leans on it being the required status. Today that is aspirational: `.github/CI.md` still lists "Replace the existing required status list with `Required CI`" as a pending step, and `test-packages-result` also backs a required status. Pre-existing wording; the comment added here avoids the exclusivity claim, but the rollout should settle it.

## Interaction worth knowing about

A merge queue configured with a 60-minute timeout measures **wall time**, which includes the queue wait this issue measured at p90 ~25-32 minutes. A chain of 45-minute jobs can exceed that budget. The fix belongs at the queue, not in shrinking job ceilings back toward the queue wait — recorded in `.github/CI.md`.

Closes #2163
Part of willgriffin/nixos-config#176

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "claude",
  "session": "2d2501c9-75fd-4e19-b900-73e80927df23",
  "issue": "2163",
  "policy_revision": "1.0.0",
  "validation": [
    "actionlint 1.7.12: exit 0 on .github/workflows/",
    "yamllint 1.37.1: 8 line-length warnings, identical to origin/main baseline (8), none introduced",
    "node scripts/publish-workflow-policy.test.mjs: 1 pass, 0 fail; publish-release still pinned at exactly 45",
    "lefthook: validate-workflows, secret-scan, forbidden-artifacts, commitlint green",
    "self-hosted sweep re-derived from tree: 21 arc-happyvertical jobs, all timeout-minutes 45, none unset",
    "pnpm knowledge:check --changed --strict: 42 pre-existing stale-domain-knowledge errors in gitignored .smrt/ build artifacts, staled by the rebased-in v0.40.37 package.json bumps; reproduces identically with this diff stashed; diff touches only .github/"
  ]
}
```
