### PR TITLE
docs(ci): correct the CI_TEST_TMPDIR volume description

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -97,8 +97,8 @@ That volume is **disk-backed, not a tmpfs**. On the metal fleet it is a plain
 node's state disk: 9.5 ms per synced write measured inside a runner Pod on
 `metal-782bcb5e4e67`, 3.8 ms on `pxe-runner`. That latency is why
 `packages/vitest` strips durability from file-backed SQLite test databases
-(#2221) — roughly 41k fsyncs of catalog seeding ran 200-400 s against a 60 s
-timeout before it did.
+(#2221) — before it did, catalog-seeding tests issuing roughly 41k fsyncs
+took 200-400 s each against a 60 s timeout.
 
 Do not "fix" that by making the volume memory-backed. Memory-backed volumes
 were deliberately removed from this Pod shape because they are charged

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -89,8 +89,24 @@ mounts without measuring runner memory and install latency. The shared setup
 action also points `TMPDIR` at the workspace-backed runner temp directory so
 SQLite fixtures and other temporary test files bypass the container overlay
 filesystem. Self-hosted runners can provide `CI_TEST_TMPDIR` to route those
-files to a bounded, test-only tmpfs; other runners retain the workspace-backed
-fallback.
+files to a bounded, test-only scratch volume; other runners retain the
+workspace-backed fallback.
+
+That volume is **disk-backed, not a tmpfs**. On the metal fleet it is a plain
+`emptyDir` with a size limit and no `medium: Memory`, so writes land on the
+node's state disk: 9.5 ms per synced write measured inside a runner Pod on
+`metal-782bcb5e4e67`, 3.8 ms on `pxe-runner`. That latency is why
+`packages/vitest` strips durability from file-backed SQLite test databases
+(#2221) — roughly 41k fsyncs of catalog seeding ran 200-400 s against a 60 s
+timeout before it did.
+
+Do not "fix" that by making the volume memory-backed. Memory-backed volumes
+were deliberately removed from this Pod shape because they are charged
+against the container memory limit, and the runner's current memory figure
+was settled only after a smaller shape measured an 18% merge-queue failure
+rate; the reasoning lives next to the shape in `willgriffin/nixos-config`.
+Making synced writes cheap belongs in the runner image instead
+(happyvertical/iac#1329).
 
 ## Hosted Turbo cache
 


### PR DESCRIPTION
## Summary

`.github/CI.md` described the `CI_TEST_TMPDIR` volume as a "bounded, test-only tmpfs". On the metal fleet it is a plain disk-backed `emptyDir` — `emptyDir: { sizeLimit }` with no `medium: 'Memory'` — so writes land on the node's state disk. Measured inside a live runner Pod: **9.5 ms per synced write** on `metal-782bcb5e4e67`, 3.8 ms on `pxe-runner`.

The inaccuracy is load-bearing, not cosmetic. It invites exactly the "just make it a tmpfs" change that `willgriffin/nixos-config` already evaluated and reversed: memory-backed volumes are charged against the container memory limit, and the runner's current memory figure was settled only after a smaller shape measured an **18% merge-queue failure rate**. I proposed that change during the #2215 investigation on the strength of this sentence, and the nixos-config comment is what corrected it.

The rewrite records the real latency, points at the fsync-durability handling that exists because of it (#2221), and directs the actual fix to the runner image (happyvertical/iac#1329, merged).

## Validation

Docs only. `pnpm smrt dev:knowledge-check` reports no errors; the two `stale-domain-knowledge` warnings it emits are pre-existing on `main` (they name `package.json` changes from the v0.40.51 release bump in `packages/agents` and `packages/secrets`) and are untouched by this change.

Closes #2224

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"67f1e3e5-cdcc-435f-88d7-babb2801e252","issue":"2224","policy_revision":"1.0.0","validation":["pnpm smrt dev:knowledge-check: 0 errors; 2 pre-existing stale-domain-knowledge warnings from the v0.40.51 release bump, unrelated to this docs change","claim verified against measurements taken inside live runner Pods (dd oflag=dsync) and against nixos-config patdown_jit_provider.mjs"]}
```
