### PR TITLE
perf(vitest): disable fsync durability on file-backed SQLite test databases

### DIFF
--- a/packages/vitest/AGENTS.md
+++ b/packages/vitest/AGENTS.md
@@ -79,16 +79,17 @@ build, and every test still receives its own database file and transaction.
 Existing non-empty database files are never replaced. PostgreSQL, DuckDB, JSON,
 remote libSQL, and in-memory SQLite retain their normal preparation paths.
 
-The setup file also strips durability from local file-backed SQLite handles
+Local file-backed SQLite test databases also run without durability
 (`synchronous=OFF`, `journal_mode=MEMORY`, `temp_store=MEMORY`, #2221): test
 databases are throwaway, and SQLite's default 2-3 fsyncs per transaction
 turned fsync-heavy suites into 60s-timeout failures on CI runners with slow
-disks (9.5 ms/fsync measured on the metal fleet). Applied best-effort at
-every `getDatabase` return path, once per handle; other engines and the
-explicit opt-out paths (`__smrtSkipVitestSchemaPreparation`,
-`SMRT_VITEST_AUTO_SCHEMA=0`) are untouched. Do not "fix" a durability-shaped
-test by removing this — a test that needs real fsync semantics should create
-its own database with `__smrtSkipVitestSchemaPreparation`.
+disks (9.5 ms/fsync measured on the metal fleet). Applied best-effort, once
+per handle, in two places: the setup file's `getDatabase` mock and the
+isolated test-db factories (whose internal schema-preparation skip bypasses
+the mock). Other engines are untouched. Do not "fix" a durability-shaped
+test by removing this — a test that needs real fsync semantics should open
+its database with `getDatabase` + `__smrtSkipVitestSchemaPreparation`
+directly, which stays fully vanilla.
 
 ```typescript
 let db, cleanup;

--- a/packages/vitest/AGENTS.md
+++ b/packages/vitest/AGENTS.md
@@ -79,6 +79,17 @@ build, and every test still receives its own database file and transaction.
 Existing non-empty database files are never replaced. PostgreSQL, DuckDB, JSON,
 remote libSQL, and in-memory SQLite retain their normal preparation paths.
 
+The setup file also strips durability from local file-backed SQLite handles
+(`synchronous=OFF`, `journal_mode=MEMORY`, `temp_store=MEMORY`, #2221): test
+databases are throwaway, and SQLite's default 2-3 fsyncs per transaction
+turned fsync-heavy suites into 60s-timeout failures on CI runners with slow
+disks (9.5 ms/fsync measured on the metal fleet). Applied best-effort at
+every `getDatabase` return path, once per handle; other engines and the
+explicit opt-out paths (`__smrtSkipVitestSchemaPreparation`,
+`SMRT_VITEST_AUTO_SCHEMA=0`) are untouched. Do not "fix" a durability-shaped
+test by removing this — a test that needs real fsync semantics should create
+its own database with `__smrtSkipVitestSchemaPreparation`.
+
 ```typescript
 let db, cleanup;
 beforeEach(async () => {

--- a/packages/vitest/src/__tests__/issue-2221-sqlite-speed-pragmas.test.ts
+++ b/packages/vitest/src/__tests__/issue-2221-sqlite-speed-pragmas.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression tests for Issue #2221 — file-backed SQLite test databases must
+ * run without fsync durability.
+ *
+ * SQLite's defaults (`synchronous=FULL`, DELETE journal) cost 2-3 fsyncs per
+ * transaction. On CI runners with slow fsync (9.5 ms/write measured on the
+ * metal fleet) that turned the users package's catalog-seeding tests into
+ * 200-400 s timeouts. Test databases are throwaway, so the setup file strips
+ * durability from local file-backed SQLite handles.
+ */
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getDatabase } from '@happyvertical/sql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { applySqliteSpeedPragmas } from '../setup.js';
+
+const testDir = join(tmpdir(), `smrt-vitest-issue-2221-${Date.now()}`);
+
+async function pragmaValue(
+  db: { query: (sql: string) => Promise<unknown> },
+  pragma: string,
+): Promise<unknown> {
+  // The sql adapter returns pg-style results: { rows: [{ <pragma>: value }] }.
+  const result = (await db.query(`PRAGMA ${pragma}`)) as {
+    rows?: Array<Record<string, unknown>>;
+  };
+  const row = result?.rows?.[0];
+  return row ? Object.values(row)[0] : undefined;
+}
+
+describe('Issue #2221 - SQLite speed pragmas', () => {
+  beforeAll(() => {
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterAll(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('disables durability on a local file-backed SQLite database', async () => {
+    const url = join(testDir, 'speed-pragmas.db');
+    const options = { type: 'sqlite' as const, url };
+    const db = (await getDatabase(options)) as unknown as {
+      query: (sql: string) => Promise<unknown>;
+    };
+
+    await applySqliteSpeedPragmas(db, options);
+
+    // synchronous: 0 = OFF; journal_mode reports the active mode string.
+    expect(Number(await pragmaValue(db, 'synchronous'))).toBe(0);
+    expect(String(await pragmaValue(db, 'journal_mode')).toLowerCase()).toBe(
+      'memory',
+    );
+    // The database still works after the pragmas.
+    await db.query('CREATE TABLE IF NOT EXISTS t (id INTEGER PRIMARY KEY)');
+    await db.query('INSERT INTO t DEFAULT VALUES');
+    const count = (await db.query('SELECT COUNT(*) AS n FROM t')) as {
+      rows?: Array<{ n: number | bigint }>;
+    };
+    expect(Number(count.rows?.[0]?.n)).toBe(1);
+  });
+
+  it('leaves in-memory SQLite untouched (no file, no fsync to save)', async () => {
+    const options = { type: 'sqlite' as const, url: ':memory:' };
+    const db = (await getDatabase(options)) as unknown as {
+      query: (sql: string) => Promise<unknown>;
+    };
+
+    const before = Number(await pragmaValue(db, 'synchronous'));
+    await applySqliteSpeedPragmas(db, options);
+    expect(Number(await pragmaValue(db, 'synchronous'))).toBe(before);
+  });
+
+  it('never throws for a handle without a query method', async () => {
+    await expect(
+      applySqliteSpeedPragmas({}, {
+        type: 'sqlite',
+        url: join(testDir, 'no-query.db'),
+      } as Parameters<typeof applySqliteSpeedPragmas>[1]),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/vitest/src/__tests__/issue-2221-sqlite-speed-pragmas.test.ts
+++ b/packages/vitest/src/__tests__/issue-2221-sqlite-speed-pragmas.test.ts
@@ -14,7 +14,7 @@ import { join } from 'node:path';
 import { getDatabase } from '@happyvertical/sql';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { applySqliteSpeedPragmas } from '../setup.js';
+import { applySqliteSpeedPragmas } from '../sqlite-schema-template.js';
 
 const testDir = join(tmpdir(), `smrt-vitest-issue-2221-${Date.now()}`);
 

--- a/packages/vitest/src/setup.ts
+++ b/packages/vitest/src/setup.ts
@@ -62,6 +62,55 @@ interface SmrtCoreSchemaModule {
 
 const preparedSchemasByDb = new WeakMap<object, string>();
 const preparedSchemasByConfig = new Map<string, string>();
+const speedPragmasApplied = new WeakSet<object>();
+
+/**
+ * Strip durability from local file-backed SQLite test databases.
+ *
+ * Test databases are created fresh per test and discarded afterwards, so
+ * crash durability buys nothing — but SQLite's defaults (`synchronous=FULL`,
+ * DELETE journal) cost 2-3 fsyncs per transaction. On runners with slow
+ * fsync that dominates wall time: 9.5 ms/fsync measured on the metal CI
+ * fleet turned the users package's catalog-seeding tests (~41k fsyncs) into
+ * 200-400 s timeouts (#2221). `synchronous=OFF` removes fsync entirely,
+ * `journal_mode=MEMORY` removes journal-file I/O (per-connection, safe for
+ * the single-connection chains test databases use), and `temp_store=MEMORY`
+ * keeps sort/temp b-trees off disk.
+ *
+ * Only file-backed local SQLite is touched: PostgreSQL and DuckDB reject
+ * these pragmas, in-memory SQLite never fsyncs, and a thrown pragma must
+ * never fail a test, so everything is guarded and best-effort.
+ *
+ * @internal exported for regression testing only (#2221)
+ */
+export async function applySqliteSpeedPragmas(
+  db: unknown,
+  options: VitestDatabaseOptions,
+): Promise<void> {
+  if (!db || typeof db !== 'object' || speedPragmasApplied.has(db)) {
+    return;
+  }
+  const isConfigObject =
+    options && typeof options === 'object' && !('query' in options);
+  if (
+    !isConfigObject ||
+    !getLocalSqliteFilePath(options as { type?: string; url?: string })
+  ) {
+    return;
+  }
+  const query = (db as { query?: (sql: string) => Promise<unknown> }).query;
+  if (typeof query !== 'function') {
+    return;
+  }
+  speedPragmasApplied.add(db);
+  try {
+    await query.call(db, 'PRAGMA synchronous = OFF');
+    await query.call(db, 'PRAGMA journal_mode = MEMORY');
+    await query.call(db, 'PRAGMA temp_store = MEMORY');
+  } catch {
+    // Best-effort: an adapter that rejects pragmas keeps its defaults.
+  }
+}
 
 function findWorkspaceRoot(startDir: string): string | null {
   let current = startDir;
@@ -270,15 +319,20 @@ vi.mock('@happyvertical/sql', async () => {
           );
         }
       } catch {
-        return db ?? actual.getDatabase(options);
+        const fallbackDb = db ?? (await actual.getDatabase(options));
+        await applySqliteSpeedPragmas(fallbackDb, options);
+        return fallbackDb;
       }
 
       const schemaSql = schemaSqlBatches.filter(Boolean).join('\n-- smrt --\n');
       if (!schemaSql) {
-        return db ?? actual.getDatabase(options);
+        const bareDb = db ?? (await actual.getDatabase(options));
+        await applySqliteSpeedPragmas(bareDb, options);
+        return bareDb;
       }
 
       if (db && preparedSchemasByDb.get(db as object) === schemaSql) {
+        await applySqliteSpeedPragmas(db, options);
         return db;
       }
 
@@ -289,12 +343,14 @@ vi.mock('@happyvertical/sql', async () => {
       ) {
         db ??= await actual.getDatabase(options);
         preparedSchemasByDb.set(db as object, schemaSql);
+        await applySqliteSpeedPragmas(db, options);
         return db;
       }
 
       const prepareSchema = async (
         database: Awaited<ReturnType<typeof actual.getDatabase>>,
       ): Promise<void> => {
+        await applySqliteSpeedPragmas(database, options);
         for (const schemaBatch of schemaSqlBatches) {
           if (!schemaBatch) {
             continue;
@@ -323,6 +379,10 @@ vi.mock('@happyvertical/sql', async () => {
         preparedSchemasByConfig.set(preparationKey, schemaSql);
       }
 
+      // Template-cloned databases arrive on a fresh connection that never
+      // passed through prepareSchema, so the pragmas are (re)applied here;
+      // the WeakSet makes this a no-op for connections already configured.
+      await applySqliteSpeedPragmas(db, options);
       return db;
     },
   };

--- a/packages/vitest/src/setup.ts
+++ b/packages/vitest/src/setup.ts
@@ -24,6 +24,7 @@ import { dirname, join } from 'node:path';
 import type { SchemaDefinition } from '@happyvertical/smrt-core';
 import { afterAll, beforeAll, vi } from 'vitest';
 import {
+  applySqliteSpeedPragmas,
   getDatabaseFromSqliteSchemaTemplate,
   getLocalSqliteFilePath,
 } from './sqlite-schema-template.js';
@@ -62,55 +63,9 @@ interface SmrtCoreSchemaModule {
 
 const preparedSchemasByDb = new WeakMap<object, string>();
 const preparedSchemasByConfig = new Map<string, string>();
-const speedPragmasApplied = new WeakSet<object>();
-
-/**
- * Strip durability from local file-backed SQLite test databases.
- *
- * Test databases are created fresh per test and discarded afterwards, so
- * crash durability buys nothing — but SQLite's defaults (`synchronous=FULL`,
- * DELETE journal) cost 2-3 fsyncs per transaction. On runners with slow
- * fsync that dominates wall time: 9.5 ms/fsync measured on the metal CI
- * fleet turned the users package's catalog-seeding tests (~41k fsyncs) into
- * 200-400 s timeouts (#2221). `synchronous=OFF` removes fsync entirely,
- * `journal_mode=MEMORY` removes journal-file I/O (per-connection, safe for
- * the single-connection chains test databases use), and `temp_store=MEMORY`
- * keeps sort/temp b-trees off disk.
- *
- * Only file-backed local SQLite is touched: PostgreSQL and DuckDB reject
- * these pragmas, in-memory SQLite never fsyncs, and a thrown pragma must
- * never fail a test, so everything is guarded and best-effort.
- *
- * @internal exported for regression testing only (#2221)
- */
-export async function applySqliteSpeedPragmas(
-  db: unknown,
-  options: VitestDatabaseOptions,
-): Promise<void> {
-  if (!db || typeof db !== 'object' || speedPragmasApplied.has(db)) {
-    return;
-  }
-  const isConfigObject =
-    options && typeof options === 'object' && !('query' in options);
-  if (
-    !isConfigObject ||
-    !getLocalSqliteFilePath(options as { type?: string; url?: string })
-  ) {
-    return;
-  }
-  const query = (db as { query?: (sql: string) => Promise<unknown> }).query;
-  if (typeof query !== 'function') {
-    return;
-  }
-  speedPragmasApplied.add(db);
-  try {
-    await query.call(db, 'PRAGMA synchronous = OFF');
-    await query.call(db, 'PRAGMA journal_mode = MEMORY');
-    await query.call(db, 'PRAGMA temp_store = MEMORY');
-  } catch {
-    // Best-effort: an adapter that rejects pragmas keeps its defaults.
-  }
-}
+// applySqliteSpeedPragmas (#2221) lives in sqlite-schema-template.ts so the
+// isolated test-db factories can share it without importing this setup
+// file's vi.mock/beforeAll side effects.
 
 function findWorkspaceRoot(startDir: string): string | null {
   let current = startDir;

--- a/packages/vitest/src/sqlite-schema-template.ts
+++ b/packages/vitest/src/sqlite-schema-template.ts
@@ -99,6 +99,57 @@ export function getLocalSqliteFilePath(
   return isAbsolute(url) ? url : resolve(url);
 }
 
+const speedPragmasApplied = new WeakSet<object>();
+
+/**
+ * Strip durability from local file-backed SQLite test databases.
+ *
+ * Test databases are created fresh per test and discarded afterwards, so
+ * crash durability buys nothing — but SQLite's defaults (`synchronous=FULL`,
+ * DELETE journal) cost 2-3 fsyncs per transaction. On runners with slow
+ * fsync that dominates wall time: 9.5 ms/fsync measured on the metal CI
+ * fleet turned the users package's catalog-seeding tests (~41k fsyncs) into
+ * 200-400 s timeouts (#2221). `synchronous=OFF` removes fsync entirely,
+ * `journal_mode=MEMORY` removes journal-file I/O (per-connection, safe for
+ * the single-connection chains test databases use), and `temp_store=MEMORY`
+ * keeps sort/temp b-trees off disk.
+ *
+ * Only file-backed local SQLite is touched: PostgreSQL and DuckDB reject
+ * these pragmas, in-memory SQLite never fsyncs, and a thrown pragma must
+ * never fail a test, so everything is guarded and best-effort. Applied by
+ * the setup file's `getDatabase` mock and by the isolated test-db factories;
+ * a test that needs real durability semantics must open its database with
+ * `getDatabase` and `__smrtSkipVitestSchemaPreparation` directly.
+ */
+export async function applySqliteSpeedPragmas(
+  db: unknown,
+  options: { type?: string; url?: string } | undefined,
+): Promise<void> {
+  if (!db || typeof db !== 'object' || speedPragmasApplied.has(db)) {
+    return;
+  }
+  const isConfigObject =
+    options && typeof options === 'object' && !('query' in options);
+  if (!isConfigObject || !getLocalSqliteFilePath(options)) {
+    return;
+  }
+  const query = (db as { query?: (sql: string) => Promise<unknown> }).query;
+  if (typeof query !== 'function') {
+    return;
+  }
+  // Marked before execution on purpose: a handle whose pragmas failed once
+  // (e.g. transient SQLITE_BUSY) stays best-effort-configured rather than
+  // retrying on every getDatabase call.
+  speedPragmasApplied.add(db);
+  try {
+    await query.call(db, 'PRAGMA synchronous = OFF');
+    await query.call(db, 'PRAGMA journal_mode = MEMORY');
+    await query.call(db, 'PRAGMA temp_store = MEMORY');
+  } catch {
+    // Best-effort: an adapter that rejects pragmas keeps its defaults.
+  }
+}
+
 /**
  * Open a fresh local SQLite database using an immutable schema-only template.
  *

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -46,7 +46,10 @@ import {
   materializeManifestDDLForEngine,
   tokenizeSQLDDLBody,
 } from '@happyvertical/smrt-core/schema/utils';
-import { getDatabaseFromSqliteSchemaTemplate } from './sqlite-schema-template.js';
+import {
+  applySqliteSpeedPragmas,
+  getDatabaseFromSqliteSchemaTemplate,
+} from './sqlite-schema-template.js';
 import type {
   DatabaseInterfaceWithTransaction,
   TransactionHandle,
@@ -489,6 +492,11 @@ export async function createIsolatedTestDb(
           ...config,
           __smrtSkipVitestSchemaPreparation: true,
         } as VitestDatabaseConnectionOptions)) as DatabaseInterfaceWithTransaction);
+
+  // Isolated test databases are throwaway, so strip fsync durability from
+  // local file-backed SQLite (#2221). The schema-preparation skip above also
+  // bypasses the setup file's pragma application, so it happens here.
+  await applySqliteSpeedPragmas(baseDb, config);
 
   // Sync schema if provided (must be done before transaction for DDL)
   if (schema && config.type !== 'sqlite') {


### PR DESCRIPTION
## Summary

Test databases are throwaway, but file-backed SQLite test DBs ran with full durability — 2-3 fsyncs per transaction. On the metal CI fleet (9.5 ms/fsync measured on metal-782) that turned `packages/users`' catalog-seeding tests (~41k fsyncs) into 200-400 s runs against a 60 s timeout: the direct, measured cause of all three of #2215's merge-queue ejections ([full RCA](https://github.com/happyvertical/smrt/pull/2215#issuecomment-5181099078)).

`applySqliteSpeedPragmas` (in `sqlite-schema-template.ts`, side-effect-free so both consumers share it) applies `synchronous=OFF`, `journal_mode=MEMORY`, `temp_store=MEMORY` to local file-backed SQLite handles — once per handle (WeakSet), best-effort (try/catch), gated on `getLocalSqliteFilePath` so PostgreSQL/DuckDB/JSON/in-memory are untouched. Applied in two places:

- the setup file's `getDatabase` mock, on every return path;
- `createIsolatedTestDb` (covering `createIsolatedTestDbFromManifest`), whose internal `__smrtSkipVitestSchemaPreparation` bypasses the mock — a codex review catch.

Raw `getDatabase` + skip flag stays fully vanilla as the documented durability escape hatch (AGENTS.md).

## Measured

- The two offending users test files: **16.45 s → 3.55 s** of test time on fast NVMe (macOS fsync); on the metal fleet the fsyncs go to zero, ending the 60 s-timeout class entirely.
- Full users suite 448 passed; vitest suite 55 passed incl. a new regression test proving the pragmas engage on file-backed handles, skip `:memory:`, and never throw.

## Validation

- `packages/vitest`: tests + `tsc --noEmit` green; `packages/users`: full suite green (twice, once per revision)
- Biome clean on all touched files; knowledge freshness green
- Review: claude correctness lens (clean r1 with polish; verified both fix revisions clean) + codex gpt-5.6-sol xhigh (r1 material coverage finding — fixed; r2 clean). Residual: template-build DDL still runs with durability once per process (perf-nit, noted by review).

Closes #2221

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"67f1e3e5-cdcc-435f-88d7-babb2801e252","issue":"2221","policy_revision":"1.0.0","validation":["packages/vitest tests + typecheck green","packages/users full suite green","biome clean","knowledge check fresh","review: claude lens + codex, 2 rounds, final clean","measured: offender files 16.45s -> 3.55s tests on NVMe"]}
```
