### PR TITLE
fix(scanner,dev-mcp): make knowledge discovery terminate in a consumer app

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -15,8 +15,9 @@ smrt db:rollback             # Rollback migrations
 smrt docs:agents             # Generate .agents/smrt-framework.md
 smrt docs:claude             # Deprecated alias writing .claude/smrt-framework.md
 smrt dev:knowledge-*         # Deterministic agent knowledge index/check/diff
+smrt dev:knowledge-index --scope installed # Installed @happyvertical/* deps, versions, AGENTS.md hashes
 smrt knowledge:review-context --scope package --package <name>
-smrt knowledge:architecture-context --scope project|local|package|sdk
+smrt knowledge:architecture-context --scope project|local|package|sdk|installed
 smrt dev:knowledge-check --format markdown|json
 smrt generate:mcp            # Generate MCP server
 smrt config:export           # Export agent config for SSG

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -95,8 +95,8 @@ the tracker or writing to the database.
 | `smrt dev:knowledge-index --format markdown\|json` | Print the deterministic s-m-r-t + SDK knowledge index |
 | `smrt dev:knowledge-check --format markdown\|json` | Check agent knowledge freshness |
 | `smrt dev:knowledge-diff --format markdown\|json` | Show changed files and affected package experts |
-| `smrt knowledge:review-context --scope project\|local\|package\|sdk --package <name> --format markdown\|json` | Build a model-ready domain review prompt bundle |
-| `smrt knowledge:architecture-context --scope project\|local\|package\|sdk --package <name> --format markdown\|json` | Build a model-ready domain architecture prompt bundle |
+| `smrt knowledge:review-context --scope project\|local\|package\|sdk\|installed --package <name> --format markdown\|json` | Build a model-ready domain review prompt bundle |
+| `smrt knowledge:architecture-context --scope project\|local\|package\|sdk\|installed --package <name> --format markdown\|json` | Build a model-ready domain architecture prompt bundle |
 
 ### Configuration
 

--- a/packages/cli/src/commands/dev-knowledge.ts
+++ b/packages/cli/src/commands/dev-knowledge.ts
@@ -68,7 +68,8 @@ export const devKnowledgeCommands: Record<string, CLICommand> = {
       },
       scope: {
         type: 'string',
-        description: 'Knowledge scope: project, local, package, or sdk',
+        description:
+          'Knowledge scope: project, local, package, sdk, or installed',
         default: 'project',
       },
       package: {
@@ -118,7 +119,8 @@ export const devKnowledgeCommands: Record<string, CLICommand> = {
       },
       scope: {
         type: 'string',
-        description: 'Knowledge scope: project, local, package, or sdk',
+        description:
+          'Knowledge scope: project, local, package, sdk, or installed',
         default: 'project',
       },
       package: {
@@ -168,7 +170,8 @@ export const devKnowledgeCommands: Record<string, CLICommand> = {
       },
       scope: {
         type: 'string',
-        description: 'Knowledge scope: project, local, package, or sdk',
+        description:
+          'Knowledge scope: project, local, package, sdk, or installed',
         default: 'project',
       },
       package: {
@@ -262,7 +265,8 @@ function contextOptions(
     },
     scope: {
       type: 'string',
-      description: 'Knowledge scope: project, local, package, or sdk',
+      description:
+        'Knowledge scope: project, local, package, sdk, or installed',
       default: 'project',
     },
     package: {

--- a/packages/core/src/manifest/__tests__/generator-discovery-bounds.test.ts
+++ b/packages/core/src/manifest/__tests__/generator-discovery-bounds.test.ts
@@ -1,0 +1,41 @@
+import { resolve } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const discoverSourceFiles = vi.hoisted(() => vi.fn(async () => [] as string[]));
+
+vi.mock('../../utils/import-workspace-module.js', () => ({
+  importWorkspaceModule: vi.fn(async () => ({ discoverSourceFiles })),
+}));
+
+import { ManifestBuilder } from '../generator.js';
+
+describe('ManifestBuilder discovery bounds', () => {
+  beforeEach(() => {
+    discoverSourceFiles.mockClear();
+  });
+
+  it('applies the scanner discovery bounds to its preflight glob', async () => {
+    const cwd = resolve(process.cwd());
+    const absoluteInclude = resolve(cwd, 'src/**/*.ts');
+
+    await new ManifestBuilder().generate({
+      include: [absoluteInclude],
+      exclude: [],
+    });
+
+    expect(discoverSourceFiles).toHaveBeenCalledWith({
+      cwd,
+      include: [absoluteInclude],
+      exclude: [],
+      followSymbolicLinks: false,
+    });
+  });
+
+  it('passes an explicit symlink opt-in to its preflight glob', async () => {
+    await new ManifestBuilder().generate({ followSymbolicLinks: true });
+
+    expect(discoverSourceFiles).toHaveBeenCalledWith(
+      expect.objectContaining({ followSymbolicLinks: true }),
+    );
+  });
+});

--- a/packages/core/src/manifest/generator.ts
+++ b/packages/core/src/manifest/generator.ts
@@ -42,6 +42,11 @@ export interface ManifestBuilderOptions {
   include?: string[];
   exclude?: string[];
   followImports?: boolean;
+  /**
+   * Follow symbolic links while discovering sources. Defaults to `false` —
+   * see `OxcScannerOptions.followSymbolicLinks` (#2275).
+   */
+  followSymbolicLinks?: boolean;
 
   // Scanner Configuration
   baseClasses?: string[];
@@ -276,6 +281,7 @@ export class ManifestBuilder {
       includePrivateMethods: config.includePrivateMethods,
       includeStaticMethods: config.includeStaticMethods,
       followImports: config.followImports,
+      followSymbolicLinks: options.followSymbolicLinks,
     });
 
     const { results, resolved } = await scanner.scanAndResolve();

--- a/packages/core/src/manifest/generator.ts
+++ b/packages/core/src/manifest/generator.ts
@@ -6,7 +6,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, isAbsolute, relative, resolve } from 'node:path';
 import { createLogger } from '@happyvertical/logger';
-import fg from 'fast-glob';
 import { ManifestGenerator } from '../scanner/manifest-generator.js';
 import type { SmartObjectManifest } from '../scanner/types.js';
 import { MANIFEST_TIMESTAMP } from '../scanner/types.js';
@@ -129,7 +128,7 @@ export class ManifestBuilder {
     options: ManifestBuilderOptions = {},
   ): Promise<SmartObjectManifest> {
     // 1. Discover files to scan
-    const files = this.discoverFiles(options);
+    const files = await this.discoverFiles(options);
 
     if (files.length === 0) {
       logger.info('[smrt] No source files found');
@@ -196,13 +195,17 @@ export class ManifestBuilder {
   /**
    * Discover source files based on include/exclude patterns
    */
-  private discoverFiles(options: ManifestBuilderOptions): string[] {
+  private async discoverFiles(
+    options: ManifestBuilderOptions,
+  ): Promise<string[]> {
     const include = options.include || ['src/**/*.ts'];
     const exclude = options.exclude || ['src/**/*.d.ts', 'node_modules/**'];
-
-    return fg.sync(include, {
-      absolute: true,
-      ignore: exclude,
+    const { discoverSourceFiles } = await importScanner();
+    return discoverSourceFiles({
+      cwd: process.cwd(),
+      include,
+      exclude,
+      followSymbolicLinks: options.followSymbolicLinks ?? false,
     });
   }
 

--- a/packages/core/src/utils/scanner-module.ts
+++ b/packages/core/src/utils/scanner-module.ts
@@ -42,4 +42,10 @@ export interface ManifestAdapterLike {
 export interface ScannerModule {
   OxcScanner: OxcScannerConstructor;
   ManifestAdapter: new () => ManifestAdapterLike;
+  discoverSourceFiles(options: {
+    cwd: string;
+    include: string[];
+    exclude: string[];
+    followSymbolicLinks?: boolean;
+  }): Promise<string[]>;
 }

--- a/packages/core/src/utils/scanner-module.ts
+++ b/packages/core/src/utils/scanner-module.ts
@@ -24,6 +24,7 @@ export interface OxcScannerConstructor {
     includePrivateMethods?: boolean;
     includeStaticMethods?: boolean;
     followImports?: boolean;
+    followSymbolicLinks?: boolean;
   }): OxcScannerLike;
 }
 

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -76,6 +76,13 @@ export interface SmrtPluginOptions {
   include?: string[];
   /** Patterns to exclude */
   exclude?: string[];
+  /**
+   * Follow symbolic links while discovering sources. Defaults to `false`: a
+   * pnpm `node_modules` is a symlink graph with cycles, so a link-following
+   * walk does not terminate on a real install (#2275). Enable it only for a
+   * project that genuinely keeps sources behind a link.
+   */
+  followSymbolicLinks?: boolean;
   /** Output directory for generated files */
   outDir?: string;
   /** Enable hot module replacement */
@@ -210,6 +217,7 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
     projectRoot: configuredProjectRoot,
     include = ['src/**/*.ts', 'src/**/*.js'],
     exclude = ['**/*.test.ts', '**/*.spec.ts', '**/node_modules/**'],
+    followSymbolicLinks = false,
     hmr = true,
     watch = true,
     generateTypes = true,
@@ -1024,6 +1032,7 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
         cwd: rootDir,
         include,
         exclude: safeExclude,
+        followSymbolicLinks,
       });
 
       // Scan and resolve inheritance

--- a/packages/scanner/AGENTS.md
+++ b/packages/scanner/AGENTS.md
@@ -27,6 +27,29 @@ executes the source.
   `ScanResults`, `FileScanResult`, `OxcScannerOptions`, `InferredFieldType`,
   `FieldTypeInference`.
 
+## Discovery boundaries
+
+File discovery is the difference between a scan that finishes and one that
+exhausts the heap when the scanner is pointed at an application root (#2275):
+
+- `dot: true` is set so ignore patterns apply beneath dot directories. Without
+  it a `**` cannot cross a dot segment, so `**/node_modules/**` pruned the root
+  `node_modules` but nothing under `.svelte-kit/`, `.vercel/`, or `.turbo/`.
+- `MANDATORY_EXCLUDE` (`**/node_modules/**`, `**/.*/**`, `**/.*`) is unioned with the
+  caller's `exclude` and cannot be overridden. `exclude` REPLACES the defaults,
+  so every caller that narrowed it had silently reopened `node_modules`.
+- `followSymbolicLinks` defaults to `false`. A pnpm `node_modules` is a symlink
+  graph with cycles, not a tree, so a link-following walk reaches the same real
+  directory once per path leading to it. This drops symlinked *files* as well as
+  directories, so pass `followSymbolicLinks: true` for a project that genuinely
+  keeps sources behind a link — it is threaded through `smrtPlugin` and
+  `ManifestBuilderOptions` for the build path.
+- Patterns are rewritten relative to `cwd` before globbing. Globs match as text,
+  so an absolute pattern would hand `**/.*/**` the project's own ancestors and a
+  checkout under `~/.worktrees` or `~/.cache` would match nothing at all.
+- `dot: true` would otherwise widen the result to hidden files, so `**/.*` is in
+  the mandatory prunes too: hidden files stay out, exactly as before.
+
 ## How It Works
 
 1. `fast-glob` finds `.ts` files matching include/exclude patterns.

--- a/packages/scanner/AGENTS.md
+++ b/packages/scanner/AGENTS.md
@@ -22,6 +22,8 @@ executes the source.
   and asserts every `@smrt()` object reached `dist/manifest.json` (issue #1483).
   Returns `ok` / `incomplete` / `missing-manifest` / `scan-error` / `skipped`.
   Driven by `scripts/verify-manifest-completeness.mjs` from `prepack`.
+- `discoverSourceFiles(options)` — shared bounded source-discovery policy used
+  by `OxcScanner` and the core manifest preflight.
 - Types (re-exported from `./types`): `RawClassDefinition`,
   `RawFieldDefinition`, `RawMethodDefinition`, `ResolvedClassDefinition`,
   `ScanResults`, `FileScanResult`, `OxcScannerOptions`, `InferredFieldType`,
@@ -35,9 +37,10 @@ exhausts the heap when the scanner is pointed at an application root (#2275):
 - `dot: true` is set so ignore patterns apply beneath dot directories. Without
   it a `**` cannot cross a dot segment, so `**/node_modules/**` pruned the root
   `node_modules` but nothing under `.svelte-kit/`, `.vercel/`, or `.turbo/`.
-- `MANDATORY_EXCLUDE` (`**/node_modules/**`, `**/.*/**`, `**/.*`) is unioned with the
-  caller's `exclude` and cannot be overridden. `exclude` REPLACES the defaults,
-  so every caller that narrowed it had silently reopened `node_modules`.
+- Mandatory excludes (`**/node_modules/**`, `**/.*/**`, `**/.*`) are unioned
+  with the caller's `exclude` and cannot be overridden. `exclude` REPLACES the
+  defaults, so every caller that narrowed it had silently reopened
+  `node_modules`.
 - `followSymbolicLinks` defaults to `false`. A pnpm `node_modules` is a symlink
   graph with cycles, not a tree, so a link-following walk reaches the same real
   directory once per path leading to it. This drops symlinked *files* as well as
@@ -66,6 +69,7 @@ exhausts the heap when the scanner is pointed at an application root (#2275):
   `parseSource`, `extractSmrtImports`, field/decorator/type extractors).
 - `src/scanner.ts` — `OxcScanner`: globbing + multi-file orchestration
   (`scan` / `scanAndResolve`).
+- `src/discovery.ts` — shared bounded glob policy for every scanner entry point.
 - `src/inheritance-resolver.ts` — `InheritanceResolver`: cross-file inheritance
   merging.
 - `src/manifest-adapter.ts` — `ManifestAdapter`: raw → manifest conversion and

--- a/packages/scanner/src/__tests__/scanner-discovery-bounds.test.ts
+++ b/packages/scanner/src/__tests__/scanner-discovery-bounds.test.ts
@@ -1,0 +1,205 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { OxcScanner } from '../scanner.js';
+
+/**
+ * Discovery must terminate and stay proportional to a project's own sources
+ * when the scanner is pointed at an application root (#2275).
+ *
+ * Two settings are load-bearing and were both wrong:
+ *
+ * 1. `dot`. Without it a `**` cannot cross a dot segment, so
+ *    `**\/node_modules/**` pruned `node_modules` at the root but nothing
+ *    beneath `.svelte-kit/`, `.vercel/`, or any other dot directory. Those
+ *    subtrees were walked in full and every entry then discarded, because the
+ *    positive patterns could not match there either.
+ * 2. `followSymbolicLinks`. A pnpm `node_modules` is a symlink graph with
+ *    cycles rather than a tree, so a link-following walk reaches the same real
+ *    directory once per path leading to it — and never finishes.
+ *
+ * The cyclic fixtures below hang forever on the old behaviour, which is the
+ * failure this regression guards. An output assertion alone could not catch it:
+ * the runaway traversal produced no extra matches, only unbounded work.
+ */
+describe('OxcScanner file discovery bounds', () => {
+  let dir: string;
+
+  function write(rel: string, source: string): void {
+    const full = join(dir, rel);
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(full, source);
+  }
+
+  function writeSmrtClass(rel: string, className: string): void {
+    write(
+      rel,
+      `import { smrt, SmrtObject } from '@happyvertical/smrt-core';\n@smrt()\nexport class ${className} extends SmrtObject { name = ''; }\n`,
+    );
+  }
+
+  /**
+   * A pnpm-shaped store: each materialized package carries links to every
+   * sibling, so descending into one package leads straight into the next and
+   * the graph closes on itself exactly as a real store does.
+   *
+   * Branching is the point. A self-referential link is harmless — the kernel
+   * stops resolving it after MAXSYMLINKS hops — but a clique multiplies into
+   * `siblings ** MAXSYMLINKS` distinct paths to the same real directories,
+   * which is unbounded in every practical sense.
+   *
+   * @param packageDir - Where the store materializes `<name>`, relative to the
+   *   fixture root. Varying this is how the same graph gets tested both inside
+   *   and outside a `node_modules` path.
+   */
+  function writeSymlinkClique(
+    names: string[],
+    packageDir: (name: string) => string,
+  ): void {
+    for (const name of names) {
+      write(
+        join(packageDir(name), 'package.json'),
+        JSON.stringify({ name: `@happyvertical/${name}`, version: '1.0.0' }),
+      );
+      write(
+        join(packageDir(name), 'index.ts'),
+        `export const ${name.replaceAll('-', '_')} = 1;\n`,
+      );
+      mkdirSync(join(dir, packageDir(name), 'links'), { recursive: true });
+    }
+    for (const name of names) {
+      for (const sibling of names.filter((other) => other !== name)) {
+        symlinkSync(
+          join(dir, packageDir(sibling)),
+          join(dir, packageDir(name), 'links', sibling),
+        );
+      }
+    }
+  }
+
+  const pnpmStorePath = (prefix: string) => (name: string) =>
+    join(
+      prefix,
+      'node_modules',
+      '.pnpm',
+      `@happyvertical+${name}@1.0.0`,
+      'node_modules',
+      '@happyvertical',
+      name,
+    );
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'smrt-scanner-bounds-'));
+    writeSmrtClass('src/widget.ts', 'Widget');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('prunes node_modules and dot directories even when a caller empties exclude', async () => {
+    // `exclude` REPLACES the defaults, so a caller that narrows it used to
+    // reopen `node_modules`; and `dot: true` alone would make generated and
+    // tool state discoverable. Both prunes have to survive `exclude: []`.
+    writeSmrtClass(
+      'node_modules/@happyvertical/smrt-x/src/model.ts',
+      'Vendored',
+    );
+    writeSmrtClass('.agent-scratch/checkout/src/ghost.ts', 'Ghost');
+    writeSmrtClass('.svelte-kit/generated/shadow.ts', 'Shadow');
+    writeSmrtClass('src/.hidden.ts', 'Hidden');
+
+    const scanner = new OxcScanner({ cwd: dir, exclude: [] });
+    const { resolved } = await scanner.scanAndResolve();
+
+    expect(resolved.map((entry) => entry.className)).toEqual(['Widget']);
+  });
+
+  it('does not follow a symlinked directory back into itself', async () => {
+    // The cheap, deterministic half of the symlink guard: the kernel stops a
+    // self-referential link after MAXSYMLINKS, so the pre-fix walk terminated
+    // here — with one copy of the same file per hop.
+    symlinkSync(join(dir, 'src'), join(dir, 'src', 'loop'));
+
+    const { results, resolved } = await new OxcScanner({
+      cwd: dir,
+    }).scanAndResolve();
+
+    expect(results.fileCount).toBe(1);
+    expect(resolved.map((entry) => entry.className)).toEqual(['Widget']);
+  });
+
+  it('rewrites absolute include patterns so the dot prune cannot swallow them', async () => {
+    // A checkout under `~/.worktrees` or `~/.cache` matched by an absolute
+    // pattern would otherwise hand `**\/.*\/**` its own ancestors and discover
+    // nothing at all, silently.
+    const nested = join(dir, '.worktrees', 'app');
+    mkdirSync(join(nested, 'src'), { recursive: true });
+    writeSmrtClass('.worktrees/app/src/nested.ts', 'Nested');
+
+    const { resolved } = await new OxcScanner({
+      cwd: nested,
+      include: [`${nested}/**/*.ts`],
+    }).scanAndResolve();
+
+    expect(resolved.map((entry) => entry.className)).toEqual(['Nested']);
+  });
+
+  it('terminates on a cyclic pnpm store beneath a dot directory', async () => {
+    writeSymlinkClique(
+      ['smrt-a', 'smrt-b', 'smrt-c', 'smrt-d'],
+      pnpmStorePath('.agent-scratch/checkout'),
+    );
+
+    const scanner = new OxcScanner({ cwd: dir });
+    const { results, resolved } = await scanner.scanAndResolve();
+
+    expect(resolved.map((entry) => entry.className)).toEqual(['Widget']);
+    expect(results.fileCount).toBe(1);
+    // Bounded deliberately: a regression here does not fail, it never returns,
+    // and an unbounded wait would take the rest of the suite down with it.
+  }, 5000);
+
+  it('terminates on a cyclic symlink graph outside node_modules', async () => {
+    // Termination must not depend on a path segment being named
+    // `node_modules`: a vendored checkout, a workspace link, or an agent
+    // worktree can close the same loop anywhere in the tree.
+    writeSymlinkClique(['dep-a', 'dep-b', 'dep-c', 'dep-d'], (name) =>
+      join('vendor', name),
+    );
+
+    const scanner = new OxcScanner({ cwd: dir });
+    const { resolved } = await scanner.scanAndResolve();
+
+    expect(resolved.map((entry) => entry.className)).toEqual(['Widget']);
+  }, 5000);
+
+  it('still reaches symlinked sources when a caller opts in', async () => {
+    // Link following is opt-in rather than removed: a project that really does
+    // keep sources behind a link can ask for them, and accepts the cost.
+    mkdirSync(join(dir, 'external'), { recursive: true });
+    writeSmrtClass('external/models/linked.ts', 'Linked');
+    symlinkSync(join(dir, 'external', 'models'), join(dir, 'src', 'linked'));
+
+    const strict = await new OxcScanner({
+      cwd: join(dir, 'src'),
+    }).scanAndResolve();
+    expect(strict.resolved.map((entry) => entry.className)).toEqual(['Widget']);
+
+    const permissive = await new OxcScanner({
+      cwd: join(dir, 'src'),
+      followSymbolicLinks: true,
+    }).scanAndResolve();
+    expect(permissive.resolved.map((entry) => entry.className).sort()).toEqual([
+      'Linked',
+      'Widget',
+    ]);
+  });
+});

--- a/packages/scanner/src/__tests__/scanner-discovery-bounds.test.ts
+++ b/packages/scanner/src/__tests__/scanner-discovery-bounds.test.ts
@@ -8,6 +8,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { normalizeGlobSeparators, relativeGlobToCwd } from '../discovery.js';
 import { OxcScanner } from '../scanner.js';
 
 /**
@@ -150,6 +151,33 @@ describe('OxcScanner file discovery bounds', () => {
     }).scanAndResolve();
 
     expect(resolved.map((entry) => entry.className)).toEqual(['Nested']);
+  });
+
+  it('preserves escapes in relative glob patterns', async () => {
+    writeSmrtClass('src/routes/[id]/model.ts', 'EscapedRoute');
+
+    const { resolved } = await new OxcScanner({
+      cwd: dir,
+      include: ['src/routes/\\[id\\]/**/*.ts'],
+    }).scanAndResolve();
+
+    expect(resolved.map((entry) => entry.className)).toEqual(['EscapedRoute']);
+  });
+
+  it('normalizes Windows separators only after an absolute glob is rewritten', () => {
+    expect(normalizeGlobSeparators('src\\**\\*.ts', '\\')).toBe('src/**/*.ts');
+    expect(normalizeGlobSeparators('src/routes/\\[id\\]/**/*.ts', '/')).toBe(
+      'src/routes/\\[id\\]/**/*.ts',
+    );
+    expect(
+      relativeGlobToCwd('C:/repo/src/routes/\\[id\\]/**/*.ts', 'C:\\repo'),
+    ).toBe('src/routes/\\[id\\]/**/*.ts');
+    expect(relativeGlobToCwd('C:\\other\\**\\*.ts', 'C:\\repo')).toBe(
+      'C:/other/**/*.ts',
+    );
+    expect(
+      relativeGlobToCwd('C:/other/routes/\\[id\\]/**/*.ts', 'C:\\repo'),
+    ).toBe('C:/other/routes/\\[id\\]/**/*.ts');
   });
 
   it('terminates on a cyclic pnpm store beneath a dot directory', async () => {

--- a/packages/scanner/src/discovery.ts
+++ b/packages/scanner/src/discovery.ts
@@ -1,0 +1,85 @@
+import { isAbsolute, resolve, sep, win32 } from 'node:path';
+import fg from 'fast-glob';
+
+const MANDATORY_DISCOVERY_EXCLUDES: readonly string[] = Object.freeze([
+  '**/node_modules/**',
+  '**/.*/**',
+  '**/.*',
+]);
+
+export interface SourceDiscoveryOptions {
+  cwd: string;
+  include: string[];
+  exclude: string[];
+  followSymbolicLinks?: boolean;
+}
+
+/**
+ * Discover authored source files with the bounded policy shared by every
+ * scanner entry point, including ManifestBuilder's preflight (#2275).
+ */
+export async function discoverSourceFiles(
+  options: SourceDiscoveryOptions,
+): Promise<string[]> {
+  const cwd = resolve(options.cwd);
+  return fg(
+    options.include.map((pattern) => relativeGlobToCwd(pattern, cwd)),
+    {
+      cwd,
+      ignore: [
+        ...options.exclude.map((pattern) => relativeGlobToCwd(pattern, cwd)),
+        ...MANDATORY_DISCOVERY_EXCLUDES,
+      ],
+      absolute: true,
+      onlyFiles: true,
+      dot: true,
+      followSymbolicLinks: options.followSymbolicLinks ?? false,
+    },
+  );
+}
+
+/** Preserve relative glob escapes; normalize separators only after rewriting. */
+export function relativeGlobToCwd(pattern: string, cwd: string): string {
+  const windowsAbsolute = win32.isAbsolute(pattern);
+  if (!isAbsolute(pattern) && !windowsAbsolute) return pattern;
+
+  const cwdVariants = [
+    cwd,
+    cwd.replaceAll('\\', '/'),
+    cwd.replaceAll('/', '\\'),
+  ];
+  for (const prefix of new Set(cwdVariants)) {
+    const comparablePattern = windowsAbsolute ? pattern.toLowerCase() : pattern;
+    const comparablePrefix = windowsAbsolute ? prefix.toLowerCase() : prefix;
+    if (comparablePattern === comparablePrefix) return '.';
+
+    const boundary = pattern.charAt(prefix.length);
+    if (
+      comparablePattern.startsWith(comparablePrefix) &&
+      (boundary === '/' || boundary === '\\')
+    ) {
+      const rewritten = pattern.slice(prefix.length + 1);
+      // A slash-authored glob can contain meaningful backslash escapes such as
+      // `\\[id\\]`; only native Windows path syntax needs separator rewriting.
+      return boundary === '\\'
+        ? normalizeGlobSeparators(rewritten, '\\')
+        : rewritten;
+    }
+  }
+
+  // fast-glob requires slash separators even when an absolute pattern points
+  // outside cwd and therefore cannot be made relative.
+  const slashAuthoredWindows = /^[A-Za-z]:\//.test(pattern);
+  return windowsAbsolute && !slashAuthoredWindows
+    ? normalizeGlobSeparators(pattern, '\\')
+    : pattern;
+}
+
+export function normalizeGlobSeparators(
+  pattern: string,
+  pathSeparator = sep,
+): string {
+  return pathSeparator === '/'
+    ? pattern
+    : pattern.replaceAll(pathSeparator, '/');
+}

--- a/packages/scanner/src/index.ts
+++ b/packages/scanner/src/index.ts
@@ -18,6 +18,12 @@
  * ```
  */
 
+export {
+  discoverSourceFiles,
+  normalizeGlobSeparators,
+  relativeGlobToCwd,
+  type SourceDiscoveryOptions,
+} from './discovery.js';
 export { InheritanceResolver } from './inheritance-resolver.js';
 export { ManifestAdapter } from './manifest-adapter.js';
 export { extractSmrtImports, parseFile, parseSource } from './oxc-parser.js';

--- a/packages/scanner/src/scanner.ts
+++ b/packages/scanner/src/scanner.ts
@@ -5,7 +5,7 @@
  * Provides a simple API for scanning TypeScript files for SMRT classes.
  */
 
-import { resolve } from 'node:path';
+import { isAbsolute, resolve } from 'node:path';
 import fg from 'fast-glob';
 import { InheritanceResolver } from './inheritance-resolver.js';
 import { parseFile } from './oxc-parser.js';
@@ -30,6 +30,22 @@ const DEFAULT_EXCLUDE = [
   '**/*.spec.ts',
   '**/__tests__/**',
 ];
+
+/**
+ * Prunes that always apply, on top of whatever `exclude` a caller passes.
+ *
+ * `exclude` replaces {@link DEFAULT_EXCLUDE} wholesale, so every caller that
+ * narrowed the excludes also silently reopened `node_modules` — and installed
+ * dependencies are never a project's own `@smrt()` sources. Dot directories are
+ * generated or tool state (`.git`, `.svelte-kit`, `.turbo`, `.vercel`, agent
+ * scratch) and are pruned for the same reason: nothing authored lives there.
+ * `**\/.*` keeps hidden FILES out of the result too, so turning `dot` on to
+ * make these prunes work does not quietly widen what gets scanned.
+ *
+ * These are load-bearing for termination, not just for speed. See
+ * {@link OxcScanner.discoverFiles}.
+ */
+const MANDATORY_EXCLUDE = ['**/node_modules/**', '**/.*/**', '**/.*'];
 
 /**
  * High-performance TypeScript scanner that discovers `@smrt()`-decorated
@@ -85,6 +101,7 @@ export class OxcScanner {
       includePrivateMethods: options.includePrivateMethods ?? false,
       includeStaticMethods: options.includeStaticMethods ?? true,
       externalManifests: options.externalManifests || new Map(),
+      followSymbolicLinks: options.followSymbolicLinks ?? false,
     };
 
     this.resolver = new InheritanceResolver({
@@ -294,16 +311,44 @@ export class OxcScanner {
   }
 
   /**
-   * Discover files to scan using fast-glob
+   * Discover files to scan using fast-glob.
+   *
+   * Two settings here decide whether discovery terminates at all when the
+   * scanner is pointed at an application root rather than a package `src/`:
+   *
+   * - `dot: true`. Without it a `**` in an ignore pattern cannot cross a
+   *   dot segment, so `**\/node_modules/**` prunes `node_modules` at the root
+   *   but NOT `.svelte-kit/…/node_modules` or any other `node_modules` under a
+   *   dot directory. Those subtrees were then walked in full and every entry
+   *   discarded — unbounded work that could never produce a match.
+   * - `followSymbolicLinks: false`. pnpm materializes `node_modules` as a
+   *   symlink graph with cycles, so a link-following walk revisits the same
+   *   real directories once per path that reaches them.
+   *
+   * Together they were enough to exhaust a 4 GB heap on a consumer app that
+   * installs the published packages (#2275).
+   *
+   * Patterns are rewritten relative to `cwd` first. fast-glob matches `ignore`
+   * in whatever space the patterns use, so an absolute pattern would hand
+   * `**\/.*\/**` the project's own ancestors — a checkout under `~/.worktrees`
+   * or `~/.cache` would then match nothing at all, silently.
    */
   private async discoverFiles(): Promise<string[]> {
-    const patterns = this.options.include;
+    const cwd = resolve(this.options.cwd);
+    const patterns = this.options.include.map((pattern) =>
+      relativeToCwd(pattern, cwd),
+    );
 
     const files = await fg(patterns, {
-      cwd: this.options.cwd,
-      ignore: this.options.exclude,
+      cwd,
+      ignore: [
+        ...this.options.exclude.map((pattern) => relativeToCwd(pattern, cwd)),
+        ...MANDATORY_EXCLUDE,
+      ],
       absolute: true,
       onlyFiles: true,
+      dot: true,
+      followSymbolicLinks: this.options.followSymbolicLinks,
     });
 
     return files;
@@ -316,6 +361,23 @@ export class OxcScanner {
     // parseFile is synchronous but we wrap it for potential future async
     return parseFile(filePath);
   }
+}
+
+/**
+ * Rewrites an absolute pattern rooted inside `cwd` as a `cwd`-relative one.
+ *
+ * Globs are matched as text, so a pattern's leading directories become part of
+ * every comparison — including the mandatory prunes. Patterns outside `cwd` are
+ * left alone: nothing sensible can be said about them relative to a root they
+ * do not live under.
+ */
+function relativeToCwd(pattern: string, cwd: string): string {
+  const normalized = pattern.replaceAll('\\', '/');
+  if (!isAbsolute(normalized)) return normalized;
+  const prefix = `${cwd.replaceAll('\\', '/').replace(/\/+$/, '')}/`;
+  return normalized.startsWith(prefix)
+    ? normalized.slice(prefix.length)
+    : normalized;
 }
 
 /**

--- a/packages/scanner/src/scanner.ts
+++ b/packages/scanner/src/scanner.ts
@@ -5,8 +5,8 @@
  * Provides a simple API for scanning TypeScript files for SMRT classes.
  */
 
-import { isAbsolute, resolve } from 'node:path';
-import fg from 'fast-glob';
+import { resolve } from 'node:path';
+import { discoverSourceFiles } from './discovery.js';
 import { InheritanceResolver } from './inheritance-resolver.js';
 import { parseFile } from './oxc-parser.js';
 import type {
@@ -45,8 +45,6 @@ const DEFAULT_EXCLUDE = [
  * These are load-bearing for termination, not just for speed. See
  * {@link OxcScanner.discoverFiles}.
  */
-const MANDATORY_EXCLUDE = ['**/node_modules/**', '**/.*/**', '**/.*'];
-
 /**
  * High-performance TypeScript scanner that discovers `@smrt()`-decorated
  * classes in a project's source files.
@@ -334,24 +332,12 @@ export class OxcScanner {
    * or `~/.cache` would then match nothing at all, silently.
    */
   private async discoverFiles(): Promise<string[]> {
-    const cwd = resolve(this.options.cwd);
-    const patterns = this.options.include.map((pattern) =>
-      relativeToCwd(pattern, cwd),
-    );
-
-    const files = await fg(patterns, {
-      cwd,
-      ignore: [
-        ...this.options.exclude.map((pattern) => relativeToCwd(pattern, cwd)),
-        ...MANDATORY_EXCLUDE,
-      ],
-      absolute: true,
-      onlyFiles: true,
-      dot: true,
+    return discoverSourceFiles({
+      cwd: this.options.cwd,
+      include: this.options.include,
+      exclude: this.options.exclude,
       followSymbolicLinks: this.options.followSymbolicLinks,
     });
-
-    return files;
   }
 
   /**
@@ -361,23 +347,6 @@ export class OxcScanner {
     // parseFile is synchronous but we wrap it for potential future async
     return parseFile(filePath);
   }
-}
-
-/**
- * Rewrites an absolute pattern rooted inside `cwd` as a `cwd`-relative one.
- *
- * Globs are matched as text, so a pattern's leading directories become part of
- * every comparison — including the mandatory prunes. Patterns outside `cwd` are
- * left alone: nothing sensible can be said about them relative to a root they
- * do not live under.
- */
-function relativeToCwd(pattern: string, cwd: string): string {
-  const normalized = pattern.replaceAll('\\', '/');
-  if (!isAbsolute(normalized)) return normalized;
-  const prefix = `${cwd.replaceAll('\\', '/').replace(/\/+$/, '')}/`;
-  return normalized.startsWith(prefix)
-    ? normalized.slice(prefix.length)
-    : normalized;
 }
 
 /**

--- a/packages/scanner/src/types.ts
+++ b/packages/scanner/src/types.ts
@@ -330,6 +330,17 @@ export interface OxcScannerOptions {
 
   /** External package manifests for base class resolution */
   externalManifests?: Map<string, ExternalManifest>;
+
+  /**
+   * Follow symbolic links while discovering files. Defaults to `false`.
+   *
+   * A package's own sources are real files, while a pnpm `node_modules` is a
+   * symlink graph with cycles: every store entry links back out to its
+   * siblings, so a link-following walk reaches the same real directory once per
+   * path that leads to it and never terminates in practice. Discovery therefore
+   * stays on real directories unless a caller explicitly opts back in.
+   */
+  followSymbolicLinks?: boolean;
 }
 
 /**

--- a/packages/smrt-dev-mcp/AGENTS.md
+++ b/packages/smrt-dev-mcp/AGENTS.md
@@ -44,6 +44,36 @@ amplify into unbounded filesystem work. Discovery also stops before package
 reads when more than 512 packages match, revalidates confinement immediately
 before reading each package, and runs at most eight scanner fallbacks at once.
 
+### Consumer apps (#2275)
+
+An app that installs the published packages authors none of them, so workspace
+discovery alone sees nothing. Every installed `@happyvertical/smrt-*` package,
+plus the known SDK packages, is resolved from the project's and each workspace
+package's `node_modules/@happyvertical` scope directory and marked
+`isInstalledDependency`. This is an enumeration, not a walk: pnpm materializes
+a store whose entries link back out to their siblings, so a descent reads the
+same package once per path that reaches it. Real paths deduplicate the result;
+each package is still read through its `node_modules` path, because a realpath
+escapes the root wherever an ancestor is a symlink. A workspace package linked
+into a sibling's `node_modules` is authored source and is never marked
+installed.
+
+- `--scope installed` reports exactly those packages. `local` and `package`
+  exclude them; `project` includes them; the index also lists them separately
+  as `installedPackages` (`schemaVersion: 3`). It is a reporting scope:
+  `dev:knowledge-check` has no authored packages to gate under it.
+- Each package carries `agentDocSha256`, the hash of its shipped `AGENTS.md`.
+  That is the drift signal a consumer diffs against a recorded baseline — a
+  version bump is not, because most releases do not touch a documented surface.
+- The freshness gate skips installed packages entirely: indexed, never checked.
+  A consumer cannot add an `AGENTS.md` to a dependency, and a published
+  package's artifact hashes cannot match its republished sources.
+- Coverage and the `no-smrt-objects-discovered` guard count authored packages
+  only. Dependencies ship their own objects, so counting them would make that
+  guard unreachable in exactly the projects most likely to have broken
+  discovery. A project whose own packages contribute nothing while its
+  dependencies do gets the `no-authored-smrt-objects` warning instead.
+
 Per package, objects resolve in this order, and the winner is recorded in
 `objectSource` with a reason:
 
@@ -52,7 +82,7 @@ Per package, objects resolve in this order, and the winner is recorded in
 3. `scanner` — `OxcScanner` + `ManifestAdapter` over the package's sources
 4. `none` — with a machine-readable reason
 
-The index exposes `coverage` and `diagnostics` (`schemaVersion: 2`). Zero
+The index exposes `coverage` and `diagnostics` (added in `schemaVersion: 2`). Zero
 discovered objects is an **error-grade** diagnostic that names the roots and
 artifact paths checked plus the fix, and it propagates into
 `smrt-architecture`/`smrt-review`/`reflect-*` results and prompt bundles.

--- a/packages/smrt-dev-mcp/README.md
+++ b/packages/smrt-dev-mcp/README.md
@@ -124,7 +124,7 @@ dependency edge — by connected component, keeping the copy the others depend o
 and reports `duplicate-object-identity`. Unrelated packages that share a class
 name stay distinct.
 
-The index therefore carries two extra blocks (`schemaVersion: 2`):
+The index therefore carries two extra blocks (added in `schemaVersion: 2`):
 
 - `coverage` — `workspaceGlobs`, `workspaceGlobSource`, `packageDirs`,
   `packagesWithObjects`, and `packagesWithoutObjects` with a reason, the artifact
@@ -133,6 +133,13 @@ The index therefore carries two extra blocks (`schemaVersion: 2`):
   error-grade diagnostic naming the roots and artifact paths checked plus the
   commands to fix it, so an unseen project is never reported as a project with no
   model. `smrt-architecture`, `smrt-review`, and the `reflect-*` tools surface it.
+
+`schemaVersion: 3` adds the consumer-app view: `installedPackages` lists every
+installed `@happyvertical/smrt-*` package plus the known SDK packages — the ones
+the project installs rather than authors — each with `isInstalledDependency`, its
+version, and `agentDocSha256`, the hash of its shipped `AGENTS.md`. That hash is
+what a downstream project diffs against a recorded baseline to find documentation
+drift. Reach it with `--scope installed`.
 
 ## Response Budgets
 
@@ -300,7 +307,7 @@ coverage, relationship-v2 counts, and freshness status.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `rootDir` | `string` | No | Project root directory (default: cwd) |
-| `scope` | `string` | No | `project`, `local`, `package`, or `sdk` |
+| `scope` | `string` | No | `project`, `local`, `package`, `sdk`, or `installed` |
 | `package` | `string` | No | Package name or short name to focus |
 
 ### `check-knowledge-freshness`
@@ -323,7 +330,7 @@ Alias over the deterministic checker that emphasizes downstream
 | `rootDir` | `string` | No | Project root directory (default: cwd) |
 | `changed` | `boolean` | No | Limit stale-pattern checks to changed files |
 | `strict` | `boolean` | No | Treat stale-pattern findings as errors |
-| `scope` | `string` | No | `project`, `local`, `package`, or `sdk` |
+| `scope` | `string` | No | `project`, `local`, `package`, `sdk`, or `installed` |
 | `package` | `string` | No | Package name or short name to focus |
 
 ### `build-review-context`

--- a/packages/smrt-dev-mcp/src/index.ts
+++ b/packages/smrt-dev-mcp/src/index.ts
@@ -302,7 +302,7 @@ const TOOL_DEFINITIONS: Array<
         rootDir: { type: 'string' },
         scope: {
           type: 'string',
-          enum: ['project', 'local', 'package', 'sdk'],
+          enum: ['project', 'local', 'package', 'sdk', 'installed'],
           default: 'project',
         },
         package: { type: 'string' },
@@ -339,7 +339,7 @@ const TOOL_DEFINITIONS: Array<
         strict: { type: 'boolean' },
         scope: {
           type: 'string',
-          enum: ['project', 'local', 'package', 'sdk'],
+          enum: ['project', 'local', 'package', 'sdk', 'installed'],
           default: 'project',
         },
         package: { type: 'string' },
@@ -380,7 +380,7 @@ const TOOL_DEFINITIONS: Array<
         documentation: { type: 'string' },
         scope: {
           type: 'string',
-          enum: ['project', 'local', 'package', 'sdk'],
+          enum: ['project', 'local', 'package', 'sdk', 'installed'],
           default: 'project',
         },
         package: { type: 'string' },
@@ -454,7 +454,7 @@ const TOOL_DEFINITIONS: Array<
         focus: { type: 'string' },
         scope: {
           type: 'string',
-          enum: ['project', 'local', 'package', 'sdk'],
+          enum: ['project', 'local', 'package', 'sdk', 'installed'],
           default: 'project',
         },
         package: { type: 'string' },
@@ -601,7 +601,8 @@ export function createServer(): Server {
             },
             {
               name: 'scope',
-              description: 'Knowledge scope: project, local, package, or sdk.',
+              description:
+                'Knowledge scope: project, local, package, sdk, or installed.',
               required: false,
             },
             {
@@ -639,7 +640,8 @@ export function createServer(): Server {
             },
             {
               name: 'scope',
-              description: 'Knowledge scope: project, local, package, or sdk.',
+              description:
+                'Knowledge scope: project, local, package, sdk, or installed.',
               required: false,
             },
             {
@@ -1147,6 +1149,10 @@ function sanitizeKnowledgeIndex(index: KnowledgeIndexResult) {
     packages,
     smrtPackages: packages.filter((pkg) => pkg.kind === 'smrt'),
     sdkPackages: packages.filter((pkg) => pkg.kind === 'sdk'),
+    // Rebuilt from the sanitized list rather than carried over by the spread.
+    // Installed dependencies live outside the project root, so theirs are the
+    // absolute host paths this projection exists to strip (#2275).
+    installedPackages: packages.filter((pkg) => pkg.isInstalledDependency),
   };
 }
 

--- a/packages/smrt-dev-mcp/src/knowledge/consumer-app.test.ts
+++ b/packages/smrt-dev-mcp/src/knowledge/consumer-app.test.ts
@@ -4,7 +4,12 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildKnowledgeIndex, checkKnowledgeFreshness } from './index.js';
+import {
+  buildArchitectureContext,
+  buildKnowledgeIndex,
+  buildReviewContext,
+  checkKnowledgeFreshness,
+} from './index.js';
 
 /**
  * Counts the directories discovery actually opens.
@@ -65,6 +70,7 @@ describe('knowledge index in a consumer app', () => {
     'smrt-tenancy',
     'smrt-users',
     'smrt-web',
+    'utils',
   ];
 
   async function write(path: string, content: string): Promise<void> {
@@ -297,9 +303,74 @@ describe('knowledge index in a consumer app', () => {
       expect(index.packages.map((pkg) => pkg.name)).toEqual(['demo-app']);
     }
 
-    // SMRT packages are not SDK packages, so the SDK scope stays empty here.
+    // The known SDK package remains available only through the SDK scope.
     const sdk = await buildKnowledgeIndex({ rootDir, scope: 'sdk' });
-    expect(sdk.packages).toEqual([]);
+    expect(sdk.packages.map((pkg) => pkg.name)).toEqual([
+      '@happyvertical/utils',
+    ]);
+  });
+
+  it('keeps an authored package selector out of installed review context', async () => {
+    const context = await buildReviewContext({
+      rootDir,
+      scope: 'installed',
+      package: 'demo-app',
+      changedFiles: [],
+    });
+
+    expect(context.selectedPackages).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'demo-app' })]),
+    );
+    expect(context.selectedPackages.length).toBeGreaterThan(0);
+    expect(
+      context.selectedPackages.every((pkg) => pkg.isInstalledDependency),
+    ).toBe(true);
+    expect(context.selectedSdkPackages.length).toBeGreaterThan(0);
+    expect(
+      context.selectedSdkPackages.every((pkg) => pkg.isInstalledDependency),
+    ).toBe(true);
+  });
+
+  it('keeps installed SDK dependencies required by an authored package', async () => {
+    const context = await buildReviewContext({
+      rootDir,
+      scope: 'package',
+      package: 'demo-app',
+      changedFiles: [],
+    });
+
+    expect(context.selectedPackages.map((pkg) => pkg.name)).toEqual([
+      'demo-app',
+    ]);
+    expect(context.selectedSdkPackages.map((pkg) => pkg.name)).toEqual([
+      '@happyvertical/utils',
+    ]);
+  });
+
+  it('does not use an installed framework fallback for package scope', async () => {
+    // An authored default SDK makes this assertion fail on the old fallback;
+    // without it the installed SDK is already filtered and [] is vacuous.
+    await write(
+      join(rootDir, 'packages', 'utils', 'package.json'),
+      JSON.stringify({
+        name: '@happyvertical/utils',
+        version: '0.0.1',
+        private: true,
+      }),
+    );
+    await write(
+      join(rootDir, 'packages', 'utils', 'AGENTS.md'),
+      '# Authored utils\n',
+    );
+
+    const context = await buildArchitectureContext({
+      rootDir,
+      scope: 'package',
+      package: 'not-installed-or-authored',
+    });
+
+    expect(context.selectedPackages).toEqual([]);
+    expect(context.selectedSdkPackages).toEqual([]);
   });
 
   it('does not fail freshness on documentation a consumer cannot author', async () => {

--- a/packages/smrt-dev-mcp/src/knowledge/consumer-app.test.ts
+++ b/packages/smrt-dev-mcp/src/knowledge/consumer-app.test.ts
@@ -1,0 +1,430 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildKnowledgeIndex, checkKnowledgeFreshness } from './index.js';
+
+/**
+ * Counts the directories discovery actually opens.
+ *
+ * The module under test reads directories through `readdirSync` and
+ * `opendirSync`, so mocking `node:fs` here is what makes traversal observable —
+ * a spy on the `fs` namespace would not be, because the transitive glob
+ * machinery captures its adapter at import time. `vi.hoisted` keeps the array
+ * defined before the hoisted factory closes over it.
+ */
+const openedDirs = vi.hoisted(() => [] as string[]);
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  const record =
+    <Fn extends (...args: never[]) => unknown>(fn: Fn) =>
+    (path: never, ...rest: never[]) => {
+      openedDirs.push(String(path));
+      return fn(path, ...(rest as never[]));
+    };
+  return {
+    ...actual,
+    default: actual,
+    readdirSync: record(
+      actual.readdirSync as (...args: never[]) => unknown,
+    ) as typeof actual.readdirSync,
+    opendirSync: record(
+      actual.opendirSync as (...args: never[]) => unknown,
+    ) as typeof actual.opendirSync,
+  };
+});
+
+/**
+ * The consumer-app case: an application that installs the published packages
+ * rather than authoring them (#2275).
+ *
+ * The fixture is deliberately shaped like a real pnpm install — a store whose
+ * entries link back out to each other, reachable through a dot directory — and
+ * the whole file hangs rather than fails on the pre-fix code. That is the
+ * regression: discovery re-walked the same real directories once per path that
+ * reached them until the heap ran out.
+ */
+describe('knowledge index in a consumer app', () => {
+  let rootDir: string;
+
+  const AGENT_DOC = '# smrt-content\n\nPublished package guidance.\n';
+  const CORE_DOC = '# smrt-core\n\nFoundation guidance.\n';
+  /**
+   * Enough packages for the sibling links to form a branching cycle rather than
+   * a single loop. A kernel gives up on one self-referential link after
+   * MAXSYMLINKS hops, but a clique multiplies into `(n-1) ** MAXSYMLINKS`
+   * distinct paths to the same real directories — which is the shape that
+   * exhausted the heap on a real install.
+   */
+  const INSTALLED = [
+    'smrt-content',
+    'smrt-core',
+    'smrt-jobs',
+    'smrt-tenancy',
+    'smrt-users',
+    'smrt-web',
+  ];
+
+  async function write(path: string, content: string): Promise<void> {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, content);
+  }
+
+  /** Where pnpm materializes a package inside the virtual store. */
+  function storeDir(name: string, version: string): string {
+    return join(
+      rootDir,
+      'node_modules',
+      '.pnpm',
+      `@happyvertical+${name}@${version}`,
+      'node_modules',
+      '@happyvertical',
+      name,
+    );
+  }
+
+  async function writeInstalledPackage(options: {
+    name: string;
+    version: string;
+    agentDoc: string;
+    objects: string[];
+  }): Promise<void> {
+    const directory = storeDir(options.name, options.version);
+    await write(
+      join(directory, 'package.json'),
+      JSON.stringify({
+        name: `@happyvertical/${options.name}`,
+        version: options.version,
+        files: ['dist', 'AGENTS.md', 'CLAUDE.md'],
+        exports: {
+          '.': { import: './dist/index.js' },
+          './smrt-knowledge.json': './dist/smrt-knowledge.json',
+        },
+      }),
+    );
+    await write(join(directory, 'AGENTS.md'), options.agentDoc);
+    await write(join(directory, 'CLAUDE.md'), '@AGENTS.md');
+    await write(
+      join(directory, 'dist', 'smrt-knowledge.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        generatedAt: new Date().toISOString(),
+        packageName: `@happyvertical/${options.name}`,
+        packageVersion: options.version,
+        sourceHashes: {},
+        exports: ['.', './smrt-knowledge.json'],
+        dependencies: {},
+        smrtDependencies: [],
+        sdkDependencies: [],
+        tags: [],
+        risks: [],
+        objects: options.objects.map((name) => ({
+          name,
+          qualifiedName: `@happyvertical/${options.name}:${name}`,
+          collection: `${name.toLowerCase()}s`,
+          fields: [],
+          relationships: [],
+          methods: [],
+          surfaces: [],
+          relationshipFeatures: [],
+          tags: [],
+          risks: [],
+        })),
+        surfaces: [],
+        prompts: [],
+        relationshipsV2: {
+          foreignKeyFields: 0,
+          crossPackageRefFields: 0,
+          junctionCollections: 0,
+          hierarchicalObjects: 0,
+          polymorphicAssociations: 0,
+          uuidColumns: 0,
+        },
+      }),
+    );
+    // The store entry's own scope directory, which is where pnpm puts the
+    // sibling links that close the graph.
+    mkdirSync(join(directory, 'node_modules', '@happyvertical'), {
+      recursive: true,
+    });
+  }
+
+  /** Links `from` to `to` inside the store, the way pnpm wires peers. */
+  function linkSibling(from: string, to: string): void {
+    symlinkSync(
+      storeDir(to, '1.0.0'),
+      join(storeDir(from, '1.0.0'), 'node_modules', '@happyvertical', to),
+    );
+  }
+
+  beforeEach(async () => {
+    openedDirs.length = 0;
+    rootDir = mkdtempSync(join(tmpdir(), 'smrt-consumer-app-'));
+
+    // A single-package application: no workspace globs, no packages/ directory.
+    await write(
+      join(rootDir, 'package.json'),
+      JSON.stringify({
+        name: 'demo-app',
+        version: '0.0.1',
+        private: true,
+        dependencies: Object.fromEntries(
+          INSTALLED.map((name) => [`@happyvertical/${name}`, '1.0.0']),
+        ),
+      }),
+    );
+    await write(
+      join(rootDir, 'AGENTS.md'),
+      '# demo-app\n\nApplication guide.\n',
+    );
+    await write(join(rootDir, 'CLAUDE.md'), '@AGENTS.md');
+    await write(join(rootDir, 'src', 'app.ts'), 'export const app = 1;\n');
+
+    for (const name of INSTALLED) {
+      await writeInstalledPackage({
+        name,
+        version: '1.0.0',
+        agentDoc: name === 'smrt-core' ? CORE_DOC : AGENT_DOC,
+        objects: [name === 'smrt-content' ? 'Article' : 'Placeholder'],
+      });
+    }
+
+    // Cross-links between store entries: this is the cycle that made a
+    // recursive descent non-terminating.
+    for (const from of INSTALLED) {
+      for (const to of INSTALLED.filter((name) => name !== from)) {
+        linkSibling(from, to);
+      }
+    }
+
+    // The project's public scope directory, symlinked into the store as pnpm
+    // does for direct dependencies.
+    mkdirSync(join(rootDir, 'node_modules', '@happyvertical'), {
+      recursive: true,
+    });
+    for (const name of INSTALLED) {
+      symlinkSync(
+        storeDir(name, '1.0.0'),
+        join(rootDir, 'node_modules', '@happyvertical', name),
+      );
+    }
+
+    // A framework cache directory holding a second copy of the same graph.
+    // Dot directories were the hole in the ignore patterns: nothing beneath one
+    // was pruned, so the walk fell straight into this store.
+    mkdirSync(join(rootDir, '.svelte-kit', 'output'), { recursive: true });
+    symlinkSync(
+      join(rootDir, 'node_modules'),
+      join(rootDir, '.svelte-kit', 'output', 'node_modules'),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('reports every installed @happyvertical package under scope installed', async () => {
+    const index = await buildKnowledgeIndex({ rootDir, scope: 'installed' });
+
+    expect(index.packages.map((pkg) => pkg.name)).toEqual(
+      INSTALLED.map((name) => `@happyvertical/${name}`).sort(),
+    );
+
+    const content = index.packages.find(
+      (pkg) => pkg.name === '@happyvertical/smrt-content',
+    );
+    expect(content?.version).toBe('1.0.0');
+    expect(content?.hasAgentsMd).toBe(true);
+    expect(content?.isInstalledDependency).toBe(true);
+    expect(content?.exportKeys).toEqual(['.', './smrt-knowledge.json']);
+    expect(content?.objectSource).toBe('domain-artifact');
+    expect(content?.objects.map((object) => object.className)).toEqual([
+      'Article',
+    ]);
+  });
+
+  it('hashes each shipped AGENTS.md so a consumer can diff documentation drift', async () => {
+    const index = await buildKnowledgeIndex({ rootDir, scope: 'installed' });
+    const content = index.packages.find(
+      (pkg) => pkg.name === '@happyvertical/smrt-content',
+    );
+
+    expect(content?.agentDocSha256).toBe(
+      createHash('sha256').update(AGENT_DOC).digest('hex'),
+    );
+    // A version bump is not the signal; the doc hash is. Two packages on the
+    // same version must still be distinguishable by what they document.
+    const core = index.packages.find(
+      (pkg) => pkg.name === '@happyvertical/smrt-core',
+    );
+    expect(core?.version).toBe(content?.version);
+    expect(core?.agentDocSha256).not.toBe(content?.agentDocSha256);
+  });
+
+  it('resolves each installed package exactly once despite the symlink graph', async () => {
+    const index = await buildKnowledgeIndex({ rootDir, scope: 'project' });
+    const installedNames = index.installedPackages.map((pkg) => pkg.name);
+
+    expect(installedNames).toEqual([...new Set(installedNames)]);
+    expect(installedNames).toEqual(
+      INSTALLED.map((name) => `@happyvertical/${name}`).sort(),
+    );
+    // The application itself stays in the index alongside its dependencies.
+    expect(index.packages.map((pkg) => pkg.name)).toContain('demo-app');
+  });
+
+  it('enumerates the scope directory instead of walking node_modules', async () => {
+    await buildKnowledgeIndex({ rootDir, scope: 'installed' });
+
+    const inStore = openedDirs.filter((path) =>
+      path.includes(join('node_modules', '.pnpm')),
+    );
+    // Every package is reachable from every other one, so a descent would read
+    // the store's directories over and over. Resolution reads the project's
+    // `@happyvertical` scope directory and stats each entry once instead, so
+    // the store itself is never opened.
+    expect(inStore).toEqual([]);
+    expect(
+      openedDirs.filter((path) => path.includes('node_modules')),
+    ).toHaveLength(1);
+  });
+
+  it('keeps installed dependencies out of the workspace-authored scopes', async () => {
+    for (const scope of ['local', 'package'] as const) {
+      const index = await buildKnowledgeIndex({ rootDir, scope });
+      expect(index.packages.map((pkg) => pkg.name)).toEqual(['demo-app']);
+    }
+
+    // SMRT packages are not SDK packages, so the SDK scope stays empty here.
+    const sdk = await buildKnowledgeIndex({ rootDir, scope: 'sdk' });
+    expect(sdk.packages).toEqual([]);
+  });
+
+  it('does not fail freshness on documentation a consumer cannot author', async () => {
+    const result = await checkKnowledgeFreshness({ rootDir });
+
+    expect(result.issues.map((issue) => issue.packageName)).not.toContain(
+      '@happyvertical/smrt-content',
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('does not report a discovery failure when only dependencies carry objects', async () => {
+    const index = await buildKnowledgeIndex({ rootDir });
+
+    expect(index.diagnostics.map((entry) => entry.code)).not.toContain(
+      'no-smrt-objects-discovered',
+    );
+    // The project's own packages still contributed nothing, and a workspace
+    // that is supposed to declare @smrt() classes needs to hear about it.
+    expect(index.diagnostics.map((entry) => entry.code)).toContain(
+      'no-authored-smrt-objects',
+    );
+  });
+});
+
+/**
+ * A workspace whose own packages are linked into each other's `node_modules`,
+ * which is how pnpm wires an internal dependency. Those links resolve to
+ * authored source, and calling that source an installed dependency would
+ * quietly exempt it from every rule in the freshness gate (#2275).
+ */
+describe('workspace packages reached through node_modules links', () => {
+  let rootDir: string;
+
+  async function write(path: string, content: string): Promise<void> {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, content);
+  }
+
+  async function writeWorkspacePackage(name: string): Promise<void> {
+    const directory = join(rootDir, 'packages', name.split('/')[1] as string);
+    await write(
+      join(directory, 'package.json'),
+      JSON.stringify({
+        name,
+        version: '1.0.0',
+        files: ['dist', 'AGENTS.md', 'CLAUDE.md'],
+        exports: { '.': { import: './dist/index.js' } },
+      }),
+    );
+    await write(join(directory, 'AGENTS.md'), `# ${name}\n\nAuthored.\n`);
+    await write(join(directory, 'CLAUDE.md'), '@AGENTS.md');
+  }
+
+  beforeEach(async () => {
+    rootDir = mkdtempSync(join(tmpdir(), 'smrt-workspace-links-'));
+    await write(
+      join(rootDir, 'pnpm-workspace.yaml'),
+      "packages:\n  - 'packages/*'\n",
+    );
+    await write(
+      join(rootDir, 'package.json'),
+      JSON.stringify({
+        name: 'demo-workspace',
+        version: '0.0.1',
+        private: true,
+      }),
+    );
+    await write(join(rootDir, 'AGENTS.md'), '# demo-workspace\n');
+    await write(join(rootDir, 'CLAUDE.md'), '@AGENTS.md');
+
+    // One `smrt-*` name and one SDK-allowlist name: only the second is
+    // vulnerable, because `dedupePackages` lets an `sdk`-kind entry be replaced.
+    await writeWorkspacePackage('@happyvertical/smrt-widgets');
+    await writeWorkspacePackage('@happyvertical/utils');
+
+    for (const [consumer, dependency] of [
+      ['smrt-widgets', '@happyvertical/utils'],
+      ['utils', '@happyvertical/smrt-widgets'],
+    ] as const) {
+      const scope = join(
+        rootDir,
+        'packages',
+        consumer,
+        'node_modules',
+        '@happyvertical',
+      );
+      mkdirSync(scope, { recursive: true });
+      symlinkSync(
+        join(rootDir, 'packages', dependency.split('/')[1] as string),
+        join(scope, dependency.split('/')[1] as string),
+      );
+    }
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('keeps linked workspace packages authored, not installed', async () => {
+    const index = await buildKnowledgeIndex({ rootDir });
+    const byName = new Map(index.packages.map((pkg) => [pkg.name, pkg]));
+
+    expect(
+      byName.get('@happyvertical/smrt-widgets')?.isInstalledDependency,
+    ).toBe(false);
+    expect(byName.get('@happyvertical/utils')?.isInstalledDependency).toBe(
+      false,
+    );
+    expect(index.installedPackages).toEqual([]);
+  });
+
+  it('still gates linked workspace packages in the freshness check', async () => {
+    // `@happyvertical/utils` is exempt for an unrelated, pre-existing reason —
+    // an SDK-allowlist name is `kind: 'sdk'` wherever it lives — so the gate is
+    // asserted through the linked `smrt-*` package instead.
+    await writeFile(
+      join(rootDir, 'packages', 'smrt-widgets', 'CLAUDE.md'),
+      '# not a shim\n',
+    );
+
+    const result = await checkKnowledgeFreshness({ rootDir });
+
+    expect(
+      result.issues.map((issue) => `${issue.packageName}:${issue.code}`),
+    ).toContain('@happyvertical/smrt-widgets:claude-not-shim');
+  });
+});

--- a/packages/smrt-dev-mcp/src/knowledge/index.ts
+++ b/packages/smrt-dev-mcp/src/knowledge/index.ts
@@ -30,7 +30,17 @@ import type {
 
 export type KnowledgePackageKind = 'smrt' | 'sdk' | 'workspace';
 export type KnowledgeIssueSeverity = 'error' | 'warning';
-export type KnowledgeScope = 'project' | 'local' | 'package' | 'sdk';
+/**
+ * `installed` is the consumer-app scope (#2275): every `@happyvertical/*`
+ * package this project installs, rather than the packages it authors. The other
+ * scopes all describe the workspace's own sources.
+ */
+export type KnowledgeScope =
+  | 'project'
+  | 'local'
+  | 'package'
+  | 'sdk'
+  | 'installed';
 
 /**
  * Where a package's objects actually came from (#2143). Recording provenance is
@@ -110,6 +120,15 @@ export interface KnowledgePackage {
   docSource: 'AGENTS.md' | 'CLAUDE.md' | null;
   agentDoc?: string;
   /**
+   * SHA-256 of the shipped `AGENTS.md`, when there is one.
+   *
+   * A version bump is a poor drift signal because most releases do not touch a
+   * package's documented surface. This hash is the stable identity a consumer
+   * diffs against its own recorded baseline to answer "which installed packages
+   * changed their documented surface since I last verified my copy?" (#2275).
+   */
+  agentDocSha256?: string;
+  /**
    * Sibling module docs linked from the package's `AGENTS.md` (#2108). Oversized
    * package docs are split by module into `agents/<module>.md` rather than nested
    * `AGENTS.md` files (chains are additive), so this prose is only reachable
@@ -129,6 +148,13 @@ export interface KnowledgePackage {
   isWorkspaceRoot: boolean;
   /** `private: true` packages publish nothing, so packaging rules do not apply. */
   isPrivate: boolean;
+  /**
+   * True when the package was resolved out of `node_modules` rather than
+   * authored in this workspace. This repository's docs and packaging rules do
+   * not apply to it — a consumer cannot add an `AGENTS.md` to a dependency —
+   * so the freshness gate skips it entirely: indexed, never checked (#2275).
+   */
+  isInstalledDependency: boolean;
   objectSource: KnowledgeObjectSource;
   /**
    * Machine-readable reason a package produced no objects, or a note about
@@ -173,13 +199,24 @@ export interface KnowledgeDiagnostic {
 }
 
 export interface SmrtKnowledgeIndex {
-  /** 2 adds `coverage` and `diagnostics` (additive, #2143). */
-  schemaVersion: 2;
+  /**
+   * 2 adds `coverage` and `diagnostics` (additive, #2143); 3 adds
+   * `installedPackages` plus each package's `isInstalledDependency` and
+   * `agentDocSha256` (additive, #2275).
+   */
+  schemaVersion: 3;
   generatedAt: string;
   rootDir: string;
   packages: KnowledgePackage[];
   smrtPackages: KnowledgePackage[];
   sdkPackages: KnowledgePackage[];
+  /**
+   * Installed `@happyvertical/*` dependencies, SMRT and SDK alike. In a
+   * consumer app this is the whole audit surface. In this monorepo it holds the
+   * registry-installed SDK packages; the `smrt-*` names resolve to workspace
+   * copies, which win the name-keyed dedupe (#2275).
+   */
+  installedPackages: KnowledgePackage[];
   relationshipsV2: {
     foreignKeyFields: number;
     crossPackageRefFields: number;
@@ -438,7 +475,7 @@ export async function buildKnowledgeIndex(
   await applyScannerFallbacks(packages, memberExcludes);
 
   packages.push(
-    ...discoverInstalledSdkPackages(rootDir, packageDirs, includeDocs),
+    ...discoverInstalledPackages(rootDir, packageDirs, includeDocs),
   );
 
   const uniquePackages = dedupePackages(packages);
@@ -458,12 +495,15 @@ export async function buildKnowledgeIndex(
   });
 
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
     generatedAt: new Date().toISOString(),
     rootDir,
     packages: scopedPackages,
     smrtPackages,
     sdkPackages,
+    installedPackages: scopedPackages.filter(
+      (pkg) => pkg.isInstalledDependency,
+    ),
     relationshipsV2: summarizeRelationshipsV2(scopedPackages),
     coverage,
     diagnostics: buildIndexDiagnostics(
@@ -482,16 +522,21 @@ function buildCoverage(options: {
   packageDirs: string[];
   packages: KnowledgePackage[];
 }): KnowledgeCoverage {
+  // Coverage answers "did discovery see THIS PROJECT", so it reports on the
+  // packages the project authors. An installed dependency's objects are not
+  // project coverage, and listing every dependency that ships no model as a
+  // gap made the answer unreadable in a consumer app (#2275).
+  const authored = options.packages.filter((pkg) => !pkg.isInstalledDependency);
   return {
     workspaceGlobs: options.globs,
     workspaceGlobSource: options.globSource,
     packageDirs: options.packageDirs.map(
       (dir) => relative(options.rootDir, dir) || '.',
     ),
-    packagesWithObjects: options.packages
+    packagesWithObjects: authored
       .filter((pkg) => pkg.objects.length > 0)
       .map((pkg) => `${pkg.name} (${pkg.objects.length}, ${pkg.objectSource})`),
-    packagesWithoutObjects: options.packages
+    packagesWithoutObjects: authored
       .filter((pkg) => pkg.objects.length === 0)
       .map((pkg) => ({
         name: pkg.name,
@@ -530,12 +575,41 @@ function buildIndexDiagnostics(
   discoveryDiagnostics: KnowledgeDiagnostic[] = [],
 ): KnowledgeDiagnostic[] {
   const diagnostics: KnowledgeDiagnostic[] = [...discoveryDiagnostics];
-  const totalObjects = packages.reduce(
+  // Counted over authored packages only. Installed `@happyvertical/smrt-*`
+  // dependencies ship their own `smrt-knowledge.json`, so counting them would
+  // make this guard unreachable in any project that depends on the framework —
+  // exactly the projects whose own discovery is most likely to be broken
+  // (#2143, #2275).
+  const authoredPackages = packages.filter((pkg) => !pkg.isInstalledDependency);
+  const authoredObjects = authoredPackages.reduce(
     (total, pkg) => total + pkg.objects.length,
     0,
   );
+  const installedObjects = packages.reduce(
+    (total, pkg) =>
+      total + (pkg.isInstalledDependency ? pkg.objects.length : 0),
+    0,
+  );
 
-  if (totalObjects === 0) {
+  if (authoredObjects === 0 && installedObjects > 0) {
+    diagnostics.push({
+      severity: 'warning',
+      code: 'no-authored-smrt-objects',
+      message: [
+        `No SMRT objects were discovered in the project's own packages under ${rootDir},`,
+        `though ${installedObjects} were read from installed dependencies.`,
+        'Expected for an application that only consumes the framework;',
+        'a discovery failure if this workspace is supposed to declare @smrt() classes.',
+      ].join(' '),
+      remedy: [
+        'If this workspace authors SMRT objects, confirm rootDir is the workspace root,',
+        'confirm the workspace globs cover the directories that hold @smrt() classes,',
+        'and run `pnpm build` in the owning package to emit .smrt/manifest.json.',
+      ].join(' '),
+    });
+  }
+
+  if (authoredObjects === 0 && installedObjects === 0) {
     diagnostics.push({
       severity: 'error',
       code: 'no-smrt-objects-discovered',
@@ -546,7 +620,7 @@ function buildIndexDiagnostics(
         'Treat this as a discovery failure, not as evidence that the project has no SMRT model.',
       ].join(' '),
       checkedPaths: [
-        ...new Set(packages.flatMap((pkg) => pkg.checkedObjectPaths)),
+        ...new Set(authoredPackages.flatMap((pkg) => pkg.checkedObjectPaths)),
       ],
       remedy: [
         'Confirm rootDir is the workspace root;',
@@ -656,10 +730,18 @@ export async function checkKnowledgeFreshnessFromIndex(
   // inclusion (#2143). But in a single-package repository the root IS the
   // published package, so exempting every root would turn this gate into a
   // no-op for exactly the layout #2143 added support for.
-  const hasMemberPackages = index.packages.some(
+  //
+  // Installed dependencies are excluded throughout: a consumer app cannot add
+  // an AGENTS.md to a package it merely installs, so gating on one would make
+  // `dev:knowledge-check` unpassable everywhere downstream (#2275). They are
+  // still indexed and reported — only the authored-source rules skip them.
+  const authoredPackages = index.packages.filter(
+    (item) => !item.isInstalledDependency,
+  );
+  const hasMemberPackages = authoredPackages.some(
     (item) => item.kind !== 'sdk' && !item.isWorkspaceRoot,
   );
-  const memberDirectories = index.packages
+  const memberDirectories = authoredPackages
     .filter(
       (item) =>
         item.kind !== 'sdk' && !item.isWorkspaceRoot && item.relativeDirectory,
@@ -678,7 +760,7 @@ export async function checkKnowledgeFreshnessFromIndex(
         directory !== pkg.relativeDirectory &&
         pkg.relativeDirectory.startsWith(`${directory}/`),
     );
-  for (const pkg of index.packages.filter(
+  for (const pkg of authoredPackages.filter(
     (item) =>
       item.kind !== 'sdk' && !(item.isWorkspaceRoot && hasMemberPackages),
   )) {
@@ -770,7 +852,7 @@ export async function checkKnowledgeFreshnessFromIndex(
     }
   }
 
-  for (const pkg of index.packages) {
+  for (const pkg of authoredPackages) {
     issues.push(...checkDomainKnowledgeArtifact(index.rootDir, pkg));
   }
 
@@ -1083,6 +1165,7 @@ export function renderKnowledgeIndexMarkdown(
     '',
     `- SMRT packages: ${index.smrtPackages.length}`,
     `- SDK packages: ${index.sdkPackages.length}`,
+    `- Installed dependencies: ${index.installedPackages.length}`,
     `- foreignKey fields: ${index.relationshipsV2.foreignKeyFields}`,
     `- crossPackageRef fields: ${index.relationshipsV2.crossPackageRefFields}`,
     `- junction collections: ${index.relationshipsV2.junctionCollections}`,
@@ -1113,6 +1196,10 @@ export function renderKnowledgeIndexMarkdown(
     lines.push(
       `- docs: ${pkg.docSource ?? '(none)'}${pkg.hasClaudeShim ? ' + CLAUDE.md shim' : ''}`,
     );
+    if (pkg.isInstalledDependency) {
+      lines.push('- source: installed dependency');
+      lines.push(`- AGENTS.md sha256: ${pkg.agentDocSha256 ?? '(none)'}`);
+    }
     if (pkg.moduleDocs.length > 0) {
       lines.push(
         `- module docs: ${pkg.moduleDocs.map((doc) => doc.path).join(', ')}`,
@@ -1557,7 +1644,29 @@ function discoverProjectPackageDirs(rootDir: string): {
   };
 }
 
-function discoverInstalledSdkPackages(
+/**
+ * Installed `@happyvertical/*` packages, resolved once each (#2275).
+ *
+ * Reads the `@happyvertical` scope directory of the project and of every
+ * workspace package — one `readdir` per scope directory, resolving each entry's
+ * real path — instead of descending through `node_modules`. Under pnpm those
+ * entries are symlinks into a store whose entries link back out to each other,
+ * so a descent revisits the same package once per path that reaches it. The
+ * realpath is the dedupe key only: the same store entry reached from three
+ * scope directories is read once, but it is read through its `node_modules`
+ * path, because a realpath is the wrong thing to report. On a host where any
+ * ancestor of the root is a symlink (`/var` on macOS, a symlinked worktree),
+ * `relative(rootDir, realpath)` escapes the root entirely.
+ *
+ * Workspace packages linked into a sibling's `node_modules` are skipped here.
+ * They are authored source that happens to be reachable through a link, and
+ * calling them installed would exempt them from the freshness gate.
+ *
+ * Both SMRT and SDK packages are returned. A consumer app authors neither, and
+ * its `@happyvertical/smrt-*` dependencies are exactly the surface it needs to
+ * audit; excluding them is why the index could see nothing in a consumer app.
+ */
+function discoverInstalledPackages(
   rootDir: string,
   packageDirs: string[],
   includeDocs: boolean,
@@ -1566,35 +1675,58 @@ function discoverInstalledSdkPackages(
     join(rootDir, 'node_modules', '@happyvertical'),
     ...packageDirs.map((dir) => join(dir, 'node_modules', '@happyvertical')),
   ];
+  const workspaceRealPaths = new Set(
+    [rootDir, ...packageDirs].flatMap((dir) => {
+      try {
+        return [realpathSync(dir)];
+      } catch {
+        return [];
+      }
+    }),
+  );
 
-  return scopeDirs
-    .filter(
-      (scopeDir, index, all) =>
-        existsSync(scopeDir) && all.indexOf(scopeDir) === index,
+  const byRealPath = new Map<string, string>();
+  for (const scopeDir of new Set(scopeDirs)) {
+    if (!existsSync(scopeDir)) continue;
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(scopeDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+      const entryPath = join(scopeDir, entry.name);
+      let resolved: string;
+      try {
+        resolved = realpathSync(entryPath);
+      } catch {
+        // A dangling link is not an installed package.
+        continue;
+      }
+      if (workspaceRealPaths.has(resolved)) continue;
+      if (byRealPath.has(resolved)) continue;
+      byRealPath.set(resolved, entryPath);
+    }
+  }
+
+  const packages: KnowledgePackage[] = [];
+  for (const directory of byRealPath.values()) {
+    const packageJson = objectRecord(readJson(join(directory, 'package.json')));
+    const name = packageJson.name;
+    if (typeof name !== 'string') continue;
+    if (
+      !SDK_PACKAGE_NAMES.has(name) &&
+      !name.startsWith('@happyvertical/smrt-')
     )
-    .flatMap((scopeDir) =>
-      readdirSync(scopeDir, { withFileTypes: true })
-        .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
-        .map((entry) => {
-          const entryPath = join(scopeDir, entry.name);
-          try {
-            return lstatSync(entryPath).isSymbolicLink()
-              ? realpathSync(entryPath)
-              : entryPath;
-          } catch {
-            return entryPath;
-          }
-        }),
-    )
-    .filter((dir) => {
-      const pkg = objectRecord(readJson(join(dir, 'package.json')));
-      return (
-        typeof pkg.name === 'string' &&
-        SDK_PACKAGE_NAMES.has(pkg.name) &&
-        !pkg.name.startsWith('@happyvertical/smrt-')
-      );
-    })
-    .map((dir) => readKnowledgePackage(rootDir, dir, includeDocs));
+      continue;
+    packages.push(
+      readKnowledgePackage(rootDir, directory, includeDocs, {
+        installed: true,
+      }),
+    );
+  }
+  return packages.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 function filterKnowledgePackages(
@@ -1610,12 +1742,16 @@ function filterKnowledgePackages(
     switch (options.scope) {
       case 'local':
         return (
-          pkg.kind !== 'sdk' && !pkg.relativeDirectory.includes('node_modules')
+          pkg.kind !== 'sdk' &&
+          !pkg.isInstalledDependency &&
+          !pkg.relativeDirectory.includes('node_modules')
         );
       case 'package':
-        return pkg.kind !== 'sdk';
+        return pkg.kind !== 'sdk' && !pkg.isInstalledDependency;
       case 'sdk':
         return pkg.kind === 'sdk';
+      case 'installed':
+        return pkg.isInstalledDependency;
       case 'project':
       case undefined:
         return true;
@@ -1629,6 +1765,7 @@ function readKnowledgePackage(
   rootDir: string,
   directory: string,
   includeDocs: boolean,
+  options: { installed?: boolean } = {},
 ): KnowledgePackage {
   const packageJson = objectRecord(readJson(join(directory, 'package.json')));
   const dependencies = stringRecord(packageJson.dependencies);
@@ -1690,6 +1827,12 @@ function readKnowledgePackage(
       ? domainKnowledge?.content.agentDoc ||
         (hasAgentsMd ? agentsContent : fallbackClaudeDoc || undefined)
       : undefined,
+    // Always hashed, even when doc bodies are excluded: the hash is the drift
+    // signal, and dropping it with the body would make `includeDocs: false`
+    // useless for a consumer audit (#2275).
+    agentDocSha256: hasAgentsMd
+      ? createHash('sha256').update(agentsContent).digest('hex')
+      : undefined,
     // Prefer the built artifact, but fall back to resolving the links straight
     // from AGENTS.md so a package without a generated smrt-knowledge.json still
     // surfaces its module docs.
@@ -1715,6 +1858,7 @@ function readKnowledgePackage(
     relationshipFeatures: relationshipFeatures(objects),
     isWorkspaceRoot: resolve(directory) === resolve(rootDir),
     isPrivate: packageJson.private === true,
+    isInstalledDependency: options.installed === true,
     objectSource: resolvedObjects.source,
     objectSourceReason: resolvedObjects.reason,
     checkedObjectPaths: resolvedObjects.checkedPaths,
@@ -2955,8 +3099,13 @@ function scopeAllowsPackage(
   switch (scope) {
     case 'sdk':
       return false;
+    case 'installed':
+      return pkg.isInstalledDependency;
     case 'local':
-      return !pkg.relativeDirectory.includes('node_modules');
+      return (
+        !pkg.isInstalledDependency &&
+        !pkg.relativeDirectory.includes('node_modules')
+      );
     case 'package':
     case 'project':
     case undefined:

--- a/packages/smrt-dev-mcp/src/knowledge/index.ts
+++ b/packages/smrt-dev-mcp/src/knowledge/index.ts
@@ -31,9 +31,10 @@ import type {
 export type KnowledgePackageKind = 'smrt' | 'sdk' | 'workspace';
 export type KnowledgeIssueSeverity = 'error' | 'warning';
 /**
- * `installed` is the consumer-app scope (#2275): every `@happyvertical/*`
- * package this project installs, rather than the packages it authors. The other
- * scopes all describe the workspace's own sources.
+ * `installed` is the consumer-app scope (#2275): installed
+ * `@happyvertical/smrt-*` packages and packages in the known HappyVertical SDK
+ * allowlist, rather than packages the project authors. The other scopes all
+ * describe the workspace's own sources.
  */
 export type KnowledgeScope =
   | 'project'
@@ -2976,7 +2977,10 @@ function selectPackages(
   const packageName = options.packageName?.toLowerCase();
   if (packageName) {
     for (const pkg of domainPackages(index)) {
-      if (packageMatches(pkg, packageName)) {
+      if (
+        scopeAllowsPackage(pkg, options.scope) &&
+        packageMatches(pkg, packageName)
+      ) {
         selected.add(pkg);
       }
     }
@@ -3020,7 +3024,7 @@ function selectPackages(
       '@happyvertical/smrt-dev-mcp',
     ]) {
       const pkg = index.smrtPackages.find((item) => item.name === name);
-      if (pkg) selected.add(pkg);
+      if (pkg && scopeAllowsPackage(pkg, options.scope)) selected.add(pkg);
     }
 
     // A downstream product has none of those framework packages in its
@@ -3061,10 +3065,13 @@ function selectSdkPackages(
   const packageName = options.packageName?.toLowerCase();
 
   for (const sdk of index.sdkPackages) {
+    const selectedDependency = sdkNames.has(sdk.name);
+    if (!scopeAllowsSdkPackage(sdk, options.scope, selectedDependency))
+      continue;
     const shortName = sdk.name.replace('@happyvertical/', '');
     if (
       options.scope === 'sdk' ||
-      sdkNames.has(sdk.name) ||
+      selectedDependency ||
       (packageName && packageMatches(sdk, packageName)) ||
       text.includes(sdk.name.toLowerCase()) ||
       includesToken(text, shortName)
@@ -3073,19 +3080,41 @@ function selectSdkPackages(
     }
   }
 
-  if (selected.size === 0) {
+  if (selected.size === 0 && !(packageName && selectedPackages.length === 0)) {
     for (const name of [
       '@happyvertical/ai',
       '@happyvertical/sql',
       '@happyvertical/files',
       '@happyvertical/utils',
     ]) {
-      const sdk = index.sdkPackages.find((item) => item.name === name);
+      const sdk = index.sdkPackages.find(
+        (item) =>
+          item.name === name &&
+          scopeAllowsSdkPackage(item, options.scope, false),
+      );
       if (sdk) selected.add(sdk);
     }
   }
 
   return [...selected].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function scopeAllowsSdkPackage(
+  pkg: KnowledgePackage,
+  scope: KnowledgeScope | undefined,
+  selectedDependency: boolean,
+): boolean {
+  switch (scope) {
+    case 'installed':
+      return pkg.isInstalledDependency;
+    case 'local':
+    case 'package':
+      return !pkg.isInstalledDependency || selectedDependency;
+    case 'sdk':
+    case 'project':
+    case undefined:
+      return true;
+  }
 }
 
 function domainPackages(index: SmrtKnowledgeIndex): KnowledgePackage[] {
@@ -3107,6 +3136,7 @@ function scopeAllowsPackage(
         !pkg.relativeDirectory.includes('node_modules')
       );
     case 'package':
+      return !pkg.isInstalledDependency;
     case 'project':
     case undefined:
       return true;

--- a/packages/smrt-dev-mcp/src/mcp-stdio.test.ts
+++ b/packages/smrt-dev-mcp/src/mcp-stdio.test.ts
@@ -296,6 +296,14 @@ describe('smrt-dev-mcp stdio server', () => {
     );
     expect(projectKnowledge.rootDir).toBe('.');
     expect(projectKnowledge.packages[0]).not.toHaveProperty('directory');
+    // Installed dependencies are the packages whose paths are absolute and
+    // outside the root, so this list is the one that leaks host paths if it is
+    // carried over by a spread instead of rebuilt from sanitized entries
+    // (#2275).
+    expect(Array.isArray(projectKnowledge.installedPackages)).toBe(true);
+    for (const pkg of projectKnowledge.installedPackages) {
+      expect(pkg).not.toHaveProperty('directory');
+    }
 
     const packageUri = resourceUris.find((uri) =>
       uri.startsWith('smrt://knowledge/package/'),


### PR DESCRIPTION
Closes #2275. Parent: #1679.

## What was wrong

`smrt dev:knowledge-check` run from a consumer app that installs the published
packages exhausted the heap. Measured on `happyvertical/s-m-r-t.dev` before this
change: **479 s wall clock, 4.53 GB peak RSS**, then `Ineffective mark-compacts
near heap limit`. `dev:knowledge-index --scope sdk` never returned.

The issue's hypothesis — pnpm's store is a symlink graph with cycles, and the
walk re-visits each package once per path that reaches it — is confirmed, with
one more link in the chain that explains why the same code is fine in this
monorepo:

1. `OxcScanner.discoverFiles` called fast-glob with the default `dot: false`.
   picomatch will not let a `**` cross a dot segment, so `**/node_modules/**`
   pruned `node_modules` at the project root and **nowhere else**. Anything
   under `.svelte-kit/`, `.vercel/`, `.turbo/`, or agent scratch was walked in
   full — and then discarded, because the positive patterns could not match
   there either. Pure waste, and the door into the store.
2. `followSymbolicLinks` defaulted to `true`, so once inside, the walk followed
   pnpm's sibling links and reached the same real directories once per path.
   Traced on the real app: **1.4 M `readdir` calls against ~5 300 real
   directories, 29 files matched**, RSS climbing steadily throughout.

Reproduced with a controlled fixture: with default options fast-glob makes 20
`readdir` calls inside `.dotdir/**/node_modules`; with `dot: true` it makes zero.

Separately, and this is the second half of the issue: `discoverInstalledSdkPackages`
only accepted names in the SDK allowlist and explicitly rejected
`@happyvertical/smrt-*`. Even when it finished, a consumer app's index listed
one package — the app itself — and reported `no-smrt-objects-discovered`.

## What changed

**`packages/scanner`** — the fix belongs here, not in the knowledge module: the
Vite plugin, the manifest generator, and `introspect-project` all point the same
scanner at an application root.

- `discoverFiles` passes `dot: true`, so ignore patterns prune everywhere.
- `MANDATORY_EXCLUDE` (`**/node_modules/**`, `**/.*/**`, `**/.*`) is unioned
  with the caller's `exclude` and cannot be overridden. `exclude` replaces the
  defaults wholesale, so every caller that narrowed it had silently reopened
  `node_modules`; the last entry keeps hidden files out, so turning `dot` on
  does not quietly widen what gets scanned.
- Patterns are rewritten relative to `cwd` first. Globs match as text, so an
  absolute pattern would otherwise hand the dot prune the project's own
  ancestors and a checkout under `~/.worktrees` would discover nothing.
- `followSymbolicLinks` is a new option defaulting to `false`, threaded through
  `smrtPlugin` and `ManifestBuilderOptions` so the build path can opt back in.
  A project that genuinely keeps sources behind a link can ask for them.

**`packages/smrt-dev-mcp`** — a consumer-app mode.

- Installed `@happyvertical/*` packages, SMRT and SDK alike, are resolved by
  enumerating each `node_modules/@happyvertical` scope directory and
  deduplicating by real path — one `readdir` per scope directory, no descent.
- New scope `installed`; `local` and `package` exclude installed dependencies,
  `project` includes them, and the index lists them as `installedPackages`
  (`schemaVersion: 3`).
- Every package now carries `agentDocSha256`, the hash of its shipped
  `AGENTS.md`. That is the drift signal the issue asks for: a version bump is
  not, because most releases do not touch a documented surface.
- The freshness gate skips installed dependencies entirely: indexed, never
  checked. A consumer cannot add an `AGENTS.md` to a package it installs, and a
  published package's artifact hashes cannot match its republished sources.
  Coverage and the zero-objects guard likewise count authored packages only.

## Measurements

Against `happyvertical/s-m-r-t.dev` (21 installed `@happyvertical/smrt-*`
packages, 56 `@happyvertical` store entries), Node 24.18.0, default heap:

| command | before | after |
|---|---|---|
| `dev:knowledge-check --scope project` | 479 s, 4.53 GB, OOM | **0.30 s, 119 MB**, 1 real finding |
| `dev:knowledge-index --scope installed` | n/a (scope did not exist) | **0.04 s, 85 MB**, 21 packages |
| `dev:knowledge-index --scope sdk` | no output in 400 s | 0.04 s |

The output is right, not just fast: all 21 packages with `version`,
`hasAgentsMd`, `exportKeys`, `objectSource: domain-artifact`, and
`agentDocSha256`. The one remaining `knowledge-check` finding is genuine — that
app's `CLAUDE.md` is a full copy rather than an `@AGENTS.md` shim.

This monorepo is unchanged: 85 packages, 63 SMRT, 20 SDK, zero installed
packages leaking into the authored scopes, `knowledge:check --strict` green.

## Regression coverage

`packages/scanner/src/__tests__/scanner-discovery-bounds.test.ts` and
`packages/smrt-dev-mcp/src/knowledge/consumer-app.test.ts` build pnpm-shaped
symlink cliques — branching, not self-referential, because the kernel abandons a
self-link after MAXSYMLINKS but a clique multiplies into `(n-1) ** MAXSYMLINKS`
paths. Reverting only the fast-glob options in `discoverFiles` fails the scanner
suite and every knowledge test in the new file, the termination ones by timeout;
those two are bounded at 5 s each so a regression fails rather than eating the
run. Cheaper deterministic guards sit beside them: a self-referential link
(16 matches before, 1 after), `exclude: []` with a vendored `node_modules`
source, and an absolute include pattern under a `.worktrees/` ancestor. The
knowledge suite asserts the store is never opened at all — one directory read
under `node_modules`, none under `.pnpm`, observed through both `readdirSync`
and `opendirSync`.

## Review

Two reviewers ran the full diff; both found material issues, all fixed here:
the `no-smrt-objects-discovered` guard had become unreachable in any project
with installed SMRT deps (it now counts authored packages, with a new
`no-authored-smrt-objects` warning for the consumer case); installed packages
were reported by real path, which escapes the root wherever an ancestor is a
symlink (`/var` on macOS); a workspace package linked into a sibling's
`node_modules` could be flagged installed and drop out of the gate; the dot
prune could zero discovery for absolute include patterns; `followSymbolicLinks`
had no opt-in path from `smrtPlugin`/`ManifestBuilderOptions`; and
`installedPackages` bypassed the MCP path sanitizer, leaking host paths into
the knowledge resource.

## Follow-ups, not built here

- Point 3 of #2275 — a machine-readable diff against a caller-supplied previous
  state, with a non-zero exit — is deliberately out of scope. `--scope installed
  --format json` is the deterministic projection a caller diffs; the baseline
  file stays with the caller for now.
- `packages/scanner/src/__tests__/benchmark.test.ts` ("should scale linearly
  with file count") compares wall-clock across three identical scans and is a
  pre-existing timing flake. This change adds constant per-entry ignore work
  that cancels in a ratio, but it will read as causal on a scanner PR.
- happyvertical/s-m-r-t.dev#158 replaces that app's local
  `scripts/check-data-freshness.mjs` (whose header asks to be deleted when this
  lands) with this CLI.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-pr2298-reviewfix-20260810","issue":2275,"policy_revision":"1.0.0","status":"complete","head":"bace62c50e0e7d5fe0cfdf536c0d9c76fd5bc2ec","validation":["pnpm build --force (62/62 tasks)","scanner tests 11 files / 205 tests","smrt-dev-mcp tests 10 files / 139 tests","core tests 260 files / 3171 tests","scanner, smrt-dev-mcp, core typechecks","pnpm smrt dev:knowledge-check (0 errors, 0 warnings)","three-perspective review-cycle CLEAN"]}
```
