### PR TITLE
feat(smrt-app-mcp): add principal-aware MCP tool policy

### DIFF
--- a/packages/smrt-app-mcp/README.md
+++ b/packages/smrt-app-mcp/README.md
@@ -2,7 +2,7 @@
 
 App-runtime MCP server scaffolding for s-m-r-t apps. Provides:
 
-- **Core** — `createMcpAppServer({ smrtOptions, serverInfo, allowedClassNames, publicToolPatterns?, workflowAssertions? })` returning `{ listTools, callTool }` wired to `@happyvertical/smrt-core/generators/mcp`.
+- **Core** — `createMcpAppServer({ smrtOptions, serverInfo, allowedClassNames, publicToolPatterns?, toolPolicy?, workflowAssertions? })` returning `{ listTools, callTool }` wired to `@happyvertical/smrt-core/generators/mcp`.
 - **SvelteKit adapters** (`./sveltekit`) — `mountMcpToolsRoute` / `mountMcpCallRoute` for `/api/mcp/{tools,call}/+server.ts`.
 
 For piping a deployed app's MCP surface to a local stdio MCP client, see `@happyvertical/smrt-app-cli` — the client-side runtime CLI exposes a `startMcpBridge()` default and a generic `smrt-mcp-bridge` bin.
@@ -22,6 +22,11 @@ export const mcpServer = createMcpAppServer({
       .split(',')
       .map((s) => s.trim())
       .filter(Boolean),
+  toolPolicy: ({ tool, principal }) => {
+    if (!principal) return tool.name === 'application_get';
+    if (principal.kind === 'human') return principal.roles?.includes('admin') ?? false;
+    return principal.kind === 'service' && principal.scopes?.includes('mcp:applications') === true;
+  },
   workflowAssertions: {
     application_update: (args, user) => {
       if (!user?.id) throw new McpAccessError(401, 'sign in first');
@@ -45,3 +50,18 @@ import { mcpServer } from '$lib/server/mcp';
 export const POST = mountMcpCallRoute(mcpServer);
 ```
 
+`toolPolicy` is evaluated for every tool eligible under the allow-list and
+base public/authenticated rule, on both discovery and a direct call. Return
+`false` to hide the tool from discovery and deny a direct call with the safe,
+non-retryable `mcp_tool_access_denied` code. Its HTTP response is the shared
+structured failure envelope under `error` (`ok: false`, `code`, `message`,
+`status`, `retryable`) and never includes tool, principal, scope, or
+policy-error details. Policy errors also fail closed. The default remains unchanged:
+unauthenticated callers only see/read tools selected by `publicToolPatterns`.
+
+SvelteKit mounts resolve `event.locals.user` once as the principal for both
+routes. Use `resolvePrincipal` when your app stores a human or scoped-service
+principal elsewhere; `resolveUser` remains a legacy compatibility alias.
+`resolveAuthenticated` is also retained as a deprecated legacy gate; when a
+new `resolvePrincipal` is not supplied, it makes that same route principal
+unauthenticated for both discovery and calls.

--- a/packages/smrt-app-mcp/README.md
+++ b/packages/smrt-app-mcp/README.md
@@ -64,4 +64,7 @@ routes. Use `resolvePrincipal` when your app stores a human or scoped-service
 principal elsewhere; `resolveUser` remains a legacy compatibility alias.
 `resolveAuthenticated` is also retained as a deprecated legacy gate; when a
 new `resolvePrincipal` is not supplied, it makes that same route principal
-unauthenticated for both discovery and calls.
+unauthenticated for both discovery and calls. If an older mount supplies only
+`resolveAuthenticated: () => true` and no principal, discovery keeps its old
+boolean behavior while calls remain user-less as before; migrate that mount to
+`resolvePrincipal` for one identity across both routes.

--- a/packages/smrt-app-mcp/src/__tests__/server.test.ts
+++ b/packages/smrt-app-mcp/src/__tests__/server.test.ts
@@ -5,8 +5,8 @@
  * workflow-assertion paths in isolation.
  */
 
-import { describe, expect, it, vi } from 'vitest';
-import { McpAccessError } from '../errors.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MCP_TOOL_ACCESS_DENIED_CODE, McpAccessError } from '../errors.js';
 import { createMcpAppServer } from '../server.js';
 
 const generateToolsMock = vi.fn();
@@ -33,6 +33,11 @@ function tool(name: string) {
 }
 
 describe('createMcpAppServer', () => {
+  beforeEach(() => {
+    generateToolsMock.mockReset();
+    handleToolCallMock.mockReset();
+  });
+
   it('filters tools to the allow-listed class prefixes', async () => {
     generateToolsMock.mockResolvedValue([
       tool('opportunity_list'),
@@ -73,6 +78,69 @@ describe('createMcpAppServer', () => {
     ]);
   });
 
+  it('applies one principal policy to unauthenticated, human, and scoped-service discovery', async () => {
+    generateToolsMock.mockResolvedValue([
+      tool('opportunity_get'),
+      tool('opportunity_create'),
+    ]);
+    const policyCalls = vi.fn(({ tool: candidate, principal }) => {
+      if (!principal) return candidate.name === 'opportunity_get';
+      if (principal.kind === 'human') {
+        return principal.roles?.includes('operator') ?? false;
+      }
+      return (
+        principal.kind === 'service' &&
+        principal.scopes?.includes('mcp:opportunities:write') === true
+      );
+    });
+    const server = createMcpAppServer({
+      smrtOptions: () => ({}),
+      serverInfo: { name: 'app', version: '0.1.0' },
+      allowedClassNames: ['Opportunity'],
+      publicToolPatterns: () => ['opportunity_get'],
+      toolPolicy: policyCalls,
+    });
+
+    await expect(server.listTools({ principal: null })).resolves.toMatchObject([
+      { name: 'opportunity_get' },
+    ]);
+    await expect(
+      server.listTools({
+        principal: { id: 'human-1', kind: 'human', roles: ['operator'] },
+      }),
+    ).resolves.toMatchObject([
+      { name: 'opportunity_get' },
+      { name: 'opportunity_create' },
+    ]);
+    await expect(
+      server.listTools({
+        principal: {
+          id: 'service-1',
+          kind: 'service',
+          scopes: ['mcp:opportunities:read'],
+        },
+      }),
+    ).resolves.toMatchObject([]);
+    await expect(
+      server.listTools({
+        principal: {
+          id: 'service-2',
+          kind: 'service',
+          scopes: ['mcp:opportunities:write'],
+        },
+      }),
+    ).resolves.toMatchObject([
+      { name: 'opportunity_get' },
+      { name: 'opportunity_create' },
+    ]);
+    expect(policyCalls).toHaveBeenCalledWith(
+      expect.objectContaining({
+        principal: null,
+        tool: expect.objectContaining({ name: 'opportunity_get' }),
+      }),
+    );
+  });
+
   it('rejects calls to tools outside the allow-list with 404', async () => {
     generateToolsMock.mockResolvedValue([tool('opportunity_list')]);
     const server = createMcpAppServer({
@@ -99,6 +167,57 @@ describe('createMcpAppServer', () => {
     await expect(
       server.callTool({ name: 'opportunity_create', user: null }),
     ).rejects.toBeInstanceOf(McpAccessError);
+  });
+
+  it('denies a direct call hidden by the principal policy without dispatching it', async () => {
+    generateToolsMock.mockResolvedValue([tool('opportunity_create')]);
+    const server = createMcpAppServer({
+      smrtOptions: () => ({}),
+      serverInfo: { name: 'app', version: '0.1.0' },
+      allowedClassNames: ['Opportunity'],
+      toolPolicy: ({ principal }) =>
+        principal?.kind === 'service' &&
+        principal.scopes?.includes('mcp:opportunities:write') === true,
+    });
+
+    await expect(
+      server.callTool({
+        name: 'opportunity_create',
+        principal: {
+          id: 'service-1',
+          kind: 'service',
+          scopes: ['mcp:opportunities:read'],
+        },
+      }),
+    ).rejects.toMatchObject({
+      metadata: {
+        code: MCP_TOOL_ACCESS_DENIED_CODE,
+        retryable: false,
+      },
+      status: 403,
+    });
+    expect(handleToolCallMock).not.toHaveBeenCalled();
+  });
+
+  it('fails closed without exposing a thrown policy error', async () => {
+    generateToolsMock.mockResolvedValue([tool('opportunity_get')]);
+    const server = createMcpAppServer({
+      smrtOptions: () => ({}),
+      serverInfo: { name: 'app', version: '0.1.0' },
+      allowedClassNames: ['Opportunity'],
+      publicToolPatterns: () => ['opportunity_get'],
+      toolPolicy: () => {
+        throw new Error('service credential was unavailable');
+      },
+    });
+
+    await expect(
+      server.callTool({ name: 'opportunity_get', principal: null }),
+    ).rejects.toMatchObject({
+      message: 'MCP tool access is not permitted.',
+      metadata: { code: MCP_TOOL_ACCESS_DENIED_CODE, retryable: false },
+      status: 403,
+    });
   });
 
   it('runs workflow assertions and lets them inject server-trusted args', async () => {

--- a/packages/smrt-app-mcp/src/__tests__/server.test.ts
+++ b/packages/smrt-app-mcp/src/__tests__/server.test.ts
@@ -265,20 +265,26 @@ describe('createMcpAppServer', () => {
   });
 
   it('reads public patterns lazily so env stubbing in tests works', async () => {
-    generateToolsMock.mockResolvedValue([tool('opportunity_list')]);
+    generateToolsMock.mockResolvedValue([
+      tool('opportunity_list'),
+      tool('opportunity_get'),
+    ]);
     const patternRef = { value: [] as string[] };
+    const publicToolPatterns = vi.fn(() => patternRef.value);
     const server = createMcpAppServer({
       smrtOptions: () => ({}),
       serverInfo: { name: 'app', version: '0.1.0' },
       allowedClassNames: ['Opportunity'],
-      publicToolPatterns: () => patternRef.value,
+      publicToolPatterns,
     });
 
     expect((await server.listTools({ authenticated: false })).length).toBe(0);
+    expect(publicToolPatterns).toHaveBeenCalledTimes(1);
 
     patternRef.value = ['opportunity_*'];
     expect(
       (await server.listTools({ authenticated: false })).map((t) => t.name),
-    ).toEqual(['opportunity_list']);
+    ).toEqual(['opportunity_list', 'opportunity_get']);
+    expect(publicToolPatterns).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/smrt-app-mcp/src/__tests__/sveltekit.test.ts
+++ b/packages/smrt-app-mcp/src/__tests__/sveltekit.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { McpAccessError } from '../errors.js';
+import { MCP_TOOL_ACCESS_DENIED_CODE, McpAccessError } from '../errors.js';
 import type { McpAppServer } from '../server.js';
 import { mountMcpCallRoute, mountMcpToolsRoute } from '../sveltekit.js';
 
@@ -37,11 +37,11 @@ function makeServer(overrides: Partial<McpAppServer> = {}): McpAppServer {
 }
 
 describe('mountMcpToolsRoute', () => {
-  it('returns the wrapped tools shape and honours resolveAuthenticated', async () => {
-    let received: boolean | null = null;
+  it('returns the wrapped tools shape and resolves a principal', async () => {
+    let received: unknown = null;
     const server = makeServer({
-      listTools: async ({ authenticated }) => {
-        received = authenticated;
+      listTools: async ({ principal }) => {
+        received = principal;
         return [
           {
             name: 'a',
@@ -52,11 +52,13 @@ describe('mountMcpToolsRoute', () => {
       },
     });
     const handler = mountMcpToolsRoute(server, {
-      resolveAuthenticated: (event) => event.locals?.flag === true,
+      resolvePrincipal: (event) =>
+        event.locals?.principal as { id: string; kind: string },
     });
-    const response = await handler(makeEvent({ locals: { flag: true } }));
+    const principal = { id: 'service-1', kind: 'service' };
+    const response = await handler(makeEvent({ locals: { principal } }));
     expect(response.status).toBe(200);
-    expect(received).toBe(true);
+    expect(received).toBe(principal);
     expect(await response.json()).toEqual({
       tools: [
         {
@@ -66,6 +68,35 @@ describe('mountMcpToolsRoute', () => {
         },
       ],
     });
+  });
+
+  it('keeps the legacy authentication gate without splitting route principals', async () => {
+    let discoveredPrincipal: unknown;
+    let calledPrincipal: unknown;
+    const principal = { id: 'u-1', kind: 'human' };
+    const server = makeServer({
+      listTools: async ({ principal: received }) => {
+        discoveredPrincipal = received;
+        return [];
+      },
+      callTool: async ({ principal: received }) => {
+        calledPrincipal = received;
+        return { content: [] };
+      },
+    });
+    const options = {
+      resolveAuthenticated: () => false,
+      resolveUser: () => principal,
+    };
+
+    await mountMcpToolsRoute(server, options)(makeEvent({}));
+    await mountMcpCallRoute(
+      server,
+      options,
+    )(makeEvent({ body: { name: 'x' } }));
+
+    expect(discoveredPrincipal).toBeNull();
+    expect(calledPrincipal).toBeNull();
   });
 
   it('maps McpAccessError onto the right status code', async () => {
@@ -106,8 +137,40 @@ describe('mountMcpCallRoute', () => {
     expect(received).toEqual({
       arguments: { foo: 1 },
       name: 'x',
-      user: { id: 'u-1' },
+      principal: { id: 'u-1' },
     });
+  });
+
+  it('uses the same resolved principal shape for discovery and direct calls', async () => {
+    let discoveredPrincipal: unknown = null;
+    let calledPrincipal: unknown = null;
+    const principal = {
+      id: 'service-1',
+      kind: 'service',
+      scopes: ['mcp:opportunities:write'],
+    };
+    const server = makeServer({
+      listTools: async ({ principal: received }) => {
+        discoveredPrincipal = received;
+        return [];
+      },
+      callTool: async ({ principal: received }) => {
+        calledPrincipal = received;
+        return { content: [] };
+      },
+    });
+    const options = {
+      resolvePrincipal: () => principal,
+    };
+
+    await mountMcpToolsRoute(server, options)(makeEvent({}));
+    await mountMcpCallRoute(
+      server,
+      options,
+    )(makeEvent({ body: { name: 'x' } }));
+
+    expect(discoveredPrincipal).toBe(principal);
+    expect(calledPrincipal).toBe(principal);
   });
 
   it('translates McpAccessError thrown from callTool', async () => {
@@ -121,5 +184,30 @@ describe('mountMcpCallRoute', () => {
     );
     expect(response.status).toBe(401);
     expect(await response.json()).toEqual({ error: 'auth required' });
+  });
+
+  it('returns the shared safe failure envelope for policy denials', async () => {
+    const server = makeServer({
+      callTool: async () => {
+        throw new McpAccessError(403, 'MCP tool access is not permitted.', {
+          code: MCP_TOOL_ACCESS_DENIED_CODE,
+          retryable: false,
+        });
+      },
+    });
+
+    const response = await mountMcpCallRoute(server)(
+      makeEvent({ body: { name: 'x' } }),
+    );
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        ok: false,
+        code: MCP_TOOL_ACCESS_DENIED_CODE,
+        message: 'MCP tool access is not permitted.',
+        status: 403,
+        retryable: false,
+      },
+    });
   });
 });

--- a/packages/smrt-app-mcp/src/__tests__/sveltekit.test.ts
+++ b/packages/smrt-app-mcp/src/__tests__/sveltekit.test.ts
@@ -99,6 +99,36 @@ describe('mountMcpToolsRoute', () => {
     expect(calledPrincipal).toBeNull();
   });
 
+  it('preserves a positive legacy discovery marker when no principal is available', async () => {
+    let discoveryInput: unknown;
+    let callInput: unknown;
+    const server = makeServer({
+      listTools: async (input) => {
+        discoveryInput = input;
+        return [];
+      },
+      callTool: async (input) => {
+        callInput = input;
+        return { content: [] };
+      },
+    });
+    const options = {
+      resolveAuthenticated: () => true,
+      resolveUser: () => null,
+    };
+
+    await mountMcpToolsRoute(server, options)(makeEvent({}));
+    await mountMcpCallRoute(
+      server,
+      options,
+    )(makeEvent({ body: { name: 'x' } }));
+
+    // This was the previous tools-route input. Calls remain user-less, as
+    // before; apps should migrate to resolvePrincipal for shared identity.
+    expect(discoveryInput).toEqual({ authenticated: true });
+    expect(callInput).toEqual({ arguments: {}, name: 'x', principal: null });
+  });
+
   it('maps McpAccessError onto the right status code', async () => {
     const server = makeServer({
       listTools: async () => {

--- a/packages/smrt-app-mcp/src/errors.ts
+++ b/packages/smrt-app-mcp/src/errors.ts
@@ -1,3 +1,16 @@
+/** Machine-readable code for a principal policy denial. */
+export const MCP_TOOL_ACCESS_DENIED_CODE = 'mcp_tool_access_denied';
+
+/**
+ * Metadata that is safe to expose for an app-MCP access failure. Policy
+ * implementations must not place principal, scope, tool, or internal-error
+ * details here.
+ */
+export interface McpAccessErrorMetadata {
+  code?: string;
+  retryable?: boolean;
+}
+
 /**
  * Error returned by the MCP app server when a caller tries to use a tool
  * they are not allowed to access. The HTTP layer should map `status` onto
@@ -7,6 +20,7 @@ export class McpAccessError extends Error {
   constructor(
     readonly status: number,
     message: string,
+    readonly metadata: McpAccessErrorMetadata = {},
   ) {
     super(message);
     this.name = 'McpAccessError';

--- a/packages/smrt-app-mcp/src/index.ts
+++ b/packages/smrt-app-mcp/src/index.ts
@@ -22,16 +22,23 @@
  * @packageDocumentation
  */
 
-export { McpAccessError } from './errors.js';
+export {
+  MCP_TOOL_ACCESS_DENIED_CODE,
+  McpAccessError,
+  type McpAccessErrorMetadata,
+} from './errors.js';
 export {
   type CallToolInput,
   type CreateMcpAppServerOptions,
   createMcpAppServer,
   type ListToolsInput,
+  type McpAppPrincipal,
   type McpAppServer,
   type McpAppUser,
   type McpPublicToolPatternsThunk,
   type McpSmrtOptionsThunk,
+  type McpToolPolicy,
+  type McpToolPolicyContext,
   type McpWorkflowAssertion,
 } from './server.js';
 export {

--- a/packages/smrt-app-mcp/src/server.ts
+++ b/packages/smrt-app-mcp/src/server.ts
@@ -203,10 +203,10 @@ export function createMcpAppServer(
   function passesBasePolicy(
     tool: MCPTool,
     principal: McpAppPrincipal | null,
+    publicPatterns?: readonly string[],
   ): boolean {
-    return (
-      Boolean(principal) || isPublicToolName(tool.name, getPublicPatterns())
-    );
+    if (principal) return true;
+    return isPublicToolName(tool.name, publicPatterns ?? []);
   }
 
   async function passesToolPolicy(
@@ -225,9 +225,13 @@ export function createMcpAppServer(
   async function listTools(input: ListToolsInput): Promise<MCPTool[]> {
     const principal = principalForList(input);
     const tools = await allowedTools();
+    // Keep the lazy thunk per request, not per tool. Besides avoiding repeated
+    // work, this gives one consistent public surface when a thunk reads a
+    // dynamic source such as an environment-backed configuration.
+    const publicPatterns = principal ? undefined : getPublicPatterns();
     const visible = await Promise.all(
       tools.map(async (tool) => {
-        if (!passesBasePolicy(tool, principal)) return false;
+        if (!passesBasePolicy(tool, principal, publicPatterns)) return false;
         return passesToolPolicy(tool, principal);
       }),
     );
@@ -243,7 +247,8 @@ export function createMcpAppServer(
       throw new McpAccessError(404, `Unknown MCP tool: ${input.name}`);
     }
 
-    if (!passesBasePolicy(tool, principal)) {
+    const publicPatterns = principal ? undefined : getPublicPatterns();
+    if (!passesBasePolicy(tool, principal, publicPatterns)) {
       throw new McpAccessError(
         401,
         `Authentication is required for MCP tool: ${input.name}`,

--- a/packages/smrt-app-mcp/src/server.ts
+++ b/packages/smrt-app-mcp/src/server.ts
@@ -7,6 +7,8 @@
  *    objects, not everything decorated with `@smrt()`),
  *  - a public-tool policy for unauthenticated callers (read-only patterns
  *    via `publicToolPatterns`),
+ *  - an optional principal-aware `toolPolicy`, used for both discovery and
+ *    direct calls,
  *  - a pluggable `workflowAssertions` hook so apps can guard their own
  *    domain-specific tool calls (e.g. "approval requires an authenticated
  *    user") without that policy living in this package.
@@ -20,18 +22,48 @@ import type {
   MCPTool,
 } from '@happyvertical/smrt-core/generators/mcp';
 import { MCPGenerator } from '@happyvertical/smrt-core/generators/mcp';
-import { McpAccessError } from './errors.js';
+import { MCP_TOOL_ACCESS_DENIED_CODE, McpAccessError } from './errors.js';
 import {
   classNamePrefixes,
   isAllowedCoreTool,
   isPublicToolName,
 } from './tools.js';
 
-/** Minimal user shape used for tool-call attribution. */
-export interface McpAppUser {
-  id: string;
+/**
+ * Generic authenticated caller information available to app-MCP policy.
+ *
+ * `kind`, `roles`, and `scopes` are deliberately unconstrained so an app can
+ * represent a human or a scoped service without this package encoding an
+ * application's identity or capability model. A missing principal means the
+ * request is unauthenticated.
+ */
+export interface McpAppPrincipal {
+  id?: string;
+  kind?: string;
   roles?: string[];
+  scopes?: string[];
 }
+
+/** Minimal legacy user shape used for generated tool-call attribution. */
+export interface McpAppUser extends McpAppPrincipal {
+  id: string;
+}
+
+/** Context supplied to the optional per-tool principal policy. */
+export interface McpToolPolicyContext {
+  principal: McpAppPrincipal | null;
+  tool: MCPTool;
+}
+
+/**
+ * Per-tool access policy. Return `true` to expose/allow the tool and `false`
+ * to hide it from discovery and deny a direct call. A thrown error is treated
+ * as a denial so policy implementation details cannot escape the app-MCP
+ * boundary.
+ */
+export type McpToolPolicy = (
+  context: McpToolPolicyContext,
+) => boolean | Promise<boolean>;
 
 /**
  * Workflow assertion hook signature. Throw `McpAccessError` to reject the
@@ -75,6 +107,12 @@ export interface CreateMcpAppServerOptions {
    */
   publicToolPatterns?: McpPublicToolPatternsThunk;
   /**
+   * Optional generic principal-aware tool policy. It is evaluated for every
+   * tool that passes the app allow-list and base public/authenticated policy,
+   * for both discovery and a direct call.
+   */
+  toolPolicy?: McpToolPolicy;
+  /**
    * Optional per-tool guards. Keyed by tool name. The assertion runs after
    * tool resolution and before `MCPGenerator.handleToolCall`; throwing
    * `McpAccessError` aborts the call with the error's status. Implementations
@@ -85,15 +123,25 @@ export interface CreateMcpAppServerOptions {
 
 /** Tool listing inputs. */
 export interface ListToolsInput {
-  /** Whether the calling principal is authenticated. */
-  authenticated: boolean;
+  /** Caller used for public/authenticated and optional tool-policy checks. */
+  principal?: McpAppPrincipal | null;
+  /**
+   * Backwards-compatible authenticated marker. New mounts should pass
+   * `principal` so discovery and direct calls use the same identity.
+   */
+  authenticated?: boolean;
 }
 
 /** Tool call inputs. */
 export interface CallToolInput {
   name: string;
   arguments?: Record<string, unknown>;
-  /** Authenticated user; null/undefined means unauthenticated. */
+  /** Caller used for public/authenticated and optional tool-policy checks. */
+  principal?: McpAppPrincipal | null;
+  /**
+   * Backwards-compatible user input. New callers should pass `principal`.
+   * Null/undefined means unauthenticated.
+   */
   user?: McpAppUser | null;
 }
 
@@ -116,46 +164,105 @@ export function createMcpAppServer(
   const allowedPrefixes = classNamePrefixes(options.allowedClassNames);
   const getPublicPatterns =
     options.publicToolPatterns ?? ((): readonly string[] => []);
+  const toolPolicy = options.toolPolicy;
   const workflowAssertions = options.workflowAssertions ?? {};
 
-  function makeGenerator(user?: McpAppUser | null): MCPGenerator {
+  function userForGenerator(
+    principal?: McpAppPrincipal | null,
+  ): McpAppUser | undefined {
+    if (!principal?.id) return undefined;
+    return { id: principal.id, roles: principal.roles };
+  }
+
+  function makeGenerator(principal?: McpAppPrincipal | null): MCPGenerator {
+    const user = userForGenerator(principal);
     return new MCPGenerator(options.serverInfo as MCPConfig, {
       ...options.smrtOptions(),
-      user: user?.id ? { id: user.id, roles: user.roles } : undefined,
+      user,
     });
   }
 
-  async function listTools(input: ListToolsInput): Promise<MCPTool[]> {
+  function principalForList(input: ListToolsInput): McpAppPrincipal | null {
+    if (input.principal !== undefined) return input.principal;
+    // Preserve callers of the original boolean API without inventing an id.
+    return input.authenticated ? {} : null;
+  }
+
+  function principalForCall(input: CallToolInput): McpAppPrincipal | null {
+    if (input.principal !== undefined) return input.principal;
+    return input.user ?? null;
+  }
+
+  async function allowedTools(): Promise<MCPTool[]> {
     const tools = await makeGenerator().generateTools();
-    const allowed = tools.filter((tool) =>
+    return tools.filter((tool) =>
       isAllowedCoreTool(tool.name, allowedPrefixes),
     );
-    if (input.authenticated) return allowed;
-    const patterns = getPublicPatterns();
-    return allowed.filter((tool) => isPublicToolName(tool.name, patterns));
+  }
+
+  function passesBasePolicy(
+    tool: MCPTool,
+    principal: McpAppPrincipal | null,
+  ): boolean {
+    return (
+      Boolean(principal) || isPublicToolName(tool.name, getPublicPatterns())
+    );
+  }
+
+  async function passesToolPolicy(
+    tool: MCPTool,
+    principal: McpAppPrincipal | null,
+  ): Promise<boolean> {
+    if (!toolPolicy) return true;
+    try {
+      return Boolean(await toolPolicy({ principal, tool }));
+    } catch {
+      // A policy failure must fail closed and never leak implementation detail.
+      return false;
+    }
+  }
+
+  async function listTools(input: ListToolsInput): Promise<MCPTool[]> {
+    const principal = principalForList(input);
+    const tools = await allowedTools();
+    const visible = await Promise.all(
+      tools.map(async (tool) => {
+        if (!passesBasePolicy(tool, principal)) return false;
+        return passesToolPolicy(tool, principal);
+      }),
+    );
+    return tools.filter((_, index) => visible[index]);
   }
 
   async function callTool(input: CallToolInput): Promise<MCPResponse> {
     const args = input.arguments ?? {};
-    const user = input.user ?? null;
-    const tools = await listTools({ authenticated: true });
-    if (!tools.some((tool) => tool.name === input.name)) {
+    const principal = principalForCall(input);
+    const tools = await allowedTools();
+    const tool = tools.find((candidate) => candidate.name === input.name);
+    if (!tool) {
       throw new McpAccessError(404, `Unknown MCP tool: ${input.name}`);
     }
 
-    if (!user && !isPublicToolName(input.name, getPublicPatterns())) {
+    if (!passesBasePolicy(tool, principal)) {
       throw new McpAccessError(
         401,
         `Authentication is required for MCP tool: ${input.name}`,
       );
     }
 
-    const assertion = workflowAssertions[input.name];
-    if (assertion) {
-      assertion(args, user);
+    if (!(await passesToolPolicy(tool, principal))) {
+      throw new McpAccessError(403, 'MCP tool access is not permitted.', {
+        code: MCP_TOOL_ACCESS_DENIED_CODE,
+        retryable: false,
+      });
     }
 
-    return makeGenerator(user).handleToolCall({
+    const assertion = workflowAssertions[input.name];
+    if (assertion) {
+      assertion(args, userForGenerator(principal) ?? null);
+    }
+
+    return makeGenerator(principal).handleToolCall({
       method: 'tools/call',
       params: { arguments: args, name: input.name },
     });

--- a/packages/smrt-app-mcp/src/sveltekit.ts
+++ b/packages/smrt-app-mcp/src/sveltekit.ts
@@ -15,7 +15,7 @@
  */
 
 import { McpAccessError } from './errors.js';
-import type { CallToolInput, McpAppServer, McpAppUser } from './server.js';
+import type { CallToolInput, McpAppPrincipal, McpAppServer } from './server.js';
 
 /** Minimal subset of a SvelteKit RequestEvent we actually touch. */
 type SvelteKitRequestEvent = {
@@ -26,27 +26,50 @@ type SvelteKitRequestEvent = {
 
 type SvelteKitHandler = (event: SvelteKitRequestEvent) => Promise<Response>;
 
-/** Locals reader used to pull the authenticated user out of `event.locals`. */
-export type McpUserResolver = (
+/** Locals reader used to pull the request principal out of `event.locals`. */
+export type McpPrincipalResolver = (
   event: SvelteKitRequestEvent,
-) => McpAppUser | null | undefined;
+) => McpAppPrincipal | null | undefined;
 
-const defaultResolveUser: McpUserResolver = (event) =>
-  (event.locals?.user ?? null) as McpAppUser | null;
+/** Backwards-compatible alias for callers that name the principal a user. */
+export type McpUserResolver = McpPrincipalResolver;
 
-const defaultResolveAuthenticated = (event: SvelteKitRequestEvent): boolean =>
-  Boolean(event.locals?.user);
+const defaultResolvePrincipal: McpPrincipalResolver = (event) =>
+  (event.locals?.user ?? null) as McpAppPrincipal | null;
+
+function resolveRequestPrincipal(
+  event: SvelteKitRequestEvent,
+  options: MountMcpRouteOptions,
+): McpAppPrincipal | null {
+  const resolvePrincipal =
+    options.resolvePrincipal ?? options.resolveUser ?? defaultResolvePrincipal;
+  const principal = resolvePrincipal(event) ?? null;
+  // Keep the legacy boolean gate for existing apps, but apply it to the same
+  // principal that both routes receive. A new principal resolver supersedes it.
+  if (
+    !options.resolvePrincipal &&
+    options.resolveAuthenticated &&
+    !options.resolveAuthenticated(event)
+  ) {
+    return null;
+  }
+  return principal;
+}
 
 /** Options shared by both route mounts. */
 export interface MountMcpRouteOptions {
   /**
-   * Resolve the authenticated user from `event.locals`. Defaults to
-   * `event.locals.user`.
+   * Resolve the request principal once for both discovery and direct calls.
+   * Defaults to `event.locals.user`.
+   */
+  resolvePrincipal?: McpPrincipalResolver;
+  /**
+   * Backwards-compatible alias for `resolvePrincipal`.
    */
   resolveUser?: McpUserResolver;
   /**
-   * Resolve whether the request is authenticated. Defaults to
-   * `Boolean(event.locals.user)`.
+   * Deprecated legacy authentication gate. When `resolvePrincipal` is not
+   * supplied, a false result makes the principal null for both routes.
    */
   resolveAuthenticated?: (event: SvelteKitRequestEvent) => boolean;
 }
@@ -59,18 +82,15 @@ export function mountMcpToolsRoute(
   server: McpAppServer,
   options: MountMcpRouteOptions = {},
 ): SvelteKitHandler {
-  const resolveAuthenticated =
-    options.resolveAuthenticated ?? defaultResolveAuthenticated;
-
   return async (event) => {
     try {
       const tools = await server.listTools({
-        authenticated: resolveAuthenticated(event),
+        principal: resolveRequestPrincipal(event, options),
       });
       return jsonResponse({ tools });
     } catch (error) {
       if (error instanceof McpAccessError) {
-        return jsonResponse({ error: error.message }, error.status);
+        return jsonResponse(mcpAccessErrorBody(error), error.status);
       }
       throw error;
     }
@@ -85,8 +105,6 @@ export function mountMcpCallRoute(
   server: McpAppServer,
   options: MountMcpRouteOptions = {},
 ): SvelteKitHandler {
-  const resolveUser = options.resolveUser ?? defaultResolveUser;
-
   return async (event) => {
     const body = (await event.request.json().catch(() => null)) as {
       arguments?: Record<string, unknown>;
@@ -100,17 +118,33 @@ export function mountMcpCallRoute(
     const input: CallToolInput = {
       arguments: body.arguments ?? {},
       name: body.name,
-      user: resolveUser(event) ?? null,
+      principal: resolveRequestPrincipal(event, options),
     };
 
     try {
       return jsonResponse(await server.callTool(input));
     } catch (error) {
       if (error instanceof McpAccessError) {
-        return jsonResponse({ error: error.message }, error.status);
+        return jsonResponse(mcpAccessErrorBody(error), error.status);
       }
       throw error;
     }
+  };
+}
+
+function mcpAccessErrorBody(error: McpAccessError): unknown {
+  const { code, retryable } = error.metadata;
+  // Preserve the legacy shape unless an error deliberately opts into the
+  // shared structured failure contract.
+  if (!code) return { error: error.message };
+  return {
+    error: {
+      ok: false,
+      code,
+      message: error.message,
+      status: error.status,
+      ...(retryable === undefined ? {} : { retryable }),
+    },
   };
 }
 
@@ -122,4 +156,4 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 export { McpAccessError } from './errors.js';
-export type { McpAppServer } from './server.js';
+export type { McpAppPrincipal, McpAppServer } from './server.js';

--- a/packages/smrt-app-mcp/src/sveltekit.ts
+++ b/packages/smrt-app-mcp/src/sveltekit.ts
@@ -26,6 +26,12 @@ type SvelteKitRequestEvent = {
 
 type SvelteKitHandler = (event: SvelteKitRequestEvent) => Promise<Response>;
 
+type ResolvedRequestPrincipal = {
+  principal: McpAppPrincipal | null;
+  /** Defined only for the legacy discovery-only authentication adapter. */
+  legacyAuthenticated?: boolean;
+};
+
 /** Locals reader used to pull the request principal out of `event.locals`. */
 export type McpPrincipalResolver = (
   event: SvelteKitRequestEvent,
@@ -40,7 +46,7 @@ const defaultResolvePrincipal: McpPrincipalResolver = (event) =>
 function resolveRequestPrincipal(
   event: SvelteKitRequestEvent,
   options: MountMcpRouteOptions,
-): McpAppPrincipal | null {
+): ResolvedRequestPrincipal {
   const resolvePrincipal =
     options.resolvePrincipal ?? options.resolveUser ?? defaultResolvePrincipal;
   const principal = resolvePrincipal(event) ?? null;
@@ -51,9 +57,25 @@ function resolveRequestPrincipal(
     options.resolveAuthenticated &&
     !options.resolveAuthenticated(event)
   ) {
-    return null;
+    return { principal: null, legacyAuthenticated: false };
   }
-  return principal;
+  return {
+    principal,
+    ...(options.resolvePrincipal || !options.resolveAuthenticated
+      ? {}
+      : { legacyAuthenticated: true }),
+  };
+}
+
+function listToolsInput(resolved: ResolvedRequestPrincipal) {
+  // Before principal-aware routes, `resolveAuthenticated` affected discovery
+  // independently of `resolveUser`. Preserve a true legacy result only when
+  // there is no principal to pass; new routes should use `resolvePrincipal`
+  // for a single identity on both discovery and calls.
+  if (!resolved.principal && resolved.legacyAuthenticated) {
+    return { authenticated: true };
+  }
+  return { principal: resolved.principal };
 }
 
 /** Options shared by both route mounts. */
@@ -84,9 +106,9 @@ export function mountMcpToolsRoute(
 ): SvelteKitHandler {
   return async (event) => {
     try {
-      const tools = await server.listTools({
-        principal: resolveRequestPrincipal(event, options),
-      });
+      const tools = await server.listTools(
+        listToolsInput(resolveRequestPrincipal(event, options)),
+      );
       return jsonResponse({ tools });
     } catch (error) {
       if (error instanceof McpAccessError) {
@@ -118,7 +140,7 @@ export function mountMcpCallRoute(
     const input: CallToolInput = {
       arguments: body.arguments ?? {},
       name: body.name,
-      principal: resolveRequestPrincipal(event, options),
+      principal: resolveRequestPrincipal(event, options).principal,
     };
 
     try {


### PR DESCRIPTION
Fixes #2184

## Summary

- Add an optional, reusable principal-aware per-tool policy to `@happyvertical/smrt-app-mcp`.
- Apply the policy consistently to tool discovery and direct calls; policy-hidden tools cannot be invoked directly.
- Pass one SvelteKit-resolved principal to both routes, while retaining the legacy user/authentication options safely.

## Neutral safe error contract

This change is intentionally application-neutral: it has no Work, capability, or other app-specific policy logic.

It aligns with #2181 and #2182 on the safe denial envelope:

```json
{
  "error": {
    "ok": false,
    "code": "mcp_tool_access_denied",
    "message": "MCP tool access is not permitted.",
    "status": 403,
    "retryable": false
  }
}
```

The envelope omits tool, principal, scope, and policy-error details. A thrown policy fails closed before workflow assertions or tool dispatch.

## Validation

Exact final head: `1d0f4a48c66481436be64b2f7bb0f39a73d9bfc8`

Runtime used for every claimed green validation:
`/Users/will/.local/share/fnm/node-versions/v24.18.0/installation/bin/node` — `v24.18.0`

- Exact-head: `pnpm --filter @happyvertical/smrt-app-mcp test` (29 tests), `check`, `build`, and `verify:pack`
- Exact-head: `pnpm smrt dev:knowledge-check`, `pnpm audit:policy`, `git show --check`, and `git diff --check`
- Full workspace (same exact Node binary, exact head): `pnpm build`, `pnpm test` (119 tasks), `pnpm typecheck`, `pnpm lint`, `pnpm format`, `pnpm smrt dev:knowledge-check`, and `pnpm audit:policy`
- Review-cycle: independent code review found the `resolveAuthenticated` compatibility omission; it was restored, tested, and the confirmation review approved with no findings.

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019fbe64-896b-7bb3-a665-ec73bc012374","issue":"2184","policy_revision":"1.0.0","validation":["Exact head 1d0f4a48c66481436be64b2f7bb0f39a73d9bfc8; package suite, build, pack, knowledge, audit, and diff checks pass on Node v24.18.0 at /Users/will/.local/share/fnm/node-versions/v24.18.0/installation/bin/node.","Full workspace build, test, typecheck, lint, format, knowledge, audit, and diff checks passed at the exact head on the same Node binary.","Review-cycle confirmation review approved with no findings."]}