### PR TITLE
fix(docs): repair README catalog and branding, run check-readmes in CI

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -255,15 +255,46 @@ jobs:
       # Pin Node to the version declared in package.json engines so that
       # `import.meta.dirname` (Node 20.11+) and other modern features used by
       # scripts/check-standards.mjs are guaranteed available regardless of the
-      # ubuntu-latest default. Skip dep install — the script reads only
-      # package.json files and uses no node_modules.
+      # ubuntu-latest default. check-standards.mjs itself needs no dep install:
+      # it reads only package.json files and uses no node_modules.
       - name: Set up Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.18.0'
 
+      # Deliberately ordered before the install below, so a standards violation
+      # still fails in seconds instead of paying for dependency resolution.
       - name: Run standards check
         run: node scripts/check-standards.mjs
+
+      # #2287: the root `check:standards` script chains check-standards.mjs and
+      # check-readmes.mjs, but this job only ever invoked the first script
+      # directly. The README validator therefore never ran in CI, and main
+      # drifted into package-catalog and branding violations unnoticed.
+      #
+      # Unlike every other checker in this job, check-readmes.mjs is not
+      # dependency-free: it imports `typescript` to type-check the root README
+      # quick start against packages/core/src/index.ts, and
+      # scripts/workspaces.mjs shells out to pnpm to expand pnpm-workspace.yaml.
+      # Hence the pnpm setup and install below.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          run_install: false
+
+      # --ignore-scripts: the validator only needs modules resolvable on disk,
+      # never executed, and this job runs under pull_request_target — declining
+      # to run PR-head lifecycle scripts keeps a privileged-context install
+      # inert. Package linking, which is all the validator depends on, is
+      # unaffected.
+      # No registry auth: .npmrc points @happyvertical at public npmjs, and the
+      # lockfile carries no npm.pkg.github.com tarballs, so this install needs
+      # no token.
+      - name: Install dependencies for README validation
+        run: pnpm install --frozen-lockfile --ignore-scripts --loglevel error
+
+      - name: Run README validation
+        run: pnpm run check:readmes
 
       # DAG guardrails (#1582). Node-only, no node_modules: inter-smrt
       # peerDependencies drive pnpm's per-peer-set physical fan-out, and a

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Status legend:
 | [`smrt-secrets`](./packages/secrets/README.md) | Stable | Tenant envelope encryption, rotation, and audit. |
 | [`smrt-features`](./packages/features/README.md) | Preview | Code-first feature flags and tenant overrides. |
 | [`smrt-languages`](./packages/languages/README.md) | Preview | Language strings, overrides, and translation jobs. |
+| [`smrt-fields`](./packages/fields/README.md) | Preview | Layered field policy store, resolution engine, and form surfaces. |
 
 ### Web, mobile, and templates
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -119,7 +119,7 @@ src/routes/api/**/+server.ts
 !src/routes/api/v1/**/+server.ts
 ```
 
-Migration takes the recognized SMRT header plus the contiguous run of
+Migration takes that recognized legacy header plus the contiguous run of
 recursive `+server.ts` wildcards directly beneath it, negations included. The
 run is matched by shape rather than against your current `routesDir`, so a
 project that moved `routesDir` after adopting the plugin still migrates, and

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -148,6 +148,6 @@ for the capture, privacy, retention, and schedule contract.
 
 ## Example application
 
-The [SMRT SaaS starter field-policy walkthrough](https://github.com/happyvertical/smrt-saas-starter/pull/51)
-uses SMRT `0.40.61` and shows the owner/admin controls and the member-facing
+The [s-m-r-t SaaS starter field-policy walkthrough](https://github.com/happyvertical/smrt-saas-starter/pull/51)
+uses s-m-r-t `0.40.61` and shows the owner/admin controls and the member-facing
 personal form flow in a working application.


### PR DESCRIPTION
## Problem

`node scripts/check-readmes.mjs` failed on a pristine `origin/main` tree (`cf0adc244`) with three violations:

```
- root package catalog is missing ./packages/fields/README.md
- packages/core/README.md uses obsolete SMRT prose; write s-m-r-t
- packages/fields/README.md uses obsolete SMRT prose; write s-m-r-t
```

## Why it drifted

The README validator was effectively **not in CI**. The root npm script chains both checkers:

```
"check:standards": "node scripts/check-standards.mjs && node scripts/check-readmes.mjs"
```

but the `check-standards` job invoked the first script *directly* (`run: node scripts/check-standards.mjs`), so the `&& check-readmes.mjs` half never executed. Lefthook does not run it either — nothing had enforced catalog, local-link, branding, or quick-start invariants since the job started calling the script instead of the npm script.

## Changes

**1. The three violations**

- `README.md` — adds the `smrt-fields` catalog row, placed with its documented architecture family (`smrt-features` / `smrt-languages`) and `Preview` to match them.
- `packages/core/README.md` — "the recognized SMRT header" → "that recognized legacy header". It refers to the `LEGACY_GITIGNORE_HEADER` literal shown in the fence directly above, not to the brand.
- `packages/fields/README.md` — "SMRT SaaS starter" / "uses SMRT" → `s-m-r-t`, matching how the root README already writes that same link.

`hasObsoleteBrandName` bans a bare `SMRT` word in *prose* only; `markdownProse` strips fenced and inline code, so the gitignore sample and `` `0.40.61` `` were never the problem.

**2. CI wiring — yes, it should run**

Added to the `check-standards` job. Unlike every other checker there, `check-readmes.mjs` is **not dependency-free**: it imports `typescript` to type-check the root README quick start against `packages/core/src/index.ts`, and `scripts/workspaces.mjs` shells out to `pnpm` to expand `pnpm-workspace.yaml`. The job therefore gains pnpm setup plus an install.

Three deliberate choices:

- The existing install-free `check-standards.mjs` step stays **first**, so a standards violation still fails in seconds instead of paying for dependency resolution.
- The install uses `--ignore-scripts`. The validator only needs modules resolvable on disk, never executed, and this job runs under `pull_request_target` — declining to run PR-head lifecycle scripts keeps a privileged-context install inert. Package linking, all the validator depends on, is unaffected.
- No registry auth. `.npmrc` points `@happyvertical` at public npmjs and the lockfile carries no `npm.pkg.github.com` tarballs (verified `@happyvertical/sql@0.85.5` resolves unauthenticated), so no token is passed.

## Validation

- `node scripts/check-readmes.mjs` — passes (64 packages, catalog, links, branding, quick start).
- `node scripts/check-standards.mjs` — passes (63 packages, 0 violations).
- `node --test scripts/readme-system.test.mjs` — 14/14 pass.
- `yamllint` + `actionlint` on the workflow — clean. The one remaining yamllint long-line warning is pre-existing (`mode:`, line 428) and untouched.
- `pnpm knowledge:check --strict` — fresh, 0 errors / 0 warnings.
- Biome ignores the changed file types.

**The new CI steps were reproduced end-to-end locally**, because `pull_request_target` loads workflow YAML from the base branch — see the risk note below. In a clean detached worktree at this commit: `pnpm install --frozen-lockfile --ignore-scripts` followed by `pnpm run check:readmes` exits 0.

## Risk

This edits a `pull_request_target` workflow, so **these steps do not execute on this PR** — CI here runs `main`'s YAML. They first execute in the merge queue. That is why the steps were reproduced in a clean worktree rather than trusting a green check on this PR. The local reproduction used a warm pnpm store; CI has no cache configured on this job, so expect a cold install to add roughly a minute to a job that previously ran in seconds.

Closes #2287

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"182c2a83-c132-48c7-8b59-6448fa68a6a5","issue":2287,"policy_revision":"1.0.0","policy_source_commit":"ca4562cb35081b537262974a56f6938141e745b0","validation":["check-readmes","check-standards","readme-system node:test","yamllint","actionlint","knowledge freshness","clean-worktree CI reproduction"]}
```
