### PR TITLE
feat(fields): add field-policy usage learning loop

### DIFF
--- a/docs/content/field-policies.md
+++ b/docs/content/field-policies.md
@@ -1,0 +1,411 @@
+---
+id: field-policies
+title: Field policy
+sidebar_label: Field policy
+---
+
+# Field policy
+
+Field policy lets an application adapt a form to an organization and to an
+individual without changing the source model. It resolves a stable,
+browser-safe field policy from the model’s code seed and sparse overrides.
+
+Use it when the domain model is shared but the form should vary by tenant or
+person: an organization may make a field advanced, set a default, change its
+help text, or lock that choice; a member may then personalize only the fields
+the organization leaves available.
+
+## What is resolved
+
+A resolved field contains:
+
+- a default value, when one exists;
+- a visibility tier: <code>basic</code>, <code>advanced</code>, or <code>hidden</code>;
+- label, help, order, group, and lock state; and
+- the field’s required state.
+
+Resolution is low to high priority:
+
+| Layer | Intended owner |
+| --- | --- |
+| Code seed | Application developer |
+| App policy | Platform administrator |
+| Tenant policy, from ancestor to current tenant | Organization administrator |
+| User policy | Signed-in member |
+
+A higher layer changes only the values it supplies. A <code>null</code> column on a policy
+row inherits the lower value. Deleting a row resets that scope completely, so
+future lower-layer changes flow through again.
+
+## Start with the model
+
+The model is still the authoritative field definition. Fields must be present
+in the live object registry to be policy-addressable. Add clear descriptions
+and UI hints where the model is declared:
+
+~~~typescript
+import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+
+@smrt({ packageName: '@acme/billing' })
+export class Invoice extends SmrtObject {
+  @field({
+    required: true,
+    description: 'Shown on the customer invoice.',
+    ui: { basic: true, group: 'billing', order: 1 },
+  })
+  title = '';
+
+  @field({
+    description: 'Visible only to invoice staff.',
+    ui: { basic: false, group: 'billing', order: 2 },
+  })
+  internalNotes = '';
+}
+~~~
+
+The seed has a few useful rules:
+
+- With no <code>ui.basic: true</code> marker, every field initially appears in the basic
+  view. Once any field is marked basic, unmarked fields initially become
+  advanced. <code>basic: false</code> explicitly makes a field advanced.
+- <code>description</code> seeds help text. <code>ui.group</code> and <code>ui.order</code> organize the form.
+- <code>ui.locked: true</code> seeds an organization lock. App or tenant policy can
+  subsequently set its effective lock state.
+- A required field cannot resolve to <code>advanced</code> or <code>hidden</code> unless it has a
+  usable default. The resolver forces a required, default-less field back to
+  basic as a final safety net.
+
+Code owns the definition, type, and security classification. Policy does not
+make a system field, relationship pseudo-field, transient field, sensitive
+field, or read-permission-gated field editable.
+
+## Resolve in trusted server code
+
+Use <code>resolveFieldPolicy()</code> where the server needs to render or apply an
+effective policy. Server code can pass its already-authenticated tenant and
+user identity explicitly:
+
+~~~typescript
+import { resolveFieldPolicy } from '@happyvertical/smrt-fields';
+
+const policy = await resolveFieldPolicy(
+  '@acme/billing:Invoice',
+  {
+    tenantId: requestTenant.id,
+    userId: session.user.id,
+    db,
+  },
+);
+
+if (policy.fields.internalNotes.visibility === 'advanced') {
+  // Render it behind the form’s advanced disclosure.
+}
+~~~
+
+<code>resolveFieldPolicyExplained()</code> additionally returns the ordered
+contributions used by the gear and settings UI. Use that result for an audit or
+explanation instead of reimplementing precedence in an application.
+
+The generated browser action is <code>resolveBatch({ objectRefs })</code>. It derives
+the tenant and user solely from the authenticated ambient request context; the
+request body cannot choose another identity. A host should pass only canonical
+object refs it registered for that application—not arbitrary request input—and
+keep the generated definition registry as its allowlist.
+
+## Policy writes and reset
+
+Policy rows are deliberately sparse. Each row identifies one object field and
+one scope, and may provide any combination of default, visibility, help,
+label, order, and lock. Use server code or generated actions within an
+established authenticated tenancy context; a client must never send a target
+tenant or user id.
+
+~~~typescript
+import { FieldPolicyCollection } from '@happyvertical/smrt-fields';
+
+// Run inside a trusted tenant context for the administrator.
+// The context supplies the tenant and principal attribution.
+const policies = await FieldPolicyCollection.create({ db });
+
+await policies.create({
+  objectRef: '@acme/billing:Invoice',
+  fieldName: 'internalNotes',
+  scopeType: 'tenant',
+  visibility: 'advanced',
+  defaultValueRaw: 'Not visible to customers',
+});
+~~~
+
+Use <code>defaultValueRaw</code> when calling server APIs with a normal JavaScript
+value. The <code>defaultValue</code> property is the JSON-encoded wire channel, so a
+string must be encoded (for example, <code>JSON.stringify('Net 30')</code>). The
+browser gear handles this serialization for its generated write adapter.
+
+To reset the whole customization at a scope, delete that scope’s row. To keep a
+row while returning one property to the lower layer, set that property to
+<code>null</code>.
+
+### Permissions and scope
+
+There are two permission slugs:
+
+| Permission | Grants |
+| --- | --- |
+| <code>fields.policy.manage</code> | App- and tenant-scope policy administration |
+| <code>fields.policy.personalize</code> | The current user’s user-scope policy only |
+
+Permission is not a cross-scope selector. A tenant-context caller can operate
+only in its own tenant, and a user policy always belongs to the current user.
+A service or API-key context without a user identity cannot read or write the
+personal tier. No ambient identity means writes fail closed. Hosts should
+install and verify their authenticated principal-context middleware before
+exposing generated Field Policy routes.
+
+App and tenant scopes may set <code>locked</code>; the user scope may not. When an
+organization lock resolves true, personal writes are rejected and existing
+personal overrides are skipped. This is why a member’s form may change after an
+administrator updates a policy.
+
+## Headless Svelte adoption
+
+The Svelte package is intentionally headless. A custom form owns layout and
+controls while <code>FieldPolicyProvider</code> supplies resolved state and
+<code>PolicyField</code> supplies policy behavior:
+
+~~~svelte
+<script lang="ts">
+  import {
+    FieldPolicyProvider,
+    ModeSwitch,
+    PolicyField,
+  } from '@happyvertical/smrt-fields/svelte';
+
+  let { policy, invoice = $bindable({}) } = $props();
+</script>
+
+<FieldPolicyProvider {policy}>
+  <ModeSwitch />
+
+  <PolicyField name="title">
+    <input id="title" bind:value={invoice.title} />
+  </PolicyField>
+
+  <PolicyField name="internalNotes">
+    <textarea id="internalNotes" bind:value={invoice.internalNotes}></textarea>
+  </PolicyField>
+</FieldPolicyProvider>
+~~~
+
+<code>PolicyField</code> applies labels, help, required state, basic/advanced visibility,
+and defaults for new records. It does not overwrite a loaded record or a value
+the user cleared. Outside a provider it degrades to rendering its children, so
+an application can adopt it incrementally. Use its <code>render</code> snippet when a
+custom layout needs the resolved field data directly.
+
+## Generated ObjectForm and source registry
+
+<code>ObjectForm</code> renders the safe intersection of a generated browser field
+definition and a resolved policy. It supports either direct SSR props or an
+application-wide source registry.
+
+For the registry path, add every generated collection definition the
+application actually supports. The registry calls the generated
+<code>resolveBatch</code> action, validates the response before it drives a form, and
+fails closed with an accessible error when a definition or policy is missing.
+
+~~~svelte
+<script lang="ts">
+  import {
+    ObjectForm,
+    ObjectFormSourceProvider,
+    ObjectFormSourceRegistry,
+  } from '@happyvertical/smrt-fields/svelte';
+
+  import { collectionDefinitions, fieldPoliciesClient } from '$lib/generated';
+
+  const source = new ObjectFormSourceRegistry(fieldPoliciesClient);
+  for (const definition of Object.values(collectionDefinitions)) {
+    source.register(definition);
+  }
+
+  let invoice = $state({});
+</script>
+
+<ObjectFormSourceProvider {source}>
+  <ObjectForm
+    objectRef="@acme/billing:Invoice"
+    bind:value={invoice}
+    showModeSwitch
+  />
+</ObjectFormSourceProvider>
+~~~
+
+The browser wire types are text, integer, decimal, boolean, datetime, JSON,
+foreign-key, and cross-package-reference. There is no <code>select</code> wire type.
+For a select-like UX, preserve the actual stored type and register a
+field-specific component with <code>FieldInputRegistry.registerField()</code>.
+Reference fields intentionally use identifier inputs until the host registers
+a chooser.
+
+Use <code>policyToVisibleColumnIds(policy, columns)</code> for a matching DataTable
+view. It hides policy-hidden mapped fields while preserving computed and
+action columns; a statically hidden column remains hidden.
+
+## Gear, Focus, and the control panel
+
+The field settings gear is the per-form editing experience:
+
+1. Adapt the generated collection client’s <code>getEditorState</code>, create, update,
+   and delete calls to <code>FieldPolicyGearProvider</code>.
+2. Wrap a form in the provider.
+3. Render <code>FieldPolicyGearButton</code>, or set <code>showPolicyGear</code> on
+   <code>ObjectForm</code>.
+
+The adapter has no tenant or user parameters. Identity remains server-derived.
+The editor exposes only rows and layers the caller may edit; it does not reopen
+general policy listing.
+
+For an organization-wide destination, build the server payload with
+<code>buildFieldPolicySettingsCatalog()</code> and render it with
+<code>FieldPolicyControlPanel</code>. The host supplies its SettingsCatalog component,
+route transport, confirmation handler, and real server-side route permission.
+The control panel uses a bounded, permission-gated audit: it shows the current
+tenant’s editable rows, app summaries, and per-field counts of member
+overrides—not other members’ values.
+
+<code>fieldPolicyControlPanelNavItem()</code> creates a tenant-navigation item only when
+the caller has <code>fields.policy.manage</code>. Use
+<code>registerFieldPolicyFocusTool(shell, objectRef, tool)</code> to attach a form’s
+settings UI to an AdminShell-compatible Focus subject. Both are structural
+integration seams: Fields does not assume a particular shell or client
+transport.
+
+## Security and privacy checklist
+
+Before deploying a Field Policy UI, confirm all of the following:
+
+- The host sets a trusted authenticated principal context before generated
+  routes or server actions run.
+- The host registers and allows only the object’s canonical <code>objectRef</code> and
+  generated browser definition that it intends to serve.
+- Browser requests do not supply tenant or user identity. Use context-derived
+  generated actions for browser resolution and editing.
+- Do not create defaults for sensitive, transient, or read-permission-gated
+  fields. The package rejects them and omits those fields from browser policy
+  responses.
+- Reference defaults are UUID strings unless their field explicitly declares a
+  text id type.
+- Treat policy help, labels, and defaults as administrator-controlled content;
+  render them as text rather than executable markup.
+- Use reset and drift-prune confirmations in the control panel. They are
+  deletions and therefore cannot be undone from that UI.
+
+The package intentionally does not expose generated policy list or get
+endpoints: unscoped reads could enumerate tenant or user preferences.
+
+## Owner and member walkthrough
+
+The [SMRT SaaS starter field-policy walkthrough](https://github.com/happyvertical/smrt-saas-starter/pull/51)
+uses SMRT `0.40.61` and demonstrates a full host integration:
+
+1. An owner or organization administrator opens the field settings destination
+   and uses the gear or control panel to set organization defaults.
+2. A member sees those resolved defaults in the generated form and may make a
+   personal adjustment only when granted <code>fields.policy.personalize</code>.
+3. If the owner locks a field, the member’s edit path closes and the
+   organization policy takes effect immediately on the next resolution.
+
+## Usage learning and suggestions
+
+The optional learning loop turns recent, aggregated form usage into
+administrator-reviewed organization suggestions. It is deliberately
+suggestion-first: there is no automatic acceptance.
+
+### Capture authenticated form usage
+
+The server usage action is context-derived. Its bounded <code>entries</code> array contains
+<code>{ objectRef, fieldName, value?, matchedDefault? }</code>; it returns
+<code>{ accepted, dropped }</code>. The action requires both an ambient tenant
+and an authenticated user. It has no identity selectors in its payload, and
+anonymous/public forms do not contribute usage.
+
+For browser forms, collect and report only after the host persistence handler
+acknowledges success (returns or resolves <code>true</code>). The helper is
+deliberately fire-and-forget: a telemetry failure must not make the saved
+record look like a failed submission.
+
+~~~typescript
+import {
+  collectFieldUsageEntries,
+  reportFieldUsage,
+} from '@happyvertical/smrt-fields/svelte';
+
+const entries = collectFieldUsageEntries({
+  objectRef: '@acme/billing:Invoice',
+  values: invoice,
+  fields: {
+    title: 'text',
+    internalNotes: 'text',
+  },
+  // `policy` is the resolved policy for this object.
+  defaults: policy.fields,
+});
+
+reportFieldUsage(usageReporter, entries);
+~~~
+
+Manual hosts pass the optional <code>defaults</code> map from their resolved
+policy. This lets a count-only field report <code>matchedDefault: true</code>
+without sending its raw value. <code>ObjectForm</code> supplies that map
+automatically.
+
+<code>FieldUsageReporter</code> is a structural browser contract with
+<code>reportUsage({ entries })</code>. <code>ObjectForm</code> accepts the same
+<code>usageReporter</code> prop and reports its nonblank rendered basic and advanced
+fields only after that success acknowledgement. Hosts own the authenticated
+transport.
+
+The server validates every entry against the live registry. Unknown or
+unaddressable fields are dropped rather than trusting a stale client.
+Sensitive and read-permission-gated fields remain count-only: their values are
+not stored. The browser sends raw values only for low-cardinality boolean and
+reference fields; text, numbers, dates, and JSON are count-only signals. The
+server permits histograms only for those boolean/reference categories and, not
+a client claim, resolves defaults and decides whether a supplied value is a
+deviation.
+
+### Review suggestions
+
+Suggestion reads and decisions are manage-gated and context-derived: they
+require <code>fields.policy.manage</code> in the ambient tenant. The browser
+contract is <code>FieldPolicySuggestionAdapter</code> with
+<code>pendingSuggestions({ objectRefs? })</code>, <code>acceptSuggestion({ id })</code>,
+and <code>dismissSuggestion({ id })</code>. The host binds those methods to its
+authenticated generated client and can render the transport-neutral
+<code>FieldPolicySuggestionQueue</code>. Gear and control-panel hosts use the same
+adapter rather than assuming a route or client implementation.
+
+Pending suggestions are either:
+
+- <code>promote</code>: make a field basic in the tenant policy; or
+- <code>default</code>: apply the proposed default to the tenant policy.
+
+Accepting applies the corresponding tenant policy through the normal policy
+validation rails. Dismissing applies a 30-day cooldown by default; a host may
+request a bounded cooldown from one hour to one year. Pending, accept, and
+dismiss requests identify only the suggestion (and an optional dismiss
+cooldown), never a tenant or user.
+
+### Schedule deliberately
+
+Call <code>ensureFieldUsageLearningSchedules({ db })</code> from trusted
+deployment startup or migration code to install the two global schedules. The
+installer creates them dormant by default; enablement is a deployment decision,
+not an automatic side effect.
+
+The default maintenance schedule runs daily at 02:30 and the suggestion run
+every Monday at 03:00, both in the scheduler host’s local time. Maintenance
+keeps usage counters for 90 days and at most 100,000 rows, and removes accepted
+suggestions after 180 days. The suggestion window is 30 days: promotion needs
+five distinct users, while a default needs 10 submissions with at least 80%
+dominance. Hosts may configure these defaults when installing schedules.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -10,6 +10,7 @@ const sidebars: SidebarsConfig = {
       items: [
         { type: 'doc', id: 'data-compartmentalization' },
         { type: 'doc', id: 'dispatch' },
+        { type: 'doc', id: 'field-policies' },
       ],
     },
     {

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -1,140 +1,153 @@
 # @happyvertical/smrt-fields
 
-Layered field policy for SMRT objects: personalize per-field defaults,
-visibility tiers (basic/advanced/hidden), help text, labels, ordering, and
-org locks at app, tenant, and user scope — over the code-authored
-`@field({ ui })` seed.
+`@happyvertical/smrt-fields` lets an application adjust an object's form
+defaults, labels, help, order, visibility, and locks without changing the
+object's source. Policies layer organization and personal choices over the
+code-authored field definition.
+
+For the complete application and operator guide, see the
+[field policy guide](https://happyvertical.github.io/smrt/field-policies).
+
+## Install
+
+```bash
+pnpm add @happyvertical/smrt-fields
+```
+
+The package includes `@happyvertical/smrt-users` because policy writes and
+operator actions use its permission and tenant context services.
+
+## Define a safe code seed
+
+The decorated model remains the definition of a field. Use its description
+and `ui` hints to supply a useful first form before any policy row exists.
 
 ```typescript
-import {
-  FieldPolicy,
-  FieldPolicyCollection,
-  resolveFieldPolicy,
-  resolveFieldPolicyExplained,
-} from '@happyvertical/smrt-fields';
+import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
 
-// An org (tenant) demotes an optional field and sets a default
-const policies = await FieldPolicyCollection.create({ db });
-await policies.create({
-  objectRef: '@happyvertical/smrt-content:Article',
-  fieldName: 'summary',
-  scopeType: 'tenant',
-  tenantId,
-  visibility: 'advanced',
-  defaultValue: JSON.stringify('TBD'),
-});
+@smrt({ packageName: '@acme/billing' })
+export class Invoice extends SmrtObject {
+  @field({
+    required: true,
+    description: 'Shown on the customer invoice.',
+    ui: { basic: true, group: 'billing', order: 1 },
+  })
+  title = '';
 
-// Resolve the effective policy for a user in that tenant
-const resolved = await resolveFieldPolicy(
-  '@happyvertical/smrt-content:Article',
-  { tenantId, userId, db },
+  @field({ ui: { basic: false, group: 'billing', order: 2 } })
+  internalNotes = '';
+}
+```
+
+If no field has `ui.basic: true`, fields start in the basic view. Once at
+least one field is marked basic, unmarked fields start advanced. `group` and
+`order` are code-owned hints; `locked: true` seeds a lock that can prevent a
+personal override.
+
+## Resolve on the server
+
+Use the resolver in trusted server code when rendering SSR or applying a
+server-owned workflow. It merges code → app → tenant ancestry → user.
+
+```typescript
+import { resolveFieldPolicy } from '@happyvertical/smrt-fields';
+
+const policy = await resolveFieldPolicy(
+  '@acme/billing:Invoice',
+  { tenantId: requestTenant.id, userId: session.user.id, db },
 );
-resolved.fields.summary.visibility; // 'advanced'
 
-// Explain variant: per-layer contributions for admin/gear UIs
-const explained = await resolveFieldPolicyExplained(
-  '@happyvertical/smrt-content:Article',
-  { tenantId, userId, db },
-);
+const title = policy.fields.title;
 ```
 
-Resolution layers (low → high): code seed → app rows → tenant rows
-(hierarchy walk via the users tenant loader, or a flat fallback when an
-injected hierarchy provider cannot resolve the tenant) → user rows. A NULL column inherits
-from the lower layer; resetting a customization is a row delete.
+The client-facing generated `resolveBatch` action derives the tenant and user
+from the authenticated request context. Do not accept those identifiers from a
+browser request. It returns only fields that are safe to expose; sensitive,
+transient, and read-permission-gated fields are omitted.
 
-`@happyvertical/smrt-users` is a required runtime dependency: Field Policy
-uses its permission catalog and operation guard for every write and gear
-action. The hierarchy fallback concerns tenant ancestry only; it is not a
-users-authorization fallback.
+## Use policy-aware Svelte forms
 
-Writes are validated against the live `ObjectRegistry`: unknown
-objects/fields are rejected, defaults are type-checked, and defaults on
-`transient`/`sensitive`/`readPermission`-gated fields are refused. Required
-fields can only be demoted from `basic` when a usable default resolves —
-and the resolver re-enforces that invariant at read time.
-
-See `AGENTS.md` for the full architecture notes.
-
-## Svelte ObjectForm
-
-`@happyvertical/smrt-fields/svelte` provides provider-free generated forms.
-Pass only the generated browser field definitions and the matching resolved
-policy; `ObjectForm` renders their safe intersection, honors policy visibility
-and ordering, and keeps form state transport-neutral.
-
-```svelte
-<script lang="ts">
-  import { ObjectForm, createFieldInputRegistry } from '@happyvertical/smrt-fields/svelte';
-
-  const inputRegistry = createFieldInputRegistry();
-  // inputRegistry.registerField(objectRef, 'body', RichTextInput);
-</script>
-
-<ObjectForm {objectRef} fields={collectionDefinition.fields} {policy}
-  bind:value={record} {inputRegistry} />
-```
-
-Pass an `actions` snippet to place host controls inside the owned native form.
-The snippet renders after ObjectForm's policy-ordered fields, so a regular
-submit button keeps native Enter/click submission and ObjectForm's validation
-and `onsubmit` handling without querying the DOM.
-
-```svelte
-<ObjectForm {objectRef} fields={collectionDefinition.fields} {policy}
-  bind:value={record} onsubmit={save}>
-  {#snippet actions()}
-    <button type="submit">Save</button>
-  {/snippet}
-</ObjectForm>
-```
-
-An app can register all of its generated collection definitions once and put
-the `resolveBatch` custom-action client behind an `ObjectFormSourceProvider`.
-Then forms need only their canonical object reference; the registry validates
-the generated definition and the untyped custom-action response before it is
-rendered, failing closed with an accessible error state on a missing or
-mismatched response.
+For a custom form, provide a resolved policy with `FieldPolicyProvider` and
+wrap each input in `PolicyField`. The wrapper applies visibility, labels, help,
+and new-record defaults while preserving your markup and input component.
 
 ```svelte
 <script lang="ts">
   import {
-    ObjectForm,
-    ObjectFormSourceProvider,
-    ObjectFormSourceRegistry,
+    FieldPolicyProvider,
+    PolicyField,
   } from '@happyvertical/smrt-fields/svelte';
 
-  const source = new ObjectFormSourceRegistry(fieldPoliciesClient);
-  for (const definition of Object.values(collectionDefinitions)) source.register(definition);
+  let { policy, invoice = $bindable({}) } = $props();
 </script>
 
-<ObjectFormSourceProvider {source}>
-  <ObjectForm objectRef="@happyvertical/smrt-products:Product" bind:value={record} />
-</ObjectFormSourceProvider>
+<FieldPolicyProvider {policy}>
+  <PolicyField name="title">
+    <input id="title" bind:value={invoice.title} />
+  </PolicyField>
+</FieldPolicyProvider>
 ```
 
-The built-ins support text, integer, decimal, boolean, datetime, JSON, and
-reference identifiers. `FieldInputRegistry` is per app: a field-specific
-renderer takes precedence over a wire-type renderer. SMRT has no `select` wire
-type: keep the persisted wire type (normally `text`) and register a
-field-specific select-like renderer with `registerField(objectRef, fieldName,
-component)`. Reference fields deliberately remain provider-free identifier
-inputs unless an app registers its own chooser. `policyToVisibleColumnIds`
-adapts the same resolved policy to `DataTable` without hiding unmapped action or
-computed columns; static `column.hidden` remains authoritative.
+For generated forms, register the application's generated collection
+definitions once in an `ObjectFormSourceRegistry`, place it in an
+`ObjectFormSourceProvider`, then render an `ObjectForm` by canonical
+`objectRef`. The registry validates both the generated field definition and
+the `resolveBatch` response before rendering. See the guide for the complete
+setup, including field-specific input renderers and policy-aware tables.
 
-When a mounted create form starts another record, replace the bound record with
-an empty object or change `createSessionKey`; both begin a new default-prefill
-session without reapplying defaults after an in-form user clear.
+## Administration and personal settings
 
-## Policy settings gear
+Use `FieldPolicyGearProvider` with an adapter to the generated
+`getEditorState`, create, update, and delete actions. It derives identity on
+the server; adapter methods intentionally do not accept tenant or user ids.
+Use `FieldPolicyGearButton` or `showPolicyGear` on `ObjectForm` to expose
+the editor.
 
-`FieldPolicyGearProvider` makes the context-derived `editor-state` action
-available to any policy-aware form without choosing a client transport. Pass an
-adapter around the generated collection client's `getEditorState`, `create`,
-`update`, and `delete` calls; it must not accept tenant or user identifiers.
-Use `FieldPolicyGearButton` where the form wants its affordance, or set
-`showPolicyGear` on `ObjectForm`. `registerFieldPolicyFocusTool(shell,
-objectRef, tool)` is a structural AdminShell seam: it registers the required
-`{ type: 'object-form', id: objectRef }` subject and returns the shell's
-disposer without making Fields depend on `smrt-svelte`.
+For a settings destination, the server builds data with
+`buildFieldPolicySettingsCatalog()` and the browser renders it through
+`FieldPolicyControlPanel`. Hosts supply route, transport, confirmation, and
+AdminShell adapters. `fieldPolicyControlPanelNavItem()` and
+`registerFieldPolicyFocusTool()` are structural seams, so Fields does not
+take a dependency on a particular application shell.
+
+`fields.policy.manage` permits app and tenant administration.
+`fields.policy.personalize` permits only the current user's personal choices.
+The host must still establish a trusted authenticated principal context and
+enforce the route permission before rendering an operator destination.
+
+## Important behavior
+
+- A policy row is sparse: `null` means inherit the lower layer. Delete a row
+  to reset that scope completely.
+- `defaultValue` is the JSON-encoded wire channel. Server code with a plain
+  value should use `defaultValueRaw` or `setDefaultValue()`.
+- Required fields cannot be hidden or moved to advanced without a usable
+  resolved default. Resolution forces a required, default-less field back to
+  basic as a safety net.
+- App and tenant rows may lock a field. While the resolved organization policy
+  is locked, personal writes are rejected and old personal rows do not apply.
+- Defaults are rejected for sensitive, transient, and read-permission-gated
+  fields. Reference defaults must use a valid UUID unless that reference
+  declares a text id type.
+
+## Usage learning
+
+Optional usage capture records bounded, aggregated submissions from
+authenticated tenant members and turns qualified patterns into
+administrator-reviewed tenant-policy suggestions. It never auto-applies a
+suggestion. `ObjectForm` reports only after its host confirms persistence;
+browser values transit only for low-cardinality boolean and reference fields,
+and telemetry failures never affect the saved submit.
+
+Operators enable the dormant maintenance and suggestion schedules explicitly
+with `ensureFieldUsageLearningSchedules({ db })`. The learning loop retains
+aggregates and uses conservative thresholds; its accepted/dismissed suggestion
+queue is restricted to `fields.policy.manage`. See the
+[field policy guide](https://happyvertical.github.io/smrt/field-policies#usage-learning-and-suggestions)
+for the capture, privacy, retention, and schedule contract.
+
+## Example application
+
+The [SMRT SaaS starter field-policy walkthrough](https://github.com/happyvertical/smrt-saas-starter/pull/51)
+uses SMRT `0.40.61` and shows the owner/admin controls and the member-facing
+personal form flow in a working application.

--- a/packages/fields/src/collections/FieldPolicySuggestionCollection.ts
+++ b/packages/fields/src/collections/FieldPolicySuggestionCollection.ts
@@ -1,0 +1,813 @@
+import { SmrtCollection, smrt } from '@happyvertical/smrt-core';
+import {
+  getCurrentTenant,
+  isSuperAdminBypass,
+  TenantIsolationError,
+} from '@happyvertical/smrt-tenancy';
+import { assertOperationPermission } from '@happyvertical/smrt-users';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { invalidateFieldPolicyCache } from '../cache.js';
+import { deterministicFieldsUuid } from '../deterministic-id.js';
+import {
+  assertDefaultValueMatchesFieldType,
+  getFieldReadPermission,
+  getObjectFieldMap,
+  isSensitiveField,
+  isTransientField,
+} from '../field-definitions.js';
+import {
+  ACTIVE_SUGGESTION_KEY,
+  FieldPolicySuggestion,
+} from '../models/FieldPolicySuggestion.js';
+import { MANAGE_FIELD_POLICY_PERMISSION } from '../permissions.js';
+import type {
+  AcceptFieldPolicySuggestionResult,
+  DismissFieldPolicySuggestionResult,
+  PendingFieldPolicySuggestionsResult,
+} from '../types.js';
+
+/**
+ * Raised when a pending→settled transition loses its race: another caller
+ * (accept or dismiss) already settled the suggestion — whether the loss is
+ * detected by the compare-and-set or by the load that preceded it, so
+ * overlapping decisions get ONE error type regardless of timing.
+ *
+ * Carries BOTH `httpStatus` and `status` = 409. `httpStatus` is the property
+ * core's generated REST error mapping honors (an integer OWN property, checked
+ * with `Object.hasOwn`); `status` mirrors the users-style shape this package
+ * already uses on `FieldPolicyPermissionError`. NOTE: that mapping arrived with
+ * #2049 and is NOT in this branch's core yet, so until #2049 lands ahead of
+ * this work the generated routes still surface these as 500s — the property is
+ * set now so the 409 becomes real the moment it does.
+ */
+export class FieldPolicySuggestionConflictError extends Error {
+  /** Core's generated-REST status contract (own integer property). */
+  readonly httpStatus = 409;
+  /** The users-style shape mirrored by this package's authorization errors. */
+  readonly status = 409;
+
+  constructor(operation: string, suggestionId: string) {
+    super(
+      `${operation}: suggestion "${suggestionId}" was already decided by ` +
+        `another request (it is no longer pending)`,
+    );
+    this.name = 'FieldPolicySuggestionConflictError';
+  }
+}
+
+/** Expected generated-route denial when the suggestion queue lacks a tenant. */
+class FieldPolicySuggestionRequestContextError extends TenantIsolationError {
+  readonly httpStatus = 403;
+  readonly status = 403;
+
+  constructor(message: string, details?: { tenantId?: string }) {
+    super(message, details);
+    this.name = 'FieldPolicySuggestionRequestContextError';
+  }
+}
+
+/** Transaction handle shape (mirrors `FieldPolicy`'s identity-change path). */
+type SuggestionTransactionHandle = DatabaseInterface & {
+  commit: () => Promise<void>;
+  rollback: () => Promise<void>;
+};
+
+/** Options binding a collection to an open transaction (the sales precedent). */
+function transactionBoundOptions(db: DatabaseInterface): {
+  db: DatabaseInterface;
+  _reuseInitializedDb: boolean;
+  _deferRuntimeInitialization: boolean;
+} {
+  return {
+    db,
+    // The transaction database is the SAME initialized database on a pinned
+    // connection — skip system-table bootstrap and runtime service setup.
+    _reuseInitializedDb: true,
+    _deferRuntimeInitialization: true,
+  };
+}
+
+/**
+ * Compare-and-set the pending→settled transition: the UPDATE only applies
+ * `WHERE status = 'pending'`, so exactly one of a racing accept/dismiss pair
+ * can win. Returns whether this caller claimed it.
+ *
+ * `RETURNING id` (not a row count) is the reliable "did it apply" signal — the
+ * DuckDB/JSON adapters report an UPDATE that matched nothing as `rowCount: 1`
+ * (the jobs `writeOwnedJob` precedent).
+ *
+ * Deliberately raw SQL rather than a model save: a conditional transition is
+ * not expressible through `save()`, and routing it through the model would
+ * re-run PROPOSAL validation — which is exactly what wedges a stale suggestion
+ * (its field may since have been removed or become gated). Ownership and the
+ * manage permission are asserted by the caller before this runs.
+ */
+async function claimSuggestionTransition(
+  db: DatabaseInterface,
+  suggestionId: string,
+  patch: {
+    status: 'accepted' | 'dismissed';
+    activeKey: string;
+    decidedAt: Date;
+    decidedBy: string | null;
+    cooldownUntil: Date | null;
+  },
+): Promise<boolean> {
+  const result = await db.query(
+    `UPDATE _smrt_field_policy_suggestions
+        SET status = ?,
+            active_key = ?,
+            decided_at = ?,
+            decided_by = ?,
+            cooldown_until = ?
+      WHERE id = ? AND status = 'pending'
+      RETURNING id`,
+    patch.status,
+    patch.activeKey,
+    patch.decidedAt.toISOString(),
+    patch.decidedBy,
+    patch.cooldownUntil ? patch.cooldownUntil.toISOString() : null,
+    suggestionId,
+  );
+  return (result?.rows?.length ?? 0) > 0;
+}
+
+/**
+ * Compensating revert for drivers without transactions: put a claimed row back
+ * to `pending` after a refused policy write, so the suggestion is never left
+ * settled without its policy. The active slot was held across the whole
+ * decision, so this restores state the caller still owns.
+ */
+async function revertSuggestionToPending(
+  db: DatabaseInterface,
+  suggestionId: string,
+): Promise<void> {
+  await db.query(
+    `UPDATE _smrt_field_policy_suggestions
+        SET status = 'pending',
+            active_key = ?,
+            decided_at = NULL,
+            decided_by = NULL,
+            cooldown_until = NULL
+      WHERE id = ?`,
+    ACTIVE_SUGGESTION_KEY,
+    suggestionId,
+  );
+}
+
+/**
+ * Release the active slot after an accepted decision is fully durable: the row
+ * keys itself by its own id, so a post-cool-down regeneration may take the
+ * shared slot again while this settled row remains addressable.
+ */
+async function settleSuggestionActiveKey(
+  db: DatabaseInterface,
+  suggestionId: string,
+): Promise<void> {
+  await db.query(
+    `UPDATE _smrt_field_policy_suggestions
+        SET active_key = ?
+      WHERE id = ?`,
+    suggestionId,
+    suggestionId,
+  );
+}
+
+/**
+ * Raised when a non-transactional accept could neither complete its policy
+ * write NOR undo its claim. Both causes are carried: the row may be sitting
+ * `accepted` without a policy, which an operator must reconcile — silently
+ * reporting only the policy error would imply the suggestion is still pending.
+ */
+export class FieldPolicySuggestionCompensationError extends Error {
+  readonly httpStatus = 500;
+  readonly status = 500;
+  readonly revertCause: unknown;
+
+  constructor(suggestionId: string, cause: unknown, revertCause: unknown) {
+    super(
+      `acceptSuggestion: the policy write for suggestion "${suggestionId}" ` +
+        `failed AND reverting it to pending also failed; the suggestion may ` +
+        `be left accepted without its policy row and needs reconciliation ` +
+        `(policy error: ${cause instanceof Error ? cause.message : String(cause)}; ` +
+        `revert error: ${
+          revertCause instanceof Error
+            ? revertCause.message
+            : String(revertCause)
+        })`,
+      { cause },
+    );
+    this.name = 'FieldPolicySuggestionCompensationError';
+    this.revertCause = revertCause;
+  }
+}
+
+/**
+ * Stable id for the org-scope policy row an acceptance creates, derived from
+ * the policy natural key.
+ *
+ * With a random id, two concurrent acceptances for the same field would each
+ * mint a row and the natural-key upsert would resolve them by REPLACING one
+ * (dropping its column and dangling its id). A deterministic id turns that into
+ * a primary-key collision the loser can detect and fall back from.
+ */
+export function fieldPolicyRowId(
+  tenantId: string,
+  objectRef: string,
+  fieldName: string,
+): Promise<string> {
+  return deterministicFieldsUuid([
+    'field-policy-row',
+    'tenant',
+    tenantId,
+    objectRef,
+    fieldName,
+  ]);
+}
+
+/**
+ * Atomically set ONE column on the tenant-scope policy row for a field, keyed
+ * by the policy natural key. Returns the surviving row id, or `null` when no
+ * row exists yet.
+ *
+ * A single statement: concurrent acceptances of a `promote` and a `default`
+ * suggestion for the same field touch disjoint columns and cannot drop each
+ * other's write. `RETURNING id` (never a row count) is the reliable applied
+ * signal — some adapters report a no-match UPDATE as `rowCount: 1`.
+ */
+async function updatePolicyColumn(
+  db: DatabaseInterface,
+  target: {
+    objectRef: string;
+    fieldName: string;
+    tenantId: string;
+    column: 'visibility' | 'default_value';
+    value: string | null;
+    decidedBy: string | null;
+  },
+): Promise<string | null> {
+  const result = await db.query(
+    `UPDATE _smrt_field_policies
+        SET ${target.column} = ?,
+            updated_by = ?,
+            updated_at = ?
+      WHERE object_ref = ?
+        AND field_name = ?
+        AND scope_type = 'tenant'
+        AND tenant_id = ?
+      RETURNING id`,
+    target.value,
+    target.decidedBy,
+    new Date().toISOString(),
+    target.objectRef,
+    target.fieldName,
+    target.tenantId,
+  );
+  const rows = result?.rows ?? [];
+  const id = rows[0]?.id;
+  return id === undefined || id === null ? null : String(id);
+}
+
+/**
+ * Re-apply the stored-default security rail at ACCEPTANCE time, through the
+ * same shared helpers `FieldPolicy` and `FieldPolicySuggestion` validate with
+ * (not a copy of the rules).
+ *
+ * A suggestion is validated when queued, but a field can turn sensitive,
+ * `readPermission`-gated, transient, or change type before anyone accepts it —
+ * and the atomic column update deliberately bypasses the model, so the rail is
+ * asserted here instead of being silently skipped.
+ */
+async function assertAcceptedDefaultStillAllowed(
+  suggestion: FieldPolicySuggestion,
+): Promise<void> {
+  const fields = await getObjectFieldMap(suggestion.objectRef);
+  const fieldDef = fields.get(suggestion.fieldName);
+  if (!fieldDef) {
+    throw new Error(
+      `Unknown field "${suggestion.fieldName}" on "${suggestion.objectRef}"`,
+    );
+  }
+  if (
+    isSensitiveField(fieldDef) ||
+    getFieldReadPermission(fieldDef) !== undefined ||
+    isTransientField(fieldDef)
+  ) {
+    throw new Error(
+      `Cannot store a default for "${suggestion.objectRef}.` +
+        `${suggestion.fieldName}": the field is sensitive, ` +
+        `read-permission-gated, or transient`,
+    );
+  }
+  if (suggestion.proposedValue === null) {
+    throw new Error(
+      "FieldPolicySuggestion of kind 'default' requires a proposedValue",
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(suggestion.proposedValue);
+  } catch (error) {
+    throw new Error(
+      `FieldPolicySuggestion.proposedValue is not valid JSON: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  assertDefaultValueMatchesFieldType(
+    suggestion.objectRef,
+    suggestion.fieldName,
+    fieldDef,
+    parsed,
+  );
+}
+
+/** Default cool-down a dismissal applies (30 days). */
+export const DEFAULT_SUGGESTION_COOL_DOWN_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Bounds for a caller-supplied dismissal cool-down. */
+export const MIN_SUGGESTION_COOL_DOWN_MS = 60 * 60 * 1000; // 1 hour
+export const MAX_SUGGESTION_COOL_DOWN_MS = 365 * 24 * 60 * 60 * 1000; // 1 year
+
+/** Upper bound on objectRefs accepted by the pending filter. */
+const MAX_PENDING_OBJECT_REFS = 100;
+
+/**
+ * Collection surface for {@link FieldPolicySuggestion} plus the three
+ * manage-gated actions the gear badge / control-panel queue consume (#2051;
+ * UI integration is #2050-follow-up territory — this is the minimal seam).
+ *
+ * All three actions are custom collection-scoped routes (the resolveBatch
+ * mechanism — single-segment paths, both transports dispatch). Identity is
+ * ambient-context-only and every action requires `fields.policy.manage` (or
+ * super-admin bypass) within an ambient tenant: pending suggestions describe
+ * org-wide usage, and accept/dismiss are org policy decisions.
+ */
+@smrt({
+  // Mirror the item's active-slot natural key. The collection decorator emits
+  // another schema for the same table; omitting this would reintroduce the
+  // default `(slug, context)` unique index in generated migrations.
+  conflictColumns: [
+    'object_ref',
+    'field_name',
+    'tenant_id',
+    'kind',
+    'active_key',
+  ],
+  api: {
+    include: ['pendingSuggestions', 'acceptSuggestion', 'dismissSuggestion'],
+    // Queue reads and decisions are scoped to the authenticated principal's
+    // tenant and require fields.policy.manage; request payloads never select
+    // that identity.
+    principalContext: true,
+    routes: {
+      pendingSuggestions: {
+        scope: 'collection',
+        method: 'POST',
+        path: 'pending',
+      },
+      acceptSuggestion: {
+        scope: 'collection',
+        method: 'POST',
+        path: 'accept',
+      },
+      dismissSuggestion: {
+        scope: 'collection',
+        method: 'POST',
+        path: 'dismiss',
+      },
+    },
+  },
+  cli: false,
+  mcp: false,
+})
+export class FieldPolicySuggestionCollection extends SmrtCollection<FieldPolicySuggestion> {
+  static readonly _itemClass = FieldPolicySuggestion;
+
+  /**
+   * The caller's tenant's PENDING suggestions (optionally filtered to a set
+   * of objectRefs), newest first, plus the total for the gear badge.
+   */
+  async pendingSuggestions(
+    options: { objectRefs?: string[] } = {},
+  ): Promise<PendingFieldPolicySuggestionsResult> {
+    const tenantId = await this.requireManageContext('pendingSuggestions');
+    const objectRefs = normalizeObjectRefsFilter(options.objectRefs);
+
+    const where: Record<string, unknown> = { tenantId, status: 'pending' };
+    if (objectRefs) {
+      where['objectRef in'] = objectRefs;
+    }
+    const rows = await this.list({ where, orderBy: 'created_at DESC' });
+
+    return {
+      suggestions: rows.map((row) => row.toSuggestionData()),
+      total: rows.length,
+    };
+  }
+
+  /**
+   * Accept a pending suggestion: CLAIM the pending→accepted transition, then
+   * write the corresponding org-scope `FieldPolicy` row THROUGH NORMAL
+   * VALIDATION (registry check, type check, security rail, required-field
+   * invariant, ownership boundary, and the #2049 permission split — the
+   * ambient caller must hold `fields.policy.manage`, which this action also
+   * asserts up front).
+   *
+   * An existing tenant row for the same `(objectRef, fieldName)` is UPDATED
+   * (read-modify-write), preserving its other sparse columns — never
+   * duplicated through the natural-key upsert.
+   *
+   * Concurrency: the claim is a compare-and-set on `status` (the jobs
+   * `writeOwnedJob` precedent — a guarded UPDATE with `RETURNING id`), so an
+   * overlapping accept/dismiss pair cannot both win; the loser throws
+   * {@link FieldPolicySuggestionConflictError} (409). Claim and policy write
+   * run in ONE transaction when the driver supports it, so a rejected policy
+   * write can never leave the suggestion settled without its policy (and vice
+   * versa). Drivers without transactions get an explicit compensating revert.
+   */
+  async acceptSuggestion(
+    options: { id?: string } = {},
+  ): Promise<AcceptFieldPolicySuggestionResult> {
+    const tenantId = await this.requireManageContext('acceptSuggestion');
+    const suggestion = await this.loadOwnedPendingSuggestion(
+      'acceptSuggestion',
+      options.id,
+      tenantId,
+    );
+    const suggestionId = String(suggestion.id);
+    const decidedBy = getCurrentTenant()?.userId ?? null;
+    const decidedAt = new Date();
+
+    const claim = {
+      status: 'accepted' as const,
+      activeKey: suggestionId,
+      decidedAt,
+      decidedBy,
+      cooldownUntil: null,
+    };
+
+    const tx = await this.beginTransactionIfSupported();
+    if (tx) {
+      let policyRowId: string;
+      try {
+        const claimed = await claimSuggestionTransition(
+          tx,
+          suggestionId,
+          claim,
+        );
+        if (!claimed) {
+          throw new FieldPolicySuggestionConflictError(
+            'acceptSuggestion',
+            suggestionId,
+          );
+        }
+        policyRowId = await this.applyAcceptedPolicy(
+          tx,
+          suggestion,
+          tenantId,
+          decidedBy,
+        );
+        await tx.commit();
+      } catch (error) {
+        try {
+          await tx.rollback();
+        } catch {
+          // Preserve the original failure; rollback errors are secondary.
+        }
+        throw error;
+      }
+      // The policy save inside the transaction invalidated the resolver cache
+      // under the TRANSACTION handle's namespace, which is not the app db's —
+      // so the committed change would otherwise stay invisible for the cache
+      // TTL. Re-invalidate against this collection's db now that it is durable.
+      invalidateFieldPolicyCache(suggestion.objectRef, this.db);
+      suggestion.status = 'accepted';
+      suggestion.decidedAt = decidedAt;
+      suggestion.decidedBy = decidedBy;
+      return { suggestion: suggestion.toSuggestionData(), policyRowId };
+    }
+
+    // No transaction support (e.g. a transaction VIEW, which exposes
+    // `transaction` but not `beginTransaction`). Claim in TWO steps so the
+    // identity's active slot is never free while the decision is in flight:
+    //
+    //   1. flip `status` to accepted but KEEP `activeKey = 'active'` — the
+    //      compare-and-set still makes exactly one decision win, while the
+    //      unique index keeps holding the slot, so generation running in this
+    //      window cannot insert a fresh pending suggestion that would then
+    //      collide with the compensation (and be resolved against the stale
+    //      pre-acceptance policy);
+    //   2. only AFTER the policy write succeeds, settle the key to the row's
+    //      id, releasing the slot for a future post-cool-down regeneration.
+    //
+    // A refused policy write therefore reverts into a slot nothing else can
+    // have taken. Generation's suppression keys off the slot (not `status`)
+    // precisely so step 1 suppresses it.
+    const claimed = await claimSuggestionTransition(this.db, suggestionId, {
+      ...claim,
+      activeKey: ACTIVE_SUGGESTION_KEY,
+    });
+    if (!claimed) {
+      throw new FieldPolicySuggestionConflictError(
+        'acceptSuggestion',
+        suggestionId,
+      );
+    }
+    let policyRowId: string;
+    try {
+      policyRowId = await this.applyAcceptedPolicy(
+        this.db,
+        suggestion,
+        tenantId,
+        decidedBy,
+      );
+    } catch (error) {
+      // Compensate back to pending. The slot was held throughout, so a
+      // collision here is not an expected race — it means the row was mutated
+      // underneath us and the compensation did NOT restore it. Surface that
+      // instead of swallowing it: the caller must not be told the suggestion
+      // is still pending when it may be stuck accepted-without-policy.
+      try {
+        await revertSuggestionToPending(this.db, suggestionId);
+      } catch (revertError) {
+        throw new FieldPolicySuggestionCompensationError(
+          suggestionId,
+          error,
+          revertError,
+        );
+      }
+      throw error;
+    }
+
+    // Release the slot now that the policy is durable.
+    await settleSuggestionActiveKey(this.db, suggestionId);
+    // The atomic column update bypasses the model, so it does not invalidate
+    // the resolver cache the way `FieldPolicy.save()` does — do it here so org
+    // forms shift immediately on this path too.
+    invalidateFieldPolicyCache(suggestion.objectRef, this.db);
+
+    suggestion.status = 'accepted';
+    suggestion.decidedAt = decidedAt;
+    suggestion.decidedBy = decidedBy;
+    return { suggestion: suggestion.toSuggestionData(), policyRowId };
+  }
+
+  /**
+   * Dismiss a pending suggestion: set status + a cool-down until which the
+   * generation job will NOT regenerate the same
+   * `(objectRef, fieldName, tenantId, kind)` suggestion.
+   *
+   * Validates OWNERSHIP and PENDING STATUS ONLY — deliberately NOT continued
+   * proposal eligibility. A queued suggestion whose field has since been
+   * removed, turned sensitive/`readPermission`-gated/transient, or retyped is
+   * exactly the row an operator most needs to clear; re-running proposal
+   * validation on the way out would reject the dismissal and, because pending
+   * rows are never pruned, wedge it in the queue forever. The claim is the same
+   * compare-and-set as accept, so it also bypasses the model's proposal
+   * validation by construction.
+   */
+  async dismissSuggestion(
+    options: { id?: string; coolDownMs?: number } = {},
+  ): Promise<DismissFieldPolicySuggestionResult> {
+    const tenantId = await this.requireManageContext('dismissSuggestion');
+    const suggestion = await this.loadOwnedPendingSuggestion(
+      'dismissSuggestion',
+      options.id,
+      tenantId,
+    );
+    const suggestionId = String(suggestion.id);
+    const coolDownMs = normalizeCoolDownMs(options.coolDownMs);
+    const decidedAt = new Date();
+    const decidedBy = getCurrentTenant()?.userId ?? null;
+    const cooldownUntil = new Date(decidedAt.getTime() + coolDownMs);
+
+    const claimed = await claimSuggestionTransition(this.db, suggestionId, {
+      status: 'dismissed',
+      activeKey: suggestionId,
+      decidedAt,
+      decidedBy,
+      cooldownUntil,
+    });
+    if (!claimed) {
+      throw new FieldPolicySuggestionConflictError(
+        'dismissSuggestion',
+        suggestionId,
+      );
+    }
+
+    suggestion.status = 'dismissed';
+    suggestion.cooldownUntil = cooldownUntil;
+    suggestion.decidedAt = decidedAt;
+    suggestion.decidedBy = decidedBy;
+    return { suggestion: suggestion.toSuggestionData() };
+  }
+
+  /**
+   * Write the org-scope policy column an accepted suggestion implies, bound to
+   * `db` so it participates in the caller's transaction.
+   *
+   * A `promote` and a `default` suggestion for the SAME field share one sparse
+   * `FieldPolicy` row but own DIFFERENT columns, and both may be accepted
+   * concurrently. A read-modify-save of the whole row therefore loses updates:
+   * each acceptance reads the row (or its absence) before the other's save
+   * lands, and the later full-row write erases the sibling's column — and, via
+   * the natural-key upsert, can even replace the row id, dangling the earlier
+   * caller's `policyRowId`. (Distinct from the suggestion-row race fixed
+   * earlier: that one guards the pending→settled transition; this one is on the
+   * shared policy row.) So this NEVER writes a whole row over an existing one:
+   *
+   * 1. An ATOMIC partial UPDATE sets only this acceptance's column, keyed by
+   *    the policy natural key and `RETURNING id` — one statement, so no
+   *    interleaving can drop the sibling's column, and the returned id is
+   *    always the surviving row.
+   * 2. Only when no row exists yet does it CREATE through the model, so full
+   *    validation (registry, type check, security rail, required-field
+   *    invariant, ownership + permission split) runs on the row that is
+   *    actually inserted. The row carries a DETERMINISTIC id under strict
+   *    insert, so two concurrent creates cannot each mint a row: the loser
+   *    collides and falls back to step 1, applying only its own column.
+   *
+   * The update path skips the model, so the value rail is re-checked here
+   * through the SHARED helpers the models use (a field can turn sensitive or
+   * gated between a suggestion being queued and accepted). Promotion to `basic`
+   * needs no such check: the required-field invariant restricts only
+   * advanced/hidden, and org locks constrain the user tier, not org rows.
+   */
+  private async applyAcceptedPolicy(
+    db: DatabaseInterface,
+    suggestion: FieldPolicySuggestion,
+    tenantId: string,
+    decidedBy: string | null,
+  ): Promise<string> {
+    if (suggestion.kind === 'default') {
+      await assertAcceptedDefaultStillAllowed(suggestion);
+    }
+
+    const target = {
+      objectRef: suggestion.objectRef,
+      fieldName: suggestion.fieldName,
+      tenantId,
+      column:
+        suggestion.kind === 'promote'
+          ? ('visibility' as const)
+          : ('default_value' as const),
+      value: suggestion.kind === 'promote' ? 'basic' : suggestion.proposedValue,
+      decidedBy,
+    };
+
+    const updatedId = await updatePolicyColumn(db, target);
+    if (updatedId) {
+      return updatedId;
+    }
+
+    // Dynamic import breaks the module cycle risk with the policy model
+    // family (mirrors the resolver/collection seams in this package).
+    const { FieldPolicyCollection } = await import(
+      './FieldPolicyCollection.js'
+    );
+    const policies = await FieldPolicyCollection.create(
+      transactionBoundOptions(db),
+    );
+    const deterministicId = await fieldPolicyRowId(
+      tenantId,
+      suggestion.objectRef,
+      suggestion.fieldName,
+    );
+
+    try {
+      const created = await policies.create({
+        id: deterministicId,
+        objectRef: suggestion.objectRef,
+        fieldName: suggestion.fieldName,
+        scopeType: 'tenant',
+        tenantId,
+        ...(suggestion.kind === 'promote'
+          ? { visibility: 'basic' as const }
+          : { defaultValue: suggestion.proposedValue }),
+        updatedBy: decidedBy,
+        // Strict insert: a concurrent acceptance that already created the row
+        // must NOT be adopted-and-overwritten (that is the lost update).
+        _insertOnly: true,
+      });
+      return String(created.id);
+    } catch (error) {
+      // Someone created the row between the update and the insert. Apply just
+      // this acceptance's column to the surviving row.
+      const racedId = await updatePolicyColumn(db, target);
+      if (racedId) {
+        return racedId;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * A driver transaction handle, or `null` when the driver has none (the
+   * `FieldPolicy.saveAfterIdentityChange` probe, same shape).
+   */
+  private async beginTransactionIfSupported(): Promise<SuggestionTransactionHandle | null> {
+    if (typeof this.db.beginTransaction !== 'function') {
+      return null;
+    }
+    const tx = (await this.db.beginTransaction()) as
+      | SuggestionTransactionHandle
+      | undefined;
+    return tx ?? null;
+  }
+
+  /**
+   * Ambient manage gate shared by the three actions: an ambient tenant
+   * context is required (no context ⇒ no identity ⇒ fail closed — the
+   * suggestion queue is never an anonymous surface), and the caller must hold
+   * `fields.policy.manage` unless running under super-admin bypass.
+   */
+  private async requireManageContext(action: string): Promise<string> {
+    const context = getCurrentTenant();
+    if (!context?.tenantId) {
+      throw new FieldPolicySuggestionRequestContextError(
+        `${action} requires an ambient tenant context (fail closed): the ` +
+          'suggestion queue is scoped to the caller tenant',
+      );
+    }
+    if (!isSuperAdminBypass()) {
+      await assertOperationPermission({
+        collection: 'fields.policy',
+        action: MANAGE_FIELD_POLICY_PERMISSION.split('.').at(-1) ?? 'manage',
+        db: this.db,
+        tenantId: context.tenantId,
+        userId: context.userId ?? null,
+        permissionSet: context.permissions,
+      });
+    }
+    return context.tenantId;
+  }
+
+  private async loadOwnedPendingSuggestion(
+    action: string,
+    id: string | undefined,
+    tenantId: string,
+  ): Promise<FieldPolicySuggestion> {
+    if (typeof id !== 'string' || id.trim() === '') {
+      throw new Error(`${action} requires a suggestion "id" string`);
+    }
+    const suggestion = await this.get(id);
+    if (!suggestion) {
+      throw new Error(`${action}: no suggestion found for id "${id}"`);
+    }
+    if (suggestion.tenantId !== tenantId) {
+      throw new TenantIsolationError(
+        `Tenant isolation violation in ${action}: the suggestion belongs to ` +
+          `another tenant`,
+        {
+          tenantId,
+          attemptedTenantId: suggestion.tenantId ?? undefined,
+        },
+      );
+    }
+    if (suggestion.status !== 'pending') {
+      // The SAME conflict the compare-and-set raises: whether a competing
+      // decision landed before this request read the row or after, the caller
+      // sees one error type (and one status) instead of a different failure
+      // per interleaving.
+      throw new FieldPolicySuggestionConflictError(action, id);
+    }
+    return suggestion;
+  }
+}
+
+function normalizeObjectRefsFilter(
+  rawRefs: string[] | undefined,
+): string[] | null {
+  if (rawRefs === undefined) {
+    return null;
+  }
+  if (!Array.isArray(rawRefs) || rawRefs.length === 0) {
+    throw new Error(
+      'pendingSuggestions "objectRefs" must be a non-empty string array when provided',
+    );
+  }
+  if (rawRefs.some((ref) => typeof ref !== 'string' || ref.trim() === '')) {
+    throw new Error('pendingSuggestions objectRefs must be non-empty strings');
+  }
+  const objectRefs = [...new Set(rawRefs)];
+  if (objectRefs.length > MAX_PENDING_OBJECT_REFS) {
+    throw new Error(
+      `pendingSuggestions accepts at most ${MAX_PENDING_OBJECT_REFS} ` +
+        `objectRefs per call (got ${objectRefs.length})`,
+    );
+  }
+  return objectRefs;
+}
+
+function normalizeCoolDownMs(raw: number | undefined): number {
+  if (raw === undefined) {
+    return DEFAULT_SUGGESTION_COOL_DOWN_MS;
+  }
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+    throw new Error('dismissSuggestion coolDownMs must be a finite number');
+  }
+  return Math.min(
+    Math.max(raw, MIN_SUGGESTION_COOL_DOWN_MS),
+    MAX_SUGGESTION_COOL_DOWN_MS,
+  );
+}

--- a/packages/fields/src/collections/FieldPolicySuggestionCollection.ts
+++ b/packages/fields/src/collections/FieldPolicySuggestionCollection.ts
@@ -12,6 +12,7 @@ import {
   assertDefaultValueMatchesFieldType,
   getFieldReadPermission,
   getObjectFieldMap,
+  isPolicyAddressableField,
   isSensitiveField,
   isTransientField,
 } from '../field-definitions.js';
@@ -281,24 +282,7 @@ async function updatePolicyColumn(
 async function assertAcceptedDefaultStillAllowed(
   suggestion: FieldPolicySuggestion,
 ): Promise<void> {
-  const fields = await getObjectFieldMap(suggestion.objectRef);
-  const fieldDef = fields.get(suggestion.fieldName);
-  if (!fieldDef) {
-    throw new Error(
-      `Unknown field "${suggestion.fieldName}" on "${suggestion.objectRef}"`,
-    );
-  }
-  if (
-    isSensitiveField(fieldDef) ||
-    getFieldReadPermission(fieldDef) !== undefined ||
-    isTransientField(fieldDef)
-  ) {
-    throw new Error(
-      `Cannot store a default for "${suggestion.objectRef}.` +
-        `${suggestion.fieldName}": the field is sensitive, ` +
-        `read-permission-gated, or transient`,
-    );
-  }
+  const fieldDef = await assertAcceptedPolicyTargetStillAllowed(suggestion);
   if (suggestion.proposedValue === null) {
     throw new Error(
       "FieldPolicySuggestion of kind 'default' requires a proposedValue",
@@ -319,6 +303,32 @@ async function assertAcceptedDefaultStillAllowed(
     fieldDef,
     parsed,
   );
+}
+
+/** Re-check every policy-addressability rail before an atomic acceptance write. */
+async function assertAcceptedPolicyTargetStillAllowed(
+  suggestion: FieldPolicySuggestion,
+) {
+  const fields = await getObjectFieldMap(suggestion.objectRef);
+  const fieldDef = fields.get(suggestion.fieldName);
+  if (!fieldDef || !isPolicyAddressableField(fieldDef)) {
+    throw new Error(
+      `Field "${suggestion.fieldName}" on "${suggestion.objectRef}" ` +
+        `is not policy-addressable`,
+    );
+  }
+  if (
+    isSensitiveField(fieldDef) ||
+    getFieldReadPermission(fieldDef) !== undefined ||
+    isTransientField(fieldDef)
+  ) {
+    throw new Error(
+      `Cannot apply a policy for "${suggestion.objectRef}.` +
+        `${suggestion.fieldName}": the field is sensitive, ` +
+        `read-permission-gated, or transient`,
+    );
+  }
+  return fieldDef;
 }
 
 /** Default cool-down a dismissal applies (30 days). */
@@ -627,11 +637,12 @@ export class FieldPolicySuggestionCollection extends SmrtCollection<FieldPolicyS
    *    insert, so two concurrent creates cannot each mint a row: the loser
    *    collides and falls back to step 1, applying only its own column.
    *
-   * The update path skips the model, so the value rail is re-checked here
-   * through the SHARED helpers the models use (a field can turn sensitive or
-   * gated between a suggestion being queued and accepted). Promotion to `basic`
-   * needs no such check: the required-field invariant restricts only
-   * advanced/hidden, and org locks constrain the user tier, not org rows.
+   * The update path skips the model, so BOTH kinds re-check live target
+   * addressability through the shared helpers (a field can turn sensitive,
+   * gated, transient, or disappear between queueing and acceptance). Defaults
+   * additionally re-check their value/type rail; a promotion to `basic` has no
+   * value payload, and the required-field invariant restricts only
+   * advanced/hidden. Org locks constrain the user tier, not org rows.
    */
   private async applyAcceptedPolicy(
     db: DatabaseInterface,
@@ -641,6 +652,8 @@ export class FieldPolicySuggestionCollection extends SmrtCollection<FieldPolicyS
   ): Promise<string> {
     if (suggestion.kind === 'default') {
       await assertAcceptedDefaultStillAllowed(suggestion);
+    } else {
+      await assertAcceptedPolicyTargetStillAllowed(suggestion);
     }
 
     const target = {

--- a/packages/fields/src/collections/FieldUsageCounterCollection.ts
+++ b/packages/fields/src/collections/FieldUsageCounterCollection.ts
@@ -1,0 +1,591 @@
+import { SmrtCollection, smrt } from '@happyvertical/smrt-core';
+import {
+  getCurrentTenant,
+  TenantIsolationError,
+} from '@happyvertical/smrt-tenancy';
+import { deterministicFieldsUuid } from '../deterministic-id.js';
+import {
+  type FieldDefinitionMap,
+  getFieldReadPermission,
+  getObjectFieldMap,
+  isSensitiveField,
+  isStorableReferenceId,
+  isTransientField,
+  type RegisteredFieldInfo,
+} from '../field-definitions.js';
+import {
+  FieldUsageCounter,
+  fieldUsagePeriodForDate,
+  MAX_VALUE_HISTOGRAM_KEY_LENGTH,
+} from '../models/FieldUsageCounter.js';
+import { FieldUsageReportReceipt } from '../models/FieldUsageReportReceipt.js';
+import type {
+  FieldUsageReportEntry,
+  FieldUsageReportResult,
+  ResolvedFieldPolicy,
+} from '../types.js';
+
+/**
+ * Deviation comparison: strict equality, then a JSON round-trip so structured
+ * and Date-shaped values compare by serialization. Mirrors the browser-side
+ * `usageValuesEqual` (the packaging boundary bars value imports across the
+ * subpath split — the permission-slug precedent); a node test pins the two
+ * behaviours equal.
+ */
+export function usageValuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Per-call bound on reported entries — the rate rail for the fire-and-forget
+ * ingestion action (the resolveBatch precedent). Mirrored browser-side by
+ * `src/svelte/usage-capture.ts` (`USAGE_REPORT_BATCH_LIMIT`); a node test
+ * pins the two equal.
+ */
+export const MAX_USAGE_REPORT_ENTRIES = 100;
+
+/** Expected generated-route denial for a missing trusted report principal. */
+class FieldUsageRequestContextError extends TenantIsolationError {
+  readonly httpStatus = 403;
+  readonly status = 403;
+
+  constructor(message: string, details?: { tenantId?: string }) {
+    super(message, details);
+    this.name = 'FieldUsageRequestContextError';
+  }
+}
+
+/**
+ * Collection surface for {@link FieldUsageCounter} plus the batched usage
+ * ingestion action (#2051).
+ *
+ * `reportUsage` is a custom collection-scoped action (the resolveBatch
+ * mechanism — single-segment path, so the generated SvelteKit transport AND
+ * core's runtime `APIGenerator` both dispatch it). Everything else is CLOSED:
+ * no generated CRUD, no CLI, no MCP — counters are written only through this
+ * action and read only by trusted server-side code (the learning jobs).
+ */
+@smrt({
+  // A decorated collection emits its own schema for the item's table. Mirror
+  // the model natural key so manifest-driven migrations cannot add the
+  // fallback `(slug, context)` unique index to this shared system table.
+  conflictColumns: ['object_ref', 'field_name', 'tenant_id', 'period'],
+  api: {
+    include: ['reportUsage'],
+    // The action derives tenant/user exclusively from the authenticated
+    // request context; generated routes must establish that context before
+    // dispatching it (the FieldPolicyCollection precedent).
+    principalContext: true,
+    routes: {
+      reportUsage: {
+        scope: 'collection',
+        method: 'POST',
+        path: 'report',
+      },
+    },
+  },
+  cli: false,
+  mcp: false,
+})
+export class FieldUsageCounterCollection extends SmrtCollection<FieldUsageCounter> {
+  static readonly _itemClass = FieldUsageCounter;
+
+  /**
+   * Record a batch of field submissions into the current UTC-day counters.
+   *
+   * Identity is AMBIENT-ONLY (the resolveBatch posture): the tenant AND the
+   * user come exclusively from the tenant context established by the app's
+   * auth hook — the request body cannot attribute usage to another tenant or
+   * user. Both are REQUIRED and the call fails closed without them (#2047
+   * round-3 posture):
+   *
+   * - No ambient tenant ⇒ the report is unattributable.
+   * - No ambient USER ⇒ the caller is an unauthenticated principal (a
+   *   deployment that resolves the tenant from host/header alone). Such
+   *   callers could otherwise inflate counts and histograms without bound
+   *   (the batch cap is per call), and `distinctUsers` — the promote signal —
+   *   is meaningless without a principal. Consequence, accepted deliberately:
+   *   ANONYMOUS/PUBLIC FORMS DO NOT CONTRIBUTE USAGE. The learning loop is
+   *   for authenticated org users.
+   *
+   * Any authenticated in-tenant principal may report (no manage slug needed).
+   * A durable receipt admits at most one `(tenant, user, object, field, UTC
+   * day)` contribution, and the batch stays bounded per call
+   * ({@link MAX_USAGE_REPORT_ENTRIES}).
+   *
+   * Server-side derivation (the client is never the authority):
+   * - Fields are validated against the live `ObjectRegistry`; unknown or
+   *   non-usage-addressable entries (system, relationship pseudo-fields, STI
+   *   meta storage, transient) are DROPPED and counted, never failing the
+   *   batch (stale clients after a redeploy are expected).
+   * - Sensitivity comes from BOTH `field.sensitive` and `field._meta.sensitive`
+   *   (and `readPermission` in both places): such fields are recorded
+   *   COUNT-ONLY — their values are never persisted anywhere in usage data,
+   *   default-matching or not.
+   * - DEVIATION (`setCount`, distinct users) is decided by comparing the
+   *   submitted value against the default RESOLVED HERE for the calling
+   *   identity — never against a client claim. Every accepted entry also
+   *   increments `submissionCount`, the dominance denominator.
+   * - Values are histogrammed only for low-cardinality field types
+   *   (`boolean`, `foreignKey`, `crossPackageRef`) with type-checked samples;
+   *   free text is never histogrammed.
+   *
+   * Bounded trust in `matchedDefault`: an entry may omit `value` entirely
+   * (`collectFieldUsageEntries({ includeValues: false })` — apps that prefer
+   * no value transit). Only then is the entry's `matchedDefault` flag read, to
+   * decide the deviation bit alone. It can never create a histogram entry,
+   * never bypass the count-only rail, and never manufacture distinct users
+   * beyond the caller's own id. The once-per-field/day receipt means a lying
+   * client gets only one such contribution, so repeated POSTs cannot inflate
+   * thresholds or steer a `default` suggestion.
+   */
+  async reportUsage(
+    options: { entries?: FieldUsageReportEntry[] } = {},
+  ): Promise<FieldUsageReportResult> {
+    const entries = validateEntriesInput(options.entries);
+
+    const context = getCurrentTenant();
+    const tenantId = context?.tenantId;
+    if (!tenantId) {
+      throw new FieldUsageRequestContextError(
+        'reportUsage requires an ambient tenant context: usage is ' +
+          'unattributable without one, so the call fails closed',
+      );
+    }
+    const userId = context.userId;
+    if (!userId) {
+      throw new FieldUsageRequestContextError(
+        'reportUsage requires an ambient AUTHENTICATED user: an ' +
+          'unauthenticated caller could inflate counters without bound and ' +
+          'distinct-user thresholds are meaningless without a principal, so ' +
+          'the call fails closed (anonymous forms do not contribute usage)',
+        { tenantId },
+      );
+    }
+    const period = fieldUsagePeriodForDate(new Date());
+    const receipts = await FieldUsageReportReceiptCollection.create({
+      db: this.db,
+    });
+
+    // Group by (objectRef, fieldName) so one bucket row is touched once per
+    // batch (bounds registry and db work per call).
+    const groups = new Map<string, Map<string, FieldUsageReportEntry[]>>();
+    for (const entry of entries) {
+      let byField = groups.get(entry.objectRef);
+      if (!byField) {
+        byField = new Map<string, FieldUsageReportEntry[]>();
+        groups.set(entry.objectRef, byField);
+      }
+      const samples = byField.get(entry.fieldName);
+      if (samples) {
+        samples.push(entry);
+      } else {
+        byField.set(entry.fieldName, [entry]);
+      }
+    }
+
+    let accepted = 0;
+    let dropped = 0;
+
+    for (const [objectRef, byField] of groups) {
+      let fieldMap: FieldDefinitionMap;
+      try {
+        fieldMap = await getObjectFieldMap(objectRef);
+      } catch {
+        for (const samples of byField.values()) {
+          dropped += samples.length;
+        }
+        continue;
+      }
+
+      const resolvedFields = await this.resolveDefaultsForCaller(
+        objectRef,
+        tenantId,
+        userId,
+      );
+      if (!resolvedFields) {
+        // Defaults are the deviation authority; without them every entry
+        // would have to be guessed. Drop the group rather than guess.
+        for (const samples of byField.values()) {
+          dropped += samples.length;
+        }
+        continue;
+      }
+
+      for (const [fieldName, samples] of byField) {
+        const fieldDef = fieldMap.get(fieldName);
+        if (!fieldDef || !isUsageAddressableField(fieldDef)) {
+          dropped += samples.length;
+          continue;
+        }
+
+        // The durable receipt is the rate rail: at most ONE sample from this
+        // user can influence this field's evidence per UTC day, even across
+        // repeated requests or concurrent app replicas. Claim it only after
+        // registry validation, so a stale/unknown field cannot burn a valid
+        // field's daily allowance. Repeated reports are intentionally ignored
+        // (not reported as `dropped`, which is reserved for stale entries).
+        if (
+          !(await receipts.claim({
+            tenantId,
+            userId,
+            objectRef,
+            fieldName,
+            period,
+          }))
+        ) {
+          continue;
+        }
+
+        // Batches can carry more than one value for a field, but the same
+        // daily rule applies within one request too. The first sample is the
+        // one durable contribution for this member/day/field.
+        const sample = samples[0];
+
+        const countOnly =
+          isSensitiveField(fieldDef) ||
+          getFieldReadPermission(fieldDef) !== undefined;
+        const histogramEligible =
+          !countOnly && isHistogramEligibleField(fieldDef);
+        const resolved = resolvedFields[fieldName];
+        const hasDefault = resolved?.hasDefault === true;
+        const defaultValue = hasDefault ? resolved?.defaultValue : undefined;
+
+        let deviations = 0;
+        const histogramKeys: string[] = [];
+        if ('value' in sample) {
+          // Server-derived deviation: the resolved default is the authority.
+          if (!hasDefault || !usageValuesEqual(sample.value, defaultValue)) {
+            deviations += 1;
+          }
+          if (histogramEligible) {
+            const key = serializeHistogramSample(fieldDef, sample.value);
+            if (key !== null) {
+              histogramKeys.push(key);
+            }
+          }
+        } else if (sample.matchedDefault !== true) {
+          // Value-less entry: only the deviation bit is taken from the
+          // client hint (see the bounded-trust note above).
+          deviations += 1;
+        }
+
+        await this.mergeIntoBucket({
+          objectRef,
+          fieldName,
+          tenantId,
+          period,
+          userId,
+          submissionCount: 1,
+          deviationCount: deviations,
+          histogramKeys,
+        });
+        accepted += 1;
+      }
+    }
+
+    return { accepted, dropped };
+  }
+
+  /**
+   * The defaults the CALLER's forms would have prefilled — the deviation
+   * authority. Resolved for the ambient `(tenant, user)` identity (the
+   * resolver's own TTL cache keeps repeat batches cheap).
+   *
+   * Ingestion is fire-and-forget, so a stored-layer read failure degrades to
+   * the CODE-SEED-only resolution (no db) rather than failing the request;
+   * `null` (both attempts failed) makes the caller drop the group.
+   */
+  private async resolveDefaultsForCaller(
+    objectRef: string,
+    tenantId: string,
+    userId: string,
+  ): Promise<Record<string, ResolvedFieldPolicy> | undefined | null> {
+    // Dynamic import mirrors the resolver seams elsewhere in this package
+    // (the resolver statically imports the policy collection).
+    const { resolveFieldPolicy } = await import('../field-policy-resolver.js');
+    try {
+      const resolved = await resolveFieldPolicy(objectRef, {
+        tenantId,
+        userId,
+        db: this.db,
+      });
+      return resolved.fields;
+    } catch {
+      try {
+        const seedOnly = await resolveFieldPolicy(objectRef, {
+          tenantId,
+          userId,
+        });
+        return seedOnly.fields;
+      } catch {
+        return null;
+      }
+    }
+  }
+
+  /**
+   * Counter rows within a period window (inclusive bounds, lexicographic ISO
+   * day comparison), optionally restricted to one tenant — the read the
+   * suggestion-generation job consumes.
+   */
+  async listWindow(options: {
+    fromPeriod: string;
+    toPeriod?: string;
+    tenantId?: string | null;
+  }): Promise<FieldUsageCounter[]> {
+    const where: Record<string, unknown> = {
+      'period >=': options.fromPeriod,
+    };
+    if (options.toPeriod) {
+      where['period <='] = options.toPeriod;
+    }
+    if (options.tenantId) {
+      where.tenantId = options.tenantId;
+    }
+    return this.list({ where, orderBy: 'period ASC' });
+  }
+
+  /**
+   * Idempotent read-modify-write merge into the deterministic day bucket.
+   * Counters are approximate by design: concurrent cross-process merges may
+   * lose an increment (documented on the model), while the deterministic id
+   * plus the natural-key unique index keep concurrent creates converging on
+   * one row.
+   */
+  private async mergeIntoBucket(options: {
+    objectRef: string;
+    fieldName: string;
+    tenantId: string;
+    period: string;
+    userId: string;
+    /** Every observed submission (the dominance denominator). */
+    submissionCount: number;
+    /** Submissions that differed from the resolved default. */
+    deviationCount: number;
+    histogramKeys: string[];
+  }): Promise<void> {
+    const id = await fieldUsageCounterId(
+      options.tenantId,
+      options.objectRef,
+      options.fieldName,
+      options.period,
+    );
+
+    const existing = await this.get(id);
+    const counter =
+      existing ??
+      new FieldUsageCounter({
+        db: this.db,
+        id,
+        objectRef: options.objectRef,
+        fieldName: options.fieldName,
+        tenantId: options.tenantId,
+        period: options.period,
+      });
+
+    counter.submissionCount += options.submissionCount;
+    counter.setCount += options.deviationCount;
+    // Distinct users track the PROMOTE signal: only a caller who actually set
+    // a non-default value counts as "actively filling this field in".
+    if (options.deviationCount > 0) {
+      counter.addDistinctUser(options.userId);
+    }
+    for (const key of options.histogramKeys) {
+      counter.recordHistogramSample(key);
+    }
+    if (!existing) {
+      await counter.initialize();
+    }
+    await counter.save();
+  }
+}
+
+/** Internal only — this table has no generated surface. */
+@smrt({
+  conflictColumns: [
+    'tenant_id',
+    'user_id',
+    'object_ref',
+    'field_name',
+    'period',
+  ],
+  api: false,
+  cli: false,
+  mcp: false,
+})
+class FieldUsageReportReceiptCollection extends SmrtCollection<FieldUsageReportReceipt> {
+  static readonly _itemClass = FieldUsageReportReceipt;
+
+  async claim(options: {
+    tenantId: string;
+    userId: string;
+    objectRef: string;
+    fieldName: string;
+    period: string;
+  }): Promise<boolean> {
+    const id = await fieldUsageReportReceiptId(
+      options.tenantId,
+      options.userId,
+      options.objectRef,
+      options.fieldName,
+      options.period,
+    );
+    if (await this.get(id)) return false;
+    try {
+      await this.create({ ...options, id, _insertOnly: true });
+      return true;
+    } catch (error) {
+      // Only a receipt that now exists proves another request won the race;
+      // validation/schema/connection failures must remain visible.
+      if (await this.get(id)) return false;
+      throw error;
+    }
+  }
+}
+
+/**
+ * Deterministic bucket row id (the TenantUsageMetric `recordUsage` precedent):
+ * SHA-256 over the natural key, formatted as a v5-style UUID so the id column
+ * stays native UUID on PostgreSQL/DuckDB.
+ */
+export async function fieldUsageCounterId(
+  tenantId: string,
+  objectRef: string,
+  fieldName: string,
+  period: string,
+): Promise<string> {
+  return deterministicFieldsUuid([
+    'field-usage-counter',
+    tenantId,
+    objectRef,
+    fieldName,
+    period,
+  ]);
+}
+
+/** Deterministic receipt id for the durable once-per-day contribution rule. */
+export async function fieldUsageReportReceiptId(
+  tenantId: string,
+  userId: string,
+  objectRef: string,
+  fieldName: string,
+  period: string,
+): Promise<string> {
+  return deterministicFieldsUuid([
+    'field-usage-report-receipt',
+    tenantId,
+    userId,
+    objectRef,
+    fieldName,
+    period,
+  ]);
+}
+
+/** Mirrors the resolver's policy-addressable exclusions, plus transient. */
+function isUsageAddressableField(field: RegisteredFieldInfo): boolean {
+  if (field._meta?.__smrtSystemField === true) {
+    return false;
+  }
+  if (
+    field.type === 'oneToMany' ||
+    field.type === 'manyToMany' ||
+    field.type === 'meta'
+  ) {
+    return false;
+  }
+  return !isTransientField(field);
+}
+
+/**
+ * Histogram eligibility (#2051 pin): ONLY low-cardinality field types —
+ * `boolean` and reference ids (`foreignKey` / `crossPackageRef`). Free text
+ * is NEVER histogrammed, even when non-sensitive (PII risk); numeric,
+ * datetime, and json fields are count-only too.
+ */
+export function isHistogramEligibleField(field: RegisteredFieldInfo): boolean {
+  return (
+    field.type === 'boolean' ||
+    field.type === 'foreignKey' ||
+    field.type === 'crossPackageRef'
+  );
+}
+
+/**
+ * Serialize one sample into a histogram key, type-checked against the field:
+ * booleans must be real booleans (`'true'` / `'false'` keys); reference ids
+ * must be STORABLE ids for the field — `isStorableReferenceId` applies the same
+ * native-UUID / `idType: 'text'` rule stored defaults are held to, within the
+ * bounded key length. Anything else is skipped (the submission still counts —
+ * count-only for that sample).
+ *
+ * The reference check is load-bearing, not cosmetic: recording an unstorable
+ * id would let an authenticated caller poison a histogram, win dominance with
+ * it, and produce a `default` suggestion whose write is then rejected by the
+ * same rule — turning a bad sample into a stuck generation candidate.
+ */
+export function serializeHistogramSample(
+  field: RegisteredFieldInfo,
+  value: unknown,
+): string | null {
+  if (field.type === 'boolean') {
+    return typeof value === 'boolean' ? String(value) : null;
+  }
+  if (
+    isStorableReferenceId(field, value) &&
+    value.length <= MAX_VALUE_HISTOGRAM_KEY_LENGTH
+  ) {
+    return value;
+  }
+  return null;
+}
+
+/** Decode a histogram key back into the typed value it was recorded from. */
+export function decodeHistogramKey(
+  field: RegisteredFieldInfo,
+  key: string,
+): unknown {
+  if (field.type === 'boolean') {
+    return key === 'true';
+  }
+  return key;
+}
+
+function validateEntriesInput(
+  rawEntries: FieldUsageReportEntry[] | undefined,
+): FieldUsageReportEntry[] {
+  if (!Array.isArray(rawEntries) || rawEntries.length === 0) {
+    throw new Error(
+      'reportUsage requires a non-empty "entries" array of ' +
+        '{ objectRef, fieldName, value?, matchedDefault? } samples',
+    );
+  }
+  if (rawEntries.length > MAX_USAGE_REPORT_ENTRIES) {
+    throw new Error(
+      `reportUsage accepts at most ${MAX_USAGE_REPORT_ENTRIES} entries ` +
+        `per call (got ${rawEntries.length})`,
+    );
+  }
+  for (const entry of rawEntries) {
+    if (
+      !entry ||
+      typeof entry !== 'object' ||
+      typeof entry.objectRef !== 'string' ||
+      entry.objectRef.trim() === '' ||
+      typeof entry.fieldName !== 'string' ||
+      entry.fieldName.trim() === ''
+    ) {
+      throw new Error(
+        'reportUsage entries must carry non-empty objectRef and fieldName strings',
+      );
+    }
+  }
+  return rawEntries;
+}

--- a/packages/fields/src/collections/FieldUsageCounterCollection.ts
+++ b/packages/fields/src/collections/FieldUsageCounterCollection.ts
@@ -28,7 +28,7 @@ import type {
 /**
  * Deviation comparison: strict equality, then a JSON round-trip so structured
  * and Date-shaped values compare by serialization. Mirrors the browser-side
- * `usageValuesEqual` (the packaging boundary bars value imports across the
+ * `fieldUsageValuesEqual` (the packaging boundary bars value imports across the
  * subpath split — the permission-slug precedent); a node test pins the two
  * behaviours equal.
  */
@@ -45,9 +45,8 @@ export function usageValuesEqual(a: unknown, b: unknown): boolean {
 
 /**
  * Per-call bound on reported entries — the rate rail for the fire-and-forget
- * ingestion action (the resolveBatch precedent). Mirrored browser-side by
- * `src/svelte/usage-capture.ts` (`USAGE_REPORT_BATCH_LIMIT`); a node test
- * pins the two equal.
+ * ingestion action (the resolveBatch precedent). The browser deliberately
+ * does not impose a duplicate limit: every report is server-bounded here.
  */
 export const MAX_USAGE_REPORT_ENTRIES = 100;
 

--- a/packages/fields/src/deterministic-id.ts
+++ b/packages/fields/src/deterministic-id.ts
@@ -1,0 +1,36 @@
+/**
+ * Deterministic row ids for this package's idempotent writes (the
+ * `TenantUsageMetric.recordUsage` precedent).
+ *
+ * A leaf module (no package-internal imports) so both consumers — usage counter
+ * buckets and the global learning schedules — share one implementation. The
+ * output is formatted as a v5-shaped UUID so id columns stay native UUID on
+ * PostgreSQL/DuckDB.
+ */
+
+/**
+ * SHA-256 over the namespaced parts, formatted as a v5-style UUID.
+ *
+ * The same parts always produce the same id, which is what turns
+ * "check then create" into a race-free write: concurrent creators converge on
+ * one primary key instead of inserting near-duplicate rows.
+ */
+export async function deterministicFieldsUuid(
+  parts: readonly string[],
+): Promise<string> {
+  const bytes = new TextEncoder().encode(JSON.stringify(parts));
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', bytes));
+  const uuid = digest.slice(0, 16);
+  uuid[6] = (uuid[6] & 0x0f) | 0x50;
+  uuid[8] = (uuid[8] & 0x3f) | 0x80;
+  const hex = Array.from(uuid, (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join('-');
+}

--- a/packages/fields/src/field-definitions.ts
+++ b/packages/fields/src/field-definitions.ts
@@ -220,6 +220,21 @@ function usesTextIdStorage(field: RegisteredFieldInfo): boolean {
 }
 
 /**
+ * True when a reference identifier can be stored in the field's backing
+ * column. Native UUID columns accept UUIDs only; `idType: 'text'` opts into
+ * arbitrary non-empty string identifiers. Shared by policy defaults and the
+ * usage histogram so a poisoned sample can never become an unwriteable
+ * suggestion.
+ */
+export function isStorableReferenceId(
+  field: RegisteredFieldInfo,
+  value: unknown,
+): value is string {
+  if (typeof value !== 'string' || value === '') return false;
+  return usesTextIdStorage(field) || UUID_PATTERN.test(value);
+}
+
+/**
  * Type-check a parsed default value against the manifest field type.
  *
  * Explicit `null` is allowed only for optional fields (a required field with a
@@ -287,7 +302,7 @@ export function assertDefaultValueMatchesFieldType(
       // Reference columns are native UUID on PostgreSQL/DuckDB unless the
       // field explicitly opts into text ids — a non-UUID default would
       // validate here but fail at insert time on those dialects.
-      if (!usesTextIdStorage(field) && !UUID_PATTERN.test(value)) {
+      if (!isStorableReferenceId(field, value)) {
         throw new Error(
           `${label} must be a UUID string (the reference column stores ` +
             `native UUIDs; declare idType 'text' on the field to store ` +

--- a/packages/fields/src/field-policy-batch.test.ts
+++ b/packages/fields/src/field-policy-batch.test.ts
@@ -37,7 +37,7 @@ class PolicyBatchDoc extends SmrtObject {
   @field({ required: true })
   docName: string = '';
 
-  @field({ ui: { basic: true } })
+  @field({ default: '', ui: { basic: true } })
   blurb: string = '';
 
   @field({ sensitive: true })

--- a/packages/fields/src/field-policy-resolver.test.ts
+++ b/packages/fields/src/field-policy-resolver.test.ts
@@ -39,7 +39,7 @@ class PolicyResolverDoc extends SmrtObject {
   @field({ required: true, description: 'Title help' })
   title: string = '';
 
-  @field({ ui: { basic: true, group: 'main', order: 2 } })
+  @field({ default: '', ui: { basic: true, group: 'main', order: 2 } })
   summary: string = '';
 
   // The scanner only carries an initializer default into the manifest when
@@ -51,7 +51,7 @@ class PolicyResolverDoc extends SmrtObject {
   @field({ nullable: true })
   subtitle: string | null = null;
 
-  @field({ ui: { locked: true } })
+  @field({ default: 'default', ui: { locked: true } })
   theme: string = 'default';
 
   @field({ sensitive: true })

--- a/packages/fields/src/field-policy-suggestions.test.ts
+++ b/packages/fields/src/field-policy-suggestions.test.ts
@@ -619,6 +619,40 @@ describe('FieldPolicySuggestion actions (#2051)', () => {
     ).rejects.toThrow(/sensitive, read-permission-gated, or transient/);
   });
 
+  it('still refuses a promote whose existing policy target became gated', async () => {
+    // Exercise the atomic UPDATE path: a stale promote must not bypass the
+    // model's live addressability rail merely because a tenant row exists.
+    await asManager(() =>
+      policies.create({
+        objectRef,
+        fieldName: 'featured',
+        scopeType: 'tenant',
+        tenantId,
+        help: 'existing sparse row',
+      }),
+    );
+    const seeded = await seedSuggestion({ fieldName: 'featured' });
+    await db.query(
+      `UPDATE _smrt_field_policy_suggestions SET field_name = ? WHERE id = ?`,
+      'apiToken',
+      String(seeded.id),
+    );
+
+    await expect(
+      asManager(() => suggestions.acceptSuggestion({ id: String(seeded.id) })),
+    ).rejects.toThrow(/sensitive, read-permission-gated, or transient/);
+    const row = await policies.list({
+      where: {
+        objectRef,
+        fieldName: 'featured',
+        scopeType: 'tenant',
+        tenantId,
+      },
+    });
+    expect(row).toHaveLength(1);
+    expect(row[0].visibility).toBeNull();
+  });
+
   it('holds the active slot across a NON-TRANSACTIONAL accept (P2 regression)', async () => {
     // A database VIEW exposes `transaction` but not `beginTransaction`, so the
     // accept takes the two-step claim path. Model that by hiding

--- a/packages/fields/src/field-policy-suggestions.test.ts
+++ b/packages/fields/src/field-policy-suggestions.test.ts
@@ -1,0 +1,786 @@
+/**
+ * #2051 suggestion surface: the manage-gated `pendingSuggestions` /
+ * `acceptSuggestion` / `dismissSuggestion` actions, tenant isolation on
+ * suggestion rows, and acceptance flowing through FieldPolicy's NORMAL
+ * validation (the resolver output shift is the end-to-end proof).
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  field,
+  getTestDatabase,
+  ObjectRegistry,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import {
+  resetTenancy,
+  setupTestTenancy,
+  TenantIsolationError,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+// Side-effect import: registers smrt-users' classes (Tenant) so the resolver's
+// default hierarchy loader can walk the tenants table.
+import '../../users/src/index.js';
+import { clearFieldPolicyCache } from './cache.js';
+import { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
+import {
+  DEFAULT_SUGGESTION_COOL_DOWN_MS,
+  FieldPolicySuggestionCollection,
+  FieldPolicySuggestionConflictError,
+} from './collections/FieldPolicySuggestionCollection.js';
+import { resolveFieldPolicy } from './field-policy-resolver.js';
+import {
+  ACTIVE_SUGGESTION_KEY,
+  FieldPolicySuggestion,
+} from './models/FieldPolicySuggestion.js';
+import { MANAGE_FIELD_POLICY_PERMISSION } from './permissions.js';
+import type { AcceptFieldPolicySuggestionResult } from './types.js';
+import { runFieldPolicySuggestionGeneration } from './usage-learning.js';
+
+@smrt({
+  packageName: '@test/smrt-fields-suggestions',
+  visibility: 'internal',
+  api: false,
+  cli: false,
+  mcp: false,
+})
+class SuggestionDoc extends SmrtObject {
+  @field({ ui: { basic: true } })
+  headline: string = '';
+
+  // Unmarked while headline is basic ⇒ resolves 'advanced' (cold-start rule):
+  // the promote-suggestion target.
+  @field()
+  region: string = '';
+
+  @field({ type: 'boolean' })
+  featured: boolean = false;
+
+  @field({ sensitive: true })
+  apiToken: string = '';
+}
+
+function fixtureRef(): string {
+  const registered = ObjectRegistry.getClassByConstructor(SuggestionDoc);
+  if (!registered?.qualifiedName) {
+    throw new Error('SuggestionDoc is not registered with a qualified name');
+  }
+  return registered.qualifiedName;
+}
+
+/**
+ * A database handle WITHOUT `beginTransaction` — the shape a transaction view
+ * presents (it exposes `transaction` only), which is what drives the
+ * two-step claim path.
+ */
+function nonTransactionalView(db: DatabaseInterface): DatabaseInterface {
+  return new Proxy(db, {
+    get(target, property, receiver) {
+      if (property === 'beginTransaction') {
+        return undefined;
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+    has(target, property) {
+      return property === 'beginTransaction'
+        ? false
+        : Reflect.has(target, property);
+    },
+  });
+}
+
+describe('FieldPolicySuggestion actions (#2051)', () => {
+  let db: DatabaseInterface;
+  let suggestions: FieldPolicySuggestionCollection;
+  let policies: FieldPolicyCollection;
+  let objectRef: string;
+  let tenantId: string;
+  let userId: string;
+
+  const asManager = <T>(fn: () => Promise<T>): Promise<T> =>
+    withTenant(
+      {
+        tenantId,
+        userId,
+        permissions: new Set([MANAGE_FIELD_POLICY_PERMISSION]),
+      },
+      fn,
+    );
+
+  const asMember = <T>(fn: () => Promise<T>): Promise<T> =>
+    withTenant({ tenantId, userId, permissions: new Set<string>() }, fn);
+
+  /** Trusted-execution creation (no ambient context) — the generation job's path. */
+  const seedSuggestion = (
+    overrides: Partial<{
+      tenantId: string;
+      fieldName: string;
+      kind: 'promote' | 'default';
+      proposedValue: string | null;
+    }> = {},
+  ) =>
+    suggestions.create({
+      tenantId: overrides.tenantId ?? tenantId,
+      objectRef,
+      fieldName: overrides.fieldName ?? 'region',
+      kind: overrides.kind ?? 'promote',
+      proposedValue: overrides.proposedValue ?? null,
+      evidence: JSON.stringify({ summary: 'seeded for test' }),
+      status: 'pending',
+    });
+
+  beforeEach(async () => {
+    setupTestTenancy();
+    clearFieldPolicyCache();
+    db = await getTestDatabase({
+      // `FieldUsageCounter` backs the generation pass the non-transactional
+      // interleaving test runs mid-decision.
+      classes: [
+        'FieldPolicy',
+        'FieldPolicySuggestion',
+        'FieldUsageCounter',
+        'Tenant',
+      ],
+    });
+    suggestions = await FieldPolicySuggestionCollection.create({ db });
+    policies = await FieldPolicyCollection.create({ db });
+    objectRef = fixtureRef();
+    tenantId = randomUUID();
+    userId = randomUUID();
+  });
+
+  afterEach(async () => {
+    clearFieldPolicyCache();
+    resetTenancy();
+    if (typeof (db as { close?: () => Promise<void> }).close === 'function') {
+      await (db as unknown as { close: () => Promise<void> }).close();
+    }
+  });
+
+  it('gates all three actions on ambient context + fields.policy.manage', async () => {
+    await expect(suggestions.pendingSuggestions()).rejects.toThrow(
+      TenantIsolationError,
+    );
+    await expect(
+      asMember(() => suggestions.pendingSuggestions()),
+    ).rejects.toThrow(/Permission denied/);
+    await expect(
+      asMember(() => suggestions.acceptSuggestion({ id: randomUUID() })),
+    ).rejects.toThrow(/Permission denied/);
+    await expect(
+      asMember(() => suggestions.dismissSuggestion({ id: randomUUID() })),
+    ).rejects.toThrow(/Permission denied/);
+  });
+
+  it('lists only the ambient tenant’s pending suggestions', async () => {
+    await seedSuggestion();
+    await seedSuggestion({ tenantId: randomUUID(), fieldName: 'headline' });
+
+    const result = await asManager(() => suggestions.pendingSuggestions());
+    expect(result.total).toBe(1);
+    expect(result.suggestions).toHaveLength(1);
+    expect(result.suggestions[0].tenantId).toBe(tenantId);
+    expect(result.suggestions[0].fieldName).toBe('region');
+    expect(result.suggestions[0].evidence.summary).toBe('seeded for test');
+
+    // The objectRefs filter is validated and applied.
+    const filtered = await asManager(() =>
+      suggestions.pendingSuggestions({ objectRefs: ['@test/nowhere:Nope'] }),
+    );
+    expect(filtered.total).toBe(0);
+    await expect(
+      asManager(() => suggestions.pendingSuggestions({ objectRefs: [] })),
+    ).rejects.toThrow(/non-empty string array/);
+  });
+
+  it('accepting a promote suggestion writes the org row and SHIFTS resolver output', async () => {
+    const seeded = await seedSuggestion();
+
+    const before = await resolveFieldPolicy(objectRef, { tenantId, db });
+    expect(before.fields.region.visibility).toBe('advanced');
+
+    const result = await asManager(() =>
+      suggestions.acceptSuggestion({ id: String(seeded.id) }),
+    );
+    expect(result.suggestion.status).toBe('accepted');
+    expect(result.suggestion.decidedBy).toBe(userId);
+
+    const rows = await policies.list({
+      where: { objectRef, fieldName: 'region', scopeType: 'tenant', tenantId },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].visibility).toBe('basic');
+    expect(String(rows[0].id)).toBe(result.policyRowId);
+
+    // The org's forms change: the resolver now reports the field as basic.
+    const after = await resolveFieldPolicy(objectRef, { tenantId, db });
+    expect(after.fields.region.visibility).toBe('basic');
+  });
+
+  it('accepting a default suggestion UPDATES an existing tenant row in place', async () => {
+    await withTenant(
+      {
+        tenantId,
+        userId,
+        permissions: new Set([MANAGE_FIELD_POLICY_PERMISSION]),
+      },
+      async () => {
+        await policies.create({
+          objectRef,
+          fieldName: 'featured',
+          scopeType: 'tenant',
+          tenantId,
+          help: 'kept through acceptance',
+        });
+      },
+    );
+
+    const seeded = await seedSuggestion({
+      fieldName: 'featured',
+      kind: 'default',
+      proposedValue: JSON.stringify(true),
+    });
+    const result = await asManager(() =>
+      suggestions.acceptSuggestion({ id: String(seeded.id) }),
+    );
+
+    const rows = await policies.list({
+      where: {
+        objectRef,
+        fieldName: 'featured',
+        scopeType: 'tenant',
+        tenantId,
+      },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].getDefaultValue()).toBe(true);
+    expect(rows[0].help).toBe('kept through acceptance');
+    expect(String(rows[0].id)).toBe(result.policyRowId);
+
+    const resolved = await resolveFieldPolicy(objectRef, { tenantId, db });
+    expect(resolved.fields.featured.defaultValue).toBe(true);
+  });
+
+  it('acceptance runs FieldPolicy’s NORMAL validation (corrupt payloads are rejected)', async () => {
+    const seeded = await seedSuggestion({
+      fieldName: 'featured',
+      kind: 'default',
+      proposedValue: JSON.stringify(true),
+    });
+    // Corrupt the stored payload underneath the model (registry drift stand-in)
+    // — acceptance must fail in FieldPolicy validation, not write a junk row.
+    await db.query(
+      `UPDATE _smrt_field_policy_suggestions SET proposed_value = ? WHERE id = ?`,
+      '{not json',
+      String(seeded.id),
+    );
+
+    await expect(
+      asManager(() => suggestions.acceptSuggestion({ id: String(seeded.id) })),
+    ).rejects.toThrow(/not valid JSON/);
+
+    const rows = await policies.list({
+      where: {
+        objectRef,
+        fieldName: 'featured',
+        scopeType: 'tenant',
+        tenantId,
+      },
+    });
+    expect(rows).toHaveLength(0);
+    // The suggestion stays pending — nothing was half-applied.
+    const pending = await asManager(() => suggestions.pendingSuggestions());
+    expect(pending.total).toBe(1);
+  });
+
+  it('dismissing sets status + cool-down and leaves the queue', async () => {
+    const seeded = await seedSuggestion();
+    const before = Date.now();
+    const result = await asManager(() =>
+      suggestions.dismissSuggestion({ id: String(seeded.id) }),
+    );
+    expect(result.suggestion.status).toBe('dismissed');
+    expect(result.suggestion.decidedBy).toBe(userId);
+    const cooldown = Date.parse(result.suggestion.cooldownUntil ?? '');
+    expect(cooldown).toBeGreaterThanOrEqual(
+      before + DEFAULT_SUGGESTION_COOL_DOWN_MS - 1000,
+    );
+
+    const pending = await asManager(() => suggestions.pendingSuggestions());
+    expect(pending.total).toBe(0);
+
+    // A settled suggestion cannot be decided again — and it raises the SAME
+    // conflict type the compare-and-set does (see the ordering test below).
+    await expect(
+      asManager(() => suggestions.acceptSuggestion({ id: String(seeded.id) })),
+    ).rejects.toThrow(FieldPolicySuggestionConflictError);
+  });
+
+  it('raises ONE conflict type for both settle-then-decide orderings (P2 regression)', async () => {
+    // Ordering A: the competing decision lands BEFORE this request loads the
+    // row, so the load sees a settled row.
+    const settledFirst = await seedSuggestion();
+    await asManager(() =>
+      suggestions.dismissSuggestion({ id: String(settledFirst.id) }),
+    );
+    const loadPathError = await asManager(() =>
+      suggestions
+        .acceptSuggestion({ id: String(settledFirst.id) })
+        .then(() => null)
+        .catch((error: unknown) => error),
+    );
+
+    // Ordering B: it lands AFTER the load, so only the compare-and-set can
+    // detect it. Loading and settling interleave via the racing pair.
+    const racedRow = await seedSuggestion({ fieldName: 'featured' });
+    const outcomes = await Promise.allSettled([
+      asManager(() =>
+        suggestions.acceptSuggestion({ id: String(racedRow.id) }),
+      ),
+      asManager(() =>
+        suggestions.dismissSuggestion({ id: String(racedRow.id) }),
+      ),
+    ]);
+    // Either decision may win the race; take whichever one lost.
+    const rejected = outcomes.filter((o) => o.status === 'rejected');
+    expect(rejected).toHaveLength(1);
+    const claimPathError = (rejected[0] as PromiseRejectedResult).reason;
+
+    // Purely-by-timing differences must not change the caller's contract.
+    expect(loadPathError).toBeInstanceOf(FieldPolicySuggestionConflictError);
+    expect(claimPathError).toBeInstanceOf(FieldPolicySuggestionConflictError);
+    for (const error of [loadPathError, claimPathError]) {
+      // `httpStatus` is core's generated-REST contract (own integer property);
+      // `status` mirrors this package's FieldPolicyPermissionError shape.
+      expect(Object.hasOwn(error as object, 'httpStatus')).toBe(true);
+      expect((error as { httpStatus: number }).httpStatus).toBe(409);
+      expect((error as { status: number }).status).toBe(409);
+      expect((error as Error).name).toBe('FieldPolicySuggestionConflictError');
+    }
+  });
+
+  it('rejects foreign-tenant decisions and in-context foreign writes', async () => {
+    const foreignTenant = randomUUID();
+    const foreign = await seedSuggestion({ tenantId: foreignTenant });
+
+    await expect(
+      asManager(() => suggestions.acceptSuggestion({ id: String(foreign.id) })),
+    ).rejects.toThrow(TenantIsolationError);
+    await expect(
+      asManager(() =>
+        suggestions.dismissSuggestion({ id: String(foreign.id) }),
+      ),
+    ).rejects.toThrow(TenantIsolationError);
+
+    // Direct model writes from a foreign context hit the same boundary.
+    await expect(
+      asManager(async () => {
+        const row = new FieldPolicySuggestion({
+          db,
+          tenantId: foreignTenant,
+          objectRef,
+          fieldName: 'region',
+          kind: 'promote',
+          evidence: '{}',
+          status: 'pending',
+        });
+        await row.save();
+      }),
+    ).rejects.toThrow(TenantIsolationError);
+
+    // An in-tenant principal MAY create a suggestion through normal
+    // validation — the #1885 learning-agent seam.
+    await asMember(async () => {
+      await suggestions.create({
+        tenantId,
+        objectRef,
+        fieldName: 'headline',
+        kind: 'promote',
+        evidence: JSON.stringify({ summary: 'proposed by a learning agent' }),
+        status: 'pending',
+      });
+    });
+    const pending = await asManager(() => suggestions.pendingSuggestions());
+    expect(pending.suggestions.some((s) => s.fieldName === 'headline')).toBe(
+      true,
+    );
+  });
+
+  it('lets exactly one of a racing accept+dismiss pair win (P2 regression)', async () => {
+    const seeded = await seedSuggestion();
+    const id = String(seeded.id);
+
+    const outcomes = await Promise.allSettled([
+      asManager(() => suggestions.acceptSuggestion({ id })),
+      asManager(() => suggestions.dismissSuggestion({ id })),
+    ]);
+
+    const fulfilled = outcomes.filter((o) => o.status === 'fulfilled');
+    const rejected = outcomes.filter((o) => o.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    // The loser reports a clear 409 conflict, not a generic failure.
+    const error = (rejected[0] as PromiseRejectedResult).reason;
+    expect(error).toBeInstanceOf(FieldPolicySuggestionConflictError);
+    expect((error as { status: number }).status).toBe(409);
+    expect((error as Error).message).toMatch(/no longer pending/);
+
+    // Final state is internally consistent: the policy row exists IFF the
+    // winner was the accept.
+    const settled = await suggestions.get(id);
+    const policyRows = await policies.list({
+      where: { objectRef, fieldName: 'region', scopeType: 'tenant', tenantId },
+    });
+    if (settled?.status === 'accepted') {
+      expect(policyRows).toHaveLength(1);
+      expect(policyRows[0].visibility).toBe('basic');
+      expect(settled.cooldownUntil).toBeNull();
+    } else {
+      expect(settled?.status).toBe('dismissed');
+      expect(policyRows).toHaveLength(0);
+      expect(settled?.cooldownUntil).not.toBeNull();
+    }
+  });
+
+  it('keeps BOTH columns when promote+default are accepted concurrently (P1 regression)', async () => {
+    // The two suggestions own DIFFERENT columns of the SAME sparse policy row.
+    // A read-modify-save of the whole row loses one of them: each acceptance
+    // reads before the other's write lands, and the later save erases the
+    // sibling's column (and can replace the row id, dangling a policyRowId).
+    const promote = await seedSuggestion({ fieldName: 'featured' });
+    const setDefault = await seedSuggestion({
+      fieldName: 'featured',
+      kind: 'default',
+      proposedValue: JSON.stringify(true),
+    });
+
+    // Drive the NON-TRANSACTIONAL path: sqlite's pool runs one transaction at
+    // a time, so the tx path already serializes these two acceptances on this
+    // driver — the exposure is the tx-less path (a transaction VIEW) and, on
+    // PostgreSQL, READ COMMITTED, where two transactions interleave freely.
+    const nonTxSuggestions = await FieldPolicySuggestionCollection.create({
+      db: nonTransactionalView(db),
+    });
+
+    // Force the interleaving: hold both acceptances until each has finished
+    // looking for an existing row, so neither can serialize behind the other.
+    const originalCreate = FieldPolicyCollection.create;
+    let arrived = 0;
+    let releaseBoth: () => void = () => {};
+    const bothArrived = new Promise<void>((resolve) => {
+      releaseBoth = () => {
+        arrived += 1;
+        if (arrived >= 2) resolve();
+      };
+    });
+    let results: AcceptFieldPolicySuggestionResult[];
+    try {
+      (FieldPolicyCollection as unknown as { create: unknown }).create = async (
+        ...args: unknown[]
+      ) => {
+        releaseBoth();
+        await bothArrived;
+        return (
+          originalCreate as (...a: unknown[]) => Promise<FieldPolicyCollection>
+        ).apply(FieldPolicyCollection, args);
+      };
+      results = await Promise.all([
+        asManager(() =>
+          nonTxSuggestions.acceptSuggestion({ id: String(promote.id) }),
+        ),
+        asManager(() =>
+          nonTxSuggestions.acceptSuggestion({ id: String(setDefault.id) }),
+        ),
+      ]);
+    } finally {
+      (FieldPolicyCollection as unknown as { create: unknown }).create =
+        originalCreate;
+    }
+
+    // Both suggestions are accepted...
+    expect(results.map((result) => result.suggestion.status)).toEqual([
+      'accepted',
+      'accepted',
+    ]);
+
+    // ...exactly ONE policy row survives, carrying BOTH columns...
+    const rows = await policies.list({
+      where: {
+        objectRef,
+        fieldName: 'featured',
+        scopeType: 'tenant',
+        tenantId,
+      },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].visibility).toBe('basic');
+    expect(rows[0].getDefaultValue()).toBe(true);
+
+    // ...and BOTH returned ids resolve to that row (neither dangles).
+    const survivingId = String(rows[0].id);
+    expect(results.map((result) => result.policyRowId)).toEqual([
+      survivingId,
+      survivingId,
+    ]);
+
+    // The resolver reflects both changes for the org.
+    clearFieldPolicyCache();
+    const resolved = await resolveFieldPolicy(objectRef, { tenantId, db });
+    expect(resolved.fields.featured.visibility).toBe('basic');
+    expect(resolved.fields.featured.defaultValue).toBe(true);
+  });
+
+  it('applies a second acceptance onto an EXISTING policy row without clobbering', async () => {
+    // The sequential path over a pre-existing row (e.g. one the gear created):
+    // each acceptance must touch only its own column and leave the rest alone.
+    await withTenant(
+      {
+        tenantId,
+        userId,
+        permissions: new Set([MANAGE_FIELD_POLICY_PERMISSION]),
+      },
+      async () => {
+        await policies.create({
+          objectRef,
+          fieldName: 'featured',
+          scopeType: 'tenant',
+          tenantId,
+          help: 'kept through both acceptances',
+        });
+      },
+    );
+
+    const promote = await seedSuggestion({ fieldName: 'featured' });
+    const setDefault = await seedSuggestion({
+      fieldName: 'featured',
+      kind: 'default',
+      proposedValue: JSON.stringify(true),
+    });
+    const first = await asManager(() =>
+      suggestions.acceptSuggestion({ id: String(promote.id) }),
+    );
+    const second = await asManager(() =>
+      suggestions.acceptSuggestion({ id: String(setDefault.id) }),
+    );
+
+    const rows = await policies.list({
+      where: {
+        objectRef,
+        fieldName: 'featured',
+        scopeType: 'tenant',
+        tenantId,
+      },
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].visibility).toBe('basic');
+    expect(rows[0].getDefaultValue()).toBe(true);
+    expect(rows[0].help).toBe('kept through both acceptances');
+    expect(first.policyRowId).toBe(String(rows[0].id));
+    expect(second.policyRowId).toBe(String(rows[0].id));
+  });
+
+  it('still refuses an accepted default whose field became gated', async () => {
+    // The atomic column update bypasses the model, so the stored-default rail
+    // must be re-asserted at acceptance time — a field can turn sensitive
+    // between queueing and approval.
+    await withTenant(
+      {
+        tenantId,
+        userId,
+        permissions: new Set([MANAGE_FIELD_POLICY_PERMISSION]),
+      },
+      async () => {
+        await policies.create({
+          objectRef,
+          fieldName: 'featured',
+          scopeType: 'tenant',
+          tenantId,
+          help: 'pre-existing row',
+        });
+      },
+    );
+    const seeded = await seedSuggestion({
+      fieldName: 'featured',
+      kind: 'default',
+      proposedValue: JSON.stringify(true),
+    });
+    await db.query(
+      `UPDATE _smrt_field_policy_suggestions SET field_name = ? WHERE id = ?`,
+      'apiToken',
+      String(seeded.id),
+    );
+
+    await expect(
+      asManager(() => suggestions.acceptSuggestion({ id: String(seeded.id) })),
+    ).rejects.toThrow(/sensitive, read-permission-gated, or transient/);
+  });
+
+  it('holds the active slot across a NON-TRANSACTIONAL accept (P2 regression)', async () => {
+    // A database VIEW exposes `transaction` but not `beginTransaction`, so the
+    // accept takes the two-step claim path. Model that by hiding
+    // `beginTransaction` from the collection's db.
+    const viewLike = nonTransactionalView(db);
+    const nonTxSuggestions = await FieldPolicySuggestionCollection.create({
+      db: viewLike,
+    });
+    const seeded = await seedSuggestion();
+    const id = String(seeded.id);
+
+    // Interleave generation between the claim and the policy write: it must
+    // see the slot as TAKEN and create no competing pending row (which would
+    // otherwise resolve against the pre-acceptance policy and collide with the
+    // compensation).
+    let observedDuringDecision: Array<{ status: string; activeKey: string }> =
+      [];
+    const originalCreate = FieldPolicyCollection.create;
+    try {
+      (FieldPolicyCollection as unknown as { create: unknown }).create = async (
+        ...args: unknown[]
+      ) => {
+        const rows = await suggestions.list({ where: { tenantId } });
+        observedDuringDecision = rows.map((row) => ({
+          status: row.status,
+          activeKey: row.activeKey,
+        }));
+        await runFieldPolicySuggestionGeneration({ db });
+        return (
+          originalCreate as (...a: unknown[]) => Promise<FieldPolicyCollection>
+        ).apply(FieldPolicyCollection, args);
+      };
+      await asManager(() => nonTxSuggestions.acceptSuggestion({ id }));
+    } finally {
+      (FieldPolicyCollection as unknown as { create: unknown }).create =
+        originalCreate;
+    }
+
+    // Mid-decision the row was already accepted but still HELD the slot.
+    expect(observedDuringDecision).toEqual([
+      { status: 'accepted', activeKey: ACTIVE_SUGGESTION_KEY },
+    ]);
+    // Generation created nothing in that window.
+    const all = await suggestions.list({ where: { tenantId } });
+    expect(all).toHaveLength(1);
+    // And the slot is released once the policy is durable.
+    expect(all[0].status).toBe('accepted');
+    expect(all[0].activeKey).toBe(id);
+    const policyRows = await policies.list({
+      where: { objectRef, fieldName: 'region', scopeType: 'tenant', tenantId },
+    });
+    expect(policyRows).toHaveLength(1);
+  });
+
+  it('reverts a NON-TRANSACTIONAL accept whose policy write is refused', async () => {
+    const viewLike = nonTransactionalView(db);
+    const nonTxSuggestions = await FieldPolicySuggestionCollection.create({
+      db: viewLike,
+    });
+    // A `default` suggestion whose stored payload cannot pass FieldPolicy
+    // validation: the claim happens, the policy write is refused.
+    const seeded = await seedSuggestion({
+      fieldName: 'featured',
+      kind: 'default',
+      proposedValue: JSON.stringify(true),
+    });
+    const id = String(seeded.id);
+    await db.query(
+      `UPDATE _smrt_field_policy_suggestions SET proposed_value = ? WHERE id = ?`,
+      '{not json',
+      id,
+    );
+
+    await expect(
+      asManager(() => nonTxSuggestions.acceptSuggestion({ id })),
+    ).rejects.toThrow(/not valid JSON/);
+
+    // Compensated back to pending, still holding its slot, with no policy row.
+    const reverted = await suggestions.get(id);
+    expect(reverted?.status).toBe('pending');
+    expect(reverted?.activeKey).toBe(ACTIVE_SUGGESTION_KEY);
+    expect(reverted?.decidedAt).toBeNull();
+    expect(
+      await policies.list({
+        where: {
+          objectRef,
+          fieldName: 'featured',
+          scopeType: 'tenant',
+          tenantId,
+        },
+      }),
+    ).toHaveLength(0);
+
+    // It is still decidable afterwards (the queue is not wedged).
+    const queue = await asManager(() => suggestions.pendingSuggestions());
+    expect(queue.total).toBe(1);
+  });
+
+  it('dismisses a STALE suggestion whose field became gated (P2 regression)', async () => {
+    const seeded = await seedSuggestion();
+    // The field turns sensitive after the suggestion was queued (a redeploy).
+    // Re-running proposal validation on the way out would reject the dismissal
+    // and, since pending rows are never pruned, wedge it in the queue forever.
+    await db.query(
+      `UPDATE _smrt_field_policy_suggestions SET field_name = ? WHERE id = ?`,
+      'apiToken',
+      String(seeded.id),
+    );
+
+    const result = await asManager(() =>
+      suggestions.dismissSuggestion({ id: String(seeded.id) }),
+    );
+    expect(result.suggestion.status).toBe('dismissed');
+    expect(result.suggestion.cooldownUntil).not.toBeNull();
+
+    const queue = await asManager(() => suggestions.pendingSuggestions());
+    expect(queue.total).toBe(0);
+  });
+
+  it('dismisses a STALE suggestion whose object no longer exists', async () => {
+    const seeded = await seedSuggestion();
+    await db.query(
+      `UPDATE _smrt_field_policy_suggestions SET object_ref = ? WHERE id = ?`,
+      '@test/removed:GoneDoc',
+      String(seeded.id),
+    );
+
+    const result = await asManager(() =>
+      suggestions.dismissSuggestion({ id: String(seeded.id) }),
+    );
+    expect(result.suggestion.status).toBe('dismissed');
+
+    // Acceptance of an unresolvable suggestion still fails (it would have to
+    // write a policy row for a field that no longer exists) — only the exit
+    // path is validation-free.
+    const other = await seedSuggestion({ fieldName: 'headline' });
+    await db.query(
+      `UPDATE _smrt_field_policy_suggestions SET object_ref = ? WHERE id = ?`,
+      '@test/removed:GoneDoc',
+      String(other.id),
+    );
+    await expect(
+      asManager(() => suggestions.acceptSuggestion({ id: String(other.id) })),
+    ).rejects.toThrow(/Unknown field policy objectRef|no class with that/);
+  });
+
+  it('normal validation refuses suggestions for gated or unknown fields', async () => {
+    await expect(seedSuggestion({ fieldName: 'apiToken' })).rejects.toThrow(
+      /sensitive, read-permission-gated, or transient/,
+    );
+    await expect(seedSuggestion({ fieldName: 'nope' })).rejects.toThrow(
+      /Unknown field/,
+    );
+    await expect(
+      seedSuggestion({ kind: 'default', proposedValue: null }),
+    ).rejects.toThrow(/requires a proposedValue/);
+    await expect(
+      seedSuggestion({
+        kind: 'default',
+        fieldName: 'featured',
+        proposedValue: JSON.stringify('not-a-boolean'),
+      }),
+    ).rejects.toThrow(/must be a boolean/);
+  });
+});

--- a/packages/fields/src/field-policy.test.ts
+++ b/packages/fields/src/field-policy.test.ts
@@ -75,7 +75,7 @@ class PolicyModelDoc extends SmrtObject {
   @field({ ui: { locked: true } })
   lockedByCode: string = '';
 
-  @field({ required: true })
+  @field({ required: true, default: 'general' })
   category: string = 'general';
 
   @meta()

--- a/packages/fields/src/field-usage-counters.test.ts
+++ b/packages/fields/src/field-usage-counters.test.ts
@@ -1,0 +1,776 @@
+/**
+ * #2051 usage ingestion: the batched `reportUsage` action and the counter
+ * model's bounded-approximation mechanics.
+ *
+ * The security AC lives here: sensitive and `readPermission`-gated fields are
+ * COUNT-ONLY — their raw values never persist anywhere in usage data. No
+ * production model uses `readPermission` yet, so the gated fixture is created
+ * here (the #2047 batch-test precedent).
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  crossPackageRef,
+  field,
+  getTestDatabase,
+  ObjectRegistry,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import {
+  resetTenancy,
+  setupTestTenancy,
+  TenantIsolationError,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+// Side-effect import: registers smrt-users' classes (Tenant) so the default
+// resolution inside ingestion can walk the tenant table.
+import '../../users/src/index.js';
+import { clearFieldPolicyCache } from './cache.js';
+import { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
+import {
+  FieldUsageCounterCollection,
+  fieldUsageCounterId,
+  MAX_USAGE_REPORT_ENTRIES,
+  usageValuesEqual as serverUsageValuesEqual,
+} from './collections/FieldUsageCounterCollection.js';
+import {
+  FieldUsageCounter,
+  fieldUsagePeriodForDate,
+  MAX_DISTINCT_USERS_PER_BUCKET,
+  MAX_VALUE_HISTOGRAM_BUCKETS,
+} from './models/FieldUsageCounter.js';
+import { MANAGE_FIELD_POLICY_PERMISSION } from './permissions.js';
+import type { FieldUsageReportEntry } from './types.js';
+import { runFieldPolicySuggestionGeneration } from './usage-learning.js';
+
+@smrt({
+  packageName: '@test/smrt-fields-usage',
+  visibility: 'internal',
+  api: false,
+  cli: false,
+  mcp: false,
+})
+class UsageCaptureDoc extends SmrtObject {
+  @field({ ui: { basic: true } })
+  title: string = '';
+
+  // No recorded code default: a bare `= false` initializer is NOT captured in
+  // the manifest (only an explicit `default:` option is), so every non-blank
+  // submission of this field is a deviation.
+  @field({ type: 'boolean' })
+  featured: boolean = false;
+
+  // Explicit default — the P1 dominance scenario: `false` submissions match
+  // the default, `true` submissions deviate.
+  @field({ type: 'boolean', default: false })
+  optedIn: boolean = false;
+
+  @crossPackageRef('@happyvertical/smrt-users:User', { nullable: true })
+  ownerId: string | null = null;
+
+  // Text-id reference: its legitimate ids are arbitrary strings, including
+  // prototype-shaped ones like `constructor` / `toString` / `__proto__`.
+  @crossPackageRef('@happyvertical/smrt-users:User', {
+    nullable: true,
+    idType: 'text',
+  })
+  externalRef: string | null = null;
+
+  @field({ sensitive: true })
+  taxId: string = '';
+
+  // readPermission fixture: no production model uses the option yet, so the
+  // count-only contract is pinned here (#2051 pin 7).
+  @field({ readPermission: 'fields.usage.read' })
+  gatedNotes: string = '';
+
+  @field({ transient: true })
+  derived: string = '';
+}
+
+function fixtureRef(): string {
+  const registered = ObjectRegistry.getClassByConstructor(UsageCaptureDoc);
+  if (!registered?.qualifiedName) {
+    throw new Error('UsageCaptureDoc is not registered with a qualified name');
+  }
+  return registered.qualifiedName;
+}
+
+describe('FieldUsageCounterCollection.reportUsage (#2051)', () => {
+  let db: DatabaseInterface;
+  let counters: FieldUsageCounterCollection;
+  let objectRef: string;
+  let tenantId: string;
+  let userId: string;
+
+  const report = (
+    entries: FieldUsageReportEntry[],
+    identity: { tenantId?: string; userId?: string | null } = {},
+  ) => {
+    const invoke = (samples: FieldUsageReportEntry[], sampleUserId?: string) =>
+      withTenant(
+        {
+          tenantId: identity.tenantId ?? tenantId,
+          ...(identity.userId === null
+            ? {}
+            : { userId: sampleUserId ?? identity.userId ?? userId }),
+          permissions: new Set<string>(),
+        },
+        () => counters.reportUsage({ entries: samples }),
+      );
+
+    // Most tests exercise one authenticated form submission containing many
+    // DIFFERENT fields. For repeated samples of the same field, model the
+    // distinct members those aggregates represent — one member can now
+    // contribute only once per field/day by design.
+    if (entries.length === 0 || entries.length > MAX_USAGE_REPORT_ENTRIES) {
+      return invoke(entries);
+    }
+    const seen = new Set<string>();
+    if (
+      entries.every(
+        (entry) => !seen.has(entry.fieldName) && !!seen.add(entry.fieldName),
+      )
+    ) {
+      return invoke(entries);
+    }
+    return Promise.all(
+      entries.map((entry, index) =>
+        invoke(
+          [entry],
+          index === 0 || identity.userId !== undefined
+            ? (identity.userId ?? userId)
+            : randomUUID(),
+        ),
+      ),
+    ).then((results) => ({
+      accepted: results.reduce((sum, result) => sum + result.accepted, 0),
+      dropped: results.reduce((sum, result) => sum + result.dropped, 0),
+    }));
+  };
+
+  beforeEach(async () => {
+    setupTestTenancy();
+    clearFieldPolicyCache();
+    // `FieldPolicy` + `Tenant` back the server-side default resolution the
+    // deviation bit is derived from (#2051 round-2: dominance needs a real
+    // denominator, so ingestion must know what the default was).
+    db = await getTestDatabase({
+      classes: [
+        'FieldUsageCounter',
+        'FieldUsageReportReceipt',
+        'FieldPolicySuggestion',
+        'FieldPolicy',
+        'Tenant',
+      ],
+    });
+    counters = await FieldUsageCounterCollection.create({ db });
+    objectRef = fixtureRef();
+    tenantId = randomUUID();
+    userId = randomUUID();
+  });
+
+  afterEach(async () => {
+    clearFieldPolicyCache();
+    resetTenancy();
+    if (typeof (db as { close?: () => Promise<void> }).close === 'function') {
+      await (db as unknown as { close: () => Promise<void> }).close();
+    }
+  });
+
+  it('fails closed without an ambient tenant context', async () => {
+    await expect(
+      counters.reportUsage({
+        entries: [{ objectRef, fieldName: 'title', value: 'x' }],
+      }),
+    ).rejects.toThrow(TenantIsolationError);
+    expect(await counters.list({})).toHaveLength(0);
+  });
+
+  it('records counts for the ambient identity only — the body cannot attribute', async () => {
+    const result = await report([
+      { objectRef, fieldName: 'title', value: 'Hello' },
+    ]);
+    expect(result).toEqual({ accepted: 1, dropped: 0 });
+
+    const rows = await counters.list({});
+    expect(rows).toHaveLength(1);
+    expect(rows[0].tenantId).toBe(tenantId);
+    expect(rows[0].period).toBe(fieldUsagePeriodForDate(new Date()));
+    expect(rows[0].submissionCount).toBe(1);
+    expect(rows[0].setCount).toBe(1);
+    expect(rows[0].getDistinctUserIds()).toEqual([userId]);
+    expect(rows[0].distinctUserCount).toBe(1);
+    // Free text is NEVER histogrammed, even when non-sensitive (PII risk).
+    expect(rows[0].valueHistogram).toBeNull();
+  });
+
+  it('fails closed for a tenant WITHOUT an authenticated user', async () => {
+    // Middleware that resolves the tenant from host/header alone leaves no
+    // ambient user: such a caller could inflate counters without bound and
+    // distinctUsers would be meaningless, so ingestion refuses it.
+    await expect(
+      report([{ objectRef, fieldName: 'title', value: 'anon' }], {
+        userId: null,
+      }),
+    ).rejects.toThrow(/requires an ambient AUTHENTICATED user/);
+    expect(await counters.list({})).toHaveLength(0);
+
+    // The same batch from an authenticated principal is accepted.
+    const result = await report([
+      { objectRef, fieldName: 'title', value: 'signed in' },
+    ]);
+    expect(result).toEqual({ accepted: 1, dropped: 0 });
+    expect(await counters.list({})).toHaveLength(1);
+  });
+
+  it('separates total submissions from deviations against the RESOLVED default', async () => {
+    // `optedIn` declares `default: false`, so `false` submissions are NOT
+    // deviations while `true` submissions are.
+    await report([
+      { objectRef, fieldName: 'optedIn', value: false },
+      { objectRef, fieldName: 'optedIn', value: false },
+      { objectRef, fieldName: 'optedIn', value: true },
+    ]);
+
+    const [row] = await counters.list({ where: { fieldName: 'optedIn' } });
+    expect(row.submissionCount).toBe(3);
+    expect(row.setCount).toBe(1);
+    // The histogram covers ALL submissions — that is the dominance denominator.
+    expect(row.getValueHistogram()).toEqual({ false: 2, true: 1 });
+    expect(row.isLegacyBucket()).toBe(false);
+
+    // A field with NO recorded code default has nothing to deviate from, so
+    // every submission counts as one (documented consequence).
+    await report([{ objectRef, fieldName: 'featured', value: false }]);
+    const [bare] = await counters.list({ where: { fieldName: 'featured' } });
+    expect(bare.submissionCount).toBe(1);
+    expect(bare.setCount).toBe(1);
+  });
+
+  it('re-derives deviations from an ORG default, never from the client', async () => {
+    await withTenant(
+      {
+        tenantId,
+        userId,
+        permissions: new Set([MANAGE_FIELD_POLICY_PERMISSION]),
+      },
+      async () => {
+        const policies = await FieldPolicyCollection.create({ db });
+        await policies.create({
+          objectRef,
+          fieldName: 'optedIn',
+          scopeType: 'tenant',
+          tenantId,
+          defaultValue: JSON.stringify(true),
+        });
+      },
+    );
+    clearFieldPolicyCache();
+
+    // With the org default now `true`, `true` submissions stop being
+    // deviations and `false` ones start being them — the opposite of the code
+    // seed, and of what a stale client claims in these payloads.
+    await report([
+      { objectRef, fieldName: 'optedIn', value: true, matchedDefault: false },
+      { objectRef, fieldName: 'optedIn', value: false, matchedDefault: true },
+    ]);
+
+    const [row] = await counters.list({ where: { fieldName: 'optedIn' } });
+    expect(row.submissionCount).toBe(2);
+    expect(row.setCount).toBe(1);
+    expect(row.getValueHistogram()).toEqual({ true: 1, false: 1 });
+  });
+
+  it('counts value-less entries as submissions, honoring matchedDefault for the bit only', async () => {
+    await report([
+      { objectRef, fieldName: 'optedIn', matchedDefault: true },
+      { objectRef, fieldName: 'optedIn', matchedDefault: true },
+      { objectRef, fieldName: 'optedIn' },
+    ]);
+
+    const [row] = await counters.list({ where: { fieldName: 'optedIn' } });
+    expect(row.submissionCount).toBe(3);
+    expect(row.setCount).toBe(1);
+    // No value ⇒ no histogram, so a value-less batch can never drive a
+    // `default` suggestion.
+    expect(row.valueHistogram).toBeNull();
+  });
+
+  it('attributes distinct users only when the caller actually deviated', async () => {
+    const defaultOnlyUser = randomUUID();
+    await report([{ objectRef, fieldName: 'optedIn', value: false }], {
+      userId: defaultOnlyUser,
+    });
+    await report([{ objectRef, fieldName: 'optedIn', value: true }]);
+
+    const [row] = await counters.list({ where: { fieldName: 'optedIn' } });
+    expect(row.submissionCount).toBe(2);
+    expect(row.setCount).toBe(1);
+    expect(row.getDistinctUserIds()).toEqual([userId]);
+  });
+
+  it('keeps sensitive and readPermission-gated fields COUNT-ONLY: values never persist', async () => {
+    const secret = 'TAX-123-45-6789';
+    const gated = 'privileged-note';
+    await report([
+      { objectRef, fieldName: 'taxId', value: secret },
+      { objectRef, fieldName: 'gatedNotes', value: gated },
+    ]);
+
+    const rows = await counters.list({});
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.submissionCount).toBe(1);
+      expect(row.setCount).toBe(1);
+      expect(row.valueHistogram).toBeNull();
+      expect(row.valueHistogramOverflowed).toBe(false);
+    }
+
+    // Belt-and-braces: the raw values appear NOWHERE in the persisted rows.
+    const raw = await db.query('SELECT * FROM _smrt_field_usage_counters');
+    const dump = JSON.stringify(
+      Array.isArray(raw) ? raw : ((raw as { rows?: unknown[] }).rows ?? []),
+    );
+    expect(dump).not.toContain(secret);
+    expect(dump).not.toContain(gated);
+  });
+
+  it('histograms only low-cardinality types (boolean, reference ids)', async () => {
+    const owner = randomUUID();
+    await report([
+      { objectRef, fieldName: 'featured', value: true },
+      { objectRef, fieldName: 'featured', value: true },
+      { objectRef, fieldName: 'featured', value: false },
+      { objectRef, fieldName: 'ownerId', value: owner },
+      { objectRef, fieldName: 'title', value: 'free text stays out' },
+    ]);
+
+    const rows = await counters.list({});
+    const byField = new Map(rows.map((row) => [row.fieldName, row]));
+
+    expect(byField.get('featured')?.getValueHistogram()).toEqual({
+      true: 2,
+      false: 1,
+    });
+    // `featured` has no recorded code default, so all three submissions
+    // deviate; the histogram still covers every one of them.
+    expect(byField.get('featured')?.submissionCount).toBe(3);
+    expect(byField.get('featured')?.setCount).toBe(3);
+    expect(byField.get('ownerId')?.getValueHistogram()).toEqual({
+      [owner]: 1,
+    });
+    expect(byField.get('title')?.valueHistogram).toBeNull();
+  });
+
+  it('type-checks histogram samples (junk counts but is not recorded)', async () => {
+    await report([
+      { objectRef, fieldName: 'featured', value: 'not-a-boolean' },
+      { objectRef, fieldName: 'featured', value: true },
+      { objectRef, fieldName: 'ownerId', value: 42 },
+    ]);
+
+    const rows = await counters.list({});
+    const byField = new Map(rows.map((row) => [row.fieldName, row]));
+    // Both count as submissions and as deviations (neither equals `false`),
+    // but only the real boolean is histogrammed.
+    expect(byField.get('featured')?.submissionCount).toBe(2);
+    expect(byField.get('featured')?.setCount).toBe(2);
+    expect(byField.get('featured')?.getValueHistogram()).toEqual({ true: 1 });
+    expect(byField.get('ownerId')?.submissionCount).toBe(1);
+    expect(byField.get('ownerId')?.setCount).toBe(1);
+    expect(byField.get('ownerId')?.valueHistogram).toBeNull();
+  });
+
+  it('drops unknown and non-usage-addressable entries without failing the batch', async () => {
+    const result = await report([
+      { objectRef, fieldName: 'title', value: 'kept' },
+      { objectRef, fieldName: 'derived', value: 'transient out' },
+      { objectRef, fieldName: 'nope', value: 'unknown field' },
+      { objectRef: '@test/nowhere:Nope', fieldName: 'title', value: 'x' },
+    ]);
+    expect(result).toEqual({ accepted: 1, dropped: 3 });
+
+    const rows = await counters.list({});
+    expect(rows).toHaveLength(1);
+    expect(rows[0].fieldName).toBe('title');
+  });
+
+  it('merges same-day reports into one deterministic bucket per field', async () => {
+    const otherUser = randomUUID();
+    await report([{ objectRef, fieldName: 'featured', value: true }]);
+    await report([{ objectRef, fieldName: 'featured', value: true }], {
+      userId: otherUser,
+    });
+
+    const rows = await counters.list({});
+    expect(rows).toHaveLength(1);
+    const expectedId = await fieldUsageCounterId(
+      tenantId,
+      objectRef,
+      'featured',
+      fieldUsagePeriodForDate(new Date()),
+    );
+    expect(rows[0].id).toBe(expectedId);
+    expect(rows[0].submissionCount).toBe(2);
+    expect(rows[0].setCount).toBe(2);
+    expect(new Set(rows[0].getDistinctUserIds())).toEqual(
+      new Set([userId, otherUser]),
+    );
+    expect(rows[0].getValueHistogram()).toEqual({ true: 2 });
+  });
+
+  it('lets one member contribute one field sample per day, blocking threshold inflation', async () => {
+    const repeated = { objectRef, fieldName: 'optedIn', value: true };
+    for (let attempt = 0; attempt < 25; attempt += 1) {
+      await withTenant(
+        { tenantId, userId, permissions: new Set<string>() },
+        () => counters.reportUsage({ entries: [repeated] }),
+      );
+    }
+
+    const [row] = await counters.list({ where: { fieldName: 'optedIn' } });
+    expect(row.submissionCount).toBe(1);
+    expect(row.setCount).toBe(1);
+    expect(row.getValueHistogram()).toEqual({ true: 1 });
+
+    // Even deliberately permissive generation thresholds cannot turn one
+    // repeated caller into a dominant-value/default suggestion.
+    const result = await runFieldPolicySuggestionGeneration({
+      db,
+      minSetCount: 2,
+      defaultDominanceRatio: 0.5,
+      minDistinctUsers: 2,
+    });
+    expect(result.created).toBe(0);
+  });
+
+  it('bounds the batch and validates entry shape', async () => {
+    await expect(report([])).rejects.toThrow(/non-empty "entries"/);
+    // Input validation precedes the context gate, so no identity is needed.
+    await expect(counters.reportUsage({})).rejects.toThrow(
+      /non-empty "entries"/,
+    );
+    await expect(report([{ objectRef, fieldName: '' }])).rejects.toThrow(
+      /non-empty objectRef and fieldName/,
+    );
+
+    const tooMany = Array.from({ length: 101 }, () => ({
+      objectRef,
+      fieldName: 'title',
+      value: 'x',
+    }));
+    await expect(report(tooMany)).rejects.toThrow(/at most 100 entries/);
+  });
+
+  it('compares submitted values deterministically for server-side deviations', () => {
+    for (const [a, b] of [
+      [1, 1],
+      [0, false],
+      ['x', 'x'],
+      [{ a: 1 }, { a: 1 }],
+      [null, undefined],
+      [new Date('2026-01-01'), '2026-01-01T00:00:00.000Z'],
+    ] as Array<[unknown, unknown]>) {
+      expect(serverUsageValuesEqual(a, b)).toBe(
+        a === b || JSON.stringify(a) === JSON.stringify(b),
+      );
+    }
+  });
+
+  it('never records an unstorable reference id in a histogram (P1 regression)', async () => {
+    // A UUID-backed reference column would reject this id at insert time, so a
+    // recorded histogram entry could win dominance and then be refused at
+    // suggestion-write time. The submission still COUNTS; only the value is
+    // dropped.
+    const validOwner = randomUUID();
+    const result = await report([
+      { objectRef, fieldName: 'ownerId', value: 'not-a-uuid' },
+      { objectRef, fieldName: 'ownerId', value: '' },
+      {
+        objectRef,
+        fieldName: 'ownerId',
+        value: `${validOwner}-overlong-suffix`,
+      },
+      { objectRef, fieldName: 'ownerId', value: validOwner },
+    ]);
+    expect(result).toEqual({ accepted: 4, dropped: 0 });
+
+    const [row] = await counters.list({ where: { fieldName: 'ownerId' } });
+    expect(row.submissionCount).toBe(4);
+    expect(row.setCount).toBe(4);
+    expect(row.getValueHistogram()).toEqual({ [validOwner]: 1 });
+    const dump = JSON.stringify(row.getValueHistogram());
+    expect(dump).not.toContain('not-a-uuid');
+  });
+
+  it('counts prototype-shaped text ids as ordinary buckets (P2 regression)', async () => {
+    // On a plain object these read back as inherited members (a missing bucket
+    // looks present) and `__proto__` hits the prototype setter instead of
+    // creating an own key — both silently corrupt counts.
+    await report([
+      { objectRef, fieldName: 'externalRef', value: 'constructor' },
+      { objectRef, fieldName: 'externalRef', value: 'constructor' },
+      { objectRef, fieldName: 'externalRef', value: '__proto__' },
+      { objectRef, fieldName: 'externalRef', value: 'toString' },
+      { objectRef, fieldName: 'externalRef', value: 'hasOwnProperty' },
+      { objectRef, fieldName: 'externalRef', value: 'ordinary-id' },
+    ]);
+
+    const [row] = await counters.list({ where: { fieldName: 'externalRef' } });
+    const histogram = row.getValueHistogram();
+    // NOTE: the expectation is built with `Object.fromEntries`, never an object
+    // literal — `{ __proto__: 1 }` sets the prototype instead of defining a
+    // key, which is the same hazard this test guards in the production path.
+    expect(histogram).toEqual(
+      Object.fromEntries([
+        ['constructor', 2],
+        ['__proto__', 1],
+        ['toString', 1],
+        ['hasOwnProperty', 1],
+        ['ordinary-id', 1],
+      ]),
+    );
+    // Own keys, not inherited members — and the counts survive the JSON
+    // round-trip through the column.
+    expect(Object.keys(histogram).sort()).toEqual([
+      '__proto__',
+      'constructor',
+      'hasOwnProperty',
+      'ordinary-id',
+      'toString',
+    ]);
+    for (const key of Object.keys(histogram)) {
+      expect(Object.hasOwn(histogram, key)).toBe(true);
+      expect(typeof histogram[key]).toBe('number');
+    }
+    // A null-prototype map: no inherited members to shadow a missing bucket.
+    expect(Object.getPrototypeOf(histogram)).toBeNull();
+    expect(row.submissionCount).toBe(6);
+  });
+
+  it('rejects cross-tenant counter writes from an ambient context', async () => {
+    const foreign = new FieldUsageCounter({
+      db,
+      objectRef,
+      fieldName: 'title',
+      tenantId: randomUUID(),
+      period: fieldUsagePeriodForDate(new Date()),
+    });
+    await expect(
+      withTenant(
+        { tenantId, userId, permissions: new Set<string>() },
+        async () => {
+          foreign.setCount = 1;
+          await foreign.save();
+        },
+      ),
+    ).rejects.toThrow(TenantIsolationError);
+  });
+});
+
+describe('FieldUsageCounter persisted ownership (#2051 P2)', () => {
+  let db: DatabaseInterface;
+  let counters: FieldUsageCounterCollection;
+  let objectRef: string;
+  let foreignTenant: string;
+  let callerTenant: string;
+  let bucketId: string;
+
+  beforeEach(async () => {
+    setupTestTenancy();
+    clearFieldPolicyCache();
+    db = await getTestDatabase({
+      classes: ['FieldUsageCounter', 'FieldPolicy', 'Tenant'],
+    });
+    counters = await FieldUsageCounterCollection.create({ db });
+    objectRef = fixtureRef();
+    foreignTenant = randomUUID();
+    callerTenant = randomUUID();
+    const period = fieldUsagePeriodForDate(new Date());
+    bucketId = await fieldUsageCounterId(
+      foreignTenant,
+      objectRef,
+      'title',
+      period,
+    );
+    // Seeded by trusted execution (no ambient context), as the ingestion path
+    // and learning jobs do.
+    await counters.create({
+      id: bucketId,
+      objectRef,
+      fieldName: 'title',
+      tenantId: foreignTenant,
+      period,
+      submissionCount: 7,
+      setCount: 7,
+    });
+  });
+
+  afterEach(async () => {
+    clearFieldPolicyCache();
+    resetTenancy();
+    if (typeof (db as { close?: () => Promise<void> }).close === 'function') {
+      await (db as unknown as { close: () => Promise<void> }).close();
+    }
+  });
+
+  it('refuses to adopt a foreign row by re-stamping tenantId', async () => {
+    await expect(
+      withTenant(
+        {
+          tenantId: callerTenant,
+          userId: randomUUID(),
+          permissions: new Set(),
+        },
+        async () => {
+          // Bucket ids are deterministic and the helper is exported, so a
+          // foreign row is trivially addressable: load it, re-stamp the tenant,
+          // and an in-memory-only check would happily save it.
+          const foreign = await counters.get(bucketId);
+          if (!foreign) throw new Error('fixture row missing');
+          foreign.tenantId = callerTenant;
+          foreign.setCount = 999;
+          await foreign.save();
+        },
+      ),
+    ).rejects.toThrow(TenantIsolationError);
+
+    const untouched = await counters.get(bucketId);
+    expect(untouched?.tenantId).toBe(foreignTenant);
+    expect(untouched?.setCount).toBe(7);
+  });
+
+  it('refuses to delete a foreign row, re-stamped or not', async () => {
+    await expect(
+      withTenant(
+        {
+          tenantId: callerTenant,
+          userId: randomUUID(),
+          permissions: new Set(),
+        },
+        async () => {
+          const foreign = await counters.get(bucketId);
+          if (!foreign) throw new Error('fixture row missing');
+          await foreign.delete();
+        },
+      ),
+    ).rejects.toThrow(TenantIsolationError);
+
+    await expect(
+      withTenant(
+        {
+          tenantId: callerTenant,
+          userId: randomUUID(),
+          permissions: new Set(),
+        },
+        async () => {
+          const foreign = await counters.get(bucketId);
+          if (!foreign) throw new Error('fixture row missing');
+          foreign.tenantId = callerTenant;
+          await foreign.delete();
+        },
+      ),
+    ).rejects.toThrow(TenantIsolationError);
+
+    expect(await counters.get(bucketId)).not.toBeNull();
+  });
+
+  it('still allows the owning tenant and trusted execution', async () => {
+    await withTenant(
+      { tenantId: foreignTenant, userId: randomUUID(), permissions: new Set() },
+      async () => {
+        const own = await counters.get(bucketId);
+        if (!own) throw new Error('fixture row missing');
+        own.setCount = 8;
+        await own.save();
+      },
+    );
+    expect((await counters.get(bucketId))?.setCount).toBe(8);
+
+    const trusted = await counters.get(bucketId);
+    if (!trusted) throw new Error('fixture row missing');
+    await trusted.delete();
+    expect(await counters.get(bucketId)).toBeNull();
+  });
+});
+
+describe('FieldUsageCounter bounded approximations', () => {
+  it('caps the distinct-user set with an honest overflow marker', () => {
+    const counter = new FieldUsageCounter();
+    for (let i = 0; i < MAX_DISTINCT_USERS_PER_BUCKET; i++) {
+      counter.addDistinctUser(`user-${i}`);
+    }
+    expect(counter.distinctUserCount).toBe(MAX_DISTINCT_USERS_PER_BUCKET);
+    expect(counter.distinctUsersOverflowed).toBe(false);
+
+    counter.addDistinctUser('one-too-many');
+    expect(counter.distinctUserCount).toBe(MAX_DISTINCT_USERS_PER_BUCKET);
+    expect(counter.distinctUsersOverflowed).toBe(true);
+    expect(counter.getDistinctUserIds()).not.toContain('one-too-many');
+
+    // Re-adding a KNOWN user never trips the marker.
+    const before = counter.distinctUsersOverflowed;
+    counter.addDistinctUser('user-0');
+    expect(counter.distinctUsersOverflowed).toBe(before);
+  });
+
+  it('caps histogram buckets while existing keys keep counting', () => {
+    const counter = new FieldUsageCounter();
+    for (let i = 0; i < MAX_VALUE_HISTOGRAM_BUCKETS; i++) {
+      counter.recordHistogramSample(`value-${i}`);
+    }
+    counter.recordHistogramSample('overflow-key');
+    expect(counter.valueHistogramOverflowed).toBe(true);
+    expect(counter.getValueHistogram()['overflow-key']).toBeUndefined();
+
+    counter.recordHistogramSample('value-0');
+    expect(counter.getValueHistogram()['value-0']).toBe(2);
+  });
+
+  it('keeps prototype-shaped histogram keys distinct through the round trip', () => {
+    const counter = new FieldUsageCounter();
+    for (const key of ['constructor', '__proto__', 'toString', 'valueOf']) {
+      counter.recordHistogramSample(key);
+      counter.recordHistogramSample(key);
+    }
+    expect(counter.getValueHistogram()).toEqual(
+      Object.fromEntries([
+        ['constructor', 2],
+        ['__proto__', 2],
+        ['toString', 2],
+        ['valueOf', 2],
+      ]),
+    );
+
+    // Re-hydrating from the serialized column preserves them (JSON.parse
+    // materializes `__proto__` as an ordinary own property).
+    const rehydrated = new FieldUsageCounter({
+      valueHistogram: counter.valueHistogram,
+    });
+    const rehydratedHistogram = rehydrated.getValueHistogram();
+    // Read through a variable key: on this null-prototype map `__proto__` is
+    // ordinary DATA, but the literal accessor is (rightly) lint-flagged.
+    const protoKey = '__proto__';
+    expect(rehydratedHistogram[protoKey]).toBe(2);
+    expect(rehydratedHistogram.constructor).toBe(2);
+    expect(Object.hasOwn(rehydratedHistogram, protoKey)).toBe(true);
+    expect(Object.getPrototypeOf(rehydrated.getValueHistogram())).toBeNull();
+
+    // The bucket cap counts real buckets, not prototype members.
+    expect(Object.keys(rehydrated.getValueHistogram())).toHaveLength(4);
+    expect(counter.valueHistogramOverflowed).toBe(false);
+  });
+
+  it('parses junk JSON columns as empty (guarded helpers)', () => {
+    const counter = new FieldUsageCounter({
+      distinctUserIds: '{not json',
+      valueHistogram: '[definitely not]',
+    });
+    expect(counter.getDistinctUserIds()).toEqual([]);
+    expect(counter.getValueHistogram()).toEqual({});
+  });
+});

--- a/packages/fields/src/field-usage-learning.test.ts
+++ b/packages/fields/src/field-usage-learning.test.ts
@@ -1,0 +1,1210 @@
+/**
+ * #2051 learning jobs: threshold-driven suggestion generation (evidence,
+ * dedup, dismissal cool-down), counter/suggestion retention, the schedule
+ * target contract, and the dormant AgentSchedule installer.
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  crossPackageRef,
+  field,
+  getTestDatabase,
+  ObjectRegistry,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import {
+  resetTenancy,
+  setupTestTenancy,
+  TenantIsolationError,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+// Side-effect import: registers smrt-users' classes (Tenant) for the
+// resolver's default hierarchy loader.
+import '../../users/src/index.js';
+import { clearFieldPolicyCache } from './cache.js';
+import { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
+import { FieldPolicySuggestionCollection } from './collections/FieldPolicySuggestionCollection.js';
+import {
+  FieldUsageCounterCollection,
+  fieldUsageCounterId,
+} from './collections/FieldUsageCounterCollection.js';
+import { resolveFieldPolicy } from './field-policy-resolver.js';
+import { ACTIVE_SUGGESTION_KEY } from './models/FieldPolicySuggestion.js';
+import { fieldUsagePeriodForDate } from './models/FieldUsageCounter.js';
+import { MANAGE_FIELD_POLICY_PERMISSION } from './permissions.js';
+import {
+  FIELD_USAGE_SUGGESTION_DEFAULTS,
+  FieldUsageLearningAgent,
+  MAX_REPORTED_GROUP_FAILURES,
+  pruneFieldPolicySuggestions,
+  pruneFieldUsageCounters,
+  runFieldPolicySuggestionGeneration,
+  runFieldUsageMaintenance,
+} from './usage-learning.js';
+import {
+  DEFAULT_FIELD_USAGE_MAINTENANCE_CRON,
+  DEFAULT_FIELD_USAGE_SUGGESTION_CRON,
+  ensureFieldUsageLearningSchedules,
+  FIELD_USAGE_LEARNING_AGENT_TYPE,
+  FIELD_USAGE_MAINTENANCE_METHOD,
+  FIELD_USAGE_SUGGESTION_METHOD,
+  type FieldUsageAgentsModule,
+  fieldUsageScheduleId,
+} from './usage-schedules.js';
+import { isMissingWorkspaceDependency } from './users-module.js';
+
+@smrt({
+  packageName: '@test/smrt-fields-learning',
+  visibility: 'internal',
+  api: false,
+  cli: false,
+  mcp: false,
+})
+class LearningDoc extends SmrtObject {
+  @field({ ui: { basic: true } })
+  headline: string = '';
+
+  // Unmarked while headline is basic ⇒ 'advanced': the promote candidate.
+  @field()
+  region: string = '';
+
+  // Histogram-eligible default candidate; also advanced (unmarked). No
+  // recorded code default (a bare `= false` initializer is not captured in the
+  // manifest), so any submitted value is a deviation.
+  @field({ type: 'boolean' })
+  featured: boolean = false;
+
+  // Explicit `default: false` — the P1 dominance scenario: a value seen only
+  // in deviations must NOT look dominant against a sea of default submissions.
+  @field({ type: 'boolean', default: false })
+  optedIn: boolean = false;
+
+  // UUID-backed reference: the poisoned-histogram fixture (a non-UUID id is
+  // refused by the FieldPolicy rail at suggestion-write time).
+  @crossPackageRef('@happyvertical/smrt-users:User', { nullable: true })
+  ownerRef: string | null = null;
+
+  // Text-id reference: arbitrary ids are legitimate here, including
+  // prototype-shaped ones.
+  @crossPackageRef('@happyvertical/smrt-users:User', {
+    nullable: true,
+    idType: 'text',
+  })
+  externalOwner: string | null = null;
+}
+
+function fixtureRef(): string {
+  const registered = ObjectRegistry.getClassByConstructor(LearningDoc);
+  if (!registered?.qualifiedName) {
+    throw new Error('LearningDoc is not registered with a qualified name');
+  }
+  return registered.qualifiedName;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function daysAgoPeriod(days: number): string {
+  return fieldUsagePeriodForDate(new Date(Date.now() - days * DAY_MS));
+}
+
+describe('field usage learning jobs (#2051)', () => {
+  let db: DatabaseInterface;
+  let counters: FieldUsageCounterCollection;
+  let suggestions: FieldPolicySuggestionCollection;
+  let policies: FieldPolicyCollection;
+  let objectRef: string;
+  let tenantId: string;
+
+  /** Seed a counter bucket through the trusted (no-context) path. */
+  async function seedCounter(options: {
+    fieldName: string;
+    daysAgo?: number;
+    setCount: number;
+    /** Total submissions; defaults to `setCount` (all deviations). */
+    submissionCount?: number;
+    users?: string[];
+    usersOverflowed?: boolean;
+    histogram?: Record<string, number>;
+    tenantId?: string;
+    /** Emulate a pre-`submissionCount` row (total unknown). */
+    legacy?: boolean;
+  }): Promise<void> {
+    const owner = options.tenantId ?? tenantId;
+    const period = daysAgoPeriod(options.daysAgo ?? 0);
+    const users = options.users ?? [];
+    await counters.create({
+      id: await fieldUsageCounterId(
+        owner,
+        objectRef,
+        options.fieldName,
+        period,
+      ),
+      objectRef,
+      fieldName: options.fieldName,
+      tenantId: owner,
+      period,
+      submissionCount: options.legacy
+        ? 0
+        : (options.submissionCount ?? options.setCount),
+      setCount: options.setCount,
+      distinctUserIds: JSON.stringify(users),
+      distinctUserCount: users.length,
+      distinctUsersOverflowed: options.usersOverflowed ?? false,
+      ...(options.histogram
+        ? { valueHistogram: JSON.stringify(options.histogram) }
+        : {}),
+    });
+  }
+
+  const users = (n: number) => Array.from({ length: n }, () => randomUUID());
+
+  beforeEach(async () => {
+    setupTestTenancy();
+    clearFieldPolicyCache();
+    db = await getTestDatabase({
+      classes: [
+        'FieldPolicy',
+        'FieldPolicySuggestion',
+        'FieldUsageCounter',
+        'Tenant',
+      ],
+    });
+    counters = await FieldUsageCounterCollection.create({ db });
+    suggestions = await FieldPolicySuggestionCollection.create({ db });
+    policies = await FieldPolicyCollection.create({ db });
+    objectRef = fixtureRef();
+    tenantId = randomUUID();
+  });
+
+  afterEach(async () => {
+    clearFieldPolicyCache();
+    resetTenancy();
+    if (typeof (db as { close?: () => Promise<void> }).close === 'function') {
+      await (db as unknown as { close: () => Promise<void> }).close();
+    }
+  });
+
+  describe('suggestion generation', () => {
+    it('creates a promote suggestion with human-readable evidence once thresholds pass', async () => {
+      await seedCounter({
+        fieldName: 'region',
+        daysAgo: 2,
+        setCount: 9,
+        users: users(3),
+      });
+      await seedCounter({
+        fieldName: 'region',
+        daysAgo: 1,
+        setCount: 8,
+        users: users(2),
+      });
+
+      const summary = await runFieldPolicySuggestionGeneration({ db });
+      expect(summary.created).toBe(1);
+
+      const rows = await suggestions.list({
+        where: { tenantId, objectRef, fieldName: 'region', kind: 'promote' },
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].status).toBe('pending');
+      const evidence = rows[0].getEvidence();
+      expect(evidence.summary).toMatch(
+        /5 users set "region" to a non-default value in 17 of 17 submissions/,
+      );
+      expect(evidence.submissionCount).toBe(17);
+      expect(evidence.distinctUsers).toBe(5);
+      expect(evidence.setCount).toBe(17);
+      expect(evidence.threshold).toBe(
+        FIELD_USAGE_SUGGESTION_DEFAULTS.minDistinctUsers,
+      );
+    });
+
+    it('stays quiet below thresholds, for already-basic fields, and outside the window', async () => {
+      // Below the distinct-user threshold.
+      await seedCounter({
+        fieldName: 'region',
+        daysAgo: 1,
+        setCount: 20,
+        users: users(4),
+      });
+      // Already-basic field with plenty of usage.
+      await seedCounter({
+        fieldName: 'headline',
+        daysAgo: 1,
+        setCount: 50,
+        users: users(20),
+      });
+
+      let summary = await runFieldPolicySuggestionGeneration({ db });
+      expect(summary.created).toBe(0);
+
+      // Enough distinct users, but the buckets fell out of the window.
+      await seedCounter({
+        fieldName: 'region',
+        daysAgo: 45,
+        setCount: 30,
+        users: users(30),
+      });
+      summary = await runFieldPolicySuggestionGeneration({ db });
+      expect(summary.created).toBe(0);
+      expect(await suggestions.list({ where: { tenantId } })).toHaveLength(0);
+    });
+
+    it('treats an overflowed distinct-user set as an honest lower bound', async () => {
+      await seedCounter({
+        fieldName: 'region',
+        daysAgo: 1,
+        setCount: 300,
+        users: users(6),
+        usersOverflowed: true,
+      });
+      const summary = await runFieldPolicySuggestionGeneration({ db });
+      expect(summary.created).toBe(1);
+      const [row] = await suggestions.list({
+        where: { tenantId, fieldName: 'region' },
+      });
+      expect(row.getEvidence().distinctUsersAtLeast).toBe(true);
+      expect(row.getEvidence().summary).toMatch(/at least 6 users/);
+    });
+
+    it('creates a default suggestion from a value dominating TOTAL submissions', async () => {
+      await seedCounter({
+        fieldName: 'featured',
+        daysAgo: 1,
+        setCount: 12,
+        submissionCount: 12,
+        users: users(2),
+        histogram: { true: 11, false: 1 },
+      });
+
+      const summary = await runFieldPolicySuggestionGeneration({ db });
+      expect(summary.created).toBe(1);
+
+      const [row] = await suggestions.list({
+        where: { tenantId, fieldName: 'featured', kind: 'default' },
+      });
+      expect(row.getProposedValue()).toBe(true);
+      const evidence = row.getEvidence();
+      expect(evidence.topValue).toBe(true);
+      expect(evidence.topValueShare).toBeCloseTo(11 / 12, 4);
+      expect(evidence.submissionCount).toBe(12);
+      expect(evidence.setCount).toBe(12);
+      expect(evidence.summary).toMatch(
+        /92% of all 12 submissions used the value true/,
+      );
+    });
+
+    it('does NOT propose a value that only dominates the DEVIATIONS (P1 regression)', async () => {
+      // The reported scenario: a boolean defaulting to `false` collects 10
+      // `true` deviations while ~1000 submissions keep the default. Counting
+      // only deviations made `true` look 100% dominant; against TOTAL
+      // submissions it is ~1%.
+      await seedCounter({
+        fieldName: 'optedIn',
+        daysAgo: 1,
+        setCount: 10,
+        submissionCount: 1010,
+        users: users(2),
+        histogram: { true: 10, false: 1000 },
+      });
+
+      const summary = await runFieldPolicySuggestionGeneration({ db });
+      expect(summary.created).toBe(0);
+      expect(
+        await suggestions.list({ where: { tenantId, kind: 'default' } }),
+      ).toHaveLength(0);
+
+      // The SAME deviation count against a small total DOES dominate (another
+      // tenant, so the windows do not merge) — proving the denominator alone
+      // changed the verdict.
+      const smallTotalTenant = randomUUID();
+      await seedCounter({
+        fieldName: 'optedIn',
+        daysAgo: 1,
+        setCount: 10,
+        submissionCount: 11,
+        users: users(2),
+        histogram: { true: 10, false: 1 },
+        tenantId: smallTotalTenant,
+      });
+      const second = await runFieldPolicySuggestionGeneration({ db });
+      expect(second.created).toBe(1);
+      expect(
+        await suggestions.list({ where: { tenantId, kind: 'default' } }),
+      ).toHaveLength(0);
+      const [row] = await suggestions.list({
+        where: {
+          tenantId: smallTotalTenant,
+          fieldName: 'optedIn',
+          kind: 'default',
+        },
+      });
+      expect(row.getProposedValue()).toBe(true);
+      // Evidence states BOTH numbers: deviations and the total behind the %.
+      expect(row.getEvidence().summary).toMatch(
+        /10 of 11 submissions.*91% of all 11 submissions/,
+      );
+    });
+
+    it('merges prototype-shaped text ids without corrupting counts (P2 regression)', async () => {
+      // Split across two buckets so the MERGE path (not just storage) has to
+      // accumulate `constructor` / `__proto__` / `toString` as plain data.
+      const histogramA = Object.fromEntries([
+        ['constructor', 6],
+        ['__proto__', 1],
+        ['toString', 1],
+      ]);
+      const histogramB = Object.fromEntries([
+        ['constructor', 6],
+        ['__proto__', 1],
+      ]);
+      await seedCounter({
+        fieldName: 'externalOwner',
+        daysAgo: 2,
+        setCount: 8,
+        submissionCount: 8,
+        users: users(2),
+        histogram: histogramA,
+      });
+      await seedCounter({
+        fieldName: 'externalOwner',
+        daysAgo: 1,
+        setCount: 7,
+        submissionCount: 7,
+        users: users(2),
+        histogram: histogramB,
+      });
+
+      const summary = await runFieldPolicySuggestionGeneration({ db });
+      expect(summary.groupsFailed).toBe(0);
+      expect(summary.created).toBe(1);
+
+      // 12 of 15 submissions used `constructor` (80% — exactly the threshold),
+      // so it is proposed as the org default with an honest share.
+      const [row] = await suggestions.list({
+        where: { tenantId, fieldName: 'externalOwner', kind: 'default' },
+      });
+      expect(row.getProposedValue()).toBe('constructor');
+      expect(row.getEvidence().topValue).toBe('constructor');
+      expect(row.getEvidence().topValueShare).toBeCloseTo(12 / 15, 4);
+    });
+
+    it('skips default suggestions for legacy buckets with no recorded total', async () => {
+      await seedCounter({
+        fieldName: 'featured',
+        daysAgo: 1,
+        setCount: 40,
+        users: users(6),
+        histogram: { true: 40 },
+        legacy: true,
+      });
+
+      const summary = await runFieldPolicySuggestionGeneration({ db });
+      // Promote still fires (it needs no denominator); default is skipped, and
+      // the evidence says the total was never recorded.
+      expect(
+        await suggestions.list({ where: { tenantId, kind: 'default' } }),
+      ).toHaveLength(0);
+      expect(summary.created).toBe(1);
+      const [promote] = await suggestions.list({
+        where: { tenantId, kind: 'promote' },
+      });
+      expect(promote.getEvidence().submissionCountUnknown).toBe(true);
+      expect(promote.getEvidence().summary).toMatch(
+        /40 of an unrecorded number of submissions/,
+      );
+    });
+
+    it('skips default suggestions when dominance is weak or the default already matches', async () => {
+      await seedCounter({
+        fieldName: 'featured',
+        daysAgo: 1,
+        setCount: 12,
+        submissionCount: 12,
+        users: users(2),
+        histogram: { true: 7, false: 5 },
+      });
+      let summary = await runFieldPolicySuggestionGeneration({ db });
+      expect(summary.created).toBe(0);
+
+      // Dominant, but the org default already IS the dominant value.
+      await withTenant(
+        {
+          tenantId,
+          userId: randomUUID(),
+          permissions: new Set([MANAGE_FIELD_POLICY_PERMISSION]),
+        },
+        async () => {
+          await policies.create({
+            objectRef,
+            fieldName: 'featured',
+            scopeType: 'tenant',
+            tenantId,
+            defaultValue: JSON.stringify(true),
+          });
+        },
+      );
+      await seedCounter({
+        fieldName: 'featured',
+        daysAgo: 2,
+        setCount: 100,
+        submissionCount: 100,
+        users: users(2),
+        histogram: { true: 100 },
+      });
+      summary = await runFieldPolicySuggestionGeneration({ db });
+      expect(summary.created).toBe(0);
+    });
+
+    it('dedups against pending suggestions and honors the dismissal cool-down', async () => {
+      await seedCounter({
+        fieldName: 'region',
+        daysAgo: 1,
+        setCount: 30,
+        users: users(8),
+      });
+
+      expect((await runFieldPolicySuggestionGeneration({ db })).created).toBe(
+        1,
+      );
+      // Pending suggestion suppresses regeneration.
+      const second = await runFieldPolicySuggestionGeneration({ db });
+      expect(second.created).toBe(0);
+      expect(second.suppressed).toBeGreaterThanOrEqual(1);
+
+      // Dismissed with a live cool-down: still suppressed.
+      const [pending] = await suggestions.list({
+        where: { tenantId, fieldName: 'region', status: 'pending' },
+      });
+      await withTenant(
+        {
+          tenantId,
+          userId: randomUUID(),
+          permissions: new Set([MANAGE_FIELD_POLICY_PERMISSION]),
+        },
+        () => suggestions.dismissSuggestion({ id: String(pending.id) }),
+      );
+      expect((await runFieldPolicySuggestionGeneration({ db })).created).toBe(
+        0,
+      );
+
+      // Cool-down elapsed (raw clock rewind): regeneration resumes.
+      await db.query(
+        `UPDATE _smrt_field_policy_suggestions SET cooldown_until = ? WHERE id = ?`,
+        new Date(Date.now() - 1000).toISOString(),
+        String(pending.id),
+      );
+      expect((await runFieldPolicySuggestionGeneration({ db })).created).toBe(
+        1,
+      );
+    });
+
+    it('never lets one unprocessable group abort the run (P1 regression)', async () => {
+      // A poisoned group: a reference histogram carrying an id the FieldPolicy
+      // rail refuses (non-UUID for a UUID-backed column). Its `default`
+      // candidate wins dominance and then fails suggestion validation — which
+      // used to abort the whole cross-tenant pass, starving every later group
+      // until the buckets expired.
+      const poisonedTenant = '00000000-0000-4000-8000-000000000001';
+      const healthyTenant = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+      await seedCounter({
+        fieldName: 'ownerRef',
+        daysAgo: 1,
+        setCount: 12,
+        submissionCount: 12,
+        users: users(2),
+        histogram: { 'not-a-uuid': 12 },
+        tenantId: poisonedTenant,
+      });
+      await seedCounter({
+        fieldName: 'region',
+        daysAgo: 1,
+        setCount: 30,
+        users: users(8),
+        tenantId: healthyTenant,
+      });
+
+      const summary = await runFieldPolicySuggestionGeneration({ db });
+
+      // The bad group is reported, not thrown...
+      expect(summary.groupsFailed).toBe(1);
+      expect(summary.failures).toHaveLength(1);
+      expect(summary.failures[0]).toContain('ownerRef');
+      expect(summary.failures.length).toBeLessThanOrEqual(
+        MAX_REPORTED_GROUP_FAILURES,
+      );
+      // ...and the healthy group still produced its suggestion.
+      expect(summary.created).toBe(1);
+      const healthy = await suggestions.list({
+        where: { tenantId: healthyTenant, fieldName: 'region' },
+      });
+      expect(healthy).toHaveLength(1);
+      expect(
+        await suggestions.list({ where: { tenantId: poisonedTenant } }),
+      ).toHaveLength(0);
+
+      // A clean re-run reports no failures once the poisoned bucket is gone.
+      await db.query(
+        `DELETE FROM _smrt_field_usage_counters WHERE tenant_id = ?`,
+        poisonedTenant,
+      );
+      const second = await runFieldPolicySuggestionGeneration({ db });
+      expect(second.groupsFailed).toBe(0);
+      expect(second.failures).toEqual([]);
+    });
+
+    it('keeps ONE active row when overlapping runs race the dedup (P2 regression)', async () => {
+      await seedCounter({
+        fieldName: 'region',
+        daysAgo: 1,
+        setCount: 30,
+        users: users(8),
+      });
+
+      // Two overlapping generation passes (the global + a tenant-specific
+      // schedule) both observe "no pending row" before either inserts. The
+      // active-slot unique index converges them, so no duplicate can exist —
+      // the guarantee is structural, not a check-then-insert race.
+      await Promise.all([
+        runFieldPolicySuggestionGeneration({ db }),
+        runFieldPolicySuggestionGeneration({ db }),
+      ]);
+
+      const pending = await suggestions.list({
+        where: { tenantId, objectRef, fieldName: 'region', kind: 'promote' },
+      });
+      expect(pending).toHaveLength(1);
+      expect(pending[0].status).toBe('pending');
+      expect(pending[0].activeKey).toBe(ACTIVE_SUGGESTION_KEY);
+    });
+
+    it('frees the active slot on settle, keeping settled history addressable', async () => {
+      await seedCounter({
+        fieldName: 'region',
+        daysAgo: 1,
+        setCount: 30,
+        users: users(8),
+      });
+      await runFieldPolicySuggestionGeneration({ db });
+      const [active] = await suggestions.list({
+        where: { tenantId, fieldName: 'region', status: 'pending' },
+      });
+
+      await withTenant(
+        {
+          tenantId,
+          userId: randomUUID(),
+          permissions: new Set([MANAGE_FIELD_POLICY_PERMISSION]),
+        },
+        () => suggestions.dismissSuggestion({ id: String(active.id) }),
+      );
+
+      // Settled rows key themselves by id (id preserved — core conflicts a
+      // persisted row on its PK), so the shared 'active' slot is free again.
+      const settled = await suggestions.get(String(active.id));
+      expect(settled?.status).toBe('dismissed');
+      expect(settled?.activeKey).toBe(String(active.id));
+
+      // Cool-down elapsed ⇒ a new active row may be written alongside the
+      // settled one, and both survive.
+      await db.query(
+        `UPDATE _smrt_field_policy_suggestions SET cooldown_until = ? WHERE id = ?`,
+        new Date(Date.now() - 1000).toISOString(),
+        String(active.id),
+      );
+      await runFieldPolicySuggestionGeneration({ db });
+      const all = await suggestions.list({
+        where: { tenantId, fieldName: 'region', kind: 'promote' },
+      });
+      expect(all).toHaveLength(2);
+      expect(all.filter((row) => row.status === 'pending')).toHaveLength(1);
+      expect(all.filter((row) => row.status === 'dismissed')).toHaveLength(1);
+    });
+
+    it('restricts an ambient-context run to the ambient tenant', async () => {
+      const otherTenant = randomUUID();
+      await seedCounter({
+        fieldName: 'region',
+        daysAgo: 1,
+        setCount: 30,
+        users: users(8),
+      });
+      await seedCounter({
+        fieldName: 'region',
+        daysAgo: 1,
+        setCount: 30,
+        users: users(8),
+        tenantId: otherTenant,
+      });
+
+      await withTenant(
+        { tenantId, userId: randomUUID(), permissions: new Set<string>() },
+        async () => {
+          const summary = await runFieldPolicySuggestionGeneration({ db });
+          expect(summary.created).toBe(1);
+        },
+      );
+      expect(
+        await suggestions.list({ where: { tenantId, status: 'pending' } }),
+      ).toHaveLength(1);
+      expect(
+        await suggestions.list({
+          where: { tenantId: otherTenant, status: 'pending' },
+        }),
+      ).toHaveLength(0);
+    });
+
+    it('accepting a generated suggestion shifts the resolver for the org (end to end)', async () => {
+      await seedCounter({
+        fieldName: 'region',
+        daysAgo: 1,
+        setCount: 30,
+        users: users(8),
+      });
+      await runFieldPolicySuggestionGeneration({ db });
+
+      const before = await resolveFieldPolicy(objectRef, { tenantId, db });
+      expect(before.fields.region.visibility).toBe('advanced');
+
+      const managerId = randomUUID();
+      await withTenant(
+        {
+          tenantId,
+          userId: managerId,
+          permissions: new Set([MANAGE_FIELD_POLICY_PERMISSION]),
+        },
+        async () => {
+          const { suggestions: pending } =
+            await suggestions.pendingSuggestions();
+          expect(pending).toHaveLength(1);
+          await suggestions.acceptSuggestion({ id: pending[0].id });
+        },
+      );
+
+      const after = await resolveFieldPolicy(objectRef, { tenantId, db });
+      expect(after.fields.region.visibility).toBe('basic');
+    });
+  });
+
+  describe('retention', () => {
+    it('prunes counter rows by age (period cutoff), oldest first', async () => {
+      await seedCounter({ fieldName: 'region', daysAgo: 40, setCount: 1 });
+      await seedCounter({ fieldName: 'region', daysAgo: 10, setCount: 1 });
+      await seedCounter({ fieldName: 'region', daysAgo: 0, setCount: 1 });
+
+      const result = await pruneFieldUsageCounters(db, {
+        maxAgeMs: 30 * DAY_MS,
+      });
+      expect(result.pruned).toBe(1);
+      const remaining = await counters.list({ orderBy: 'period ASC' });
+      expect(remaining.map((row) => row.period)).toEqual([
+        daysAgoPeriod(10),
+        daysAgoPeriod(0),
+      ]);
+    });
+
+    it('prunes counter rows over maxRows, keeping the newest buckets', async () => {
+      for (const daysAgo of [5, 4, 3, 2, 1]) {
+        await seedCounter({ fieldName: 'region', daysAgo, setCount: 1 });
+      }
+      const result = await pruneFieldUsageCounters(db, { maxRows: 2 });
+      expect(result.pruned).toBe(3);
+      const remaining = await counters.list({ orderBy: 'period ASC' });
+      expect(remaining.map((row) => row.period)).toEqual([
+        daysAgoPeriod(2),
+        daysAgoPeriod(1),
+      ]);
+    });
+
+    it('honors an EXPLICIT zero bound instead of the default (P2 regression)', async () => {
+      // `0` is a value the prune functions accept and it means "purge
+      // everything"; swapping it for the 90d/100k default silently ignores an
+      // operator's explicit instruction.
+      for (const daysAgo of [5, 1, 0]) {
+        await seedCounter({ fieldName: 'region', daysAgo, setCount: 1 });
+      }
+      await suggestions.create({
+        tenantId,
+        objectRef,
+        fieldName: 'headline',
+        kind: 'promote',
+        evidence: '{}',
+        status: 'accepted',
+        decidedAt: new Date(),
+      });
+
+      const purged = await runFieldUsageMaintenance({
+        db,
+        counterMaxRows: 0,
+        counterMaxAgeMs: 0,
+        suggestionAcceptedMaxAgeMs: 0,
+      });
+      expect(purged.countersPruned).toBeGreaterThanOrEqual(3);
+      expect(await counters.list({})).toHaveLength(0);
+      // An accepted suggestion of age >= 0 is settled history, so it goes too.
+      expect(purged.suggestionsPruned).toBe(1);
+
+      // `undefined` still takes the documented default: nothing this fresh is
+      // pruned by the 90d / 100k / 180d bounds.
+      for (const daysAgo of [5, 1, 0]) {
+        await seedCounter({ fieldName: 'region', daysAgo, setCount: 1 });
+      }
+      await suggestions.create({
+        tenantId,
+        objectRef,
+        fieldName: 'headline',
+        kind: 'promote',
+        evidence: '{}',
+        status: 'accepted',
+        decidedAt: new Date(),
+      });
+      const defaulted = await runFieldUsageMaintenance({ db });
+      expect(defaulted.countersPruned).toBe(0);
+      expect(defaulted.suggestionsPruned).toBe(0);
+      expect(await counters.list({})).toHaveLength(3);
+    });
+
+    it('requires at least one bound (pruneChangeFeed parity)', async () => {
+      await expect(pruneFieldUsageCounters(db, {})).rejects.toThrow(
+        /maxAgeMs and\/or maxRows/,
+      );
+    });
+
+    it('prunes ONLY settled suggestions: dismissed past cool-down or accepted old', async () => {
+      const mkSuggestion = async (
+        fieldName: string,
+        status: 'pending' | 'accepted' | 'dismissed',
+        options: { cooldownUntil?: Date; decidedAt?: Date } = {},
+      ) =>
+        suggestions.create({
+          tenantId,
+          objectRef,
+          fieldName,
+          kind: 'promote',
+          evidence: '{}',
+          status,
+          ...(options.cooldownUntil
+            ? { cooldownUntil: options.cooldownUntil }
+            : {}),
+          ...(options.decidedAt ? { decidedAt: options.decidedAt } : {}),
+        });
+
+      const now = new Date();
+      await mkSuggestion('region', 'pending');
+      await mkSuggestion('headline', 'dismissed', {
+        cooldownUntil: new Date(now.getTime() - 1000), // past cool-down
+        decidedAt: new Date(now.getTime() - 1000),
+      });
+      await mkSuggestion('featured', 'dismissed', {
+        cooldownUntil: new Date(now.getTime() + DAY_MS), // still cooling down
+        decidedAt: now,
+      });
+
+      const acceptedOld = await mkSuggestion('region', 'accepted', {
+        decidedAt: new Date(now.getTime() - 200 * DAY_MS),
+      });
+      const acceptedRecent = await mkSuggestion('headline', 'accepted', {
+        decidedAt: now,
+      });
+
+      const result = await pruneFieldPolicySuggestions(db, {
+        acceptedMaxAgeMs: 180 * DAY_MS,
+        now,
+      });
+      expect(result.pruned).toBe(2);
+
+      const remaining = await suggestions.list({ where: { tenantId } });
+      const keys = remaining.map((row) => `${row.fieldName}:${row.status}`);
+      expect(keys).toContain('region:pending');
+      expect(keys).toContain('featured:dismissed');
+      expect(keys).toContain('headline:accepted');
+      expect(remaining.map((row) => String(row.id))).not.toContain(
+        String(acceptedOld.id),
+      );
+      expect(remaining.map((row) => String(row.id))).toContain(
+        String(acceptedRecent.id),
+      );
+    });
+
+    it('runFieldUsageMaintenance combines both prunes and reports the tally', async () => {
+      await seedCounter({ fieldName: 'region', daysAgo: 120, setCount: 1 });
+      await seedCounter({ fieldName: 'region', daysAgo: 0, setCount: 1 });
+      await suggestions.create({
+        tenantId,
+        objectRef,
+        fieldName: 'headline',
+        kind: 'promote',
+        evidence: '{}',
+        status: 'dismissed',
+        cooldownUntil: new Date(Date.now() - 1000),
+        decidedAt: new Date(Date.now() - 1000),
+      });
+
+      const summary = await runFieldUsageMaintenance({ db });
+      expect(summary.countersPruned).toBe(1);
+      expect(summary.suggestionsPruned).toBe(1);
+      expect(await counters.list({})).toHaveLength(1);
+    });
+  });
+
+  describe('schedule target + installer', () => {
+    it('registers the agent type the schedules name, with a closed background allowlist', () => {
+      const registered = ObjectRegistry.getClassByConstructor(
+        FieldUsageLearningAgent,
+      );
+      expect(registered?.qualifiedName).toBe(FIELD_USAGE_LEARNING_AGENT_TYPE);
+      expect([...FieldUsageLearningAgent.backgroundEligibleMethods]).toEqual([
+        FIELD_USAGE_MAINTENANCE_METHOD,
+        FIELD_USAGE_SUGGESTION_METHOD,
+      ]);
+    });
+
+    it('runs the schedule methods with methodArgs payload overrides', async () => {
+      await seedCounter({
+        fieldName: 'region',
+        daysAgo: 1,
+        setCount: 3,
+        users: users(2),
+      });
+      await seedCounter({ fieldName: 'region', daysAgo: 4, setCount: 1 });
+      // The jobs runner constructs the registered class and initializes it
+      // before invoking the scheduled method — mirror that here.
+      const agent = new FieldUsageLearningAgent({ db });
+      await agent.initialize();
+      // Threshold lowered through the schedule payload: 2 users suffice.
+      const summary = await agent.runSuggestionGeneration({
+        minDistinctUsers: 2,
+        junk: 'ignored',
+      });
+      expect(summary.created).toBe(1);
+
+      // Age pruning is day-granular (`period < day(now - maxAgeMs)`), so the
+      // 4-day-old bucket falls, the 1-day-old bucket survives.
+      const maintenance = await agent.runUsageMaintenance({
+        counterMaxAgeMs: 2 * DAY_MS,
+      });
+      expect(maintenance.countersPruned).toBe(1);
+    });
+
+    it('installs DORMANT global schedules idempotently through the agents seam', async () => {
+      const created: Array<Record<string, unknown>> = [];
+      const fakeAgents: FieldUsageAgentsModule = {
+        AgentScheduleCollection: {
+          create: async () => ({
+            list: async (options: { where: Record<string, unknown> }) =>
+              created.filter((row) =>
+                options.where.id !== undefined
+                  ? row.id === options.where.id
+                  : row.method === options.where.method,
+              ) as Array<{ id?: string }>,
+            create: async (data: Record<string, unknown>) => {
+              // Model the real strict-insert contract: a caller-supplied id
+              // that already exists raises instead of adopting the row.
+              if (
+                data._insertOnly === true &&
+                created.some((row) => row.id === data.id)
+              ) {
+                throw new Error(`UNIQUE constraint failed: id ${data.id}`);
+              }
+              const row = { ...data, saved: false };
+              created.push(row);
+              return {
+                ...row,
+                save: async () => {
+                  row.saved = true;
+                  return row;
+                },
+              };
+            },
+          }),
+        },
+      };
+
+      const first = await ensureFieldUsageLearningSchedules({
+        db,
+        agentsModule: fakeAgents,
+      });
+      expect(first).toEqual({ installed: true, created: 2 });
+      expect(created).toHaveLength(2);
+      for (const row of created) {
+        expect(row.agentType).toBe(FIELD_USAGE_LEARNING_AGENT_TYPE);
+        expect(row.tenantId).toBeNull();
+        expect(row.enabled).toBe(false); // DORMANT by default
+        expect(row.status).toBe('disabled');
+        expect(row.saved).toBe(true);
+      }
+      expect(created.map((row) => row.method)).toEqual([
+        FIELD_USAGE_MAINTENANCE_METHOD,
+        FIELD_USAGE_SUGGESTION_METHOD,
+      ]);
+      expect(created.map((row) => row.cron)).toEqual([
+        DEFAULT_FIELD_USAGE_MAINTENANCE_CRON,
+        DEFAULT_FIELD_USAGE_SUGGESTION_CRON,
+      ]);
+
+      // Ids are DETERMINISTIC (that is what makes concurrent installs converge)
+      // and the installer never advertises a timezone it cannot honor.
+      expect(created.map((row) => row.id)).toEqual([
+        await fieldUsageScheduleId(FIELD_USAGE_MAINTENANCE_METHOD),
+        await fieldUsageScheduleId(FIELD_USAGE_SUGGESTION_METHOD),
+      ]);
+      for (const row of created) {
+        expect(row.timezone).toBeUndefined();
+        expect(row._insertOnly).toBe(true);
+      }
+
+      // Idempotent: existing rows are never touched or duplicated.
+      const second = await ensureFieldUsageLearningSchedules({
+        db,
+        agentsModule: fakeAgents,
+      });
+      expect(second).toEqual({ installed: true, created: 0 });
+      expect(created).toHaveLength(2);
+    });
+
+    it('yields exactly one row per schedule under concurrent installs (P2 regression)', async () => {
+      // Two replicas starting against an EMPTY database: both pre-checks see
+      // nothing, so only the deterministic id + strict insert can prevent
+      // duplicate schedules (which, when enabled, would run every job twice).
+      const rows: Array<Record<string, unknown>> = [];
+      let releaseChecks: () => void = () => {};
+      const bothChecked = new Promise<void>((resolve) => {
+        let seen = 0;
+        releaseChecks = () => {
+          seen += 1;
+          if (seen >= 2) resolve();
+        };
+      });
+
+      const fakeAgents: FieldUsageAgentsModule = {
+        AgentScheduleCollection: {
+          create: async () => ({
+            list: async (options: { where: Record<string, unknown> }) => {
+              // The installer re-reads by id after a failed insert to confirm
+              // a genuine collision; that lookup must not be interleaved.
+              if (options.where.id !== undefined) {
+                return rows.filter(
+                  (row) => row.id === options.where.id,
+                ) as Array<{ id?: string; tenantId?: string | null }>;
+              }
+              const matches = rows.filter(
+                (row) => row.method === options.where.method,
+              ) as Array<{ id?: string; tenantId?: string | null }>;
+              // Force the interleaving: both installers finish their existence
+              // check before either inserts.
+              releaseChecks();
+              await bothChecked;
+              return matches;
+            },
+            create: async (data: Record<string, unknown>) => {
+              if (rows.some((row) => row.id === data.id)) {
+                throw new Error(`UNIQUE constraint failed: id ${data.id}`);
+              }
+              rows.push({ ...data });
+              return { ...data, save: async () => data };
+            },
+          }),
+        },
+      };
+
+      const [a, b] = await Promise.all([
+        ensureFieldUsageLearningSchedules({ db, agentsModule: fakeAgents }),
+        ensureFieldUsageLearningSchedules({ db, agentsModule: fakeAgents }),
+      ]);
+
+      expect(rows).toHaveLength(2);
+      expect(new Set(rows.map((row) => row.method)).size).toBe(2);
+      expect(new Set(rows.map((row) => row.id)).size).toBe(2);
+      // Between them exactly two rows were created; the loser reports 0 for
+      // whichever schedules it lost.
+      expect(a.created + b.created).toBe(2);
+      expect(a.installed && b.installed).toBe(true);
+    });
+
+    it('still installs the GLOBAL rows when tenant-scoped ones exist (P2 regression)', async () => {
+      // A deployment may run tenant-specific schedules for the same agent type
+      // and method. An unscoped existence check would match those and silently
+      // skip the global schedules this installer promises.
+      const rows: Array<Record<string, unknown>> = [
+        {
+          id: randomUUID(),
+          tenantId: randomUUID(),
+          agentType: FIELD_USAGE_LEARNING_AGENT_TYPE,
+          method: FIELD_USAGE_MAINTENANCE_METHOD,
+        },
+        {
+          id: randomUUID(),
+          tenantId: randomUUID(),
+          agentType: FIELD_USAGE_LEARNING_AGENT_TYPE,
+          method: FIELD_USAGE_SUGGESTION_METHOD,
+        },
+      ];
+      const fakeAgents: FieldUsageAgentsModule = {
+        AgentScheduleCollection: {
+          create: async () => ({
+            list: async (options: { where: Record<string, unknown> }) =>
+              rows.filter(
+                (row) => row.method === options.where.method,
+              ) as Array<{
+                id?: string;
+                tenantId?: string | null;
+              }>,
+            create: async (data: Record<string, unknown>) => {
+              const row = { ...data, id: randomUUID() };
+              rows.push(row);
+              return { ...row, save: async () => row };
+            },
+          }),
+        },
+      };
+
+      const result = await ensureFieldUsageLearningSchedules({
+        db,
+        agentsModule: fakeAgents,
+      });
+      expect(result).toEqual({ installed: true, created: 2 });
+      const globals = rows.filter(
+        (row) => row.tenantId === null || row.tenantId === undefined,
+      );
+      expect(globals).toHaveLength(2);
+      expect(globals.map((row) => row.method)).toEqual([
+        FIELD_USAGE_MAINTENANCE_METHOD,
+        FIELD_USAGE_SUGGESTION_METHOD,
+      ]);
+      // The pre-existing tenant rows were left untouched.
+      expect(
+        rows.filter((row) => typeof row.tenantId === 'string'),
+      ).toHaveLength(2);
+
+      // And a second pass now finds the globals and creates nothing.
+      const again = await ensureFieldUsageLearningSchedules({
+        db,
+        agentsModule: fakeAgents,
+      });
+      expect(again).toEqual({ installed: true, created: 0 });
+    });
+
+    it('propagates non-collision install failures instead of faking success (P2 regression)', async () => {
+      // A transient DB/schema/validation error must NOT be read as "another
+      // installer won the deterministic-id race": that would report
+      // installed:true with the schedule missing.
+      const brokenAgents: FieldUsageAgentsModule = {
+        AgentScheduleCollection: {
+          create: async () => ({
+            list: async (options: { where: Record<string, unknown> }) => {
+              // Nothing exists — neither the pre-check nor the collision
+              // re-read finds a row, so the failure cannot be a collision.
+              void options;
+              return [];
+            },
+            create: async () => {
+              throw new Error('no such column: method_args');
+            },
+          }),
+        },
+      };
+      await expect(
+        ensureFieldUsageLearningSchedules({ db, agentsModule: brokenAgents }),
+      ).rejects.toThrow(/no such column/);
+
+      // A GENUINE collision (the row is there on re-read) still reports
+      // installed:true and creates nothing.
+      const existingRows: Array<Record<string, unknown>> = [];
+      const collidingAgents: FieldUsageAgentsModule = {
+        AgentScheduleCollection: {
+          create: async () => ({
+            list: async (options: { where: Record<string, unknown> }) =>
+              options.where.id === undefined
+                ? [] // pre-check sees nothing (the racing replica is mid-insert)
+                : (existingRows.filter(
+                    (row) => row.id === options.where.id,
+                  ) as Array<{ id?: string; tenantId?: string | null }>),
+            create: async (data: Record<string, unknown>) => {
+              // Simulate the racing replica landing its row first.
+              existingRows.push({ ...data });
+              throw new Error('UNIQUE constraint failed: id');
+            },
+          }),
+        },
+      };
+      const result = await ensureFieldUsageLearningSchedules({
+        db,
+        agentsModule: collidingAgents,
+      });
+      expect(result).toEqual({ installed: true, created: 0 });
+    });
+
+    it('opt-in activation and per-schedule threshold payloads are honored', async () => {
+      const created: Array<Record<string, unknown>> = [];
+      const fakeAgents: FieldUsageAgentsModule = {
+        AgentScheduleCollection: {
+          create: async () => ({
+            list: async () => [],
+            create: async (data: Record<string, unknown>) => {
+              created.push(data);
+              return { ...data, save: async () => data };
+            },
+          }),
+        },
+      };
+
+      await ensureFieldUsageLearningSchedules({
+        db,
+        agentsModule: fakeAgents,
+        enabled: true,
+        suggestionArgs: { minDistinctUsers: 3 },
+      });
+      expect(created[0].enabled).toBe(true);
+      expect(created[0].status).toBe('active');
+      expect(created[1].methodArgs).toEqual({ minDistinctUsers: 3 });
+    });
+
+    it('refuses installation from a non-bypass tenant context (global state)', async () => {
+      await expect(
+        withTenant(
+          { tenantId, userId: randomUUID(), permissions: new Set<string>() },
+          () =>
+            ensureFieldUsageLearningSchedules({
+              db,
+              agentsModule: {
+                AgentScheduleCollection: {
+                  create: async () => ({
+                    list: async () => [],
+                    create: async (data: Record<string, unknown>) => data,
+                  }),
+                },
+              },
+            }),
+        ),
+      ).rejects.toThrow(TenantIsolationError);
+    });
+
+    it('detects a missing agents package vs an installed-but-broken one', () => {
+      const missing = new Error(
+        "Cannot find package '@happyvertical/smrt-agents' imported from x",
+      );
+      expect(
+        isMissingWorkspaceDependency(missing, '@happyvertical/smrt-agents'),
+      ).toBe(true);
+
+      const wrapped = new Error(
+        'Failed to load @happyvertical/smrt-agents for field usage learning schedule installation: could not find source.',
+      );
+      expect(
+        isMissingWorkspaceDependency(wrapped, '@happyvertical/smrt-agents'),
+      ).toBe(true);
+
+      // A transitive failure INSIDE an installed agents package rethrows.
+      const transitive = new Error('boom');
+      transitive.cause = new Error(
+        "Cannot find package '@happyvertical/ai' imported from packages/agents/src/agent.ts",
+      );
+      expect(
+        isMissingWorkspaceDependency(transitive, '@happyvertical/smrt-agents'),
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/fields/src/field-usage-learning.test.ts
+++ b/packages/fields/src/field-usage-learning.test.ts
@@ -20,7 +20,7 @@ import {
   withTenant,
 } from '@happyvertical/smrt-tenancy';
 import type { DatabaseInterface } from '@happyvertical/sql';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // Side-effect import: registers smrt-users' classes (Tenant) for the
 // resolver's default hierarchy loader.
 import '../../users/src/index.js';
@@ -41,6 +41,7 @@ import {
   MAX_REPORTED_GROUP_FAILURES,
   pruneFieldPolicySuggestions,
   pruneFieldUsageCounters,
+  pruneFieldUsageReportReceipts,
   runFieldPolicySuggestionGeneration,
   runFieldUsageMaintenance,
 } from './usage-learning.js';
@@ -169,6 +170,7 @@ describe('field usage learning jobs (#2051)', () => {
         'FieldPolicy',
         'FieldPolicySuggestion',
         'FieldUsageCounter',
+        'FieldUsageReportReceipt',
         'Tenant',
       ],
     });
@@ -719,6 +721,34 @@ describe('field usage learning jobs (#2051)', () => {
       ]);
     });
 
+    it('prunes daily receipts at the counter age cutoff without reopening active de-duplication', async () => {
+      await withTenant(
+        { tenantId, userId: randomUUID(), permissions: new Set() },
+        () =>
+          counters.reportUsage({
+            entries: [
+              { objectRef, fieldName: 'region' },
+              { objectRef, fieldName: 'headline' },
+            ],
+          }),
+      );
+
+      const now = Date.now();
+      const clock = vi.spyOn(Date, 'now').mockReturnValue(now + 120 * DAY_MS);
+      try {
+        const countersPruned = await pruneFieldUsageCounters(db, {
+          maxAgeMs: 90 * DAY_MS,
+        });
+        const receiptsPruned = await pruneFieldUsageReportReceipts(db, {
+          maxAgeMs: 90 * DAY_MS,
+        });
+        expect(countersPruned.pruned).toBe(2);
+        expect(receiptsPruned.pruned).toBe(2);
+      } finally {
+        clock.mockRestore();
+      }
+    });
+
     it('honors an EXPLICIT zero bound instead of the default (P2 regression)', async () => {
       // `0` is a value the prune functions accept and it means "purge
       // everything"; swapping it for the 90d/100k default silently ignores an
@@ -845,6 +875,7 @@ describe('field usage learning jobs (#2051)', () => {
 
       const summary = await runFieldUsageMaintenance({ db });
       expect(summary.countersPruned).toBe(1);
+      expect(summary.receiptsPruned).toBe(0);
       expect(summary.suggestionsPruned).toBe(1);
       expect(await counters.list({})).toHaveLength(1);
     });

--- a/packages/fields/src/generated-surfaces.test.ts
+++ b/packages/fields/src/generated-surfaces.test.ts
@@ -26,6 +26,8 @@ import {
 } from '../../users/src/index.js';
 import { clearFieldPolicyCache } from './cache.js';
 import { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
+import { FieldPolicySuggestionCollection } from './collections/FieldPolicySuggestionCollection.js';
+import { FieldUsageCounterCollection } from './collections/FieldUsageCounterCollection.js';
 import {
   MANAGE_FIELD_POLICY_PERMISSION,
   PERSONALIZE_FIELD_POLICY_PERMISSION,
@@ -71,14 +73,25 @@ const passThroughAuth =
 describe('smrt-fields generated surfaces', () => {
   let db: Awaited<ReturnType<typeof getTestDatabase>>;
   let policies: FieldPolicyCollection;
+  let suggestions: FieldPolicySuggestionCollection;
+  let counters: FieldUsageCounterCollection;
 
   beforeEach(async () => {
     setupTestTenancy();
     clearFieldPolicyCache();
     db = await getTestDatabase({
-      classes: ['FieldPolicy', 'Tenant', 'Membership'],
+      classes: [
+        'FieldPolicy',
+        'FieldPolicySuggestion',
+        'FieldUsageCounter',
+        'FieldUsageReportReceipt',
+        'Tenant',
+        'Membership',
+      ],
     });
     policies = await FieldPolicyCollection.create({ db });
+    suggestions = await FieldPolicySuggestionCollection.create({ db });
+    counters = await FieldUsageCounterCollection.create({ db });
   });
 
   afterEach(async () => {
@@ -305,6 +318,168 @@ describe('smrt-fields generated surfaces', () => {
       }),
     );
     expect(badJson.status).toBe(400);
+  });
+
+  it('dispatches usage and suggestion custom routes with trusted tenant identity only', async () => {
+    const objectRef = fixtureRef();
+    const tenantA = randomUUID();
+    const tenantB = randomUUID();
+    const userA = randomUUID();
+    const userB = randomUUID();
+    const api = new APIGenerator({ authMiddleware: passThroughAuth }, { db });
+    api.registerCollection('fieldusagecounter', counters);
+    api.registerCollection('fieldpolicysuggestion', suggestions);
+    const handler = api.generateHandler();
+
+    // Both system tables remain closed outside their explicitly declared
+    // collection actions; no generated CRUD/read surface may leak rows.
+    for (const path of ['fieldusagecounter', 'fieldpolicysuggestion']) {
+      expect(
+        (await handler(new Request(`http://localhost/api/v1/${path}`))).status,
+      ).toBe(405);
+      expect(
+        (
+          await handler(
+            new Request(`http://localhost/api/v1/${path}`, {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({}),
+            }),
+          )
+        ).status,
+      ).toBe(405);
+    }
+
+    // No trusted tenant/user context means no report attribution and no queue
+    // access, regardless of identity-shaped request body keys.
+    const reportWithoutPrincipal = await handler(
+      new Request('http://localhost/api/v1/fieldusagecounter/report', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          entries: [{ objectRef, fieldName: 'headline', value: 'x' }],
+          tenantId: tenantA,
+          userId: userA,
+        }),
+      }),
+    );
+    expect(reportWithoutPrincipal.status).toBe(403);
+    const pendingWithoutPrincipal = await handler(
+      new Request('http://localhost/api/v1/fieldpolicysuggestion/pending', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ tenantId: tenantA }),
+      }),
+    );
+    expect(pendingWithoutPrincipal.status).toBe(403);
+
+    const reported = await withTenant(
+      { tenantId: tenantA, userId: userA, permissions: new Set<string>() },
+      () =>
+        handler(
+          new Request('http://localhost/api/v1/fieldusagecounter/report', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              entries: [{ objectRef, fieldName: 'headline', value: 'x' }],
+              // These untrusted body values cannot redirect the counter.
+              tenantId: tenantB,
+              userId: userB,
+            }),
+          }),
+        ),
+    );
+    expect(reported.status).toBe(200);
+    expect(await reported.json()).toMatchObject({
+      action: 'reportUsage',
+      result: { accepted: 1, dropped: 0 },
+    });
+    expect((await counters.list({})).map((row) => row.tenantId)).toEqual([
+      tenantA,
+    ]);
+
+    const pendingAccept = await withSystemContext(() =>
+      suggestions.create({
+        tenantId: tenantA,
+        objectRef,
+        fieldName: 'requiredHeadline',
+        kind: 'promote',
+        evidence: '{}',
+      }),
+    );
+    const pendingDismiss = await withSystemContext(() =>
+      suggestions.create({
+        tenantId: tenantA,
+        objectRef,
+        fieldName: 'headline',
+        kind: 'promote',
+        evidence: '{}',
+      }),
+    );
+
+    const managerA = {
+      tenantId: tenantA,
+      userId: userA,
+      permissions: new Set([MANAGE_FIELD_POLICY_PERMISSION]),
+    };
+    const managerB = {
+      tenantId: tenantB,
+      userId: userB,
+      permissions: new Set([MANAGE_FIELD_POLICY_PERMISSION]),
+    };
+    const pendingA = await withTenant(managerA, () =>
+      handler(
+        new Request('http://localhost/api/v1/fieldpolicysuggestion/pending', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({}),
+        }),
+      ),
+    );
+    expect(pendingA.status).toBe(200);
+    expect(await pendingA.json()).toMatchObject({
+      action: 'pendingSuggestions',
+      result: { total: 2 },
+    });
+    const pendingB = await withTenant(managerB, () =>
+      handler(
+        new Request('http://localhost/api/v1/fieldpolicysuggestion/pending', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ tenantId: tenantA }),
+        }),
+      ),
+    );
+    expect(pendingB.status).toBe(200);
+    expect(await pendingB.json()).toMatchObject({
+      action: 'pendingSuggestions',
+      result: { total: 0 },
+    });
+
+    const accepted = await withTenant(managerA, () =>
+      handler(
+        new Request('http://localhost/api/v1/fieldpolicysuggestion/accept', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ id: pendingAccept.id, tenantId: tenantB }),
+        }),
+      ),
+    );
+    expect(accepted.status).toBe(200);
+    expect(await accepted.json()).toMatchObject({ action: 'acceptSuggestion' });
+    const dismissed = await withTenant(managerA, () =>
+      handler(
+        new Request('http://localhost/api/v1/fieldpolicysuggestion/dismiss', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ id: pendingDismiss.id, tenantId: tenantB }),
+        }),
+      ),
+    );
+    expect(dismissed.status).toBe(200);
+    expect(await dismissed.json()).toMatchObject({
+      action: 'dismissSuggestion',
+    });
   });
 
   it('creates a row at EVERY scope tier through the generated REST surface', async () => {
@@ -859,6 +1034,85 @@ describe('smrt-fields generated surfaces', () => {
       (index) => index?.unique === true,
     );
     expect(uniqueIndexes.map((index) => index.columns)).toEqual([naturalKey]);
+  });
+
+  it('mirrors natural keys on every decorated #2051 collection table schema', () => {
+    // The scanner retains per-class schemas in the manifest even when runtime
+    // registry schemas collapse by table name. Assert the two model/collection
+    // pairs here so a future collection config cannot silently fall back to
+    // SmrtObject's `(slug, context)` index.
+    const manifest = JSON.parse(
+      readFileSync(resolve(process.cwd(), '.smrt/manifest.json'), 'utf8'),
+    ) as {
+      objects?: Record<
+        string,
+        {
+          schema?: {
+            indexes?: Array<{ columns?: string[]; unique?: boolean }>;
+          };
+        }
+      >;
+    };
+    const expected = [
+      {
+        suffixes: [':FieldUsageCounter', ':FieldUsageCounterCollection'],
+        naturalKey: ['object_ref', 'field_name', 'tenant_id', 'period'],
+      },
+      {
+        suffixes: [
+          ':FieldPolicySuggestion',
+          ':FieldPolicySuggestionCollection',
+        ],
+        naturalKey: [
+          'object_ref',
+          'field_name',
+          'tenant_id',
+          'kind',
+          'active_key',
+        ],
+      },
+      {
+        suffixes: [
+          ':FieldUsageReportReceipt',
+          ':FieldUsageReportReceiptCollection',
+        ],
+        naturalKey: [
+          'tenant_id',
+          'user_id',
+          'object_ref',
+          'field_name',
+          'period',
+        ],
+      },
+    ];
+
+    for (const { suffixes, naturalKey } of expected) {
+      const entries = Object.entries(manifest.objects ?? {}).filter(([name]) =>
+        suffixes.some((suffix) => name.endsWith(suffix)),
+      );
+      expect(entries).toHaveLength(2);
+      for (const [name, entry] of entries) {
+        const uniqueIndexes = (entry.schema?.indexes ?? []).filter(
+          (index) => index.unique === true,
+        );
+        expect({
+          name,
+          unique: uniqueIndexes.map((index) => index.columns),
+        }).toEqual({
+          name,
+          unique: [naturalKey],
+        });
+      }
+    }
+
+    // Keep imports live: they are also a direct source-mode registration
+    // smoke test for the two collection decorators.
+    expect(FieldUsageCounterCollection._itemClass.name).toBe(
+      'FieldUsageCounter',
+    );
+    expect(FieldPolicySuggestionCollection._itemClass.name).toBe(
+      'FieldPolicySuggestion',
+    );
   });
 
   it('exposes nothing over MCP or the runtime CLI', async () => {

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -22,6 +22,17 @@ export {
 } from './cache.js';
 export { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
 export {
+  FieldPolicySuggestionCollection,
+  FieldPolicySuggestionConflictError,
+} from './collections/FieldPolicySuggestionCollection.js';
+export {
+  decodeHistogramKey,
+  FieldUsageCounterCollection,
+  isHistogramEligibleField,
+  MAX_USAGE_REPORT_ENTRIES,
+  serializeHistogramSample,
+} from './collections/FieldUsageCounterCollection.js';
+export {
   assertDefaultValueMatchesFieldType,
   buildCodeSeedDelta,
   buildCodeSeedVisibility,
@@ -33,6 +44,7 @@ export {
   isPolicyAddressableField,
   isRequiredField,
   isSensitiveField,
+  isStorableReferenceId,
   isTransientField,
   isUsableRequiredDefault,
   type RegisteredFieldInfo,
@@ -45,6 +57,16 @@ export {
   resolveSurvivingTenantChainIds,
 } from './field-policy-resolver.js';
 export { FieldPolicy } from './models/FieldPolicy.js';
+export {
+  ACTIVE_SUGGESTION_KEY,
+  FieldPolicySuggestion,
+} from './models/FieldPolicySuggestion.js';
+export {
+  FieldUsageCounter,
+  fieldUsagePeriodForDate,
+  MAX_DISTINCT_USERS_PER_BUCKET,
+  MAX_VALUE_HISTOGRAM_BUCKETS,
+} from './models/FieldUsageCounter.js';
 export {
   ensureFieldPolicyPermissionsRegistered,
   FIELD_POLICY_PERMISSION_DEFINITIONS,
@@ -65,7 +87,9 @@ export {
   parseFieldPolicyCatalogQuery,
 } from './settings-catalog.js';
 export {
+  type AcceptFieldPolicySuggestionResult,
   APP_FIELD_POLICY_SCOPE_KEY,
+  type DismissFieldPolicySuggestionResult,
   type ExplainedObjectFieldPolicy,
   FIELD_POLICY_SCOPE_TYPES,
   FIELD_POLICY_VISIBILITIES,
@@ -83,16 +107,33 @@ export {
   type FieldPolicyLayerContribution,
   type FieldPolicyOptions,
   type FieldPolicyScopeType,
+  type FieldPolicySuggestionData,
+  type FieldPolicySuggestionKind,
+  type FieldPolicySuggestionStatus,
   type FieldPolicyTenantHierarchyLoader,
   type FieldPolicyTenantHierarchyProvider,
   type FieldPolicyTenantNode,
   type FieldPolicyUsersModule,
   type FieldPolicyUsersTenantRecord,
   type FieldPolicyVisibility,
+  type FieldUsageReportEntry,
+  type FieldUsageReportResult,
+  type PendingFieldPolicySuggestionsResult,
   type ResolvedFieldPolicy,
   type ResolvedObjectFieldPolicy,
   type ResolveFieldPolicyOptions,
 } from './types.js';
+export {
+  FieldUsageLearningAgent,
+  pruneFieldPolicySuggestions,
+  pruneFieldUsageCounters,
+  runFieldPolicySuggestionGeneration,
+  runFieldUsageMaintenance,
+} from './usage-learning.js';
+export {
+  ensureFieldUsageLearningSchedules,
+  FIELD_USAGE_LEARNING_AGENT_TYPE,
+} from './usage-schedules.js';
 
 // Contribute the field-policy capabilities to the shared runtime catalog on
 // import, so normal role seeding and every server gate recognize the slugs.

--- a/packages/fields/src/models/FieldPolicySuggestion.ts
+++ b/packages/fields/src/models/FieldPolicySuggestion.ts
@@ -1,0 +1,406 @@
+import {
+  crossPackageRef,
+  field,
+  SmrtObject,
+  type SmrtObjectOptions,
+  smrt,
+} from '@happyvertical/smrt-core';
+import {
+  getCurrentTenant,
+  isSuperAdminBypass,
+  TenantIsolationError,
+  tenantId,
+} from '@happyvertical/smrt-tenancy';
+import {
+  assertDefaultValueMatchesFieldType,
+  getFieldReadPermission,
+  getObjectFieldMap,
+  isSensitiveField,
+  isTransientField,
+} from '../field-definitions.js';
+import {
+  FIELD_POLICY_SUGGESTION_KINDS,
+  FIELD_POLICY_SUGGESTION_STATUSES,
+  type FieldPolicySuggestionData,
+  type FieldPolicySuggestionKind,
+  type FieldPolicySuggestionStatus,
+} from '../types.js';
+
+/**
+ * `activeKey` sentinel for the single ACTIVE (pending) suggestion per
+ * `(objectRef, fieldName, tenantId, kind)`. Settled rows key themselves by id,
+ * so history never competes for the slot.
+ */
+export const ACTIVE_SUGGESTION_KEY = 'active';
+
+export interface FieldPolicySuggestionOptions extends SmrtObjectOptions {
+  objectRef?: string;
+  fieldName?: string;
+  tenantId?: string;
+  kind?: FieldPolicySuggestionKind;
+  proposedValue?: string | null;
+  evidence?: string;
+  status?: FieldPolicySuggestionStatus;
+  cooldownUntil?: Date | null;
+  decidedBy?: string | null;
+  decidedAt?: Date | null;
+}
+
+/**
+ * A pending, human-reviewable field-policy improvement proposed from real
+ * usage (epic #2045, issue #2051): promote a field to the `basic` tier, or
+ * seed an org default with the dominant observed value.
+ *
+ * Suggestion-first by design — a row DOES NOTHING until a
+ * `fields.policy.manage` holder accepts it, and acceptance writes the
+ * org-scope {@link ../models/FieldPolicy.FieldPolicy} row through NORMAL
+ * validation (registry check, type check, security rail, required-field
+ * invariant, ownership + permission split). Dismissing sets a cool-down that
+ * suppresses regeneration of the same suggestion.
+ *
+ * **One ACTIVE suggestion per identity, structurally** (not merely by a
+ * check-then-insert): {@link activeKey} is a computed column holding the
+ * sentinel {@link ACTIVE_SUGGESTION_KEY} while the row is `pending` and the
+ * row's own id once it settles, and it participates in `conflictColumns`. The
+ * unique index therefore admits at most ONE pending row per
+ * `(objectRef, fieldName, tenantId, kind)` while every settled row keys
+ * itself — so two overlapping generation runs (e.g. a global and a
+ * tenant-specific schedule) UPSERT onto the same row instead of duplicating,
+ * with no transaction spanning their reads. It is the `FieldPolicy.scopeKey`
+ * trick applied to a lifecycle slot. On settle the column flips to the row's
+ * id, which frees the slot for a post-cool-down regeneration while keeping the
+ * dismissed/accepted history (and its id) intact — core conflicts a persisted
+ * row on its primary key (#1472), so the flip is a plain UPDATE.
+ *
+ * #1885 seam: this substrate is fully independent of personas'
+ * `DirectiveProposal` review queue (no shared producer discriminator —
+ * deliberately out of scope). Tenant learning agents MAY create
+ * FieldPolicySuggestion rows through this model's normal validation; the
+ * reviewed `fields.policy.manage` acceptance gate is unchanged by who
+ * proposed.
+ */
+// Generated surfaces are CLOSED: reads would enumerate every tenant's
+// suggestion queue (the model is not class-level tenant-scoped, see below),
+// and generated writes would let callers forge evidence or flip status
+// without the gate. All access goes through the collection's scoped actions
+// (`pendingSuggestions`, `acceptSuggestion`, `dismissSuggestion`) or trusted
+// server-side code.
+@smrt({
+  tableName: '_smrt_field_policy_suggestions',
+  conflictColumns: [
+    'object_ref',
+    'field_name',
+    'tenant_id',
+    'kind',
+    'active_key',
+  ],
+  api: { include: [] },
+  cli: false,
+  mcp: { include: [] },
+})
+export class FieldPolicySuggestion extends SmrtObject {
+  /** Qualified class name of the target object (`@package/name:ClassName`). */
+  @field({ required: true })
+  objectRef: string = '';
+
+  /** Field name on the target object (validated against the registry). */
+  @field({ required: true })
+  fieldName: string = '';
+
+  /** Owning tenant (required — suggestions always target one org). */
+  @tenantId()
+  tenantId?: string;
+
+  /** What the suggestion proposes ('promote' | 'default'). */
+  @field({ required: true })
+  kind: FieldPolicySuggestionKind = 'promote';
+
+  /**
+   * JSON-encoded proposed default (`kind: 'default'` only) — the exact
+   * encoding `FieldPolicy.defaultValue` stores, so acceptance passes it
+   * through unchanged. NULL for `promote`.
+   */
+  @field({ type: 'text', nullable: true })
+  proposedValue: string | null = null;
+
+  /**
+   * Human-readable evidence as a JSON string: a `summary` sentence plus the
+   * structured window/threshold numbers behind it (see
+   * `buildFieldUsageEvidence`).
+   */
+  @field({ type: 'text' })
+  evidence: string = '{}';
+
+  /** Lifecycle status ('pending' | 'accepted' | 'dismissed'). */
+  @field({ required: true })
+  status: FieldPolicySuggestionStatus = 'pending';
+
+  /**
+   * Computed lifecycle-slot key, set in `save()`: {@link ACTIVE_SUGGESTION_KEY}
+   * while `pending`, else the row's own id. It exists ONLY to make the
+   * `conflictColumns` unique index express "at most one ACTIVE suggestion per
+   * identity, unlimited settled history" (the `FieldPolicy.scopeKey`
+   * precedent) — never read it for logic; `status` owns that.
+   */
+  @field({ type: 'text', required: true })
+  activeKey: string = ACTIVE_SUGGESTION_KEY;
+
+  /**
+   * Until this instant, a dismissed suggestion suppresses regeneration of the
+   * same `(objectRef, fieldName, tenantId, kind)` suggestion. NULL until
+   * dismissed.
+   */
+  @field({ type: 'datetime', nullable: true })
+  cooldownUntil: Date | null = null;
+
+  /** Who accepted/dismissed (audit attribution, #2050); not validated. */
+  @crossPackageRef('@happyvertical/smrt-users:User', { nullable: true })
+  decidedBy: string | null = null;
+
+  /** When the suggestion was accepted/dismissed. */
+  @field({ type: 'datetime', nullable: true })
+  decidedAt: Date | null = null;
+
+  constructor(options: FieldPolicySuggestionOptions = {}) {
+    super(options);
+    if (options.objectRef !== undefined) this.objectRef = options.objectRef;
+    if (options.fieldName !== undefined) this.fieldName = options.fieldName;
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.kind !== undefined) this.kind = options.kind;
+    if (options.proposedValue !== undefined) {
+      this.proposedValue = options.proposedValue;
+    }
+    if (options.evidence !== undefined) this.evidence = options.evidence;
+    if (options.status !== undefined) this.status = options.status;
+    if (options.cooldownUntil !== undefined) {
+      this.cooldownUntil = options.cooldownUntil;
+    }
+    if (options.decidedBy !== undefined) this.decidedBy = options.decidedBy;
+    if (options.decidedAt !== undefined) this.decidedAt = options.decidedAt;
+  }
+
+  /** Parse the stored evidence object (guarded; junk parses as empty). */
+  getEvidence(): Record<string, unknown> {
+    try {
+      const parsed = JSON.parse(this.evidence);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {};
+    } catch {
+      return {};
+    }
+  }
+
+  /** Serialize an evidence object into the stored JSON string. */
+  setEvidence(evidence: Record<string, unknown>): void {
+    this.evidence = JSON.stringify(evidence);
+  }
+
+  /** Parse the proposed value; `undefined` when none is stored. */
+  getProposedValue(): unknown {
+    if (this.proposedValue === null || this.proposedValue === undefined) {
+      return undefined;
+    }
+    try {
+      return JSON.parse(this.proposedValue);
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** Serialized row shape for the collection actions. */
+  toSuggestionData(): FieldPolicySuggestionData {
+    return {
+      id: String(this.id),
+      objectRef: this.objectRef,
+      fieldName: this.fieldName,
+      tenantId: String(this.tenantId ?? ''),
+      kind: this.kind,
+      proposedValue: this.proposedValue ?? null,
+      evidence: this.getEvidence(),
+      status: this.status,
+      cooldownUntil: toIsoOrNull(this.cooldownUntil),
+      decidedBy: this.decidedBy ?? null,
+      decidedAt: toIsoOrNull(this.decidedAt),
+    };
+  }
+
+  override async save(): Promise<this> {
+    await this.assertRowOwnedByAmbientContext('save');
+    await this.validateFieldPolicySuggestion();
+    this.applyActiveKey();
+    return super.save();
+  }
+
+  /**
+   * Recompute the lifecycle-slot key: the shared sentinel while pending (so
+   * the unique index admits exactly one), the row's own id once settled (so
+   * history never competes for the slot and the freed slot allows a
+   * post-cool-down regeneration). A settled row that has not been persisted
+   * yet is assigned its id here — the key must be unique from the first write.
+   */
+  private applyActiveKey(): void {
+    if (this.status === 'pending') {
+      this.activeKey = ACTIVE_SUGGESTION_KEY;
+      return;
+    }
+    if (!this.id) {
+      this.id = crypto.randomUUID();
+    }
+    this.activeKey = String(this.id);
+  }
+
+  override async delete(): Promise<void> {
+    await this.assertRowOwnedByAmbientContext('delete');
+    await super.delete();
+  }
+
+  /**
+   * The "normal validation" the #1885 seam promises producers: registry-known
+   * field, policy-addressable, never sensitive/read-permission-gated/transient
+   * (those fields are count-only in usage data and get no suggestions), valid
+   * kind/status, and for `default` suggestions a JSON proposed value that
+   * type-checks against the manifest field type.
+   */
+  private async validateFieldPolicySuggestion(): Promise<void> {
+    if (!this.objectRef || this.objectRef.trim() === '') {
+      throw new Error('FieldPolicySuggestion.objectRef is required');
+    }
+    if (!this.fieldName || this.fieldName.trim() === '') {
+      throw new Error('FieldPolicySuggestion.fieldName is required');
+    }
+    if (!this.tenantId) {
+      throw new Error('FieldPolicySuggestion.tenantId is required');
+    }
+    if (!FIELD_POLICY_SUGGESTION_KINDS.includes(this.kind)) {
+      throw new Error(
+        `FieldPolicySuggestion.kind must be one of ` +
+          `${FIELD_POLICY_SUGGESTION_KINDS.join(', ')}; got "${this.kind}"`,
+      );
+    }
+    if (!FIELD_POLICY_SUGGESTION_STATUSES.includes(this.status)) {
+      throw new Error(
+        `FieldPolicySuggestion.status must be one of ` +
+          `${FIELD_POLICY_SUGGESTION_STATUSES.join(', ')}; got "${this.status}"`,
+      );
+    }
+
+    const fields = await getObjectFieldMap(this.objectRef);
+    const fieldDef = fields.get(this.fieldName);
+    if (!fieldDef) {
+      throw new Error(
+        `Unknown field "${this.fieldName}" on "${this.objectRef}"`,
+      );
+    }
+    if (
+      fieldDef._meta?.__smrtSystemField === true ||
+      fieldDef.type === 'oneToMany' ||
+      fieldDef.type === 'manyToMany' ||
+      fieldDef.type === 'meta'
+    ) {
+      throw new Error(
+        `Field "${this.fieldName}" on "${this.objectRef}" is not ` +
+          `policy-addressable, so it cannot carry a suggestion`,
+      );
+    }
+    if (
+      isSensitiveField(fieldDef) ||
+      getFieldReadPermission(fieldDef) !== undefined ||
+      isTransientField(fieldDef)
+    ) {
+      throw new Error(
+        `Field "${this.fieldName}" on "${this.objectRef}" is sensitive, ` +
+          `read-permission-gated, or transient; usage data for it is ` +
+          `count-only and it cannot carry a suggestion`,
+      );
+    }
+
+    if (this.kind === 'default') {
+      if (this.proposedValue === null) {
+        throw new Error(
+          "FieldPolicySuggestion of kind 'default' requires a proposedValue",
+        );
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(this.proposedValue);
+      } catch (error) {
+        throw new Error(
+          `FieldPolicySuggestion.proposedValue is not valid JSON: ` +
+            `${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      assertDefaultValueMatchesFieldType(
+        this.objectRef,
+        this.fieldName,
+        fieldDef,
+        parsed,
+      );
+    } else if (this.proposedValue !== null) {
+      throw new Error(
+        "FieldPolicySuggestion of kind 'promote' must not carry a proposedValue",
+      );
+    }
+  }
+
+  /**
+   * Tenant write boundary (the FieldPolicy posture): inside a non-bypass
+   * tenant context a caller may only touch its own tenant's suggestions —
+   * checked against BOTH the in-memory scope and, for persisted rows, the
+   * PERSISTED tenant (a foreign row cannot be re-scoped into the caller's
+   * tenant). Trusted execution (no context / bypass) is exempt — that is what
+   * lets the scheduled generation job and platform flows operate.
+   */
+  private async assertRowOwnedByAmbientContext(
+    operation: 'save' | 'delete',
+  ): Promise<void> {
+    const context = getCurrentTenant();
+    if (!context || isSuperAdminBypass()) {
+      return;
+    }
+    if (this.tenantId !== context.tenantId) {
+      throw new TenantIsolationError(
+        `Tenant isolation violation in FieldPolicySuggestion.${operation}: ` +
+          `context tenant is '${context.tenantId}' but the row belongs to ` +
+          `'${this.tenantId}'`,
+        {
+          tenantId: context.tenantId,
+          attemptedTenantId: this.tenantId ?? undefined,
+        },
+      );
+    }
+    if (this.id) {
+      const persisted = await this.db.get(this.tableName, { id: this.id });
+      if (persisted) {
+        const row = persisted as Record<string, unknown>;
+        const persistedTenant =
+          row.tenantId ?? row.tenant_id ?? this.tenantId ?? null;
+        if (
+          persistedTenant !== null &&
+          String(persistedTenant) !== context.tenantId
+        ) {
+          throw new TenantIsolationError(
+            `Tenant isolation violation in FieldPolicySuggestion.` +
+              `${operation}: the persisted row belongs to ` +
+              `'${String(persistedTenant)}'`,
+            {
+              tenantId: context.tenantId,
+              attemptedTenantId: String(persistedTenant),
+            },
+          );
+        }
+      }
+    }
+  }
+}
+
+function toIsoOrNull(value: Date | string | null | undefined): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
+}

--- a/packages/fields/src/models/FieldUsageCounter.ts
+++ b/packages/fields/src/models/FieldUsageCounter.ts
@@ -1,0 +1,411 @@
+import {
+  field,
+  SmrtObject,
+  type SmrtObjectOptions,
+  smrt,
+} from '@happyvertical/smrt-core';
+import {
+  getCurrentTenant,
+  isSuperAdminBypass,
+  TenantIsolationError,
+  tenantId,
+} from '@happyvertical/smrt-tenancy';
+
+/**
+ * Cap on distinct-user ids stored per bucket. For threshold questions
+ * ("did at least N distinct users set this field?") the capped set is EXACT up
+ * to the cap; once overflowed, {@link FieldUsageCounter.distinctUserCount} is
+ * an honest LOWER BOUND that trivially satisfies any threshold ≤ the cap.
+ */
+export const MAX_DISTINCT_USERS_PER_BUCKET = 100;
+
+/** Cap on histogram buckets per counter row (bounded storage). */
+export const MAX_VALUE_HISTOGRAM_BUCKETS = 25;
+
+/** Longest histogram key recorded; longer samples are skipped (count-only). */
+export const MAX_VALUE_HISTOGRAM_KEY_LENGTH = 64;
+
+/** `period` bucket format: UTC calendar day. */
+export const FIELD_USAGE_PERIOD_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/** The UTC day bucket for a timestamp (`YYYY-MM-DD`). */
+export function fieldUsagePeriodForDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * A prototype-free histogram map.
+ *
+ * Histogram keys are user-supplied values (an `idType: 'text'` reference id may
+ * legitimately be `constructor`, `toString`, or `__proto__`). On a plain object
+ * those either resolve to inherited members — making an absent bucket look
+ * present and corrupting its count — or, for `__proto__`, invoke the prototype
+ * setter instead of creating an own key. A null-prototype object has no such
+ * members, so every key behaves like data. Use this everywhere histogram counts
+ * are accumulated (storage AND merge paths).
+ */
+export function emptyHistogram(): Record<string, number> {
+  return Object.create(null) as Record<string, number>;
+}
+
+export interface FieldUsageCounterOptions extends SmrtObjectOptions {
+  objectRef?: string;
+  fieldName?: string;
+  tenantId?: string;
+  period?: string;
+  submissionCount?: number;
+  setCount?: number;
+  distinctUserCount?: number;
+  distinctUserIds?: string;
+  distinctUsersOverflowed?: boolean;
+  valueHistogram?: string | null;
+  valueHistogramOverflowed?: boolean;
+}
+
+/**
+ * Period-bucketed field usage counter (epic #2045, issue #2051).
+ *
+ * One row aggregates field submissions for a single
+ * `(objectRef, fieldName, tenantId, period)` — the substrate the
+ * suggestion-generation job reads. Counters are deliberately APPROXIMATE:
+ * ingestion is fire-and-forget and concurrent bucket merges may lose an
+ * increment (read-modify-write), which is acceptable for usage statistics and
+ * documented here rather than papered over.
+ *
+ * TWO counters, because they answer different questions:
+ * - {@link submissionCount} — EVERY observed submission of the field
+ *   (default-matching or not). It is the denominator for value dominance:
+ *   "N% of submissions used value V". Without it, a value seen only in
+ *   deviations would look 100% dominant even against thousands of
+ *   default-valued submissions.
+ * - {@link setCount} — submissions whose value DIFFERED from the resolved
+ *   default (server-derived). It plus {@link distinctUserIds} is the
+ *   promote signal ("real users are actively filling this in").
+ *
+ * Content rails (enforced by the ingestion action, which derives everything
+ * from the live registry and never trusts the client):
+ * - Sensitive and read-permission-gated fields are COUNT-ONLY: their raw
+ *   values are never recorded anywhere in usage data — not even for
+ *   default-matching submissions.
+ * - Value histograms exist only for low-cardinality field types (`boolean`,
+ *   `foreignKey`, `crossPackageRef`) — never free text, even non-sensitive
+ *   text (PII risk) — with a bounded bucket count and key length. They cover
+ *   ALL submissions (not just deviations) so the dominance ratio is a true
+ *   fraction of {@link submissionCount}.
+ * - `distinctUserIds` is a capped set with an overflow marker (see
+ *   {@link MAX_DISTINCT_USERS_PER_BUCKET} for the honesty contract).
+ */
+// All generated surfaces are CLOSED: rows aggregate cross-tenant usage, so
+// list/get would leak other tenants' activity and create/update/delete would
+// let clients forge counters. The ONLY write path is the collection's
+// `reportUsage` action (ambient-identity, fail closed); reads happen
+// server-side in the learning jobs.
+@smrt({
+  tableName: '_smrt_field_usage_counters',
+  conflictColumns: ['object_ref', 'field_name', 'tenant_id', 'period'],
+  api: { include: [] },
+  cli: false,
+  mcp: { include: [] },
+})
+export class FieldUsageCounter extends SmrtObject {
+  /** Qualified class name of the target object (`@package/name:ClassName`). */
+  @field({ required: true })
+  objectRef: string = '';
+
+  /** Field name on the target object. */
+  @field({ required: true })
+  fieldName: string = '';
+
+  /**
+   * Owning tenant. REQUIRED: ingestion fails closed without an ambient tenant
+   * context, so every row is attributable (and the conflict-column tuple
+   * stays total). Native UUID on PostgreSQL/DuckDB.
+   */
+  @tenantId()
+  tenantId?: string;
+
+  /** UTC day bucket (`YYYY-MM-DD`); lexicographic order is time order. */
+  @field({ required: true })
+  period: string = '';
+
+  /**
+   * EVERY observed submission of this field in the bucket, whether or not the
+   * value matched the resolved default — the dominance denominator.
+   *
+   * Rows written before this column existed carry `0` while `setCount > 0`;
+   * {@link isLegacyBucket} detects that shape and the generation job then
+   * treats the total as UNKNOWN and skips `default` suggestions for the group
+   * (promote, which needs no denominator, still works).
+   */
+  @field({ type: 'integer' })
+  submissionCount: number = 0;
+
+  /**
+   * Submissions whose value DIFFERED from the server-resolved default (the
+   * promote signal). Always `<= submissionCount` on rows written by the
+   * current ingestion path.
+   */
+  @field({ type: 'integer' })
+  setCount: number = 0;
+
+  /**
+   * Size of the stored distinct-user set. When
+   * {@link distinctUsersOverflowed} is true this is a LOWER BOUND (the set is
+   * capped), never an estimate.
+   */
+  @field({ type: 'integer' })
+  distinctUserCount: number = 0;
+
+  /** JSON array of distinct user ids, capped (see the class doc). */
+  @field({ type: 'text' })
+  distinctUserIds: string = '[]';
+
+  /** True once a distinct user was NOT added because the set is at its cap. */
+  @field({ type: 'boolean' })
+  distinctUsersOverflowed: boolean = false;
+
+  /**
+   * JSON object `serializedValue -> count` for histogram-eligible fields;
+   * NULL when the field is count-only. Keys are bounded in number and length.
+   */
+  @field({ type: 'text', nullable: true })
+  valueHistogram: string | null = null;
+
+  /** True once a sample was dropped because the bucket cap was reached. */
+  @field({ type: 'boolean' })
+  valueHistogramOverflowed: boolean = false;
+
+  constructor(options: FieldUsageCounterOptions = {}) {
+    super(options);
+    if (options.objectRef !== undefined) this.objectRef = options.objectRef;
+    if (options.fieldName !== undefined) this.fieldName = options.fieldName;
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.period !== undefined) this.period = options.period;
+    if (options.submissionCount !== undefined) {
+      this.submissionCount = options.submissionCount;
+    }
+    if (options.setCount !== undefined) this.setCount = options.setCount;
+    if (options.distinctUserCount !== undefined) {
+      this.distinctUserCount = options.distinctUserCount;
+    }
+    if (options.distinctUserIds !== undefined) {
+      this.distinctUserIds = options.distinctUserIds;
+    }
+    if (options.distinctUsersOverflowed !== undefined) {
+      this.distinctUsersOverflowed = options.distinctUsersOverflowed;
+    }
+    if (options.valueHistogram !== undefined) {
+      this.valueHistogram = options.valueHistogram;
+    }
+    if (options.valueHistogramOverflowed !== undefined) {
+      this.valueHistogramOverflowed = options.valueHistogramOverflowed;
+    }
+  }
+
+  /** Parse the stored distinct-user set (guarded; junk parses as empty). */
+  getDistinctUserIds(): string[] {
+    try {
+      const parsed = JSON.parse(this.distinctUserIds);
+      return Array.isArray(parsed)
+        ? parsed.filter((id): id is string => typeof id === 'string')
+        : [];
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Add a user to the distinct set, honoring the cap. At the cap the id is
+   * NOT added and the overflow marker is set instead, keeping
+   * {@link distinctUserCount} an honest lower bound.
+   */
+  addDistinctUser(userId: string): void {
+    const ids = this.getDistinctUserIds();
+    if (ids.includes(userId)) {
+      return;
+    }
+    if (ids.length >= MAX_DISTINCT_USERS_PER_BUCKET) {
+      this.distinctUsersOverflowed = true;
+      return;
+    }
+    ids.push(userId);
+    this.distinctUserIds = JSON.stringify(ids);
+    this.distinctUserCount = ids.length;
+  }
+
+  /**
+   * Parse the stored histogram (guarded; junk parses as empty).
+   *
+   * Returns a NULL-PROTOTYPE object. Histogram keys are user-supplied ids —
+   * an `idType: 'text'` reference may legitimately be `constructor`,
+   * `toString`, or `__proto__` — and on a plain object those inherit truthy
+   * prototype values (so a missing bucket reads as present) or, for
+   * `__proto__`, hit the prototype setter instead of creating an own key.
+   * Both would silently corrupt counts. See {@link emptyHistogram}.
+   */
+  getValueHistogram(): Record<string, number> {
+    const histogram = emptyHistogram();
+    if (!this.valueHistogram) {
+      return histogram;
+    }
+    try {
+      const parsed = JSON.parse(this.valueHistogram);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return histogram;
+      }
+      // `Object.entries` yields OWN enumerable keys only, and `JSON.parse`
+      // materializes `__proto__` as an ordinary own data property, so the
+      // round trip preserves every legitimate id.
+      for (const [key, count] of Object.entries(parsed)) {
+        if (typeof count === 'number' && Number.isFinite(count) && count > 0) {
+          histogram[key] = count;
+        }
+      }
+      return histogram;
+    } catch {
+      return emptyHistogram();
+    }
+  }
+
+  /**
+   * Record one histogram sample under an already-serialized key, honoring the
+   * bucket cap (a NEW key past the cap is dropped and the overflow marker
+   * set; existing keys keep counting).
+   *
+   * Bucket presence is an OWN-key test, never a truthiness/`undefined` read,
+   * so prototype-shaped ids behave like any other key.
+   */
+  recordHistogramSample(key: string): void {
+    if (key.length === 0 || key.length > MAX_VALUE_HISTOGRAM_KEY_LENGTH) {
+      return;
+    }
+    const histogram = this.getValueHistogram();
+    if (!Object.hasOwn(histogram, key)) {
+      if (Object.keys(histogram).length >= MAX_VALUE_HISTOGRAM_BUCKETS) {
+        this.valueHistogramOverflowed = true;
+        return;
+      }
+      histogram[key] = 1;
+    } else {
+      histogram[key] += 1;
+    }
+    this.valueHistogram = JSON.stringify(histogram);
+  }
+
+  /**
+   * Whether this bucket predates the {@link submissionCount} column (or was
+   * corrupted): it records deviations without a total, so no honest dominance
+   * ratio can be computed from it. The generation job skips `default`
+   * suggestions for any group containing such a bucket.
+   */
+  isLegacyBucket(): boolean {
+    return this.submissionCount < this.setCount;
+  }
+
+  override async save(): Promise<this> {
+    await this.assertRowOwnedByAmbientContext('save');
+    this.validateFieldUsageCounter();
+    return super.save();
+  }
+
+  override async delete(): Promise<void> {
+    await this.assertRowOwnedByAmbientContext('delete');
+    await super.delete();
+  }
+
+  private validateFieldUsageCounter(): void {
+    if (!this.objectRef || this.objectRef.trim() === '') {
+      throw new Error('FieldUsageCounter.objectRef is required');
+    }
+    if (!this.fieldName || this.fieldName.trim() === '') {
+      throw new Error('FieldUsageCounter.fieldName is required');
+    }
+    if (!this.tenantId) {
+      throw new Error('FieldUsageCounter.tenantId is required');
+    }
+    if (!FIELD_USAGE_PERIOD_PATTERN.test(this.period)) {
+      throw new Error(
+        `FieldUsageCounter.period must be a UTC day bucket (YYYY-MM-DD); ` +
+          `got "${this.period}"`,
+      );
+    }
+    if (!Number.isInteger(this.submissionCount) || this.submissionCount < 0) {
+      throw new Error(
+        'FieldUsageCounter.submissionCount must be a non-negative integer',
+      );
+    }
+    if (!Number.isInteger(this.setCount) || this.setCount < 0) {
+      throw new Error(
+        'FieldUsageCounter.setCount must be a non-negative integer',
+      );
+    }
+    if (
+      !Number.isInteger(this.distinctUserCount) ||
+      this.distinctUserCount < 0
+    ) {
+      throw new Error(
+        'FieldUsageCounter.distinctUserCount must be a non-negative integer',
+      );
+    }
+  }
+
+  /**
+   * Tenant write boundary (the FieldPolicy posture — no class-level
+   * `@TenantScoped`, because the learning jobs legitimately operate
+   * cross-tenant in trusted execution): inside a non-bypass tenant context a
+   * caller may only touch rows of its own tenant; without a context (system/
+   * job execution) writes are trusted.
+   *
+   * Checked against BOTH the in-memory tenant and — for a row that already
+   * exists — the PERSISTED one. The persisted check is what makes the boundary
+   * real: bucket ids are deterministic and the deriving helper is exported, so
+   * a foreign row is trivially addressable, and an in-memory-only check would
+   * let a caller load it, re-stamp `tenantId` with its own, and adopt or delete
+   * another tenant's counters (the #2047 FieldPolicy pattern).
+   */
+  private async assertRowOwnedByAmbientContext(
+    operation: 'save' | 'delete',
+  ): Promise<void> {
+    const context = getCurrentTenant();
+    if (!context || isSuperAdminBypass()) {
+      return;
+    }
+    if (this.tenantId !== context.tenantId) {
+      throw new TenantIsolationError(
+        `Tenant isolation violation in FieldUsageCounter.${operation}: ` +
+          `context tenant is '${context.tenantId}' but the row belongs to ` +
+          `'${this.tenantId}'`,
+        {
+          tenantId: context.tenantId,
+          attemptedTenantId: this.tenantId ?? undefined,
+        },
+      );
+    }
+
+    const persistedTenantId = await this.getPersistedTenantId();
+    if (persistedTenantId !== null && persistedTenantId !== context.tenantId) {
+      throw new TenantIsolationError(
+        `Tenant isolation violation in FieldUsageCounter.${operation}: the ` +
+          `persisted row belongs to '${persistedTenantId}'`,
+        {
+          tenantId: context.tenantId,
+          attemptedTenantId: persistedTenantId,
+        },
+      );
+    }
+  }
+
+  /** The stored tenant for this row's id; `null` when it is not persisted. */
+  private async getPersistedTenantId(): Promise<string | null> {
+    if (!this.id) {
+      return null;
+    }
+    const existing = await this.db.get(this.tableName, { id: this.id });
+    if (!existing) {
+      return null;
+    }
+    const row = existing as Record<string, unknown>;
+    const value = row.tenantId ?? row.tenant_id;
+    return value === undefined || value === null ? null : String(value);
+  }
+}

--- a/packages/fields/src/models/FieldUsageReportReceipt.ts
+++ b/packages/fields/src/models/FieldUsageReportReceipt.ts
@@ -1,0 +1,63 @@
+import {
+  crossPackageRef,
+  field,
+  SmrtObject,
+  type SmrtObjectOptions,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { tenantId } from '@happyvertical/smrt-tenancy';
+
+/**
+ * Durable daily receipt for one member's contribution to one field.
+ *
+ * The counter action creates this before incrementing its aggregate. Its
+ * natural key makes the anti-inflation rule durable across requests and
+ * replicas: one `(tenant, user, object, field, UTC day)` sample may affect
+ * usage evidence. Receipts intentionally retain no submitted value.
+ */
+@smrt({
+  tableName: '_smrt_field_usage_report_receipts',
+  conflictColumns: [
+    'tenant_id',
+    'user_id',
+    'object_ref',
+    'field_name',
+    'period',
+  ],
+  api: { include: [] },
+  cli: false,
+  mcp: { include: [] },
+})
+export class FieldUsageReportReceipt extends SmrtObject {
+  @tenantId()
+  tenantId?: string;
+
+  @crossPackageRef('@happyvertical/smrt-users:User')
+  userId: string = '';
+
+  @field({ required: true })
+  objectRef: string = '';
+
+  @field({ required: true })
+  fieldName: string = '';
+
+  @field({ required: true })
+  period: string = '';
+
+  constructor(options: FieldUsageReportReceiptOptions = {}) {
+    super(options);
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.userId !== undefined) this.userId = options.userId;
+    if (options.objectRef !== undefined) this.objectRef = options.objectRef;
+    if (options.fieldName !== undefined) this.fieldName = options.fieldName;
+    if (options.period !== undefined) this.period = options.period;
+  }
+}
+
+export interface FieldUsageReportReceiptOptions extends SmrtObjectOptions {
+  tenantId?: string;
+  userId?: string;
+  objectRef?: string;
+  fieldName?: string;
+  period?: string;
+}

--- a/packages/fields/src/svelte/__tests__/FieldPolicyControlPanel.test.ts
+++ b/packages/fields/src/svelte/__tests__/FieldPolicyControlPanel.test.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../types.js';
 import FieldPolicyControlPanel from '../components/FieldPolicyControlPanel.svelte';
 import type { FieldPolicyControlPanelAdapter } from '../settings-catalog.js';
+import type { FieldPolicySuggestionAdapter } from '../suggestions.js';
 import SettingsCatalogStub from './fixtures/SettingsCatalogStub.svelte';
 
 const objectRef = '@test/smrt-fields:ControlPanelDocument';
@@ -140,6 +141,16 @@ function data(pageSize = 25): FieldPolicySettingsCatalogData {
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
 function adapter(
   options: { onDelete?: (id: string) => Promise<void>; calls?: string[] } = {},
 ): FieldPolicyControlPanelAdapter {
@@ -169,6 +180,7 @@ function renderPanel(
     confirmAction?: (message: string) => boolean | Promise<boolean>;
     onchanged?: () => void;
     panelData?: FieldPolicySettingsCatalogData;
+    suggestionAdapter?: FieldPolicySuggestionAdapter;
   } = {},
 ) {
   return render(FieldPolicyControlPanel, {
@@ -179,11 +191,45 @@ function renderPanel(
       baseUrl: '/settings/fields',
       confirmAction: options.confirmAction,
       onchanged: options.onchanged,
+      suggestionAdapter: options.suggestionAdapter,
     },
   });
 }
 
 describe('FieldPolicyControlPanel', () => {
+  it('surfaces a reviewed pending-suggestion queue through the structural host adapter', async () => {
+    const pendingSuggestions = vi.fn(async () => ({
+      suggestions: [
+        {
+          id: 'suggestion-title',
+          objectRef,
+          fieldName: 'title',
+          kind: 'promote',
+          proposedValue: null,
+          evidence: { summary: '3 users set this field 5 times.' },
+          status: 'pending',
+        },
+      ],
+      total: 1,
+    }));
+    renderPanel(adapter(), {
+      suggestionAdapter: {
+        pendingSuggestions,
+        acceptSuggestion: async () => undefined,
+        dismissSuggestion: async () => undefined,
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(
+        screen.getByRole('heading', { name: 'Pending field suggestions' }),
+      ).toBeVisible(),
+    );
+    expect(pendingSuggestions).toHaveBeenCalledWith({
+      objectRefs: [objectRef],
+    });
+  });
+
   it('uses SSR data for the first render and preserves pageSize in catalog navigation', () => {
     renderPanel();
 
@@ -269,5 +315,36 @@ describe('FieldPolicyControlPanel', () => {
       ]),
     );
     expect(screen.getByRole('alert')).toHaveTextContent('second delete failed');
+  });
+
+  it('does not let an older deferred audit refresh overwrite newer panel data', async () => {
+    const staleAudit = deferred<FieldPolicyAuditSnapshot>();
+    const panelAdapter = adapter();
+    panelAdapter.loadAudit = vi.fn(() => staleAudit.promise);
+    const rendered = renderPanel(panelAdapter);
+    await vi.waitFor(() => expect(panelAdapter.load).toHaveBeenCalledTimes(1));
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Edit settings' }),
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Save', exact: true }),
+    );
+    await vi.waitFor(() =>
+      expect(panelAdapter.loadAudit).toHaveBeenCalledTimes(1),
+    );
+
+    await rendered.rerender({
+      data: { ...data(), audit: audit([], false) },
+    });
+    expect(
+      screen.queryByRole('heading', { name: 'Manifest drift' }),
+    ).toBeNull();
+
+    staleAudit.resolve(audit());
+    await Promise.resolve();
+    expect(
+      screen.queryByRole('heading', { name: 'Manifest drift' }),
+    ).toBeNull();
   });
 });

--- a/packages/fields/src/svelte/__tests__/ObjectForm.test.ts
+++ b/packages/fields/src/svelte/__tests__/ObjectForm.test.ts
@@ -17,6 +17,7 @@ import { tick } from 'svelte';
 import { describe, expect, it, vi } from 'vitest';
 import type { ResolvedObjectFieldPolicy } from '../../types.js';
 import FieldInput from '../components/FieldInput.svelte';
+import type { ObjectFormProps } from '../components/ObjectForm.svelte';
 import { policyToVisibleColumnIds } from '../data-table.js';
 import {
   type ObjectFormCollectionDefinition,
@@ -310,6 +311,147 @@ describe('ObjectForm component', () => {
     await fireEvent.input(metadata);
     await userEvent.click(submit);
     expect(onsubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports only after a synchronous host persistence acknowledgement', async () => {
+    const onsubmit = vi.fn(() => true);
+    const reportUsage = vi.fn(() => {
+      throw new Error('metrics unavailable');
+    });
+    render(ObjectFormActionsFixture, {
+      props: { fields, policy, onsubmit, usageReporter: { reportUsage } },
+    });
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: 'Name' }),
+      'Deluxe',
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Save product' }));
+
+    expect(onsubmit).toHaveBeenCalledTimes(1);
+    expect(reportUsage).toHaveBeenCalledWith({
+      entries: [{ objectRef: '@test:Product', fieldName: 'name' }],
+    });
+
+    const metadata = screen.getByRole('textbox', {
+      name: 'Metadata',
+    }) as HTMLTextAreaElement;
+    metadata.value = '{not json}';
+    await fireEvent.input(metadata);
+    await userEvent.click(screen.getByRole('button', { name: 'Save product' }));
+    expect(reportUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports after an asynchronous host persistence acknowledgement', async () => {
+    const onsubmit = vi.fn(async () => true);
+    const reportUsage = vi.fn();
+    render(ObjectFormActionsFixture, {
+      props: { fields, policy, onsubmit, usageReporter: { reportUsage } },
+    });
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: 'Name' }),
+      'Deluxe',
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Save product' }));
+
+    await vi.waitFor(() => expect(reportUsage).toHaveBeenCalledTimes(1));
+  });
+
+  it('keeps named void and Promise<void> persistence handlers compatible without treating either as success', async () => {
+    function legacyVoidHandler(_event: SubmitEvent): void {}
+    async function legacyAsyncVoidHandler(_event: SubmitEvent): Promise<void> {}
+    const handlers: Array<NonNullable<ObjectFormProps['onsubmit']>> = [
+      legacyVoidHandler,
+      legacyAsyncVoidHandler,
+    ];
+
+    for (const onsubmit of handlers) {
+      const reportUsage = vi.fn();
+      const view = render(ObjectFormActionsFixture, {
+        props: { fields, policy, onsubmit, usageReporter: { reportUsage } },
+      });
+      await userEvent.type(
+        screen.getByRole('textbox', { name: 'Name' }),
+        'Deluxe',
+      );
+      await userEvent.click(
+        screen.getByRole('button', { name: 'Save product' }),
+      );
+      await Promise.resolve();
+      expect(reportUsage).not.toHaveBeenCalled();
+      view.unmount();
+    }
+  });
+
+  it('marks a count-only text default as matched after persistence', async () => {
+    const policyWithTextDefault: ResolvedObjectFieldPolicy = {
+      ...policy,
+      fields: {
+        ...policy.fields,
+        name: {
+          ...policy.fields.name,
+          hasDefault: true,
+          defaultValue: 'Default product name',
+        },
+      },
+    };
+    const reportUsage = vi.fn();
+    render(ObjectFormActionsFixture, {
+      props: {
+        fields,
+        policy: policyWithTextDefault,
+        onsubmit: () => true,
+        usageReporter: { reportUsage },
+      },
+    });
+    await tick();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save product' }));
+
+    expect(reportUsage).toHaveBeenCalledWith({
+      entries: [
+        {
+          objectRef: '@test:Product',
+          fieldName: 'name',
+          matchedDefault: true,
+        },
+      ],
+    });
+  });
+
+  it('does not report when the host cancels, omits success, rejects, or local validation fails', async () => {
+    let attempt = 0;
+    const onsubmit = vi.fn(async () => {
+      attempt++;
+      if (attempt === 1) return undefined;
+      if (attempt === 2) return false;
+      throw new Error('persistence failed');
+    });
+    const reportUsage = vi.fn();
+    render(ObjectFormActionsFixture, {
+      props: { fields, policy, onsubmit, usageReporter: { reportUsage } },
+    });
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: 'Name' }),
+      'Deluxe',
+    );
+    const submit = screen.getByRole('button', { name: 'Save product' });
+    await userEvent.click(submit);
+    await userEvent.click(submit);
+    await userEvent.click(submit);
+    await vi.waitFor(() => expect(onsubmit).toHaveBeenCalledTimes(3));
+    expect(reportUsage).not.toHaveBeenCalled();
+
+    const metadata = screen.getByRole('textbox', {
+      name: 'Metadata',
+    }) as HTMLTextAreaElement;
+    metadata.value = '{not json}';
+    await fireEvent.input(metadata);
+    await userEvent.click(submit);
+    expect(onsubmit).toHaveBeenCalledTimes(3);
+    expect(reportUsage).not.toHaveBeenCalled();
   });
 
   it('is axe-clean for its generated basic form', async () => {

--- a/packages/fields/src/svelte/__tests__/ObjectForm.test.ts
+++ b/packages/fields/src/svelte/__tests__/ObjectForm.test.ts
@@ -358,6 +358,31 @@ describe('ObjectForm component', () => {
     await vi.waitFor(() => expect(reportUsage).toHaveBeenCalledTimes(1));
   });
 
+  it('reports the submitted values when a successful create clears its bound record', async () => {
+    const reportUsage = vi.fn();
+    render(ObjectFormActionsFixture, {
+      props: {
+        fields,
+        policy,
+        onsubmit: async () => true,
+        usageReporter: { reportUsage },
+        resetAfterSuccessfulSubmit: true,
+      },
+    });
+
+    await userEvent.type(
+      screen.getByRole('textbox', { name: 'Name' }),
+      'Deluxe',
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Save product' }));
+
+    await vi.waitFor(() =>
+      expect(reportUsage).toHaveBeenCalledWith({
+        entries: [{ objectRef: '@test:Product', fieldName: 'name' }],
+      }),
+    );
+  });
+
   it('keeps named void and Promise<void> persistence handlers compatible without treating either as success', async () => {
     function legacyVoidHandler(_event: SubmitEvent): void {}
     async function legacyAsyncVoidHandler(_event: SubmitEvent): Promise<void> {}

--- a/packages/fields/src/svelte/__tests__/UsageLearning.test.ts
+++ b/packages/fields/src/svelte/__tests__/UsageLearning.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+import {
+  expectNoA11yViolations,
+  render,
+  screen,
+  userEvent,
+} from '@happyvertical/smrt-vitest/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import FieldPolicySuggestionQueue from '../components/FieldPolicySuggestionQueue.svelte';
+import type { FieldPolicyEditorAdapter } from '../field-policy-editor.js';
+import {
+  type FieldPolicySuggestionAdapter,
+  parsePendingFieldPolicySuggestions,
+} from '../suggestions.js';
+import {
+  collectFieldUsageEntries,
+  reportFieldUsage,
+} from '../usage-capture.js';
+import SuggestionGearFixture from './fixtures/SuggestionGearFixture.svelte';
+
+const pending = {
+  suggestions: [
+    {
+      id: 'suggestion-1',
+      objectRef: '@test:Widget',
+      fieldName: 'status',
+      kind: 'promote' as const,
+      proposedValue: null,
+      evidence: { summary: '6 users set this field 12 times.' },
+      status: 'pending',
+    },
+  ],
+  total: 1,
+};
+
+function suggestionAdapter(): FieldPolicySuggestionAdapter {
+  return {
+    pendingSuggestions: vi.fn(async () => pending),
+    acceptSuggestion: vi.fn(async () => undefined),
+    dismissSuggestion: vi.fn(async () => undefined),
+  };
+}
+
+const editorAdapter: FieldPolicyEditorAdapter = {
+  load: async () => ({
+    capabilities: { manage: true, personalize: false },
+    personalLowerDefaultUsable: {},
+    policy: { objectRef: '@test:Widget', fields: {}, layers: {} },
+    rows: { app: [], tenant: [], user: [] },
+  }),
+  create: async () => undefined,
+  update: async () => undefined,
+  delete: async () => undefined,
+};
+
+describe('field usage capture', () => {
+  it('keeps free-form values out of browser telemetry while retaining count signals', () => {
+    expect(
+      collectFieldUsageEntries({
+        objectRef: '@test:Widget',
+        fields: {
+          title: 'text',
+          enabled: 'boolean',
+          count: 'integer',
+          ownerId: 'foreignKey',
+          metadata: 'json',
+        },
+        values: {
+          title: 'A title',
+          enabled: false,
+          count: 0,
+          ownerId: '4f552b7e-88a4-499a-9ce4-6a88bec3b439',
+          metadata: { email: 'member@example.test' },
+          omitted: 'not rendered',
+        },
+        defaults: {
+          title: { hasDefault: true, defaultValue: 'A title' },
+          count: { hasDefault: true, defaultValue: 1 },
+          metadata: {
+            hasDefault: true,
+            defaultValue: { email: 'member@example.test' },
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        objectRef: '@test:Widget',
+        fieldName: 'title',
+        matchedDefault: true,
+      },
+      { objectRef: '@test:Widget', fieldName: 'enabled', value: false },
+      { objectRef: '@test:Widget', fieldName: 'count' },
+      {
+        objectRef: '@test:Widget',
+        fieldName: 'ownerId',
+        value: '4f552b7e-88a4-499a-9ce4-6a88bec3b439',
+      },
+      {
+        objectRef: '@test:Widget',
+        fieldName: 'metadata',
+        matchedDefault: true,
+      },
+    ]);
+  });
+
+  it('contains synchronous and asynchronous reporter failures outside the submit path', async () => {
+    const sync = {
+      reportUsage: () => {
+        throw new Error('offline');
+      },
+    };
+    const rejected = {
+      reportUsage: async () => {
+        throw new Error('offline');
+      },
+    };
+    expect(() =>
+      reportFieldUsage(sync, [
+        { objectRef: '@test:Widget', fieldName: 'title' },
+      ]),
+    ).not.toThrow();
+    expect(() =>
+      reportFieldUsage(rejected, [
+        { objectRef: '@test:Widget', fieldName: 'title' },
+      ]),
+    ).not.toThrow();
+    await Promise.resolve();
+  });
+});
+
+describe('field policy suggestion review', () => {
+  it('fails closed for malformed generated-action output', () => {
+    expect(() =>
+      parsePendingFieldPolicySuggestions({ suggestions: [], total: '1' }),
+    ).toThrow(/Unable to load pending/i);
+    expect(() =>
+      parsePendingFieldPolicySuggestions({
+        suggestions: [{ id: 'missing fields' }],
+        total: 1,
+      }),
+    ).toThrow(/Unable to load pending/i);
+  });
+
+  it('renders an accessible reviewed queue and refreshes after approve or dismiss', async () => {
+    const adapter = suggestionAdapter();
+    const { container } = render(FieldPolicySuggestionQueue, {
+      props: { adapter, objectRefs: ['@test:Widget'] },
+    });
+    await vi.waitFor(() =>
+      expect(screen.getByText(/6 users set/i)).toBeVisible(),
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Pending field suggestions' }),
+    ).toBeVisible();
+    await userEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    await vi.waitFor(() =>
+      expect(adapter.acceptSuggestion).toHaveBeenCalledWith({
+        id: 'suggestion-1',
+      }),
+    );
+    expect(adapter.pendingSuggestions).toHaveBeenCalledWith({
+      objectRefs: ['@test:Widget'],
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('announces a pending-suggestion count on the policy gear without exposing suggestion details', async () => {
+    render(SuggestionGearFixture, {
+      props: { adapter: editorAdapter, suggestionAdapter: suggestionAdapter() },
+    });
+    await vi.waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: 'Field settings, 1 pending suggestion',
+        }),
+      ).toBeVisible(),
+    );
+    expect(screen.getByText('1')).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/packages/fields/src/svelte/__tests__/fixtures/ObjectFormActionsFixture.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/ObjectFormActionsFixture.svelte
@@ -11,13 +11,26 @@ interface Props {
   policy: ResolvedObjectFieldPolicy;
   onsubmit: NonNullable<ObjectFormProps['onsubmit']>;
   usageReporter?: FieldUsageReporter;
+  resetAfterSuccessfulSubmit?: boolean;
 }
 
-let { fields, policy, onsubmit, usageReporter }: Props = $props();
+let {
+  fields,
+  policy,
+  onsubmit,
+  usageReporter,
+  resetAfterSuccessfulSubmit = false,
+}: Props = $props();
 let record = $state<Record<string, unknown>>({});
+
+async function submit(event: SubmitEvent): Promise<boolean | undefined> {
+  const result = await onsubmit(event);
+  if (result === true && resetAfterSuccessfulSubmit) record = {};
+  return result === true ? true : undefined;
+}
 </script>
 
-<ObjectForm objectRef={policy.objectRef} {fields} {policy} bind:value={record} {onsubmit} {usageReporter}>
+<ObjectForm objectRef={policy.objectRef} {fields} {policy} bind:value={record} onsubmit={submit} {usageReporter}>
   {#snippet actions()}
     <button type="submit">Save product</button>
   {/snippet}

--- a/packages/fields/src/svelte/__tests__/fixtures/ObjectFormActionsFixture.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/ObjectFormActionsFixture.svelte
@@ -1,19 +1,23 @@
 <script lang="ts">
 import type { ResolvedObjectFieldPolicy } from '../../../types.js';
-import ObjectForm from '../../components/ObjectForm.svelte';
+import ObjectForm, {
+  type ObjectFormProps,
+} from '../../components/ObjectForm.svelte';
 import type { ObjectFormFieldDefinition } from '../../types.js';
+import type { FieldUsageReporter } from '../../usage-capture.js';
 
 interface Props {
   fields: Record<string, ObjectFormFieldDefinition>;
   policy: ResolvedObjectFieldPolicy;
-  onsubmit: (event: SubmitEvent) => void;
+  onsubmit: NonNullable<ObjectFormProps['onsubmit']>;
+  usageReporter?: FieldUsageReporter;
 }
 
-let { fields, policy, onsubmit }: Props = $props();
+let { fields, policy, onsubmit, usageReporter }: Props = $props();
 let record = $state<Record<string, unknown>>({});
 </script>
 
-<ObjectForm objectRef={policy.objectRef} {fields} {policy} bind:value={record} {onsubmit}>
+<ObjectForm objectRef={policy.objectRef} {fields} {policy} bind:value={record} {onsubmit} {usageReporter}>
   {#snippet actions()}
     <button type="submit">Save product</button>
   {/snippet}

--- a/packages/fields/src/svelte/__tests__/fixtures/SuggestionGearFixture.svelte
+++ b/packages/fields/src/svelte/__tests__/fixtures/SuggestionGearFixture.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+import FieldPolicyGearButton from '../../components/FieldPolicyGearButton.svelte';
+import FieldPolicyGearProvider from '../../components/FieldPolicyGearProvider.svelte';
+import type { FieldPolicyEditorAdapter } from '../../field-policy-editor.js';
+import type { FieldPolicySuggestionAdapter } from '../../suggestions.js';
+
+let {
+  adapter,
+  suggestionAdapter,
+}: {
+  adapter: FieldPolicyEditorAdapter;
+  suggestionAdapter: FieldPolicySuggestionAdapter;
+} = $props();
+</script>
+
+<FieldPolicyGearProvider
+  objectRef="@test:Widget"
+  fields={{ title: { type: 'text' } }}
+  {adapter}
+  {suggestionAdapter}
+>
+  <FieldPolicyGearButton />
+</FieldPolicyGearProvider>

--- a/packages/fields/src/svelte/components/FieldPolicyControlPanel.svelte
+++ b/packages/fields/src/svelte/components/FieldPolicyControlPanel.svelte
@@ -29,7 +29,9 @@ import {
   orgRowIdsForObject,
   prunableDriftRows,
 } from '../settings-catalog.js';
+import type { FieldPolicySuggestionAdapter } from '../suggestions.js';
 import FieldPolicyEditor from './FieldPolicyEditor.svelte';
+import FieldPolicySuggestionQueue from './FieldPolicySuggestionQueue.svelte';
 
 export interface FieldPolicyCatalogComponentProps {
   page: FieldPolicySettingsCatalogPage;
@@ -48,6 +50,8 @@ export interface FieldPolicyControlPanelProps {
   heading?: string;
   onchanged?: () => void;
   confirmAction?: (message: string) => boolean | Promise<boolean>;
+  /** Optional reviewed-suggestion queue transport. */
+  suggestionAdapter?: FieldPolicySuggestionAdapter;
 }
 
 let {
@@ -59,6 +63,7 @@ let {
   heading = 'Field settings',
   onchanged,
   confirmAction,
+  suggestionAdapter,
 }: FieldPolicyControlPanelProps = $props();
 
 // Before client effects run (including SSR), render the server snapshot.
@@ -70,6 +75,7 @@ let loadingEditor = $state(false);
 let busy = $state(false);
 let error = $state<string | null>(null);
 let generation = 0;
+let auditGeneration = 0;
 
 const Catalog = $derived(catalog);
 const visibleAudit = $derived(audit ?? data.audit);
@@ -83,6 +89,9 @@ const preservedParams = $derived(fieldPolicyCatalogPreservedParams(data));
 
 $effect(() => {
   data;
+  // A prop snapshot supersedes every in-flight mutation refresh. Without this
+  // invalidation, an older response can overwrite newer SSR/navigation data.
+  auditGeneration++;
   audit = data.audit;
   editorState = null;
   editorOpen = false;
@@ -114,11 +123,15 @@ async function loadEditor(): Promise<void> {
 }
 
 async function refreshAudit(): Promise<boolean> {
+  const token = ++auditGeneration;
   const refs = auditObjectRefs(data.page);
   try {
-    audit = await adapter.loadAudit({ ...refs, includeDrift: true });
+    const refreshed = await adapter.loadAudit({ ...refs, includeDrift: true });
+    if (token !== auditGeneration) return false;
+    audit = refreshed;
     return true;
   } catch (cause) {
+    if (token !== auditGeneration) return false;
     error =
       cause instanceof Error
         ? cause.message
@@ -195,6 +208,13 @@ function valueText(cell: FieldPolicyLayerCell): string {
     return String(cell.defaultValue);
   }
 }
+
+async function suggestionChanged(): Promise<void> {
+  if (await refreshAudit()) {
+    await loadEditor();
+    onchanged?.();
+  }
+}
 </script>
 
 {#if canManage}
@@ -232,6 +252,13 @@ function valueText(cell: FieldPolicyLayerCell): string {
         fields={selected.fields}
         onclose={() => editorOpen = false}
         onmutated={editorMutated}
+      />
+    {/if}
+    {#if suggestionAdapter}
+      <FieldPolicySuggestionQueue
+        adapter={suggestionAdapter}
+        objectRefs={auditObjectRefs(data.page).objectRefs}
+        onchanged={suggestionChanged}
       />
     {/if}
     {#if prunableDriftRows(visibleAudit).length}

--- a/packages/fields/src/svelte/components/FieldPolicyGearButton.svelte
+++ b/packages/fields/src/svelte/components/FieldPolicyGearButton.svelte
@@ -10,8 +10,15 @@ const gear = getFieldPolicyGearContext();
 </script>
 
 {#if gear.canEdit}
-  <Button type="button" variant="ghost" class={className} aria-haspopup="dialog" onclick={() => gear.show()}>
+  <Button type="button" variant="ghost" class={className} aria-haspopup="dialog" aria-label={gear.pendingSuggestionCount > 0 ? `${label}, ${gear.pendingSuggestionCount} pending suggestion${gear.pendingSuggestionCount === 1 ? '' : 's'}` : label} onclick={() => gear.show()}>
     <span aria-hidden="true">⚙</span>
     <span>{label}</span>
+    {#if gear.pendingSuggestionCount > 0}
+      <span class="field-policy-gear-button__badge" aria-hidden="true">{gear.pendingSuggestionCount}</span>
+    {/if}
   </Button>
 {/if}
+
+<style>
+  .field-policy-gear-button__badge { border-radius: 999px; background: var(--smrt-color-secondary-container, #e8def8); min-inline-size: 1.25rem; padding-inline: 0.25rem; text-align: center; }
+</style>

--- a/packages/fields/src/svelte/components/FieldPolicyGearProvider.svelte
+++ b/packages/fields/src/svelte/components/FieldPolicyGearProvider.svelte
@@ -12,6 +12,10 @@ import {
   setFieldPolicyGearContext,
 } from '../gear-context.svelte.js';
 import type { FieldInputRegistry } from '../input-registry.js';
+import {
+  type FieldPolicySuggestionAdapter,
+  parsePendingFieldPolicySuggestions,
+} from '../suggestions.js';
 import type { ObjectFormFieldDefinition } from '../types.js';
 import FieldPolicyEditor from './FieldPolicyEditor.svelte';
 
@@ -22,6 +26,8 @@ interface Props {
   inputRegistry?: FieldInputRegistry;
   /** Hosts in an app-wide context pass app; tenant hosts retain the default. */
   organizationScope?: FieldPolicyOrganizationScope;
+  /** Optional reviewed-suggestion transport for the gear badge. */
+  suggestionAdapter?: FieldPolicySuggestionAdapter;
   children?: Snippet;
 }
 
@@ -31,6 +37,7 @@ let {
   adapter,
   inputRegistry,
   organizationScope = 'tenant',
+  suggestionAdapter,
   children,
 }: Props = $props();
 
@@ -38,6 +45,7 @@ let editorState = $state<FieldPolicyEditorState | null>(null);
 let error = $state<string | null>(null);
 let open = $state(false);
 let loading = $state(false);
+let pendingSuggestionCount = $state(0);
 
 const controller: FieldPolicyGearController = {
   get state() {
@@ -54,6 +62,9 @@ const controller: FieldPolicyGearController = {
       !!editorState &&
       (editorState.capabilities.manage || editorState.capabilities.personalize)
     );
+  },
+  get pendingSuggestionCount() {
+    return pendingSuggestionCount;
   },
   show() {
     if (this.canEdit) open = true;
@@ -104,16 +115,39 @@ async function reload(generation = ++loadGeneration): Promise<void> {
   }
 }
 
+async function reloadPendingSuggestions(
+  generation = ++suggestionGeneration,
+): Promise<void> {
+  if (!suggestionAdapter) {
+    pendingSuggestionCount = 0;
+    return;
+  }
+  try {
+    const result = parsePendingFieldPolicySuggestions(
+      await suggestionAdapter.pendingSuggestions({ objectRefs: [objectRef] }),
+    );
+    if (generation === suggestionGeneration) {
+      pendingSuggestionCount = result.total;
+    }
+  } catch {
+    // A metrics/read failure must not suppress ordinary policy editing.
+    if (generation === suggestionGeneration) pendingSuggestionCount = 0;
+  }
+}
+
 let loadGeneration = 0;
+let suggestionGeneration = 0;
 $effect(() => {
   const generation = ++loadGeneration;
   editorState = null;
   error = null;
   open = false;
   void reload(generation);
+  void reloadPendingSuggestions();
   return () => {
     // A delayed transport response must never repopulate a prior object.
     if (loadGeneration === generation) loadGeneration++;
+    suggestionGeneration++;
   };
 });
 </script>

--- a/packages/fields/src/svelte/components/FieldPolicySuggestionQueue.svelte
+++ b/packages/fields/src/svelte/components/FieldPolicySuggestionQueue.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+/** Accessible, host-transport-neutral review queue for pending suggestions. */
+import { Button } from '@happyvertical/smrt-ui/ui';
+import {
+  type FieldPolicySuggestion,
+  type FieldPolicySuggestionAdapter,
+  fieldPolicySuggestionEvidence,
+  parsePendingFieldPolicySuggestions,
+} from '../suggestions.js';
+
+export interface FieldPolicySuggestionQueueProps {
+  adapter: FieldPolicySuggestionAdapter;
+  objectRefs?: readonly string[];
+  heading?: string;
+  onchanged?: () => void;
+}
+
+let {
+  adapter,
+  objectRefs,
+  heading = 'Pending field suggestions',
+  onchanged,
+}: FieldPolicySuggestionQueueProps = $props();
+
+let suggestions = $state<FieldPolicySuggestion[]>([]);
+let total = $state(0);
+let loading = $state(false);
+let busyId = $state<string | null>(null);
+let error = $state<string | null>(null);
+let generation = 0;
+
+async function load(): Promise<void> {
+  const token = ++generation;
+  loading = true;
+  error = null;
+  try {
+    const result = parsePendingFieldPolicySuggestions(
+      await adapter.pendingSuggestions(
+        objectRefs?.length ? { objectRefs } : undefined,
+      ),
+    );
+    if (token !== generation) return;
+    suggestions = result.suggestions;
+    total = result.total;
+  } catch (cause) {
+    if (token !== generation) return;
+    suggestions = [];
+    total = 0;
+    error =
+      cause instanceof Error
+        ? cause.message
+        : 'Unable to load pending field suggestions.';
+  } finally {
+    if (token === generation) loading = false;
+  }
+}
+
+async function decide(
+  suggestion: FieldPolicySuggestion,
+  decision: 'approve' | 'dismiss',
+): Promise<void> {
+  if (busyId) return;
+  busyId = suggestion.id;
+  error = null;
+  try {
+    if (decision === 'approve') {
+      await adapter.acceptSuggestion({ id: suggestion.id });
+    } else {
+      await adapter.dismissSuggestion({ id: suggestion.id });
+    }
+    await load();
+    onchanged?.();
+  } catch (cause) {
+    error =
+      cause instanceof Error
+        ? cause.message
+        : 'Unable to update this field suggestion.';
+  } finally {
+    busyId = null;
+  }
+}
+
+$effect(() => {
+  adapter;
+  objectRefs;
+  void load();
+});
+
+function description(suggestion: FieldPolicySuggestion): string {
+  return suggestion.kind === 'promote'
+    ? `Promote ${suggestion.fieldName} to the basic form.`
+    : `Set an organization default for ${suggestion.fieldName}.`;
+}
+</script>
+
+<section class="field-policy-suggestion-queue" aria-label={heading}>
+  <header>
+    <h2>{heading}</h2>
+    {#if !loading}<span class="field-policy-suggestion-queue__count">{total}</span>{/if}
+  </header>
+  {#if loading}
+    <p role="status" aria-live="polite">Loading pending suggestions…</p>
+  {:else if error}
+    <p role="alert">{error}</p>
+  {:else if suggestions.length === 0}
+    <p>No pending field suggestions.</p>
+  {:else}
+    <ul>
+      {#each suggestions as suggestion (suggestion.id)}
+        <li>
+          <article>
+            <h3>{suggestion.objectRef} · {suggestion.fieldName}</h3>
+            <p>{description(suggestion)}</p>
+            <p>{fieldPolicySuggestionEvidence(suggestion)}</p>
+            <div class="field-policy-suggestion-queue__actions">
+              <Button type="button" disabled={busyId !== null} onclick={() => decide(suggestion, 'approve')}>Approve</Button>
+              <Button type="button" variant="ghost" disabled={busyId !== null} onclick={() => decide(suggestion, 'dismiss')}>Dismiss</Button>
+            </div>
+          </article>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</section>
+
+<style>
+  .field-policy-suggestion-queue { display: grid; gap: var(--smrt-spacing-3, 0.75rem); }
+  .field-policy-suggestion-queue header { align-items: center; display: flex; gap: var(--smrt-spacing-2, 0.5rem); }
+  .field-policy-suggestion-queue h2, .field-policy-suggestion-queue h3 { margin: 0; }
+  .field-policy-suggestion-queue__count { border-radius: 999px; background: var(--smrt-color-secondary-container, #e8def8); min-inline-size: 1.5rem; padding: 0.125rem 0.4rem; text-align: center; }
+  .field-policy-suggestion-queue ul { display: grid; gap: var(--smrt-spacing-3, 0.75rem); list-style: none; margin: 0; padding: 0; }
+  .field-policy-suggestion-queue article { border: 1px solid var(--smrt-color-outline-variant, currentColor); border-radius: var(--smrt-shape-corner-small, 0.25rem); display: grid; gap: var(--smrt-spacing-2, 0.5rem); padding: var(--smrt-spacing-3, 0.75rem); }
+  .field-policy-suggestion-queue article p { margin: 0; }
+  .field-policy-suggestion-queue__actions { display: flex; flex-wrap: wrap; gap: var(--smrt-spacing-2, 0.5rem); }
+</style>

--- a/packages/fields/src/svelte/components/FieldPolicySuggestionQueue.svelte
+++ b/packages/fields/src/svelte/components/FieldPolicySuggestionQueue.svelte
@@ -129,7 +129,7 @@ function description(suggestion: FieldPolicySuggestion): string {
   .field-policy-suggestion-queue h2, .field-policy-suggestion-queue h3 { margin: 0; }
   .field-policy-suggestion-queue__count { border-radius: 999px; background: var(--smrt-color-secondary-container, #e8def8); min-inline-size: 1.5rem; padding: 0.125rem 0.4rem; text-align: center; }
   .field-policy-suggestion-queue ul { display: grid; gap: var(--smrt-spacing-3, 0.75rem); list-style: none; margin: 0; padding: 0; }
-  .field-policy-suggestion-queue article { border: 1px solid var(--smrt-color-outline-variant, currentColor); border-radius: var(--smrt-shape-corner-small, 0.25rem); display: grid; gap: var(--smrt-spacing-2, 0.5rem); padding: var(--smrt-spacing-3, 0.75rem); }
+  .field-policy-suggestion-queue article { border: 1px solid var(--smrt-color-outline-variant, currentColor); border-radius: var(--smrt-radius-small, 0.25rem); display: grid; gap: var(--smrt-spacing-2, 0.5rem); padding: var(--smrt-spacing-3, 0.75rem); }
   .field-policy-suggestion-queue article p { margin: 0; }
   .field-policy-suggestion-queue__actions { display: flex; flex-wrap: wrap; gap: var(--smrt-spacing-2, 0.5rem); }
 </style>

--- a/packages/fields/src/svelte/components/ObjectForm.svelte
+++ b/packages/fields/src/svelte/components/ObjectForm.svelte
@@ -21,6 +21,11 @@ import {
   type ObjectFormFieldDefinition,
   type ObjectFormFieldSnippetProps,
 } from '../types.js';
+import {
+  collectFieldUsageEntries,
+  type FieldUsageReporter,
+  reportFieldUsage,
+} from '../usage-capture.js';
 import AdvancedFields from './AdvancedFields.svelte';
 import FieldInput from './FieldInput.svelte';
 import FieldPolicyGearButton from './FieldPolicyGearButton.svelte';
@@ -57,9 +62,22 @@ export interface ObjectFormProps {
   renderers?: Readonly<Record<string, Snippet<[ObjectFormFieldSnippetProps]>>>;
   /** Optional controls rendered after the policy-ordered fields inside the form. */
   actions?: Snippet;
+  /**
+   * Optional telemetry transport. It runs only when `onsubmit` explicitly
+   * resolves `true` after persistence; identity and field sensitivity remain
+   * server-derived.
+   */
+  usageReporter?: FieldUsageReporter;
   class?: string;
-  onsubmit?: (event: SubmitEvent) => void;
+  /** Return true only after the host has persisted this record successfully. */
+  onsubmit?: ObjectFormSubmitHandler;
 }
+
+// biome-ignore lint/suspicious/noConfusingVoidType: void handlers remain a supported legacy integration and never acknowledge persistence.
+export type ObjectFormSubmitAcknowledgement = boolean | void;
+export type ObjectFormSubmitHandler = (
+  event: SubmitEvent,
+) => ObjectFormSubmitAcknowledgement | Promise<ObjectFormSubmitAcknowledgement>;
 
 let {
   objectRef,
@@ -74,6 +92,7 @@ let {
   inputRegistry,
   renderers = {},
   actions,
+  usageReporter,
   class: className = '',
   onsubmit,
 }: ObjectFormProps = $props();
@@ -199,6 +218,60 @@ function setValidity(name: string, valid: boolean): void {
 
 function fieldId(name: string): string {
   return `${formInstanceId}-${name}`;
+}
+
+function captureUsage(): void {
+  if (!resolvedPolicy) return;
+  reportFieldUsage(
+    usageReporter,
+    collectFieldUsageEntries({
+      objectRef,
+      values: value,
+      // Hidden fields are not submitted user inputs. Basic and advanced fields
+      // are included even when a value matches the default so the server's
+      // dominance calculation has a complete denominator.
+      fields: Object.fromEntries(
+        formFields
+          .filter(
+            (field) =>
+              resolvedPolicy.fields[field.name].visibility !== 'hidden',
+          )
+          .map((field) => [field.name, field.definition.type]),
+      ),
+      defaults: Object.fromEntries(
+        formFields
+          .filter(
+            (field) =>
+              resolvedPolicy.fields[field.name].visibility !== 'hidden',
+          )
+          .map((field) => {
+            const resolved = resolvedPolicy.fields[field.name];
+            return [
+              field.name,
+              {
+                hasDefault: resolved.hasDefault,
+                defaultValue: resolved.defaultValue,
+              },
+            ];
+          }),
+      ),
+    }),
+  );
+}
+
+async function handleSubmit(event: SubmitEvent): Promise<void> {
+  if (invalidFields.size > 0) {
+    event.preventDefault();
+    return;
+  }
+  if (!onsubmit) return;
+  try {
+    // Form prevents native navigation itself, so persistence acknowledgement
+    // must be explicit rather than inferred from event.defaultPrevented.
+    if ((await onsubmit(event)) === true) captureUsage();
+  } catch {
+    // The host owns persistence errors; rejected submissions never emit usage.
+  }
 }
 
 // Apply policy defaults to a create record once, before a user can interact
@@ -330,7 +403,7 @@ function inputFor(field: ObjectFormField): FieldInputComponent {
       <div class="object-form__gear"><FieldPolicyGearButton /></div>
     {/if}
   {/if}
-  <Form class="object-form {className}" onsubmit={(event) => { if (invalidFields.size > 0) { event.preventDefault(); return; } onsubmit?.(event); }}>
+  <Form class="object-form {className}" onsubmit={handleSubmit}>
     {@render renderGroups(basicGroups)}
     {#if advancedGroups.length > 0}
       <AdvancedFields open>

--- a/packages/fields/src/svelte/components/ObjectForm.svelte
+++ b/packages/fields/src/svelte/components/ObjectForm.svelte
@@ -220,13 +220,13 @@ function fieldId(name: string): string {
   return `${formInstanceId}-${name}`;
 }
 
-function captureUsage(): void {
+function captureUsage(values: Readonly<Record<string, unknown>>): void {
   if (!resolvedPolicy) return;
   reportFieldUsage(
     usageReporter,
     collectFieldUsageEntries({
       objectRef,
-      values: value,
+      values,
       // Hidden fields are not submitted user inputs. Basic and advanced fields
       // are included even when a value matches the default so the server's
       // dominance calculation has a complete denominator.
@@ -265,12 +265,28 @@ async function handleSubmit(event: SubmitEvent): Promise<void> {
     return;
   }
   if (!onsubmit) return;
+  // A successful create commonly replaces the bound record before its
+  // persistence promise resolves. Snapshot before awaiting so usage describes
+  // the fields that were submitted, not the newly cleared next-record state.
+  const submittedValues = snapshotUsageValues(value);
   try {
     // Form prevents native navigation itself, so persistence acknowledgement
     // must be explicit rather than inferred from event.defaultPrevented.
-    if ((await onsubmit(event)) === true) captureUsage();
+    if ((await onsubmit(event)) === true) captureUsage(submittedValues);
   } catch {
     // The host owns persistence errors; rejected submissions never emit usage.
+  }
+}
+
+function snapshotUsageValues(
+  record: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  try {
+    return structuredClone(record);
+  } catch {
+    // Generated form values are wire-safe, but retain a shallow fallback for
+    // host extensions that add an uncloneable value outside telemetry fields.
+    return { ...record };
   }
 }
 

--- a/packages/fields/src/svelte/gear-context.svelte.ts
+++ b/packages/fields/src/svelte/gear-context.svelte.ts
@@ -6,6 +6,8 @@ export interface FieldPolicyGearController {
   readonly error: string | null;
   readonly open: boolean;
   readonly canEdit: boolean;
+  /** Pending reviewed suggestions for this form's object, when configured. */
+  readonly pendingSuggestionCount: number;
   show(): void;
   hide(): void;
   reload(): Promise<void>;

--- a/packages/fields/src/svelte/index.ts
+++ b/packages/fields/src/svelte/index.ts
@@ -22,6 +22,7 @@ import FieldPolicyEditor from './components/FieldPolicyEditor.svelte';
 import FieldPolicyGearButton from './components/FieldPolicyGearButton.svelte';
 import FieldPolicyGearProvider from './components/FieldPolicyGearProvider.svelte';
 import FieldPolicyProvider from './components/FieldPolicyProvider.svelte';
+import FieldPolicySuggestionQueue from './components/FieldPolicySuggestionQueue.svelte';
 import FormHelp from './components/FormHelp.svelte';
 import ModeSwitch from './components/ModeSwitch.svelte';
 import ObjectForm from './components/ObjectForm.svelte';
@@ -36,6 +37,7 @@ export {
   FieldPolicyGearButton,
   FieldPolicyGearProvider,
   FieldPolicyProvider,
+  FieldPolicySuggestionQueue,
   FormHelp,
   ModeSwitch,
   ObjectForm,
@@ -51,6 +53,10 @@ export type FieldPolicyProviderProps = ComponentProps<
 export type FormHelpProps = ComponentProps<typeof FormHelp>;
 export type ModeSwitchProps = ComponentProps<typeof ModeSwitch>;
 export type ObjectFormProps = ComponentProps<typeof ObjectForm>;
+export type {
+  ObjectFormSubmitAcknowledgement,
+  ObjectFormSubmitHandler,
+} from './components/ObjectForm.svelte';
 export type ObjectFormSourceProviderProps = ComponentProps<
   typeof ObjectFormSourceProvider
 >;
@@ -63,6 +69,9 @@ export type FieldPolicyGearButtonProps = ComponentProps<
 >;
 export type FieldPolicyGearProviderProps = ComponentProps<
   typeof FieldPolicyGearProvider
+>;
+export type FieldPolicySuggestionQueueProps = ComponentProps<
+  typeof FieldPolicySuggestionQueue
 >;
 export type PolicyFieldProps = ComponentProps<typeof PolicyField>;
 
@@ -142,6 +151,13 @@ export {
   orgRowIdsForObject,
   prunableDriftRows,
 } from './settings-catalog.js';
+export {
+  type FieldPolicySuggestion,
+  type FieldPolicySuggestionAdapter,
+  type FieldPolicySuggestionKind,
+  fieldPolicySuggestionEvidence,
+  parsePendingFieldPolicySuggestions,
+} from './suggestions.js';
 // Snippet escape-hatch props
 export type {
   FieldInputProps,
@@ -155,3 +171,15 @@ export type {
   ObjectFormWireType,
   PolicyFieldSnippetProps,
 } from './types.js';
+export {
+  type CollectFieldUsageEntriesOptions,
+  canCaptureFieldUsageValue,
+  collectFieldUsageEntries,
+  type FieldUsageDefault,
+  type FieldUsageEntry,
+  type FieldUsageReporter,
+  type FieldUsageWireType,
+  fieldUsageValuesEqual,
+  isBlankFieldValue,
+  reportFieldUsage,
+} from './usage-capture.js';

--- a/packages/fields/src/svelte/suggestions.ts
+++ b/packages/fields/src/svelte/suggestions.ts
@@ -1,0 +1,104 @@
+/**
+ * Structural browser contracts for field-policy suggestion review.
+ *
+ * These types intentionally omit tenant, user, authorization, and field
+ * sensitivity data. Hosts bind methods to authenticated generated clients;
+ * the server derives identity and validates every action.
+ */
+
+export type FieldPolicySuggestionKind = 'promote' | 'default';
+
+export interface FieldPolicySuggestion {
+  id: string;
+  objectRef: string;
+  fieldName: string;
+  kind: FieldPolicySuggestionKind;
+  proposedValue: string | null;
+  evidence: Readonly<Record<string, unknown>>;
+}
+
+export interface FieldPolicySuggestionAdapter {
+  pendingSuggestions(input?: {
+    objectRefs?: readonly string[];
+  }): Promise<unknown>;
+  acceptSuggestion(input: { id: string }): Promise<unknown>;
+  dismissSuggestion(input: { id: string }): Promise<unknown>;
+}
+
+/**
+ * Validate generated custom-action output at the browser boundary. A malformed
+ * response is an error, never an empty queue that could conceal work.
+ */
+export function parsePendingFieldPolicySuggestions(value: unknown): {
+  suggestions: FieldPolicySuggestion[];
+  total: number;
+} {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Unable to load pending field suggestions.');
+  }
+  const candidate = value as {
+    suggestions?: unknown;
+    total?: unknown;
+  };
+  const total = candidate.total;
+  if (
+    !Array.isArray(candidate.suggestions) ||
+    typeof total !== 'number' ||
+    !Number.isSafeInteger(total) ||
+    total < 0
+  ) {
+    throw new Error('Unable to load pending field suggestions.');
+  }
+  const suggestions = candidate.suggestions.map(parseSuggestion);
+  if (total < suggestions.length) {
+    throw new Error('Unable to load pending field suggestions.');
+  }
+  return { suggestions, total };
+}
+
+function parseSuggestion(value: unknown): FieldPolicySuggestion {
+  if (!value || typeof value !== 'object') {
+    throw new Error('Unable to load pending field suggestions.');
+  }
+  const candidate = value as Partial<FieldPolicySuggestion> & {
+    status?: unknown;
+  };
+  if (
+    typeof candidate.id !== 'string' ||
+    typeof candidate.objectRef !== 'string' ||
+    typeof candidate.fieldName !== 'string' ||
+    (candidate.kind !== 'promote' && candidate.kind !== 'default') ||
+    (candidate.proposedValue !== null &&
+      typeof candidate.proposedValue !== 'string') ||
+    !isRecord(candidate.evidence) ||
+    (candidate.status !== undefined && candidate.status !== 'pending')
+  ) {
+    throw new Error('Unable to load pending field suggestions.');
+  }
+  return {
+    id: candidate.id,
+    objectRef: candidate.objectRef,
+    fieldName: candidate.fieldName,
+    kind: candidate.kind,
+    proposedValue: candidate.proposedValue,
+    evidence: candidate.evidence,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** Human-readable evidence without assuming a server-side evidence schema. */
+export function fieldPolicySuggestionEvidence(
+  suggestion: FieldPolicySuggestion,
+): string {
+  const summary = suggestion.evidence.summary;
+  if (typeof summary === 'string' && summary.trim()) return summary;
+  const distinctUsers = suggestion.evidence.distinctUsers;
+  const setCount = suggestion.evidence.setCount;
+  if (typeof distinctUsers === 'number' && typeof setCount === 'number') {
+    return `${distinctUsers} users set this field ${setCount} times.`;
+  }
+  return 'Based on recent organization field usage.';
+}

--- a/packages/fields/src/svelte/usage-capture.ts
+++ b/packages/fields/src/svelte/usage-capture.ts
@@ -1,0 +1,131 @@
+/**
+ * Browser-safe usage capture primitives for the field-policy learning loop.
+ *
+ * Hosts own the authenticated transport. This module deliberately carries no
+ * tenant, user, permission, or field-sensitivity information: the server
+ * derives all of that from its ambient context and live object registry.
+ */
+/** One submitted field value sent to the host's usage transport. */
+export interface FieldUsageEntry {
+  objectRef: string;
+  fieldName: string;
+  value?: unknown;
+  /** Optional value-less hint; normal ObjectForm capture sends the value. */
+  matchedDefault?: boolean;
+}
+
+/** Resolved default metadata used only for a value-less count signal. */
+export interface FieldUsageDefault {
+  hasDefault: boolean;
+  defaultValue: unknown;
+}
+
+/**
+ * Structural host transport for the counters collection's batched action.
+ * A reporter must never be allowed to affect a successful form submission.
+ */
+export interface FieldUsageReporter {
+  reportUsage(input: { entries: readonly FieldUsageEntry[] }): unknown;
+}
+
+export interface CollectFieldUsageEntriesOptions {
+  objectRef: string;
+  values: Readonly<Record<string, unknown>>;
+  /**
+   * Rendered field names and their persisted browser wire type. The type is
+   * used only to minimize value transit — it is never a sensitivity or
+   * authorization decision.
+   */
+  fields?: Readonly<Record<string, FieldUsageWireType>>;
+  /**
+   * Resolved defaults for rendered fields. For count-only values, a matching
+   * default is sent as a positive hint so the server does not treat it as a
+   * deviation. Absent or non-matching defaults deliberately send no hint.
+   */
+  defaults?: Readonly<Record<string, FieldUsageDefault>>;
+}
+
+export type FieldUsageWireType =
+  | 'text'
+  | 'integer'
+  | 'decimal'
+  | 'boolean'
+  | 'datetime'
+  | 'json'
+  | 'foreignKey'
+  | 'crossPackageRef';
+
+/** Values may transit only for bounded, identifier-like wire types. */
+export function canCaptureFieldUsageValue(
+  type: FieldUsageWireType | undefined,
+): boolean {
+  return (
+    type === 'boolean' || type === 'foreignKey' || type === 'crossPackageRef'
+  );
+}
+
+/**
+ * Collect every non-blank submitted field, including values matching a
+ * resolved default. Values transit only for bounded boolean/reference fields;
+ * free text, numbers, dates, and JSON emit count-only signals. Capturing only
+ * deviations would make the default's dominance denominator disappear. The
+ * server still derives eligibility, sensitivity, and every aggregate.
+ */
+export function collectFieldUsageEntries(
+  options: CollectFieldUsageEntriesOptions,
+): FieldUsageEntry[] {
+  const fields =
+    options.fields ??
+    Object.fromEntries(
+      Object.keys(options.values).map((fieldName) => [fieldName, undefined]),
+    );
+  const entries: FieldUsageEntry[] = [];
+  for (const [fieldName, type] of Object.entries(fields)) {
+    const value = options.values[fieldName];
+    if (isBlankFieldValue(value)) continue;
+    if (canCaptureFieldUsageValue(type)) {
+      entries.push({ objectRef: options.objectRef, fieldName, value });
+      continue;
+    }
+    const fieldDefault = options.defaults?.[fieldName];
+    entries.push({
+      objectRef: options.objectRef,
+      fieldName,
+      ...(fieldDefault?.hasDefault &&
+      fieldUsageValuesEqual(value, fieldDefault.defaultValue)
+        ? { matchedDefault: true }
+        : {}),
+    });
+  }
+  return entries;
+}
+
+/** Zero and false are submissions; only absent/null/empty-string values are not. */
+export function isBlankFieldValue(value: unknown): boolean {
+  return value === undefined || value === null || value === '';
+}
+
+/** JSON-safe equality for the count-only default-match hint. */
+export function fieldUsageValuesEqual(left: unknown, right: unknown): boolean {
+  if (left === right) return true;
+  try {
+    return JSON.stringify(left) === JSON.stringify(right);
+  } catch {
+    return false;
+  }
+}
+
+/** Fire-and-forget by design: metrics transport failures never reject submit. */
+export function reportFieldUsage(
+  reporter: FieldUsageReporter | undefined,
+  entries: readonly FieldUsageEntry[],
+): void {
+  if (!reporter || entries.length === 0) return;
+  try {
+    void Promise.resolve(reporter.reportUsage({ entries })).catch(
+      () => undefined,
+    );
+  } catch {
+    // A synchronous host adapter failure is non-fatal by the same contract.
+  }
+}

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -318,4 +318,58 @@ export type FieldPolicyEditorStateResult =
   | FieldPolicyEditorState
   | FieldPolicyEditorStateDenied;
 
+// ---------------------------------------------------------------------------
+// Usage capture + promotion suggestions (#2051)
+// ---------------------------------------------------------------------------
+
+export type FieldPolicySuggestionKind = 'promote' | 'default';
+export const FIELD_POLICY_SUGGESTION_KINDS: readonly FieldPolicySuggestionKind[] =
+  ['promote', 'default'];
+
+export type FieldPolicySuggestionStatus = 'pending' | 'accepted' | 'dismissed';
+export const FIELD_POLICY_SUGGESTION_STATUSES: readonly FieldPolicySuggestionStatus[] =
+  ['pending', 'accepted', 'dismissed'];
+
+/** One bounded client-side form submission sample. */
+export interface FieldUsageReportEntry {
+  objectRef: string;
+  fieldName: string;
+  value?: unknown;
+  /** Used only for value-less samples; server comparison wins when present. */
+  matchedDefault?: boolean;
+}
+
+export interface FieldUsageReportResult {
+  accepted: number;
+  dropped: number;
+}
+
+export interface FieldPolicySuggestionData {
+  id: string;
+  objectRef: string;
+  fieldName: string;
+  tenantId: string;
+  kind: FieldPolicySuggestionKind;
+  proposedValue: string | null;
+  evidence: Record<string, unknown>;
+  status: FieldPolicySuggestionStatus;
+  cooldownUntil: string | null;
+  decidedBy: string | null;
+  decidedAt: string | null;
+}
+
+export interface PendingFieldPolicySuggestionsResult {
+  suggestions: FieldPolicySuggestionData[];
+  total: number;
+}
+
+export interface AcceptFieldPolicySuggestionResult {
+  suggestion: FieldPolicySuggestionData;
+  policyRowId: string;
+}
+
+export interface DismissFieldPolicySuggestionResult {
+  suggestion: FieldPolicySuggestionData;
+}
+
 export type { SmrtClassOptions };

--- a/packages/fields/src/usage-learning.ts
+++ b/packages/fields/src/usage-learning.ts
@@ -105,6 +105,7 @@ export const FIELD_USAGE_SUGGESTION_DEFAULTS: FieldUsageSuggestionConfig = {
 
 export interface FieldUsageMaintenanceSummary {
   countersPruned: number;
+  receiptsPruned: number;
   suggestionsPruned: number;
 }
 
@@ -211,6 +212,41 @@ export async function pruneFieldUsageCounters(
   return { pruned };
 }
 
+/**
+ * Drop durable anti-inflation receipts at the same age cutoff as counters.
+ *
+ * Deliberately do NOT delete a receipt merely because its counter row is
+ * absent: report ingestion claims its receipt before merging the counter, so
+ * an orphan sweep could otherwise reopen the once-per-user/day quota during
+ * that in-flight interval. A max-row counter trim likewise leaves its recent
+ * receipts until the age cutoff — retaining a de-duplication guard is safer
+ * than allowing a second contribution for that day.
+ */
+export async function pruneFieldUsageReportReceipts(
+  db: DatabaseInterface,
+  options: { maxAgeMs: number; tenantId?: string | null },
+): Promise<{ pruned: number }> {
+  if (!Number.isFinite(options.maxAgeMs) || options.maxAgeMs < 0) {
+    throw new Error(
+      `pruneFieldUsageReportReceipts maxAgeMs must be >= 0, got ` +
+        `${options.maxAgeMs}`,
+    );
+  }
+  const cutoffDay = fieldUsagePeriodForDate(
+    new Date(Date.now() - options.maxAgeMs),
+  );
+  const tenantCondition = options.tenantId ? ' AND tenant_id = ?' : '';
+  const tenantParams = options.tenantId ? [options.tenantId] : [];
+  return {
+    pruned: await deleteCounted(
+      db,
+      `period < ?${tenantCondition}`,
+      [cutoffDay, ...tenantParams],
+      '_smrt_field_usage_report_receipts',
+    ),
+  };
+}
+
 export interface FieldPolicySuggestionRetention {
   /** Drop ACCEPTED suggestions decided longer ago than this. */
   acceptedMaxAgeMs: number;
@@ -265,7 +301,9 @@ export interface RunFieldUsageMaintenanceOptions
 /**
  * The "aggregation" schedule's work. Ingestion pre-aggregates into period
  * buckets, so the roll-up job's real job is retention: prune counter buckets
- * per `{maxAgeMs, maxRows}` and settle old suggestion rows.
+ * and durable receipts at the shared age cutoff, then settle old suggestion
+ * rows. Max-row trimming leaves recent receipts intact to preserve daily
+ * de-duplication while an ingestion merge is in flight.
  */
 export async function runFieldUsageMaintenance(
   options: RunFieldUsageMaintenanceOptions,
@@ -278,6 +316,10 @@ export async function runFieldUsageMaintenance(
     maxRows: config.counterMaxRows,
     tenantId: ambientTenantId,
   });
+  const receipts = await pruneFieldUsageReportReceipts(options.db, {
+    maxAgeMs: config.counterMaxAgeMs,
+    tenantId: ambientTenantId,
+  });
   const suggestions = await pruneFieldPolicySuggestions(options.db, {
     acceptedMaxAgeMs: config.suggestionAcceptedMaxAgeMs,
     tenantId: ambientTenantId,
@@ -285,6 +327,7 @@ export async function runFieldUsageMaintenance(
 
   return {
     countersPruned: counters.pruned,
+    receiptsPruned: receipts.pruned,
     suggestionsPruned: suggestions.pruned,
   };
 }

--- a/packages/fields/src/usage-learning.ts
+++ b/packages/fields/src/usage-learning.ts
@@ -1,0 +1,975 @@
+/**
+ * The #2051 learning loop: scheduled aggregation/retention over
+ * `_smrt_field_usage_counters` and threshold-driven generation of
+ * `_smrt_field_policy_suggestions`.
+ *
+ * Scheduling substrate: there is NO generic cron package API — the de-facto
+ * convention is an `AgentSchedule` row (`@happyvertical/smrt-agents`)
+ * dispatched by smrt-jobs' `ScheduleRunner`, which resolves `agentType`
+ * through the `ObjectRegistry` and invokes the method on the registered
+ * class. {@link FieldUsageLearningAgent} is that schedule target. It is a
+ * registered `@smrt()` SmrtObject — deliberately NOT a subclass of the agents
+ * package's `Agent` base: smrt-agents sits above smrt-fields in the
+ * dependency DAG (it hard-depends on smrt-users/ai/secrets, all of which this
+ * package keeps optional), and the dispatch machinery only requires registry
+ * resolution plus the jobs package's `backgroundEligibleMethods` allowlist
+ * contract (a static property, no import needed). Schedule rows are created
+ * DORMANT by `ensureFieldUsageLearningSchedules` (see `usage-schedules.ts`).
+ *
+ * Both jobs are tenant-safe by construction: in trusted execution (no ambient
+ * tenant context, or super-admin bypass) they operate across all tenants;
+ * inside a non-bypass tenant context they restrict themselves to the ambient
+ * tenant (fail closed), so per-tenant schedule rows are also valid.
+ */
+
+import {
+  SmrtObject,
+  type SmrtObjectOptions,
+  smrt,
+} from '@happyvertical/smrt-core';
+import {
+  getCurrentTenant,
+  isSuperAdminBypass,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { FieldPolicySuggestionCollection } from './collections/FieldPolicySuggestionCollection.js';
+import {
+  decodeHistogramKey,
+  FieldUsageCounterCollection,
+  isHistogramEligibleField,
+} from './collections/FieldUsageCounterCollection.js';
+import {
+  type FieldDefinitionMap,
+  getFieldReadPermission,
+  getObjectFieldMap,
+  isSensitiveField,
+  isTransientField,
+} from './field-definitions.js';
+import {
+  ACTIVE_SUGGESTION_KEY,
+  type FieldPolicySuggestion,
+} from './models/FieldPolicySuggestion.js';
+import type { FieldUsageCounter } from './models/FieldUsageCounter.js';
+import {
+  emptyHistogram,
+  fieldUsagePeriodForDate,
+} from './models/FieldUsageCounter.js';
+import type {
+  FieldPolicySuggestionKind,
+  ResolvedFieldPolicy,
+} from './types.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Config (documented defaults; overridable per run through the schedule's
+// `methodArgs` payload)
+// ---------------------------------------------------------------------------
+
+export interface FieldUsageMaintenanceConfig {
+  /** Drop counter buckets older than this (by `period`). Default 90 days. */
+  counterMaxAgeMs: number;
+  /** Keep at most this many counter rows (oldest pruned first). Default 100k. */
+  counterMaxRows: number;
+  /** Drop ACCEPTED suggestions decided longer ago than this. Default 180 days. */
+  suggestionAcceptedMaxAgeMs: number;
+}
+
+export const FIELD_USAGE_MAINTENANCE_DEFAULTS: FieldUsageMaintenanceConfig = {
+  counterMaxAgeMs: 90 * DAY_MS,
+  counterMaxRows: 100_000,
+  suggestionAcceptedMaxAgeMs: 180 * DAY_MS,
+};
+
+export interface FieldUsageSuggestionConfig {
+  /** Usage window the thresholds evaluate over. Default 30 days. */
+  windowDays: number;
+  /** Distinct users required for a `promote` suggestion. Default 5. */
+  minDistinctUsers: number;
+  /** Submissions required before a `default` suggestion. Default 10. */
+  minSetCount: number;
+  /**
+   * Share of windowed submissions a single value must reach for a `default`
+   * suggestion (denominator is TOTAL setCount, so histogram overflow can only
+   * make this more conservative). Default 0.8.
+   */
+  defaultDominanceRatio: number;
+}
+
+export const FIELD_USAGE_SUGGESTION_DEFAULTS: FieldUsageSuggestionConfig = {
+  windowDays: 30,
+  minDistinctUsers: 5,
+  minSetCount: 10,
+  defaultDominanceRatio: 0.8,
+};
+
+export interface FieldUsageMaintenanceSummary {
+  countersPruned: number;
+  suggestionsPruned: number;
+}
+
+export interface FieldUsageSuggestionRunSummary {
+  /**
+   * Suggestions this run wrote. Under overlapping runs both may report a
+   * create for the same candidate while the model's active-slot unique index
+   * converges them onto ONE row (see `FieldPolicySuggestion.activeKey`) — the
+   * tally is per-run work, not a row count.
+   */
+  created: number;
+  /** Candidates suppressed by a pending or cooling-down suggestion. */
+  suppressed: number;
+  /** Distinct (tenant, objectRef, fieldName) groups evaluated. */
+  groupsConsidered: number;
+  /**
+   * Groups whose evaluation threw and was skipped. A failing group never
+   * aborts the run — a global pass must keep serving every other tenant.
+   */
+  groupsFailed: number;
+  /**
+   * Bounded sample of failure messages (`MAX_REPORTED_GROUP_FAILURES`) so an
+   * operator can see WHY without the summary growing with the queue.
+   */
+  failures: string[];
+}
+
+/** Cap on {@link FieldUsageSuggestionRunSummary.failures} entries. */
+export const MAX_REPORTED_GROUP_FAILURES = 5;
+
+// ---------------------------------------------------------------------------
+// Retention (the pruneChangeFeed shape: {maxAgeMs?, maxRows?}, oldest-first)
+// ---------------------------------------------------------------------------
+
+export interface FieldUsageCounterRetention {
+  maxAgeMs?: number;
+  maxRows?: number;
+  /** Restrict pruning to one tenant (ambient-context runs). */
+  tenantId?: string | null;
+}
+
+/**
+ * Prune counter rows to bound growth. Applies whichever bounds are provided
+ * (at least one required): `maxAgeMs` drops buckets whose `period` day is
+ * older than the cutoff; `maxRows` keeps only the newest N rows by
+ * `(period, id)`, deleting oldest-first. Mirrors core's `pruneChangeFeed`.
+ */
+export async function pruneFieldUsageCounters(
+  db: DatabaseInterface,
+  retention: FieldUsageCounterRetention,
+): Promise<{ pruned: number }> {
+  const { maxAgeMs, maxRows } = retention;
+  if (maxAgeMs == null && maxRows == null) {
+    throw new Error('pruneFieldUsageCounters requires maxAgeMs and/or maxRows');
+  }
+  if (maxAgeMs != null && (!Number.isFinite(maxAgeMs) || maxAgeMs < 0)) {
+    throw new Error(
+      `pruneFieldUsageCounters maxAgeMs must be >= 0, got ${maxAgeMs}`,
+    );
+  }
+  if (maxRows != null && (!Number.isFinite(maxRows) || maxRows < 0)) {
+    throw new Error(
+      `pruneFieldUsageCounters maxRows must be >= 0, got ${maxRows}`,
+    );
+  }
+
+  const tenantCondition = retention.tenantId ? ' AND tenant_id = ?' : '';
+  const tenantParams = retention.tenantId ? [retention.tenantId] : [];
+  let pruned = 0;
+
+  if (maxAgeMs != null) {
+    const cutoffDay = fieldUsagePeriodForDate(new Date(Date.now() - maxAgeMs));
+    pruned += await deleteCounted(db, `period < ?${tenantCondition}`, [
+      cutoffDay,
+      ...tenantParams,
+    ]);
+  }
+
+  if (maxRows != null) {
+    const countRows = getQueryRows(
+      await db.query(
+        `SELECT COUNT(*) AS total FROM _smrt_field_usage_counters` +
+          `${retention.tenantId ? ' WHERE tenant_id = ?' : ''}`,
+        ...tenantParams,
+      ),
+    );
+    const total = numberFromRow(countRows[0] ?? {}, 'total');
+    const excess = total - Math.floor(maxRows);
+    if (excess > 0) {
+      await db.query(
+        `DELETE FROM _smrt_field_usage_counters
+          WHERE id IN (
+            SELECT id FROM _smrt_field_usage_counters
+            ${retention.tenantId ? 'WHERE tenant_id = ?' : ''}
+            ORDER BY period ASC, id ASC
+            LIMIT ${excess}
+          )`,
+        ...tenantParams,
+      );
+      pruned += excess;
+    }
+  }
+
+  return { pruned };
+}
+
+export interface FieldPolicySuggestionRetention {
+  /** Drop ACCEPTED suggestions decided longer ago than this. */
+  acceptedMaxAgeMs: number;
+  /** Restrict pruning to one tenant (ambient-context runs). */
+  tenantId?: string | null;
+  /** Clock override for deterministic tests. */
+  now?: Date;
+}
+
+/**
+ * Prune settled suggestion rows ONLY (#2051 pin): a dismissed suggestion once
+ * its cool-down has fully elapsed (its suppression job is done), and an
+ * accepted suggestion once it is old. Pending suggestions are NEVER pruned.
+ */
+export async function pruneFieldPolicySuggestions(
+  db: DatabaseInterface,
+  retention: FieldPolicySuggestionRetention,
+): Promise<{ pruned: number }> {
+  const { acceptedMaxAgeMs } = retention;
+  if (!Number.isFinite(acceptedMaxAgeMs) || acceptedMaxAgeMs < 0) {
+    throw new Error(
+      `pruneFieldPolicySuggestions acceptedMaxAgeMs must be >= 0, got ` +
+        `${acceptedMaxAgeMs}`,
+    );
+  }
+  const now = retention.now ?? new Date();
+  const acceptedCutoff = new Date(now.getTime() - acceptedMaxAgeMs);
+  const tenantCondition = retention.tenantId ? ' AND tenant_id = ?' : '';
+  const tenantParams = retention.tenantId ? [retention.tenantId] : [];
+
+  const pruned = await deleteCounted(
+    db,
+    `((status = 'dismissed' AND cooldown_until IS NOT NULL ` +
+      `AND cooldown_until <= ?) ` +
+      `OR (status = 'accepted' AND decided_at IS NOT NULL ` +
+      `AND decided_at <= ?))${tenantCondition}`,
+    [now.toISOString(), acceptedCutoff.toISOString(), ...tenantParams],
+    '_smrt_field_policy_suggestions',
+  );
+  return { pruned };
+}
+
+// ---------------------------------------------------------------------------
+// Job entry points (pure functions; the agent methods delegate here)
+// ---------------------------------------------------------------------------
+
+export interface RunFieldUsageMaintenanceOptions
+  extends Partial<FieldUsageMaintenanceConfig> {
+  db: DatabaseInterface;
+}
+
+/**
+ * The "aggregation" schedule's work. Ingestion pre-aggregates into period
+ * buckets, so the roll-up job's real job is retention: prune counter buckets
+ * per `{maxAgeMs, maxRows}` and settle old suggestion rows.
+ */
+export async function runFieldUsageMaintenance(
+  options: RunFieldUsageMaintenanceOptions,
+): Promise<FieldUsageMaintenanceSummary> {
+  const config = normalizeMaintenanceConfig(options);
+  const ambientTenantId = restrictingTenantId();
+
+  const counters = await pruneFieldUsageCounters(options.db, {
+    maxAgeMs: config.counterMaxAgeMs,
+    maxRows: config.counterMaxRows,
+    tenantId: ambientTenantId,
+  });
+  const suggestions = await pruneFieldPolicySuggestions(options.db, {
+    acceptedMaxAgeMs: config.suggestionAcceptedMaxAgeMs,
+    tenantId: ambientTenantId,
+  });
+
+  return {
+    countersPruned: counters.pruned,
+    suggestionsPruned: suggestions.pruned,
+  };
+}
+
+export interface RunFieldPolicySuggestionGenerationOptions
+  extends Partial<FieldUsageSuggestionConfig> {
+  db: DatabaseInterface;
+  /** Clock override for deterministic tests. */
+  now?: Date;
+}
+
+/**
+ * The threshold job: evaluate windowed counters per
+ * `(tenantId, objectRef, fieldName)` and create PENDING suggestions with
+ * human-readable evidence.
+ *
+ * - `promote`: at least `minDistinctUsers` distinct users set the field to a
+ *   non-default value in the window AND the org-resolved visibility is not
+ *   already `basic`.
+ * - `default`: at least `minSetCount` TOTAL submissions, a single recorded
+ *   value covers `defaultDominanceRatio` of those TOTAL submissions (not of
+ *   the deviations — see `FieldUsageCounter.submissionCount`), and it differs
+ *   from the org-resolved default. Only histogram-eligible fields
+ *   (low-cardinality, non-sensitive, non-gated) can ever qualify, and a group
+ *   containing a legacy bucket with no recorded total is skipped rather than
+ *   ratioed against the wrong denominator.
+ *
+ * Dedup: a candidate is suppressed while the same
+ * `(tenantId, objectRef, fieldName, kind)` has a PENDING suggestion or a
+ * DISMISSED one still inside its cool-down. Accepted history never blocks —
+ * once accepted, the resolved policy itself stops regeneration (visibility is
+ * basic / the default matches). The pre-check is an optimization only: the
+ * single-active guarantee is STRUCTURAL (`FieldPolicySuggestion.activeKey` in
+ * `conflictColumns`), so overlapping runs upsert onto one row instead of
+ * duplicating.
+ *
+ * Sensitive, read-permission-gated, and transient fields are skipped
+ * entirely: their usage rows are count-only observability data and never
+ * produce suggestions.
+ */
+export async function runFieldPolicySuggestionGeneration(
+  options: RunFieldPolicySuggestionGenerationOptions,
+): Promise<FieldUsageSuggestionRunSummary> {
+  const config = normalizeSuggestionConfig(options);
+  const now = options.now ?? new Date();
+  const ambientTenantId = restrictingTenantId();
+
+  const counters = await FieldUsageCounterCollection.create({
+    db: options.db,
+  });
+  const suggestions = await FieldPolicySuggestionCollection.create({
+    db: options.db,
+  });
+
+  const fromPeriod = fieldUsagePeriodForDate(
+    new Date(now.getTime() - (config.windowDays - 1) * DAY_MS),
+  );
+  const toPeriod = fieldUsagePeriodForDate(now);
+  const rows = await counters.listWindow({
+    fromPeriod,
+    toPeriod,
+    tenantId: ambientTenantId,
+  });
+
+  const groups = groupCounters(rows);
+  const fieldMaps = new Map<string, FieldDefinitionMap | null>();
+  const resolvedPolicies = new Map<
+    string,
+    Record<string, ResolvedFieldPolicy>
+  >();
+
+  const summary: FieldUsageSuggestionRunSummary = {
+    created: 0,
+    suppressed: 0,
+    groupsConsidered: 0,
+    groupsFailed: 0,
+    failures: [],
+  };
+
+  for (const group of groups) {
+    summary.groupsConsidered += 1;
+
+    // One bad group must NEVER abort the run: a global (cross-tenant) pass
+    // processes every tenant, so an unprocessable group — a since-changed
+    // field, a rejected proposal payload, a transient db error — would
+    // otherwise starve every group after it for as long as its buckets live.
+    // Failures are counted (with a bounded sample of messages) and the run
+    // continues.
+    try {
+      await evaluateGroup(group);
+    } catch (error) {
+      summary.groupsFailed += 1;
+      if (summary.failures.length < MAX_REPORTED_GROUP_FAILURES) {
+        summary.failures.push(
+          `${group.tenantId} ${group.objectRef}.${group.fieldName}: ` +
+            `${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
+  return summary;
+
+  async function evaluateGroup(group: CounterGroup): Promise<void> {
+    let fieldMap = fieldMaps.get(group.objectRef);
+    if (fieldMap === undefined) {
+      try {
+        fieldMap = await getObjectFieldMap(group.objectRef);
+      } catch {
+        fieldMap = null; // stale counters for a since-removed class
+      }
+      fieldMaps.set(group.objectRef, fieldMap);
+    }
+    if (!fieldMap) {
+      return;
+    }
+    const fieldDef = fieldMap.get(group.fieldName);
+    if (
+      !fieldDef ||
+      isSensitiveField(fieldDef) ||
+      getFieldReadPermission(fieldDef) !== undefined ||
+      isTransientField(fieldDef)
+    ) {
+      return;
+    }
+
+    const stats = mergeGroupStats(group.buckets);
+
+    const policyKey = `${group.tenantId}\0${group.objectRef}`;
+    let orgFields = resolvedPolicies.get(policyKey);
+    if (!orgFields) {
+      // Org-tier resolution (code → app → tenant chain; no user tier). The
+      // resolver's own context assertion keeps ambient-context runs honest.
+      const { resolveFieldPolicy } = await import('./field-policy-resolver.js');
+      const resolved = await resolveFieldPolicy(group.objectRef, {
+        tenantId: group.tenantId,
+        db: options.db,
+      });
+      orgFields = resolved.fields;
+      resolvedPolicies.set(policyKey, orgFields);
+    }
+    const fieldPolicy = orgFields[group.fieldName];
+    if (!fieldPolicy) {
+      return;
+    }
+
+    // -- promote ---------------------------------------------------------
+    if (
+      stats.distinctUsers >= config.minDistinctUsers &&
+      fieldPolicy.visibility !== 'basic'
+    ) {
+      const created = await createUnlessSuppressed(suggestions, {
+        tenantId: group.tenantId,
+        objectRef: group.objectRef,
+        fieldName: group.fieldName,
+        kind: 'promote',
+        proposedValue: null,
+        evidence: buildFieldUsageEvidence({
+          kind: 'promote',
+          fieldName: group.fieldName,
+          objectRef: group.objectRef,
+          windowStart: fromPeriod,
+          windowEnd: toPeriod,
+          distinctUsers: stats.distinctUsers,
+          distinctUsersAtLeast: stats.distinctUsersOverflowed,
+          setCount: stats.setCount,
+          submissionCount: stats.submissionTotalKnown
+            ? stats.submissionCount
+            : undefined,
+          threshold: config.minDistinctUsers,
+        }),
+        now,
+      });
+      if (created) {
+        summary.created += 1;
+      } else {
+        summary.suppressed += 1;
+      }
+    }
+
+    // -- default ---------------------------------------------------------
+    // Dominance is measured against TOTAL submissions, never against
+    // deviations alone: a value seen only in deviations would otherwise look
+    // 100% dominant even when the default it would replace is what almost
+    // everyone submits. Legacy buckets (no recorded total) make the
+    // denominator unknown, so the group is skipped rather than guessed.
+    if (
+      isHistogramEligibleField(fieldDef) &&
+      stats.submissionTotalKnown &&
+      stats.submissionCount >= config.minSetCount
+    ) {
+      const top = topHistogramEntry(stats.histogram);
+      if (top) {
+        const share = top.count / stats.submissionCount;
+        const proposed = decodeHistogramKey(fieldDef, top.key);
+        const currentDefault = fieldPolicy.hasDefault
+          ? fieldPolicy.defaultValue
+          : undefined;
+        if (
+          share >= config.defaultDominanceRatio &&
+          !sameProposedValue(proposed, currentDefault)
+        ) {
+          const created = await createUnlessSuppressed(suggestions, {
+            tenantId: group.tenantId,
+            objectRef: group.objectRef,
+            fieldName: group.fieldName,
+            kind: 'default',
+            proposedValue: JSON.stringify(proposed),
+            evidence: buildFieldUsageEvidence({
+              kind: 'default',
+              fieldName: group.fieldName,
+              objectRef: group.objectRef,
+              windowStart: fromPeriod,
+              windowEnd: toPeriod,
+              distinctUsers: stats.distinctUsers,
+              distinctUsersAtLeast: stats.distinctUsersOverflowed,
+              setCount: stats.setCount,
+              submissionCount: stats.submissionCount,
+              threshold: config.minSetCount,
+              topValue: proposed,
+              topValueShare: share,
+            }),
+            now,
+          });
+          if (created) {
+            summary.created += 1;
+          } else {
+            summary.suppressed += 1;
+          }
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The schedule target
+// ---------------------------------------------------------------------------
+
+/**
+ * The registered schedule target for the #2051 learning loop (see the module
+ * doc for why it is NOT an smrt-agents `Agent` subclass). Rows of its system
+ * table are never written — the class exists so `AgentSchedule.agentType`
+ * resolves through the `ObjectRegistry` and smrt-jobs can construct it and
+ * invoke the two allowlisted methods.
+ */
+@smrt({
+  tableName: '_smrt_field_usage_learning_agents',
+  api: { include: [] },
+  cli: false,
+  mcp: { include: [] },
+})
+export class FieldUsageLearningAgent extends SmrtObject {
+  /**
+   * The smrt-jobs opt-in background allowlist (S5 contract): ONLY these two
+   * methods are reachable from a persisted job/schedule row.
+   */
+  static backgroundEligibleMethods: ReadonlyArray<string> = [
+    'runUsageMaintenance',
+    'runSuggestionGeneration',
+  ];
+
+  constructor(options: SmrtObjectOptions = {}) {
+    super(options);
+  }
+
+  /** Schedule entry point for {@link runFieldUsageMaintenance}. */
+  async runUsageMaintenance(
+    args: Record<string, unknown> = {},
+  ): Promise<FieldUsageMaintenanceSummary> {
+    return runFieldUsageMaintenance({
+      db: this.db,
+      ...pickFiniteNumbers(args, [
+        'counterMaxAgeMs',
+        'counterMaxRows',
+        'suggestionAcceptedMaxAgeMs',
+      ]),
+    });
+  }
+
+  /** Schedule entry point for {@link runFieldPolicySuggestionGeneration}. */
+  async runSuggestionGeneration(
+    args: Record<string, unknown> = {},
+  ): Promise<FieldUsageSuggestionRunSummary> {
+    return runFieldPolicySuggestionGeneration({
+      db: this.db,
+      ...pickFiniteNumbers(args, [
+        'windowDays',
+        'minDistinctUsers',
+        'minSetCount',
+        'defaultDominanceRatio',
+      ]),
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Evidence
+// ---------------------------------------------------------------------------
+
+export interface FieldUsageEvidenceInput {
+  kind: FieldPolicySuggestionKind;
+  objectRef: string;
+  fieldName: string;
+  windowStart: string;
+  windowEnd: string;
+  distinctUsers: number;
+  /** True when the distinct-user set overflowed (count is a lower bound). */
+  distinctUsersAtLeast: boolean;
+  /** Submissions that DIFFERED from the resolved default. */
+  setCount: number;
+  /**
+   * TOTAL submissions observed in the window (the dominance denominator).
+   * `undefined` only for legacy buckets that never recorded a total, in which
+   * case the summary states the deviation count alone.
+   */
+  submissionCount?: number;
+  /** The threshold the candidate cleared (documented in the evidence). */
+  threshold: number;
+  topValue?: unknown;
+  topValueShare?: number;
+}
+
+/**
+ * Human-readable evidence for a suggestion: a `summary` sentence a reviewer
+ * can read as-is, plus the structured numbers behind it.
+ *
+ * The sentence always states BOTH numbers when known — deviations and total
+ * submissions — so a reviewer can see the base rate a dominance percentage was
+ * computed against instead of trusting a bare ratio.
+ */
+export function buildFieldUsageEvidence(
+  input: FieldUsageEvidenceInput,
+): Record<string, unknown> {
+  const users = `${input.distinctUsersAtLeast ? 'at least ' : ''}${
+    input.distinctUsers
+  } user${input.distinctUsers === 1 && !input.distinctUsersAtLeast ? '' : 's'}`;
+  const deviations =
+    `${input.setCount} of ` +
+    (input.submissionCount === undefined
+      ? 'an unrecorded number of submissions'
+      : `${input.submissionCount} submission${
+          input.submissionCount === 1 ? '' : 's'
+        }`);
+  const base =
+    `${users} set "${input.fieldName}" to a non-default value in ` +
+    `${deviations} between ${input.windowStart} and ${input.windowEnd}.`;
+  const summary =
+    input.kind === 'default'
+      ? `${base} ${Math.round((input.topValueShare ?? 0) * 100)}% of all ` +
+        `${input.submissionCount ?? 0} submissions used the value ` +
+        `${JSON.stringify(input.topValue)}.`
+      : base;
+
+  return {
+    summary,
+    objectRef: input.objectRef,
+    fieldName: input.fieldName,
+    windowStart: input.windowStart,
+    windowEnd: input.windowEnd,
+    distinctUsers: input.distinctUsers,
+    ...(input.distinctUsersAtLeast ? { distinctUsersAtLeast: true } : {}),
+    setCount: input.setCount,
+    ...(input.submissionCount !== undefined
+      ? { submissionCount: input.submissionCount }
+      : { submissionCountUnknown: true }),
+    threshold: input.threshold,
+    ...(input.topValue !== undefined ? { topValue: input.topValue } : {}),
+    ...(input.topValueShare !== undefined
+      ? { topValueShare: Number(input.topValueShare.toFixed(4)) }
+      : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+interface CounterGroup {
+  tenantId: string;
+  objectRef: string;
+  fieldName: string;
+  buckets: FieldUsageCounter[];
+}
+
+function groupCounters(rows: FieldUsageCounter[]): CounterGroup[] {
+  const byKey = new Map<string, CounterGroup>();
+  for (const row of rows) {
+    if (!row.tenantId) {
+      continue;
+    }
+    const key = `${row.tenantId}\0${row.objectRef}\0${row.fieldName}`;
+    let group = byKey.get(key);
+    if (!group) {
+      group = {
+        tenantId: row.tenantId,
+        objectRef: row.objectRef,
+        fieldName: row.fieldName,
+        buckets: [],
+      };
+      byKey.set(key, group);
+    }
+    group.buckets.push(row);
+  }
+  return [...byKey.values()];
+}
+
+interface GroupStats {
+  /** Total submissions in the window (the dominance denominator). */
+  submissionCount: number;
+  /**
+   * False when ANY bucket in the window predates the `submissionCount` column
+   * (or is corrupt): the total is then unknown, so `default` suggestions are
+   * skipped for the group rather than computed against a wrong denominator.
+   */
+  submissionTotalKnown: boolean;
+  /** Submissions that differed from the resolved default. */
+  setCount: number;
+  distinctUsers: number;
+  distinctUsersOverflowed: boolean;
+  histogram: Record<string, number>;
+}
+
+/**
+ * Merge a group's buckets: sum counts, UNION the capped distinct-user sets
+ * (an overflowed bucket makes the union an honest lower bound), and sum
+ * histogram buckets.
+ */
+function mergeGroupStats(buckets: FieldUsageCounter[]): GroupStats {
+  let submissionCount = 0;
+  let submissionTotalKnown = true;
+  let setCount = 0;
+  let overflowed = false;
+  const users = new Set<string>();
+  // Null-prototype: histogram keys are user-supplied ids, so `constructor` /
+  // `toString` / `__proto__` must accumulate as plain data (see
+  // `emptyHistogram`). The `hasOwn` read below is the matching own-key test.
+  const histogram = emptyHistogram();
+
+  for (const bucket of buckets) {
+    submissionCount += bucket.submissionCount;
+    if (bucket.isLegacyBucket()) {
+      submissionTotalKnown = false;
+    }
+    setCount += bucket.setCount;
+    overflowed = overflowed || bucket.distinctUsersOverflowed;
+    for (const id of bucket.getDistinctUserIds()) {
+      users.add(id);
+    }
+    for (const [key, count] of Object.entries(bucket.getValueHistogram())) {
+      histogram[key] =
+        (Object.hasOwn(histogram, key) ? histogram[key] : 0) + count;
+    }
+  }
+
+  return {
+    submissionCount,
+    submissionTotalKnown,
+    setCount,
+    distinctUsers: users.size,
+    distinctUsersOverflowed: overflowed,
+    histogram,
+  };
+}
+
+function topHistogramEntry(
+  histogram: Record<string, number>,
+): { key: string; count: number } | null {
+  let top: { key: string; count: number } | null = null;
+  for (const [key, count] of Object.entries(histogram)) {
+    if (!top || count > top.count) {
+      top = { key, count };
+    }
+  }
+  return top;
+}
+
+function sameProposedValue(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+async function createUnlessSuppressed(
+  suggestions: FieldPolicySuggestionCollection,
+  candidate: {
+    tenantId: string;
+    objectRef: string;
+    fieldName: string;
+    kind: FieldPolicySuggestionKind;
+    proposedValue: string | null;
+    evidence: Record<string, unknown>;
+    now: Date;
+  },
+): Promise<boolean> {
+  const existing = await suggestions.list({
+    where: {
+      tenantId: candidate.tenantId,
+      objectRef: candidate.objectRef,
+      fieldName: candidate.fieldName,
+      kind: candidate.kind,
+    },
+  });
+  // Suppression keys off the ACTIVE SLOT, not `status`: a row holding
+  // `activeKey === 'active'` is either pending or mid-decision (the
+  // non-transactional accept holds the slot across its policy write). Keying
+  // off `status` alone would let generation insert a competing pending row in
+  // that window — which would then resolve against the pre-acceptance policy
+  // and collide with the decision's compensation. Cooling-down dismissals
+  // suppress too, even though they have released the slot.
+  const suppressed = existing.some(
+    (row) =>
+      row.activeKey === ACTIVE_SUGGESTION_KEY ||
+      (row.status === 'dismissed' && isWithinCoolDown(row, candidate.now)),
+  );
+  if (suppressed) {
+    return false;
+  }
+
+  await suggestions.create({
+    tenantId: candidate.tenantId,
+    objectRef: candidate.objectRef,
+    fieldName: candidate.fieldName,
+    kind: candidate.kind,
+    proposedValue: candidate.proposedValue,
+    evidence: JSON.stringify(candidate.evidence),
+    status: 'pending',
+  });
+  return true;
+}
+
+function isWithinCoolDown(row: FieldPolicySuggestion, now: Date): boolean {
+  const raw = row.cooldownUntil as Date | string | null;
+  if (raw === null || raw === undefined) {
+    return false;
+  }
+  const until = raw instanceof Date ? raw.getTime() : Date.parse(String(raw));
+  return Number.isFinite(until) && until > now.getTime();
+}
+
+/** Ambient-context restriction: non-bypass runs stay inside their tenant. */
+function restrictingTenantId(): string | null {
+  const context = getCurrentTenant();
+  if (!context || isSuperAdminBypass()) {
+    return null;
+  }
+  return context.tenantId;
+}
+
+/**
+ * Retention bounds are NON-NEGATIVE, not strictly positive: `0` is a meaningful
+ * value the prune functions explicitly accept (`maxRows: 0` purges every row,
+ * `maxAgeMs: 0` every bucket before today), so silently swapping it for the
+ * 100k/90d default would ignore an operator's explicit "purge everything".
+ * Only `undefined` (and non-finite junk) falls back to the default.
+ */
+function normalizeMaintenanceConfig(
+  options: Partial<FieldUsageMaintenanceConfig>,
+): FieldUsageMaintenanceConfig {
+  return {
+    counterMaxAgeMs: nonNegativeOrDefault(
+      options.counterMaxAgeMs,
+      FIELD_USAGE_MAINTENANCE_DEFAULTS.counterMaxAgeMs,
+    ),
+    counterMaxRows: nonNegativeOrDefault(
+      options.counterMaxRows,
+      FIELD_USAGE_MAINTENANCE_DEFAULTS.counterMaxRows,
+    ),
+    suggestionAcceptedMaxAgeMs: nonNegativeOrDefault(
+      options.suggestionAcceptedMaxAgeMs,
+      FIELD_USAGE_MAINTENANCE_DEFAULTS.suggestionAcceptedMaxAgeMs,
+    ),
+  };
+}
+
+function normalizeSuggestionConfig(
+  options: Partial<FieldUsageSuggestionConfig>,
+): FieldUsageSuggestionConfig {
+  const ratio = positiveOrDefault(
+    options.defaultDominanceRatio,
+    FIELD_USAGE_SUGGESTION_DEFAULTS.defaultDominanceRatio,
+  );
+  return {
+    windowDays: Math.max(
+      1,
+      Math.floor(
+        positiveOrDefault(
+          options.windowDays,
+          FIELD_USAGE_SUGGESTION_DEFAULTS.windowDays,
+        ),
+      ),
+    ),
+    minDistinctUsers: Math.max(
+      1,
+      Math.floor(
+        positiveOrDefault(
+          options.minDistinctUsers,
+          FIELD_USAGE_SUGGESTION_DEFAULTS.minDistinctUsers,
+        ),
+      ),
+    ),
+    minSetCount: Math.max(
+      1,
+      Math.floor(
+        positiveOrDefault(
+          options.minSetCount,
+          FIELD_USAGE_SUGGESTION_DEFAULTS.minSetCount,
+        ),
+      ),
+    ),
+    defaultDominanceRatio: Math.min(Math.max(ratio, 0.01), 1),
+  };
+}
+
+/** Strictly positive knobs (thresholds, windows): `0` is not meaningful. */
+function positiveOrDefault(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}
+
+/** Retention bounds: `0` is meaningful ("purge everything"), so keep it. */
+function nonNegativeOrDefault(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : fallback;
+}
+
+function pickFiniteNumbers(
+  args: Record<string, unknown>,
+  keys: string[],
+): Record<string, number> {
+  const picked: Record<string, number> = {};
+  if (!args || typeof args !== 'object') {
+    return picked;
+  }
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      picked[key] = value;
+    }
+  }
+  return picked;
+}
+
+async function deleteCounted(
+  db: DatabaseInterface,
+  condition: string,
+  params: unknown[],
+  table = '_smrt_field_usage_counters',
+): Promise<number> {
+  const countRows = getQueryRows(
+    await db.query(
+      `SELECT COUNT(*) AS total FROM ${table} WHERE ${condition}`,
+      ...params,
+    ),
+  );
+  const total = numberFromRow(countRows[0] ?? {}, 'total');
+  if (total > 0) {
+    await db.query(`DELETE FROM ${table} WHERE ${condition}`, ...params);
+  }
+  return total;
+}
+
+function getQueryRows(result: unknown): Record<string, unknown>[] {
+  return Array.isArray(result)
+    ? (result as Record<string, unknown>[])
+    : ((result as { rows?: Record<string, unknown>[] })?.rows ?? []);
+}
+
+function numberFromRow(row: Record<string, unknown>, key: string): number {
+  const value = row[key];
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+  if (typeof value === 'string') {
+    return Number.parseFloat(value) || 0;
+  }
+  return 0;
+}

--- a/packages/fields/src/usage-schedules.ts
+++ b/packages/fields/src/usage-schedules.ts
@@ -1,0 +1,266 @@
+/**
+ * Dormant `AgentSchedule` installation for the #2051 learning loop.
+ *
+ * `@happyvertical/smrt-agents` is an OPTIONAL dependency of this package
+ * (the smrt-users seam): agents sits ABOVE fields in the dependency DAG (it
+ * hard-depends on smrt-users, ai, and secrets — exactly the packages fields
+ * keeps optional), so the installer dynamic-imports it and degrades
+ * gracefully (`installed: false`) when it is not present. The schedule TARGET
+ * (`FieldUsageLearningAgent`) needs no agents import at all — smrt-jobs
+ * resolves `agentType` through the `ObjectRegistry`.
+ *
+ * DORMANT BY DEFAULT (the epic's suggestion-first posture): schedules are
+ * created with `enabled: false` / `status: 'disabled'` unless the caller
+ * explicitly opts in with `enabled: true` (or later runs the AgentSchedule
+ * `enable()` operator command / flips the row). Activation is a deliberate
+ * per-deployment decision documented in this package's AGENTS.md.
+ */
+
+import { importWorkspaceModule } from '@happyvertical/smrt-core/utils/import-workspace-module';
+import {
+  getCurrentTenant,
+  isSuperAdminBypass,
+  TenantIsolationError,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { deterministicFieldsUuid } from './deterministic-id.js';
+import type {
+  FieldUsageMaintenanceConfig,
+  FieldUsageSuggestionConfig,
+} from './usage-learning.js';
+import { isMissingWorkspaceDependency } from './users-module.js';
+
+/** Registry-qualified schedule target (`AgentSchedule.agentType`). */
+export const FIELD_USAGE_LEARNING_AGENT_TYPE =
+  '@happyvertical/smrt-fields:FieldUsageLearningAgent';
+
+/** Method the aggregation/retention schedule invokes. */
+export const FIELD_USAGE_MAINTENANCE_METHOD = 'runUsageMaintenance';
+
+/** Method the suggestion-generation schedule invokes. */
+export const FIELD_USAGE_SUGGESTION_METHOD = 'runSuggestionGeneration';
+
+/**
+ * Default cadence for counter maintenance: daily at 02:30 — in the SCHEDULER
+ * HOST'S LOCAL TIME. See {@link ensureFieldUsageLearningSchedules} for why no
+ * timezone can be selected here.
+ */
+export const DEFAULT_FIELD_USAGE_MAINTENANCE_CRON = '30 2 * * *';
+
+/** Default cadence for suggestion generation: weekly, Monday 03:00 host-local. */
+export const DEFAULT_FIELD_USAGE_SUGGESTION_CRON = '0 3 * * 1';
+
+/**
+ * Stable id for a global learning schedule, derived from the agent type and
+ * method (the `TenantUsageMetric.recordUsage` precedent).
+ *
+ * `_smrt_agent_schedules` has no natural-key uniqueness on
+ * `(agent_type, method)`, so a check-then-create would let two replicas
+ * starting against an empty database each insert their own random-id row —
+ * and with `enabled: true` every job would then run twice. A deterministic id
+ * makes the insert converge on ONE primary key instead.
+ */
+export function fieldUsageScheduleId(method: string): Promise<string> {
+  return deterministicFieldsUuid([
+    'field-usage-learning-schedule',
+    FIELD_USAGE_LEARNING_AGENT_TYPE,
+    method,
+  ]);
+}
+
+/**
+ * Structural surface of the agents module the installer consumes (no static
+ * import — mirrors `FieldPolicyUsersModule`). `create`/`list`/`save` are the
+ * standard SmrtCollection/SmrtObject shapes.
+ */
+export interface FieldUsageAgentsScheduleRow {
+  id?: string | null;
+  enabled?: boolean;
+  /**
+   * Owning tenant; `null`/absent marks the GLOBAL schedules this installer
+   * manages. Read so the existence check cannot mistake a tenant-specific
+   * schedule for the global one.
+   */
+  tenantId?: string | null;
+  save?: () => Promise<unknown>;
+}
+
+export interface FieldUsageAgentsModule {
+  AgentScheduleCollection: {
+    create(options: { db: DatabaseInterface }): Promise<{
+      list(options: {
+        where: Record<string, unknown>;
+      }): Promise<FieldUsageAgentsScheduleRow[]>;
+      create(
+        data: Record<string, unknown>,
+      ): Promise<FieldUsageAgentsScheduleRow>;
+    }>;
+  };
+}
+
+export interface EnsureFieldUsageLearningSchedulesOptions {
+  db: DatabaseInterface;
+  /**
+   * Whether the schedules start enabled. DEFAULT FALSE — the learning loop
+   * ships dormant; enabling it is an explicit deployment opt-in.
+   */
+  enabled?: boolean;
+  maintenanceCron?: string;
+  suggestionCron?: string;
+  /** Threshold/retention overrides persisted into the schedules' methodArgs. */
+  maintenanceArgs?: Partial<FieldUsageMaintenanceConfig>;
+  suggestionArgs?: Partial<FieldUsageSuggestionConfig>;
+  /** Injection seam for tests / hosts that already loaded the agents module. */
+  agentsModule?: FieldUsageAgentsModule;
+}
+
+export interface EnsureFieldUsageLearningSchedulesResult {
+  /** False when `@happyvertical/smrt-agents` is not installed (no-op). */
+  installed: boolean;
+  /** Schedules created by THIS call (existing rows are left untouched). */
+  created: number;
+}
+
+/**
+ * Idempotently create the two GLOBAL (tenant-null) `AgentSchedule` rows for
+ * the learning loop — the aggregation/retention roll-up and the
+ * suggestion-generation job. An existing GLOBAL row for the agent type +
+ * method is never modified (operator state like enable/disable is preserved).
+ *
+ * The existence check is scoped to the GLOBAL rows deliberately: a deployment
+ * may also run tenant-specific schedules for the same agent type and method
+ * (the ambient-context runs the jobs support), and matching one of those would
+ * silently skip installing the global schedule this function promises. Tenant
+ * rows are read but never touched.
+ *
+ * Concurrency: each schedule is written under a DETERMINISTIC id
+ * ({@link fieldUsageScheduleId}) with insert-only semantics, so two replicas
+ * installing at once converge on one row — the pre-check is only the cheap
+ * path, and a primary-key collision is treated as "already installed" rather
+ * than an error. Insert-only also means an existing row's operator state
+ * (enabled/disabled, edited cron) is never overwritten by a later install.
+ *
+ * **No timezone option, deliberately.** `AgentSchedule` carries a `timezone`
+ * column, but `getNextCronDate(cron, _timezone)` ignores the argument and
+ * matches against host-local `getHours()`/`getDate()`, and smrt-jobs'
+ * `ScheduleRunner` recalculates with the same host-local parser. Accepting a
+ * timezone here would advertise control this stack does not have, so these
+ * schedules fire in the SCHEDULER HOST'S LOCAL TIME — pick crons accordingly
+ * (see `agents/usage-learning.md`). Fixing the agents-side parser is out of
+ * scope for this package.
+ *
+ * System operation: global schedules are platform state, so a non-bypass
+ * ambient tenant context is rejected (fail closed) — call this from trusted
+ * startup/migration code.
+ */
+export async function ensureFieldUsageLearningSchedules(
+  options: EnsureFieldUsageLearningSchedulesOptions,
+): Promise<EnsureFieldUsageLearningSchedulesResult> {
+  const context = getCurrentTenant();
+  if (context && !isSuperAdminBypass()) {
+    throw new TenantIsolationError(
+      'ensureFieldUsageLearningSchedules installs GLOBAL schedules and must ' +
+        'run from trusted execution (no ambient tenant context, or ' +
+        'super-admin bypass)',
+      { tenantId: context.tenantId },
+    );
+  }
+
+  let agentsModule = options.agentsModule;
+  if (!agentsModule) {
+    try {
+      agentsModule = await importWorkspaceModule<FieldUsageAgentsModule>({
+        packageName: '@happyvertical/smrt-agents',
+        sourceEntry: 'packages/agents/src/index.ts',
+        purpose: 'field usage learning schedule installation',
+      });
+    } catch (error) {
+      if (isMissingWorkspaceDependency(error, '@happyvertical/smrt-agents')) {
+        return { installed: false, created: 0 };
+      }
+      throw error;
+    }
+  }
+
+  const schedules = await agentsModule.AgentScheduleCollection.create({
+    db: options.db,
+  });
+  const enabled = options.enabled ?? false;
+  let created = 0;
+
+  const definitions = [
+    {
+      method: FIELD_USAGE_MAINTENANCE_METHOD,
+      cron: options.maintenanceCron ?? DEFAULT_FIELD_USAGE_MAINTENANCE_CRON,
+      methodArgs: options.maintenanceArgs ?? {},
+    },
+    {
+      method: FIELD_USAGE_SUGGESTION_METHOD,
+      cron: options.suggestionCron ?? DEFAULT_FIELD_USAGE_SUGGESTION_CRON,
+      methodArgs: options.suggestionArgs ?? {},
+    },
+  ];
+
+  for (const definition of definitions) {
+    const existing = await schedules.list({
+      where: {
+        agentType: FIELD_USAGE_LEARNING_AGENT_TYPE,
+        method: definition.method,
+      },
+    });
+    // Filter to the GLOBAL scope in memory rather than adding
+    // `tenantId: null` to the where clause: an explicit `tenant_id IS NULL`
+    // filter is what the tenancy interceptor flags as an isolation violation
+    // (the reason `queryGlobal` exists), and this must also work under the
+    // bypass context the guard above allows.
+    if (existing.some(isGlobalScheduleRow)) {
+      continue;
+    }
+
+    const id = await fieldUsageScheduleId(definition.method);
+    let row: FieldUsageAgentsScheduleRow;
+    try {
+      row = await schedules.create({
+        id,
+        tenantId: null,
+        agentType: FIELD_USAGE_LEARNING_AGENT_TYPE,
+        agentId: null,
+        cron: definition.cron,
+        method: definition.method,
+        agentConfig: {},
+        methodArgs: definition.methodArgs,
+        enabled,
+        status: enabled ? 'active' : 'disabled',
+        // Strict insert: a concurrent replica that already created this row
+        // must NOT be adopted-and-overwritten (that would resurrect a
+        // deliberately disabled schedule or clobber an edited cron).
+        _insertOnly: true,
+      });
+    } catch (error) {
+      // ONLY a confirmed collision may be swallowed. Constraint-error text is
+      // not portable across sqlite/PostgreSQL/DuckDB (and core wraps driver
+      // errors), so the evidence is the ROW ITSELF: re-read the deterministic
+      // id and treat "it exists now" as proof another installer won the race.
+      // Anything else — schema drift, validation, a dropped connection — must
+      // propagate, or the installer would report success with the schedule
+      // missing.
+      const raced = await schedules.list({ where: { id } });
+      if (raced.length === 0) {
+        throw error;
+      }
+      continue;
+    }
+    // The schedulePersonaInstance precedent: an explicit save() runs the
+    // model's beforeSave (next-run calculation) even if create() already
+    // persisted the row.
+    await row.save?.();
+    created += 1;
+  }
+
+  return { installed: true, created };
+}
+
+/** Whether a schedule row is one of the GLOBAL (tenant-null) rows. */
+function isGlobalScheduleRow(row: FieldUsageAgentsScheduleRow): boolean {
+  return row.tenantId === null || row.tenantId === undefined;
+}

--- a/packages/fields/src/users-module.ts
+++ b/packages/fields/src/users-module.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared detection for OPTIONAL workspace dependencies
+ * (`@happyvertical/smrt-users`, and since #2051 `@happyvertical/smrt-agents`
+ * for the dormant learning schedules).
+ *
+ * A leaf module (no package-internal imports) so every dynamic-import seam —
+ * the resolver's default tenant-hierarchy loader, the permission catalog
+ * registration, and the schedule installer — shares one matcher without
+ * creating an import cycle through the resolver/collection/model chain.
+ */
+
+/** Node's missing-module message shapes, capturing the quoted specifier. */
+const MISSING_MODULE_TARGET_PATTERN =
+  /Cannot find (?:package|module) '([^']+)'/;
+
+/** Whether a missing-module TARGET specifier is `packageName` (or a subpath). */
+function isPackageSpecifier(target: string, packageName: string): boolean {
+  return target === packageName || target.startsWith(`${packageName}/`);
+}
+
+/**
+ * Whether an import failure means the named workspace package is simply not
+ * installed (→ graceful degradation) rather than installed-but-broken
+ * (→ rethrow, surfacing the problem instead of silently degrading).
+ *
+ * The decision is made on the missing-module TARGET parsed from Node's
+ * `Cannot find package/module '<specifier>'` message (walking the full
+ * `cause` chain): only a target that IS the package (or one of its subpaths)
+ * counts. A transitive failure INSIDE an installed package names the other
+ * module as the target — with the package path merely appearing as the
+ * importer — and therefore rethrows. `importWorkspaceModule`'s own
+ * source-fallback wrapper (`Failed to load <packageName> for ...`) is also
+ * accepted: it is thrown only when the package itself cannot be located.
+ *
+ * Exported for direct testing; not re-exported from the package index.
+ */
+export function isMissingWorkspaceDependency(
+  error: unknown,
+  packageName: string,
+): boolean {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current);
+
+    const match = current.message.match(MISSING_MODULE_TARGET_PATTERN);
+    if (match && isPackageSpecifier(match[1], packageName)) {
+      return true;
+    }
+
+    if (current.message.includes(`Failed to load ${packageName} for`)) {
+      return true;
+    }
+
+    current = current.cause;
+  }
+
+  return false;
+}
+
+/** {@link isMissingWorkspaceDependency} for `@happyvertical/smrt-users`. */
+export function isMissingUsersDependency(error: unknown): boolean {
+  return isMissingWorkspaceDependency(error, '@happyvertical/smrt-users');
+}


### PR DESCRIPTION
## Summary

- Add privacy-bounded, context-derived field-usage counters, manager-reviewed policy suggestions, retention, and opt-in dormant schedules.
- Add transport-neutral Svelte capture, suggestion queue, and gear/control-panel integrations; capture requires an explicit successful host acknowledgement.
- Publish the Fields integration and operator guide, including the SMRT 0.40.61 starter walkthrough.

## Validation

- `pnpm --filter @happyvertical/smrt-fields test` — 16 files / 241 tests
- `pnpm --filter @happyvertical/smrt-fields typecheck`
- `pnpm --filter @happyvertical/smrt-fields check` — 0 errors, 0 warnings
- `pnpm --filter @happyvertical/smrt-fields build` and `verify:pack`
- `pnpm exec biome check packages/fields/src docs/content/field-policies.md docs/sidebars.ts`
- `node scripts/check-svelte-tokens.mjs`
- `pnpm smrt dev:knowledge-check`
- Final API, Svelte, security, and acceptance review re-audits: clear

The local pre-commit/pre-push strict knowledge hook remains blocked by five pre-existing stale knowledge artifacts outside this PR (`core`, `smrt-mobile-contract`, `profiles`, `tenancy`, and `users`); the repository-level knowledge check completes with those warnings only.

## Drive-by fixes

- Declare explicit manifest defaults in three existing Fields policy test fixtures (`741aa28fc`).
- Use the emitted `--smrt-radius-small` token in the new suggestion queue (`87f5204a2`).

Closes #2051
Closes #2266
Parent: #2045
Refs #2052

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"bc4a54d3-fafe-46f0-bfca-7f00df246581","issue":2051,"policy_revision":"1.0.0","status":"complete","validation":["Fields tests 16 files / 241 tests","Fields typecheck","Fields svelte-check 0 errors / 0 warnings","Fields build and packed-export verification","Biome and emitted Svelte-token checks","knowledge check","API, Svelte, security, and acceptance review re-audits clear"]}
```