### PR TITLE
ci: merge-queue survivability hardening (timeout walls + dead-group sweep)

### DIFF
--- a/.github/workflows/merge-queue-cleanup.yml
+++ b/.github/workflows/merge-queue-cleanup.yml
@@ -1,0 +1,60 @@
+name: Merge Queue Cleanup
+
+# GitHub keeps dispatching queued jobs for merge-group branches that the
+# queue has already deleted — on 2026-08-03, 25 of 103 self-hosted dispatches
+# went to dead gh-readonly-queue/* groups, starving live queue validations on
+# a 5-7 slot fleet. This sweep cancels every non-completed merge_group run
+# whose head branch no longer exists. It runs on branch deletion for
+# immediacy, on a schedule as the guarantee (bot-driven deletions do not
+# reliably trigger the delete event), and on manual dispatch.
+on:
+  delete:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  sweep:
+    name: Cancel runs of deleted merge-group branches
+    # For delete events, only branch deletions in the queue namespace are
+    # interesting; schedule and dispatch always sweep.
+    if: >-
+      github.event_name != 'delete' ||
+      (github.event.ref_type == 'branch' &&
+      startsWith(github.event.ref, 'gh-readonly-queue/'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sweep dead merge-group runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          swept=0
+          for status in queued in_progress; do
+            ids=$(gh api "repos/$REPO/actions/runs?event=merge_group&status=$status&per_page=100" \
+              | jq -r '.workflow_runs[] | [.id, .head_branch] | @tsv')
+            [ -n "$ids" ] || continue
+            while IFS=$'\t' read -r rid branch; do
+              [ -n "$rid" ] && [ -n "$branch" ] || continue
+              # URL-encode the branch name for the existence probe.
+              encoded=$(printf '%s' "$branch" | jq -sRr @uri)
+              if probe=$(gh api "repos/$REPO/branches/$encoded" 2>&1); then
+                continue  # branch alive: run is a live queue entry, leave it
+              fi
+              # Fail safe: only an explicit 404 marks the branch dead. A rate
+              # limit or transient error must never cancel a live run.
+              case "$probe" in
+                *"HTTP 404"*) ;;
+                *) echo "skipping run $rid: branch probe failed non-404"; continue ;;
+              esac
+              echo "cancelling $status run $rid for deleted branch $branch"
+              gh api -X POST "repos/$REPO/actions/runs/$rid/cancel" --silent || true
+              swept=$((swept + 1))
+            done <<< "$ids"
+          done
+          echo "swept $swept dead run(s)"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -23,7 +23,7 @@ jobs:
     name: Detect Affected Validation Scope
     if: inputs.mode == 'affected'
     runs-on: arc-happyvertical
-    timeout-minutes: 45
+    timeout-minutes: 90
     outputs:
       knowledge: ${{ steps.filter.outputs.knowledge }}
     steps:
@@ -53,7 +53,7 @@ jobs:
     name: Build
     if: inputs.mode == 'full'
     runs-on: arc-happyvertical
-    timeout-minutes: 45
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repository
@@ -133,7 +133,7 @@ jobs:
     needs: build
     if: inputs.mode == 'full'
     runs-on: arc-happyvertical
-    timeout-minutes: 45
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repository
@@ -162,7 +162,7 @@ jobs:
   lint:
     name: Lint
     runs-on: arc-happyvertical
-    timeout-minutes: 45
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repository
@@ -183,7 +183,7 @@ jobs:
     needs: affected-scope
     if: inputs.mode == 'affected'
     runs-on: arc-happyvertical
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -217,7 +217,7 @@ jobs:
     needs: affected-scope
     if: inputs.mode == 'affected' && needs.affected-scope.outputs.knowledge == 'true'
     runs-on: arc-happyvertical
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -248,7 +248,7 @@ jobs:
     needs: build
     if: inputs.mode == 'full'
     runs-on: arc-happyvertical
-    timeout-minutes: 45
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repository
@@ -289,7 +289,7 @@ jobs:
     needs: build
     if: always() && (inputs.mode == 'affected' || needs.build.result == 'success')
     runs-on: arc-happyvertical
-    timeout-minutes: 45
+    timeout-minutes: 90
 
     steps:
       # fetch-depth: 0 so the gate can diff against the PR base to find the
@@ -354,7 +354,7 @@ jobs:
     # A remote-cache outage can add several minutes of cold setup and build
     # time, so this shard stays on the standard ceiling rather than a tighter
     # one; cache misses must not cancel an otherwise healthy core suite.
-    timeout-minutes: 45
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -408,7 +408,7 @@ jobs:
     needs: build
     if: inputs.mode == 'full'
     runs-on: arc-happyvertical
-    timeout-minutes: 45
+    timeout-minutes: 90
 
     steps:
       - name: Checkout repository
@@ -447,7 +447,7 @@ jobs:
     # Each shard runs ~1/3 of package tests and lets Turbo build only their
     # dependency closures. Runner-pool contention still applies, so this keeps
     # the standard ceiling rather than a shard-specific one.
-    timeout-minutes: 45
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -543,7 +543,7 @@ jobs:
     needs: test-packages
     runs-on: arc-happyvertical
     if: always() && inputs.mode == 'full'
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - name: Verify all Test Packages shards passed
         run: |


### PR DESCRIPTION
## Summary

Patch train for #2206, one attributed commit per item:

1. **`test-suite.yml`: `timeout-minutes` 45 → 90 on all 12 jobs.** The test shards take ~6–10 min on landgraf but ~5–7× longer on patdown's serial slot; when FIFO routes one there it exceeds the 45-minute budget, GitHub cancels the job, the rollup goes red, and the queue ejects its head. Two merge-killing instances on 08-03 (runs 30798553114 and 30832703730, both cancelled at 45m18–19s with the runner healthy — exit 0, no OOM). 90 gives ~1.8× margin over the ~50-min slow-slot reality. Entries stacked behind this train in the merge queue inherit the new budgets immediately (merge-group runs read workflows from the group ref).
2. **New `merge-queue-cleanup.yml`.** GitHub keeps dispatching queued jobs for deleted `gh-readonly-queue/*` branches — 25 of 103 self-hosted dispatches on 08-03 went to dead groups, starving live validations; it was hand-cancelled three times today. The sweep cancels every non-completed `merge_group` run whose head branch 404s, on branch delete + 15-min cron + manual dispatch. Fail-safe: only an explicit `HTTP 404` marks a branch dead; rate limits and transient errors skip.

## Validation

- actionlint green on both files; pre-commit hooks green (knowledge-check, secret scan, workflow validation, commitlint)
- Review-cycle, 2 reviewers, both clean with empirical verification:
  - `%2F`-encoded slash branch names confirmed working against the live branches API (200 on a six-slash branch; the gh CLI double-encode bug cli/cli#10628 verified scoped to Packages-API paths only)
  - gh 404 stderr strings confirmed matching the `*"HTTP 404"*` guard; non-404 failures skip, never cancel
  - `event=merge_group&status=` filters confirmed AND-combining; delete-event `ref` confirmed short-name against six real queue deletions from today
  - overlap-safety: double-cancel benign, sweeps cannot target sweeps, `swept` counter survives the here-string loop
  - timeout math vs the queue's 360-min `check_response_timeout`: worst realistic slow-slot path ~110 min, well inside
- Reviewer notes carried as follow-ups, not blockers: `publish-dry-run.yml`/`postgres-tests.yml`/`build.yml` still at 45 (thin but sufficient margin today); `per_page=100` unpaginated (self-heals next cron)

Closes #2206

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"claude-issue-2206-20260803","issue":"2206","head_sha":"0a025c6912963a39a2953c65dbceeec328466960","policy_revision":"1.0.0","status":"complete"}
```