### PR TITLE
fix(ci): terminalize cancelled publish summaries

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -210,6 +210,12 @@ reason recorded next to the setting or here:
 - `required-ci` and `test-packages-result`, which only read `needs.*.result`.
   Both finish in seconds, so failing fast is correct for a job that just
   reports other jobs' results.
+- Publish Dry Run's `publish-dry-run-summary`, which only downloads and verifies
+  artifacts before reporting upstream results. It runs on GitHub-hosted capacity
+  with a ten-minute hang guard and skips cancelled workflows. Keeping it off the
+  metal lane is required: an `always()` metal summary can be newly queued after
+  an invalidated merge group is cancelled, preventing the run from becoming
+  terminal and making queue-idle checks report phantom work.
 
 `postgres-tests` remains at 45 as a deliberate exception. #2164 retired the unserved
 `arc-happyvertical-node` label, deleted the `node-runner-smoke` workflow that

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -231,15 +231,15 @@ jobs:
     needs:
       - prepare-publish
       - validate-publish-shards
-    # `always()` alone would keep this summary running — and failing on the
-    # missing artifacts — after the two jobs above skip on a pull request, so it
-    # carries the same lane guard (#2214 item 4).
+    # Do not let cancellation enqueue a fresh summary job after GitHub has
+    # invalidated a merge group. This job only verifies artifacts and reports
+    # upstream results, so it must not consume scarce metal capacity.
     if: >-
-      always() &&
+      !cancelled() && always() &&
       (github.event_name != 'pull_request_target' ||
       vars.CI_MERGE_QUEUE_ENABLED != 'true')
-    runs-on: ${{ vars.CI_HOSTED_FALLBACK_ENABLED == 'true' && 'ubuntu-latest' || 'arc-happyvertical-nodocker' }}
-    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository

--- a/scripts/publish-workflow-policy.test.mjs
+++ b/scripts/publish-workflow-policy.test.mjs
@@ -10,9 +10,13 @@ const batchWorkflow = readFileSync(
   new URL('../.github/workflows/on-merge-main.yml', import.meta.url),
   'utf8',
 );
+const publishDryRunWorkflow = readFileSync(
+  new URL('../.github/workflows/publish-dry-run.yml', import.meta.url),
+  'utf8',
+);
 
-function job(name) {
-  const match = workflow.match(
+function job(name, source = workflow) {
+  const match = source.match(
     new RegExp(
       `^  ${name}:\\n([\\s\\S]*?)(?=^  [a-z][a-z0-9-]*:\\n|(?![\\s\\S]))`,
       'm',
@@ -21,6 +25,15 @@ function job(name) {
   assert.ok(match, `workflow job ${name} must exist`);
   return match[0];
 }
+
+test('publish dry-run summary terminalizes cancellation without using metal', () => {
+  const summary = job('publish-dry-run-summary', publishDryRunWorkflow);
+
+  assert.match(summary, /^      !cancelled\(\) && always\(\) &&$/m);
+  assert.match(summary, /^    runs-on: ubuntu-latest$/m);
+  assert.match(summary, /^    timeout-minutes: 10$/m);
+  assert.doesNotMatch(summary, /arc-happyvertical/);
+});
 
 test('final publisher skips workspace installation and allows recovery headroom', () => {
   const publisher = job('publish-release');


### PR DESCRIPTION
Closes #2299.

## What was wrong

Cancelled or invalidated merge-group runs could remain top-level queued indefinitely. The publish-dry-run summary used always() and requested arc-happyvertical-nodocker, so cancellation of its upstream metal work could enqueue a fresh summary job onto the already-starved metal fleet. Normal workflow cancellation did not terminalize that always-job tail, and queue-idle checks counted the zombie runs as active.

During the 2026-08-10 incident, seven invalidated merge-group runs exhibited this exact state. Their heavy jobs were cancelled while only Publish Dry Run / Version And Pack Validation remained queued without a runner.

## What changed

- The publish summary now skips cancelled workflows with !cancelled().
- The control-plane summary runs on ubuntu-latest rather than metal.
- Its hang guard is reduced from 45 to 10 minutes.
- Workflow-policy coverage locks the condition, hosted runner, timeout, and absence of a metal label.
- CI documentation records the invariant and the failure mode.

## Validation

- node --test scripts/publish-workflow-policy.test.mjs (3 passed)
- pnpm exec actionlint .github/workflows/publish-dry-run.yml
- pnpm test:ci-scripts (42 passed)
- pnpm build / forced final rebuild (62 tasks)
- pnpm typecheck (122 tasks)
- pnpm test (full monorepo, 64 packages)
- pnpm lint
- pnpm format-check plus pre-push formatter (2863 files)
- pnpm audit:policy
- pnpm smrt dev:knowledge-check and strict pre-push knowledge check (0 errors, 0 warnings)
- pre-commit and pre-push workflow validation

## Review

Three independent review-cycle passes covered correctness, security/operations, and tests/documentation. All returned clean on the committed revision.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019fecc6-fbb4-7ea3-8828-1b772139eee3","issue":2299,"policy_revision":"1.0.0","status":"complete","validation":["publish workflow policy 3 tests","CI scripts 42 tests","actionlint","build 62 tasks","typecheck 122 tasks","full monorepo test 64 packages","lint and format","audit policy","strict knowledge check 0 errors 0 warnings","three-perspective review-cycle clean"]}
```
