### PR TITLE
fix(core): reject WHERE conditions the SQL layer cannot execute

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -59,7 +59,20 @@ an `initialize()` hook may query through the same transaction-bound PostgreSQL
 client. Keep this serialization invariant; use `select` when callers need plain
 rows without model hydration.
 
-**WHERE operators**: `=`, `>`, `<`, `>=`, `<=`, `!=`, `in`, `not in`, `like`, `is null`, `is not null`. Arrays auto-detect `IN`. Dot notation for JSON paths: `metadata.userId`.
+**WHERE operators**: `=`, `>`, `<`, `>=`, `<=`, `!=`, `in`, `not in`, `like`.
+Arrays auto-detect `IN`. NULL is a value, not an operator: `{ deletedAt: null }`
+renders `IS NULL` and `{ 'deletedAt !=': null }` renders `IS NOT NULL`.
+
+This list is the set `@happyvertical/sql`'s `buildWhere` can execute, and
+`convertWhereKeys` accepts nothing outside it — an operator accepted here but
+unknown there fails inside the query builder, after the API said the query was
+valid (#2276). Two entries were removed for that reason and now reject at the
+API boundary: `contains` (never existed in the SQL layer; use `like` with
+explicit wildcards) and dot-notation JSON paths such as `metadata.userId` (never
+rewritten into an extraction expression, so they reached SQL as qualified column
+references). Re-adding either requires the query builder to support it first;
+`src/__tests__/issue-2276-where-contract.test.ts` executes every accepted
+operator against a database to keep the two in step.
 
 STI child collections auto-filter by `_meta_type`.
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -41,7 +41,7 @@ refreshes `last_used_at`. Keep semantic search behind the
 
 ```typescript
 await collection.list({
-  where: { status: 'active', price: { op: '>', value: 10 } },
+  where: { status: 'active', 'price >': 10 },
   limit: 50, offset: 0, orderBy: 'created_at DESC'
 });
 ```

--- a/packages/core/src/__tests__/issue-115-sql-injection-prevention.test.ts
+++ b/packages/core/src/__tests__/issue-115-sql-injection-prevention.test.ts
@@ -330,19 +330,29 @@ describe('Issue #115: SQL Injection Prevention', () => {
         'name.x)/**/=/**/1',
       ];
       for (const key of payloads) {
+        // Assert the identifier guard specifically. Dotted keys are also
+        // rejected as unsupported JSON paths since #2276, so matching the
+        // generic "Invalid WHERE clause field" prefix would pass even if this
+        // guard were removed.
         await expect(
           collection.list({ where: { [key]: 'value' } }),
-        ).rejects.toThrow(/Invalid WHERE clause field/);
+        ).rejects.toThrow(/Field names must be identifiers/);
       }
     });
 
-    it('should still accept a legitimate JSON-path key', async () => {
+    it('should not report a well-formed JSON-path key as malformed', async () => {
       // metadata isn't a declared column on this class, so it resolves to the
       // field-whitelist error — NOT the identifier-format error. The point is
-      // the strict guard does not reject well-formed dotted identifiers.
+      // the strict guard does not reject well-formed dotted identifiers on
+      // shape. (Dotted keys are separately rejected as unsupported JSON paths
+      // since #2276, but only once the base column is known to exist, so this
+      // key never reaches that check.)
       await expect(
         collection.list({ where: { 'metadata.userId': 'value' } }),
       ).rejects.toThrow(/Field does not exist/);
+      await expect(
+        collection.list({ where: { 'metadata.userId': 'value' } }),
+      ).rejects.not.toThrow(/Field names must be identifiers/);
     });
   });
 

--- a/packages/core/src/__tests__/issue-2276-where-contract.test.ts
+++ b/packages/core/src/__tests__/issue-2276-where-contract.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Issue #2276: WHERE validation accepted conditions the SQL layer cannot execute.
+ * https://github.com/happyvertical/smrt/issues/2276
+ *
+ * `convertWhereKeys` hands its output straight to `@happyvertical/sql`'s
+ * `buildWhere`, so the operators and field syntax it accepts are a promise about
+ * what that builder can execute. Two entries broke the promise:
+ *
+ * - `contains` was whitelisted but has never existed in `parseConditionKey`, so
+ *   `buildWhere` could not split it off the key and threw
+ *   `Invalid SQL identifier: name contains` — a query-builder error, naming
+ *   query-builder concepts, for a query this layer had just accepted.
+ * - Dot-notation JSON paths validated but were never rewritten into an
+ *   extraction expression, so `metadata.color` arrived as a qualified column
+ *   reference and SQLite answered `no such column`, surfaced as an opaque
+ *   `DatabaseError: Failed to execute raw query`.
+ *
+ * Both now fail at the API boundary with an actionable message. The load-bearing
+ * test in this file is "every accepted operator executes": it is what keeps the
+ * whitelist and the query builder from drifting apart again.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection';
+import { SmrtObject } from '../object';
+import { ObjectRegistry, smrt } from '../registry';
+
+@smrt({ api: { include: ['list', 'get'] } })
+class WhereContractItem extends SmrtObject {
+  name: string = '';
+  category: string = '';
+  priority: number = 0;
+  metadata: Record<string, any> = {};
+}
+
+class WhereContractItemCollection extends SmrtCollection<WhereContractItem> {
+  static readonly _itemClass = WhereContractItem;
+}
+
+/**
+ * Undecorated on purpose: with no `@smrt()` registration there are no manifest
+ * fields, so `convertWhereKeys` takes the `skipFieldValidation` branch (#869)
+ * and cannot check any column name. Used to pin what the JSON-path rejection
+ * does when nothing knows which columns are real.
+ */
+class UnregisteredItem extends SmrtObject {
+  name: string = '';
+}
+
+class UnregisteredItemCollection extends SmrtCollection<UnregisteredItem> {
+  static readonly _itemClass = UnregisteredItem;
+}
+
+/**
+ * Every operator the validator accepts, with a value and the ids it must match
+ * against the fixture rows below. Adding an operator to `VALID_OPERATORS`
+ * without adding it here leaves it unexercised; adding it here without the SQL
+ * layer supporting it fails this suite.
+ */
+const ACCEPTED_OPERATORS: Array<{
+  where: Record<string, unknown>;
+  expected: string[];
+}> = [
+  { where: { category: 'A' }, expected: ['alpha'] },
+  { where: { 'category =': 'A' }, expected: ['alpha'] },
+  { where: { 'category !=': 'A' }, expected: ['beta', 'gamma'] },
+  { where: { 'priority >': 2 }, expected: ['gamma'] },
+  { where: { 'priority <': 2 }, expected: ['alpha'] },
+  { where: { 'priority >=': 2 }, expected: ['beta', 'gamma'] },
+  { where: { 'priority <=': 2 }, expected: ['alpha', 'beta'] },
+  { where: { 'category in': ['A', 'B'] }, expected: ['alpha', 'beta'] },
+  { where: { 'category not in': ['A', 'B'] }, expected: ['gamma'] },
+  { where: { 'name like': 'Al%' }, expected: ['alpha'] },
+  // Arrays without an explicit operator auto-detect IN.
+  { where: { category: ['A', 'C'] }, expected: ['alpha', 'gamma'] },
+];
+
+describe('Issue #2276: WHERE contract matches what the SQL layer executes', () => {
+  ObjectRegistry.registerCollection(
+    'WhereContractItem',
+    WhereContractItemCollection,
+  );
+
+  let collection: WhereContractItemCollection;
+
+  beforeAll(async () => {
+    collection = await WhereContractItemCollection.create({
+      db: { type: 'sqlite', url: ':memory:' },
+    });
+
+    await collection.create({
+      name: 'Alpha',
+      category: 'A',
+      priority: 1,
+      metadata: { color: 'red', count: 10 },
+    });
+    await collection.create({
+      name: 'Beta',
+      category: 'B',
+      priority: 2,
+      metadata: { color: 'blue', count: 20 },
+    });
+    await collection.create({
+      name: 'Gamma',
+      category: 'C',
+      priority: 3,
+      metadata: { color: 'red', count: 30 },
+    });
+  });
+
+  afterAll(async () => {
+    await collection.db?.close?.();
+  });
+
+  describe('every accepted operator executes', () => {
+    // This is the regression guard for the whole issue. Validation passing is
+    // not evidence an operator works; only reaching the database is.
+    it.each(ACCEPTED_OPERATORS)('executes $where end-to-end', async ({
+      where,
+      expected,
+    }) => {
+      const results = await collection.list({ where });
+      expect(results.map((r: any) => r.name.toLowerCase()).sort()).toEqual(
+        [...expected].sort(),
+      );
+    });
+
+    it('treats NULL as a value, not an operator', async () => {
+      // The query builder turns a null value into `IS NULL` for `=` and
+      // `IS NOT NULL` for anything else, so `is null` is not — and must not
+      // become — a whitelist entry. AGENTS.md documents it this way; this is
+      // what holds that documentation to the code.
+      expect(await collection.list({ where: { name: null } })).toHaveLength(0);
+      expect(
+        await collection.list({ where: { 'name !=': null } }),
+      ).toHaveLength(3);
+      await expect(
+        collection.list({ where: { 'name is null': true } }),
+      ).rejects.toThrow('Invalid WHERE clause operator');
+    });
+  });
+
+  describe("the 'contains' operator is rejected at the API boundary", () => {
+    it('rejects contains instead of failing inside the query builder', async () => {
+      await expect(
+        collection.list({ where: { 'name contains': 'lph' } }),
+      ).rejects.toThrow('Invalid WHERE clause operator');
+    });
+
+    it('never surfaces the query builder error it used to produce', async () => {
+      // The bug's signature: an internal `Invalid SQL identifier: name contains`
+      // raised by buildWhere after this layer had approved the query.
+      await expect(
+        collection.list({ where: { 'name contains': 'lph' } }),
+      ).rejects.not.toThrow(/Invalid SQL identifier/);
+    });
+
+    it('names the operator and points at the supported alternative', async () => {
+      await expect(
+        collection.list({ where: { 'name contains': 'lph' } }),
+      ).rejects.toThrow(/'contains'[\s\S]*'like' with explicit wildcards/);
+    });
+
+    it('no longer advertises contains in the valid-operator list', async () => {
+      await expect(
+        collection.list({ where: { 'name bogus': 'x' } }),
+      ).rejects.toThrow(
+        /Valid operators: =, >, <, >=, <=, !=, in, not in, like$/,
+      );
+    });
+
+    it('still rejects other unknown operators without a hint', async () => {
+      await expect(
+        collection.list({ where: { 'priority between': [1, 10] } }),
+      ).rejects.toThrow('Invalid WHERE clause operator');
+    });
+
+    it('does not splice a prototype member into the hint', async () => {
+      // The hint lookup key is caller-supplied. Held in a plain object it would
+      // resolve `toString`/`constructor` through Object.prototype and append a
+      // function body to the error message.
+      for (const operator of ['toString', 'constructor', 'hasOwnProperty']) {
+        await expect(
+          collection.list({ where: { [`name ${operator}`]: 'x' } }),
+        ).rejects.toThrow(
+          /Valid operators: =, >, <, >=, <=, !=, in, not in, like$/,
+        );
+      }
+    });
+  });
+
+  describe('dot-notation JSON paths are rejected at the API boundary', () => {
+    it('rejects a JSON path instead of failing at execution', async () => {
+      await expect(
+        collection.list({ where: { 'metadata.color': 'red' } }),
+      ).rejects.toThrow('Dot-notation JSON paths are not supported');
+    });
+
+    it('never surfaces the opaque database error it used to produce', async () => {
+      await expect(
+        collection.list({ where: { 'metadata.color': 'red' } }),
+      ).rejects.not.toThrow(/Failed to execute raw query/);
+    });
+
+    it('names the offending key and the column to filter instead', async () => {
+      await expect(
+        collection.list({ where: { 'metadata.color': 'red' } }),
+      ).rejects.toThrow(/'metadata\.color'[\s\S]*'metadata' column/);
+    });
+
+    it('rejects a JSON path carrying an operator', async () => {
+      await expect(
+        collection.list({ where: { 'metadata.count >': 5 } }),
+      ).rejects.toThrow('Dot-notation JSON paths are not supported');
+    });
+
+    it('rejects a nested JSON path', async () => {
+      await expect(
+        collection.list({ where: { 'metadata.nested.deep': 'x' } }),
+      ).rejects.toThrow('Dot-notation JSON paths are not supported');
+    });
+
+    it('leaves the plain column filter working', async () => {
+      // The rejection is scoped to the path suffix; the column itself is
+      // unaffected, which is what the error message tells callers to fall back to.
+      const results = await collection.list({
+        where: { metadata: JSON.stringify({ color: 'red', count: 10 }) },
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('Alpha');
+    });
+  });
+
+  describe('every more specific guard reports before the JSON-path rejection', () => {
+    // The JSON-path message ends in advice — "filter on the '<column>' column
+    // itself". That advice is only true for a key whose sole problem is the
+    // path suffix, so every guard that describes a different problem with the
+    // same key has to answer first.
+
+    it('reports an injection payload as an invalid identifier, not a JSON path', async () => {
+      // #1379: the identifier allowlist still catches a crafted path suffix.
+      await expect(
+        collection.list({
+          where: {
+            'metadata.x))/**/UNION/**/SELECT/**/secret/**/FROM/**/users--': 1,
+          },
+        }),
+      ).rejects.toThrow('Field names must be identifiers');
+    });
+
+    it('reports a prototype-pollution key as such, not as a JSON path', async () => {
+      await expect(
+        collection.list({ where: { 'constructor.prototype.isAdmin': true } }),
+      ).rejects.toThrow('Prototype pollution attempts are not allowed');
+    });
+
+    it('reports an unknown base column as unknown, not as a JSON path', async () => {
+      // Without this ordering a typo'd key is answered with advice to filter on
+      // a column that does not exist — the message would assert something false
+      // about the schema.
+      await expect(
+        collection.list({ where: { 'noSuchColumn.path': 'value' } }),
+      ).rejects.toThrow(/Field does not exist/);
+      await expect(
+        collection.list({ where: { 'noSuchColumn.path': 'value' } }),
+      ).rejects.not.toThrow(/Dot-notation JSON paths/);
+    });
+
+    it('reports an invalid operator on a JSON path as an operator problem', async () => {
+      await expect(
+        collection.list({ where: { 'metadata.color contains': 'red' } }),
+      ).rejects.toThrow('Invalid WHERE clause operator');
+    });
+
+    it('still rejects the path when no manifest exists to check the column against', async () => {
+      // #869: a class with no registered fields skips column checking entirely,
+      // so the JSON-path message here names a column nobody verified. That is
+      // the documented limit of that mode, not a hole in this rejection — the
+      // key is still refused, which is what keeps it out of the query builder.
+      const unregistered = await UnregisteredItemCollection.create({
+        db: { type: 'sqlite', url: ':memory:' },
+      });
+      try {
+        // No manifest means no generated schema either, so give `list()` a
+        // table to reach — otherwise it fails on the missing table before the
+        // WHERE validation this test is about ever runs.
+        await unregistered.db?.query(
+          'CREATE TABLE IF NOT EXISTS unregistered_items (id TEXT PRIMARY KEY, name TEXT)',
+        );
+        await expect(
+          unregistered.list({ where: { 'anythingAtAll.path': 'x' } }),
+        ).rejects.toThrow('Dot-notation JSON paths are not supported');
+      } finally {
+        await unregistered.db?.close?.();
+      }
+    });
+  });
+});

--- a/packages/core/src/__tests__/issue-792-complex-where.test.ts
+++ b/packages/core/src/__tests__/issue-792-complex-where.test.ts
@@ -3,9 +3,14 @@
  * https://github.com/happyvertical/smrt/issues/792
  *
  * Tests for:
- * - 'not in' operator validation (SMRT-side; SQL execution depends on SDK)
- * - 'contains' operator validation (SMRT-side; SQL execution depends on SDK)
- * - Dot-notation field name validation for JSON path queries
+ * - 'not in' operator validation
+ * - Dot-notation field name handling for JSON path queries
+ *
+ * The 'contains' operator and dot-notation JSON paths were removed from the
+ * accepted surface in #2276: both passed validation here and then failed inside
+ * the query builder, because neither was ever implemented downstream. Their
+ * rejection is covered by `issue-2276-where-contract.test.ts`; this file keeps
+ * the parts of #792 that do execute.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -62,31 +67,23 @@ describe('Issue #792: Complex WHERE clause support', () => {
   });
 
   describe('not in operator', () => {
-    it('should pass validation for not in operator', async () => {
-      // 'not in' passes SMRT-side validation. SQL execution depends on SDK.
-      try {
-        const results = await collection.list({
-          where: { 'category not in': ['A', 'B'] },
-        });
-        // If SDK supports NOT IN, verify results
-        expect(results).toHaveLength(1);
-        expect(results[0].name).toBe('Gamma');
-      } catch (e: any) {
-        // SQL-level error is acceptable; validation error is not
-        expect(e.message).not.toContain('Invalid WHERE clause operator');
-      }
+    it('should execute not in against the database', async () => {
+      // Asserted end-to-end rather than "validation did not throw": #2276 was
+      // exactly a condition that passed validation and then failed to execute,
+      // so a swallowed SQL error is not evidence the operator works.
+      const results = await collection.list({
+        where: { 'category not in': ['A', 'B'] },
+      });
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('Gamma');
     });
 
-    it('should pass validation for not in with single value array', async () => {
-      try {
-        const results = await collection.list({
-          where: { 'status not in': ['archived'] },
-        });
-        expect(results).toHaveLength(2);
-        expect(results.every((r: any) => r.status === 'active')).toBe(true);
-      } catch (e: any) {
-        expect(e.message).not.toContain('Invalid WHERE clause operator');
-      }
+    it('should execute not in with a single value array', async () => {
+      const results = await collection.list({
+        where: { 'status not in': ['archived'] },
+      });
+      expect(results).toHaveLength(2);
+      expect(results.every((r: any) => r.status === 'active')).toBe(true);
     });
 
     it('should reject not in with non-array value', async () => {
@@ -102,49 +99,38 @@ describe('Issue #792: Complex WHERE clause support', () => {
     });
   });
 
-  describe('dot-notation field name validation', () => {
-    it('should pass validation for dot-notation on existing JSON column', async () => {
-      // The field 'metadata' exists on the model, so 'metadata.userId' should
-      // pass SMRT-side validation (validates 'metadata' base column exists).
-      // The actual JSON extraction SQL depends on SDK adapter support.
-      // Here we verify the validation doesn't throw an "Invalid WHERE clause field" error.
-      try {
-        await collection.list({ where: { 'metadata.userId': 'user-1' } });
-      } catch (e: any) {
-        // If it fails, it should be a SQL-level error, not a validation error
-        expect(e.message).not.toContain('Field does not exist');
-      }
+  describe('dot-notation field names', () => {
+    // #792 accepted these at validation on the assumption the SDK would extract
+    // the JSON path. It never did, so #2276 moved the rejection here, where the
+    // caller can act on it. Message-level assertions live in
+    // `issue-2276-where-contract.test.ts`.
+    it('should reject dot-notation on an existing JSON column', async () => {
+      await expect(
+        collection.list({ where: { 'metadata.userId': 'user-1' } }),
+      ).rejects.toThrow('Dot-notation JSON paths are not supported');
     });
 
     it('should reject dot-notation for non-existent base fields', async () => {
-      // For classes with registered fields (manifest), this throws a validation error.
-      // For inline test classes (no manifest, issue #869), field validation is skipped
-      // and the error comes from the SQL layer instead.
+      // The unknown column is the more specific problem, so it wins over the
+      // JSON-path rejection — otherwise a typo'd key would be answered with
+      // advice to filter on a column that does not exist.
       await expect(
         collection.list({ where: { 'nonExistentField.path': 'value' } }),
-      ).rejects.toThrow();
+      ).rejects.toThrow(/Field does not exist/);
     });
 
-    it('should pass validation for dot-notation with operators', async () => {
-      try {
-        await collection.list({ where: { 'metadata.count >': 5 } });
-      } catch (e: any) {
-        // SQL-level error is OK; validation error is not
-        expect(e.message).not.toContain('Field does not exist');
-        expect(e.message).not.toContain('Invalid WHERE clause operator');
-      }
+    it('should reject dot-notation carrying an operator', async () => {
+      await expect(
+        collection.list({ where: { 'metadata.count >': 5 } }),
+      ).rejects.toThrow('Dot-notation JSON paths are not supported');
     });
   });
 
   describe('operator validation', () => {
-    it('should accept contains operator at validation level', async () => {
-      // 'contains' is accepted by validation. SQL execution depends on SDK.
-      try {
-        await collection.list({ where: { 'metadata contains': 'userId' } });
-      } catch (e: any) {
-        // SQL-level error is fine, but it should NOT be a validation error
-        expect(e.message).not.toContain('Invalid WHERE clause operator');
-      }
+    it('should reject the contains operator', async () => {
+      await expect(
+        collection.list({ where: { 'metadata contains': 'userId' } }),
+      ).rejects.toThrow('Invalid WHERE clause operator');
     });
 
     it('should still reject invalid operators', async () => {
@@ -153,12 +139,13 @@ describe('Issue #792: Complex WHERE clause support', () => {
       ).rejects.toThrow('Invalid WHERE clause operator');
     });
 
-    it('should list new operators in error message', async () => {
+    it('should list the executable operators in the error message', async () => {
       try {
         await collection.list({ where: { 'name invalid': 'x' } });
+        expect.unreachable('invalid operator should have thrown');
       } catch (e: any) {
         expect(e.message).toContain('not in');
-        expect(e.message).toContain('contains');
+        expect(e.message).not.toContain('contains');
       }
     });
   });

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -348,7 +348,19 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
   private convertWhereKeys(
     where: Record<string, unknown>,
   ): Record<string, unknown> {
-    // Whitelist of allowed SQL operators
+    // Whitelist of allowed SQL operators.
+    //
+    // This list is a contract, not a wish list (#2276): every entry must be an
+    // operator `@happyvertical/sql`'s `parseConditionKey` recognises, because a
+    // key this method accepts is passed straight to `buildWhere`. An operator
+    // accepted here but unknown there is not "unimplemented" — `buildWhere`
+    // fails to split it off the key, tries to read `"<field> <operator>"` as one
+    // identifier, and throws `Invalid SQL identifier` from inside the query
+    // builder. The caller gets a SQL-layer error naming SQL-layer concepts for a
+    // query the API told them was valid. Keep this list in lockstep with
+    // `VALID_OPERATORS` in `@happyvertical/sql`'s `shared/utils.ts`; the
+    // "executes every accepted operator" test in
+    // `src/__tests__/issue-2276-where-contract.test.ts` is what enforces it.
     const VALID_OPERATORS = [
       '=',
       '>',
@@ -359,8 +371,29 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       'in',
       'not in',
       'like',
-      'contains',
     ];
+
+    // Operators callers reach for that this layer cannot honour, mapped to the
+    // supported way to express the same intent. Being listed here only improves
+    // the rejection message — these are rejected exactly like any other unknown
+    // operator. A Map, not an object literal, because the lookup key is
+    // caller-supplied: `{ 'name toString': 'x' }` would otherwise find
+    // `Object.prototype.toString` and splice a function into the error text.
+    const UNSUPPORTED_OPERATOR_HINTS = new Map<string, string>([
+      // `contains` shipped in this whitelist but never existed in the SQL layer,
+      // so it has always failed at execution (#2276). It is not re-implemented
+      // here as `like '%value%'` because that would be a different operator
+      // wearing its name: `%` and `_` in the value would silently become
+      // wildcards (escaping them needs a `LIKE ... ESCAPE` clause `buildWhere`
+      // cannot emit), and `LIKE` is case-insensitive on SQLite but
+      // case-sensitive on PostgreSQL, so the same call would mean two things.
+      // Restoring it belongs in the SQL layer, where the dialect is known —
+      // tracked in happyvertical/sdk#1192.
+      [
+        'contains',
+        "Use 'like' with explicit wildcards instead, e.g. { 'name like': '%term%' }.",
+      ],
+    ]);
 
     // Get schema fields for validation (sync from cache)
     const fields = this.getFieldsSync();
@@ -480,8 +513,12 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
         );
       }
 
-      // Support dot-notation for JSON path queries (e.g., 'metadata.userId')
-      // Validate against the first segment (the column name), pass full path through
+      // Split a dot-notation JSON path (e.g. 'metadata.userId') into its base
+      // column and path suffix. The suffix is rejected further down (#2276), but
+      // it is parsed and reassembled first so the guards between here and there
+      // — the #1379 identifier check, the #1540 sensitive-`@meta`-path check,
+      // and the schema field whitelist — still see the whole key rather than a
+      // truncated column name.
       const dotIndex = fieldName.indexOf('.');
       const baseFieldName =
         dotIndex >= 0 ? fieldName.substring(0, dotIndex) : fieldName;
@@ -561,9 +598,11 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
 
       // Validate operator
       if (!VALID_OPERATORS.includes(effectiveOperator)) {
+        const hint = UNSUPPORTED_OPERATOR_HINTS.get(effectiveOperator);
         throw new Error(
           `Invalid WHERE clause operator: '${operator}'. ` +
-            `Valid operators: ${VALID_OPERATORS.join(', ')}`,
+            `Valid operators: ${VALID_OPERATORS.join(', ')}` +
+            (hint ? `. ${hint}` : ''),
         );
       }
 
@@ -574,6 +613,45 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
           `Invalid WHERE clause field: '${fieldName}'. ` +
             `Field does not exist on ${itemClassName}. ` +
             `Valid fields: ${Array.from(validFieldNames).sort().join(', ')}`,
+        );
+      }
+
+      // Reject dot-notation JSON paths (#2276).
+      //
+      // These validated but were never rewritten into a JSON extraction
+      // expression, so `metadata.color` reached SQL verbatim, where it reads as
+      // the qualified column reference `metadata.color` — a column `color` on a
+      // table `metadata`. SQLite answers `no such column`, surfaced to the
+      // caller as an opaque `DatabaseError: Failed to execute raw query` for a
+      // query this method had just accepted.
+      //
+      // Rewriting them here would mean emitting dialect-specific extraction
+      // (`json_extract(col, '$.path')` on SQLite, `col->>'path'` on
+      // PostgreSQL/DuckDB) and resolving the comparison typing that differs
+      // between them — `->>` yields text, so `metadata.count > 5` would compare
+      // a string against a number on PostgreSQL while working on SQLite. That is
+      // a feature with its own semantics to settle, not a repair of this
+      // validator, so this rejects until it exists — tracked in #2282.
+      //
+      // Placed last among the field checks on purpose. Every guard above
+      // describes a different problem with the same key, and each one's message
+      // is more specific than this one: a sensitive `_meta_data.<prop>` path
+      // must still report that it was rejected for being sensitive (#1540), and
+      // a typo'd base column must still report that the column does not exist
+      // rather than being told to "filter on the '<typo>' column itself". By
+      // running here, the advice this message gives is only ever offered for a
+      // column that actually exists — except under `skipFieldValidation`, where
+      // the class has no registered fields and nothing knows which columns are
+      // real (#869). There the base column named below is only the caller's own
+      // word for it, exactly as it is for every other key on such a class.
+      if (jsonPath) {
+        throw new Error(
+          `Invalid WHERE clause field: '${fieldName}'. ` +
+            `Dot-notation JSON paths are not supported — the path is not ` +
+            `rewritten into a JSON extraction expression, so it would reach SQL ` +
+            `as a qualified column reference and fail at execution. ` +
+            `Filter on the '${baseFieldName}' column itself, or filter the ` +
+            `extracted values in application code.`,
         );
       }
 

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -77,8 +77,14 @@ export interface FieldOptions {
    * For regular (column-backed) fields the index is a plain column index.
    * For `@meta()` fields stored inside `_meta_data` JSONB, the index targets
    * the JSON path — `json_extract(_meta_data, '$.fieldName')` on SQLite,
-   * `(_meta_data->>'fieldName')` on Postgres — giving WHERE clauses on that
-   * meta key the same performance as a real column.
+   * `(_meta_data->>'fieldName')` on Postgres.
+   *
+   * Note that `collection.list({ where })` cannot currently reach a JSON-path
+   * index: dot-notation keys such as `_meta_data.fieldName` are rejected,
+   * because nothing rewrites them into the matching extraction expression
+   * (#2276, tracked in #2282). The index is still emitted and still serves
+   * hand-written SQL that spells the expression out; it just has no
+   * collection-level query to accelerate yet.
    */
   indexed?: boolean;
   /** Whether the field is nullable */


### PR DESCRIPTION
Closes #2276.

`SmrtCollection.convertWhereKeys` hands its output straight to `@happyvertical/sql`'s `buildWhere`, so the operators and field syntax it accepts are a promise about what that builder can execute. Two entries broke the promise, and both failure modes were reproduced against the pinned `@happyvertical/sql@0.85.5` before touching anything:

```
list({ where: { 'name contains': 'lph' } })
  → Error: Invalid SQL identifier: name contains. Condition keys must be plain
    identifiers; wrap developer-authored SQL expressions in raw().

list({ where: { 'metadata.color': 'red' } })
  → DatabaseError: Failed to execute raw query     (SQLite: no such column: metadata.color)
```

Neither is an error the caller can act on. The first is the query builder's internal identifier check, naming query-builder concepts, raised for a query the API had just approved. The second is opaque — nothing in it says "JSON paths do not work here".

## Direction: reject at the API boundary, implement in the layer that can

Both are now rejected by `convertWhereKeys` with a message that names what failed and what to use instead. Neither was implemented here, and the reasons are recorded in the code:

**`contains`** was whitelisted but has never existed in `parseConditionKey`, so it has always failed at execution. It is not re-implemented as `like '%value%'`, because that would be a different operator wearing its name:

- `%` and `_` in the value would silently become wildcards. Escaping them needs a `LIKE … ESCAPE` clause that `buildWhere` has no way to emit.
- `LIKE` is case-insensitive on SQLite and case-sensitive on PostgreSQL, so the same call would mean two different things depending on the adapter.

Both are decidable in the SQL layer, where the dialect is known, and not decidable here. Filed as happyvertical/sdk#1192, which also raises the unsettled semantics question — the original test for it read `{ 'metadata contains': 'userId' }`, i.e. JSON containment, which is a third operator again.

**Dot-notation JSON paths** validated but were never rewritten into an extraction expression. Implementing them means emitting `json_extract(col, '$.path')` on SQLite versus `col->>'path'` on PostgreSQL/DuckDB *and* settling comparison typing, which differs between them: `->>` yields text, so `{ 'metadata.count >': 5 }` would compare a string against a number on PostgreSQL while working on SQLite. That is a feature with semantics to decide, not a repair of this validator. Split out as #2282, which notes the existing `renderIndexTarget` machinery to reuse and that `@meta({ indexed: true })` already builds JSON-path indexes with no query able to reach them.

## Changes

- `packages/core/src/collection.ts` — drop `contains` from `VALID_OPERATORS`; reject dot-notation JSON paths; add an operator-specific hint so `contains` points at `like` rather than only listing valid operators. The whitelist now carries a comment stating it is a contract with `buildWhere`, not a wish list.
- Guard ordering is load-bearing and documented in place. The JSON-path rejection runs **last** among the field checks, because its message ends in advice — "filter on the `'<column>'` column itself" — and every guard above it describes a different problem with the same key: a sensitive `_meta_data.<prop>` path must still report that it was rejected for being sensitive (#1540), an injection payload must still hit the identifier allowlist (#1379), and a typo'd base column must still report that the column does not exist rather than being told to filter on it. Running last means the advice is only ever offered for a column that actually exists.
- `packages/core/src/decorators/index.ts` — the `indexed` JSDoc claimed a JSON-path index gives "WHERE clauses on that meta key the same performance as a real column". No `list({ where })` call can reach that index, before or after this change. Corrected, with the gap pointed at #2282.
- `packages/core/src/__tests__/issue-2276-where-contract.test.ts` — new, 29 tests.
- `packages/core/AGENTS.md` — corrected the WHERE-operator line. It listed `is null` / `is not null` as operators (they are not — NULL is a value: `{ deletedAt: null }` renders `IS NULL`, `{ 'deletedAt !=': null }` renders `IS NOT NULL`) and advertised dot notation as supported.

## Test coverage

The load-bearing test is **"every accepted operator executes"**: a table of every operator in `VALID_OPERATORS` run end-to-end against SQLite and asserted on results. Validation passing is not evidence an operator works, and that gap is the whole issue — this is what stops the whitelist and the query builder drifting apart again. Adding an operator to the whitelist without adding it to the table leaves it unexercised; adding it to the table without SQL-layer support fails the suite.

Alongside it: both rejections assert the *old* error can no longer surface (`rejects.not.toThrow(/Invalid SQL identifier/)`, `rejects.not.toThrow(/Failed to execute raw query/)`), the messages name the operator/key and the alternative, and a dedicated block pins the guard ordering above — including the `skipFieldValidation` (#869) case, where no manifest exists to check the column against and the key is still refused.

**Verified failing before the fix**: 11 of the new tests fail against unmodified `collection.ts`, covering both reported cases.

Two existing suites were tightened rather than just updated:

- `issue-792-complex-where.test.ts` asserted `contains` and dot notation "pass validation" inside `try/catch` blocks that swallowed the SQL error. That pattern is how #2276 stayed hidden; the `not in` tests there now assert results end-to-end.
- `issue-115-sql-injection-prevention.test.ts` matched the generic `Invalid WHERE clause field` prefix, which would now pass even if the `#1379` identifier guard were deleted. It asserts the identifier message specifically, plus that a well-formed dotted key is never reported as malformed — keeping shape and support distinguishable.

## Drive-by fixes

- `packages/core/AGENTS.md` — the `SmrtCollection Query` example documented `where: { price: { op: '>', value: 10 } }`, which no code path supports: `convertWhereKeys` reads the key as a plain `=` condition and binds the object as the parameter, so the call throws `Failed to execute raw query` (verified against SQLite). One line, replaced with the operator-suffix form the validator accepts. Same defect class as this issue, in the same doc section. Own commit.

## Out of scope, filed separately

**#2283 — OR is unreachable through `list()`.** `buildWhere` accepts a 2D array (inner ANDed, outer ORed) and documents it, but `convertWhereKeys` iterates `Object.entries`, so array indices arrive as keys `'0'`, `'1'` and fail the identifier check:

```
list({ where: [[{ name: 'Alpha' }], [{ name: 'Beta' }]] })
  → Invalid WHERE clause field: '0'. Field names must be identifiers …
```

Not folded in, and not a one-liner: `convertWhereKeys` is the security boundary for the generated REST/MCP `where` surfaces (prototype-pollution rejection, the `#1379` identifier allowlist, the `#1540` sensitive-column ban, the schema whitelist, operator/value-type checks). Recursing into a 2D array means all of those must hold at every depth for input arriving from HTTP query strings, and it changes the public `where` type. Design change with a security review attached, so it stays its own issue.

**#2292 — the `Field does not exist` message enumerates sensitive column names.** Pre-existing and unrelated to this change, surfaced during review: `validFieldNames` is built from unfiltered `Object.keys(fields)`, so the error lists `@field({ sensitive: true })` columns by name. #1540 closed the value oracle; the names still leak.

## Compatibility

Neither rejected form has ever executed, so no working call can break. Repo-wide grep found no non-test caller of either — the generated REST `field[op]` parser and `smrt-web`'s `SMRT_TO_REST_OPERATOR` map never included `contains`. The change converts two runtime failures into API-boundary errors.

## Validation

- `pnpm test` in `packages/core` — 260 files passed, 5 skipped
- root `pnpm test` — 123/123 turbo tasks successful across the monorepo
- root `pnpm build` — 62/62 tasks
- `turbo typecheck --filter=@happyvertical/smrt-core` — 7/7 tasks
- `pnpm knowledge:check --changed --strict` — fresh, 0 errors
- `node scripts/check-agents-chain.mjs` — 66 chains under limit
- `node scripts/check-audit-policy.mjs` — clean
- biome formatting applied to all touched files

## Cross-repo

- happyvertical/sdk#1192 — implement `contains` in `buildWhere` (blocks restoring the operator)
- #2282 — JSON-path WHERE extraction
- #2283 — OR through `list()`
- #2292 — sensitive column names in the field-list error
- happyvertical/s-m-r-t.dev#157 — the site's `/reference/collections` documents both as unavailable, but describes them as failing at query time. Both now fail at the call, and its "confirm the behavior on your adapter" note for dot notation no longer applies.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"smrt-2276-where-validation-rebase","issue":2276,"policy_revision":"1.0.0","policy_source_commit":"ca4562cb35081b537262974a56f6938141e745b0","validation":["packages/core vitest (260 files)","root pnpm test (123/123 turbo tasks)","root pnpm build (62/62)","turbo typecheck --filter=@happyvertical/smrt-core","pnpm knowledge:check --changed --strict","check-agents-chain","check-audit-policy","biome check","review-cycle (3 reviewers, 2 rounds)","rebase onto v0.40.62 base + full reinstall/rebuild"]}
```

