### PR TITLE
fix(core): rebuild the table for SQLite type changes instead of exiting 1

### DIFF
--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -65,6 +65,21 @@ after that commit. This is the mode for large index rollouts.
 - Without the flag, a batch containing explicit `CONCURRENTLY` DDL is rejected
   before the transaction opens — PostgreSQL cannot run it there.
 
+## `db:migrate` on SQLite: type changes rebuild the table
+
+SQLite has no `ALTER COLUMN ... TYPE`, so a type-bucket change (the common one
+being a numeric default edited `0` → `0.0`) is applied as the documented table
+rebuild — stage, copy, drop, rename, replay indexes and triggers — planned by
+`smrt-core`'s `migrations/sqlite-rebuild.ts` and executed inside the same
+atomic batch as everything else. It is no longer a "manual intervention" that
+makes `db:migrate` exit 1 on every run (#2370). All drifted columns of one
+table are fixed by one rebuild; `--dry-run` prints the whole statement list.
+
+The rebuild refuses — and the column stays manual drift — when another table
+declares a foreign key onto the target while `PRAGMA foreign_keys` is ON,
+because `DROP TABLE` would fire those children's `ON DELETE` actions. Fix that
+one by hand (or against a connection with enforcement disabled).
+
 ## `db:rollback` is execute-or-refuse
 
 Schema state is diff-driven: `db:migrate` derives every migration from the

--- a/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
@@ -126,6 +126,42 @@ describe('partitionSchemaChanges', () => {
     ]);
   });
 
+  it('executes a SQLite table-rebuild type upgrade instead of asking for manual work (#2370)', () => {
+    // The differ now answers a SQLite type change with the executable
+    // table-rebuild plan. It must land in the executable migration set —
+    // `db:migrate` exiting 1 on "manual intervention" was the whole bug.
+    const rebuild = [
+      'PRAGMA defer_foreign_keys = ON',
+      'DROP TABLE IF EXISTS "_smrt_rebuild_contents"',
+      'CREATE TABLE "_smrt_rebuild_contents" (\n  "id" TEXT PRIMARY KEY,\n  "score" REAL\n)',
+      'INSERT INTO "_smrt_rebuild_contents" ("id", "score") SELECT "id", "score" FROM "contents"',
+      'DROP TABLE "contents"',
+      'PRAGMA legacy_alter_table = ON',
+      'ALTER TABLE "_smrt_rebuild_contents" RENAME TO "contents"',
+      'PRAGMA legacy_alter_table = OFF',
+    ];
+
+    const { migrations, manualInterventions } = partitionSchemaChanges(
+      [
+        {
+          type: 'type_upgrade',
+          table: 'contents',
+          name: 'score',
+          column: { type: 'REAL' },
+          mismatch: { expected: 'REAL', actual: 'INTEGER' },
+          sql: rebuild[0],
+          sqlStatements: rebuild,
+        },
+      ],
+      () => 'Content',
+    );
+
+    expect(manualInterventions).toEqual([]);
+    expect(migrations).toHaveLength(1);
+    expect(migrations[0].type).toBe('type_upgrade');
+    expect(migrations[0].sqlStatements).toEqual(rebuild);
+  });
+
   it('drops no-op type upgrades from the action lists', () => {
     const { migrations, manualInterventions } = partitionSchemaChanges(
       [

--- a/packages/core/agents/schema-paths.md
+++ b/packages/core/agents/schema-paths.md
@@ -224,9 +224,14 @@ Four properties of that module are load-bearing; keep them if you touch it:
 
 - **The target shape comes from the live `sqlite_master` DDL**, retyping only
   the drifted columns. It is not regenerated from the manifest, so the rebuild
-  never becomes an implicit `DROP COLUMN`, never fights the `add_column`
-  changes in the same batch, and preserves table constraints, `CHECK`s, and
-  `WITHOUT ROWID`/`STRICT`.
+  never becomes an implicit `DROP COLUMN`, and it preserves table constraints,
+  `CHECK`s, and `WITHOUT ROWID`/`STRICT`.
+- **The rebuild is hoisted ahead of the table's other column changes.** Its
+  staging DDL and copy list are captured at diff time, and the differ emits
+  changes in manifest field order, so a new field declared above the retyped
+  one would otherwise run `ALTER TABLE ... ADD COLUMN` first and have the
+  rebuild silently drop it — both statements succeed and the batch commits.
+  Rebuild first, then add columns to the rebuilt table.
 - **The copy carries no `CAST`.** SQLite applies the destination column's
   affinity on insert — the same conversion a fresh table performs. An explicit
   cast is worse: non-numeric TEXT cast to REAL/INTEGER silently becomes `0`,

--- a/packages/core/agents/schema-paths.md
+++ b/packages/core/agents/schema-paths.md
@@ -209,3 +209,42 @@ replaces the automatic standalone `tenant_id` index rather than duplicating it.
 Unknown columns, malformed entries, and a name collision with a different index
 all fail generation — a silently dropped index only surfaces later as a
 production slowdown. Rule 8 above is why this works at runtime at all.
+
+### 14. A SQLite type change is a table rebuild (#2370)
+
+SQLite has no `ALTER TABLE ... ALTER COLUMN ... TYPE`, so
+`src/migrations/sqlite-rebuild.ts` answers a `type_upgrade` on SQLite with the
+statement list SQLite's own docs prescribe: stage a new table under
+`_smrt_rebuild_<table>`, copy, drop, rename, replay the indexes and triggers.
+`SchemaComparer.compareTable` swaps that plan in for the differ's
+"requires table recreation" placeholder, so `db:migrate` applies it inside the
+normal atomic batch instead of exiting 1 forever.
+
+Four properties of that module are load-bearing; keep them if you touch it:
+
+- **The target shape comes from the live `sqlite_master` DDL**, retyping only
+  the drifted columns. It is not regenerated from the manifest, so the rebuild
+  never becomes an implicit `DROP COLUMN`, never fights the `add_column`
+  changes in the same batch, and preserves table constraints, `CHECK`s, and
+  `WITHOUT ROWID`/`STRICT`.
+- **The copy carries no `CAST`.** SQLite applies the destination column's
+  affinity on insert — the same conversion a fresh table performs. An explicit
+  cast is worse: non-numeric TEXT cast to REAL/INTEGER silently becomes `0`,
+  and an ISO timestamp cast to NUMERIC-affinity `DATETIME` becomes its year.
+- **It refuses when any table has a foreign key onto the target and
+  `PRAGMA foreign_keys` is ON** (the SMRT adapter's default). `DROP TABLE`
+  performs an implicit `DELETE FROM` that fires `ON DELETE CASCADE` on
+  children, and `defer_foreign_keys` defers constraint *checks*, not FK
+  *actions* — verified: the child rows go. The target's own self-reference
+  counts, because the staging table copies that clause and becomes a child of
+  the table being dropped (verified: a two-row self-referencing table finishes
+  the rebuild holding one row). Such a column stays manual drift.
+- **`PRAGMA legacy_alter_table` brackets the rename**, because SQLite ≥ 3.25
+  re-parses the schema on `ALTER TABLE ... RENAME` and a view still pointing at
+  the just-dropped table makes it fail outright. It is restored immediately
+  after; a rolled-back batch leaves it set on that connection, which is inert
+  here only because nothing else in SMRT renames a table.
+
+All the drifted columns of one table share a single rebuild: the first change
+carries the plan and the rest become `no change needed` comments that the CLI
+classifies as no-ops.

--- a/packages/core/src/migrations/__tests__/orchestrate.test.ts
+++ b/packages/core/src/migrations/__tests__/orchestrate.test.ts
@@ -268,14 +268,70 @@ describe('schema orchestration', () => {
     expect(tables.rows).toHaveLength(1);
   });
 
-  it('surfaces SQLite type-upgrade comments as unactionableChanges, not as applied DDL', async () => {
+  it('plans an executable SQLite table rebuild for a type upgrade (#2370)', async () => {
     // Pre-create the column with INTEGER; manifest declares REAL. SQLite
-    // can't widen the type in place — the differ emits an advisory
-    // comment-only "requires table recreation" SQL. Before the fix, that
-    // comment was passed to the tracker and recorded as a successful
-    // migration, so the drift would re-appear every run.
+    // can't widen the type in place, and the differ used to emit an advisory
+    // comment that left the drift unfixable forever. It now emits the
+    // table-rebuild plan, which the orchestrator must pass through as real
+    // DDL (comment-only statements are still filtered out).
     await db.query(
       'CREATE TABLE documents (id TEXT PRIMARY KEY, score INTEGER);',
+    );
+    await db.query("INSERT INTO documents VALUES ('d1', 4);");
+
+    vi.spyOn(ObjectRegistry, 'getAllSchemasAsDefinitions').mockReturnValue({
+      documents: {
+        tableName: 'documents',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          score: { type: 'REAL' },
+        },
+        indexes: [],
+        triggers: [],
+        foreignKeys: [],
+        dependencies: [],
+        version: '1.0.0',
+      },
+    });
+
+    const pending = await getPendingSchemaStatements(db);
+
+    expect(pending.hasChanges).toBe(true);
+    expect(pending.statements.some((sql) => sql.startsWith('--'))).toBe(false);
+    expect(pending.statements).toContain(
+      'ALTER TABLE "_smrt_rebuild_documents" RENAME TO "documents"',
+    );
+    // Nothing is left for a human to do.
+    expect(pending.unactionableChanges).toEqual([]);
+    expect(pending.hasManualDrift).toBe(false);
+
+    const result = await migrateSmrtSchemas({
+      db,
+      packageName: '@test/app',
+      name: '20260818_000000_sqlite_rebuild',
+    });
+    expect(result.applied).toBe(true);
+
+    const columns = (await db.query('PRAGMA table_info("documents")')).rows as {
+      name: string;
+      type: string;
+    }[];
+    expect(columns.find((c) => c.name === 'score')?.type).toBe('REAL');
+    expect((await db.query('SELECT score FROM documents')).rows[0]).toEqual({
+      score: 4,
+    });
+  });
+
+  it('still surfaces an unplannable SQLite type upgrade as unactionable drift', async () => {
+    // A child table with ON DELETE CASCADE makes the rebuild unsafe (the
+    // DROP TABLE step would cascade its rows away), so the differ keeps the
+    // advisory comment. The orchestrator must strip that comment from the
+    // executable statements and report the drift as manual.
+    await db.query(
+      'CREATE TABLE documents (id TEXT PRIMARY KEY, score INTEGER);',
+    );
+    await db.query(
+      'CREATE TABLE document_notes (id TEXT PRIMARY KEY, document_id TEXT REFERENCES documents(id) ON DELETE CASCADE);',
     );
 
     vi.spyOn(ObjectRegistry, 'getAllSchemasAsDefinitions').mockReturnValue({
@@ -295,16 +351,7 @@ describe('schema orchestration', () => {
 
     const pending = await getPendingSchemaStatements(db);
 
-    // The pre-created table already exists and the only divergence is the
-    // SQLite type-widening (which can't be applied in-place). The filter
-    // should strip the comment-only "requires table recreation" SQL, so
-    // nothing executable survives — tighter than the previous
-    // every-statement loop (which couldn't distinguish "filter dropped
-    // all candidates" from "filter saw nothing").
     expect(pending.statements).toEqual([]);
-
-    // The unresolved drift should surface via unactionableChanges so the
-    // caller can prompt for manual remediation. Exactly one column drifted.
     expect(pending.unactionableChanges).toHaveLength(1);
     expect(pending.hasManualDrift).toBe(true);
     expect(pending.unactionableChanges[0].type).toBe('type_upgrade');

--- a/packages/core/src/migrations/__tests__/orchestrate.test.ts
+++ b/packages/core/src/migrations/__tests__/orchestrate.test.ts
@@ -322,6 +322,53 @@ describe('schema orchestration', () => {
     });
   });
 
+  it('does not report a column covered by a sibling rebuild as manual drift (#2370)', async () => {
+    // Two drifted columns on one table share a single rebuild: the second
+    // change is a `no change needed` comment. Comment-only SQL normally means
+    // "a human must act", so without the no-op exemption this fully
+    // auto-repairable migration would report hasManualDrift.
+    await db.query(
+      'CREATE TABLE documents (id TEXT PRIMARY KEY, score INTEGER, weight INTEGER);',
+    );
+
+    vi.spyOn(ObjectRegistry, 'getAllSchemasAsDefinitions').mockReturnValue({
+      documents: {
+        tableName: 'documents',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          score: { type: 'REAL' },
+          weight: { type: 'REAL' },
+        },
+        indexes: [],
+        triggers: [],
+        foreignKeys: [],
+        dependencies: [],
+        version: '1.0.0',
+      },
+    });
+
+    const pending = await getPendingSchemaStatements(db);
+
+    expect(pending.unactionableChanges).toEqual([]);
+    expect(pending.hasManualDrift).toBe(false);
+    expect(pending.statements.some((sql) => sql.startsWith('--'))).toBe(false);
+
+    const result = await migrateSmrtSchemas({
+      db,
+      packageName: '@test/app',
+      name: '20260818_000100_sqlite_rebuild_multi',
+    });
+    expect(result.applied).toBe(true);
+    expect(result.hasManualDrift).toBe(false);
+
+    const columns = (await db.query('PRAGMA table_info("documents")')).rows as {
+      name: string;
+      type: string;
+    }[];
+    expect(columns.find((c) => c.name === 'score')?.type).toBe('REAL');
+    expect(columns.find((c) => c.name === 'weight')?.type).toBe('REAL');
+  });
+
   it('still surfaces an unplannable SQLite type upgrade as unactionable drift', async () => {
     // A child table with ON DELETE CASCADE makes the rebuild unsafe (the
     // DROP TABLE step would cascade its rows away), so the differ keeps the

--- a/packages/core/src/migrations/__tests__/sqlite-table-rebuild.test.ts
+++ b/packages/core/src/migrations/__tests__/sqlite-table-rebuild.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Issue #2370 — SQLite table-rebuild migration.
+ *
+ * SQLite has no `ALTER TABLE ... ALTER COLUMN ... TYPE`, so before this the
+ * differ emitted an advisory comment for every type-bucket change and
+ * `db:migrate` exited 1 with "manual intervention required" forever. These
+ * tests run the rebuild against real in-memory SQLite and assert the two
+ * things a rebuild must never get wrong: the rows survive, and the schema
+ * objects that died with the dropped table come back.
+ */
+
+import type { DatabaseProvider } from '@happyvertical/sql';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { SchemaDefinition } from '../../schema/types.js';
+import { getSQLFromDiff, SchemaComparer } from '../differ.js';
+import {
+  isSqliteRebuildPlaceholder,
+  parseCreateTableBody,
+  readColumnDefinitionName,
+  replaceColumnType,
+  rewriteSqliteCreateTable,
+} from '../sqlite-rebuild.js';
+import { MigrationTracker } from '../tracker.js';
+
+/**
+ * The DDL a migration runner would actually execute: `getSQLFromDiff` still
+ * carries the differ's advisory comments, which the orchestrator and the CLI
+ * both filter out before handing statements to the tracker.
+ */
+function executableSql(diff: { changes: { sql?: string }[] }): string[] {
+  return getSQLFromDiff(diff as Parameters<typeof getSQLFromDiff>[0]).filter(
+    (sql) => !sql.trim().startsWith('--'),
+  );
+}
+
+/** Manifest for `products` where `price` is declared REAL (`0.0`). */
+function productsManifest(
+  priceType: 'REAL' | 'INTEGER' = 'REAL',
+  extra: Record<string, { type: 'TEXT' | 'INTEGER' | 'REAL' }> = {},
+): Record<string, SchemaDefinition> {
+  return {
+    products: {
+      tableName: 'products',
+      ddl: '',
+      columns: {
+        id: { type: 'TEXT', primaryKey: true },
+        name: { type: 'TEXT' },
+        price: { type: priceType },
+        ...extra,
+      },
+      indexes: [
+        { name: 'products_name_idx', columns: ['name'] },
+        { name: 'products_price_idx', columns: ['price'] },
+      ],
+      triggers: [],
+      foreignKeys: [],
+      dependencies: [],
+      version: '1.0.0',
+    },
+  };
+}
+
+describe('#2370 SQLite table rebuild — pure DDL rewriting', () => {
+  it('retypes only the requested column and preserves everything else', () => {
+    const rewritten = rewriteSqliteCreateTable(
+      `CREATE TABLE "products" (\n  "id" TEXT PRIMARY KEY,\n  "name" TEXT NOT NULL DEFAULT 'x, y',\n  "price" INTEGER DEFAULT 0 CHECK ("price" >= 0)\n)`,
+      {
+        tableName: '_smrt_rebuild_products',
+        columnTypes: new Map([['price', 'REAL']]),
+      },
+    );
+
+    expect(rewritten).toContain('CREATE TABLE "_smrt_rebuild_products"');
+    expect(rewritten).toContain('"price" REAL DEFAULT 0 CHECK ("price" >= 0)');
+    expect(rewritten).toContain(`"name" TEXT NOT NULL DEFAULT 'x, y'`);
+    expect(rewritten).toContain('"id" TEXT PRIMARY KEY');
+  });
+
+  it('preserves table-level constraints and trailing table options', () => {
+    const rewritten = rewriteSqliteCreateTable(
+      `CREATE TABLE "t" ("a" TEXT, "b" INTEGER, UNIQUE ("a", "b"), CHECK ("b" > 0)) WITHOUT ROWID`,
+      { tableName: 't_new', columnTypes: new Map([['b', 'REAL']]) },
+    );
+
+    expect(rewritten).toContain('"b" REAL');
+    expect(rewritten).toContain('UNIQUE ("a", "b")');
+    expect(rewritten).toContain('CHECK ("b" > 0)');
+    expect(rewritten?.endsWith('WITHOUT ROWID')).toBe(true);
+  });
+
+  it('refuses to rewrite when the target column is absent', () => {
+    expect(
+      rewriteSqliteCreateTable(`CREATE TABLE "t" ("a" TEXT)`, {
+        tableName: 't_new',
+        columnTypes: new Map([['missing', 'REAL']]),
+      }),
+    ).toBeNull();
+  });
+
+  it('splits the body on top-level commas only', () => {
+    const parsed = parseCreateTableBody(
+      `CREATE TABLE "t" ("a" VARCHAR(10) DEFAULT 'a,b', "b" NUMERIC(10, 2), PRIMARY KEY ("a", "b"))`,
+    );
+
+    expect(parsed?.items).toHaveLength(3);
+    expect(parsed?.items[1]).toBe('"b" NUMERIC(10, 2)');
+  });
+
+  it('classifies table constraints as non-column items', () => {
+    expect(readColumnDefinitionName('"a" TEXT')).toBe('a');
+    expect(readColumnDefinitionName('PRIMARY KEY ("a")')).toBeNull();
+    expect(readColumnDefinitionName('CONSTRAINT c CHECK (1)')).toBeNull();
+    // A quoted identifier that happens to spell a constraint keyword is still
+    // a column.
+    expect(readColumnDefinitionName('"check" TEXT')).toBe('check');
+  });
+
+  it('replaces sized types and adds one to an untyped column', () => {
+    expect(replaceColumnType('"a" VARCHAR(255) NOT NULL', 'TEXT')).toBe(
+      '"a" TEXT NOT NULL',
+    );
+    expect(replaceColumnType('"a" DOUBLE PRECISION', 'REAL')).toBe('"a" REAL');
+    expect(replaceColumnType('"a" NOT NULL', 'REAL')).toBe('"a" REAL NOT NULL');
+  });
+});
+
+describe('#2370 SQLite table rebuild — live database', () => {
+  let db: DatabaseProvider;
+
+  beforeEach(async () => {
+    db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+  });
+
+  afterEach(async () => {
+    if (db && typeof db.close === 'function') {
+      try {
+        await db.close();
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  async function seedProducts(): Promise<void> {
+    await db.query(
+      `CREATE TABLE "products" (
+        "id" TEXT PRIMARY KEY,
+        "name" TEXT NOT NULL DEFAULT '',
+        "price" INTEGER DEFAULT 0
+      )`,
+    );
+    await db.query(`CREATE INDEX "products_name_idx" ON "products" ("name")`);
+    await db.query(
+      `CREATE UNIQUE INDEX "products_premium_idx" ON "products" ("name") WHERE "price" > 100`,
+    );
+    await db.query(
+      `CREATE TRIGGER "products_guard" BEFORE DELETE ON "products" BEGIN SELECT 1; END`,
+    );
+    await db.query(
+      `INSERT INTO "products" ("id", "name", "price") VALUES ('p1', 'Widget', 3)`,
+    );
+    await db.query(
+      `INSERT INTO "products" ("id", "name", "price") VALUES ('p2', 'Gadget', 0)`,
+    );
+  }
+
+  it('emits an executable rebuild instead of a "requires table recreation" comment', async () => {
+    await seedProducts();
+
+    const diff = await new SchemaComparer(db).compare(productsManifest());
+    const upgrades = diff.changes.filter((c) => c.type === 'type_upgrade');
+
+    expect(upgrades).toHaveLength(1);
+    expect(upgrades[0].name).toBe('price');
+    expect(isSqliteRebuildPlaceholder(upgrades[0].sql)).toBe(false);
+
+    const statements = upgrades[0].sqlStatements ?? [];
+    expect(statements.some((s) => s.startsWith('--'))).toBe(false);
+    expect(statements).toEqual(
+      expect.arrayContaining([
+        'PRAGMA defer_foreign_keys = ON',
+        'DROP TABLE IF EXISTS "_smrt_rebuild_products"',
+        'DROP TABLE "products"',
+        'ALTER TABLE "_smrt_rebuild_products" RENAME TO "products"',
+      ]),
+    );
+    expect(
+      statements.some((s) => /^CREATE TABLE "_smrt_rebuild_products"/.test(s)),
+    ).toBe(true);
+    // The rebuild must be part of the executable statement stream now.
+    expect(getSQLFromDiff(diff).length).toBeGreaterThan(0);
+  });
+
+  it('applies the rebuild through the tracker, preserving rows and recreating indexes/triggers', async () => {
+    await seedProducts();
+
+    const diff = await new SchemaComparer(db).compare(productsManifest());
+    const statements = executableSql(diff);
+
+    const tracker = new MigrationTracker({ db });
+    const [result] = await tracker.applyAll(
+      [
+        {
+          id: 'type_upgrade_products_price',
+          description: 'rebuild products for price REAL',
+          version: '1.0.0',
+          up: statements,
+          down: [],
+        },
+      ],
+      { atomic: true },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+
+    // Data preserved, and INTEGER values are now stored as REAL.
+    const rows = (
+      await db.query(
+        `SELECT "id", "name", "price", typeof("price") AS price_type FROM "products" ORDER BY "id"`,
+      )
+    ).rows as {
+      id: string;
+      name: string;
+      price: number;
+      price_type: string;
+    }[];
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ id: 'p1', name: 'Widget', price: 3 });
+    expect(rows[0].price_type).toBe('real');
+    expect(rows[1]).toMatchObject({ id: 'p2', name: 'Gadget', price: 0 });
+
+    // The declared column type changed.
+    const columns = (await db.query(`PRAGMA table_info("products")`)).rows as {
+      name: string;
+      type: string;
+      notnull: number;
+      dflt_value: string | null;
+      pk: number;
+    }[];
+    const price = columns.find((c) => c.name === 'price');
+    expect(price?.type).toBe('REAL');
+    expect(price?.dflt_value).toBe('0');
+    // Untouched columns keep their constraints.
+    const name = columns.find((c) => c.name === 'name');
+    expect(name?.notnull).toBe(1);
+    expect(columns.find((c) => c.name === 'id')?.pk).toBe(1);
+
+    // Indexes (including the partial one) and the trigger are back.
+    const objects = (
+      await db.query(
+        `SELECT name, type, sql FROM sqlite_master WHERE tbl_name = 'products' AND sql IS NOT NULL ORDER BY name`,
+      )
+    ).rows as { name: string; type: string; sql: string }[];
+    const names = objects.map((o) => o.name);
+    expect(names).toContain('products_name_idx');
+    expect(names).toContain('products_premium_idx');
+    expect(names).toContain('products_guard');
+    expect(
+      objects.find((o) => o.name === 'products_premium_idx')?.sql,
+    ).toContain('WHERE "price" > 100');
+
+    // The staging table is gone and the connection pragma was restored.
+    const staging = (
+      await db.query(
+        `SELECT name FROM sqlite_master WHERE name = '_smrt_rebuild_products'`,
+      )
+    ).rows;
+    expect(staging).toHaveLength(0);
+    const legacy = (await db.query('PRAGMA legacy_alter_table')).rows[0] as {
+      legacy_alter_table: number;
+    };
+    expect(legacy.legacy_alter_table).toBe(0);
+
+    // And the drift is gone: a re-diff sees no type upgrade.
+    const reDiff = await new SchemaComparer(db).compare(productsManifest());
+    expect(
+      reDiff.changes.filter((c) => c.type === 'type_upgrade'),
+    ).toHaveLength(0);
+  });
+
+  it('rebuilds every drifted column of a table in one pass', async () => {
+    await db.query(
+      `CREATE TABLE "products" (
+        "id" TEXT PRIMARY KEY,
+        "name" TEXT,
+        "price" INTEGER,
+        "weight" INTEGER
+      )`,
+    );
+    await db.query(
+      `INSERT INTO "products" ("id", "name", "price", "weight") VALUES ('p1', 'Widget', 2, 5)`,
+    );
+
+    const manifest = productsManifest('REAL', { weight: { type: 'REAL' } });
+    const diff = await new SchemaComparer(db).compare(manifest);
+    const upgrades = diff.changes.filter((c) => c.type === 'type_upgrade');
+
+    // Two drifted columns, one rebuild: the second is a no-op comment that
+    // points at the first (the CLI classifies it `noop` and drops it).
+    expect(upgrades).toHaveLength(2);
+    expect(upgrades[0].sqlStatements?.length).toBeGreaterThan(0);
+    expect(upgrades[1].sqlStatements).toBeUndefined();
+    expect(upgrades[1].sql).toContain('no change needed');
+
+    const tracker = new MigrationTracker({ db });
+    const [result] = await tracker.applyAll(
+      [
+        {
+          id: 'rebuild_products',
+          description: 'rebuild',
+          version: '1.0.0',
+          up: executableSql(diff),
+          down: [],
+        },
+      ],
+      { atomic: true },
+    );
+    expect(result.success).toBe(true);
+
+    const columns = (await db.query(`PRAGMA table_info("products")`)).rows as {
+      name: string;
+      type: string;
+    }[];
+    expect(columns.find((c) => c.name === 'price')?.type).toBe('REAL');
+    expect(columns.find((c) => c.name === 'weight')?.type).toBe('REAL');
+    expect(
+      (await db.query(`SELECT COUNT(*) AS n FROM "products"`)).rows[0],
+    ).toMatchObject({ n: 1 });
+  });
+
+  it('preserves columns the manifest no longer declares', async () => {
+    await db.query(
+      `CREATE TABLE "products" (
+        "id" TEXT PRIMARY KEY,
+        "name" TEXT,
+        "price" INTEGER,
+        "legacy_note" TEXT
+      )`,
+    );
+    await db.query(
+      `INSERT INTO "products" VALUES ('p1', 'Widget', 7, 'keep me')`,
+    );
+
+    const diff = await new SchemaComparer(db).compare(productsManifest());
+    const tracker = new MigrationTracker({ db });
+    const [result] = await tracker.applyAll(
+      [
+        {
+          id: 'rebuild_products',
+          description: 'rebuild',
+          version: '1.0.0',
+          up: executableSql(diff),
+          down: [],
+        },
+      ],
+      { atomic: true },
+    );
+    expect(result.success).toBe(true);
+
+    const row = (await db.query(`SELECT * FROM "products"`)).rows[0] as {
+      legacy_note: string;
+      price: number;
+    };
+    expect(row.legacy_note).toBe('keep me');
+    expect(row.price).toBe(7);
+  });
+
+  it('refuses the rebuild when another table has a foreign key onto it', async () => {
+    await seedProducts();
+    await db.query(
+      `CREATE TABLE "order_lines" (
+        "id" TEXT PRIMARY KEY,
+        "product_id" TEXT REFERENCES "products"("id") ON DELETE CASCADE
+      )`,
+    );
+    await db.query(`INSERT INTO "order_lines" VALUES ('l1', 'p1')`);
+
+    // Guard the premise: this adapter enables foreign-key enforcement, which
+    // makes DROP TABLE cascade-delete the child rows.
+    const enforcement = (await db.query('PRAGMA foreign_keys')).rows[0] as {
+      foreign_keys: number;
+    };
+    expect(enforcement.foreign_keys).toBe(1);
+
+    const diff = await new SchemaComparer(db).compare(productsManifest());
+    const upgrades = diff.changes.filter((c) => c.type === 'type_upgrade');
+
+    expect(upgrades).toHaveLength(1);
+    expect(upgrades[0].sqlStatements).toBeUndefined();
+    expect(upgrades[0].sql?.startsWith('--')).toBe(true);
+    expect(upgrades[0].sql).toContain('order_lines');
+    // No rebuild DDL is emitted, so the child rows are never at risk.
+    expect(
+      getSQLFromDiff(diff).filter((sql) => sql.includes('_smrt_rebuild_')),
+    ).toEqual([]);
+    expect(
+      (await db.query(`SELECT COUNT(*) AS n FROM "order_lines"`)).rows[0],
+    ).toMatchObject({ n: 1 });
+  });
+
+  it('refuses the rebuild when the table references itself', async () => {
+    // The staging table copies the self-reference verbatim, which makes it a
+    // child of the live table — so `DROP TABLE` cascades the *staged* rows
+    // away and the rebuild would silently lose data.
+    await db.query(
+      `CREATE TABLE "products" (
+        "id" TEXT PRIMARY KEY,
+        "name" TEXT,
+        "price" INTEGER,
+        "parent_id" TEXT REFERENCES "products"("id") ON DELETE CASCADE
+      )`,
+    );
+    await db.query(`INSERT INTO "products" VALUES ('p1', 'Widget', 1, NULL)`);
+    await db.query(`INSERT INTO "products" VALUES ('p2', 'Part', 2, 'p1')`);
+
+    const diff = await new SchemaComparer(db).compare(productsManifest());
+    const upgrades = diff.changes.filter((c) => c.type === 'type_upgrade');
+
+    expect(upgrades).toHaveLength(1);
+    expect(upgrades[0].sqlStatements).toBeUndefined();
+    expect(upgrades[0].sql).toContain('products');
+    expect(
+      getSQLFromDiff(diff).filter((sql) => sql.includes('_smrt_rebuild_')),
+    ).toEqual([]);
+  });
+
+  it('rolls the table back intact when a later statement in the batch fails', async () => {
+    await seedProducts();
+
+    const diff = await new SchemaComparer(db).compare(productsManifest());
+    const tracker = new MigrationTracker({ db });
+    const results = await tracker.applyAll(
+      [
+        {
+          id: 'rebuild_products',
+          description: 'rebuild',
+          version: '1.0.0',
+          up: [...executableSql(diff), 'SELECT this_is_not_valid_sql()'],
+          down: [],
+        },
+      ],
+      { atomic: true },
+    );
+
+    expect(results[0].success).toBe(false);
+
+    // Original shape and data intact.
+    const columns = (await db.query(`PRAGMA table_info("products")`)).rows as {
+      name: string;
+      type: string;
+    }[];
+    expect(columns.find((c) => c.name === 'price')?.type).toBe('INTEGER');
+    expect(
+      (await db.query(`SELECT COUNT(*) AS n FROM "products"`)).rows[0],
+    ).toMatchObject({ n: 2 });
+    expect(
+      (
+        await db.query(
+          `SELECT COUNT(*) AS n FROM sqlite_master WHERE tbl_name = 'products' AND type = 'index' AND sql IS NOT NULL`,
+        )
+      ).rows[0],
+    ).toMatchObject({ n: 2 });
+  });
+});

--- a/packages/core/src/migrations/__tests__/sqlite-table-rebuild.test.ts
+++ b/packages/core/src/migrations/__tests__/sqlite-table-rebuild.test.ts
@@ -367,6 +367,75 @@ describe('#2370 SQLite table rebuild — live database', () => {
     expect(row.price).toBe(7);
   });
 
+  it('keeps a same-batch added column when the manifest declares it first', async () => {
+    // The differ emits changes in manifest field order, so a new field
+    // declared above the retyped one puts `add_column` before the rebuild.
+    // The rebuild's staging DDL and copy list were captured before the batch
+    // ran, so executing in that order would silently drop the freshly added
+    // column — both statements succeed and the transaction commits.
+    await db.query(
+      `CREATE TABLE "products" ("id" TEXT PRIMARY KEY, "price" INTEGER)`,
+    );
+    await db.query(`INSERT INTO "products" VALUES ('p1', 5)`);
+
+    const manifest: Record<string, SchemaDefinition> = {
+      products: {
+        tableName: 'products',
+        ddl: '',
+        columns: {
+          id: { type: 'TEXT', primaryKey: true },
+          // Declared before the drifted column on purpose.
+          sku: { type: 'TEXT' },
+          price: { type: 'REAL' },
+        },
+        indexes: [],
+        triggers: [],
+        foreignKeys: [],
+        dependencies: [],
+        version: '1.0.0',
+      },
+    };
+
+    const diff = await new SchemaComparer(db).compare(manifest);
+    const columnChanges = diff.changes.filter(
+      (c) => c.type === 'add_column' || c.type === 'type_upgrade',
+    );
+    expect(columnChanges.map((c) => c.type)).toEqual([
+      'type_upgrade',
+      'add_column',
+    ]);
+
+    const tracker = new MigrationTracker({ db });
+    const [result] = await tracker.applyAll(
+      [
+        {
+          id: 'rebuild_and_add',
+          description: 'rebuild + add column',
+          version: '1.0.0',
+          up: executableSql(diff),
+          down: [],
+        },
+      ],
+      { atomic: true },
+    );
+    expect(result.success).toBe(true);
+
+    const columns = (await db.query(`PRAGMA table_info("products")`)).rows as {
+      name: string;
+      type: string;
+    }[];
+    expect(columns.map((c) => c.name).sort()).toEqual(['id', 'price', 'sku']);
+    expect(columns.find((c) => c.name === 'price')?.type).toBe('REAL');
+    expect((await db.query(`SELECT * FROM "products"`)).rows[0]).toMatchObject({
+      id: 'p1',
+      price: 5,
+    });
+
+    // And the schema is fully reconciled — no drift left over.
+    const reDiff = await new SchemaComparer(db).compare(manifest);
+    expect(reDiff.changes).toEqual([]);
+  });
+
   it('refuses the rebuild when another table has a foreign key onto it', async () => {
     await seedProducts();
     await db.query(

--- a/packages/core/src/migrations/differ.ts
+++ b/packages/core/src/migrations/differ.ts
@@ -17,6 +17,10 @@ import type {
   SQLDataType,
 } from '../schema/types.js';
 import { isJsonPathIndex, renderIndexTarget } from '../schema/utils.js';
+import {
+  planSqliteTableRebuilds,
+  sqliteRebuildPlaceholderSql,
+} from './sqlite-rebuild.js';
 import type { DatabaseInterface, SqlTableSchemaInfo } from './types.js';
 
 const logger = createLogger({ level: 'info' });
@@ -294,7 +298,20 @@ export class SchemaComparer {
 
     // Compare columns
     const columnChanges = this.compareColumns(tableName, manifest, dbSchema);
-    changes.push(...columnChanges);
+    // #2370: SQLite cannot change a column's type in place. Turn the
+    // "requires table recreation" placeholders those comparisons emit into an
+    // executable table rebuild (see `./sqlite-rebuild.ts`); anything the
+    // rebuild can't do safely stays manual drift, as before.
+    changes.push(
+      ...(this.engine === 'sqlite'
+        ? await planSqliteTableRebuilds({
+            db: this.db,
+            tableName,
+            changes: columnChanges,
+            mapType: (type) => this.ddlStrategy.mapType(type),
+          })
+        : columnChanges),
+    );
 
     // Partial-index predicates are not surfaced by `getTableSchema()` (the
     // @happyvertical/sql introspection returns only name/columns/unique), so
@@ -1032,10 +1049,11 @@ export class SchemaComparer {
             sql: `-- SQLite: ${quotedCol} already stores JSON as TEXT (no change needed)`,
           };
         }
-        // For other type upgrades, SQLite requires recreating the table
-        return {
-          sql: `-- SQLite: Type upgrade for ${quotedCol} requires table recreation`,
-        };
+        // Every other upgrade needs the whole table rebuilt. `compareTable`
+        // replaces this placeholder with the executable plan (#2370); it
+        // survives only when the rebuild is unsafe or unavailable, and then
+        // means the same thing it always did — manual intervention.
+        return { sql: sqliteRebuildPlaceholderSql(colName) };
 
       case 'postgres': {
         // PostgreSQL defaults must be dropped/reset around some type changes

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -50,6 +50,18 @@ export {
   migrateSmrtSchemas,
   type PendingSchemaStatementsResult,
 } from './orchestrate.js';
+// SQLite table rebuild (type changes SQLite cannot ALTER in place)
+export {
+  type BuildSqliteRebuildStatementsInput,
+  buildSqliteRebuildStatements,
+  isSqliteRebuildPlaceholder,
+  type PlanSqliteTableRebuildsOptions,
+  planSqliteTableRebuilds,
+  rewriteSqliteCreateTable,
+  SQLITE_REBUILD_TABLE_PREFIX,
+  type SqliteTableRebuildPlan,
+  sqliteRebuildPlaceholderSql,
+} from './sqlite-rebuild.js';
 // Core classes
 export {
   buildConcurrentIndexPlan,

--- a/packages/core/src/migrations/orchestrate.ts
+++ b/packages/core/src/migrations/orchestrate.ts
@@ -338,12 +338,34 @@ function isCommentOnlySql(sql: string): boolean {
 }
 
 /**
+ * True if `sql` is an advisory comment that says *nothing needs to happen* —
+ * as opposed to one that says a human has to act.
+ *
+ * The differ emits both kinds. "This SQLite column already stores JSON as
+ * TEXT" and "#2370: this column is rebuilt together with its sibling" are
+ * no-ops; "requires table recreation" / "blocked: …" are real manual drift.
+ * Treating the first kind as drift makes a fully auto-repairable migration
+ * report `hasManualDrift: true`.
+ *
+ * Keep in sync with `classifyTypeUpgradeSql`'s `noop` arm in
+ * `@happyvertical/smrt-cli` (`src/commands/db-migrate-actions.ts`), which
+ * applies the same rule on the CLI side.
+ */
+function isNoOpAdvisorySql(sql: string): boolean {
+  const trimmed = sql.trim();
+  return (
+    /no change needed/i.test(trimmed) || /already stores .* as /i.test(trimmed)
+  );
+}
+
+/**
  * Surface changes the differ produced but that the migrator cannot apply
  * automatically — either `type_mismatch` entries (the differ explicitly
  * gives up on these) or `type_upgrade` entries whose generated SQL is
- * advisory-comment-only (SQLite table-recreation cases, etc.). Callers
- * use this to distinguish "schema is in sync" from "schema is drifted but
- * we can't fix it from here."
+ * advisory-comment-only (a SQLite rebuild that would be unsafe, etc.).
+ * Callers use this to distinguish "schema is in sync" from "schema is
+ * drifted but we can't fix it from here", so a comment that means "already
+ * handled" must not land here.
  */
 function collectUnactionableChanges(
   diff: Awaited<ReturnType<typeof generateSchemaDiff>>,
@@ -357,7 +379,8 @@ function collectUnactionableChanges(
     const statements = change.sqlStatements ?? (change.sql ? [change.sql] : []);
     if (
       statements.length > 0 &&
-      statements.every((stmt) => isCommentOnlySql(stmt.trim()))
+      statements.every((stmt) => isCommentOnlySql(stmt.trim())) &&
+      !statements.every((stmt) => isNoOpAdvisorySql(stmt))
     ) {
       unactionable.push(change);
     }

--- a/packages/core/src/migrations/sqlite-rebuild.ts
+++ b/packages/core/src/migrations/sqlite-rebuild.ts
@@ -1,0 +1,768 @@
+/**
+ * SQLite table-rebuild migrations (issue #2370)
+ *
+ * SQLite has no `ALTER TABLE ... ALTER COLUMN ... TYPE`. Before this module
+ * every type-bucket change on SQLite (the canonical one being a numeric
+ * default edited from `0` to `0.0`, i.e. INTEGER → REAL) turned into an
+ * advisory differ comment, which `db:migrate` classifies as
+ * *manual intervention* and exits 1 for — forever, because nothing in the
+ * toolchain could ever perform the change.
+ *
+ * This module turns that comment into the executable rebuild SQLite's own
+ * documentation prescribes ("Making Other Kinds Of Table Schema Changes",
+ * lang_altertable.html):
+ *
+ * 1. `PRAGMA defer_foreign_keys = ON` — defers foreign-key enforcement to
+ *    COMMIT so the window where the table does not exist cannot raise. It is
+ *    honored *inside* a transaction (unlike `PRAGMA foreign_keys`, which is a
+ *    silent no-op there) and resets itself at COMMIT/ROLLBACK.
+ * 2. Create a new table under a reserved `_smrt_rebuild_` name carrying the
+ *    target shape.
+ * 3. Copy every row across.
+ * 4. Drop the original table.
+ * 5. Rename the new table into its place, with `PRAGMA legacy_alter_table`
+ *    ON for the rename itself (see {@link buildSqliteRebuildStatements}).
+ * 6. Recreate the indexes and triggers that died with the original table.
+ *
+ * The whole plan is a plain statement list, so it is executed by the
+ * `MigrationTracker` inside the same transaction as the rest of the batch:
+ * a failure anywhere rolls the table back to its original shape and contents.
+ *
+ * ## The target shape comes from the live DDL, not from the manifest
+ *
+ * The new table is the *original* `CREATE TABLE` text with only the drifted
+ * columns' type tokens replaced. That deliberately preserves everything the
+ * manifest does not model or does not own here: columns the manifest has
+ * dropped (SMRT is additive — a rebuild must not become an implicit
+ * `DROP COLUMN`), table-level constraints, `CHECK`s, collations, and table
+ * options such as `WITHOUT ROWID`. It also keeps this path from colliding
+ * with the `add_column` changes in the same batch, which still run their own
+ * `ALTER TABLE ... ADD COLUMN` against the rebuilt table.
+ *
+ * ## Why the copy carries no CAST
+ *
+ * The copy is a plain `INSERT INTO new SELECT ... FROM old`; SQLite applies
+ * the destination column's *affinity* on insert, which is exactly the
+ * conversion a fresh table would have performed (integer `1` becomes real
+ * `1.0` in a REAL column). An explicit `CAST` would be strictly worse: casting
+ * a non-numeric TEXT value to REAL/INTEGER silently yields `0`, and casting an
+ * ISO timestamp string to SQLite's NUMERIC-affinity `DATETIME` silently yields
+ * the leading year. Affinity conversion leaves values it cannot convert
+ * untouched instead of destroying them.
+ *
+ * ## When the rebuild refuses
+ *
+ * With `PRAGMA foreign_keys` enabled — which the SMRT SQLite adapter is by
+ * default — `DROP TABLE` performs an implicit `DELETE FROM` that fires
+ * `ON DELETE` actions on children. A child with `ON DELETE CASCADE` therefore
+ * loses its rows, and `defer_foreign_keys` does not help: it defers
+ * constraint *checks*, not FK *actions*. So when any table declares a foreign
+ * key onto the rebuild target and enforcement is on, the plan is refused and
+ * the change stays a manual intervention. That includes the target's own
+ * self-references, because the staging table copies them and so becomes a
+ * child of the table being dropped.
+ */
+
+import { createLogger } from '@happyvertical/logger';
+import { quoteIdentifier } from '../schema/sql-identifiers.js';
+import type { SchemaChange, SQLDataType } from '../schema/types.js';
+import type { DatabaseInterface } from './types.js';
+
+const logger = createLogger({ level: 'info' });
+
+/**
+ * Prefix of the reserved staging table a rebuild creates. `_smrt_`-prefixed
+ * names are SMRT system tables, which the differ's dropped-table sweep skips,
+ * so a staging table left behind by a non-transactional adapter cannot be
+ * mistaken for user data.
+ */
+export const SQLITE_REBUILD_TABLE_PREFIX = '_smrt_rebuild_';
+
+/**
+ * The advisory SQL the differ emits for a SQLite type upgrade it cannot
+ * perform with an `ALTER TABLE`. `planSqliteTableRebuilds` replaces it with an
+ * executable plan; when it cannot, the comment survives and `db:migrate`
+ * reports the column as manual drift exactly as it did before #2370.
+ */
+export function sqliteRebuildPlaceholderSql(columnName: string): string {
+  return `-- SQLite: Type upgrade for ${quoteIdentifier(columnName)} requires table recreation`;
+}
+
+/**
+ * True when `sql` is the differ's "requires table recreation" placeholder —
+ * i.e. a type upgrade waiting for this module to turn it into a rebuild.
+ */
+export function isSqliteRebuildPlaceholder(sql: string | undefined): boolean {
+  return typeof sql === 'string' && sql.includes('requires table recreation');
+}
+
+function blockedSql(columnName: string, reason: string): string {
+  // Must stay a single line, and must not read as a no-op: the CLI classifies
+  // any comment that says "no change needed" as noop and drops it silently.
+  return `-- SQLite: ${quoteIdentifier(columnName)} requires a table rebuild, blocked: ${reason}`;
+}
+
+function coveredSql(columnName: string, rebuiltWith: string): string {
+  // Classified `noop` by the CLI (`no change needed`): the sibling change
+  // carrying the plan rebuilds the whole table, this column included.
+  return `-- SQLite: ${quoteIdentifier(columnName)} is rebuilt with ${quoteIdentifier(rebuiltWith)} in one table rebuild (no change needed)`;
+}
+
+/** A rebuild plan: the ordered statements plus what they touch. */
+export interface SqliteTableRebuildPlan {
+  /** Ordered, executable statements. Run them in one transaction. */
+  statements: string[];
+  /** Columns copied from the old table into the new one, in table order. */
+  copiedColumns: string[];
+  /** Names of the indexes and triggers recreated after the swap. */
+  recreatedObjects: string[];
+}
+
+/** Live SQLite state a rebuild needs before it can plan anything. */
+interface SqliteRebuildContext {
+  /** `sqlite_master.sql` for the table (SQLite normalizes IF NOT EXISTS away). */
+  createTableSql: string;
+  /**
+   * Column names in `PRAGMA table_info` order. That pragma omits generated
+   * columns, which is what the copy wants: they are not insertable and the
+   * preserved DDL recomputes them in the new table.
+   */
+  columns: string[];
+  /** Indexes and triggers that will die with the dropped table. */
+  objects: { name: string; sql: string }[];
+  /** Whether `PRAGMA foreign_keys` enforcement is on for this connection. */
+  foreignKeysEnabled: boolean;
+  /** Current `PRAGMA legacy_alter_table` value, restored after the rename. */
+  legacyAlterTable: boolean;
+  /** Other tables declaring a foreign key onto this table. */
+  inboundReferences: string[];
+}
+
+export interface PlanSqliteTableRebuildsOptions {
+  db: DatabaseInterface;
+  tableName: string;
+  /** The table's changes, as produced by the differ's column comparison. */
+  changes: SchemaChange[];
+  /** Abstract → SQLite type mapping (the engine's DDL strategy `mapType`). */
+  mapType: (type: SQLDataType) => string;
+}
+
+/**
+ * Replace every "requires table recreation" placeholder for `tableName` with
+ * one executable rebuild.
+ *
+ * All of the table's drifted columns are retyped by a *single* rebuild, so the
+ * first placeholder carries the plan and the rest become no-ops that reference
+ * it. Returns the changes unchanged when there is nothing to rebuild, and
+ * leaves the placeholders in place (annotated with the reason) when the
+ * rebuild cannot be planned safely — the pre-#2370 manual-intervention
+ * behavior.
+ */
+export async function planSqliteTableRebuilds(
+  options: PlanSqliteTableRebuildsOptions,
+): Promise<SchemaChange[]> {
+  const { db, tableName, changes, mapType } = options;
+
+  const pending = changes.filter(
+    (change) =>
+      change.type === 'type_upgrade' &&
+      change.name &&
+      change.column &&
+      isSqliteRebuildPlaceholder(change.sql),
+  );
+  if (pending.length === 0) {
+    return changes;
+  }
+
+  const block = (reason: string): SchemaChange[] => {
+    logger.debug(
+      `[SQLiteRebuild] Cannot rebuild ${tableName}: ${reason}; leaving ${pending.length} type upgrade(s) as manual drift`,
+    );
+    return changes.map((change) =>
+      pending.includes(change)
+        ? { ...change, sql: blockedSql(change.name as string, reason) }
+        : change,
+    );
+  };
+
+  let context: SqliteRebuildContext;
+  try {
+    context = await readSqliteRebuildContext(db, tableName);
+  } catch (error) {
+    return block(
+      `live schema introspection failed (${error instanceof Error ? error.message : String(error)})`,
+    );
+  }
+
+  if (!context.createTableSql) {
+    return block('no CREATE TABLE statement found in sqlite_master');
+  }
+  if (context.columns.length === 0) {
+    return block('PRAGMA table_info returned no columns');
+  }
+  if (context.foreignKeysEnabled && context.inboundReferences.length > 0) {
+    return block(
+      `PRAGMA foreign_keys is ON and ${context.inboundReferences
+        .map((name) => `"${name}"`)
+        .join(
+          ', ',
+        )} declare a foreign key onto this table, so DROP TABLE would fire their ON DELETE actions`,
+    );
+  }
+
+  const columnTypes = new Map<string, string>();
+  for (const change of pending) {
+    columnTypes.set(
+      change.name as string,
+      mapType((change.column as { type: SQLDataType }).type),
+    );
+  }
+
+  const plan = buildSqliteRebuildStatements({
+    tableName,
+    createTableSql: context.createTableSql,
+    columnTypes,
+    columns: context.columns,
+    objects: context.objects,
+    legacyAlterTable: context.legacyAlterTable,
+  });
+
+  if (!plan) {
+    return block(
+      'the live CREATE TABLE statement could not be rewritten for the target column types',
+    );
+  }
+
+  const [primary, ...covered] = pending;
+  return changes.map((change) => {
+    if (change === primary) {
+      return {
+        ...change,
+        // `sql` stays a real statement so the CLI classifies this upgrade as
+        // executable; every consumer that actually runs the change prefers
+        // `sqlStatements`.
+        sql: plan.statements[0],
+        sqlStatements: plan.statements,
+      };
+    }
+    if (covered.includes(change)) {
+      const { sqlStatements: _dropped, ...rest } = change;
+      return {
+        ...rest,
+        sql: coveredSql(change.name as string, primary.name as string),
+      };
+    }
+    return change;
+  });
+}
+
+/**
+ * Read everything the rebuild needs from the live database.
+ *
+ * Every query is SQLite-only (`sqlite_master`, `PRAGMA`), and the caller only
+ * reaches this for an engine already detected as SQLite.
+ */
+async function readSqliteRebuildContext(
+  db: DatabaseInterface,
+  tableName: string,
+): Promise<SqliteRebuildContext> {
+  const tableRows = await db.query(
+    `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`,
+    tableName,
+  );
+  const createTableSql = readString(
+    (tableRows.rows[0] as { sql?: unknown } | undefined)?.sql,
+  );
+
+  const columnRows = await db.query(
+    `PRAGMA table_info(${quoteIdentifier(tableName)})`,
+  );
+  const columns = columnRows.rows
+    .map((row) => readString((row as { name?: unknown }).name))
+    .filter((name): name is string => Boolean(name));
+
+  // `sql IS NULL` marks the implicit indexes SQLite creates for inline
+  // PRIMARY KEY / UNIQUE constraints; those are carried by the CREATE TABLE
+  // text and must not be replayed separately.
+  const objectRows = await db.query(
+    `SELECT name, sql FROM sqlite_master
+      WHERE tbl_name = ? AND sql IS NOT NULL
+        AND type IN ('index', 'trigger') AND name NOT LIKE 'sqlite_%'`,
+    tableName,
+  );
+  const objects: { name: string; sql: string }[] = [];
+  for (const row of objectRows.rows as { name?: unknown; sql?: unknown }[]) {
+    const name = readString(row.name);
+    const sql = readString(row.sql);
+    if (name && sql) {
+      objects.push({ name, sql });
+    }
+  }
+
+  const foreignKeysEnabled = readPragmaFlag(
+    await db.query('PRAGMA foreign_keys'),
+  );
+  const legacyAlterTable = readPragmaFlag(
+    await db.query('PRAGMA legacy_alter_table'),
+  );
+
+  const inboundReferences = foreignKeysEnabled
+    ? await readInboundForeignKeys(db, tableName)
+    : [];
+
+  return {
+    createTableSql,
+    columns,
+    objects,
+    foreignKeysEnabled,
+    legacyAlterTable,
+    inboundReferences,
+  };
+}
+
+/**
+ * Names of tables that declare a foreign key onto `tableName`.
+ *
+ * The table itself counts. A self-reference is copied verbatim into the
+ * staging table, which therefore becomes a real child of the live table, and
+ * `DROP TABLE` then cascades the *staged* rows away — verified: a two-row
+ * self-referencing table finishes the rebuild holding one row.
+ */
+async function readInboundForeignKeys(
+  db: DatabaseInterface,
+  tableName: string,
+): Promise<string[]> {
+  const tables = await db.query(
+    `SELECT name FROM sqlite_master
+      WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`,
+  );
+
+  const referencing: string[] = [];
+  const target = tableName.toLowerCase();
+  for (const row of tables.rows as { name?: unknown }[]) {
+    const name = readString(row.name);
+    if (!name) continue;
+    const fks = await db.query(
+      `PRAGMA foreign_key_list(${quoteIdentifier(name)})`,
+    );
+    const referencesTarget = (fks.rows as { table?: unknown }[]).some(
+      (fk) => readString(fk.table).toLowerCase() === target,
+    );
+    if (referencesTarget) {
+      referencing.push(name);
+    }
+  }
+
+  return referencing;
+}
+
+function readString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+/** Read a single-row/single-column PRAGMA result as a boolean. */
+function readPragmaFlag(result: { rows: Record<string, unknown>[] }): boolean {
+  const row = result.rows[0];
+  if (!row) return false;
+  const value = Object.values(row)[0];
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') return value !== '0' && value !== '';
+  return false;
+}
+
+export interface BuildSqliteRebuildStatementsInput {
+  tableName: string;
+  /** The live `sqlite_master.sql` CREATE TABLE text. */
+  createTableSql: string;
+  /** Column name → target SQLite type, for the columns being retyped. */
+  columnTypes: Map<string, string>;
+  /** Every column of the live table, in `PRAGMA table_info` order. */
+  columns: string[];
+  /** Indexes and triggers to replay after the swap. */
+  objects: { name: string; sql: string }[];
+  /** Current `PRAGMA legacy_alter_table` value, restored after the rename. */
+  legacyAlterTable: boolean;
+}
+
+/**
+ * Build the ordered statement list for one table rebuild.
+ *
+ * Returns `null` when the live `CREATE TABLE` text cannot be rewritten (an
+ * unparsable statement, or a requested column that is not in it) — the caller
+ * then leaves the change as manual drift rather than emitting SQL that would
+ * "succeed" without fixing the column, which would re-diff forever.
+ *
+ * `PRAGMA legacy_alter_table` brackets the rename because SQLite ≥ 3.25
+ * re-parses the whole schema on `ALTER TABLE ... RENAME`: a view left
+ * referencing the just-dropped table makes the rename fail outright
+ * ("error in view … no such table"). Legacy mode renames the table without
+ * that reference rewriting, which is exactly what a rebuild wants — the name
+ * the views refer to is about to exist again. It is restored to its previous
+ * value immediately afterwards; a rolled-back batch leaves it set, which is
+ * inert for SMRT (nothing else in the toolchain renames a table) but is
+ * documented in `packages/core/agents/schema-paths.md`.
+ */
+export function buildSqliteRebuildStatements(
+  input: BuildSqliteRebuildStatementsInput,
+): SqliteTableRebuildPlan | null {
+  const {
+    tableName,
+    createTableSql,
+    columnTypes,
+    columns,
+    objects,
+    legacyAlterTable,
+  } = input;
+
+  const stagingTable = `${SQLITE_REBUILD_TABLE_PREFIX}${tableName}`;
+  const createStaging = rewriteSqliteCreateTable(createTableSql, {
+    tableName: stagingTable,
+    columnTypes,
+  });
+  if (!createStaging) {
+    return null;
+  }
+
+  const quotedTable = quoteIdentifier(tableName);
+  const quotedStaging = quoteIdentifier(stagingTable);
+  const columnList = columns.map((name) => quoteIdentifier(name)).join(', ');
+
+  const statements = [
+    // Deferred FK enforcement survives the window where the table is absent.
+    // Unlike `PRAGMA foreign_keys`, this one is honored inside a transaction
+    // and resets itself at COMMIT/ROLLBACK.
+    'PRAGMA defer_foreign_keys = ON',
+    // Idempotent for a retry after a partially applied non-transactional run.
+    `DROP TABLE IF EXISTS ${quotedStaging}`,
+    createStaging,
+    `INSERT INTO ${quotedStaging} (${columnList}) SELECT ${columnList} FROM ${quotedTable}`,
+    `DROP TABLE ${quotedTable}`,
+    'PRAGMA legacy_alter_table = ON',
+    `ALTER TABLE ${quotedStaging} RENAME TO ${quotedTable}`,
+    `PRAGMA legacy_alter_table = ${legacyAlterTable ? 'ON' : 'OFF'}`,
+    // The indexes and triggers went down with the dropped table. Their
+    // original text still names the table correctly (it was renamed back), so
+    // replaying it verbatim preserves partial predicates, expression indexes,
+    // and trigger bodies that a manifest-driven regeneration would flatten.
+    ...objects.map((object) => object.sql),
+  ];
+
+  return {
+    statements,
+    copiedColumns: [...columns],
+    recreatedObjects: objects.map((object) => object.name),
+  };
+}
+
+/**
+ * Rewrite a live `CREATE TABLE` statement into the rebuild's target shape:
+ * the same body under a new table name, with the declared type of each column
+ * in `columnTypes` replaced.
+ *
+ * Everything else is preserved verbatim — other columns, their defaults,
+ * `NOT NULL`/`PRIMARY KEY`/`CHECK`/`COLLATE` clauses, table-level
+ * constraints, and trailing table options (`WITHOUT ROWID`, `STRICT`).
+ *
+ * Returns `null` if the statement cannot be parsed or if any requested column
+ * is not present in it.
+ */
+export function rewriteSqliteCreateTable(
+  createTableSql: string,
+  target: { tableName: string; columnTypes: Map<string, string> },
+): string | null {
+  const parsed = parseCreateTableBody(createTableSql);
+  if (!parsed) {
+    return null;
+  }
+
+  const wanted = new Map<string, string>();
+  for (const [name, type] of target.columnTypes) {
+    wanted.set(name.toLowerCase(), type);
+  }
+
+  const rewritten: string[] = [];
+  for (const item of parsed.items) {
+    const columnName = readColumnDefinitionName(item);
+    const newType = columnName ? wanted.get(columnName.toLowerCase()) : null;
+    if (!columnName || !newType) {
+      rewritten.push(item);
+      continue;
+    }
+    const replaced = replaceColumnType(item, newType);
+    if (!replaced) {
+      return null;
+    }
+    rewritten.push(replaced);
+    wanted.delete(columnName.toLowerCase());
+  }
+
+  if (wanted.size > 0) {
+    // A column the differ wants retyped is not in the live DDL. Rebuilding
+    // would not fix the drift, so refuse instead of emitting a no-op plan.
+    return null;
+  }
+
+  const tail = parsed.tail ? ` ${parsed.tail}` : '';
+  return `CREATE TABLE ${quoteIdentifier(target.tableName)} (\n  ${rewritten.join(
+    ',\n  ',
+  )}\n)${tail}`;
+}
+
+interface ParsedCreateTable {
+  /** Top-level, comma-separated column and constraint definitions. */
+  items: string[];
+  /** Table options after the closing paren (`WITHOUT ROWID`, `STRICT`). */
+  tail: string;
+}
+
+/**
+ * Split a `CREATE TABLE` statement into its top-level definition items plus
+ * any trailing table options, honoring SQLite's quoting (`'…'`, `"…"`,
+ * `` `…` ``, `[…]`) and comments so a quoted comma or paren cannot split the
+ * body.
+ *
+ * @internal exported for testing
+ */
+export function parseCreateTableBody(sql: string): ParsedCreateTable | null {
+  let index = 0;
+  let open = -1;
+  while (index < sql.length) {
+    const skipped = skipQuotedOrComment(sql, index);
+    if (skipped !== null) {
+      index = skipped;
+      continue;
+    }
+    if (sql[index] === '(') {
+      open = index;
+      break;
+    }
+    index++;
+  }
+  if (open === -1) {
+    return null;
+  }
+
+  const items: string[] = [];
+  let depth = 1;
+  let itemStart = open + 1;
+  let close = -1;
+  index = open + 1;
+  while (index < sql.length) {
+    const skipped = skipQuotedOrComment(sql, index);
+    if (skipped !== null) {
+      index = skipped;
+      continue;
+    }
+    const char = sql[index];
+    if (char === '(') {
+      depth++;
+    } else if (char === ')') {
+      depth--;
+      if (depth === 0) {
+        close = index;
+        items.push(sql.slice(itemStart, index));
+        break;
+      }
+    } else if (char === ',' && depth === 1) {
+      items.push(sql.slice(itemStart, index));
+      itemStart = index + 1;
+    }
+    index++;
+  }
+
+  if (close === -1) {
+    return null;
+  }
+
+  const trimmed = items.map((item) => item.trim()).filter(Boolean);
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  return {
+    items: trimmed,
+    tail: sql
+      .slice(close + 1)
+      .trim()
+      .replace(/;+$/, '')
+      .trim(),
+  };
+}
+
+/**
+ * If `sql[index]` opens a quoted identifier, string literal, or comment,
+ * return the index just past its end. Otherwise return `null`.
+ */
+function skipQuotedOrComment(sql: string, index: number): number | null {
+  const char = sql[index];
+
+  if (char === "'" || char === '"' || char === '`') {
+    let cursor = index + 1;
+    while (cursor < sql.length) {
+      if (sql[cursor] === char) {
+        // A doubled delimiter is an escaped one, not the end of the token.
+        if (sql[cursor + 1] === char) {
+          cursor += 2;
+          continue;
+        }
+        return cursor + 1;
+      }
+      cursor++;
+    }
+    return sql.length;
+  }
+
+  if (char === '[') {
+    const end = sql.indexOf(']', index + 1);
+    return end === -1 ? sql.length : end + 1;
+  }
+
+  if (char === '-' && sql[index + 1] === '-') {
+    const end = sql.indexOf('\n', index);
+    return end === -1 ? sql.length : end + 1;
+  }
+
+  if (char === '/' && sql[index + 1] === '*') {
+    const end = sql.indexOf('*/', index + 2);
+    return end === -1 ? sql.length : end + 2;
+  }
+
+  return null;
+}
+
+/**
+ * Keywords that start a *table*-level constraint, i.e. a body item that is not
+ * a column definition.
+ */
+const TABLE_CONSTRAINT_KEYWORDS = new Set([
+  'constraint',
+  'primary',
+  'unique',
+  'check',
+  'foreign',
+]);
+
+/**
+ * Keywords that end a column's type name and start its constraint list.
+ */
+const COLUMN_CONSTRAINT_KEYWORDS = new Set([
+  'constraint',
+  'primary',
+  'not',
+  'null',
+  'unique',
+  'check',
+  'default',
+  'collate',
+  'references',
+  'generated',
+  'as',
+]);
+
+interface Identifier {
+  name: string;
+  end: number;
+}
+
+/** Read the leading identifier of a body item (quoted or bare). */
+function readLeadingIdentifier(item: string): Identifier | null {
+  let index = 0;
+  while (index < item.length && /\s/.test(item[index])) index++;
+  if (index >= item.length) return null;
+
+  const char = item[index];
+  if (char === '"' || char === '`' || char === '[') {
+    const end = skipQuotedOrComment(item, index);
+    if (end === null) return null;
+    const raw = item.slice(index + 1, end - 1);
+    // `[…]` has no escape form; `"…"` / `` `…` `` double the delimiter.
+    return {
+      name: char === '[' ? raw : raw.split(char + char).join(char),
+      end,
+    };
+  }
+
+  const match = /^[A-Za-z_][\w$]*/.exec(item.slice(index));
+  if (!match) return null;
+  return { name: match[0], end: index + match[0].length };
+}
+
+/**
+ * The column name of a body item, or `null` when the item is a table-level
+ * constraint rather than a column definition.
+ *
+ * @internal exported for testing
+ */
+export function readColumnDefinitionName(item: string): string | null {
+  const identifier = readLeadingIdentifier(item);
+  if (!identifier) return null;
+
+  const isQuoted = /^\s*["`[]/.test(item);
+  if (
+    !isQuoted &&
+    TABLE_CONSTRAINT_KEYWORDS.has(identifier.name.toLowerCase())
+  ) {
+    return null;
+  }
+  return identifier.name;
+}
+
+/**
+ * Replace the declared type of a column definition, keeping its name and every
+ * constraint that follows. A column declared without a type gets one inserted.
+ *
+ * @internal exported for testing
+ */
+export function replaceColumnType(
+  item: string,
+  newType: string,
+): string | null {
+  const identifier = readLeadingIdentifier(item);
+  if (!identifier) return null;
+
+  const head = item.slice(0, identifier.end);
+  let index = identifier.end;
+
+  // The type name is one or more bare words followed by an optional
+  // `(size[, size])` — everything before the first column-constraint keyword.
+  let typeEnd = index;
+  while (index < item.length) {
+    while (index < item.length && /\s/.test(item[index])) index++;
+    const match = /^[A-Za-z_][\w$]*/.exec(item.slice(index));
+    if (!match || COLUMN_CONSTRAINT_KEYWORDS.has(match[0].toLowerCase())) {
+      break;
+    }
+    index += match[0].length;
+    typeEnd = index;
+  }
+
+  // Optional parenthesized type argument, e.g. VARCHAR(255).
+  if (typeEnd > identifier.end) {
+    let cursor = typeEnd;
+    while (cursor < item.length && /\s/.test(item[cursor])) cursor++;
+    if (item[cursor] === '(') {
+      let depth = 0;
+      while (cursor < item.length) {
+        const skipped = skipQuotedOrComment(item, cursor);
+        if (skipped !== null) {
+          cursor = skipped;
+          continue;
+        }
+        if (item[cursor] === '(') depth++;
+        else if (item[cursor] === ')') {
+          depth--;
+          if (depth === 0) {
+            typeEnd = cursor + 1;
+            break;
+          }
+        }
+        cursor++;
+      }
+    }
+  }
+
+  const rest = item.slice(typeEnd);
+  const separator = rest.length === 0 || /^\s/.test(rest) ? '' : ' ';
+  return `${head} ${newType}${separator}${rest}`;
+}

--- a/packages/core/src/migrations/sqlite-rebuild.ts
+++ b/packages/core/src/migrations/sqlite-rebuild.ts
@@ -35,9 +35,10 @@
  * manifest does not model or does not own here: columns the manifest has
  * dropped (SMRT is additive — a rebuild must not become an implicit
  * `DROP COLUMN`), table-level constraints, `CHECK`s, collations, and table
- * options such as `WITHOUT ROWID`. It also keeps this path from colliding
- * with the `add_column` changes in the same batch, which still run their own
- * `ALTER TABLE ... ADD COLUMN` against the rebuilt table.
+ * options such as `WITHOUT ROWID`. The `add_column` changes in the same batch
+ * still run their own `ALTER TABLE ... ADD COLUMN`, against the rebuilt table
+ * — {@link planSqliteTableRebuilds} hoists the rebuild ahead of them for
+ * exactly that reason.
  *
  * ## Why the copy carries no CAST
  *
@@ -157,6 +158,16 @@ export interface PlanSqliteTableRebuildsOptions {
  * leaves the placeholders in place (annotated with the reason) when the
  * rebuild cannot be planned safely — the pre-#2370 manual-intervention
  * behavior.
+ *
+ * When a plan is produced, the rebuild is hoisted to the front of the table's
+ * changes. The plan's staging DDL and copy list are captured from the live
+ * schema *at diff time*, so a same-batch `ALTER TABLE ... ADD COLUMN` that ran
+ * first would be silently undone by the rebuild — both statements succeed, the
+ * transaction commits, and the new column is simply gone. The differ emits
+ * changes in manifest field order, which puts an `add_column` first whenever
+ * the new field is declared above the retyped one, so the order has to be
+ * imposed here rather than assumed. Rebuild first, then add columns to the
+ * rebuilt table.
  */
 export async function planSqliteTableRebuilds(
   options: PlanSqliteTableRebuildsOptions,
@@ -234,7 +245,7 @@ export async function planSqliteTableRebuilds(
   }
 
   const [primary, ...covered] = pending;
-  return changes.map((change) => {
+  const rebuilt = changes.map((change) => {
     if (change === primary) {
       return {
         ...change,
@@ -254,6 +265,17 @@ export async function planSqliteTableRebuilds(
     }
     return change;
   });
+
+  // Hoist the rebuild ahead of the table's other column changes, keeping both
+  // groups in their original relative order. Consumers execute `diff.changes`
+  // in order, and the plan was built from the pre-batch table shape.
+  const rebuildPositions = new Set(
+    pending.map((change) => changes.indexOf(change)),
+  );
+  return [
+    ...rebuilt.filter((_, index) => rebuildPositions.has(index)),
+    ...rebuilt.filter((_, index) => !rebuildPositions.has(index)),
+  ];
 }
 
 /**


### PR DESCRIPTION
## Problem

SQLite has no `ALTER TABLE ... ALTER COLUMN ... TYPE`. Every type-bucket change
on SQLite — canonically a numeric default edited from `0` to `0.0`
(INTEGER → REAL) — became an advisory differ comment
(`-- SQLite: Type upgrade for "x" requires table recreation`), which
`partitionSchemaChanges` classifies as **manual intervention** and
`shouldFailDbMigrate` turns into a non-zero exit. Nothing in the toolchain
could ever perform the change, so `smrt db:migrate` failed on that database
forever and the drift was permanent.

## Change

New `packages/core/src/migrations/sqlite-rebuild.ts` plans the rebuild
SQLite's own documentation prescribes, and `SchemaComparer.compareTable` swaps
that plan in for the placeholder (12-line hunk in `differ.ts`, which #2369
owns):

```
PRAGMA defer_foreign_keys = ON
DROP TABLE IF EXISTS "_smrt_rebuild_products"
CREATE TABLE "_smrt_rebuild_products" (…)      -- live DDL, drifted types replaced
INSERT INTO "_smrt_rebuild_products" (cols) SELECT cols FROM "products"
DROP TABLE "products"
PRAGMA legacy_alter_table = ON
ALTER TABLE "_smrt_rebuild_products" RENAME TO "products"
PRAGMA legacy_alter_table = OFF                -- restored to its previous value
CREATE INDEX …  /  CREATE TRIGGER …            -- replayed from sqlite_master
```

The statements land in `change.sqlStatements`, so the tracker runs them inside
the normal atomic batch: a failure anywhere rolls the table back to its
original shape and contents (test). All drifted columns of one table share a
single rebuild — the first change carries the plan, the rest become
`no change needed` comments the CLI classifies as no-ops.

### Four decisions that are load-bearing

- **The target shape is the live `sqlite_master` DDL** with only the drifted
  column types replaced — not a manifest regeneration. So the rebuild never
  becomes an implicit `DROP COLUMN` for a column the manifest dropped, never
  collides with the `add_column` changes in the same batch (which would then
  hit "duplicate column name"), and preserves table constraints, `CHECK`s,
  collations, and `WITHOUT ROWID`/`STRICT`. It also keeps this out of #2369's
  nullability/default territory.
- **The copy carries no `CAST`**, despite the issue text. SQLite applies the
  destination column's affinity on insert — the exact conversion a fresh table
  performs (integer `1` → real `1.0`, asserted via `typeof()`). An explicit
  cast is strictly worse: non-numeric TEXT cast to REAL/INTEGER silently
  becomes `0`, and an ISO timestamp cast to NUMERIC-affinity `DATETIME`
  becomes its leading year.
- **It refuses when any table declares a foreign key onto the target and
  `PRAGMA foreign_keys` is ON** (the adapter's default — verified, it returns
  1 on a fresh connection). `DROP TABLE` performs an implicit `DELETE FROM`
  that fires `ON DELETE CASCADE` on children, and `defer_foreign_keys` defers
  constraint *checks*, not FK *actions*. Verified against real SQLite: the
  child rows go. **The target's own self-reference counts** — the staging
  table copies that clause and so becomes a child of the table being dropped;
  verified, a two-row self-referencing table finishes the rebuild holding one
  row. Both cases stay manual drift with a comment naming the tables.
- **`PRAGMA legacy_alter_table` brackets the rename.** SQLite ≥ 3.25 re-parses
  the whole schema on `ALTER TABLE ... RENAME`, so a view still pointing at
  the just-dropped table makes the rename fail outright (verified: "error in
  view"). Legacy mode renames without that rewriting, which is what a rebuild
  wants — the name the views refer to is about to exist again. It is restored
  to its pre-flight value immediately after; a rolled-back batch leaves it
  set, which is inert here because nothing else in SMRT renames a table, and
  that caveat is documented.

`change.sql` is the plan's first statement (`PRAGMA defer_foreign_keys = ON`)
so the CLI classifies the upgrade as executable while a consumer that ignores
`sqlStatements` runs something harmless rather than a half-rebuild.

PostgreSQL and DuckDB paths are untouched — the whole module is behind
`this.engine === 'sqlite'`.

## Tests

`packages/core/src/migrations/__tests__/sqlite-table-rebuild.test.ts` (12
cases, real in-memory SQLite, no mocking):

- the differ emits executable statements instead of the placeholder;
- applying through `MigrationTracker` preserves both rows, flips
  `typeof(price)` to `real`, keeps `NOT NULL`/`DEFAULT`/`PRIMARY KEY` on the
  untouched columns, brings back a plain index, a **partial unique** index
  (predicate intact) and a trigger, leaves no staging table, restores the
  pragma, and re-diffs clean;
- two drifted columns on one table → one rebuild plus a no-op;
- a column the manifest no longer declares survives with its data;
- the FK refusal and the self-reference refusal emit no rebuild DDL;
- a failure later in the batch rolls the table back to INTEGER with both rows
  and both indexes;
- pure-function cases for the DDL rewriting: sized types, multi-word types,
  untyped columns, quoted identifiers spelling constraint keywords, top-level
  comma splitting with a quoted comma, table constraints and `WITHOUT ROWID`.

Updated: `orchestrate.test.ts` (the SQLite type upgrade is now planned and
applied end to end; a second case keeps the unactionable-drift path covered
through the FK refusal) and `db-migrate-actions.test.ts` (a rebuild lands in
the executable migration set, not `manualInterventions`).

No generator or schema-emission change, so there is nothing to add to the
#2359 schema path-parity test (which is not on this base yet).

## Validation

- `packages/core` full `pnpm test` — 3559 passed, 62 skipped (288 files)
- `packages/cli` full `pnpm test` — 867 passed, 7 skipped (60 files)
- `packages/sales` `commission-adjustment-service.test.ts` (the only
  out-of-package `getSQLFromDiff` consumer) — 26 passed
- `pnpm typecheck` (core, cli) — clean
- `npx biome check` on the changed files — clean
- `pnpm smrt dev:knowledge-check` — fresh, 0 errors / 0 warnings
- `pnpm check:agents-chain` — clean (cli 4.6 KB under the cap)
- `node scripts/check-coverage.mjs --packages core,cli` — core 86.93%, cli
  90.15% (T1 floor 80%)
- `pnpm test:postgres` (core) could not run locally — no
  `CI_POSTGRES_BASE_URL`/`DATABASE_URL` service in this worktree. The change
  emits no PostgreSQL SQL and is gated on `engine === 'sqlite'`; CI covers the
  lane.

Merged `origin/main` (9c213741d, #2399) before pushing; the only conflict was
adjacent new sections in `packages/cli/AGENTS.md`, resolved by keeping both.

Closes #2370
Refs #2382

## Review feedback (c7d81f8e0)

Two findings from the pre-ship review round, both about how the plan interacts
with the rest of the batch — neither was reachable through a public API in a
way the first test set covered:

- **A same-batch `add_column` could be silently undone.** The staging DDL and
  copy list are captured at diff time, and the differ emits column changes in
  manifest field order, so a new field declared *above* the retyped one ran
  `ALTER TABLE ... ADD COLUMN` first and the rebuild then recreated the table
  from the pre-ADD shape: both statements succeed, the transaction commits,
  the column is gone. `planSqliteTableRebuilds` now hoists the rebuild ahead of
  the table's other column changes (stable within each group). The regression
  test asserts the emitted order, the final column set, and a clean re-diff —
  and fails on the previous ordering.
- **A covered column was reported as manual drift.** `collectUnactionableChanges`
  treats any comment-only change as drift a human must fix, but the second
  drifted column on a table carries a `no change needed` comment because the
  sibling rebuild covers it, so `hasManualDrift` was `true` for a fully
  auto-repairable migration. No-op comments are now exempt, matching the CLI's
  long-standing `classifyTypeUpgradeSql` rule; this also clears the same false
  positive for the pre-existing "already stores JSON as TEXT" comment.

Post-fix validation: `packages/core` full `pnpm test` — 3561 passed, 62
skipped; `packages/cli` command tests — 561 passed; typecheck, biome and
knowledge-check clean. Merged `origin/main` again (db1b68d92, #2403); the only
conflict was an adjacent new rule in `packages/core/agents/schema-paths.md`
(kept both, renumbered).

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","policy_revision":"1.0.0","runtime":"claude","session":"2e828b4a-bf86-463b-8159-3ee4e9f1275f","issue":"https://github.com/happyvertical/smrt/issues/2370"}
```
