### PR TITLE
fix(template-sveltekit): declare the generated MCP server's runtime deps

### DIFF
--- a/packages/template-sveltekit/AGENTS.md
+++ b/packages/template-sveltekit/AGENTS.md
@@ -17,6 +17,16 @@ It is the ground-up alternative to `smrt-saas-starter`.
 - Directly used `@happyvertical/smrt-*` packages share one current release range.
 - `@happyvertical/smrt-cli` is a direct dev dependency because scripts/docs use
   its binary. `@happyvertical/smrt-web` stays opt-in until a page imports it.
+- The generated MCP server resolves its imports from the scaffolded app, not
+  from the CLI, so every specifier `generate-mcp` emits must be declared here.
+  `@modelcontextprotocol/server` (plus its `/stdio` subpath),
+  `@happyvertical/smrt-core`, and `@happyvertical/smrt-config` are always
+  emitted and are always dependencies. `@happyvertical/smrt-jobs` (task actions)
+  and `@happyvertical/smrt-tenancy` (tenant-scoped objects) are conditional;
+  tenancy is already a dependency for other reasons, and jobs is documented in
+  the template README as an add-when-needed. Do not assume pnpm exposes the
+  CLI's or core's transitive dependencies to the app root — its strict layout
+  does not (#2297).
 - `smrtConsumer()` explicitly consumes profiles, tenancy, and users manifests;
   `smrtPlugin()` scans `src/lib/objects`, generates Vite virtual definitions,
   SvelteKit routes, runtime registration, and knowledge artifacts.

--- a/packages/template-sveltekit/template.config.js
+++ b/packages/template-sveltekit/template.config.js
@@ -19,12 +19,14 @@ export default {
 
   // Dependencies to add to generated project
   dependencies: {
+    '@happyvertical/smrt-config': '^0.40.62',
     '@happyvertical/smrt-core': '^0.40.62',
     '@happyvertical/smrt-profiles': '^0.40.62',
     '@happyvertical/smrt-svelte': '^0.40.62',
     '@happyvertical/smrt-tenancy': '^0.40.62',
     '@happyvertical/smrt-ui': '^0.40.62',
     '@happyvertical/smrt-users': '^0.40.62',
+    '@modelcontextprotocol/server': '^2.0.0',
   },
 
   devDependencies: {

--- a/packages/template-sveltekit/template/README.md
+++ b/packages/template-sveltekit/template/README.md
@@ -227,7 +227,27 @@ Generate a standalone MCP server when you are ready to configure a transport:
 pnpm smrt generate-mcp --no-config --no-readme
 ```
 
-The output is `.smrt/mcp-server/index.js`. It is generated and ignored.
+The output is `.smrt/mcp-server/index.js`. It is generated and ignored. Run it
+with:
+
+```bash
+node .smrt/mcp-server/index.js
+```
+
+The generated entry resolves its imports from this project, not from the CLI, so
+every module it imports must be a dependency here. `@modelcontextprotocol/server`,
+`@happyvertical/smrt-core`, and `@happyvertical/smrt-config` are always imported
+and are already declared. Two more are emitted only when your objects need them,
+and you must add them yourself:
+
+| Emitted when | Dependency | Already declared? |
+| --- | --- | --- |
+| An exposed object declares task actions (`@smrt({ mcp: { tasks: true } })`) | `@happyvertical/smrt-jobs` | No — add it |
+| An exposed object is tenant-scoped | `@happyvertical/smrt-tenancy` | Yes |
+
+Add the jobs package on the same release line as the other
+`@happyvertical/smrt-*` pins in `package.json`, then reinstall. Missing one of
+these fails at startup with `ERR_MODULE_NOT_FOUND` naming the package to add.
 
 WebMCP is opt-in per browser surface. First add the browser runtime, then put
 registration in a dedicated page that actually exposes tools:

--- a/packages/template-sveltekit/template/package.json
+++ b/packages/template-sveltekit/template/package.json
@@ -28,11 +28,13 @@
     "@happyvertical/smrt-cli": "^0.40.62"
   },
   "dependencies": {
+    "@happyvertical/smrt-config": "^0.40.62",
     "@happyvertical/smrt-core": "^0.40.62",
     "@happyvertical/smrt-profiles": "^0.40.62",
     "@happyvertical/smrt-svelte": "^0.40.62",
     "@happyvertical/smrt-tenancy": "^0.40.62",
     "@happyvertical/smrt-ui": "^0.40.62",
-    "@happyvertical/smrt-users": "^0.40.62"
+    "@happyvertical/smrt-users": "^0.40.62",
+    "@modelcontextprotocol/server": "^2.0.0"
   }
 }


### PR DESCRIPTION
Closes #2297.

Split out of #2279 / PR #2295, which made the generated MCP server itself runnable but left the template it is documented against unable to load it.

## The problem

`smrt generate-mcp` emits an entry that imports, unconditionally:

- `@modelcontextprotocol/server` and `@modelcontextprotocol/server/stdio`
- `@happyvertical/smrt-core`
- `@happyvertical/smrt-config`

The template declared only `@happyvertical/smrt-core`. pnpm's strict layout does not make the CLI's or core's transitive dependencies resolvable from the app root, so `node .smrt/mcp-server/index.js` — the exact command `template/README.md` documents — died before the server started:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@modelcontextprotocol/server'
imported from .../scaffold/.smrt/mcp-server/index.js
```

Probing a freshly scaffolded, freshly installed app confirms which specifiers were reachable and which were not:

| Specifier | Before |
| --- | --- |
| `@happyvertical/smrt-core` | resolves |
| `@happyvertical/smrt-tenancy` | resolves |
| `@happyvertical/smrt-config` | **`ERR_MODULE_NOT_FOUND`** |
| `@modelcontextprotocol/server` | **`ERR_MODULE_NOT_FOUND`** |
| `@happyvertical/smrt-jobs` | `ERR_MODULE_NOT_FOUND` (conditional — see below) |

## The change

Four files, all in `packages/template-sveltekit`:

- **`template/package.json`** — add `@happyvertical/smrt-config` and `@modelcontextprotocol/server` to the scaffolded `dependencies`.
- **`template.config.js`** — mirror both entries. `__tests__/templateMetadata.test.ts` asserts the gnode metadata and the scaffolded manifest are equal, and the two scaffolding paths (`copyTemplate()` vs `smrt gnode create`) read different ones.
- **`template/README.md`** — document running the server, and the two *conditionally* emitted imports a consumer has to add themselves.
- **`AGENTS.md`** — record the underlying invariant: the generated server resolves from the scaffolded app, so every specifier `generate-mcp` emits has to be declared in the template.

### Version pinning

The smrt entry uses the template's existing `^0.40.62` release range, which `scripts/sync-template-versions.mjs` rewrites to the published version at release time (it matches `@happyvertical/smrt-*` only, and Renovate is configured to skip these files).

`@modelcontextprotocol/server` is pinned `^2.0.0`. The monorepo pins it exactly `2.0.0` in its own four packages, but that convention exists for Renovate-managed internal manifests; this file ships to consumers, where every other third-party dep is already a caret range and the scaffolded app carries its own lockfile. The generated code is coupled to the v2 API surface (`serveStdio`, string-keyed request handlers), so `^2.0.0` is the correct semver expression of that. There is no pnpm catalog entry for `@modelcontextprotocol/*` to reuse.

### Conditional imports

Two more specifiers are emitted only under a predicate, so declaring them unconditionally would put unused runtime deps in every scaffold. They are documented instead:

| Emitted when | Dependency | Already declared? |
| --- | --- | --- |
| An exposed object declares task actions | `@happyvertical/smrt-jobs` | No — README tells you to add it |
| An exposed object is tenant-scoped | `@happyvertical/smrt-tenancy` | Yes |

## Verification

#2295 **had landed** on `origin/main` (`26d35dd9f`) when this was verified, so this branch is based on it and the normal `.js` target was exercised — no `.ts` workaround needed.

Verified against the real path rather than a unit test, using the local post-#2295 CLI to generate and the app's own npm-installed dependencies to run:

1. `copyTemplate()` → fresh scaffold
2. `pnpm install` — both new deps resolved from npm (`smrt-config@0.40.62`, `@modelcontextprotocol/server@2.0.0`)
3. `vite build` — **83 objects registered**
4. `smrt generate-mcp --no-config --no-readme` — emitted bare imports are exactly `@modelcontextprotocol/server`, `.../stdio`, `@happyvertical/smrt-core`, `@happyvertical/smrt-config`, all now declared
5. `node .smrt/mcp-server/index.js` + MCP `initialize` handshake over stdio:

```
initialize OK
  protocolVersion: 2025-06-18
  serverInfo:      mcp-repro-after 1.0.0
  capabilities:    {"tools":{}}
tools/list OK — 759 tools
```

The same scaffold built from the pre-fix template, run through the identical harness, fails at `@modelcontextprotocol/server`.

## Other scaffolds

Checked, as the issue asks. Neither is folded in here:

- **`smrt init`** (`packages/cli/src/commands/init.ts`) — the gap exists but is a **materially different problem**. `init` is an in-place initializer for an existing SvelteKit project and **never writes or patches `package.json` at all**; it only reads it to detect SvelteKit and then prints an untracked `npm install @happyvertical/smrt-core` hint. Fixing it means making `init` manage dependencies, which is a behavior change rather than a dependency-list edit. Filed separately as #2301.
- **`smrt-app-mcp`** — **not a scaffold**. It is a published runtime library (`createMcpAppServer()`, `mountMcpRoute`), and it already correctly declares `@modelcontextprotocol/server` and `@happyvertical/smrt-jobs`. No gap.
- **`template-site-static-json`** (a third scaffold, not named in the issue) — declares `smrt-core` and `smrt-config` but not `@modelcontextprotocol/server`. Deliberately left alone: it contains **zero `@smrt()` objects**, uses `adapter-static`, and mentions MCP nowhere in its README or config, so `generate-mcp` there would emit a toolless server. Adding an MCP runtime dep to a static-site scaffold would be dead weight, not a fix.

## Validation

| Check | Result |
| --- | --- |
| `pnpm --filter @happyvertical/smrt-template-sveltekit test` | 6 files / **29 passed** |
| `smrt dev:knowledge-check` | 0 errors, 0 warnings |
| `node scripts/sync-template-versions.mjs --check` | in sync with `^0.40.62` |
| `node scripts/check-standards.mjs` | 63 packages, 0 violations |
| `pnpm check:agents-chain` | 66 chains under 32768 bytes |
| End-to-end scaffold → generate → `initialize` handshake | pass (above) |

Two honest notes:

- **biome does not cover these files.** All four changed paths are ignored by `biome.json` (`Checked 0 files`), so biome is not a gate here — the template tests and the standards/version-sync checkers are.
- **`node scripts/check-readmes.mjs` reports 3 failures, all pre-existing on `main`** and none in files this PR touches: a missing root-catalog row for `packages/fields/README.md`, and obsolete `SMRT` prose in `packages/core/README.md` and `packages/fields/README.md`. `git diff origin/main --name-only` on this branch returns only the four `template-sveltekit` paths.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude-code","session":"1959f06c-b7c2-4179-8636-b67c71723ae6","issue":2297,"policy_revision":"1.0.0","status":"complete","validation":["template-sveltekit tests 6 files / 29 passed","smrt dev:knowledge-check 0 errors / 0 warnings","sync-template-versions --check in sync with ^0.40.62","check-standards 63 packages / 0 violations","check-agents-chain 66 chains under limit","end-to-end: scaffold + pnpm install + vite build (83 objects) + generate-mcp + node .smrt/mcp-server/index.js + MCP initialize handshake + tools/list 759 tools","pre-fix scaffold reproduces ERR_MODULE_NOT_FOUND on @modelcontextprotocol/server through the identical harness","biome ignores all four changed paths (not a gate here)","check-readmes 3 failures all pre-existing on main in untouched files"]}
```
