### PR TITLE
fix(profiles,users): serialize backfill setup with OIDC provisioning transactions

### DIFF
--- a/packages/profiles/AGENTS.md
+++ b/packages/profiles/AGENTS.md
@@ -90,10 +90,13 @@ import { smrtProfilesGenerateBioPrompt } from '@happyvertical/smrt-profiles';
   `@happyvertical/smrt-profiles/internal/oidc-provisioning` subpath instead of
   duplicating adapter probing, locking, or retry policy, and supply both exact
   issuer/subject and normalized-email lock keys in deterministic order. The
-  coordinator additionally serializes all SQLite/DuckDB provisioning
-  transactions per database URL because those adapters cannot overlap
-  unrelated root transactions safely and retries bounded PostgreSQL
-  deadlock/serialization failures. New OIDC Profiles use per-profile,
+  coordinator additionally serializes every root-handle statement it owns per
+  database URL on SQLite/DuckDB — shared `_smrt_backfills` initialization, the
+  provisioning transaction, and the post-commit rebind — because those adapters
+  multiplex one native connection and cannot overlap unrelated root
+  transactions safely; a statement issued outside that window races an open
+  transaction and DuckDB fails the losing prepared statement. It retries
+  bounded PostgreSQL deadlock/serialization failures. New OIDC Profiles use per-profile,
   non-semantic slugs so duplicate display names never invoke natural-key upsert.
   Caller-owned transactions never execute `_smrt_backfills` DDL; paths that
   perform canonical email lookup or reservation require the table to already

--- a/packages/profiles/AGENTS.md
+++ b/packages/profiles/AGENTS.md
@@ -94,8 +94,10 @@ import { smrtProfilesGenerateBioPrompt } from '@happyvertical/smrt-profiles';
   database URL on SQLite/DuckDB — shared `_smrt_backfills` initialization, the
   provisioning transaction, and the post-commit rebind — because those adapters
   multiplex one native connection and cannot overlap unrelated root
-  transactions safely; a statement issued outside that window races an open
-  transaction and DuckDB fails the losing prepared statement. It retries
+  transactions safely. **Never overlap two statements on one such handle,
+  transaction-bound or not** — no `Promise.all` over reads, not even
+  primary-key rebinds — because DuckDB fails the losing prepared statement or
+  aborts the process outright. It retries
   bounded PostgreSQL deadlock/serialization failures. New OIDC Profiles use per-profile,
   non-semantic slugs so duplicate display names never invoke natural-key upsert.
   Caller-owned transactions never execute `_smrt_backfills` DDL; paths that

--- a/packages/profiles/src/__tests__/oidc-provisioning-coordinator.test.ts
+++ b/packages/profiles/src/__tests__/oidc-provisioning-coordinator.test.ts
@@ -1,6 +1,9 @@
 import { getDatabase } from '@happyvertical/sql';
 import { describe, expect, it } from 'vitest';
+import { createProfileFromOidc } from '../auth/index.js';
 import { coordinateOidcProvisioning } from '../auth/oidcProvisioningCoordinator';
+import { ProfileTypeCollection } from '../collections/ProfileTypeCollection.js';
+import { backfillProfileEmailKeys } from '../migrations/backfillProfileEmailKeys.js';
 
 type DatabaseInterface = Awaited<ReturnType<typeof getDatabase>>;
 
@@ -132,6 +135,82 @@ describe('coordinateOidcProvisioning shared-connection ordering', () => {
     } finally {
       releaseFirstTransaction.resolve();
       await Promise.allSettled([first, second]);
+      await db.close?.();
+    }
+  });
+
+  /**
+   * #2352: the ordering guard above only covers statements the coordinator
+   * itself owns. A single flow can just as easily overlap its own statements
+   * — the post-commit rebind used `Promise.all` over two or three primary-key
+   * reads — and on one native connection that is the same defect. Counting
+   * in-flight statements catches both without racing: an overlap is a
+   * structural property of the call, not a timing accident.
+   */
+  it('never overlaps two statements on one shared DuckDB connection during concurrent provisioning', async () => {
+    const db = (await getDatabase({
+      type: 'duckdb',
+      url: ':memory:',
+    })) as DatabaseInterface;
+    await ProfileTypeCollection.create({ db });
+    await backfillProfileEmailKeys(db);
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const overlapped: string[] = [];
+    const observe = (database: DatabaseInterface): DatabaseInterface =>
+      new Proxy(database, {
+        get(target, property, receiver) {
+          if (property === 'query') {
+            return async (sql: string, ...params: unknown[]) => {
+              inFlight += 1;
+              maxInFlight = Math.max(maxInFlight, inFlight);
+              if (inFlight > 1) {
+                overlapped.push(sql.replace(/\s+/gu, ' ').trim());
+              }
+              try {
+                return await target.query(sql, ...params);
+              } finally {
+                inFlight -= 1;
+              }
+            };
+          }
+          if (property === 'transaction') {
+            const transaction = target.transaction;
+            if (!transaction) return undefined;
+            return async <T>(
+              callback: (tx: DatabaseInterface) => Promise<T>,
+            ): Promise<T> =>
+              transaction.call(target, (tx) => callback(observe(tx)));
+          }
+          const value = Reflect.get(target, property, receiver);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      }) as DatabaseInterface;
+
+    const sharedClaims = {
+      sub: 'overlap-guard-subject',
+      iss: 'https://auth.example.com',
+      email_verified: true,
+      name: 'Overlap Guard',
+    };
+    try {
+      await Promise.all([
+        createProfileFromOidc(
+          { ...sharedClaims, email: 'overlap-guard-first@example.com' },
+          'example',
+          { db: observe(db) },
+        ),
+        createProfileFromOidc(
+          { ...sharedClaims, email: 'overlap-guard-second@example.com' },
+          'example',
+          { db: observe(db) },
+        ),
+      ]);
+
+      expect(overlapped).toEqual([]);
+      expect(maxInFlight).toBe(1);
+    } finally {
       await db.close?.();
     }
   });

--- a/packages/profiles/src/__tests__/oidc-provisioning-coordinator.test.ts
+++ b/packages/profiles/src/__tests__/oidc-provisioning-coordinator.test.ts
@@ -1,0 +1,131 @@
+import { getDatabase } from '@happyvertical/sql';
+import { describe, expect, it } from 'vitest';
+import { coordinateOidcProvisioning } from '../auth/oidcProvisioningCoordinator';
+
+type DatabaseInterface = Awaited<ReturnType<typeof getDatabase>>;
+
+interface Deferred {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+function createDeferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+/** Give a blocked flow every chance to reach its first statement. */
+async function settleEventLoop(): Promise<void> {
+  for (let tick = 0; tick < 5; tick += 1) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+describe('coordinateOidcProvisioning shared-connection ordering', () => {
+  /**
+   * #2352: SQLite and DuckDB root handles multiplex one native connection, so
+   * any coordinator statement issued while a concurrent flow holds that
+   * connection's transaction races it. DuckDB reports the loser as
+   * `Failed to execute prepared statement` or aborts the worker outright, and
+   * the shared `_smrt_backfills` initialization used to run before the adapter
+   * lock. Every statement the coordinator owns must run inside that lock.
+   */
+  it('issues no statement on a shared DuckDB root handle while another flow holds its provisioning transaction', async () => {
+    const db = (await getDatabase({
+      type: 'duckdb',
+      url: ':memory:',
+      __smrtSkipVitestSchemaPreparation: true,
+    })) as DatabaseInterface;
+    const statementsDuringTransaction: string[] = [];
+    let openTransactions = 0;
+
+    const observeRoot = (database: DatabaseInterface): DatabaseInterface =>
+      new Proxy(database, {
+        get(target, property, receiver) {
+          if (property === 'query') {
+            return async (sql: string, ...params: unknown[]) => {
+              if (openTransactions > 0) {
+                // Record instead of executing. Really racing the connection
+                // would corrupt it and hide the ordering defect behind an
+                // adapter error.
+                statementsDuringTransaction.push(
+                  sql.replace(/\s+/gu, ' ').trim(),
+                );
+                throw new Error(
+                  'A coordinator statement raced an open provisioning transaction.',
+                );
+              }
+              return target.query(sql, ...params);
+            };
+          }
+          if (property === 'transaction') {
+            const transaction = target.transaction;
+            if (!transaction) return undefined;
+            return async <T>(
+              callback: (tx: DatabaseInterface) => Promise<T>,
+            ): Promise<T> => {
+              openTransactions += 1;
+              try {
+                return await transaction.call(target, callback);
+              } finally {
+                openTransactions -= 1;
+              }
+            };
+          }
+          const value = Reflect.get(target, property, receiver);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      }) as DatabaseInterface;
+
+    const firstTransactionOpen = createDeferred();
+    const releaseFirstTransaction = createDeferred();
+    const coordinate = (
+      lockKey: string,
+      provision: () => Promise<string>,
+    ): Promise<string> =>
+      coordinateOidcProvisioning<string>({
+        db: observeRoot(db),
+        lockKeys: [lockKey],
+        isRaceConflict: () => false,
+        createTransactionError: (message, cause) =>
+          new Error(message, cause === undefined ? undefined : { cause }),
+        createConcurrencyError: (cause) =>
+          new Error(
+            'Concurrent provisioning did not converge.',
+            cause === undefined ? undefined : { cause },
+          ),
+        provision,
+      });
+
+    let first: Promise<string> | undefined;
+    let second: Promise<string> | undefined;
+    try {
+      first = coordinate('identity:first', async () => {
+        firstTransactionOpen.resolve();
+        await releaseFirstTransaction.promise;
+        return 'first';
+      });
+      await firstTransactionOpen.promise;
+
+      // The second flow must block on the adapter lock rather than touch the
+      // connection the first flow's transaction owns.
+      second = coordinate('identity:second', async () => 'second');
+      await settleEventLoop();
+      expect(statementsDuringTransaction).toEqual([]);
+
+      releaseFirstTransaction.resolve();
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        'first',
+        'second',
+      ]);
+      expect(statementsDuringTransaction).toEqual([]);
+    } finally {
+      releaseFirstTransaction.resolve();
+      await Promise.allSettled([first, second]);
+      await db.close?.();
+    }
+  });
+});

--- a/packages/profiles/src/__tests__/oidc-provisioning-coordinator.test.ts
+++ b/packages/profiles/src/__tests__/oidc-provisioning-coordinator.test.ts
@@ -108,11 +108,18 @@ describe('coordinateOidcProvisioning shared-connection ordering', () => {
         await releaseFirstTransaction.promise;
         return 'first';
       });
-      await firstTransactionOpen.promise;
+      first.catch(() => undefined);
+      // Racing the flow itself turns an early failure into that failure
+      // rather than a hook timeout waiting for a signal that never arrives.
+      await Promise.race([firstTransactionOpen.promise, first]);
 
       // The second flow must block on the adapter lock rather than touch the
-      // connection the first flow's transaction owns.
+      // connection the first flow's transaction owns. Mark it handled up
+      // front: when this guard catches a regression the flow rejects while
+      // nothing awaits it yet, and the unhandled rejection would drown the
+      // assertion that actually names the offending statement.
       second = coordinate('identity:second', async () => 'second');
+      second.catch(() => undefined);
       await settleEventLoop();
       expect(statementsDuringTransaction).toEqual([]);
 

--- a/packages/profiles/src/auth/oidcProvisioningCoordinator.ts
+++ b/packages/profiles/src/auth/oidcProvisioningCoordinator.ts
@@ -82,15 +82,19 @@ export interface OidcProvisioningCoordinatorOptions<T> {
 export async function coordinateOidcProvisioning<T>(
   options: OidcProvisioningCoordinatorOptions<T>,
 ): Promise<T> {
-  // Establish the shared backfill table outside the provisioning transaction.
-  // Transaction-bound callers are handled below via savepoints and must not
-  // leak DDL into their caller's transaction.
   const rootBackfillTableReady =
     typeof options.db.beginTransaction === 'function';
-  if (rootBackfillTableReady) {
-    await new BackfillTracker({ db: options.db }).initialize();
-  }
   return withProvisioningLocks(options.db, options.lockKeys, async () => {
+    // Establish the shared backfill table outside the provisioning
+    // transaction but inside the coordinator locks. Transaction-bound callers
+    // are handled below via savepoints and must not leak DDL into their
+    // caller's transaction, and SQLite and DuckDB root handles multiplex one
+    // native connection: a statement issued here while a concurrent flow
+    // holds that connection's transaction races it, and DuckDB then fails the
+    // in-flight prepared statement outright (#2352).
+    if (rootBackfillTableReady) {
+      await new BackfillTracker({ db: options.db }).initialize();
+    }
     const result = await retryProvisioning(options, () =>
       withProvisioningTransaction(
         options.db,

--- a/packages/profiles/src/auth/resolveIdentity.ts
+++ b/packages/profiles/src/auth/resolveIdentity.ts
@@ -519,10 +519,13 @@ async function rebindOidcProfileResult<
   const [profile, oidcIdentity] = await withSystemContext(async () => {
     const profiles = await ProfileCollection.create({ db: rootDb });
     const identities = await OidcIdentityCollection.create({ db: rootDb });
-    return Promise.all([
-      profiles.get({ id: profileId }),
-      identities.get({ id: identityId }),
-    ]);
+    // Read one statement at a time. SQLite and DuckDB handles multiplex a
+    // single native connection, so overlapping statements on it fail the
+    // losing prepared statement or abort the process outright (#2352). These
+    // are primary-key reads, so the sequential cost is one extra round trip.
+    const rebound = await profiles.get({ id: profileId });
+    const reboundIdentity = await identities.get({ id: identityId });
+    return [rebound, reboundIdentity] as const;
   });
   if (!profile || !oidcIdentity) {
     throw new Error(

--- a/packages/users/AGENTS.md
+++ b/packages/users/AGENTS.md
@@ -295,9 +295,12 @@ the package root).
   private `oidc_profile_email_reservations.email_key`, `User.emailKey`, and the
   unique `User.profileId`; local callbacks acquire exact issuer/subject and normalized
   email locks in deterministic order so changed email claims also serialize.
-  SQLite and DuckDB callbacks additionally serialize transactions per database
-  URL because one adapter cannot safely overlap unrelated root transactions;
-  owner-authorized DuckDB callbacks use that same root-handle serialization;
+  SQLite and DuckDB callbacks additionally serialize every root-handle statement
+  the coordinator owns per database URL — `_smrt_backfills` initialization, the
+  transaction, and the post-commit rebind — because one adapter multiplexes a
+  single native connection and cannot safely overlap unrelated root
+  transactions; owner-authorized DuckDB callbacks use that same root-handle
+  serialization;
   PostgreSQL deadlock and serialization errors use a bounded transaction retry.
   Newly provisioned Profiles use non-semantic per-profile slugs so equal IdP
   display names cannot trigger a natural-key upsert;

--- a/packages/users/AGENTS.md
+++ b/packages/users/AGENTS.md
@@ -299,8 +299,10 @@ the package root).
   the coordinator owns per database URL — `_smrt_backfills` initialization, the
   transaction, and the post-commit rebind — because one adapter multiplexes a
   single native connection and cannot safely overlap unrelated root
-  transactions; owner-authorized DuckDB callbacks use that same root-handle
-  serialization;
+  transactions. Never overlap two statements on one such handle, inside a
+  transaction or not: rebind and owner/email candidate reads are sequential,
+  never `Promise.all`. Owner-authorized DuckDB callbacks use that same
+  root-handle serialization;
   PostgreSQL deadlock and serialization errors use a bounded transaction retry.
   Newly provisioned Profiles use non-semantic per-profile slugs so equal IdP
   display names cannot trigger a natural-key upsert;

--- a/packages/users/src/collections/UserCollection.ts
+++ b/packages/users/src/collections/UserCollection.ts
@@ -640,12 +640,15 @@ export class UserCollection extends SmrtCollection<User> {
        LIMIT 2${lockClause}`,
       profileId,
     );
-    const owners = await Promise.all(
-      result.rows.map((row) =>
-        typeof row.id === 'string' ? this.get({ id: row.id }) : null,
-      ),
-    );
-    return owners.filter((owner): owner is User => owner !== null);
+    // Sequential by design: this runs on the caller's transaction handle, and
+    // SQLite/DuckDB multiplex one native connection per handle (#2352).
+    const owners: User[] = [];
+    for (const row of result.rows) {
+      if (typeof row.id !== 'string') continue;
+      const owner = await this.get({ id: row.id });
+      if (owner !== null && owner !== undefined) owners.push(owner);
+    }
+    return owners;
   }
 
   private async validateProfileOwnerAuthorization(
@@ -723,11 +726,12 @@ export class UserCollection extends SmrtCollection<User> {
       const users = await UserCollection.create({ db: rootDb });
       const profiles = await ProfileCollection.create({ db: rootDb });
       const identities = await OidcIdentityCollection.create({ db: rootDb });
-      const [user, profile, oidcIdentity] = await Promise.all([
-        users.get({ id: userId }),
-        profiles.get({ id: profileId }),
-        identities.get({ id: identityId }),
-      ]);
+      // Read one statement at a time. SQLite and DuckDB handles multiplex a
+      // single native connection, so overlapping statements on it fail the
+      // losing prepared statement or abort the process outright (#2352).
+      const user = await users.get({ id: userId });
+      const profile = await profiles.get({ id: profileId });
+      const oidcIdentity = await identities.get({ id: identityId });
       if (!user || !profile || !oidcIdentity) {
         throw new OidcProvisioningError(
           'concurrency_conflict',
@@ -805,12 +809,15 @@ export class UserCollection extends SmrtCollection<User> {
     for (const row of result.rows) {
       this.assertUserEmailKeyCurrent(row, email);
     }
-    const users = await Promise.all(
-      result.rows.map((row) =>
-        typeof row.id === 'string' ? this.get({ id: row.id }) : null,
-      ),
-    );
-    return users.filter((user): user is User => user !== null);
+    // Sequential by design: this runs on the caller's transaction handle, and
+    // SQLite/DuckDB multiplex one native connection per handle (#2352).
+    const matched: User[] = [];
+    for (const row of result.rows) {
+      if (typeof row.id !== 'string') continue;
+      const user = await this.get({ id: row.id });
+      if (user !== null && user !== undefined) matched.push(user);
+    }
+    return matched;
   }
 
   /** Require the deploy-time backfill marker before indexed identity reads. */


### PR DESCRIPTION
Closes #2352

## Root cause (verified, not assumed)

The issue's hypothesis is correct, and I confirmed it two ways.

**1. Adapter-level.** The DuckDB adapter guards `transaction()` / `beginTransaction()` with an internal `connectionLock`, but top-level `query()` takes no lock. A statement left in flight when `BEGIN TRANSACTION` runs on the same native connection fails immediately:

```
probe3a commit-then-concurrent-root-reads:  ok            (400 rounds)
probe3b root-stmt-in-flight-at-BEGIN:       FAILED
  sql: 'SELECT 1 FROM t LIMIT 1'
  originalError: 'Failed to execute prepared statement'
```

So concurrent root reads are *not* the hazard (the post-commit rebind's `Promise.all` is fine); a root statement overlapping an open transaction on the same connection is.

**2. In the failing test.** Instrumenting `oidc-account-linking.test.ts` with sub-millisecond start/end markers on the shared root handle shows the exact overlap on this machine, even on a green run:

```
0.265 root start (inflight 1, txdepth 0) SELECT 1 FROM _smrt_backfills LIMIT 1   ← flow A, pre-lock
0.275 root start (inflight 2, txdepth 0) SELECT 1 FROM _smrt_backfills LIMIT 1   ← flow B, pre-lock
0.575 root end   (inflight 1, txdepth 0)
0.800 >>> BEGIN (depth 1, inflight 1)                    ← flow A opens its transaction
0.853 root end   (inflight 0, txdepth 1)                 ← flow B's statement ends INSIDE flow A's transaction
```

`coordinateOidcProvisioning` established the shared `_smrt_backfills` table **before** acquiring its `adapter-transaction` lock ("outside the provisioning transaction"). Both flows therefore issue a root statement while unserialized; whichever flow wins the lock opens `BEGIN TRANSACTION` on the same native connection a few hundred microseconds later, while the other flow's statement is still in flight. The window is ~50µs here, which is why the metal pods mostly get away with it and 4-vCPU hosted runners do not.

Everything else the coordinator does on the root handle — the transaction and the post-commit rebind — was already inside the lock, which is why the reported stack surfaced in `rebindOidcProfileResult`: it is a victim of the poisoned connection, not the cause.

## Fix

Move the tracker initialization inside `withProvisioningLocks`, still outside the provisioning transaction. Every root-handle statement the coordinator owns — tracker setup, the transaction, the post-commit rebind — is now serialized per database URL on SQLite/DuckDB. Transaction-bound callers are unchanged: they still never run `_smrt_backfills` DDL.

`@happyvertical/smrt-profiles` and `@happyvertical/smrt-users` both route through this one coordinator (`@happyvertical/smrt-profiles/internal/oidc-provisioning`), so the single change covers both failing suites — there is no second copy in `smrt-users`. No assertion was weakened: `maxActiveLookups`/`maxActiveResolvers` stay `1` and every row-count assertion is untouched.

Postgres root handles are unaffected in substance: they never take the `adapter-transaction` key, so initialization simply moves under the identity/email locks, and the shared initialization promise makes repeat calls a single cached check.

## Regression guard

`packages/profiles/src/__tests__/oidc-provisioning-coordinator.test.ts` asserts the ordering contract deterministically rather than by racing: it blocks one flow inside its provisioning transaction, starts a second flow, and asserts the second issues **no** statement on the shared DuckDB root handle. Reverting only the fix turns it red with the precise offender:

```
AssertionError: expected [ Array(1) ] to deeply equal []
+ [ "SELECT 1 FROM _smrt_backfills LIMIT 1" ]
```

## Validation

- `@happyvertical/smrt-profiles` full suite — 17 files, **209 passed** (was 208; +1 new test)
- `@happyvertical/smrt-users` — `oidc-provisioning-safety.test.ts` **93 passed**; whole node suite 22 files / **421 passed**. The 7 Svelte component files cannot load in an agent worktree (vite8 + rolldown `Could not resolve 'node:module'`), so CI is the gate for those.
- 20/20 local repeats of `oidc-account-linking.test.ts -t "independent DuckDB handles"`
- 20/20 local repeats of `oidc-provisioning-safety.test.ts -t "one DuckDB root handle"`
- #2191-style `--sequence.shuffle` probe: 6/6 green on each OIDC file (43 and 93 tests)
- `pnpm typecheck` (profiles, users), `biome check` on touched files, `pnpm check:agents-chain`, `pnpm smrt dev:knowledge-check` — clean
- The real acceptance test is this PR's own hosted `affected-package-tests` shards.

No changeset is committed — release automation generates them on merge.

---

## Update: hosted CI found a second, dominant hazard

Run [31994388100](https://github.com/happyvertical/smrt/actions/runs/31994388100) on `5edce0dbd` (lock-ordering fix only) shows the fix above was **necessary but not sufficient**:

- shard 3/3 — green
- shard 1/3 — `@happyvertical/smrt-users#test`, all 3 retries, `Failed to execute raw query` at `UserCollection.ts:726` inside `withProvisioningLock`
- shard 2/3 — `@happyvertical/smrt-profiles#test`, silent worker abort (16/17 files, 201/209 tests) — the issue's other reported signature

Both failures are *inside* the coordinator lock, where no other flow can run. So the remaining overlap is a flow racing **itself**: `rebindOidcProvisioningResult` / `rebindOidcProfileResult` issued their two or three primary-key reads through `Promise.all` on one native DuckDB connection. That is why the originally reported profiles stack pointed at `SELECT * FROM profiles WHERE id = $1` in the rebind — it was the direct cause, not a downstream victim. My local probe passed 400 rounds of that shape on macOS/arm64; the hosted x86 runners do not tolerate it.

**Second fix** (`c7bca9561`): the rebind reads and the `LIMIT 2` owner/email candidate reads are now sequential in both packages. They are primary-key lookups — one or two extra round trips on a first login, immaterial on pooled Postgres.

**Second guard**: `never overlaps two statements on one shared DuckDB connection during concurrent provisioning` counts in-flight statements across the root handle *and* its transaction handle while two real `createProfileFromOidc` flows run. It fails on structure, not on a race — restoring either `Promise.all` turns it red naming the duplicated statement:

```
AssertionError: expected [ …(2) ] to deeply equal []
+ "SELECT * FROM oidc_identities WHERE id = $1",
+ "SELECT * FROM oidc_identities WHERE id = $1",
```

This guard would have caught the original defect on any machine, which the timing-dependent suites could not.

**Revalidation:** profiles 17 files / 210 passed; users node suite 22 files / 421 passed (7 Svelte files need CI — vite8+rolldown cannot load the plugin in an agent worktree); 20/20 repeats of the users DuckDB test; 6/6 shuffle on the guard file; typecheck, biome, agents-chain, knowledge-check clean.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","policy_revision":"1.0.0","runtime":"claude","session":"bb4c7a21-74b8-4fce-972c-107c341951d9","issue":"https://github.com/happyvertical/smrt/issues/2352"}
```
