### PR TITLE
fix(deps): stop Renovate bumping androidx past the compileSdk 36 pin

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,18 @@
       "matchFileNames": ["packages/*/template/package.json"],
       "matchPackageNames": ["@happyvertical/smrt-*"],
       "enabled": false
+    },
+    {
+      "description": "androidx.core 1.18+ and androidx.lifecycle 2.11+ require compileSdk 37, and both seed apps are pinned to compileSdk 36 (packages/smrt-android/AGENTS.md, and android-compile-sdk in each gradle/libs.versions.toml). The catalogs record that coupling in comments, which Renovate cannot read, so every weekly update bumped straight past it and left :sample:checkDebugAarMetadata failing on the whole PR (#2234). Remove these two rules in the same change that moves the toolchain to compileSdk 37.",
+      "matchManagers": ["gradle"],
+      "matchPackageNames": ["androidx.core:core-ktx"],
+      "allowedVersions": "<1.18"
+    },
+    {
+      "description": "See the androidx.core rule above — same compileSdk 36 coupling, androidx.lifecycle side (#2234).",
+      "matchManagers": ["gradle"],
+      "matchPackageNames": ["androidx.lifecycle:lifecycle-runtime-compose"],
+      "allowedVersions": "<2.11"
     }
   ]
 }


### PR DESCRIPTION
<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"8a94e288-0358-403f-a3a6-8e81a80e6c5d","issue":"2234","head_sha":"9689dd41c0716d4606ffa9dc55940078b87780bb","policy_revision":"1.0.0","status":"complete"}
```

## Summary

`smrt-android library + sample` fails on every weekly dependency PR because Renovate bumps
two Gradle versions past a constraint that `libs.versions.toml` records only in a comment:

```diff
 # 1.18+ requires compileSdk 37; the toolchain pin is compileSdk 36.
-core-ktx = "1.17.0"
+core-ktx = "1.19.0"
 # 2.11+ requires compileSdk 37; the toolchain pin is compileSdk 36.
-lifecycle = "2.10.0"
+lifecycle = "2.11.0"
```

`:sample:checkDebugAarMetadata` then fails with `Dependency 'androidx.core:core-ktx:1.19.0'
requires ... version 37 or later of the Android APIs. :sample is currently compiled against
android-36.` Renovate cannot read the comments, so this recurs weekly — it is currently red
on #2189.

## Change

Two `allowedVersions` rules in `renovate.json`, matched to exactly the two modules the
catalog declares (`androidx.core:core-ktx`, `androidx.lifecycle:lifecycle-runtime-compose`).
This mirrors how that file already encodes the starter-template pin: a `description` giving
the reason, so the rule can be removed deliberately rather than guessed at later.

## Why not raise compileSdk to 37

compileSdk 36 is an existing, recorded decision — `packages/smrt-android/AGENTS.md` states
the toolchain as "Gradle 9.6.1 / compileSdk 36 / minSdk 26 / JVM 21", and both catalogs pin
`android-compile-sdk = "36"`. Moving to 37 is the mobile owner's call and would need the CI
Android SDK platform to move with it. This PR only makes Renovate honour the decision that
is already made; the rules are removed in whichever change does raise the toolchain.

## Validation

- `renovate-config-validator` — `Config validated successfully against 1 file(s)`
- `node -e "JSON.parse(...)"` — valid JSON
- `biome check renovate.json` — path is ignored by the repo's Biome config, so no diagnostics apply
- Config-only change; no package or source code is touched, so no test suite is in scope

Closes #2234
