### PR TITLE
fix(ci): bound the mcp-conformance-fixture beforeAll with hookTimeout

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -3,6 +3,9 @@
 ### Required Setup
 `vitest.config.ts` MUST include `smrtVitestPlugin()` in plugins array. Without it: "No field metadata" errors.
 
+### Timeouts
+Never set `testTimeout` without also setting `hookTimeout` — hooks do NOT inherit it and stay on vitest's 10s default. Symptom: the file fails with "Hook timed out in 10000ms" while every test reports *skipped*. Budget for where the work happens: setup that spawns processes or generates code is bounded by `hookTimeout`, not `testTimeout`.
+
 ### Database
 - Use real in-memory SQLite for SmrtObject/SmrtCollection tests
 - `createIsolatedTestDb()` for transaction-isolated tests (rolls back on cleanup)

--- a/TESTING_STANDARD.md
+++ b/TESTING_STANDARD.md
@@ -138,6 +138,31 @@ No field metadata found for 'Document'.
 
 **Note on watch mode**: The manifest is generated once at vitest startup. If you add new classes or fields while vitest is running in watch mode, restart vitest to pick up the changes.
 
+### ⚠️ Never raise `testTimeout` without raising `hookTimeout`
+
+`testTimeout` and `hookTimeout` are independent. Raising only `testTimeout`
+leaves every `beforeAll`/`beforeEach`/`afterAll`/`afterEach` on vitest's **10s
+default**, so a slow hook fails the whole file while the test bodies report as
+*skipped* — a failure mode that looks nothing like a timeout in the test you
+were budgeting for.
+
+```typescript
+test: {
+  testTimeout: 30000,
+  hookTimeout: 30000, // match testTimeout; hooks do not inherit it
+}
+```
+
+This has bitten the repo repeatedly: smrt-svelte's teardown hook (#1426), and
+`mcp-conformance-fixture`, whose `beforeAll` generates a server and spawns two
+`tsx` children — it measured 10,022ms against the 10,000ms default and ejected
+a PR from the merge queue (#2238). Packages run in shared CI shards, so a hook
+that overruns takes unrelated PRs down with it.
+
+Budget by **where the work happens**, not by where the assertions are: if setup
+does the expensive work (spawning processes, generating code, building
+bundles), `hookTimeout` is the limit that matters.
+
 ### Watch Mode
 
 ```bash

--- a/packages/mcp-conformance-fixture/vitest.config.ts
+++ b/packages/mcp-conformance-fixture/vitest.config.ts
@@ -3,5 +3,16 @@ import { smrtVitestPlugin } from '../vitest/src/index.ts';
 
 export default defineConfig({
   plugins: [smrtVitestPlugin()],
-  test: { environment: 'node', testTimeout: 240_000 },
+  test: {
+    environment: 'node',
+    testTimeout: 240_000,
+    // Match testTimeout. Nearly all of this suite's work happens in `beforeAll`,
+    // not in the test bodies: it regenerates the MCP server with `MCPGenerator`,
+    // spawns a `tsx` child over stdio to negotiate the protocol and list tools,
+    // then spawns a second `tsx` child for the HTTP adapter. Left at vitest's
+    // 10s `hookTimeout` default that hook measured 10,022ms on a loaded runner
+    // and ejected PR #2230 from the merge queue (#2238). This package sits in
+    // the shared `test-packages` shard, so the miss was not local to that PR.
+    hookTimeout: 240_000,
+  },
 });


### PR DESCRIPTION
## Summary

`packages/mcp-conformance-fixture/vitest.config.ts` set `testTimeout: 240_000`
but no `hookTimeout`, so its `beforeAll` ran against vitest's **10s default** —
hooks do not inherit `testTimeout`. On a loaded runner that hook measured
10,022ms and ejected PR #2230 from the merge queue.

The fix is `hookTimeout: 240_000` alongside the existing `testTimeout`, matching
the repo's prevailing "match testTimeout" convention (smrt-svelte, ads, chat,
cli, content, …; core goes higher at 60s/120s; bundle-gate is the one package
that deliberately diverges).

## The diagnosis was verified, not assumed

Everything that could have been supplying a bound was ruled out:

- The hook takes **no per-hook timeout argument** (`beforeAll(async () => {…})`).
- `vitest.workspace.ts` is a **re-export shim, not a vitest workspace config** —
  it exports `smrtVitestPlugin` and a setup path. There is no root vitest config.
- `smrtVitestPlugin` sets no timeouts (the only `Timeout` hits in
  `packages/vitest/src` are two `setTimeout` sleeps in `test-db.ts`).
- CI passes no timeout flag or env: the package's `test` script is a bare
  `vitest run`, invoked through turbo.

Two positive reproductions, both against the **unmodified** hook:

| probe | result |
|---|---|
| `vitest run --hookTimeout=1` | `Error: Hook timed out in 1ms.` — 1 file failed, **2 tests skipped** |
| probe config with `hookTimeout: 1` | same failure |

That is the CI signature exactly (`Hook timed out in 10000ms`, 1 failed, 2
skipped), and the second probe confirms the **config-level** option is the
operative one, not just the CLI flag.

## Why the hook, and not the tests, is the expensive part

`beforeAll` does essentially all of the suite's work — slightly more than the
issue described, since it spawns **two** `tsx` children, not one:

1. `rm -rf` + `mkdir` the generated dir
2. `MCPGenerator.generateServer()`
3. spawn `tsx` over stdio → connect `Client` → negotiate `2026-07-28` → `listTools`
4. `startHttpAdapter()` → spawn a second `tsx` for the HTTP adapter

The two test bodies only issue requests against what the hook already built:
**25ms and 192ms** locally, against a 240s budget. Locally the hook is ~1.94s of
the 2.16s total; CI's >10s means roughly 5x amplification under load, which is
ordinary for a shard runner spawning child processes.

## Blast radius

The fixture is `private: true` but has a `test` script, and
`scripts/test-packages-shard.mjs` excludes only `smrt-core` — so it runs in the
shared `test-packages` shard. The 22ms margin was never local to #2230: any PR
in the merge queue could hit it, after a full merge-group validation cycle had
already been spent.

## Sibling sweep — none affected

33 of 58 `vitest.config.ts` files set `testTimeout` without `hookTimeout`, but
the omission only matters where a **hook** does heavy work. Only three packages
have process-spawning or generation code anywhere in their test files, and in
all three it sits in test bodies rather than hooks:

| package | hook does | measured | budget |
|---|---|---|---|
| `smrt-app-mcp` | in-process `createHttpServer` + `listen(0)` | conformance test **189ms** | 15s |
| `smrt-dev-mcp` | in-process `createHttpServer` + `listen(0)` | conformance test **622ms** | 30s |
| `tenancy` | in-memory sqlite seed (`generateServer` is inside `it()` bodies) | — | 30s |

Their hooks are tens of milliseconds; even 100x CI amplification stays far under
the 10s default. No sibling needs this fix, so the change stays at one package.

## Documentation

The issue notes this trap is "worth a line in the testing conventions if it bites
a third time" — it has (smrt-svelte teardown in #1426, then #2220, now this), so
it is recorded in `TESTING_STANDARD.md` and `.claude/rules/testing.md`. The
signature is worth naming because it is misleading: the file fails while every
test body reports as **skipped**, so it does not read as a timeout in the test
you were budgeting for.

## Validation

- `@happyvertical/smrt-mcp-conformance-fixture` full suite: **2 files/2 tests
  passed**, 3.26s (transform 376ms, import 845ms, tests 2.33s)
- `tsc --noEmit` green for the fixture package
- `pnpm smrt dev:knowledge-check`: **fresh, 0 errors, 0 warnings**
- `pnpm check:agents-chain`: 65 chains under the 32,768-byte cap (the two
  >80% warnings, `packages/users` and `packages/chat`, are pre-existing and
  untouched here)
- `biome check` on the three touched paths: all three are ignored by
  `biome.json` (a vitest config and two markdown files), so there is nothing for
  it to lint
- `git status` clean apart from the three intended files; `git diff-tree` on the
  commit confirms exactly those three

Closes #2238

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"claude","session":"53e2c43c-41e2-4f9f-a63a-996baed10afd","issue":"2238","policy_revision":"1.0.0","status":"complete","validation":["mcp-conformance-fixture full suite: 2 files / 2 tests passed in 3.26s","tsc --noEmit green for the fixture package","diagnosis reproduced twice on the unmodified hook: --hookTimeout=1 and a probe config with hookTimeout:1 both yield the CI signature (1 failed, 2 skipped)","ruled out per-hook argument, root/workspace config, smrtVitestPlugin, and CI flags as alternative sources of the bound","sibling sweep of 33 testTimeout-without-hookTimeout configs: only smrt-app-mcp (189ms/15s), smrt-dev-mcp (622ms/30s), tenancy spawn or generate, and all do so in test bodies, not hooks","pnpm smrt dev:knowledge-check fresh (0 errors, 0 warnings)","pnpm check:agents-chain: 65 chains under cap"]}
