### PR TITLE
feat(core): add bounded collection read plans

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -76,6 +76,18 @@ operator against a database to keep the two in step.
 
 STI child collections auto-filter by `_meta_type`.
 
+## Bounded Collection Read Plans
+
+Use `executeCollectionReadPlan()` when one operation needs several independent
+collections. It bounds top-level `collection.list()` concurrency while keeping
+all reads on the normal registry/collection path. Callers must choose an
+explicit positive `maxConcurrency` and pass their normal shared
+`collectionOptions` when database or tenant context matters.
+
+The executor deliberately does not compose SQL, cache the plan, or change pool
+defaults. On failure it stops starting queued entries, drains operations already
+in flight, and rethrows the first error.
+
 ## Object Memory & Semantic Search
 
 Two persistence primitives every `SmrtObject`/`SmrtCollection` inherits — load-bearing for learning agents, usable by any object. Full guide: `docs/content/core.md` → "Context Memory System".

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -67,6 +67,44 @@ const results = await products.list({
 
 ```
 
+### Bounded multi-collection reads
+
+When one request needs several independent collections, use a keyed read plan
+instead of an unbounded `Promise.all`. Every entry still uses the normal
+collection `list()` path, but only the requested number of operations run at
+once:
+
+```typescript
+import {
+  executeCollectionReadPlan,
+  type SmrtCollectionReadPlanEntry,
+} from '@happyvertical/smrt-core';
+
+const categories: SmrtCollectionReadPlanEntry<Category> = {
+  className: 'Category',
+  options: { orderBy: 'name ASC' },
+};
+const products: SmrtCollectionReadPlanEntry<Product> = {
+  className: 'Product',
+  options: { where: { isPublished: true }, orderBy: 'name ASC' },
+};
+const records = await executeCollectionReadPlan(
+  {
+    categories,
+    products,
+  },
+  {
+    collectionOptions: { db: 'file:products.db' },
+    maxConcurrency: 2,
+  },
+);
+```
+
+`maxConcurrency` is required and must be a positive integer. If an entry
+fails, the executor starts no further queued entries, waits for already-running
+entries to settle, and rethrows the first error. Read plans do not compose SQL,
+cache whole-plan results, or change database pool defaults.
+
 ### Generate metadata and migrate
 
 Configure Vite 8's Oxc decorator transform and point `smrtPlugin()` at the

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -173,7 +173,7 @@
     "generate": "node scripts/generate-manifest.js",
     "generate:test": "node scripts/generate-test-manifest.js",
     "test": "node scripts/generate-test-manifest.js && vitest run",
-    "test:postgres": "node scripts/generate-test-manifest.js && NODE_OPTIONS=--trace-deprecation node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/__tests__/change-feed-concurrency.optional.test.ts src/__tests__/issue-2069-postgres-date-instant.optional.test.ts src/__tests__/issue-2070-postgres-hydration.optional.test.ts",
+    "test:postgres": "node scripts/generate-test-manifest.js && NODE_OPTIONS=--trace-deprecation node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/__tests__/change-feed-concurrency.optional.test.ts src/__tests__/collection-read-plan-postgres.optional.test.ts src/__tests__/issue-2069-postgres-date-instant.optional.test.ts src/__tests__/issue-2070-postgres-hydration.optional.test.ts",
     "test:integration": "TEST_INTEGRATION=1 vitest run src/__tests__/full-registry-integration.test.ts src/__tests__/manifest-no-leak.test.ts",
     "test:watch": "node scripts/generate-test-manifest.js && vitest",
     "build": "node scripts/generate-manifest.js && vite build && cp -r src/vite-plugin/templates dist/vite-plugin/ && cp -r scripts dist/ && cp src/manifest/static-manifest.json dist/manifest.json && cp src/manifest/smrt-knowledge.json dist/smrt-knowledge.json",

--- a/packages/core/src/__tests__/collection-read-plan-isolation.test.ts
+++ b/packages/core/src/__tests__/collection-read-plan-isolation.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Real registry/database isolation coverage for bounded read plans (#2304).
+ */
+
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { executeCollectionReadPlan } from '../collection-read-plan';
+import { SmrtObject } from '../object';
+import { ObjectRegistry, smrt } from '../registry';
+import { getTestDatabase } from '../testing/database';
+
+@smrt()
+class ReadPlanIsolationProbe extends SmrtObject {
+  marker: string = '';
+}
+
+describe('bounded read plan database isolation (#2304)', () => {
+  let databaseA: DatabaseInterface;
+  let databaseB: DatabaseInterface;
+
+  beforeAll(async () => {
+    [databaseA, databaseB] = await Promise.all([
+      getTestDatabase({
+        type: 'sqlite',
+        url: ':memory:',
+        classes: ['ReadPlanIsolationProbe'],
+      }),
+      getTestDatabase({
+        type: 'sqlite',
+        url: ':memory:',
+        classes: ['ReadPlanIsolationProbe'],
+      }),
+    ]);
+
+    const [recordsA, recordsB] = await Promise.all([
+      ObjectRegistry.getCollection<ReadPlanIsolationProbe>(
+        'ReadPlanIsolationProbe',
+        { db: databaseA },
+      ),
+      ObjectRegistry.getCollection<ReadPlanIsolationProbe>(
+        'ReadPlanIsolationProbe',
+        { db: databaseB },
+      ),
+    ]);
+    await Promise.all([
+      recordsA.create({ marker: 'tenant-a' }),
+      recordsB.create({ marker: 'tenant-b' }),
+    ]);
+  });
+
+  afterAll(async () => {
+    await Promise.all([databaseA.close?.(), databaseB.close?.()]);
+  });
+
+  it('does not reuse registry or read-cache state across databases', async () => {
+    const plan = {
+      records: {
+        className: 'ReadPlanIsolationProbe',
+        options: { cache: { ttl: 60_000 } },
+      },
+    };
+
+    const [resultA, resultB] = await Promise.all([
+      executeCollectionReadPlan(plan, {
+        collectionOptions: { db: databaseA },
+        maxConcurrency: 1,
+      }),
+      executeCollectionReadPlan(plan, {
+        collectionOptions: { db: databaseB },
+        maxConcurrency: 1,
+      }),
+    ]);
+
+    expect(resultA.records.map((record) => record.marker)).toEqual([
+      'tenant-a',
+    ]);
+    expect(resultB.records.map((record) => record.marker)).toEqual([
+      'tenant-b',
+    ]);
+  });
+});

--- a/packages/core/src/__tests__/collection-read-plan-postgres.optional.test.ts
+++ b/packages/core/src/__tests__/collection-read-plan-postgres.optional.test.ts
@@ -1,0 +1,160 @@
+/**
+ * PostgreSQL pool behavior for bounded collection read plans (issue #2304).
+ *
+ * Runs only in the dedicated disposable PostgreSQL shard. The test lets an
+ * initialized read pool expire to zero clients, then proves that a 26-read
+ * plan keeps the cold pool at or below the requested concurrency while using
+ * the normal collection query path.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { getDatabase } from '@happyvertical/sql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection.js';
+import { executeCollectionReadPlan } from '../collection-read-plan.js';
+import { field } from '../decorators/index.js';
+import { SmrtObject } from '../object.js';
+import { ObjectRegistry, smrt } from '../registry.js';
+
+const pgUrl = process.env.SMRT_TEST_POSTGRES_URL;
+const TABLE = 'issue_2304_read_plan_probes';
+
+@smrt({ tableName: 'issue_2304_read_plan_probes' })
+class Issue2304ReadPlanProbe extends SmrtObject {
+  @field()
+  position: number = 0;
+}
+
+class Issue2304ReadPlanProbeCollection extends SmrtCollection<Issue2304ReadPlanProbe> {
+  static readonly _itemClass = Issue2304ReadPlanProbe;
+}
+
+interface PublicPoolCounters {
+  idleCount: number;
+  totalCount: number;
+  waitingCount: number;
+}
+
+function poolCounters(db: DatabaseInterface): PublicPoolCounters {
+  return db.client as PublicPoolCounters;
+}
+
+async function waitForPoolExpiry(
+  pool: PublicPoolCounters,
+  timeoutMs = 15_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (pool.totalCount > 0) {
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `PostgreSQL pool did not expire within ${timeoutMs}ms (total=${pool.totalCount}, idle=${pool.idleCount})`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
+describe.skipIf(!pgUrl)('bounded read plan PostgreSQL pool (#2304)', () => {
+  let adminDb: DatabaseInterface;
+  let readDb: DatabaseInterface;
+
+  beforeAll(async () => {
+    adminDb = (await getDatabase({
+      type: 'postgres',
+      url: pgUrl,
+      dbid: `smrt-test-read-plan-admin-${randomUUID()}`,
+      max: 1,
+    } as Parameters<typeof getDatabase>[0])) as DatabaseInterface;
+
+    await adminDb.query(`DROP TABLE IF EXISTS "${TABLE}"`);
+    const registration = ObjectRegistry.getClassByConstructor(
+      Issue2304ReadPlanProbe,
+    );
+    const className =
+      registration?.qualifiedName ||
+      registration?.name ||
+      Issue2304ReadPlanProbe.name;
+    const ddl = ObjectRegistry.getSchemaDDL(className, 'postgres');
+    if (!ddl) throw new Error(`Missing schema DDL for ${className}`);
+    await adminDb.query(ddl);
+
+    for (const position of [1, 2, 3]) {
+      const id = randomUUID();
+      await adminDb.insert(TABLE, {
+        id,
+        slug: id,
+        context: '',
+        created_at: new Date(),
+        updated_at: new Date(),
+        position,
+      });
+    }
+
+    readDb = (await getDatabase({
+      type: 'postgres',
+      url: pgUrl,
+      dbid: `smrt-test-read-plan-reader-${randomUUID()}`,
+      max: 20,
+    } as Parameters<typeof getDatabase>[0])) as DatabaseInterface;
+
+    // Initialize and cache the collection before measuring only the read plan.
+    await ObjectRegistry.getCollection<Issue2304ReadPlanProbe>(
+      'Issue2304ReadPlanProbe',
+      { db: readDb },
+    );
+    await waitForPoolExpiry(poolCounters(readDb));
+  }, 30_000);
+
+  afterAll(async () => {
+    try {
+      await readDb?.close?.();
+      await adminDb?.query(`DROP TABLE IF EXISTS "${TABLE}"`);
+    } finally {
+      await adminDb?.close?.();
+      ObjectRegistry.clear();
+    }
+  });
+
+  it('opens at most maxConcurrency clients for 26 cold reads', async () => {
+    const pool = poolCounters(readDb);
+    expect(pool.totalCount).toBe(0);
+
+    const originalQuery = readDb.query.bind(readDb);
+    let queryCount = 0;
+    readDb.query = ((...args: unknown[]) => {
+      queryCount += 1;
+      return (originalQuery as (...queryArgs: unknown[]) => unknown)(...args);
+    }) as DatabaseInterface['query'];
+
+    const plan = Object.fromEntries(
+      Array.from({ length: 26 }, (_, index) => [
+        `read${index}`,
+        {
+          className: 'Issue2304ReadPlanProbe',
+          options: { orderBy: 'position ASC' },
+        },
+      ]),
+    );
+
+    const result = await executeCollectionReadPlan(plan, {
+      collectionOptions: { db: readDb },
+      maxConcurrency: 2,
+    });
+
+    expect(queryCount).toBe(26);
+    expect(pool.totalCount).toBeGreaterThan(0);
+    expect(pool.totalCount).toBeLessThanOrEqual(2);
+    expect(pool.idleCount).toBe(pool.totalCount);
+    expect(pool.waitingCount).toBe(0);
+
+    const resultShapes = Object.values(result).map((rows) =>
+      JSON.stringify(rows),
+    );
+    expect(new Set(resultShapes).size).toBe(1);
+    const orderedRows = JSON.parse(resultShapes[0]) as Array<{
+      position: number;
+    }>;
+    expect(orderedRows.map((row) => row.position)).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/core/src/__tests__/issue-117-memory-leak-prevention.test.ts
+++ b/packages/core/src/__tests__/issue-117-memory-leak-prevention.test.ts
@@ -230,6 +230,26 @@ describe('Issue #117: Memory Leak Prevention', () => {
   });
 
   describe('Cache Key Uniqueness', () => {
+    it('keeps string database options isolated', async () => {
+      const databaseA = `file:${path.join(tempDir, 'string-db-a.db')}`;
+      const databaseB = `file:${path.join(tempDir, 'string-db-b.db')}`;
+      const collection1 = await ObjectRegistry.getCollection<CacheTestObject>(
+        'CacheTestObject',
+        { db: databaseA },
+      );
+      const collection2 = await ObjectRegistry.getCollection<CacheTestObject>(
+        'CacheTestObject',
+        { db: databaseB },
+      );
+      const collection1Again =
+        await ObjectRegistry.getCollection<CacheTestObject>('CacheTestObject', {
+          db: databaseA,
+        });
+
+      expect(collection1).not.toBe(collection2);
+      expect(collection1Again).toBe(collection1);
+    });
+
     it('should cache different persistence configurations separately', async () => {
       const collection1 = await ObjectRegistry.getCollection<CacheTestObject>(
         'CacheTestObject',

--- a/packages/core/src/__typechecks__/collection-read-plan.ts
+++ b/packages/core/src/__typechecks__/collection-read-plan.ts
@@ -57,6 +57,22 @@ type ProjectionIncludeIsRejected = Expect<
   >
 >;
 
+type MixedOptions =
+  | { limit: number; select?: undefined }
+  | { select: readonly ['id']; include?: never };
+type MixedEntry = SmrtCollectionReadPlanEntry<ReadPlanTypeProbe, MixedOptions>;
+const mixed: MixedEntry = {
+  className: 'ReadPlanTypeProbe',
+  options: { select: ['id'] },
+};
+type MixedResult = SmrtCollectionReadPlanResult<{ mixed: MixedEntry }>;
+type MixedResultIsSound = Expect<
+  Equal<
+    MixedResult['mixed'],
+    ReadPlanTypeProbe[] | { id: string | null | undefined }[]
+  >
+>;
+
 // @ts-expect-error projection-typed entries require their projection options
 const missingProjectionOptions: SmrtCollectionReadPlanEntry<
   ReadPlanTypeProbe,
@@ -93,4 +109,5 @@ export type CollectionReadPlanTypeAssertions = [
   ProjectedResultIsTyped,
   InvalidOptionsAreRejected,
   ProjectionIncludeIsRejected,
+  MixedResultIsSound,
 ];

--- a/packages/core/src/__typechecks__/collection-read-plan.ts
+++ b/packages/core/src/__typechecks__/collection-read-plan.ts
@@ -45,6 +45,26 @@ type InvalidOptionsAreRejected = Expect<
     false
   >
 >;
+type ProjectionIncludeIsRejected = Expect<
+  Equal<
+    {
+      select: readonly ['id'];
+      include: string[];
+    } extends NonNullable<SmrtCollectionReadPlan[string]['options']>
+      ? true
+      : false,
+    false
+  >
+>;
+
+// @ts-expect-error projection-typed entries require their projection options
+const missingProjectionOptions: SmrtCollectionReadPlanEntry<
+  ReadPlanTypeProbe,
+  { select: readonly ['id'] }
+> = {
+  className: 'ReadPlanTypeProbe',
+};
+void missingProjectionOptions;
 
 async function validateExecutorInference(): Promise<void> {
   const result = await executeCollectionReadPlan(
@@ -72,4 +92,5 @@ export type CollectionReadPlanTypeAssertions = [
   PlainResultIsTyped,
   ProjectedResultIsTyped,
   InvalidOptionsAreRejected,
+  ProjectionIncludeIsRejected,
 ];

--- a/packages/core/src/__typechecks__/collection-read-plan.ts
+++ b/packages/core/src/__typechecks__/collection-read-plan.ts
@@ -1,0 +1,75 @@
+import {
+  executeCollectionReadPlan,
+  type SmrtCollectionReadPlan,
+  type SmrtCollectionReadPlanEntry,
+  type SmrtCollectionReadPlanResult,
+} from '../collection-read-plan';
+import type { SmrtObject } from '../object';
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <
+    Value,
+  >() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Value extends true> = Value;
+
+type ReadPlanTypeProbe = SmrtObject & { name: string };
+
+const plain: SmrtCollectionReadPlanEntry<ReadPlanTypeProbe> = {
+  className: 'ReadPlanTypeProbe',
+};
+const projected: SmrtCollectionReadPlanEntry<
+  ReadPlanTypeProbe,
+  { select: readonly ['id', 'name'] }
+> = {
+  className: 'ReadPlanTypeProbe',
+  options: { select: ['id', 'name'] },
+};
+
+type Result = SmrtCollectionReadPlanResult<{
+  plain: typeof plain;
+  projected: typeof projected;
+}>;
+type PlainResultIsTyped = Expect<Equal<Result['plain'], ReadPlanTypeProbe[]>>;
+type ProjectedResultIsTyped = Expect<
+  Equal<Result['projected'], { id: string | null | undefined; name: string }[]>
+>;
+type InvalidOptionsAreRejected = Expect<
+  Equal<
+    { limit: string } extends NonNullable<
+      SmrtCollectionReadPlan[string]['options']
+    >
+      ? true
+      : false,
+    false
+  >
+>;
+
+async function validateExecutorInference(): Promise<void> {
+  const result = await executeCollectionReadPlan(
+    { plain, projected },
+    { maxConcurrency: 1 },
+  );
+  type ExecutorPlainResultIsTyped = Expect<
+    Equal<typeof result.plain, ReadPlanTypeProbe[]>
+  >;
+  type ExecutorProjectedResultIsTyped = Expect<
+    Equal<
+      typeof result.projected,
+      { id: string | null | undefined; name: string }[]
+    >
+  >;
+  const assertions: [
+    ExecutorPlainResultIsTyped,
+    ExecutorProjectedResultIsTyped,
+  ] = [true, true];
+  void assertions;
+}
+void validateExecutorInference;
+
+export type CollectionReadPlanTypeAssertions = [
+  PlainResultIsTyped,
+  ProjectedResultIsTyped,
+  InvalidOptionsAreRejected,
+];

--- a/packages/core/src/collection-read-plan.test.ts
+++ b/packages/core/src/collection-read-plan.test.ts
@@ -1,0 +1,243 @@
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+import type { SmrtCollection } from './collection';
+import {
+  executeCollectionReadPlan,
+  type SmrtCollectionReadPlanEntry,
+} from './collection-read-plan';
+import { SmrtObject } from './object';
+import { ObjectRegistry } from './registry';
+
+class ReadPlanProbe extends SmrtObject {
+  name: string = '';
+}
+
+function mockCollection(
+  list: (options?: unknown) => Promise<unknown[]>,
+): SmrtCollection<ReadPlanProbe> {
+  return { list } as unknown as SmrtCollection<ReadPlanProbe>;
+}
+
+function fakeDatabase(url: string): DatabaseInterface {
+  return {
+    close: vi.fn(),
+    query: vi.fn(),
+    url,
+  } as unknown as DatabaseInterface;
+}
+
+describe('executeCollectionReadPlan', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('preserves plan keys and model result typing', async () => {
+    vi.spyOn(ObjectRegistry, 'getCollection').mockImplementation(
+      async (className: string) =>
+        mockCollection(async () => {
+          await new Promise((resolve) =>
+            setTimeout(resolve, className === 'AlphaProbe' ? 5 : 1),
+          );
+          return [{ name: className } as unknown as ReadPlanProbe];
+        }),
+    );
+
+    const alpha: SmrtCollectionReadPlanEntry<ReadPlanProbe> = {
+      className: 'AlphaProbe',
+    };
+    const beta: SmrtCollectionReadPlanEntry<ReadPlanProbe> = {
+      className: 'BetaProbe',
+    };
+    const result = await executeCollectionReadPlan(
+      { alpha, beta },
+      { maxConcurrency: 2 },
+    );
+
+    expectTypeOf(result).toMatchTypeOf<{
+      alpha: ReadPlanProbe[];
+      beta: ReadPlanProbe[];
+    }>();
+    expect(Object.keys(result)).toEqual(['alpha', 'beta']);
+    expect(result.alpha[0].name).toBe('AlphaProbe');
+    expect(result.beta[0].name).toBe('BetaProbe');
+  });
+
+  it('returns special plan keys as own data properties', async () => {
+    vi.spyOn(ObjectRegistry, 'getCollection').mockResolvedValue(
+      mockCollection(async () => []),
+    );
+    const plan = Object.fromEntries([
+      ['__proto__', { className: 'ReadPlanProbe' }],
+    ]);
+
+    const result = await executeCollectionReadPlan(plan, {
+      maxConcurrency: 1,
+    });
+
+    expect(Object.hasOwn(result, '__proto__')).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(result, '__proto__')?.value).toEqual(
+      [],
+    );
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+  });
+
+  it('never exceeds the configured list-operation concurrency', async () => {
+    let active = 0;
+    let maximumActive = 0;
+
+    vi.spyOn(ObjectRegistry, 'getCollection').mockImplementation(
+      async (className: string) =>
+        mockCollection(async () => {
+          active += 1;
+          maximumActive = Math.max(maximumActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          active -= 1;
+          return [{ name: className } as unknown as ReadPlanProbe];
+        }),
+    );
+
+    const result = await executeCollectionReadPlan(
+      Object.fromEntries(
+        Array.from({ length: 7 }, (_, index) => [
+          `entry${index}`,
+          { className: `Probe${index}` },
+        ]),
+      ),
+      { maxConcurrency: 2 },
+    );
+
+    expect(maximumActive).toBe(2);
+    expect(active).toBe(0);
+    expect(Object.keys(result)).toHaveLength(7);
+  });
+
+  it('forwards list options and retains projection result typing', async () => {
+    const list = vi.fn(async () => [{ id: 'probe-1', name: 'Published' }]);
+    vi.spyOn(ObjectRegistry, 'getCollection').mockResolvedValue(
+      mockCollection(list),
+    );
+
+    const projection: SmrtCollectionReadPlanEntry<
+      ReadPlanProbe,
+      {
+        orderBy: string;
+        select: readonly ['id', 'name'];
+      }
+    > = {
+      className: 'ReadPlanProbe',
+      options: {
+        orderBy: 'name ASC',
+        select: ['id', 'name'] as const,
+      },
+    };
+
+    const result = await executeCollectionReadPlan(
+      { published: projection },
+      { maxConcurrency: 1 },
+    );
+
+    expectTypeOf(result.published).toEqualTypeOf<
+      { id: string | null | undefined; name: string }[]
+    >();
+    expect(list).toHaveBeenCalledWith(projection.options);
+    expect(result.published).toEqual([{ id: 'probe-1', name: 'Published' }]);
+  });
+
+  it.each([
+    0,
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+  ])('rejects maxConcurrency=%s before resolving a collection', async (maxConcurrency) => {
+    const getCollection = vi.spyOn(ObjectRegistry, 'getCollection');
+
+    await expect(
+      executeCollectionReadPlan(
+        { probe: { className: 'ReadPlanProbe' } },
+        { maxConcurrency },
+      ),
+    ).rejects.toThrow('maxConcurrency must be a positive integer');
+    expect(getCollection).not.toHaveBeenCalled();
+  });
+
+  it('drains in-flight reads but starts no queued entry after a failure', async () => {
+    const failure = new Error('read failed');
+    let secondSettled = false;
+    const started: string[] = [];
+
+    vi.spyOn(ObjectRegistry, 'getCollection').mockImplementation(
+      async (className: string) =>
+        mockCollection(async () => {
+          started.push(className);
+          if (className === 'FirstProbe') {
+            await new Promise((resolve) => setTimeout(resolve, 1));
+            throw failure;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          secondSettled = true;
+          return [];
+        }),
+    );
+
+    await expect(
+      executeCollectionReadPlan(
+        {
+          first: { className: 'FirstProbe' },
+          second: { className: 'SecondProbe' },
+          third: { className: 'ThirdProbe' },
+          fourth: { className: 'FourthProbe' },
+        },
+        { maxConcurrency: 2 },
+      ),
+    ).rejects.toBe(failure);
+
+    expect(secondSettled).toBe(true);
+    expect(started).toEqual(['FirstProbe', 'SecondProbe']);
+  });
+
+  it('keeps collection resolution scoped to the supplied database', async () => {
+    const databaseA = fakeDatabase('sqlite://tenant-a');
+    const databaseB = fakeDatabase('sqlite://tenant-b');
+    const getCollection = vi
+      .spyOn(ObjectRegistry, 'getCollection')
+      .mockImplementation(async (_className: string, options?: unknown) => {
+        const db = (options as { db?: DatabaseInterface } | undefined)?.db;
+        const marker = db === databaseA ? 'tenant-a' : 'tenant-b';
+        return mockCollection(async () => [
+          { name: marker } as unknown as ReadPlanProbe,
+        ]);
+      });
+
+    const records: SmrtCollectionReadPlanEntry<ReadPlanProbe> = {
+      className: 'ReadPlanProbe',
+    };
+    const plan = { records };
+    const resultA = await executeCollectionReadPlan(plan, {
+      collectionOptions: { db: databaseA },
+      maxConcurrency: 1,
+    });
+    const resultB = await executeCollectionReadPlan(plan, {
+      collectionOptions: { db: databaseB },
+      maxConcurrency: 1,
+    });
+
+    expect(resultA.records[0].name).toBe('tenant-a');
+    expect(resultB.records[0].name).toBe('tenant-b');
+    expect(getCollection).toHaveBeenNthCalledWith(1, 'ReadPlanProbe', {
+      db: databaseA,
+    });
+    expect(getCollection).toHaveBeenNthCalledWith(2, 'ReadPlanProbe', {
+      db: databaseB,
+    });
+  });
+
+  it('returns an empty keyed result without resolving collections', async () => {
+    const getCollection = vi.spyOn(ObjectRegistry, 'getCollection');
+
+    await expect(
+      executeCollectionReadPlan({}, { maxConcurrency: 3 }),
+    ).resolves.toEqual({});
+    expect(getCollection).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/collection-read-plan.ts
+++ b/packages/core/src/collection-read-plan.ts
@@ -28,6 +28,20 @@ type SmrtCollectionReadOptions<ModelType extends SmrtObject> =
 type DynamicSmrtListOptions = SmrtCollectionReadOptions<DynamicSmrtObject>;
 declare const smrtCollectionReadPlanModel: unique symbol;
 
+type SmrtCollectionReadPlanEntryOptions<
+  ModelType extends SmrtObject,
+  ListOptions extends SmrtCollectionReadOptions<ModelType> | undefined,
+> =
+  ListOptions extends SmrtProjectedCollectionReadOptions<ModelType>
+    ? {
+        /** Projection options forwarded unchanged to `SmrtCollection.list()`. */
+        options: ListOptions;
+      }
+    : {
+        /** Standard hydrated-list options forwarded unchanged to `SmrtCollection.list()`. */
+        options?: ListOptions;
+      };
+
 /**
  * One independent collection read in a bounded read plan.
  *
@@ -36,23 +50,15 @@ declare const smrtCollectionReadPlanModel: unique symbol;
  */
 export type SmrtCollectionReadPlanEntry<
   ModelType extends SmrtObject = SmrtObject,
-  ListOptions extends SmrtCollectionReadOptions<ModelType> | undefined =
-    | SmrtHydratedCollectionReadOptions<ModelType>
-    | undefined,
+  ListOptions extends
+    | SmrtCollectionReadOptions<ModelType>
+    | undefined = SmrtHydratedCollectionReadOptions<ModelType>,
 > = {
   /** Registered SMRT object or collection name. */
   className: string;
   /** @internal Retains the model type for keyed result inference. */
   readonly [smrtCollectionReadPlanModel]?: ModelType;
-} & ([ListOptions] extends [SmrtProjectedCollectionReadOptions<ModelType>]
-  ? {
-      /** Projection options forwarded unchanged to `SmrtCollection.list()`. */
-      options: ListOptions;
-    }
-  : {
-      /** Standard hydrated-list options forwarded unchanged to `SmrtCollection.list()`. */
-      options?: ListOptions;
-    });
+} & SmrtCollectionReadPlanEntryOptions<ModelType, ListOptions>;
 
 /** A keyed group of independent collection reads. */
 export type SmrtCollectionReadPlan = Record<

--- a/packages/core/src/collection-read-plan.ts
+++ b/packages/core/src/collection-read-plan.ts
@@ -1,0 +1,160 @@
+import type { SmrtClassOptions } from './class';
+import type {
+  SmrtCollection,
+  SmrtListOptions,
+  SmrtSelectedRow,
+  SmrtSelectField,
+} from './collection';
+import type { SmrtObject } from './object';
+import { ObjectRegistry } from './registry';
+
+type DynamicSmrtObject = SmrtObject & Record<string, unknown>;
+type DynamicSmrtListOptions = SmrtListOptions<DynamicSmrtObject>;
+
+/**
+ * One independent collection read in a bounded read plan.
+ *
+ * `ModelType` is optional for dynamic registries. Consumers that know the
+ * model type can annotate an entry to retain model/projection result typing.
+ */
+export interface SmrtCollectionReadPlanEntry<
+  ModelType extends SmrtObject = SmrtObject,
+  ListOptions extends SmrtListOptions<ModelType> | undefined =
+    | SmrtListOptions<ModelType>
+    | undefined,
+> {
+  /** Registered SMRT object or collection name. */
+  className: string;
+  /** Standard options forwarded unchanged to `SmrtCollection.list()`. */
+  options?: ListOptions;
+}
+
+/** A keyed group of independent collection reads. */
+export type SmrtCollectionReadPlan = Record<
+  string,
+  {
+    className: string;
+    options?: DynamicSmrtListOptions;
+  }
+>;
+
+type SmrtCollectionReadPlanEntryResult<Entry> =
+  Entry extends SmrtCollectionReadPlanEntry<infer ModelType, infer ListOptions>
+    ? ListOptions extends {
+        select: infer Select extends readonly SmrtSelectField<ModelType>[];
+      }
+      ? SmrtSelectedRow<ModelType, Select>[]
+      : ModelType[]
+    : never;
+
+/** Results retain the exact keys declared by the input plan. */
+export type SmrtCollectionReadPlanResult<Plan extends SmrtCollectionReadPlan> =
+  {
+    [Key in keyof Plan]: SmrtCollectionReadPlanEntryResult<Plan[Key]>;
+  };
+
+export interface ExecuteCollectionReadPlanOptions {
+  /**
+   * Maximum number of top-level `collection.list()` operations in flight.
+   * Must be a positive integer and is intentionally required so callers make
+   * workload policy explicit.
+   */
+  maxConcurrency: number;
+  /** Normal options used to resolve every collection in the plan. */
+  collectionOptions?: SmrtClassOptions;
+}
+
+async function listCollection(
+  collection: SmrtCollection<DynamicSmrtObject>,
+  options: DynamicSmrtListOptions | undefined,
+): Promise<unknown[]> {
+  if (options?.select !== undefined) {
+    return await collection.list(
+      options as DynamicSmrtListOptions & {
+        select: readonly SmrtSelectField<DynamicSmrtObject>[];
+        include?: never;
+      },
+    );
+  }
+
+  return await collection.list(
+    options as
+      | (Omit<DynamicSmrtListOptions, 'select'> & {
+          select?: undefined;
+        })
+      | undefined,
+  );
+}
+
+/**
+ * Execute independent collection reads without unbounded database fan-out.
+ *
+ * Each entry resolves through `ObjectRegistry.getCollection()` and calls the
+ * collection's public `list()` method, preserving interceptors, tenancy, STI,
+ * hydration, eager loading, projections, and opt-in collection caching.
+ *
+ * On failure, no additional queued entry is started. Operations that were
+ * already in flight are allowed to settle before the first error is rethrown,
+ * so the function never leaves detached database work behind.
+ *
+ * This function does not compose SQL, cache the plan, or change database pool
+ * defaults. It only bounds top-level list-operation concurrency.
+ */
+export async function executeCollectionReadPlan<
+  const Plan extends SmrtCollectionReadPlan,
+>(
+  plan: Plan,
+  options: ExecuteCollectionReadPlanOptions,
+): Promise<SmrtCollectionReadPlanResult<Plan>> {
+  if (
+    !Number.isInteger(options.maxConcurrency) ||
+    options.maxConcurrency <= 0
+  ) {
+    throw new RangeError('maxConcurrency must be a positive integer');
+  }
+
+  const entries = Object.entries(plan) as [keyof Plan, Plan[keyof Plan]][];
+
+  if (entries.length === 0) {
+    return Object.fromEntries([]) as SmrtCollectionReadPlanResult<Plan>;
+  }
+
+  let nextIndex = 0;
+  let failed = false;
+  let firstError: unknown;
+  const values: unknown[][] = new Array(entries.length);
+
+  const runWorker = async (): Promise<void> => {
+    while (!failed) {
+      const entryIndex = nextIndex;
+      nextIndex += 1;
+      if (entryIndex >= entries.length) return;
+
+      const [, entry] = entries[entryIndex];
+
+      try {
+        const collection =
+          await ObjectRegistry.getCollection<DynamicSmrtObject>(
+            entry.className,
+            options.collectionOptions,
+          );
+        const value = await listCollection(collection, entry.options);
+        values[entryIndex] = value;
+      } catch (error) {
+        if (!failed) {
+          failed = true;
+          firstError = error;
+        }
+        return;
+      }
+    }
+  };
+
+  const workerCount = Math.min(options.maxConcurrency, entries.length);
+  await Promise.all(Array.from({ length: workerCount }, runWorker));
+
+  if (failed) throw firstError;
+  return Object.fromEntries(
+    entries.map(([key], index) => [key, values[index]]),
+  ) as SmrtCollectionReadPlanResult<Plan>;
+}

--- a/packages/core/src/collection-read-plan.ts
+++ b/packages/core/src/collection-read-plan.ts
@@ -9,7 +9,24 @@ import type { SmrtObject } from './object';
 import { ObjectRegistry } from './registry';
 
 type DynamicSmrtObject = SmrtObject & Record<string, unknown>;
-type DynamicSmrtListOptions = SmrtListOptions<DynamicSmrtObject>;
+type SmrtHydratedCollectionReadOptions<ModelType extends SmrtObject> = Omit<
+  SmrtListOptions<ModelType>,
+  'select'
+> & {
+  select?: undefined;
+};
+type SmrtProjectedCollectionReadOptions<ModelType extends SmrtObject> = Omit<
+  SmrtListOptions<ModelType>,
+  'select' | 'include'
+> & {
+  select: readonly SmrtSelectField<ModelType>[];
+  include?: never;
+};
+type SmrtCollectionReadOptions<ModelType extends SmrtObject> =
+  | SmrtHydratedCollectionReadOptions<ModelType>
+  | SmrtProjectedCollectionReadOptions<ModelType>;
+type DynamicSmrtListOptions = SmrtCollectionReadOptions<DynamicSmrtObject>;
+declare const smrtCollectionReadPlanModel: unique symbol;
 
 /**
  * One independent collection read in a bounded read plan.
@@ -17,17 +34,25 @@ type DynamicSmrtListOptions = SmrtListOptions<DynamicSmrtObject>;
  * `ModelType` is optional for dynamic registries. Consumers that know the
  * model type can annotate an entry to retain model/projection result typing.
  */
-export interface SmrtCollectionReadPlanEntry<
+export type SmrtCollectionReadPlanEntry<
   ModelType extends SmrtObject = SmrtObject,
-  ListOptions extends SmrtListOptions<ModelType> | undefined =
-    | SmrtListOptions<ModelType>
+  ListOptions extends SmrtCollectionReadOptions<ModelType> | undefined =
+    | SmrtHydratedCollectionReadOptions<ModelType>
     | undefined,
-> {
+> = {
   /** Registered SMRT object or collection name. */
   className: string;
-  /** Standard options forwarded unchanged to `SmrtCollection.list()`. */
-  options?: ListOptions;
-}
+  /** @internal Retains the model type for keyed result inference. */
+  readonly [smrtCollectionReadPlanModel]?: ModelType;
+} & ([ListOptions] extends [SmrtProjectedCollectionReadOptions<ModelType>]
+  ? {
+      /** Projection options forwarded unchanged to `SmrtCollection.list()`. */
+      options: ListOptions;
+    }
+  : {
+      /** Standard hydrated-list options forwarded unchanged to `SmrtCollection.list()`. */
+      options?: ListOptions;
+    });
 
 /** A keyed group of independent collection reads. */
 export type SmrtCollectionReadPlan = Record<
@@ -38,14 +63,23 @@ export type SmrtCollectionReadPlan = Record<
   }
 >;
 
-type SmrtCollectionReadPlanEntryResult<Entry> =
-  Entry extends SmrtCollectionReadPlanEntry<infer ModelType, infer ListOptions>
-    ? ListOptions extends {
-        select: infer Select extends readonly SmrtSelectField<ModelType>[];
-      }
-      ? SmrtSelectedRow<ModelType, Select>[]
-      : ModelType[]
-    : never;
+type SmrtCollectionReadPlanEntryModel<Entry> = Entry extends {
+  readonly [smrtCollectionReadPlanModel]?: infer ModelType;
+}
+  ? ModelType extends SmrtObject
+    ? ModelType
+    : SmrtObject
+  : SmrtObject;
+
+type SmrtCollectionReadPlanEntryResult<Entry> = Entry extends {
+  options: { select: infer Select };
+}
+  ? Select extends readonly SmrtSelectField<
+      SmrtCollectionReadPlanEntryModel<Entry>
+    >[]
+    ? SmrtSelectedRow<SmrtCollectionReadPlanEntryModel<Entry>, Select>[]
+    : never
+  : SmrtCollectionReadPlanEntryModel<Entry>[];
 
 /** Results retain the exact keys declared by the input plan. */
 export type SmrtCollectionReadPlanResult<Plan extends SmrtCollectionReadPlan> =
@@ -116,7 +150,9 @@ export async function executeCollectionReadPlan<
   const entries = Object.entries(plan) as [keyof Plan, Plan[keyof Plan]][];
 
   if (entries.length === 0) {
-    return Object.fromEntries([]) as SmrtCollectionReadPlanResult<Plan>;
+    return Object.fromEntries(
+      [],
+    ) as unknown as SmrtCollectionReadPlanResult<Plan>;
   }
 
   let nextIndex = 0;
@@ -156,5 +192,5 @@ export async function executeCollectionReadPlan<
   if (failed) throw firstError;
   return Object.fromEntries(
     entries.map(([key], index) => [key, values[index]]),
-  ) as SmrtCollectionReadPlanResult<Plan>;
+  ) as unknown as SmrtCollectionReadPlanResult<Plan>;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,6 +74,7 @@ export {
   resolveDbCacheKey,
   stopCacheInvalidationListeners,
 } from './collection-cache';
+export * from './collection-read-plan';
 export type {
   AiUsageConfig,
   GlobalSignalConfig,

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1657,18 +1657,24 @@ export class ObjectRegistry {
     // CRITICAL FIX for issue #384: Use unique db instance ID for cache key
     // Without this, different tests with different db instances would share
     // the same cached collection, causing queries to hit the wrong database
-    let dbId: number | undefined;
+    let dbCacheKey: string | undefined;
     if (options.db && typeof options.db === 'object') {
       // Get or assign unique ID for this db instance
       if (!ObjectRegistry.dbInstanceIds.has(options.db)) {
         ObjectRegistry.dbInstanceIds.set(options.db, ObjectRegistry.nextDbId++);
       }
-      dbId = ObjectRegistry.dbInstanceIds.get(options.db);
+      const dbId = ObjectRegistry.dbInstanceIds.get(options.db);
+      dbCacheKey = dbId === undefined ? undefined : `instance:${dbId}`;
+    } else if (typeof options.db === 'string') {
+      // String database URLs/paths are valid SmrtClassOptions too. They must
+      // participate in the key or two scoped callers can reuse a collection
+      // bound to the first caller's database.
+      dbCacheKey = `string:${options.db}`;
     }
 
     const cacheKey = `${canonicalName}:${JSON.stringify({
       persistence: options.persistence,
-      db: dbId !== undefined ? `db:${dbId}` : undefined,
+      db: dbCacheKey,
       ai: options.ai ? 'present' : undefined,
     })}`;
 


### PR DESCRIPTION
## Summary

- add a typed, keyed `executeCollectionReadPlan()` API that bounds top-level collection reads while preserving normal SMRT registry, tenancy, STI, eager-loading, projection, hydration, and cache behavior
- stop queued work after the first failure, drain already-running reads, preserve input key order, and make concurrency policy explicit
- include string-valued database identity in the registry collection cache key to prevent cross-database reuse
- document the API and add compiler, SQLite isolation, failure/race, and PostgreSQL cold-pool coverage

## Validation

- Node 24.18.0
- focused runtime tests: 23 passed
- compiler-enforced public plain/projection inference and invalid-option rejection: passed
- PostgreSQL cold-pool probe: 26 reads, `maxConcurrency: 2`, pool `totalCount <= 2`, `waitingCount = 0`, ordered results `[1, 2, 3]`
- `pnpm format-check`
- `pnpm lint`
- `pnpm check:standards`
- `pnpm typecheck` — 122 tasks passed
- `pnpm build` — 62 tasks passed
- `pnpm test` — full 64-package graph passed; core 3,234 tests passed, 46 skipped
- `pnpm knowledge:check --changed --strict --format markdown` — 0 errors, 0 warnings
- independent implementation and API/concurrency reviews: clear

The broader local optional-PostgreSQL script also reproduced two unrelated existing failures in the change-feed barrier and timestamp error-wrapping tests; both reproduce independently and this change does not touch those paths. The new #2304 PostgreSQL probe passes non-skipped.

Closes #2304

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-019ff09f-2fcd-7060-ae59-c6731b4446d2",
  "issue": "https://github.com/happyvertical/smrt/issues/2304",
  "policy_revision": "1.0.0",
  "validation": [
    "focused runtime 23/23",
    "public TypeScript contract",
    "PostgreSQL cold-pool probe",
    "full typecheck/build/test",
    "strict knowledge freshness",
    "independent review cycle"
  ]
}
```

