### PR TITLE
perf(ci): unblock the validation lane — occupancy, hosted light jobs, fixture hookTimeout

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -3,6 +3,9 @@
 ### Required Setup
 `vitest.config.ts` MUST include `smrtVitestPlugin()` in plugins array. Without it: "No field metadata" errors.
 
+### Timeouts
+Never set `testTimeout` without also setting `hookTimeout` — hooks do NOT inherit it and stay on vitest's 10s default. Symptom: the file fails with "Hook timed out in 10000ms" while every test reports *skipped*. Budget for where the work happens: setup that spawns processes or generates code is bounded by `hookTimeout`, not `testTimeout`.
+
 ### Database
 - Use real in-memory SQLite for SmrtObject/SmrtCollection tests
 - `createIsolatedTestDb()` for transaction-isolated tests (rolls back on cleanup)

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -75,9 +75,9 @@ the trusted base branch rather than contributor-controlled merge YAML. It passes
 a PR head SHA to reusable general-CI workflows only when the head repository
 equals `github.repository`; merge-group and trusted push workflows use the
 broker normally. External fork PRs keep a base-revision hosted control-plane
-check, while the self-hosted validation and publish-dry-run calls are skipped
-and `Required CI` rejects the run. Broker admission must also deny those fork
-events before making a reservation.
+check, while the self-hosted validation call is skipped and `Required CI`
+rejects the run on that skipped result. Broker admission must also deny those
+fork events before making a reservation.
 
 `CI_NODE_RUNNER_ENABLED` is gone from this tree — nothing reads it, and the
 migration it was conditioned on is live. If the repository still defines the
@@ -222,19 +222,34 @@ reversal lever.
 
 - Unset/false: PRs run the historical full suite.
 - `true`: PRs run lint, affected typecheck and tests across the changed
-  packages and everything that depends on them, touched coverage, and — only
-  when knowledge-sensitive paths change — affected knowledge freshness. The
+  packages and everything that depends on them, and — only when
+  knowledge-sensitive paths change — affected knowledge freshness. The
   complete suite runs for `merge_group`.
 
-Publish dry-run sits outside that split: it runs for same-repository PRs and for
-`merge_group` in both modes. No lane in `on-pull-request.yml` or
-`test-suite.yml` runs PostgreSQL in either mode; PostgreSQL lives only in
-`postgres-tests.yml`, described below.
+Coverage Gate and Publish Dry Run are merge-group only (#2214 items 4 and 8).
+Both used to run in both lanes while the merge group re-ran them in full
+regardless, so the PR copies were duplicate fleet occupancy rather than the
+binding gate — and Coverage Gate additionally paid a cold full build on PRs,
+because the seed `build` job is full-mode only. Neither loses meaning in the
+merge group: `check-coverage.mjs` resolves its diff base as `BASE_REF || 'main'`
+plus `merge-base`, which is correct for the synthetic merge-group head. The
+trade is that a coverage or packaging regression now ejects from the queue
+instead of reddening the PR; authors can pre-check coverage locally with
+`node scripts/check-coverage.mjs --packages <list>`.
 
-`Required CI` is the sole required repository-validation status. Its aggregator
-requires the same eight jobs to succeed for both PR and merge-group events; what
-differs between the two is the mode `test-suite.yml` runs in, not the set of
-jobs the aggregator checks.
+Publish Dry Run's gate lives inside `publish-dry-run.yml`, not on its caller.
+Every reusable or self-hosted job in `on-pull-request.yml` must carry the
+canonical trusted-base admission expression byte-for-byte, so narrowing a lane
+from the caller's `if:` is not available — gate the called workflow instead.
+
+No lane in `on-pull-request.yml` or `test-suite.yml` runs PostgreSQL in either
+mode; PostgreSQL lives only in `postgres-tests.yml`, described below.
+
+`Required CI` is the sole required repository-validation status. Seven jobs must
+succeed for both PR and merge-group events; Publish Dry Run is required only for
+`merge_group`, where it runs. The aggregator still fails if it reports anything
+other than `skipped` or `success` on a PR, so re-enabling it there cannot
+silently leave it un-gated.
 
 Rollout status:
 

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -46,13 +46,23 @@ never prevent the tests from running.
   omits the label so lint rejects it instead. If a node capability lane is ever
   activated again it needs a fresh, served label.
 - Lightweight lifecycle, policy, stale-management, and mobile jobs remain
-  GitHub-hosted when they do not benefit from a self-hosted cache. Aggregation
-  is not uniform: `required-ci` is hosted, but `test-packages-result` runs on
-  `arc-happyvertical-nodocker` even though it only reads `needs.*.result`. It
-  is capped at the standard rather than moved, because it backs a required
-  status.
-- Every self-hosted job in `test-suite.yml` and `publish-dry-run.yml`
-  selects its runner through the emergency lane selector
+  GitHub-hosted when they do not benefit from a self-hosted cache.
+- Three `test-suite.yml` jobs are pinned to a plain `ubuntu-latest`
+  permanently (#2236, phase 0 of happyvertical/iac#1349): `affected-scope`
+  (checkout plus a paths-filter), `lint` (Biome via `npx`, no workspace
+  install), and `test-packages-result` (no checkout at all — it reads
+  `needs.*.result` and exits). None runs a Turbo task or `setup-environment`,
+  so none can restore from the internal cache or the hosted shim, and the
+  fleet's memory is irrelevant to all three. On the fleet they could instead
+  wait out a netboot of up to 780 s, or queue behind the heavy shards on an
+  8-slot pool. Hosted minutes are free and unmetered on this public
+  repository, so the move costs nothing and returns the slots. This resolves
+  the aggregation asymmetry previously recorded here: `test-packages-result`
+  and `required-ci` are the same shape of job and are now on the same lane.
+  Backing a required status argues for starting promptly, not for queueing.
+- Every job in `test-suite.yml` that is still on the fleet, and every
+  self-hosted job in `publish-dry-run.yml`, selects its runner through the
+  emergency lane selector
   `${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || '<label>' }}`.
   Flipping that repository variable moves the merge-blocking validation path
   onto GitHub-hosted runners without a workflow merge — which would itself
@@ -60,9 +70,12 @@ never prevent the tests from running.
   aggregates jobs from both; a lever that moved only the test suite would
   leave the aggregator blocked on queued dry-run jobs. It is a manual
   lever, not a dispatcher; automated hosted fallback is tracked separately.
-  The release publish path, standalone build, and postgres jobs stay on the
-  self-hosted label and queue instead. actionlint does not validate labels
-  inside expressions, so the allowlist in `.github/actionlint.yaml` is
+  The three pinned jobs above carry no lever, and must not be given one: they
+  are already hosted, so a fallback has nothing to move them to, and an
+  expression with one reachable branch invites a reader to believe the other
+  is live. The release publish path, standalone build, and postgres jobs stay
+  on the self-hosted label and queue instead. actionlint does not validate
+  labels inside expressions, so the allowlist in `.github/actionlint.yaml` is
   unaffected. The variable selects only the runner: on `pull_request_target`
   events both main-scoped cache write paths stay closed — the Turbo shim
   refuses the event and the pnpm-store `actions/cache` step is skipped (see
@@ -181,11 +194,15 @@ These jobs deliberately sit below the standard, with the reason recorded next
 to the setting or here:
 
 - GitHub-hosted jobs that set a timeout (`dependency-audit` at 10,
-  `mobile.yml`'s two Linux Gradle jobs at 30). Hosted runners never enter the
+  `mobile.yml`'s two Linux Gradle jobs at 30, and `test-suite.yml`'s
+  `affected-scope` and `lint` at 10). Hosted runners never enter the
   self-hosted queue, so the fragility above does not apply and their values can
-  track observed runtime.
-- `required-ci`, which only reads `needs.*.result`. It finishes in seconds, so
-  failing fast is correct for a job that just reports other jobs' results.
+  track observed runtime. The last two came down from the 90-minute standard
+  when they were pinned to hosted (#2236); at 6 s and 18 s measured, ten
+  minutes is a hang guard rather than a capacity budget.
+- `required-ci` and `test-packages-result`, which only read `needs.*.result`.
+  Both finish in seconds, so failing fast is correct for a job that just
+  reports other jobs' results.
 
 `postgres-tests` is at the standard 45. #2164 retired the unserved
 `arc-happyvertical-node` label, deleted the `node-runner-smoke` workflow that
@@ -378,11 +395,13 @@ to `true`, PR validation re-resolved every job from the self-hosted label to
 | Coverage Gate | 5.8 min | 90 |
 | `validate-publish-shards` (two) | 1.3 and 1.4 min | 45 |
 | Affected build, typecheck, tests | 1.1 min | 90 |
-| Lint | 0.3 min | 90 |
+| Lint | 0.3 min | 10 |
+| `Detect Affected Validation Scope` | 0.1 min | 10 |
 
 Nothing approached a ceiling, and these are cold numbers: PR validation runs
 on `pull_request_target`, where the Turbo shim is refused, so no job restored
-from the hosted cache pool.
+from the hosted cache pool. The last two rows carry their post-#2236 ceilings;
+they were at the 90-minute standard when the rehearsal ran.
 
 Two limits on what that rehearsal proves. It exercised the pull-request path
 in `affected` mode, not a `merge_group` run in `full` mode, so the six
@@ -390,3 +409,32 @@ in `affected` mode, not a `merge_group` run in `full` mode, so the six
 lever is repository-wide: flipping it moves every open pull request, not only
 the one being tested. Re-measure with a full merge-group transit before
 treating hosted as an equivalent lane rather than an emergency one.
+
+### Phase 0 hosted pinning (#2236)
+
+Those rehearsal numbers are the baseline for pinning `affected-scope`, `lint`,
+and `test-packages-result` to hosted permanently (Runner selection, above).
+The rehearsal measured them as a *fallback*; the pinning makes the same
+placement the steady state, so the per-job durations should reproduce and are
+not the interesting result.
+
+The interesting result is the second-order one: three jobs per validation pass
+stop taking a slot on an 8-slot fleet, which should show up as reduced queue
+wait for the heavy shards rather than as faster light jobs. Record after
+merge, comparing ten runs either side:
+
+| measure | before | after |
+| --- | --- | --- |
+| `Lint` duration | 0.3 min hosted (rehearsal) / fleet baseline TBD | |
+| `Detect Affected Validation Scope` duration | 0.1 min hosted (rehearsal) / fleet baseline TBD | |
+| `test-packages-result` duration | fleet baseline TBD | |
+| `test-core` shard queue wait (p50/p95) | | |
+| `test-packages` shard queue wait (p50/p95) | | |
+| `Required CI` wall clock, `merge_group` | | |
+
+Queue wait is the gap between a job's `createdAt` and `startedAt`, which
+`timeout-minutes` never governs — see Job timeouts. If the heavy shards' wait
+does not improve, the freed slots were not the binding constraint and the
+capacity oracle in phases 1-2 of happyvertical/iac#1349 is the next lever, not
+a wider pinning. Rollback is per-job and independent: restore the lever
+expression and the 90-minute standard on any job that regresses.

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -242,6 +242,14 @@ Every reusable or self-hosted job in `on-pull-request.yml` must carry the
 canonical trusted-base admission expression byte-for-byte, so narrowing a lane
 from the caller's `if:` is not available — gate the called workflow instead.
 
+Both gates key off `CI_MERGE_QUEUE_ENABLED`, not off the event alone, because
+clearing that variable is the documented rollback lever and it stops GitHub
+producing `merge_group` events at all. Coverage Gate gets this for free: the
+caller's `mode` expression falls back to `full` on the same lever, so it runs on
+PRs again. Publish Dry Run tests the lever explicitly — without it, a rollback
+would leave packaging unvalidated all the way into `publish.yml`, since
+`on-merge-main.yml` runs test and build but never a pack validation.
+
 No lane in `on-pull-request.yml` or `test-suite.yml` runs PostgreSQL in either
 mode; PostgreSQL lives only in `postgres-tests.yml`, described below.
 

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -401,6 +401,10 @@ jobs:
 
   publish-dry-run:
     name: Publish Dry Run
+    # This gate is the canonical trusted-base self-hosted admission expression
+    # and must stay byte-identical — `hv-agent check-pr` requires every reusable
+    # or self-hosted job in this workflow to carry it, so the merge-queue-only
+    # narrowing for #2214 item 4 lives inside publish-dry-run.yml instead.
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request_target' &&
@@ -443,11 +447,29 @@ jobs:
           DEPENDENCY_AUDIT: ${{ needs.dependency-audit.result }}
           TEST_SUITE: ${{ needs.test.result }}
           PUBLISH_DRY_RUN: ${{ needs.publish-dry-run.result }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          for result in "$VALIDATE_COMMITS" "$VALIDATE_WORKFLOWS" "$CHECK_SDK" "$SECRET_SCAN" "$CHECK_STANDARDS" "$DEPENDENCY_AUDIT" "$TEST_SUITE" "$PUBLISH_DRY_RUN"; do
+          for result in \
+            "$VALIDATE_COMMITS" "$VALIDATE_WORKFLOWS" "$CHECK_SDK" \
+            "$SECRET_SCAN" "$CHECK_STANDARDS" "$DEPENDENCY_AUDIT" \
+            "$TEST_SUITE"; do
             if [ "$result" != success ]; then
               echo "::error::full validation did not succeed"
               exit 1
             fi
           done
+
+          # Publish Dry Run is merge-queue only (#2214 item 4), so it reports
+          # `skipped` on a pull request. Require success where it actually runs,
+          # and still fail here if it somehow ran and failed on a PR — accepting
+          # any result outright would silently un-gate it if it is re-enabled.
+          if [ "$EVENT_NAME" = merge_group ]; then
+            if [ "$PUBLISH_DRY_RUN" != success ]; then
+              echo "::error::publish dry run did not succeed in the merge group"
+              exit 1
+            fi
+          elif [ "$PUBLISH_DRY_RUN" != skipped ] && [ "$PUBLISH_DRY_RUN" != success ]; then
+            echo "::error::publish dry run reported '$PUBLISH_DRY_RUN' on a pull request"
+            exit 1
+          fi

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -27,9 +27,19 @@ jobs:
     # it in full regardless, so the per-PR copy was duplicate occupancy rather
     # than the binding gate. The gate lives here rather than on the caller's
     # `if:`, which must stay byte-identical to the canonical trusted-base
-    # admission expression. Negating pull_request_target (rather than testing
-    # for merge_group) keeps the workflow_dispatch escape hatch working.
-    if: github.event_name != 'pull_request_target'
+    # admission expression.
+    #
+    # Skip ONLY when the merge queue will re-run it. Clearing
+    # CI_MERGE_QUEUE_ENABLED is the documented rollback lever, and it stops
+    # GitHub producing merge_group events entirely — gating on the event alone
+    # would leave packaging unvalidated all the way into publish.yml, since
+    # on-merge-main.yml runs test and build but never a pack validation. This
+    # mirrors the caller's `mode` expression, which falls back to full
+    # validation on the same lever. Testing the event rather than merge_group
+    # also keeps the workflow_dispatch escape hatch working.
+    if: >-
+      github.event_name != 'pull_request_target' ||
+      vars.CI_MERGE_QUEUE_ENABLED != 'true'
     # Emergency lane selector: publish dry run backs the required aggregator in
     # the merge queue, so it must move with the CI_HOSTED_FALLBACK_ENABLED lever
     # or a fleet outage would keep Required CI blocked despite the fallback. See
@@ -224,7 +234,10 @@ jobs:
     # `always()` alone would keep this summary running — and failing on the
     # missing artifacts — after the two jobs above skip on a pull request, so it
     # carries the same lane guard (#2214 item 4).
-    if: always() && github.event_name != 'pull_request_target'
+    if: >-
+      always() &&
+      (github.event_name != 'pull_request_target' ||
+      vars.CI_MERGE_QUEUE_ENABLED != 'true')
     runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
     timeout-minutes: 45
 

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -22,10 +22,18 @@ permissions:
 jobs:
   prepare-publish:
     name: Prepare Publish Validation
-    # Emergency lane selector: publish dry run backs the required aggregator,
-    # so it must move with the CI_HOSTED_FALLBACK_ENABLED lever or a fleet
-    # outage would keep Required CI blocked despite the fallback. See the
-    # selector comment in test-suite.yml and the Hosted Turbo cache section
+    # Skip the pull-request lane (#2214 item 4). This is a full-tree build plus
+    # a two-shard pack validation on the metal fleet, and the merge group re-ran
+    # it in full regardless, so the per-PR copy was duplicate occupancy rather
+    # than the binding gate. The gate lives here rather than on the caller's
+    # `if:`, which must stay byte-identical to the canonical trusted-base
+    # admission expression. Negating pull_request_target (rather than testing
+    # for merge_group) keeps the workflow_dispatch escape hatch working.
+    if: github.event_name != 'pull_request_target'
+    # Emergency lane selector: publish dry run backs the required aggregator in
+    # the merge queue, so it must move with the CI_HOSTED_FALLBACK_ENABLED lever
+    # or a fleet outage would keep Required CI blocked despite the fallback. See
+    # the selector comment in test-suite.yml and the Hosted Turbo cache section
     # of CI.md.
     runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
     timeout-minutes: 45
@@ -213,7 +221,10 @@ jobs:
     needs:
       - prepare-publish
       - validate-publish-shards
-    if: always()
+    # `always()` alone would keep this summary running — and failing on the
+    # missing artifacts — after the two jobs above skip on a pull request, so it
+    # carries the same lane guard (#2214 item 4).
+    if: always() && github.event_name != 'pull_request_target'
     runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
     timeout-minutes: 45
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -480,60 +480,35 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           auth-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # smrt-video loads the full SMRT manifest graph. When it runs near the end
-      # of shard 2 beside another Turbo task, constrained ARC runners can kill
-      # its otherwise passing Vitest fork. Run it first through Turbo so a fresh
-      # runner builds its dependency closure, then exclude it from the general
-      # batch so coverage remains exactly once.
-      - name: Run video package tests in isolation
-        if: matrix.shard == '2/3'
-        run: pnpm turbo run test --concurrency=1 --filter='@happyvertical/smrt-video'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_ENV: test
-          VITEST_MAX_WORKERS: '1'
-          # Node sizes its default old-space from HOST memory, and this runner
-          # exposes the whole host (see the CPU note below), so V8 will happily
-          # grow a fork past the container's own limit and the kernel kills it —
-          # surfacing as Vitest's silent `Worker exited unexpectedly` with no
-          # `JavaScript heap out of memory`. Cap the heap so V8 collects instead
-          # of ballooning. This BOUNDS the fork; it does not give it more room.
-          NODE_OPTIONS: --max-old-space-size=4096
-
-      # smrt-voice pulls the same heavy AI/SQL graph as smrt-video and dies the
-      # same way inside the concurrent batch, where it shares the runner with a
-      # second Turbo task. Give it the treatment already proven for video: run
-      # it first, alone, with a dedicated heap, then exclude it below so
-      # coverage still happens exactly once.
-      - name: Run voice package tests in isolation
-        if: matrix.shard == '1/3'
-        run: pnpm turbo run test --concurrency=1 --filter='@happyvertical/smrt-voice'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_ENV: test
-          VITEST_MAX_WORKERS: '1'
-          NODE_OPTIONS: --max-old-space-size=4096
-
-      # Each shard runs ~1/3 of the remaining non-core packages
+      # Each shard runs ~1/3 of the non-core packages
       # (scripts/test-packages-shard.mjs round-robins by name), keeping
-      # per-runner load low so transient resource-pressure timing flakes stay
-      # rare.
-      - name: Run package tests (shard ${{ matrix.shard }}, excluding core, video and voice)
+      # per-runner load low.
+      #
+      # smrt-video and smrt-voice used to run here as isolated pre-steps with a
+      # dedicated heap, then were excluded from this batch. That was a
+      # workaround for silent `Worker exited unexpectedly` deaths attributed to
+      # memory pressure. The attribution was wrong: the failing shards recorded
+      # cgroup `oom_kill = 0`, and the real cause was an AVX2 SIGILL in
+      # @happyvertical/pdf on x86-64-v2 metal, fixed by the 0.65.9 guard
+      # (#2195/#2196). The isolation is removed with the cause (#2214 item 6);
+      # the shard script already round-robins both packages onto these same two
+      # runners (voice -> 1/3, video -> 2/3), so placement is unchanged.
+      - name: Run package tests (shard ${{ matrix.shard }}, excluding core)
         run: |
           set -o pipefail
           node scripts/test-packages-shard.mjs '${{ matrix.shard }}' |
-            xargs -r pnpm turbo run test --concurrency=2 \
-              --filter='!@happyvertical/smrt-video' \
-              --filter='!@happyvertical/smrt-voice'
+            xargs -r pnpm turbo run test --concurrency=2
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_ENV: test
-          # The node runner exposes all 32 host CPUs. Cap each of the two
-          # concurrent Turbo tasks so Vitest cannot fan out to dozens of workers.
+          # The node runner exposes all 32 host CPUs while the pod holds a
+          # 4-CPU quota, so uncapped Vitest over-fans. Cap each of the two
+          # concurrent Turbo tasks.
           VITEST_MAX_WORKERS: '2'
-          # Same host-vs-container heap mismatch as the video step above, halved
-          # because two Turbo tasks run concurrently here. smrt-voice pulls the
-          # heavy AI/SQL graph and has been dying the same silent way.
+          # Node likewise sizes its default old-space from host memory, so bound
+          # the heap explicitly rather than letting a fork grow against the
+          # pod's limit. Halved from a single-task budget because two Turbo
+          # tasks run concurrently here.
           NODE_OPTIONS: --max-old-space-size=2048
 
       - name: Upload test results

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -526,8 +526,10 @@ jobs:
       # cgroup `oom_kill = 0`, and the real cause was an AVX2 SIGILL in
       # @happyvertical/pdf on x86-64-v2 metal, fixed by the 0.65.9 guard
       # (#2195/#2196). The isolation is removed with the cause (#2214 item 6);
-      # the shard script already round-robins both packages onto these same two
-      # runners (voice -> 1/3, video -> 2/3), so placement is unchanged.
+      # both packages now shard like every other one. Do not record which shard
+      # they land on: the script sorts all testable packages and assigns
+      # `index % n`, so every assignment shifts whenever a package is added or
+      # removed anywhere in the workspace.
       - name: Run package tests (shard ${{ matrix.shard }}, excluding core)
         run: |
           set -o pipefail

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -22,19 +22,23 @@ jobs:
   affected-scope:
     name: Detect Affected Validation Scope
     if: inputs.mode == 'affected'
-    # Emergency lane selector, used on every self-hosted job in this file:
-    # flipping the repository variable CI_HOSTED_FALLBACK_ENABLED to 'true'
-    # moves validation to GitHub-hosted runners without a workflow merge —
-    # which would itself need the down fleet. Automated dispatch is a later
-    # issue; this is the manual lever. The variable is owner controlled and
-    # selects only the runner; the Turbo cache shim in setup-environment
-    # additionally refuses pull_request_target events, so PR-head code never
-    # writes the main-scoped hosted cache pool. Fallback PR validation
-    # therefore builds cold, while merge-group and main runs restore
-    # build/generate:test/typecheck seeded by turbo-cache-seed.yml. Rehearse
-    # before relying on it; see the Hosted Turbo cache section of CI.md.
-    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
-    timeout-minutes: 90
+    # Permanently GitHub-hosted (#2236, happyvertical/iac#1349 phase 0). This
+    # job is a checkout plus a paths-filter — no Turbo task, no dependency
+    # install, no contact with either the internal cache or the hosted shim —
+    # so the metal fleet offers it nothing, while a cold node there can make it
+    # wait out a netboot of up to 780s. Measured at 6s hosted on the full
+    # rehearsal (run 30969467329).
+    #
+    # Deliberately a plain label rather than the CI_HOSTED_FALLBACK_ENABLED
+    # selector the metal jobs below carry: a lever that can only ever resolve
+    # to ubuntu-latest reads as a choice when there is none, and this job needs
+    # no fleet-outage escape hatch because it never depends on the fleet.
+    runs-on: ubuntu-latest
+    # Hosted jobs never enter the self-hosted queue, so the queue-wait
+    # fragility behind the 90-minute standard does not apply and the ceiling
+    # can track observed runtime (see Job timeouts in CI.md). Ten minutes is a
+    # hang guard against a stuck checkout, not a capacity budget.
+    timeout-minutes: 10
     outputs:
       knowledge: ${{ steps.filter.outputs.knowledge }}
     steps:
@@ -63,6 +67,21 @@ jobs:
   build:
     name: Build
     if: inputs.mode == 'full'
+    # Emergency lane selector, used on every job in this file that is still on
+    # the fleet: flipping the repository variable CI_HOSTED_FALLBACK_ENABLED to
+    # 'true' moves validation to GitHub-hosted runners without a workflow merge
+    # — which would itself need the down fleet. Automated dispatch is a later
+    # issue; this is the manual lever. The variable is owner controlled and
+    # selects only the runner; the Turbo cache shim in setup-environment
+    # additionally refuses pull_request_target events, so PR-head code never
+    # writes the main-scoped hosted cache pool. Fallback PR validation
+    # therefore builds cold, while merge-group and main runs restore
+    # build/generate:test/typecheck seeded by turbo-cache-seed.yml. Rehearse
+    # before relying on it; see the Hosted Turbo cache section of CI.md.
+    #
+    # The jobs pinned to a plain ubuntu-latest (affected-scope, lint,
+    # test-packages-result) are outside this lever by design — they are already
+    # hosted, so there is nothing for a fallback to move (#2236).
     runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
     timeout-minutes: 90
 
@@ -172,8 +191,16 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
-    timeout-minutes: 90
+    # Permanently GitHub-hosted (#2236, happyvertical/iac#1349 phase 0). Biome
+    # arrives through `npx` and the job deliberately never runs the workspace
+    # install, so there is no Turbo task and no pnpm store to warm — the metal
+    # fleet's memory and internal cache are both irrelevant here. Measured at
+    # 18s hosted on the full rehearsal (run 30969467329). See the note on the
+    # `build` job for why this carries no fallback lever.
+    runs-on: ubuntu-latest
+    # Hosted; ceiling tracks observed runtime rather than the self-hosted
+    # queue-wait standard (Job timeouts, CI.md).
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository
@@ -535,9 +562,20 @@ jobs:
   test-packages-result:
     name: Test Packages
     needs: test-packages
-    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
+    # Permanently GitHub-hosted (#2236, happyvertical/iac#1349 phase 0). This
+    # job does no checkout and no setup — it reads needs.test-packages.result
+    # and exits — so holding a slot on an 8-slot fleet bought nothing, and a
+    # busy fleet could delay a required status by the length of a netboot.
+    # CI.md previously recorded this as an unresolved asymmetry against the
+    # already-hosted `required-ci`, which is structurally the same job; the two
+    # now match. Backing a required status is a reason to make it start
+    # promptly, not a reason to queue it. See the note on `build` for why this
+    # carries no fallback lever.
+    runs-on: ubuntu-latest
     if: always() && inputs.mode == 'full'
-    timeout-minutes: 90
+    # Same reasoning as required-ci: this finishes in seconds, so failing fast
+    # is correct for a job that only reports other jobs' results.
+    timeout-minutes: 5
     steps:
       - name: Verify all Test Packages shards passed
         run: |

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -298,7 +298,16 @@ jobs:
   coverage-gate:
     name: Coverage Gate
     needs: build
-    if: always() && (inputs.mode == 'affected' || needs.build.result == 'success')
+    # Full-mode only (#2214 item 8). This used to run in both lanes, and in
+    # affected mode the seed `build` job is skipped, so it paid a cold full
+    # build before it could measure anything — 26-45 min against 4-5 min on a
+    # warm cache. The merge group re-ran it in full immediately afterwards, so
+    # the affected copy bought nothing but occupancy. check-coverage.mjs
+    # resolves its base as `BASE_REF || 'main'` plus merge-base, which is
+    # correct for the merge_group synthetic head, so the gate keeps its full
+    # meaning here. Authors keep the local pre-check:
+    #   node scripts/check-coverage.mjs --packages <list>
+    if: inputs.mode == 'full'
     runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
     timeout-minutes: 90
 
@@ -339,10 +348,9 @@ jobs:
       # PR #2102. Measured turbo selections from that base:
       #   [sha]     -> 2 packages      ...[sha] -> 53 packages
       #   [sha]...  -> 2 packages      scanner... -> 1 package
-      # setup-environment restores the build job's per-SHA Turbo cache, so in
-      # full mode this is a cache hit. In affected mode the `build` job is
-      # skipped (`build.if: mode == full`), so this can be a cold build; that
-      # cost is accepted because correctness of the gate comes first.
+      # setup-environment restores the build job's per-SHA Turbo cache, and this
+      # job runs only after `build` has seeded it, so this is a cache hit rather
+      # than a rebuild.
       - name: Build packages
         run: pnpm run build
         env:

--- a/TESTING_STANDARD.md
+++ b/TESTING_STANDARD.md
@@ -138,6 +138,31 @@ No field metadata found for 'Document'.
 
 **Note on watch mode**: The manifest is generated once at vitest startup. If you add new classes or fields while vitest is running in watch mode, restart vitest to pick up the changes.
 
+### ⚠️ Never raise `testTimeout` without raising `hookTimeout`
+
+`testTimeout` and `hookTimeout` are independent. Raising only `testTimeout`
+leaves every `beforeAll`/`beforeEach`/`afterAll`/`afterEach` on vitest's **10s
+default**, so a slow hook fails the whole file while the test bodies report as
+*skipped* — a failure mode that looks nothing like a timeout in the test you
+were budgeting for.
+
+```typescript
+test: {
+  testTimeout: 30000,
+  hookTimeout: 30000, // match testTimeout; hooks do not inherit it
+}
+```
+
+This has bitten the repo repeatedly: smrt-svelte's teardown hook (#1426), and
+`mcp-conformance-fixture`, whose `beforeAll` generates a server and spawns two
+`tsx` children — it measured 10,022ms against the 10,000ms default and ejected
+a PR from the merge queue (#2238). Packages run in shared CI shards, so a hook
+that overruns takes unrelated PRs down with it.
+
+Budget by **where the work happens**, not by where the assertions are: if setup
+does the expensive work (spawning processes, generating code, building
+bundles), `hookTimeout` is the limit that matters.
+
 ### Watch Mode
 
 ```bash


### PR DESCRIPTION
<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"8a94e288-0358-403f-a3a6-8e81a80e6c5d","issue":"2214","head_sha":"547f6aabf15d4f0380eb2b02dfb5f699aea69e89","policy_revision":"1.0.0","status":"complete"}
```

## Why this is one PR

The CI lane is the thing blocking every other PR, and the fixes for it were spread across
three PRs that each needed a full validation pass on the very lane they were trying to unclog
— and two of them edit the same file. Consolidating them means one validation pass and one
merge, at the front of the queue, after which everything else can drain normally.

Supersedes #2217, #2237 and #2239, all closed in favour of this branch. Commits are preserved
by `git cherry-pick` with their original authors.

| commits | from | closes |
| --- | --- | --- |
| `c1261fd` `fd8d622` `3a2dd46` `41bac73` `48af5e9` | #2217 | #2214 |
| `7ed30a3` | #2237 | #2236 |
| `9e8558a` | #2239 | #2238 |

## What lands

**Stop paying for work the merge group repeats (#2214).** Coverage Gate becomes full-mode
only; Publish Dry Run runs only where it actually gates — it skips the pull-request lane but
*not* when `CI_MERGE_QUEUE_ENABLED` is cleared, since that lever stops `merge_group` events
entirely and packaging would otherwise reach `publish.yml` unvalidated. The smrt-video/voice
test isolation steps are dropped. The required aggregator now demands success in the merge
group and tolerates only `skipped` on a PR, so re-enabling the job cannot silently un-gate it.

**Get the light jobs off the metal fleet (#2236).** `affected-scope`, `lint` and
`test-packages-result` pin to `ubuntu-latest` — a paths-filter, Biome via `npx`, and a job
that only reads `needs.*.result`. None touches the workspace install.

**Stop the class of hook timeout recurring (#2238).** The `mcp-conformance-fixture` config fix
landed independently on `main` via #2231 while this PR was open, so **that hunk is gone and
this branch takes main's `hookTimeout: 30_000` unchanged** — the value is main's call, not
re-litigated here. What remains is the part still missing from the repo: the rule itself, in
`.claude/rules/testing.md` and `TESTING_STANDARD.md`. Hooks do not inherit `testTimeout`, and
nothing said so, which is why the same bug was fixed three separate times in one afternoon
(#2238, #2239, #2240) after already hitting smrt-svelte's teardown in #1426.

## Conflict resolution

#2217 and #2237 both edit `.github/workflows/test-suite.yml` and `.github/CI.md`. The result is
the union of both intents, verified job by job rather than assumed:

- the three light jobs are hosted, per #2236
- every heavy job keeps the `CI_HOSTED_FALLBACK_ENABLED` selector
- `coverage-gate` keeps **#2217's** narrowed `if: inputs.mode == 'full'`. #2237 branched before
  that landed and still carried the old `always() && (inputs.mode == 'affected' || …)` form.

Rebased onto `main` after #2231 merged; the only conflict was the fixture config described
above, resolved in main's favour.

## Validation

- `actionlint` on all three changed workflows — clean, exit 0
- All three workflows parse via `js-yaml`; the job/`if`/`runs-on` matrix was diffed against both
  source branches to confirm neither PR's intent was dropped in the merge, and re-checked after
  the rebase
- `packages/mcp-conformance-fixture/vitest.config.ts` is byte-identical to `main`
- No conflict markers in the diff; `.github/CI.md` has no duplicated headings and its prose
  matches the resulting job placement

The workflow changes here are validated by `main`'s YAML under `pull_request_target`, so they
first execute in the merge queue — expected for this class of change.

Closes #2214
Closes #2236
Closes #2238
