### PR TITLE
feat(auth): harden remote MCP authorization (#2151)

### DIFF
--- a/docs/content/architecture/remote-mcp-authorization.md
+++ b/docs/content/architecture/remote-mcp-authorization.md
@@ -1,0 +1,93 @@
+# Remote MCP authorization
+
+This is the deployment contract for Anytown, Ergot, and other applications that
+put a SMRT MCP HTTP surface on the public internet. SMRT currently supplies the
+application-scoped `/api/mcp/tools` and `/api/mcp/call` adapters and a local
+stdio bridge. It does **not** supply an OAuth authorization server or the MCP
+Streamable HTTP transport. Until the stateless transport lands, terminate OAuth
+at the application gateway and populate the authenticated SvelteKit principal
+only after token validation.
+
+## Authorization-server contract
+
+Use one stable HTTPS issuer identifier per authorization server. The gateway
+must validate token signature, `iss`, audience/resource, expiry, and scopes
+before a request reaches the MCP route. Never accept a token minted for another
+issuer or resource.
+
+The authorization server metadata must:
+
+- expose the exact issuer as `issuer`;
+- set `authorization_response_iss_parameter_supported: true` and include that
+  exact value as `iss` in successful and error authorization responses;
+- advertise `client_id_metadata_document_supported: true` when supported;
+- expose `registration_endpoint` only when RFC 7591 Dynamic Client Registration
+  is intentionally retained as a compatibility fallback.
+
+Clients compare response `iss` and discovered `issuer` with exact string
+comparison. A missing `iss` from a server that advertised support, or any
+mismatch (including a trailing-slash difference), aborts the grant before the
+authorization code is exchanged.
+
+## Client registration
+
+Prefer a pre-registered client when one exists. Otherwise use a Client ID
+Metadata Document; use DCR only when the authorization server does not advertise
+metadata-document support. `@happyvertical/smrt-app-cli` exports
+`resolveMcpClientRegistration()` to apply that order and
+`createMcpClientIdMetadataDocument()` to build the document.
+
+```ts
+const registration = resolveMcpClientRegistration(serverMetadata, {
+  applicationType: 'native',
+  clientId: 'https://client.anytown.example/oauth/mcp.json',
+  clientName: 'Anytown MCP Client',
+  redirectUris: ['http://127.0.0.1:3210/callback'],
+});
+```
+
+Host the returned metadata document at the exact HTTPS `clientId` URL. It must
+remain byte-for-byte identical in its `client_id` field. The helper's DCR
+fallback includes `application_type`, `grant_types`, `response_types`, and
+`token_endpoint_auth_method`; post that request only to the discovered
+`registration_endpoint`.
+
+## Application wiring
+
+For the current application adapters:
+
+1. Protect both `/api/mcp/tools` and `/api/mcp/call` at the same gateway.
+2. Validate the bearer token at the gateway and populate `event.locals.user`,
+   `tenantId`, and permissions from the validated principal. Header presence is
+   not authentication.
+3. Keep `publicToolPatterns` empty unless anonymous read access is deliberate.
+4. Preserve tenant isolation and the app allow-list for every tool invocation.
+5. Do not expose the generated stdio server remotely; stdio obtains credentials
+   from its environment and has no per-request OAuth principal.
+
+The app CLI and its stdio MCP bridge use SMRT's first-party terminal device flow,
+not the MCP authorization-code flow. The terminal start response emits an
+issuer, and stored bearer tokens are keyed by that exact issuer and sent only to
+the server saved with the login. `@happyvertical/smrt-agents` ships no MCP client
+or OAuth credential store, so RFC 9207 and client registration are not
+applicable to that package today.
+
+## Deployment verification
+
+Before promoting Anytown or Ergot:
+
+- fetch authorization-server metadata and assert the issuer and both advertised
+  capabilities match deployment policy;
+- have the authorization server fetch the HTTPS Client ID Metadata Document and
+  reject a request whose redirect URI is not listed;
+- exercise the DCR compatibility path, when enabled, and capture the received
+  request showing `application_type`;
+- confirm a callback with the expected `iss` succeeds, while missing and
+  mismatched `iss` values fail before the token endpoint is called;
+- log in the app CLI, switch its server URL, and confirm the prior bearer token
+  is not sent;
+- call a protected MCP tool with a valid token, a token from another issuer, a
+  token for another audience, and no token; only the first request may dispatch.
+
+Keep issuer metadata, client documents, and gateway policy in deployment source
+control. Never place client secrets or bearer tokens in the repository.

--- a/packages/app-cli/AGENTS.md
+++ b/packages/app-cli/AGENTS.md
@@ -13,6 +13,8 @@ Application CLI support for SMRT-based apps.
 - Keep commands app-agnostic; pass app identity through `CliConfigContext`.
 - Treat transient auth polling failures as recoverable until the server-issued expiration window closes.
 - Do not persist tokens, server URLs, or app slugs outside the configured local CLI config path.
+- Bind persisted bearer tokens to the exact issuer emitted by the device flow
+  and to the server selected during login. Never reuse them after either changes.
 - Keep command output stream-injectable so tests can assert behavior without writing to the real terminal.
 
 ## Gotchas

--- a/packages/app-cli/README.md
+++ b/packages/app-cli/README.md
@@ -90,6 +90,13 @@ surface is typically mounted with
 - Device-code login distinguishes pending approval, expiry, transient network
   failure, and hard rejection.
 - Tokens and server configuration stay in the app-specific local config path.
+- Device-flow responses identify their issuer. Tokens are keyed by that exact
+  issuer and are not reused when the configured server changes.
+
+For standards-based remote MCP OAuth registration, use
+`registerMcpClient()` (Client ID Metadata Document first, executable RFC 7591
+DCR fallback with `application_type`) and follow the
+[remote MCP authorization guide](../../docs/content/architecture/remote-mcp-authorization.md).
 
 ## Public API
 
@@ -101,6 +108,8 @@ surface is typically mounted with
 | `invokeCommand()` | Invoke one generated resource command |
 | `buildFlagParser()` | Convert supported JSON Schema to flags |
 | `loadCliConfig()` / `saveCliConfig()` | Read and write namespaced CLI config |
+| `resolveMcpClientRegistration()` | Inspect the selected Client ID Metadata or DCR path |
+| `registerMcpClient()` | Use Client ID Metadata or execute the DCR fallback |
 
 ## Development
 

--- a/packages/app-cli/src/__tests__/config.test.ts
+++ b/packages/app-cli/src/__tests__/config.test.ts
@@ -47,11 +47,15 @@ describe('config persistence', () => {
     expect(s.mode & 0o777).toBe(0o600);
     const raw = JSON.parse(await readFile(path, 'utf8'));
     expect(raw.serverUrl).toBe('https://example.test');
-    expect(raw.token).toBe('tok_abc');
+    expect(raw.credentialIssuer).toBe('https://example.test');
+    expect(raw.tokensByIssuer).toEqual({
+      'https://example.test': 'tok_abc',
+    });
     const loaded = await loadCliConfig(context);
     expect(loaded).toEqual({
+      credentialIssuer: 'https://example.test',
       serverUrl: 'https://example.test',
-      token: 'tok_abc',
+      tokensByIssuer: { 'https://example.test': 'tok_abc' },
     });
   });
 
@@ -125,7 +129,60 @@ describe('env var precedence', () => {
   it('env token wins over config token', async () => {
     await saveAuth(context, 'https://x', 'tok_cfg');
     process.env.TESTCFG_TOKEN = 'tok_env';
+    process.env.TESTCFG_SERVER_URL = 'https://x';
     expect(await getStoredToken(context)).toBe('tok_env');
+  });
+
+  it('requires an environment token to be bound to the exact environment server', async () => {
+    process.env.TESTCFG_TOKEN = 'tok_env';
+    process.env.TESTCFG_SERVER_URL = 'https://issuer-a.example';
+
+    expect(
+      await getStoredToken(context, undefined, 'https://issuer-a.example'),
+    ).toBe('tok_env');
+    expect(
+      await getStoredToken(context, undefined, 'https://issuer-b.example'),
+    ).toBeUndefined();
+
+    delete process.env.TESTCFG_SERVER_URL;
+    expect(
+      await getStoredToken(context, undefined, 'https://issuer-a.example'),
+    ).toBeUndefined();
+  });
+
+  it('does not reuse an issuer-bound token when the target server changes', async () => {
+    await saveAuth(
+      context,
+      'https://resource.example',
+      'tok_issuer_a',
+      'https://issuer-a.example',
+    );
+
+    expect(await getStoredToken(context)).toBe('tok_issuer_a');
+    process.env.TESTCFG_SERVER_URL = 'https://other-resource.example';
+    expect(await getStoredToken(context)).toBeUndefined();
+  });
+
+  it('replaces rather than reuses credentials when an issuer changes', async () => {
+    await saveAuth(
+      context,
+      'https://resource.example',
+      'tok_issuer_a',
+      'https://issuer-a.example',
+    );
+    await saveAuth(
+      context,
+      'https://resource.example',
+      'tok_issuer_b',
+      'https://issuer-b.example',
+    );
+
+    const config = await loadCliConfig(context);
+    expect(config.credentialIssuer).toBe('https://issuer-b.example');
+    expect(config.tokensByIssuer).toEqual({
+      'https://issuer-b.example': 'tok_issuer_b',
+    });
+    expect(await getStoredToken(context, config)).toBe('tok_issuer_b');
   });
 });
 
@@ -148,6 +205,28 @@ describe('requestJson', () => {
       { fetch: fetchMock as any },
     );
     expect(r).toEqual({ ok: true });
+  });
+
+  it('does not send an environment bearer token to a request-level server override', async () => {
+    process.env.TESTCFG_TOKEN = 'tok_issuer_a';
+    process.env.TESTCFG_SERVER_URL = 'https://issuer-a.example';
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      expect((init.headers as Headers).has('authorization')).toBe(false);
+      return new Response('{"ok":true}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    await requestJson(
+      context,
+      '/test',
+      { method: 'GET' },
+      {
+        fetch: fetchMock as any,
+        serverUrl: 'https://issuer-b.example',
+      },
+    );
   });
 
   it('throws on 401 with server error message', async () => {

--- a/packages/app-cli/src/__tests__/mcp-oauth.test.ts
+++ b/packages/app-cli/src/__tests__/mcp-oauth.test.ts
@@ -161,7 +161,11 @@ describe('MCP OAuth client registration', () => {
 
     const dcr = await registerMcpClient(
       { registration_endpoint: registrationEndpoint },
-      client,
+      {
+        applicationType: client.applicationType,
+        clientName: client.clientName,
+        redirectUris: client.redirectUris,
+      },
     );
     expect(dcr).toMatchObject({
       clientId: 'reference-dcr-client',

--- a/packages/app-cli/src/__tests__/mcp-oauth.test.ts
+++ b/packages/app-cli/src/__tests__/mcp-oauth.test.ts
@@ -1,0 +1,177 @@
+import { createServer } from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createMcpClientIdMetadataDocument,
+  type McpClientIdMetadataDocument,
+  registerMcpClient,
+  resolveMcpClientRegistration,
+} from '../mcp-oauth.js';
+
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve())),
+      ),
+  );
+});
+
+const client = {
+  applicationType: 'native' as const,
+  clientId: 'https://client.example/oauth/mcp.json',
+  clientName: 'Reference MCP Client',
+  redirectUris: ['http://127.0.0.1:3210/callback'],
+};
+
+describe('MCP OAuth client registration', () => {
+  it('uses a valid Client ID Metadata Document as the primary path', () => {
+    const registration = resolveMcpClientRegistration(
+      {
+        client_id_metadata_document_supported: true,
+        registration_endpoint: 'https://issuer.example/register',
+      },
+      client,
+    );
+
+    expect(registration).toEqual({
+      clientId: client.clientId,
+      kind: 'client_id_metadata_document',
+      metadataDocument: {
+        application_type: 'native',
+        client_id: client.clientId,
+        client_name: client.clientName,
+        grant_types: ['authorization_code'],
+        redirect_uris: client.redirectUris,
+        response_types: ['code'],
+        token_endpoint_auth_method: 'none',
+      },
+    });
+  });
+
+  it('retains application_type in the RFC 7591 DCR fallback', () => {
+    const registration = resolveMcpClientRegistration(
+      { registration_endpoint: 'https://issuer.example/register' },
+      client,
+    );
+
+    expect(registration.kind).toBe('dynamic_client_registration');
+    if (registration.kind !== 'dynamic_client_registration') return;
+    expect(registration.request.application_type).toBe('native');
+    expect(registration.request).not.toHaveProperty('client_id');
+  });
+
+  it('rejects a metadata client_id that is not an HTTPS document URL', () => {
+    expect(() =>
+      createMcpClientIdMetadataDocument({
+        ...client,
+        clientId: 'http://client.example/oauth/mcp.json',
+      }),
+    ).toThrow('must use HTTPS');
+  });
+
+  it('interoperates with a reference server using CIMD first and a real DCR POST as fallback', async () => {
+    const requests: Record<string, unknown>[] = [];
+    let hostedDocument: McpClientIdMetadataDocument | undefined;
+    let referenceOrigin = '';
+    const referenceServer = createServer((request, response) => {
+      if (request.url === '/client.json' && request.method === 'GET') {
+        response
+          .writeHead(hostedDocument ? 200 : 404, {
+            'content-type': 'application/json',
+          })
+          .end(hostedDocument ? JSON.stringify(hostedDocument) : undefined);
+        return;
+      }
+      if (request.url?.startsWith('/authorize?') && request.method === 'GET') {
+        void (async () => {
+          const clientId = new URL(
+            request.url ?? '',
+            referenceOrigin,
+          ).searchParams.get('client_id');
+          // The localhost route stands in for DNS routing to the public HTTPS
+          // client_id while retaining the exact public identifier in the body.
+          const metadataResponse = await fetch(
+            `${referenceOrigin}/client.json`,
+          );
+          const metadata = (await metadataResponse.json()) as Record<
+            string,
+            unknown
+          >;
+          if (metadata.client_id !== clientId) {
+            response.writeHead(400).end();
+            return;
+          }
+          response.writeHead(204).end();
+        })().catch(() => response.writeHead(500).end());
+        return;
+      }
+      if (request.url !== '/register' || request.method !== 'POST') {
+        response.writeHead(404).end();
+        return;
+      }
+      let body = '';
+      request.setEncoding('utf8');
+      request.on('data', (chunk) => {
+        body += chunk;
+      });
+      request.on('end', () => {
+        const registration = JSON.parse(body) as Record<string, unknown>;
+        requests.push(registration);
+        if (
+          registration.application_type !== 'native' ||
+          'client_id' in registration
+        ) {
+          response.writeHead(400).end();
+          return;
+        }
+        response
+          .writeHead(201, { 'content-type': 'application/json' })
+          .end(JSON.stringify({ client_id: 'reference-dcr-client' }));
+      });
+    });
+    servers.push(referenceServer);
+    await new Promise<void>((resolve) =>
+      referenceServer.listen(0, '127.0.0.1', resolve),
+    );
+    const address = referenceServer.address();
+    if (!address || typeof address === 'string') throw new Error('no address');
+    referenceOrigin = `http://127.0.0.1:${address.port}`;
+    const registrationEndpoint = `${referenceOrigin}/register`;
+
+    const cimd = await registerMcpClient(
+      {
+        client_id_metadata_document_supported: true,
+        registration_endpoint: registrationEndpoint,
+      },
+      client,
+    );
+    expect(cimd.kind).toBe('client_id_metadata_document');
+    expect(cimd.clientId).toBe(client.clientId);
+    expect(cimd.metadataDocument?.client_id).toBe(client.clientId);
+    expect(requests).toHaveLength(0);
+    hostedDocument = cimd.metadataDocument;
+    const authorization = await fetch(
+      `${referenceOrigin}/authorize?client_id=${encodeURIComponent(cimd.clientId)}`,
+    );
+    expect(authorization.status).toBe(204);
+
+    const dcr = await registerMcpClient(
+      { registration_endpoint: registrationEndpoint },
+      client,
+    );
+    expect(dcr).toMatchObject({
+      clientId: 'reference-dcr-client',
+      kind: 'dynamic_client_registration',
+    });
+    expect(requests).toEqual([
+      expect.objectContaining({
+        application_type: 'native',
+        client_name: client.clientName,
+      }),
+    ]);
+  });
+});

--- a/packages/app-cli/src/commands/auth.ts
+++ b/packages/app-cli/src/commands/auth.ts
@@ -20,6 +20,7 @@ interface AuthStartResponse {
   deviceCode: string;
   expiresAt: string;
   interval?: number;
+  issuer?: string;
   userCode: string;
   verificationUrl: string;
 }
@@ -90,7 +91,12 @@ export async function runAuthLogin(
       );
 
       if (token.status === 'approved' && token.accessToken) {
-        await saveAuth(options.context, targetServer, token.accessToken);
+        await saveAuth(
+          options.context,
+          targetServer,
+          token.accessToken,
+          start.issuer ?? targetServer,
+        );
         stdout.write(`Authenticated to ${targetServer}\n`);
         return;
       }

--- a/packages/app-cli/src/config.ts
+++ b/packages/app-cli/src/config.ts
@@ -187,7 +187,7 @@ export async function clearStoredToken(
   await saveCliConfig(context, config);
 }
 
-/** Persist a login: writes both serverUrl and token to the config file. */
+/** Persist a login with the bearer token keyed by its exact issuer. */
 export async function saveAuth(
   context: CliConfigContext,
   serverUrl: string,

--- a/packages/app-cli/src/config.ts
+++ b/packages/app-cli/src/config.ts
@@ -23,8 +23,13 @@ import { dirname, join } from 'node:path';
 
 /** Shape stored on disk in the app's CLI config file. */
 export interface CliConfig {
+  /** Issuer selected for the currently configured server. */
+  credentialIssuer?: string;
   serverUrl?: string;
+  /** Legacy single-token field. Read only when its stored server still matches. */
   token?: string;
+  /** Bearer credentials keyed by their exact issuer identifier. */
+  tokensByIssuer?: Record<string, string>;
 }
 
 /**
@@ -136,13 +141,34 @@ export async function getServerUrl(
   return url.replace(/\/+$/u, '');
 }
 
-/** Resolve the stored bearer token (env var wins over config). */
+/** Resolve a bearer token only when it is bound to the exact target server. */
 export async function getStoredToken(
   context: CliConfigContext,
   config?: CliConfig,
+  serverUrl?: string,
 ): Promise<string | undefined> {
   const resolved = config ?? (await loadCliConfig(context));
-  return process.env[`${context.envPrefix}_TOKEN`] ?? resolved.token;
+  const targetServer = (
+    serverUrl ?? (await getServerUrl(context, resolved))
+  ).replace(/\/+$/u, '');
+  const environmentToken = process.env[`${context.envPrefix}_TOKEN`];
+  const environmentServer = process.env[
+    `${context.envPrefix}_SERVER_URL`
+  ]?.replace(/\/+$/u, '');
+  if (environmentToken) {
+    return environmentServer === targetServer ? environmentToken : undefined;
+  }
+
+  const configuredServer = resolved.serverUrl?.replace(/\/+$/u, '');
+  if (!configuredServer || configuredServer !== targetServer) return undefined;
+
+  if (resolved.credentialIssuer) {
+    return resolved.tokensByIssuer?.[resolved.credentialIssuer];
+  }
+
+  // Legacy configs predate issuer-keyed storage. They remain usable only for
+  // the exact server saved alongside the token and migrate on the next login.
+  return resolved.token;
 }
 
 /** Remove the token from the config file (e.g. on logout). */
@@ -150,6 +176,13 @@ export async function clearStoredToken(
   context: CliConfigContext,
 ): Promise<void> {
   const config = await loadCliConfig(context);
+  if (config.credentialIssuer && config.tokensByIssuer) {
+    delete config.tokensByIssuer[config.credentialIssuer];
+    if (Object.keys(config.tokensByIssuer).length === 0) {
+      delete config.tokensByIssuer;
+    }
+  }
+  delete config.credentialIssuer;
   delete config.token;
   await saveCliConfig(context, config);
 }
@@ -159,12 +192,20 @@ export async function saveAuth(
   context: CliConfigContext,
   serverUrl: string,
   token: string,
+  issuer = serverUrl,
 ): Promise<void> {
   const config = await loadCliConfig(context);
+  const normalizedServerUrl = serverUrl.replace(/\/+$/u, '');
+  if (!issuer.trim()) throw new Error('Credential issuer must not be empty.');
+  const exactIssuer = issuer;
   await saveCliConfig(context, {
     ...config,
-    serverUrl: serverUrl.replace(/\/+$/u, ''),
-    token,
+    credentialIssuer: exactIssuer,
+    serverUrl: normalizedServerUrl,
+    token: undefined,
+    tokensByIssuer: {
+      [exactIssuer]: token,
+    },
   });
 }
 
@@ -221,7 +262,7 @@ export async function requestJson<T = unknown>(
   const serverUrl = (
     options.serverUrl ?? (await getServerUrl(context, config))
   ).replace(/\/+$/u, '');
-  const token = await getStoredToken(context, config);
+  const token = await getStoredToken(context, config, serverUrl);
   const headers = new Headers(init.headers);
 
   if (options.requireAuth && options.auth !== false && !token) {

--- a/packages/app-cli/src/index.ts
+++ b/packages/app-cli/src/index.ts
@@ -57,6 +57,17 @@ export {
   type ResourceListResponse,
 } from './discovery.js';
 export { buildUrl, invokeCommand } from './invoke.js';
+export {
+  createMcpClientIdMetadataDocument,
+  type McpClientIdMetadataDocument,
+  type McpClientRegistration,
+  type McpClientRegistrationOptions,
+  type McpRegisteredClient,
+  type OAuthApplicationType,
+  type OAuthAuthorizationServerMetadata,
+  registerMcpClient,
+  resolveMcpClientRegistration,
+} from './mcp-oauth.js';
 export { type RenderResult, renderResponse } from './output.js';
 export {
   type BuildParserResult,

--- a/packages/app-cli/src/mcp-oauth.ts
+++ b/packages/app-cli/src/mcp-oauth.ts
@@ -1,0 +1,158 @@
+/** MCP OAuth client-registration helpers for remote HTTP deployments. */
+
+export type OAuthApplicationType = 'native' | 'web';
+
+export interface McpClientIdMetadataDocument {
+  application_type: OAuthApplicationType;
+  client_id: string;
+  client_name: string;
+  grant_types: ['authorization_code'];
+  redirect_uris: string[];
+  response_types: ['code'];
+  token_endpoint_auth_method: 'none';
+}
+
+export interface OAuthAuthorizationServerMetadata {
+  client_id_metadata_document_supported?: boolean;
+  registration_endpoint?: string;
+}
+
+export interface McpClientRegistrationOptions {
+  applicationType: OAuthApplicationType;
+  clientId: string;
+  clientName: string;
+  redirectUris: string[];
+}
+
+export type McpClientRegistration =
+  | {
+      clientId: string;
+      kind: 'client_id_metadata_document';
+      metadataDocument: McpClientIdMetadataDocument;
+    }
+  | {
+      endpoint: string;
+      kind: 'dynamic_client_registration';
+      request: Omit<McpClientIdMetadataDocument, 'client_id'>;
+    };
+
+export interface McpRegisteredClient {
+  clientId: string;
+  kind: McpClientRegistration['kind'];
+  metadataDocument?: McpClientIdMetadataDocument;
+  registrationResponse?: Record<string, unknown>;
+}
+
+/** Build and validate the document hosted at an HTTPS URL used as client_id. */
+export function createMcpClientIdMetadataDocument(
+  options: McpClientRegistrationOptions,
+): McpClientIdMetadataDocument {
+  const clientId = new URL(options.clientId);
+  if (clientId.protocol !== 'https:' || clientId.pathname === '/') {
+    throw new Error(
+      'MCP client_id metadata URL must use HTTPS and include a path.',
+    );
+  }
+  if (clientId.search || clientId.hash) {
+    throw new Error(
+      'MCP client_id metadata URL must not include query or fragment.',
+    );
+  }
+  if (!options.clientName.trim()) {
+    throw new Error('MCP client_name must not be empty.');
+  }
+  if (options.redirectUris.length === 0) {
+    throw new Error('MCP client metadata requires at least one redirect URI.');
+  }
+  for (const redirectUri of options.redirectUris) new URL(redirectUri);
+
+  return {
+    application_type: options.applicationType,
+    client_id: options.clientId,
+    client_name: options.clientName,
+    grant_types: ['authorization_code'],
+    redirect_uris: [...options.redirectUris],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none',
+  };
+}
+
+/**
+ * Select registration in MCP priority order: Client ID Metadata Documents
+ * first, then RFC 7591 DCR as a compatibility fallback.
+ */
+export function resolveMcpClientRegistration(
+  authorizationServer: OAuthAuthorizationServerMetadata,
+  options: McpClientRegistrationOptions,
+): McpClientRegistration {
+  const metadataDocument = createMcpClientIdMetadataDocument(options);
+  if (authorizationServer.client_id_metadata_document_supported === true) {
+    return {
+      clientId: metadataDocument.client_id,
+      kind: 'client_id_metadata_document',
+      metadataDocument,
+    };
+  }
+
+  if (authorizationServer.registration_endpoint) {
+    const { client_id: _clientId, ...request } = metadataDocument;
+    return {
+      endpoint: authorizationServer.registration_endpoint,
+      kind: 'dynamic_client_registration',
+      request,
+    };
+  }
+
+  throw new Error(
+    'Authorization server supports neither Client ID Metadata Documents nor dynamic client registration.',
+  );
+}
+
+/**
+ * Complete client registration against discovered authorization-server
+ * metadata. A Client ID Metadata Document needs no registration request: the
+ * authorization server retrieves it from the HTTPS client_id. The legacy DCR
+ * fallback is executed as an RFC 7591 JSON POST.
+ */
+export async function registerMcpClient(
+  authorizationServer: OAuthAuthorizationServerMetadata,
+  options: McpClientRegistrationOptions,
+  fetchImpl: typeof fetch = fetch,
+): Promise<McpRegisteredClient> {
+  const registration = resolveMcpClientRegistration(
+    authorizationServer,
+    options,
+  );
+  if (registration.kind === 'client_id_metadata_document') {
+    return {
+      clientId: registration.clientId,
+      kind: registration.kind,
+      metadataDocument: registration.metadataDocument,
+    };
+  }
+
+  const response = await fetchImpl(registration.endpoint, {
+    body: JSON.stringify(registration.request),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST',
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Dynamic client registration failed: HTTP ${response.status}`,
+    );
+  }
+  const body: unknown = await response.json();
+  if (
+    typeof body !== 'object' ||
+    body === null ||
+    typeof (body as Record<string, unknown>).client_id !== 'string' ||
+    !(body as Record<string, unknown>).client_id
+  ) {
+    throw new Error('Dynamic client registration response omitted client_id.');
+  }
+  return {
+    clientId: (body as Record<string, unknown>).client_id as string,
+    kind: registration.kind,
+    registrationResponse: body as Record<string, unknown>,
+  };
+}

--- a/packages/app-cli/src/mcp-oauth.ts
+++ b/packages/app-cli/src/mcp-oauth.ts
@@ -19,7 +19,8 @@ export interface OAuthAuthorizationServerMetadata {
 
 export interface McpClientRegistrationOptions {
   applicationType: OAuthApplicationType;
-  clientId: string;
+  /** HTTPS metadata-document URL. Required only when CIMD is advertised. */
+  clientId?: string;
   clientName: string;
   redirectUris: string[];
 }
@@ -43,10 +44,36 @@ export interface McpRegisteredClient {
   registrationResponse?: Record<string, unknown>;
 }
 
+type McpRegistrationRequest = Omit<McpClientIdMetadataDocument, 'client_id'>;
+
+function createMcpRegistrationRequest(
+  options: McpClientRegistrationOptions,
+): McpRegistrationRequest {
+  if (!options.clientName.trim()) {
+    throw new Error('MCP client_name must not be empty.');
+  }
+  if (options.redirectUris.length === 0) {
+    throw new Error('MCP client metadata requires at least one redirect URI.');
+  }
+  for (const redirectUri of options.redirectUris) new URL(redirectUri);
+
+  return {
+    application_type: options.applicationType,
+    client_name: options.clientName,
+    grant_types: ['authorization_code'],
+    redirect_uris: [...options.redirectUris],
+    response_types: ['code'],
+    token_endpoint_auth_method: 'none',
+  };
+}
+
 /** Build and validate the document hosted at an HTTPS URL used as client_id. */
 export function createMcpClientIdMetadataDocument(
   options: McpClientRegistrationOptions,
 ): McpClientIdMetadataDocument {
+  if (!options.clientId) {
+    throw new Error('MCP client_id metadata URL is required for CIMD.');
+  }
   const clientId = new URL(options.clientId);
   if (clientId.protocol !== 'https:' || clientId.pathname === '/') {
     throw new Error(
@@ -58,22 +85,9 @@ export function createMcpClientIdMetadataDocument(
       'MCP client_id metadata URL must not include query or fragment.',
     );
   }
-  if (!options.clientName.trim()) {
-    throw new Error('MCP client_name must not be empty.');
-  }
-  if (options.redirectUris.length === 0) {
-    throw new Error('MCP client metadata requires at least one redirect URI.');
-  }
-  for (const redirectUri of options.redirectUris) new URL(redirectUri);
-
   return {
-    application_type: options.applicationType,
+    ...createMcpRegistrationRequest(options),
     client_id: options.clientId,
-    client_name: options.clientName,
-    grant_types: ['authorization_code'],
-    redirect_uris: [...options.redirectUris],
-    response_types: ['code'],
-    token_endpoint_auth_method: 'none',
   };
 }
 
@@ -85,8 +99,8 @@ export function resolveMcpClientRegistration(
   authorizationServer: OAuthAuthorizationServerMetadata,
   options: McpClientRegistrationOptions,
 ): McpClientRegistration {
-  const metadataDocument = createMcpClientIdMetadataDocument(options);
   if (authorizationServer.client_id_metadata_document_supported === true) {
+    const metadataDocument = createMcpClientIdMetadataDocument(options);
     return {
       clientId: metadataDocument.client_id,
       kind: 'client_id_metadata_document',
@@ -95,11 +109,10 @@ export function resolveMcpClientRegistration(
   }
 
   if (authorizationServer.registration_endpoint) {
-    const { client_id: _clientId, ...request } = metadataDocument;
     return {
       endpoint: authorizationServer.registration_endpoint,
       kind: 'dynamic_client_registration',
-      request,
+      request: createMcpRegistrationRequest(options),
     };
   }
 

--- a/packages/smrt-app-mcp/README.md
+++ b/packages/smrt-app-mcp/README.md
@@ -7,6 +7,16 @@ App-runtime MCP server scaffolding for s-m-r-t apps. Provides:
 
 For piping a deployed app's MCP surface to a local stdio MCP client, see `@happyvertical/smrt-app-cli` — the client-side runtime CLI exposes a `startMcpBridge()` default and a generic `smrt-mcp-bridge` bin.
 
+For public deployments, follow the
+[remote MCP authorization contract](../../docs/content/architecture/remote-mcp-authorization.md).
+This package trusts the principal supplied by the application adapter; it does
+not implement an OAuth authorization server or validate bearer tokens itself.
+
+For public deployments, follow the
+[remote MCP authorization contract](../../docs/content/architecture/remote-mcp-authorization.md).
+This package trusts the principal supplied by the application adapter; it does
+not implement an OAuth authorization server or validate bearer tokens itself.
+
 ```ts
 // src/lib/server/mcp.ts
 import { createMcpAppServer, McpAccessError } from '@happyvertical/smrt-app-mcp';
@@ -49,7 +59,6 @@ import { mountMcpCallRoute } from '@happyvertical/smrt-app-mcp/sveltekit';
 import { mcpServer } from '$lib/server/mcp';
 export const POST = mountMcpCallRoute(mcpServer);
 ```
-
 `toolPolicy` is evaluated for every tool eligible under the allow-list and
 base public/authenticated rule, on both discovery and a direct call. Return
 `false` to hide the tool from discovery and deny a direct call with the safe,

--- a/packages/smrt-app-mcp/README.md
+++ b/packages/smrt-app-mcp/README.md
@@ -12,11 +12,6 @@ For public deployments, follow the
 This package trusts the principal supplied by the application adapter; it does
 not implement an OAuth authorization server or validate bearer tokens itself.
 
-For public deployments, follow the
-[remote MCP authorization contract](../../docs/content/architecture/remote-mcp-authorization.md).
-This package trusts the principal supplied by the application adapter; it does
-not implement an OAuth authorization server or validate bearer tokens itself.
-
 ```ts
 // src/lib/server/mcp.ts
 import { createMcpAppServer, McpAccessError } from '@happyvertical/smrt-app-mcp';
@@ -59,6 +54,7 @@ import { mountMcpCallRoute } from '@happyvertical/smrt-app-mcp/sveltekit';
 import { mcpServer } from '$lib/server/mcp';
 export const POST = mountMcpCallRoute(mcpServer);
 ```
+
 `toolPolicy` is evaluated for every tool eligible under the allow-list and
 base public/authenticated rule, on both discovery and a direct call. Return
 `false` to hide the tool from discovery and deny a direct call with the safe,

--- a/packages/users/AGENTS.md
+++ b/packages/users/AGENTS.md
@@ -240,6 +240,10 @@ the package root).
   refuses to provision a user when the IdP explicitly returns
   `email_verified: false` (opt out with `{ allowUnverifiedEmail: true }`). An
   absent claim makes no assertion and is not enforced.
+- **RFC 9207 response issuer is exact.** OIDC callbacks validate a supplied
+  `iss` against discovered metadata with exact string comparison before trusting
+  a code or error. If metadata advertises issuer-response support, `iss` is
+  required.
 - **Verified-email Profile reuse is fail-closed.** The typed canonical scenarios
   live in
   `packages/profiles/src/testing/oidcProvisioningDecisionMatrix.ts`; both

--- a/packages/users/README.md
+++ b/packages/users/README.md
@@ -374,6 +374,14 @@ can pass `transactionCookieSecret` to the route helpers. On success it creates
 or reuses a s-m-r-t `Profile`, links an `OidcIdentity`, creates or reuses a `User`,
 records `lastLoginAt`, and sets the standard s-m-r-t session cookie.
 
+RFC 9207 authorization-response issuer validation uses exact string comparison
+against the discovered issuer before an authorization code or provider error is
+trusted. When discovery advertises
+`authorization_response_iss_parameter_supported: true`, a missing `iss` is also
+rejected. Remote MCP deployments must require their external authorization
+server to advertise and emit `iss`; see the
+[remote MCP authorization guide](../../docs/content/architecture/remote-mcp-authorization.md).
+
 The typed [OIDC provisioning decision matrix](../profiles/src/testing/oidcProvisioningDecisionMatrix.ts)
 is the canonical behavior contract shared with Profiles. Its executable rows
 declare exact reuse and new-identity outcomes, resolver invocation and

--- a/packages/users/src/__tests__/helpers/oidc-test-server.ts
+++ b/packages/users/src/__tests__/helpers/oidc-test-server.ts
@@ -22,6 +22,7 @@ import { exportJWK, generateKeyPair, SignJWT } from 'jose';
 import { USER_EMAIL_KEY_BACKFILL_NAME } from '../../migrations/backfillUserEmailKeys.js';
 
 export interface OidcTestServerOptions {
+  authorizationResponseIssuerSupported?: boolean;
   audience?: string | string[];
   authorizedParty?: string;
   idTokenEmailVerified?: boolean;
@@ -226,6 +227,12 @@ export async function startOidcServer(
 
     if (url.pathname === '/.well-known/openid-configuration') {
       sendJson(response, 200, {
+        ...(options.authorizationResponseIssuerSupported === undefined
+          ? {}
+          : {
+              authorization_response_iss_parameter_supported:
+                options.authorizationResponseIssuerSupported,
+            }),
         authorization_endpoint: `${issuer}/authorize`,
         issuer,
         jwks_uri: `${issuer}/jwks`,

--- a/packages/users/src/__tests__/oidc-login-service.test.ts
+++ b/packages/users/src/__tests__/oidc-login-service.test.ts
@@ -350,6 +350,29 @@ describe('OidcLoginService', () => {
     expect(server.tokenRequests).toHaveLength(0);
   });
 
+  it('rejects an invalid callback envelope before OIDC discovery', async () => {
+    const fetchMock = vi.fn();
+    const service = new OidcLoginService({
+      db: { type: 'sqlite', url: ':memory:' },
+      fetch: fetchMock,
+      provider: {
+        clientId: 'smrt-client',
+        issuer: 'https://issuer.example',
+        redirectUri: 'https://app.example/auth/dex/callback',
+      },
+      providerName: 'dex',
+    });
+    const transaction = service.createTransaction();
+    const callback = new URL(
+      `https://app.example/auth/dex/callback?code=code&state=attacker-state`,
+    );
+
+    await expect(
+      service.exchangeCallback(callback, transaction),
+    ).rejects.toThrow('state validation failed');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('validates RFC 9207 iss before trusting an authorization error', async () => {
     const server = await startOidcServer({
       authorizationResponseIssuerSupported: true,

--- a/packages/users/src/__tests__/oidc-login-service.test.ts
+++ b/packages/users/src/__tests__/oidc-login-service.test.ts
@@ -263,7 +263,9 @@ describe('OidcLoginService', () => {
   });
 
   it('exchanges a Dex-compatible callback, verifies the ID token, and creates a SMRT user', async () => {
-    const server = await startOidcServer();
+    const server = await startOidcServer({
+      authorizationResponseIssuerSupported: true,
+    });
     cleanup.push(server.close);
     const isolated = await createOidcTestDb();
     cleanup.push(isolated.cleanup);
@@ -313,6 +315,66 @@ describe('OidcLoginService', () => {
 
     const fetchUrls = fetchSpy.mock.calls.map(([input]) => toFetchUrl(input));
     expect(fetchUrls).toContain(`${server.issuer}/jwks`);
+  });
+
+  it('requires and exactly matches RFC 9207 iss when the provider advertises support', async () => {
+    const server = await startOidcServer({
+      authorizationResponseIssuerSupported: true,
+    });
+    cleanup.push(server.close);
+    const service = new OidcLoginService({
+      db: { type: 'sqlite', url: ':memory:' },
+      provider: {
+        clientId: 'smrt-client',
+        issuer: server.issuer,
+        redirectUri: `${server.issuer}/auth/dex/callback`,
+        tokenEndpointAuthMethod: 'none',
+      },
+      providerName: 'dex',
+    });
+    const transaction = service.createTransaction();
+
+    const missingIssuer = new URL(
+      `${server.issuer}/auth/dex/callback?code=code&state=${transaction.state}`,
+    );
+    await expect(
+      service.exchangeCallback(missingIssuer, transaction),
+    ).rejects.toThrow('missing authorization response issuer');
+
+    const normalizedButNotExact = new URL(missingIssuer);
+    normalizedButNotExact.searchParams.set('iss', `${server.issuer}/`);
+    await expect(
+      service.exchangeCallback(normalizedButNotExact, transaction),
+    ).rejects.toThrow('issuer validation failed');
+
+    expect(server.tokenRequests).toHaveLength(0);
+  });
+
+  it('validates RFC 9207 iss before trusting an authorization error', async () => {
+    const server = await startOidcServer({
+      authorizationResponseIssuerSupported: true,
+    });
+    cleanup.push(server.close);
+    const service = new OidcLoginService({
+      db: { type: 'sqlite', url: ':memory:' },
+      provider: {
+        clientId: 'smrt-client',
+        issuer: server.issuer,
+        redirectUri: `${server.issuer}/auth/dex/callback`,
+        tokenEndpointAuthMethod: 'none',
+      },
+      providerName: 'dex',
+    });
+    const transaction = service.createTransaction();
+    const callback = new URL(`${server.issuer}/auth/dex/callback`);
+    callback.searchParams.set('error', 'access_denied');
+    callback.searchParams.set('error_description', 'untrusted description');
+    callback.searchParams.set('iss', 'https://attacker.example');
+    callback.searchParams.set('state', transaction.state);
+
+    await expect(
+      service.exchangeCallback(callback, transaction),
+    ).rejects.toThrow('issuer validation failed');
   });
 
   it('runs a pre-provision resolver inside the stock token-exchange flow', async () => {

--- a/packages/users/src/__tests__/terminal-auth-handlers.test.ts
+++ b/packages/users/src/__tests__/terminal-auth-handlers.test.ts
@@ -96,6 +96,7 @@ describe('terminal-auth SvelteKit handlers', () => {
     const body = (await response.json()) as Record<string, unknown>;
     expect(body.userCode).toMatch(/^WG-[0-9A-F]{8}$/u);
     expect(typeof body.deviceCode).toBe('string');
+    expect(body.issuer).toBe('https://example.com');
     expect(body.verificationUrl).toBe(
       `https://example.com/terminal-login?code=${encodeURIComponent(String(body.userCode))}`,
     );

--- a/packages/users/src/services/OidcLoginService.ts
+++ b/packages/users/src/services/OidcLoginService.ts
@@ -92,6 +92,7 @@ export interface ResolvedOidcProviderConfig extends OidcProviderConfig {
 }
 
 export interface OidcProviderMetadata {
+  authorization_response_iss_parameter_supported?: boolean;
   authorization_endpoint: string;
   end_session_endpoint?: string;
   issuer: string;
@@ -613,7 +614,8 @@ export class OidcLoginService {
     callbackUrl: string | URL,
     transaction: OidcTransaction,
   ): Promise<OidcCallbackResult> {
-    const code = this.validateCallback(callbackUrl, transaction);
+    const metadata = await this.getMetadata();
+    const code = this.validateCallback(callbackUrl, transaction, metadata);
     const tokens = await this.exchangeCode(code, transaction);
     const idTokenClaims = await this.verifyIdToken(
       tokens.idToken,
@@ -648,12 +650,31 @@ export class OidcLoginService {
   private validateCallback(
     callbackUrl: string | URL,
     transaction: OidcTransaction,
+    metadata: OidcProviderMetadata,
   ): string {
     if (transaction.provider !== this.providerName) {
       throw new OidcLoginError('OIDC login transaction provider mismatch.');
     }
 
     const url = callbackUrl instanceof URL ? callbackUrl : new URL(callbackUrl);
+    const state = url.searchParams.get('state');
+    if (!state || state !== transaction.state) {
+      throw new OidcLoginError('OIDC state validation failed.');
+    }
+
+    const responseIssuer = url.searchParams.get('iss');
+    if (
+      !responseIssuer &&
+      metadata.authorization_response_iss_parameter_supported === true
+    ) {
+      throw new OidcLoginError(
+        'OIDC callback missing authorization response issuer.',
+      );
+    }
+    if (responseIssuer && responseIssuer !== metadata.issuer) {
+      throw new OidcLoginError('OIDC response issuer validation failed.');
+    }
+
     const error = url.searchParams.get('error');
     if (error) {
       const description = url.searchParams.get('error_description');
@@ -662,19 +683,6 @@ export class OidcLoginService {
           ? `OIDC provider returned "${error}": ${description}`
           : `OIDC provider returned "${error}".`,
       );
-    }
-
-    const state = url.searchParams.get('state');
-    if (!state || state !== transaction.state) {
-      throw new OidcLoginError('OIDC state validation failed.');
-    }
-
-    const responseIssuer = url.searchParams.get('iss');
-    if (
-      responseIssuer &&
-      normalizeIssuer(responseIssuer) !== this.provider.issuer
-    ) {
-      throw new OidcLoginError('OIDC response issuer validation failed.');
     }
 
     const code = url.searchParams.get('code');

--- a/packages/users/src/services/OidcLoginService.ts
+++ b/packages/users/src/services/OidcLoginService.ts
@@ -614,6 +614,7 @@ export class OidcLoginService {
     callbackUrl: string | URL,
     transaction: OidcTransaction,
   ): Promise<OidcCallbackResult> {
+    this.validateCallbackEnvelope(callbackUrl, transaction);
     const metadata = await this.getMetadata();
     const code = this.validateCallback(callbackUrl, transaction, metadata);
     const tokens = await this.exchangeCode(code, transaction);
@@ -649,18 +650,10 @@ export class OidcLoginService {
 
   private validateCallback(
     callbackUrl: string | URL,
-    transaction: OidcTransaction,
+    _transaction: OidcTransaction,
     metadata: OidcProviderMetadata,
   ): string {
-    if (transaction.provider !== this.providerName) {
-      throw new OidcLoginError('OIDC login transaction provider mismatch.');
-    }
-
     const url = callbackUrl instanceof URL ? callbackUrl : new URL(callbackUrl);
-    const state = url.searchParams.get('state');
-    if (!state || state !== transaction.state) {
-      throw new OidcLoginError('OIDC state validation failed.');
-    }
 
     const responseIssuer = url.searchParams.get('iss');
     if (
@@ -691,6 +684,21 @@ export class OidcLoginService {
     }
 
     return code;
+  }
+
+  private validateCallbackEnvelope(
+    callbackUrl: string | URL,
+    transaction: OidcTransaction,
+  ): void {
+    if (transaction.provider !== this.providerName) {
+      throw new OidcLoginError('OIDC login transaction provider mismatch.');
+    }
+
+    const url = callbackUrl instanceof URL ? callbackUrl : new URL(callbackUrl);
+    const state = url.searchParams.get('state');
+    if (!state || state !== transaction.state) {
+      throw new OidcLoginError('OIDC state validation failed.');
+    }
   }
 
   private async exchangeCode(

--- a/packages/users/src/services/TerminalAuthService.ts
+++ b/packages/users/src/services/TerminalAuthService.ts
@@ -92,6 +92,8 @@ export interface CliAuthStartResult {
   deviceCode: string;
   expiresAt: string;
   interval: number;
+  /** Stable issuer used by clients to bind the resulting bearer credential. */
+  issuer: string;
   userCode: string;
   verificationUrl: string;
 }
@@ -242,6 +244,7 @@ export class TerminalAuthService {
       deviceCode,
       expiresAt: expiresAt.toISOString(),
       interval: this.pollIntervalSeconds,
+      issuer: trimmedOrigin,
       userCode,
       verificationUrl: `${trimmedOrigin}${this.verificationPath}?code=${encodeURIComponent(userCode)}`,
     };


### PR DESCRIPTION
## Summary

- enforce RFC 9207 authorization-response issuer validation before trusting errors or exchanging codes
- bind terminal CLI credentials to exact issuers and exact resource-server targets, including environment credentials
- add public Client ID Metadata Document helpers with executable DCR fallback and `application_type`
- document the 2026-07-28 remote MCP authorization story, including current app-mcp and agents applicability plus Anytown/Ergot deployment checks

## Validation

- users focused auth tests: 24/24
- app-cli tests: 94/94
- live reference authorization server: CIMD retrieval and exact `client_id` accepted; real DCR JSON POST accepted
- users and app-cli package typechecks: green
- app-cli production build and public runtime/declaration exports: green
- root build: 61/61
- root tests: 119/119 on final rerun
- root typecheck: 118/118
- knowledge freshness: 0 errors, 0 warnings
- audit policy and pre-push repository gates: green
- security code review, manual QA, and security gate: PASS

Closes #2151
Part of #2145

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-issue-2151-final-20260802",
  "issue": "2151",
  "head_sha": "9ce8b513f739f1d811d959078b8d9adfb633207e",
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "RFC 9207 focused users auth tests: 24/24 passed, including pre-discovery callback-envelope rejection",
    "app-cli tests: 94/94 passed; exact target credential binding covered",
    "live reference AS retrieves and validates hosted CIMD; real DCR POST needs no CIMD client_id, retains application_type, and omits caller client_id",
    "users and app-cli typechecks passed; app-cli build and public exports verified",
    "root build: 61/61 tasks passed",
    "root tests: 119/119 tasks passed on the exact rebased head after #2191 stabilized the DuckDB rail",
    "root typecheck: 118/118 tasks passed",
    "SMRT knowledge freshness: 0 errors and 0 warnings; audit policy passed",
    "exact-head security code review, manual QA R19-R25/S22-S26/A16-A19, and final security gate passed",
    "rebased onto v0.40.46; retained #2186 principal-aware toolPolicy documentation and added the remote authorization boundary without overlap with #2192",
    "generator-created content route artifacts were excluded from the commit; committed scope is exactly 17 auth and documentation files"
  ]
}
```
