### PR TITLE
fix(core): emit portable paths in generated smrt-register manifests

### DIFF
--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -526,6 +526,26 @@ describe('SvelteKit Route Generator', () => {
       expect(registrationContent).toContain(
         'const smrtRegistrationManifests = JSON.parse(',
       );
+
+      // #2341: smrt-register.ts is tracked in consumer repositories, so the
+      // embedded manifest must never carry the generating machine's absolute
+      // paths — that made the file uncommittable and left every build dirty.
+      expect(registrationContent).not.toContain(projectRoot);
+      const embedded = JSON.parse(
+        JSON.parse(
+          registrationContent.match(
+            /const smrtRegistrationManifests = JSON\.parse\((".*?")\);/s,
+          )?.[1] as string,
+        ),
+      ) as Record<string, { objects: Record<string, { filePath?: string }> }>;
+      expect(embedded.LocalThing.objects.LocalThing.filePath).toBe(
+        'src/lib/objects/LocalThing.ts',
+      );
+      for (const entry of Object.values(embedded)) {
+        for (const objectDef of Object.values(entry.objects)) {
+          expect(objectDef.filePath).not.toMatch(/^([/\\]|[A-Za-z]:[/\\])/);
+        }
+      }
     });
 
     it('should fall back to object package metadata and skip empty re-registrations', async () => {

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -1531,9 +1531,9 @@ async function generateRegistrationFile(
    */
   function portableObjectManifest(
     root: string,
-    objectDef: Record<string, unknown>,
-  ): Record<string, unknown> {
-    const filePath = objectDef.filePath;
+    objectDef: SmartObjectDefinition,
+  ): SmartObjectDefinition {
+    const { filePath } = objectDef;
     if (typeof filePath !== 'string' || !isAbsolute(filePath)) {
       return objectDef;
     }

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -11,7 +11,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
-import { join, relative } from 'node:path';
+import { isAbsolute, join, relative, sep } from 'node:path';
 import type { DomainKnowledgeConfig } from '@happyvertical/smrt-types';
 import { generateConditionalGetRouteHelper } from '../generators/conditional-get.js';
 import { resolveCustomActionMetadata } from '../generators/custom-action.js';
@@ -1517,6 +1517,32 @@ async function generateRegistrationFile(
     ).replace(/\\/g, '/');
     consumerRegistrationImport = `import '${consumerRegistrationPath.startsWith('.') ? consumerRegistrationPath : `./${consumerRegistrationPath}`}';`;
   }
+  /**
+   * Strip machine specifics from an object definition before it is embedded in
+   * generated source.
+   *
+   * `smrt-register.ts` is a tracked file in consumer repositories, and the
+   * scanner records `filePath` as an absolute path. Embedding it verbatim wrote
+   * the generating machine's home directory into the repository, so the file
+   * could never be committed without breaking every other checkout and CI, and
+   * every build left a dirty working tree (#2341). The field is only produced
+   * at scan time — nothing reads it back through `_manifest` at runtime — so a
+   * project-relative path keeps the shape without the machine.
+   */
+  function portableObjectManifest(
+    root: string,
+    objectDef: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const filePath = objectDef.filePath;
+    if (typeof filePath !== 'string' || !isAbsolute(filePath)) {
+      return objectDef;
+    }
+    return {
+      ...objectDef,
+      filePath: relative(root, filePath).split(sep).join('/'),
+    };
+  }
+
   const registrationManifests = Object.fromEntries(
     Object.entries(manifest.objects).flatMap(([className, objectDef]) => {
       if (isCollectionManifestClass(manifest, objectDef)) return [];
@@ -1533,7 +1559,9 @@ async function generateRegistrationFile(
           {
             ...manifest,
             packageName,
-            objects: { [className]: objectDef },
+            objects: {
+              [className]: portableObjectManifest(projectRoot, objectDef),
+            },
           },
         ],
       ];


### PR DESCRIPTION
Closes #2341

## Problem

`smrt-register.ts` is a **tracked** file in consumer repositories, but the registration manifest the SvelteKit generator embeds in it carried the scanner's absolute `filePath`:

```json
"filePath":"/Users/will/Work/anytown/repos/anytown.ai/apps/template-small-town/src/lib/smrt/Redirect.ts"
```

So the generating machine's home directory ended up inside committed source. Consumers could not commit the generated output without breaking every other checkout and CI, and every `pnpm build` left a dirty working tree — which trips cleanliness gates.

## Fix

The embedded `filePath` is now project-relative with forward slashes. Nothing reads it back through `_manifest` at runtime — the registry's `filePath` handling resolves manifest *files*, not object definitions — so relativizing keeps the manifest shape without the machine specifics. Non-absolute values pass through untouched.

## Verified against the reproducing consumer

anytown `@anytown/template-small-town`, rebuilt with this branch linked:

- absolute `/Users/...` occurrences in the regenerated `smrt-register.ts`: **0** (was 1)
- `filePath` now reads `src/lib/smrt/Redirect.ts`
- the only remaining diff versus the committed file is the intended 0.40.68 `_manifest` / `_manifestKey` registration (#2308) plus the `.smrt/register.js` import — deterministic, machine-independent, and now committable

## Scope correction

I filed #2341 with a second symptom — the generator stripping lines from consumers' template `.gitignore` files. **That one is not a bug and is withdrawn** (detail in the issue): the removed lines are `LEGACY_GITIGNORE_HEADER` and its pattern run, and `stripLegacyGeneratedRouteIgnores()` removes them deliberately to migrate projects onto the bounded `# BEGIN`/`# END` block from #2185. The downstream fix is for the consumer to commit the migrated `.gitignore`. This PR changes nothing about that path.

## Validation

- `@happyvertical/smrt-core` — 3,255 tests passed, 6 files skipped
- generator suite — 71 passed, including a new regression assertion that the emitted content contains no absolute path and that every embedded `filePath` is relative

No changeset is committed — AGENTS.md:39 says release automation generates them on merge.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","policy_revision":"1.0.0","runtime":"claude","session":"cc711e03-43fb-435d-90ab-92e8c8d225ea","issue":"https://github.com/happyvertical/smrt/issues/2341"}
```
