### PR TITLE
feat(core): conform custom action discovery

### DIFF
--- a/packages/core/agents/generators.md
+++ b/packages/core/agents/generators.md
@@ -27,4 +27,29 @@ The web module also emits a build-time **`manifestHash`** constant (#1764): `com
 
 Per-field web emission (#2046): `buildWebFieldDefinitions` carries `description` (from `@field({ description })`) and sanitized `ui` hints (from `@field({ ui: { basic, group, order, locked } })`, read off the manifest `_meta.ui` bag through per-key type guards) into each emitted field definition, and `buildWebToolDescriptors` threads the same `description` into browser MCP tool schemas. `sensitive`/`transient` fields are excluded from emission entirely, so their descriptions never ship. Both keys are conditional, so hint-less schemas emit byte-identical definitions (and hashes) as before; adding a description/ui hint changes the manifest hash — deliberate over-invalidation, harmless per the #1764 contract.
 
+## Custom-action contract
+
+`resolveCustomActionMetadata()` is the common discovery and invocation contract
+for generated REST routes and API clients, MCP, CLI, WebMCP, and simple
+REST-resource discovery. Receiver scope comes from the executable method, never a
+configuration-only `api.routes[name].scope` override: instance model methods
+are item-scoped and require `id`; static model methods and recognized
+`SmrtCollection` methods are collection-scoped and do not accept `id`. Route
+configuration may still choose its path and HTTP verb, but it cannot turn an
+instance call into `ClassRef.action` or vice versa.
+
+When scanner method metadata exists, discovery projects each named parameter
+and its JSON-schema type, and invokers pass the values positionally in declared
+order. The legacy single `options` bag remains compatible when metadata is
+absent (or the declared method takes `options`). Do not infer this from runtime
+function arity.
+
+Custom actions may return an explicit, domain-neutral failure object with
+`ok: false`, `code`, and `message` plus optional `status`, `details`,
+`retryable`, and `correlationId`. `normalizeCustomActionFailure()` redacts it;
+generated REST returns `{ error: failure }` with the non-2xx status, while MCP
+returns `isError: true` and `_meta['io.happyvertical/smrt']`. Opaque successful
+objects (including `{ code, message }`) remain untouched; thrown exceptions are
+not reclassified as domain failures.
+
 Generated reads (`list`/`get`) on the REST and SvelteKit generators support conditional GET (helpers in `src/generators/conditional-get.ts`). ETag v2 (#1765): the validator is the table's change-feed version (`getTableVersion`) keyed by the request representation, so a **concrete** `If-None-Match` short-circuits into a 304 with an empty body **before** the collection query runs — an unchanged table revalidates with zero table scan. A wildcard `If-None-Match: *` is deferred until the payload builds (existence confirmed), so a missing item still returns 404, not a false 304. Tenant-scoped reads fold the active tenant into the representation (`resolveTenantEtagDiscriminator`) so one tenant's cached validator never satisfies another's read of the same URL. Routes whose GET renders via a **custom serializer** (which can load related tables the base-table version can't observe) keep the v1 body-hash ETag (`#1757`, query-first but correct); the default `toPublicJSON` path — all REST reads and non-serializer SvelteKit reads — uses v2. v2 is weakly consistent by design (the cost of not reading the data): a revalidation in the sub-statement window between a committed write and its feed append can return a stale 304 that self-heals on the next revalidation. The other v2 window — a deploy that changes the response shape WITHOUT a table write — is closed by the **#1764 ETag salt**: `computeTableVersionEtag(version, representation, manifestHash?)` folds the build's web-collection shape digest into the digest, so a shape-only redeploy busts every read validator (`undefined` reproduces the pre-#1764 unsalted value byte-for-byte for direct helper callers). The generated SvelteKit route bakes the digest in as a `MANIFEST_HASH` constant (via `generateConditionalGetRouteHelper`'s `manifestHash` option, sourced from `computeWebManifestHash(manifest)`) — automatic for the SvelteKit transport. The runtime `APIGenerator` auto-populates the same salt from the runtime registry with `computeRuntimeWebManifestHash()` when `APIConfig.manifestHash` is omitted; explicit `APIConfig.manifestHash` still wins for custom setups. The digest scope is get-OR-list (`selectWebEtagSaltEntries`), so **get-only** routes are salted too. Strong consistency still requires the v1 body-hash path. Cache-Control policy (unchanged from #1757): `private, no-cache` by default; public models may opt into shared caching via `@smrt({ api: { public: true | 'read', cache: { sMaxage } } })` → `public, max-age=0, s-maxage=<n>`; non-public models never emit shared-cache headers. Tenant-scoped models (any mode) never emit them either — bodies vary with session-cookie tenant context that URL-keyed shared caches cannot see; `sMaxage` is neutralized to `private, no-cache` with a one-time warning.

--- a/packages/core/agents/generators.md
+++ b/packages/core/agents/generators.md
@@ -42,7 +42,14 @@ When scanner method metadata exists, discovery projects each named parameter
 and its JSON-schema type, and invokers pass the values positionally in declared
 order. The legacy single `options` bag remains compatible when metadata is
 absent (or the declared method takes `options`). Do not infer this from runtime
-function arity.
+function arity. An omitted typed `options` parameter remains `undefined`, so a
+method's JavaScript default initializer continues to apply; an explicit `null`
+remains `null`. Flat tool inputs reserve `id` for an item receiver. If an
+item action itself declares an `id` parameter, its flat MCP/WebMCP field is
+`actionId` (and CLI uses `--action-id`); REST keeps its independent path/body
+namespaces. Typed CLI actions may use standard flag names such as `limit`,
+`offset`, `where`, and `format` without those values being stripped as CRUD
+flags.
 
 Custom actions may return an explicit, domain-neutral failure object with
 `ok: false`, `code`, and `message` plus optional `status`, `details`,

--- a/packages/core/agents/generators.md
+++ b/packages/core/agents/generators.md
@@ -44,9 +44,9 @@ order. The legacy single `options` bag remains compatible when metadata is
 absent (or the declared method takes `options`). Do not infer this from runtime
 function arity. An omitted typed `options` parameter remains `undefined`, so a
 method's JavaScript default initializer continues to apply; an explicit `null`
-remains `null`. Flat tool inputs reserve `id` for an item receiver. If an
-item action itself declares an `id` parameter, its flat MCP/WebMCP field is
-`actionId` (and CLI uses `--action-id`); REST keeps its independent path/body
+remains `null`. Flat tool and CLI inputs reserve `id` for receiver parsing. If
+an action declares an `id` parameter, its flat MCP/WebMCP field is `actionId`
+(and CLI uses `--action-id`); REST keeps its independent path/body
 namespaces. Typed CLI actions may use standard flag names such as `limit`,
 `offset`, `where`, and `format` without those values being stripped as CRUD
 flags.

--- a/packages/core/src/generators/cli-commands.spec.ts
+++ b/packages/core/src/generators/cli-commands.spec.ts
@@ -36,22 +36,14 @@ class CliCmdWidget extends SmrtObject {
     return { kind: 'instance', name: this.name, options };
   }
 
-  // Public on the object too (so command exposure passes), but when invoked
-  // without an id the collection's same-named method runs instead.
-  async tally(options: any = {}): Promise<any> {
-    return { kind: 'instance-tally', options };
+  // A model static action is collection-targeted and accepts no item id.
+  static async tally(options: any = {}): Promise<any> {
+    return { kind: 'collection', options };
   }
 }
 
 class CliCmdWidgetCollection extends SmrtCollection<CliCmdWidget> {
   static readonly _itemClass = CliCmdWidget;
-
-  // Collection-level custom action (invoked when no id is provided). The CLI
-  // exposure gate validates against the object's methods, so `tally` is also
-  // declared on the object above.
-  async tally(options: any = {}): Promise<any> {
-    return { kind: 'collection', options };
-  }
 }
 
 function captureLog<T>(
@@ -71,6 +63,15 @@ function captureLog<T>(
 
 describe('CLI generator parsing + dispatch (#1500)', () => {
   ObjectRegistry.registerCollection('CliCmdWidget', CliCmdWidgetCollection);
+  ObjectRegistry.getMethods('CliCmdWidget').set('tally', {
+    name: 'tally',
+    async: true,
+    isPublic: true,
+    isStatic: true,
+    returnType: 'Promise<any>',
+    parameters: [{ name: 'options', type: 'any', optional: true, default: {} }],
+  });
+  ObjectRegistry.invalidateAllInheritanceCaches();
 
   let db: any;
 

--- a/packages/core/src/generators/cli-commands.spec.ts
+++ b/packages/core/src/generators/cli-commands.spec.ts
@@ -59,6 +59,10 @@ class CliCmdWidget extends SmrtObject {
   static async tally(options: any = {}): Promise<any> {
     return { kind: 'collection', options };
   }
+
+  static async archive(id: string): Promise<any> {
+    return { kind: 'archive', actionId: id };
+  }
 }
 
 class CliCmdWidgetCollection extends SmrtCollection<CliCmdWidget> {
@@ -102,6 +106,14 @@ describe('CLI generator parsing + dispatch (#1500)', () => {
       { name: 'where', type: 'string', optional: false },
       { name: 'format', type: 'string', optional: false },
     ],
+  });
+  ObjectRegistry.getMethods('CliCmdWidget').set('archive', {
+    name: 'archive',
+    async: true,
+    isPublic: true,
+    isStatic: true,
+    returnType: 'Promise<any>',
+    parameters: [{ name: 'id', type: 'string', optional: false }],
   });
   ObjectRegistry.getMethods('CliCmdWidget').set('move', {
     name: 'move',
@@ -376,6 +388,11 @@ describe('CLI generator parsing + dispatch (#1500)', () => {
         ]),
       );
       expect(moved.out).toContain('"destinationId": "destination-2"');
+
+      const archived = await captureLog(() =>
+        gen.run(['clicmdwidget:archive', '--action-id', 'archive-3']),
+      );
+      expect(archived.out).toContain('"actionId": "archive-3"');
 
       const defaults = await captureLog(() =>
         gen.run(['clicmdwidget:withDefaults', created.id as string]),

--- a/packages/core/src/generators/cli-commands.spec.ts
+++ b/packages/core/src/generators/cli-commands.spec.ts
@@ -36,6 +36,25 @@ class CliCmdWidget extends SmrtObject {
     return { kind: 'instance', name: this.name, options };
   }
 
+  async window(
+    limit: number,
+    offset: number,
+    where: string,
+    format: string,
+  ): Promise<any> {
+    return { kind: 'window', limit, offset, where, format };
+  }
+
+  async move(id: string): Promise<any> {
+    return { kind: 'move', destinationId: id };
+  }
+
+  async withDefaults(
+    options: any = { source: 'method-default' },
+  ): Promise<any> {
+    return { kind: 'defaults', options };
+  }
+
   // A model static action is collection-targeted and accepts no item id.
   static async tally(options: any = {}): Promise<any> {
     return { kind: 'collection', options };
@@ -70,6 +89,35 @@ describe('CLI generator parsing + dispatch (#1500)', () => {
     isStatic: true,
     returnType: 'Promise<any>',
     parameters: [{ name: 'options', type: 'any', optional: true, default: {} }],
+  });
+  ObjectRegistry.getMethods('CliCmdWidget').set('window', {
+    name: 'window',
+    async: true,
+    isPublic: true,
+    isStatic: false,
+    returnType: 'Promise<any>',
+    parameters: [
+      { name: 'limit', type: 'number', optional: false },
+      { name: 'offset', type: 'number', optional: false },
+      { name: 'where', type: 'string', optional: false },
+      { name: 'format', type: 'string', optional: false },
+    ],
+  });
+  ObjectRegistry.getMethods('CliCmdWidget').set('move', {
+    name: 'move',
+    async: true,
+    isPublic: true,
+    isStatic: false,
+    returnType: 'Promise<any>',
+    parameters: [{ name: 'id', type: 'string', optional: false }],
+  });
+  ObjectRegistry.getMethods('CliCmdWidget').set('withDefaults', {
+    name: 'withDefaults',
+    async: true,
+    isPublic: true,
+    isStatic: false,
+    returnType: 'Promise<any>',
+    parameters: [{ name: 'options', type: 'any', optional: true }],
   });
   ObjectRegistry.invalidateAllInheritanceCaches();
 
@@ -285,6 +333,54 @@ describe('CLI generator parsing + dispatch (#1500)', () => {
       );
       expect(out).toContain('"kind": "collection"');
       expect(out).toContain('"scope": "all"');
+    });
+
+    it('preserves typed parameters that share standard CLI flag names', async () => {
+      const collection = await CliCmdWidgetCollection.create({ db });
+      const created = await collection.create({ name: 'WindowTarget', qty: 1 });
+      await created.save();
+      const gen = new CLIGenerator({}, { db });
+
+      const { out } = await captureLog(() =>
+        gen.run([
+          'clicmdwidget:window',
+          created.id as string,
+          '--limit',
+          '5',
+          '--offset',
+          '2',
+          '--where',
+          'status=active',
+          '--format',
+          'json',
+        ]),
+      );
+      expect(out).toContain('"limit": 5');
+      expect(out).toContain('"offset": 2');
+      expect(out).toContain('"where": "status=active"');
+      expect(out).toContain('"format": "json"');
+    });
+
+    it('keeps item receiver ids separate and preserves omitted options defaults', async () => {
+      const collection = await CliCmdWidgetCollection.create({ db });
+      const created = await collection.create({ name: 'MoveTarget', qty: 1 });
+      await created.save();
+      const gen = new CLIGenerator({}, { db });
+
+      const moved = await captureLog(() =>
+        gen.run([
+          'clicmdwidget:move',
+          created.id as string,
+          '--action-id',
+          'destination-2',
+        ]),
+      );
+      expect(moved.out).toContain('"destinationId": "destination-2"');
+
+      const defaults = await captureLog(() =>
+        gen.run(['clicmdwidget:withDefaults', created.id as string]),
+      );
+      expect(defaults.out).toContain('"source": "method-default"');
     });
   });
 

--- a/packages/core/src/generators/cli.ts
+++ b/packages/core/src/generators/cli.ts
@@ -20,11 +20,16 @@
  */
 
 import type { AIClient, AIClientOptions } from '@happyvertical/ai';
-import type { SmrtCollection } from '../collection';
+import { SmrtCollection } from '../collection';
 import type { DatabaseConfig } from '../database.js';
 import type { PublicJsonOptions, SmrtObject } from '../object';
 import { ObjectRegistry } from '../registry';
 import type { RegisteredClass } from '../registry/types.js';
+import {
+  buildCustomActionInvocationArgs,
+  normalizeCustomActionFailure,
+  resolveCustomActionMetadata,
+} from './custom-action.js';
 import { runWithTenantGate } from './tenant-gate.js';
 
 /**
@@ -42,7 +47,7 @@ interface PublicSerializable {
  */
 type DynamicallyCallable = Record<
   string,
-  ((options: Record<string, unknown>) => unknown) | unknown
+  ((...args: unknown[]) => unknown) | unknown
 >;
 
 /**
@@ -424,22 +429,59 @@ export class CLIGenerator {
       }
 
       default:
-        return this.executeCustomAction(collection, action, positional, flags);
+        return this.executeCustomAction(
+          objectName,
+          collection,
+          action,
+          positional,
+          flags,
+        );
     }
   }
 
   /**
-   * Execute a custom method on an instance (when an id is given) or on the
-   * collection (singleton actions). Mirrors the MCP custom-action path.
+   * Execute a custom method against its manifest-declared item/collection
+   * target. The legacy collection fallback remains only for unavailable
+   * metadata, where target scope cannot be established safely.
    */
   private async executeCustomAction(
+    objectName: string,
     collection: SmrtCollection<SmrtObject>,
     action: string,
     positional: string | undefined,
     flags: Record<string, string | boolean>,
   ): Promise<unknown> {
-    const options = this.customOptions(flags);
     const id = positional ?? this.flagString(flags.id);
+    const args = this.customOptions(flags);
+    const methodDef = (await ObjectRegistry.getAllMethods(objectName)).get(
+      action,
+    );
+    const metadata = resolveCustomActionMetadata({
+      actionName: action,
+      method: methodDef,
+      apiConfig: ObjectRegistry.getConfig(objectName).api,
+      ...(this.hasCollectionReceiver(ObjectRegistry.getClass(objectName))
+        ? { defaultScope: 'collection' as const }
+        : {}),
+    });
+    const invocationArgs =
+      metadata.parameters?.length === 1 &&
+      metadata.parameters[0]?.name === 'options'
+        ? { options: args }
+        : args;
+    const methodArgs = buildCustomActionInvocationArgs(
+      metadata,
+      invocationArgs,
+    );
+
+    if (methodDef && metadata.idRequired && !id) {
+      throw new Error(`An id is required for custom action '${action}'`);
+    }
+    if (methodDef && !metadata.idRequired && id) {
+      throw new Error(
+        `Custom action '${action}' is collection-scoped and does not accept an id`,
+      );
+    }
 
     if (id) {
       const object = await collection.get(id);
@@ -450,17 +492,46 @@ export class CLIGenerator {
       if (typeof candidate !== 'function') {
         throw new Error(`Method '${action}' not found on object instance`);
       }
-      return candidate.call(object, options);
+      const result = await candidate.call(object, ...methodArgs);
+      const failure = normalizeCustomActionFailure(result);
+      if (failure) throw new Error(JSON.stringify({ error: failure }));
+      return result;
+    }
+
+    if (methodDef?.isStatic) {
+      const classInfo = ObjectRegistry.getClass(objectName);
+      const candidate = (
+        classInfo?.constructor as unknown as DynamicallyCallable | undefined
+      )?.[action];
+      if (typeof candidate !== 'function') {
+        throw new Error(`Static method '${action}' not found on ${objectName}`);
+      }
+      const result = await candidate.call(
+        classInfo?.constructor,
+        ...methodArgs,
+      );
+      const failure = normalizeCustomActionFailure(result);
+      if (failure) throw new Error(JSON.stringify({ error: failure }));
+      return result;
     }
 
     const collectionCandidate = (collection as unknown as DynamicallyCallable)[
       action
     ];
     if (typeof collectionCandidate === 'function') {
-      return collectionCandidate.call(collection, options);
+      const result = await collectionCandidate.call(collection, ...methodArgs);
+      const failure = normalizeCustomActionFailure(result);
+      if (failure) throw new Error(JSON.stringify({ error: failure }));
+      return result;
     }
     throw new Error(
       `Method '${action}' not found on collection. Provide an id for object-specific actions.`,
+    );
+  }
+
+  private hasCollectionReceiver(classInfo?: RegisteredClass): boolean {
+    return (
+      !!classInfo && classInfo.constructor.prototype instanceof SmrtCollection
     );
   }
 

--- a/packages/core/src/generators/cli.ts
+++ b/packages/core/src/generators/cli.ts
@@ -27,6 +27,7 @@ import { ObjectRegistry } from '../registry';
 import type { RegisteredClass } from '../registry/types.js';
 import {
   buildCustomActionInvocationArgs,
+  customActionParameterInputName,
   normalizeCustomActionFailure,
   resolveCustomActionMetadata,
 } from './custom-action.js';
@@ -452,7 +453,6 @@ export class CLIGenerator {
     flags: Record<string, string | boolean>,
   ): Promise<unknown> {
     const id = positional ?? this.flagString(flags.id);
-    const args = this.customOptions(flags);
     const methodDef = (await ObjectRegistry.getAllMethods(objectName)).get(
       action,
     );
@@ -464,10 +464,13 @@ export class CLIGenerator {
         ? { defaultScope: 'collection' as const }
         : {}),
     });
+    const args = this.customOptions(flags, metadata);
     const invocationArgs =
       metadata.parameters?.length === 1 &&
       metadata.parameters[0]?.name === 'options'
-        ? { options: args }
+        ? Object.keys(args).length > 0
+          ? { options: args }
+          : {}
         : args;
     const methodArgs = buildCustomActionInvocationArgs(
       metadata,
@@ -562,13 +565,31 @@ export class CLIGenerator {
     return data;
   }
 
-  /** Collect non-reserved flags as custom-action options. */
+  /**
+   * Collect custom-action flags. Typed action parameters may deliberately use
+   * standard CLI names such as `limit`, `offset`, `where`, or `format`; retain
+   * those rather than silently dropping them as CRUD flags. Item actions keep
+   * `--id` for their receiver and accept an action parameter named `id` as
+   * `--action-id` to preserve separate namespaces.
+   */
   private customOptions(
     flags: Record<string, string | boolean>,
+    metadata?: { parameters?: Array<{ name: string }>; idRequired: boolean },
   ): Record<string, unknown> {
+    const declaredInputs = new Set(
+      (metadata?.parameters ?? []).map((parameter) =>
+        customActionParameterInputName(
+          metadata ?? { idRequired: false },
+          parameter.name,
+        ),
+      ),
+    );
     const options: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(flags)) {
-      if (RESERVED_FLAGS.has(key)) continue;
+    for (const [rawKey, value] of Object.entries(flags)) {
+      const key = rawKey === 'action-id' ? 'actionId' : rawKey;
+      if (rawKey === 'id') continue;
+      if (RESERVED_FLAGS.has(rawKey) && !declaredInputs.has(key)) continue;
+      if (rawKey === 'action-id' && !declaredInputs.has(key)) continue;
       options[key] = this.coerceValue(value);
     }
     return options;

--- a/packages/core/src/generators/custom-action.test.ts
+++ b/packages/core/src/generators/custom-action.test.ts
@@ -92,6 +92,50 @@ describe('custom action conformance', () => {
     ).toEqual([{ colour: 'blue' }]);
   });
 
+  it('keeps an item receiver id distinct from an action id parameter', () => {
+    const metadata = resolveCustomActionMetadata({
+      actionName: 'move',
+      method: {
+        isStatic: false,
+        parameters: [{ name: 'id', type: 'string', optional: false }],
+      },
+    });
+
+    expect(buildCustomActionInputSchema(metadata)).toMatchObject({
+      properties: {
+        id: { type: 'string' },
+        actionId: { type: 'string' },
+      },
+      required: ['id', 'actionId'],
+    });
+    expect(
+      buildCustomActionInvocationArgs(metadata, {
+        id: 'receiver-1',
+        actionId: 'destination-2',
+      }),
+    ).toEqual(['destination-2']);
+  });
+
+  it('leaves an omitted typed options parameter undefined for method defaults', () => {
+    const metadata = resolveCustomActionMetadata({
+      actionName: 'configure',
+      method: {
+        isStatic: false,
+        parameters: [{ name: 'options', type: 'object', optional: true }],
+      },
+    });
+
+    expect(buildCustomActionInvocationArgs(metadata, { id: 'item-1' })).toEqual(
+      [undefined],
+    );
+    expect(
+      buildCustomActionInvocationArgs(metadata, {
+        id: 'item-1',
+        options: null,
+      }),
+    ).toEqual([null]);
+  });
+
   it('requires an explicit failure marker and redacts conventional failures', () => {
     expect(
       normalizeCustomActionFailure({ code: 'opaque', message: 'a success' }),

--- a/packages/core/src/generators/custom-action.test.ts
+++ b/packages/core/src/generators/custom-action.test.ts
@@ -116,6 +116,25 @@ describe('custom action conformance', () => {
     ).toEqual(['destination-2']);
   });
 
+  it('aliases an id parameter for collection actions too', () => {
+    const metadata = resolveCustomActionMetadata({
+      actionName: 'archive',
+      method: {
+        isStatic: true,
+        parameters: [{ name: 'id', type: 'string', optional: false }],
+      },
+    });
+
+    expect(metadata).toMatchObject({ scope: 'collection', idRequired: false });
+    expect(buildCustomActionInputSchema(metadata)).toMatchObject({
+      properties: { actionId: { type: 'string' } },
+      required: ['actionId'],
+    });
+    expect(
+      buildCustomActionInvocationArgs(metadata, { actionId: 'archive-1' }),
+    ).toEqual(['archive-1']);
+  });
+
   it('leaves an omitted typed options parameter undefined for method defaults', () => {
     const metadata = resolveCustomActionMetadata({
       actionName: 'configure',

--- a/packages/core/src/generators/custom-action.test.ts
+++ b/packages/core/src/generators/custom-action.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCustomActionInputSchema,
+  buildCustomActionInvocationArgs,
+  normalizeCustomActionFailure,
+  resolveCustomActionMetadata,
+} from './custom-action.js';
+
+describe('custom action conformance', () => {
+  const itemMethod = {
+    isStatic: false,
+    parameters: [
+      { name: 'idempotencyKey', type: 'string', optional: false },
+      { name: 'expectedVersion', type: 'number', optional: true },
+    ],
+  };
+
+  it('keeps an instance receiver item-scoped despite a collection route override', () => {
+    const metadata = resolveCustomActionMetadata({
+      actionName: 'apply',
+      method: itemMethod,
+      apiConfig: { routes: { apply: { scope: 'collection' } } },
+    });
+
+    expect(metadata).toMatchObject({
+      scope: 'item',
+      idRequired: true,
+      isStatic: false,
+    });
+    expect(buildCustomActionInputSchema(metadata)).toMatchObject({
+      properties: {
+        id: { type: 'string' },
+        idempotencyKey: { type: 'string' },
+        expectedVersion: { type: 'number' },
+      },
+      required: ['id', 'idempotencyKey'],
+    });
+    expect(
+      buildCustomActionInvocationArgs(metadata, {
+        id: 'item-1',
+        idempotencyKey: 'retry-1',
+        expectedVersion: 7,
+      }),
+    ).toEqual(['retry-1', 7]);
+  });
+
+  it('keeps static and recognized collection receivers collection-scoped', () => {
+    const staticMetadata = resolveCustomActionMetadata({
+      actionName: 'rebalance',
+      method: { ...itemMethod, isStatic: true },
+      apiConfig: { routes: { rebalance: { scope: 'item' } } },
+    });
+    const collectionMetadata = resolveCustomActionMetadata({
+      actionName: 'fanout',
+      method: itemMethod,
+      defaultScope: 'collection',
+      apiConfig: { routes: { fanout: { scope: 'item' } } },
+    });
+
+    for (const metadata of [staticMetadata, collectionMetadata]) {
+      expect(metadata).toMatchObject({
+        scope: 'collection',
+        idRequired: false,
+      });
+      expect(buildCustomActionInputSchema(metadata)).toMatchObject({
+        properties: {
+          idempotencyKey: { type: 'string' },
+          expectedVersion: { type: 'number' },
+        },
+        required: ['idempotencyKey'],
+      });
+      expect(
+        buildCustomActionInvocationArgs(metadata, {
+          idempotencyKey: 'retry-2',
+          expectedVersion: 8,
+        }),
+      ).toEqual(['retry-2', 8]);
+    }
+  });
+
+  it('preserves the legacy options bag when canonical method metadata is absent', () => {
+    const metadata = resolveCustomActionMetadata({ actionName: 'legacy' });
+    expect(buildCustomActionInputSchema(metadata)).toMatchObject({
+      properties: { id: { type: 'string' }, options: { type: 'object' } },
+      required: ['id'],
+    });
+    expect(
+      buildCustomActionInvocationArgs(metadata, {
+        id: 'item-1',
+        colour: 'blue',
+      }),
+    ).toEqual([{ colour: 'blue' }]);
+  });
+
+  it('requires an explicit failure marker and redacts conventional failures', () => {
+    expect(
+      normalizeCustomActionFailure({ code: 'opaque', message: 'a success' }),
+    ).toBeUndefined();
+    expect(
+      normalizeCustomActionFailure({
+        ok: false,
+        code: 'conflict',
+        message: 'Bearer top-secret token=also-secret',
+        status: 409,
+        details: { authorization: 'secret', safe: 'Bearer hidden' },
+        retryable: false,
+        correlationId: 'correlation-1',
+      }),
+    ).toEqual({
+      ok: false,
+      code: 'conflict',
+      message: 'Bearer [REDACTED] token=[REDACTED]',
+      status: 409,
+      details: { authorization: '[REDACTED]', safe: 'Bearer [REDACTED]' },
+      retryable: false,
+      correlationId: 'correlation-1',
+    });
+  });
+});

--- a/packages/core/src/generators/custom-action.ts
+++ b/packages/core/src/generators/custom-action.ts
@@ -1,0 +1,256 @@
+/**
+ * Canonical custom-action metadata and transport-safe result helpers.
+ *
+ * Custom actions are intentionally distinct from generated CRUD. Their target
+ * is derived from method metadata: instance methods target an item and static
+ * methods target the collection. API route configuration may shape an HTTP
+ * route, but it cannot change a method's receiver.
+ */
+
+import type { MethodDefinition } from '../scanner/types.js';
+import { convertTypeToJsonSchema } from '../tools/tool-generator.js';
+
+export type CustomActionScope = 'item' | 'collection';
+
+export interface CustomActionMetadata {
+  scope: CustomActionScope;
+  /** An item-targeted action requires its target identifier. */
+  idRequired: boolean;
+  /** Present only when scanner/manifest metadata is available. */
+  parameters?: MethodDefinition['parameters'];
+  /** Collection actions on a model class invoke its static method. */
+  isStatic: boolean;
+}
+
+export interface ResolveCustomActionMetadataOptions {
+  actionName: string;
+  method?: {
+    isStatic?: boolean;
+    parameters?: MethodDefinition['parameters'];
+  };
+  apiConfig?: unknown;
+  /** Collection-class actions have a collection receiver even when non-static. */
+  defaultScope?: CustomActionScope;
+}
+
+type JsonSchema = Record<string, unknown>;
+type ToolArgs = Record<string, unknown>;
+
+/**
+ * Resolve the target contract shared by MCP, generated REST, CLI discovery,
+ * and WebMCP. A missing manifest method retains the historical item-shaped
+ * schema; runtime callers may still provide their legacy collection fallback.
+ */
+export function resolveCustomActionMetadata(
+  options: ResolveCustomActionMetadataOptions,
+): CustomActionMetadata {
+  const defaultScope =
+    options.defaultScope ?? (options.method?.isStatic ? 'collection' : 'item');
+  const requestedScope = readConfiguredScope(
+    options.apiConfig,
+    options.actionName,
+  );
+  // A route-only scope override cannot manufacture a receiver. A normal
+  // instance method is always item-targeted; a static model method and a
+  // recognized collection-class method are always collection-targeted. Keep
+  // a matching explicit value for diagnostics/config round-tripping only.
+  const scope = requestedScope === defaultScope ? requestedScope : defaultScope;
+
+  return {
+    scope,
+    idRequired: scope === 'item',
+    ...(options.method?.parameters
+      ? { parameters: options.method.parameters }
+      : {}),
+    isStatic: options.method?.isStatic === true,
+  };
+}
+
+/** Build the custom-action portion of an MCP/WebMCP JSON Schema. */
+export function buildCustomActionInputSchema(
+  metadata: CustomActionMetadata,
+): JsonSchema {
+  const properties: Record<string, JsonSchema> = {};
+  const required: string[] = [];
+
+  if (metadata.idRequired) {
+    properties.id = {
+      type: 'string',
+      description: 'ID of the object to execute action on',
+    };
+    required.push('id');
+  }
+
+  // Absent metadata is the legacy options-bag contract. Do not infer direct
+  // positional arguments from runtime function arity: it is lossy after
+  // transpilation and would make discovery non-deterministic.
+  if (!metadata.parameters) {
+    properties.options = {
+      type: 'object',
+      description: 'Additional options for the custom action',
+      additionalProperties: true,
+    };
+  } else if (
+    metadata.parameters.length === 1 &&
+    metadata.parameters[0]?.name === 'options'
+  ) {
+    const parameter = metadata.parameters[0];
+    properties.options = {
+      ...convertTypeToJsonSchema(parameter.type),
+      description: 'Options for the custom action',
+      ...(parameter.default !== undefined
+        ? { default: parameter.default }
+        : {}),
+    };
+    if (!parameter.optional) required.push('options');
+  } else {
+    for (const parameter of metadata.parameters) {
+      properties[parameter.name] = {
+        ...convertTypeToJsonSchema(parameter.type),
+        ...(parameter.default !== undefined
+          ? { default: parameter.default }
+          : {}),
+      };
+      if (!parameter.optional) required.push(parameter.name);
+    }
+  }
+
+  return {
+    type: 'object',
+    properties,
+    ...(required.length > 0 ? { required } : {}),
+  };
+}
+
+/**
+ * Translate a transport object into the method's call arguments. Legacy
+ * actions retain their single options-bag invocation; scanner metadata enables
+ * an exact positional projection without changing legacy action behavior.
+ */
+export function buildCustomActionInvocationArgs(
+  metadata: CustomActionMetadata,
+  args: ToolArgs,
+): unknown[] {
+  const { id: _id, options, ...directArgs } = args;
+
+  if (!metadata.parameters) {
+    return [
+      isRecord(options) && Object.keys(options).length > 0
+        ? options
+        : directArgs,
+    ];
+  }
+  if (metadata.parameters.length === 0) return [];
+  if (
+    metadata.parameters.length === 1 &&
+    metadata.parameters[0]?.name === 'options'
+  ) {
+    return [options ?? {}];
+  }
+  return metadata.parameters.map((parameter) => args[parameter.name]);
+}
+
+/**
+ * Domain-neutral returned-failure convention for custom actions. The explicit
+ * `ok: false` marker prevents successful opaque values such as `{ code,
+ * message }` from being reclassified as failures by a transport.
+ */
+export interface CustomActionFailure {
+  ok: false;
+  code: string;
+  message: string;
+  status: number;
+  details?: unknown;
+  retryable?: boolean;
+  correlationId?: string;
+}
+
+/** Stable MCP `_meta` member shared with the app discovery contract (#2181). */
+export const SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY = 'io.happyvertical/smrt';
+
+/**
+ * Detect, validate, and redact an explicitly returned custom-action failure.
+ * Unknown return values remain opaque successes. `status` defaults to 400 so
+ * REST callers receive non-2xx semantics even when an adapter omits it.
+ */
+export function normalizeCustomActionFailure(
+  value: unknown,
+): CustomActionFailure | undefined {
+  if (!isRecord(value) || value.ok !== false) return undefined;
+  if (typeof value.code !== 'string' || typeof value.message !== 'string') {
+    return undefined;
+  }
+
+  const status =
+    typeof value.status === 'number' &&
+    Number.isInteger(value.status) &&
+    value.status >= 400 &&
+    value.status <= 599
+      ? value.status
+      : 400;
+
+  return {
+    ok: false,
+    code: value.code,
+    message: redactText(value.message),
+    status,
+    ...(Object.hasOwn(value, 'details')
+      ? { details: redactValue(value.details) }
+      : {}),
+    ...(typeof value.retryable === 'boolean'
+      ? { retryable: value.retryable }
+      : {}),
+    ...(typeof value.correlationId === 'string'
+      ? { correlationId: value.correlationId }
+      : {}),
+  };
+}
+
+function readConfiguredScope(
+  apiConfig: unknown,
+  actionName: string,
+): CustomActionScope | undefined {
+  if (!isRecord(apiConfig) || !isRecord(apiConfig.routes)) return undefined;
+  const route = apiConfig.routes[actionName];
+  return isRecord(route) &&
+    (route.scope === 'item' || route.scope === 'collection')
+    ? route.scope
+    : undefined;
+}
+
+function redactValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (typeof value === 'string') return redactText(value);
+  if (value === null || typeof value !== 'object') return value;
+  if (seen.has(value)) return '[REDACTED]';
+  seen.add(value);
+  if (Array.isArray(value))
+    return value.map((entry) => redactValue(entry, seen));
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return '[REDACTED]';
+  const result: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    result[key] = isSensitiveKey(key)
+      ? '[REDACTED]'
+      : redactValue(nested, seen);
+  }
+  return result;
+}
+
+function redactText(value: string): string {
+  return value
+    .replace(/\bBearer\s+[^\s,;]+/giu, 'Bearer [REDACTED]')
+    .replace(
+      /\b(token|secret|password|api[_-]?key)=([^\s&]+)/giu,
+      '$1=[REDACTED]',
+    );
+}
+
+function isSensitiveKey(key: string): boolean {
+  return /(?:token|secret|password|authorization|cookie|credential|api[_-]?key)/iu.test(
+    key,
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/core/src/generators/custom-action.ts
+++ b/packages/core/src/generators/custom-action.ts
@@ -22,6 +22,21 @@ export interface CustomActionMetadata {
   isStatic: boolean;
 }
 
+/**
+ * Return the transport field for a method parameter. Item tools reserve `id`
+ * for the receiver, so an action parameter named `id` is exposed as
+ * `actionId`. REST already has separate path/body namespaces; flat tool and
+ * CLI inputs use this alias to avoid silently passing the receiver ID twice.
+ */
+export function customActionParameterInputName(
+  metadata: Pick<CustomActionMetadata, 'idRequired'>,
+  parameterName: string,
+): string {
+  return metadata.idRequired && parameterName === 'id'
+    ? 'actionId'
+    : parameterName;
+}
+
 export interface ResolveCustomActionMetadataOptions {
   actionName: string;
   method?: {
@@ -105,13 +120,17 @@ export function buildCustomActionInputSchema(
     if (!parameter.optional) required.push('options');
   } else {
     for (const parameter of metadata.parameters) {
-      properties[parameter.name] = {
+      const inputName = customActionParameterInputName(
+        metadata,
+        parameter.name,
+      );
+      properties[inputName] = {
         ...convertTypeToJsonSchema(parameter.type),
         ...(parameter.default !== undefined
           ? { default: parameter.default }
           : {}),
       };
-      if (!parameter.optional) required.push(parameter.name);
+      if (!parameter.optional) required.push(inputName);
     }
   }
 
@@ -145,9 +164,15 @@ export function buildCustomActionInvocationArgs(
     metadata.parameters.length === 1 &&
     metadata.parameters[0]?.name === 'options'
   ) {
-    return [options ?? {}];
+    // Preserve `undefined` (and an explicit `null`) so JavaScript default
+    // parameter initializers and intentional null handling retain their native
+    // semantics. Legacy options bags still receive an empty object below.
+    return [options];
   }
-  return metadata.parameters.map((parameter) => args[parameter.name]);
+  return metadata.parameters.map(
+    (parameter) =>
+      args[customActionParameterInputName(metadata, parameter.name)],
+  );
 }
 
 /**

--- a/packages/core/src/generators/custom-action.ts
+++ b/packages/core/src/generators/custom-action.ts
@@ -23,18 +23,16 @@ export interface CustomActionMetadata {
 }
 
 /**
- * Return the transport field for a method parameter. Item tools reserve `id`
- * for the receiver, so an action parameter named `id` is exposed as
- * `actionId`. REST already has separate path/body namespaces; flat tool and
- * CLI inputs use this alias to avoid silently passing the receiver ID twice.
+ * Return the transport field for a method parameter. Flat tool and CLI
+ * transports reserve `id` for receiver parsing even when a collection action
+ * rejects it, so every action parameter named `id` is exposed as `actionId`.
+ * REST already has separate path/body namespaces.
  */
 export function customActionParameterInputName(
-  metadata: Pick<CustomActionMetadata, 'idRequired'>,
+  _metadata: Pick<CustomActionMetadata, 'idRequired'>,
   parameterName: string,
 ): string {
-  return metadata.idRequired && parameterName === 'id'
-    ? 'actionId'
-    : parameterName;
+  return parameterName === 'id' ? 'actionId' : parameterName;
 }
 
 export interface ResolveCustomActionMetadataOptions {

--- a/packages/core/src/generators/index.ts
+++ b/packages/core/src/generators/index.ts
@@ -21,6 +21,17 @@ export {
   versionConditionalResponse,
   warnIfSharedCacheNeutralized,
 } from './conditional-get';
+export {
+  buildCustomActionInputSchema,
+  buildCustomActionInvocationArgs,
+  type CustomActionFailure,
+  type CustomActionMetadata,
+  type CustomActionScope,
+  normalizeCustomActionFailure,
+  type ResolveCustomActionMetadataOptions,
+  resolveCustomActionMetadata,
+  SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY,
+} from './custom-action';
 // Live `_events` SSE route (#1763). The generated SvelteKit route imports
 // `buildChangeEventStream` from the package root, so the stream lifecycle is
 // written and tested once in core. `handleEventsRoute` stays internal (rest.ts

--- a/packages/core/src/generators/index.ts
+++ b/packages/core/src/generators/index.ts
@@ -27,6 +27,7 @@ export {
   type CustomActionFailure,
   type CustomActionMetadata,
   type CustomActionScope,
+  customActionParameterInputName,
   normalizeCustomActionFailure,
   type ResolveCustomActionMetadataOptions,
   resolveCustomActionMetadata,

--- a/packages/core/src/generators/mcp-runtime-template.test.ts
+++ b/packages/core/src/generators/mcp-runtime-template.test.ts
@@ -60,9 +60,7 @@ describe('generated MCP custom-action runtime (#2182)', () => {
     expect(source).toContain(
       "? ObjectRegistry.getClass('Document')?.constructor",
     );
-    expect(source).toContain(
-      "actionMeta.scope === 'item' && parameterName === 'id'",
-    );
+    expect(source).toContain("parameterName === 'id'");
     expect(source).toContain("? 'actionId'");
     expect(source).toMatch(/actionMeta\.optionsParameter\s+\? \[options\]/);
     expect(source).toContain('actionMethod.call(target, ...methodArgs)');

--- a/packages/core/src/generators/mcp-runtime-template.test.ts
+++ b/packages/core/src/generators/mcp-runtime-template.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { generateRuntimeBootstrap } from './mcp-runtime-template.js';
+
+describe('generated MCP custom-action runtime (#2182)', () => {
+  it('carries canonical receivers and positional invocation metadata without exposing it as a tool field', () => {
+    const source = generateRuntimeBootstrap({
+      tools: [
+        {
+          name: 'document_apply',
+          description: 'Apply an item action',
+          inputSchema: { type: 'object' },
+        },
+        {
+          name: 'document_rebalance',
+          description: 'Rebalance a collection action',
+          inputSchema: { type: 'object' },
+        },
+        {
+          name: 'document_restoreintocontent',
+          description: 'Restore a camelCase item action',
+          inputSchema: { type: 'object' },
+        },
+      ],
+      customActions: {
+        document_apply: {
+          scope: 'item',
+          isStatic: false,
+          methodName: 'apply',
+          parameterNames: ['idempotencyKey', 'expectedVersion'],
+          legacyOptions: false,
+        },
+        document_rebalance: {
+          scope: 'collection',
+          isStatic: true,
+          methodName: 'rebalance',
+          parameterNames: ['idempotencyKey', 'expectedVersion'],
+          legacyOptions: false,
+        },
+        document_configure: {
+          scope: 'item',
+          isStatic: false,
+          methodName: 'configure',
+          parameterNames: ['options'],
+          optionsParameter: true,
+          legacyOptions: false,
+        },
+        document_restoreintocontent: {
+          scope: 'item',
+          isStatic: false,
+          methodName: 'restoreIntoContent',
+          parameterNames: ['idempotencyKey'],
+          legacyOptions: false,
+        },
+      },
+    });
+
+    expect(source).toContain('const CUSTOM_ACTIONS = {"document_apply"');
+    expect(source).toContain("actionMeta.scope === 'item' && !id");
+    expect(source).toContain("actionMeta.scope === 'collection' && id");
+    expect(source).toContain(
+      "? ObjectRegistry.getClass('Document')?.constructor",
+    );
+    expect(source).toContain(
+      '(actionMeta.parameterNames || []).map((parameterName) => args[parameterName])',
+    );
+    expect(source).toMatch(/actionMeta\.optionsParameter\s+\? \[options\]/);
+    expect(source).toContain('actionMethod.call(target, ...methodArgs)');
+    expect(source).toContain("target[actionMeta.methodName || 'apply']");
+    expect(source).toContain(
+      "target[actionMeta.methodName || 'restoreintocontent']",
+    );
+    expect(source).toContain('"methodName":"restoreIntoContent"');
+    expect(source).toContain('normalizeCustomActionFailure(result)');
+    expect(source).toContain('isError: true');
+    expect(source).not.toContain('customActions:');
+  });
+});

--- a/packages/core/src/generators/mcp-runtime-template.test.ts
+++ b/packages/core/src/generators/mcp-runtime-template.test.ts
@@ -61,8 +61,9 @@ describe('generated MCP custom-action runtime (#2182)', () => {
       "? ObjectRegistry.getClass('Document')?.constructor",
     );
     expect(source).toContain(
-      '(actionMeta.parameterNames || []).map((parameterName) => args[parameterName])',
+      "actionMeta.scope === 'item' && parameterName === 'id'",
     );
+    expect(source).toContain("? 'actionId'");
     expect(source).toMatch(/actionMeta\.optionsParameter\s+\? \[options\]/);
     expect(source).toContain('actionMethod.call(target, ...methodArgs)');
     expect(source).toContain("target[actionMeta.methodName || 'apply']");

--- a/packages/core/src/generators/mcp-runtime-template.ts
+++ b/packages/core/src/generators/mcp-runtime-template.ts
@@ -10,6 +10,7 @@
  * - Graceful shutdown
  */
 
+import type { CustomActionScope } from './custom-action.js';
 import type { MCPConfig, MCPContext } from './mcp.js';
 
 /**
@@ -44,6 +45,19 @@ export interface RuntimeOptions {
     description: string;
     inputSchema: Record<string, unknown>;
   }>;
+  /** Internal invocation metadata; never exposed by the MCP tools/list result. */
+  customActions?: Record<
+    string,
+    {
+      scope: CustomActionScope;
+      isStatic: boolean;
+      /** Declared method name; tool IDs are lowercased protocol aliases. */
+      methodName?: string;
+      parameterNames?: string[];
+      optionsParameter?: boolean;
+      legacyOptions: boolean;
+    }
+  >;
 
   /**
    * Lowercased simple names of objects that are `@TenantScoped` (#1554). When
@@ -68,6 +82,7 @@ export function generateRuntimeBootstrap(options: RuntimeOptions = {}): string {
     description = 'Auto-generated MCP server from SMRT objects',
     debug = false,
     tools = [],
+    customActions = {},
     tenantScopedObjects = [],
   } = options;
 
@@ -86,7 +101,9 @@ export function generateRuntimeBootstrap(options: RuntimeOptions = {}): string {
   const generateSwitchCases = (indent: string) => {
     return tools
       .map((tool) => {
-        const [objectName, action] = tool.name.split('_');
+        const separator = tool.name.indexOf('_');
+        const objectName = tool.name.slice(0, separator);
+        const action = tool.name.slice(separator + 1);
 
         switch (action) {
           case 'list':
@@ -184,12 +201,17 @@ ${indent}  return { content: [{ type: 'text', text: JSON.stringify({ success: tr
 ${indent}}`;
 
           default:
-            // Custom action
+            // Custom action. Its descriptor is deliberately kept separate
+            // from TOOLS so MCP clients receive only protocol-defined fields.
             return `${indent}case '${tool.name}': {
+${indent}  const actionMeta = CUSTOM_ACTIONS['${tool.name}'] || { scope: 'item', isStatic: false, legacyOptions: true };
 ${indent}  const { id, options = {}, ...directArgs } = args;
 
-${indent}  if (!id) {
+${indent}  if (actionMeta.scope === 'item' && !id) {
 ${indent}    throw new Error('ID is required for custom action ${action}');
+${indent}  }
+${indent}  if (actionMeta.scope === 'collection' && id) {
+${indent}    throw new Error('Custom action ${action} is collection-scoped and does not accept an ID');
 ${indent}  }
 
 ${indent}  const collection = await ObjectRegistry.getCollection('${capitalize(objectName)}', {
@@ -197,17 +219,33 @@ ${indent}    persistence: { type: 'sql', url: process.env.DATABASE_URL || ':memo
 ${indent}    ai: aiConfig
 ${indent}  });
 
-${indent}  const object = await collection.get(id);
-${indent}  if (!object) {
-${indent}    throw new Error('Object not found');
+${indent}  const target = actionMeta.scope === 'item'
+${indent}    ? await collection.get(id)
+${indent}    : actionMeta.isStatic
+${indent}      ? ObjectRegistry.getClass('${capitalize(objectName)}')?.constructor
+${indent}      : collection;
+${indent}  if (!target) {
+${indent}    throw new Error(actionMeta.scope === 'item' ? 'Object not found' : 'Custom action target not found');
+${indent}  }
+${indent}  const actionMethod = target[actionMeta.methodName || '${action}'];
+${indent}  if (typeof actionMethod !== 'function') {
+${indent}    throw new Error('Method ${action} not found on custom action target');
 ${indent}  }
 
-${indent}  if (typeof object['${action}'] !== 'function') {
-${indent}    throw new Error('Method ${action} not found on object');
+${indent}  const methodArgs = actionMeta.legacyOptions
+${indent}    ? [Object.keys(options).length > 0 ? options : directArgs]
+${indent}    : actionMeta.optionsParameter
+${indent}      ? [options]
+${indent}      : (actionMeta.parameterNames || []).map((parameterName) => args[parameterName]);
+${indent}  const result = await actionMethod.call(target, ...methodArgs);
+${indent}  const failure = normalizeCustomActionFailure(result);
+${indent}  if (failure) {
+${indent}    return {
+${indent}      content: [{ type: 'text', text: JSON.stringify({ error: failure }) }],
+${indent}      isError: true,
+${indent}      _meta: { [SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY]: failure },
+${indent}    };
 ${indent}  }
-
-${indent}  const methodArgs = Object.keys(options).length > 0 ? options : directArgs;
-${indent}  const result = await object['${action}'](methodArgs);
 
 ${indent}  return { content: [{ type: 'text', text: JSON.stringify(toPublicResult(result)) }] };
 ${indent}}`;
@@ -241,6 +279,7 @@ import {
   type ListToolsRequest,
 } from '@modelcontextprotocol/sdk/types.js';
 import { ObjectRegistry } from '@happyvertical/smrt-core';
+import { normalizeCustomActionFailure, SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY } from '@happyvertical/smrt-core';
 import { config } from '@happyvertical/smrt-config';
 ${hasTenantScoped ? "import { enableTenancy, runTenantScopedEntryPoint } from '@happyvertical/smrt-tenancy';\n" : ''}
 // Server configuration
@@ -251,6 +290,7 @@ const DEBUG = ${debug};
 
 // Static tool definitions (generated at build time)
 const TOOLS = ${toolsCode};
+const CUSTOM_ACTIONS = ${JSON.stringify(customActions)};
 ${
   hasTenantScoped
     ? `

--- a/packages/core/src/generators/mcp-runtime-template.ts
+++ b/packages/core/src/generators/mcp-runtime-template.ts
@@ -237,7 +237,7 @@ ${indent}    ? [Object.keys(options ?? {}).length > 0 ? options : directArgs]
 ${indent}    : actionMeta.optionsParameter
 ${indent}      ? [options]
 ${indent}      : (actionMeta.parameterNames || []).map((parameterName) => args[
-${indent}          actionMeta.scope === 'item' && parameterName === 'id'
+${indent}          parameterName === 'id'
 ${indent}            ? 'actionId'
 ${indent}            : parameterName
 ${indent}        ]);

--- a/packages/core/src/generators/mcp-runtime-template.ts
+++ b/packages/core/src/generators/mcp-runtime-template.ts
@@ -205,7 +205,7 @@ ${indent}}`;
             // from TOOLS so MCP clients receive only protocol-defined fields.
             return `${indent}case '${tool.name}': {
 ${indent}  const actionMeta = CUSTOM_ACTIONS['${tool.name}'] || { scope: 'item', isStatic: false, legacyOptions: true };
-${indent}  const { id, options = {}, ...directArgs } = args;
+${indent}  const { id, options, ...directArgs } = args;
 
 ${indent}  if (actionMeta.scope === 'item' && !id) {
 ${indent}    throw new Error('ID is required for custom action ${action}');
@@ -233,10 +233,14 @@ ${indent}    throw new Error('Method ${action} not found on custom action target
 ${indent}  }
 
 ${indent}  const methodArgs = actionMeta.legacyOptions
-${indent}    ? [Object.keys(options).length > 0 ? options : directArgs]
+${indent}    ? [Object.keys(options ?? {}).length > 0 ? options : directArgs]
 ${indent}    : actionMeta.optionsParameter
 ${indent}      ? [options]
-${indent}      : (actionMeta.parameterNames || []).map((parameterName) => args[parameterName]);
+${indent}      : (actionMeta.parameterNames || []).map((parameterName) => args[
+${indent}          actionMeta.scope === 'item' && parameterName === 'id'
+${indent}            ? 'actionId'
+${indent}            : parameterName
+${indent}        ]);
 ${indent}  const result = await actionMethod.call(target, ...methodArgs);
 ${indent}  const failure = normalizeCustomActionFailure(result);
 ${indent}  if (failure) {

--- a/packages/core/src/generators/mcp.test.ts
+++ b/packages/core/src/generators/mcp.test.ts
@@ -165,7 +165,14 @@ class MCPUnderscoreMethodAgent extends SmrtObject {
 
 @smrt({
   mcp: {
-    include: ['apply', 'rebalance', 'restoreIntoContent', 'fail', 'opaque'],
+    include: [
+      'apply',
+      'rebalance',
+      'restoreIntoContent',
+      'move',
+      'fail',
+      'opaque',
+    ],
   },
   api: { routes: { apply: { scope: 'collection' } } },
 })
@@ -183,6 +190,10 @@ class MCPConformanceAgent extends SmrtObject {
 
   async restoreIntoContent(idempotencyKey: string): Promise<any> {
     return { receiver: 'camelCase', idempotencyKey };
+  }
+
+  async move(id: string): Promise<any> {
+    return { receiver: 'item', actionId: id };
   }
 
   async fail(): Promise<any> {
@@ -245,6 +256,14 @@ describe('MCPGenerator with Custom Actions', () => {
       isStatic: false,
       returnType: 'Promise<any>',
       parameters: [{ name: 'idempotencyKey', type: 'string', optional: false }],
+    });
+    ObjectRegistry.getMethods('MCPConformanceAgent').set('move', {
+      name: 'move',
+      async: true,
+      isPublic: true,
+      isStatic: false,
+      returnType: 'Promise<any>',
+      parameters: [{ name: 'id', type: 'string', optional: false }],
     });
     for (const name of ['fail', 'opaque']) {
       ObjectRegistry.getMethods('MCPConformanceAgent').set(name, {
@@ -338,6 +357,13 @@ describe('MCPGenerator with Custom Actions', () => {
           idempotencyKey: { type: 'string' },
         },
         required: ['id', 'idempotencyKey'],
+      });
+      expect(inputSchema('mcpconformanceagent_move')).toMatchObject({
+        properties: {
+          id: { type: 'string' },
+          actionId: { type: 'string' },
+        },
+        required: ['id', 'actionId'],
       });
       // A collection-class method has a real collection receiver, so it is
       // collection-scoped even though it is not static.
@@ -577,6 +603,18 @@ describe('MCPGenerator with Custom Actions', () => {
         idempotencyKey: 'camel-case',
       });
 
+      const moveResponse = await generator.handleToolCall({
+        method: 'tools/call',
+        params: {
+          name: 'mcpconformanceagent_move',
+          arguments: { id: 'item-1', actionId: 'destination-2' },
+        },
+      });
+      expect(JSON.parse(moveResponse.content[0].text)).toMatchObject({
+        receiver: 'item',
+        actionId: 'destination-2',
+      });
+
       const staticResponse = await generator.handleToolCall({
         method: 'tools/call',
         params: {
@@ -678,6 +716,7 @@ describe('MCPGenerator with Custom Actions', () => {
         expect(handlers).toContain(
           "case 'mcpconformanceagent_restoreintocontent'",
         );
+        expect(handlers).toContain("case 'mcpconformanceagent_move'");
         expect(handlers).toContain("case 'mcpconformancecollection_fanout'");
         expect(handlers).toContain(
           'Custom action rebalance is collection-scoped and does not accept an ID',
@@ -686,6 +725,7 @@ describe('MCPGenerator with Custom Actions', () => {
           'ObjectRegistry.getClass("MCPConformanceAgent")?.constructor',
         );
         expect(handlers).toContain('args["idempotencyKey"]');
+        expect(handlers).toContain('args["actionId"]');
         expect(handlers).toContain('target["restoreIntoContent"]');
         expect(handlers).toContain('actionMethod.call(target, ...methodArgs)');
         expect(handlers).toContain('normalizeCustomActionFailure(result)');

--- a/packages/core/src/generators/mcp.test.ts
+++ b/packages/core/src/generators/mcp.test.ts
@@ -2,8 +2,12 @@
  * Tests for MCP generator with custom action support
  */
 
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { SmrtCollection } from '../collection';
 import { SmrtObject } from '../object';
 import { ObjectRegistry } from '../registry';
 import { MCPGenerator } from './mcp';
@@ -159,6 +163,52 @@ class MCPUnderscoreMethodAgent extends SmrtObject {
   }
 }
 
+@smrt({
+  mcp: {
+    include: ['apply', 'rebalance', 'restoreIntoContent', 'fail', 'opaque'],
+  },
+  api: { routes: { apply: { scope: 'collection' } } },
+})
+class MCPConformanceAgent extends SmrtObject {
+  async apply(idempotencyKey: string, expectedVersion?: number): Promise<any> {
+    return { receiver: 'item', idempotencyKey, expectedVersion };
+  }
+
+  static async rebalance(
+    idempotencyKey: string,
+    expectedVersion?: number,
+  ): Promise<any> {
+    return { receiver: 'static', idempotencyKey, expectedVersion };
+  }
+
+  async restoreIntoContent(idempotencyKey: string): Promise<any> {
+    return { receiver: 'camelCase', idempotencyKey };
+  }
+
+  async fail(): Promise<any> {
+    return {
+      ok: false,
+      code: 'conflict',
+      message: 'Bearer private-token',
+      status: 409,
+      details: { authorization: 'private-token', safe: 'still-safe' },
+    };
+  }
+
+  async opaque(): Promise<any> {
+    return { code: 'opaque-success', message: 'leave me untouched' };
+  }
+}
+
+@smrt({ mcp: { include: ['fanout'] } })
+class MCPConformanceCollection extends SmrtCollection<MCPConformanceAgent> {
+  static readonly _itemClass = MCPConformanceAgent;
+
+  async fanout(idempotencyKey: string, expectedVersion?: number): Promise<any> {
+    return { receiver: 'collection', idempotencyKey, expectedVersion };
+  }
+}
+
 describe('MCPGenerator with Custom Actions', () => {
   let generator: MCPGenerator;
 
@@ -166,6 +216,58 @@ describe('MCPGenerator with Custom Actions', () => {
     // Authenticated context so the fail-closed tool-auth gate (#1540) allows
     // mutating custom actions; auth itself is covered by dedicated tests.
     generator = new MCPGenerator({}, { user: { id: 'test-user' } });
+    ObjectRegistry.getMethods('MCPConformanceAgent').set('apply', {
+      name: 'apply',
+      async: true,
+      isPublic: true,
+      isStatic: false,
+      returnType: 'Promise<any>',
+      parameters: [
+        { name: 'idempotencyKey', type: 'string', optional: false },
+        { name: 'expectedVersion', type: 'number', optional: true },
+      ],
+    });
+    ObjectRegistry.getMethods('MCPConformanceAgent').set('rebalance', {
+      name: 'rebalance',
+      async: true,
+      isPublic: true,
+      isStatic: true,
+      returnType: 'Promise<any>',
+      parameters: [
+        { name: 'idempotencyKey', type: 'string', optional: false },
+        { name: 'expectedVersion', type: 'number', optional: true },
+      ],
+    });
+    ObjectRegistry.getMethods('MCPConformanceAgent').set('restoreIntoContent', {
+      name: 'restoreIntoContent',
+      async: true,
+      isPublic: true,
+      isStatic: false,
+      returnType: 'Promise<any>',
+      parameters: [{ name: 'idempotencyKey', type: 'string', optional: false }],
+    });
+    for (const name of ['fail', 'opaque']) {
+      ObjectRegistry.getMethods('MCPConformanceAgent').set(name, {
+        name,
+        async: true,
+        isPublic: true,
+        isStatic: false,
+        returnType: 'Promise<any>',
+        parameters: [],
+      });
+    }
+    ObjectRegistry.getMethods('MCPConformanceCollection').set('fanout', {
+      name: 'fanout',
+      async: true,
+      isPublic: true,
+      isStatic: false,
+      returnType: 'Promise<any>',
+      parameters: [
+        { name: 'idempotencyKey', type: 'string', optional: false },
+        { name: 'expectedVersion', type: 'number', optional: true },
+      ],
+    });
+    ObjectRegistry.invalidateAllInheritanceCaches();
   });
 
   afterEach(() => {
@@ -204,6 +306,53 @@ describe('MCPGenerator with Custom Actions', () => {
       expect(researchTool?.inputSchema.type).toBe('object');
       expect(researchTool?.inputSchema.properties.id).toBeDefined();
       expect(researchTool?.inputSchema.properties.options).toBeDefined();
+    });
+
+    it('projects canonical custom-action receivers and typed parameters', async () => {
+      const tools = await generator.generateTools();
+      const inputSchema = (name: string) =>
+        tools.find((tool) => tool.name === name)?.inputSchema;
+
+      expect(inputSchema('mcpconformanceagent_apply')).toMatchObject({
+        properties: {
+          id: { type: 'string' },
+          idempotencyKey: { type: 'string' },
+          expectedVersion: { type: 'number' },
+        },
+        required: ['id', 'idempotencyKey'],
+      });
+      expect(inputSchema('mcpconformanceagent_rebalance')).toMatchObject({
+        properties: {
+          idempotencyKey: { type: 'string' },
+          expectedVersion: { type: 'number' },
+        },
+        required: ['idempotencyKey'],
+      });
+      // Tool IDs are lowercased protocol aliases, but the handler resolves the
+      // declared camelCase method name before invocation.
+      expect(
+        inputSchema('mcpconformanceagent_restoreintocontent'),
+      ).toMatchObject({
+        properties: {
+          id: { type: 'string' },
+          idempotencyKey: { type: 'string' },
+        },
+        required: ['id', 'idempotencyKey'],
+      });
+      // A collection-class method has a real collection receiver, so it is
+      // collection-scoped even though it is not static.
+      expect(inputSchema('mcpconformancecollection_fanout')).toMatchObject({
+        properties: {
+          idempotencyKey: { type: 'string' },
+          expectedVersion: { type: 'number' },
+        },
+        required: ['idempotencyKey'],
+      });
+      // Custom-action discovery never broadens an explicit MCP allowlist into
+      // generic mutation tools.
+      expect(tools.map((tool) => tool.name)).not.toContain(
+        'mcpconformanceagent_create',
+      );
     });
 
     it('should warn about invalid custom actions', async () => {
@@ -353,20 +502,21 @@ describe('MCPGenerator with Custom Actions', () => {
       expect(result.amount).toBe(42);
     });
 
-    it('should handle custom actions without ID (collection-level)', async () => {
-      // Mock collection with custom method
+    it('handles recognized collection actions without an ID', async () => {
+      // A collection-class method has an actual collection receiver.
       const mockCollection = {
-        research: vi
-          .fn()
-          .mockResolvedValue({ action: 'research', level: 'collection' }),
+        fanout: vi.fn().mockResolvedValue({
+          action: 'fanout',
+          level: 'collection',
+        }),
       };
 
       const request = {
         method: 'tools/call',
         params: {
-          name: 'mcptestagent_research',
+          name: 'mcpconformancecollection_fanout',
           arguments: {
-            options: { query: 'collection query' },
+            idempotencyKey: 'collection-query',
           },
         },
       };
@@ -383,8 +533,168 @@ describe('MCPGenerator with Custom Actions', () => {
 
       expect(response.content[0].type).toBe('text');
       const result = JSON.parse(response.content[0].text);
-      expect(result.action).toBe('research');
+      expect(result.action).toBe('fanout');
       expect(result.level).toBe('collection');
+      expect(mockCollection.fanout).toHaveBeenCalledWith(
+        'collection-query',
+        undefined,
+      );
+    });
+
+    it('uses item, static, and collection receivers with positional typed arguments', async () => {
+      const item = new MCPConformanceAgent({});
+      const collection = {
+        get: vi.fn().mockResolvedValue(item),
+      };
+      (generator as any).getCollection = vi.fn().mockReturnValue(collection);
+
+      const itemResponse = await generator.handleToolCall({
+        method: 'tools/call',
+        params: {
+          name: 'mcpconformanceagent_apply',
+          arguments: {
+            id: 'item-1',
+            idempotencyKey: 'retry-item',
+            expectedVersion: 3,
+          },
+        },
+      });
+      expect(JSON.parse(itemResponse.content[0].text)).toMatchObject({
+        receiver: 'item',
+        idempotencyKey: 'retry-item',
+        expectedVersion: 3,
+      });
+
+      const camelCaseResponse = await generator.handleToolCall({
+        method: 'tools/call',
+        params: {
+          name: 'mcpconformanceagent_restoreintocontent',
+          arguments: { id: 'item-1', idempotencyKey: 'camel-case' },
+        },
+      });
+      expect(JSON.parse(camelCaseResponse.content[0].text)).toMatchObject({
+        receiver: 'camelCase',
+        idempotencyKey: 'camel-case',
+      });
+
+      const staticResponse = await generator.handleToolCall({
+        method: 'tools/call',
+        params: {
+          name: 'mcpconformanceagent_rebalance',
+          arguments: { idempotencyKey: 'retry-static', expectedVersion: 4 },
+        },
+      });
+      expect(JSON.parse(staticResponse.content[0].text)).toMatchObject({
+        receiver: 'static',
+        idempotencyKey: 'retry-static',
+        expectedVersion: 4,
+      });
+
+      const collectionReceiver = {
+        fanout: vi.fn(function (
+          idempotencyKey: string,
+          expectedVersion?: number,
+        ) {
+          return {
+            receiver: this === collectionReceiver ? 'collection' : 'wrong',
+            idempotencyKey,
+            expectedVersion,
+          };
+        }),
+      };
+      (generator as any).getCollection = vi
+        .fn()
+        .mockReturnValue(collectionReceiver);
+      const collectionResponse = await generator.handleToolCall({
+        method: 'tools/call',
+        params: {
+          name: 'mcpconformancecollection_fanout',
+          arguments: { idempotencyKey: 'retry-collection', expectedVersion: 5 },
+        },
+      });
+      expect(JSON.parse(collectionResponse.content[0].text)).toMatchObject({
+        receiver: 'collection',
+        idempotencyKey: 'retry-collection',
+        expectedVersion: 5,
+      });
+      expect(collectionReceiver.fanout).toHaveBeenCalledWith(
+        'retry-collection',
+        5,
+      );
+    });
+
+    it('returns redacted conventional failures as MCP errors without changing opaque successes', async () => {
+      const object = new MCPConformanceAgent({});
+      (generator as any).getCollection = vi
+        .fn()
+        .mockReturnValue({ get: vi.fn().mockResolvedValue(object) });
+
+      const failure = await generator.handleToolCall({
+        method: 'tools/call',
+        params: {
+          name: 'mcpconformanceagent_fail',
+          arguments: { id: 'item-1' },
+        },
+      });
+      expect(failure.isError).toBe(true);
+      expect(failure._meta).toMatchObject({
+        'io.happyvertical/smrt': {
+          code: 'conflict',
+          status: 409,
+          message: 'Bearer [REDACTED]',
+          details: { authorization: '[REDACTED]', safe: 'still-safe' },
+        },
+      });
+      expect(failure.content[0].text).not.toContain('private-token');
+
+      const opaque = await generator.handleToolCall({
+        method: 'tools/call',
+        params: {
+          name: 'mcpconformanceagent_opaque',
+          arguments: { id: 'item-1' },
+        },
+      });
+      expect(opaque.isError).toBeUndefined();
+      expect(JSON.parse(opaque.content[0].text)).toEqual({
+        code: 'opaque-success',
+        message: 'leave me untouched',
+      });
+    });
+
+    it('emits the same custom-action receiver, positional arguments, and error contract for modular MCP servers', async () => {
+      const outputDir = await mkdtemp(join(tmpdir(), 'smrt-modular-mcp-'));
+      try {
+        await generator.generateServer({
+          outputPath: join(outputDir, 'index.js'),
+          modular: true,
+        });
+        const handlers = await readFile(
+          join(outputDir, 'handlers', 'index.ts'),
+          'utf-8',
+        );
+
+        expect(handlers).toContain("case 'mcpconformanceagent_apply'");
+        expect(handlers).toContain("case 'mcpconformanceagent_rebalance'");
+        expect(handlers).toContain(
+          "case 'mcpconformanceagent_restoreintocontent'",
+        );
+        expect(handlers).toContain("case 'mcpconformancecollection_fanout'");
+        expect(handlers).toContain(
+          'Custom action rebalance is collection-scoped and does not accept an ID',
+        );
+        expect(handlers).toContain(
+          'ObjectRegistry.getClass("MCPConformanceAgent")?.constructor',
+        );
+        expect(handlers).toContain('args["idempotencyKey"]');
+        expect(handlers).toContain('target["restoreIntoContent"]');
+        expect(handlers).toContain('actionMethod.call(target, ...methodArgs)');
+        expect(handlers).toContain('normalizeCustomActionFailure(result)');
+        expect(handlers).toContain(
+          '[SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY]: failure',
+        );
+      } finally {
+        await rm(outputDir, { recursive: true, force: true });
+      }
     });
 
     it('should handle errors in custom action execution', async () => {

--- a/packages/core/src/generators/mcp.test.ts
+++ b/packages/core/src/generators/mcp.test.ts
@@ -168,6 +168,7 @@ class MCPUnderscoreMethodAgent extends SmrtObject {
     include: [
       'apply',
       'rebalance',
+      'archive',
       'restoreIntoContent',
       'move',
       'fail',
@@ -186,6 +187,10 @@ class MCPConformanceAgent extends SmrtObject {
     expectedVersion?: number,
   ): Promise<any> {
     return { receiver: 'static', idempotencyKey, expectedVersion };
+  }
+
+  static async archive(id: string): Promise<any> {
+    return { receiver: 'static', actionId: id };
   }
 
   async restoreIntoContent(idempotencyKey: string): Promise<any> {
@@ -248,6 +253,14 @@ describe('MCPGenerator with Custom Actions', () => {
         { name: 'idempotencyKey', type: 'string', optional: false },
         { name: 'expectedVersion', type: 'number', optional: true },
       ],
+    });
+    ObjectRegistry.getMethods('MCPConformanceAgent').set('archive', {
+      name: 'archive',
+      async: true,
+      isPublic: true,
+      isStatic: true,
+      returnType: 'Promise<any>',
+      parameters: [{ name: 'id', type: 'string', optional: false }],
     });
     ObjectRegistry.getMethods('MCPConformanceAgent').set('restoreIntoContent', {
       name: 'restoreIntoContent',
@@ -346,6 +359,10 @@ describe('MCPGenerator with Custom Actions', () => {
           expectedVersion: { type: 'number' },
         },
         required: ['idempotencyKey'],
+      });
+      expect(inputSchema('mcpconformanceagent_archive')).toMatchObject({
+        properties: { actionId: { type: 'string' } },
+        required: ['actionId'],
       });
       // Tool IDs are lowercased protocol aliases, but the handler resolves the
       // declared camelCase method name before invocation.
@@ -628,6 +645,18 @@ describe('MCPGenerator with Custom Actions', () => {
         expectedVersion: 4,
       });
 
+      const archiveResponse = await generator.handleToolCall({
+        method: 'tools/call',
+        params: {
+          name: 'mcpconformanceagent_archive',
+          arguments: { actionId: 'archive-2' },
+        },
+      });
+      expect(JSON.parse(archiveResponse.content[0].text)).toMatchObject({
+        receiver: 'static',
+        actionId: 'archive-2',
+      });
+
       const collectionReceiver = {
         fanout: vi.fn(function (
           idempotencyKey: string,
@@ -713,6 +742,7 @@ describe('MCPGenerator with Custom Actions', () => {
 
         expect(handlers).toContain("case 'mcpconformanceagent_apply'");
         expect(handlers).toContain("case 'mcpconformanceagent_rebalance'");
+        expect(handlers).toContain("case 'mcpconformanceagent_archive'");
         expect(handlers).toContain(
           "case 'mcpconformanceagent_restoreintocontent'",
         );

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -16,6 +16,7 @@ import {
   buildCustomActionInvocationArgs,
   type CustomActionFailure,
   type CustomActionMetadata,
+  customActionParameterInputName,
   normalizeCustomActionFailure,
   resolveCustomActionMetadata,
   SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY,
@@ -1596,18 +1597,23 @@ ${indent}}`;
                 this.hasCollectionReceiver(classInfo),
               );
               const methodArgs = !metadata.parameters
-                ? 'Object.keys(options).length > 0 ? options : directArgs'
+                ? 'Object.keys(options ?? {}).length > 0 ? options : directArgs'
                 : metadata.parameters.length === 1 &&
                     metadata.parameters[0]?.name === 'options'
                   ? 'options'
                   : `[${metadata.parameters
                       .map(
                         (parameter) =>
-                          `args[${JSON.stringify(parameter.name)}]`,
+                          `args[${JSON.stringify(
+                            customActionParameterInputName(
+                              metadata,
+                              parameter.name,
+                            ),
+                          )}]`,
                       )
                       .join(', ')}]`;
               return `${indent}case '${tool.name}': {
-${indent}  const { id, options = {}, ...directArgs } = args;
+${indent}  const { id, options, ...directArgs } = args;
 
 ${indent}  if (${JSON.stringify(metadata.scope)} === 'item' && !id) {
 ${indent}    throw new Error('ID is required for custom action ${action}');

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -10,7 +10,16 @@ import { SmrtCollection } from '../collection';
 import type { PublicJsonOptions, SmrtObject } from '../object';
 import { ObjectRegistry } from '../registry';
 import type { RegisteredClass } from '../registry/types.js';
-import type { FieldDefinition } from '../scanner/types.js';
+import type { FieldDefinition, MethodDefinition } from '../scanner/types.js';
+import {
+  buildCustomActionInputSchema,
+  buildCustomActionInvocationArgs,
+  type CustomActionFailure,
+  type CustomActionMetadata,
+  normalizeCustomActionFailure,
+  resolveCustomActionMetadata,
+  SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY,
+} from './custom-action.js';
 import {
   generateClaudeConfig,
   generateMCPDocumentation,
@@ -97,6 +106,35 @@ export interface MCPResponse {
     type: 'text';
     text: string;
   }>;
+  isError?: boolean;
+  _meta?: Record<string, unknown>;
+}
+
+class CustomActionFailureError extends Error {
+  constructor(readonly failure: CustomActionFailure) {
+    super(failure.message);
+    this.name = 'CustomActionFailureError';
+  }
+}
+
+/**
+ * MCP tool identifiers are lowercase for stable protocol vocabulary, while
+ * JavaScript method names retain their declared casing. Resolve a tool suffix
+ * back to the registry's canonical method name before inspecting metadata or
+ * invoking it.
+ */
+function resolveCustomActionMethod(
+  methods: Map<string, MethodDefinition>,
+  toolAction: string,
+): [methodName: string, method: MethodDefinition | undefined] {
+  const direct = methods.get(toolAction);
+  if (direct) return [toolAction, direct];
+  for (const [methodName, method] of methods) {
+    if (methodName.toLowerCase() === toolAction.toLowerCase()) {
+      return [methodName, method];
+    }
+  }
+  return [toolAction, undefined];
 }
 
 /**
@@ -385,27 +423,15 @@ export class MCPGenerator {
           const methodDef = methods.get(methodName);
           if (methodDef && !methodDef.isPublic) continue;
 
-          // Generate tool for this method
-          const toolName = `${lowerName}_${methodName}`.toLowerCase();
-          tools.push({
-            name: toolName,
-            description: `Execute ${methodName} action on ${objectName}`,
-            inputSchema: {
-              type: 'object',
-              properties: {
-                id: {
-                  type: 'string',
-                  description: 'ID of the object to execute action on',
-                },
-                options: {
-                  type: 'object',
-                  description: 'Additional options for the custom action',
-                  additionalProperties: true,
-                },
-              },
-              required: ['id'],
-            },
-          });
+          tools.push(
+            this.buildCustomActionTool(
+              objectName,
+              lowerName,
+              methodName,
+              methodDef,
+              this.hasCollectionReceiver(classInfo),
+            ),
+          );
         }
       } else {
         // No custom methods in include = show all discovered methods by default
@@ -416,32 +442,62 @@ export class MCPGenerator {
           // Always respect exclude list
           if (excluded.includes(methodName)) continue;
 
-          // Generate MCP tool for this custom method
-          const toolName = `${lowerName}_${methodName}`.toLowerCase();
-          tools.push({
-            name: toolName,
-            description: `Execute ${methodName} action on ${objectName}`,
-            inputSchema: {
-              type: 'object',
-              properties: {
-                id: {
-                  type: 'string',
-                  description: 'ID of the object to execute action on',
-                },
-                options: {
-                  type: 'object',
-                  description: 'Additional options for the custom action',
-                  additionalProperties: true,
-                },
-              },
-              required: ['id'],
-            },
-          });
+          tools.push(
+            this.buildCustomActionTool(
+              objectName,
+              lowerName,
+              methodName,
+              methodDef,
+              this.hasCollectionReceiver(classInfo),
+            ),
+          );
         }
       }
     }
 
     return tools;
+  }
+
+  private buildCustomActionTool(
+    objectName: string,
+    lowerName: string,
+    methodName: string,
+    methodDef?: MethodDefinition,
+    collectionReceiver = false,
+  ): MCPTool {
+    const metadata = this.resolveCustomActionMetadata(
+      objectName,
+      methodName,
+      methodDef,
+      collectionReceiver,
+    );
+    return {
+      name: `${lowerName}_${methodName}`.toLowerCase(),
+      description: `Execute ${methodName} action on ${objectName}`,
+      inputSchema: buildCustomActionInputSchema(
+        metadata,
+      ) as MCPTool['inputSchema'],
+    };
+  }
+
+  private resolveCustomActionMetadata(
+    objectName: string,
+    action: string,
+    method?: MethodDefinition,
+    collectionReceiver = false,
+  ): CustomActionMetadata {
+    return resolveCustomActionMetadata({
+      actionName: action,
+      method,
+      apiConfig: ObjectRegistry.getConfig(objectName).api,
+      ...(collectionReceiver ? { defaultScope: 'collection' } : {}),
+    });
+  }
+
+  private hasCollectionReceiver(classInfo?: RegisteredClass): boolean {
+    return (
+      !!classInfo && classInfo.constructor.prototype instanceof SmrtCollection
+    );
   }
 
   /**
@@ -606,6 +662,20 @@ export class MCPGenerator {
         ],
       };
     } catch (error) {
+      if (error instanceof CustomActionFailureError) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({ error: error.failure }),
+            },
+          ],
+          isError: true,
+          _meta: {
+            [SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY]: error.failure,
+          },
+        };
+      }
       return {
         content: [
           {
@@ -983,7 +1053,12 @@ export class MCPGenerator {
       default: {
         // Handle custom actions. The method may return a SmrtObject (or array),
         // so serialize through toPublicData to strip sensitive fields (#1540).
-        const result = await this.executeCustomAction(collection, action, args);
+        const result = await this.executeCustomAction(
+          collection,
+          action,
+          args,
+          objectName,
+        );
         return this.toPublicData(result);
       }
     }
@@ -996,12 +1071,35 @@ export class MCPGenerator {
     collection: SmrtCollection<SmrtObject>,
     action: string,
     args: ToolArgs,
+    objectName?: string,
   ): Promise<unknown> {
-    const { id, options: rawOptions = {}, ...directArgs } = args;
-    // Args arrive as untyped JSON; `options` is a nested object bag.
-    const options = rawOptions as Record<string, unknown>;
+    const id = args.id;
+    const [methodName, methodDef] = objectName
+      ? resolveCustomActionMethod(
+          await ObjectRegistry.getAllMethods(objectName),
+          action,
+        )
+      : [action, undefined];
+    const metadata = this.resolveCustomActionMetadata(
+      objectName ?? '',
+      methodName,
+      methodDef,
+      objectName
+        ? this.hasCollectionReceiver(ObjectRegistry.getClass(objectName))
+        : false,
+    );
+    const methodArgs = buildCustomActionInvocationArgs(metadata, args);
 
     try {
+      if (methodDef && metadata.idRequired && !id) {
+        throw new Error(`ID is required for custom action '${action}'`);
+      }
+      if (!metadata.idRequired && id && methodDef) {
+        throw new Error(
+          `Custom action '${action}' is collection-scoped and does not accept an ID`,
+        );
+      }
+
       // If an ID is provided, get the specific object and call the method on it
       if (id) {
         const object = await collection.get(id as string);
@@ -1013,44 +1111,64 @@ export class MCPGenerator {
         // through a record view and narrow the value to a callable after the
         // `typeof === 'function'` guard.
         const objectWithMethods = object as unknown as Record<string, unknown>;
-        const objectMethod = objectWithMethods[action];
+        const objectMethod = objectWithMethods[methodName];
         if (typeof objectMethod === 'function') {
-          // Call the method with the provided options
-          // If options is provided, use it; otherwise use directArgs
-          const methodArgs =
-            Object.keys(options).length > 0 ? options : directArgs;
           // `.call(object, …)` preserves the receiver binding of the original
           // member call (`object[action](…)`) — the method relies on `this`.
           const result = await (objectMethod as InstanceCallable).call(
             object,
-            methodArgs,
+            ...methodArgs,
           );
+          const failure = normalizeCustomActionFailure(result);
+          if (failure) throw new CustomActionFailureError(failure);
           return result;
         } else {
-          throw new Error(`Method '${action}' not found on object instance`);
+          throw new Error(
+            `Method '${methodName}' not found on object instance`,
+          );
         }
+      } else if (metadata.isStatic && objectName) {
+        const classInfo = ObjectRegistry.getClass(objectName);
+        const classMethod = (
+          classInfo?.constructor as unknown as
+            | Record<string, unknown>
+            | undefined
+        )?.[methodName];
+        if (typeof classMethod !== 'function') {
+          throw new Error(
+            `Static method '${methodName}' not found on ${objectName}`,
+          );
+        }
+        const result = await (classMethod as InstanceCallable).call(
+          classInfo?.constructor,
+          ...methodArgs,
+        );
+        const failure = normalizeCustomActionFailure(result);
+        if (failure) throw new CustomActionFailureError(failure);
+        return result;
       } else {
         // No ID provided, try to call the method on the collection
         const collectionMethod = (
           collection as unknown as Record<string, unknown>
-        )[action];
+        )[methodName];
         if (typeof collectionMethod === 'function') {
-          const methodArgs =
-            Object.keys(options).length > 0 ? options : directArgs;
           // `.call(collection, …)` preserves the receiver binding of the
           // original member call (`collection[action](…)`).
           const result = await (collectionMethod as InstanceCallable).call(
             collection,
-            methodArgs,
+            ...methodArgs,
           );
+          const failure = normalizeCustomActionFailure(result);
+          if (failure) throw new CustomActionFailureError(failure);
           return result;
         } else {
           throw new Error(
-            `Method '${action}' not found on collection. For object-specific actions, provide an 'id' parameter.`,
+            `Method '${methodName}' not found on collection. For object-specific actions, provide an 'id' parameter.`,
           );
         }
       }
     } catch (error) {
+      if (error instanceof CustomActionFailureError) throw error;
       throw new Error(
         `Failed to execute custom action '${action}': ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
@@ -1156,6 +1274,7 @@ export class MCPGenerator {
         context: this.context,
         debug,
         tools,
+        customActions: await this.runtimeCustomActions(tools),
         tenantScopedObjects: await this.tenantScopedObjectNames(tools),
       };
 
@@ -1190,6 +1309,55 @@ export class MCPGenerator {
     const mcpScript = generateMCPScript(outputPath);
     console.log(`\n📝 Add this to your package.json scripts:`);
     console.log(`   "mcp": "${mcpScript}"\n`);
+  }
+
+  private async runtimeCustomActions(
+    tools: MCPTool[],
+  ): Promise<NonNullable<RuntimeOptions['customActions']>> {
+    const metadata: NonNullable<RuntimeOptions['customActions']> = {};
+    const crudActions = new Set(['list', 'get', 'create', 'update', 'delete']);
+    const classes = ObjectRegistry.getAllClasses();
+
+    for (const tool of tools) {
+      const separator = tool.name.indexOf('_');
+      if (separator === -1) continue;
+      const objectPrefix = tool.name.slice(0, separator);
+      const action = tool.name.slice(separator + 1);
+      if (crudActions.has(action)) continue;
+      const matched = Array.from(classes.entries()).find(
+        ([key, info]) => (info.name || key).toLowerCase() === objectPrefix,
+      );
+      if (!matched) continue;
+      const [key, classInfo] = matched;
+      const objectName = classInfo.name || key;
+      const [methodName, method] = resolveCustomActionMethod(
+        await ObjectRegistry.getAllMethods(objectName),
+        action,
+      );
+      const resolved = this.resolveCustomActionMetadata(
+        objectName,
+        methodName,
+        method,
+        this.hasCollectionReceiver(classInfo),
+      );
+      metadata[tool.name] = {
+        scope: resolved.scope,
+        isStatic: resolved.isStatic,
+        methodName,
+        ...(resolved.parameters
+          ? {
+              parameterNames: resolved.parameters.map(
+                (parameter) => parameter.name,
+              ),
+              optionsParameter:
+                resolved.parameters.length === 1 &&
+                resolved.parameters[0]?.name === 'options',
+            }
+          : {}),
+        legacyOptions: !resolved.parameters,
+      };
+    }
+    return metadata;
   }
 
   /**
@@ -1298,13 +1466,16 @@ export const tools: Array<{
     const capitalize = (str: string) =>
       str.charAt(0).toUpperCase() + str.slice(1);
 
-    const switchCases = tools
-      .map((tool) => {
-        const [objectName, action] = tool.name.split('_');
+    const switchCases = (
+      await Promise.all(
+        tools.map(async (tool) => {
+          const separator = tool.name.indexOf('_');
+          const objectName = tool.name.slice(0, separator);
+          const action = tool.name.slice(separator + 1);
 
-        switch (action) {
-          case 'list':
-            return `${indent}case '${tool.name}': {
+          switch (action) {
+            case 'list':
+              return `${indent}case '${tool.name}': {
 ${indent}  const limit = args.limit ?? 50;
 ${indent}  const offset = args.offset ?? 0;
 ${indent}  const where = args.where ?? {};
@@ -1319,8 +1490,8 @@ ${indent}  const itemsPublic = items.map((item) => item.toPublicJSON(PUBLIC_JSON
 ${indent}  return { content: [{ type: 'text', text: JSON.stringify(itemsPublic) }] };
 ${indent}}`;
 
-          case 'get':
-            return `${indent}case '${tool.name}': {
+            case 'get':
+              return `${indent}case '${tool.name}': {
 ${indent}  if (!args.id && !args.slug) {
 ${indent}    throw new Error('Either id or slug is required');
 ${indent}  }
@@ -1340,8 +1511,8 @@ ${indent}  }
 ${indent}  return { content: [{ type: 'text', text: JSON.stringify(item.toPublicJSON(PUBLIC_JSON_OPTIONS)) }] };
 ${indent}}`;
 
-          case 'create':
-            return `${indent}case '${tool.name}': {
+            case 'create':
+              return `${indent}case '${tool.name}': {
 ${indent}  const collection = await ObjectRegistry.getCollection('${capitalize(objectName)}', {
 ${indent}    persistence: { type: 'sql', url: process.env.DATABASE_URL || ':memory:' },
 ${indent}    ai: aiConfig
@@ -1353,8 +1524,8 @@ ${indent}  await newItem.save();
 ${indent}  return { content: [{ type: 'text', text: JSON.stringify(newItem.toPublicJSON(PUBLIC_JSON_OPTIONS)) }] };
 ${indent}}`;
 
-          case 'update':
-            return `${indent}case '${tool.name}': {
+            case 'update':
+              return `${indent}case '${tool.name}': {
 ${indent}  const { id, ...updateData } = args;
 ${indent}  if (!id) {
 ${indent}    throw new Error('ID is required for update');
@@ -1376,8 +1547,8 @@ ${indent}  await existing.save();
 ${indent}  return { content: [{ type: 'text', text: JSON.stringify(existing.toPublicJSON(PUBLIC_JSON_OPTIONS)) }] };
 ${indent}}`;
 
-          case 'delete':
-            return `${indent}case '${tool.name}': {
+            case 'delete':
+              return `${indent}case '${tool.name}': {
 ${indent}  if (!args.id) {
 ${indent}    throw new Error('ID is required for delete');
 ${indent}  }
@@ -1397,37 +1568,95 @@ ${indent}  await toDelete.delete();
 ${indent}  return { content: [{ type: 'text', text: JSON.stringify({ success: true, message: 'Object deleted successfully' }) }] };
 ${indent}}`;
 
-          default:
-            // Custom action
-            return `${indent}case '${tool.name}': {
+            default: {
+              // Custom actions use the same canonical receiver/argument contract
+              // as the in-process and standalone MCP runtimes. In particular,
+              // a route config cannot turn an instance method into a static one.
+              const matched = Array.from(
+                ObjectRegistry.getAllClasses().entries(),
+              ).find(
+                ([key, info]) =>
+                  (info.name || key).toLowerCase() === objectName.toLowerCase(),
+              );
+              if (!matched) {
+                throw new Error(
+                  `Unable to resolve custom-action target for tool '${tool.name}'`,
+                );
+              }
+              const [classKey, classInfo] = matched;
+              const registeredName = classInfo.name || classKey;
+              const [methodName, method] = resolveCustomActionMethod(
+                await ObjectRegistry.getAllMethods(registeredName),
+                action,
+              );
+              const metadata = this.resolveCustomActionMetadata(
+                registeredName,
+                methodName,
+                method,
+                this.hasCollectionReceiver(classInfo),
+              );
+              const methodArgs = !metadata.parameters
+                ? 'Object.keys(options).length > 0 ? options : directArgs'
+                : metadata.parameters.length === 1 &&
+                    metadata.parameters[0]?.name === 'options'
+                  ? 'options'
+                  : `[${metadata.parameters
+                      .map(
+                        (parameter) =>
+                          `args[${JSON.stringify(parameter.name)}]`,
+                      )
+                      .join(', ')}]`;
+              return `${indent}case '${tool.name}': {
 ${indent}  const { id, options = {}, ...directArgs } = args;
 
-${indent}  if (!id) {
+${indent}  if (${JSON.stringify(metadata.scope)} === 'item' && !id) {
 ${indent}    throw new Error('ID is required for custom action ${action}');
 ${indent}  }
+${indent}  if (${JSON.stringify(metadata.scope)} === 'collection' && id) {
+${indent}    throw new Error('Custom action ${action} is collection-scoped and does not accept an ID');
+${indent}  }
 
-${indent}  const collection = await ObjectRegistry.getCollection('${capitalize(objectName)}', {
+${indent}  const collection = await ObjectRegistry.getCollection(${JSON.stringify(registeredName)}, {
 ${indent}    persistence: { type: 'sql', url: process.env.DATABASE_URL || ':memory:' },
 ${indent}    ai: aiConfig
 ${indent}  });
 
-${indent}  const object = await collection.get(id);
-${indent}  if (!object) {
-${indent}    throw new Error('Object not found');
+${indent}  const target = ${JSON.stringify(metadata.scope)} === 'item'
+${indent}    ? await collection.get(id)
+${indent}    : ${metadata.isStatic}
+${indent}      ? ObjectRegistry.getClass(${JSON.stringify(registeredName)})?.constructor
+${indent}      : collection;
+${indent}  if (!target) {
+${indent}    throw new Error(${JSON.stringify(
+                metadata.scope === 'item'
+                  ? 'Object not found'
+                  : 'Custom action target not found',
+              )});
 ${indent}  }
 
-${indent}  if (typeof object['${action}'] !== 'function') {
-${indent}    throw new Error('Method ${action} not found on object');
+${indent}  const actionMethod = target[${JSON.stringify(methodName)}];
+${indent}  if (typeof actionMethod !== 'function') {
+${indent}    throw new Error('Method ${methodName} not found on custom action target');
 ${indent}  }
 
-${indent}  const methodArgs = Object.keys(options).length > 0 ? options : directArgs;
-${indent}  const result = await object['${action}'](methodArgs);
+${indent}  const methodArgs = ${methodArgs.startsWith('[') ? methodArgs : `[${methodArgs}]`};
+${indent}  const result = await actionMethod.call(target, ...methodArgs);
+${indent}  const failure = normalizeCustomActionFailure(result);
+${indent}  if (failure) {
+${indent}    return {
+${indent}      content: [{ type: 'text', text: JSON.stringify({ error: failure }) }],
+${indent}      isError: true,
+${indent}      _meta: { [SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY]: failure },
+${indent}    };
+${indent}  }
 
 ${indent}  return { content: [{ type: 'text', text: JSON.stringify(toPublicResult(result)) }] };
 ${indent}}`;
-        }
-      })
-      .join('\n\n');
+            }
+          }
+        }),
+      )
+    ).join('\n\n');
 
     return switchCases;
   }
@@ -1459,7 +1688,7 @@ ${indent}}`;
  * principal) and tenancy is enabled so the interceptor enforces filtering.
  */
 
-import { ObjectRegistry } from '@happyvertical/smrt-core';
+import { ObjectRegistry, normalizeCustomActionFailure, SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY } from '@happyvertical/smrt-core';
 ${hasTenantScoped ? "import { enableTenancy, runTenantScopedEntryPoint } from '@happyvertical/smrt-tenancy';\n" : ''}${
   hasTenantScoped
     ? `

--- a/packages/core/src/generators/tool-schema.ts
+++ b/packages/core/src/generators/tool-schema.ts
@@ -1,3 +1,8 @@
+import {
+  buildCustomActionInputSchema,
+  type CustomActionMetadata,
+} from './custom-action.js';
+
 /**
  * Transport-agnostic tool-descriptor builder (#1812, tracer).
  *
@@ -125,6 +130,7 @@ export function fieldTypeToJsonSchema(field: ToolFieldMeta): ToolJsonSchema {
 export function buildToolInputSchema(
   action: string,
   fields: ToolFieldMeta[],
+  customAction?: CustomActionMetadata,
 ): ToolJsonSchema {
   switch (action) {
     case 'list':
@@ -206,22 +212,13 @@ export function buildToolInputSchema(
       };
 
     default:
-      // Custom method: mirrors mcp.ts's custom-action tool shape.
-      return {
-        type: 'object',
-        properties: {
-          id: {
-            type: 'string',
-            description: 'ID of the object to execute action on',
-          },
-          options: {
-            type: 'object',
-            description: 'Additional options for the custom action',
-            additionalProperties: true,
-          },
+      return buildCustomActionInputSchema(
+        customAction ?? {
+          scope: 'item',
+          idRequired: true,
+          isStatic: false,
         },
-        required: ['id'],
-      };
+      );
   }
 }
 
@@ -256,6 +253,7 @@ export function buildToolDescriptors(opts: {
   className: string;
   fields: ToolFieldMeta[];
   actions: string[];
+  customActions?: Record<string, CustomActionMetadata>;
   toolPrefix?: string;
 }): ToolDescriptor[] {
   const { className, fields, actions } = opts;
@@ -267,7 +265,11 @@ export function buildToolDescriptors(opts: {
     // FIRST underscore only (mcp.ts #1378), so a lowercased join is safe here.
     name: `${prefix}_${action}`.toLowerCase(),
     description: describeAction(action, className),
-    inputSchema: buildToolInputSchema(action, fields),
+    inputSchema: buildToolInputSchema(
+      action,
+      fields,
+      opts.customActions?.[action],
+    ),
     readOnly: action === 'list' || action === 'get',
   }));
 }

--- a/packages/core/src/scanner/__tests__/manifest-generator-coverage.test.ts
+++ b/packages/core/src/scanner/__tests__/manifest-generator-coverage.test.ts
@@ -475,6 +475,19 @@ describe('ManifestGenerator coverage', () => {
       expect(code).not.toContain("app.delete('/notes/:id'");
     });
 
+    it('keeps custom-action endpoint discovery aligned with its item receiver', () => {
+      const gen = new ManifestGenerator();
+      const m = baseManifest();
+      m.objects.Note.decoratorConfig.api = {
+        include: ['summarize'],
+        // This cannot turn the non-static method into a collection receiver.
+        routes: { summarize: { scope: 'collection' } },
+      };
+
+      const endpoints = gen.generateRestEndpoints(m);
+      expect(endpoints).toBe('POST /notes/:id/summarize');
+    });
+
     it('generates MCP tool names and JSON tool definitions', () => {
       const gen = new ManifestGenerator();
       const names = gen.generateMCPTools(baseManifest());

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -5,6 +5,7 @@
 import { createHash } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { createLogger } from '@happyvertical/logger';
+import { resolveCustomActionMetadata } from '../generators/custom-action.js';
 import {
   loadExternalManifestSync,
   lookupInManifest,
@@ -2016,10 +2017,16 @@ ${fields}
     const isCollectionClass =
       obj.extends === 'SmrtCollection' || !!obj.extendsTypeArg;
 
+    const defaultScope =
+      isCollectionClass || actionDef.isStatic ? 'collection' : 'item';
+
     return {
-      scope:
-        routeConfig?.scope ||
-        (isCollectionClass || actionDef.isStatic ? 'collection' : 'item'),
+      scope: resolveCustomActionMetadata({
+        actionName,
+        method: actionDef,
+        apiConfig: config,
+        defaultScope,
+      }).scope,
       method:
         routeConfig?.method?.toUpperCase() === 'GET' ||
         routeConfig?.method?.toUpperCase() === 'POST' ||

--- a/packages/core/src/vite-plugin/api-client-entries.test.ts
+++ b/packages/core/src/vite-plugin/api-client-entries.test.ts
@@ -5,6 +5,7 @@ import type {
 } from '../scanner/types.js';
 import {
   type ApiClientCrudMethod,
+  renderApiClientCustomMethodParameters,
   selectApiClientEntries,
 } from './api-client-entries.js';
 
@@ -74,6 +75,33 @@ function permutations<T>(values: T[]): T[][] {
 }
 
 describe('selectApiClientEntries', () => {
+  it('renders required typed custom-action parameters as required client options', () => {
+    expect(
+      renderApiClientCustomMethodParameters(
+        {
+          name: 'apply',
+          scope: 'item',
+          pathParamNames: [],
+          parameters: [
+            {
+              name: 'idempotencyKey',
+              type: 'string',
+              optional: false,
+            },
+            {
+              name: 'expectedVersion',
+              type: 'number',
+              optional: true,
+            },
+          ],
+        },
+        (type) => type,
+      ),
+    ).toBe(
+      'id: string, options: { idempotencyKey: string; expectedVersion?: number }',
+    );
+  });
+
   it('selects populated model payloads and stable secondary keys independent of manifest order', () => {
     const collectionFirst = selectApiClientEntries(buildManifest(false));
     const modelFirst = selectApiClientEntries(buildManifest(true));
@@ -204,34 +232,36 @@ describe('selectApiClientEntries', () => {
       customMethods: [{ name: 'reveal', scope: 'collection' }],
     });
 
-    expect(
-      selectApiClientEntries({
-        ...implicitManifest,
-        objects: {
-          ...implicitManifest.objects,
-          SecretCollection: {
-            ...implicitCollection,
-            methods: {
-              reveal: {
-                name: 'reveal',
-                async: true,
-                parameters: [],
-                returnType: 'string',
-                isStatic: false,
-                isPublic: true,
-              },
+    const overrideEntry = selectApiClientEntries({
+      ...implicitManifest,
+      objects: {
+        ...implicitManifest.objects,
+        SecretCollection: {
+          ...implicitCollection,
+          methods: {
+            reveal: {
+              name: 'reveal',
+              async: true,
+              parameters: [],
+              returnType: 'string',
+              isStatic: false,
+              isPublic: true,
             },
-            decoratorConfig: {
-              api: {
-                routes: {
-                  reveal: { scope: 'item' },
-                },
+          },
+          decoratorConfig: {
+            api: {
+              routes: {
+                reveal: { scope: 'item' },
               },
             },
           },
         },
-      }),
-    ).toEqual([]);
+      },
+    })[0];
+    expect(overrideEntry).toMatchObject({
+      crudMethods: [],
+      customMethods: [{ name: 'reveal', scope: 'collection' }],
+    });
 
     expect(
       selectApiClientEntries({

--- a/packages/core/src/vite-plugin/api-client-entries.ts
+++ b/packages/core/src/vite-plugin/api-client-entries.ts
@@ -94,7 +94,7 @@ export function renderApiClientCustomMethodParameters(
     const parameterNames = new Set(params.map((param) => param.name));
     const properties = params.map(
       (param) =>
-        `${param.name}${pathParamNames.has(param.name) ? '' : '?'}: ${mapType(param.type)}`,
+        `${param.name}${pathParamNames.has(param.name) || !param.optional ? '' : '?'}: ${mapType(param.type)}`,
     );
     for (const pathParamName of method.pathParamNames) {
       if (!parameterNames.has(pathParamName)) {
@@ -107,7 +107,12 @@ export function renderApiClientCustomMethodParameters(
         : 'Record<string, never>';
   }
 
-  const optionsParameter = `${method.pathParamNames.length > 0 ? 'options' : 'options?'}: ${optionsType}`;
+  const hasRequiredOptions = hasSingleOptionsParameter
+    ? !params[0]?.optional
+    : params.some(
+        (param) => !pathParamNames.has(param.name) && !param.optional,
+      );
+  const optionsParameter = `${method.pathParamNames.length > 0 || hasRequiredOptions ? 'options' : 'options?'}: ${optionsType}`;
   return method.scope === 'collection'
     ? optionsParameter
     : `id: string, ${optionsParameter}`;
@@ -191,12 +196,6 @@ function resolveGeneratedClientCustomMethods(
     if (included && !included.includes(name)) return [];
     if (excluded?.includes(name)) return [];
 
-    const scope =
-      config?.routes?.[name]?.scope ??
-      (isCollection || method.isStatic ? 'collection' : 'item');
-    if (isCollection && scope !== 'collection') return [];
-    if (!isCollection && scope === 'collection' && !method.isStatic) return [];
-
     const routeConfig = resolveApiActionRouteConfig(
       name,
       method,
@@ -208,7 +207,7 @@ function resolveGeneratedClientCustomMethods(
     return [
       {
         name,
-        scope,
+        scope: routeConfig.scope,
         pathParamNames: routeConfig.pathParamNames,
         parameters: method.parameters ?? [],
       },

--- a/packages/core/src/vite-plugin/generated-client-integration.test.ts
+++ b/packages/core/src/vite-plugin/generated-client-integration.test.ts
@@ -151,6 +151,13 @@ export class GenClientProductCollection extends SmrtCollection<GenClientProduct>
   async invalidItemScope(): Promise<GenClientProduct[]> {
     return this.list();
   }
+
+  async bulkReindex(
+    idempotencyKey: string,
+    expectedVersion?: number,
+  ): Promise<GenClientProduct[]> {
+    return this.list();
+  }
 }
 
 @smrt({
@@ -268,8 +275,10 @@ export class GenClientReadonly extends SmrtObject {
     expect(clientSource).toContain('findFeatured: (options)');
     expect(clientSource).not.toContain('findFeatured: (id, options)');
     expect(clientSource).not.toContain('list: (id, options)');
-    expect(clientSource).not.toContain('invalidItemScope: (');
-    expect(clientSource).not.toContain('invalidCollectionScope: (');
+    expect(clientSource).toContain('invalidItemScope: (options)');
+    expect(clientSource).not.toContain('invalidItemScope: (id, options)');
+    expect(clientSource).toContain('invalidCollectionScope: (id, options)');
+    expect(clientSource).not.toContain('invalidCollectionScope: (options)');
     expect(clientSource).toContain('describe: (id, options)');
     expect(clientSource).not.toContain('describe: (options)');
     expect(clientSource).toContain('featured: (options)');
@@ -296,7 +305,7 @@ export class GenClientReadonly extends SmrtObject {
       'utf-8',
     );
     expect(declarationSource).toContain(
-      '"genclientproducts": CrudOperations<GenClientProductData>;',
+      '"genclientproducts": CrudOperations<GenClientProductData> & {\n      invalidCollectionScope(id: string, options?: Record<string, never>): Promise<any>;',
     );
     expect(declarationSource).not.toContain(
       '"genclientproducts": CrudOperations<GenClientProductCollectionData>;',
@@ -307,10 +316,17 @@ export class GenClientReadonly extends SmrtObject {
     expect(declarationSource).toMatch(
       /export interface GenClientProductData \{[\s\S]*?name: string;[\s\S]*?price: number;[\s\S]*?\n {2}\}/,
     );
-    expect(declarationSource).not.toContain('invalidItemScope(');
-    expect(declarationSource).not.toContain('invalidCollectionScope(');
+    expect(declarationSource).toContain(
+      'invalidItemScope(options?: Record<string, never>): Promise<any>;',
+    );
+    expect(declarationSource).toContain(
+      'invalidCollectionScope(id: string, options?: Record<string, never>): Promise<any>;',
+    );
     expect(declarationSource).toContain(
       'findFeatured(options?: Record<string, any>): Promise<any>;',
+    );
+    expect(declarationSource).toContain(
+      'bulkReindex(options: { idempotencyKey: string; expectedVersion?: number }): Promise<any>;',
     );
     expect(declarationSource).toContain(
       'describe(id: string, options: { tone: string }): Promise<any>;',

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -49,6 +49,7 @@ export {
   findCliApiCoherenceViolations,
   generateSvelteKitRoutes,
   methodNameToKebab,
+  resolveApiActionRouteConfig,
   resolveApiActionSet,
   validateCliIncludeAgainstApi,
 } from './sveltekit-generator.js';

--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -29,6 +29,7 @@ import {
   findCliApiCoherenceViolations,
   generateSvelteKitRoutes,
   methodNameToKebab,
+  resolveApiActionRouteConfig,
   resolveApiActionSet,
   validateCliIncludeAgainstApi,
 } from './sveltekit-generator';
@@ -46,6 +47,37 @@ describe('methodNameToKebab (#1305)', () => {
     ['parseHTML5Data', 'parse-html5-data'],
   ])('%s → %s', (input, expected) => {
     expect(methodNameToKebab(input)).toBe(expected);
+  });
+});
+
+describe('custom-action target resolution (#2182)', () => {
+  it('keeps a non-static model action on its item receiver despite route scope', () => {
+    expect(
+      resolveApiActionRouteConfig(
+        'apply',
+        { isStatic: false },
+        { routes: { apply: { scope: 'collection' } } },
+      ).scope,
+    ).toBe('item');
+  });
+
+  it('keeps static and collection-class actions on collection receivers', () => {
+    expect(
+      resolveApiActionRouteConfig(
+        'rebalance',
+        { isStatic: true },
+        { routes: { rebalance: { scope: 'item' } } },
+      ).scope,
+    ).toBe('collection');
+    expect(
+      resolveApiActionRouteConfig(
+        'fanout',
+        { isStatic: false },
+        { routes: { fanout: { scope: 'item' } } },
+        {},
+        'collection',
+      ).scope,
+    ).toBe('collection');
   });
 });
 
@@ -706,6 +738,12 @@ describe('SvelteKit Route Generator', () => {
       expect(analyzeContent).toContain('export const POST: RequestHandler');
       expect(analyzeContent).toContain('await item.analyze');
       expect(analyzeContent).toContain("action: 'analyze'");
+      expect(analyzeContent).toContain(
+        "import { normalizeCustomActionFailure } from '@happyvertical/smrt-core';",
+      );
+      expect(analyzeContent).toContain(
+        'return json({ error: failure }, { status: failure.status });',
+      );
 
       // Should write summarize action route
       const summarizeRoute = vi
@@ -1037,7 +1075,7 @@ describe('SvelteKit Route Generator', () => {
       expect(content).toContain('await item.syncFacts(options)');
     });
 
-    it('should skip collection-scoped custom routes for non-static methods', async () => {
+    it('keeps non-static custom routes item-scoped despite a collection override', async () => {
       const consoleWarnSpy = vi
         .spyOn(console, 'warn')
         .mockImplementation(() => {});
@@ -1079,16 +1117,15 @@ describe('SvelteKit Route Generator', () => {
         objectsDir: 'src/lib/objects',
       });
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        '[smrt] Skipping Document.browseFacts - collection API routes require a static method',
-      );
-
       const browseFactsRoute = vi
         .mocked(writeFileSync)
         .mock.calls.find((call) =>
-          call[0].toString().includes('documents/facts/+server.ts'),
+          call[0].toString().includes('documents/[id]/facts/+server.ts'),
         );
-      expect(browseFactsRoute).toBeUndefined();
+      expect(browseFactsRoute).toBeDefined();
+      const content = browseFactsRoute?.[1] as string;
+      expect(content).toContain('await item.browseFacts(options)');
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
 
       consoleWarnSpy.mockRestore();
     });
@@ -2414,12 +2451,9 @@ describe('SvelteKit Route Generator', () => {
       expect(() => validateCliIncludeAgainstApi(manifest)).not.toThrow();
     });
 
-    // Regression: resolveApiActionSet must mirror the scope/static skip rules
-    // applied by route generation, otherwise the lint reports a false negative
-    // (passes a cli.include method that no route is actually emitted for).
-    it('excludes collection-scoped non-static methods on a non-collection class', () => {
-      // User wrote `routes[name].scope: 'collection'` for an instance method
-      // — the generator skips this with a warning. The lint must agree.
+    it('keeps config-only collection overrides item-scoped for non-static methods', () => {
+      // A route declaration cannot turn an instance action into a ClassRef
+      // call. REST discovery now agrees with MCP/WebMCP's item contract.
       const manifest: SmartObjectManifest = {
         objects: {
           Doc: {
@@ -2445,16 +2479,15 @@ describe('SvelteKit Route Generator', () => {
           },
         },
       };
-      expect(Array.from(resolveApiActionSet(manifest.objects.Doc))).toEqual([]);
-      expect(findCliApiCoherenceViolations(manifest)).toEqual([
-        { className: 'Doc', unreachable: ['broken'] },
+      expect(Array.from(resolveApiActionSet(manifest.objects.Doc))).toEqual([
+        'broken',
       ]);
+      expect(findCliApiCoherenceViolations(manifest)).toEqual([]);
     });
 
-    it('excludes scope=item methods on a SmrtCollection class', () => {
-      // Collection classes only emit collection-scoped custom routes; an
-      // explicit `routes[name].scope = 'item'` override on a collection class
-      // method is a misconfig the generator skips. The lint must agree.
+    it('keeps recognized collection-class methods collection-scoped', () => {
+      // A collection class has a collection receiver even when its action is
+      // not static, so a route-only item override cannot remove it.
       const manifest: SmartObjectManifest = {
         objects: {
           DocCollection: {
@@ -2489,14 +2522,10 @@ describe('SvelteKit Route Generator', () => {
           },
         },
       };
-      // misconfigured has explicit scope: 'item' on a collection class -> skipped.
-      // listSpecial defaults to 'collection' on collection class -> exposed.
       expect(
         Array.from(resolveApiActionSet(manifest.objects.DocCollection)).sort(),
-      ).toEqual(['listSpecial']);
-      expect(findCliApiCoherenceViolations(manifest)).toEqual([
-        { className: 'DocCollection', unreachable: ['misconfigured'] },
-      ]);
+      ).toEqual(['listSpecial', 'misconfigured']);
+      expect(findCliApiCoherenceViolations(manifest)).toEqual([]);
     });
 
     it('does not claim CRUD routes for collection classes', () => {
@@ -2585,13 +2614,8 @@ describe('SvelteKit Route Generator', () => {
         Array.from(
           resolveApiActionSet(manifest.objects.SpecialDocCollection, manifest),
         ),
-      ).toEqual(['collectionAction']);
-      expect(findCliApiCoherenceViolations(manifest)).toEqual([
-        {
-          className: 'SpecialDocCollection',
-          unreachable: ['itemAction'],
-        },
-      ]);
+      ).toEqual(['collectionAction', 'itemAction']);
+      expect(findCliApiCoherenceViolations(manifest)).toEqual([]);
     });
   });
 

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -14,6 +14,7 @@ import {
 import { join, relative } from 'node:path';
 import type { DomainKnowledgeConfig } from '@happyvertical/smrt-types';
 import { generateConditionalGetRouteHelper } from '../generators/conditional-get.js';
+import { resolveCustomActionMetadata } from '../generators/custom-action.js';
 import type {
   ApiConfig,
   ApiCustomRouteConfig,
@@ -820,8 +821,15 @@ export function resolveApiActionRouteConfig(
     routeOptions,
   );
 
+  const scope = resolveCustomActionMetadata({
+    actionName,
+    method: actionDef,
+    apiConfig,
+    defaultScope,
+  }).scope;
+
   return {
-    scope: routeConfig?.scope || defaultScope,
+    scope,
     method: normalizeApiHttpMethod(routeConfig?.method),
     pathSegments,
     pathParamNames: extractRoutePathParamNames(pathSegments),
@@ -1941,8 +1949,6 @@ export function resolveApiActionSet(
   const actions = objectIsCollectionClass
     ? new Set<string>()
     : new Set<string>(resolveStandardCrudActions(apiConfig));
-  const config = getApiConfigObject(apiConfig);
-
   // Custom (non-CRUD, public) methods. We mirror BOTH the include/exclude
   // filter AND the scope/static skip rules that the route generators apply
   // (sveltekit-generator.ts generateRoutesForObject and
@@ -1953,14 +1959,17 @@ export function resolveApiActionSet(
     if (!method.isPublic) continue;
     if (!shouldIncludeInApi(name, apiConfig)) continue;
 
-    const routeConfig: ApiCustomRouteConfig | undefined =
-      config?.routes?.[name];
     const defaultScope: 'item' | 'collection' = objectIsCollectionClass
       ? 'collection'
       : method.isStatic
         ? 'collection'
         : 'item';
-    const scope = routeConfig?.scope || defaultScope;
+    const scope = resolveCustomActionMetadata({
+      actionName: name,
+      method,
+      apiConfig,
+      defaultScope,
+    }).scope;
 
     if (objectIsCollectionClass) {
       // Collection classes only emit collection-scoped custom routes.
@@ -2507,6 +2516,7 @@ function generateActionRouteTemplate(
 
   const importBlock = [
     "import { error, json } from '@sveltejs/kit';",
+    "import { normalizeCustomActionFailure } from '@happyvertical/smrt-core';",
     hostType === 'collection' || routeConfig.scope !== 'collection'
       ? "import { getCollection } from '$lib/server/smrt';"
       : "import { ObjectRegistry } from '@happyvertical/smrt-core';",
@@ -2611,6 +2621,11 @@ ${optionsLoad}${scopedOptions.source}  const result = ${buildActionInvocationExp
       invocationArgs,
     )};
 
+  const failure = normalizeCustomActionFailure(result);
+  if (failure) {
+    return json({ error: failure }, { status: failure.status });
+  }
+
   return json({
     action: '${actionName}',
     result: toPublicResult(result, publicJsonOptions),
@@ -2650,6 +2665,11 @@ ${optionsLoad}${scopedOptions.source}  const ClassRef = registered.constructor a
     invocationArgs,
   )};
 
+  const failure = normalizeCustomActionFailure(result);
+  if (failure) {
+    return json({ error: failure }, { status: failure.status });
+  }
+
   return json({
     action: '${actionName}',
     result: toPublicResult(result, publicJsonOptions),
@@ -2686,6 +2706,11 @@ ${optionsLoad}  const result = ${buildActionInvocationExpression(
     actionName,
     invocationArgs,
   )};
+
+  const failure = normalizeCustomActionFailure(result);
+  if (failure) {
+    return json({ error: failure }, { status: failure.status });
+  }
 
   return json({
     action: '${actionName}',

--- a/packages/core/src/vite-plugin/web-collections.test.ts
+++ b/packages/core/src/vite-plugin/web-collections.test.ts
@@ -210,6 +210,7 @@ describe('buildWebToolDescriptors', () => {
   });
 
   it('threads @field descriptions into the generated tool input schemas (#2046)', () => {
+  it('threads @field descriptions into the generated tool input schemas (#2046)', () => {
     const entry = selectWebCollectionEntries(
       manifest(
         obj({
@@ -236,6 +237,59 @@ describe('buildWebToolDescriptors', () => {
     expect(props.name?.description).toBe('Display name shown on invoices');
     // No authored description → the type-derived fallback, not an empty string.
     expect(props.price?.description).toBeTruthy();
+  });
+
+  it('uses the same item receiver and typed custom arguments as Node MCP', () => {
+    const entry = selectWebCollectionEntries(
+      manifest(
+        obj({
+          className: 'Product',
+          collection: 'products',
+           fields: { name: field({ type: 'text' }) },
+          methods: {
+            apply: {
+              name: 'apply',
+              isPublic: true,
+              isStatic: false,
+              async: true,
+              returnType: 'Promise<void>',
+              parameters: [
+                {
+                  name: 'idempotencyKey',
+                  type: 'string',
+                  optional: false,
+                },
+                {
+                  name: 'expectedVersion',
+                  type: 'number',
+                  optional: true,
+                },
+              ],
+            },
+          },
+          decoratorConfig: {
+            api: {
+              include: ['list', 'apply'],
+              // A config-only collection override cannot change this instance
+              // method's receiver.
+              routes: { apply: { scope: 'collection' } },
+            },
+          } as SmartObjectDefinition['decoratorConfig'],
+        }),
+      ),
+    )[0];
+
+    const descriptor = buildWebToolDescriptors(entry).find(
+      (tool) => tool.action === 'apply',
+    );
+    expect(descriptor?.inputSchema).toMatchObject({
+      properties: {
+        id: { type: 'string' },
+        idempotencyKey: { type: 'string' },
+        expectedVersion: { type: 'number' },
+      },
+       required: ['id', 'idempotencyKey'],
+     });
   });
 
   it('stays OUT of buildWebCollectionDefinition, so the #1764 shape digest never covers it', () => {

--- a/packages/core/src/vite-plugin/web-collections.test.ts
+++ b/packages/core/src/vite-plugin/web-collections.test.ts
@@ -210,7 +210,6 @@ describe('buildWebToolDescriptors', () => {
   });
 
   it('threads @field descriptions into the generated tool input schemas (#2046)', () => {
-  it('threads @field descriptions into the generated tool input schemas (#2046)', () => {
     const entry = selectWebCollectionEntries(
       manifest(
         obj({
@@ -245,7 +244,7 @@ describe('buildWebToolDescriptors', () => {
         obj({
           className: 'Product',
           collection: 'products',
-           fields: { name: field({ type: 'text' }) },
+          fields: { name: field({ type: 'text' }) },
           methods: {
             apply: {
               name: 'apply',
@@ -288,8 +287,8 @@ describe('buildWebToolDescriptors', () => {
         idempotencyKey: { type: 'string' },
         expectedVersion: { type: 'number' },
       },
-       required: ['id', 'idempotencyKey'],
-     });
+      required: ['id', 'idempotencyKey'],
+    });
   });
 
   it('stays OUT of buildWebCollectionDefinition, so the #1764 shape digest never covers it', () => {

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -24,6 +24,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { resolveCustomActionMetadata } from '../generators/custom-action.js';
 import {
   buildToolDescriptors,
   type ToolDescriptor,
@@ -702,6 +703,16 @@ export function buildWebToolDescriptors(
     className: entry.obj.className,
     fields,
     actions: entry.actions,
+    customActions: Object.fromEntries(
+      entry.actions.map((action) => [
+        action,
+        resolveCustomActionMetadata({
+          actionName: action,
+          method: entry.obj.methods?.[action],
+          apiConfig: entry.obj.decoratorConfig?.api,
+        }),
+      ]),
+    ),
   });
 }
 


### PR DESCRIPTION
Closes #2182

## Summary
- Resolve custom-action collection versus item scope from its executable receiver, and project that contract through REST, CLI, MCP, resource discovery, and generated client metadata.
- Emit typed named custom-action parameters when manifest metadata is available while retaining legacy options-bag actions.
- Return conventional structured custom-action failures as redacted REST non-2xx responses and MCP errors; opaque successful values remain unchanged.

## Validation
- fnm exec --using 24.18.0 pnpm --filter @happyvertical/smrt-core test -- --reporter=dot (266 passed, 5 skipped; 3,178 passed, 45 skipped)
- fnm exec --using 24.18.0 pnpm --filter @happyvertical/smrt-core typecheck
- fnm exec --using 24.18.0 pnpm --filter @happyvertical/smrt-core build
- focused 206-test core generator/scanner/vite suite, Biome, audit-policy, and knowledge check

## Scope note
- The existing smrt-web custom-action tracer remains intentionally out of scope: this change provides core discovery conformance without adding native HTTP MCP behavior.

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019fbe52-9efb-7f92-b546-ba38d621b8ff","issue":2182,"linked_issue":2182,"policy_revision":"1.0.0","status":"complete","validation":["Node 24.18.0 core full test: 3178 passed, 45 skipped","Node 24.18.0 core typecheck and build","focused generator/scanner/vite test suite, Biome, audit-policy, knowledge check"]}