### PR TITLE
fix(core): include generated routes in clean SvelteKit builds

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -200,9 +200,12 @@
   "devDependencies": {
     "@faker-js/faker": "^10.5.0",
     "@huggingface/transformers": "^3.8.1",
+    "@sveltejs/kit": "^2.69.1",
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@types/node": "24.13.2",
     "@types/pluralize": "^0.0.33",
     "@xenova/transformers": "^2.17.2",
+    "svelte": "^5.56.4",
     "vite": "8.1.4",
     "vite-plugin-dts": "4.5.4",
     "vitest": "4.1.10"

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type {
   DomainKnowledgeConfig,
@@ -269,6 +269,25 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
   let config: ResolvedConfig | null = null; // Store resolved config for closeBundle hook
   let resolvedPluginNames: string[] = [];
   let hasFreshConfigResolvedManifest = false;
+  let configHookManifest: SmartObjectManifest | null = null;
+  let generatedRoutesDuringConfig = false;
+
+  async function generateConfiguredSvelteKitRoutes(
+    rootDir: string,
+    currentManifest: SmartObjectManifest,
+  ): Promise<void> {
+    await generateSvelteKitRoutes(rootDir, currentManifest, {
+      enabled: svelteKit.enabled,
+      routesDir: svelteKit.routesDir || 'src/routes/api',
+      objectsDir: svelteKit.objectsDir || 'src/lib/objects',
+      configPath: svelteKit.configPath || 'src/lib/server',
+      configFileName: svelteKit.configFileName || 'smrt.ts',
+      kebabRoutes: svelteKit.kebabRoutes ?? false,
+      changesRoute: svelteKit.changesRoute,
+      eventsRoute: svelteKit.eventsRoute,
+      knowledge: await resolveKnowledgeConfig(rootDir, currentManifest),
+    });
+  }
 
   /**
    * Write manifest to .smrt/manifest.json for CLI discovery.
@@ -517,6 +536,31 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
 
   return {
     name: 'smrt-auto-service',
+    // SvelteKit inventories routes in a `config.order = 'pre'` hook. Put SMRT
+    // in Vite's earlier plugin tier so this plugin's own pre hook runs first
+    // even when the documented plugin array lists sveltekit() before us.
+    enforce: 'pre',
+
+    // SvelteKit inventories filesystem routes in its config hook. Generate
+    // SMRT routes in an earlier config hook so a clean checkout's first build
+    // sees them; configResolved is too late because Vite runs those hooks
+    // concurrently (#2313).
+    config: {
+      order: 'pre',
+      async handler(userConfig) {
+        if (!svelteKit.enabled) return;
+
+        projectRoot =
+          configuredProjectRoot ??
+          resolve(process.cwd(), userConfig.root ?? '.');
+        configHookManifest = await scanAndGenerateManifest(projectRoot);
+        await generateConfiguredSvelteKitRoutes(
+          projectRoot,
+          configHookManifest,
+        );
+        generatedRoutesDuringConfig = true;
+      },
+    },
 
     // Expose options for external access (e.g., test manifest generation)
     api: {
@@ -560,7 +604,9 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
       console.log(`[smrt] Running in ${pluginMode} mode`);
 
       // Scan files and generate initial manifest in all modes
-      manifest = await scanAndGenerateManifest(projectRoot);
+      manifest =
+        configHookManifest ?? (await scanAndGenerateManifest(projectRoot));
+      configHookManifest = null;
 
       // Write local manifest for CLI discovery (Issue #963)
       if (manifest) {
@@ -573,19 +619,10 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
       }
 
       // Generate SvelteKit routes if enabled
-      if (svelteKit.enabled && manifest) {
-        await generateSvelteKitRoutes(projectRoot, manifest, {
-          enabled: svelteKit.enabled,
-          routesDir: svelteKit.routesDir || 'src/routes/api',
-          objectsDir: svelteKit.objectsDir || 'src/lib/objects',
-          configPath: svelteKit.configPath || 'src/lib/server',
-          configFileName: svelteKit.configFileName || 'smrt.ts',
-          kebabRoutes: svelteKit.kebabRoutes ?? false,
-          changesRoute: svelteKit.changesRoute,
-          eventsRoute: svelteKit.eventsRoute,
-          knowledge: await resolveKnowledgeConfig(projectRoot, manifest),
-        });
+      if (svelteKit.enabled && manifest && !generatedRoutesDuringConfig) {
+        await generateConfiguredSvelteKitRoutes(projectRoot, manifest);
       }
+      generatedRoutesDuringConfig = false;
 
       // Vite calls buildStart immediately after configResolved for the initial
       // build. The manifest already reflects the same source tree, so let that

--- a/packages/core/src/vite-plugin/local-manifest.test.ts
+++ b/packages/core/src/vite-plugin/local-manifest.test.ts
@@ -13,6 +13,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { resolveConfig } from 'vite';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { smrtPlugin } from './index';
 
@@ -207,6 +208,47 @@ describe('smrtPlugin local manifest writing (Issue #963)', () => {
     );
     expect(existsSync(join(invokingRoot, generatedRoute))).toBe(false);
     expect(existsSync(join(invokingRoot, '.gitignore'))).toBe(false);
+  });
+
+  it('generates routes before SvelteKit inventories a clean checkout (#2313)', async () => {
+    createLocalSmrtObject(tmpDir);
+    const generatedRoute = join(
+      tmpDir,
+      'src/routes/api/localthings/+server.ts',
+    );
+    let routeExistedDuringConfig = false;
+
+    await resolveConfig(
+      {
+        root: tmpDir,
+        configFile: false,
+        logLevel: 'silent',
+        plugins: [
+          {
+            name: 'sveltekit-route-inventory-fixture',
+            config: {
+              order: 'pre',
+              handler() {
+                routeExistedDuringConfig = existsSync(generatedRoute);
+              },
+            },
+          },
+          smrtPlugin({
+            include: ['src/**/*.ts'],
+            generateTypes: false,
+            svelteKit: {
+              enabled: true,
+              routesDir: 'src/routes/api',
+              objectsDir: 'src',
+            },
+          }),
+        ],
+      },
+      'build',
+    );
+
+    expect(routeExistedDuringConfig).toBe(true);
+    expect(existsSync(generatedRoute)).toBe(true);
   });
 
   it('writes domain knowledge when config omits this package override', async () => {

--- a/packages/core/src/vite-plugin/sveltekit-clean-build.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-clean-build.test.ts
@@ -1,0 +1,149 @@
+import { execFile } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+
+describe('SvelteKit clean build route generation (#2313)', () => {
+  const projectRoot = resolve(
+    import.meta.dirname,
+    `__test-sveltekit-clean-build-${process.pid}`,
+  );
+
+  afterEach(() => {
+    if (existsSync(projectRoot)) {
+      rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('includes generated item routes in the first build with documented plugin order', async () => {
+    mkdirSync(join(projectRoot, 'src/lib/objects'), { recursive: true });
+    mkdirSync(join(projectRoot, 'src/lib/server'), { recursive: true });
+    mkdirSync(join(projectRoot, 'src/routes'), { recursive: true });
+
+    writeFileSync(
+      join(projectRoot, 'package.json'),
+      JSON.stringify({
+        name: 'smrt-clean-build-fixture',
+        private: true,
+        type: 'module',
+        dependencies: { '@happyvertical/smrt-core': '*' },
+      }),
+    );
+    writeFileSync(
+      join(projectRoot, 'svelte.config.js'),
+      'export default {};\n',
+    );
+    writeFileSync(
+      join(projectRoot, 'tsconfig.json'),
+      JSON.stringify({ extends: './.svelte-kit/tsconfig.json' }),
+    );
+    writeFileSync(
+      join(projectRoot, 'src/app.html'),
+      '<!doctype html><html><head>%sveltekit.head%</head><body><div style="display: contents">%sveltekit.body%</div></body></html>',
+    );
+    writeFileSync(
+      join(projectRoot, 'src/routes/+page.svelte'),
+      '<h1>Clean build fixture</h1>\n',
+    );
+    writeFileSync(
+      join(projectRoot, 'src/lib/objects/Item.ts'),
+      [
+        "import { SmrtObject, smrt } from '@happyvertical/smrt-core';",
+        '',
+        "@smrt({ api: { include: ['list', 'get'] } })",
+        'export class Item extends SmrtObject {',
+        "  title: string = '';",
+        '}',
+        '',
+      ].join('\n'),
+    );
+    // Keep the integration focused on filesystem route inventory. The real
+    // generator preserves an app-owned collection factory, so provide the
+    // smallest valid one and avoid exercising database bootstrap in SvelteKit's
+    // post-build module analysis.
+    writeFileSync(
+      join(projectRoot, 'src/lib/server/smrt.ts'),
+      'export async function getCollection() { return {}; }\n',
+    );
+
+    const consumerPluginUrl = pathToFileURL(
+      resolve(import.meta.dirname, '../consumer-plugin/index.ts'),
+    ).href;
+    const smrtPluginUrl = pathToFileURL(
+      resolve(import.meta.dirname, 'index.ts'),
+    ).href;
+    writeFileSync(
+      join(projectRoot, 'vite.config.ts'),
+      `import { sveltekit } from '@sveltejs/kit/vite';
+import { smrtConsumer } from ${JSON.stringify(consumerPluginUrl)};
+import { smrtPlugin } from ${JSON.stringify(smrtPluginUrl)};
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@happyvertical/smrt-core': ${JSON.stringify(resolve(import.meta.dirname, '../index.ts'))},
+    },
+  },
+  oxc: { decorator: { legacy: true, emitDecoratorMetadata: true } },
+  plugins: [
+    sveltekit(),
+    smrtConsumer({
+      projectRoot: ${JSON.stringify(projectRoot)},
+      packages: [],
+      disableScanning: true,
+      generateTypes: false,
+      svelteKit: true,
+    }),
+    smrtPlugin({
+      projectRoot: ${JSON.stringify(projectRoot)},
+      include: ['src/lib/objects/**/*.ts'],
+      generateTypes: false,
+      svelteKit: {
+        enabled: true,
+        routesDir: 'src/routes/api',
+        objectsDir: 'src/lib/objects',
+        configPath: 'src/lib/server',
+        configFileName: 'smrt.ts',
+        changesRoute: { enabled: false },
+        eventsRoute: { enabled: false },
+      },
+    }),
+  ],
+});
+`,
+    );
+
+    const viteCli = resolve(
+      import.meta.dirname,
+      '../../node_modules/vite/bin/vite.js',
+    );
+    await execFileAsync(process.execPath, [viteCli, 'build'], {
+      cwd: projectRoot,
+      maxBuffer: 32 * 1024 * 1024,
+      timeout: 110_000,
+    });
+
+    const generatedRoute = join(
+      projectRoot,
+      'src/routes/api/items/[id]/+server.ts',
+    );
+    const serverManifest = join(
+      projectRoot,
+      '.svelte-kit/output/server/manifest-full.js',
+    );
+    expect(existsSync(generatedRoute)).toBe(true);
+    expect(existsSync(serverManifest)).toBe(true);
+    expect(readFileSync(serverManifest, 'utf8')).toContain('/api/items/[id]');
+  }, 120_000);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -900,6 +900,12 @@ importers:
       '@huggingface/transformers':
         specifier: ^3.8.1
         version: 3.8.1(@types/node@24.13.2)
+      '@sveltejs/kit':
+        specifier: ^2.69.1
+        version: 2.69.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)))(svelte@5.56.4)(typescript@5.9.3)(vite@8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^7.1.2
+        version: 7.1.2(svelte@5.56.4)(vite@8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -909,6 +915,9 @@ importers:
       '@xenova/transformers':
         specifier: ^2.17.2
         version: 2.17.2(@types/node@24.13.2)
+      svelte:
+        specifier: ^5.56.4
+        version: 5.56.4
       vite:
         specifier: 8.1.4
         version: 8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)


### PR DESCRIPTION
Closes #2313

Generate filesystem-backed SMRT API routes before SvelteKit inventories its route tree. The SMRT plugin now runs in Vite's pre tier and performs its initial scan/generation in a pre config hook, while preserving the existing configResolved compatibility path and watch rescans.

Adds a real clean child-process SvelteKit production build regression using the documented `sveltekit(), smrtConsumer(), smrtPlugin()` order and asserts `/api/items/[id]` is present in the first emitted server manifest.

Validation:
- Node 24.18.0 core typecheck
- focused Vite/SvelteKit tests: 16 passed
- full core suite: 265 files, 3241 passed, 46 skipped
- Biome and `git diff --check`
- correctness, security, and test review-cycle: APPROVE on exact `73d463b8f`

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"019ff249-6db8-7541-a632-f9a26186f90a","issue":2313,"policy_revision":"1.0.0","status":"complete","validation":["node-24-core-typecheck","focused-vite-sveltekit-16-pass","full-core-3241-pass","biome-diff-check","three-reviewer-cycle"]}
