### PR TITLE
test(oidc): stabilize DuckDB transaction fixtures

### DIFF
--- a/packages/profiles/src/__tests__/oidc-account-linking.test.ts
+++ b/packages/profiles/src/__tests__/oidc-account-linking.test.ts
@@ -1216,8 +1216,8 @@ async function profileMatrixIdentityBindings(
 async function profileMatrixRowCounts(
   db: DatabaseInterface,
 ): Promise<{ profile: number; oidcIdentity: number }> {
-  // A caller-owned DuckDB transaction has one native connection. Keep the
-  // observation queries ordered so assertions do not contend with each other.
+  // Caller-owned transactions share a connection. Keep observation queries
+  // ordered; DuckDB must not contend with its native connection.
   const profile = await countRows(db, 'profiles');
   const oidcIdentity = await countRows(db, 'oidc_identities');
   return { profile, oidcIdentity };

--- a/packages/profiles/src/__tests__/oidc-account-linking.test.ts
+++ b/packages/profiles/src/__tests__/oidc-account-linking.test.ts
@@ -767,7 +767,11 @@ describe('OIDC Account Linking', () => {
     it.each([
       getOidcProvisioningDecisionScenario('duckdb-caller-owned-transaction'),
     ])('$id — $title (Profiles manual transaction)', async (scenario) => {
-      const db = await getDatabase({ type: 'duckdb', url: ':memory:' });
+      const db = await getDatabase({
+        type: 'duckdb',
+        url: ':memory:',
+        __smrtSkipVitestSchemaPreparation: true,
+      });
       await syncSchema({ db, schema: OIDC_PROFILES_DUCKDB_TEST_SCHEMA });
       const before = await profileMatrixRowCounts(db);
       if (!db.beginTransaction) {
@@ -811,7 +815,11 @@ describe('OIDC Account Linking', () => {
     it.each([
       getOidcProvisioningDecisionScenario('duckdb-caller-owned-transaction'),
     ])('$id — $title (Profiles callback transaction)', async (scenario) => {
-      const db = await getDatabase({ type: 'duckdb', url: ':memory:' });
+      const db = await getDatabase({
+        type: 'duckdb',
+        url: ':memory:',
+        __smrtSkipVitestSchemaPreparation: true,
+      });
       await syncSchema({ db, schema: OIDC_PROFILES_DUCKDB_TEST_SCHEMA });
       const before = await profileMatrixRowCounts(db);
       if (!db.transaction) {
@@ -1208,10 +1216,10 @@ async function profileMatrixIdentityBindings(
 async function profileMatrixRowCounts(
   db: DatabaseInterface,
 ): Promise<{ profile: number; oidcIdentity: number }> {
-  const [profile, oidcIdentity] = await Promise.all([
-    countRows(db, 'profiles'),
-    countRows(db, 'oidc_identities'),
-  ]);
+  // A caller-owned DuckDB transaction has one native connection. Keep the
+  // observation queries ordered so assertions do not contend with each other.
+  const profile = await countRows(db, 'profiles');
+  const oidcIdentity = await countRows(db, 'oidc_identities');
   return { profile, oidcIdentity };
 }
 

--- a/packages/users/src/__tests__/oidc-provisioning-safety.test.ts
+++ b/packages/users/src/__tests__/oidc-provisioning-safety.test.ts
@@ -1776,8 +1776,8 @@ function assertSelectedProfile(options: {
 async function provisioningRowCounts(
   db: DatabaseInterface,
 ): Promise<ProvisioningRowCounts> {
-  // A caller-owned DuckDB transaction has one native connection. Keep the
-  // observation queries ordered so assertions do not contend with each other.
+  // Caller-owned transactions share a connection. Keep observation queries
+  // ordered; DuckDB must not contend with its native connection.
   const profile = await countRows(db, 'profiles');
   const oidcIdentity = await countRows(db, 'oidc_identities');
   const user = await countRows(db, 'users');

--- a/packages/users/src/__tests__/oidc-provisioning-safety.test.ts
+++ b/packages/users/src/__tests__/oidc-provisioning-safety.test.ts
@@ -547,6 +547,7 @@ describe('safe OIDC provisioning', () => {
     const duckDb = (await getDatabase({
       type: 'duckdb',
       url: ':memory:',
+      __smrtSkipVitestSchemaPreparation: true,
     })) as DatabaseInterface;
     await syncSchema({ db: duckDb, schema: OIDC_USERS_TEST_SCHEMA });
     await prepareOidcEmailKeyBackfills(duckDb);
@@ -600,6 +601,7 @@ describe('safe OIDC provisioning', () => {
     const duckDb = (await getDatabase({
       type: 'duckdb',
       url: ':memory:',
+      __smrtSkipVitestSchemaPreparation: true,
     })) as DatabaseInterface;
     await syncSchema({ db: duckDb, schema: OIDC_USERS_TEST_SCHEMA });
     await prepareOidcEmailKeyBackfills(duckDb);
@@ -1182,6 +1184,7 @@ describe('safe OIDC provisioning', () => {
     const duckDb = (await getDatabase({
       type: 'duckdb',
       url: ':memory:',
+      __smrtSkipVitestSchemaPreparation: true,
     })) as DatabaseInterface;
     await syncSchema({ db: duckDb, schema: OIDC_USERS_TEST_SCHEMA });
     const before = await provisioningRowCounts(duckDb);
@@ -1221,6 +1224,7 @@ describe('safe OIDC provisioning', () => {
     const duckDb = (await getDatabase({
       type: 'duckdb',
       url: ':memory:',
+      __smrtSkipVitestSchemaPreparation: true,
     })) as DatabaseInterface;
     await syncSchema({ db: duckDb, schema: OIDC_USERS_TEST_SCHEMA });
     const before = await provisioningRowCounts(duckDb);
@@ -1772,12 +1776,12 @@ function assertSelectedProfile(options: {
 async function provisioningRowCounts(
   db: DatabaseInterface,
 ): Promise<ProvisioningRowCounts> {
-  const [profile, oidcIdentity, user, session] = await Promise.all([
-    countRows(db, 'profiles'),
-    countRows(db, 'oidc_identities'),
-    countRows(db, 'users'),
-    countRows(db, 'sessions'),
-  ]);
+  // A caller-owned DuckDB transaction has one native connection. Keep the
+  // observation queries ordered so assertions do not contend with each other.
+  const profile = await countRows(db, 'profiles');
+  const oidcIdentity = await countRows(db, 'oidc_identities');
+  const user = await countRows(db, 'users');
+  const session = await countRows(db, 'sessions');
   return { profile, oidcIdentity, user, session };
 }
 


### PR DESCRIPTION
## Summary

- opt explicit OIDC DuckDB fixtures out of broad Vitest schema preparation, then retain their existing narrow schema synchronization
- serialize row-count observations within caller-owned DuckDB transactions to avoid concurrent queries on one native connection
- preserve the transaction, cross-handle, and error assertions

## Root cause

Vitest's broad automatic schema preparation could contend with explicit narrow OIDC test schemas, and concurrent observation queries shared a caller-owned DuckDB connection.

## Validation

- `pnpm --filter @happyvertical/smrt-profiles test`
- `pnpm --filter @happyvertical/smrt-users test`
- Profiles and Users package shuffle probes (seeds `2172` and `8191`)
- `pnpm --filter @happyvertical/smrt-users exec vitest run --coverage --reporter=dot --silent`
- three consecutive `pnpm test` runs
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint && pnpm format-check`
- `pnpm smrt dev:knowledge-check && pnpm audit:policy`
- independent code review: CLEAR

Closes #2172

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-issue-2172-20260802","issue":"2172","head_sha":"2d838a464d8a9997428e275570ecedbc8aaec95f","policy_revision":"1.0.0","status":"complete"}
```