### PR TITLE
docs(core): record schema-path invariants and #2382 agent lessons

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -208,7 +208,7 @@ local development and watch mode.
 
 Production DDL comes from the **manifest** paths
 (`generateSTISchemaFromManifest`/`generateCTISchemaFromManifest`, selected in
-`scanner/manifest-generator.ts` → registered `schema` → `db:migrate`). The
+`src/scanner/manifest-generator.ts` → registered `schema` → `db:migrate`). The
 **registry** paths feed `getTestDatabase()` and emit foreign-key indexes
 production never gets: the suite runs on a richer schema than it ships.
 
@@ -228,7 +228,7 @@ production never gets: the suite runs on a richer schema than it ships.
 - **Filesystem support is a lazy boundary (#1979)**: `SmrtClass` acquires `options.fs` adapters via `createFilesystemAdapter()` (`src/filesystem-loader.ts`), never a static `@happyvertical/files` import — the files SDK statically pulls @aws-sdk/client-s3 and reaches googleapis, and a static edge here would land it in every downstream SSR bundle. Node/tsx/vite-dev runtimes resolve it on first use; fully-bundled deployments import `@happyvertical/smrt-core/filesystem` at startup. Use `importOptionalDependency()` (`src/lazy-external.ts`) for any similar optional heavyweight dependency.
 - **Never override toJSON()** — handles STI discriminator + meta field extraction. Use `transformJSON()`
 - **Property init order**: TypeScript initializers run first, then `initialize()` applies option values (options win)
-- **No runtime schema creation**: application tables must be prepared explicitly via migrations/tooling; runtime verification is `tableExists()` only (`schema/table-verifier.ts`) — no column, type, or index check
+- **No runtime schema creation**: application tables must be prepared explicitly via migrations/tooling; runtime verification is `tableExists()` only (`src/schema/table-verifier.ts`) — no column, type, or index check
 - **Retry logic**: `db.get()` (3 retries, 250ms) and `db.upsert()` (3 retries, 500ms) have built-in retry
 - **Field caching**: `_cachedFields` populated during `Collection.create()` — eliminates async `getFields()` per query
 - **Smart cloning**: arrays/objects shallow-cloned in property init to prevent aliasing (Issue #22)

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -17,6 +17,7 @@ subsystem you are editing. This file keeps what holds across all of them.
 | `src/change-feed.ts` | the adapter-agnostic change-observation spine — `_smrt_changes`, cursors, table versions, generated `_changes` routes, retention | [agents/change-feed.md](agents/change-feed.md) |
 | `src/change-signals.ts` + the generated `_events` SSE route | the push companion to the change feed — the signal bus, cross-replica fan-out, the SSE route, and its documented gaps | [agents/change-signals.md](agents/change-signals.md) |
 | `src/generators/` + `src/vite-plugin/web-collections.ts` | REST/CLI/MCP/web-collection generation, the `manifestHash` emission sites, and generated conditional-GET / ETag v2 semantics | [agents/generators.md](agents/generators.md) |
+| `src/schema/` | the five `SchemaGenerator` entry points, which two reach production, why schema drift stayed invisible, and the #2382 index/tenancy rules | [agents/schema-paths.md](agents/schema-paths.md) |
 
 ## SmrtObject Lifecycle
 
@@ -203,12 +204,31 @@ byte/provenance/path/content drift, skips scans and manifest writes, and still
 generates routes, types, registration, and virtual modules. Omit it for normal
 local development and watch mode.
 
+## Schema paths (#2382)
+
+Production DDL comes from the **manifest** paths
+(`generateSTISchemaFromManifest`/`generateCTISchemaFromManifest`, selected in
+`scanner/manifest-generator.ts` → registered `schema` → `db:migrate`). The
+**registry** paths feed `getTestDatabase()` and emit foreign-key indexes
+production never gets: the suite runs on a richer schema than it ships.
+
+- Change column/index emission on every shipping path, proven by a path-parity
+  test (#2359 adds one). A "same as migrations" comment is a claim to check.
+- Every new query predicate ships with its index, or a reason it doesn't.
+- Numeric types, uuid casts, conflict targets, timestamps, migrations: run the
+  `test:postgres` lane — SQLite affinity accepts what PostgreSQL rejects.
+- Read `dist/manifest.json`/regenerated schemas for what a decorator produced;
+  count across all packages instead of sampling.
+- Tenant scoping is whole-path: every unique constraint and conflict target on a
+  tenant-scoped table carries the tenant column, and every read path — not only
+  `list()` — is interceptor-aware.
+
 ## Gotchas
 
 - **Filesystem support is a lazy boundary (#1979)**: `SmrtClass` acquires `options.fs` adapters via `createFilesystemAdapter()` (`src/filesystem-loader.ts`), never a static `@happyvertical/files` import — the files SDK statically pulls @aws-sdk/client-s3 and reaches googleapis, and a static edge here would land it in every downstream SSR bundle. Node/tsx/vite-dev runtimes resolve it on first use; fully-bundled deployments import `@happyvertical/smrt-core/filesystem` at startup. Use `importOptionalDependency()` (`src/lazy-external.ts`) for any similar optional heavyweight dependency.
 - **Never override toJSON()** — handles STI discriminator + meta field extraction. Use `transformJSON()`
 - **Property init order**: TypeScript initializers run first, then `initialize()` applies option values (options win)
-- **No runtime schema creation**: application tables must be prepared explicitly via migrations/tooling; runtime only verifies and fails clearly
+- **No runtime schema creation**: application tables must be prepared explicitly via migrations/tooling; runtime verification is `tableExists()` only (`schema/table-verifier.ts`) — no column, type, or index check
 - **Retry logic**: `db.get()` (3 retries, 250ms) and `db.upsert()` (3 retries, 500ms) have built-in retry
 - **Field caching**: `_cachedFields` populated during `Collection.create()` — eliminates async `getFields()` per query
 - **Smart cloning**: arrays/objects shallow-cloned in property init to prevent aliasing (Issue #22)

--- a/packages/core/agents/schema-paths.md
+++ b/packages/core/agents/schema-paths.md
@@ -17,9 +17,9 @@ produce the same schema for the same class.
 
 | Entry point | Selected by | Status |
 |---|---|---|
-| `generateSTISchemaFromManifest` | `scanner/manifest-generator.ts` | **production** |
-| `generateCTISchemaFromManifest` | `scanner/manifest-generator.ts` | **production** |
-| `generateSTISchemaFromRegistry` | `testing/database.ts` (`getTestDatabase()`), `schema/utils.ts` (`generateSchema`; `ensureSchema` only as a fallback) | tests + runtime helpers |
+| `generateSTISchemaFromManifest` | `src/scanner/manifest-generator.ts` | **production** |
+| `generateCTISchemaFromManifest` | `src/scanner/manifest-generator.ts` | **production** |
+| `generateSTISchemaFromRegistry` | `src/testing/database.ts` (`getTestDatabase()`), `src/schema/utils.ts` (`generateSchema`; `ensureSchema` only as a fallback) | tests + runtime helpers |
 | `generateSchemaFromRegistry` | the same two callers | tests + runtime helpers |
 | `generateSchema` (AST) | the `smrt:schema` virtual module, which has no consumer | dead (#2380) |
 
@@ -31,14 +31,14 @@ Production DDL takes the manifest route:
                  ├─▶ smrt db:migrate | db:diff | db:status
                  │     (the CLI drives SchemaComparer + MigrationTracker directly)
                  └─▶ migrateSmrtSchemas() / getPendingSchemaStatements()
-                       (migrations/orchestrate.ts — exported for programmatic use;
-                        no in-repo caller outside its own tests)
+                       (src/migrations/orchestrate.ts — exported for programmatic
+                        use; no in-repo caller outside its own tests)
 ```
 
 The suite takes the registry route, and the registry route emits indexes the
 manifest route does not — per-column foreign-key indexes, and STI partial FK
 indexes filtered by `_meta_type`. Tests therefore run against a richer schema
-than any deployment receives. `testing/database.ts`'s "Generate schema using
+than any deployment receives. `src/testing/database.ts`'s "Generate schema using
 SchemaGenerator (same as migrations)" comment describes an intent, not the code.
 
 The manifest STI path even populates a `fkColumnsByClass` map and never reads it
@@ -48,7 +48,7 @@ FK loop at all. Both manifest paths then skip the explicit
 "FK columns and unique columns get their own indexes", which holds on the
 registry paths and not on this one.
 
-`schema/utils.ts` sits in between, and the two exports differ:
+`src/schema/utils.ts` sits in between, and the two exports differ:
 
 - `generateSchema()` (reached from `SmrtCollection.generateSchema()`) always
   rebuilds from the registry and writes the result back into the registry,
@@ -59,22 +59,23 @@ registry paths and not on this one.
   `generateSchema()` when no schema is registered at all.
 
 So a normal build keeps the manifest schema through `db:setup`, and a
-registry-derived schema is usually a test/dev artifact — but not always. One
-shipping consumer takes the registry route at runtime: `smrt-content`'s
-`src/hooks.server.ts` `bootstrapSchema()` calls `generateSchema()` for every
-registered class and then `ensureSchema()`, from the SvelteKit `handle` hook on
-any `/api/*` request, with no dev-mode gate despite the file header. In that
-process `getAllSchemasAsDefinitions()` returns registry-derived schemas. Always
-check which route a process actually took before trusting a reproduction.
+registry-derived schema is a dev/test artifact. `smrt-content` shows what one
+looks like: `packages/content/src/hooks.server.ts` `bootstrapSchema()` calls
+`generateSchema()` for every registered class and then `ensureSchema()` from the
+SvelteKit `handle` hook on any `/api/*` request, so that process holds
+registry-derived schemas rather than the manifest ones. It reaches only that
+package's own `vite dev` app — the library build excludes the file and the
+package never exports it — but it is the shape to recognize. Check which route a
+process actually took before trusting a reproduction.
 
 ## Why the drift stayed invisible
 
 Every drift oracle compares a database with the same artifact that dropped the
 index:
 
-- `verifyPersistenceTable()` (`schema/table-verifier.ts`) calls `db.tableExists()`
-  and nothing else. "Runtime verifies schema" has always meant existence-only —
-  no column, type, constraint, or index comparison.
+- `verifyPersistenceTable()` (`src/schema/table-verifier.ts`) calls
+  `db.tableExists()` and nothing else. "Runtime verifies schema" has always meant
+  existence-only — no column, type, constraint, or index comparison.
 - `smrt doctor` never opens a database connection.
 - `db:status` and `db:diff` diff the live database against
   `getAllSchemasAsDefinitions()`, i.e. the manifest projection.
@@ -107,11 +108,16 @@ spread on the assessed workload was 21 ms → 0.1 ms.
 
 ### 3. Run the PostgreSQL lane
 
-Anything touching numeric types, uuid casts, upsert conflict targets,
-timestamps, or migrations runs `pnpm --filter @happyvertical/smrt-<pkg>
-test:postgres` (core, cli, users, sales, marketing, analytics, and vitest carry
-the lane). SQLite's type affinity accepts values PostgreSQL rejects — a money
-field declared `number = 0` compiles to INTEGER and only fails on PG (#2361).
+Anything touching numeric types, uuid casts, upsert conflict targets, timestamps,
+or migrations runs the package's `test:postgres` script:
+
+```bash
+pnpm --filter @happyvertical/smrt-<pkg> test:postgres
+```
+
+core, cli, users, sales, marketing, analytics, and vitest carry the lane.
+SQLite's type affinity accepts values PostgreSQL rejects — a money field declared
+`number = 0` compiles to INTEGER and only fails on PG (#2361).
 
 ### 4. Read the built artifact, not the source
 

--- a/packages/core/agents/schema-paths.md
+++ b/packages/core/agents/schema-paths.md
@@ -1,0 +1,176 @@
+# smrt-core/schema paths
+
+Module semantics for `src/schema/` — which `SchemaGenerator` entry point reaches
+a real database, what each one emits, and the rules that keep them in step.
+Package orientation, the cross-module invariants, and the traps that apply
+before editing anything live in [../AGENTS.md](../AGENTS.md) — read that first;
+its "Schema paths" section is the short form of everything below.
+
+Written from the 2026-08-17 database-layer gap assessment (epic #2382). Symbol
+names here are stable; the line numbers the assessment quotes are not, so trust
+this call graph and re-grep before citing a location.
+
+## Five entry points, two of which ship
+
+`src/schema/generator.ts` exposes five index-emitting entry points. They do not
+produce the same schema for the same class.
+
+| Entry point | Selected by | Status |
+|---|---|---|
+| `generateSTISchemaFromManifest` | `scanner/manifest-generator.ts` | **production** |
+| `generateCTISchemaFromManifest` | `scanner/manifest-generator.ts` | **production** |
+| `generateSTISchemaFromRegistry` | `testing/database.ts` (`getTestDatabase()`), `schema/utils.ts` (`generateSchema`; `ensureSchema` only as a fallback) | tests + runtime helpers |
+| `generateSchemaFromRegistry` | the same two callers | tests + runtime helpers |
+| `generateSchema` (AST) | the `smrt:schema` virtual module, which has no consumer | dead (#2380) |
+
+Production DDL takes the manifest route:
+
+```
+@smrt() class ─▶ scanner ─▶ manifest.json ─▶ generate{STI,CTI}SchemaFromManifest
+              ─▶ registered `schema` ─▶ ObjectRegistry.getAllSchemasAsDefinitions()
+                 ├─▶ smrt db:migrate | db:diff | db:status
+                 │     (the CLI drives SchemaComparer + MigrationTracker directly)
+                 └─▶ migrateSmrtSchemas() / getPendingSchemaStatements()
+                       (migrations/orchestrate.ts — exported for programmatic use;
+                        no in-repo caller outside its own tests)
+```
+
+The suite takes the registry route, and the registry route emits indexes the
+manifest route does not — per-column foreign-key indexes, and STI partial FK
+indexes filtered by `_meta_type`. Tests therefore run against a richer schema
+than any deployment receives. `testing/database.ts`'s "Generate schema using
+SchemaGenerator (same as migrations)" comment describes an intent, not the code.
+
+The manifest STI path even populates a `fkColumnsByClass` map and never reads it
+— only its registry counterpart iterates one — and the manifest CTI path has no
+FK loop at all. Both manifest paths then skip the explicit
+`@foreignKey(X, { indexed: true })` opt-in — the CTI one under a comment claiming
+"FK columns and unique columns get their own indexes", which holds on the
+registry paths and not on this one.
+
+`schema/utils.ts` sits in between, and the two exports differ:
+
+- `generateSchema()` (reached from `SmrtCollection.generateSchema()`) always
+  rebuilds from the registry and writes the result back into the registry,
+  replacing whatever the manifest registered for that class.
+- `ensureSchema()` (reached from the deprecated `smrt db:setup`) is
+  manifest-first: it takes `ObjectRegistry.getSchema()` plus the merged
+  `getAllSchemasAsDefinitions()` table definition, and only falls back to
+  `generateSchema()` when no schema is registered at all.
+
+So a normal build keeps the manifest schema through `db:setup`, and a
+registry-derived schema is usually a test/dev artifact — but not always. One
+shipping consumer takes the registry route at runtime: `smrt-content`'s
+`src/hooks.server.ts` `bootstrapSchema()` calls `generateSchema()` for every
+registered class and then `ensureSchema()`, from the SvelteKit `handle` hook on
+any `/api/*` request, with no dev-mode gate despite the file header. In that
+process `getAllSchemasAsDefinitions()` returns registry-derived schemas. Always
+check which route a process actually took before trusting a reproduction.
+
+## Why the drift stayed invisible
+
+Every drift oracle compares a database with the same artifact that dropped the
+index:
+
+- `verifyPersistenceTable()` (`schema/table-verifier.ts`) calls `db.tableExists()`
+  and nothing else. "Runtime verifies schema" has always meant existence-only —
+  no column, type, constraint, or index comparison.
+- `smrt doctor` never opens a database connection.
+- `db:status` and `db:diff` diff the live database against
+  `getAllSchemasAsDefinitions()`, i.e. the manifest projection.
+
+An index the manifest never emitted is "in sync" by construction. That is how a
+production database reached 164 unindexed `tenant_id` columns while `db:status`
+reported no drift (#2356 → #2359). The assessment's other counts — 196/231
+`@foreignKey` and 91/92 `@crossPackageRef` columns with no production index,
+238/238 tables carrying a redundant index on the primary key, zero DB-level
+foreign-key constraints on any engine — come from regenerating every package's
+schema against a live database, so re-measure rather than quote them once the
+epic's fixes land.
+
+## Rules
+
+### 1. Verify against the production path, not the test path
+
+Any change to column or index emission goes on **all** paths that ship and is
+proven by a path-parity test. #2359 adds that test under `src/schema/`; until it
+lands, assert the parity yourself in the nearest generator test — a green suite
+otherwise proves the registry paths only. Read the call graph before believing a
+comment: "same as migrations" was wrong for years.
+
+### 2. Every new query predicate ships with its index
+
+Collection methods, poll loops, auth lookups, junction right-side filters, and
+polymorphic owner lookups all count — or write down why the predicate does not
+need one. For list workloads, EXPLAIN on a PostgreSQL snapshot; the measured
+spread on the assessed workload was 21 ms → 0.1 ms.
+
+### 3. Run the PostgreSQL lane
+
+Anything touching numeric types, uuid casts, upsert conflict targets,
+timestamps, or migrations runs `pnpm --filter @happyvertical/smrt-<pkg>
+test:postgres` (core, cli, users, sales, marketing, analytics, and vitest carry
+the lane). SQLite's type affinity accepts values PostgreSQL rejects — a money
+field declared `number = 0` compiles to INTEGER and only fails on PG (#2361).
+
+### 4. Read the built artifact, not the source
+
+What a decorator produced is in `dist/manifest.json` and in regenerated schemas:
+`integer` vs `decimal`, the actual index list, the actual conflict columns. When
+the question is "how many tables/columns/indexes", regenerate and count across
+every package; do not sample a few and extrapolate.
+
+### 5. Index intent belongs on both the constraint and the read path
+
+A conflict target is not automatically a unique index, and a unique index is not
+automatically the index a read path uses. Custom `conflictColumns` replace the
+`(slug, context)` index while `loadFromSlug`/`getId` still query slug+context;
+STI drops `@field({ unique: true })`. Check the pair, not the declaration.
+
+### 6. Multi-tenancy is a whole-path property
+
+Every unique constraint and every conflict target on a tenant-scoped table
+includes the tenant column — otherwise a second tenant's `save()` of the same
+natural key updates the first tenant's row through `DO UPDATE SET` (#2360). And
+every read path is interceptor-aware: hydration (`loadFromId`/`loadFromSlug`),
+get-by-slug, vector search, and collection memory, not only `list()` (#2365).
+
+### 7. Retry only transient errors
+
+Classify through the cause chain (SQLSTATE), never on a message substring, and
+never retry inside an aborted PostgreSQL transaction (`25P02`). Test the
+contract end to end against a real database, not only the classifier (#2366).
+
+### 8. Thread new decorator options through every config-rebuild site
+
+A new `@smrt()` or `@field()` option that affects schema must reach the
+`SchemaGeneratorConfig` type in `src/schema/generator.ts` and every site that
+rebuilds that config — `src/schema/utils.ts` and `src/testing/database.ts` — or
+it is silently dropped on the paths that rebuild it (#2357).
+
+### 9. Delete or wire dead paths, and write docs to what the code does
+
+Dead code that looks canonical misleads the next agent: the AST `generateSchema`
+path, `SchemaOverrideSystem`, and the never-emitted `triggers: []` all read as
+supported surfaces (#2380). Documentation follows the implementation, not the
+intent — say "verifies the table exists" when that is what runs.
+
+### 10. Untracked "known limitation" comments are bugs nobody will read
+
+File the issue and link it from the comment. A `products` comment explaining why
+a conflict-column change was refrained from sat there for months — and
+misdescribed the failure mode the whole time.
+
+### 11. Consumer repair scripts are signals
+
+Downstream repair tooling (anytown's `db-repair-plan.ts` carried column-type
+repairs, missing STI columns and indexes, and `tenant_id` backfills since April)
+is the consumer-side record of framework gaps. Mine it during triage.
+
+### 12. Try to falsify before filing, and treat operations as correctness
+
+Re-verify a finding at source before it becomes an issue — one assessment
+candidate claimed conflict indexes past two columns were narrowed to two
+columns, when only the index *name* is shortened. And an index fix that ships
+without a bounded-timeout, `CONCURRENTLY`-capable migrate path can take
+production down on rollout (#2362).


### PR DESCRIPTION
Closes #2381

The 2026-08-17 database-layer assessment (epic #2382) found one structural condition behind #2356 and #2358: the generator paths that produce production DDL are not the paths the suite exercises, and nothing compares a live database with what the model layer assumes. Those lessons lived only in the tracker. This puts them in the docs every agent loads.

## Change

**`packages/core/AGENTS.md`** — a new "Schema paths" section carrying the five load-bearing invariants inline (production = the manifest paths / tests = the registry paths, path parity, index-with-predicate, the PostgreSQL lane, built-artifact verification, whole-path tenancy), plus a Modules-table row pointing at the detail. It also corrects the "no runtime schema creation" gotcha to what the code does: runtime verification is `tableExists()` only (`schema/table-verifier.ts`) — no column, type, or index check.

**`packages/core/agents/schema-paths.md`** (new module doc) — the call graph for all five `SchemaGenerator` entry points and which two ship, why every drift oracle was blind to an index the manifest never emitted, and twelve rules distilled from the assessment.

Detail went into the module doc so the additive instruction chain stays small, per the root `AGENTS.md` split rule.

## Verified, not transcribed

Every claim was re-checked at source rather than copied out of the assessment:

- the five entry points in `schema/generator.ts`: `generateSchema` (AST), `generateSchemaFromRegistry`, `generateSTISchemaFromRegistry`, `generateSTISchemaFromManifest`, `generateCTISchemaFromManifest`
- `scanner/manifest-generator.ts` selects only the two `*FromManifest` paths; `testing/database.ts` and `schema/utils.ts` select the registry ones
- the manifest STI path populates `fkColumnsByClass` and never reads it (the registry STI path is that map's only consumer); the manifest CTI path has no FK loop; both skip the `@foreignKey(…, { indexed: true })` opt-in under a comment claiming FK columns "get their own indexes"
- `verifyPersistenceTable()` is `db.tableExists()` and nothing else
- no `REFERENCES` in `schema/ddl/*` or `migrations/differ.ts`; `triggers: []` on all four live paths; `SchemaOverrideSystem` exported but never called; the AST path feeds only the consumer-less `smrt:schema` virtual module
- `test:postgres` exists in core, cli, users, sales, marketing, analytics, and vitest

Two review passes — a local `codex review` and an independent claim-by-claim fact check of the draft against source — found five inaccuracies, each re-confirmed at source and fixed before this PR opened:

- `db:migrate`/`db:diff`/`db:status` drive `SchemaComparer` + `MigrationTracker` from the CLI and do **not** route through `migrations/orchestrate.ts`; that module has no caller outside its own tests, so the diagram now shows it as a separate exported API.
- `ensureSchema()` is manifest-first — it prefers `ObjectRegistry.getSchema()` and the merged definitions, falling back to the registry builder only when nothing is registered. `generateSchema()` is the one that always rebuilds and overwrites. The draft conflated them.
- The path-parity test does not exist yet; it is now described as forthcoming with #2359, with interim guidance to assert parity in the nearest generator test.
- The "FK columns and unique columns get their own indexes" comment lives only on the manifest CTI path, not on both.
- `smrt-content`'s `hooks.server.ts` `bootstrapSchema()` calls `generateSchema()` + `ensureSchema()` from the SvelteKit `handle` hook on every `/api/*` request. The doc now carries it as the concrete example of a process holding registry-derived rather than manifest-derived schemas.

The PR reviewers then caught two more, fixed in `8f54412c4`: in-package file references were missing the `src/` prefix the rest of the document uses, and the `pnpm --filter … test:postgres` inline code span was split across a newline so half of it rendered as plain text (both Copilot). Codex also correctly narrowed the `smrt-content` example — `packages/content/vite.config.ts` excludes `src/hooks.server.ts` from the library build and the package never exports it, so it reaches only that package's own `vite dev` app and is a dev/test example, not a shipping runtime path. The doc says so now.

## Doc budget

`packages/core` sits at 26,538 / 32,768 bytes of additive chain with 6,230 bytes of headroom, which leaves room for the one-line appends the other epic PRs make. That crosses the script's informational 80% notice — a warning, not a failure; `check:agents-chain` exits 0 — and the notice's own remedy (split per-module semantics into `agents/<module>.md`) is what this PR does.

## Validation

- `pnpm check:agents-chain` — pass
- `pnpm smrt dev:knowledge-check` — 0 errors, 0 warnings (core rebuilt first, since the knowledge artifact embeds these docs)
- `pnpm check:standards` — standards + README gates pass
- `pnpm test:ci-scripts` — 42 pass
- `@happyvertical/smrt-core` full suite — 266 files, **3255 passed**, 6 files / 46 tests skipped
- `@happyvertical/smrt-cli` `docs-claude`, `docs-claude-handler`, `dev-knowledge-handlers` — 48 pass (the tests that read `AGENTS.md`)
- lint is a no-op for this change: biome ignores markdown, verified by running `biome check` on both files

No source file changes, so typecheck and the PostgreSQL lanes are unaffected. No changeset is committed — release automation generates them on merge.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","policy_revision":"1.0.0","runtime":"claude","session":"2e828b4a-bf86-463b-8159-3ee4e9f1275f","issue":"https://github.com/happyvertical/smrt/issues/2381"}
```
