### PR TITLE
perf(ci): batch release publication

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -322,6 +322,24 @@ fixed shared database name or remove the wrapper from their package script.
 
 ## Release artifacts
 
+Routine releases are batched to avoid repeatedly invalidating merge-queue work.
+Merging a pull request advances `main` once and does not invoke the publisher.
+`.github/workflows/on-merge-main.yml` runs daily at 07:17 UTC and can also be
+dispatched manually for an urgent release. Each run versions every eligible
+commit since the previous release, so a group of merged pull requests produces
+one release commit and tag. The workflow checks for active merge-group runs and
+queue refs before starting and again before the irreversible registry and Git
+release phase. An API error or non-idle queue fails closed and defers the
+release. Once registry publication begins, the matching `main` and tag update
+must complete so the registry and Git release cannot be stranded out of sync.
+To publish a specific cohort immediately, let every pull request in the cohort
+merge and the queue drain before dispatching `on-merge-main.yml`; do not enqueue
+new work while that release is publishing.
+
+Do not restore a `push` trigger on the batch workflow. A release commit changes
+the base of every speculative merge-group branch; publishing after each merge
+therefore cancels or restarts validation for entries still in the queue (#2174).
+
 Each package is packed once. Pack shards verify that exact tarball and emit a
 schema-versioned manifest containing package name, version, filename, and
 SHA-256. Profiles and Sales validation additionally install each exact tarball

--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -1,9 +1,12 @@
-name: On Merge to Main
-# Testing hook validation
+name: Batched Release
 
 on:
-  push:
-    branches: [main]
+  # Merge queue entries are built on the current main tip. Publishing after
+  # every merge pushes a second release commit to main, invalidating every
+  # speculative group still in flight. Batch routine releases once daily;
+  # workflow_dispatch remains the urgent-release path.
+  schedule:
+    - cron: '17 7 * * *'
 
   workflow_dispatch:
     inputs:
@@ -34,78 +37,20 @@ permissions:
   actions: write
 
 jobs:
-  # Cancel any in-progress PR validation checks when PR is merged
-  cancel-pr-checks:
-    name: Cancel PR Validation Checks
-    if: github.event_name == 'push' && vars.CI_MERGE_QUEUE_ENABLED != 'true'
+  queue-idle:
+    name: Require Idle Merge Queue
     runs-on: ubuntu-latest
-
+    permissions:
+      actions: read
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          fetch-depth: 2
 
-      - name: Extract PR number from merge commit
-        id: get-pr
-        run: |
-          # Get PR number from merge commit message
-          pr_number=$(git log -1 --pretty=%B | \
-            grep -oP '#\K\d+' | head -1)
-
-          if [ -n "$pr_number" ]; then
-            echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
-            echo "📝 Detected merged PR: #$pr_number"
-          else
-            echo "ℹ️  No PR number found in commit message"
-          fi
-
-      - name: Cancel in-progress PR workflows
-        if: steps.get-pr.outputs.pr_number
+      - name: Defer release while merge groups are active
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pr_number="${{ steps.get-pr.outputs.pr_number }}"
-          echo "🔍 Looking for running workflows for PR #$pr_number..."
-
-          # Find in-progress workflow runs for on-pull-request.yml
-          jq_filter='.[] | select(.status == "in_progress"'
-          jq_filter="$jq_filter"' or .status == "queued")'
-          jq_filter="$jq_filter"' | select(.headBranch'
-          jq_filter="$jq_filter"' | test("'"$pr_number"'$"))'
-          jq_filter="$jq_filter"' | .databaseId'
-
-          runs=$(gh run list \
-            --repo "${{ github.repository }}" \
-            --workflow="on-pull-request.yml" \
-            --json databaseId,status,headBranch \
-            --jq "$jq_filter" \
-            --limit 50)
-
-          if [ -z "$runs" ]; then
-            echo "✅ No running PR workflows to cancel"
-            exit 0
-          fi
-
-          # Cancel each in-progress run
-          cancelled=0
-          failed=0
-          for run_id in $runs; do
-            echo "🛑 Cancelling workflow run: $run_id"
-            if gh run cancel "$run_id" \
-              --repo "${{ github.repository }}"; then
-              ((cancelled++))
-            else
-              ((failed++))
-            fi
-          done
-
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-          echo "✅ Cancelled $cancelled workflow run(s) for PR #$pr_number"
-          if [ $failed -gt 0 ]; then
-            echo "⚠️  Failed to cancel $failed workflow run(s)"
-          fi
-          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/check-merge-queue-idle.mjs
 
   # Run tests
   test:
@@ -129,9 +74,10 @@ jobs:
   # Publish packages and deploy docs
   publish:
     name: Publish
-    needs: [test, build]
+    needs: [queue-idle, test, build]
     if: |
       always() &&
+      needs.queue-idle.result == 'success' &&
       (vars.CI_MERGE_QUEUE_ENABLED == 'true' || needs.build.result == 'success')
     uses: ./.github/workflows/publish.yml
     secrets: inherit
@@ -142,3 +88,4 @@ jobs:
       packages: read
       id-token: write
       pages: write
+      actions: read

--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -34,7 +34,7 @@ permissions:
   pull-requests: write
   id-token: write
   pages: write
-  actions: write
+  actions: read
 
 jobs:
   queue-idle:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,9 @@
 # =============================================================================
 # EDITABLE WORKFLOW - Customize for this repository
 # =============================================================================
-# This workflow is called by .github/workflows/happyvertical/on-merge-main.yml
-# when code is merged to the main branch, after tests and build pass.
+# This workflow is called by .github/workflows/on-merge-main.yml for a
+# scheduled or manually dispatched batch, after tests and build pass when the
+# merge queue fallback requires them.
 #
 # Uses the shared direct publish workflow from SDK to version and publish
 # packages without creating intermediate "Version Packages" PRs.
@@ -34,6 +35,7 @@ env:
   PUBLISH_PACK_SHARD_COUNT: '2'
 
 permissions:
+  actions: read
   contents: write
   issues: write
   pull-requests: write
@@ -370,6 +372,15 @@ jobs:
 
       - name: Verify complete release artifact set
         run: node scripts/verify-publish-artifacts.mjs publish-pack-output
+
+      # Recheck immediately before the irreversible release phase. Once npm
+      # publication starts, the matching main/tag update must not be deferred:
+      # doing so would strand a registry release that the collision guard cannot
+      # safely reconstruct on a later run.
+      - name: Recheck merge queue before publication
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/check-merge-queue-idle.mjs
 
       - name: Publish validated release
         env:

--- a/scripts/check-merge-queue-idle.mjs
+++ b/scripts/check-merge-queue-idle.mjs
@@ -1,0 +1,110 @@
+import { pathToFileURL } from 'node:url';
+
+const ACTIVE_RUN_STATUSES = ['queued', 'in_progress'];
+
+async function githubJson(fetchImpl, apiUrl, token, path) {
+  const response = await fetchImpl(`${apiUrl}${path}`, {
+    headers: {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${token}`,
+      'x-github-api-version': '2022-11-28',
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `GitHub API ${response.status} for ${path}: ${body.slice(0, 500)}`,
+    );
+  }
+
+  return response.json();
+}
+
+export async function inspectMergeQueue({
+  apiUrl = process.env.GITHUB_API_URL ?? 'https://api.github.com',
+  fetchImpl = globalThis.fetch,
+  repository = process.env.GITHUB_REPOSITORY,
+  token = process.env.GITHUB_TOKEN,
+} = {}) {
+  if (!repository || !token) {
+    throw new Error('GITHUB_REPOSITORY and GITHUB_TOKEN are required');
+  }
+
+  const encodedRepository = repository
+    .split('/')
+    .map(encodeURIComponent)
+    .join('/');
+  const [queueRefs, ...runResponses] = await Promise.all([
+    githubJson(
+      fetchImpl,
+      apiUrl,
+      token,
+      `/repos/${encodedRepository}/git/matching-refs/heads/gh-readonly-queue/main/`,
+    ),
+    ...ACTIVE_RUN_STATUSES.map((status) =>
+      githubJson(
+        fetchImpl,
+        apiUrl,
+        token,
+        `/repos/${encodedRepository}/actions/runs?event=merge_group&status=${status}&per_page=100`,
+      ),
+    ),
+  ]);
+
+  if (!Array.isArray(queueRefs)) {
+    throw new Error('GitHub matching-refs response was not an array');
+  }
+
+  const activeRuns = runResponses.flatMap((response, index) => {
+    if (!Array.isArray(response.workflow_runs)) {
+      throw new Error(
+        `GitHub Actions response for ${ACTIVE_RUN_STATUSES[index]} was invalid`,
+      );
+    }
+    return response.workflow_runs;
+  });
+
+  return {
+    activeRuns,
+    queueRefs,
+  };
+}
+
+export async function requireIdleMergeQueue(options) {
+  const { activeRuns, queueRefs } = await inspectMergeQueue(options);
+
+  if (activeRuns.length > 0 || queueRefs.length > 0) {
+    const runSummary = activeRuns
+      .map((run) => run.html_url ?? run.head_branch ?? run.id)
+      .join(', ');
+    const refSummary = queueRefs
+      .map((entry) => entry.ref ?? 'unknown queue ref')
+      .join(', ');
+    throw new Error(
+      [
+        `Merge queue is active (${activeRuns.length} run(s), ${queueRefs.length} ref(s)); release deferred.`,
+        runSummary && `Runs: ${runSummary}`,
+        refSummary && `Refs: ${refSummary}`,
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    );
+  }
+
+  return { activeRuns, queueRefs };
+}
+
+async function main() {
+  try {
+    await requireIdleMergeQueue();
+    console.log('Merge queue is idle; release may proceed.');
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/check-merge-queue-idle.test.mjs
+++ b/scripts/check-merge-queue-idle.test.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  inspectMergeQueue,
+  requireIdleMergeQueue,
+} from './check-merge-queue-idle.mjs';
+
+function response(body, { ok = true, status = 200 } = {}) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function githubFetch({ queueRefs = [], queued = [], inProgress = [] } = {}) {
+  return async (url) => {
+    if (url.includes('/git/matching-refs/')) {
+      return response(queueRefs);
+    }
+    if (url.includes('status=queued')) {
+      return response({ workflow_runs: queued });
+    }
+    if (url.includes('status=in_progress')) {
+      return response({ workflow_runs: inProgress });
+    }
+    throw new Error(`Unexpected URL: ${url}`);
+  };
+}
+
+const options = {
+  repository: 'happyvertical/smrt',
+  token: 'test-token',
+};
+
+test('allows a release only when merge-group runs and queue refs are absent', async () => {
+  const state = await requireIdleMergeQueue({
+    ...options,
+    fetchImpl: githubFetch(),
+  });
+
+  assert.deepEqual(state, { activeRuns: [], queueRefs: [] });
+});
+
+test('defers a release when an active merge group exists', async () => {
+  await assert.rejects(
+    requireIdleMergeQueue({
+      ...options,
+      fetchImpl: githubFetch({
+        inProgress: [
+          {
+            head_branch: 'gh-readonly-queue/main/pr-2254',
+            html_url: 'https://github.com/happyvertical/smrt/actions/runs/1',
+          },
+        ],
+      }),
+    }),
+    /Merge queue is active \(1 run\(s\), 0 ref\(s\)\)/,
+  );
+});
+
+test('defers a release when a queue ref exists before its run starts', async () => {
+  await assert.rejects(
+    requireIdleMergeQueue({
+      ...options,
+      fetchImpl: githubFetch({
+        queueRefs: [{ ref: 'refs/heads/gh-readonly-queue/main/pr-2254' }],
+      }),
+    }),
+    /Merge queue is active \(0 run\(s\), 1 ref\(s\)\)/,
+  );
+});
+
+test('fails closed when GitHub cannot prove the queue is idle', async () => {
+  await assert.rejects(
+    inspectMergeQueue({
+      ...options,
+      fetchImpl: async () => response({ message: 'unavailable' }, { ok: false, status: 503 }),
+    }),
+    /GitHub API 503/,
+  );
+});

--- a/scripts/publish-workflow-policy.test.mjs
+++ b/scripts/publish-workflow-policy.test.mjs
@@ -6,6 +6,10 @@ const workflow = readFileSync(
   new URL('../.github/workflows/publish.yml', import.meta.url),
   'utf8',
 );
+const batchWorkflow = readFileSync(
+  new URL('../.github/workflows/on-merge-main.yml', import.meta.url),
+  'utf8',
+);
 
 function job(name) {
   const match = workflow.match(
@@ -25,5 +29,31 @@ test('final publisher skips workspace installation and allows recovery headroom'
   assert.match(
     publisher,
     /- name: Setup Environment[\s\S]*?install-deps: 'false'/,
+  );
+});
+
+test('routine releases batch instead of publishing after every main push', () => {
+  const publisher = job('publish-release');
+
+  assert.doesNotMatch(batchWorkflow, /^  push:/m);
+  assert.match(batchWorkflow, /^  schedule:\n    - cron: '17 7 \* \* \*'$/m);
+  assert.match(batchWorkflow, /^  workflow_dispatch:$/m);
+  assert.match(batchWorkflow, /^  queue-idle:$/m);
+  assert.match(batchWorkflow, /needs: \[queue-idle, test, build\]/);
+  assert.match(
+    batchWorkflow,
+    /needs\.queue-idle\.result == 'success'/,
+  );
+  assert.match(
+    batchWorkflow,
+    /run: node scripts\/check-merge-queue-idle\.mjs/,
+  );
+  assert.match(
+    publisher,
+    /- name: Recheck merge queue before publication[\s\S]*?run: node scripts\/check-merge-queue-idle\.mjs/,
+  );
+  assert.ok(
+    publisher.lastIndexOf('node scripts/check-merge-queue-idle.mjs') <
+      publisher.indexOf('node scripts/publish-validated-artifacts.mjs'),
   );
 });


### PR DESCRIPTION
Closes #2174

## Summary

- batch routine releases daily instead of publishing after every merge to `main`
- fail closed when active merge-group runs or queue refs exist, both before the batch and before publication
- document the batching and registry/Git consistency invariant

## Validation

- `pnpm build`
- `pnpm test:ci-scripts` (37/37)
- `actionlint .github/workflows/on-merge-main.yml .github/workflows/publish.yml`
- `pnpm smrt dev:knowledge-check`
- `pnpm audit:policy`
- pre-commit and pre-push validation
- Terra review cycle: workflow, release, and policy reviewers clean

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"24589361-dd9f-448f-86b5-b3da4ca093bc","issue":2174,"head_sha":"b3476bcc044726c158f003d85408d8ef1d1f5a40","policy_revision":"1.0.0","status":"complete","validation":["pnpm build: 62 packages","pnpm test:ci-scripts: 37 passed","actionlint: clean","knowledge check: clean","audit policy: clean","three-reviewer Terra review cycle: clean"]}
```
