### PR TITLE
fix(test): replace dead singleFork option with Vitest 4 fork controls (#2144)

### DIFF
--- a/docs/content/PROJECT_REQUIREMENTS.md
+++ b/docs/content/PROJECT_REQUIREMENTS.md
@@ -16,10 +16,9 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     testTimeout: 60000,
+    fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: { singleFork: true, isolate: true }
-    },
+    isolate: false,
   },
 });
 ```

--- a/docs/content/PROJECT_REQUIREMENTS.md
+++ b/docs/content/PROJECT_REQUIREMENTS.md
@@ -18,12 +18,23 @@ export default defineConfig({
     testTimeout: 60000,
     fileParallelism: false,
     pool: 'forks',
-    isolate: false,
   },
 });
 ```
 
 **Why**: The vitest plugin automatically generates manifests and loads cross-package dependencies. Without it, tests will fail with "unregistered class" or "No field metadata found" errors.
+
+**Note**: do not add `maxWorkers` — `fileParallelism: false` already pins the
+pool to a single worker and Vitest overrides any user-supplied value. Do not add
+`singleFork` either: it was `poolOptions.forks.singleFork` in Vitest 3 and does
+not exist in Vitest 4, and unknown keys are ignored rather than rejected.
+
+Keep the default `isolate: true`. Disabling isolation shares one module registry
+across test files and makes them order-dependent, which is only worth it for
+unusually heavy packages and only after verifying that suite under randomized
+file order (`--sequence.shuffle.files --sequence.seed=N`). If a heavy package
+needs relief but depends on per-file isolation, keep `isolate: true` and raise
+the per-fork heap with `NODE_OPTIONS=--max-old-space-size=...` instead.
 
 ### 2. package.json Dependencies
 

--- a/docs/content/standards.md
+++ b/docs/content/standards.md
@@ -219,14 +219,18 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    // Reuse one fork per package so the SMRT manifest and base-class
+    // graph load once instead of once per test file.
+    isolate: false,
   },
 });
 ```
+
+> **Note**: `fileParallelism: false` already pins the pool to a single worker —
+> Vitest overrides any user-supplied `maxWorkers` in that case — so `isolate`
+> is the only knob left that controls how often the module graph is reloaded.
+> The `poolOptions.forks.singleFork` option was removed in Vitest 4; a stray
+> `singleFork` key is silently ignored rather than rejected.
 
 > **Note**: Inside this monorepo, packages import `smrtVitestPlugin` directly from the workspace source (`../vitest/src/index.ts`) rather than from the published `@happyvertical/smrt-vitest`. This avoids a circular workspace build dependency. Consumer projects (outside the monorepo) should import from the package name.
 

--- a/docs/content/standards.md
+++ b/docs/content/standards.md
@@ -219,18 +219,39 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    // Reuse one fork per package so the SMRT manifest and base-class
-    // graph load once instead of once per test file.
-    isolate: false,
   },
 });
 ```
 
 > **Note**: `fileParallelism: false` already pins the pool to a single worker —
-> Vitest overrides any user-supplied `maxWorkers` in that case — so `isolate`
-> is the only knob left that controls how often the module graph is reloaded.
-> The `poolOptions.forks.singleFork` option was removed in Vitest 4; a stray
-> `singleFork` key is silently ignored rather than rejected.
+> Vitest overrides any user-supplied `maxWorkers` in that case, so do not add
+> `maxWorkers`. The `poolOptions.forks.singleFork` option was removed in
+> Vitest 4, and a flat `test.singleFork` was never valid at any version; a
+> stray `singleFork` key is silently ignored rather than rejected.
+
+#### `isolate: false` is an opt-in exception, not the default
+
+Files still run one at a time under `fileParallelism: false`, but `isolate`
+defaults to `true`, so each test file gets a fresh fork that reloads the whole
+SMRT manifest and base-class graph. Setting `isolate: false` reuses one fork and
+loads that graph once, which is worth it for the heaviest packages —
+`packages/video` uses it and drops from four worker forks to one.
+
+**Do not apply it by default.** It shares one module registry across test files,
+which makes execution order significant, and Vitest reorders files between runs
+from its cached durations. Measured on this repo, 3 of 14 packages broke under
+it: `agents` and `assets` raised `Class '...' is not registered` because the
+`ObjectRegistry` `globalThis` singleton carried mutated state across files, and
+`content` leaked module-level Svelte mocks. Before enabling it for a package,
+run that suite under randomized file order
+(`vitest run --sequence.shuffle.files --sequence.seed=N`) across several seeds
+and keep per-file isolation if any of them fail.
+
+If a package needs the memory relief but its suite depends on per-file
+isolation, keep `isolate: true` and raise the per-fork heap instead
+(`NODE_OPTIONS=--max-old-space-size=...` on that package's `test` script).
+Correctness beats uniformity: never disable isolation to make a package match
+its siblings.
 
 > **Note**: Inside this monorepo, packages import `smrtVitestPlugin` directly from the workspace source (`../vitest/src/index.ts`) rather than from the published `@happyvertical/smrt-vitest`. This avoids a circular workspace build dependency. Consumer projects (outside the monorepo) should import from the package name.
 

--- a/packages/ads/vitest.config.ts
+++ b/packages/ads/vitest.config.ts
@@ -11,6 +11,5 @@ export default defineConfig({
     hookTimeout: 30000, // Allow longer setup time in CI
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/affiliates/vitest.config.ts
+++ b/packages/affiliates/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/agents/vitest.config.ts
+++ b/packages/agents/vitest.config.ts
@@ -24,6 +24,5 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/analytics/vitest.config.ts
+++ b/packages/analytics/vitest.config.ts
@@ -23,7 +23,6 @@ export default defineConfig({
     fileParallelism: false,
     // Vitest 4.x: pool options are now top-level
     pool: 'forks',
-    singleFork: true,
     // Multi-adapter test projects (Vitest 4.x)
     projects: [
       {

--- a/packages/assets-ergot/vitest.config.ts
+++ b/packages/assets-ergot/vitest.config.ts
@@ -29,6 +29,5 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/assets-local/vitest.config.ts
+++ b/packages/assets-local/vitest.config.ts
@@ -29,6 +29,5 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/assets/vitest.config.ts
+++ b/packages/assets/vitest.config.ts
@@ -24,6 +24,5 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/chat/vitest.config.ts
+++ b/packages/chat/vitest.config.ts
@@ -25,7 +25,6 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/commerce/vitest.config.ts
+++ b/packages/commerce/vitest.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
     fileParallelism: false,
     // Use single-threaded pool to avoid database contention
     pool: 'forks',
-    singleFork: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/config/vitest.config.ts
+++ b/packages/config/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/content/vitest.config.ts
+++ b/packages/content/vitest.config.ts
@@ -31,7 +31,6 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/events/vitest.config.ts
+++ b/packages/events/vitest.config.ts
@@ -13,6 +13,5 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/facts/vitest.config.ts
+++ b/packages/facts/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/features/vitest.config.ts
+++ b/packages/features/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 60000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/gnode/vitest.config.ts
+++ b/packages/gnode/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/images/vitest.config.ts
+++ b/packages/images/vitest.config.ts
@@ -27,7 +27,6 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
     coverage: {
       // Exclude @smrt/core-generated code from the coverage denominator: the
       // SvelteKit route handlers (gitignored, "Auto-generated … DO NOT EDIT")

--- a/packages/inventory/vitest.config.ts
+++ b/packages/inventory/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/jobs/vitest.config.ts
+++ b/packages/jobs/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/languages/vitest.config.ts
+++ b/packages/languages/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/ledgers/vitest.config.ts
+++ b/packages/ledgers/vitest.config.ts
@@ -13,7 +13,6 @@ export default defineConfig({
     fileParallelism: false,
     // Use single-threaded pool to avoid database contention
     pool: 'forks',
-    singleFork: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/manufacturing/vitest.config.ts
+++ b/packages/manufacturing/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/marketing/vitest.config.ts
+++ b/packages/marketing/vitest.config.ts
@@ -15,6 +15,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/marketing/vitest.svelte.config.ts
+++ b/packages/marketing/vitest.svelte.config.ts
@@ -16,6 +16,5 @@ export default defineConfig({
     },
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/personas/vitest.config.ts
+++ b/packages/personas/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/places/vitest.config.ts
+++ b/packages/places/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/profiles/vitest.config.ts
+++ b/packages/profiles/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/projects/vitest.config.ts
+++ b/packages/projects/vitest.config.ts
@@ -25,7 +25,6 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/prompts/vitest.config.ts
+++ b/packages/prompts/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/properties/vitest.config.ts
+++ b/packages/properties/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/reports/vitest.config.ts
+++ b/packages/reports/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/sales/vitest.config.ts
+++ b/packages/sales/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/scanner/vitest.config.ts
+++ b/packages/scanner/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/secrets/vitest.config.ts
+++ b/packages/secrets/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/sites/vitest.config.ts
+++ b/packages/sites/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/smrt-dev-mcp/vitest.config.ts
+++ b/packages/smrt-dev-mcp/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/smrt-mobile-contract/vitest.config.ts
+++ b/packages/smrt-mobile-contract/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/smrt-svelte/vitest.config.ts
+++ b/packages/smrt-svelte/vitest.config.ts
@@ -60,6 +60,5 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/smrt-ui/vitest.config.ts
+++ b/packages/smrt-ui/vitest.config.ts
@@ -27,6 +27,5 @@ export default defineConfig({
     hookTimeout: 60000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/social/vitest.config.ts
+++ b/packages/social/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/subscriptions/vitest.config.ts
+++ b/packages/subscriptions/vitest.config.ts
@@ -12,6 +12,5 @@ export default defineConfig({
     hookTimeout: 60000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/support/vitest.config.ts
+++ b/packages/support/vitest.config.ts
@@ -25,6 +25,5 @@ export default defineConfig({
     hookTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/tags/vitest.config.ts
+++ b/packages/tags/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/tenancy/vitest.config.ts
+++ b/packages/tenancy/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/types/vitest.config.ts
+++ b/packages/types/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });

--- a/packages/users/vitest.config.ts
+++ b/packages/users/vitest.config.ts
@@ -27,7 +27,6 @@ export default defineConfig({
     fileParallelism: false,
     // Use single-threaded pool to avoid database contention
     pool: 'forks',
-    singleFork: true,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/packages/video/vitest.config.ts
+++ b/packages/video/vitest.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
+    // Reuse one fork per package so the SMRT manifest and base-class
+    // graph load once instead of once per test file.
+    isolate: false,
   },
 });

--- a/packages/voice/vitest.config.ts
+++ b/packages/voice/vitest.config.ts
@@ -10,6 +10,5 @@ export default defineConfig({
     testTimeout: 30000,
     fileParallelism: false,
     pool: 'forks',
-    singleFork: true,
   },
 });


### PR DESCRIPTION
<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"claude","session":"claude-2144-vitest-fork-config-01","issue":"2144","policy_revision":"1.0.0","status":"complete","validation":["verified singleFork absent from entire vitest@4.1.10 tree and no --single-fork CLI flag","full suite for all 46 touched packages run twice: 92 runs, 44/46 green both runs","packages/video passed 10 randomized file orders (--sequence.shuffle.files seeds 1-10) plus repeat sequential runs","profiles and users flakes proven pre-existing: users reproduced the failure with pristine origin/main config restored","measured video fork count 4 -> 1, worker peak RSS sum ~1676MB -> ~538MB, wall 7.5s -> 4.6s","pnpm build green 61/61 tasks","pnpm typecheck green 118/118 tasks","pnpm smrt dev:knowledge-check fresh, 0 errors 0 warnings","biome check on touched paths: paths outside configured includes, no unrelated files reformatted","generator-deleted content route files restored before staging; commits contain exactly the 49 intended files","review follow-up: marketing svelte config dead key removed, both marketing suites run twice green","review follow-up: canonical doc snippets restored to isolated baseline, isolate:false documented as opt-in with heap fallback","rebased onto origin/main 648e4b5c2; rebuild and knowledge-check re-run green after rebase with no generator drift","all 4 review threads replied to individually and resolved"]}

## Summary

`test.singleFork: true` appeared in **47** vitest configs and is **dead configuration** — nothing reads it. This removes it everywhere and adds the one Vitest 4 option that actually does the intended work (`isolate: false`) to `packages/video`, the package that exhausts its CI runner.

The issue as originally filed said `packages/video` had no `vitest.config.ts`. That premise was wrong — the file exists and matches its siblings. The real defect is that the option those siblings rely on has never done anything.

## Root cause

Verified directly against the installed toolchain (`vitest@4.1.10`):

- `grep -rl "singleFork" node_modules/.pnpm/vitest@4.1.10*/` returns **no matches** — the string does not exist in the package tree.
- There is no `--single-fork` CLI flag (`--isolate`/`--no-isolate` and `--fileParallelism` are the real knobs).

Two causes stacked:

1. In Vitest 3 the option was `test.poolOptions.forks.singleFork` — **nested**. Every one of these 46 configs used the **flat** top-level `test.singleFork`, so it was already inert *before* the v4 upgrade.
2. Vitest 4 dropped `poolOptions` in favour of top-level `isolate` and `maxWorkers` (both in `InlineConfig` / `SerializedConfig`).

It went unnoticed because `vitest.config.ts` sits in a blind spot for both gates that would have caught it:

| gate | scope | covers `vitest.config.ts`? |
| --- | --- | --- |
| tsconfig `include` | `src/**/*` | no |
| biome `files.includes` | `packages/*/src/**/*` | no |

TypeScript excess-property checking never ran on these files, and Vitest ignores unknown keys rather than rejecting them.

### What was actually still working

`fileParallelism: false` **is** honored, so files already ran one at a time. But `isolate` defaults to `true`, so each file still got a **fresh fork** that reloaded the entire SMRT manifest and base-class graph. For `packages/video` that is 88 base classes (85 external) and a 26-object manifest, per file.

## Why `maxWorkers: 1` is deliberately NOT added

The obvious replacement is `maxWorkers: 1`. It is redundant. From Vitest's own config resolution:

```js
if (resolved.maxWorkers) resolved.maxWorkers = resolveInlineWorkerOption(resolved.maxWorkers);
if (!(options.fileParallelism ?? mode !== "benchmark"))
  // ignore user config, parallelism cannot be implemented without limiting workers
  resolved.maxWorkers = 1;
```

`fileParallelism: false` already forces `maxWorkers = 1` and **explicitly ignores user config**. Adding it would reintroduce exactly the failure mode this PR fixes: a key that reads as load-bearing but is not. `isolate` is the only remaining knob that changes behavior.

## Why `isolate: false` is NOT applied repo-wide

This was the proposed fix, and it is **not safe in this repo**. `isolate: false` shares one module registry across test files, which makes execution order significant — and Vitest reorders files between runs from its cached durations (`node_modules/.vite/vitest/*/results.json` stores per-file `duration` and `failed`, and the sequencer sorts on them). A cold-cache run and a warm-cache run therefore execute a different order.

Applying it to all 46 packages and running each suite twice, **3 of the first 14 packages evaluated failed**:

| package | failure under `isolate: false` |
| --- | --- |
| `agents` | `Class 'AgentConfig' is not registered` — the `ObjectRegistry` `globalThis` singleton carries mutated state across files |
| `assets` | same registry-state class of failure |
| `content` | module-level Svelte mock leakage (`clientMocks.createClient`, unparsed fetch URLs); 22 tests failed on one order, 9 on another |

`content` is one of the four packages the issue proposed changing, and it is the one most broken by it. Control: `agents` failed under `isolate: false` and passes on the same commit with per-file isolation restored, so these are caused by the change, not pre-existing flakiness.

Trading a memory flake for an order-dependence flake would not have made CI more deterministic. **Correctness over uniformity: only `packages/video` gets `isolate: false`.** The other 46 configs lose the dead key and keep Vitest's default per-file isolation — a pure deletion with no behavior change.

### Per-package decision

| packages | decision | rationale |
| --- | --- | --- |
| `video` | `isolate: false` | Heaviest target and the one that actually dies in CI. Passed 10 consecutive randomized file orders. |
| `agents`, `assets`, `content` | keep `isolate: true` | **Proven** isolation-dependent — they fail under `isolate: false`. |
| the other 43 configs | keep `isolate: true` | No demonstrated need. Not opted out speculatively, since each opt-out is a latent order-dependence risk. |

The documented escape hatch for a heavy package that *is* isolation-dependent is to keep `isolate: true` and raise the per-fork heap (`NODE_OPTIONS=--max-old-space-size=...`) rather than disable isolation. No package needed that here.

## Docs

`docs/content/standards.md` and `docs/content/PROJECT_REQUIREMENTS.md` both propagated the dead pattern (in the *nested* Vitest 3 form, while the configs used the flat form — dead either way). Both canonical snippets now show the isolated baseline. `isolate: false` is documented as an opt-in, per-package optimization that requires verifying the suite under randomized file order first, with the heap fallback named. Both also state why `maxWorkers` and `singleFork` must not be added.

## Measured effect on `packages/video`

Sampling the whole process tree every 50 ms (`ps` RSS across all descendants):

Median of 3 runs each on an idle machine:

| metric | before (`isolate` default `true`) | after (`isolate: false`) |
| --- | --- | --- |
| distinct worker forks | **4** (one per test file) | **1** |
| max concurrent processes | 4–5 | 3 |
| sum of worker peak RSS | **~1676 MB** | **~538 MB** (-68%) |
| peak whole-tree RSS | ~1132 MB | ~1133 MB (unchanged) |
| wall time | 7.5 s | 4.6 s (-39%) |

Read this honestly: **peak instantaneous RSS is not reduced** (~1.1 GB either way), because `fileParallelism: false` already serialized the workers. What drops is fork count and total allocation churn — the suite stops allocating and freeing ~500 MB four times over, and there are 3 fewer worker processes that can be killed. The observed CI signature was `Test Files 1 passed (4)` with 3 `Worker exited unexpectedly` errors: exactly 3 forks dying and the one warm start passing. This removes those 3 forks.

## Validation

- Full suite for **every one of the 46 touched packages, run twice** (cold then warm results cache, which reorders files): **92 runs, 44/46 packages green on both runs.**
- `packages/marketing` runs two configs (`vitest run && vitest run --config vitest.svelte.config.ts`); both were run twice after the follow-up fix — default 15 passed / 1 skipped, svelte 5 passed.
- `packages/video` (the only behavior change) additionally passed **10 consecutive randomized file orders** (`--sequence.shuffle.files`, seeds 1-10) plus repeat sequential runs — 4 files / 31 tests every time.
- Full workspace `pnpm build` green (61/61 tasks).
- `npx biome check` on touched paths: these paths fall outside biome's configured `includes`, so there is nothing for it to enforce; no unrelated files were reformatted.

### The two non-green packages are pre-existing flakes, not regressions

`profiles` and `users` each failed one of their two runs, both in DuckDB OIDC tests (`profiles`: `serializes one issuer/subject ... across independent DuckDB handles`; `users`: `oidc-provisioning-safety`, `Catalog Error: Table with name sessions does not exist`). Both are in the **pure-deletion** set, so their effective Vitest config is unchanged.

Control run, to avoid asserting that from theory alone: `packages/users/vitest.config.ts` was restored to the **exact `origin/main` content** (dead key back in place) and the suite run 4 more times — **it still failed on run 4**. The flake reproduces on unmodified `main`, so it is pre-existing and independent of this change. The deletion was then re-applied. Worth a separate issue; not caused here.

## The real verification is the merge queue

**Local green does not prove this fix.** The failure is memory-pressure dependent and only reproduces under runner contention — the same commit passed all three shards at 10:54Z and died at 15:48Z. The merge-queue run under contention is the actual verification, not any local result in this PR.

## Review follow-up

Both reviewers caught the same real problem, and they were right: the first revision had updated the canonical doc snippets to show `isolate: false` unconditionally, which contradicted this PR's own conclusion and would have handed order-dependent failures to any package copying the template. Fixed in `6873bda17`.

Copilot also caught that `packages/marketing/vitest.svelte.config.ts` still carried the dead key — it is the only vitest config in the repo with a non-standard filename, so the `packages/*/vitest.config.ts` sweep missed it. Verified there are no other variants:

```
$ grep -rn "singleFork" packages/ --include="*.ts"
NONE
```

## Follow-up (not in this PR)

`vitest.config.ts` is excluded from both typecheck and lint across all 57 packages, so any future invalid Vitest option will be silently ignored the same way. Bringing these files under one of the two gates would turn this class of bug into a build error. Worth filing separately rather than widening this change.

The `profiles` / `users` DuckDB OIDC flakes documented above are also worth their own issue; they reproduce on unmodified `main`.

Closes #2144
