### PR TITLE
fix(cli): make db:rollback execute the recorded DOWN or refuse loudly

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -13,7 +13,8 @@ smrt db:migrate --postgres-safe # PostgreSQL concurrent-index mode (see below)
 smrt db:migrate --force-migration <exact-id> [--force-migration <exact-id>...] # Force exact generated migrations in one atomic batch
 smrt db:migrate-uuid         # Convert schema-declared UUID text columns after data remap
 smrt db:diff                 # Show schema differences without generating migration files
-smrt db:rollback             # Rollback migrations
+smrt db:rollback             # Roll back migrations by executing their recorded DOWN
+smrt db:rollback --mark-only # Record-only flip; schema deliberately untouched
 smrt docs:agents             # Generate .agents/smrt-framework.md
 smrt docs:claude             # Deprecated alias writing .claude/smrt-framework.md
 smrt dev:knowledge-*         # Deterministic agent knowledge index/check/diff
@@ -63,6 +64,36 @@ after that commit. This is the mode for large index rollouts.
   runs inside the atomic transaction (still bounded by the timeouts).
 - Without the flag, a batch containing explicit `CONCURRENTLY` DDL is rejected
   before the transaction opens — PostgreSQL cannot run it there.
+
+## `db:rollback` is execute-or-refuse
+
+Schema state is diff-driven: `db:migrate` derives every migration from the
+manifest at run time and stores **no SQL** in `_smrt_schema_migrations`. So
+`db:rollback` can only honour the one DOWN script that is reconstructible from
+a tracking row — `create_table_<table>` → `DROP TABLE IF EXISTS "<table>"`,
+the exact statement `db:migrate` records for `diff.added_tables`.
+
+- Rows with a reconstructible DOWN are **executed** through
+  `MigrationTracker.rollback` (transactional), then marked `rolled_back`.
+- Anything else is **refused**: non-zero exit, an error naming each migration
+  and why, and no row touched. Refusal is all-or-nothing across the selected
+  set — a partial revert would leave the chain in a state the remaining DOWN
+  scripts were not written against. This includes rows recorded
+  `is_reversible` under a caller-chosen name: reversible at apply time, but the
+  SQL was never persisted, so it cannot be replayed (#2378).
+- `--mark-only` is the explicit opt-in for the record-only flip (for an
+  operator who already reverted the schema by hand). It says in its own output
+  that the schema was not changed, and it is the only path that moves a row
+  without running DDL.
+- A failed DOWN stops the batch; the migrations behind it are reported
+  `Not attempted` and left `completed`.
+- `--dry-run` previews the DOWN statements and still exits non-zero when the
+  real run would refuse. Both `--dry-run` and `--mark-only` are declared
+  kebab-cased, so handlers must read `options['dry-run']` / `options['mark-only']`
+  (`parseCliArgs` returns keys verbatim — the #1385 data-loss class).
+
+Reverting a non-`create_table` change is a forward operation: update the
+`@smrt` object definitions and run `db:migrate` again.
 
 ## Architecture
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -48,7 +48,8 @@ The four snapshot options are atomic: supplying any one requires all four.
 | `smrt db:migrate --force-migration <exact-id> [--force-migration <exact-id>...]` | Force one or more exact generated migrations in one atomic batch while preserving every other guard |
 | `smrt db:migrate-uuid` | Convert schema-declared UUID text columns to native PostgreSQL uuid after data has been remapped |
 | `smrt db:diff` | Show schema differences without generating migration files |
-| `smrt db:rollback` | Rollback last migration |
+| `smrt db:rollback` | Roll back the last migration by executing its recorded DOWN script; refuses when no DOWN script exists |
+| `smrt db:rollback --mark-only` | Record-only: mark migrations rolled back without running any DOWN script (schema untouched) |
 | `smrt db:history` | Show migration history with active-vs-superseded failure classification |
 
 File-backed SQL/TypeScript migration generation is not supported. s-m-r-t schema

--- a/packages/cli/src/commands/__tests__/db-rollback.test.ts
+++ b/packages/cli/src/commands/__tests__/db-rollback.test.ts
@@ -246,9 +246,11 @@ describe('db:rollback (real SQLite)', () => {
       const parsed = lastJson();
       expect(process.exitCode).toBe(1);
       expect(parsed.error).toContain('Refusing to roll back');
-      expect(parsed.nonReversible).toEqual([
+      expect(parsed.unrecoverable).toEqual([
         { name: 'jn_one', reason: 'was applied without a DOWN script' },
       ]);
+      // Back-compat: the pre-#2378 payload listed plain names under this key.
+      expect(parsed.nonReversible).toEqual(['jn_one']);
       expect(parsed.guidance.join(' ')).toContain('--mark-only');
       expect((await statusByName()).jn_one).toBe('completed');
     });
@@ -273,10 +275,13 @@ describe('db:rollback (real SQLite)', () => {
 
       const parsed = lastJson();
       expect(process.exitCode).toBe(1);
-      expect(parsed.nonReversible[0].name).toBe('custom_one');
-      expect(parsed.nonReversible[0].reason).toContain(
+      expect(parsed.unrecoverable[0].name).toBe('custom_one');
+      expect(parsed.unrecoverable[0].reason).toContain(
         'cannot be reconstructed',
       );
+      // A row the tracking table calls reversible still lands in the
+      // compat key, because this run cannot reverse it either.
+      expect(parsed.nonReversible).toEqual(['custom_one']);
       expect(await tableExists('custom_tbl')).toBe(true);
     });
 
@@ -502,6 +507,23 @@ describe('db:rollback (real SQLite)', () => {
 
     expect(process.exitCode).toBe(1);
     expect(errorOutput()).toContain('Refusing to roll back');
+    const history = await readHistory();
+    expect(history.every((m) => m.status === 'completed')).toBe(true);
+  });
+
+  it('marks an unrecoverable migration with ⊘ in --dry-run --mark-only output', async () => {
+    // The only preview that lists an unrecoverable row: without --mark-only the
+    // run refuses before reaching the dry-run listing.
+    await seedMigrations([nonReversibleDef('dm_one')]);
+
+    await dbRollbackCommand.handler([], {
+      dryRun: true,
+      markOnly: true,
+      force: true,
+    });
+
+    expect(output()).toContain('⊘ dm_one (no DOWN script)');
+    expect(output()).not.toContain('↩ dm_one');
     const history = await readHistory();
     expect(history.every((m) => m.status === 'completed')).toBe(true);
   });

--- a/packages/cli/src/commands/__tests__/db-rollback.test.ts
+++ b/packages/cli/src/commands/__tests__/db-rollback.test.ts
@@ -1,12 +1,13 @@
-import { rmSync } from 'node:fs';
+import { readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { clearCache, setConfig } from '@happyvertical/smrt-config';
 import { MigrationTracker } from '@happyvertical/smrt-core/migrations';
 import { getDatabase } from '@happyvertical/sql';
 import { parseCliArgs } from '@happyvertical/utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { dbRollbackCommand } from '../db-rollback.js';
+import { dbRollbackCommand, recoverDownStatements } from '../db-rollback.js';
 
 // The command prompts via node:readline/promises when not forced. Stub the
 // module so the "confirm"/"decline" branches can be exercised deterministically
@@ -27,29 +28,51 @@ vi.mock('node:readline/promises', () => ({
  * `finally`), so each test uses a unique on-disk SQLite file that the command
  * and the test both open by URL — letting us pre-seed real migration history
  * with the real MigrationTracker, run the command, then re-open the file to
- * assert how it mutated the `_smrt_schema_migrations` rows.
+ * assert how it mutated the `_smrt_schema_migrations` rows *and* the schema.
  *
- * Note on reversibility: the command builds a synthetic rollback definition with
- * an empty `down`, so a row recorded as reversible (a real `down` was present at
- * apply time) FAILS the tracker rollback, while a non-reversible row (applied
- * with an empty `down`) is force-marked `rolled_back`. The tests below seed each
- * kind deliberately to drive both branches.
+ * Regression contract for #2378: the command must never report a rollback it
+ * did not perform. A migration whose DOWN script cannot be recovered is
+ * refused (non-zero exit, row untouched); a `create_table_<table>` migration
+ * has its recorded `DROP TABLE IF EXISTS "<table>"` actually executed; and the
+ * old record-only flip survives only behind the explicit `--mark-only` flag,
+ * which says in its own output that the schema was not changed.
  */
 describe('db:rollback (real SQLite)', () => {
   let dbUrl: string;
   let logSpy: ReturnType<typeof vi.spyOn>;
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
-  function reversibleDef(id: string) {
+  /**
+   * Mirrors what `db:migrate` records for `diff.added_tables`: the name
+   * `create_table_<table>` and the DOWN `DROP TABLE IF EXISTS "<table>"`.
+   * This is the only migration class with a recoverable DOWN.
+   */
+  function createTableDef(table: string) {
+    return {
+      id: `create_table_${table}`,
+      description: `Create table ${table}`,
+      version: '1.0.0',
+      up: [`CREATE TABLE ${table} (id TEXT PRIMARY KEY)`],
+      down: [`DROP TABLE IF EXISTS "${table}"`],
+    };
+  }
+
+  /**
+   * A reversible migration applied under a caller-chosen name: its DOWN SQL
+   * lives nowhere in `_smrt_schema_migrations`, so the command cannot
+   * reconstruct it.
+   */
+  function customReversibleDef(id: string, table: string) {
     return {
       id,
       description: `Migration ${id}`,
       version: '1.0.0',
-      up: [`CREATE TABLE ${id} (id TEXT PRIMARY KEY)`],
-      down: [`DROP TABLE ${id}`],
+      up: [`CREATE TABLE ${table} (id TEXT PRIMARY KEY)`],
+      down: [`DROP TABLE IF EXISTS "${table}"`],
     };
   }
 
+  /** What every non-`create_table_*` auto-migration looks like: no DOWN. */
   function nonReversibleDef(id: string) {
     return {
       id,
@@ -65,7 +88,7 @@ describe('db:rollback (real SQLite)', () => {
   }
 
   async function seedMigrations(
-    defs: Array<ReturnType<typeof reversibleDef>>,
+    defs: Array<ReturnType<typeof createTableDef>>,
   ): Promise<void> {
     const db = await freshDb();
     const tracker = new MigrationTracker({ db });
@@ -85,6 +108,23 @@ describe('db:rollback (real SQLite)', () => {
     const history = await tracker.getHistory({ limit: 100 });
     await db.close?.();
     return history.map((m: any) => ({ name: m.name, status: m.status }));
+  }
+
+  async function statusByName(): Promise<Record<string, string>> {
+    return Object.fromEntries(
+      (await readHistory()).map((m) => [m.name, m.status]),
+    );
+  }
+
+  /** Ground truth for "did the schema actually change?". */
+  async function tableExists(name: string): Promise<boolean> {
+    const db = await freshDb();
+    const result = await db.query(
+      `SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
+      name,
+    );
+    await db.close?.();
+    return result.rows.length > 0;
   }
 
   beforeEach(() => {
@@ -118,8 +158,8 @@ describe('db:rollback (real SQLite)', () => {
     return logSpy.mock.calls.map((call) => call.join(' ')).join('\n');
   }
 
-  // JSON mode can emit multiple JSON documents (e.g. a non-reversible warning
-  // followed by the final summary); the meaningful payload is the last one.
+  // JSON mode can emit multiple JSON documents; the meaningful payload is the
+  // last one.
   function lastJson(): any {
     const jsonCalls = logSpy.mock.calls
       .map((call) => call.join(''))
@@ -178,102 +218,220 @@ describe('db:rollback (real SQLite)', () => {
     expect(parsed.message).toBe('No migrations to rollback');
   });
 
-  it('force-marks the most recent non-reversible migration rolled back by default', async () => {
-    await seedMigrations([
-      nonReversibleDef('m_one'),
-      nonReversibleDef('m_two'),
-      nonReversibleDef('m_three'),
-    ]);
+  describe('honesty contract (#2378)', () => {
+    it('refuses a migration with no DOWN script instead of marking it rolled back', async () => {
+      await seedMigrations([
+        nonReversibleDef('m_one'),
+        nonReversibleDef('m_two'),
+      ]);
 
-    await dbRollbackCommand.handler([], { force: true });
+      await dbRollbackCommand.handler([], { force: true });
 
-    const byName = Object.fromEntries(
-      (await readHistory()).map((m) => [m.name, m.status]),
-    );
-    expect(byName.m_three).toBe('rolled_back');
-    expect(byName.m_two).toBe('completed');
-    expect(byName.m_one).toBe('completed');
-    expect(output()).toContain('Successfully rolled back 1 migration');
+      expect(process.exitCode).toBe(1);
+      expect(errorOutput()).toContain('Refusing to roll back');
+      expect(errorOutput()).toContain('m_two');
+      expect(errorOutput()).toContain('--mark-only');
+      // The row is untouched and so is the schema — the two must agree.
+      const byName = await statusByName();
+      expect(byName.m_two).toBe('completed');
+      expect(byName.m_one).toBe('completed');
+      expect(await tableExists('m_two')).toBe(true);
+    });
+
+    it('emits a JSON refusal naming every unrecoverable migration', async () => {
+      await seedMigrations([nonReversibleDef('jn_one')]);
+
+      await dbRollbackCommand.handler([], { json: true, force: true });
+
+      const parsed = lastJson();
+      expect(process.exitCode).toBe(1);
+      expect(parsed.error).toContain('Refusing to roll back');
+      expect(parsed.nonReversible).toEqual([
+        { name: 'jn_one', reason: 'was applied without a DOWN script' },
+      ]);
+      expect(parsed.guidance.join(' ')).toContain('--mark-only');
+      expect((await statusByName()).jn_one).toBe('completed');
+    });
+
+    it('executes the recorded DOWN script of a create_table migration', async () => {
+      await seedMigrations([createTableDef('r_one')]);
+      expect(await tableExists('r_one')).toBe(true);
+
+      await dbRollbackCommand.handler([], { force: true });
+
+      expect(process.exitCode).toBeUndefined();
+      // The schema — not just the tracking row — actually moved.
+      expect(await tableExists('r_one')).toBe(false);
+      expect((await statusByName()).create_table_r_one).toBe('rolled_back');
+      expect(output()).toContain('Successfully rolled back 1 migration');
+    });
+
+    it('refuses a reversible migration whose DOWN SQL was never persisted', async () => {
+      await seedMigrations([customReversibleDef('custom_one', 'custom_tbl')]);
+
+      await dbRollbackCommand.handler([], { json: true, force: true });
+
+      const parsed = lastJson();
+      expect(process.exitCode).toBe(1);
+      expect(parsed.nonReversible[0].name).toBe('custom_one');
+      expect(parsed.nonReversible[0].reason).toContain(
+        'cannot be reconstructed',
+      );
+      expect(await tableExists('custom_tbl')).toBe(true);
+    });
+
+    it('refuses the whole batch when only some migrations have a DOWN script', async () => {
+      // Newest first: the create_table row is rollback-able, the older one is
+      // not. Rolling back only the reversible half would leave the chain in a
+      // state no DOWN script was written against, so nothing runs.
+      await seedMigrations([
+        nonReversibleDef('mixed_old'),
+        createTableDef('mixed_new'),
+      ]);
+
+      await dbRollbackCommand.handler([], { steps: 2, force: true });
+
+      expect(process.exitCode).toBe(1);
+      const byName = await statusByName();
+      expect(byName.create_table_mixed_new).toBe('completed');
+      expect(byName.mixed_old).toBe('completed');
+      expect(await tableExists('mixed_new')).toBe(true);
+      expect(await tableExists('mixed_old')).toBe(true);
+    });
+
+    it('marks rows rolled back without touching the schema under --mark-only', async () => {
+      await seedMigrations([nonReversibleDef('mo_one')]);
+
+      await dbRollbackCommand.handler([], { force: true, markOnly: true });
+
+      expect(process.exitCode).toBeUndefined();
+      expect((await statusByName()).mo_one).toBe('rolled_back');
+      // Explicitly opted into: the row moved, the schema did not, and the
+      // output says so.
+      expect(await tableExists('mo_one')).toBe(true);
+      expect(output()).toContain('schema was NOT changed');
+    });
+
+    it('reports --mark-only in the JSON summary', async () => {
+      await seedMigrations([nonReversibleDef('mj_one')]);
+
+      await dbRollbackCommand.handler([], {
+        force: true,
+        json: true,
+        markOnly: true,
+      });
+
+      const parsed = lastJson();
+      expect(parsed.success).toBe(true);
+      expect(parsed.markOnly).toBe(true);
+      expect(parsed.results[0]).toMatchObject({
+        name: 'mj_one',
+        success: true,
+        markedOnly: true,
+      });
+    });
+
+    it('stops after a failed DOWN and reports the rest as not attempted', async () => {
+      // A real SQLite fault, no mocking: `DROP TABLE IF EXISTS` refuses to
+      // drop a view ("use DROP VIEW to delete view"), so the reconstructed
+      // DOWN of `create_table_v_bad` genuinely fails.
+      await seedMigrations([
+        createTableDef('keep_me'),
+        {
+          id: 'create_table_v_bad',
+          description: 'Create view v_bad',
+          version: '1.0.0',
+          up: ['CREATE VIEW v_bad AS SELECT 1 AS id'],
+          down: ['DROP TABLE IF EXISTS "v_bad"'],
+        },
+      ]);
+
+      await dbRollbackCommand.handler([], {
+        steps: 2,
+        force: true,
+        json: true,
+      });
+
+      const parsed = lastJson();
+      expect(process.exitCode).toBe(1);
+      expect(parsed.success).toBe(false);
+      expect(parsed.errorCount).toBe(2);
+      expect(parsed.results[0]).toMatchObject({
+        name: 'create_table_v_bad',
+        success: false,
+      });
+      expect(parsed.results[1].error).toContain('Not attempted');
+      // The migration behind the failure was never touched.
+      const byName = await statusByName();
+      expect(byName.create_table_keep_me).toBe('completed');
+      expect(await tableExists('keep_me')).toBe(true);
+    });
+
+    it('prints a stack trace for rollback failures in verbose mode', async () => {
+      await seedMigrations([
+        {
+          id: 'create_table_v_verbose',
+          description: 'Create view v_verbose',
+          version: '1.0.0',
+          up: ['CREATE VIEW v_verbose AS SELECT 1 AS id'],
+          down: ['DROP TABLE IF EXISTS "v_verbose"'],
+        },
+      ]);
+
+      await dbRollbackCommand.handler([], { force: true, verbose: true });
+
+      expect(errorOutput()).toContain('failed');
+      expect(process.exitCode).toBe(1);
+    });
   });
 
   it('rolls back N migrations when --steps is provided', async () => {
     await seedMigrations([
-      nonReversibleDef('s_one'),
-      nonReversibleDef('s_two'),
-      nonReversibleDef('s_three'),
+      createTableDef('s_one'),
+      createTableDef('s_two'),
+      createTableDef('s_three'),
     ]);
 
     await dbRollbackCommand.handler([], { steps: 2, force: true });
 
-    const byName = Object.fromEntries(
-      (await readHistory()).map((m) => [m.name, m.status]),
-    );
-    expect(byName.s_three).toBe('rolled_back');
-    expect(byName.s_two).toBe('rolled_back');
-    expect(byName.s_one).toBe('completed');
+    const byName = await statusByName();
+    expect(byName.create_table_s_three).toBe('rolled_back');
+    expect(byName.create_table_s_two).toBe('rolled_back');
+    expect(byName.create_table_s_one).toBe('completed');
+    expect(await tableExists('s_three')).toBe(false);
+    expect(await tableExists('s_two')).toBe(false);
+    expect(await tableExists('s_one')).toBe(true);
   });
 
   it('rolls back everything after a target migration with --to (exclusive)', async () => {
     await seedMigrations([
-      nonReversibleDef('t_one'),
-      nonReversibleDef('t_two'),
-      nonReversibleDef('t_three'),
+      createTableDef('t_one'),
+      createTableDef('t_two'),
+      createTableDef('t_three'),
     ]);
 
-    await dbRollbackCommand.handler([], { to: 't_one', force: true });
+    await dbRollbackCommand.handler([], {
+      to: 'create_table_t_one',
+      force: true,
+    });
 
-    const byName = Object.fromEntries(
-      (await readHistory()).map((m) => [m.name, m.status]),
-    );
-    expect(byName.t_three).toBe('rolled_back');
-    expect(byName.t_two).toBe('rolled_back');
-    expect(byName.t_one).toBe('completed');
+    const byName = await statusByName();
+    expect(byName.create_table_t_three).toBe('rolled_back');
+    expect(byName.create_table_t_two).toBe('rolled_back');
+    expect(byName.create_table_t_one).toBe('completed');
+    expect(await tableExists('t_one')).toBe(true);
   });
 
-  it('warns about non-reversible migrations in the rollback set', async () => {
-    await seedMigrations([nonReversibleDef('w_one')]);
+  it('lists the DOWN statements it is about to run', async () => {
+    await seedMigrations([createTableDef('p_list')]);
 
     await dbRollbackCommand.handler([], { force: true });
 
-    expect(output()).toContain('not reversible');
-  });
-
-  it('reports a JSON error when some migrations are not reversible', async () => {
-    await seedMigrations([nonReversibleDef('jn_one')]);
-
-    await dbRollbackCommand.handler([], { json: true, force: true });
-
-    const lines = logSpy.mock.calls.map((call) => call.join(' '));
-    const nonReversibleLine = lines.find((line) =>
-      line.includes('not reversible'),
-    );
-    expect(nonReversibleLine).toBeDefined();
-  });
-
-  it('records a failed result when a reversible migration cannot run its (empty) DOWN script', async () => {
-    // A reversible row drives the tracker.rollback path; the synthetic
-    // definition the command builds has an empty `down`, so the tracker reports
-    // the migration as not reversible and the command counts it as an error.
-    await seedMigrations([reversibleDef('rev_one')]);
-
-    await dbRollbackCommand.handler([], { json: true, force: true });
-
-    const parsed = lastJson();
-    expect(parsed.success).toBe(false);
-    expect(parsed.errorCount).toBe(1);
-    expect(parsed.results[0].success).toBe(false);
-  });
-
-  it('prints a stack trace for reversible rollback failures in verbose mode', async () => {
-    await seedMigrations([reversibleDef('rev_v')]);
-
-    await dbRollbackCommand.handler([], { force: true, verbose: true });
-
-    expect(errorOutput()).toContain('failed');
+    expect(output()).toContain('DROP TABLE IF EXISTS "p_list"');
   });
 
   it('errors when --to references an unknown migration', async () => {
-    await seedMigrations([nonReversibleDef('only_one')]);
+    await seedMigrations([createTableDef('only_one')]);
 
     await dbRollbackCommand.handler([], { to: 'does_not_exist', force: true });
 
@@ -282,7 +440,7 @@ describe('db:rollback (real SQLite)', () => {
   });
 
   it('returns a JSON error when --to references an unknown migration', async () => {
-    await seedMigrations([nonReversibleDef('only_one')]);
+    await seedMigrations([createTableDef('only_one')]);
 
     await dbRollbackCommand.handler([], {
       to: 'does_not_exist',
@@ -296,31 +454,32 @@ describe('db:rollback (real SQLite)', () => {
 
   it('reports nothing to rollback when --to targets the latest migration', async () => {
     await seedMigrations([
-      nonReversibleDef('top_one'),
-      nonReversibleDef('top_two'),
+      createTableDef('top_one'),
+      createTableDef('top_two'),
     ]);
 
     // The latest applied migration is at index 0; nothing comes after it.
-    await dbRollbackCommand.handler([], { to: 'top_two', force: true });
+    await dbRollbackCommand.handler([], {
+      to: 'create_table_top_two',
+      force: true,
+    });
 
     expect(output()).toContain('Nothing to rollback');
   });
 
-  it('previews a rollback without mutating history in --dry-run mode', async () => {
-    await seedMigrations([
-      nonReversibleDef('d_one'),
-      nonReversibleDef('d_two'),
-    ]);
+  it('previews a rollback without mutating history or schema in --dry-run mode', async () => {
+    await seedMigrations([createTableDef('d_one'), createTableDef('d_two')]);
 
     await dbRollbackCommand.handler([], { dryRun: true, force: true });
 
     expect(output()).toContain('Dry-run');
     const history = await readHistory();
     expect(history.every((m) => m.status === 'completed')).toBe(true);
+    expect(await tableExists('d_two')).toBe(true);
   });
 
   it('emits structured dry-run output in JSON mode', async () => {
-    await seedMigrations([nonReversibleDef('dj_one')]);
+    await seedMigrations([createTableDef('dj_one')]);
 
     await dbRollbackCommand.handler([], {
       dryRun: true,
@@ -330,14 +489,25 @@ describe('db:rollback (real SQLite)', () => {
 
     const parsed = lastJson();
     expect(parsed.dryRun).toBe(true);
-    expect(parsed.migrationsToRollback[0].name).toBe('dj_one');
+    expect(parsed.migrationsToRollback[0].name).toBe('create_table_dj_one');
+    expect(parsed.migrationsToRollback[0].down).toEqual([
+      'DROP TABLE IF EXISTS "dj_one"',
+    ]);
+  });
+
+  it('refuses (non-zero) in --dry-run when the real run would refuse', async () => {
+    await seedMigrations([nonReversibleDef('dn_one')]);
+
+    await dbRollbackCommand.handler([], { dryRun: true, force: true });
+
+    expect(process.exitCode).toBe(1);
+    expect(errorOutput()).toContain('Refusing to roll back');
+    const history = await readHistory();
+    expect(history.every((m) => m.status === 'completed')).toBe(true);
   });
 
   it('emits a JSON summary of a successful rollback', async () => {
-    await seedMigrations([
-      nonReversibleDef('jr_one'),
-      nonReversibleDef('jr_two'),
-    ]);
+    await seedMigrations([createTableDef('jr_one'), createTableDef('jr_two')]);
 
     await dbRollbackCommand.handler([], { json: true, force: true });
 
@@ -345,28 +515,31 @@ describe('db:rollback (real SQLite)', () => {
     expect(parsed.success).toBe(true);
     expect(parsed.successCount).toBe(1);
     expect(parsed.errorCount).toBe(0);
-    expect(parsed.results[0].name).toBe('jr_two');
+    expect(parsed.results[0].name).toBe('create_table_jr_two');
+    expect(parsed.results[0].statements).toEqual([
+      'DROP TABLE IF EXISTS "jr_two"',
+    ]);
   });
 
   it('cancels the rollback when the interactive prompt is declined', async () => {
-    await seedMigrations([nonReversibleDef('c_one')]);
+    await seedMigrations([createTableDef('c_one')]);
     questionMock.mockResolvedValue('n');
 
     await dbRollbackCommand.handler([], {});
 
     expect(output()).toContain('Cancelled by user');
-    const history = await readHistory();
-    expect(history[0].status).toBe('completed');
+    expect((await statusByName()).create_table_c_one).toBe('completed');
+    expect(await tableExists('c_one')).toBe(true);
   });
 
   it('proceeds with the rollback when the interactive prompt is confirmed', async () => {
-    await seedMigrations([nonReversibleDef('p_one')]);
+    await seedMigrations([createTableDef('p_one')]);
     questionMock.mockResolvedValue('yes');
 
     await dbRollbackCommand.handler([], {});
 
-    const history = await readHistory();
-    expect(history[0].status).toBe('rolled_back');
+    expect((await statusByName()).create_table_p_one).toBe('rolled_back');
+    expect(await tableExists('p_one')).toBe(false);
     expect(questionMock).toHaveBeenCalled();
   });
 
@@ -378,8 +551,10 @@ describe('db:rollback (real SQLite)', () => {
    * through and executed real rollbacks. The handler-direct tests above passed a
    * `{ dryRun: true }` key the real CLI never produces, masking the hole — these
    * tests route through `parseCliArgs` like the actual command dispatcher.
+   * `--mark-only` is declared the same way and is covered here for the same
+   * reason.
    */
-  describe('--dry-run via parseCliArgs (regression #1385)', () => {
+  describe('kebab option keys via parseCliArgs (regression #1385)', () => {
     function route(argv: string[]) {
       const parsed = parseCliArgs(
         ['db:rollback', ...argv],
@@ -389,26 +564,25 @@ describe('db:rollback (real SQLite)', () => {
       return dbRollbackCommand.handler(parsed.args, parsed.options);
     }
 
-    it('produces the kebab option key, not a camelCase one', () => {
+    it('produces the kebab option keys, not camelCase ones', () => {
       const parsed = parseCliArgs(
-        ['db:rollback', '--dry-run', '--force'],
+        ['db:rollback', '--dry-run', '--mark-only', '--force'],
         [dbRollbackCommand as any],
         {},
       );
-      // Proves the premise: the real CLI never yields `dryRun`.
+      // Proves the premise: the real CLI never yields `dryRun`/`markOnly`.
       expect(parsed.options['dry-run']).toBe(true);
+      expect(parsed.options['mark-only']).toBe(true);
       expect((parsed.options as any).dryRun).toBeUndefined();
+      expect((parsed.options as any).markOnly).toBeUndefined();
     });
 
     it('does NOT execute any rollback when --dry-run is passed (data-loss guard)', async () => {
       await seedMigrations([
-        nonReversibleDef('dry_one'),
-        nonReversibleDef('dry_two'),
+        createTableDef('dry_one'),
+        createTableDef('dry_two'),
       ]);
 
-      // Stub the destructive boundaries: the reversible path goes through
-      // MigrationTracker.rollback; the non-reversible path issues a raw UPDATE
-      // via db.query. Neither must fire under --dry-run.
       const rollbackSpy = vi.spyOn(MigrationTracker.prototype, 'rollback');
 
       await route(['--dry-run', '--force']);
@@ -416,15 +590,16 @@ describe('db:rollback (real SQLite)', () => {
       expect(rollbackSpy).not.toHaveBeenCalled();
       expect(output()).toContain('Dry-run');
 
-      // Real DB state is the ground truth: nothing was marked rolled_back.
+      // Real DB state is the ground truth: nothing was rolled back or dropped.
       const history = await readHistory();
       expect(history.every((m) => m.status === 'completed')).toBe(true);
+      expect(await tableExists('dry_two')).toBe(true);
 
       rollbackSpy.mockRestore();
     });
 
     it('emits structured dry-run JSON without mutating history via the CLI path', async () => {
-      await seedMigrations([nonReversibleDef('dry_json')]);
+      await seedMigrations([createTableDef('dry_json')]);
 
       await route(['--dry-run', '--json', '--force']);
 
@@ -435,12 +610,105 @@ describe('db:rollback (real SQLite)', () => {
     });
 
     it('still executes the rollback when --dry-run is absent (CLI path)', async () => {
-      await seedMigrations([nonReversibleDef('wet_one')]);
+      await seedMigrations([createTableDef('wet_one')]);
 
       await route(['--force']);
 
-      const history = await readHistory();
-      expect(history[0].status).toBe('rolled_back');
+      expect((await statusByName()).create_table_wet_one).toBe('rolled_back');
+      expect(await tableExists('wet_one')).toBe(false);
     });
+
+    it('honours --mark-only from the CLI path', async () => {
+      await seedMigrations([nonReversibleDef('cli_mark')]);
+
+      await route(['--mark-only', '--force']);
+
+      expect((await statusByName()).cli_mark).toBe('rolled_back');
+      expect(await tableExists('cli_mark')).toBe(true);
+      expect(output()).toContain('schema was NOT changed');
+    });
+
+    it('refuses from the CLI path when --mark-only is absent', async () => {
+      await seedMigrations([nonReversibleDef('cli_refuse')]);
+
+      await route(['--force']);
+
+      expect(process.exitCode).toBe(1);
+      expect((await statusByName()).cli_refuse).toBe('completed');
+    });
+  });
+});
+
+describe('recoverDownStatements', () => {
+  it('reconstructs the DOWN of a create_table migration', () => {
+    expect(
+      recoverDownStatements({
+        name: 'create_table_users',
+        is_reversible: true,
+      }),
+    ).toEqual({
+      recoverable: true,
+      statements: ['DROP TABLE IF EXISTS "users"'],
+    });
+  });
+
+  it('refuses a create_table row that was not recorded reversible', () => {
+    const recovery = recoverDownStatements({
+      name: 'create_table_users',
+      is_reversible: false,
+    });
+    expect(recovery.recoverable).toBe(false);
+    expect(recovery).toMatchObject({
+      reason: expect.stringContaining('not reversible'),
+    });
+  });
+
+  it('refuses a reversible migration whose SQL is not stored', () => {
+    const recovery = recoverDownStatements({
+      name: 'add_column_users_email',
+      is_reversible: true,
+    });
+    expect(recovery.recoverable).toBe(false);
+    expect(recovery).toMatchObject({
+      reason: expect.stringContaining('cannot be reconstructed'),
+    });
+  });
+
+  it('refuses an auto-migration applied without a DOWN', () => {
+    const recovery = recoverDownStatements({
+      name: 'add_index_users_email',
+      is_reversible: false,
+    });
+    expect(recovery.recoverable).toBe(false);
+    expect(recovery).toMatchObject({
+      reason: 'was applied without a DOWN script',
+    });
+  });
+
+  it('refuses a create_table row whose table name is not a plain identifier', () => {
+    const recovery = recoverDownStatements({
+      name: 'create_table_users"; DROP TABLE secrets; --',
+      is_reversible: true,
+    });
+    expect(recovery.recoverable).toBe(false);
+    expect(recovery).toMatchObject({
+      reason: expect.stringContaining('not a plain identifier'),
+    });
+  });
+
+  /**
+   * Coupling guard: the reconstruction above is only valid while `db:migrate`
+   * keeps recording that exact DOWN for `diff.added_tables`. If this assertion
+   * fails, update `recoverDownStatements` in `db-rollback.ts` alongside it.
+   */
+  it('matches the DOWN script db:migrate records for added tables', () => {
+    const source = readFileSync(
+      fileURLToPath(new URL('../utilities.ts', import.meta.url)),
+      'utf8',
+    );
+    // Regexes (not string literals) so the `${…}` we are matching against is
+    // not itself flagged as an unintended template placeholder.
+    expect(source).toMatch(/DROP TABLE IF EXISTS "\$\{schema\.tableName\}"/);
+    expect(source).toMatch(/`create_table_\$\{schema\.tableName\}`/);
   });
 });

--- a/packages/cli/src/commands/db-rollback.ts
+++ b/packages/cli/src/commands/db-rollback.ts
@@ -10,7 +10,7 @@
  * records for `create_table_<table>` migrations. Everything else is refused
  * rather than flipped to `rolled_back` with the schema untouched (#2378).
  * `--mark-only` is the explicit, honestly-labelled opt-in for the record-only
- * flip an operator who reverted the schema by hand actually wants.
+ * flip that an operator who reverted the schema by hand actually wants.
  */
 
 import type { DatabaseInterface } from '@happyvertical/sql';
@@ -51,9 +51,15 @@ interface RollbackResult {
 const CREATE_TABLE_MIGRATION_PREFIX = 'create_table_';
 
 /**
- * Table names SMRT generates are plain snake_case identifiers. Anything else
- * in a `create_table_*` row was not written by `db:migrate`, so its DOWN is not
- * ours to reconstruct.
+ * The suffix of a `create_table_*` row must be a bare SQL identifier before it
+ * is interpolated into the reconstructed `DROP TABLE`. Quotes, whitespace,
+ * semicolons and dots all fail closed (the migration is refused) rather than
+ * producing a statement that drops something other than the recorded table.
+ *
+ * Deliberately not lowercase-only: `classnameToTablename` yields snake_case,
+ * but `@smrt({ tableName })` passes a consumer-supplied name through verbatim,
+ * so a legitimately reversible table can carry capitals. This is a shape and
+ * injection guard, not a naming-convention check.
  */
 const SAFE_TABLE_NAME_RE = /^[A-Za-z_][A-Za-z0-9_$]*$/;
 
@@ -327,7 +333,12 @@ export const dbRollbackCommand: CLICommand = {
               {
                 error: REFUSAL_ERROR,
                 dryRun: Boolean(dryRun),
-                nonReversible: unrecoverable,
+                // `unrecoverable` is the accurate key: it also covers rows
+                // recorded reversible whose DOWN SQL was never persisted.
+                // `nonReversible` keeps the pre-#2378 name-array shape for
+                // existing JSON consumers.
+                unrecoverable,
+                nonReversible: unrecoverable.map((entry) => entry.name),
                 guidance: REFUSAL_GUIDANCE,
               },
               null,
@@ -397,10 +408,12 @@ export const dbRollbackCommand: CLICommand = {
               : 'Would execute the DOWN script of the following migrations:',
           );
           for (const { migration, recovery } of plan) {
+            // Same markers as the plan listing above: `⊘` never stands for a
+            // migration this run could revert.
             const status = recovery.recoverable
-              ? `(${recovery.statements.length} DOWN statement(s))`
-              : '(no DOWN script)';
-            console.log(`  ↩ ${migration.name} ${status}`);
+              ? `↩ ${migration.name} (${recovery.statements.length} DOWN statement(s))`
+              : `⊘ ${migration.name} (no DOWN script)`;
+            console.log(`  ${status}`);
           }
           console.log();
         }

--- a/packages/cli/src/commands/db-rollback.ts
+++ b/packages/cli/src/commands/db-rollback.ts
@@ -1,7 +1,16 @@
 /**
  * db:rollback Command
  *
- * Reverts applied migrations using their DOWN scripts.
+ * Reverts applied migrations by executing the DOWN script that produced them —
+ * or refuses, loudly and with a non-zero exit, when no DOWN script exists.
+ *
+ * SMRT schema migrations are diff-driven: `db:migrate` derives them from the
+ * manifest at run time and stores no SQL in `_smrt_schema_migrations`, so the
+ * only DOWN this command can honour is the deterministic one `db:migrate`
+ * records for `create_table_<table>` migrations. Everything else is refused
+ * rather than flipped to `rolled_back` with the schema untouched (#2378).
+ * `--mark-only` is the explicit, honestly-labelled opt-in for the record-only
+ * flip an operator who reverted the schema by hand actually wants.
  */
 
 import type { DatabaseInterface } from '@happyvertical/sql';
@@ -15,6 +24,8 @@ interface DbRollbackOptions {
   'dry-run'?: boolean;
   // Camel fallback honoured for handler-direct callers/tests (see handler).
   dryRun?: boolean;
+  'mark-only'?: boolean;
+  markOnly?: boolean;
   force?: boolean;
   json?: boolean;
   verbose?: boolean;
@@ -24,13 +35,107 @@ interface DbRollbackOptions {
 interface RollbackResult {
   name: string;
   success: boolean;
-  noDownScript?: boolean;
+  /** DOWN statements that were executed (absent on the record-only path). */
+  statements?: string[];
+  /** Record-only flip: the tracking row moved, the schema did not. */
+  markedOnly?: boolean;
   error?: string;
+}
+
+/**
+ * Name prefix of the only migration class `db:migrate` records a DOWN script
+ * for (`utilities.ts`, `diff.added_tables` loop:
+ * `down: ['DROP TABLE IF EXISTS "<table>"']`). Keep the two in step — this
+ * command reconstructs that exact statement from the recorded migration name.
+ */
+const CREATE_TABLE_MIGRATION_PREFIX = 'create_table_';
+
+/**
+ * Table names SMRT generates are plain snake_case identifiers. Anything else
+ * in a `create_table_*` row was not written by `db:migrate`, so its DOWN is not
+ * ours to reconstruct.
+ */
+const SAFE_TABLE_NAME_RE = /^[A-Za-z_][A-Za-z0-9_$]*$/;
+
+/** Human-readable refusal headline, printed above the per-migration reasons. */
+const REFUSAL_HEADLINE =
+  'Refusing to roll back: no DOWN script is available for the selected migration(s).';
+
+/** Single-line refusal used for the JSON payload. */
+const REFUSAL_ERROR = `${REFUSAL_HEADLINE} Nothing was changed.`;
+
+/** Why the refusal happened and the two ways forward, printed with it. */
+const REFUSAL_GUIDANCE = [
+  'SMRT schema migrations are diff-driven: db:migrate stores no SQL in _smrt_schema_migrations and records a DOWN script only for create_table_<table> migrations.',
+  'Revert these by updating the @smrt object definitions and running smrt db:migrate, or by reverting the schema by hand.',
+  'Re-run with --mark-only to mark them rolled_back in the tracking table WITHOUT changing the schema (record-only).',
+];
+
+/** Outcome of trying to reconstruct a migration's DOWN script. */
+export type DownRecovery =
+  | { recoverable: true; statements: string[] }
+  | { recoverable: false; reason: string };
+
+/** The fields of a `_smrt_schema_migrations` row this command reasons about. */
+interface RollbackCandidate {
+  name: string;
+  is_reversible: boolean;
+}
+
+/**
+ * Reconstruct the DOWN script for an applied migration, or explain why it
+ * cannot be reconstructed.
+ *
+ * Recoverable only for `create_table_<table>` rows recorded as reversible: the
+ * DOWN `db:migrate` attached to them is the deterministic
+ * `DROP TABLE IF EXISTS "<table>"`. A row recorded reversible under any other
+ * name came from a caller-supplied `MigrationDefinition` whose SQL was never
+ * persisted, so it is refused rather than guessed at.
+ *
+ * Exported for unit testing.
+ */
+export function recoverDownStatements(
+  migration: RollbackCandidate,
+): DownRecovery {
+  if (!migration.name.startsWith(CREATE_TABLE_MIGRATION_PREFIX)) {
+    return {
+      recoverable: false,
+      reason: migration.is_reversible
+        ? 'recorded as reversible, but its DOWN SQL is not stored in _smrt_schema_migrations and cannot be reconstructed'
+        : 'was applied without a DOWN script',
+    };
+  }
+
+  if (!migration.is_reversible) {
+    return {
+      recoverable: false,
+      reason: 'is recorded as not reversible',
+    };
+  }
+
+  const tableName = migration.name.slice(CREATE_TABLE_MIGRATION_PREFIX.length);
+  if (!SAFE_TABLE_NAME_RE.test(tableName)) {
+    return {
+      recoverable: false,
+      reason: `names table "${tableName}", which is not a plain identifier db:migrate would have generated`,
+    };
+  }
+
+  return {
+    recoverable: true,
+    statements: [`DROP TABLE IF EXISTS "${tableName}"`],
+  };
+}
+
+/** One planned rollback: the applied row plus the DOWN it can (or cannot) run. */
+interface RollbackPlanEntry<TMigration extends RollbackCandidate> {
+  migration: TMigration;
+  recovery: DownRecovery;
 }
 
 export const dbRollbackCommand: CLICommand = {
   name: 'db:rollback',
-  description: 'Rollback applied migrations',
+  description: 'Rollback applied migrations by executing their DOWN script',
   aliases: ['rollback', 'migration-rollback'],
   args: [],
   options: {
@@ -49,6 +154,13 @@ export const dbRollbackCommand: CLICommand = {
       type: 'boolean',
       description: 'Preview rollback without executing',
       default: false,
+    },
+    'mark-only': {
+      type: 'boolean',
+      description:
+        'Record-only: mark migrations rolled back WITHOUT running any DOWN script (schema untouched)',
+      default: false,
+      short: 'm',
     },
     force: {
       type: 'boolean',
@@ -76,7 +188,10 @@ export const dbRollbackCommand: CLICommand = {
     // arrives as the kebab key `options['dry-run']` — not `options.dryRun`.
     // Read the kebab key first (real CLI path) and keep the camel fallback so
     // handler-direct callers/tests passing `{ dryRun: true }` still work.
+    // Same rule for `--mark-only`, whose miss would be the same data-loss class
+    // of bug as #1385.
     const dryRun = options['dry-run'] ?? options.dryRun;
+    const markOnly = options['mark-only'] ?? options.markOnly;
 
     try {
       // 1. Load CLI config
@@ -165,46 +280,83 @@ export const dbRollbackCommand: CLICommand = {
         return;
       }
 
-      // 7. Display migrations to be rolled back
+      // 7. Plan the rollback: resolve the DOWN script for every selected row
+      //    before anything is displayed, prompted for, or executed.
+      const plan: RollbackPlanEntry<(typeof applied)[number]>[] =
+        migrationsToRollback.map((migration) => ({
+          migration,
+          recovery: recoverDownStatements(migration),
+        }));
+      // Flattened to `{ name, reason }` here so the refusal payload below is
+      // built from an already-narrowed shape rather than re-testing the union.
+      const unrecoverable = plan.flatMap(({ migration, recovery }) =>
+        recovery.recoverable
+          ? []
+          : [{ name: migration.name, reason: recovery.reason }],
+      );
+
       if (!options.json) {
         console.log(
           `Migrations to rollback (${migrationsToRollback.length}):\n`,
         );
-        for (const m of migrationsToRollback) {
-          const appliedAt = m.applied_at.toISOString().substring(0, 19);
+        for (const { migration, recovery } of plan) {
+          const appliedAt = migration.applied_at.toISOString().substring(0, 19);
+          const marker = recovery.recoverable ? '↩' : '⊘';
           console.log(
-            `  ↩ ${m.name} (${shortChecksum(m.checksum)} applied ${appliedAt})`,
+            `  ${marker} ${migration.name} (${shortChecksum(migration.checksum)} applied ${appliedAt})`,
           );
+          if (recovery.recoverable) {
+            for (const sql of recovery.statements) {
+              console.log(`      ${sql};`);
+            }
+          } else {
+            console.log(`      no DOWN script — ${recovery.reason}`);
+          }
         }
         console.log();
       }
 
-      // 8. Check if migrations are reversible
-      const nonReversible = migrationsToRollback.filter(
-        (m) => !m.is_reversible,
-      );
-      if (nonReversible.length > 0) {
+      // 8. Refuse rather than lie. Without a DOWN script the schema cannot be
+      //    reverted, and marking the row `rolled_back` anyway would leave the
+      //    tracking table describing a database that does not exist. Refusal is
+      //    all-or-nothing: a partial revert would leave the chain inconsistent.
+      if (unrecoverable.length > 0 && !markOnly) {
         if (options.json) {
           console.log(
-            JSON.stringify({
-              error: 'Some migrations are not reversible',
-              nonReversible: nonReversible.map((m) => m.name),
-            }),
+            JSON.stringify(
+              {
+                error: REFUSAL_ERROR,
+                dryRun: Boolean(dryRun),
+                nonReversible: unrecoverable,
+                guidance: REFUSAL_GUIDANCE,
+              },
+              null,
+              2,
+            ),
           );
         } else {
-          console.log('⚠️  Warning: Some migrations are not reversible:\n');
-          for (const m of nonReversible) {
-            console.log(`   - ${m.name}`);
+          console.error(`❌ ${REFUSAL_HEADLINE}\n`);
+          for (const detail of unrecoverable) {
+            console.error(`   - ${detail.name} — ${detail.reason}`);
           }
-          console.log(
-            '\n   These migrations will be marked as rolled back but no DOWN script will run.\n',
-          );
+          console.error();
+          for (const line of REFUSAL_GUIDANCE) {
+            console.error(`   ${line}`);
+          }
+          console.error('\n   Nothing was changed.\n');
         }
+
+        process.exitCode = 1;
+        return;
       }
 
       // 9. Confirm rollback (unless --force or --dry-run)
       if (!options.force && !dryRun && !options.json) {
-        console.log('⚠️  WARNING: This will revert database changes!');
+        console.log(
+          markOnly
+            ? '⚠️  WARNING: This marks migrations rolled back WITHOUT changing the schema!'
+            : '⚠️  WARNING: This will revert database changes!',
+        );
 
         const readline = await import('node:readline/promises');
         const rl = readline.createInterface({
@@ -228,21 +380,27 @@ export const dbRollbackCommand: CLICommand = {
           console.log(
             JSON.stringify({
               dryRun: true,
-              migrationsToRollback: migrationsToRollback.map((m) => ({
-                name: m.name,
-                checksum: m.checksum,
-                isReversible: m.is_reversible,
+              markOnly: Boolean(markOnly),
+              migrationsToRollback: plan.map(({ migration, recovery }) => ({
+                name: migration.name,
+                checksum: migration.checksum,
+                isReversible: migration.is_reversible,
+                down: recovery.recoverable ? recovery.statements : [],
               })),
             }),
           );
         } else {
           console.log('📋 Dry-run - no changes made\n');
-          console.log('Would rollback the following migrations:');
-          for (const m of migrationsToRollback) {
-            const status = m.is_reversible
-              ? '(has DOWN script)'
+          console.log(
+            markOnly
+              ? 'Would mark the following migrations rolled back (schema untouched):'
+              : 'Would execute the DOWN script of the following migrations:',
+          );
+          for (const { migration, recovery } of plan) {
+            const status = recovery.recoverable
+              ? `(${recovery.statements.length} DOWN statement(s))`
               : '(no DOWN script)';
-            console.log(`  ↩ ${m.name} ${status}`);
+            console.log(`  ↩ ${migration.name} ${status}`);
           }
           console.log();
         }
@@ -251,62 +409,87 @@ export const dbRollbackCommand: CLICommand = {
 
       // 11. Execute rollbacks
       if (!options.json) {
-        console.log('🔨 Rolling back migrations...\n');
+        console.log(
+          markOnly
+            ? '🔨 Marking migrations rolled back (record-only)...\n'
+            : '🔨 Rolling back migrations...\n',
+        );
       }
 
       let successCount = 0;
       let errorCount = 0;
       const results: RollbackResult[] = [];
+      let stoppedBy: string | null = null;
 
-      for (const migration of migrationsToRollback) {
+      for (const { migration, recovery } of plan) {
+        // A failed DOWN leaves the schema in a state the older DOWN scripts
+        // were not written against, so stop instead of compounding it.
+        if (stoppedBy) {
+          const message = `Not attempted: rollback stopped after ${stoppedBy} failed`;
+          if (!options.json) {
+            console.error(`  ⊘ ${migration.name} skipped: ${message}`);
+          }
+          results.push({
+            name: migration.name,
+            success: false,
+            error: message,
+          });
+          errorCount++;
+          continue;
+        }
+
         try {
-          // We need the DOWN script from the migration definition
-          // For now, we'll mark as rolled back but note that full rollback
-          // requires the original migration file with DOWN statements
-
-          // Create a minimal definition for rollback
-          const definition = {
-            id: migration.name,
-            description: `Rollback: ${migration.name}`,
-            version: migration.version,
-            up: [],
-            down: [], // Would need to load from migration file
-          };
-
-          if (migration.is_reversible) {
-            // Note: Full implementation would load DOWN script from file
-            // For now, just mark as rolled back
-            const result = await tracker.rollback(migration.name, definition, {
-              dryRun: false,
-            });
-
-            if (result.success) {
-              if (!options.json) {
-                console.log(`  ✓ ${migration.name} rolled back`);
-              }
-              results.push({ name: migration.name, success: true });
-              successCount++;
-            } else {
-              throw result.error || new Error('Rollback failed');
-            }
-          } else {
-            // Mark as rolled back without executing DOWN
+          if (markOnly) {
+            // Record-only: the operator asserts the schema was already
+            // reverted. Never dressed up as an executed rollback.
             await db.query(
               `UPDATE _smrt_schema_migrations SET status = 'rolled_back', rolled_back_at = CURRENT_TIMESTAMP WHERE name = ?`,
               [migration.name],
             );
             if (!options.json) {
               console.log(
-                `  ⊙ ${migration.name} marked as rolled back (no DOWN script)`,
+                `  ⊙ ${migration.name} marked rolled back (schema untouched)`,
               );
             }
             results.push({
               name: migration.name,
               success: true,
-              noDownScript: true,
+              markedOnly: true,
             });
             successCount++;
+            continue;
           }
+
+          if (!recovery.recoverable) {
+            // Unreachable: step 8 refuses this set unless --mark-only.
+            throw new Error(`No DOWN script available — ${recovery.reason}`);
+          }
+
+          const result = await tracker.rollback(
+            migration.name,
+            {
+              id: migration.name,
+              description: `Rollback: ${migration.name}`,
+              version: migration.version,
+              up: [],
+              down: recovery.statements,
+            },
+            { dryRun: false },
+          );
+
+          if (!result.success) {
+            throw result.error || new Error('Rollback failed');
+          }
+
+          if (!options.json) {
+            console.log(`  ✓ ${migration.name} rolled back`);
+          }
+          results.push({
+            name: migration.name,
+            success: true,
+            statements: recovery.statements,
+          });
+          successCount++;
         } catch (error) {
           errorCount++;
           const errorMsg =
@@ -319,6 +502,7 @@ export const dbRollbackCommand: CLICommand = {
             success: false,
             error: errorMsg,
           });
+          stoppedBy = migration.name;
 
           if (options.verbose && error instanceof Error && error.stack) {
             console.error(`\n${error.stack}\n`);
@@ -332,6 +516,7 @@ export const dbRollbackCommand: CLICommand = {
           JSON.stringify(
             {
               success: errorCount === 0,
+              markOnly: Boolean(markOnly),
               successCount,
               errorCount,
               results,
@@ -346,6 +531,10 @@ export const dbRollbackCommand: CLICommand = {
           console.log(
             `⚠️  Rollback completed with errors: ${successCount} succeeded, ${errorCount} failed\n`,
           );
+        } else if (markOnly) {
+          console.log(
+            `✅ Marked ${successCount} migration(s) rolled back — the schema was NOT changed\n`,
+          );
         } else {
           console.log(
             `✅ Successfully rolled back ${successCount} migration(s)\n`,
@@ -357,6 +546,10 @@ export const dbRollbackCommand: CLICommand = {
         console.log('   smrt db:history  - View migration history');
         console.log('   smrt db:migrate  - Re-apply migrations');
         console.log();
+      }
+
+      if (errorCount > 0) {
+        process.exitCode = 1;
       }
     } catch (error) {
       if (options.json) {


### PR DESCRIPTION
Closes #2378 (epic #2382, finding D3).

## The lie

`db:rollback` built a synthetic `MigrationDefinition` with `down: []` for every selected row, so:

- a row recorded **reversible** failed with `Migration X is not reversible (no down statements)` — a confusing error about a migration the tracking table calls reversible;
- a row recorded **not reversible** was flipped to `rolled_back` by a raw `UPDATE` with the schema untouched, and the command printed `✅ Successfully rolled back 1 migration(s)`.

`db-rollback.test.ts:181` enshrined the second half. After that flip the tracking table describes a database that never existed, and `db:migrate` will happily "re-apply" a migration whose DDL is still in place.

## The fix: execute-or-refuse

Schema state is diff-driven — `db:migrate` derives every migration from the manifest at run time and stores **no SQL** in `_smrt_schema_migrations`. The only DOWN it records is the deterministic one it attaches to `diff.added_tables`: `create_table_<table>` → `DROP TABLE IF EXISTS "<table>"`.

The command now resolves a DOWN for every selected row *before* it displays, prompts, or executes anything:

- **Reconstructible** (`create_table_<table>`, recorded reversible, plain identifier) → the recorded statement runs through `MigrationTracker.rollback` (transactional), then the row is marked `rolled_back`.
- **Anything else** → refused: non-zero exit, an error naming each migration and why, no row touched. This includes a row recorded `is_reversible` under a caller-chosen name — reversible at apply time, but the SQL was never persisted, so it cannot be replayed. Refusal is **all-or-nothing** across the selected set; a partial revert would leave the chain in a state the remaining DOWN scripts were not written against.
- A failed DOWN **stops** the batch; migrations behind it report `Not attempted` and stay `completed`. A batch with errors now exits non-zero (it previously printed "completed with errors" and exited 0).
- `--dry-run` previews the actual DOWN statements and still exits non-zero when the real run would refuse.

## `--mark-only`

The record-only flip survives, but only as an explicit opt-in for an operator who already reverted the schema by hand (the issue's `db:mark-rolled-back` alternative, expressed as a flag). Its prompt and its summary both say the schema was not changed, and it is the only path that moves a row without running DDL.

Like `--dry-run`, it is declared kebab-cased, so the handler reads `options['mark-only']` first — a miss there is the #1385 data-loss class of bug, and both keys are now covered by `parseCliArgs`-routed tests.

## Tests

`db-rollback.test.ts` runs against a real on-disk SQLite database and now asserts **schema** state, not just row state — `sqlite_master` is the oracle:

- table is actually gone after an executed DOWN;
- table still present *and* row still `completed` after a refusal;
- table still present after a `--mark-only` flip;
- mixed set (one reconstructible, one not) changes nothing;
- the "stop after a failure" path uses a genuine SQLite fault, no mocking: `DROP TABLE IF EXISTS` refuses to drop a view, so the reconstructed DOWN of a `create_table_v_bad` row really fails and the migration behind it reports `Not attempted`;
- unit tests for `recoverDownStatements`, including a `create_table_` row whose "table name" is not a plain identifier;
- a coupling guard asserts `utilities.ts` still generates the exact `create_table_<table>` name and `DROP TABLE IF EXISTS "<table>"` DOWN this reconstruction mirrors.

No generator or schema change, so there is nothing to add to the #2359 schema path-parity test.

## Review feedback (a1f62df3a)

Four Copilot threads, all addressed and resolved:

- dry-run listing now uses the same `↩`/`⊘` markers as the plan listing (reachable with an unrecoverable row only under `--dry-run --mark-only`; new test covers it);
- refusal JSON gains an accurate `unrecoverable: [{ name, reason }]` key, with `nonReversible` reverted to the pre-#2378 plain name array for existing consumers;
- `SAFE_TABLE_NAME_RE` keeps its character set — lowercasing it would refuse a legitimate `@smrt({ tableName })` name carrying capitals, which reaches `SMRT_TABLE_NAME` verbatim — and the comment now states the guard it actually is;
- doc-comment grammar.

## Validation

- `packages/cli` full `pnpm test` — 841 passed, 7 skipped (58 files)
- `packages/cli` `pnpm typecheck` — clean
- `npx biome check` on the changed files — clean
- `pnpm knowledge:check --strict` — fresh, 0 errors / 0 warnings
- `pnpm check:standards`, `pnpm check:agents-chain` — clean
- `node scripts/check-coverage.mjs --packages cli` — 90.15% lines (T1 floor 80%); `db-rollback.ts` at 96.47% statements
- `pnpm test:postgres` (cli) could not run locally — no `CI_POSTGRES_BASE_URL`/`DATABASE_URL` service in this worktree. The change adds no engine-specific SQL (`DROP TABLE IF EXISTS "<table>"` is portable) and touches none of that lane's three test files; CI covers it.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","policy_revision":"1.0.0","runtime":"claude","session":"claude-2378-reviewfix-20260817T170616Z","issue":"https://github.com/happyvertical/smrt/issues/2378"}
```
