### PR TITLE
feat(dev-mcp): project structural knowledge facts

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -122,6 +122,14 @@ client at all.
 Keep `manifest.json` runtime-focused. `smrt-knowledge.json` is the deterministic
 agent contract for downstream review and architecture tools.
 
+The schema-version-1 object projection is additive and high-signal: it retains
+normalized tenant mode/field, explicit `cti`/`sti` strategy, conflict columns,
+method signatures, and field defaults/constraints/readonly/transient flags.
+Sensitive fields are removed before both `fields` and `relationships` are
+derived, including legacy flags stored under `_meta`; matching field and
+snake-case column names are also removed from projected conflict columns, and a
+sensitive custom tenant field is omitted while retaining scope and mode.
+
 Config precedence for knowledge is defaults → top-level `knowledge` in
 `smrt.config.ts` → `packages[packageName].knowledge` → plugin option →
 object-level `@smrt({ knowledge })`.

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -129,6 +129,9 @@ Sensitive fields are removed before both `fields` and `relationships` are
 derived, including legacy flags stored under `_meta`; matching field and
 snake-case column names are also removed from projected conflict columns, and a
 sensitive custom tenant field is omitted while retaining scope and mode.
+Generated artifacts assert this boundary with `sensitiveFieldsExcluded: true`;
+the optional marker keeps schema version 1 additive while letting readers
+identify older artifacts that require raw-manifest corroboration.
 
 Config precedence for knowledge is defaults → top-level `knowledge` in
 `smrt.config.ts` → `packages[packageName].knowledge` → plugin option →

--- a/packages/core/src/knowledge.test.ts
+++ b/packages/core/src/knowledge.test.ts
@@ -84,6 +84,7 @@ describe('buildDomainKnowledgeManifest', () => {
     const order = artifact.objects.find((object) => object.name === 'Order');
 
     expect(artifact.schemaVersion).toBe(1);
+    expect(artifact.sensitiveFieldsExcluded).toBe(true);
     expect(order).toMatchObject({
       tenant: { scoped: true, mode: 'required', field: 'tenantId' },
       tableStrategy: 'sti',

--- a/packages/core/src/knowledge.test.ts
+++ b/packages/core/src/knowledge.test.ts
@@ -79,6 +79,68 @@ describe('buildDomainKnowledgeManifest', () => {
     );
   });
 
+  it('projects structural facts without exposing sensitive fields', () => {
+    const artifact = buildFixtureArtifact(rootDir);
+    const order = artifact.objects.find((object) => object.name === 'Order');
+
+    expect(artifact.schemaVersion).toBe(1);
+    expect(order).toMatchObject({
+      tenant: { scoped: true, mode: 'required', field: 'tenantId' },
+      tableStrategy: 'sti',
+      conflictColumns: ['tenant_id', 'profile_id'],
+      methods: ['approve'],
+      methodSignatures: [
+        {
+          name: 'approve',
+          async: true,
+          static: true,
+          params: ['reason?: string'],
+          returns: 'Promise<void>',
+        },
+      ],
+    });
+    expect(
+      artifact.objects.find((object) => object.name === 'OrderLinks'),
+    ).toMatchObject({
+      relationshipFeatures: ['SmrtJunction', 'foreignKey'],
+      conflictColumns: ['order_id', 'item_id'],
+    });
+    expect(order?.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'attempts',
+          default: 0,
+          constraints: { min: 0, max: 3 },
+          readonly: true,
+        }),
+        expect.objectContaining({ name: 'active', default: false }),
+        expect.objectContaining({
+          name: 'reference',
+          constraints: { minLength: 2, maxLength: 24, pattern: '^[A-Z]+' },
+        }),
+        expect.objectContaining({ name: 'preview', transient: true }),
+      ]),
+    );
+    expect(order?.fields.map((field) => field.name)).not.toEqual(
+      expect.arrayContaining(['secretId', 'legacySecretId', 'apiTokenID']),
+    );
+    expect(order?.relationships.map((field) => field.name)).not.toEqual(
+      expect.arrayContaining(['secretId', 'legacySecretId', 'apiTokenID']),
+    );
+  });
+
+  it('redacts a sensitive tenant field identity while retaining tenant scope', () => {
+    const manifest = fixtureManifest();
+    manifest.objects['@example/orders:Order'].decoratorConfig.tenantScoped = {
+      field: 'secretId',
+      mode: 'optional',
+    };
+    const artifact = buildDomainKnowledgeManifest({ manifest, rootDir });
+    const order = artifact.objects.find((object) => object.name === 'Order');
+
+    expect(order?.tenant).toEqual({ scoped: true, mode: 'optional' });
+  });
+
   it('preserves relationship details and relationships-v2 counts', () => {
     const artifact = buildFixtureArtifact(rootDir);
     const order = artifact.objects.find((object) => object.name === 'Order');
@@ -99,7 +161,7 @@ describe('buildDomainKnowledgeManifest', () => {
       ]),
     );
     expect(artifact.relationshipsV2).toMatchObject({
-      foreignKeyFields: 1,
+      foreignKeyFields: 3,
       crossPackageRefFields: 1,
       junctionCollections: 1,
       hierarchicalObjects: 1,
@@ -109,10 +171,23 @@ describe('buildDomainKnowledgeManifest', () => {
 
   it('records stable source hashes', () => {
     const artifact = buildFixtureArtifact(rootDir);
+    const rebuilt = buildFixtureArtifact(rootDir);
+    const changedManifest = fixtureManifest();
+    changedManifest.objects[
+      '@example/orders:Order'
+    ].decoratorConfig.conflictColumns = ['tenant_id', 'reference'];
+    const changed = buildDomainKnowledgeManifest({
+      manifest: changedManifest,
+      rootDir,
+    });
 
     expect(artifact.sourceHashes).toHaveProperty('packageJson');
     expect(artifact.sourceHashes).toHaveProperty('agents');
     expect(artifact.sourceHashes).toHaveProperty('manifest');
+    expect(rebuilt.sourceHashes).toEqual(artifact.sourceHashes);
+    expect(changed.sourceHashes.manifest).not.toBe(
+      artifact.sourceHashes.manifest,
+    );
   });
 
   it('omits moduleDocs when AGENTS.md links no sibling docs', () => {
@@ -273,14 +348,48 @@ function fixtureManifest(): SmartObjectManifest {
             type: 'crossPackageRef',
             related: '@happyvertical/smrt-profiles:Profile',
           },
+          attempts: {
+            type: 'integer',
+            default: 0,
+            min: 0,
+            max: 3,
+            readonly: true,
+          },
+          active: { type: 'boolean', default: false },
+          reference: {
+            type: 'text',
+            _meta: {
+              minLength: 2,
+              maxLength: 24,
+              pattern: { source: '^[A-Z]+' },
+            },
+          },
+          preview: { type: 'text', _meta: { transient: true } },
+          secretId: {
+            type: 'foreignKey',
+            related: 'Secret',
+            sensitive: true,
+          },
+          legacySecretId: {
+            type: 'foreignKey',
+            related: 'LegacySecret',
+            _meta: { sensitive: true },
+          },
+          apiTokenID: { type: 'text', _meta: { sensitive: true } },
         },
         methods: {
           approve: {
             name: 'approve',
             async: true,
-            parameters: [],
+            parameters: [
+              {
+                name: 'reason',
+                type: 'string',
+                optional: true,
+              },
+            ],
             returnType: 'Promise<void>',
-            isStatic: false,
+            isStatic: true,
             isPublic: true,
           },
         },
@@ -288,6 +397,15 @@ function fixtureManifest(): SmartObjectManifest {
           api: true,
           cli: { include: ['approve'] },
           mcp: { include: ['get', 'approve'] },
+          tenantScoped: true,
+          tableStrategy: 'sti',
+          conflictColumns: [
+            'tenant_id',
+            'profile_id',
+            'secret_id',
+            'legacy_secret_id',
+            'api_token_i_d',
+          ],
           knowledge: {
             tags: ['payments'],
             summary: 'Order aggregate',
@@ -308,9 +426,12 @@ function fixtureManifest(): SmartObjectManifest {
         className: 'OrderLinks',
         qualifiedName: '@example/orders:OrderLinks',
         collection: 'order_links',
-        fields: {},
+        fields: {
+          orderId: { type: 'foreignKey', related: 'Order', required: true },
+          itemId: { type: 'foreignKey', related: 'Item', required: true },
+        },
         methods: {},
-        decoratorConfig: {},
+        decoratorConfig: { conflictColumns: ['order_id', 'item_id'] },
         extends: 'SmrtJunction',
       },
       '@example/orders:OrderTree': {

--- a/packages/core/src/knowledge.ts
+++ b/packages/core/src/knowledge.ts
@@ -3,15 +3,20 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { basename, join, relative, resolve, sep } from 'node:path';
 import type {
   DomainKnowledgeConfig,
+  DomainKnowledgeField,
+  DomainKnowledgeFieldConstraints,
   DomainKnowledgeManifest,
+  DomainKnowledgeMethodSignature,
   DomainKnowledgeModuleDoc,
   DomainKnowledgeObject,
   DomainKnowledgeSurface,
+  DomainKnowledgeTenant,
 } from '@happyvertical/smrt-types';
 import type {
   SmartObjectDefinition,
   SmartObjectManifest,
 } from './scanner/types.js';
+import { toSnakeCase } from './utils/naming.js';
 
 /**
  * Minimal package.json shape consumed by the knowledge builder.
@@ -200,13 +205,36 @@ function buildKnowledgeObject(
     typeof object.decoratorConfig?.knowledge === 'object'
       ? object.decoratorConfig.knowledge
       : {};
-  const fields = Object.entries(object.fields).map(([name, field]) => ({
-    name,
-    type: field.type,
-    required: field.required,
-    related: field.related,
-    columnType: columnType(object, name),
-  }));
+  const fields = Object.entries(object.fields)
+    .filter(([, field]) => !isSensitiveField(field))
+    .map(([name, field]): DomainKnowledgeField => {
+      const defaultValue = fieldValue(field, 'default');
+      return {
+        name,
+        type: field.type,
+        required: field.required,
+        related: field.related,
+        columnType: columnType(object, name),
+        ...(defaultValue.present ? { default: defaultValue.value } : {}),
+        constraints: fieldConstraints(field),
+        readonly:
+          field.readonly === true || field._meta?.readonly === true
+            ? true
+            : undefined,
+        transient:
+          field.transient === true || field._meta?.transient === true
+            ? true
+            : undefined,
+      };
+    });
+  const sensitiveIdentifiers = sensitiveFieldIdentifiers(object.fields);
+  const tenant = sanitizeTenantFacts(
+    tenantFacts(object.decoratorConfig?.tenantScoped),
+    sensitiveIdentifiers,
+  );
+  const conflictColumns = object.decoratorConfig?.conflictColumns?.filter(
+    (column) => !sensitiveIdentifiers.has(column),
+  );
   const relationships = fields
     .filter((field) => RELATIONSHIP_FIELD_TYPES.has(field.type))
     .map((field) => ({
@@ -228,12 +256,117 @@ function buildKnowledgeObject(
     fields,
     relationships,
     methods: Object.keys(object.methods).sort(),
+    methodSignatures: methodSignatures(object),
+    tenant,
+    tableStrategy: object.decoratorConfig?.tableStrategy,
+    conflictColumns:
+      conflictColumns && conflictColumns.length > 0
+        ? conflictColumns
+        : undefined,
     surfaces: objectSurfaces(object),
-    relationshipFeatures: relationshipFeatures(object),
+    relationshipFeatures: relationshipFeatures(object, fields),
     tags: knowledge.tags ?? [],
     summary: knowledge.summary,
     risks: knowledge.risks ?? [],
   };
+}
+
+function isSensitiveField(field: SmartObjectDefinition['fields'][string]) {
+  return field.sensitive === true || field._meta?.sensitive === true;
+}
+
+function sensitiveFieldIdentifiers(
+  fields: SmartObjectDefinition['fields'],
+): Set<string> {
+  return new Set(
+    Object.entries(fields)
+      .filter(([, field]) => isSensitiveField(field))
+      .flatMap(([name]) => [name, toSnakeCase(name), camelToSnake(name)]),
+  );
+}
+
+function fieldValue(
+  field: SmartObjectDefinition['fields'][string],
+  key: 'default' | 'min' | 'max' | 'minLength' | 'maxLength',
+): { present: boolean; value: unknown } {
+  if (Object.hasOwn(field, key)) {
+    return { present: field[key] !== undefined, value: field[key] };
+  }
+  const value = field._meta?.[key];
+  return { present: value !== undefined, value };
+}
+
+function fieldConstraints(
+  field: SmartObjectDefinition['fields'][string],
+): DomainKnowledgeFieldConstraints | undefined {
+  const constraints: DomainKnowledgeFieldConstraints = {};
+  for (const key of ['min', 'max', 'minLength', 'maxLength'] as const) {
+    const value = fieldValue(field, key);
+    if (value.present && typeof value.value === 'number') {
+      constraints[key] = value.value;
+    }
+  }
+  const pattern = normalizePattern(
+    (field as { pattern?: unknown }).pattern ?? field._meta?.pattern,
+  );
+  if (pattern !== undefined) constraints.pattern = pattern;
+  return Object.keys(constraints).length > 0 ? constraints : undefined;
+}
+
+function normalizePattern(pattern: unknown): string | undefined {
+  if (typeof pattern === 'string') return pattern;
+  if (pattern instanceof RegExp) return pattern.source;
+  if (
+    pattern &&
+    typeof pattern === 'object' &&
+    typeof (pattern as { source?: unknown }).source === 'string'
+  ) {
+    return (pattern as { source: string }).source;
+  }
+  return undefined;
+}
+
+function tenantFacts(
+  tenantScoped: SmartObjectDefinition['decoratorConfig']['tenantScoped'],
+): DomainKnowledgeTenant | undefined {
+  if (!tenantScoped) return undefined;
+  if (tenantScoped === true) {
+    return { scoped: true, mode: 'required', field: 'tenantId' };
+  }
+  return {
+    scoped: true,
+    mode: tenantScoped.mode ?? 'required',
+    field: tenantScoped.field ?? 'tenantId',
+  };
+}
+
+function sanitizeTenantFacts(
+  tenant: DomainKnowledgeTenant | undefined,
+  sensitiveIdentifiers: Set<string>,
+): DomainKnowledgeTenant | undefined {
+  if (!tenant?.field || !sensitiveIdentifiers.has(tenant.field)) return tenant;
+  return { scoped: tenant.scoped, mode: tenant.mode };
+}
+
+function methodSignatures(
+  object: SmartObjectDefinition,
+): DomainKnowledgeMethodSignature[] | undefined {
+  const signatures = Object.values(object.methods)
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((method) => ({
+      name: method.name,
+      async: method.async || undefined,
+      static: method.isStatic || undefined,
+      params:
+        method.parameters.length > 0
+          ? method.parameters.map(
+              (parameter) =>
+                `${parameter.name}${parameter.optional ? '?' : ''}: ${parameter.type}`,
+            )
+          : undefined,
+      returns: method.returnType || undefined,
+    }));
+  return signatures.length > 0 ? signatures : undefined;
 }
 
 function objectSurfaces(
@@ -321,9 +454,12 @@ function apiMethod(operation: string): string {
   }
 }
 
-function relationshipFeatures(object: SmartObjectDefinition): string[] {
+function relationshipFeatures(
+  object: SmartObjectDefinition,
+  fields: DomainKnowledgeField[],
+): string[] {
   const features = new Set<string>();
-  for (const field of Object.values(object.fields)) {
+  for (const field of fields) {
     if (field.type === 'foreignKey') features.add('foreignKey');
     if (field.type === 'crossPackageRef') features.add('crossPackageRef');
     if (field.type === 'oneToMany') features.add('oneToMany');
@@ -333,8 +469,8 @@ function relationshipFeatures(object: SmartObjectDefinition): string[] {
   if (object.extends === 'SmrtHierarchical') features.add('SmrtHierarchical');
   if (
     object.extends === 'SmrtPolymorphicAssociation' ||
-    object.fields.metaType ||
-    object.fields.metaId
+    fields.some((field) => field.name === 'metaType') ||
+    fields.some((field) => field.name === 'metaId')
   ) {
     features.add('SmrtPolymorphicAssociation');
   }

--- a/packages/core/src/knowledge.ts
+++ b/packages/core/src/knowledge.ts
@@ -156,6 +156,7 @@ export function buildDomainKnowledgeManifest(
 
   return {
     schemaVersion: 1,
+    sensitiveFieldsExcluded: true,
     generatedAt: new Date().toISOString(),
     packageName,
     packageVersion,

--- a/packages/smrt-dev-mcp/AGENTS.md
+++ b/packages/smrt-dev-mcp/AGENTS.md
@@ -146,6 +146,13 @@ launcher or a small wrapper script with an absolute Node path.
 - **Domain artifacts first**: discovery must prefer `.smrt/smrt-knowledge.json`,
   then `dist/smrt-knowledge.json`, then source artifacts before raw manifest
   fallback
+- **Structural projection stays additive and sanitized**: schema-version-1
+  domain artifacts and raw-manifest fallback both carry tenant mode/field,
+  `cti`/`sti`, conflict columns, method signatures, and selected field schema
+  facts. Preserve `methods: string[]`; remove top-level and `_meta` sensitive
+  fields before deriving both fields and relationships, and remove their field
+  and snake-case column names from projected conflict columns.
+  If a custom tenant field is sensitive, retain scope/mode but omit its name.
 - **Skill loading**: bundled skills must be included in `package.json` `files`
   because runtime reads them from the installed package directory
 - **Portable plugin boundary**: `mcp.json` launches only `./dist/index.js` from
@@ -185,7 +192,8 @@ launcher or a small wrapper script with an absolute Node path.
 - **Budgets are enforced at the transport boundary**: `KnowledgePackage` carries
   the full `agentDoc` and domain manifest, so the MCP handlers project a compact
   package record unless `detail: 'full'`. Library callers (the CLI) still receive
-  the full objects.
+  the full objects. Structural object facts render into prompt Markdown only in
+  full detail; summary mode remains names/counts/paths.
 - **Private packages skip packaging checks**: the `files` allowlist governs npm
   publication, so `private: true` packages are exempt; authored docs are still
   required. A workspace root is exempt from both — but **only when member

--- a/packages/smrt-dev-mcp/AGENTS.md
+++ b/packages/smrt-dev-mcp/AGENTS.md
@@ -153,6 +153,9 @@ launcher or a small wrapper script with an absolute Node path.
   fields before deriving both fields and relationships, and remove their field
   and snake-case column names from projected conflict columns.
   If a custom tenant field is sensitive, retain scope/mode but omit its name.
+  A schema-v1 artifact without `sensitiveFieldsExcluded: true` is legacy: use
+  the owning raw manifest to allowlist its current non-sensitive fields and
+  structural identifiers, or omit uncorroborated field facts fail-closed.
 - **Skill loading**: bundled skills must be included in `package.json` `files`
   because runtime reads them from the installed package directory
 - **Portable plugin boundary**: `mcp.json` launches only `./dist/index.js` from

--- a/packages/smrt-dev-mcp/README.md
+++ b/packages/smrt-dev-mcp/README.md
@@ -181,6 +181,9 @@ legacy sensitivity flags under `_meta`.
 Sensitive field names and their snake-case column names are also removed from
 projected conflict columns. A sensitive custom tenant-field name is omitted
 while its tenant scope and mode remain available.
+New artifacts record `sensitiveFieldsExcluded: true`. For a legacy schema-v1
+artifact without that marker, the reader cross-checks the owning raw manifest
+and omits any field or structural identifier it cannot corroborate as safe.
 
 ## Cache Metadata
 

--- a/packages/smrt-dev-mcp/README.md
+++ b/packages/smrt-dev-mcp/README.md
@@ -154,10 +154,13 @@ Knowledge and introspection tools return a **summary** by default and accept
   budget.
 - `smrt-architecture`, `smrt-review`, and the `build-*-context` tools list
   authored `AGENTS.md` and module docs **by path** rather than embedding them,
-  and return compact package records.
+  and return compact package records. With `detail: "full"`, their prompt
+  bundles also render high-signal object facts: tenant mode/field, `cti`/`sti`
+  strategy, conflict columns, method signatures, and field
+  defaults/constraints/readonly/transient flags.
 
-The `smrt dev:knowledge-*` CLI commands request `detail: "full"`, so their output
-is unchanged.
+The `smrt dev:knowledge-*` CLI commands request `detail: "full"`, so they remain
+full-detail and unbudgeted.
 
 ## Knowledge Boundary
 
@@ -171,7 +174,13 @@ Downstream s-m-r-t packages/apps can publish their own scoped
 `.smrt/smrt-knowledge.json`, then `dist/smrt-knowledge.json`, then source
 manifest artifacts before falling back to raw manifest/doc scanning. The runtime
 `manifest.json` stays focused on object registration; `smrt-knowledge.json` is
-the agent/developer contract.
+the agent/developer contract. Its schema-version-1 structural keys are additive,
+and older artifacts without them remain readable. Sensitive fields are excluded
+from both the curated artifact and raw-manifest fallback projection, including
+legacy sensitivity flags under `_meta`.
+Sensitive field names and their snake-case column names are also removed from
+projected conflict columns. A sensitive custom tenant-field name is omitted
+while its tenant scope and mode remain available.
 
 ## Cache Metadata
 

--- a/packages/smrt-dev-mcp/src/knowledge/index.test.ts
+++ b/packages/smrt-dev-mcp/src/knowledge/index.test.ts
@@ -420,6 +420,19 @@ describe('SMRT knowledge index', () => {
               tags: [],
               risks: [],
             },
+            {
+              name: 'UnscopedArtifact',
+              qualifiedName: '@happyvertical/smrt-demo:UnscopedArtifact',
+              collection: 'unscoped_artifacts',
+              fields: [],
+              relationships: [],
+              methods: [],
+              tenant: { scoped: false },
+              surfaces: [],
+              relationshipFeatures: [],
+              tags: [],
+              risks: [],
+            },
           ],
           surfaces: [
             {
@@ -457,6 +470,7 @@ describe('SMRT knowledge index', () => {
     expect(demo?.objects.map((object) => object.className)).toEqual([
       'ArtifactDemo',
       'LegacyArtifact',
+      'UnscopedArtifact',
     ]);
     expect(demo?.mcpTools.map((tool) => tool.name)).toEqual([
       'artifactdemo_sync',
@@ -505,6 +519,16 @@ describe('SMRT knowledge index', () => {
       methods: [],
     });
     expect(demo?.objects[1].tenant).toBeUndefined();
+    expect(demo?.objects[2].tenant).toEqual({ scoped: false });
+
+    const architecture = await buildArchitectureContext({
+      rootDir,
+      package: '@happyvertical/smrt-demo',
+      detail: 'full',
+    });
+    expect(architecture.promptBundle.contextMarkdown).toContain(
+      '@happyvertical/smrt-demo:UnscopedArtifact — tenant unscoped',
+    );
   });
 
   it('fails freshness when exported domain knowledge is missing', async () => {

--- a/packages/smrt-dev-mcp/src/knowledge/index.test.ts
+++ b/packages/smrt-dev-mcp/src/knowledge/index.test.ts
@@ -76,6 +76,15 @@ describe('SMRT knowledge index', () => {
                 mcp: {
                   include: ['list', 'get'],
                 },
+                tenantScoped: { mode: 'optional', field: 'workspaceId' },
+                tableStrategy: 'sti',
+                conflictColumns: [
+                  'workspace_id',
+                  'code',
+                  'secret_id',
+                  'legacy_secret_id',
+                  'api_token_i_d',
+                ],
               },
               fields: {
                 ownerId: {
@@ -86,6 +95,36 @@ describe('SMRT knowledge index', () => {
                 profileId: {
                   type: 'crossPackageRef',
                   related: '@happyvertical/smrt-profiles:Profile',
+                },
+                attempts: {
+                  type: 'integer',
+                  default: 0,
+                  min: 0,
+                  max: 5,
+                  readonly: true,
+                },
+                preview: { type: 'text', _meta: { transient: true } },
+                secretId: {
+                  type: 'foreignKey',
+                  related: 'Secret',
+                  sensitive: true,
+                },
+                legacySecretId: {
+                  type: 'foreignKey',
+                  related: 'LegacySecret',
+                  _meta: { sensitive: true },
+                },
+                apiTokenID: { type: 'text', _meta: { sensitive: true } },
+              },
+              methods: {
+                sync: {
+                  name: 'sync',
+                  async: true,
+                  parameters: [
+                    { name: 'force', type: 'boolean', optional: true },
+                  ],
+                  returnType: 'Promise<void>',
+                  isStatic: false,
                 },
               },
               schema: {
@@ -102,7 +141,30 @@ describe('SMRT knowledge index', () => {
               qualifiedName: '@happyvertical/smrt-demo:DemoLinks',
               extends: 'SmrtJunction',
               collection: 'demo_links',
-              fields: {},
+              decoratorConfig: {
+                tenantScoped: {
+                  mode: 'required',
+                  field: 'privateTenantId',
+                },
+                conflictColumns: ['left_id', 'right_id', 'private_tenant_id'],
+              },
+              fields: {
+                leftId: {
+                  type: 'foreignKey',
+                  related: 'Left',
+                  required: true,
+                },
+                rightId: {
+                  type: 'foreignKey',
+                  related: 'Right',
+                  required: true,
+                },
+                privateTenantId: {
+                  type: 'foreignKey',
+                  related: 'Tenant',
+                  sensitive: true,
+                },
+              },
               methods: {
                 byLeft: { name: 'byLeft' },
               },
@@ -158,12 +220,59 @@ describe('SMRT knowledge index', () => {
     expect(index.smrtPackages[0].mcpTools.map((tool) => tool.name)).toEqual(
       expect.arrayContaining(['get_demos', 'list_demos']),
     );
-    expect(index.relationshipsV2.foreignKeyFields).toBe(2);
+    expect(index.relationshipsV2.foreignKeyFields).toBe(4);
     expect(index.relationshipsV2.crossPackageRefFields).toBe(1);
     expect(index.relationshipsV2.junctionCollections).toBe(1);
     expect(index.relationshipsV2.hierarchicalObjects).toBe(1);
     expect(index.relationshipsV2.polymorphicAssociations).toBe(1);
     expect(index.relationshipsV2.uuidColumns).toBe(3);
+  });
+
+  it('projects raw-manifest structural facts and filters sensitive fields', async () => {
+    const index = await buildKnowledgeIndex({ rootDir });
+    const demo = index.smrtPackages[0].objects.find(
+      (object) => object.className === 'Demo',
+    );
+
+    expect(demo).toMatchObject({
+      tenant: { scoped: true, mode: 'optional', field: 'workspaceId' },
+      tableStrategy: 'sti',
+      conflictColumns: ['workspace_id', 'code'],
+      methods: ['sync'],
+      methodSignatures: [
+        {
+          name: 'sync',
+          async: true,
+          params: ['force?: boolean'],
+          returns: 'Promise<void>',
+        },
+      ],
+    });
+    expect(demo?.fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'attempts',
+          default: 0,
+          constraints: { min: 0, max: 5 },
+          readonly: true,
+        }),
+        expect.objectContaining({ name: 'preview', transient: true }),
+      ]),
+    );
+    expect(demo?.fields.map((field) => field.name)).not.toEqual(
+      expect.arrayContaining(['secretId', 'legacySecretId', 'apiTokenID']),
+    );
+    expect(demo?.relationships.map((field) => field.name)).not.toEqual(
+      expect.arrayContaining(['secretId', 'legacySecretId', 'apiTokenID']),
+    );
+    const links = index.smrtPackages[0].objects.find(
+      (object) => object.className === 'DemoLinks',
+    );
+    expect(links).toMatchObject({
+      tenant: { scoped: true, mode: 'required' },
+      conflictColumns: ['left_id', 'right_id'],
+    });
+    expect(JSON.stringify(links)).not.toContain('privateTenantId');
   });
 
   it('filters the index by package scope and package name', async () => {
@@ -213,6 +322,36 @@ describe('SMRT knowledge index', () => {
                   related: '@happyvertical/smrt-profiles:Profile',
                   columnType: 'UUID',
                 },
+                {
+                  name: 'attempts',
+                  type: 'integer',
+                  default: 0,
+                  constraints: { min: 0, max: 3 },
+                  readonly: true,
+                },
+                {
+                  name: 'secretId',
+                  type: 'foreignKey',
+                  related: 'Secret',
+                  sensitive: true,
+                },
+                {
+                  name: 'legacySecretId',
+                  type: 'foreignKey',
+                  related: 'LegacySecret',
+                  _meta: { sensitive: true },
+                },
+                {
+                  name: 'privateTenantId',
+                  type: 'foreignKey',
+                  related: 'Tenant',
+                  sensitive: true,
+                },
+                {
+                  name: 'apiTokenID',
+                  type: 'text',
+                  _meta: { sensitive: true },
+                },
               ],
               relationships: [
                 {
@@ -221,8 +360,42 @@ describe('SMRT knowledge index', () => {
                   related: '@happyvertical/smrt-profiles:Profile',
                   columnType: 'UUID',
                 },
+                {
+                  name: 'secretId',
+                  type: 'foreignKey',
+                  related: 'Secret',
+                  sensitive: true,
+                },
+                {
+                  name: 'legacySecretId',
+                  type: 'foreignKey',
+                  related: 'LegacySecret',
+                  _meta: { sensitive: true },
+                },
               ],
               methods: ['sync'],
+              methodSignatures: [
+                {
+                  name: 'sync',
+                  async: true,
+                  params: ['force?: boolean'],
+                  returns: 'Promise<void>',
+                },
+              ],
+              tenant: {
+                scoped: true,
+                mode: 'required',
+                field: 'privateTenantId',
+              },
+              tableStrategy: 'cti',
+              conflictColumns: [
+                'tenant_id',
+                'profile_id',
+                'secret_id',
+                'legacy_secret_id',
+                'private_tenant_id',
+                'api_token_i_d',
+              ],
               surfaces: [
                 {
                   kind: 'mcp',
@@ -233,6 +406,18 @@ describe('SMRT knowledge index', () => {
               ],
               relationshipFeatures: ['crossPackageRef', 'uuidColumns'],
               tags: ['artifact'],
+              risks: [],
+            },
+            {
+              name: 'LegacyArtifact',
+              qualifiedName: '@happyvertical/smrt-demo:LegacyArtifact',
+              collection: 'legacy_artifacts',
+              fields: [],
+              relationships: [],
+              methods: [],
+              surfaces: [],
+              relationshipFeatures: [],
+              tags: [],
               risks: [],
             },
           ],
@@ -271,11 +456,55 @@ describe('SMRT knowledge index', () => {
     );
     expect(demo?.objects.map((object) => object.className)).toEqual([
       'ArtifactDemo',
+      'LegacyArtifact',
     ]);
     expect(demo?.mcpTools.map((tool) => tool.name)).toEqual([
       'artifactdemo_sync',
     ]);
     expect(demo?.agentDoc).toContain('Artifact guidance');
+    expect(demo?.objects[0]).toMatchObject({
+      tenant: { scoped: true, mode: 'required' },
+      tableStrategy: 'cti',
+      conflictColumns: ['tenant_id', 'profile_id'],
+      methodSignatures: [
+        {
+          name: 'sync',
+          async: true,
+          params: ['force?: boolean'],
+          returns: 'Promise<void>',
+        },
+      ],
+    });
+    expect(demo?.objects[0].fields).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'attempts',
+          default: 0,
+          constraints: { min: 0, max: 3 },
+          readonly: true,
+        }),
+      ]),
+    );
+    expect(demo?.objects[0].fields.map((field) => field.name)).not.toEqual(
+      expect.arrayContaining(['secretId', 'legacySecretId', 'apiTokenID']),
+    );
+    expect(
+      demo?.objects[0].relationships.map((field) => field.name),
+    ).not.toEqual(
+      expect.arrayContaining(['secretId', 'legacySecretId', 'apiTokenID']),
+    );
+    expect(JSON.stringify(demo)).not.toMatch(
+      /secretId|legacySecretId|privateTenantId|apiTokenID|secret_id|legacy_secret_id|private_tenant_id|api_token_i_d/,
+    );
+    expect(JSON.stringify(demo?.domainKnowledge)).not.toMatch(
+      /secretId|legacySecretId|privateTenantId|apiTokenID|secret_id|legacy_secret_id|private_tenant_id|api_token_i_d/,
+    );
+    expect(demo?.objects[1]).toMatchObject({
+      className: 'LegacyArtifact',
+      fields: [],
+      methods: [],
+    });
+    expect(demo?.objects[1].tenant).toBeUndefined();
   });
 
   it('fails freshness when exported domain knowledge is missing', async () => {
@@ -422,6 +651,49 @@ describe('SMRT knowledge index', () => {
     expect(result.promptBundle.contextMarkdown).toContain(
       '@happyvertical/smrt-demo',
     );
+    expect(result.promptBundle.contextMarkdown).not.toContain(
+      'Object structural facts',
+    );
+  });
+
+  it('renders structural facts in full review and architecture bundles', async () => {
+    const review = await buildReviewContext({
+      rootDir,
+      changedFiles: ['packages/demo/src/demo.ts'],
+      detail: 'full',
+    });
+    const architecture = await buildArchitectureContext({
+      rootDir,
+      package: '@happyvertical/smrt-demo',
+      detail: 'full',
+    });
+    const smrtReviewResult = await smrtReview({
+      rootDir,
+      changedFiles: ['packages/demo/src/demo.ts'],
+      detail: 'full',
+      mode: 'prompt-bundle',
+    });
+
+    for (const markdown of [
+      review.promptBundle.contextMarkdown,
+      architecture.promptBundle.contextMarkdown,
+      smrtReviewResult.promptBundle?.contextMarkdown ?? '',
+    ]) {
+      expect(markdown).toContain('Object structural facts');
+      expect(markdown).toContain(
+        'tenant optional via workspaceId; table strategy sti; conflict columns workspace_id, code',
+      );
+      expect(markdown).toContain(
+        'field attempts: integer (default 0; constraints min=0, max=5; readonly)',
+      );
+      expect(markdown).toContain(
+        'method async sync(force?: boolean): Promise<void>',
+      );
+      expect(markdown).not.toContain('secretId');
+      expect(markdown).not.toContain('legacySecretId');
+      expect(markdown).not.toContain('apiTokenID');
+      expect(markdown).not.toContain('api_token_i_d');
+    }
   });
 
   it('embeds every linked module doc when nothing narrows the request (#2108)', async () => {

--- a/packages/smrt-dev-mcp/src/knowledge/index.test.ts
+++ b/packages/smrt-dev-mcp/src/knowledge/index.test.ts
@@ -297,6 +297,7 @@ describe('SMRT knowledge index', () => {
       JSON.stringify(
         {
           schemaVersion: 1,
+          sensitiveFieldsExcluded: true,
           generatedAt: new Date().toISOString(),
           packageName: '@happyvertical/smrt-demo',
           packageVersion: '1.0.0',
@@ -528,6 +529,138 @@ describe('SMRT knowledge index', () => {
     });
     expect(architecture.promptBundle.contextMarkdown).toContain(
       '@happyvertical/smrt-demo:UnscopedArtifact — tenant unscoped',
+    );
+  });
+
+  it('uses the raw manifest to sanitize marker-less legacy artifacts', async () => {
+    await mkdir(join(rootDir, 'packages', 'demo', '.smrt'), {
+      recursive: true,
+    });
+    await writeFile(
+      join(rootDir, 'packages', 'demo', '.smrt', 'smrt-knowledge.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        generatedAt: new Date().toISOString(),
+        packageName: '@happyvertical/smrt-demo',
+        sourceHashes: {},
+        exports: [],
+        dependencies: {},
+        smrtDependencies: [],
+        sdkDependencies: [],
+        tags: [],
+        risks: [],
+        objects: [
+          {
+            name: 'Demo',
+            qualifiedName: '@happyvertical/smrt-demo:Demo',
+            fields: [
+              { name: 'ownerId', type: 'foreignKey', related: 'Owner' },
+              { name: 'secretId', type: 'foreignKey', related: 'Secret' },
+              {
+                name: 'legacySecretId',
+                type: 'foreignKey',
+                related: 'LegacySecret',
+              },
+              { name: 'apiTokenID', type: 'text' },
+            ],
+            relationships: [
+              { name: 'ownerId', type: 'foreignKey', related: 'Owner' },
+              { name: 'secretId', type: 'foreignKey', related: 'Secret' },
+              {
+                name: 'legacySecretId',
+                type: 'foreignKey',
+                related: 'LegacySecret',
+              },
+            ],
+            methods: [],
+            tenant: { scoped: true, mode: 'optional', field: 'workspaceId' },
+            conflictColumns: [
+              'workspace_id',
+              'code',
+              'secret_id',
+              'legacy_secret_id',
+              'api_token_i_d',
+            ],
+            surfaces: [],
+            relationshipFeatures: [],
+            tags: [],
+            risks: [],
+          },
+          {
+            name: 'DemoLinks',
+            qualifiedName: '@happyvertical/smrt-demo:DemoLinks',
+            fields: [
+              { name: 'leftId', type: 'foreignKey', related: 'Left' },
+              { name: 'rightId', type: 'foreignKey', related: 'Right' },
+              {
+                name: 'privateTenantId',
+                type: 'foreignKey',
+                related: 'Tenant',
+              },
+            ],
+            relationships: [
+              { name: 'leftId', type: 'foreignKey', related: 'Left' },
+              { name: 'rightId', type: 'foreignKey', related: 'Right' },
+              {
+                name: 'privateTenantId',
+                type: 'foreignKey',
+                related: 'Tenant',
+              },
+            ],
+            methods: [],
+            tenant: {
+              scoped: true,
+              mode: 'required',
+              field: 'privateTenantId',
+            },
+            conflictColumns: ['left_id', 'right_id', 'private_tenant_id'],
+            surfaces: [],
+            relationshipFeatures: [],
+            tags: [],
+            risks: [],
+          },
+        ],
+        surfaces: [],
+        prompts: [],
+        relationshipsV2: {
+          foreignKeyFields: 0,
+          crossPackageRefFields: 0,
+          junctionCollections: 0,
+          hierarchicalObjects: 0,
+          polymorphicAssociations: 0,
+          uuidColumns: 0,
+        },
+      }),
+    );
+
+    const index = await buildKnowledgeIndex({ rootDir });
+    const pkg = index.packages.find(
+      (candidate) => candidate.name === '@happyvertical/smrt-demo',
+    );
+    const demo = pkg?.objects.find((object) => object.className === 'Demo');
+    const links = pkg?.objects.find(
+      (object) => object.className === 'DemoLinks',
+    );
+
+    expect(demo?.fields.map((field) => field.name)).toEqual(['ownerId']);
+    expect(demo?.relationships.map((field) => field.name)).toEqual(['ownerId']);
+    expect(demo?.conflictColumns).toEqual(['workspace_id', 'code']);
+    expect(links).toMatchObject({
+      tenant: { scoped: true, mode: 'required' },
+      conflictColumns: ['left_id', 'right_id'],
+    });
+    const serialized = JSON.stringify(pkg);
+    expect(serialized).not.toMatch(
+      /secretId|legacySecretId|apiTokenID|privateTenantId|secret_id|legacy_secret_id|api_token_i_d|private_tenant_id/,
+    );
+
+    const architecture = await buildArchitectureContext({
+      rootDir,
+      package: '@happyvertical/smrt-demo',
+      detail: 'full',
+    });
+    expect(architecture.promptBundle.contextMarkdown).not.toMatch(
+      /secretId|legacySecretId|apiTokenID|privateTenantId/,
     );
   });
 

--- a/packages/smrt-dev-mcp/src/knowledge/index.ts
+++ b/packages/smrt-dev-mcp/src/knowledge/index.ts
@@ -1801,12 +1801,15 @@ function readKnowledgePackage(
   const agentsContent = hasAgentsMd ? readFileSync(agentsPath, 'utf8') : '';
   const fallbackClaudeDoc =
     hasClaudeMd && claudeContent.trim() !== '@AGENTS.md' ? claudeContent : '';
+  const manifest = readManifest(directory);
   const discoveredDomainKnowledge = readDomainKnowledge(directory);
   const domainKnowledge = discoveredDomainKnowledge
     ? {
         ...discoveredDomainKnowledge,
         content: sanitizeDomainKnowledgeManifest(
           discoveredDomainKnowledge.content,
+          manifest?.content,
+          name,
         ),
       }
     : null;
@@ -1815,7 +1818,6 @@ function readKnowledgePackage(
     : fallbackClaudeDoc
       ? 'CLAUDE.md'
       : null;
-  const manifest = readManifest(directory);
   const resolvedObjects = resolvePackageObjects({
     packageName: name,
     directory,
@@ -2307,20 +2309,61 @@ function readDomainKnowledgeObjects(
 
 function sanitizeDomainKnowledgeManifest(
   manifest: DomainKnowledgeManifest,
+  rawManifest?: Record<string, unknown>,
+  packageName?: string,
 ): DomainKnowledgeManifest {
+  const rawObjects = rawManifest
+    ? ownedManifestObjectsByIdentity(rawManifest, packageName)
+    : new Map<string, Record<string, unknown>>();
+  const projectionIsSanitized = manifest.sensitiveFieldsExcluded === true;
   return {
     ...manifest,
     objects: manifest.objects.map((object): DomainKnowledgeObject => {
-      const sensitiveIdentifiers = sensitiveKnowledgeFieldIdentifiers(
+      const rawObject =
+        (object.qualifiedName
+          ? rawObjects.get(object.qualifiedName)
+          : undefined) ?? rawObjects.get(object.name);
+      const rawFields = objectRecord(rawObject?.fields);
+      const artifactSensitiveIdentifiers = sensitiveKnowledgeFieldIdentifiers(
         object.fields.map((field) => [field.name, field]),
       );
+      const rawSensitiveIdentifiers = sensitiveKnowledgeFieldIdentifiers(
+        Object.entries(rawFields),
+      );
+      const sensitiveIdentifiers = new Set([
+        ...artifactSensitiveIdentifiers,
+        ...rawSensitiveIdentifiers,
+      ]);
+      const rawSafeFieldNames = new Set(
+        Object.entries(rawFields)
+          .filter(([, field]) => !isSensitiveKnowledgeField(field))
+          .map(([name]) => name),
+      );
+      const canTrustField = (field: DomainKnowledgeField) =>
+        projectionIsSanitized ||
+        (rawObject !== undefined && rawSafeFieldNames.has(field.name));
       const fields = object.fields
-        .filter((field) => !isSensitiveKnowledgeField(field))
+        .filter(
+          (field) => canTrustField(field) && !isSensitiveKnowledgeField(field),
+        )
         .map((field) => projectKnowledgeField(field.name, field));
       const safeFieldNames = new Set(fields.map((field) => field.name));
-      const conflictColumns = object.conflictColumns?.filter(
+      const rawDecoratorConfig = objectRecord(rawObject?.decoratorConfig);
+      const projectedConflictColumns = projectionIsSanitized
+        ? object.conflictColumns
+        : rawObject
+          ? stringArray(rawDecoratorConfig.conflictColumns)
+          : undefined;
+      const conflictColumns = projectedConflictColumns?.filter(
         (column) => !sensitiveIdentifiers.has(column),
       );
+      const projectedTenant = projectionIsSanitized
+        ? object.tenant
+        : rawObject
+          ? projectTenant(rawDecoratorConfig.tenantScoped)
+          : object.tenant
+            ? { scoped: object.tenant.scoped, mode: object.tenant.mode }
+            : undefined;
       return {
         ...object,
         fields,
@@ -2331,7 +2374,7 @@ function sanitizeDomainKnowledgeManifest(
               !isSensitiveKnowledgeField(field),
           )
           .map((field) => projectKnowledgeField(field.name, field)),
-        tenant: sanitizeKnowledgeTenant(object.tenant, sensitiveIdentifiers),
+        tenant: sanitizeKnowledgeTenant(projectedTenant, sensitiveIdentifiers),
         conflictColumns:
           conflictColumns && conflictColumns.length > 0
             ? conflictColumns
@@ -2339,6 +2382,27 @@ function sanitizeDomainKnowledgeManifest(
       };
     }),
   };
+}
+
+function ownedManifestObjectsByIdentity(
+  manifest: Record<string, unknown>,
+  packageName?: string,
+): Map<string, Record<string, unknown>> {
+  const owned = packageName
+    ? partitionOwnedObjects(manifest, packageName).owned
+    : objectRecord(manifest.objects);
+  const objects = new Map<string, Record<string, unknown>>();
+  for (const [key, value] of Object.entries(owned)) {
+    const object = objectRecord(value);
+    objects.set(key, object);
+    if (typeof object.className === 'string') {
+      objects.set(object.className, object);
+    }
+    if (typeof object.qualifiedName === 'string') {
+      objects.set(object.qualifiedName, object);
+    }
+  }
+  return objects;
 }
 
 function isSensitiveKnowledgeField(value: unknown): boolean {

--- a/packages/smrt-dev-mcp/src/knowledge/index.ts
+++ b/packages/smrt-dev-mcp/src/knowledge/index.ts
@@ -22,10 +22,16 @@ import {
   MODULE_DOC_HASH_PREFIX,
   readAgentModuleDocs,
 } from '@happyvertical/smrt-core/knowledge';
+import { toSnakeCase } from '@happyvertical/smrt-core/utils';
 import { ManifestAdapter, OxcScanner } from '@happyvertical/smrt-scanner';
 import type {
+  DomainKnowledgeField,
+  DomainKnowledgeFieldConstraints,
   DomainKnowledgeManifest,
+  DomainKnowledgeMethodSignature,
   DomainKnowledgeModuleDoc,
+  DomainKnowledgeObject,
+  DomainKnowledgeTenant,
 } from '@happyvertical/smrt-types';
 import { TOOLS } from '../tool-catalog.js';
 import { checkMcpToolDocumentation } from './mcp-docs.js';
@@ -69,13 +75,7 @@ export type WorkspaceGlobSource =
   | 'package.json#workspaces'
   | 'fallback';
 
-export interface KnowledgeField {
-  name: string;
-  type: string;
-  required?: boolean;
-  related?: string;
-  columnType?: string;
-}
+export type KnowledgeField = DomainKnowledgeField;
 
 export interface KnowledgeObject {
   className: string;
@@ -89,6 +89,10 @@ export interface KnowledgeObject {
   fields: KnowledgeField[];
   relationships: KnowledgeField[];
   methods: string[];
+  methodSignatures?: DomainKnowledgeMethodSignature[];
+  tenant?: DomainKnowledgeTenant;
+  tableStrategy?: 'cti' | 'sti';
+  conflictColumns?: string[];
 }
 
 export interface KnowledgePrompt {
@@ -1797,7 +1801,15 @@ function readKnowledgePackage(
   const agentsContent = hasAgentsMd ? readFileSync(agentsPath, 'utf8') : '';
   const fallbackClaudeDoc =
     hasClaudeMd && claudeContent.trim() !== '@AGENTS.md' ? claudeContent : '';
-  const domainKnowledge = readDomainKnowledge(directory);
+  const discoveredDomainKnowledge = readDomainKnowledge(directory);
+  const domainKnowledge = discoveredDomainKnowledge
+    ? {
+        ...discoveredDomainKnowledge,
+        content: sanitizeDomainKnowledgeManifest(
+          discoveredDomainKnowledge.content,
+        ),
+      }
+    : null;
   const docSource = hasAgentsMd
     ? 'AGENTS.md'
     : fallbackClaudeDoc
@@ -2184,22 +2196,24 @@ function readManifestObjects(
     const fields = objectRecord(item.fields);
     const schemaColumns = objectRecord(schema.columns);
     const decoratorConfig = objectRecord(item.decoratorConfig);
-    const knowledgeFields = Object.entries(fields).map(([fieldName, field]) => {
-      const fieldInfo = objectRecord(field);
-      const columnName = camelToSnake(fieldName);
-      const column = objectRecord(schemaColumns[columnName]);
-      return {
-        name: fieldName,
-        type: String(fieldInfo.type ?? 'unknown'),
-        required:
-          typeof fieldInfo.required === 'boolean'
-            ? fieldInfo.required
-            : undefined,
-        related:
-          typeof fieldInfo.related === 'string' ? fieldInfo.related : undefined,
-        columnType: typeof column.type === 'string' ? column.type : undefined,
-      };
-    });
+    const knowledgeFields = Object.entries(fields)
+      .filter(([, field]) => !isSensitiveKnowledgeField(field))
+      .map(([fieldName, field]) => {
+        const columnName = camelToSnake(fieldName);
+        const column = objectRecord(schemaColumns[columnName]);
+        return projectKnowledgeField(fieldName, field, column.type);
+      });
+    const methods = objectRecord(item.methods);
+    const sensitiveIdentifiers = sensitiveKnowledgeFieldIdentifiers(
+      Object.entries(fields),
+    );
+    const tenant = sanitizeKnowledgeTenant(
+      projectTenant(decoratorConfig.tenantScoped),
+      sensitiveIdentifiers,
+    );
+    const conflictColumns = stringArray(decoratorConfig.conflictColumns).filter(
+      (column) => !sensitiveIdentifiers.has(column),
+    );
 
     return {
       className: String(item.className ?? item.name ?? 'Unknown'),
@@ -2224,7 +2238,15 @@ function readManifestObjects(
       relationships: knowledgeFields.filter((field) =>
         RELATIONSHIP_FIELD_TYPES.has(field.type),
       ),
-      methods: Object.keys(objectRecord(item.methods)).sort(),
+      methods: Object.keys(methods).sort(),
+      methodSignatures: projectMethodSignatures(methods),
+      tenant,
+      tableStrategy:
+        decoratorConfig.tableStrategy === 'cti' ||
+        decoratorConfig.tableStrategy === 'sti'
+          ? decoratorConfig.tableStrategy
+          : undefined,
+      conflictColumns: conflictColumns.length > 0 ? conflictColumns : undefined,
     };
   });
 }
@@ -2232,34 +2254,213 @@ function readManifestObjects(
 function readDomainKnowledgeObjects(
   manifest: DomainKnowledgeManifest,
 ): KnowledgeObject[] {
-  return manifest.objects.map((object) => ({
-    className: object.name,
-    qualifiedName: object.qualifiedName,
-    extends: object.extends,
-    collection: object.collection,
-    mcpOperations: object.surfaces
-      .filter((surface) => surface.kind === 'mcp')
-      .map((surface) => surface.operation)
-      .sort(),
-    tableName: object.tableName,
-    idColumnType: object.fields.find((field) => field.name === 'id')
-      ?.columnType,
-    fields: object.fields.map((field) => ({
-      name: field.name,
-      type: field.type,
-      required: field.required,
-      related: field.related,
-      columnType: field.columnType,
-    })),
-    relationships: object.relationships.map((field) => ({
-      name: field.name,
-      type: field.type,
-      required: field.required,
-      related: field.related,
-      columnType: field.columnType,
-    })),
-    methods: object.methods,
-  }));
+  return manifest.objects.map((object) => {
+    const sensitiveIdentifiers = sensitiveKnowledgeFieldIdentifiers(
+      object.fields.map((field) => [field.name, field]),
+    );
+    const fields = object.fields
+      .filter((field) => !isSensitiveKnowledgeField(field))
+      .map((field) => projectKnowledgeField(field.name, field));
+    const safeFieldNames = new Set(fields.map((field) => field.name));
+    const conflictColumns = object.conflictColumns?.filter(
+      (column) => !sensitiveIdentifiers.has(column),
+    );
+    const tenant = sanitizeKnowledgeTenant(
+      object.tenant ? { ...object.tenant } : undefined,
+      sensitiveIdentifiers,
+    );
+    return {
+      className: object.name,
+      qualifiedName: object.qualifiedName,
+      extends: object.extends,
+      collection: object.collection,
+      mcpOperations: object.surfaces
+        .filter((surface) => surface.kind === 'mcp')
+        .map((surface) => surface.operation)
+        .sort(),
+      tableName: object.tableName,
+      idColumnType: fields.find((field) => field.name === 'id')?.columnType,
+      fields,
+      relationships: object.relationships
+        .filter(
+          (field) =>
+            safeFieldNames.has(field.name) && !isSensitiveKnowledgeField(field),
+        )
+        .map((field) => projectKnowledgeField(field.name, field)),
+      methods: object.methods,
+      methodSignatures: object.methodSignatures?.map((signature) => ({
+        name: signature.name,
+        async: signature.async,
+        static: signature.static,
+        params: signature.params ? [...signature.params] : undefined,
+        returns: signature.returns,
+      })),
+      tenant,
+      tableStrategy: object.tableStrategy,
+      conflictColumns:
+        conflictColumns && conflictColumns.length > 0
+          ? conflictColumns
+          : undefined,
+    };
+  });
+}
+
+function sanitizeDomainKnowledgeManifest(
+  manifest: DomainKnowledgeManifest,
+): DomainKnowledgeManifest {
+  return {
+    ...manifest,
+    objects: manifest.objects.map((object): DomainKnowledgeObject => {
+      const sensitiveIdentifiers = sensitiveKnowledgeFieldIdentifiers(
+        object.fields.map((field) => [field.name, field]),
+      );
+      const fields = object.fields
+        .filter((field) => !isSensitiveKnowledgeField(field))
+        .map((field) => projectKnowledgeField(field.name, field));
+      const safeFieldNames = new Set(fields.map((field) => field.name));
+      const conflictColumns = object.conflictColumns?.filter(
+        (column) => !sensitiveIdentifiers.has(column),
+      );
+      return {
+        ...object,
+        fields,
+        relationships: object.relationships
+          .filter(
+            (field) =>
+              safeFieldNames.has(field.name) &&
+              !isSensitiveKnowledgeField(field),
+          )
+          .map((field) => projectKnowledgeField(field.name, field)),
+        tenant: sanitizeKnowledgeTenant(object.tenant, sensitiveIdentifiers),
+        conflictColumns:
+          conflictColumns && conflictColumns.length > 0
+            ? conflictColumns
+            : undefined,
+      };
+    }),
+  };
+}
+
+function isSensitiveKnowledgeField(value: unknown): boolean {
+  const field = objectRecord(value);
+  return (
+    field.sensitive === true || objectRecord(field._meta).sensitive === true
+  );
+}
+
+function sensitiveKnowledgeFieldIdentifiers(
+  fields: Array<[string, unknown]>,
+): Set<string> {
+  return new Set(
+    fields
+      .filter(([, field]) => isSensitiveKnowledgeField(field))
+      .flatMap(([name]) => [name, toSnakeCase(name), camelToSnake(name)]),
+  );
+}
+
+function projectKnowledgeField(
+  name: string,
+  value: unknown,
+  columnType?: unknown,
+): KnowledgeField {
+  const field = objectRecord(value);
+  const meta = objectRecord(field._meta);
+  const declaredConstraints = objectRecord(field.constraints);
+  const constraints: DomainKnowledgeFieldConstraints = {};
+  for (const key of ['min', 'max', 'minLength', 'maxLength'] as const) {
+    const candidate = field[key] ?? meta[key] ?? declaredConstraints[key];
+    if (typeof candidate === 'number') constraints[key] = candidate;
+  }
+  const pattern = normalizeKnowledgePattern(
+    field.pattern ?? meta.pattern ?? declaredConstraints.pattern,
+  );
+  if (pattern !== undefined) constraints.pattern = pattern;
+  const hasDefault = Object.hasOwn(field, 'default')
+    ? field.default !== undefined
+    : meta.default !== undefined;
+
+  return {
+    name,
+    type: String(field.type ?? 'unknown'),
+    required: typeof field.required === 'boolean' ? field.required : undefined,
+    related: typeof field.related === 'string' ? field.related : undefined,
+    columnType:
+      typeof columnType === 'string'
+        ? columnType
+        : typeof field.columnType === 'string'
+          ? field.columnType
+          : undefined,
+    ...(hasDefault
+      ? {
+          default: Object.hasOwn(field, 'default')
+            ? field.default
+            : meta.default,
+        }
+      : {}),
+    constraints: Object.keys(constraints).length > 0 ? constraints : undefined,
+    readonly:
+      field.readonly === true || meta.readonly === true ? true : undefined,
+    transient:
+      field.transient === true || meta.transient === true ? true : undefined,
+  };
+}
+
+function normalizeKnowledgePattern(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  const source = objectRecord(value).source;
+  return typeof source === 'string' ? source : undefined;
+}
+
+function projectTenant(value: unknown): DomainKnowledgeTenant | undefined {
+  if (value === true) {
+    return { scoped: true, mode: 'required', field: 'tenantId' };
+  }
+  const config = objectRecord(value);
+  if (Object.keys(config).length === 0) return undefined;
+  return {
+    scoped: true,
+    mode: config.mode === 'optional' ? 'optional' : 'required',
+    field: typeof config.field === 'string' ? config.field : 'tenantId',
+  };
+}
+
+function sanitizeKnowledgeTenant(
+  tenant: DomainKnowledgeTenant | undefined,
+  sensitiveIdentifiers: Set<string>,
+): DomainKnowledgeTenant | undefined {
+  if (!tenant?.field || !sensitiveIdentifiers.has(tenant.field)) return tenant;
+  return { scoped: tenant.scoped, mode: tenant.mode };
+}
+
+function projectMethodSignatures(
+  methods: Record<string, unknown>,
+): DomainKnowledgeMethodSignature[] | undefined {
+  const signatures = Object.entries(methods)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([methodName, value]) => {
+      const method = objectRecord(value);
+      const params = Array.isArray(method.parameters)
+        ? method.parameters.map((raw) => {
+            const parameter = objectRecord(raw);
+            const name =
+              typeof parameter.name === 'string' ? parameter.name : 'arg';
+            const type =
+              typeof parameter.type === 'string' ? parameter.type : 'unknown';
+            return `${name}${parameter.optional === true ? '?' : ''}: ${type}`;
+          })
+        : undefined;
+      return {
+        name: typeof method.name === 'string' ? method.name : methodName,
+        async: method.async === true ? true : undefined,
+        static: method.isStatic === true ? true : undefined,
+        params: params && params.length > 0 ? params : undefined,
+        returns:
+          typeof method.returnType === 'string' && method.returnType
+            ? method.returnType
+            : undefined,
+      };
+    });
+  return signatures.length > 0 ? signatures : undefined;
 }
 
 function readDomainKnowledgePrompts(
@@ -3344,6 +3545,11 @@ function renderPackageContext(
     return lines.join('\n');
   }
 
+  const structuralFacts = renderObjectStructuralFacts(pkg.objects);
+  if (structuralFacts.length > 0) {
+    lines.push('', '#### Object structural facts', '', ...structuralFacts);
+  }
+
   if (pkg.agentDoc) {
     lines.push('', pkg.agentDoc.trim());
   }
@@ -3364,6 +3570,77 @@ function renderPackageContext(
   }
   lines.push('');
   return lines.join('\n');
+}
+
+function renderObjectStructuralFacts(objects: KnowledgeObject[]): string[] {
+  const lines: string[] = [];
+  for (const object of objects) {
+    const objectFacts = [
+      object.tenant
+        ? `tenant ${object.tenant.mode ?? 'required'}${object.tenant.field ? ` via ${object.tenant.field}` : ''}`
+        : undefined,
+      object.tableStrategy
+        ? `table strategy ${object.tableStrategy}`
+        : undefined,
+      object.conflictColumns && object.conflictColumns.length > 0
+        ? `conflict columns ${object.conflictColumns.join(', ')}`
+        : undefined,
+    ].filter((fact): fact is string => Boolean(fact));
+    const structuralFields = object.fields.filter(
+      (field) =>
+        Object.hasOwn(field, 'default') ||
+        field.constraints !== undefined ||
+        field.readonly === true ||
+        field.transient === true,
+    );
+    const signatures = object.methodSignatures ?? [];
+    if (
+      objectFacts.length === 0 &&
+      structuralFields.length === 0 &&
+      signatures.length === 0
+    ) {
+      continue;
+    }
+
+    lines.push(
+      `- ${object.qualifiedName ?? object.className}${objectFacts.length > 0 ? ` — ${objectFacts.join('; ')}` : ''}`,
+    );
+    for (const field of structuralFields) {
+      const facts = [
+        Object.hasOwn(field, 'default')
+          ? `default ${renderKnowledgeValue(field.default)}`
+          : undefined,
+        field.constraints
+          ? `constraints ${Object.entries(field.constraints)
+              .map(([key, value]) => `${key}=${renderKnowledgeValue(value)}`)
+              .join(', ')}`
+          : undefined,
+        field.readonly ? 'readonly' : undefined,
+        field.transient ? 'transient' : undefined,
+      ].filter((fact): fact is string => Boolean(fact));
+      lines.push(
+        `  - field ${field.name}: ${field.type} (${facts.join('; ')})`,
+      );
+    }
+    for (const signature of signatures) {
+      const prefix = [
+        signature.static ? 'static' : '',
+        signature.async ? 'async' : '',
+      ]
+        .filter(Boolean)
+        .join(' ');
+      lines.push(
+        `  - method ${prefix ? `${prefix} ` : ''}${signature.name}(${(signature.params ?? []).join(', ')})${signature.returns ? `: ${signature.returns}` : ''}`,
+      );
+    }
+  }
+  return lines;
+}
+
+function renderKnowledgeValue(value: unknown): string {
+  const rendered = JSON.stringify(value);
+  if (rendered === undefined) return String(value);
+  return rendered.length > 120 ? `${rendered.slice(0, 117)}...` : rendered;
 }
 
 function getChangedFiles(rootDir: string, base?: string): string[] {

--- a/packages/smrt-dev-mcp/src/knowledge/index.ts
+++ b/packages/smrt-dev-mcp/src/knowledge/index.ts
@@ -3577,7 +3577,9 @@ function renderObjectStructuralFacts(objects: KnowledgeObject[]): string[] {
   for (const object of objects) {
     const objectFacts = [
       object.tenant
-        ? `tenant ${object.tenant.mode ?? 'required'}${object.tenant.field ? ` via ${object.tenant.field}` : ''}`
+        ? object.tenant.scoped
+          ? `tenant ${object.tenant.mode ?? 'required'}${object.tenant.field ? ` via ${object.tenant.field}` : ''}`
+          : 'tenant unscoped'
         : undefined,
       object.tableStrategy
         ? `table strategy ${object.tableStrategy}`

--- a/packages/smrt-dev-mcp/src/mcp-stdio.test.ts
+++ b/packages/smrt-dev-mcp/src/mcp-stdio.test.ts
@@ -1,9 +1,11 @@
 import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/client';
 import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(__dirname, '..');
@@ -12,15 +14,145 @@ const tsxBin = join(repoRoot, 'node_modules', '.bin', 'tsx');
 
 let activeClient: Client | undefined;
 let activeTransport: StdioClientTransport | undefined;
+let fixtureRoot: string;
+let installedRoot: string;
+
+async function writeFixturePackage(options: {
+  directory: string;
+  name: string;
+  className: string;
+  collection: string;
+}) {
+  const directory = join(fixtureRoot, 'packages', options.directory);
+  await mkdir(join(directory, 'src', 'manifest'), { recursive: true });
+  await mkdir(join(directory, 'src', 'models'), { recursive: true });
+  await writeFile(
+    join(directory, 'package.json'),
+    JSON.stringify({
+      name: options.name,
+      version: '1.0.0',
+      type: 'module',
+      private: true,
+    }),
+  );
+  await writeFile(
+    join(directory, 'AGENTS.md'),
+    `# ${options.className}\n\nFixture package guidance.\n`,
+  );
+  await writeFile(join(directory, 'CLAUDE.md'), '@AGENTS.md\n');
+  await writeFile(
+    join(directory, 'src', 'models', `${options.className}.ts`),
+    `export class ${options.className} {}\n`,
+  );
+  await writeFile(
+    join(directory, 'src', 'manifest', 'manifest.json'),
+    JSON.stringify({
+      version: '1',
+      packageName: options.name,
+      objects: {
+        [`${options.name}:${options.className}`]: {
+          className: options.className,
+          qualifiedName: `${options.name}:${options.className}`,
+          extends: 'SmrtObject',
+          collection: options.collection,
+          fields: {
+            title: { type: 'text', required: true },
+          },
+        },
+      },
+    }),
+  );
+}
+
+async function createFixtureWorkspace() {
+  fixtureRoot = await mkdtemp(join(tmpdir(), 'smrt-dev-mcp-stdio-'));
+  await writeFile(
+    join(fixtureRoot, 'package.json'),
+    JSON.stringify({
+      name: 'mcp-stdio-fixture',
+      private: true,
+      dependencies: { '@happyvertical/smrt-jobs': '1.0.0' },
+    }),
+  );
+  await writeFile(
+    join(fixtureRoot, 'pnpm-workspace.yaml'),
+    "packages:\n  - 'packages/*'\n",
+  );
+  await writeFixturePackage({
+    directory: 'content',
+    name: '@happyvertical/smrt-content',
+    className: 'Article',
+    collection: 'articles',
+  });
+  await writeFixturePackage({
+    directory: 'profiles',
+    name: '@happyvertical/smrt-profiles',
+    className: 'Profile',
+    collection: 'profiles',
+  });
+
+  installedRoot = await mkdtemp(join(tmpdir(), 'smrt-dev-mcp-installed-'));
+  const installedPackage = join(installedRoot, 'smrt-jobs');
+  await mkdir(join(installedPackage, 'dist'), { recursive: true });
+  await mkdir(join(fixtureRoot, 'node_modules', '@happyvertical'), {
+    recursive: true,
+  });
+  await writeFile(
+    join(installedPackage, 'package.json'),
+    JSON.stringify({
+      name: '@happyvertical/smrt-jobs',
+      version: '1.0.0',
+      files: ['dist', 'AGENTS.md', 'CLAUDE.md'],
+      exports: {
+        './smrt-knowledge.json': './dist/smrt-knowledge.json',
+      },
+    }),
+  );
+  await writeFile(join(installedPackage, 'AGENTS.md'), '# Jobs\n');
+  await writeFile(join(installedPackage, 'CLAUDE.md'), '@AGENTS.md\n');
+  await writeFile(
+    join(installedPackage, 'dist', 'smrt-knowledge.json'),
+    JSON.stringify({
+      schemaVersion: 1,
+      sensitiveFieldsExcluded: true,
+      generatedAt: new Date().toISOString(),
+      packageName: '@happyvertical/smrt-jobs',
+      packageVersion: '1.0.0',
+      sourceHashes: {},
+      exports: ['./smrt-knowledge.json'],
+      dependencies: {},
+      smrtDependencies: [],
+      sdkDependencies: [],
+      tags: [],
+      risks: [],
+      objects: [],
+      surfaces: [],
+      prompts: [],
+      relationshipsV2: {
+        foreignKeyFields: 0,
+        crossPackageRefFields: 0,
+        junctionCollections: 0,
+        hierarchicalObjects: 0,
+        polymorphicAssociations: 0,
+        uuidColumns: 0,
+      },
+    }),
+  );
+  await symlink(
+    installedPackage,
+    join(fixtureRoot, 'node_modules', '@happyvertical', 'smrt-jobs'),
+  );
+}
 
 async function createMcpClient() {
   expect(existsSync(tsxBin)).toBe(true);
 
   const transport = new StdioClientTransport({
     command: tsxBin,
-    args: ['src/index.ts'],
-    cwd: packageRoot,
-    stderr: 'pipe',
+    args: [join(packageRoot, 'src', 'index.ts')],
+    cwd: fixtureRoot,
+    // Keep the child stream drained and preserve fatal diagnostics in CI.
+    stderr: 'inherit',
   });
   const client = new Client(
     { name: 'smrt-dev-mcp-smoke-test', version: '1.0.0' },
@@ -45,22 +177,26 @@ function textContent(result: Awaited<ReturnType<Client['callTool']>>): string {
   return first.text;
 }
 
+beforeEach(async () => {
+  await createFixtureWorkspace();
+});
+
 afterEach(async () => {
   await activeClient?.close();
   await activeTransport?.close();
   activeClient = undefined;
   activeTransport = undefined;
+  await rm(fixtureRoot, { recursive: true, force: true });
+  await rm(installedRoot, { recursive: true, force: true });
 });
 
 describe('smrt-dev-mcp stdio server', () => {
-  // This smoke spawns a real server and drives ~11 whole-workspace tool calls
-  // against the smrt monorepo. Discovery now reaches every workspace member
-  // (#2143), and a member without build artifacts falls back to an OXC source
-  // scan — seconds per package on a cold CI runner, versus a fast artifact read
-  // locally. The cost therefore tracks how much of the repo is prebuilt, so this
-  // needs a budget well above the 30s default rather than a flaky margin.
+  // This smoke validates the real stdio process boundary against a controlled
+  // workspace. Whole-monorepo discovery belongs in the knowledge integration
+  // suites; repeating it for every protocol call made this process test depend
+  // on runner memory, checkout artifacts, and repository size.
   it('lists and calls knowledge tools over MCP stdio', {
-    timeout: 300_000,
+    timeout: 60_000,
   }, async () => {
     const client = await createMcpClient();
 
@@ -87,7 +223,7 @@ describe('smrt-dev-mcp stdio server', () => {
 
     const reflectResult = await client.callTool({
       name: 'reflect-knowledge',
-      arguments: { rootDir: repoRoot },
+      arguments: { rootDir: fixtureRoot },
     });
     const reflect = JSON.parse(textContent(reflectResult));
     expect(reflect.smrtPackageCount).toBeGreaterThan(0);
@@ -103,7 +239,7 @@ describe('smrt-dev-mcp stdio server', () => {
 
     const domainReflectResult = await client.callTool({
       name: 'reflect-domain-knowledge',
-      arguments: { rootDir: repoRoot },
+      arguments: { rootDir: fixtureRoot },
     });
     const domainReflect = JSON.parse(textContent(domainReflectResult));
     expect(domainReflect.domainKnowledgePackageCount).toBeGreaterThanOrEqual(0);
@@ -111,7 +247,7 @@ describe('smrt-dev-mcp stdio server', () => {
     const reviewResult = await client.callTool({
       name: 'build-review-context',
       arguments: {
-        rootDir: repoRoot,
+        rootDir: fixtureRoot,
         changedFiles: ['packages/content/src/models/Article.ts'],
       },
     });
@@ -137,7 +273,7 @@ describe('smrt-dev-mcp stdio server', () => {
     const fullReviewResult = await client.callTool({
       name: 'build-review-context',
       arguments: {
-        rootDir: repoRoot,
+        rootDir: fixtureRoot,
         changedFiles: ['packages/content/src/models/Article.ts'],
         detail: 'full',
       },
@@ -154,7 +290,7 @@ describe('smrt-dev-mcp stdio server', () => {
     const domainReviewResult = await client.callTool({
       name: 'build-domain-review-context',
       arguments: {
-        rootDir: repoRoot,
+        rootDir: fixtureRoot,
         changedFiles: ['packages/content/src/models/Article.ts'],
         scope: 'package',
         package: 'content',
@@ -168,7 +304,7 @@ describe('smrt-dev-mcp stdio server', () => {
     const architectureResult = await client.callTool({
       name: 'build-architecture-context',
       arguments: {
-        rootDir: repoRoot,
+        rootDir: fixtureRoot,
         idea: 'Publishing workflow with profiles and scheduled social posts',
       },
     });
@@ -183,7 +319,7 @@ describe('smrt-dev-mcp stdio server', () => {
     const domainArchitectureResult = await client.callTool({
       name: 'build-domain-architecture-context',
       arguments: {
-        rootDir: repoRoot,
+        rootDir: fixtureRoot,
         idea: 'Publishing workflow with profiles and scheduled social posts',
         scope: 'package',
         package: 'profiles',
@@ -240,7 +376,7 @@ describe('smrt-dev-mcp stdio server', () => {
     const domainPromptResult = await client.getPrompt({
       name: 'domain-code-review',
       arguments: {
-        rootDir: repoRoot,
+        rootDir: fixtureRoot,
         changedFiles: 'packages/content/src/models/Article.ts',
         scope: 'package',
         package: 'content',
@@ -255,7 +391,7 @@ describe('smrt-dev-mcp stdio server', () => {
     const architecturePromptResult = await client.getPrompt({
       name: 'domain-architecture',
       arguments: {
-        rootDir: repoRoot,
+        rootDir: fixtureRoot,
         idea: 'Publishing workflow with profiles and scheduled social posts',
         scope: 'package',
         package: 'profiles',
@@ -301,9 +437,11 @@ describe('smrt-dev-mcp stdio server', () => {
     // carried over by a spread instead of rebuilt from sanitized entries
     // (#2275).
     expect(Array.isArray(projectKnowledge.installedPackages)).toBe(true);
+    expect(projectKnowledge.installedPackages).toHaveLength(1);
     for (const pkg of projectKnowledge.installedPackages) {
       expect(pkg).not.toHaveProperty('directory');
     }
+    expect(JSON.stringify(projectKnowledge)).not.toContain(tmpdir());
 
     const packageUri = resourceUris.find((uri) =>
       uri.startsWith('smrt://knowledge/package/'),

--- a/packages/smrt-dev-mcp/src/tool-catalog.ts
+++ b/packages/smrt-dev-mcp/src/tool-catalog.ts
@@ -29,6 +29,9 @@ const DEV_MCP_OUTPUT_SCHEMA: NonNullable<Tool['outputSchema']> = {
   },
 };
 
+const KNOWLEDGE_DETAIL_DESCRIPTION =
+  'summary: authored package docs are listed by path to stay inside tool-result budgets. full: embed docs and render structural object facts.';
+
 // Tool definitions
 const TOOL_DEFINITIONS: Array<
   Pick<Tool, 'name' | 'description' | 'inputSchema'>
@@ -306,8 +309,7 @@ const TOOL_DEFINITIONS: Array<
           type: 'string',
           enum: ['summary', 'full'],
           default: 'summary',
-          description:
-            'summary: authored package docs are listed by path to stay inside tool-result budgets. full: embed them.',
+          description: KNOWLEDGE_DETAIL_DESCRIPTION,
         },
       },
     },
@@ -333,8 +335,7 @@ const TOOL_DEFINITIONS: Array<
           type: 'string',
           enum: ['summary', 'full'],
           default: 'summary',
-          description:
-            'summary: authored package docs are listed by path to stay inside tool-result budgets. full: embed them.',
+          description: KNOWLEDGE_DETAIL_DESCRIPTION,
         },
       },
     },
@@ -359,8 +360,7 @@ const TOOL_DEFINITIONS: Array<
           type: 'string',
           enum: ['summary', 'full'],
           default: 'summary',
-          description:
-            'summary: authored package docs are listed by path to stay inside tool-result budgets. full: embed them.',
+          description: KNOWLEDGE_DETAIL_DESCRIPTION,
         },
       },
     },
@@ -380,8 +380,7 @@ const TOOL_DEFINITIONS: Array<
           type: 'string',
           enum: ['summary', 'full'],
           default: 'summary',
-          description:
-            'summary: authored package docs are listed by path to stay inside tool-result budgets. full: embed them.',
+          description: KNOWLEDGE_DETAIL_DESCRIPTION,
         },
       },
     },
@@ -407,8 +406,7 @@ const TOOL_DEFINITIONS: Array<
           type: 'string',
           enum: ['summary', 'full'],
           default: 'summary',
-          description:
-            'summary: authored package docs are listed by path to stay inside tool-result budgets. full: embed them.',
+          description: KNOWLEDGE_DETAIL_DESCRIPTION,
         },
       },
     },
@@ -428,8 +426,7 @@ const TOOL_DEFINITIONS: Array<
           type: 'string',
           enum: ['summary', 'full'],
           default: 'summary',
-          description:
-            'summary: authored package docs are listed by path to stay inside tool-result budgets. full: embed them.',
+          description: KNOWLEDGE_DETAIL_DESCRIPTION,
         },
       },
     },

--- a/packages/types/AGENTS.md
+++ b/packages/types/AGENTS.md
@@ -17,4 +17,4 @@ Shared TypeScript type definitions. Prevents circular dependencies between packa
 - **Zero runtime code**: only type definitions and enums
 - **Always `import type`**: use `import type { Signal }` to avoid runtime imports (except enums which have runtime values)
 - **Add shared types here**: if two+ packages need the same type, put it here instead of in `smrt-core`
-- **Knowledge compatibility**: keep `DomainKnowledgeManifest.schemaVersion` at 1 for additive optional facts and preserve `DomainKnowledgeObject.methods: string[]`; structured signatures live in the optional `methodSignatures` sibling
+- **Knowledge compatibility**: keep `DomainKnowledgeManifest.schemaVersion` at 1 for additive optional facts and preserve `DomainKnowledgeObject.methods: string[]`; structured signatures live in the optional `methodSignatures` sibling. Generators set `sensitiveFieldsExcluded: true`; readers must treat its absence as a legacy artifact that needs raw-manifest corroboration.

--- a/packages/types/AGENTS.md
+++ b/packages/types/AGENTS.md
@@ -10,9 +10,11 @@ Shared TypeScript type definitions. Prevents circular dependencies between packa
 | `module.ts` | `SmrtModuleMeta`, `ModuleUISlot`, `ModuleComponentType` — module registration and UI slots |
 | `user.ts` | `UserStatus`, `TenantStatus`, `MembershipStatus`, `SessionStatus`, `OverrideEffect` — status enums |
 | `identity.ts` | `User`, `Tenant`, `Role`, `Membership`, `SmrtEntityFields` — cross-package identity data contracts (runtime classes live in smrt-users, which `implements` these) |
+| `knowledge.ts` | Additive schema-version-1 domain knowledge contracts shared by core generation and development tooling |
 
 ## Rules
 
 - **Zero runtime code**: only type definitions and enums
 - **Always `import type`**: use `import type { Signal }` to avoid runtime imports (except enums which have runtime values)
 - **Add shared types here**: if two+ packages need the same type, put it here instead of in `smrt-core`
+- **Knowledge compatibility**: keep `DomainKnowledgeManifest.schemaVersion` at 1 for additive optional facts and preserve `DomainKnowledgeObject.methods: string[]`; structured signatures live in the optional `methodSignatures` sibling

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -28,12 +28,16 @@ export type {
 } from './identity.js';
 export type {
   DomainKnowledgeConfig,
+  DomainKnowledgeField,
+  DomainKnowledgeFieldConstraints,
   DomainKnowledgeFreshnessResult,
   DomainKnowledgeManifest,
+  DomainKnowledgeMethodSignature,
   DomainKnowledgeModuleDoc,
   DomainKnowledgeObject,
   DomainKnowledgeSurface,
   DomainKnowledgeSurfaceKind,
+  DomainKnowledgeTenant,
 } from './knowledge.js';
 export type {
   ModuleComponentType,

--- a/packages/types/src/knowledge.ts
+++ b/packages/types/src/knowledge.ts
@@ -119,6 +119,8 @@ export interface DomainKnowledgeModuleDoc {
 /** The package-level domain-knowledge artifact (`smrt-knowledge.json`) — the agent/developer contract. */
 export interface DomainKnowledgeManifest {
   schemaVersion: 1;
+  /** True when generation removed sensitive fields before projecting objects. */
+  sensitiveFieldsExcluded?: true;
   generatedAt: string;
   packageName?: string;
   packageVersion?: string;

--- a/packages/types/src/knowledge.ts
+++ b/packages/types/src/knowledge.ts
@@ -38,6 +38,44 @@ export interface DomainKnowledgeConfig {
   risks?: string[];
 }
 
+/** Validation constraints retained in the curated agent-facing field shape. */
+export interface DomainKnowledgeFieldConstraints {
+  min?: number;
+  max?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+}
+
+/** A field retained in the curated agent-facing object shape. */
+export interface DomainKnowledgeField {
+  name: string;
+  type: string;
+  required?: boolean;
+  related?: string;
+  columnType?: string;
+  default?: unknown;
+  constraints?: DomainKnowledgeFieldConstraints;
+  readonly?: boolean;
+  transient?: boolean;
+}
+
+/** Additive structured signature; `methods: string[]` remains the compatibility surface. */
+export interface DomainKnowledgeMethodSignature {
+  name: string;
+  async?: boolean;
+  static?: boolean;
+  params?: string[];
+  returns?: string;
+}
+
+/** Normalized tenancy facts from `@smrt({ tenantScoped })`. */
+export interface DomainKnowledgeTenant {
+  scoped: boolean;
+  mode?: 'required' | 'optional';
+  field?: string;
+}
+
 /** One object's entry in the domain-knowledge manifest (fields, relationships, surfaces). */
 export interface DomainKnowledgeObject {
   name: string;
@@ -47,21 +85,13 @@ export interface DomainKnowledgeObject {
   packageName?: string;
   extends?: string;
   visibility?: string;
-  fields: Array<{
-    name: string;
-    type: string;
-    required?: boolean;
-    related?: string;
-    columnType?: string;
-  }>;
-  relationships: Array<{
-    name: string;
-    type: string;
-    required?: boolean;
-    related?: string;
-    columnType?: string;
-  }>;
+  fields: DomainKnowledgeField[];
+  relationships: DomainKnowledgeField[];
   methods: string[];
+  methodSignatures?: DomainKnowledgeMethodSignature[];
+  tenant?: DomainKnowledgeTenant;
+  tableStrategy?: 'cti' | 'sti';
+  conflictColumns?: string[];
   surfaces: DomainKnowledgeSurface[];
   relationshipFeatures: string[];
   tags: string[];


### PR DESCRIPTION
## Summary

- widen the additive schema-version-1 knowledge contract with tenant, table strategy, conflict keys, method signatures, and field schema facts
- preserve summary budgets while rendering structural facts in full review and architecture context
- remove sensitive fields and indirect identifiers across generated, raw-manifest, stored-domain, resource, and Markdown projections
- fail closed for legacy schema-v1 artifacts by corroborating their fields and structural identifiers against the owning raw manifest
- keep legacy schema-version-1 artifacts and methods string arrays compatible
- stabilize the end-to-end stdio smoke on a controlled authored/installed package fixture, with child diagnostics visible instead of rebuilding the full monorepo on every protocol call

## Validation

- Node 25.2.1 (satisfies `>=24.18.0`)
- package builds: smrt-types, smrt-core, smrt-dev-mcp
- typechecks: smrt-types, smrt-core, smrt-dev-mcp
- core knowledge tests: 14/14
- smrt-core full tests: 3,243 passed, 46 skipped
- smrt-dev-mcp full tests: 154/154
- exact coverage order (core, then smrt-dev-mcp): 86.42% and 84.82%; repeated dev-MCP coverage 154/154
- stdio smoke stress: 5/5 fresh-process passes at 1.59–1.64 seconds
- strict knowledge freshness: 0 errors, 0 warnings
- package standards, README, agent-chain, audit-policy, Biome, and full pre-push checks
- three-reviewer final round clear on correctness, security, tests, docs, compatibility, and exact head

Closes #1819
Parent: #2307

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-stale-prs-20260812-stdio-fix","issue":1819,"policy_revision":"1.0.0","status":"complete","validation":["Node 25.2.1 package builds and typechecks green","core knowledge 14/14 and core full suite 3243 passed","dev-MCP full suite 154/154","core and dev-MCP coverage green at 86.42% and 84.82%","stdio stress 5/5 fresh-process passes","strict knowledge freshness 0 errors and 0 warnings","three-reviewer final round clear"]}

