### PR TITLE
feat(app-cli): add discovery conformance contract

### DIFF
--- a/packages/app-cli/README.md
+++ b/packages/app-cli/README.md
@@ -46,6 +46,38 @@ Resources and their commands are discovered from the app's `/_resources`
 surface. JSON Schema becomes CLI flags, while unsupported schema shapes are
 reported instead of silently guessed.
 
+## Discovery conformance artifact
+
+`createResourceListHandler()` includes an `artifact` beside the compatible
+`user`, `warnings`, and `resources` response fields. The artifact has a stable
+schema selector, version, canonical ordering, and a `sha256:<hex>` digest. The
+CLI validates it before using its embedded discovery payload.
+
+For a released downstream app, install the exact published
+`@happyvertical/smrt-users` version and pin a captured artifact like this:
+
+```ts
+import {
+  validateDiscoveryConformanceArtifact,
+} from '@happyvertical/smrt-users/app-contract';
+
+const response = await fetch('https://app.example/api/_resources');
+const body = await response.json();
+const artifact = validateDiscoveryConformanceArtifact(body.artifact);
+
+console.log(artifact.schema, artifact.version, artifact.integrity.digest);
+// Store all three selectors and the canonical JSON in your packaged-runtime test.
+```
+
+The result contract embedded in the artifact names the common `code`,
+`message`, `details`, `retryable`, `correlationId`, `idempotencyKey`, and
+`expectedVersion` metadata. `mcp tools` and `mcp call` print this as a JSON
+success/error envelope. HTTP failures may use either a conventional top-level
+metadata object or `{ error: metadata }`; both normalize to that same shape.
+The stdio bridge carries it in MCP `_meta` under
+`io.happyvertical/smrt`. It deliberately does not synthesize MCP
+`structuredContent`.
+
 ## Add an app-specific command
 
 ```ts

--- a/packages/app-cli/README.md
+++ b/packages/app-cli/README.md
@@ -74,6 +74,9 @@ The result contract embedded in the artifact names the common `code`,
 `expectedVersion` metadata. `mcp tools` and `mcp call` print this as a JSON
 success/error envelope. HTTP failures may use either a conventional top-level
 metadata object or `{ error: metadata }`; both normalize to that same shape.
+Generated action failures use the latter form with
+`{ error: { ok: false, code, message, status, ... } }`; the CLI reports the
+HTTP status beside that normalized metadata.
 The stdio bridge carries it in MCP `_meta` under
 `io.happyvertical/smrt`. It deliberately does not synthesize MCP
 `structuredContent`.

--- a/packages/app-cli/src/__tests__/bridge.test.ts
+++ b/packages/app-cli/src/__tests__/bridge.test.ts
@@ -1,0 +1,85 @@
+import { SMRT_MCP_RESULT_METADATA_KEY as CONTRACT_METADATA_KEY } from '@happyvertical/smrt-users/app-contract';
+import { describe, expect, it } from 'vitest';
+import {
+  formatMcpCallResult,
+  SMRT_MCP_RESULT_METADATA_KEY,
+  toMcpTransportError,
+} from '../bridge.js';
+
+function resultMetadata(result: object): unknown {
+  return (result as { _meta?: Record<string, unknown> })._meta?.[
+    SMRT_MCP_RESULT_METADATA_KEY
+  ];
+}
+
+function errorMetadata(error: object): unknown {
+  return (error as { data?: Record<string, unknown> }).data?.[
+    SMRT_MCP_RESULT_METADATA_KEY
+  ];
+}
+
+describe('formatMcpCallResult', () => {
+  it('re-exports the canonical artifact selector', () => {
+    expect(SMRT_MCP_RESULT_METADATA_KEY).toBe(CONTRACT_METADATA_KEY);
+  });
+
+  it('returns an MCP-native error with redacted structured metadata', () => {
+    const result = formatMcpCallResult({
+      ok: false,
+      status: 503,
+      error: {
+        code: 'upstream_timeout',
+        message: 'Bearer bridge-secret failed',
+        details: { refreshToken: 'bridge-secret', retryAfter: 5 },
+        retryable: true,
+        correlationId: 'corr-bridge',
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: 'text', text: 'Bearer [REDACTED] failed' },
+    ]);
+    expect(resultMetadata(result)).toEqual({
+      code: 'upstream_timeout',
+      message: 'Bearer [REDACTED] failed',
+      details: { refreshToken: '[REDACTED]', retryAfter: 5 },
+      retryable: true,
+      correlationId: 'corr-bridge',
+    });
+    expect(
+      (result as { structuredContent?: unknown }).structuredContent,
+    ).toBeUndefined();
+  });
+
+  it('redacts remote MCP error text and ListTools JSON-RPC error data', () => {
+    const result = formatMcpCallResult({
+      ok: true,
+      result: {
+        content: [{ type: 'text', text: 'Bearer remote-secret failed' }],
+        isError: true,
+      },
+      metadata: { code: 'ok' },
+    });
+    expect(result.content).toEqual([
+      { type: 'text', text: 'Bearer [REDACTED] failed' },
+    ]);
+    expect(resultMetadata(result)).toMatchObject({
+      code: 'mcp_tool_error',
+      message: 'Bearer [REDACTED] failed',
+    });
+
+    const error = toMcpTransportError({
+      code: 'tools_unavailable',
+      message: 'Bearer list-secret failed',
+      details: { authorization: 'Bearer list-secret' },
+    });
+    expect(error.message).toContain('Bearer [REDACTED] failed');
+    expect(error.message).not.toContain('list-secret');
+    expect(errorMetadata(error)).toEqual({
+      code: 'tools_unavailable',
+      message: 'Bearer [REDACTED] failed',
+      details: { authorization: '[REDACTED]' },
+    });
+  });
+});

--- a/packages/app-cli/src/__tests__/config.test.ts
+++ b/packages/app-cli/src/__tests__/config.test.ts
@@ -259,8 +259,10 @@ describe('requestJson', () => {
           new Response(
             JSON.stringify({
               error: {
+                ok: false,
                 code: 'upstream_timeout',
                 message: 'Bearer top-secret-token failed',
+                status: 503,
                 details: {
                   accessToken: 'top-secret-token',
                   retryAfter: 5,

--- a/packages/app-cli/src/__tests__/config.test.ts
+++ b/packages/app-cli/src/__tests__/config.test.ts
@@ -13,6 +13,7 @@ import {
   getStoredToken,
   loadCliConfig,
   requestJson,
+  requestJsonResult,
   saveAuth,
 } from '../config.js';
 
@@ -246,6 +247,110 @@ describe('requestJson', () => {
         { fetch: fetchMock as any },
       ),
     ).rejects.toThrow(/unauthenticated/);
+  });
+
+  it('preserves a redacted structured error envelope', async () => {
+    const result = await requestJsonResult(
+      context,
+      '/test',
+      { method: 'GET' },
+      {
+        fetch: async () =>
+          new Response(
+            JSON.stringify({
+              error: {
+                code: 'upstream_timeout',
+                message: 'Bearer top-secret-token failed',
+                details: {
+                  accessToken: 'top-secret-token',
+                  retryAfter: 5,
+                },
+                retryable: true,
+                correlationId: 'corr-42',
+                idempotencyKey: { field: 'idempotencyKey', required: true },
+                expectedVersion: { field: 'expectedVersion', required: false },
+              },
+            }),
+            {
+              status: 503,
+              headers: { 'content-type': 'application/json' },
+            },
+          ),
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 503,
+      error: {
+        code: 'upstream_timeout',
+        message: 'Bearer [REDACTED] failed',
+        details: { accessToken: '[REDACTED]', retryAfter: 5 },
+        retryable: true,
+        correlationId: 'corr-42',
+        idempotencyKey: { field: 'idempotencyKey', required: true },
+        expectedVersion: { field: 'expectedVersion', required: false },
+      },
+    });
+  });
+
+  it('normalizes a conventional top-level HTTP failure envelope', async () => {
+    const result = await requestJsonResult(
+      context,
+      '/test',
+      { method: 'POST' },
+      {
+        fetch: async () =>
+          new Response(
+            JSON.stringify({
+              code: 'version_conflict',
+              message: 'Expected version is stale.',
+              details: { currentVersion: 4 },
+              retryable: false,
+              correlationId: 'corr-version',
+              expectedVersion: { field: 'expectedVersion', required: true },
+            }),
+            { status: 409, headers: { 'content-type': 'application/json' } },
+          ),
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 409,
+      error: {
+        code: 'version_conflict',
+        message: 'Expected version is stale.',
+        details: { currentVersion: 4 },
+        retryable: false,
+        correlationId: 'corr-version',
+        expectedVersion: { field: 'expectedVersion', required: true },
+      },
+    });
+  });
+
+  it('leaves opaque successful domain values untouched', async () => {
+    const result = await requestJsonResult<{ token: string; value: string }>(
+      context,
+      '/test',
+      { method: 'GET' },
+      {
+        fetch: async () =>
+          new Response(
+            JSON.stringify({
+              token: 'domain-token-value',
+              value: 'preserve me',
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          ),
+      },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      result: { token: 'domain-token-value', value: 'preserve me' },
+      metadata: { code: 'ok', retryable: false },
+    });
   });
 
   it('rejects responses with Content-Length above maxResponseBytes — #1311 round-4 A4', async () => {

--- a/packages/app-cli/src/__tests__/config.test.ts
+++ b/packages/app-cli/src/__tests__/config.test.ts
@@ -407,6 +407,36 @@ describe('requestJson', () => {
     ).rejects.toThrow(/Response too large/);
   });
 
+  it('normalizes a response-stream failure as a retryable network error', async () => {
+    const body = new ReadableStream({
+      start(controller) {
+        controller.error(new Error('Bearer read-secret connection reset'));
+      },
+    });
+    const result = await requestJsonResult(
+      context,
+      '/test',
+      { method: 'GET' },
+      {
+        fetch: async () =>
+          new Response(body, {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+      },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 0,
+      error: {
+        code: 'network_error',
+        message: 'Bearer [REDACTED] connection reset',
+        retryable: true,
+      },
+    });
+  });
+
   it('honors custom maxResponseBytes opt-out (Infinity) — #1311 round-4 A4', async () => {
     const fetchMock = vi.fn(
       async () =>

--- a/packages/app-cli/src/__tests__/discovery.test.ts
+++ b/packages/app-cli/src/__tests__/discovery.test.ts
@@ -5,6 +5,7 @@
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { createDiscoveryConformanceArtifact } from '@happyvertical/smrt-users/app-contract';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type CliConfigContext, saveAuth } from '../config.js';
 import {
@@ -71,6 +72,34 @@ describe('fetchResourceList', () => {
     await expect(
       fetchResourceList(context, { fetch: fetchMock as any }),
     ).rejects.toThrow(/auth login/);
+  });
+
+  it('rejects a malformed discovery artifact instead of consuming it', async () => {
+    const artifact = createDiscoveryConformanceArtifact({
+      user: { authenticated: true },
+      warnings: [],
+      resources: [],
+    });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            ...artifact.discovery,
+            artifact: {
+              ...artifact,
+              integrity: {
+                ...artifact.integrity,
+                digest: `sha256:${'0'.repeat(64)}`,
+              },
+            },
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+    );
+
+    await expect(
+      fetchResourceList(context, { fetch: fetchMock as any }),
+    ).rejects.toThrow(/digest/);
   });
 });
 

--- a/packages/app-cli/src/__tests__/mcp.test.ts
+++ b/packages/app-cli/src/__tests__/mcp.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { runMcpCommand } from '../commands/mcp.js';
+import { createAppCli } from '../index.js';
+
+const originalExitCode = process.exitCode;
+const originalExitTestServerUrl = process.env.MCP_EXIT_TEST_SERVER_URL;
+
+afterEach(() => {
+  process.exitCode = originalExitCode;
+  if (originalExitTestServerUrl === undefined) {
+    delete process.env.MCP_EXIT_TEST_SERVER_URL;
+  } else {
+    process.env.MCP_EXIT_TEST_SERVER_URL = originalExitTestServerUrl;
+  }
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('mcp CLI command', () => {
+  it('prints the generic structured error envelope as JSON', async () => {
+    const stdout = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+    const stderr = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+    const succeeded = await runMcpCommand(
+      {
+        context: { envPrefix: 'MCPCLI', defaultServerUrl: 'https://app.test' },
+        stdout,
+        stderr,
+        fetch: async () =>
+          new Response(
+            JSON.stringify({
+              error: {
+                code: 'retry_later',
+                details: { authorization: 'Bearer not-for-output' },
+                message: 'Bearer not-for-output failed',
+                retryable: true,
+              },
+            }),
+            { status: 503, headers: { 'content-type': 'application/json' } },
+          ),
+      },
+      ['tools'],
+    );
+
+    const output = JSON.parse(String((stdout.write as any).mock.calls[0][0]));
+    expect(output).toEqual({
+      ok: false,
+      status: 503,
+      error: {
+        code: 'retry_later',
+        message: 'Bearer [REDACTED] failed',
+        details: { authorization: '[REDACTED]' },
+        retryable: true,
+      },
+    });
+    expect(stderr.write).toHaveBeenCalledWith('Bearer [REDACTED] failed\n');
+    expect(succeeded).toBe(false);
+  });
+
+  it('preserves a nonzero process exit status for envelope failures', async () => {
+    process.exitCode = undefined;
+    process.env.MCP_EXIT_TEST_SERVER_URL = 'https://app.test';
+    vi.stubGlobal(
+      'fetch',
+      async () =>
+        new Response(JSON.stringify({ error: { code: 'unavailable' } }), {
+          status: 503,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await createAppCli({
+      name: 'mcp-exit-test',
+      defaultServerUrl: 'https://app.test',
+    }).run(['mcp', 'tools']);
+
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/app-cli/src/bridge.ts
+++ b/packages/app-cli/src/bridge.ts
@@ -21,17 +21,29 @@
  * @packageDocumentation
  */
 
+import { SMRT_MCP_RESULT_METADATA_KEY as APP_CONTRACT_MCP_RESULT_METADATA_KEY } from '@happyvertical/smrt-users/app-contract';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
   type CallToolRequest,
   CallToolRequestSchema,
   type CallToolResult,
+  ErrorCode,
   type ListToolsRequest,
   ListToolsRequestSchema,
   type ListToolsResult,
+  McpError,
 } from '@modelcontextprotocol/sdk/types.js';
-import { type CliConfigContext, requestJson } from './config.js';
+import {
+  type AppCliResultMetadata,
+  type CliConfigContext,
+  type RequestJsonResult,
+  redactTransportValue,
+  requestJsonResult,
+} from './config.js';
+
+/** Namespace shared with the published SMRT app-result contract. */
+export { SMRT_MCP_RESULT_METADATA_KEY } from '@happyvertical/smrt-users/app-contract';
 
 /**
  * Configuration for the bridge.
@@ -73,12 +85,14 @@ export function createMcpStdioBridge(options: McpStdioBridgeOptions): {
   server.setRequestHandler(
     ListToolsRequestSchema,
     async (_request: ListToolsRequest): Promise<ListToolsResult> => {
-      return requestJson<ListToolsResult>(
+      const outcome = await requestJsonResult<ListToolsResult>(
         options,
         toolsPath,
         { method: 'GET' },
         { fetch: options.fetch },
       );
+      if (!outcome.ok) throw toMcpTransportError(outcome.error);
+      return withMcpMetadata(outcome.result, outcome.metadata);
     },
   );
 
@@ -86,30 +100,16 @@ export function createMcpStdioBridge(options: McpStdioBridgeOptions): {
     CallToolRequestSchema,
     async (request: CallToolRequest): Promise<CallToolResult> => {
       const { name, arguments: args = {} } = request.params;
-      try {
-        return await requestJson<CallToolResult>(
-          options,
-          callPath,
-          {
-            body: JSON.stringify({ arguments: args, name }),
-            method: 'POST',
-          },
-          { fetch: options.fetch },
-        );
-      } catch (error) {
-        return {
-          content: [
-            {
-              text:
-                error instanceof Error
-                  ? error.message
-                  : 'MCP tool call failed.',
-              type: 'text',
-            },
-          ],
-          isError: true,
-        };
-      }
+      const outcome = await requestJsonResult<CallToolResult>(
+        options,
+        callPath,
+        {
+          body: JSON.stringify({ arguments: args, name }),
+          method: 'POST',
+        },
+        { fetch: options.fetch },
+      );
+      return formatMcpCallResult(outcome);
     },
   );
 
@@ -117,6 +117,126 @@ export function createMcpStdioBridge(options: McpStdioBridgeOptions): {
     server,
     connect: () => server.connect(new StdioServerTransport()),
   };
+}
+
+/**
+ * Preserve the HTTP result/error envelope in protocol-permitted MCP metadata.
+ * This deliberately does not create `structuredContent`; #2149 owns declared
+ * output schema semantics for generated tools.
+ */
+export function formatMcpCallResult(
+  outcome: RequestJsonResult<CallToolResult>,
+): CallToolResult {
+  if (!outcome.ok) {
+    const error = sanitizeMetadata(outcome.error);
+    return withMcpMetadata(
+      {
+        content: [
+          {
+            text: error.message ?? error.code,
+            type: 'text',
+          },
+        ],
+        isError: true,
+      },
+      error,
+    );
+  }
+
+  const metadata = isMcpErrorResult(outcome.result)
+    ? {
+        ...outcome.metadata,
+        code:
+          outcome.metadata.code === 'ok'
+            ? 'mcp_tool_error'
+            : outcome.metadata.code,
+        message: outcome.metadata.message ?? resultText(outcome.result),
+      }
+    : outcome.metadata;
+  return withMcpMetadata(
+    isMcpErrorResult(outcome.result)
+      ? redactMcpErrorContent(outcome.result)
+      : outcome.result,
+    metadata,
+  );
+}
+
+function withMcpMetadata<T extends object>(
+  result: T,
+  metadata: AppCliResultMetadata,
+): T {
+  const existing = isRecord((result as { _meta?: unknown })._meta)
+    ? (result as { _meta: Record<string, unknown> })._meta
+    : {};
+  return {
+    ...result,
+    _meta: {
+      ...existing,
+      [APP_CONTRACT_MCP_RESULT_METADATA_KEY]: sanitizeMetadata(metadata),
+    },
+  } as T;
+}
+
+function sanitizeMetadata(
+  metadata: AppCliResultMetadata,
+): AppCliResultMetadata {
+  return {
+    ...metadata,
+    ...(metadata.message
+      ? { message: String(redactTransportValue(metadata.message)) }
+      : {}),
+    ...(metadata.details !== undefined
+      ? {
+          details: redactTransportValue(
+            metadata.details,
+          ) as AppCliResultMetadata['details'],
+        }
+      : {}),
+    ...(metadata.correlationId
+      ? { correlationId: String(redactTransportValue(metadata.correlationId)) }
+      : {}),
+  };
+}
+
+/** Convert an HTTP transport failure into an MCP JSON-RPC error safely. */
+export function toMcpTransportError(metadata: AppCliResultMetadata): McpError {
+  const sanitized = sanitizeMetadata(metadata);
+  return new McpError(
+    ErrorCode.InternalError,
+    sanitized.message ?? sanitized.code,
+    { [APP_CONTRACT_MCP_RESULT_METADATA_KEY]: sanitized },
+  );
+}
+
+function isMcpErrorResult(result: CallToolResult): boolean {
+  return (result as { isError?: unknown }).isError === true;
+}
+
+function resultText(result: CallToolResult): string | undefined {
+  const content = (result as { content?: unknown }).content;
+  if (!Array.isArray(content)) return undefined;
+  const text = content.find(
+    (entry): entry is { text: string } =>
+      isRecord(entry) && typeof entry.text === 'string',
+  );
+  return text?.text;
+}
+
+function redactMcpErrorContent(result: CallToolResult): CallToolResult {
+  const content = (result as { content?: unknown }).content;
+  if (!Array.isArray(content)) return result;
+  return {
+    ...result,
+    content: content.map((entry) =>
+      isRecord(entry) && typeof entry.text === 'string'
+        ? { ...entry, text: String(redactTransportValue(entry.text)) }
+        : entry,
+    ),
+  } as CallToolResult;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 /**

--- a/packages/app-cli/src/commands/mcp.ts
+++ b/packages/app-cli/src/commands/mcp.ts
@@ -8,30 +8,34 @@
  */
 
 import type { CliConfigContext } from '../config.js';
-import { requestJson } from '../config.js';
+import { requestJsonResult } from '../config.js';
 
 export interface McpCommandOptions {
   context: CliConfigContext;
   stdout?: NodeJS.WriteStream;
+  stderr?: NodeJS.WriteStream;
   fetch?: typeof fetch;
 }
 
 export async function runMcpCommand(
   options: McpCommandOptions,
   args: string[],
-): Promise<void> {
+): Promise<boolean> {
   const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
   const sub = args[0];
 
   if (sub === 'tools') {
-    const result = await requestJson(
+    const result = await requestJsonResult(
       options.context,
       '/api/mcp/tools',
       { method: 'GET' },
       { fetch: options.fetch },
     );
     stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-    return;
+    if (!result.ok)
+      stderr.write(`${result.error.message ?? result.error.code}\n`);
+    return result.ok;
   }
 
   if (sub === 'call') {
@@ -46,7 +50,7 @@ export async function runMcpCommand(
         `Could not parse mcp call payload: ${(error as Error).message}`,
       );
     }
-    const result = await requestJson(
+    const result = await requestJsonResult(
       options.context,
       '/api/mcp/call',
       {
@@ -56,7 +60,9 @@ export async function runMcpCommand(
       { fetch: options.fetch },
     );
     stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-    return;
+    if (!result.ok)
+      stderr.write(`${result.error.message ?? result.error.code}\n`);
+    return result.ok;
   }
 
   throw new Error('Usage: mcp tools | mcp call <tool> [<json>]');

--- a/packages/app-cli/src/config.ts
+++ b/packages/app-cli/src/config.ts
@@ -20,6 +20,12 @@ import {
 } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+import type {
+  AppResultMetadata,
+  DeclaredActionField,
+  JsonValue,
+} from '@happyvertical/smrt-users/app-contract';
+import { SMRT_MCP_RESULT_METADATA_KEY } from '@happyvertical/smrt-users/app-contract';
 
 /** Shape stored on disk in the app's CLI config file. */
 export interface CliConfig {
@@ -245,6 +251,38 @@ export interface RequestJsonOptions {
 
 const DEFAULT_MAX_RESPONSE_BYTES = 10 * 1024 * 1024; // 10 MB
 
+/** Structured metadata preserved for CLI JSON and MCP bridge consumers. */
+export type AppCliResultMetadata = AppResultMetadata;
+export type { DeclaredActionField };
+
+export interface RequestJsonSuccess<T> {
+  ok: true;
+  result: T;
+  metadata: AppCliResultMetadata;
+}
+
+export interface RequestJsonFailure {
+  ok: false;
+  status: number;
+  error: AppCliResultMetadata;
+}
+
+/** Generic result/error envelope for a JSON request. */
+export type RequestJsonResult<T> = RequestJsonSuccess<T> | RequestJsonFailure;
+
+/** Error compatibility wrapper returned by the legacy throwing helper. */
+export class AppCliRequestError extends Error {
+  readonly status: number;
+  readonly metadata: AppCliResultMetadata;
+
+  constructor(status: number, metadata: AppCliResultMetadata) {
+    super(metadata.message ?? `HTTP ${status}`);
+    this.name = 'AppCliRequestError';
+    this.status = status;
+    this.metadata = metadata;
+  }
+}
+
 /**
  * JSON request helper that injects the stored bearer token. Returns the
  * parsed JSON body on success; throws an `Error` with the server's `error`
@@ -256,6 +294,26 @@ export async function requestJson<T = unknown>(
   init: RequestInit = {},
   options: RequestJsonOptions = {},
 ): Promise<T> {
+  const outcome = await requestJsonResult<T>(context, path, init, options);
+  if (!outcome.ok) {
+    throw new AppCliRequestError(outcome.status, outcome.error);
+  }
+  return outcome.result;
+}
+
+/**
+ * Issue a JSON request without flattening a failure to an Error message.
+ *
+ * Metadata is deliberately copied only from conventional result/error fields
+ * and response headers. Every value crossing this boundary is redacted before
+ * a CLI or MCP client can observe it.
+ */
+export async function requestJsonResult<T = unknown>(
+  context: CliConfigContext,
+  path: string,
+  init: RequestInit = {},
+  options: RequestJsonOptions = {},
+): Promise<RequestJsonResult<T>> {
   // Reuse the caller's pre-loaded config when supplied, otherwise read
   // from disk. (#1311 review P2.)
   const config = options.loadedConfig ?? (await loadCliConfig(context));
@@ -266,9 +324,11 @@ export async function requestJson<T = unknown>(
   const headers = new Headers(init.headers);
 
   if (options.requireAuth && options.auth !== false && !token) {
-    throw new Error(
-      `Not authenticated. Run \`${context.envPrefix.toLowerCase()} auth login\` first.`,
-    );
+    return failure(401, {
+      code: 'not_authenticated',
+      message: `Not authenticated. Run \`${context.envPrefix.toLowerCase()} auth login\` first.`,
+      retryable: false,
+    });
   }
 
   if (!headers.has('content-type') && init.body) {
@@ -279,33 +339,185 @@ export async function requestJson<T = unknown>(
   }
 
   const fetchImpl = options.fetch ?? fetch;
-  const response = await fetchImpl(`${serverUrl}${path}`, {
-    ...init,
-    headers,
-  });
+  let response: Response;
+  try {
+    response = await fetchImpl(`${serverUrl}${path}`, {
+      ...init,
+      headers,
+    });
+  } catch (error) {
+    return failure(0, {
+      code: 'network_error',
+      message: redactMessage(
+        error instanceof Error ? error.message : String(error),
+      ),
+      retryable: true,
+    });
+  }
 
   const contentType = response.headers.get('content-type') ?? '';
   const maxBytes = options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
-  const text = await readBodyWithCap(response, maxBytes);
-  const parsed =
-    contentType.includes('application/json') && text
-      ? (JSON.parse(text) as unknown)
-      : (text as unknown);
-
-  if (!response.ok) {
-    const message =
-      parsed && typeof parsed === 'object' && 'error' in parsed
-        ? String((parsed as { error: unknown }).error)
-        : `HTTP ${response.status}: ${response.statusText}`;
-    // Attach the HTTP status as a property so downstream callers (e.g.
-    // the auth-login polling loop) can distinguish transient 5xx from
-    // terminal 4xx without parsing the message string. Server-supplied
-    // `error` fields stay verbatim in `.message` for the user-facing
-    // CLI output. (#1311 review #2.)
-    throw Object.assign(new Error(message), { status: response.status });
+  let text: string;
+  try {
+    text = await readBodyWithCap(response, maxBytes);
+  } catch (error) {
+    return failure(response.status, {
+      code: 'response_too_large',
+      message: redactMessage(
+        error instanceof Error ? error.message : String(error),
+      ),
+      retryable: response.status >= 500,
+    });
+  }
+  let parsed: unknown = text;
+  if (contentType.includes('application/json') && text) {
+    try {
+      parsed = JSON.parse(text) as unknown;
+    } catch {
+      return failure(response.status, {
+        code: 'invalid_json_response',
+        message: 'Server returned invalid JSON.',
+        retryable: response.status >= 500,
+      });
+    }
   }
 
-  return parsed as T;
+  if (!response.ok) {
+    return failure(
+      response.status,
+      metadataFromResponse(
+        parsed,
+        response.headers,
+        `http_${response.status}`,
+        response.status >= 500 ||
+          response.status === 408 ||
+          response.status === 429,
+        `HTTP ${response.status}: ${response.statusText}`,
+      ),
+    );
+  }
+
+  return {
+    ok: true,
+    result: parsed as T,
+    metadata: metadataFromResponse(parsed, response.headers, 'ok', false),
+  };
+}
+
+/** Redact conventional credential fields before emitting transport metadata. */
+export function redactTransportValue(value: unknown): unknown {
+  if (typeof value === 'string') return redactMessage(value);
+  if (Array.isArray(value)) return value.map(redactTransportValue);
+  if (!isRecord(value)) return value;
+  const redacted: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    redacted[key] = isSensitiveKey(key)
+      ? '[REDACTED]'
+      : redactTransportValue(nested);
+  }
+  return redacted;
+}
+
+function failure(
+  status: number,
+  error: AppCliResultMetadata,
+): RequestJsonFailure {
+  return { ok: false, status, error };
+}
+
+function metadataFromResponse(
+  payload: unknown,
+  headers: Headers,
+  fallbackCode: string,
+  fallbackRetryable: boolean,
+  fallbackMessage?: string,
+): AppCliResultMetadata {
+  const record = isRecord(payload) ? payload : undefined;
+  const error = record && isRecord(record.error) ? record.error : undefined;
+  const meta = firstRecord(
+    error,
+    record && isRecord(record.metadata) ? record.metadata : undefined,
+    record && isRecord(record.meta) ? record.meta : undefined,
+    getMcpMetadata(record),
+    record,
+  );
+  const message = firstString(
+    meta?.message,
+    error?.message,
+    typeof record?.error === 'string' ? record.error : undefined,
+    fallbackMessage,
+  );
+  const details = meta?.details ?? error?.details;
+  const correlationId = firstString(
+    meta?.correlationId,
+    error?.correlationId,
+    headers.get('x-correlation-id') ?? undefined,
+    headers.get('x-request-id') ?? undefined,
+  );
+  const idempotencyKey = declaredActionField(
+    meta?.idempotencyKey ?? meta?.idempotency,
+  );
+  const expectedVersion = declaredActionField(meta?.expectedVersion);
+  return {
+    code: firstString(meta?.code, error?.code) ?? fallbackCode,
+    ...(message ? { message: redactMessage(message) } : {}),
+    ...(details !== undefined
+      ? { details: redactTransportValue(details) as JsonValue }
+      : {}),
+    retryable:
+      typeof meta?.retryable === 'boolean'
+        ? meta.retryable
+        : typeof error?.retryable === 'boolean'
+          ? error.retryable
+          : fallbackRetryable,
+    ...(correlationId ? { correlationId: redactMessage(correlationId) } : {}),
+    ...(idempotencyKey ? { idempotencyKey } : {}),
+    ...(expectedVersion ? { expectedVersion } : {}),
+  };
+}
+
+function getMcpMetadata(
+  record: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!record || !isRecord(record._meta)) return undefined;
+  const meta = record._meta[SMRT_MCP_RESULT_METADATA_KEY];
+  return isRecord(meta) ? meta : undefined;
+}
+
+function declaredActionField(value: unknown): DeclaredActionField | undefined {
+  if (!isRecord(value) || typeof value.field !== 'string') return undefined;
+  return { field: value.field, required: value.required === true };
+}
+
+function firstRecord(
+  ...values: Array<Record<string, unknown> | undefined>
+): Record<string, unknown> | undefined {
+  return values.find((value) => value !== undefined);
+}
+
+function firstString(...values: Array<unknown>): string | undefined {
+  return values.find(
+    (value): value is string => typeof value === 'string' && value !== '',
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isSensitiveKey(key: string): boolean {
+  return /(?:authorization|token|secret|password|cookie|credential|api[-_]?key)/iu.test(
+    key,
+  );
+}
+
+function redactMessage(message: string): string {
+  return message
+    .replace(/bearer\s+[a-z0-9._~+/=-]+/giu, 'Bearer [REDACTED]')
+    .replace(
+      /((?:token|secret|password|api[-_]?key|authorization)=)[^&\s,]+/giu,
+      '$1[REDACTED]',
+    );
 }
 
 /**

--- a/packages/app-cli/src/config.ts
+++ b/packages/app-cli/src/config.ts
@@ -361,6 +361,15 @@ export async function requestJsonResult<T = unknown>(
   try {
     text = await readBodyWithCap(response, maxBytes);
   } catch (error) {
+    if (!(error instanceof ResponseTooLargeError)) {
+      return failure(0, {
+        code: 'network_error',
+        message: redactMessage(
+          error instanceof Error ? error.message : String(error),
+        ),
+        retryable: true,
+      });
+    }
     return failure(response.status, {
       code: 'response_too_large',
       message: redactMessage(
@@ -520,6 +529,13 @@ function redactMessage(message: string): string {
     );
 }
 
+class ResponseTooLargeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ResponseTooLargeError';
+  }
+}
+
 /**
  * Read the response body into a UTF-8 string, capping at `maxBytes`. On
  * overflow, throw with a clear message — better than OOM-ing the CLI
@@ -540,7 +556,7 @@ async function readBodyWithCap(
     } catch {
       // Stream may already be locked/closed.
     }
-    throw new Error(
+    throw new ResponseTooLargeError(
       `Response too large: ${cl} bytes exceeds ${maxBytes}-byte cap`,
     );
   }
@@ -555,7 +571,7 @@ async function readBodyWithCap(
       if (!value) continue;
       size += value.byteLength;
       if (size > maxBytes) {
-        throw new Error(
+        throw new ResponseTooLargeError(
           `Response too large: exceeded ${maxBytes}-byte cap mid-stream`,
         );
       }

--- a/packages/app-cli/src/discovery.ts
+++ b/packages/app-cli/src/discovery.ts
@@ -15,6 +15,7 @@
  * @packageDocumentation
  */
 
+import { validateDiscoveryConformanceArtifact } from '@happyvertical/smrt-users/app-contract';
 import type {
   CliResource as HandlerCliResource,
   CommandDefinition as HandlerCommandDefinition,
@@ -58,7 +59,7 @@ export async function fetchResourceList(
   options: FetchResourceListOptions = {},
 ): Promise<ResourceListResponse> {
   try {
-    return await requestJson<ResourceListResponse>(
+    const response = await requestJson<ResourceListResponse>(
       context,
       options.path ?? '/api/_resources',
       { method: 'GET' },
@@ -68,6 +69,9 @@ export async function fetchResourceList(
         loadedConfig: options.loadedConfig,
       },
     );
+    if (!response.artifact) return response;
+    const artifact = validateDiscoveryConformanceArtifact(response.artifact);
+    return { ...artifact.discovery, artifact };
   } catch (error) {
     if (error instanceof Error && /401|unauthor/i.test(error.message)) {
       throw new Error(

--- a/packages/app-cli/src/index.ts
+++ b/packages/app-cli/src/index.ts
@@ -27,6 +27,8 @@ import {
 } from './config.js';
 
 export {
+  AppCliRequestError,
+  type AppCliResultMetadata,
   type CliConfig,
   type CliConfigContext,
   clearStoredToken,
@@ -34,7 +36,10 @@ export {
   getStoredToken,
   loadCliConfig,
   type RequestJsonOptions,
+  type RequestJsonResult,
+  redactTransportValue,
   requestJson,
+  requestJsonResult,
   saveAuth,
   saveCliConfig,
 } from './config.js';
@@ -84,6 +89,7 @@ import { invokeCommand } from './invoke.js';
 import { renderResponse } from './output.js';
 import { buildFlagParser } from './parser.js';
 
+export { SMRT_MCP_RESULT_METADATA_KEY } from '@happyvertical/smrt-users/app-contract';
 export {
   createMcpStdioBridge,
   type McpStdioBridgeOptions,
@@ -263,7 +269,9 @@ async function dispatchCli(
   }
 
   if (command === 'mcp') {
-    return runMcpCommand({ context, stdout }, rest);
+    const succeeded = await runMcpCommand({ context, stdout, stderr }, rest);
+    if (!succeeded) process.exitCode = 1;
+    return;
   }
 
   if (command === 'resources') {

--- a/packages/app-cli/vite.config.ts
+++ b/packages/app-cli/vite.config.ts
@@ -32,6 +32,8 @@ export default defineConfig({
 
         '@modelcontextprotocol/sdk',
         /^@modelcontextprotocol\/sdk\//,
+        '@happyvertical/smrt-users',
+        /^@happyvertical\/smrt-users\//,
       ],
       output: {
         entryFileNames: '[name].js',

--- a/packages/users/README.md
+++ b/packages/users/README.md
@@ -10,6 +10,16 @@ pnpm add @happyvertical/smrt-users
 
 ## Usage
 
+### Application discovery conformance
+
+The SvelteKit `createResourceListHandler()` export produces the app CLI
+discovery response and now includes a deterministic `artifact`. Consumers can
+import the published `@happyvertical/smrt-users/app-contract` entrypoint to
+validate the schema/version selector and SHA-256 integrity digest before using
+the embedded resource catalog. See
+[`@happyvertical/smrt-app-cli`](../app-cli/README.md#discovery-conformance-artifact)
+for the exact packaged-runtime pinning workflow.
+
 ### Roles and permissions
 
 ```typescript

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -11,6 +11,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./app-contract": {
+      "types": "./dist/app-contract.d.ts",
+      "import": "./dist/app-contract.js"
+    },
     "./sveltekit": {
       "types": "./dist/sveltekit/index.d.ts",
       "import": "./dist/sveltekit.js"

--- a/packages/users/src/__tests__/resource-list-handler.test.ts
+++ b/packages/users/src/__tests__/resource-list-handler.test.ts
@@ -10,6 +10,11 @@
 import { ObjectRegistry } from '@happyvertical/smrt-core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  SMRT_DISCOVERY_CONFORMANCE_SCHEMA,
+  SMRT_DISCOVERY_CONFORMANCE_VERSION,
+  validateDiscoveryConformanceArtifact,
+} from '../app-contract.js';
+import {
   type CliResource,
   type CommandPolicyContext,
   createResourceListHandler,
@@ -112,6 +117,55 @@ describe('createResourceListHandler', () => {
     expect(res.body.user.authenticated).toBe(false);
     expect(res.body.resources).toEqual([]);
     expect(res.body.warnings).toEqual([]);
+    expect(validateDiscoveryConformanceArtifact(res.body.artifact)).toEqual(
+      res.body.artifact,
+    );
+    expect(res.body.artifact).toMatchObject({
+      schema: SMRT_DISCOVERY_CONFORMANCE_SCHEMA,
+      version: SMRT_DISCOVERY_CONFORMANCE_VERSION,
+    });
+  });
+
+  it('includes declared idempotency and expected-version fields in its artifact', async () => {
+    mockRegistry({
+      Job: makeRegistered(
+        'Job',
+        { api: { include: ['run'] }, cli: { mirror: 'api' } },
+        { run: { isStatic: true } },
+        {
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'run',
+                parameters: {
+                  type: 'object',
+                  properties: {
+                    expectedVersion: { type: 'integer' },
+                    idempotencyKey: { type: 'string' },
+                  },
+                  required: ['idempotencyKey'],
+                },
+              },
+            },
+          ],
+        },
+      ),
+    });
+
+    const res = await call(
+      { ensureRegistry: noopRegistry },
+      { locals: authedLocals },
+    );
+
+    const command = (res.body.resources[0] as CliResource).commands[0];
+    expect(command.requirements).toEqual({
+      idempotencyKey: { field: 'idempotencyKey', required: true },
+      expectedVersion: { field: 'expectedVersion', required: false },
+    });
+    expect(
+      res.body.artifact.discovery.resources[0].commands[0].requirements,
+    ).toEqual(command.requirements);
   });
 
   it('returns CRUD commands when cli: true and api: true', async () => {

--- a/packages/users/src/app-contract.test.ts
+++ b/packages/users/src/app-contract.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalizeDiscoveryArtifact,
+  createDiscoveryConformanceArtifact,
+  DiscoveryArtifactValidationError,
+  type DiscoveryPayload,
+  deriveCommandRequirements,
+  validateDiscoveryConformanceArtifact,
+} from './app-contract.js';
+
+const discovery: DiscoveryPayload = {
+  user: { authenticated: true, id: 'user-1' },
+  warnings: ['z-warning', 'a-warning'],
+  resources: [
+    {
+      slug: 'zebras',
+      className: 'Zebra',
+      label: 'Zebra',
+      apiPath: 'zebras',
+      commands: [
+        {
+          methodName: 'write',
+          commandName: 'write',
+          kind: 'custom',
+          scope: 'collection',
+          httpMethod: 'POST',
+          pathSegments: ['write'],
+        },
+      ],
+    },
+    {
+      slug: 'alpacas',
+      className: 'Alpaca',
+      label: 'Alpaca',
+      apiPath: 'alpacas',
+      commands: [
+        {
+          methodName: 'zebra',
+          commandName: 'zebra',
+          kind: 'custom',
+          scope: 'collection',
+          httpMethod: 'POST',
+          pathSegments: ['zebra'],
+        },
+        {
+          methodName: 'alpha',
+          commandName: 'alpha',
+          kind: 'custom',
+          scope: 'collection',
+          httpMethod: 'POST',
+          pathSegments: ['alpha'],
+        },
+      ],
+    },
+  ],
+};
+
+describe('SMRT discovery conformance artifact', () => {
+  it('is deterministic, validates its schema, and exposes the result contract', () => {
+    const first = createDiscoveryConformanceArtifact(discovery);
+    const second = createDiscoveryConformanceArtifact({
+      ...discovery,
+      warnings: [...discovery.warnings].reverse(),
+      resources: [...discovery.resources].reverse(),
+    });
+
+    expect(first.integrity.digest).toBe(second.integrity.digest);
+    const { integrity: _firstIntegrity, ...firstUnsigned } = first;
+    const { integrity: _secondIntegrity, ...secondUnsigned } = second;
+    expect(canonicalizeDiscoveryArtifact(firstUnsigned)).toBe(
+      canonicalizeDiscoveryArtifact(secondUnsigned),
+    );
+    expect(first.discovery.warnings).toEqual(['a-warning', 'z-warning']);
+    expect(first.discovery.resources.map((resource) => resource.slug)).toEqual([
+      'alpacas',
+      'zebras',
+    ]);
+    expect(
+      first.discovery.resources[0]?.commands.map(
+        (command) => command.commandName,
+      ),
+    ).toEqual(['alpha', 'zebra']);
+    expect(validateDiscoveryConformanceArtifact(first)).toEqual(first);
+    expect(first.resultContract).toEqual({
+      schema: 'https://smrt.dev/schemas/app-result/v1',
+      version: 1,
+      mcpMetadataKey: 'io.happyvertical/smrt',
+      metadataFields: [
+        'code',
+        'message',
+        'details',
+        'retryable',
+        'correlationId',
+        'idempotencyKey',
+        'expectedVersion',
+      ],
+    });
+  });
+
+  it('rejects malformed ordering and integrity tampering', () => {
+    const artifact = createDiscoveryConformanceArtifact(discovery);
+    const unsorted = {
+      ...artifact,
+      discovery: {
+        ...artifact.discovery,
+        warnings: [...artifact.discovery.warnings].reverse(),
+      },
+    };
+    expect(() => validateDiscoveryConformanceArtifact(unsorted)).toThrow(
+      DiscoveryArtifactValidationError,
+    );
+
+    const tampered = {
+      ...artifact,
+      discovery: { ...artifact.discovery, user: { authenticated: false } },
+    };
+    expect(() => validateDiscoveryConformanceArtifact(tampered)).toThrow(
+      /digest/,
+    );
+  });
+
+  it('projects declared idempotency and expected-version fields', () => {
+    expect(
+      deriveCommandRequirements({
+        type: 'object',
+        properties: { expectedVersion: {}, idempotencyKey: {}, title: {} },
+        required: ['idempotencyKey'],
+      }),
+    ).toEqual({
+      idempotencyKey: { field: 'idempotencyKey', required: true },
+      expectedVersion: { field: 'expectedVersion', required: false },
+    });
+  });
+});

--- a/packages/users/src/app-contract.test.ts
+++ b/packages/users/src/app-contract.test.ts
@@ -130,5 +130,29 @@ describe('SMRT discovery conformance artifact', () => {
       idempotencyKey: { field: 'idempotencyKey', required: true },
       expectedVersion: { field: 'expectedVersion', required: false },
     });
+
+    const expectedVersionOnly = deriveCommandRequirements({
+      type: 'object',
+      properties: { expectedVersion: {} },
+    });
+    expect(expectedVersionOnly).toEqual({
+      expectedVersion: { field: 'expectedVersion', required: false },
+    });
+    expect(Object.keys(expectedVersionOnly ?? {})).toEqual(['expectedVersion']);
+
+    const resource = discovery.resources[0];
+    if (!resource) throw new Error('test discovery requires one resource');
+    const command = resource.commands[0];
+    if (!command) throw new Error('test resource requires one command');
+    const artifact = createDiscoveryConformanceArtifact({
+      ...discovery,
+      resources: [
+        {
+          ...resource,
+          commands: [{ ...command, requirements: expectedVersionOnly }],
+        },
+      ],
+    });
+    expect(validateDiscoveryConformanceArtifact(artifact)).toEqual(artifact);
   });
 });

--- a/packages/users/src/app-contract.ts
+++ b/packages/users/src/app-contract.ts
@@ -1,0 +1,550 @@
+/**
+ * Versioned discovery and cross-transport contracts for SMRT application
+ * surfaces.
+ *
+ * The artifact is intentionally data-only: downstream apps may persist its
+ * canonical JSON and pin the SHA-256 digest without parsing CLI help text or
+ * depending on a particular transport implementation.
+ *
+ * @packageDocumentation
+ */
+
+import { createHash, timingSafeEqual } from 'node:crypto';
+import type {
+  CliResource,
+  CommandDefinition,
+  ResourceListResponseBody,
+} from './sveltekit/resource-list-handler.js';
+
+/** Immutable selector for this discovery artifact family. */
+export const SMRT_DISCOVERY_CONFORMANCE_SCHEMA =
+  'https://smrt.dev/schemas/discovery-conformance/v1';
+/** Version of the discovery artifact payload. */
+export const SMRT_DISCOVERY_CONFORMANCE_VERSION = 1 as const;
+/** Versioned selector for structured application results and errors. */
+export const SMRT_APP_RESULT_SCHEMA = 'https://smrt.dev/schemas/app-result/v1';
+/** Version of the structured application result contract. */
+export const SMRT_APP_RESULT_VERSION = 1 as const;
+/** MCP result `_meta` member carrying the app-result metadata. */
+export const SMRT_MCP_RESULT_METADATA_KEY = 'io.happyvertical/smrt';
+
+/** JSON-safe value used by structured details and parameter schemas. */
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/** A declared input field which controls retry or optimistic-concurrency use. */
+export interface DeclaredActionField {
+  /** JSON Schema property name supplied by the action. */
+  field: string;
+  /** Whether the action marks the field required. */
+  required: boolean;
+}
+
+/** Retry and concurrency declarations projected from a command schema. */
+export interface CommandRequirements {
+  idempotencyKey?: DeclaredActionField;
+  expectedVersion?: DeclaredActionField;
+}
+
+/** Machine-readable metadata shared by HTTP CLI and MCP bridge results. */
+export interface AppResultMetadata {
+  code: string;
+  message?: string;
+  details?: JsonValue;
+  retryable?: boolean;
+  correlationId?: string;
+  idempotencyKey?: DeclaredActionField;
+  expectedVersion?: DeclaredActionField;
+}
+
+export interface AppResultContract {
+  schema: typeof SMRT_APP_RESULT_SCHEMA;
+  version: typeof SMRT_APP_RESULT_VERSION;
+  mcpMetadataKey: typeof SMRT_MCP_RESULT_METADATA_KEY;
+  metadataFields: readonly [
+    'code',
+    'message',
+    'details',
+    'retryable',
+    'correlationId',
+    'idempotencyKey',
+    'expectedVersion',
+  ];
+}
+
+/** Stable description of the result metadata contract contained in an artifact. */
+export const SMRT_APP_RESULT_CONTRACT: AppResultContract = {
+  schema: SMRT_APP_RESULT_SCHEMA,
+  version: SMRT_APP_RESULT_VERSION,
+  mcpMetadataKey: SMRT_MCP_RESULT_METADATA_KEY,
+  metadataFields: [
+    'code',
+    'message',
+    'details',
+    'retryable',
+    'correlationId',
+    'idempotencyKey',
+    'expectedVersion',
+  ],
+};
+
+/** The pre-artifact wire payload, kept for the existing `/_resources` fields. */
+export type DiscoveryPayload = Omit<ResourceListResponseBody, 'artifact'>;
+
+export interface DiscoveryArtifactIntegrity {
+  algorithm: 'sha256';
+  /** `sha256:<lowercase-hex>` over canonical unsigned artifact JSON. */
+  digest: string;
+}
+
+/** Versioned payload a consumer can validate and pin. */
+export interface DiscoveryConformanceArtifact {
+  schema: typeof SMRT_DISCOVERY_CONFORMANCE_SCHEMA;
+  version: typeof SMRT_DISCOVERY_CONFORMANCE_VERSION;
+  discovery: DiscoveryPayload;
+  resultContract: AppResultContract;
+  integrity: DiscoveryArtifactIntegrity;
+}
+
+/** A JSON Schema export for consumers that validate artifacts outside Node. */
+export const SMRT_DISCOVERY_CONFORMANCE_ARTIFACT_SCHEMA = {
+  $id: SMRT_DISCOVERY_CONFORMANCE_SCHEMA,
+  type: 'object',
+  required: ['schema', 'version', 'discovery', 'resultContract', 'integrity'],
+  properties: {
+    schema: { const: SMRT_DISCOVERY_CONFORMANCE_SCHEMA },
+    version: { const: SMRT_DISCOVERY_CONFORMANCE_VERSION },
+    discovery: {
+      type: 'object',
+      required: ['user', 'warnings', 'resources'],
+      properties: {
+        user: { type: 'object', required: ['authenticated'] },
+        warnings: { type: 'array', items: { type: 'string' } },
+        resources: { type: 'array' },
+      },
+    },
+    resultContract: {
+      type: 'object',
+      required: ['schema', 'version', 'mcpMetadataKey', 'metadataFields'],
+    },
+    integrity: {
+      type: 'object',
+      required: ['algorithm', 'digest'],
+      properties: {
+        algorithm: { const: 'sha256' },
+        digest: { type: 'string', pattern: '^sha256:[a-f0-9]{64}$' },
+      },
+    },
+  },
+} as const;
+
+/** Thrown when an artifact is malformed, non-canonical, or fails its digest. */
+export class DiscoveryArtifactValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DiscoveryArtifactValidationError';
+  }
+}
+
+/**
+ * Project conventionally named request fields from a JSON Schema into the
+ * discovery contract. This is declarative only: the action remains the owner
+ * of enforcement and may use a body field or adapt it to an HTTP header.
+ */
+export function deriveCommandRequirements(
+  parameters: Record<string, unknown> | undefined,
+): CommandRequirements | undefined {
+  const properties = isRecord(parameters?.properties)
+    ? parameters.properties
+    : undefined;
+  if (!properties) return undefined;
+
+  const required = new Set(
+    Array.isArray(parameters?.required)
+      ? parameters.required.filter(
+          (value): value is string => typeof value === 'string',
+        )
+      : [],
+  );
+  const findField = (
+    names: readonly string[],
+  ): DeclaredActionField | undefined => {
+    const field = names.find((name) => Object.hasOwn(properties, name));
+    return field ? { field, required: required.has(field) } : undefined;
+  };
+
+  const requirements: CommandRequirements = {
+    idempotencyKey: findField(['idempotencyKey', 'idempotency_key']),
+    expectedVersion: findField(['expectedVersion', 'expected_version']),
+  };
+  return requirements.idempotencyKey || requirements.expectedVersion
+    ? requirements
+    : undefined;
+}
+
+/** Produce a deterministically ordered artifact with a SHA-256 integrity pin. */
+export function createDiscoveryConformanceArtifact(
+  discovery: DiscoveryPayload,
+): DiscoveryConformanceArtifact {
+  const normalizedDiscovery = normalizeDiscovery(discovery);
+  const unsigned = {
+    schema: SMRT_DISCOVERY_CONFORMANCE_SCHEMA,
+    version: SMRT_DISCOVERY_CONFORMANCE_VERSION,
+    discovery: normalizedDiscovery,
+    resultContract: SMRT_APP_RESULT_CONTRACT,
+  } as const;
+
+  return {
+    ...unsigned,
+    integrity: {
+      algorithm: 'sha256',
+      digest: digestUnsignedArtifact(unsigned),
+    },
+  };
+}
+
+/**
+ * Validate structure, canonical ordering, and the integrity digest. Returns
+ * the typed artifact so consumers can use one operation for validation and
+ * consumption.
+ */
+export function validateDiscoveryConformanceArtifact(
+  value: unknown,
+): DiscoveryConformanceArtifact {
+  if (!isRecord(value)) fail('artifact must be an object');
+  if (value.schema !== SMRT_DISCOVERY_CONFORMANCE_SCHEMA) {
+    fail(`unsupported artifact schema: ${String(value.schema)}`);
+  }
+  if (value.version !== SMRT_DISCOVERY_CONFORMANCE_VERSION) {
+    fail(`unsupported artifact version: ${String(value.version)}`);
+  }
+  if (!isRecord(value.integrity) || value.integrity.algorithm !== 'sha256') {
+    fail('artifact integrity.algorithm must be sha256');
+  }
+  if (
+    typeof value.integrity.digest !== 'string' ||
+    !/^sha256:[a-f0-9]{64}$/u.test(value.integrity.digest)
+  ) {
+    fail('artifact integrity.digest must be lowercase sha256 hex');
+  }
+  validateResultContract(value.resultContract);
+  const discovery = validateDiscovery(value.discovery);
+  const artifact: DiscoveryConformanceArtifact = {
+    schema: SMRT_DISCOVERY_CONFORMANCE_SCHEMA,
+    version: SMRT_DISCOVERY_CONFORMANCE_VERSION,
+    discovery,
+    resultContract: SMRT_APP_RESULT_CONTRACT,
+    integrity: {
+      algorithm: 'sha256',
+      digest: value.integrity.digest,
+    },
+  };
+  const expected = digestUnsignedArtifact({
+    schema: artifact.schema,
+    version: artifact.version,
+    discovery: artifact.discovery,
+    resultContract: artifact.resultContract,
+  });
+  if (!safeDigestEqual(expected, artifact.integrity.digest)) {
+    fail('artifact integrity digest does not match canonical payload');
+  }
+  return artifact;
+}
+
+/** Canonical JSON bytes whose digest is carried by the artifact. */
+export function canonicalizeDiscoveryArtifact(
+  artifact: Omit<DiscoveryConformanceArtifact, 'integrity'>,
+): string {
+  return canonicalJson(artifact);
+}
+
+function normalizeDiscovery(discovery: DiscoveryPayload): DiscoveryPayload {
+  const resources = [...discovery.resources]
+    .map(normalizeResource)
+    .sort((left, right) => compareText(left.slug, right.slug));
+  return {
+    user: discovery.user.id
+      ? { authenticated: discovery.user.authenticated, id: discovery.user.id }
+      : { authenticated: discovery.user.authenticated },
+    warnings: [...discovery.warnings].sort(compareText),
+    resources,
+  };
+}
+
+function normalizeResource(resource: CliResource): CliResource {
+  const commands = [...resource.commands]
+    .map(normalizeCommand)
+    .sort((left, right) => compareText(left.commandName, right.commandName));
+  return {
+    slug: resource.slug,
+    className: resource.className,
+    ...(resource.qualifiedName
+      ? { qualifiedName: resource.qualifiedName }
+      : {}),
+    ...(resource.packageName ? { packageName: resource.packageName } : {}),
+    label: resource.label,
+    apiPath: resource.apiPath,
+    commands,
+  };
+}
+
+function normalizeCommand(command: CommandDefinition): CommandDefinition {
+  return {
+    methodName: command.methodName,
+    commandName: command.commandName,
+    kind: command.kind,
+    scope: command.scope,
+    httpMethod: command.httpMethod,
+    pathSegments: [...command.pathSegments],
+    ...(command.description ? { description: command.description } : {}),
+    ...(command.parameters
+      ? {
+          parameters: canonicalJsonValue(command.parameters) as Record<
+            string,
+            unknown
+          >,
+        }
+      : {}),
+    ...(command.requirements ? { requirements: command.requirements } : {}),
+  };
+}
+
+function validateDiscovery(value: unknown): DiscoveryPayload {
+  if (!isRecord(value)) fail('artifact discovery must be an object');
+  if (!isRecord(value.user) || typeof value.user.authenticated !== 'boolean') {
+    fail('artifact discovery.user.authenticated must be boolean');
+  }
+  if (value.user.id !== undefined && typeof value.user.id !== 'string') {
+    fail('artifact discovery.user.id must be a string');
+  }
+  if (!Array.isArray(value.warnings) || !value.warnings.every(isString)) {
+    fail('artifact discovery.warnings must be a string array');
+  }
+  assertSorted(value.warnings, 'artifact discovery.warnings');
+  if (!Array.isArray(value.resources)) {
+    fail('artifact discovery.resources must be an array');
+  }
+  const resources = value.resources.map(validateResource);
+  assertSorted(
+    resources.map((resource) => resource.slug),
+    'artifact discovery.resources',
+  );
+  return {
+    user: value.user.id
+      ? { authenticated: value.user.authenticated, id: value.user.id }
+      : { authenticated: value.user.authenticated },
+    warnings: [...value.warnings],
+    resources,
+  };
+}
+
+function validateResource(value: unknown): CliResource {
+  if (!isRecord(value)) fail('artifact resource must be an object');
+  const slug = requireArtifactString(value.slug, 'resource.slug');
+  const className = requireArtifactString(
+    value.className,
+    'resource.className',
+  );
+  const label = requireArtifactString(value.label, 'resource.label');
+  const apiPath = requireArtifactString(value.apiPath, 'resource.apiPath');
+  if (!Array.isArray(value.commands))
+    fail('artifact resource.commands must be an array');
+  const commands = value.commands.map(validateCommand);
+  assertSorted(
+    commands.map((command) => command.commandName),
+    'artifact resource.commands',
+  );
+  return {
+    slug,
+    className,
+    ...(typeof value.qualifiedName === 'string'
+      ? { qualifiedName: value.qualifiedName }
+      : {}),
+    ...(typeof value.packageName === 'string'
+      ? { packageName: value.packageName }
+      : {}),
+    label,
+    apiPath,
+    commands,
+  };
+}
+
+function validateCommand(value: unknown): CommandDefinition {
+  if (!isRecord(value)) fail('artifact command must be an object');
+  const methodName = requireArtifactString(
+    value.methodName,
+    'command.methodName',
+  );
+  const commandName = requireArtifactString(
+    value.commandName,
+    'command.commandName',
+  );
+  const httpMethod = requireArtifactString(
+    value.httpMethod,
+    'command.httpMethod',
+  );
+  if (value.kind !== 'crud' && value.kind !== 'custom') {
+    fail('artifact command.kind must be crud or custom');
+  }
+  if (value.scope !== 'item' && value.scope !== 'collection') {
+    fail('artifact command.scope must be item or collection');
+  }
+  if (
+    !Array.isArray(value.pathSegments) ||
+    !value.pathSegments.every(isString)
+  ) {
+    fail('artifact command.pathSegments must be a string array');
+  }
+  if (value.parameters !== undefined && !isRecord(value.parameters)) {
+    fail('artifact command.parameters must be an object');
+  }
+  const requirements = validateRequirements(value.requirements);
+  return {
+    methodName,
+    commandName,
+    kind: value.kind,
+    scope: value.scope,
+    httpMethod: httpMethod as CommandDefinition['httpMethod'],
+    pathSegments: [...value.pathSegments],
+    ...(typeof value.description === 'string'
+      ? { description: value.description }
+      : {}),
+    ...(value.parameters
+      ? {
+          parameters: canonicalJsonValue(value.parameters) as Record<
+            string,
+            unknown
+          >,
+        }
+      : {}),
+    ...(requirements ? { requirements } : {}),
+  };
+}
+
+function validateRequirements(value: unknown): CommandRequirements | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) fail('artifact command.requirements must be an object');
+  const parseField = (
+    candidate: unknown,
+    name: string,
+  ): DeclaredActionField | undefined => {
+    if (candidate === undefined) return undefined;
+    if (
+      !isRecord(candidate) ||
+      typeof candidate.field !== 'string' ||
+      candidate.field === '' ||
+      typeof candidate.required !== 'boolean'
+    ) {
+      fail(`artifact command.requirements.${name} is invalid`);
+    }
+    return { field: candidate.field, required: candidate.required };
+  };
+  const requirements: CommandRequirements = {
+    idempotencyKey: parseField(value.idempotencyKey, 'idempotencyKey'),
+    expectedVersion: parseField(value.expectedVersion, 'expectedVersion'),
+  };
+  return requirements.idempotencyKey || requirements.expectedVersion
+    ? requirements
+    : undefined;
+}
+
+function validateResultContract(value: unknown): void {
+  if (!isRecord(value)) fail('artifact resultContract must be an object');
+  if (
+    value.schema !== SMRT_APP_RESULT_SCHEMA ||
+    value.version !== SMRT_APP_RESULT_VERSION ||
+    value.mcpMetadataKey !== SMRT_MCP_RESULT_METADATA_KEY ||
+    !Array.isArray(value.metadataFields) ||
+    canonicalJson(value.metadataFields) !==
+      canonicalJson(SMRT_APP_RESULT_CONTRACT.metadataFields)
+  ) {
+    fail('artifact resultContract does not match SMRT app-result v1');
+  }
+}
+
+function digestUnsignedArtifact(
+  artifact: Omit<DiscoveryConformanceArtifact, 'integrity'>,
+): string {
+  return `sha256:${createHash('sha256')
+    .update(canonicalizeDiscoveryArtifact(artifact), 'utf8')
+    .digest('hex')}`;
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalJsonValue(value));
+}
+
+function canonicalJsonValue(value: unknown): JsonValue {
+  if (
+    value === null ||
+    typeof value === 'boolean' ||
+    typeof value === 'string'
+  ) {
+    return value;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value))
+      fail('artifact cannot contain non-finite numbers');
+    return value;
+  }
+  if (Array.isArray(value)) return value.map(canonicalJsonValue);
+  if (isRecord(value)) {
+    const normalized: Record<string, JsonValue> = {};
+    for (const key of Object.keys(value).sort(compareText)) {
+      normalized[key] = canonicalJsonValue(value[key]);
+    }
+    return normalized;
+  }
+  fail(`artifact contains unsupported value type: ${typeof value}`);
+}
+
+function safeDigestEqual(left: string, right: string): boolean {
+  const leftBytes = Buffer.from(left, 'utf8');
+  const rightBytes = Buffer.from(right, 'utf8');
+  return (
+    leftBytes.length === rightBytes.length &&
+    timingSafeEqual(leftBytes, rightBytes)
+  );
+}
+
+function assertSorted(values: readonly string[], name: string): void {
+  for (let index = 1; index < values.length; index += 1) {
+    const previous = values[index - 1];
+    const current = values[index];
+    if (
+      previous !== undefined &&
+      current !== undefined &&
+      compareText(previous, current) > 0
+    ) {
+      fail(`${name} must be deterministically sorted`);
+    }
+  }
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function requireArtifactString(value: unknown, name: string): string {
+  if (typeof value !== 'string' || value === '') {
+    fail(`artifact ${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function fail(message: string): never {
+  throw new DiscoveryArtifactValidationError(message);
+}

--- a/packages/users/src/app-contract.ts
+++ b/packages/users/src/app-contract.ts
@@ -14,7 +14,7 @@ import type {
   CliResource,
   CommandDefinition,
   ResourceListResponseBody,
-} from './sveltekit/resource-list-handler.js';
+} from './sveltekit.js';
 
 /** Immutable selector for this discovery artifact family. */
 export const SMRT_DISCOVERY_CONFORMANCE_SCHEMA =
@@ -178,13 +178,13 @@ export function deriveCommandRequirements(
     return field ? { field, required: required.has(field) } : undefined;
   };
 
-  const requirements: CommandRequirements = {
-    idempotencyKey: findField(['idempotencyKey', 'idempotency_key']),
-    expectedVersion: findField(['expectedVersion', 'expected_version']),
+  const idempotencyKey = findField(['idempotencyKey', 'idempotency_key']);
+  const expectedVersion = findField(['expectedVersion', 'expected_version']);
+  if (!idempotencyKey && !expectedVersion) return undefined;
+  return {
+    ...(idempotencyKey ? { idempotencyKey } : {}),
+    ...(expectedVersion ? { expectedVersion } : {}),
   };
-  return requirements.idempotencyKey || requirements.expectedVersion
-    ? requirements
-    : undefined;
 }
 
 /** Produce a deterministically ordered artifact with a SHA-256 integrity pin. */
@@ -294,6 +294,9 @@ function normalizeResource(resource: CliResource): CliResource {
 }
 
 function normalizeCommand(command: CommandDefinition): CommandDefinition {
+  const requirements = command.requirements
+    ? normalizeRequirements(command.requirements)
+    : undefined;
   return {
     methodName: command.methodName,
     commandName: command.commandName,
@@ -310,7 +313,7 @@ function normalizeCommand(command: CommandDefinition): CommandDefinition {
           >,
         }
       : {}),
-    ...(command.requirements ? { requirements: command.requirements } : {}),
+    ...(requirements ? { requirements } : {}),
   };
 }
 
@@ -444,13 +447,21 @@ function validateRequirements(value: unknown): CommandRequirements | undefined {
     }
     return { field: candidate.field, required: candidate.required };
   };
-  const requirements: CommandRequirements = {
+  return normalizeRequirements({
     idempotencyKey: parseField(value.idempotencyKey, 'idempotencyKey'),
     expectedVersion: parseField(value.expectedVersion, 'expectedVersion'),
+  });
+}
+
+function normalizeRequirements(
+  requirements: CommandRequirements,
+): CommandRequirements | undefined {
+  const { idempotencyKey, expectedVersion } = requirements;
+  if (!idempotencyKey && !expectedVersion) return undefined;
+  return {
+    ...(idempotencyKey ? { idempotencyKey } : {}),
+    ...(expectedVersion ? { expectedVersion } : {}),
   };
-  return requirements.idempotencyKey || requirements.expectedVersion
-    ? requirements
-    : undefined;
 }
 
 function validateResultContract(value: unknown): void {

--- a/packages/users/src/sveltekit/index.ts
+++ b/packages/users/src/sveltekit/index.ts
@@ -55,6 +55,28 @@ import {
   type TerminalAuthServiceOptions,
 } from '../services/TerminalAuthService.js';
 
+export {
+  type AppResultContract,
+  type AppResultMetadata,
+  type CommandRequirements,
+  canonicalizeDiscoveryArtifact,
+  createDiscoveryConformanceArtifact,
+  type DeclaredActionField,
+  type DiscoveryArtifactIntegrity,
+  DiscoveryArtifactValidationError,
+  type DiscoveryConformanceArtifact,
+  type DiscoveryPayload,
+  deriveCommandRequirements,
+  type JsonValue,
+  SMRT_APP_RESULT_CONTRACT,
+  SMRT_APP_RESULT_SCHEMA,
+  SMRT_APP_RESULT_VERSION,
+  SMRT_DISCOVERY_CONFORMANCE_ARTIFACT_SCHEMA,
+  SMRT_DISCOVERY_CONFORMANCE_SCHEMA,
+  SMRT_DISCOVERY_CONFORMANCE_VERSION,
+  SMRT_MCP_RESULT_METADATA_KEY,
+  validateDiscoveryConformanceArtifact,
+} from '../app-contract.js';
 export type {
   NormalizedOidcClaims,
   OidcProfileOwnerAuthorization,

--- a/packages/users/src/sveltekit/resource-list-handler.ts
+++ b/packages/users/src/sveltekit/resource-list-handler.ts
@@ -37,6 +37,12 @@ import {
   methodNameToKebab,
   resolveApiActionSet,
 } from '@happyvertical/smrt-core/vite-plugin';
+import {
+  type CommandRequirements,
+  createDiscoveryConformanceArtifact,
+  type DiscoveryConformanceArtifact,
+  deriveCommandRequirements,
+} from '../app-contract.js';
 import type { TerminalAuthServiceOptions } from '../services/TerminalAuthService.js';
 import { loadBearerSessionContext, parseBearerToken } from './index.js';
 import type { SessionLocals } from './types.js';
@@ -101,6 +107,8 @@ export interface CommandDefinition {
   description?: string;
   /** JSONSchema describing the command's argv-flag surface. */
   parameters?: Record<string, unknown>;
+  /** Retry and optimistic-concurrency fields declared by the action schema. */
+  requirements?: CommandRequirements;
 }
 
 export interface CliResource {
@@ -143,6 +151,8 @@ export interface ResourceListResponseBody {
   user: { authenticated: boolean; id?: string };
   warnings: string[];
   resources: CliResource[];
+  /** Versioned deterministic artifact for consumers that integrity-pin discovery. */
+  artifact?: DiscoveryConformanceArtifact;
 }
 
 /**
@@ -406,12 +416,17 @@ export function createResourceListHandler(
       .filter((_, i) => warnResults[i])
       .map((w) => `${w.ref}: ${w.reason}`);
 
-    const body: ResourceListResponseBody = {
+    const discovery: Omit<ResourceListResponseBody, 'artifact'> = {
       user: session.user
         ? { authenticated: true, id: String(session.user.id ?? '') }
         : { authenticated: false },
       warnings: visibleWarnings,
       resources,
+    };
+    const artifact = createDiscoveryConformanceArtifact(discovery);
+    const body: ResourceListResponseBody = {
+      ...discovery,
+      artifact,
     };
 
     return jsonResponse(body, 200, {
@@ -749,6 +764,7 @@ function buildCustomCommand(
   }
 
   const parameters = resolveParametersSchema(def, methodName, methodDef);
+  const requirements = deriveCommandRequirements(parameters);
 
   return {
     methodName,
@@ -759,6 +775,7 @@ function buildCustomCommand(
     pathSegments,
     description: methodDef?.description,
     parameters,
+    ...(requirements ? { requirements } : {}),
   };
 }
 

--- a/packages/users/vite.config.ts
+++ b/packages/users/vite.config.ts
@@ -1,6 +1,6 @@
 import { createPackageConfig } from '../../vite.config.base.js';
 
 export default createPackageConfig('users', {
-  entries: ['sveltekit', 'ui', 'playground'],
+  entries: ['app-contract', 'sveltekit', 'ui', 'playground'],
   svelte: 'svelte',
 });


### PR DESCRIPTION
## Summary

- Add the versioned, deterministic, SHA-256-verifiable discovery conformance artifact and public `@happyvertical/smrt-users/app-contract` entrypoint.
- Normalize generic HTTP CLI result/error metadata and preserve it in stdio MCP `_meta` with canonical selector reuse, without generating `structuredContent`.
- Redact recognized credential-bearing error data/text, preserve opaque successful domain values, and document the generated-artifact pinning workflow.

## Validation

- Node `v24.18.0`: `pnpm --filter @happyvertical/smrt-users exec vitest run src/app-contract.test.ts src/__tests__/resource-list-handler.test.ts` — 33 passed.
- Node `v24.18.0`: `pnpm --filter @happyvertical/smrt-app-cli exec vitest run src/__tests__/discovery.test.ts src/__tests__/config.test.ts src/__tests__/bridge.test.ts src/__tests__/mcp.test.ts` — 34 passed.
- Node `v24.18.0`: affected dependency-closure build plus `@happyvertical/smrt-users` and `@happyvertical/smrt-app-cli` typechecks — passed.
- `pnpm knowledge:check --changed --strict --format markdown` and `pnpm audit:policy` — passed.

## Scope

- Refs #2145 (parent coordination); no native HTTP MCP, SDK v2, issuer authorization, or generator changes.
- The client normalizer accepts both `{ error: metadata }` and conventional top-level HTTP error metadata; generated action failures use `{ error: { ok: false, code, message, status, ... } }` and are covered here.

Closes #2181

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019fcfc4-91a7-7a42-9154-78a5e33eb0c1","issue":2181,"policy_revision":"1.0.0","head":"32c128cdd1196249204924868505615f05a85b6e","validation":{"node":"v24.18.0","status":"local-pass-pending-fresh-ci","users_focused":"33 passed","app_cli_focused":"34 passed","affected_closure_build":"passed","users_typecheck":"passed","app_cli_typecheck":"passed","knowledge_check":"passed","audit_policy":"passed","review_cycle":"pending"}}
```
