### PR TITLE
feat(mcp): emit cache metadata for catalogs

### DIFF
--- a/docs/content/core.md
+++ b/docs/content/core.md
@@ -543,6 +543,19 @@ await generator.generate();
 // Creates: ./mcp/documents-mcp-server.js for AI model integration
 ```
 
+Generated `tools/list` results are sorted by tool name and advertise a one-day
+`private` cache lifetime. Only a reviewed global, unauthenticated catalog may
+opt into shared caching, and the opt-in is rejected for a server that exposes
+tenant-scoped tools:
+
+```typescript
+const generator = new MCPGenerator({
+  cache: {
+    toolsList: { cacheScope: 'public', publicCatalog: true },
+  },
+});
+```
+
 ## SMRT Development MCP
 
 Use `@happyvertical/smrt-dev-mcp` for development-time code generation,

--- a/packages/app-cli/README.md
+++ b/packages/app-cli/README.md
@@ -115,6 +115,11 @@ The package also ships the generic `smrt-mcp-bridge` binary. The remote app
 surface is typically mounted with
 [`@happyvertical/smrt-app-mcp`](../smrt-app-mcp/README.md).
 
+The bridge canonicalizes its `tools/list` catalog by tool name and emits a
+one-day `private` cache lifetime. The catalog is tied to the configured local
+app credentials, so it never opts into shared caching even when an upstream
+app serves public tools.
+
 ## Configuration and authentication
 
 - `name` supplies the display name and default environment-variable prefix.

--- a/packages/app-cli/src/__tests__/bridge.test.ts
+++ b/packages/app-cli/src/__tests__/bridge.test.ts
@@ -123,7 +123,14 @@ describe('runMcpStdioBridge', () => {
       });
 
       const tools = await client.listTools();
-      expect(tools.tools.map((tool) => tool.name)).toEqual(['echo']);
+      expect(tools).toMatchObject({
+        ttlMs: 86_400_000,
+        cacheScope: 'private',
+      });
+      expect(tools.tools.map((tool) => tool.name)).toEqual([
+        'antelope',
+        'zebra',
+      ]);
 
       const result = await client.callTool({
         name: 'echo',
@@ -158,7 +165,10 @@ describe('runMcpStdioBridge', () => {
       await client.connect(transport);
       expect(client.getNegotiatedProtocolVersion()).toBe('2025-11-25');
       const tools = await client.listTools();
-      expect(tools.tools.map((tool) => tool.name)).toEqual(['echo']);
+      expect(tools.tools.map((tool) => tool.name)).toEqual([
+        'antelope',
+        'zebra',
+      ]);
     } finally {
       await client.close();
       await transport.close();

--- a/packages/app-cli/src/__tests__/bridge.test.ts
+++ b/packages/app-cli/src/__tests__/bridge.test.ts
@@ -128,7 +128,9 @@ describe('runMcpStdioBridge', () => {
         cacheScope: 'private',
       });
       expect(tools.tools.map((tool) => tool.name)).toEqual([
+        'I_list',
         'antelope',
+        'i_list',
         'zebra',
       ]);
 
@@ -166,7 +168,9 @@ describe('runMcpStdioBridge', () => {
       expect(client.getNegotiatedProtocolVersion()).toBe('2025-11-25');
       const tools = await client.listTools();
       expect(tools.tools.map((tool) => tool.name)).toEqual([
+        'I_list',
         'antelope',
+        'i_list',
         'zebra',
       ]);
     } finally {

--- a/packages/app-cli/src/__tests__/fixtures/mcp-stdio-bridge.ts
+++ b/packages/app-cli/src/__tests__/fixtures/mcp-stdio-bridge.ts
@@ -18,8 +18,18 @@ await runMcpStdioBridge({
               inputSchema: { type: 'object' },
             },
             {
+              name: 'i_list',
+              description: 'Lowercase i through the HTTP bridge',
+              inputSchema: { type: 'object' },
+            },
+            {
               name: 'antelope',
               description: 'Antelope through the HTTP bridge',
+              inputSchema: { type: 'object' },
+            },
+            {
+              name: 'I_list',
+              description: 'Uppercase I through the HTTP bridge',
               inputSchema: { type: 'object' },
             },
           ],

--- a/packages/app-cli/src/__tests__/fixtures/mcp-stdio-bridge.ts
+++ b/packages/app-cli/src/__tests__/fixtures/mcp-stdio-bridge.ts
@@ -13,8 +13,13 @@ await runMcpStdioBridge({
         JSON.stringify({
           tools: [
             {
-              name: 'echo',
-              description: 'Echo through the HTTP bridge',
+              name: 'zebra',
+              description: 'Zebra through the HTTP bridge',
+              inputSchema: { type: 'object' },
+            },
+            {
+              name: 'antelope',
+              description: 'Antelope through the HTTP bridge',
               inputSchema: { type: 'object' },
             },
           ],

--- a/packages/app-cli/src/bridge.ts
+++ b/packages/app-cli/src/bridge.ts
@@ -46,6 +46,12 @@ import {
 /** Namespace shared with the published SMRT app-result contract. */
 export { SMRT_MCP_RESULT_METADATA_KEY } from '@happyvertical/smrt-users/app-contract';
 
+const MCP_STABLE_CATALOG_TTL_MS = 86_400_000;
+const PRIVATE_TOOL_LIST_CACHE_HINT = {
+  ttlMs: MCP_STABLE_CATALOG_TTL_MS,
+  cacheScope: 'private' as const,
+};
+
 /**
  * Configuration for the bridge.
  *
@@ -81,6 +87,7 @@ export function createMcpStdioBridge(options: McpStdioBridgeOptions): {
 
   const server = new Server(options.serverInfo, {
     capabilities: { tools: {} },
+    cacheHints: { 'tools/list': PRIVATE_TOOL_LIST_CACHE_HINT },
   });
 
   server.setRequestHandler(
@@ -93,7 +100,14 @@ export function createMcpStdioBridge(options: McpStdioBridgeOptions): {
         { fetch: options.fetch },
       );
       if (!outcome.ok) throw toMcpTransportError(outcome.error);
-      return withMcpMetadata(outcome.result, outcome.metadata);
+      const result = withMcpMetadata(outcome.result, outcome.metadata);
+      return {
+        ...result,
+        tools: [...result.tools].sort((left, right) =>
+          left.name.localeCompare(right.name),
+        ),
+        ...PRIVATE_TOOL_LIST_CACHE_HINT,
+      };
     },
   );
 

--- a/packages/app-cli/src/bridge.ts
+++ b/packages/app-cli/src/bridge.ts
@@ -52,6 +52,10 @@ const PRIVATE_TOOL_LIST_CACHE_HINT = {
   cacheScope: 'private' as const,
 };
 
+function compareToolNames(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
 /**
  * Configuration for the bridge.
  *
@@ -104,7 +108,7 @@ export function createMcpStdioBridge(options: McpStdioBridgeOptions): {
       return {
         ...result,
         tools: [...result.tools].sort((left, right) =>
-          left.name.localeCompare(right.name),
+          compareToolNames(left.name, right.name),
         ),
         ...PRIVATE_TOOL_LIST_CACHE_HINT,
       };

--- a/packages/core/src/generators/index.ts
+++ b/packages/core/src/generators/index.ts
@@ -55,9 +55,16 @@ export type {
   MCPRequest,
   MCPResponse,
   MCPTool,
+  MCPToolListCacheHint,
+  MCPToolListCacheOptions,
 } from './mcp';
 // MCP Server Generator
-export { MCPGenerator } from './mcp';
+export {
+  MCP_STABLE_CATALOG_TTL_MS,
+  MCPGenerator,
+  resolveMCPToolListCacheHint,
+  sortMCPTools,
+} from './mcp';
 export type { APIConfig, APIContext, RestServerConfig } from './rest';
 // REST API Generator and server utilities
 export {

--- a/packages/core/src/generators/mcp-runtime-template.test.ts
+++ b/packages/core/src/generators/mcp-runtime-template.test.ts
@@ -1,4 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { ObjectRegistry } from '../registry.js';
+import {
+  MCP_STABLE_CATALOG_TTL_MS,
+  MCPGenerator,
+  resolveMCPToolListCacheHint,
+  sortMCPTools,
+} from './mcp.js';
 import { generateRuntimeBootstrap } from './mcp-runtime-template.js';
 
 describe('generated MCP custom-action runtime (#2182)', () => {
@@ -18,6 +25,92 @@ describe('generated MCP custom-action runtime (#2182)', () => {
     expect(source).toContain('ObjectRegistry.loadAllManifests');
     expect(source).not.toContain('@modelcontextprotocol/sdk');
     expect(source).not.toContain('initialize');
+  });
+
+  it('emits a private cacheable, byte-stable tool catalog by default', () => {
+    const source = generateRuntimeBootstrap({
+      tools: [
+        { name: 'zebra_list', description: 'Zebra', inputSchema: {} },
+        { name: 'antelope_list', description: 'Antelope', inputSchema: {} },
+      ],
+    });
+
+    expect(source).toContain(
+      "cacheHints: {\n          'tools/list': TOOL_LIST_CACHE_HINT,",
+    );
+    expect(source).toContain(
+      'const TOOL_LIST_CACHE_HINT = {"ttlMs":86400000,"cacheScope":"private"};',
+    );
+    expect(source).toContain(
+      'tools: [...TOOLS].sort((left, right) => left.name.localeCompare(right.name))',
+    );
+  });
+
+  it('requires an explicit global-catalog opt-in and never shares tenant catalogs', () => {
+    expect(resolveMCPToolListCacheHint(undefined, false)).toEqual({
+      ttlMs: MCP_STABLE_CATALOG_TTL_MS,
+      cacheScope: 'private',
+    });
+    expect(
+      resolveMCPToolListCacheHint({ cacheScope: 'public' }, false),
+    ).toMatchObject({ cacheScope: 'private' });
+    expect(
+      resolveMCPToolListCacheHint(
+        { cacheScope: 'public', publicCatalog: true },
+        false,
+      ),
+    ).toMatchObject({ cacheScope: 'public' });
+    expect(
+      resolveMCPToolListCacheHint(
+        { cacheScope: 'public', publicCatalog: true },
+        true,
+      ),
+    ).toMatchObject({ cacheScope: 'private' });
+  });
+
+  it('treats registry-declared tenant tools as private even without the tenancy runtime', async () => {
+    const allClasses = vi
+      .spyOn(ObjectRegistry, 'getAllClasses')
+      .mockReturnValue(
+        new Map([
+          ['TenantCacheDocument', { name: 'TenantCacheDocument' }],
+        ]) as ReturnType<typeof ObjectRegistry.getAllClasses>,
+      );
+    const isTenantScoped = vi
+      .spyOn(ObjectRegistry, 'isTenantScoped')
+      .mockReturnValue(true);
+    const generator = new MCPGenerator();
+    const detector = generator as unknown as {
+      hasTenantScopedTools(tools: Array<{ name: string }>): Promise<boolean>;
+    };
+
+    try {
+      await expect(
+        detector.hasTenantScopedTools([{ name: 'tenantcachedocument_list' }]),
+      ).resolves.toBe(true);
+    } finally {
+      allClasses.mockRestore();
+      isTenantScoped.mockRestore();
+    }
+  });
+
+  it('sorts a copied tool catalog independently of discovery order', () => {
+    const source = [
+      { name: 'zebra_list' },
+      { name: 'antelope_list' },
+      { name: 'marmoset_list' },
+    ];
+
+    expect(sortMCPTools(source).map((tool) => tool.name)).toEqual([
+      'antelope_list',
+      'marmoset_list',
+      'zebra_list',
+    ]);
+    expect(source.map((tool) => tool.name)).toEqual([
+      'zebra_list',
+      'antelope_list',
+      'marmoset_list',
+    ]);
   });
 
   it('carries canonical receivers and positional invocation metadata without exposing it as a tool field', () => {

--- a/packages/core/src/generators/mcp-runtime-template.test.ts
+++ b/packages/core/src/generators/mcp-runtime-template.test.ts
@@ -42,7 +42,7 @@ describe('generated MCP custom-action runtime (#2182)', () => {
       'const TOOL_LIST_CACHE_HINT = {"ttlMs":86400000,"cacheScope":"private"};',
     );
     expect(source).toContain(
-      'tools: [...TOOLS].sort((left, right) => left.name.localeCompare(right.name))',
+      'tools: [...TOOLS].sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0)',
     );
   });
 
@@ -99,10 +99,14 @@ describe('generated MCP custom-action runtime (#2182)', () => {
       { name: 'zebra_list' },
       { name: 'antelope_list' },
       { name: 'marmoset_list' },
+      { name: 'i_list' },
+      { name: 'I_list' },
     ];
 
     expect(sortMCPTools(source).map((tool) => tool.name)).toEqual([
+      'I_list',
       'antelope_list',
+      'i_list',
       'marmoset_list',
       'zebra_list',
     ]);
@@ -110,6 +114,8 @@ describe('generated MCP custom-action runtime (#2182)', () => {
       'zebra_list',
       'antelope_list',
       'marmoset_list',
+      'i_list',
+      'I_list',
     ]);
   });
 

--- a/packages/core/src/generators/mcp-runtime-template.ts
+++ b/packages/core/src/generators/mcp-runtime-template.ts
@@ -488,7 +488,7 @@ ${
       }
 
       return {
-        tools: [...TOOLS].sort((left, right) => left.name.localeCompare(right.name)),
+        tools: [...TOOLS].sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0),
       };
     });
 

--- a/packages/core/src/generators/mcp-runtime-template.ts
+++ b/packages/core/src/generators/mcp-runtime-template.ts
@@ -46,6 +46,11 @@ export interface RuntimeOptions {
     inputSchema: Record<string, unknown>;
     outputSchema?: Record<string, unknown>;
   }>;
+  /** Cache hint emitted for deploy-static tools/list results. */
+  toolListCacheHint?: {
+    ttlMs: number;
+    cacheScope: 'private' | 'public';
+  };
   /** Internal invocation metadata; never exposed by the MCP tools/list result. */
   customActions?: Record<
     string,
@@ -94,6 +99,7 @@ export function generateRuntimeBootstrap(options: RuntimeOptions = {}): string {
     customActions = {},
     tenantScopedObjects = [],
     stiTargets = {},
+    toolListCacheHint = { ttlMs: 86_400_000, cacheScope: 'private' },
   } = options;
 
   // Generate static tool array as TypeScript code
@@ -307,6 +313,7 @@ const DEBUG = ${debug};
 
 // Static tool definitions (generated at build time)
 const TOOLS = ${toolsCode};
+const TOOL_LIST_CACHE_HINT = ${JSON.stringify(toolListCacheHint)};
 const CUSTOM_ACTIONS = ${JSON.stringify(customActions)};
 const STI_TARGETS: Record<string, Record<string, string>> = ${JSON.stringify(stiTargets)};
 ${
@@ -468,6 +475,9 @@ ${
         capabilities: {
           tools: {},
         },
+        cacheHints: {
+          'tools/list': TOOL_LIST_CACHE_HINT,
+        },
       }
     );
 
@@ -478,7 +488,7 @@ ${
       }
 
       return {
-        tools: TOOLS,
+        tools: [...TOOLS].sort((left, right) => left.name.localeCompare(right.name)),
       };
     });
 

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -53,10 +53,78 @@ export interface MCPConfig {
   name?: string;
   version?: string;
   description?: string;
+  /**
+   * Cache policy for generated MCP protocol results.
+   *
+   * Generated catalog results are private by default. A public tool catalog
+   * needs both an explicit public scope and an explicit assertion that the
+   * entire catalog is global and unauthenticated; tenant-scoped catalogs are
+   * always forced back to private.
+   */
+  cache?: {
+    toolsList?: MCPToolListCacheOptions;
+  };
   server?: {
     name: string;
     version: string;
   };
+}
+
+export const MCP_STABLE_CATALOG_TTL_MS = 86_400_000;
+
+export interface MCPToolListCacheOptions {
+  /** Cache lifetime in milliseconds. Defaults to one day for a deploy-static catalog. */
+  ttlMs?: number;
+  /** Requested cache visibility. Defaults to private. */
+  cacheScope?: 'private' | 'public';
+  /**
+   * Explicitly attest that every listed tool is global and unauthenticated.
+   * This must accompany `cacheScope: 'public'`; tenant-scoped tool sets cannot
+   * opt in regardless of this assertion.
+   */
+  publicCatalog?: true;
+}
+
+export interface MCPToolListCacheHint {
+  ttlMs: number;
+  cacheScope: 'private' | 'public';
+}
+
+/**
+ * Resolve the generated tools/list cache policy at generation time.
+ *
+ * A shared cache may otherwise serve one tenant's tool catalog to another, so
+ * public caching is deliberately double opt-in and unavailable when a
+ * generated server exposes any tenant-scoped object.
+ */
+export function resolveMCPToolListCacheHint(
+  options: MCPToolListCacheOptions | undefined,
+  hasTenantScopedTools: boolean,
+): MCPToolListCacheHint {
+  const ttlMs = options?.ttlMs ?? MCP_STABLE_CATALOG_TTL_MS;
+  if (!Number.isSafeInteger(ttlMs) || ttlMs < 0) {
+    throw new RangeError(
+      'MCP tools/list cache ttlMs must be a non-negative safe integer.',
+    );
+  }
+  if (
+    options?.cacheScope !== undefined &&
+    options.cacheScope !== 'private' &&
+    options.cacheScope !== 'public'
+  ) {
+    throw new RangeError(
+      "MCP tools/list cacheScope must be 'private' or 'public'.",
+    );
+  }
+
+  const cacheScope =
+    !hasTenantScopedTools &&
+    options?.cacheScope === 'public' &&
+    options.publicCatalog === true
+      ? 'public'
+      : 'private';
+
+  return { ttlMs, cacheScope };
 }
 
 export interface MCPContext {
@@ -89,6 +157,11 @@ export interface MCPTool {
   inputSchema: ToolJsonSchema;
   /** Public result schema for tools/call structuredContent. */
   outputSchema: ToolJsonSchema;
+}
+
+/** Return a copied, canonical tool sequence for byte-stable tools/list output. */
+export function sortMCPTools<T extends Pick<MCPTool, 'name'>>(tools: T[]): T[] {
+  return [...tools].sort((left, right) => left.name.localeCompare(right.name));
 }
 
 export interface MCPRequest {
@@ -217,7 +290,7 @@ export class MCPGenerator {
       tools.push(...objectTools);
     }
 
-    return tools;
+    return sortMCPTools(tools);
   }
 
   /**
@@ -1102,6 +1175,32 @@ export class MCPGenerator {
   }
 
   /**
+   * Whether a catalog contains a tenant-scoped class for cache isolation.
+   *
+   * Unlike the emitted runtime tenant gate, cache visibility must also fail
+   * closed for core-declared `@smrt({ tenantScoped })` models when the optional
+   * tenancy package is not installed. The registry covers that form, while
+   * `tenantScopedObjectNames()` covers the tenancy-owned decorator form.
+   */
+  private async hasTenantScopedTools(tools: MCPTool[]): Promise<boolean> {
+    if ((await this.tenantScopedObjectNames(tools)).length > 0) return true;
+
+    for (const tool of tools) {
+      const [objectName] = tool.name.split('_');
+      if (!objectName) continue;
+      for (const [key, info] of ObjectRegistry.getAllClasses()) {
+        const simpleName = info.name || key;
+        if (simpleName.toLowerCase() === objectName.toLowerCase()) {
+          if (ObjectRegistry.isTenantScoped(simpleName)) return true;
+          break;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
    * Execute a resolved MCP action (CRUD or custom) against a collection. Always
    * invoked inside the tenant gate established by {@link executeAction}.
    */
@@ -1440,6 +1539,10 @@ export class MCPGenerator {
     } else {
       // Generate single-file server with static tools
       const tools = await this.generateTools();
+      const tenantScopedObjects = await this.tenantScopedObjectNames(tools);
+      const hasTenantScopedTools =
+        tenantScopedObjects.length > 0 ||
+        (await this.hasTenantScopedTools(tools));
 
       const runtimeOptions: RuntimeOptions = {
         name: serverName,
@@ -1450,8 +1553,12 @@ export class MCPGenerator {
         debug,
         tools,
         customActions: await this.runtimeCustomActions(tools),
-        tenantScopedObjects: await this.tenantScopedObjectNames(tools),
+        tenantScopedObjects,
         stiTargets: this.runtimeStiTargets(tools),
+        toolListCacheHint: resolveMCPToolListCacheHint(
+          this.config.cache?.toolsList,
+          hasTenantScopedTools,
+        ),
       };
 
       const serverCode = generateRuntimeBootstrap(runtimeOptions);
@@ -1608,24 +1715,33 @@ export class MCPGenerator {
     await writeFile(configPath, configCode, 'utf-8');
     console.log(`✅ Generated config: ${configPath}`);
 
+    const generatedTools = await this.generateTools();
+
     // Generate tools/index.ts with tool definitions
     const toolsPath = resolve(toolsDir, 'index.ts');
-    const toolsCode = await this.generateToolsFile();
+    const toolsCode = this.generateToolsFile(generatedTools);
     await writeFile(toolsPath, toolsCode, 'utf-8');
     console.log(`✅ Generated tools: ${toolsPath}`);
 
     // Generate handlers/index.ts with tool call handlers
     const handlersPath = resolve(handlersDir, 'index.ts');
-    const tenantScopedObjects = await this.tenantScopedObjectNames(
-      await this.generateTools(),
-    );
+    const tenantScopedObjects =
+      await this.tenantScopedObjectNames(generatedTools);
+    const hasTenantScopedTools =
+      tenantScopedObjects.length > 0 ||
+      (await this.hasTenantScopedTools(generatedTools));
     const handlersCode = await this.generateHandlersFile(tenantScopedObjects);
     await writeFile(handlersPath, handlersCode, 'utf-8');
     console.log(`✅ Generated handlers: ${handlersPath}`);
 
     // Generate main index.js entry point
     const indexPath = resolve(outputDir, 'index.js');
-    const indexCode = this.generateModularIndex();
+    const indexCode = this.generateModularIndex(
+      resolveMCPToolListCacheHint(
+        this.config.cache?.toolsList,
+        hasTenantScopedTools,
+      ),
+    );
     await writeFile(indexPath, indexCode, 'utf-8');
     console.log(`✅ Generated MCP server: ${indexPath}`);
   }
@@ -1653,9 +1769,7 @@ export const DEBUG = ${debug};
   /**
    * Generate tools definitions file for modular server
    */
-  private async generateToolsFile(): Promise<string> {
-    const tools = await this.generateTools();
-
+  private generateToolsFile(tools: MCPTool[]): string {
     return `/**
  * MCP Tools Definitions
  * Auto-generated from SMRT objects
@@ -2075,7 +2189,9 @@ ${
   /**
    * Generate modular index file (main entry point)
    */
-  private generateModularIndex(): string {
+  private generateModularIndex(
+    toolListCacheHint: MCPToolListCacheHint,
+  ): string {
     return `#!/usr/bin/env node
 /**
  * Auto-generated MCP Server
@@ -2097,6 +2213,8 @@ import { getAI } from '@happyvertical/ai';
 import { SERVER_NAME, SERVER_VERSION, DEBUG } from './config.js';
 import { tools } from './tools/index.js';
 import { handleToolCall } from './handlers/index.js';
+
+const TOOL_LIST_CACHE_HINT = ${JSON.stringify(toolListCacheHint)};
 
 /**
  * Main server startup function
@@ -2132,6 +2250,9 @@ export async function createServer() {
         capabilities: {
           tools: {},
         },
+        cacheHints: {
+          'tools/list': TOOL_LIST_CACHE_HINT,
+        },
       }
     );
 
@@ -2142,7 +2263,7 @@ export async function createServer() {
       }
 
       return {
-        tools: tools.map(tool => ({
+        tools: [...tools].sort((left, right) => left.name.localeCompare(right.name)).map(tool => ({
           name: tool.name,
           description: tool.description,
           inputSchema: tool.inputSchema,

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -161,7 +161,9 @@ export interface MCPTool {
 
 /** Return a copied, canonical tool sequence for byte-stable tools/list output. */
 export function sortMCPTools<T extends Pick<MCPTool, 'name'>>(tools: T[]): T[] {
-  return [...tools].sort((left, right) => left.name.localeCompare(right.name));
+  return [...tools].sort((left, right) =>
+    left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+  );
 }
 
 export interface MCPRequest {
@@ -2263,7 +2265,7 @@ export async function createServer() {
       }
 
       return {
-        tools: [...tools].sort((left, right) => left.name.localeCompare(right.name)).map(tool => ({
+        tools: [...tools].sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0).map(tool => ({
           name: tool.name,
           description: tool.description,
           inputSchema: tool.inputSchema,

--- a/packages/mcp-conformance-fixture/src/generated-server-conformance.test.ts
+++ b/packages/mcp-conformance-fixture/src/generated-server-conformance.test.ts
@@ -183,6 +183,41 @@ describe('generated Tier-1 MCP 2026-07-28 conformance', () => {
       resultType: 'complete',
       _meta: { [SERVER_INFO_META_KEY]: { name: 'smrt-generated-conformance' } },
     });
+
+    const listResponse = await fetch(mcpUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'mcp-method': 'tools/list',
+        'mcp-protocol-version': '2026-07-28',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+        params: {
+          _meta: {
+            [PROTOCOL_VERSION_META_KEY]: '2026-07-28',
+            [CLIENT_INFO_META_KEY]: {
+              name: 'generated-fixture-test',
+              version: '0.0.0',
+            },
+            [CLIENT_CAPABILITIES_META_KEY]: {},
+          },
+        },
+      }),
+    });
+    const list = (await listResponse.json()) as any;
+    expect(list.result).toMatchObject({
+      resultType: 'complete',
+      ttlMs: 86_400_000,
+      cacheScope: 'private',
+    });
+    expect(
+      list.result.tools.map((tool: { name: string }) => tool.name),
+    ).toEqual(
+      [...list.result.tools.map((tool: { name: string }) => tool.name)].sort(),
+    );
   });
 
   it('passes the official server suite with the reviewed baseline', async () => {

--- a/packages/smrt-app-mcp/README.md
+++ b/packages/smrt-app-mcp/README.md
@@ -2,7 +2,7 @@
 
 App-runtime MCP server scaffolding for s-m-r-t apps. Provides:
 
-- **Core** — `createMcpAppServer({ smrtOptions, serverInfo, allowedClassNames, publicToolPatterns?, toolPolicy?, workflowAssertions? })` returning `{ listTools, callTool }` wired to `@happyvertical/smrt-core/generators/mcp`.
+- **Core** — `createMcpAppServer({ smrtOptions, serverInfo, allowedClassNames, publicToolPatterns?, toolListCache?, toolPolicy?, workflowAssertions? })` returning `{ listTools, callTool }` wired to `@happyvertical/smrt-core/generators/mcp`.
 - **SvelteKit adapters** (`./sveltekit`) — `mountMcpRoute` mounts a modern
   2026-07-28 stateless Streamable HTTP MCP endpoint. The REST-shaped
   `mountMcpToolsRoute` / `mountMcpCallRoute` aliases remain available for one
@@ -58,6 +58,13 @@ deterministically ordered by name. Stock MCP clients send the required
 `Mcp-Method` header (and `Mcp-Name` for `tools/call`); the mount validates them
 against the JSON-RPC body and returns the protocol `HeaderMismatch` error
 (`-32020`, HTTP 400) for a missing or mismatched header.
+
+`tools/list` emits the required cache metadata with a one-day, `private`
+default. Shared (`public`) caching is intentionally exceptional: set
+`toolListCache: { cacheScope: 'public', publicCatalog: true }` only for a
+reviewed catalog where every allowed tool is unauthenticated, read-only, and
+global. The server verifies that shape (including the absence of tenant-scoped
+tools and principal-aware policy) and falls back to `private` otherwise.
 
 The route constructs a fresh protocol server for every HTTP request. It does
 not issue or rely on `Mcp-Session-Id`, sticky load-balancer routing, or a held

--- a/packages/smrt-app-mcp/src/__tests__/mcp-conformance.test.ts
+++ b/packages/smrt-app-mcp/src/__tests__/mcp-conformance.test.ts
@@ -3,6 +3,7 @@ import { createServer as createHttpServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { MCPTool } from '@happyvertical/smrt-core/generators/mcp';
 import { toNodeHandler } from '@modelcontextprotocol/node';
 import {
   CLIENT_CAPABILITIES_META_KEY,
@@ -67,7 +68,37 @@ describe('smrt-app-mcp MCP 2026-07-28 conformance', () => {
     expect(list.body.result).toMatchObject({
       resultType: 'complete',
       tools: [],
+      ttlMs: 86_400_000,
+      cacheScope: 'private',
     });
+  });
+
+  it('sorts protocol tool lists independently of app-server discovery order', async () => {
+    const unsortedServer: McpAppServer = {
+      ...appServer,
+      async listTools() {
+        return [
+          {
+            name: 'zebra_list',
+            description: 'Zebra',
+            inputSchema: { type: 'object' },
+          },
+          {
+            name: 'antelope_list',
+            description: 'Antelope',
+            inputSchema: { type: 'object' },
+          },
+        ] satisfies MCPTool[];
+      },
+    };
+    const unsortedHandler = createMcpHandler(() =>
+      createMcpProtocolServer(unsortedServer),
+    );
+
+    const response = await modernRequest(unsortedHandler, 'tools/list');
+    expect(
+      response.body.result.tools.map((tool: { name: string }) => tool.name),
+    ).toEqual(['antelope_list', 'zebra_list']);
   });
 
   it('allowlists access-error metadata before exposing it over MCP', async () => {

--- a/packages/smrt-app-mcp/src/__tests__/mcp-conformance.test.ts
+++ b/packages/smrt-app-mcp/src/__tests__/mcp-conformance.test.ts
@@ -88,6 +88,16 @@ describe('smrt-app-mcp MCP 2026-07-28 conformance', () => {
             description: 'Antelope',
             inputSchema: { type: 'object' },
           },
+          {
+            name: 'I_list',
+            description: 'Uppercase I',
+            inputSchema: { type: 'object' },
+          },
+          {
+            name: 'i_list',
+            description: 'Lowercase i',
+            inputSchema: { type: 'object' },
+          },
         ] satisfies MCPTool[];
       },
     };
@@ -98,7 +108,7 @@ describe('smrt-app-mcp MCP 2026-07-28 conformance', () => {
     const response = await modernRequest(unsortedHandler, 'tools/list');
     expect(
       response.body.result.tools.map((tool: { name: string }) => tool.name),
-    ).toEqual(['antelope_list', 'zebra_list']);
+    ).toEqual(['I_list', 'antelope_list', 'i_list', 'zebra_list']);
   });
 
   it('allowlists access-error metadata before exposing it over MCP', async () => {

--- a/packages/smrt-app-mcp/src/__tests__/server.test.ts
+++ b/packages/smrt-app-mcp/src/__tests__/server.test.ts
@@ -5,6 +5,7 @@
  * workflow-assertion paths in isolation.
  */
 
+import { ObjectRegistry } from '@happyvertical/smrt-core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MCP_TOOL_ACCESS_DENIED_CODE, McpAccessError } from '../errors.js';
 import { createMcpAppServer } from '../server.js';
@@ -21,7 +22,7 @@ vi.mock('@happyvertical/smrt-core/generators/mcp', () => {
       return handleToolCallMock(request);
     }
   }
-  return { MCPGenerator };
+  return { MCPGenerator, MCP_STABLE_CATALOG_TTL_MS: 86_400_000 };
 });
 
 function tool(name: string) {
@@ -286,5 +287,79 @@ describe('createMcpAppServer', () => {
       (await server.listTools({ authenticated: false })).map((t) => t.name),
     ).toEqual(['opportunity_get', 'opportunity_list']);
     expect(publicToolPatterns).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps tool catalogs private unless every tool explicitly opts into a safe public catalog', async () => {
+    generateToolsMock.mockResolvedValue([
+      tool('opportunity_list'),
+      tool('opportunity_get'),
+    ]);
+    const defaultServer = createMcpAppServer({
+      smrtOptions: () => ({}),
+      serverInfo: { name: 'app', version: '0.1.0' },
+      allowedClassNames: ['Opportunity'],
+      publicToolPatterns: () => ['opportunity_*'],
+    });
+    await expect(defaultServer.getToolsListCacheHint?.()).resolves.toEqual({
+      ttlMs: 86_400_000,
+      cacheScope: 'private',
+    });
+
+    const publicServer = createMcpAppServer({
+      smrtOptions: () => ({}),
+      serverInfo: { name: 'app', version: '0.1.0' },
+      allowedClassNames: ['Opportunity'],
+      publicToolPatterns: () => ['opportunity_*'],
+      toolListCache: { cacheScope: 'public', publicCatalog: true },
+    });
+    await expect(publicServer.getToolsListCacheHint?.()).resolves.toEqual({
+      ttlMs: 86_400_000,
+      cacheScope: 'public',
+    });
+
+    generateToolsMock.mockResolvedValue([
+      tool('opportunity_list'),
+      tool('opportunity_create'),
+    ]);
+    const mixedServer = createMcpAppServer({
+      smrtOptions: () => ({}),
+      serverInfo: { name: 'app', version: '0.1.0' },
+      allowedClassNames: ['Opportunity'],
+      publicToolPatterns: () => ['opportunity_*'],
+      toolListCache: { cacheScope: 'public', publicCatalog: true },
+    });
+    await expect(mixedServer.getToolsListCacheHint?.()).resolves.toMatchObject({
+      cacheScope: 'private',
+    });
+  });
+
+  it('keeps explicitly public catalogs private when a registered tool is tenant-scoped', async () => {
+    generateToolsMock.mockResolvedValue([tool('cachemetadatatenant_list')]);
+    const allClasses = vi
+      .spyOn(ObjectRegistry, 'getAllClasses')
+      .mockReturnValue(
+        new Map([
+          ['CacheMetadataTenant', { name: 'CacheMetadataTenant' }],
+        ]) as ReturnType<typeof ObjectRegistry.getAllClasses>,
+      );
+    const isTenantScoped = vi
+      .spyOn(ObjectRegistry, 'isTenantScoped')
+      .mockReturnValue(true);
+    const server = createMcpAppServer({
+      smrtOptions: () => ({}),
+      serverInfo: { name: 'app', version: '0.1.0' },
+      allowedClassNames: ['CacheMetadataTenant'],
+      publicToolPatterns: () => ['cachemetadatatenant_*'],
+      toolListCache: { cacheScope: 'public', publicCatalog: true },
+    });
+
+    try {
+      await expect(server.getToolsListCacheHint?.()).resolves.toMatchObject({
+        cacheScope: 'private',
+      });
+    } finally {
+      allClasses.mockRestore();
+      isTenantScoped.mockRestore();
+    }
   });
 });

--- a/packages/smrt-app-mcp/src/__tests__/server.test.ts
+++ b/packages/smrt-app-mcp/src/__tests__/server.test.ts
@@ -334,7 +334,7 @@ describe('createMcpAppServer', () => {
   });
 
   it('keeps explicitly public catalogs private when a registered tool is tenant-scoped', async () => {
-    generateToolsMock.mockResolvedValue([tool('cachemetadatatenant_list')]);
+    generateToolsMock.mockResolvedValue([tool('CacheMetadataTenant_list')]);
     const allClasses = vi
       .spyOn(ObjectRegistry, 'getAllClasses')
       .mockReturnValue(
@@ -349,7 +349,7 @@ describe('createMcpAppServer', () => {
       smrtOptions: () => ({}),
       serverInfo: { name: 'app', version: '0.1.0' },
       allowedClassNames: ['CacheMetadataTenant'],
-      publicToolPatterns: () => ['cachemetadatatenant_*'],
+      publicToolPatterns: () => ['CacheMetadataTenant_*'],
       toolListCache: { cacheScope: 'public', publicCatalog: true },
     });
 

--- a/packages/smrt-app-mcp/src/index.ts
+++ b/packages/smrt-app-mcp/src/index.ts
@@ -41,6 +41,8 @@ export {
   type McpAppUser,
   type McpPublicToolPatternsThunk,
   type McpSmrtOptionsThunk,
+  type McpToolListCacheHint,
+  type McpToolListCacheOptions,
   type McpToolPolicy,
   type McpToolPolicyContext,
   type McpWorkflowAssertion,

--- a/packages/smrt-app-mcp/src/protocol.ts
+++ b/packages/smrt-app-mcp/src/protocol.ts
@@ -10,6 +10,11 @@ import {
 import { McpAccessError } from './errors.js';
 import type { McpAppPrincipal, McpAppServer } from './server.js';
 
+const DEFAULT_TOOL_LIST_CACHE_HINT = {
+  ttlMs: 86_400_000,
+  cacheScope: 'private' as const,
+};
+
 export interface McpProtocolServerOptions {
   /** Resolve the authenticated application principal for each MCP request. */
   principal?:
@@ -41,13 +46,21 @@ export function createMcpProtocolServer(
 ): Server {
   const server = new Server(appServer.serverInfo, {
     capabilities: { tools: {} },
+    cacheHints: { 'tools/list': DEFAULT_TOOL_LIST_CACHE_HINT },
   });
 
-  server.setRequestHandler('tools/list', async (_request, context) => ({
-    tools: (await appServer.listTools({
-      principal: await resolvePrincipal(options.principal, context),
-    })) as Tool[],
-  }));
+  server.setRequestHandler('tools/list', async (_request, context) => {
+    const principal = await resolvePrincipal(options.principal, context);
+    const cacheHint =
+      (await appServer.getToolsListCacheHint?.()) ??
+      DEFAULT_TOOL_LIST_CACHE_HINT;
+    return {
+      tools: [...(await appServer.listTools({ principal }))].sort(
+        (left, right) => left.name.localeCompare(right.name),
+      ) as Tool[],
+      ...cacheHint,
+    };
+  });
 
   server.setRequestHandler('tools/call', async (request, context) => {
     try {

--- a/packages/smrt-app-mcp/src/protocol.ts
+++ b/packages/smrt-app-mcp/src/protocol.ts
@@ -9,6 +9,7 @@ import {
 } from '@modelcontextprotocol/server';
 import { McpAccessError } from './errors.js';
 import type { McpAppPrincipal, McpAppServer } from './server.js';
+import { compareMcpToolNames } from './tools.js';
 
 const DEFAULT_TOOL_LIST_CACHE_HINT = {
   ttlMs: 86_400_000,
@@ -56,7 +57,7 @@ export function createMcpProtocolServer(
       DEFAULT_TOOL_LIST_CACHE_HINT;
     return {
       tools: [...(await appServer.listTools({ principal }))].sort(
-        (left, right) => left.name.localeCompare(right.name),
+        (left, right) => compareMcpToolNames(left.name, right.name),
       ) as Tool[],
       ...cacheHint,
     };

--- a/packages/smrt-app-mcp/src/server.ts
+++ b/packages/smrt-app-mcp/src/server.ts
@@ -16,12 +16,19 @@
  * @packageDocumentation
  */
 
+import {
+  isTenantScopedClassResolved,
+  ObjectRegistry,
+} from '@happyvertical/smrt-core';
 import type {
   MCPConfig,
   MCPResponse,
   MCPTool,
 } from '@happyvertical/smrt-core/generators/mcp';
-import { MCPGenerator } from '@happyvertical/smrt-core/generators/mcp';
+import {
+  MCP_STABLE_CATALOG_TTL_MS,
+  MCPGenerator,
+} from '@happyvertical/smrt-core/generators/mcp';
 import { MCP_TOOL_ACCESS_DENIED_CODE, McpAccessError } from './errors.js';
 import {
   classNamePrefixes,
@@ -85,6 +92,23 @@ export type McpSmrtOptionsThunk = () => Record<string, unknown>;
 /** Public-tool patterns thunk — same lazy-evaluation rationale. */
 export type McpPublicToolPatternsThunk = () => readonly string[];
 
+export interface McpToolListCacheHint {
+  ttlMs: number;
+  cacheScope: 'private' | 'public';
+}
+
+export interface McpToolListCacheOptions {
+  /** Cache lifetime in milliseconds. Defaults to one day for a deploy-static catalog. */
+  ttlMs?: number;
+  /** Requested cache visibility. Defaults to private. */
+  cacheScope?: 'private' | 'public';
+  /**
+   * Explicit attestation that every allowed tool is global, unauthenticated,
+   * and safe to share through an intermediary cache.
+   */
+  publicCatalog?: true;
+}
+
 /**
  * Options for `createMcpAppServer`.
  */
@@ -106,6 +130,12 @@ export interface CreateMcpAppServerOptions {
    * (everything requires auth).
    */
   publicToolPatterns?: McpPublicToolPatternsThunk;
+  /**
+   * Cache policy for the MCP tools/list result. Public caching is honored only
+   * when this explicitly opts in and every allowed tool is a non-tenant,
+   * unauthenticated read-only tool with no principal-aware policy.
+   */
+  toolListCache?: McpToolListCacheOptions;
   /**
    * Optional generic principal-aware tool policy. It is evaluated for every
    * tool that passes the app allow-list and base public/authenticated policy,
@@ -149,8 +179,52 @@ export interface CallToolInput {
 export interface McpAppServer {
   listTools(input: ListToolsInput): Promise<MCPTool[]>;
   callTool(input: CallToolInput): Promise<MCPResponse>;
+  /** Cache policy for protocol tools/list responses. */
+  getToolsListCacheHint?(): Promise<McpToolListCacheHint>;
   /** Read-only view of the configured server identity. */
   readonly serverInfo: CreateMcpAppServerOptions['serverInfo'];
+}
+
+function configuredToolListCacheHint(
+  options: McpToolListCacheOptions | undefined,
+): McpToolListCacheHint {
+  const ttlMs = options?.ttlMs ?? MCP_STABLE_CATALOG_TTL_MS;
+  if (!Number.isSafeInteger(ttlMs) || ttlMs < 0) {
+    throw new RangeError(
+      'MCP tools/list cache ttlMs must be a non-negative safe integer.',
+    );
+  }
+  if (
+    options?.cacheScope !== undefined &&
+    options.cacheScope !== 'private' &&
+    options.cacheScope !== 'public'
+  ) {
+    throw new RangeError(
+      "MCP tools/list cacheScope must be 'private' or 'public'.",
+    );
+  }
+  return {
+    ttlMs,
+    cacheScope:
+      options?.cacheScope === 'public' && options.publicCatalog === true
+        ? 'public'
+        : 'private',
+  };
+}
+
+function isTenantScopedTool(tool: MCPTool): boolean {
+  const separator = tool.name.indexOf('_');
+  if (separator <= 0) return false;
+  const objectName = tool.name.slice(0, separator);
+  for (const [key, classInfo] of ObjectRegistry.getAllClasses()) {
+    const name = classInfo.name || key;
+    if (name.toLowerCase() === objectName) {
+      return (
+        ObjectRegistry.isTenantScoped(name) || isTenantScopedClassResolved(name)
+      );
+    }
+  }
+  return false;
 }
 
 /**
@@ -166,6 +240,9 @@ export function createMcpAppServer(
     options.publicToolPatterns ?? ((): readonly string[] => []);
   const toolPolicy = options.toolPolicy;
   const workflowAssertions = options.workflowAssertions ?? {};
+  const requestedToolListCacheHint = configuredToolListCacheHint(
+    options.toolListCache,
+  );
 
   function userForGenerator(
     principal?: McpAppPrincipal | null,
@@ -238,6 +315,30 @@ export function createMcpAppServer(
     return tools.filter((_, index) => visible[index]);
   }
 
+  async function getToolsListCacheHint(): Promise<McpToolListCacheHint> {
+    if (requestedToolListCacheHint.cacheScope !== 'public') {
+      return requestedToolListCacheHint;
+    }
+
+    // A principal-aware policy can make one caller's catalog differ from
+    // another's. Likewise, tenant-scoped reads must never be shared across
+    // tenants. The requested public scope is therefore honored only for a
+    // complete, unauthenticated, non-tenant read-only catalog.
+    const tools = await allowedTools();
+    const publicPatterns = getPublicPatterns();
+    const isSafePublicCatalog =
+      !toolPolicy &&
+      tools.every(
+        (tool) =>
+          isPublicToolName(tool.name, publicPatterns) &&
+          !isTenantScopedTool(tool),
+      );
+
+    return isSafePublicCatalog
+      ? requestedToolListCacheHint
+      : { ...requestedToolListCacheHint, cacheScope: 'private' };
+  }
+
   async function callTool(input: CallToolInput): Promise<MCPResponse> {
     const args = input.arguments ?? {};
     const principal = principalForCall(input);
@@ -276,6 +377,7 @@ export function createMcpAppServer(
   return {
     listTools,
     callTool,
+    getToolsListCacheHint,
     serverInfo: options.serverInfo,
   };
 }

--- a/packages/smrt-app-mcp/src/server.ts
+++ b/packages/smrt-app-mcp/src/server.ts
@@ -32,6 +32,7 @@ import {
 import { MCP_TOOL_ACCESS_DENIED_CODE, McpAccessError } from './errors.js';
 import {
   classNamePrefixes,
+  compareMcpToolNames,
   isAllowedCoreTool,
   isPublicToolName,
 } from './tools.js';
@@ -215,7 +216,7 @@ function configuredToolListCacheHint(
 function isTenantScopedTool(tool: MCPTool): boolean {
   const separator = tool.name.indexOf('_');
   if (separator <= 0) return false;
-  const objectName = tool.name.slice(0, separator);
+  const objectName = tool.name.slice(0, separator).toLowerCase();
   for (const [key, classInfo] of ObjectRegistry.getAllClasses()) {
     const name = classInfo.name || key;
     if (name.toLowerCase() === objectName) {
@@ -273,8 +274,10 @@ export function createMcpAppServer(
   async function allowedTools(): Promise<MCPTool[]> {
     const tools = await makeGenerator().generateTools();
     return tools
-      .filter((tool) => isAllowedCoreTool(tool.name, allowedPrefixes))
-      .sort((left, right) => left.name.localeCompare(right.name));
+      .filter((tool) =>
+        isAllowedCoreTool(tool.name.toLowerCase(), allowedPrefixes),
+      )
+      .sort((left, right) => compareMcpToolNames(left.name, right.name));
   }
 
   function passesBasePolicy(

--- a/packages/smrt-app-mcp/src/tools.ts
+++ b/packages/smrt-app-mcp/src/tools.ts
@@ -85,3 +85,11 @@ export function isAllowedCoreTool(
   }
   return false;
 }
+
+/**
+ * Compare tool names by Unicode code unit, rather than the host locale, so a
+ * catalog has one byte-stable order across every runtime.
+ */
+export function compareMcpToolNames(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/packages/smrt-dev-mcp/README.md
+++ b/packages/smrt-dev-mcp/README.md
@@ -166,6 +166,14 @@ manifest artifacts before falling back to raw manifest/doc scanning. The runtime
 `manifest.json` stays focused on object registration; `smrt-knowledge.json` is
 the agent/developer contract.
 
+## Cache Metadata
+
+The deploy-static `tools/list` and `prompts/list` catalogs advertise a one-day
+`private` cache lifetime. Workspace knowledge resources (`resources/list` and
+`resources/read`) are also `private`, but use `ttlMs: 0`: they are rebuilt from
+the current workspace on each request and have no transport-visible invalidation
+signal that could make a positive freshness promise honest.
+
 After using a model to update package docs or expertise, always run the
 deterministic checker again:
 

--- a/packages/smrt-dev-mcp/src/index.ts
+++ b/packages/smrt-dev-mcp/src/index.ts
@@ -59,6 +59,10 @@ type PromptArguments = Record<string, string> | undefined;
 
 const JSON_SCHEMA_2020_12 = 'https://json-schema.org/draft/2020-12/schema';
 
+function compareToolNames(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
 /**
  * Stable success/error envelope for development tools. `data` preserves each
  * tool's existing payload exactly; coverage/diagnostics are promoted only when
@@ -524,7 +528,7 @@ export const TOOLS: Tool[] = TOOL_DEFINITIONS.map((tool) => ({
     $schema: JSON_SCHEMA_2020_12,
   },
   outputSchema: DEV_MCP_OUTPUT_SCHEMA,
-})).sort((left, right) => left.name.localeCompare(right.name));
+})).sort((left, right) => compareToolNames(left.name, right.name));
 
 export function createServer(): Server {
   if (DEBUG) {

--- a/packages/smrt-dev-mcp/src/index.ts
+++ b/packages/smrt-dev-mcp/src/index.ts
@@ -41,6 +41,17 @@ const DOMAIN_CODE_REVIEW_PROMPT = 'domain-code-review';
 const DOMAIN_ARCHITECTURE_PROMPT = 'domain-architecture';
 const KNOWLEDGE_PROJECT_URI = 'smrt://knowledge/project';
 const KNOWLEDGE_PACKAGE_PREFIX = 'smrt://knowledge/package/';
+const DEPLOY_STATIC_CATALOG_CACHE_HINT = {
+  ttlMs: 86_400_000,
+  cacheScope: 'private' as const,
+};
+// Knowledge resources are rebuilt from the workspace on every request. There
+// is no transport-visible project-graph invalidation signal, so a nonzero TTL
+// would promise stale data could not be served after an edit.
+const LIVE_KNOWLEDGE_CACHE_HINT = {
+  ttlMs: 0,
+  cacheScope: 'private' as const,
+};
 
 type KnowledgeIndexResult = Awaited<ReturnType<typeof buildKnowledgeIndex>>;
 type KnowledgePackageResult = KnowledgeIndexResult['packages'][number];
@@ -513,7 +524,7 @@ export const TOOLS: Tool[] = TOOL_DEFINITIONS.map((tool) => ({
     $schema: JSON_SCHEMA_2020_12,
   },
   outputSchema: DEV_MCP_OUTPUT_SCHEMA,
-}));
+})).sort((left, right) => left.name.localeCompare(right.name));
 
 export function createServer(): Server {
   if (DEBUG) {
@@ -530,6 +541,12 @@ export function createServer(): Server {
         prompts: {},
         resources: {},
         tools: {},
+      },
+      cacheHints: {
+        'tools/list': DEPLOY_STATIC_CATALOG_CACHE_HINT,
+        'prompts/list': DEPLOY_STATIC_CATALOG_CACHE_HINT,
+        'resources/list': LIVE_KNOWLEDGE_CACHE_HINT,
+        'resources/read': LIVE_KNOWLEDGE_CACHE_HINT,
       },
     },
   );

--- a/packages/smrt-dev-mcp/src/mcp-conformance.spec.ts
+++ b/packages/smrt-dev-mcp/src/mcp-conformance.spec.ts
@@ -47,7 +47,34 @@ describe('smrt-dev-mcp MCP 2026-07-28 conformance', () => {
       _meta: { [SERVER_INFO_META_KEY]: { name: 'smrt-dev-mcp' } },
     });
     const list = await modernRequest(handler, 'tools/list');
-    expect(list.body.result.resultType).toBe('complete');
+    expect(list.body.result).toMatchObject({
+      resultType: 'complete',
+      ttlMs: 86_400_000,
+      cacheScope: 'private',
+    });
+
+    const prompts = await modernRequest(handler, 'prompts/list');
+    expect(prompts.body.result).toMatchObject({
+      ttlMs: 86_400_000,
+      cacheScope: 'private',
+    });
+
+    const resources = await modernRequest(handler, 'resources/list');
+    expect(resources.body.result).toMatchObject({
+      ttlMs: 0,
+      cacheScope: 'private',
+    });
+
+    const read = await modernRequest(
+      handler,
+      'resources/read',
+      'resources/read',
+      { uri: 'smrt-dev-mcp://agent-skills/smrt-code-review' },
+    );
+    expect(read.body.result).toMatchObject({
+      ttlMs: 0,
+      cacheScope: 'private',
+    });
 
     const mismatch = await modernRequest(
       handler,
@@ -97,7 +124,14 @@ async function modernRequest(
   target: McpHttpHandler,
   method: string,
   headerMethod = method,
+  params: Record<string, unknown> = {},
 ) {
+  const mcpName =
+    typeof params.name === 'string'
+      ? params.name
+      : typeof params.uri === 'string'
+        ? params.uri
+        : undefined;
   const response = await target.fetch(
     new Request('http://localhost/mcp', {
       method: 'POST',
@@ -105,12 +139,14 @@ async function modernRequest(
         'content-type': 'application/json',
         'mcp-method': headerMethod,
         'mcp-protocol-version': '2026-07-28',
+        ...(mcpName === undefined ? {} : { 'mcp-name': mcpName }),
       },
       body: JSON.stringify({
         jsonrpc: '2.0',
         id: 1,
         method,
         params: {
+          ...params,
           _meta: {
             [PROTOCOL_VERSION_META_KEY]: '2026-07-28',
             [CLIENT_INFO_META_KEY]: {


### PR DESCRIPTION
## Summary

- Emit deterministic MCP catalog cache metadata across generated, app, development, and CLI bridge servers.
- Keep catalog caching private by default; public opt-in fails closed for tenant-scoped registrations.
- Use locale-independent code-unit ordering for byte-stable tool catalogs, including mixed-case names.
- Mark development knowledge resources private with zero TTL and extend executable conformance coverage.

## Validation

- pnpm build
- pnpm typecheck
- pnpm test
- pnpm test:mcp-conformance
- pnpm audit:policy
- pnpm knowledge:check --changed --strict --format markdown
- Pre-push policy suite

Closes #2150

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-issue-2150-cache-metadata-r3-20260808","issue":2150,"policy_revision":"1.0.0","status":"complete","validation":["pnpm build","pnpm typecheck","pnpm test","pnpm test:mcp-conformance","pnpm audit:policy","strict knowledge check","review-cycle passed","pre-push policy suite","locale-independent ordering regressions"]}
```