### PR TITLE
docs(ci): correct stale PostgreSQL-lane and merge-queue-rollout claims in CI.md

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -57,28 +57,38 @@ fallback.
 
 ## Pull requests and merge groups
 
-`CI_MERGE_QUEUE_ENABLED` controls the staged rollout:
+`CI_MERGE_QUEUE_ENABLED` selects which validation shape a pull request gets. It
+is `true` on this repository; the unset/false branch is retained only as a
+reversal lever.
 
-- Unset/false: PRs run the historical full suite and publish dry-run. This
-  preserves the existing required status contexts during observation.
-- `true`: PRs run affected build, typecheck, tests, touched coverage, relevant
-  knowledge checks, and affected PostgreSQL coverage. The complete suite and
-  publish dry-run run for `merge_group`.
+- Unset/false: PRs run the historical full suite.
+- `true`: PRs run lint, affected typecheck and tests across the changed
+  packages and everything that depends on them, touched coverage, and — only
+  when knowledge-sensitive paths change — affected knowledge freshness. The
+  complete suite runs for `merge_group`.
+
+Publish dry-run sits outside that split: it runs for same-repository PRs and for
+`merge_group` in both modes. No lane in `on-pull-request.yml` or
+`test-suite.yml` runs PostgreSQL in either mode; PostgreSQL lives only in
+`postgres-tests.yml`, described below.
 
 `Required CI` is the sole required repository-validation status. Its aggregator
-explicitly checks different expected job sets for PR and merge-group events. Do
-not change the ruleset until this context has completed successfully on a
-representative code-changing PR run.
+requires the same eight jobs to succeed for both PR and merge-group events; what
+differs between the two is the mode `test-suite.yml` runs in, not the set of
+jobs the aggregator checks.
 
-After that canary run:
+Rollout status:
 
-1. Verify the `arc-happyvertical` broker canary and one representative SMRT run.
-2. Set `CI_POSTGRES_ENABLED=true` after a manual `postgres-tests.yml` dispatch
-   passes on `arc-happyvertical`.
-3. Set `CI_MERGE_QUEUE_ENABLED=true`.
-4. Replace the existing required status list with `Required CI`.
-5. Add a repository merge queue using merge commits, concurrency one, group
-   size one, zero wait, all-green behavior, and a 60-minute timeout.
+1. Done. The `arc-happyvertical` broker landed in #2124, and every self-hosted
+   job selects it.
+2. Pending. `CI_POSTGRES_ENABLED` is still unset, so the scheduled PostgreSQL
+   lane stays skipped. Set it to `true` after a manual `postgres-tests.yml`
+   dispatch passes on `arc-happyvertical`.
+3. Done. `CI_MERGE_QUEUE_ENABLED` is `true`.
+4. Done. The required status list is exactly `Required CI`.
+5. Done. The repository merge queue uses squash merges, up to five entries
+   building concurrently, one entry merged at a time, zero wait, all-green
+   behavior, and a 60-minute timeout.
 
 When merge queue mode is enabled, the main workflow skips duplicate tests and
 the standalone build. The versioned release build, exact-artifact publication,
@@ -101,9 +111,12 @@ runner image already provides the libpq client binaries the wrapper needs for
 still gets its own database under `--concurrency=2`; no job depends on a
 cluster-local credential, and there is no production database secret access.
 
-Scheduled and PR PostgreSQL lanes remain skipped until the repository variable
-`CI_POSTGRES_ENABLED` is `true`. Manual dispatch remains available for
-validation before the lane is required.
+There is no PR-triggered PostgreSQL lane. `postgres-tests.yml` triggers on
+`workflow_call`, `workflow_dispatch`, and a nightly `schedule`, and its only
+caller, `on-demand-validation.yml`, is dispatch-only. The scheduled run stays
+skipped until the repository variable `CI_POSTGRES_ENABLED` is `true`, which it
+currently is not. Manual dispatch bypasses that variable and remains available
+for validation before the lane is required.
 
 Interrupted jobs are cleaned hourly after six hours. Tests must never use a
 fixed shared database name or remove the wrapper from their package script.
@@ -144,9 +157,12 @@ policy explicitly allows the `core-js` and `sharp` install scripts required by
 the locked Docusaurus dependency graph; CI must not bypass or interactively
 approve that policy.
 
-The manual `publish-mode=changesets` option is an emergency fallback for the
-first two successful artifact-based releases. Remove the option after both
-releases complete and downstream consumers install the published packages.
+The manual `publish-mode=changesets` option is a standing emergency fallback,
+not a time-boxed one. Both trigger paths default to `artifacts` and
+`on-merge-main.yml` never passes the input, so the fallback is reachable only
+through manual dispatch. Its versioning half is not dormant: `prepare-release`
+runs `changeset:auto` and `changeset:version` on every release regardless of
+mode, so only the publication step differs between the two.
 
 ## Acceptance and rollback
 
@@ -159,6 +175,6 @@ Runner placement remains brokered through `arc-happyvertical`; change backing
 capacity only in runner-pool policy, not workflow labels. Merge-queue rollout
 can be reversed independently by clearing `CI_MERGE_QUEUE_ENABLED`, restoring
 the previous required status list, and removing the merge-queue rule.
-PostgreSQL can be removed from the required aggregator without altering SQLite
-coverage. The artifact publisher can temporarily fall back to Changesets
-through manual dispatch.
+PostgreSQL is not part of the required aggregator, so toggling
+`CI_POSTGRES_ENABLED` never alters SQLite coverage. The artifact publisher can
+temporarily fall back to Changesets through manual dispatch.


### PR DESCRIPTION
Closes #2168. Documentation only — `.github/CI.md`. No workflow files are modified.

These statements were surfaced during the #2167 timeout audit and deliberately left out of that PR: they are unrelated to timeouts and needed a judgement call on PostgreSQL-lane intent and merge-queue rollout state. #2167 ledgers them under "Audit findings deliberately left alone".

## Corrections

| `CI.md` | Was | Verified state |
|---|---|---|
| L60-68 | `true` mode makes PRs run "affected PostgreSQL coverage" | `on-pull-request.yml` has **no** postgres reference at any line; `test-suite.yml` has no PostgreSQL job in either mode |
| L70-73 | (implied) publish dry-run is merge-group-only in `true` mode | `publish-dry-run` is ungated by the variable and runs for same-repository PRs too |
| L75-78 | Aggregator "explicitly checks different expected job sets" per event | `required-ci` declares one `needs` list and one uniform success loop — zero `event_name` branching |
| L80-91 | Rollout list written as pending | Step 1 landed in #2124; steps 3-5 are live; only step 2 is outstanding |
| L114-119 | "Scheduled **and PR** PostgreSQL lanes remain skipped…" | No PR-triggered lane exists; the scheduled half was correct |
| L160-165 | `publish-mode=changesets` removable "after both releases complete" | 55 releases have completed since #1922 introduced it |
| L178-180 | "PostgreSQL can be removed from the required aggregator" | No PostgreSQL entry exists in the aggregator to remove |

### Rollout state, verified against the live repository

| Step | Doc said | Actual | Now reads |
|---|---|---|---|
| 1 | Verify broker canary | #2124 (`3c51209d0`); all 21 self-hosted jobs on `arc-happyvertical`, zero `arc-happyvertical-node` | Done |
| 2 | Set `CI_POSTGRES_ENABLED=true` | variable absent | **Pending** — the one item still open |
| 3 | Set `CI_MERGE_QUEUE_ENABLED=true` | `true` | Done |
| 4 | Required list → `Required CI` | ruleset `19140738` requires exactly `Required CI` | Done |
| 5 | Merge queue: merge commits, group size one | ruleset `19137910`: `SQUASH`, `max_entries_to_build: 5`, `max_entries_to_merge: 1`, wait `0`, `ALLGREEN`, `60` | Done, and **the description was wrong on two counts** — squash not merge commits, five concurrent builds not one |

## Judgement call: `publish-mode=changesets` is kept

The doc's own instruction was to remove the option after the first two artifact-based releases; 55 have completed. **Retired the framing, kept the option**, because the fallback is live infrastructure rather than dead code:

- `prepare-release` runs `changeset:auto` and `changeset:version` on **every** release regardless of mode (`publish.yml:102-103`), so only the publication step differs between the two modes. There is no dormant-and-rotted half.
- `CI.md`'s own "Acceptance and rollback" section already lists the fallback as a standing recovery lever. Deleting the input would have contradicted a documented rollback path in the same file.
- Removing a `workflow_call` input plus a `workflow_dispatch` choice is a pipeline change, not a doc correction, and does not belong in this cycle.

Happy to file that removal separately if the intent really is to retire it.

## Scope notes

Finding 3 in the table (the aggregator sentence) was found while verifying the other five and was **added to #2168's scope before any edit**, so it is tracked work rather than a drive-by. It sits in the same paragraph block as finding 1 and could not have been split into a separate commit without splitting a contiguous hunk. There is no `Drive-by fixes` ledger on this PR.

Two related findings are **deliberately excluded**, both workflow changes rather than doc corrections:

1. `on-demand-validation.yml:13-40` defines a `postgres-scope` job whose `required` output is computed from `github.event_name == 'merge_group'` plus a `pull_request`-gated paths filter. Neither can fire under a dispatch-only trigger, and no job consumes the output — `postgres-tests` declares no `needs`.
2. The `CI_NODE_RUNNER_ENABLED` repository variable is still set to `true` with no consumer in `.github/` or `scripts/`. `CI.md:46-47` already describes it accurately as retired and removable; only the deletion is outstanding.

## Validation

- `actionlint .github/workflows/*.yml` — clean, exit 0.
- `yamllint .github/workflows/` — exit 0; the six line-length warnings are pre-existing in `publish.yml`, `agent-policy.yml`, and `on-pull-request.yml`, all untouched here.
- The lefthook `validate-workflows` hook globs `.github/workflows/*.{yml,yaml}` and does not match a `CI.md`-only change, so its underlying tools were run directly instead, as above.
- `commitlint --from=HEAD~1 --to=HEAD` — 0 problems, 0 warnings.
- Turbo's `...[sha]` filter direction was verified empirically rather than asserted: `--filter='...@happyvertical/smrt-core'` selects 57 packages and `--filter='@happyvertical/smrt-core...'` selects 4, confirming the leading ellipsis selects dependents. A review pass caught the doc calling this a "dependency closure"; it now reads "the changed packages and everything that depends on them".
- `pnpm knowledge:check --changed --strict` is **not** green — it fails on ~42 stale-domain-knowledge errors in gitignored `.smrt/` build artifacts. Confirmed environmental: it reproduces identically on a clean tree with zero modifications, and this change touches no package, manifest, or `AGENTS.md`.
- Commits used `--no-verify` because worktree lefthook hooks fail with "device not configured" (no TTY). The gates that cover this change were run manually, as listed.

## Review

One `review-cycle` round at docs-only roster size (two reviewers). Independent `codex` review (`gpt-5.6-terra`, xhigh) returned clean on both the initial and the amended revision, having independently re-read the workflow definitions, repository variables, and merge-queue ruleset. The self-review pass produced one material finding — the inverted Turbo filter direction above — which was fixed and re-verified.

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "claude",
  "session": "9d1dfb43-8e46-4f6c-9a42-9b2e6c1d91f4",
  "issue": "https://github.com/happyvertical/smrt/issues/2168",
  "policy_revision": "1.0.0",
  "validation": [
    "actionlint .github/workflows/*.yml clean (exit 0)",
    "yamllint .github/workflows/ exit 0; warnings pre-existing in untouched files",
    "lefthook validate-workflows glob does not match a CI.md-only change; underlying yamllint+actionlint run directly",
    "commitlint --from=HEAD~1 --to=HEAD: 0 problems, 0 warnings",
    "turbo filter ellipsis direction verified empirically (57 dependents vs 4 dependencies)",
    "knowledge:check --changed --strict fails identically on a clean tree (gitignored .smrt/ artifacts, environmental)",
    "review-cycle: 1 round, codex clean on initial and amended revision, 1 self-review finding fixed"
  ]
}
```
