### PR TITLE
fix(core,scanner): make build output reproducible

### DIFF
--- a/packages/core/scripts/generate-manifest.js
+++ b/packages/core/scripts/generate-manifest.js
@@ -83,8 +83,16 @@ async function generateManifest() {
         process.cwd(),
         'src/manifest/smrt-knowledge.json',
       );
-      const knowledge = preserveGeneratedAtIfUnchanged(
-        knowledgePath,
+      // src/manifest/smrt-knowledge.json is gitignored build output that the
+      // package build copies verbatim to dist/smrt-knowledge.json, so it must
+      // not carry the clock: a fresh checkout has no previous file for
+      // preserveGeneratedAtIfUnchanged to carry a value forward from, and
+      // every build would emit different bytes (#2232). Mirrors
+      // DETERMINISTIC_GENERATED_AT in src/scanner/types.ts, duplicated as a
+      // literal because this script runs before core is built.
+      const DeterministicGeneratedAt = '1970-01-01T00:00:00.000Z';
+      const knowledge = withDeterministicGeneratedAt(
+        DeterministicGeneratedAt,
         buildDomainKnowledgeManifest({
           manifest,
           rootDir: process.cwd(),
@@ -109,6 +117,10 @@ async function generateManifest() {
 // Run if called directly
 if (import.meta.url === `file://${process.argv[1]}`) {
   generateManifest();
+}
+
+function withDeterministicGeneratedAt(generatedAt, nextKnowledge) {
+  return { ...nextKnowledge, generatedAt };
 }
 
 function preserveGeneratedAtIfUnchanged(path, nextKnowledge) {

--- a/packages/core/src/consumer-plugin/index.ts
+++ b/packages/core/src/consumer-plugin/index.ts
@@ -8,6 +8,7 @@ import * as path from 'node:path';
 import type { Plugin } from 'vite';
 import { generateDeclarations } from '../prebuild/index.js';
 import type { SmartObjectManifest } from '../scanner/types.js';
+import { MANIFEST_TIMESTAMP } from '../scanner/types.js';
 import { generateClientModule } from '../vite-plugin/generated-client.js';
 
 /**
@@ -148,7 +149,11 @@ export function smrtConsumer(options: SmrtConsumerOptions = {}): Plugin {
         }
       } else {
         console.log('[smrt:consumer] No SMRT packages found');
-        typeManifest = { version: '1.0.0', timestamp: Date.now(), objects: {} };
+        typeManifest = {
+          version: '1.0.0',
+          timestamp: MANIFEST_TIMESTAMP,
+          objects: {},
+        };
       }
     },
 
@@ -174,7 +179,11 @@ export function smrtConsumer(options: SmrtConsumerOptions = {}): Plugin {
       const cleanId = id.startsWith('\0') ? id.slice(1) : id;
 
       if (!typeManifest) {
-        typeManifest = { version: '1.0.0', timestamp: Date.now(), objects: {} };
+        typeManifest = {
+          version: '1.0.0',
+          timestamp: MANIFEST_TIMESTAMP,
+          objects: {},
+        };
       }
 
       switch (cleanId) {
@@ -275,7 +284,7 @@ async function aggregateTypeManifests(
 ): Promise<ConsumerManifest> {
   const aggregatedManifest: ConsumerManifest = {
     version: '1.0.0',
-    timestamp: Date.now(),
+    timestamp: MANIFEST_TIMESTAMP,
     objects: {},
   };
 

--- a/packages/core/src/manifest/__tests__/generator.test.ts
+++ b/packages/core/src/manifest/__tests__/generator.test.ts
@@ -7,6 +7,7 @@ import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { MANIFEST_TIMESTAMP } from '../../scanner/types.js';
 import { ManifestBuilder } from '../generator.js';
 
 describe('ManifestBuilder', () => {
@@ -529,7 +530,9 @@ class TestClass extends SmrtObject {
         expect(manifest.version).toBe('1.0.0');
         expect(manifest.objects).toEqual({});
         expect(manifest.moduleType).toBe('smrt');
-        expect(manifest.timestamp).toBeGreaterThan(0);
+        // Fixed, not wall-clock: manifests reach build output, so a varying
+        // timestamp would make every build emit different bytes (#2223).
+        expect(manifest.timestamp).toBe(MANIFEST_TIMESTAMP);
       } finally {
         process.chdir(originalCwd);
       }

--- a/packages/core/src/manifest/__tests__/issue-2223-deterministic-manifest.test.ts
+++ b/packages/core/src/manifest/__tests__/issue-2223-deterministic-manifest.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regression tests for Issue #2223 — build output must be reproducible.
+ *
+ * Manifests are inlined verbatim into every package bundle
+ * (`registerPackageManifest(JSON.parse("…"))`), and knowledge artifacts are
+ * emitted into `dist/`. Any wall-clock value in either changes the emitted
+ * bytes on every build, which changes Vite's content hash, which changes
+ * `dist/`, which invalidates downstream Turbo tasks through
+ * `dependsOn: ['^build']`. Measured before the fix: one rebuilt package
+ * churned 202 of 245 task hashes, and `typecheck` never reused a cache entry
+ * across runs (11/118 cold, 16/118 warm, no time saved).
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  DETERMINISTIC_GENERATED_AT,
+  MANIFEST_TIMESTAMP,
+} from '../../scanner/types.js';
+import { createEmptyStaticManifest } from '../store.js';
+
+describe('Issue #2223 - deterministic build output', () => {
+  it('pins the manifest timestamp to a fixed value', () => {
+    expect(MANIFEST_TIMESTAMP).toBe(0);
+  });
+
+  it('pins the emitted knowledge generatedAt to a parseable fixed instant', () => {
+    expect(DETERMINISTIC_GENERATED_AT).toBe('1970-01-01T00:00:00.000Z');
+    expect(Number.isNaN(Date.parse(DETERMINISTIC_GENERATED_AT))).toBe(false);
+  });
+
+  it('generates byte-identical empty manifests across calls', () => {
+    const first = JSON.stringify(createEmptyStaticManifest());
+    const second = JSON.stringify(createEmptyStaticManifest());
+
+    expect(second).toBe(first);
+  });
+
+  it('keeps the manifest timestamp stable across a clock advance', () => {
+    const before = createEmptyStaticManifest().timestamp;
+    const start = Date.now();
+    while (Date.now() === start) {
+      // Spin until the wall clock ticks, so a Date.now()-based
+      // implementation is guaranteed to produce a different value.
+    }
+
+    expect(createEmptyStaticManifest().timestamp).toBe(before);
+  });
+});

--- a/packages/core/src/manifest/__tests__/store-coverage.test.ts
+++ b/packages/core/src/manifest/__tests__/store-coverage.test.ts
@@ -23,6 +23,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { SmartObjectManifest } from '../../scanner/types.js';
+import { MANIFEST_TIMESTAMP } from '../../scanner/types.js';
 import {
   cloneManifestSchemaColumns,
   createEmptyStaticManifest,
@@ -157,7 +158,8 @@ describe('manifest/store coverage', () => {
       const empty = createEmptyStaticManifest();
       expect(empty.packageName).toBe('@happyvertical/smrt-core');
       expect(empty.objects).toEqual({});
-      expect(empty.timestamp).toBeGreaterThan(0);
+      // Fixed, not wall-clock — see #2223.
+      expect(empty.timestamp).toBe(MANIFEST_TIMESTAMP);
     });
   });
 

--- a/packages/core/src/manifest/generator.ts
+++ b/packages/core/src/manifest/generator.ts
@@ -9,6 +9,7 @@ import { createLogger } from '@happyvertical/logger';
 import fg from 'fast-glob';
 import { ManifestGenerator } from '../scanner/manifest-generator.js';
 import type { SmartObjectManifest } from '../scanner/types.js';
+import { MANIFEST_TIMESTAMP } from '../scanner/types.js';
 import { importWorkspaceModule } from '../utils/import-workspace-module.js';
 import type { ScannerModule } from '../utils/scanner-module.js';
 import {
@@ -607,7 +608,7 @@ export default ${exportName};
   ): SmartObjectManifest {
     const manifest: SmartObjectManifest = {
       version: '1.0.0',
-      timestamp: Date.now(),
+      timestamp: MANIFEST_TIMESTAMP,
       objects: {},
       moduleType: options.moduleType || 'smrt',
     };

--- a/packages/core/src/manifest/manifest-loader.ts
+++ b/packages/core/src/manifest/manifest-loader.ts
@@ -33,6 +33,7 @@ import type {
   SmartObjectDefinition,
   SmartObjectManifest,
 } from '../scanner/types.js';
+import { MANIFEST_TIMESTAMP } from '../scanner/types.js';
 import { parse } from '../utils/json.js';
 import {
   createQualifiedName,
@@ -295,7 +296,7 @@ function getStaticManifest(): SmartObjectManifest {
       // Fallback to empty manifest if file doesn't exist yet (during build)
       setStaticManifestCache({
         version: '1.0.0',
-        timestamp: Date.now(),
+        timestamp: MANIFEST_TIMESTAMP,
         objects: {},
         packageName: '@happyvertical/smrt-core',
       });

--- a/packages/core/src/manifest/store.ts
+++ b/packages/core/src/manifest/store.ts
@@ -24,6 +24,7 @@ import type {
   SmartObjectDefinition,
   SmartObjectManifest,
 } from '../scanner/types.js';
+import { MANIFEST_TIMESTAMP } from '../scanner/types.js';
 import type { ColumnDefinition } from '../schema/types.js';
 import {
   createQualifiedName,
@@ -228,7 +229,7 @@ export function getLocalTestManifestCache():
 export function createEmptyStaticManifest(): SmartObjectManifest {
   return {
     version: '1.0.0',
-    timestamp: Date.now(),
+    timestamp: MANIFEST_TIMESTAMP,
     objects: {},
     packageName: '@happyvertical/smrt-core',
   };

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -39,6 +39,7 @@ import type {
   SmrtVisibility,
   ValidationRule,
 } from './types.js';
+import { MANIFEST_TIMESTAMP } from './types.js';
 
 /** Package.json shape consumed for import-path and component discovery. */
 interface PackageJsonLike {
@@ -155,7 +156,7 @@ export class ManifestGenerator {
   ): SmartObjectManifest {
     const manifest: SmartObjectManifest = {
       version: '1.0.0',
-      timestamp: Date.now(),
+      timestamp: MANIFEST_TIMESTAMP,
       objects: {},
     };
 

--- a/packages/core/src/scanner/types.ts
+++ b/packages/core/src/scanner/types.ts
@@ -448,8 +448,43 @@ export interface SmartObjectDefinition {
   agent?: AgentManifest;
 }
 
+/**
+ * Fixed `timestamp` for every manifest that can reach build output.
+ *
+ * Manifests are inlined into bundles (`registerPackageManifest(JSON.parse(...))`),
+ * so a wall-clock value changes the emitted bytes on every build. That changes
+ * Vite's content hash, which changes `dist/`, which invalidates every
+ * downstream package through `dependsOn: ['^build']` — one rebuilt package
+ * churned 202 of 245 task hashes, and `typecheck` never reused a cache entry
+ * across runs (#2223).
+ *
+ * Nothing reads the field: `getManifestTimestampsHash` invalidates on
+ * filesystem mtimes, and `normalizeManifestForHash` deletes it before
+ * comparing. A fixed value therefore costs no information.
+ *
+ * Genuine runtime caches that expire on elapsed time — the discovery cache in
+ * `manifest/discover-smrt-packages.ts` — keep using the clock; they never
+ * reach build output.
+ */
+export const MANIFEST_TIMESTAMP = 0;
+
+/**
+ * Fixed `generatedAt` for knowledge artifacts emitted into `dist/`.
+ *
+ * Same reasoning as {@link MANIFEST_TIMESTAMP}: build output is compared
+ * byte-for-byte, so it cannot carry the clock. The Unix epoch is used rather
+ * than `0` because the field is an ISO-8601 string, and a parseable value
+ * keeps any consumer that formats it working.
+ *
+ * The working copy under `.smrt/` keeps a real timestamp — it is useful to a
+ * human there, and `preserveKnowledgeGeneratedAt` already stops it churning
+ * across incremental rebuilds.
+ */
+export const DETERMINISTIC_GENERATED_AT = '1970-01-01T00:00:00.000Z';
+
 export interface SmartObjectManifest {
   version: string;
+  /** Always {@link MANIFEST_TIMESTAMP} for build-output manifests. */
   timestamp: number;
   packageName?: string; // Root package name (should be set for all new manifests)
   packageVersion?: string; // Root package version

--- a/packages/core/src/schema/code-generator.ts
+++ b/packages/core/src/schema/code-generator.ts
@@ -4,6 +4,7 @@
  */
 
 import type { SmartObjectDefinition } from '../scanner/types.js';
+import { MANIFEST_TIMESTAMP } from '../scanner/types.js';
 import type {
   ColumnDefinition,
   ForeignKeyDefinition,
@@ -175,7 +176,7 @@ ${fkStrings.join(',\n')}
   ): string {
     const manifest = {
       version: '1.0.0',
-      timestamp: Date.now(),
+      timestamp: MANIFEST_TIMESTAMP,
       packageName,
       schemas: Object.fromEntries(
         Object.entries(schemas).map(([className, schema]) => [

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -14,6 +14,10 @@ import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite';
 import { buildDomainKnowledgeManifest } from '../knowledge.js';
 import { discoverSmrtPackages } from '../manifest/discover-smrt-packages.js';
 import type { SmartObjectManifest } from '../scanner/types';
+import {
+  DETERMINISTIC_GENERATED_AT,
+  MANIFEST_TIMESTAMP,
+} from '../scanner/types.js';
 import type { SchemaDefinition } from '../schema/types.js';
 import { importWorkspaceModule } from '../utils/import-workspace-module.js';
 import type { ScannerModule } from '../utils/scanner-module.js';
@@ -289,11 +293,21 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
     }
   }
 
+  /**
+   * @param deterministic - Emit a fixed `generatedAt` instead of the clock.
+   *   Set for artifacts written into the build output directory: `dist/` is
+   *   compared byte-for-byte by downstream caches, and a fresh checkout has no
+   *   previous file for {@link preserveKnowledgeGeneratedAt} to carry a value
+   *   forward from, so every build would otherwise emit different bytes
+   *   (#2223). The working copy under `.smrt/` keeps a real timestamp, which
+   *   is where it is useful to a human and where preservation already works.
+   */
   async function writeDomainKnowledgeArtifact(
     m: SmartObjectManifest,
     rootDir: string,
     outputPath: string,
     manifestPath: string,
+    deterministic = false,
   ): Promise<void> {
     const resolvedKnowledge = await resolveKnowledgeConfig(rootDir, m);
     if (resolvedKnowledge.enabled === false) {
@@ -309,15 +323,10 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
       manifestPath,
       config: resolvedKnowledge,
     });
-    writeFileSync(
-      outputPath,
-      JSON.stringify(
-        preserveKnowledgeGeneratedAt(outputPath, artifact),
-        null,
-        2,
-      ),
-      'utf-8',
-    );
+    const emitted = deterministic
+      ? { ...artifact, generatedAt: DETERMINISTIC_GENERATED_AT }
+      : preserveKnowledgeGeneratedAt(outputPath, artifact);
+    writeFileSync(outputPath, JSON.stringify(emitted, null, 2), 'utf-8');
   }
 
   async function resolveKnowledgeConfig(
@@ -947,6 +956,7 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
           projectRoot,
           knowledgePath,
           manifestPath,
+          true,
         );
 
         const objectCount = Object.keys(manifest.objects).length;
@@ -2257,7 +2267,7 @@ async function generateSchemaModule(
     // Create JSON manifest for schemas
     const schemaManifest = {
       version: '1.0.0',
-      timestamp: Date.now(),
+      timestamp: MANIFEST_TIMESTAMP,
       packageName: manifest.packageName || 'unknown',
       schemas: schemas,
       dependencies: Array.from(

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -13,10 +13,10 @@ import type {
 import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite';
 import { buildDomainKnowledgeManifest } from '../knowledge.js';
 import { discoverSmrtPackages } from '../manifest/discover-smrt-packages.js';
-import type { SmartObjectManifest } from '../scanner/types';
 import {
   DETERMINISTIC_GENERATED_AT,
   MANIFEST_TIMESTAMP,
+  type SmartObjectManifest,
 } from '../scanner/types.js';
 import type { SchemaDefinition } from '../schema/types.js';
 import { importWorkspaceModule } from '../utils/import-workspace-module.js';

--- a/packages/mcp-conformance-fixture/vitest.config.ts
+++ b/packages/mcp-conformance-fixture/vitest.config.ts
@@ -3,5 +3,16 @@ import { smrtVitestPlugin } from '../vitest/src/index.ts';
 
 export default defineConfig({
   plugins: [smrtVitestPlugin()],
-  test: { environment: 'node', testTimeout: 240_000 },
+  test: {
+    environment: 'node',
+    testTimeout: 240_000,
+    // The beforeAll hook generates the MCP server, spawns it through tsx, and
+    // waits for the HTTP endpoint to answer. That is comfortably under
+    // vitest's 10s hook default on an idle machine and reliably over it on a
+    // contended CI runner, where it fails as `Hook timed out in 10000ms` with
+    // every test reported as skipped. testTimeout was already raised for the
+    // same reason; hooks need the same treatment (30000 matches the other
+    // packages that hit this).
+    hookTimeout: 30_000,
+  },
 });

--- a/packages/scanner/src/manifest-adapter.ts
+++ b/packages/scanner/src/manifest-adapter.ts
@@ -157,8 +157,28 @@ interface SmartObjectDefinition {
   staticProperties?: Record<string, unknown>;
 }
 
+/**
+ * Fixed `timestamp` for generated manifests.
+ *
+ * The manifest this adapter returns is inlined verbatim into every package
+ * bundle by smrt-core's Vite plugin, so a wall-clock value changes the emitted
+ * bytes on every build. That changes Vite's content hash, which changes
+ * `dist/`, which invalidates every downstream package through Turbo's
+ * `dependsOn: ['^build']` — one rebuilt package churned 202 of 245 task
+ * hashes, and `typecheck` never reused a cache entry across runs (#2223).
+ *
+ * Nothing reads the field: manifest invalidation uses filesystem mtimes, and
+ * smrt-core's knowledge hashing deletes it before comparing.
+ *
+ * smrt-core declares the same constant as `MANIFEST_TIMESTAMP`; it is
+ * duplicated here rather than imported because this package deliberately does
+ * not depend on smrt-core.
+ */
+const MANIFEST_TIMESTAMP = 0;
+
 interface SmartObjectManifest {
   version: string;
+  /** Always {@link MANIFEST_TIMESTAMP}: build output must be reproducible. */
   timestamp: number;
   packageName?: string;
   packageVersion?: string;
@@ -355,7 +375,7 @@ export class ManifestAdapter {
 
     return {
       version: '1.0.0',
-      timestamp: Date.now(),
+      timestamp: MANIFEST_TIMESTAMP,
       packageName: options.packageName,
       packageVersion: options.packageVersion,
       objects,


### PR DESCRIPTION
## Summary

Two wall-clock values were baked into build output, so no two builds of the same source produced the same bytes.

The package manifest is inlined verbatim into every bundle by the Vite plugin — `registerPackageManifest(JSON.parse("{...\"timestamp\":1785938706903...}"))` — and the knowledge artifact written into `dist/` carries `generatedAt`. Both changed on every run, changing Vite's content hash and therefore the emitted chunk filenames and `dist/` itself.

- Manifests that can reach build output use a fixed `MANIFEST_TIMESTAMP`. Nothing reads the field: invalidation uses filesystem mtimes (`getManifestTimestampsHash`), and knowledge hashing deletes it before comparing (`normalizeManifestForHash`). The genuine runtime cache in `discover-smrt-packages.ts` still uses the clock — it never reaches build output.
- The knowledge artifact emitted into `dist/` uses a fixed `generatedAt`; the working copy under `.smrt/` keeps a real timestamp, where it is useful to a human and where `preserveKnowledgeGeneratedAt` already prevents churn. That preservation could never help `dist/`, because a fresh checkout has no previous file to carry a value forward from — exactly the CI case.
- `packages/scanner` declares its own copy of the constant rather than importing it, since it deliberately does not depend on smrt-core.

## Verification

Two forced builds of `packages/users`, tree-hashed:

| | before | after |
|---|---|---|
| build 1 | `19c47f75…` | `9898c100…` |
| build 2 | `793ae4f7…` | `9898c100…` |

Byte-identical after, different every time before. Core 3122 tests pass, scanner 197 pass. A new regression test pins both constants, asserts empty manifests serialize identically across calls, and asserts the timestamp survives a deliberate clock advance — so a `Date.now()` reintroduction fails the suite.

Two existing tests asserted `timestamp > 0`; they encoded the old behavior and now assert the new invariant.

## What this does not fix — and here is why

#2223 is that `typecheck` never reuses its cache across runs. Reproducible output is a prerequisite and independently correct, but measuring after this change, a rebuild still churns **202 of 245** task hashes. I traced the remaining root with `turbo --dry=json` per-file input hashes:

```
ROOT @happyvertical/smrt-core#build
  changed inputs: src/manifest/test-manifest.json,
                  src/manifest/test-manifest-stub.ts
```

Those are `generate:test` **outputs that live inside `src/`**, and `build.inputs` is `src/**`, so a build rewrites its own inputs. The content genuinely differs between writes — the file gains and loses test-only classes such as `@happyvertical/smrt-core:CliCmdWidget` (defined in `cli-commands.spec.ts`) depending on which producer wrote it last. `build` consumes a file produced by `generate:test` without declaring it as a dependency (`build dependsOn ['^build','generate']`).

That is a distinct defect needing a design decision — who owns `test-manifest.json`, or whether `build` should depend on `generate:test` — so it stays on #2223 rather than being guessed at here. Note the stub is statically imported by `test-manifest-loader.ts`, so simply excluding it from `build.inputs` would be wrong.

Closes #2232

## Review follow-up

Codex caught a real gap: the plugin path covers packages that build through `smrtPlugin`, but **core does not install that plugin** — its build runs `scripts/generate-manifest.js` and copies `src/manifest/smrt-knowledge.json` into `dist/`. That source file is gitignored, so on a fresh checkout `preserveGeneratedAtIfUnchanged` has nothing to carry forward and every build wrote a new wall-clock value. Reproduced by deleting the gitignored file: `18:20:43.203Z` then `18:20:50.615Z`. The script now emits the same fixed instant, and core's whole dist tree hashes identically across fresh builds (`ea430999…` twice).

Copilot's duplicate-specifier note is also fixed — one `../scanner/types.js` import with an inline `type` specifier.


## Drive-by fixes

- `packages/mcp-conformance-fixture/vitest.config.ts` — add `hookTimeout: 30_000`. The suite had raised `testTimeout` to 240s but left hooks at vitest's 10s default, while its `beforeAll` generates the MCP server, spawns it through `tsx`, and waits on the HTTP endpoint. It failed twice here as `Hook timed out in 10000ms` (both tests reported skipped) while passing locally — a latent gap that a contended fleet exposed. Included rather than deferred because the fixture is in the affected set for any change to core, so it blocks every such PR until fixed; `30000` matches the other packages that already hit this.

Refs #2223

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"67f1e3e5-cdcc-435f-88d7-babb2801e252","issue":"2232","policy_revision":"1.0.0","validation":["two forced builds of packages/users produce a byte-identical dist tree hash (9898c100...), verified repeatedly","packages/core: 3122 tests pass, 5 skipped","packages/scanner: 197 tests pass","typecheck clean on core and scanner; biome clean on all touched files","new regression test pins both constants and asserts stability across a clock advance","review fix: core dist tree hashes identically across fresh builds (ea430999) after covering the non-plugin generate-manifest.js path"]}
```



