### PR TITLE
feat(fields): add FieldPolicy model, layered resolver, and batch resolve action

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -24,6 +24,7 @@
       "@happyvertical/smrt-events",
       "@happyvertical/smrt-facts",
       "@happyvertical/smrt-features",
+      "@happyvertical/smrt-fields",
       "@happyvertical/smrt-gnode",
       "@happyvertical/smrt-images",
       "@happyvertical/smrt-inventory",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ for package-specific architecture and validation.
 ## Orientation
 
 - Foundation: `core`, `config`, `types`, `scanner`, `tenancy`, `vitest`, `cli`.
-- Runtime: `agents`, `jobs`, `users`, `profiles`, `personas`.
+- Runtime: `agents`, `jobs`, `users`, `profiles`, `personas`, `fields`.
 - Domain packages include content/media, commerce, events, places, facts, sites,
   properties, tags, social, marketing, and secrets.
 - Client/tooling packages include `smrt-web`, `smrt-svelte`, mobile packages,

--- a/packages/core/src/generators/rest-custom-actions.spec.ts
+++ b/packages/core/src/generators/rest-custom-actions.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * Contract coverage for the runtime REST transport's decorator-declared
+ * custom COLLECTION action dispatch (#2047).
+ *
+ * The generated SvelteKit/CLI/MCP transports already share one custom-action
+ * contract via `./custom-action` (scope resolution, argument projection,
+ * returned-failure normalization). These tests pin that the runtime
+ * `APIGenerator` transport matches it, because a divergence here silently
+ * degrades an action request into a CRUD write.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection';
+import { field } from '../decorators';
+import { SmrtObject } from '../object';
+import { ObjectRegistry, smrt } from '../registry';
+import { getTestDatabase } from '../testing/database';
+import { APIGenerator } from './rest';
+
+// `scope` is OMITTED on every route below: it is optional and defaults to
+// `collection` for statics / `item` for instance methods. Requiring a literal
+// `scope: 'collection'` used to skip these routes entirely, letting
+// `POST /<collection>/<action>` fall through into `create`.
+@smrt({
+  api: {
+    public: true,
+    include: ['create', 'list', 'get', 'quote', 'ping', 'refuse'],
+    routes: {
+      quote: { method: 'POST', path: 'quote' },
+      ping: { method: 'POST', path: 'ping' },
+      refuse: { method: 'POST', path: 'refuse' },
+    },
+  },
+})
+class ActionWidget extends SmrtObject {
+  @field({ type: 'text' })
+  name: string = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.name !== undefined) this.name = options.name;
+  }
+}
+
+class ActionWidgetCollection extends SmrtCollection<ActionWidget> {
+  static readonly _itemClass = ActionWidget;
+
+  /** Single `options` bag — the common shape, passed straight through. */
+  async quote(options: { symbol?: string } = {}): Promise<{ symbol: string }> {
+    return { symbol: options.symbol ?? 'none' };
+  }
+
+  /** Zero parameters — must dispatch with NO request body at all. */
+  async ping(): Promise<{ pong: true }> {
+    return { pong: true };
+  }
+
+  /** Returns the shared `{ ok: false }` failure convention. */
+  async refuse(): Promise<unknown> {
+    return {
+      ok: false,
+      code: 'not_allowed',
+      message: 'refused with token=supersecret in the text',
+      status: 422,
+    };
+  }
+}
+
+describe('runtime REST custom collection actions (#2047)', () => {
+  ObjectRegistry.registerCollection('ActionWidget', ActionWidgetCollection);
+
+  let db: any;
+  let handler: (req: Request) => Promise<Response>;
+
+  beforeAll(async () => {
+    db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['ActionWidget'],
+    });
+    const collection = await ActionWidgetCollection.create({ db });
+    const api = new APIGenerator({ basePath: '/api/v1' }, { db });
+    api.registerCollection('actionwidgets', collection);
+    handler = api.generateHandler();
+  });
+
+  afterAll(async () => {
+    await db?.close?.();
+  });
+
+  const post = (path: string, body?: unknown): Promise<Response> =>
+    handler(
+      new Request(`http://localhost/api/v1/actionwidgets/${path}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      }),
+    );
+
+  it('dispatches an action whose route omits an explicit scope', async () => {
+    const response = await post('quote', { symbol: 'HV' });
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      action: string;
+      result: { symbol: string };
+    };
+    expect(payload.action).toBe('quote');
+    expect(payload.result.symbol).toBe('HV');
+
+    // Critically, it must NOT have degraded into a create: `create` is
+    // exposed on this object, so a fall-through would have persisted a row
+    // (and returned 201) instead of invoking the action.
+    const listed = await handler(
+      new Request('http://localhost/api/v1/actionwidgets'),
+    );
+    const listedPayload = (await listed.json()) as { data?: unknown[] };
+    expect(listedPayload.data ?? []).toHaveLength(0);
+  });
+
+  it('invokes a zero-parameter action without requiring a request body', async () => {
+    const response = await post('ping');
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      action: string;
+      result: { pong: boolean };
+    };
+    expect(payload.action).toBe('ping');
+    expect(payload.result.pong).toBe(true);
+  });
+
+  it('maps a returned failure to its status and redacts the payload', async () => {
+    const response = await post('refuse');
+    expect(response.status).toBe(422);
+    const payload = (await response.json()) as {
+      error: { ok: boolean; code: string; message: string; status: number };
+      action?: string;
+    };
+    // Never a 200 wrapping the raw failure object.
+    expect(payload.action).toBeUndefined();
+    expect(payload.error.ok).toBe(false);
+    expect(payload.error.code).toBe('not_allowed');
+    expect(payload.error.status).toBe(422);
+    expect(payload.error.message).toContain('[REDACTED]');
+    expect(payload.error.message).not.toContain('supersecret');
+  });
+});

--- a/packages/core/src/generators/rest.ts
+++ b/packages/core/src/generators/rest.ts
@@ -14,6 +14,7 @@ import {
 import type { PublicJsonOptions, SmrtObject } from '../object';
 import { ObjectRegistry } from '../registry';
 import type {
+  ApiCustomRouteConfig,
   RegisteredClass,
   RegisteredField,
   SmrtObjectConstructor,
@@ -556,6 +557,22 @@ export class APIGenerator {
     objectName?: string,
   ): Promise<Response> {
     try {
+      // Decorator-declared custom collection actions dispatch BEFORE CRUD
+      // routing: without this, `POST /<collection>/<action>` would fall into
+      // `handleCreate` with the action segment silently discarded (#2047).
+      if (objectId && objectName) {
+        const customResponse = await this.dispatchCustomCollectionAction(
+          req,
+          collection,
+          objectId,
+          url,
+          objectName,
+        );
+        if (customResponse) {
+          return customResponse;
+        }
+      }
+
       const action = this.getCrudAction(req.method, objectId);
       if (action && !this.isApiActionEnabled(objectName, action)) {
         return this.createErrorResponse(405, 'Method not allowed');
@@ -697,6 +714,157 @@ export class APIGenerator {
 
     const registered = ObjectRegistry.getClassByConstructor(itemClass);
     return registered?.qualifiedName || registered?.name || itemClass.name;
+  }
+
+  /**
+   * Dispatch a decorator-declared custom COLLECTION-scoped action —
+   * `@smrt({ api: { include: [...], routes: { action: { scope: 'collection',
+   * method, path } } } })` — on the runtime transport (#2047). The generated
+   * SvelteKit transport already dispatches these routes; this keeps the two
+   * transports coherent for the same decorator metadata.
+   *
+   * Deliberately narrow, matching this router's URL shape: single-segment
+   * collection-scoped paths only (multi-segment custom paths remain a
+   * SvelteKit-transport feature), the action must be exposed by `api.include`
+   * (and not excluded), and the HTTP method must match the route metadata.
+   * Non-matching requests fall through to CRUD handling unchanged. A matched
+   * route whose implementation cannot be resolved returns 501 rather than
+   * falling through — the request must never degrade into a malformed CRUD
+   * write.
+   *
+   * The single-options-parameter convention mirrors the generated SvelteKit
+   * action routes: non-GET bodies parse as the options object, GET query
+   * params become the options object, and the response wraps the sanitized
+   * result as `{ action, result }`.
+   */
+  private async dispatchCustomCollectionAction(
+    req: Request,
+    collection: SmrtCollection<SmrtObject>,
+    pathSegment: string,
+    url: URL,
+    objectName: string,
+  ): Promise<Response | null> {
+    const apiConfig = ObjectRegistry.getConfig(objectName)?.api;
+    if (!apiConfig || typeof apiConfig !== 'object' || !apiConfig.routes) {
+      return null;
+    }
+
+    for (const [actionName, routeConfig] of Object.entries(
+      apiConfig.routes as Record<string, ApiCustomRouteConfig>,
+    )) {
+      if (routeConfig?.scope !== 'collection') {
+        continue;
+      }
+      const routePath = routeConfig.path || actionName;
+      if (routePath.includes('/') || routePath !== pathSegment) {
+        continue;
+      }
+      const routeMethod = (routeConfig.method || 'POST').toUpperCase();
+      if (routeMethod !== req.method.toUpperCase()) {
+        continue;
+      }
+      // Explicit exposure only: same include/exclude gating as the SvelteKit
+      // generator applies to custom actions.
+      if (apiConfig.include && !apiConfig.include.includes(actionName)) {
+        continue;
+      }
+      if (apiConfig.exclude?.includes(actionName)) {
+        continue;
+      }
+
+      // Receiver: an instance method on the registered collection, or a
+      // static on the item class (the two hosts the generators support).
+      const collectionMethod = (
+        collection as unknown as Record<string, unknown>
+      )[actionName];
+      const itemConstructor = ObjectRegistry.getClass(objectName)
+        ?.constructor as unknown as Record<string, unknown> | undefined;
+      const staticMethod = itemConstructor?.[actionName];
+
+      const invoke =
+        typeof collectionMethod === 'function'
+          ? (options: unknown) =>
+              (collectionMethod as (o: unknown) => unknown).call(
+                collection,
+                options,
+              )
+          : typeof staticMethod === 'function'
+            ? (options: unknown) =>
+                (staticMethod as (o: unknown) => unknown).call(
+                  itemConstructor,
+                  options,
+                )
+            : null;
+
+      if (!invoke) {
+        return this.createErrorResponse(
+          501,
+          `Custom action '${actionName}' is declared but not implemented`,
+        );
+      }
+
+      let options: unknown;
+      if (routeMethod === 'GET') {
+        options = Object.fromEntries(url.searchParams.entries());
+      } else {
+        try {
+          options = await req.json();
+        } catch {
+          return this.createErrorResponse(400, 'Invalid JSON body');
+        }
+      }
+
+      const result = await invoke(options);
+      return this.createJsonResponse({
+        action: actionName,
+        result: this.sanitizeActionResult(result),
+      });
+    }
+
+    return null;
+  }
+
+  /**
+   * Public-safe projection for custom-action results, mirroring the generated
+   * SvelteKit routes' `toPublicResult`: a `SmrtObject` (anything exposing
+   * `toPublicJSON`) becomes its public projection with the caller's
+   * permissions, arrays and plain objects are walked, non-plain instances and
+   * primitives pass through, and a cycle guard breaks reference loops.
+   */
+  private sanitizeActionResult(
+    value: unknown,
+    seen: WeakSet<object> = new WeakSet(),
+  ): unknown {
+    if (value === null || typeof value !== 'object') {
+      return value;
+    }
+    if (seen.has(value)) {
+      return null;
+    }
+    const serializable = value as {
+      toPublicJSON?: (options?: PublicJsonOptions) => unknown;
+    };
+    if (typeof serializable.toPublicJSON === 'function') {
+      seen.add(value);
+      return this.sanitizeActionResult(
+        serializable.toPublicJSON(this.getPublicJsonOptions()),
+        seen,
+      );
+    }
+    if (Array.isArray(value)) {
+      seen.add(value);
+      return value.map((entry) => this.sanitizeActionResult(entry, seen));
+    }
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== Object.prototype && proto !== null) {
+      return value;
+    }
+    seen.add(value);
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      out[key] = this.sanitizeActionResult(entry, seen);
+    }
+    return out;
   }
 
   /**

--- a/packages/core/src/generators/rest.ts
+++ b/packages/core/src/generators/rest.ts
@@ -856,14 +856,23 @@ export class APIGenerator {
         }
       }
 
-      const result = await invoke(
-        buildCustomActionInvocationArgs(metadata, {
-          ...(options && typeof options === 'object' && !Array.isArray(options)
-            ? (options as Record<string, unknown>)
-            : {}),
-          options,
-        }),
-      );
+      // Project declared parameters only when the registry actually knows
+      // them. Without metadata the historical single-options call is kept
+      // verbatim, so an opaque body (an array, or any non-record payload an
+      // existing action already accepts) still arrives unchanged rather than
+      // being silently normalized away.
+      const invocationArgs = metadata.parameters
+        ? buildCustomActionInvocationArgs(metadata, {
+            ...(options &&
+            typeof options === 'object' &&
+            !Array.isArray(options)
+              ? (options as Record<string, unknown>)
+              : {}),
+            options,
+          })
+        : [options];
+
+      const result = await invoke(invocationArgs);
 
       const failure = normalizeCustomActionFailure(result);
       if (failure) {

--- a/packages/core/src/generators/rest.ts
+++ b/packages/core/src/generators/rest.ts
@@ -45,6 +45,11 @@ import {
   warnIfSharedCacheNeutralized,
   warnIfTenantScopedPublicRead,
 } from './conditional-get';
+import {
+  buildCustomActionInvocationArgs,
+  normalizeCustomActionFailure,
+  resolveCustomActionMetadata,
+} from './custom-action';
 import { handleEventsRoute } from './events-route';
 
 export interface APIConfig {
@@ -727,15 +732,24 @@ export class APIGenerator {
    * collection-scoped paths only (multi-segment custom paths remain a
    * SvelteKit-transport feature), the action must be exposed by `api.include`
    * (and not excluded), and the HTTP method must match the route metadata.
-   * Non-matching requests fall through to CRUD handling unchanged. A matched
-   * route whose implementation cannot be resolved returns 501 rather than
-   * falling through — the request must never degrade into a malformed CRUD
-   * write.
+   * Non-matching requests fall through to CRUD handling unchanged.
    *
-   * The single-options-parameter convention mirrors the generated SvelteKit
-   * action routes: non-GET bodies parse as the options object, GET query
-   * params become the options object, and the response wraps the sanitized
-   * result as `{ action, result }`.
+   * Scope is resolved through the shared `resolveCustomActionMetadata`
+   * contract, not read off the route alone: `scope` is OPTIONAL and defaults
+   * to `collection` for statics and `item` for instance methods, so requiring
+   * a literal `scope: 'collection'` would skip a valid static action and let
+   * `POST /<collection>/<action>` fall through into `create`. The receiver
+   * decides — a route-only scope cannot manufacture one — so an action with no
+   * collection-hosted receiver falls through unless the route explicitly
+   * declared `scope: 'collection'`, in which case it is declared-but-missing
+   * and returns 501 rather than degrading into a malformed CRUD write.
+   *
+   * Arguments, failures, and result shaping all reuse the shared custom-action
+   * helpers so this transport matches generated REST/CLI/MCP exactly: declared
+   * parameters are projected (a zero-parameter action takes no body at all, an
+   * `options` bag is passed through, named parameters are read off the body),
+   * a returned `{ ok: false, ... }` failure becomes its requested non-2xx
+   * status with a redacted payload, and success wraps as `{ action, result }`.
    */
   private async dispatchCustomCollectionAction(
     req: Request,
@@ -752,14 +766,11 @@ export class APIGenerator {
     for (const [actionName, routeConfig] of Object.entries(
       apiConfig.routes as Record<string, ApiCustomRouteConfig>,
     )) {
-      if (routeConfig?.scope !== 'collection') {
-        continue;
-      }
-      const routePath = routeConfig.path || actionName;
+      const routePath = routeConfig?.path || actionName;
       if (routePath.includes('/') || routePath !== pathSegment) {
         continue;
       }
-      const routeMethod = (routeConfig.method || 'POST').toUpperCase();
+      const routeMethod = (routeConfig?.method || 'POST').toUpperCase();
       if (routeMethod !== req.method.toUpperCase()) {
         continue;
       }
@@ -780,41 +791,85 @@ export class APIGenerator {
       const itemConstructor = ObjectRegistry.getClass(objectName)
         ?.constructor as unknown as Record<string, unknown> | undefined;
       const staticMethod = itemConstructor?.[actionName];
+      const isCollectionHosted = typeof collectionMethod === 'function';
+      const isStaticHosted =
+        !isCollectionHosted && typeof staticMethod === 'function';
 
-      const invoke =
-        typeof collectionMethod === 'function'
-          ? (options: unknown) =>
-              (collectionMethod as (o: unknown) => unknown).call(
-                collection,
-                options,
-              )
-          : typeof staticMethod === 'function'
-            ? (options: unknown) =>
-                (staticMethod as (o: unknown) => unknown).call(
-                  itemConstructor,
-                  options,
-                )
-            : null;
-
-      if (!invoke) {
-        return this.createErrorResponse(
-          501,
-          `Custom action '${actionName}' is declared but not implemented`,
-        );
+      if (!isCollectionHosted && !isStaticHosted) {
+        // Declared collection routes must not degrade into a CRUD write;
+        // anything else (an item-scoped action reached at the collection URL,
+        // or an unrelated segment) falls through unchanged.
+        if (routeConfig?.scope === 'collection') {
+          return this.createErrorResponse(
+            501,
+            `Custom action '${actionName}' is declared but not implemented`,
+          );
+        }
+        continue;
       }
 
+      const metadata = resolveCustomActionMetadata({
+        actionName,
+        apiConfig,
+        method: ObjectRegistry.getMethods(objectName)?.get(actionName),
+        // A collection instance method is collection-hosted even when it is
+        // not static; a static on the item class already defaults the same
+        // way. Either receiver makes this route collection-targeted.
+        defaultScope: 'collection',
+      });
+      if (metadata.scope !== 'collection') {
+        continue;
+      }
+
+      const invoke = isCollectionHosted
+        ? (args: unknown[]) =>
+            (collectionMethod as (...a: unknown[]) => unknown).apply(
+              collection,
+              args,
+            )
+        : (args: unknown[]) =>
+            (staticMethod as (...a: unknown[]) => unknown).apply(
+              itemConstructor,
+              args,
+            );
+
+      // An ABSENT body is "no input", not a malformed one — a zero-parameter
+      // action is legitimately called with no body at all. A body that is
+      // present but unparseable stays a 400 rather than degrading into a CRUD
+      // write. GET reads the query string instead.
       let options: unknown;
       if (routeMethod === 'GET') {
         options = Object.fromEntries(url.searchParams.entries());
       } else {
+        let rawBody = '';
         try {
-          options = await req.json();
+          rawBody = await req.text();
         } catch {
-          return this.createErrorResponse(400, 'Invalid JSON body');
+          rawBody = '';
+        }
+        if (rawBody.trim() !== '') {
+          try {
+            options = JSON.parse(rawBody);
+          } catch {
+            return this.createErrorResponse(400, 'Invalid JSON body');
+          }
         }
       }
 
-      const result = await invoke(options);
+      const result = await invoke(
+        buildCustomActionInvocationArgs(metadata, {
+          ...(options && typeof options === 'object' && !Array.isArray(options)
+            ? (options as Record<string, unknown>)
+            : {}),
+          options,
+        }),
+      );
+
+      const failure = normalizeCustomActionFailure(result);
+      if (failure) {
+        return this.createJsonResponse({ error: failure }, failure.status);
+      }
+
       return this.createJsonResponse({
         action: actionName,
         result: this.sanitizeActionResult(result),

--- a/packages/fields/AGENTS.md
+++ b/packages/fields/AGENTS.md
@@ -19,7 +19,11 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
   precedent). Reads go through `resolveBatch` (context-scoped) or the
   server-side resolver. Keep the api include lists in lockstep: a decorated
   collection's config is the RUNTIME registry authority for its item class,
-  while build-time generation reads each manifest object's own config.
+  while build-time generation reads each manifest object's own config. Both
+  transports dispatch the action: generated SvelteKit routes natively, and
+  core's runtime `APIGenerator` via its decorator-route dispatch
+  (single-segment collection-scoped paths; multi-segment custom paths remain
+  SvelteKit-only).
 - `resolveFieldPolicy(objectRef, { tenantId, userId, db })` — merged policy
 - `resolveFieldPolicyExplained(...)` — merged policy plus ordered per-layer
   contributions (code/app/tenant/user) for gear/admin UIs (#2049/#2050)
@@ -55,8 +59,12 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
   never apply).
 - **Security rail**: defaults are refused on `transient`, `sensitive`, and
   `readPermission`-gated fields (both top-level and `_meta` flags checked).
-  `resolveBatch` responses omit sensitive/read-permission-gated fields for
-  every caller (fail closed) and transient fields (client-emission parity).
+  Reference-field (`foreignKey`/`crossPackageRef`) defaults must be UUID
+  strings unless the field declares `idType: 'text'` — the columns are
+  native UUID on PostgreSQL/DuckDB and a non-UUID default would fail at
+  insert time. `resolveBatch` responses omit sensitive/read-permission-gated
+  fields for every caller (fail closed) and transient fields
+  (client-emission parity).
 - **Required-field invariant**: demoting a required field to
   advanced/hidden requires a usable resolved default (not null/empty) —
   enforced at write time AND re-enforced at resolution (a required field with
@@ -72,12 +80,18 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
   remains the authoritative enforcement at read time.
 - **Isolation**: a non-bypass tenant context may only resolve/write its own
   tenant (and own user when the context carries one); app-scope writes inside
-  a tenant context require super-admin bypass. `save()` and `delete()` on an
-  EXISTING row additionally authorize the caller against the row's PERSISTED
-  scope before accepting anything — a foreign row cannot be re-scoped into
-  the caller's tenant/user or deleted by id from another tenant's context.
-  `resolveBatch` takes identity exclusively from the ambient tenant context —
-  the request body cannot select another tenant or user.
+  a tenant context require super-admin bypass. With NO ambient identity at
+  all (tenancy ALS never entered — e.g. a runtime API deployment without the
+  smrt-users session hook), only app-scope writes/deletes are accepted:
+  tenant- and user-scope rows are unattributable without a context and are
+  rejected outright. Residual: such ALS-less deployments can still write APP
+  rows with any authenticated principal until the #2049 permission layer
+  adds `fields:policy:manage`. `save()` and `delete()` on an EXISTING row
+  additionally authorize the caller against the row's PERSISTED scope before
+  accepting anything — a foreign row cannot be re-scoped into the caller's
+  tenant/user or deleted by id from another tenant's context. `resolveBatch`
+  takes identity exclusively from the ambient tenant context — the request
+  body cannot select another tenant or user.
 
 ## Caching and invalidation
 

--- a/packages/fields/AGENTS.md
+++ b/packages/fields/AGENTS.md
@@ -1,0 +1,89 @@
+# smrt-fields
+
+Layered field policy store and resolution engine (epic #2045). Personalizes
+per-field `{defaultValue, visibility, help, label, order, locked}` for any
+`@smrt()` object at app, tenant, and user scope over the code seed.
+
+## Core pieces
+
+- `FieldPolicy` (`_smrt_field_policies` table) — sparse override rows keyed
+  `(objectRef, fieldName, scopeType, scopeKey)`; NULL column = inherit from
+  the lower layer, reset = row DELETE (later lower-layer changes flow through)
+- `FieldPolicyCollection` — CRUD surface plus the `resolveBatch` custom
+  collection-scoped action (`POST /<collection>/resolve`)
+- `resolveFieldPolicy(objectRef, { tenantId, userId, db })` — merged policy
+- `resolveFieldPolicyExplained(...)` — merged policy plus ordered per-layer
+  contributions (code/app/tenant/user) for gear/admin UIs (#2049/#2050)
+
+## Resolution layers (priority low → high)
+
+1. Code seed — manifest field defaults, `description` as help, `_meta.ui`
+   hints (#2046: `basic`/`group`/`order`/`locked`; cold-start rule: no
+   `basic` markers ⇒ everything basic, any marker ⇒ unmarked fields advanced)
+2. App rows — `scopeType: 'app'`, `tenantId`/`userId` null
+3. Tenant rows — hierarchy walk root → leaf via an injected
+   `tenantHierarchyLoader` (smrt-features shape); the default loader
+   dynamic-imports `@happyvertical/smrt-users` and falls back to a flat
+   single-tenant chain when absent; chain nodes that break permission
+   inheritance reset their baseline to the app-layer state
+4. User rows — keyed by `userId` alone (preferences follow the user); both
+   defaults AND visibility resolve through this tier
+
+## Invariants
+
+- **Scope shape**: app ⇒ `tenantId`+`userId` null; tenant ⇒ only `tenantId`;
+  user ⇒ only `userId`. `scopeKey` (`userId ?? tenantId ?? '__app__'`) exists
+  ONLY to keep the `conflictColumns` unique index total — never read it for
+  scoping logic.
+- **Manifest as definition registry**: writes validate against the live
+  `ObjectRegistry` (never checked-in manifest.json artifacts): unknown
+  objectRef/fieldName rejected; defaults type-checked against the field type;
+  system fields and relationship pseudo-fields are not policy-addressable.
+- **Security rail**: defaults are refused on `transient`, `sensitive`, and
+  `readPermission`-gated fields (both top-level and `_meta` flags checked).
+  `resolveBatch` responses omit sensitive/read-permission-gated fields for
+  every caller (fail closed) and transient fields (client-emission parity).
+- **Required-field invariant**: demoting a required field to
+  advanced/hidden requires a usable resolved default (not null/empty) —
+  enforced at write time AND re-enforced at resolution (a required field with
+  no usable default always resolves `basic`, flagged `visibilityForced`).
+- **Org lock**: `locked` may be set on app/tenant rows only; while the
+  code/app/tenant tiers resolve locked, user-scope writes are rejected and
+  existing user rows are skipped at resolution.
+- **Isolation**: a non-bypass tenant context may only resolve/write its own
+  tenant (and own user when the context carries one); app-scope writes inside
+  a tenant context require super-admin bypass. `resolveBatch` takes identity
+  exclusively from the ambient tenant context — the request body cannot
+  select another tenant or user.
+
+## Caching and invalidation
+
+- Resolver results cached per `(dbNamespace, objectRef, tenantId, userId)`
+  with a 30s TTL (`cache.ts` mirrors smrt-prompts' `getDbNamespace`).
+- `FieldPolicy.save()`/`.delete()` invalidate ALL entries for the row's
+  `(db, objectRef)` — coarser than prompts because tenant hierarchy makes a
+  parent-tenant row affect every descendant's resolution.
+- `_smrt_field_policies` rows do NOT ride the client change feed: core's
+  change-feed writer deliberately skips `_smrt_`-prefixed system tables, and
+  the emit side is private. Live client invalidation is a core-side decision;
+  do not add custom push/emit paths here.
+
+## Gotchas
+
+- The sort-order column is `displayOrder` (resolved output exposes `order`):
+  a column literally named `order` is an SQL keyword the runtime INSERT path
+  does not quote.
+- `FieldPolicy` deliberately has NO class-level `@TenantScoped` (the
+  prompts/features precedent): resolution legitimately reads app rows and
+  ancestor-tenant rows, which the tenancy interceptor would block. Isolation
+  is enforced at the resolver/save boundaries instead.
+- Identity changes (objectRef/fieldName/scope) on a persisted row go through
+  delete-then-insert (transactional when the driver supports it) because the
+  natural-key upsert would otherwise collide with the primary key.
+
+## Related
+
+- `@happyvertical/smrt-prompts` / `smrt-languages` / `smrt-features` — the
+  same architecture family (override rows + layered resolver + TTL cache)
+- Core `FieldUIHints` (#2046) — the `@field({ ui })` code seed this package
+  resolves over

--- a/packages/fields/AGENTS.md
+++ b/packages/fields/AGENTS.md
@@ -78,25 +78,47 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
   locks are honored at save time too. On updates the resolver sees the row's
   persisted version (no self-exclusion), so the resolver-side safety net
   remains the authoritative enforcement at read time.
-- **Isolation**: a non-bypass tenant context may only resolve/write its own
-  tenant (and own user when the context carries one); app-scope writes inside
-  a tenant context require super-admin bypass. With NO ambient identity at
-  all (tenancy ALS never entered — e.g. a runtime API deployment without the
-  smrt-users session hook), only app-scope writes/deletes are accepted:
-  tenant- and user-scope rows are unattributable without a context and are
-  rejected outright. Residual: such ALS-less deployments can still write APP
-  rows with any authenticated principal until the #2049 permission layer
-  adds `fields:policy:manage`. `save()` and `delete()` on an EXISTING row
-  additionally authorize the caller against the row's PERSISTED scope before
-  accepting anything — a foreign row cannot be re-scoped into the caller's
-  tenant/user or deleted by id from another tenant's context. `resolveBatch`
-  takes identity exclusively from the ambient tenant context — the request
-  body cannot select another tenant or user.
+- **Isolation — a MISSING identity component DENIES, it never skips.** This
+  is the package rule; both the write guard
+  (`FieldPolicy.assertScopeOwnedByAmbientContext`) and the read guard
+  (`assertResolutionAllowedInContext`) obey it. A non-bypass tenant context
+  may only resolve/write its own tenant, and the user tier only for its own
+  user id — a context carrying permissions but NO `userId` (no `resolveUserId`
+  hook configured: API-key auth, service principals, background jobs, a bare
+  `withTenant({ tenantId })`) may not touch the user tier at all. Skipping
+  that check instead of denying it was a live ownership bypass: user rows are
+  `tenantId: null` by design, so nothing else contains such a write. App-scope
+  writes inside a tenant context require super-admin bypass. With NO ambient
+  identity at all (tenancy ALS never entered), only app-scope writes/deletes
+  are accepted; context-LESS *reads* stay allowed because
+  `resolveFieldPolicy` is a trusted server-side API. Residual: ALS-less
+  deployments can still write APP rows with any authenticated principal until
+  the #2049 permission layer adds `fields:policy:manage`. `save()`/`delete()`
+  on an existing row additionally authorize against the row's PERSISTED
+  scope, looked up by primary key AND — because a generated create always
+  mints a fresh UUID while the `conflictColumns` upsert still replaces the
+  occupant — by NATURAL key. `resolveBatch` takes identity exclusively from
+  the ambient context; the request body cannot select another tenant or user.
+- **Scope attribution**: inside an ambient context the model DERIVES a
+  missing `tenantId` (tenant rows) or `userId` (user rows) from that context,
+  and always stamps `updatedBy` from it. Core's mass-assignment guard treats
+  `tenantId` as server-managed and strips it from every generated write body
+  while `FieldPolicy` is deliberately not `@TenantScoped`, so without this the
+  org tier is write-dead over REST/SvelteKit (scope-shape validation throws).
+  Deriving grants nothing — the ownership guard already pinned the value to
+  the ambient one. An explicit value is never overwritten, so a super-admin
+  bypass caller writing ANOTHER tenant's row must go through a server-side
+  model call; the generated routes still strip it.
 
 ## Caching and invalidation
 
-- Resolver results cached per `(dbNamespace, objectRef, tenantId, userId)`
-  with a 30s TTL (`cache.ts` mirrors smrt-prompts' `getDbNamespace`).
+- Resolver results cached per
+  `(dbNamespace, objectRef, tenantId, userId, hierarchyLoader)` with a 30s TTL
+  (`cache.ts` mirrors smrt-prompts' `getDbNamespace`). The loader identity is
+  part of the key because an injected `tenantHierarchyLoader` yields a
+  different ancestor chain — and so different defaults/locks — for the same
+  `(db, objectRef, tenant, user)`; it goes LAST so the `(db, objectRef)`
+  prefix scan still invalidates every loader's entries.
 - `FieldPolicy.save()`/`.delete()` invalidate ALL entries for the row's
   `(db, objectRef)` — coarser than prompts because tenant hierarchy makes a
   parent-tenant row affect every descendant's resolution.
@@ -117,6 +139,19 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
 - Identity changes (objectRef/fieldName/scope) on a persisted row go through
   delete-then-insert (transactional when the driver supports it) because the
   natural-key upsert would otherwise collide with the primary key.
+- `withSystemContext()` does NOT unlock tenant/user-scope writes:
+  `getCurrentTenant()` returns undefined inside it, so the context-absent rule
+  rejects those tiers before any bypass check. Seeds and migrations that must
+  write org/user rows use a `superAdminBypass` context instead.
+- The MODEL's `cli`/`mcp` decorator config is dead at runtime: the registry
+  re-registers the item slot with the COLLECTION's config wholesale, so
+  `FieldPolicyCollection`'s `cli: false, mcp: false` is what actually closes
+  those surfaces. Keep both in lockstep anyway — build-time generation reads
+  the model's own config. Related: `ObjectRegistry.getTableName(
+  'FieldPolicyCollection')` resolves to the UNPREFIXED collection fallback
+  `field_policies`; persistence uses the item class
+  (`_smrt_field_policies`), and both are pinned in
+  `generated-surfaces.test.ts`.
 
 ## Related
 

--- a/packages/fields/AGENTS.md
+++ b/packages/fields/AGENTS.md
@@ -139,6 +139,15 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
 - Identity changes (objectRef/fieldName/scope) on a persisted row go through
   delete-then-insert (transactional when the driver supports it) because the
   natural-key upsert would otherwise collide with the primary key.
+- `FieldPolicyCollection` MUST repeat FieldPolicy's `conflictColumns`. A
+  decorated collection emits its OWN manifest schema for the item's table, and
+  without the natural key that schema falls back to SmrtObject's default unique
+  `(slug, context)` index; manifest-driven migrations aggregate both onto
+  `_smrt_field_policies`, where the stray index rejects legitimate layered rows
+  (all policy rows have NULL slug/context). The runtime registry cannot catch
+  this — `getAllSchemas()` is keyed by TABLE name, so the two schemas collapse
+  into one entry. Pinned against the generated manifest in
+  `generated-surfaces.test.ts`.
 - `withSystemContext()` does NOT unlock tenant/user-scope writes:
   `getCurrentTenant()` returns undefined inside it, so the context-absent rule
   rejects those tiers before any bypass check. Seeds and migrations that must

--- a/packages/fields/AGENTS.md
+++ b/packages/fields/AGENTS.md
@@ -9,8 +9,17 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
 - `FieldPolicy` (`_smrt_field_policies` table) — sparse override rows keyed
   `(objectRef, fieldName, scopeType, scopeKey)`; NULL column = inherit from
   the lower layer, reset = row DELETE (later lower-layer changes flow through)
-- `FieldPolicyCollection` — CRUD surface plus the `resolveBatch` custom
-  collection-scoped action (`POST /<collection>/resolve`)
+- `FieldPolicyCollection` — write surface plus the `resolveBatch` custom
+  collection-scoped action (`POST /<collection>/resolve`). NO generated
+  surface exposes read verbs: API `list`/`get` on this non-tenant-scoped
+  model would enumerate every tenant's and user's rows; the model's CLI is
+  writes-only (the generated CLI invokes over HTTP, and the cli↔api
+  coherence gate rejects CLI entries without API routes); the runtime
+  CLI/MCP surfaces are closed by the collection config (ContentContributions
+  precedent). Reads go through `resolveBatch` (context-scoped) or the
+  server-side resolver. Keep the api include lists in lockstep: a decorated
+  collection's config is the RUNTIME registry authority for its item class,
+  while build-time generation reads each manifest object's own config.
 - `resolveFieldPolicy(objectRef, { tenantId, userId, db })` — merged policy
 - `resolveFieldPolicyExplained(...)` — merged policy plus ordered per-layer
   contributions (code/app/tenant/user) for gear/admin UIs (#2049/#2050)
@@ -23,9 +32,12 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
 2. App rows — `scopeType: 'app'`, `tenantId`/`userId` null
 3. Tenant rows — hierarchy walk root → leaf via an injected
    `tenantHierarchyLoader` (smrt-features shape); the default loader
-   dynamic-imports `@happyvertical/smrt-users` and falls back to a flat
-   single-tenant chain when absent; chain nodes that break permission
-   inheritance reset their baseline to the app-layer state
+   dynamic-imports `@happyvertical/smrt-users` (missing-package failures —
+   `ERR_MODULE_NOT_FOUND` / "Cannot find package" across the cause chain —
+   fall back to a flat single-tenant chain). A node that breaks permission
+   inheritance discards every earlier tenant contribution (chain-structural),
+   so only the suffix from the LAST break participates — in merging AND in
+   the explained layers, which therefore replay to the merged result
 4. User rows — keyed by `userId` alone (preferences follow the user); both
    defaults AND visibility resolve through this tier
 
@@ -38,7 +50,9 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
 - **Manifest as definition registry**: writes validate against the live
   `ObjectRegistry` (never checked-in manifest.json artifacts): unknown
   objectRef/fieldName rejected; defaults type-checked against the field type;
-  system fields and relationship pseudo-fields are not policy-addressable.
+  system fields, relationship pseudo-fields, and STI meta storage fields are
+  not policy-addressable (the resolver excludes them, so rows would silently
+  never apply).
 - **Security rail**: defaults are refused on `transient`, `sensitive`, and
   `readPermission`-gated fields (both top-level and `_meta` flags checked).
   `resolveBatch` responses omit sensitive/read-permission-gated fields for
@@ -50,11 +64,20 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
 - **Org lock**: `locked` may be set on app/tenant rows only; while the
   code/app/tenant tiers resolve locked, user-scope writes are rejected and
   existing user rows are skipped at resolution.
+- **Write-time org checks reuse the resolver**: the required-demotion default
+  and the user-write lock are computed by `resolveFieldPolicy` over the org
+  tiers (default hierarchy loader), so cascading ancestor-tenant defaults and
+  locks are honored at save time too. On updates the resolver sees the row's
+  persisted version (no self-exclusion), so the resolver-side safety net
+  remains the authoritative enforcement at read time.
 - **Isolation**: a non-bypass tenant context may only resolve/write its own
   tenant (and own user when the context carries one); app-scope writes inside
-  a tenant context require super-admin bypass. `resolveBatch` takes identity
-  exclusively from the ambient tenant context — the request body cannot
-  select another tenant or user.
+  a tenant context require super-admin bypass. `save()` and `delete()` on an
+  EXISTING row additionally authorize the caller against the row's PERSISTED
+  scope before accepting anything — a foreign row cannot be re-scoped into
+  the caller's tenant/user or deleted by id from another tenant's context.
+  `resolveBatch` takes identity exclusively from the ambient tenant context —
+  the request body cannot select another tenant or user.
 
 ## Caching and invalidation
 

--- a/packages/fields/AGENTS.md
+++ b/packages/fields/AGENTS.md
@@ -129,6 +129,15 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
 
 ## Gotchas
 
+- Defaults have TWO explicit constructor channels, never sniffed:
+  `defaultValue` is ALREADY JSON-encoded (the wire contract — generated write
+  routes hand the request body straight to the constructor, and #2049's gear
+  posts `JSON.stringify(draft.defaultValue)`), while `defaultValueRaw` is a
+  plain value that is always serialized, strings included. Passing both throws.
+  One option cannot carry both meanings: `'"TBD"'` and `'TBD'` are
+  indistinguishable, so `{ defaultValue: 'Net 30' }` is a parse error that
+  names `defaultValueRaw` in its message. `setDefaultValue()` is the
+  method-level plain channel.
 - The sort-order column is `displayOrder` (resolved output exposes `order`):
   a column literally named `order` is an SQL keyword the runtime INSERT path
   does not quote.

--- a/packages/fields/CLAUDE.md
+++ b/packages/fields/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -1,0 +1,52 @@
+# @happyvertical/smrt-fields
+
+Layered field policy for SMRT objects: personalize per-field defaults,
+visibility tiers (basic/advanced/hidden), help text, labels, ordering, and
+org locks at app, tenant, and user scope — over the code-authored
+`@field({ ui })` seed.
+
+```typescript
+import {
+  FieldPolicy,
+  FieldPolicyCollection,
+  resolveFieldPolicy,
+  resolveFieldPolicyExplained,
+} from '@happyvertical/smrt-fields';
+
+// An org (tenant) demotes an optional field and sets a default
+const policies = await FieldPolicyCollection.create({ db });
+await policies.create({
+  objectRef: '@happyvertical/smrt-content:Article',
+  fieldName: 'summary',
+  scopeType: 'tenant',
+  tenantId,
+  visibility: 'advanced',
+  defaultValue: JSON.stringify('TBD'),
+});
+
+// Resolve the effective policy for a user in that tenant
+const resolved = await resolveFieldPolicy(
+  '@happyvertical/smrt-content:Article',
+  { tenantId, userId, db },
+);
+resolved.fields.summary.visibility; // 'advanced'
+
+// Explain variant: per-layer contributions for admin/gear UIs
+const explained = await resolveFieldPolicyExplained(
+  '@happyvertical/smrt-content:Article',
+  { tenantId, userId, db },
+);
+```
+
+Resolution layers (low → high): code seed → app rows → tenant rows
+(hierarchy walk via an optional `tenantHierarchyLoader`; flat fallback
+without `@happyvertical/smrt-users`) → user rows. A NULL column inherits
+from the lower layer; resetting a customization is a row delete.
+
+Writes are validated against the live `ObjectRegistry`: unknown
+objects/fields are rejected, defaults are type-checked, and defaults on
+`transient`/`sensitive`/`readPermission`-gated fields are refused. Required
+fields can only be demoted from `basic` when a usable default resolves —
+and the resolver re-enforces that invariant at read time.
+
+See `AGENTS.md` for the full architecture notes.

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -35,6 +35,7 @@
     "@happyvertical/sql": "catalog:"
   },
   "devDependencies": {
+    "@happyvertical/smrt-cli": "workspace:*",
     "@happyvertical/smrt-users": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",
     "@types/node": "24.13.2",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@happyvertical/smrt-fields",
+  "version": "0.40.33",
+  "description": "Layered field policy store and resolver (defaults, visibility tiers, help text) for SMRT objects",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "CLAUDE.md",
+    "AGENTS.md"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./manifest": "./dist/manifest.json",
+    "./manifest.json": "./dist/manifest.json"
+  },
+  "scripts": {
+    "build": "vite build --mode library",
+    "build:watch": "vite build --mode library --watch",
+    "clean": "rm -rf dist",
+    "dev": "vite dev",
+    "prepack": "node ../../scripts/prepack-package.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
+  },
+  "dependencies": {
+    "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-tenancy": "workspace:*",
+    "@happyvertical/sql": "catalog:"
+  },
+  "devDependencies": {
+    "@happyvertical/smrt-users": "workspace:*",
+    "@happyvertical/smrt-vitest": "workspace:*",
+    "@types/node": "24.13.2",
+    "typescript": "5.9.3",
+    "vite": "8.1.4",
+    "vitest": "4.1.10"
+  },
+  "keywords": [
+    "smrt",
+    "field-policy",
+    "form-defaults",
+    "visibility",
+    "multi-tenant"
+  ],
+  "author": "HappyVertical",
+  "license": "MIT",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/happyvertical/smrt.git",
+    "directory": "packages/fields"
+  }
+}

--- a/packages/fields/src/__smrt-register__.ts
+++ b/packages/fields/src/__smrt-register__.ts
@@ -1,0 +1,26 @@
+/**
+ * Self-registers this package's build-time manifest before any @smrt() decorator
+ * in the package fires. Fixes issue #1132: in consumer runtimes (tsx, SvelteKit
+ * SSR, plain `vite dev`) the decorator's synchronous manifest lookup previously
+ * missed because no step populated the global manifest cache — classes got
+ * registered with zero fields and `save()` / `toJSON()` silently dropped every
+ * declared property.
+ *
+ * Import this module as the first statement in `src/index.ts` so its top-level
+ * side effect runs ahead of any class module's @smrt() decorator.
+ *
+ * Silent no-op in dev/test, where the vitest plugin already populates manifests
+ * via a different path. Only needs to succeed in the published dist output.
+ *
+ * @see https://github.com/happyvertical/smrt/issues/1132
+ */
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+
+// During library builds, smrtPlugin replaces this entire module with generated
+// code that embeds the scanned manifest inline (#1506/#1507) — published dists
+// never resolve this URL, so downstream bundlers cannot break registration by
+// relocating the compiled module away from dist/manifest.json. The runtime
+// lookup below is the fallback for source-mode runs without that transform.
+ObjectRegistry.registerPackageManifest(
+  new URL('./manifest.json', import.meta.url),
+);

--- a/packages/fields/src/cache.ts
+++ b/packages/fields/src/cache.ts
@@ -1,0 +1,126 @@
+import type { DatabaseInterface } from '@happyvertical/sql';
+import type { ExplainedObjectFieldPolicy } from './types.js';
+
+const FIELD_POLICY_CACHE_TTL_MS = 30_000;
+
+type CacheEntry = {
+  expiresAt: number;
+  value: ExplainedObjectFieldPolicy;
+};
+
+const fieldPolicyCache = new Map<string, CacheEntry>();
+const dbInstanceIds = new WeakMap<object, string>();
+let nextDbId = 1;
+
+/**
+ * Namespace a cache key by database identity so parallel test databases (and
+ * multi-database processes) never share entries. Mirrors
+ * `packages/prompts/src/cache.ts` exactly.
+ */
+function getDbNamespace(db: unknown): string {
+  if (!db) {
+    return 'no-db';
+  }
+
+  if (typeof db === 'string') {
+    return `db:${db}`;
+  }
+
+  if (typeof db === 'object') {
+    const dbObject = db as Record<string, unknown>;
+    if (typeof dbObject.query === 'function') {
+      if (!dbInstanceIds.has(dbObject)) {
+        dbInstanceIds.set(dbObject, `db-instance:${nextDbId++}`);
+      }
+      const namespace = dbInstanceIds.get(dbObject);
+      if (namespace) {
+        return namespace;
+      }
+
+      return 'db-instance:unknown';
+    }
+
+    try {
+      return `db-config:${JSON.stringify(dbObject)}`;
+    } catch {
+      return 'db-config:opaque';
+    }
+  }
+
+  return 'db:unknown';
+}
+
+function buildCacheKey(
+  objectRef: string,
+  tenantId: string | null | undefined,
+  userId: string | null | undefined,
+  db: DatabaseInterface | unknown,
+): string {
+  return `${getDbNamespace(db)}::${objectRef}::${tenantId ?? 'app'}::${
+    userId ?? 'user:none'
+  }`;
+}
+
+export function getFieldPolicyCacheTtlMs(): number {
+  return FIELD_POLICY_CACHE_TTL_MS;
+}
+
+export function getCachedFieldPolicy(
+  objectRef: string,
+  tenantId: string | null | undefined,
+  userId: string | null | undefined,
+  db: DatabaseInterface | unknown,
+): ExplainedObjectFieldPolicy | null {
+  const cacheKey = buildCacheKey(objectRef, tenantId, userId, db);
+  const cached = fieldPolicyCache.get(cacheKey);
+
+  if (!cached) {
+    return null;
+  }
+
+  if (cached.expiresAt <= Date.now()) {
+    fieldPolicyCache.delete(cacheKey);
+    return null;
+  }
+
+  return cached.value;
+}
+
+export function setCachedFieldPolicy(
+  objectRef: string,
+  tenantId: string | null | undefined,
+  userId: string | null | undefined,
+  db: DatabaseInterface | unknown,
+  value: ExplainedObjectFieldPolicy,
+): void {
+  fieldPolicyCache.set(buildCacheKey(objectRef, tenantId, userId, db), {
+    expiresAt: Date.now() + FIELD_POLICY_CACHE_TTL_MS,
+    value,
+  });
+}
+
+/**
+ * Drop every cached resolution for `(db, objectRef)`.
+ *
+ * Deliberately coarser than the prompts precedent (which deletes a single
+ * `(key, tenantId)` entry when the tenant is known): tenant HIERARCHY makes a
+ * parent-tenant row change affect every descendant tenant's resolution, and a
+ * lock or app-row change affects user-tier entries too, so precise
+ * invalidation would have to know the whole tenant tree. Per-objectRef prefix
+ * invalidation is always correct and the 30s TTL keeps the cost bounded.
+ */
+export function invalidateFieldPolicyCache(
+  objectRef: string,
+  db: DatabaseInterface | unknown,
+): void {
+  const keyPrefix = `${getDbNamespace(db)}::${objectRef}::`;
+  for (const cacheKey of fieldPolicyCache.keys()) {
+    if (cacheKey.startsWith(keyPrefix)) {
+      fieldPolicyCache.delete(cacheKey);
+    }
+  }
+}
+
+export function clearFieldPolicyCache(): void {
+  fieldPolicyCache.clear();
+}

--- a/packages/fields/src/cache.ts
+++ b/packages/fields/src/cache.ts
@@ -50,15 +50,44 @@ function getDbNamespace(db: unknown): string {
   return 'db:unknown';
 }
 
+const hierarchyLoaderIds = new WeakMap<object, string>();
+let nextLoaderId = 1;
+
+/**
+ * Namespace a cache key by tenant-hierarchy loader identity.
+ *
+ * An injected `tenantHierarchyLoader` can produce a completely different
+ * ancestor chain — and therefore different resolved defaults and locks — for
+ * the same `(db, objectRef, tenantId, userId)`. Without this component an
+ * injected loader would serve (or be served) the DEFAULT loader's cached
+ * result. Callers that pass no loader all share the `default` namespace.
+ */
+function getHierarchyLoaderNamespace(loader: unknown): string {
+  if (typeof loader !== 'function') {
+    return 'loader:default';
+  }
+
+  const key = loader as unknown as object;
+  if (!hierarchyLoaderIds.has(key)) {
+    hierarchyLoaderIds.set(key, `loader:${nextLoaderId++}`);
+  }
+  return hierarchyLoaderIds.get(key) ?? 'loader:unknown';
+}
+
+/**
+ * Loader namespace goes LAST so `invalidateFieldPolicyCache`'s
+ * `(db, objectRef)` prefix scan still clears every loader's entries.
+ */
 function buildCacheKey(
   objectRef: string,
   tenantId: string | null | undefined,
   userId: string | null | undefined,
   db: DatabaseInterface | unknown,
+  hierarchyLoader?: unknown,
 ): string {
   return `${getDbNamespace(db)}::${objectRef}::${tenantId ?? 'app'}::${
     userId ?? 'user:none'
-  }`;
+  }::${getHierarchyLoaderNamespace(hierarchyLoader)}`;
 }
 
 export function getFieldPolicyCacheTtlMs(): number {
@@ -70,8 +99,15 @@ export function getCachedFieldPolicy(
   tenantId: string | null | undefined,
   userId: string | null | undefined,
   db: DatabaseInterface | unknown,
+  hierarchyLoader?: unknown,
 ): ExplainedObjectFieldPolicy | null {
-  const cacheKey = buildCacheKey(objectRef, tenantId, userId, db);
+  const cacheKey = buildCacheKey(
+    objectRef,
+    tenantId,
+    userId,
+    db,
+    hierarchyLoader,
+  );
   const cached = fieldPolicyCache.get(cacheKey);
 
   if (!cached) {
@@ -92,11 +128,15 @@ export function setCachedFieldPolicy(
   userId: string | null | undefined,
   db: DatabaseInterface | unknown,
   value: ExplainedObjectFieldPolicy,
+  hierarchyLoader?: unknown,
 ): void {
-  fieldPolicyCache.set(buildCacheKey(objectRef, tenantId, userId, db), {
-    expiresAt: Date.now() + FIELD_POLICY_CACHE_TTL_MS,
-    value,
-  });
+  fieldPolicyCache.set(
+    buildCacheKey(objectRef, tenantId, userId, db, hierarchyLoader),
+    {
+      expiresAt: Date.now() + FIELD_POLICY_CACHE_TTL_MS,
+      value,
+    },
+  );
 }
 
 /**

--- a/packages/fields/src/collections/FieldPolicyCollection.ts
+++ b/packages/fields/src/collections/FieldPolicyCollection.ts
@@ -22,12 +22,21 @@ const MAX_BATCH_OBJECT_REFS = 100;
  * `resolveBatch` is a custom collection-scoped action (NOT a system route —
  * core's generated system trio is closed): the generated route parses the
  * body, calls the method on the app-configured collection instance (which
- * carries the app database), and serializes the plain result. Exposure is
- * fully explicit: only `resolveBatch` over the API, nothing over MCP/CLI.
+ * carries the app database), and serializes the plain result.
+ *
+ * Exposure note: a decorated collection's config becomes the RUNTIME registry
+ * authority for its item class (core merges the collection registration onto
+ * the item slot), while build-time generation reads each manifest object's
+ * own config. This config therefore mirrors FieldPolicy's API posture —
+ * writes open plus the batch action, reads CLOSED (generated list/get would
+ * enumerate every tenant's/user's rows) — and closes the runtime CLI/MCP
+ * surfaces entirely (the ContentContributions precedent; the cli↔api
+ * coherence gate does not admit standard CRUD entries on a collection's
+ * `cli.include`). Keep the api include lists in lockstep with FieldPolicy's.
  */
 @smrt({
   api: {
-    include: ['resolveBatch'],
+    include: ['create', 'update', 'delete', 'resolveBatch'],
     routes: {
       resolveBatch: {
         scope: 'collection',
@@ -36,43 +45,11 @@ const MAX_BATCH_OBJECT_REFS = 100;
       },
     },
   },
-  mcp: false,
   cli: false,
+  mcp: false,
 })
 export class FieldPolicyCollection extends SmrtCollection<FieldPolicy> {
   static readonly _itemClass = FieldPolicy;
-
-  private excludeRowId(
-    items: FieldPolicy[],
-    excludeId?: string,
-  ): FieldPolicy[] {
-    return items.filter((item) => (excludeId ? item.id !== excludeId : true));
-  }
-
-  /** App-scope row for one field, or null. */
-  async getAppRow(
-    objectRef: string,
-    fieldName: string,
-    options: { excludeId?: string } = {},
-  ): Promise<FieldPolicy | null> {
-    const items = await this.list({
-      where: { objectRef, fieldName, scopeType: 'app' },
-    });
-    return this.excludeRowId(items, options.excludeId)[0] ?? null;
-  }
-
-  /** Direct tenant-scope row for one field and tenant, or null. */
-  async getTenantRow(
-    objectRef: string,
-    fieldName: string,
-    tenantId: string,
-    options: { excludeId?: string } = {},
-  ): Promise<FieldPolicy | null> {
-    const items = await this.list({
-      where: { objectRef, fieldName, scopeType: 'tenant', tenantId },
-    });
-    return this.excludeRowId(items, options.excludeId)[0] ?? null;
-  }
 
   /** All app-scope rows for an object, keyed by field name. */
   async getAppRows(objectRef: string): Promise<Map<string, FieldPolicy>> {

--- a/packages/fields/src/collections/FieldPolicyCollection.ts
+++ b/packages/fields/src/collections/FieldPolicyCollection.ts
@@ -1,0 +1,215 @@
+import { SmrtCollection, smrt } from '@happyvertical/smrt-core';
+import { getCurrentTenant } from '@happyvertical/smrt-tenancy';
+import {
+  getFieldReadPermission,
+  getObjectFieldMap,
+  isSensitiveField,
+  isTransientField,
+} from '../field-definitions.js';
+import { FieldPolicy } from '../models/FieldPolicy.js';
+import type {
+  FieldPolicyBatchResult,
+  ResolvedObjectFieldPolicy,
+} from '../types.js';
+
+/** Upper bound on objectRefs per batch call — bounds registry/db work per request. */
+const MAX_BATCH_OBJECT_REFS = 100;
+
+/**
+ * Collection surface for {@link FieldPolicy} rows plus the batch resolve
+ * action consumed by client bootstrapping (#2048).
+ *
+ * `resolveBatch` is a custom collection-scoped action (NOT a system route —
+ * core's generated system trio is closed): the generated route parses the
+ * body, calls the method on the app-configured collection instance (which
+ * carries the app database), and serializes the plain result. Exposure is
+ * fully explicit: only `resolveBatch` over the API, nothing over MCP/CLI.
+ */
+@smrt({
+  api: {
+    include: ['resolveBatch'],
+    routes: {
+      resolveBatch: {
+        scope: 'collection',
+        method: 'POST',
+        path: 'resolve',
+      },
+    },
+  },
+  mcp: false,
+  cli: false,
+})
+export class FieldPolicyCollection extends SmrtCollection<FieldPolicy> {
+  static readonly _itemClass = FieldPolicy;
+
+  private excludeRowId(
+    items: FieldPolicy[],
+    excludeId?: string,
+  ): FieldPolicy[] {
+    return items.filter((item) => (excludeId ? item.id !== excludeId : true));
+  }
+
+  /** App-scope row for one field, or null. */
+  async getAppRow(
+    objectRef: string,
+    fieldName: string,
+    options: { excludeId?: string } = {},
+  ): Promise<FieldPolicy | null> {
+    const items = await this.list({
+      where: { objectRef, fieldName, scopeType: 'app' },
+    });
+    return this.excludeRowId(items, options.excludeId)[0] ?? null;
+  }
+
+  /** Direct tenant-scope row for one field and tenant, or null. */
+  async getTenantRow(
+    objectRef: string,
+    fieldName: string,
+    tenantId: string,
+    options: { excludeId?: string } = {},
+  ): Promise<FieldPolicy | null> {
+    const items = await this.list({
+      where: { objectRef, fieldName, scopeType: 'tenant', tenantId },
+    });
+    return this.excludeRowId(items, options.excludeId)[0] ?? null;
+  }
+
+  /** All app-scope rows for an object, keyed by field name. */
+  async getAppRows(objectRef: string): Promise<Map<string, FieldPolicy>> {
+    const rows = await this.list({
+      where: { objectRef, scopeType: 'app' },
+    });
+    const byField = new Map<string, FieldPolicy>();
+    for (const row of rows) {
+      byField.set(row.fieldName, row);
+    }
+    return byField;
+  }
+
+  /**
+   * All tenant-scope rows for an object across a tenant chain, keyed
+   * `tenantId → fieldName → row`.
+   */
+  async getTenantRows(
+    objectRef: string,
+    tenantIds: string[],
+  ): Promise<Map<string, Map<string, FieldPolicy>>> {
+    const byTenant = new Map<string, Map<string, FieldPolicy>>();
+    if (tenantIds.length === 0) {
+      return byTenant;
+    }
+
+    const rows = await this.list({
+      where: { objectRef, scopeType: 'tenant', 'tenantId in': tenantIds },
+    });
+    for (const row of rows) {
+      if (!row.tenantId) {
+        continue;
+      }
+      let byField = byTenant.get(row.tenantId);
+      if (!byField) {
+        byField = new Map<string, FieldPolicy>();
+        byTenant.set(row.tenantId, byField);
+      }
+      byField.set(row.fieldName, row);
+    }
+    return byTenant;
+  }
+
+  /** All user-scope rows for an object and user, keyed by field name. */
+  async getUserRows(
+    objectRef: string,
+    userId: string,
+  ): Promise<Map<string, FieldPolicy>> {
+    const rows = await this.list({
+      where: { objectRef, scopeType: 'user', userId },
+    });
+    const byField = new Map<string, FieldPolicy>();
+    for (const row of rows) {
+      byField.set(row.fieldName, row);
+    }
+    return byField;
+  }
+
+  /**
+   * Resolve merged field policy for a set of objectRefs for the CURRENT
+   * caller, gated for public consumption.
+   *
+   * Caller identity comes exclusively from the ambient tenant context
+   * (established by the app's auth hook, e.g. smrt-users' session context) —
+   * the request body cannot select another tenant or user (fail closed).
+   * Server-side consumers wanting explicit identities call
+   * `resolveFieldPolicy()` directly instead.
+   *
+   * Field gating mirrors the REST serializer's derivation (`sensitive` /
+   * `readPermission` read from both the top level and `_meta`): sensitive and
+   * read-permission-gated fields are ABSENT from the response for every
+   * caller (the generated action route cannot convey per-caller grants to
+   * this method, so gated fields fail closed), and transient fields are
+   * stripped for parity with generated client field definitions.
+   */
+  async resolveBatch(
+    options: { objectRefs?: string[] } = {},
+  ): Promise<FieldPolicyBatchResult> {
+    const rawRefs = options.objectRefs;
+    if (!Array.isArray(rawRefs) || rawRefs.length === 0) {
+      throw new Error(
+        'resolveBatch requires a non-empty "objectRefs" string array',
+      );
+    }
+    if (rawRefs.some((ref) => typeof ref !== 'string' || ref.trim() === '')) {
+      throw new Error('resolveBatch objectRefs must be non-empty strings');
+    }
+    const objectRefs = [...new Set(rawRefs)];
+    if (objectRefs.length > MAX_BATCH_OBJECT_REFS) {
+      throw new Error(
+        `resolveBatch accepts at most ${MAX_BATCH_OBJECT_REFS} objectRefs ` +
+          `per call (got ${objectRefs.length})`,
+      );
+    }
+
+    const context = getCurrentTenant();
+    const tenantId = context?.tenantId ?? null;
+    const userId = context?.userId ?? null;
+
+    // Dynamic import breaks the module cycle with the resolver (which imports
+    // this collection statically for its row reads).
+    const { resolveFieldPolicy } = await import('../field-policy-resolver.js');
+
+    const policies: Record<string, ResolvedObjectFieldPolicy> = {};
+    for (const objectRef of objectRefs) {
+      const resolved = await resolveFieldPolicy(objectRef, {
+        tenantId,
+        userId,
+        db: this.db,
+      });
+      policies[objectRef] = await this.gateResolvedForPublicResponse(resolved);
+    }
+
+    return { policies };
+  }
+
+  private async gateResolvedForPublicResponse(
+    resolved: ResolvedObjectFieldPolicy,
+  ): Promise<ResolvedObjectFieldPolicy> {
+    const fieldMap = await getObjectFieldMap(resolved.objectRef);
+    const fields: ResolvedObjectFieldPolicy['fields'] = {};
+
+    for (const [fieldName, policy] of Object.entries(resolved.fields)) {
+      const fieldDef = fieldMap.get(fieldName);
+      if (!fieldDef) {
+        continue;
+      }
+      if (
+        isSensitiveField(fieldDef) ||
+        getFieldReadPermission(fieldDef) !== undefined ||
+        isTransientField(fieldDef)
+      ) {
+        continue;
+      }
+      fields[fieldName] = policy;
+    }
+
+    return { objectRef: resolved.objectRef, fields };
+  }
+}

--- a/packages/fields/src/collections/FieldPolicyCollection.ts
+++ b/packages/fields/src/collections/FieldPolicyCollection.ts
@@ -34,7 +34,15 @@ const MAX_BATCH_OBJECT_REFS = 100;
  * coherence gate does not admit standard CRUD entries on a collection's
  * `cli.include`). Keep the api include lists in lockstep with FieldPolicy's.
  */
+// `conflictColumns` MUST mirror FieldPolicy's. A decorated collection emits
+// its OWN schema for the item's table (`_smrt_field_policies`), and without
+// the natural key that schema falls back to SmrtObject's default unique
+// `(slug, context)` index. Manifest-driven migrations aggregate both schemas
+// onto the one physical table, so the stray index would reject legitimate
+// layered rows — every policy row has a NULL slug and context, and the app,
+// tenant, and user rows for a field are distinct only by the real natural key.
 @smrt({
+  conflictColumns: ['object_ref', 'field_name', 'scope_type', 'scope_key'],
   api: {
     include: ['create', 'update', 'delete', 'resolveBatch'],
     routes: {

--- a/packages/fields/src/field-definitions.ts
+++ b/packages/fields/src/field-definitions.ts
@@ -1,0 +1,264 @@
+/**
+ * Manifest-as-definition-registry helpers.
+ *
+ * Field policy is validated and seeded from the LIVE `ObjectRegistry` (never
+ * from checked-in `manifest.json` artifacts): the registry is the runtime
+ * source of truth for which objects/fields exist, their types, their security
+ * flags, and their `_meta.ui` presentation hints (#2046).
+ */
+
+import type { FieldUIHints } from '@happyvertical/smrt-core';
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+import type { FieldPolicyDelta, FieldPolicyVisibility } from './types.js';
+
+/**
+ * Field map for one object, keyed by field name (includes inherited fields).
+ * Derived structurally from the PUBLIC `ObjectRegistry.getAllFields` return
+ * type — core does not export its internal `RegisteredField` name.
+ */
+export type FieldDefinitionMap = Awaited<
+  ReturnType<typeof ObjectRegistry.getAllFields>
+>;
+
+/** One field's registered metadata, as returned by `getAllFields`. */
+export type RegisteredFieldInfo =
+  FieldDefinitionMap extends Map<string, infer F> ? F : never;
+
+/**
+ * Resolve `objectRef` (qualified `@package/name:ClassName`) against the live
+ * registry, throwing a descriptive error when the class is unknown.
+ */
+export function requireRegisteredObject(objectRef: string): void {
+  if (!objectRef || !objectRef.includes(':')) {
+    throw new Error(
+      `Field policy objectRef must be a qualified class name ` +
+        `("@package/name:ClassName"), got "${objectRef}"`,
+    );
+  }
+  if (!ObjectRegistry.getClassByQualifiedName(objectRef)) {
+    throw new Error(
+      `Unknown field policy objectRef "${objectRef}": no class with that ` +
+        `qualified name is registered`,
+    );
+  }
+}
+
+/** Load the full (inherited) field map for a registered objectRef. */
+export async function getObjectFieldMap(
+  objectRef: string,
+): Promise<FieldDefinitionMap> {
+  requireRegisteredObject(objectRef);
+  return ObjectRegistry.getAllFields(objectRef);
+}
+
+/**
+ * Narrow a manifest `_meta.ui` bag to the known {@link FieldUIHints} keys with
+ * their expected primitive types, dropping junk (mirrors the sanitization the
+ * web emission applies in core's `web-collections.ts`).
+ */
+export function sanitizeFieldUIHints(value: unknown): FieldUIHints | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const raw = value as Record<string, unknown>;
+  const ui: FieldUIHints = {
+    ...(typeof raw.basic === 'boolean' ? { basic: raw.basic } : {}),
+    ...(typeof raw.group === 'string' ? { group: raw.group } : {}),
+    ...(typeof raw.order === 'number' && Number.isFinite(raw.order)
+      ? { order: raw.order }
+      : {}),
+    ...(typeof raw.locked === 'boolean' ? { locked: raw.locked } : {}),
+  };
+  return Object.keys(ui).length > 0 ? ui : undefined;
+}
+
+/** Security rail: `sensitive` may live top-level or under `_meta` (STI merges). */
+export function isSensitiveField(field: RegisteredFieldInfo): boolean {
+  return field.sensitive === true || field._meta?.sensitive === true;
+}
+
+/** Security rail: `readPermission` may live top-level or under `_meta`. */
+export function getFieldReadPermission(
+  field: RegisteredFieldInfo,
+): string | undefined {
+  if (typeof field.readPermission === 'string') {
+    return field.readPermission;
+  }
+  const metaPermission = field._meta?.readPermission;
+  return typeof metaPermission === 'string' ? metaPermission : undefined;
+}
+
+export function isTransientField(field: RegisteredFieldInfo): boolean {
+  return field.transient === true || field._meta?.transient === true;
+}
+
+/** A field is required when flagged required and not explicitly nullable. */
+export function isRequiredField(field: RegisteredFieldInfo): boolean {
+  if (field._meta?.nullable === true) {
+    return false;
+  }
+  return field.required === true || field._meta?.required === true;
+}
+
+/** The manifest/code default for a field, boxed; `undefined` when none. */
+export function getCodeDefault(
+  field: RegisteredFieldInfo,
+): { value: unknown } | undefined {
+  if (field.default !== undefined) {
+    return { value: field.default };
+  }
+  if (field._meta?.default !== undefined) {
+    return { value: field._meta.default };
+  }
+  return undefined;
+}
+
+/**
+ * A resolved default satisfies the required-field invariant only when it is a
+ * value a form could actually submit: explicit `null` and the empty string do
+ * not count (a required text field "defaulting" to `''` is still unfilled).
+ */
+export function isUsableRequiredDefault(
+  defaultBox: { value: unknown } | undefined,
+): boolean {
+  if (!defaultBox) {
+    return false;
+  }
+  return defaultBox.value !== null && defaultBox.value !== '';
+}
+
+/**
+ * Compute the code-seed visibility for every field of an object using the
+ * cold-start rule (#2046): with no `ui.basic` markers anywhere on the object,
+ * every field is `basic`; once any field is marked `basic: true`, unmarked
+ * fields default to `advanced` (and an explicit `basic: false` is always
+ * `advanced`).
+ */
+export function buildCodeSeedVisibility(
+  fields: FieldDefinitionMap,
+): Map<string, FieldPolicyVisibility> {
+  let hasBasicMarkers = false;
+  const hints = new Map<string, FieldUIHints | undefined>();
+  for (const [name, field] of fields) {
+    const ui = sanitizeFieldUIHints(field._meta?.ui);
+    hints.set(name, ui);
+    if (ui?.basic === true) {
+      hasBasicMarkers = true;
+    }
+  }
+
+  const visibility = new Map<string, FieldPolicyVisibility>();
+  for (const [name] of fields) {
+    const ui = hints.get(name);
+    if (ui?.basic === true) {
+      visibility.set(name, 'basic');
+    } else if (ui?.basic === false || hasBasicMarkers) {
+      visibility.set(name, 'advanced');
+    } else {
+      visibility.set(name, 'basic');
+    }
+  }
+  return visibility;
+}
+
+/** Code-seed delta for one field (visibility supplied by the cold-start pass). */
+export function buildCodeSeedDelta(
+  field: RegisteredFieldInfo,
+  visibility: FieldPolicyVisibility,
+): FieldPolicyDelta {
+  const ui = sanitizeFieldUIHints(field._meta?.ui);
+  const help =
+    typeof field.description === 'string'
+      ? field.description
+      : typeof field._meta?.description === 'string'
+        ? field._meta.description
+        : undefined;
+  const codeDefault = getCodeDefault(field);
+
+  return {
+    ...(codeDefault ? { default: codeDefault } : {}),
+    visibility,
+    ...(help !== undefined ? { help } : {}),
+    ...(ui?.order !== undefined ? { order: ui.order } : {}),
+    ...(ui?.locked === true ? { locked: true } : {}),
+  };
+}
+
+/** Code-seed grouping key (`ui.group`) — not overridable by stored rows. */
+export function getCodeSeedGroup(field: RegisteredFieldInfo): string | null {
+  return sanitizeFieldUIHints(field._meta?.ui)?.group ?? null;
+}
+
+/**
+ * Type-check a parsed default value against the manifest field type.
+ *
+ * Explicit `null` is allowed only for optional fields (a required field with a
+ * null default has no usable default). Unsupported field types reject defaults
+ * outright (fail closed).
+ */
+export function assertDefaultValueMatchesFieldType(
+  objectRef: string,
+  fieldName: string,
+  field: RegisteredFieldInfo,
+  value: unknown,
+): void {
+  const label = `Field policy default for "${objectRef}.${fieldName}"`;
+
+  if (value === null) {
+    if (isRequiredField(field)) {
+      throw new Error(
+        `${label} may not be null: the field is required, so a null default ` +
+          `is never a usable default`,
+      );
+    }
+    return;
+  }
+
+  switch (field.type) {
+    case 'text':
+      if (typeof value !== 'string') {
+        throw new Error(`${label} must be a string (field type "text")`);
+      }
+      return;
+    case 'integer':
+      if (typeof value !== 'number' || !Number.isInteger(value)) {
+        throw new Error(`${label} must be an integer (field type "integer")`);
+      }
+      return;
+    case 'decimal':
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new Error(
+          `${label} must be a finite number (field type "decimal")`,
+        );
+      }
+      return;
+    case 'boolean':
+      if (typeof value !== 'boolean') {
+        throw new Error(`${label} must be a boolean (field type "boolean")`);
+      }
+      return;
+    case 'datetime':
+      if (typeof value !== 'string' || Number.isNaN(Date.parse(value))) {
+        throw new Error(
+          `${label} must be a date-parseable string (field type "datetime")`,
+        );
+      }
+      return;
+    case 'json':
+      // Any JSON value (it already survived JSON.parse).
+      return;
+    case 'foreignKey':
+    case 'crossPackageRef':
+      if (typeof value !== 'string') {
+        throw new Error(
+          `${label} must be a string id (field type "${field.type}")`,
+        );
+      }
+      return;
+    default:
+      throw new Error(
+        `${label} is not supported: defaults cannot target ` +
+          `"${String(field.type)}" fields`,
+      );
+  }
+}

--- a/packages/fields/src/field-definitions.ts
+++ b/packages/fields/src/field-definitions.ts
@@ -29,7 +29,7 @@ export type RegisteredFieldInfo =
  * registry, throwing a descriptive error when the class is unknown.
  */
 export function requireRegisteredObject(objectRef: string): void {
-  if (!objectRef || !objectRef.includes(':')) {
+  if (!objectRef?.includes(':')) {
     throw new Error(
       `Field policy objectRef must be a qualified class name ` +
         `("@package/name:ClassName"), got "${objectRef}"`,

--- a/packages/fields/src/field-definitions.ts
+++ b/packages/fields/src/field-definitions.ts
@@ -92,9 +92,17 @@ export function isTransientField(field: RegisteredFieldInfo): boolean {
   return field.transient === true || field._meta?.transient === true;
 }
 
-/** A field is required when flagged required and not explicitly nullable. */
+/**
+ * A field is required when flagged required and not explicitly nullable.
+ *
+ * `nullable` is read from BOTH the top level and `_meta` for the same reason
+ * `sensitive`/`readPermission`/`transient` are: registrations reach the
+ * registry through several paths (decorator, manifest, STI merge) and land the
+ * flag in either place. Checking only one side made the pair asymmetric —
+ * `required` was read from both while `nullable` was read from one.
+ */
 export function isRequiredField(field: RegisteredFieldInfo): boolean {
-  if (field._meta?.nullable === true) {
+  if (field.nullable === true || field._meta?.nullable === true) {
     return false;
   }
   return field.required === true || field._meta?.required === true;

--- a/packages/fields/src/field-definitions.ts
+++ b/packages/fields/src/field-definitions.ts
@@ -189,6 +189,14 @@ export function getCodeSeedGroup(field: RegisteredFieldInfo): string | null {
   return sanitizeFieldUIHints(field._meta?.ui)?.group ?? null;
 }
 
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Whether a reference field stores text ids instead of native UUIDs. */
+function usesTextIdStorage(field: RegisteredFieldInfo): boolean {
+  return field.idType === 'text' || field._meta?.idType === 'text';
+}
+
 /**
  * Type-check a parsed default value against the manifest field type.
  *
@@ -252,6 +260,16 @@ export function assertDefaultValueMatchesFieldType(
       if (typeof value !== 'string') {
         throw new Error(
           `${label} must be a string id (field type "${field.type}")`,
+        );
+      }
+      // Reference columns are native UUID on PostgreSQL/DuckDB unless the
+      // field explicitly opts into text ids — a non-UUID default would
+      // validate here but fail at insert time on those dialects.
+      if (!usesTextIdStorage(field) && !UUID_PATTERN.test(value)) {
+        throw new Error(
+          `${label} must be a UUID string (the reference column stores ` +
+            `native UUIDs; declare idType 'text' on the field to store ` +
+            `arbitrary ids)`,
         );
       }
       return;

--- a/packages/fields/src/field-policy-batch.test.ts
+++ b/packages/fields/src/field-policy-batch.test.ts
@@ -1,0 +1,199 @@
+import { randomUUID } from 'node:crypto';
+import {
+  field,
+  getTestDatabase,
+  ObjectRegistry,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import {
+  resetTenancy,
+  setupTestTenancy,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+// Side-effect import: registers smrt-users' classes (Tenant) so
+// getTestDatabase can create the tenants table the default hierarchy loader
+// reads under an ambient tenant context.
+import '../../users/src/index.js';
+import { clearFieldPolicyCache } from './cache.js';
+import { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
+
+@smrt({
+  packageName: '@test/smrt-fields-batch',
+  visibility: 'internal',
+  api: false,
+  cli: false,
+  mcp: false,
+})
+class PolicyBatchDoc extends SmrtObject {
+  @field({ required: true })
+  docName: string = '';
+
+  @field({ ui: { basic: true } })
+  blurb: string = '';
+
+  @field({ sensitive: true })
+  secretKey: string = '';
+
+  // readPermission fixture: no production model uses the option yet, so the
+  // batch gating contract is pinned here.
+  @field({ readPermission: 'fields.batch.read' })
+  gatedNotes: string = '';
+
+  @field({ transient: true })
+  derived: string = '';
+}
+
+function fixtureRef(): string {
+  const registered = ObjectRegistry.getClassByConstructor(PolicyBatchDoc);
+  if (!registered?.qualifiedName) {
+    throw new Error('PolicyBatchDoc is not registered with a qualified name');
+  }
+  return registered.qualifiedName;
+}
+
+describe('FieldPolicyCollection.resolveBatch', () => {
+  let db: DatabaseInterface;
+  let policies: FieldPolicyCollection;
+  let objectRef: string;
+
+  beforeEach(async () => {
+    setupTestTenancy();
+    clearFieldPolicyCache();
+    // 'Tenant' backs the default hierarchy loader (smrt-users is installed
+    // in this workspace, so resolveBatch walks the real tenant table).
+    db = await getTestDatabase({ classes: ['FieldPolicy', 'Tenant'] });
+    policies = await FieldPolicyCollection.create({ db });
+    objectRef = fixtureRef();
+  });
+
+  afterEach(async () => {
+    clearFieldPolicyCache();
+    resetTenancy();
+    if (typeof (db as { close?: () => Promise<void> }).close === 'function') {
+      await (db as unknown as { close: () => Promise<void> }).close();
+    }
+  });
+
+  it('omits sensitive, read-permission-gated, and transient fields for every caller', async () => {
+    const result = await policies.resolveBatch({ objectRefs: [objectRef] });
+
+    const fields = result.policies[objectRef].fields;
+    expect(fields.docName).toBeDefined();
+    expect(fields.blurb).toBeDefined();
+    expect(fields.secretKey).toBeUndefined();
+    expect(fields.gatedNotes).toBeUndefined();
+    expect(fields.derived).toBeUndefined();
+  });
+
+  it('validates the objectRefs input and fails on unknown refs', async () => {
+    await expect(policies.resolveBatch({})).rejects.toThrow(
+      /non-empty "objectRefs"/,
+    );
+    await expect(policies.resolveBatch({ objectRefs: [] })).rejects.toThrow(
+      /non-empty "objectRefs"/,
+    );
+    await expect(
+      policies.resolveBatch({ objectRefs: [42 as any] }),
+    ).rejects.toThrow(/non-empty strings/);
+    await expect(
+      policies.resolveBatch({ objectRefs: ['@test/nowhere:Nope'] }),
+    ).rejects.toThrow(/Unknown field policy objectRef/);
+
+    const tooMany = Array.from({ length: 101 }, (_, i) => `@test/x:C${i}`);
+    await expect(
+      policies.resolveBatch({ objectRefs: tooMany }),
+    ).rejects.toThrow(/at most 100 objectRefs/);
+  });
+
+  it('deduplicates repeated refs', async () => {
+    const result = await policies.resolveBatch({
+      objectRefs: [objectRef, objectRef],
+    });
+    expect(Object.keys(result.policies)).toEqual([objectRef]);
+  });
+
+  it('resolves for the ambient tenant context identity (tenant and user tiers)', async () => {
+    const tenantId = randomUUID();
+    const userId = randomUUID();
+
+    await policies.create({
+      objectRef,
+      fieldName: 'blurb',
+      scopeType: 'app',
+      defaultValue: JSON.stringify('app blurb'),
+    });
+    await withTenant(
+      { tenantId, userId, permissions: new Set<string>() },
+      async () => {
+        await policies.create({
+          objectRef,
+          fieldName: 'blurb',
+          scopeType: 'tenant',
+          tenantId,
+          defaultValue: JSON.stringify('tenant blurb'),
+        });
+        await policies.create({
+          objectRef,
+          fieldName: 'blurb',
+          scopeType: 'user',
+          userId,
+          defaultValue: JSON.stringify('user blurb'),
+        });
+      },
+    );
+
+    // Outside any context: app tier only.
+    const anonymous = await policies.resolveBatch({ objectRefs: [objectRef] });
+    expect(anonymous.policies[objectRef].fields.blurb.defaultValue).toBe(
+      'app blurb',
+    );
+
+    // Inside a session context, tenant + user tiers apply.
+    await withTenant(
+      { tenantId, userId, permissions: new Set<string>() },
+      async () => {
+        const scoped = await policies.resolveBatch({
+          objectRefs: [objectRef],
+        });
+        expect(scoped.policies[objectRef].fields.blurb.defaultValue).toBe(
+          'user blurb',
+        );
+      },
+    );
+
+    // Tenant-only context: the user tier stays out.
+    await withTenant({ tenantId, permissions: new Set<string>() }, async () => {
+      const tenantOnly = await policies.resolveBatch({
+        objectRefs: [objectRef],
+      });
+      expect(tenantOnly.policies[objectRef].fields.blurb.defaultValue).toBe(
+        'tenant blurb',
+      );
+    });
+  });
+
+  it('ignores identity keys smuggled into the request body', async () => {
+    const tenantId = randomUUID();
+    await withTenant({ tenantId, permissions: new Set<string>() }, async () => {
+      await policies.create({
+        objectRef,
+        fieldName: 'blurb',
+        scopeType: 'tenant',
+        tenantId,
+        defaultValue: JSON.stringify('tenant blurb'),
+      });
+    });
+
+    // Without an ambient context, a body-supplied tenantId must not select
+    // the tenant tier: only the code seed (blurb's initializer '') resolves.
+    const spoofed = await policies.resolveBatch({
+      objectRefs: [objectRef],
+      tenantId,
+      userId: randomUUID(),
+    } as any);
+    expect(spoofed.policies[objectRef].fields.blurb.defaultValue).toBe('');
+  });
+});

--- a/packages/fields/src/field-policy-resolver.test.ts
+++ b/packages/fields/src/field-policy-resolver.test.ts
@@ -373,6 +373,133 @@ describe('resolveFieldPolicy', () => {
     );
   });
 
+  it('denies user-targeted resolution from a context carrying no user id', async () => {
+    // Read-side mirror of the write-side rule (#2047): a MISSING identity
+    // component denies, it never skips. Tenancy adapters populate
+    // `permissions` while leaving `userId` undefined whenever no
+    // `resolveUserId` hook is configured (API-key auth, service principals,
+    // background jobs) — such a context must not be able to read ANY user's
+    // resolved policy through the public `resolveFieldPolicy` export.
+    const contextTenant = randomUUID();
+    const foreignUser = randomUUID();
+
+    await withTenant(
+      { tenantId: contextTenant, permissions: new Set<string>() },
+      async () => {
+        await expect(
+          resolveFieldPolicy(objectRef, {
+            db,
+            tenantId: contextTenant,
+            userId: foreignUser,
+            tenantHierarchyLoader: flatLoader,
+          }),
+        ).rejects.toThrow(TenantIsolationError);
+
+        // App/tenant-only resolution is unaffected — no user is targeted.
+        const orgOnly = await resolveFieldPolicy(objectRef, {
+          db,
+          tenantId: contextTenant,
+          tenantHierarchyLoader: flatLoader,
+        });
+        expect(orgOnly.objectRef).toBe(objectRef);
+      },
+    );
+
+    // Context-LESS server-side callers stay allowed: `resolveFieldPolicy` is
+    // a trusted server API and the public batch route never lets a request
+    // body select a user.
+    const serverSide = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId: contextTenant,
+      userId: foreignUser,
+      tenantHierarchyLoader: flatLoader,
+    });
+    expect(serverSide.objectRef).toBe(objectRef);
+
+    // Super-admin bypass keeps its deliberate cross-user capability.
+    await withTenant(
+      {
+        tenantId: contextTenant,
+        permissions: new Set<string>(),
+        superAdminBypass: true,
+      },
+      async () => {
+        const bypassed = await resolveFieldPolicy(objectRef, {
+          db,
+          tenantId: contextTenant,
+          userId: foreignUser,
+          tenantHierarchyLoader: flatLoader,
+        });
+        expect(bypassed.objectRef).toBe(objectRef);
+      },
+    );
+  });
+
+  it('keys the cache by tenant-hierarchy loader identity', async () => {
+    // An injected loader produces a different ancestor chain — and therefore
+    // different resolved defaults/locks — for the same
+    // (db, objectRef, tenantId, userId). Without the loader in the cache key
+    // it would be served the DEFAULT loader's result (or poison it).
+    const rootTenant = randomUUID();
+    const leafTenant = randomUUID();
+
+    await withTenant(
+      {
+        tenantId: rootTenant,
+        permissions: new Set<string>(),
+        superAdminBypass: true,
+      },
+      () =>
+        policies.create({
+          objectRef,
+          fieldName: 'summary',
+          scopeType: 'tenant',
+          tenantId: rootTenant,
+          help: 'from the root tenant',
+        }),
+    );
+
+    // Flat loader: the leaf tenant has no ancestors, so the root row misses.
+    const flat = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId: leafTenant,
+      tenantHierarchyLoader: flatLoader,
+    });
+    expect(flat.fields.summary.help).toBeNull();
+
+    // Hierarchy loader: the same (db, objectRef, tenant) now inherits it.
+    const hierarchyLoader: FieldPolicyTenantHierarchyLoader = async () => ({
+      async getChain() {
+        return [
+          {
+            id: rootTenant,
+            inheritPermissions: true,
+            cascadePermissions: true,
+          },
+          {
+            id: leafTenant,
+            inheritPermissions: true,
+            cascadePermissions: true,
+          },
+        ];
+      },
+    });
+    const nested = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId: leafTenant,
+      tenantHierarchyLoader: hierarchyLoader,
+    });
+    expect(nested.fields.summary.help).toBe('from the root tenant');
+
+    // Each loader keeps its own entry rather than overwriting the other's.
+    const flatAgain = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId: leafTenant,
+      tenantHierarchyLoader: flatLoader,
+    });
+    expect(flatAgain.fields.summary.help).toBeNull();
+  });
+
   it('walks an injected tenant hierarchy root → leaf', async () => {
     const rootTenant = randomUUID();
     const childTenant = randomUUID();

--- a/packages/fields/src/field-policy-resolver.test.ts
+++ b/packages/fields/src/field-policy-resolver.test.ts
@@ -71,6 +71,21 @@ function fixtureRef(): string {
 const flatLoader: FieldPolicyTenantHierarchyLoader = async () => null;
 
 /**
+ * Seed tenant/user-scope rows under a super-admin bypass context (the
+ * context-absent fail-closed rule rejects them without any ambient identity).
+ */
+function seedPolicies<T>(fn: () => Promise<T>): Promise<T> {
+  return withTenant(
+    {
+      tenantId: randomUUID(),
+      permissions: new Set<string>(),
+      superAdminBypass: true,
+    },
+    fn,
+  );
+}
+
+/**
  * Sequentially replay the explained layer deltas (plus the required-field
  * safety net) and assert the result reproduces the merged policy for every
  * field — the contract that lets #2049/#2050 UIs trust the layer lists.
@@ -197,20 +212,22 @@ describe('resolveFieldPolicy', () => {
       defaultValue: JSON.stringify('app default'),
       help: 'app help',
     });
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId,
-      defaultValue: JSON.stringify('tenant default'),
-    });
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'user',
-      userId,
-      defaultValue: JSON.stringify('user default'),
-      visibility: 'hidden',
+    await seedPolicies(async () => {
+      await policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId,
+        defaultValue: JSON.stringify('tenant default'),
+      });
+      await policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'user',
+        userId,
+        defaultValue: JSON.stringify('user default'),
+        visibility: 'hidden',
+      });
     });
 
     const appOnly = await resolveFieldPolicy(objectRef, { db });
@@ -252,13 +269,15 @@ describe('resolveFieldPolicy', () => {
       scopeType: 'app',
       defaultValue: JSON.stringify('app default'),
     });
-    const tenantRow = await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId,
-      defaultValue: JSON.stringify('tenant default'),
-    });
+    const tenantRow = await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId,
+        defaultValue: JSON.stringify('tenant default'),
+      }),
+    );
 
     const before = await resolveFieldPolicy(objectRef, {
       db,
@@ -267,8 +286,12 @@ describe('resolveFieldPolicy', () => {
     });
     expect(before.fields.summary.defaultValue).toBe('tenant default');
 
-    // Reset = row delete; the delete also invalidates the cache.
-    await tenantRow.delete();
+    // Reset = row delete (inside the row's own tenant context; the
+    // context-absent rule rejects bare tenant-row deletes). The delete also
+    // invalidates the cache.
+    await withTenant({ tenantId, permissions: new Set<string>() }, async () => {
+      await tenantRow.delete();
+    });
 
     const after = await resolveFieldPolicy(objectRef, {
       db,
@@ -282,13 +305,15 @@ describe('resolveFieldPolicy', () => {
     const tenantA = randomUUID();
     const tenantB = randomUUID();
 
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId: tenantA,
-      defaultValue: JSON.stringify('tenant A'),
-    });
+    await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId: tenantA,
+        defaultValue: JSON.stringify('tenant A'),
+      }),
+    );
 
     const forA = await resolveFieldPolicy(objectRef, {
       db,
@@ -371,14 +396,16 @@ describe('resolveFieldPolicy', () => {
       },
     });
 
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId: rootTenant,
-      defaultValue: JSON.stringify('root default'),
-      help: 'root help',
-    });
+    await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId: rootTenant,
+        defaultValue: JSON.stringify('root default'),
+        help: 'root help',
+      }),
+    );
 
     // The ancestor's policy cascades to the child.
     const inherited = await resolveFieldPolicy(objectRef, {
@@ -389,13 +416,15 @@ describe('resolveFieldPolicy', () => {
     expect(inherited.fields.summary.defaultValue).toBe('root default');
 
     // A child row overrides the ancestor sparsely.
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId: childTenant,
-      defaultValue: JSON.stringify('child default'),
-    });
+    await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId: childTenant,
+        defaultValue: JSON.stringify('child default'),
+      }),
+    );
     clearFieldPolicyCache();
     const overridden = await resolveFieldPolicy(objectRef, {
       db,
@@ -434,22 +463,24 @@ describe('resolveFieldPolicy', () => {
       scopeType: 'app',
       defaultValue: JSON.stringify('app default'),
     });
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId: rootTenant,
-      defaultValue: JSON.stringify('root default'),
-      help: 'root help',
-    });
-    // The child's own sparse row survives the break and applies over the
-    // app layer (NOT over the discarded root layer).
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId: detachedChild,
-      help: 'child help',
+    await seedPolicies(async () => {
+      await policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId: rootTenant,
+        defaultValue: JSON.stringify('root default'),
+        help: 'root help',
+      });
+      // The child's own sparse row survives the break and applies over the
+      // app layer (NOT over the discarded root layer).
+      await policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId: detachedChild,
+        help: 'child help',
+      });
     });
 
     const explained = await resolveFieldPolicyExplained(objectRef, {
@@ -485,13 +516,15 @@ describe('resolveFieldPolicy', () => {
       inheritPermissions: true,
     });
 
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId: String(root.id),
-      defaultValue: JSON.stringify('root via users'),
-    });
+    await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId: String(root.id),
+        defaultValue: JSON.stringify('root via users'),
+      }),
+    );
 
     const resolved = await resolveFieldPolicy(objectRef, {
       db,
@@ -502,13 +535,15 @@ describe('resolveFieldPolicy', () => {
 
   it('falls back to a flat tenant chain without a hierarchy provider', async () => {
     const tenantId = randomUUID();
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId,
-      defaultValue: JSON.stringify('flat default'),
-    });
+    await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId,
+        defaultValue: JSON.stringify('flat default'),
+      }),
+    );
 
     const resolved = await resolveFieldPolicy(objectRef, {
       db,
@@ -522,13 +557,15 @@ describe('resolveFieldPolicy', () => {
     const userId = randomUUID();
 
     // User personalizes summary while it is unlocked.
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'user',
-      userId,
-      defaultValue: JSON.stringify('user default'),
-    });
+    await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'user',
+        userId,
+        defaultValue: JSON.stringify('user default'),
+      }),
+    );
     const beforeLock = await resolveFieldPolicy(objectRef, { db, userId });
     expect(beforeLock.fields.summary.defaultValue).toBe('user default');
 
@@ -563,13 +600,15 @@ describe('resolveFieldPolicy', () => {
       scopeType: 'app',
       defaultValue: JSON.stringify('Seeded title'),
     });
-    await policies.create({
-      objectRef,
-      fieldName: 'title',
-      scopeType: 'tenant',
-      tenantId,
-      visibility: 'hidden',
-    });
+    await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'title',
+        scopeType: 'tenant',
+        tenantId,
+        visibility: 'hidden',
+      }),
+    );
 
     const withDefault = await resolveFieldPolicy(objectRef, {
       db,
@@ -594,13 +633,15 @@ describe('resolveFieldPolicy', () => {
 
   it('caches per (db, objectRef, tenant, user) and invalidates on save/delete', async () => {
     const tenantId = randomUUID();
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId,
-      defaultValue: JSON.stringify('cached value'),
-    });
+    await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId,
+        defaultValue: JSON.stringify('cached value'),
+      }),
+    );
 
     const first = await resolveFieldPolicy(objectRef, {
       db,
@@ -632,13 +673,15 @@ describe('resolveFieldPolicy', () => {
 
     // Model-layer writes invalidate: an upsert through the collection is
     // visible immediately.
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId,
-      defaultValue: JSON.stringify('written value'),
-    });
+    await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId,
+        defaultValue: JSON.stringify('written value'),
+      }),
+    );
     const afterWrite = await resolveFieldPolicy(objectRef, {
       db,
       tenantId,
@@ -658,19 +701,21 @@ describe('resolveFieldPolicy', () => {
       defaultValue: JSON.stringify('app default'),
       help: 'app help',
     });
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId,
-      defaultValue: JSON.stringify('tenant default'),
-    });
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'user',
-      userId,
-      visibility: 'advanced',
+    await seedPolicies(async () => {
+      await policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId,
+        defaultValue: JSON.stringify('tenant default'),
+      });
+      await policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'user',
+        userId,
+        visibility: 'advanced',
+      });
     });
 
     const explained = await resolveFieldPolicyExplained(objectRef, {
@@ -728,13 +773,15 @@ describe('isMissingUsersDependency', () => {
     );
     expect(isMissingUsersDependency(wrapped)).toBe(true);
 
-    // A cause-only code (wrapper without one of the known texts).
-    const inner = new Error(
-      'some loader failure for @happyvertical/smrt-users',
-    );
-    const carrier = new Error('import failed', { cause: inner });
-    (inner as { code?: string }).code = 'ERR_MODULE_NOT_FOUND';
-    expect(isMissingUsersDependency(carrier)).toBe(true);
+    // A missing users SUBPATH specifier counts as missing users too.
+    expect(
+      isMissingUsersDependency(
+        new Error(
+          "Cannot find module '@happyvertical/smrt-users/collections' " +
+            'imported from /app/server.js',
+        ),
+      ),
+    ).toBe(true);
 
     // importWorkspaceModule's own source-fallback message.
     expect(
@@ -748,14 +795,40 @@ describe('isMissingUsersDependency', () => {
   });
 
   it('rethrows installed-but-broken failures instead of falling back', () => {
-    // A transitive missing dependency INSIDE smrt-users names the other
-    // package — that is a broken install, not an absent one.
+    // A transitive missing dependency INSIDE an installed smrt-users names
+    // the OTHER package as the target — the users path appears only as the
+    // importer. That is a broken install and must surface, not silently
+    // degrade to the flat-tenant fallback.
     const transitive = new Error(
       "Cannot find package 'left-pad' imported from " +
-        '/workspace/packages/users/dist/index.js',
+        '/app/node_modules/@happyvertical/smrt-users/dist/index.js',
     );
     (transitive as { code?: string }).code = 'ERR_MODULE_NOT_FOUND';
     expect(isMissingUsersDependency(transitive)).toBe(false);
+
+    // Same shape arriving through a wrapper's cause chain.
+    expect(
+      isMissingUsersDependency(
+        new Error('import failed', { cause: transitive }),
+      ),
+    ).toBe(false);
+
+    // A users install whose dist is missing resolves to a FILE PATH target,
+    // not the bare specifier — broken install, rethrow.
+    const brokenDist = new Error(
+      'Cannot find module ' +
+        "'/app/node_modules/@happyvertical/smrt-users/dist/index.js'",
+    );
+    (brokenDist as { code?: string }).code = 'ERR_MODULE_NOT_FOUND';
+    expect(isMissingUsersDependency(brokenDist)).toBe(false);
+
+    // ERR_MODULE_NOT_FOUND without a parseable quoted target is ambiguous —
+    // fail toward surfacing the error.
+    const unparseable = new Error(
+      'some loader failure for @happyvertical/smrt-users',
+    );
+    (unparseable as { code?: string }).code = 'ERR_MODULE_NOT_FOUND';
+    expect(isMissingUsersDependency(unparseable)).toBe(false);
 
     // An unrelated runtime error mentioning the package is not a missing
     // module either.

--- a/packages/fields/src/field-policy-resolver.test.ts
+++ b/packages/fields/src/field-policy-resolver.test.ts
@@ -1,0 +1,622 @@
+import { randomUUID } from 'node:crypto';
+import {
+  field,
+  getTestDatabase,
+  ObjectRegistry,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import {
+  resetTenancy,
+  setupTestTenancy,
+  TenantIsolationError,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TenantCollection } from '../../users/src/index.js';
+import { clearFieldPolicyCache } from './cache.js';
+import { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
+import {
+  resolveFieldPolicy,
+  resolveFieldPolicyExplained,
+} from './field-policy-resolver.js';
+import type { FieldPolicyTenantHierarchyLoader } from './types.js';
+
+@smrt({
+  packageName: '@test/smrt-fields-resolver',
+  visibility: 'internal',
+  api: false,
+  cli: false,
+  mcp: false,
+})
+class PolicyResolverDoc extends SmrtObject {
+  @field({ required: true, description: 'Title help' })
+  title: string = '';
+
+  @field({ ui: { basic: true, group: 'main', order: 2 } })
+  summary: string = '';
+
+  // The scanner only carries an initializer default into the manifest when
+  // the decorator omits `type` (annotation inference) — with an explicit
+  // `type`, declare `default` explicitly.
+  @field({ type: 'integer', default: 3, ui: { order: 5 } })
+  priority: number = 3;
+
+  @field({ nullable: true })
+  subtitle: string | null = null;
+
+  @field({ ui: { locked: true } })
+  theme: string = 'default';
+
+  @field({ sensitive: true })
+  secret: string = '';
+}
+
+function fixtureRef(): string {
+  const registered = ObjectRegistry.getClassByConstructor(PolicyResolverDoc);
+  if (!registered?.qualifiedName) {
+    throw new Error(
+      'PolicyResolverDoc is not registered with a qualified name',
+    );
+  }
+  return registered.qualifiedName;
+}
+
+const flatLoader: FieldPolicyTenantHierarchyLoader = async () => null;
+
+describe('resolveFieldPolicy', () => {
+  let db: DatabaseInterface;
+  let policies: FieldPolicyCollection;
+  let objectRef: string;
+
+  beforeEach(async () => {
+    setupTestTenancy();
+    clearFieldPolicyCache();
+    db = await getTestDatabase({ classes: ['FieldPolicy', 'Tenant'] });
+    policies = await FieldPolicyCollection.create({ db });
+    objectRef = fixtureRef();
+  });
+
+  afterEach(async () => {
+    clearFieldPolicyCache();
+    resetTenancy();
+    if (typeof (db as { close?: () => Promise<void> }).close === 'function') {
+      await (db as unknown as { close: () => Promise<void> }).close();
+    }
+  });
+
+  it('rejects unknown objectRefs', async () => {
+    await expect(
+      resolveFieldPolicy('@test/nowhere:Nope', { db }),
+    ).rejects.toThrow(/Unknown field policy objectRef/);
+  });
+
+  it('seeds resolution from the manifest (defaults, ui hints, cold-start rule)', async () => {
+    const resolved = await resolveFieldPolicy(objectRef, { db });
+
+    // summary carries the only ui.basic marker, so unmarked fields land in
+    // the advanced tier.
+    expect(resolved.fields.summary.visibility).toBe('basic');
+    expect(resolved.fields.summary.group).toBe('main');
+    expect(resolved.fields.summary.order).toBe(2);
+    expect(resolved.fields.priority.visibility).toBe('advanced');
+    expect(resolved.fields.priority.hasDefault).toBe(true);
+    expect(resolved.fields.priority.defaultValue).toBe(3);
+    expect(resolved.fields.priority.order).toBe(5);
+
+    // Required field with no usable default is forced visible (safety net):
+    // its code default '' does not count as usable.
+    expect(resolved.fields.title.visibility).toBe('basic');
+    expect(resolved.fields.title.visibilityForced).toBe(true);
+    expect(resolved.fields.title.required).toBe(true);
+    expect(resolved.fields.title.help).toBe('Title help');
+
+    // Code-seeded lock resolves through.
+    expect(resolved.fields.theme.locked).toBe(true);
+    expect(resolved.fields.theme.hasDefault).toBe(true);
+    expect(resolved.fields.theme.defaultValue).toBe('default');
+
+    // The server-side resolver still covers sensitive fields (the batch
+    // action strips them for the wire) and never framework system fields.
+    expect(resolved.fields.secret).toBeDefined();
+    expect(resolved.fields.id).toBeUndefined();
+    expect(resolved.fields.slug).toBeUndefined();
+    expect(resolved.fields.context).toBeUndefined();
+  });
+
+  it('resolves defaults and visibility through app, tenant, and user tiers', async () => {
+    const tenantId = randomUUID();
+    const userId = randomUUID();
+
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'app',
+      defaultValue: JSON.stringify('app default'),
+      help: 'app help',
+    });
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId,
+      defaultValue: JSON.stringify('tenant default'),
+    });
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'user',
+      userId,
+      defaultValue: JSON.stringify('user default'),
+      visibility: 'hidden',
+    });
+
+    const appOnly = await resolveFieldPolicy(objectRef, { db });
+    expect(appOnly.fields.summary.defaultValue).toBe('app default');
+    expect(appOnly.fields.summary.visibility).toBe('basic');
+
+    const tenantTier = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId,
+      tenantHierarchyLoader: flatLoader,
+    });
+    expect(tenantTier.fields.summary.defaultValue).toBe('tenant default');
+    // Sparse inheritance: the tenant row set only the default, so help still
+    // comes from the app row.
+    expect(tenantTier.fields.summary.help).toBe('app help');
+
+    const userTier = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId,
+      userId,
+      tenantHierarchyLoader: flatLoader,
+    });
+    expect(userTier.fields.summary.defaultValue).toBe('user default');
+    expect(userTier.fields.summary.visibility).toBe('hidden');
+    expect(userTier.fields.summary.help).toBe('app help');
+
+    // The user tier applies without a tenant too (user rows are keyed by
+    // user alone).
+    const userNoTenant = await resolveFieldPolicy(objectRef, { db, userId });
+    expect(userNoTenant.fields.summary.defaultValue).toBe('user default');
+  });
+
+  it('flows lower layers through again when an override row is deleted', async () => {
+    const tenantId = randomUUID();
+
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'app',
+      defaultValue: JSON.stringify('app default'),
+    });
+    const tenantRow = await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId,
+      defaultValue: JSON.stringify('tenant default'),
+    });
+
+    const before = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId,
+      tenantHierarchyLoader: flatLoader,
+    });
+    expect(before.fields.summary.defaultValue).toBe('tenant default');
+
+    // Reset = row delete; the delete also invalidates the cache.
+    await tenantRow.delete();
+
+    const after = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId,
+      tenantHierarchyLoader: flatLoader,
+    });
+    expect(after.fields.summary.defaultValue).toBe('app default');
+  });
+
+  it('isolates tenants: another tenant sees neither rows nor cache entries', async () => {
+    const tenantA = randomUUID();
+    const tenantB = randomUUID();
+
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId: tenantA,
+      defaultValue: JSON.stringify('tenant A'),
+    });
+
+    const forA = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId: tenantA,
+      tenantHierarchyLoader: flatLoader,
+    });
+    const forB = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId: tenantB,
+      tenantHierarchyLoader: flatLoader,
+    });
+
+    expect(forA.fields.summary.defaultValue).toBe('tenant A');
+    // Tenant B inherits only the code seed (summary's initializer '').
+    expect(forB.fields.summary.defaultValue).toBe('');
+  });
+
+  it('fails closed when resolving across an active tenant or user context', async () => {
+    const contextTenant = randomUUID();
+    const otherTenant = randomUUID();
+    const contextUser = randomUUID();
+    const otherUser = randomUUID();
+
+    await withTenant(
+      {
+        tenantId: contextTenant,
+        userId: contextUser,
+        permissions: new Set<string>(),
+      },
+      async () => {
+        await expect(
+          resolveFieldPolicy(objectRef, {
+            db,
+            tenantId: otherTenant,
+            tenantHierarchyLoader: flatLoader,
+          }),
+        ).rejects.toThrow(TenantIsolationError);
+
+        await expect(
+          resolveFieldPolicy(objectRef, {
+            db,
+            tenantId: contextTenant,
+            userId: otherUser,
+            tenantHierarchyLoader: flatLoader,
+          }),
+        ).rejects.toThrow(TenantIsolationError);
+
+        // Own identities resolve fine inside the context.
+        const own = await resolveFieldPolicy(objectRef, {
+          db,
+          tenantId: contextTenant,
+          userId: contextUser,
+          tenantHierarchyLoader: flatLoader,
+        });
+        expect(own.objectRef).toBe(objectRef);
+      },
+    );
+  });
+
+  it('walks an injected tenant hierarchy root → leaf', async () => {
+    const rootTenant = randomUUID();
+    const childTenant = randomUUID();
+    const loader: FieldPolicyTenantHierarchyLoader = async () => ({
+      async getChain(tenantId: string) {
+        if (tenantId !== childTenant) {
+          return [];
+        }
+        return [
+          {
+            id: rootTenant,
+            inheritPermissions: true,
+            cascadePermissions: true,
+          },
+          {
+            id: childTenant,
+            inheritPermissions: true,
+            cascadePermissions: true,
+          },
+        ];
+      },
+    });
+
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId: rootTenant,
+      defaultValue: JSON.stringify('root default'),
+      help: 'root help',
+    });
+
+    // The ancestor's policy cascades to the child.
+    const inherited = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId: childTenant,
+      tenantHierarchyLoader: loader,
+    });
+    expect(inherited.fields.summary.defaultValue).toBe('root default');
+
+    // A child row overrides the ancestor sparsely.
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId: childTenant,
+      defaultValue: JSON.stringify('child default'),
+    });
+    clearFieldPolicyCache();
+    const overridden = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId: childTenant,
+      tenantHierarchyLoader: loader,
+    });
+    expect(overridden.fields.summary.defaultValue).toBe('child default');
+    expect(overridden.fields.summary.help).toBe('root help');
+  });
+
+  it('resets the baseline when a chain node breaks permission inheritance', async () => {
+    const rootTenant = randomUUID();
+    const detachedChild = randomUUID();
+    const loader: FieldPolicyTenantHierarchyLoader = async () => ({
+      async getChain() {
+        return [
+          {
+            id: rootTenant,
+            inheritPermissions: true,
+            // Root does not cascade → the child's baseline resets to the
+            // app-layer state.
+            cascadePermissions: false,
+          },
+          {
+            id: detachedChild,
+            inheritPermissions: true,
+            cascadePermissions: true,
+          },
+        ];
+      },
+    });
+
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'app',
+      defaultValue: JSON.stringify('app default'),
+    });
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId: rootTenant,
+      defaultValue: JSON.stringify('root default'),
+    });
+
+    const resolved = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId: detachedChild,
+      tenantHierarchyLoader: loader,
+    });
+    expect(resolved.fields.summary.defaultValue).toBe('app default');
+  });
+
+  it('uses the smrt-users tenant hierarchy via the default loader', async () => {
+    const tenants = await TenantCollection.create({ db });
+    const root = await tenants.create({ name: 'Root Tenant' });
+    await root.save();
+    const child = await tenants.createChild(root.id, {
+      name: 'Child Tenant',
+      inheritPermissions: true,
+    });
+
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId: String(root.id),
+      defaultValue: JSON.stringify('root via users'),
+    });
+
+    const resolved = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId: String(child.id),
+    });
+    expect(resolved.fields.summary.defaultValue).toBe('root via users');
+  });
+
+  it('falls back to a flat tenant chain without a hierarchy provider', async () => {
+    const tenantId = randomUUID();
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId,
+      defaultValue: JSON.stringify('flat default'),
+    });
+
+    const resolved = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId,
+      tenantHierarchyLoader: flatLoader,
+    });
+    expect(resolved.fields.summary.defaultValue).toBe('flat default');
+  });
+
+  it('skips the user layer while the org tiers resolve locked', async () => {
+    const userId = randomUUID();
+
+    // User personalizes summary while it is unlocked.
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'user',
+      userId,
+      defaultValue: JSON.stringify('user default'),
+    });
+    const beforeLock = await resolveFieldPolicy(objectRef, { db, userId });
+    expect(beforeLock.fields.summary.defaultValue).toBe('user default');
+
+    // The org later locks the field: the stale user row stops applying.
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'app',
+      defaultValue: JSON.stringify('org default'),
+      locked: true,
+    });
+    const afterLock = await resolveFieldPolicy(objectRef, { db, userId });
+    expect(afterLock.fields.summary.defaultValue).toBe('org default');
+    expect(afterLock.fields.summary.locked).toBe(true);
+
+    const explained = await resolveFieldPolicyExplained(objectRef, {
+      db,
+      userId,
+    });
+    expect(
+      explained.layers.summary.some((layer) => layer.layer === 'user'),
+    ).toBe(false);
+  });
+
+  it('forces required fields visible after a two-row deletion sequence', async () => {
+    const tenantId = randomUUID();
+
+    // The org seeds a usable default, then a tenant demotion relies on it.
+    const appDefault = await policies.create({
+      objectRef,
+      fieldName: 'title',
+      scopeType: 'app',
+      defaultValue: JSON.stringify('Seeded title'),
+    });
+    await policies.create({
+      objectRef,
+      fieldName: 'title',
+      scopeType: 'tenant',
+      tenantId,
+      visibility: 'hidden',
+    });
+
+    const withDefault = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId,
+      tenantHierarchyLoader: flatLoader,
+    });
+    expect(withDefault.fields.title.visibility).toBe('hidden');
+    expect(withDefault.fields.title.visibilityForced).toBeUndefined();
+
+    // Deleting the DEFAULT row (not the demotion row) would strand a hidden
+    // required field — the resolver safety net forces it visible.
+    await appDefault.delete();
+
+    const afterDeletion = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId,
+      tenantHierarchyLoader: flatLoader,
+    });
+    expect(afterDeletion.fields.title.visibility).toBe('basic');
+    expect(afterDeletion.fields.title.visibilityForced).toBe(true);
+  });
+
+  it('caches per (db, objectRef, tenant, user) and invalidates on save/delete', async () => {
+    const tenantId = randomUUID();
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId,
+      defaultValue: JSON.stringify('cached value'),
+    });
+
+    const first = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId,
+      tenantHierarchyLoader: flatLoader,
+    });
+    expect(first.fields.summary.defaultValue).toBe('cached value');
+
+    // A raw UPDATE bypasses save() so no invalidation fires: the resolver
+    // must keep serving the cached value.
+    await db.query(
+      `UPDATE _smrt_field_policies SET default_value = ? WHERE object_ref = ?`,
+      [JSON.stringify('stale value'), objectRef],
+    );
+    const cached = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId,
+      tenantHierarchyLoader: flatLoader,
+    });
+    expect(cached.fields.summary.defaultValue).toBe('cached value');
+
+    clearFieldPolicyCache();
+    const fresh = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId,
+      tenantHierarchyLoader: flatLoader,
+    });
+    expect(fresh.fields.summary.defaultValue).toBe('stale value');
+
+    // Model-layer writes invalidate: an upsert through the collection is
+    // visible immediately.
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId,
+      defaultValue: JSON.stringify('written value'),
+    });
+    const afterWrite = await resolveFieldPolicy(objectRef, {
+      db,
+      tenantId,
+      tenantHierarchyLoader: flatLoader,
+    });
+    expect(afterWrite.fields.summary.defaultValue).toBe('written value');
+  });
+
+  it('explains per-layer contributions alongside the merged result', async () => {
+    const tenantId = randomUUID();
+    const userId = randomUUID();
+
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'app',
+      defaultValue: JSON.stringify('app default'),
+      help: 'app help',
+    });
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId,
+      defaultValue: JSON.stringify('tenant default'),
+    });
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'user',
+      userId,
+      visibility: 'advanced',
+    });
+
+    const explained = await resolveFieldPolicyExplained(objectRef, {
+      db,
+      tenantId,
+      userId,
+      tenantHierarchyLoader: flatLoader,
+    });
+
+    const layers = explained.layers.summary;
+    expect(layers.map((layer) => layer.layer)).toEqual([
+      'code',
+      'app',
+      'tenant',
+      'user',
+    ]);
+    expect(layers[0].delta.visibility).toBe('basic');
+    expect(layers[1].delta.default).toEqual({ value: 'app default' });
+    expect(layers[1].delta.help).toBe('app help');
+    expect(layers[2].tenantId).toBe(tenantId);
+    expect(layers[2].delta.default).toEqual({ value: 'tenant default' });
+    expect(layers[3].userId).toBe(userId);
+    expect(layers[3].delta.visibility).toBe('advanced');
+
+    // The merged view reproduces the layered application.
+    expect(explained.fields.summary.defaultValue).toBe('tenant default');
+    expect(explained.fields.summary.visibility).toBe('advanced');
+    expect(explained.fields.summary.help).toBe('app help');
+  });
+
+  it('resolves the code seed alone when no database is supplied', async () => {
+    const resolved = await resolveFieldPolicy(objectRef, {});
+    expect(resolved.fields.summary.visibility).toBe('basic');
+    expect(resolved.fields.priority.defaultValue).toBe(3);
+  });
+});

--- a/packages/fields/src/field-policy-resolver.test.ts
+++ b/packages/fields/src/field-policy-resolver.test.ts
@@ -18,10 +18,15 @@ import { TenantCollection } from '../../users/src/index.js';
 import { clearFieldPolicyCache } from './cache.js';
 import { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
 import {
+  isMissingUsersDependency,
   resolveFieldPolicy,
   resolveFieldPolicyExplained,
 } from './field-policy-resolver.js';
-import type { FieldPolicyTenantHierarchyLoader } from './types.js';
+import type {
+  ExplainedObjectFieldPolicy,
+  FieldPolicyTenantHierarchyLoader,
+  FieldPolicyVisibility,
+} from './types.js';
 
 @smrt({
   packageName: '@test/smrt-fields-resolver',
@@ -64,6 +69,62 @@ function fixtureRef(): string {
 }
 
 const flatLoader: FieldPolicyTenantHierarchyLoader = async () => null;
+
+/**
+ * Sequentially replay the explained layer deltas (plus the required-field
+ * safety net) and assert the result reproduces the merged policy for every
+ * field — the contract that lets #2049/#2050 UIs trust the layer lists.
+ */
+function expectLayersToReproduceMerged(
+  explained: ExplainedObjectFieldPolicy,
+): void {
+  for (const [fieldName, merged] of Object.entries(explained.fields)) {
+    const contributions = explained.layers[fieldName] ?? [];
+    let defaultBox: { value: unknown } | undefined;
+    let visibility: FieldPolicyVisibility = 'basic';
+    let help: string | undefined;
+    let label: string | undefined;
+    let order: number | undefined;
+    let locked: boolean | undefined;
+
+    for (const { delta } of contributions) {
+      defaultBox = delta.default ?? defaultBox;
+      visibility = delta.visibility ?? visibility;
+      help = delta.help ?? help;
+      label = delta.label ?? label;
+      order = delta.order ?? order;
+      locked = delta.locked ?? locked;
+    }
+
+    const usableDefault =
+      defaultBox !== undefined &&
+      defaultBox.value !== null &&
+      defaultBox.value !== '';
+    if (merged.required && !usableDefault && visibility !== 'basic') {
+      visibility = 'basic';
+    }
+
+    expect({
+      fieldName,
+      hasDefault: defaultBox !== undefined,
+      defaultValue: defaultBox?.value,
+      visibility,
+      help: help ?? null,
+      label: label ?? null,
+      order: order ?? null,
+      locked: locked === true,
+    }).toEqual({
+      fieldName,
+      hasDefault: merged.hasDefault,
+      defaultValue: merged.defaultValue,
+      visibility: merged.visibility,
+      help: merged.help,
+      label: merged.label,
+      order: merged.order,
+      locked: merged.locked,
+    });
+  }
+}
 
 describe('resolveFieldPolicy', () => {
   let db: DatabaseInterface;
@@ -379,14 +440,40 @@ describe('resolveFieldPolicy', () => {
       scopeType: 'tenant',
       tenantId: rootTenant,
       defaultValue: JSON.stringify('root default'),
+      help: 'root help',
+    });
+    // The child's own sparse row survives the break and applies over the
+    // app layer (NOT over the discarded root layer).
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId: detachedChild,
+      help: 'child help',
     });
 
-    const resolved = await resolveFieldPolicy(objectRef, {
+    const explained = await resolveFieldPolicyExplained(objectRef, {
       db,
       tenantId: detachedChild,
       tenantHierarchyLoader: loader,
     });
-    expect(resolved.fields.summary.defaultValue).toBe('app default');
+    expect(explained.fields.summary.defaultValue).toBe('app default');
+    expect(explained.fields.summary.help).toBe('child help');
+
+    // The discarded ancestor never appears in the explained layers, so the
+    // listed contributions reproduce the merged result on replay.
+    const summaryLayers = explained.layers.summary;
+    expect(
+      summaryLayers.some(
+        (layer) => layer.layer === 'tenant' && layer.tenantId === rootTenant,
+      ),
+    ).toBe(false);
+    expect(
+      summaryLayers.some(
+        (layer) => layer.layer === 'tenant' && layer.tenantId === detachedChild,
+      ),
+    ).toBe(true);
+    expectLayersToReproduceMerged(explained);
   });
 
   it('uses the smrt-users tenant hierarchy via the default loader', async () => {
@@ -608,15 +695,76 @@ describe('resolveFieldPolicy', () => {
     expect(layers[3].userId).toBe(userId);
     expect(layers[3].delta.visibility).toBe('advanced');
 
-    // The merged view reproduces the layered application.
+    // The merged view reproduces the layered application — for summary and
+    // for every other field's listed contributions.
     expect(explained.fields.summary.defaultValue).toBe('tenant default');
     expect(explained.fields.summary.visibility).toBe('advanced');
     expect(explained.fields.summary.help).toBe('app help');
+    expectLayersToReproduceMerged(explained);
   });
 
   it('resolves the code seed alone when no database is supplied', async () => {
     const resolved = await resolveFieldPolicy(objectRef, {});
     expect(resolved.fields.summary.visibility).toBe('basic');
     expect(resolved.fields.priority.defaultValue).toBe(3);
+  });
+});
+
+describe('isMissingUsersDependency', () => {
+  it("treats Node's ERR_MODULE_NOT_FOUND missing-package shape as absent", () => {
+    // The exact shape Node raises for a missing bare specifier.
+    const direct = new Error(
+      "Cannot find package '@happyvertical/smrt-users' imported from " +
+        '/app/node_modules/@happyvertical/smrt-fields/dist/index.js',
+    );
+    (direct as { code?: string }).code = 'ERR_MODULE_NOT_FOUND';
+    expect(isMissingUsersDependency(direct)).toBe(true);
+
+    // The same failure surfaced through a wrapper's cause chain.
+    const wrapped = new Error(
+      'Failed to load @happyvertical/smrt-users for tenant-aware field ' +
+        'policy resolution',
+      { cause: direct },
+    );
+    expect(isMissingUsersDependency(wrapped)).toBe(true);
+
+    // A cause-only code (wrapper without one of the known texts).
+    const inner = new Error(
+      'some loader failure for @happyvertical/smrt-users',
+    );
+    const carrier = new Error('import failed', { cause: inner });
+    (inner as { code?: string }).code = 'ERR_MODULE_NOT_FOUND';
+    expect(isMissingUsersDependency(carrier)).toBe(true);
+
+    // importWorkspaceModule's own source-fallback message.
+    expect(
+      isMissingUsersDependency(
+        new Error(
+          'Failed to load @happyvertical/smrt-users for tenant-aware field ' +
+            'policy resolution: could not find /workspace/packages/users/src',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('rethrows installed-but-broken failures instead of falling back', () => {
+    // A transitive missing dependency INSIDE smrt-users names the other
+    // package — that is a broken install, not an absent one.
+    const transitive = new Error(
+      "Cannot find package 'left-pad' imported from " +
+        '/workspace/packages/users/dist/index.js',
+    );
+    (transitive as { code?: string }).code = 'ERR_MODULE_NOT_FOUND';
+    expect(isMissingUsersDependency(transitive)).toBe(false);
+
+    // An unrelated runtime error mentioning the package is not a missing
+    // module either.
+    expect(
+      isMissingUsersDependency(
+        new Error('@happyvertical/smrt-users threw during initialization'),
+      ),
+    ).toBe(false);
+
+    expect(isMissingUsersDependency('not an error')).toBe(false);
   });
 });

--- a/packages/fields/src/field-policy-resolver.ts
+++ b/packages/fields/src/field-policy-resolver.ts
@@ -1,0 +1,387 @@
+import { importWorkspaceModule } from '@happyvertical/smrt-core/utils/import-workspace-module';
+import {
+  assertTenantReadAllowed,
+  getCurrentTenant,
+  isSuperAdminBypass,
+  TenantIsolationError,
+} from '@happyvertical/smrt-tenancy';
+import { getCachedFieldPolicy, setCachedFieldPolicy } from './cache.js';
+import { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
+import {
+  buildCodeSeedDelta,
+  buildCodeSeedVisibility,
+  type FieldDefinitionMap,
+  getCodeSeedGroup,
+  getObjectFieldMap,
+  isRequiredField,
+  isUsableRequiredDefault,
+} from './field-definitions.js';
+import type { FieldPolicy } from './models/FieldPolicy.js';
+import type {
+  ExplainedObjectFieldPolicy,
+  FieldPolicyDelta,
+  FieldPolicyLayerContribution,
+  FieldPolicyTenantHierarchyProvider,
+  FieldPolicyTenantNode,
+  FieldPolicyUsersModule,
+  FieldPolicyVisibility,
+  ResolvedFieldPolicy,
+  ResolvedObjectFieldPolicy,
+  ResolveFieldPolicyOptions,
+  SmrtClassOptions,
+} from './types.js';
+
+/** Accumulated merge state for one field while layers apply. */
+interface MergedPolicyState {
+  default?: { value: unknown };
+  visibility: FieldPolicyVisibility;
+  help?: string;
+  label?: string;
+  order?: number;
+  locked?: boolean;
+}
+
+/**
+ * Resolve the merged field policy for `objectRef` in the given
+ * `(tenantId, userId)` context: code seed → app rows → tenant rows (hierarchy
+ * walk root → leaf) → user rows. Defaults AND visibility both resolve through
+ * the user tier.
+ *
+ * Results are cached per `(database, objectRef, tenantId, userId)` with a
+ * short TTL; `FieldPolicy.save()`/`.delete()` invalidate the object's entries.
+ */
+export async function resolveFieldPolicy(
+  objectRef: string,
+  options: ResolveFieldPolicyOptions = {},
+): Promise<ResolvedObjectFieldPolicy> {
+  const explained = await resolveFieldPolicyExplained(objectRef, options);
+  return { objectRef: explained.objectRef, fields: explained.fields };
+}
+
+/**
+ * Explain variant: the merged result plus ordered per-layer contributions for
+ * each field, so the gear UI (#2049, "shows inherited base") and the control
+ * panel (#2050, effective-value-per-layer) never re-derive precedence.
+ *
+ * A user-layer row suppressed by an effective org lock is omitted from the
+ * layer list too — the listed layers always reproduce the merged result.
+ */
+export async function resolveFieldPolicyExplained(
+  objectRef: string,
+  options: ResolveFieldPolicyOptions = {},
+): Promise<ExplainedObjectFieldPolicy> {
+  const tenantId = options.tenantId ?? null;
+  const userId = options.userId ?? null;
+
+  assertResolutionAllowedInContext(tenantId, userId);
+
+  let collection: FieldPolicyCollection | null = null;
+  let cacheDb: unknown = options.db;
+  if (options.db) {
+    collection = await FieldPolicyCollection.create({ db: options.db });
+    cacheDb = collection.db;
+  }
+
+  // The field map load also validates objectRef against the live registry, so
+  // unknown refs throw before the cache is consulted.
+  const fieldMap = await getObjectFieldMap(objectRef);
+
+  const cached = getCachedFieldPolicy(objectRef, tenantId, userId, cacheDb);
+  if (cached) {
+    return cached;
+  }
+
+  const policyFields = selectPolicyAddressableFields(fieldMap);
+  const codeVisibility = buildCodeSeedVisibility(fieldMap);
+
+  const appRows = collection
+    ? await collection.getAppRows(objectRef)
+    : new Map<string, FieldPolicy>();
+
+  let chain: FieldPolicyTenantNode[] = [];
+  let tenantRows = new Map<string, Map<string, FieldPolicy>>();
+  if (collection && tenantId) {
+    chain = await resolveTenantChain(tenantId, options);
+    tenantRows = await collection.getTenantRows(
+      objectRef,
+      chain.map((node) => node.id),
+    );
+  }
+
+  const userRows =
+    collection && userId
+      ? await collection.getUserRows(objectRef, userId)
+      : new Map<string, FieldPolicy>();
+
+  const fields: Record<string, ResolvedFieldPolicy> = {};
+  const layers: Record<string, FieldPolicyLayerContribution[]> = {};
+
+  for (const [fieldName, fieldDef] of policyFields) {
+    const contributions: FieldPolicyLayerContribution[] = [];
+
+    const codeDelta = buildCodeSeedDelta(
+      fieldDef,
+      codeVisibility.get(fieldName) ?? 'basic',
+    );
+    contributions.push({ layer: 'code', delta: codeDelta });
+
+    let state: MergedPolicyState = applyDelta(
+      { visibility: 'basic' },
+      codeDelta,
+    );
+
+    const appRow = appRows.get(fieldName);
+    if (appRow) {
+      const delta = rowToDelta(appRow);
+      contributions.push({ layer: 'app', delta });
+      state = applyDelta(state, delta);
+    }
+
+    // Tenant chain walk, root → leaf, mirroring smrt-features: a node only
+    // inherits the accumulated tenant-layer state when its parent cascades
+    // permissions and it accepts them; otherwise its baseline resets to the
+    // app-layer state.
+    const appLayerState = state;
+    let accumulated = appLayerState;
+    for (let index = 0; index < chain.length; index++) {
+      const current = chain[index];
+      const previous = index > 0 ? chain[index - 1] : null;
+      const shouldInherit =
+        index === 0 ||
+        (!!previous?.cascadePermissions && current.inheritPermissions);
+      const baseline = shouldInherit ? accumulated : appLayerState;
+
+      const row = tenantRows.get(current.id)?.get(fieldName);
+      if (row) {
+        const delta = rowToDelta(row);
+        contributions.push({ layer: 'tenant', tenantId: current.id, delta });
+        accumulated = applyDelta(baseline, delta);
+      } else {
+        accumulated = baseline;
+      }
+    }
+    state = accumulated;
+
+    // Org lock: when the code/app/tenant tiers resolve locked, the user tier
+    // is skipped entirely — a stale user row cannot bypass a later lock.
+    const orgLocked = state.locked === true;
+    const userRow = userId ? userRows.get(fieldName) : undefined;
+    if (userRow && !orgLocked) {
+      const delta = rowToDelta(userRow);
+      contributions.push({ layer: 'user', userId: userId as string, delta });
+      state = applyDelta(state, delta);
+    }
+
+    // Resolver-side required-field safety net: a required field with no
+    // usable resolved default is ALWAYS visible, regardless of stored
+    // visibility — write-time enforcement alone breaks when a DIFFERENT row's
+    // deletion removes the default a demotion relied on.
+    const required = isRequiredField(fieldDef);
+    let visibilityForced = false;
+    if (
+      required &&
+      !isUsableRequiredDefault(state.default) &&
+      state.visibility !== 'basic'
+    ) {
+      state = { ...state, visibility: 'basic' };
+      visibilityForced = true;
+    }
+
+    fields[fieldName] = {
+      fieldName,
+      hasDefault: state.default !== undefined,
+      defaultValue: state.default?.value,
+      visibility: state.visibility,
+      help: state.help ?? null,
+      label: state.label ?? null,
+      order: state.order ?? null,
+      group: getCodeSeedGroup(fieldDef),
+      locked: state.locked === true,
+      required,
+      ...(visibilityForced ? { visibilityForced: true } : {}),
+    };
+    layers[fieldName] = contributions;
+  }
+
+  const explained: ExplainedObjectFieldPolicy = { objectRef, fields, layers };
+  setCachedFieldPolicy(objectRef, tenantId, userId, cacheDb, explained);
+  return explained;
+}
+
+/**
+ * Fail-closed isolation guard: an active non-bypass tenant context may only
+ * resolve its own tenant (and, when the context carries a user id, its own
+ * user). App-only resolution (`tenantId` null) is always allowed — app rows
+ * are global data.
+ */
+function assertResolutionAllowedInContext(
+  tenantId: string | null,
+  userId: string | null,
+): void {
+  if (tenantId) {
+    assertTenantReadAllowed(tenantId, 'resolveFieldPolicy');
+  }
+
+  if (!userId) {
+    return;
+  }
+  const context = getCurrentTenant();
+  if (
+    context &&
+    !isSuperAdminBypass() &&
+    context.userId !== undefined &&
+    context.userId !== userId
+  ) {
+    throw new TenantIsolationError(
+      `Tenant isolation violation in resolveFieldPolicy: context user is ` +
+        `'${context.userId}' but resolution requested '${userId}'`,
+      { tenantId: context.tenantId },
+    );
+  }
+}
+
+/**
+ * Fields that participate in policy resolution: everything except injected
+ * framework system fields, relationship pseudo-fields, and STI meta
+ * internals (matching the exclusions of the generated web field definitions).
+ */
+function selectPolicyAddressableFields(
+  fieldMap: FieldDefinitionMap,
+): FieldDefinitionMap {
+  const selected: FieldDefinitionMap = new Map();
+  for (const [name, field] of fieldMap) {
+    if (field._meta?.__smrtSystemField === true) {
+      continue;
+    }
+    if (
+      field.type === 'oneToMany' ||
+      field.type === 'manyToMany' ||
+      field.type === 'meta'
+    ) {
+      continue;
+    }
+    selected.set(name, field);
+  }
+  return selected;
+}
+
+/** A stored row's sparse contribution (NULL columns contribute nothing). */
+function rowToDelta(row: FieldPolicy): FieldPolicyDelta {
+  const delta: FieldPolicyDelta = {};
+
+  if (row.defaultValue !== null && row.defaultValue !== undefined) {
+    try {
+      delta.default = { value: JSON.parse(row.defaultValue) };
+    } catch {
+      // Unparseable stored JSON (should be prevented by save-time validation)
+      // contributes nothing rather than poisoning resolution.
+    }
+  }
+  if (row.visibility !== null && row.visibility !== undefined) {
+    delta.visibility = row.visibility;
+  }
+  if (row.help !== null && row.help !== undefined) {
+    delta.help = row.help;
+  }
+  if (row.label !== null && row.label !== undefined) {
+    delta.label = row.label;
+  }
+  if (row.displayOrder !== null && row.displayOrder !== undefined) {
+    delta.order = row.displayOrder;
+  }
+  if (row.locked !== null && row.locked !== undefined) {
+    delta.locked = row.locked;
+  }
+
+  return delta;
+}
+
+function applyDelta(
+  state: MergedPolicyState,
+  delta: FieldPolicyDelta,
+): MergedPolicyState {
+  return {
+    default: delta.default ?? state.default,
+    visibility: delta.visibility ?? state.visibility,
+    help: delta.help ?? state.help,
+    label: delta.label ?? state.label,
+    order: delta.order ?? state.order,
+    locked: delta.locked ?? state.locked,
+  };
+}
+
+async function resolveTenantChain(
+  tenantId: string,
+  options: ResolveFieldPolicyOptions,
+): Promise<FieldPolicyTenantNode[]> {
+  const loader = options.tenantHierarchyLoader || defaultTenantHierarchyLoader;
+  const provider = await loader({ db: options.db } as SmrtClassOptions);
+
+  if (provider) {
+    const chain = await provider.getChain(tenantId);
+    if (chain.length > 0) {
+      return chain;
+    }
+  }
+
+  // Flat-tenant fallback (no hierarchy provider, or the provider does not
+  // know the tenant): treat the tenant as a single-node chain.
+  return [{ id: tenantId, inheritPermissions: true, cascadePermissions: true }];
+}
+
+/**
+ * Default hierarchy loader: dynamic-imports `@happyvertical/smrt-users` (the
+ * smrt-features precedent — a loader function, not a container registration)
+ * and returns `null` when it is not installed so resolution degrades to the
+ * flat-tenant fallback.
+ */
+async function defaultTenantHierarchyLoader(
+  options: SmrtClassOptions,
+): Promise<FieldPolicyTenantHierarchyProvider | null> {
+  try {
+    const usersModule = await importWorkspaceModule<FieldPolicyUsersModule>({
+      packageName: '@happyvertical/smrt-users',
+      sourceEntry: 'packages/users/src/collections/index.ts',
+      purpose: 'tenant-aware field policy resolution',
+    });
+
+    const tenantCollection = await usersModule.TenantCollection.create(options);
+    return {
+      async getChain(tenantId: string): Promise<FieldPolicyTenantNode[]> {
+        const tenant = await tenantCollection.get({ id: tenantId });
+        if (!tenant) {
+          return [];
+        }
+
+        const ancestors = await tenantCollection.getAncestorsFromRoot(tenantId);
+        return [...ancestors, tenant].map((node) => ({
+          id: String(node.id),
+          inheritPermissions: Boolean(node.inheritPermissions),
+          cascadePermissions: Boolean(node.cascadePermissions),
+        }));
+      },
+    };
+  } catch (error) {
+    if (isMissingUsersDependency(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function isMissingUsersDependency(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const causeMessage =
+    error.cause instanceof Error ? ` ${error.cause.message}` : '';
+  const text = `${error.message}${causeMessage}`;
+
+  return (
+    text.includes('@happyvertical/smrt-users') &&
+    (text.includes('Cannot find module') ||
+      text.includes('Failed to load') ||
+      text.includes('could not find'))
+  );
+}

--- a/packages/fields/src/field-policy-resolver.ts
+++ b/packages/fields/src/field-policy-resolver.ts
@@ -386,43 +386,56 @@ async function defaultTenantHierarchyLoader(
   }
 }
 
+/** Node's missing-module message shapes, capturing the quoted specifier. */
+const MISSING_MODULE_TARGET_PATTERN =
+  /Cannot find (?:package|module) '([^']+)'/;
+
+/** Whether a missing-module TARGET specifier is smrt-users (or a subpath). */
+function isUsersSpecifier(target: string): boolean {
+  return (
+    target === '@happyvertical/smrt-users' ||
+    target.startsWith('@happyvertical/smrt-users/')
+  );
+}
+
 /**
  * Whether an import failure means `@happyvertical/smrt-users` is simply not
  * installed (→ flat-tenant fallback) rather than installed-but-broken
- * (→ rethrow). Node reports a missing bare specifier as
- * `ERR_MODULE_NOT_FOUND` with the message `Cannot find package '...'`, so
- * both the error `code` (across the whole `cause` chain) and that message
- * text are matched alongside the wrapper texts `importWorkspaceModule`
- * produces. A transitive `ERR_MODULE_NOT_FOUND` raised INSIDE smrt-users
- * names the other package, fails the smrt-users text check, and rethrows.
+ * (→ rethrow, surfacing the problem instead of silently losing ancestor
+ * locks/defaults).
+ *
+ * The decision is made on the missing-module TARGET parsed from Node's
+ * `Cannot find package/module '<specifier>'` message (walking the full
+ * `cause` chain): only a target that IS smrt-users (or one of its subpaths)
+ * counts. A transitive failure INSIDE an installed smrt-users names the
+ * other package as the target — with the users path merely appearing as the
+ * importer — and therefore rethrows. `importWorkspaceModule`'s own
+ * source-fallback wrapper ("Failed to load @happyvertical/smrt-users for
+ * ...") is also accepted: it is thrown only when the users package itself
+ * cannot be located.
  *
  * Exported for direct testing; not re-exported from the package index.
  */
 export function isMissingUsersDependency(error: unknown): boolean {
-  let sawModuleNotFound = false;
-  let text = '';
   let current: unknown = error;
   const seen = new Set<unknown>();
 
   while (current instanceof Error && !seen.has(current)) {
     seen.add(current);
-    text += ` ${current.message}`;
-    const code = (current as { code?: unknown }).code;
-    if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
-      sawModuleNotFound = true;
+
+    const match = current.message.match(MISSING_MODULE_TARGET_PATTERN);
+    if (match && isUsersSpecifier(match[1])) {
+      return true;
     }
+
+    if (
+      current.message.includes('Failed to load @happyvertical/smrt-users for')
+    ) {
+      return true;
+    }
+
     current = current.cause;
   }
 
-  if (!text.includes('@happyvertical/smrt-users')) {
-    return false;
-  }
-
-  return (
-    sawModuleNotFound ||
-    text.includes('Cannot find package') ||
-    text.includes('Cannot find module') ||
-    text.includes('Failed to load') ||
-    text.includes('could not find')
-  );
+  return false;
 }

--- a/packages/fields/src/field-policy-resolver.ts
+++ b/packages/fields/src/field-policy-resolver.ts
@@ -98,13 +98,20 @@ export async function resolveFieldPolicyExplained(
     ? await collection.getAppRows(objectRef)
     : new Map<string, FieldPolicy>();
 
-  let chain: FieldPolicyTenantNode[] = [];
+  let survivingChain: FieldPolicyTenantNode[] = [];
   let tenantRows = new Map<string, Map<string, FieldPolicy>>();
   if (collection && tenantId) {
-    chain = await resolveTenantChain(tenantId, options);
+    const chain = await resolveTenantChain(tenantId, options);
+    // Permission-inheritance breaks are chain-STRUCTURAL (node flags, not
+    // rows), so a break at node i discards every earlier tenant contribution
+    // for ALL fields — the merge baseline resets to the app-layer state
+    // there. Only the suffix from the LAST break participates in merging and
+    // in the explained layers, so sequentially replaying the listed deltas
+    // always reproduces the merged result.
+    survivingChain = selectSurvivingChainSuffix(chain);
     tenantRows = await collection.getTenantRows(
       objectRef,
-      chain.map((node) => node.id),
+      survivingChain.map((node) => node.id),
     );
   }
 
@@ -137,30 +144,18 @@ export async function resolveFieldPolicyExplained(
       state = applyDelta(state, delta);
     }
 
-    // Tenant chain walk, root → leaf, mirroring smrt-features: a node only
-    // inherits the accumulated tenant-layer state when its parent cascades
-    // permissions and it accepts them; otherwise its baseline resets to the
-    // app-layer state.
-    const appLayerState = state;
-    let accumulated = appLayerState;
-    for (let index = 0; index < chain.length; index++) {
-      const current = chain[index];
-      const previous = index > 0 ? chain[index - 1] : null;
-      const shouldInherit =
-        index === 0 ||
-        (!!previous?.cascadePermissions && current.inheritPermissions);
-      const baseline = shouldInherit ? accumulated : appLayerState;
-
-      const row = tenantRows.get(current.id)?.get(fieldName);
+    // Tenant chain walk, root → leaf, over the surviving suffix only (nodes
+    // before the last permission-inheritance break contribute nothing — see
+    // selectSurvivingChainSuffix). Equivalent to smrt-features' baseline
+    // walk, but the explained contributions never list discarded ancestors.
+    for (const node of survivingChain) {
+      const row = tenantRows.get(node.id)?.get(fieldName);
       if (row) {
         const delta = rowToDelta(row);
-        contributions.push({ layer: 'tenant', tenantId: current.id, delta });
-        accumulated = applyDelta(baseline, delta);
-      } else {
-        accumulated = baseline;
+        contributions.push({ layer: 'tenant', tenantId: node.id, delta });
+        state = applyDelta(state, delta);
       }
     }
-    state = accumulated;
 
     // Org lock: when the code/app/tenant tiers resolve locked, the user tier
     // is skipped entirely — a stale user row cannot bypass a later lock.
@@ -310,6 +305,28 @@ function applyDelta(
   };
 }
 
+/**
+ * The chain suffix that actually participates in merging: nodes from the
+ * LAST permission-inheritance break onward (a node breaks inheritance when
+ * its parent does not cascade permissions or it does not accept them —
+ * smrt-features semantics). Everything before the last break is discarded
+ * for every field, so it is excluded from both merging and the explained
+ * layer contributions.
+ */
+function selectSurvivingChainSuffix(
+  chain: FieldPolicyTenantNode[],
+): FieldPolicyTenantNode[] {
+  let survivingStart = 0;
+  for (let index = 1; index < chain.length; index++) {
+    const inherits =
+      chain[index - 1].cascadePermissions && chain[index].inheritPermissions;
+    if (!inherits) {
+      survivingStart = index;
+    }
+  }
+  return chain.slice(survivingStart);
+}
+
 async function resolveTenantChain(
   tenantId: string,
   options: ResolveFieldPolicyOptions,
@@ -369,19 +386,43 @@ async function defaultTenantHierarchyLoader(
   }
 }
 
-function isMissingUsersDependency(error: unknown): boolean {
-  if (!(error instanceof Error)) {
+/**
+ * Whether an import failure means `@happyvertical/smrt-users` is simply not
+ * installed (→ flat-tenant fallback) rather than installed-but-broken
+ * (→ rethrow). Node reports a missing bare specifier as
+ * `ERR_MODULE_NOT_FOUND` with the message `Cannot find package '...'`, so
+ * both the error `code` (across the whole `cause` chain) and that message
+ * text are matched alongside the wrapper texts `importWorkspaceModule`
+ * produces. A transitive `ERR_MODULE_NOT_FOUND` raised INSIDE smrt-users
+ * names the other package, fails the smrt-users text check, and rethrows.
+ *
+ * Exported for direct testing; not re-exported from the package index.
+ */
+export function isMissingUsersDependency(error: unknown): boolean {
+  let sawModuleNotFound = false;
+  let text = '';
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+    text += ` ${current.message}`;
+    const code = (current as { code?: unknown }).code;
+    if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') {
+      sawModuleNotFound = true;
+    }
+    current = current.cause;
+  }
+
+  if (!text.includes('@happyvertical/smrt-users')) {
     return false;
   }
 
-  const causeMessage =
-    error.cause instanceof Error ? ` ${error.cause.message}` : '';
-  const text = `${error.message}${causeMessage}`;
-
   return (
-    text.includes('@happyvertical/smrt-users') &&
-    (text.includes('Cannot find module') ||
-      text.includes('Failed to load') ||
-      text.includes('could not find'))
+    sawModuleNotFound ||
+    text.includes('Cannot find package') ||
+    text.includes('Cannot find module') ||
+    text.includes('Failed to load') ||
+    text.includes('could not find')
   );
 }

--- a/packages/fields/src/field-policy-resolver.ts
+++ b/packages/fields/src/field-policy-resolver.ts
@@ -86,7 +86,13 @@ export async function resolveFieldPolicyExplained(
   // unknown refs throw before the cache is consulted.
   const fieldMap = await getObjectFieldMap(objectRef);
 
-  const cached = getCachedFieldPolicy(objectRef, tenantId, userId, cacheDb);
+  const cached = getCachedFieldPolicy(
+    objectRef,
+    tenantId,
+    userId,
+    cacheDb,
+    options.tenantHierarchyLoader,
+  );
   if (cached) {
     return cached;
   }
@@ -199,15 +205,29 @@ export async function resolveFieldPolicyExplained(
   }
 
   const explained: ExplainedObjectFieldPolicy = { objectRef, fields, layers };
-  setCachedFieldPolicy(objectRef, tenantId, userId, cacheDb, explained);
+  setCachedFieldPolicy(
+    objectRef,
+    tenantId,
+    userId,
+    cacheDb,
+    explained,
+    options.tenantHierarchyLoader,
+  );
   return explained;
 }
 
 /**
  * Fail-closed isolation guard: an active non-bypass tenant context may only
- * resolve its own tenant (and, when the context carries a user id, its own
- * user). App-only resolution (`tenantId` null) is always allowed — app rows
- * are global data.
+ * resolve its own tenant and its own user. App-only resolution (`tenantId`
+ * null) is always allowed — app rows are global data.
+ *
+ * Mirrors the write-side rule in `FieldPolicy`: a MISSING identity component
+ * denies, it never skips. A context that carries permissions but no user id
+ * (no `resolveUserId` hook configured — API-key auth, service principals,
+ * background jobs) must not be able to read any user's resolved policy.
+ * Context-LESS callers stay allowed: `resolveFieldPolicy` is a trusted
+ * server-side API, and the public `resolveBatch` route never lets a request
+ * body select a user — it takes identity from the ambient context alone.
  */
 function assertResolutionAllowedInContext(
   tenantId: string | null,
@@ -221,12 +241,18 @@ function assertResolutionAllowedInContext(
     return;
   }
   const context = getCurrentTenant();
-  if (
-    context &&
-    !isSuperAdminBypass() &&
-    context.userId !== undefined &&
-    context.userId !== userId
-  ) {
+  if (!context || isSuperAdminBypass()) {
+    return;
+  }
+  if (context.userId === undefined) {
+    throw new TenantIsolationError(
+      `Tenant isolation violation in resolveFieldPolicy: the ambient ` +
+        `context carries no user id, so user-scope resolution for ` +
+        `'${userId}' is not attributable`,
+      { tenantId: context.tenantId },
+    );
+  }
+  if (context.userId !== userId) {
     throw new TenantIsolationError(
       `Tenant isolation violation in resolveFieldPolicy: context user is ` +
         `'${context.userId}' but resolution requested '${userId}'`,

--- a/packages/fields/src/field-policy.test.ts
+++ b/packages/fields/src/field-policy.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import {
+  crossPackageRef,
   field,
   getTestDatabase,
   meta,
@@ -62,6 +63,12 @@ class PolicyModelDoc extends SmrtObject {
 
   @meta()
   legacyNotes: string = '';
+
+  @crossPackageRef('@happyvertical/smrt-users:User')
+  reviewerId: string = '';
+
+  @crossPackageRef('@happyvertical/smrt-users:User', { idType: 'text' })
+  externalRef: string = '';
 }
 
 function fixtureRef(): string {
@@ -70,6 +77,23 @@ function fixtureRef(): string {
     throw new Error('PolicyModelDoc is not registered with a qualified name');
   }
   return registered.qualifiedName;
+}
+
+/**
+ * Seed tenant/user-scope rows the way real ops flows do: under a super-admin
+ * bypass context. Without any ambient identity such rows are rejected
+ * outright (the context-absent fail-closed rule), so bare-context seeding is
+ * reserved for app-scope rows.
+ */
+function seedPolicies<T>(fn: () => Promise<T>): Promise<T> {
+  return withTenant(
+    {
+      tenantId: randomUUID(),
+      permissions: new Set<string>(),
+      superAdminBypass: true,
+    },
+    fn,
+  );
 }
 
 describe('FieldPolicy write-time validation', () => {
@@ -388,13 +412,15 @@ describe('FieldPolicy write-time validation', () => {
     expect(viaCodeDefault.visibility).toBe('advanced');
 
     // A tenant demotion may rely on the app row's stored default.
-    const tenantRow = await policies.create({
-      objectRef,
-      fieldName: 'title',
-      scopeType: 'tenant',
-      tenantId: randomUUID(),
-      visibility: 'hidden',
-    });
+    const tenantRow = await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'title',
+        scopeType: 'tenant',
+        tenantId: randomUUID(),
+        visibility: 'hidden',
+      }),
+    );
     expect(tenantRow.visibility).toBe('hidden');
 
     // Optional fields demote freely.
@@ -408,26 +434,28 @@ describe('FieldPolicy write-time validation', () => {
   });
 
   it('restricts locked to org rows and enforces the lock against user writes', async () => {
-    await expect(
-      policies.create({
-        objectRef,
-        fieldName: 'summary',
-        scopeType: 'user',
-        userId: randomUUID(),
-        locked: true,
-      }),
-    ).rejects.toThrow(/locked may only be set on org rows/);
+    await seedPolicies(async () => {
+      await expect(
+        policies.create({
+          objectRef,
+          fieldName: 'summary',
+          scopeType: 'user',
+          userId: randomUUID(),
+          locked: true,
+        }),
+      ).rejects.toThrow(/locked may only be set on org rows/);
 
-    // Code-seeded lock (ui.locked) blocks user-scope writes outright.
-    await expect(
-      policies.create({
-        objectRef,
-        fieldName: 'lockedByCode',
-        scopeType: 'user',
-        userId: randomUUID(),
-        help: 'mine',
-      }),
-    ).rejects.toThrow(/locked by org policy/);
+      // Code-seeded lock (ui.locked) blocks user-scope writes outright.
+      await expect(
+        policies.create({
+          objectRef,
+          fieldName: 'lockedByCode',
+          scopeType: 'user',
+          userId: randomUUID(),
+          help: 'mine',
+        }),
+      ).rejects.toThrow(/locked by org policy/);
+    });
 
     // App-row lock blocks user writes on an otherwise-open field.
     await policies.create({
@@ -436,15 +464,17 @@ describe('FieldPolicy write-time validation', () => {
       scopeType: 'app',
       locked: true,
     });
-    await expect(
-      policies.create({
-        objectRef,
-        fieldName: 'summary',
-        scopeType: 'user',
-        userId: randomUUID(),
-        help: 'mine',
-      }),
-    ).rejects.toThrow(/locked by org policy/);
+    await seedPolicies(async () => {
+      await expect(
+        policies.create({
+          objectRef,
+          fieldName: 'summary',
+          scopeType: 'user',
+          userId: randomUUID(),
+          help: 'mine',
+        }),
+      ).rejects.toThrow(/locked by org policy/);
+    });
 
     // An explicit org unlock on a code-locked field re-opens the user tier.
     await policies.create({
@@ -453,13 +483,15 @@ describe('FieldPolicy write-time validation', () => {
       scopeType: 'app',
       locked: false,
     });
-    const userRow = await policies.create({
-      objectRef,
-      fieldName: 'lockedByCode',
-      scopeType: 'user',
-      userId: randomUUID(),
-      help: 'mine',
-    });
+    const userRow = await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'lockedByCode',
+        scopeType: 'user',
+        userId: randomUUID(),
+        help: 'mine',
+      }),
+    );
     expect(userRow.help).toBe('mine');
   });
 
@@ -486,13 +518,15 @@ describe('FieldPolicy write-time validation', () => {
 
     // Distinct scopes coexist for the same field.
     const tenantId = randomUUID();
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId,
-      help: 'tenant help',
-    });
+    await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId,
+        help: 'tenant help',
+      }),
+    );
     const allRows = await policies.list({
       where: { objectRef, fieldName: 'summary' },
     });
@@ -610,34 +644,38 @@ describe('FieldPolicy write-time validation', () => {
     const contextUser = randomUUID();
     const foreignUser = randomUUID();
 
-    // Rows created outside any context (platform admin flow).
+    // App row seeded bare (allowed without ambient identity); tenant/user
+    // rows seeded under bypass like real ops flows.
     const appRow = await policies.create({
       objectRef,
       fieldName: 'summary',
       scopeType: 'app',
       help: 'app row',
     });
-    const foreignTenantRow = await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId: foreignTenant,
-      help: 'foreign tenant row',
-    });
-    const foreignUserRow = await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'user',
-      userId: foreignUser,
-      help: 'foreign user row',
-    });
-    const ownTenantRow = await policies.create({
-      objectRef,
-      fieldName: 'category',
-      scopeType: 'tenant',
-      tenantId: contextTenant,
-      help: 'own tenant row',
-    });
+    const { foreignTenantRow, foreignUserRow, ownTenantRow } =
+      await seedPolicies(async () => ({
+        foreignTenantRow: await policies.create({
+          objectRef,
+          fieldName: 'summary',
+          scopeType: 'tenant',
+          tenantId: foreignTenant,
+          help: 'foreign tenant row',
+        }),
+        foreignUserRow: await policies.create({
+          objectRef,
+          fieldName: 'summary',
+          scopeType: 'user',
+          userId: foreignUser,
+          help: 'foreign user row',
+        }),
+        ownTenantRow: await policies.create({
+          objectRef,
+          fieldName: 'category',
+          scopeType: 'tenant',
+          tenantId: contextTenant,
+          help: 'own tenant row',
+        }),
+      }));
 
     await withTenant(
       {
@@ -689,20 +727,24 @@ describe('FieldPolicy write-time validation', () => {
     const contextUser = randomUUID();
     const foreignUser = randomUUID();
 
-    const foreignTenantRow = await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId: foreignTenant,
-      help: 'foreign tenant policy',
-    });
-    const foreignUserRow = await policies.create({
-      objectRef,
-      fieldName: 'category',
-      scopeType: 'user',
-      userId: foreignUser,
-      help: 'foreign user policy',
-    });
+    const { foreignTenantRow, foreignUserRow } = await seedPolicies(
+      async () => ({
+        foreignTenantRow: await policies.create({
+          objectRef,
+          fieldName: 'summary',
+          scopeType: 'tenant',
+          tenantId: foreignTenant,
+          help: 'foreign tenant policy',
+        }),
+        foreignUserRow: await policies.create({
+          objectRef,
+          fieldName: 'category',
+          scopeType: 'user',
+          userId: foreignUser,
+          help: 'foreign user policy',
+        }),
+      }),
+    );
 
     await withTenant(
       {
@@ -759,13 +801,15 @@ describe('FieldPolicy write-time validation', () => {
     });
 
     // The parent tenant locks the field; no direct child row exists.
-    await policies.create({
-      objectRef,
-      fieldName: 'summary',
-      scopeType: 'tenant',
-      tenantId: String(root.id),
-      locked: true,
-    });
+    await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId: String(root.id),
+        locked: true,
+      }),
+    );
 
     const userId = randomUUID();
     await withTenant(
@@ -798,23 +842,29 @@ describe('FieldPolicy write-time validation', () => {
     });
 
     // The only usable default for required `title` lives on the ROOT tenant.
-    await policies.create({
-      objectRef,
-      fieldName: 'title',
-      scopeType: 'tenant',
-      tenantId: String(root.id),
-      defaultValue: JSON.stringify('Root seeded title'),
-    });
+    await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'title',
+        scopeType: 'tenant',
+        tenantId: String(root.id),
+        defaultValue: JSON.stringify('Root seeded title'),
+      }),
+    );
 
     // A child-tenant demotion resolves that ancestor default through the
     // hierarchy walk and is accepted.
-    const childDemotion = await policies.create({
-      objectRef,
-      fieldName: 'title',
-      scopeType: 'tenant',
-      tenantId: String(child.id),
-      visibility: 'hidden',
-    });
+    const childDemotion = await withTenant(
+      { tenantId: String(child.id), permissions: new Set<string>() },
+      () =>
+        policies.create({
+          objectRef,
+          fieldName: 'title',
+          scopeType: 'tenant',
+          tenantId: String(child.id),
+          visibility: 'hidden',
+        }),
+    );
     expect(childDemotion.visibility).toBe('hidden');
 
     // A user demotion under the child tenant's context resolves it too.
@@ -838,14 +888,95 @@ describe('FieldPolicy write-time validation', () => {
     );
 
     // An unrelated tenant with no ancestor default is still rejected.
+    await seedPolicies(async () => {
+      await expect(
+        policies.create({
+          objectRef,
+          fieldName: 'title',
+          scopeType: 'tenant',
+          tenantId: randomUUID(),
+          visibility: 'hidden',
+        }),
+      ).rejects.toThrow(/no resolved default/);
+    });
+  });
+
+  it('fails closed without any ambient identity: app-scope writes only', async () => {
+    // No tenant context is active: tenant- and user-scope rows are
+    // unattributable and rejected outright (a runtime API deployment whose
+    // middleware never enters the tenancy ALS must not accept them).
     await expect(
       policies.create({
         objectRef,
-        fieldName: 'title',
+        fieldName: 'summary',
         scopeType: 'tenant',
         tenantId: randomUUID(),
-        visibility: 'hidden',
+        help: 'x',
       }),
-    ).rejects.toThrow(/no resolved default/);
+    ).rejects.toThrow(TenantIsolationError);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'user',
+        userId: randomUUID(),
+        help: 'x',
+      }),
+    ).rejects.toThrow(TenantIsolationError);
+
+    // App-scope rows remain the legitimate server-side/ops path.
+    const appRow = await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'app',
+      help: 'app ok',
+    });
+    expect(appRow.help).toBe('app ok');
+
+    // Deletes obey the same rule: a seeded tenant row cannot be deleted
+    // without an ambient identity, while app rows can.
+    const seededTenantRow = await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'category',
+        scopeType: 'tenant',
+        tenantId: randomUUID(),
+        help: 'seeded',
+      }),
+    );
+    await expect(seededTenantRow.delete()).rejects.toThrow(
+      TenantIsolationError,
+    );
+    await appRow.delete();
+  });
+
+  it('validates reference-field defaults as UUIDs unless the field stores text ids', async () => {
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'reviewerId',
+        scopeType: 'app',
+        defaultValue: JSON.stringify('not-a-uuid'),
+      }),
+    ).rejects.toThrow(/must be a UUID string/);
+
+    const uuidDefault = randomUUID();
+    const uuidRow = await policies.create({
+      objectRef,
+      fieldName: 'reviewerId',
+      scopeType: 'app',
+      defaultValue: JSON.stringify(uuidDefault),
+    });
+    expect(uuidRow.getDefaultValue()).toBe(uuidDefault);
+
+    // idType 'text' references accept arbitrary string ids.
+    const textRow = await policies.create({
+      objectRef,
+      fieldName: 'externalRef',
+      scopeType: 'app',
+      defaultValue: JSON.stringify('legacy-id-42'),
+    });
+    expect(textRow.getDefaultValue()).toBe('legacy-id-42');
   });
 });

--- a/packages/fields/src/field-policy.test.ts
+++ b/packages/fields/src/field-policy.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import {
   field,
   getTestDatabase,
+  meta,
   ObjectRegistry,
   SmrtObject,
   smrt,
@@ -14,6 +15,10 @@ import {
 } from '@happyvertical/smrt-tenancy';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+// Registers smrt-users' classes (Tenant) so getTestDatabase can create the
+// tenants table the write-time org checks read through the default hierarchy
+// loader.
+import { TenantCollection } from '../../users/src/index.js';
 import { clearFieldPolicyCache } from './cache.js';
 import { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
 
@@ -54,6 +59,9 @@ class PolicyModelDoc extends SmrtObject {
 
   @field({ required: true })
   category: string = 'general';
+
+  @meta()
+  legacyNotes: string = '';
 }
 
 function fixtureRef(): string {
@@ -72,7 +80,7 @@ describe('FieldPolicy write-time validation', () => {
   beforeEach(async () => {
     setupTestTenancy();
     clearFieldPolicyCache();
-    db = await getTestDatabase({ classes: ['FieldPolicy'] });
+    db = await getTestDatabase({ classes: ['FieldPolicy', 'Tenant'] });
     policies = await FieldPolicyCollection.create({ db });
     objectRef = fixtureRef();
   });
@@ -123,6 +131,17 @@ describe('FieldPolicy write-time validation', () => {
         help: 'x',
       }),
     ).rejects.toThrow(/system field/);
+
+    // STI meta storage fields are excluded by the resolver, so accepting a
+    // row would persist policy that silently never applies.
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'legacyNotes',
+        scopeType: 'app',
+        help: 'x',
+      }),
+    ).rejects.toThrow(/STI meta storage/);
   });
 
   it('rejects invalid scopeType, visibility, and displayOrder values', async () => {
@@ -583,5 +602,250 @@ describe('FieldPolicy write-time validation', () => {
         expect(crossTenant.help).toBe('bypass');
       },
     );
+  });
+
+  it('fails closed on deletes of rows the ambient context does not own', async () => {
+    const contextTenant = randomUUID();
+    const foreignTenant = randomUUID();
+    const contextUser = randomUUID();
+    const foreignUser = randomUUID();
+
+    // Rows created outside any context (platform admin flow).
+    const appRow = await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'app',
+      help: 'app row',
+    });
+    const foreignTenantRow = await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId: foreignTenant,
+      help: 'foreign tenant row',
+    });
+    const foreignUserRow = await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'user',
+      userId: foreignUser,
+      help: 'foreign user row',
+    });
+    const ownTenantRow = await policies.create({
+      objectRef,
+      fieldName: 'category',
+      scopeType: 'tenant',
+      tenantId: contextTenant,
+      help: 'own tenant row',
+    });
+
+    await withTenant(
+      {
+        tenantId: contextTenant,
+        userId: contextUser,
+        permissions: new Set<string>(),
+      },
+      async () => {
+        // A caller holding a foreign row id (e.g. via the generated DELETE
+        // route) must not remove rows outside its own scope.
+        await expect(appRow.delete()).rejects.toThrow(TenantIsolationError);
+        await expect(foreignTenantRow.delete()).rejects.toThrow(
+          TenantIsolationError,
+        );
+        await expect(foreignUserRow.delete()).rejects.toThrow(
+          TenantIsolationError,
+        );
+
+        // Own-tenant rows remain deletable.
+        await ownTenantRow.delete();
+      },
+    );
+
+    const remaining = await policies.list({ where: { objectRef } });
+    expect(remaining.map((row) => row.help).sort()).toEqual([
+      'app row',
+      'foreign tenant row',
+      'foreign user row',
+    ]);
+
+    // Super-admin bypass keeps deliberate cross-scope deletes.
+    await withTenant(
+      {
+        tenantId: contextTenant,
+        permissions: new Set<string>(),
+        superAdminBypass: true,
+      },
+      async () => {
+        await foreignTenantRow.delete();
+      },
+    );
+    const afterBypass = await policies.list({ where: { objectRef } });
+    expect(afterBypass).toHaveLength(2);
+  });
+
+  it('rejects re-scoping a foreign persisted row into the caller scope', async () => {
+    const contextTenant = randomUUID();
+    const foreignTenant = randomUUID();
+    const contextUser = randomUUID();
+    const foreignUser = randomUUID();
+
+    const foreignTenantRow = await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId: foreignTenant,
+      help: 'foreign tenant policy',
+    });
+    const foreignUserRow = await policies.create({
+      objectRef,
+      fieldName: 'category',
+      scopeType: 'user',
+      userId: foreignUser,
+      help: 'foreign user policy',
+    });
+
+    await withTenant(
+      {
+        tenantId: contextTenant,
+        userId: contextUser,
+        permissions: new Set<string>(),
+      },
+      async () => {
+        // Authorization runs against the PERSISTED scope, so flipping the
+        // ownership columns to the caller's own ids must not be accepted
+        // (the identity-change path would otherwise delete the foreign row).
+        foreignTenantRow.tenantId = contextTenant;
+        await expect(foreignTenantRow.save()).rejects.toThrow(
+          TenantIsolationError,
+        );
+
+        foreignUserRow.userId = contextUser;
+        await expect(foreignUserRow.save()).rejects.toThrow(
+          TenantIsolationError,
+        );
+
+        // Even without changing scope, mutating a foreign row is rejected.
+        const [persistedForeign] = await policies.list({
+          where: { objectRef, fieldName: 'summary', scopeType: 'tenant' },
+        });
+        persistedForeign.help = 'hijacked';
+        await expect(persistedForeign.save()).rejects.toThrow(
+          TenantIsolationError,
+        );
+      },
+    );
+
+    // The foreign rows survive unchanged under their original scope.
+    const rows = await policies.list({ where: { objectRef } });
+    expect(rows.map((row) => row.help).sort()).toEqual([
+      'foreign tenant policy',
+      'foreign user policy',
+    ]);
+    expect(rows.find((row) => row.scopeType === 'tenant')?.tenantId).toBe(
+      foreignTenant,
+    );
+    expect(rows.find((row) => row.scopeType === 'user')?.userId).toBe(
+      foreignUser,
+    );
+  });
+
+  it('enforces a cascading ancestor-tenant lock against user writes', async () => {
+    const tenants = await TenantCollection.create({ db });
+    const root = await tenants.create({ name: 'Lock Root' });
+    await root.save();
+    const child = await tenants.createChild(root.id, {
+      name: 'Lock Child',
+      inheritPermissions: true,
+    });
+
+    // The parent tenant locks the field; no direct child row exists.
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId: String(root.id),
+      locked: true,
+    });
+
+    const userId = randomUUID();
+    await withTenant(
+      {
+        tenantId: String(child.id),
+        userId,
+        permissions: new Set<string>(),
+      },
+      async () => {
+        await expect(
+          policies.create({
+            objectRef,
+            fieldName: 'summary',
+            scopeType: 'user',
+            userId,
+            help: 'mine',
+          }),
+        ).rejects.toThrow(/locked by org policy/);
+      },
+    );
+  });
+
+  it('accepts demotions whose only usable default cascades from an ancestor tenant', async () => {
+    const tenants = await TenantCollection.create({ db });
+    const root = await tenants.create({ name: 'Default Root' });
+    await root.save();
+    const child = await tenants.createChild(root.id, {
+      name: 'Default Child',
+      inheritPermissions: true,
+    });
+
+    // The only usable default for required `title` lives on the ROOT tenant.
+    await policies.create({
+      objectRef,
+      fieldName: 'title',
+      scopeType: 'tenant',
+      tenantId: String(root.id),
+      defaultValue: JSON.stringify('Root seeded title'),
+    });
+
+    // A child-tenant demotion resolves that ancestor default through the
+    // hierarchy walk and is accepted.
+    const childDemotion = await policies.create({
+      objectRef,
+      fieldName: 'title',
+      scopeType: 'tenant',
+      tenantId: String(child.id),
+      visibility: 'hidden',
+    });
+    expect(childDemotion.visibility).toBe('hidden');
+
+    // A user demotion under the child tenant's context resolves it too.
+    const userId = randomUUID();
+    await withTenant(
+      {
+        tenantId: String(child.id),
+        userId,
+        permissions: new Set<string>(),
+      },
+      async () => {
+        const userDemotion = await policies.create({
+          objectRef,
+          fieldName: 'title',
+          scopeType: 'user',
+          userId,
+          visibility: 'advanced',
+        });
+        expect(userDemotion.visibility).toBe('advanced');
+      },
+    );
+
+    // An unrelated tenant with no ancestor default is still rejected.
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'title',
+        scopeType: 'tenant',
+        tenantId: randomUUID(),
+        visibility: 'hidden',
+      }),
+    ).rejects.toThrow(/no resolved default/);
   });
 });

--- a/packages/fields/src/field-policy.test.ts
+++ b/packages/fields/src/field-policy.test.ts
@@ -22,6 +22,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { TenantCollection } from '../../users/src/index.js';
 import { clearFieldPolicyCache } from './cache.js';
 import { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
+import { resolveFieldPolicy } from './field-policy-resolver.js';
 
 @smrt({
   packageName: '@test/smrt-fields-model',
@@ -94,6 +95,37 @@ function seedPolicies<T>(fn: () => Promise<T>): Promise<T> {
     },
     fn,
   );
+}
+
+/**
+ * Run inside a NON-bypass signed-in context (tenant + user), the shape a real
+ * request carries.
+ *
+ * `seedPolicies` uses super-admin bypass, which returns from the ownership
+ * guard before the user branch is ever reached — so bypass-seeded fixtures
+ * cannot exercise the user path at all. Tests that mean to cover it must use
+ * this instead.
+ */
+function asUser<T>(
+  identity: { userId: string; tenantId?: string },
+  fn: () => Promise<T>,
+): Promise<T> {
+  return withTenant(
+    {
+      tenantId: identity.tenantId ?? randomUUID(),
+      userId: identity.userId,
+      permissions: new Set<string>(),
+    },
+    fn,
+  );
+}
+
+/** A tenant-only context: permissions resolved, no `resolveUserId` hook. */
+function asUserlessTenant<T>(
+  fn: () => Promise<T>,
+  tenantId: string = randomUUID(),
+): Promise<T> {
+  return withTenant({ tenantId, permissions: new Set<string>() }, fn);
 }
 
 describe('FieldPolicy write-time validation', () => {
@@ -978,5 +1010,253 @@ describe('FieldPolicy write-time validation', () => {
       defaultValue: JSON.stringify('legacy-id-42'),
     });
     expect(textRow.getDefaultValue()).toBe('legacy-id-42');
+  });
+
+  it('denies every user-tier write from a context that carries no user id', async () => {
+    // Regression for the userless-context ownership bypass (#2047): the guard
+    // used to read `context.userId !== undefined && scope.userId !== ...`, so
+    // it VANISHED for any context without a user id. Tenancy adapters produce
+    // exactly that shape whenever no `resolveUserId` hook is configured
+    // (API-key auth, service principals, background jobs, a bare
+    // `withTenant({ tenantId })`), and user rows carry `tenantId: null` by
+    // design — so nothing else contained the write. Rule: a missing identity
+    // component DENIES, it never skips.
+    const victimUser = randomUUID();
+    const victimRow = await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'user',
+        userId: victimUser,
+        help: 'victim',
+      }),
+    );
+
+    await asUserlessTenant(async () => {
+      // Create a row owned by someone else.
+      await expect(
+        policies.create({
+          objectRef,
+          fieldName: 'category',
+          scopeType: 'user',
+          userId: victimUser,
+          help: 'forged',
+        }),
+      ).rejects.toThrow(TenantIsolationError);
+
+      // Overwrite an existing foreign row (the generated PUT echoes the saved
+      // row back, so this would double as a read primitive).
+      victimRow.help = 'tampered';
+      await expect(victimRow.save()).rejects.toThrow(TenantIsolationError);
+
+      // Delete an existing foreign row.
+      await expect(victimRow.delete()).rejects.toThrow(TenantIsolationError);
+
+      // A user row for "self" is refused too: the context supplies no owner,
+      // so the scope shape can never be completed.
+      await expect(
+        policies.create({
+          objectRef,
+          fieldName: 'category',
+          scopeType: 'user',
+          help: 'mine',
+        }),
+      ).rejects.toThrow(/must set userId/);
+    });
+
+    const survivors = await policies.list({
+      where: { objectRef, scopeType: 'user' },
+    });
+    expect(survivors).toHaveLength(1);
+    expect(survivors[0].help).toBe('victim');
+    expect(survivors[0].userId).toBe(victimUser);
+  });
+
+  it('runs the non-bypass user path end to end', async () => {
+    // Every other user-tier fixture seeds under super-admin bypass, which
+    // short-circuits the ownership guard before the user branch — this drives
+    // the real signed-in path instead.
+    const userId = randomUUID();
+    const tenantId = randomUUID();
+
+    await asUser({ userId, tenantId }, async () => {
+      // The owner column is derived from the ambient context, not the body.
+      const row = await policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'user',
+        help: 'mine',
+      });
+      expect(row.userId).toBe(userId);
+      expect(row.tenantId).toBeNull();
+      expect(row.scopeKey).toBe(userId);
+
+      row.help = 'mine, edited';
+      await row.save();
+
+      const persisted = await policies.list({
+        where: { objectRef, fieldName: 'summary', scopeType: 'user' },
+      });
+      expect(persisted).toHaveLength(1);
+      expect(persisted[0].help).toBe('mine, edited');
+
+      await row.delete();
+      expect(
+        await policies.list({
+          where: { objectRef, fieldName: 'summary', scopeType: 'user' },
+        }),
+      ).toHaveLength(0);
+    });
+  });
+
+  it('stamps updatedBy from the ambient context instead of the request body', async () => {
+    // Audit attribution (#2050/#2051) must not be forgeable through the open
+    // write routes: the server stamps it inside any ambient context.
+    const userId = randomUUID();
+    const spoofed = randomUUID();
+
+    const userRow = await asUser({ userId }, () =>
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'user',
+        help: 'mine',
+        updatedBy: spoofed,
+      }),
+    );
+    expect(userRow.updatedBy).toBe(userId);
+
+    // A context with no user id attributes to null rather than keeping the
+    // client's claim.
+    const orgRow = await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'category',
+        scopeType: 'app',
+        help: 'org',
+        updatedBy: spoofed,
+      }),
+    );
+    expect(orgRow.updatedBy).toBeNull();
+
+    // Context-less/system flows keep whatever attribution they set.
+    const systemRow = await policies.create({
+      objectRef,
+      fieldName: 'wordCount',
+      scopeType: 'app',
+      help: 'system',
+      updatedBy: spoofed,
+    });
+    expect(systemRow.updatedBy).toBe(spoofed);
+  });
+
+  it('authorizes an upsert against the row it would replace, not only by id', async () => {
+    // Every generated create arrives with a freshly minted UUID, so the
+    // primary-key lookup always misses — yet the `conflictColumns` upsert
+    // still replaces whatever row holds (objectRef, fieldName, scopeType,
+    // scopeKey). The persisted-scope guard therefore falls back to the
+    // NATURAL key. Defence in depth: the new-scope check also refuses this
+    // today (the scope key is derived from the caller's own owner id), but
+    // the guard is no longer contingent on the id matching.
+    const victimUser = randomUUID();
+    await seedPolicies(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'user',
+        userId: victimUser,
+        help: 'victim',
+      }),
+    );
+
+    await asUser({ userId: randomUUID() }, async () => {
+      await expect(
+        policies.create({
+          objectRef,
+          fieldName: 'summary',
+          scopeType: 'user',
+          userId: victimUser,
+          help: 'overwritten',
+        }),
+      ).rejects.toThrow(TenantIsolationError);
+    });
+
+    const rows = await policies.list({
+      where: { objectRef, fieldName: 'summary', scopeType: 'user' },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].help).toBe('victim');
+  });
+
+  it('lets a tenant row unlock an app-tier or code-seed lock (pinned semantics)', async () => {
+    // `locked` is an ordinary sparse delta, so the LAST org layer to set it
+    // wins: a tenant row with `locked: false` overrides the app tier's — and
+    // the code seed's — `locked: true`. That inverts the usual "higher tier
+    // only tightens" intuition and is deliberate: a tenant must be able to
+    // opt its own users back into personalizing a field. Pinned here because
+    // #2050's control panel surfaces the unlock as an org action.
+    const tenantId = randomUUID();
+    const siblingTenant = randomUUID();
+    const userId = randomUUID();
+
+    // App tier locks `summary`; the code seed locks `lockedByCode`.
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'app',
+      locked: true,
+    });
+
+    await seedPolicies(async () => {
+      await policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId,
+        locked: false,
+      });
+      await policies.create({
+        objectRef,
+        fieldName: 'lockedByCode',
+        scopeType: 'tenant',
+        tenantId,
+        locked: false,
+      });
+    });
+
+    const unlocked = await resolveFieldPolicy(objectRef, { tenantId, db });
+    expect(unlocked.fields.summary.locked).toBe(false);
+    expect(unlocked.fields.lockedByCode.locked).toBe(false);
+
+    // The write side agrees: user rows are accepted inside that tenant.
+    await asUser({ userId, tenantId }, async () => {
+      const row = await policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'user',
+        help: 'mine',
+      });
+      expect(row.help).toBe('mine');
+    });
+
+    // The unlock is tenant-local: a sibling tenant still resolves locked and
+    // still refuses user writes.
+    const stillLocked = await resolveFieldPolicy(objectRef, {
+      tenantId: siblingTenant,
+      db,
+    });
+    expect(stillLocked.fields.summary.locked).toBe(true);
+    expect(stillLocked.fields.lockedByCode.locked).toBe(true);
+
+    await asUser({ userId, tenantId: siblingTenant }, async () => {
+      await expect(
+        policies.create({
+          objectRef,
+          fieldName: 'summary',
+          scopeType: 'user',
+          help: 'mine',
+        }),
+      ).rejects.toThrow(/locked by org policy/);
+    });
   });
 });

--- a/packages/fields/src/field-policy.test.ts
+++ b/packages/fields/src/field-policy.test.ts
@@ -1,0 +1,587 @@
+import { randomUUID } from 'node:crypto';
+import {
+  field,
+  getTestDatabase,
+  ObjectRegistry,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import {
+  resetTenancy,
+  setupTestTenancy,
+  TenantIsolationError,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { clearFieldPolicyCache } from './cache.js';
+import { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
+
+@smrt({
+  packageName: '@test/smrt-fields-model',
+  visibility: 'internal',
+  api: false,
+  cli: false,
+  mcp: false,
+})
+class PolicyModelDoc extends SmrtObject {
+  @field({ required: true, description: 'Document title' })
+  title: string = '';
+
+  @field({ ui: { basic: true, group: 'main', order: 1 } })
+  summary: string = '';
+
+  @field({ type: 'integer' })
+  wordCount: number = 0;
+
+  @field({ type: 'boolean' })
+  published: boolean = false;
+
+  @field({ type: 'datetime', nullable: true })
+  publishAt: Date | null = null;
+
+  @field({ sensitive: true })
+  apiSecret: string = '';
+
+  @field({ readPermission: 'fields.finance.read' })
+  budgetCode: string = '';
+
+  @field({ transient: true })
+  preview: string = '';
+
+  @field({ ui: { locked: true } })
+  lockedByCode: string = '';
+
+  @field({ required: true })
+  category: string = 'general';
+}
+
+function fixtureRef(): string {
+  const registered = ObjectRegistry.getClassByConstructor(PolicyModelDoc);
+  if (!registered?.qualifiedName) {
+    throw new Error('PolicyModelDoc is not registered with a qualified name');
+  }
+  return registered.qualifiedName;
+}
+
+describe('FieldPolicy write-time validation', () => {
+  let db: DatabaseInterface;
+  let policies: FieldPolicyCollection;
+  let objectRef: string;
+
+  beforeEach(async () => {
+    setupTestTenancy();
+    clearFieldPolicyCache();
+    db = await getTestDatabase({ classes: ['FieldPolicy'] });
+    policies = await FieldPolicyCollection.create({ db });
+    objectRef = fixtureRef();
+  });
+
+  afterEach(async () => {
+    clearFieldPolicyCache();
+    resetTenancy();
+    if (typeof (db as { close?: () => Promise<void> }).close === 'function') {
+      await (db as unknown as { close: () => Promise<void> }).close();
+    }
+  });
+
+  it('rejects unknown objectRef and unqualified names', async () => {
+    await expect(
+      policies.create({
+        objectRef: '@test/nowhere:Nope',
+        fieldName: 'title',
+        scopeType: 'app',
+        help: 'x',
+      }),
+    ).rejects.toThrow(/Unknown field policy objectRef/);
+
+    await expect(
+      policies.create({
+        objectRef: 'PolicyModelDoc',
+        fieldName: 'title',
+        scopeType: 'app',
+        help: 'x',
+      }),
+    ).rejects.toThrow(/qualified class name/);
+  });
+
+  it('rejects unknown, system, and framework field names', async () => {
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'doesNotExist',
+        scopeType: 'app',
+        help: 'x',
+      }),
+    ).rejects.toThrow(/Unknown field "doesNotExist"/);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'slug',
+        scopeType: 'app',
+        help: 'x',
+      }),
+    ).rejects.toThrow(/system field/);
+  });
+
+  it('rejects invalid scopeType, visibility, and displayOrder values', async () => {
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'org' as any,
+        help: 'x',
+      }),
+    ).rejects.toThrow(/scopeType must be one of/);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'app',
+        visibility: 'invisible' as any,
+      }),
+    ).rejects.toThrow(/visibility must be null or one of/);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'app',
+        displayOrder: 1.5,
+      }),
+    ).rejects.toThrow(/displayOrder must be null or an integer/);
+  });
+
+  it('enforces scope shape: app/tenant/user each carry exactly their own id', async () => {
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'app',
+        tenantId: randomUUID(),
+        help: 'x',
+      }),
+    ).rejects.toThrow(/App-scope field policy rows/);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        help: 'x',
+      }),
+    ).rejects.toThrow(/Tenant-scope field policy rows/);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'tenant',
+        tenantId: randomUUID(),
+        userId: randomUUID(),
+        help: 'x',
+      }),
+    ).rejects.toThrow(/Tenant-scope field policy rows/);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'user',
+        tenantId: randomUUID(),
+        userId: randomUUID(),
+        help: 'x',
+      }),
+    ).rejects.toThrow(/User-scope field policy rows/);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'user',
+        help: 'x',
+      }),
+    ).rejects.toThrow(/User-scope field policy rows/);
+  });
+
+  it('type-checks defaults against the manifest field type', async () => {
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'wordCount',
+        scopeType: 'app',
+        defaultValue: JSON.stringify('not a number'),
+      }),
+    ).rejects.toThrow(/must be an integer/);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'wordCount',
+        scopeType: 'app',
+        defaultValue: JSON.stringify(1.5),
+      }),
+    ).rejects.toThrow(/must be an integer/);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'published',
+        scopeType: 'app',
+        defaultValue: JSON.stringify('true'),
+      }),
+    ).rejects.toThrow(/must be a boolean/);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'app',
+        defaultValue: JSON.stringify(42),
+      }),
+    ).rejects.toThrow(/must be a string/);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'publishAt',
+        scopeType: 'app',
+        defaultValue: JSON.stringify('not-a-date'),
+      }),
+    ).rejects.toThrow(/date-parseable/);
+
+    // Matching types persist.
+    const ok = await policies.create({
+      objectRef,
+      fieldName: 'wordCount',
+      scopeType: 'app',
+      defaultValue: JSON.stringify(250),
+    });
+    expect(ok.getDefaultValue()).toBe(250);
+  });
+
+  it('rejects invalid JSON defaults and null defaults on required fields', async () => {
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'app',
+        defaultValue: '{not json',
+      }),
+    ).rejects.toThrow(/not valid JSON/);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'title',
+        scopeType: 'app',
+        defaultValue: JSON.stringify(null),
+      }),
+    ).rejects.toThrow(/may not be null/);
+
+    // Null default on an optional field is a legitimate "default to null".
+    const ok = await policies.create({
+      objectRef,
+      fieldName: 'publishAt',
+      scopeType: 'app',
+      defaultValue: JSON.stringify(null),
+    });
+    expect(ok.defaultValue).toBe('null');
+  });
+
+  it('refuses defaults on transient, sensitive, and read-permission-gated fields', async () => {
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'preview',
+        scopeType: 'app',
+        defaultValue: JSON.stringify('x'),
+      }),
+    ).rejects.toThrow(/transient field/);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'apiSecret',
+        scopeType: 'app',
+        defaultValue: JSON.stringify('x'),
+      }),
+    ).rejects.toThrow(/sensitive field/);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'budgetCode',
+        scopeType: 'app',
+        defaultValue: JSON.stringify('x'),
+      }),
+    ).rejects.toThrow(/read-permission-gated field/);
+
+    // Presentation-only policy (no default) is still allowed on gated fields.
+    const ok = await policies.create({
+      objectRef,
+      fieldName: 'apiSecret',
+      scopeType: 'app',
+      label: 'API secret',
+    });
+    expect(ok.label).toBe('API secret');
+  });
+
+  it('enforces the required-field invariant on visibility demotion', async () => {
+    // title is required and its code default ('') is not usable.
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'title',
+        scopeType: 'app',
+        visibility: 'hidden',
+      }),
+    ).rejects.toThrow(/no resolved default/);
+
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'title',
+        scopeType: 'app',
+        visibility: 'advanced',
+      }),
+    ).rejects.toThrow(/no resolved default/);
+
+    // Same row supplies a usable default: allowed.
+    const withOwnDefault = await policies.create({
+      objectRef,
+      fieldName: 'title',
+      scopeType: 'app',
+      visibility: 'hidden',
+      defaultValue: JSON.stringify('Untitled'),
+    });
+    expect(withOwnDefault.visibility).toBe('hidden');
+
+    // category is required WITH a usable code default: demotion allowed.
+    const viaCodeDefault = await policies.create({
+      objectRef,
+      fieldName: 'category',
+      scopeType: 'app',
+      visibility: 'advanced',
+    });
+    expect(viaCodeDefault.visibility).toBe('advanced');
+
+    // A tenant demotion may rely on the app row's stored default.
+    const tenantRow = await policies.create({
+      objectRef,
+      fieldName: 'title',
+      scopeType: 'tenant',
+      tenantId: randomUUID(),
+      visibility: 'hidden',
+    });
+    expect(tenantRow.visibility).toBe('hidden');
+
+    // Optional fields demote freely.
+    const optional = await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'app',
+      visibility: 'hidden',
+    });
+    expect(optional.visibility).toBe('hidden');
+  });
+
+  it('restricts locked to org rows and enforces the lock against user writes', async () => {
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'user',
+        userId: randomUUID(),
+        locked: true,
+      }),
+    ).rejects.toThrow(/locked may only be set on org rows/);
+
+    // Code-seeded lock (ui.locked) blocks user-scope writes outright.
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'lockedByCode',
+        scopeType: 'user',
+        userId: randomUUID(),
+        help: 'mine',
+      }),
+    ).rejects.toThrow(/locked by org policy/);
+
+    // App-row lock blocks user writes on an otherwise-open field.
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'app',
+      locked: true,
+    });
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'user',
+        userId: randomUUID(),
+        help: 'mine',
+      }),
+    ).rejects.toThrow(/locked by org policy/);
+
+    // An explicit org unlock on a code-locked field re-opens the user tier.
+    await policies.create({
+      objectRef,
+      fieldName: 'lockedByCode',
+      scopeType: 'app',
+      locked: false,
+    });
+    const userRow = await policies.create({
+      objectRef,
+      fieldName: 'lockedByCode',
+      scopeType: 'user',
+      userId: randomUUID(),
+      help: 'mine',
+    });
+    expect(userRow.help).toBe('mine');
+  });
+
+  it('upserts on the natural key so one row exists per (object, field, scope)', async () => {
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'app',
+      help: 'first',
+    });
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'app',
+      help: 'second',
+    });
+
+    const rows = await policies.list({
+      where: { objectRef, fieldName: 'summary', scopeType: 'app' },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].help).toBe('second');
+    expect(rows[0].scopeKey).toBe('__app__');
+
+    // Distinct scopes coexist for the same field.
+    const tenantId = randomUUID();
+    await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'tenant',
+      tenantId,
+      help: 'tenant help',
+    });
+    const allRows = await policies.list({
+      where: { objectRef, fieldName: 'summary' },
+    });
+    expect(allRows).toHaveLength(2);
+  });
+
+  it('handles identity changes with delete-then-insert semantics', async () => {
+    const row = await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'app',
+      help: 'moving',
+    });
+
+    row.fieldName = 'category';
+    await row.save();
+
+    const summaryRows = await policies.list({
+      where: { objectRef, fieldName: 'summary', scopeType: 'app' },
+    });
+    const categoryRows = await policies.list({
+      where: { objectRef, fieldName: 'category', scopeType: 'app' },
+    });
+    expect(summaryRows).toHaveLength(0);
+    expect(categoryRows).toHaveLength(1);
+    expect(categoryRows[0].help).toBe('moving');
+  });
+
+  it('fails closed on writes that cross the ambient tenant context', async () => {
+    const contextTenant = randomUUID();
+    const otherTenant = randomUUID();
+    const contextUser = randomUUID();
+    const otherUser = randomUUID();
+
+    await withTenant(
+      {
+        tenantId: contextTenant,
+        userId: contextUser,
+        permissions: new Set<string>(),
+      },
+      async () => {
+        await expect(
+          policies.create({
+            objectRef,
+            fieldName: 'summary',
+            scopeType: 'tenant',
+            tenantId: otherTenant,
+            help: 'x',
+          }),
+        ).rejects.toThrow(TenantIsolationError);
+
+        await expect(
+          policies.create({
+            objectRef,
+            fieldName: 'summary',
+            scopeType: 'app',
+            help: 'x',
+          }),
+        ).rejects.toThrow(TenantIsolationError);
+
+        await expect(
+          policies.create({
+            objectRef,
+            fieldName: 'summary',
+            scopeType: 'user',
+            userId: otherUser,
+            help: 'x',
+          }),
+        ).rejects.toThrow(TenantIsolationError);
+
+        // Own tenant and own user rows are allowed.
+        const own = await policies.create({
+          objectRef,
+          fieldName: 'summary',
+          scopeType: 'tenant',
+          tenantId: contextTenant,
+          help: 'own tenant',
+        });
+        expect(own.help).toBe('own tenant');
+
+        const ownUser = await policies.create({
+          objectRef,
+          fieldName: 'summary',
+          scopeType: 'user',
+          userId: contextUser,
+          help: 'own user',
+        });
+        expect(ownUser.help).toBe('own user');
+      },
+    );
+
+    // Super-admin bypass keeps deliberate cross-tenant capability.
+    await withTenant(
+      {
+        tenantId: contextTenant,
+        permissions: new Set<string>(),
+        superAdminBypass: true,
+      },
+      async () => {
+        const crossTenant = await policies.create({
+          objectRef,
+          fieldName: 'category',
+          scopeType: 'tenant',
+          tenantId: otherTenant,
+          help: 'bypass',
+        });
+        expect(crossTenant.help).toBe('bypass');
+      },
+    );
+  });
+});

--- a/packages/fields/src/field-policy.test.ts
+++ b/packages/fields/src/field-policy.test.ts
@@ -1012,6 +1012,69 @@ describe('FieldPolicy write-time validation', () => {
     expect(textRow.getDefaultValue()).toBe('legacy-id-42');
   });
 
+  it('round-trips a plain string default through defaultValueRaw', async () => {
+    // `defaultValue` is the ENCODED channel (the wire contract: generated
+    // write routes hand the request body straight to the constructor, and the
+    // #2049 gear posts `JSON.stringify(...)`), so a plain string sent through
+    // it is unparseable. `defaultValueRaw` is the plain channel — the option
+    // twin of setDefaultValue() — and strings go through it unchanged.
+    const row = await policies.create({
+      objectRef,
+      fieldName: 'summary',
+      scopeType: 'app',
+      defaultValueRaw: 'Net 30',
+    });
+    // Stored encoded, read back plain.
+    expect(row.defaultValue).toBe('"Net 30"');
+    expect(row.getDefaultValue()).toBe('Net 30');
+
+    // ...and it survives resolution as the plain value.
+    const resolved = await resolveFieldPolicy(objectRef, { db });
+    expect(resolved.fields.summary.hasDefault).toBe(true);
+    expect(resolved.fields.summary.defaultValue).toBe('Net 30');
+
+    // Strings that merely LOOK like JSON stay literal through the raw channel
+    // — the ambiguity the two-channel split exists to remove.
+    const literal = await policies.create({
+      objectRef,
+      fieldName: 'category',
+      scopeType: 'app',
+      defaultValueRaw: 'null',
+    });
+    expect(literal.getDefaultValue()).toBe('null');
+
+    // The encoded channel still means encoded (no double-encoding), which is
+    // what every generated write surface and the gear rely on.
+    const encoded = await policies.create({
+      objectRef,
+      fieldName: 'wordCount',
+      scopeType: 'app',
+      defaultValue: JSON.stringify(42),
+    });
+    expect(encoded.getDefaultValue()).toBe(42);
+
+    // A plain string in the encoded channel fails loudly, naming the fix.
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'app',
+        defaultValue: 'Net 30',
+      }),
+    ).rejects.toThrow(/defaultValueRaw/);
+
+    // Supplying both channels is rejected rather than silently resolved.
+    await expect(
+      policies.create({
+        objectRef,
+        fieldName: 'summary',
+        scopeType: 'app',
+        defaultValue: JSON.stringify('a'),
+        defaultValueRaw: 'b',
+      }),
+    ).rejects.toThrow(/not both/);
+  });
+
   it('denies every user-tier write from a context that carries no user id', async () => {
     // Regression for the userless-context ownership bypass (#2047): the guard
     // used to read `context.userId !== undefined && scope.userId !== ...`, so

--- a/packages/fields/src/generated-surfaces.test.ts
+++ b/packages/fields/src/generated-surfaces.test.ts
@@ -24,6 +24,9 @@ class PolicySurfaceDoc extends SmrtObject {
 
   @field({ ui: { basic: true } })
   tagline: string = '';
+
+  @field({ sensitive: true })
+  apiToken: string = '';
 }
 
 function fixtureRef(): string {
@@ -113,6 +116,56 @@ describe('smrt-fields generated surfaces', () => {
       }),
     );
     expect(deleteResponse.status).toBe(204);
+  });
+
+  it('dispatches the batch resolve action on the runtime REST transport', async () => {
+    const objectRef = fixtureRef();
+    const api = new APIGenerator({ authMiddleware: passThroughAuth }, { db });
+    api.registerCollection('fieldpolicy', policies);
+    const handler = api.generateHandler();
+
+    // POST /<collection>/resolve dispatches the decorator-declared custom
+    // action rather than degrading into a malformed create.
+    const response = await handler(
+      new Request('http://localhost/api/v1/fieldpolicy/resolve', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ objectRefs: [objectRef] }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      action: string;
+      result: {
+        policies: Record<
+          string,
+          { fields: Record<string, { visibility: string }> }
+        >;
+      };
+    };
+    expect(payload.action).toBe('resolveBatch');
+    const fields = payload.result.policies[objectRef].fields;
+    expect(fields.headline).toBeDefined();
+    // Field gating holds on this transport too: sensitive fields absent.
+    expect(fields.apiToken).toBeUndefined();
+
+    // Wrong method for the action path falls through to CRUD handling,
+    // where reads are closed.
+    const wrongMethod = await handler(
+      new Request('http://localhost/api/v1/fieldpolicy/resolve'),
+    );
+    expect(wrongMethod.status).toBe(405);
+
+    // A matched action with an unparseable body is a client error, never a
+    // CRUD write.
+    const badJson = await handler(
+      new Request('http://localhost/api/v1/fieldpolicy/resolve', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{not json',
+      }),
+    );
+    expect(badJson.status).toBe(400);
   });
 
   it('exposes nothing over MCP or the runtime CLI', async () => {

--- a/packages/fields/src/generated-surfaces.test.ts
+++ b/packages/fields/src/generated-surfaces.test.ts
@@ -1,0 +1,136 @@
+import {
+  APIGenerator,
+  field,
+  MCPGenerator,
+  ObjectRegistry,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CLIGenerator } from '../../cli/src/cli-generator.js';
+import { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
+
+@smrt({
+  packageName: '@test/smrt-fields-surfaces',
+  visibility: 'internal',
+  api: false,
+  cli: false,
+  mcp: false,
+})
+class PolicySurfaceDoc extends SmrtObject {
+  @field({ ui: { basic: true } })
+  headline: string = '';
+
+  @field({ ui: { basic: true } })
+  tagline: string = '';
+}
+
+function fixtureRef(): string {
+  const registered = ObjectRegistry.getClassByConstructor(PolicySurfaceDoc);
+  if (!registered?.qualifiedName) {
+    throw new Error('PolicySurfaceDoc is not registered with a qualified name');
+  }
+  return registered.qualifiedName;
+}
+
+// Generated REST routes are fail-closed (#1540). These tests exercise verb
+// exposure, not auth, so they simulate an authenticated gateway with a
+// pass-through auth middleware. Auth itself is covered by smrt-core tests.
+const passThroughAuth =
+  () =>
+  async (req: Request): Promise<Request | Response> =>
+    req;
+
+describe('smrt-fields generated surfaces', () => {
+  let db: Awaited<ReturnType<typeof getTestDatabase>>;
+  let policies: FieldPolicyCollection;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({ classes: ['FieldPolicy'] });
+    policies = await FieldPolicyCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    if (typeof (db as { close?: () => Promise<void> }).close === 'function') {
+      await (db as unknown as { close: () => Promise<void> }).close();
+    }
+  });
+
+  it('exposes writes but NO reads over the generated REST surface', async () => {
+    const objectRef = fixtureRef();
+    const existing = await policies.create({
+      objectRef,
+      fieldName: 'headline',
+      scopeType: 'app',
+      help: 'seeded',
+    });
+
+    const api = new APIGenerator({ authMiddleware: passThroughAuth }, { db });
+    api.registerCollection('fieldpolicy', policies);
+    const handler = api.generateHandler();
+
+    // Reads are closed: list/get on this non-tenant-scoped model would
+    // enumerate every tenant's and user's policy rows.
+    const listResponse = await handler(
+      new Request('http://localhost/api/v1/fieldpolicy'),
+    );
+    const getResponse = await handler(
+      new Request(`http://localhost/api/v1/fieldpolicy/${existing.id}`),
+    );
+    expect(listResponse.status).toBe(405);
+    expect(getResponse.status).toBe(405);
+
+    // Writes stay open (each guarded by the model's save/delete boundaries).
+    // The create targets a DIFFERENT field: a natural-key upsert would
+    // replace the seeded row's id and invalidate the update/delete steps.
+    const createResponse = await handler(
+      new Request('http://localhost/api/v1/fieldpolicy', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          objectRef,
+          fieldName: 'tagline',
+          scopeType: 'app',
+          label: 'Tagline',
+        }),
+      }),
+    );
+    expect(createResponse.status).toBe(201);
+
+    const updateResponse = await handler(
+      new Request(`http://localhost/api/v1/fieldpolicy/${existing.id}`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ help: 'updated help' }),
+      }),
+    );
+    expect(updateResponse.status).toBe(200);
+
+    const deleteResponse = await handler(
+      new Request(`http://localhost/api/v1/fieldpolicy/${existing.id}`, {
+        method: 'DELETE',
+      }),
+    );
+    expect(deleteResponse.status).toBe(204);
+  });
+
+  it('exposes nothing over MCP or the runtime CLI', async () => {
+    const mcp = new MCPGenerator({}, { db });
+    const toolNames = (await mcp.generateTools()).map((tool) => tool.name);
+    expect(toolNames.filter((name) => name.startsWith('fieldpolicy'))).toEqual(
+      [],
+    );
+
+    // The decorated collection's config is the runtime registry authority for
+    // the item class, and it closes the CLI surface entirely (the
+    // ContentContributions precedent) — reads would otherwise reach every
+    // tenant's rows over the CLI's HTTP transport.
+    const cli = new CLIGenerator({ prompt: false }, { db });
+    const commands = await (cli as any).generateObjectCommands(
+      'FieldPolicy',
+      {},
+    );
+    expect(commands.map((command: any) => command.name)).toEqual([]);
+  });
+});

--- a/packages/fields/src/generated-surfaces.test.ts
+++ b/packages/fields/src/generated-surfaces.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import {
   APIGenerator,
   field,
@@ -7,8 +8,18 @@ import {
   smrt,
 } from '@happyvertical/smrt-core';
 import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import {
+  resetTenancy,
+  setupTestTenancy,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { CLIGenerator } from '../../cli/src/cli-generator.js';
+// Registers smrt-users' Tenant so getTestDatabase can create the tenants
+// table the user-tier write-time lock check reads through the default
+// hierarchy loader.
+import { TenantCollection } from '../../users/src/index.js';
+import { clearFieldPolicyCache } from './cache.js';
 import { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
 
 @smrt({
@@ -50,11 +61,15 @@ describe('smrt-fields generated surfaces', () => {
   let policies: FieldPolicyCollection;
 
   beforeEach(async () => {
-    db = await getTestDatabase({ classes: ['FieldPolicy'] });
+    setupTestTenancy();
+    clearFieldPolicyCache();
+    db = await getTestDatabase({ classes: ['FieldPolicy', 'Tenant'] });
     policies = await FieldPolicyCollection.create({ db });
   });
 
   afterEach(async () => {
+    clearFieldPolicyCache();
+    resetTenancy();
     if (typeof (db as { close?: () => Promise<void> }).close === 'function') {
       await (db as unknown as { close: () => Promise<void> }).close();
     }
@@ -166,6 +181,160 @@ describe('smrt-fields generated surfaces', () => {
       }),
     );
     expect(badJson.status).toBe(400);
+  });
+
+  it('creates a row at EVERY scope tier through the generated REST surface', async () => {
+    // Regression for the write-dead org tier (#2047): core's mass-assignment
+    // guard strips `tenantId` from every generated create/update body, and
+    // FieldPolicy is deliberately not @TenantScoped so nothing repopulated
+    // it — a `POST {scopeType:'tenant', tenantId}` therefore always reached
+    // scope-shape validation with `tenantId === null` and threw, making
+    // #2050's org-admin tier unreachable from any generated surface. It went
+    // unnoticed because the model-level tests call `policies.create()`
+    // directly, so these deliberately drive the transport instead.
+    const objectRef = fixtureRef();
+    const api = new APIGenerator({ authMiddleware: passThroughAuth }, { db });
+    api.registerCollection('fieldpolicy', policies);
+    const handler = api.generateHandler();
+
+    const post = (body: unknown): Promise<Response> =>
+      handler(
+        new Request('http://localhost/api/v1/fieldpolicy', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(body),
+        }),
+      );
+
+    const tenantId = randomUUID();
+    const userId = randomUUID();
+
+    // App tier: no owner columns at all, no ambient context.
+    expect(
+      (
+        await post({
+          objectRef,
+          fieldName: 'headline',
+          scopeType: 'app',
+          label: 'Headline',
+        })
+      ).status,
+    ).toBe(201);
+
+    // Tenant tier: the body names the tenant, the transport strips it, and
+    // the model re-derives it from the ambient context.
+    await withTenant(
+      { tenantId, userId, permissions: new Set<string>() },
+      async () => {
+        expect(
+          (
+            await post({
+              objectRef,
+              fieldName: 'headline',
+              scopeType: 'tenant',
+              tenantId,
+              label: 'Org headline',
+            })
+          ).status,
+        ).toBe(201);
+
+        // User tier through the same transport.
+        expect(
+          (
+            await post({
+              objectRef,
+              fieldName: 'tagline',
+              scopeType: 'user',
+              userId,
+              label: 'My tagline',
+            })
+          ).status,
+        ).toBe(201);
+      },
+    );
+
+    const appRows = await policies.list({
+      where: { objectRef, scopeType: 'app' },
+    });
+    expect(appRows).toHaveLength(1);
+    expect(appRows[0].tenantId).toBeNull();
+    expect(appRows[0].userId).toBeNull();
+    expect(appRows[0].scopeKey).toBe('__app__');
+
+    const tenantRows = await policies.list({
+      where: { objectRef, scopeType: 'tenant' },
+    });
+    expect(tenantRows).toHaveLength(1);
+    expect(tenantRows[0].tenantId).toBe(tenantId);
+    expect(tenantRows[0].userId).toBeNull();
+    expect(tenantRows[0].scopeKey).toBe(tenantId);
+    expect(tenantRows[0].label).toBe('Org headline');
+
+    const userRows = await policies.list({
+      where: { objectRef, scopeType: 'user' },
+    });
+    expect(userRows).toHaveLength(1);
+    expect(userRows[0].userId).toBe(userId);
+    expect(userRows[0].tenantId).toBeNull();
+    expect(userRows[0].scopeKey).toBe(userId);
+  });
+
+  it('derives the tenant owner from the context, never from the request body', async () => {
+    // The transport strip means a forged `tenantId` in the body is inert:
+    // the row is always attributed to the ambient tenant.
+    const objectRef = fixtureRef();
+    const api = new APIGenerator({ authMiddleware: passThroughAuth }, { db });
+    api.registerCollection('fieldpolicy', policies);
+    const handler = api.generateHandler();
+
+    const contextTenant = randomUUID();
+    const foreignTenant = randomUUID();
+
+    await withTenant(
+      { tenantId: contextTenant, permissions: new Set<string>() },
+      async () => {
+        const response = await handler(
+          new Request('http://localhost/api/v1/fieldpolicy', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              objectRef,
+              fieldName: 'headline',
+              scopeType: 'tenant',
+              tenantId: foreignTenant,
+              label: 'forged',
+            }),
+          }),
+        );
+        expect(response.status).toBe(201);
+      },
+    );
+
+    const rows = await policies.list({
+      where: { objectRef, scopeType: 'tenant' },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].tenantId).toBe(contextTenant);
+  });
+
+  it('keeps the prefixed system table name as the registry authority', async () => {
+    // The decorated collection's config is re-registered onto the ITEM slot
+    // wholesale, so a registry change could silently move every policy row to
+    // a different table. `_smrt_field_policies` survives only because
+    // `resolveTableName` prefers the manifest entry — pin both the item slot
+    // and the instance that actually issues the SQL.
+    expect(ObjectRegistry.getTableName('FieldPolicy')).toBe(
+      '_smrt_field_policies',
+    );
+    expect(policies.tableName).toBe('_smrt_field_policies');
+
+    // The COLLECTION's own registry slot resolves to the unprefixed
+    // collection-fallback name. Nothing reads it for persistence (rows go
+    // through the item class above), and the generated route path derives
+    // from it — but it must never become the persistence authority.
+    expect(ObjectRegistry.getTableName('FieldPolicyCollection')).toBe(
+      'field_policies',
+    );
   });
 
   it('exposes nothing over MCP or the runtime CLI', async () => {

--- a/packages/fields/src/generated-surfaces.test.ts
+++ b/packages/fields/src/generated-surfaces.test.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import {
   APIGenerator,
   field,
@@ -335,6 +337,68 @@ describe('smrt-fields generated surfaces', () => {
     expect(ObjectRegistry.getTableName('FieldPolicyCollection')).toBe(
       'field_policies',
     );
+  });
+
+  it('declares the natural key on BOTH classes that map to the policy table', () => {
+    // The decorated collection emits its OWN manifest schema for
+    // `_smrt_field_policies`. Without `conflictColumns` that schema falls back
+    // to SmrtObject's default unique `(slug, context)` index, and
+    // manifest-driven migrations aggregate both schemas onto the one physical
+    // table — so the stray index would reject legitimate layered rows (every
+    // policy row has a NULL slug and context, and the app/tenant/user rows for
+    // one field differ only by the real natural key).
+    //
+    // The runtime registry cannot catch this: `getAllSchemas()` and
+    // `getAllSchemasAsDefinitions()` are both keyed by TABLE name, so the two
+    // schemas collapse into one entry and the divergence is invisible until a
+    // consumer runs migrations off the manifest. Pin it at the source instead.
+    const naturalKey = ['object_ref', 'field_name', 'scope_type', 'scope_key'];
+
+    // Read the manifest the SMRT vitest plugin regenerates at startup — it is
+    // the same artifact consumer migrations consume, and the only place the
+    // per-class schemas stay distinct.
+    const manifest = JSON.parse(
+      readFileSync(resolve(process.cwd(), '.smrt/manifest.json'), 'utf8'),
+    ) as {
+      objects?: Record<
+        string,
+        {
+          tableName?: string;
+          schema?: {
+            indexes?: Array<{ columns?: string[]; unique?: boolean }>;
+          };
+        }
+      >;
+    };
+    const policyEntries = Object.entries(manifest.objects ?? {}).filter(
+      ([name]) =>
+        name.endsWith(':FieldPolicy') ||
+        name.endsWith(':FieldPolicyCollection'),
+    );
+    // Both the model and its decorated collection emit a schema here.
+    expect(policyEntries).toHaveLength(2);
+
+    for (const [name, entry] of policyEntries) {
+      const uniqueIndexes = (entry.schema?.indexes ?? []).filter(
+        (index) => index?.unique === true,
+      );
+      expect({
+        name,
+        unique: uniqueIndexes.map((index) => index.columns),
+      }).toEqual({ name, unique: [naturalKey] });
+    }
+
+    // The effective (table-keyed) schema carries exactly that one unique
+    // index, and nothing keyed on slug.
+    const definitions = ObjectRegistry.getAllSchemasAsDefinitions();
+    const policySchema = Object.values(definitions).find(
+      (schema) => schema?.tableName === '_smrt_field_policies',
+    );
+    expect(policySchema).toBeDefined();
+    const uniqueIndexes = (policySchema?.indexes ?? []).filter(
+      (index) => index?.unique === true,
+    );
+    expect(uniqueIndexes.map((index) => index.columns)).toEqual([naturalKey]);
   });
 
   it('exposes nothing over MCP or the runtime CLI', async () => {

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -1,0 +1,63 @@
+/**
+ * @happyvertical/smrt-fields
+ *
+ * Layered field policy store and resolver for SMRT objects (epic #2045):
+ * per-field defaults, visibility tiers, help text, labels, ordering, and org
+ * locks, personalized at app, tenant, and user scope over the code seed.
+ *
+ * @packageDocumentation
+ */
+
+// Self-register this package's manifest before any @smrt() decorator fires
+// downstream. Must come first so the side effect runs ahead of the class
+// module loads below. See __smrt-register__.ts for issue #1132 context.
+import './__smrt-register__.js';
+
+export {
+  clearFieldPolicyCache,
+  getFieldPolicyCacheTtlMs,
+  invalidateFieldPolicyCache,
+} from './cache.js';
+export { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
+export {
+  assertDefaultValueMatchesFieldType,
+  buildCodeSeedDelta,
+  buildCodeSeedVisibility,
+  type FieldDefinitionMap,
+  getCodeDefault,
+  getCodeSeedGroup,
+  getFieldReadPermission,
+  getObjectFieldMap,
+  isRequiredField,
+  isSensitiveField,
+  isTransientField,
+  isUsableRequiredDefault,
+  type RegisteredFieldInfo,
+  requireRegisteredObject,
+  sanitizeFieldUIHints,
+} from './field-definitions.js';
+export {
+  resolveFieldPolicy,
+  resolveFieldPolicyExplained,
+} from './field-policy-resolver.js';
+export { FieldPolicy } from './models/FieldPolicy.js';
+export {
+  APP_FIELD_POLICY_SCOPE_KEY,
+  type ExplainedObjectFieldPolicy,
+  FIELD_POLICY_SCOPE_TYPES,
+  FIELD_POLICY_VISIBILITIES,
+  type FieldPolicyBatchResult,
+  type FieldPolicyDelta,
+  type FieldPolicyLayerContribution,
+  type FieldPolicyOptions,
+  type FieldPolicyScopeType,
+  type FieldPolicyTenantHierarchyLoader,
+  type FieldPolicyTenantHierarchyProvider,
+  type FieldPolicyTenantNode,
+  type FieldPolicyUsersModule,
+  type FieldPolicyUsersTenantRecord,
+  type FieldPolicyVisibility,
+  type ResolvedFieldPolicy,
+  type ResolvedObjectFieldPolicy,
+  type ResolveFieldPolicyOptions,
+} from './types.js';

--- a/packages/fields/src/models/FieldPolicy.ts
+++ b/packages/fields/src/models/FieldPolicy.ts
@@ -14,7 +14,6 @@ import type { DatabaseInterface } from '@happyvertical/sql';
 import { invalidateFieldPolicyCache } from '../cache.js';
 import {
   assertDefaultValueMatchesFieldType,
-  getCodeDefault,
   getFieldReadPermission,
   getObjectFieldMap,
   isRequiredField,
@@ -22,7 +21,6 @@ import {
   isTransientField,
   isUsableRequiredDefault,
   type RegisteredFieldInfo,
-  sanitizeFieldUIHints,
 } from '../field-definitions.js';
 import {
   APP_FIELD_POLICY_SCOPE_KEY,
@@ -31,6 +29,7 @@ import {
   type FieldPolicyOptions,
   type FieldPolicyScopeType,
   type FieldPolicyVisibility,
+  type ResolvedFieldPolicy,
 } from '../types.js';
 
 type FieldPolicyIdentity = {
@@ -38,6 +37,8 @@ type FieldPolicyIdentity = {
   fieldName: string;
   scopeType: string;
   scopeKey: string;
+  tenantId: string | null;
+  userId: string | null;
 };
 
 type FieldPolicyTransactionHandle = DatabaseInterface & {
@@ -59,12 +60,20 @@ type FieldPolicyTransactionHandle = DatabaseInterface & {
  * defaults are type-checked, and the security rail (`sensitive` /
  * `readPermission` / `transient`) refuses stored defaults outright.
  */
+// The generated surfaces expose NO read verbs anywhere: list/get on this
+// non-@TenantScoped model would enumerate every tenant's and user's policy
+// rows to any authenticated principal, and the generated CLI invokes methods
+// over HTTP so CLI reads would be equally exposed (and unreachable once the
+// API closes them — the build-time cli↔api coherence gate enforces that).
+// Reads go through the context-scoped batch resolver
+// (FieldPolicyCollection.resolveBatch) and the server-side resolver/explain
+// APIs.
 @smrt({
   tableName: '_smrt_field_policies',
   conflictColumns: ['object_ref', 'field_name', 'scope_type', 'scope_key'],
-  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  api: { include: ['create', 'update', 'delete'] },
   cli: {
-    include: ['list', 'get', 'create', 'update', 'delete'],
+    include: ['create', 'update', 'delete'],
     exclude: ['getDefaultValue', 'setDefaultValue'],
   },
   mcp: { include: [] },
@@ -182,6 +191,13 @@ export class FieldPolicy extends SmrtObject {
 
   override async save(): Promise<this> {
     const previousIdentity = await this.getPersistedIdentity();
+    // The caller must own the row AS PERSISTED before any mutation is
+    // accepted — otherwise a foreign row could be re-scoped into the caller's
+    // own tenant/user (and the identity-change path below would then delete
+    // the original foreign row).
+    if (previousIdentity) {
+      this.assertScopeOwnedByAmbientContext(previousIdentity, 'save');
+    }
     this.normalizeDefaultValueForPersistence();
     await this.validateFieldPolicy();
     // scopeKey makes the conflict-column tuple total even though tenantId and
@@ -276,9 +292,19 @@ export class FieldPolicy extends SmrtObject {
   }
 
   override async delete(): Promise<void> {
-    const objectRef = this.objectRef;
+    // Authorize against the PERSISTED row, not in-memory state: the generated
+    // DELETE route (and any caller holding a foreign row id) must not remove
+    // app rows or another tenant's/user's rows from inside a tenant context.
+    const persisted = await this.getPersistedIdentity();
+    if (persisted) {
+      this.assertScopeOwnedByAmbientContext(persisted, 'delete');
+    }
+    const objectRef = persisted?.objectRef ?? this.objectRef;
     await super.delete();
     invalidateFieldPolicyCache(objectRef, this.db);
+    if (this.objectRef && this.objectRef !== objectRef) {
+      invalidateFieldPolicyCache(this.objectRef, this.db);
+    }
   }
 
   private async validateFieldPolicy(): Promise<void> {
@@ -333,6 +359,14 @@ export class FieldPolicy extends SmrtObject {
           `pseudo-field and is not policy-addressable`,
       );
     }
+    // The resolver excludes STI meta storage fields, so accepting a row here
+    // would persist policy that silently never applies.
+    if (fieldDef.type === 'meta') {
+      throw new Error(
+        `Field "${this.fieldName}" on "${this.objectRef}" is STI meta ` +
+          `storage and is not policy-addressable`,
+      );
+    }
 
     if (this.locked !== null && this.scopeType === 'user') {
       throw new Error(
@@ -352,31 +386,82 @@ export class FieldPolicy extends SmrtObject {
     }
 
     // Required-field invariant (write side): demoting a required field to
-    // advanced/hidden needs a usable resolved default. The resolver enforces
+    // advanced/hidden needs a usable resolved default — either this row's own
+    // default or one resolved by the org tiers (code → app → tenant chain,
+    // INCLUDING cascading ancestor-tenant defaults). The resolver enforces
     // the same rule again at read time (safety net) because a DIFFERENT row's
     // later deletion can invalidate what held here.
-    if (
+    const demotesRequiredField =
       (this.visibility === 'advanced' || this.visibility === 'hidden') &&
-      isRequiredField(fieldDef)
-    ) {
-      const ownDefault =
-        this.defaultValue !== null
-          ? { value: this.parseDefaultValueOrThrow() }
+      isRequiredField(fieldDef);
+    const ownDefault =
+      demotesRequiredField && this.defaultValue !== null
+        ? { value: this.parseDefaultValueOrThrow() }
+        : undefined;
+    const needsOrgDefault =
+      demotesRequiredField && !isUsableRequiredDefault(ownDefault);
+    const needsLockCheck = this.scopeType === 'user';
+
+    if (needsOrgDefault || needsLockCheck) {
+      const orgPolicy = await this.resolveOrgTierFieldPolicy();
+
+      if (needsOrgDefault) {
+        const orgDefault = orgPolicy?.hasDefault
+          ? { value: orgPolicy.defaultValue }
           : undefined;
-      const effectiveDefault =
-        ownDefault ?? (await this.resolveLowerLayerDefault(fieldDef));
-      if (!isUsableRequiredDefault(effectiveDefault)) {
+        if (!isUsableRequiredDefault(orgDefault)) {
+          throw new Error(
+            `Cannot set visibility "${this.visibility}" for required field ` +
+              `"${this.objectRef}.${this.fieldName}": no resolved default ` +
+              `exists at or below this layer`,
+          );
+        }
+      }
+
+      // Org lock enforcement (write side): the effective lock includes
+      // cascading ancestor-tenant locks, not just the direct tenant row. The
+      // resolver additionally skips the user layer at read time whenever the
+      // org tiers resolve locked, so stale user rows cannot bypass a lock.
+      if (needsLockCheck && orgPolicy?.locked) {
         throw new Error(
-          `Cannot set visibility "${this.visibility}" for required field ` +
-            `"${this.objectRef}.${this.fieldName}": no resolved default ` +
-            `exists at or below this layer`,
+          `Field "${this.objectRef}.${this.fieldName}" is locked by org ` +
+            `policy; user-scope overrides are not allowed`,
         );
       }
     }
+  }
 
-    if (this.scopeType === 'user') {
-      await this.assertNotLockedForUserWrite(fieldDef);
-    }
+  /**
+   * Effective org-tier (code → app → tenant hierarchy) policy for this row's
+   * field, computed by the RESOLVER so write-time checks share the one
+   * precedence implementation — including ancestor-tenant cascades via the
+   * default hierarchy loader. The chain tenant is the row's own tenant for
+   * tenant-scope rows, the ambient context tenant for user-scope rows, and
+   * none for app-scope rows (their only lower layer is the code seed).
+   *
+   * On updates the resolver sees this row's PERSISTED version (there is no
+   * self-exclusion), so a save that removes the only default while demoting
+   * can pass here; the resolver-side safety net stays authoritative at read
+   * time.
+   */
+  private async resolveOrgTierFieldPolicy(): Promise<
+    ResolvedFieldPolicy | undefined
+  > {
+    const tenantIdForChain =
+      this.scopeType === 'tenant'
+        ? this.tenantId
+        : this.scopeType === 'user'
+          ? (getCurrentTenant()?.tenantId ?? null)
+          : null;
+
+    // Dynamic import: the resolver statically imports the collection, which
+    // statically imports this model.
+    const { resolveFieldPolicy } = await import('../field-policy-resolver.js');
+    const resolved = await resolveFieldPolicy(this.objectRef, {
+      tenantId: tenantIdForChain,
+      db: this.options.db ?? this.options.persistence,
+    });
+    return resolved.fields[this.fieldName];
   }
 
   /**
@@ -410,46 +495,68 @@ export class FieldPolicy extends SmrtObject {
 
   /**
    * Fail-closed write boundary against the ambient tenant context: a
-   * non-bypass tenant-scoped caller may only write rows for its own tenant
+   * non-bypass tenant-scoped caller may only touch rows for its own tenant
    * (and, when the context carries a user id, only user rows for itself);
-   * app-wide rows require no tenant context or super-admin bypass.
+   * app-wide rows require no tenant context or super-admin bypass. Applied to
+   * the NEW scope on save and to the PERSISTED scope on save/delete of an
+   * existing row.
    */
-  private validateTenantContextBoundary(): void {
+  private assertScopeOwnedByAmbientContext(
+    scope: {
+      scopeType: string;
+      tenantId: string | null;
+      userId: string | null;
+    },
+    operation: 'save' | 'delete',
+  ): void {
     const context = getCurrentTenant();
     if (!context || isSuperAdminBypass()) {
       return;
     }
 
-    if (this.scopeType === 'app') {
+    if (scope.scopeType === 'app') {
       throw new TenantIsolationError(
-        'App-scope field policy writes are not allowed inside a tenant ' +
-          'context (use a system context or super-admin bypass)',
+        `App-scope field policy ${operation}s are not allowed inside a ` +
+          'tenant context (use a system context or super-admin bypass)',
         { tenantId: context.tenantId },
       );
     }
 
-    if (this.scopeType === 'tenant' && this.tenantId !== context.tenantId) {
+    if (scope.scopeType === 'tenant' && scope.tenantId !== context.tenantId) {
       throw new TenantIsolationError(
-        `Tenant isolation violation in FieldPolicy.save: context tenant is ` +
-          `'${context.tenantId}' but the row targets '${this.tenantId}'`,
+        `Tenant isolation violation in FieldPolicy.${operation}: context ` +
+          `tenant is '${context.tenantId}' but the row belongs to ` +
+          `'${scope.tenantId}'`,
         {
           tenantId: context.tenantId,
-          attemptedTenantId: this.tenantId ?? undefined,
+          attemptedTenantId: scope.tenantId ?? undefined,
         },
       );
     }
 
     if (
-      this.scopeType === 'user' &&
+      scope.scopeType === 'user' &&
       context.userId !== undefined &&
-      this.userId !== context.userId
+      scope.userId !== context.userId
     ) {
       throw new TenantIsolationError(
-        `Tenant isolation violation in FieldPolicy.save: context user is ` +
-          `'${context.userId}' but the row targets '${this.userId}'`,
+        `Tenant isolation violation in FieldPolicy.${operation}: context ` +
+          `user is '${context.userId}' but the row belongs to ` +
+          `'${scope.userId}'`,
         { tenantId: context.tenantId },
       );
     }
+  }
+
+  private validateTenantContextBoundary(): void {
+    this.assertScopeOwnedByAmbientContext(
+      {
+        scopeType: this.scopeType,
+        tenantId: this.tenantId,
+        userId: this.userId,
+      },
+      'save',
+    );
   }
 
   private validateDefaultAgainstSecurityRail(
@@ -489,108 +596,6 @@ export class FieldPolicy extends SmrtObject {
     }
   }
 
-  /**
-   * Best-effort lower-layer default for the write-time required-field check:
-   * code seed, then the app row, then — for user rows saved inside a tenant
-   * context — that tenant's direct row. Hierarchy-sourced (ancestor tenant)
-   * defaults are only visible to the resolver, which re-enforces the
-   * invariant at read time.
-   */
-  private async resolveLowerLayerDefault(
-    fieldDef: RegisteredFieldInfo,
-  ): Promise<{ value: unknown } | undefined> {
-    const layers: Array<{ value: unknown } | undefined> = [
-      getCodeDefault(fieldDef),
-    ];
-
-    const { FieldPolicyCollection } = await import(
-      '../collections/FieldPolicyCollection.js'
-    );
-    const collection = await FieldPolicyCollection.create({
-      db: this.options.db ?? this.options.persistence,
-    });
-
-    if (this.scopeType !== 'app') {
-      const appRow = await collection.getAppRow(
-        this.objectRef,
-        this.fieldName,
-        { excludeId: this.id ?? undefined },
-      );
-      if (appRow && appRow.defaultValue !== null) {
-        layers.push({ value: appRow.getDefaultValue() });
-      }
-    }
-
-    if (this.scopeType === 'user') {
-      const contextTenantId = getCurrentTenant()?.tenantId;
-      if (contextTenantId) {
-        const tenantRow = await collection.getTenantRow(
-          this.objectRef,
-          this.fieldName,
-          contextTenantId,
-          { excludeId: this.id ?? undefined },
-        );
-        if (tenantRow && tenantRow.defaultValue !== null) {
-          layers.push({ value: tenantRow.getDefaultValue() });
-        }
-      }
-    }
-
-    // Highest contributing lower layer wins (tenant over app over code).
-    for (let index = layers.length - 1; index >= 0; index--) {
-      const layer = layers[index];
-      if (layer !== undefined) {
-        return layer;
-      }
-    }
-    return undefined;
-  }
-
-  /**
-   * Org lock enforcement (write side): a user-scope row is rejected while the
-   * effective lock — code seed (`ui.locked`), overridden by the app row, then
-   * by the ambient context tenant's row — is true. The resolver additionally
-   * skips the user layer at read time whenever the org tiers resolve locked,
-   * so stale user rows cannot bypass a later lock.
-   */
-  private async assertNotLockedForUserWrite(
-    fieldDef: RegisteredFieldInfo,
-  ): Promise<void> {
-    const ui = sanitizeFieldUIHints(fieldDef._meta?.ui);
-    let effectiveLocked = ui?.locked === true;
-
-    const { FieldPolicyCollection } = await import(
-      '../collections/FieldPolicyCollection.js'
-    );
-    const collection = await FieldPolicyCollection.create({
-      db: this.options.db ?? this.options.persistence,
-    });
-
-    const appRow = await collection.getAppRow(this.objectRef, this.fieldName);
-    if (appRow && appRow.locked !== null) {
-      effectiveLocked = appRow.locked;
-    }
-
-    const contextTenantId = getCurrentTenant()?.tenantId;
-    if (contextTenantId) {
-      const tenantRow = await collection.getTenantRow(
-        this.objectRef,
-        this.fieldName,
-        contextTenantId,
-      );
-      if (tenantRow && tenantRow.locked !== null) {
-        effectiveLocked = tenantRow.locked;
-      }
-    }
-
-    if (effectiveLocked) {
-      throw new Error(
-        `Field "${this.objectRef}.${this.fieldName}" is locked by org ` +
-          `policy; user-scope overrides are not allowed`,
-      );
-    }
-  }
-
   private async getPersistedIdentity(): Promise<FieldPolicyIdentity | null> {
     if (!this.id) {
       return null;
@@ -611,12 +616,18 @@ export class FieldPolicy extends SmrtObject {
       }
       return fallback;
     };
+    const readNullable = (camel: string, snake: string): string | null => {
+      const value = row[camel] !== undefined ? row[camel] : row[snake];
+      return value === undefined || value === null ? null : String(value);
+    };
 
     return {
       objectRef: read('objectRef', 'object_ref', this.objectRef),
       fieldName: read('fieldName', 'field_name', this.fieldName),
       scopeType: read('scopeType', 'scope_type', this.scopeType),
       scopeKey: read('scopeKey', 'scope_key', this.scopeKey),
+      tenantId: readNullable('tenantId', 'tenant_id'),
+      userId: readNullable('userId', 'user_id'),
     };
   }
 

--- a/packages/fields/src/models/FieldPolicy.ts
+++ b/packages/fields/src/models/FieldPolicy.ts
@@ -494,12 +494,18 @@ export class FieldPolicy extends SmrtObject {
   }
 
   /**
-   * Fail-closed write boundary against the ambient tenant context: a
-   * non-bypass tenant-scoped caller may only touch rows for its own tenant
-   * (and, when the context carries a user id, only user rows for itself);
-   * app-wide rows require no tenant context or super-admin bypass. Applied to
+   * Fail-closed write boundary against the ambient tenant context, applied to
    * the NEW scope on save and to the PERSISTED scope on save/delete of an
    * existing row.
+   *
+   * With NO ambient identity at all (no tenant context entered — e.g. a
+   * runtime API deployment whose auth middleware never enters the tenancy
+   * ALS), only app-scope rows are accepted: tenant- and user-scope rows are
+   * unattributable without a context, so they are rejected outright rather
+   * than allowed by default. Inside a non-bypass context, a caller may only
+   * touch rows for its own tenant (and, when the context carries a user id,
+   * only user rows for itself); app-wide rows then require super-admin
+   * bypass (or a context-less/system caller).
    */
   private assertScopeOwnedByAmbientContext(
     scope: {
@@ -510,7 +516,20 @@ export class FieldPolicy extends SmrtObject {
     operation: 'save' | 'delete',
   ): void {
     const context = getCurrentTenant();
-    if (!context || isSuperAdminBypass()) {
+
+    if (!context) {
+      if (scope.scopeType === 'tenant' || scope.scopeType === 'user') {
+        throw new TenantIsolationError(
+          `${scope.scopeType === 'tenant' ? 'Tenant' : 'User'}-scope field ` +
+            `policy ${operation}s require an ambient tenant context (or ` +
+            `super-admin bypass); without one the caller identity is ` +
+            `unattributable`,
+        );
+      }
+      return;
+    }
+
+    if (isSuperAdminBypass()) {
       return;
     }
 

--- a/packages/fields/src/models/FieldPolicy.ts
+++ b/packages/fields/src/models/FieldPolicy.ts
@@ -152,15 +152,25 @@ export class FieldPolicy extends SmrtObject {
     if (options.scopeType !== undefined) this.scopeType = options.scopeType;
     if (options.tenantId !== undefined) this.tenantId = options.tenantId;
     if (options.userId !== undefined) this.userId = options.userId;
-    if (options.defaultValue !== undefined) {
-      if (
-        typeof options.defaultValue === 'string' ||
-        options.defaultValue === null
-      ) {
-        this.defaultValue = options.defaultValue;
-      } else {
-        this.defaultValue = JSON.stringify(options.defaultValue);
-      }
+    // Two explicit channels, never sniffed: `defaultValue` is already
+    // JSON-encoded (the wire contract — generated write routes pass the
+    // request body straight through, and the gear posts JSON.stringify'd
+    // values), `defaultValueRaw` is a plain value that is always serialized.
+    // One option carrying both meanings cannot distinguish `'"TBD"'` from
+    // `'TBD'`, so supplying both is rejected rather than silently resolved.
+    if (
+      options.defaultValue !== undefined &&
+      options.defaultValueRaw !== undefined
+    ) {
+      throw new Error(
+        'FieldPolicy accepts either defaultValue (already JSON-encoded) or ' +
+          'defaultValueRaw (a plain value to serialize), not both',
+      );
+    }
+    if (options.defaultValueRaw !== undefined) {
+      this.setDefaultValue(options.defaultValueRaw);
+    } else if (options.defaultValue !== undefined) {
+      this.defaultValue = options.defaultValue;
     }
     if (options.visibility !== undefined) this.visibility = options.visibility;
     if (options.help !== undefined) this.help = options.help;
@@ -675,11 +685,16 @@ export class FieldPolicy extends SmrtObject {
     try {
       return JSON.parse(this.defaultValue as string);
     } catch (error) {
+      // The overwhelmingly likely cause is a PLAIN string sent through the
+      // encoded channel (`{ defaultValue: 'Net 30' }`), which is also the most
+      // natural-looking call — so name the fix instead of only reporting the
+      // parse failure.
       throw new Error(
         `FieldPolicy default for "${this.objectRef}.${this.fieldName}" is ` +
           `not valid JSON: ${
             error instanceof Error ? error.message : String(error)
-          }`,
+          }. The "defaultValue" option is the already-encoded channel; pass a ` +
+          `plain value as "defaultValueRaw" (or call setDefaultValue()).`,
       );
     }
   }

--- a/packages/fields/src/models/FieldPolicy.ts
+++ b/packages/fields/src/models/FieldPolicy.ts
@@ -1,0 +1,640 @@
+import {
+  crossPackageRef,
+  field,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import {
+  getCurrentTenant,
+  isSuperAdminBypass,
+  TenantIsolationError,
+  tenantId,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { invalidateFieldPolicyCache } from '../cache.js';
+import {
+  assertDefaultValueMatchesFieldType,
+  getCodeDefault,
+  getFieldReadPermission,
+  getObjectFieldMap,
+  isRequiredField,
+  isSensitiveField,
+  isTransientField,
+  isUsableRequiredDefault,
+  type RegisteredFieldInfo,
+  sanitizeFieldUIHints,
+} from '../field-definitions.js';
+import {
+  APP_FIELD_POLICY_SCOPE_KEY,
+  FIELD_POLICY_SCOPE_TYPES,
+  FIELD_POLICY_VISIBILITIES,
+  type FieldPolicyOptions,
+  type FieldPolicyScopeType,
+  type FieldPolicyVisibility,
+} from '../types.js';
+
+type FieldPolicyIdentity = {
+  objectRef: string;
+  fieldName: string;
+  scopeType: string;
+  scopeKey: string;
+};
+
+type FieldPolicyTransactionHandle = DatabaseInterface & {
+  commit: () => Promise<void>;
+  rollback: () => Promise<void>;
+};
+
+/**
+ * Sparse, layered field policy override (epic #2045, issue #2047).
+ *
+ * One row personalizes a subset of `{defaultValue, visibility, help, label,
+ * displayOrder, locked}` for a single `(objectRef, fieldName)` at one scope
+ * tier. A NULL column means "inherit from the lower layer" (code seed → app →
+ * tenant → user), so resetting a customization is a row DELETE — later
+ * lower-layer changes then flow through (sparse-delta rationale, #1770).
+ *
+ * Rows are validated at write time against the live `ObjectRegistry` (the
+ * manifest is the definition registry): unknown objects/fields are rejected,
+ * defaults are type-checked, and the security rail (`sensitive` /
+ * `readPermission` / `transient`) refuses stored defaults outright.
+ */
+@smrt({
+  tableName: '_smrt_field_policies',
+  conflictColumns: ['object_ref', 'field_name', 'scope_type', 'scope_key'],
+  api: { include: ['list', 'get', 'create', 'update', 'delete'] },
+  cli: {
+    include: ['list', 'get', 'create', 'update', 'delete'],
+    exclude: ['getDefaultValue', 'setDefaultValue'],
+  },
+  mcp: { include: [] },
+})
+export class FieldPolicy extends SmrtObject {
+  /** Qualified class name of the target object (`@package/name:ClassName`). */
+  @field({ required: true })
+  objectRef: string = '';
+
+  /** Field name on the target object (validated against the registry). */
+  @field({ required: true })
+  fieldName: string = '';
+
+  /** Scope tier this row belongs to ('app' | 'tenant' | 'user'). */
+  @field({ required: true })
+  scopeType: FieldPolicyScopeType = 'app';
+
+  /** Owning tenant for tenant-scope rows; NULL otherwise (native UUID on PG). */
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  /** Owning user for user-scope rows; NULL otherwise. */
+  @crossPackageRef('@happyvertical/smrt-users:User', { nullable: true })
+  userId: string | null = null;
+
+  /**
+   * Computed uniqueness key (`userId ?? tenantId ?? '__app__'`), set in
+   * `save()`. Used ONLY by `conflictColumns` so the unique index stays total
+   * while `tenantId`/`userId` are nullable — mirrors `PromptOverride.context`.
+   * Never read it for scoping logic; `scopeType` + the typed columns own that.
+   */
+  @field({ type: 'text', required: true })
+  scopeKey: string = '';
+
+  /** JSON-encoded default value; NULL = inherit. JSON `null` = "default to null". */
+  @field({ type: 'text', nullable: true })
+  defaultValue: string | null = null;
+
+  /** Visibility override ('basic' | 'advanced' | 'hidden'); NULL = inherit. */
+  @field({ type: 'text', nullable: true })
+  visibility: FieldPolicyVisibility | null = null;
+
+  /** Help text override; NULL = inherit (code seed: field description). */
+  @field({ type: 'text', nullable: true })
+  help: string | null = null;
+
+  /** Label override; NULL = inherit (consumers derive from the field name). */
+  @field({ type: 'text', nullable: true })
+  label: string | null = null;
+
+  /**
+   * Sort-order override; NULL = inherit (code seed: `ui.order`). Named
+   * `displayOrder` because a column literally named `order` is an SQL keyword
+   * the runtime INSERT path does not quote; resolved output exposes `order`.
+   */
+  @field({ type: 'integer', nullable: true })
+  displayOrder: number | null = null;
+
+  /**
+   * Org lock (app/tenant rows only): when the effective lock is true, the
+   * user tier may not override this field. NULL = inherit (code seed:
+   * `ui.locked`); org rows may set `false` to explicitly unlock.
+   */
+  @field({ type: 'boolean', nullable: true })
+  locked: boolean | null = null;
+
+  /** Audit attribution for #2050 ("who changed what"); not validated. */
+  @crossPackageRef('@happyvertical/smrt-users:User', { nullable: true })
+  updatedBy: string | null = null;
+
+  constructor(options: FieldPolicyOptions = {}) {
+    super(options);
+
+    if (options.objectRef !== undefined) this.objectRef = options.objectRef;
+    if (options.fieldName !== undefined) this.fieldName = options.fieldName;
+    if (options.scopeType !== undefined) this.scopeType = options.scopeType;
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.userId !== undefined) this.userId = options.userId;
+    if (options.defaultValue !== undefined) {
+      if (
+        typeof options.defaultValue === 'string' ||
+        options.defaultValue === null
+      ) {
+        this.defaultValue = options.defaultValue;
+      } else {
+        this.defaultValue = JSON.stringify(options.defaultValue);
+      }
+    }
+    if (options.visibility !== undefined) this.visibility = options.visibility;
+    if (options.help !== undefined) this.help = options.help;
+    if (options.label !== undefined) this.label = options.label;
+    if (options.displayOrder !== undefined) {
+      this.displayOrder = options.displayOrder;
+    }
+    if (options.locked !== undefined) this.locked = options.locked;
+    if (options.updatedBy !== undefined) this.updatedBy = options.updatedBy;
+  }
+
+  /** Parse the stored JSON default. `undefined` = no stored default (inherit). */
+  getDefaultValue(): unknown {
+    if (this.defaultValue === null || this.defaultValue === undefined) {
+      return undefined;
+    }
+    try {
+      return JSON.parse(this.defaultValue);
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** Serialize a default value; `undefined` clears the override (inherit). */
+  setDefaultValue(value: unknown): void {
+    this.defaultValue = value === undefined ? null : JSON.stringify(value);
+  }
+
+  override async save(): Promise<this> {
+    const previousIdentity = await this.getPersistedIdentity();
+    this.normalizeDefaultValueForPersistence();
+    await this.validateFieldPolicy();
+    // scopeKey makes the conflict-column tuple total even though tenantId and
+    // userId are nullable (nullable columns would allow duplicate NULL rows).
+    this.scopeKey = this.userId ?? this.tenantId ?? APP_FIELD_POLICY_SCOPE_KEY;
+
+    const identityChanged =
+      previousIdentity &&
+      (previousIdentity.objectRef !== this.objectRef ||
+        previousIdentity.fieldName !== this.fieldName ||
+        previousIdentity.scopeType !== this.scopeType ||
+        previousIdentity.scopeKey !== this.scopeKey);
+
+    const result =
+      identityChanged && previousIdentity
+        ? await this.saveAfterIdentityChange()
+        : await super.save();
+
+    if (identityChanged && previousIdentity) {
+      invalidateFieldPolicyCache(previousIdentity.objectRef, this.db);
+    }
+    invalidateFieldPolicyCache(this.objectRef, this.db);
+    return result;
+  }
+
+  private async saveAfterIdentityChange(): Promise<this> {
+    if (typeof this.db.beginTransaction === 'function') {
+      return this.saveAfterIdentityChangeInTransaction();
+    }
+
+    return this.saveAfterIdentityChangeWithDeferredDelete();
+  }
+
+  private async saveAfterIdentityChangeInTransaction(): Promise<this> {
+    const originalDb = this._db;
+    const originalOptionsDb = this.options.db;
+    const tx = (await this.db.beginTransaction?.()) as
+      | FieldPolicyTransactionHandle
+      | undefined;
+
+    if (!tx) {
+      return this.saveAfterIdentityChangeWithDeferredDelete();
+    }
+
+    try {
+      this._db = tx;
+      this.options.db = tx;
+      await super.delete();
+      const result = await super.save();
+      await tx.commit();
+      return result;
+    } catch (error) {
+      try {
+        await tx.rollback();
+      } catch {
+        // Preserve the original save error; rollback failures are secondary.
+      }
+      throw error;
+    } finally {
+      this._db = originalDb;
+      this.options.db = originalOptionsDb;
+    }
+  }
+
+  private async saveAfterIdentityChangeWithDeferredDelete(): Promise<this> {
+    const previousId = this.id;
+    if (!previousId) {
+      return super.save();
+    }
+
+    const replacementId = crypto.randomUUID();
+    let replacementSaved = false;
+    this.id = replacementId;
+
+    try {
+      const result = await super.save();
+      replacementSaved = true;
+      await this.db.delete(this.tableName, { id: previousId });
+      return result;
+    } catch (error) {
+      if (replacementSaved) {
+        try {
+          await this.db.delete(this.tableName, { id: replacementId });
+        } catch {
+          // Best effort cleanup keeps the original row as the source of truth.
+        }
+      }
+
+      this.id = previousId;
+      throw error;
+    }
+  }
+
+  override async delete(): Promise<void> {
+    const objectRef = this.objectRef;
+    await super.delete();
+    invalidateFieldPolicyCache(objectRef, this.db);
+  }
+
+  private async validateFieldPolicy(): Promise<void> {
+    if (!this.objectRef || this.objectRef.trim() === '') {
+      throw new Error('FieldPolicy.objectRef is required');
+    }
+    if (!this.fieldName || this.fieldName.trim() === '') {
+      throw new Error('FieldPolicy.fieldName is required');
+    }
+    if (!FIELD_POLICY_SCOPE_TYPES.includes(this.scopeType)) {
+      throw new Error(
+        `FieldPolicy.scopeType must be one of ` +
+          `${FIELD_POLICY_SCOPE_TYPES.join(', ')}; got "${this.scopeType}"`,
+      );
+    }
+    if (
+      this.visibility !== null &&
+      !FIELD_POLICY_VISIBILITIES.includes(this.visibility)
+    ) {
+      throw new Error(
+        `FieldPolicy.visibility must be null or one of ` +
+          `${FIELD_POLICY_VISIBILITIES.join(', ')}; got "${this.visibility}"`,
+      );
+    }
+    if (
+      this.displayOrder !== null &&
+      (typeof this.displayOrder !== 'number' ||
+        !Number.isInteger(this.displayOrder))
+    ) {
+      throw new Error('FieldPolicy.displayOrder must be null or an integer');
+    }
+
+    this.validateScopeConsistency();
+    this.validateTenantContextBoundary();
+
+    const fields = await getObjectFieldMap(this.objectRef);
+    const fieldDef = fields.get(this.fieldName);
+    if (!fieldDef) {
+      throw new Error(
+        `Unknown field "${this.fieldName}" on "${this.objectRef}"`,
+      );
+    }
+    if (fieldDef._meta?.__smrtSystemField === true) {
+      throw new Error(
+        `Field "${this.fieldName}" on "${this.objectRef}" is a framework ` +
+          `system field and is not policy-addressable`,
+      );
+    }
+    if (fieldDef.type === 'oneToMany' || fieldDef.type === 'manyToMany') {
+      throw new Error(
+        `Field "${this.fieldName}" on "${this.objectRef}" is a relationship ` +
+          `pseudo-field and is not policy-addressable`,
+      );
+    }
+
+    if (this.locked !== null && this.scopeType === 'user') {
+      throw new Error(
+        'FieldPolicy.locked may only be set on org rows (app or tenant scope)',
+      );
+    }
+
+    if (this.defaultValue !== null) {
+      this.validateDefaultAgainstSecurityRail(fieldDef);
+      const parsed = this.parseDefaultValueOrThrow();
+      assertDefaultValueMatchesFieldType(
+        this.objectRef,
+        this.fieldName,
+        fieldDef,
+        parsed,
+      );
+    }
+
+    // Required-field invariant (write side): demoting a required field to
+    // advanced/hidden needs a usable resolved default. The resolver enforces
+    // the same rule again at read time (safety net) because a DIFFERENT row's
+    // later deletion can invalidate what held here.
+    if (
+      (this.visibility === 'advanced' || this.visibility === 'hidden') &&
+      isRequiredField(fieldDef)
+    ) {
+      const ownDefault =
+        this.defaultValue !== null
+          ? { value: this.parseDefaultValueOrThrow() }
+          : undefined;
+      const effectiveDefault =
+        ownDefault ?? (await this.resolveLowerLayerDefault(fieldDef));
+      if (!isUsableRequiredDefault(effectiveDefault)) {
+        throw new Error(
+          `Cannot set visibility "${this.visibility}" for required field ` +
+            `"${this.objectRef}.${this.fieldName}": no resolved default ` +
+            `exists at or below this layer`,
+        );
+      }
+    }
+
+    if (this.scopeType === 'user') {
+      await this.assertNotLockedForUserWrite(fieldDef);
+    }
+  }
+
+  /**
+   * Exactly-one-owner scope shape: app rows carry neither id, tenant rows
+   * carry only `tenantId`, user rows carry only `userId` (the user tier is
+   * keyed by user alone so preferences follow the user across tenants).
+   */
+  private validateScopeConsistency(): void {
+    if (this.scopeType === 'app') {
+      if (this.tenantId !== null || this.userId !== null) {
+        throw new Error(
+          'App-scope field policy rows must have tenantId and userId null',
+        );
+      }
+      return;
+    }
+    if (this.scopeType === 'tenant') {
+      if (!this.tenantId || this.userId !== null) {
+        throw new Error(
+          'Tenant-scope field policy rows must set tenantId and leave userId null',
+        );
+      }
+      return;
+    }
+    if (!this.userId || this.tenantId !== null) {
+      throw new Error(
+        'User-scope field policy rows must set userId and leave tenantId null',
+      );
+    }
+  }
+
+  /**
+   * Fail-closed write boundary against the ambient tenant context: a
+   * non-bypass tenant-scoped caller may only write rows for its own tenant
+   * (and, when the context carries a user id, only user rows for itself);
+   * app-wide rows require no tenant context or super-admin bypass.
+   */
+  private validateTenantContextBoundary(): void {
+    const context = getCurrentTenant();
+    if (!context || isSuperAdminBypass()) {
+      return;
+    }
+
+    if (this.scopeType === 'app') {
+      throw new TenantIsolationError(
+        'App-scope field policy writes are not allowed inside a tenant ' +
+          'context (use a system context or super-admin bypass)',
+        { tenantId: context.tenantId },
+      );
+    }
+
+    if (this.scopeType === 'tenant' && this.tenantId !== context.tenantId) {
+      throw new TenantIsolationError(
+        `Tenant isolation violation in FieldPolicy.save: context tenant is ` +
+          `'${context.tenantId}' but the row targets '${this.tenantId}'`,
+        {
+          tenantId: context.tenantId,
+          attemptedTenantId: this.tenantId ?? undefined,
+        },
+      );
+    }
+
+    if (
+      this.scopeType === 'user' &&
+      context.userId !== undefined &&
+      this.userId !== context.userId
+    ) {
+      throw new TenantIsolationError(
+        `Tenant isolation violation in FieldPolicy.save: context user is ` +
+          `'${context.userId}' but the row targets '${this.userId}'`,
+        { tenantId: context.tenantId },
+      );
+    }
+  }
+
+  private validateDefaultAgainstSecurityRail(
+    fieldDef: RegisteredFieldInfo,
+  ): void {
+    if (isTransientField(fieldDef)) {
+      throw new Error(
+        `Cannot store a default for transient field ` +
+          `"${this.objectRef}.${this.fieldName}"`,
+      );
+    }
+    if (isSensitiveField(fieldDef)) {
+      throw new Error(
+        `Cannot store a default for sensitive field ` +
+          `"${this.objectRef}.${this.fieldName}"`,
+      );
+    }
+    const readPermission = getFieldReadPermission(fieldDef);
+    if (readPermission) {
+      throw new Error(
+        `Cannot store a default for read-permission-gated field ` +
+          `"${this.objectRef}.${this.fieldName}" (requires "${readPermission}")`,
+      );
+    }
+  }
+
+  private parseDefaultValueOrThrow(): unknown {
+    try {
+      return JSON.parse(this.defaultValue as string);
+    } catch (error) {
+      throw new Error(
+        `FieldPolicy default for "${this.objectRef}.${this.fieldName}" is ` +
+          `not valid JSON: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+      );
+    }
+  }
+
+  /**
+   * Best-effort lower-layer default for the write-time required-field check:
+   * code seed, then the app row, then — for user rows saved inside a tenant
+   * context — that tenant's direct row. Hierarchy-sourced (ancestor tenant)
+   * defaults are only visible to the resolver, which re-enforces the
+   * invariant at read time.
+   */
+  private async resolveLowerLayerDefault(
+    fieldDef: RegisteredFieldInfo,
+  ): Promise<{ value: unknown } | undefined> {
+    const layers: Array<{ value: unknown } | undefined> = [
+      getCodeDefault(fieldDef),
+    ];
+
+    const { FieldPolicyCollection } = await import(
+      '../collections/FieldPolicyCollection.js'
+    );
+    const collection = await FieldPolicyCollection.create({
+      db: this.options.db ?? this.options.persistence,
+    });
+
+    if (this.scopeType !== 'app') {
+      const appRow = await collection.getAppRow(
+        this.objectRef,
+        this.fieldName,
+        { excludeId: this.id ?? undefined },
+      );
+      if (appRow && appRow.defaultValue !== null) {
+        layers.push({ value: appRow.getDefaultValue() });
+      }
+    }
+
+    if (this.scopeType === 'user') {
+      const contextTenantId = getCurrentTenant()?.tenantId;
+      if (contextTenantId) {
+        const tenantRow = await collection.getTenantRow(
+          this.objectRef,
+          this.fieldName,
+          contextTenantId,
+          { excludeId: this.id ?? undefined },
+        );
+        if (tenantRow && tenantRow.defaultValue !== null) {
+          layers.push({ value: tenantRow.getDefaultValue() });
+        }
+      }
+    }
+
+    // Highest contributing lower layer wins (tenant over app over code).
+    for (let index = layers.length - 1; index >= 0; index--) {
+      const layer = layers[index];
+      if (layer !== undefined) {
+        return layer;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Org lock enforcement (write side): a user-scope row is rejected while the
+   * effective lock — code seed (`ui.locked`), overridden by the app row, then
+   * by the ambient context tenant's row — is true. The resolver additionally
+   * skips the user layer at read time whenever the org tiers resolve locked,
+   * so stale user rows cannot bypass a later lock.
+   */
+  private async assertNotLockedForUserWrite(
+    fieldDef: RegisteredFieldInfo,
+  ): Promise<void> {
+    const ui = sanitizeFieldUIHints(fieldDef._meta?.ui);
+    let effectiveLocked = ui?.locked === true;
+
+    const { FieldPolicyCollection } = await import(
+      '../collections/FieldPolicyCollection.js'
+    );
+    const collection = await FieldPolicyCollection.create({
+      db: this.options.db ?? this.options.persistence,
+    });
+
+    const appRow = await collection.getAppRow(this.objectRef, this.fieldName);
+    if (appRow && appRow.locked !== null) {
+      effectiveLocked = appRow.locked;
+    }
+
+    const contextTenantId = getCurrentTenant()?.tenantId;
+    if (contextTenantId) {
+      const tenantRow = await collection.getTenantRow(
+        this.objectRef,
+        this.fieldName,
+        contextTenantId,
+      );
+      if (tenantRow && tenantRow.locked !== null) {
+        effectiveLocked = tenantRow.locked;
+      }
+    }
+
+    if (effectiveLocked) {
+      throw new Error(
+        `Field "${this.objectRef}.${this.fieldName}" is locked by org ` +
+          `policy; user-scope overrides are not allowed`,
+      );
+    }
+  }
+
+  private async getPersistedIdentity(): Promise<FieldPolicyIdentity | null> {
+    if (!this.id) {
+      return null;
+    }
+
+    const existing = await this.db.get(this.tableName, { id: this.id });
+    if (!existing) {
+      return null;
+    }
+
+    const row = existing as Record<string, unknown>;
+    const read = (camel: string, snake: string, fallback: string): string => {
+      if (row[camel] !== undefined && row[camel] !== null) {
+        return String(row[camel]);
+      }
+      if (row[snake] !== undefined && row[snake] !== null) {
+        return String(row[snake]);
+      }
+      return fallback;
+    };
+
+    return {
+      objectRef: read('objectRef', 'object_ref', this.objectRef),
+      fieldName: read('fieldName', 'field_name', this.fieldName),
+      scopeType: read('scopeType', 'scope_type', this.scopeType),
+      scopeKey: read('scopeKey', 'scope_key', this.scopeKey),
+    };
+  }
+
+  private normalizeDefaultValueForPersistence(): void {
+    const raw = this.defaultValue as unknown;
+
+    if (raw === null || raw === undefined) {
+      this.defaultValue = null;
+      return;
+    }
+
+    if (typeof raw === 'string') {
+      this.defaultValue = raw;
+      return;
+    }
+
+    // Non-string writes (e.g. a plain value assigned directly) serialize so
+    // the column always stores a JSON string.
+    this.defaultValue = JSON.stringify(raw);
+  }
+}

--- a/packages/fields/src/models/FieldPolicy.ts
+++ b/packages/fields/src/models/FieldPolicy.ts
@@ -190,6 +190,10 @@ export class FieldPolicy extends SmrtObject {
   }
 
   override async save(): Promise<this> {
+    // Runs BEFORE the persisted-identity lookup: that lookup falls back to
+    // the natural key, which includes the scope key derived from these
+    // columns.
+    this.attributeScopeToAmbientContext();
     const previousIdentity = await this.getPersistedIdentity();
     // The caller must own the row AS PERSISTED before any mutation is
     // accepted — otherwise a foreign row could be re-scoped into the caller's
@@ -198,11 +202,20 @@ export class FieldPolicy extends SmrtObject {
     if (previousIdentity) {
       this.assertScopeOwnedByAmbientContext(previousIdentity, 'save');
     }
+    // Audit attribution (#2050): inside an ambient context the SERVER stamps
+    // who wrote the row — a client-supplied `updatedBy` is overwritten, so
+    // attribution cannot be spoofed through the generated write routes. A
+    // context without a user id attributes to null; trusted context-less
+    // flows keep whatever explicit attribution they set.
+    const ambientContext = getCurrentTenant();
+    if (ambientContext) {
+      this.updatedBy = ambientContext.userId ?? null;
+    }
     this.normalizeDefaultValueForPersistence();
     await this.validateFieldPolicy();
     // scopeKey makes the conflict-column tuple total even though tenantId and
     // userId are nullable (nullable columns would allow duplicate NULL rows).
-    this.scopeKey = this.userId ?? this.tenantId ?? APP_FIELD_POLICY_SCOPE_KEY;
+    this.scopeKey = this.computeScopeKey();
 
     const identityChanged =
       previousIdentity &&
@@ -493,6 +506,45 @@ export class FieldPolicy extends SmrtObject {
     }
   }
 
+  /** `userId ?? tenantId ?? '__app__'` — the `conflictColumns` scope key. */
+  private computeScopeKey(): string {
+    return this.userId ?? this.tenantId ?? APP_FIELD_POLICY_SCOPE_KEY;
+  }
+
+  /**
+   * Derive a scope-owner column the transport could not carry (#2047).
+   *
+   * Core's mass-assignment guard treats `tenantId` as server-managed and
+   * strips it from EVERY generated create/update body, and `FieldPolicy` is
+   * deliberately not `@TenantScoped`, so the tenancy interceptor never
+   * repopulates it. A `POST {scopeType:'tenant', tenantId}` therefore always
+   * reached `validateScopeConsistency` with `tenantId === null`, making the
+   * org tier write-dead over every generated surface — the model, as the
+   * single validation authority for these rows, fills it in instead.
+   *
+   * This grants nothing: `assertScopeOwnedByAmbientContext` already requires
+   * a non-bypass caller's tenant/user rows to name exactly the ambient
+   * tenant/user, so the derived value is the ONLY value that could ever have
+   * been accepted. An explicit value is never overwritten (a super-admin
+   * bypass caller keeps naming other scopes), and with no ambient context
+   * nothing is derived — scope-shape validation rejects the row as before.
+   * Consequence: a bypass caller writing ANOTHER tenant's row must pass
+   * `tenantId` through a server-side model call, because the generated routes
+   * still strip it.
+   */
+  private attributeScopeToAmbientContext(): void {
+    const context = getCurrentTenant();
+    if (!context) {
+      return;
+    }
+    if (this.scopeType === 'tenant' && this.tenantId === null) {
+      this.tenantId = context.tenantId;
+    }
+    if (this.scopeType === 'user' && this.userId === null) {
+      this.userId = context.userId ?? null;
+    }
+  }
+
   /**
    * Fail-closed write boundary against the ambient tenant context, applied to
    * the NEW scope on save and to the PERSISTED scope on save/delete of an
@@ -503,9 +555,12 @@ export class FieldPolicy extends SmrtObject {
    * ALS), only app-scope rows are accepted: tenant- and user-scope rows are
    * unattributable without a context, so they are rejected outright rather
    * than allowed by default. Inside a non-bypass context, a caller may only
-   * touch rows for its own tenant (and, when the context carries a user id,
-   * only user rows for itself); app-wide rows then require super-admin
-   * bypass (or a context-less/system caller).
+   * touch rows for its own tenant, and user rows only for its own user id —
+   * a context that carries NO user id may not touch the user tier at all.
+   * App-wide rows then require super-admin bypass (or a context-less/system
+   * caller).
+   *
+   * Package rule: a missing identity component DENIES, it never skips.
    */
   private assertScopeOwnedByAmbientContext(
     scope: {
@@ -553,17 +608,31 @@ export class FieldPolicy extends SmrtObject {
       );
     }
 
-    if (
-      scope.scopeType === 'user' &&
-      context.userId !== undefined &&
-      scope.userId !== context.userId
-    ) {
-      throw new TenantIsolationError(
-        `Tenant isolation violation in FieldPolicy.${operation}: context ` +
-          `user is '${context.userId}' but the row belongs to ` +
-          `'${scope.userId}'`,
-        { tenantId: context.tenantId },
-      );
+    if (scope.scopeType === 'user') {
+      // A MISSING identity component denies, never skips. Tenancy adapters
+      // populate `permissions` while leaving `userId` undefined whenever no
+      // `resolveUserId` hook is configured (API-key auth, service principals,
+      // background jobs, a bare `withTenant({ tenantId })`), and user rows
+      // carry `tenantId: null` by design — so skipping the check here would
+      // let any such caller create, re-scope, or delete ANY user's rows in
+      // ANY tenant, with the generated PUT echoing the row back as a read
+      // primitive.
+      if (context.userId === undefined) {
+        throw new TenantIsolationError(
+          `User-scope field policy ${operation}s require an ambient context ` +
+            `that carries a user id; this context cannot attribute a ` +
+            `user-scope write`,
+          { tenantId: context.tenantId },
+        );
+      }
+      if (scope.userId !== context.userId) {
+        throw new TenantIsolationError(
+          `Tenant isolation violation in FieldPolicy.${operation}: context ` +
+            `user is '${context.userId}' but the row belongs to ` +
+            `'${scope.userId}'`,
+          { tenantId: context.tenantId },
+        );
+      }
     }
   }
 
@@ -615,17 +684,27 @@ export class FieldPolicy extends SmrtObject {
     }
   }
 
+  /**
+   * The persisted row this save/delete would replace, looked up by primary
+   * key and — when that misses — by the NATURAL key.
+   *
+   * The natural-key fallback is load-bearing for authorization: every
+   * generated create arrives with a freshly minted UUID, so a primary-key
+   * lookup always misses, yet the `conflictColumns` upsert still overwrites
+   * whatever row already occupies `(objectRef, fieldName, scopeType,
+   * scopeKey)`. Authorizing on the primary key alone therefore skipped the
+   * persisted-scope guard on exactly the path that can replace an existing
+   * row's contents.
+   */
   private async getPersistedIdentity(): Promise<FieldPolicyIdentity | null> {
-    if (!this.id) {
-      return null;
-    }
-
-    const existing = await this.db.get(this.tableName, { id: this.id });
+    const existing =
+      (await this.getPersistedRowById()) ??
+      (await this.getPersistedRowByNaturalKey());
     if (!existing) {
       return null;
     }
 
-    const row = existing as Record<string, unknown>;
+    const row = existing;
     const read = (camel: string, snake: string, fallback: string): string => {
       if (row[camel] !== undefined && row[camel] !== null) {
         return String(row[camel]);
@@ -648,6 +727,35 @@ export class FieldPolicy extends SmrtObject {
       tenantId: readNullable('tenantId', 'tenant_id'),
       userId: readNullable('userId', 'user_id'),
     };
+  }
+
+  private async getPersistedRowById(): Promise<Record<string, unknown> | null> {
+    if (!this.id) {
+      return null;
+    }
+    const row = await this.db.get(this.tableName, { id: this.id });
+    return (row as Record<string, unknown> | undefined) ?? null;
+  }
+
+  /**
+   * The row occupying this row's `conflictColumns` tuple, if any. Column
+   * names are the physical snake_case ones: this reads the driver directly
+   * rather than through a collection (the model has no collection handle).
+   */
+  private async getPersistedRowByNaturalKey(): Promise<Record<
+    string,
+    unknown
+  > | null> {
+    if (!this.objectRef || !this.fieldName) {
+      return null;
+    }
+    const row = await this.db.get(this.tableName, {
+      object_ref: this.objectRef,
+      field_name: this.fieldName,
+      scope_type: this.scopeType,
+      scope_key: this.computeScopeKey(),
+    });
+    return (row as Record<string, unknown> | undefined) ?? null;
   }
 
   private normalizeDefaultValueForPersistence(): void {

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -1,0 +1,190 @@
+import type {
+  SmrtClassOptions,
+  SmrtObjectOptions,
+} from '@happyvertical/smrt-core';
+
+/**
+ * Scope tier a {@link FieldPolicy} row belongs to.
+ *
+ * Resolution precedence is code seed → `app` → `tenant` (hierarchy walk,
+ * root → leaf) → `user`. Unlike smrt-features (which ships only
+ * `global`/`tenant`), the user tier is implemented end to end here — both
+ * defaults and visibility resolve through it.
+ */
+export type FieldPolicyScopeType = 'app' | 'tenant' | 'user';
+
+/**
+ * Visibility tier for a field in generated/consuming form UIs.
+ *
+ * - `basic`: shown before the advanced disclosure
+ * - `advanced`: shown behind the advanced disclosure
+ * - `hidden`: not rendered (requires the field to be optional or have a
+ *   resolved default — the required-field invariant)
+ */
+export type FieldPolicyVisibility = 'basic' | 'advanced' | 'hidden';
+
+/**
+ * `scopeKey` value for app-scope rows. `scopeKey` exists ONLY so the
+ * `conflictColumns` unique index stays total while `tenantId`/`userId` are
+ * nullable (nullable columns would allow duplicate NULL rows) — the same
+ * trick as `PromptOverride.context`.
+ */
+export const APP_FIELD_POLICY_SCOPE_KEY = '__app__';
+
+export const FIELD_POLICY_SCOPE_TYPES: readonly FieldPolicyScopeType[] = [
+  'app',
+  'tenant',
+  'user',
+];
+
+export const FIELD_POLICY_VISIBILITIES: readonly FieldPolicyVisibility[] = [
+  'basic',
+  'advanced',
+  'hidden',
+];
+
+export interface FieldPolicyOptions extends SmrtObjectOptions {
+  objectRef?: string;
+  fieldName?: string;
+  scopeType?: FieldPolicyScopeType;
+  tenantId?: string | null;
+  userId?: string | null;
+  /** JSON-encoded default value (string), or a plain value to be serialized. */
+  defaultValue?: unknown;
+  visibility?: FieldPolicyVisibility | null;
+  help?: string | null;
+  label?: string | null;
+  displayOrder?: number | null;
+  locked?: boolean | null;
+  updatedBy?: string | null;
+}
+
+/**
+ * The sparse contribution of one layer (code seed or one stored row).
+ *
+ * `default` is boxed so an explicit JSON `null` default (meaning "default to
+ * null") stays distinguishable from "this layer contributes no default".
+ */
+export interface FieldPolicyDelta {
+  default?: { value: unknown };
+  visibility?: FieldPolicyVisibility;
+  help?: string;
+  label?: string;
+  order?: number;
+  locked?: boolean;
+}
+
+/** One layer's contribution to a field's resolved policy (explain variant). */
+export interface FieldPolicyLayerContribution {
+  layer: 'code' | 'app' | 'tenant' | 'user';
+  /** Chain node id for `tenant` layers (root → leaf order). */
+  tenantId?: string;
+  /** User id for the `user` layer. */
+  userId?: string;
+  delta: FieldPolicyDelta;
+}
+
+/** Fully merged policy for a single field. */
+export interface ResolvedFieldPolicy {
+  fieldName: string;
+  /** True when any layer resolved a default (including an explicit null). */
+  hasDefault: boolean;
+  /** Parsed default value; `undefined` when {@link hasDefault} is false. */
+  defaultValue: unknown;
+  visibility: FieldPolicyVisibility;
+  help: string | null;
+  label: string | null;
+  order: number | null;
+  /** Grouping key — code-seed only (`ui.group`), not overridable by rows. */
+  group: string | null;
+  locked: boolean;
+  /** Mirror of the manifest required flag (nullable fields are optional). */
+  required: boolean;
+  /**
+   * True when the resolver forced `basic` visibility because the field is
+   * required and no usable default resolved (the resolver-side safety net for
+   * the required-field invariant).
+   */
+  visibilityForced?: boolean;
+}
+
+/** Merged policy for every field of one object. */
+export interface ResolvedObjectFieldPolicy {
+  objectRef: string;
+  fields: Record<string, ResolvedFieldPolicy>;
+}
+
+/**
+ * Explain variant: merged result plus the ordered per-layer contributions for
+ * each field, so admin/gear UIs (#2049/#2050) never re-derive precedence.
+ * Layers are listed in application order (code, app, tenant chain root → leaf,
+ * user); tenant chain nodes that break permission inheritance reset the
+ * baseline to the app-layer state before their delta applies.
+ */
+export interface ExplainedObjectFieldPolicy extends ResolvedObjectFieldPolicy {
+  layers: Record<string, FieldPolicyLayerContribution[]>;
+}
+
+/** Minimal tenant node consumed by the hierarchy walk (mirrors smrt-features). */
+export interface FieldPolicyTenantNode {
+  id: string;
+  inheritPermissions: boolean;
+  cascadePermissions: boolean;
+}
+
+/** Provider returning the root → leaf tenant chain (mirrors smrt-features). */
+export interface FieldPolicyTenantHierarchyProvider {
+  getChain(tenantId: string): Promise<FieldPolicyTenantNode[]>;
+}
+
+/**
+ * Loader-function DI seam (NOT a container registration): the resolver calls
+ * it lazily and treats `null` as "no hierarchy available" (flat-tenant
+ * fallback). The default loader dynamic-imports `@happyvertical/smrt-users`
+ * and returns `null` when it is not installed.
+ */
+export type FieldPolicyTenantHierarchyLoader = (
+  options: SmrtClassOptions,
+) => Promise<FieldPolicyTenantHierarchyProvider | null>;
+
+export interface ResolveFieldPolicyOptions {
+  tenantId?: string | null;
+  userId?: string | null;
+  /**
+   * Database holding `_smrt_field_policies`. Without it, only the code seed
+   * resolves (stored layers are skipped) — the smrt-prompts precedent.
+   */
+  db?: SmrtClassOptions['db'];
+  tenantHierarchyLoader?: FieldPolicyTenantHierarchyLoader;
+}
+
+/**
+ * Minimal structural shape of the tenant surface loaded from
+ * `@happyvertical/smrt-users` by the default hierarchy loader. Only the
+ * permission-cascade fields consumed by the chain walk are modeled.
+ */
+export interface FieldPolicyUsersTenantRecord {
+  id: string;
+  inheritPermissions?: boolean;
+  cascadePermissions?: boolean;
+}
+
+export interface FieldPolicyUsersModule {
+  TenantCollection: {
+    create(options: SmrtClassOptions): Promise<{
+      get(criteria: {
+        id: string;
+      }): Promise<FieldPolicyUsersTenantRecord | null>;
+      getAncestorsFromRoot(
+        tenantId: string,
+      ): Promise<FieldPolicyUsersTenantRecord[]>;
+    }>;
+  };
+}
+
+/** Result shape of the batch resolve action (`FieldPolicyCollection.resolveBatch`). */
+export interface FieldPolicyBatchResult {
+  policies: Record<string, ResolvedObjectFieldPolicy>;
+}
+
+export type { SmrtClassOptions };

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -118,8 +118,10 @@ export interface ResolvedObjectFieldPolicy {
  * Explain variant: merged result plus the ordered per-layer contributions for
  * each field, so admin/gear UIs (#2049/#2050) never re-derive precedence.
  * Layers are listed in application order (code, app, tenant chain root → leaf,
- * user); tenant chain nodes that break permission inheritance reset the
- * baseline to the app-layer state before their delta applies.
+ * user) and contain ONLY contributions that survive into the merged result:
+ * tenant ancestors discarded by a permission-inheritance break and user rows
+ * suppressed by an effective org lock are omitted, so sequentially replaying
+ * the listed deltas reproduces the merged policy.
  */
 export interface ExplainedObjectFieldPolicy extends ResolvedObjectFieldPolicy {
   layers: Record<string, FieldPolicyLayerContribution[]>;

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -49,8 +49,29 @@ export interface FieldPolicyOptions extends SmrtObjectOptions {
   scopeType?: FieldPolicyScopeType;
   tenantId?: string | null;
   userId?: string | null;
-  /** JSON-encoded default value (string), or a plain value to be serialized. */
-  defaultValue?: unknown;
+  /**
+   * ENCODED channel: an already-JSON-encoded default, exactly as the column
+   * stores it (`'"Net 30"'`, `'42'`, `'null'`), or `null` to inherit.
+   *
+   * This is the wire contract: the generated write routes hand the request
+   * body straight to the constructor, and the #2049/#2050 gear posts
+   * `JSON.stringify(draft.defaultValue)`. It must therefore keep meaning
+   * "already encoded" — auto-serializing here would double-encode every gear
+   * write.
+   *
+   * Use {@link FieldPolicyOptions.defaultValueRaw} for a plain value. The two
+   * are mutually exclusive: `'"TBD"'` and `'TBD'` are indistinguishable once
+   * a single option carries both meanings, so the channel must be explicit
+   * rather than sniffed.
+   */
+  defaultValue?: string | null;
+  /**
+   * PLAIN channel: any value, always serialized — strings included. The
+   * constructor-option twin of {@link FieldPolicy.setDefaultValue}, so
+   * `{ defaultValueRaw: 'Net 30' }` stores `'"Net 30"'` rather than the
+   * unparseable literal `Net 30`.
+   */
+  defaultValueRaw?: unknown;
   visibility?: FieldPolicyVisibility | null;
   help?: string | null;
   label?: string | null;

--- a/packages/fields/tsconfig.json
+++ b/packages/fields/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
+    "types": ["node"],
+    "lib": ["ES2023"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/fields/vite.config.ts
+++ b/packages/fields/vite.config.ts
@@ -1,0 +1,3 @@
+import { createPackageConfig } from '../../vite.config.base.js';
+
+export default createPackageConfig('fields');

--- a/packages/fields/vitest.config.ts
+++ b/packages/fields/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import { smrtVitestPlugin } from '../vitest/src/index.ts';
+
+export default defineConfig({
+  plugins: [smrtVitestPlugin({ verbose: true })],
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    testTimeout: 60000,
+    fileParallelism: false,
+    pool: 'forks',
+    singleFork: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1052,6 +1052,37 @@ importers:
         specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  packages/fields:
+    dependencies:
+      '@happyvertical/smrt-core':
+        specifier: workspace:*
+        version: link:../core
+      '@happyvertical/smrt-tenancy':
+        specifier: workspace:*
+        version: link:../tenancy
+      '@happyvertical/sql':
+        specifier: ^0.84.0
+        version: 0.84.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+    devDependencies:
+      '@happyvertical/smrt-users':
+        specifier: workspace:*
+        version: link:../users
+      '@happyvertical/smrt-vitest':
+        specifier: workspace:*
+        version: link:../vitest
+      '@types/node':
+        specifier: 24.13.2
+        version: 24.13.2
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 8.1.4
+        version: 8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vitest:
+        specifier: 4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+
   packages/gnode:
     dependencies:
       '@happyvertical/ai':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1064,6 +1064,9 @@ importers:
         specifier: ^0.84.0
         version: 0.84.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
     devDependencies:
+      '@happyvertical/smrt-cli':
+        specifier: workspace:*
+        version: link:../cli
       '@happyvertical/smrt-users':
         specifier: workspace:*
         version: link:../users

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,6 +55,7 @@
     { "path": "./packages/content" },
     { "path": "./packages/events" },
     { "path": "./packages/facts" },
+    { "path": "./packages/fields" },
     { "path": "./packages/gnode" },
     { "path": "./packages/images" },
     { "path": "./packages/messages" },


### PR DESCRIPTION
## Summary

First slice of the smrt-fields epic (#2045): the `FieldPolicy` model, the layered
app → tenant → user resolver over the #2046 code seed, and the `resolveBatch`
collection action that client bootstrapping (#2048) consumes.

- **`FieldPolicy`** (`_smrt_field_policies`) — sparse override rows keyed
  `(objectRef, fieldName, scopeType, scopeKey)`. A NULL column means "inherit
  from the lower layer", so resetting a customization is a row DELETE and later
  lower-layer changes flow through. Writes validate against the live
  `ObjectRegistry`: unknown objects/fields rejected, defaults type-checked,
  and the security rail (`sensitive` / `readPermission` / `transient`) refuses
  stored defaults outright.
- **`resolveFieldPolicy` / `resolveFieldPolicyExplained`** — code seed → app
  rows → tenant chain (hierarchy walk root → leaf, permission-inheritance
  breaks discard earlier ancestors) → user rows, with a 30s TTL cache. The
  explained variant returns ordered per-layer contributions that replay to the
  merged result, so #2049/#2050 UIs never re-derive precedence.
- **Required-field invariant** — demoting a required field to advanced/hidden
  needs a usable resolved default, enforced at write time AND re-enforced at
  resolution (a different row's later deletion can invalidate what held).
- **Closed read surfaces** — no generated `list`/`get` anywhere: this model is
  deliberately not `@TenantScoped`, so a generated read would enumerate every
  tenant's and user's rows. Reads go through the context-scoped `resolveBatch`
  action or the server-side resolver.
- Core's runtime `APIGenerator` gains decorator-route dispatch for
  single-segment collection-scoped custom actions, so `POST /<collection>/resolve`
  works on the runtime transport as it already did on generated SvelteKit routes.

Parent: #2045 (epic stays open).

## Review fixes in this cycle

A read-only review of the slice returned **needs-fixes** with two P1s. Both are
fixed here, each with a regression test that fails without the fix (verified by
reverting the fix and re-running).

**P1-1 — userless-context user-scope ownership bypass.**
`assertScopeOwnedByAmbientContext` guarded the user tier with
`context.userId !== undefined && scope.userId !== context.userId`, so the check
VANISHED for any ambient context without a user id. Tenancy adapters produce
exactly that shape whenever no `resolveUserId` hook is configured (API-key auth,
service principals, background jobs, a bare `withTenant({ tenantId })`), and
user rows are `tenantId: null` by design, so nothing else contained the write:
such a caller could create, re-scope, or delete ANY user's rows in ANY tenant,
with the generated PUT echoing the row back as a read primitive. The package
rule is now **a missing identity component DENIES, it never skips**, applied on
the write side and mirrored on the read side in `assertResolutionAllowedInContext`
(the public `resolveFieldPolicy` export). Context-LESS reads stay allowed —
that is the trusted server-side path, and `resolveBatch` never lets a request
body select a user.

**P1-2 — the tenant tier could not be created through any generated write surface.**
Core's mass-assignment guard treats `tenantId` as server-managed and strips it
from every create/update body, while `FieldPolicy` is deliberately not
`@TenantScoped` so the tenancy interceptor never repopulates it. A
`POST {scopeType:'tenant', tenantId}` therefore always reached scope-shape
validation with `tenantId === null` and returned 500 — #2050's entire
org-admin tier was unreachable from REST/SvelteKit, and it went unnoticed
because the model-level tests call `policies.create()` directly.

Fixed **model-side, not in core**: `save()` now derives a missing tenant/user
owner from the ambient context. This grants nothing — the ownership guard
already pinned the value to the ambient one, so the derived value is the only
value that could ever have been accepted — and it keeps the model as the single
validation authority instead of adding an escape hatch to a guard every package
in the monorepo depends on. `packages/core` is unchanged by this fix.

Also in this cycle:

- Server-side **`updatedBy` stamping pulled forward from the #2050 branch**, so
  audit attribution is not forgeable through the open write routes before #2051
  consumes it. A client-supplied value is overwritten inside any ambient
  context; context-less/system flows keep what they set.
- The persisted-scope guard now falls back to a **natural-key lookup**. Every
  generated create mints a fresh UUID, so the primary-key lookup always missed
  while the `conflictColumns` upsert still replaced the occupant.
- `isRequiredField` reads `nullable` from the top level as well as `_meta`,
  matching how `required` — and `sensitive`/`readPermission`/`transient` —
  were already read from both. Defensive only: on the scanner-manifest path
  `nullable` always lands in `_meta` (verified), so this covers the
  runtime-decorator registration path used by consumer packages without a
  baked manifest. No behaviour change is observable in-repo, so it carries no
  dedicated test.
- The resolver cache key includes **tenant-hierarchy loader identity** — an
  injected loader was being served the default loader's ancestor chain.
- AGENTS.md records the deny-on-missing-identity rule, scope attribution, that
  `withSystemContext()` does not unlock org/user writes (seeds need
  `superAdminBypass`), and that the model's `cli`/`mcp` config is dead at
  runtime because the registry re-registers the item slot with the
  collection's config.

Five test groups from the review brief were added. The P1-2 regression drives
one row per scope tier through `APIGenerator`, never through `policies.create()`
— model-level tests are exactly what hid the defect.

## Accepted design residuals

Recorded rather than fixed here, deliberately:

- **`resolveBatch` is authorized under the `post` verb, identical to `create`.**
  An app cannot grant bootstrap-read without also granting policy writes. It is
  a property of how core authorizes collection-scoped custom actions, not of
  this package; changing it is a core-wide auth decision.
- **Custom-action validation errors surface as 500.** `resolveBatch`'s input
  validation and `TenantIsolationError` both become generic 500s because the
  `resolveErrorHttpStatus` opt-in rail does not exist at this landing point.
  #2049 adds it; the 400/403 mapping belongs in that cycle, not this one.
- **Core has no opt-in for models that carry tenancy as explicit domain data.**
  `applyWritablePolicy`'s `serverManaged` set is unconditional and duplicated in
  `sveltekit-generator.ts`. Solving P1-2 model-side avoids touching either copy;
  if a second model ever needs this, the escape hatch belongs in core.
- **Bypass callers cannot write another tenant's row over REST.** The transport
  still strips `tenantId`, and derivation only fills from the ambient context.
  Cross-tenant admin writes go through a server-side model call.

## Independent review cycle

A codex review (gpt-5.6-sol, xhigh) of the full diff returned four findings,
all in the slice's pre-existing code rather than the fixes above. All four were
verified against the source and fixed in `123e14398`:

- **[P1] Stray unique index on the policy table.** A decorated collection emits
  its OWN manifest schema for the item's table, and `FieldPolicyCollection` did
  not repeat FieldPolicy's `conflictColumns` — so its schema fell back to
  SmrtObject's default unique `(slug, context)` index. Manifest-driven consumer
  migrations aggregate both onto `_smrt_field_policies`, where that index
  rejects legitimate layered rows: every policy row has a NULL slug and
  context, and the app/tenant/user rows for one field differ only by the real
  natural key. Confirmed in the generated manifest before the fix. The runtime
  registry cannot surface it — `getAllSchemas()` is keyed by TABLE name, so the
  two schemas collapse into one entry — so the new test asserts against the
  generated manifest, and fails without the fix.
- **[P1] Scope was read off the route alone.** `ApiCustomRouteConfig.scope` is
  OPTIONAL and documented to default to `collection` for statics / `item` for
  instance methods, but the dispatcher required a literal `scope: 'collection'`.
  A valid static action that omitted it was skipped, so
  `POST /<collection>/<action>` fell through to CRUD and created an object
  wherever `create` is exposed. Scope now resolves through the shared
  `resolveCustomActionMetadata`, with the receiver deciding.
- **[P2] Arguments ignored declared parameters.** Every action was invoked with
  one options object; `buildCustomActionInvocationArgs` now projects them as
  the SvelteKit/CLI/MCP transports do. Unchanged wherever parameter metadata is
  absent, which is currently every collection-hosted action.
- **[P2] Returned failures were served as 200.** An action returning the shared
  `{ ok: false, code, message, status }` convention had the raw object wrapped
  as a success; `normalizeCustomActionFailure` now applies first.

Also folded in: an ABSENT request body is no longer conflated with a malformed
one, so a zero-parameter action can be called with no body while a present-but-
unparseable body stays a 400. The dispatcher had no core-side coverage at all;
`rest-custom-actions.spec.ts` adds it.

### Review threads

- **Copilot, `types.ts:52` — `defaultValue` carried two meanings.** The option
  was documented and implemented as "JSON-encoded string, or a plain value to
  serialize", so the natural call `{ defaultValue: 'Net 30' }` stored
  unparseable text. The ambiguity is inherent — `'"TBD"'` and `'TBD'` are
  indistinguishable — so the channel had to become explicit. Which channel
  keeps which meaning was settled by the callers, not by taste: every existing
  caller passes PRE-ENCODED values, decisively including #2049/#2050's gear,
  whose `planFieldSettingsWrite` posts `JSON.stringify(draft.defaultValue)`
  into a `FieldPolicyRowPatch` typed `defaultValue: string | null` straight
  through the generated write routes. Auto-serializing `defaultValue` would
  have silently double-encoded every gear write across the rest of the epic.
  So `defaultValue` keeps the encoded meaning (now typed `string | null`
  instead of `unknown`), and the plain value gets the new explicit
  `defaultValueRaw` — the option twin of the existing `setDefaultValue()`.
  Supplying both throws; the parse failure now names the fix. Storage and every
  read site are unchanged and stay symmetric. Fixed in `c1043544f`.
- Both codex P2s (typed custom-action arguments; failures served as 200) were
  already fixed by `123e14398`.

## Validation

- `@happyvertical/smrt-fields`: 4 files, **55 tests passed** (43 before this
  cycle, 12 added); `tsc --noEmit` green
- `@happyvertical/smrt-core` FULL suite: 255 files passed / 5 skipped, **3,121
  tests passed** (45 skipped); `tsc --noEmit` green
- `tsc --noEmit` also green for `smrt-tenancy`, `smrt-users`, `smrt-cli`
- `turbo typecheck`: 104/109 tasks successful. The 5 non-successes are all the
  documented nested-worktree `Tsconfig not found .../packages/accounts` artifact
  (a vite-8 oxc-transform / pnpm-symlink issue that does not reproduce in CI's
  isolated checkout — see the note in
  `packages/products/scripts/check-web-engine-code-split.mjs`), hit by `build`
  tasks in packages this branch does not touch, plus the typechecks blocked
  behind them.
- `biome check` clean on every touched file
- `pnpm smrt dev:knowledge-check`: fresh, 0 errors, 0 warnings
- `pnpm check:agents-chain`: 65 chains under the 32,768-byte cap. This slice's
  chain (root + `packages/fields`) is **19,616 bytes — 13,152 headroom**. The
  largest chain repo-wide is `packages/users` at 29,997 (2,771 headroom),
  untouched here.
- Regression tests were verified by reverting each fix and re-running:
  the userless-context write guard (P1-1), both scope-tier REST tests (P1-2,
  which returned 500 with "Tenant-scope field policy rows must set tenantId"),
  the resolver read-side mirror, and the hierarchy-loader cache key all fail
  without their fix. The `updatedBy` test cannot pass without the stamping by
  construction (the body supplies a different id than the assertion expects).
  The natural-key authorization test is defence-in-depth and is noted as such
  in the test itself: the new-scope check also refuses that write today,
  because the scope key is derived from the caller's own owner id.

Rebased onto `origin/main`, dropping the duplicate #2046 commit already merged
as PR #2153; `packages/core/agents/generators.md` and
`packages/core/src/vite-plugin/web-collections.test.ts` are byte-identical to
main.

Closes #2047




<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"claude","session":"53e2c43c-41e2-4f9f-a63a-996baed10afd","issue":"2047","policy_revision":"1.0.0","status":"complete","validation":["smrt-fields full suite (55 tests) and smrt-core full suite (3121 tests)","tsc --noEmit for core, fields, tenancy, users, cli","biome check on all touched files","pnpm smrt dev:knowledge-check fresh (0 errors, 0 warnings)","pnpm check:agents-chain under cap (fields chain 19616 bytes, 13152 headroom)","codex full-diff review: 4 findings, all verified and fixed","all PR review threads addressed and resolved"]}
