### PR TITLE
fix(fields): mount the policy-driven form preview inside its provider

### DIFF
--- a/docs/content/field-policies.md
+++ b/docs/content/field-policies.md
@@ -238,8 +238,8 @@ the resolved policy and filtered by the current mode.
 
 Unlike <code>PolicyField</code>, these three do not degrade outside a provider. Each
 derives its whole output from the resolved policy, so outside one they raise an
-error naming <code>FieldPolicyProvider</code> rather than rendering an empty
-control.
+error naming <code>FieldPolicyProvider</code> rather than rendering an empty or
+absent control.
 
 The provider contributes no markup, so it can wrap a page header as well as the
 form when help belongs above the fields. Wrap once, though: each
@@ -287,9 +287,11 @@ fails closed with an accessible error when a definition or policy is missing.
 ~~~
 
 <code>ObjectForm</code> creates its own <code>FieldPolicyProvider</code> around the
-fields it renders, so it needs no outer provider and should not be given one.
-It renders <code>ModeSwitch</code> with <code>showModeSwitch</code>; it does not
-currently expose a seam for <code>FormHelp</code>.
+fields it renders, so it needs no outer provider and should not be given one. It
+renders <code>ModeSwitch</code> with <code>showModeSwitch</code>. Its
+<code>actions</code> snippet renders inside that provider, so
+<code>FormHelp</code> placed there resolves the form's policy — but there is no
+header seam, so it can only appear below the fields.
 
 The browser wire types are text, integer, decimal, boolean, datetime, JSON,
 foreign-key, and cross-package-reference. There is no <code>select</code> wire type.

--- a/docs/content/field-policies.md
+++ b/docs/content/field-policies.md
@@ -202,6 +202,52 @@ the user cleared. Outside a provider it degrades to rendering its children, so
 an application can adopt it incrementally. Use its <code>render</code> snippet when a
 custom layout needs the resolved field data directly.
 
+### Provider-only compositions
+
+Three optional compositions layer over the same form. <code>ModeSwitch</code>
+toggles basic and advanced. <code>AdvancedFields</code> collapses advanced-tier
+fields into a disclosure. <code>FormHelp</code> is a help toggle that lists the
+object description and every visible field's label and help text, assembled from
+the resolved policy and filtered by the current mode.
+
+~~~svelte
+<script lang="ts">
+  import {
+    FieldPolicyProvider,
+    FormHelp,
+    ModeSwitch,
+    PolicyField,
+  } from '@happyvertical/smrt-fields/svelte';
+
+  let { policy, invoice = $bindable({}) } = $props();
+</script>
+
+<FieldPolicyProvider {policy}>
+  <header>
+    <h2>Invoice</h2>
+    <FormHelp objectDescription="An invoice issued to a customer." />
+  </header>
+
+  <ModeSwitch />
+
+  <PolicyField name="title">
+    <input id="title" bind:value={invoice.title} />
+  </PolicyField>
+</FieldPolicyProvider>
+~~~
+
+Unlike <code>PolicyField</code>, these three do not degrade outside a provider. Each
+derives its whole output from the resolved policy, so outside one they raise an
+error naming <code>FieldPolicyProvider</code> rather than rendering an empty
+control.
+
+The provider contributes no markup, so it can wrap a page header as well as the
+form when help belongs above the fields. Wrap once, though: each
+<code>FieldPolicyProvider</code> owns its own mode state, and a nested provider
+shadows the outer one for everything inside it. Two providers means an outer
+<code>FormHelp</code> whose glossary does not follow the inner
+<code>ModeSwitch</code>.
+
 ## Generated ObjectForm and source registry
 
 <code>ObjectForm</code> renders the safe intersection of a generated browser field
@@ -239,6 +285,11 @@ fails closed with an accessible error when a definition or policy is missing.
   />
 </ObjectFormSourceProvider>
 ~~~
+
+<code>ObjectForm</code> creates its own <code>FieldPolicyProvider</code> around the
+fields it renders, so it needs no outer provider and should not be given one.
+It renders <code>ModeSwitch</code> with <code>showModeSwitch</code>; it does not
+currently expose a seam for <code>FormHelp</code>.
 
 The browser wire types are text, integer, decimal, boolean, datetime, JSON,
 foreign-key, and cross-package-reference. There is no <code>select</code> wire type.

--- a/packages/fields/AGENTS.md
+++ b/packages/fields/AGENTS.md
@@ -210,8 +210,10 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
   out. It must not add a second: each provider constructs its own
   `FieldPolicyModeStore` and `setContext` shadows for the subtree, so a
   `FormHelp` above a nested provider stops tracking the `ModeSwitch` inside it.
-  `ObjectForm` builds its own provider internally and exposes no `FormHelp`
-  seam, so that composition is currently unreachable through it.
+  `ObjectForm` builds its own provider, so never wrap it in another; its
+  `actions` snippet renders INSIDE that provider (context resolves at the render
+  site), which is the only way to reach `FormHelp` through it — below the
+  fields, since there is no header seam (#2289).
 
 ## Defaults control panel (#2050)
 

--- a/packages/fields/AGENTS.md
+++ b/packages/fields/AGENTS.md
@@ -196,6 +196,22 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
 - `policyToVisibleColumnIds(policy, columns)` feeds smrt-ui `DataTable`'s
   `visibleColumnIds`; it filters policy-hidden mapped fields, preserves unmapped
   computed/action columns, and cannot reveal a static `column.hidden` column.
+- **Two-tier context contract.** `PolicyField` alone reads the context with
+  `tryGetFieldPolicyContext()`, because outside a Provider it still has the
+  caller's children to render verbatim (incremental adoption). The
+  provider-only compositions — `ModeSwitch`, `AdvancedFields`, `FormHelp` —
+  read it with the throwing `getFieldPolicyContext()`: their whole output is
+  derived from the resolved policy, so degrading would render an empty or
+  absent control instead of surfacing the missing Provider. Do not convert one
+  of them to the non-throwing accessor in isolation (#2272).
+- **One provider per form.** `FieldPolicyProvider` renders only
+  `{@render children?.()}`, so a host wanting `FormHelp` in a page header
+  extends the SAME provider over the header rather than hoisting the component
+  out. It must not add a second: each provider constructs its own
+  `FieldPolicyModeStore` and `setContext` shadows for the subtree, so a
+  `FormHelp` above a nested provider stops tracking the `ModeSwitch` inside it.
+  `ObjectForm` builds its own provider internally and exposes no `FormHelp`
+  seam, so that composition is currently unreachable through it.
 
 ## Defaults control panel (#2050)
 

--- a/packages/fields/src/svelte/__tests__/FormHelp.test.ts
+++ b/packages/fields/src/svelte/__tests__/FormHelp.test.ts
@@ -162,6 +162,17 @@ describe('FormHelp', () => {
     expect(terms[1]).toHaveTextContent('Name');
   });
 
+  it('throws an actionable error outside a FieldPolicyProvider (#2272)', () => {
+    // Deliberate contract: FormHelp's whole output is the resolved glossary, so
+    // it reports a missing Provider instead of degrading to an empty panel.
+    // (PolicyField degrades because it has caller-owned children to preserve.)
+    expect(() =>
+      render(FormHelp, {
+        props: { objectDescription: 'A widget is a configurable thing.' },
+      }),
+    ).toThrow(/Wrap your form in <FieldPolicyProvider>/);
+  });
+
   it('is axe-clean', async () => {
     const { container } = render(FormHelpFixture, {
       props: { policy: makePolicy() },

--- a/packages/fields/src/svelte/__tests__/playground.test.ts
+++ b/packages/fields/src/svelte/__tests__/playground.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+/**
+ * Playground smoke tests (#2272).
+ *
+ * Registering `@happyvertical/smrt-fields/playground` publishes EVERY entry in
+ * the module, and `PlaygroundHost` mounts the selected one bare — no
+ * `<svelte:boundary>` around it. So a preview that throws on mount is not a
+ * contained failure the host can route around; a host cannot offer the sound
+ * entry without also offering one that breaks the page.
+ *
+ * That is exactly how #2272 shipped: the `Policy-Driven Form` preview rendered
+ * `<FormHelp>` outside its `<FieldPolicyProvider>`, and no unit test could see
+ * it, because `FormHelp`'s own tests always mount it through a provider
+ * fixture — they exercise the component's contract, never the preview's
+ * composition.
+ *
+ * These tests therefore load and MOUNT every exported entry the way
+ * `PlaygroundHost` does — one mount per declared mode, with the entry props and
+ * mode props merged (`PlaygroundHost.svelte`). Nothing wraps the component, so
+ * a preview that needs an ancestor provider must supply its own.
+ *
+ * Structural types below: this package must not depend on
+ * `@happyvertical/smrt-playground`, so the module shape is asserted, not
+ * imported.
+ */
+import { cleanup, render } from '@happyvertical/smrt-vitest/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import playground from '../playground.js';
+
+interface PreviewModeConfig {
+  label?: string;
+  props?: Record<string, unknown>;
+}
+
+interface PreviewEntry {
+  id: string;
+  title: string;
+  props?: Record<string, unknown>;
+  modes?: Record<string, PreviewModeConfig | true>;
+  loadComponent: () => Promise<unknown>;
+}
+
+const entries = playground.entries as readonly PreviewEntry[];
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('smrt-fields playground module', () => {
+  it('publishes the field-policy previews', () => {
+    expect(playground.packageName).toBe('@happyvertical/smrt-fields');
+    expect(entries.map((entry) => entry.id)).toEqual([
+      'policy-form',
+      'object-form',
+    ]);
+
+    for (const entry of entries) {
+      expect(entry.loadComponent).toEqual(expect.any(Function));
+      expect(entry.modes).toHaveProperty('mock');
+    }
+  });
+
+  // One case per entry/mode so a failure names the broken preview.
+  for (const entry of entries) {
+    for (const [mode, config] of Object.entries(entry.modes ?? {})) {
+      it(`mounts the "${entry.title}" preview in ${mode} mode`, async () => {
+        const loaded = await entry.loadComponent();
+        const component =
+          typeof loaded === 'function'
+            ? loaded
+            : (loaded as { default: unknown }).default;
+        expect(component).toEqual(expect.any(Function));
+
+        // Mirror PlaygroundHost: entry props, then mode props. Nothing else.
+        const props = {
+          ...(entry.props ?? {}),
+          ...(config === true ? {} : (config.props ?? {})),
+        };
+
+        const { container } = render(component as never, {
+          props: props as never,
+        });
+
+        expect(container.textContent?.trim()).not.toBe('');
+      });
+    }
+  }
+});

--- a/packages/fields/src/svelte/components/FormHelp.svelte
+++ b/packages/fields/src/svelte/components/FormHelp.svelte
@@ -20,9 +20,10 @@
  * To put form help in a page header, extend the SAME provider over the header —
  * it renders no markup of its own. Do not add a second one: each provider owns
  * its own mode store and shadows the outer for its subtree, so a `FormHelp`
- * above a nested provider stops tracking the `ModeSwitch` inside it. That is
- * why `ObjectForm`, which builds its own provider internally, currently has no
- * seam for this component (#2272).
+ * above a nested provider stops tracking the `ModeSwitch` inside it. Inside
+ * `ObjectForm`, which builds its own provider, use its `actions` snippet — it
+ * renders within that provider, so the glossary resolves. There is no header
+ * seam, so it lands below the fields (#2272).
  */
 import { getFieldPolicyContext } from '../context.svelte.js';
 

--- a/packages/fields/src/svelte/components/FormHelp.svelte
+++ b/packages/fields/src/svelte/components/FormHelp.svelte
@@ -20,10 +20,11 @@
  * To put form help in a page header, extend the SAME provider over the header —
  * it renders no markup of its own. Do not add a second one: each provider owns
  * its own mode store and shadows the outer for its subtree, so a `FormHelp`
- * above a nested provider stops tracking the `ModeSwitch` inside it. Inside
- * `ObjectForm`, which builds its own provider, use its `actions` snippet — it
- * renders within that provider, so the glossary resolves. There is no header
- * seam, so it lands below the fields (#2272).
+ * above a nested provider stops tracking the `ModeSwitch` inside it (#2272).
+ *
+ * Inside `ObjectForm`, which builds its own provider, use its `actions` snippet
+ * — it renders within that provider, so the glossary resolves. There is no
+ * header seam, so it lands below the fields; tracked in #2289.
  */
 import { getFieldPolicyContext } from '../context.svelte.js';
 

--- a/packages/fields/src/svelte/components/FormHelp.svelte
+++ b/packages/fields/src/svelte/components/FormHelp.svelte
@@ -9,7 +9,20 @@
  * plus the object description if provided. The data comes entirely from the
  * resolved policy — no separate fetch needed.
  *
- * Must be used inside a FieldPolicyProvider.
+ * Must be used inside a FieldPolicyProvider — deliberately, via the throwing
+ * accessor. The panel's payload IS the resolved glossary, so with no provider
+ * there is nothing to assemble and a `?` affordance that opens onto "No field
+ * help available." would hide the mistake instead of reporting it. This matches
+ * the other provider-only compositions (`ModeSwitch`, `AdvancedFields`);
+ * `PolicyField` degrades instead only because it has caller-owned children to
+ * render verbatim.
+ *
+ * To put form help in a page header, extend the SAME provider over the header —
+ * it renders no markup of its own. Do not add a second one: each provider owns
+ * its own mode store and shadows the outer for its subtree, so a `FormHelp`
+ * above a nested provider stops tracking the `ModeSwitch` inside it. That is
+ * why `ObjectForm`, which builds its own provider internally, currently has no
+ * seam for this component (#2272).
  */
 import { getFieldPolicyContext } from '../context.svelte.js';
 

--- a/packages/fields/src/svelte/context.svelte.ts
+++ b/packages/fields/src/svelte/context.svelte.ts
@@ -12,6 +12,21 @@
  * outside a Provider: an unwrapped field renders its children verbatim, and a
  * consumer can adopt the primitives incrementally without wrapping the whole
  * form.
+ *
+ * The two accessors are a deliberate two-tier contract, not a style choice:
+ *
+ * - `tryGetFieldPolicyContext` is for a primitive that still has something
+ *   meaningful to render without a policy — today only `PolicyField`, whose
+ *   fallback is the caller's own children.
+ * - `getFieldPolicyContext` is for the provider-only compositions
+ *   (`ModeSwitch`, `AdvancedFields`, `FormHelp`) whose entire output is derived
+ *   from the resolved policy. Degrading those would render an empty or absent
+ *   control rather than surface the missing Provider, so they throw with an
+ *   actionable message instead (#2272).
+ *
+ * One provider per form. `setContext` shadows, so a nested `FieldPolicyProvider`
+ * gives its subtree a second, independent `FieldPolicyModeStore` — consumers
+ * above the nested provider then stop tracking the `ModeSwitch` below it.
  */
 
 import { getContext, setContext } from 'svelte';

--- a/packages/fields/src/svelte/playground/FieldPolicyFormPreview.svelte
+++ b/packages/fields/src/svelte/playground/FieldPolicyFormPreview.svelte
@@ -97,19 +97,25 @@ function handleSubmit() {
 </script>
 
 <section class="field-policy-preview">
-  <header class="preview-header">
-    <h2>Hand-written form adopting PolicyField</h2>
-    <p class="preview-desc">
-      A developer-authored product form. Two fields (name, SKU) adopt
-      PolicyField for help, defaults, and progressive disclosure; the rest stay
-      hand-written. Toggle the mode switch to reveal advanced-tier fields.
-    </p>
-    <FormHelp
-      objectDescription="A sellable catalog product with wholesale pricing and inventory controls."
-    />
-  </header>
-
+  <!--
+    ONE provider, extended over the header too. FormHelp assembles its glossary
+    from the provider context and must live inside it; the provider renders no
+    markup of its own, so covering the header costs no layout. Do not add a
+    second provider to reach it — a nested one shadows this mode store — #2272.
+  -->
   <FieldPolicyProvider policy={resolvedPolicy} mode="basic">
+    <header class="preview-header">
+      <h2>Hand-written form adopting PolicyField</h2>
+      <p class="preview-desc">
+        A developer-authored product form. Two fields (name, SKU) adopt
+        PolicyField for help, defaults, and progressive disclosure; the rest stay
+        hand-written. Toggle the mode switch to reveal advanced-tier fields.
+      </p>
+      <FormHelp
+        objectDescription="A sellable catalog product with wholesale pricing and inventory controls."
+      />
+    </header>
+
     <div class="toolbar">
       <ModeSwitch />
     </div>


### PR DESCRIPTION
Closes #2272.

## What was broken

`@happyvertical/smrt-fields`' `Policy-Driven Form` playground preview threw on mount. `FieldPolicyFormPreview.svelte` rendered `<FormHelp>` in its `<header>`, above and outside the `<FieldPolicyProvider>` that publishes the context `FormHelp` requires. Registering the `./playground` module registers both of its entries, so the sibling `Generated ObjectForm` entry — which mounts fine — could not be shown without the broken one.

## The contract question, and the answer

#2272 offered two fixes: move `<FormHelp>` inside the provider, or switch `FormHelp` to the non-throwing `tryGetFieldPolicyContext()` and let it degrade. **This PR does the first and keeps `FormHelp` throwing**, deliberately.

The package already has a coherent two-tier context contract, and `FormHelp` is on the correct tier:

- `PolicyField` reads the context with `tryGetFieldPolicyContext()` because outside a provider it still has something real to render — the caller's own children, verbatim. That fallback is the documented incremental-adoption path.
- `ModeSwitch`, `AdvancedFields`, and `FormHelp` read it with the throwing `getFieldPolicyContext()`. Their entire output is derived from the resolved policy. `FormHelp` has no children to preserve: with no provider its glossary is empty, so it would render a `?` affordance that opens onto "No field help available." That is not graceful degradation — it is a broken control that no longer reports why.

Two further points settled it:

1. `FormHelp`'s dependency shape is identical to `ModeSwitch`'s and `AdvancedFields`'. Making one of the three non-throwing would fragment the contract for no gain.
2. The "form help in a page header" case the issue raises is not actually blocked. `FieldPolicyProvider` renders exactly `{@render children?.()}` and contributes no markup, so a host extends the *same* provider over the header — which is what this preview now does, and what the docs now show. The preview wanted a real glossary; degrading `FormHelp` would have left it mounting with an empty one, converting a loud bug into a silent one.

Review surfaced one genuine limit of that answer, and the docs now state it rather than paper over it: the workaround is "extend the one provider", not "add another". Each `FieldPolicyProvider` owns its own `FieldPolicyModeStore` and `setContext` shadows for its subtree, so nesting a second one desyncs an outer `FormHelp` from the inner `ModeSwitch`.

That matters most for `ObjectForm`, which builds its own provider. Review also corrected my first reading of it: `ObjectForm`'s `actions` snippet renders *inside* that provider (Svelte resolves context at the render site), so `FormHelp` placed there does work and emits a full glossary — verified empirically. The real gap is placement, not reachability: there is no header seam, so form-level help can only land below the fields. Filed as **#2289**, not fixed here.

## Changes

- `packages/fields/src/svelte/playground/FieldPolicyFormPreview.svelte` — the provider now wraps the header too. The rendered DOM under `<section>` is unchanged (the provider emits no markup), so layout and scoped styles are untouched.
- `packages/fields/src/svelte/__tests__/playground.test.ts` (new) — mounts every exported playground entry.
- `packages/fields/src/svelte/__tests__/FormHelp.test.ts` — pins the throwing contract with its actionable message.
- `packages/fields/src/svelte/components/FormHelp.svelte`, `context.svelte.ts` — document why the two accessors differ, so the next reader does not "fix" this by swapping the accessor.
- `packages/fields/AGENTS.md`, `docs/content/field-policies.md` — state the contract, the one-provider-per-form rule, and `ObjectForm`'s internal provider. `FormHelp` was previously absent from the public doc entirely; that gap is how the sharp edge shipped.

## The test that would have caught this

No test in the monorepo mounted a playground entry. `FormHelp`'s own tests all mount it through a provider fixture, so they exercise the component's contract, never the preview's composition — the bug was structurally invisible to them.

The new test loads and mounts every entry the way `PlaygroundHost` does: one case per entry and declared mode, with `entry.props` and mode props merged, and nothing wrapping the component. Reverting the preview fix turns it red with the original error.

## Siblings

I surveyed all 15 packages that export `./playground`. **No sibling is broken today**, but the coverage gap is monorepo-wide:

- Only `smrt-ui` shares the structural exposure — it is the other package with dedicated preview wrappers that compose throwing-context primitives (`AccordionItem` inside `Accordion`, `Radio` inside `RadioGroup`). Both are composed correctly right now; a one-line hoist reproduces #2272 exactly with nothing to catch it. Its existing `playground.test.ts` asserts metadata only and never mounts.
- The other 13 point `loadComponent` at real components that use no throwing accessor.
- No shared mount-all-previews helper exists anywhere.

The new test's loop is package-agnostic. Generalizing it into `@happyvertical/smrt-vitest` and adopting it across all 15 packages is filed as **#2285** rather than expanded into this PR. #2285 also carries the runtime complement review turned up: `PlaygroundHost` mounts `<PreviewComponent>` with no `<svelte:boundary>`, so a mount throw takes the host page rather than the one panel — which is why #2272 presented as a stuck spinner.

## Downstream

`s-m-r-t.dev` deliberately does not register this playground module because of #2272, carrying a `playgroundNote`, a `playgrounds.ts` comment, and an `AGENTS.md` entry that all point here. Re-registering once a release ships this fix is tracked as **happyvertical/s-m-r-t.dev#156**.

## Validation

- `pnpm --filter @happyvertical/smrt-fields test` — 17 files, 248 tests pass (was 244; +3 playground, +1 FormHelp contract)
- `pnpm --filter @happyvertical/smrt-fields typecheck` — clean
- `pnpm --filter @happyvertical/smrt-fields check` (svelte-check) — 1225 files, 0 errors, 0 warnings
- `turbo build --filter=@happyvertical/smrt-fields` — clean
- `pnpm knowledge:check` — fresh
- `pnpm check:agents-chain` — `packages/fields/AGENTS.md` well under the 32 KB cap
- `pnpm check:svelte-tokens`, `check:standards`, `check:package-dag`, `check:no-smrt-peers`, and the design-token checks — clean
- `biome check` on the touched TypeScript — clean

Pre-existing and unrelated: `node scripts/check-readmes.mjs` fails identically on a pristine `origin/main` tree (fields README missing from the root catalog, obsolete prose in `core`/`fields` READMEs). CI runs `check-standards.mjs` directly rather than the `check:standards` npm script, so that validator is not in the gate. Not touched here.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"claude-2272-fields-playground-fix3-20260810","issue":2272,"policy_revision":"1.0.0","policy_source_commit":"ca4562cb35081b537262974a56f6938141e745b0","validation":["fields package tests","svelte-check","typecheck","turbo build","knowledge freshness","agents-chain","repo standards and design-token checks","biome","lefthook pre-commit and pre-push","review-cycle"]}
```
