### PR TITLE
fix(mcp-conformance-fixture): set hookTimeout to match testTimeout

### DIFF
--- a/packages/mcp-conformance-fixture/vitest.config.ts
+++ b/packages/mcp-conformance-fixture/vitest.config.ts
@@ -3,5 +3,12 @@ import { smrtVitestPlugin } from '../vitest/src/index.ts';
 
 export default defineConfig({
   plugins: [smrtVitestPlugin()],
-  test: { environment: 'node', testTimeout: 240_000 },
+  // hookTimeout matches testTimeout because this suite's expensive work is in
+  // beforeAll, not in the tests: it generates the MCP server, spawns `tsx` on
+  // the generated TypeScript for the stdio transport, completes a protocol
+  // handshake, and then spawns the HTTP adapter as a second process. The `it`
+  // blocks only POST to that already-running adapter. Left at vitest's 10s
+  // default the hook aborted at 10067ms on a contended runner, reporting both
+  // tests as skipped and taking unrelated PRs down with it (#2240).
+  test: { environment: 'node', testTimeout: 240_000, hookTimeout: 240_000 },
 });


### PR DESCRIPTION
<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"8a94e288-0358-403f-a3a6-8e81a80e6c5d","issue":"2240","head_sha":"8451eac142f993640ee0e4d512596b1cd141e40d","policy_revision":"1.0.0","status":"complete"}
```

## Summary

`packages/mcp-conformance-fixture` had `testTimeout: 240_000` but no `hookTimeout`, so its
`beforeAll` ran against vitest's **10 s default**. That is backwards for this suite — the
expensive work is entirely in the hook:

| | work |
|---|---|
| `beforeAll` | generate the MCP server, spawn `tsx` on the generated TypeScript (stdio transport), complete a protocol handshake with `listTools` assertions, then spawn the HTTP adapter as a **second** process |
| each `it` | one `fetch` POST to the already-running adapter |

So the cheap half held the 240 s budget and the heavy half held none.

## Impact

This is nondeterministic and it failed PRs that have nothing to do with MCP:

- **#2230** (`feat(fields)`) was admitted to the merge queue and then **ejected** by this in
  `test-packages (2/3)` — which is why it silently reverted to CLEAN with no visible cause.
- **#2231** (`fix(core,scanner)`) went red on `Validate Changes / Affected Build, Typecheck, and Tests`
  with the identical failure.

Both showed:

```
❯ src/generated-server-conformance.test.ts (2 tests | 2 skipped) 10067ms
Error: Hook timed out in 10000ms.
  ❯ src/generated-server-conformance.test.ts:27:1
```

67 ms over the line, both tests **skipped** — the failure carried no signal about the code
under test. Because the merge queue runs `mode: full` while the PR lane runs `mode: affected`,
a PR could sit at CLEAN and still be ejected on queue entry.

## Why match `testTimeout` rather than pick 30 s

The repo's usual value is `hookTimeout: 30000` (with `60_000` in `bundle-gate`), but those
hooks do not spawn two `tsx` processes. Matching the value this package already declares for
the same workload avoids inventing a third number, and the hook runs once per suite so there
is no cost to the headroom. It only relaxes a limit — it cannot mask a failure, since an
actually-hung spawn still fails, just later.

## Validation

- `pnpm --filter @happyvertical/smrt-mcp-conformance-fixture test` — **2 passed**, 3.32 s total
  on an idle machine, confirming the hook is normally fast and the 10 s default was marginal
  only under CI contention rather than covering a real hang
- `npx turbo build --filter=@happyvertical/smrt-mcp-conformance-fixture...` — 6/6 successful
- `biome check` — the path is ignored by the repo's Biome config, so no diagnostics apply
- Single-file test-config change; no runtime or source code is touched

Related: #2220 is the same class (permission tests marginal against their timeout, failing the
merge queue nondeterministically).

Closes #2240
