### PR TITLE
fix(core,cli): make generate-mcp output runnable and stop swallowing --version

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -18,7 +18,9 @@ smrt dev:knowledge-*         # Deterministic agent knowledge index/check/diff
 smrt knowledge:review-context --scope package --package <name>
 smrt knowledge:architecture-context --scope project|local|package|sdk
 smrt dev:knowledge-check --format markdown|json
-smrt generate:mcp            # Generate MCP server
+smrt generate-mcp            # Generate MCP server (aliases: generate-mcp-server, mcp)
+smrt generate-types          # Generate TypeScript declarations (alias: generate-declarations)
+smrt generate-routes         # Generate SvelteKit API routes (aliases: routes, generate:routes)
 smrt config:export           # Export agent config for SSG
 smrt init                    # Init new project
 smrt gnode                   # Scaffold gnode site
@@ -50,4 +52,13 @@ migrations are manifest-driven through registered objects and project manifests.
 
 - **Test mode detection**: checks `NODE_ENV=test`, `VITEST=true`, `global.it`/`describe` — could conflict with other test runners
 - **External package load failures silenced**: one package failing doesn't prevent others from loading
+- **Generation command names are hyphenated**: `generate-mcp` and `generate-types` have
+  no colon alias. Only `generate-routes` and `generate-register` declare one, so
+  `smrt generate:mcp` is an unknown command (#2279).
+- **Subcommand `--version` beats the global flag**: `parseCliArgs` in
+  `@happyvertical/utils` dispatches to the built-in `version` command for a
+  `--version` token anywhere in argv. `parseCliCommandArgs` rescopes that token to
+  the named subcommand (`smrt generate-mcp --version 0.1.0`) and only leaves it
+  global when it appears before or without a subcommand (#2279). `--help` is
+  deliberately untouched.
 - **Schema history nuance**: `db:status` / `db:history` should distinguish active live drift from superseded failed generated schema repairs instead of treating all failed rows as current blockers

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -83,8 +83,23 @@ the tracker or writing to the database.
 
 | Command | Description |
 |---------|------------|
-| `smrt generate:mcp` | Generate MCP server from registered objects |
-| `smrt generate:types` | Generate TypeScript declarations from manifest |
+| `smrt generate-mcp` | Generate MCP server from registered objects (aliases: `generate-mcp-server`, `mcp`) |
+| `smrt generate-types` | Generate TypeScript declarations from manifest (alias: `generate-declarations`) |
+| `smrt generate-routes` | Generate SvelteKit API routes (aliases: `routes`, `generate:routes`) |
+| `smrt generate-register` | Generate `.smrt/register.js` from discovered packages (aliases: `register`, `generate:register`) |
+
+Generation commands are hyphenated. `generate-routes` and `generate-register`
+also answer to a colon alias for backward compatibility; `generate-mcp` and
+`generate-types` do not.
+
+`smrt generate-mcp` writes `.smrt/mcp-server/index.js` by default and emits
+JavaScript for a `.js` target, so `node .smrt/mcp-server/index.js` runs it
+directly. The generated server is always an ES module. Ask for a `.ts` target
+to keep the annotated TypeScript for `tsx` or Node's type stripping:
+
+```bash
+smrt generate-mcp --output-path .smrt/mcp-server/index.ts
+```
 
 ### Documentation
 
@@ -162,7 +177,7 @@ Custom methods on s-m-r-t objects are auto-discovered from manifests. Method par
 smrt introspect
 
 # Generate an MCP server
-smrt generate:mcp
+smrt generate-mcp
 
 # Scaffold a package playground definition
 smrt playground init

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -94,12 +94,19 @@ also answer to a colon alias for backward compatibility; `generate-mcp` and
 
 `smrt generate-mcp` writes `.smrt/mcp-server/index.js` by default and emits
 JavaScript for a `.js` target, so `node .smrt/mcp-server/index.js` runs it
-directly. The generated server is always an ES module. Ask for a `.ts` target
-to keep the annotated TypeScript for `tsx` or Node's type stripping:
+directly. Ask for a `.ts` target to keep the annotated TypeScript for `tsx` or
+Node's type stripping:
 
 ```bash
 smrt generate-mcp --output-path .smrt/mcp-server/index.ts
 ```
+
+The generated server is always an ES module, so a `.cjs`/`.cts` output path is
+rejected. It imports `@modelcontextprotocol/server`, `@happyvertical/smrt-core`,
+and `@happyvertical/smrt-config` at runtime (plus `@happyvertical/smrt-jobs` for
+task actions and `@happyvertical/smrt-tenancy` for tenant-scoped objects), so
+those have to be resolvable from the project you run it in — under pnpm's strict
+layout that means declaring them, not relying on the CLI's own dependencies.
 
 ### Documentation
 

--- a/packages/cli/src/__tests__/cli-generator-coverage.test.ts
+++ b/packages/cli/src/__tests__/cli-generator-coverage.test.ts
@@ -23,7 +23,11 @@
 import { ObjectRegistry } from '@happyvertical/smrt-core';
 import { parseCliArgs } from '@happyvertical/utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { CLIGenerator } from '../cli-generator.js';
+import {
+  type CLICommand,
+  CLIGenerator,
+  parseCliCommandArgs,
+} from '../cli-generator.js';
 
 /** Minimal in-memory collection backed by a Map (not a mocked DB adapter). */
 function makeMemoryCollection(seed: Array<Record<string, any>> = []) {
@@ -1012,5 +1016,120 @@ describe('CLIGenerator - handleSingletonMethod', () => {
         },
       ),
     ).rejects.toThrow(/registered from manifest/);
+  });
+});
+
+/**
+ * Regression for the swallowed `--version` flag (#2279).
+ *
+ * `parseCliArgs` in `@happyvertical/utils` returns the built-in `version`
+ * command for a `--version` token anywhere in argv, so `smrt generate-mcp
+ * --version 0.1.0` printed the CLI version and generated nothing. A
+ * subcommand's own declared option must win once a subcommand is named; a
+ * global `--version` with no subcommand must not.
+ */
+describe('CLIGenerator - subcommand-scoped --version (regression #2279)', () => {
+  /** Shaped like the real `generate-mcp` command: it declares `--version`. */
+  const generateMcp: CLICommand = {
+    name: 'generate-mcp',
+    description: 'Generate MCP server from registered SMRT objects',
+    aliases: ['generate-mcp-server', 'mcp'],
+    args: [],
+    options: {
+      'output-path': {
+        type: 'string',
+        description: 'Output path for MCP server file',
+        default: '.smrt/mcp-server/index.js',
+      },
+      version: {
+        type: 'string',
+        description: 'Server version',
+        default: '1.0.0',
+      },
+    },
+  };
+
+  it('routes --version to the subcommand that declares it', () => {
+    const parsed = parseCliCommandArgs(
+      ['generate-mcp', '--version', '0.1.0'],
+      [],
+      { 'generate-mcp': generateMcp },
+    );
+
+    expect(parsed.command).toBe('generate-mcp');
+    expect(parsed.options.version).toBe('0.1.0');
+    expect(parsed.options['output-path']).toBe('.smrt/mcp-server/index.js');
+  });
+
+  it('routes the inline --version=value form and command aliases', () => {
+    const parsed = parseCliCommandArgs(
+      ['mcp', '--version=0.2.0'],
+      [generateMcp],
+    );
+
+    expect(parsed.command).toBe('mcp');
+    expect(parsed.options.version).toBe('0.2.0');
+  });
+
+  it('keeps the declared default when the flag is absent', () => {
+    const parsed = parseCliCommandArgs(['generate-mcp'], [generateMcp]);
+
+    expect(parsed.options.version).toBe('1.0.0');
+  });
+
+  it('defers to the built-in lookup before built-ins are loaded', () => {
+    // First parse pass sees object commands only; it must still report the
+    // subcommand so executeCommand() can re-parse with the real definition.
+    const parsed = parseCliCommandArgs(
+      ['generate-mcp', '--version', '0.1.0'],
+      [],
+    );
+
+    expect(parsed.command).toBe('generate-mcp');
+  });
+
+  it('still prints the CLI version for a global --version', () => {
+    expect(parseCliCommandArgs(['--version'], [generateMcp]).command).toBe(
+      'version',
+    );
+    expect(
+      parseCliCommandArgs(['--version', 'generate-mcp'], [generateMcp]).command,
+    ).toBe('version');
+  });
+
+  it('leaves --help alone so subcommand help still works', () => {
+    expect(
+      parseCliCommandArgs(['generate-mcp', '--help'], [generateMcp]).command,
+    ).toBe('help');
+  });
+
+  it('reads the same tokens as parseCliArgs for a full process.argv', () => {
+    const parsed = parseCliCommandArgs(
+      [
+        '/usr/bin/node',
+        '/opt/smrt/dist/index.js',
+        'generate-mcp',
+        '--version',
+        '0.3.0',
+      ],
+      [generateMcp],
+    );
+
+    expect(parsed.command).toBe('generate-mcp');
+    expect(parsed.options.version).toBe('0.3.0');
+
+    expect(
+      parseCliCommandArgs(
+        ['/usr/bin/node', '/opt/smrt/dist/index.js', '--version'],
+        [generateMcp],
+      ).command,
+    ).toBe('version');
+  });
+
+  it('does not rescope a --version positional after --', () => {
+    expect(
+      parseCliCommandArgs(['generate-mcp', '--', '--version'], [generateMcp])
+        .command,
+    ).toBe('version');
   });
 });

--- a/packages/cli/src/__tests__/generate-mcp-dispatch.test.ts
+++ b/packages/cli/src/__tests__/generate-mcp-dispatch.test.ts
@@ -1,0 +1,50 @@
+/**
+ * End-to-end dispatch regression for `smrt generate-mcp --version` (#2279).
+ *
+ * The unit tests in cli-generator-coverage.test.ts pin the parser behaviour;
+ * this one drives the real handler the CLI binary uses, through the lazily
+ * loaded built-in command map, and asserts the command actually ran with the
+ * requested version instead of exiting after printing the CLI version.
+ */
+
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CLIGenerator } from '../cli-generator.js';
+
+describe('smrt generate-mcp --version (regression #2279)', () => {
+  let cli: CLIGenerator;
+  let outputDir: string;
+
+  beforeEach(async () => {
+    outputDir = await mkdtemp(join(tmpdir(), 'smrt-generate-mcp-'));
+    cli = new CLIGenerator({ prompt: false, colors: false });
+    // Loading the consumer's compiled classes from disk is irrelevant here.
+    vi.spyOn(cli as never, 'tryLoadUserClasses').mockResolvedValue(undefined);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await rm(outputDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('generates a server stamped with the requested version', async () => {
+    const outputPath = join(outputDir, 'index.js');
+
+    await cli.generateHandler()([
+      'generate-mcp',
+      '--output-path',
+      outputPath,
+      '--version',
+      '0.1.0',
+      '--no-config',
+      '--no-readme',
+    ]);
+
+    const generated = await readFile(outputPath, 'utf-8');
+    expect(generated).toContain('const SERVER_VERSION = "0.1.0"');
+  });
+});

--- a/packages/cli/src/cli-generator.ts
+++ b/packages/cli/src/cli-generator.ts
@@ -7,7 +7,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { createInterface } from 'node:readline';
 import { fileURLToPath } from 'node:url';
 import type {
@@ -219,15 +219,194 @@ function collectRepeatableOptionValues(
 }
 
 /**
+ * Option name a subcommand may declare that collides with a global CLI flag.
+ *
+ * `parseCliArgs` dispatches to the built-in `version` command whenever
+ * `--version` appears anywhere in argv, so `smrt generate-mcp --version 0.1.0`
+ * never reached the subcommand and exited without generating anything (#2279).
+ * Only `--version` is rescoped: `--help` after a subcommand still prints help,
+ * which is what someone typing it wants.
+ */
+const SCOPED_GLOBAL_FLAG = 'version';
+
+/**
+ * Private option name the scoped flag is parsed under. Renaming the token is
+ * what keeps `parseCliArgs` from intercepting it; the value is mapped back onto
+ * the declared name before any handler sees it.
+ */
+const SCOPED_GLOBAL_FLAG_ALIAS = 'smrt-scoped-version';
+
+/**
+ * Index of the first real argument, mirroring the node/script-path stripping
+ * `parseCliArgs` does. The CLI entry point passes `process.argv.slice(2)`, but
+ * the shared parser also accepts a full `process.argv`, and this wrapper must
+ * read the same tokens the parser will.
+ */
+function firstArgumentIndex(argv: string[]): number {
+  let index = 0;
+  if (argv.length > index && basename(argv[index]) === 'node') {
+    index += 1;
+  }
+  if (argv.length > index && argv[index].endsWith('.js')) {
+    index += 1;
+  }
+  return index;
+}
+
+/**
+ * Resolve the command a plain argv addresses, mirroring the multi-word command
+ * matching in `parseCliArgs` (up to three leading words, names or aliases).
+ *
+ * @returns The matched command, if any, and how many leading argv tokens it consumed
+ */
+function matchLeadingCommand(
+  argv: string[],
+  commands: CLICommand[],
+  builtInCommands: Record<string, CLICommand>,
+): { command?: CLICommand; wordCount: number } {
+  for (let width = Math.min(3, argv.length); width > 0; width -= 1) {
+    const candidateName = argv.slice(0, width).join(' ');
+    const found =
+      builtInCommands[candidateName] ??
+      commands.find(
+        (candidate) =>
+          candidate.name === candidateName ||
+          candidate.aliases?.includes(candidateName),
+      );
+    if (found) {
+      return { command: found, wordCount: width };
+    }
+  }
+
+  return { wordCount: 0 };
+}
+
+/**
+ * Rewrite a subcommand-scoped `--version` token to a private alias so the
+ * shared parser routes it to the subcommand instead of the global version
+ * command. Tokens before the subcommand — and a bare `smrt --version` — are
+ * left alone, so the global flag still wins when it is used globally.
+ *
+ * @returns Rewritten argv and the matched command, or `null` when nothing applies
+ */
+function rescopeGlobalFlag(
+  argv: string[],
+  commands: CLICommand[],
+  builtInCommands: Record<string, CLICommand>,
+): { argv: string[]; command?: CLICommand } | null {
+  const start = firstArgumentIndex(argv);
+  const leading = argv[start];
+  if (!leading || leading.startsWith('-')) {
+    return null;
+  }
+
+  const flag = `--${SCOPED_GLOBAL_FLAG}`;
+  const inlinePrefix = `${flag}=`;
+  const aliasFlag = `--${SCOPED_GLOBAL_FLAG_ALIAS}`;
+  const { command, wordCount } = matchLeadingCommand(
+    argv.slice(start),
+    commands,
+    builtInCommands,
+  );
+  // An unmatched leading token is still a command request: the built-in command
+  // map is loaded lazily, so the first parse pass sees object commands only.
+  const firstOptionIndex = start + Math.max(wordCount, 1);
+
+  let rewritten = false;
+  const rescoped = [...argv];
+  for (let index = firstOptionIndex; index < rescoped.length; index += 1) {
+    const token = rescoped[index];
+    // Everything past `--` is positional, so it keeps whatever meaning the
+    // shared parser already gives it.
+    if (token === '--') {
+      break;
+    }
+    if (token === flag) {
+      rescoped[index] = aliasFlag;
+      rewritten = true;
+      continue;
+    }
+    if (token.startsWith(inlinePrefix)) {
+      rescoped[index] = `${aliasFlag}=${token.slice(inlinePrefix.length)}`;
+      rewritten = true;
+    }
+  }
+
+  return rewritten ? { argv: rescoped, command } : null;
+}
+
+/**
+ * Swap a matched command's declared `version` option for the private alias the
+ * rescoped token is parsed under, so its type, default, and short flag still
+ * apply. Commands that do not declare the option are returned untouched.
+ */
+function declareScopedGlobalFlag(
+  command: CLICommand | undefined,
+  commands: CLICommand[],
+  builtInCommands: Record<string, CLICommand>,
+): { commands: CLICommand[]; builtInCommands: Record<string, CLICommand> } {
+  const declaredOptions = command?.options;
+  const declared = declaredOptions?.[SCOPED_GLOBAL_FLAG];
+  if (!command || !declaredOptions || !declared) {
+    return { commands, builtInCommands };
+  }
+
+  const { [SCOPED_GLOBAL_FLAG]: _replaced, ...otherOptions } = declaredOptions;
+  const rewrittenCommand: CLICommand = {
+    ...command,
+    options: {
+      ...otherOptions,
+      [SCOPED_GLOBAL_FLAG_ALIAS]: { ...declared },
+    },
+  };
+
+  return {
+    commands: commands.map((candidate) =>
+      candidate === command ? rewrittenCommand : candidate,
+    ),
+    builtInCommands: Object.fromEntries(
+      Object.entries(builtInCommands).map(([name, candidate]) => [
+        name,
+        candidate === command ? rewrittenCommand : candidate,
+      ]),
+    ),
+  };
+}
+
+/**
  * Parse one command while preserving every occurrence of options marked
- * `multiple`. Non-repeatable options retain the shared SDK parser behavior.
+ * `multiple`, and while letting a subcommand's own options win over the
+ * global flags the shared parser intercepts. Everything else retains the
+ * shared SDK parser behavior.
  */
 export function parseCliCommandArgs(
   argv: string[],
   commands: CLICommand[],
   builtInCommands: Record<string, CLICommand> = {},
 ): ParsedArgs {
-  const parsed = parseCliArgs(argv, commands, builtInCommands);
+  const rescoped = rescopeGlobalFlag(argv, commands, builtInCommands);
+  let parsed: ParsedArgs;
+
+  if (rescoped) {
+    const declared = declareScopedGlobalFlag(
+      rescoped.command,
+      commands,
+      builtInCommands,
+    );
+    parsed = parseCliArgs(
+      rescoped.argv,
+      declared.commands,
+      declared.builtInCommands,
+    );
+    if (SCOPED_GLOBAL_FLAG_ALIAS in parsed.options) {
+      parsed.options[SCOPED_GLOBAL_FLAG] =
+        parsed.options[SCOPED_GLOBAL_FLAG_ALIAS];
+      delete parsed.options[SCOPED_GLOBAL_FLAG_ALIAS];
+    }
+  } else {
+    parsed = parseCliArgs(argv, commands, builtInCommands);
+  }
+
   const command = parsed.command
     ? (builtInCommands[parsed.command] ??
       commands.find(

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -127,7 +127,7 @@ export const generateCommands: Record<string, CLICommand> = {
       modular: {
         type: 'boolean',
         description:
-          'Generate modular directory structure (tools/, handlers/, config.ts)',
+          'Generate modular directory structure (tools/, handlers/, config)',
         default: false,
       },
       debug: {

--- a/packages/core/agents/generators.md
+++ b/packages/core/agents/generators.md
@@ -30,19 +30,22 @@ Per-field web emission (#2046): `buildWebFieldDefinitions` carries `description`
 ## Generated MCP server output language
 
 `MCPGenerator` builds every file as TypeScript, so the requested `outputPath`
-extension decides what is written (#2279). `.ts`/`.mts`/`.cts` targets keep the
-source verbatim for `tsx` or Node type stripping; every other target
-(`.smrt/mcp-server/index.js` by default) is transpiled to JavaScript with the
-`typescript` dependency before writing, because the printed run script and the
-generated `claude-config.example.json` both invoke it with plain `node`.
-`src/generators/mcp-emit.ts` owns that decision — do not reintroduce a bare
-`writeFile` of generated source.
+extension decides what is written (#2279). `.ts`/`.mts` targets keep the source
+verbatim for `tsx` or Node type stripping — which is why the generated source
+must stay erasable-syntax-only (no parameter properties, enums, or namespaces).
+Every other target (`.smrt/mcp-server/index.js` by default) is transpiled to
+JavaScript with the `typescript` dependency before writing, because the printed
+run script and the generated `claude-config.example.json` both invoke it with
+plain `node`. A `.cjs`/`.cts` target is rejected outright: generated servers are
+ES modules. `src/generators/mcp-emit.ts` owns those decisions — do not
+reintroduce a bare `writeFile` of generated source.
 
-Modular output writes `config`, `tools/index`, and `handlers/index` in the entry
-point's *language* — `.ts` for any TypeScript target (a `.mts`/`.cts` entry still
-gets `.ts` siblings), `.js` otherwise — and the entry's relative import
-specifiers are emitted with that same extension, so the files it imports exist.
-The entry is written at the requested path rather than a hardcoded `index.js`.
+Modular output writes `config`, `tools/index`, and `handlers/index` with the
+entry point's own extension, and emits the entry's relative import specifiers
+with that same extension, so the files it imports both exist and load with the
+same module semantics — an `.mjs` entry gets `.mjs` siblings, not `.js` ones a
+CommonJS package would then parse as CommonJS. The entry is written at the
+requested path rather than a hardcoded `index.js`.
 Generated code also has to be valid in an ES module: `arguments` is not a legal
 binding name there, however convenient it reads.
 

--- a/packages/core/agents/generators.md
+++ b/packages/core/agents/generators.md
@@ -27,6 +27,25 @@ The web module also emits a build-time **`manifestHash`** constant (#1764): `com
 
 Per-field web emission (#2046): `buildWebFieldDefinitions` carries `description` (from `@field({ description })`) and sanitized `ui` hints (from `@field({ ui: { basic, group, order, locked } })`, read off the manifest `_meta.ui` bag through per-key type guards) into each emitted field definition, and `buildWebToolDescriptors` threads the same `description` into browser MCP tool schemas. `sensitive`/`transient` fields are excluded from emission entirely, so their descriptions never ship. Both keys are conditional, so hint-less schemas emit byte-identical definitions (and hashes) as before; adding a description/ui hint changes the manifest hash — deliberate over-invalidation, harmless per the #1764 contract.
 
+## Generated MCP server output language
+
+`MCPGenerator` builds every file as TypeScript, so the requested `outputPath`
+extension decides what is written (#2279). `.ts`/`.mts`/`.cts` targets keep the
+source verbatim for `tsx` or Node type stripping; every other target
+(`.smrt/mcp-server/index.js` by default) is transpiled to JavaScript with the
+`typescript` dependency before writing, because the printed run script and the
+generated `claude-config.example.json` both invoke it with plain `node`.
+`src/generators/mcp-emit.ts` owns that decision — do not reintroduce a bare
+`writeFile` of generated source.
+
+Modular output writes `config`, `tools/index`, and `handlers/index` in the entry
+point's *language* — `.ts` for any TypeScript target (a `.mts`/`.cts` entry still
+gets `.ts` siblings), `.js` otherwise — and the entry's relative import
+specifiers are emitted with that same extension, so the files it imports exist.
+The entry is written at the requested path rather than a hardcoded `index.js`.
+Generated code also has to be valid in an ES module: `arguments` is not a legal
+binding name there, however convenient it reads.
+
 ## Custom-action contract
 
 `resolveCustomActionMetadata()` is the common discovery and invocation contract

--- a/packages/core/src/generators/mcp-emit.test.ts
+++ b/packages/core/src/generators/mcp-emit.test.ts
@@ -14,6 +14,7 @@
 import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { copyFile, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { stripTypeScriptTypes } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -25,11 +26,12 @@ import {
 import { ObjectRegistry } from '../registry.js';
 import { MCPGenerator } from './mcp.js';
 import {
-  generatedSourceExtension,
+  generatedSiblingExtension,
   renderGeneratedSource,
   resolveGeneratedSourceLanguage,
   transpileGeneratedSource,
 } from './mcp-emit.js';
+import { generateRuntimeBootstrap } from './mcp-runtime-template.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -44,18 +46,45 @@ async function expectParsesAsEsModule(filePath: string): Promise<void> {
   }
 }
 
+describe('generated TypeScript stays erasable', () => {
+  /**
+   * A `.ts` target is written verbatim and documented as runnable through
+   * Node's type stripping, which only erases — it cannot transform. Parameter
+   * properties, enums, and namespaces would make the emitted server fail with
+   * `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`.
+   */
+  it('emits no transform-only syntax, including for task actions', () => {
+    const source = generateRuntimeBootstrap({
+      name: 'erasable-server',
+      tools: [
+        {
+          name: 'widget_reindex',
+          description: 'Reindex widgets',
+          inputSchema: { type: 'object' },
+        },
+      ],
+      taskActions: {
+        widget_reindex: { objectName: 'widget', objectType: 'Widget' },
+      },
+    });
+
+    expect(source).toContain('McpTaskExtensionTransport');
+    expect(() => stripTypeScriptTypes(source, { mode: 'strip' })).not.toThrow();
+  });
+});
+
 describe('resolveGeneratedSourceLanguage', () => {
   it('treats TypeScript extensions as TypeScript', () => {
     expect(resolveGeneratedSourceLanguage('server.ts')).toBe('typescript');
     expect(resolveGeneratedSourceLanguage('/abs/server.mts')).toBe(
       'typescript',
     );
-    expect(resolveGeneratedSourceLanguage('/abs/Server.CTS')).toBe(
+    expect(resolveGeneratedSourceLanguage('/abs/Server.MTS')).toBe(
       'typescript',
     );
   });
 
-  it('treats every other extension as JavaScript', () => {
+  it('treats every other module extension as JavaScript', () => {
     expect(resolveGeneratedSourceLanguage('.smrt/mcp-server/index.js')).toBe(
       'javascript',
     );
@@ -63,9 +92,25 @@ describe('resolveGeneratedSourceLanguage', () => {
     expect(resolveGeneratedSourceLanguage('server')).toBe('javascript');
   });
 
-  it('maps the language onto the extension used for sibling modules', () => {
-    expect(generatedSourceExtension('typescript')).toBe('.ts');
-    expect(generatedSourceExtension('javascript')).toBe('.js');
+  it('rejects CommonJS targets, which no generated server can run', () => {
+    // The generated server uses `import` and `import.meta.url`.
+    expect(() => resolveGeneratedSourceLanguage('server.cjs')).toThrow(
+      /ES module/,
+    );
+    expect(() => resolveGeneratedSourceLanguage('server.cts')).toThrow(
+      /ES module/,
+    );
+    expect(() => generatedSiblingExtension('server.cjs')).toThrow(/ES module/);
+  });
+
+  it("gives sibling modules the entry point's own extension", () => {
+    expect(generatedSiblingExtension('out/index.ts')).toBe('.ts');
+    expect(generatedSiblingExtension('out/index.mts')).toBe('.mts');
+    expect(generatedSiblingExtension('out/index.js')).toBe('.js');
+    // An `.mjs` entry in a CommonJS package needs `.mjs` siblings, or Node
+    // parses them as CommonJS and their `export` statements fail.
+    expect(generatedSiblingExtension('out/index.mjs')).toBe('.mjs');
+    expect(generatedSiblingExtension('out/server')).toBe('.js');
   });
 });
 
@@ -238,6 +283,40 @@ describe('MCPGenerator - generated output is runnable (#2279)', () => {
       'utf-8',
     );
     expect(handlersContent).not.toContain('arguments: any');
+  });
+
+  it('gives an .mjs modular entry .mjs siblings and specifiers', async () => {
+    const outputDir = join(tmpDir, 'modular-mjs');
+
+    await generator.generateServer({
+      outputPath: join(outputDir, 'index.mjs'),
+      serverName: 'emit-modular-mjs',
+      serverVersion: '1.0.0',
+      modular: true,
+    });
+
+    const indexContent = await readFile(join(outputDir, 'index.mjs'), 'utf-8');
+    expect(indexContent).toContain("from './config.mjs'");
+    expect(indexContent).toContain("from './tools/index.mjs'");
+    expect(indexContent).toContain("from './handlers/index.mjs'");
+
+    for (const relative of [
+      'index.mjs',
+      'config.mjs',
+      join('tools', 'index.mjs'),
+      join('handlers', 'index.mjs'),
+    ]) {
+      await expectParsesAsEsModule(join(outputDir, relative));
+    }
+  });
+
+  it('refuses a CommonJS output path instead of writing an unusable file', async () => {
+    await expect(
+      generator.generateServer({
+        outputPath: join(tmpDir, 'index.cjs'),
+        serverName: 'emit-cjs-server',
+      }),
+    ).rejects.toThrow(/ES module/);
   });
 
   it('writes the modular entry at the requested path', async () => {

--- a/packages/core/src/generators/mcp-emit.test.ts
+++ b/packages/core/src/generators/mcp-emit.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Regression tests for the generated MCP server's emit language (#2279).
+ *
+ * `smrt generate-mcp` used to write the TypeScript runtime template straight
+ * into `.smrt/mcp-server/index.js`, so the file the CLI told you to run died
+ * with `SyntaxError: Unexpected identifier 'CallToolRequest'`. The output
+ * language now follows the requested extension: JavaScript targets are
+ * transpiled, TypeScript targets are written verbatim.
+ *
+ * Syntax is verified by `node --check` on a `.mjs` copy, which parses the file
+ * as an ES module without executing it — the exact failure mode from the issue.
+ */
+
+import { execFile } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { copyFile, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  McpIntegrationTestProduct,
+  McpIntegrationTestProductCollection,
+} from '../__tests__/fixtures/mcp-integration-test-classes.js';
+import { ObjectRegistry } from '../registry.js';
+import { MCPGenerator } from './mcp.js';
+import {
+  generatedSourceExtension,
+  renderGeneratedSource,
+  resolveGeneratedSourceLanguage,
+  transpileGeneratedSource,
+} from './mcp-emit.js';
+
+const execFileAsync = promisify(execFile);
+
+/** Parse a generated file as an ES module without running it. */
+async function expectParsesAsEsModule(filePath: string): Promise<void> {
+  const moduleCopy = `${filePath}.${randomUUID().slice(0, 8)}.mjs`;
+  await copyFile(filePath, moduleCopy);
+  try {
+    await execFileAsync(process.execPath, ['--check', moduleCopy]);
+  } finally {
+    await rm(moduleCopy, { force: true });
+  }
+}
+
+describe('resolveGeneratedSourceLanguage', () => {
+  it('treats TypeScript extensions as TypeScript', () => {
+    expect(resolveGeneratedSourceLanguage('server.ts')).toBe('typescript');
+    expect(resolveGeneratedSourceLanguage('/abs/server.mts')).toBe(
+      'typescript',
+    );
+    expect(resolveGeneratedSourceLanguage('/abs/Server.CTS')).toBe(
+      'typescript',
+    );
+  });
+
+  it('treats every other extension as JavaScript', () => {
+    expect(resolveGeneratedSourceLanguage('.smrt/mcp-server/index.js')).toBe(
+      'javascript',
+    );
+    expect(resolveGeneratedSourceLanguage('server.mjs')).toBe('javascript');
+    expect(resolveGeneratedSourceLanguage('server')).toBe('javascript');
+  });
+
+  it('maps the language onto the extension used for sibling modules', () => {
+    expect(generatedSourceExtension('typescript')).toBe('.ts');
+    expect(generatedSourceExtension('javascript')).toBe('.js');
+  });
+});
+
+describe('transpileGeneratedSource', () => {
+  it('strips type-only imports and annotations while keeping value imports', async () => {
+    const output = await transpileGeneratedSource(
+      [
+        '#!/usr/bin/env node',
+        "import { type CallToolRequest, Server } from '@modelcontextprotocol/server';",
+        'const STI_TARGETS: Record<string, Record<string, string>> = {};',
+        'export function boot(server: Server): Record<string, unknown> {',
+        '  return { server, STI_TARGETS };',
+        '}',
+      ].join('\n'),
+    );
+
+    expect(output).toContain('#!/usr/bin/env node');
+    expect(output).toContain("from '@modelcontextprotocol/server'");
+    expect(output).toContain('Server');
+    expect(output).not.toContain('CallToolRequest');
+    expect(output).not.toContain('Record<string');
+  });
+
+  it('reports the source it failed on instead of writing broken output', async () => {
+    await expect(
+      transpileGeneratedSource('const = ;', 'index.js'),
+    ).rejects.toThrow(/Failed to transpile generated MCP source \(index\.js\)/);
+  });
+
+  it('leaves TypeScript untouched when the target is TypeScript', async () => {
+    const source = 'const value: number = 1;\n';
+    expect(await renderGeneratedSource(source, 'typescript')).toBe(source);
+  });
+});
+
+describe('MCPGenerator - generated output is runnable (#2279)', () => {
+  let tmpDir: string;
+  let generator: MCPGenerator;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'smrt-mcp-emit-'));
+    ObjectRegistry.registerCollection(
+      'McpIntegrationTestProduct',
+      McpIntegrationTestProductCollection,
+    );
+    // Reference the item class so the fixture module is not tree-shaken away.
+    expect(McpIntegrationTestProduct.name).toBe('McpIntegrationTestProduct');
+
+    generator = new MCPGenerator({
+      name: 'emit-test-server',
+      version: '1.0.0',
+      description: 'Emit test server',
+    });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('writes JavaScript that node can parse for the default .js target', async () => {
+    const outputPath = join(tmpDir, 'index.js');
+
+    await generator.generateServer({
+      outputPath,
+      serverName: 'emit-js-server',
+      serverVersion: '1.0.0',
+    });
+
+    const content = await readFile(outputPath, 'utf-8');
+    expect(content).toContain('#!/usr/bin/env node');
+    expect(content).toContain('emit-js-server');
+    // The two annotations that made the shipped `.js` output unparseable.
+    expect(content).not.toContain('type CallToolRequest');
+    expect(content).not.toContain('const STI_TARGETS: Record<');
+
+    await expectParsesAsEsModule(outputPath);
+  });
+
+  it('keeps TypeScript for a .ts target so type-aware runners still work', async () => {
+    const outputPath = join(tmpDir, 'index.ts');
+
+    await generator.generateServer({
+      outputPath,
+      serverName: 'emit-ts-server',
+      serverVersion: '1.0.0',
+    });
+
+    const content = await readFile(outputPath, 'utf-8');
+    expect(content).toContain('type CallToolRequest');
+    expect(content).toContain('const STI_TARGETS: Record<');
+  });
+
+  it('points the Claude config example at the file it generated', async () => {
+    const outputPath = join(tmpDir, 'configured', 'index.js');
+
+    await generator.generateServer({
+      outputPath,
+      serverName: 'emit-config-server',
+      serverVersion: '1.0.0',
+      generateClaudeConfigFile: true,
+    });
+
+    const config = JSON.parse(
+      await readFile(
+        join(tmpDir, 'configured', 'claude-config.example.json'),
+        'utf-8',
+      ),
+    );
+    const args = config.mcpServers['emit-config-server'].args as string[];
+
+    expect(config.mcpServers['emit-config-server'].command).toBe('node');
+    expect(args).toEqual([outputPath]);
+    await expectParsesAsEsModule(args[0]);
+  });
+
+  it('emits modular files node can resolve and parse', async () => {
+    const outputDir = join(tmpDir, 'modular');
+    const indexPath = join(outputDir, 'index.js');
+
+    await generator.generateServer({
+      outputPath: indexPath,
+      serverName: 'emit-modular-server',
+      serverVersion: '1.0.0',
+      modular: true,
+    });
+
+    const indexContent = await readFile(indexPath, 'utf-8');
+    expect(indexContent).toContain("from './config.js'");
+    expect(indexContent).toContain("from './tools/index.js'");
+    expect(indexContent).toContain("from './handlers/index.js'");
+    // Unused package imports fail to resolve in consumers that do not depend
+    // on them, which is just as fatal as a syntax error.
+    expect(indexContent).not.toContain('@happyvertical/sql');
+    expect(indexContent).not.toContain('@happyvertical/ai');
+
+    for (const relative of [
+      'index.js',
+      'config.js',
+      join('tools', 'index.js'),
+      join('handlers', 'index.js'),
+    ]) {
+      await expectParsesAsEsModule(join(outputDir, relative));
+    }
+  });
+
+  it('emits modular TypeScript with matching sibling specifiers', async () => {
+    const outputDir = join(tmpDir, 'modular-ts');
+
+    await generator.generateServer({
+      outputPath: join(outputDir, 'index.ts'),
+      serverName: 'emit-modular-ts-server',
+      serverVersion: '1.0.0',
+      modular: true,
+    });
+
+    const indexContent = await readFile(join(outputDir, 'index.ts'), 'utf-8');
+    expect(indexContent).toContain("from './config.ts'");
+    expect(indexContent).toContain("from './tools/index.ts'");
+    expect(indexContent).toContain("from './handlers/index.ts'");
+
+    const toolsContent = await readFile(
+      join(outputDir, 'tools', 'index.ts'),
+      'utf-8',
+    );
+    expect(toolsContent).toContain('Array<{');
+
+    // `arguments` is a reserved binding in every module, TypeScript included.
+    const handlersContent = await readFile(
+      join(outputDir, 'handlers', 'index.ts'),
+      'utf-8',
+    );
+    expect(handlersContent).not.toContain('arguments: any');
+  });
+
+  it('writes the modular entry at the requested path', async () => {
+    const outputDir = join(tmpDir, 'named-entry');
+    const indexPath = join(outputDir, 'server.js');
+
+    await generator.generateServer({
+      outputPath: indexPath,
+      serverName: 'emit-named-entry',
+      serverVersion: '1.0.0',
+      modular: true,
+    });
+
+    await expectParsesAsEsModule(indexPath);
+  });
+});

--- a/packages/core/src/generators/mcp-emit.ts
+++ b/packages/core/src/generators/mcp-emit.ts
@@ -6,9 +6,12 @@
  * the caller asked for as `outputPath` decides how that source has to be
  * written (#2279):
  *
- * - `.ts` / `.mts` / `.cts` — write the TypeScript verbatim. The consumer runs
- *   it through `tsx` or Node's type stripping, which is what the repository's
- *   own MCP conformance fixture does.
+ * - `.ts` / `.mts` — write the TypeScript verbatim. The consumer runs it
+ *   through `tsx` or Node's type stripping, which is what the repository's own
+ *   MCP conformance fixture does. The generated source therefore has to stay
+ *   erasable-syntax-only.
+ * - `.cjs` / `.cts` — rejected. Generated servers are ES modules, so a
+ *   CommonJS target cannot run in any language.
  * - anything else (`.js` by default) — transpile to JavaScript first, so
  *   `node .smrt/mcp-server/index.js` runs instead of dying on
  *   `SyntaxError: Unexpected identifier 'CallToolRequest'`.
@@ -21,7 +24,27 @@
 /** Language a generated file is written in, derived from its extension. */
 export type GeneratedSourceLanguage = 'typescript' | 'javascript';
 
-const TYPESCRIPT_EXTENSIONS = ['.ts', '.mts', '.cts'];
+/** Extension a generated module may be written with. */
+export type GeneratedSourceExtension = '.ts' | '.mts' | '.js' | '.mjs';
+
+const TYPESCRIPT_EXTENSIONS = ['.ts', '.mts'];
+
+/**
+ * Generated servers are ES modules — they use `import` and `import.meta.url` —
+ * so a CommonJS target can never run whatever language it is written in.
+ */
+const COMMONJS_EXTENSIONS = ['.cjs', '.cts'];
+
+function assertModuleTarget(outputPath: string, lowerCased: string): void {
+  const commonJs = COMMONJS_EXTENSIONS.find((extension) =>
+    lowerCased.endsWith(extension),
+  );
+  if (commonJs) {
+    throw new Error(
+      `Cannot generate an MCP server at '${outputPath}': the generated server is an ES module, so a ${commonJs} target cannot run. Use .js/.mjs for JavaScript or .ts/.mts for TypeScript.`,
+    );
+  }
+}
 
 /**
  * Decide how a generated file must be written from the path the caller asked
@@ -30,11 +53,13 @@ const TYPESCRIPT_EXTENSIONS = ['.ts', '.mts', '.cts'];
  *
  * @param outputPath - Path the generated file will be written to
  * @returns The language the file contents must be written in
+ * @throws When the path asks for a CommonJS target
  */
 export function resolveGeneratedSourceLanguage(
   outputPath: string,
 ): GeneratedSourceLanguage {
   const lowerCased = outputPath.toLowerCase();
+  assertModuleTarget(outputPath, lowerCased);
   return TYPESCRIPT_EXTENSIONS.some((extension) =>
     lowerCased.endsWith(extension),
   )
@@ -44,15 +69,24 @@ export function resolveGeneratedSourceLanguage(
 
 /**
  * Extension for modules emitted alongside a generated entry point, so the
- * modular server's relative imports resolve to files that exist on disk.
+ * modular server's relative imports resolve to files that exist on disk *and*
+ * are loaded with the entry's own module semantics. An `.mjs` entry point in a
+ * CommonJS package needs `.mjs` siblings, not `.js` ones that Node would then
+ * parse as CommonJS.
  *
- * @param language - Language the generated files are written in
- * @returns `.ts` for TypeScript output, `.js` for JavaScript output
+ * @param outputPath - Path of the generated entry point
+ * @returns The extension every sibling module is written with
+ * @throws When the path asks for a CommonJS target
  */
-export function generatedSourceExtension(
-  language: GeneratedSourceLanguage,
-): '.ts' | '.js' {
-  return language === 'typescript' ? '.ts' : '.js';
+export function generatedSiblingExtension(
+  outputPath: string,
+): GeneratedSourceExtension {
+  const lowerCased = outputPath.toLowerCase();
+  assertModuleTarget(outputPath, lowerCased);
+  if (lowerCased.endsWith('.mts')) return '.mts';
+  if (lowerCased.endsWith('.ts')) return '.ts';
+  if (lowerCased.endsWith('.mjs')) return '.mjs';
+  return '.js';
 }
 
 type TypeScriptApi = typeof import('typescript');

--- a/packages/core/src/generators/mcp-emit.ts
+++ b/packages/core/src/generators/mcp-emit.ts
@@ -1,0 +1,141 @@
+/**
+ * Emit helpers for generated MCP server sources.
+ *
+ * The MCP generators build their output as TypeScript source: the runtime
+ * template carries type-only imports, type annotations, and generics. Whatever
+ * the caller asked for as `outputPath` decides how that source has to be
+ * written (#2279):
+ *
+ * - `.ts` / `.mts` / `.cts` — write the TypeScript verbatim. The consumer runs
+ *   it through `tsx` or Node's type stripping, which is what the repository's
+ *   own MCP conformance fixture does.
+ * - anything else (`.js` by default) — transpile to JavaScript first, so
+ *   `node .smrt/mcp-server/index.js` runs instead of dying on
+ *   `SyntaxError: Unexpected identifier 'CallToolRequest'`.
+ *
+ * Transpilation uses the `typescript` package that `@happyvertical/smrt-core`
+ * already depends on, imported lazily so that merely importing the generators
+ * does not pull the compiler into memory.
+ */
+
+/** Language a generated file is written in, derived from its extension. */
+export type GeneratedSourceLanguage = 'typescript' | 'javascript';
+
+const TYPESCRIPT_EXTENSIONS = ['.ts', '.mts', '.cts'];
+
+/**
+ * Decide how a generated file must be written from the path the caller asked
+ * for. Unknown extensions emit JavaScript: `node` is the documented way to run
+ * a generated server, so JavaScript is the safe default.
+ *
+ * @param outputPath - Path the generated file will be written to
+ * @returns The language the file contents must be written in
+ */
+export function resolveGeneratedSourceLanguage(
+  outputPath: string,
+): GeneratedSourceLanguage {
+  const lowerCased = outputPath.toLowerCase();
+  return TYPESCRIPT_EXTENSIONS.some((extension) =>
+    lowerCased.endsWith(extension),
+  )
+    ? 'typescript'
+    : 'javascript';
+}
+
+/**
+ * Extension for modules emitted alongside a generated entry point, so the
+ * modular server's relative imports resolve to files that exist on disk.
+ *
+ * @param language - Language the generated files are written in
+ * @returns `.ts` for TypeScript output, `.js` for JavaScript output
+ */
+export function generatedSourceExtension(
+  language: GeneratedSourceLanguage,
+): '.ts' | '.js' {
+  return language === 'typescript' ? '.ts' : '.js';
+}
+
+type TypeScriptApi = typeof import('typescript');
+
+/**
+ * Load the TypeScript compiler API lazily.
+ *
+ * `typescript` is CommonJS: Node's ESM interop exposes the whole API on
+ * `default`, while bundlers hand back the namespace itself.
+ */
+async function loadTypeScript(): Promise<TypeScriptApi> {
+  const imported = (await import('typescript')) as TypeScriptApi & {
+    default?: TypeScriptApi;
+  };
+  return imported.default ?? imported;
+}
+
+/**
+ * Transpile generated TypeScript to runnable ESM JavaScript.
+ *
+ * `verbatimModuleSyntax` keeps every value import the template emits (an
+ * unused-looking import must not be elided: the generated server relies on
+ * side effects and on imports whose only use is inside emitted switch cases),
+ * while type-only import specifiers are dropped.
+ *
+ * @param source - Generated TypeScript source
+ * @param label - Target path or name reported in transpile diagnostics
+ * @returns Equivalent JavaScript source
+ * @throws When the generated source is not valid TypeScript
+ */
+export async function transpileGeneratedSource(
+  source: string,
+  label = 'generated MCP source',
+): Promise<string> {
+  const ts = await loadTypeScript();
+
+  const { outputText, diagnostics } = ts.transpileModule(source, {
+    // The input is always TypeScript regardless of where it will be written;
+    // a `.js` file name here would make the compiler parse it as JavaScript.
+    fileName: 'smrt-generated-mcp-source.ts',
+    reportDiagnostics: true,
+    compilerOptions: {
+      target: ts.ScriptTarget.ESNext,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      verbatimModuleSyntax: true,
+      removeComments: false,
+      newLine: ts.NewLineKind.LineFeed,
+    },
+  });
+
+  const errors = (diagnostics ?? []).filter(
+    (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
+  );
+  if (errors.length > 0) {
+    const details = errors
+      .map((diagnostic) =>
+        ts.flattenDiagnosticMessageText(diagnostic.messageText, ' '),
+      )
+      .join('; ');
+    throw new Error(
+      `Failed to transpile generated MCP source (${label}): ${details}`,
+    );
+  }
+
+  return outputText;
+}
+
+/**
+ * Render generated TypeScript for the requested output language.
+ *
+ * @param source - Generated TypeScript source
+ * @param language - Language the file must be written in
+ * @param label - Target path or name reported in transpile diagnostics
+ * @returns Source ready to be written to disk
+ */
+export async function renderGeneratedSource(
+  source: string,
+  language: GeneratedSourceLanguage,
+  label = 'generated MCP source',
+): Promise<string> {
+  if (language === 'typescript') {
+    return source;
+  }
+  return transpileGeneratedSource(source, label);
+}

--- a/packages/core/src/generators/mcp-examples.spec.ts
+++ b/packages/core/src/generators/mcp-examples.spec.ts
@@ -185,15 +185,15 @@ describe('MCP Generator - Example Projects', () => {
 
       // Verify modular structure
       const configContent = await readFile(
-        join(outputDir, 'config.ts'),
+        join(outputDir, 'config.js'),
         'utf-8',
       );
       const toolsContent = await readFile(
-        join(outputDir, 'tools', 'index.ts'),
+        join(outputDir, 'tools', 'index.js'),
         'utf-8',
       );
       const handlersContent = await readFile(
-        join(outputDir, 'handlers', 'index.ts'),
+        join(outputDir, 'handlers', 'index.js'),
         'utf-8',
       );
 
@@ -329,9 +329,9 @@ describe('MCP Generator - Example Projects', () => {
       // Verify generated files
       const expectedFiles = [
         'index.js',
-        'config.ts',
-        'tools/index.ts',
-        'handlers/index.ts',
+        'config.js',
+        'tools/index.js',
+        'handlers/index.js',
         'claude-config.example.json',
         'MCP-README.md',
       ];
@@ -344,7 +344,7 @@ describe('MCP Generator - Example Projects', () => {
 
       // Verify the server includes task tools
       const toolsContent = await readFile(
-        join(projectDir, '.smrt', 'mcp-server', 'tools', 'index.ts'),
+        join(projectDir, '.smrt', 'mcp-server', 'tools', 'index.js'),
         'utf-8',
       );
       expect(toolsContent).toContain('task_list');

--- a/packages/core/src/generators/mcp-integration.spec.ts
+++ b/packages/core/src/generators/mcp-integration.spec.ts
@@ -232,15 +232,15 @@ describe('MCPGenerator - Integration Tests', () => {
 
       // Verify file structure
       const configContent = await readFile(
-        join(outputDir, 'config.ts'),
+        join(outputDir, 'config.js'),
         'utf-8',
       );
       const toolsContent = await readFile(
-        join(outputDir, 'tools', 'index.ts'),
+        join(outputDir, 'tools', 'index.js'),
         'utf-8',
       );
       const handlersContent = await readFile(
-        join(outputDir, 'handlers', 'index.ts'),
+        join(outputDir, 'handlers', 'index.js'),
         'utf-8',
       );
       const indexContent = await readFile(join(outputDir, 'index.js'), 'utf-8');

--- a/packages/core/src/generators/mcp-modular.test.ts
+++ b/packages/core/src/generators/mcp-modular.test.ts
@@ -94,12 +94,12 @@ describe('MCPGenerator - Modular Generation', () => {
 
       // Verify all expected files exist
       await access(join(outputDir, 'index.js'));
-      await access(join(outputDir, 'config.ts'));
-      await access(join(outputDir, 'tools', 'index.ts'));
-      await access(join(outputDir, 'handlers', 'index.ts'));
+      await access(join(outputDir, 'config.js'));
+      await access(join(outputDir, 'tools', 'index.js'));
+      await access(join(outputDir, 'handlers', 'index.js'));
     });
 
-    it('should create properly structured config.ts file', async () => {
+    it('should create properly structured config module', async () => {
       const outputDir = join(tmpDir, 'config-structure');
 
       await generator.generateServer({
@@ -113,7 +113,7 @@ describe('MCPGenerator - Modular Generation', () => {
       });
 
       const configContent = await readFile(
-        join(outputDir, 'config.ts'),
+        join(outputDir, 'config.js'),
         'utf-8',
       );
 
@@ -125,7 +125,7 @@ describe('MCPGenerator - Modular Generation', () => {
       expect(configContent).toContain('export const DEBUG = true');
     });
 
-    it('should create tools/index.ts with tool definitions', async () => {
+    it('should create tools module with tool definitions', async () => {
       const outputDir = join(tmpDir, 'tools-structure');
 
       await generator.generateServer({
@@ -138,19 +138,17 @@ describe('MCPGenerator - Modular Generation', () => {
       });
 
       const toolsContent = await readFile(
-        join(outputDir, 'tools', 'index.ts'),
+        join(outputDir, 'tools', 'index.js'),
         'utf-8',
       );
 
-      // Verify structure
-      expect(toolsContent).toContain('export const tools');
-      expect(toolsContent).toContain('Array<{');
-      expect(toolsContent).toContain('name: string');
-      expect(toolsContent).toContain('description: string');
-      expect(toolsContent).toContain('inputSchema: any');
+      // Verify structure. A `.js` target is emitted as JavaScript, so the
+      // declaration's TypeScript annotation is gone (#2279).
+      expect(toolsContent).toContain('export const tools = [');
+      expect(toolsContent).not.toContain('Array<{');
     });
 
-    it('should create handlers/index.ts with tool call handler', async () => {
+    it('should create handlers module with tool call handler', async () => {
       const outputDir = join(tmpDir, 'handlers-structure');
 
       await generator.generateServer({
@@ -163,18 +161,18 @@ describe('MCPGenerator - Modular Generation', () => {
       });
 
       const handlersContent = await readFile(
-        join(outputDir, 'handlers', 'index.ts'),
+        join(outputDir, 'handlers', 'index.js'),
         'utf-8',
       );
 
-      // Verify structure
+      // Verify structure. A `.js` target is emitted as JavaScript, so the
+      // handler signature carries no TypeScript annotations (#2279).
       expect(handlersContent).toContain('export async function handleToolCall');
-      expect(handlersContent).toContain('name: string');
-      expect(handlersContent).toContain('arguments: any');
       expect(handlersContent).toContain('switch (name)');
+      expect(handlersContent).not.toContain('arguments: any');
     });
 
-    it('should create modular index.js that imports from separate files', async () => {
+    it('should create a modular entry point that imports from separate files', async () => {
       const outputDir = join(tmpDir, 'modular-index');
 
       await generator.generateServer({
@@ -266,7 +264,7 @@ describe('MCPGenerator - Modular Generation', () => {
       });
 
       const configContent = await readFile(
-        join(outputDir, 'config.ts'),
+        join(outputDir, 'config.js'),
         'utf-8',
       );
       expect(configContent).toContain('export const DEBUG = true');
@@ -395,9 +393,9 @@ describe('MCPGenerator - Modular Generation', () => {
       });
 
       await access(join(deepDir, 'index.js'));
-      await access(join(deepDir, 'config.ts'));
-      await access(join(deepDir, 'tools', 'index.ts'));
-      await access(join(deepDir, 'handlers', 'index.ts'));
+      await access(join(deepDir, 'config.js'));
+      await access(join(deepDir, 'tools', 'index.js'));
+      await access(join(deepDir, 'handlers', 'index.js'));
     });
   });
 });

--- a/packages/core/src/generators/mcp-runtime-template.ts
+++ b/packages/core/src/generators/mcp-runtime-template.ts
@@ -626,7 +626,13 @@ class McpTaskExtensionTransport {
   onerror?: (error: Error) => void;
   onmessage?: (message: any) => void;
 
-  constructor(private readonly wire: StdioServerTransport) {}
+  // An explicit field, not a parameter property: a \`.ts\` target has to stay
+  // erasable-syntax-only so Node's type stripping can run it (#2279).
+  wire: StdioServerTransport;
+
+  constructor(wire: StdioServerTransport) {
+    this.wire = wire;
+  }
 
   async start() {
     this.wire.onclose = () => this.onclose?.();

--- a/packages/core/src/generators/mcp.test.ts
+++ b/packages/core/src/generators/mcp.test.ts
@@ -736,7 +736,7 @@ describe('MCPGenerator with Custom Actions', () => {
           modular: true,
         });
         const handlers = await readFile(
-          join(outputDir, 'handlers', 'index.ts'),
+          join(outputDir, 'handlers', 'index.js'),
           'utf-8',
         );
 

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -21,8 +21,9 @@ import {
   SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY,
 } from './custom-action.js';
 import {
+  type GeneratedSourceExtension,
   type GeneratedSourceLanguage,
-  generatedSourceExtension,
+  generatedSiblingExtension,
   renderGeneratedSource,
   resolveGeneratedSourceLanguage,
 } from './mcp-emit.js';
@@ -1942,9 +1943,9 @@ export class MCPGenerator {
    * Creates separate files for tools, handlers, configuration, and main entry point.
    * This makes the generated server easier to customize and extend.
    *
-   * The sibling modules use the entry point's language — `.ts` for any
-   * TypeScript target, `.js` otherwise — and the entry emits matching relative
-   * specifiers, so its imports resolve to files that exist (#2279).
+   * The sibling modules use the entry point's own extension and the entry
+   * emits matching relative specifiers, so its imports resolve to files that
+   * exist and load with the same module semantics (#2279).
    *
    * @param indexPath - Absolute path of the entry point to generate
    * @param serverName - Server name
@@ -1960,7 +1961,7 @@ export class MCPGenerator {
     language: GeneratedSourceLanguage,
   ): Promise<void> {
     const outputDir = dirname(indexPath);
-    const extension = generatedSourceExtension(language);
+    const extension = generatedSiblingExtension(indexPath);
 
     // Create subdirectories
     const toolsDir = resolve(outputDir, 'tools');
@@ -2459,7 +2460,7 @@ ${
    */
   private generateModularIndex(
     toolListCacheHint: MCPToolListCacheHint,
-    extension: '.ts' | '.js' = '.js',
+    extension: GeneratedSourceExtension = '.js',
   ): string {
     return `#!/usr/bin/env node
 /**

--- a/packages/core/src/generators/mcp.ts
+++ b/packages/core/src/generators/mcp.ts
@@ -21,6 +21,12 @@ import {
   SMRT_CUSTOM_ACTION_ERROR_METADATA_KEY,
 } from './custom-action.js';
 import {
+  type GeneratedSourceLanguage,
+  generatedSourceExtension,
+  renderGeneratedSource,
+  resolveGeneratedSourceLanguage,
+} from './mcp-emit.js';
+import {
   generateClaudeConfig,
   generateMCPDocumentation,
   generateMCPScript,
@@ -35,6 +41,25 @@ import {
   type ToolFieldMeta,
   type ToolJsonSchema,
 } from './tool-schema.js';
+
+/**
+ * Write one generated module, rendering it for the requested output language.
+ *
+ * Every generator in this file produces TypeScript source; a JavaScript target
+ * is transpiled on the way out so the written file is runnable as-is (#2279).
+ *
+ * @param targetPath - Absolute path of the file to write
+ * @param source - Generated TypeScript source
+ * @param language - Language the file must be written in
+ */
+async function writeGeneratedFile(
+  targetPath: string,
+  source: string,
+  language: GeneratedSourceLanguage,
+): Promise<void> {
+  const rendered = await renderGeneratedSource(source, language, targetPath);
+  await writeFile(targetPath, rendered, 'utf-8');
+}
 
 /**
  * Runtime tool-call arguments. They arrive as untyped JSON from the MCP client,
@@ -1682,7 +1707,13 @@ export class MCPGenerator {
    */
   async generateServer(
     options: {
-      /** Path to output server file (relative or absolute) */
+      /**
+       * Path to output server file (relative or absolute).
+       *
+       * The extension decides the emitted language: `.ts`/`.mts`/`.cts` keep
+       * the generated TypeScript, anything else is transpiled to JavaScript so
+       * plain `node <path>` runs it (#2279).
+       */
       outputPath?: string;
 
       /** Server name for configuration */
@@ -1700,7 +1731,7 @@ export class MCPGenerator {
       /** Generate README documentation */
       generateReadme?: boolean;
 
-      /** Generate modular directory structure (tools/, handlers/, config.ts) */
+      /** Generate modular directory structure (tools/, handlers/, config) */
       modular?: boolean;
     } = {},
   ): Promise<void> {
@@ -1718,16 +1749,21 @@ export class MCPGenerator {
     const resolvedPath = resolve(process.cwd(), outputPath);
     const outputDir = dirname(resolvedPath);
 
+    // The requested extension decides whether the generated TypeScript is
+    // written verbatim or transpiled to runnable JavaScript first (#2279).
+    const language = resolveGeneratedSourceLanguage(resolvedPath);
+
     // Ensure output directory exists
     await mkdir(outputDir, { recursive: true });
 
     if (modular) {
-      // Generate modular structure: tools/, handlers/, config.ts, index.js
+      // Generate modular structure: tools/, handlers/, config, entry point
       await this.generateModularServer(
-        outputDir,
+        resolvedPath,
         serverName,
         serverVersion,
         debug,
+        language,
       );
     } else {
       // Generate single-file server with static tools
@@ -1758,7 +1794,7 @@ export class MCPGenerator {
       const serverCode = generateRuntimeBootstrap(runtimeOptions);
 
       // Write server file
-      await writeFile(resolvedPath, serverCode, 'utf-8');
+      await writeGeneratedFile(resolvedPath, serverCode, language);
       console.log(`✅ Generated MCP server: ${resolvedPath}`);
     }
 
@@ -1906,17 +1942,26 @@ export class MCPGenerator {
    * Creates separate files for tools, handlers, configuration, and main entry point.
    * This makes the generated server easier to customize and extend.
    *
-   * @param outputDir - Directory to generate files in
+   * The sibling modules use the entry point's language — `.ts` for any
+   * TypeScript target, `.js` otherwise — and the entry emits matching relative
+   * specifiers, so its imports resolve to files that exist (#2279).
+   *
+   * @param indexPath - Absolute path of the entry point to generate
    * @param serverName - Server name
    * @param serverVersion - Server version
    * @param debug - Enable debug logging
+   * @param language - Language the generated files are written in
    */
   private async generateModularServer(
-    outputDir: string,
+    indexPath: string,
     serverName: string,
     serverVersion: string,
     debug: boolean,
+    language: GeneratedSourceLanguage,
   ): Promise<void> {
+    const outputDir = dirname(indexPath);
+    const extension = generatedSourceExtension(language);
+
     // Create subdirectories
     const toolsDir = resolve(outputDir, 'tools');
     const handlersDir = resolve(outputDir, 'handlers');
@@ -1924,44 +1969,44 @@ export class MCPGenerator {
     await mkdir(toolsDir, { recursive: true });
     await mkdir(handlersDir, { recursive: true });
 
-    // Generate config.ts
-    const configPath = resolve(outputDir, 'config.ts');
+    // Generate config module
+    const configPath = resolve(outputDir, `config${extension}`);
     const configCode = this.generateConfigFile(
       serverName,
       serverVersion,
       debug,
     );
-    await writeFile(configPath, configCode, 'utf-8');
+    await writeGeneratedFile(configPath, configCode, language);
     console.log(`✅ Generated config: ${configPath}`);
 
     const generatedTools = await this.generateTools();
 
-    // Generate tools/index.ts with tool definitions
-    const toolsPath = resolve(toolsDir, 'index.ts');
+    // Generate tools module with tool definitions
+    const toolsPath = resolve(toolsDir, `index${extension}`);
     const toolsCode = this.generateToolsFile(generatedTools);
-    await writeFile(toolsPath, toolsCode, 'utf-8');
+    await writeGeneratedFile(toolsPath, toolsCode, language);
     console.log(`✅ Generated tools: ${toolsPath}`);
 
-    // Generate handlers/index.ts with tool call handlers
-    const handlersPath = resolve(handlersDir, 'index.ts');
+    // Generate handlers module with tool call handlers
+    const handlersPath = resolve(handlersDir, `index${extension}`);
     const tenantScopedObjects =
       await this.tenantScopedObjectNames(generatedTools);
     const hasTenantScopedTools =
       tenantScopedObjects.length > 0 ||
       (await this.hasTenantScopedTools(generatedTools));
     const handlersCode = await this.generateHandlersFile(tenantScopedObjects);
-    await writeFile(handlersPath, handlersCode, 'utf-8');
+    await writeGeneratedFile(handlersPath, handlersCode, language);
     console.log(`✅ Generated handlers: ${handlersPath}`);
 
-    // Generate main index.js entry point
-    const indexPath = resolve(outputDir, 'index.js');
+    // Generate main entry point
     const indexCode = this.generateModularIndex(
       resolveMCPToolListCacheHint(
         this.config.cache?.toolsList,
         hasTenantScopedTools,
       ),
+      extension,
     );
-    await writeFile(indexPath, indexCode, 'utf-8');
+    await writeGeneratedFile(indexPath, indexCode, language);
     console.log(`✅ Generated MCP server: ${indexPath}`);
   }
 
@@ -2363,11 +2408,11 @@ function errorResult(structuredContent: any, text: string, _meta?: Record<string
  */
 export async function handleToolCall(
   name: string,
-  arguments: any = {},
+  toolArguments: any = {},
   aiConfig: any = {}
 ) {
   try {
-    const args = arguments;
+    const args = toolArguments;
 
     const runToolBody = async () => {
       switch (name) {
@@ -2408,9 +2453,13 @@ ${
 
   /**
    * Generate modular index file (main entry point)
+   *
+   * @param toolListCacheHint - Cache hint emitted for `tools/list` results
+   * @param extension - Extension of the sibling modules this entry imports
    */
   private generateModularIndex(
     toolListCacheHint: MCPToolListCacheHint,
+    extension: '.ts' | '.js' = '.js',
   ): string {
     return `#!/usr/bin/env node
 /**
@@ -2427,12 +2476,10 @@ import { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { ObjectRegistry } from '@happyvertical/smrt-core';
 import { loadConfig } from '@happyvertical/smrt-config';
-import { getDatabase } from '@happyvertical/sql';
-import { getAI } from '@happyvertical/ai';
 
-import { SERVER_NAME, SERVER_VERSION, DEBUG } from './config.js';
-import { tools } from './tools/index.js';
-import { handleToolCall } from './handlers/index.js';
+import { SERVER_NAME, SERVER_VERSION, DEBUG } from './config${extension}';
+import { tools } from './tools/index${extension}';
+import { handleToolCall } from './handlers/index${extension}';
 
 const TOOL_LIST_CACHE_HINT = ${JSON.stringify(toolListCacheHint)};
 

--- a/packages/tenancy/src/__tests__/cli-mcp-tenant-context.spec.ts
+++ b/packages/tenancy/src/__tests__/cli-mcp-tenant-context.spec.ts
@@ -191,7 +191,7 @@ describe('Generated CLI/MCP fail-closed tenant context (#1554)', () => {
       const { join } = await import('node:path');
       const dir = await generateInto(true);
       const handlers = await readFile(
-        join(dir, 'handlers', 'index.ts'),
+        join(dir, 'handlers', 'index.js'),
         'utf-8',
       );
       expect(handlers).toContain('enableTenancy()');


### PR DESCRIPTION
Closes #2279.

All three defects were reproduced by running the documented happy path against
`origin/main`, and each fix is verified the same way — by executing the output,
not by reading it.

## 1. `generate-mcp` emitted TypeScript into a `.js` path

`MCPGenerator` builds its output as TypeScript (type-only imports, annotations,
generics) and wrote it verbatim wherever the caller pointed, so the file the CLI
told you to run died with `SyntaxError: Unexpected identifier 'CallToolRequest'`.

**Chosen fix: transpile when the target is JavaScript**, not "default the output
to `.ts`". The extension is now authoritative — `.ts`/`.mts`/`.cts` keeps the
annotated source for `tsx` or Node type stripping (what
`packages/mcp-conformance-fixture` already does), anything else is transpiled
with the `typescript` package `@happyvertical/smrt-core` already depends on,
imported lazily.

Why this way:

- It keeps `.smrt/mcp-server/index.js` working as the default. Everything
  downstream already points there — the printed `"mcp": "node …"` script, the
  generated `claude-config.example.json`, the sveltekit template README, users'
  existing package.json scripts. Moving the default to `.ts` would have made all
  of those wrong instead, and would have pushed a Node-version/type-stripping
  requirement onto every consumer's runtime.
- No new dependency and no experimental Node API.
- Asking for `.ts` still gets you TypeScript, so the typed workflow is not lost.

`--modular` had the same defect plus two more, all of which made its output
unloadable in every project:

- sibling modules were written as `config.ts` / `tools/index.ts` /
  `handlers/index.ts` while the generated entry imported `./config.js` etc. Both
  the file names and the specifiers now follow the entry's own extension, and the
  entry is written at the requested path instead of a hardcoded `index.js`.
- the generated `handleToolCall` declared a parameter literally named
  `arguments`, which is illegal in any ES module (and in TypeScript modules) —
  renamed to `toolArguments`.
- the generated entry imported `getDatabase` from `@happyvertical/sql` and
  `getAI` from `@happyvertical/ai` and used neither, so it failed to resolve in
  any consumer that does not depend on both.

Verified end to end from a package with no local edits: `generate-mcp` (single
file and `--modular`), then `node <generated entry>` completing an MCP
`initialize` handshake.

## 2. `--version` was swallowed before subcommand dispatch

`parseCliArgs` in `@happyvertical/utils` returns the built-in `version` command
for a `--version` token anywhere in argv, so `smrt generate-mcp --version 0.1.0`
never reached the command that declares the option.

**`@happyvertical/utils` is an external published package and is not fixable
here**, so the precedence is applied in `packages/cli`'s own
`parseCliCommandArgs` wrapper instead: once a leading token names a subcommand,
a following `--version` is rescoped to a private alias, parsed under the
subcommand's own declared option (keeping its type, default, and short flag),
and mapped back onto `version` before any handler runs. A `--version` that
appears before or without a subcommand — and one after a `--` terminator — still
prints the CLI version.

`--help` is deliberately left alone: `smrt <cmd> --help` showing help is what
someone typing it wants.

One intentional behaviour change: `smrt <cmd> --version` on a command that does
*not* declare the option now runs the command (with an ignored `version: true`)
rather than printing the CLI version. That is the stated precedence rule, and it
is recorded in `packages/cli/AGENTS.md`.

## 3. README documented command names that do not exist

`packages/cli/README.md` used `smrt generate:mcp` and `smrt generate:types`;
neither is registered, and both error with `Unknown command`. This is an
inconsistency rather than uniform staleness — `generate-routes` and
`generate-register` really do declare colon aliases — so the README (and the
same stale line in `packages/cli/AGENTS.md`) now lists each registered name with
its actual aliases. No colon aliases were added: whether `generate-mcp` and
`generate-types` should gain them is a naming decision worth its own issue, not
a silent expansion of this one.

## Drive-by fixes

- `packages/core/src/generators/mcp.ts`: removed the two unused
  `@happyvertical/sql` / `@happyvertical/ai` imports from the generated modular
  entry (2 lines), and renamed the generated `arguments` parameter. Both were
  found while executing the modular output for defect 1 and are the same "the
  generated server cannot run" defect, so they ship here rather than as a new
  cycle.

## Tests

- `packages/core/src/generators/mcp-emit.test.ts` (new): the emitted `.js`
  server is parsed with `node --check` on a `.mjs` copy — the exact failure from
  the issue, as a parse-only check that never executes the file. Covers the
  single-file and modular outputs, the `.ts` passthrough, the modular specifier
  and dead-import contract, and the `claude-config.example.json` pointing at the
  file that was actually generated.
- `packages/cli/src/__tests__/cli-generator-coverage.test.ts`: parser-level
  regressions for `--version` — space and inline forms, aliases, declared
  defaults, the lazily-loaded built-in path, full `process.argv` input, and the
  global/`--`/`--help` cases that must not change.
- `packages/cli/src/__tests__/generate-mcp-dispatch.test.ts` (new): drives the
  real handler end to end and asserts the generated server carries the requested
  version.
- Existing MCP generator tests updated for the modular extensions; assertions
  that pinned TypeScript annotations in `.js` output were replaced rather than
  deleted.

## Review round two

Automated review of the first head found three more ways the generated output
could still fail to load. All three are fixed in the follow-up commit:

- A `.cjs`/`.cts` output path is now rejected. The generated server uses
  `import` and `import.meta.url`, so no CommonJS target can run in either
  language; failing loudly beats writing a file that cannot load.
- Modular sibling modules take the entry point's *own* extension rather than a
  two-valued language, so an `.mjs` entry gets `.mjs` siblings and matching
  specifiers instead of `.js` files a CommonJS package would misparse.
- The generated task-extension transport assigns its field explicitly instead of
  using a TypeScript parameter property, which Node's strip-only type stripping
  cannot transform. A `.ts` target is now erasable-syntax-only, pinned by a test
  that runs the task-action bootstrap through `node:module`'s
  `stripTypeScriptTypes` — which throws on parameter properties, so the
  assertion is not vacuous.

A fourth finding is real but out of scope: `packages/template-sveltekit` does not
declare `@modelcontextprotocol/server` or `@happyvertical/smrt-config`, which the
generated entry imports, so pnpm's strict layout cannot resolve them from a
scaffolded app. That is a dependency change to a published template, so it is
filed as #2297; the CLI README now states which packages the generated server
needs at runtime.

## Follow-up (not in this PR)

happyvertical/s-m-r-t.dev PR #154 documents workarounds for these defects.
Once this lands, that repo's `AGENTS.md` entry and its
`/guides/expose-your-app-over-mcp` task guide should be updated to drop the
workarounds. That repo is intentionally untouched here.

The four lower-priority stale documentation claims mentioned at the end of
#2279 (`smrt-app-mcp`, `smrt-app-cli`, `docs/content/core.md`) are not addressed
here; they need the detail from the site PR body to fix accurately.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude-code","session":"94a9e688-edcb-4e84-97a8-16a221e3e7f1","issue":2279,"policy_revision":"1.0.0","status":"complete","validation":["smrt-core generator suite 327 passed; full smrt-core 3181 passed / 45 skipped","smrt-cli tests 807 passed / 6 skipped","smrt-tenancy tests 135 passed","smrt-mcp-conformance-fixture tests 6 passed (generated .ts server driven by a real MCP client)","root pnpm test 123/123 turbo tasks on the final head","root pnpm typecheck 122/122 and pnpm build 62/62 on the final head","coverage gate cli 90.01% / core 86.14% / tenancy 85.49% against the T1 80% floor","knowledge freshness, agents-chain, and MCP protocol hygiene clean","biome check clean on changed files, repo warning baseline unchanged","manual: generate-mcp single-file and --modular executed, node completed an MCP initialize handshake against both","review-cycle plus two automated review rounds; every actionable finding fixed or filed as #2297"]}
```
