### PR TITLE
fix(deps): override deepmerge-ts <8.0.0 for GHSA-ggr8-5vv4-36mx

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,7 @@ overrides:
   markdown-it@<14.1.2: 14.3.0
   body-parser@<2.3.0: 2.3.0
   sharp@<0.35.0: 0.35.3
+  deepmerge-ts@<8.0.0: 8.0.1
 
 importers:
 
@@ -6828,8 +6829,8 @@ packages:
   dedent-js@1.0.1:
     resolution: {integrity: sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==}
 
-  deepmerge-ts@7.1.5:
-    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+  deepmerge-ts@8.0.1:
+    resolution: {integrity: sha512-szCXE7YLCvLKR9bFPJcvsezOShdalctSvrgN/LM/QGUEPZQajwjmsMObZ6/DuANT5lxzM/wtO8Feubwdkz8myA==}
     engines: {node: '>=16.0.0'}
 
   deepmerge@4.3.1:
@@ -14245,7 +14246,7 @@ snapshots:
 
   dedent-js@1.0.1: {}
 
-  deepmerge-ts@7.1.5: {}
+  deepmerge-ts@8.0.1: {}
 
   deepmerge@4.3.1: {}
 
@@ -15082,7 +15083,7 @@ snapshots:
   html-to-text@10.0.0:
     dependencies:
       '@selderee/plugin-htmlparser2': 0.12.0(selderee@0.12.0)
-      deepmerge-ts: 7.1.5
+      deepmerge-ts: 8.0.1
       dom-serializer: 2.0.0
       htmlparser2: 10.1.0
       selderee: 0.12.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -90,6 +90,17 @@ overrides:
   # these use, so a single unified pin is preferred over shipping three
   # vulnerable copies.
   'sharp@<0.35.0': 0.35.3
+  # deepmerge-ts <8.0.0 exhausts the stack on recursive object graphs
+  # (GHSA-ggr8-5vv4-36mx). It reaches the tree only through
+  # packages/messages -> @happyvertical/email -> mailparser -> html-to-text,
+  # and html-to-text@10.0.0 is already the latest release while still declaring
+  # `deepmerge-ts: ^7.1.5`, so there is nothing to upgrade to. html-to-text
+  # imports only `deepmergeCustom`, which 8.x still exports with the same dual
+  # CJS/ESM entry points and `node >=16` engine; 8.0.0's breaking changes are
+  # type-level renames plus `deepmergeInto`/map-merge semantics it never uses.
+  # Verified: html-to-text conversion output is byte-identical on 7.1.5 and
+  # 8.0.1 across default, wordwrap, selector-composition, and limits paths.
+  'deepmerge-ts@<8.0.0': 8.0.1
 
 auditConfig:
   # Every entry here suppresses an advisory for the WHOLE tree, including future


### PR DESCRIPTION
Closes #2385

## Problem

`pnpm audit --audit-level=high` — the `Dependency Vulnerability Audit` job, and therefore
`Required CI` — started failing on every open PR in the repo on **GHSA-ggr8-5vv4-36mx**
("DeepmergeTS has stack exhaustion when merging recursive object graphs", vulnerable
`<8.0.0`, patched `>=8.0.0`). It was the only high/critical advisory in the tree.

Single path, entering through one workspace package:

```
packages/messages > @happyvertical/email > mailparser@3.9.9 > html-to-text@10.0.0 > deepmerge-ts@7.1.5
```

## Why an override and not an upgrade

`html-to-text@10.0.0` is **already the latest published release** and still declares
`deepmerge-ts: ^7.1.5`, so there is no direct-consumer upgrade to move to. `mailparser` and
`@happyvertical/email` are both upstream-owned. The pin has to come from this repo.

The suppression fallback (`auditConfig.ignoreGhsas` + an `audit-policy.json` record) was
**not** used — the advisory is genuinely resolved, so `ignoreGhsas` stays `[]` and
`audit-policy.json` is untouched.

## Fix

One root `pnpm-workspace.yaml` override, with the selector written against the **advisory
range** rather than the version resolved today, so it keeps protecting if the advisory
widens (per AGENTS.md / #2028):

```yaml
'deepmerge-ts@<8.0.0': 8.0.1
```

## Compatibility — verified, not assumed

- `html-to-text@10` imports exactly one symbol, `deepmergeCustom`, which 8.x still exports
  (8.x's export list is a superset of 7.x's).
- `deepmerge-ts@8.0.1` keeps the **identical** dual CJS/ESM `exports` map and `node >=16`
  engine as 7.1.5 — it is not ESM-only, so `html-to-text`'s CJS entry still resolves.
- 8.0.0's breaking changes are type-level renames (`DeepMergeMetaMetaData` →
  `DeepMergeMergeInfo`, the `metaMeta` callback parameter → `mergeInfo`) plus
  `deepmergeInto` leak-mutation and map-merge semantics. `html-to-text` uses none of them:
  it only builds two `deepmergeCustom` instances with `filterValues`/`mergeArrays`/
  `metaDataUpdater`, all positional at runtime.
- **Empirical check:** ran `html-to-text@10.0.0` against `deepmerge-ts@7.1.5` and `8.0.1`
  side by side over the default, `wordwrap`, selector-composition (the root-`selectors`
  `keyPath` `metaDataUpdater` path), nested per-selector option merge, non-root
  array-overwrite, `compile()`, and `limits` cases. Output was **byte-identical**; the only
  diff between the two runs was the version banner.

## Validation

| Check | Result |
| --- | --- |
| `pnpm audit --audit-level=high` | exit 0, no high/critical (was 1 high) |
| `pnpm audit:policy` / `node scripts/check-audit-policy.mjs` | 5 accepted records, **0 suppressions**, none past recheck |
| `pnpm-lock.yaml` | single `deepmerge-ts@8.0.1`, no 7.x copy left |
| `node scripts/check-standards.mjs` | 64 packages, 0 violations |
| `@happyvertical/smrt-messages` build | 17/17 tasks successful |
| `@happyvertical/smrt-messages` test | 19 files passed, 1 skipped; 269 passed, 15 skipped |
| `@happyvertical/smrt-messages` typecheck | 1253 files, 0 errors |

The acceptance test for this PR is its own `Dependency Vulnerability Audit` job.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","policy_revision":"1.0.0","runtime":"claude","session":"bb4c7a21-74b8-4fce-972c-107c341951d9","issue":"https://github.com/happyvertical/smrt/issues/2385"}
```
