### PR TITLE
fix(policy): sync generation-24 lifecycle workflow

### DIFF
--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-      - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
+      - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2
       # cosign-installer v4 shells out to envsubst, which is not part of the
       # provider-neutral general runner contract. Download the publisher-
       # compatible cosign v3 binary directly and verify its pinned SHA-256 so


### PR DESCRIPTION
Closes #2333

Regenerates the managed lifecycle workflow from the assigned generation-24 candidate policy artifact. This advances only the immutable `oras-project/setup-oras` pin from v1 to canonical v2; no generated policy was hand-edited.

Validation:
- generation-24 signed artifact audit
- actionlint and yamllint
- full 66-package build under Node 24.18.0
- strict SMRT knowledge freshness (Markdown and JSON)
- independent Terra review

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-ef4c-smrt-policy-2333","issue":2333,"policy_revision":"1.0.0","status":"complete","validation":["generation-24 signed artifact audit","actionlint and yamllint","full 66-package build under Node 24.18.0","strict SMRT knowledge freshness (Markdown and JSON)","independent Terra review"]}