### PR TITLE
feat(fields): add ObjectForm submit actions

### DIFF
--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -75,6 +75,20 @@ and ordering, and keeps form state transport-neutral.
   bind:value={record} {inputRegistry} />
 ```
 
+Pass an `actions` snippet to place host controls inside the owned native form.
+The snippet renders after ObjectForm's policy-ordered fields, so a regular
+submit button keeps native Enter/click submission and ObjectForm's validation
+and `onsubmit` handling without querying the DOM.
+
+```svelte
+<ObjectForm {objectRef} fields={collectionDefinition.fields} {policy}
+  bind:value={record} onsubmit={save}>
+  {#snippet actions()}
+    <button type="submit">Save</button>
+  {/snippet}
+</ObjectForm>
+```
+
 An app can register all of its generated collection definitions once and put
 the `resolveBatch` custom-action client behind an `ObjectFormSourceProvider`.
 Then forms need only their canonical object reference; the registry validates

--- a/packages/fields/src/svelte/__tests__/ObjectForm.test.ts
+++ b/packages/fields/src/svelte/__tests__/ObjectForm.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../index.js';
 import { FieldInputRegistry } from '../input-registry.js';
 import { resolveObjectFormFields } from '../object-form.js';
+import ObjectFormActionsFixture from './fixtures/ObjectFormActionsFixture.svelte';
 import ObjectFormFixture from './fixtures/ObjectFormFixture.svelte';
 import ObjectFormRegistryFixture from './fixtures/ObjectFormRegistryFixture.svelte';
 import ObjectFormSnippetFixture from './fixtures/ObjectFormSnippetFixture.svelte';
@@ -287,6 +288,28 @@ describe('ObjectForm component', () => {
     expect(
       screen.queryByRole('textbox', { name: 'Name' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('renders host actions inside the form and keeps submit validation and callbacks intact', async () => {
+    const onsubmit = vi.fn();
+    render(ObjectFormActionsFixture, { props: { fields, policy, onsubmit } });
+
+    const submit = screen.getByRole('button', { name: 'Save product' });
+    expect(submit).toHaveAttribute('type', 'submit');
+    await userEvent.type(
+      screen.getByRole('textbox', { name: 'Name' }),
+      'Deluxe',
+    );
+    await userEvent.click(submit);
+    expect(onsubmit).toHaveBeenCalledTimes(1);
+
+    const metadata = screen.getByRole('textbox', {
+      name: 'Metadata',
+    }) as HTMLTextAreaElement;
+    metadata.value = '{not json}';
+    await fireEvent.input(metadata);
+    await userEvent.click(submit);
+    expect(onsubmit).toHaveBeenCalledTimes(1);
   });
 
   it('is axe-clean for its generated basic form', async () => {

--- a/packages/fields/src/svelte/__tests__/fixtures/ObjectFormActionsFixture.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/ObjectFormActionsFixture.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import type { ResolvedObjectFieldPolicy } from '../../../types.js';
+import ObjectForm from '../../components/ObjectForm.svelte';
+import type { ObjectFormFieldDefinition } from '../../types.js';
+
+interface Props {
+  fields: Record<string, ObjectFormFieldDefinition>;
+  policy: ResolvedObjectFieldPolicy;
+  onsubmit: (event: SubmitEvent) => void;
+}
+
+let { fields, policy, onsubmit }: Props = $props();
+let record = $state<Record<string, unknown>>({});
+</script>
+
+<ObjectForm objectRef={policy.objectRef} {fields} {policy} bind:value={record} {onsubmit}>
+  {#snippet actions()}
+    <button type="submit">Save product</button>
+  {/snippet}
+</ObjectForm>

--- a/packages/fields/src/svelte/components/ObjectForm.svelte
+++ b/packages/fields/src/svelte/components/ObjectForm.svelte
@@ -55,6 +55,8 @@ export interface ObjectFormProps {
   inputRegistry?: FieldInputRegistry;
   /** Per-field custom widget snippets, keyed by field name. */
   renderers?: Readonly<Record<string, Snippet<[ObjectFormFieldSnippetProps]>>>;
+  /** Optional controls rendered after the policy-ordered fields inside the form. */
+  actions?: Snippet;
   class?: string;
   onsubmit?: (event: SubmitEvent) => void;
 }
@@ -71,6 +73,7 @@ let {
   showPolicyGear = false,
   inputRegistry,
   renderers = {},
+  actions,
   class: className = '',
   onsubmit,
 }: ObjectFormProps = $props();
@@ -334,6 +337,7 @@ function inputFor(field: ObjectFormField): FieldInputComponent {
         {@render renderGroups(advancedGroups)}
       </AdvancedFields>
     {/if}
+    {@render actions?.()}
   </Form>
 </FieldPolicyProvider>
 {/if}


### PR DESCRIPTION
## Summary

- add a typed `actions` snippet rendered inside ObjectForm’s existing native form
- preserve policy ordering, validation, and the existing `onsubmit` contract
- document the host submission pattern and cover valid and invalid submit behavior

## Validation

- `pnpm --filter @happyvertical/smrt-fields test` — 10 files / 146 tests
- `pnpm --filter @happyvertical/smrt-fields check` — 0 errors / 0 warnings
- `pnpm --filter @happyvertical/smrt-fields typecheck`
- `pnpm --filter @happyvertical/smrt-fields build`
- `pnpm --filter @happyvertical/smrt-fields verify:pack`
- `pnpm exec biome check packages/fields`
- `pnpm knowledge:check --changed --strict --format markdown`
- `pnpm audit:policy`
- pre-push repository gates
- correctness, API-boundary, and Svelte UX review: PASS

Closes #2263
Refs #2052

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"47192f18-4b51-4d64-8eed-1f3fc7a18b4d","issue":"https://github.com/happyvertical/smrt/issues/2263","policy_revision":"1.0.0","status":"complete","validation":["fields 146/146 plus check, typecheck, build, and pack","Biome, knowledge, audit policy, and pre-push green","correctness, API-boundary, and Svelte UX review PASS"]}
```