### PR TITLE
feat(core): declare MCP structured response schemas

### DIFF
--- a/packages/core/src/generators/mcp-protocol.spec.ts
+++ b/packages/core/src/generators/mcp-protocol.spec.ts
@@ -68,11 +68,15 @@ describe('MCP Protocol Compliance', () => {
         expect(tool).toHaveProperty('name');
         expect(tool).toHaveProperty('description');
         expect(tool).toHaveProperty('inputSchema');
+        expect(tool).toHaveProperty('outputSchema');
 
         // Types
         expect(typeof tool.name).toBe('string');
         expect(typeof tool.description).toBe('string');
         expect(typeof tool.inputSchema).toBe('object');
+        expect(typeof tool.outputSchema).toBe('object');
+        // MCP outputSchema/structuredContent must use an object root.
+        expect(tool.outputSchema.type).toBe('object');
       });
     });
 
@@ -142,7 +146,7 @@ describe('MCP Protocol Compliance', () => {
       expect(getTool).toBeDefined();
       expect(getTool?.description).toContain('Get');
       expect(getTool?.inputSchema.properties).toHaveProperty('id');
-      expect(getTool?.inputSchema.required).toContain('id');
+      expect(getTool?.inputSchema.required).toBeUndefined();
     });
 
     it('should define custom action tools correctly', async () => {
@@ -188,6 +192,11 @@ describe('MCP Protocol Compliance', () => {
           expect(typeof item.text).toBe('string');
         }
       });
+
+      expect(response.structuredContent).toMatchObject({
+        data: expect.any(Array),
+        meta: expect.objectContaining({ count: expect.any(Number) }),
+      });
     });
 
     it('should return errors in MCP format', async () => {
@@ -208,6 +217,30 @@ describe('MCP Protocol Compliance', () => {
       const errorContent = response.content[0];
       expect(errorContent.type).toBe('text');
       expect(errorContent.text).toContain('Unknown tool');
+      expect(response.isError).toBe(true);
+      expect(response.structuredContent).toMatchObject({
+        error: { message: expect.stringContaining('Unknown tool') },
+      });
+    });
+
+    it('keeps custom-action text compatible while exposing an object envelope', async () => {
+      const item = await collection.create({ name: 'custom-result' });
+      await item.save();
+      const response = await generator.handleToolCall({
+        method: 'tools/call',
+        params: {
+          name: 'protocoltestobject_testaction',
+          arguments: { id: item.id },
+        },
+      });
+
+      expect(JSON.parse(response.content[0].text)).toMatchObject({
+        action: 'testAction',
+        result: 'success',
+      });
+      expect(response.structuredContent).toMatchObject({
+        data: { action: 'testAction', result: 'success' },
+      });
     });
   });
 

--- a/packages/core/src/generators/mcp-runtime-template.test.ts
+++ b/packages/core/src/generators/mcp-runtime-template.test.ts
@@ -11,6 +11,11 @@ describe('generated MCP custom-action runtime (#2182)', () => {
     expect(source).toContain("setRequestHandler('tools/call'");
     expect(source).toContain('serveStdio(() => createServer()');
     expect(source).toContain('await loadConfig()');
+    expect(source).toContain('structuredContent');
+    expect(source).toContain('function successResult');
+    expect(source).toContain('function errorResult');
+    expect(source).toContain('function resolveCreateTarget');
+    expect(source).toContain('ObjectRegistry.loadAllManifests');
     expect(source).not.toContain('@modelcontextprotocol/sdk');
     expect(source).not.toContain('initialize');
   });
@@ -85,5 +90,25 @@ describe('generated MCP custom-action runtime (#2182)', () => {
     expect(source).toContain('normalizeCustomActionFailure(result)');
     expect(source).toContain('isError: true');
     expect(source).not.toContain('customActions:');
+  });
+
+  it('resolves STI create discriminators before applying write policy', () => {
+    const source = generateRuntimeBootstrap({
+      tools: [
+        {
+          name: 'animal_create',
+          description: 'Create an animal',
+          inputSchema: { type: 'object' },
+        },
+      ],
+      stiTargets: {
+        animal: { '@test/animals:Cat': '@test/animals:Cat' },
+      },
+    });
+
+    expect(source).toContain("resolveCreateTarget('animal', args, aiConfig)");
+    expect(source).toContain('const STI_TARGETS');
+    expect(source).toContain('"@test/animals:Cat":"@test/animals:Cat"');
+    expect(source).toContain('applyWritablePolicy(targetObjectName, args)');
   });
 });

--- a/packages/core/src/generators/mcp-runtime-template.ts
+++ b/packages/core/src/generators/mcp-runtime-template.ts
@@ -44,6 +44,7 @@ export interface RuntimeOptions {
     name: string;
     description: string;
     inputSchema: Record<string, unknown>;
+    outputSchema?: Record<string, unknown>;
   }>;
   /** Internal invocation metadata; never exposed by the MCP tools/list result. */
   customActions?: Record<
@@ -67,6 +68,14 @@ export interface RuntimeOptions {
    * `SMRT_MCP_ALLOW_CROSS_TENANT` env vars (this server has no auth principal).
    */
   tenantScopedObjects?: string[];
+
+  /**
+   * Build-time approved STI discriminators, keyed by the lowercased MCP object
+   * prefix. The generated runtime uses this instead of searching an initially
+   * empty registry, then loads the approved qualified type through the public
+   * collection API.
+   */
+  stiTargets?: Record<string, Record<string, string>>;
 }
 
 /**
@@ -84,6 +93,7 @@ export function generateRuntimeBootstrap(options: RuntimeOptions = {}): string {
     tools = [],
     customActions = {},
     tenantScopedObjects = [],
+    stiTargets = {},
   } = options;
 
   // Generate static tool array as TypeScript code
@@ -113,13 +123,17 @@ ${indent}  const offset = args.offset ?? 0;
 ${indent}  const where = args.where ?? {};
 
 ${indent}  const collection = await ObjectRegistry.getCollection('${capitalize(objectName)}', {
-${indent}    persistence: { type: 'sql', url: process.env.DATABASE_URL || ':memory:' },
+${indent}    persistence: { type: process.env.DATABASE_TYPE || 'sqlite', url: process.env.DATABASE_URL || ':memory:' },
 ${indent}    ai: aiConfig
 ${indent}  });
 
 ${indent}  const items = await collection.list({ where, limit, offset });
 ${indent}  const itemsPublic = items.map((item) => item.toPublicJSON(PUBLIC_JSON_OPTIONS));
-${indent}  return { content: [{ type: 'text', text: JSON.stringify(itemsPublic) }] };
+${indent}  const structuredContent = {
+${indent}    data: itemsPublic,
+${indent}    meta: { total: await collection.count({ where }), limit, offset, count: items.length },
+${indent}  };
+${indent}  return successResult(structuredContent, JSON.stringify(itemsPublic));
 ${indent}}`;
 
           case 'get':
@@ -129,7 +143,7 @@ ${indent}    throw new Error('Either id or slug is required');
 ${indent}  }
 
 ${indent}  const collection = await ObjectRegistry.getCollection('${capitalize(objectName)}', {
-${indent}    persistence: { type: 'sql', url: process.env.DATABASE_URL || ':memory:' },
+${indent}    persistence: { type: process.env.DATABASE_TYPE || 'sqlite', url: process.env.DATABASE_URL || ':memory:' },
 ${indent}    ai: aiConfig
 ${indent}  });
 
@@ -140,20 +154,17 @@ ${indent}  if (!item) {
 ${indent}    throw new Error('Object not found');
 ${indent}  }
 
-${indent}  return { content: [{ type: 'text', text: JSON.stringify(item.toPublicJSON(PUBLIC_JSON_OPTIONS)) }] };
+${indent}  return successResult(item.toPublicJSON(PUBLIC_JSON_OPTIONS));
 ${indent}}`;
 
           case 'create':
             return `${indent}case '${tool.name}': {
-${indent}  const collection = await ObjectRegistry.getCollection('${capitalize(objectName)}', {
-${indent}    persistence: { type: 'sql', url: process.env.DATABASE_URL || ':memory:' },
-${indent}    ai: aiConfig
-${indent}  });
+${indent}  const { collection, objectName: targetObjectName } = await resolveCreateTarget('${objectName}', args, aiConfig);
 
-${indent}  const newItem = await collection.create(applyWritablePolicy('${capitalize(objectName)}', args));
+${indent}  const newItem = await collection.create(applyWritablePolicy(targetObjectName, args));
 ${indent}  await newItem.save();
 
-${indent}  return { content: [{ type: 'text', text: JSON.stringify(newItem.toPublicJSON(PUBLIC_JSON_OPTIONS)) }] };
+${indent}  return successResult(newItem.toPublicJSON(PUBLIC_JSON_OPTIONS));
 ${indent}}`;
 
           case 'update':
@@ -164,7 +175,7 @@ ${indent}    throw new Error('ID is required for update');
 ${indent}  }
 
 ${indent}  const collection = await ObjectRegistry.getCollection('${capitalize(objectName)}', {
-${indent}    persistence: { type: 'sql', url: process.env.DATABASE_URL || ':memory:' },
+${indent}    persistence: { type: process.env.DATABASE_TYPE || 'sqlite', url: process.env.DATABASE_URL || ':memory:' },
 ${indent}    ai: aiConfig
 ${indent}  });
 
@@ -176,7 +187,7 @@ ${indent}  }
 ${indent}  Object.assign(existing, applyWritablePolicy('${capitalize(objectName)}', updateData));
 ${indent}  await existing.save();
 
-${indent}  return { content: [{ type: 'text', text: JSON.stringify(existing.toPublicJSON(PUBLIC_JSON_OPTIONS)) }] };
+${indent}  return successResult(existing.toPublicJSON(PUBLIC_JSON_OPTIONS));
 ${indent}}`;
 
           case 'delete':
@@ -186,7 +197,7 @@ ${indent}    throw new Error('ID is required for delete');
 ${indent}  }
 
 ${indent}  const collection = await ObjectRegistry.getCollection('${capitalize(objectName)}', {
-${indent}    persistence: { type: 'sql', url: process.env.DATABASE_URL || ':memory:' },
+${indent}    persistence: { type: process.env.DATABASE_TYPE || 'sqlite', url: process.env.DATABASE_URL || ':memory:' },
 ${indent}    ai: aiConfig
 ${indent}  });
 
@@ -197,7 +208,7 @@ ${indent}  }
 
 ${indent}  await toDelete.delete();
 
-${indent}  return { content: [{ type: 'text', text: JSON.stringify({ success: true, message: 'Object deleted successfully' }) }] };
+${indent}  return successResult({ success: true, message: 'Object deleted successfully' });
 ${indent}}`;
 
           default:
@@ -215,7 +226,7 @@ ${indent}    throw new Error('Custom action ${action} is collection-scoped and d
 ${indent}  }
 
 ${indent}  const collection = await ObjectRegistry.getCollection('${capitalize(objectName)}', {
-${indent}    persistence: { type: 'sql', url: process.env.DATABASE_URL || ':memory:' },
+${indent}    persistence: { type: process.env.DATABASE_TYPE || 'sqlite', url: process.env.DATABASE_URL || ':memory:' },
 ${indent}    ai: aiConfig
 ${indent}  });
 
@@ -244,14 +255,15 @@ ${indent}        ]);
 ${indent}  const result = await actionMethod.call(target, ...methodArgs);
 ${indent}  const failure = normalizeCustomActionFailure(result);
 ${indent}  if (failure) {
-${indent}    return {
-${indent}      content: [{ type: 'text', text: JSON.stringify({ error: failure }) }],
-${indent}      isError: true,
-${indent}      _meta: { [SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY]: failure },
-${indent}    };
+${indent}    return errorResult(
+${indent}      { error: failure },
+${indent}      JSON.stringify({ error: failure }),
+${indent}      { [SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY]: failure },
+${indent}    );
 ${indent}  }
 
-${indent}  return { content: [{ type: 'text', text: JSON.stringify(toPublicResult(result)) }] };
+${indent}  const publicResult = toPublicResult(result);
+${indent}  return successResult({ data: publicResult }, JSON.stringify(publicResult));
 ${indent}}`;
         }
       })
@@ -280,6 +292,8 @@ import {
   Server,
 } from '@modelcontextprotocol/server';
 import { serveStdio } from '@modelcontextprotocol/server/stdio';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { ObjectRegistry } from '@happyvertical/smrt-core';
 import { normalizeCustomActionFailure, SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY } from '@happyvertical/smrt-core';
@@ -294,6 +308,7 @@ const DEBUG = ${debug};
 // Static tool definitions (generated at build time)
 const TOOLS = ${toolsCode};
 const CUSTOM_ACTIONS = ${JSON.stringify(customActions)};
+const STI_TARGETS: Record<string, Record<string, string>> = ${JSON.stringify(stiTargets)};
 ${
   hasTenantScoped
     ? `
@@ -347,6 +362,23 @@ function applyWritablePolicy(objectName: string, data: any): Record<string, any>
   return result;
 }
 
+/** Resolve an advertised STI discriminator to its registered subtype collection. */
+async function resolveCreateTarget(baseObjectName: string, args: Record<string, any>, aiConfig: any) {
+  let objectName = baseObjectName;
+  const discriminator = args._meta_type;
+  const targets = STI_TARGETS[baseObjectName];
+  if (typeof discriminator === 'string' && targets) {
+    const target = targets[discriminator];
+    if (!target) throw new Error('Unknown STI discriminator: ' + discriminator);
+    objectName = target;
+  }
+  const collection = await ObjectRegistry.getCollection(objectName, {
+    persistence: { type: process.env.DATABASE_TYPE || 'sqlite', url: process.env.DATABASE_URL || ':memory:' },
+    ai: aiConfig,
+  });
+  return { collection, objectName };
+}
+
 /**
  * Sensitive-field-safe serialization for custom-action results (#1540).
  * Recurses through arrays and plain objects so nested SmrtObjects are stripped
@@ -371,6 +403,22 @@ function toPublicResult(value: any, seen: WeakSet<object> = new WeakSet()): any 
   return out;
 }
 
+function successResult(structuredContent: any, text = JSON.stringify(structuredContent)) {
+  return {
+    content: [{ type: 'text', text }],
+    structuredContent,
+  };
+}
+
+function errorResult(structuredContent: any, text: string, _meta?: Record<string, any>) {
+  return {
+    content: [{ type: 'text', text }],
+    isError: true,
+    structuredContent,
+    ...(_meta ? { _meta } : {}),
+  };
+}
+
 /**
  * Main server startup function
  */
@@ -390,6 +438,17 @@ ${
 `
     : ''
 }
+    // Register the application package manifest before resolving generated
+    // object names. Generated servers are commonly run from the application
+    // package itself, which is not a node_modules dependency of its process.
+    const localManifestPaths = [
+      resolve(process.cwd(), 'dist', 'manifest.json'),
+      resolve(process.cwd(), '.smrt', 'manifest.json'),
+    ].filter(existsSync);
+    if (localManifestPaths.length > 0) {
+      ObjectRegistry.loadAllManifests({ manifestPaths: localManifestPaths });
+    }
+
     // Load configuration from environment and .smrt.config files
     const appConfig = await loadConfig();
     const aiConfig = appConfig?.ai || {};
@@ -467,15 +526,10 @@ ${
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
         console.error(\`[MCP] Tool execution failed: \${toolName}\`, error);
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: \`Error executing tool \${toolName}: \${errorMessage}\`,
-            },
-          ],
-          isError: true,
-        };
+        return errorResult(
+          { error: { message: errorMessage } },
+          \`Error executing tool \${toolName}: \${errorMessage}\`,
+        );
       }
     });
 

--- a/packages/core/src/generators/mcp-schemas.spec.ts
+++ b/packages/core/src/generators/mcp-schemas.spec.ts
@@ -194,6 +194,12 @@ class McpFkWidget extends SmrtObject {
   }
 }
 
+@smrt({ idType: 'text', mcp: { include: ['get', 'update', 'delete'] } })
+class McpTextIdWidget extends SmrtObject {
+  @field({ type: 'text' })
+  title = '';
+}
+
 @smrt({
   tableStrategy: 'sti',
   mcp: { include: ['create', 'get'] },
@@ -228,6 +234,22 @@ describe('MCP foreignKey field schema (#1500)', () => {
     const authorId = schema.$defs[ref.slice('#/$defs/'.length)];
     expect(authorId.type).toBe('string');
     expect(authorId.description).toContain('ID of related');
+  });
+});
+
+describe('MCP text identifier schemas (#2149)', () => {
+  it('does not falsely advertise UUID-only identifiers', async () => {
+    const generator = new MCPGenerator();
+    const tools = await generator.generateTools();
+
+    for (const action of ['get', 'update', 'delete']) {
+      const tool = tools.find(
+        (candidate) => candidate.name === `mcptextidwidget_${action}`,
+      );
+      const properties = tool?.inputSchema.properties as Record<string, any>;
+      expect(properties.id.type).toBe('string');
+      expect(properties.id.format).toBeUndefined();
+    }
   });
 });
 

--- a/packages/core/src/generators/mcp-schemas.spec.ts
+++ b/packages/core/src/generators/mcp-schemas.spec.ts
@@ -116,6 +116,10 @@ describe('MCP tool input schemas (#1500)', () => {
   it('allows id or slug on the get tool, with UUID-format ids', () => {
     const get = tool('mcpschemawidget_get');
     expect(get?.inputSchema.required).toBeUndefined();
+    expect(get?.inputSchema.anyOf).toEqual([
+      { required: ['id'] },
+      { required: ['slug'] },
+    ]);
     const props = get?.inputSchema.properties as Record<string, any>;
     expect(props.id.type).toBe('string');
     expect(props.id.format).toBe('uuid');

--- a/packages/core/src/generators/mcp-schemas.spec.ts
+++ b/packages/core/src/generators/mcp-schemas.spec.ts
@@ -65,10 +65,42 @@ describe('MCP tool input schemas (#1500)', () => {
 
   const tool = (name: string) => tools.find((t) => t.name === name);
 
+  const resolveField = (schema: any, propertyName: string) => {
+    const ref = schema.properties[propertyName].$ref as string;
+    return schema.$defs[ref.slice('#/$defs/'.length)];
+  };
+
   it('emits the five CRUD tools for the object', () => {
     for (const verb of ['list', 'get', 'create', 'update', 'delete']) {
       expect(tool(`mcpschemawidget_${verb}`)).toBeDefined();
     }
+  });
+
+  it('declares draft-2020-12 input/output schemas with local-only refs', () => {
+    const refs: string[] = [];
+    const collectRefs = (value: unknown): void => {
+      if (Array.isArray(value)) {
+        value.forEach(collectRefs);
+      } else if (value && typeof value === 'object') {
+        for (const [key, entry] of Object.entries(value)) {
+          if (key === '$ref') refs.push(String(entry));
+          collectRefs(entry);
+        }
+      }
+    };
+
+    for (const generatedTool of tools) {
+      expect(generatedTool.inputSchema.$schema).toBe(
+        'https://json-schema.org/draft/2020-12/schema',
+      );
+      expect(generatedTool.outputSchema.$schema).toBe(
+        'https://json-schema.org/draft/2020-12/schema',
+      );
+      collectRefs(generatedTool.inputSchema);
+      collectRefs(generatedTool.outputSchema);
+    }
+
+    expect(refs.every((ref) => ref.startsWith('#/$defs/'))).toBe(true);
   });
 
   it('builds the list tool with pagination + where properties', () => {
@@ -81,43 +113,50 @@ describe('MCP tool input schemas (#1500)', () => {
     expect(props.where.additionalProperties).toBe(true);
   });
 
-  it('marks id (not slug) as required on the get tool', () => {
+  it('allows id or slug on the get tool, with UUID-format ids', () => {
     const get = tool('mcpschemawidget_get');
-    expect(get?.inputSchema.required).toEqual(['id']);
+    expect(get?.inputSchema.required).toBeUndefined();
     const props = get?.inputSchema.properties as Record<string, any>;
     expect(props.id.type).toBe('string');
+    expect(props.id.format).toBe('uuid');
     expect(props.slug.type).toBe('string');
   });
 
   it('maps every field type in the create tool schema', () => {
     const create = tool('mcpschemawidget_create');
-    const props = create?.inputSchema.properties as Record<string, any>;
+    const schema = create?.inputSchema as any;
+    const title = resolveField(schema, 'title');
+    const count = resolveField(schema, 'count');
+    const rating = resolveField(schema, 'rating');
+    const active = resolveField(schema, 'active');
+    const startsAt = resolveField(schema, 'startsAt');
+    const payload = resolveField(schema, 'payload');
 
     // text with length constraints
-    expect(props.title.type).toBe('string');
-    expect(props.title.maxLength).toBe(50);
-    expect(props.title.minLength).toBe(3);
+    expect(title.type).toBe('string');
+    expect(title.maxLength).toBe(50);
+    expect(title.minLength).toBe(3);
 
     // integer with min/max + default
-    expect(props.count.type).toBe('integer');
-    expect(props.count.minimum).toBe(0);
-    expect(props.count.maximum).toBe(10);
-    expect(props.count.default).toBe(1);
+    expect(count.type).toBe('integer');
+    expect(count.minimum).toBe(0);
+    expect(count.maximum).toBe(10);
+    expect(count.default).toBe(1);
 
     // decimal → number with min/max
-    expect(props.rating.type).toBe('number');
-    expect(props.rating.minimum).toBe(0.5);
-    expect(props.rating.maximum).toBe(99.5);
+    expect(rating.type).toBe('number');
+    expect(rating.minimum).toBe(0.5);
+    expect(rating.maximum).toBe(99.5);
 
     // boolean
-    expect(props.active.type).toBe('boolean');
+    expect(active.type).toBe('boolean');
 
-    // datetime → string/date-time
-    expect(props.startsAt.type).toBe('string');
-    expect(props.startsAt.format).toBe('date-time');
+    // nullable datetime → draft-2020-12 type union/date-time
+    expect(startsAt.type).toEqual(['string', 'null']);
+    expect(startsAt.format).toBe('date-time');
 
     // json → object
-    expect(props.payload.type).toBe('object');
+    expect(payload.type).toBe('object');
 
     // required-field propagation onto the create schema.
     expect(create?.inputSchema.required).toContain('title');
@@ -151,14 +190,94 @@ class McpFkWidget extends SmrtObject {
   }
 }
 
+@smrt({
+  tableStrategy: 'sti',
+  mcp: { include: ['create', 'get'] },
+})
+class McpStiAnimal extends SmrtObject {
+  @field({ type: 'text', required: true })
+  name = '';
+}
+
+@smrt({ mcp: { include: ['create', 'get'] } })
+class McpStiCat extends McpStiAnimal {
+  @field({ type: 'integer' })
+  lives = 9;
+}
+
+@smrt({ mcp: { include: ['get'] } })
+class McpSensitiveWidget extends SmrtObject {
+  @field({ type: 'text' })
+  title = '';
+
+  @field({ type: 'text', sensitive: true })
+  apiToken = '';
+}
+
 describe('MCP foreignKey field schema (#1500)', () => {
   it('renders a foreignKey field as a string with a related-id description', async () => {
     const generator = new MCPGenerator();
     const tools = await generator.generateTools();
     const create = tools.find((t) => t.name === 'mcpfkwidget_create');
-    const props = create?.inputSchema.properties as Record<string, any>;
-    expect(props.authorId.type).toBe('string');
-    expect(props.authorId.description).toContain('ID of related');
+    const schema = create?.inputSchema as any;
+    const ref = schema.properties.authorId.$ref as string;
+    const authorId = schema.$defs[ref.slice('#/$defs/'.length)];
+    expect(authorId.type).toBe('string');
+    expect(authorId.description).toContain('ID of related');
+  });
+});
+
+describe('MCP STI schemas (#2149)', () => {
+  it('uses a discriminated oneOf for STI create and public item shapes', async () => {
+    const generator = new MCPGenerator();
+    const tools = await generator.generateTools();
+    const create = tools.find((tool) => tool.name === 'mcpstianimal_create');
+    const get = tools.find((tool) => tool.name === 'mcpstianimal_get');
+
+    expect(create?.inputSchema.oneOf).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          properties: expect.objectContaining({
+            _meta_type: { const: '@happyvertical/smrt-core:McpStiCat' },
+          }),
+          required: expect.arrayContaining(['_meta_type']),
+        }),
+      ]),
+    );
+    if (!get) throw new Error('Expected MCP STI get tool');
+    const [successSchema] = get.outputSchema.anyOf ?? [];
+    expect(successSchema).toEqual(
+      expect.objectContaining({
+        oneOf: expect.arrayContaining([
+          expect.objectContaining({
+            properties: expect.objectContaining({
+              _meta_type: { const: '@happyvertical/smrt-core:McpStiCat' },
+            }),
+          }),
+        ]),
+      }),
+    );
+  });
+});
+
+describe('MCP public output schemas (#2149)', () => {
+  it('does not expose sensitive fields declared behind toPublicJSON()', async () => {
+    const generator = new MCPGenerator();
+    const tools = await generator.generateTools();
+    const get = tools.find((tool) => tool.name === 'mcpsensitivewidget_get');
+    if (!get) throw new Error('Expected MCP sensitive-widget get tool');
+    const [publicItem] = get.outputSchema.anyOf ?? [];
+
+    expect(publicItem).toEqual(
+      expect.objectContaining({
+        properties: expect.objectContaining({ title: expect.anything() }),
+      }),
+    );
+    expect(publicItem).toEqual(
+      expect.not.objectContaining({
+        properties: expect.objectContaining({ apiToken: expect.anything() }),
+      }),
+    );
   });
 });
 

--- a/packages/core/src/generators/mcp.test.ts
+++ b/packages/core/src/generators/mcp.test.ts
@@ -762,6 +762,9 @@ describe('MCPGenerator with Custom Actions', () => {
         expect(handlers).toContain(
           '[SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY]: failure',
         );
+        expect(handlers).toContain('const STI_TARGETS');
+        expect(handlers).toContain('resolveCreateTarget');
+        expect(handlers).toContain("process.env.DATABASE_TYPE || 'sqlite'");
       } finally {
         await rm(outputDir, { recursive: true, force: true });
       }

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -12,7 +12,6 @@ import { ObjectRegistry } from '../registry';
 import type { RegisteredClass } from '../registry/types.js';
 import type { FieldDefinition, MethodDefinition } from '../scanner/types.js';
 import {
-  buildCustomActionInputSchema,
   buildCustomActionInvocationArgs,
   type CustomActionFailure,
   type CustomActionMetadata,
@@ -29,13 +28,13 @@ import {
   type RuntimeOptions,
 } from './mcp-runtime-template.js';
 import { runWithTenantGate } from './tenant-gate.js';
-
-/**
- * A JSON Schema fragment for an MCP tool input property. The shape varies by
- * field kind (string/number/object/…), so values are `unknown`; this is only
- * ever serialized into the generated tool definitions, never read back.
- */
-type McpJsonSchema = Record<string, unknown>;
+import {
+  buildToolInputSchema,
+  fieldTypeToJsonSchema,
+  finalizeMcpJsonSchema,
+  type ToolFieldMeta,
+  type ToolJsonSchema,
+} from './tool-schema.js';
 
 /**
  * Runtime tool-call arguments. They arrive as untyped JSON from the MCP client,
@@ -87,11 +86,9 @@ export interface MCPContext {
 export interface MCPTool {
   name: string;
   description: string;
-  inputSchema: {
-    type: string;
-    properties: Record<string, McpJsonSchema>;
-    required?: string[];
-  };
+  inputSchema: ToolJsonSchema;
+  /** Public result schema for tools/call structuredContent. */
+  outputSchema: ToolJsonSchema;
 }
 
 export interface MCPRequest {
@@ -109,6 +106,8 @@ export interface MCPResponse {
   }>;
   isError?: boolean;
   _meta?: Record<string, unknown>;
+  /** Machine-readable projection matching the tool's declared outputSchema. */
+  structuredContent?: unknown;
 }
 
 class CustomActionFailureError extends Error {
@@ -238,33 +237,8 @@ export class MCPGenerator {
       tools.push({
         name: `${lowerName}_list`,
         description: `List ${objectName} objects with optional filtering`,
-        inputSchema: {
-          type: 'object',
-          properties: {
-            limit: {
-              type: 'integer',
-              description: 'Maximum number of items to return',
-              default: 50,
-              minimum: 1,
-              maximum: 1000,
-            },
-            offset: {
-              type: 'integer',
-              description: 'Number of items to skip',
-              default: 0,
-              minimum: 0,
-            },
-            orderBy: {
-              type: 'string',
-              description: 'Field to order by (e.g., "created_at DESC")',
-            },
-            where: {
-              type: 'object',
-              description: 'Filter conditions as key-value pairs',
-              additionalProperties: true,
-            },
-          },
-        },
+        inputSchema: this.buildInputSchema(objectName, 'list', fields),
+        outputSchema: this.buildOutputSchema(objectName, 'list', fields),
       });
     }
 
@@ -273,67 +247,28 @@ export class MCPGenerator {
       tools.push({
         name: `${lowerName}_get`,
         description: `Get a specific ${objectName} by ID or slug`,
-        inputSchema: {
-          type: 'object',
-          properties: {
-            id: {
-              type: 'string',
-              description: 'Unique identifier of the object',
-            },
-            slug: {
-              type: 'string',
-              description: 'URL-friendly identifier of the object',
-            },
-          },
-          required: ['id'],
-        },
+        inputSchema: this.buildInputSchema(objectName, 'get', fields),
+        outputSchema: this.buildOutputSchema(objectName, 'get', fields),
       });
     }
 
     // CREATE tool
     if (shouldInclude('create')) {
-      const properties: Record<string, McpJsonSchema> = {};
-      const required: string[] = [];
-
-      for (const [fieldName, field] of fields) {
-        properties[fieldName] = this.fieldToMCPSchema(field);
-        if (field._meta?.required) {
-          required.push(fieldName);
-        }
-      }
-
       tools.push({
         name: `${lowerName}_create`,
         description: `Create a new ${objectName}`,
-        inputSchema: {
-          type: 'object',
-          properties,
-          required,
-        },
+        inputSchema: this.buildInputSchema(objectName, 'create', fields),
+        outputSchema: this.buildOutputSchema(objectName, 'create', fields),
       });
     }
 
     // UPDATE tool
     if (shouldInclude('update')) {
-      const properties: Record<string, McpJsonSchema> = {
-        id: {
-          type: 'string',
-          description: 'ID of the object to update',
-        },
-      };
-
-      for (const [fieldName, field] of fields) {
-        properties[fieldName] = this.fieldToMCPSchema(field);
-      }
-
       tools.push({
         name: `${lowerName}_update`,
         description: `Update an existing ${objectName}`,
-        inputSchema: {
-          type: 'object',
-          properties,
-          required: ['id'],
-        },
+        inputSchema: this.buildInputSchema(objectName, 'update', fields),
+        outputSchema: this.buildOutputSchema(objectName, 'update', fields),
       });
     }
 
@@ -342,16 +277,8 @@ export class MCPGenerator {
       tools.push({
         name: `${lowerName}_delete`,
         description: `Delete a ${objectName} by ID`,
-        inputSchema: {
-          type: 'object',
-          properties: {
-            id: {
-              type: 'string',
-              description: 'ID of the object to delete',
-            },
-          },
-          required: ['id'],
-        },
+        inputSchema: this.buildInputSchema(objectName, 'delete', fields),
+        outputSchema: this.buildOutputSchema(objectName, 'delete', fields),
       });
     }
 
@@ -475,9 +402,17 @@ export class MCPGenerator {
     return {
       name: `${lowerName}_${methodName}`.toLowerCase(),
       description: `Execute ${methodName} action on ${objectName}`,
-      inputSchema: buildCustomActionInputSchema(
+      inputSchema: this.buildInputSchema(
+        objectName,
+        methodName,
+        ObjectRegistry.getFields(objectName),
         metadata,
-      ) as MCPTool['inputSchema'],
+      ),
+      outputSchema: this.buildOutputSchema(
+        objectName,
+        methodName,
+        ObjectRegistry.getFields(objectName),
+      ),
     };
   }
 
@@ -540,57 +475,242 @@ export class MCPGenerator {
     }
   }
 
+  /** Normalize registry fields for the transport-neutral schema emitter. */
+  private toToolFields(fields: Map<string, FieldDefinition>): ToolFieldMeta[] {
+    return Array.from(fields, ([name, field]) => ({
+      name,
+      type: field.type,
+      required: field.required ?? field._meta?.required,
+      nullable: field._meta?.nullable === true,
+      description:
+        typeof field._meta?.description === 'string'
+          ? field._meta.description
+          : undefined,
+      default: field._meta?.default,
+      maxLength: field._meta?.maxLength,
+      minLength: field._meta?.minLength,
+      min: field._meta?.min,
+      max: field._meta?.max,
+      related: field.related,
+    }));
+  }
+
   /**
-   * Convert field definition to MCP schema
+   * Add the optional STI discriminator branches to write schemas. The legacy
+   * branch preserves existing base-class creates that let SMRT pick the base
+   * type; an explicit `_meta_type` selects a known child collection below.
    */
-  private fieldToMCPSchema(field: FieldDefinition): McpJsonSchema {
-    const schema: McpJsonSchema = {
-      description: field._meta?.description || `${field.type} field`,
+  private buildInputSchema(
+    objectName: string,
+    action: string,
+    fields: Map<string, FieldDefinition>,
+    customAction?: CustomActionMetadata,
+  ): ToolJsonSchema {
+    const schema = buildToolInputSchema(
+      action,
+      this.toToolFields(fields),
+      customAction,
+    );
+    if (action !== 'create' && action !== 'update') return schema;
+
+    const variants = this.getStiVariants(objectName);
+    if (variants.length === 0) return schema;
+
+    const properties = {
+      ...((schema.properties as Record<string, ToolJsonSchema> | undefined) ??
+        {}),
+      _meta_type: {
+        type: 'string',
+        description:
+          'Optional STI discriminator. When provided for create, selects the declared subtype.',
+      },
+    };
+    return finalizeMcpJsonSchema({
+      ...schema,
+      properties,
+      oneOf: [
+        { not: { required: ['_meta_type'] } },
+        ...variants.map(({ name, discriminator }) => {
+          const variantFields = ObjectRegistry.getFields(name);
+          return {
+            properties: {
+              ...this.buildFieldSchemaProperties(variantFields),
+              _meta_type: { const: discriminator },
+            },
+            required: [
+              '_meta_type',
+              ...this.toToolFields(variantFields)
+                .filter((field) => field.required)
+                .map((field) => field.name),
+            ],
+          };
+        }),
+      ],
+    });
+  }
+
+  /**
+   * Public output schemas follow the actual `toPublicJSON()` boundary: known
+   * non-sensitive fields are described, while `additionalProperties` keeps
+   * framework/system fields and application transforms honest.
+   */
+  private buildOutputSchema(
+    objectName: string,
+    action: string,
+    fields: Map<string, FieldDefinition>,
+  ): ToolJsonSchema {
+    const errorSchema: ToolJsonSchema = {
+      type: 'object',
+      properties: {
+        error: { type: 'object', additionalProperties: true },
+      },
+      required: ['error'],
     };
 
-    switch (field.type) {
-      case 'text':
-        schema.type = 'string';
-        if (field._meta?.maxLength) schema.maxLength = field._meta.maxLength;
-        if (field._meta?.minLength) schema.minLength = field._meta.minLength;
-        break;
-      case 'integer':
-        schema.type = 'integer';
-        if (field._meta?.min !== undefined) schema.minimum = field._meta.min;
-        if (field._meta?.max !== undefined) schema.maximum = field._meta.max;
-        break;
-      case 'decimal':
-        schema.type = 'number';
-        if (field._meta?.min !== undefined) schema.minimum = field._meta.min;
-        if (field._meta?.max !== undefined) schema.maximum = field._meta.max;
-        break;
-      case 'boolean':
-        schema.type = 'boolean';
-        break;
-      case 'datetime':
-        schema.type = 'string';
-        schema.format = 'date-time';
-        break;
-      case 'json':
-        schema.type = 'object';
-        break;
-      case 'foreignKey':
-        schema.type = 'string';
-        // Lockstep with tool-schema.ts fieldTypeToJsonSchema: the generic
-        // relation hint is a fallback — an authored description wins (#2046).
-        if (!field._meta?.description) {
-          schema.description = `ID of related ${field.related || 'object'}`;
-        }
-        break;
-      default:
-        schema.type = 'string';
+    if (!['list', 'get', 'create', 'update', 'delete'].includes(action)) {
+      // Custom action results are deliberately domain-defined and can be any
+      // JSON value. MCP structuredContent itself must be object-rooted, so the
+      // machine-readable projection carries that value in `data`; legacy text
+      // keeps the original public result unchanged.
+      return finalizeMcpJsonSchema({
+        type: 'object',
+        anyOf: [
+          {
+            type: 'object',
+            properties: { data: {} },
+            required: ['data'],
+          },
+          { $ref: '#/$defs/error' },
+        ],
+        $defs: { error: errorSchema },
+      });
     }
 
-    if (field._meta?.default !== undefined) {
-      schema.default = field._meta.default;
+    const itemSchema = this.buildPublicItemSchema(objectName, fields);
+
+    if (action === 'list') {
+      return finalizeMcpJsonSchema({
+        type: 'object',
+        anyOf: [
+          {
+            type: 'object',
+            properties: {
+              data: {
+                type: 'array',
+                items: { $ref: '#/$defs/publicItem' },
+              },
+              meta: {
+                type: 'object',
+                properties: {
+                  total: { type: 'integer', minimum: 0 },
+                  limit: { type: 'integer', minimum: 0 },
+                  offset: { type: 'integer', minimum: 0 },
+                  count: { type: 'integer', minimum: 0 },
+                },
+                required: ['total', 'limit', 'offset', 'count'],
+              },
+            },
+            required: ['data', 'meta'],
+          },
+          { $ref: '#/$defs/error' },
+        ],
+        $defs: { publicItem: itemSchema, error: errorSchema },
+      });
     }
 
-    return schema;
+    if (action === 'delete') {
+      return finalizeMcpJsonSchema({
+        type: 'object',
+        anyOf: [
+          {
+            type: 'object',
+            properties: {
+              success: { const: true },
+              message: { type: 'string' },
+            },
+            required: ['success', 'message'],
+          },
+          { $ref: '#/$defs/error' },
+        ],
+        $defs: { error: errorSchema },
+      });
+    }
+
+    return finalizeMcpJsonSchema({
+      type: 'object',
+      anyOf: [itemSchema, { $ref: '#/$defs/error' }],
+      $defs: { error: errorSchema },
+    });
+  }
+
+  private buildPublicItemSchema(
+    objectName: string,
+    fields: Map<string, FieldDefinition>,
+  ): ToolJsonSchema {
+    const properties = this.buildFieldSchemaProperties(fields, true);
+
+    const variants = this.getStiVariants(objectName);
+    if (variants.length > 0) {
+      return {
+        oneOf: variants.map(({ name, discriminator }) => ({
+          type: 'object',
+          properties: {
+            ...this.buildFieldSchemaProperties(
+              ObjectRegistry.getFields(name),
+              true,
+            ),
+            _meta_type: { const: discriminator },
+          },
+          required: ['_meta_type'],
+          additionalProperties: true,
+        })),
+      };
+    }
+
+    return { type: 'object', properties, additionalProperties: true };
+  }
+
+  private buildFieldSchemaProperties(
+    fields: Map<string, FieldDefinition>,
+    publicOnly = false,
+  ): Record<string, ToolJsonSchema> {
+    const properties: Record<string, ToolJsonSchema> = {};
+    for (const [name, field] of fields) {
+      if (
+        publicOnly &&
+        (field._meta?.sensitive === true || field._meta?.transient === true)
+      ) {
+        continue;
+      }
+      const [toolField] = this.toToolFields(new Map([[name, field]]));
+      if (!toolField) continue;
+      properties[name] = { ...fieldTypeToJsonSchema(toolField) };
+    }
+    return properties;
+  }
+
+  private getStiVariants(
+    objectName: string,
+  ): Array<{ name: string; discriminator: string }> {
+    if (ObjectRegistry.getTableStrategy(objectName) !== 'sti') return [];
+
+    const base = ObjectRegistry.getClass(objectName);
+    const baseNames = new Set(
+      [objectName, base?.name, base?.qualifiedName].filter(
+        (name): name is string => typeof name === 'string',
+      ),
+    );
+    const variants = new Map<string, { name: string; discriminator: string }>();
+    for (const [key, info] of ObjectRegistry.getAllClasses()) {
+      const name = info.name || key;
+      const chain = ObjectRegistry.getInheritanceChain(name);
+      if (!chain.some((ancestor) => baseNames.has(ancestor))) continue;
+      const discriminator = info.qualifiedName || name;
+      variants.set(discriminator, { name, discriminator });
+    }
+    return Array.from(variants.values()).sort((left, right) =>
+      left.discriminator.localeCompare(right.discriminator),
+    );
   }
 
   /**
@@ -653,39 +773,71 @@ export class MCPGenerator {
         args,
         actualObjectName,
       );
+      const publicResult = this.toJsonValue(result);
+      const structuredContent = this.toStructuredContent(action, publicResult);
 
       return {
         content: [
           {
             type: 'text',
-            text: JSON.stringify(result, null, 2),
+            text: JSON.stringify(publicResult, null, 2),
           },
         ],
+        structuredContent,
       };
     } catch (error) {
       if (error instanceof CustomActionFailureError) {
+        const structuredContent = { error: error.failure };
         return {
           content: [
             {
               type: 'text',
-              text: JSON.stringify({ error: error.failure }),
+              text: JSON.stringify(structuredContent),
             },
           ],
           isError: true,
+          structuredContent,
           _meta: {
             [SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY]: error.failure,
           },
         };
       }
+      const message = error instanceof Error ? error.message : 'Unknown error';
       return {
         content: [
           {
             type: 'text',
-            text: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            text: `Error: ${message}`,
           },
         ],
+        isError: true,
+        structuredContent: { error: { message } },
       };
     }
+  }
+
+  /** Convert runtime values to the JSON values MCP structuredContent permits. */
+  private toJsonValue(value: unknown): unknown {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? null : JSON.parse(serialized);
+  }
+
+  /** Build the MCP-required object root without changing legacy text payloads. */
+  private toStructuredContent(
+    action: string,
+    publicResult: unknown,
+  ): Record<string, unknown> {
+    if (!['list', 'get', 'create', 'update', 'delete'].includes(action)) {
+      return { data: publicResult };
+    }
+    if (
+      publicResult === null ||
+      typeof publicResult !== 'object' ||
+      Array.isArray(publicResult)
+    ) {
+      throw new Error(`Expected object result for MCP ${action} action`);
+    }
+    return publicResult as Record<string, unknown>;
   }
 
   /**
@@ -857,8 +1009,29 @@ export class MCPGenerator {
     args: ToolArgs,
     objectName?: string,
   ): Promise<unknown> {
+    let targetCollection = collection;
+    let targetObjectName = objectName;
+    if (
+      action === 'create' &&
+      objectName &&
+      typeof args._meta_type === 'string'
+    ) {
+      const variant = this.getStiVariants(objectName).find(
+        (candidate) => candidate.discriminator === args._meta_type,
+      );
+      if (!variant) {
+        throw new Error(`Unknown STI discriminator: ${args._meta_type}`);
+      }
+      const classInfo = ObjectRegistry.getClass(variant.name);
+      if (!classInfo) {
+        throw new Error(`STI subtype '${variant.name}' is not registered`);
+      }
+      targetCollection = await this.getCollection(variant.name, classInfo);
+      targetObjectName = variant.name;
+    }
+
     const mutating = action !== 'list' && action !== 'get';
-    this.requireToolAuth(objectName, mutating);
+    this.requireToolAuth(targetObjectName, mutating);
 
     // Fail-closed tenant context (#1554). For tenant-scoped objects, establish
     // the context from the principal's tenant (or an explicit cross-tenant
@@ -867,12 +1040,12 @@ export class MCPGenerator {
     // is resolved inside tenancy by class name so it matches the interceptor.
     return runWithTenantGate(
       {
-        className: objectName,
+        className: targetObjectName,
         tenantId: this.context.tenantId,
         allowCrossTenant: this.context.allowCrossTenant,
         surface: 'MCP',
       },
-      () => this.runAction(collection, action, args, objectName),
+      () => this.runAction(targetCollection, action, args, targetObjectName),
     );
   }
 
@@ -1277,6 +1450,7 @@ export class MCPGenerator {
         tools,
         customActions: await this.runtimeCustomActions(tools),
         tenantScopedObjects: await this.tenantScopedObjectNames(tools),
+        stiTargets: this.runtimeStiTargets(tools),
       };
 
       const serverCode = generateRuntimeBootstrap(runtimeOptions);
@@ -1359,6 +1533,44 @@ export class MCPGenerator {
       };
     }
     return metadata;
+  }
+
+  /**
+   * Emit only the STI discriminator targets advertised by create-tool schemas.
+   * Generated processes start with an empty registry, so resolving the
+   * qualified target through `getCollection()` both validates the declaration
+   * and lets the public registry loader register the selected subtype.
+   */
+  private runtimeStiTargets(
+    tools: MCPTool[],
+  ): Record<string, Record<string, string>> {
+    const targets: Record<string, Record<string, string>> = {};
+    const classes = ObjectRegistry.getAllClasses();
+
+    for (const tool of tools) {
+      const separator = tool.name.indexOf('_');
+      if (separator === -1 || tool.name.slice(separator + 1) !== 'create') {
+        continue;
+      }
+      const objectPrefix = tool.name.slice(0, separator);
+      const matched = Array.from(classes.entries()).find(
+        ([key, info]) => (info.name || key).toLowerCase() === objectPrefix,
+      );
+      if (!matched) continue;
+
+      const [key, classInfo] = matched;
+      const variants = this.getStiVariants(classInfo.name || key);
+      if (variants.length === 0) continue;
+
+      targets[objectPrefix] = Object.fromEntries(
+        variants.map((variant) => [
+          variant.discriminator,
+          variant.discriminator,
+        ]),
+      );
+    }
+
+    return targets;
   }
 
   /**
@@ -1452,6 +1664,7 @@ export const tools: Array<{
   name: string;
   description: string;
   inputSchema: any;
+  outputSchema: any;
 }> = ${JSON.stringify(tools, null, 2)};
 `;
   }
@@ -1461,8 +1674,9 @@ export const tools: Array<{
    */
   private async generateToolSwitchCases(
     indent: string = '    ',
+    generatedTools?: MCPTool[],
   ): Promise<string> {
-    const tools = await this.generateTools();
+    const tools = generatedTools ?? (await this.generateTools());
 
     const capitalize = (str: string) =>
       str.charAt(0).toUpperCase() + str.slice(1);
@@ -1482,13 +1696,17 @@ ${indent}  const offset = args.offset ?? 0;
 ${indent}  const where = args.where ?? {};
 
 ${indent}  const collection = await ObjectRegistry.getCollection('${capitalize(objectName)}', {
-${indent}    persistence: { type: 'sql', url: process.env.DATABASE_URL || ':memory:' },
+${indent}    persistence: { type: process.env.DATABASE_TYPE || 'sqlite', url: process.env.DATABASE_URL || ':memory:' },
 ${indent}    ai: aiConfig
 ${indent}  });
 
 ${indent}  const items = await collection.list({ where, limit, offset });
 ${indent}  const itemsPublic = items.map((item) => item.toPublicJSON(PUBLIC_JSON_OPTIONS));
-${indent}  return { content: [{ type: 'text', text: JSON.stringify(itemsPublic) }] };
+${indent}  const structuredContent = {
+${indent}    data: itemsPublic,
+${indent}    meta: { total: await collection.count({ where }), limit, offset, count: items.length },
+${indent}  };
+${indent}  return successResult(structuredContent, JSON.stringify(itemsPublic));
 ${indent}}`;
 
             case 'get':
@@ -1498,7 +1716,7 @@ ${indent}    throw new Error('Either id or slug is required');
 ${indent}  }
 
 ${indent}  const collection = await ObjectRegistry.getCollection('${capitalize(objectName)}', {
-${indent}    persistence: { type: 'sql', url: process.env.DATABASE_URL || ':memory:' },
+${indent}    persistence: { type: process.env.DATABASE_TYPE || 'sqlite', url: process.env.DATABASE_URL || ':memory:' },
 ${indent}    ai: aiConfig
 ${indent}  });
 
@@ -1509,20 +1727,17 @@ ${indent}  if (!item) {
 ${indent}    throw new Error('Object not found');
 ${indent}  }
 
-${indent}  return { content: [{ type: 'text', text: JSON.stringify(item.toPublicJSON(PUBLIC_JSON_OPTIONS)) }] };
+${indent}  return successResult(item.toPublicJSON(PUBLIC_JSON_OPTIONS));
 ${indent}}`;
 
             case 'create':
               return `${indent}case '${tool.name}': {
-${indent}  const collection = await ObjectRegistry.getCollection('${capitalize(objectName)}', {
-${indent}    persistence: { type: 'sql', url: process.env.DATABASE_URL || ':memory:' },
-${indent}    ai: aiConfig
-${indent}  });
+${indent}  const { collection, objectName: targetObjectName } = await resolveCreateTarget('${objectName}', args, aiConfig);
 
-${indent}  const newItem = await collection.create(applyWritablePolicy('${capitalize(objectName)}', args));
+${indent}  const newItem = await collection.create(applyWritablePolicy(targetObjectName, args));
 ${indent}  await newItem.save();
 
-${indent}  return { content: [{ type: 'text', text: JSON.stringify(newItem.toPublicJSON(PUBLIC_JSON_OPTIONS)) }] };
+${indent}  return successResult(newItem.toPublicJSON(PUBLIC_JSON_OPTIONS));
 ${indent}}`;
 
             case 'update':
@@ -1533,7 +1748,7 @@ ${indent}    throw new Error('ID is required for update');
 ${indent}  }
 
 ${indent}  const collection = await ObjectRegistry.getCollection('${capitalize(objectName)}', {
-${indent}    persistence: { type: 'sql', url: process.env.DATABASE_URL || ':memory:' },
+${indent}    persistence: { type: process.env.DATABASE_TYPE || 'sqlite', url: process.env.DATABASE_URL || ':memory:' },
 ${indent}    ai: aiConfig
 ${indent}  });
 
@@ -1545,7 +1760,7 @@ ${indent}  }
 ${indent}  Object.assign(existing, applyWritablePolicy('${capitalize(objectName)}', updateData));
 ${indent}  await existing.save();
 
-${indent}  return { content: [{ type: 'text', text: JSON.stringify(existing.toPublicJSON(PUBLIC_JSON_OPTIONS)) }] };
+${indent}  return successResult(existing.toPublicJSON(PUBLIC_JSON_OPTIONS));
 ${indent}}`;
 
             case 'delete':
@@ -1555,7 +1770,7 @@ ${indent}    throw new Error('ID is required for delete');
 ${indent}  }
 
 ${indent}  const collection = await ObjectRegistry.getCollection('${capitalize(objectName)}', {
-${indent}    persistence: { type: 'sql', url: process.env.DATABASE_URL || ':memory:' },
+${indent}    persistence: { type: process.env.DATABASE_TYPE || 'sqlite', url: process.env.DATABASE_URL || ':memory:' },
 ${indent}    ai: aiConfig
 ${indent}  });
 
@@ -1566,7 +1781,7 @@ ${indent}  }
 
 ${indent}  await toDelete.delete();
 
-${indent}  return { content: [{ type: 'text', text: JSON.stringify({ success: true, message: 'Object deleted successfully' }) }] };
+${indent}  return successResult({ success: true, message: 'Object deleted successfully' });
 ${indent}}`;
 
             default: {
@@ -1623,7 +1838,7 @@ ${indent}    throw new Error('Custom action ${action} is collection-scoped and d
 ${indent}  }
 
 ${indent}  const collection = await ObjectRegistry.getCollection(${JSON.stringify(registeredName)}, {
-${indent}    persistence: { type: 'sql', url: process.env.DATABASE_URL || ':memory:' },
+${indent}    persistence: { type: process.env.DATABASE_TYPE || 'sqlite', url: process.env.DATABASE_URL || ':memory:' },
 ${indent}    ai: aiConfig
 ${indent}  });
 
@@ -1649,14 +1864,15 @@ ${indent}  const methodArgs = ${methodArgs.startsWith('[') ? methodArgs : `[${me
 ${indent}  const result = await actionMethod.call(target, ...methodArgs);
 ${indent}  const failure = normalizeCustomActionFailure(result);
 ${indent}  if (failure) {
-${indent}    return {
-${indent}      content: [{ type: 'text', text: JSON.stringify({ error: failure }) }],
-${indent}      isError: true,
-${indent}      _meta: { [SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY]: failure },
-${indent}    };
+${indent}    return errorResult(
+${indent}      { error: failure },
+${indent}      JSON.stringify({ error: failure }),
+${indent}      { [SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY]: failure },
+${indent}    );
 ${indent}  }
 
-${indent}  return { content: [{ type: 'text', text: JSON.stringify(toPublicResult(result)) }] };
+${indent}  const publicResult = toPublicResult(result);
+${indent}  return successResult({ data: publicResult }, JSON.stringify(publicResult));
 ${indent}}`;
             }
           }
@@ -1673,7 +1889,9 @@ ${indent}}`;
   private async generateHandlersFile(
     tenantScopedObjects: string[] = [],
   ): Promise<string> {
-    const switchCases = await this.generateToolSwitchCases('        ');
+    const tools = await this.generateTools();
+    const switchCases = await this.generateToolSwitchCases('        ', tools);
+    const stiTargets = this.runtimeStiTargets(tools);
     const tenantScopedSet = Array.from(
       new Set(tenantScopedObjects.map((n) => n.toLowerCase())),
     );
@@ -1713,6 +1931,7 @@ const PUBLIC_JSON_OPTIONS = {
     .map((permission) => permission.trim())
     .filter(Boolean),
 };
+const STI_TARGETS: Record<string, Record<string, string>> = ${JSON.stringify(stiTargets)};
 
 /**
  * Mass-assignment guard (#1540): strip framework/server-managed and
@@ -1747,6 +1966,23 @@ function applyWritablePolicy(objectName: string, data: any): Record<string, any>
   return result;
 }
 
+/** Resolve an advertised STI discriminator to its registered subtype collection. */
+async function resolveCreateTarget(baseObjectName: string, args: Record<string, any>, aiConfig: any) {
+  let objectName = baseObjectName;
+  const discriminator = args._meta_type;
+  const targets = STI_TARGETS[baseObjectName];
+  if (typeof discriminator === 'string' && targets) {
+    const target = targets[discriminator];
+    if (!target) throw new Error('Unknown STI discriminator: ' + discriminator);
+    objectName = target;
+  }
+  const collection = await ObjectRegistry.getCollection(objectName, {
+    persistence: { type: process.env.DATABASE_TYPE || 'sqlite', url: process.env.DATABASE_URL || ':memory:' },
+    ai: aiConfig,
+  });
+  return { collection, objectName };
+}
+
 /**
  * Sensitive-field-safe serialization for custom-action results (#1540).
  * Recurses through arrays and plain objects so nested SmrtObjects are stripped
@@ -1769,6 +2005,22 @@ function toPublicResult(value: any, seen: WeakSet<object> = new WeakSet()): any 
     out[key] = toPublicResult(entry, seen);
   }
   return out;
+}
+
+function successResult(structuredContent: any, text = JSON.stringify(structuredContent)) {
+  return {
+    content: [{ type: 'text', text }],
+    structuredContent,
+  };
+}
+
+function errorResult(structuredContent: any, text: string, _meta?: Record<string, any>) {
+  return {
+    content: [{ type: 'text', text }],
+    isError: true,
+    structuredContent,
+    ...(_meta ? { _meta } : {}),
+  };
 }
 
 /**
@@ -1810,15 +2062,10 @@ ${
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
 
-    return {
-      content: [
-        {
-          type: 'text',
-          text: \`Error executing tool \${name}: \${errorMessage}\`,
-        },
-      ],
-      isError: true,
-    };
+    return errorResult(
+      { error: { message: errorMessage } },
+      \`Error executing tool \${name}: \${errorMessage}\`,
+    );
   }
 }
 `;
@@ -1838,7 +2085,10 @@ ${
 
 import { Server } from '@modelcontextprotocol/server';
 import { serveStdio } from '@modelcontextprotocol/server/stdio';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { ObjectRegistry } from '@happyvertical/smrt-core';
 import { loadConfig } from '@happyvertical/smrt-config';
 import { getDatabase } from '@happyvertical/sql';
 import { getAI } from '@happyvertical/ai';
@@ -1854,6 +2104,17 @@ export async function createServer() {
     if (DEBUG) {
       console.error(\`[MCP] Starting server: \${SERVER_NAME} v\${SERVER_VERSION}\`);
       console.error(\`[MCP] Available tools:\`, tools.map(t => t.name).join(', '));
+    }
+
+    // Register the application package manifest before resolving generated
+    // object names. Generated servers are commonly run from the application
+    // package itself, which is not a node_modules dependency of its process.
+    const localManifestPaths = [
+      resolve(process.cwd(), 'dist', 'manifest.json'),
+      resolve(process.cwd(), '.smrt', 'manifest.json'),
+    ].filter(existsSync);
+    if (localManifestPaths.length > 0) {
+      ObjectRegistry.loadAllManifests({ manifestPaths: localManifestPaths });
     }
 
     // Load configuration from environment and .smrt.config files
@@ -1884,6 +2145,7 @@ export async function createServer() {
           name: tool.name,
           description: tool.description,
           inputSchema: tool.inputSchema,
+          outputSchema: tool.outputSchema,
         })),
       };
     });

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -510,6 +510,7 @@ export class MCPGenerator {
       action,
       this.toToolFields(fields),
       customAction,
+      ObjectRegistry.getConfig(objectName).idType,
     );
     if (action !== 'create' && action !== 'update') return schema;
 

--- a/packages/core/src/generators/tool-schema.test.ts
+++ b/packages/core/src/generators/tool-schema.test.ts
@@ -104,13 +104,18 @@ describe('buildToolInputSchema', () => {
     );
   });
 
-  it('accepts id OR slug for get (neither required at the schema level)', () => {
+  it('requires id OR slug for get', () => {
     const schema = buildToolInputSchema('get', PRODUCT_FIELDS);
     const props = schema.properties as Record<string, unknown>;
     expect(props).toHaveProperty('id');
     expect(props).toHaveProperty('slug');
-    // Relaxed from the historical required:['id'] so a slug-only call is valid.
+    // A branch-level requirement preserves slug-only lookup support while
+    // rejecting an empty argument object before it reaches the handler.
     expect(schema.required).toBeUndefined();
+    expect(schema.anyOf).toEqual([
+      { required: ['id'] },
+      { required: ['slug'] },
+    ]);
   });
 
   it('promotes required model fields onto the create schema', () => {

--- a/packages/core/src/generators/tool-schema.test.ts
+++ b/packages/core/src/generators/tool-schema.test.ts
@@ -118,6 +118,24 @@ describe('buildToolInputSchema', () => {
     ]);
   });
 
+  it('omits UUID format for text-id CRUD objects', () => {
+    for (const action of ['get', 'update', 'delete']) {
+      const schema = buildToolInputSchema(
+        action,
+        PRODUCT_FIELDS,
+        undefined,
+        'text',
+      );
+      const properties = schema.properties as Record<string, unknown>;
+      expect(properties.id).toEqual(
+        expect.objectContaining({ type: 'string' }),
+      );
+      expect(properties.id).not.toEqual(
+        expect.objectContaining({ format: 'uuid' }),
+      );
+    }
+  });
+
   it('promotes required model fields onto the create schema', () => {
     const schema = buildToolInputSchema('create', PRODUCT_FIELDS);
     expect(schema.required).toEqual(['name']);
@@ -212,6 +230,28 @@ describe('buildToolDescriptors', () => {
       toolPrefix: 'catalog_item',
     });
     expect(tool.name).toBe('catalog_item_list');
+  });
+
+  it('propagates text idType to every CRUD descriptor', () => {
+    const descriptors = buildToolDescriptors({
+      className: 'TextProduct',
+      fields: PRODUCT_FIELDS,
+      actions: ['get', 'update', 'delete'],
+      idType: 'text',
+    });
+
+    for (const descriptor of descriptors) {
+      const properties = descriptor.inputSchema.properties as Record<
+        string,
+        unknown
+      >;
+      expect(properties.id).toEqual(
+        expect.objectContaining({ type: 'string' }),
+      );
+      expect(properties.id).not.toEqual(
+        expect.objectContaining({ format: 'uuid' }),
+      );
+    }
   });
 });
 

--- a/packages/core/src/generators/tool-schema.test.ts
+++ b/packages/core/src/generators/tool-schema.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
+  assertMcpJsonSchemaSafety,
   buildToolDescriptors,
   buildToolInputSchema,
   fieldTypeToJsonSchema,
   isCrudAction,
+  JSON_SCHEMA_2020_12,
+  MCP_SCHEMA_LIMITS,
   type ToolFieldMeta,
 } from './tool-schema.js';
 
@@ -80,6 +83,16 @@ describe('fieldTypeToJsonSchema', () => {
     });
     expect(schema).toMatchObject({ minimum: 0, maximum: 9999, default: 0 });
   });
+
+  it('uses a nullable type union when metadata permits null', () => {
+    expect(
+      fieldTypeToJsonSchema({
+        name: 'publishedAt',
+        type: 'datetime',
+        nullable: true,
+      }),
+    ).toMatchObject({ type: ['string', 'null'], format: 'date-time' });
+  });
 });
 
 describe('buildToolInputSchema', () => {
@@ -103,8 +116,11 @@ describe('buildToolInputSchema', () => {
   it('promotes required model fields onto the create schema', () => {
     const schema = buildToolInputSchema('create', PRODUCT_FIELDS);
     expect(schema.required).toEqual(['name']);
+    expect(schema.$schema).toBe(JSON_SCHEMA_2020_12);
+    expect(schema.$defs).toBeDefined();
     const props = schema.properties as Record<string, unknown>;
     expect(props).toHaveProperty('price');
+    expect(props.name).toEqual({ $ref: '#/$defs/field_0' });
     expect(props).not.toHaveProperty('id'); // server-assigned, never on create
   });
 
@@ -121,6 +137,34 @@ describe('buildToolInputSchema', () => {
     expect(schema.required).toEqual(['id']);
     const props = schema.properties as Record<string, unknown>;
     expect(props).toHaveProperty('options');
+  });
+});
+
+describe('MCP JSON Schema safety bounds', () => {
+  it('rejects external refs without attempting to dereference them', () => {
+    expect(() =>
+      assertMcpJsonSchemaSafety({ $ref: 'https://example.test/schema.json' }),
+    ).toThrow('local #/$defs/ references');
+  });
+
+  it('rejects schemas whose composition exceeds the depth bound', () => {
+    const schema: Record<string, unknown> = {};
+    let cursor = schema;
+    for (let index = 0; index <= MCP_SCHEMA_LIMITS.maxDepth; index += 1) {
+      const next: Record<string, unknown> = {};
+      cursor.allOf = [next];
+      cursor = next;
+    }
+
+    expect(() => assertMcpJsonSchemaSafety(schema)).toThrow('levels of depth');
+  });
+
+  it('rejects schemas whose serialized size exceeds the transport budget', () => {
+    expect(() =>
+      assertMcpJsonSchemaSafety({
+        description: 'x'.repeat(MCP_SCHEMA_LIMITS.maxSerializedBytes),
+      }),
+    ).toThrow('serialized bytes');
   });
 });
 

--- a/packages/core/src/generators/tool-schema.ts
+++ b/packages/core/src/generators/tool-schema.ts
@@ -151,6 +151,9 @@ export interface ToolFieldMeta {
   related?: string;
 }
 
+/** Storage contract for the synthetic primary identifier. */
+export type ToolIdType = 'uuid' | 'text';
+
 /** The CRUD verbs with dedicated input-schema skeletons; anything else is custom. */
 const CRUD_ACTIONS = new Set(['list', 'get', 'create', 'update', 'delete']);
 
@@ -254,7 +257,14 @@ export function buildToolInputSchema(
   action: string,
   fields: ToolFieldMeta[],
   customAction?: CustomActionMetadata,
+  idType: ToolIdType = 'uuid',
 ): ToolJsonSchema {
+  const identifierSchema = (description: string): ToolJsonSchema => ({
+    type: 'string',
+    ...(idType === 'uuid' ? { format: 'uuid' } : {}),
+    description,
+  });
+
   switch (action) {
     case 'list':
       return finalizeMcpJsonSchema({
@@ -293,11 +303,7 @@ export function buildToolInputSchema(
         type: 'object',
         anyOf: [{ required: ['id'] }, { required: ['slug'] }],
         properties: {
-          id: {
-            type: 'string',
-            format: 'uuid',
-            description: 'Unique identifier of the object',
-          },
+          id: identifierSchema('Unique identifier of the object'),
           slug: {
             type: 'string',
             description: 'URL-friendly identifier of the object',
@@ -323,11 +329,7 @@ export function buildToolInputSchema(
       const { properties: fieldProperties, defs } =
         buildFieldProperties(fields);
       const properties: Record<string, ToolJsonSchema> = {
-        id: {
-          type: 'string',
-          format: 'uuid',
-          description: 'ID of the object to update',
-        },
+        id: identifierSchema('ID of the object to update'),
         ...fieldProperties,
       };
       return finalizeMcpJsonSchema({
@@ -342,11 +344,7 @@ export function buildToolInputSchema(
       return finalizeMcpJsonSchema({
         type: 'object',
         properties: {
-          id: {
-            type: 'string',
-            format: 'uuid',
-            description: 'ID of the object to delete',
-          },
+          id: identifierSchema('ID of the object to delete'),
         },
         required: ['id'],
       });
@@ -397,6 +395,7 @@ export function buildToolDescriptors(opts: {
   actions: string[];
   customActions?: Record<string, CustomActionMetadata>;
   toolPrefix?: string;
+  idType?: ToolIdType;
 }): ToolDescriptor[] {
   const { className, fields, actions } = opts;
   const prefix = (opts.toolPrefix ?? className).toLowerCase();
@@ -411,6 +410,7 @@ export function buildToolDescriptors(opts: {
       action,
       fields,
       opts.customActions?.[action],
+      opts.idType,
     ),
     readOnly: action === 'list' || action === 'get',
   }));

--- a/packages/core/src/generators/tool-schema.ts
+++ b/packages/core/src/generators/tool-schema.ts
@@ -31,6 +31,104 @@ import {
  */
 export type ToolJsonSchema = Record<string, unknown>;
 
+/** The only JSON Schema dialect emitted by generated MCP and WebMCP tools. */
+export const JSON_SCHEMA_2020_12 =
+  'https://json-schema.org/draft/2020-12/schema';
+
+/**
+ * Bounds for generated schemas. Field metadata is authored input, so it must
+ * not turn a tools/list response into an unbounded composition or validation
+ * workload. These limits are deliberately far above normal SMRT objects while
+ * still keeping schemas comfortably inside MCP transport budgets.
+ */
+export const MCP_SCHEMA_LIMITS = {
+  maxDepth: 16,
+  maxNodes: 2_048,
+  maxSerializedBytes: 65_536,
+} as const;
+
+/**
+ * Apply the draft-2020-12 dialect and reject schemas that violate MCP's
+ * bounded-composition contract. Generated schemas only ever reference local
+ * `$defs`; external refs are neither emitted nor followed.
+ */
+export function finalizeMcpJsonSchema(schema: ToolJsonSchema): ToolJsonSchema {
+  const finalized = {
+    ...schema,
+    $schema: JSON_SCHEMA_2020_12,
+  };
+  assertMcpJsonSchemaSafety(finalized);
+  return finalized;
+}
+
+/**
+ * Validate the resource envelope of an emitted schema without resolving refs.
+ * This is intentionally structural rather than a general JSON-Schema
+ * evaluator: the server already owns every schema it emits, and this guard
+ * exists to keep authored metadata from introducing hostile shape growth.
+ */
+export function assertMcpJsonSchemaSafety(schema: ToolJsonSchema): void {
+  let nodes = 0;
+  const ancestors = new WeakSet<object>();
+
+  const visit = (value: unknown, depth: number, key?: string): void => {
+    nodes += 1;
+    if (nodes > MCP_SCHEMA_LIMITS.maxNodes) {
+      throw new Error(
+        `MCP JSON Schema exceeds ${MCP_SCHEMA_LIMITS.maxNodes} nodes`,
+      );
+    }
+    if (depth > MCP_SCHEMA_LIMITS.maxDepth) {
+      throw new Error(
+        `MCP JSON Schema exceeds ${MCP_SCHEMA_LIMITS.maxDepth} levels of depth`,
+      );
+    }
+    if (key === '$ref') {
+      if (
+        typeof value !== 'string' ||
+        !value.startsWith('#/$defs/') ||
+        value.includes('://')
+      ) {
+        throw new Error(
+          'MCP JSON Schema may only use local #/$defs/ references',
+        );
+      }
+      return;
+    }
+    if (value === null || typeof value !== 'object') return;
+    if (ancestors.has(value)) {
+      throw new Error('MCP JSON Schema must not contain cyclic values');
+    }
+
+    ancestors.add(value);
+    if (Array.isArray(value)) {
+      for (const entry of value) visit(entry, depth + 1);
+    } else {
+      for (const [childKey, child] of Object.entries(value)) {
+        visit(child, depth + 1, childKey);
+      }
+    }
+    ancestors.delete(value);
+  };
+
+  visit(schema, 0);
+
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(schema);
+  } catch {
+    throw new Error('MCP JSON Schema must be JSON-serializable');
+  }
+  if (
+    new TextEncoder().encode(serialized).byteLength >
+    MCP_SCHEMA_LIMITS.maxSerializedBytes
+  ) {
+    throw new Error(
+      `MCP JSON Schema exceeds ${MCP_SCHEMA_LIMITS.maxSerializedBytes} serialized bytes`,
+    );
+  }
+}
+
 /**
  * Normalized field metadata — the intersection of what the runtime registry
  * (`FieldDefinition._meta`) and the build-time manifest (`WebFieldDefinition`)
@@ -47,6 +145,8 @@ export interface ToolFieldMeta {
   minLength?: number;
   min?: number;
   max?: number;
+  /** Field values may explicitly be null in the runtime/manifest contract. */
+  nullable?: boolean;
   /** For `foreignKey`: the related class name, for the generated description. */
   related?: string;
 }
@@ -103,6 +203,7 @@ export function fieldTypeToJsonSchema(field: ToolFieldMeta): ToolJsonSchema {
       schema.type = 'object';
       break;
     case 'foreignKey':
+    case 'crossPackageRef':
       schema.type = 'string';
       // The generic relation hint is a fallback only — an authored
       // `@field({ description })` wins (#2046 threads descriptions into web
@@ -119,7 +220,29 @@ export function fieldTypeToJsonSchema(field: ToolFieldMeta): ToolJsonSchema {
     schema.default = field.default;
   }
 
+  if (field.nullable && typeof schema.type === 'string') {
+    schema.type = [schema.type, 'null'];
+  }
+
   return schema;
+}
+
+function buildFieldProperties(fields: ToolFieldMeta[]): {
+  properties: Record<string, ToolJsonSchema>;
+  defs: Record<string, ToolJsonSchema>;
+} {
+  const properties: Record<string, ToolJsonSchema> = {};
+  const defs: Record<string, ToolJsonSchema> = {};
+
+  fields.forEach((field, index) => {
+    // Numeric keys avoid JSON Pointer escaping and keep output deterministic
+    // even for an authored field name containing `/` or `~`.
+    const defKey = `field_${index}`;
+    defs[defKey] = fieldTypeToJsonSchema(field);
+    properties[field.name] = { $ref: `#/$defs/${defKey}` };
+  });
+
+  return { properties, defs };
 }
 
 /**
@@ -134,7 +257,7 @@ export function buildToolInputSchema(
 ): ToolJsonSchema {
   switch (action) {
     case 'list':
-      return {
+      return finalizeMcpJsonSchema({
         type: 'object',
         properties: {
           limit: {
@@ -160,7 +283,7 @@ export function buildToolInputSchema(
             additionalProperties: true,
           },
         },
-      };
+      });
 
     case 'get':
       // Either `id` OR `slug` identifies the object (collection.get resolves
@@ -168,11 +291,12 @@ export function buildToolInputSchema(
       // that at least one is present. This intentionally relaxes mcp.ts's
       // historical `required: ['id']`, which over-constrained slug-only lookups;
       // when mcp.ts adopts this helper it inherits the fix.
-      return {
+      return finalizeMcpJsonSchema({
         type: 'object',
         properties: {
           id: {
             type: 'string',
+            format: 'uuid',
             description: 'Unique identifier of the object',
           },
           slug: {
@@ -180,44 +304,63 @@ export function buildToolInputSchema(
             description: 'URL-friendly identifier of the object',
           },
         },
-      };
+      });
 
     case 'create': {
-      const properties: Record<string, ToolJsonSchema> = {};
+      const { properties, defs } = buildFieldProperties(fields);
       const required: string[] = [];
       for (const field of fields) {
-        properties[field.name] = fieldTypeToJsonSchema(field);
         if (field.required) required.push(field.name);
       }
-      return { type: 'object', properties, required };
+      return finalizeMcpJsonSchema({
+        type: 'object',
+        properties,
+        ...(required.length > 0 ? { required } : {}),
+        ...(Object.keys(defs).length > 0 ? { $defs: defs } : {}),
+      });
     }
 
     case 'update': {
+      const { properties: fieldProperties, defs } =
+        buildFieldProperties(fields);
       const properties: Record<string, ToolJsonSchema> = {
-        id: { type: 'string', description: 'ID of the object to update' },
+        id: {
+          type: 'string',
+          format: 'uuid',
+          description: 'ID of the object to update',
+        },
+        ...fieldProperties,
       };
-      for (const field of fields) {
-        properties[field.name] = fieldTypeToJsonSchema(field);
-      }
-      return { type: 'object', properties, required: ['id'] };
+      return finalizeMcpJsonSchema({
+        type: 'object',
+        properties,
+        required: ['id'],
+        ...(Object.keys(defs).length > 0 ? { $defs: defs } : {}),
+      });
     }
 
     case 'delete':
-      return {
+      return finalizeMcpJsonSchema({
         type: 'object',
         properties: {
-          id: { type: 'string', description: 'ID of the object to delete' },
+          id: {
+            type: 'string',
+            format: 'uuid',
+            description: 'ID of the object to delete',
+          },
         },
         required: ['id'],
-      };
+      });
 
     default:
-      return buildCustomActionInputSchema(
-        customAction ?? {
-          scope: 'item',
-          idRequired: true,
-          isStatic: false,
-        },
+      return finalizeMcpJsonSchema(
+        buildCustomActionInputSchema(
+          customAction ?? {
+            scope: 'item',
+            idRequired: true,
+            isStatic: false,
+          },
+        ),
       );
   }
 }

--- a/packages/core/src/generators/tool-schema.ts
+++ b/packages/core/src/generators/tool-schema.ts
@@ -287,12 +287,11 @@ export function buildToolInputSchema(
 
     case 'get':
       // Either `id` OR `slug` identifies the object (collection.get resolves
-      // both), so neither is required at the schema level — the handler validates
-      // that at least one is present. This intentionally relaxes mcp.ts's
-      // historical `required: ['id']`, which over-constrained slug-only lookups;
-      // when mcp.ts adopts this helper it inherits the fix.
+      // both). The schema must require one of them just as the handler does,
+      // while still allowing slug-only lookups.
       return finalizeMcpJsonSchema({
         type: 'object',
+        anyOf: [{ required: ['id'] }, { required: ['slug'] }],
         properties: {
           id: {
             type: 'string',

--- a/packages/core/src/prebuild/index.ts
+++ b/packages/core/src/prebuild/index.ts
@@ -335,6 +335,7 @@ declare module '@smrt/web' {
   export interface SmrtWebFieldDefinition {
     type: SmrtWebFieldType;
     required?: boolean;
+    nullable?: boolean;
     default?: unknown;
     /** Developer-authored \`@field({ description })\` (#2046) — end-user help seed. */
     description?: string;

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -1759,6 +1759,7 @@ declare module '@happyvertical/smrt-virt-web' {
   export interface SmrtWebFieldDefinition {
     type: SmrtWebFieldType;
     required?: boolean;
+    nullable?: boolean;
     default?: unknown;
     /** Developer-authored \`@field({ description })\` (#2046) — end-user help seed. */
     description?: string;

--- a/packages/core/src/vite-plugin/web-collections.test.ts
+++ b/packages/core/src/vite-plugin/web-collections.test.ts
@@ -271,6 +271,31 @@ describe('buildWebToolDescriptors', () => {
     expect(definition.type).toEqual(['string', 'null']);
   });
 
+  it('does not advertise UUID-only identifiers for text-id objects', () => {
+    const entry = selectWebCollectionEntries(
+      manifest(
+        obj({
+          className: 'ExternalProduct',
+          collection: 'external-products',
+          decoratorConfig: { idType: 'text' },
+        }),
+      ),
+    )[0];
+
+    for (const action of ['get', 'update', 'delete']) {
+      const descriptor = buildWebToolDescriptors(entry).find(
+        (tool) => tool.action === action,
+      );
+      const properties = descriptor?.inputSchema.properties as Record<
+        string,
+        unknown
+      >;
+      expect(properties.id).not.toEqual(
+        expect.objectContaining({ format: 'uuid' }),
+      );
+    }
+  });
+
   it('uses the same item receiver and typed custom arguments as Node MCP', () => {
     const entry = selectWebCollectionEntries(
       manifest(

--- a/packages/core/src/vite-plugin/web-collections.test.ts
+++ b/packages/core/src/vite-plugin/web-collections.test.ts
@@ -229,13 +229,46 @@ describe('buildWebToolDescriptors', () => {
     const create = buildWebToolDescriptors(entry).find(
       (d) => d.action === 'create',
     );
-    const props = (create?.inputSchema.properties ?? {}) as Record<
-      string,
-      { description?: string }
-    >;
-    expect(props.name?.description).toBe('Display name shown on invoices');
+    const schema = create?.inputSchema as {
+      properties: Record<string, { $ref: string }>;
+      $defs: Record<string, { description?: string }>;
+    };
+    const definition = (name: string) =>
+      schema.$defs[schema.properties[name].$ref.slice('#/$defs/'.length)];
+    expect(definition('name').description).toBe(
+      'Display name shown on invoices',
+    );
     // No authored description → the type-derived fallback, not an empty string.
-    expect(props.price?.description).toBeTruthy();
+    expect(definition('price').description).toBeTruthy();
+  });
+
+  it('preserves nullable manifest fields in generated tool schemas', () => {
+    const entry = selectWebCollectionEntries(
+      manifest(
+        obj({
+          className: 'Product',
+          collection: 'products',
+          fields: {
+            discontinuedAt: field({
+              type: 'datetime',
+              _meta: { nullable: true },
+            }),
+          },
+        }),
+      ),
+    )[0];
+    const create = buildWebToolDescriptors(entry).find(
+      (tool) => tool.action === 'create',
+    );
+    const schema = create?.inputSchema as {
+      properties: Record<string, { $ref: string }>;
+      $defs: Record<string, { type?: unknown }>;
+    };
+    const definition =
+      schema.$defs[
+        schema.properties.discontinuedAt.$ref.slice('#/$defs/'.length)
+      ];
+    expect(definition.type).toEqual(['string', 'null']);
   });
 
   it('uses the same item receiver and typed custom arguments as Node MCP', () => {
@@ -508,6 +541,25 @@ describe('buildWebFieldDefinitions', () => {
       meta: { type: 'json' },
       ownerId: { type: 'foreignKey' },
       tenantRef: { type: 'crossPackageRef' },
+    });
+  });
+
+  it('carries nullable through as public field metadata', () => {
+    const fields = buildWebFieldDefinitions(
+      obj({
+        className: 'Product',
+        collection: 'products',
+        fields: {
+          discontinuedAt: field({
+            type: 'datetime',
+            _meta: { nullable: true },
+          }),
+        },
+      }),
+    );
+    expect(fields.discontinuedAt).toEqual({
+      type: 'datetime',
+      nullable: true,
     });
   });
 

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -79,6 +79,8 @@ export type WebFieldType = Exclude<
 export interface WebFieldDefinition {
   type: WebFieldType;
   required?: boolean;
+  /** Whether the public field contract explicitly permits `null`. */
+  nullable?: boolean;
   default?: unknown;
   /**
    * The developer-authored `@field({ description })` (#2046) — the same text
@@ -556,6 +558,7 @@ export function buildWebFieldDefinitions(
       // Safe: the three skips above are exactly the types WebFieldType excludes.
       type: field.type as WebFieldType,
       ...(field.required !== undefined ? { required: field.required } : {}),
+      ...(field._meta?.nullable === true ? { nullable: true } : {}),
       ...(field.default !== undefined ? { default: field.default } : {}),
       ...(description !== undefined ? { description } : {}),
       ...(ui ? { ui } : {}),
@@ -690,6 +693,7 @@ export function buildWebToolDescriptors(
       name,
       type: def.type,
       ...(def.required !== undefined ? { required: def.required } : {}),
+      ...(def.nullable === true ? { nullable: true } : {}),
       ...(def.default !== undefined ? { default: def.default } : {}),
       // #2046: the authored field description flows into the generated JSON
       // Schema (`fieldTypeToJsonSchema` prefers it over the type-derived

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -680,9 +680,9 @@ export function buildWebRelationships(
  * Deliberately NOT part of {@link buildWebCollectionDefinition}: descriptors are
  * layered onto the emitted value by {@link generateWebModule} instead, so the
  * #1764 {@link computeWebManifestHash} shape digest keeps hashing ONLY the row
- * shape. That is safe because a descriptor is a pure function of
- * className/actions/fields — all already in the hash — so excluding it never
- * lets the digest under-cover a real shape change.
+ * shape. That remains safe because descriptor-only inputs (including `idType`)
+ * do not alter persisted public rows or read responses, which are the cache
+ * contracts this digest protects.
  */
 export function buildWebToolDescriptors(
   entry: WebCollectionEntry,
@@ -717,6 +717,7 @@ export function buildWebToolDescriptors(
         }),
       ]),
     ),
+    idType: entry.obj.decoratorConfig.idType,
   });
 }
 

--- a/packages/mcp-conformance-fixture/src/fixture-objects.ts
+++ b/packages/mcp-conformance-fixture/src/fixture-objects.ts
@@ -21,3 +21,26 @@ export class ConformanceGadget extends SmrtObject {
 export class ConformanceGadgetCollection extends SmrtCollection<ConformanceGadget> {
   static readonly _itemClass = ConformanceGadget;
 }
+
+@smrt({
+  tableStrategy: 'sti',
+  api: false,
+  cli: false,
+  mcp: { include: ['create', 'get'] },
+})
+export class ConformanceAnimal extends SmrtObject {
+  name = '';
+}
+
+@smrt({ api: false, cli: false })
+export class ConformanceCat extends ConformanceAnimal {
+  lives = 9;
+}
+
+export class ConformanceAnimalCollection extends SmrtCollection<ConformanceAnimal> {
+  static readonly _itemClass = ConformanceAnimal;
+}
+
+export class ConformanceCatCollection extends SmrtCollection<ConformanceCat> {
+  static readonly _itemClass = ConformanceCat;
+}

--- a/packages/mcp-conformance-fixture/src/generated-server-conformance.test.ts
+++ b/packages/mcp-conformance-fixture/src/generated-server-conformance.test.ts
@@ -3,6 +3,7 @@ import { mkdir, rm } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { MCPGenerator } from '@happyvertical/smrt-core/generators/mcp';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
 import { Client } from '@modelcontextprotocol/client';
 import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 import {
@@ -18,15 +19,25 @@ const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = resolve(packageRoot, '..', '..');
 const generatedDir = join(packageRoot, '.generated-tmp');
 const generatedPath = join(generatedDir, 'index.ts');
+const generatedDatabasePath = join(generatedDir, 'fixture.sqlite');
 const tsxBin = join(repoRoot, 'node_modules', '.bin', 'tsx');
 const conformanceBin = join(packageRoot, 'node_modules', '.bin', 'conformance');
 const baselinePath = join(packageRoot, 'conformance-baseline.yml');
 let httpChild: ChildProcess | undefined;
 let mcpUrl: string;
+const originalDatabaseUrl = process.env.DATABASE_URL;
+const originalDatabaseType = process.env.DATABASE_TYPE;
 
 beforeAll(async () => {
   await rm(generatedDir, { force: true, recursive: true });
   await mkdir(generatedDir, { recursive: true });
+  await getTestDatabase({
+    type: 'sqlite',
+    url: generatedDatabasePath,
+    classes: ['ConformanceAnimal', 'ConformanceCat'],
+  });
+  process.env.DATABASE_TYPE = 'sqlite';
+  process.env.DATABASE_URL = generatedDatabasePath;
   const generator = new MCPGenerator({
     name: 'smrt-generated-conformance',
     version: '0.0.0',
@@ -60,8 +71,20 @@ beforeAll(async () => {
       expect.arrayContaining([
         'conformancewidget_list',
         'conformancegadget_create',
+        'conformanceanimal_create',
       ]),
     );
+    const listTool = tools.tools.find(
+      (tool) => tool.name === 'conformancewidget_list',
+    );
+    expect(listTool).toMatchObject({
+      inputSchema: {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+      },
+      outputSchema: {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+      },
+    });
   } finally {
     await client.close();
     await transport.close();
@@ -72,12 +95,64 @@ beforeAll(async () => {
 
 afterAll(async () => {
   httpChild?.kill('SIGTERM');
+  if (originalDatabaseType === undefined) {
+    delete process.env.DATABASE_TYPE;
+  } else {
+    process.env.DATABASE_TYPE = originalDatabaseType;
+  }
+  if (originalDatabaseUrl === undefined) {
+    delete process.env.DATABASE_URL;
+  } else {
+    process.env.DATABASE_URL = originalDatabaseUrl;
+  }
   if (process.env.MCP_CONFORMANCE_KEEP_GENERATED !== 'true') {
     await rm(generatedDir, { force: true, recursive: true });
   }
 });
 
 describe('generated Tier-1 MCP 2026-07-28 conformance', () => {
+  it('creates an advertised STI subtype through the generated runtime', async () => {
+    const transport = new StdioClientTransport({
+      command: tsxBin,
+      args: [generatedPath],
+      cwd: packageRoot,
+      stderr: 'pipe',
+      env: {
+        DATABASE_TYPE: 'sqlite',
+        DATABASE_URL: generatedDatabasePath,
+      },
+    });
+    const client = new Client(
+      { name: 'generated-sti-test', version: '0.0.0' },
+      {
+        capabilities: {},
+        versionNegotiation: { mode: { pin: '2026-07-28' } },
+      },
+    );
+    try {
+      await client.connect(transport);
+      const result = await client.callTool({
+        name: 'conformanceanimal_create',
+        arguments: {
+          name: 'Mittens',
+          lives: 7,
+          _meta_type:
+            '@happyvertical/smrt-mcp-conformance-fixture:ConformanceCat',
+        },
+      });
+      expect(result.isError, JSON.stringify(result)).not.toBe(true);
+      expect(result.structuredContent).toMatchObject({
+        name: 'Mittens',
+        lives: 7,
+        _meta_type:
+          '@happyvertical/smrt-mcp-conformance-fixture:ConformanceCat',
+      });
+    } finally {
+      await client.close();
+      await transport.close();
+    }
+  });
+
   it('answers discover with SDK-stamped complete metadata', async () => {
     const response = await fetch(mcpUrl, {
       method: 'POST',

--- a/packages/smrt-dev-mcp/src/index.test.ts
+++ b/packages/smrt-dev-mcp/src/index.test.ts
@@ -23,6 +23,16 @@ describe('smrt-dev-mcp tools', () => {
     expect(names).toContain('review-smrt-project');
     expect(names).toContain('list-agent-skills');
     expect(names).toContain('get-agent-skill');
+
+    for (const tool of TOOLS) {
+      expect(tool.inputSchema.$schema).toBe(
+        'https://json-schema.org/draft/2020-12/schema',
+      );
+      expect(tool.outputSchema).toMatchObject({
+        type: 'object',
+        required: ['ok', 'coverage', 'diagnostics', 'data'],
+      });
+    }
   });
 
   it('advertises the package version', () => {

--- a/packages/smrt-dev-mcp/src/index.ts
+++ b/packages/smrt-dev-mcp/src/index.ts
@@ -46,8 +46,33 @@ type KnowledgeIndexResult = Awaited<ReturnType<typeof buildKnowledgeIndex>>;
 type KnowledgePackageResult = KnowledgeIndexResult['packages'][number];
 type PromptArguments = Record<string, string> | undefined;
 
+const JSON_SCHEMA_2020_12 = 'https://json-schema.org/draft/2020-12/schema';
+
+/**
+ * Stable success/error envelope for development tools. `data` preserves each
+ * tool's existing payload exactly; coverage/diagnostics are promoted only when
+ * the underlying result actually reports them.
+ */
+const DEV_MCP_OUTPUT_SCHEMA: NonNullable<Tool['outputSchema']> = {
+  $schema: JSON_SCHEMA_2020_12,
+  type: 'object',
+  additionalProperties: false,
+  required: ['ok', 'coverage', 'diagnostics', 'data'],
+  properties: {
+    ok: { type: 'boolean' },
+    coverage: { type: ['object', 'null'], additionalProperties: true },
+    diagnostics: {
+      type: 'array',
+      items: { type: 'object', additionalProperties: true },
+    },
+    data: {},
+  },
+};
+
 // Tool definitions
-export const TOOLS = [
+const TOOL_DEFINITIONS: Array<
+  Pick<Tool, 'name' | 'description' | 'inputSchema'>
+> = [
   // Code Generation Tools
   {
     name: 'generate-smrt-class',
@@ -481,6 +506,15 @@ export const TOOLS = [
   },
 ];
 
+export const TOOLS: Tool[] = TOOL_DEFINITIONS.map((tool) => ({
+  ...tool,
+  inputSchema: {
+    ...tool.inputSchema,
+    $schema: JSON_SCHEMA_2020_12,
+  },
+  outputSchema: DEV_MCP_OUTPUT_SCHEMA,
+}));
+
 export function createServer(): Server {
   if (DEBUG) {
     console.error(`[${SERVER_NAME}] Starting server v${SERVER_VERSION}`);
@@ -505,7 +539,7 @@ export function createServer(): Server {
     if (DEBUG) {
       console.error(`[${SERVER_NAME}] ListTools request`);
     }
-    return { tools: TOOLS as Tool[] };
+    return { tools: TOOLS };
   });
 
   server.setRequestHandler('prompts/list', async () => {
@@ -945,6 +979,7 @@ export function createServer(): Server {
             text: result,
           },
         ],
+        structuredContent: toDevToolStructuredContent(result),
       };
     } catch (error) {
       const errorMessage =
@@ -959,6 +994,12 @@ export function createServer(): Server {
           },
         ],
         isError: true,
+        structuredContent: {
+          ok: false,
+          coverage: null,
+          diagnostics: [{ severity: 'error', message: errorMessage }],
+          data: null,
+        },
       };
     }
   });
@@ -1144,6 +1185,26 @@ function compactKnowledgePackage(pkg: KnowledgePackageResult) {
 function detailArg(args: unknown): string | undefined {
   const detail = (args as Record<string, unknown> | undefined)?.detail;
   return typeof detail === 'string' ? detail : undefined;
+}
+
+function toDevToolStructuredContent(result: string) {
+  let data: unknown = result;
+  try {
+    data = JSON.parse(result);
+  } catch {
+    // `generate-smrt-class` intentionally returns source text, not JSON.
+  }
+
+  const source = isRecord(data) ? data : undefined;
+  const coverage = isRecord(source?.coverage) ? source.coverage : null;
+  const diagnostics = Array.isArray(source?.diagnostics)
+    ? source.diagnostics.filter(isRecord)
+    : [];
+  return { ok: true, coverage, diagnostics, data };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
 function sanitizeKnowledgePackage(pkg: KnowledgePackageResult) {

--- a/packages/smrt-dev-mcp/src/mcp-stdio.test.ts
+++ b/packages/smrt-dev-mcp/src/mcp-stdio.test.ts
@@ -92,6 +92,14 @@ describe('smrt-dev-mcp stdio server', () => {
     const reflect = JSON.parse(textContent(reflectResult));
     expect(reflect.smrtPackageCount).toBeGreaterThan(0);
     expect(reflect.freshness.ok).toBe(true);
+    expect(reflectResult).toMatchObject({
+      structuredContent: {
+        ok: true,
+        coverage: expect.any(Object),
+        diagnostics: expect.any(Array),
+        data: expect.objectContaining({ smrtPackageCount: expect.any(Number) }),
+      },
+    });
 
     const domainReflectResult = await client.callTool({
       name: 'reflect-domain-knowledge',

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -159,6 +159,8 @@ export interface SmrtWebFieldUIHints {
 export interface SmrtWebFieldDefinition {
   type: SmrtWebFieldType;
   required?: boolean;
+  /** Whether the public field contract explicitly permits `null`. */
+  nullable?: boolean;
   default?: unknown;
   /** Developer-authored `@field({ description })` (#2046) — end-user help seed. */
   description?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,10 +69,12 @@ overrides:
   fast-uri@>=3.0.0 <3.1.5: 3.1.5
   ip-address@<=10.3.0: 10.3.1
   fast-xml-builder@>=1.0.0 <1.1.7: 1.2.1
-  js-yaml@>=4.0.0 <4.2.0: 4.3.0
+  js-yaml@>=4.0.0 <4.3.1: 4.3.1
   svelte@>=5.0.0 <5.54.0: 5.56.4
   brace-expansion@>=4.0.0 <5.0.9: 5.0.9
-  js-yaml@>=3.0.0 <3.15.0: 3.15.0
+  js-yaml@>=3.0.0 <3.15.1: 3.15.1
+  pdfjs-dist@>=5.6.83 <6.2.108: 6.2.108
+  nanoid@<3.3.17: 3.3.17
   axios@>=1.15.2 <1.18.0: 1.18.0
   postcss@<=8.5.17: 8.5.18
   markdown-it@<14.1.2: 14.3.0
@@ -7663,12 +7665,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@26.1.0:
@@ -8164,8 +8166,8 @@ packages:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -8477,8 +8479,8 @@ packages:
   pdf-lib@1.17.1:
     resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
 
-  pdfjs-dist@6.1.200:
-    resolution: {integrity: sha512-o8MolyzirkkLrcdsae/HEOiIcXWI7DS5zGpvqW8xTC2YUsW30rltFw2bDGvw/fskUdEMrQm2br68jzDS5BH2vw==}
+  pdfjs-dist@6.2.108:
+    resolution: {integrity: sha512-YxFb+SQcodN2rnX9Tn3dHYlqfb7NjlzzfONPpJd+AKoKtUjEdevTfbC07d5TcczzOK6261auRkP/M8OBHs9vFQ==}
     engines: {node: '>=22.13.0 || >=24'}
 
   peberminta@0.10.0:
@@ -10628,7 +10630,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -10808,7 +10810,7 @@ snapshots:
       fingerprint-generator: 2.1.82
       fingerprint-injector: 2.1.82(playwright@1.61.1)
       lodash.merge: 4.6.2
-      nanoid: 3.3.15
+      nanoid: 3.3.17
       ow: 0.28.2
       p-limit: 3.1.0
       proxy-chain: 2.7.1
@@ -11441,7 +11443,7 @@ snapshots:
       '@napi-rs/canvas': 0.1.100
       marked: 18.0.7
       pdf-lib: 1.17.1
-      pdfjs-dist: 6.1.200
+      pdfjs-dist: 6.2.108
       puppeteer-core: 25.4.0
       unpdf: 1.6.2(@napi-rs/canvas@0.1.100)
     optionalDependencies:
@@ -11466,7 +11468,7 @@ snapshots:
   '@happyvertical/repos@0.85.5':
     dependencies:
       '@happyvertical/graphql': 0.85.5
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@happyvertical/secrets@0.85.5(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)':
     dependencies:
@@ -14019,7 +14021,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -15316,12 +15318,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -15818,7 +15820,7 @@ snapshots:
 
   mute-stream@1.0.0: {}
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.17: {}
 
   negotiator@1.0.0: {}
 
@@ -16152,7 +16154,7 @@ snapshots:
       pako: 1.0.11
       tslib: 1.14.1
 
-  pdfjs-dist@6.1.200:
+  pdfjs-dist@6.2.108:
     optionalDependencies:
       '@napi-rs/canvas': 1.0.3
 
@@ -16263,7 +16265,7 @@ snapshots:
 
   postcss@8.5.18:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -16387,7 +16389,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       pify: 4.0.1
       strip-bom: 3.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,10 +64,15 @@ overrides:
   'fast-uri@>=3.0.0 <3.1.5': 3.1.5
   'ip-address@<=10.3.0': 10.3.1
   'fast-xml-builder@>=1.0.0 <1.1.7': 1.2.1
-  'js-yaml@>=4.0.0 <4.2.0': 4.3.0
+  'js-yaml@>=4.0.0 <4.3.1': 4.3.1
   'svelte@>=5.0.0 <5.54.0': 5.56.4
   'brace-expansion@>=4.0.0 <5.0.9': 5.0.9
-  'js-yaml@>=3.0.0 <3.15.0': 3.15.0
+  'js-yaml@>=3.0.0 <3.15.1': 3.15.1
+  # @happyvertical/pdf currently pins pdfjs-dist 6.1.200. The public package
+  # has no newer release, so keep the resolved implementation on the first
+  # patched line while preserving the package's public API surface.
+  'pdfjs-dist@>=5.6.83 <6.2.108': 6.2.108
+  'nanoid@<3.3.17': 3.3.17
   'axios@>=1.15.2 <1.18.0': 1.18.0
   'postcss@<=8.5.17': 8.5.18
   # The advisory names 14.1.2 as the first patched version, but that tag was


### PR DESCRIPTION
## Summary

- Emit bounded JSON Schema 2020-12 input schemas, including local `$defs`, nullable unions, formats, and STI discriminated variants.
- Declare honest output schemas and return matching `structuredContent` for generated CRUD and custom MCP tools while preserving legacy text projections.
- Align `smrt-dev-mcp` tools with an explicit `{ ok, coverage, diagnostics, data }` contract and cover generated-server conformance, including STI creation.
- Remediate the high-severity dependency-audit paths that blocked this PR.

## Bundled dependency remediation

- Explicitly approved follow-up for #2252, limited to the `js-yaml`, `pdfjs-dist`, and `nanoid` audit paths. It uses bounded advisory-range pnpm overrides; no advisories are suppressed.

## Validation

- Core MCP generator, dev-MCP, web, and conformance-fixture focused suites; generated fixture and official MCP conformance rail.
- `pnpm lint`, `pnpm format`, `pnpm audit:policy`, `pnpm typecheck && pnpm build && pnpm test` (before this dependency-only follow-up).
- `pnpm audit --audit-level=high` — no high or critical findings.
- `pnpm audit:policy`, `pnpm --filter @happyvertical/smrt-content typecheck`, `pnpm --filter @happyvertical/smrt-content test` (302 passed), and `pnpm --filter @happyvertical/smrt-content build`.
- `pnpm format`, `pnpm typecheck` (122 tasks), and `pnpm smrt dev:knowledge-check`.
- Bounded final review of the override and lockfile diff: clean.

Closes #2149
Closes #2252

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019fdff9-c070-7dd3-8e5c-b02acfee2f2a","issue":"2149","policy_revision":"1.0.0","validation":["core MCP generator focused suites (114 tests)","smrt-dev-mcp suite (124 tests)","generated fixture and official MCP conformance","core/dev-MCP/web/fixture typecheck and build","root lint, format, audit policy, typecheck, build, and test","dependency audit high gate: no high or critical findings","audit policy, content typecheck/test (302 passed), content build","root format, typecheck (122 tasks), and knowledge freshness","final dependency/lockfile review: clean"]}