### PR TITLE
fix(core,vitest): render manifest tables and indexes through the DDL strategy (#2358)

### DIFF
--- a/docs/content/core.md
+++ b/docs/content/core.md
@@ -129,7 +129,11 @@ must name its target engine, for example
 `ObjectRegistry.getSchemaDDL('Event', 'postgres')` or
 `ObjectRegistry.getAllSchemas('postgres')`. The one-argument registry forms are
 retained for compatibility with code that inspects cached manifests; their
-engine-neutral `ddl` must not be executed on PostgreSQL.
+engine-neutral `ddl` must not be executed on PostgreSQL. More generally, a
+manifest's `schema.ddl` is a CREATE TABLE preview with no indexes and abstract
+types; `db:migrate`, `MigrationGenerator`, `SchemaAggregator`, and
+`createIsolatedTestDbFromManifest` all render the structured `schema.columns`
+and `schema.indexes` through the engine DDL strategy instead (#2358).
 
 Schemas created before SMRT adopted `TIMESTAMPTZ` may contain PostgreSQL
 `TIMESTAMP` columns. By default SMRT reports these as manual drift and does not

--- a/packages/core/agents/schema-paths.md
+++ b/packages/core/agents/schema-paths.md
@@ -180,3 +180,21 @@ candidate claimed conflict indexes past two columns were narrowed to two
 columns, when only the index *name* is shortened. And an index fix that ships
 without a bounded-timeout, `CONCURRENTLY`-capable migrate path can take
 production down on rollout (#2362).
+
+### 13. `schema.ddl` is a preview, not the table
+
+`SchemaDefinition.ddl` / `manifest.json` `schema.ddl` is the engine-neutral
+CREATE TABLE string from `SchemaGenerator.generateSQL()` with no engine: no
+indexes, no triggers, abstract `REAL`/`JSON`/`UUID`/`TIMESTAMP`. It is kept for
+backward compatibility only. Everything that needs an executable table renders
+`columns` + `indexes` through `getDDLStrategy(engine)` — `db:migrate`
+(`migrations/orchestrate.ts`), `MigrationGenerator` (default
+`materializeStructuredSchema: true`; `false` is a deprecated opt-out),
+`SchemaAggregator`, and `createIsolatedTestDbFromManifest` in smrt-vitest, the
+last three via `src/schema/manifest-schema.ts` (`collectManifestTables` /
+`renderCollectedManifestTable`). The cached string is executed only for
+manifest objects with no structured columns. Do not add a new consumer of the
+string, and do not write a private CREATE INDEX renderer — the retired ones
+dropped `where` and `jsonPath` (#2358). Every DDL strategy also spells out
+`PRIMARY KEY NOT NULL`: SQLite lets a bare non-INTEGER PRIMARY KEY hold NULL.
+

--- a/packages/core/agents/schema-paths.md
+++ b/packages/core/agents/schema-paths.md
@@ -220,9 +220,11 @@ backward compatibility only. Everything that needs an executable table renders
 (`migrations/orchestrate.ts`), `MigrationGenerator` (default
 `materializeStructuredSchema: true`; `false` is a deprecated opt-out),
 `SchemaAggregator`, and `createIsolatedTestDbFromManifest` in smrt-vitest, the
-last three via `src/schema/manifest-schema.ts` (`collectManifestTables` /
-`renderCollectedManifestTable`). The cached string is executed only for
-manifest objects with no structured columns. Do not add a new consumer of the
+last two via `src/schema/manifest-schema.ts` (`collectManifestTables` /
+`renderCollectedManifestTable`). The cached string is merged in only for a
+table whose contributors expose no structured columns (hand-authored
+manifests); table constraints that exist only in the string are dropped with a
+warning, as `db:migrate` drops them. Do not add a new consumer of the
 string, and do not write a private CREATE INDEX renderer — the retired ones
 dropped `where` and `jsonPath` (#2358). Every DDL strategy also spells out
 `PRIMARY KEY NOT NULL`: SQLite lets a bare non-INTEGER PRIMARY KEY hold NULL.

--- a/packages/core/src/__tests__/schema-aggregator-sti-merge.test.ts
+++ b/packages/core/src/__tests__/schema-aggregator-sti-merge.test.ts
@@ -148,22 +148,174 @@ describe('SchemaAggregator STI merge', () => {
       '@happyvertical/smrt-content:Content',
       '@happyvertical/praeco:Agenda',
     ]);
+    // Rendered from the merged structured columns through the PostgreSQL
+    // strategy (#2358) — the cached `ddl` string is not what ships.
+    expect(contents?.ddl).toContain('"id" TEXT PRIMARY KEY NOT NULL');
     expect(contents?.ddl).toContain('"meeting_id" TEXT');
     expect(contents?.ddl).toContain('"url" TEXT NOT NULL DEFAULT \'\'');
     expect(contents?.ddl).toContain('"created_at" TIMESTAMPTZ');
     expect(contents?.ddl).toContain('"updated_at" TIMESTAMPTZ');
-    expect(contents?.ddl).toContain('"payload" TEXT DEFAULT $$a,b(c)$$');
+    expect(contents?.ddl).toContain('"_meta_data" JSONB');
+    expect(contents?.ddl).toContain('"tenant_id" uuid');
+    // The structured column says `payload: TEXT` with no default; the cached
+    // string's `$$a,b(c)$$` default is not authoritative.
+    expect(contents?.ddl).toMatch(/"payload" TEXT[,\n]/);
+    expect(contents?.ddl).not.toContain('$$a,b(c)$$');
     expect(contents?.ddl).not.toMatch(
       /"(?:created_at|updated_at)"\s+TIMESTAMP\b/,
     );
     expect(contents?.indexes).toContain(
       'CREATE INDEX IF NOT EXISTS "contents_meeting_id_idx" ON "contents" ("meeting_id");',
     );
+    expect(Object.keys(contents?.columns ?? {})).toEqual(
+      expect.arrayContaining(['meeting_id', 'url', 'payload']),
+    );
     expect(result.sql).toContain('"meeting_id" TEXT');
     expect(result.sql).toContain('"created_at" TIMESTAMPTZ');
+    expect(result.sql).toContain('"contents_meeting_id_idx"');
   });
 
-  it('inserts merged STI columns before trailing table constraints', () => {
+  it('renders partial and JSON-path indexes through the dialect strategy (#2358)', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'schema-aggregator-indexes-'));
+    tempDirs.push(tempDir);
+
+    const manifestPath = writeManifest(tempDir, 'events.manifest.json', {
+      packageName: '@happyvertical/events',
+      version: '1.0.0',
+      objects: {
+        '@happyvertical/events:Event': {
+          className: 'Event',
+          schema: {
+            tableName: 'events',
+            ddl: 'CREATE TABLE IF NOT EXISTS "events" ("id" TEXT PRIMARY KEY NOT NULL);',
+            columns: {
+              id: { type: 'UUID', primaryKey: true, notNull: true },
+              tenant_id: { type: 'UUID', referenceKind: 'tenantId' },
+              _meta_type: { type: 'TEXT', notNull: true, default: '' },
+              _meta_data: { type: 'JSON' },
+              deleted_at: { type: 'TIMESTAMP' },
+            },
+            indexes: [
+              { name: 'events_tenant_id_idx', columns: ['tenant_id'] },
+              {
+                name: 'events_tenant_active_idx',
+                columns: ['tenant_id'],
+                unique: true,
+                where: '"deleted_at" IS NULL',
+              },
+              {
+                name: 'events_meta_kind_idx',
+                columns: [],
+                jsonPath: { column: '_meta_data', path: 'kind' },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const postgres = new SchemaAggregator().aggregate({
+      packages: ['@happyvertical/events'],
+      localPaths: { '@happyvertical/events': manifestPath },
+      dialect: 'postgres',
+    });
+    const pgEvents = postgres.tables.get('events');
+    expect(pgEvents?.ddl).toContain('"id" uuid PRIMARY KEY NOT NULL');
+    expect(pgEvents?.ddl).toContain('"_meta_data" JSONB');
+    expect(pgEvents?.ddl).toContain('"deleted_at" TIMESTAMPTZ');
+    // Manifest `default` (not `defaultValue`) is honoured.
+    expect(pgEvents?.ddl).toContain('"_meta_type" TEXT NOT NULL DEFAULT \'\'');
+    expect(pgEvents?.indexes).toEqual([
+      'CREATE INDEX IF NOT EXISTS "events_tenant_id_idx" ON "events" ("tenant_id");',
+      'CREATE UNIQUE INDEX IF NOT EXISTS "events_tenant_active_idx" ON "events" ("tenant_id") WHERE "deleted_at" IS NULL;',
+      'CREATE INDEX IF NOT EXISTS "events_meta_kind_idx" ON "events" (("_meta_data"->>\'kind\'));',
+    ]);
+
+    const sqlite = new SchemaAggregator().aggregate({
+      packages: ['@happyvertical/events'],
+      localPaths: { '@happyvertical/events': manifestPath },
+      dialect: 'sqlite',
+    });
+    const liteEvents = sqlite.tables.get('events');
+    expect(liteEvents?.ddl).toContain('"id" TEXT PRIMARY KEY NOT NULL');
+    expect(liteEvents?.ddl).toContain('"_meta_data" TEXT');
+    expect(liteEvents?.ddl).toContain('"deleted_at" DATETIME');
+    expect(liteEvents?.indexes).toEqual([
+      'CREATE INDEX IF NOT EXISTS "events_tenant_id_idx" ON "events" ("tenant_id");',
+      'CREATE UNIQUE INDEX IF NOT EXISTS "events_tenant_active_idx" ON "events" ("tenant_id") WHERE "deleted_at" IS NULL;',
+      'CREATE INDEX IF NOT EXISTS "events_meta_kind_idx" ON "events" ((json_extract("_meta_data", \'$.kind\')));',
+    ]);
+    expect(sqlite.sql).toContain('PRAGMA foreign_keys = ON;');
+    expect(sqlite.sql).toContain('WHERE "deleted_at" IS NULL');
+  });
+
+  it('degrades a table to the cached-DDL merge when one STI contributor exposes no columns', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'schema-aggregator-mixed-'));
+    tempDirs.push(tempDir);
+
+    const baseManifestPath = writeManifest(tempDir, 'base.manifest.json', {
+      packageName: '@happyvertical/base',
+      version: '1.0.0',
+      objects: {
+        '@happyvertical/base:Content': {
+          className: 'Content',
+          schema: {
+            tableName: 'contents',
+            ddl: 'CREATE TABLE IF NOT EXISTS "contents" ("id" TEXT PRIMARY KEY NOT NULL, "title" TEXT);',
+            columns: {
+              id: { type: 'TEXT', primaryKey: true, notNull: true },
+              title: { type: 'TEXT' },
+            },
+            indexes: [{ name: 'contents_title_idx', columns: ['title'] }],
+          },
+        },
+      },
+    });
+    const legacyManifestPath = writeManifest(tempDir, 'legacy.manifest.json', {
+      packageName: '@happyvertical/legacy',
+      version: '1.0.0',
+      objects: {
+        '@happyvertical/legacy:Agenda': {
+          className: 'Agenda',
+          schema: {
+            tableName: 'contents',
+            // Hand-authored manifest: cached DDL only, no structured columns.
+            ddl: 'CREATE TABLE IF NOT EXISTS "contents" ("id" TEXT PRIMARY KEY NOT NULL, "title" TEXT, "meeting_id" TEXT, CHECK (length("id") > 0));',
+            indexes: [
+              { name: 'contents_meeting_id_idx', columns: ['meeting_id'] },
+            ],
+          },
+        },
+      },
+    });
+
+    const result = new SchemaAggregator().aggregate({
+      packages: ['@happyvertical/base', '@happyvertical/legacy'],
+      localPaths: {
+        '@happyvertical/base': baseManifestPath,
+        '@happyvertical/legacy': legacyManifestPath,
+      },
+      dialect: 'sqlite',
+    });
+
+    const contents = result.tables.get('contents');
+    expect(contents?.sources).toEqual([
+      '@happyvertical/base:Content',
+      '@happyvertical/legacy:Agenda',
+    ]);
+    // Both contributors' columns survive, via the cached-string merge, and
+    // the legacy contributor's table constraint is preserved.
+    expect(contents?.ddl).toContain('"meeting_id" TEXT');
+    expect(contents?.ddl).toContain('"title" TEXT');
+    expect(contents?.ddl).toContain('CHECK (length("id") > 0)');
+    // Indexes always come from the structured `indexes` arrays.
+    expect(contents?.indexes).toEqual([
+      'CREATE INDEX IF NOT EXISTS "contents_title_idx" ON "contents" ("title");',
+      'CREATE INDEX IF NOT EXISTS "contents_meeting_id_idx" ON "contents" ("meeting_id");',
+    ]);
+  });
+
+  it('inserts merged STI columns before trailing table constraints (cached-DDL fallback for column-less manifests)', () => {
     const tempDir = mkdtempSync(
       join(tmpdir(), 'schema-aggregator-sti-constraints-'),
     );
@@ -182,10 +334,6 @@ describe('SchemaAggregator STI merge', () => {
   "slug" TEXT NOT NULL,
   UNIQUE("slug")
 );`,
-            columns: {
-              id: { type: 'TEXT', primaryKey: true, notNull: true },
-              slug: { type: 'TEXT', notNull: true },
-            },
             indexes: [],
           },
         },
@@ -206,11 +354,6 @@ describe('SchemaAggregator STI merge', () => {
   "meeting_id" TEXT,
   UNIQUE("slug")
 );`,
-            columns: {
-              id: { type: 'TEXT', primaryKey: true, notNull: true },
-              slug: { type: 'TEXT', notNull: true },
-              meeting_id: { type: 'TEXT' },
-            },
             indexes: [],
           },
         },
@@ -232,7 +375,7 @@ describe('SchemaAggregator STI merge', () => {
     expect(contents?.ddl).toMatch(/"meeting_id" TEXT,\n\s+UNIQUE\("slug"\)/);
   });
 
-  it('merges STI columns when quoted table names and comments contain parentheses', () => {
+  it('merges cached DDL for column-less manifests when quoted table names and comments contain parentheses', () => {
     const tempDir = mkdtempSync(
       join(tmpdir(), 'schema-aggregator-sti-quoted-parens-'),
     );
@@ -255,15 +398,6 @@ describe('SchemaAggregator STI merge', () => {
   CHECK (label <> 'a  b'),
   CONSTRAINT repeated_check CHECK (id <> '')
 );`,
-            columns: {
-              id: { type: 'TEXT', primaryKey: true, notNull: true },
-              created_at: {
-                type: 'TIMESTAMP',
-                notNull: true,
-                defaultValue: 'current_timestamp',
-              },
-              label: { type: 'TEXT' },
-            },
             indexes: [],
           },
         },
@@ -290,16 +424,6 @@ describe('SchemaAggregator STI merge', () => {
   CHECK (label <> 'a b'),
   constraint repeated_check check(id<>'')
 );`,
-            columns: {
-              id: { type: 'TEXT', primaryKey: true, notNull: true },
-              created_at: {
-                type: 'TIMESTAMP',
-                notNull: true,
-                defaultValue: 'current_timestamp',
-              },
-              label: { type: 'TEXT' },
-              starts_at: { type: 'TIMESTAMP' },
-            },
             indexes: [],
           },
         },

--- a/packages/core/src/migrations/__tests__/generator.test.ts
+++ b/packages/core/src/migrations/__tests__/generator.test.ts
@@ -465,6 +465,43 @@ describe('MigrationGenerator', () => {
       expect(duckdb).not.toContain('WHERE');
     });
 
+    it('still emits the table indexes on the deprecated cached-ddl path (#2358)', () => {
+      const diff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [
+          {
+            tableName: 'events',
+            ddl: 'CREATE TABLE IF NOT EXISTS "events" ("id" TEXT PRIMARY KEY NOT NULL, "tenant_id" TEXT);',
+            columns: {
+              id: { type: 'UUID', primaryKey: true, notNull: true },
+              tenant_id: { type: 'UUID', referenceKind: 'tenantId' },
+            },
+            indexes: [{ name: 'events_tenant_id_idx', columns: ['tenant_id'] }],
+            triggers: [],
+            foreignKeys: [],
+            dependencies: [],
+            version: '1.0.0',
+          },
+        ],
+        dropped_tables: [],
+        changes: [],
+      };
+
+      const migration = new MigrationGenerator({
+        engine: 'sqlite',
+        materializeStructuredSchema: false,
+      }).generateFromDiff(diff, { name: '0001_events' });
+
+      // The opt-out only affects the CREATE TABLE rendering...
+      expect(migration.up[0]).toBe(
+        'CREATE TABLE IF NOT EXISTS "events" ("id" TEXT PRIMARY KEY NOT NULL, "tenant_id" TEXT);',
+      );
+      // ...the indexes still come from the strategy.
+      expect(migration.up).toContain(
+        'CREATE INDEX IF NOT EXISTS "events_tenant_id_idx" ON "events" ("tenant_id");',
+      );
+    });
+
     it('makes cached manifest DDL instant-safe for PostgreSQL on the deprecated cached-ddl path (#2069)', () => {
       const diff: SchemaDiff = {
         has_changes: true,

--- a/packages/core/src/migrations/__tests__/generator.test.ts
+++ b/packages/core/src/migrations/__tests__/generator.test.ts
@@ -391,6 +391,13 @@ describe('MigrationGenerator', () => {
       expect(
         migration.down.filter((s) => s.startsWith('DROP TABLE')),
       ).toHaveLength(1);
+      // The SQL file terminates every statement with exactly one `;` even
+      // though strategy-rendered statements already carry their own.
+      expect(migration.content).not.toContain(';;');
+      expect(migration.content).toContain(
+        'CREATE INDEX IF NOT EXISTS "events_tenant_id_idx" ON "events" ("tenant_id");\n',
+      );
+      expect(migration.content).toContain('DROP TABLE IF EXISTS "events";');
     });
 
     it('emits SQLite primary keys with an explicit NOT NULL (#2358)', () => {

--- a/packages/core/src/migrations/__tests__/generator.test.ts
+++ b/packages/core/src/migrations/__tests__/generator.test.ts
@@ -315,7 +315,157 @@ describe('MigrationGenerator', () => {
       expect(up).not.toContain('JSONB');
     });
 
-    it('makes cached manifest DDL instant-safe for PostgreSQL by default (#2069)', () => {
+    it('renders new tables from structured columns and emits their indexes and triggers by default (#2358)', () => {
+      const diff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [
+          {
+            tableName: 'events',
+            // Cached engine-neutral preview: CREATE TABLE only, abstract types.
+            // It must not be what the migration executes.
+            ddl: 'CREATE TABLE IF NOT EXISTS "events" ("id" TEXT PRIMARY KEY NOT NULL, "tenant_id" TEXT, "payload" JSON, "deleted_at" TIMESTAMP);',
+            columns: {
+              id: { type: 'UUID', primaryKey: true, notNull: true },
+              tenant_id: { type: 'UUID', referenceKind: 'tenantId' },
+              payload: { type: 'JSON' },
+              deleted_at: { type: 'TIMESTAMP' },
+            },
+            indexes: [
+              { name: 'events_tenant_id_idx', columns: ['tenant_id'] },
+              {
+                name: 'events_id_active_idx',
+                columns: ['id'],
+                unique: true,
+                where: '"deleted_at" IS NULL',
+              },
+            ],
+            triggers: [],
+            foreignKeys: [],
+            dependencies: [],
+            version: '1.0.0',
+          },
+        ],
+        dropped_tables: [],
+        // An `add_index` for a DIFFERENT, existing table must still be
+        // emitted exactly once — the added table's indexes come from the
+        // strategy, not from `diff.changes`.
+        changes: [
+          {
+            type: 'add_index',
+            table: 'users',
+            name: 'users_email_idx',
+            index: { name: 'users_email_idx', columns: ['email'] },
+          },
+        ],
+      };
+
+      const migration = new MigrationGenerator({
+        engine: 'postgres',
+      }).generateFromDiff(diff, { name: '0001_events' });
+      const up = migration.up.join('\n');
+
+      // Structured render, not the cached string: PG types.
+      expect(up).toContain('"id" uuid PRIMARY KEY NOT NULL');
+      expect(up).toContain('"tenant_id" uuid');
+      expect(up).toContain('"payload" JSONB');
+      expect(up).toContain('"deleted_at" TIMESTAMPTZ');
+      expect(up).not.toMatch(/"payload"\s+JSON\b/);
+      // The table's own indexes, including the partial predicate.
+      expect(up).toContain(
+        'CREATE INDEX IF NOT EXISTS "events_tenant_id_idx" ON "events" ("tenant_id");',
+      );
+      expect(up).toContain(
+        'CREATE UNIQUE INDEX IF NOT EXISTS "events_id_active_idx" ON "events" ("id") WHERE "deleted_at" IS NULL;',
+      );
+      // No double emission: one CREATE TABLE, two table indexes, one add_index.
+      expect(
+        migration.up.filter((s) => s.startsWith('CREATE TABLE')),
+      ).toHaveLength(1);
+      expect(
+        migration.up.filter((s) => /CREATE (UNIQUE )?INDEX/.test(s)),
+      ).toHaveLength(3);
+      expect(
+        migration.up.filter((s) => s.includes('users_email_idx')),
+      ).toHaveLength(1);
+      // DOWN drops the table once (indexes go with it).
+      expect(
+        migration.down.filter((s) => s.startsWith('DROP TABLE')),
+      ).toHaveLength(1);
+    });
+
+    it('emits SQLite primary keys with an explicit NOT NULL (#2358)', () => {
+      const diff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [
+          {
+            tableName: 'things',
+            columns: {
+              id: { type: 'TEXT', primaryKey: true },
+              name: { type: 'TEXT' },
+            },
+            indexes: [],
+            triggers: [],
+            foreignKeys: [],
+            dependencies: [],
+            version: '1.0.0',
+          } as SchemaDefinition,
+        ],
+        dropped_tables: [],
+        changes: [],
+      };
+
+      const up = new MigrationGenerator({ engine: 'sqlite' })
+        .generateFromDiff(diff, { name: '0001_things' })
+        .up.join('\n');
+      // SQLite lets a bare `TEXT PRIMARY KEY` hold NULL; the strategy must
+      // spell out NOT NULL.
+      expect(up).toContain('"id" TEXT PRIMARY KEY NOT NULL');
+    });
+
+    it('keeps the partial predicate on generated add_index statements (#2358)', () => {
+      const diff: SchemaDiff = {
+        has_changes: true,
+        added_tables: [],
+        dropped_tables: [],
+        changes: [
+          {
+            type: 'add_index',
+            table: 'events',
+            name: 'events_active_idx',
+            index: {
+              name: 'events_active_idx',
+              columns: ['tenant_id'],
+              where: '"deleted_at" IS NULL',
+            },
+          },
+        ],
+      };
+
+      const sqlite = new MigrationGenerator({ engine: 'sqlite' })
+        .generateFromDiff(diff, { name: '0001_idx' })
+        .up.join('\n');
+      expect(sqlite).toContain(
+        'CREATE INDEX IF NOT EXISTS "events_active_idx" ON "events" ("tenant_id") WHERE "deleted_at" IS NULL',
+      );
+
+      const postgres = new MigrationGenerator({ engine: 'postgres' })
+        .generateFromDiff(diff, { name: '0001_idx' })
+        .up.join('\n');
+      expect(postgres).toContain(
+        'CREATE INDEX CONCURRENTLY IF NOT EXISTS "events_active_idx" ON "events" ("tenant_id") WHERE "deleted_at" IS NULL',
+      );
+
+      // DuckDB rejects partial indexes: degrade to a full index (differ parity).
+      const duckdb = new MigrationGenerator({ engine: 'duckdb' })
+        .generateFromDiff(diff, { name: '0001_idx' })
+        .up.join('\n');
+      expect(duckdb).toContain(
+        'CREATE INDEX IF NOT EXISTS "events_active_idx" ON "events" ("tenant_id")',
+      );
+      expect(duckdb).not.toContain('WHERE');
+    });
+
+    it('makes cached manifest DDL instant-safe for PostgreSQL on the deprecated cached-ddl path (#2069)', () => {
       const diff: SchemaDiff = {
         has_changes: true,
         added_tables: [
@@ -351,7 +501,13 @@ describe('MigrationGenerator', () => {
         changes: [],
       };
 
-      const up = new MigrationGenerator({ engine: 'postgres' })
+      // `materializeStructuredSchema: false` is the deprecated opt-out that
+      // re-enables executing the cached string (#2358); the default renders
+      // the structured columns through the engine strategy.
+      const up = new MigrationGenerator({
+        engine: 'postgres',
+        materializeStructuredSchema: false,
+      })
         .generateFromDiff(diff, { name: '0001_events' })
         .up.join('\n');
 
@@ -381,7 +537,7 @@ describe('MigrationGenerator', () => {
       expect(up).not.toContain('CONSTRAINT TIMESTAMPTZ');
     });
 
-    it('materializes PostgreSQL CREATE TABLE header variants (#2069)', () => {
+    it('materializes PostgreSQL CREATE TABLE header variants on the deprecated cached-ddl path (#2069)', () => {
       const variants = [
         'CREATE UNLOGGED TABLE events (occurred_at TIMESTAMP);',
         'CREATE TEMP TABLE events (occurred_at TIMESTAMP);',
@@ -408,7 +564,10 @@ describe('MigrationGenerator', () => {
           changes: [],
         };
 
-        const up = new MigrationGenerator({ engine: 'postgres' })
+        const up = new MigrationGenerator({
+          engine: 'postgres',
+          materializeStructuredSchema: false,
+        })
           .generateFromDiff(diff, { name: '0001_events' })
           .up.join('\n');
         expect(up).toContain('occurred_at TIMESTAMPTZ');

--- a/packages/core/src/migrations/generator.ts
+++ b/packages/core/src/migrations/generator.ts
@@ -70,10 +70,17 @@ export class MigrationGenerator {
       includeDown?: boolean;
       packageName?: string;
       /**
-       * Ignore cached manifest DDL and materialize structured columns for the
-       * selected engine. Framework-owned executable paths should enable this;
-       * the default preserves the published custom-DDL contract while still
-       * materializing bare PostgreSQL TIMESTAMP columns as TIMESTAMPTZ.
+       * Render new tables from their structured columns through the engine's
+       * DDL strategy (default, `true`) — the same renderer `db:migrate` uses,
+       * so column types, indexes and triggers match what the differ expects
+       * on the next run.
+       *
+       * @deprecated Passing `false` re-enables the retired cached-`ddl` string
+       * path (#2358): it emits the manifest's engine-neutral CREATE TABLE with
+       * only bare PostgreSQL `TIMESTAMP` rewritten, so `REAL`/`JSON` drift on
+       * PostgreSQL and no indexes are created. Schemas that expose no
+       * structured columns always fall back to their cached `ddl` regardless
+       * of this flag.
        */
       materializeStructuredSchema?: boolean;
     } = {},
@@ -83,7 +90,7 @@ export class MigrationGenerator {
     this.includeDown = options.includeDown ?? true;
     this.packageName = options.packageName;
     this.materializeStructuredSchema =
-      options.materializeStructuredSchema ?? false;
+      options.materializeStructuredSchema ?? true;
   }
 
   /**
@@ -96,9 +103,14 @@ export class MigrationGenerator {
     const upStatements: string[] = [];
     const downStatements: string[] = [];
 
-    // Handle new tables
+    // Handle new tables: CREATE TABLE plus the table's indexes and triggers,
+    // exactly as the migration orchestrator emits them (#2358). The differ
+    // only produces `add_index` changes for tables that already exist, so
+    // there is no double emission against `diff.changes`.
     for (const schema of diff.added_tables) {
       upStatements.push(this.generateCreateTable(schema));
+      upStatements.push(...this.generateTableIndexes(schema));
+      upStatements.push(...this.generateTableTriggers(schema));
       if (this.includeDown || options.includeDown) {
         downStatements.push(this.generateDropTable(schema.tableName));
       }
@@ -286,20 +298,34 @@ ${downStatementsStr}
     }
 
     if (!this.materializeStructuredSchema && schema.ddl?.trim()) {
-      // Preserve the documented custom-DDL contract by default, including
-      // table-level constraints that structured ColumnDefinition cannot
-      // represent. Engine-aware framework callers explicitly opt into the
-      // structured materialization path below.
+      // Deprecated opt-out (#2358): the cached string is engine-neutral and
+      // index-less; only bare PostgreSQL TIMESTAMP is rewritten.
       return materializeManifestDDLForEngine(schema.ddl, this.engine);
     }
 
     // The manifest's pre-generated `ddl` is deliberately engine-neutral and
-    // may contain abstract TIMESTAMP/JSON/UUID types. Always materialize the
+    // may contain abstract TIMESTAMP/JSON/UUID types. Materialize the
     // structured columns through the selected engine strategy; executing the
     // cached string on PostgreSQL would otherwise bypass TIMESTAMPTZ and lose
     // JavaScript Date offsets (#2069). This matches the migration orchestrator
     // and also prevents JSON/REAL/UUID drift after a create.
     return getDDLStrategy(this.engine).generateCreateTable(schema);
+  }
+
+  /**
+   * Generate the CREATE INDEX statements for a new table through the engine
+   * strategy (partial `WHERE`, JSON-path targets, inline-UNIQUE engines).
+   */
+  private generateTableIndexes(schema: SchemaDefinition): string[] {
+    return getDDLStrategy(this.engine).generateIndexes(schema);
+  }
+
+  /**
+   * Generate the CREATE TRIGGER statements for a new table (engines without
+   * trigger support return none).
+   */
+  private generateTableTriggers(schema: SchemaDefinition): string[] {
+    return getDDLStrategy(this.engine).generateTriggers(schema);
   }
 
   /**
@@ -432,13 +458,18 @@ ${downStatementsStr}
   ): string {
     const uniqueStr = index.unique ? 'UNIQUE ' : '';
     const target = renderIndexTarget(index, this.engine);
+    // Partial-index predicate. DuckDB (and the JSON adapter backed by it)
+    // rejects partial indexes, so the declaration degrades to a full index
+    // there — matching the differ and the DuckDB DDL strategy.
+    const whereClause =
+      this.engine !== 'duckdb' && index.where ? ` WHERE ${index.where}` : '';
 
     if (this.engine === 'postgres') {
       // PostgreSQL: use CONCURRENTLY for production safety
-      return `CREATE ${uniqueStr}INDEX CONCURRENTLY IF NOT EXISTS ${this.quoteIdentifier(index.name)} ON ${this.quoteIdentifier(tableName)} (${target})`;
+      return `CREATE ${uniqueStr}INDEX CONCURRENTLY IF NOT EXISTS ${this.quoteIdentifier(index.name)} ON ${this.quoteIdentifier(tableName)} (${target})${whereClause}`;
     }
 
-    return `CREATE ${uniqueStr}INDEX IF NOT EXISTS ${this.quoteIdentifier(index.name)} ON ${this.quoteIdentifier(tableName)} (${target})`;
+    return `CREATE ${uniqueStr}INDEX IF NOT EXISTS ${this.quoteIdentifier(index.name)} ON ${this.quoteIdentifier(tableName)} (${target})${whereClause}`;
   }
 
   /**

--- a/packages/core/src/migrations/generator.ts
+++ b/packages/core/src/migrations/generator.ts
@@ -76,9 +76,11 @@ export class MigrationGenerator {
        * on the next run.
        *
        * @deprecated Passing `false` re-enables the retired cached-`ddl` string
-       * path (#2358): it emits the manifest's engine-neutral CREATE TABLE with
-       * only bare PostgreSQL `TIMESTAMP` rewritten, so `REAL`/`JSON` drift on
-       * PostgreSQL and no indexes are created. Schemas that expose no
+       * path for the CREATE TABLE only (#2358): it emits the manifest's
+       * engine-neutral CREATE TABLE with only bare PostgreSQL `TIMESTAMP`
+       * rewritten, so `REAL`/`JSON` drift on PostgreSQL. The table's indexes
+       * and triggers are still rendered through the engine strategy either
+       * way — the flag never suppresses them. Schemas that expose no
        * structured columns always fall back to their cached `ddl` regardless
        * of this flag.
        */

--- a/packages/core/src/migrations/generator.ts
+++ b/packages/core/src/migrations/generator.ts
@@ -225,7 +225,7 @@ export class MigrationGenerator {
       lines.push('-- Add your UP statements here');
     } else {
       for (const stmt of upStatements) {
-        lines.push(`${stmt};`);
+        lines.push(this.terminateStatement(stmt));
       }
     }
 
@@ -236,7 +236,7 @@ export class MigrationGenerator {
       lines.push('-- Add your DOWN statements here');
     } else {
       for (const stmt of downStatements) {
-        lines.push(`${stmt};`);
+        lines.push(this.terminateStatement(stmt));
       }
     }
 
@@ -519,6 +519,17 @@ ${downStatementsStr}
     if (typeof value === 'boolean') return value ? '1' : '0';
     if (typeof value === 'number') return String(value);
     return String(value);
+  }
+
+  /**
+   * Terminate a statement with exactly one `;` for the SQL file format.
+   *
+   * Strategy-rendered statements (`generateCreateTable`, `generateIndexes`,
+   * `generateTriggers`) already end with `;`, while differ-produced ALTERs do
+   * not — appending unconditionally wrote `;;` (#2406 review).
+   */
+  private terminateStatement(stmt: string): string {
+    return stmt.trimEnd().endsWith(';') ? stmt : `${stmt};`;
   }
 
   /**

--- a/packages/core/src/migrations/generator.ts
+++ b/packages/core/src/migrations/generator.ts
@@ -5,8 +5,10 @@
  * Supports both SQL and TypeScript formats.
  */
 
+import { createLogger } from '@happyvertical/logger';
 import { getDDLStrategy } from '../schema/ddl/index.js';
 import { materializeManifestDDLForEngine } from '../schema/ddl/materialize-manifest.js';
+import { cachedDdlTableConstraints } from '../schema/manifest-schema.js';
 import type {
   MigrationDefinition,
   SchemaChange,
@@ -16,6 +18,8 @@ import type {
 import { renderIndexTarget } from '../schema/utils.js';
 import { computeChecksum } from './checksum.js';
 import type { DatabaseEngine } from './types.js';
+
+const logger = createLogger({ level: 'info' });
 
 /**
  * Options for migration generation
@@ -311,6 +315,21 @@ ${downStatementsStr}
     // cached string on PostgreSQL would otherwise bypass TIMESTAMPTZ and lose
     // JavaScript Date offsets (#2069). This matches the migration orchestrator
     // and also prevents JSON/REAL/UUID drift after a create.
+    if (schema.ddl?.trim()) {
+      // Table-level constraints that live only in a hand-authored cached
+      // string cannot be represented structurally and are dropped — as
+      // `db:migrate` already drops them. Say so instead of losing them
+      // silently (#2358).
+      const constraints = cachedDdlTableConstraints(schema.ddl);
+      if (constraints.length > 0) {
+        logger.warn(
+          `[MigrationGenerator] cached ddl for table "${schema.tableName}" declares ` +
+            `${constraints.length} table constraint(s) that structured columns cannot ` +
+            `carry (${constraints.join('; ')}); the structured schema is authoritative ` +
+            `and they are not rendered (#2358).`,
+        );
+      }
+    }
     return getDDLStrategy(this.engine).generateCreateTable(schema);
   }
 

--- a/packages/core/src/scanner/types.ts
+++ b/packages/core/src/scanner/types.ts
@@ -208,6 +208,11 @@ export interface ManifestIndexDefinition {
  */
 export interface ManifestSchema {
   tableName: string;
+  /**
+   * Engine-neutral CREATE TABLE preview. Not executable as-is: no indexes,
+   * abstract SQL types. Consumers render `columns` + `indexes` through the
+   * engine DDL strategy (see `schema/manifest-schema.ts`, #2358).
+   */
   ddl: string;
   columns: Record<string, ManifestColumnDefinition>;
   indexes: ManifestIndexDefinition[];

--- a/packages/core/src/schema/ddl/base-strategy.ts
+++ b/packages/core/src/schema/ddl/base-strategy.ts
@@ -97,13 +97,15 @@ export abstract class BaseDDLStrategy implements DDLStrategy {
       this.mapType(columnDef.type),
     ];
 
-    // Primary key
+    // Primary key. NOT NULL is emitted explicitly as well: SQLite's legacy
+    // behaviour lets a non-INTEGER PRIMARY KEY column hold NULL, so a bare
+    // `"id" TEXT PRIMARY KEY` accepts NULL ids there (#2358). PostgreSQL and
+    // DuckDB already imply NOT NULL for a primary key; the explicit clause is
+    // redundant but valid on every engine and keeps the rendered DDL identical
+    // to the engine-neutral `SchemaGenerator.generateSQL()` output.
     if (columnDef.primaryKey) {
-      parts.push('PRIMARY KEY');
-    }
-
-    // NOT NULL (skip for primary key - it's implicit)
-    if (columnDef.notNull && !columnDef.primaryKey) {
+      parts.push('PRIMARY KEY', 'NOT NULL');
+    } else if (columnDef.notNull) {
       parts.push('NOT NULL');
     }
 

--- a/packages/core/src/schema/ddl/base-strategy.ts
+++ b/packages/core/src/schema/ddl/base-strategy.ts
@@ -101,8 +101,9 @@ export abstract class BaseDDLStrategy implements DDLStrategy {
     // behaviour lets a non-INTEGER PRIMARY KEY column hold NULL, so a bare
     // `"id" TEXT PRIMARY KEY` accepts NULL ids there (#2358). PostgreSQL and
     // DuckDB already imply NOT NULL for a primary key; the explicit clause is
-    // redundant but valid on every engine and keeps the rendered DDL identical
-    // to the engine-neutral `SchemaGenerator.generateSQL()` output.
+    // redundant but valid on every engine, and matches the engine-neutral
+    // `SchemaGenerator.generateSQL()` output for SMRT-generated id columns
+    // (which always carry `notNull: true`).
     if (columnDef.primaryKey) {
       parts.push('PRIMARY KEY', 'NOT NULL');
     } else if (columnDef.notNull) {

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -1323,9 +1323,11 @@ export class SchemaGenerator {
       });
     }
 
-    // Generate DDL
     // Tenancy injects `tenant_id` but nothing indexes it (#2356). Added
-    // before the DDL is rendered so the emitted SQL creates it too.
+    // before the schema definition is finalized so every consumer of the
+    // structured `indexes` array (migrations, test databases, aggregation)
+    // creates it. The cached `ddl` string below is CREATE TABLE only and is
+    // not an executable representation of the table (#2358).
     this.ensureTenantIdIndex(indexes, columns, tableName);
 
     const schemaDefinition: SchemaDefinition = {
@@ -1503,9 +1505,11 @@ export class SchemaGenerator {
       });
     }
 
-    // Generate DDL
     // Tenancy injects `tenant_id` but nothing indexes it (#2356). Added
-    // before the DDL is rendered so the emitted SQL creates it too.
+    // before the schema definition is finalized so every consumer of the
+    // structured `indexes` array (migrations, test databases, aggregation)
+    // creates it. The cached `ddl` string below is CREATE TABLE only and is
+    // not an executable representation of the table (#2358).
     this.ensureTenantIdIndex(indexes, columns, tableName);
 
     const schemaDefinition: SchemaDefinition = {
@@ -1625,19 +1629,21 @@ export class SchemaGenerator {
   }
 
   /**
-   * Generate SQL CREATE TABLE statement from schema definition
+   * Generate the CREATE TABLE statement for a schema definition.
    *
-   * This is the single source of truth for SQL generation, consolidating
-   * logic that was previously duplicated across multiple code paths.
+   * With an `engine` this delegates to that engine's DDL strategy. Without
+   * one it renders the engine-neutral preview stored in `schema.ddl` and
+   * `manifest.json`: abstract SQL types, no indexes, no triggers. That
+   * preview is NOT an executable representation of the table (#2358) —
+   * executable paths (`db:migrate`, `MigrationGenerator`, `SchemaAggregator`,
+   * `createIsolatedTestDbFromManifest`) render `schema.columns` and
+   * `schema.indexes` through `getDDLStrategy(engine)` instead.
    *
    * @param schema - Schema definition object
-   * @returns SQL CREATE TABLE statement with indexes
+   * @param engine - Optional target engine; omit for the neutral preview
+   * @returns SQL CREATE TABLE statement (no indexes)
    */
   generateSQL(schema: SchemaDefinition, engine?: DatabaseEngine): string {
-    // NOTE: We no longer append indexes to DDL string here.
-    // The SDK expects ddl to contain ONLY the CREATE TABLE statement.
-    // Indexes are stored separately in schema.indexes as SQL strings
-    // and the SDK handles them via syncSchema() or dedicated index creation.
     if (engine) {
       return getDDLStrategy(engine).generateCreateTable(schema);
     }

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -6,6 +6,20 @@ export { SchemaCodeGenerator } from './code-generator.js';
 // Re-export DDL strategies for per-engine schema generation
 export * from './ddl/index.js';
 export { SchemaGenerator } from './generator.js';
+// Structured manifest → SchemaDefinition helpers (#2358): the supported way
+// to turn raw manifest JSON into executable, engine-specific DDL.
+export {
+  type CollectedManifestTable,
+  collectManifestTables,
+  type ManifestColumnLike,
+  type ManifestIndexLike,
+  type ManifestSchemaLike,
+  manifestColumnsToDefinitions,
+  manifestIndexesToDefinitions,
+  manifestSchemaToDefinition,
+  mergeSchemaDefinitionInto,
+  renderCollectedManifestTable,
+} from './manifest-schema.js';
 export { SchemaOverrideSystem } from './override-system.js';
 export type {
   AggregatedTable,

--- a/packages/core/src/schema/manifest-schema.test.ts
+++ b/packages/core/src/schema/manifest-schema.test.ts
@@ -274,6 +274,52 @@ describe('collectManifestTables + renderCollectedManifestTable', () => {
     ]);
   });
 
+  it('inlines UNIQUE for a column-less contributor on inline-unique engines (DuckDB/JSON)', () => {
+    const legacy = {
+      tableName: 'legacy_keys',
+      ddl: 'CREATE TABLE IF NOT EXISTS "legacy_keys" ("id" TEXT PRIMARY KEY NOT NULL, "slug" TEXT NOT NULL, "context" TEXT NOT NULL, "tenant_id" TEXT, UNIQUE("tenant_id"));',
+      indexes: [
+        {
+          name: 'legacy_keys_slug_context_idx',
+          columns: ['slug', 'context'],
+          unique: true,
+        },
+        // Already declared inline by the cached string — must not duplicate.
+        {
+          name: 'legacy_keys_tenant_id_idx',
+          columns: ['tenant_id'],
+          unique: true,
+        },
+        { name: 'legacy_keys_slug_idx', columns: ['slug'] },
+      ],
+    };
+    const tables = collectManifestTables([
+      { schema: legacy, source: 'x:LegacyKey' },
+    ]);
+    const table = tables.get('legacy_keys');
+    if (!table) throw new Error('missing');
+
+    for (const engine of ['duckdb', 'json'] as const) {
+      const rendered = renderCollectedManifestTable(table, engine);
+      // The strategy skips plain unique indexes on these engines...
+      expect(rendered.indexes).toEqual([
+        'CREATE INDEX IF NOT EXISTS "legacy_keys_slug_idx" ON "legacy_keys" ("slug");',
+      ]);
+      // ...so the uniqueness must be inline in the CREATE TABLE.
+      expect(rendered.createTable).toContain('UNIQUE("slug", "context")');
+      expect(rendered.createTable.match(/UNIQUE\("tenant_id"\)/g)).toHaveLength(
+        1,
+      );
+    }
+
+    // SQLite/PostgreSQL keep them as separate unique indexes, string untouched.
+    const sqlite = renderCollectedManifestTable(table, 'sqlite');
+    expect(sqlite.createTable).toBe(legacy.ddl);
+    expect(sqlite.indexes[0]).toBe(
+      'CREATE UNIQUE INDEX IF NOT EXISTS "legacy_keys_slug_context_idx" ON "legacy_keys" ("slug", "context");',
+    );
+  });
+
   it('skips objects with neither columns nor ddl', () => {
     const tables = collectManifestTables([
       { schema: { tableName: 'ghost' }, source: 'x:Ghost' },

--- a/packages/core/src/schema/manifest-schema.test.ts
+++ b/packages/core/src/schema/manifest-schema.test.ts
@@ -137,11 +137,14 @@ describe('collectManifestTables + renderCollectedManifestTable', () => {
     );
   });
 
-  it('is exactly what the migration path renders for the same definition', () => {
-    // Path parity (#2358): the migration orchestrator emits
-    // strategy.generateCreateTable + generateIndexes + generateTriggers for a
-    // new table. Consumers of raw manifests must land on the same statements.
-    // TODO(#2359): fold into src/schema/schema-path-parity.test.ts once it lands.
+  it('renders a structured table with the same strategy calls the migration orchestrator makes', () => {
+    // Guards the wiring only: `migrations/orchestrate.ts` emits
+    // strategy.generateCreateTable + generateIndexes for a new table, and a
+    // structured manifest table must land on those exact statements. The
+    // end-to-end path-parity proof (isolated test DB vs. generated migration
+    // on a real database) lives in
+    // packages/vitest/src/__tests__/manifest-schema-path-parity.test.ts.
+    // TODO(#2359): fold both into src/schema/schema-path-parity.test.ts.
     const tables = collectManifestTables([
       { schema: structuredEvent, source: '@pkg:Event' },
     ]);
@@ -156,9 +159,6 @@ describe('collectManifestTables + renderCollectedManifestTable', () => {
       );
       expect(rendered.indexes).toEqual(
         strategy.generateIndexes(table.definition),
-      );
-      expect(rendered.triggers).toEqual(
-        strategy.generateTriggers(table.definition),
       );
     }
   });

--- a/packages/core/src/schema/manifest-schema.test.ts
+++ b/packages/core/src/schema/manifest-schema.test.ts
@@ -312,12 +312,78 @@ describe('collectManifestTables + renderCollectedManifestTable', () => {
       );
     }
 
+    // An unquoted hand-authored spelling of the same constraint is not
+    // duplicated either.
+    const unquoted = collectManifestTables([
+      {
+        schema: {
+          ...legacy,
+          ddl: legacy.ddl.replace('UNIQUE("tenant_id")', 'UNIQUE( tenant_id )'),
+        },
+        source: 'x:LegacyKey',
+      },
+    ]).get('legacy_keys');
+    if (!unquoted) throw new Error('missing');
+    const duck = renderCollectedManifestTable(unquoted, 'duckdb');
+    expect(
+      duck.createTable.match(/UNIQUE\(\s*"?tenant_id"?\s*\)/g),
+    ).toHaveLength(1);
+
     // SQLite/PostgreSQL keep them as separate unique indexes, string untouched.
     const sqlite = renderCollectedManifestTable(table, 'sqlite');
     expect(sqlite.createTable).toBe(legacy.ddl);
     expect(sqlite.indexes[0]).toBe(
       'CREATE UNIQUE INDEX IF NOT EXISTS "legacy_keys_slug_context_idx" ON "legacy_keys" ("slug", "context");',
     );
+  });
+
+  it('inlines UNIQUE for a mixed table (structured base + column-less subclass) on DuckDB/JSON', () => {
+    const base = {
+      tableName: 'mixed_keys',
+      columns: {
+        id: { type: 'UUID', primaryKey: true, notNull: true },
+        slug: { type: 'TEXT', notNull: true },
+        context: { type: 'TEXT', notNull: true, default: '' },
+      },
+      indexes: [
+        {
+          name: 'mixed_keys_slug_context_idx',
+          columns: ['slug', 'context'],
+          unique: true,
+        },
+      ],
+    };
+    const child = {
+      tableName: 'mixed_keys',
+      ddl: 'CREATE TABLE IF NOT EXISTS "mixed_keys" ("id" TEXT PRIMARY KEY NOT NULL, "external_ref" TEXT);',
+      indexes: [
+        {
+          name: 'mixed_keys_external_ref_idx',
+          columns: ['external_ref'],
+          unique: true,
+        },
+      ],
+    };
+    const table = collectManifestTables([
+      { schema: base, source: 'a:Base' },
+      { schema: child, source: 'b:Child' },
+    ]).get('mixed_keys');
+    if (!table) throw new Error('missing');
+    expect(table.structured).toBe(false);
+
+    for (const engine of ['duckdb', 'json'] as const) {
+      const rendered = renderCollectedManifestTable(table, engine);
+      // Structured part via the strategy (inline UNIQUE for its own index)...
+      expect(rendered.createTable).toContain('UNIQUE("slug", "context")');
+      // ...legacy column merged in, and the legacy contributor's unique index
+      // inlined too, since the strategy skips it in generateIndexes.
+      expect(rendered.createTable).toContain('"external_ref" TEXT');
+      expect(rendered.createTable).toContain('UNIQUE("external_ref")');
+      expect(
+        rendered.createTable.match(/UNIQUE\("slug", "context"\)/g),
+      ).toHaveLength(1);
+      expect(rendered.indexes).toEqual([]);
+    }
   });
 
   it('skips objects with neither columns nor ddl', () => {

--- a/packages/core/src/schema/manifest-schema.test.ts
+++ b/packages/core/src/schema/manifest-schema.test.ts
@@ -1,0 +1,362 @@
+/**
+ * #2358 — `schema.ddl` is a CREATE TABLE preview, not the table.
+ *
+ * Every consumer of raw manifest JSON must render tables and indexes from
+ * the structured `columns` / `indexes` through the engine DDL strategy —
+ * the same renderer `db:migrate` uses — and only fall back to the cached
+ * `ddl` string when a manifest object exposes no structured columns.
+ *
+ * Also covers the SQLite primary-key NOT NULL fix that ships with #2358:
+ * a bare `"id" TEXT PRIMARY KEY` accepts NULL on SQLite.
+ */
+
+import type { DatabaseProvider } from '@happyvertical/sql';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getDDLStrategy } from './ddl/index.js';
+import {
+  collectManifestTables,
+  manifestSchemaToDefinition,
+  mergeSchemaDefinitionInto,
+  renderCollectedManifestTable,
+} from './manifest-schema.js';
+import type { SchemaDefinition } from './types.js';
+
+const CACHED_PREVIEW =
+  'CREATE TABLE IF NOT EXISTS "events" ("id" TEXT PRIMARY KEY NOT NULL, "slug" TEXT NOT NULL, "payload" JSON);';
+
+const structuredEvent = {
+  tableName: 'events',
+  ddl: CACHED_PREVIEW,
+  columns: {
+    id: { type: 'UUID', primaryKey: true, notNull: true, referenceKind: 'id' },
+    slug: { type: 'TEXT', notNull: true },
+    context: { type: 'TEXT', notNull: true, default: '' },
+    payload: { type: 'JSON' },
+    ratio: { type: 'REAL' },
+    tenant_id: { type: 'UUID', referenceKind: 'tenantId' },
+    deleted_at: { type: 'TIMESTAMP' },
+    _meta_data: { type: 'JSON' },
+  },
+  indexes: [
+    {
+      name: 'events_slug_context_idx',
+      columns: ['slug', 'context'],
+      unique: true,
+    },
+    { name: 'events_tenant_id_idx', columns: ['tenant_id'] },
+    {
+      name: 'events_tenant_live_idx',
+      columns: ['tenant_id'],
+      where: '"deleted_at" IS NULL',
+    },
+    {
+      name: 'events_meta_kind_idx',
+      columns: [],
+      jsonPath: { column: '_meta_data', path: 'kind' },
+    },
+  ],
+  version: 'v1',
+} as const;
+
+describe('manifestSchemaToDefinition', () => {
+  it('maps manifest columns (default → defaultValue) and keeps where/jsonPath on indexes', () => {
+    const definition = manifestSchemaToDefinition(structuredEvent);
+
+    expect(definition.tableName).toBe('events');
+    expect(definition.ddl).toBe(CACHED_PREVIEW);
+    expect(definition.columns.context).toEqual({
+      type: 'TEXT',
+      notNull: true,
+      defaultValue: '',
+    });
+    expect(definition.columns.id).toEqual({
+      type: 'UUID',
+      primaryKey: true,
+      notNull: true,
+      referenceKind: 'id',
+    });
+    expect(definition.indexes.map((index) => index.name)).toEqual([
+      'events_slug_context_idx',
+      'events_tenant_id_idx',
+      'events_tenant_live_idx',
+      'events_meta_kind_idx',
+    ]);
+    expect(definition.indexes[2].where).toBe('"deleted_at" IS NULL');
+    expect(definition.indexes[3].jsonPath).toEqual({
+      column: '_meta_data',
+      path: 'kind',
+    });
+  });
+
+  it('accepts registry-style `defaultValue` as well as manifest-style `default`', () => {
+    const definition = manifestSchemaToDefinition({
+      tableName: 't',
+      columns: {
+        a: { type: 'TEXT', defaultValue: 'x' },
+        b: { type: 'INTEGER', default: 0 },
+      },
+    });
+    expect(definition.columns.a.defaultValue).toBe('x');
+    expect(definition.columns.b.defaultValue).toBe(0);
+  });
+});
+
+describe('collectManifestTables + renderCollectedManifestTable', () => {
+  it('renders a structured table through the engine strategy, never the cached ddl', () => {
+    const tables = collectManifestTables([
+      { schema: structuredEvent, source: '@pkg:Event' },
+    ]);
+    const table = tables.get('events');
+    expect(table?.structured).toBe(true);
+    expect(table?.sources).toEqual(['@pkg:Event']);
+
+    if (!table) throw new Error('events table missing');
+    const pg = renderCollectedManifestTable(table, 'postgres');
+    expect(pg.createTable).not.toBe(CACHED_PREVIEW);
+    expect(pg.createTable).toContain('"id" uuid PRIMARY KEY NOT NULL');
+    expect(pg.createTable).toContain('"payload" JSONB');
+    expect(pg.createTable).toContain('"ratio" DOUBLE PRECISION');
+    expect(pg.createTable).toContain('"deleted_at" TIMESTAMPTZ');
+    expect(pg.indexes).toEqual([
+      'CREATE UNIQUE INDEX IF NOT EXISTS "events_slug_context_idx" ON "events" ("slug", "context");',
+      'CREATE INDEX IF NOT EXISTS "events_tenant_id_idx" ON "events" ("tenant_id");',
+      'CREATE INDEX IF NOT EXISTS "events_tenant_live_idx" ON "events" ("tenant_id") WHERE "deleted_at" IS NULL;',
+      'CREATE INDEX IF NOT EXISTS "events_meta_kind_idx" ON "events" (("_meta_data"->>\'kind\'));',
+    ]);
+
+    const sqlite = renderCollectedManifestTable(table, 'sqlite');
+    expect(sqlite.createTable).toContain('"id" TEXT PRIMARY KEY NOT NULL');
+    expect(sqlite.createTable).toContain('"payload" TEXT');
+    expect(sqlite.createTable).toContain('"deleted_at" DATETIME');
+    expect(sqlite.indexes[2]).toBe(
+      'CREATE INDEX IF NOT EXISTS "events_tenant_live_idx" ON "events" ("tenant_id") WHERE "deleted_at" IS NULL;',
+    );
+    expect(sqlite.indexes[3]).toBe(
+      'CREATE INDEX IF NOT EXISTS "events_meta_kind_idx" ON "events" ((json_extract("_meta_data", \'$.kind\')));',
+    );
+  });
+
+  it('is exactly what the migration path renders for the same definition', () => {
+    // Path parity (#2358): the migration orchestrator emits
+    // strategy.generateCreateTable + generateIndexes + generateTriggers for a
+    // new table. Consumers of raw manifests must land on the same statements.
+    // TODO(#2359): fold into src/schema/schema-path-parity.test.ts once it lands.
+    const tables = collectManifestTables([
+      { schema: structuredEvent, source: '@pkg:Event' },
+    ]);
+    const table = tables.get('events');
+    if (!table) throw new Error('events table missing');
+
+    for (const engine of ['sqlite', 'postgres'] as const) {
+      const strategy = getDDLStrategy(engine);
+      const rendered = renderCollectedManifestTable(table, engine);
+      expect(rendered.createTable).toBe(
+        strategy.generateCreateTable(table.definition),
+      );
+      expect(rendered.indexes).toEqual(
+        strategy.generateIndexes(table.definition),
+      );
+      expect(rendered.triggers).toEqual(
+        strategy.generateTriggers(table.definition),
+      );
+    }
+  });
+
+  it('merges STI contributors structurally: columns first-wins, indexes deduplicated by name', () => {
+    const base = {
+      tableName: 'contents',
+      columns: {
+        id: { type: 'TEXT', primaryKey: true, notNull: true },
+        title: { type: 'TEXT', notNull: true, default: '' },
+      },
+      indexes: [{ name: 'contents_meta_type_idx', columns: ['_meta_type'] }],
+    };
+    const child = {
+      tableName: 'contents',
+      columns: {
+        id: { type: 'TEXT', primaryKey: true, notNull: true },
+        // A subtype re-declaring `title` differently does not win.
+        title: { type: 'TEXT' },
+        meeting_id: { type: 'TEXT' },
+      },
+      indexes: [
+        { name: 'contents_meta_type_idx', columns: ['_meta_type'] },
+        { name: 'contents_meeting_id_idx', columns: ['meeting_id'] },
+      ],
+    };
+
+    const tables = collectManifestTables([
+      { schema: base, source: 'a:Content' },
+      { schema: child, source: 'b:Agenda' },
+    ]);
+    const table = tables.get('contents');
+    expect(table?.structured).toBe(true);
+    expect(table?.sources).toEqual(['a:Content', 'b:Agenda']);
+    expect(Object.keys(table?.definition.columns ?? {})).toEqual([
+      'id',
+      'title',
+      'meeting_id',
+    ]);
+    expect(table?.definition.columns.title).toEqual({
+      type: 'TEXT',
+      notNull: true,
+      defaultValue: '',
+    });
+    expect(table?.definition.indexes.map((index) => index.name)).toEqual([
+      'contents_meta_type_idx',
+      'contents_meeting_id_idx',
+    ]);
+  });
+
+  it('falls back to the cached ddl only for column-less contributors, still rendering indexes', () => {
+    const legacy = {
+      tableName: 'legacy_things',
+      ddl: 'CREATE TABLE IF NOT EXISTS "legacy_things" ("id" TEXT PRIMARY KEY NOT NULL, "occurred_at" TIMESTAMP, CHECK (length("id") > 0));',
+      indexes: [
+        { name: 'legacy_things_occurred_idx', columns: ['occurred_at'] },
+      ],
+    };
+    const tables = collectManifestTables([
+      { schema: legacy, source: 'x:LegacyThing' },
+    ]);
+    const table = tables.get('legacy_things');
+    expect(table?.structured).toBe(false);
+    if (!table) throw new Error('missing');
+
+    const pg = renderCollectedManifestTable(table, 'postgres');
+    // Cached string, made minimally PG-safe (bare TIMESTAMP → TIMESTAMPTZ).
+    expect(pg.createTable).toContain('"occurred_at" TIMESTAMPTZ');
+    expect(pg.createTable).toContain('CHECK (length("id") > 0)');
+    // Indexes never lived in the string; they come from the strategy.
+    expect(pg.indexes).toEqual([
+      'CREATE INDEX IF NOT EXISTS "legacy_things_occurred_idx" ON "legacy_things" ("occurred_at");',
+    ]);
+  });
+
+  it('degrades a table to the cached-ddl merge when any contributor lacks columns', () => {
+    const structured = {
+      tableName: 'contents',
+      ddl: 'CREATE TABLE IF NOT EXISTS "contents" ("id" TEXT PRIMARY KEY NOT NULL, "title" TEXT);',
+      columns: {
+        id: { type: 'TEXT', primaryKey: true, notNull: true },
+        title: { type: 'TEXT' },
+      },
+      indexes: [],
+    };
+    const legacy = {
+      tableName: 'contents',
+      ddl: 'CREATE TABLE IF NOT EXISTS "contents" ("id" TEXT PRIMARY KEY NOT NULL, "title" TEXT, "meeting_id" TEXT);',
+      indexes: [{ name: 'contents_meeting_id_idx', columns: ['meeting_id'] }],
+    };
+    const tables = collectManifestTables([
+      { schema: structured, source: 'a:Content' },
+      { schema: legacy, source: 'b:Agenda' },
+    ]);
+    const table = tables.get('contents');
+    expect(table?.structured).toBe(false);
+    if (!table) throw new Error('missing');
+    const sqlite = renderCollectedManifestTable(table, 'sqlite');
+    expect(sqlite.createTable).toContain('"meeting_id" TEXT');
+    expect(sqlite.createTable).toContain('"title" TEXT');
+    expect(sqlite.indexes).toEqual([
+      'CREATE INDEX IF NOT EXISTS "contents_meeting_id_idx" ON "contents" ("meeting_id");',
+    ]);
+  });
+
+  it('skips objects with neither columns nor ddl', () => {
+    const tables = collectManifestTables([
+      { schema: { tableName: 'ghost' }, source: 'x:Ghost' },
+    ]);
+    expect(tables.size).toBe(0);
+  });
+});
+
+describe('mergeSchemaDefinitionInto', () => {
+  it('appends new columns and indexes without overwriting existing ones', () => {
+    const target: SchemaDefinition = {
+      tableName: 't',
+      columns: { id: { type: 'TEXT', primaryKey: true } },
+      indexes: [{ name: 't_a_idx', columns: ['a'] }],
+      triggers: [],
+      foreignKeys: [],
+      dependencies: [],
+      version: '',
+    };
+    mergeSchemaDefinitionInto(target, {
+      tableName: 't',
+      columns: { id: { type: 'UUID' }, b: { type: 'INTEGER' } },
+      indexes: [
+        { name: 't_a_idx', columns: ['a'], unique: true },
+        { name: 't_b_idx', columns: ['b'] },
+      ],
+      triggers: [],
+      foreignKeys: [],
+      dependencies: [],
+      version: '',
+    });
+    expect(target.columns.id).toEqual({ type: 'TEXT', primaryKey: true });
+    expect(target.columns.b).toEqual({ type: 'INTEGER' });
+    expect(target.indexes).toEqual([
+      { name: 't_a_idx', columns: ['a'] },
+      { name: 't_b_idx', columns: ['b'] },
+    ]);
+  });
+});
+
+describe('DDL strategies emit NOT NULL on primary keys (#2358)', () => {
+  let db: DatabaseProvider | undefined;
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      try {
+        await db.close();
+      } catch {
+        // ignore
+      }
+    }
+    db = undefined;
+  });
+
+  const things: SchemaDefinition = {
+    tableName: 'pk_things',
+    columns: {
+      id: { type: 'TEXT', primaryKey: true },
+      name: { type: 'TEXT' },
+    },
+    indexes: [],
+    triggers: [],
+    foreignKeys: [],
+    dependencies: [],
+    version: '',
+  };
+
+  it('renders PRIMARY KEY NOT NULL on every engine', () => {
+    for (const engine of ['sqlite', 'postgres', 'duckdb', 'json'] as const) {
+      const sql = getDDLStrategy(engine).generateCreateTable(things);
+      expect(sql, engine).toMatch(/"id" \S+ PRIMARY KEY NOT NULL/);
+    }
+  });
+
+  it('SQLite rejects a NULL id once the strategy spells out NOT NULL', async () => {
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    await db.query(getDDLStrategy('sqlite').generateCreateTable(things));
+
+    // Regression baseline: a bare TEXT PRIMARY KEY accepts NULL on SQLite.
+    await db.query(
+      'CREATE TABLE "pk_bare" ("id" TEXT PRIMARY KEY, "name" TEXT)',
+    );
+    await expect(
+      db.query('INSERT INTO "pk_bare" ("id", "name") VALUES (NULL, ?)', 'x'),
+    ).resolves.toBeDefined();
+
+    await expect(
+      db.query('INSERT INTO "pk_things" ("id", "name") VALUES (NULL, ?)', 'x'),
+    ).rejects.toThrow();
+    const rows = (await db.query(
+      'SELECT COUNT(*) AS n FROM "pk_things"',
+    )) as unknown as Array<{ n: number }> | { rows: Array<{ n: number }> };
+    const [row] = Array.isArray(rows) ? rows : rows.rows;
+    expect(Number(row.n)).toBe(0);
+  });
+});

--- a/packages/core/src/schema/manifest-schema.test.ts
+++ b/packages/core/src/schema/manifest-schema.test.ts
@@ -234,19 +234,20 @@ describe('collectManifestTables + renderCollectedManifestTable', () => {
     ]);
   });
 
-  it('degrades a table to the cached-ddl merge when any contributor lacks columns', () => {
+  it('merges a column-less contributor on top of the strategy render when contributors are mixed', () => {
     const structured = {
       tableName: 'contents',
-      ddl: 'CREATE TABLE IF NOT EXISTS "contents" ("id" TEXT PRIMARY KEY NOT NULL, "title" TEXT);',
+      // A structured contributor need not carry a cached ddl at all.
       columns: {
-        id: { type: 'TEXT', primaryKey: true, notNull: true },
+        id: { type: 'UUID', primaryKey: true, notNull: true },
         title: { type: 'TEXT' },
+        payload: { type: 'JSON' },
       },
       indexes: [],
     };
     const legacy = {
       tableName: 'contents',
-      ddl: 'CREATE TABLE IF NOT EXISTS "contents" ("id" TEXT PRIMARY KEY NOT NULL, "title" TEXT, "meeting_id" TEXT);',
+      ddl: 'CREATE TABLE IF NOT EXISTS "contents" ("id" TEXT PRIMARY KEY NOT NULL, "title" TEXT, "meeting_id" TEXT, "seen_at" TIMESTAMP, CHECK (length("id") > 0));',
       indexes: [{ name: 'contents_meeting_id_idx', columns: ['meeting_id'] }],
     };
     const tables = collectManifestTables([
@@ -256,10 +257,19 @@ describe('collectManifestTables + renderCollectedManifestTable', () => {
     const table = tables.get('contents');
     expect(table?.structured).toBe(false);
     if (!table) throw new Error('missing');
-    const sqlite = renderCollectedManifestTable(table, 'sqlite');
-    expect(sqlite.createTable).toContain('"meeting_id" TEXT');
-    expect(sqlite.createTable).toContain('"title" TEXT');
-    expect(sqlite.indexes).toEqual([
+
+    const pg = renderCollectedManifestTable(table, 'postgres');
+    // Structured contributor keeps its engine typing (not the legacy string's
+    // "id" TEXT / "payload" JSON), the legacy-only columns and table
+    // constraint are appended, and shared columns are not duplicated.
+    expect(pg.createTable).toContain('"id" uuid PRIMARY KEY NOT NULL');
+    expect(pg.createTable).toContain('"payload" JSONB');
+    expect(pg.createTable).toContain('"meeting_id" TEXT');
+    expect(pg.createTable).toContain('"seen_at" TIMESTAMPTZ');
+    expect(pg.createTable).toContain('CHECK (length("id") > 0)');
+    expect(pg.createTable.match(/"title" TEXT/g)).toHaveLength(1);
+    expect(pg.createTable.match(/"id" /g)).toHaveLength(1);
+    expect(pg.indexes).toEqual([
       'CREATE INDEX IF NOT EXISTS "contents_meeting_id_idx" ON "contents" ("meeting_id");',
     ]);
   });

--- a/packages/core/src/schema/manifest-schema.ts
+++ b/packages/core/src/schema/manifest-schema.ts
@@ -1,0 +1,349 @@
+/**
+ * Manifest schema → structured `SchemaDefinition` helpers (#2358).
+ *
+ * A manifest's `schema.ddl` string is an engine-neutral CREATE TABLE preview:
+ * it carries no indexes and no per-engine type mapping, so nothing that needs
+ * an executable schema may treat it as authoritative. Every consumer that
+ * reads raw manifest JSON — `SchemaAggregator`, `createIsolatedTestDbFromManifest`
+ * in `@happyvertical/smrt-vitest`, third-party tooling — should collect the
+ * structured `columns` / `indexes` through this module and render them with
+ * `getDDLStrategy(engine)`, exactly as `db:migrate` does.
+ *
+ * The cached `ddl` string is used only when a manifest object exposes no
+ * structured columns at all (hand-authored or pre-structured manifests); that
+ * legacy path keeps working but is not engine-complete.
+ *
+ * IMPORTANT: keep this module a leaf — type-only imports plus the DDL
+ * strategies. It is imported by `@happyvertical/smrt-vitest`, and must not
+ * pull the registry/collection module graph.
+ */
+
+import { getDDLStrategy } from './ddl/index.js';
+import {
+  findCreateTableBodyRange,
+  getSQLDefinitionComparisonKey,
+  getSQLDefinitionIdentifier,
+  isSQLTableConstraintDefinition,
+  materializeManifestDDLForEngine,
+  tokenizeSQLDDLBody,
+} from './ddl/materialize-manifest.js';
+import type { DatabaseEngine, EngineSpecificDDL } from './ddl/types.js';
+import type {
+  ColumnDefinition,
+  IndexDefinition,
+  SchemaDefinition,
+  SQLDataType,
+} from './types.js';
+
+/**
+ * Column shape as it appears in raw manifest JSON. `ManifestColumnDefinition`
+ * spells the default `default`; registry-side `ColumnDefinition` spells it
+ * `defaultValue`. Hand-authored manifests use either.
+ */
+export interface ManifestColumnLike {
+  type: string;
+  primaryKey?: boolean;
+  referenceKind?: ColumnDefinition['referenceKind'];
+  notNull?: boolean;
+  unique?: boolean;
+  default?: unknown;
+  defaultValue?: unknown;
+  foreignKey?: ColumnDefinition['foreignKey'];
+  check?: string;
+}
+
+/** Index shape as it appears in raw manifest JSON. */
+export interface ManifestIndexLike {
+  name: string;
+  columns?: string[];
+  unique?: boolean;
+  where?: string;
+  jsonPath?: IndexDefinition['jsonPath'];
+}
+
+/** The subset of a manifest object's `schema` this module reads. */
+export interface ManifestSchemaLike {
+  tableName: string;
+  ddl?: string;
+  columns?: Record<string, ManifestColumnLike>;
+  indexes?: ManifestIndexLike[];
+  version?: string;
+}
+
+/**
+ * Convert one raw manifest column map into structured `ColumnDefinition`s.
+ * Picks known fields only, so stray manifest keys never leak into DDL.
+ */
+export function manifestColumnsToDefinitions(
+  columns: Record<string, ManifestColumnLike> | undefined,
+): Record<string, ColumnDefinition> {
+  const result: Record<string, ColumnDefinition> = {};
+  for (const [name, column] of Object.entries(columns || {})) {
+    if (!column || typeof column.type !== 'string') continue;
+    const definition: ColumnDefinition = {
+      type: column.type as SQLDataType,
+    };
+    if (column.primaryKey !== undefined)
+      definition.primaryKey = column.primaryKey;
+    if (column.referenceKind !== undefined)
+      definition.referenceKind = column.referenceKind;
+    if (column.notNull !== undefined) definition.notNull = column.notNull;
+    if (column.unique !== undefined) definition.unique = column.unique;
+    const defaultValue =
+      column.defaultValue !== undefined ? column.defaultValue : column.default;
+    if (defaultValue !== undefined) definition.defaultValue = defaultValue;
+    if (column.foreignKey) definition.foreignKey = { ...column.foreignKey };
+    if (column.check) definition.check = column.check;
+    result[name] = definition;
+  }
+  return result;
+}
+
+/**
+ * Convert raw manifest indexes into structured `IndexDefinition`s, keeping
+ * `where` (partial) and `jsonPath` (expression) targets — the two fields the
+ * retired string-based renderers dropped.
+ */
+export function manifestIndexesToDefinitions(
+  indexes: ManifestIndexLike[] | undefined,
+): IndexDefinition[] {
+  const result: IndexDefinition[] = [];
+  for (const index of indexes || []) {
+    if (!index?.name) continue;
+    const definition: IndexDefinition = {
+      name: index.name,
+      columns: Array.isArray(index.columns) ? [...index.columns] : [],
+    };
+    if (index.unique !== undefined) definition.unique = index.unique;
+    if (index.where) definition.where = index.where;
+    if (index.jsonPath?.column && index.jsonPath.path) {
+      definition.jsonPath = { ...index.jsonPath };
+    }
+    result.push(definition);
+  }
+  return result;
+}
+
+/**
+ * Convert one manifest object's `schema` into a `SchemaDefinition`.
+ *
+ * The cached `ddl` string is carried along (non-authoritative) so callers can
+ * fall back to it when the manifest exposes no structured columns.
+ */
+export function manifestSchemaToDefinition(
+  schema: ManifestSchemaLike,
+): SchemaDefinition {
+  return {
+    tableName: schema.tableName,
+    ddl: schema.ddl,
+    columns: manifestColumnsToDefinitions(schema.columns),
+    indexes: manifestIndexesToDefinitions(schema.indexes),
+    triggers: [],
+    foreignKeys: [],
+    dependencies: [],
+    version: schema.version ?? '',
+  };
+}
+
+/**
+ * One physical table collected from one or more manifest objects (STI
+ * subclasses share a table and each contributes columns and indexes).
+ */
+export interface CollectedManifestTable {
+  tableName: string;
+  /**
+   * Structured union of every contributor: columns first-wins by name,
+   * indexes deduplicated by name.
+   */
+  definition: SchemaDefinition;
+  /**
+   * `true` when every contributor exposed structured columns, i.e. the table
+   * can be rendered by a DDL strategy. `false` means at least one contributor
+   * carried only a cached `ddl` string and the table must fall back to it.
+   */
+  structured: boolean;
+  /**
+   * The contributors' cached `ddl` strings merged column-wise (legacy path).
+   * Empty when no contributor carried a `ddl`.
+   */
+  legacyDdl: string;
+  /** `<package>:<ClassName>` labels of the contributors, in encounter order. */
+  sources: string[];
+}
+
+/**
+ * Deterministic STI merge of two structured definitions: existing columns
+ * win, new columns are appended, indexes are deduplicated by name.
+ */
+export function mergeSchemaDefinitionInto(
+  target: SchemaDefinition,
+  incoming: SchemaDefinition,
+): void {
+  for (const [name, column] of Object.entries(incoming.columns)) {
+    if (!(name in target.columns)) {
+      target.columns[name] = column;
+    }
+  }
+  const indexNames = new Set(target.indexes.map((index) => index.name));
+  for (const index of incoming.indexes) {
+    if (!indexNames.has(index.name)) {
+      indexNames.add(index.name);
+      target.indexes.push(index);
+    }
+  }
+}
+
+/**
+ * Collect manifest schemas into physical tables.
+ *
+ * Accepts the `schema` entries of manifest objects (any package, any manifest)
+ * in encounter order and groups them by `tableName`, merging STI contributors
+ * structurally. Objects without a `schema`/`tableName` are skipped by the
+ * caller; objects with neither columns nor `ddl` are ignored here.
+ */
+export function collectManifestTables(
+  entries: Iterable<{ schema: ManifestSchemaLike; source: string }>,
+): Map<string, CollectedManifestTable> {
+  const tables = new Map<string, CollectedManifestTable>();
+
+  for (const { schema, source } of entries) {
+    if (!schema?.tableName) continue;
+    const definition = manifestSchemaToDefinition(schema);
+    const hasColumns = Object.keys(definition.columns).length > 0;
+    const ddl = typeof schema.ddl === 'string' ? schema.ddl : '';
+    if (!hasColumns && !ddl.trim()) continue;
+
+    const existing = tables.get(schema.tableName);
+    if (!existing) {
+      tables.set(schema.tableName, {
+        tableName: schema.tableName,
+        definition,
+        structured: hasColumns,
+        legacyDdl: ddl,
+        sources: [source],
+      });
+      continue;
+    }
+
+    mergeSchemaDefinitionInto(existing.definition, definition);
+    existing.structured = existing.structured && hasColumns;
+    existing.legacyDdl = existing.legacyDdl
+      ? ddl
+        ? mergeManifestDDL(existing.legacyDdl, ddl)
+        : existing.legacyDdl
+      : ddl;
+    existing.sources.push(source);
+  }
+
+  return tables;
+}
+
+/**
+ * Render a collected table for one engine.
+ *
+ * Structured tables go through the engine strategy for the CREATE TABLE
+ * (per-engine types, inline UNIQUE where the engine needs it) and for every
+ * index (partial `WHERE`, JSON-path expressions, engine-specific syntax).
+ * Legacy tables keep the merged cached `ddl` string, made minimally safe with
+ * `materializeManifestDDLForEngine`, but still render their indexes through
+ * the strategy — the string never carried them.
+ */
+export function renderCollectedManifestTable(
+  table: CollectedManifestTable,
+  engine: DatabaseEngine,
+): EngineSpecificDDL {
+  const strategy = getDDLStrategy(engine);
+  const createTable = table.structured
+    ? strategy.generateCreateTable(table.definition)
+    : materializeManifestDDLForEngine(table.legacyDdl, engine);
+  return {
+    createTable,
+    indexes: strategy.generateIndexes(table.definition),
+    triggers: strategy.generateTriggers(table.definition),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Legacy cached-DDL string merge (column-less manifests only)
+// ---------------------------------------------------------------------------
+
+function parseDefinitionsFromDDL(ddl: string): {
+  columns: Map<string, string>;
+  tableElements: string[];
+} {
+  const columns = new Map<string, string>();
+  const tableElements: string[] = [];
+  const bodyRange = findCreateTableBodyRange(ddl);
+  if (!bodyRange) return { columns, tableElements };
+  const [bodyStart, bodyEnd] = bodyRange;
+
+  const segments = tokenizeSQLDDLBody(ddl.slice(bodyStart + 1, bodyEnd));
+
+  for (const segment of segments) {
+    const identifier = getSQLDefinitionIdentifier(segment);
+    if (!identifier) continue;
+    if (isSQLTableConstraintDefinition(segment)) {
+      tableElements.push(segment);
+      continue;
+    }
+
+    columns.set(identifier.name, segment);
+  }
+
+  return { columns, tableElements };
+}
+
+/**
+ * Merge two cached CREATE TABLE strings for the same table (STI subclasses):
+ * the union of columns, existing definitions winning, new columns inserted
+ * before any trailing table constraints, missing table constraints appended.
+ *
+ * Only the legacy column-less manifest path uses this; structured manifests
+ * merge through `mergeSchemaDefinitionInto`.
+ *
+ * @internal
+ */
+export function mergeManifestDDL(existingDDL: string, newDDL: string): string {
+  const existingDefinitions = parseDefinitionsFromDDL(existingDDL);
+  const newDefinitions = parseDefinitionsFromDDL(newDDL);
+
+  const missingCols: string[] = [];
+  for (const [name, def] of newDefinitions.columns) {
+    if (!existingDefinitions.columns.has(name)) {
+      missingCols.push(def);
+    }
+  }
+
+  const existingTableElements = new Set(
+    existingDefinitions.tableElements.map(getSQLDefinitionComparisonKey),
+  );
+  const missingTableElements = newDefinitions.tableElements.filter(
+    (definition) =>
+      !existingTableElements.has(getSQLDefinitionComparisonKey(definition)),
+  );
+
+  if (missingCols.length === 0 && missingTableElements.length === 0) {
+    return existingDDL;
+  }
+
+  const bodyRange = findCreateTableBodyRange(existingDDL);
+  if (!bodyRange) return existingDDL;
+  const [bodyStart, bodyEnd] = bodyRange;
+  const prefix = existingDDL.slice(0, bodyStart + 1);
+  const body = existingDDL.slice(bodyStart + 1, bodyEnd);
+  const suffix = existingDDL.slice(bodyEnd);
+  const segments = tokenizeSQLDDLBody(body);
+  const firstConstraintIndex = segments.findIndex((segment) =>
+    isSQLTableConstraintDefinition(segment),
+  );
+  const insertionIndex =
+    firstConstraintIndex === -1 ? segments.length : firstConstraintIndex;
+  const mergedSegments = [
+    ...segments.slice(0, insertionIndex),
+    ...missingCols,
+    ...segments.slice(insertionIndex),
+    ...missingTableElements,
+  ];
+
+  return `${prefix}\n${mergedSegments.map((segment) => `  ${segment}`).join(',\n')}\n${suffix}`;
+}

--- a/packages/core/src/schema/manifest-schema.ts
+++ b/packages/core/src/schema/manifest-schema.ts
@@ -212,6 +212,13 @@ export function collectManifestTables(
   entries: Iterable<{ schema: ManifestSchemaLike; source: string }>,
 ): Map<string, CollectedManifestTable> {
   const tables = new Map<string, CollectedManifestTable>();
+  // Structured contributors whose cached ddl declares table constraints. Only
+  // a fully structured table drops them (a mixed table re-merges the string),
+  // so the warning is decided after collection.
+  const constraintCarriers = new Map<
+    string,
+    Array<{ source: string; constraints: string[] }>
+  >();
 
   for (const { schema, source } of entries) {
     if (!schema?.tableName) continue;
@@ -221,7 +228,12 @@ export function collectManifestTables(
     if (!hasColumns && !ddl.trim()) continue;
 
     if (hasColumns && ddl.trim()) {
-      warnAboutDroppedTableConstraints(schema.tableName, source, ddl);
+      const constraints = cachedDdlTableConstraints(ddl);
+      if (constraints.length > 0) {
+        const carriers = constraintCarriers.get(schema.tableName) ?? [];
+        carriers.push({ source, constraints });
+        constraintCarriers.set(schema.tableName, carriers);
+      }
     }
 
     const existing = tables.get(schema.tableName);
@@ -244,6 +256,13 @@ export function collectManifestTables(
         : existing.legacyDdl
       : ddl;
     existing.sources.push(source);
+  }
+
+  for (const [tableName, carriers] of constraintCarriers) {
+    if (!tables.get(tableName)?.structured) continue;
+    for (const { source, constraints } of carriers) {
+      warnAboutDroppedTableConstraints(tableName, source, constraints);
+    }
   }
 
   return tables;
@@ -299,10 +318,19 @@ export function renderCollectedManifestTable(
         (index) =>
           `UNIQUE(${index.columns.map((column) => quoteIdentifier(column)).join(', ')})`,
       );
-    if (uniqueElements.length > 0) {
+    // Hand-authored strings may spell the same constraint without quotes
+    // (`UNIQUE(tenant_id)`); compare quote- and whitespace-insensitively so
+    // the synthesized element is not added beside it.
+    const declared = new Set(
+      cachedDdlTableConstraints(createTable).map(normalizeTableElement),
+    );
+    const missing = uniqueElements.filter(
+      (element) => !declared.has(normalizeTableElement(element)),
+    );
+    if (missing.length > 0) {
       createTable = mergeManifestDDL(
         createTable,
-        `CREATE TABLE ${quoteIdentifier(table.tableName)} (\n  ${uniqueElements.join(',\n  ')}\n)`,
+        `CREATE TABLE ${quoteIdentifier(table.tableName)} (\n  ${missing.join(',\n  ')}\n)`,
       );
     }
   }
@@ -356,20 +384,28 @@ export function cachedDdlTableConstraints(ddl: string): string[] {
   return parseDefinitionsFromDDL(ddl).tableElements;
 }
 
+/** Quote/whitespace/case-insensitive key for a table constraint element. */
+function normalizeTableElement(element: string): string {
+  return element.replace(/"/g, '').replace(/\s+/g, '').toLowerCase();
+}
+
+const warnedDroppedConstraints = new Set<string>();
+
 /**
- * Warn once per table+source when a structured contributor's cached `ddl`
- * declares table constraints that the structured render cannot carry. The
- * structured schema is authoritative: a constraint that lives only in the
- * string never reaches `db:migrate` either, so rendering it here would
+ * Warn once per process per table+source when a structured contributor's
+ * cached `ddl` declares table constraints that the structured render cannot
+ * carry. The structured schema is authoritative: a constraint that lives only
+ * in the string never reaches `db:migrate` either, so rendering it here would
  * recreate the test/production drift #2358 removes.
  */
 function warnAboutDroppedTableConstraints(
   tableName: string,
   source: string,
-  ddl: string,
+  constraints: string[],
 ): void {
-  const constraints = cachedDdlTableConstraints(ddl);
-  if (constraints.length === 0) return;
+  const key = `${tableName}\0${source}`;
+  if (warnedDroppedConstraints.has(key)) return;
+  warnedDroppedConstraints.add(key);
   logger.warn(
     `[manifest-schema] ${source}: cached ddl for table "${tableName}" declares ` +
       `${constraints.length} table constraint(s) that structured columns cannot ` +

--- a/packages/core/src/schema/manifest-schema.ts
+++ b/packages/core/src/schema/manifest-schema.ts
@@ -13,11 +13,12 @@
  * structured columns at all (hand-authored or pre-structured manifests); that
  * legacy path keeps working but is not engine-complete.
  *
- * IMPORTANT: keep this module a leaf — type-only imports plus the DDL
- * strategies. It is imported by `@happyvertical/smrt-vitest`, and must not
- * pull the registry/collection module graph.
+ * Keep this module light — type-only imports plus the DDL strategies and the
+ * logger — so it can be re-exported from lightweight entry points without
+ * pulling the registry/collection module graph in by itself.
  */
 
+import { createLogger } from '@happyvertical/logger';
 import { getDDLStrategy } from './ddl/index.js';
 import {
   findCreateTableBodyRange,
@@ -35,6 +36,8 @@ import type {
   SchemaDefinition,
   SQLDataType,
 } from './types.js';
+
+const logger = createLogger({ level: 'info' });
 
 /**
  * Column shape as it appears in raw manifest JSON. `ManifestColumnDefinition`
@@ -162,7 +165,8 @@ export interface CollectedManifestTable {
    * table is rendered by a DDL strategy. `false` means at least one
    * contributor carried only a cached `ddl` string: the CREATE TABLE is then
    * the strategy render of the structured contributors (if any) merged with
-   * the cached strings of the column-less ones.
+   * the cached strings of the column-less ones. The decision is per table,
+   * not per contributor.
    */
   structured: boolean;
   /**
@@ -215,6 +219,10 @@ export function collectManifestTables(
     const hasColumns = Object.keys(definition.columns).length > 0;
     const ddl = typeof schema.ddl === 'string' ? schema.ddl : '';
     if (!hasColumns && !ddl.trim()) continue;
+
+    if (hasColumns && ddl.trim()) {
+      warnAboutDroppedTableConstraints(schema.tableName, source, ddl);
+    }
 
     const existing = tables.get(schema.tableName);
     if (!existing) {
@@ -337,16 +345,49 @@ function parseDefinitionsFromDDL(ddl: string): {
 }
 
 /**
+ * Table-level constraints (`UNIQUE(...)`, `CHECK (...)`, `CONSTRAINT ...`,
+ * ...) declared in a cached CREATE TABLE string. Structured `columns` cannot
+ * represent them, so a structured render drops them — exactly as `db:migrate`
+ * does. Exposed so callers can warn instead of losing them silently.
+ *
+ * @internal
+ */
+export function cachedDdlTableConstraints(ddl: string): string[] {
+  return parseDefinitionsFromDDL(ddl).tableElements;
+}
+
+/**
+ * Warn once per table+source when a structured contributor's cached `ddl`
+ * declares table constraints that the structured render cannot carry. The
+ * structured schema is authoritative: a constraint that lives only in the
+ * string never reaches `db:migrate` either, so rendering it here would
+ * recreate the test/production drift #2358 removes.
+ */
+function warnAboutDroppedTableConstraints(
+  tableName: string,
+  source: string,
+  ddl: string,
+): void {
+  const constraints = cachedDdlTableConstraints(ddl);
+  if (constraints.length === 0) return;
+  logger.warn(
+    `[manifest-schema] ${source}: cached ddl for table "${tableName}" declares ` +
+      `${constraints.length} table constraint(s) that structured columns cannot ` +
+      `carry (${constraints.join('; ')}). They are not rendered — the ` +
+      `structured schema is authoritative (#2358). Declare uniqueness through ` +
+      `indexes/conflictColumns or a column-level constraint instead.`,
+  );
+}
+
+/**
  * Merge two cached CREATE TABLE strings for the same table (STI subclasses):
  * the union of columns, existing definitions winning, new columns inserted
  * before any trailing table constraints, missing table constraints appended.
  *
  * Only the legacy column-less manifest path uses this; structured manifests
  * merge through `mergeSchemaDefinitionInto`.
- *
- * @internal
  */
-export function mergeManifestDDL(existingDDL: string, newDDL: string): string {
+function mergeManifestDDL(existingDDL: string, newDDL: string): string {
   const existingDefinitions = parseDefinitionsFromDDL(existingDDL);
   const newDefinitions = parseDefinitionsFromDDL(newDDL);
 

--- a/packages/core/src/schema/manifest-schema.ts
+++ b/packages/core/src/schema/manifest-schema.ts
@@ -157,9 +157,11 @@ export interface CollectedManifestTable {
    */
   definition: SchemaDefinition;
   /**
-   * `true` when every contributor exposed structured columns, i.e. the table
-   * can be rendered by a DDL strategy. `false` means at least one contributor
-   * carried only a cached `ddl` string and the table must fall back to it.
+   * `true` when every contributor exposed structured columns, i.e. the whole
+   * table is rendered by a DDL strategy. `false` means at least one
+   * contributor carried only a cached `ddl` string: the CREATE TABLE is then
+   * the strategy render of the structured contributors (if any) merged with
+   * the cached strings of the column-less ones.
    */
   structured: boolean;
   /**
@@ -244,18 +246,30 @@ export function collectManifestTables(
  * Structured tables go through the engine strategy for the CREATE TABLE
  * (per-engine types, inline UNIQUE where the engine needs it) and for every
  * index (partial `WHERE`, JSON-path expressions, engine-specific syntax).
- * Legacy tables keep the merged cached `ddl` string, made minimally safe with
- * `materializeManifestDDLForEngine`, but still render their indexes through
- * the strategy — the string never carried them.
+ * Tables with a column-less contributor keep that contributor's cached `ddl`
+ * string, made minimally safe with `materializeManifestDDLForEngine`, merged
+ * on top of the strategy render of any structured contributors — so a
+ * structured STI base never loses its engine typing to a hand-authored
+ * subclass, and the subclass's extra columns and table constraints survive.
+ * Indexes always render through the strategy — the string never carried them.
  */
 export function renderCollectedManifestTable(
   table: CollectedManifestTable,
   engine: DatabaseEngine,
 ): EngineSpecificDDL {
   const strategy = getDDLStrategy(engine);
-  const createTable = table.structured
-    ? strategy.generateCreateTable(table.definition)
-    : materializeManifestDDLForEngine(table.legacyDdl, engine);
+  const hasColumns = Object.keys(table.definition.columns).length > 0;
+  let createTable: string;
+  if (table.structured) {
+    createTable = strategy.generateCreateTable(table.definition);
+  } else if (hasColumns) {
+    createTable = mergeManifestDDL(
+      strategy.generateCreateTable(table.definition),
+      materializeManifestDDLForEngine(table.legacyDdl, engine),
+    );
+  } else {
+    createTable = materializeManifestDDLForEngine(table.legacyDdl, engine);
+  }
   return {
     createTable,
     indexes: strategy.generateIndexes(table.definition),

--- a/packages/core/src/schema/manifest-schema.ts
+++ b/packages/core/src/schema/manifest-schema.ts
@@ -28,6 +28,7 @@ import {
   tokenizeSQLDDLBody,
 } from './ddl/materialize-manifest.js';
 import type { DatabaseEngine, EngineSpecificDDL } from './ddl/types.js';
+import { quoteIdentifier } from './sql-identifiers.js';
 import type {
   ColumnDefinition,
   IndexDefinition,
@@ -270,6 +271,34 @@ export function renderCollectedManifestTable(
   } else {
     createTable = materializeManifestDDLForEngine(table.legacyDdl, engine);
   }
+
+  // Engines that need UNIQUE inline for ON CONFLICT (DuckDB, JSON) get it
+  // from `generateCreateTable` on the structured path and skip those indexes
+  // in `generateIndexes`. A cached string never carried them, so a table with
+  // a column-less contributor would lose its uniqueness entirely; append the
+  // missing constraints as table elements (deduplicated against any the
+  // string already declares).
+  if (!table.structured && strategy.requiresInlineUnique()) {
+    const uniqueElements = table.definition.indexes
+      .filter(
+        (index) =>
+          index.unique &&
+          !index.where &&
+          !index.jsonPath &&
+          index.columns.length > 0,
+      )
+      .map(
+        (index) =>
+          `UNIQUE(${index.columns.map((column) => quoteIdentifier(column)).join(', ')})`,
+      );
+    if (uniqueElements.length > 0) {
+      createTable = mergeManifestDDL(
+        createTable,
+        `CREATE TABLE ${quoteIdentifier(table.tableName)} (\n  ${uniqueElements.join(',\n  ')}\n)`,
+      );
+    }
+  }
+
   return {
     createTable,
     indexes: strategy.generateIndexes(table.definition),

--- a/packages/core/src/schema/schema-aggregator.ts
+++ b/packages/core/src/schema/schema-aggregator.ts
@@ -4,6 +4,12 @@
  * Aggregates database schemas across multiple SMRT package manifests.
  * Handles STI table deduplication, index merging, and sorting for deterministic output.
  *
+ * Tables and indexes are rendered from the manifests' structured `columns` /
+ * `indexes` through the dialect's DDL strategy (`getDDLStrategy`), the same
+ * renderer `smrt db:migrate` uses — never from the cached `schema.ddl` string,
+ * which carries no indexes and no per-engine types (#2358). Objects that expose
+ * no structured columns fall back to their cached `ddl` for the CREATE TABLE.
+ *
  * This replaces the manual generate-schema.ts pattern used by downstream
  * projects like blindmanpress.com (Issue #1013).
  *
@@ -31,16 +37,12 @@ import { join } from 'node:path';
 import { discoverSmrtPackages } from '../manifest/discover-smrt-packages.js';
 import { loadExternalManifestSync } from '../manifest/manifest-loader.js';
 import type { SmartObjectManifest } from '../scanner/types.js';
+import type { DatabaseEngine } from './ddl/types.js';
 import {
-  findCreateTableBodyRange,
-  getSQLDefinitionComparisonKey,
-  getSQLDefinitionIdentifier,
-  isSQLTableConstraintDefinition,
-  materializeManifestDDLForEngine,
-  tokenizeSQLDDLBody,
-} from './ddl/materialize-manifest.js';
-import { quoteIdentifier } from './sql-identifiers.js';
-import { renderIndexTarget } from './utils.js';
+  collectManifestTables,
+  renderCollectedManifestTable,
+} from './manifest-schema.js';
+import type { ColumnDefinition } from './types.js';
 
 // ============================================================================
 // Types
@@ -52,14 +54,21 @@ import { renderIndexTarget } from './utils.js';
 export interface AggregatedTable {
   /** Table name */
   tableName: string;
-  /** CREATE TABLE statement (most comprehensive version for STI tables) */
+  /**
+   * CREATE TABLE statement rendered by the dialect's DDL strategy from the
+   * merged structured columns of every contributing class (STI union).
+   */
   ddl: string;
-  /** CREATE INDEX statements (deduplicated across sources) */
+  /**
+   * CREATE INDEX statements rendered by the same strategy (partial `WHERE`
+   * and JSON-path targets included), deduplicated by index name across
+   * sources.
+   */
   indexes: string[];
   /** Package:className sources that contribute to this table */
   sources: string[];
-  /** Schema definition metadata */
-  columns?: Record<string, unknown>;
+  /** Merged structured columns (first contributor wins per column name) */
+  columns?: Record<string, ColumnDefinition>;
 }
 
 /**
@@ -141,77 +150,6 @@ const DEFAULT_MINIMAL_SKIP_PATTERNS: RegExp[] = [
   /_relationship_term/,
   /_relationship_type/,
 ];
-
-function parseDefinitionsFromDDL(ddl: string): {
-  columns: Map<string, string>;
-  tableElements: string[];
-} {
-  const columns = new Map<string, string>();
-  const tableElements: string[] = [];
-  const bodyRange = findCreateTableBodyRange(ddl);
-  if (!bodyRange) return { columns, tableElements };
-  const [bodyStart, bodyEnd] = bodyRange;
-
-  const segments = tokenizeSQLDDLBody(ddl.slice(bodyStart + 1, bodyEnd));
-
-  for (const segment of segments) {
-    const identifier = getSQLDefinitionIdentifier(segment);
-    if (!identifier) continue;
-    if (isSQLTableConstraintDefinition(segment)) {
-      tableElements.push(segment);
-      continue;
-    }
-
-    columns.set(identifier.name, segment);
-  }
-
-  return { columns, tableElements };
-}
-
-function mergeDDL(existingDDL: string, newDDL: string): string {
-  const existingDefinitions = parseDefinitionsFromDDL(existingDDL);
-  const newDefinitions = parseDefinitionsFromDDL(newDDL);
-
-  const missingCols: string[] = [];
-  for (const [name, def] of newDefinitions.columns) {
-    if (!existingDefinitions.columns.has(name)) {
-      missingCols.push(def);
-    }
-  }
-
-  const existingTableElements = new Set(
-    existingDefinitions.tableElements.map(getSQLDefinitionComparisonKey),
-  );
-  const missingTableElements = newDefinitions.tableElements.filter(
-    (definition) =>
-      !existingTableElements.has(getSQLDefinitionComparisonKey(definition)),
-  );
-
-  if (missingCols.length === 0 && missingTableElements.length === 0) {
-    return existingDDL;
-  }
-
-  const bodyRange = findCreateTableBodyRange(existingDDL);
-  if (!bodyRange) return existingDDL;
-  const [bodyStart, bodyEnd] = bodyRange;
-  const prefix = existingDDL.slice(0, bodyStart + 1);
-  const body = existingDDL.slice(bodyStart + 1, bodyEnd);
-  const suffix = existingDDL.slice(bodyEnd);
-  const segments = tokenizeSQLDDLBody(body);
-  const firstConstraintIndex = segments.findIndex((segment) =>
-    isSQLTableConstraintDefinition(segment),
-  );
-  const insertionIndex =
-    firstConstraintIndex === -1 ? segments.length : firstConstraintIndex;
-  const mergedSegments = [
-    ...segments.slice(0, insertionIndex),
-    ...missingCols,
-    ...segments.slice(insertionIndex),
-    ...missingTableElements,
-  ];
-
-  return `${prefix}\n${mergedSegments.map((segment) => `  ${segment}`).join(',\n')}\n${suffix}`;
-}
 
 // ============================================================================
 // SchemaAggregator
@@ -315,7 +253,10 @@ export class SchemaAggregator {
           ) as SmartObjectManifest;
           // Only use local if it has schemas
           const hasSchemas = Object.values(content.objects || {}).some(
-            (obj) => obj.schema?.ddl,
+            (obj) =>
+              obj.schema?.tableName &&
+              (Object.keys(obj.schema.columns || {}).length > 0 ||
+                obj.schema.ddl),
           );
           if (hasSchemas) return content;
         } catch {
@@ -349,92 +290,52 @@ export class SchemaAggregator {
   /**
    * Extract schemas from manifests, deduplicating STI tables.
    *
-   * For STI tables (shared by multiple classes across packages),
-   * keeps the most comprehensive DDL (largest) and merges indexes.
+   * STI tables (shared by multiple classes across packages) are merged
+   * structurally — columns first-wins by name, indexes deduplicated by name —
+   * and every table is rendered through the dialect's DDL strategy, the same
+   * renderer `db:migrate` uses. The manifest's cached `schema.ddl` string is
+   * consulted only for objects that expose no structured columns (#2358).
    */
   private extractSchemas(
     manifests: SmartObjectManifest[],
     dialect?: 'postgres' | 'sqlite',
   ): Map<string, AggregatedTable> {
-    const tables = new Map<string, AggregatedTable>();
-    // The aggregator only knows sqlite vs postgres; jsonPath rendering
-    // treats anything non-sqlite as the postgres-style `->>` form, which
-    // is also what DuckDB accepts. Default mirrors `AggregateOptions.dialect`
-    // (`@default 'postgres'`) so unspecified callers get the documented shape.
-    const engine: 'sqlite' | 'postgres' | 'duckdb' =
-      dialect === 'sqlite' ? 'sqlite' : 'postgres';
+    // Default mirrors `AggregateOptions.dialect` (`@default 'postgres'`) so
+    // unspecified callers get the documented shape.
+    const engine: DatabaseEngine = dialect === 'sqlite' ? 'sqlite' : 'postgres';
 
+    const entries: Array<{
+      schema: NonNullable<SmartObjectManifest['objects'][string]['schema']>;
+      source: string;
+    }> = [];
     for (const manifest of manifests) {
       for (const [_key, object] of Object.entries(manifest.objects)) {
         const schema = object.schema;
-        if (!schema?.ddl) continue;
-
+        if (!schema?.tableName) continue;
         const className: string = object.className || _key;
-        const tableName: string = schema.tableName;
-        const existing = tables.get(tableName);
-        const executableDDL = materializeManifestDDLForEngine(
-          schema.ddl,
-          engine,
-        );
-
-        if (existing) {
-          // STI table — merge columns from every subtype into the shared DDL.
-          existing.ddl = mergeDDL(existing.ddl, executableDDL);
-          existing.sources.push(`${manifest.packageName || '?'}:${className}`);
-          if (schema.columns) {
-            existing.columns = {
-              ...(existing.columns || {}),
-              ...schema.columns,
-            };
-          }
-
-          // Merge indexes (deduplicate by SQL text)
-          for (const idx of schema.indexes || []) {
-            const indexDdl = this.formatIndexDdl(idx, tableName, engine);
-            if (!existing.indexes.includes(indexDdl)) {
-              existing.indexes.push(indexDdl);
-            }
-          }
-        } else {
-          // New table
-          const indexes: string[] = [];
-          for (const idx of schema.indexes || []) {
-            indexes.push(this.formatIndexDdl(idx, tableName, engine));
-          }
-
-          tables.set(tableName, {
-            tableName,
-            ddl: executableDDL,
-            indexes,
-            sources: [`${manifest.packageName || '?'}:${className}`],
-            columns: schema.columns,
-          });
-        }
+        entries.push({
+          schema,
+          source: `${manifest.packageName || '?'}:${className}`,
+        });
       }
     }
 
-    return tables;
-  }
+    const tables = new Map<string, AggregatedTable>();
+    for (const [tableName, table] of collectManifestTables(entries)) {
+      const rendered = renderCollectedManifestTable(table, engine);
+      tables.set(tableName, {
+        tableName,
+        ddl: rendered.createTable,
+        indexes: rendered.indexes,
+        sources: table.sources,
+        columns:
+          Object.keys(table.definition.columns).length > 0
+            ? table.definition.columns
+            : undefined,
+      });
+    }
 
-  /**
-   * Format an index definition into a CREATE INDEX statement.
-   */
-  private formatIndexDdl(
-    idx: {
-      name: string;
-      columns: string[];
-      unique?: boolean;
-      jsonPath?: { column: string; path: string };
-    },
-    tableName: string,
-    engine: 'sqlite' | 'postgres' | 'duckdb' = 'sqlite',
-  ): string {
-    const target = renderIndexTarget(idx, engine);
-    const indexName = quoteIdentifier(idx.name);
-    const table = quoteIdentifier(tableName);
-    return idx.unique
-      ? `CREATE UNIQUE INDEX IF NOT EXISTS ${indexName} ON ${table} (${target});`
-      : `CREATE INDEX IF NOT EXISTS ${indexName} ON ${table} (${target});`;
+    return tables;
   }
 
   /**

--- a/packages/core/src/schema/schema-aggregator.ts
+++ b/packages/core/src/schema/schema-aggregator.ts
@@ -40,9 +40,9 @@ import type { SmartObjectManifest } from '../scanner/types.js';
 import type { DatabaseEngine } from './ddl/types.js';
 import {
   collectManifestTables,
+  type ManifestColumnLike,
   renderCollectedManifestTable,
 } from './manifest-schema.js';
-import type { ColumnDefinition } from './types.js';
 
 // ============================================================================
 // Types
@@ -56,7 +56,10 @@ export interface AggregatedTable {
   tableName: string;
   /**
    * CREATE TABLE statement rendered by the dialect's DDL strategy from the
-   * merged structured columns of every contributing class (STI union).
+   * merged structured columns of every contributing class (STI union). A
+   * table with a column-less contributor (hand-authored manifest) has that
+   * contributor's cached `ddl` merged on top; a table with no structured
+   * columns at all is the merged cached `ddl`.
    */
   ddl: string;
   /**
@@ -67,8 +70,12 @@ export interface AggregatedTable {
   indexes: string[];
   /** Package:className sources that contribute to this table */
   sources: string[];
-  /** Merged structured columns (first contributor wins per column name) */
-  columns?: Record<string, ColumnDefinition>;
+  /**
+   * Manifest column metadata as published in `manifest.json` (`default`,
+   * not `defaultValue`), merged across contributors — first contributor wins
+   * per column name, matching the rendered DDL.
+   */
+  columns?: Record<string, ManifestColumnLike>;
 }
 
 /**
@@ -308,6 +315,13 @@ export class SchemaAggregator {
       schema: NonNullable<SmartObjectManifest['objects'][string]['schema']>;
       source: string;
     }> = [];
+    // Published manifest column metadata, merged first-wins per table so
+    // `AggregatedTable.columns` keeps its manifest shape for downstream
+    // generate-schema scripts.
+    const manifestColumns = new Map<
+      string,
+      Record<string, ManifestColumnLike>
+    >();
     for (const manifest of manifests) {
       for (const [_key, object] of Object.entries(manifest.objects)) {
         const schema = object.schema;
@@ -317,6 +331,13 @@ export class SchemaAggregator {
           schema,
           source: `${manifest.packageName || '?'}:${className}`,
         });
+        if (schema.columns && Object.keys(schema.columns).length > 0) {
+          const merged = manifestColumns.get(schema.tableName) ?? {};
+          for (const [name, column] of Object.entries(schema.columns)) {
+            if (!(name in merged)) merged[name] = column;
+          }
+          manifestColumns.set(schema.tableName, merged);
+        }
       }
     }
 
@@ -328,10 +349,7 @@ export class SchemaAggregator {
         ddl: rendered.createTable,
         indexes: rendered.indexes,
         sources: table.sources,
-        columns:
-          Object.keys(table.definition.columns).length > 0
-            ? table.definition.columns
-            : undefined,
+        columns: manifestColumns.get(tableName),
       });
     }
 

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -123,8 +123,8 @@ export interface SchemaDefinition {
    * per-engine type mapping (`REAL`/`JSON`/`UUID`/`TIMESTAMP` stay abstract).
    * Kept for backward compatibility with published manifests and third-party
    * tooling; framework consumers render `columns` and `indexes` through
-   * `getDDLStrategy(engine)` and only fall back to `ddl` when `columns` is
-   * empty (hand-authored manifests).
+   * `getDDLStrategy(engine)` and only merge `ddl` in for a table whose
+   * contributors expose no `columns` (hand-authored manifests).
    */
   ddl?: string;
   columns: Record<string, ColumnDefinition>;

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -77,7 +77,16 @@ export interface ForeignKeyDefinition {
 
 export interface SchemaDefinition {
   tableName: string;
-  /** SQL DDL statement for table creation (optional - may be generated lazily) */
+  /**
+   * Engine-neutral CREATE TABLE preview (optional; may be generated lazily).
+   *
+   * Non-authoritative (#2358): it carries no indexes, no triggers and no
+   * per-engine type mapping (`REAL`/`JSON`/`UUID`/`TIMESTAMP` stay abstract).
+   * Kept for backward compatibility with published manifests and third-party
+   * tooling; framework consumers render `columns` and `indexes` through
+   * `getDDLStrategy(engine)` and only fall back to `ddl` when `columns` is
+   * empty (hand-authored manifests).
+   */
   ddl?: string;
   columns: Record<string, ColumnDefinition>;
   indexes: IndexDefinition[];

--- a/packages/core/src/schema/utils.ts
+++ b/packages/core/src/schema/utils.ts
@@ -23,6 +23,17 @@ export {
 // Index-rendering helpers live in a separate file to avoid pulling the
 // heavyweight registry/collection module graph into the DDL strategies.
 export { isJsonPathIndex, renderIndexTarget } from './index-utils.js';
+// Structured manifest → executable DDL helpers (#2358). Re-exported here for
+// `@happyvertical/smrt-vitest`, which already imports this subpath.
+export {
+  type CollectedManifestTable,
+  collectManifestTables,
+  type ManifestColumnLike,
+  type ManifestIndexLike,
+  type ManifestSchemaLike,
+  manifestSchemaToDefinition,
+  renderCollectedManifestTable,
+} from './manifest-schema.js';
 
 /**
  * Generates a complete database schema SQL statement for a class

--- a/packages/core/src/schema/utils.ts
+++ b/packages/core/src/schema/utils.ts
@@ -31,7 +31,10 @@ export {
   type ManifestColumnLike,
   type ManifestIndexLike,
   type ManifestSchemaLike,
+  manifestColumnsToDefinitions,
+  manifestIndexesToDefinitions,
   manifestSchemaToDefinition,
+  mergeSchemaDefinitionInto,
   renderCollectedManifestTable,
 } from './manifest-schema.js';
 

--- a/packages/vitest/AGENTS.md
+++ b/packages/vitest/AGENTS.md
@@ -72,6 +72,17 @@ same `retry` policy inline in their own `vitest.config.ts`.
 
 **DB adapter auto-detection**: `DATABASE_URL` set → PostgreSQL; otherwise → SQLite temp files.
 
+`createIsolatedTestDbFromManifest()` renders tables **and indexes** from the
+manifest's structured `schema.columns` / `schema.indexes` through the engine
+DDL strategy (`collectManifestTables` + `renderCollectedManifestTable` from
+`@happyvertical/smrt-core/schema/utils`) — the same renderer `db:migrate` uses,
+so partial `WHERE` predicates, JSON-path targets and per-engine types match a
+migrated database (#2358; parity asserted in
+`src/__tests__/manifest-schema-path-parity.test.ts`). The cached `schema.ddl`
+string is a CREATE TABLE preview and is executed only for manifest objects that
+expose no `columns` (hand-authored manifests). Do not add a private DDL/index
+renderer here; extend the core strategy instead.
+
 For local file-backed SQLite, identical schemas are prepared once per Vitest
 process and cloned from an immutable schema-only template for later databases.
 The cache key is the full generated DDL, concurrent first callers share one

--- a/packages/vitest/AGENTS.md
+++ b/packages/vitest/AGENTS.md
@@ -79,9 +79,9 @@ DDL strategy (`collectManifestTables` + `renderCollectedManifestTable` from
 so partial `WHERE` predicates, JSON-path targets and per-engine types match a
 migrated database (#2358; parity asserted in
 `src/__tests__/manifest-schema-path-parity.test.ts`). The cached `schema.ddl`
-string is a CREATE TABLE preview and is executed only for manifest objects that
-expose no `columns` (hand-authored manifests). Do not add a private DDL/index
-renderer here; extend the core strategy instead.
+string is a CREATE TABLE preview and is merged in only for a table whose
+contributors expose no `columns` (hand-authored manifests). Do not add a
+private DDL/index renderer here; extend the core strategy instead.
 
 For local file-backed SQLite, identical schemas are prepared once per Vitest
 process and cloned from an immutable schema-only template for later databases.

--- a/packages/vitest/src/__tests__/issue-2069-postgres-manifest.optional.test.ts
+++ b/packages/vitest/src/__tests__/issue-2069-postgres-manifest.optional.test.ts
@@ -62,4 +62,104 @@ postgresDescribe('PostgreSQL manifest Date materialization (#2069)', () => {
       rmSync(manifestPath, { force: true });
     }
   });
+
+  it('renders structured manifest columns and indexes through the PostgreSQL strategy (#2358)', async () => {
+    const suffix = randomUUID().replaceAll('-', '').slice(0, 12);
+    const tableName = `issue_2358_manifest_${suffix}`;
+    const manifestPath = join(
+      tmpdir(),
+      `smrt-vitest-issue-2358-${suffix}.json`,
+    );
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        objects: {
+          StructuredRecord: {
+            className: 'StructuredRecord',
+            schema: {
+              tableName,
+              // Cached preview: CREATE TABLE only, abstract types. Must NOT
+              // be what the database receives.
+              ddl: `CREATE TABLE IF NOT EXISTS "${tableName}" ("id" TEXT PRIMARY KEY NOT NULL, "payload" JSON, "ratio" REAL, "occurred_at" TIMESTAMP, "deleted_at" TIMESTAMP)`,
+              columns: {
+                id: { type: 'UUID', primaryKey: true, notNull: true },
+                payload: { type: 'JSON' },
+                ratio: { type: 'REAL' },
+                occurred_at: { type: 'TIMESTAMP', notNull: true },
+                deleted_at: { type: 'TIMESTAMP' },
+              },
+              indexes: [
+                { name: `${tableName}_occurred_idx`, columns: ['occurred_at'] },
+                {
+                  name: `${tableName}_live_idx`,
+                  columns: ['occurred_at'],
+                  where: '"deleted_at" IS NULL',
+                },
+                {
+                  name: `${tableName}_kind_idx`,
+                  columns: [],
+                  jsonPath: { column: 'payload', path: 'kind' },
+                },
+              ],
+            },
+          },
+        },
+      }),
+    );
+
+    const result = await createIsolatedTestDbFromManifest({ manifestPath });
+    try {
+      const columnsResult = await result.db.query(
+        `SELECT column_name, data_type, is_nullable
+         FROM information_schema.columns
+         WHERE table_schema = current_schema()
+           AND table_name = $1
+         ORDER BY ordinal_position`,
+        tableName,
+      );
+      const columns = (
+        Array.isArray(columnsResult)
+          ? columnsResult
+          : ((columnsResult as { rows?: unknown[] }).rows ?? [])
+      ) as Array<{
+        column_name: string;
+        data_type: string;
+        is_nullable: string;
+      }>;
+      const byName = new Map(columns.map((c) => [c.column_name, c]));
+      expect(byName.get('id')).toMatchObject({
+        data_type: 'uuid',
+        is_nullable: 'NO',
+      });
+      expect(byName.get('payload')?.data_type).toBe('jsonb');
+      expect(byName.get('ratio')?.data_type).toBe('double precision');
+      expect(byName.get('occurred_at')?.data_type).toBe(
+        'timestamp with time zone',
+      );
+
+      const indexResult = await result.db.query(
+        `SELECT indexname, indexdef FROM pg_indexes
+         WHERE schemaname = current_schema() AND tablename = $1
+         ORDER BY indexname`,
+        tableName,
+      );
+      const indexes = (
+        Array.isArray(indexResult)
+          ? indexResult
+          : ((indexResult as { rows?: unknown[] }).rows ?? [])
+      ) as Array<{ indexname: string; indexdef: string }>;
+      const defs = new Map(indexes.map((i) => [i.indexname, i.indexdef]));
+      expect(defs.has(`${tableName}_occurred_idx`)).toBe(true);
+      expect(defs.get(`${tableName}_live_idx`)).toMatch(
+        /WHERE \(deleted_at IS NULL\)/,
+      );
+      expect(defs.get(`${tableName}_kind_idx`)).toContain("->> 'kind'");
+
+      await result.db.rollback();
+      await result.baseDb.query(`DROP TABLE IF EXISTS "${tableName}"`);
+    } finally {
+      await result.cleanup();
+      rmSync(manifestPath, { force: true });
+    }
+  });
 });

--- a/packages/vitest/src/__tests__/manifest-schema-path-parity.test.ts
+++ b/packages/vitest/src/__tests__/manifest-schema-path-parity.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Schema path parity for `createIsolatedTestDbFromManifest` (#2358).
+ *
+ * A manifest-derived isolated test database must carry the same tables and
+ * the same indexes as the migration path (`db:migrate` /
+ * `MigrationGenerator`) for the same manifest schema — including partial
+ * `WHERE` predicates, JSON-path targets, and the SQLite primary-key NOT NULL.
+ * Before #2358 the test-db path executed the cached `schema.ddl` string and a
+ * private index renderer that dropped `where`/`jsonPath`, so tests ran against
+ * a schema no deployment received.
+ *
+ * TODO(#2359): fold these assertions into
+ * `packages/core/src/schema/schema-path-parity.test.ts` once it lands. They
+ * live here because smrt-core cannot depend on smrt-vitest.
+ *
+ * SQLite-only: the assertions read `sqlite_master`. The PostgreSQL manifest
+ * lane (`issue-2069-postgres-manifest.optional.test.ts`) covers PG typing.
+ */
+
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MigrationGenerator } from '@happyvertical/smrt-core/migrations';
+import { manifestSchemaToDefinition } from '@happyvertical/smrt-core/schema/utils';
+import { getDatabase } from '@happyvertical/sql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  createIsolatedTestDbFromManifest,
+  getTestAdapter,
+} from '../test-db.js';
+
+const testDir = join(tmpdir(), `smrt-vitest-parity-${Date.now()}`);
+
+type Row = Record<string, unknown>;
+
+async function rows(
+  db: { query: (sql: string, ...params: unknown[]) => Promise<unknown> },
+  sql: string,
+): Promise<Row[]> {
+  const result = await db.query(sql);
+  return Array.isArray(result)
+    ? (result as Row[])
+    : ((result as { rows?: Row[] }).rows ?? []);
+}
+
+/**
+ * Named (non-autoindex) indexes of a table: name → normalized SQL.
+ *
+ * Whitespace and identifier quotes are normalized: the isolated test-db path
+ * applies its DDL through the SDK's `syncSchema`, which stores the statement
+ * with bare identifiers, while a directly executed migration keeps the
+ * quotes. Both are the same index.
+ */
+async function indexMap(
+  db: { query: (sql: string, ...params: unknown[]) => Promise<unknown> },
+  tableName: string,
+): Promise<Map<string, string>> {
+  const result = await rows(
+    db,
+    `SELECT name, sql FROM sqlite_master WHERE type = 'index' AND tbl_name = '${tableName}' AND sql IS NOT NULL ORDER BY name`,
+  );
+  return new Map(
+    result.map((row) => [
+      String(row.name),
+      String(row.sql).replace(/"/g, '').replace(/\s+/g, ' ').trim(),
+    ]),
+  );
+}
+
+async function columnMap(
+  db: { query: (sql: string, ...params: unknown[]) => Promise<unknown> },
+  tableName: string,
+): Promise<Map<string, { type: string; notnull: number; pk: number }>> {
+  const result = await rows(db, `PRAGMA table_info('${tableName}')`);
+  return new Map(
+    result.map((row) => [
+      String(row.name),
+      {
+        type: String(row.type),
+        notnull: Number(row.notnull),
+        pk: Number(row.pk),
+      },
+    ]),
+  );
+}
+
+const sqliteDescribe = getTestAdapter() === 'sqlite' ? describe : describe.skip;
+
+sqliteDescribe('manifest test-db ↔ migration path parity (#2358)', () => {
+  const manifestPath = join(testDir, 'parity-manifest.json');
+
+  // A structured manifest as `smrt build` / `smrtVitestPlugin()` writes it:
+  // engine-neutral cached `ddl` (CREATE TABLE only, abstract types) plus the
+  // authoritative `columns` / `indexes`. Two STI classes share `events`.
+  const manifest = {
+    packageName: '@test/parity',
+    objects: {
+      '@test/parity:Event': {
+        className: 'Event',
+        schema: {
+          tableName: 'events',
+          ddl: 'CREATE TABLE IF NOT EXISTS "events" ("id" TEXT PRIMARY KEY NOT NULL, "slug" TEXT NOT NULL, "context" TEXT NOT NULL DEFAULT \'\', "_meta_type" TEXT NOT NULL DEFAULT \'\', "_meta_data" JSON, "tenant_id" UUID, "deleted_at" TIMESTAMP);',
+          columns: {
+            id: { type: 'UUID', primaryKey: true, notNull: true },
+            slug: { type: 'TEXT', notNull: true },
+            context: { type: 'TEXT', notNull: true, default: '' },
+            _meta_type: { type: 'TEXT', notNull: true, default: '' },
+            _meta_data: { type: 'JSON' },
+            tenant_id: { type: 'UUID', referenceKind: 'tenantId' },
+            deleted_at: { type: 'TIMESTAMP' },
+          },
+          indexes: [
+            {
+              name: 'events_slug_context_meta_type_idx',
+              columns: ['slug', 'context', '_meta_type'],
+              unique: true,
+            },
+            { name: 'events_meta_type_idx', columns: ['_meta_type'] },
+            { name: 'events_tenant_id_idx', columns: ['tenant_id'] },
+            {
+              name: 'events_tenant_live_idx',
+              columns: ['tenant_id'],
+              where: '"deleted_at" IS NULL',
+            },
+            {
+              name: 'events_meta_kind_idx',
+              columns: [],
+              jsonPath: { column: '_meta_data', path: 'kind' },
+            },
+          ],
+          version: 'a',
+        },
+      },
+      '@test/parity:ScheduledEvent': {
+        className: 'ScheduledEvent',
+        extends: 'Event',
+        schema: {
+          tableName: 'events',
+          ddl: 'CREATE TABLE IF NOT EXISTS "events" ("id" TEXT PRIMARY KEY NOT NULL, "starts_at" TIMESTAMP);',
+          columns: {
+            id: { type: 'UUID', primaryKey: true, notNull: true },
+            starts_at: { type: 'TIMESTAMP' },
+          },
+          indexes: [
+            { name: 'events_meta_type_idx', columns: ['_meta_type'] },
+            { name: 'events_starts_at_idx', columns: ['starts_at'] },
+          ],
+          version: 'b',
+        },
+      },
+    },
+  };
+
+  beforeAll(() => {
+    mkdirSync(testDir, { recursive: true });
+    writeFileSync(manifestPath, JSON.stringify(manifest));
+  });
+
+  afterAll(() => {
+    if (existsSync(testDir)) rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('creates the same columns and indexes as a generated migration for the same schema', async () => {
+    // Path A: the isolated test database.
+    const isolated = await createIsolatedTestDbFromManifest({ manifestPath });
+
+    // Path B: the migration path — the merged STI definition rendered by
+    // MigrationGenerator (which, like the orchestrator, delegates to the
+    // engine DDL strategy) and applied to a fresh database.
+    const migrated = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    try {
+      const base = manifestSchemaToDefinition(
+        manifest.objects['@test/parity:Event'].schema,
+      );
+      const child = manifestSchemaToDefinition(
+        manifest.objects['@test/parity:ScheduledEvent'].schema,
+      );
+      for (const [name, column] of Object.entries(child.columns)) {
+        if (!(name in base.columns)) base.columns[name] = column;
+      }
+      for (const index of child.indexes) {
+        if (!base.indexes.some((existing) => existing.name === index.name)) {
+          base.indexes.push(index);
+        }
+      }
+
+      const migration = new MigrationGenerator({
+        engine: 'sqlite',
+      }).generateFromDiff(
+        {
+          has_changes: true,
+          added_tables: [base],
+          dropped_tables: [],
+          changes: [],
+        },
+        { name: '0001_events' },
+      );
+      for (const statement of migration.up) {
+        await migrated.query(statement);
+      }
+
+      const isolatedIndexes = await indexMap(isolated.baseDb, 'events');
+      const migratedIndexes = await indexMap(migrated, 'events');
+      expect([...isolatedIndexes.keys()]).toEqual([...migratedIndexes.keys()]);
+      expect(isolatedIndexes).toEqual(migratedIndexes);
+
+      // The specific indexes the retired string renderers lost.
+      expect(isolatedIndexes.get('events_tenant_live_idx')).toContain(
+        'WHERE deleted_at IS NULL',
+      );
+      expect(isolatedIndexes.get('events_meta_kind_idx')).toContain(
+        "json_extract(_meta_data, '$.kind')",
+      );
+      expect(isolatedIndexes.get('events_slug_context_meta_type_idx')).toMatch(
+        /^CREATE UNIQUE INDEX/,
+      );
+      // STI union: the child's index is present exactly once.
+      expect(isolatedIndexes.has('events_starts_at_idx')).toBe(true);
+      expect(isolatedIndexes.size).toBe(6);
+
+      const isolatedColumns = await columnMap(isolated.baseDb, 'events');
+      const migratedColumns = await columnMap(migrated, 'events');
+      expect(isolatedColumns).toEqual(migratedColumns);
+      expect([...isolatedColumns.keys()]).toEqual([
+        'id',
+        'slug',
+        'context',
+        '_meta_type',
+        '_meta_data',
+        'tenant_id',
+        'deleted_at',
+        'starts_at',
+      ]);
+      // Engine types come from the SQLite strategy, not the cached string.
+      expect(isolatedColumns.get('deleted_at')?.type).toBe('DATETIME');
+      expect(isolatedColumns.get('_meta_data')?.type).toBe('TEXT');
+      // Primary key is NOT NULL on SQLite (#2358).
+      expect(isolatedColumns.get('id')).toEqual({
+        type: 'TEXT',
+        notnull: 1,
+        pk: 1,
+      });
+    } finally {
+      await isolated.cleanup();
+      if (typeof migrated.close === 'function') await migrated.close();
+    }
+  });
+
+  it('rejects a NULL primary key in the isolated test database', async () => {
+    const isolated = await createIsolatedTestDbFromManifest({ manifestPath });
+    try {
+      await expect(
+        isolated.db.query(
+          `INSERT INTO "events" ("id", "slug", "_meta_type") VALUES (NULL, 'x', 'Event')`,
+        ),
+      ).rejects.toThrow();
+    } finally {
+      await isolated.cleanup();
+    }
+  });
+});

--- a/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
+++ b/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
@@ -7,13 +7,10 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { materializeManifestDDLForEngine } from '@happyvertical/smrt-core/schema/utils';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-
 // Import the function we're testing
-import {
-  createIsolatedTestDbFromManifest,
-  materializeManifestDDLForAdapter,
-} from '../test-db.js';
+import { createIsolatedTestDbFromManifest } from '../test-db.js';
 
 // Test fixtures directory
 const testDir = join(tmpdir(), `smrt-vitest-test-${Date.now()}`);
@@ -43,7 +40,7 @@ describe('createIsolatedTestDbFromManifest', () => {
       FOREIGN KEY ("id") REFERENCES "parents"("id")
     );`;
 
-    const postgres = materializeManifestDDLForAdapter(ddl, 'postgres');
+    const postgres = materializeManifestDDLForEngine(ddl, 'postgres');
     expect(postgres).toContain('"occurred_at" TIMESTAMPTZ(3) NOT NULL');
     expect(postgres).toContain(
       '"legacy_wall_time" TIMESTAMP WITHOUT TIME ZONE',
@@ -57,7 +54,7 @@ describe('createIsolatedTestDbFromManifest', () => {
     expect(postgres).toContain('"label" TEXT DEFAULT \'TIMESTAMP\'');
     expect(postgres).toContain('"payload" TEXT DEFAULT $tag$a,b(c)$tag$');
     expect(postgres).toContain('FOREIGN KEY ("id") REFERENCES "parents"("id")');
-    expect(materializeManifestDDLForAdapter(ddl, 'sqlite')).toBe(ddl);
+    expect(materializeManifestDDLForEngine(ddl, 'sqlite')).toBe(ddl);
   });
 
   describe('manifest loading', () => {

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -46,7 +46,6 @@ import {
   type CollectedManifestTable,
   collectManifestTables,
   type ManifestSchemaLike,
-  materializeManifestDDLForEngine,
   renderCollectedManifestTable,
 } from '@happyvertical/smrt-core/schema/utils';
 import {
@@ -651,28 +650,6 @@ function collectTableDependencies(table: CollectedManifestTable): string[] {
   return dependencies;
 }
 
-/**
- * Materialize abstract manifest timestamp columns for the selected adapter.
- *
- * Manifests intentionally cache engine-neutral CREATE TABLE text. PostgreSQL
- * interprets a bare `TIMESTAMP` as timezone-naive storage, while SMRT Date
- * fields represent instants and therefore require `TIMESTAMPTZ`. Transform
- * only the leading type token of column definitions so string literals,
- * identifiers, table constraints, and explicitly qualified timestamp types
- * remain untouched.
- *
- * Only the legacy column-less manifest path still executes cached DDL text;
- * structured manifests render through the engine DDL strategy (#2358).
- *
- * @internal
- */
-export function materializeManifestDDLForAdapter(
-  ddl: string,
-  adapter: TestDbAdapter,
-): string {
-  return materializeManifestDDLForEngine(ddl, adapter);
-}
-
 function getPackageNameFromKey(key: string): string | undefined {
   const separatorIndex = key.lastIndexOf(':');
   if (separatorIndex <= 0) {
@@ -1173,6 +1150,9 @@ export async function createIsolatedTestDbFromManifest(
   // CREATE INDEX statements after tables exist. This includes the UNIQUE
   // indexes required for UPSERT/ON CONFLICT to work and, unlike the retired
   // string renderer, keeps partial `WHERE` predicates and JSON-path targets.
+  // Triggers are not applied: manifests carry no trigger definitions
+  // (`ManifestSchema` has no `triggers`), and multi-statement trigger bodies
+  // would not survive the schema splitter below.
   const createIndexDDL = rendered
     .flatMap((ddl) => ddl.indexes)
     .filter(Boolean)

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -43,8 +43,11 @@ import { join } from 'node:path';
 // misclassified as table-bearing and lost their FK/junction columns.
 import { isSmrtCollectionExtendsName } from '@happyvertical/smrt-core';
 import {
+  type CollectedManifestTable,
+  collectManifestTables,
+  type ManifestSchemaLike,
   materializeManifestDDLForEngine,
-  tokenizeSQLDDLBody,
+  renderCollectedManifestTable,
 } from '@happyvertical/smrt-core/schema/utils';
 import {
   applySqliteSpeedPragmas,
@@ -72,13 +75,14 @@ function removeSqliteFiles(url: string): void {
 // ============================================================================
 
 /**
- * Schema definition from a manifest object
+ * Schema definition from a manifest object.
+ *
+ * `columns` and `indexes` are the structured, authoritative schema and are
+ * rendered through the engine DDL strategy; `ddl` is the engine-neutral
+ * CREATE TABLE preview and is only used when an object exposes no columns
+ * (hand-authored manifests, #2358).
  */
-interface ManifestSchema {
-  tableName: string;
-  ddl: string;
-  indexes?: Array<{ name: string; columns: string[]; unique?: boolean }>;
-}
+type ManifestSchema = ManifestSchemaLike;
 
 /**
  * Object definition from a manifest
@@ -597,45 +601,13 @@ function loadManifest(manifestPath?: string): ManifestFile | null {
 }
 
 /**
- * Index definition from manifest
- */
-interface ManifestIndex {
-  name: string;
-  columns: string[];
-  unique?: boolean;
-}
-
-/**
  * Table info extracted from manifest for dependency sorting
  */
 interface TableInfo {
   tableName: string;
-  ddl: string;
-  indexes: ManifestIndex[];
+  /** Structured STI union of every contributing manifest object */
+  table: CollectedManifestTable;
   dependencies: string[];
-}
-
-/**
- * Generate CREATE INDEX statements from manifest indexes
- *
- * Generates both regular and UNIQUE indexes.
- * UNIQUE indexes on conflict columns (like slug, context) are required
- * for UPSERT/ON CONFLICT to work in SQLite.
- */
-function generateIndexDDL(tableName: string, indexes: ManifestIndex[]): string {
-  if (!indexes || indexes.length === 0) return '';
-
-  const statements: string[] = [];
-  for (const index of indexes) {
-    if (!index.columns || index.columns.length === 0) continue;
-
-    const indexType = index.unique ? 'UNIQUE INDEX' : 'INDEX';
-    const columns = index.columns.map((c) => `"${c}"`).join(', ');
-    statements.push(
-      `CREATE ${indexType} IF NOT EXISTS "${index.name}" ON "${tableName}" (${columns});`,
-    );
-  }
-  return statements.join('\n');
 }
 
 /**
@@ -659,11 +631,26 @@ function extractForeignKeyDependencies(ddl: string): string[] {
 }
 
 /**
- * Tokenize CREATE TABLE body into individual column/constraint definitions.
- *
- * Splits on top-level commas (not inside parentheses or quotes) so it works
- * for both multi-line and single-line DDL strings.
+ * Collect the tables a collected manifest table depends on: structured
+ * `foreignKey.table` references first, then any `REFERENCES` clauses in the
+ * contributors' cached DDL strings (hand-authored manifests).
  */
+function collectTableDependencies(table: CollectedManifestTable): string[] {
+  const dependencies: string[] = [];
+  for (const column of Object.values(table.definition.columns)) {
+    const target = column.foreignKey?.table;
+    if (target && !dependencies.includes(target)) {
+      dependencies.push(target);
+    }
+  }
+  for (const dep of extractForeignKeyDependencies(table.legacyDdl)) {
+    if (!dependencies.includes(dep)) {
+      dependencies.push(dep);
+    }
+  }
+  return dependencies;
+}
+
 /**
  * Materialize abstract manifest timestamp columns for the selected adapter.
  *
@@ -674,6 +661,9 @@ function extractForeignKeyDependencies(ddl: string): string[] {
  * identifiers, table constraints, and explicitly qualified timestamp types
  * remain untouched.
  *
+ * Only the legacy column-less manifest path still executes cached DDL text;
+ * structured manifests render through the engine DDL strategy (#2358).
+ *
  * @internal
  */
 export function materializeManifestDDLForAdapter(
@@ -681,96 +671,6 @@ export function materializeManifestDDLForAdapter(
   adapter: TestDbAdapter,
 ): string {
   return materializeManifestDDLForEngine(ddl, adapter);
-}
-
-/** Keywords that indicate a table-level constraint, not a column definition */
-const CONSTRAINT_KEYWORDS = new Set([
-  'CONSTRAINT',
-  'PRIMARY',
-  'FOREIGN',
-  'UNIQUE',
-  'CHECK',
-]);
-
-/**
- * Parse column definitions from a CREATE TABLE DDL statement
- *
- * Returns a Map of column name → full column definition line.
- * Skips table-level constraints (FOREIGN KEY, PRIMARY KEY, etc.).
- */
-function parseColumnsFromDDL(ddl: string): Map<string, string> {
-  const columns = new Map<string, string>();
-  // Match the body between CREATE TABLE ... ( ... )
-  const bodyMatch = ddl.match(
-    /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"?\w+"?\s*\(([\s\S]+)\)/i,
-  );
-  if (!bodyMatch) return columns;
-
-  const segments = tokenizeSQLDDLBody(bodyMatch[1]);
-
-  for (const segment of segments) {
-    // Extract first identifier and check if it's a constraint keyword
-    const colMatch = segment.match(/^"?([a-zA-Z_][a-zA-Z0-9_]*)"?\s+/);
-    if (!colMatch) continue;
-
-    const firstToken = colMatch[1].toUpperCase();
-    if (CONSTRAINT_KEYWORDS.has(firstToken)) continue;
-
-    columns.set(colMatch[1], segment);
-  }
-
-  return columns;
-}
-
-/**
- * Merge two DDL statements for the same table (STI subclasses)
- *
- * Takes the union of all columns from both DDLs.
- * When a column exists in both, the existing definition is kept.
- */
-function mergeDDL(existingDDL: string, newDDL: string): string {
-  const existingCols = parseColumnsFromDDL(existingDDL);
-  const newCols = parseColumnsFromDDL(newDDL);
-
-  // Find columns in newDDL that are missing from existingDDL
-  const missingCols: string[] = [];
-  for (const [name, def] of newCols) {
-    if (!existingCols.has(name)) {
-      missingCols.push(def);
-    }
-  }
-
-  if (missingCols.length === 0) return existingDDL;
-
-  // Insert missing columns before the closing paren
-  const closingIdx = existingDDL.lastIndexOf(')');
-  if (closingIdx === -1) return existingDDL;
-
-  const before = existingDDL.substring(0, closingIdx).trimEnd();
-  const after = existingDDL.substring(closingIdx);
-  const additions = missingCols.map((col) => `  ${col}`).join(',\n');
-
-  return `${before},\n${additions}\n${after}`;
-}
-
-/**
- * Merge indexes from multiple STI subclasses sharing the same table
- *
- * Deduplicates by index name, keeping the first occurrence.
- */
-function mergeIndexes(
-  existing: ManifestIndex[],
-  incoming: ManifestIndex[],
-): ManifestIndex[] {
-  const names = new Set(existing.map((i) => i.name));
-  const merged = [...existing];
-  for (const idx of incoming) {
-    if (!names.has(idx.name)) {
-      names.add(idx.name);
-      merged.push(idx);
-    }
-  }
-  return merged;
 }
 
 function getPackageNameFromKey(key: string): string | undefined {
@@ -1032,22 +932,26 @@ function buildEffectiveIncludeObjects(
 }
 
 /**
- * Extract DDL from manifest objects with STI deduplication
+ * Extract tables from manifest objects with STI deduplication
  *
- * Multiple classes may share the same table (STI), so we deduplicate by tableName.
- * When STI subclasses add columns, DDLs are merged to include all columns.
- * Also extracts indexes for generating CREATE INDEX statements.
+ * Multiple classes may share the same table (STI), so we deduplicate by
+ * tableName and merge their structured columns and indexes (first contributor
+ * wins per column name; indexes deduplicated by name). The merged definition
+ * is rendered through the engine DDL strategy — the same renderer
+ * `db:migrate` uses — so the isolated test database has the same tables and
+ * indexes as a migrated one (#2358). Objects that expose no structured
+ * columns fall back to their cached `ddl` string for the CREATE TABLE.
  */
-function extractDDLFromManifest(
+function extractTablesFromManifest(
   manifest: ManifestFile,
   includeObjects?: string[],
 ): TableInfo[] {
-  const tableMap = new Map<string, TableInfo>();
   const effectiveIncludes = buildEffectiveIncludeObjects(
     manifest,
     includeObjects,
   );
 
+  const entries: Array<{ schema: ManifestSchema; source: string }> = [];
   for (const [key, objectDef] of Object.entries(manifest.objects)) {
     // Skip if filter is specified and class not included
     // Compare against both the key (e.g., '@dumm/models:Product') and className (e.g., 'Product')
@@ -1062,36 +966,18 @@ function extractDDLFromManifest(
     }
 
     // Skip objects without schema (abstract classes, etc.)
-    if (!objectDef.schema?.ddl || !objectDef.schema?.tableName) {
+    if (!objectDef.schema?.tableName) {
       continue;
     }
 
-    const { tableName, ddl, indexes = [] } = objectDef.schema;
-
-    // Merge by tableName — STI subclasses may add columns to the same table
-    const existing = tableMap.get(tableName);
-    if (!existing) {
-      tableMap.set(tableName, {
-        tableName,
-        ddl,
-        indexes,
-        dependencies: extractForeignKeyDependencies(ddl),
-      });
-    } else {
-      // Merge DDL columns and indexes from this STI subclass
-      existing.ddl = mergeDDL(existing.ddl, ddl);
-      existing.indexes = mergeIndexes(existing.indexes, indexes);
-      // Merge FK dependencies
-      const newDeps = extractForeignKeyDependencies(ddl);
-      for (const dep of newDeps) {
-        if (!existing.dependencies.includes(dep)) {
-          existing.dependencies.push(dep);
-        }
-      }
-    }
+    entries.push({ schema: objectDef.schema, source: key });
   }
 
-  return Array.from(tableMap.values());
+  return Array.from(collectManifestTables(entries).values()).map((table) => ({
+    tableName: table.tableName,
+    table,
+    dependencies: collectTableDependencies(table),
+  }));
 }
 
 /**
@@ -1259,8 +1145,8 @@ export async function createIsolatedTestDbFromManifest(
     );
   }
 
-  // 2. Extract DDL with STI deduplication
-  const tables = extractDDLFromManifest(manifest, includeObjects);
+  // 2. Extract tables with STI deduplication
+  const tables = extractTablesFromManifest(manifest, includeObjects);
   if (tables.length === 0) {
     throw new Error(
       includeObjects
@@ -1269,28 +1155,26 @@ export async function createIsolatedTestDbFromManifest(
     );
   }
 
-  // 3. Sort by FK dependencies and join DDL
+  // 3. Sort by FK dependencies and render through the engine DDL strategy
   // Use Map for O(1) lookups instead of O(n) Array.find()
   const tableMap = new Map(tables.map((t) => [t.tableName, t] as const));
   const sortedTableNames = sortByDependencies(tables);
+  const rendered = sortedTableNames.flatMap((name) => {
+    const table = tableMap.get(name);
+    return table ? [renderCollectedManifestTable(table.table, adapter)] : [];
+  });
 
-  // Generate CREATE TABLE statements first
-  const createTableDDL = sortedTableNames
-    .map((name) => {
-      const ddl = tableMap.get(name)?.ddl;
-      return ddl ? materializeManifestDDLForAdapter(ddl, adapter) : ddl;
-    })
+  // CREATE TABLE statements first
+  const createTableDDL = rendered
+    .map((ddl) => ddl.createTable)
     .filter(Boolean)
     .join('\n\n');
 
-  // Generate CREATE INDEX statements after tables exist
-  // This includes UNIQUE indexes required for UPSERT/ON CONFLICT to work
-  const createIndexDDL = sortedTableNames
-    .map((name) => {
-      const table = tableMap.get(name);
-      if (!table) return '';
-      return generateIndexDDL(table.tableName, table.indexes);
-    })
+  // CREATE INDEX statements after tables exist. This includes the UNIQUE
+  // indexes required for UPSERT/ON CONFLICT to work and, unlike the retired
+  // string renderer, keeps partial `WHERE` predicates and JSON-path targets.
+  const createIndexDDL = rendered
+    .flatMap((ddl) => ddl.indexes)
     .filter(Boolean)
     .join('\n');
 


### PR DESCRIPTION
Closes #2358. Parent: #2382 (finding C3). Refs #2359, #2357.

## Problem

`SchemaDefinition.ddl` (manifest `schema.ddl`) is the engine-neutral CREATE TABLE preview from `SchemaGenerator.generateSQL()` with no engine: **no indexes, no triggers, abstract `REAL`/`JSON`/`UUID`/`TIMESTAMP`**. Three consumers still treated it as the executable table, and each carried a private `CREATE INDEX` renderer that dropped `where` and `jsonPath`:

- `MigrationGenerator` (`migrations/generator.ts`) — default `materializeStructuredSchema: false` executed the cached string; a new table got `CREATE TABLE` and nothing else, so a generated migration file created tables without their indexes.
- `SchemaAggregator` (`schema/schema-aggregator.ts`) — string-merged STI DDL and formatted indexes itself.
- `createIsolatedTestDbFromManifest` (`smrt-vitest/test-db.ts`) — same, so tests ran against a schema no deployment received (partial indexes became full indexes, JSON-path indexes vanished).

Separately, the structured DDL strategies emitted `"id" TEXT PRIMARY KEY` without `NOT NULL`, which SQLite accepts NULL ids through.

## Decision (coordinator, over the issue's "make the string complete" option)

Route every consumer through `getDDLStrategy(engine)` — the renderer `db:migrate` (`migrations/orchestrate.ts`) already uses — keep `schema.indexes` structured as the differ's source of truth, and demote `schema.ddl` to a documented, non-authoritative preview kept for backward compatibility. Retire the DDL-string dialect rather than teach it indexes.

## Change

- **New leaf module `packages/core/src/schema/manifest-schema.ts`** (exported from `@happyvertical/smrt-core/schema` and `/schema/utils`): `manifestSchemaToDefinition`, `collectManifestTables` (groups manifest objects by table, STI-merges columns first-wins and indexes by name), `renderCollectedManifestTable` (strategy `generateCreateTable` + `generateIndexes` + `generateTriggers`). A table falls back to the cached `ddl` string (`materializeManifestDDLForEngine`) only when a contributor exposes no structured `columns`; its indexes still come from the strategy. The string-merge helper moved here from the aggregator for that legacy path.
- **`MigrationGenerator`**: `materializeStructuredSchema` defaults to `true` (`false` is `@deprecated`, kept for third-party callers); new tables emit indexes and triggers after `CREATE TABLE`, exactly as the orchestrator does. The differ only produces `add_index` for tables that already exist, so there is no double emission (test asserts it). `generateAddIndex` keeps the partial `WHERE` (DuckDB degrades to full, matching the differ).
- **`SchemaAggregator`**: structured collection + dialect strategy; `AggregatedTable.columns` is now the merged `ColumnDefinition` map.
- **`createIsolatedTestDbFromManifest`**: same helpers; private `generateIndexDDL`/`mergeDDL`/`parseColumnsFromDDL` deleted. FK ordering now also reads structured `foreignKey.table`.
- **DDL strategies** (`base-strategy.ts`): every primary key renders `PRIMARY KEY NOT NULL` (valid on SQLite/PG/DuckDB, verified DuckDB 1.4.3; the differ does not compare `notNull`, so no drift is reported for existing tables).
- **Docs**: `SchemaDefinition.ddl` / `ManifestSchema.ddl` JSDoc, `generateSQL` doc, `packages/core/agents/schema-paths.md` rule 14, `packages/vitest/AGENTS.md`, `docs/content/core.md`. The two `generator.ts` comments inherited from #2384 ("before the DDL is rendered so the emitted SQL creates it too") are reworded. `packages/core/AGENTS.md` untouched.

## Path parity

- `packages/vitest/src/__tests__/manifest-schema-path-parity.test.ts`: a structured two-class STI manifest → isolated test DB vs. `MigrationGenerator` output applied to a fresh SQLite DB → identical `sqlite_master` index set (incl. partial `WHERE`, `json_extract` target, unique conflict index, STI child index) and identical `PRAGMA table_info` (incl. `id` NOT NULL). Also asserts a NULL id is rejected.
- `packages/core/src/schema/manifest-schema.test.ts`: rendered output equals `strategy.generateCreateTable/Indexes/Triggers` for sqlite+postgres; STI merge, legacy fallback, mixed-contributor degradation, `PRIMARY KEY NOT NULL` on all four engines with a SQLite NULL-id regression.
- These should be folded into `packages/core/src/schema/schema-path-parity.test.ts` once #2359 (PR #2396) lands; they live in smrt-vitest because core cannot depend on it.
- Updated: `migrations/__tests__/generator.test.ts` (indexes+triggers emitted, no double emission, `add_index` keeps `WHERE`, PK NOT NULL; the #2069 cached-string tests now opt into the deprecated path), `schema-aggregator-sti-merge.test.ts` (structured merge + partial/JSON-path indexes on both dialects; the two adversarial string-parsing cases now run column-less as the legacy fallback), `issue-2069-postgres-manifest.optional.test.ts` (structured PG case: uuid/JSONB/double precision/timestamptz, `pg_indexes` partial predicate and `->>` target).

## Validation

- `packages/core`: `pnpm typecheck`, full `pnpm test` (275 files / 3511 tests green, before and after merging origin/main incl. #2395/#2400), `pnpm test:postgres` against a disposable `postgres:17-alpine` — 27/29 green; the 2 failures (`change-feed-concurrency` best-effort feed race, `issue-2069` "outside UTC session") **fail identically on the untouched base** with this local container, so they are environment artifacts; CI's PG lane is the gate.
- `packages/vitest`: `pnpm typecheck`, full suite (57 tests) and `test:postgres` (structured + legacy manifest cases) green.
- `packages/personas` (consumer of `createIsolatedTestDbFromManifest`) full suite green. `packages/support` cannot run in this agent worktree (known vite8/rolldown "Tsconfig not found" artifact for Svelte-configured packages) — CI gates it.
- `pnpm knowledge:check --strict`, `check:agents-chain`, biome on all touched files: clean.

## Review cycle

Two independent Claude reviewers (correctness lens; tests/docs/contract lens). Material findings and dispositions:

- Mixed contributors (structured STI base + hand-authored column-less subclass) dropped the structured columns → fixed: structured part rendered by the strategy, cached string merged on top (`422c5dc30`).
- `materializeStructuredSchema: false` JSDoc claimed no indexes are created, but indexes/triggers are always strategy-rendered → doc corrected + test (`baea6e4c0`); intentional: the opt-out only affects the CREATE TABLE.
- DuckDB/JSON + column-less contributor + plain unique index lost uniqueness (strategy skips those indexes, string had no inline UNIQUE) → inline `UNIQUE(...)` elements appended, deduplicated (`baea6e4c0`).
- `AggregatedTable.columns` changed shape (`default`→`defaultValue`) → reverted to the published manifest shape, merged first-wins (`7545b3091`).
- Structured schema + cached `ddl` with table constraints drops the constraints silently → now `logger.warn`s in `collectManifestTables` and `MigrationGenerator`; kept as designed (the structured schema is authoritative, exactly as `db:migrate`; rendering them would recreate test/production drift) (`7545b3091`).
- Docs/naming polish (table-scoped fallback wording, "last two", dead alias in smrt-vitest, symmetric exports, vacuous assertion) → fixed (`7545b3091`); the constraint warning is now scoped to fully structured tables and deduplicated, and inline-UNIQUE dedup is quote-insensitive, with a mixed-table DuckDB/JSON test (`5c7091e75`).
- Both reviewers re-verified HEAD after the fixes: no new material findings.

**Decision for the coordinator (not changed here):** one reviewer flagged that flipping the published `materializeStructuredSchema` default and adding `NOT NULL` to every rendered PK is a behaviour change shipped as `fix` (patch) rather than `fix!`. Left as `fix` per the retire-the-string decision; say the word and I will add the `!`/`BREAKING CHANGE` footer. API surface note: `materializeManifestDDLForAdapter` (an `@internal` one-line alias in `smrt-vitest/src/test-db.ts`) is deleted; it was never exported from the `@happyvertical/smrt-vitest` package entry, so no consumer-visible export changes.

`codex review` (gpt-5.6-sol xhigh) could not run: the account is at its usage limit until 2026-08-19; GitHub auto-reviewers cover the gap.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","policy_revision":"1.0.0","runtime":"claude","session":"2e828b4a-bf86-463b-8159-3ee4e9f1275f","issue":"https://github.com/happyvertical/smrt/issues/2358","validation":"core typecheck+full test+test:postgres (2 pre-existing local-env failures), vitest typecheck+test+test:postgres, personas test, knowledge:check --strict, biome"}
```
