### PR TITLE
fix(core): make the merged STI table shape registration-order independent

### DIFF
--- a/packages/core/agents/schema-paths.md
+++ b/packages/core/agents/schema-paths.md
@@ -219,3 +219,45 @@ from raw source (never `related: '() => Target'`). An unresolved target silently
 costs the relationship edge, `loadRelated()`, and the FK-derived index (#2379).
 A thunk resolves at decoration time, so a target declared later in the same
 module is still in its temporal dead zone — use the string form there.
+
+### 15. The merged table shape is registration-order independent (#2372)
+
+`getAllSchemas()` and `getAllSchemasAsDefinitions()` fold every class that
+shares a physical table — the whole STI hierarchy — into one shape. Both route
+through `buildMergedTableSchemas()`, which groups contributors by table and
+then merges them in a **deterministic** order: the STI base first, then
+ancestors before descendants, then by qualified name.
+
+That order matters because the first contributor seeds the table: it supplies
+the fallback base columns, the `idType`, the conflict columns and the cached
+DDL, and its columns win every merge conflict. When registration order decided
+it, an STI child that carries no manifest `schema` — the external- and
+consumer-manifest case — seeded the table from bare fallback columns and the
+base class's richer ones were skipped when it registered later, yielding
+`context TEXT` instead of `context TEXT NOT NULL DEFAULT ''` and timestamps
+with no NOT NULL/DEFAULT. The shipped content manifest lists `Article` before
+`Content`, so the losing order was the one that shipped, and the differ
+compares types only, so the weak fresh-create was never repaired.
+
+Two invariants keep the two assembly paths agreeing:
+
+- `createBaseColumns()` mirrors what `generateSchemaFromManifest` /
+  `generateSTISchemaFromManifest` emit for the same table, so a table built
+  from runtime field metadata alone has the same NOT NULL/DEFAULT shape as one
+  built from a manifest. Note `_meta_type` is `TEXT NOT NULL` with **no**
+  default, matching the generator.
+- `fieldsToColumns()` reads `required`, `default`, and `description` from the
+  top level *or* `_meta`. Registry fields normalize them into `_meta`
+  (`manifest-field-merge.ts`), so reading only the top level silently dropped
+  NOT NULL and DEFAULT for every registry-sourced field.
+
+STI columns stay nullable regardless of the field's `required` flag
+(`fieldsToColumns(fields, { stiUnionColumns: true })`): the table holds the
+union of all subtypes' fields, so a column only one subtype declares is never
+populated on a sibling's row. Declared defaults are still emitted. This matches
+`generateSTISchemaFromManifest`, which sets `notNull: false` on every non-system
+STI column.
+
+When adding a class-level input to the merged shape, take it from the seeding
+contributor rather than "whichever class arrives first", and cover it with a
+child-first/base-first equality test.

--- a/packages/core/src/__tests__/issue-2372-sti-shape-registration-order.test.ts
+++ b/packages/core/src/__tests__/issue-2372-sti-shape-registration-order.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Issue #2372: the merged STI table shape depended on class registration order.
+ *
+ * `getAllSchemas()` / `getAllSchemasAsDefinitions()` merged first-wins: the
+ * class that happened to register first for a table seeded the base columns,
+ * the id type, the conflict columns and the cached DDL, and won every column
+ * conflict. An STI child that carries no manifest `schema` (the external- and
+ * consumer-manifest case) therefore seeded the table from bare fallback base
+ * columns — `context TEXT` instead of `context TEXT NOT NULL DEFAULT ''`,
+ * timestamps without NOT NULL/DEFAULT — and the base class's richer columns
+ * were skipped when it registered later. The differ compares types only, so a
+ * weak fresh-create was never repaired.
+ *
+ * In the shipped content manifest `Article` precedes `Content`, so the order
+ * that loses is the one that actually ships.
+ *
+ * These regressions register the same hierarchy in several orders and assert
+ * one identical merged schema.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ObjectRegistry } from '../registry.js';
+import { snapshotObjectRegistryState } from '../test-utils.js';
+
+/**
+ * Base-class manifest entry, shaped like real `generateSTISchemaFromManifest`
+ * output: system columns carry NOT NULL/DEFAULT, every field column is
+ * nullable (the table is the union of all subtypes' fields).
+ */
+const BASE_MANIFEST = {
+  className: 'Issue2372Content',
+  fields: {
+    title: { type: 'text', required: true, default: '' },
+    body: { type: 'text', required: false, default: '' },
+  },
+  methods: {},
+  decoratorConfig: { tableStrategy: 'sti' },
+  schema: {
+    tableName: 'issue2372_contents',
+    ddl: '',
+    columns: {
+      id: {
+        type: 'UUID',
+        primaryKey: true,
+        notNull: true,
+        referenceKind: 'id',
+      },
+      slug: { type: 'TEXT', notNull: true },
+      context: { type: 'TEXT', notNull: true, defaultValue: '' },
+      created_at: {
+        type: 'TIMESTAMP',
+        notNull: true,
+        defaultValue: 'current_timestamp',
+      },
+      updated_at: {
+        type: 'TIMESTAMP',
+        notNull: true,
+        defaultValue: 'current_timestamp',
+      },
+      _meta_type: { type: 'TEXT', notNull: true },
+      _meta_data: { type: 'JSON', notNull: false },
+      title: { type: 'TEXT', notNull: false, defaultValue: '' },
+      body: { type: 'TEXT', notNull: false, defaultValue: '' },
+    },
+    indexes: [
+      {
+        name: 'issue2372_contents_meta_type_idx',
+        columns: ['_meta_type'],
+      },
+    ],
+    triggers: [],
+    foreignKeys: [],
+    dependencies: [],
+    version: '1.0.0',
+  },
+};
+
+/**
+ * Same-package STI children with no manifest `schema` block. Their columns can
+ * only come from runtime field metadata, which keeps `required`/`default`
+ * under `_meta`.
+ */
+const ARTICLE_MANIFEST = {
+  className: 'Issue2372Article',
+  extends: 'Issue2372Content',
+  fields: {
+    title: { type: 'text', required: true, default: '' },
+    body: { type: 'text', required: false, default: '' },
+    byline: { type: 'text', required: true, default: 'staff' },
+  },
+  methods: {},
+  decoratorConfig: { tableStrategy: 'sti' },
+};
+
+const MIRROR_MANIFEST = {
+  className: 'Issue2372Mirror',
+  extends: 'Issue2372Content',
+  fields: {
+    title: { type: 'text', required: true, default: '' },
+    sourceUrl: { type: 'text', required: true, default: '' },
+  },
+  methods: {},
+  decoratorConfig: { tableStrategy: 'sti' },
+};
+
+type ManifestEntry = typeof BASE_MANIFEST | typeof ARTICLE_MANIFEST;
+
+const PACKAGE_NAME = '@test/issue-2372';
+
+function register(entry: ManifestEntry) {
+  ObjectRegistry.registerFromManifest(
+    entry.className,
+    entry as never,
+    PACKAGE_NAME,
+  );
+}
+
+/**
+ * Register the hierarchy in the given order and return the merged table.
+ */
+function schemaForOrder(order: ManifestEntry[]) {
+  const restore = snapshotObjectRegistryState();
+  try {
+    for (const entry of order) {
+      register(entry);
+    }
+    return {
+      definition:
+        ObjectRegistry.getAllSchemasAsDefinitions().issue2372_contents,
+      bootstrap: ObjectRegistry.getAllSchemas().issue2372_contents,
+    };
+  } finally {
+    restore();
+  }
+}
+
+describe('Issue #2372: merged STI table shape is registration-order independent', () => {
+  let restoreRegistry: () => void;
+
+  beforeEach(() => {
+    restoreRegistry = snapshotObjectRegistryState();
+  });
+
+  afterEach(() => {
+    restoreRegistry();
+  });
+
+  it('produces an identical schema whether the base or the child registers first', () => {
+    const baseFirst = schemaForOrder([BASE_MANIFEST, ARTICLE_MANIFEST]);
+    const childFirst = schemaForOrder([ARTICLE_MANIFEST, BASE_MANIFEST]);
+
+    expect(baseFirst.definition).toBeDefined();
+    expect(childFirst.definition).toEqual(baseFirst.definition);
+
+    // Column order drives the generated DDL, so it has to match too.
+    expect(Object.keys(childFirst.definition?.columns ?? {})).toEqual(
+      Object.keys(baseFirst.definition?.columns ?? {}),
+    );
+    expect(childFirst.definition?.ddl).toBe(baseFirst.definition?.ddl);
+  });
+
+  it('keeps the same shape across every permutation of a multi-child hierarchy', () => {
+    const permutations: ManifestEntry[][] = [
+      [BASE_MANIFEST, ARTICLE_MANIFEST, MIRROR_MANIFEST],
+      [ARTICLE_MANIFEST, BASE_MANIFEST, MIRROR_MANIFEST],
+      [ARTICLE_MANIFEST, MIRROR_MANIFEST, BASE_MANIFEST],
+      [MIRROR_MANIFEST, ARTICLE_MANIFEST, BASE_MANIFEST],
+    ];
+
+    const [expected, ...rest] = permutations.map(schemaForOrder);
+    expect(expected.definition?.columns.byline).toBeDefined();
+    expect(expected.definition?.columns.source_url).toBeDefined();
+
+    for (const actual of rest) {
+      expect(actual.definition).toEqual(expected.definition);
+      expect(actual.bootstrap).toEqual(expected.bootstrap);
+    }
+  });
+
+  it('keeps NOT NULL and DEFAULT on the base columns when a child registers first', () => {
+    const { definition } = schemaForOrder([ARTICLE_MANIFEST, BASE_MANIFEST]);
+    const columns = definition?.columns ?? {};
+
+    expect(columns.context).toMatchObject({
+      type: 'TEXT',
+      notNull: true,
+      defaultValue: '',
+    });
+    expect(columns.created_at).toMatchObject({
+      type: 'TIMESTAMP',
+      notNull: true,
+      defaultValue: 'current_timestamp',
+    });
+    expect(columns.updated_at).toMatchObject({
+      type: 'TIMESTAMP',
+      notNull: true,
+      defaultValue: 'current_timestamp',
+    });
+    expect(columns.slug).toMatchObject({ type: 'TEXT', notNull: true });
+    expect(columns.id).toMatchObject({ primaryKey: true, notNull: true });
+    expect(columns._meta_type).toMatchObject({ type: 'TEXT', notNull: true });
+
+    expect(definition?.ddl).toContain(`"context" TEXT NOT NULL DEFAULT ''`);
+    expect(definition?.ddl).toContain(
+      '"created_at" TIMESTAMP NOT NULL DEFAULT current_timestamp',
+    );
+  });
+
+  it('carries a child field default onto the shared table while keeping the column nullable', () => {
+    const { definition } = schemaForOrder([BASE_MANIFEST, ARTICLE_MANIFEST]);
+    const byline = definition?.columns.byline;
+
+    // The default lives under `_meta` on a registry field; reading only the
+    // top level dropped it.
+    expect(byline?.defaultValue).toBe('staff');
+    // An STI table holds the union of all subtypes' fields, so a column only
+    // one subtype declares must stay nullable even though the field is
+    // `required` on that subtype.
+    expect(byline?.notNull).toBe(false);
+  });
+
+  it('seeds conflict columns and indexes from the STI base regardless of order', () => {
+    const baseFirst = schemaForOrder([BASE_MANIFEST, ARTICLE_MANIFEST]);
+    const childFirst = schemaForOrder([ARTICLE_MANIFEST, BASE_MANIFEST]);
+
+    const names = (schema: typeof baseFirst) =>
+      (schema.definition?.indexes ?? []).map((index) => index.name).sort();
+
+    expect(names(childFirst)).toEqual(names(baseFirst));
+    expect(names(baseFirst)).toContain('issue2372_contents_meta_type_idx');
+  });
+});

--- a/packages/core/src/__tests__/issue-2372-sti-shape-registration-order.test.ts
+++ b/packages/core/src/__tests__/issue-2372-sti-shape-registration-order.test.ts
@@ -103,7 +103,10 @@ const MIRROR_MANIFEST = {
   decoratorConfig: { tableStrategy: 'sti' },
 };
 
-type ManifestEntry = typeof BASE_MANIFEST | typeof ARTICLE_MANIFEST;
+type ManifestEntry =
+  | typeof BASE_MANIFEST
+  | typeof ARTICLE_MANIFEST
+  | typeof MIRROR_MANIFEST;
 
 const PACKAGE_NAME = '@test/issue-2372';
 

--- a/packages/core/src/registry/__tests__/schema-builder-helpers.test.ts
+++ b/packages/core/src/registry/__tests__/schema-builder-helpers.test.ts
@@ -309,4 +309,50 @@ describe('schema-builder: fieldsToColumns', () => {
     );
     expect(columns.status.defaultValue).toBe('active');
   });
+
+  it('reads required/default/description from _meta (issue #2372)', () => {
+    // Registry-sourced fields normalize these into `_meta`; reading only the
+    // top level dropped NOT NULL and DEFAULT for every such field.
+    const columns = fieldsToColumns(
+      fieldMap({
+        status: {
+          type: 'text',
+          _meta: {
+            required: true,
+            default: 'active',
+            description: 'lifecycle state',
+          },
+        },
+      }),
+    );
+    expect(columns.status.notNull).toBe(true);
+    expect(columns.status.defaultValue).toBe('active');
+    expect(columns.status.description).toBe('lifecycle state');
+  });
+
+  it('prefers a top-level value over the _meta copy', () => {
+    const columns = fieldsToColumns(
+      fieldMap({
+        status: {
+          type: 'text',
+          default: 'top',
+          _meta: { default: 'meta' },
+        },
+      }),
+    );
+    expect(columns.status.defaultValue).toBe('top');
+  });
+
+  it('keeps STI union columns nullable while still emitting defaults', () => {
+    // An STI table is the union of every subtype's fields, so a column only
+    // one subtype declares must stay nullable — sibling rows never fill it.
+    const columns = fieldsToColumns(
+      fieldMap({
+        byline: { type: 'text', _meta: { required: true, default: 'staff' } },
+      }),
+      { stiUnionColumns: true },
+    );
+    expect(columns.byline.notNull).toBe(false);
+    expect(columns.byline.defaultValue).toBe('staff');
+  });
 });

--- a/packages/core/src/registry/manifest-field-merge.ts
+++ b/packages/core/src/registry/manifest-field-merge.ts
@@ -36,7 +36,18 @@ function readExistingFieldMeta(
   return undefined;
 }
 
-function readManifestFieldMeta(
+/**
+ * Read a schema-shaping field attribute from either placement.
+ *
+ * `required`, `default`, and `description` are written at the top level by
+ * manifest field definitions but are normalized into `_meta` by
+ * {@link createFieldFromManifest} / {@link mergeManifestField}. Any consumer
+ * that shapes a column from a field must therefore check both placements, or
+ * it silently drops NOT NULL and DEFAULT for every registry-sourced field
+ * (issue #2372). Top level wins so an explicit manifest value overrides the
+ * normalized copy.
+ */
+export function readFieldAttribute(
   fieldDef: ManifestFieldInput,
   key: 'required' | 'default' | 'description',
 ) {
@@ -50,6 +61,8 @@ function readManifestFieldMeta(
 
   return undefined;
 }
+
+const readManifestFieldMeta = readFieldAttribute;
 
 function assignDefinedMeta(
   target: Record<string, unknown>,

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -23,8 +23,10 @@ import {
   type CollectionRegistrationLookup,
   isCollectionRegistration,
 } from './collection-resolution';
+import { readFieldAttribute } from './manifest-field-merge';
 import { findClass } from './name-resolver';
 import { getClasses, getCollectionTableNames } from './shared-state';
+import type { RegisteredClass } from './types';
 
 type ForeignKeyAction = NonNullable<
   NonNullable<ColumnDefinition['foreignKey']>['onDelete']
@@ -73,11 +75,12 @@ function mergeRuntimeFieldColumns(
   className: string,
   schemaColumns: Record<string, ColumnDefinition> | undefined,
   fields: Map<string, FieldDefinition>,
+  options?: FieldsToColumnsOptions,
 ): Record<string, ColumnDefinition> {
   const columnsToUse = { ...(schemaColumns || {}) };
 
   if (fields.size > 0) {
-    const fieldColumns = fieldsToColumns(fields);
+    const fieldColumns = fieldsToColumns(fields, options);
     for (const [columnName, columnDef] of Object.entries(fieldColumns)) {
       if (!columnsToUse[columnName]) {
         columnsToUse[columnName] = columnDef;
@@ -134,28 +137,63 @@ function getReferenceKind(
   return undefined;
 }
 
-function shouldEmitDefault(fieldDef: FieldDefinition, sqlType: SQLDataType) {
+function shouldEmitDefault(
+  fieldDef: FieldDefinition,
+  sqlType: SQLDataType,
+  defaultValue: unknown,
+) {
   return !(
     getReferenceKind(fieldDef) === 'tenantId' &&
     sqlType === 'UUID' &&
-    fieldDef.default === ''
+    defaultValue === ''
   );
 }
 
-function createBaseColumns(registered: {
-  config?: { idType?: 'uuid' | 'text' };
-}): Record<string, ColumnDefinition> {
-  return {
+/**
+ * Fallback base columns for a table whose contributing class carries no
+ * manifest columns.
+ *
+ * These mirror what the manifest schema generators emit for the same table
+ * (`generateSchemaFromManifest` / `generateSTISchemaFromManifest`), so a table
+ * assembled from runtime field metadata alone has the same NOT NULL and
+ * DEFAULT shape as one assembled from a manifest. Divergence here is what made
+ * the merged table shape depend on which class registered first (#2372).
+ */
+function createBaseColumns(
+  registered: {
+    config?: { idType?: 'uuid' | 'text' };
+  },
+  isSTI: boolean,
+): Record<string, ColumnDefinition> {
+  const baseColumns: Record<string, ColumnDefinition> = {
     id: {
       type: registered.config?.idType === 'text' ? 'TEXT' : 'UUID',
       primaryKey: true,
+      notNull: true,
       referenceKind: 'id',
     },
     slug: { type: 'TEXT', notNull: true },
-    context: { type: 'TEXT' },
-    created_at: { type: 'TIMESTAMP' },
-    updated_at: { type: 'TIMESTAMP' },
+    context: { type: 'TEXT', notNull: true, defaultValue: '' },
+    created_at: {
+      type: 'TIMESTAMP',
+      notNull: true,
+      defaultValue: 'current_timestamp',
+    },
+    updated_at: {
+      type: 'TIMESTAMP',
+      notNull: true,
+      defaultValue: 'current_timestamp',
+    },
   };
+
+  // STI tables also carry the discriminator and the meta payload column
+  // (issue #690: db:diff needs them to detect schema changes).
+  if (isSTI) {
+    baseColumns._meta_type = { type: 'TEXT', notNull: true };
+    baseColumns._meta_data = { type: 'JSON', notNull: false };
+  }
+
+  return baseColumns;
 }
 
 /**
@@ -280,6 +318,251 @@ function withConflictIndex(
 }
 
 /**
+ * A registered class that contributes columns to one physical table.
+ *
+ * For a single-table-inheritance hierarchy every class in the hierarchy is a
+ * contributor to the same table.
+ */
+interface TableContributor {
+  registered: RegisteredClass;
+  simpleName: string;
+  qualifiedName: string;
+  isSTI: boolean;
+  /** True when this class is the STI base that owns the table. */
+  isSTIBase: boolean;
+  /** Inheritance depth; ancestors sort before descendants. */
+  depth: number;
+  /** Conflict-column lookup key (the STI base for STI members). */
+  conflictKey: string;
+}
+
+/**
+ * A merged physical table assembled from every class that contributes to it.
+ */
+interface MergedTableSchema {
+  tableName: string;
+  columns: Record<string, ColumnDefinition>;
+  indexes: IndexDefinition[];
+  ddl: string;
+  isSTI: boolean;
+  conflictColumns: string[];
+}
+
+/**
+ * Resolve the physical table a registered class writes to.
+ *
+ * STI subclasses are folded onto their base's table. Returns `undefined` when
+ * the class has no table (for example an unresolvable manifest stub).
+ *
+ * R5-canon: STI lookups use the qualified key so a colliding simple name in
+ * another package cannot yield the wrong table strategy or STI base and move
+ * this class's columns under that other package's table.
+ */
+function resolveContributorTable(
+  registered: RegisteredClass,
+  fallbackName: string,
+): { tableName: string; contributor: TableContributor } | undefined {
+  const simpleName = registered.name || fallbackName;
+  const qualifiedName = registered.qualifiedName ?? simpleName;
+
+  // STI subclasses loaded from external manifests can arrive with a null
+  // tableName; registerFromManifest() then derives one from the class name.
+  // Adopt the STI base's tableName instead so the subclass lands on the
+  // shared table (issue #703).
+  if (!registered.schema?.tableName && registered.extends) {
+    if (ObjectRegistry.getTableStrategy(qualifiedName) === 'sti') {
+      const stiBaseName = ObjectRegistry.getSTIBase(qualifiedName);
+      if (stiBaseName && stiBaseName !== qualifiedName) {
+        const stiBaseClass = findClass(stiBaseName);
+        if (stiBaseClass?.schema?.tableName) {
+          if (!registered.schema) {
+            registered.schema = {
+              tableName: '',
+              ddl: '',
+              columns: {},
+              indexes: [],
+              triggers: [],
+              foreignKeys: [],
+              dependencies: [],
+              version: '',
+            };
+          }
+          registered.schema.tableName = stiBaseClass.schema.tableName;
+        }
+      }
+    }
+  }
+
+  if (!registered.schema?.tableName) {
+    return undefined;
+  }
+
+  let tableName = registered.schema.tableName;
+  const tableStrategy = ObjectRegistry.getTableStrategy(qualifiedName);
+  const isSTI = tableStrategy === 'sti';
+  let isSTIBase = isSTI;
+  let conflictKey = qualifiedName;
+
+  if (isSTI) {
+    const stiBaseName = ObjectRegistry.getSTIBase(qualifiedName);
+    if (stiBaseName) {
+      conflictKey = stiBaseName;
+      if (stiBaseName !== qualifiedName) {
+        isSTIBase = false;
+        // STI subclasses serialize to the base class's table even when they
+        // carry a tableName of their own (issue #693).
+        const stiBaseClass = findClass(stiBaseName);
+        if (stiBaseClass?.schema?.tableName) {
+          tableName = stiBaseClass.schema.tableName;
+        }
+      }
+    }
+  }
+
+  return {
+    tableName,
+    contributor: {
+      registered,
+      simpleName,
+      qualifiedName,
+      isSTI,
+      isSTIBase,
+      depth: ObjectRegistry.getInheritanceChain(qualifiedName).length,
+      conflictKey,
+    },
+  };
+}
+
+/**
+ * Order the classes that share one table deterministically.
+ *
+ * The first contributor seeds the table: it supplies the base columns, the
+ * `idType`, the conflict columns and the cached DDL, and its columns win every
+ * merge conflict. Registration order must not decide that, or the same
+ * hierarchy yields a different table shape depending on which class a manifest
+ * happens to list first — child-first dropped NOT NULL and DEFAULT from the
+ * base columns (#2372).
+ *
+ * Order: the STI base first, then ancestors before descendants, then by
+ * qualified name so the result is a total order.
+ */
+function sortTableContributors(contributors: TableContributor[]) {
+  return [...contributors].sort((a, b) => {
+    if (a.isSTIBase !== b.isSTIBase) {
+      return a.isSTIBase ? -1 : 1;
+    }
+    if (a.depth !== b.depth) {
+      return a.depth - b.depth;
+    }
+    return a.qualifiedName.localeCompare(b.qualifiedName);
+  });
+}
+
+/**
+ * Assemble every physical table from the classes that contribute to it.
+ *
+ * Shared by {@link getAllSchemas} and {@link getAllSchemasAsDefinitions} so
+ * both produce the same merged shape. The result depends only on what is
+ * registered, never on the order it was registered in.
+ */
+function buildMergedTableSchemas(): Record<string, MergedTableSchema> {
+  // Pass 1: group contributing classes by physical table.
+  const contributorsByTable = new Map<string, TableContributor[]>();
+
+  for (const [className, registered] of getClasses()) {
+    // Collection classes have no table of their own; their schemas carry
+    // collection properties (loaded, options, ...) rather than columns.
+    if (
+      isCollectionRegistration(
+        className,
+        registered,
+        collectionRegistrationLookup,
+      )
+    ) {
+      continue;
+    }
+
+    const resolved = resolveContributorTable(registered, className);
+    if (!resolved) {
+      continue;
+    }
+
+    const existing = contributorsByTable.get(resolved.tableName);
+    if (existing) {
+      existing.push(resolved.contributor);
+    } else {
+      contributorsByTable.set(resolved.tableName, [resolved.contributor]);
+    }
+  }
+
+  // Pass 2: merge each table's contributors in deterministic order.
+  const tableSchemas: Record<string, MergedTableSchema> = {};
+
+  for (const [tableName, contributors] of contributorsByTable) {
+    for (const contributor of sortTableContributors(contributors)) {
+      const { registered, simpleName, isSTI } = contributor;
+
+      // The manifest schema stays authoritative for the columns it defines.
+      // Runtime field metadata backfills columns the manifest never had (for
+      // example tenantScoped injections) and applies explicit sqlType
+      // overrides, without erasing richer manifest metadata.
+      const columnsToUse = mergeRuntimeFieldColumns(
+        simpleName,
+        registered.schema?.columns,
+        registered.fields,
+        { stiUnionColumns: isSTI },
+      );
+
+      let tableSchema = tableSchemas[tableName];
+      if (!tableSchema) {
+        tableSchema = {
+          tableName,
+          columns: {
+            ...createBaseColumns(registered, isSTI),
+            ...columnsToUse,
+          },
+          indexes: [],
+          ddl: registered.schema?.ddl || '',
+          isSTI,
+          conflictColumns: ObjectRegistry.getConflictColumns(
+            contributor.conflictKey,
+          ),
+        };
+        tableSchemas[tableName] = tableSchema;
+      } else {
+        // Another class sharing this table (STI): add only columns the
+        // seeding contributor did not already define.
+        for (const [colName, colDef] of Object.entries(columnsToUse)) {
+          if (!tableSchema.columns[colName]) {
+            tableSchema.columns[colName] = colDef;
+          }
+        }
+      }
+
+      // Merge indexes, keeping the first definition of each name.
+      const schemaIndexes = registered.schema?.indexes;
+      if (schemaIndexes && schemaIndexes.length > 0) {
+        const existingNames = new Set(
+          tableSchema.indexes.map((index) => index.name),
+        );
+        for (const index of schemaIndexes) {
+          // Legacy string-format indexes carry no columns and cannot be merged.
+          if (typeof index === 'string') {
+            continue;
+          }
+          if (!existingNames.has(index.name)) {
+            tableSchema.indexes.push(index);
+            existingNames.add(index.name);
+          }
+        }
+      }
+    }
+  }
+
+  return tableSchemas;
+}
+
+/**
  * Get all pre-generated schemas for explicit adapter bootstrap paths.
  *
  * Returns schemas in SDK SchemaProvider format for all registered classes.
@@ -297,165 +580,9 @@ function withConflictIndex(
 export function getAllSchemas(
   engine?: DatabaseEngine,
 ): Record<string, { tableName: string; ddl: string; indexes?: string[] }> {
-  // Step 1: Collect all schemas grouped by tableName
-  // For STI, multiple classes may share the same table
-  const tableSchemas: Record<
-    string,
-    {
-      tableName: string;
-      columns: Record<string, ColumnDefinition>;
-      indexes: IndexDefinition[];
-      ddl: string;
-      isSTI: boolean;
-      conflictColumns: string[];
-    }
-  > = {};
-
-  for (const [_className, registered] of getClasses()) {
-    // Skip collection classes - they don't have their own tables
-    // Their schemas incorrectly contain collection properties (loaded, options, etc.)
-    if (
-      isCollectionRegistration(
-        _className,
-        registered,
-        collectionRegistrationLookup,
-      )
-    ) {
-      continue;
-    }
-
-    // Issue #951: Use simple name for STI comparisons (map key may be qualified)
-    const simpleName = registered.name || _className;
-
-    // Issue #703: Handle STI subclasses with null tableName from external manifests
-    // When loaded from external manifests, tableName may be null, causing
-    // registerFromManifest() to derive a tableName from class name.
-    // For STI subclasses, we need to use the STI base's tableName instead.
-    if (!registered.schema?.tableName && registered.extends) {
-      // R5-canon: use the qualified key for STI lookups so colliding
-      // simple names don't resolve to the wrong package's class.
-      // `getTableStrategy` / `getSTIBase` both accept qualified names
-      // via `findClass`'s multi-strategy lookup.
-      const qualifiedName = registered.qualifiedName ?? simpleName;
-      const lookupKey = qualifiedName;
-      const tableStrategy = ObjectRegistry.getTableStrategy(lookupKey);
-      if (tableStrategy === 'sti') {
-        const stiBaseName = ObjectRegistry.getSTIBase(lookupKey);
-        if (stiBaseName && stiBaseName !== qualifiedName) {
-          const stiBaseClass = findClass(stiBaseName);
-          if (stiBaseClass?.schema?.tableName) {
-            // Ensure we have a schema object to modify
-            if (!registered.schema) {
-              registered.schema = {
-                tableName: '',
-                ddl: '',
-                columns: {},
-                indexes: [],
-                triggers: [],
-                foreignKeys: [],
-                dependencies: [],
-                version: '',
-              };
-            }
-            // Set tableName from STI base so the following block processes this class
-            registered.schema.tableName = stiBaseClass.schema.tableName;
-          }
-        }
-      }
-    }
-
-    if (registered.schema?.tableName) {
-      // For STI subclasses, use the STI base class's tableName
-      // This ensures all STI subclass columns are merged into the parent table
-      // (Issue #693: STI subclasses with separate tableName still serialize to parent table)
-      let tableName = registered.schema.tableName;
-      // R5-canon: same qualified-key strategy as the block above.
-      const qualifiedName = registered.qualifiedName ?? simpleName;
-      const lookupKey = qualifiedName;
-      const tableStrategy = ObjectRegistry.getTableStrategy(lookupKey);
-      if (tableStrategy === 'sti') {
-        const stiBaseName = ObjectRegistry.getSTIBase(lookupKey);
-        if (stiBaseName && stiBaseName !== qualifiedName) {
-          // This is an STI subclass - use the base class's tableName
-          const stiBaseClass = findClass(stiBaseName);
-          if (stiBaseClass?.schema?.tableName) {
-            tableName = stiBaseClass.schema.tableName;
-          }
-        }
-      }
-
-      // Start with manifest columns, then backfill any columns that only exist
-      // in runtime field metadata (for example tenantScoped injections). We do
-      // not replace existing manifest column metadata here, because the manifest
-      // is authoritative for foreign keys, defaults, and other schema details.
-      // Explicit decorator sqlType overrides are patched onto the merged column.
-      const columnsToUse = mergeRuntimeFieldColumns(
-        simpleName,
-        registered.schema.columns,
-        registered.fields,
-      );
-
-      if (!tableSchemas[tableName]) {
-        // First class for this table - initialize with base columns
-        // These are required for all tables but are skipped by fieldsToColumns()
-        const baseColumns = createBaseColumns(registered);
-
-        // For STI tables, add discriminator and data columns
-        // (Issue #690: db:diff needs these columns to detect schema changes)
-        const isSTI = tableStrategy === 'sti';
-        if (isSTI) {
-          baseColumns._meta_type = {
-            type: 'TEXT',
-            notNull: true,
-            defaultValue: '',
-          };
-          baseColumns._meta_data = { type: 'JSON' };
-        }
-
-        tableSchemas[tableName] = {
-          tableName,
-          columns: { ...baseColumns, ...columnsToUse },
-          indexes: [],
-          ddl: registered.schema.ddl || '',
-          isSTI,
-          conflictColumns: ObjectRegistry.getConflictColumns(
-            isSTI
-              ? ObjectRegistry.getSTIBase(lookupKey) || lookupKey
-              : lookupKey,
-          ),
-        };
-      } else {
-        // Additional class sharing this table (STI scenario)
-        // Merge columns from this class into the existing schema
-        for (const [colName, colDef] of Object.entries(columnsToUse)) {
-          if (!tableSchemas[tableName].columns[colName]) {
-            // New column from this subtype - add it
-            tableSchemas[tableName].columns[colName] = colDef;
-          }
-        }
-      }
-
-      // Merge indexes (avoid duplicates by name)
-      if (registered.schema.indexes && registered.schema.indexes.length > 0) {
-        const existingNames = new Set(
-          tableSchemas[tableName].indexes.map((idx) =>
-            typeof idx === 'string' ? idx : idx.name,
-          ),
-        );
-        for (const idx of registered.schema.indexes) {
-          const indexName = typeof idx === 'string' ? idx : idx.name;
-          if (!existingNames.has(indexName)) {
-            if (typeof idx === 'string') {
-              // Legacy string format - skip, can't merge properly
-            } else {
-              tableSchemas[tableName].indexes.push(idx);
-              existingNames.add(idx.name);
-            }
-          }
-        }
-      }
-    }
-  }
+  // Step 1: Assemble every table from its contributing classes. The merge is
+  // deterministic, so the shape does not depend on registration order (#2372).
+  const tableSchemas = buildMergedTableSchemas();
 
   // Step 2: Convert to output format, regenerating DDL for merged schemas
   const schemas: Record<
@@ -549,142 +676,9 @@ export function getAllSchemas(
  * @returns Map of tableName to SchemaDefinition
  */
 export function getAllSchemasAsDefinitions(): Record<string, SchemaDefinition> {
-  // Step 1: Collect all schemas grouped by tableName
-  // For STI, multiple classes may share the same table
-  const tableSchemas: Record<
-    string,
-    {
-      tableName: string;
-      columns: Record<string, ColumnDefinition>;
-      indexes: IndexDefinition[];
-      isSTI: boolean;
-      conflictColumns: string[];
-    }
-  > = {};
-
-  for (const [_className, registered] of getClasses()) {
-    // Skip collection classes - they don't have their own tables
-    if (
-      isCollectionRegistration(
-        _className,
-        registered,
-        collectionRegistrationLookup,
-      )
-    ) {
-      continue;
-    }
-
-    // Issue #951: Use simple name for STI comparisons (map key may be qualified)
-    const simpleName = registered.name || _className;
-
-    // Handle STI subclasses with null tableName from external manifests
-    if (!registered.schema?.tableName && registered.extends) {
-      // R5-canon: use the qualified key for STI lookups so colliding
-      // simple names don't resolve to the wrong package's class.
-      // `getTableStrategy` / `getSTIBase` both accept qualified names
-      // via `findClass`'s multi-strategy lookup.
-      const qualifiedName = registered.qualifiedName ?? simpleName;
-      const lookupKey = qualifiedName;
-      const tableStrategy = ObjectRegistry.getTableStrategy(lookupKey);
-      if (tableStrategy === 'sti') {
-        const stiBaseName = ObjectRegistry.getSTIBase(lookupKey);
-        if (stiBaseName && stiBaseName !== qualifiedName) {
-          const stiBaseClass = findClass(stiBaseName);
-          if (stiBaseClass?.schema?.tableName) {
-            if (!registered.schema) {
-              registered.schema = {
-                tableName: '',
-                ddl: '',
-                columns: {},
-                indexes: [],
-                triggers: [],
-                foreignKeys: [],
-                dependencies: [],
-                version: '',
-              };
-            }
-            registered.schema.tableName = stiBaseClass.schema.tableName;
-          }
-        }
-      }
-    }
-
-    if (registered.schema?.tableName) {
-      // For STI subclasses, use the STI base class's tableName.
-      // R5-canon: qualified-key lookup so a colliding simple name in
-      // another package can't yield the wrong tableStrategy / STI base
-      // and move this class's columns under that other package's table.
-      let tableName = registered.schema.tableName;
-      const qualifiedName = registered.qualifiedName ?? simpleName;
-      const lookupKey = qualifiedName;
-      const tableStrategy = ObjectRegistry.getTableStrategy(lookupKey);
-      if (tableStrategy === 'sti') {
-        const stiBaseName = ObjectRegistry.getSTIBase(lookupKey);
-        if (stiBaseName && stiBaseName !== qualifiedName) {
-          const stiBaseClass = findClass(stiBaseName);
-          if (stiBaseClass?.schema?.tableName) {
-            tableName = stiBaseClass.schema.tableName;
-          }
-        }
-      }
-
-      // Manifest schema remains authoritative for existing columns. Runtime
-      // field metadata can backfill missing columns and apply explicit sqlType
-      // overrides without erasing richer manifest metadata.
-      const columnsToUse = mergeRuntimeFieldColumns(
-        simpleName,
-        registered.schema.columns,
-        registered.fields,
-      );
-
-      if (!tableSchemas[tableName]) {
-        // First class for this table - initialize with base columns
-        const baseColumns = createBaseColumns(registered);
-
-        const isSTI = tableStrategy === 'sti';
-        if (isSTI) {
-          baseColumns._meta_type = {
-            type: 'TEXT',
-            notNull: true,
-            defaultValue: '',
-          };
-          baseColumns._meta_data = { type: 'JSON' };
-        }
-
-        tableSchemas[tableName] = {
-          tableName,
-          columns: { ...baseColumns, ...columnsToUse },
-          indexes: [],
-          isSTI,
-          conflictColumns: ObjectRegistry.getConflictColumns(
-            isSTI
-              ? ObjectRegistry.getSTIBase(lookupKey) || lookupKey
-              : lookupKey,
-          ),
-        };
-      } else {
-        // Additional class sharing this table (STI scenario) - merge columns
-        for (const [colName, colDef] of Object.entries(columnsToUse)) {
-          if (!tableSchemas[tableName].columns[colName]) {
-            tableSchemas[tableName].columns[colName] = colDef;
-          }
-        }
-      }
-
-      // Merge indexes (avoid duplicates by name)
-      if (registered.schema.indexes && registered.schema.indexes.length > 0) {
-        const existingNames = new Set(
-          tableSchemas[tableName].indexes.map((idx) => idx.name),
-        );
-        for (const idx of registered.schema.indexes) {
-          if (!existingNames.has(idx.name)) {
-            tableSchemas[tableName].indexes.push(idx);
-            existingNames.add(idx.name);
-          }
-        }
-      }
-    }
-  }
+  // Step 1: Assemble every table from its contributing classes. The merge is
+  // deterministic, so the shape does not depend on registration order (#2372).
+  const tableSchemas = buildMergedTableSchemas();
 
   // Step 2: Convert to SchemaDefinition format
   const schemas: Record<string, SchemaDefinition> = {};
@@ -812,17 +806,40 @@ export function formatDefaultValue(value: unknown, type: string): string {
 }
 
 /**
+ * Options for {@link fieldsToColumns}.
+ */
+export interface FieldsToColumnsOptions {
+  /**
+   * Shape the columns for a single-table-inheritance table.
+   *
+   * An STI table holds the union of every subtype's fields, so a column that
+   * only one subtype declares must stay nullable — rows of sibling subtypes
+   * never populate it. This matches `generateSTISchemaFromManifest`, which
+   * emits `notNull: false` for every non-system column on an STI table.
+   * Declared defaults are still emitted.
+   */
+  stiUnionColumns?: boolean;
+}
+
+/**
  * Convert a Map of field definitions to column definitions
  *
  * Used by getAllSchemas() to generate columns from fields when a class
  * has no pre-generated schema (e.g., STI subclasses registered from manifest).
  *
+ * `required`, `default`, and `description` are read from either the top level
+ * or `_meta`: registry-sourced fields normalize them into `_meta`, so reading
+ * only the top level dropped NOT NULL and DEFAULT for every such field
+ * (#2372).
+ *
  * @param fields - Map of field name to field definition
+ * @param options - Table-shape options (see {@link FieldsToColumnsOptions})
  * @returns Record of column name to column definition
  * @private
  */
 export function fieldsToColumns(
   fields: Map<string, FieldDefinition>,
+  options?: FieldsToColumnsOptions,
 ): Record<string, ColumnDefinition> {
   const columns: Record<string, ColumnDefinition> = {};
 
@@ -865,20 +882,28 @@ export function fieldsToColumns(
     const normalizedSqlType = String(sqlType).toUpperCase() as SQLDataType;
     const referenceKind = getReferenceKind(fieldDef);
 
+    const required = readFieldAttribute(fieldDef, 'required');
+    const defaultValue = readFieldAttribute(fieldDef, 'default');
+    const description = readFieldAttribute(fieldDef, 'description');
+
     const column: ColumnDefinition = {
       type: normalizedSqlType,
       referenceKind,
-      notNull: fieldDef._meta?.nullable ? false : fieldDef.required || false,
+      notNull: options?.stiUnionColumns
+        ? false
+        : fieldDef._meta?.nullable
+          ? false
+          : Boolean(required),
       unique: fieldDef._meta?.unique || false,
-      description: fieldDef.description,
+      description: description as string | undefined,
     };
 
     // Handle default values
     if (
-      fieldDef.default !== undefined &&
-      shouldEmitDefault(fieldDef, normalizedSqlType)
+      defaultValue !== undefined &&
+      shouldEmitDefault(fieldDef, normalizedSqlType, defaultValue)
     ) {
-      column.defaultValue = fieldDef.default;
+      column.defaultValue = defaultValue;
     }
 
     // Handle foreign keys


### PR DESCRIPTION
Closes #2372

Part of epic #2382 (finding A6). Independent; `packages/core/src/registry/schema-builder.ts` only. #2360 (PR #2404) touches the same file lightly and rebases on this.

## Problem

`getAllSchemas()` and `getAllSchemasAsDefinitions()` fold every class that shares one physical table — a whole STI hierarchy — into one merged shape. The merge was **first-wins over `getClasses()` Map insertion order**: whichever class registered first for a table seeded the fallback base columns, the `idType`, the conflict columns and the cached DDL, and won every column conflict.

The fallback base columns (`createBaseColumns()`) were weaker than what the manifest generators emit for the same table — `context TEXT` where `generateSTISchemaFromManifest` emits `context TEXT NOT NULL DEFAULT ''`, `created_at`/`updated_at TIMESTAMP` with no NOT NULL/DEFAULT, `id` without NOT NULL, `_meta_type` carrying a `DEFAULT ''` the generator does not emit. So an STI child that carries no manifest `schema` block — the external- and consumer-manifest case, which `registerFromManifest()` explicitly handles by synthesizing an empty schema — seeded the table from the weak fallback, and the base class's richer columns were then skipped, because the merge only adds columns that are not already present.

Independently, `fieldsToColumns()` read top-level `required`/`default`/`description`, but registry-sourced fields normalize those into `_meta` (`manifest-field-merge.ts`). Every column derived from runtime field metadata therefore lost its NOT NULL and DEFAULT regardless of order.

The differ compares column *types* only (#2369/#2370), so a weak fresh-create was never repaired.

The order that loses is the one that ships: in `packages/content/src/manifest/manifest.json`, `Article` is entry 26 and `Content` is entry 31.

## Change

Both entry points now route through one shared `buildMergedTableSchemas()` in `registry/schema-builder.ts`, replacing two near-identical inlined loops:

- **Pass 1** groups contributing classes by physical table (`resolveContributorTable()`, which preserves the existing #703 null-tableName backfill and the #693 STI-child table redirect, both on the R5-canon qualified key).
- **Pass 2** merges each table's contributors in a **deterministic total order** (`sortTableContributors()`): the STI base first, then inheritance depth ascending, then qualified name. The seeding contributor — not "whoever registered first" — supplies the base columns, `idType`, conflict columns and DDL.

Two supporting fixes keep the assembly paths agreeing, per the assessment's rule 1 (verify against the production path):

- `createBaseColumns(registered, isSTI)` now mirrors `generateSchemaFromManifest` / `generateSTISchemaFromManifest` (`schema/generator.ts:1343-1384`): `id` NOT NULL, `context TEXT NOT NULL DEFAULT ''`, timestamps `NOT NULL DEFAULT current_timestamp`, `_meta_type TEXT NOT NULL` (no default), `_meta_data JSON` `notNull: false`. A table assembled from runtime field metadata alone now has the same shape as one assembled from a manifest.
- `fieldsToColumns()` reads `required`/`default`/`description` from the top level **or** `_meta`, via a new exported `readFieldAttribute()` in `manifest-field-merge.ts` (top level wins, so an explicit manifest value still overrides the normalized copy).

**STI columns stay nullable.** `fieldsToColumns(fields, { stiUnionColumns: true })` forces `notNull: false` on an STI table even when the field is `required`, matching `generator.ts:1456-1457` ("STI: All columns nullable (union of child fields)") — a column only one subtype declares is never populated on a sibling's row, so honouring `required` there would have broken inserts for every other subtype. Declared defaults are still emitted. Non-STI tables do honour `required`, which is what the manifest path does for them.

### Fresh-create DDL change (release note)

This is in the schema release wave and changes fresh-create DDL for tables that previously fell back to the weak base columns:

- `context` gains `NOT NULL DEFAULT ''`; `created_at`/`updated_at` gain `NOT NULL DEFAULT current_timestamp`; `id` gains `NOT NULL`. All match what the manifest path already emitted for the same table, so this narrows a divergence rather than introducing one.
- `_meta_type` **loses** its `DEFAULT ''` on the fallback path, again matching the generator. The model layer always writes the discriminator on insert, and the differ ignores default drift, so existing tables are unaffected.

No migration is required: the differ compares types only, so it emits nothing for these, and every affected shape was already the manifest path's output on the winning order.

## Validation

Re-run in full on the current head after merging main through #2407 (which also appended to `schema-paths.md`; its §15 stays, this note is now §16).

- `@happyvertical/smrt-core`: `pnpm test` green — **280 files / 3584 tests** (10 files / 62 tests skipped, the PostgreSQL `optional` lanes); `pnpm typecheck` clean; `biome check` clean on all touched files; `pnpm smrt dev:knowledge-check` ✓ 0 errors 0 warnings after rebuilding core; `pnpm check:agents-chain` ✓ (core AGENTS.md untouched — the note went to `packages/core/agents/schema-paths.md` §16).
- `@happyvertical/smrt-cli` (the `db:migrate` / `db:diff` / `db:parity` consumer of these paths): **867 tests** green.
- **Regression** `packages/core/src/__tests__/issue-2372-sti-shape-registration-order.test.ts` (5 tests) registers the same hierarchy base-first, child-first, and in four permutations of a multi-child hierarchy, asserting one identical `SchemaDefinition` — including column key order, since that drives the generated DDL — plus the specific NOT NULL/DEFAULT and STI-nullability properties. **4 of the 5 fail on the untouched base**; the fifth is the index-merge assertion, which was already order-stable here.
- **Unit** `registry/__tests__/schema-builder-helpers.test.ts` +4 tests for the `_meta` read, top-level precedence, and the STI union-nullability rule.
- **Empirical check against the real shipped manifest** (scratch, not committed): registering all 35 objects of `packages/content/src/manifest/manifest.json` in shipped order vs fully reversed order produced **byte-identical** merged schemas for every table on this branch, and a **differing `contents` table on the untouched base**. `contents` comes out with all 35 columns and the canonical strong base columns either way.
- Review cycle: independent Claude subagent review (codex is out of quota until Aug 19) plus CI and the GitHub auto-reviewers. The reviewer independently re-derived `resolveContributorTable()` against the original inlined blocks, confirmed `sortTableContributors()` is a true total order (a `localeCompare` tie is only reachable for the same `RegisteredClass` object under the documented dual-key registry state, where the merge is idempotent), confirmed `isSTIBase` resolves correctly for a 3-level hierarchy, confirmed `stiUnionColumns` never weakens CTI tables or manifest-authoritative columns, cross-checked the new `createBaseColumns()` shape against `generateCTISchemaFromManifest` as well, and confirmed `getInheritanceChain()` is cached. **No defects found.** Its one below-threshold note — the test's `ManifestEntry` union omitted the second STI child fixture — is fixed in `13e88faa5`.
- Environment note: `smrt-vitest`, `smrt-agents` and the `smrt-playground-host` build hit the known agent-worktree startup artifact (`Tsconfig not found` from vite:oxc/rolldown; the playground build resolves a path into the shared checkout). Both reproduce on the untouched tree in this worktree — CI gates them.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","policy_revision":"1.0.0","runtime":"claude","session":"2e828b4a-bf86-463b-8159-3ee4e9f1275f","issue":"https://github.com/happyvertical/smrt/issues/2372"}
```

