### PR TITLE
fix(core): narrow SvelteKit generated route ignores

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -98,6 +98,30 @@ pnpm smrt db:migrate
 Runtime verifies application tables but does not create them. Rebuild the
 manifest and rerun the migration after changing persisted object fields.
 
+### Generated SvelteKit routes
+
+Enable SvelteKit route generation with `svelteKit: { enabled: true }`. Its
+default output directory is `src/routes/api`; set `svelteKit.routesDir` when
+your application uses a different route root.
+
+The plugin records only the concrete `+server.ts` files it generated in a
+bounded `.gitignore` block. Handwritten handlers below `routesDir` remain
+visible to Git, including routes that live beside generated resource handlers.
+Generation refreshes that block, so stale generated paths stop being ignored
+when the generator no longer owns them.
+
+**Migration note:** the first generation after this release replaces the
+legacy adjacent pair below with the bounded exact-path block:
+
+```gitignore
+# SMRT auto-generated routes (from Vite plugin)
+src/routes/api/**/+server.ts
+```
+
+Only that recognized SMRT pair is migrated. A broad rule that you added or
+moved yourself is left unchanged; remove or narrow it manually if it hides a
+handwritten route.
+
 ### AI operations
 
 With an AI provider configured, every object can use the inherited `is()` and

--- a/packages/core/src/vite-plugin/sveltekit-generator.runtime.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.runtime.test.ts
@@ -259,13 +259,16 @@ describe('generated SvelteKit helper runtime', () => {
     expect(gitignore).toContain('# Application-owned output');
     expect(gitignore).toContain('coverage/');
     expect(gitignore).toContain(generatedCollectionRoute);
-    expect(gitignore).toContain('src/routes/api/widgets/[id]/+server.ts');
+    expect(gitignore).toContain('src/routes/api/widgets/\\[id\\]/+server.ts');
     expect(gitignore).not.toContain('src/routes/api/**/+server.ts');
     expect(readFileSync(handwrittenRoute, 'utf-8')).toContain('handwritten');
     expect(
       readFileSync(join(projectRoot, generatedCollectionRoute), 'utf-8'),
     ).toContain('export const GET');
     expect(isIgnoredByGit(projectRoot, generatedCollectionRoute)).toBe(true);
+    expect(
+      isIgnoredByGit(projectRoot, 'src/routes/api/widgets/[id]/+server.ts'),
+    ).toBe(true);
     expect(
       isIgnoredByGit(projectRoot, 'src/routes/api/_resources/+server.ts'),
     ).toBe(false);

--- a/packages/core/src/vite-plugin/sveltekit-generator.runtime.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.runtime.test.ts
@@ -1,4 +1,11 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -68,6 +75,24 @@ function writeWorkspaceCoreShim(projectRoot: string): void {
   );
 }
 
+function isIgnoredByGit(projectRoot: string, relativePath: string): boolean {
+  const result = spawnSync(
+    'git',
+    ['check-ignore', '--no-index', '--quiet', relativePath],
+    { cwd: projectRoot },
+  );
+  if (result.error) throw result.error;
+  return result.status === 0;
+}
+
+function initializeGitRepository(projectRoot: string): void {
+  const result = spawnSync('git', ['init', '--quiet'], { cwd: projectRoot });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`git init failed with status ${result.status}`);
+  }
+}
+
 describe('generated SvelteKit helper runtime', () => {
   const originalScopedDbGetter = globalThis.__smrtGetRequestScopedDatabase;
   let projectRoot = '';
@@ -97,6 +122,7 @@ describe('generated SvelteKit helper runtime', () => {
       'export class Widget {}\n',
     );
     writeWorkspaceCoreShim(projectRoot);
+    initializeGitRepository(projectRoot);
   });
 
   afterEach(() => {
@@ -187,5 +213,103 @@ describe('generated SvelteKit helper runtime', () => {
         }),
       ],
     ]);
+  });
+
+  it('migrates the default route directory without ignoring handwritten handlers', async () => {
+    const handwrittenRoute = join(
+      projectRoot,
+      'src/routes/api/_resources/+server.ts',
+    );
+    mkdirSync(join(projectRoot, 'src/routes/api/_resources'), {
+      recursive: true,
+    });
+    writeFileSync(
+      handwrittenRoute,
+      'export const GET = () => new Response("handwritten");\n',
+    );
+    writeFileSync(
+      join(projectRoot, '.gitignore'),
+      [
+        'node_modules/',
+        '# SMRT auto-generated routes (from Vite plugin)',
+        'src/routes/api/**/+server.ts',
+        '# Application-owned output',
+        'coverage/',
+        '',
+      ].join('\n'),
+    );
+
+    const manifest = createManifest(
+      projectRoot,
+      join(projectRoot, 'src/lib/objects/Widget.ts'),
+    );
+    const options = {
+      configFileName: 'smrt.ts',
+      configPath: 'src/lib/server',
+      enabled: true,
+      objectsDir: 'src/lib/objects',
+      routesDir: 'src/routes/api',
+    };
+
+    await generateSvelteKitRoutes(projectRoot, manifest, options);
+    await generateSvelteKitRoutes(projectRoot, manifest, options);
+
+    const gitignore = readFileSync(join(projectRoot, '.gitignore'), 'utf-8');
+    const generatedCollectionRoute = 'src/routes/api/widgets/+server.ts';
+    expect(gitignore).toContain('# Application-owned output');
+    expect(gitignore).toContain('coverage/');
+    expect(gitignore).toContain(generatedCollectionRoute);
+    expect(gitignore).toContain('src/routes/api/widgets/[id]/+server.ts');
+    expect(gitignore).not.toContain('src/routes/api/**/+server.ts');
+    expect(readFileSync(handwrittenRoute, 'utf-8')).toContain('handwritten');
+    expect(
+      readFileSync(join(projectRoot, generatedCollectionRoute), 'utf-8'),
+    ).toContain('export const GET');
+    expect(isIgnoredByGit(projectRoot, generatedCollectionRoute)).toBe(true);
+    expect(
+      isIgnoredByGit(projectRoot, 'src/routes/api/_resources/+server.ts'),
+    ).toBe(false);
+  });
+
+  it('uses the configured routesDir for exact generated ignores', async () => {
+    const handwrittenRoute = join(
+      projectRoot,
+      'src/routes/generated-api/manual/+server.ts',
+    );
+    mkdirSync(join(projectRoot, 'src/routes/generated-api/manual'), {
+      recursive: true,
+    });
+    writeFileSync(
+      handwrittenRoute,
+      'export const GET = () => new Response("manual");\n',
+    );
+
+    await generateSvelteKitRoutes(
+      projectRoot,
+      createManifest(
+        projectRoot,
+        join(projectRoot, 'src/lib/objects/Widget.ts'),
+      ),
+      {
+        configFileName: 'smrt.ts',
+        configPath: 'src/lib/server',
+        enabled: true,
+        objectsDir: 'src/lib/objects',
+        routesDir: 'src/routes/generated-api',
+      },
+    );
+
+    const gitignore = readFileSync(join(projectRoot, '.gitignore'), 'utf-8');
+    expect(gitignore).toContain('src/routes/generated-api/widgets/+server.ts');
+    expect(gitignore).not.toContain('src/routes/api/**/+server.ts');
+    expect(
+      isIgnoredByGit(
+        projectRoot,
+        'src/routes/generated-api/widgets/+server.ts',
+      ),
+    ).toBe(true);
+    expect(
+      isIgnoredByGit(projectRoot, 'src/routes/generated-api/manual/+server.ts'),
+    ).toBe(false);
   });
 });

--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -1506,7 +1506,7 @@ describe('SvelteKit Route Generator', () => {
   });
 
   describe('.gitignore Updates', () => {
-    it('should add generated routes pattern to .gitignore', async () => {
+    it('should add exact generated route paths to .gitignore', async () => {
       vi.mocked(existsSync).mockReturnValue(true);
       vi.mocked(readFileSync).mockReturnValue('node_modules/\n.env\n');
 
@@ -1542,16 +1542,29 @@ describe('SvelteKit Route Generator', () => {
       expect(gitignoreWrite).toBeDefined();
       const content = gitignoreWrite?.[1] as string;
 
-      expect(content).toContain('# SMRT auto-generated routes');
-      expect(content).toContain('src/routes/api/**/+server.ts');
+      expect(content).toContain(
+        '# BEGIN SMRT auto-generated routes (Vite plugin)',
+      );
+      expect(content).toContain('src/routes/api/testobjects/+server.ts');
+      expect(content).toContain('src/routes/api/testobjects/[id]/+server.ts');
+      expect(content).not.toContain('src/routes/api/**/+server.ts');
       expect(content).toContain('node_modules/');
       expect(content).toContain('.env');
     });
 
-    it('should not duplicate .gitignore entries', async () => {
+    it('should migrate only the legacy SMRT broad route entry', async () => {
       vi.mocked(existsSync).mockReturnValue(true);
       vi.mocked(readFileSync).mockReturnValue(
-        'node_modules/\n# SMRT auto-generated routes (from Vite plugin)\nsrc/routes/api/**/+server.ts\n',
+        [
+          'node_modules/',
+          '# Application-owned broad rule',
+          'src/routes/api/**/+server.ts',
+          '# SMRT auto-generated routes (from Vite plugin)',
+          'src/routes/api/**/+server.ts',
+          '# Application-owned rule',
+          'src/routes/api/_resources/+server.ts',
+          '',
+        ].join('\n'),
       );
 
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -1574,12 +1587,21 @@ describe('SvelteKit Route Generator', () => {
         objectsDir: 'src/lib/objects',
       });
 
-      // Should not write to .gitignore since patterns already exist
-      const gitignoreWrites = vi
+      const gitignoreWrite = vi
         .mocked(writeFileSync)
-        .mock.calls.filter((call) => call[0].toString().endsWith('.gitignore'));
+        .mock.calls.find((call) => call[0].toString().endsWith('.gitignore'));
+      const content = gitignoreWrite?.[1] as string;
 
-      expect(gitignoreWrites).toHaveLength(0);
+      expect(gitignoreWrite).toBeDefined();
+      expect(
+        content
+          .split('\n')
+          .filter((line) => line === 'src/routes/api/**/+server.ts'),
+      ).toHaveLength(1);
+      expect(content).toContain('src/routes/api/testobjects/+server.ts');
+      expect(content).toContain('# Application-owned broad rule');
+      expect(content).toContain('# Application-owned rule');
+      expect(content).toContain('src/routes/api/_resources/+server.ts');
 
       consoleSpy.mockRestore();
     });
@@ -1616,8 +1638,11 @@ describe('SvelteKit Route Generator', () => {
       expect(gitignoreWrite).toBeDefined();
       const content = gitignoreWrite?.[1] as string;
 
-      expect(content).toContain('# SMRT auto-generated routes');
-      expect(content).toContain('src/routes/api/**/+server.ts');
+      expect(content).toContain(
+        '# BEGIN SMRT auto-generated routes (Vite plugin)',
+      );
+      expect(content).toContain('src/routes/api/testobjects/+server.ts');
+      expect(content).not.toContain('src/routes/api/**/+server.ts');
     });
   });
 

--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -1546,7 +1546,9 @@ describe('SvelteKit Route Generator', () => {
         '# BEGIN SMRT auto-generated routes (Vite plugin)',
       );
       expect(content).toContain('src/routes/api/testobjects/+server.ts');
-      expect(content).toContain('src/routes/api/testobjects/[id]/+server.ts');
+      expect(content).toContain(
+        'src/routes/api/testobjects/\\[id\\]/+server.ts',
+      );
       expect(content).not.toContain('src/routes/api/**/+server.ts');
       expect(content).toContain('node_modules/');
       expect(content).toContain('.env');

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -81,6 +81,12 @@ export interface SvelteKitOptions {
 // Keep this aligned with biome.json formatter.lineWidth.
 const BIOME_LINE_WIDTH = 80;
 const STANDARD_API_ACTIONS = ['list', 'get', 'create', 'update', 'delete'];
+const GITIGNORE_MANAGED_BLOCK_START =
+  '# BEGIN SMRT auto-generated routes (Vite plugin)';
+const GITIGNORE_MANAGED_BLOCK_END =
+  '# END SMRT auto-generated routes (Vite plugin)';
+const LEGACY_GITIGNORE_HEADER =
+  '# SMRT auto-generated routes (from Vite plugin)';
 
 export interface ResolvedApiActionRouteConfig {
   scope: 'item' | 'collection';
@@ -1134,18 +1140,20 @@ export async function generateSvelteKitRoutes(
   // Generate centralized configuration file first (if it doesn't exist)
   await generateSmrtConfigFile(projectRoot, manifest, options);
 
+  const generatedRoutePaths: string[] = [];
   let generatedCount = 0;
   let skippedCollections = 0;
   for (const [className, objectDef] of Object.entries(manifest.objects)) {
     if (isCollectionManifestClass(manifest, objectDef)) {
-      const generatedCollectionRoutes = await generateCollectionRoutesForObject(
+      const collectionRoutePaths = await generateCollectionRoutesForObject(
         projectRoot,
         className,
         objectDef,
         manifest,
         options,
       );
-      if (generatedCollectionRoutes) {
+      generatedRoutePaths.push(...collectionRoutePaths);
+      if (collectionRoutePaths.length > 0) {
         generatedCount++;
       } else {
         console.log(
@@ -1155,34 +1163,51 @@ export async function generateSvelteKitRoutes(
       }
       continue;
     }
-    await generateRoutesForObject(
-      projectRoot,
-      className,
-      objectDef,
-      manifest,
-      options,
+    generatedRoutePaths.push(
+      ...(await generateRoutesForObject(
+        projectRoot,
+        className,
+        objectDef,
+        manifest,
+        options,
+      )),
     );
     generatedCount++;
   }
 
   if (options.knowledge?.api?.enabled) {
-    generateKnowledgeRoute(projectRoot, options);
+    generatedRoutePaths.push(generateKnowledgeRoute(projectRoot, options));
   }
 
   // Batch write contract route (#1759): {routesDir}/sync/apply/+server.ts.
-  generateSyncApplyRoute(projectRoot, manifest, options);
+  if (generateSyncApplyRoute(projectRoot, manifest, options)) {
+    generatedRoutePaths.push(
+      join(projectRoot, options.routesDir, 'sync', 'apply', '+server.ts'),
+    );
+  }
   // Change-feed route (#1758) — cleanup rides clearGeneratedRouteFiles above.
-  generateChangesRoute(projectRoot, manifest, options);
+  if (generateChangesRoute(projectRoot, manifest, options)) {
+    generatedRoutePaths.push(
+      join(projectRoot, options.routesDir, '_changes', '+server.ts'),
+    );
+  }
   // Live change-signal SSE route (#1763) — cleanup rides the sweep above.
-  generateEventsRoute(
-    projectRoot,
-    manifest,
-    options,
-    computeWebManifestHash(manifest),
-  );
+  if (
+    generateEventsRoute(
+      projectRoot,
+      manifest,
+      options,
+      computeWebManifestHash(manifest),
+    )
+  ) {
+    generatedRoutePaths.push(
+      join(projectRoot, options.routesDir, '_events', '+server.ts'),
+    );
+  }
 
-  // Update .gitignore to exclude generated routes
-  updateGitignore(projectRoot, options);
+  // Ignore only the concrete route files generated in this pass. This keeps
+  // handwritten handlers below routesDir visible to Git.
+  updateGitignore(projectRoot, options, generatedRoutePaths);
 
   const skippedMsg =
     skippedCollections > 0
@@ -1261,13 +1286,13 @@ function clearGeneratedKnowledgeRoute(
 function generateKnowledgeRoute(
   projectRoot: string,
   options: SvelteKitOptions,
-): void {
+): string {
   const routeDir = knowledgeRouteDir(projectRoot, options);
   const route = generateKnowledgeRouteTemplate(
     options.knowledge ?? {},
     readKnowledgeRouteArtifact(projectRoot),
   );
-  writeRoute(routeDir, '+server.ts', route);
+  return writeRoute(routeDir, '+server.ts', route);
 }
 
 function readKnowledgeRouteArtifact(
@@ -1647,15 +1672,16 @@ async function generateRoutesForObject(
   objectDef: SmartObjectDefinition,
   manifest: SmartObjectManifest,
   options: SvelteKitOptions,
-): Promise<void> {
+): Promise<string[]> {
   const collectionName = objectDef.collection;
   const routeDir = join(projectRoot, options.routesDir, collectionName);
+  const generatedRoutePaths: string[] = [];
 
   // Check if API is enabled for this object
   const apiConfig = objectDef.decoratorConfig?.api;
   if (apiConfig === false) {
     console.log(`[smrt] Skipping ${className} - API disabled`);
-    return;
+    return generatedRoutePaths;
   }
 
   // Determine which CRUD actions to include via the shared resolver.
@@ -1672,7 +1698,9 @@ async function generateRoutesForObject(
       options,
       routeDir,
     );
-    writeRoute(routeDir, '+server.ts', collectionRoute);
+    generatedRoutePaths.push(
+      writeRoute(routeDir, '+server.ts', collectionRoute),
+    );
   }
 
   // Generate item route (get, update, delete)
@@ -1690,7 +1718,9 @@ async function generateRoutesForObject(
       options,
       join(routeDir, '[id]'),
     );
-    writeRoute(join(routeDir, '[id]'), '+server.ts', itemRoute);
+    generatedRoutePaths.push(
+      writeRoute(join(routeDir, '[id]'), '+server.ts', itemRoute),
+    );
   }
 
   // Generate custom action routes
@@ -1748,8 +1778,12 @@ async function generateRoutesForObject(
       manifest,
       options,
     );
-    writeRoute(actionRouteDir, '+server.ts', actionRoute);
+    generatedRoutePaths.push(
+      writeRoute(actionRouteDir, '+server.ts', actionRoute),
+    );
   }
+
+  return generatedRoutePaths;
 }
 
 async function generateCollectionRoutesForObject(
@@ -1758,11 +1792,12 @@ async function generateCollectionRoutesForObject(
   objectDef: SmartObjectDefinition,
   manifest: SmartObjectManifest,
   options: SvelteKitOptions,
-): Promise<boolean> {
+): Promise<string[]> {
+  const generatedRoutePaths: string[] = [];
   const apiConfig = objectDef.decoratorConfig?.api;
   if (apiConfig === false) {
     console.log(`[smrt] Skipping ${className} - API disabled`);
-    return false;
+    return generatedRoutePaths;
   }
 
   const routeDir = join(projectRoot, options.routesDir, objectDef.collection);
@@ -1781,10 +1816,8 @@ async function generateCollectionRoutesForObject(
   );
 
   if (customActions.length === 0) {
-    return false;
+    return generatedRoutePaths;
   }
-
-  let generatedAnyRoutes = false;
   const actionSpecs: Array<{
     routeDir: string;
     spec: GeneratedActionRouteSpec;
@@ -1831,11 +1864,12 @@ async function generateCollectionRoutesForObject(
       manifest,
       options,
     );
-    writeRoute(actionRouteDir, '+server.ts', actionRoute);
-    generatedAnyRoutes = true;
+    generatedRoutePaths.push(
+      writeRoute(actionRouteDir, '+server.ts', actionRoute),
+    );
   }
 
-  return generatedAnyRoutes;
+  return generatedRoutePaths;
 }
 
 /**
@@ -2025,7 +2059,7 @@ export function validateCliIncludeAgainstApi(
 /**
  * Writes a route file, creating directories as needed
  */
-function writeRoute(dir: string, filename: string, content: string): void {
+function writeRoute(dir: string, filename: string, content: string): string {
   try {
     // Create directory if needed
     if (!existsSync(dir)) {
@@ -2036,6 +2070,7 @@ function writeRoute(dir: string, filename: string, content: string): void {
     const filePath = join(dir, filename);
     writeFileSync(filePath, content, 'utf-8');
     console.log(`[smrt] Generated: ${filePath}`);
+    return filePath;
   } catch (error) {
     console.error(`[smrt] [ERROR] Failed to write route file:`);
     console.error(`[smrt] [ERROR]   Directory: ${dir}`);
@@ -2782,21 +2817,12 @@ function rolesFrom(value: unknown): string[] {
 /**
  * Updates .gitignore to exclude auto-generated routes
  */
-function updateGitignore(projectRoot: string, options: SvelteKitOptions): void {
+function updateGitignore(
+  projectRoot: string,
+  options: SvelteKitOptions,
+  generatedRoutePaths: readonly string[],
+): void {
   const gitignorePath = join(projectRoot, '.gitignore');
-
-  // Patterns to add
-  const patternsToAdd = [
-    '# SMRT auto-generated routes (from Vite plugin)',
-    `${options.routesDir}/**/+server.ts`,
-  ];
-  if (options.knowledge?.api?.enabled) {
-    const knowledgeRoute = relative(
-      projectRoot,
-      join(knowledgeRouteDir(projectRoot, options), '+server.ts'),
-    ).replaceAll('\\', '/');
-    patternsToAdd.push(knowledgeRoute);
-  }
 
   // Read existing .gitignore or create empty string
   let gitignoreContent = '';
@@ -2804,33 +2830,77 @@ function updateGitignore(projectRoot: string, options: SvelteKitOptions): void {
     gitignoreContent = readFileSync(gitignorePath, 'utf-8');
   }
 
-  // Check if patterns already exist
-  let needsUpdate = false;
-  const linesToAdd: string[] = [];
+  const generatedPaths = [
+    ...new Set(
+      generatedRoutePaths.map((path) =>
+        relative(projectRoot, path).replaceAll('\\', '/'),
+      ),
+    ),
+  ].sort((a, b) => a.localeCompare(b));
+  const updatedContent = updateGeneratedRouteIgnoreBlock(
+    gitignoreContent,
+    options.routesDir,
+    generatedPaths,
+  );
 
-  for (const pattern of patternsToAdd) {
-    // Skip if pattern already exists (check for exact match or similar)
-    if (!gitignoreContent.includes(pattern)) {
-      linesToAdd.push(pattern);
-      needsUpdate = true;
+  if (updatedContent !== gitignoreContent) {
+    writeFileSync(gitignorePath, updatedContent, 'utf-8');
+    console.log('[smrt] Updated .gitignore with generated route paths');
+  }
+}
+
+function updateGeneratedRouteIgnoreBlock(
+  gitignoreContent: string,
+  routesDir: string,
+  generatedPaths: readonly string[],
+): string {
+  const lines = gitignoreContent.split('\n');
+  const startIndex = lines.indexOf(GITIGNORE_MANAGED_BLOCK_START);
+  const endIndex = lines.indexOf(GITIGNORE_MANAGED_BLOCK_END);
+  const managedBlock = [
+    GITIGNORE_MANAGED_BLOCK_START,
+    ...generatedPaths,
+    GITIGNORE_MANAGED_BLOCK_END,
+  ];
+
+  if (startIndex !== -1 || endIndex !== -1) {
+    if (startIndex === -1 || endIndex < startIndex) {
+      // An incomplete marker pair may have been authored by a consumer. Do
+      // not guess at its boundary or remove any user-managed ignore rules.
+      return gitignoreContent;
     }
+
+    lines.splice(
+      startIndex,
+      endIndex - startIndex + 1,
+      ...(generatedPaths.length > 0 ? managedBlock : []),
+    );
+    return lines.join('\n');
   }
 
-  if (needsUpdate) {
-    // Ensure file ends with newline before adding
-    if (gitignoreContent.length > 0 && !gitignoreContent.endsWith('\n')) {
-      gitignoreContent += '\n';
-    }
-
-    // Add a blank line before our section if file has content
-    if (gitignoreContent.length > 0 && !gitignoreContent.endsWith('\n\n')) {
-      gitignoreContent += '\n';
-    }
-
-    // Add our patterns
-    gitignoreContent += `${linesToAdd.join('\n')}\n`;
-
-    writeFileSync(gitignorePath, gitignoreContent, 'utf-8');
-    console.log('[smrt] Updated .gitignore with generated route patterns');
+  // Versions before #2185 wrote exactly this header followed by a recursive
+  // wildcard. Remove only that adjacent, generator-owned pair; an equivalent
+  // user rule elsewhere is intentionally preserved.
+  const legacyPattern = `${routesDir.replaceAll('\\', '/')}/**/+server.ts`;
+  const legacyIndex = lines.findIndex(
+    (line, index) =>
+      line === LEGACY_GITIGNORE_HEADER && lines[index + 1] === legacyPattern,
+  );
+  if (legacyIndex !== -1) {
+    lines.splice(legacyIndex, 2);
   }
+
+  if (generatedPaths.length === 0) {
+    return lines.join('\n');
+  }
+
+  let updatedContent = lines.join('\n');
+  if (updatedContent.length > 0 && !updatedContent.endsWith('\n')) {
+    updatedContent += '\n';
+  }
+  if (updatedContent.length > 0 && !updatedContent.endsWith('\n\n')) {
+    updatedContent += '\n';
+  }
+
+  return `${updatedContent}${managedBlock.join('\n')}\n`;
 }

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -2833,7 +2833,7 @@ function updateGitignore(
   const generatedPaths = [
     ...new Set(
       generatedRoutePaths.map((path) =>
-        relative(projectRoot, path).replaceAll('\\', '/'),
+        gitignorePatternForPath(relative(projectRoot, path)),
       ),
     ),
   ].sort((a, b) => a.localeCompare(b));
@@ -2847,6 +2847,13 @@ function updateGitignore(
     writeFileSync(gitignorePath, updatedContent, 'utf-8');
     console.log('[smrt] Updated .gitignore with generated route paths');
   }
+}
+
+function gitignorePatternForPath(path: string): string {
+  // Generated SvelteKit item routes include literal `[id]` segments. Escape
+  // every Git pattern metacharacter so the managed block ignores files, not
+  // glob expressions that happen to resemble their paths.
+  return path.replaceAll('\\', '/').replaceAll(/([*?[\]\\!#])/g, '\\$1');
 }
 
 function updateGeneratedRouteIgnoreBlock(


### PR DESCRIPTION
## Summary

- Replace the recursive SvelteKit `.gitignore` rule with a bounded block of exact routes written by the generator.
- Migrate only the recognized legacy SMRT header-plus-wildcard pair, preserving application-owned rules and handwritten handlers.
- Escape Git pattern metacharacters in generated paths, so SvelteKit literal item segments such as `[id]` are also ignored.
- Add repeated-generation Git regression coverage for default and configured route directories, plus behavior and migration documentation.

## Validation

- `fnm exec --using 24.18.0 pnpm exec vitest run packages/core/src/vite-plugin/sveltekit-generator.test.ts packages/core/src/vite-plugin/sveltekit-generator.runtime.test.ts --reporter=dot` (69 passed)
- `fnm exec --using 24.18.0 pnpm build` (passed)
- `fnm exec --using 24.18.0 pnpm typecheck` (passed; core typecheck rerun after the review fix)
- `fnm exec --using 24.18.0 pnpm lint`, `pnpm format`, `pnpm smrt dev:knowledge-check`, and `pnpm audit:policy` (passed)
- `fnm exec --using 24.18.0 pnpm test` is blocked by the unrelated scanner benchmark threshold: `Large Project (500 files)` observed 16.723706158659567 ms; threshold is <10 ms.

No manual changeset: repository release automation determines the `@happyvertical/smrt-core` package release after merge.

Closes #2185

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019fbe7c-52dc-7991-b23b-f091cb0c5efa","issue":2185,"linked_issue":2185,"policy_revision":"1.0.0","status":"complete","validation":["focused-vitest:69-passed","root-build:passed","root-typecheck:passed","core-typecheck-review-fix:passed","root-lint:passed","root-format:passed","knowledge-check:passed","audit-policy:passed","root-test:scanner-benchmark-threshold-unrelated"],"head":"15c39d3cc599b0e9d790ef02dbe93895bc518e7b","claim_comment_id":"IC_kwDOQDruXs8AAAABMyAS1A","review_cycle":"approved"}
```