### PR TITLE
feat(ci): hosted Turbo cache shim, seed workflow, and manual fallback lever

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -1,10 +1,15 @@
 # Continuous integration architecture
 
 SMRT uses hosted runners for lightweight static and control-plane checks and
-the shared `arc-happyvertical` broker pool for general builds, tests, and publishing. The
-internal Turborepo server is the build-output cache; GitHub Actions cache
-archives are deliberately not used for `.turbo/cache`. If the remote cache is
-unavailable, Turbo performs a cold build.
+the shared `arc-happyvertical` broker pool for general builds, tests, and publishing.
+There are two build-output caches, split by lane: self-hosted runners use the
+internal Turborepo server, and GitHub-hosted runners use GitHub Actions cache
+entries written through the `caching-for-turbo` shim (key prefix `turbogha_`)
+described under Hosted Turbo cache below. Raw GitHub Actions cache archives of
+`.turbo/cache` remain deliberately unused — the archive model pays full
+upload/download for a mostly unchanged blob and races on save. If either
+remote cache is unavailable, Turbo performs a cold build; a cache outage
+never fails a job.
 
 ## Manifest generation
 
@@ -36,6 +41,16 @@ never prevent the tests from running.
   is not uniform: `required-ci` is hosted, but `test-packages-result` runs on
   `arc-happyvertical` even though it only reads `needs.*.result`. It is capped
   at the standard rather than moved, because it backs a required status.
+- Every self-hosted job in `test-suite.yml` selects its runner through the
+  emergency lane selector
+  `${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || '<label>' }}`.
+  Flipping that repository variable moves the merge-blocking validation path
+  onto GitHub-hosted runners without a workflow merge — which would itself
+  need the down fleet. It is a manual lever, not a dispatcher; automated
+  hosted fallback is tracked separately. Publish, build, and postgres jobs
+  stay on the self-hosted label and queue instead. actionlint does not
+  validate labels inside expressions, so the allowlist in
+  `.github/actionlint.yaml` is unaffected.
 
 The PR caller uses `pull_request_target`, so GitHub loads runner selection from
 the trusted base branch rather than contributor-controlled merge YAML. It passes
@@ -58,6 +73,39 @@ SQLite fixtures and other temporary test files bypass the container overlay
 filesystem. Self-hosted runners can provide `CI_TEST_TMPDIR` to route those
 files to a bounded, test-only tmpfs; other runners retain the workspace-backed
 fallback.
+
+## Hosted Turbo cache
+
+GitHub-hosted runners cannot reach the internal Turbo cache server, so the
+shared setup action starts the `rharkor/caching-for-turbo` shim on them: a
+localhost server speaking the Vercel remote-cache API that stores one GitHub
+Actions cache entry per Turbo task hash under the `turbogha_` key prefix. The
+gate is `runner.environment == 'github-hosted'` — the pod-injected `TURBO_*`
+variables are runner process env, which the `env` context in a step `if:`
+cannot see. Self-hosted pods therefore never start the shim and keep the
+internal server. The `turbo-cache-shim` input (`auto`/`on`/`off`) is the
+per-call kill switch; `on` is debug-only because the shim's `GITHUB_ENV`
+exports would shadow the pod-injected internal cache env.
+
+GitHub Actions cache is branch-scoped: runs restore only entries written by
+their own branch or by main. PR and merge-group runs cannot warm each other,
+so `turbo-cache-seed.yml` (push to main, daily schedule as a 7-day-idle
+eviction backstop, manual dispatch) seeds `build` and `typecheck` — the
+latter pulling `generate:test` through its task dependencies — which are
+exactly the task types `test-suite.yml` restores. `test` tasks are
+environment-sensitive and deliberately not seeded. The scheduled and push
+runs stay skipped until the repository variable
+`CI_HOSTED_TURBO_CACHE_ENABLED` is `true`; manual dispatch bypasses the
+variable so the lane can be validated first, mirroring the PostgreSQL lane.
+
+The `turbogha_` pool shares the repository's 10 GiB Actions cache quota with
+`mobile.yml`'s Gradle entries (about 3.8 GiB when this lane was added) under
+least-recently-used eviction. An unbounded Turbo pool degrades the mobile
+nightly to slower cold Gradle runs rather than breaking it, but watch the
+usage report the seed job prints. The shim's built-in cleanup options apply
+only to its S3 provider, so pruning here is manual:
+`gh cache list --key turbogha_` and `gh cache delete`. Entries idle for
+seven days expire on their own.
 
 ## Job timeouts
 
@@ -234,3 +282,11 @@ the previous required status list, and removing the merge-queue rule.
 PostgreSQL is not part of the required aggregator, so toggling
 `CI_POSTGRES_ENABLED` never alters SQLite coverage. The artifact publisher can
 temporarily fall back to Changesets through manual dispatch.
+
+The hosted Turbo cache lane has two independent clearable levers:
+`CI_HOSTED_TURBO_CACHE_ENABLED` stops scheduled and push seeding (entries then
+expire within seven days), and `CI_HOSTED_FALLBACK_ENABLED` returns
+`test-suite.yml` to the self-hosted label. The per-call `turbo-cache-shim:
+'off'` input disables the shim for a single caller. Rehearse the fallback
+lever on a scratch pull request in a quiet window before relying on it, and
+record the observed hosted timings here.

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -41,20 +41,24 @@ never prevent the tests from running.
   is not uniform: `required-ci` is hosted, but `test-packages-result` runs on
   `arc-happyvertical` even though it only reads `needs.*.result`. It is capped
   at the standard rather than moved, because it backs a required status.
-- Every self-hosted job in `test-suite.yml` selects its runner through the
-  emergency lane selector
+- Every self-hosted job in `test-suite.yml` and `publish-dry-run.yml`
+  selects its runner through the emergency lane selector
   `${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || '<label>' }}`.
   Flipping that repository variable moves the merge-blocking validation path
   onto GitHub-hosted runners without a workflow merge — which would itself
-  need the down fleet. It is a manual lever, not a dispatcher; automated
-  hosted fallback is tracked separately. Publish, build, and postgres jobs
-  stay on the self-hosted label and queue instead. actionlint does not
-  validate labels inside expressions, so the allowlist in
-  `.github/actionlint.yaml` is unaffected. The variable selects only the
-  runner: on `pull_request_target` events the Turbo shim stays off (see
-  Hosted Turbo cache), so fallback PR validation builds cold while
-  merge-group fallback runs stay warm — the merge queue, not PR validation,
-  is the gate that decides what lands.
+  need the down fleet. Both files must carry it because `Required CI`
+  aggregates jobs from both; a lever that moved only the test suite would
+  leave the aggregator blocked on queued dry-run jobs. It is a manual
+  lever, not a dispatcher; automated hosted fallback is tracked separately.
+  The release publish path, standalone build, and postgres jobs stay on the
+  self-hosted label and queue instead. actionlint does not validate labels
+  inside expressions, so the allowlist in `.github/actionlint.yaml` is
+  unaffected. The variable selects only the runner: on `pull_request_target`
+  events both main-scoped cache write paths stay closed — the Turbo shim
+  refuses the event and the pnpm-store `actions/cache` step is skipped (see
+  Hosted Turbo cache) — so fallback PR validation builds and installs cold
+  while merge-group fallback runs stay warm. The merge queue, not PR
+  validation, is the gate that decides what lands.
 
 The PR caller uses `pull_request_target`, so GitHub loads runner selection from
 the trusted base branch rather than contributor-controlled merge YAML. It passes
@@ -94,7 +98,10 @@ refuses `pull_request_target` events — those runs carry main's cache write
 scope while executing PR-head code, so the shim there would hand unreviewed
 code a write path into entries every other run restores — and it sets
 `continue-on-error` so a shim that fails to start degrades the job to a cold
-build instead of failing it.
+build instead of failing it. The pnpm-store `actions/cache` step in the same
+action is skipped on `pull_request_target` for the same write-scope reason:
+`pnpm install` runs PR-head lifecycle scripts, and the saved store would be
+a main-scoped entry trusted runs restore.
 
 Two properties of this pool differ from the internal server and matter for
 trust in it. Entries are immutable: a save against an existing `turbogha_`

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -50,7 +50,11 @@ never prevent the tests from running.
   hosted fallback is tracked separately. Publish, build, and postgres jobs
   stay on the self-hosted label and queue instead. actionlint does not
   validate labels inside expressions, so the allowlist in
-  `.github/actionlint.yaml` is unaffected.
+  `.github/actionlint.yaml` is unaffected. The variable selects only the
+  runner: on `pull_request_target` events the Turbo shim stays off (see
+  Hosted Turbo cache), so fallback PR validation builds cold while
+  merge-group fallback runs stay warm — the merge queue, not PR validation,
+  is the gate that decides what lands.
 
 The PR caller uses `pull_request_target`, so GitHub loads runner selection from
 the trusted base branch rather than contributor-controlled merge YAML. It passes
@@ -85,7 +89,25 @@ variables are runner process env, which the `env` context in a step `if:`
 cannot see. Self-hosted pods therefore never start the shim and keep the
 internal server. The `turbo-cache-shim` input (`auto`/`on`/`off`) is the
 per-call kill switch; `on` is debug-only because the shim's `GITHUB_ENV`
-exports would shadow the pod-injected internal cache env.
+exports would shadow the pod-injected internal cache env. The step also
+refuses `pull_request_target` events — those runs carry main's cache write
+scope while executing PR-head code, so the shim there would hand unreviewed
+code a write path into entries every other run restores — and it sets
+`continue-on-error` so a shim that fails to start degrades the job to a cold
+build instead of failing it.
+
+Two properties of this pool differ from the internal server and matter for
+trust in it. Entries are immutable: a save against an existing `turbogha_`
+key fails, so the first write for a task hash wins until the entry expires
+or is pruned. And Turbo only re-executes when a hashed input changes: a main
+commit that changes a helper script outside a task's declared inputs keeps
+the old hash, so the stale entry keeps winning — forcing the seed would not
+replace it. The exposure is bounded (it requires a helper-only change, the
+lane is emergency-only, and idle entries expire in seven days), and the
+remediation is pruning `turbogha_` entries when activating the fallback
+after a suspect change, not forcing builds. The durable fix for a recurring
+case is declaring the helper in the task's `inputs` in `turbo.json`, which
+benefits the internal cache equally.
 
 GitHub Actions cache is branch-scoped: runs restore only entries written by
 their own branch or by main. PR and merge-group runs cannot warm each other,

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -33,6 +33,16 @@ inputs:
     required: false
     default: ''
 
+  turbo-cache-shim:
+    description: >-
+      Turborepo remote-cache shim backed by GitHub Actions cache. 'auto'
+      enables it only on GitHub-hosted runners; self-hosted pods receive the
+      internal Turbo cache server env from iac and must not have it shadowed.
+      'on' forces the shim everywhere (debug only: its GITHUB_ENV exports
+      override pod-injected process env). 'off' disables it everywhere.
+    required: false
+    default: 'auto'
+
 outputs:
   pnpm-cache-hit:
     description: 'Whether pnpm cache was hit'
@@ -224,6 +234,22 @@ runs:
         key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
           ${{ runner.os }}-playwright-
+
+    # Hosted-runner counterpart of the pod-injected internal Turbo cache.
+    # Self-hosted pods get TURBO_API/TURBO_TOKEN/TURBO_TEAM as runner process
+    # env from iac; process env is invisible to the `env` context in step
+    # `if:`, so the discriminator is runner.environment, which never matches
+    # on those pods and leaves the internal cache untouched. On hosted
+    # runners the shim starts a localhost server speaking the Vercel
+    # remote-cache API over GitHub Actions cache entries (key prefix
+    # turbogha_) and exports the TURBO_* env itself. Turbo treats a failing
+    # remote cache as a warning and builds cold, so this step can degrade a
+    # job but never fail it.
+    - name: Setup Turbo cache shim (GitHub-hosted runners)
+      if: >-
+        inputs.turbo-cache-shim != 'off' &&
+        (inputs.turbo-cache-shim == 'on' || runner.environment == 'github-hosted')
+      uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
 
     # Check if ONNX deps are already installed or supplied by the runner image.
     - name: Install system dependencies for ONNX Runtime

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -242,13 +242,25 @@ runs:
     # on those pods and leaves the internal cache untouched. On hosted
     # runners the shim starts a localhost server speaking the Vercel
     # remote-cache API over GitHub Actions cache entries (key prefix
-    # turbogha_) and exports the TURBO_* env itself. Turbo treats a failing
-    # remote cache as a warning and builds cold, so this step can degrade a
-    # job but never fail it.
+    # turbogha_) and exports the TURBO_* env itself.
+    #
+    # pull_request_target is excluded: those runs use the base branch's cache
+    # write scope (main) while executing PR-head code, so enabling the shim
+    # there would let an unreviewed PR write task artifacts every other run
+    # restores. Hosted PR validation therefore builds cold; merge-group and
+    # main-push hosted runs keep the shim (their writes land in their own
+    # branch scope and only reads come from main).
+    #
+    # continue-on-error: if the shim fails to start (port in use, slow VM),
+    # no TURBO_* is exported and turbo simply builds cold — the step must
+    # degrade the job, never fail it, because the hosted lane exists for
+    # fleet-down emergencies.
     - name: Setup Turbo cache shim (GitHub-hosted runners)
       if: >-
         inputs.turbo-cache-shim != 'off' &&
+        github.event_name != 'pull_request_target' &&
         (inputs.turbo-cache-shim == 'on' || runner.environment == 'github-hosted')
+      continue-on-error: true
       uses: rharkor/caching-for-turbo@2238fae6eb9a9936f92356f54cb3660200d105e7 # v2.5.1
 
     # Check if ONNX deps are already installed or supplied by the runner image.

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -215,9 +215,16 @@ runs:
       run: |
         echo "path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
+    # pull_request_target is excluded for the same reason as the Turbo shim
+    # below: those runs carry main's cache write scope while pnpm install
+    # executes PR-head lifecycle scripts, so saving the store there would
+    # give unreviewed code a main-scoped entry that trusted runs restore.
+    # Hosted fallback PR jobs install cold instead.
     - name: Setup pnpm cache
       id: pnpm-cache
-      if: steps.pnpm-store-strategy.outputs.use-actions-cache == 'true'
+      if: >-
+        steps.pnpm-store-strategy.outputs.use-actions-cache == 'true' &&
+        github.event_name != 'pull_request_target'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
       with:
         path: ${{ steps.pnpm-store.outputs.path }}

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -22,7 +22,12 @@ permissions:
 jobs:
   prepare-publish:
     name: Prepare Publish Validation
-    runs-on: arc-happyvertical
+    # Emergency lane selector: publish dry run backs the required aggregator,
+    # so it must move with the CI_HOSTED_FALLBACK_ENABLED lever or a fleet
+    # outage would keep Required CI blocked despite the fallback. See the
+    # selector comment in test-suite.yml and the Hosted Turbo cache section
+    # of CI.md.
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     timeout-minutes: 45
     outputs:
       should-validate: ${{ steps.prepare.outputs.should_validate }}
@@ -142,7 +147,7 @@ jobs:
   validate-publish-shards:
     needs: prepare-publish
     if: needs.prepare-publish.outputs.should-validate == 'true'
-    runs-on: arc-happyvertical
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -209,7 +214,7 @@ jobs:
       - prepare-publish
       - validate-publish-shards
     if: always()
-    runs-on: arc-happyvertical
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -22,7 +22,17 @@ jobs:
   affected-scope:
     name: Detect Affected Validation Scope
     if: inputs.mode == 'affected'
-    runs-on: arc-happyvertical
+    # Emergency lane selector, used on every self-hosted job in this file:
+    # flipping the repository variable CI_HOSTED_FALLBACK_ENABLED to 'true'
+    # moves validation to GitHub-hosted runners without a workflow merge —
+    # which would itself need the down fleet. Automated dispatch is a later
+    # issue; this is the manual lever. Repository variables are owner
+    # controlled, so pull_request_target trust is unchanged. Hosted runs are
+    # slower (4-core) but the Turbo cache shim in setup-environment restores
+    # build/generate:test/typecheck seeded from main by turbo-cache-seed.yml,
+    # keeping them inside the 90-minute ceilings. Rehearse before relying on
+    # it; see the Hosted Turbo cache section of CI.md.
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     timeout-minutes: 90
     outputs:
       knowledge: ${{ steps.filter.outputs.knowledge }}
@@ -52,7 +62,7 @@ jobs:
   build:
     name: Build
     if: inputs.mode == 'full'
-    runs-on: arc-happyvertical
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     timeout-minutes: 90
 
     steps:
@@ -132,7 +142,7 @@ jobs:
     name: Typecheck
     needs: build
     if: inputs.mode == 'full'
-    runs-on: arc-happyvertical
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     timeout-minutes: 90
 
     steps:
@@ -161,7 +171,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: arc-happyvertical
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     timeout-minutes: 90
 
     steps:
@@ -182,7 +192,7 @@ jobs:
     name: Affected Build, Typecheck, and Tests
     needs: affected-scope
     if: inputs.mode == 'affected'
-    runs-on: arc-happyvertical
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     timeout-minutes: 90
     steps:
       - name: Checkout repository
@@ -216,7 +226,7 @@ jobs:
     name: Affected Knowledge Freshness
     needs: affected-scope
     if: inputs.mode == 'affected' && needs.affected-scope.outputs.knowledge == 'true'
-    runs-on: arc-happyvertical
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     timeout-minutes: 90
     steps:
       - name: Checkout repository
@@ -247,7 +257,7 @@ jobs:
     name: Knowledge Freshness
     needs: build
     if: inputs.mode == 'full'
-    runs-on: arc-happyvertical
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     timeout-minutes: 90
 
     steps:
@@ -288,7 +298,7 @@ jobs:
     name: Coverage Gate
     needs: build
     if: always() && (inputs.mode == 'affected' || needs.build.result == 'success')
-    runs-on: arc-happyvertical
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     timeout-minutes: 90
 
     steps:
@@ -350,7 +360,7 @@ jobs:
   test-core:
     needs: build
     if: inputs.mode == 'full'
-    runs-on: arc-happyvertical
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     # A remote-cache outage can add several minutes of cold setup and build
     # time, so this shard stays on the standard ceiling rather than a tighter
     # one; cache misses must not cancel an otherwise healthy core suite.
@@ -407,7 +417,7 @@ jobs:
     name: Test Integration
     needs: build
     if: inputs.mode == 'full'
-    runs-on: arc-happyvertical
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     timeout-minutes: 90
 
     steps:
@@ -443,7 +453,7 @@ jobs:
   test-packages:
     needs: build
     if: inputs.mode == 'full'
-    runs-on: arc-happyvertical
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     # Each shard runs ~1/3 of package tests and lets Turbo build only their
     # dependency closures. Runner-pool contention still applies, so this keeps
     # the standard ceiling rather than a shard-specific one.
@@ -541,7 +551,7 @@ jobs:
   test-packages-result:
     name: Test Packages
     needs: test-packages
-    runs-on: arc-happyvertical
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     if: always() && inputs.mode == 'full'
     timeout-minutes: 90
     steps:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -26,12 +26,13 @@ jobs:
     # flipping the repository variable CI_HOSTED_FALLBACK_ENABLED to 'true'
     # moves validation to GitHub-hosted runners without a workflow merge —
     # which would itself need the down fleet. Automated dispatch is a later
-    # issue; this is the manual lever. Repository variables are owner
-    # controlled, so pull_request_target trust is unchanged. Hosted runs are
-    # slower (4-core) but the Turbo cache shim in setup-environment restores
-    # build/generate:test/typecheck seeded from main by turbo-cache-seed.yml,
-    # keeping them inside the 90-minute ceilings. Rehearse before relying on
-    # it; see the Hosted Turbo cache section of CI.md.
+    # issue; this is the manual lever. The variable is owner controlled and
+    # selects only the runner; the Turbo cache shim in setup-environment
+    # additionally refuses pull_request_target events, so PR-head code never
+    # writes the main-scoped hosted cache pool. Fallback PR validation
+    # therefore builds cold, while merge-group and main runs restore
+    # build/generate:test/typecheck seeded by turbo-cache-seed.yml. Rehearse
+    # before relying on it; see the Hosted Turbo cache section of CI.md.
     runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical' }}
     timeout-minutes: 90
     outputs:

--- a/.github/workflows/turbo-cache-seed.yml
+++ b/.github/workflows/turbo-cache-seed.yml
@@ -1,0 +1,93 @@
+name: Turbo Cache Seed
+
+# Keeps the GitHub-hosted Turborepo cache pool warm so hosted runners are a
+# viable fallback lane when the self-hosted fleet is saturated or down. The
+# pool is GitHub Actions cache entries (key prefix turbogha_) written through
+# the caching-for-turbo shim in setup-environment; the self-hosted lanes use
+# the internal Turbo cache server instead and never read or write this pool.
+#
+# GitHub Actions cache is branch-scoped: a run can only restore entries
+# written by its own branch or by main, so PR and merge-group runs cannot
+# warm each other. Entries seeded from main are the only cross-branch
+# warmth, which is why this workflow exists.
+#
+# Standalone on purpose: on-merge-main.yml gates its build and test jobs off
+# while CI_MERGE_QUEUE_ENABLED is true, so a seed job added there would
+# never run.
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Backstop against GitHub's 7-day idle eviction during quiet weeks.
+    # Offset from the postgres-tests schedule (08:00) and the mobile
+    # nightly (09:17).
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+permissions:
+  contents: read
+  packages: read
+  # For the cache-usage report step only; cache save/restore inside the job
+  # uses the Actions runtime token and needs no permission grant.
+  actions: read
+
+# Spelled out because the string shorthand silently defaults
+# cancel-in-progress to false. Cancelling is correct here: a newer main
+# commit's task hashes supersede an in-flight seed's anyway.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  seed:
+    name: Seed Hosted Turbo Cache
+    # Dispatch bypasses the variable so the lane can be validated before it
+    # is enabled, mirroring postgres-tests.yml.
+    if: github.event_name == 'workflow_dispatch' || vars.CI_HOSTED_TURBO_CACHE_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    # Hosted job: the value tracks observed runtime rather than the
+    # self-hosted queue-wait standard. 45 covers a fully cold build;
+    # tighten after ten runs.
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+        with:
+          setup-playwright: 'false'
+          # 'auto' already resolves to on for hosted runners; explicit so a
+          # grep for the shim finds its one deliberate consumer.
+          turbo-cache-shim: 'auto'
+
+      # No TURBO_FORCE: unlike the publish builds, this lane exists to reuse
+      # and refresh cached results, so trusting restored outputs for
+      # unchanged packages is correct and keeps incremental seeds cheap.
+      - name: Seed build outputs
+        shell: bash
+        run: pnpm run build
+
+      # typecheck depends on build and generate:test, so this single
+      # invocation seeds the remaining task types that test-suite.yml
+      # restores. The test tasks themselves are environment-sensitive and
+      # deliberately not seeded.
+      - name: Seed typecheck and test manifests
+        shell: bash
+        run: pnpm turbo run typecheck
+
+      # Cheap observability: the turbogha_ pool shares the repository's
+      # 10 GiB Actions cache quota with mobile.yml's Gradle entries under
+      # LRU eviction. Watch this before trusting the fallback lane.
+      - name: Report Actions cache usage
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/actions/cache/usage"
+          echo
+          gh cache list --key turbogha_ --limit 20 --sort size_in_bytes --order desc || true

--- a/.github/workflows/turbo-cache-seed.yml
+++ b/.github/workflows/turbo-cache-seed.yml
@@ -60,6 +60,12 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           setup-playwright: 'false'
+          # Auth matches the sibling self-hosted call sites. The lockfile
+          # currently resolves entirely from public npmjs, but passing the
+          # token keeps the seed robust if GitHub Packages dependencies
+          # return.
+          registry-url: 'https://npm.pkg.github.com'
+          auth-token: ${{ secrets.GITHUB_TOKEN }}
           # 'auto' already resolves to on for hosted runners; explicit so a
           # grep for the shim finds its one deliberate consumer.
           turbo-cache-shim: 'auto'

--- a/.github/workflows/turbo-cache-seed.yml
+++ b/.github/workflows/turbo-cache-seed.yml
@@ -64,9 +64,14 @@ jobs:
           # grep for the shim finds its one deliberate consumer.
           turbo-cache-shim: 'auto'
 
-      # No TURBO_FORCE: unlike the publish builds, this lane exists to reuse
-      # and refresh cached results, so trusting restored outputs for
-      # unchanged packages is correct and keeps incremental seeds cheap.
+      # No TURBO_FORCE: this lane exists to reuse and refresh cached results,
+      # so trusting restored outputs for unchanged packages is correct and
+      # keeps incremental seeds cheap. Forcing would not harden anything
+      # either: GitHub Actions cache entries are immutable — a save for an
+      # existing turbogha_ key fails, first write wins per task hash — so a
+      # forced re-execution cannot replace an entry whose inputs Turbo did
+      # not hash (see the stale-helper caveat in CI.md's Hosted Turbo cache
+      # section; the remediation there is pruning, not forcing).
       - name: Seed build outputs
         shell: bash
         run: pnpm run build
@@ -88,6 +93,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api "repos/${GITHUB_REPOSITORY}/actions/cache/usage"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/cache/usage" || true
           echo
           gh cache list --key turbogha_ --limit 20 --sort size_in_bytes --order desc || true


### PR DESCRIPTION
## Summary

GitHub-hosted runners could not reach the internal Turbo cache, so every hosted build ran cold (~35 min vs ~3 warm, measured on #2215's merge groups). This gives hosted runners their own warm cache and makes them a usable emergency lane — smrt is public, so the lane costs nothing:

- **Shim** — `setup-environment` gains a `turbo-cache-shim: auto|on|off` input; on GitHub-hosted runners it starts `rharkor/caching-for-turbo` (SHA-pinned v2.5.1), a localhost Vercel-API server storing per-task-hash entries in GitHub Actions cache under `turbogha_`. Self-hosted pods keep the iac-injected internal cache untouched (`runner.environment` gate — pod env is process env the `env` context cannot see). `continue-on-error` + Turbo's warn-on-cache-failure mean the shim can degrade a job but never fail it.
- **Seed** — `turbo-cache-seed.yml` (push to main + daily cron + dispatch, gated on `CI_HOSTED_TURBO_CACHE_ENABLED` with dispatch bypass, mirroring the PostgreSQL lane) seeds `build` and `typecheck` (pulling `generate:test`) — the exact task types `test-suite.yml` restores. GitHub cache is branch-scoped, so main-seeded entries are the only cross-PR warmth. Standalone because `on-merge-main.yml` gates its jobs off under `CI_MERGE_QUEUE_ENABLED`.
- **Lever** — every self-hosted job in `test-suite.yml` **and** `publish-dry-run.yml` (Required CI aggregates from both) selects its runner via `vars.CI_HOSTED_FALLBACK_ENABLED`. Flipping one repo variable moves the merge-blocking path to `ubuntu-latest` without a workflow merge. Automated dispatch (broker capacity oracle) is a separate later issue.

## Security posture

`pull_request_target` runs carry main's cache write scope while executing PR-head code, so both main-scoped write paths are closed there: the shim refuses the event and the pnpm-store `actions/cache` step is skipped. Fallback PR validation builds and installs cold; merge-group fallback runs stay warm (their writes land in the isolated queue-branch scope). GitHub cache entries are immutable (first write wins per task hash) — the stale-helper caveat and prune remediation are documented in CI.md.

## Sequencing

Land **after** #2215 (same `runs-on` lines in `test-suite.yml` + CI.md sections). This PR is written against current main labels; if #2215 merges first, the lever lines rebase mechanically onto `arc-happyvertical-nodocker`.

## Validation

- `actionlint` clean on all changed workflows; `yamllint` pre-existing warnings only (composite action linted manually — it sits outside every automated glob)
- `scripts/publish-workflow-policy.test.mjs` green; knowledge freshness green
- Shim pin verified: tag v2.5.1 == `2238fae`; save/restore semantics verified against pinned source (immutable keys, localhost-only bind, cleanup S3-only)
- Review: claude correctness lens (2 material findings round 1, 1 residual round 2 — all fixed, final pass clean) + codex gpt-5.6-sol xhigh (round 1 P2 dispositioned via source verification, round 2 P1 fixed, round 3 clean)

Post-merge proof sequence (documented in CI.md): dispatch the seed twice (cold → warm, expect FULL TURBO), enable `CI_HOSTED_TURBO_CACHE_ENABLED`, then rehearse the lever on a scratch PR in a quiet window before relying on it.

Closes #2218

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"67f1e3e5-cdcc-435f-88d7-babb2801e252","issue":"2218","policy_revision":"1.0.0","validation":["actionlint clean on test-suite.yml publish-dry-run.yml turbo-cache-seed.yml","yamllint: pre-existing warnings only incl. composite action","publish-workflow-policy test green","knowledge check fresh","review: claude lens + codex, 3 rounds, final clean"]}
```
