### PR TITLE
fix(ci): avoid docs scope tag SIGPIPE

### DIFF
--- a/.github/workflows/on-merge-main.yml
+++ b/.github/workflows/on-merge-main.yml
@@ -67,7 +67,8 @@ jobs:
         id: release-base
         shell: bash
         run: |
-          tag=$(git tag --merged HEAD --list 'v*' --sort=-version:refname | head -n 1)
+          tag=$(git tag --merged HEAD --list 'v*' --sort=-version:refname)
+          tag=${tag%%$'\n'*}
           if [ -z "$tag" ]; then
             echo "No prior release tag found; deploy documentation."
             echo "ref=HEAD^" >> "$GITHUB_OUTPUT"

--- a/scripts/publish-workflow-policy.test.mjs
+++ b/scripts/publish-workflow-policy.test.mjs
@@ -55,6 +55,11 @@ test('routine releases batch instead of publishing after every main push', () =>
   assert.match(batchWorkflow, /^  docs-scope:$/m);
   assert.match(batchWorkflow, /fetch-depth: 0/);
   assert.match(batchWorkflow, /git tag --merged HEAD --list 'v\*'/);
+  assert.doesNotMatch(
+    batchWorkflow,
+    /git tag --merged HEAD --list 'v\*' --sort=-version:refname \| head -n 1/,
+  );
+  assert.match(batchWorkflow, /tag=\$\{tag%%\$'\\n'\*\}/);
   assert.match(
     batchWorkflow,
     /base: \$\{\{ steps\.release-base\.outputs\.ref \}\}/,


### PR DESCRIPTION
## Summary

- Avoid the `pipefail` SIGPIPE in release-tag selection while preserving the highest merged `v*` tag.
- Add policy coverage that prevents restoring the `head -n 1` pipeline.

## Validation

- `node --test scripts/publish-workflow-policy.test.mjs`
- `pnpm test:ci-scripts` (41/41)
- `actionlint .github/workflows/on-merge-main.yml`
- strict Bash merged-tag selection probe
- `pnpm knowledge:check --changed --strict --format markdown`
- Terra review: accepted

Closes #2216

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-ci-perf-2216-release-20260808","issue":"2216","head_sha":"1b24a71ea0660f0a1f6418a2bee630b5562dc992","policy_revision":"1.0.0","status":"complete","validation":["workflow policy test: clean","CI scripts: 41 passed","actionlint: clean","knowledge check: clean","Terra review: accepted"]}
```
