### PR TITLE
feat(mcp): add durable tasks extension

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -368,6 +368,27 @@ class Product extends SmrtObject { /* ... */ }
 
 Generators produce OpenAPI REST endpoints, Commander CLI commands, and MCP server tools respectively. The Vite plugin (`smrtPlugin`) generates virtual modules at dev time for routes, clients, and manifests.
 
+### Durable MCP tasks
+
+Long-running item actions may opt into the experimental
+`io.modelcontextprotocol/tasks` extension. Tasks are disabled by default; list
+the action names explicitly and mark the action as background-eligible:
+
+```typescript
+@smrt({
+  mcp: { include: ['generateReport'], tasks: ['generateReport'] },
+})
+class Report extends SmrtObject {
+  @backgroundEligible()
+  async generateReport(): Promise<ReportResult> { /* ... */ }
+}
+```
+
+The generated MCP server advertises the extension only when at least one task
+action is enabled. A task-aware client can request the action as a durable job,
+then use `tasks/get`, `tasks/update`, and `tasks/cancel` to observe or control
+it. Generated stdio servers run an `mcp-tasks` worker automatically.
+
 ## Dependencies
 
 - `@happyvertical/ai` -- AI client (is/do operations, embeddings)

--- a/packages/core/src/__tests__/system-table-compatibility.test.ts
+++ b/packages/core/src/__tests__/system-table-compatibility.test.ts
@@ -148,6 +148,15 @@ describe('system table compatibility', () => {
     const columns = await db.query(`PRAGMA table_info(_smrt_jobs)`);
     const columnNames = columns.rows.map((row: { name: string }) => row.name);
     expect(columnNames).toContain('tenant_id');
+    expect(columnNames).toEqual(
+      expect.arrayContaining([
+        'task_id',
+        'task_owner_id',
+        'task_result',
+        'task_input_requests',
+        'task_input_responses',
+      ]),
+    );
 
     const indexes = await db.query(`
       SELECT name FROM sqlite_master
@@ -156,6 +165,14 @@ describe('system table compatibility', () => {
     `);
     const indexNames = indexes.rows.map((row: { name: string }) => row.name);
     expect(indexNames).toContain('idx_smrt_jobs_tenant_id');
+    const taskIndexes = await db.query(`
+      SELECT name FROM sqlite_master
+      WHERE type = 'index'
+        AND name = 'idx_smrt_jobs_task_id'
+    `);
+    expect(taskIndexes.rows.map((row: { name: string }) => row.name)).toContain(
+      'idx_smrt_jobs_task_id',
+    );
   });
 
   it('upgrades legacy jobs tables without replaying system DDL', async () => {
@@ -209,6 +226,15 @@ describe('system table compatibility', () => {
     const columns = await db.query(`PRAGMA table_info(_smrt_jobs)`);
     const columnNames = columns.rows.map((row: { name: string }) => row.name);
     expect(columnNames).toContain('tenant_id');
+    expect(columnNames).toEqual(
+      expect.arrayContaining([
+        'task_id',
+        'task_owner_id',
+        'task_result',
+        'task_input_requests',
+        'task_input_responses',
+      ]),
+    );
 
     const indexes = await db.query(`
       SELECT name FROM sqlite_master
@@ -217,6 +243,14 @@ describe('system table compatibility', () => {
     `);
     const indexNames = indexes.rows.map((row: { name: string }) => row.name);
     expect(indexNames).toContain('idx_smrt_jobs_tenant_id');
+    const taskIndexes = await db.query(`
+      SELECT name FROM sqlite_master
+      WHERE type = 'index'
+        AND name = 'idx_smrt_jobs_task_id'
+    `);
+    expect(taskIndexes.rows.map((row: { name: string }) => row.name)).toContain(
+      'idx_smrt_jobs_task_id',
+    );
   });
 
   it('upgrades legacy job event tables without replaying system DDL', async () => {
@@ -261,6 +295,18 @@ describe('system table compatibility', () => {
   });
 
   it('skips Postgres jobs DDL when the compatibility column and index already exist', async () => {
+    const existingColumns = new Set([
+      'tenant_id',
+      'task_id',
+      'task_owner_id',
+      'task_result',
+      'task_input_requests',
+      'task_input_responses',
+    ]);
+    const existingIndexes = new Set([
+      'idx_smrt_jobs_tenant_id',
+      'idx_smrt_jobs_task_id',
+    ]);
     const query = vi
       .fn()
       .mockImplementation(async (sql: string, ...params: unknown[]) => {
@@ -271,12 +317,13 @@ describe('system table compatibility', () => {
 
         if (sql.includes('information_schema.columns')) {
           expect(sql).toContain('table_schema = current_schema()');
-          expect(params).toEqual(['_smrt_jobs', 'tenant_id']);
+          expect(params[0]).toBe('_smrt_jobs');
+          expect(existingColumns.has(params[1] as string)).toBe(true);
           return { rows: [{ '?column?': 1 }] };
         }
 
         if (sql.includes('pg_indexes')) {
-          expect(params).toEqual(['idx_smrt_jobs_tenant_id']);
+          expect(existingIndexes.has(params[0] as string)).toBe(true);
           return { rows: [{ '?column?': 1 }] };
         }
 

--- a/packages/core/src/generators/mcp-runtime-template.test.ts
+++ b/packages/core/src/generators/mcp-runtime-template.test.ts
@@ -16,13 +16,16 @@ describe('generated MCP custom-action runtime (#2182)', () => {
     expect(source).toContain("from '@modelcontextprotocol/server/stdio'");
     expect(source).toContain("setRequestHandler('tools/list'");
     expect(source).toContain("setRequestHandler('tools/call'");
-    expect(source).toContain('serveStdio(() => createServer()');
+    expect(source).toContain('const server = await createServer()');
+    expect(source).toContain('serveStdio(() => server');
     expect(source).toContain('await loadConfig()');
     expect(source).toContain('structuredContent');
     expect(source).toContain('function successResult');
     expect(source).toContain('function errorResult');
     expect(source).toContain('function resolveCreateTarget');
     expect(source).toContain('ObjectRegistry.loadAllManifests');
+    expect(source).toContain('SMRT_MCP_REGISTER_PATH');
+    expect(source).toContain("resolve(process.cwd(), '.smrt', 'register.js')");
     expect(source).not.toContain('@modelcontextprotocol/sdk');
     expect(source).not.toContain('initialize');
   });
@@ -44,6 +47,28 @@ describe('generated MCP custom-action runtime (#2182)', () => {
     expect(source).toContain(
       'tools: [...TOOLS].sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0)',
     );
+  });
+
+  it('emits the Tasks extension only for eligible generated actions', () => {
+    const disabled = generateRuntimeBootstrap({ tools: [], taskActions: {} });
+    const enabled = generateRuntimeBootstrap({
+      tools: [],
+      taskActions: {
+        report_generate: {
+          objectName: 'Report',
+          objectType: '@test/reports:Report',
+        },
+      },
+    });
+
+    expect(disabled).not.toContain(
+      "extensions: { 'io.modelcontextprotocol/tasks': {} }",
+    );
+    expect(enabled).toContain(
+      "extensions: { 'io.modelcontextprotocol/tasks': {} }",
+    );
+    expect(enabled).toContain('class McpTaskExtensionTransport');
+    expect(enabled).toContain('new McpTaskExtensionTransport');
   });
 
   it('requires an explicit global-catalog opt-in and never shares tenant catalogs', () => {

--- a/packages/core/src/generators/mcp-runtime-template.ts
+++ b/packages/core/src/generators/mcp-runtime-template.ts
@@ -64,6 +64,14 @@ export interface RuntimeOptions {
       legacyOptions: boolean;
     }
   >;
+  /** Task-enabled item custom actions. Never emitted in tools/list. */
+  taskActions?: Record<
+    string,
+    {
+      objectName: string;
+      objectType: string;
+    }
+  >;
 
   /**
    * Lowercased simple names of objects that are `@TenantScoped` (#1554). When
@@ -97,6 +105,7 @@ export function generateRuntimeBootstrap(options: RuntimeOptions = {}): string {
     debug = false,
     tools = [],
     customActions = {},
+    taskActions = {},
     tenantScopedObjects = [],
     stiTargets = {},
     toolListCacheHint = { ttlMs: 86_400_000, cacheScope: 'private' },
@@ -104,6 +113,7 @@ export function generateRuntimeBootstrap(options: RuntimeOptions = {}): string {
 
   // Generate static tool array as TypeScript code
   const toolsCode = tools.length > 0 ? JSON.stringify(tools, null, 2) : '[]';
+  const hasTaskActions = Object.keys(taskActions).length > 0;
 
   // Fail-closed tenant context (#1554): only wire the tenancy gate when at
   // least one exposed object is tenant-scoped, so apps without tenancy never
@@ -297,13 +307,14 @@ import {
   type ListToolsRequest,
   Server,
 } from '@modelcontextprotocol/server';
-import { serveStdio } from '@modelcontextprotocol/server/stdio';
+import { ${hasTaskActions ? 'StdioServerTransport, ' : ''}serveStdio } from '@modelcontextprotocol/server/stdio';
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { ObjectRegistry } from '@happyvertical/smrt-core';
 import { normalizeCustomActionFailure, SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY } from '@happyvertical/smrt-core';
 import { loadConfig } from '@happyvertical/smrt-config';
+${hasTaskActions ? "import { McpTaskStore, TaskRunner } from '@happyvertical/smrt-jobs';\n" : ''}
 ${hasTenantScoped ? "import { enableTenancy, runTenantScopedEntryPoint } from '@happyvertical/smrt-tenancy';\n" : ''}
 // Server configuration
 const SERVER_NAME = ${JSON.stringify(name)};
@@ -315,6 +326,7 @@ const DEBUG = ${debug};
 const TOOLS = ${toolsCode};
 const TOOL_LIST_CACHE_HINT = ${JSON.stringify(toolListCacheHint)};
 const CUSTOM_ACTIONS = ${JSON.stringify(customActions)};
+const TASK_ACTIONS = ${JSON.stringify(taskActions)};
 const STI_TARGETS: Record<string, Record<string, string>> = ${JSON.stringify(stiTargets)};
 ${
   hasTenantScoped
@@ -426,6 +438,143 @@ function errorResult(structuredContent: any, text: string, _meta?: Record<string
   };
 }
 
+${
+  hasTaskActions
+    ? `
+// The bundled SDK validates tools/call responses against its older result
+// codec, which does not yet know CreateTaskResult. Intercept the extension at
+// the transport boundary, then pass every non-task message untouched to the
+// SDK server. This keeps ordinary MCP behaviour and version negotiation owned
+// by the SDK while making the extension available today.
+const MCP_TASKS_EXTENSION = 'io.modelcontextprotocol/tasks';
+let taskRuntime: Promise<{ store: McpTaskStore; runner: TaskRunner }> | undefined;
+
+function clientSupportsTasks(message: any): boolean {
+  return message?.params?._meta?.['io.modelcontextprotocol/clientCapabilities']
+    ?.extensions?.[MCP_TASKS_EXTENSION] !== undefined;
+}
+
+function jsonRpcError(id: any, code: number, message: string, data?: any) {
+  return { jsonrpc: '2.0', id, error: { code, message, ...(data === undefined ? {} : { data }) } };
+}
+
+async function getTaskRuntime() {
+  if (!taskRuntime) {
+    taskRuntime = (async () => {
+      const firstAction = Object.values(TASK_ACTIONS)[0] as { objectName: string } | undefined;
+      if (!firstAction) throw new Error('No task-enabled MCP action is configured');
+      const collection = await ObjectRegistry.getCollection(firstAction.objectName, {
+        persistence: { type: process.env.DATABASE_TYPE || 'sqlite', url: process.env.DATABASE_URL || ':memory:' },
+      });
+      const db = collection.db;
+      const store = await McpTaskStore.create(db, { ownerId: process.env.SMRT_MCP_TENANT_ID || null });
+      const runner = new TaskRunner({ queues: ['mcp-tasks'] });
+      await runner.initialize(db);
+      await runner.start();
+      return { store, runner };
+    })();
+  }
+  return taskRuntime;
+}
+
+function taskInvocationArgs(actionMeta: any, args: Record<string, any>): any[] {
+  const { id: _id, options, ...directArgs } = args;
+  if (actionMeta.legacyOptions) {
+    return [Object.keys(options ?? {}).length > 0 ? options : directArgs];
+  }
+  if (actionMeta.optionsParameter) return [options];
+  const parameterNames = actionMeta.parameterNames || [];
+  const invocationParameterNames = parameterNames.at(-1) === 'context'
+    ? parameterNames.slice(0, -1)
+    : parameterNames;
+  return invocationParameterNames.map((parameterName: string) =>
+    args[parameterName === 'id' ? 'actionId' : parameterName],
+  );
+}
+
+async function handleTaskExtensionMessage(message: any): Promise<any | null> {
+  if (!message || typeof message !== 'object' || message.id === undefined) return null;
+  const method = message.method;
+  const params = message.params ?? {};
+  const action = method === 'tools/call' ? TASK_ACTIONS[params.name] : undefined;
+  const isTaskMethod = action || ['tasks/get', 'tasks/update', 'tasks/cancel'].includes(method);
+  if (!isTaskMethod) return null;
+  if (!clientSupportsTasks(message)) {
+    // A task-only method cannot fall back to a legacy response shape. A task
+    // tool can still run normally when the client did not opt in, so let the
+    // SDK handle that direct tools/call path.
+    if (method === 'tools/call') return null;
+    return jsonRpcError(message.id, -32021, 'Missing required client capability', {
+      requiredCapabilities: { extensions: { [MCP_TASKS_EXTENSION]: {} } },
+    });
+  }
+  try {
+    const { store } = await getTaskRuntime();
+    if (action) {
+      if (typeof params.arguments?.id !== 'string') {
+        return jsonRpcError(message.id, -32602, 'Task-enabled custom actions require an id');
+      }
+      const actionMeta = CUSTOM_ACTIONS[params.name];
+      const task = await store.createTask({
+        objectType: action.objectType,
+        objectId: params.arguments.id,
+        method: actionMeta.methodName || params.name.slice(params.name.indexOf('_') + 1),
+        invocationArgs: taskInvocationArgs(actionMeta, params.arguments),
+        tenantId: ${hasTenantScoped ? 'MCP_TENANT_ID ?? null' : 'null'},
+      });
+      return { jsonrpc: '2.0', id: message.id, result: { resultType: 'task', content: [], structuredContent: {}, ...task } };
+    }
+    if (typeof params.taskId !== 'string') {
+      return jsonRpcError(message.id, -32602, 'taskId is required');
+    }
+    if (method === 'tasks/get') {
+      const task = await store.getTask(params.taskId);
+      return { jsonrpc: '2.0', id: message.id, result: { resultType: 'complete', ...task } };
+    }
+    if (method === 'tasks/update') {
+      await store.updateTask(
+        params.taskId,
+        params.inputResponses && typeof params.inputResponses === 'object'
+          ? params.inputResponses
+          : {},
+      );
+      return { jsonrpc: '2.0', id: message.id, result: { resultType: 'complete' } };
+    }
+    await store.cancelTask(params.taskId);
+    return { jsonrpc: '2.0', id: message.id, result: { resultType: 'complete' } };
+  } catch (error) {
+    const messageText = error instanceof Error ? error.message : 'Task operation failed';
+    return jsonRpcError(message.id, -32602, messageText);
+  }
+}
+
+class McpTaskExtensionTransport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: any) => void;
+
+  constructor(private readonly wire: StdioServerTransport) {}
+
+  async start() {
+    this.wire.onclose = () => this.onclose?.();
+    this.wire.onerror = (error) => this.onerror?.(error);
+    this.wire.onmessage = (message) => {
+      void (async () => {
+        const response = await handleTaskExtensionMessage(message);
+        if (response) await this.wire.send(response);
+        else this.onmessage?.(message);
+      })().catch((error) => this.onerror?.(error instanceof Error ? error : new Error(String(error))));
+    };
+    await this.wire.start();
+  }
+
+  close() { return this.wire.close(); }
+  send(message: any) { return this.wire.send(message); }
+}
+`
+    : ''
+}
+
 /**
  * Main server startup function
  */
@@ -456,6 +605,16 @@ ${
       ObjectRegistry.loadAllManifests({ manifestPaths: localManifestPaths });
     }
 
+    // A manifest supplies schemas and tool metadata, while an executable
+    // custom action also needs the application's actual class constructor.
+    // Consumer builds generate this registration module; load it after the
+    // manifest so decorators enrich the already-known metadata.
+    const localRegisterPath = process.env.SMRT_MCP_REGISTER_PATH
+      || resolve(process.cwd(), '.smrt', 'register.js');
+    if (existsSync(localRegisterPath)) {
+      await import(pathToFileURL(localRegisterPath).href);
+    }
+
     // Load configuration from environment and .smrt.config files
     const appConfig = await loadConfig();
     const aiConfig = appConfig?.ai || {};
@@ -474,6 +633,7 @@ ${
       {
         capabilities: {
           tools: {},
+          ${hasTaskActions ? "extensions: { 'io.modelcontextprotocol/tasks': {} }," : ''}
         },
         cacheHints: {
           'tools/list': TOOL_LIST_CACHE_HINT,
@@ -548,11 +708,18 @@ ${
 
 async function main() {
   try {
-    const handle = serveStdio(() => createServer(), {
+    // Initialize the registry before accepting an intercepted task call. The
+    // SDK would normally invoke this factory for the first regular message,
+    // but task calls can be the first message on a stdio connection.
+    const server = await createServer();
+    const transport = ${hasTaskActions ? 'new McpTaskExtensionTransport(new StdioServerTransport())' : 'undefined'};
+    const handle = serveStdio(() => server, {
+      ...(transport ? { transport } : {}),
       onerror: (error) => console.error('[MCP] Protocol error:', error),
     });
     const shutdown = async () => {
       if (DEBUG) console.error('[MCP] Shutting down gracefully');
+      ${hasTaskActions ? 'if (taskRuntime) {\n        const { runner } = await taskRuntime;\n        await runner.stop();\n      }' : ''}
       await handle.close();
       process.exit(0);
     };

--- a/packages/core/src/generators/mcp-runtime-template.ts
+++ b/packages/core/src/generators/mcp-runtime-template.ts
@@ -306,6 +306,7 @@ import {
   type CallToolRequest,
   type ListToolsRequest,
   Server,
+  ${hasTaskActions ? 'specTypeSchemas,' : ''}
 } from '@modelcontextprotocol/server';
 import { ${hasTaskActions ? 'StdioServerTransport, ' : ''}serveStdio } from '@modelcontextprotocol/server/stdio';
 import { existsSync } from 'node:fs';
@@ -454,6 +455,70 @@ function clientSupportsTasks(message: any): boolean {
     ?.extensions?.[MCP_TASKS_EXTENSION] !== undefined;
 }
 
+/** Validate the 2026 request envelope before task dispatch mutates a job. */
+function taskEnvelopeError(message: any): { code: number; message: string; data?: any } | undefined {
+  const meta = message?.params?._meta;
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) {
+    return {
+      code: -32602,
+      message: 'Request is missing the required _meta envelope for protocol revision 2026-07-28',
+    };
+  }
+  const protocolVersion = meta['io.modelcontextprotocol/protocolVersion'];
+  if (protocolVersion !== '2026-07-28') {
+    return typeof protocolVersion === 'string'
+      ? {
+          code: -32022,
+          message: 'Unsupported protocol version: ' + protocolVersion,
+          data: { supported: ['2026-07-28'], requested: protocolVersion },
+        }
+      : {
+          code: -32602,
+          message: 'Invalid _meta envelope for protocol revision 2026-07-28: io.modelcontextprotocol/protocolVersion must be a string',
+        };
+  }
+  if (!specTypeSchemas.ClientCapabilities.safeParse(
+    meta['io.modelcontextprotocol/clientCapabilities'],
+  ).success) {
+    return {
+      code: -32602,
+      message: 'Invalid _meta envelope for protocol revision 2026-07-28: io.modelcontextprotocol/clientCapabilities is invalid',
+    };
+  }
+  if (
+    meta['io.modelcontextprotocol/clientInfo'] !== undefined &&
+    !specTypeSchemas.Implementation.safeParse(
+      meta['io.modelcontextprotocol/clientInfo'],
+    ).success
+  ) {
+    return {
+      code: -32602,
+      message: 'Invalid _meta envelope for protocol revision 2026-07-28: io.modelcontextprotocol/clientInfo is invalid',
+    };
+  }
+  if (
+    meta['io.modelcontextprotocol/logLevel'] !== undefined &&
+    !specTypeSchemas.LoggingLevel.safeParse(
+      meta['io.modelcontextprotocol/logLevel'],
+    ).success
+  ) {
+    return {
+      code: -32602,
+      message: 'Invalid _meta envelope for protocol revision 2026-07-28: io.modelcontextprotocol/logLevel is invalid',
+    };
+  }
+  if (
+    meta.progressToken !== undefined &&
+    !specTypeSchemas.ProgressToken.safeParse(meta.progressToken).success
+  ) {
+    return {
+      code: -32602,
+      message: 'Invalid _meta envelope for protocol revision 2026-07-28: progressToken is invalid',
+    };
+  }
+  return undefined;
+}
+
 function jsonRpcError(id: any, code: number, message: string, data?: any) {
   return { jsonrpc: '2.0', id, error: { code, message, ...(data === undefined ? {} : { data }) } };
 }
@@ -499,6 +564,14 @@ async function handleTaskExtensionMessage(message: any): Promise<any | null> {
   const action = method === 'tools/call' ? TASK_ACTIONS[params.name] : undefined;
   const isTaskMethod = action || ['tasks/get', 'tasks/update', 'tasks/cancel'].includes(method);
   if (!isTaskMethod) return null;
+  // A task-enabled tool retains its normal synchronous behaviour until its
+  // client explicitly opts into Tasks. Do not impose the task envelope on
+  // legacy calls that will be passed untouched to the SDK.
+  if (!clientSupportsTasks(message) && method === 'tools/call') return null;
+  const envelopeError = taskEnvelopeError(message);
+  if (envelopeError) {
+    return jsonRpcError(message.id, envelopeError.code, envelopeError.message, envelopeError.data);
+  }
   if (!clientSupportsTasks(message)) {
     // A task-only method cannot fall back to a legacy response shape. A task
     // tool can still run normally when the client did not opt in, so let the

--- a/packages/core/src/generators/mcp-tasks.spec.ts
+++ b/packages/core/src/generators/mcp-tasks.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { SmrtObject } from '../object.js';
+import { smrt } from '../registry.js';
+import { MCPGenerator, type MCPTaskStore } from './mcp.js';
+
+@smrt({ mcp: { include: ['slowAction'], tasks: ['slowAction'] } })
+class TaskEnabledProtocolProbe extends SmrtObject {
+  async slowAction(options: { prompt: string }) {
+    return { prompt: options.prompt };
+  }
+}
+
+@smrt({ mcp: { include: ['slowAction'] } })
+class TaskDisabledProtocolProbe extends SmrtObject {
+  async slowAction(options: { prompt: string }) {
+    return { prompt: options.prompt };
+  }
+}
+
+describe('MCP Tasks extension eligibility', () => {
+  it('defaults task support off unless a model explicitly opts in', async () => {
+    const generator = new MCPGenerator();
+    expect(
+      await generator.supportsTaskTool('taskdisabledprotocolprobe_slowaction'),
+    ).toBe(false);
+    expect(
+      await generator.supportsTaskTool('taskenabledprotocolprobe_slowaction'),
+    ).toBe(true);
+  });
+
+  it('projects exact custom-action arguments into a durable task store', async () => {
+    let received: Parameters<MCPTaskStore['createTask']>[0] | undefined;
+    const taskStore: MCPTaskStore = {
+      createTask: async (input) => {
+        received = input;
+        return {
+          taskId: 'task-1',
+          status: 'working',
+          createdAt: '2026-08-09T00:00:00.000Z',
+          lastUpdatedAt: '2026-08-09T00:00:00.000Z',
+          ttlMs: 60_000,
+        };
+      },
+    };
+    const generator = new MCPGenerator({}, { taskStore });
+
+    const result = await generator.createTask({
+      method: 'tools/call',
+      params: {
+        name: 'taskenabledprotocolprobe_slowaction',
+        arguments: { id: 'probe-1', options: { prompt: 'hello' } },
+      },
+    });
+
+    expect(received).toMatchObject({
+      objectId: 'probe-1',
+      method: 'slowAction',
+      invocationArgs: [{ prompt: 'hello' }],
+    });
+    expect(result).toMatchObject({
+      resultType: 'task',
+      taskId: 'task-1',
+      status: 'working',
+    });
+  });
+});

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -149,6 +149,34 @@ export interface MCPContext {
    * or this flag, tenant-scoped tool calls fail closed when tenancy is enabled.
    */
   allowCrossTenant?: boolean;
+  /**
+   * Optional durable backing store for the MCP Tasks extension. Core owns
+   * task eligibility and action argument projection; jobs-backed runtimes own
+   * persistence so `@happyvertical/smrt-core` stays independent of jobs.
+   */
+  taskStore?: MCPTaskStore;
+}
+
+/** Minimal durable task-store contract implemented by `@smrt-jobs`. */
+export interface MCPTaskStore {
+  createTask(input: {
+    objectType: string;
+    objectId: string;
+    method: string;
+    invocationArgs: unknown[];
+    tenantId?: string | null;
+  }): Promise<MCPTask>;
+}
+
+/** Flat MCP Tasks extension projection shared by generated and app transports. */
+export interface MCPTask {
+  taskId: string;
+  status: 'working' | 'input_required' | 'completed' | 'cancelled' | 'failed';
+  createdAt: string;
+  lastUpdatedAt: string;
+  ttlMs: number;
+  pollIntervalMs?: number;
+  statusMessage?: string;
 }
 
 export interface MCPTool {
@@ -183,6 +211,15 @@ export interface MCPResponse {
   _meta?: Record<string, unknown>;
   /** Machine-readable projection matching the tool's declared outputSchema. */
   structuredContent?: unknown;
+  /** Set only for a Tasks extension CreateTaskResult. */
+  resultType?: 'task' | 'complete';
+  taskId?: string;
+  status?: MCPTask['status'];
+  createdAt?: string;
+  lastUpdatedAt?: string;
+  ttlMs?: number;
+  pollIntervalMs?: number;
+  statusMessage?: string;
 }
 
 class CustomActionFailureError extends Error {
@@ -210,6 +247,43 @@ function resolveCustomActionMethod(
     }
   }
   return [toolAction, undefined];
+}
+
+/** Preserve a declared method's case when a runtime-only class has no manifest. */
+function resolveRuntimeMethodName(
+  classConstructor: unknown,
+  action: string,
+): string {
+  let prototype: object | null | undefined = (
+    classConstructor as { prototype?: object } | undefined
+  )?.prototype;
+  while (prototype && prototype !== Object.prototype) {
+    const match = Object.getOwnPropertyNames(prototype).find(
+      (name) => name.toLowerCase() === action.toLowerCase(),
+    );
+    if (match) return match;
+    prototype = Object.getPrototypeOf(prototype) as object | null;
+  }
+  return action;
+}
+
+/**
+ * Background task methods receive `JobExecutionContext` from TaskRunner, not
+ * from untrusted MCP arguments. Keep that conventional trailing parameter out
+ * of the persisted positional call so the runner can append its live context.
+ */
+function buildTaskActionInvocationArgs(
+  metadata: CustomActionMetadata,
+  args: ToolArgs,
+): unknown[] {
+  const parameters = metadata.parameters;
+  if (parameters?.at(-1)?.name === 'context') {
+    return buildCustomActionInvocationArgs(
+      { ...metadata, parameters: parameters.slice(0, -1) },
+      args,
+    );
+  }
+  return buildCustomActionInvocationArgs(metadata, args);
 }
 
 /**
@@ -892,6 +966,123 @@ export class MCPGenerator {
     }
   }
 
+  /** Whether a visible tool has explicitly opted into durable task execution. */
+  async supportsTaskTool(name: string): Promise<boolean> {
+    return (
+      (await this.resolveTaskAction(name, { id: '__mcp_task_probe__' })) !==
+      null
+    );
+  }
+
+  /**
+   * Create a durable MCP task for an explicitly enabled item custom action.
+   * The caller is responsible for checking the client's extension capability
+   * before exposing this result on the wire.
+   */
+  async createTask(request: MCPRequest): Promise<MCPResponse> {
+    if (!this.context.taskStore) {
+      throw new Error(
+        'MCP Tasks is enabled but no durable task store is configured',
+      );
+    }
+    const resolved = await this.resolveTaskAction(
+      request.params.name,
+      request.params.arguments,
+    );
+    if (!resolved) {
+      throw new Error(
+        `MCP task execution is not enabled for tool: ${request.params.name}`,
+      );
+    }
+    const task = await this.context.taskStore.createTask({
+      objectType: resolved.objectType,
+      objectId: resolved.objectId,
+      method: resolved.methodName,
+      invocationArgs: resolved.invocationArgs,
+      tenantId: this.context.tenantId ?? null,
+    });
+    return {
+      content: [],
+      structuredContent: {},
+      resultType: 'task',
+      ...task,
+    };
+  }
+
+  private async resolveTaskAction(
+    toolName: string,
+    args: ToolArgs,
+  ): Promise<{
+    objectType: string;
+    objectId: string;
+    methodName: string;
+    invocationArgs: unknown[];
+  } | null> {
+    const separator = toolName.indexOf('_');
+    if (separator <= 0) return null;
+    const objectPrefix = toolName.slice(0, separator);
+    const action = toolName.slice(separator + 1);
+    if (['list', 'get', 'create', 'update', 'delete'].includes(action)) {
+      return null;
+    }
+    const classEntry = Array.from(
+      ObjectRegistry.getAllClasses().entries(),
+    ).find(
+      ([key, info]) =>
+        (info.name || key).toLowerCase() === objectPrefix.toLowerCase(),
+    );
+    if (!classEntry) return null;
+    const [key, classInfo] = classEntry;
+    const objectName = classInfo.name || key;
+    const mcpConfig = ObjectRegistry.getConfig(objectName).mcp;
+    const configuredTasks =
+      typeof mcpConfig === 'object' ? mcpConfig.tasks : undefined;
+    if (
+      configuredTasks !== true &&
+      (!Array.isArray(configuredTasks) ||
+        !configuredTasks.some(
+          (method) => method.toLowerCase() === action.toLowerCase(),
+        ))
+    ) {
+      return null;
+    }
+
+    // The action must already be visible through the normal MCP surface. This
+    // keeps `tasks: true` from silently widening a class's configured tool set.
+    const tools = await this.generateTools();
+    if (!tools.some((tool) => tool.name === toolName)) return null;
+
+    const [resolvedMethodName, method] = resolveCustomActionMethod(
+      await ObjectRegistry.getAllMethods(objectName),
+      action,
+    );
+    const methodName = method
+      ? resolvedMethodName
+      : resolveRuntimeMethodName(classInfo.constructor, action);
+    const metadata = this.resolveCustomActionMetadata(
+      objectName,
+      methodName,
+      method,
+      this.hasCollectionReceiver(classInfo),
+    );
+    // TaskRunner preserves the canonical persisted-object hydration invariant.
+    // Collection/static receivers do not have that target and intentionally do
+    // not claim Tasks support until a separate durable receiver contract exists.
+    if (
+      !metadata.idRequired ||
+      metadata.isStatic ||
+      typeof args.id !== 'string'
+    ) {
+      return null;
+    }
+    return {
+      objectType: classInfo.qualifiedName || objectName,
+      objectId: args.id,
+      methodName,
+      invocationArgs: buildTaskActionInvocationArgs(metadata, args),
+    };
+  }
+
   /** Convert runtime values to the JSON values MCP structuredContent permits. */
   private toJsonValue(value: unknown): unknown {
     const serialized = JSON.stringify(value);
@@ -1555,6 +1746,7 @@ export class MCPGenerator {
         debug,
         tools,
         customActions: await this.runtimeCustomActions(tools),
+        taskActions: await this.runtimeTaskActions(tools),
         tenantScopedObjects,
         stiTargets: this.runtimeStiTargets(tools),
         toolListCacheHint: resolveMCPToolListCacheHint(
@@ -1643,6 +1835,31 @@ export class MCPGenerator {
       };
     }
     return metadata;
+  }
+
+  /** Emit only task-enabled item custom actions for the generated runtime. */
+  private async runtimeTaskActions(
+    tools: MCPTool[],
+  ): Promise<NonNullable<RuntimeOptions['taskActions']>> {
+    const actions: NonNullable<RuntimeOptions['taskActions']> = {};
+    const classes = ObjectRegistry.getAllClasses();
+    for (const tool of tools) {
+      if (!(await this.supportsTaskTool(tool.name))) continue;
+      const separator = tool.name.indexOf('_');
+      if (separator <= 0) continue;
+      const objectPrefix = tool.name.slice(0, separator).toLowerCase();
+      const matched = Array.from(classes.entries()).find(
+        ([key, info]) => (info.name || key).toLowerCase() === objectPrefix,
+      );
+      if (!matched) continue;
+      const [key, classInfo] = matched;
+      const objectName = classInfo.name || key;
+      actions[tool.name] = {
+        objectName,
+        objectType: classInfo.qualifiedName || objectName,
+      };
+    }
+    return actions;
   }
 
   /**
@@ -2042,6 +2259,7 @@ const MCP_ALLOW_CROSS_TENANT = process.env.SMRT_MCP_ALLOW_CROSS_TENANT === 'true
 `
     : ''
 }
+
 const PUBLIC_JSON_OPTIONS = {
   permissions: (process.env.SMRT_MCP_PERMISSIONS || '')
     .split(',')

--- a/packages/core/src/registry/types.ts
+++ b/packages/core/src/registry/types.ts
@@ -403,6 +403,15 @@ export interface SmartObjectConfig {
          * Exclude specific tools (supports both standard CRUD actions and custom methods)
          */
         exclude?: string[];
+
+        /**
+         * Enable the MCP Tasks extension for long-running custom actions.
+         *
+         * `false`/omitted keeps tasks fully disabled. `true` enables eligible
+         * item-scoped custom actions exposed by this MCP configuration; an
+         * array enables only the named actions.
+         */
+        tasks?: boolean | string[];
       };
 
   /**

--- a/packages/core/src/system/compatibility.ts
+++ b/packages/core/src/system/compatibility.ts
@@ -703,6 +703,34 @@ export async function ensureJobsSystemTableCompatibility(
     'tenant_id',
     typeHint,
   );
+  // MCP task support was added after `_smrt_jobs` had already shipped. Keep
+  // the task projection in the job row so a task can never outlive (or lose
+  // track of) the worker job that executes it. JSON is portable here because
+  // SMRT's adapters serialize JSON fields to text where necessary.
+  await addColumnIfMissing(db, '_smrt_jobs', 'task_id', 'TEXT', typeHint);
+  await addColumnIfMissing(db, '_smrt_jobs', 'task_owner_id', 'TEXT', typeHint);
+  await addColumnIfMissing(db, '_smrt_jobs', 'task_result', 'TEXT', typeHint);
+  await addColumnIfMissing(
+    db,
+    '_smrt_jobs',
+    'task_input_requests',
+    'TEXT',
+    typeHint,
+  );
+  await addColumnIfMissing(
+    db,
+    '_smrt_jobs',
+    'task_input_responses',
+    'TEXT',
+    typeHint,
+  );
+  await addUniqueIndexIfMissing(
+    db,
+    'idx_smrt_jobs_task_id',
+    '_smrt_jobs',
+    'task_id',
+    typeHint,
+  );
 }
 
 export async function ensureJobEventsSystemTableCompatibility(

--- a/packages/jobs/README.md
+++ b/packages/jobs/README.md
@@ -117,6 +117,25 @@ runner.on('job:failed', (job, error) => { /* ... */ });
 process.on('SIGTERM', () => runner.stop());
 ```
 
+### Back MCP task operations with durable jobs
+
+`McpTaskStore` persists the MCP `io.modelcontextprotocol/tasks` lifecycle on
+the same `_smrt_jobs` row that executes the operation. `createTask()` creates a
+correlated job, `getTask()` maps its queue state, and `cancelTask()` cancels
+that exact job without leaving a second record behind. Long-running task
+actions can request client input through `JobExecutionContext.task`:
+
+```typescript
+async generate(context: JobExecutionContext) {
+  const { tone } = await context.task!.requestInput({ tone: { type: 'string' } });
+  return this.render(tone);
+}
+```
+
+Run a `TaskRunner` for the `mcp-tasks` queue in application deployments. Task
+cancellation is cooperative: the job row becomes cancelled immediately and a
+running handler must observe its context before doing further side effects.
+
 ### Liveness-safe job execution
 
 `TaskRunner` records heartbeat telemetry, but recovery keys on a worker

--- a/packages/jobs/README.md
+++ b/packages/jobs/README.md
@@ -126,7 +126,7 @@ that exact job without leaving a second record behind. Long-running task
 actions can request client input through `JobExecutionContext.task`:
 
 ```typescript
-async generate(context: JobExecutionContext) {
+async generate(options: Record<string, never>, context: JobExecutionContext) {
   const { tone } = await context.task!.requestInput({ tone: { type: 'string' } });
   return this.render(tone);
 }

--- a/packages/jobs/src/__tests__/mcp-task.test.ts
+++ b/packages/jobs/src/__tests__/mcp-task.test.ts
@@ -16,6 +16,9 @@ class McpTaskProbe extends SmrtObject {
   name = '';
 
   @backgroundEligible()
+  async voidResult(): Promise<void> {}
+
+  @backgroundEligible()
   async slow(
     options: { value: string },
     _context?: JobExecutionContext,
@@ -120,6 +123,36 @@ describe('MCP Tasks durable jobs adapter', () => {
       expect(completed.result).toEqual({
         content: [{ type: 'text', text: JSON.stringify({ value: 'done' }) }],
         structuredContent: { data: { value: 'done' } },
+      });
+    } finally {
+      await runner.stop();
+    }
+  });
+
+  it('normalizes a void action result to valid JSON in the durable task payload', async () => {
+    const { db, probe } = await createProbe();
+    const store = await McpTaskStore.create(db, { ownerId: 'principal-a' });
+    const created = await store.createTask({
+      objectType: 'McpTaskProbe',
+      objectId: probe.id ?? '',
+      method: 'voidResult',
+      invocationArgs: [],
+    });
+    const runner = new TaskRunner({
+      queues: ['mcp-tasks'],
+      pollInterval: 5,
+      concurrency: 1,
+    });
+    await runner.initialize(db);
+    await runner.start();
+    try {
+      const completed = await waitFor(
+        () => store.getTask(created.taskId),
+        (task) => task.status === 'completed',
+      );
+      expect(completed.result).toEqual({
+        content: [{ type: 'text', text: 'null' }],
+        structuredContent: { data: null },
       });
     } finally {
       await runner.stop();

--- a/packages/jobs/src/__tests__/mcp-task.test.ts
+++ b/packages/jobs/src/__tests__/mcp-task.test.ts
@@ -1,0 +1,226 @@
+import {
+  getTestDatabase,
+  ObjectRegistry,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { afterEach, describe, expect, it } from 'vitest';
+import { backgroundEligible } from '../background-policy.js';
+import type { JobExecutionContext } from '../logger-extension.js';
+import { McpTaskStore } from '../mcp-task.js';
+import { TaskRunner } from '../runner.js';
+
+@smrt()
+class McpTaskProbe extends SmrtObject {
+  name = '';
+
+  @backgroundEligible()
+  async slow(
+    options: { value: string },
+    _context?: JobExecutionContext,
+  ): Promise<{ value: string }> {
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    return { value: options.value };
+  }
+
+  @backgroundEligible()
+  async needsInput(
+    _options: Record<string, never>,
+    context?: JobExecutionContext,
+  ): Promise<{ answer: unknown }> {
+    const answers = await context?.task?.requestInput({
+      answer: { type: 'string', description: 'A required answer' },
+    });
+    return { answer: answers?.answer };
+  }
+
+  @backgroundEligible()
+  async needsTwoInputs(
+    _options: Record<string, never>,
+    context?: JobExecutionContext,
+  ): Promise<{ first: unknown; second: unknown }> {
+    const first = await context?.task?.requestInput({
+      first: { type: 'string' },
+    });
+    const second = await context?.task?.requestInput({
+      second: { type: 'string' },
+    });
+    return { first: first?.first, second: second?.second };
+  }
+}
+
+class McpTaskProbeCollection extends SmrtCollection<McpTaskProbe> {
+  static readonly _itemClass = McpTaskProbe;
+}
+
+afterEach(() => {
+  ObjectRegistry.clearCollectionCache?.();
+});
+
+async function createProbe() {
+  ObjectRegistry.registerCollection('McpTaskProbe', McpTaskProbeCollection);
+  const db = await getTestDatabase({
+    type: 'sqlite',
+    url: ':memory:',
+    classes: ['McpTaskProbe', 'SmrtJob', 'SmrtJobEvent', 'SmrtWorker'],
+  });
+  const collection = await McpTaskProbeCollection.create({ db });
+  const probe = await collection.create({ name: 'task probe' });
+  return { db, probe };
+}
+
+async function waitFor<T>(
+  read: () => Promise<T>,
+  predicate: (value: T) => boolean,
+): Promise<T> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const value = await read();
+    if (predicate(value)) return value;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('Timed out waiting for task state');
+}
+
+describe('MCP Tasks durable jobs adapter', () => {
+  it('persists one correlated job, runs it, and returns its CallToolResult', async () => {
+    const { db, probe } = await createProbe();
+    const store = await McpTaskStore.create(db, { ownerId: 'principal-a' });
+    const created = await store.createTask({
+      objectType: 'McpTaskProbe',
+      objectId: probe.id ?? '',
+      method: 'slow',
+      invocationArgs: [{ value: 'done' }],
+    });
+
+    const correlated = await db.query(
+      'SELECT id, task_id, task_owner_id, status FROM _smrt_jobs WHERE task_id = ?',
+      created.taskId,
+    );
+    expect(correlated.rows).toHaveLength(1);
+    expect(correlated.rows[0]).toMatchObject({
+      task_id: created.taskId,
+      task_owner_id: 'principal-a',
+      status: 'pending',
+    });
+
+    const runner = new TaskRunner({
+      queues: ['mcp-tasks'],
+      pollInterval: 5,
+      concurrency: 1,
+    });
+    await runner.initialize(db);
+    await runner.start();
+    try {
+      const completed = await waitFor(
+        () => store.getTask(created.taskId),
+        (task) => task.status === 'completed',
+      );
+      expect(completed.result).toEqual({
+        content: [{ type: 'text', text: JSON.stringify({ value: 'done' }) }],
+        structuredContent: { data: { value: 'done' } },
+      });
+    } finally {
+      await runner.stop();
+    }
+  });
+
+  it('uses the same job row for cancellation and never leaves it pending', async () => {
+    const { db, probe } = await createProbe();
+    const store = await McpTaskStore.create(db, { ownerId: 'principal-a' });
+    const created = await store.createTask({
+      objectType: 'McpTaskProbe',
+      objectId: probe.id ?? '',
+      method: 'slow',
+      invocationArgs: [{ value: 'never' }],
+    });
+
+    await store.cancelTask(created.taskId);
+    const task = await store.getTask(created.taskId);
+    expect(task.status).toBe('cancelled');
+    const rows = await db.query(
+      'SELECT status FROM _smrt_jobs WHERE task_id = ?',
+      created.taskId,
+    );
+    expect(rows.rows).toEqual([{ status: 'cancelled' }]);
+  });
+
+  it('accepts only outstanding task input keys and resumes the running job', async () => {
+    const { db, probe } = await createProbe();
+    const store = await McpTaskStore.create(db, { ownerId: 'principal-a' });
+    const created = await store.createTask({
+      objectType: 'McpTaskProbe',
+      objectId: probe.id ?? '',
+      method: 'needsInput',
+      invocationArgs: [{}],
+    });
+    const runner = new TaskRunner({
+      queues: ['mcp-tasks'],
+      pollInterval: 5,
+      concurrency: 1,
+    });
+    await runner.initialize(db);
+    await runner.start();
+    try {
+      await waitFor(
+        () => store.getTask(created.taskId),
+        (task) => task.status === 'input_required',
+      );
+      await store.updateTask(created.taskId, { ignored: 'no', answer: 'yes' });
+      const completed = await waitFor(
+        () => store.getTask(created.taskId),
+        (task) => task.status === 'completed',
+      );
+      expect(completed.result).toMatchObject({
+        structuredContent: { data: { answer: 'yes' } },
+      });
+    } finally {
+      await runner.stop();
+    }
+  });
+
+  it('clears consumed input responses before requesting another input round', async () => {
+    const { db, probe } = await createProbe();
+    const store = await McpTaskStore.create(db, { ownerId: 'principal-a' });
+    const created = await store.createTask({
+      objectType: 'McpTaskProbe',
+      objectId: probe.id ?? '',
+      method: 'needsTwoInputs',
+      invocationArgs: [{}],
+    });
+    const runner = new TaskRunner({
+      queues: ['mcp-tasks'],
+      pollInterval: 5,
+      concurrency: 1,
+    });
+    await runner.initialize(db);
+    await runner.start();
+    try {
+      await waitFor(
+        () => store.getTask(created.taskId),
+        (task) => task.status === 'input_required',
+      );
+      await store.updateTask(created.taskId, { first: 'one' });
+      await waitFor(
+        async () =>
+          db.query(
+            'SELECT task_input_requests FROM _smrt_jobs WHERE task_id = ?',
+            created.taskId,
+          ),
+        (result) =>
+          String(result.rows[0]?.task_input_requests).includes('second'),
+      );
+      await store.updateTask(created.taskId, { second: 'two' });
+      const completed = await waitFor(
+        () => store.getTask(created.taskId),
+        (task) => task.status === 'completed',
+      );
+      expect(completed.result).toMatchObject({
+        structuredContent: { data: { first: 'one', second: 'two' } },
+      });
+    } finally {
+      await runner.stop();
+    }
+  });
+});

--- a/packages/jobs/src/index.ts
+++ b/packages/jobs/src/index.ts
@@ -95,6 +95,21 @@ export {
   type JobExecutionContext,
   type JobProgressInput,
 } from './logger-extension.js';
+// Durable MCP Tasks extension adapter.
+export {
+  type CreateMcpTaskInput,
+  createMcpTaskResult,
+  getMcpTaskMarker,
+  MCP_TASKS_EXTENSION,
+  type McpTask,
+  McpTaskCancelledError,
+  type McpTaskJobMarker,
+  McpTaskNotFoundError,
+  type McpTaskStatus,
+  McpTaskStore,
+  requestMcpTaskInput,
+  taskFromJob,
+} from './mcp-task.js';
 // Object extension (mixin)
 export {
   type BackgroundCapable,

--- a/packages/jobs/src/logger-extension.ts
+++ b/packages/jobs/src/logger-extension.ts
@@ -39,6 +39,16 @@ export interface JobExecutionContext {
     message: string,
     data?: Record<string, unknown>,
   ): Promise<void>;
+  /**
+   * Present only for a job created by the MCP Tasks extension. Calling this
+   * persists an input request and resolves after `tasks/update` supplies every
+   * requested key (or rejects cooperatively if the task is cancelled).
+   */
+  task?: {
+    requestInput(
+      inputRequests: Record<string, unknown>,
+    ): Promise<Record<string, unknown>>;
+  };
 }
 
 /**

--- a/packages/jobs/src/mcp-task.ts
+++ b/packages/jobs/src/mcp-task.ts
@@ -1,0 +1,397 @@
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { createId } from '@happyvertical/utils';
+import { type SmrtJob, SmrtJobCollection } from './smrt-job.js';
+
+/** The MCP Tasks extension identifier implemented by this durable adapter. */
+export const MCP_TASKS_EXTENSION = 'io.modelcontextprotocol/tasks';
+
+/** MCP task states defined by the Tasks extension. */
+export type McpTaskStatus =
+  | 'working'
+  | 'input_required'
+  | 'completed'
+  | 'cancelled'
+  | 'failed';
+
+/** Durable shape returned by `tasks/get` after the transport adds `resultType`. */
+export interface McpTask {
+  taskId: string;
+  status: McpTaskStatus;
+  createdAt: string;
+  lastUpdatedAt: string;
+  ttlMs: number;
+  pollIntervalMs?: number;
+  statusMessage?: string;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string };
+}
+
+/** Arguments passed through an MCP tool action into its backing job. */
+export interface CreateMcpTaskInput {
+  objectType: string;
+  objectId: string;
+  method: string;
+  /** Exact positional custom-action invocation produced by the MCP generator. */
+  invocationArgs: unknown[];
+  tenantId?: string | null;
+  /** Optional agent constructor configuration retained by normal background jobs. */
+  agentConfig?: Record<string, unknown>;
+  timeout?: number;
+  pollIntervalMs?: number;
+  ttlMs?: number;
+}
+
+/** Internal persisted marker distinguishing task invocations from normal jobs. */
+export interface McpTaskJobMarker {
+  invocationArgs: unknown[];
+  pollIntervalMs: number;
+  ttlMs: number;
+}
+
+/** Serialize a completed task exactly as an MCP CallToolResult. */
+export function createMcpTaskResult(result: unknown): Record<string, unknown> {
+  const publicResult = toPublicTaskData(result);
+  return {
+    content: [{ type: 'text', text: JSON.stringify(publicResult) }],
+    structuredContent: { data: publicResult },
+  };
+}
+
+/** Thrown when a task doesn't belong to the current task-store principal. */
+export class McpTaskNotFoundError extends Error {
+  constructor(taskId: string) {
+    super(`MCP task not found: ${taskId}`);
+    this.name = 'McpTaskNotFoundError';
+  }
+}
+
+/** Cooperative cancellation observed by an operation awaiting task input. */
+export class McpTaskCancelledError extends Error {
+  constructor(taskId: string) {
+    super(`MCP task was cancelled: ${taskId}`);
+    this.name = 'McpTaskCancelledError';
+  }
+}
+
+/**
+ * Durable adapter between the MCP Tasks extension and `_smrt_jobs`.
+ *
+ * A task is a projection of exactly one job row: `task_id` is a unique
+ * correlation key on the row and cancellation changes that same row. This is
+ * intentionally not a second task table, which prevents an orphaned queued
+ * job when a caller cancels an MCP task.
+ */
+export class McpTaskStore {
+  private readonly ownerId: string | null;
+
+  private constructor(
+    private readonly collection: SmrtJobCollection,
+    options: {
+      ownerId?: string | null;
+      pollIntervalMs?: number;
+      ttlMs?: number;
+    },
+  ) {
+    this.ownerId = options.ownerId ?? null;
+    this.pollIntervalMs = options.pollIntervalMs ?? 250;
+    this.ttlMs = options.ttlMs ?? 86_400_000;
+  }
+
+  readonly pollIntervalMs: number;
+  readonly ttlMs: number;
+
+  static async create(
+    db: DatabaseInterface,
+    options: {
+      ownerId?: string | null;
+      pollIntervalMs?: number;
+      ttlMs?: number;
+    } = {},
+  ): Promise<McpTaskStore> {
+    const collection = await SmrtJobCollection.create({ db });
+    return new McpTaskStore(collection, options);
+  }
+
+  /** Create one pending job and return its immediately-pollable task projection. */
+  async createTask(input: CreateMcpTaskInput): Promise<McpTask> {
+    const taskId = createId();
+    const pollIntervalMs = input.pollIntervalMs ?? this.pollIntervalMs;
+    const ttlMs = input.ttlMs ?? this.ttlMs;
+    const marker: McpTaskJobMarker = {
+      invocationArgs: input.invocationArgs,
+      pollIntervalMs,
+      ttlMs,
+    };
+    const args: Record<string, unknown> = {
+      _mcpTask: marker,
+      ...(input.agentConfig ? { _agentConfig: input.agentConfig } : {}),
+    };
+
+    const job = await this.collection.enqueueJob({
+      tenantId: input.tenantId ?? null,
+      queue: 'mcp-tasks',
+      objectType: input.objectType,
+      objectId: input.objectId,
+      method: input.method,
+      args,
+      timeout: input.timeout,
+      taskId,
+      taskOwnerId: this.ownerId,
+      taskInputRequests: null,
+      taskInputResponses: null,
+    });
+
+    return taskFromJob(job, { pollIntervalMs, ttlMs });
+  }
+
+  /** Get a task only when it belongs to this store's principal. */
+  async getTask(taskId: string): Promise<McpTask> {
+    const job = await this.findTaskJob(taskId);
+    const marker = getMcpTaskMarker(job);
+    return taskFromJob(
+      job,
+      marker ?? {
+        pollIntervalMs: this.pollIntervalMs,
+        ttlMs: this.ttlMs,
+      },
+    );
+  }
+
+  /**
+   * Persist only values requested by an outstanding `requestInput()` call.
+   * Unknown and already-consumed keys are intentionally ignored per SEP-2663.
+   */
+  async updateTask(
+    taskId: string,
+    inputResponses: Record<string, unknown>,
+  ): Promise<void> {
+    const job = await this.findTaskJob(taskId);
+    const requested = asRecord(job.taskInputRequests);
+    if (Object.keys(requested).length === 0) return;
+
+    const current = asRecord(job.taskInputResponses);
+    const accepted: Record<string, unknown> = { ...current };
+    for (const key of Object.keys(requested)) {
+      if (Object.hasOwn(inputResponses, key)) {
+        accepted[key] = inputResponses[key];
+      }
+    }
+
+    await this.collection.query(
+      `UPDATE _smrt_jobs
+          SET task_input_responses = ?, updated_at = ?
+        WHERE id = ? AND task_id = ?`,
+      [JSON.stringify(accepted), new Date().toISOString(), job.id, taskId],
+      { allowRawOnTenantScoped: true },
+    );
+  }
+
+  /**
+   * Cooperatively cancel the backing job. A completion race cannot resurrect
+   * it because TaskRunner terminal writes require `status = 'running'`.
+   */
+  async cancelTask(taskId: string): Promise<void> {
+    const job = await this.findTaskJob(taskId);
+    if (
+      job.status === 'completed' ||
+      job.status === 'failed' ||
+      job.status === 'cancelled'
+    ) {
+      return;
+    }
+
+    const now = new Date().toISOString();
+    await this.collection.query(
+      `UPDATE _smrt_jobs
+          SET status = 'cancelled', completed_at = ?, updated_at = ?
+        WHERE id = ? AND task_id = ? AND status IN ('pending', 'running')`,
+      [now, now, job.id, taskId],
+      { allowRawOnTenantScoped: true },
+    );
+  }
+
+  private async findTaskJob(taskId: string): Promise<SmrtJob> {
+    const ownerPredicate =
+      this.ownerId === null ? 'task_owner_id IS NULL' : 'task_owner_id = ?';
+    const params = this.ownerId === null ? [taskId] : [taskId, this.ownerId];
+    const jobs = await this.collection.query(
+      `SELECT * FROM _smrt_jobs WHERE task_id = ? AND ${ownerPredicate} LIMIT 1`,
+      params,
+      { allowRawOnTenantScoped: true },
+    );
+    const job = jobs[0];
+    if (!job) throw new McpTaskNotFoundError(taskId);
+    return job;
+  }
+}
+
+/** Retrieve an internal task marker without exposing it to ordinary job callers. */
+export function getMcpTaskMarker(
+  job: Pick<SmrtJob, 'args'>,
+): McpTaskJobMarker | null {
+  const marker = asRecord(asRecord(job.args)._mcpTask);
+  if (!Array.isArray(marker.invocationArgs)) return null;
+  return {
+    invocationArgs: marker.invocationArgs,
+    pollIntervalMs: asPositiveInt(marker.pollIntervalMs, 250),
+    ttlMs: asPositiveInt(marker.ttlMs, 86_400_000),
+  };
+}
+
+/**
+ * Make a task operation wait for user input. It is intentionally a method on
+ * JobExecutionContext rather than an MCP transport concern, so generated
+ * stdio and stateless HTTP share one durable input seam.
+ */
+export async function requestMcpTaskInput(
+  db: DatabaseInterface,
+  job: Pick<SmrtJob, 'id' | 'taskId' | 'workerId'>,
+  inputRequests: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const jobId = job.id;
+  const taskId = job.taskId;
+  if (!jobId || !taskId || !job.workerId) {
+    throw new Error(
+      'Task input is only available while an MCP task job is running',
+    );
+  }
+  if (Object.keys(inputRequests).length === 0) return {};
+
+  const now = new Date().toISOString();
+  await db.query(
+    `UPDATE _smrt_jobs
+        SET task_input_requests = ?, task_input_responses = NULL, updated_at = ?
+      WHERE id = ? AND task_id = ? AND worker_id = ? AND status = 'running'`,
+    JSON.stringify(inputRequests),
+    now,
+    jobId,
+    taskId,
+    job.workerId,
+  );
+
+  while (true) {
+    const result = await db.query(
+      `SELECT status, task_input_responses FROM _smrt_jobs WHERE id = ? AND task_id = ?`,
+      jobId,
+      taskId,
+    );
+    const row = result.rows[0] as
+      | { status?: string; task_input_responses?: unknown }
+      | undefined;
+    if (!row || row.status === 'cancelled')
+      throw new McpTaskCancelledError(taskId);
+    if (row.status !== 'running')
+      throw new Error(`MCP task is no longer running: ${taskId}`);
+
+    const responses = asRecord(parseJson(row.task_input_responses));
+    if (
+      Object.keys(inputRequests).every((key) => Object.hasOwn(responses, key))
+    ) {
+      const selected = Object.fromEntries(
+        Object.keys(inputRequests).map((key) => [key, responses[key]]),
+      );
+      await db.query(
+        `UPDATE _smrt_jobs
+            SET task_input_requests = NULL, updated_at = ?
+          WHERE id = ? AND task_id = ? AND worker_id = ? AND status = 'running'`,
+        new Date().toISOString(),
+        jobId,
+        taskId,
+        job.workerId,
+      );
+      return selected;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+/** Convert the job state into the flat task shape required by `tasks/get`. */
+export function taskFromJob(
+  job: SmrtJob,
+  marker: Pick<McpTaskJobMarker, 'pollIntervalMs' | 'ttlMs'>,
+): McpTask {
+  const status = taskStatusFromJob(job);
+  const createdAt = toIso(job.created_at) ?? new Date().toISOString();
+  const lastUpdatedAt = toIso(job.updated_at) ?? createdAt;
+  const task: McpTask = {
+    taskId: job.taskId ?? '',
+    status,
+    createdAt,
+    lastUpdatedAt,
+    ttlMs: marker.ttlMs,
+    pollIntervalMs: marker.pollIntervalMs,
+  };
+  if (status === 'input_required')
+    task.statusMessage = 'Waiting for required input';
+  if (status === 'cancelled') task.statusMessage = 'Task cancelled';
+  if (status === 'failed') {
+    task.statusMessage = job.lastError ?? 'Task failed';
+    task.error = { code: -32603, message: task.statusMessage };
+  }
+  if (status === 'completed' && job.taskResult) task.result = job.taskResult;
+  return task;
+}
+
+function taskStatusFromJob(job: SmrtJob): McpTaskStatus {
+  if (job.status === 'completed') return 'completed';
+  if (job.status === 'cancelled') return 'cancelled';
+  if (job.status === 'failed') return 'failed';
+  if (Object.keys(asRecord(job.taskInputRequests)).length > 0)
+    return 'input_required';
+  return 'working';
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value))
+    return {};
+  return value as Record<string, unknown>;
+}
+
+function parseJson(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return {};
+  }
+}
+
+function asPositiveInt(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+    ? value
+    : fallback;
+}
+
+function toIso(value: Date | string | null | undefined): string | undefined {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') return value;
+  return undefined;
+}
+
+/** Match generated MCP's sensitive-field-safe public serialization boundary. */
+function toPublicTaskData(
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  const publicSource = value as {
+    toPublicJSON?: (options?: Record<string, unknown>) => unknown;
+  };
+  if (typeof publicSource.toPublicJSON === 'function') {
+    return publicSource.toPublicJSON({});
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return '[Circular]';
+    seen.add(value);
+    return value.map((entry) => toPublicTaskData(entry, seen));
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return value;
+  if (seen.has(value)) return '[Circular]';
+  seen.add(value);
+  const out: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    out[key] = toPublicTaskData(nested, seen);
+  }
+  return out;
+}

--- a/packages/jobs/src/mcp-task.ts
+++ b/packages/jobs/src/mcp-task.ts
@@ -50,7 +50,10 @@ export interface McpTaskJobMarker {
 
 /** Serialize a completed task exactly as an MCP CallToolResult. */
 export function createMcpTaskResult(result: unknown): Record<string, unknown> {
-  const publicResult = toPublicTaskData(result);
+  // JSON.stringify(undefined) returns undefined rather than valid JSON. The
+  // generated MCP result boundary represents non-JSON/void action results as
+  // null, so preserve that contract in the durable task payload too.
+  const publicResult = toPublicTaskData(result) ?? null;
   return {
     content: [{ type: 'text', text: JSON.stringify(publicResult) }],
     structuredContent: { data: publicResult },

--- a/packages/jobs/src/runner.ts
+++ b/packages/jobs/src/runner.ts
@@ -8,6 +8,7 @@ import { fromConfig, type RetryDecision } from '@happyvertical/jobs';
 import { createLogger } from '@happyvertical/logger';
 import {
   getClassConfigResolvers,
+  normalizeCustomActionFailure,
   ObjectRegistry,
   resolveLazyConfig,
   type SmrtObject,
@@ -23,6 +24,11 @@ import {
   type JobExecutionContext,
   type JobProgressInput,
 } from './logger-extension.js';
+import {
+  createMcpTaskResult,
+  getMcpTaskMarker,
+  requestMcpTaskInput,
+} from './mcp-task.js';
 import { type SmrtJob, SmrtJobCollection } from './smrt-job.js';
 import { type SmrtJobEvent, SmrtJobEventCollection } from './smrt-job-event.js';
 import { SmrtWorkerCollection } from './smrt-worker.js';
@@ -420,6 +426,9 @@ export class TaskRunner extends EventEmitter {
         status: 'completed',
         completed_at: completedAt.toISOString(),
         result_pointer: result?.resultPointer ?? null,
+        task_result: result?.taskResult
+          ? JSON.stringify(result.taskResult)
+          : null,
         updated_at: completedAt.toISOString(),
       });
 
@@ -427,6 +436,7 @@ export class TaskRunner extends EventEmitter {
         job.status = 'completed';
         job.completedAt = completedAt;
         job.resultPointer = result?.resultPointer ?? null;
+        job.taskResult = result?.taskResult ?? null;
         await this.appendJobEvent(job, {
           type: 'progress',
           level: 'info',
@@ -471,7 +481,11 @@ export class TaskRunner extends EventEmitter {
   private async runWithTimeout(
     job: SmrtJob,
     captureHandle: (handle: NodeJS.Timeout) => void,
-  ): Promise<{ result?: unknown; resultPointer?: string }> {
+  ): Promise<{
+    result?: unknown;
+    resultPointer?: string;
+    taskResult?: Record<string, unknown>;
+  }> {
     if (job.timeoutBehavior === 'warn') {
       const handle = setTimeout(() => {
         this.logger.warn(
@@ -535,12 +549,15 @@ export class TaskRunner extends EventEmitter {
   /**
    * Execute a job by invoking the method on the SmrtObject
    */
-  private async executeJob(
-    job: SmrtJob,
-  ): Promise<{ result?: unknown; resultPointer?: string }> {
+  private async executeJob(job: SmrtJob): Promise<{
+    result?: unknown;
+    resultPointer?: string;
+    taskResult?: Record<string, unknown>;
+  }> {
     const runJob = async (): Promise<{
       result?: unknown;
       resultPointer?: string;
+      taskResult?: Record<string, unknown>;
     }> => {
       // Get the object class from registry
       const registeredClass = ObjectRegistry.getClass(job.objectType);
@@ -559,7 +576,12 @@ export class TaskRunner extends EventEmitter {
         string,
         unknown
       >;
-      const { _agentConfig: _, _scheduleId: __, ...methodArgs } = rawArgs;
+      const {
+        _agentConfig: _,
+        _scheduleId: __,
+        _mcpTask: ___,
+        ...methodArgs
+      } = rawArgs;
 
       // Resolve any lazy / env-derived config sentinels at execute time so
       // operators can rotate env vars without rewriting persisted schedule
@@ -656,9 +678,26 @@ export class TaskRunner extends EventEmitter {
         );
       }
 
-      const result = await method.call(instance, methodArgs, executionContext);
+      const taskMarker = getMcpTaskMarker(job);
+      const result = taskMarker
+        ? await (
+            method as (...args: unknown[]) => Promise<unknown> | unknown
+          ).call(instance, ...taskMarker.invocationArgs, executionContext)
+        : await method.call(instance, methodArgs, executionContext);
 
-      return { result };
+      // Generated custom actions use an explicit `{ ok: false, ... }` return
+      // convention. A task must surface that as a failed terminal state, not
+      // a successfully completed task whose payload happens to describe an
+      // error.
+      if (taskMarker) {
+        const failure = normalizeCustomActionFailure(result);
+        if (failure) throw new Error(failure.message);
+      }
+
+      return {
+        result,
+        ...(taskMarker ? { taskResult: createMcpTaskResult(result) } : {}),
+      };
     };
 
     if (job.tenantId) {
@@ -804,6 +843,18 @@ export class TaskRunner extends EventEmitter {
           data,
         });
       },
+      ...(job.taskId && this.db
+        ? {
+            task: {
+              requestInput: (inputRequests: Record<string, unknown>) =>
+                requestMcpTaskInput(
+                  this.db as DatabaseInterface,
+                  job,
+                  inputRequests,
+                ),
+            },
+          }
+        : {}),
     };
   }
 

--- a/packages/jobs/src/smrt-job.ts
+++ b/packages/jobs/src/smrt-job.ts
@@ -137,6 +137,32 @@ export class SmrtJob extends SmrtObject {
   @field({ type: 'text', nullable: true })
   resultPointer: string | null = null;
 
+  /**
+   * Correlation identifier for an MCP Tasks extension task.
+   *
+   * A task is deliberately represented by its backing job rather than a second
+   * queue row: every task transition therefore has exactly one durable worker
+   * target to cancel, recover, and inspect.
+   */
+  @field({ type: 'text', nullable: true, unique: true })
+  taskId: string | null = null;
+
+  /** Principal that created an MCP task, when the transport has one. */
+  @field({ type: 'text', nullable: true })
+  taskOwnerId: string | null = null;
+
+  /** Completed MCP CallToolResult, stored only for MCP task jobs. */
+  @field({ type: 'json', nullable: true })
+  taskResult: Record<string, unknown> | null = null;
+
+  /** Outstanding input requests made through JobExecutionContext.task. */
+  @field({ type: 'json', nullable: true })
+  taskInputRequests: Record<string, unknown> | null = null;
+
+  /** Accepted task input responses, keyed by the requested input name. */
+  @field({ type: 'json', nullable: true })
+  taskInputResponses: Record<string, unknown> | null = null;
+
   /** Retry strategy configuration */
   @field({ type: 'json' })
   retryStrategy: RetryStrategyConfig = {
@@ -228,6 +254,16 @@ export interface SmrtJobData {
   timeout?: number;
   timeoutBehavior?: TimeoutBehavior;
   retryStrategy?: RetryStrategyConfig;
+  /** MCP task correlation ID. Internal callers only. */
+  taskId?: string | null;
+  /** MCP task owner/principal ID. Internal callers only. */
+  taskOwnerId?: string | null;
+  /** Completed MCP CallToolResult. Internal callers only. */
+  taskResult?: Record<string, unknown> | null;
+  /** Outstanding MCP task input requests. Internal callers only. */
+  taskInputRequests?: Record<string, unknown> | null;
+  /** Accepted MCP task input responses. Internal callers only. */
+  taskInputResponses?: Record<string, unknown> | null;
 }
 
 /**

--- a/packages/mcp-conformance-fixture/README.md
+++ b/packages/mcp-conformance-fixture/README.md
@@ -3,7 +3,9 @@
 Private CI fixture for the MCP 2026-07-28 compatibility rail. The test
 generates a Tier-1 server from `MCPGenerator`, negotiates it directly over
 stdio with the exact scoped SDK v2 client, then runs the pinned official MCP
-server conformance suite against the generated server factory.
+server conformance suite against the generated server factory. It also covers
+the opt-in durable MCP tasks extension end to end, including completion and
+cancellation of its correlated job.
 
 ```bash
 pnpm --filter @happyvertical/smrt-mcp-conformance-fixture test

--- a/packages/mcp-conformance-fixture/package.json
+++ b/packages/mcp-conformance-fixture/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@happyvertical/smrt-config": "workspace:*",
     "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-jobs": "workspace:*",
     "@modelcontextprotocol/server": "2.0.0"
   },
   "devDependencies": {

--- a/packages/mcp-conformance-fixture/src/fixture-objects.ts
+++ b/packages/mcp-conformance-fixture/src/fixture-objects.ts
@@ -1,4 +1,5 @@
 import { SmrtCollection, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { backgroundEligible } from '@happyvertical/smrt-jobs';
 
 @smrt({ api: false, cli: false, mcp: { include: ['list', 'get'] } })
 export class ConformanceWidget extends SmrtObject {
@@ -43,4 +44,23 @@ export class ConformanceAnimalCollection extends SmrtCollection<ConformanceAnima
 
 export class ConformanceCatCollection extends SmrtCollection<ConformanceCat> {
   static readonly _itemClass = ConformanceCat;
+}
+
+@smrt({
+  api: false,
+  cli: false,
+  mcp: { include: ['slowGenerate'], tasks: ['slowGenerate'] },
+})
+export class ConformanceTaskWidget extends SmrtObject {
+  name = '';
+
+  @backgroundEligible()
+  async slowGenerate(options: { prompt: string }) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    return { generated: options.prompt };
+  }
+}
+
+export class ConformanceTaskWidgetCollection extends SmrtCollection<ConformanceTaskWidget> {
+  static readonly _itemClass = ConformanceTaskWidget;
 }

--- a/packages/mcp-conformance-fixture/src/generated-server-conformance.test.ts
+++ b/packages/mcp-conformance-fixture/src/generated-server-conformance.test.ts
@@ -203,6 +203,51 @@ describe('generated Tier-1 MCP 2026-07-28 conformance', () => {
     }
   });
 
+  it('rejects an invalid stdio task envelope before creating a durable job', async () => {
+    const transport = openRawStdio();
+    try {
+      const before = await fixtureDb.query(
+        'SELECT task_id FROM _smrt_jobs WHERE task_id IS NOT NULL',
+      );
+      const malformedEnvelopes = [
+        {
+          code: -32602,
+          meta: {
+            [CLIENT_CAPABILITIES_META_KEY]: {
+              extensions: { 'io.modelcontextprotocol/tasks': {} },
+            },
+          },
+        },
+        {
+          code: -32022,
+          meta: {
+            [PROTOCOL_VERSION_META_KEY]: '2025-06-18',
+            [CLIENT_CAPABILITIES_META_KEY]: {
+              extensions: { 'io.modelcontextprotocol/tasks': {} },
+            },
+          },
+        },
+      ];
+      for (const { code, meta } of malformedEnvelopes) {
+        const response = await transport.request(
+          'tools/call',
+          {
+            name: 'conformancetaskwidget_slowgenerate',
+            arguments: { id: taskWidget.id, options: { prompt: 'invalid' } },
+          },
+          { meta },
+        );
+        expect(response.error).toMatchObject({ code });
+      }
+      const jobs = await fixtureDb.query(
+        'SELECT task_id FROM _smrt_jobs WHERE task_id IS NOT NULL',
+      );
+      expect(jobs.rows).toEqual(before.rows);
+    } finally {
+      await transport.close();
+    }
+  });
+
   it('creates an advertised STI subtype through the generated runtime', async () => {
     const transport = new StdioClientTransport({
       command: tsxBin,
@@ -376,7 +421,11 @@ function openRawStdio() {
   });
 
   return {
-    request(method: string, params: Record<string, unknown>) {
+    request(
+      method: string,
+      params: Record<string, unknown>,
+      options: { meta?: Record<string, unknown> } = {},
+    ) {
       const id = ++sequence;
       const request = {
         jsonrpc: '2.0',
@@ -384,7 +433,7 @@ function openRawStdio() {
         method,
         params: {
           ...params,
-          _meta: {
+          _meta: options.meta ?? {
             [PROTOCOL_VERSION_META_KEY]: '2026-07-28',
             [CLIENT_INFO_META_KEY]: {
               name: 'generated-task-fixture',

--- a/packages/mcp-conformance-fixture/src/generated-server-conformance.test.ts
+++ b/packages/mcp-conformance-fixture/src/generated-server-conformance.test.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, spawn } from 'node:child_process';
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { MCPGenerator } from '@happyvertical/smrt-core/generators/mcp';
@@ -13,31 +13,54 @@ import {
   SERVER_INFO_META_KEY,
 } from '@modelcontextprotocol/server';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import './fixture-objects.js';
+import {
+  type ConformanceTaskWidget,
+  ConformanceTaskWidgetCollection,
+} from './fixture-objects.js';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = resolve(packageRoot, '..', '..');
 const generatedDir = join(packageRoot, '.generated-tmp');
 const generatedPath = join(generatedDir, 'index.ts');
 const generatedDatabasePath = join(generatedDir, 'fixture.sqlite');
+const generatedRegisterPath = join(generatedDir, 'fixture-register.ts');
 const tsxBin = join(repoRoot, 'node_modules', '.bin', 'tsx');
 const conformanceBin = join(packageRoot, 'node_modules', '.bin', 'conformance');
 const baselinePath = join(packageRoot, 'conformance-baseline.yml');
 let httpChild: ChildProcess | undefined;
 let mcpUrl: string;
+let fixtureDb: Awaited<ReturnType<typeof getTestDatabase>>;
 const originalDatabaseUrl = process.env.DATABASE_URL;
 const originalDatabaseType = process.env.DATABASE_TYPE;
+const originalRegisterPath = process.env.SMRT_MCP_REGISTER_PATH;
+let taskWidget: ConformanceTaskWidget;
 
 beforeAll(async () => {
   await rm(generatedDir, { force: true, recursive: true });
   await mkdir(generatedDir, { recursive: true });
-  await getTestDatabase({
+  await writeFile(
+    generatedRegisterPath,
+    "import '../src/fixture-objects.ts';\n",
+  );
+  fixtureDb = await getTestDatabase({
     type: 'sqlite',
     url: generatedDatabasePath,
-    classes: ['ConformanceAnimal', 'ConformanceCat'],
+    classes: [
+      'ConformanceAnimal',
+      'ConformanceCat',
+      'ConformanceTaskWidget',
+      'SmrtJob',
+      'SmrtJobEvent',
+      'SmrtWorker',
+    ],
   });
+  const taskWidgets = await ConformanceTaskWidgetCollection.create({
+    db: fixtureDb,
+  });
+  taskWidget = await taskWidgets.create({ name: 'generated task widget' });
   process.env.DATABASE_TYPE = 'sqlite';
   process.env.DATABASE_URL = generatedDatabasePath;
+  process.env.SMRT_MCP_REGISTER_PATH = generatedRegisterPath;
   const generator = new MCPGenerator({
     name: 'smrt-generated-conformance',
     version: '0.0.0',
@@ -105,12 +128,81 @@ afterAll(async () => {
   } else {
     process.env.DATABASE_URL = originalDatabaseUrl;
   }
+  if (originalRegisterPath === undefined) {
+    delete process.env.SMRT_MCP_REGISTER_PATH;
+  } else {
+    process.env.SMRT_MCP_REGISTER_PATH = originalRegisterPath;
+  }
   if (process.env.MCP_CONFORMANCE_KEEP_GENERATED !== 'true') {
     await rm(generatedDir, { force: true, recursive: true });
   }
 });
 
 describe('generated Tier-1 MCP 2026-07-28 conformance', () => {
+  it('creates and completes a durable task through generated stdio', async () => {
+    const transport = openRawStdio();
+    try {
+      const discover = await transport.request('server/discover', {});
+      expect(discover.result).toMatchObject({
+        capabilities: {
+          extensions: { 'io.modelcontextprotocol/tasks': {} },
+        },
+      });
+
+      const created = await transport.request('tools/call', {
+        name: 'conformancetaskwidget_slowgenerate',
+        arguments: { id: taskWidget.id, options: { prompt: 'fixture' } },
+      });
+      expect(created.result).toMatchObject({
+        resultType: 'task',
+        status: 'working',
+      });
+      const taskId = created.result.taskId as string;
+
+      let completed: any;
+      let latest: any;
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        const task = await transport.request('tasks/get', { taskId });
+        latest = task.result;
+        if (task.result?.status === 'completed') {
+          completed = task.result;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      expect(completed, JSON.stringify(latest)).toMatchObject({
+        resultType: 'complete',
+        result: { structuredContent: { data: { generated: 'fixture' } } },
+      });
+    } finally {
+      await transport.close();
+    }
+  });
+
+  it('cancels the correlated generated-stdio task without leaving a queued job', async () => {
+    const transport = openRawStdio();
+    try {
+      const created = await transport.request('tools/call', {
+        name: 'conformancetaskwidget_slowgenerate',
+        arguments: { id: taskWidget.id, options: { prompt: 'cancelled' } },
+      });
+      expect(created.error, JSON.stringify(created)).toBeUndefined();
+      const taskId = created.result.taskId as string;
+
+      const cancelled = await transport.request('tasks/cancel', { taskId });
+      expect(cancelled.result).toEqual({ resultType: 'complete' });
+      const task = await transport.request('tasks/get', { taskId });
+      expect(task.result).toMatchObject({ status: 'cancelled' });
+      const jobs = await fixtureDb.query(
+        'SELECT status FROM _smrt_jobs WHERE task_id = ?',
+        taskId,
+      );
+      expect(jobs.rows).toEqual([{ status: 'cancelled' }]);
+    } finally {
+      await transport.close();
+    }
+  });
+
   it('creates an advertised STI subtype through the generated runtime', async () => {
     const transport = new StdioClientTransport({
       command: tsxBin,
@@ -233,6 +325,88 @@ describe('generated Tier-1 MCP 2026-07-28 conformance', () => {
     expect(result.code, result.output).toBe(0);
   });
 });
+
+function openRawStdio() {
+  const child = spawn(tsxBin, [generatedPath], {
+    cwd: packageRoot,
+    env: {
+      ...process.env,
+      DATABASE_TYPE: 'sqlite',
+      DATABASE_URL: generatedDatabasePath,
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  let sequence = 0;
+  let buffer = '';
+  const pending = new Map<
+    number,
+    { resolve: (value: any) => void; reject: (error: Error) => void }
+  >();
+  child.stdout?.on('data', (chunk) => {
+    buffer += String(chunk);
+    let newline = buffer.indexOf('\n');
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline).trim();
+      buffer = buffer.slice(newline + 1);
+      if (line) {
+        try {
+          const message = JSON.parse(line) as { id?: number };
+          const request =
+            message.id === undefined ? undefined : pending.get(message.id);
+          if (request && message.id !== undefined) {
+            pending.delete(message.id);
+            request.resolve(message);
+          }
+        } catch {
+          // Stdio protocol frames are JSON only; ignore non-protocol diagnostics.
+        }
+      }
+      newline = buffer.indexOf('\n');
+    }
+  });
+  child.once('error', (error) => {
+    for (const request of pending.values()) request.reject(error);
+    pending.clear();
+  });
+  child.once('exit', (code) => {
+    if (code === 0 || pending.size === 0) return;
+    const error = new Error(`Generated MCP stdio process exited: ${code}`);
+    for (const request of pending.values()) request.reject(error);
+    pending.clear();
+  });
+
+  return {
+    request(method: string, params: Record<string, unknown>) {
+      const id = ++sequence;
+      const request = {
+        jsonrpc: '2.0',
+        id,
+        method,
+        params: {
+          ...params,
+          _meta: {
+            [PROTOCOL_VERSION_META_KEY]: '2026-07-28',
+            [CLIENT_INFO_META_KEY]: {
+              name: 'generated-task-fixture',
+              version: '0.0.0',
+            },
+            [CLIENT_CAPABILITIES_META_KEY]: {
+              extensions: { 'io.modelcontextprotocol/tasks': {} },
+            },
+          },
+        },
+      };
+      return new Promise<any>((resolve, reject) => {
+        pending.set(id, { resolve, reject });
+        child.stdin?.write(`${JSON.stringify(request)}\n`);
+      });
+    },
+    async close() {
+      child.kill('SIGTERM');
+      await new Promise<void>((resolve) => child.once('exit', () => resolve()));
+    },
+  };
+}
 
 function startHttpAdapter(): Promise<string> {
   return new Promise((resolveUrl, rejectStart) => {

--- a/packages/smrt-app-mcp/README.md
+++ b/packages/smrt-app-mcp/README.md
@@ -53,8 +53,14 @@ export const POST = mountMcpRoute(mcpServer);
 
 `mountMcpRoute` is a modern-only, fetch-style Streamable HTTP endpoint. It
 serves `server/discover`, `tools/list`, and `tools/call` with the SDK's
-2026-07-28 envelope and reports only the `tools` capability. Tool discovery is
-deterministically ordered by name. Stock MCP clients send the required
+2026-07-28 envelope. It advertises the optional
+`io.modelcontextprotocol/tasks` extension only when an allowed object enables
+MCP tasks (`mcp: { tasks: [...] }`); task-aware clients can then call
+`tasks/get`, `tasks/update`, and `tasks/cancel`. Application deployments must
+run a `TaskRunner` for the `mcp-tasks` queue. Task lifecycle operations require
+a stable authenticated principal id; include its `tenantId` in the principal
+when the application uses tenant-scoped objects. Tool discovery is deterministically
+ordered by name. Stock MCP clients send the required
 `Mcp-Method` header (and `Mcp-Name` for `tools/call`); the mount validates them
 against the JSON-RPC body and returns the protocol `HeaderMismatch` error
 (`-32020`, HTTP 400) for a missing or mismatched header.

--- a/packages/smrt-app-mcp/package.json
+++ b/packages/smrt-app-mcp/package.json
@@ -56,6 +56,8 @@
   "author": "HappyVertical",
   "dependencies": {
     "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-jobs": "workspace:*",
+    "@happyvertical/sql": "catalog:",
     "@modelcontextprotocol/server": "2.0.0"
   },
   "devDependencies": {

--- a/packages/smrt-app-mcp/src/__tests__/mcp-tasks.test.ts
+++ b/packages/smrt-app-mcp/src/__tests__/mcp-tasks.test.ts
@@ -1,0 +1,417 @@
+import {
+  getTestDatabase,
+  ObjectRegistry,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import {
+  backgroundEligible,
+  type JobExecutionContext,
+  TaskRunner,
+} from '@happyvertical/smrt-jobs';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createMcpAppServer, type McpAppPrincipal } from '../server.js';
+import { mountMcpRoute } from '../sveltekit.js';
+
+@smrt({
+  mcp: { include: ['slow', 'needsInput'], tasks: ['slow', 'needsInput'] },
+})
+class AppTaskProbe extends SmrtObject {
+  name = '';
+
+  @backgroundEligible()
+  async slow(options: { value: string }) {
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    return { value: options.value };
+  }
+
+  @backgroundEligible()
+  async needsInput(
+    _options: Record<string, never>,
+    context?: JobExecutionContext,
+  ): Promise<{ answer: unknown }> {
+    const response = await context?.task?.requestInput({
+      answer: { type: 'string', description: 'A required answer' },
+    });
+    return { answer: response?.answer };
+  }
+}
+
+class AppTaskProbeCollection extends SmrtCollection<AppTaskProbe> {
+  static readonly _itemClass = AppTaskProbe;
+}
+
+afterEach(() => {
+  ObjectRegistry.clearCollectionCache?.();
+});
+
+function taskEvent(
+  method: string,
+  params: Record<string, unknown>,
+  principal: McpAppPrincipal | null = { id: 'principal-a' },
+  options: {
+    mcpMethod?: string | null;
+    mcpName?: string | null;
+    taskCapability?: boolean;
+  } = {},
+) {
+  const url = new URL('https://example.com/api/mcp');
+  return {
+    locals: { principal },
+    url,
+    request: new Request(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'mcp-protocol-version': '2026-07-28',
+        ...(options.mcpMethod === null
+          ? {}
+          : { 'mcp-method': options.mcpMethod ?? method }),
+        ...(options.mcpName === null
+          ? {}
+          : method === 'tools/call' && typeof params.name === 'string'
+            ? { 'mcp-name': options.mcpName ?? params.name }
+            : {}),
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method,
+        params: {
+          ...params,
+          _meta: {
+            'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+            'io.modelcontextprotocol/clientInfo': {
+              name: 'app-task-test',
+              version: '0.0.0',
+            },
+            'io.modelcontextprotocol/clientCapabilities': {
+              extensions:
+                options.taskCapability === false
+                  ? {}
+                  : { 'io.modelcontextprotocol/tasks': {} },
+            },
+          },
+        },
+      }),
+    }),
+  };
+}
+
+async function waitForTaskStatus(
+  handler: ReturnType<typeof mountMcpRoute>,
+  taskId: string,
+  status: string,
+) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const response = await handler(taskEvent('tasks/get', { taskId }));
+    const body = (await response.json()) as {
+      result?: { status?: string; result?: unknown };
+    };
+    if (body.result?.status === status) return body.result;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('Timed out waiting for app MCP task completion');
+}
+
+function waitForCompleted(
+  handler: ReturnType<typeof mountMcpRoute>,
+  taskId: string,
+) {
+  return waitForTaskStatus(handler, taskId, 'completed');
+}
+
+describe('app MCP Tasks extension', () => {
+  it('advertises only when enabled and completes a task over stateless HTTP', async () => {
+    ObjectRegistry.registerCollection('AppTaskProbe', AppTaskProbeCollection);
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['AppTaskProbe', 'SmrtJob', 'SmrtJobEvent', 'SmrtWorker'],
+    });
+    const collection = await AppTaskProbeCollection.create({ db });
+    const probe = await collection.create({ name: 'app task probe' });
+    const appServer = createMcpAppServer({
+      smrtOptions: () => ({ db }),
+      serverInfo: { name: 'app-task-test', version: '0.0.0' },
+      allowedClassNames: ['AppTaskProbe'],
+    });
+    const handler = mountMcpRoute(appServer, {
+      resolvePrincipal: (event) =>
+        event.locals?.principal as { id: string } | undefined,
+    });
+    const runner = new TaskRunner({
+      queues: ['mcp-tasks'],
+      pollInterval: 5,
+      concurrency: 1,
+    });
+    await runner.initialize(db);
+    await runner.start();
+    try {
+      const discover = await handler(taskEvent('server/discover', {}));
+      expect((await discover.json()).result).toMatchObject({
+        capabilities: {
+          extensions: { 'io.modelcontextprotocol/tasks': {} },
+        },
+      });
+
+      const createdResponse = await handler(
+        taskEvent('tools/call', {
+          name: 'apptaskprobe_slow',
+          arguments: { id: probe.id, options: { value: 'finished' } },
+        }),
+      );
+      const created = (await createdResponse.json()) as {
+        result: { resultType: string; taskId: string; status: string };
+      };
+      expect(created.result).toMatchObject({
+        resultType: 'task',
+        status: 'working',
+      });
+
+      const completed = await waitForCompleted(handler, created.result.taskId);
+      expect(completed).toMatchObject({
+        resultType: 'complete',
+        result: { structuredContent: { data: { value: 'finished' } } },
+      });
+
+      const inputCreatedResponse = await handler(
+        taskEvent('tools/call', {
+          name: 'apptaskprobe_needsinput',
+          arguments: { id: probe.id, _options: {} },
+        }),
+      );
+      const inputCreated = (await inputCreatedResponse.json()) as {
+        result: { taskId: string };
+      };
+      await waitForTaskStatus(
+        handler,
+        inputCreated.result.taskId,
+        'input_required',
+      );
+      const update = await handler(
+        taskEvent('tasks/update', {
+          taskId: inputCreated.result.taskId,
+          inputResponses: { ignored: 'no', answer: 'yes' },
+        }),
+      );
+      expect((await update.json()).result).toEqual({ resultType: 'complete' });
+      const inputCompleted = await waitForCompleted(
+        handler,
+        inputCreated.result.taskId,
+      );
+      expect(inputCompleted).toMatchObject({
+        result: { structuredContent: { data: { answer: 'yes' } } },
+      });
+
+      const jobs = await db.query(
+        'SELECT task_id, status FROM _smrt_jobs WHERE task_id = ?',
+        created.result.taskId,
+      );
+      expect(jobs.rows).toEqual([
+        { task_id: created.result.taskId, status: 'completed' },
+      ]);
+    } finally {
+      await runner.stop();
+    }
+  });
+
+  it('cancels the correlated pending job through tasks/cancel', async () => {
+    ObjectRegistry.registerCollection('AppTaskProbe', AppTaskProbeCollection);
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['AppTaskProbe', 'SmrtJob', 'SmrtJobEvent', 'SmrtWorker'],
+    });
+    const collection = await AppTaskProbeCollection.create({ db });
+    const probe = await collection.create({ name: 'cancel task probe' });
+    const handler = mountMcpRoute(
+      createMcpAppServer({
+        smrtOptions: () => ({ db }),
+        serverInfo: { name: 'app-task-test', version: '0.0.0' },
+        allowedClassNames: ['AppTaskProbe'],
+      }),
+      {
+        resolvePrincipal: (event) =>
+          event.locals?.principal as { id: string } | undefined,
+      },
+    );
+    const createdResponse = await handler(
+      taskEvent('tools/call', {
+        name: 'apptaskprobe_slow',
+        arguments: { id: probe.id, options: { value: 'cancelled' } },
+      }),
+    );
+    const created = (await createdResponse.json()) as {
+      result: { taskId: string };
+    };
+    const cancelled = await handler(
+      taskEvent('tasks/cancel', { taskId: created.result.taskId }),
+    );
+    expect((await cancelled.json()).result).toEqual({ resultType: 'complete' });
+    const task = await handler(
+      taskEvent('tasks/get', { taskId: created.result.taskId }),
+    );
+    expect((await task.json()).result).toMatchObject({ status: 'cancelled' });
+  });
+
+  it('scopes task lifecycle lookups to the originating tenant and principal', async () => {
+    ObjectRegistry.registerCollection('AppTaskProbe', AppTaskProbeCollection);
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['AppTaskProbe', 'SmrtJob', 'SmrtJobEvent', 'SmrtWorker'],
+    });
+    const collection = await AppTaskProbeCollection.create({ db });
+    const probe = await collection.create({ name: 'tenant task probe' });
+    const handler = mountMcpRoute(
+      createMcpAppServer({
+        smrtOptions: () => ({ db }),
+        serverInfo: { name: 'app-task-test', version: '0.0.0' },
+        allowedClassNames: ['AppTaskProbe'],
+      }),
+      {
+        resolvePrincipal: (event) =>
+          event.locals?.principal as McpAppPrincipal | undefined,
+      },
+    );
+    const tenantA = { id: 'principal-a', tenantId: 'tenant-a' };
+    const createdResponse = await handler(
+      taskEvent(
+        'tools/call',
+        {
+          name: 'apptaskprobe_slow',
+          arguments: { id: probe.id, options: { value: 'tenant' } },
+        },
+        tenantA,
+      ),
+    );
+    const created = (await createdResponse.json()) as {
+      result: { taskId: string };
+    };
+    const persisted = await db.query(
+      'SELECT task_owner_id FROM _smrt_jobs WHERE task_id = ?',
+      created.result.taskId,
+    );
+    expect(persisted.rows).toEqual([
+      { task_owner_id: JSON.stringify(['tenant-a', 'principal-a']) },
+    ]);
+    const inaccessible = await handler(
+      taskEvent(
+        'tasks/get',
+        { taskId: created.result.taskId },
+        { id: 'principal-a', tenantId: 'tenant-b' },
+      ),
+    );
+    expect((await inaccessible.json()).error).toMatchObject({ code: -32602 });
+  });
+
+  it('requires a stable principal id before creating a task', async () => {
+    ObjectRegistry.registerCollection('AppTaskProbe', AppTaskProbeCollection);
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['AppTaskProbe', 'SmrtJob', 'SmrtJobEvent', 'SmrtWorker'],
+    });
+    const collection = await AppTaskProbeCollection.create({ db });
+    const probe = await collection.create({ name: 'anonymous task probe' });
+    const handler = mountMcpRoute(
+      createMcpAppServer({
+        smrtOptions: () => ({ db }),
+        serverInfo: { name: 'app-task-test', version: '0.0.0' },
+        allowedClassNames: ['AppTaskProbe'],
+      }),
+      {
+        resolvePrincipal: (event) =>
+          event.locals?.principal as McpAppPrincipal | undefined,
+      },
+    );
+    const anonymousPrincipal = {};
+    const discover = await handler(
+      taskEvent('server/discover', {}, anonymousPrincipal),
+    );
+    const discovered = (await discover.json()) as {
+      result: { capabilities: { extensions?: unknown } };
+    };
+    expect(discovered.result.capabilities.extensions).toBeUndefined();
+    const created = await handler(
+      taskEvent(
+        'tools/call',
+        {
+          name: 'apptaskprobe_slow',
+          arguments: { id: probe.id, options: { value: 'protected' } },
+        },
+        anonymousPrincipal,
+      ),
+    );
+    expect((await created.json()).error).toMatchObject({
+      code: -32600,
+      message: 'Authentication is required for MCP tasks.',
+    });
+  });
+
+  it('retains modern routing and client-capability gates for task requests', async () => {
+    ObjectRegistry.registerCollection('AppTaskProbe', AppTaskProbeCollection);
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['AppTaskProbe', 'SmrtJob', 'SmrtJobEvent', 'SmrtWorker'],
+    });
+    const collection = await AppTaskProbeCollection.create({ db });
+    const probe = await collection.create({ name: 'header task probe' });
+    const handler = mountMcpRoute(
+      createMcpAppServer({
+        smrtOptions: () => ({ db }),
+        serverInfo: { name: 'app-task-test', version: '0.0.0' },
+        allowedClassNames: ['AppTaskProbe'],
+      }),
+      {
+        resolvePrincipal: (event) => event.locals?.principal as { id: string },
+      },
+    );
+
+    const requests = [
+      {
+        event: taskEvent(
+          'tools/call',
+          {
+            name: 'apptaskprobe_slow',
+            arguments: { id: probe.id, options: {} },
+          },
+          { id: 'principal-a' },
+          { mcpName: null },
+        ),
+        code: -32020,
+      },
+      {
+        event: taskEvent(
+          'tools/call',
+          {
+            name: 'apptaskprobe_slow',
+            arguments: { id: probe.id, options: {} },
+          },
+          { id: 'principal-a' },
+          { mcpMethod: 'tasks/get' },
+        ),
+        code: -32020,
+      },
+      {
+        event: taskEvent(
+          'tasks/get',
+          { taskId: 'missing' },
+          { id: 'principal-a' },
+          { taskCapability: false },
+        ),
+        code: -32021,
+      },
+    ];
+
+    for (const { event, code } of requests) {
+      const response = await handler(event);
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.code).toBe(code);
+    }
+  });
+});

--- a/packages/smrt-app-mcp/src/__tests__/mcp-tasks.test.ts
+++ b/packages/smrt-app-mcp/src/__tests__/mcp-tasks.test.ts
@@ -53,7 +53,9 @@ function taskEvent(
   options: {
     mcpMethod?: string | null;
     mcpName?: string | null;
+    protocolVersionHeader?: string | null;
     taskCapability?: boolean;
+    meta?: Record<string, unknown>;
   } = {},
 ) {
   const url = new URL('https://example.com/api/mcp');
@@ -64,7 +66,12 @@ function taskEvent(
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'mcp-protocol-version': '2026-07-28',
+        ...(options.protocolVersionHeader === null
+          ? {}
+          : {
+              'mcp-protocol-version':
+                options.protocolVersionHeader ?? '2026-07-28',
+            }),
         ...(options.mcpMethod === null
           ? {}
           : { 'mcp-method': options.mcpMethod ?? method }),
@@ -80,7 +87,7 @@ function taskEvent(
         method,
         params: {
           ...params,
-          _meta: {
+          _meta: options.meta ?? {
             'io.modelcontextprotocol/protocolVersion': '2026-07-28',
             'io.modelcontextprotocol/clientInfo': {
               name: 'app-task-test',
@@ -406,6 +413,36 @@ describe('app MCP Tasks extension', () => {
         ),
         code: -32021,
       },
+      {
+        event: taskEvent(
+          'tools/call',
+          {
+            name: 'apptaskprobe_slow',
+            arguments: { id: probe.id, options: {} },
+          },
+          { id: 'principal-a' },
+          {
+            meta: {
+              'io.modelcontextprotocol/clientCapabilities': {
+                extensions: { 'io.modelcontextprotocol/tasks': {} },
+              },
+            },
+          },
+        ),
+        code: -32602,
+      },
+      {
+        event: taskEvent(
+          'tools/call',
+          {
+            name: 'apptaskprobe_slow',
+            arguments: { id: probe.id, options: {} },
+          },
+          { id: 'principal-a' },
+          { protocolVersionHeader: '2025-06-18' },
+        ),
+        code: -32020,
+      },
     ];
 
     for (const { event, code } of requests) {
@@ -413,5 +450,50 @@ describe('app MCP Tasks extension', () => {
       expect(response.status).toBe(400);
       expect((await response.json()).error.code).toBe(code);
     }
+    const taskJobs = await db.query(
+      'SELECT task_id FROM _smrt_jobs WHERE task_id IS NOT NULL',
+    );
+    expect(taskJobs.rows).toEqual([]);
+  });
+
+  it('accepts standard whitespace and Base64-encoded MCP task headers', async () => {
+    ObjectRegistry.registerCollection('AppTaskProbe', AppTaskProbeCollection);
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['AppTaskProbe', 'SmrtJob', 'SmrtJobEvent', 'SmrtWorker'],
+    });
+    const collection = await AppTaskProbeCollection.create({ db });
+    const probe = await collection.create({
+      name: 'encoded header task probe',
+    });
+    const handler = mountMcpRoute(
+      createMcpAppServer({
+        smrtOptions: () => ({ db }),
+        serverInfo: { name: 'app-task-test', version: '0.0.0' },
+        allowedClassNames: ['AppTaskProbe'],
+      }),
+      {
+        resolvePrincipal: (event) => event.locals?.principal as { id: string },
+      },
+    );
+    const response = await handler(
+      taskEvent(
+        'tools/call',
+        {
+          name: 'apptaskprobe_slow',
+          arguments: { id: probe.id, options: {} },
+        },
+        { id: 'principal-a' },
+        {
+          mcpMethod: ' \ttools/call ',
+          mcpName: ' =?base64?YXBwdGFza3Byb2JlX3Nsb3c=?= ',
+        },
+      ),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      result: { resultType: 'task', status: 'working' },
+    });
   });
 });

--- a/packages/smrt-app-mcp/src/protocol.ts
+++ b/packages/smrt-app-mcp/src/protocol.ts
@@ -11,6 +11,8 @@ import { McpAccessError } from './errors.js';
 import type { McpAppPrincipal, McpAppServer } from './server.js';
 import { compareMcpToolNames } from './tools.js';
 
+export const MCP_TASKS_EXTENSION = 'io.modelcontextprotocol/tasks';
+
 const DEFAULT_TOOL_LIST_CACHE_HINT = {
   ttlMs: 86_400_000,
   cacheScope: 'private' as const,
@@ -45,8 +47,17 @@ export function createMcpProtocolServer(
   appServer: McpAppServer,
   options: McpProtocolServerOptions = {},
 ): Server {
+  // Task lifecycle records are owner-scoped. Unlike ordinary public read-only
+  // tools, they cannot be safely exposed without a stable principal id.
+  const tasksEnabled =
+    appServer.tasksEnabled &&
+    typeof options.principal !== 'function' &&
+    Boolean(options.principal?.id);
   const server = new Server(appServer.serverInfo, {
-    capabilities: { tools: {} },
+    capabilities: {
+      tools: {},
+      ...(tasksEnabled ? { extensions: { [MCP_TASKS_EXTENSION]: {} } } : {}),
+    } as never,
     cacheHints: { 'tools/list': DEFAULT_TOOL_LIST_CACHE_HINT },
   });
 

--- a/packages/smrt-app-mcp/src/server.ts
+++ b/packages/smrt-app-mcp/src/server.ts
@@ -29,6 +29,12 @@ import {
   MCP_STABLE_CATALOG_TTL_MS,
   MCPGenerator,
 } from '@happyvertical/smrt-core/generators/mcp';
+import {
+  type McpTask,
+  McpTaskNotFoundError,
+  McpTaskStore,
+} from '@happyvertical/smrt-jobs';
+import type { DatabaseInterface } from '@happyvertical/sql';
 import { MCP_TOOL_ACCESS_DENIED_CODE, McpAccessError } from './errors.js';
 import {
   classNamePrefixes,
@@ -47,6 +53,10 @@ import {
  */
 export interface McpAppPrincipal {
   id?: string;
+  /** Tenant boundary for task ownership and generated tenant-scoped actions. */
+  tenantId?: string;
+  /** Trusted operator override for generated tenant-scoped actions. */
+  allowCrossTenant?: boolean;
   kind?: string;
   roles?: string[];
   scopes?: string[];
@@ -180,6 +190,28 @@ export interface CallToolInput {
 export interface McpAppServer {
   listTools(input: ListToolsInput): Promise<MCPTool[]>;
   callTool(input: CallToolInput): Promise<MCPResponse>;
+  /** Whether this app has any explicitly enabled Tasks extension action. */
+  hasTaskSupport?(): Promise<boolean>;
+  /** Whether a particular visible tool is task-enabled. */
+  isTaskTool?(name: string): Promise<boolean>;
+  /** Static declaration used by the protocol discovery capability surface. */
+  readonly tasksEnabled?: boolean;
+  /** Create a durable task after applying the same tool policy as tools/call. */
+  callTask?(input: CallToolInput): Promise<MCPResponse>;
+  /** Principal-scoped task lifecycle operations. */
+  getTask?(input: {
+    taskId: string;
+    principal?: McpAppPrincipal | null;
+  }): Promise<McpTask>;
+  updateTask?(input: {
+    taskId: string;
+    inputResponses: Record<string, unknown>;
+    principal?: McpAppPrincipal | null;
+  }): Promise<void>;
+  cancelTask?(input: {
+    taskId: string;
+    principal?: McpAppPrincipal | null;
+  }): Promise<void>;
   /** Cache policy for protocol tools/list responses. */
   getToolsListCacheHint?(): Promise<McpToolListCacheHint>;
   /** Read-only view of the configured server identity. */
@@ -229,6 +261,15 @@ function isTenantScopedTool(tool: MCPTool): boolean {
 }
 
 /**
+ * Scope task lookup to both the authenticated principal and its tenant. The
+ * opaque value is stored in the existing job row, so no separate task table
+ * can accidentally bypass a tenant boundary.
+ */
+function taskOwnerIdFor(principal: McpAppPrincipal): string {
+  return JSON.stringify([principal.tenantId ?? null, principal.id]);
+}
+
+/**
  * Build the app-runtime MCP server core. The returned object is intentionally
  * framework-agnostic: HTTP wrappers live in `@happyvertical/smrt-app-mcp/sveltekit`
  * and a stdio bridge lives in `@happyvertical/smrt-app-mcp/bin/smrt-mcp-bridge`.
@@ -244,6 +285,13 @@ export function createMcpAppServer(
   const requestedToolListCacheHint = configuredToolListCacheHint(
     options.toolListCache,
   );
+  const tasksEnabled = options.allowedClassNames.some((className) => {
+    const mcp = ObjectRegistry.getConfig(className).mcp;
+    return (
+      typeof mcp === 'object' &&
+      (mcp.tasks === true || (Array.isArray(mcp.tasks) && mcp.tasks.length > 0))
+    );
+  });
 
   function userForGenerator(
     principal?: McpAppPrincipal | null,
@@ -252,11 +300,33 @@ export function createMcpAppServer(
     return { id: principal.id, roles: principal.roles };
   }
 
-  function makeGenerator(principal?: McpAppPrincipal | null): MCPGenerator {
+  async function taskStoreFor(
+    principal?: McpAppPrincipal | null,
+  ): Promise<McpTaskStore> {
+    if (!principal?.id) {
+      throw new McpAccessError(
+        401,
+        'Authentication is required for MCP tasks.',
+      );
+    }
+    const db = options.smrtOptions().db as DatabaseInterface | undefined;
+    if (!db) {
+      throw new Error('MCP Tasks requires smrtOptions() to provide a database');
+    }
+    return McpTaskStore.create(db, { ownerId: taskOwnerIdFor(principal) });
+  }
+
+  function makeGenerator(
+    principal?: McpAppPrincipal | null,
+    taskStore?: McpTaskStore,
+  ): MCPGenerator {
     const user = userForGenerator(principal);
     return new MCPGenerator(options.serverInfo as MCPConfig, {
       ...options.smrtOptions(),
       user,
+      tenantId: principal?.tenantId,
+      allowCrossTenant: principal?.allowCrossTenant,
+      ...(taskStore ? { taskStore } : {}),
     });
   }
 
@@ -377,9 +447,110 @@ export function createMcpAppServer(
     });
   }
 
+  async function authorizeCall(input: CallToolInput): Promise<{
+    args: Record<string, unknown>;
+    principal: McpAppPrincipal | null;
+    tool: MCPTool;
+  }> {
+    const args = input.arguments ?? {};
+    const principal = principalForCall(input);
+    const tools = await allowedTools();
+    const tool = tools.find((candidate) => candidate.name === input.name);
+    if (!tool) throw new McpAccessError(404, 'Unknown MCP tool.');
+    const publicPatterns = principal ? undefined : getPublicPatterns();
+    if (!passesBasePolicy(tool, principal, publicPatterns)) {
+      throw new McpAccessError(
+        401,
+        `Authentication is required for MCP tool: ${input.name}`,
+      );
+    }
+    if (!(await passesToolPolicy(tool, principal))) {
+      throw new McpAccessError(403, 'MCP tool access is not permitted.', {
+        code: MCP_TOOL_ACCESS_DENIED_CODE,
+        retryable: false,
+      });
+    }
+    const assertion = workflowAssertions[input.name];
+    if (assertion) assertion(args, userForGenerator(principal) ?? null);
+    return { args, principal, tool };
+  }
+
+  async function hasTaskSupport(): Promise<boolean> {
+    const tools = await allowedTools();
+    const generator = makeGenerator();
+    for (const tool of tools) {
+      if (await generator.supportsTaskTool(tool.name)) return true;
+    }
+    return false;
+  }
+
+  async function isTaskTool(name: string): Promise<boolean> {
+    const tools = await allowedTools();
+    if (!tools.some((tool) => tool.name === name)) return false;
+    return makeGenerator().supportsTaskTool(name);
+  }
+
+  async function callTask(input: CallToolInput): Promise<MCPResponse> {
+    const { args, principal } = await authorizeCall(input);
+    const taskStore = await taskStoreFor(principal);
+    return makeGenerator(principal, taskStore).createTask({
+      method: 'tools/call',
+      params: { arguments: args, name: input.name },
+    });
+  }
+
+  async function withTaskStore<T>(
+    principal: McpAppPrincipal | null | undefined,
+    operation: (store: McpTaskStore) => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await operation(await taskStoreFor(principal));
+    } catch (error) {
+      if (error instanceof McpTaskNotFoundError) {
+        throw new McpAccessError(404, 'Unknown MCP task.');
+      }
+      throw error;
+    }
+  }
+
+  async function getTask(input: {
+    taskId: string;
+    principal?: McpAppPrincipal | null;
+  }): Promise<McpTask> {
+    return withTaskStore(input.principal, (store) =>
+      store.getTask(input.taskId),
+    );
+  }
+
+  async function updateTask(input: {
+    taskId: string;
+    inputResponses: Record<string, unknown>;
+    principal?: McpAppPrincipal | null;
+  }): Promise<void> {
+    await withTaskStore(input.principal, (store) =>
+      store.updateTask(input.taskId, input.inputResponses),
+    );
+  }
+
+  async function cancelTask(input: {
+    taskId: string;
+    principal?: McpAppPrincipal | null;
+  }): Promise<void> {
+    await withTaskStore(input.principal, (store) =>
+      store.cancelTask(input.taskId),
+    );
+  }
+
   return {
     listTools,
     callTool,
+    hasTaskSupport,
+    isTaskTool,
+    callTask,
+    getTask,
+    updateTask,
+    cancelTask,
+    tasksEnabled,
     getToolsListCacheHint,
     serverInfo: options.serverInfo,
   };

--- a/packages/smrt-app-mcp/src/sveltekit.ts
+++ b/packages/smrt-app-mcp/src/sveltekit.ts
@@ -16,7 +16,7 @@
 
 import { createMcpHandler } from '@modelcontextprotocol/server';
 import { McpAccessError } from './errors.js';
-import { createMcpProtocolServer } from './protocol.js';
+import { createMcpProtocolServer, MCP_TASKS_EXTENSION } from './protocol.js';
 import type { CallToolInput, McpAppPrincipal, McpAppServer } from './server.js';
 
 /** Minimal subset of a SvelteKit RequestEvent we actually touch. */
@@ -129,6 +129,12 @@ export function mountMcpRoute(
 ): McpSvelteKitHandler {
   return async (event) => {
     const resolved = resolveRequestPrincipal(event, options);
+    const taskResponse = await maybeHandleTaskRequest(
+      server,
+      resolved.principal,
+      event.request,
+    );
+    if (taskResponse) return taskResponse;
     const handler = createMcpHandler(
       () =>
         createMcpProtocolServer(protocolServerForRequest(server, resolved), {
@@ -146,6 +152,172 @@ export function mountMcpRoute(
     );
     return handler.fetch(event.request);
   };
+}
+
+/**
+ * The installed MCP SDK validates tools/call against a pre-Tasks result codec.
+ * Intercept the extension before the SDK handler so the regular stateless HTTP
+ * protocol stays untouched for every other method.
+ */
+async function maybeHandleTaskRequest(
+  server: McpAppServer,
+  principal: McpAppPrincipal | null,
+  request: Request,
+): Promise<Response | null> {
+  if (
+    !server.tasksEnabled ||
+    !server.hasTaskSupport ||
+    !server.callTask ||
+    !server.getTask ||
+    !server.updateTask ||
+    !server.cancelTask ||
+    request.method !== 'POST'
+  ) {
+    return null;
+  }
+  const body = (await request
+    .clone()
+    .json()
+    .catch(() => null)) as {
+    id?: string | number | null;
+    jsonrpc?: string;
+    method?: string;
+    params?: Record<string, unknown>;
+  } | null;
+  if (body?.jsonrpc !== '2.0' || body.id === undefined) return null;
+  const params = body.params ?? {};
+  const taskTool =
+    body.method === 'tools/call' &&
+    typeof params.name === 'string' &&
+    (await server.hasTaskSupport()) &&
+    (await server.isTaskTool?.(params.name)) === true;
+  const taskMethod = ['tasks/get', 'tasks/update', 'tasks/cancel'].includes(
+    body.method ?? '',
+  );
+  if (!taskTool && !taskMethod) return null;
+
+  // The SDK normally performs this modern HTTP routing validation before
+  // dispatch. Task responses are intercepted ahead of that SDK handler, so
+  // retain the same fail-closed header/body contract here.
+  const headerMismatch = taskHeaderMismatch(request, body.method, params);
+  if (headerMismatch) {
+    return jsonRpcResponse(body.id, undefined, headerMismatch, 400);
+  }
+
+  const clientCapabilities = asRecord(params._meta)[
+    'io.modelcontextprotocol/clientCapabilities'
+  ];
+  const clientSupportsTasks = Object.hasOwn(
+    asRecord(asRecord(clientCapabilities).extensions),
+    MCP_TASKS_EXTENSION,
+  );
+
+  // A synchronous fallback exists for tools/call; lifecycle methods do not.
+  if (!clientSupportsTasks && body.method === 'tools/call') return null;
+  if (!clientSupportsTasks) {
+    return jsonRpcResponse(
+      body.id,
+      undefined,
+      {
+        code: -32021,
+        message: 'Missing required client capability',
+        data: {
+          requiredCapabilities: { extensions: { [MCP_TASKS_EXTENSION]: {} } },
+        },
+      },
+      400,
+    );
+  }
+
+  try {
+    if (body.method === 'tools/call') {
+      const result = await server.callTask({
+        name: params.name as string,
+        arguments: (params.arguments as Record<string, unknown>) ?? {},
+        principal,
+      });
+      return jsonRpcResponse(body.id, result);
+    }
+    if (typeof params.taskId !== 'string') {
+      return jsonRpcResponse(body.id, undefined, {
+        code: -32602,
+        message: 'taskId is required',
+      });
+    }
+    if (body.method === 'tasks/get') {
+      const task = await server.getTask({ taskId: params.taskId, principal });
+      return jsonRpcResponse(body.id, { resultType: 'complete', ...task });
+    }
+    if (body.method === 'tasks/update') {
+      await server.updateTask({
+        taskId: params.taskId,
+        inputResponses:
+          params.inputResponses && typeof params.inputResponses === 'object'
+            ? (params.inputResponses as Record<string, unknown>)
+            : {},
+        principal,
+      });
+      return jsonRpcResponse(body.id, { resultType: 'complete' });
+    }
+    await server.cancelTask({ taskId: params.taskId, principal });
+    return jsonRpcResponse(body.id, { resultType: 'complete' });
+  } catch (error) {
+    if (error instanceof McpAccessError) {
+      const { code, retryable } = error.metadata;
+      return jsonRpcResponse(body.id, undefined, {
+        code: error.status === 404 ? -32602 : -32600,
+        message: error.message,
+        data: {
+          ...(typeof code === 'string' ? { code } : {}),
+          ...(typeof retryable === 'boolean' ? { retryable } : {}),
+        },
+      });
+    }
+    const message =
+      error instanceof Error ? error.message : 'Task operation failed';
+    return jsonRpcResponse(body.id, undefined, { code: -32602, message });
+  }
+}
+
+function taskHeaderMismatch(
+  request: Request,
+  method: string | undefined,
+  params: Record<string, unknown>,
+): { code: number; message: string } | undefined {
+  if (!method || request.headers.get('mcp-method') !== method) {
+    return {
+      code: -32020,
+      message: 'Mcp-Method header must match the JSON-RPC method.',
+    };
+  }
+  if (
+    method === 'tools/call' &&
+    request.headers.get('mcp-name') !== params.name
+  ) {
+    return {
+      code: -32020,
+      message: 'Mcp-Name header must match the tools/call name.',
+    };
+  }
+  return undefined;
+}
+
+function jsonRpcResponse(
+  id: string | number | null,
+  result?: unknown,
+  error?: { code: number; message: string; data?: unknown },
+  status = 200,
+): Response {
+  return new Response(
+    JSON.stringify({ jsonrpc: '2.0', id, ...(error ? { error } : { result }) }),
+    { status, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
 }
 
 /**

--- a/packages/smrt-app-mcp/src/sveltekit.ts
+++ b/packages/smrt-app-mcp/src/sveltekit.ts
@@ -14,7 +14,11 @@
  * ```
  */
 
-import { createMcpHandler } from '@modelcontextprotocol/server';
+import {
+  classifyInboundRequest,
+  createMcpHandler,
+  isJsonContentType,
+} from '@modelcontextprotocol/server';
 import { McpAccessError } from './errors.js';
 import { createMcpProtocolServer, MCP_TASKS_EXTENSION } from './protocol.js';
 import type { CallToolInput, McpAppPrincipal, McpAppServer } from './server.js';
@@ -166,7 +170,6 @@ async function maybeHandleTaskRequest(
 ): Promise<Response | null> {
   if (
     !server.tasksEnabled ||
-    !server.hasTaskSupport ||
     !server.callTask ||
     !server.getTask ||
     !server.updateTask ||
@@ -189,12 +192,45 @@ async function maybeHandleTaskRequest(
   const taskTool =
     body.method === 'tools/call' &&
     typeof params.name === 'string' &&
-    (await server.hasTaskSupport()) &&
     (await server.isTaskTool?.(params.name)) === true;
   const taskMethod = ['tasks/get', 'tasks/update', 'tasks/cancel'].includes(
     body.method ?? '',
   );
   if (!taskTool && !taskMethod) return null;
+
+  // Keep task requests on the SDK's protocol-validation path until their
+  // 2026 request envelope is known-good. In particular, never enqueue durable
+  // work for malformed envelopes, unsupported revisions, or non-JSON bodies.
+  // The fallback handler owns its wire-exact error response for those cases.
+  if (!isJsonContentType(request.headers.get('content-type'))) return null;
+  const classification = classifyInboundRequest({
+    httpMethod: request.method,
+    protocolVersionHeader:
+      request.headers.get('mcp-protocol-version') ?? undefined,
+    mcpMethodHeader: request.headers.get('mcp-method') ?? undefined,
+    mcpNameHeader: request.headers.get('mcp-name') ?? undefined,
+    body: body as never,
+  });
+  if (classification.kind === 'reject') {
+    return jsonRpcResponse(
+      body.id,
+      undefined,
+      {
+        code: classification.code,
+        message: classification.message,
+        ...(classification.data === undefined
+          ? {}
+          : { data: classification.data }),
+      },
+      classification.httpStatus,
+    );
+  }
+  if (
+    classification.kind !== 'modern' ||
+    classification.classification.revision !== '2026-07-28'
+  ) {
+    return null;
+  }
 
   // The SDK normally performs this modern HTTP routing validation before
   // dispatch. Task responses are intercepted ahead of that SDK handler, so
@@ -284,15 +320,23 @@ function taskHeaderMismatch(
   method: string | undefined,
   params: Record<string, unknown>,
 ): { code: number; message: string } | undefined {
-  if (!method || request.headers.get('mcp-method') !== method) {
+  if (
+    !method ||
+    normalizeHeaderValue(request.headers.get('mcp-method') ?? '') !== method
+  ) {
     return {
       code: -32020,
       message: 'Mcp-Method header must match the JSON-RPC method.',
     };
   }
+  const toolName =
+    method === 'tools/call' && typeof params.name === 'string'
+      ? params.name
+      : undefined;
+  const headerName = request.headers.get('mcp-name');
   if (
-    method === 'tools/call' &&
-    request.headers.get('mcp-name') !== params.name
+    toolName !== undefined &&
+    (headerName === null || decodeMcpHeaderValue(headerName) !== toolName)
   ) {
     return {
       code: -32020,
@@ -300,6 +344,35 @@ function taskHeaderMismatch(
     };
   }
   return undefined;
+}
+
+/** Match the SDK's RFC 9110 optional-whitespace handling for MCP headers. */
+function normalizeHeaderValue(value: string): string {
+  return value.replace(/^[\t ]+|[\t ]+$/g, '');
+}
+
+/** Decode the SDK's canonical Base64 sentinel for an MCP header value. */
+function decodeMcpHeaderValue(value: string): string | undefined {
+  const normalized = normalizeHeaderValue(value);
+  const prefix = '=?base64?';
+  if (!normalized.startsWith(prefix) || !normalized.endsWith('?=')) {
+    return normalized;
+  }
+  const encoded = normalized.slice(prefix.length, -2);
+  if (
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+      encoded,
+    )
+  ) {
+    return undefined;
+  }
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(
+      Uint8Array.from(atob(encoded), (character) => character.charCodeAt(0)),
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 function jsonRpcResponse(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1476,6 +1476,9 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
+      '@happyvertical/smrt-jobs':
+        specifier: workspace:*
+        version: link:../jobs
       '@modelcontextprotocol/server':
         specifier: 2.0.0
         version: 2.0.0
@@ -2155,6 +2158,12 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
+      '@happyvertical/smrt-jobs':
+        specifier: workspace:*
+        version: link:../jobs
+      '@happyvertical/sql':
+        specifier: ^0.85.5
+        version: 0.85.5(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@modelcontextprotocol/server':
         specifier: 2.0.0
         version: 2.0.0


### PR DESCRIPTION
## Summary

- Add opt-in durable MCP Tasks support backed by the jobs lifecycle.
- Recover and address review follow-ups: validate modern task envelopes before mutation across generated stdio and app HTTP paths, preserve SDK standard-header semantics, normalize void task results to `null`, and avoid eager task-surface discovery.
- Keep task ownership keyed to a stable principal ID; omit Tasks discovery when one is unavailable.

## Validation

- `pnpm exec vitest run --shard=3/3` in `packages/core` (rerun of the originally interrupted affected-core shard)
- Focused core MCP generator suites: 10 passing tests
- `@happyvertical/smrt-jobs`: 19 files / 124 tests; typecheck and build
- `@happyvertical/smrt-app-mcp`: 5 files / 48 tests; typecheck and build
- Generated stdio conformance: 6 passing tests; typecheck
- Core typecheck and build; `pnpm smrt dev:knowledge-check`; `pnpm audit:policy`; pre-commit and pre-push checks
- Final code review recall and gate review: clear

The prior `affected-core-tests (3/3)` failure on `a7e4641` was a self-hosted runner communication loss, with no failing assertion or test exit; this head reruns that shard locally.

Closes #2148

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019fe4b3-6eda-7043-bbab-b715416b33c6","issue":2148,"policy_revision":"1.0.0","status":"complete","validation":["core affected shard 3/3","core MCP generator specs","jobs tests/typecheck/build","app-MCP tests/typecheck/build","generated stdio conformance/typecheck","knowledge and policy checks","final review-cycle clear"]}
```