### PR TITLE
fix(core): accept the combined embedding field in semanticSearch

### DIFF
--- a/packages/core/src/__tests__/embedding-search.test.ts
+++ b/packages/core/src/__tests__/embedding-search.test.ts
@@ -94,6 +94,23 @@ class SearchTestDocumentCollection extends SmrtCollection<SearchTestDocument> {
   static readonly _itemClass = SearchTestDocument;
 }
 
+// Test document whose embeddings config declares a combined field (#2281)
+@smrt({
+  embeddings: {
+    fields: ['title', 'body'],
+    combinedField: { name: 'content', template: '{title}\n\n{body}' },
+    autoGenerate: false,
+  },
+})
+class CombinedFieldDocument extends SmrtObject {
+  title: string = '';
+  body: string = '';
+}
+
+class CombinedFieldDocumentCollection extends SmrtCollection<CombinedFieldDocument> {
+  static readonly _itemClass = CombinedFieldDocument;
+}
+
 describe('Semantic Search', () => {
   let tempDir: string;
   let dbPath: string;
@@ -444,5 +461,108 @@ describe('Semantic Search', () => {
 
       expect(stats.generated).toBe(10);
     });
+  });
+});
+
+describe('Semantic Search with a combined embedding field (#2281)', () => {
+  let tempDir: string;
+  let dbPath: string;
+  let collection: CombinedFieldDocumentCollection;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'smrt-combined-field-test-'));
+    dbPath = join(tempDir, 'documents.db');
+
+    ObjectRegistry.registerCollection(
+      'CombinedFieldDocument',
+      CombinedFieldDocumentCollection,
+    );
+
+    collection = await CombinedFieldDocumentCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+      ai: {
+        embed: async (texts: string | string[]) => {
+          const textArray = Array.isArray(texts) ? texts : [texts];
+          return {
+            embeddings: textArray.map((t) => createSemanticEmbeddings(t)),
+          };
+        },
+      } as any,
+    });
+
+    vi.spyOn(EmbeddingProvider.prototype, 'embed').mockImplementation(
+      async (texts: string | string[]) => {
+        const textArray = Array.isArray(texts) ? texts : [texts];
+        return textArray.map((t) => createSemanticEmbeddings(t));
+      },
+    );
+
+    vi.spyOn(EmbeddingProvider.prototype, 'getModelName').mockReturnValue(
+      'test-model',
+    );
+    vi.spyOn(EmbeddingProvider.prototype, 'getDimensions').mockReturnValue(5);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  async function seedCombinedDocument() {
+    const doc = await collection.create({
+      title: 'AI Revolution',
+      body: 'Machine learning and AI are transforming software development.',
+    });
+    await doc.save();
+    await doc.generateEmbeddings();
+    return doc;
+  }
+
+  it('stores a vector under the combined field name', async () => {
+    const doc = await seedCombinedDocument();
+
+    // generateEmbeddings() writes one vector per configured field plus the
+    // combined one, which is what semanticSearch must be able to reach.
+    expect(await doc.getEmbedding('title')).not.toBeNull();
+    expect(await doc.getEmbedding('body')).not.toBeNull();
+    expect(await doc.getEmbedding('content')).not.toBeNull();
+  });
+
+  it('accepts the combined field name in semanticSearch', async () => {
+    const doc = await seedCombinedDocument();
+
+    const results = await collection.semanticSearch(
+      'artificial intelligence and machine learning',
+      { field: 'content', limit: 5 },
+    );
+
+    expect(results.map((r) => r.id)).toContain(doc.id);
+    expect(results[0]._similarity).toBeDefined();
+  });
+
+  it('matches findSimilar, which already accepted the combined field', async () => {
+    const doc = await seedCombinedDocument();
+    const other = await collection.create({
+      title: 'Deep Learning Guide',
+      body: 'Neural networks and computer vision represent the future of AI.',
+    });
+    await other.save();
+    await other.generateEmbeddings();
+
+    const similar = await collection.findSimilar(doc, { field: 'content' });
+
+    expect(similar.map((s) => s.id)).toContain(other.id);
+  });
+
+  it('rejects unknown fields and lists the combined field as available', async () => {
+    await seedCombinedDocument();
+
+    await expect(
+      collection.semanticSearch('anything', { field: 'not-a-field' }),
+    ).rejects.toThrow(/Available fields: title, body, content/);
   });
 });

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -15,6 +15,7 @@ import {
 } from './collection-cache';
 import { EmbeddingProvider } from './embeddings/provider';
 import { EmbeddingStorage } from './embeddings/storage';
+import type { ClassEmbeddingConfig } from './embeddings/types';
 import {
   createInterceptorContext,
   GlobalInterceptors,
@@ -67,6 +68,27 @@ function resolveMetaTypeInWhere<T extends Record<string, unknown>>(
   }
 
   return where;
+}
+
+/**
+ * Field names that carry a stored embedding vector for a class (Issue #2281)
+ *
+ * `SmrtObject.generateEmbeddings()` writes one vector per configured field and,
+ * when `combinedField` is set, an extra vector under `combinedField.name`. Any
+ * of those names is a legitimate target for the collection's semantic-search
+ * methods, so validation and error messages should describe the whole set.
+ *
+ * @param config - Resolved embedding configuration for the class
+ * @returns Configured field names, plus the combined field name when distinct
+ */
+function getSearchableEmbeddingFields(
+  config: Pick<ClassEmbeddingConfig, 'fields' | 'combinedField'>,
+): string[] {
+  const combinedName = config.combinedField?.name;
+  if (!combinedName || config.fields.includes(combinedName)) {
+    return config.fields;
+  }
+  return [...config.fields, combinedName];
 }
 
 /**
@@ -3100,7 +3122,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    *
    * @param query - Text to search for
    * @param options - Search options
-   * @param options.field - Specific field to search (defaults to first embedding field)
+   * @param options.field - Specific field to search (defaults to first embedding
+   *   field). Any configured embedding field, or the configured
+   *   `combinedField.name`, is accepted.
    * @param options.limit - Maximum results to return (default: 10)
    * @param options.minSimilarity - Minimum similarity threshold 0-1 (default: 0)
    * @param options.where - Additional WHERE filters to apply
@@ -3116,6 +3140,11 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    * for (const article of results) {
    *   console.log(`${article.title} (similarity: ${article._similarity})`);
    * }
+   *
+   * // Search the combined vector built from `combinedField.template`
+   * const combined = await articles.semanticSearch('machine learning trends', {
+   *   field: 'content'
+   * });
    * ```
    */
   public async semanticSearch(
@@ -3141,12 +3170,16 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       );
     }
 
-    // Determine which field to search
+    // Determine which field to search.
+    // `generateEmbeddings()` also stores a vector under the configured
+    // `combinedField.name`, and `findSimilar`/`findSimilarToEmbedding` happily
+    // search it, so it belongs in the searchable set here too (#2281).
     const searchField = field || embeddingConfig.fields[0];
-    if (!embeddingConfig.fields.includes(searchField)) {
+    const searchableFields = getSearchableEmbeddingFields(embeddingConfig);
+    if (!searchableFields.includes(searchField)) {
       throw new Error(
         `Field '${searchField}' is not configured for embeddings on ${this._itemClass.name}. ` +
-          `Available fields: ${embeddingConfig.fields.join(', ')}`,
+          `Available fields: ${searchableFields.join(', ')}`,
       );
     }
 

--- a/packages/core/src/embeddings/types.ts
+++ b/packages/core/src/embeddings/types.ts
@@ -217,7 +217,10 @@ export interface GenerateEmbeddingsOptions {
  */
 export interface SemanticSearchOptions {
   /**
-   * Field to search (default: combined field or first configured field)
+   * Field to search (default: first configured field)
+   *
+   * Accepts any field listed in `fields`, or the configured
+   * `combinedField.name` — `generateEmbeddings()` stores a vector for each.
    */
   field?: string;
 


### PR DESCRIPTION
Closes #2281.

## The problem

`SmrtObject.generateEmbeddings()` stores a vector per configured embedding field
**and**, when `embeddings.combinedField` is set, an extra vector under
`combinedField.name` (`packages/core/src/object.ts`, the `if (config.combinedField)`
branch). Reading that vector back was asymmetric:

| call | before |
| --- | --- |
| `collection.semanticSearch(q, { field: 'content' })` | **throws** |
| `collection.findSimilar(obj, { field: 'content' })` | works |
| `collection.findSimilarToEmbedding(vec, { field: 'content' })` | works |

All three compute `searchField` with the identical `field || embeddingConfig.fields[0]`
expression. Only `semanticSearch` validated it, against `embeddingConfig.fields` alone.

The decisive detail: immediately past that throw, `semanticSearch` embeds the query and
delegates to `findSimilarToEmbedding({ field: searchField, ... })` — the sibling with no
check at all. The lookup path the guard was protecting already worked for the combined
field; the guard was the only thing in front of it. A caller could get the intended
behaviour today by embedding the query themselves, which is exactly what the "validated"
method does internally. That makes this an oversight rather than a real constraint.

## The change

`packages/core/src/collection.ts`

- New module-local `getSearchableEmbeddingFields(config)` returns the configured fields
  plus `combinedField?.name` when it is set and not already among them.
- `semanticSearch` validates against that set instead of `embeddingConfig.fields`.
- **The `Available fields:` list in the error now includes the combined field name**, so
  the message stops advertising a narrower set than the sibling methods accept.
- JSDoc for `options.field` documents that the combined name is accepted, with an example.

`packages/core/src/embeddings/types.ts`

- `SemanticSearchOptions.field` said the default was "combined field or first configured
  field". The default is and remains `fields[0]`; corrected, and the accepted set is now
  stated. This doc was describing behaviour the code never had.

**No behaviour change for existing callers.** The default search field is untouched; the
only difference is that a previously-rejected, already-working configuration is no longer
rejected.

## Regression test

`packages/core/src/__tests__/embedding-search.test.ts` gains a `CombinedFieldDocument`
class configured with `combinedField: { name: 'content', template: '{title}\n\n{body}' }`
and four cases following the conventions of the existing suite in that file:

1. `generateEmbeddings()` stores vectors under `title`, `body`, **and** `content`.
2. `semanticSearch(q, { field: 'content' })` resolves and returns the seeded document.
3. `findSimilar(doc, { field: 'content' })` still works — pins the parity the fix restores.
4. An unknown field still throws, and the message lists `title, body, content`.

Verified the test earns its keep: with `collection.ts` reverted to `main`, cases 2 and 4
fail (`Field 'content' is not configured for embeddings on CombinedFieldDocument.
Available fields: title, body`) while case 3 passes — reproducing the reported asymmetry
exactly. With the fix, all four pass.

## Judgement call for the reviewer: should the siblings validate too?

`findSimilar` and `findSimilarToEmbedding` validate **nothing** — an unknown field name
silently returns `[]` (no stored embeddings match) rather than telling the caller they
typo'd the field. I deliberately did **not** tighten them here:

- It is a behaviour change, not a bug fix. Any caller passing a name that is not in the
  config currently gets an empty array; making that throw could break working code, and
  the blast radius is not knowable from this repo.
- It is out of scope for #2281, which is about a false rejection, not a missing one.

My position: the silent-empty-result behaviour is worse for users than an error, and I
think the siblings **should** validate against the same widened set — but as its own
change with its own issue, so it can be released deliberately rather than riding along
with a fix. Happy to file that follow-up if a reviewer agrees.

## Downstream note

happyvertical/s-m-r-t.dev PR #154 currently documents this asymmetry as intended
*behaviour* in its reference pages. Those notes should be reworded once this lands. That
repo is untouched by this PR.

## Validation

| command | result |
| --- | --- |
| `pnpm --filter @happyvertical/smrt-core test` | **pass** — 259 files, 3173 passed, 45 skipped, 0 failed |
| `pnpm --filter @happyvertical/smrt-core typecheck` | **pass** |
| `pnpm build` | **pass** — 62/62 tasks |
| `pnpm typecheck` | **pass** — 122/122 tasks |
| `pnpm lint` | no-op — no package in the workspace defines a `lint` script (`turbo lint` runs 0 tasks). Ran `biome check` on the three changed files instead: clean. |
| `pnpm knowledge:check --strict` | **pass** — 0 errors, 0 warnings |
| `pnpm test` (root, all 64 packages) | **two runs, each with one failure, in different unrelated packages; both green on retry.** Details below. |

Stated plainly rather than rounded up: the root suite did not go green in a single pass
on this machine.

- Run 1: `@happyvertical/smrt-analytics` — `Cannot find module packages/core/dist/change-feed.js`
  while importing the core barrel, which then cancelled 11 in-flight sibling tasks
  (their `ELIFECYCLE` lines are turbo cancellation, not test failures). A module-resolution
  fault in core's own `dist/`, in a package that does not touch semantic search.
- Run 2: analytics passed. `@happyvertical/smrt-fields` failed one Svelte case,
  `ObjectFormGeneratedApi.integration.test.ts` — `Unable to find an accessible element
  with the role "group"`, a testing-library render race. Re-run on its own: **2/2 pass.**

Different package each time, neither reachable from a change confined to
`SmrtCollection.semanticSearch` field validation, and each passing on re-run — consistent
with load-sensitive flakes (another heavy test run was competing for CPU on this host)
rather than anything in this diff. Flagging it so CI is read with that context; if either
recurs on CI, it is worth a separate look.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude-code","session":"94a9e688-edcb-4e84-97a8-16a221e3e7f1","issue":2281,"policy_revision":"1.0.0","status":"complete","validation":["smrt-core tests 259 files / 3173 passed / 45 skipped","smrt-core typecheck","root pnpm build 62/62 tasks","root pnpm typecheck 122/122 tasks","biome check clean on all changed files","knowledge:check --strict 0 errors / 0 warnings","root pnpm test: two unrelated flakes (smrt-analytics, smrt-fields), each green on re-run","regression test verified failing on main and passing with the fix"]}
```
