### PR TITLE
fix(core): index tenancy-injected tenant_id columns

### DIFF
--- a/packages/core/src/schema/generator-branches.test.ts
+++ b/packages/core/src/schema/generator-branches.test.ts
@@ -564,3 +564,71 @@ describe('SchemaGenerator.generateSQL / formatDefaultValue', () => {
     expect(sql).toContain('"email" TEXT NOT NULL UNIQUE');
   });
 });
+
+describe('SchemaGenerator tenant_id auto-index (#2356)', () => {
+  it('indexes a tenancy-injected tenant_id column', () => {
+    const generator = new SchemaGenerator();
+    const schema = generator.generateSchema(
+      objectDef('Note', {
+        tenantId: {
+          type: 'text',
+          _meta: { __tenancy: { isTenantIdField: true } },
+        },
+        title: { type: 'text' },
+      }),
+    );
+
+    // Derive the tenant column rather than assuming its spelling: the
+    // build-time path keeps the field name, the registry path snake_cases it.
+    const tenantColumn = Object.entries(schema.columns).find(
+      ([, column]) => column.referenceKind === 'tenantId',
+    )?.[0];
+    expect(tenantColumn).toBeDefined();
+    expect(
+      schema.indexes.some((index) => index.columns[0] === tenantColumn),
+    ).toBe(true);
+  });
+
+  it('adds nothing when the object is not tenant-scoped', () => {
+    const generator = new SchemaGenerator();
+    const schema = generator.generateSchema(
+      objectDef('Plain', { title: { type: 'text' } }),
+    );
+
+    expect(
+      Object.values(schema.columns).some(
+        (column) => column.referenceKind === 'tenantId',
+      ),
+    ).toBe(false);
+    expect(schema.indexes.some((index) => /tenant/i.test(index.name))).toBe(
+      false,
+    );
+  });
+
+  it('does not duplicate when an index already leads with tenant_id', () => {
+    const generator = new SchemaGenerator();
+    const schema = generator.generateSchema(
+      objectDef(
+        'Scoped',
+        {
+          tenantId: {
+            type: 'text',
+            _meta: { __tenancy: { isTenantIdField: true } },
+          },
+          externalId: { type: 'text' },
+        },
+        // conflictColumns produce a unique index leading on tenant_id, which
+        // already serves tenant-scoped lookups.
+        { conflictColumns: ['tenantId', 'externalId'] },
+      ),
+    );
+
+    const tenantColumn = Object.entries(schema.columns).find(
+      ([, column]) => column.referenceKind === 'tenantId',
+    )?.[0];
+    const leading = schema.indexes.filter(
+      (index) => index.columns[0] === tenantColumn,
+    );
+    expect(leading.length).toBe(1);
+  });
+});

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -365,7 +365,6 @@ export class SchemaGenerator {
       columns: string[];
       unique?: boolean;
       where?: string;
-      description?: string;
     }>,
     columns: Record<string, { referenceKind?: string } | undefined>,
     tableName: string,
@@ -380,10 +379,11 @@ export class SchemaGenerator {
     );
     if (alreadyLeading) return;
 
+    // No `description`: ManifestIndexDefinition has no such field, and this
+    // helper feeds the manifest paths as well as the structured ones.
     indexes.push({
       name: `${tableName}_${tenantColumn}_idx`,
       columns: [tenantColumn],
-      description: `Index for tenant scoping on ${tenantColumn}`,
     });
   }
 

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -81,6 +81,9 @@ export class SchemaGenerator {
     const dependencies = this.extractDependencies(objectDef, foreignKeys);
     const version = this.generateVersion(objectDef);
 
+    // Tenancy injects `tenant_id` but nothing indexes it (#2356).
+    this.ensureTenantIdIndex(indexes, columns, tableName);
+
     return {
       tableName,
       columns,
@@ -342,6 +345,48 @@ export class SchemaGenerator {
   /**
    * Generate index definitions
    */
+  /**
+   * Ensure a tenancy-injected `tenant_id` column has an index leading with it.
+   *
+   * Tenancy injects the column but nothing indexed it: the generated set covers
+   * foreign keys, unique columns, `updated_at` and the STI discriminator, and
+   * `tenant_id` is in none of those. Every tenant-scoped read filters on it, so
+   * without an index each one scans the whole multi-tenant table — measured in
+   * one production database, 164 of 212 tenant-scoped tables had no such index
+   * (#2356).
+   *
+   * "Leading with it" rather than "always add": a table that already has a
+   * composite index starting on `tenant_id` (commonly from `conflictColumns`)
+   * is already served, and a standalone duplicate would only cost writes.
+   */
+  private ensureTenantIdIndex(
+    indexes: Array<{
+      name: string;
+      columns: string[];
+      unique?: boolean;
+      where?: string;
+      description?: string;
+    }>,
+    columns: Record<string, { referenceKind?: string } | undefined>,
+    tableName: string,
+  ): void {
+    const tenantColumn = Object.entries(columns).find(
+      ([, columnDef]) => columnDef?.referenceKind === 'tenantId',
+    )?.[0];
+    if (!tenantColumn) return;
+
+    const alreadyLeading = indexes.some(
+      (index) => index.columns?.[0] === tenantColumn,
+    );
+    if (alreadyLeading) return;
+
+    indexes.push({
+      name: `${tableName}_${tenantColumn}_idx`,
+      columns: [tenantColumn],
+      description: `Index for tenant scoping on ${tenantColumn}`,
+    });
+  }
+
   private generateIndexes(
     objectDef: SmartObjectDefinition,
     columns: Record<string, ColumnDefinition>,
@@ -736,6 +781,9 @@ export class SchemaGenerator {
       });
     }
 
+    // Tenancy injects `tenant_id` but nothing indexes it (#2356).
+    this.ensureTenantIdIndex(indexes, columns, tableName);
+
     return {
       tableName,
       columns,
@@ -1052,6 +1100,9 @@ export class SchemaGenerator {
       });
     }
 
+    // Tenancy injects `tenant_id` but nothing indexes it (#2356).
+    this.ensureTenantIdIndex(indexes, columns, tableName);
+
     return {
       tableName,
       columns,
@@ -1273,6 +1324,10 @@ export class SchemaGenerator {
     }
 
     // Generate DDL
+    // Tenancy injects `tenant_id` but nothing indexes it (#2356). Added
+    // before the DDL is rendered so the emitted SQL creates it too.
+    this.ensureTenantIdIndex(indexes, columns, tableName);
+
     const schemaDefinition: SchemaDefinition = {
       tableName,
       columns: this.convertManifestColumnsToSchemaColumns(columns),
@@ -1449,6 +1504,10 @@ export class SchemaGenerator {
     }
 
     // Generate DDL
+    // Tenancy injects `tenant_id` but nothing indexes it (#2356). Added
+    // before the DDL is rendered so the emitted SQL creates it too.
+    this.ensureTenantIdIndex(indexes, columns, tableName);
+
     const schemaDefinition: SchemaDefinition = {
       tableName,
       columns: this.convertManifestColumnsToSchemaColumns(columns),


### PR DESCRIPTION
Closes #2356

## Problem

Tenancy injects a `tenant_id` column but nothing indexes it. `SchemaGenerator` auto-creates indexes for foreign keys, unique columns, `updated_at` and the STI discriminator — `tenant_id` is in none of those categories, so tenant-scoped tables get the column with no index behind it and every tenant-scoped read scans the whole multi-tenant table.

Measured in one production database:

| | count |
|---|---:|
| tables carrying `tenant_id` | 212 |
| with an index leading on `tenant_id` | 48 |
| **without** | **164** |

The 48 that had one got it incidentally, from `conflictColumns` unique indexes that happen to start on `tenant_id`. Largest unindexed tables: `fact_subjects` (100,207 rows / 47 MB), `events` (42,721 / 46 MB), `facts` (49,859 / 42 MB).

Benchmarked on a `contents`-shaped table at 120,003 rows / 202 tenants (Postgres 17), for `WHERE tenant_id = ? AND status IN (...) ORDER BY <date> DESC LIMIT 10`:

| | plan | buffers | time |
|---|---|---:|---:|
| no index | Parallel Seq Scan + top-N sort | 35,576 | 21.2 ms |
| leading `tenant_id` index | Index Scan | 163 | 0.79 ms |

## Fix

`ensureTenantIdIndex()` runs on all four schema paths (build-time AST, registry, STI-from-manifest, CTI-from-manifest) and keys off the column's `referenceKind === 'tenantId'` — the metadata tenancy sets wherever it injects the column.

It only adds an index when none already **leads** with that column. A table whose `conflictColumns` index already starts on `tenant_id` is left alone rather than carrying a redundant duplicate that would only cost writes. This also composes with #2357: once a composite `(tenant_id, <sort column>)` can be declared, declaring one suppresses the standalone automatically.

## Validation

- `@happyvertical/smrt-core` — **3,258 tests passed**, 6 files skipped
- 3 new tests: indexes a tenancy-injected column; adds nothing for a non-tenant-scoped object; does not duplicate when an index already leads with `tenant_id`
- verified against real packages: **18 of 18** tenant-scoped tables across `smrt-content`, `smrt-users` and `smrt-events` now carry a leading tenant index

## Notes

Indexes reach the database through `schema.indexes`, which the migration orchestrator renders per dialect — `schema.ddl` is `CREATE TABLE` only and never carried indexes for any index, new or existing. That asymmetry is a real defect but a separate one, filed as **#2358**; it does not affect this change, because the `db:migrate` path emits `strategy.generateIndexes(schema)` for added tables.

No changeset is committed — AGENTS.md:39 says release automation generates them on merge.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","policy_revision":"1.0.0","runtime":"claude","session":"2e828b4a-bf86-463b-8159-3ee4e9f1275f","issue":"https://github.com/happyvertical/smrt/issues/2356"}
```

