### PR TITLE
feat(fields): add policy control panel and audit catalog

### DIFF
--- a/packages/fields/AGENTS.md
+++ b/packages/fields/AGENTS.md
@@ -197,6 +197,26 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
   `visibleColumnIds`; it filters policy-hidden mapped fields, preserves unmapped
   computed/action columns, and cannot reveal a static `column.hidden` column.
 
+## Defaults control panel (#2050)
+
+- `buildFieldPolicySettingsCatalog()` is the server-side, URL/GET-driven
+  catalog builder. It structurally targets `SettingsCatalog`, but this package
+  must not import `smrt-svelte`; hosts inject `SettingsCatalog` into
+  `FieldPolicyControlPanel` and retain their own route and transport adapters.
+- `policyAudit` is the only routed organization roll-up. It requires
+  `fields.policy.manage`, returns only the caller tenant's editable rows and
+  read-only app summaries, and represents other users strictly as per-field
+  counts. It resolves only requested page refs; never pre-resolve the catalog.
+- Display code/app/org values by replaying the explained resolver layers, not
+  by independently calculating precedence. Reset and drift prune are ordinary
+  model deletes, so existing scope/permission validation remains authoritative.
+  The panel asks for an explicit confirmation before either destructive action;
+  SSR hosts can inject that confirmation decision instead of relying on
+  `window.confirm`.
+- `fieldPolicyControlPanelNavItem()` is a structural AdminShell tenant-nav
+  seam. It never imports `smrt-svelte` or `smrt-web`; the host supplies the
+  returned entry and must enforce its real route permission server-side.
+
 ## Related
 
 - `@happyvertical/smrt-prompts` / `smrt-languages` / `smrt-features` — the

--- a/packages/fields/src/collections/FieldPolicyCollection.ts
+++ b/packages/fields/src/collections/FieldPolicyCollection.ts
@@ -1,9 +1,16 @@
 import { SmrtCollection, smrt } from '@happyvertical/smrt-core';
-import { getCurrentTenant } from '@happyvertical/smrt-tenancy';
-import { checkOperationPermission } from '@happyvertical/smrt-users';
+import {
+  getCurrentTenant,
+  isSuperAdminBypass,
+} from '@happyvertical/smrt-tenancy';
+import {
+  checkOperationPermission,
+  MembershipCollection,
+} from '@happyvertical/smrt-users';
 import {
   getFieldReadPermission,
   getObjectFieldMap,
+  isPolicyAddressableField,
   isSensitiveField,
   isTransientField,
   isUsableRequiredDefault,
@@ -15,7 +22,11 @@ import {
 } from '../permissions.js';
 import type {
   ExplainedObjectFieldPolicy,
+  FieldPolicyAuditRow,
+  FieldPolicyAuditSnapshot,
   FieldPolicyBatchResult,
+  FieldPolicyDriftReason,
+  FieldPolicyDriftRow,
   FieldPolicyEditorRow,
   FieldPolicyEditorStateResult,
   ResolvedObjectFieldPolicy,
@@ -23,6 +34,10 @@ import type {
 
 /** Upper bound on objectRefs per batch call — bounds registry/db work per request. */
 const MAX_BATCH_OBJECT_REFS = 100;
+/** Public cap shared by the server catalog and browser adapter. */
+export const MAX_FIELD_POLICY_AUDIT_OBJECT_REFS = MAX_BATCH_OBJECT_REFS;
+/** Count queries are projected, so they can cover a page plus an off-page selection. */
+export const MAX_FIELD_POLICY_AUDIT_COUNT_REFS = MAX_BATCH_OBJECT_REFS * 2;
 
 /**
  * Collection surface for {@link FieldPolicy} rows plus the batch resolve
@@ -53,7 +68,14 @@ const MAX_BATCH_OBJECT_REFS = 100;
 @smrt({
   conflictColumns: ['object_ref', 'field_name', 'scope_type', 'scope_key'],
   api: {
-    include: ['create', 'update', 'delete', 'resolveBatch', 'getEditorState'],
+    include: [
+      'create',
+      'update',
+      'delete',
+      'resolveBatch',
+      'getEditorState',
+      'policyAudit',
+    ],
     // The collection-scoped editor action shares the sparse cross-scope
     // policy table, so generated SvelteKit routes establish identity from
     // authenticated locals even though FieldPolicy is not @TenantScoped.
@@ -69,6 +91,11 @@ const MAX_BATCH_OBJECT_REFS = 100;
         method: 'POST',
         path: 'editor-state',
       },
+      policyAudit: {
+        scope: 'collection',
+        method: 'POST',
+        path: 'policy-audit',
+      },
     },
   },
   cli: false,
@@ -76,6 +103,270 @@ const MAX_BATCH_OBJECT_REFS = 100;
 })
 export class FieldPolicyCollection extends SmrtCollection<FieldPolicy> {
   static readonly _itemClass = FieldPolicy;
+
+  /**
+   * Permission-gated, tenant-scoped audit read for the defaults control
+   * panel. It returns editable own-tenant rows, read-only app summaries,
+   * projected user override counts, and identity-only manifest drift rows.
+   */
+  async policyAudit(
+    options: {
+      objectRefs?: string[];
+      countObjectRefs?: string[];
+      /** Capability-only bootstrap for catalog builders before page selection. */
+      summaryOnly?: boolean;
+      /** Return row/count roll-ups without resolving field-policy layers. */
+      countsOnly?: boolean;
+      /** Return the first bounded page of manifest drift candidates. */
+      includeDrift?: boolean;
+    } = {},
+  ): Promise<FieldPolicyAuditSnapshot> {
+    const objectRefs = normalizeAuditRefs(
+      options.objectRefs,
+      'objectRefs',
+      MAX_FIELD_POLICY_AUDIT_OBJECT_REFS,
+    );
+    const countObjectRefs = normalizeAuditRefs(
+      options.countObjectRefs ?? objectRefs,
+      'countObjectRefs',
+      MAX_FIELD_POLICY_AUDIT_COUNT_REFS,
+    );
+    const context = getCurrentTenant();
+    const tenantId = context?.tenantId ?? null;
+    const userId = context?.userId ?? null;
+    const permissionOptions = {
+      collection: 'fields.policy',
+      db: this.db,
+      tenantId,
+      userId,
+      permissionSet: context?.permissions,
+      onDeny: 'return' as const,
+    };
+    const manage = tenantId
+      ? await checkOperationPermission({
+          ...permissionOptions,
+          action: MANAGE_FIELD_POLICY_PERMISSION.split('.').at(-1) ?? 'manage',
+        })
+      : { allowed: false };
+    const personalize = userId
+      ? await checkOperationPermission({
+          ...permissionOptions,
+          action:
+            PERSONALIZE_FIELD_POLICY_PERMISSION.split('.').at(-1) ??
+            'personalize',
+        })
+      : { allowed: false };
+    const caller = {
+      tenantId,
+      userId,
+      canManageOrg: manage.allowed,
+      canPersonalize: personalize.allowed && userId !== null,
+    };
+    if (!caller.canManageOrg || tenantId === null) return emptyAudit(caller);
+    if (options.summaryOnly === true) return emptyAudit(caller);
+
+    const fieldMaps = new Map<
+      string,
+      Promise<Awaited<ReturnType<typeof getObjectFieldMap>> | null>
+    >();
+    const fieldMapFor = (objectRef: string) => {
+      let loaded = fieldMaps.get(objectRef);
+      if (!loaded) {
+        loaded = getObjectFieldMap(objectRef).catch(() => null);
+        fieldMaps.set(objectRef, loaded);
+      }
+      return loaded;
+    };
+    const classify = async (
+      row: Pick<FieldPolicy, 'objectRef' | 'fieldName'>,
+    ): Promise<'ok' | 'gated' | FieldPolicyDriftReason> => {
+      const fields = await fieldMapFor(row.objectRef);
+      if (!fields) return 'unknown-object';
+      const definition = fields.get(row.fieldName);
+      if (!definition) return 'unknown-field';
+      if (
+        isSensitiveField(definition) ||
+        getFieldReadPermission(definition) !== undefined ||
+        isTransientField(definition)
+      ) {
+        return 'gated';
+      }
+      return isPolicyAddressableField(definition) ? 'ok' : 'excluded-field';
+    };
+
+    const [appRows, orgRows, ownUserRows] = objectRefs.length
+      ? await Promise.all([
+          this.list({
+            where: { scopeType: 'app', 'objectRef in': objectRefs },
+          }),
+          this.list({
+            where: {
+              scopeType: 'tenant',
+              tenantId,
+              'objectRef in': objectRefs,
+            },
+          }),
+          userId
+            ? this.list({
+                where: {
+                  scopeType: 'user',
+                  userId,
+                  'objectRef in': objectRefs,
+                },
+              })
+            : Promise.resolve([] as FieldPolicy[]),
+        ])
+      : ([[], [], []] as [FieldPolicy[], FieldPolicy[], FieldPolicy[]]);
+    const audit: FieldPolicyAuditSnapshot = {
+      ...emptyAudit(caller),
+      policies: options.countsOnly
+        ? {}
+        : await this.resolveAuditPolicies(objectRefs, tenantId, fieldMapFor),
+    };
+    const append = async (
+      row: FieldPolicy,
+      target: FieldPolicyAuditRow[],
+      driftPrunable: boolean,
+    ) => {
+      const state = await classify(row);
+      if (state === 'ok') target.push(toAuditRow(row));
+      else if (state !== 'gated') {
+        audit.driftRows.push({
+          ...toDriftIdentity(row),
+          reason: state,
+          prunable: driftPrunable,
+        });
+      }
+    };
+    for (const row of orgRows) await append(row, audit.orgRows, true);
+    for (const row of appRows)
+      await append(row, audit.appRows, isSuperAdminBypass());
+    for (const row of ownUserRows) {
+      const state = await classify(row);
+      if (state !== 'ok' && state !== 'gated') {
+        audit.driftRows.push({
+          ...toDriftIdentity(row),
+          reason: state,
+          prunable: caller.canPersonalize,
+        });
+      }
+    }
+
+    if (options.includeDrift === true) {
+      // Drift is a separate bounded list: catalog browsing must not scan every
+      // policy row merely to populate a secondary maintenance affordance.
+      const [driftAppRows, driftOrgRows, driftUserRows] = await Promise.all([
+        this.list({ where: { scopeType: 'app' }, limit: 100 }),
+        this.list({ where: { scopeType: 'tenant', tenantId }, limit: 100 }),
+        userId
+          ? this.list({ where: { scopeType: 'user', userId }, limit: 100 })
+          : Promise.resolve([] as FieldPolicy[]),
+      ]);
+      const knownIds = new Set(
+        [...appRows, ...orgRows, ...ownUserRows].map((row) => String(row.id)),
+      );
+      for (const [rows, prunable] of [
+        [driftAppRows, isSuperAdminBypass()],
+        [driftOrgRows, true],
+        [driftUserRows, caller.canPersonalize],
+      ] as const) {
+        for (const row of rows) {
+          if (knownIds.has(String(row.id))) continue;
+          const state = await classify(row);
+          if (state !== 'ok' && state !== 'gated') {
+            audit.driftRows.push({
+              ...toDriftIdentity(row),
+              reason: state,
+              prunable,
+            });
+          }
+        }
+      }
+    }
+
+    // User policy rows intentionally have no tenantId because preferences
+    // follow the user. Resolve tenant membership first so this roll-up cannot
+    // leak whether users belonging only to another tenant customized a field.
+    const memberships = await MembershipCollection.create({ db: this.db });
+    const memberIds = (await memberships.findActiveByTenant(tenantId))
+      .map((membership) => membership.userId)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+    const projected =
+      countObjectRefs.length && memberIds.length
+        ? await this.list({
+            where: {
+              scopeType: 'user',
+              'objectRef in': countObjectRefs,
+              'userId in': memberIds,
+            },
+            select: ['objectRef', 'fieldName'],
+          })
+        : [];
+    for (const row of projected) {
+      if ((await classify(row)) !== 'ok') continue;
+      const byField = audit.userOverrideCounts[row.objectRef] ?? {};
+      audit.userOverrideCounts[row.objectRef] = byField;
+      byField[row.fieldName] = (byField[row.fieldName] ?? 0) + 1;
+    }
+
+    const { resolveSurvivingTenantChainIds } = await import(
+      '../field-policy-resolver.js'
+    );
+    const ancestorIds = (
+      await resolveSurvivingTenantChainIds(tenantId, {
+        db: this.db,
+      })
+    ).filter((id) => id !== tenantId);
+    if (ancestorIds.length && objectRefs.length) {
+      const ancestors = await this.list({
+        where: {
+          scopeType: 'tenant',
+          'tenantId in': ancestorIds,
+          'objectRef in': objectRefs,
+        },
+      });
+      for (const row of ancestors) {
+        if ((await classify(row)) !== 'ok') continue;
+        const names = audit.inheritedOrgKeys[row.objectRef] ?? [];
+        audit.inheritedOrgKeys[row.objectRef] = names;
+        if (!names.includes(row.fieldName)) names.push(row.fieldName);
+      }
+    }
+    audit.orgRows.sort(sortAuditRows);
+    audit.appRows.sort(sortAuditRows);
+    audit.driftRows.sort(sortDriftRows);
+    for (const names of Object.values(audit.inheritedOrgKeys)) names.sort();
+    return audit;
+  }
+
+  private async resolveAuditPolicies(
+    objectRefs: string[],
+    tenantId: string,
+    fieldMapFor: (
+      objectRef: string,
+    ) => Promise<Awaited<ReturnType<typeof getObjectFieldMap>> | null>,
+  ): Promise<Record<string, ExplainedObjectFieldPolicy>> {
+    const { resolveFieldPolicyExplained } = await import(
+      '../field-policy-resolver.js'
+    );
+    const policies: Record<string, ExplainedObjectFieldPolicy> = {};
+    for (const objectRef of objectRefs) {
+      if (!(await fieldMapFor(objectRef))) continue;
+      const resolved = await resolveFieldPolicyExplained(objectRef, {
+        tenantId,
+        db: this.db,
+      });
+      policies[objectRef] = await this.gateExplainedForEditorResponse(
+        resolved,
+        {
+          manage: true,
+          personalize: false,
+        },
+        true,
+      );
+    }
+    return policies;
+  }
 
   /** All app-scope rows for an object, keyed by field name. */
   async getAppRows(objectRef: string): Promise<Map<string, FieldPolicy>> {
@@ -359,6 +650,7 @@ export class FieldPolicyCollection extends SmrtCollection<FieldPolicy> {
   private async gateExplainedForEditorResponse(
     resolved: ExplainedObjectFieldPolicy,
     capabilities: { manage: boolean; personalize: boolean },
+    includeCode = false,
   ): Promise<ExplainedObjectFieldPolicy> {
     const fieldMap = await getObjectFieldMap(resolved.objectRef);
     const fields: ExplainedObjectFieldPolicy['fields'] = {};
@@ -378,6 +670,7 @@ export class FieldPolicyCollection extends SmrtCollection<FieldPolicy> {
       fields[fieldName] = policy;
       layers[fieldName] = (resolved.layers[fieldName] ?? []).filter(
         (layer) =>
+          (includeCode && layer.layer === 'code') ||
           (capabilities.manage &&
             (layer.layer === 'app' || layer.layer === 'tenant')) ||
           (capabilities.personalize && layer.layer === 'user'),
@@ -409,4 +702,101 @@ export class FieldPolicyCollection extends SmrtCollection<FieldPolicy> {
       }))
       .sort((left, right) => left.fieldName.localeCompare(right.fieldName));
   }
+}
+
+function normalizeAuditRefs(
+  value: unknown,
+  label: string,
+  maximum: number,
+): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    throw new Error(`policyAudit ${label} must be a string array`);
+  }
+  if (value.some((ref) => typeof ref !== 'string' || ref.trim() === '')) {
+    throw new Error(`policyAudit ${label} must contain non-empty strings`);
+  }
+  const refs = [...new Set(value)];
+  if (refs.length > maximum) {
+    throw new Error(
+      `policyAudit ${label} accepts at most ${maximum} objectRefs`,
+    );
+  }
+  return refs;
+}
+
+function emptyAudit(
+  caller: FieldPolicyAuditSnapshot['caller'],
+): FieldPolicyAuditSnapshot {
+  return {
+    orgRows: [],
+    appRows: [],
+    inheritedOrgKeys: {},
+    userOverrideCounts: {},
+    driftRows: [],
+    policies: {},
+    caller,
+  };
+}
+
+function dateText(value: unknown): string | null {
+  if (value instanceof Date) return value.toISOString();
+  return typeof value === 'string' ? value : null;
+}
+
+function toAuditRow(row: FieldPolicy): FieldPolicyAuditRow {
+  return {
+    objectRef: row.objectRef,
+    defaultValue: row.defaultValue,
+    displayOrder: row.displayOrder,
+    fieldName: row.fieldName,
+    help: row.help,
+    id: String(row.id),
+    label: row.label,
+    locked: row.locked,
+    scopeType: row.scopeType,
+    tenantId: row.tenantId,
+    updatedBy: row.updatedBy,
+    userId: row.userId,
+    visibility: row.visibility,
+    createdAt: dateText((row as { createdAt?: unknown }).createdAt),
+    updatedAt: dateText((row as { updatedAt?: unknown }).updatedAt),
+  };
+}
+
+function toDriftIdentity(
+  row: FieldPolicy,
+): Omit<FieldPolicyDriftRow, 'reason' | 'prunable'> {
+  return {
+    id: String(row.id),
+    objectRef: row.objectRef,
+    fieldName: row.fieldName,
+    scopeType: row.scopeType,
+    tenantId: row.tenantId,
+    userId: row.userId,
+    updatedBy: row.updatedBy,
+    createdAt: dateText((row as { createdAt?: unknown }).createdAt),
+    updatedAt: dateText((row as { updatedAt?: unknown }).updatedAt),
+  };
+}
+
+function sortAuditRows(
+  left: FieldPolicyAuditRow,
+  right: FieldPolicyAuditRow,
+): number {
+  return (
+    left.objectRef.localeCompare(right.objectRef) ||
+    left.fieldName.localeCompare(right.fieldName)
+  );
+}
+
+function sortDriftRows(
+  left: FieldPolicyDriftRow,
+  right: FieldPolicyDriftRow,
+): number {
+  return (
+    left.objectRef.localeCompare(right.objectRef) ||
+    left.fieldName.localeCompare(right.fieldName) ||
+    left.scopeType.localeCompare(right.scopeType)
+  );
 }

--- a/packages/fields/src/collections/FieldPolicyCollection.ts
+++ b/packages/fields/src/collections/FieldPolicyCollection.ts
@@ -288,9 +288,13 @@ export class FieldPolicyCollection extends SmrtCollection<FieldPolicy> {
     // follow the user. Resolve tenant membership first so this roll-up cannot
     // leak whether users belonging only to another tenant customized a field.
     const memberships = await MembershipCollection.create({ db: this.db });
-    const memberIds = (await memberships.findActiveByTenant(tenantId))
-      .map((membership) => membership.userId)
-      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+    const memberIds = [
+      ...new Set(
+        (await memberships.findActiveByTenant(tenantId))
+          .map((membership) => membership.userId?.trim())
+          .filter((id): id is string => Boolean(id)),
+      ),
+    ];
     const projected =
       countObjectRefs.length && memberIds.length
         ? await this.list({

--- a/packages/fields/src/field-definitions.ts
+++ b/packages/fields/src/field-definitions.ts
@@ -93,6 +93,20 @@ export function isTransientField(field: RegisteredFieldInfo): boolean {
 }
 
 /**
+ * True when a registered field can receive a policy row.  Keep this shared by
+ * the resolver and the catalog audit: otherwise a row that never resolves can
+ * accidentally be presented as an editable setting.
+ */
+export function isPolicyAddressableField(field: RegisteredFieldInfo): boolean {
+  return (
+    field._meta?.__smrtSystemField !== true &&
+    field.type !== 'oneToMany' &&
+    field.type !== 'manyToMany' &&
+    field.type !== 'meta'
+  );
+}
+
+/**
  * A field is required when flagged required and not explicitly nullable.
  *
  * `nullable` is read from BOTH the top level and `_meta` for the same reason

--- a/packages/fields/src/field-policy-batch.test.ts
+++ b/packages/fields/src/field-policy-batch.test.ts
@@ -14,16 +14,17 @@ import {
 } from '@happyvertical/smrt-tenancy';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-// Side-effect import: registers smrt-users' classes (Tenant) so
+// Registers smrt-users' classes (Tenant/Membership) so
 // getTestDatabase can create the tenants table the default hierarchy loader
 // reads under an ambient tenant context.
-import '../../users/src/index.js';
+import { MembershipCollection } from '../../users/src/index.js';
 import { clearFieldPolicyCache } from './cache.js';
 import { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
 import {
   MANAGE_FIELD_POLICY_PERMISSION,
   PERSONALIZE_FIELD_POLICY_PERMISSION,
 } from './permissions.js';
+import { buildFieldPolicySettingsCatalog } from './settings-catalog.js';
 
 @smrt({
   packageName: '@test/smrt-fields-batch',
@@ -69,7 +70,9 @@ describe('FieldPolicyCollection.resolveBatch', () => {
     clearFieldPolicyCache();
     // 'Tenant' backs the default hierarchy loader (smrt-users is installed
     // in this workspace, so resolveBatch walks the real tenant table).
-    db = await getTestDatabase({ classes: ['FieldPolicy', 'Tenant'] });
+    db = await getTestDatabase({
+      classes: ['FieldPolicy', 'Tenant', 'Membership'],
+    });
     policies = await FieldPolicyCollection.create({ db });
     objectRef = fixtureRef();
   });
@@ -382,6 +385,121 @@ describe('FieldPolicyCollection.resolveBatch', () => {
           'tenant',
           'user',
         ]);
+      },
+    );
+  });
+
+  it('returns a manage-gated catalog audit with rows, explained layers, and count-only user overrides', async () => {
+    const tenantId = randomUUID();
+    const managerId = randomUUID();
+    const otherUserId = randomUUID();
+    const foreignTenantId = randomUUID();
+    const foreignUserId = randomUUID();
+    const memberships = await MembershipCollection.create({ db });
+    await memberships.create({
+      userId: otherUserId,
+      tenantId,
+      roleId: randomUUID(),
+    });
+    await memberships.create({
+      userId: foreignUserId,
+      tenantId: foreignTenantId,
+      roleId: randomUUID(),
+    });
+    await withTenant(
+      {
+        tenantId,
+        userId: managerId,
+        permissions: new Set<string>(),
+        superAdminBypass: true,
+      },
+      async () => {
+        await policies.create({
+          objectRef,
+          fieldName: 'blurb',
+          scopeType: 'app',
+          label: 'Application label',
+        });
+        await policies.create({
+          objectRef,
+          fieldName: 'blurb',
+          scopeType: 'tenant',
+          tenantId,
+          help: 'Tenant help',
+        });
+        await policies.create({
+          objectRef,
+          fieldName: 'blurb',
+          scopeType: 'user',
+          userId: otherUserId,
+          label: 'Private label',
+        });
+        await policies.create({
+          objectRef,
+          fieldName: 'blurb',
+          scopeType: 'user',
+          userId: foreignUserId,
+          label: 'Foreign private label',
+        });
+      },
+    );
+
+    await withTenant(
+      {
+        tenantId,
+        userId: managerId,
+        permissions: new Set([MANAGE_FIELD_POLICY_PERMISSION]),
+      },
+      async () => {
+        const audit = await policies.policyAudit({ objectRefs: [objectRef] });
+        expect(audit.caller.canManageOrg).toBe(true);
+        expect(audit.appRows).toMatchObject([
+          { objectRef, fieldName: 'blurb', label: 'Application label' },
+        ]);
+        expect(audit.orgRows).toMatchObject([
+          { objectRef, fieldName: 'blurb', help: 'Tenant help' },
+        ]);
+        expect(audit.userOverrideCounts[objectRef]?.blurb).toBe(1);
+        expect(audit.policies[objectRef]?.fields.blurb.help).toBe(
+          'Tenant help',
+        );
+        expect(
+          audit.policies[objectRef]?.layers.blurb.map((layer) => layer.layer),
+        ).toEqual(['code', 'app', 'tenant']);
+
+        const catalog = await buildFieldPolicySettingsCatalog({
+          collection: policies,
+          objectRefs: [objectRef],
+          customizedOnly: true,
+        });
+        expect(catalog.page.items).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ objectRef, fieldName: 'blurb' }),
+          ]),
+        );
+
+        const countsOnly = await policies.policyAudit({
+          objectRefs: [objectRef],
+          countsOnly: true,
+        });
+        expect(countsOnly.policies).toEqual({});
+        expect(countsOnly.appRows).toHaveLength(1);
+        expect(countsOnly.orgRows).toHaveLength(1);
+        expect(countsOnly.userOverrideCounts[objectRef]?.blurb).toBe(1);
+      },
+    );
+
+    await withTenant(
+      { tenantId, userId: managerId, permissions: new Set<string>() },
+      async () => {
+        const denied = await policies.policyAudit({ objectRefs: [objectRef] });
+        expect(denied).toMatchObject({
+          orgRows: [],
+          appRows: [],
+          driftRows: [],
+          policies: {},
+          caller: { canManageOrg: false },
+        });
       },
     );
   });

--- a/packages/fields/src/field-policy-resolver.ts
+++ b/packages/fields/src/field-policy-resolver.ts
@@ -13,6 +13,7 @@ import {
   type FieldDefinitionMap,
   getCodeSeedGroup,
   getObjectFieldMap,
+  isPolicyAddressableField,
   isRequiredField,
   isUsableRequiredDefault,
 } from './field-definitions.js';
@@ -56,6 +57,20 @@ export async function resolveFieldPolicy(
 ): Promise<ResolvedObjectFieldPolicy> {
   const explained = await resolveFieldPolicyExplained(objectRef, options);
   return { objectRef: explained.objectRef, fields: explained.fields };
+}
+
+/**
+ * The tenant ids whose rows participate in precedence for a tenant, root to
+ * leaf. Catalog code uses this instead of reimplementing inheritance-break
+ * handling when it decides whether an inherited override is customized.
+ */
+export async function resolveSurvivingTenantChainIds(
+  tenantId: string,
+  options: ResolveFieldPolicyOptions = {},
+): Promise<string[]> {
+  assertResolutionAllowedInContext(tenantId, null);
+  const chain = await resolveTenantChain(tenantId, options);
+  return selectSurvivingChainSuffix(chain).map((node) => node.id);
 }
 
 /**
@@ -280,17 +295,9 @@ function selectPolicyAddressableFields(
 ): FieldDefinitionMap {
   const selected: FieldDefinitionMap = new Map();
   for (const [name, field] of fieldMap) {
-    if (field._meta?.__smrtSystemField === true) {
-      continue;
+    if (isPolicyAddressableField(field)) {
+      selected.set(name, field);
     }
-    if (
-      field.type === 'oneToMany' ||
-      field.type === 'manyToMany' ||
-      field.type === 'meta'
-    ) {
-      continue;
-    }
-    selected.set(name, field);
   }
   return selected;
 }

--- a/packages/fields/src/generated-surfaces.test.ts
+++ b/packages/fields/src/generated-surfaces.test.ts
@@ -18,9 +18,8 @@ import {
 } from '@happyvertical/smrt-tenancy';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { CLIGenerator } from '../../cli/src/cli-generator.js';
-// Registers smrt-users' Tenant so getTestDatabase can create the tenants
-// table the user-tier write-time lock check reads through the default
-// hierarchy loader.
+// Registers smrt-users' Tenant/Membership so test databases cover hierarchy
+// reads and the control-panel's tenant-scoped user-override counts.
 import {
   TenantCollection,
   withPrincipalPermissionContext,
@@ -76,7 +75,9 @@ describe('smrt-fields generated surfaces', () => {
   beforeEach(async () => {
     setupTestTenancy();
     clearFieldPolicyCache();
-    db = await getTestDatabase({ classes: ['FieldPolicy', 'Tenant'] });
+    db = await getTestDatabase({
+      classes: ['FieldPolicy', 'Tenant', 'Membership'],
+    });
     policies = await FieldPolicyCollection.create({ db });
   });
 
@@ -736,6 +737,33 @@ describe('smrt-fields generated surfaces', () => {
     );
     expect(pluralRoute.status).toBe(200);
     expect((await pluralRoute.json()).action).toBe('getEditorState');
+
+    // The control-panel roll-up is likewise a collection action: it must
+    // dispatch through the generated runtime route rather than falling
+    // through to CRUD (which would reopen the sparse policy table).
+    const auditRoute = await withTenant(
+      {
+        tenantId,
+        userId,
+        permissions: new Set([MANAGE_FIELD_POLICY_PERMISSION]),
+      },
+      () =>
+        handler(
+          new Request('http://localhost/api/v1/fieldpolicy/policy-audit', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ objectRefs: [objectRef] }),
+          }),
+        ),
+    );
+    expect(auditRoute.status).toBe(200);
+    expect(await auditRoute.json()).toMatchObject({
+      action: 'policyAudit',
+      result: {
+        caller: { canManageOrg: true },
+        policies: { [objectRef]: { fields: { headline: expect.anything() } } },
+      },
+    });
   });
 
   it('keeps the prefixed system table name as the registry authority', async () => {

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -30,6 +30,7 @@ export {
   getCodeSeedGroup,
   getFieldReadPermission,
   getObjectFieldMap,
+  isPolicyAddressableField,
   isRequiredField,
   isSensitiveField,
   isTransientField,
@@ -41,6 +42,7 @@ export {
 export {
   resolveFieldPolicy,
   resolveFieldPolicyExplained,
+  resolveSurvivingTenantChainIds,
 } from './field-policy-resolver.js';
 export { FieldPolicy } from './models/FieldPolicy.js';
 export {
@@ -50,12 +52,29 @@ export {
   PERSONALIZE_FIELD_POLICY_PERMISSION,
 } from './permissions.js';
 export {
+  type BuildFieldPolicySettingsCatalogOptions,
+  buildFieldPolicySettingsCatalog,
+  type FieldPolicyCatalogField,
+  type FieldPolicyCatalogObjectSummary,
+  type FieldPolicyDetailItem,
+  type FieldPolicySettingsCatalogData,
+  type FieldPolicySettingsCatalogPage,
+  type FieldPolicySettingsCatalogQuery,
+  type FieldPolicySummaryItem,
+  fieldPolicyCatalogItemId,
+  parseFieldPolicyCatalogQuery,
+} from './settings-catalog.js';
+export {
   APP_FIELD_POLICY_SCOPE_KEY,
   type ExplainedObjectFieldPolicy,
   FIELD_POLICY_SCOPE_TYPES,
   FIELD_POLICY_VISIBILITIES,
+  type FieldPolicyAuditRow,
+  type FieldPolicyAuditSnapshot,
   type FieldPolicyBatchResult,
   type FieldPolicyDelta,
+  type FieldPolicyDriftReason,
+  type FieldPolicyDriftRow,
   type FieldPolicyEditorCapabilities,
   type FieldPolicyEditorRow,
   type FieldPolicyEditorState,

--- a/packages/fields/src/settings-catalog.ts
+++ b/packages/fields/src/settings-catalog.ts
@@ -1,0 +1,411 @@
+/**
+ * Server-side data builder for the field-policy AdminShell destination.
+ *
+ * This deliberately mirrors the `@happyvertical/smrt-svelte/settings`
+ * contract structurally. Fields does not depend on smrt-svelte, and only the
+ * selected object carries its browser-safe field definitions.
+ */
+
+import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+import {
+  FieldPolicyCollection,
+  MAX_FIELD_POLICY_AUDIT_OBJECT_REFS,
+} from './collections/FieldPolicyCollection.js';
+import {
+  getFieldReadPermission,
+  getObjectFieldMap,
+  isPolicyAddressableField,
+  isSensitiveField,
+  isTransientField,
+} from './field-definitions.js';
+import type { FieldPolicyAuditSnapshot } from './types.js';
+
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = 100;
+const FORM_TYPES = new Set([
+  'text',
+  'integer',
+  'decimal',
+  'boolean',
+  'datetime',
+  'json',
+  'foreignKey',
+  'crossPackageRef',
+]);
+const SYSTEM_NAMES = new Set([
+  'id',
+  'slug',
+  'context',
+  'createdAt',
+  'created_at',
+  'updatedAt',
+  'updated_at',
+  'deletedAt',
+  'deleted_at',
+  'tenantId',
+  'tenant_id',
+]);
+
+export interface FieldPolicyCatalogField {
+  type:
+    | 'text'
+    | 'integer'
+    | 'decimal'
+    | 'boolean'
+    | 'datetime'
+    | 'json'
+    | 'foreignKey'
+    | 'crossPackageRef';
+  required?: boolean;
+  default?: unknown;
+  description?: string;
+  ui?: { basic?: boolean; group?: string; order?: number; locked?: boolean };
+}
+
+export interface FieldPolicySummaryItem {
+  id: string;
+  label: string;
+  description?: string;
+  eyebrow?: string;
+  status?: string;
+  objectRef: string;
+  fieldName: string;
+  className: string;
+  packageName: string;
+}
+
+export interface FieldPolicyDetailItem extends FieldPolicySummaryItem {
+  fields: Record<string, FieldPolicyCatalogField>;
+}
+
+/** Structural SettingsCatalogPage mirror; `SettingsCatalog` accepts it directly. */
+export interface FieldPolicySettingsCatalogPage {
+  items: FieldPolicySummaryItem[];
+  selected: FieldPolicyDetailItem | null;
+  query: string;
+  page: number;
+  pageSize: number;
+  total: number;
+}
+
+export interface FieldPolicyCatalogObjectSummary {
+  objectRef: string;
+  className: string;
+  packageName: string;
+  fieldCount: number;
+}
+
+export interface FieldPolicySettingsCatalogData {
+  page: FieldPolicySettingsCatalogPage;
+  audit: FieldPolicyAuditSnapshot;
+  objects: FieldPolicyCatalogObjectSummary[];
+  packages: string[];
+  filters: {
+    packageFilter: string | null;
+    objectFilter: string | null;
+    customizedOnly: boolean;
+  };
+}
+
+export interface FieldPolicySettingsCatalogQuery {
+  query?: string | null;
+  page?: number | null;
+  pageSize?: number | null;
+  selectedId?: string | null;
+  packageFilter?: string | null;
+  objectFilter?: string | null;
+  customizedOnly?: boolean;
+}
+
+export interface BuildFieldPolicySettingsCatalogOptions
+  extends FieldPolicySettingsCatalogQuery {
+  db?: SmrtClassOptions['db'];
+  collection?: FieldPolicyCollection;
+  objectRefs?: string[];
+}
+
+interface CatalogObject {
+  objectRef: string;
+  className: string;
+  packageName: string;
+  fields: Record<string, FieldPolicyCatalogField>;
+}
+
+export function fieldPolicyCatalogItemId(
+  objectRef: string,
+  fieldName: string,
+): string {
+  return `${objectRef}::${fieldName}`;
+}
+
+export function parseFieldPolicyCatalogQuery(
+  params: URLSearchParams,
+): FieldPolicySettingsCatalogQuery {
+  return {
+    query: params.get('q'),
+    page: integerParam(params.get('page')),
+    pageSize: integerParam(params.get('pageSize')),
+    selectedId: params.get('selected'),
+    packageFilter: params.get('package'),
+    objectFilter: params.get('object'),
+    customizedOnly: params.get('customized') === '1',
+  };
+}
+
+export async function buildFieldPolicySettingsCatalog(
+  options: BuildFieldPolicySettingsCatalogOptions,
+): Promise<FieldPolicySettingsCatalogData> {
+  const collection =
+    options.collection ??
+    (options.db
+      ? await FieldPolicyCollection.create({ db: options.db })
+      : null);
+  if (!collection) throw new Error('A db or FieldPolicyCollection is required');
+
+  const filters = {
+    packageFilter: stringFilter(options.packageFilter),
+    objectFilter: stringFilter(options.objectFilter),
+    customizedOnly: options.customizedOnly === true,
+  };
+  const query = options.query?.trim() ?? '';
+  const pageSize = clamp(options.pageSize, 1, MAX_PAGE_SIZE, DEFAULT_PAGE_SIZE);
+  // Authorization is established before registry enumeration, but this must
+  // stay a capability-only call: no policy rows are read until the URL-driven
+  // page (or the explicit customized filter) identifies its object refs.
+  const baseAudit = await collection.policyAudit({ summaryOnly: true });
+  if (!baseAudit.caller.canManageOrg) {
+    return {
+      page: emptyPage(query, pageSize),
+      audit: baseAudit,
+      objects: [],
+      packages: [],
+      filters,
+    };
+  }
+
+  const objects = await listCatalogObjects(options.objectRefs);
+  const candidates = objects.filter(
+    (object) =>
+      (!filters.packageFilter ||
+        object.packageName === filters.packageFilter) &&
+      (!filters.objectFilter || object.objectRef === filters.objectFilter),
+  );
+  const allCandidateRefs = candidates.map((object) => object.objectRef);
+  const countAudit =
+    filters.customizedOnly && allCandidateRefs.length
+      ? await loadAuditCounts(collection, allCandidateRefs, baseAudit)
+      : baseAudit;
+  const customized = customizedKeys(countAudit);
+  const entries = candidates.flatMap((object) =>
+    Object.entries(object.fields)
+      .filter(
+        ([fieldName]) =>
+          !filters.customizedOnly ||
+          customized.has(fieldPolicyCatalogItemId(object.objectRef, fieldName)),
+      )
+      .map(([fieldName, field]) => ({
+        item: {
+          id: fieldPolicyCatalogItemId(object.objectRef, fieldName),
+          label: fieldName,
+          ...(field.description ? { description: field.description } : {}),
+          eyebrow: `${object.className} · ${object.packageName}`,
+          objectRef: object.objectRef,
+          fieldName,
+          className: object.className,
+          packageName: object.packageName,
+        },
+        search:
+          `${fieldName} ${spaced(fieldName)} ${object.className} ${object.packageName} ${object.objectRef} ${field.description ?? ''}`.toLowerCase(),
+      })),
+  );
+  const filtered = query
+    ? entries.filter((entry) => entry.search.includes(query.toLowerCase()))
+    : entries;
+  const total = filtered.length;
+  const page = clamp(
+    options.page,
+    1,
+    Math.max(1, Math.ceil(total / pageSize)),
+    1,
+  );
+  const items = filtered
+    .slice((page - 1) * pageSize, page * pageSize)
+    .map((entry) => entry.item);
+  const selectedSummary =
+    (options.selectedId
+      ? filtered.find((entry) => entry.item.id === options.selectedId)?.item
+      : undefined) ?? items[0];
+  const selected = selectedSummary
+    ? {
+        ...selectedSummary,
+        fields:
+          objects.find(
+            (object) => object.objectRef === selectedSummary.objectRef,
+          )?.fields ?? {},
+      }
+    : null;
+  const auditRefs = selected
+    ? uniqueRefs([selected.objectRef, ...items.map((item) => item.objectRef)])
+    : [];
+  const audit = auditRefs.length
+    ? await collection.policyAudit({
+        objectRefs: auditRefs.slice(0, MAX_FIELD_POLICY_AUDIT_OBJECT_REFS),
+        countObjectRefs: auditRefs,
+        includeDrift: true,
+      })
+    : await collection.policyAudit({ includeDrift: true });
+  return {
+    page: { items, selected, query, page, pageSize, total },
+    audit,
+    objects: objects.map(({ objectRef, className, packageName, fields }) => ({
+      objectRef,
+      className,
+      packageName,
+      fieldCount: Object.keys(fields).length,
+    })),
+    packages: [...new Set(objects.map((object) => object.packageName))].sort(),
+    filters,
+  };
+}
+
+async function listCatalogObjects(
+  objectRefs?: string[],
+): Promise<CatalogObject[]> {
+  const refs: string[] = objectRefs
+    ? [...objectRefs]
+    : Array.from(ObjectRegistry.getPublicClasses().values()).reduce<string[]>(
+        (result, registered) => {
+          if (registered.qualifiedName) result.push(registered.qualifiedName);
+          return result;
+        },
+        [],
+      );
+  const unique = [...new Set(refs)].sort();
+  const objects: CatalogObject[] = [];
+  for (const objectRef of unique) {
+    const registered = ObjectRegistry.getClassByQualifiedName(objectRef);
+    if (
+      !registered ||
+      ObjectRegistry.getTableName(objectRef)?.startsWith('_smrt_')
+    )
+      continue;
+    const fields = await getObjectFieldMap(objectRef);
+    const selected: Record<string, FieldPolicyCatalogField> = {};
+    for (const [name, definition] of fields) {
+      if (
+        SYSTEM_NAMES.has(name) ||
+        !isPolicyAddressableField(definition) ||
+        isSensitiveField(definition) ||
+        isTransientField(definition) ||
+        getFieldReadPermission(definition) !== undefined ||
+        !FORM_TYPES.has(String(definition.type))
+      )
+        continue;
+      selected[name] = {
+        type: definition.type as FieldPolicyCatalogField['type'],
+        ...(definition.required === true ? { required: true } : {}),
+        ...(definition.default !== undefined
+          ? { default: definition.default }
+          : {}),
+        ...(typeof definition.description === 'string'
+          ? { description: definition.description }
+          : {}),
+      };
+    }
+    if (!Object.keys(selected).length) continue;
+    const colon = objectRef.lastIndexOf(':');
+    const packageName = colon === -1 ? '' : objectRef.slice(0, colon);
+    const className = colon === -1 ? objectRef : objectRef.slice(colon + 1);
+    objects.push({ objectRef, className, packageName, fields: selected });
+  }
+  return objects;
+}
+
+async function loadAuditCounts(
+  collection: FieldPolicyCollection,
+  refs: string[],
+  baseline: FieldPolicyAuditSnapshot,
+): Promise<FieldPolicyAuditSnapshot> {
+  const userOverrideCounts: FieldPolicyAuditSnapshot['userOverrideCounts'] = {};
+  const orgRows: FieldPolicyAuditSnapshot['orgRows'] = [];
+  const appRows: FieldPolicyAuditSnapshot['appRows'] = [];
+  const inheritedOrgKeys: FieldPolicyAuditSnapshot['inheritedOrgKeys'] = {};
+  const chunkSize = MAX_FIELD_POLICY_AUDIT_OBJECT_REFS;
+  for (let offset = 0; offset < refs.length; offset += chunkSize) {
+    const audit = await collection.policyAudit({
+      objectRefs: refs.slice(offset, offset + chunkSize),
+      countObjectRefs: refs.slice(offset, offset + chunkSize),
+      countsOnly: true,
+    });
+    for (const [objectRef, byField] of Object.entries(
+      audit.userOverrideCounts,
+    )) {
+      userOverrideCounts[objectRef] = {
+        ...(userOverrideCounts[objectRef] ?? {}),
+        ...byField,
+      };
+    }
+    orgRows.push(...audit.orgRows);
+    appRows.push(...audit.appRows);
+    for (const [objectRef, fieldNames] of Object.entries(
+      audit.inheritedOrgKeys,
+    )) {
+      const names = inheritedOrgKeys[objectRef] ?? [];
+      inheritedOrgKeys[objectRef] = names;
+      for (const fieldName of fieldNames) {
+        if (!names.includes(fieldName)) names.push(fieldName);
+      }
+    }
+  }
+  return {
+    ...baseline,
+    orgRows,
+    appRows,
+    inheritedOrgKeys,
+    userOverrideCounts,
+  };
+}
+
+function customizedKeys(audit: FieldPolicyAuditSnapshot): Set<string> {
+  const keys = new Set<string>();
+  for (const row of [...audit.orgRows, ...audit.appRows])
+    keys.add(fieldPolicyCatalogItemId(row.objectRef, row.fieldName));
+  for (const [objectRef, names] of Object.entries(audit.inheritedOrgKeys))
+    for (const name of names)
+      keys.add(fieldPolicyCatalogItemId(objectRef, name));
+  for (const [objectRef, fields] of Object.entries(audit.userOverrideCounts))
+    for (const [name, count] of Object.entries(fields))
+      if (count > 0) keys.add(fieldPolicyCatalogItemId(objectRef, name));
+  return keys;
+}
+
+function emptyPage(
+  query: string,
+  pageSize: number,
+): FieldPolicySettingsCatalogPage {
+  return { items: [], selected: null, query, page: 1, pageSize, total: 0 };
+}
+function uniqueRefs(refs: string[]): string[] {
+  return [...new Set(refs)];
+}
+function stringFilter(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+function integerParam(value: string | null): number | null {
+  return value && /^\d+$/.test(value) ? Number(value) : null;
+}
+function clamp(
+  value: number | null | undefined,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  return Number.isFinite(value)
+    ? Math.min(max, Math.max(min, Math.trunc(value as number)))
+    : fallback;
+}
+function spaced(value: string): string {
+  return value.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/[_-]/g, ' ');
+}

--- a/packages/fields/src/svelte/__tests__/FieldPolicyControlPanel.test.ts
+++ b/packages/fields/src/svelte/__tests__/FieldPolicyControlPanel.test.ts
@@ -1,0 +1,273 @@
+// @vitest-environment jsdom
+import { render, screen, userEvent } from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  FieldPolicyDetailItem,
+  FieldPolicySettingsCatalogData,
+} from '../../settings-catalog.js';
+import type {
+  FieldPolicyAuditSnapshot,
+  FieldPolicyEditorState,
+} from '../../types.js';
+import FieldPolicyControlPanel from '../components/FieldPolicyControlPanel.svelte';
+import type { FieldPolicyControlPanelAdapter } from '../settings-catalog.js';
+import SettingsCatalogStub from './fixtures/SettingsCatalogStub.svelte';
+
+const objectRef = '@test/smrt-fields:ControlPanelDocument';
+
+function editorState(): FieldPolicyEditorState {
+  return {
+    capabilities: { manage: true, personalize: false },
+    personalLowerDefaultUsable: { title: false },
+    policy: {
+      objectRef,
+      fields: {
+        title: {
+          fieldName: 'title',
+          hasDefault: false,
+          defaultValue: undefined,
+          visibility: 'basic',
+          help: null,
+          label: 'Title',
+          order: 1,
+          group: null,
+          locked: false,
+          required: false,
+        },
+      },
+      layers: { title: [] },
+    },
+    rows: {
+      app: [],
+      tenant: [
+        {
+          id: 'org-title',
+          fieldName: 'title',
+          scopeType: 'tenant',
+          tenantId: 'tenant',
+          userId: null,
+          defaultValue: null,
+          displayOrder: null,
+          help: null,
+          label: null,
+          locked: null,
+          visibility: null,
+        },
+      ],
+      user: [],
+    },
+  };
+}
+
+function audit(orgIds = ['org-title'], drift = true): FieldPolicyAuditSnapshot {
+  return {
+    caller: {
+      tenantId: 'tenant',
+      userId: 'user',
+      canManageOrg: true,
+      canPersonalize: false,
+    },
+    appRows: [],
+    orgRows: orgIds.map((id) => ({
+      id,
+      objectRef,
+      fieldName: 'title',
+      scopeType: 'tenant' as const,
+      tenantId: 'tenant',
+      userId: null,
+      updatedBy: null,
+      createdAt: null,
+      updatedAt: null,
+      defaultValue: null,
+      displayOrder: null,
+      help: null,
+      label: null,
+      locked: null,
+      visibility: null,
+    })),
+    inheritedOrgKeys: {},
+    userOverrideCounts: {},
+    driftRows: drift
+      ? [
+          {
+            id: 'stale-row',
+            objectRef,
+            fieldName: 'retired',
+            scopeType: 'tenant' as const,
+            tenantId: 'tenant',
+            userId: null,
+            updatedBy: null,
+            createdAt: null,
+            updatedAt: null,
+            reason: 'unknown-field' as const,
+            prunable: true,
+          },
+        ]
+      : [],
+    policies: {
+      [objectRef]: editorState().policy,
+    },
+  };
+}
+
+function data(pageSize = 25): FieldPolicySettingsCatalogData {
+  const selected: FieldPolicyDetailItem = {
+    id: `${objectRef}::title`,
+    label: 'title',
+    objectRef,
+    fieldName: 'title',
+    className: 'ControlPanelDocument',
+    packageName: '@test/smrt-fields',
+    fields: { title: { type: 'text' } },
+  };
+  return {
+    page: {
+      items: [selected],
+      selected,
+      query: '',
+      page: 1,
+      pageSize,
+      total: 1,
+    },
+    audit: audit(),
+    objects: [],
+    packages: [],
+    filters: {
+      packageFilter: null,
+      objectFilter: null,
+      customizedOnly: false,
+    },
+  };
+}
+
+function adapter(
+  options: { onDelete?: (id: string) => Promise<void>; calls?: string[] } = {},
+): FieldPolicyControlPanelAdapter {
+  return {
+    load: vi.fn(async () => {
+      options.calls?.push('load');
+      return editorState();
+    }),
+    loadAudit: vi.fn(async (input) => {
+      options.calls?.push('audit');
+      return audit();
+    }),
+    create: vi.fn(async () => undefined),
+    update: vi.fn(async () => {
+      options.calls?.push('update');
+    }),
+    delete: vi.fn(async ({ id }) => {
+      options.calls?.push(`delete:${id}`);
+      await options.onDelete?.(id);
+    }),
+  };
+}
+
+function renderPanel(
+  panelAdapter = adapter(),
+  options: {
+    confirmAction?: (message: string) => boolean | Promise<boolean>;
+    onchanged?: () => void;
+    panelData?: FieldPolicySettingsCatalogData;
+  } = {},
+) {
+  return render(FieldPolicyControlPanel, {
+    props: {
+      data: options.panelData ?? data(),
+      adapter: panelAdapter,
+      catalog: SettingsCatalogStub,
+      baseUrl: '/settings/fields',
+      confirmAction: options.confirmAction,
+      onchanged: options.onchanged,
+    },
+  });
+}
+
+describe('FieldPolicyControlPanel', () => {
+  it('uses SSR data for the first render and preserves pageSize in catalog navigation', () => {
+    renderPanel();
+
+    expect(
+      screen.getByRole('heading', { name: 'Field settings' }),
+    ).toBeVisible();
+    expect(screen.getByText('Title')).toBeVisible();
+    expect(
+      screen.getByRole('link', { name: 'catalog navigation' }),
+    ).toHaveAttribute('href', '/settings/fields?pageSize=25');
+  });
+
+  it('refreshes audit with drift and reloads editor state before notifying after an editor mutation', async () => {
+    const calls: string[] = [];
+    const panelAdapter = adapter({ calls });
+    const onchanged = () => calls.push('changed');
+    renderPanel(panelAdapter, { onchanged });
+    await vi.waitFor(() => expect(panelAdapter.load).toHaveBeenCalledTimes(1));
+    calls.length = 0;
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Edit settings' }),
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Save', exact: true }),
+    );
+
+    await vi.waitFor(() =>
+      expect(calls).toEqual(['update', 'audit', 'load', 'changed']),
+    );
+    expect(panelAdapter.loadAudit).toHaveBeenLastCalledWith({
+      objectRefs: [objectRef],
+      countObjectRefs: [objectRef],
+      includeDrift: true,
+    });
+  });
+
+  it('does not reset organization rows or prune drift when confirmation is declined', async () => {
+    const panelAdapter = adapter();
+    const confirmAction = vi.fn(() => false);
+    renderPanel(panelAdapter, { confirmAction });
+    await vi.waitFor(() => expect(panelAdapter.load).toHaveBeenCalledTimes(1));
+    vi.mocked(panelAdapter.delete).mockClear();
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'Reset all organization overrides for this object',
+      }),
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Prune' }));
+
+    expect(confirmAction).toHaveBeenCalledTimes(2);
+    expect(panelAdapter.delete).not.toHaveBeenCalled();
+  });
+
+  it('refreshes audit and editor state after a partial organization reset failure', async () => {
+    const calls: string[] = [];
+    const panelAdapter = adapter({
+      calls,
+      onDelete: async (id) => {
+        if (id === 'org-second') throw new Error('second delete failed');
+      },
+    });
+    renderPanel(panelAdapter, {
+      confirmAction: () => true,
+      panelData: { ...data(), audit: audit(['org-first', 'org-second']) },
+    });
+    await vi.waitFor(() => expect(panelAdapter.load).toHaveBeenCalledTimes(1));
+    calls.length = 0;
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'Reset all organization overrides for this object',
+      }),
+    );
+
+    await vi.waitFor(() =>
+      expect(calls).toEqual([
+        'delete:org-first',
+        'delete:org-second',
+        'audit',
+        'load',
+      ]),
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('second delete failed');
+  });
+});

--- a/packages/fields/src/svelte/__tests__/fixtures/SettingsCatalogStub.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/SettingsCatalogStub.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+import type { Snippet } from 'svelte';
+import type {
+  FieldPolicyDetailItem,
+  FieldPolicySettingsCatalogPage,
+} from '../../../settings-catalog.js';
+
+interface Props {
+  page: FieldPolicySettingsCatalogPage;
+  baseUrl: string;
+  detail: Snippet<[{ item: FieldPolicyDetailItem }]>;
+  preservedParams?: Record<string, string>;
+}
+
+let { page, baseUrl, detail, preservedParams = {} }: Props = $props();
+const href = $derived(
+  `${baseUrl}?${new URLSearchParams(preservedParams).toString()}`,
+);
+</script>
+
+<a aria-label="catalog navigation" {href}>Catalog navigation</a>
+{#if page.selected}
+  {@render detail({ item: page.selected })}
+{/if}

--- a/packages/fields/src/svelte/__tests__/settings-catalog.test.ts
+++ b/packages/fields/src/svelte/__tests__/settings-catalog.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import type { FieldPolicyAuditSnapshot } from '../../types.js';
+import {
+  auditObjectRefs,
+  fieldPolicyCatalogPreservedParams,
+  fieldPolicyControlPanelNavItem,
+  fieldPolicyRollup,
+  orgRowIdsForObject,
+  prunableDriftRows,
+} from '../settings-catalog.js';
+
+const objectRef = '@test/smrt-fields:Document';
+
+function audit(): FieldPolicyAuditSnapshot {
+  return {
+    caller: {
+      tenantId: 'tenant',
+      userId: 'user',
+      canManageOrg: true,
+      canPersonalize: true,
+    },
+    appRows: [],
+    orgRows: [
+      {
+        id: 'org-row',
+        objectRef,
+        fieldName: 'title',
+        scopeType: 'tenant',
+        tenantId: 'tenant',
+        userId: null,
+        updatedBy: 'user',
+        createdAt: null,
+        updatedAt: null,
+        defaultValue: null,
+        displayOrder: null,
+        help: null,
+        label: null,
+        locked: null,
+        visibility: 'advanced',
+      },
+    ],
+    inheritedOrgKeys: {},
+    userOverrideCounts: { [objectRef]: { title: 2 } },
+    driftRows: [
+      {
+        id: 'stale',
+        objectRef: '@gone:Old',
+        fieldName: 'gone',
+        scopeType: 'tenant',
+        tenantId: 'tenant',
+        userId: null,
+        updatedBy: null,
+        createdAt: null,
+        updatedAt: null,
+        reason: 'unknown-object',
+        prunable: true,
+      },
+    ],
+    policies: {
+      [objectRef]: {
+        objectRef,
+        fields: {
+          title: {
+            fieldName: 'title',
+            hasDefault: true,
+            defaultValue: 'tenant',
+            visibility: 'advanced',
+            help: null,
+            label: null,
+            order: null,
+            group: null,
+            locked: false,
+            required: false,
+          },
+        },
+        layers: {
+          title: [
+            {
+              layer: 'code',
+              delta: { default: { value: 'code' }, visibility: 'basic' },
+            },
+            {
+              layer: 'tenant',
+              tenantId: 'tenant',
+              delta: { default: { value: 'tenant' }, visibility: 'advanced' },
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+describe('field-policy control-panel adapters', () => {
+  it('replays explained layers for code/app/org cells and never exposes user rows', () => {
+    const rollup = fieldPolicyRollup(audit(), objectRef, 'title');
+    expect(rollup.code).toMatchObject({
+      defaultValue: 'code',
+      visibility: 'basic',
+    });
+    expect(rollup.org).toMatchObject({
+      defaultValue: 'tenant',
+      visibility: 'advanced',
+      contributed: true,
+    });
+    expect(rollup.userCount).toBe(2);
+    expect(rollup.orgRow?.id).toBe('org-row');
+  });
+
+  it('keeps a selected off-page object in the capped policy read while count refs remain complete', () => {
+    const page = {
+      items: Array.from({ length: 100 }, (_, index) => ({
+        objectRef: `@test:Thing${index}`,
+      })),
+      selected: { objectRef: '@test:Selected' },
+    };
+    const refs = auditObjectRefs(page as never);
+    expect(refs.objectRefs).toHaveLength(100);
+    expect(refs.objectRefs[0]).toBe('@test:Selected');
+    expect(refs.countObjectRefs).toHaveLength(101);
+  });
+
+  it('selects only caller-prunable drift rows and produces a permission-gated tenant nav item', () => {
+    expect(prunableDriftRows(audit()).map((row) => row.id)).toEqual(['stale']);
+    expect(orgRowIdsForObject(audit(), objectRef)).toEqual(['org-row']);
+    expect(
+      fieldPolicyControlPanelNavItem({
+        href: '/admin/fields',
+        permissions: [],
+      }),
+    ).toBeNull();
+    expect(
+      fieldPolicyControlPanelNavItem({
+        href: '/admin/fields',
+        permissions: ['fields.policy.manage'],
+      }),
+    ).toMatchObject({ href: '/admin/fields', label: 'Field settings' });
+  });
+
+  it('keeps a nondefault page size across catalog search, selection, and pagination links', () => {
+    expect(
+      fieldPolicyCatalogPreservedParams({
+        page: { pageSize: 25 },
+        filters: {
+          packageFilter: 'package',
+          objectFilter: 'object',
+          customizedOnly: true,
+        },
+      } as never),
+    ).toEqual({
+      package: 'package',
+      object: 'object',
+      customized: '1',
+      pageSize: '25',
+    });
+  });
+});

--- a/packages/fields/src/svelte/__tests__/settings-catalog.test.ts
+++ b/packages/fields/src/svelte/__tests__/settings-catalog.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { FieldPolicyAuditSnapshot } from '../../types.js';
 import {
   auditObjectRefs,
+  decorateCatalogPage,
   fieldPolicyCatalogPreservedParams,
   fieldPolicyControlPanelNavItem,
   fieldPolicyRollup,
@@ -118,6 +119,35 @@ describe('field-policy control-panel adapters', () => {
     expect(refs.objectRefs).toHaveLength(100);
     expect(refs.objectRefs[0]).toBe('@test:Selected');
     expect(refs.countObjectRefs).toHaveLength(101);
+  });
+
+  it('decorates an off-page selected detail alongside page summaries', () => {
+    const page = decorateCatalogPage(
+      {
+        items: [],
+        selected: {
+          id: 'selected',
+          objectRef,
+          fieldName: 'title',
+          className: 'Document',
+          packageName: '@test/smrt-fields',
+          label: 'Raw title',
+          description: 'Raw description',
+          fields: {},
+        },
+        query: '',
+        page: 1,
+        pageSize: 25,
+        total: 1,
+      },
+      audit(),
+    );
+
+    expect(page.selected).toMatchObject({
+      label: 'Title',
+      status: 'Organization · 2 user overrides',
+      fields: {},
+    });
   });
 
   it('selects only caller-prunable drift rows and produces a permission-gated tenant nav item', () => {

--- a/packages/fields/src/svelte/components/FieldPolicyControlPanel.svelte
+++ b/packages/fields/src/svelte/components/FieldPolicyControlPanel.svelte
@@ -1,0 +1,261 @@
+<script lang="ts">
+/**
+ * Main-content tenant-admin destination for field defaults. The host supplies
+ * the SettingsCatalog shell and generated-client adapter, keeping this package
+ * independent of both smrt-svelte and smrt-web.
+ */
+import { Button } from '@happyvertical/smrt-ui/ui';
+import type { Component, Snippet } from 'svelte';
+import type {
+  FieldPolicyDetailItem,
+  FieldPolicySettingsCatalogData,
+  FieldPolicySettingsCatalogPage,
+} from '../../settings-catalog.js';
+import type {
+  FieldPolicyAuditSnapshot,
+  FieldPolicyEditorState,
+} from '../../types.js';
+import {
+  editorStateErrorMessage,
+  isFieldPolicyEditorState,
+} from '../field-policy-editor.js';
+import {
+  auditObjectRefs,
+  decorateCatalogPage,
+  type FieldPolicyControlPanelAdapter,
+  type FieldPolicyLayerCell,
+  fieldPolicyCatalogPreservedParams,
+  fieldPolicyRollup,
+  orgRowIdsForObject,
+  prunableDriftRows,
+} from '../settings-catalog.js';
+import FieldPolicyEditor from './FieldPolicyEditor.svelte';
+
+export interface FieldPolicyCatalogComponentProps {
+  page: FieldPolicySettingsCatalogPage;
+  baseUrl: string;
+  detail: Snippet<[{ item: FieldPolicyDetailItem }]>;
+  preservedParams?: Record<string, string>;
+  searchPlaceholder?: string;
+}
+
+export interface FieldPolicyControlPanelProps {
+  data: FieldPolicySettingsCatalogData;
+  adapter: FieldPolicyControlPanelAdapter;
+  catalog: Component<FieldPolicyCatalogComponentProps>;
+  baseUrl: string;
+  permissions?: readonly string[];
+  heading?: string;
+  onchanged?: () => void;
+  confirmAction?: (message: string) => boolean | Promise<boolean>;
+}
+
+let {
+  data,
+  adapter,
+  catalog,
+  baseUrl,
+  permissions,
+  heading = 'Field settings',
+  onchanged,
+  confirmAction,
+}: FieldPolicyControlPanelProps = $props();
+
+// Before client effects run (including SSR), render the server snapshot.
+// Later mutations replace `audit`; prop changes continue to resync it below.
+let audit = $state<FieldPolicyAuditSnapshot | null>(null);
+let editorState = $state<FieldPolicyEditorState | null>(null);
+let editorOpen = $state(false);
+let loadingEditor = $state(false);
+let busy = $state(false);
+let error = $state<string | null>(null);
+let generation = 0;
+
+const Catalog = $derived(catalog);
+const visibleAudit = $derived(audit ?? data.audit);
+const canManage = $derived(
+  visibleAudit.caller.canManageOrg &&
+    (permissions === undefined || permissions.includes('fields.policy.manage')),
+);
+const selected = $derived(data.page.selected);
+const decoratedPage = $derived(decorateCatalogPage(data.page, visibleAudit));
+const preservedParams = $derived(fieldPolicyCatalogPreservedParams(data));
+
+$effect(() => {
+  data;
+  audit = data.audit;
+  editorState = null;
+  editorOpen = false;
+  error = null;
+  void loadEditor();
+});
+
+async function loadEditor(): Promise<void> {
+  if (!selected || !canManage) return;
+  const token = ++generation;
+  loadingEditor = true;
+  try {
+    const result = await adapter.load({ objectRef: selected.objectRef });
+    if (token !== generation) return;
+    if (isFieldPolicyEditorState(result, selected.objectRef)) {
+      editorState = result;
+    } else {
+      error = editorStateErrorMessage(result);
+    }
+  } catch (cause) {
+    if (token === generation)
+      error =
+        cause instanceof Error
+          ? cause.message
+          : 'Unable to load field settings.';
+  } finally {
+    if (token === generation) loadingEditor = false;
+  }
+}
+
+async function refreshAudit(): Promise<boolean> {
+  const refs = auditObjectRefs(data.page);
+  try {
+    audit = await adapter.loadAudit({ ...refs, includeDrift: true });
+    return true;
+  } catch (cause) {
+    error =
+      cause instanceof Error
+        ? cause.message
+        : 'Unable to refresh field settings.';
+    return false;
+  }
+}
+
+async function confirm(message: string): Promise<boolean> {
+  if (confirmAction) return await confirmAction(message);
+  return typeof window !== 'undefined' && window.confirm(message);
+}
+
+async function resetOrganization(): Promise<void> {
+  if (!selected || busy) return;
+  const ids = orgRowIdsForObject(visibleAudit, selected.objectRef);
+  if (!ids.length) return;
+  if (
+    !(await confirm(
+      'Reset every organization override for this object? This cannot be undone.',
+    ))
+  )
+    return;
+  busy = true;
+  error = null;
+  let changed = false;
+  try {
+    for (const id of ids) {
+      await adapter.delete({ id });
+      changed = true;
+    }
+  } catch (cause) {
+    error =
+      cause instanceof Error
+        ? cause.message
+        : 'Unable to reset organization overrides.';
+  } finally {
+    const refreshed = await refreshAudit();
+    await loadEditor();
+    if (changed && refreshed) onchanged?.();
+    busy = false;
+  }
+}
+
+async function prune(id: string): Promise<void> {
+  if (busy) return;
+  if (!(await confirm('Prune this stale policy row? This cannot be undone.')))
+    return;
+  busy = true;
+  error = null;
+  try {
+    await adapter.delete({ id });
+    if (await refreshAudit()) onchanged?.();
+  } catch (cause) {
+    error =
+      cause instanceof Error ? cause.message : 'Unable to prune stale policy.';
+  } finally {
+    busy = false;
+  }
+}
+
+async function editorMutated(): Promise<void> {
+  if (await refreshAudit()) {
+    await loadEditor();
+    onchanged?.();
+  }
+}
+
+function valueText(cell: FieldPolicyLayerCell): string {
+  if (!cell.hasDefault) return 'No default';
+  try {
+    return JSON.stringify(cell.defaultValue) ?? 'undefined';
+  } catch {
+    return String(cell.defaultValue);
+  }
+}
+</script>
+
+{#if canManage}
+  <section class="field-policy-control-panel" aria-label={heading}>
+    <header>
+      <h1>{heading}</h1>
+      <p>Manage inherited defaults, visibility, help, labels, order, and locks for every registered field.</p>
+    </header>
+    {#if error}<p class="field-policy-control-panel__error" role="alert">{error}</p>{/if}
+    <Catalog page={decoratedPage} {baseUrl} {preservedParams} searchPlaceholder="Search fields">
+      {#snippet detail({ item }: { item: FieldPolicyDetailItem })}
+        {@const rollup = fieldPolicyRollup(visibleAudit, item.objectRef, item.fieldName)}
+        <article class="field-policy-control-panel__detail">
+          <h2>{rollup.resolved?.label ?? item.label}</h2>
+          <p>{rollup.resolved?.help ?? item.description ?? 'No help text.'}</p>
+          <dl class="field-policy-control-panel__layers">
+            <div><dt>Code {rollup.code.contributed ? 'override' : 'inherited'}</dt><dd><code>{valueText(rollup.code)}</code> · {rollup.code.visibility}{rollup.code.locked ? ' · locked' : ''}</dd></div>
+            <div><dt>App {rollup.app.contributed ? 'override' : 'inherited'}</dt><dd><code>{valueText(rollup.app)}</code> · {rollup.app.visibility}{rollup.app.locked ? ' · locked' : ''}</dd></div>
+            <div><dt>Organization {rollup.org.contributed ? 'override' : 'inherited'}</dt><dd><code>{valueText(rollup.org)}</code> · {rollup.org.visibility}{rollup.org.locked ? ' · locked' : ''}</dd></div>
+            <div><dt>Users</dt><dd>{rollup.userCount} personal override{rollup.userCount === 1 ? '' : 's'}</dd></div>
+          </dl>
+          {#if rollup.orgRow}<p>Organization row last changed {rollup.orgRow.updatedAt ?? 'unknown'}{rollup.orgRow.updatedBy ? ` by ${rollup.orgRow.updatedBy}` : ''}.</p>{/if}
+          {#if rollup.appRow}<p>App row is read-only{rollup.appRow.updatedBy ? ` (last changed by ${rollup.appRow.updatedBy})` : ''}.</p>{/if}
+          <div class="field-policy-control-panel__actions">
+            <Button type="button" disabled={busy || loadingEditor || !editorState} onclick={() => editorOpen = true}>Edit settings</Button>
+            <Button type="button" variant="ghost" disabled={busy || orgRowIdsForObject(visibleAudit, item.objectRef).length === 0} onclick={resetOrganization}>Reset all organization overrides for this object</Button>
+          </div>
+        </article>
+      {/snippet}
+    </Catalog>
+    {#if editorOpen && editorState && selected}
+      <FieldPolicyEditor
+        state={editorState}
+        {adapter}
+        fields={selected.fields}
+        onclose={() => editorOpen = false}
+        onmutated={editorMutated}
+      />
+    {/if}
+    {#if prunableDriftRows(visibleAudit).length}
+      <section class="field-policy-control-panel__drift" aria-label="Manifest drift">
+        <h2>Manifest drift</h2>
+        <p>These policy rows no longer match a registered field and are ignored by the resolver.</p>
+        <ul>
+          {#each prunableDriftRows(visibleAudit) as row (row.id)}
+            <li><code>{row.objectRef}.{row.fieldName}</code> — {row.reason} <Button type="button" variant="ghost" disabled={busy} onclick={() => prune(row.id)}>Prune</Button></li>
+          {/each}
+        </ul>
+      </section>
+    {/if}
+  </section>
+{/if}
+
+<style>
+  .field-policy-control-panel { display: grid; gap: var(--smrt-spacing-4); }
+  .field-policy-control-panel header p, .field-policy-control-panel__detail > p { color: var(--smrt-color-on-surface-variant); }
+  .field-policy-control-panel__error { color: var(--smrt-color-error, #b42318); }
+  .field-policy-control-panel__layers { display: grid; gap: var(--smrt-spacing-2); }
+  .field-policy-control-panel__layers div { display: grid; grid-template-columns: 10rem minmax(0, 1fr); gap: var(--smrt-spacing-2); }
+  .field-policy-control-panel__layers dt { font-weight: 600; }
+  .field-policy-control-panel__layers dd { margin: 0; }
+  .field-policy-control-panel__actions { display: flex; flex-wrap: wrap; gap: var(--smrt-spacing-2); }
+  .field-policy-control-panel__drift ul { display: grid; gap: var(--smrt-spacing-2); padding-inline-start: var(--smrt-spacing-5); }
+</style>

--- a/packages/fields/src/svelte/index.ts
+++ b/packages/fields/src/svelte/index.ts
@@ -17,6 +17,7 @@
 
 import type { ComponentProps } from 'svelte';
 import AdvancedFields from './components/AdvancedFields.svelte';
+import FieldPolicyControlPanel from './components/FieldPolicyControlPanel.svelte';
 import FieldPolicyEditor from './components/FieldPolicyEditor.svelte';
 import FieldPolicyGearButton from './components/FieldPolicyGearButton.svelte';
 import FieldPolicyGearProvider from './components/FieldPolicyGearProvider.svelte';
@@ -30,6 +31,7 @@ import PolicyField from './components/PolicyField.svelte';
 // Components
 export {
   AdvancedFields,
+  FieldPolicyControlPanel,
   FieldPolicyEditor,
   FieldPolicyGearButton,
   FieldPolicyGearProvider,
@@ -53,6 +55,9 @@ export type ObjectFormSourceProviderProps = ComponentProps<
   typeof ObjectFormSourceProvider
 >;
 export type FieldPolicyEditorProps = ComponentProps<typeof FieldPolicyEditor>;
+export type FieldPolicyControlPanelProps = ComponentProps<
+  typeof FieldPolicyControlPanel
+>;
 export type FieldPolicyGearButtonProps = ComponentProps<
   typeof FieldPolicyGearButton
 >;
@@ -61,6 +66,13 @@ export type FieldPolicyGearProviderProps = ComponentProps<
 >;
 export type PolicyFieldProps = ComponentProps<typeof PolicyField>;
 
+export type {
+  FieldPolicyCatalogObjectSummary,
+  FieldPolicyDetailItem,
+  FieldPolicySettingsCatalogData,
+  FieldPolicySettingsCatalogPage,
+  FieldPolicySummaryItem,
+} from '../settings-catalog.js';
 // Re-export resolved-policy types consumers need (from the core package)
 export type {
   ResolvedFieldPolicy,
@@ -115,6 +127,21 @@ export {
   assertObjectFormCollectionDefinition,
   ObjectFormSourceRegistry,
 } from './object-form-source.svelte.js';
+export type {
+  FieldPolicyControlPanelAdapter,
+  FieldPolicyFieldRollup,
+  FieldPolicyLayerCell,
+} from './settings-catalog.js';
+export {
+  auditObjectRefs,
+  decorateCatalogItem,
+  decorateCatalogPage,
+  fieldPolicyControlPanelNavItem,
+  fieldPolicyRollup,
+  MAX_FIELD_POLICY_AUDIT_OBJECT_REFS,
+  orgRowIdsForObject,
+  prunableDriftRows,
+} from './settings-catalog.js';
 // Snippet escape-hatch props
 export type {
   FieldInputProps,

--- a/packages/fields/src/svelte/settings-catalog.ts
+++ b/packages/fields/src/svelte/settings-catalog.ts
@@ -1,0 +1,203 @@
+/** Browser-safe view helpers for the field-policy settings catalog. */
+
+import type {
+  FieldPolicyDetailItem,
+  FieldPolicySettingsCatalogData,
+  FieldPolicySettingsCatalogPage,
+  FieldPolicySummaryItem,
+} from '../settings-catalog.js';
+import type {
+  FieldPolicyAuditSnapshot,
+  FieldPolicyDriftRow,
+  FieldPolicyLayerContribution,
+  FieldPolicyVisibility,
+  ResolvedFieldPolicy,
+} from '../types.js';
+import type { FieldPolicyEditorAdapter } from './field-policy-editor.js';
+
+export const MAX_FIELD_POLICY_AUDIT_OBJECT_REFS = 100;
+
+export interface FieldPolicyControlPanelAdapter
+  extends FieldPolicyEditorAdapter {
+  loadAudit(input?: {
+    objectRefs?: string[];
+    countObjectRefs?: string[];
+    includeDrift?: boolean;
+  }): Promise<FieldPolicyAuditSnapshot>;
+}
+
+/** Keeps every catalog navigation path on the caller-selected page size. */
+export function fieldPolicyCatalogPreservedParams(
+  data: Pick<FieldPolicySettingsCatalogData, 'page' | 'filters'>,
+): Record<string, string> {
+  return {
+    ...(data.filters.packageFilter
+      ? { package: data.filters.packageFilter }
+      : {}),
+    ...(data.filters.objectFilter ? { object: data.filters.objectFilter } : {}),
+    ...(data.filters.customizedOnly ? { customized: '1' } : {}),
+    pageSize: String(data.page.pageSize),
+  };
+}
+
+export interface FieldPolicyLayerCell {
+  contributed: boolean;
+  defaultValue: unknown;
+  hasDefault: boolean;
+  locked: boolean;
+  visibility: FieldPolicyVisibility;
+  visibilityForced: boolean;
+}
+
+export interface FieldPolicyFieldRollup {
+  known: boolean;
+  code: FieldPolicyLayerCell;
+  app: FieldPolicyLayerCell;
+  org: FieldPolicyLayerCell;
+  userCount: number;
+  orgRow?: FieldPolicyAuditSnapshot['orgRows'][number];
+  appRow?: FieldPolicyAuditSnapshot['appRows'][number];
+  resolved?: ResolvedFieldPolicy;
+}
+
+export function auditObjectRefs(
+  page: Pick<FieldPolicySettingsCatalogPage, 'items' | 'selected'>,
+): { objectRefs: string[]; countObjectRefs: string[] } {
+  const countObjectRefs = [
+    ...new Set([
+      ...(page.selected ? [page.selected.objectRef] : []),
+      ...page.items.map((item) => item.objectRef),
+    ]),
+  ];
+  return {
+    objectRefs: countObjectRefs.slice(0, MAX_FIELD_POLICY_AUDIT_OBJECT_REFS),
+    countObjectRefs,
+  };
+}
+
+export function fieldPolicyRollup(
+  audit: FieldPolicyAuditSnapshot,
+  objectRef: string,
+  fieldName: string,
+): FieldPolicyFieldRollup {
+  const policy = audit.policies[objectRef];
+  const resolved = policy?.fields[fieldName];
+  const layers = policy?.layers[fieldName] ?? [];
+  const cell = (
+    tiers: readonly FieldPolicyLayerContribution['layer'][],
+    own: FieldPolicyLayerContribution['layer'],
+  ): FieldPolicyLayerCell => {
+    let defaultValue: unknown;
+    let hasDefault = false;
+    let visibility: FieldPolicyVisibility = 'basic';
+    let locked = false;
+    const accepted = layers.filter((layer) => tiers.includes(layer.layer));
+    for (const layer of accepted) {
+      if (layer.delta.default) {
+        hasDefault = true;
+        defaultValue = layer.delta.default.value;
+      }
+      if (layer.delta.visibility) visibility = layer.delta.visibility;
+      if (layer.delta.locked !== undefined) locked = layer.delta.locked;
+    }
+    const visibilityForced =
+      resolved?.visibilityForced === true && visibility !== 'basic';
+    return {
+      contributed: accepted.some((layer) => layer.layer === own),
+      defaultValue,
+      hasDefault,
+      visibility: visibilityForced ? 'basic' : visibility,
+      locked,
+      visibilityForced,
+    };
+  };
+  return {
+    known: resolved !== undefined,
+    code: cell(['code'], 'code'),
+    app: cell(['code', 'app'], 'app'),
+    org: cell(['code', 'app', 'tenant'], 'tenant'),
+    userCount: audit.userOverrideCounts[objectRef]?.[fieldName] ?? 0,
+    orgRow: audit.orgRows.find(
+      (row) => row.objectRef === objectRef && row.fieldName === fieldName,
+    ),
+    appRow: audit.appRows.find(
+      (row) => row.objectRef === objectRef && row.fieldName === fieldName,
+    ),
+    ...(resolved ? { resolved } : {}),
+  };
+}
+
+export function decorateCatalogPage(
+  page: FieldPolicySettingsCatalogPage,
+  audit: FieldPolicyAuditSnapshot,
+): FieldPolicySettingsCatalogPage {
+  return {
+    ...page,
+    items: page.items.map((item) => decorateCatalogItem(item, audit)),
+  };
+}
+
+export function decorateCatalogItem(
+  item: FieldPolicySummaryItem,
+  audit: FieldPolicyAuditSnapshot,
+): FieldPolicySummaryItem {
+  const rollup = fieldPolicyRollup(audit, item.objectRef, item.fieldName);
+  const status = [
+    rollup.app.contributed || rollup.appRow ? 'App' : null,
+    rollup.org.contributed || rollup.orgRow ? 'Organization' : null,
+    rollup.userCount
+      ? `${rollup.userCount} user override${rollup.userCount === 1 ? '' : 's'}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  return {
+    ...item,
+    label: rollup.resolved?.label ?? humanize(item.fieldName),
+    description: rollup.resolved?.help ?? item.description,
+    ...(status ? { status } : {}),
+  };
+}
+
+export function orgRowIdsForObject(
+  audit: FieldPolicyAuditSnapshot,
+  objectRef: string,
+): string[] {
+  return audit.orgRows
+    .filter((row) => row.objectRef === objectRef)
+    .map((row) => row.id);
+}
+
+export function prunableDriftRows(
+  audit: FieldPolicyAuditSnapshot,
+): FieldPolicyDriftRow[] {
+  return audit.driftRows.filter((row) => row.prunable);
+}
+
+/** Structural tenant-nav seam; hosts supply it to AdminShell's tenant edge. */
+export function fieldPolicyControlPanelNavItem(options: {
+  href: string;
+  permissions?: readonly string[];
+  label?: string;
+  icon?: string;
+}): { href: string; label: string; icon?: string } | null {
+  if (
+    options.permissions &&
+    !options.permissions.includes('fields.policy.manage')
+  )
+    return null;
+  return {
+    href: options.href,
+    label: options.label ?? 'Field settings',
+    ...(options.icon ? { icon: options.icon } : {}),
+  };
+}
+
+function humanize(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/^./, (character) => character.toUpperCase());
+}
+
+export type { FieldPolicyDetailItem };

--- a/packages/fields/src/svelte/settings-catalog.ts
+++ b/packages/fields/src/svelte/settings-catalog.ts
@@ -134,13 +134,14 @@ export function decorateCatalogPage(
   return {
     ...page,
     items: page.items.map((item) => decorateCatalogItem(item, audit)),
+    selected: page.selected ? decorateCatalogItem(page.selected, audit) : null,
   };
 }
 
-export function decorateCatalogItem(
-  item: FieldPolicySummaryItem,
+export function decorateCatalogItem<T extends FieldPolicySummaryItem>(
+  item: T,
   audit: FieldPolicyAuditSnapshot,
-): FieldPolicySummaryItem {
+): Omit<T, 'label' | 'description' | 'status'> & FieldPolicySummaryItem {
   const rollup = fieldPolicyRollup(audit, item.objectRef, item.fieldName);
   const status = [
     rollup.app.contributed || rollup.appRow ? 'App' : null,

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -259,6 +259,53 @@ export interface FieldPolicyEditorState {
   };
 }
 
+/** A stored organization row with the immutable audit metadata needed by #2050. */
+export interface FieldPolicyAuditRow extends FieldPolicyEditorRow {
+  objectRef: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+/** Why a persisted policy row is no longer usable by the live registry. */
+export type FieldPolicyDriftReason =
+  | 'unknown-object'
+  | 'unknown-field'
+  | 'excluded-field';
+
+/** Drift is deliberately identity-only: stale values are never serialized. */
+export interface FieldPolicyDriftRow {
+  id: string;
+  objectRef: string;
+  fieldName: string;
+  scopeType: FieldPolicyScopeType;
+  tenantId: string | null;
+  userId: string | null;
+  updatedBy: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  reason: FieldPolicyDriftReason;
+  prunable: boolean;
+}
+
+/**
+ * Tenant-admin catalog read surface. Foreign user rows are represented only
+ * by counts; their values and identifiers never leave the collection.
+ */
+export interface FieldPolicyAuditSnapshot {
+  orgRows: FieldPolicyAuditRow[];
+  appRows: FieldPolicyAuditRow[];
+  inheritedOrgKeys: Record<string, string[]>;
+  userOverrideCounts: Record<string, Record<string, number>>;
+  driftRows: FieldPolicyDriftRow[];
+  policies: Record<string, ExplainedObjectFieldPolicy>;
+  caller: {
+    tenantId: string | null;
+    userId: string | null;
+    canManageOrg: boolean;
+    canPersonalize: boolean;
+  };
+}
+
 /** Explicit 403 result used by generated custom-action transports. */
 export interface FieldPolicyEditorStateDenied {
   code: 'permission_denied';


### PR DESCRIPTION
## Summary

- add a manager-gated FieldPolicy audit surface with active-membership override counts and bounded drift reporting
- build the manifest-driven SettingsCatalog page and browser adapter without introducing a smrt-svelte dependency
- add the Svelte control panel, AdminShell nav helper, confirmation/refresh safety, exports, docs, and regression coverage

## Validation

- `pnpm --filter @happyvertical/smrt-fields test` — 12 files / 155 tests
- `pnpm --filter @happyvertical/smrt-fields check` — 0 errors / 0 warnings
- `pnpm --filter @happyvertical/smrt-fields typecheck`
- `pnpm --filter @happyvertical/smrt-fields build`
- `pnpm --filter @happyvertical/smrt-fields verify:pack`
- `pnpm exec biome check packages/fields`
- `pnpm knowledge:check --changed --strict --format markdown`
- `pnpm audit:policy`
- `pnpm check:agents-chain`
- pre-push repository gates

## Review cycle

Terra implementation received independent correctness, API-boundary, security, and Svelte UX review. All findings were addressed and the final verdict is CLEAR/APPROVE.

Closes #2050
Refs #2045

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"0d64d98a-44e5-4d7f-b773-95ff3ce0929f","issue":"https://github.com/happyvertical/smrt/issues/2050","policy_revision":"1.0.0","status":"complete","validation":["fields 155/155 plus check, typecheck, build, and pack","Biome, knowledge, audit policy, agents-chain, pre-commit, and pre-push green","final Terra security, correctness, UX, and API-boundary review PASS"]}
```
