### PR TITLE
feat(fields): headless form primitives (FieldPolicyProvider, PolicyField, help)

### DIFF
--- a/packages/fields/ambient.d.ts
+++ b/packages/fields/ambient.d.ts
@@ -1,0 +1,6 @@
+declare module '*.svelte' {
+  import type { Component } from 'svelte';
+
+  const component: Component<Record<string, any>>;
+  export default component;
+}

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -15,12 +15,22 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./svelte": {
+      "types": "./dist/svelte/index.d.ts",
+      "svelte": "./dist/svelte/index.js",
+      "import": "./dist/svelte/index.js"
+    },
     "./manifest": "./dist/manifest.json",
-    "./manifest.json": "./dist/manifest.json"
+    "./manifest.json": "./dist/manifest.json",
+    "./playground": {
+      "types": "./dist/playground.d.ts",
+      "import": "./dist/playground.js"
+    }
   },
   "scripts": {
-    "build": "vite build --mode library",
+    "build": "vite build --mode library && svelte-package -i src/svelte -o dist/svelte --tsconfig tsconfig.svelte.json",
     "build:watch": "vite build --mode library --watch",
+    "check": "svelte-check --tsconfig ./tsconfig.svelte.json",
     "clean": "rm -rf dist",
     "dev": "vite dev",
     "prepack": "node ../../scripts/prepack-package.js",
@@ -29,16 +39,30 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."
   },
+  "peerDependencies": {
+    "svelte": "^5.56.4"
+  },
+  "peerDependenciesMeta": {
+    "svelte": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@happyvertical/smrt-core": "workspace:*",
     "@happyvertical/smrt-tenancy": "workspace:*",
+    "@happyvertical/smrt-ui": "workspace:*",
     "@happyvertical/sql": "catalog:"
   },
   "devDependencies": {
     "@happyvertical/smrt-cli": "workspace:*",
     "@happyvertical/smrt-users": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",
+    "@sveltejs/package": "^2.5.8",
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "@testing-library/svelte": "^5.4.2",
     "@types/node": "24.13.2",
+    "svelte": "^5.56.4",
+    "svelte-check": "^4.7.1",
     "typescript": "5.9.3",
     "vite": "8.1.4",
     "vitest": "4.1.10"

--- a/packages/fields/src/playground.ts
+++ b/packages/fields/src/playground.ts
@@ -1,0 +1,1 @@
+export { default } from './svelte/playground.js';

--- a/packages/fields/src/svelte/__tests__/FormHelp.test.ts
+++ b/packages/fields/src/svelte/__tests__/FormHelp.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+/**
+ * Component tests for FormHelp (#2048).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it } from 'vitest';
+import type { ResolvedObjectFieldPolicy } from '../../types.js';
+import FieldPolicyProvider from '../components/FieldPolicyProvider.svelte';
+import FormHelp from '../components/FormHelp.svelte';
+import FormHelpFixture from './fixtures/FormHelpFixture.svelte';
+
+function makePolicy(): ResolvedObjectFieldPolicy {
+  return {
+    objectRef: '@test:Widget',
+    fields: {
+      name: {
+        fieldName: 'name',
+        hasDefault: false,
+        defaultValue: undefined,
+        visibility: 'basic',
+        help: 'The display name for this widget',
+        label: 'Name',
+        order: 2,
+        group: null,
+        locked: false,
+        required: true,
+      },
+      sku: {
+        fieldName: 'sku',
+        hasDefault: true,
+        defaultValue: 'W-001',
+        visibility: 'basic',
+        help: 'Stock keeping unit code',
+        label: 'SKU',
+        order: 1,
+        group: null,
+        locked: false,
+        required: false,
+      },
+      hidden: {
+        fieldName: 'hidden',
+        hasDefault: false,
+        defaultValue: undefined,
+        visibility: 'hidden',
+        help: 'Should not appear in glossary',
+        label: 'Hidden',
+        order: 3,
+        group: null,
+        locked: false,
+        required: false,
+      },
+    },
+  };
+}
+
+describe('FormHelp', () => {
+  it('renders a help toggle button', () => {
+    render(FormHelpFixture, {
+      props: { policy: makePolicy() },
+    });
+
+    expect(screen.getByText('Help')).toBeInTheDocument();
+  });
+
+  it('shows glossary entries when expanded', async () => {
+    render(FormHelpFixture, {
+      props: { policy: makePolicy() },
+    });
+
+    // Open the help panel
+    await userEvent.click(screen.getByText('Help'));
+
+    expect(
+      screen.getByText('The display name for this widget'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Stock keeping unit code')).toBeInTheDocument();
+  });
+
+  it('excludes hidden-tier fields from the glossary', async () => {
+    render(FormHelpFixture, {
+      props: { policy: makePolicy() },
+    });
+
+    await userEvent.click(screen.getByText('Help'));
+
+    expect(
+      screen.queryByText('Should not appear in glossary'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows object description when provided', async () => {
+    render(FormHelpFixture, {
+      props: {
+        policy: makePolicy(),
+        objectDescription: 'A widget is a configurable thing.',
+      },
+    });
+
+    await userEvent.click(screen.getByText('Help'));
+
+    expect(
+      screen.getByText('A widget is a configurable thing.'),
+    ).toBeInTheDocument();
+  });
+
+  it('orders glossary by resolved order (SKU before Name)', async () => {
+    render(FormHelpFixture, {
+      props: { policy: makePolicy() },
+    });
+
+    await userEvent.click(screen.getByText('Help'));
+
+    const terms = screen.getAllByRole('term');
+    expect(terms[0]).toHaveTextContent('SKU');
+    expect(terms[1]).toHaveTextContent('Name');
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(FormHelpFixture, {
+      props: { policy: makePolicy() },
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('is axe-clean when expanded', async () => {
+    const { container } = render(FormHelpFixture, {
+      props: { policy: makePolicy() },
+    });
+    await userEvent.click(screen.getByText('Help'));
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/fields/src/svelte/__tests__/FormHelp.test.ts
+++ b/packages/fields/src/svelte/__tests__/FormHelp.test.ts
@@ -42,6 +42,18 @@ function makePolicy(): ResolvedObjectFieldPolicy {
         locked: false,
         required: false,
       },
+      wholesalePrice: {
+        fieldName: 'wholesalePrice',
+        hasDefault: false,
+        defaultValue: undefined,
+        visibility: 'advanced',
+        help: 'Price for wholesale customers',
+        label: 'Wholesale Price',
+        order: 4,
+        group: null,
+        locked: false,
+        required: false,
+      },
       hidden: {
         fieldName: 'hidden',
         hasDefault: false,
@@ -91,6 +103,36 @@ describe('FormHelp', () => {
     expect(
       screen.queryByText('Should not appear in glossary'),
     ).not.toBeInTheDocument();
+  });
+
+  it('excludes advanced-tier fields from the glossary in basic mode', async () => {
+    // The glossary mirrors PolicyField visibility: advanced-tier fields are
+    // not visible in basic mode, so their help must not be listed either.
+    render(FormHelpFixture, {
+      props: { policy: makePolicy(), mode: 'basic' },
+    });
+
+    await userEvent.click(screen.getByText('Help'));
+
+    expect(
+      screen.queryByText('Price for wholesale customers'),
+    ).not.toBeInTheDocument();
+    // Basic-tier entries still present.
+    expect(
+      screen.getByText('The display name for this widget'),
+    ).toBeInTheDocument();
+  });
+
+  it('includes advanced-tier fields in the glossary in advanced mode', async () => {
+    render(FormHelpFixture, {
+      props: { policy: makePolicy(), mode: 'advanced' },
+    });
+
+    await userEvent.click(screen.getByText('Help'));
+
+    expect(
+      screen.getByText('Price for wholesale customers'),
+    ).toBeInTheDocument();
   });
 
   it('shows object description when provided', async () => {

--- a/packages/fields/src/svelte/__tests__/ModeUX.test.ts
+++ b/packages/fields/src/svelte/__tests__/ModeUX.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+/**
+ * Component tests for ModeSwitch and AdvancedFields (#2048).
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { tick } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import type { ResolvedObjectFieldPolicy } from '../../types.js';
+import AdvancedFields from '../components/AdvancedFields.svelte';
+import FieldPolicyProvider from '../components/FieldPolicyProvider.svelte';
+import ModeSwitch from '../components/ModeSwitch.svelte';
+import AdvancedFieldsFixture from './fixtures/AdvancedFieldsFixture.svelte';
+import ModeSwitchFixture from './fixtures/ModeSwitchFixture.svelte';
+
+function makePolicy(): ResolvedObjectFieldPolicy {
+  return {
+    objectRef: '@test:Widget',
+    fields: {
+      name: {
+        fieldName: 'name',
+        hasDefault: false,
+        defaultValue: undefined,
+        visibility: 'basic',
+        help: 'Name',
+        label: 'Name',
+        order: 1,
+        group: null,
+        locked: false,
+        required: true,
+      },
+      secretKey: {
+        fieldName: 'secretKey',
+        hasDefault: false,
+        defaultValue: undefined,
+        visibility: 'advanced',
+        help: 'Secret key',
+        label: 'Secret Key',
+        order: 2,
+        group: null,
+        locked: false,
+        required: false,
+      },
+      another: {
+        fieldName: 'another',
+        hasDefault: false,
+        defaultValue: undefined,
+        visibility: 'advanced',
+        help: 'Another',
+        label: 'Another',
+        order: 3,
+        group: null,
+        locked: false,
+        required: false,
+      },
+    },
+  };
+}
+
+describe('ModeSwitch', () => {
+  it('renders basic and advanced options', () => {
+    render(ModeSwitchFixture, { props: { policy: makePolicy() } });
+
+    // SegmentedControl renders as a radiogroup with radio options
+    expect(
+      screen.getByRole('radiogroup', { name: 'View mode' }),
+    ).toBeInTheDocument();
+  });
+
+  it('switching to advanced reveals advanced fields', async () => {
+    render(ModeSwitchFixture, { props: { policy: makePolicy() } });
+
+    expect(
+      screen.queryByRole('textbox', { name: /Secret Key/ }),
+    ).not.toBeInTheDocument();
+
+    // SegmentedControl renders radio buttons — click the Advanced label
+    await userEvent.click(screen.getByText('Advanced'));
+    await tick();
+
+    expect(
+      screen.getByRole('textbox', { name: /Secret Key/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(ModeSwitchFixture, {
+      props: { policy: makePolicy() },
+    });
+    await expectNoA11yViolations(container);
+  });
+});
+
+describe('AdvancedFields', () => {
+  it('shows disclosure with field count in advanced mode', async () => {
+    render(AdvancedFieldsFixture, {
+      props: { policy: makePolicy(), mode: 'advanced' },
+    });
+    await tick();
+
+    expect(screen.getByText(/Advanced · 2 fields/)).toBeInTheDocument();
+  });
+
+  it('does not render in basic mode', () => {
+    render(AdvancedFieldsFixture, {
+      props: { policy: makePolicy(), mode: 'basic' },
+    });
+
+    expect(screen.queryByText(/Advanced ·/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', { name: /Secret/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('uses singular "field" for one advanced field', async () => {
+    const policy = makePolicy();
+    // Remove one advanced field
+    delete policy.fields.another;
+    render(AdvancedFieldsFixture, {
+      props: { policy, mode: 'advanced' },
+    });
+    await tick();
+
+    expect(screen.getByText(/Advanced · 1 field$/)).toBeInTheDocument();
+  });
+
+  it('is axe-clean', async () => {
+    const { container } = render(AdvancedFieldsFixture, {
+      props: { policy: makePolicy(), mode: 'advanced' },
+    });
+    await tick();
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/fields/src/svelte/__tests__/PolicyField.test.ts
+++ b/packages/fields/src/svelte/__tests__/PolicyField.test.ts
@@ -212,6 +212,24 @@ describe('FieldPolicyProvider + PolicyField', () => {
     expect(screen.queryByRole('paragraph')).not.toBeInTheDocument();
   });
 
+  it('links the help hint to the input via aria-describedby', async () => {
+    const policy = makePolicy();
+    render(ProviderFieldFixture, {
+      props: { policy, mode: 'basic' },
+    });
+    await tick();
+
+    // `name` has resolved help rendered as the hint paragraph #name-help —
+    // the input must reference it for screen readers.
+    const input = screen.getByRole('textbox', { name: /Name/ });
+    expect(input.getAttribute('aria-describedby')).toBe('name-help');
+    expect(document.getElementById('name-help')).not.toBeNull();
+
+    // `sku` has no resolved help → no hint id, no dangling aria reference.
+    const skuInput = screen.getByRole('textbox', { name: /SKU/ });
+    expect(skuInput.hasAttribute('aria-describedby')).toBe(false);
+  });
+
   it('helpDensity tooltip falls back to a visible hint when there is no label', () => {
     // Policy with no resolved label → label === null → help must still render
     const policy = makePolicy({

--- a/packages/fields/src/svelte/__tests__/PolicyField.test.ts
+++ b/packages/fields/src/svelte/__tests__/PolicyField.test.ts
@@ -24,6 +24,7 @@ import FieldPolicyProvider from '../components/FieldPolicyProvider.svelte';
 import PolicyField from '../components/PolicyField.svelte';
 import DomPrefillFixture from './fixtures/DomPrefillFixture.svelte';
 import GracefulDegradeFixture from './fixtures/GracefulDegradeFixture.svelte';
+import NoIdFixture from './fixtures/NoIdFixture.svelte';
 import PrefillFixture from './fixtures/PrefillFixture.svelte';
 import ProviderFieldFixture from './fixtures/ProviderFieldFixture.svelte';
 import RevealPrefillFixture from './fixtures/RevealPrefillFixture.svelte';
@@ -208,8 +209,9 @@ describe('FieldPolicyProvider + PolicyField', () => {
     expect(label?.getAttribute('title')).toBe('The widget name');
     // The help text is no longer rendered as visible text content
     expect(screen.queryByText('The widget name')).not.toBeInTheDocument();
-    // No visible hint paragraph
-    expect(screen.queryByRole('paragraph')).not.toBeInTheDocument();
+    // No visible hint element (query the component's stable class rather than
+    // a role — `<p>` has no ARIA role, so a role query is unreliable).
+    expect(document.querySelectorAll('.policy-field__hint').length).toBe(0);
   });
 
   it('links the help hint to the input via aria-describedby', async () => {
@@ -228,6 +230,35 @@ describe('FieldPolicyProvider + PolicyField', () => {
     // `sku` has no resolved help → no hint id, no dangling aria reference.
     const skuInput = screen.getByRole('textbox', { name: /SKU/ });
     expect(skuInput.hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  it('associates the label with the wrapped control via for/id', async () => {
+    const policy = makePolicy();
+    render(ProviderFieldFixture, {
+      props: { policy, mode: 'basic' },
+    });
+    await tick();
+
+    // The fixture inputs carry id={name} — the label's `for` must match it so
+    // the accessible name comes from the rendered label.
+    const label = screen.getByText('Name').closest('label');
+    expect(label?.getAttribute('for')).toBe('name');
+    expect(document.getElementById('name')).not.toBeNull();
+
+    const skuLabel = screen.getByText('SKU').closest('label');
+    expect(skuLabel?.getAttribute('for')).toBe('sku');
+  });
+
+  it('assigns an id to a wrapped control that has none (for never dangles)', async () => {
+    const policy = makePolicy();
+    render(NoIdFixture, { props: { policy, mode: 'basic' } });
+    await tick();
+
+    const label = screen.getByText('Name').closest('label');
+    const forTarget = label?.getAttribute('for');
+    expect(forTarget).toBe('name');
+    // The wrapper must have given the id-less control an id the label hits.
+    expect(document.getElementById(forTarget as string)).not.toBeNull();
   });
 
   it('helpDensity tooltip falls back to a visible hint when there is no label', () => {

--- a/packages/fields/src/svelte/__tests__/PolicyField.test.ts
+++ b/packages/fields/src/svelte/__tests__/PolicyField.test.ts
@@ -1,0 +1,327 @@
+// @vitest-environment jsdom
+/**
+ * Component tests for FieldPolicyProvider + PolicyField (#2048).
+ *
+ * Covers the acceptance criteria:
+ * - PolicyField adoption with no layout change; unwrapped fields keep working
+ * - Basic mode hides advanced-tier fields; disclosure reveals them
+ * - Required-with-default fields prefill; loaded-record edits never overwritten
+ * - Help hint renders from resolved help (manifest description → org override)
+ * - Graceful degradation outside a Provider
+ * - Snippet escape hatch
+ * - a11y (axe-clean)
+ */
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { tick } from 'svelte';
+import { describe, expect, it } from 'vitest';
+import type { ResolvedObjectFieldPolicy } from '../../types.js';
+import FieldPolicyProvider from '../components/FieldPolicyProvider.svelte';
+import PolicyField from '../components/PolicyField.svelte';
+import DomPrefillFixture from './fixtures/DomPrefillFixture.svelte';
+import GracefulDegradeFixture from './fixtures/GracefulDegradeFixture.svelte';
+import PrefillFixture from './fixtures/PrefillFixture.svelte';
+import ProviderFieldFixture from './fixtures/ProviderFieldFixture.svelte';
+import SnippetFixture from './fixtures/SnippetFixture.svelte';
+import TooltipFixture from './fixtures/TooltipFixture.svelte';
+
+function makePolicy(
+  overrides: Partial<ResolvedObjectFieldPolicy> = {},
+): ResolvedObjectFieldPolicy {
+  return {
+    objectRef: '@test:Widget',
+    fields: {
+      name: {
+        fieldName: 'name',
+        hasDefault: false,
+        defaultValue: undefined,
+        visibility: 'basic',
+        help: 'The widget name',
+        label: 'Name',
+        order: 1,
+        group: null,
+        locked: false,
+        required: true,
+      },
+      sku: {
+        fieldName: 'sku',
+        hasDefault: true,
+        defaultValue: 'WIDG-001',
+        visibility: 'basic',
+        help: null,
+        label: 'SKU',
+        order: 2,
+        group: null,
+        locked: false,
+        required: false,
+      },
+      wholesalePrice: {
+        fieldName: 'wholesalePrice',
+        hasDefault: true,
+        defaultValue: 0,
+        visibility: 'advanced',
+        help: 'Price for wholesale customers',
+        label: 'Wholesale Price',
+        order: 3,
+        group: 'pricing',
+        locked: false,
+        required: false,
+      },
+      internalNotes: {
+        fieldName: 'internalNotes',
+        hasDefault: false,
+        defaultValue: undefined,
+        visibility: 'hidden',
+        help: 'Internal only',
+        label: 'Internal Notes',
+        order: 4,
+        group: null,
+        locked: false,
+        required: false,
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('FieldPolicyProvider + PolicyField', () => {
+  it('renders basic fields in basic mode', () => {
+    const policy = makePolicy();
+    render(ProviderFieldFixture, {
+      props: { policy, mode: 'basic' },
+    });
+
+    expect(screen.getByRole('textbox', { name: /Name/ })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /SKU/ })).toBeInTheDocument();
+  });
+
+  it('hides advanced fields in basic mode', () => {
+    const policy = makePolicy();
+    render(ProviderFieldFixture, {
+      props: { policy, mode: 'basic' },
+    });
+
+    // wholesalePrice is type=number → role is spinbutton, not textbox
+    expect(
+      screen.queryByRole('spinbutton', { name: /Wholesale Price/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('reveals advanced fields in advanced mode', async () => {
+    const policy = makePolicy();
+    render(ProviderFieldFixture, {
+      props: { policy, mode: 'advanced' },
+    });
+    // Wait for the provider's mode-sync $effect to flush (the untrack() seed
+    // reflects the requested mode on first paint, but $effect reactivity in
+    // jsdom needs a tick for the DOM to settle).
+    await tick();
+
+    // wholesalePrice is type=number → role is spinbutton, not textbox
+    expect(
+      screen.getByRole('spinbutton', { name: /Wholesale Price/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('never renders hidden-tier fields', () => {
+    const policy = makePolicy();
+    render(ProviderFieldFixture, {
+      props: { policy, mode: 'advanced' },
+    });
+
+    expect(screen.queryByText('Internal Notes')).not.toBeInTheDocument();
+  });
+
+  it('renders help hint from resolved help text', () => {
+    const policy = makePolicy();
+    render(ProviderFieldFixture, {
+      props: { policy, mode: 'basic' },
+    });
+
+    expect(screen.getByText('The widget name')).toBeInTheDocument();
+  });
+
+  it('renders required marker for required fields', () => {
+    const policy = makePolicy();
+    render(ProviderFieldFixture, {
+      props: { policy, mode: 'basic' },
+    });
+
+    const nameField = screen.getByText('Name').closest('.policy-field');
+    expect(nameField?.querySelector('.policy-field__required')).not.toBeNull();
+  });
+
+  it('does not render required marker for optional fields', () => {
+    const policy = makePolicy();
+    render(ProviderFieldFixture, {
+      props: { policy, mode: 'basic' },
+    });
+
+    const skuField = screen.getByText('SKU').closest('.policy-field');
+    expect(skuField?.querySelector('.policy-field__required')).toBeNull();
+  });
+
+  it('exposes default value via snippet props for prefill signal', () => {
+    const policy = makePolicy();
+    render(PrefillFixture, {
+      props: { policy, mode: 'basic' },
+    });
+
+    // The fixture renders the default value text from snippet props
+    expect(screen.getByText('Default: WIDG-001')).toBeInTheDocument();
+  });
+
+  it('degrades gracefully outside a Provider (renders children verbatim)', () => {
+    render(GracefulDegradeFixture);
+
+    // Should render the input even without a provider
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('snippet escape hatch receives resolved policy data', () => {
+    const policy = makePolicy();
+    render(SnippetFixture, {
+      props: { policy, mode: 'basic' },
+    });
+
+    expect(screen.getByTestId('field-label')).toHaveTextContent('Name');
+    expect(screen.getByTestId('field-help')).toHaveTextContent(
+      'The widget name',
+    );
+    expect(screen.getByTestId('field-required')).toHaveTextContent('true');
+  });
+
+  it('helpDensity tooltip attaches help to the label title and hides the hint', () => {
+    const policy = makePolicy();
+    render(TooltipFixture, {
+      props: { policy, helpDensity: 'tooltip' },
+    });
+
+    // Help moves to the label's title attribute
+    const label = screen.getByText('Name').closest('label');
+    expect(label).not.toBeNull();
+    expect(label?.getAttribute('title')).toBe('The widget name');
+    // The help text is no longer rendered as visible text content
+    expect(screen.queryByText('The widget name')).not.toBeInTheDocument();
+    // No visible hint paragraph
+    expect(screen.queryByRole('paragraph')).not.toBeInTheDocument();
+  });
+
+  it('helpDensity tooltip falls back to a visible hint when there is no label', () => {
+    // Policy with no resolved label → label === null → help must still render
+    const policy = makePolicy({
+      fields: {
+        name: {
+          fieldName: 'name',
+          hasDefault: false,
+          defaultValue: undefined,
+          visibility: 'basic',
+          help: 'Orphan help text',
+          label: null,
+          order: 1,
+          group: null,
+          locked: false,
+          required: false,
+        },
+      },
+    });
+    render(TooltipFixture, {
+      props: { policy, helpDensity: 'tooltip' },
+    });
+
+    expect(screen.getByText('Orphan help text')).toBeInTheDocument();
+  });
+
+  it('mode toggle reveals advanced fields', async () => {
+    const policy = makePolicy();
+    render(ProviderFieldFixture, {
+      props: { policy, mode: 'basic' },
+    });
+
+    // Advanced field not visible initially
+    expect(
+      screen.queryByRole('spinbutton', { name: /Wholesale/ }),
+    ).not.toBeInTheDocument();
+
+    // Toggle mode (the fixture's button calls modeStore.toggle() via context)
+    await userEvent.click(screen.getByRole('button', { name: 'Toggle Mode' }));
+
+    expect(
+      screen.getByRole('spinbutton', { name: /Wholesale Price/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('is axe-clean', async () => {
+    const policy = makePolicy();
+    const { container } = render(ProviderFieldFixture, {
+      props: { policy, mode: 'basic' },
+    });
+    await expectNoA11yViolations(container);
+  });
+});
+
+describe('PolicyField default prefill (new records only)', () => {
+  it('prefills an empty input with the resolved default for a new record', async () => {
+    const policy = makePolicy();
+    render(DomPrefillFixture, {
+      props: { policy, isNewRecord: true, skuValue: '' },
+    });
+    await tick();
+
+    // The sku field has a resolved default of 'WIDG-001'; the empty input
+    // should be prefilled with it.
+    const input = screen.getByRole<HTMLInputElement>('textbox', {
+      name: /SKU/,
+    });
+    expect(input.value).toBe('WIDG-001');
+    // The bound state should pick up the prefilled value too
+    expect(screen.getByTestId('sku-state')).toHaveTextContent('WIDG-001');
+  });
+
+  it('does NOT clobber a loaded record with an existing value', async () => {
+    const policy = makePolicy();
+    render(DomPrefillFixture, {
+      props: { policy, isNewRecord: true, skuValue: 'EXISTING-999' },
+    });
+    await tick();
+
+    // The input already has a value (loaded record); the default must NOT
+    // overwrite it.
+    const input = screen.getByRole<HTMLInputElement>('textbox', {
+      name: /SKU/,
+    });
+    expect(input.value).toBe('EXISTING-999');
+    expect(screen.getByTestId('sku-state')).toHaveTextContent('EXISTING-999');
+  });
+
+  it('does NOT prefill when isNewRecord is false', async () => {
+    const policy = makePolicy();
+    render(DomPrefillFixture, {
+      props: { policy, isNewRecord: false, skuValue: '' },
+    });
+    await tick();
+
+    // isNewRecord=false → no prefill even though the field is empty and has a
+    // resolved default.
+    const input = screen.getByRole<HTMLInputElement>('textbox', {
+      name: /SKU/,
+    });
+    expect(input.value).toBe('');
+  });
+});
+
+describe('PolicyField standalone', () => {
+  it('renders without a provider (no crash)', () => {
+    render(PolicyField, {
+      props: { name: 'test' },
+      target: document.body,
+    });
+
+    // No label wrapping since no context, just children area
+    // Should not throw
+  });
+});

--- a/packages/fields/src/svelte/__tests__/PolicyField.test.ts
+++ b/packages/fields/src/svelte/__tests__/PolicyField.test.ts
@@ -26,6 +26,7 @@ import DomPrefillFixture from './fixtures/DomPrefillFixture.svelte';
 import GracefulDegradeFixture from './fixtures/GracefulDegradeFixture.svelte';
 import PrefillFixture from './fixtures/PrefillFixture.svelte';
 import ProviderFieldFixture from './fixtures/ProviderFieldFixture.svelte';
+import RevealPrefillFixture from './fixtures/RevealPrefillFixture.svelte';
 import SnippetFixture from './fixtures/SnippetFixture.svelte';
 import TooltipFixture from './fixtures/TooltipFixture.svelte';
 
@@ -311,6 +312,80 @@ describe('PolicyField default prefill (new records only)', () => {
       name: /SKU/,
     });
     expect(input.value).toBe('');
+  });
+});
+
+describe('PolicyField prefill on reveal (advanced-tier fields)', () => {
+  it('prefills an advanced field when the mode switch reveals it', async () => {
+    const policy = makePolicy();
+    render(RevealPrefillFixture, {
+      props: { policy, isNewRecord: true },
+    });
+    await tick();
+
+    // Hidden in basic mode: no input to prefill yet.
+    expect(
+      screen.queryByRole('spinbutton', { name: /Wholesale Price/ }),
+    ).not.toBeInTheDocument();
+
+    // Reveal the advanced tier.
+    await userEvent.click(screen.getByRole('button', { name: 'Toggle Mode' }));
+    await tick();
+
+    // wholesalePrice resolves default 0 — a legitimate integer default that
+    // must survive the undefined/null guards.
+    const input = screen.getByRole<HTMLInputElement>('spinbutton', {
+      name: /Wholesale Price/,
+    });
+    expect(input.value).toBe('0');
+    // The bound state picked up the prefilled value via the dispatched event.
+    expect(screen.getByTestId('wholesale-state')).toHaveTextContent('0');
+  });
+
+  it('does NOT prefill a revealed advanced field when isNewRecord is false', async () => {
+    const policy = makePolicy();
+    render(RevealPrefillFixture, {
+      props: { policy, isNewRecord: false },
+    });
+    await tick();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Toggle Mode' }));
+    await tick();
+
+    const input = screen.getByRole<HTMLInputElement>('spinbutton', {
+      name: /Wholesale Price/,
+    });
+    expect(input.value).toBe('');
+  });
+
+  it('prefills only once — a deliberately cleared input is never re-filled', async () => {
+    const policy = makePolicy();
+    render(RevealPrefillFixture, {
+      props: { policy, isNewRecord: true },
+    });
+    await tick();
+
+    // Reveal → prefill runs once.
+    await userEvent.click(screen.getByRole('button', { name: 'Toggle Mode' }));
+    await tick();
+    const input = screen.getByRole<HTMLInputElement>('spinbutton', {
+      name: /Wholesale Price/,
+    });
+    expect(input.value).toBe('0');
+
+    // The user deliberately clears the field.
+    await userEvent.clear(input);
+    await tick();
+
+    // Hide and reveal again: the one-shot guard must prevent a re-prefill.
+    await userEvent.click(screen.getByRole('button', { name: 'Toggle Mode' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Toggle Mode' }));
+    await tick();
+
+    const revealed = screen.getByRole<HTMLInputElement>('spinbutton', {
+      name: /Wholesale Price/,
+    });
+    expect(revealed.value).toBe('');
   });
 });
 

--- a/packages/fields/src/svelte/__tests__/fixtures/AdvancedFieldsFixture.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/AdvancedFieldsFixture.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+import type { ResolvedObjectFieldPolicy } from '../../../types.js';
+import AdvancedFields from '../../components/AdvancedFields.svelte';
+import FieldPolicyProvider from '../../components/FieldPolicyProvider.svelte';
+import PolicyField from '../../components/PolicyField.svelte';
+
+let {
+  policy,
+  mode = 'advanced',
+}: {
+  policy: ResolvedObjectFieldPolicy;
+  mode?: 'basic' | 'advanced';
+} = $props();
+</script>
+
+<FieldPolicyProvider {policy} {mode}>
+  <PolicyField name="name">
+    <input id="name" name="name" type="text" />
+  </PolicyField>
+  <AdvancedFields>
+    <PolicyField name="secretKey">
+      <input id="secretKey" name="secretKey" type="text" />
+    </PolicyField>
+    {#if policy.fields.another}
+      <PolicyField name="another">
+        <input id="another" name="another" type="text" />
+      </PolicyField>
+    {/if}
+  </AdvancedFields>
+</FieldPolicyProvider>

--- a/packages/fields/src/svelte/__tests__/fixtures/DomPrefillFixture.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/DomPrefillFixture.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+/**
+ * Test fixture: PolicyField with bind:value inputs to verify prefill.
+ * - New record with default → input prefilled from resolved default
+ * - Loaded record with existing value → input NOT clobbered by default
+ */
+import { untrack } from 'svelte';
+import type { ResolvedObjectFieldPolicy } from '../../../types.js';
+import FieldPolicyProvider from '../../components/FieldPolicyProvider.svelte';
+import PolicyField from '../../components/PolicyField.svelte';
+
+let {
+  policy,
+  isNewRecord = true,
+  skuValue = '',
+}: {
+  policy: ResolvedObjectFieldPolicy;
+  isNewRecord?: boolean;
+  skuValue?: string;
+} = $props();
+
+// Seed the bound value once from the prop (untrack makes the one-shot capture
+// explicit, mirroring ThemeProvider's SSR-seeding pattern — a loaded record's
+// existing value must never be re-synced from the prop).
+let sku = $state(untrack(() => skuValue));
+</script>
+
+<FieldPolicyProvider {policy} mode="basic">
+  <PolicyField name="sku" {isNewRecord}>
+    <input id="sku" name="sku" type="text" bind:value={sku} />
+  </PolicyField>
+  <div data-testid="sku-state">{sku}</div>
+</FieldPolicyProvider>

--- a/packages/fields/src/svelte/__tests__/fixtures/FormHelpFixture.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/FormHelpFixture.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+import type { ResolvedObjectFieldPolicy } from '../../../types.js';
+import FieldPolicyProvider from '../../components/FieldPolicyProvider.svelte';
+import FormHelp from '../../components/FormHelp.svelte';
+
+let {
+  policy,
+  objectDescription,
+}: {
+  policy: ResolvedObjectFieldPolicy;
+  objectDescription?: string;
+} = $props();
+</script>
+
+<FieldPolicyProvider {policy} mode="basic">
+  <FormHelp {objectDescription} />
+</FieldPolicyProvider>

--- a/packages/fields/src/svelte/__tests__/fixtures/GracefulDegradeFixture.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/GracefulDegradeFixture.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+/**
+ * Test fixture: PolicyField rendered WITHOUT a FieldPolicyProvider.
+ * Verifies graceful degradation — children render verbatim.
+ */
+import PolicyField from '../../components/PolicyField.svelte';
+</script>
+
+<PolicyField name="standalone">
+  <input type="text" />
+</PolicyField>

--- a/packages/fields/src/svelte/__tests__/fixtures/ModeSwitchFixture.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/ModeSwitchFixture.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+import type { ResolvedObjectFieldPolicy } from '../../../types.js';
+import FieldPolicyProvider from '../../components/FieldPolicyProvider.svelte';
+import ModeSwitch from '../../components/ModeSwitch.svelte';
+import PolicyField from '../../components/PolicyField.svelte';
+
+let { policy }: { policy: ResolvedObjectFieldPolicy } = $props();
+</script>
+
+<FieldPolicyProvider {policy} mode="basic">
+  <ModeSwitch />
+  <PolicyField name="name">
+    <input id="name" name="name" type="text" />
+  </PolicyField>
+  <PolicyField name="secretKey">
+    <input id="secretKey" name="secretKey" type="text" />
+  </PolicyField>
+</FieldPolicyProvider>

--- a/packages/fields/src/svelte/__tests__/fixtures/NoIdFixture.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/NoIdFixture.svelte
@@ -1,19 +1,24 @@
 <script lang="ts">
+/**
+ * Test fixture: PolicyField wrapping a control with NO id attribute — the
+ * wrapper must assign one so the label's `for` never dangles.
+ */
+
 import type { ResolvedObjectFieldPolicy } from '../../../types.js';
 import FieldPolicyProvider from '../../components/FieldPolicyProvider.svelte';
-import FormHelp from '../../components/FormHelp.svelte';
+import PolicyField from '../../components/PolicyField.svelte';
 
 let {
   policy,
-  objectDescription,
   mode = 'basic',
 }: {
   policy: ResolvedObjectFieldPolicy;
-  objectDescription?: string;
   mode?: 'basic' | 'advanced';
 } = $props();
 </script>
 
 <FieldPolicyProvider {policy} {mode}>
-  <FormHelp {objectDescription} />
+  <PolicyField name="name">
+    <input type="text" />
+  </PolicyField>
 </FieldPolicyProvider>

--- a/packages/fields/src/svelte/__tests__/fixtures/PrefillFixture.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/PrefillFixture.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+/**
+ * Test fixture: PolicyField with snippet escape hatch showing prefill signal.
+ * Demonstrates that the snippet receives the default value from resolved policy.
+ */
+
+import type { ResolvedObjectFieldPolicy } from '../../../types.js';
+import FieldPolicyProvider from '../../components/FieldPolicyProvider.svelte';
+import PolicyField from '../../components/PolicyField.svelte';
+
+let {
+  policy,
+  mode = 'basic',
+}: {
+  policy: ResolvedObjectFieldPolicy;
+  mode?: 'basic' | 'advanced';
+} = $props();
+</script>
+
+<FieldPolicyProvider {policy} {mode}>
+  <PolicyField name="sku">
+    {#snippet render({ defaultValue })}
+      <div>Default: {String(defaultValue)}</div>
+    {/snippet}
+  </PolicyField>
+</FieldPolicyProvider>

--- a/packages/fields/src/svelte/__tests__/fixtures/ProviderFieldFixture.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/ProviderFieldFixture.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+/**
+ * Test fixture: FieldPolicyProvider wrapping PolicyField-wrapped inputs.
+ * Includes a mode toggle button to test switching between basic/advanced.
+ *
+ * The toggle lives in its own component so getContext runs during component
+ * initialisation (the only valid time for getContext in Svelte 5) instead of
+ * inside an event handler.
+ */
+
+import type { ResolvedObjectFieldPolicy } from '../../../types.js';
+import FieldPolicyProvider from '../../components/FieldPolicyProvider.svelte';
+import PolicyField from '../../components/PolicyField.svelte';
+import ToggleModeButton from './ToggleModeButton.svelte';
+
+let {
+  policy,
+  mode = 'basic',
+}: {
+  policy: ResolvedObjectFieldPolicy;
+  mode?: 'basic' | 'advanced';
+} = $props();
+</script>
+
+<FieldPolicyProvider {policy} {mode}>
+  <PolicyField name="name">
+    <input id="name" name="name" type="text" />
+  </PolicyField>
+  <PolicyField name="sku">
+    <input id="sku" name="sku" type="text" />
+  </PolicyField>
+  <PolicyField name="wholesalePrice">
+    <input id="wholesalePrice" name="wholesalePrice" type="number" />
+  </PolicyField>
+  <PolicyField name="internalNotes">
+    <input id="internalNotes" name="internalNotes" type="text" />
+  </PolicyField>
+  <ToggleModeButton />
+</FieldPolicyProvider>

--- a/packages/fields/src/svelte/__tests__/fixtures/RevealPrefillFixture.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/RevealPrefillFixture.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+/**
+ * Test fixture: an advanced-tier PolicyField with a resolved default that is
+ * hidden at mount (basic mode) and revealed by the mode toggle. Verifies
+ * prefill runs on first reveal, not only at mount.
+ */
+import type { ResolvedObjectFieldPolicy } from '../../../types.js';
+import FieldPolicyProvider from '../../components/FieldPolicyProvider.svelte';
+import PolicyField from '../../components/PolicyField.svelte';
+import ToggleModeButton from './ToggleModeButton.svelte';
+
+let {
+  policy,
+  isNewRecord = true,
+}: {
+  policy: ResolvedObjectFieldPolicy;
+  isNewRecord?: boolean;
+} = $props();
+
+let wholesale = $state('');
+</script>
+
+<FieldPolicyProvider {policy} mode="basic">
+  <PolicyField name="wholesalePrice" {isNewRecord}>
+    <input id="wholesalePrice" name="wholesalePrice" type="number" bind:value={wholesale} />
+  </PolicyField>
+  <div data-testid="wholesale-state">{wholesale}</div>
+  <ToggleModeButton />
+</FieldPolicyProvider>

--- a/packages/fields/src/svelte/__tests__/fixtures/SnippetFixture.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/SnippetFixture.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+/**
+ * Test fixture: PolicyField snippet escape hatch with full policy data.
+ * Verifies the snippet receives resolved label, help, required, etc.
+ */
+
+import type { ResolvedObjectFieldPolicy } from '../../../types.js';
+import FieldPolicyProvider from '../../components/FieldPolicyProvider.svelte';
+import PolicyField from '../../components/PolicyField.svelte';
+
+let {
+  policy,
+  mode = 'basic',
+}: {
+  policy: ResolvedObjectFieldPolicy;
+  mode?: 'basic' | 'advanced';
+} = $props();
+</script>
+
+<FieldPolicyProvider {policy} {mode}>
+  <PolicyField name="name">
+    {#snippet render({ label, help, required })}
+      <div data-testid="field-label">{label}</div>
+      <div data-testid="field-help">{help}</div>
+      <div data-testid="field-required">{String(required)}</div>
+    {/snippet}
+  </PolicyField>
+</FieldPolicyProvider>

--- a/packages/fields/src/svelte/__tests__/fixtures/ToggleModeButton.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/ToggleModeButton.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+/**
+ * Test helper: a button rendered inside a FieldPolicyProvider that toggles
+ * the provider's mode state. Captures the context during component
+ * initialisation (getContext is only valid there in Svelte 5).
+ */
+import { getFieldPolicyContext } from '../../context.svelte.js';
+
+const context = getFieldPolicyContext();
+</script>
+
+<button onclick={() => context.mode.toggle()}>
+  Toggle Mode
+</button>

--- a/packages/fields/src/svelte/__tests__/fixtures/TooltipFixture.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/TooltipFixture.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+/**
+ * Test fixture: PolicyField with helpDensity='tooltip' to verify the help
+ * text attaches to the label as a title attribute instead of rendering a
+ * visible hint.
+ */
+
+import type { ResolvedObjectFieldPolicy } from '../../../types.js';
+import FieldPolicyProvider from '../../components/FieldPolicyProvider.svelte';
+import PolicyField from '../../components/PolicyField.svelte';
+
+let {
+  policy,
+  helpDensity = 'tooltip',
+}: {
+  policy: ResolvedObjectFieldPolicy;
+  helpDensity?: 'hint' | 'tooltip';
+} = $props();
+</script>
+
+<FieldPolicyProvider {policy} mode="basic">
+  <PolicyField name="name" {helpDensity}>
+    <input id="name" name="name" type="text" />
+  </PolicyField>
+</FieldPolicyProvider>

--- a/packages/fields/src/svelte/components/AdvancedFields.svelte
+++ b/packages/fields/src/svelte/components/AdvancedFields.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+/**
+ * AdvancedFields — a disclosure section for advanced-tier fields.
+ *
+ * An optional composition that wraps PolicyField-wrapped advanced fields. Uses
+ * `@happyvertical/smrt-ui/ui`'s Disclosure (native `<details>/<summary>` —
+ * good a11y baseline). The title shows the advanced field count from the
+ * resolved policy.
+ *
+ * The disclosure's open state is **not** coupled to the provider's mode: the
+ * mode determines *visibility* (advanced fields are hidden in basic mode),
+ * while the disclosure provides a *collapsed* view of those same fields when
+ * they are visible (advanced mode). Consumers who prefer the mode toggle alone
+ * (ModeSwitch) do not need this component.
+ *
+ * Must be used inside a FieldPolicyProvider.
+ */
+import { Disclosure } from '@happyvertical/smrt-ui/ui';
+import type { Snippet } from 'svelte';
+import { getFieldPolicyContext } from '../context.svelte.js';
+
+export interface Props {
+  /**
+   * Title for the disclosure. Defaults to "Advanced" with the field count.
+   */
+  title?: string;
+  /** Whether the disclosure starts open. */
+  open?: boolean;
+  /** Children — the advanced fields to render inside the disclosure. */
+  children?: Snippet;
+  /** Additional class. */
+  class?: string;
+}
+
+let { title, open = false, children, class: className = '' }: Props = $props();
+
+const context = getFieldPolicyContext();
+
+const resolvedTitle = $derived(
+  title ??
+    `Advanced · ${context.advancedFieldCount} field${context.advancedFieldCount === 1 ? '' : 's'}`,
+);
+</script>
+
+{#if context.mode.current === 'advanced' && context.advancedFieldCount > 0}
+  <Disclosure title={resolvedTitle} {open} class={className}>
+    {@render children?.()}
+  </Disclosure>
+{/if}

--- a/packages/fields/src/svelte/components/FieldPolicyProvider.svelte
+++ b/packages/fields/src/svelte/components/FieldPolicyProvider.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+/**
+ * FieldPolicyProvider — the form-level entry point for policy-driven forms.
+ *
+ * Receives a resolved {@link ResolvedObjectFieldPolicy} **as props** (SSR
+ * `initialData` or a client fetch by the app). Owns mode state (`basic`/
+ * `advanced`) and publishes the reactive context consumed by `PolicyField`,
+ * `ModeSwitch`, `AdvancedFields`, and `FormHelp`.
+ *
+ * No `smrt-web` import in the core primitive — an optional `./web` adapter can
+ * wire live invalidation for apps that want it; this component is policy-source
+ * agnostic.
+ *
+ * SSR seeding: props seed `$state` via `untrack()` so the first render reflects
+ * the request, with a client-only `$effect` resync — the same pattern as
+ * ThemeProvider (`smrt-ui/src/themes/ThemeProvider.svelte:53-70`).
+ */
+
+import type { Snippet } from 'svelte';
+import { untrack } from 'svelte';
+import type {
+  ResolvedFieldPolicy,
+  ResolvedObjectFieldPolicy,
+} from '../../types.js';
+import {
+  type FieldPolicyContextValue,
+  type FieldPolicyMode,
+  FieldPolicyModeStore,
+  setFieldPolicyContext,
+} from '../context.svelte.js';
+
+export interface Props {
+  /**
+   * Pre-resolved field policy for the object. Pass the output of
+   * `resolveFieldPolicy()` (server-side) or the `resolveBatch` endpoint
+   * response (client-side).
+   */
+  policy: ResolvedObjectFieldPolicy;
+  /** Initial display mode — 'basic' hides advanced-tier fields. */
+  mode?: FieldPolicyMode;
+  /** Children rendered inside the provider. */
+  children?: Snippet;
+}
+
+let { policy, mode: modeProp = 'basic', children }: Props = $props();
+
+// --- Reactive mode state (owned by the provider component) ---
+// Using a class with $state fields: Svelte 5 tracks class field reactivity
+// correctly across the context boundary (the class instance is the reactive
+// root, not a component closure variable).
+// Seed via untrack() so the first SSR/client render reflects the requested
+// mode; the $effect below resyncs later prop changes (ThemeProvider precedent).
+const modeStore = new FieldPolicyModeStore(untrack(() => modeProp));
+
+$effect(() => {
+  modeStore.set(modeProp);
+});
+
+// --- Resolved field lookup (reactive over policy prop changes) ---
+function getField(fieldName: string): ResolvedFieldPolicy | undefined {
+  return policy.fields[fieldName];
+}
+
+// --- Advanced field count for the disclosure label ---
+const advancedFieldCount = $derived.by(() => {
+  let count = 0;
+  for (const field of Object.values(policy.fields)) {
+    if (field.visibility === 'advanced') {
+      count++;
+    }
+  }
+  return count;
+});
+
+const context: FieldPolicyContextValue = {
+  get policy() {
+    return policy;
+  },
+  mode: modeStore,
+  getField,
+  get advancedFieldCount() {
+    return advancedFieldCount;
+  },
+};
+
+setFieldPolicyContext(context);
+</script>
+
+{@render children?.()}

--- a/packages/fields/src/svelte/components/FormHelp.svelte
+++ b/packages/fields/src/svelte/components/FormHelp.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+/**
+ * FormHelp — a `?` affordance assembling the object description + per-field
+ * glossary from the manifest (org-overridden text where present).
+ *
+ * Renders a button toggling a details/summary panel listing every visible
+ * field's label and help text, plus the object description if provided. The
+ * data comes entirely from the resolved policy — no separate fetch needed.
+ *
+ * Must be used inside a FieldPolicyProvider.
+ */
+import { getFieldPolicyContext } from '../context.svelte.js';
+
+export interface Props {
+  /**
+   * Object-level description (e.g. the SmrtObject class `description`). When
+   * provided, it appears at the top of the help panel.
+   */
+  objectDescription?: string;
+  /** Label for the toggle button. */
+  label?: string;
+  /** Additional class. */
+  class?: string;
+}
+
+let {
+  objectDescription,
+  label = 'Help',
+  class: className = '',
+}: Props = $props();
+
+const context = getFieldPolicyContext();
+
+// Build the glossary: one entry per field that has help text, ordered by the
+// resolved `order` when available, then by insertion order.
+const glossary = $derived.by(() => {
+  const entries: Array<{
+    label: string;
+    help: string;
+    order: number;
+  }> = [];
+
+  for (const field of Object.values(context.policy.fields)) {
+    if (field.visibility === 'hidden') continue;
+    const labelText = field.label ?? field.fieldName;
+    if (field.help) {
+      entries.push({
+        label: labelText,
+        help: field.help,
+        order: field.order ?? Number.MAX_SAFE_INTEGER,
+      });
+    }
+  }
+
+  // Stable sort by resolved order
+  entries.sort((a, b) => a.order - b.order);
+  return entries;
+});
+</script>
+
+<details class="form-help {className}">
+  <summary class="form-help__toggle">
+    <span class="form-help__icon" aria-hidden="true">?</span>
+    <span class="form-help__label">{label}</span>
+  </summary>
+  <div class="form-help__panel">
+    {#if objectDescription}
+      <p class="form-help__description">{objectDescription}</p>
+    {/if}
+    {#if glossary.length > 0}
+      <dl class="form-help__glossary">
+        {#each glossary as entry}
+          <dt class="form-help__term">{entry.label}</dt>
+          <dd class="form-help__definition">{entry.help}</dd>
+        {/each}
+      </dl>
+    {:else}
+      <p class="form-help__empty">No field help available.</p>
+    {/if}
+  </div>
+</details>
+
+<style>
+  .form-help {
+    display: inline-block;
+  }
+
+  .form-help__toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--smrt-spacing-1, 0.25rem);
+    cursor: pointer;
+    list-style: none;
+    font: var(--smrt-typography-label-medium-font, inherit);
+    color: var(--smrt-color-on-surface-variant, currentColor);
+  }
+
+  .form-help__toggle::-webkit-details-marker {
+    display: none;
+  }
+
+  .form-help__toggle:focus-visible {
+    outline: 2px solid var(--smrt-color-primary, #6750a4);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+
+  .form-help__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25em;
+    height: 1.25em;
+    border-radius: 50%;
+    border: 1px solid currentColor;
+    font: var(--smrt-typography-label-small-font, inherit);
+    line-height: 1;
+  }
+
+  .form-help__panel {
+    padding: var(--smrt-spacing-3, 0.75rem) 0;
+    color: var(--smrt-color-on-surface, currentColor);
+  }
+
+  .form-help__description {
+    margin: 0 0 var(--smrt-spacing-2, 0.5rem);
+    font: var(--smrt-typography-body-medium-font, inherit);
+  }
+
+  .form-help__glossary {
+    margin: 0;
+    display: grid;
+    gap: var(--smrt-spacing-1, 0.25rem);
+  }
+
+  .form-help__term {
+    font: var(--smrt-typography-label-medium-font, inherit);
+    font-weight: 600;
+  }
+
+  .form-help__definition {
+    margin: 0 0 var(--smrt-spacing-2, 0.5rem);
+    font: var(--smrt-typography-body-small-font, inherit);
+    color: var(--smrt-color-on-surface-variant, currentColor);
+  }
+
+  .form-help__empty {
+    font: var(--smrt-typography-body-small-font, inherit);
+    color: var(--smrt-color-on-surface-variant, currentColor);
+  }
+</style>

--- a/packages/fields/src/svelte/components/FormHelp.svelte
+++ b/packages/fields/src/svelte/components/FormHelp.svelte
@@ -4,8 +4,10 @@
  * glossary from the manifest (org-overridden text where present).
  *
  * Renders a button toggling a details/summary panel listing every visible
- * field's label and help text, plus the object description if provided. The
- * data comes entirely from the resolved policy — no separate fetch needed.
+ * field's label and help text — matching PolicyField visibility, so
+ * advanced-tier entries only appear while the provider mode is `advanced` —
+ * plus the object description if provided. The data comes entirely from the
+ * resolved policy — no separate fetch needed.
  *
  * Must be used inside a FieldPolicyProvider.
  */
@@ -31,8 +33,10 @@ let {
 
 const context = getFieldPolicyContext();
 
-// Build the glossary: one entry per field that has help text, ordered by the
-// resolved `order` when available, then by insertion order.
+// Build the glossary: one entry per field that has help text AND is visible
+// in the current mode (advanced-tier entries disappear in basic mode,
+// matching PolicyField visibility), ordered by the resolved `order` when
+// available, then by insertion order.
 const glossary = $derived.by(() => {
   const entries: Array<{
     label: string;
@@ -40,8 +44,10 @@ const glossary = $derived.by(() => {
     order: number;
   }> = [];
 
+  const mode = context.mode.current;
   for (const field of Object.values(context.policy.fields)) {
     if (field.visibility === 'hidden') continue;
+    if (field.visibility === 'advanced' && mode !== 'advanced') continue;
     const labelText = field.label ?? field.fieldName;
     if (field.help) {
       entries.push({

--- a/packages/fields/src/svelte/components/ModeSwitch.svelte
+++ b/packages/fields/src/svelte/components/ModeSwitch.svelte
@@ -30,7 +30,11 @@ const options: SegmentedControlOption[] = [
 ];
 
 function onValueChange(value: string | number): void {
-  context.mode.set(value as 'basic' | 'advanced');
+  // Validate before setting — SegmentedControl hands back `string | number`,
+  // and a stray value must never corrupt the mode state.
+  if (value === 'basic' || value === 'advanced') {
+    context.mode.set(value);
+  }
 }
 </script>
 

--- a/packages/fields/src/svelte/components/ModeSwitch.svelte
+++ b/packages/fields/src/svelte/components/ModeSwitch.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+/**
+ * ModeSwitch — a Basic/Advanced toggle built on SegmentedControl.
+ *
+ * An optional composition for PolicyField-wrapped forms. Reads and writes the
+ * provider's reactive mode state. Must be used inside a FieldPolicyProvider.
+ *
+ * Uses `@happyvertical/smrt-ui/forms`'s SegmentedControl (exported from there,
+ * not `./ui` — see the plan-review addendum in #2048).
+ */
+
+import type { SegmentedControlOption } from '@happyvertical/smrt-ui/forms';
+import { SegmentedControl } from '@happyvertical/smrt-ui/forms';
+import { getFieldPolicyContext } from '../context.svelte.js';
+
+export interface Props {
+  /** Accessible label for the segmented control. */
+  label?: string;
+  /** Additional class. */
+  class?: string;
+}
+
+let { label = 'View mode', class: className = '' }: Props = $props();
+
+const context = getFieldPolicyContext();
+
+const options: SegmentedControlOption[] = [
+  { value: 'basic', label: 'Basic' },
+  { value: 'advanced', label: 'Advanced' },
+];
+
+function onValueChange(value: string | number): void {
+  context.mode.set(value as 'basic' | 'advanced');
+}
+</script>
+
+<SegmentedControl
+  {options}
+  {label}
+  value={context.mode.current}
+  onvaluechange={onValueChange}
+  class={className}
+/>

--- a/packages/fields/src/svelte/components/PolicyField.svelte
+++ b/packages/fields/src/svelte/components/PolicyField.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+/**
+ * PolicyField — layout-neutral wrapper around any input.
+ *
+ * Contributes:
+ * - Visibility by resolved tier × current mode (advanced fields hidden in
+ *   basic mode)
+ * - Initial-value prefill from the resolved default (new records only —
+ *   never clobbers loaded values)
+ * - Label rendering (resolved label or fallback to field name)
+ * - Help hint rendered from resolved help (manifest description → org/user
+ *   override)
+ * - Required marker
+ *
+ * Headless escape hatch: pass a `render` snippet receiving
+ * `{visible, label, help, defaultValue, required, tier}` for fully custom
+ * rendering. Without a snippet, PolicyField wraps children in a label + help
+ * affordance and controls visibility.
+ *
+ * Graceful degradation: outside a FieldPolicyProvider, PolicyField renders its
+ * children verbatim (no visibility filtering, no label/help injection) so
+ * forms can adopt it incrementally.
+ */
+import type { Snippet } from 'svelte';
+import { onMount } from 'svelte';
+import { tryGetFieldPolicyContext } from '../context.svelte.js';
+import type { PolicyFieldSnippetProps } from '../types.js';
+
+export interface Props {
+  /** The field name matching a key in the resolved policy's `fields`. */
+  name: string;
+  /**
+   * Children — the actual input(s). Always rendered when the field is visible
+   * (unless the `render` snippet escape hatch is used).
+   */
+  children?: Snippet;
+  /**
+   * Headless escape hatch: a snippet receiving all resolved policy data for
+   * fully custom rendering. When provided, it replaces the default label +
+   * children + help layout entirely.
+   */
+  render?: Snippet<[PolicyFieldSnippetProps]>;
+  /**
+   * Whether this is a new record. When true (default) and the field has a
+   * resolved default, the provider can prefill. Set to false for loaded
+   * records to prevent overwriting existing values.
+   * @default true
+   */
+  isNewRecord?: boolean;
+  /**
+   * Override the resolved label. When provided, takes precedence over the
+   * policy label.
+   */
+  label?: string;
+  /**
+   * Override the resolved help text. When provided, takes precedence over
+   * the policy help.
+   */
+  help?: string;
+  /**
+   * Density of the help hint: 'hint' (inline hint text, default) or
+   * 'tooltip' (title attribute on the label).
+   * @default 'hint'
+   */
+  helpDensity?: 'hint' | 'tooltip';
+  /** Additional class for the wrapper element. */
+  class?: string;
+}
+
+let {
+  name,
+  children,
+  render: renderSnippet,
+  isNewRecord = true,
+  label: labelOverride,
+  help: helpOverride,
+  helpDensity = 'hint',
+  class: className = '',
+}: Props = $props();
+
+const context = tryGetFieldPolicyContext();
+
+// Reactive resolved field policy — undefined when not in a Provider or when
+// the field name is not in the resolved set.
+const resolvedField = $derived(context?.getField(name));
+
+const tier = $derived(resolvedField?.visibility ?? 'basic');
+
+// A field is visible when:
+// - No context (graceful degradation → always visible)
+// - Tier is 'basic'
+// - Tier is 'advanced' and mode is 'advanced'
+// - Tier is 'hidden' → never visible (but required-and-defaultless fields are
+//   forced basic by the resolver, so this is a safety net)
+const visible = $derived.by(() => {
+  if (!context) return true;
+  if (tier === 'hidden') return false;
+  if (tier === 'basic') return true;
+  // advanced
+  return context.mode.current === 'advanced';
+});
+
+const label = $derived(labelOverride ?? resolvedField?.label ?? null);
+
+const help = $derived(helpOverride ?? resolvedField?.help ?? null);
+
+const required = $derived(resolvedField?.required ?? false);
+
+const hasDefault = $derived(resolvedField?.hasDefault ?? false);
+
+const defaultValue = $derived(resolvedField?.defaultValue);
+
+// Snippet escape hatch data
+const snippetProps = $derived<PolicyFieldSnippetProps>({
+  visible,
+  label,
+  help,
+  defaultValue,
+  required,
+  tier,
+});
+
+// --- Default prefill (new records only) ---
+// On mount, if this is a new record and the field has a resolved default,
+// prefill the wrapped input's value — but ONLY when the input is currently
+// empty (a loaded record with an existing value is never clobbered). The
+// prefill is a one-shot DOM write inside onMount (client-only), mirroring the
+// "defaults only apply to new records" invariant from the resolver.
+//
+// After writing a value we dispatch the event the matching binding listens to
+// (`input` for text-like controls, `change` for select/checkbox/radio) so a
+// consumer's `bind:value` variable picks the prefilled value up instead of
+// staying stale.
+let rootEl = $state<HTMLDivElement | null>(null);
+
+function prefillInputs(): void {
+  if (!rootEl || !isNewRecord || !hasDefault || defaultValue === undefined) {
+    return;
+  }
+
+  const inputs = rootEl.querySelectorAll<
+    HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+  >('input, textarea, select');
+
+  for (const input of inputs) {
+    if (input instanceof HTMLSelectElement) {
+      if (input.value === '' || input.value === undefined) {
+        input.value = String(defaultValue ?? '');
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      continue;
+    }
+
+    const inputType = (input as HTMLInputElement).type;
+    if (inputType === 'checkbox') {
+      const checkbox = input as HTMLInputElement;
+      if (!checkbox.checked && defaultValue === true) {
+        checkbox.checked = true;
+        checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      continue;
+    }
+
+    if (inputType === 'radio') {
+      const radio = input as HTMLInputElement;
+      if (String(defaultValue) === radio.value && !radio.checked) {
+        radio.checked = true;
+        radio.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      continue;
+    }
+
+    // text / textarea / number / date / etc.
+    const textInput = input as HTMLInputElement | HTMLTextAreaElement;
+    if (textInput.value === '' || textInput.value === undefined) {
+      textInput.value = String(defaultValue ?? '');
+      textInput.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  }
+}
+
+onMount(() => {
+  prefillInputs();
+});
+</script>
+
+{#if renderSnippet}
+  {@render renderSnippet(snippetProps)}
+{:else if visible}
+  <div class="policy-field {className}" bind:this={rootEl}>
+    {#if label !== null}
+      <label
+        class="policy-field__label"
+        for={name}
+        title={helpDensity === 'tooltip' && help !== null ? help : undefined}
+      >
+        {label}{#if required}<span class="policy-field__required" aria-hidden="true">*</span>{/if}
+      </label>
+    {/if}
+    {@render children?.()}
+    {#if help !== null && (helpDensity === 'hint' || label === null)}
+      <!-- Hint text density, or tooltip density with no label to attach the
+           title attribute to (fall back to visible help rather than dropping
+           it). -->
+      <p class="policy-field__hint" id="{name}-help">{help}</p>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .policy-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--smrt-spacing-1, 0.25rem);
+  }
+
+  .policy-field__label {
+    font: var(--smrt-typography-label-large-font, inherit);
+    color: var(--smrt-color-on-surface, currentColor);
+  }
+
+  .policy-field__required {
+    color: var(--smrt-color-error, #b3261e);
+    margin-left: 0.25em;
+  }
+
+  .policy-field__hint {
+    font: var(--smrt-typography-body-small-font, inherit);
+    color: var(--smrt-color-on-surface-variant, currentColor);
+    margin: 0;
+  }
+</style>

--- a/packages/fields/src/svelte/components/PolicyField.svelte
+++ b/packages/fields/src/svelte/components/PolicyField.svelte
@@ -22,7 +22,6 @@
  * forms can adopt it incrementally.
  */
 import type { Snippet } from 'svelte';
-import { onMount } from 'svelte';
 import { tryGetFieldPolicyContext } from '../context.svelte.js';
 import type { PolicyFieldSnippetProps } from '../types.js';
 
@@ -121,20 +120,26 @@ const snippetProps = $derived<PolicyFieldSnippetProps>({
 });
 
 // --- Default prefill (new records only) ---
-// On mount, if this is a new record and the field has a resolved default,
-// prefill the wrapped input's value — but ONLY when the input is currently
-// empty (a loaded record with an existing value is never clobbered). The
-// prefill is a one-shot DOM write inside onMount (client-only), mirroring the
-// "defaults only apply to new records" invariant from the resolver.
+// When this is a new record and the field has a resolved default, prefill the
+// wrapped input's value — but ONLY when the input is currently empty (a loaded
+// record with an existing value is never clobbered). Mirrors the "defaults
+// only apply to new records" invariant from the resolver.
+//
+// Runs via $effect rather than onMount so it also covers advanced-tier fields
+// that are hidden at mount and revealed later by the mode switch: the wrapper
+// div (and rootEl) only exist once the field is visible, and the effect re-runs
+// when visibility flips. A one-shot `prefilled` guard prevents re-filling an
+// input the user has deliberately cleared.
 //
 // After writing a value we dispatch the event the matching binding listens to
 // (`input` for text-like controls, `change` for select/checkbox/radio) so a
 // consumer's `bind:value` variable picks the prefilled value up instead of
 // staying stale.
 let rootEl = $state<HTMLDivElement | null>(null);
+let prefilled = false;
 
 function prefillInputs(): void {
-  if (!rootEl || !isNewRecord || !hasDefault || defaultValue === undefined) {
+  if (!rootEl) {
     return;
   }
 
@@ -144,7 +149,7 @@ function prefillInputs(): void {
 
   for (const input of inputs) {
     if (input instanceof HTMLSelectElement) {
-      if (input.value === '' || input.value === undefined) {
+      if (input.value === '') {
         input.value = String(defaultValue ?? '');
         input.dispatchEvent(new Event('change', { bubbles: true }));
       }
@@ -172,14 +177,31 @@ function prefillInputs(): void {
 
     // text / textarea / number / date / etc.
     const textInput = input as HTMLInputElement | HTMLTextAreaElement;
-    if (textInput.value === '' || textInput.value === undefined) {
+    if (textInput.value === '') {
       textInput.value = String(defaultValue ?? '');
       textInput.dispatchEvent(new Event('input', { bubbles: true }));
     }
   }
 }
 
-onMount(() => {
+// Prefill is a one-shot per component instance: it runs the first time the
+// wrapper exists with a usable default (mount for visible fields, or first
+// reveal for advanced-tier fields hidden in basic mode). The `visible` read
+// makes the effect re-run when a hidden field becomes visible; the `prefilled`
+// guard keeps it one-shot so a user who clears the input is never re-filled.
+$effect(() => {
+  if (prefilled || !visible || !isNewRecord || !hasDefault) {
+    return;
+  }
+  if (defaultValue === undefined || defaultValue === null) {
+    return;
+  }
+  if (!rootEl) {
+    // Wrapper not mounted yet — rootEl is tracked $state, so the effect
+    // re-runs once the binding lands.
+    return;
+  }
+  prefilled = true;
   prefillInputs();
 });
 </script>

--- a/packages/fields/src/svelte/components/PolicyField.svelte
+++ b/packages/fields/src/svelte/components/PolicyField.svelte
@@ -184,6 +184,36 @@ function prefillInputs(): void {
   }
 }
 
+// Link the help hint to the first wrapped control programmatically. Only
+// when the hint is actually rendered as a paragraph (hint density, or tooltip
+// density with no label) — otherwise the aria-describedby target would not
+// exist. Respects a consumer-provided aria-describedby and only fills in the
+// missing association. Runs after the wrapper exists, so it also covers
+// advanced-tier fields revealed later by the mode switch.
+const hintRendered = $derived(
+  help !== null && (helpDensity === 'hint' || label === null),
+);
+
+$effect(() => {
+  if (!rootEl || !hintRendered) {
+    return;
+  }
+  const control = rootEl.querySelector<HTMLElement>('input, textarea, select');
+  if (!control) {
+    return;
+  }
+  if (control.hasAttribute('aria-describedby')) {
+    return; // Consumer owns the association — never overwrite it.
+  }
+  control.setAttribute('aria-describedby', `${name}-help`);
+  return () => {
+    // Hint no longer rendered (or wrapper torn down) — drop the link we added.
+    if (control.getAttribute('aria-describedby') === `${name}-help`) {
+      control.removeAttribute('aria-describedby');
+    }
+  };
+});
+
 // Prefill is a one-shot per component instance: it runs the first time the
 // wrapper exists with a usable default (mount for visible fields, or first
 // reveal for advanced-tier fields hidden in basic mode). The `visible` read

--- a/packages/fields/src/svelte/components/PolicyField.svelte
+++ b/packages/fields/src/svelte/components/PolicyField.svelte
@@ -7,10 +7,18 @@
  *   basic mode)
  * - Initial-value prefill from the resolved default (new records only —
  *   never clobbers loaded values)
- * - Label rendering (resolved label or fallback to field name)
+ * - Label rendering (the resolved label; when the policy has no label the
+ *   label element is omitted rather than fabricated from the raw field name,
+ *   and tooltip-density help falls back to a visible hint)
  * - Help hint rendered from resolved help (manifest description → org/user
  *   override)
  * - Required marker
+ *
+ * Label ↔ control association: the default wrapper renders
+ * `<label for={name}>`, so the wrapped control should carry an `id` equal to
+ * the field `name`. When the first wrapped control has a different `id`, the
+ * `for` attribute is re-pointed to it after mount; when it has no `id` at
+ * all, the wrapper assigns `id={name}` so the association is guaranteed.
  *
  * Headless escape hatch: pass a `render` snippet receiving
  * `{visible, label, help, defaultValue, required, tier}` for fully custom
@@ -214,6 +222,40 @@ $effect(() => {
   };
 });
 
+// --- Label ↔ control association (default wrapper only) ---
+// The wrapper renders `<label for={name}>`, which only associates with the
+// wrapped control when that control's `id` matches. Consumers normally give
+// the input `id={name}`; this effect repairs the association once the wrapper
+// exists (covering advanced-tier fields revealed later by the mode switch):
+// - control with its own id → re-point `for` at that id;
+// - control with no id → assign `id={name}` so the association holds;
+// - no wrapped control at all → omit `for` (a dangling reference is worse
+//   than none).
+//
+// `controlId` is undefined until the first effect pass (SSR and first paint
+// keep the documented `for={name}` convention); afterwards it is the repaired
+// target id, or null when there is no wrapped control.
+let controlId = $state<string | null | undefined>(undefined);
+
+$effect(() => {
+  if (!rootEl || label === null || !visible) {
+    return;
+  }
+  // Form controls only — buttons and contenteditable hosts are out of scope
+  // (same scope as the aria-describedby effect above).
+  const control = rootEl.querySelector<HTMLElement>('input, textarea, select');
+  if (!control) {
+    controlId = null;
+    return;
+  }
+  if (control.id) {
+    controlId = control.id;
+  } else {
+    control.setAttribute('id', name);
+    controlId = name;
+  }
+});
+
 // Prefill is a one-shot per component instance: it runs the first time the
 // wrapper exists with a usable default (mount for visible fields, or first
 // reveal for advanced-tier fields hidden in basic mode). The `visible` read
@@ -241,9 +283,13 @@ $effect(() => {
 {:else if visible}
   <div class="policy-field {className}" bind:this={rootEl}>
     {#if label !== null}
+      <!-- `for` tracks the repaired label↔control association: the `name`
+           convention before the first effect pass (SSR / first paint), the
+           repaired control id afterwards; Svelte omits the attribute entirely
+           when it resolves to null (no wrapped control). -->
       <label
         class="policy-field__label"
-        for={name}
+        for={controlId === undefined ? name : controlId}
         title={helpDensity === 'tooltip' && help !== null ? help : undefined}
       >
         {label}{#if required}<span class="policy-field__required" aria-hidden="true">*</span>{/if}

--- a/packages/fields/src/svelte/context.svelte.ts
+++ b/packages/fields/src/svelte/context.svelte.ts
@@ -1,0 +1,92 @@
+/**
+ * Svelte context for the field-policy form primitives (#2048).
+ *
+ * `FieldPolicyProvider` seeds a {@link FieldPolicyContextValue} into the
+ * component tree from a pre-resolved {@link ResolvedObjectFieldPolicy} (SSR
+ * `initialData` or a client fetch by the app — no smrt-web import in the
+ * primitives). `PolicyField` and the mode-UX compositions read it through
+ * {@link getFieldPolicyContext} / {@link tryGetFieldPolicyContext}.
+ *
+ * Mirrors the established `tryGet…` pattern (`tryGetControlInteractionContext`,
+ * `useI18n`'s process-wide fallback) so `PolicyField` degrades gracefully
+ * outside a Provider: an unwrapped field renders its children verbatim, and a
+ * consumer can adopt the primitives incrementally without wrapping the whole
+ * form.
+ */
+
+import { getContext, setContext } from 'svelte';
+import type {
+  ResolvedFieldPolicy,
+  ResolvedObjectFieldPolicy,
+} from '../types.js';
+
+/** UI display mode for progressive disclosure. */
+export type FieldPolicyMode = 'basic' | 'advanced';
+
+/**
+ * Reactive mode store implemented as a class with `$state` fields. Svelte 5
+ * tracks `$state` on class instances correctly across context boundaries —
+ * the instance is the reactive root, not the closure.
+ */
+export class FieldPolicyModeStore {
+  current = $state<FieldPolicyMode>('basic');
+
+  constructor(initial: FieldPolicyMode = 'basic') {
+    this.current = initial;
+  }
+
+  set(next: FieldPolicyMode): void {
+    this.current = next;
+  }
+
+  toggle(): void {
+    this.current = this.current === 'basic' ? 'advanced' : 'basic';
+  }
+}
+
+/** Svelte 5 runes-backed reactive context published by FieldPolicyProvider. */
+export interface FieldPolicyContextValue {
+  /** The fully resolved policy for one object. */
+  readonly policy: ResolvedObjectFieldPolicy;
+  /** Reactive mode store (basic/advanced) owned by the provider. */
+  readonly mode: FieldPolicyModeStore;
+  /**
+   * Lookup of a single field's resolved policy by name.
+   * Returns `undefined` when the field is not in the resolved set.
+   */
+  getField(fieldName: string): ResolvedFieldPolicy | undefined;
+  /** Count of advanced-visible fields for the disclosure label. */
+  readonly advancedFieldCount: number;
+}
+
+const FIELD_POLICY_CONTEXT_KEY = Symbol('smrt-field-policy-context');
+
+/** Publish the context (called by FieldPolicyProvider). */
+export function setFieldPolicyContext(context: FieldPolicyContextValue): void {
+  setContext(FIELD_POLICY_CONTEXT_KEY, context);
+}
+
+/** Read the context, throwing when there is no Provider. */
+export function getFieldPolicyContext(): FieldPolicyContextValue {
+  const context = tryGetFieldPolicyContext();
+  if (!context) {
+    throw new Error(
+      'FieldPolicy context not found. Wrap your form in ' +
+        '<FieldPolicyProvider> from @happyvertical/smrt-fields/svelte.',
+    );
+  }
+  return context;
+}
+
+/**
+ * Optional reader — returns `undefined` when no Provider wraps the consumer.
+ * Used by `PolicyField` so it can render children verbatim outside a Provider
+ * (graceful degradation / incremental adoption).
+ */
+export function tryGetFieldPolicyContext():
+  | FieldPolicyContextValue
+  | undefined {
+  return getContext<FieldPolicyContextValue | undefined>(
+    FIELD_POLICY_CONTEXT_KEY,
+  );
+}

--- a/packages/fields/src/svelte/index.ts
+++ b/packages/fields/src/svelte/index.ts
@@ -1,0 +1,59 @@
+/**
+ * @happyvertical/smrt-fields/svelte
+ *
+ * Headless form primitives for policy-driven forms (#2048). These components
+ * consume a pre-resolved {@link ResolvedObjectFieldPolicy} (from
+ * `@happyvertical/smrt-fields`) and contribute visibility-by-mode, default
+ * prefill, label/help rendering, and progressive disclosure — without owning
+ * markup or layout.
+ *
+ * The primitives are policy-source agnostic: the app passes the resolved
+ * policy as props (SSR `initialData` or a client fetch). No `smrt-web` import
+ * in the core — an optional `./web` adapter can wire live invalidation for
+ * apps that want it.
+ *
+ * @packageDocumentation
+ */
+
+import type { ComponentProps } from 'svelte';
+import AdvancedFields from './components/AdvancedFields.svelte';
+import FieldPolicyProvider from './components/FieldPolicyProvider.svelte';
+import FormHelp from './components/FormHelp.svelte';
+import ModeSwitch from './components/ModeSwitch.svelte';
+import PolicyField from './components/PolicyField.svelte';
+
+// Components
+export {
+  AdvancedFields,
+  FieldPolicyProvider,
+  FormHelp,
+  ModeSwitch,
+  PolicyField,
+};
+
+// Component prop types
+export type AdvancedFieldsProps = ComponentProps<typeof AdvancedFields>;
+export type FieldPolicyProviderProps = ComponentProps<
+  typeof FieldPolicyProvider
+>;
+export type FormHelpProps = ComponentProps<typeof FormHelp>;
+export type ModeSwitchProps = ComponentProps<typeof ModeSwitch>;
+export type PolicyFieldProps = ComponentProps<typeof PolicyField>;
+
+// Re-export resolved-policy types consumers need (from the core package)
+export type {
+  ResolvedFieldPolicy,
+  ResolvedObjectFieldPolicy,
+} from '../types.js';
+export type {
+  FieldPolicyContextValue,
+  FieldPolicyMode,
+} from './context.svelte.js';
+// Context types and accessors
+export {
+  getFieldPolicyContext,
+  setFieldPolicyContext,
+  tryGetFieldPolicyContext,
+} from './context.svelte.js';
+// Snippet escape-hatch props
+export type { PolicyFieldSnippetProps } from './types.js';

--- a/packages/fields/src/svelte/playground.ts
+++ b/packages/fields/src/svelte/playground.ts
@@ -1,0 +1,32 @@
+/**
+ * Field-policy playground previews (#2048).
+ *
+ * Registered with the shared playground host via the auto-discovered
+ * "packages/STAR/src/svelte/playground.ts" convention (smrt-playground vite
+ * plugin).
+ */
+const loadFieldPolicyForm = () =>
+  import('./playground/FieldPolicyFormPreview.svelte');
+
+export default {
+  packageName: '@happyvertical/smrt-fields',
+  displayName: 'Field Policies',
+  description:
+    'Headless form primitives: FieldPolicyProvider, PolicyField, basic/advanced modes, and manifest-sourced help.',
+  entries: [
+    {
+      id: 'policy-form',
+      title: 'Policy-Driven Form',
+      description:
+        'A hand-written product form adopting PolicyField on a subset of fields — visibility by mode, default prefill, help hints, and the form-level glossary.',
+      loadComponent: loadFieldPolicyForm,
+      order: 1,
+      tags: ['forms', 'fields', 'policy', 'defaults'],
+      modes: {
+        mock: {
+          label: 'Mock',
+        },
+      },
+    },
+  ],
+};

--- a/packages/fields/src/svelte/playground/FieldPolicyFormPreview.svelte
+++ b/packages/fields/src/svelte/playground/FieldPolicyFormPreview.svelte
@@ -1,0 +1,212 @@
+<script lang="ts">
+/**
+ * Playground preview (#2048 AC1): a hand-written widget form that adopts
+ * PolicyField on a subset of its fields WITHOUT giving up its markup.
+ *
+ * The resolved policy is passed as a prop (the headless contract — the app
+ * supplies the policy, no smrt-web import). Two fields adopt PolicyField
+ * (name, sku) to gain help hints + required markers + prefill; the remaining
+ * fields stay as raw hand-written markup, proving "unwrapped fields keep
+ * working untouched" and "no layout change".
+ *
+ * The Basic/Advanced switch + disclosure + form help demonstrate the mode UX
+ * and glossary affordances layered over the same hand-written form.
+ */
+import { Input, Textarea } from '@happyvertical/smrt-ui/forms';
+import { Button } from '@happyvertical/smrt-ui/ui';
+import type { ResolvedObjectFieldPolicy } from '../../types.js';
+import {
+  AdvancedFields,
+  FieldPolicyProvider,
+  FormHelp,
+  ModeSwitch,
+  PolicyField,
+} from '../index.js';
+
+/**
+ * A resolved policy shaped exactly like `resolveFieldPolicy()` / the
+ * `resolveBatch` endpoint response. In a real app this comes from the server
+ * or the batch endpoint; here it is a static fixture for the mock playground.
+ */
+const resolvedPolicy: ResolvedObjectFieldPolicy = {
+  objectRef: '@happyvertical/smrt-products:Product',
+  fields: {
+    name: {
+      fieldName: 'name',
+      hasDefault: false,
+      defaultValue: undefined,
+      visibility: 'basic',
+      help: 'The customer-facing product name. Keep it short and unique.',
+      label: 'Product name',
+      order: 1,
+      group: null,
+      locked: false,
+      required: true,
+    },
+    sku: {
+      fieldName: 'sku',
+      hasDefault: true,
+      defaultValue: 'SKU-0000',
+      visibility: 'basic',
+      help: 'Stock-keeping unit. Auto-prefilled from the code default.',
+      label: 'SKU',
+      order: 2,
+      group: null,
+      locked: false,
+      required: false,
+    },
+    wholesalePrice: {
+      fieldName: 'wholesalePrice',
+      hasDefault: true,
+      defaultValue: 0,
+      visibility: 'advanced',
+      help: 'Per-unit price for wholesale channels. Hidden in basic mode.',
+      label: 'Wholesale price',
+      order: 3,
+      group: 'pricing',
+      locked: false,
+      required: false,
+    },
+    reorderPoint: {
+      fieldName: 'reorderPoint',
+      hasDefault: false,
+      defaultValue: undefined,
+      visibility: 'advanced',
+      help: 'Inventory level that triggers a reorder suggestion.',
+      label: 'Reorder point',
+      order: 4,
+      group: 'inventory',
+      locked: false,
+      required: false,
+    },
+  },
+};
+
+let name = $state('');
+let sku = $state('');
+let wholesalePrice = $state('');
+let reorderPoint = $state('');
+// A raw, unwrapped field — deliberately NOT wrapped in PolicyField.
+let rawNotes = $state('');
+
+let submitted = $state<string | null>(null);
+
+function handleSubmit() {
+  submitted = `Saved "${name || '(unnamed)'}" (sku: ${sku || '(auto)'})`;
+}
+</script>
+
+<section class="field-policy-preview">
+  <header class="preview-header">
+    <h2>Hand-written form adopting PolicyField</h2>
+    <p class="preview-desc">
+      A developer-authored product form. Two fields (name, SKU) adopt
+      PolicyField for help, defaults, and progressive disclosure; the rest stay
+      hand-written. Toggle the mode switch to reveal advanced-tier fields.
+    </p>
+    <FormHelp
+      objectDescription="A sellable catalog product with wholesale pricing and inventory controls."
+    />
+  </header>
+
+  <FieldPolicyProvider policy={resolvedPolicy} mode="basic">
+    <div class="toolbar">
+      <ModeSwitch />
+    </div>
+
+    <form class="widget-form" onsubmit={(e) => { e.preventDefault(); handleSubmit(); }}>
+      <!-- Adopted field: gets label, help hint, required marker from the policy -->
+      <PolicyField name="name">
+        <Input id="name" name="name" bind:value={name} placeholder="Widget Deluxe" />
+      </PolicyField>
+
+      <!-- Adopted field: prefilled with the resolved default on new records -->
+      <PolicyField name="sku">
+        <Input id="sku" name="sku" bind:value={sku} />
+      </PolicyField>
+
+      <!-- Unwrapped hand-written field — keeps working untouched -->
+      <div class="raw-field">
+        <label for="rawNotes">Notes (unwrapped, hand-written)</label>
+        <Textarea
+          id="rawNotes"
+          name="rawNotes"
+          bind:value={rawNotes}
+          placeholder="Free-form notes, no policy wrapping"
+        />
+      </div>
+
+      <!-- Advanced-tier fields live in the disclosure -->
+      <AdvancedFields>
+        <PolicyField name="wholesalePrice">
+          <Input id="wholesalePrice" name="wholesalePrice" type="number" bind:value={wholesalePrice} />
+        </PolicyField>
+        <PolicyField name="reorderPoint">
+          <Input id="reorderPoint" name="reorderPoint" type="number" bind:value={reorderPoint} />
+        </PolicyField>
+      </AdvancedFields>
+
+      <div class="actions">
+        <Button type="submit">Save product</Button>
+      </div>
+    </form>
+
+    {#if submitted}
+      <p class="status" role="status">{submitted}</p>
+    {/if}
+  </FieldPolicyProvider>
+</section>
+
+<style>
+  .field-policy-preview {
+    display: flex;
+    flex-direction: column;
+    gap: var(--smrt-spacing-4, 1rem);
+    max-width: 40rem;
+  }
+
+  .preview-header h2 {
+    font: var(--smrt-typography-headline-small-font, inherit);
+    margin: 0 0 var(--smrt-spacing-1, 0.25rem);
+  }
+
+  .preview-desc {
+    font: var(--smrt-typography-body-medium-font, inherit);
+    color: var(--smrt-color-on-surface-variant, currentColor);
+    margin: 0 0 var(--smrt-spacing-2, 0.5rem);
+  }
+
+  .toolbar {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: var(--smrt-spacing-3, 0.75rem);
+  }
+
+  .widget-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--smrt-spacing-3, 0.75rem);
+  }
+
+  .raw-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--smrt-spacing-1, 0.25rem);
+  }
+
+  .raw-field label {
+    font: var(--smrt-typography-label-large-font, inherit);
+    color: var(--smrt-color-on-surface, currentColor);
+  }
+
+  .actions {
+    display: flex;
+    gap: var(--smrt-spacing-2, 0.5rem);
+    padding-top: var(--smrt-spacing-2, 0.5rem);
+  }
+
+  .status {
+    font: var(--smrt-typography-body-medium-font, inherit);
+    color: var(--smrt-color-primary, #6750a4);
+  }
+</style>

--- a/packages/fields/src/svelte/types.ts
+++ b/packages/fields/src/svelte/types.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared types for the field-policy Svelte primitives.
+ */
+
+/**
+ * Props for the PolicyField headless snippet escape hatch — all the data a
+ * fully custom renderer needs.
+ */
+export interface PolicyFieldSnippetProps {
+  visible: boolean;
+  label: string | null;
+  help: string | null;
+  defaultValue: unknown;
+  required: boolean;
+  /** Resolved visibility tier from the policy. */
+  tier: 'basic' | 'advanced' | 'hidden';
+}

--- a/packages/fields/tsconfig.build.json
+++ b/packages/fields/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.package-build.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "exclude": [
+    "src/svelte/**/*",
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/fields/tsconfig.json
+++ b/packages/fields/tsconfig.json
@@ -9,5 +9,5 @@
     "lib": ["ES2023"]
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts", "src/svelte/**", "src/playground.ts"]
 }

--- a/packages/fields/tsconfig.svelte.json
+++ b/packages/fields/tsconfig.svelte.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.package-svelte.json",
+  "include": ["ambient.d.ts", "src/**/*.ts", "src/**/*.svelte"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/fields/vite.config.ts
+++ b/packages/fields/vite.config.ts
@@ -1,3 +1,6 @@
 import { createPackageConfig } from '../../vite.config.base.js';
 
-export default createPackageConfig('fields');
+export default createPackageConfig('fields', {
+  entries: ['playground'],
+  svelte: 'svelte',
+});

--- a/packages/fields/vitest.config.ts
+++ b/packages/fields/vitest.config.ts
@@ -1,8 +1,14 @@
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'vitest/config';
 import { smrtVitestPlugin } from '../vitest/src/index.ts';
 
 export default defineConfig({
-  plugins: [smrtVitestPlugin({ verbose: true })],
+  plugins: [smrtVitestPlugin({ verbose: true }), svelte({ hot: false })],
+  // Resolve Svelte's `browser` export condition so mount/unmount resolve to
+  // the client runtime under jsdom (mirrors agents/assets configs).
+  resolve: {
+    conditions: ['browser'],
+  },
   test: {
     globals: true,
     environment: 'node',
@@ -11,5 +17,9 @@ export default defineConfig({
     fileParallelism: false,
     pool: 'forks',
     singleFork: true,
+    // The shared Svelte component-test harness (S11 #1416). Only activates
+    // under a DOM, so node-environment tests are unaffected; component tests
+    // opt in with `// @vitest-environment jsdom`.
+    setupFiles: ['@happyvertical/smrt-vitest/svelte-setup'],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1063,6 +1063,9 @@ importers:
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy
+      '@happyvertical/smrt-ui':
+        specifier: workspace:*
+        version: link:../smrt-ui
       '@happyvertical/sql':
         specifier: ^0.85.5
         version: 0.85.5(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
@@ -1076,9 +1079,24 @@ importers:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest
+      '@sveltejs/package':
+        specifier: ^2.5.8
+        version: 2.5.8(svelte@5.56.4)(typescript@5.9.3)
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.1.2
+        version: 7.1.2(svelte@5.56.4)(vite@8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@testing-library/svelte':
+        specifier: ^5.4.2
+        version: 5.4.2(svelte@5.56.4)(vite@8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@4.1.10)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
+      svelte:
+        specifier: ^5.56.4
+        version: 5.56.4
+      svelte-check:
+        specifier: ^4.7.1
+        version: 4.7.1(picomatch@4.0.5)(svelte@5.56.4)(typescript@5.9.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

Implements #2048: headless form primitives for smrt-fields field policies, giving hand-written forms visibility, defaults, and help without giving up their markup.

New `@happyvertical/smrt-fields/svelte` subpath (per the plan-review addendum decision — smrt-ui cannot host these due to its import-graph rule, and domain-package Svelte subpaths are the established pattern):

- **`FieldPolicyProvider`** — Svelte context receiving the resolved policy as props (no smrt-web import; SSR `initialData`-compatible via `untrack()`-seeded `$state` with client-only `$effect` resync, mirroring ThemeProvider). Owns `basic`/`advanced` mode state.
- **`PolicyField`** — layout-neutral wrapper: visibility by resolved tier × mode, one-shot default prefill (new records only, never clobbers loaded values), label, help hint (hint/tooltip density), required marker, and a headless `render` snippet escape hatch receiving `{visible, label, help, defaultValue, required, tier}`. Degrades gracefully outside a Provider (`tryGetFieldPolicyContext`).
- **`ModeSwitch`** — Basic/Advanced SegmentedControl bound to provider mode.
- **`AdvancedFields`** — "Advanced · N fields" disclosure section.
- **`FormHelp`** — `?` affordance with object description + per-field glossary from the resolved policy.

Plus playground adoption (`FieldPolicyFormPreview`) demonstrating a hand-written form adopting PolicyField on a subset of fields.

### Prefill-on-reveal fix (found during validation)

`onMount`-based prefill never ran for advanced-tier fields hidden in basic mode — the wrapper div (and `rootEl` binding) only exist once the field is visible. Prefill is now a `$effect` tracking visibility + `rootEl` with a one-shot guard, so:

- advanced fields prefill on first reveal by the mode switch
- loaded records are never overwritten (`isNewRecord=false` skips entirely; empty-only writes otherwise)
- a deliberately cleared input is never re-filled
- a resolved default of `0`/`false` still prefills (guards only `null`/`undefined`)

## Acceptance criteria

- [x] Hand-written form adopts PolicyField on a subset of fields with no layout change (playground preview); unwrapped fields untouched
- [x] Basic mode hides advanced-tier fields; disclosure/toggle reveals them; prefill on new records only; loaded records never clobbered
- [x] Help hint renders from resolved help end-to-end (manifest description → resolver → client emission → UI); org/user override wins (resolver layer order, tested via resolved-policy props)
- [x] Primitives live in `@happyvertical/smrt-fields/svelte` (plan-review addendum decision replaces the smrt-ui/smrt-svelte AC); `svelte-check` green; **zero** `smrt-web` imports
- [x] Named-interface props only (no inline intersected generics); component tests per SMRT Svelte conventions (jsdom + testing-library + axe)

## Validation

```
pnpm vitest run src/svelte   → 36/36 passed (PolicyField 22, ModeUX 7, FormHelp 7)
pnpm test                    → 91/91 passed (7 files, full smrt-fields suite)
pnpm check (svelte-check)    → 0 errors, 0 warnings
pnpm typecheck               → clean
pnpm build                   → clean
pnpm verify:pack             → all packed exports verified (incl. dist/svelte)
pnpm knowledge:check --changed --strict → fresh (0 errors)
```

Lefthook pre-commit hooks (secret-scan, commitlint, knowledge-check) all passed on every commit.

## Review-cycle evidence

- **Codex CLI**: unavailable — hit ChatGPT usage limit ("try again at Aug 7th, 2026 9:36 PM" UTC). Recorded as blocker; not retried.
- **Copilot CLI**: unavailable — rejects the classic `ghp_` PAT in GITHUB_TOKEN (org only has a classic PAT; fine-grained token not available).
- **Fallback**: independent fresh-context reviewer subagent ran the full pre-commit verification pipeline on `git diff origin/main...HEAD` (76KB):
  - Static security scan: 0 secrets, 0 dangerous patterns (eval/exec/shell/pickle) — verified by reviewer
  - Verdict: **passed=true**, no security concerns, no logic errors
  - Suggestions addressed in `45c68d6c3`: `aria-describedby` linking the help hint to the wrapped control (+ test); ModeSwitch value validated instead of blindly cast
  - Deferred doc-level notes: label `for`/`id` convention assumes consumer uses `id={name}`; prefill writes the default to every control inside the wrapper (multi-control fields); AdvancedFields disclosure open-state resets on mode round-trip (children destroyed while hidden — acceptable, matches native `<details>` semantics)

Branch: `feat/issue-2048-field-policy-primitives` (3 commits, cleanly based on current origin/main `29e0e07be`).

Closes #2048


<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"hermes","session":"793e781d-4096-4020-9016-296a05ad0ace","issue":"https://github.com/happyvertical/smrt/issues/2048","policy_revision":"1.0.0","status":"complete","validation":["pnpm test 91/91 (fields)","svelte-check 0 errors","pnpm typecheck clean","pnpm build clean","pnpm verify:pack clean","knowledge:check --changed --strict fresh"]}
```

## Lifecycle re-trigger note (2026-08-07T00:58Z)

Fresh claim cycle after the released-blocked handoff (GitHub Actions incident qcvjkzcs7j74 recovered 2026-08-07T00:01Z, webhooks restored to full throughput). The org lifecycle check (agent-policy.yml) first ran on head `981480bc1` at 00:45Z and failed solely because this PR body predated the `hv-agent-run:v1` metadata requirement. Metadata added here; re-triggering validation on a new head via an empty `chore(ci)` commit. No code changes since the validated head `981480bc1`.
