### PR TITLE
fix(deps): override three 2026-08-03 high advisories to patched versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ overrides:
   '@grpc/grpc-js@>=1.14.0 <1.14.4': 1.14.4
   minimatch@>=9.0.0 <10.0.0: 10.2.5
   minimatch@>=10.0.0 <10.2.3: 10.2.5
-  undici@>=7.0.0 <7.28.0: 7.28.0
+  undici@>=7.0.0 <7.29.0: 7.29.0
   nodemailer@<9.0.1: 9.0.3
   tar@>=7.0.0 <7.5.21: 7.5.22
   protobufjs@<7.6.5: 7.6.5
@@ -66,7 +66,8 @@ overrides:
   '@sveltejs/kit@>=2.0.0 <2.57.1': 2.69.1
   lodash@>=4.0.0 <4.18.0: 4.18.1
   path-to-regexp@>=8.0.0 <8.4.0: 8.4.2
-  fast-uri@>=3.0.0 <=3.1.3: 3.1.4
+  fast-uri@>=3.0.0 <3.1.5: 3.1.5
+  ip-address@<=10.3.0: 10.3.1
   fast-xml-builder@>=1.0.0 <1.1.7: 1.2.1
   js-yaml@>=4.0.0 <4.2.0: 4.3.0
   svelte@>=5.0.0 <5.54.0: 5.56.4
@@ -6855,8 +6856,8 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -7342,8 +7343,8 @@ packages:
     resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
     engines: {node: '>=12.22.0'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -9242,8 +9243,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   undici@8.9.0:
@@ -13335,7 +13336,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13597,7 +13598,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.28.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   chokidar@4.0.3:
@@ -14141,7 +14142,7 @@ snapshots:
   express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.3.1
 
   express@5.2.1:
     dependencies:
@@ -14194,7 +14195,7 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-xml-builder@1.2.0:
     dependencies:
@@ -14888,7 +14889,7 @@ snapshots:
       - supports-color
     optional: true
 
-  ip-address@10.2.0: {}
+  ip-address@10.3.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -16481,7 +16482,7 @@ snapshots:
 
   socks@2.8.9:
     dependencies:
-      ip-address: 10.2.0
+      ip-address: 10.3.1
       smart-buffer: 4.2.0
 
   sonic-boom@4.2.1:
@@ -16877,7 +16878,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   undici@8.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,7 @@ overrides:
   # only named exports, all of which minimatch 10 still provides.
   'minimatch@>=9.0.0 <10.0.0': 10.2.5
   'minimatch@>=10.0.0 <10.2.3': 10.2.5
-  'undici@>=7.0.0 <7.28.0': 7.28.0
+  'undici@>=7.0.0 <7.29.0': 7.29.0
   'nodemailer@<9.0.1': 9.0.3
   'tar@>=7.0.0 <7.5.21': 7.5.22
   # protobufjs 6.x reaches the graph through the optional, deprecated
@@ -61,7 +61,8 @@ overrides:
   '@sveltejs/kit@>=2.0.0 <2.57.1': 2.69.1
   'lodash@>=4.0.0 <4.18.0': 4.18.1
   'path-to-regexp@>=8.0.0 <8.4.0': 8.4.2
-  'fast-uri@>=3.0.0 <=3.1.3': 3.1.4
+  'fast-uri@>=3.0.0 <3.1.5': 3.1.5
+  'ip-address@<=10.3.0': 10.3.1
   'fast-xml-builder@>=1.0.0 <1.1.7': 1.2.1
   'js-yaml@>=4.0.0 <4.2.0': 4.3.0
   'svelte@>=5.0.0 <5.54.0': 5.56.4


### PR DESCRIPTION
## Summary

Three high-severity advisories published upstream today fail `pnpm audit --audit-level=high` — a `Required CI` need — on every merge-group build, so the entire merge queue has been un-mergeable since ~19:59Z (first red: run 30848147249). Per the #2203 pattern:

- widen `undici@>=7.0.0 <7.28.0: 7.28.0` → `<7.29.0: 7.29.0` (GHSA-4cwx-7wf7-3272, cross-user information disclosure)
- widen `fast-uri@>=3.0.0 <=3.1.3: 3.1.4` → `<3.1.5: 3.1.5` (GHSA-7p8r-x3mc-p8w7, host confusion via backslash)
- add `ip-address@<=10.3.0: 10.3.1` (GHSA-mwp4-54f8-5fhr, SSRF via leading-zero octets)

Lockfile refreshed with `--lockfile-only`; only the three packages (plus their consumers' resolved-version pointers in ajv/cheerio/express-rate-limit/socks snapshots) moved.

## Validation

- `pnpm audit --audit-level=high` exit 0 on the refreshed lockfile (remaining: 1 low / 7 moderate, non-blocking by policy)
- `pnpm audit:policy` green: 5 accepted records, 0 suppressions, none past recheck
- Review (material-findings-only): pins meet each advisory's patched version exactly; lockfile enumeration shows single clean resolutions (undici 7.29.0 on the 7.x line with the direct 8.9.0 already patched; fast-uri 3.1.5; ip-address 10.3.1); both ip-address consumers (socks ^10.1.1, express-rate-limit ^10.2.0) natively admit 10.3.1 — no forced cross-major
- Pre-commit hooks green (knowledge-check, secret scan, workflow validation, commitlint)

Closes #2207

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"claude-issue-2207-20260803","issue":"2207","head_sha":"91252b14342ca005fdecf6cd0adaf2f8648b629d","policy_revision":"1.0.0","status":"complete"}
```
