### PR TITLE
fix(core,tenancy): close tenant-isolation gaps on read paths

### DIFF
--- a/packages/core/src/__tests__/issue-2365-read-interceptor-plumbing.test.ts
+++ b/packages/core/src/__tests__/issue-2365-read-interceptor-plumbing.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Core-side plumbing for the #2365 tenancy read gaps.
+ *
+ * The real tenant interceptor lives in @happyvertical/smrt-tenancy (which
+ * depends on core), so core proves the SEAMS it exposes, with a plain
+ * registered interceptor and the core-side tenant hooks — the same inversion
+ * pattern the #1782 REST read-scope spec uses:
+ *
+ * 1. `resolveGetStringFilter()` — the single source of truth for
+ *    `collection.get()`'s string-filter semantics that `beforeGet`
+ *    interceptors must reuse (a slug string resolves to the natural key, not
+ *    to `{ id }`).
+ * 2. `loadFromId()` / `loadFromSlug()` / `getSavedId()` run their filters
+ *    through the `beforeGet` interceptor pipeline, converting interceptor
+ *    field-name keys (camelCase) to column form.
+ * 3. Collection memory (`remember()`/`recall()`) keys its `_smrt_contexts`
+ *    owner id per tenant via the dispatch tenant hooks when the item class is
+ *    tenant-scoped.
+ *
+ * Real in-memory SQLite; no mocking.
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection';
+import { field } from '../decorators/index';
+import {
+  setDispatchTenantResolver,
+  setTenantScopedClassResolver,
+} from '../dispatch/tenant-resolver';
+import {
+  type CollectionInterceptor,
+  createInterceptorContext,
+  GlobalInterceptors,
+  resolveGetStringFilter,
+} from '../interceptors';
+import { SmrtObject } from '../object';
+import { ObjectRegistry, smrt } from '../registry';
+import { getTestDatabase } from '../testing/database';
+
+const ROW_ALPHA_ID = 'aaaa2365-aaaa-4aaa-8aaa-aaaaaaaaaa01';
+const ROW_BETA_ID = 'bbbb2365-bbbb-4bbb-8bbb-bbbbbbbbbb02';
+
+@smrt()
+class ReadPlumbingDoc extends SmrtObject {
+  @field({ type: 'text' })
+  title = '';
+
+  // Two-word field name so the camelCase -> snake_case conversion of
+  // interceptor-injected keys is actually exercised (column: group_key).
+  @field({ type: 'text' })
+  groupKey = '';
+
+  // biome linting allows `any` in test files; this mirrors the loose options
+  // bag SmrtObject accepts.
+  constructor(options: any = {}) {
+    super(options);
+    if (options.title !== undefined) this.title = options.title;
+    if (options.groupKey !== undefined) this.groupKey = options.groupKey;
+  }
+}
+
+class ReadPlumbingDocCollection extends SmrtCollection<ReadPlumbingDoc> {
+  static readonly _itemClass = ReadPlumbingDoc;
+}
+
+describe('resolveGetStringFilter (#2365)', () => {
+  it('resolves a UUID string to an id lookup', () => {
+    expect(
+      resolveGetStringFilter('550e8400-e29b-41d4-a716-446655440000'),
+    ).toEqual({ id: '550e8400-e29b-41d4-a716-446655440000' });
+    // Case-insensitive, like the get() detection it replaced.
+    expect(
+      resolveGetStringFilter('550E8400-E29B-41D4-A716-446655440000'),
+    ).toEqual({ id: '550E8400-E29B-41D4-A716-446655440000' });
+  });
+
+  it('resolves a non-UUID string to the slug natural key', () => {
+    expect(resolveGetStringFilter('my-widget')).toEqual({
+      slug: 'my-widget',
+      context: '',
+    });
+    // Near-UUID strings that do not match the shape stay slugs.
+    expect(resolveGetStringFilter('550e8400-e29b-41d4-a716')).toEqual({
+      slug: '550e8400-e29b-41d4-a716',
+      context: '',
+    });
+  });
+});
+
+describe('read-path interceptor plumbing (#2365)', () => {
+  let docs: ReadPlumbingDocCollection;
+  // Shared handle for constructing fixture objects directly.
+  let db: any;
+
+  // A minimal read-scoping interceptor: restricts every get-shaped read to
+  // groupKey 'alpha' (injected in FIELD-name form, exactly like the tenancy
+  // interceptor injects `tenantId`).
+  const groupInterceptor: CollectionInterceptor = {
+    name: 'issue-2365-group-scope',
+    priority: 50,
+    beforeGet(className, filter) {
+      if (className !== 'ReadPlumbingDoc') return;
+      if (typeof filter === 'string') {
+        return { ...resolveGetStringFilter(filter), groupKey: 'alpha' };
+      }
+      if (!('groupKey' in filter)) {
+        return { ...filter, groupKey: 'alpha' };
+      }
+      return;
+    },
+  };
+
+  beforeAll(async () => {
+    ObjectRegistry.registerCollection(
+      'ReadPlumbingDoc',
+      ReadPlumbingDocCollection,
+    );
+    db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['ReadPlumbingDoc'],
+    });
+    docs = await ReadPlumbingDocCollection.create({ db });
+
+    await docs.create({
+      id: ROW_ALPHA_ID,
+      slug: 'alpha-doc',
+      title: 'alpha row',
+      groupKey: 'alpha',
+    });
+    await docs.create({
+      id: ROW_BETA_ID,
+      slug: 'beta-doc',
+      title: 'beta row',
+      groupKey: 'beta',
+    });
+
+    GlobalInterceptors.register(groupInterceptor);
+  });
+
+  afterAll(async () => {
+    GlobalInterceptors.unregister(groupInterceptor);
+    await docs.db?.close?.();
+  });
+
+  it('collection.get() by slug resolves the natural key and applies the injected scope', async () => {
+    const inScope = await docs.get('alpha-doc');
+    expect(inScope?.title).toBe('alpha row');
+
+    const outOfScope = await docs.get('beta-doc');
+    expect(outOfScope).toBeNull();
+  });
+
+  it('loadFromSlug() hydration honours the injected scope', async () => {
+    const inScope = new ReadPlumbingDoc({ db, slug: 'alpha-doc' });
+    await inScope.initialize();
+    expect(inScope.title).toBe('alpha row');
+
+    const outOfScope = new ReadPlumbingDoc({ db, slug: 'beta-doc' });
+    await outOfScope.initialize();
+    expect(outOfScope.title).toBe('');
+  });
+
+  it('loadFromId() hydration honours the injected scope', async () => {
+    const inScope = new ReadPlumbingDoc({ db, id: ROW_ALPHA_ID });
+    await inScope.initialize();
+    expect(inScope.title).toBe('alpha row');
+
+    const outOfScope = new ReadPlumbingDoc({ db, id: ROW_BETA_ID });
+    await outOfScope.initialize();
+    expect(outOfScope.title).toBe('');
+  });
+
+  it('getSavedId() honours the injected scope', async () => {
+    const inScope = new ReadPlumbingDoc({ db, slug: 'alpha-doc' });
+    await inScope.initialize();
+    expect(await inScope.getSavedId()).toBe(ROW_ALPHA_ID);
+
+    const outOfScope = new ReadPlumbingDoc({ db, slug: 'beta-doc' });
+    await outOfScope.initialize();
+    expect(await outOfScope.getSavedId()).toBeNull();
+  });
+
+  it('a beforeGet interceptor returning a string still resolves through the shared helper', async () => {
+    const rewriting: CollectionInterceptor = {
+      name: 'issue-2365-string-rewrite',
+      priority: 40,
+      beforeGet(className) {
+        if (className !== 'ReadPlumbingDoc') return;
+        return 'beta-doc';
+      },
+    };
+    GlobalInterceptors.unregister(groupInterceptor);
+    GlobalInterceptors.register(rewriting);
+    try {
+      const probe = new ReadPlumbingDoc({ db, slug: 'alpha-doc' });
+      await probe.initialize();
+      // The interceptor redirected the natural-key lookup to beta-doc.
+      expect(probe.title).toBe('beta row');
+    } finally {
+      GlobalInterceptors.unregister(rewriting);
+      GlobalInterceptors.register(groupInterceptor);
+    }
+  });
+});
+
+describe('collection memory tenant keying via core hooks (#2365)', () => {
+  let docs: ReadPlumbingDocCollection;
+
+  beforeAll(async () => {
+    ObjectRegistry.registerCollection(
+      'ReadPlumbingDoc',
+      ReadPlumbingDocCollection,
+    );
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['ReadPlumbingDoc'],
+    });
+    docs = await ReadPlumbingDocCollection.create({ db });
+  });
+
+  afterEach(() => {
+    setDispatchTenantResolver(undefined);
+    setTenantScopedClassResolver(undefined);
+  });
+
+  afterAll(async () => {
+    await docs.db?.close?.();
+  });
+
+  it('keys memory per tenant when the class is tenant-scoped and a tenant is active', async () => {
+    setTenantScopedClassResolver(
+      (className) => className === 'ReadPlumbingDoc',
+    );
+
+    setDispatchTenantResolver(() => 'tenant-a');
+    await docs.remember({ scope: 's', key: 'k', value: { owner: 'a' } });
+
+    setDispatchTenantResolver(() => 'tenant-b');
+    await docs.remember({ scope: 's', key: 'k', value: { owner: 'b' } });
+    expect(await docs.recall({ scope: 's', key: 'k' })).toEqual({
+      owner: 'b',
+    });
+
+    setDispatchTenantResolver(() => 'tenant-a');
+    expect(await docs.recall({ scope: 's', key: 'k' })).toEqual({
+      owner: 'a',
+    });
+
+    // No active tenant (resolver returns undefined) -> shared key, which has
+    // no entry yet.
+    setDispatchTenantResolver(() => undefined);
+    expect(await docs.recall({ scope: 's', key: 'k' })).toBeNull();
+  });
+
+  it('keeps the shared key when the class is not tenant-scoped', async () => {
+    // No tenant-scoped resolver registered: tenant context must not re-key.
+    setDispatchTenantResolver(() => 'tenant-a');
+    await docs.remember({ scope: 'shared-s', key: 'k', value: { owner: 'x' } });
+
+    setDispatchTenantResolver(undefined);
+    expect(await docs.recall({ scope: 'shared-s', key: 'k' })).toEqual({
+      owner: 'x',
+    });
+  });
+});

--- a/packages/core/src/__tests__/issue-2365-read-interceptor-plumbing.test.ts
+++ b/packages/core/src/__tests__/issue-2365-read-interceptor-plumbing.test.ts
@@ -181,6 +181,20 @@ describe('read-path interceptor plumbing (#2365)', () => {
     expect(await outOfScope.getSavedId()).toBeNull();
   });
 
+  it('getId() never adopts an out-of-scope row id', async () => {
+    const inScope = new ReadPlumbingDoc({ db, slug: 'alpha-doc' });
+    await inScope.initialize();
+    expect(await inScope.getId()).toBe(ROW_ALPHA_ID);
+
+    // Out of scope: the natural-key lookup must miss, so getId() mints a
+    // fresh uuid instead of adopting beta's row id (which would steer a
+    // subsequent save() onto beta's row).
+    const outOfScope = new ReadPlumbingDoc({ db, slug: 'beta-doc' });
+    await outOfScope.initialize();
+    const id = await outOfScope.getId();
+    expect(id).not.toBe(ROW_BETA_ID);
+  });
+
   it('a beforeGet interceptor returning a string still resolves through the shared helper', async () => {
     const rewriting: CollectionInterceptor = {
       name: 'issue-2365-string-rewrite',

--- a/packages/core/src/__tests__/issue-2365-read-scope-postgres.optional.test.ts
+++ b/packages/core/src/__tests__/issue-2365-read-scope-postgres.optional.test.ts
@@ -126,9 +126,8 @@ describe.skipIf(!pgUrl)('#2365 read scoping on PostgreSQL (optional)', () => {
     // created from the class's PostgreSQL DDL directly (the issue-2070
     // pattern); getTestDatabase only installs the portable system tables.
     await db.query(`DROP TABLE IF EXISTS "${TABLE}"`);
-    const registration = ObjectRegistry.getClassByConstructor(
-      Issue2365PgReadDoc,
-    );
+    const registration =
+      ObjectRegistry.getClassByConstructor(Issue2365PgReadDoc);
     const className =
       registration?.qualifiedName ||
       registration?.name ||

--- a/packages/core/src/__tests__/issue-2365-read-scope-postgres.optional.test.ts
+++ b/packages/core/src/__tests__/issue-2365-read-scope-postgres.optional.test.ts
@@ -1,0 +1,245 @@
+/**
+ * PostgreSQL lane for the #2365 read-path scoping seams.
+ *
+ * SQLite's type affinity masks the dialect risks these paths carry on
+ * PostgreSQL, where `id` is a native uuid column:
+ *
+ * - Before the fix, a `beforeGet` interceptor rewrote every string filter to
+ *   `{ id: filter, ... }`, so `collection.get('<slug>')` under a read scope
+ *   raised `invalid input syntax for type uuid`. The fixed contract resolves
+ *   the string through `resolveGetStringFilter()` first; this suite proves a
+ *   slug lookup with an interceptor-injected predicate works against real
+ *   PostgreSQL, including a uuid-column predicate bound from a JS string.
+ * - Hydration (`loadFromSlug`) now routes through the interceptor pipeline
+ *   with camelCase field keys converted to snake_case columns.
+ * - `findSimilarToEmbedding()` pre-filters candidates by the beforeList
+ *   read predicate BEFORE top-K, stringifying native-uuid candidate ids.
+ *
+ * Runs only when SMRT_TEST_POSTGRES_URL is set (the disposable CI PostgreSQL
+ * shard, `pnpm test:postgres`).
+ */
+
+import { randomUUID } from 'node:crypto';
+import { getDatabase } from '@happyvertical/sql';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { SmrtCollection } from '../collection';
+import { field } from '../decorators/index';
+import { EmbeddingProvider } from '../embeddings/provider';
+import { EmbeddingStorage } from '../embeddings/storage';
+import {
+  type CollectionInterceptor,
+  GlobalInterceptors,
+  resolveGetStringFilter,
+} from '../interceptors';
+import { SmrtObject } from '../object';
+import { ObjectRegistry, smrt } from '../registry';
+import { getDDLStrategy } from '../schema/ddl/index';
+import { getTestDatabase } from '../testing/database';
+
+const pgUrl = process.env.SMRT_TEST_POSTGRES_URL;
+
+// Keep in sync with the literal in the @smrt() config below — the manifest
+// scanner only accepts literal values inside a decorator config.
+const TABLE = 'issue_2365_pg_read_docs';
+const ROW_ALPHA_ID = randomUUID();
+const ROW_BETA_ID = randomUUID();
+const EMBED_MODEL = 'test-model-2365';
+
+@smrt({
+  tableName: 'issue_2365_pg_read_docs',
+  embeddings: {
+    fields: ['content'],
+    autoGenerate: false,
+  },
+})
+class Issue2365PgReadDoc extends SmrtObject {
+  @field({ type: 'text' })
+  title = '';
+
+  @field({ type: 'text' })
+  content = '';
+
+  // Two-word field name: interceptor-injected keys arrive in field form
+  // (camelCase) and must reach PostgreSQL as the group_key column.
+  @field({ type: 'text' })
+  groupKey = '';
+
+  // biome linting allows `any` in test files; this mirrors the loose options
+  // bag SmrtObject accepts.
+  constructor(options: any = {}) {
+    super(options);
+    if (options.title !== undefined) this.title = options.title;
+    if (options.content !== undefined) this.content = options.content;
+    if (options.groupKey !== undefined) this.groupKey = options.groupKey;
+  }
+}
+
+class Issue2365PgReadDocCollection extends SmrtCollection<Issue2365PgReadDoc> {
+  static readonly _itemClass = Issue2365PgReadDoc;
+}
+
+// Scopes reads to group 'alpha' — the same injection shape as the tenancy
+// interceptor (field-name keys), including a uuid-column predicate for the
+// get path so uuid binding from a JS string is exercised on real PostgreSQL.
+const scopeInterceptor: CollectionInterceptor = {
+  name: 'issue-2365-pg-read-scope',
+  priority: 50,
+  beforeGet(className, filter) {
+    if (className !== 'Issue2365PgReadDoc') return;
+    if (typeof filter === 'string') {
+      return { ...resolveGetStringFilter(filter), groupKey: 'alpha' };
+    }
+    if (!('groupKey' in filter)) {
+      return { ...filter, groupKey: 'alpha' };
+    }
+    return;
+  },
+  beforeList(className, options) {
+    if (className !== 'Issue2365PgReadDoc') return;
+    const where = options.where ?? {};
+    if ('groupKey' in where) return;
+    return { ...options, where: { ...where, groupKey: 'alpha' } };
+  },
+};
+
+describe.skipIf(!pgUrl)('#2365 read scoping on PostgreSQL (optional)', () => {
+  vi.setConfig({ testTimeout: 30_000, hookTimeout: 60_000 });
+
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+  let docs: Issue2365PgReadDocCollection;
+
+  beforeAll(async () => {
+    ObjectRegistry.registerCollection(
+      'Issue2365PgReadDoc',
+      Issue2365PgReadDocCollection,
+    );
+
+    db = await getDatabase({
+      type: 'postgres',
+      url: pgUrl,
+      dbid: `smrt-test-2365-${randomUUID()}`,
+    } as Parameters<typeof getDatabase>[0]);
+
+    // Fresh table per run: earlier runs of this suite (or a schema change)
+    // must not leak stale rows or shape into this one. `getTestDatabase`
+    // emits SQLite-flavoured application DDL, so the application table is
+    // created from the class's PostgreSQL DDL directly (the issue-2070
+    // pattern); getTestDatabase only installs the portable system tables.
+    await db.query(`DROP TABLE IF EXISTS "${TABLE}"`);
+    const registration = ObjectRegistry.getClassByConstructor(
+      Issue2365PgReadDoc,
+    );
+    const className =
+      registration?.qualifiedName ||
+      registration?.name ||
+      Issue2365PgReadDoc.name;
+    const schema = ObjectRegistry.getSchema(className);
+    const ddl = ObjectRegistry.getSchemaDDL(className, 'postgres');
+    if (!schema || !ddl) throw new Error(`Missing schema for ${className}`);
+    await db.query(ddl);
+    for (const indexSql of getDDLStrategy('postgres').generateIndexes(schema)) {
+      await db.query(indexSql);
+    }
+    await getTestDatabase({ db, classes: [] });
+    await db.query(
+      `DELETE FROM _smrt_embeddings WHERE object_class = 'Issue2365PgReadDoc'`,
+    );
+
+    docs = await Issue2365PgReadDocCollection.create({ db });
+
+    await docs.create({
+      id: ROW_ALPHA_ID,
+      slug: 'alpha-doc',
+      title: 'alpha row',
+      content: 'alpha content',
+      groupKey: 'alpha',
+    });
+    await docs.create({
+      id: ROW_BETA_ID,
+      slug: 'beta-doc',
+      title: 'beta row',
+      content: 'beta content',
+      groupKey: 'beta',
+    });
+
+    await EmbeddingStorage.upsert(db, {
+      objectClass: 'Issue2365PgReadDoc',
+      objectId: ROW_ALPHA_ID,
+      fieldName: 'content',
+      contentHash: 'hash-alpha',
+      embedding: [0.9, 0.1, 0],
+      model: EMBED_MODEL,
+      dimensions: 3,
+    });
+    // The out-of-scope row ranks HIGHER for the probe vector, so a top-1
+    // computed before scoping would be fully occupied by it.
+    await EmbeddingStorage.upsert(db, {
+      objectClass: 'Issue2365PgReadDoc',
+      objectId: ROW_BETA_ID,
+      fieldName: 'content',
+      contentHash: 'hash-beta',
+      embedding: [1, 0, 0],
+      model: EMBED_MODEL,
+      dimensions: 3,
+    });
+
+    vi.spyOn(EmbeddingProvider.prototype, 'getModelName').mockReturnValue(
+      EMBED_MODEL,
+    );
+
+    GlobalInterceptors.register(scopeInterceptor);
+  });
+
+  afterAll(async () => {
+    GlobalInterceptors.unregister(scopeInterceptor);
+    vi.restoreAllMocks();
+    try {
+      await db?.query(
+        `DELETE FROM _smrt_embeddings WHERE object_class = 'Issue2365PgReadDoc'`,
+      );
+      await db?.query(`DROP TABLE IF EXISTS "${TABLE}"`);
+    } catch {
+      // Best-effort cleanup; the next run drops the table anyway.
+    }
+  });
+
+  it('get() by slug under a read scope resolves the natural key (no uuid cast error)', async () => {
+    const inScope = await docs.get('alpha-doc');
+    expect(inScope?.title).toBe('alpha row');
+
+    const outOfScope = await docs.get('beta-doc');
+    expect(outOfScope).toBeNull();
+  });
+
+  it('get() with an interceptor-injected uuid predicate binds from a JS string', async () => {
+    const found = await docs.get({ id: ROW_ALPHA_ID });
+    expect(found?.title).toBe('alpha row');
+  });
+
+  it('loadFromSlug() hydration converts injected camelCase keys to columns on PostgreSQL', async () => {
+    const inScope = new Issue2365PgReadDoc({ db, slug: 'alpha-doc' });
+    await inScope.initialize();
+    expect(inScope.title).toBe('alpha row');
+
+    const outOfScope = new Issue2365PgReadDoc({ db, slug: 'beta-doc' });
+    await outOfScope.initialize();
+    expect(outOfScope.title).toBe('');
+  });
+
+  it('loadFromId() hydration honours the injected scope on native uuid ids', async () => {
+    const outOfScope = new Issue2365PgReadDoc({ db, id: ROW_BETA_ID });
+    await outOfScope.initialize();
+    expect(outOfScope.title).toBe('');
+  });
+
+  it('findSimilarToEmbedding() restricts candidates before top-K (uuid ids stringified)', async () => {
+    // Probe vector matches the out-of-scope row exactly; before the fix the
+    // top-1 was that row and the post-hoc filter starved the result to [].
+    const results = await docs.findSimilarToEmbedding([1, 0, 0], {
+      field: 'content',
+      limit: 1,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(ROW_ALPHA_ID);
+  });
+});

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -13,6 +13,13 @@ import {
   resolveDbCacheKey,
   setCachedRows,
 } from './collection-cache';
+// Leaf-module import (not './dispatch'): the dispatch barrel re-exports
+// DispatchCollection, which extends SmrtCollection — importing the barrel from
+// this module would create an evaluation-order cycle.
+import {
+  isTenantScopedClassResolved,
+  resolveDispatchTenantScope,
+} from './dispatch/tenant-resolver.js';
 import { EmbeddingProvider } from './embeddings/provider';
 import { EmbeddingStorage } from './embeddings/storage';
 import type { ClassEmbeddingConfig } from './embeddings/types';
@@ -20,6 +27,7 @@ import {
   createInterceptorContext,
   GlobalInterceptors,
   type ListOptions as InterceptorListOptions,
+  resolveGetStringFilter,
 } from './interceptors';
 import type { SmrtObject } from './object';
 import { QueryBoundsError, QueryOrderByError } from './query-bounds';
@@ -36,6 +44,14 @@ import {
 import { chunkArray, IN_LIST_CHUNK_SIZE } from './utils/chunk';
 
 const logger = createLogger({ level: 'info' });
+
+/**
+ * `_smrt_contexts.owner_id` value for collection-level (as opposed to
+ * per-object) memory. Tenant-scoped collections suffix the active tenant id
+ * (`__collection__:<tenantId>`) so learned memory never crosses tenants —
+ * see {@link SmrtCollection.resolveCollectionMemoryOwnerId} (#2365).
+ */
+const COLLECTION_MEMORY_OWNER_ID = '__collection__';
 
 /**
  * Validate an optional collection-level list bound (#2367).
@@ -1835,13 +1851,12 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       interceptorContext,
     );
 
-    let where =
+    // String-filter resolution shares one helper with `beforeGet` interceptors
+    // (#2365): an interceptor that rewrites the string into an object filter
+    // must resolve id-vs-slug exactly the way this method would.
+    let where: Record<string, unknown> =
       typeof interceptedFilter === 'string'
-        ? /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-            interceptedFilter,
-          )
-          ? { id: interceptedFilter }
-          : { slug: interceptedFilter, context: '' }
+        ? resolveGetStringFilter(interceptedFilter)
         : interceptedFilter;
 
     // Fix for issue #386: Add _meta_type filter for STI child collections.
@@ -3286,10 +3301,49 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
   }
 
   /**
+   * Resolve the `_smrt_contexts.owner_id` key for collection-level memory
+   * (#2365).
+   *
+   * `_smrt_contexts` has no tenant column, so before this hook a tenant-scoped
+   * collection's learned memory (`remember()`/`recall()`) was filed under one
+   * shared `__collection__` key and leaked across tenants. For a tenant-scoped
+   * item class under an active tenant context the key becomes
+   * `__collection__:<tenantId>`; everything else (tenancy disabled, no active
+   * tenant, system context, non-tenant-scoped class) keeps the shared
+   * `__collection__` key. Tenant-keyed memory is strictly isolated — a tenant
+   * recall does NOT fall back to the shared key, so memory learned outside a
+   * tenant context is invisible inside one (and vice versa).
+   *
+   * Tenant resolution uses the same core-side trust anchors as the generated
+   * REST read scope (#1782): `resolveDispatchTenantScope()` for the active
+   * tenant and the triple tenant-scoped-class check covering `@smrt()` config,
+   * manifest config, and the tenancy-filled `@TenantScoped()` resolver.
+   */
+  private resolveCollectionMemoryOwnerId(): string {
+    const itemClassName = this.getResolvedItemClassName();
+    const tenantScoped =
+      ObjectRegistry.isTenantScoped(itemClassName) ||
+      !!ObjectRegistry.getConfig(itemClassName)?.tenantScoped ||
+      isTenantScopedClassResolved(itemClassName);
+    if (!tenantScoped) {
+      return COLLECTION_MEMORY_OWNER_ID;
+    }
+    const scope = resolveDispatchTenantScope();
+    if (!scope.enforced || !scope.tenantId) {
+      return COLLECTION_MEMORY_OWNER_ID;
+    }
+    return `${COLLECTION_MEMORY_OWNER_ID}:${scope.tenantId}`;
+  }
+
+  /**
    * Remember collection-level context
    *
    * Stores context applicable to all instances of this collection type.
    * Use for patterns that apply to the entire collection (e.g., default parsing strategies).
+   *
+   * Under an active tenant context on a tenant-scoped class, memory is keyed
+   * per tenant and never shared across tenants (#2365) — see
+   * {@link resolveCollectionMemoryOwnerId}.
    *
    * `expiresAt` is stored on the `_smrt_contexts` row as caller-managed metadata.
    * {@link recall} and {@link recallAll} do **not** filter on it, so an expired
@@ -3344,7 +3398,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       {
         id,
         owner_class: this._itemClass.name,
-        owner_id: '__collection__',
+        owner_id: this.resolveCollectionMemoryOwnerId(),
         scope: options.scope,
         key: options.key,
         value: JSON.stringify(options.value),
@@ -3388,6 +3442,8 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       throw new Error('Database not initialized. Call initialize() first.');
     }
 
+    const ownerId = this.resolveCollectionMemoryOwnerId();
+
     // Use single() with template literals for custom SQL query.
     // The query projects `value` (a JSON string) and `confidence`.
     let result: Record<string, unknown> | null;
@@ -3396,7 +3452,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
         SELECT value, confidence
         FROM _smrt_contexts
         WHERE owner_class = ${this._itemClass.name}
-          AND owner_id = ${'__collection__'}
+          AND owner_id = ${ownerId}
           AND scope = ${options.scope}
           AND key = ${options.key}
           AND confidence >= ${options.minConfidence}
@@ -3408,7 +3464,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
         SELECT value, confidence
         FROM _smrt_contexts
         WHERE owner_class = ${this._itemClass.name}
-          AND owner_id = ${'__collection__'}
+          AND owner_id = ${ownerId}
           AND scope = ${options.scope}
           AND key = ${options.key}
         ORDER BY confidence DESC, version DESC
@@ -3487,7 +3543,10 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       FROM _smrt_contexts
       WHERE owner_class = ? AND owner_id = ?
     `;
-    const params: unknown[] = [this._itemClass.name, '__collection__'];
+    const params: unknown[] = [
+      this._itemClass.name,
+      this.resolveCollectionMemoryOwnerId(),
+    ];
 
     if (options.scope) {
       if (options.includeDescendants) {
@@ -3550,7 +3609,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       `DELETE FROM _smrt_contexts
        WHERE owner_class = ? AND owner_id = ? AND scope = ? AND key = ?`,
       this._itemClass.name,
-      '__collection__',
+      this.resolveCollectionMemoryOwnerId(),
       options.scope,
       options.key,
     );
@@ -3584,7 +3643,10 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       DELETE FROM _smrt_contexts
       WHERE owner_class = ? AND owner_id = ?
     `;
-    const params: unknown[] = [this._itemClass.name, '__collection__'];
+    const params: unknown[] = [
+      this._itemClass.name,
+      this.resolveCollectionMemoryOwnerId(),
+    ];
 
     if (options.includeDescendants) {
       query += ` AND (scope = ? OR scope LIKE ?)`;
@@ -3607,6 +3669,11 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    *
    * Generates an embedding for the query text and finds similar objects
    * based on cosine similarity of stored embeddings.
+   *
+   * Under an active tenant context on a tenant-scoped class, candidates are
+   * restricted to the tenant's rows BEFORE top-K ranking (#2365), so results
+   * are never starved by — and similarity ranks never leak — other tenants'
+   * content.
    *
    * @param query - Text to search for
    * @param options - Search options
@@ -3857,6 +3924,46 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     const storage = projectConfig?.storage || 'json';
     const vector = storage === 'native' ? this.systemDb.vector : undefined;
 
+    // Tenant pre-filter (#2365): _smrt_embeddings has no tenant column, so
+    // top-K used to rank across ALL tenants and only the final list() below
+    // dropped foreign rows — starving results and soft-leaking which tenants
+    // have similar content. Resolve the tenant read predicate through the
+    // SAME beforeList interceptor pipeline that guards collection reads (an
+    // empty where comes back either untouched — tenancy off, class not
+    // scoped, bypass/system context — or with exactly the injected tenant
+    // predicate, or beforeList throws for `mode: 'required'` without
+    // context), then restrict the candidate id set BEFORE ranking.
+    const itemClassName = this.getResolvedItemClassName();
+    const tenantPrefilterContext = createInterceptorContext(
+      itemClassName,
+      'list',
+      this.constructor.name,
+    );
+    const tenantPrefilter = await GlobalInterceptors.executeBeforeList(
+      itemClassName,
+      { where: {} },
+      tenantPrefilterContext,
+    );
+    let candidateObjectIds: string[] | undefined;
+    if (
+      tenantPrefilter.where &&
+      Object.keys(tenantPrefilter.where).length > 0
+    ) {
+      const candidateWhere = this.convertWhereKeys(tenantPrefilter.where);
+      const { sql: candidateWhereSql, values: candidateValues } =
+        buildWhere(candidateWhere);
+      const { rows: candidateRows } = await this.db.query(
+        `SELECT id FROM ${this.tableName} ${candidateWhereSql}`,
+        ...candidateValues,
+      );
+      candidateObjectIds = candidateRows.map((row: Record<string, unknown>) =>
+        String(row.id),
+      );
+      if (candidateObjectIds.length === 0) {
+        return [];
+      }
+    }
+
     // Use unified search method (delegates to native or in-memory)
     const scored = await EmbeddingStorage.searchSimilar(
       this.systemDb,
@@ -3867,6 +3974,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
         model,
         limit,
         minSimilarity,
+        objectIds: candidateObjectIds,
       },
       vector,
     );

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -3952,6 +3952,14 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       const candidateWhere = this.convertWhereKeys(tenantPrefilter.where);
       const { sql: candidateWhereSql, values: candidateValues } =
         buildWhere(candidateWhere);
+      // Deliberately unbounded: _smrt_embeddings has no tenant column, so the
+      // only exact way to scope ranking is the full id set of the tenant's
+      // rows. Capping it here would silently drop rows from the ranking —
+      // wrong results, not a perf tweak. The native path chunks the ids
+      // against bind-variable limits (see searchSimilar); the id-only
+      // projection keeps the row cost minimal. If this becomes a hot spot for
+      // very large tenants, the durable fix is a tenant column on
+      // _smrt_embeddings, not a cap.
       const { rows: candidateRows } = await this.db.query(
         `SELECT id FROM ${this.tableName} ${candidateWhereSql}`,
         ...candidateValues,

--- a/packages/core/src/embeddings/storage.ts
+++ b/packages/core/src/embeddings/storage.ts
@@ -8,6 +8,7 @@
 import { randomUUID } from 'node:crypto';
 import { createLogger } from '@happyvertical/logger';
 import type { DatabaseInterface, VectorCapabilities } from '@happyvertical/sql';
+import { chunkArray, IN_LIST_CHUNK_SIZE } from '../utils/chunk';
 import { CosineSimilarity } from './similarity';
 import type { StoredEmbedding } from './types';
 
@@ -108,10 +109,23 @@ export class EmbeddingStorage {
       model?: string;
       limit?: number;
       minSimilarity?: number;
+      /**
+       * Restrict candidates to these object ids BEFORE ranking (#2365).
+       * `undefined` means no restriction; an empty array means no candidates
+       * (the search returns no results). Used by tenant-scoped collections so
+       * top-K never ranks rows the caller is not allowed to see.
+       */
+      objectIds?: string[];
     } = {},
     vector?: VectorCapabilities,
   ): Promise<Array<{ objectId: string; similarity: number }>> {
-    const { field, model, limit = 10, minSimilarity = 0 } = options;
+    const { field, model, limit = 10, minSimilarity = 0, objectIds } = options;
+
+    // An explicit empty candidate set means "nothing is visible" — never fall
+    // through to the unrestricted search.
+    if (objectIds !== undefined && objectIds.length === 0) {
+      return [];
+    }
 
     // Native vector search path
     if (vector) {
@@ -132,25 +146,52 @@ export class EmbeddingStorage {
           params.push(model);
         }
 
-        const results = await vector.search(
-          '_smrt_embeddings',
-          VECTOR_COLUMN,
-          embedding,
-          {
-            limit,
-            metric: 'cosine',
-            where: conditions.join(' AND '),
-            params,
-          },
-        );
+        // Candidate restriction (#2365). The id list is chunked so one query
+        // never exceeds the backend's bind-variable limit; per-chunk top-K
+        // results merge into an exact global top-K because every chunk
+        // returns its own best `limit` candidates.
+        const idChunks = objectIds
+          ? chunkArray(objectIds, IN_LIST_CHUNK_SIZE)
+          : [undefined];
 
-        // Convert cosine distance (0=identical, 2=opposite) to similarity (1=identical, -1=opposite)
-        return results
-          .map((r) => ({
-            objectId: r.object_id as string,
-            similarity: 1 - r.distance,
-          }))
-          .filter((r) => r.similarity >= minSimilarity);
+        const merged: Array<{ objectId: string; similarity: number }> = [];
+        for (const chunk of idChunks) {
+          const chunkConditions = [...conditions];
+          const chunkParams = [...params];
+          if (chunk) {
+            const placeholders = chunk.map(
+              (_, index) => `$${chunkParams.length + 2 + index}`,
+            );
+            chunkConditions.push(`object_id IN (${placeholders.join(', ')})`);
+            chunkParams.push(...chunk);
+          }
+
+          const results = await vector.search(
+            '_smrt_embeddings',
+            VECTOR_COLUMN,
+            embedding,
+            {
+              limit,
+              metric: 'cosine',
+              where: chunkConditions.join(' AND '),
+              params: chunkParams,
+            },
+          );
+
+          // Convert cosine distance (0=identical, 2=opposite) to similarity
+          // (1=identical, -1=opposite)
+          merged.push(
+            ...results.map((r) => ({
+              objectId: r.object_id as string,
+              similarity: 1 - r.distance,
+            })),
+          );
+        }
+
+        return merged
+          .filter((r) => r.similarity >= minSimilarity)
+          .sort((a, b) => b.similarity - a.similarity)
+          .slice(0, limit);
       } catch (error) {
         // Fall back to in-memory search on vector search failure
         logger.warn(
@@ -167,11 +208,18 @@ export class EmbeddingStorage {
       model,
     );
 
-    if (storedEmbeddings.length === 0) {
+    // Candidate restriction (#2365): drop invisible rows BEFORE ranking so
+    // top-K is computed only over what the caller may see.
+    const allowedIds = objectIds ? new Set(objectIds) : undefined;
+    const candidates = allowedIds
+      ? storedEmbeddings.filter((stored) => allowedIds.has(stored.object_id))
+      : storedEmbeddings;
+
+    if (candidates.length === 0) {
       return [];
     }
 
-    return storedEmbeddings
+    return candidates
       .map((stored) => ({
         objectId: stored.object_id,
         similarity: CosineSimilarity.calculate(embedding, stored.embedding),

--- a/packages/core/src/interceptors.ts
+++ b/packages/core/src/interceptors.ts
@@ -578,6 +578,36 @@ export class GlobalInterceptors {
 }
 
 /**
+ * Canonical UUID shape used by `SmrtCollection.get()` to decide whether a
+ * string filter is an id or a slug.
+ */
+const GET_STRING_FILTER_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Resolve a string filter to the WHERE shape `SmrtCollection.get()` gives it:
+ * a UUID string becomes `{ id }`, anything else becomes the natural-key lookup
+ * `{ slug, context: '' }`.
+ *
+ * This is the single source of truth for that string-filter contract. Any
+ * `beforeGet` interceptor that rewrites a string filter into an object filter
+ * MUST resolve it through this helper first — the tenancy interceptor used to
+ * rewrite every string to `{ id: filter, tenantId }`, which broke get-by-slug
+ * under an active tenant context (null on SQLite, a uuid cast error on
+ * PostgreSQL native-uuid id columns). See #2365.
+ *
+ * @param filter - The string filter passed to `get()`
+ * @returns The object filter `get()` would build for that string
+ */
+export function resolveGetStringFilter(
+  filter: string,
+): { id: string } | { slug: string; context: string } {
+  return GET_STRING_FILTER_UUID_PATTERN.test(filter)
+    ? { id: filter }
+    : { slug: filter, context: '' };
+}
+
+/**
  * Helper function to create an interceptor context
  * @internal
  */

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -25,7 +25,11 @@ import {
   TenantIsolationError,
   ValidationError,
 } from './errors';
-import { createInterceptorContext, GlobalInterceptors } from './interceptors';
+import {
+  createInterceptorContext,
+  GlobalInterceptors,
+  resolveGetStringFilter,
+} from './interceptors';
 import { ObjectRegistry } from './registry';
 import type { RegisteredField, SmrtObjectConstructor } from './registry/types';
 import { verifyPersistenceTable } from './schema/table-verifier';
@@ -34,7 +38,12 @@ import {
   type ToolCall,
   type ToolCallResult,
 } from './tools/tool-executor';
-import { fieldsFromClass, tableNameFromClass, toSnakeCase } from './utils';
+import {
+  fieldsFromClass,
+  keysToSnakeCase,
+  tableNameFromClass,
+  toSnakeCase,
+} from './utils';
 
 // DEBUG_STI raises the level to 'debug' so the env-gated STI hydration traces
 // below (logger.debug, inside `if (process.env.DEBUG_STI)` guards) actually emit;
@@ -1587,6 +1596,10 @@ export class SmrtObject extends SmrtClass {
   /**
    * Gets the ID of this object if it's already saved in the database
    *
+   * Both lookups run through the `beforeGet` interceptor pipeline (#2365), so
+   * under an active tenant context only rows visible to that tenant count as
+   * "saved".
+   *
    * @returns Promise resolving to the saved ID or null if not saved
    */
   async getSavedId() {
@@ -1598,17 +1611,66 @@ export class SmrtObject extends SmrtClass {
 
     // Try to find by id first
     if (this.id) {
-      const byId = await this.db.get(this.tableName, { id: this.id });
+      const byId = await this.db.get(
+        this.tableName,
+        await this.interceptGetFilter({ id: this.id }),
+      );
       if (byId) return byId.id;
     }
 
     // Fall back to finding by slug
     if (this.slug) {
-      const bySlug = await this.db.get(this.tableName, { slug: this.slug });
+      const bySlug = await this.db.get(
+        this.tableName,
+        await this.interceptGetFilter({ slug: this.slug }),
+      );
       if (bySlug) return bySlug.id;
     }
 
     return null;
+  }
+
+  /**
+   * Run the registered `beforeGet` interceptors over a direct hydration filter
+   * and return it in database column form (#2365).
+   *
+   * `loadFromId()`, `loadFromSlug()` and `getSavedId()` query `this.db.get`
+   * directly instead of going through `SmrtCollection.get()`, so before this
+   * hook they bypassed every read interceptor: under an active tenant context,
+   * `new Model({ slug }).initialize()` happily hydrated another tenant's row
+   * even though every collection read was filtered. Routing the filter through
+   * `GlobalInterceptors.executeBeforeGet` gives hydration the same read
+   * predicate as collection reads — the tenancy interceptor adds its tenant
+   * filter (or throws `TenantContextError` for `mode: 'required'` classes
+   * outside a tenant context), and the existing bypasses (`withSystemContext`,
+   * super-admin bypass) keep working because they short-circuit inside the
+   * interceptor itself.
+   *
+   * Interceptors speak field names (`tenantId`); `this.db.get` speaks column
+   * names, so the merged filter is converted to snake_case before use. The
+   * base filters (`id`, `slug`, `context`) are already column-shaped and pass
+   * through unchanged.
+   *
+   * @param filter - The column-shaped hydration filter to intercept
+   * @returns The intercepted filter with all keys in column form
+   */
+  private async interceptGetFilter(
+    filter: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    const className = this.getResolvedClassName();
+    const interceptorContext = createInterceptorContext(className, 'get');
+    const intercepted = await GlobalInterceptors.executeBeforeGet(
+      className,
+      filter,
+      interceptorContext,
+    );
+    // An interceptor may hand back a string (the public beforeGet contract
+    // allows it); resolve it the same way SmrtCollection.get() would.
+    const resolved =
+      typeof intercepted === 'string'
+        ? resolveGetStringFilter(intercepted)
+        : intercepted;
+    return keysToSnakeCase(resolved as Record<string, unknown>);
   }
 
   /**
@@ -2332,8 +2394,10 @@ export class SmrtObject extends SmrtClass {
   /**
    * Hydrates this object from the database using its `id` property.
    *
-   * Queries the database for a row matching `{ id: this._id }` and calls
-   * `loadDataFromDb()` if found. Transient failures are retried up to 4 times
+   * Queries the database for a row matching `{ id: this._id }` — after running
+   * the filter through the `beforeGet` interceptor pipeline (#2365), so tenant
+   * scoping applies to hydration exactly as it does to collection reads — and
+   * calls `loadDataFromDb()` if found. Transient failures are retried up to 4 times
    * total — the initial try plus 3 retries — sleeping 250, 500 and 1000 ms
    * between them; deterministic failures are not. A malformed identifier
    * (PostgreSQL `22P02 invalid_text_representation` on a `uuid` column) is a
@@ -2357,19 +2421,23 @@ export class SmrtObject extends SmrtClass {
    * ```
    */
   public async loadFromId() {
-    try {
-      if (!this._id) {
-        throw ValidationError.requiredField('id', this.constructor.name);
-      }
+    if (!this._id) {
+      throw ValidationError.requiredField('id', this.constructor.name);
+    }
 
+    // Resolve the read filter through beforeGet interceptors before the retry
+    // wrapper (#2365): a tenancy error (missing required context, isolation
+    // violation) is a caller error that must propagate unchanged, not be
+    // wrapped into a retried DatabaseError.
+    const filter = await this.interceptGetFilter({ id: this._id });
+
+    try {
       await this.verifyStorageReady();
 
       await ErrorUtils.withRetry(
         async () => {
           try {
-            const existing = await this.db.get(this.tableName, {
-              id: this._id,
-            });
+            const existing = await this.db.get(this.tableName, filter);
             if (existing) {
               await this.loadDataFromDb(existing);
             }
@@ -2418,10 +2486,15 @@ export class SmrtObject extends SmrtClass {
   public async loadFromSlug() {
     await this.verifyStorageReady();
 
-    const existing = await this.db.get(this.tableName, {
-      slug: this._slug,
-      context: this._context || '',
-    });
+    // Route the natural-key lookup through beforeGet interceptors so slug
+    // hydration carries the same read predicate as collection reads (#2365).
+    const existing = await this.db.get(
+      this.tableName,
+      await this.interceptGetFilter({
+        slug: this._slug,
+        context: this._context || '',
+      }),
+    );
     if (existing) {
       await this.loadDataFromDb(existing);
     }

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -1519,6 +1519,12 @@ export class SmrtObject extends SmrtClass {
   /**
    * Gets or generates a unique ID for this object
    *
+   * The natural-key lookup runs through the `beforeGet` interceptor pipeline
+   * (#2365), so under an active tenant context this can only adopt the id of
+   * a row visible to that tenant — never another tenant's same-slug row,
+   * which would both disclose the foreign id and steer a subsequent `save()`
+   * onto the foreign row.
+   *
    * @returns Promise resolving to the object's ID
    */
   async getId() {
@@ -1526,10 +1532,13 @@ export class SmrtObject extends SmrtClass {
       await this.verifyStorageReady();
 
       // lookup by slug and context using adapter method
-      const saved = await this.db.get(this.tableName, {
-        slug: this.slug,
-        context: this.context,
-      });
+      const saved = await this.db.get(
+        this.tableName,
+        await this.interceptGetFilter({
+          slug: this.slug,
+          context: this.context,
+        }),
+      );
       if (saved) {
         this.id = saved.id;
       }
@@ -1634,9 +1643,9 @@ export class SmrtObject extends SmrtClass {
    * Run the registered `beforeGet` interceptors over a direct hydration filter
    * and return it in database column form (#2365).
    *
-   * `loadFromId()`, `loadFromSlug()` and `getSavedId()` query `this.db.get`
-   * directly instead of going through `SmrtCollection.get()`, so before this
-   * hook they bypassed every read interceptor: under an active tenant context,
+   * `loadFromId()`, `loadFromSlug()`, `getSavedId()` and `getId()` query
+   * `this.db.get` directly instead of going through `SmrtCollection.get()`, so
+   * before this hook they bypassed every read interceptor: under an active tenant context,
    * `new Model({ slug }).initialize()` happily hydrated another tenant's row
    * even though every collection read was filtered. Routing the filter through
    * `GlobalInterceptors.executeBeforeGet` gives hydration the same read

--- a/packages/tenancy/AGENTS.md
+++ b/packages/tenancy/AGENTS.md
@@ -27,7 +27,7 @@ Hooks into SmrtCollection via `GlobalInterceptors.register()` (priority 100, run
 | Hook | Behavior |
 |------|----------|
 | `beforeList` | Injects `tenantId` into WHERE clause; validates existing filters match context |
-| `beforeGet` | Same — converts ID lookup to `{ id, tenantId }` |
+| `beforeGet` | Same — resolves string lookups via core's `resolveGetStringFilter()` (UUID → `{ id }`, else `{ slug, context: '' }`) and adds the tenant predicate (#2365) |
 | `beforeSave` | Auto-populates tenantId if empty + `autoPopulate: true`; validates if already set |
 | `beforeDelete` | Validates instance.tenantId matches context |
 | `beforeQuery` | Enforces raw SQL policy on tenant-scoped classes (`throw`/`warn`/`allow`) |
@@ -37,6 +37,31 @@ Hooks into SmrtCollection via `GlobalInterceptors.register()` (priority 100, run
 Mismatches throw `TenantIsolationError`. Missing required context throws `TenantContextError`.
 
 **Optional-mode reads with no context pass through UNFILTERED at the interceptor.** That is intentional for trusted/admin call paths, but it means the interceptor alone does not protect a tenant-scoped model exposed as `@smrt({ api: { public } })`: an anonymous HTTP read has no context, so the interceptor would return every tenant's rows. The generated REST + SvelteKit read routes close this by injecting a `{ tenantId: null }` filter when tenancy is enabled but no context is active, so public/anonymous reads fail closed to **global (NULL-tenant) rows only** — mirroring the dispatch resolver's *enforced, no active tenant → global rows only* rule (#1782). Authenticated reads still scope to the caller's tenant via the interceptor.
+
+## Read-Path Coverage (#2365)
+
+Tenant scoping is a whole-path property — every read path is interceptor-aware,
+not only collection list/get:
+
+- **Get-by-slug**: `collection.get('<slug>')` works under a tenant context. The
+  interceptor resolves string filters with core's `resolveGetStringFilter()`
+  instead of assuming they are ids. Any custom `beforeGet` interceptor that
+  rewrites a string filter must do the same.
+- **Hydration**: `new Model({ id | slug }).initialize()`, `loadFromId()`,
+  `loadFromSlug()` and `getSavedId()` run their filters through the `beforeGet`
+  pipeline, so constructor hydration cannot read another tenant's row.
+  Required-mode classes fail closed (`TenantContextError`) when hydrated
+  outside a tenant context; `withSystemContext()` / super-admin bypass remain
+  the explicit cross-tenant paths.
+- **Vector search**: `semanticSearch()` / `findSimilarToEmbedding()` restrict
+  candidates to the tenant's rows BEFORE top-K ranking (the tenant predicate is
+  resolved through the `beforeList` pipeline), so results are never starved by
+  — and similarity ranks never leak — other tenants' content.
+- **Collection memory**: `remember()`/`recall()`/`recallAll()`/`forget()` on a
+  tenant-scoped collection key `_smrt_contexts.owner_id` per tenant
+  (`__collection__:<tenantId>`) under an active tenant context. Isolation is
+  strict: tenant-keyed memory never falls back to the shared `__collection__`
+  key, and memory learned outside a tenant context is invisible inside one.
 
 ## Registration — Two Patterns
 

--- a/packages/tenancy/AGENTS.md
+++ b/packages/tenancy/AGENTS.md
@@ -47,9 +47,11 @@ not only collection list/get:
   interceptor resolves string filters with core's `resolveGetStringFilter()`
   instead of assuming they are ids. Any custom `beforeGet` interceptor that
   rewrites a string filter must do the same.
-- **Hydration**: `new Model({ id | slug }).initialize()`, `loadFromId()`,
-  `loadFromSlug()` and `getSavedId()` run their filters through the `beforeGet`
-  pipeline, so constructor hydration cannot read another tenant's row.
+- **Hydration and identity**: `new Model({ id | slug }).initialize()`,
+  `loadFromId()`, `loadFromSlug()`, `getSavedId()` and `getId()` run their
+  filters through the `beforeGet` pipeline, so constructor hydration cannot
+  read another tenant's row and `getId()` can never adopt another tenant's
+  same-slug row id (which would steer a later `save()` onto the foreign row).
   Required-mode classes fail closed (`TenantContextError`) when hydrated
   outside a tenant context; `withSystemContext()` / super-admin bypass remain
   the explicit cross-tenant paths.
@@ -62,6 +64,10 @@ not only collection list/get:
   (`__collection__:<tenantId>`) under an active tenant context. Isolation is
   strict: tenant-keyed memory never falls back to the shared `__collection__`
   key, and memory learned outside a tenant context is invisible inside one.
+  Two edge semantics to know: under `withSuperAdminBypass()` reads skip
+  filtering but memory still keys to the active tenant (scoped tighter, not a
+  leak), and an empty-string tenant id resolves to the shared key (an
+  empty-string tenant is a misconfiguration — real tenant ids are uuids).
 
 ## Registration — Two Patterns
 

--- a/packages/tenancy/src/__tests__/issue-2365-tenancy-read-gaps.test.ts
+++ b/packages/tenancy/src/__tests__/issue-2365-tenancy-read-gaps.test.ts
@@ -1,0 +1,586 @@
+/**
+ * Tenancy read-gap regressions (#2365).
+ *
+ * Tenant isolation was enforced on collection list/get/count/query but NOT on
+ * these read paths, each probed as a real cross-tenant read or a broken read
+ * in the 2026-08-17 database-layer assessment (epic #2382, finding B2):
+ *
+ * 1. `collection.get('<slug>')` under an active tenant context — the
+ *    interceptor rewrote every string filter to `{ id: filter, tenantId }`
+ *    before core's UUID-vs-slug detection, so a slug lookup returned null on
+ *    SQLite and raised a uuid cast error on PostgreSQL.
+ * 2. Constructor hydration — `new Model({ slug })` / `{ id }` →
+ *    `loadFromSlug()` / `loadFromId()` / `getSavedId()` called `db.get`
+ *    directly, bypassing every read interceptor: under tenant B they happily
+ *    hydrated tenant A's row.
+ * 3. `semanticSearch()` computed top-K similarity across ALL tenants and only
+ *    filtered afterwards via `list()` — starving results and soft-leaking
+ *    which tenants have similar content.
+ * 4. Collection memory (`remember()`/`recall()`) filed everything under one
+ *    shared `owner_id='__collection__'` key, so learned memory crossed
+ *    tenants.
+ *
+ * Real in-memory SQLite; the real tenant interceptor; no mocking except the
+ * external embedding call (`EmbeddingProvider.embed`), per the testing policy.
+ */
+
+import {
+  EmbeddingProvider,
+  field,
+  ObjectRegistry,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import {
+  TenantContextError,
+  withSystemContext,
+  withTenant,
+} from '../context.js';
+import { TenantScoped, tenantId } from '../decorators.js';
+import { disableTenancy, enableTenancy } from '../interceptor.js';
+
+const TENANT_A = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaa1';
+const TENANT_B = 'bbbbbbbb-2222-4222-8222-bbbbbbbbbbb2';
+const TENANT_EMPTY = 'cccccccc-3333-4333-8333-ccccccccccc3';
+
+const VICTIM_UUID = 'dddddddd-4444-4444-8444-ddddddddddd4';
+const B_DOC_UUID = 'eeeeeeee-5555-4555-8555-eeeeeeeeeee5';
+
+// biome linting allows `any` in test files; this mirrors the loose options bag
+// SmrtObject accepts.
+type FixtureOptions = any;
+
+@smrt()
+@TenantScoped({ mode: 'optional' })
+class ReadGapDoc extends SmrtObject {
+  @field({ type: 'text' })
+  title = '';
+
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  constructor(options: FixtureOptions = {}) {
+    super(options);
+    if (options.title !== undefined) this.title = options.title;
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+  }
+}
+
+class ReadGapDocCollection extends SmrtCollection<ReadGapDoc> {
+  static readonly _itemClass = ReadGapDoc;
+}
+
+@smrt()
+@TenantScoped({ mode: 'required' })
+class ReadGapStrictDoc extends SmrtObject {
+  @field({ type: 'text' })
+  title = '';
+
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  constructor(options: FixtureOptions = {}) {
+    super(options);
+    if (options.title !== undefined) this.title = options.title;
+  }
+}
+
+class ReadGapStrictDocCollection extends SmrtCollection<ReadGapStrictDoc> {
+  static readonly _itemClass = ReadGapStrictDoc;
+}
+
+@smrt({
+  embeddings: {
+    fields: ['content'],
+    autoGenerate: false,
+  },
+})
+@TenantScoped({ mode: 'optional' })
+class ReadGapEmbedDoc extends SmrtObject {
+  @field({ type: 'text' })
+  content = '';
+
+  @tenantId({ nullable: true })
+  tenantId: string | null = null;
+
+  constructor(options: FixtureOptions = {}) {
+    super(options);
+    if (options.content !== undefined) this.content = options.content;
+    if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+  }
+}
+
+class ReadGapEmbedDocCollection extends SmrtCollection<ReadGapEmbedDoc> {
+  static readonly _itemClass = ReadGapEmbedDoc;
+}
+
+// NOT tenant-scoped — proves non-scoped collection memory stays shared.
+@smrt()
+class ReadGapPlainDoc extends SmrtObject {
+  @field({ type: 'text' })
+  title = '';
+
+  constructor(options: FixtureOptions = {}) {
+    super(options);
+    if (options.title !== undefined) this.title = options.title;
+  }
+}
+
+class ReadGapPlainDocCollection extends SmrtCollection<ReadGapPlainDoc> {
+  static readonly _itemClass = ReadGapPlainDoc;
+}
+
+/**
+ * Deterministic per-document vectors. Against the probe vector `[1, 0, 0]`,
+ * every tenant-b document ranks ABOVE every tenant-a document, so a top-K
+ * computed across tenants is fully occupied by tenant-b rows — the exact
+ * starvation shape the fix removes.
+ */
+const VECTORS: Record<string, number[]> = {
+  'tenant-a close match': [0.95, 0.05, 0],
+  'tenant-a mid match': [0.8, 0.2, 0],
+  'tenant-a far match': [0.1, 0.9, 0],
+  'tenant-b exact one': [1, 0, 0],
+  'tenant-b exact two': [0.99, 0.01, 0],
+  'tenant-b exact three': [0.98, 0.02, 0],
+  'similarity probe': [1, 0, 0],
+};
+
+function vectorFor(text: string): number[] {
+  const vector = VECTORS[text];
+  if (!vector) {
+    throw new Error(`No fixture vector for text: ${text}`);
+  }
+  return vector;
+}
+
+describe('Tenancy read gaps (#2365)', () => {
+  let docs: ReadGapDocCollection;
+  let strictDocs: ReadGapStrictDocCollection;
+  let embedDocs: ReadGapEmbedDocCollection;
+  let plainDocs: ReadGapPlainDocCollection;
+  // Shared handle for constructing fixture objects directly.
+  let db: any;
+
+  beforeAll(async () => {
+    ObjectRegistry.registerCollection('ReadGapDoc', ReadGapDocCollection);
+    ObjectRegistry.registerCollection(
+      'ReadGapStrictDoc',
+      ReadGapStrictDocCollection,
+    );
+    ObjectRegistry.registerCollection(
+      'ReadGapEmbedDoc',
+      ReadGapEmbedDocCollection,
+    );
+    ObjectRegistry.registerCollection(
+      'ReadGapPlainDoc',
+      ReadGapPlainDocCollection,
+    );
+
+    db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: [
+        'ReadGapDoc',
+        'ReadGapStrictDoc',
+        'ReadGapEmbedDoc',
+        'ReadGapPlainDoc',
+      ],
+    });
+
+    docs = await ReadGapDocCollection.create({ db });
+    strictDocs = await ReadGapStrictDocCollection.create({ db });
+    embedDocs = await ReadGapEmbedDocCollection.create({ db });
+    plainDocs = await ReadGapPlainDocCollection.create({ db });
+
+    enableTenancy();
+
+    // External embedding calls are mocked (testing policy: mock ONLY external
+    // AI/API calls); everything else is the real stack.
+    vi.spyOn(EmbeddingProvider.prototype, 'embed').mockImplementation(
+      async (texts: string | string[]) => {
+        const textArray = Array.isArray(texts) ? texts : [texts];
+        return textArray.map((text) => vectorFor(text));
+      },
+    );
+    vi.spyOn(EmbeddingProvider.prototype, 'getModelName').mockReturnValue(
+      'test-model-2365',
+    );
+
+    // Seed through the normal stack so the interceptor stamps tenant ids.
+    await withTenant({ tenantId: TENANT_A }, async () => {
+      await docs.create({
+        id: VICTIM_UUID,
+        slug: 'secret-a',
+        title: 'tenant-a-original',
+      });
+    });
+    await withTenant({ tenantId: TENANT_B }, async () => {
+      await docs.create({
+        id: B_DOC_UUID,
+        slug: 'doc-b',
+        title: 'tenant-b-doc',
+      });
+    });
+  });
+
+  afterAll(async () => {
+    vi.restoreAllMocks();
+    disableTenancy();
+    await docs.db?.close?.();
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 1. collection.get('<slug>') under tenant context
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('get-by-slug under tenant context', () => {
+    it('returns the tenant-owned row for a slug lookup (was null before the fix)', async () => {
+      const found = await withTenant({ tenantId: TENANT_A }, () =>
+        docs.get('secret-a'),
+      );
+      expect(found).not.toBeNull();
+      expect(found?.title).toBe('tenant-a-original');
+      expect(found?.tenantId).toBe(TENANT_A);
+    });
+
+    it("does not return another tenant's row for a slug lookup", async () => {
+      const found = await withTenant({ tenantId: TENANT_B }, () =>
+        docs.get('secret-a'),
+      );
+      expect(found).toBeNull();
+    });
+
+    it('still scopes UUID lookups to the active tenant', async () => {
+      const own = await withTenant({ tenantId: TENANT_A }, () =>
+        docs.get(VICTIM_UUID),
+      );
+      expect(own?.title).toBe('tenant-a-original');
+
+      const foreign = await withTenant({ tenantId: TENANT_B }, () =>
+        docs.get(VICTIM_UUID),
+      );
+      expect(foreign).toBeNull();
+    });
+
+    it('slug lookups without a tenant context stay unscoped for optional-mode classes', async () => {
+      const found = await docs.get('secret-a');
+      expect(found?.title).toBe('tenant-a-original');
+    });
+
+    it('withSystemContext() remains the explicit cross-tenant read path', async () => {
+      const found = await withTenant({ tenantId: TENANT_B }, () =>
+        withSystemContext(() => docs.get('secret-a')),
+      );
+      expect(found?.title).toBe('tenant-a-original');
+    });
+
+    it('throws TenantContextError for required-mode slug lookups without context', async () => {
+      await expect(strictDocs.get('any-slug')).rejects.toThrow(
+        TenantContextError,
+      );
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 2. Constructor hydration / loadFromId / loadFromSlug / getSavedId
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('hydration through the interceptor', () => {
+    it("does NOT hydrate another tenant's row via new Model({ slug }) (the probed cross-tenant read)", async () => {
+      await withTenant({ tenantId: TENANT_B }, async () => {
+        const probe = new ReadGapDoc({ db, slug: 'secret-a' });
+        await probe.initialize();
+        expect(probe.title).toBe('');
+        expect(probe.tenantId).toBeNull();
+      });
+    });
+
+    it('hydrates the own-tenant row via new Model({ slug })', async () => {
+      await withTenant({ tenantId: TENANT_A }, async () => {
+        const probe = new ReadGapDoc({ db, slug: 'secret-a' });
+        await probe.initialize();
+        expect(probe.title).toBe('tenant-a-original');
+        expect(probe.id).toBe(VICTIM_UUID);
+      });
+    });
+
+    it("does NOT hydrate another tenant's row via new Model({ id })", async () => {
+      await withTenant({ tenantId: TENANT_B }, async () => {
+        const probe = new ReadGapDoc({ db, id: VICTIM_UUID });
+        await probe.initialize();
+        expect(probe.title).toBe('');
+      });
+    });
+
+    it('hydrates the own-tenant row via new Model({ id })', async () => {
+      await withTenant({ tenantId: TENANT_A }, async () => {
+        const probe = new ReadGapDoc({ db, id: VICTIM_UUID });
+        await probe.initialize();
+        expect(probe.title).toBe('tenant-a-original');
+      });
+    });
+
+    it('getSavedId()/isSaved() only see rows visible to the active tenant', async () => {
+      await withTenant({ tenantId: TENANT_B }, async () => {
+        const probe = new ReadGapDoc({ db, slug: 'secret-a' });
+        await probe.initialize();
+        expect(await probe.getSavedId()).toBeNull();
+        expect(await probe.isSaved()).toBe(false);
+      });
+
+      await withTenant({ tenantId: TENANT_A }, async () => {
+        const probe = new ReadGapDoc({ db, slug: 'secret-a' });
+        await probe.initialize();
+        expect(await probe.getSavedId()).toBe(VICTIM_UUID);
+        expect(await probe.isSaved()).toBe(true);
+      });
+    });
+
+    it('hydration without a tenant context stays unscoped for optional-mode classes', async () => {
+      const probe = new ReadGapDoc({ db, slug: 'secret-a' });
+      await probe.initialize();
+      expect(probe.title).toBe('tenant-a-original');
+    });
+
+    it('required-mode hydration without a tenant context fails closed', async () => {
+      const probe = new ReadGapStrictDoc({ db, slug: 'whatever' });
+      await expect(probe.initialize()).rejects.toThrow(TenantContextError);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 3. semanticSearch tenant pre-filter
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('semanticSearch under tenant context', () => {
+    beforeAll(async () => {
+      const seed = async (tenant: string, id: string, content: string) => {
+        await withTenant({ tenantId: tenant }, async () => {
+          const doc = await embedDocs.create({ id, content });
+          // Runtime embedding method not part of the static SmrtObject type.
+          await (
+            doc as unknown as { generateEmbeddings(): Promise<unknown> }
+          ).generateEmbeddings();
+        });
+      };
+
+      await seed(
+        TENANT_A,
+        'aaaa1111-aaaa-4aaa-8aaa-aaaaaaaaaa01',
+        'tenant-a close match',
+      );
+      await seed(
+        TENANT_A,
+        'aaaa1111-aaaa-4aaa-8aaa-aaaaaaaaaa02',
+        'tenant-a mid match',
+      );
+      await seed(
+        TENANT_A,
+        'aaaa1111-aaaa-4aaa-8aaa-aaaaaaaaaa03',
+        'tenant-a far match',
+      );
+      await seed(
+        TENANT_B,
+        'bbbb2222-bbbb-4bbb-8bbb-bbbbbbbbbb01',
+        'tenant-b exact one',
+      );
+      await seed(
+        TENANT_B,
+        'bbbb2222-bbbb-4bbb-8bbb-bbbbbbbbbb02',
+        'tenant-b exact two',
+      );
+      await seed(
+        TENANT_B,
+        'bbbb2222-bbbb-4bbb-8bbb-bbbbbbbbbb03',
+        'tenant-b exact three',
+      );
+    });
+
+    it("is not starved by other tenants' rows occupying the top-K (was [] before the fix)", async () => {
+      // Every tenant-b vector outranks every tenant-a vector for this probe,
+      // so the old cross-tenant top-3 contained only tenant-b rows and the
+      // post-hoc tenant filter emptied it.
+      const results = await withTenant({ tenantId: TENANT_A }, () =>
+        embedDocs.semanticSearch('similarity probe', { limit: 3 }),
+      );
+
+      expect(results).toHaveLength(3);
+      expect(results.map((r) => r.content)).toEqual([
+        'tenant-a close match',
+        'tenant-a mid match',
+        'tenant-a far match',
+      ]);
+      for (const result of results) {
+        expect(result.tenantId).toBe(TENANT_A);
+      }
+    });
+
+    it("never returns another tenant's rows", async () => {
+      const results = await withTenant({ tenantId: TENANT_B }, () =>
+        embedDocs.semanticSearch('similarity probe', { limit: 10 }),
+      );
+      expect(results.length).toBeGreaterThan(0);
+      for (const result of results) {
+        expect(result.tenantId).toBe(TENANT_B);
+        expect(result.content).toContain('tenant-b');
+      }
+    });
+
+    it('honours minSimilarity within the tenant candidate set', async () => {
+      const results = await withTenant({ tenantId: TENANT_A }, () =>
+        embedDocs.semanticSearch('similarity probe', {
+          limit: 10,
+          minSimilarity: 0.5,
+        }),
+      );
+      expect(results.map((r) => r.content)).toEqual([
+        'tenant-a close match',
+        'tenant-a mid match',
+      ]);
+    });
+
+    it('returns [] for a tenant with no rows', async () => {
+      const results = await withTenant({ tenantId: TENANT_EMPTY }, () =>
+        embedDocs.semanticSearch('similarity probe', { limit: 3 }),
+      );
+      expect(results).toEqual([]);
+    });
+
+    it('stays unscoped without a tenant context for optional-mode classes', async () => {
+      const results = await embedDocs.semanticSearch('similarity probe', {
+        limit: 3,
+      });
+      expect(results.map((r) => r.content)).toEqual([
+        'tenant-b exact one',
+        'tenant-b exact two',
+        'tenant-b exact three',
+      ]);
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 4. Collection memory keyed per tenant
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('collection memory under tenant context', () => {
+    it('keys remember()/recall() per tenant on tenant-scoped collections', async () => {
+      await withTenant({ tenantId: TENANT_A }, () =>
+        docs.remember({
+          scope: 'parser/default',
+          key: 'selector',
+          value: { owner: 'tenant-a' },
+        }),
+      );
+      await withTenant({ tenantId: TENANT_B }, () =>
+        docs.remember({
+          scope: 'parser/default',
+          key: 'selector',
+          value: { owner: 'tenant-b' },
+        }),
+      );
+      await docs.remember({
+        scope: 'parser/default',
+        key: 'selector',
+        value: { owner: 'shared' },
+      });
+
+      const recallA = await withTenant({ tenantId: TENANT_A }, () =>
+        docs.recall({ scope: 'parser/default', key: 'selector' }),
+      );
+      const recallB = await withTenant({ tenantId: TENANT_B }, () =>
+        docs.recall({ scope: 'parser/default', key: 'selector' }),
+      );
+      const recallShared = await docs.recall({
+        scope: 'parser/default',
+        key: 'selector',
+      });
+
+      expect(recallA).toEqual({ owner: 'tenant-a' });
+      expect(recallB).toEqual({ owner: 'tenant-b' });
+      expect(recallShared).toEqual({ owner: 'shared' });
+    });
+
+    it('does not leak memory learned outside any tenant into a tenant context', async () => {
+      await docs.remember({
+        scope: 'parser/global-only',
+        key: 'strategy',
+        value: { owner: 'shared' },
+      });
+
+      const recallA = await withTenant({ tenantId: TENANT_A }, () =>
+        docs.recall({ scope: 'parser/global-only', key: 'strategy' }),
+      );
+      expect(recallA).toBeNull();
+    });
+
+    it('recallAll() returns only the active tenant entries', async () => {
+      await withTenant({ tenantId: TENANT_A }, () =>
+        docs.remember({
+          scope: 'recall-all-scope',
+          key: 'a-only',
+          value: { owner: 'tenant-a' },
+        }),
+      );
+      await withTenant({ tenantId: TENANT_B }, () =>
+        docs.remember({
+          scope: 'recall-all-scope',
+          key: 'b-only',
+          value: { owner: 'tenant-b' },
+        }),
+      );
+
+      const all = await withTenant({ tenantId: TENANT_A }, () =>
+        docs.recallAll({ scope: 'recall-all-scope' }),
+      );
+      expect([...all.keys()]).toEqual(['a-only']);
+      expect(all.get('a-only')).toEqual({ owner: 'tenant-a' });
+    });
+
+    it("forget() removes only the active tenant's entry", async () => {
+      await withTenant({ tenantId: TENANT_A }, () =>
+        docs.forget({ scope: 'parser/default', key: 'selector' }),
+      );
+
+      const recallA = await withTenant({ tenantId: TENANT_A }, () =>
+        docs.recall({ scope: 'parser/default', key: 'selector' }),
+      );
+      const recallB = await withTenant({ tenantId: TENANT_B }, () =>
+        docs.recall({ scope: 'parser/default', key: 'selector' }),
+      );
+      const recallShared = await docs.recall({
+        scope: 'parser/default',
+        key: 'selector',
+      });
+
+      expect(recallA).toBeNull();
+      expect(recallB).toEqual({ owner: 'tenant-b' });
+      expect(recallShared).toEqual({ owner: 'shared' });
+    });
+
+    it('memory on non-tenant-scoped collections stays shared regardless of tenant context', async () => {
+      await withTenant({ tenantId: TENANT_A }, () =>
+        plainDocs.remember({
+          scope: 'plain-scope',
+          key: 'k',
+          value: { owner: 'anyone' },
+        }),
+      );
+
+      const noContext = await plainDocs.recall({
+        scope: 'plain-scope',
+        key: 'k',
+      });
+      const otherTenant = await withTenant({ tenantId: TENANT_B }, () =>
+        plainDocs.recall({ scope: 'plain-scope', key: 'k' }),
+      );
+
+      expect(noContext).toEqual({ owner: 'anyone' });
+      expect(otherTenant).toEqual({ owner: 'anyone' });
+    });
+  });
+});

--- a/packages/tenancy/src/__tests__/issue-2365-tenancy-read-gaps.test.ts
+++ b/packages/tenancy/src/__tests__/issue-2365-tenancy-read-gaps.test.ts
@@ -325,6 +325,23 @@ describe('Tenancy read gaps (#2365)', () => {
       });
     });
 
+    it("getId() never adopts another tenant's same-slug row id", async () => {
+      // getId() feeds save(): adopting a foreign row id would both disclose
+      // the id and steer the subsequent upsert onto the foreign row.
+      await withTenant({ tenantId: TENANT_B }, async () => {
+        const probe = new ReadGapDoc({ db, slug: 'secret-a' });
+        await probe.initialize();
+        const id = await probe.getId();
+        expect(id).not.toBe(VICTIM_UUID);
+      });
+
+      await withTenant({ tenantId: TENANT_A }, async () => {
+        const probe = new ReadGapDoc({ db, slug: 'secret-a' });
+        await probe.initialize();
+        expect(await probe.getId()).toBe(VICTIM_UUID);
+      });
+    });
+
     it('getSavedId()/isSaved() only see rows visible to the active tenant', async () => {
       await withTenant({ tenantId: TENANT_B }, async () => {
         const probe = new ReadGapDoc({ db, slug: 'secret-a' });

--- a/packages/tenancy/src/__tests__/tenancy.test.ts
+++ b/packages/tenancy/src/__tests__/tenancy.test.ts
@@ -607,18 +607,46 @@ describe('TenantInterceptor', () => {
   });
 
   describe('beforeGet', () => {
-    it('should convert string ID filter to object with tenant filter', async () => {
+    it('should convert a UUID string filter to an id lookup with tenant filter', async () => {
       registerTenantScopedClass('Document');
       const interceptor = createTenantInterceptor();
 
       await withTenant({ tenantId: 'tenant-123' }, async () => {
+        const result = interceptor.beforeGet?.(
+          'Document',
+          '550e8400-e29b-41d4-a716-446655440000',
+          {
+            className: 'Document',
+            operation: 'get',
+            timestamp: new Date(),
+          },
+        );
+
+        expect(result).toEqual({
+          id: '550e8400-e29b-41d4-a716-446655440000',
+          tenantId: 'tenant-123',
+        });
+      });
+    });
+
+    it('should convert a non-UUID string filter to a slug lookup with tenant filter (#2365)', async () => {
+      registerTenantScopedClass('Document');
+      const interceptor = createTenantInterceptor();
+
+      await withTenant({ tenantId: 'tenant-123' }, async () => {
+        // Core's get() treats non-UUID strings as slug natural keys; the
+        // interceptor must preserve that semantics, not assume `{ id }`.
         const result = interceptor.beforeGet?.('Document', 'doc-1', {
           className: 'Document',
           operation: 'get',
           timestamp: new Date(),
         });
 
-        expect(result).toEqual({ id: 'doc-1', tenantId: 'tenant-123' });
+        expect(result).toEqual({
+          slug: 'doc-1',
+          context: '',
+          tenantId: 'tenant-123',
+        });
       });
     });
 

--- a/packages/tenancy/src/interceptor.ts
+++ b/packages/tenancy/src/interceptor.ts
@@ -19,6 +19,7 @@ import {
   type ListOptions,
   type QueryInterceptResult,
   type QueryOptions,
+  resolveGetStringFilter,
   setDispatchTenantResolver,
   setTenantEntryPointRunner,
   setTenantScopedClassResolver,
@@ -173,7 +174,7 @@ function serializeInstance(
  * | Hook          | Behaviour |
  * |---------------|-----------|
  * | `beforeList`  | Injects tenant filter into `WHERE`; validates explicit filters. |
- * | `beforeGet`   | Converts ID lookups to `{ id, tenantId }` filter objects. |
+ * | `beforeGet`   | Resolves string lookups (id vs slug) and adds the tenant predicate. |
  * | `beforeSave`  | Auto-populates `tenantId`; validates existing values. |
  * | `beforeDelete`| Validates the instance's `tenantId` matches context. |
  * | `beforeQuery` | Enforces `rawQueryPolicy` on raw SQL calls. |
@@ -334,10 +335,14 @@ export function createTenantInterceptor(
 
       const tenantField = config?.field || 'tenantId';
 
-      // If filter is a string (ID), convert to object filter with tenant
+      // If filter is a string, resolve it exactly the way core's `get()` would
+      // (UUID -> id lookup, anything else -> slug/context natural key) and add
+      // the tenant predicate to whichever shape it resolves to. Rewriting every
+      // string to `{ id: filter }` broke get-by-slug under a tenant context:
+      // null on SQLite, a uuid cast error on PostgreSQL (#2365).
       if (typeof filter === 'string') {
         return {
-          id: filter,
+          ...resolveGetStringFilter(filter),
           [tenantField]: tenantContext.tenantId,
         };
       }


### PR DESCRIPTION
Closes #2365 (epic #2382, finding B2).

## The gaps

Tenant isolation was enforced on collection list/get/count/select/query, but four read paths bypassed it — each probed as a real cross-tenant read or a broken read in the 2026-08-17 database-layer assessment:

1. **`collection.get('<slug>')` broke under a tenant context.** The interceptor rewrote every string filter to `{ id: filter, tenantId }` before core's UUID-vs-slug detection — null on SQLite, `invalid input syntax for type uuid` on PostgreSQL's native-uuid id column. The same call without a tenant context worked.
2. **Constructor hydration was tenant-blind.** `new Model({ slug }).initialize()` → `loadFromSlug()`/`loadFromId()`/`getSavedId()` called `db.get` directly: under tenant B they hydrated tenant A's row.
3. **`semanticSearch()` ranked across all tenants**, then filtered via `list()` — result starvation (a top-K fully occupied by another tenant's rows filtered down to `[]`) and a soft presence leak.
4. **Collection memory was shared across tenants**: `remember()`/`recall()` filed everything under one `owner_id='__collection__'` key in `_smrt_contexts`.

## The fix

- **One string-filter contract.** New `resolveGetStringFilter()` in core (`interceptors.ts`) is the single source of truth for get()'s string semantics (UUID → `{ id }`, else `{ slug, context: '' }`); `collection.get()` and the tenancy `beforeGet` both consume it, so the interceptor now adds the tenant predicate to whichever shape the string resolves to.
- **Hydration/identity through the interceptor.** `loadFromId()`, `loadFromSlug()`, `getSavedId()` and `getId()` resolve their filters through `GlobalInterceptors.executeBeforeGet` (new `interceptGetFilter()` helper; field-name keys converted to columns). `getId()` was surfaced by the adversarial review: its unrouted `(slug, context)` lookup could adopt another tenant's row id and steer a later `save()` onto the foreign row. With no interceptors registered every path is a no-op passthrough — non-tenant deployments are behavior-identical.
- **Vector search pre-filters BEFORE top-K.** `findSimilarToEmbedding()` resolves the tenant predicate through the same `beforeList` pipeline that guards collection reads (empty where in → either untouched, the injected tenant predicate, or the required-mode throw) and passes the tenant's candidate id set into `EmbeddingStorage.searchSimilar()` — chunked `object_id IN (...)` against bind-variable limits on the native vector path (per-chunk top-K merge is an exact global top-K), `Set`-filtered before ranking on the in-memory path. An explicit empty candidate set short-circuits to `[]`. The final `list({ 'id in': ... })` still re-applies the interceptor — defense in depth.
- **Collection memory keyed per tenant.** `remember`/`recall`/`recallAll`/`forget`/`forgetScope` resolve `_smrt_contexts.owner_id` to `__collection__:<tenantId>` for tenant-scoped classes under an active tenant, via the same core dispatch trust anchors as the #1782 REST read scope (`resolveDispatchTenantScope` + the triple tenant-scoped-class check). Isolation is strict — no fallback to the shared key in either direction. Non-scoped classes and no-context calls keep the shared key.

`withSystemContext()` and super-admin bypass remain the explicit, reviewed cross-tenant read paths (they short-circuit inside the interceptor itself).

## Compatibility notes

- **Required-mode hydration now fails closed**: `new Model({ id | slug }).initialize()` on a `mode: 'required'` class outside a tenant context now throws `TenantContextError` instead of silently hydrating. That is the issue's intent (reads catch up with writes, which `beforeSave` already guarded).
- Memory previously learned under the shared `__collection__` key is no longer visible to tenant-context recalls (that visibility was the leak).
- Review notes, documented in `packages/tenancy/AGENTS.md`: under super-admin bypass, reads skip filtering but memory still keys to the active tenant (tighter, not a leak); an empty-string tenant id resolves to the shared memory key (misconfiguration only — real tenant ids are uuids).
- The tenant candidate query in the vector pre-filter is deliberately unbounded — a cap would silently drop rows from ranking; the durable fix for very large tenants is a tenant column on `_smrt_embeddings` (commented at the call site).

## Out of scope / follow-up

- #2412 (filed from this review): three remaining direct `db.get()` sites — STI legacy-discriminator upgrade planning and `validateCrossPackageRefs()` (write-path adjacent, interact with #2360 / PR #2404), and the STI discriminator peek in `loadRelated()` (instance-level #1321 guard already applies).
- Upsert/natural-key tenant semantics (finding B1) are #2360 / PR #2404.

## Tests

- `packages/tenancy/src/__tests__/issue-2365-tenancy-read-gaps.test.ts` — real tenancy interceptor on in-memory SQLite, 24 tests: slug get per tenant, cross-tenant hydration returns nothing, `getSavedId`/`isSaved`/`getId` scoping, required-mode fail-closed on get and hydration, `withSystemContext` escape hatch, semanticSearch starvation/isolation/minSimilarity/empty-tenant, per-tenant memory (remember/recall/recallAll/forget) plus shared-key semantics for non-scoped classes. **10 of the original 23 fail against the unfixed code** (verified by stashing the fix); only `EmbeddingProvider.embed` is mocked (external AI call).
- `packages/core/src/__tests__/issue-2365-read-interceptor-plumbing.test.ts` — core-side seams with a plain registered interceptor (the #1782 inversion pattern): `resolveGetStringFilter` units, get/hydration/`getSavedId`/`getId` scoping incl. camelCase→column conversion, string-returning interceptors, memory keying via the dispatch hooks.
- `packages/core/src/__tests__/issue-2365-read-scope-postgres.optional.test.ts` — PostgreSQL lane: slug get under a read scope (no uuid cast error), uuid predicate bound from a JS string, hydration key conversion on native columns, candidate pre-filter with uuid id stringification.

## Validation

- `packages/tenancy` full `pnpm test` — 160 passed (12 files); one pre-existing beforeGet unit test updated to the fixed contract (it asserted the string→`{id}` rewrite that WAS the bug)
- `packages/core` full `pnpm test` — 3569 passed, 67 skipped (290 files), twice (after each commit)
- `pnpm typecheck` core + `tsc --noEmit` tenancy — clean
- `pnpm test:postgres` (core) against a disposable PostgreSQL 17 container — new #2365 suite 5/5; `change-feed-concurrency` barrier and `issue-2069` UTC failures reproduce identically on clean `db1b68d92` against the same container (pre-existing environment artifacts; CI's disposable shard is the gate)
- `npx biome check` on all touched files — clean
- `pnpm smrt dev:knowledge-check` — fresh, 0 errors / 0 warnings (after rebuild)
- `node scripts/check-standards.mjs`, `check-agents-chain.mjs` — clean (chain headroom intact)
- `node scripts/check-coverage.mjs --packages core,tenancy` — core 86.92%, tenancy 87.02% (T1 floor 80%)

## Review

Two-reviewer cycle on a3fa0c0a9 (general + adversarial tenant-isolation; Codex out of quota until Aug 19): general reviewer clean; adversarial reviewer verified memory-key injectivity, interceptor/dispatch consistency, `$N` chunk numbering, top-K merge equivalence, empty-allowlist short-circuits, the loadFromId error contract, and byte-identical non-tenant behavior — and surfaced the `getId()` gap, fixed in a5f693245 and verified clean by a focused recall review.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","policy_revision":"1.0.0","runtime":"claude","session":"2e828b4a-bf86-463b-8159-3ee4e9f1275f","issue":"https://github.com/happyvertical/smrt/issues/2365"}
```
