### PR TITLE
fix(ci): shard affected validation closure

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -177,7 +177,7 @@ seven days expire on their own.
 
 ## Job timeouts
 
-Validation jobs on the self-hosted lanes use `timeout-minutes: 45`. The value
+Validation jobs on the self-hosted lanes use `timeout-minutes: 90`. The value
 is a standard, not a per-job estimate: the previous spread ran from 5 to 45,
 mostly unexplained, and the low end was close to the pool's own queue wait
 (p90 1483-1933s measured over 180 jobs, against a median execution of 39-50s).
@@ -204,7 +204,7 @@ to the setting or here:
   Both finish in seconds, so failing fast is correct for a job that just
   reports other jobs' results.
 
-`postgres-tests` is at the standard 45. #2164 retired the unserved
+`postgres-tests` remains at 45 as a deliberate exception. #2164 retired the unserved
 `arc-happyvertical-node` label, deleted the `node-runner-smoke` workflow that
 ran only there, and moved this job onto the general `arc-happyvertical` pool —
 the pool the 45 was measured on — so the standard applies to it for the same
@@ -212,7 +212,7 @@ reason it applies to every other job there. Its earlier 30 was inherited from a
 label whose scale set was quiesced to zero runners, where `timeout-minutes`
 never governed anything.
 
-`publish-release` is at the standard 45 but that value is load-bearing
+`publish-release` remains at 45 but that value is load-bearing
 independently of it: 45 is the documented sequential-registry recovery window
 below, and `scripts/publish-workflow-policy.test.mjs` asserts the exact number.
 Moving the standard later does not by itself license moving that job.
@@ -238,10 +238,17 @@ is `true` on this repository; the unset/false branch is retained only as a
 reversal lever.
 
 - Unset/false: PRs run the historical full suite.
-- `true`: PRs run lint, affected typecheck and tests across the changed
-  packages and everything that depends on them, and — only when
-  knowledge-sensitive paths change — affected knowledge freshness. The
-  complete suite runs for `merge_group`.
+- `true`: PRs run lint and typecheck across the changed packages and everything
+  that depends on them. Their selected test-task closure is split into three
+  deterministic non-core shards; when Turbo's selected test-task closure also
+  contains core, the existing three Vitest core shards run. The selectors read
+  Turbo's dry-run task list, log selected/total package counts, and emit each
+  selected non-core test task exactly once, so wide core closures use the full
+  suite's parallel shape without silently changing coverage. The core and
+  package matrices deliberately do not overlap: each permits two runners, and
+  a shared four-runner burst would transfer feedback latency to fleet queue
+  pressure. Only when knowledge-sensitive paths change do PRs also run
+  affected knowledge freshness. The complete suite runs for `merge_group`.
 
 Coverage Gate and Publish Dry Run are merge-group only (#2214 items 4 and 8).
 Both used to run in both lanes while the merge group re-ran them in full

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -247,7 +247,6 @@ jobs:
           pnpm turbo run typecheck --filter="...[$BASE_SHA]" --concurrency=2
 
   affected-core-tests:
-    name: Affected Core Tests (${{ matrix.shard }})
     needs: affected-test-scope
     if: inputs.mode == 'affected' && needs.affected-test-scope.outputs.core == 'true'
     runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
@@ -290,7 +289,6 @@ jobs:
           NODE_ENV: test
 
   affected-package-tests:
-    name: Affected Package Tests (${{ matrix.shard }})
     # Keep the affected test lane at two matrix workers. GitHub scopes
     # max-parallel to one matrix job, so allowing this matrix to overlap the
     # core matrix would consume four fleet slots and move the old serial delay

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -216,8 +216,8 @@ jobs:
       - name: Run Biome lint and format checks
         run: npx --yes @biomejs/biome@2.5.2 ci --diagnostic-level=error .
 
-  affected-validation:
-    name: Affected Build, Typecheck, and Tests
+  affected-typecheck:
+    name: Affected Typecheck
     needs: affected-scope
     if: inputs.mode == 'affected'
     runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
@@ -238,17 +238,146 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           auth-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Some SvelteKit package tasks generate tracked routes and restore the
-      # original tree during cleanup. Running typecheck and test together lets
-      # one task remove those routes while the other is importing them.
-      - name: Run affected dependency closures
+      - name: Run affected typecheck closure
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_ENV: test
         run: |
           pnpm turbo run typecheck --filter="...[$BASE_SHA]" --concurrency=2
-          pnpm turbo run test --filter="...[$BASE_SHA]" --concurrency=2
+
+  affected-core-tests:
+    name: Affected Core Tests (${{ matrix.shard }})
+    needs: affected-test-scope
+    if: inputs.mode == 'affected' && needs.affected-test-scope.outputs.core == 'true'
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        shard: ['1/3', '2/3', '3/3']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+        with:
+          node-version: '24.18.0'
+          install-deps: 'true'
+          setup-playwright: 'false'
+          registry-url: 'https://npm.pkg.github.com'
+          auth-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build core dependency closure
+        run: pnpm turbo run build --filter='@happyvertical/smrt-core...'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore core test manifest
+        run: pnpm turbo run generate:test --filter='@happyvertical/smrt-core'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run affected core tests (shard ${{ matrix.shard }})
+        working-directory: packages/core
+        run: pnpm exec vitest run --shard=${{ matrix.shard }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_ENV: test
+
+  affected-package-tests:
+    name: Affected Package Tests (${{ matrix.shard }})
+    # Keep the affected test lane at two matrix workers. GitHub scopes
+    # max-parallel to one matrix job, so allowing this matrix to overlap the
+    # core matrix would consume four fleet slots and move the old serial delay
+    # into queue pressure. A skipped core matrix (no core test task selected)
+    # still permits package tests.
+    needs: [affected-test-scope, affected-core-tests]
+    if: >-
+      always() && inputs.mode == 'affected' &&
+      needs.affected-test-scope.result == 'success' &&
+      (needs.affected-core-tests.result == 'success' ||
+      needs.affected-core-tests.result == 'skipped')
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        shard: ['1/3', '2/3', '3/3']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+          fetch-depth: 0
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+        with:
+          node-version: '24.18.0'
+          install-deps: 'true'
+          setup-playwright: 'false'
+          registry-url: 'https://npm.pkg.github.com'
+          auth-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Query the same Turbo test-task closure the former serial job ran, then
+      # partition its non-core packages deterministically. The dry run is also
+      # the per-shard log's count of selected packages.
+      - name: Run affected package tests (shard ${{ matrix.shard }})
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_ENV: test
+          VITEST_MAX_WORKERS: '2'
+          NODE_OPTIONS: --max-old-space-size=2048
+        run: |
+          set -o pipefail
+          pnpm turbo run test --filter="...[$BASE_SHA]" --dry=json |
+            node scripts/affected-test-shard.mjs '${{ matrix.shard }}' |
+            xargs -r pnpm turbo run test --concurrency=2
+
+  # Use Turbo's own task plan to decide whether the core Vitest shards are
+  # needed. A path filter would miss global inputs (lockfile, root config,
+  # workspace configuration) that make Turbo select core even without a direct
+  # packages/core/** edit.
+  affected-test-scope:
+    name: Detect Affected Test Scope
+    needs: affected-scope
+    if: inputs.mode == 'affected'
+    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
+    timeout-minutes: 90
+    outputs:
+      core: ${{ steps.scope.outputs.core }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+          fetch-depth: 0
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+        with:
+          node-version: '24.18.0'
+          install-deps: 'true'
+          setup-playwright: 'false'
+          registry-url: 'https://npm.pkg.github.com'
+          auth-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Detect selected core test task
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          core=$(pnpm turbo run test --filter="...[$BASE_SHA]" --dry=json |
+            node scripts/affected-test-shard.mjs --has-core)
+          printf 'core=%s\n' "$core" | tee -a "$GITHUB_OUTPUT"
 
   affected-knowledge:
     name: Affected Knowledge Freshness

--- a/scripts/affected-test-shard.mjs
+++ b/scripts/affected-test-shard.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * Select one deterministic shard of the Turbo test-task closure emitted by
+ * `turbo run test --dry=json`. Unlike test-packages-shard.mjs, this starts
+ * from the affected closure, so PR validation neither drops dependents nor
+ * expands a narrow change to every workspace package.
+ *
+ * Usage: turbo ... --dry=json | node scripts/affected-test-shard.mjs <i>/<n>
+ *
+ * The script writes `--filter=<package>` flags to stdout for xargs and a
+ * concise package-count observation to stderr for the Actions log.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const CORE_PACKAGE = '@happyvertical/smrt-core';
+
+export function parseShard(shardArg) {
+  const match = shardArg.match(/^(\d+)\/(\d+)$/);
+  const index = match ? Number.parseInt(match[1], 10) : Number.NaN;
+  const count = match ? Number.parseInt(match[2], 10) : Number.NaN;
+  if (
+    !Number.isInteger(index) ||
+    !Number.isInteger(count) ||
+    index < 1 ||
+    count < 1 ||
+    index > count
+  ) {
+    throw new Error(
+      `Invalid shard "${shardArg}"; expected "<i>/<n>" (e.g. "2/3")`,
+    );
+  }
+  return { index, count };
+}
+
+export function selectAffectedTestPackages(dryRun, { index, count }) {
+  if (!Array.isArray(dryRun?.tasks)) {
+    throw new Error('Turbo dry-run JSON did not contain a tasks array');
+  }
+
+  const packages = [
+    ...new Set(
+      dryRun.tasks
+        .filter((task) => task.task === 'test' && task.package !== CORE_PACKAGE)
+        .map((task) => task.package)
+        .filter((packageName) => typeof packageName === 'string'),
+    ),
+  ].sort();
+
+  return {
+    packages,
+    shard: packages.filter((_, packageIndex) => packageIndex % count === index - 1),
+  };
+}
+
+export function hasAffectedCoreTest(dryRun) {
+  if (!Array.isArray(dryRun?.tasks)) {
+    throw new Error('Turbo dry-run JSON did not contain a tasks array');
+  }
+  return dryRun.tasks.some(
+    (task) => task.task === 'test' && task.package === CORE_PACKAGE,
+  );
+}
+
+function readStdin() {
+  return readFileSync(0, 'utf8');
+}
+
+function main() {
+  const input = JSON.parse(readStdin());
+  if (process.argv[2] === '--has-core') {
+    process.stdout.write(hasAffectedCoreTest(input) ? 'true' : 'false');
+    return;
+  }
+
+  const shardArg = process.argv[2] ?? '';
+  const shard = parseShard(shardArg);
+  const selected = selectAffectedTestPackages(input, shard);
+  console.error(
+    `Affected test shard ${shardArg}: ${selected.shard.length} of ${selected.packages.length} non-core package(s)`,
+  );
+  process.stdout.write(
+    selected.shard.map((packageName) => `--filter=${packageName}`).join(' '),
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/affected-test-shard.test.mjs
+++ b/scripts/affected-test-shard.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  hasAffectedCoreTest,
+  parseShard,
+  selectAffectedTestPackages,
+} from './affected-test-shard.mjs';
+
+test('selectAffectedTestPackages keeps every affected non-core test task once', () => {
+  const dryRun = {
+    tasks: [
+      { task: 'build', package: '@happyvertical/smrt-alpha' },
+      { task: 'test', package: '@happyvertical/smrt-zeta' },
+      { task: 'test', package: '@happyvertical/smrt-core' },
+      { task: 'test', package: '@happyvertical/smrt-alpha' },
+      { task: 'test', package: '@happyvertical/smrt-zeta' },
+      { task: 'test', package: '@happyvertical/smrt-beta' },
+    ],
+  };
+
+  assert.deepEqual(selectAffectedTestPackages(dryRun, { index: 1, count: 2 }), {
+    packages: [
+      '@happyvertical/smrt-alpha',
+      '@happyvertical/smrt-beta',
+      '@happyvertical/smrt-zeta',
+    ],
+    shard: ['@happyvertical/smrt-alpha', '@happyvertical/smrt-zeta'],
+  });
+  assert.deepEqual(selectAffectedTestPackages(dryRun, { index: 2, count: 2 }).shard, [
+    '@happyvertical/smrt-beta',
+  ]);
+});
+
+test('hasAffectedCoreTest follows Turbo selection rather than changed paths', () => {
+  assert.equal(
+    hasAffectedCoreTest({
+      tasks: [{ task: 'test', package: '@happyvertical/smrt-core' }],
+    }),
+    true,
+  );
+  assert.equal(
+    hasAffectedCoreTest({ tasks: [] }),
+    false,
+  );
+});
+
+test('parseShard rejects malformed and out-of-range shard selectors', () => {
+  for (const selector of ['', '0/3', '4/3', '1/0', '1/3/4']) {
+    assert.throws(() => parseShard(selector), /Invalid shard/);
+  }
+});
+
+test('selectAffectedTestPackages rejects malformed Turbo output', () => {
+  assert.throws(
+    () => selectAffectedTestPackages({}, { index: 1, count: 3 }),
+    /tasks array/,
+  );
+});


### PR DESCRIPTION
## Summary

- Split affected validation into its unchanged typecheck closure plus bounded test shards.
- Derive core selection from the same Turbo dry-run task plan, so global inputs and direct core changes retain core coverage.
- Partition every selected non-core test package exactly once across three deterministic shards, with per-shard package counts in logs.
- Sequence core and package matrices to cap the affected test lane at two fleet workers; update the CI topology and 90-minute timeout documentation.

## Validation

- `pnpm test:ci-scripts` — 36 passed.
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/test-suite.yml` — passed.
- `pnpm knowledge:check --changed --strict --format markdown` — passed (0 errors, 0 warnings).
- `pnpm audit:policy`, `git diff --check`, and pre-commit/pre-push workflow validation — passed.
- Wide current closure measurement: 64 test task packages (core + 63 non-core), balanced 21/21/21.
- Review cycle: three independent Terra reviewers; two P1/P2 findings fixed and all final recalls CLEAN.

Closes #2177

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-ci-perf-2177-20260808","issue":2177,"policy_revision":"1.0.0","status":"complete","validation":["pnpm test:ci-scripts: 36 passed","actionlint test-suite.yml","knowledge:check --changed --strict: 0 errors, 0 warnings","audit policy, diff, pre-commit and pre-push checks","three-reviewer Terra review cycle clean after fixed P1/P2"]}
