### PR TITLE
docs(ci): record the hosted fallback rehearsal results

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -342,6 +342,28 @@ The hosted Turbo cache lane has two independent clearable levers:
 `CI_HOSTED_TURBO_CACHE_ENABLED` stops scheduled and push seeding (entries then
 expire within seven days), and `CI_HOSTED_FALLBACK_ENABLED` returns
 `test-suite.yml` to the self-hosted label. The per-call `turbo-cache-shim:
-'off'` input disables the shim for a single caller. Rehearse the fallback
-lever on a scratch pull request in a quiet window before relying on it, and
-record the observed hosted timings here.
+'off'` input disables the shim for a single caller.
+
+The fallback lever has been rehearsed. With `CI_HOSTED_FALLBACK_ENABLED` set
+to `true`, PR validation re-resolved every job from the self-hosted label to
+`ubuntu-latest` and `Required CI` succeeded in 8.1 minutes of wall clock
+(run `30969467329`):
+
+| job | hosted | ceiling |
+| --- | --- | --- |
+| `publish-dry-run` prepare | 6.0 min | 45 |
+| Coverage Gate | 5.8 min | 90 |
+| `validate-publish-shards` (two) | 1.3 and 1.4 min | 45 |
+| Affected build, typecheck, tests | 1.1 min | 90 |
+| Lint | 0.3 min | 90 |
+
+Nothing approached a ceiling, and these are cold numbers: PR validation runs
+on `pull_request_target`, where the Turbo shim is refused, so no job restored
+from the hosted cache pool.
+
+Two limits on what that rehearsal proves. It exercised the pull-request path
+in `affected` mode, not a `merge_group` run in `full` mode, so the six
+`test-core` and `test-packages` shards remain unmeasured on hosted. And the
+lever is repository-wide: flipping it moves every open pull request, not only
+the one being tested. Re-measure with a full merge-group transit before
+treating hosted as an equivalent lane rather than an emergency one.

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -347,9 +347,9 @@ expire within seven days), and `CI_HOSTED_FALLBACK_ENABLED` returns
 The fallback lever has been rehearsed. With `CI_HOSTED_FALLBACK_ENABLED` set
 to `true`, PR validation re-resolved every job from the self-hosted label to
 `ubuntu-latest` and `Required CI` succeeded in 8.1 minutes of wall clock
-(run `30969467329`):
+([run 30969467329](https://github.com/happyvertical/smrt/actions/runs/30969467329)):
 
-| job | hosted | ceiling |
+| job | hosted | ceiling (`timeout-minutes`) |
 | --- | --- | --- |
 | `publish-dry-run` prepare | 6.0 min | 45 |
 | Coverage Gate | 5.8 min | 90 |


### PR DESCRIPTION
## Summary

CI.md instructed that the hosted fallback lever be rehearsed before anyone relies on it, and that the observed timings be recorded there. The rehearsal has been run; this replaces the instruction with its result.

`CI_HOSTED_FALLBACK_ENABLED` was set to `true`, PR validation was re-run on [run 30969467329](https://github.com/happyvertical/smrt/actions/runs/30969467329), and the variable was returned to `false`. Every job re-resolved from `arc-happyvertical-nodocker` to `labels=ubuntu-latest` and ran on GitHub-hosted runners. **`Required CI` succeeded, 8.1 min wall clock.**

| job | hosted | ceiling |
| --- | --- | --- |
| `publish-dry-run` prepare | 6.0 min | 45 |
| Coverage Gate | 5.8 min | 90 |
| `validate-publish-shards` (two) | 1.3, 1.4 min | 45 |
| Affected build, typecheck, tests | 1.1 min | 90 |
| Lint | 0.3 min | 90 |

This settles the two risks raised in review of #2219: `prepare-publish` used 6 of its 45 minutes, and nothing came near a ceiling. The numbers are also the honest worst case for caching — PR validation runs on `pull_request_target`, where the shim is deliberately refused, so nothing restored from the hosted pool.

## What the rehearsal does not prove

Recorded in the doc alongside the numbers rather than left implicit:

- It exercised the **pull-request path in `affected` mode**, not a `merge_group` run in `full` mode. The six `test-core`/`test-packages` shards are the heavy part of the suite and remain unmeasured on hosted.
- The lever is **repository-wide**. Flipping it moves every open pull request, not only the one under test — worth knowing before reaching for it during an outage.

## Validation

Docs only. `pnpm smrt dev:knowledge-check`: 0 errors. The 10 `stale-domain-knowledge` warnings are pre-existing on `main` — they name `package.json` changes from the v0.40.51/52 release bumps and are untouched here.

Closes #2227

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"67f1e3e5-cdcc-435f-88d7-babb2801e252","issue":"2227","policy_revision":"1.0.0","validation":["pnpm smrt dev:knowledge-check: 0 errors; 10 pre-existing release-bump warnings unrelated to this change","timings transcribed from run 30969467329 job API, labels verified as ubuntu-latest","lever returned to false after the rehearsal"]}
```
