### PR TITLE
fix(deps): patch nanoid audit finding

### DIFF
--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
+      - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
       # cosign-installer v4 shells out to envsubst, which is not part of the
       # provider-neutral general runner contract. Download the publisher-
       # compatible cosign v3 binary directly and verify its pinned SHA-256 so

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ overrides:
   brace-expansion@>=4.0.0 <5.0.9: 5.0.9
   js-yaml@>=3.0.0 <3.15.1: 3.15.1
   pdfjs-dist@>=5.6.83 <6.2.108: 6.2.108
-  nanoid@<3.3.17: 3.3.17
+  nanoid@<3.3.18: 3.3.18
   axios@>=1.15.2 <1.18.0: 1.18.0
   postcss@<=8.5.17: 8.5.18
   markdown-it@<14.1.2: 14.3.0
@@ -8271,8 +8271,8 @@ packages:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10913,7 +10913,7 @@ snapshots:
       fingerprint-generator: 2.1.82
       fingerprint-injector: 2.1.82(playwright@1.61.1)
       lodash.merge: 4.6.2
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       ow: 0.28.2
       p-limit: 3.1.0
       proxy-chain: 2.7.1
@@ -15902,7 +15902,7 @@ snapshots:
 
   mute-stream@1.0.0: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   negotiator@1.0.0: {}
 
@@ -16361,7 +16361,7 @@ snapshots:
 
   postcss@8.5.18:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,7 +73,10 @@ overrides:
   # has no newer release, so keep the resolved implementation on the first
   # patched line while preserving the package's public API surface.
   'pdfjs-dist@>=5.6.83 <6.2.108': 6.2.108
-  'nanoid@<3.3.17': 3.3.17
+  # nanoid <3.3.18 can loop indefinitely for size-zero custom alphabet/random
+  # calls (GHSA-2v37-7h3g-55p8). Vite/PostCSS accepts the patched 3.3.x
+  # release, so unify the transitive graph on the first fixed version.
+  'nanoid@<3.3.18': 3.3.18
   'axios@>=1.15.2 <1.18.0': 1.18.0
   'postcss@<=8.5.17': 8.5.18
   # The advisory names 14.1.2 as the first patched version, but that tag was


### PR DESCRIPTION
Closes #2331
Closes #2333

## Patch train

- **#2331:** update the bounded `nanoid` override to 3.3.18 and regenerate the lockfile so Vite/PostCSS consumers resolve only the patched release.
- **#2333:** apply the canonical generation-24 immutable `oras-project/setup-oras` v2 pin so lifecycle validation can verify this head.

Validation:
- Node 24.19: policy gate and raw `pnpm audit --audit-level=high` (no high/critical findings)
- frozen install and full 66-package build completed on the Nanoid head
- repository CI script tests, format, and strict knowledge freshness
- final independent Terra review on the combined exact diff

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-ef4c-smrt-patchtrain-2331-2333","issue":2331,"policy_revision":"1.0.0","status":"complete","validation":["Node 24 policy and raw high-severity audit","frozen install and full 66-package build","repository CI script tests, format, and strict knowledge freshness","canonical lifecycle workflow artifact sync","Terra review cycle"]}