### PR TITLE
perf(ci): stop double-running coverage and packaging gates, drop video/voice isolation

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -75,9 +75,9 @@ the trusted base branch rather than contributor-controlled merge YAML. It passes
 a PR head SHA to reusable general-CI workflows only when the head repository
 equals `github.repository`; merge-group and trusted push workflows use the
 broker normally. External fork PRs keep a base-revision hosted control-plane
-check, while the self-hosted validation and publish-dry-run calls are skipped
-and `Required CI` rejects the run. Broker admission must also deny those fork
-events before making a reservation.
+check, while the self-hosted validation call is skipped and `Required CI`
+rejects the run on that skipped result. Broker admission must also deny those
+fork events before making a reservation.
 
 `CI_NODE_RUNNER_ENABLED` is gone from this tree — nothing reads it, and the
 migration it was conditioned on is live. If the repository still defines the
@@ -222,19 +222,34 @@ reversal lever.
 
 - Unset/false: PRs run the historical full suite.
 - `true`: PRs run lint, affected typecheck and tests across the changed
-  packages and everything that depends on them, touched coverage, and — only
-  when knowledge-sensitive paths change — affected knowledge freshness. The
+  packages and everything that depends on them, and — only when
+  knowledge-sensitive paths change — affected knowledge freshness. The
   complete suite runs for `merge_group`.
 
-Publish dry-run sits outside that split: it runs for same-repository PRs and for
-`merge_group` in both modes. No lane in `on-pull-request.yml` or
-`test-suite.yml` runs PostgreSQL in either mode; PostgreSQL lives only in
-`postgres-tests.yml`, described below.
+Coverage Gate and Publish Dry Run are merge-group only (#2214 items 4 and 8).
+Both used to run in both lanes while the merge group re-ran them in full
+regardless, so the PR copies were duplicate fleet occupancy rather than the
+binding gate — and Coverage Gate additionally paid a cold full build on PRs,
+because the seed `build` job is full-mode only. Neither loses meaning in the
+merge group: `check-coverage.mjs` resolves its diff base as `BASE_REF || 'main'`
+plus `merge-base`, which is correct for the synthetic merge-group head. The
+trade is that a coverage or packaging regression now ejects from the queue
+instead of reddening the PR; authors can pre-check coverage locally with
+`node scripts/check-coverage.mjs --packages <list>`.
 
-`Required CI` is the sole required repository-validation status. Its aggregator
-requires the same eight jobs to succeed for both PR and merge-group events; what
-differs between the two is the mode `test-suite.yml` runs in, not the set of
-jobs the aggregator checks.
+Publish Dry Run's gate lives inside `publish-dry-run.yml`, not on its caller.
+Every reusable or self-hosted job in `on-pull-request.yml` must carry the
+canonical trusted-base admission expression byte-for-byte, so narrowing a lane
+from the caller's `if:` is not available — gate the called workflow instead.
+
+No lane in `on-pull-request.yml` or `test-suite.yml` runs PostgreSQL in either
+mode; PostgreSQL lives only in `postgres-tests.yml`, described below.
+
+`Required CI` is the sole required repository-validation status. Seven jobs must
+succeed for both PR and merge-group events; Publish Dry Run is required only for
+`merge_group`, where it runs. The aggregator still fails if it reports anything
+other than `skipped` or `success` on a PR, so re-enabling it there cannot
+silently leave it un-gated.
 
 Rollout status:
 

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -242,6 +242,14 @@ Every reusable or self-hosted job in `on-pull-request.yml` must carry the
 canonical trusted-base admission expression byte-for-byte, so narrowing a lane
 from the caller's `if:` is not available — gate the called workflow instead.
 
+Both gates key off `CI_MERGE_QUEUE_ENABLED`, not off the event alone, because
+clearing that variable is the documented rollback lever and it stops GitHub
+producing `merge_group` events at all. Coverage Gate gets this for free: the
+caller's `mode` expression falls back to `full` on the same lever, so it runs on
+PRs again. Publish Dry Run tests the lever explicitly — without it, a rollback
+would leave packaging unvalidated all the way into `publish.yml`, since
+`on-merge-main.yml` runs test and build but never a pack validation.
+
 No lane in `on-pull-request.yml` or `test-suite.yml` runs PostgreSQL in either
 mode; PostgreSQL lives only in `postgres-tests.yml`, described below.
 

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -398,6 +398,10 @@ jobs:
 
   publish-dry-run:
     name: Publish Dry Run
+    # This gate is the canonical trusted-base self-hosted admission expression
+    # and must stay byte-identical — `hv-agent check-pr` requires every reusable
+    # or self-hosted job in this workflow to carry it, so the merge-queue-only
+    # narrowing for #2214 item 4 lives inside publish-dry-run.yml instead.
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request_target' &&
@@ -440,11 +444,29 @@ jobs:
           DEPENDENCY_AUDIT: ${{ needs.dependency-audit.result }}
           TEST_SUITE: ${{ needs.test.result }}
           PUBLISH_DRY_RUN: ${{ needs.publish-dry-run.result }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          for result in "$VALIDATE_COMMITS" "$VALIDATE_WORKFLOWS" "$CHECK_SDK" "$SECRET_SCAN" "$CHECK_STANDARDS" "$DEPENDENCY_AUDIT" "$TEST_SUITE" "$PUBLISH_DRY_RUN"; do
+          for result in \
+            "$VALIDATE_COMMITS" "$VALIDATE_WORKFLOWS" "$CHECK_SDK" \
+            "$SECRET_SCAN" "$CHECK_STANDARDS" "$DEPENDENCY_AUDIT" \
+            "$TEST_SUITE"; do
             if [ "$result" != success ]; then
               echo "::error::full validation did not succeed"
               exit 1
             fi
           done
+
+          # Publish Dry Run is merge-queue only (#2214 item 4), so it reports
+          # `skipped` on a pull request. Require success where it actually runs,
+          # and still fail here if it somehow ran and failed on a PR — accepting
+          # any result outright would silently un-gate it if it is re-enabled.
+          if [ "$EVENT_NAME" = merge_group ]; then
+            if [ "$PUBLISH_DRY_RUN" != success ]; then
+              echo "::error::publish dry run did not succeed in the merge group"
+              exit 1
+            fi
+          elif [ "$PUBLISH_DRY_RUN" != skipped ] && [ "$PUBLISH_DRY_RUN" != success ]; then
+            echo "::error::publish dry run reported '$PUBLISH_DRY_RUN' on a pull request"
+            exit 1
+          fi

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -27,9 +27,19 @@ jobs:
     # it in full regardless, so the per-PR copy was duplicate occupancy rather
     # than the binding gate. The gate lives here rather than on the caller's
     # `if:`, which must stay byte-identical to the canonical trusted-base
-    # admission expression. Negating pull_request_target (rather than testing
-    # for merge_group) keeps the workflow_dispatch escape hatch working.
-    if: github.event_name != 'pull_request_target'
+    # admission expression.
+    #
+    # Skip ONLY when the merge queue will re-run it. Clearing
+    # CI_MERGE_QUEUE_ENABLED is the documented rollback lever, and it stops
+    # GitHub producing merge_group events entirely — gating on the event alone
+    # would leave packaging unvalidated all the way into publish.yml, since
+    # on-merge-main.yml runs test and build but never a pack validation. This
+    # mirrors the caller's `mode` expression, which falls back to full
+    # validation on the same lever. Testing the event rather than merge_group
+    # also keeps the workflow_dispatch escape hatch working.
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      vars.CI_MERGE_QUEUE_ENABLED != 'true'
     # Emergency lane selector: publish dry run backs the required aggregator in
     # the merge queue, so it must move with the CI_HOSTED_FALLBACK_ENABLED lever
     # or a fleet outage would keep Required CI blocked despite the fallback. See
@@ -224,7 +234,10 @@ jobs:
     # `always()` alone would keep this summary running — and failing on the
     # missing artifacts — after the two jobs above skip on a pull request, so it
     # carries the same lane guard (#2214 item 4).
-    if: always() && github.event_name != 'pull_request_target'
+    if: >-
+      always() &&
+      (github.event_name != 'pull_request_target' ||
+      vars.CI_MERGE_QUEUE_ENABLED != 'true')
     runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
     timeout-minutes: 45
 

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -22,10 +22,18 @@ permissions:
 jobs:
   prepare-publish:
     name: Prepare Publish Validation
-    # Emergency lane selector: publish dry run backs the required aggregator,
-    # so it must move with the CI_HOSTED_FALLBACK_ENABLED lever or a fleet
-    # outage would keep Required CI blocked despite the fallback. See the
-    # selector comment in test-suite.yml and the Hosted Turbo cache section
+    # Skip the pull-request lane (#2214 item 4). This is a full-tree build plus
+    # a two-shard pack validation on the metal fleet, and the merge group re-ran
+    # it in full regardless, so the per-PR copy was duplicate occupancy rather
+    # than the binding gate. The gate lives here rather than on the caller's
+    # `if:`, which must stay byte-identical to the canonical trusted-base
+    # admission expression. Negating pull_request_target (rather than testing
+    # for merge_group) keeps the workflow_dispatch escape hatch working.
+    if: github.event_name != 'pull_request_target'
+    # Emergency lane selector: publish dry run backs the required aggregator in
+    # the merge queue, so it must move with the CI_HOSTED_FALLBACK_ENABLED lever
+    # or a fleet outage would keep Required CI blocked despite the fallback. See
+    # the selector comment in test-suite.yml and the Hosted Turbo cache section
     # of CI.md.
     runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
     timeout-minutes: 45
@@ -213,7 +221,10 @@ jobs:
     needs:
       - prepare-publish
       - validate-publish-shards
-    if: always()
+    # `always()` alone would keep this summary running — and failing on the
+    # missing artifacts — after the two jobs above skip on a pull request, so it
+    # carries the same lane guard (#2214 item 4).
+    if: always() && github.event_name != 'pull_request_target'
     runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
     timeout-minutes: 45
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -480,60 +480,35 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           auth-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # smrt-video loads the full SMRT manifest graph. When it runs near the end
-      # of shard 2 beside another Turbo task, constrained ARC runners can kill
-      # its otherwise passing Vitest fork. Run it first through Turbo so a fresh
-      # runner builds its dependency closure, then exclude it from the general
-      # batch so coverage remains exactly once.
-      - name: Run video package tests in isolation
-        if: matrix.shard == '2/3'
-        run: pnpm turbo run test --concurrency=1 --filter='@happyvertical/smrt-video'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_ENV: test
-          VITEST_MAX_WORKERS: '1'
-          # Node sizes its default old-space from HOST memory, and this runner
-          # exposes the whole host (see the CPU note below), so V8 will happily
-          # grow a fork past the container's own limit and the kernel kills it —
-          # surfacing as Vitest's silent `Worker exited unexpectedly` with no
-          # `JavaScript heap out of memory`. Cap the heap so V8 collects instead
-          # of ballooning. This BOUNDS the fork; it does not give it more room.
-          NODE_OPTIONS: --max-old-space-size=4096
-
-      # smrt-voice pulls the same heavy AI/SQL graph as smrt-video and dies the
-      # same way inside the concurrent batch, where it shares the runner with a
-      # second Turbo task. Give it the treatment already proven for video: run
-      # it first, alone, with a dedicated heap, then exclude it below so
-      # coverage still happens exactly once.
-      - name: Run voice package tests in isolation
-        if: matrix.shard == '1/3'
-        run: pnpm turbo run test --concurrency=1 --filter='@happyvertical/smrt-voice'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_ENV: test
-          VITEST_MAX_WORKERS: '1'
-          NODE_OPTIONS: --max-old-space-size=4096
-
-      # Each shard runs ~1/3 of the remaining non-core packages
+      # Each shard runs ~1/3 of the non-core packages
       # (scripts/test-packages-shard.mjs round-robins by name), keeping
-      # per-runner load low so transient resource-pressure timing flakes stay
-      # rare.
-      - name: Run package tests (shard ${{ matrix.shard }}, excluding core, video and voice)
+      # per-runner load low.
+      #
+      # smrt-video and smrt-voice used to run here as isolated pre-steps with a
+      # dedicated heap, then were excluded from this batch. That was a
+      # workaround for silent `Worker exited unexpectedly` deaths attributed to
+      # memory pressure. The attribution was wrong: the failing shards recorded
+      # cgroup `oom_kill = 0`, and the real cause was an AVX2 SIGILL in
+      # @happyvertical/pdf on x86-64-v2 metal, fixed by the 0.65.9 guard
+      # (#2195/#2196). The isolation is removed with the cause (#2214 item 6);
+      # the shard script already round-robins both packages onto these same two
+      # runners (voice -> 1/3, video -> 2/3), so placement is unchanged.
+      - name: Run package tests (shard ${{ matrix.shard }}, excluding core)
         run: |
           set -o pipefail
           node scripts/test-packages-shard.mjs '${{ matrix.shard }}' |
-            xargs -r pnpm turbo run test --concurrency=2 \
-              --filter='!@happyvertical/smrt-video' \
-              --filter='!@happyvertical/smrt-voice'
+            xargs -r pnpm turbo run test --concurrency=2
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_ENV: test
-          # The node runner exposes all 32 host CPUs. Cap each of the two
-          # concurrent Turbo tasks so Vitest cannot fan out to dozens of workers.
+          # The node runner exposes all 32 host CPUs while the pod holds a
+          # 4-CPU quota, so uncapped Vitest over-fans. Cap each of the two
+          # concurrent Turbo tasks.
           VITEST_MAX_WORKERS: '2'
-          # Same host-vs-container heap mismatch as the video step above, halved
-          # because two Turbo tasks run concurrently here. smrt-voice pulls the
-          # heavy AI/SQL graph and has been dying the same silent way.
+          # Node likewise sizes its default old-space from host memory, so bound
+          # the heap explicitly rather than letting a fork grow against the
+          # pod's limit. Halved from a single-task budget because two Turbo
+          # tasks run concurrently here.
           NODE_OPTIONS: --max-old-space-size=2048
 
       - name: Upload test results

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -298,7 +298,16 @@ jobs:
   coverage-gate:
     name: Coverage Gate
     needs: build
-    if: always() && (inputs.mode == 'affected' || needs.build.result == 'success')
+    # Full-mode only (#2214 item 8). This used to run in both lanes, and in
+    # affected mode the seed `build` job is skipped, so it paid a cold full
+    # build before it could measure anything — 26-45 min against 4-5 min on a
+    # warm cache. The merge group re-ran it in full immediately afterwards, so
+    # the affected copy bought nothing but occupancy. check-coverage.mjs
+    # resolves its base as `BASE_REF || 'main'` plus merge-base, which is
+    # correct for the merge_group synthetic head, so the gate keeps its full
+    # meaning here. Authors keep the local pre-check:
+    #   node scripts/check-coverage.mjs --packages <list>
+    if: inputs.mode == 'full'
     runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
     timeout-minutes: 90
 
@@ -339,10 +348,9 @@ jobs:
       # PR #2102. Measured turbo selections from that base:
       #   [sha]     -> 2 packages      ...[sha] -> 53 packages
       #   [sha]...  -> 2 packages      scanner... -> 1 package
-      # setup-environment restores the build job's per-SHA Turbo cache, so in
-      # full mode this is a cache hit. In affected mode the `build` job is
-      # skipped (`build.if: mode == full`), so this can be a cold build; that
-      # cost is accepted because correctness of the gate comes first.
+      # setup-environment restores the build job's per-SHA Turbo cache, and this
+      # job runs only after `build` has seeded it, so this is a cache hit rather
+      # than a rebuild.
       - name: Build packages
         run: pnpm run build
         env:


### PR DESCRIPTION
Three items off the queue-occupancy patch train. All three cut `arc-happyvertical`
slot occupancy without reducing what actually gates a merge.

## What changed

| Commit | Item | Change |
|---|---|---|
| `0fa7e963` | 6 | Delete the `smrt-video`/`smrt-voice` isolation steps and their `--filter='!...'` exclusions |
| `f96c553e` | 8 | Gate `Coverage Gate` to `inputs.mode == 'full'` |
| `e4a94de7` | 4 | Gate `Publish Dry Run` to `merge_group`; teach `Required CI` the split |
| `9c34ed11` | — | Update `.github/CI.md` for the above |
| `614deb47` | 4 | Review fix: keep the dry run enabled when the merge queue is disabled |

**Items 4 and 8** — both jobs ran on every PR *and* again in the merge group, which
re-ran them in full regardless, so the PR copies were duplicate fleet occupancy
rather than the binding gate. Coverage Gate was the expensive one: the seed
`build` job is full-mode only, so its mandatory full `pnpm run build` ran **cold**
on PRs — measured bimodal across 14 recent runs at 4.2–4.7 min warm vs 26–45 min
cold.

Neither loses meaning in the merge group: `check-coverage.mjs` resolves its diff
base as `BASE_REF || 'main'` plus `merge-base`, which is correct for the
`merge_group` synthetic head.

**Item 6** — the isolation steps were a workaround for silent
`Worker exited unexpectedly` deaths attributed to memory pressure. That
attribution was wrong: the failing shards recorded cgroup `oom_kill = 0`, and the
real cause was an AVX2 SIGILL in `@happyvertical/pdf` on x86-64-v2 metal, fixed
by the 0.65.9 guard (#2195, #2196). Every sampled failure predates that bump, and
the first full merge-group run after it (`30832712023`) was green on all three
shards. `scripts/test-packages-shard.mjs` already round-robins both packages onto
the same runners the isolation was pinned to (voice → 1/3, video → 2/3), so shard
placement is unchanged and each package still runs exactly once.

## Deviation from the issue text

Item 4 as written proposed a paths-filter so packaging-relevant PRs still ran the
dry run. This implements the stricter `merge_group`-only form instead: computing
the filter needs its own fleet job, and a job costs a median 16 min of pod queue
wait for ~1 s of work, which is most of what the item was trying to reclaim.

The gate also had to move. `hv-agent check-pr` requires every reusable or
self-hosted job in `on-pull-request.yml` to carry the canonical trusted-base
admission expression byte-for-byte, so the caller's `if:` cannot be narrowed —
the first attempt at this was rejected by the lifecycle preflight. The condition
lives in `publish-dry-run.yml` instead, negating `pull_request_target` rather
than testing for `merge_group` so `workflow_dispatch` still works. The summary
job needed the guard explicitly: its `always()` would otherwise leave it running,
and failing on missing artifacts, after the jobs it summarizes skip.

## Validation

- `actionlint` clean on both touched workflows; `yamllint` exit 0
- `check-standards`, `check-agents-chain`, `check-no-smrt-peers`, `check-package-dag` pass
- `Required CI` aggregator logic unit-tested across 7 result combinations:
  fork PR (skipped `Validate Changes`) still **rejected**; `cancelled` still fails;
  `merge_group` + skipped/failed dry run still fails; PR + skipped passes
- Shard placement verified empirically against `test-packages-shard.mjs`

## Residual risk

- **None of the three items is exercised by this PR's own CI.** The caller uses
  `pull_request_target`, so GitHub loads workflow YAML from the base branch — this
  PR's validation run executes `main`'s workflows, not the ones in the diff.
  Confirmed live on head `614deb47a`: `Coverage Gate` queued and `Publish Dry Run`
  executed, which is base-branch behaviour, not the gated behaviour here. All
  three items therefore first take effect in the merge group.

  `merge_group` **does** source its YAML from the merge ref — verified, since
  GitHub documents this nowhere: run `30496440494` is PR #2141's own merge_group
  run, and its `test-packages (2/3)` job contains both `Run video package tests
  in isolation` and `Run package tests (shard 2/3, excluding core and video)` —
  the step #2141 added and the rename it made, neither of which `main` had at the
  time. So the merge queue is the real test here, and a bug in these changes
  would break the queue for everyone, not just this PR. I re-verified the
  `merge_group` path statically: `mode` resolves to `full` so Coverage Gate runs;
  the caller's canonical gate admits `merge_group` and the called workflow's
  `github.event_name != 'pull_request_target'` is true so Publish Dry Run runs;
  `required-ci` takes the `merge_group` branch and requires it green.

  Per the issue, give item 6 a few full-suite transits before declaring it done.

- `vars.CI_MERGE_QUEUE_ENABLED` is read inside the called workflow. GitHub
  documents that "for reusable workflows, the variables from the caller workflow's
  repository are used", and caller and callee are both in this repository, so it
  resolves. Worst case if that ever changed: the dry run runs on PRs as it does
  today — item 4 would stop saving, nothing would break.
- `smrt-video`/`smrt-voice` have never run *inside* the shared batch under its
  2048 MB heap cap — that cap landed 2026-08-01, after their 2026-07-29 exclusion.
  Both set `fileParallelism: false` (one fork each) and video also `isolate: false`,
  and history shows `oom_kill = 0`, so this is watch-and-see rather than a known
  problem.
- Accepted trade: a coverage or packaging regression now ejects from the merge
  queue instead of reddening the PR. Local pre-check:
  `node scripts/check-coverage.mjs --packages <list>`.
- The local `codex review` CLI could not be run this session — it exits silently
  right after its `UserPromptSubmit` hooks (three attempts, including after
  clearing the stale models cache). The GitHub Codex connector did review and
  raised one P1, fixed in `614deb47` and resolved on the thread: gating the dry
  run on the event alone would have disabled it entirely under the documented
  `CI_MERGE_QUEUE_ENABLED` rollback, letting a packaging failure reach
  `publish.yml`. Copilot reviewed and generated no comments.

Closes #2214
Refs #2216

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"8a94e288-0358-403f-a3a6-8e81a80e6c5d","issue":"2214","head_sha":"3ef5c24cf2296ea496c8820ecd6d385c60662219","policy_revision":"1.0.0","status":"complete"}
```

