### PR TITLE
feat(mcp): migrate shipped servers to scoped SDK v2

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -281,6 +281,9 @@ jobs:
       - name: Check AGENTS.md instruction chains
         run: node scripts/check-agents-chain.mjs
 
+      - name: Check MCP 2026-07-28 protocol hygiene
+        run: node scripts/check-mcp-protocol-hygiene.mjs
+
       # Fails if any --smrt-* token consumed by smrt-svelte components is never
       # emitted by a theme-delivery path (issue #1431). Node-only, no deps.
       - name: Check smrt-svelte design tokens

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Status legend:
 | [`smrt-app-cli`](./packages/app-cli/README.md) | Preview | Reusable branded application CLI and stdio MCP bridge. |
 | [`smrt-dev-mcp`](./packages/smrt-dev-mcp/README.md) | Stable | Development MCP server and repository knowledge tools. |
 | [`smrt-app-mcp`](./packages/smrt-app-mcp/README.md) | Preview | App-runtime MCP server and transport adapters. |
+| [`smrt-mcp-conformance-fixture`](./packages/mcp-conformance-fixture/README.md) | Internal | Generated Tier-1 MCP 2026-07-28 conformance gate. |
 | [`smrt-bundle-gate`](./packages/bundle-gate/README.md) | Internal | Consumer bundle reachability and size regression gate. |
 
 ### Agents, identity, and operations

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -235,6 +235,12 @@ pre-push:
         them from a Modules table; keep invariants and Gotchas inline. Never add
         nested AGENTS.md files — chains are additive. Run: pnpm check:agents-chain
 
+    mcp-protocol-hygiene:
+      run: node scripts/check-mcp-protocol-hygiene.mjs
+      fail_text: |
+        ❌ Removed MCP protocol features or a monolithic SDK dependency found.
+        Run: pnpm check:mcp-protocol-hygiene
+
     deps-acyclic:
       # DAG guardrail (#1582): the smrt package graph (deps + peers) must stay
       # acyclic. Node-only; `pnpm deps:check` is the deeper source-import variant.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "check:no-smrt-peers": "node scripts/check-no-smrt-peers.mjs",
     "check:package-dag": "node scripts/check-package-dag.mjs",
     "check:mcp-config": "node scripts/check-mcp-config.mjs",
+    "check:mcp-protocol-hygiene": "node scripts/check-mcp-protocol-hygiene.mjs",
+    "test:mcp-conformance": "pnpm --filter @happyvertical/smrt-dev-mcp exec vitest run src/mcp-conformance.spec.ts && pnpm --filter @happyvertical/smrt-app-mcp exec vitest run src/__tests__/mcp-conformance.test.ts && pnpm --filter @happyvertical/smrt-mcp-conformance-fixture test",
     "check:agents-chain": "node scripts/check-agents-chain.mjs",
     "knowledge:check": "tsx scripts/check-knowledge.ts",
     "changeset": "changeset",

--- a/packages/app-cli/package.json
+++ b/packages/app-cli/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@happyvertical/smrt-users": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.25.2"
+    "@modelcontextprotocol/server": "2.0.0"
   },
   "devDependencies": {
     "@happyvertical/smrt-core": "workspace:*",

--- a/packages/app-cli/package.json
+++ b/packages/app-cli/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@happyvertical/smrt-core": "workspace:*",
+    "@modelcontextprotocol/client": "2.0.0",
     "@types/node": "24.13.2",
     "typescript": "5.9.3",
     "vite": "8.1.4",

--- a/packages/app-cli/src/__tests__/bridge.test.ts
+++ b/packages/app-cli/src/__tests__/bridge.test.ts
@@ -1,10 +1,23 @@
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { SMRT_MCP_RESULT_METADATA_KEY as CONTRACT_METADATA_KEY } from '@happyvertical/smrt-users/app-contract';
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 import { describe, expect, it } from 'vitest';
 import {
   formatMcpCallResult,
   SMRT_MCP_RESULT_METADATA_KEY,
   toMcpTransportError,
 } from '../bridge.js';
+
+const packageRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+);
+const repoRoot = resolve(packageRoot, '..', '..');
+const tsxBin = join(repoRoot, 'node_modules', '.bin', 'tsx');
 
 function resultMetadata(result: object): unknown {
   return (result as { _meta?: Record<string, unknown> })._meta?.[
@@ -81,5 +94,74 @@ describe('formatMcpCallResult', () => {
       message: 'Bearer [REDACTED] failed',
       details: { authorization: '[REDACTED]' },
     });
+  });
+});
+
+describe('runMcpStdioBridge', () => {
+  it('negotiates MCP 2026-07-28 and preserves bridged error redaction', async () => {
+    expect(existsSync(tsxBin)).toBe(true);
+    const transport = new StdioClientTransport({
+      command: tsxBin,
+      args: ['src/__tests__/fixtures/mcp-stdio-bridge.ts'],
+      cwd: packageRoot,
+      stderr: 'pipe',
+    });
+    const client = new Client(
+      { name: 'smrt-app-cli-test-client', version: '1.0.0' },
+      {
+        capabilities: {},
+        versionNegotiation: { mode: { pin: '2026-07-28' } },
+      },
+    );
+
+    try {
+      await client.connect(transport);
+      expect(client.getNegotiatedProtocolVersion()).toBe('2026-07-28');
+      expect(client.getServerVersion()).toMatchObject({
+        name: 'smrt-app-cli-test',
+        version: '1.0.0',
+      });
+
+      const tools = await client.listTools();
+      expect(tools.tools.map((tool) => tool.name)).toEqual(['echo']);
+
+      const result = await client.callTool({
+        name: 'echo',
+        arguments: { text: 'hello' },
+      });
+      expect(result.content).toEqual([
+        { type: 'text', text: 'Bearer [REDACTED] echoed' },
+      ]);
+      expect(resultMetadata(result)).toMatchObject({
+        code: 'mcp_tool_error',
+        message: 'Bearer [REDACTED] echoed',
+      });
+    } finally {
+      await client.close();
+      await transport.close();
+    }
+  });
+
+  it('preserves legacy stdio negotiation through the same factory', async () => {
+    const transport = new StdioClientTransport({
+      command: tsxBin,
+      args: ['src/__tests__/fixtures/mcp-stdio-bridge.ts'],
+      cwd: packageRoot,
+      stderr: 'pipe',
+    });
+    const client = new Client(
+      { name: 'smrt-app-cli-legacy-test-client', version: '1.0.0' },
+      { capabilities: {} },
+    );
+
+    try {
+      await client.connect(transport);
+      expect(client.getNegotiatedProtocolVersion()).toBe('2025-11-25');
+      const tools = await client.listTools();
+      expect(tools.tools.map((tool) => tool.name)).toEqual(['echo']);
+    } finally {
+      await client.close();
+      await transport.close();
+    }
   });
 });

--- a/packages/app-cli/src/__tests__/fixtures/mcp-stdio-bridge.ts
+++ b/packages/app-cli/src/__tests__/fixtures/mcp-stdio-bridge.ts
@@ -1,0 +1,36 @@
+import { runMcpStdioBridge } from '../../bridge.js';
+
+const jsonHeaders = { 'content-type': 'application/json' };
+
+await runMcpStdioBridge({
+  envPrefix: 'SMRT_APP_CLI_STDIO_TEST',
+  defaultServerUrl: 'https://bridge.test',
+  serverInfo: { name: 'smrt-app-cli-test', version: '1.0.0' },
+  fetch: async (input, init) => {
+    const url = String(input);
+    if (url.endsWith('/api/mcp/tools')) {
+      return new Response(
+        JSON.stringify({
+          tools: [
+            {
+              name: 'echo',
+              description: 'Echo through the HTTP bridge',
+              inputSchema: { type: 'object' },
+            },
+          ],
+        }),
+        { headers: jsonHeaders },
+      );
+    }
+    if (url.endsWith('/api/mcp/call') && init?.method === 'POST') {
+      return new Response(
+        JSON.stringify({
+          content: [{ type: 'text', text: 'Bearer bridge-secret echoed' }],
+          isError: true,
+        }),
+        { headers: jsonHeaders },
+      );
+    }
+    return new Response('not found', { status: 404 });
+  },
+});

--- a/packages/app-cli/src/bridge.ts
+++ b/packages/app-cli/src/bridge.ts
@@ -31,7 +31,10 @@ import {
   ProtocolErrorCode,
   Server,
 } from '@modelcontextprotocol/server';
-import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+import {
+  StdioServerTransport,
+  serveStdio,
+} from '@modelcontextprotocol/server/stdio';
 import {
   type AppCliResultMetadata,
   type CliConfigContext,
@@ -240,12 +243,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * One-call entry point — instantiate the bridge and connect stdio. Returns
- * a `Promise<void>` that resolves once the transport disconnects.
+ * One-call entry point — start the factory-owned stdio bridge. The returned
+ * promise resolves once the stdio listener is installed.
  */
 export async function runMcpStdioBridge(
   options: McpStdioBridgeOptions,
 ): Promise<void> {
-  const { connect } = createMcpStdioBridge(options);
-  await connect();
+  serveStdio(() => createMcpStdioBridge(options).server);
 }

--- a/packages/app-cli/src/bridge.ts
+++ b/packages/app-cli/src/bridge.ts
@@ -22,18 +22,16 @@
  */
 
 import { SMRT_MCP_RESULT_METADATA_KEY as APP_CONTRACT_MCP_RESULT_METADATA_KEY } from '@happyvertical/smrt-users/app-contract';
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
   type CallToolRequest,
-  CallToolRequestSchema,
   type CallToolResult,
-  ErrorCode,
   type ListToolsRequest,
-  ListToolsRequestSchema,
   type ListToolsResult,
-  McpError,
-} from '@modelcontextprotocol/sdk/types.js';
+  ProtocolError,
+  ProtocolErrorCode,
+  Server,
+} from '@modelcontextprotocol/server';
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
 import {
   type AppCliResultMetadata,
   type CliConfigContext,
@@ -83,7 +81,7 @@ export function createMcpStdioBridge(options: McpStdioBridgeOptions): {
   });
 
   server.setRequestHandler(
-    ListToolsRequestSchema,
+    'tools/list',
     async (_request: ListToolsRequest): Promise<ListToolsResult> => {
       const outcome = await requestJsonResult<ListToolsResult>(
         options,
@@ -97,7 +95,7 @@ export function createMcpStdioBridge(options: McpStdioBridgeOptions): {
   );
 
   server.setRequestHandler(
-    CallToolRequestSchema,
+    'tools/call',
     async (request: CallToolRequest): Promise<CallToolResult> => {
       const { name, arguments: args = {} } = request.params;
       const outcome = await requestJsonResult<CallToolResult>(
@@ -199,10 +197,12 @@ function sanitizeMetadata(
 }
 
 /** Convert an HTTP transport failure into an MCP JSON-RPC error safely. */
-export function toMcpTransportError(metadata: AppCliResultMetadata): McpError {
+export function toMcpTransportError(
+  metadata: AppCliResultMetadata,
+): ProtocolError {
   const sanitized = sanitizeMetadata(metadata);
-  return new McpError(
-    ErrorCode.InternalError,
+  return new ProtocolError(
+    ProtocolErrorCode.InternalError,
     sanitized.message ?? sanitized.code,
     { [APP_CONTRACT_MCP_RESULT_METADATA_KEY]: sanitized },
   );

--- a/packages/app-cli/vite.config.ts
+++ b/packages/app-cli/vite.config.ts
@@ -30,8 +30,7 @@ export default defineConfig({
         'http',
         'https',
 
-        '@modelcontextprotocol/sdk',
-        /^@modelcontextprotocol\/sdk\//,
+        /^@modelcontextprotocol\//,
         '@happyvertical/smrt-users',
         /^@happyvertical\/smrt-users\//,
       ],

--- a/packages/core/src/generators/mcp-integration.spec.ts
+++ b/packages/core/src/generators/mcp-integration.spec.ts
@@ -287,9 +287,9 @@ describe('MCPGenerator - Integration Tests', () => {
 
       // Verify @happyvertical/smrt-config usage
       expect(content).toContain(
-        "import { config } from '@happyvertical/smrt-config'",
+        "import { loadConfig } from '@happyvertical/smrt-config'",
       );
-      expect(content).toContain('await config.load()');
+      expect(content).toContain('await loadConfig()');
       expect(content).toContain('appConfig?.ai || {}');
 
       // Verify ObjectRegistry integration

--- a/packages/core/src/generators/mcp-modular.test.ts
+++ b/packages/core/src/generators/mcp-modular.test.ts
@@ -56,7 +56,7 @@ describe('MCPGenerator - Modular Generation', () => {
       const content = await readFile(outputPath, 'utf-8');
       expect(content).toContain('#!/usr/bin/env node');
       expect(content).toContain('test-server');
-      expect(content).toContain('@modelcontextprotocol/sdk');
+      expect(content).toContain('@modelcontextprotocol/server');
     });
 
     it('should use @happyvertical/smrt-config for configuration loading', async () => {
@@ -71,9 +71,9 @@ describe('MCPGenerator - Modular Generation', () => {
 
       const content = await readFile(outputPath, 'utf-8');
       expect(content).toContain(
-        "import { config } from '@happyvertical/smrt-config'",
+        "import { loadConfig } from '@happyvertical/smrt-config'",
       );
-      expect(content).toContain('await config.load()');
+      expect(content).toContain('await loadConfig()');
       expect(content).toContain('appConfig?.ai || {}');
       expect(content).not.toContain('loadEnvConfig'); // Old approach
     });

--- a/packages/core/src/generators/mcp-protocol.spec.ts
+++ b/packages/core/src/generators/mcp-protocol.spec.ts
@@ -349,7 +349,7 @@ describe('MCP Protocol Compliance', () => {
     it('should use MCP SDK compatible types', async () => {
       const tools = await generator.generateTools();
 
-      // Tool structure matches @modelcontextprotocol/sdk types
+      // Tool structure matches @modelcontextprotocol/server types
       tools.forEach((tool) => {
         // Name: string
         expect(typeof tool.name).toBe('string');

--- a/packages/core/src/generators/mcp-runtime-template.test.ts
+++ b/packages/core/src/generators/mcp-runtime-template.test.ts
@@ -2,6 +2,19 @@ import { describe, expect, it } from 'vitest';
 import { generateRuntimeBootstrap } from './mcp-runtime-template.js';
 
 describe('generated MCP custom-action runtime (#2182)', () => {
+  it('emits the SDK v2 stateless lifecycle', () => {
+    const source = generateRuntimeBootstrap({ tools: [], customActions: {} });
+
+    expect(source).toContain("from '@modelcontextprotocol/server'");
+    expect(source).toContain("from '@modelcontextprotocol/server/stdio'");
+    expect(source).toContain("setRequestHandler('tools/list'");
+    expect(source).toContain("setRequestHandler('tools/call'");
+    expect(source).toContain('serveStdio(() => createServer()');
+    expect(source).toContain('await loadConfig()');
+    expect(source).not.toContain('@modelcontextprotocol/sdk');
+    expect(source).not.toContain('initialize');
+  });
+
   it('carries canonical receivers and positional invocation metadata without exposing it as a tool field', () => {
     const source = generateRuntimeBootstrap({
       tools: [

--- a/packages/core/src/generators/mcp-runtime-template.ts
+++ b/packages/core/src/generators/mcp-runtime-template.ts
@@ -3,7 +3,7 @@
  *
  * This template provides stdio transport integration for SMRT-generated MCP servers.
  * It handles:
- * - Server initialization with @modelcontextprotocol/sdk
+ * - Server initialization with @modelcontextprotocol/server v2
  * - Tool registration from MCPGenerator
  * - Stdio transport connection
  * - Error handling and logging
@@ -274,17 +274,16 @@ ${indent}}`;
  * with an authenticated gateway. Do not expose it directly to untrusted callers.
  */
 
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
   type CallToolRequest,
   type ListToolsRequest,
-} from '@modelcontextprotocol/sdk/types.js';
+  Server,
+} from '@modelcontextprotocol/server';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
+import { pathToFileURL } from 'node:url';
 import { ObjectRegistry } from '@happyvertical/smrt-core';
 import { normalizeCustomActionFailure, SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY } from '@happyvertical/smrt-core';
-import { config } from '@happyvertical/smrt-config';
+import { loadConfig } from '@happyvertical/smrt-config';
 ${hasTenantScoped ? "import { enableTenancy, runTenantScopedEntryPoint } from '@happyvertical/smrt-tenancy';\n" : ''}
 // Server configuration
 const SERVER_NAME = ${JSON.stringify(name)};
@@ -375,8 +374,7 @@ function toPublicResult(value: any, seen: WeakSet<object> = new WeakSet()): any 
 /**
  * Main server startup function
  */
-async function main() {
-  try {
+export async function createServer(): Promise<Server> {
     if (DEBUG) {
       console.error(\`[MCP] Starting server: \${SERVER_NAME} v\${SERVER_VERSION}\`);
     }
@@ -393,7 +391,7 @@ ${
     : ''
 }
     // Load configuration from environment and .smrt.config files
-    const appConfig = await config.load();
+    const appConfig = await loadConfig();
     const aiConfig = appConfig?.ai || {};
 
     if (DEBUG) {
@@ -415,7 +413,7 @@ ${
     );
 
     // Register ListTools handler
-    server.setRequestHandler(ListToolsRequestSchema, async (_request: ListToolsRequest) => {
+    server.setRequestHandler('tools/list', async (_request: ListToolsRequest) => {
       if (DEBUG) {
         console.error(\`[MCP] ListTools request received\`);
       }
@@ -426,7 +424,7 @@ ${
     });
 
     // Register CallTool handler
-    server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest) => {
+    server.setRequestHandler('tools/call', async (request: CallToolRequest) => {
       const { name: toolName, arguments: args = {} } = request.params;
 
       if (DEBUG) {
@@ -481,44 +479,34 @@ ${
       }
     });
 
-    // Setup stdio transport
-    const transport = new StdioServerTransport();
+    return server;
+}
 
-    // Connect server to transport
-    await server.connect(transport);
-
-    if (DEBUG) {
-      console.error(\`[MCP] Server connected via stdio transport\`);
-      console.error(\`[MCP] Ready to receive requests\`);
-    }
-
-    // Handle graceful shutdown
-    process.on('SIGINT', async () => {
-      if (DEBUG) {
-        console.error(\`[MCP] Received SIGINT, shutting down gracefully\`);
-      }
-      await server.close();
-      process.exit(0);
+async function main() {
+  try {
+    const handle = serveStdio(() => createServer(), {
+      onerror: (error) => console.error('[MCP] Protocol error:', error),
     });
-
-    process.on('SIGTERM', async () => {
-      if (DEBUG) {
-        console.error(\`[MCP] Received SIGTERM, shutting down gracefully\`);
-      }
-      await server.close();
+    const shutdown = async () => {
+      if (DEBUG) console.error('[MCP] Shutting down gracefully');
+      await handle.close();
       process.exit(0);
-    });
+    };
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
   } catch (error) {
     console.error('[MCP] Fatal error during server startup:', error);
     process.exit(1);
   }
 }
 
-// Start the server
-main().catch((error) => {
-  console.error('[MCP] Unhandled error:', error);
-  process.exit(1);
-});
+// Start only when executed, so adapters and tests may import the factory.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error('[MCP] Unhandled error:', error);
+    process.exit(1);
+  });
+}
 `;
 }
 

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -1836,13 +1836,10 @@ ${
  * This server exposes SMRT objects as MCP tools for AI integration.
  */
 
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
-import { config } from '@happyvertical/smrt-config';
+import { Server } from '@modelcontextprotocol/server';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
+import { pathToFileURL } from 'node:url';
+import { loadConfig } from '@happyvertical/smrt-config';
 import { getDatabase } from '@happyvertical/sql';
 import { getAI } from '@happyvertical/ai';
 
@@ -1853,15 +1850,14 @@ import { handleToolCall } from './handlers/index.js';
 /**
  * Main server startup function
  */
-async function main() {
-  try {
+export async function createServer() {
     if (DEBUG) {
       console.error(\`[MCP] Starting server: \${SERVER_NAME} v\${SERVER_VERSION}\`);
       console.error(\`[MCP] Available tools:\`, tools.map(t => t.name).join(', '));
     }
 
     // Load configuration from environment and .smrt.config files
-    const appConfig = await config.load();
+    const appConfig = await loadConfig();
     const aiConfig = appConfig?.ai || {};
 
     // Create MCP server
@@ -1878,7 +1874,7 @@ async function main() {
     );
 
     // Register ListTools handler
-    server.setRequestHandler(ListToolsRequestSchema, async () => {
+    server.setRequestHandler('tools/list', async () => {
       if (DEBUG) {
         console.error(\`[MCP] ListTools request received\`);
       }
@@ -1893,7 +1889,7 @@ async function main() {
     });
 
     // Register CallTool handler
-    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    server.setRequestHandler('tools/call', async (request) => {
       const { name, arguments: args = {} } = request.params;
 
       if (DEBUG) {
@@ -1904,23 +1900,19 @@ async function main() {
       return await handleToolCall(name, args, aiConfig);
     });
 
-    // Setup stdio transport
-    const transport = new StdioServerTransport();
-    await server.connect(transport);
+    return server;
+}
 
-    if (DEBUG) {
-      console.error(\`[MCP] Server connected and ready\`);
-    }
-
-    // Handle graceful shutdown
+async function main() {
+  try {
+    const handle = serveStdio(() => createServer(), {
+      onerror: (error) => console.error('[MCP] Protocol error:', error),
+    });
     const shutdown = async () => {
-      if (DEBUG) {
-        console.error(\`[MCP] Shutting down gracefully\`);
-      }
-      await server.close();
+      if (DEBUG) console.error('[MCP] Shutting down gracefully');
+      await handle.close();
       process.exit(0);
     };
-
     process.on('SIGINT', shutdown);
     process.on('SIGTERM', shutdown);
   } catch (error) {
@@ -1929,10 +1921,12 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error('[MCP] Unhandled error:', error);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error('[MCP] Unhandled error:', error);
+    process.exit(1);
+  });
+}
 `;
   }
 }

--- a/packages/mcp-conformance-fixture/.gitignore
+++ b/packages/mcp-conformance-fixture/.gitignore
@@ -1,0 +1,1 @@
+.generated-tmp/

--- a/packages/mcp-conformance-fixture/AGENTS.md
+++ b/packages/mcp-conformance-fixture/AGENTS.md
@@ -1,0 +1,17 @@
+# MCP conformance fixture
+
+Private CI-only executable fixture for the Tier-1 server emitted by
+`@happyvertical/smrt-core`'s MCP generator. Generate the server during the
+test, exercise modern stdio negotiation directly, then run the pinned official
+2026-07-28 server conformance suite through an HTTP adapter around the same
+generated factory. Never publish this package or replace the generated source
+with a handwritten lookalike.
+
+The pinned upstream conformance CLI still brings the monolithic v1 SDK
+transitively. That dependency is an explicit development-tool exception; no
+shipped manifest or generated server may depend on `@modelcontextprotocol/sdk`.
+
+```bash
+pnpm test
+pnpm typecheck
+```

--- a/packages/mcp-conformance-fixture/CLAUDE.md
+++ b/packages/mcp-conformance-fixture/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/mcp-conformance-fixture/README.md
+++ b/packages/mcp-conformance-fixture/README.md
@@ -1,0 +1,15 @@
+# @happyvertical/smrt-mcp-conformance-fixture
+
+Private CI fixture for the MCP 2026-07-28 compatibility rail. The test
+generates a Tier-1 server from `MCPGenerator`, negotiates it directly over
+stdio with the exact scoped SDK v2 client, then runs the pinned official MCP
+server conformance suite against the generated server factory.
+
+```bash
+pnpm --filter @happyvertical/smrt-mcp-conformance-fixture test
+```
+
+This package is not published and is not a production transport adapter. The
+upstream conformance CLI's transitive monolithic v1 SDK is a development-only
+exception; all direct dependencies and generated/runtime imports use exact
+scoped v2 packages.

--- a/packages/mcp-conformance-fixture/conformance-baseline.yml
+++ b/packages/mcp-conformance-fixture/conformance-baseline.yml
@@ -1,0 +1,17 @@
+server:
+  - completion-complete
+  - tools-call-image
+  - tools-call-audio
+  - tools-call-embedded-resource
+  - tools-call-mixed-content
+  - tools-call-with-progress
+  - resources-list
+  - resources-read-text
+  - resources-read-binary
+  - resources-templates-read
+  - prompts-list
+  - prompts-get-simple
+  - prompts-get-with-args
+  - prompts-get-embedded-resource
+  - prompts-get-with-image
+  - dns-rebinding-protection

--- a/packages/mcp-conformance-fixture/package.json
+++ b/packages/mcp-conformance-fixture/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@happyvertical/smrt-mcp-conformance-fixture",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "files": [
+    "dist",
+    "AGENTS.md",
+    "CLAUDE.md"
+  ],
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@happyvertical/smrt-config": "workspace:*",
+    "@happyvertical/smrt-core": "workspace:*",
+    "@modelcontextprotocol/server": "2.0.0"
+  },
+  "devDependencies": {
+    "@happyvertical/smrt-vitest": "workspace:*",
+    "@modelcontextprotocol/client": "2.0.0",
+    "@modelcontextprotocol/conformance": "0.2.0-alpha.10",
+    "@modelcontextprotocol/node": "2.0.0",
+    "@types/node": "24.13.2",
+    "tsx": "^4.23.0",
+    "typescript": "5.9.3",
+    "vitest": "4.1.10"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/smrt.git",
+    "directory": "packages/mcp-conformance-fixture"
+  },
+  "author": "HappyVertical"
+}

--- a/packages/mcp-conformance-fixture/scripts/serve-generated.ts
+++ b/packages/mcp-conformance-fixture/scripts/serve-generated.ts
@@ -1,0 +1,26 @@
+import { createServer as createHttpServer } from 'node:http';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { toNodeHandler } from '@modelcontextprotocol/node';
+import { createMcpHandler, type Server } from '@modelcontextprotocol/server';
+
+const generatedPath = process.argv[2];
+if (!generatedPath) throw new Error('generated server path is required');
+const generated = (await import(
+  pathToFileURL(resolve(generatedPath)).href
+)) as {
+  createServer(): Promise<Server>;
+};
+const handler = createMcpHandler(() => generated.createServer());
+const httpServer = createHttpServer(toNodeHandler(handler));
+await new Promise<void>((resolveListen) =>
+  httpServer.listen(0, '127.0.0.1', resolveListen),
+);
+const address = httpServer.address();
+if (!address || typeof address === 'string')
+  throw new Error('missing listener');
+console.log(`http://127.0.0.1:${address.port}/mcp`);
+
+const shutdown = () => httpServer.close(() => process.exit(0));
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/packages/mcp-conformance-fixture/src/fixture-objects.ts
+++ b/packages/mcp-conformance-fixture/src/fixture-objects.ts
@@ -1,0 +1,23 @@
+import { SmrtCollection, SmrtObject, smrt } from '@happyvertical/smrt-core';
+
+@smrt({ api: false, cli: false, mcp: { include: ['list', 'get'] } })
+export class ConformanceWidget extends SmrtObject {
+  name = '';
+  description = '';
+  count = 0;
+}
+
+export class ConformanceWidgetCollection extends SmrtCollection<ConformanceWidget> {
+  static readonly _itemClass = ConformanceWidget;
+}
+
+@smrt({ api: false, cli: false, mcp: { include: ['list', 'get', 'create'] } })
+export class ConformanceGadget extends SmrtObject {
+  name = '';
+  label = '';
+  price = 0.0;
+}
+
+export class ConformanceGadgetCollection extends SmrtCollection<ConformanceGadget> {
+  static readonly _itemClass = ConformanceGadget;
+}

--- a/packages/mcp-conformance-fixture/src/generated-server-conformance.test.ts
+++ b/packages/mcp-conformance-fixture/src/generated-server-conformance.test.ts
@@ -1,0 +1,164 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import { mkdir, rm } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { MCPGenerator } from '@happyvertical/smrt-core/generators/mcp';
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
+import {
+  CLIENT_CAPABILITIES_META_KEY,
+  CLIENT_INFO_META_KEY,
+  PROTOCOL_VERSION_META_KEY,
+  SERVER_INFO_META_KEY,
+} from '@modelcontextprotocol/server';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import './fixture-objects.js';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = resolve(packageRoot, '..', '..');
+const generatedDir = join(packageRoot, '.generated-tmp');
+const generatedPath = join(generatedDir, 'index.ts');
+const tsxBin = join(repoRoot, 'node_modules', '.bin', 'tsx');
+const conformanceBin = join(packageRoot, 'node_modules', '.bin', 'conformance');
+const baselinePath = join(packageRoot, 'conformance-baseline.yml');
+let httpChild: ChildProcess | undefined;
+let mcpUrl: string;
+
+beforeAll(async () => {
+  await rm(generatedDir, { force: true, recursive: true });
+  await mkdir(generatedDir, { recursive: true });
+  const generator = new MCPGenerator({
+    name: 'smrt-generated-conformance',
+    version: '0.0.0',
+    description: 'Generated Tier-1 MCP conformance fixture',
+  });
+  await generator.generateServer({ outputPath: generatedPath });
+
+  const transport = new StdioClientTransport({
+    command: tsxBin,
+    args: [generatedPath],
+    cwd: packageRoot,
+    stderr: 'pipe',
+  });
+  const client = new Client(
+    { name: 'generated-fixture-test', version: '0.0.0' },
+    {
+      capabilities: {},
+      versionNegotiation: { mode: { pin: '2026-07-28' } },
+    },
+  );
+  try {
+    await client.connect(transport);
+    expect(client.getNegotiatedProtocolVersion()).toBe('2026-07-28');
+    expect(client.getDiscoverResult()).toBeDefined();
+    expect(client.getServerVersion()).toMatchObject({
+      name: 'smrt-generated-conformance',
+      version: '0.0.0',
+    });
+    const tools = await client.listTools();
+    expect(tools.tools.map((tool) => tool.name)).toEqual(
+      expect.arrayContaining([
+        'conformancewidget_list',
+        'conformancegadget_create',
+      ]),
+    );
+  } finally {
+    await client.close();
+    await transport.close();
+  }
+
+  mcpUrl = await startHttpAdapter();
+});
+
+afterAll(async () => {
+  httpChild?.kill('SIGTERM');
+  if (process.env.MCP_CONFORMANCE_KEEP_GENERATED !== 'true') {
+    await rm(generatedDir, { force: true, recursive: true });
+  }
+});
+
+describe('generated Tier-1 MCP 2026-07-28 conformance', () => {
+  it('answers discover with SDK-stamped complete metadata', async () => {
+    const response = await fetch(mcpUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'mcp-method': 'server/discover',
+        'mcp-protocol-version': '2026-07-28',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'server/discover',
+        params: {
+          _meta: {
+            [PROTOCOL_VERSION_META_KEY]: '2026-07-28',
+            [CLIENT_INFO_META_KEY]: {
+              name: 'generated-fixture-test',
+              version: '0.0.0',
+            },
+            [CLIENT_CAPABILITIES_META_KEY]: {},
+          },
+        },
+      }),
+    });
+    const body = (await response.json()) as any;
+    expect(body.result).toMatchObject({
+      supportedVersions: ['2026-07-28'],
+      resultType: 'complete',
+      _meta: { [SERVER_INFO_META_KEY]: { name: 'smrt-generated-conformance' } },
+    });
+  });
+
+  it('passes the official server suite with the reviewed baseline', async () => {
+    const result = await run(conformanceBin, [
+      'server',
+      '--url',
+      mcpUrl,
+      '--spec-version',
+      '2026-07-28',
+      '--expected-failures',
+      baselinePath,
+    ]);
+    expect(result.code, result.output).toBe(0);
+  });
+});
+
+function startHttpAdapter(): Promise<string> {
+  return new Promise((resolveUrl, rejectStart) => {
+    httpChild = spawn(tsxBin, ['scripts/serve-generated.ts', generatedPath], {
+      cwd: packageRoot,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    httpChild.stderr?.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    httpChild.on('error', rejectStart);
+    httpChild.on('exit', (code) => {
+      if (code !== null && code !== 0) rejectStart(new Error(stderr));
+    });
+    httpChild.stdout?.once('data', (chunk) => resolveUrl(String(chunk).trim()));
+  });
+}
+
+function run(command: string, args: string[]) {
+  return new Promise<{ code: number | null; output: string }>(
+    (resolveRun, rejectRun) => {
+      const child = spawn(command, args, {
+        cwd: packageRoot,
+        env: process.env,
+      });
+      let output = '';
+      child.stdout.on('data', (chunk) => {
+        output += String(chunk);
+      });
+      child.stderr.on('data', (chunk) => {
+        output += String(chunk);
+      });
+      child.on('error', rejectRun);
+      child.on('close', (code) => resolveRun({ code, output }));
+    },
+  );
+}

--- a/packages/mcp-conformance-fixture/tsconfig.json
+++ b/packages/mcp-conformance-fixture/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "scripts/**/*.ts"]
+}

--- a/packages/mcp-conformance-fixture/vitest.config.ts
+++ b/packages/mcp-conformance-fixture/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+import { smrtVitestPlugin } from '../vitest/src/index.ts';
+
+export default defineConfig({
+  plugins: [smrtVitestPlugin()],
+  test: { environment: 'node', testTimeout: 240_000 },
+});

--- a/packages/smrt-app-mcp/conformance-baseline.yml
+++ b/packages/smrt-app-mcp/conformance-baseline.yml
@@ -1,0 +1,17 @@
+server:
+  - completion-complete
+  - tools-call-image
+  - tools-call-audio
+  - tools-call-embedded-resource
+  - tools-call-mixed-content
+  - tools-call-with-progress
+  - resources-list
+  - resources-read-text
+  - resources-read-binary
+  - resources-templates-read
+  - prompts-list
+  - prompts-get-simple
+  - prompts-get-with-args
+  - prompts-get-embedded-resource
+  - prompts-get-with-image
+  - dns-rebinding-protection

--- a/packages/smrt-app-mcp/package.json
+++ b/packages/smrt-app-mcp/package.json
@@ -56,9 +56,11 @@
   "author": "HappyVertical",
   "dependencies": {
     "@happyvertical/smrt-core": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.25.2"
+    "@modelcontextprotocol/server": "2.0.0"
   },
   "devDependencies": {
+    "@modelcontextprotocol/conformance": "0.2.0-alpha.10",
+    "@modelcontextprotocol/node": "2.0.0",
     "@types/node": "24.13.2",
     "typescript": "5.9.3",
     "vite": "8.1.4",

--- a/packages/smrt-app-mcp/src/__tests__/mcp-conformance.test.ts
+++ b/packages/smrt-app-mcp/src/__tests__/mcp-conformance.test.ts
@@ -13,6 +13,7 @@ import {
   SERVER_INFO_META_KEY,
 } from '@modelcontextprotocol/server';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { McpAccessError } from '../errors.js';
 import { createMcpProtocolServer } from '../protocol.js';
 import type { McpAppServer } from '../server.js';
 
@@ -69,6 +70,32 @@ describe('smrt-app-mcp MCP 2026-07-28 conformance', () => {
     });
   });
 
+  it('allowlists access-error metadata before exposing it over MCP', async () => {
+    const accessErrorServer: McpAppServer = {
+      ...appServer,
+      async callTool() {
+        throw new McpAccessError(403, 'access denied', {
+          code: 'access_denied',
+          retryable: false,
+          secret: 'LEAK_ME',
+        } as { code: string; retryable: boolean; secret: string });
+      },
+    };
+    const accessErrorHandler = createMcpHandler(() =>
+      createMcpProtocolServer(accessErrorServer),
+    );
+
+    const response = await modernRequest(accessErrorHandler, 'tools/call', {
+      name: 'private-tool',
+      arguments: {},
+    });
+    expect(response.body.error.data).toEqual({
+      code: 'access_denied',
+      retryable: false,
+    });
+    expect(JSON.stringify(response.body)).not.toContain('LEAK_ME');
+  });
+
   it('passes the official server suite with the reviewed baseline', async () => {
     const result = await runConformance(mcpUrl);
     expect(result.code, result.output).toBe(0);
@@ -104,7 +131,11 @@ function runConformance(url: string) {
   );
 }
 
-async function modernRequest(target: McpHttpHandler, method: string) {
+async function modernRequest(
+  target: McpHttpHandler,
+  method: string,
+  params: Record<string, unknown> = {},
+) {
   const response = await target.fetch(
     new Request('http://localhost/mcp', {
       method: 'POST',
@@ -112,12 +143,14 @@ async function modernRequest(target: McpHttpHandler, method: string) {
         'content-type': 'application/json',
         'mcp-method': method,
         'mcp-protocol-version': '2026-07-28',
+        ...(typeof params.name === 'string' ? { 'mcp-name': params.name } : {}),
       },
       body: JSON.stringify({
         jsonrpc: '2.0',
         id: 1,
         method,
         params: {
+          ...params,
           _meta: {
             [PROTOCOL_VERSION_META_KEY]: '2026-07-28',
             [CLIENT_INFO_META_KEY]: {

--- a/packages/smrt-app-mcp/src/__tests__/mcp-conformance.test.ts
+++ b/packages/smrt-app-mcp/src/__tests__/mcp-conformance.test.ts
@@ -1,0 +1,134 @@
+import { spawn } from 'node:child_process';
+import { createServer as createHttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { toNodeHandler } from '@modelcontextprotocol/node';
+import {
+  CLIENT_CAPABILITIES_META_KEY,
+  CLIENT_INFO_META_KEY,
+  createMcpHandler,
+  type McpHttpHandler,
+  PROTOCOL_VERSION_META_KEY,
+  SERVER_INFO_META_KEY,
+} from '@modelcontextprotocol/server';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createMcpProtocolServer } from '../protocol.js';
+import type { McpAppServer } from '../server.js';
+
+const packageRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+);
+const conformanceBin = join(packageRoot, 'node_modules', '.bin', 'conformance');
+const baselinePath = join(packageRoot, 'conformance-baseline.yml');
+let httpServer: ReturnType<typeof createHttpServer>;
+let mcpUrl: string;
+let handler: McpHttpHandler;
+
+const appServer: McpAppServer = {
+  serverInfo: { name: 'smrt-app-mcp-conformance', version: '0.0.0' },
+  async listTools() {
+    return [];
+  },
+  async callTool() {
+    return { content: [{ type: 'text', text: 'unknown tool' }], isError: true };
+  },
+};
+
+beforeAll(async () => {
+  handler = createMcpHandler(() =>
+    createMcpProtocolServer(appServer, { principal: { id: 'conformance' } }),
+  );
+  httpServer = createHttpServer(toNodeHandler(handler));
+  await new Promise<void>((resolveListen) =>
+    httpServer.listen(0, '127.0.0.1', resolveListen),
+  );
+  mcpUrl = `http://127.0.0.1:${(httpServer.address() as AddressInfo).port}/mcp`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolveClose, rejectClose) =>
+    httpServer.close((error) => (error ? rejectClose(error) : resolveClose())),
+  );
+});
+
+describe('smrt-app-mcp MCP 2026-07-28 conformance', () => {
+  it('answers discover and stamps complete results from per-request metadata', async () => {
+    const discover = await modernRequest(handler, 'server/discover');
+    expect(discover.body.result).toMatchObject({
+      supportedVersions: ['2026-07-28'],
+      resultType: 'complete',
+      _meta: { [SERVER_INFO_META_KEY]: { name: 'smrt-app-mcp-conformance' } },
+    });
+    const list = await modernRequest(handler, 'tools/list');
+    expect(list.body.result).toMatchObject({
+      resultType: 'complete',
+      tools: [],
+    });
+  });
+
+  it('passes the official server suite with the reviewed baseline', async () => {
+    const result = await runConformance(mcpUrl);
+    expect(result.code, result.output).toBe(0);
+  }, 240_000);
+});
+
+function runConformance(url: string) {
+  return new Promise<{ code: number | null; output: string }>(
+    (resolveRun, rejectRun) => {
+      const child = spawn(
+        conformanceBin,
+        [
+          'server',
+          '--url',
+          url,
+          '--spec-version',
+          '2026-07-28',
+          '--expected-failures',
+          baselinePath,
+        ],
+        { cwd: packageRoot, env: process.env },
+      );
+      let output = '';
+      child.stdout.on('data', (chunk) => {
+        output += String(chunk);
+      });
+      child.stderr.on('data', (chunk) => {
+        output += String(chunk);
+      });
+      child.on('error', rejectRun);
+      child.on('close', (code) => resolveRun({ code, output }));
+    },
+  );
+}
+
+async function modernRequest(target: McpHttpHandler, method: string) {
+  const response = await target.fetch(
+    new Request('http://localhost/mcp', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'mcp-method': method,
+        'mcp-protocol-version': '2026-07-28',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method,
+        params: {
+          _meta: {
+            [PROTOCOL_VERSION_META_KEY]: '2026-07-28',
+            [CLIENT_INFO_META_KEY]: {
+              name: 'smrt-conformance',
+              version: '0.0.0',
+            },
+            [CLIENT_CAPABILITIES_META_KEY]: {},
+          },
+        },
+      }),
+    }),
+  );
+  return { status: response.status, body: (await response.json()) as any };
+}

--- a/packages/smrt-app-mcp/src/index.ts
+++ b/packages/smrt-app-mcp/src/index.ts
@@ -28,6 +28,10 @@ export {
   type McpAccessErrorMetadata,
 } from './errors.js';
 export {
+  createMcpProtocolServer,
+  type McpProtocolServerOptions,
+} from './protocol.js';
+export {
   type CallToolInput,
   type CreateMcpAppServerOptions,
   createMcpAppServer,

--- a/packages/smrt-app-mcp/src/protocol.ts
+++ b/packages/smrt-app-mcp/src/protocol.ts
@@ -1,0 +1,74 @@
+/** MCP SDK v2 protocol adapter for the framework-neutral app server core. */
+import {
+  type CallToolResult,
+  ProtocolError,
+  ProtocolErrorCode,
+  Server,
+  type ServerContext,
+  type Tool,
+} from '@modelcontextprotocol/server';
+import { McpAccessError } from './errors.js';
+import type { McpAppPrincipal, McpAppServer } from './server.js';
+
+export interface McpProtocolServerOptions {
+  /** Resolve the authenticated application principal for each MCP request. */
+  principal?:
+    | McpAppPrincipal
+    | null
+    | ((
+        context: ServerContext,
+      ) => McpAppPrincipal | null | Promise<McpAppPrincipal | null>);
+}
+
+async function resolvePrincipal(
+  option: McpProtocolServerOptions['principal'],
+  context: ServerContext,
+): Promise<McpAppPrincipal | null> {
+  if (typeof option === 'function') return (await option(context)) ?? null;
+  return option ?? null;
+}
+
+/**
+ * Adapt an app MCP core to the SDK v2 low-level server protocol.
+ *
+ * Transport ownership remains with the caller. In particular, this does not
+ * add a production HTTP endpoint; it is safe to compose with `serveStdio` or
+ * `createMcpHandler` in a deployment that supplies its own authentication.
+ */
+export function createMcpProtocolServer(
+  appServer: McpAppServer,
+  options: McpProtocolServerOptions = {},
+): Server {
+  const server = new Server(appServer.serverInfo, {
+    capabilities: { tools: {} },
+  });
+
+  server.setRequestHandler('tools/list', async (_request, context) => ({
+    tools: (await appServer.listTools({
+      principal: await resolvePrincipal(options.principal, context),
+    })) as Tool[],
+  }));
+
+  server.setRequestHandler('tools/call', async (request, context) => {
+    try {
+      return (await appServer.callTool({
+        name: request.params.name,
+        arguments: request.params.arguments,
+        principal: await resolvePrincipal(options.principal, context),
+      })) as CallToolResult;
+    } catch (error) {
+      if (error instanceof McpAccessError) {
+        throw new ProtocolError(
+          error.status === 404
+            ? ProtocolErrorCode.InvalidParams
+            : ProtocolErrorCode.InvalidRequest,
+          error.message,
+          error.metadata,
+        );
+      }
+      throw error;
+    }
+  });
+
+  return server;
+}

--- a/packages/smrt-app-mcp/src/protocol.ts
+++ b/packages/smrt-app-mcp/src/protocol.ts
@@ -58,12 +58,16 @@ export function createMcpProtocolServer(
       })) as CallToolResult;
     } catch (error) {
       if (error instanceof McpAccessError) {
+        const { code, retryable } = error.metadata;
         throw new ProtocolError(
           error.status === 404
             ? ProtocolErrorCode.InvalidParams
             : ProtocolErrorCode.InvalidRequest,
           error.message,
-          error.metadata,
+          {
+            ...(typeof code === 'string' ? { code } : {}),
+            ...(typeof retryable === 'boolean' ? { retryable } : {}),
+          },
         );
       }
       throw error;

--- a/packages/smrt-dev-mcp/README.md
+++ b/packages/smrt-dev-mcp/README.md
@@ -381,7 +381,7 @@ Prompts:
 
 ## Dependencies
 
-- `@modelcontextprotocol/sdk` -- MCP server protocol
+- `@modelcontextprotocol/server` -- MCP server protocol
 - `@happyvertical/smrt-core` -- manifest and object registry
 - `@happyvertical/smrt-types` -- shared domain knowledge contract
 

--- a/packages/smrt-dev-mcp/conformance-baseline.yml
+++ b/packages/smrt-dev-mcp/conformance-baseline.yml
@@ -1,0 +1,15 @@
+server:
+  - completion-complete
+  - tools-call-image
+  - tools-call-audio
+  - tools-call-embedded-resource
+  - tools-call-mixed-content
+  - tools-call-with-progress
+  - resources-read-text
+  - resources-read-binary
+  - resources-templates-read
+  - prompts-get-simple
+  - prompts-get-with-args
+  - prompts-get-embedded-resource
+  - prompts-get-with-image
+  - dns-rebinding-protection

--- a/packages/smrt-dev-mcp/package.json
+++ b/packages/smrt-dev-mcp/package.json
@@ -54,9 +54,12 @@
     "@happyvertical/smrt-core": "workspace:*",
     "@happyvertical/smrt-scanner": "workspace:*",
     "@happyvertical/smrt-types": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.25.2"
+    "@modelcontextprotocol/server": "2.0.0"
   },
   "devDependencies": {
+    "@modelcontextprotocol/client": "2.0.0",
+    "@modelcontextprotocol/conformance": "0.2.0-alpha.10",
+    "@modelcontextprotocol/node": "2.0.0",
     "@types/node": "24.13.2",
     "typescript": "5.9.3",
     "vite": "8.1.4",

--- a/packages/smrt-dev-mcp/scripts/verify-build-artifacts.mjs
+++ b/packages/smrt-dev-mcp/scripts/verify-build-artifacts.mjs
@@ -8,8 +8,8 @@ import {
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 
 const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const indexJs = join(packageRoot, 'dist', 'index.js');
@@ -39,7 +39,10 @@ const transport = new StdioClientTransport({
 });
 const client = new Client(
   { name: 'smrt-dev-mcp-verify-pack', version: '1.0.0' },
-  { capabilities: {} },
+  {
+    capabilities: {},
+    versionNegotiation: { mode: { pin: '2026-07-28' } },
+  },
 );
 
 try {

--- a/packages/smrt-dev-mcp/src/index.ts
+++ b/packages/smrt-dev-mcp/src/index.ts
@@ -7,18 +7,13 @@
 import { readFileSync, realpathSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
-  CallToolRequestSchema,
-  ErrorCode,
-  GetPromptRequestSchema,
-  ListPromptsRequestSchema,
-  ListResourcesRequestSchema,
-  ListToolsRequestSchema,
-  McpError,
-  ReadResourceRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
+  ProtocolError,
+  ProtocolErrorCode,
+  Server,
+  type Tool,
+} from '@modelcontextprotocol/server';
+import { serveStdio } from '@modelcontextprotocol/server/stdio';
 
 import { getAgentSkill, listAgentSkills } from './agent-skills.js';
 import {
@@ -486,7 +481,7 @@ export const TOOLS = [
   },
 ];
 
-async function main() {
+export function createServer(): Server {
   if (DEBUG) {
     console.error(`[${SERVER_NAME}] Starting server v${SERVER_VERSION}`);
   }
@@ -506,14 +501,14 @@ async function main() {
   );
 
   // List tools handler
-  server.setRequestHandler(ListToolsRequestSchema, async () => {
+  server.setRequestHandler('tools/list', async () => {
     if (DEBUG) {
       console.error(`[${SERVER_NAME}] ListTools request`);
     }
-    return { tools: TOOLS };
+    return { tools: TOOLS as Tool[] };
   });
 
-  server.setRequestHandler(ListPromptsRequestSchema, async () => {
+  server.setRequestHandler('prompts/list', async () => {
     return {
       prompts: [
         {
@@ -603,7 +598,7 @@ async function main() {
     };
   });
 
-  server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+  server.setRequestHandler('prompts/get', async (request) => {
     const { name } = request.params;
     if (name === REVIEW_SKILL_NAME) {
       return {
@@ -657,10 +652,13 @@ async function main() {
       };
     }
 
-    throw new McpError(ErrorCode.InvalidParams, `Unknown prompt: ${name}`);
+    throw new ProtocolError(
+      ProtocolErrorCode.InvalidParams,
+      `Unknown prompt: ${name}`,
+    );
   });
 
-  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+  server.setRequestHandler('resources/list', async () => {
     const index = await buildKnowledgeIndex();
     return {
       resources: [
@@ -692,7 +690,7 @@ async function main() {
     };
   });
 
-  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  server.setRequestHandler('resources/read', async (request) => {
     const { uri } = request.params;
     if (uri === REVIEW_SKILL_URI) {
       return {
@@ -726,8 +724,8 @@ async function main() {
       const index = await buildKnowledgeIndex();
       const pkg = index.packages.find((item) => item.name === packageName);
       if (!pkg) {
-        throw new McpError(
-          ErrorCode.InvalidParams,
+        throw new ProtocolError(
+          ProtocolErrorCode.InvalidParams,
           `Unknown knowledge package: ${packageName}`,
         );
       }
@@ -742,11 +740,14 @@ async function main() {
       };
     }
 
-    throw new McpError(ErrorCode.InvalidParams, `Unknown resource: ${uri}`);
+    throw new ProtocolError(
+      ProtocolErrorCode.InvalidParams,
+      `Unknown resource: ${uri}`,
+    );
   });
 
   // Call tool handler
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.setRequestHandler('tools/call', async (request) => {
     const { name, arguments: args } = request.params;
 
     if (DEBUG) {
@@ -962,9 +963,14 @@ async function main() {
     }
   });
 
-  // Setup stdio transport
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  return server;
+}
+
+async function main() {
+  const handle = serveStdio(() => createServer(), {
+    onerror: (error) =>
+      console.error(`[${SERVER_NAME}] Protocol error:`, error),
+  });
 
   if (DEBUG) {
     console.error(`[${SERVER_NAME}] Server connected via stdio`);
@@ -975,7 +981,7 @@ async function main() {
     if (DEBUG) {
       console.error(`[${SERVER_NAME}] Shutting down...`);
     }
-    await server.close();
+    await handle.close();
     process.exit(0);
   });
 
@@ -983,7 +989,7 @@ async function main() {
     if (DEBUG) {
       console.error(`[${SERVER_NAME}] Shutting down...`);
     }
-    await server.close();
+    await handle.close();
     process.exit(0);
   });
 }

--- a/packages/smrt-dev-mcp/src/mcp-conformance.spec.ts
+++ b/packages/smrt-dev-mcp/src/mcp-conformance.spec.ts
@@ -1,0 +1,127 @@
+import { spawn } from 'node:child_process';
+import { createServer as createHttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { toNodeHandler } from '@modelcontextprotocol/node';
+import {
+  CLIENT_CAPABILITIES_META_KEY,
+  CLIENT_INFO_META_KEY,
+  createMcpHandler,
+  type McpHttpHandler,
+  PROTOCOL_VERSION_META_KEY,
+  SERVER_INFO_META_KEY,
+} from '@modelcontextprotocol/server';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createServer } from './index.js';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const conformanceBin = join(packageRoot, 'node_modules', '.bin', 'conformance');
+const baselinePath = join(packageRoot, 'conformance-baseline.yml');
+let httpServer: ReturnType<typeof createHttpServer>;
+let mcpUrl: string;
+let handler: McpHttpHandler;
+
+beforeAll(async () => {
+  handler = createMcpHandler(() => createServer());
+  httpServer = createHttpServer(toNodeHandler(handler));
+  await new Promise<void>((resolveListen) =>
+    httpServer.listen(0, '127.0.0.1', resolveListen),
+  );
+  mcpUrl = `http://127.0.0.1:${(httpServer.address() as AddressInfo).port}/mcp`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolveClose, rejectClose) =>
+    httpServer.close((error) => (error ? rejectClose(error) : resolveClose())),
+  );
+});
+
+describe('smrt-dev-mcp MCP 2026-07-28 conformance', () => {
+  it('answers discover and stamps complete results from per-request metadata', async () => {
+    const discover = await modernRequest(handler, 'server/discover');
+    expect(discover.status).toBe(200);
+    expect(discover.body.result).toMatchObject({
+      supportedVersions: ['2026-07-28'],
+      resultType: 'complete',
+      _meta: { [SERVER_INFO_META_KEY]: { name: 'smrt-dev-mcp' } },
+    });
+    const list = await modernRequest(handler, 'tools/list');
+    expect(list.body.result.resultType).toBe('complete');
+
+    const mismatch = await modernRequest(
+      handler,
+      'tools/list',
+      'server/discover',
+    );
+    expect(mismatch.status).toBe(400);
+    expect(mismatch.body.error.code).toBe(-32020);
+  });
+
+  it('passes the official server suite with the reviewed baseline', async () => {
+    const result = await runConformance(mcpUrl);
+    expect(result.code, result.output).toBe(0);
+  }, 240_000);
+});
+
+function runConformance(url: string) {
+  return new Promise<{ code: number | null; output: string }>(
+    (resolveRun, rejectRun) => {
+      const child = spawn(
+        conformanceBin,
+        [
+          'server',
+          '--url',
+          url,
+          '--spec-version',
+          '2026-07-28',
+          '--expected-failures',
+          baselinePath,
+        ],
+        { cwd: packageRoot, env: process.env },
+      );
+      let output = '';
+      child.stdout.on('data', (chunk) => {
+        output += String(chunk);
+      });
+      child.stderr.on('data', (chunk) => {
+        output += String(chunk);
+      });
+      child.on('error', rejectRun);
+      child.on('close', (code) => resolveRun({ code, output }));
+    },
+  );
+}
+
+async function modernRequest(
+  target: McpHttpHandler,
+  method: string,
+  headerMethod = method,
+) {
+  const response = await target.fetch(
+    new Request('http://localhost/mcp', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'mcp-method': headerMethod,
+        'mcp-protocol-version': '2026-07-28',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method,
+        params: {
+          _meta: {
+            [PROTOCOL_VERSION_META_KEY]: '2026-07-28',
+            [CLIENT_INFO_META_KEY]: {
+              name: 'smrt-conformance',
+              version: '0.0.0',
+            },
+            [CLIENT_CAPABILITIES_META_KEY]: {},
+          },
+        },
+      }),
+    }),
+  );
+  return { status: response.status, body: (await response.json()) as any };
+}

--- a/packages/smrt-dev-mcp/src/mcp-stdio.test.ts
+++ b/packages/smrt-dev-mcp/src/mcp-stdio.test.ts
@@ -1,8 +1,8 @@
 import { existsSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { Client } from '@modelcontextprotocol/client';
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -24,7 +24,10 @@ async function createMcpClient() {
   });
   const client = new Client(
     { name: 'smrt-dev-mcp-smoke-test', version: '1.0.0' },
-    { capabilities: {} },
+    {
+      capabilities: {},
+      versionNegotiation: { mode: { pin: '2026-07-28' } },
+    },
   );
 
   activeClient = client;

--- a/packages/smrt-dev-mcp/vite.config.ts
+++ b/packages/smrt-dev-mcp/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
-        /^@modelcontextprotocol\/sdk/,
+        /^@modelcontextprotocol\//,
         /^@happyvertical\/smrt-core/,
         /^@happyvertical\/smrt-scanner/,
         /^node:/,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,6 +352,9 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
+      '@modelcontextprotocol/client':
+        specifier: 2.0.0
+        version: 2.0.0
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,7 +216,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -345,9 +345,9 @@ importers:
       '@happyvertical/smrt-users':
         specifier: workspace:*
         version: link:../users
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.25.2
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@modelcontextprotocol/server':
+        specifier: 2.0.0
+        version: 2.0.0
     devDependencies:
       '@happyvertical/smrt-core':
         specifier: workspace:*
@@ -372,7 +372,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -516,7 +516,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/smrt-agents':
         specifier: workspace:*
         version: link:../agents
@@ -586,7 +586,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -724,10 +724,10 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/documents':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -742,10 +742,10 @@ importers:
         version: 0.84.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/ocr':
         specifier: ^0.61.4
-        version: 0.61.4(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
+        version: 0.61.4(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/pdf':
         specifier: ^0.65.9
-        version: 0.65.9(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
+        version: 0.65.9(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/smrt-assets':
         specifier: workspace:*
         version: link:../assets
@@ -836,7 +836,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -915,7 +915,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -985,7 +985,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -1056,7 +1056,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -1090,7 +1090,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/images':
         specifier: ^0.84.0
         version: 0.84.0(jimp@1.6.1)(sharp@0.35.3(@types/node@24.13.2))
@@ -1252,7 +1252,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/logger':
         specifier: ^0.84.0
         version: 0.84.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
@@ -1411,6 +1411,43 @@ importers:
         specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@26.1.0)(vite@8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  packages/mcp-conformance-fixture:
+    dependencies:
+      '@happyvertical/smrt-config':
+        specifier: workspace:*
+        version: link:../config
+      '@happyvertical/smrt-core':
+        specifier: workspace:*
+        version: link:../core
+      '@modelcontextprotocol/server':
+        specifier: 2.0.0
+        version: 2.0.0
+    devDependencies:
+      '@happyvertical/smrt-vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@modelcontextprotocol/client':
+        specifier: 2.0.0
+        version: 2.0.0
+      '@modelcontextprotocol/conformance':
+        specifier: 0.2.0-alpha.10
+        version: 0.2.0-alpha.10(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/node':
+        specifier: 2.0.0
+        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.27)
+      '@types/node':
+        specifier: 24.13.2
+        version: 24.13.2
+      tsx:
+        specifier: ^4.23.0
+        version: 4.23.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+
   packages/messages:
     dependencies:
       '@happyvertical/email':
@@ -1540,7 +1577,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/cache':
         specifier: ^0.84.0
         version: 0.84.0(@opentelemetry/api@1.9.1)
@@ -1592,7 +1629,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -1677,7 +1714,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -1735,7 +1772,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/logger':
         specifier: ^0.84.0
         version: 0.84.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
@@ -2061,10 +2098,16 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.25.2
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@modelcontextprotocol/server':
+        specifier: 2.0.0
+        version: 2.0.0
     devDependencies:
+      '@modelcontextprotocol/conformance':
+        specifier: 0.2.0-alpha.10
+        version: 0.2.0-alpha.10(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/node':
+        specifier: 2.0.0
+        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.27)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -2089,10 +2132,19 @@ importers:
       '@happyvertical/smrt-types':
         specifier: workspace:*
         version: link:../types
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.25.2
-        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@modelcontextprotocol/server':
+        specifier: 2.0.0
+        version: 2.0.0
     devDependencies:
+      '@modelcontextprotocol/client':
+        specifier: 2.0.0
+        version: 2.0.0
+      '@modelcontextprotocol/conformance':
+        specifier: 0.2.0-alpha.10
+        version: 0.2.0-alpha.10(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/node':
+        specifier: 2.0.0
+        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.27)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -2502,7 +2554,7 @@ importers:
     dependencies:
       '@happyvertical/ai':
         specifier: ^0.84.0
-        version: 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        version: 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
         specifier: ^0.84.0
         version: 0.84.0
@@ -4298,8 +4350,30 @@ packages:
   '@mlc-ai/web-llm@0.2.84':
     resolution: {integrity: sha512-hrOWzK4/nGNmgoRKT8pgVmZZ2oEPpbblIWQOwpqNyvK2dysHw3KVB1gNJOuRcQfKOPhucEhX1NJzXzgMDnwSCQ==}
 
-  '@modelcontextprotocol/sdk@1.27.1':
-    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/conformance@0.2.0-alpha.10':
+    resolution: {integrity: sha512-0V/HZDdWHcg6j0zVBzBsXcPZ571IVi6umKgTpnBhtTx/jm/LONmGF6cIWL2k4Xjyps0OiHV6B37nj2s0pUg0nQ==}
+    hasBin: true
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/node@2.0.0':
+    resolution: {integrity: sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/server': ^2.0.0
+      hono: 4.12.27
+    peerDependenciesMeta:
+      hono:
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -4307,6 +4381,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
@@ -4523,6 +4601,64 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@octokit/auth-token@6.0.0':
+    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
+    engines: {node: '>= 20'}
+
+  '@octokit/core@7.0.7':
+    resolution: {integrity: sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/endpoint@11.0.4':
+    resolution: {integrity: sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@9.0.4':
+    resolution: {integrity: sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/openapi-types@28.0.0':
+    resolution: {integrity: sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==}
+
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@6.0.0':
+    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0':
+    resolution: {integrity: sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@7.1.1':
+    resolution: {integrity: sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.13':
+    resolution: {integrity: sha512-v2269YxL9Yf+x3d+gRI63FP0vFQEiWgLyBzxe/Y+0yFDg2B/Tzf5dhh9VNfccVAQnfcfwQWyk/y6Bn7rUXXs7A==}
+    engines: {node: '>= 20'}
+
+  '@octokit/rest@22.0.1':
+    resolution: {integrity: sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@octokit/types@17.0.0':
+    resolution: {integrity: sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==}
 
   '@openpgp/web-stream-tools@0.3.1':
     resolution: {integrity: sha512-EV+VQ4Dr8b+JmlGnc74FLgx7EhLyydOr4j6s6Hp+2scQh6sLQMs2h+1oEYUIslXcQPicWKG5ZQx+/dua0dgPWA==}
@@ -6131,6 +6267,9 @@ packages:
   bech32@2.0.0:
     resolution: {integrity: sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==}
 
+  before-after-hook@4.0.0:
+    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -6808,8 +6947,8 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -7530,6 +7669,9 @@ packages:
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  json-with-bigint@3.5.10:
+    resolution: {integrity: sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -9250,6 +9392,9 @@ packages:
 
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -11036,14 +11181,14 @@ snapshots:
       - supports-color
     optional: true
 
-  '@google/genai@1.50.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))':
+  '@google/genai@1.50.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))':
     dependencies:
       google-auth-library: 10.7.0
       p-retry: 4.6.2
       protobufjs: 7.6.5
       ws: 8.21.0
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -11086,11 +11231,11 @@ snapshots:
 
   '@gutenye/ocr-models@1.4.2': {}
 
-  '@happyvertical/ai@0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+  '@happyvertical/ai@0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1034.0
-      '@google/genai': 1.50.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))
+      '@google/genai': 1.50.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))
       '@happyvertical/utils': 0.84.0
       openai: 6.34.0(ws@8.21.0)(zod@4.3.6)
     transitivePeerDependencies:
@@ -11111,11 +11256,11 @@ snapshots:
       - '@node-rs/xxhash'
       - '@opentelemetry/api'
 
-  '@happyvertical/documents@0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)':
+  '@happyvertical/documents@0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)':
     dependencies:
       '@happyvertical/files': 0.84.0
-      '@happyvertical/ocr': 0.61.4(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
-      '@happyvertical/pdf': 0.65.9(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
+      '@happyvertical/ocr': 0.61.4(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
+      '@happyvertical/pdf': 0.65.9(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/spider': 1.1.13(@opentelemetry/api@1.9.1)(@types/node@24.13.2)
       '@happyvertical/utils': 0.84.0
       uuid: 13.0.2
@@ -11231,11 +11376,11 @@ snapshots:
       - debug
       - supports-color
 
-  '@happyvertical/ocr@0.61.4(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)':
+  '@happyvertical/ocr@0.61.4(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)':
     dependencies:
       '@gutenye/ocr-common': 1.4.8
       '@gutenye/ocr-models': 1.4.2
-      '@happyvertical/ai': 0.84.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@happyvertical/ai': 0.84.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/utils': 0.84.0
       onnxruntime-common: 1.27.0
       onnxruntime-node: 1.27.0
@@ -11251,9 +11396,9 @@ snapshots:
       - ws
       - zod
 
-  '@happyvertical/pdf@0.65.9(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)':
+  '@happyvertical/pdf@0.65.9(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)':
     dependencies:
-      '@happyvertical/ocr': 0.61.4(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
+      '@happyvertical/ocr': 0.61.4(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/utils': 0.84.0
       '@napi-rs/canvas': 0.1.100
       marked: 18.0.7
@@ -11883,7 +12028,43 @@ snapshots:
     dependencies:
       loglevel: 1.9.2
 
-  '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
+  '@modelcontextprotocol/client@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      jose: 6.2.3
+      pkce-challenge: 5.0.1
+      zod: 4.3.6
+
+  '@modelcontextprotocol/conformance@0.2.0-alpha.10(@cfworker/json-schema@4.1.1)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      '@octokit/rest': 22.0.1
+      commander: 14.0.3
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      jose: 6.2.3
+      undici: 7.29.0
+      yaml: 2.9.0
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.3.6
+
+  '@modelcontextprotocol/node@2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.27)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      '@modelcontextprotocol/server': 2.0.0
+    optionalDependencies:
+      hono: 4.12.27
+
+  '@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.27)
       ajv: 8.18.0
@@ -11892,7 +12073,7 @@ snapshots:
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
       hono: 4.12.27
@@ -11906,6 +12087,11 @@ snapshots:
       '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.3.6
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true
@@ -12050,6 +12236,75 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@octokit/auth-token@6.0.0': {}
+
+  '@octokit/core@7.0.7':
+    dependencies:
+      '@octokit/auth-token': 6.0.0
+      '@octokit/graphql': 9.0.4
+      '@octokit/request': 10.0.13
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      before-after-hook: 4.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.4':
+    dependencies:
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@9.0.4':
+    dependencies:
+      '@octokit/request': 10.0.13
+      '@octokit/types': 17.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/openapi-types@28.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 16.0.0
+
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.7)':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/types': 16.0.0
+
+  '@octokit/request-error@7.1.1':
+    dependencies:
+      '@octokit/types': 17.0.0
+
+  '@octokit/request@10.0.13':
+    dependencies:
+      '@octokit/endpoint': 11.0.4
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      content-type: 2.0.0
+      json-with-bigint: 3.5.10
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@22.0.1':
+    dependencies:
+      '@octokit/core': 7.0.7
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.7)
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
+  '@octokit/types@17.0.0':
+    dependencies:
+      '@octokit/openapi-types': 28.0.0
 
   '@openpgp/web-stream-tools@0.3.1(@types/node@24.13.2)(typescript@5.9.3)':
     optionalDependencies:
@@ -13421,6 +13676,8 @@ snapshots:
 
   bech32@2.0.0: {}
 
+  before-after-hook@4.0.0: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -14126,11 +14383,11 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  eventsource-parser@3.0.6: {}
+  eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.1.0
 
   exif-parser@0.1.12: {}
 
@@ -15102,6 +15359,8 @@ snapshots:
   json-schema-typed@8.0.2: {}
 
   json-stringify-safe@5.0.1: {}
+
+  json-with-bigint@3.5.10: {}
 
   json5@2.2.3: {}
 
@@ -16883,6 +17142,8 @@ snapshots:
     dependencies:
       pako: 0.2.9
       tiny-inflate: 1.0.3
+
+  universal-user-agent@7.0.3: {}
 
   universalify@0.1.2: {}
 

--- a/scripts/check-mcp-protocol-hygiene.mjs
+++ b/scripts/check-mcp-protocol-hygiene.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { extname, join, relative, resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const packagesDir = join(root, 'packages');
+const sourceExtensions = new Set(['.ts', '.mts', '.cts', '.js', '.mjs', '.cjs', '.svelte']);
+const skippedDirectories = new Set(['node_modules', 'dist', '.smrt', '.generated-tmp']);
+const banned = [
+  ['PingRequestSchema', 'ping was removed'],
+  ['logging/setLevel', 'logging/setLevel was removed'],
+  ['SetLevelRequestSchema', 'logging/setLevel was removed'],
+  ['notifications/roots/list_changed', 'roots list_changed was removed'],
+  ['RootsListChangedNotificationSchema', 'roots list_changed was removed'],
+  ['ListRootsRequestSchema', 'roots are deprecated'],
+  ['sampling/createMessage', 'sampling is deprecated'],
+  ['CreateMessageRequestSchema', 'sampling is deprecated'],
+  ['mcp-session-id', 'sessions were removed'],
+  ['SSEServerTransport', 'HTTP+SSE is deprecated'],
+  ['SSEClientTransport', 'HTTP+SSE is deprecated'],
+];
+const findings = [];
+
+for (const packageName of readdirSync(packagesDir)) {
+  const packageDir = join(packagesDir, packageName);
+  const manifestPath = join(packageDir, 'package.json');
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
+      if (manifest[section]?.['@modelcontextprotocol/sdk']) {
+        findings.push(`${relative(root, manifestPath)}: direct monolithic SDK dependency`);
+      }
+    }
+  } catch {}
+
+  const sourceDir = join(packageDir, 'src');
+  try {
+    if (statSync(sourceDir).isDirectory()) scan(sourceDir);
+  } catch {}
+}
+
+function scan(directory) {
+  for (const entry of readdirSync(directory)) {
+    if (skippedDirectories.has(entry)) continue;
+    const path = join(directory, entry);
+    if (statSync(path).isDirectory()) {
+      scan(path);
+      continue;
+    }
+    if (!sourceExtensions.has(extname(path))) continue;
+    const lines = readFileSync(path, 'utf8').split('\n');
+    lines.forEach((line, index) => {
+      if (line.includes('mcp-protocol-hygiene-allow:')) return;
+      for (const [token, reason] of banned) {
+        if (line.toLowerCase().includes(token.toLowerCase())) {
+          findings.push(`${relative(root, path)}:${index + 1}: ${reason} (${token})`);
+        }
+      }
+      if (/\b(?:client|server|mcp\w*)\s*\.\s*ping\s*\(/.test(line)) {
+        findings.push(`${relative(root, path)}:${index + 1}: ping was removed`);
+      }
+    });
+  }
+}
+
+if (findings.length) {
+  console.error(`MCP 2026-07-28 protocol hygiene failed:\n${findings.join('\n')}`);
+  process.exit(1);
+}
+console.log('MCP protocol hygiene passed: scoped SDK manifests and no removed features.');

--- a/scripts/check-mcp-protocol-hygiene.mjs
+++ b/scripts/check-mcp-protocol-hygiene.mjs
@@ -5,7 +5,14 @@ import { extname, join, relative, resolve } from 'node:path';
 const root = resolve(import.meta.dirname, '..');
 const packagesDir = join(root, 'packages');
 const sourceExtensions = new Set(['.ts', '.mts', '.cts', '.js', '.mjs', '.cjs', '.svelte']);
-const skippedDirectories = new Set(['node_modules', 'dist', '.smrt', '.generated-tmp']);
+const skippedDirectories = new Set([
+  'node_modules',
+  'dist',
+  'coverage',
+  '.smrt',
+  '.svelte-kit',
+  '.generated-tmp',
+]);
 const banned = [
   ['PingRequestSchema', 'ping was removed'],
   ['logging/setLevel', 'logging/setLevel was removed'],
@@ -23,7 +30,13 @@ const findings = [];
 
 for (const packageName of readdirSync(packagesDir)) {
   const packageDir = join(packagesDir, packageName);
-  const manifestPath = join(packageDir, 'package.json');
+  try {
+    scan(packageDir);
+  } catch {}
+}
+
+function scan(directory) {
+  const manifestPath = join(directory, 'package.json');
   try {
     const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
     for (const section of ['dependencies', 'devDependencies', 'peerDependencies']) {
@@ -33,13 +46,6 @@ for (const packageName of readdirSync(packagesDir)) {
     }
   } catch {}
 
-  const sourceDir = join(packageDir, 'src');
-  try {
-    if (statSync(sourceDir).isDirectory()) scan(sourceDir);
-  } catch {}
-}
-
-function scan(directory) {
   for (const entry of readdirSync(directory)) {
     if (skippedDirectories.has(entry)) continue;
     const path = join(directory, entry);

--- a/turbo.json
+++ b/turbo.json
@@ -110,6 +110,7 @@
         "test/**",
         "**/*.test.ts",
         "**/*.spec.ts",
+        "conformance-baseline.yml",
         "package.json",
         "vitest.config.ts",
         "vitest.config.js"


### PR DESCRIPTION
## Summary

- migrate shipped MCP consumers and generated Tier-1 servers to exact scoped MCP TypeScript SDK v2 packages
- serve the production app CLI bridge through the v2 factory-owned stdio path while preserving legacy clients and app result redaction
- add transport-neutral v2 factories for dev/app MCP, with access-error metadata allowlisting at the protocol boundary
- add official 2026-07-28 conformance rails for dev MCP, app MCP, and a genuinely generated fixture server
- add CI/pre-push protocol hygiene enforcement for removed/deprecated MCP features

## Validation

- `pnpm test:mcp-conformance` — dev MCP 2/2, app MCP 3/3, generated fixture 2/2
- app CLI — 106/106 tests; modern 2026-07-28 and legacy 2025-11-25 stdio negotiation; build/typecheck pass
- app MCP — 32/32 tests; adversarial access-error metadata leak regression; build/typecheck pass
- dev MCP — 124/124 tests; build/typecheck/packed-artifact verification pass on the prior exact head, unchanged by this focused review fix
- generated fixture — direct stdio negotiation and official suite pass; typecheck pass
- core MCP generator suites — 48/48 tests on the prior exact head, unchanged by this focused review fix
- protocol hygiene, formatting, diff check, knowledge freshness, workflow validation, package DAG, and pre-push policy hooks pass
- protocol/security review and manual QA approve the final behavior; final lifecycle gate follows exact-head CI and release

## Scope notes

The official conformance CLI's transitive monolithic v1 SDK is a documented development-only exception; every direct dependency and shipped/generated import uses exact scoped v2 `2.0.0` packages.

This intentionally does not add the production app HTTP endpoint owned by #2147 or tasks/output-schema/caching work owned by #2148–#2150.

Closes #2146

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-2146-reviewfix-20260805","issue":"2146","policy_revision":"1.0.0","status":"complete","validation":["pnpm test:mcp-conformance: dev 2/2, app 3/3, generated fixture 2/2","app-cli 106/106 with 2026-07-28 and 2025-11-25 stdio negotiation; app-mcp 32/32 with metadata leak regression","app-cli/app-mcp typechecks and builds, hygiene, formatting, knowledge, workflow, DAG, and pre-push policy checks green","final protocol/security review and manual QA approved; gate pending exact-head CI and release"]}
```
