### PR TITLE
perf(ci): pin the light validation jobs to GitHub-hosted runners

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -46,13 +46,23 @@ never prevent the tests from running.
   omits the label so lint rejects it instead. If a node capability lane is ever
   activated again it needs a fresh, served label.
 - Lightweight lifecycle, policy, stale-management, and mobile jobs remain
-  GitHub-hosted when they do not benefit from a self-hosted cache. Aggregation
-  is not uniform: `required-ci` is hosted, but `test-packages-result` runs on
-  `arc-happyvertical-nodocker` even though it only reads `needs.*.result`. It
-  is capped at the standard rather than moved, because it backs a required
-  status.
-- Every self-hosted job in `test-suite.yml` and `publish-dry-run.yml`
-  selects its runner through the emergency lane selector
+  GitHub-hosted when they do not benefit from a self-hosted cache.
+- Three `test-suite.yml` jobs are pinned to a plain `ubuntu-latest`
+  permanently (#2236, phase 0 of happyvertical/iac#1349): `affected-scope`
+  (checkout plus a paths-filter), `lint` (Biome via `npx`, no workspace
+  install), and `test-packages-result` (no checkout at all — it reads
+  `needs.*.result` and exits). None runs a Turbo task or `setup-environment`,
+  so none can restore from the internal cache or the hosted shim, and the
+  fleet's memory is irrelevant to all three. On the fleet they could instead
+  wait out a netboot of up to 780 s, or queue behind the heavy shards on an
+  8-slot pool. Hosted minutes are free and unmetered on this public
+  repository, so the move costs nothing and returns the slots. This resolves
+  the aggregation asymmetry previously recorded here: `test-packages-result`
+  and `required-ci` are the same shape of job and are now on the same lane.
+  Backing a required status argues for starting promptly, not for queueing.
+- Every job in `test-suite.yml` that is still on the fleet, and every
+  self-hosted job in `publish-dry-run.yml`, selects its runner through the
+  emergency lane selector
   `${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || '<label>' }}`.
   Flipping that repository variable moves the merge-blocking validation path
   onto GitHub-hosted runners without a workflow merge — which would itself
@@ -60,9 +70,12 @@ never prevent the tests from running.
   aggregates jobs from both; a lever that moved only the test suite would
   leave the aggregator blocked on queued dry-run jobs. It is a manual
   lever, not a dispatcher; automated hosted fallback is tracked separately.
-  The release publish path, standalone build, and postgres jobs stay on the
-  self-hosted label and queue instead. actionlint does not validate labels
-  inside expressions, so the allowlist in `.github/actionlint.yaml` is
+  The three pinned jobs above carry no lever, and must not be given one: they
+  are already hosted, so a fallback has nothing to move them to, and an
+  expression with one reachable branch invites a reader to believe the other
+  is live. The release publish path, standalone build, and postgres jobs stay
+  on the self-hosted label and queue instead. actionlint does not validate
+  labels inside expressions, so the allowlist in `.github/actionlint.yaml` is
   unaffected. The variable selects only the runner: on `pull_request_target`
   events both main-scoped cache write paths stay closed — the Turbo shim
   refuses the event and the pnpm-store `actions/cache` step is skipped (see
@@ -181,11 +194,15 @@ These jobs deliberately sit below the standard, with the reason recorded next
 to the setting or here:
 
 - GitHub-hosted jobs that set a timeout (`dependency-audit` at 10,
-  `mobile.yml`'s two Linux Gradle jobs at 30). Hosted runners never enter the
+  `mobile.yml`'s two Linux Gradle jobs at 30, and `test-suite.yml`'s
+  `affected-scope` and `lint` at 10). Hosted runners never enter the
   self-hosted queue, so the fragility above does not apply and their values can
-  track observed runtime.
-- `required-ci`, which only reads `needs.*.result`. It finishes in seconds, so
-  failing fast is correct for a job that just reports other jobs' results.
+  track observed runtime. The last two came down from the 90-minute standard
+  when they were pinned to hosted (#2236); at 6 s and 18 s measured, ten
+  minutes is a hang guard rather than a capacity budget.
+- `required-ci` and `test-packages-result`, which only read `needs.*.result`.
+  Both finish in seconds, so failing fast is correct for a job that just
+  reports other jobs' results.
 
 `postgres-tests` is at the standard 45. #2164 retired the unserved
 `arc-happyvertical-node` label, deleted the `node-runner-smoke` workflow that
@@ -355,11 +372,13 @@ to `true`, PR validation re-resolved every job from the self-hosted label to
 | Coverage Gate | 5.8 min | 90 |
 | `validate-publish-shards` (two) | 1.3 and 1.4 min | 45 |
 | Affected build, typecheck, tests | 1.1 min | 90 |
-| Lint | 0.3 min | 90 |
+| Lint | 0.3 min | 10 |
+| `Detect Affected Validation Scope` | 0.1 min | 10 |
 
 Nothing approached a ceiling, and these are cold numbers: PR validation runs
 on `pull_request_target`, where the Turbo shim is refused, so no job restored
-from the hosted cache pool.
+from the hosted cache pool. The last two rows carry their post-#2236 ceilings;
+they were at the 90-minute standard when the rehearsal ran.
 
 Two limits on what that rehearsal proves. It exercised the pull-request path
 in `affected` mode, not a `merge_group` run in `full` mode, so the six
@@ -367,3 +386,32 @@ in `affected` mode, not a `merge_group` run in `full` mode, so the six
 lever is repository-wide: flipping it moves every open pull request, not only
 the one being tested. Re-measure with a full merge-group transit before
 treating hosted as an equivalent lane rather than an emergency one.
+
+### Phase 0 hosted pinning (#2236)
+
+Those rehearsal numbers are the baseline for pinning `affected-scope`, `lint`,
+and `test-packages-result` to hosted permanently (Runner selection, above).
+The rehearsal measured them as a *fallback*; the pinning makes the same
+placement the steady state, so the per-job durations should reproduce and are
+not the interesting result.
+
+The interesting result is the second-order one: three jobs per validation pass
+stop taking a slot on an 8-slot fleet, which should show up as reduced queue
+wait for the heavy shards rather than as faster light jobs. Record after
+merge, comparing ten runs either side:
+
+| measure | before | after |
+| --- | --- | --- |
+| `Lint` duration | 0.3 min hosted (rehearsal) / fleet baseline TBD | |
+| `Detect Affected Validation Scope` duration | 0.1 min hosted (rehearsal) / fleet baseline TBD | |
+| `test-packages-result` duration | fleet baseline TBD | |
+| `test-core` shard queue wait (p50/p95) | | |
+| `test-packages` shard queue wait (p50/p95) | | |
+| `Required CI` wall clock, `merge_group` | | |
+
+Queue wait is the gap between a job's `createdAt` and `startedAt`, which
+`timeout-minutes` never governs — see Job timeouts. If the heavy shards' wait
+does not improve, the freed slots were not the binding constraint and the
+capacity oracle in phases 1-2 of happyvertical/iac#1349 is the next lever, not
+a wider pinning. Rollback is per-job and independent: restore the lever
+expression and the 90-minute standard on any job that regresses.

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -22,19 +22,23 @@ jobs:
   affected-scope:
     name: Detect Affected Validation Scope
     if: inputs.mode == 'affected'
-    # Emergency lane selector, used on every self-hosted job in this file:
-    # flipping the repository variable CI_HOSTED_FALLBACK_ENABLED to 'true'
-    # moves validation to GitHub-hosted runners without a workflow merge —
-    # which would itself need the down fleet. Automated dispatch is a later
-    # issue; this is the manual lever. The variable is owner controlled and
-    # selects only the runner; the Turbo cache shim in setup-environment
-    # additionally refuses pull_request_target events, so PR-head code never
-    # writes the main-scoped hosted cache pool. Fallback PR validation
-    # therefore builds cold, while merge-group and main runs restore
-    # build/generate:test/typecheck seeded by turbo-cache-seed.yml. Rehearse
-    # before relying on it; see the Hosted Turbo cache section of CI.md.
-    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
-    timeout-minutes: 90
+    # Permanently GitHub-hosted (#2236, happyvertical/iac#1349 phase 0). This
+    # job is a checkout plus a paths-filter — no Turbo task, no dependency
+    # install, no contact with either the internal cache or the hosted shim —
+    # so the metal fleet offers it nothing, while a cold node there can make it
+    # wait out a netboot of up to 780s. Measured at 6s hosted on the full
+    # rehearsal (run 30969467329).
+    #
+    # Deliberately a plain label rather than the CI_HOSTED_FALLBACK_ENABLED
+    # selector the metal jobs below carry: a lever that can only ever resolve
+    # to ubuntu-latest reads as a choice when there is none, and this job needs
+    # no fleet-outage escape hatch because it never depends on the fleet.
+    runs-on: ubuntu-latest
+    # Hosted jobs never enter the self-hosted queue, so the queue-wait
+    # fragility behind the 90-minute standard does not apply and the ceiling
+    # can track observed runtime (see Job timeouts in CI.md). Ten minutes is a
+    # hang guard against a stuck checkout, not a capacity budget.
+    timeout-minutes: 10
     outputs:
       knowledge: ${{ steps.filter.outputs.knowledge }}
     steps:
@@ -63,6 +67,21 @@ jobs:
   build:
     name: Build
     if: inputs.mode == 'full'
+    # Emergency lane selector, used on every job in this file that is still on
+    # the fleet: flipping the repository variable CI_HOSTED_FALLBACK_ENABLED to
+    # 'true' moves validation to GitHub-hosted runners without a workflow merge
+    # — which would itself need the down fleet. Automated dispatch is a later
+    # issue; this is the manual lever. The variable is owner controlled and
+    # selects only the runner; the Turbo cache shim in setup-environment
+    # additionally refuses pull_request_target events, so PR-head code never
+    # writes the main-scoped hosted cache pool. Fallback PR validation
+    # therefore builds cold, while merge-group and main runs restore
+    # build/generate:test/typecheck seeded by turbo-cache-seed.yml. Rehearse
+    # before relying on it; see the Hosted Turbo cache section of CI.md.
+    #
+    # The jobs pinned to a plain ubuntu-latest (affected-scope, lint,
+    # test-packages-result) are outside this lever by design — they are already
+    # hosted, so there is nothing for a fallback to move (#2236).
     runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
     timeout-minutes: 90
 
@@ -172,8 +191,16 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
-    timeout-minutes: 90
+    # Permanently GitHub-hosted (#2236, happyvertical/iac#1349 phase 0). Biome
+    # arrives through `npx` and the job deliberately never runs the workspace
+    # install, so there is no Turbo task and no pnpm store to warm — the metal
+    # fleet's memory and internal cache are both irrelevant here. Measured at
+    # 18s hosted on the full rehearsal (run 30969467329). See the note on the
+    # `build` job for why this carries no fallback lever.
+    runs-on: ubuntu-latest
+    # Hosted; ceiling tracks observed runtime rather than the self-hosted
+    # queue-wait standard (Job timeouts, CI.md).
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository
@@ -552,9 +579,20 @@ jobs:
   test-packages-result:
     name: Test Packages
     needs: test-packages
-    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
+    # Permanently GitHub-hosted (#2236, happyvertical/iac#1349 phase 0). This
+    # job does no checkout and no setup — it reads needs.test-packages.result
+    # and exits — so holding a slot on an 8-slot fleet bought nothing, and a
+    # busy fleet could delay a required status by the length of a netboot.
+    # CI.md previously recorded this as an unresolved asymmetry against the
+    # already-hosted `required-ci`, which is structurally the same job; the two
+    # now match. Backing a required status is a reason to make it start
+    # promptly, not a reason to queue it. See the note on `build` for why this
+    # carries no fallback lever.
+    runs-on: ubuntu-latest
     if: always() && inputs.mode == 'full'
-    timeout-minutes: 90
+    # Same reasoning as required-ci: this finishes in seconds, so failing fast
+    # is correct for a job that only reports other jobs' results.
+    timeout-minutes: 5
     steps:
       - name: Verify all Test Packages shards passed
         run: |


### PR DESCRIPTION
Phase 0 of happyvertical/iac#1349 for this repository: reserve the metal fleet
for the jobs that actually benefit from it.

## What moves

Three `test-suite.yml` jobs get a plain `runs-on: ubuntu-latest`:

| job | why it gains nothing from metal | hosted, measured |
| --- | --- | --- |
| `affected-scope` (`Detect Affected Validation Scope`) | checkout + `dorny/paths-filter`; no Turbo task, no install | **6 s** |
| `lint` (`Lint`) | Biome via `npx`; deliberately never runs the workspace install | **18 s** |
| `test-packages-result` (`Test Packages`) | no checkout and no setup at all — reads `needs.*.result` and exits | seconds (`required-ci` is the same shape, 3 s) |

Measurements are from the full hosted rehearsal
([run 30969467329](https://github.com/happyvertical/smrt/actions/runs/30969467329)),
cold and cacheless — that run was on `pull_request_target`, where the Turbo
shim is refused, so nothing restored.

None of the three invokes `setup-environment`, so none can restore from the
internal Turbo cache or the hosted shim, and the fleet's memory is irrelevant
to all of them. On the fleet they could instead wait out a netboot of up to
780 s or queue behind the heavy shards on an 8-slot pool. smrt is public, so
hosted minutes are free and unmetered: the move costs nothing and returns
three slots per validation pass.

## Mechanics

- Pinned jobs take a **plain label, not a lever**. An expression that can only
  ever resolve to `ubuntu-latest` reads as a choice when there is none, and
  these jobs need no fleet-outage escape hatch because they never depend on the
  fleet.
- The `CI_HOSTED_FALLBACK_ENABLED` lever **stays intact on all ten jobs that
  remain on metal**. Its shared explanation moved from `affected-scope` to
  `build`, the first job in the file that still carries it.
- Job names are byte-identical to main, so the sole required context
  (`Required CI`) and the two lifecycle rulesets are unaffected.
- `.github/actionlint.yaml` needs no change — actionlint does not validate
  labels inside expressions.
- Timeouts come down with the jobs, per CI.md's existing rule that hosted
  ceilings may track observed runtime because hosted runners never enter the
  self-hosted queue: 10 min for the two that check out, 5 for the aggregator
  (matching `required-ci`).

This also resolves an asymmetry CI.md recorded as unfinished business:
`test-packages-result` sat on metal while `required-ci` — structurally the
same job — was hosted. Backing a required status argues for starting promptly,
not for queueing.

## ONNX: a non-issue for this set

`setup-environment` installs ONNX system deps via `sudo apt-get` when
`CI_ONNX_DEPS_READY` is unset (the hosted case), costing 1-2 min per job. That
is a real lever, but **none of these three jobs invokes that composite action
at all**, so there is no `install-deps: 'false'` to apply here. Recorded so the
next hosted move of a job that *does* use it starts from the right place.

## Deliberately not moved

- `test-core` ×3, `test-packages` ×3, Coverage Gate, Build, Typecheck — the
  warm internal Turbo cache and the larger machines matter there, and their
  hosted duration under `merge_group` `full` mode has **never been measured**.
  The epic tracks measuring that separately; they must not move on assumption.
- `postgres-tests.yml` stays on `arc-happyvertical` — its `services:` container
  needs the dind lane.
- `publish-dry-run.yml`'s `publish-dry-run-summary` (8 s hosted) is a
  legitimate candidate, deferred: #2217 rewrites the `if:` immediately above
  its `runs-on`, and after that PR the job runs only in the merge group. Noted
  on #2236 to revisit rather than race #2217 for the same lines. This PR
  touches no file #2217 touches at overlapping hunks.

## When this first executes

`on-pull-request.yml` uses `pull_request_target`, so **this PR's own checks run
against main's YAML** — with these jobs still on metal. The pinned selection
first executes in the merge queue. That is expected, not a gap; it is also why
a mistake here would eject from the queue rather than redden the PR.

## Validation

- `actionlint .github/workflows/test-suite.yml` — clean
- `yamllint .github/workflows/test-suite.yml` — clean
- `node scripts/publish-workflow-policy.test.mjs` — 1 pass, 0 fail
- `pnpm smrt dev:knowledge-check` — `✓ SMRT knowledge is fresh`, 0 errors, 0
  warnings
- Runner split verified mechanically: 3 plain `ubuntu-latest`, 10 lever
  expressions remaining, job names diffed identical against `origin/main`
- Independent `codex review` could not run — the account is out of credits
  until Aug 7. Covered by own review, the GitHub auto-reviewers, and CI.

## Follow-up

`.github/CI.md` carries an empty before/after table under **Phase 0 hosted
pinning**, to be filled after merge with the moved jobs' durations and — the
result that actually matters — whether the heavy shards' queue wait improved
from the freed slots. If it did not, the freed slots were not the binding
constraint, and the capacity oracle in phases 1-2 of the epic is the next
lever rather than a wider pinning.

Closes #2236
Refs happyvertical/iac#1349

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"524cd2c5-11c6-450e-b137-756d97181723","issue":"2236","policy_revision":"1.0.0","validation":["actionlint clean on .github/workflows/test-suite.yml","yamllint clean on .github/workflows/test-suite.yml","node scripts/publish-workflow-policy.test.mjs: 1 pass 0 fail","pnpm smrt dev:knowledge-check: SMRT knowledge is fresh, 0 errors 0 warnings","runner split verified: 3 plain ubuntu-latest, 10 CI_HOSTED_FALLBACK_ENABLED lever expressions remaining","job names diffed byte-identical against origin/main, so the required context Required CI is unaffected","repo confirmed public, so the free-hosted-minutes premise holds","hosted durations sourced from measured run 30969467329, not estimated","codex review unavailable (account out of credits until Aug 7); covered by own review, GitHub auto-reviewers, and CI"]}
```
