### PR TITLE
fix(app-cli): give the suite explicit test and hook timeouts

### DIFF
--- a/packages/app-cli/vitest.config.ts
+++ b/packages/app-cli/vitest.config.ts
@@ -7,5 +7,14 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     pool: 'forks',
+    // bridge.test.ts spawns `tsx` on a fixture through StdioClientTransport and
+    // completes an MCP handshake before it asserts anything. On vitest's 5s
+    // default that passed locally and on the affected lane, then timed out
+    // three times in the merge queue — where `mode: full` actually runs this
+    // package — and ejected an unrelated PR (#2243). 30000 matches the value
+    // used across the rest of the workspace.
+    testTimeout: 30000,
+    // Hooks do not inherit testTimeout; see TESTING_STANDARD.md.
+    hookTimeout: 30000,
   },
 });


### PR DESCRIPTION
<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"8a94e288-0358-403f-a3a6-8e81a80e6c5d","issue":"2243","head_sha":"82b1abd2a9b597d387262b35feb5d91b36bdedb8","policy_revision":"1.0.0","status":"complete"}
```

## Summary

`packages/app-cli/vitest.config.ts` declared no `testTimeout`, so the suite ran on vitest's
**5 s default**. `src/__tests__/bridge.test.ts > runMcpStdioBridge` is not a 5 s test — it spawns
`tsx` on a fixture through `StdioClientTransport` and completes an MCP handshake before it
asserts anything.

## Impact

Load-sensitive, so it passes on the PR lane and fails in the merge queue, where `mode: full`
actually runs this package. A PR sits at CLEAN and is then **ejected on queue entry** by a
failure in a package it never touched:

```
FAIL src/__tests__/bridge.test.ts > runMcpStdioBridge > negotiates MCP 2026-07-28 …  (×3 retries)
Error: Test timed out in 5000ms.
Tests  1 failed | 105 passed (106)
```

That ejected #2242 — a CI-only change of workflow YAML plus two docs files — after it had
already spent a full validation cycle.

## Change

Both budgets set explicitly at `30000`, the value used by 45 other packages in the workspace.
`hookTimeout` is set alongside `testTimeout` per the rule that landed in #2242: hooks do not
inherit it.

This is the third instance of one defect class in a day — `mcp-conformance-fixture`
(`hookTimeout` at the 10 s default, fixed three times over in #2238/#2239/#2240), `app-cli`
here, and `users` in #2220. A sweep for suites that spawn processes on default budgets is
worth doing separately.

## Validation

Config-only change to test budgets; it relaxes limits and cannot mask a failure, since a
genuinely hung spawn still fails, just later. The merge-queue run exercises the fix directly,
because that is the lane where this package's tests actually execute.

Closes #2243
