### PR TITLE
fix(cli): type PostgreSQL STI repair identity parameters

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "clean": "rm -rf dist",
     "dev": "npm run build:watch",
     "test": "vitest run",
-    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/commands/__tests__/db-migrate-uuid.test.ts src/commands/__tests__/db-migrate-force-postgres.test.ts",
+    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/commands/__tests__/db-migrate-uuid.test.ts src/commands/__tests__/db-migrate-force-postgres.test.ts src/commands/__tests__/sti-upgrade.test.ts",
     "test:watch": "vitest",
     "typecheck": "tsc -p tsconfig.typecheck.json",
     "cli": "tsx src/index.ts"

--- a/packages/cli/src/commands/__tests__/sti-upgrade.test.ts
+++ b/packages/cli/src/commands/__tests__/sti-upgrade.test.ts
@@ -282,4 +282,142 @@ describe('resolveStiDiscriminatorUpgrade', () => {
       },
     ]);
   });
+
+  it('matches nullable STI conflict columns when finding qualified duplicates', async () => {
+    db = await getDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      __smrtSkipVitestSchemaPreparation: true,
+    });
+    await db.query(`
+      CREATE TABLE sti_upgrade_customs (
+        id TEXT PRIMARY KEY,
+        slug TEXT NOT NULL,
+        context TEXT NOT NULL DEFAULT '',
+        external_key TEXT,
+        _meta_type TEXT NOT NULL
+      )
+    `);
+    await db.query(`
+      INSERT INTO sti_upgrade_customs (id, slug, context, external_key, _meta_type)
+      VALUES ('legacy-1', 'legacy-slug', '', NULL, 'StiUpgradeCustomIdentity')
+    `);
+    await db.query(`
+      INSERT INTO sti_upgrade_customs (id, slug, context, external_key, _meta_type)
+      VALUES ('qualified-1', 'different-slug', '', NULL, '@happyvertical/smrt-cli:StiUpgradeCustomIdentity')
+    `);
+
+    const result = await repairStiDiscriminatorRows({
+      db,
+      tableName: 'sti_upgrade_customs',
+      className: 'StiUpgradeCustomIdentity',
+      legacyMetaType: 'StiUpgradeCustomIdentity',
+      qualifiedMetaType: '@happyvertical/smrt-cli:StiUpgradeCustomIdentity',
+    });
+
+    expect(result.updatedRows).toBe(0);
+    expect(result.conflicts).toEqual([
+      {
+        tableName: 'sti_upgrade_customs',
+        legacyMetaType: 'StiUpgradeCustomIdentity',
+        qualifiedMetaType: '@happyvertical/smrt-cli:StiUpgradeCustomIdentity',
+        legacyId: 'legacy-1',
+        qualifiedId: 'qualified-1',
+        conflictIdentity: {
+          external_key: null,
+        },
+      },
+    ]);
+  });
+
+  it.runIf(process.env.DATABASE_URL)(
+    'repairs non-null identities and detects null duplicates on PostgreSQL',
+    async () => {
+      const tableName = `sti_upgrade_pg_${Math.random().toString(36).slice(2, 10)}`;
+      db = await getDatabase({
+        type: 'postgres',
+        url: process.env.DATABASE_URL as string,
+      });
+
+      try {
+        await db.query(`
+          CREATE TABLE "${tableName}" (
+            id TEXT PRIMARY KEY,
+            slug TEXT NOT NULL,
+            context TEXT NOT NULL DEFAULT '',
+            external_key TEXT,
+            _meta_type TEXT NOT NULL
+          )
+        `);
+        await db.query(
+          `INSERT INTO "${tableName}" (id, slug, context, external_key, _meta_type)
+           VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)`,
+          'legacy-null',
+          'legacy-null',
+          '',
+          null,
+          'StiUpgradeCustomIdentity',
+          'qualified-null',
+          'qualified-null',
+          '',
+          null,
+          '@happyvertical/smrt-cli:StiUpgradeCustomIdentity',
+          'legacy-value',
+          'legacy-value',
+          '',
+          'unique-key',
+          'StiUpgradeCustomIdentity',
+        );
+
+        const result = await repairStiDiscriminatorRows({
+          db,
+          tableName,
+          className: 'StiUpgradeCustomIdentity',
+          legacyMetaType: 'StiUpgradeCustomIdentity',
+          qualifiedMetaType: '@happyvertical/smrt-cli:StiUpgradeCustomIdentity',
+        });
+
+        expect(result).toMatchObject({
+          checkedRows: 2,
+          updatedRows: 1,
+          wouldUpdateRows: 0,
+        });
+        expect(result.conflicts).toEqual([
+          {
+            tableName,
+            legacyMetaType: 'StiUpgradeCustomIdentity',
+            qualifiedMetaType:
+              '@happyvertical/smrt-cli:StiUpgradeCustomIdentity',
+            legacyId: 'legacy-null',
+            qualifiedId: 'qualified-null',
+            conflictIdentity: {
+              external_key: null,
+            },
+          },
+        ]);
+
+        const rows = (
+          await db.query(
+            `SELECT id, _meta_type FROM "${tableName}" ORDER BY id`,
+          )
+        ).rows;
+        expect(rows).toEqual([
+          {
+            id: 'legacy-null',
+            _meta_type: 'StiUpgradeCustomIdentity',
+          },
+          {
+            id: 'legacy-value',
+            _meta_type: '@happyvertical/smrt-cli:StiUpgradeCustomIdentity',
+          },
+          {
+            id: 'qualified-null',
+            _meta_type: '@happyvertical/smrt-cli:StiUpgradeCustomIdentity',
+          },
+        ]);
+      } finally {
+        await db.query(`DROP TABLE IF EXISTS "${tableName}"`);
+      }
+    },
+  );
 });

--- a/packages/cli/src/commands/sti-upgrade.ts
+++ b/packages/cli/src/commands/sti-upgrade.ts
@@ -98,10 +98,12 @@ function getRowCount(result: QueryResult): number | undefined {
 }
 
 function buildNullSafeIdentityPredicate(columns: string[]): string {
+  // A separate `? IS NULL` parameter has no PostgreSQL type context (42P18).
+  // The column comparison keeps null-safe equality while binding once.
   return columns
     .map((column) => {
       const quoted = quoteIdentifier(column);
-      return `(${quoted} = ? OR (${quoted} IS NULL AND ? IS NULL))`;
+      return `${quoted} IS NOT DISTINCT FROM ?`;
     })
     .join(' AND ');
 }
@@ -117,11 +119,7 @@ function getRowId(row: DbRow): string | null {
 }
 
 function getIdentityParams(row: DbRow, columns: string[]): unknown[] {
-  const params: unknown[] = [];
-  for (const column of columns) {
-    params.push(row[column], row[column]);
-  }
-  return params;
+  return columns.map((column) => row[column]);
 }
 
 export function getStiConflictIdentityColumns(className: string): string[] {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,28 +21,28 @@ overrides:
   '@happyvertical/smrt-types': workspace:*
   '@happyvertical/smrt-config': workspace:*
   '@happyvertical/smrt-core': workspace:*
-  '@happyvertical/ai': ^0.86.3
-  '@happyvertical/cache': ^0.86.3
-  '@happyvertical/documents': ^0.86.3
-  '@happyvertical/email': ^0.86.3
-  '@happyvertical/encryption': ^0.86.3
-  '@happyvertical/files': ^0.86.3
-  '@happyvertical/geo': ^0.86.3
-  '@happyvertical/images': ^0.86.3
-  '@happyvertical/jobs': ^0.86.3
-  '@happyvertical/json': ^0.86.3
-  '@happyvertical/logger': ^0.86.3
-  '@happyvertical/messages': ^0.86.3
+  '@happyvertical/ai': ^0.87.0
+  '@happyvertical/cache': ^0.87.0
+  '@happyvertical/documents': ^0.87.0
+  '@happyvertical/email': ^0.87.0
+  '@happyvertical/encryption': ^0.87.0
+  '@happyvertical/files': ^0.87.0
+  '@happyvertical/geo': ^0.87.0
+  '@happyvertical/images': ^0.87.0
+  '@happyvertical/jobs': ^0.87.0
+  '@happyvertical/json': ^0.87.0
+  '@happyvertical/logger': ^0.87.0
+  '@happyvertical/messages': ^0.87.0
   '@happyvertical/ocr': ^0.61.4
   '@happyvertical/pdf': ^0.65.9
-  '@happyvertical/projects': ^0.86.3
-  '@happyvertical/repos': ^0.86.3
-  '@happyvertical/secrets': ^0.86.3
-  '@happyvertical/signatures': ^0.86.3
-  '@happyvertical/speech': ^0.86.3
+  '@happyvertical/projects': ^0.87.0
+  '@happyvertical/repos': ^0.87.0
+  '@happyvertical/secrets': ^0.87.0
+  '@happyvertical/signatures': ^0.87.0
+  '@happyvertical/speech': ^0.87.0
   '@happyvertical/spider': ^1.1.13
-  '@happyvertical/sql': ^0.86.3
-  '@happyvertical/utils': ^0.86.3
+  '@happyvertical/sql': ^0.87.0
+  '@happyvertical/utils': ^0.87.0
   '@grpc/grpc-js@>=1.14.0 <1.14.4': 1.14.4
   minimatch@>=9.0.0 <10.0.0: 10.2.5
   minimatch@>=10.0.0 <10.2.3: 10.2.5
@@ -168,8 +168,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -211,11 +211,11 @@ importers:
   packages/agents:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/smrt-config':
         specifier: workspace:*
         version: link:../config
@@ -238,18 +238,18 @@ importers:
         specifier: workspace:*
         version: link:../users
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
     devDependencies:
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@sentry/node':
         specifier: 'catalog:'
         version: 10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))
@@ -309,8 +309,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@sveltejs/package':
         specifier: ^2.5.8
         version: 2.5.8(svelte@5.56.4)(typescript@5.9.3)
@@ -370,14 +370,14 @@ importers:
   packages/assets:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
@@ -394,11 +394,11 @@ importers:
         specifier: workspace:*
         version: link:../smrt-ui
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
     devDependencies:
       '@happyvertical/smrt-playground':
         specifier: workspace:*
@@ -450,8 +450,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -475,8 +475,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -523,8 +523,8 @@ importers:
   packages/chat:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/smrt-agents':
         specifier: workspace:*
         version: link:../agents
@@ -547,8 +547,8 @@ importers:
         specifier: workspace:*
         version: link:../users
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
     devDependencies:
       '@happyvertical/smrt-playground':
         specifier: workspace:*
@@ -593,14 +593,14 @@ importers:
   packages/cli:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-agents':
         specifier: workspace:*
         version: link:../agents
@@ -620,11 +620,11 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       acorn:
         specifier: ^8.17.0
         version: 8.17.0
@@ -731,23 +731,23 @@ importers:
   packages/content:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/documents':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/geo':
-        specifier: ^0.86.3
-        version: 0.86.3(@opentelemetry/api@1.9.1)
+        specifier: ^0.87.0
+        version: 0.87.0(@opentelemetry/api@1.9.1)
       '@happyvertical/images':
-        specifier: ^0.86.3
-        version: 0.86.3(jimp@1.6.1)(sharp@0.35.3(@types/node@24.13.2))
+        specifier: ^0.87.0
+        version: 0.87.0(jimp@1.6.1)(sharp@0.35.3(@types/node@24.13.2))
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/ocr':
         specifier: ^0.61.4
         version: 0.61.4(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
@@ -791,11 +791,11 @@ importers:
         specifier: ^1.1.13
         version: 1.1.13(@opentelemetry/api@1.9.1)(@types/node@24.13.2)
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       fast-xml-parser:
         specifier: ^5.10.1
         version: 5.10.1
@@ -843,17 +843,17 @@ importers:
   packages/core:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/json':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-config':
         specifier: workspace:*
         version: link:../config
@@ -864,11 +864,11 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@oxc-project/runtime':
         specifier: ^0.138.0
         version: 0.138.0
@@ -931,14 +931,14 @@ importers:
   packages/events:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-assets':
         specifier: workspace:*
         version: link:../assets
@@ -961,11 +961,11 @@ importers:
         specifier: workspace:*
         version: link:../smrt-ui
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -1001,14 +1001,14 @@ importers:
   packages/facts:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
@@ -1019,11 +1019,11 @@ importers:
         specifier: workspace:*
         version: link:../tenancy
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -1084,8 +1084,8 @@ importers:
         specifier: workspace:*
         version: link:../users
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
     devDependencies:
       '@happyvertical/smrt-cli':
         specifier: workspace:*
@@ -1124,23 +1124,23 @@ importers:
   packages/gnode:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
     devDependencies:
       '@types/node':
         specifier: 24.13.2
@@ -1158,11 +1158,11 @@ importers:
   packages/images:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/images':
-        specifier: ^0.86.3
-        version: 0.86.3(jimp@1.6.1)(sharp@0.35.3(@types/node@24.13.2))
+        specifier: ^0.87.0
+        version: 0.87.0(jimp@1.6.1)(sharp@0.35.3(@types/node@24.13.2))
       '@happyvertical/smrt-assets':
         specifier: workspace:*
         version: link:../assets
@@ -1182,8 +1182,8 @@ importers:
         specifier: workspace:*
         version: link:../smrt-ui
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       jimp:
         specifier: 'catalog:'
         version: 1.6.1
@@ -1198,8 +1198,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@sveltejs/kit':
         specifier: ^2.69.1
         version: 2.69.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.4)(vite@8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)))(svelte@5.56.4)(typescript@5.9.3)(vite@8.1.4(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -1231,8 +1231,8 @@ importers:
   packages/inventory:
     dependencies:
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
@@ -1240,8 +1240,8 @@ importers:
         specifier: workspace:*
         version: link:../tenancy
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -1262,11 +1262,11 @@ importers:
   packages/jobs:
     dependencies:
       '@happyvertical/jobs':
-        specifier: ^0.86.3
-        version: 0.86.3(@aws-sdk/client-sqs@3.1038.0)(@google-cloud/tasks@6.2.1)(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)(bull@4.16.5)(bullmq@5.76.4)
+        specifier: ^0.87.0
+        version: 0.87.0(@aws-sdk/client-sqs@3.1038.0)(@google-cloud/tasks@6.2.1)(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)(bull@4.16.5)(bullmq@5.76.4)
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-config':
         specifier: workspace:*
         version: link:../config
@@ -1283,11 +1283,11 @@ importers:
         specifier: workspace:*
         version: link:../smrt-ui
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -1320,11 +1320,11 @@ importers:
   packages/languages:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-config':
         specifier: workspace:*
         version: link:../config
@@ -1344,8 +1344,8 @@ importers:
         specifier: workspace:*
         version: link:../tenancy
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
     devDependencies:
       '@happyvertical/smrt-cli':
         specifier: workspace:*
@@ -1400,8 +1400,8 @@ importers:
   packages/manufacturing:
     dependencies:
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
@@ -1412,8 +1412,8 @@ importers:
         specifier: workspace:*
         version: link:../tenancy
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -1447,8 +1447,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@sveltejs/package':
         specifier: ^2.5.8
         version: 2.5.8(svelte@5.56.4)(typescript@5.9.3)
@@ -1523,20 +1523,20 @@ importers:
   packages/messages:
     dependencies:
       '@happyvertical/email':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/encryption':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))(@types/node@24.13.2)(typescript@5.9.3)
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))(@types/node@24.13.2)(typescript@5.9.3)
       '@happyvertical/files':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/messages':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
@@ -1556,11 +1556,11 @@ importers:
         specifier: workspace:*
         version: link:../users
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -1614,8 +1614,8 @@ importers:
         specifier: workspace:*
         version: link:../users
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -1648,20 +1648,20 @@ importers:
   packages/places:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/cache':
-        specifier: ^0.86.3
-        version: 0.86.3(@opentelemetry/api@1.9.1)
+        specifier: ^0.87.0
+        version: 0.87.0(@opentelemetry/api@1.9.1)
       '@happyvertical/files':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/geo':
-        specifier: ^0.86.3
-        version: 0.86.3(@opentelemetry/api@1.9.1)
+        specifier: ^0.87.0
+        version: 0.87.0(@opentelemetry/api@1.9.1)
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-assets':
         specifier: workspace:*
         version: link:../assets
@@ -1672,11 +1672,11 @@ importers:
         specifier: workspace:*
         version: link:../tenancy
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -1700,14 +1700,14 @@ importers:
   packages/products:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-assets':
         specifier: workspace:*
         version: link:../assets
@@ -1730,11 +1730,11 @@ importers:
         specifier: workspace:*
         version: link:../smrt-web
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       cors:
         specifier: ^2.8.6
         version: 2.8.6
@@ -1785,14 +1785,14 @@ importers:
   packages/profiles:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-assets':
         specifier: workspace:*
         version: link:../assets
@@ -1806,11 +1806,11 @@ importers:
         specifier: workspace:*
         version: link:../tenancy
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@noble/curves':
         specifier: ^1.9.7
         version: 1.9.7
@@ -1843,17 +1843,17 @@ importers:
   packages/projects:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/projects':
-        specifier: ^0.86.3
-        version: 0.86.3(typescript@5.9.3)
+        specifier: ^0.87.0
+        version: 0.87.0(typescript@5.9.3)
       '@happyvertical/repos':
-        specifier: ^0.86.3
-        version: 0.86.3(typescript@5.9.3)
+        specifier: ^0.87.0
+        version: 0.87.0(typescript@5.9.3)
       '@happyvertical/smrt-config':
         specifier: workspace:*
         version: link:../config
@@ -1879,11 +1879,11 @@ importers:
         specifier: workspace:*
         version: link:../smrt-ui
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
     devDependencies:
       '@happyvertical/smrt-cli':
         specifier: workspace:*
@@ -1931,8 +1931,8 @@ importers:
         specifier: workspace:*
         version: link:../tenancy
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -1969,8 +1969,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -1999,8 +1999,8 @@ importers:
         specifier: workspace:*
         version: link:../tenancy
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -2021,8 +2021,8 @@ importers:
   packages/sales:
     dependencies:
       '@happyvertical/signatures':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/smrt-assets':
         specifier: workspace:*
         version: link:../assets
@@ -2036,8 +2036,8 @@ importers:
         specifier: workspace:*
         version: link:../smrt-ui
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -2098,11 +2098,11 @@ importers:
   packages/secrets:
     dependencies:
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/secrets':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
@@ -2110,11 +2110,11 @@ importers:
         specifier: workspace:*
         version: link:../tenancy
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -2148,8 +2148,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -2177,8 +2177,8 @@ importers:
         specifier: workspace:*
         version: link:../jobs
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@modelcontextprotocol/server':
         specifier: 2.0.0
         version: 2.0.0
@@ -2328,8 +2328,8 @@ importers:
   packages/smrt-svelte:
     dependencies:
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-languages':
         specifier: workspace:*
         version: link:../languages
@@ -2572,18 +2572,18 @@ importers:
         specifier: workspace:*
         version: link:../video
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
     devDependencies:
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@sveltejs/package':
         specifier: ^2.5.8
         version: 2.5.8(svelte@5.56.4)(typescript@5.9.3)
@@ -2618,8 +2618,8 @@ importers:
         specifier: workspace:*
         version: link:../smrt-ui
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -2649,8 +2649,8 @@ importers:
   packages/support:
     dependencies:
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-chat':
         specifier: workspace:*
         version: link:../chat
@@ -2676,8 +2676,8 @@ importers:
         specifier: workspace:*
         version: link:../users
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -2710,14 +2710,14 @@ importers:
   packages/tags:
     dependencies:
       '@happyvertical/ai':
-        specifier: ^0.86.3
-        version: 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+        specifier: ^0.87.0
+        version: 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/files':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
@@ -2725,11 +2725,11 @@ importers:
         specifier: workspace:*
         version: link:../tenancy
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
     devDependencies:
       '@types/node':
         specifier: 24.13.2
@@ -2772,8 +2772,8 @@ importers:
   packages/tenancy:
     dependencies:
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
@@ -2784,11 +2784,11 @@ importers:
         specifier: workspace:*
         version: link:../smrt-ui
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
     devDependencies:
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
@@ -2836,8 +2836,8 @@ importers:
   packages/users:
     dependencies:
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-config':
         specifier: workspace:*
         version: link:../config
@@ -2860,8 +2860,8 @@ importers:
         specifier: workspace:*
         version: link:../smrt-ui
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -2900,8 +2900,8 @@ importers:
   packages/video:
     dependencies:
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-assets':
         specifier: workspace:*
         version: link:../assets
@@ -2924,8 +2924,8 @@ importers:
         specifier: workspace:*
         version: link:../voice
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       svelte:
         specifier: ^5.56.4
         version: 5.56.4
@@ -2934,8 +2934,8 @@ importers:
         specifier: workspace:*
         version: link:../vitest
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -2955,8 +2955,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -3007,24 +3007,24 @@ importers:
         specifier: workspace:*
         version: link:../tenancy
       '@happyvertical/speech':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       '@happyvertical/utils':
-        specifier: ^0.86.3
-        version: 0.86.3
+        specifier: ^0.87.0
+        version: 0.87.0
       svelte:
         specifier: ^5.56.4
         version: 5.56.4
     devDependencies:
       '@happyvertical/logger':
-        specifier: ^0.86.3
-        version: 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+        specifier: ^0.87.0
+        version: 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest
       '@happyvertical/sql':
-        specifier: ^0.86.3
-        version: 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+        specifier: ^0.87.0
+        version: 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -3926,40 +3926,40 @@ packages:
   '@gutenye/ocr-models@1.4.2':
     resolution: {integrity: sha512-y7cLEpGFOeroavopfCd/ejyZB/UeF6xdn0mBFqVHNOI5wQTv2My+/nKxvxKTtG4DVMBzt9TpOfaX7aZGbuciUw==}
 
-  '@happyvertical/ai@0.86.3':
-    resolution: {integrity: sha512-nvE8NUlS5eX7yF3TOeWZ1FE5qbPNdeo1xKIjKh4yYUDOB7WCwVF4lbkvpC72OGOaulZC9BCFjrmXOOD7+0hR6A==}
+  '@happyvertical/ai@0.87.0':
+    resolution: {integrity: sha512-nbvDMl4GKoxT61Z+6O6F5sIoq3ck0QWpQ21YvbdluJ2I5EgM7+AF5Y4Fm0R6t0n+01660V8WXgATKFVHZW5ZHg==}
     hasBin: true
 
-  '@happyvertical/cache@0.86.3':
-    resolution: {integrity: sha512-wzd7uGiOFFrg9NDcNFI8GCLnKv1OpJSlDSaASzjBQWWQGekns4U6l3vjLxLxXEEH8E2BHq5iSo5TqaFZ1rn2Aw==}
+  '@happyvertical/cache@0.87.0':
+    resolution: {integrity: sha512-NgPZH1x6s9f5F/5f1fghlVWnmELEkoIMc80ld3dNrjWqO/ylXA6JgvhQWubFcG3Um6yhBVQBO3U299QuD5N8vQ==}
     hasBin: true
 
-  '@happyvertical/documents@0.86.3':
-    resolution: {integrity: sha512-G799IIMm4SEkJXuejHmIxObe5EyEHJxjDwSDpQQGcrfnpLUfZUgZC8GV2tIYTEYA1HYFzNjJWxLLAo40uoQaPg==}
+  '@happyvertical/documents@0.87.0':
+    resolution: {integrity: sha512-RvDtbM1Kz5I7vWaM1oviVlAo+c3SGvJQ4LedlwAC1/3G04tibcCib7P2U/1j3RCN+ZQlF2qFhZJpT27XDRIskw==}
     hasBin: true
 
-  '@happyvertical/email@0.86.3':
-    resolution: {integrity: sha512-UYZnRt4hNaOchm6SVqctoB1OGjE1g2TfNMJ/uLCAlB0lDENfZ38XokzECayKgpfBF/V7yvcq4++oVe5fwX1TXw==}
+  '@happyvertical/email@0.87.0':
+    resolution: {integrity: sha512-uD74AykC2ORas2rDjNSnbzSRYrmIYBnjKfRFtrNkjG+bSixpiyPV5JPug75jSFXWFlxkivn/WB+wRgwsI76xwg==}
     hasBin: true
 
-  '@happyvertical/encryption@0.86.3':
-    resolution: {integrity: sha512-WIf1unbaKIc/j+wc+UVuTAH8kaJ4tD63PbK4RkmGg05LVe4j7/iAkzF8s6NIH3H5x64TwBCDo2N7E9t++nO6jQ==}
+  '@happyvertical/encryption@0.87.0':
+    resolution: {integrity: sha512-pUEx3KFXRAN1E22/QozZKUjMUg1LrTNKV0niEs50rBqxf+I/iua+YIFb4N1z7ek+Ye5QXYx04M9nCD8DafE9LA==}
     hasBin: true
 
-  '@happyvertical/files@0.86.3':
-    resolution: {integrity: sha512-MfwQQRrnT8xz4BI4SzmzavwDY3BSxMGxhcZMKmqNsHtLdXdXYMASnODTQEChzbTDIp9uVQYb8qJDmX/NhH2DJQ==}
+  '@happyvertical/files@0.87.0':
+    resolution: {integrity: sha512-GAjbTwF0vT4VPpqjuH3vtWNayM0zlOe6D5/4KwB+CBzBGO0m95/4z2P0jB3Sifv3ZvH6lAns68hQfwMybrc/SA==}
     hasBin: true
 
-  '@happyvertical/geo@0.86.3':
-    resolution: {integrity: sha512-v4LLB2QRBWVX2JwU8gxstHFHzwA8pQ1mgFOpo9XSavGJn5lUukhcpThKkUF7LIfA7s9fmyl4bXS5rUlIQ/XdJg==}
+  '@happyvertical/geo@0.87.0':
+    resolution: {integrity: sha512-QkgpRCoP6yAS+wVkr2gkKzo411ikzcE4vKq7ns3eZe/+PF+apT+ZU0+52ZV6CBpBpy8YGp5JnvBobBC0H6t/0g==}
     hasBin: true
 
-  '@happyvertical/graphql@0.86.3':
-    resolution: {integrity: sha512-F51j/F4dyuNC1h2JJwLnxcYsBLoLBfmoiJ8YY+BZ5dMZjZ9euyAXqCeBlR6I9fnaf1ha8aMrFqdZafrUB7zPZA==}
+  '@happyvertical/graphql@0.87.0':
+    resolution: {integrity: sha512-xfEGk2pVGqOfzV463NR74zgN5PDVUc/iygi2jwrkt0Y/hnZbbPVo6McUClfJYtjE9KnGPhgAtiGSQtOurXtpQA==}
     hasBin: true
 
-  '@happyvertical/images@0.86.3':
-    resolution: {integrity: sha512-L+s278RpGwZiaoER7XZMQR5WqQU2OAK206/dm4pqNvXTqm6bgIz7rCqXjUoaHsHraUoYW+khG1fnONVDhl3c5w==}
+  '@happyvertical/images@0.87.0':
+    resolution: {integrity: sha512-bv2W9GyVnm7RAAxgXrTpymD8hBhg0y4Qg4F17Bzc4DZ/eGDRt4tMxZ9lmi4rjHxXNY2PSZMEGyCKv+SABxv70w==}
     hasBin: true
     peerDependencies:
       jimp: '>=1.6.1'
@@ -3970,8 +3970,8 @@ packages:
       sharp:
         optional: true
 
-  '@happyvertical/jobs@0.86.3':
-    resolution: {integrity: sha512-jJYIgULwxZzInVX4lnlOCKjkla+76rGwFwcrQmTlq2S21+f9ut8gLRuym0lZekPQ1RpjNDRHyTKwY77XJWulFQ==}
+  '@happyvertical/jobs@0.87.0':
+    resolution: {integrity: sha512-oGhdL4n/gjS//HG6dOZ2rVpr2qcGAT2Yo2GWaeQ7MbPjQdeNSYQUpfnaAw7xjsYko8xOAsXNdhAizHW/Mdgdsw==}
     hasBin: true
     peerDependencies:
       '@aws-sdk/client-sqs': '>=3.1034.0'
@@ -3988,11 +3988,11 @@ packages:
       bullmq:
         optional: true
 
-  '@happyvertical/json@0.86.3':
-    resolution: {integrity: sha512-cdHAjTRJLlretqD6LO4wYk0hZfxNPGZDCOlM9ITnhJO6scz3eWs10VfvzKtSwmuYOrdtV9zfqSLtPVdVoRqiWQ==}
+  '@happyvertical/json@0.87.0':
+    resolution: {integrity: sha512-ciWwb/EqTQ54Jxf7D3Aecl6k3qg4qR+N98dQh3FcwKgEvP5tpnKJRLqkT18P0LCXE3Bqlr7dbT4VLo4BDUxb6w==}
 
-  '@happyvertical/logger@0.86.3':
-    resolution: {integrity: sha512-k4Djzq15f1dtzgkTn05sw+IAjW+LAFMjbG47H7t2HNULvx26q0Qnkb6GZNZ4TAE4kJ6NiMUkLTGqX3SOaC2Yng==}
+  '@happyvertical/logger@0.87.0':
+    resolution: {integrity: sha512-ObV6vUevbuMmSa/HDZ4Pn53zHbDfMHnBhrULcTMlJeBmJJdxE+vJqc/bP9g+RV1gLxYw5zp5qgllE184SerkBw==}
     hasBin: true
     peerDependencies:
       '@sentry/node': '>=10.49.0'
@@ -4000,8 +4000,8 @@ packages:
       '@sentry/node':
         optional: true
 
-  '@happyvertical/messages@0.86.3':
-    resolution: {integrity: sha512-u8Hjt50ZCwTEgBcI6/g9gKehgDS5be6kVO1oCNlHUwlix5wSaOfAkh52IOVuX20s73wBxQEr1oWXDdNM/SoAIw==}
+  '@happyvertical/messages@0.87.0':
+    resolution: {integrity: sha512-LtUOjhhJluqWs0ftnrl03Ruz9U1J5MjieS0x9C2h2CV80us3c91+D85z5dWhnT7sZcSLrxfxlJ8IRLY+ISCNCA==}
 
   '@happyvertical/ocr@0.61.4':
     resolution: {integrity: sha512-W4aU0crEdRSUWO1M3zGph6k19brH4U3uoB/k7of7nqwKvQ3/6uWQFcSTZoG2HcHo8i2eWDNBst3svDSKxyCIvg==}
@@ -4011,23 +4011,23 @@ packages:
     resolution: {integrity: sha512-FnyCI8N8YQeeuKUQdiiPoKkN4U4Hqgf/N+7Vw1HMAw0vmoliNGlPJBZcqzl6hX4N3ZdXYNP6pqiVHGmPiDiBhw==}
     engines: {node: '>=24', pnpm: '>=11.13.0'}
 
-  '@happyvertical/projects@0.86.3':
-    resolution: {integrity: sha512-NjVNT4aZBes1YDpncn5E8kTZH4o/LLLfBCpRlp8Chtb+6DbLT9A8zIkv+NS1eqQJFiUIiu1GcthswutMfZSsyw==}
+  '@happyvertical/projects@0.87.0':
+    resolution: {integrity: sha512-tpGbL7Vv/LTvJ76NGsfk9YAJ1wlZD+iVGsy0LKd4U6HEpPai0jUK76geXetAj66Z+DwE71F7ed8iYflup7bNAw==}
     hasBin: true
 
-  '@happyvertical/repos@0.86.3':
-    resolution: {integrity: sha512-fpcMDNQjq1UnADzp134Yzg0VEq8sjsglf4Flb0sDDrFGUmvnud27kt2aDrbaL52vSqdJw4HTip1wu7+1Cegvrg==}
+  '@happyvertical/repos@0.87.0':
+    resolution: {integrity: sha512-q4npb8HSUt148DdFFfJdoPaSOOxnFhYVYB1IHYj39vFUIw308ZMTP8WqirFMFswsFgJ0RU7gqiU9wduGjSiZEg==}
     hasBin: true
 
-  '@happyvertical/secrets@0.86.3':
-    resolution: {integrity: sha512-AThK20ZU6xNT77CboWc598jmerIEd1RnaQZ5sFsZU/4abpMoUJ3du6yZAGdGycv1vAXLNs3fuCwfT4itQABvwg==}
+  '@happyvertical/secrets@0.87.0':
+    resolution: {integrity: sha512-GJ78kOYLDBBmEdiEUllF7Nl16ZdokWFWtdTpA5k9naHshsE5GX7zHEhcawKFMan8VVERkq84aSxZlQ7+cqomjw==}
     hasBin: true
 
-  '@happyvertical/signatures@0.86.3':
-    resolution: {integrity: sha512-9qgmDVeJfImBeV8GhEo+VR/WLa2yQSq20YNXH72hFvKyN3FDSgoXAeABkSyxJlPsAKQy/tKTrBXR45My1U1erw==}
+  '@happyvertical/signatures@0.87.0':
+    resolution: {integrity: sha512-CbaMHyb1d9gybEQ3JH1+aDt+sQvfTa5IJxKPAZoJApbpRo+6pq1y17vIqbIQSAP1buv/Ao396b6DCLVAinhHcg==}
 
-  '@happyvertical/speech@0.86.3':
-    resolution: {integrity: sha512-2oXZopJpWBkqEBToh3hUp5EhYWhkIfyKBpZsQEl/oVQsnE/rWvmWiuS7d9utQX4hUvX3itybGDEvijGCUcAMGA==}
+  '@happyvertical/speech@0.87.0':
+    resolution: {integrity: sha512-LOcXP6mQCGnbhCp7m5cAlJXgS8WgdNPyo0bX/qumaRujt86RMwFUpDuEoXYYFuPkYRH2h3bj5oq+5sT77OI44A==}
 
   '@happyvertical/spider@1.1.13':
     resolution: {integrity: sha512-mu3HpvszT3K/4eusiZHxCI5oYCVqofE59f6rGIc4WBuyqFiqHQcGAfVsgeVSXbAD5pHPVhuRUB5abrOVO8nAaQ==}
@@ -4038,8 +4038,8 @@ packages:
       cloakbrowser:
         optional: true
 
-  '@happyvertical/sql@0.86.3':
-    resolution: {integrity: sha512-WWRdc6WdA2H2R9ZrJMZpCZXg3x7pAayLpOsjsIBnzGn+RPSbBamSIX+BgQYqlFfmm8kb+DT0RoUWnV6GevTaJQ==}
+  '@happyvertical/sql@0.87.0':
+    resolution: {integrity: sha512-z0nX1jA3y1tVxm8cFf1mLZQVFHj9PUDH+it6OFc3X6AcybHnGrCkyQ4ESDaQP59+/4yRPtzOxY5SnYfUiG0Dmg==}
     hasBin: true
     peerDependencies:
       '@russellthehippo/honker-node': ^0.3.3
@@ -4050,8 +4050,8 @@ packages:
       '@sqliteai/sqlite-vector':
         optional: true
 
-  '@happyvertical/utils@0.86.3':
-    resolution: {integrity: sha512-k60CE8XUzt/lLs0RgVrEXnyF2AKJshu1q4H/bEKihAgcSyaMNHBKI2/n1up7hkoZs3/Mf+Dx0RhnXsWJjS1LmA==}
+  '@happyvertical/utils@0.87.0':
+    resolution: {integrity: sha512-dU9mLWoJd5YiEwoLsDpJcjjIzNZZyrLusBYbosrE9f7TVogUZ56zK/HjWzvGuV5WJIN1MeTQ+XZTSU0DYLQDeQ==}
     hasBin: true
 
   '@hono/node-server@1.19.14':
@@ -11366,12 +11366,12 @@ snapshots:
 
   '@gutenye/ocr-models@1.4.2': {}
 
-  '@happyvertical/ai@0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+  '@happyvertical/ai@0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1034.0
       '@google/genai': 1.50.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))
-      '@happyvertical/utils': 0.86.3
+      '@happyvertical/utils': 0.87.0
       openai: 6.34.0(ws@8.21.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -11381,23 +11381,23 @@ snapshots:
       - ws
       - zod
 
-  '@happyvertical/cache@0.86.3(@opentelemetry/api@1.9.1)':
+  '@happyvertical/cache@0.87.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@aws-sdk/client-s3': 3.1034.0
       '@aws-sdk/credential-providers': 3.1034.0
-      '@happyvertical/utils': 0.86.3
+      '@happyvertical/utils': 0.87.0
       redis: 5.12.1(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - '@node-rs/xxhash'
       - '@opentelemetry/api'
 
-  '@happyvertical/documents@0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)':
+  '@happyvertical/documents@0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)':
     dependencies:
-      '@happyvertical/files': 0.86.3
+      '@happyvertical/files': 0.87.0
       '@happyvertical/ocr': 0.61.4(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/pdf': 0.65.9(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
       '@happyvertical/spider': 1.1.13(@opentelemetry/api@1.9.1)(@types/node@24.13.2)
-      '@happyvertical/utils': 0.86.3
+      '@happyvertical/utils': 0.87.0
       uuid: 13.0.2
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -11417,10 +11417,10 @@ snapshots:
       - yauzl
       - zod
 
-  '@happyvertical/email@0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))':
+  '@happyvertical/email@0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))':
     dependencies:
-      '@happyvertical/logger': 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
-      '@happyvertical/utils': 0.86.3
+      '@happyvertical/logger': 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+      '@happyvertical/utils': 0.87.0
       google-auth-library: 10.7.0
       googleapis: 170.1.0
       imapflow: 1.4.0
@@ -11431,10 +11431,10 @@ snapshots:
       - '@sentry/node'
       - supports-color
 
-  '@happyvertical/encryption@0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))(@types/node@24.13.2)(typescript@5.9.3)':
+  '@happyvertical/encryption@0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))(@types/node@24.13.2)(typescript@5.9.3)':
     dependencies:
-      '@happyvertical/logger': 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
-      '@happyvertical/utils': 0.86.3
+      '@happyvertical/logger': 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+      '@happyvertical/utils': 0.87.0
       '@openpgp/web-stream-tools': 0.3.1(@types/node@24.13.2)(typescript@5.9.3)
       openpgp: 6.3.0
       tweetnacl: 1.0.3
@@ -11444,30 +11444,30 @@ snapshots:
       - '@types/node'
       - typescript
 
-  '@happyvertical/files@0.86.3':
+  '@happyvertical/files@0.87.0':
     dependencies:
       '@aws-sdk/client-s3': 3.1066.0
-      '@happyvertical/utils': 0.86.3
+      '@happyvertical/utils': 0.87.0
       google-auth-library: 9.15.1
       googleapis: 144.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@happyvertical/geo@0.86.3(@opentelemetry/api@1.9.1)':
+  '@happyvertical/geo@0.87.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@googlemaps/google-maps-services-js': 3.4.2
-      '@happyvertical/cache': 0.86.3(@opentelemetry/api@1.9.1)
-      '@happyvertical/utils': 0.86.3
+      '@happyvertical/cache': 0.87.0(@opentelemetry/api@1.9.1)
+      '@happyvertical/utils': 0.87.0
     transitivePeerDependencies:
       - '@node-rs/xxhash'
       - '@opentelemetry/api'
       - debug
       - supports-color
 
-  '@happyvertical/graphql@0.86.3': {}
+  '@happyvertical/graphql@0.87.0': {}
 
-  '@happyvertical/images@0.86.3(jimp@1.6.1)(sharp@0.35.3(@types/node@24.13.2))':
+  '@happyvertical/images@0.87.0(jimp@1.6.1)(sharp@0.35.3(@types/node@24.13.2))':
     dependencies:
       '@resvg/resvg-js': 2.6.2
       satori: 0.26.0
@@ -11475,10 +11475,10 @@ snapshots:
       jimp: 1.6.1
       sharp: 0.35.3(@types/node@24.13.2)
 
-  '@happyvertical/jobs@0.86.3(@aws-sdk/client-sqs@3.1038.0)(@google-cloud/tasks@6.2.1)(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)(bull@4.16.5)(bullmq@5.76.4)':
+  '@happyvertical/jobs@0.87.0(@aws-sdk/client-sqs@3.1038.0)(@google-cloud/tasks@6.2.1)(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)(bull@4.16.5)(bullmq@5.76.4)':
     dependencies:
-      '@happyvertical/sql': 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
-      '@happyvertical/utils': 0.86.3
+      '@happyvertical/sql': 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+      '@happyvertical/utils': 0.87.0
     optionalDependencies:
       '@aws-sdk/client-sqs': 3.1038.0
       '@google-cloud/tasks': 6.2.1
@@ -11492,19 +11492,19 @@ snapshots:
       - pg-native
       - utf-8-validate
 
-  '@happyvertical/json@0.86.3': {}
+  '@happyvertical/json@0.87.0': {}
 
-  '@happyvertical/logger@0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))':
+  '@happyvertical/logger@0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))':
     dependencies:
-      '@happyvertical/utils': 0.86.3
+      '@happyvertical/utils': 0.87.0
     optionalDependencies:
       '@sentry/node': 10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))
 
-  '@happyvertical/messages@0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))':
+  '@happyvertical/messages@0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))':
     dependencies:
-      '@happyvertical/email': 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
-      '@happyvertical/logger': 0.86.3(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
-      '@happyvertical/utils': 0.86.3
+      '@happyvertical/email': 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+      '@happyvertical/logger': 0.87.0(@sentry/node@10.63.0(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1)))
+      '@happyvertical/utils': 0.87.0
       '@slack/web-api': 7.16.0
     transitivePeerDependencies:
       - '@sentry/node'
@@ -11515,8 +11515,8 @@ snapshots:
     dependencies:
       '@gutenye/ocr-common': 1.4.8
       '@gutenye/ocr-models': 1.4.2
-      '@happyvertical/ai': 0.86.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
-      '@happyvertical/utils': 0.86.3
+      '@happyvertical/ai': 0.87.0(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@happyvertical/utils': 0.87.0
       onnxruntime-common: 1.27.0
       onnxruntime-node: 1.27.0
       sharp: 0.35.3(@types/node@24.13.2)
@@ -11534,7 +11534,7 @@ snapshots:
   '@happyvertical/pdf@0.65.9(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)':
     dependencies:
       '@happyvertical/ocr': 0.61.4(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/node@24.13.2)(ws@8.21.0)(zod@4.3.6)
-      '@happyvertical/utils': 0.86.3
+      '@happyvertical/utils': 0.87.0
       '@napi-rs/canvas': 0.1.100
       marked: 18.0.7
       pdf-lib: 1.17.1
@@ -11555,25 +11555,25 @@ snapshots:
       - yauzl
       - zod
 
-  '@happyvertical/projects@0.86.3(typescript@5.9.3)':
+  '@happyvertical/projects@0.87.0(typescript@5.9.3)':
     dependencies:
-      '@happyvertical/graphql': 0.86.3
-      '@happyvertical/repos': 0.86.3(typescript@5.9.3)
+      '@happyvertical/graphql': 0.87.0
+      '@happyvertical/repos': 0.87.0(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
-  '@happyvertical/repos@0.86.3(typescript@5.9.3)':
+  '@happyvertical/repos@0.87.0(typescript@5.9.3)':
     dependencies:
-      '@happyvertical/graphql': 0.86.3
+      '@happyvertical/graphql': 0.87.0
       js-yaml: 4.3.1
       nostr-tools: 2.24.1(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
-  '@happyvertical/secrets@0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)':
+  '@happyvertical/secrets@0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)':
     dependencies:
-      '@happyvertical/sql': 0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
-      '@happyvertical/utils': 0.86.3
+      '@happyvertical/sql': 0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)
+      '@happyvertical/utils': 0.87.0
     transitivePeerDependencies:
       - '@russellthehippo/honker-node'
       - '@sqliteai/sqlite-vector'
@@ -11582,14 +11582,14 @@ snapshots:
       - pg-native
       - utf-8-validate
 
-  '@happyvertical/signatures@0.86.3': {}
+  '@happyvertical/signatures@0.87.0': {}
 
-  '@happyvertical/speech@0.86.3': {}
+  '@happyvertical/speech@0.87.0': {}
 
   '@happyvertical/spider@1.1.13(@opentelemetry/api@1.9.1)(@types/node@24.13.2)':
     dependencies:
-      '@happyvertical/cache': 0.86.3(@opentelemetry/api@1.9.1)
-      '@happyvertical/utils': 0.86.3
+      '@happyvertical/cache': 0.87.0(@opentelemetry/api@1.9.1)
+      '@happyvertical/utils': 0.87.0
       cheerio: 1.2.0
       crawlee: 3.17.0(@types/node@24.13.2)(playwright@1.61.1)
       happy-dom: 20.10.6
@@ -11606,10 +11606,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@happyvertical/sql@0.86.3(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)':
+  '@happyvertical/sql@0.87.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)':
     dependencies:
       '@duckdb/node-api': 1.4.3-r.3
-      '@happyvertical/utils': 0.86.3
+      '@happyvertical/utils': 0.87.0
       '@libsql/client': 0.17.2
       pg: 8.21.0
       sqlite-vss: 0.1.2
@@ -11622,7 +11622,7 @@ snapshots:
       - pg-native
       - utf-8-validate
 
-  '@happyvertical/utils@0.86.3':
+  '@happyvertical/utils@0.87.0':
     dependencies:
       '@paralleldrive/cuid2': 3.3.0
       date-fns: 4.4.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,28 +8,28 @@ overrides:
   '@happyvertical/smrt-types': 'workspace:*'
   '@happyvertical/smrt-config': 'workspace:*'
   '@happyvertical/smrt-core': 'workspace:*'
-  '@happyvertical/ai': ^0.86.3
-  '@happyvertical/cache': ^0.86.3
-  '@happyvertical/documents': ^0.86.3
-  '@happyvertical/email': ^0.86.3
-  '@happyvertical/encryption': ^0.86.3
-  '@happyvertical/files': ^0.86.3
-  '@happyvertical/geo': ^0.86.3
-  '@happyvertical/images': ^0.86.3
-  '@happyvertical/jobs': ^0.86.3
-  '@happyvertical/json': ^0.86.3
-  '@happyvertical/logger': ^0.86.3
-  '@happyvertical/messages': ^0.86.3
+  '@happyvertical/ai': ^0.87.0
+  '@happyvertical/cache': ^0.87.0
+  '@happyvertical/documents': ^0.87.0
+  '@happyvertical/email': ^0.87.0
+  '@happyvertical/encryption': ^0.87.0
+  '@happyvertical/files': ^0.87.0
+  '@happyvertical/geo': ^0.87.0
+  '@happyvertical/images': ^0.87.0
+  '@happyvertical/jobs': ^0.87.0
+  '@happyvertical/json': ^0.87.0
+  '@happyvertical/logger': ^0.87.0
+  '@happyvertical/messages': ^0.87.0
   '@happyvertical/ocr': ^0.61.4
   '@happyvertical/pdf': ^0.65.9
-  '@happyvertical/projects': ^0.86.3
-  '@happyvertical/repos': ^0.86.3
-  '@happyvertical/secrets': ^0.86.3
-  '@happyvertical/signatures': ^0.86.3
-  '@happyvertical/speech': ^0.86.3
+  '@happyvertical/projects': ^0.87.0
+  '@happyvertical/repos': ^0.87.0
+  '@happyvertical/secrets': ^0.87.0
+  '@happyvertical/signatures': ^0.87.0
+  '@happyvertical/speech': ^0.87.0
   '@happyvertical/spider': ^1.1.13
-  '@happyvertical/sql': ^0.86.3
-  '@happyvertical/utils': ^0.86.3
+  '@happyvertical/sql': ^0.87.0
+  '@happyvertical/utils': ^0.87.0
   '@grpc/grpc-js@>=1.14.0 <1.14.4': 1.14.4
   # minimatch 9 is the last consumer of brace-expansion 2.x, which has no
   # patched 2.x line for GHSA-mh99-v99m-4gvg (first patch is 5.0.8). Its
@@ -102,52 +102,52 @@ auditConfig:
   ignoreGhsas: []
 
 minimumReleaseAgeExclude:
-  - '@happyvertical/ai@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/cache@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/documents@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/email@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/encryption@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/files@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/geo@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/graphql@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/images@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/jobs@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/json@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/logger@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/messages@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/projects@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/repos@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/secrets@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/signatures@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/speech@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/sql@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
-  - '@happyvertical/utils@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3'
+  - '@happyvertical/ai@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/cache@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/documents@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/email@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/encryption@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/files@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/geo@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/graphql@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/images@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/jobs@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/json@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/logger@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/messages@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/projects@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/repos@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/secrets@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/signatures@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/speech@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/sql@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
+  - '@happyvertical/utils@0.80.0 || 0.80.2 || 0.84.0 || 0.85.5 || 0.86.1 || 0.86.3 || 0.87.0'
 
 catalog:
   '@aws-sdk/client-sqs': ^3.1079.0
   '@google-cloud/tasks': ^6.2.3
-  '@happyvertical/ai': ^0.86.3
-  '@happyvertical/cache': ^0.86.3
-  '@happyvertical/documents': ^0.86.3
-  '@happyvertical/email': ^0.86.3
-  '@happyvertical/encryption': ^0.86.3
-  '@happyvertical/files': ^0.86.3
-  '@happyvertical/geo': ^0.86.3
-  '@happyvertical/images': ^0.86.3
-  '@happyvertical/jobs': ^0.86.3
-  '@happyvertical/json': ^0.86.3
-  '@happyvertical/logger': ^0.86.3
-  '@happyvertical/messages': ^0.86.3
+  '@happyvertical/ai': ^0.87.0
+  '@happyvertical/cache': ^0.87.0
+  '@happyvertical/documents': ^0.87.0
+  '@happyvertical/email': ^0.87.0
+  '@happyvertical/encryption': ^0.87.0
+  '@happyvertical/files': ^0.87.0
+  '@happyvertical/geo': ^0.87.0
+  '@happyvertical/images': ^0.87.0
+  '@happyvertical/jobs': ^0.87.0
+  '@happyvertical/json': ^0.87.0
+  '@happyvertical/logger': ^0.87.0
+  '@happyvertical/messages': ^0.87.0
   '@happyvertical/ocr': ^0.61.4
   '@happyvertical/pdf': ^0.65.9
-  '@happyvertical/projects': ^0.86.3
-  '@happyvertical/repos': ^0.86.3
-  '@happyvertical/secrets': ^0.86.3
-  '@happyvertical/signatures': ^0.86.3
-  '@happyvertical/speech': ^0.86.3
+  '@happyvertical/projects': ^0.87.0
+  '@happyvertical/repos': ^0.87.0
+  '@happyvertical/secrets': ^0.87.0
+  '@happyvertical/signatures': ^0.87.0
+  '@happyvertical/speech': ^0.87.0
   '@happyvertical/spider': ^1.1.13
-  '@happyvertical/sql': ^0.86.3
-  '@happyvertical/utils': ^0.86.3
+  '@happyvertical/sql': ^0.87.0
+  '@happyvertical/utils': ^0.87.0
   '@sentry/node': ^10.63.0
   bull: ^4.16.5
   bullmq: ^5.79.2


### PR DESCRIPTION
## Summary

- replace duplicated null checks with one typed null-safe identity comparison
- preserve STI duplicate detection for NULL and non-NULL conflict values
- add SQLite and real PostgreSQL regression coverage
- register the STI suite in the managed PostgreSQL validation lane
- sync centralized SDK dependency pins to v0.87.0 from superseded PR #2327

## Validation

- Node 24 CLI build: passed
- CLI tests: 822 passed, 7 skipped
- focused STI suite: PostgreSQL case remains gated locally because no database endpoint is available
- CLI typecheck: passed

Closes #2329
Refs #2327

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-smrt-2329-20260814-r4","issue":2329,"policy_revision":"1.0.0","status":"complete","validation":["Node 24 CLI build","822 CLI tests including focused STI suite","CLI typecheck","Terra review cycle approved","Real PostgreSQL regression registered in managed CI; no local endpoint available"]}