### PR TITLE
fix(smrt-ui,smrt-svelte): raise control boundaries and status green to WCAG floors

### DIFF
--- a/packages/smrt-svelte/src/__tests__/success-never-text.test.ts
+++ b/packages/smrt-svelte/src/__tests__/success-never-text.test.ts
@@ -1,0 +1,138 @@
+/**
+ * "Green is never text" — the Svelte-stack half of the rule (#2323).
+ *
+ * `--smrt-color-success` is the one palette role that is not reliably
+ * text-safe: a green that reads as "running" at a glance sits in a narrow
+ * luminance band, so under the happyvertical light scheme it measures
+ * 4.22–4.44:1 on `surfaceDim` / `surfaceContainerHighest` / `surfaceVariant` /
+ * `background` — under the WCAG AA 4.5:1 floor for normal text. It stays legal
+ * as a MARKER: status lamps, dots, borders, and container fills (which pair
+ * with `on-success-container` ink and are AA by construction).
+ *
+ * `smrt-ui` pins this for its own components in
+ * `src/themes/__tests__/happyvertical-theme.test.ts`; that scan cannot see this
+ * package, which is how `SystemStatusChips` and `PhoneInput` drifted. This is
+ * the same check with the same matcher, scoped here.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const packageRoot = process.cwd().endsWith('packages/smrt-svelte')
+  ? process.cwd()
+  : join(process.cwd(), 'packages/smrt-svelte');
+
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.svelte-kit', 'build']);
+
+function svelteFilesUnder(dir: string): string[] {
+  const out: string[] = [];
+  let entries: ReturnType<typeof readdirSync>;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) out.push(...svelteFilesUnder(full));
+    } else if (entry.name.endsWith('.svelte')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Does this source paint TEXT with the success token?
+ *
+ * Matches on the declaration VALUE rather than requiring `var(` to sit next to
+ * `color:`, so wrappers count — `color-mix(…)`, `light-dark(…)`, and
+ * `var(--x, var(--smrt-color-success))` all paint letterforms just as directly.
+ * Resolves one level of custom-property indirection, because
+ * `--chip-color: var(--smrt-color-success)` followed by `color: var(--chip-color)`
+ * is the shape that hides this from a naive grep. `(?![\w-])` keeps
+ * `--smrt-color-success-container` (a fill, with its own ink) from matching.
+ */
+function paintsTextWithSuccess(source: string): boolean {
+  const declaration = /(?<![-\w])color\s*:\s*([^;{}]*)/g;
+  const successToken = /--smrt-color-success(?![\w-])/;
+  const customProperty = /(--[\w-]+)\s*:\s*([^;{}]*)/g;
+
+  const greenProperties = new Set<string>();
+  for (const [, name, value] of source.matchAll(customProperty)) {
+    if (successToken.test(value)) greenProperties.add(name);
+  }
+  for (const [, value] of source.matchAll(declaration)) {
+    if (successToken.test(value)) return true;
+    for (const property of greenProperties) {
+      if (value.includes(`var(${property}`)) return true;
+    }
+  }
+  return false;
+}
+
+describe('success is a marker colour, never text (#2323)', () => {
+  const files = svelteFilesUnder(join(packageRoot, 'src'));
+
+  it('finds components to scan', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('no component paints text with --smrt-color-success', () => {
+    const offenders = files
+      .filter((file) => paintsTextWithSuccess(readFileSync(file, 'utf8')))
+      .map((file) => file.slice(packageRoot.length + 1));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('detects the wrapped and indirect forms the naive check missed', () => {
+    expect(
+      paintsTextWithSuccess('.x { color: var(--smrt-color-success); }'),
+    ).toBe(true);
+    expect(
+      paintsTextWithSuccess(
+        '.x { color: color-mix(in srgb, var(--smrt-color-success) 80%, transparent); }',
+      ),
+    ).toBe(true);
+    expect(
+      paintsTextWithSuccess(
+        '.x { color: light-dark(var(--smrt-color-success), #fff); }',
+      ),
+    ).toBe(true);
+    expect(
+      paintsTextWithSuccess(
+        '.x { color: var(--y, var(--smrt-color-success)); }',
+      ),
+    ).toBe(true);
+    expect(
+      paintsTextWithSuccess(
+        '.a { --tone: var(--smrt-color-success); } .b { color: var(--tone); }',
+      ),
+    ).toBe(true);
+  });
+
+  it('leaves marker, fill, and border uses alone', () => {
+    expect(
+      paintsTextWithSuccess('.x { background: var(--smrt-color-success); }'),
+    ).toBe(false);
+    expect(
+      paintsTextWithSuccess('.x { border-color: var(--smrt-color-success); }'),
+    ).toBe(false);
+    expect(
+      paintsTextWithSuccess(
+        '.x { background-color: var(--smrt-color-success); }',
+      ),
+    ).toBe(false);
+    expect(
+      paintsTextWithSuccess(
+        '.x { color: var(--smrt-color-success-container); }',
+      ),
+    ).toBe(false);
+    expect(
+      paintsTextWithSuccess('.x { color: var(--smrt-color-on-success); }'),
+    ).toBe(false);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/PhoneInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/PhoneInput.svelte
@@ -473,12 +473,15 @@ function handleInput(e: Event) {
     opacity: 0.7;
   }
 
+  /* The green lives in `.listening-dot` below; the label reads as ordinary
+     secondary text. Painting the words with `success` measured 4.2–4.4:1 on
+     several light-scheme surfaces, under the AA floor (#2323). */
   .listening-indicator {
     display: flex;
     align-items: center;
     gap: var(--smrt-spacing-2, 8px);
     font-size: var(--smrt-typography-body-small-size, 0.75rem);
-    color: var(--smrt-color-success);
+    color: var(--smrt-color-on-surface-variant);
     margin-top: var(--smrt-spacing-1, 4px);
   }
 

--- a/packages/smrt-svelte/src/components/workspace/admin-shell/SystemStatusChips.svelte
+++ b/packages/smrt-svelte/src/components/workspace/admin-shell/SystemStatusChips.svelte
@@ -57,26 +57,33 @@ const { t } = useI18n();
     text-decoration: none;
   }
 
-  /* Success is the one status colour that is not reliably text-safe: a green
-     that reads as "running" at a glance sits in a narrow luminance band, and
-     under the happyvertical light scheme it measures 4.2–4.4:1 on several
-     surfaces — under the AA floor for normal text. Carry it as a lamp beside
-     on-surface text rather than painting the letterforms (#2323). Warning and
-     error stay as text: both clear AA on every surface in every preset. */
-  .smrt-system-status-chips [data-tone='success']::before {
+  /* Every tone is a lamp beside on-surface text; none of them paints the
+     letterforms. Status hues are chosen to be recognisable at a glance, which
+     puts them in luminance bands that are not text-safe on light surfaces —
+     measured worst-case as TEXT across all five presets: warning falls to
+     1.41:1 (material and studio light), error to 2.65:1 (glass light), success
+     to 1.66:1 (glass light). A lamp carries the same meaning with no contrast
+     obligation, and keeps the component correct under any palette rather than
+     depending on each preset tuning three hues for text (#2323). */
+  .smrt-system-status-chips [data-tone='success']::before,
+  .smrt-system-status-chips [data-tone='warning']::before,
+  .smrt-system-status-chips [data-tone='error']::before {
     content: '';
     flex: none;
     inline-size: 0.5rem;
     block-size: 0.5rem;
     border-radius: var(--smrt-radius-full, 9999px);
+  }
+
+  .smrt-system-status-chips [data-tone='success']::before {
     background: var(--smrt-color-success);
   }
 
-  .smrt-system-status-chips [data-tone='warning'] {
-    color: var(--smrt-color-warning);
+  .smrt-system-status-chips [data-tone='warning']::before {
+    background: var(--smrt-color-warning);
   }
 
-  .smrt-system-status-chips [data-tone='error'] {
-    color: var(--smrt-color-error);
+  .smrt-system-status-chips [data-tone='error']::before {
+    background: var(--smrt-color-error);
   }
 </style>

--- a/packages/smrt-svelte/src/components/workspace/admin-shell/SystemStatusChips.svelte
+++ b/packages/smrt-svelte/src/components/workspace/admin-shell/SystemStatusChips.svelte
@@ -57,8 +57,19 @@ const { t } = useI18n();
     text-decoration: none;
   }
 
-  .smrt-system-status-chips [data-tone='success'] {
-    color: var(--smrt-color-success);
+  /* Success is the one status colour that is not reliably text-safe: a green
+     that reads as "running" at a glance sits in a narrow luminance band, and
+     under the happyvertical light scheme it measures 4.2–4.4:1 on several
+     surfaces — under the AA floor for normal text. Carry it as a lamp beside
+     on-surface text rather than painting the letterforms (#2323). Warning and
+     error stay as text: both clear AA on every surface in every preset. */
+  .smrt-system-status-chips [data-tone='success']::before {
+    content: '';
+    flex: none;
+    inline-size: 0.5rem;
+    block-size: 0.5rem;
+    border-radius: var(--smrt-radius-full, 9999px);
+    background: var(--smrt-color-success);
   }
 
   .smrt-system-status-chips [data-tone='warning'] {

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -529,7 +529,7 @@ const sizeClasses = {
   }
 
   .data-table__cell--expand { width: 2.75rem; text-align: center; }
-  .data-table__expand-button { width: 1.75rem; height: 1.75rem; border: 1px solid var(--smrt-color-outline-variant); border-radius: var(--smrt-radius-full); background: transparent; color: var(--smrt-color-on-surface); cursor: pointer; }
+  .data-table__expand-button { width: 1.75rem; height: 1.75rem; border: 1px solid var(--smrt-color-outline); border-radius: var(--smrt-radius-full); background: transparent; color: var(--smrt-color-on-surface); cursor: pointer; }
   .data-table__expand-button:focus-visible { outline: 2px solid var(--smrt-color-primary); outline-offset: 2px; }
   .data-table__cell--expanded { padding: var(--smrt-spacing-4); background: var(--smrt-color-surface-container-low); }
   .data-table__footer { border-top: 2px solid var(--smrt-color-outline-variant); font-weight: var(--smrt-typography-weight-medium); }

--- a/packages/smrt-ui/src/components/feedback/LoadingOverlay.svelte
+++ b/packages/smrt-ui/src/components/feedback/LoadingOverlay.svelte
@@ -259,7 +259,7 @@ function handleKeydown(e: KeyboardEvent) {
 		font-size: var(--smrt-typography-label-large-size, 0.875rem);
 		color: var(--smrt-color-on-surface-variant, #6b7280);
 		background: transparent;
-		border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
+		border: 1px solid var(--smrt-color-outline, #9ca3af);
 		border-radius: var(--smrt-radius-md, 8px);
 		cursor: pointer;
 		transition: all var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease);

--- a/packages/smrt-ui/src/components/forms/Combobox.svelte
+++ b/packages/smrt-ui/src/components/forms/Combobox.svelte
@@ -165,7 +165,7 @@ useControlRegistration(() => {
 </div>
 <style>
   .combobox { position: relative; display: grid; gap: var(--smrt-spacing-1); color: var(--smrt-color-on-surface); }
-  label { font: var(--smrt-typography-label-large-font); } input { width: 100%; padding: var(--smrt-spacing-2) var(--smrt-spacing-3); border: 1px solid var(--smrt-color-outline-variant); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); color: inherit; }
+  label { font: var(--smrt-typography-label-large-font); } input { width: 100%; padding: var(--smrt-spacing-2) var(--smrt-spacing-3); border: 1px solid var(--smrt-color-outline); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); color: inherit; }
   input:focus { outline: 2px solid var(--smrt-color-primary); outline-offset: 1px; } .options { position: absolute; z-index: var(--smrt-z-index-dropdown); top: 100%; left: 0; right: 0; display: grid; padding: var(--smrt-spacing-1); border: 1px solid var(--smrt-color-outline-variant); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface-container); box-shadow: var(--smrt-elevation-2); }
   .options button { padding: var(--smrt-spacing-2) var(--smrt-spacing-3); border: 0; border-radius: var(--smrt-radius-extra-small); background: transparent; color: var(--smrt-color-on-surface); text-align: left; } .options button.active { background: var(--smrt-color-secondary-container); }
   :global(.combobox[data-smrt-highlighted='true']) { outline: 3px solid var(--smrt-color-tertiary); outline-offset: 4px; }

--- a/packages/smrt-ui/src/components/forms/FilePicker.svelte
+++ b/packages/smrt-ui/src/components/forms/FilePicker.svelte
@@ -106,7 +106,7 @@ useControlRegistration(() => {
   <span class="label">{label}</span><span class="description">{files.length ? `${files.length} file${files.length === 1 ? '' : 's'} selected` : description}</span>
 </label>
 <style>
-  .file-picker { display: inline-flex; flex-direction: column; gap: var(--smrt-spacing-1); padding: var(--smrt-spacing-3) var(--smrt-spacing-4); border: 1px solid var(--smrt-color-outline-variant); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); color: var(--smrt-color-on-surface); cursor: pointer; }
+  .file-picker { display: inline-flex; flex-direction: column; gap: var(--smrt-spacing-1); padding: var(--smrt-spacing-3) var(--smrt-spacing-4); border: 1px solid var(--smrt-color-outline); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); color: var(--smrt-color-on-surface); cursor: pointer; }
   .file-picker.dropzone { width: 100%; min-height: 8rem; align-items: center; justify-content: center; border-style: dashed; text-align: center; }
   .file-picker.dragging { border-color: var(--smrt-color-primary); background: var(--smrt-color-primary-container); }
   .file-picker.disabled { opacity: .5; cursor: not-allowed; } input { position: absolute; width: 1px; height: 1px; opacity: 0; }

--- a/packages/smrt-ui/src/components/forms/Input.svelte
+++ b/packages/smrt-ui/src/components/forms/Input.svelte
@@ -179,7 +179,7 @@ export function getElement(): HTMLInputElement | null {
 		line-height: var(--smrt-typography-body-medium-line-height, 1.5);
 		color: var(--smrt-color-on-surface, #1f2937);
 		background-color: var(--smrt-color-surface, #fff);
-		border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
+		border: 1px solid var(--smrt-color-outline, #6b7280);
 		border-radius: var(--smrt-radius-small, 0.375rem);
 		transition:
 			border-color var(--smrt-duration-short2, 150ms) var(--smrt-easing-standard, ease-in-out),

--- a/packages/smrt-ui/src/components/forms/InputGroup.svelte
+++ b/packages/smrt-ui/src/components/forms/InputGroup.svelte
@@ -10,7 +10,7 @@ let { prefix, suffix, children, class: className = '' }: Props = $props();
 </script>
 <div class="input-group {className}">{#if prefix}<span class="adornment">{@render prefix()}</span>{/if}<div class="control">{@render children()}</div>{#if suffix}<span class="adornment">{@render suffix()}</span>{/if}</div>
 <style>
-  .input-group { display: flex; align-items: stretch; width: 100%; border: 1px solid var(--smrt-color-outline-variant); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); overflow: hidden; }
+  .input-group { display: flex; align-items: stretch; width: 100%; border: 1px solid var(--smrt-color-outline); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); overflow: hidden; }
   .adornment { display: inline-flex; align-items: center; padding: 0 var(--smrt-spacing-3); background: var(--smrt-color-surface-container-low); color: var(--smrt-color-on-surface-variant); }
   .control { flex: 1; min-width: 0; } .control :global(input), .control :global(select), .control :global(textarea) { border: 0 !important; border-radius: 0 !important; box-shadow: none !important; }
   .input-group:focus-within { outline: 2px solid var(--smrt-color-primary); outline-offset: 1px; }

--- a/packages/smrt-ui/src/components/forms/Listbox.svelte
+++ b/packages/smrt-ui/src/components/forms/Listbox.svelte
@@ -90,7 +90,7 @@ useControlRegistration(() => {
     onkeydown={(event) => move(event, index)} onclick={() => select(option.value)}>{option.label}</button>{/each}
 </div>
 <style>
-  .listbox { display: grid; padding: var(--smrt-spacing-1); border: 1px solid var(--smrt-color-outline-variant); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); }
+  .listbox { display: grid; padding: var(--smrt-spacing-1); border: 1px solid var(--smrt-color-outline); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); }
   button { padding: var(--smrt-spacing-2) var(--smrt-spacing-3); border: 0; border-radius: var(--smrt-radius-extra-small); background: transparent; color: var(--smrt-color-on-surface); text-align: left; cursor: pointer; }
   button[aria-selected='true'] { background: var(--smrt-color-secondary-container); color: var(--smrt-color-on-secondary-container); } button:focus-visible { outline: 2px solid var(--smrt-color-primary); }
   button:disabled { opacity: .5; cursor: not-allowed; } :global(.listbox[data-smrt-highlighted='true']) { outline: 3px solid var(--smrt-color-tertiary); outline-offset: 4px; }

--- a/packages/smrt-ui/src/components/forms/MultiSelect.svelte
+++ b/packages/smrt-ui/src/components/forms/MultiSelect.svelte
@@ -152,7 +152,7 @@ useControlRegistration(() => {
 </div>
 <style>
   .multi-select { position: relative; display: grid; gap: var(--smrt-spacing-1); color: var(--smrt-color-on-surface); } .label { font: var(--smrt-typography-label-large-font); }
-  .trigger { width: 100%; min-height: 2.5rem; padding: var(--smrt-spacing-2) var(--smrt-spacing-3); border: 1px solid var(--smrt-color-outline-variant); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); color: inherit; text-align: left; }
+  .trigger { width: 100%; min-height: 2.5rem; padding: var(--smrt-spacing-2) var(--smrt-spacing-3); border: 1px solid var(--smrt-color-outline); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); color: inherit; text-align: left; }
   .options { position: absolute; z-index: var(--smrt-z-index-dropdown); top: 100%; left: 0; right: 0; display: grid; padding: var(--smrt-spacing-1); border: 1px solid var(--smrt-color-outline-variant); background: var(--smrt-color-surface-container); box-shadow: var(--smrt-elevation-2); }
   .options button { display: grid; grid-template-columns: 1.25rem 1fr; gap: var(--smrt-spacing-2); padding: var(--smrt-spacing-2); border: 0; background: transparent; color: inherit; text-align: left; } .options button[aria-selected='true'] { background: var(--smrt-color-secondary-container); }
   :global(.multi-select[data-smrt-highlighted='true']) { outline: 3px solid var(--smrt-color-tertiary); outline-offset: 4px; }

--- a/packages/smrt-ui/src/components/forms/RangeSlider.svelte
+++ b/packages/smrt-ui/src/components/forms/RangeSlider.svelte
@@ -131,7 +131,7 @@ useControlRegistration(() => {
   .range-slider__track input::-moz-range-thumb { pointer-events: auto; }
   .range-slider__inputs { display: flex; gap: var(--smrt-spacing-3); }
   .range-slider__inputs label { display: grid; gap: var(--smrt-spacing-1); flex: 1; font: var(--smrt-typography-label-small-font); color: var(--smrt-color-on-surface-variant); }
-  .range-slider__inputs input { width: 100%; padding: var(--smrt-spacing-2); border: 1px solid var(--smrt-color-outline-variant); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); color: var(--smrt-color-on-surface); }
+  .range-slider__inputs input { width: 100%; padding: var(--smrt-spacing-2); border: 1px solid var(--smrt-color-outline); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); color: var(--smrt-color-on-surface); }
   input:focus-visible { outline: 2px solid var(--smrt-color-primary); outline-offset: 3px; }
   :global(.range-slider[data-smrt-highlighted='true']) { outline: 3px solid var(--smrt-color-tertiary); outline-offset: 4px; border-radius: var(--smrt-radius-small); }
 </style>

--- a/packages/smrt-ui/src/components/forms/Select.svelte
+++ b/packages/smrt-ui/src/components/forms/Select.svelte
@@ -136,7 +136,7 @@ export function getElement(): HTMLSelectElement | null {
 		background-position: right 0.5rem center;
 		background-repeat: no-repeat;
 		background-size: 1.5em 1.5em;
-		border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
+		border: 1px solid var(--smrt-color-outline, #6b7280);
 		border-radius: 0.375rem;
 		appearance: none;
 		cursor: pointer;

--- a/packages/smrt-ui/src/components/forms/Slider.svelte
+++ b/packages/smrt-ui/src/components/forms/Slider.svelte
@@ -125,7 +125,7 @@ useControlRegistration(() => {
   .slider__header { justify-content: space-between; font: var(--smrt-typography-label-large-font); }
   output { color: var(--smrt-color-primary); font-variant-numeric: tabular-nums; }
   input[type='range'] { flex: 1; min-width: 8rem; accent-color: var(--smrt-color-primary); cursor: pointer; }
-  .slider__number { width: 5.5rem; padding: var(--smrt-spacing-2); border: 1px solid var(--smrt-color-outline-variant); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); color: var(--smrt-color-on-surface); }
+  .slider__number { width: 5.5rem; padding: var(--smrt-spacing-2); border: 1px solid var(--smrt-color-outline); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); color: var(--smrt-color-on-surface); }
   input:focus-visible { outline: 2px solid var(--smrt-color-primary); outline-offset: 3px; }
   .slider[data-smrt-highlighted='true'] { outline: 3px solid var(--smrt-color-tertiary); outline-offset: 4px; border-radius: var(--smrt-radius-small); }
 </style>

--- a/packages/smrt-ui/src/components/forms/TagsInput.svelte
+++ b/packages/smrt-ui/src/components/forms/TagsInput.svelte
@@ -99,7 +99,7 @@ useControlRegistration(() => {
 </div></div>
 <style>
   .tags-field { display: grid; gap: var(--smrt-spacing-1); color: var(--smrt-color-on-surface); } label { font: var(--smrt-typography-label-large-font); }
-  .tags { display: flex; flex-wrap: wrap; gap: var(--smrt-spacing-1); min-height: 2.5rem; padding: var(--smrt-spacing-1); border: 1px solid var(--smrt-color-outline-variant); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); }
+  .tags { display: flex; flex-wrap: wrap; gap: var(--smrt-spacing-1); min-height: 2.5rem; padding: var(--smrt-spacing-1); border: 1px solid var(--smrt-color-outline); border-radius: var(--smrt-radius-small); background: var(--smrt-color-surface); }
   .tag { display: inline-flex; align-items: center; gap: var(--smrt-spacing-1); padding: var(--smrt-spacing-1) var(--smrt-spacing-2); border-radius: var(--smrt-radius-full); background: var(--smrt-color-secondary-container); color: var(--smrt-color-on-secondary-container); }
   .tag button { border: 0; background: transparent; color: inherit; cursor: pointer; } .tags > input { flex: 1; min-width: 8rem; border: 0; outline: 0; background: transparent; color: inherit; }
   :global(.tags[data-smrt-highlighted='true']) { outline: 3px solid var(--smrt-color-tertiary); outline-offset: 4px; }

--- a/packages/smrt-ui/src/components/forms/Textarea.svelte
+++ b/packages/smrt-ui/src/components/forms/Textarea.svelte
@@ -134,7 +134,7 @@ export function getElement(): HTMLTextAreaElement | null {
 		line-height: var(--smrt-typography-body-medium-line-height, 1.5);
 		color: var(--smrt-color-on-surface, #1f2937);
 		background-color: var(--smrt-color-surface, #fff);
-		border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
+		border: 1px solid var(--smrt-color-outline, #6b7280);
 		border-radius: 0.375rem;
 		resize: vertical;
 		min-height: 80px;

--- a/packages/smrt-ui/src/components/roles/RoleSelector.svelte
+++ b/packages/smrt-ui/src/components/roles/RoleSelector.svelte
@@ -270,10 +270,17 @@ $effect(() => {
     text-align: left;
   }
 
-  .option:hover,
+  .option:hover {
+    background: var(--smrt-color-surface-container-high, #f3f4f6);
+  }
+  /* Keyboard focus needs its own indicator: the hover background alone is a
+     ~1.1:1 change against the list surface in every preset, which is invisible
+     and fails WCAG 2.4.11. Inset so it is not clipped by the list's overflow
+     (#2322). */
   .option:focus-visible {
     background: var(--smrt-color-surface-container-high, #f3f4f6);
-    outline: none;
+    outline: 2px solid var(--smrt-color-primary, #005ac1);
+    outline-offset: -2px;
   }
 
   .option.selected {

--- a/packages/smrt-ui/src/components/roles/RoleSelector.svelte
+++ b/packages/smrt-ui/src/components/roles/RoleSelector.svelte
@@ -199,7 +199,7 @@ $effect(() => {
     width: 100%;
     padding: 0.5rem 0.75rem;
     background: var(--smrt-color-surface, white);
-    border: 1px solid var(--smrt-color-outline-variant, #d1d5db);
+    border: 1px solid var(--smrt-color-outline, #6b7280);
     border-radius: var(--smrt-radius-small, 0.375rem);
     font-size: var(--smrt-typography-body-medium-size, 0.875rem);
     cursor: pointer;

--- a/packages/smrt-ui/src/components/ui/Dropdown.svelte
+++ b/packages/smrt-ui/src/components/ui/Dropdown.svelte
@@ -236,10 +236,17 @@ $effect(() => {
     color: var(--smrt-color-on-surface);
     white-space: nowrap;
   }
-  .dropdown__item:hover:not(:disabled),
+  .dropdown__item:hover:not(:disabled) {
+    background: var(--smrt-color-surface-container-high);
+  }
+  /* Keyboard focus needs its own indicator: the hover background alone is a
+     ~1.1:1 change against the menu surface in every preset, which is invisible
+     and fails WCAG 2.4.11. The ring is inset so it is not clipped by the
+     menu's overflow (#2322). */
   .dropdown__item:focus-visible {
     background: var(--smrt-color-surface-container-high);
-    outline: none;
+    outline: 2px solid var(--smrt-color-primary);
+    outline-offset: -2px;
   }
   .dropdown__item:disabled {
     opacity: 0.5;

--- a/packages/smrt-ui/src/components/ui/Dropdown.svelte
+++ b/packages/smrt-ui/src/components/ui/Dropdown.svelte
@@ -179,7 +179,7 @@ $effect(() => {
     cursor: pointer;
     padding: var(--smrt-spacing-2, 8px) var(--smrt-spacing-3, 12px);
     border-radius: var(--smrt-radius-medium, 8px);
-    border: 1px solid var(--smrt-color-outline-variant, #cac4d0);
+    border: 1px solid var(--smrt-color-outline, #79747e);
     background: var(--smrt-color-surface);
     color: var(--smrt-color-on-surface);
   }
@@ -240,9 +240,10 @@ $effect(() => {
     background: var(--smrt-color-surface-container-high);
   }
   /* Keyboard focus needs its own indicator: the hover background alone is a
-     ~1.1:1 change against the menu surface in every preset, which is invisible
-     and fails WCAG 2.4.11. The ring is inset so it is not clipped by the
-     menu's overflow (#2322). */
+     ~1.1:1 change against the menu surface in every preset (1.00:1 in glass
+     light), which is invisible and fails WCAG 2.4.11. The ring is inset so it
+     sits inside the item's padding box rather than overlapping the neighbouring
+     item or the menu's edge (#2322). */
   .dropdown__item:focus-visible {
     background: var(--smrt-color-surface-container-high);
     outline: 2px solid var(--smrt-color-primary);

--- a/packages/smrt-ui/src/components/ui/Popover.svelte
+++ b/packages/smrt-ui/src/components/ui/Popover.svelte
@@ -91,7 +91,7 @@ $effect(() => {
 
 <style>
   .popover { position: relative; display: inline-flex; }
-  .popover__trigger { appearance: none; padding: var(--smrt-spacing-2) var(--smrt-spacing-3); border: 1px solid var(--smrt-color-outline-variant); border-radius: var(--smrt-radius-medium); background: var(--smrt-color-surface); color: var(--smrt-color-on-surface); font: inherit; cursor: pointer; }
+  .popover__trigger { appearance: none; padding: var(--smrt-spacing-2) var(--smrt-spacing-3); border: 1px solid var(--smrt-color-outline); border-radius: var(--smrt-radius-medium); background: var(--smrt-color-surface); color: var(--smrt-color-on-surface); font: inherit; cursor: pointer; }
   .popover__trigger:focus-visible, .popover__panel:focus-visible { outline: 2px solid var(--smrt-color-primary); outline-offset: 2px; }
   .popover__trigger:disabled { opacity: .5; cursor: not-allowed; }
   .popover__panel { position: absolute; z-index: var(--smrt-z-index-popover, 1000); min-width: 16rem; padding: var(--smrt-spacing-4); border: 1px solid var(--smrt-color-outline-variant); border-radius: var(--smrt-radius-large); background: var(--smrt-color-surface-container); color: var(--smrt-color-on-surface); box-shadow: var(--smrt-elevation-3); }

--- a/packages/smrt-ui/src/themes/__tests__/control-boundary-contrast.test.ts
+++ b/packages/smrt-ui/src/themes/__tests__/control-boundary-contrast.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Control-boundary contrast floor, every preset (#2322).
+ *
+ * WCAG 2.2 SC 1.4.11 requires the visual boundary that identifies a UI
+ * component to clear 3:1 against its adjacent background. The form primitives
+ * used to draw their resting border with `outline-variant` — the divider role,
+ * which measures 1.2–1.7:1 in every preset — so an input's edge was effectively
+ * invisible. They now consume `outline`, and this test pins the other half of
+ * that contract: `outline` must actually be a boundary-strength value in every
+ * preset and scheme, on every surface a control can sit on.
+ *
+ * `outlineVariant` is deliberately NOT held to this floor. It is the quiet
+ * hairline for dividers, panel edges, and readout rows; raising it would erase
+ * the distinction the two tokens exist to draw.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { themes } from '../registry.js';
+import type { ColorPalette } from '../types.js';
+
+/** Every surface role a control can be placed on. */
+const SURFACES = [
+  'surface',
+  'surfaceVariant',
+  'surfaceContainer',
+  'surfaceContainerLow',
+  'surfaceContainerHigh',
+  'surfaceContainerHighest',
+  'surfaceContainerLowest',
+  'surfaceDim',
+  'surfaceBright',
+  'background',
+] as const satisfies readonly (keyof ColorPalette)[];
+
+type Rgb = [number, number, number];
+
+/**
+ * Parse `#rrggbb` or `rgba(r, g, b, a)` into a straight-alpha colour.
+ *
+ * The glass preset expresses its surfaces and outlines as `rgba(...)`, so a
+ * hex-only parser silently skips exactly the preset whose translucency makes
+ * contrast hardest to reason about — which is how glass sat at 1.42:1 unnoticed.
+ */
+function parseColor(value: string): { rgb: Rgb; alpha: number } | null {
+  const hex = value.trim().match(/^#([0-9a-f]{6})$/i);
+  if (hex) {
+    const n = Number.parseInt(hex[1], 16);
+    return { rgb: [(n >> 16) & 255, (n >> 8) & 255, n & 255], alpha: 1 };
+  }
+  const rgba = value
+    .trim()
+    .match(
+      /^rgba?\(\s*([\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)(?:[\s,/]+([\d.]+))?\s*\)$/i,
+    );
+  if (rgba) {
+    return {
+      rgb: [Number(rgba[1]), Number(rgba[2]), Number(rgba[3])],
+      alpha: rgba[4] === undefined ? 1 : Number(rgba[4]),
+    };
+  }
+  return null;
+}
+
+/** Composite `value` over an opaque backdrop, resolving any alpha. */
+function flatten(value: string, backdrop: Rgb): Rgb | null {
+  const parsed = parseColor(value);
+  if (!parsed) return null;
+  const { rgb, alpha } = parsed;
+  return rgb.map((c, i) =>
+    Math.round(c * alpha + backdrop[i] * (1 - alpha)),
+  ) as Rgb;
+}
+
+function relativeLuminance([r, g, b]: Rgb): number {
+  const [rr, gg, bb] = [r, g, b].map((n) => {
+    const s = n / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * rr + 0.7152 * gg + 0.0722 * bb;
+}
+
+function contrast(a: Rgb, b: Rgb): number {
+  const [hi, lo] = [relativeLuminance(a), relativeLuminance(b)].sort(
+    (x, y) => y - x,
+  );
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+describe('control boundaries clear the 3:1 non-text floor (#2322)', () => {
+  for (const theme of Object.values(themes)) {
+    for (const scheme of ['light', 'dark'] as const) {
+      const palette = theme[scheme];
+
+      it(`${theme.id} ${scheme}: outline is boundary-strength on every surface`, () => {
+        // Translucent surfaces resolve against the scheme's own background,
+        // which is the only backdrop the theme can promise.
+        const page = flatten(palette.background, [255, 255, 255]);
+        expect(
+          page,
+          `${theme.id} ${scheme} background must be parseable`,
+        ).not.toBeNull();
+
+        const failures: string[] = [];
+        for (const surfaceName of SURFACES) {
+          const surface = flatten(palette[surfaceName] as string, page as Rgb);
+          const outline = flatten(palette.outline, surface as Rgb);
+          expect(
+            surface && outline,
+            `${theme.id} ${scheme} ${surfaceName} must be parseable`,
+          ).toBeTruthy();
+
+          const ratio = contrast(outline as Rgb, surface as Rgb);
+          if (ratio < 3) failures.push(`${surfaceName} ${ratio.toFixed(2)}:1`);
+        }
+
+        expect(failures, `${theme.id} ${scheme} outline below 3:1`).toEqual([]);
+      });
+    }
+  }
+
+  it('keeps outline and outlineVariant as distinct roles', () => {
+    // If a preset ever "fixes" its bezel by setting it equal to the boundary,
+    // dividers become as loud as control edges and the two-token system
+    // collapses. The hairline is allowed to be quiet — it just may not BE the
+    // boundary token.
+    for (const theme of Object.values(themes)) {
+      for (const scheme of ['light', 'dark'] as const) {
+        expect(
+          theme[scheme].outlineVariant,
+          `${theme.id} ${scheme} outlineVariant must stay distinct from outline`,
+        ).not.toBe(theme[scheme].outline);
+      }
+    }
+  });
+});

--- a/packages/smrt-ui/src/themes/__tests__/control-boundary-contrast.test.ts
+++ b/packages/smrt-ui/src/themes/__tests__/control-boundary-contrast.test.ts
@@ -102,12 +102,21 @@ describe('control boundaries clear the 3:1 non-text floor (#2322)', () => {
 
         const failures: string[] = [];
         for (const surfaceName of SURFACES) {
+          // Assert each parse BEFORE it is used as the next one's backdrop.
+          // Folding these together would let an unparseable surface reach
+          // `flatten` as a null backdrop, and the test would die on a
+          // TypeError instead of naming the token that could not be read.
           const surface = flatten(palette[surfaceName] as string, page as Rgb);
+          expect(
+            surface,
+            `${theme.id} ${scheme} ${surfaceName} must be parseable`,
+          ).not.toBeNull();
+
           const outline = flatten(palette.outline, surface as Rgb);
           expect(
-            surface && outline,
-            `${theme.id} ${scheme} ${surfaceName} must be parseable`,
-          ).toBeTruthy();
+            outline,
+            `${theme.id} ${scheme} outline must be parseable`,
+          ).not.toBeNull();
 
           const ratio = contrast(outline as Rgb, surface as Rgb);
           if (ratio < 3) failures.push(`${surfaceName} ${ratio.toFixed(2)}:1`);

--- a/packages/smrt-ui/src/themes/__tests__/css-generator.test.ts
+++ b/packages/smrt-ui/src/themes/__tests__/css-generator.test.ts
@@ -91,6 +91,67 @@ describe('theme CSS generator', () => {
       expect(dark['--smrt-elevation-5']).toContain('rgba(0, 0, 0, 0.25)');
     });
 
+    it('matches every static preset CSS on colour values (drift guard)', () => {
+      // The elevation guard below caught shadows drifting; colours drifted too
+      // and nothing noticed — smrt.css carried `--smrt-theme-name: SMRT` long
+      // after the theme was renamed `s-m-r-t` (#2322). The alias test only
+      // checks that token NAMES appear in each stylesheet, so a stale VALUE
+      // sails through it. Compare the values themselves, for every preset.
+      const files: Record<string, string> = {
+        material: 'material.css',
+        glass: 'glass.css',
+        studio: 'studio.css',
+        smrt: 'smrt.css',
+        happyvertical: 'happyvertical.css',
+      };
+
+      const drift: string[] = [];
+      for (const [id, file] of Object.entries(files)) {
+        const css = readFileSync(
+          join(process.cwd(), 'src/themes/styles', file),
+          'utf8',
+        );
+        for (const scheme of ['light', 'dark'] as const) {
+          const selector = `[data-theme="${id}"][data-color-scheme="${scheme}"]`;
+          const start = css.indexOf(selector);
+          expect(start, `${file} must define ${selector}`).toBeGreaterThan(-1);
+          const open = css.indexOf('{', start);
+          const body = css.slice(open + 1, css.indexOf('\n}', open));
+
+          const defined: Record<string, string> = {};
+          for (const match of body.matchAll(
+            /(--smrt-[a-z0-9-]+):\s*([^;]+);/gi,
+          )) {
+            defined[match[1]] = match[2].trim();
+          }
+
+          const generated = generateThemeVariables(
+            getTheme(id as never),
+            scheme === 'dark',
+          );
+          for (const [token, value] of Object.entries(generated)) {
+            if (
+              !token.startsWith('--smrt-color-') &&
+              token !== '--smrt-theme-name'
+            )
+              continue;
+            // Only compare tokens the stylesheet actually declares; absence is
+            // the alias test's job, not this one's.
+            if (
+              defined[token] !== undefined &&
+              defined[token] !== String(value)
+            ) {
+              drift.push(
+                `${file} ${scheme} ${token}: css=${defined[token]} generator=${value}`,
+              );
+            }
+          }
+        }
+      }
+
+      expect(drift).toEqual([]);
+    });
+
     it('matches the static studio.css for both schemes (drift guard)', () => {
       // The static-CSS delivery path and the JS generator must agree on VALUES,
       // not just token names — this is what let the studio dark shadows diverge.

--- a/packages/smrt-ui/src/themes/glass/index.ts
+++ b/packages/smrt-ui/src/themes/glass/index.ts
@@ -78,8 +78,14 @@ const lightColors: ColorPalette = {
   background: '#f2f2f7',
   onBackground: '#000000',
 
-  // Outline - Subtle translucent borders
-  outline: 'rgba(120, 120, 128, 0.29)',
+  // Outline - Translucent borders.
+  // `outline` is the boundary role and must clear 3:1 non-text once its alpha
+  // is composited over the frosted surface (WCAG 1.4.11). At the original
+  // rgba(120, 120, 128, 0.29) it composited to 1.42:1 — a control border no one
+  // could see. Darkened the hue rather than pushing alpha toward opaque, which
+  // keeps the translucent character (#2322). `outlineVariant` stays the quiet
+  // hairline for dividers and panel edges.
+  outline: 'rgba(80, 80, 88, 0.75)',
   outlineVariant: 'rgba(120, 120, 128, 0.16)',
 
   // Inverse
@@ -154,8 +160,10 @@ const darkColors: ColorPalette = {
   background: '#000000',
   onBackground: '#ffffff',
 
-  // Outline
-  outline: 'rgba(84, 84, 88, 0.65)',
+  // Outline — see the light-scheme note. Composited over the dark frosted
+  // surface the original rgba(84, 84, 88, 0.65) measured 1.70:1; lightening the
+  // hue clears 3:1 while staying translucent (#2322).
+  outline: 'rgba(160, 160, 166, 0.8)',
   outlineVariant: 'rgba(84, 84, 88, 0.35)',
 
   // Inverse

--- a/packages/smrt-ui/src/themes/smrt/index.ts
+++ b/packages/smrt-ui/src/themes/smrt/index.ts
@@ -86,7 +86,11 @@ const lightColors: ColorPalette = {
   onBackground: '#14171c',
 
   // Outline - Hairline / line greys
-  outline: '#c6ccd4',
+  // Boundary role: clears 3:1 non-text on every surface in this scheme so
+  // control borders are perceivable (WCAG 1.4.11). Was #c6ccd4 (1.29–1.62:1),
+  // which read as a divider, not a boundary (#2322). outlineVariant below
+  // remains the hairline for dividers, readout rows, and panel edges.
+  outline: '#7c7f85',
   outlineVariant: '#dfe3e8',
 
   // Inverse
@@ -160,7 +164,9 @@ const darkColors: ColorPalette = {
   onBackground: '#c9cdd3',
 
   // Outline - Line / hairline strokes
-  outline: '#333842',
+  // See the light-scheme note: boundary role, 3:1 on every dark surface.
+  // Was #333842 (1.23–1.57:1).
+  outline: '#70747b',
   outlineVariant: '#23272e',
 
   // Inverse

--- a/packages/smrt-ui/src/themes/studio/index.ts
+++ b/packages/smrt-ui/src/themes/studio/index.ts
@@ -78,7 +78,11 @@ const lightColors: ColorPalette = {
   onBackground: '#202124',
 
   // Outline - Light gray borders
-  outline: '#dadce0',
+  // Boundary role: must clear 3:1 non-text on every surface in this scheme so
+  // control borders are perceivable (WCAG 1.4.11). Was #dadce0, a divider-weight
+  // grey measuring 1.21–1.37:1 — invisible as a control boundary (#2322).
+  // outlineVariant below stays the quiet hairline for dividers and panels.
+  outline: '#78797b',
   outlineVariant: '#e8eaed',
 
   // Inverse
@@ -150,7 +154,7 @@ const darkColors: ColorPalette = {
   onBackground: '#e8eaed',
 
   // Outline
-  outline: '#5f6368',
+  outline: '#8c8e92',
   outlineVariant: '#3c4043',
 
   // Inverse

--- a/packages/smrt-ui/src/themes/styles/glass.css
+++ b/packages/smrt-ui/src/themes/styles/glass.css
@@ -62,7 +62,7 @@
   --smrt-color-on-background: #000000;
 
   /* Outline - Subtle translucent borders */
-  --smrt-color-outline: rgba(120, 120, 128, 0.29);
+  --smrt-color-outline: rgba(80, 80, 88, 0.75);
   --smrt-color-outline-variant: rgba(120, 120, 128, 0.16);
 
   /* Inverse */
@@ -177,7 +177,7 @@
   --smrt-color-on-background: #ffffff;
 
   /* Outline */
-  --smrt-color-outline: rgba(84, 84, 88, 0.65);
+  --smrt-color-outline: rgba(160, 160, 166, 0.8);
   --smrt-color-outline-variant: rgba(84, 84, 88, 0.35);
 
   /* Inverse */

--- a/packages/smrt-ui/src/themes/styles/smrt.css
+++ b/packages/smrt-ui/src/themes/styles/smrt.css
@@ -18,7 +18,7 @@
 
 [data-theme="smrt"][data-color-scheme="light"] {
   --smrt-theme-id: smrt;
-  --smrt-theme-name: SMRT;
+  --smrt-theme-name: s-m-r-t;
   --smrt-color-scheme: light;
   --smrt-font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
   --smrt-color-primary: #e35d12;
@@ -58,7 +58,7 @@
   --smrt-color-surface-bright: #ffffff;
   --smrt-color-background: #edeff2;
   --smrt-color-on-background: #14171c;
-  --smrt-color-outline: #c6ccd4;
+  --smrt-color-outline: #7c7f85;
   --smrt-color-outline-variant: #dfe3e8;
   --smrt-color-inverse-surface: #14171c;
   --smrt-color-inverse-on-surface: #f4f6f8;
@@ -243,7 +243,7 @@
 
 [data-theme="smrt"][data-color-scheme="dark"] {
   --smrt-theme-id: smrt;
-  --smrt-theme-name: SMRT;
+  --smrt-theme-name: s-m-r-t;
   --smrt-color-scheme: dark;
   --smrt-font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
   --smrt-color-primary: #ff7a1a;
@@ -283,7 +283,7 @@
   --smrt-color-surface-bright: #23272e;
   --smrt-color-background: #0b0c0e;
   --smrt-color-on-background: #c9cdd3;
-  --smrt-color-outline: #333842;
+  --smrt-color-outline: #70747b;
   --smrt-color-outline-variant: #23272e;
   --smrt-color-inverse-surface: #edeff2;
   --smrt-color-inverse-on-surface: #14171c;

--- a/packages/smrt-ui/src/themes/styles/studio.css
+++ b/packages/smrt-ui/src/themes/styles/studio.css
@@ -62,7 +62,7 @@
   --smrt-color-on-background: #202124;
 
   /* Outline - Light gray borders */
-  --smrt-color-outline: #dadce0;
+  --smrt-color-outline: #78797b;
   --smrt-color-outline-variant: #e8eaed;
 
   /* Inverse */
@@ -169,7 +169,7 @@
   --smrt-color-on-background: #e8eaed;
 
   /* Outline */
-  --smrt-color-outline: #5f6368;
+  --smrt-color-outline: #8c8e92;
   --smrt-color-outline-variant: #3c4043;
 
   /* Inverse */


### PR DESCRIPTION
Fixes two WCAG non-text/text contrast failures found while implementing the `happyvertical` preset (#2318, PR #2321). Both are pre-existing and span every preset, which is why they were filed separately rather than smuggled into that PR.

Closes #2322. Closes #2323.

## #2322 — control boundaries were invisible

The form primitives drew their resting border with `outline-variant`, the **divider** role. Measured against the surface the control sits on, that is 1.2–1.7:1 in every preset — well under the 3:1 that SC 1.4.11 requires of the boundary that identifies a component.

Eleven interactive control surfaces now consume `outline`. Three declarations deliberately keep the hairline: `Fieldset` (a grouping container, not a control) and the two dropdown panels, which are floating surfaces whose separation comes from their shadow.

**The issue's premise was wrong in a way that mattered.** It assumed "every preset already tunes `outline` to clear 3:1" — true only for material and happyvertical. The token swap alone would have left three presets still failing, so their `outline` is retuned, measured against **every** surface a control can sit on rather than just `surface`:

| preset | scheme | before | after (worst surface) |
|---|---|---|---|
| material | light / dark | 1.70 / 2.06 | **3.30 / 3.80** |
| happyvertical | light / dark | 1.46 / 1.23 | **3.39 / 3.36** |
| studio | light / dark | 1.21 / 1.84 | **3.17 / 3.19** |
| smrt | light / dark | 1.29 / 1.23 | **3.21 / 3.19** |
| glass | light / dark | 1.42 / 1.70 | **3.46 / 3.18** |

These are worst-surface minimums, not the friendlier ratio against `surface` — several presets land within 0.2 of the floor, which is the honest picture.

Glass was invisible to my first measurement pass because its palette is `rgba` and the script skipped non-hex values — that omission is exactly how it sat at 1.42:1 unnoticed. The new test composites alpha over the scheme's own background instead of skipping, pins the floor for all five presets in both schemes, and pins `outline != outlineVariant` so a future "fix" can't collapse the two roles into one.

**Focus rings.** `Dropdown` items and `RoleSelector` options suppressed the ring with `outline: none`, leaving a ~1.1:1 background swap as the only keyboard focus indicator — the hover treatment reused for focus, which is a 2.4.11 failure. Split so hover keeps the background and `:focus-visible` gets a real inset ring.

**Drift caught in passing.** `smrt.css` still carried `--smrt-theme-name: SMRT` after the theme was renamed `s-m-r-t`. The existing lockstep guard only compared *elevation*, and the alias test only checks token *names*, so a stale value sailed through both. Added a guard comparing colour values across every preset stylesheet.

## #2323 — status colour as letterforms

`SystemStatusChips` and `PhoneInput` painted text with `--smrt-color-success`. Status hues are picked to be recognisable at a glance, which puts them in luminance bands that are not text-safe on light surfaces. Worst case as text, across all five presets:

| tone | worst | where |
|---|---|---|
| warning | **1.41:1** | material + studio light |
| success | **1.66:1** | glass light |
| error | **2.65:1** | glass light |

My first pass fixed only green and shipped a rationale claiming warning and error were fine everywhere — that was wrong, generalised from the one preset whose palette I had tuned. Review caught it. **Every tone in the chip is now a lamp beside `on-surface` text**, which also stops the component depending on each preset tuning three hues to be text-safe. `PhoneInput` already had a `.listening-dot`, so its label simply stops being green.

The scan from PR #2321 now also runs in `smrt-svelte` — it lives in `smrt-ui` and cannot see this package, which is how these drifted.

**Known remaining, not in this PR:** four sibling-package components still paint text green (`messages` ×2, `images`, `assets`), plus six `smrt-svelte` playground routes outside `src/`. A per-package guard copy doesn't reach them; a repo-wide checker in `scripts/` alongside `check-color-literals.mjs` is the structural fix. Tracked rather than bundled here.

## Visual impact — worth a look

Input, select, and textarea borders are **visibly stronger in all five presets**, and studio/smrt/glass hairlines change wherever `outline` is consumed (smrt's `.smrt-readout` and `.smrt-terminal` borders included). That was an explicit call rather than a blind sweep. Glass wasn't in the original question — its `rgba` palette hid it from the first pass — so I extended the same decision to it; say the word if you'd rather glass kept its frosted 1.42:1 hairline.

## Validation

- `pnpm test` smrt-ui: 55 files / 525 tests green (+12 new)
- One review round (independent agent): two HIGH findings, both verified and fixed in c8838344e
- `pnpm test` smrt-svelte: 56 files / 554 tests green (+4 new)
- `pnpm typecheck`: 0 errors in both (433 and 1455 files)
- `biome check`, `check-svelte-tokens` (179 tokens), `check-color-literals`, `check-coverage`, `smrt dev:knowledge-check`: all clean

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"418aba76-9761-4025-aa92-610d3ddda5c2","issues":[2322,2323],"issue":2322,"policy_revision":"1.0.0","policy_source_commit":"bd9a5ea7a3f9a323ee6d3f805728bf46aabe4079","validation":["smrt-ui pnpm test (55 files / 525 tests)","smrt-svelte pnpm test (56 files / 554 tests)","smrt-ui pnpm typecheck (433 files)","smrt-svelte pnpm typecheck (1455 files)","biome check","check-svelte-tokens","check-color-literals","check-coverage","smrt dev:knowledge-check"]}
```
