### PR TITLE
docs: correct four API claims that name nonexistent subpaths and options

### DIFF
--- a/docs/content/core.md
+++ b/docs/content/core.md
@@ -795,13 +795,15 @@ SMRT objects support vector embeddings for semantic search and similarity compar
 
 ### Configuration
 
-Configure embeddings in the `@smrt()` decorator:
+Configure which fields to embed in the `@smrt()` decorator:
 
 ```typescript
 @smrt({
   embeddings: {
-    fields: ['title', 'content', 'summary'],  // Fields to embed
-    model: 'text-embedding-3-small'            // Embedding model (optional)
+    fields: ['title', 'content', 'summary'],  // Fields to embed (required)
+    provider: 'local',                        // Override the project provider (optional)
+    autoGenerate: true,                       // Embed on save (optional, default true)
+    regenerateOnChange: true                  // Skip unchanged content (optional, default true)
   }
 })
 class Article extends SmrtObject {
@@ -810,6 +812,32 @@ class Article extends SmrtObject {
   summary: string = '';
 }
 ```
+
+`ClassEmbeddingConfig` accepts exactly `fields`, `provider`, `autoGenerate`,
+`regenerateOnChange`, and `combinedField`. **There is no `model` key here** — an
+unrecognized key in the decorator is ignored rather than rejected, so a stray
+`model` silently does nothing. The model is a project-level setting:
+
+```javascript
+// smrt.config.js
+import { defineConfig } from '@happyvertical/smrt-config';
+
+export default defineConfig({
+  smrt: {
+    embeddings: {
+      provider: 'local',                      // 'local' | 'ai' | 'auto' (default 'local')
+      localModel: 'Xenova/bge-base-en-v1.5',  // used when provider is 'local' or 'auto'
+      aiModel: 'text-embedding-3-small',      // used when provider is 'ai' or as fallback
+      dimensions: 768                         // default 768
+    }
+  }
+});
+```
+
+The project config and the class config are merged into a
+`ResolvedEmbeddingConfig` at runtime. `getEmbedding()` does take a per-call
+`model` argument, but it selects which stored vector to read rather than which
+model to generate with — see below.
 
 ### `generateEmbeddings(options?)` - Generate Vectors
 
@@ -833,14 +861,22 @@ await article.generateEmbeddings({
 
 ### `getEmbedding(fieldName, model?)` - Retrieve Embedding
 
-Retrieves the stored embedding vector for a specific field.
+Retrieves the stored embedding vector for a specific field. Returns `null` when
+no embedding is stored for that field yet — callers must handle that case.
 
 ```typescript
+// Signature: getEmbedding(fieldName: string, model?: string): Promise<number[] | null>
+
 // Get the embedding for a field
 const titleVector = await article.getEmbedding('title');
-// Returns: Float32Array with embedding values
+if (titleVector) {
+  console.log(`Embedding has ${titleVector.length} dimensions`);
+} else {
+  await article.generateEmbeddings({ fields: ['title'] });
+}
 
-// Get embedding for specific model (if multiple models used)
+// The model name is part of the storage key, so pass it to read the vector
+// stored under a specific model (defaults to the resolved project model)
 const vector = await article.getEmbedding('content', 'text-embedding-3-large');
 ```
 

--- a/docs/content/core.md
+++ b/docs/content/core.md
@@ -802,8 +802,7 @@ Configure which fields to embed in the `@smrt()` decorator:
   embeddings: {
     fields: ['title', 'content', 'summary'],  // Fields to embed (required)
     provider: 'local',                        // Override the project provider (optional)
-    autoGenerate: true,                       // Embed on save (optional, default true)
-    regenerateOnChange: true                  // Skip unchanged content (optional, default true)
+    autoGenerate: true                        // Allow save-time generation (optional, default true)
   }
 })
 class Article extends SmrtObject {
@@ -813,10 +812,13 @@ class Article extends SmrtObject {
 }
 ```
 
-`ClassEmbeddingConfig` accepts exactly `fields`, `provider`, `autoGenerate`,
-`regenerateOnChange`, and `combinedField`. **There is no `model` key here** — an
-unrecognized key in the decorator is ignored rather than rejected, so a stray
-`model` silently does nothing. The model is a project-level setting:
+The decorator's `embeddings` object accepts exactly `fields`, `provider`,
+`autoGenerate`, `regenerateOnChange`, and `combinedField`.
+
+**There is no `model` key here.** Because `smrt()` takes a typed config, writing
+one in a TypeScript object literal is an excess-property error; in plain
+JavaScript, or wherever that check does not apply, it is simply ignored, since
+nothing reads it. The model is a project-level setting:
 
 ```javascript
 // smrt.config.js
@@ -826,8 +828,8 @@ export default defineConfig({
   smrt: {
     embeddings: {
       provider: 'local',                      // 'local' | 'ai' | 'auto' (default 'local')
-      localModel: 'Xenova/bge-base-en-v1.5',  // used when provider is 'local' or 'auto'
-      aiModel: 'text-embedding-3-small',      // used when provider is 'ai' or as fallback
+      localModel: 'Xenova/bge-base-en-v1.5',  // used by 'local', and by 'auto' with no AI client
+      aiModel: 'text-embedding-3-small',      // used by 'ai', and by 'auto' when an AI client exists
       dimensions: 768                         // default 768
     }
   }
@@ -838,6 +840,16 @@ The project config and the class config are merged into a
 `ResolvedEmbeddingConfig` at runtime. `getEmbedding()` does take a per-call
 `model` argument, but it selects which stored vector to read rather than which
 model to generate with — see below.
+
+Two caveats on the class-level flags:
+
+- `autoGenerate` permits save-time generation but does not guarantee it. `save()`
+  only kicks off a background `generateEmbeddings()` when an AI client is
+  configured, so that a save never quietly loads a local transformer model. With
+  `provider: 'local'` and no AI client, call `generateEmbeddings()` yourself.
+- `regenerateOnChange` is resolved onto `ResolvedEmbeddingConfig` but is not
+  currently consulted anywhere. Unchanged content is skipped regardless; use
+  `generateEmbeddings({ force: true })` to re-embed it.
 
 ### `generateEmbeddings(options?)` - Generate Vectors
 

--- a/packages/app-cli/src/bin/smrt-mcp-bridge.ts
+++ b/packages/app-cli/src/bin/smrt-mcp-bridge.ts
@@ -18,8 +18,8 @@
  *  - `SMRT_MCP_DEFAULT_SERVER_URL` — fallback server URL.
  *
  * Apps that want their own branded bin should call `runMcpStdioBridge`
- * directly from `@happyvertical/smrt-app-mcp/cli` instead of going through
- * this generic entrypoint.
+ * directly from `@happyvertical/smrt-app-cli` — this package's root export —
+ * instead of going through this generic entrypoint.
  */
 
 import { runMcpStdioBridge } from '../bridge.js';

--- a/packages/smrt-app-mcp/src/server.ts
+++ b/packages/smrt-app-mcp/src/server.ts
@@ -271,8 +271,13 @@ function taskOwnerIdFor(principal: McpAppPrincipal): string {
 
 /**
  * Build the app-runtime MCP server core. The returned object is intentionally
- * framework-agnostic: HTTP wrappers live in `@happyvertical/smrt-app-mcp/sveltekit`
- * and a stdio bridge lives in `@happyvertical/smrt-app-mcp/bin/smrt-mcp-bridge`.
+ * framework-agnostic: HTTP wrappers live in `@happyvertical/smrt-app-mcp/sveltekit`,
+ * this package's only other export.
+ *
+ * This package ships no stdio bridge. To pipe a deployed app's HTTP MCP surface
+ * to a local stdio MCP client, use `@happyvertical/smrt-app-cli`, which provides
+ * a generic `smrt-mcp-bridge` bin plus `runMcpStdioBridge` and
+ * `createAppCli().startMcpBridge()` for branded entry points.
  */
 export function createMcpAppServer(
   options: CreateMcpAppServerOptions,


### PR DESCRIPTION
Closes #2280

Four shipped API claims named subpaths, options, and types that do not exist. All four are docs / doc comments only — no runtime code changed.

Note on paths: the issue body says `packages/smrt-app-cli/...`. That directory does not exist; the package directory is `packages/app-cli` (published name is still `@happyvertical/smrt-app-cli`). The real paths are used below.

## 1. `packages/smrt-app-mcp/src/server.ts` — `createMcpAppServer` doc comment

**Was:** "a stdio bridge lives in `@happyvertical/smrt-app-mcp/bin/smrt-mcp-bridge`".

**Evidence:** `packages/smrt-app-mcp/package.json` `exports` has exactly `.` and `./sveltekit`, and there is no `bin` field. `packages/app-cli/package.json` has `"bin": { "smrt-mcp-bridge": "./dist/bin/smrt-mcp-bridge.js" }`. The same package's `README.md:11` already points at `@happyvertical/smrt-app-cli` — the doc comment contradicted the README shipped beside it.

**Now:** says this package ships no stdio bridge, points at `@happyvertical/smrt-app-cli`, and names its three real entry points (the `smrt-mcp-bridge` bin, `runMcpStdioBridge`, `createAppCli().startMcpBridge()`) — all three verified as exported/declared.

## 2. `packages/app-cli/src/bin/smrt-mcp-bridge.ts` — branded-bin instruction

**Was:** call `runMcpStdioBridge` "directly from `@happyvertical/smrt-app-mcp/cli`". No such subpath exists (see the `exports` map above).

**Evidence:** the symbol name is unchanged — `packages/app-cli/src/index.ts` re-exports `createMcpStdioBridge`, `McpStdioBridgeOptions`, and `runMcpStdioBridge` from `./bridge.js`, and `exports` for that package is `.` only, so the root specifier is the entry point.

**Now:** points at `@happyvertical/smrt-app-cli` and flags it as this package's own root export.

## 3. `docs/content/core.md` §Vector Embeddings — decorator `model` option

**Was:** `embeddings: { fields: [...], model: 'text-embedding-3-small' }`.

**Evidence:** `ClassEmbeddingConfig` (`packages/core/src/embeddings/types.ts:64`) declares `fields`, `provider`, `autoGenerate`, `regenerateOnChange`, `combinedField` — no `model`. The model is resolved in `packages/core/src/registry/embedding-manager.ts` `resolveEmbeddingConfig()` from the project config's `localModel` / `aiModel` (`packages/config/src/types.ts:78`) onto `ResolvedEmbeddingConfig`.

**Now:** the decorator snippet shows only real keys; a following paragraph states there is no `model` key, distinguishes the TypeScript excess-property error (`smrt()` takes a typed `SmartObjectConfig`, and the `embeddings` member at `packages/core/src/registry/types.ts:509` has no index signature) from the plain-JavaScript ignore-it case, and a `smrt.config.js` snippet shows where the model actually comes from. Two caveats follow it, added after review: `autoGenerate` only triggers on `save()` when an AI client is configured (`packages/core/src/object.ts:1959-1980`), and `regenerateOnChange` is resolved onto `ResolvedEmbeddingConfig` but read nowhere, so `force: true` is the real override.

**Deliberately not overcorrected:** `getEmbedding(fieldName, model?)` genuinely does take a per-call model, so the doc keeps that and clarifies what it does — reading `packages/core/src/object.ts:3915-3960`, the argument feeds `EmbeddingStorage.get(..., modelName)`, i.e. it selects which stored vector to read, not which model to generate with.

## 4. `docs/content/core.md` — `getEmbedding` return type

**Was:** "Returns: Float32Array with embedding values".

**Evidence:** `packages/core/src/object.ts:3915` — `public async getEmbedding(fieldName: string, model?: string): Promise<number[] | null>`, returning `stored?.embedding || null`.

**Now:** states the real signature, leads with the `null` case (no stored embedding yet), and shows the guarded call. The recovery branch uses `generateEmbeddings({ fields: ['title'] })`, verified against `GenerateEmbeddingsOptions` (`packages/core/src/embeddings/types.ts:198`: `fields`, `provider`, `force`).

## Validation

| check | result |
| --- | --- |
| `pnpm turbo test --filter @happyvertical/smrt-app-cli --filter @happyvertical/smrt-app-mcp` | pass — app-cli 11 files / 106 tests, app-mcp 5 files / 48 tests |
| `pnpm turbo typecheck` (same two filters) | pass |
| `npx biome ci --diagnostic-level=error .` | pass — 2863 files, no diagnostics |
| `pnpm knowledge:check --strict --format markdown` | pass — 0 errors, 0 warnings |
| `node scripts/check-agents-chain.mjs` | pass — 66 chains under cap (two pre-existing >80% warnings in `packages/users` and `packages/chat`, untouched here) |
| full pre-push hook suite | pass on both pushes |
| repository CI on the current head | green |

Root `pnpm build` / `pnpm test` were not run in full: the diff is comment and prose hunks with no runtime effect, and the two owning packages plus a repo-wide biome and knowledge-freshness pass cover it.

One honest note on the run: `pnpm knowledge:check` initially failed with `stale-domain-knowledge` on `packages/smrt-app-mcp/.smrt/smrt-knowledge.json`. That path is gitignored, and stashing this branch's edits reproduced the identical failure on a clean tree — it is a local generated-artifact ordering artifact (the test task rewrites `.smrt/manifest.json` after build). Rebuilding the package cleared it, and the check is green above and in CI.

## Review round

Four P2 threads from the automated reviewers on the first commit were all valid and are fixed in `0f2eefc`; each thread has a reply citing the source that confirms it, and all four are resolved.

## Follow-up noted, not fixed here

`packages/config/src/types.ts:88` describes the `auto` embedding provider as "Try local first, fallback to AI". `EmbeddingProvider.embed()` and `getModelName()` do the reverse — they prefer `aiModel` when an AI client is present — and `packages/core/src/embeddings/types.ts:26` already documents it correctly. That is a fifth stale claim in a package this PR does not otherwise touch, so it is left for a separate issue rather than widened into this one.

## Left out of scope

- No changeset (release automation generates them).
- Nothing else in `docs/content/core.md` was audited; only the two claims named in the issue were corrected.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude-code","session":"94a9e688-edcb-4e84-97a8-16a221e3e7f1","issue":2280,"policy_revision":"1.0.0","status":"complete","validation":["smrt-app-cli tests 11 files / 106 tests","smrt-app-mcp tests 5 files / 48 tests","typecheck smrt-app-cli and smrt-app-mcp","biome ci repo-wide 2863 files, 0 diagnostics","knowledge:check --strict 0 errors / 0 warnings","check-agents-chain 66 chains under cap","full pre-push hook suite on both pushes","repository CI green on current head","four automated-review threads addressed and resolved"]}
```
