### PR TITLE
docs: define SMRT artifact terminology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,12 @@ the Vite plugin consumes deterministic `dist/` artifacts.
   `smrt knowledge:architecture-context` with the narrowest scope/package.
 - Runtime manifests stay runtime-focused; `.smrt/smrt-knowledge.json` and
   `dist/smrt-knowledge.json` are the agent/developer contract.
+- Use **generation snapshot** for the proposed versioned, immutable provenance
+  bundle in #2328; do not call a runtime manifest or prompt bundle generically
+  "context". See `docs/content/standards.md` for the artifact vocabulary.
+- `smrt doctor` is the umbrella project-health diagnostic. Artifact consumers
+  enforce validity themselves with the same verifier and fail closed; doctor is
+  observability, not an enforcement prerequisite.
 
 ## Frequent hazards
 

--- a/docs/content/standards.md
+++ b/docs/content/standards.md
@@ -567,12 +567,12 @@ Use these terms consistently. Do not call every generated file or ambient input
 | Term | Meaning |
 |---|---|
 | **Source model** | Authored TypeScript classes, decorators, and SMRT configuration. This is the source of truth. |
-| **Runtime manifest** | `manifest.json`, the generated intermediate representation consumed by registry, schema, route, type, CLI, and MCP tooling. It describes objects; it is not a cross-invocation provenance envelope. |
+| **Runtime manifest** | The generated intermediate representation written to `.smrt/manifest.json` in development and `dist/manifest.json` in builds, then consumed by registry, schema, route, type, CLI, and MCP tooling. It describes objects; it is not a cross-invocation provenance envelope. |
 | **Domain knowledge artifact** | `smrt-knowledge.json`, the deterministic, sanitized agent/developer projection of manifests plus package knowledge. It is not loaded as the runtime manifest. |
 | **Review or architecture context** | A temporary prompt bundle assembled from knowledge artifacts and documentation for a specific model-assisted task. It is derived input, not a persisted runtime contract. |
 | **Generation snapshot** | The proposed, versioned and immutable reuse contract tracked by [#2328](https://github.com/happyvertical/smrt/issues/2328). A snapshot may contain manifest views, normalized generator inputs, portable paths, an output inventory, and digests. No current plugin or CLI option should be described as accepting a generation snapshot until that contract is implemented. |
 | **Runtime or request context** | Live dependencies and authority for an operation, such as database, tenant, principal, AI, CLI, REST, or MCP state. It must not be serialized into a generation snapshot. |
-| **Object context** | The `SmrtObject.context` logical namespace used with a slug. This is unrelated to prompt or generation context. |
+| **Object context** | A `SmrtObject` instance's `context` value, paired with its `slug` as a logical namespace. This is unrelated to prompt or generation context. |
 | **Learned context memory** | Values stored through `remember()` / `recall()` in `_smrt_contexts`. This is mutable runtime data and is unrelated to generated artifacts. |
 
 When a design needs to reuse generated state across processes, name the exact

--- a/docs/content/standards.md
+++ b/docs/content/standards.md
@@ -559,6 +559,46 @@ If a package exports `./smrt-knowledge.json`, the package `files` allowlist must
 publish `dist` or `dist/smrt-knowledge.json`, and the deterministic checker must
 be able to find a current artifact.
 
+### Artifact and context vocabulary
+
+Use these terms consistently. Do not call every generated file or ambient input
+"context":
+
+| Term | Meaning |
+|---|---|
+| **Source model** | Authored TypeScript classes, decorators, and SMRT configuration. This is the source of truth. |
+| **Runtime manifest** | `manifest.json`, the generated intermediate representation consumed by registry, schema, route, type, CLI, and MCP tooling. It describes objects; it is not a cross-invocation provenance envelope. |
+| **Domain knowledge artifact** | `smrt-knowledge.json`, the deterministic, sanitized agent/developer projection of manifests plus package knowledge. It is not loaded as the runtime manifest. |
+| **Review or architecture context** | A temporary prompt bundle assembled from knowledge artifacts and documentation for a specific model-assisted task. It is derived input, not a persisted runtime contract. |
+| **Generation snapshot** | The proposed, versioned and immutable reuse contract tracked by [#2328](https://github.com/happyvertical/smrt/issues/2328). A snapshot may contain manifest views, normalized generator inputs, portable paths, an output inventory, and digests. No current plugin or CLI option should be described as accepting a generation snapshot until that contract is implemented. |
+| **Runtime or request context** | Live dependencies and authority for an operation, such as database, tenant, principal, AI, CLI, REST, or MCP state. It must not be serialized into a generation snapshot. |
+| **Object context** | The `SmrtObject.context` logical namespace used with a slug. This is unrelated to prompt or generation context. |
+| **Learned context memory** | Values stored through `remember()` / `recall()` in `_smrt_contexts`. This is mutable runtime data and is unrelated to generated artifacts. |
+
+When a design needs to reuse generated state across processes, name the exact
+artifact (`runtime manifest`, `domain knowledge artifact`, or `generation
+snapshot`) instead of using unqualified `context`. A runtime manifest alone is
+not sufficient proof that its source inputs, generator configuration, or
+companion outputs match.
+
+### Diagnostics SOP
+
+`smrt doctor` is the umbrella developer command for project-health diagnostics.
+Add focused, composable checks beneath it rather than introducing a generic
+`smrt validate` command; noun-scoped validators such as `smrt db:validate` keep
+their narrower contracts. `check` and `diagnose` remain aliases for `doctor`.
+
+Diagnostics report contract violations; they are not the enforcement boundary.
+Every loader, plugin, or generator that consumes a prepared artifact must call
+the same verifier directly, perform no scan or write in prepared mode, and fail
+closed on missing, stale, incompatible, or unverifiable inputs. `smrt doctor`
+may expose that verifier's result for humans and CI, but a passing doctor run
+must never be required to make an unsafe consumer reject invalid state.
+
+Keep checks read-only by default, return actionable evidence, and support
+machine-readable output when a check is intended for CI. Any future repair mode
+must identify its exact mutations and remain separate from verification.
+
 ### Model-assisted knowledge workflow
 
 Use models as optional local reviewers, not as freshness gates:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,6 +19,13 @@ pnpm add -D @happyvertical/smrt-cli
 | `smrt objects` | List all registered s-m-r-t objects |
 | `smrt schema <object>` | Show detailed schema for an object |
 | `smrt status` | Show system status (database, AI, registry) |
+| `smrt doctor` | Run the umbrella project-health diagnostics (aliases: `check`, `diagnose`) |
+
+`smrt doctor` reports project-health and integration problems. Noun-scoped
+validators such as `smrt db:validate` retain their narrower contracts; do not
+use a generic `smrt validate` command as a second project-health entry point.
+Artifact consumers must still verify their own inputs and fail closed—running
+`doctor` is an observability aid, not a prerequisite for safe loading.
 
 ### Database
 


### PR DESCRIPTION
## Summary

- define a canonical vocabulary for SMRT source models, runtime manifests, knowledge artifacts, prompt context, generation snapshots, runtime context, object context, and learned context memory
- establish `smrt doctor` as the umbrella project-health diagnostic while keeping fail-closed verification inside artifact consumers
- make the decision discoverable from the root agent guidance and CLI reference

## Validation

- `pnpm build --filter=@happyvertical/smrt-core`
- `pnpm knowledge:check --strict --format markdown`
- `pnpm check:agents-chain`
- `node scripts/check-standards.mjs`
- `node scripts/check-readmes.mjs`
- `pnpm audit:policy`
- `pnpm --dir docs build` (passes; reports pre-existing broken-link warnings outside the changed files)
- pre-commit and pre-push hook suites

Closes #2335
Refs #2328

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "01a000f6-fb82-7803-a8a2-c6ec2108b042",
  "issue": 2335,
  "linked_issue": 2335,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "core dependency build",
    "knowledge freshness",
    "agent instruction chain",
    "monorepo standards",
    "README validation",
    "dependency advisory policy",
    "Docusaurus production build",
    "pre-commit and pre-push hooks"
  ]
}
```