### PR TITLE
fix(core,jobs,agents,profiles,users): index hot poll and auth lookup predicates

### DIFF
--- a/packages/agents/src/issue-2364-hot-predicate-index.test.ts
+++ b/packages/agents/src/issue-2364-hot-predicate-index.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Issue #2364 (epic #2382, finding A3) — the agent-schedule poll predicate
+ * indexed on the PRODUCTION manifest schema path.
+ *
+ * `createIsolatedTestDbFromManifest()` with no explicit path auto-detects
+ * this package's own freshly-generated manifest and renders tables + indexes
+ * through the same structured-schema renderer `smrt db:migrate` uses (#2358)
+ * — so this proves the declared composite is actually emitted for the real
+ * shipped `AgentSchedule` class, not just the schema generator's synthetic
+ * fixtures in `@happyvertical/smrt-core`'s `schema-path-parity.test.ts`.
+ */
+
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+type Row = Record<string, unknown>;
+
+async function rows(db: DatabaseInterface, sql: string): Promise<Row[]> {
+  const result = await db.query(sql);
+  return Array.isArray(result)
+    ? (result as Row[])
+    : ((result as { rows?: Row[] }).rows ?? []);
+}
+
+describe('agent-schedule poll predicate index reaches the production manifest schema path (#2364)', () => {
+  let baseDb: DatabaseInterface;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ baseDb, cleanup } = await createIsolatedTestDbFromManifest({
+      includeObjects: ['AgentSchedule'],
+    }));
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it('indexes `ScheduleRunner.poll()`s `(enabled, status, next_run)` predicate on `_smrt_agent_schedules`', async () => {
+    const result = await rows(
+      baseDb,
+      `SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = '_smrt_agent_schedules'`,
+    );
+    const names = result.map((row) => String(row.name));
+    expect(names).toContain(
+      '_smrt_agent_schedules_enabled_status_next_run_idx',
+    );
+  });
+});

--- a/packages/agents/src/schedule.ts
+++ b/packages/agents/src/schedule.ts
@@ -50,6 +50,18 @@ export type ScheduleStatus = 'active' | 'paused' | 'disabled' | 'error';
     skipApiCheck: true,
   },
   mcp: { include: ['list', 'get'] },
+  // ScheduleRunner.poll() scans this predicate every minute (#2364, epic
+  // #2382 finding A3): `enabled = true AND status = 'active' AND
+  // next_run <= ?`, ordered by `next_run ASC`. `enabled` leads because it is
+  // the cheapest, most selective equality filter (most schedules are
+  // enabled; the composite still serves `status`-only and
+  // `(enabled, status)`-only reads as leftward prefixes).
+  indexes: [
+    {
+      name: '_smrt_agent_schedules_enabled_status_next_run_idx',
+      columns: ['enabled', 'status', 'nextRun'],
+    },
+  ],
 })
 export class AgentSchedule extends SmrtObject {
   /**

--- a/packages/agents/src/schedule.ts
+++ b/packages/agents/src/schedule.ts
@@ -52,10 +52,12 @@ export type ScheduleStatus = 'active' | 'paused' | 'disabled' | 'error';
   mcp: { include: ['list', 'get'] },
   // ScheduleRunner.poll() scans this predicate every minute (#2364, epic
   // #2382 finding A3): `enabled = true AND status = 'active' AND
-  // next_run <= ?`, ordered by `next_run ASC`. `enabled` leads because it is
-  // the cheapest, most selective equality filter (most schedules are
-  // enabled; the composite still serves `status`-only and
-  // `(enabled, status)`-only reads as leftward prefixes).
+  // next_run <= ?`, ordered by `next_run ASC`. `enabled` and `status` are
+  // both equality filters and lead `next_run`, the range filter: a B-tree
+  // composite serves an equality prefix as a direct lookup but can only
+  // range-scan its trailing column, so the two equality columns come first
+  // (the composite still serves `status`-only and `(enabled, status)`-only
+  // reads as leftward prefixes).
   indexes: [
     {
       name: '_smrt_agent_schedules_enabled_status_next_run_idx',

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -568,6 +568,12 @@ export class SchemaGenerator {
    *
    * Call this alongside {@link ensureDefaultListOrderingIndex}, before
    * {@link ensureReferenceColumnIndexes}.
+   *
+   * Blast radius: this applies retroactively to every
+   * `SmrtPolymorphicAssociation` subclass across every package on the next
+   * `db:migrate`, not only the ones a given change touches — roll the wave
+   * out with `smrt db:migrate --postgres-safe` (#2362), same as any other
+   * bulk index addition.
    */
   private ensurePolymorphicAssociationIndex(
     indexes: Array<{

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -121,6 +121,11 @@ export class SchemaGenerator {
     // the composite suppresses a standalone tenant index.
     this.ensureDefaultListOrderingIndex(indexes, columns, tableName);
 
+    // Polymorphic association owner lookup `(meta_type, meta_id)` (#2364,
+    // epic #2382 finding A3) — alongside the default-ordering composite,
+    // before the reference-column pass.
+    this.ensurePolymorphicAssociationIndex(indexes, columns, tableName);
+
     // Reference columns (@foreignKey / @crossPackageRef / tenant_id) are
     // always indexed (#2356, #2359).
     this.ensureReferenceColumnIndexes(indexes, columns, tableName);
@@ -518,6 +523,73 @@ export class SchemaGenerator {
     // No `description`: ManifestIndexDefinition has no such field, and this
     // helper feeds the manifest paths as well as the structured ones.
     indexes.push({ name, columns: orderingColumns });
+  }
+
+  /**
+   * The `(meta_type, meta_id)` owner-lookup columns for a polymorphic
+   * association table, or `null` when the table isn't one.
+   *
+   * `SmrtPolymorphicAssociation` contributes `metaType`/`metaId`/`role` (and
+   * `sortOrder`) to any concrete subclass's manifest — the scanner's
+   * `FRAMEWORK_ABSTRACT_BASE_NAMES` wiring merges the abstract base's fields
+   * directly into the subclass, because the base carries no `@smrt()`
+   * decorator of its own to declare an index on. Detected structurally, by
+   * the same three-column test `cascade.ts`'s `isPolymorphicAssociationClass`
+   * uses on registry field maps: requiring all three keeps an unrelated class
+   * that merely happens to carry a `metaType` column from being treated as an
+   * association table.
+   */
+  private getPolymorphicAssociationOwnerColumns(
+    columns: Record<string, unknown>,
+  ): string[] | null {
+    if (
+      !Object.hasOwn(columns, 'meta_type') ||
+      !Object.hasOwn(columns, 'meta_id') ||
+      !Object.hasOwn(columns, 'role')
+    ) {
+      return null;
+    }
+    return ['meta_type', 'meta_id'];
+  }
+
+  /**
+   * Ensure a polymorphic association table indexes its owner lookup
+   * `(meta_type, meta_id)` (#2364, epic #2382 finding A3).
+   *
+   * A concrete association's `conflictColumns` lead with its own FK (e.g.
+   * `AssetAssociation`'s `asset_id, meta_type, meta_id, role`), so
+   * `meta_type`/`meta_id` sit in the *middle* of that unique index — a
+   * lookup like `AssetAssociationCollection.byLeft(metaType, metaId)`
+   * ("what points at this target") filters columns 2-3 of a 4-column index
+   * and cannot use it as a leading prefix. `metaId` is deliberately a bare
+   * string, never a typed `@foreignKey`/`@crossPackageRef` (there is no
+   * single target table), so {@link ensureReferenceColumnIndexes} never
+   * covers it either.
+   *
+   * Call this alongside {@link ensureDefaultListOrderingIndex}, before
+   * {@link ensureReferenceColumnIndexes}.
+   */
+  private ensurePolymorphicAssociationIndex(
+    indexes: Array<{
+      name: string;
+      columns: string[];
+      unique?: boolean;
+      where?: string;
+      jsonPath?: unknown;
+    }>,
+    columns: Record<string, unknown>,
+    tableName: string,
+  ): void {
+    const ownerColumns = this.getPolymorphicAssociationOwnerColumns(columns);
+    if (!ownerColumns) return;
+    if (this.hasUnqualifiedLeadingColumns(indexes, ownerColumns)) return;
+
+    const name = `${tableName}_${ownerColumns.join('_')}_idx`;
+    if (indexes.some((index) => index.name === name)) return;
+
+    // No `description`: ManifestIndexDefinition has no such field, and this
+    // helper feeds the manifest paths as well as the structured ones.
+    indexes.push({ name, columns: ownerColumns });
   }
 
   /**
@@ -1390,6 +1462,11 @@ export class SchemaGenerator {
     // indexes, before the reference-column pass.
     this.ensureDefaultListOrderingIndex(indexes, columns, tableName);
 
+    // Polymorphic association owner lookup `(meta_type, meta_id)` (#2364,
+    // epic #2382 finding A3) — alongside the default-ordering composite,
+    // before the reference-column pass.
+    this.ensurePolymorphicAssociationIndex(indexes, columns, tableName);
+
     // Reference columns (@foreignKey / @crossPackageRef / tenant_id) are
     // always indexed (#2356, #2359).
     this.ensureReferenceColumnIndexes(indexes, columns, tableName);
@@ -1733,6 +1810,11 @@ export class SchemaGenerator {
     // indexes, before the reference-column pass.
     this.ensureDefaultListOrderingIndex(indexes, columns, tableName);
 
+    // Polymorphic association owner lookup `(meta_type, meta_id)` (#2364,
+    // epic #2382 finding A3) — alongside the default-ordering composite,
+    // before the reference-column pass.
+    this.ensurePolymorphicAssociationIndex(indexes, columns, tableName);
+
     // Reference columns (@foreignKey / @crossPackageRef / tenant_id) are
     // always indexed (#2356, #2359).
     this.ensureReferenceColumnIndexes(indexes, columns, tableName);
@@ -1979,6 +2061,11 @@ export class SchemaGenerator {
     // indexes, before the reference-column pass.
     this.ensureDefaultListOrderingIndex(indexes, columns, tableName);
 
+    // Polymorphic association owner lookup `(meta_type, meta_id)` (#2364,
+    // epic #2382 finding A3) — alongside the default-ordering composite,
+    // before the reference-column pass.
+    this.ensurePolymorphicAssociationIndex(indexes, columns, tableName);
+
     // Reference columns (@foreignKey / @crossPackageRef / tenant_id) are
     // always indexed (#2356, #2359). Runs last so every consumer of the
     // structured `indexes` array (migrations, test databases, aggregation)
@@ -2174,6 +2261,11 @@ export class SchemaGenerator {
     // The default list page orders by created_at (#2363) — after the declared
     // indexes, before the reference-column pass.
     this.ensureDefaultListOrderingIndex(indexes, columns, tableName);
+
+    // Polymorphic association owner lookup `(meta_type, meta_id)` (#2364,
+    // epic #2382 finding A3) — alongside the default-ordering composite,
+    // before the reference-column pass.
+    this.ensurePolymorphicAssociationIndex(indexes, columns, tableName);
 
     // Reference columns (@foreignKey / @crossPackageRef / tenant_id) are
     // always indexed (#2356, #2359). Runs last so every consumer of the

--- a/packages/core/src/schema/issue-2364-jobs-claim-index-postgres.optional.test.ts
+++ b/packages/core/src/schema/issue-2364-jobs-claim-index-postgres.optional.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Issue #2364 — live PostgreSQL plan for the jobs claim-loop predicate.
+ *
+ * Runs only in the PostgreSQL lane (`pnpm --filter @happyvertical/smrt-core
+ * test:postgres`, which supplies `DATABASE_URL`); skipped otherwise.
+ *
+ * `schema-path-parity.test.ts` proves `indexed: true` and `@smrt({ indexes })`
+ * are *emitted* identically on every schema path. Only a real planner proves
+ * the thing epic #2382 finding A3 is actually about: every ~1s, every
+ * `TaskRunner` polls `SmrtJobCollection.claimReady()` — `WHERE status =
+ * 'pending' AND run_at <= ?  ORDER BY priority DESC, run_at ASC, created_at
+ * ASC, id ASC LIMIT ?` — and before this issue `_smrt_jobs` carried no index
+ * that could serve it (only compat `tenant_id`/`task_id` indexes on legacy
+ * databases), so every poll from every runner was a sequential scan.
+ *
+ * The table shape here mirrors `@happyvertical/smrt-jobs`'s real `SmrtJob`
+ * class (`status`/`runAt` both `indexed: true`, plus the class-level
+ * `(status, run_at)` composite declared via `@smrt({ indexes })`) rather than
+ * importing it — `smrt-core` cannot depend on `smrt-jobs` (dependency
+ * direction), and `SchemaGenerator` run directly is what proves the
+ * PRODUCTION manifest path, matching `issue-2363-list-ordering-index-postgres
+ * .optional.test.ts`'s approach for the same reason.
+ *
+ * SQLite would not show this: its planner reports a very different shape and
+ * its cost model never chose the seq-scan plan the same way.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { getDatabase } from '@happyvertical/sql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { DatabaseInterface } from '../migrations/types.js';
+import { SchemaGenerator } from './generator.js';
+import { renderIndexTarget } from './index-utils.js';
+
+const pgUrl = process.env.DATABASE_URL ?? process.env.SMRT_TEST_POSTGRES_URL;
+const suffix = `${process.pid}_${Math.random().toString(36).slice(2, 8)}`;
+const TABLE = `i2364_jobs_${suffix}`;
+
+const STATUSES = ['pending', 'running', 'completed', 'failed', 'cancelled'];
+const ROWS_PER_STATUS = 2000;
+
+/** The candidate-select half of `SmrtJobCollection.claimReady()` (smrt-job.ts). */
+const CLAIM_CANDIDATES = `
+  SELECT id
+    FROM "${TABLE}"
+   WHERE status = 'pending' AND run_at <= $1
+   ORDER BY priority DESC, run_at ASC, created_at ASC, id ASC
+   LIMIT $2
+     FOR UPDATE SKIP LOCKED
+`;
+
+/** Collect every node type in an EXPLAIN (FORMAT JSON) plan tree. */
+function planNodes(node: Record<string, unknown>): string[] {
+  const nodes = [String(node['Node Type'])];
+  const children = (node.Plans ?? []) as Record<string, unknown>[];
+  for (const child of children) nodes.push(...planNodes(child));
+  return nodes;
+}
+
+/** Collect every index name the plan touches. */
+function planIndexes(node: Record<string, unknown>): string[] {
+  const names = node['Index Name'] ? [String(node['Index Name'])] : [];
+  const children = (node.Plans ?? []) as Record<string, unknown>[];
+  for (const child of children) names.push(...planIndexes(child));
+  return names;
+}
+
+/**
+ * `@happyvertical/sql` returns `{ rows, rowCount }` on PostgreSQL but a bare
+ * array on other engines; normalize so the assertions read the same either way.
+ */
+function resultRows<T = Record<string, unknown>>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[];
+  return ((result as { rows?: T[] })?.rows ?? []) as T[];
+}
+
+async function explain(
+  db: DatabaseInterface,
+  sql: string,
+  params: unknown[],
+): Promise<Record<string, unknown>> {
+  const rows = resultRows(
+    await db.query(`EXPLAIN (FORMAT JSON) ${sql}`, params),
+  );
+  const first = rows[0];
+  const plan = (first['QUERY PLAN'] ?? first.query_plan) as
+    | Array<{ Plan: Record<string, unknown> }>
+    | string;
+  const parsed = typeof plan === 'string' ? JSON.parse(plan) : plan;
+  return parsed[0].Plan as Record<string, unknown>;
+}
+
+describe.skipIf(!pgUrl)(
+  'jobs claim-loop predicate index on PostgreSQL (#2364, epic #2382 A3)',
+  () => {
+    let db: DatabaseInterface;
+    let claimIndexName: string;
+
+    beforeAll(async () => {
+      db = (await getDatabase({
+        type: 'postgres',
+        url: pgUrl,
+        dbid: `smrt-test-2364-${randomUUID()}`,
+        max: 2,
+      } as Parameters<typeof getDatabase>[0])) as unknown as DatabaseInterface;
+
+      // Build the table from the PRODUCTION schema path, not by hand: the
+      // point of the test is that what `smrt db:migrate` ships can serve the
+      // poll every runner issues roughly once per second.
+      const generator = new SchemaGenerator();
+      const schema = generator.generateCTISchemaFromManifest(
+        'JobClaimProbe',
+        TABLE,
+        {
+          status: {
+            type: 'text',
+            required: true,
+            default: 'pending',
+            _meta: { indexed: true },
+          },
+          runAt: {
+            type: 'datetime',
+            required: true,
+            _meta: { indexed: true },
+          },
+          priority: { type: 'integer', required: true, default: 50 },
+          queue: { type: 'text', required: true, default: 'default' },
+        },
+        {
+          idType: 'text',
+          indexes: [
+            {
+              name: `${TABLE}_status_run_at_idx`,
+              columns: ['status', 'runAt'],
+            },
+          ],
+        },
+      );
+
+      const claim = schema.indexes.find(
+        (index) =>
+          index.columns[0] === 'status' && index.columns[1] === 'run_at',
+      );
+      if (!claim) {
+        throw new Error(
+          `generator emitted no (status, run_at) index: ${JSON.stringify(
+            schema.indexes.map((i) => i.name),
+          )}`,
+        );
+      }
+      claimIndexName = claim.name;
+
+      await db.query(`DROP TABLE IF EXISTS "${TABLE}"`);
+      await db.query(schema.ddl);
+      for (const index of schema.indexes) {
+        await db.query(
+          `CREATE ${index.unique ? 'UNIQUE ' : ''}INDEX "${index.name}" ON "${TABLE}" (${renderIndexTarget(
+            index,
+            'postgres',
+          )})`,
+        );
+      }
+
+      // One multi-row INSERT ... SELECT unnest(): a poll loop's WHERE clause
+      // only matches a small selective slice (pending rows already due), so
+      // seed a realistic queue depth across every status. `run_at` spans past
+      // and future so roughly half of the pending rows are actually claimable
+      // — the same shape a live queue has, and selective enough that the
+      // planner has a real choice to make.
+      const ids: string[] = [];
+      const slugs: string[] = [];
+      const statuses: string[] = [];
+      const offsetsSeconds: number[] = [];
+      let n = 0;
+      for (const status of STATUSES) {
+        for (let i = 0; i < ROWS_PER_STATUS; i += 1) {
+          n += 1;
+          ids.push(randomUUID());
+          slugs.push(`job-${n}`);
+          statuses.push(status);
+          // Alternates well in the past (claimable) and well in the future
+          // (not yet due), independent of status.
+          offsetsSeconds.push(i % 2 === 0 ? -3600 : 3600);
+        }
+      }
+
+      await db.query(
+        `INSERT INTO "${TABLE}" (id, slug, context, status, run_at, priority, queue, created_at, updated_at)
+         SELECT r.id,
+                r.slug,
+                '',
+                r.status,
+                now() + make_interval(secs => r.offset_seconds),
+                50,
+                'default',
+                now(),
+                now()
+         FROM unnest($1::text[], $2::text[], $3::text[], $4::int[])
+              AS r(id, slug, status, offset_seconds)`,
+        [ids, slugs, statuses, offsetsSeconds],
+      );
+      await db.query(`ANALYZE "${TABLE}"`);
+    }, 120_000);
+
+    afterAll(async () => {
+      try {
+        await db?.query(`DROP TABLE IF EXISTS "${TABLE}"`);
+      } finally {
+        await (db as unknown as { close?: () => Promise<void> })?.close?.();
+      }
+    });
+
+    it('serves the claim candidate-select from the (status, run_at) index, not a sequential scan', async () => {
+      const plan = await explain(db, CLAIM_CANDIDATES, [
+        new Date().toISOString(),
+        100,
+      ]);
+      const nodes = planNodes(plan);
+
+      expect(planIndexes(plan)).toContain(claimIndexName);
+      expect(
+        nodes.some(
+          (node) =>
+            node.includes('Index Scan') || node.includes('Index Only Scan'),
+        ),
+      ).toBe(true);
+      expect(nodes).not.toContain('Seq Scan');
+    });
+
+    it('returns only pending rows already due, ordered as the runner expects', async () => {
+      const rows = resultRows<{ id: string }>(
+        await db.query(CLAIM_CANDIDATES.replace('FOR UPDATE SKIP LOCKED', ''), [
+          new Date().toISOString(),
+          50,
+        ]),
+      );
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows.length).toBeLessThanOrEqual(50);
+    });
+  },
+);

--- a/packages/core/src/schema/schema-path-parity.test.ts
+++ b/packages/core/src/schema/schema-path-parity.test.ts
@@ -180,6 +180,34 @@ function buildFixtureManifest(): SmartObjectManifest {
     ),
   );
 
+  // Polymorphic-association-shaped CTI (#2364, epic #2382 finding A3):
+  // `SmrtPolymorphicAssociation` merges `metaType`/`metaId`/`role`/
+  // `sortOrder` into a concrete subclass's manifest (the abstract base
+  // carries no `@smrt()` decorator of its own to declare an index on — see
+  // `AssetAssociation` in smrt-assets for the real shape this mirrors). The
+  // conflict key leads with the class's own FK, so `meta_type`/`meta_id` sit
+  // in the middle of that unique index — an owner lookup like
+  // `AssetAssociationCollection.byLeft(metaType, metaId)` ("what points at
+  // this target") filters columns 2-3 of a 4-column index and needs its own
+  // composite.
+  add(
+    objectDef(
+      'ParityAssociation',
+      {
+        ownerId: {
+          type: 'foreignKey',
+          related: 'ParityAuthor',
+          required: true,
+        },
+        metaType: { type: 'text', required: true },
+        metaId: { type: 'text', required: true },
+        role: { type: 'text', required: true, default: 'default' },
+        sortOrder: { type: 'integer', default: 0 },
+      },
+      { conflictColumns: ['owner_id', 'meta_type', 'meta_id', 'role'] },
+    ),
+  );
+
   // Self-referencing FK.
   add(
     objectDef('ParityNode', {
@@ -520,6 +548,7 @@ describe('schema path parity (#2359)', () => {
     'parity_scopeds',
     'parity_covereds',
     'parity_links',
+    'parity_associations',
     'parity_nodes',
     'parity_reports',
     'parity_content_contribution_revisions',
@@ -539,6 +568,7 @@ describe('schema path parity (#2359)', () => {
     parity_scopeds: 'ParityScoped',
     parity_covereds: 'ParityCovered',
     parity_links: 'ParityLink',
+    parity_associations: 'ParityAssociation',
     parity_nodes: 'ParityNode',
     parity_reports: 'ParityReport',
     parity_content_contribution_revisions: 'ParityContentContributionRevision',
@@ -827,6 +857,41 @@ describe('schema path parity (#2359)', () => {
         'parity_links_left_id_right_id_idx',
         'parity_links_right_id_idx',
         'parity_links_slug_context_idx',
+      ]);
+    });
+
+    it('polymorphic-association-shaped conflict key: owner lookup (meta_type, meta_id) indexed despite sitting mid-index (#2364, A3)', () => {
+      // The conflict index NAME is shortened to its first two columns
+      // (generator convention, #2359 review) but its `columns` still cover
+      // the full 4-column key — asserted separately below.
+      expect(names('parity_associations')).toEqual([
+        'parity_associations_created_at_idx',
+        'parity_associations_meta_type_meta_id_idx',
+        'parity_associations_owner_id_meta_type_idx',
+        'parity_associations_slug_context_idx',
+      ]);
+      // The leading owner_id FK is already served by the conflict index
+      // (position 0), so no redundant standalone `owner_id_idx` (mirrors the
+      // junction-shaped case above).
+      expect(names('parity_associations')).not.toContain(
+        'parity_associations_owner_id_idx',
+      );
+      expect(
+        idx('parity_associations').find(
+          (i) => i.name === 'parity_associations_meta_type_meta_id_idx',
+        )?.columns,
+      ).toEqual(['meta_type', 'meta_id']);
+      // The 4-column conflict index leads with owner_id, not meta_type — it
+      // does not serve the owner lookup as a prefix, so both indexes coexist.
+      const conflictIndex = idx('parity_associations').find(
+        (i) => i.name === 'parity_associations_owner_id_meta_type_idx',
+      );
+      expect(conflictIndex?.unique).toBe(true);
+      expect(conflictIndex?.columns).toEqual([
+        'owner_id',
+        'meta_type',
+        'meta_id',
+        'role',
       ]);
     });
 

--- a/packages/jobs/src/__tests__/issue-2364-hot-predicate-indexes.test.ts
+++ b/packages/jobs/src/__tests__/issue-2364-hot-predicate-indexes.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Issue #2364 (epic #2382, finding A3) — hot predicate indexes reach the
+ * PRODUCTION manifest schema path for the real shipped classes.
+ *
+ * `createIsolatedTestDbFromManifest()` with no explicit path auto-detects
+ * this package's own freshly-generated manifest (`dist/manifest.json` /
+ * `.smrt/manifest.json`) and renders tables + indexes through the same
+ * structured-schema renderer `smrt db:migrate` uses (#2358) — so this proves
+ * the declared indexes are actually emitted for `SmrtJob` and `ForgeDelivery`
+ * as shipped, not just the schema generator's synthetic fixtures in
+ * `@happyvertical/smrt-core`'s `schema-path-parity.test.ts`.
+ */
+
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+type Row = Record<string, unknown>;
+
+async function rows(db: DatabaseInterface, sql: string): Promise<Row[]> {
+  const result = await db.query(sql);
+  return Array.isArray(result)
+    ? (result as Row[])
+    : ((result as { rows?: Row[] }).rows ?? []);
+}
+
+async function indexNames(
+  db: DatabaseInterface,
+  tableName: string,
+): Promise<string[]> {
+  const result = await rows(
+    db,
+    `SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = '${tableName}'`,
+  );
+  return result.map((row) => String(row.name));
+}
+
+describe('hot predicate indexes reach the production manifest schema path (#2364)', () => {
+  let baseDb: DatabaseInterface;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ baseDb, cleanup } = await createIsolatedTestDbFromManifest({
+      includeObjects: ['SmrtJob', 'ForgeDelivery'],
+    }));
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it('indexes the claim-loop predicate on `_smrt_jobs`: the (status, run_at) composite plus both single columns', async () => {
+    const names = await indexNames(baseDb, '_smrt_jobs');
+    // Composite for the WHERE clause `claimReady()`/`listReady()` poll ~1s.
+    expect(names).toContain('_smrt_jobs_status_run_at_idx');
+    // Single-column parts, per issue #2364's scope.
+    expect(names).toContain('_smrt_jobs_status_idx');
+    expect(names).toContain('_smrt_jobs_run_at_idx');
+  });
+
+  it('indexes both OR-branches of the forge-delivery claim predicate on `_smrt_forge_deliveries`', async () => {
+    const names = await indexNames(baseDb, '_smrt_forge_deliveries');
+    // `claimReady()`: (status IN ('pending','retry') AND next_attempt_at <= ?)
+    expect(names).toContain(
+      '_smrt_forge_deliveries_status_next_attempt_at_idx',
+    );
+    // `claimReady()`/the expired-lease sweep: (status = 'leased' AND lease_expires_at < ?)
+    expect(names).toContain(
+      '_smrt_forge_deliveries_status_lease_expires_at_idx',
+    );
+  });
+});

--- a/packages/jobs/src/forge-projection.ts
+++ b/packages/jobs/src/forge-projection.ts
@@ -105,6 +105,24 @@ export type ForgeProjectionAuditHook = (
   api: false,
   cli: false,
   mcp: false,
+  // `claimReady()` scans two OR-branches every poll (#2364, epic #2382
+  // finding A3): `status IN ('pending','retry') AND next_attempt_at <= ?`
+  // (the common ready-to-run case) and `status = 'leased' AND
+  // lease_expires_at < ?` (reclaiming an expired lease — also the predicate
+  // of the lease-expiry-to-dead_letter sweep above it in the same method).
+  // Neither branch is a prefix of the other, so both composites are
+  // declared; PostgreSQL can combine them with a BitmapOr when planning the
+  // OR.
+  indexes: [
+    {
+      name: '_smrt_forge_deliveries_status_next_attempt_at_idx',
+      columns: ['status', 'nextAttemptAt'],
+    },
+    {
+      name: '_smrt_forge_deliveries_status_lease_expires_at_idx',
+      columns: ['status', 'leaseExpiresAt'],
+    },
+  ],
 })
 @TenantScoped({ mode: 'required' })
 export class ForgeDelivery extends SmrtObject {

--- a/packages/jobs/src/forge-projection.ts
+++ b/packages/jobs/src/forge-projection.ts
@@ -112,7 +112,8 @@ export type ForgeProjectionAuditHook = (
   // of the lease-expiry-to-dead_letter sweep above it in the same method).
   // Neither branch is a prefix of the other, so both composites are
   // declared; PostgreSQL can combine them with a BitmapOr when planning the
-  // OR.
+  // OR. Roll this out with `smrt db:migrate --postgres-safe` (#2362), same
+  // as `_smrt_jobs` above — deliveries are claimed continuously too.
   indexes: [
     {
       name: '_smrt_forge_deliveries_status_next_attempt_at_idx',

--- a/packages/jobs/src/smrt-job.ts
+++ b/packages/jobs/src/smrt-job.ts
@@ -62,6 +62,18 @@ export type TimeoutBehavior = 'fail' | 'kill' | 'warn';
     http: false,
   },
   mcp: false,
+  // Composite for the claim-loop predicate every runner polls roughly once
+  // per second (`claimReady()`/`listReady()`: `status = 'pending' AND
+  // run_at <= ?`, #2364, epic #2382 finding A3). Declared here rather than
+  // left to the jobs-compat path (`ensureJobsSystemTableCompatibility()`,
+  // #2375/#2376): that path exists to reshape a table that predates the
+  // column/index it adds on databases where the manifest hasn't migrated
+  // yet, not as the default route for new indexes on a normal decorated
+  // class — this one reaches every path (manifest, registry, `db:migrate`)
+  // the standard way and rolls out on the next `smrt db:migrate`.
+  indexes: [
+    { name: '_smrt_jobs_status_run_at_idx', columns: ['status', 'runAt'] },
+  ],
 })
 // Keep the data model tenant-scoped (defense in depth): even without a generated
 // read route, the @tenantId() field alone does NOT make collection reads filter
@@ -93,16 +105,30 @@ export class SmrtJob extends SmrtObject {
   @field({ type: 'json' })
   args: Record<string, unknown> = {};
 
-  /** When to run the job */
-  @field({ type: 'datetime', required: true })
+  /**
+   * When to run the job.
+   *
+   * Indexed (single-column, plus the class-level `(status, run_at)`
+   * composite): the claim-loop predicate every runner polls roughly once per
+   * second (#2364).
+   */
+  @field({ type: 'datetime', required: true, indexed: true })
   runAt: Date = new Date();
 
   /** Priority (higher = sooner) */
   @field({ type: 'integer', required: true, default: 50 })
   priority: number = 50;
 
-  /** Current status */
-  @field({ type: 'text', required: true, default: 'pending' })
+  /**
+   * Current status.
+   *
+   * Indexed (single-column, plus the class-level `(status, run_at)`
+   * composite): the claim-loop predicate every runner polls roughly once per
+   * second (#2364). `(status, completed_at)` — the retention cleanup
+   * predicate — is a separate index from `ensureJobsSystemTableCompatibility()`
+   * (#2375).
+   */
+  @field({ type: 'text', required: true, default: 'pending', indexed: true })
   status: JobStatus = 'pending';
 
   /** Number of execution attempts */

--- a/packages/jobs/src/smrt-job.ts
+++ b/packages/jobs/src/smrt-job.ts
@@ -71,6 +71,11 @@ export type TimeoutBehavior = 'fail' | 'kill' | 'warn';
   // yet, not as the default route for new indexes on a normal decorated
   // class — this one reaches every path (manifest, registry, `db:migrate`)
   // the standard way and rolls out on the next `smrt db:migrate`.
+  //
+  // Roll this out with `smrt db:migrate --postgres-safe` (#2362): `_smrt_jobs`
+  // is under continuous write load (every claim is an UPDATE), so a plain
+  // atomic `CREATE INDEX` would hold ACCESS EXCLUSIVE for the build and stall
+  // claiming on a busy deployment.
   indexes: [
     { name: '_smrt_jobs_status_run_at_idx', columns: ['status', 'runAt'] },
   ],

--- a/packages/profiles/src/__tests__/issue-2364-hot-predicate-indexes.test.ts
+++ b/packages/profiles/src/__tests__/issue-2364-hot-predicate-indexes.test.ts
@@ -53,12 +53,12 @@ describe('auth lookup indexes reach the production manifest schema path (#2364)'
     expect(names).toContain('magic_link_tokens_token_hash_idx');
   });
 
-  it('indexes `nostr_identities.pubkey` — `NostrIdentity.findByPubkey()`s lookup key', async () => {
+  it("indexes `nostr_identities.pubkey` — `NostrIdentity.findByPubkey()`'s lookup key", async () => {
     const names = await indexNames(baseDb, 'nostr_identities');
     expect(names).toContain('nostr_identities_pubkey_idx');
   });
 
-  it('indexes `api_keys.key_hash` — `ApiKey.verify()`s lookup key', async () => {
+  it("indexes `api_keys.key_hash` — `ApiKey.verify()`'s lookup key", async () => {
     const names = await indexNames(baseDb, 'api_keys');
     expect(names).toContain('api_keys_key_hash_idx');
   });

--- a/packages/profiles/src/__tests__/issue-2364-hot-predicate-indexes.test.ts
+++ b/packages/profiles/src/__tests__/issue-2364-hot-predicate-indexes.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Issue #2364 (epic #2382, finding A3) — auth lookup columns indexed on the
+ * PRODUCTION manifest schema path.
+ *
+ * `createIsolatedTestDbFromManifest()` with no explicit path auto-detects
+ * this package's own freshly-generated manifest and renders tables + indexes
+ * through the same structured-schema renderer `smrt db:migrate` uses (#2358)
+ * — so this proves the `indexed: true` opt-ins are actually emitted for the
+ * real shipped classes, not just the schema generator's synthetic fixtures in
+ * `@happyvertical/smrt-core`'s `schema-path-parity.test.ts`.
+ */
+
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+type Row = Record<string, unknown>;
+
+async function rows(db: DatabaseInterface, sql: string): Promise<Row[]> {
+  const result = await db.query(sql);
+  return Array.isArray(result)
+    ? (result as Row[])
+    : ((result as { rows?: Row[] }).rows ?? []);
+}
+
+async function indexNames(
+  db: DatabaseInterface,
+  tableName: string,
+): Promise<string[]> {
+  const result = await rows(
+    db,
+    `SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = '${tableName}'`,
+  );
+  return result.map((row) => String(row.name));
+}
+
+describe('auth lookup indexes reach the production manifest schema path (#2364)', () => {
+  let baseDb: DatabaseInterface;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ baseDb, cleanup } = await createIsolatedTestDbFromManifest({
+      includeObjects: ['MagicLinkToken', 'NostrIdentity', 'ApiKey'],
+    }));
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it('indexes `magic_link_tokens.token_hash` — `MagicLinkToken.verify()`s lookup key', async () => {
+    const names = await indexNames(baseDb, 'magic_link_tokens');
+    expect(names).toContain('magic_link_tokens_token_hash_idx');
+  });
+
+  it('indexes `nostr_identities.pubkey` — `NostrIdentity.findByPubkey()`s lookup key', async () => {
+    const names = await indexNames(baseDb, 'nostr_identities');
+    expect(names).toContain('nostr_identities_pubkey_idx');
+  });
+
+  it('indexes `api_keys.key_hash` — `ApiKey.verify()`s lookup key', async () => {
+    const names = await indexNames(baseDb, 'api_keys');
+    expect(names).toContain('api_keys_key_hash_idx');
+  });
+});

--- a/packages/profiles/src/models/ApiKey.ts
+++ b/packages/profiles/src/models/ApiKey.ts
@@ -7,6 +7,7 @@
 
 import { createHash, randomBytes } from 'node:crypto';
 import {
+  field,
   foreignKey,
   SmrtObject,
   type SmrtObjectOptions,
@@ -42,8 +43,12 @@ export class ApiKey extends SmrtObject {
   profileId?: string;
 
   /**
-   * SHA-256 hash of the API key
+   * SHA-256 hash of the API key.
+   *
+   * Indexed: `verify()` looks keys up by this hash on every authenticated
+   * request (#2364, epic #2382 finding A3).
    */
+  @field({ indexed: true })
   keyHash: string = '';
 
   /**

--- a/packages/profiles/src/models/MagicLinkToken.ts
+++ b/packages/profiles/src/models/MagicLinkToken.ts
@@ -7,6 +7,7 @@
 
 import { createHash, randomBytes } from 'node:crypto';
 import {
+  field,
   foreignKey,
   SmrtObject,
   type SmrtObjectOptions,
@@ -48,8 +49,12 @@ export class MagicLinkToken extends SmrtObject {
   nostrIdentityId?: string;
 
   /**
-   * SHA-256 hash of the token (never store plaintext)
+   * SHA-256 hash of the token (never store plaintext).
+   *
+   * Indexed: `verify()` looks tokens up by this hash on every magic-link
+   * click (#2364, epic #2382 finding A3).
    */
+  @field({ indexed: true })
   tokenHash: string = '';
 
   /**

--- a/packages/profiles/src/models/NostrIdentity.ts
+++ b/packages/profiles/src/models/NostrIdentity.ts
@@ -7,6 +7,7 @@
  */
 
 import {
+  field,
   foreignKey,
   SmrtObject,
   type SmrtObjectOptions,
@@ -46,8 +47,12 @@ export class NostrIdentity extends SmrtObject {
   profileId?: string;
 
   /**
-   * Hex-encoded secp256k1 public key (64 characters)
+   * Hex-encoded secp256k1 public key (64 characters).
+   *
+   * Indexed: `findByPubkey()` looks identities up by this column (#2364,
+   * epic #2382 finding A3).
    */
+  @field({ indexed: true })
   pubkey: string = '';
 
   /**

--- a/packages/users/src/__tests__/issue-2364-hot-predicate-indexes.test.ts
+++ b/packages/users/src/__tests__/issue-2364-hot-predicate-indexes.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Issue #2364 (epic #2382, finding A3) — read-path lookup columns indexed on
+ * the PRODUCTION manifest schema path.
+ *
+ * `createIsolatedTestDbFromManifest()` with no explicit path auto-detects
+ * this package's own freshly-generated manifest and renders tables + indexes
+ * through the same structured-schema renderer `smrt db:migrate` uses (#2358)
+ * — so this proves the `indexed: true` opt-ins are actually emitted for the
+ * real shipped classes, not just the schema generator's synthetic fixtures in
+ * `@happyvertical/smrt-core`'s `schema-path-parity.test.ts`.
+ */
+
+import { createIsolatedTestDbFromManifest } from '@happyvertical/smrt-vitest';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+type Row = Record<string, unknown>;
+
+async function rows(db: DatabaseInterface, sql: string): Promise<Row[]> {
+  const result = await db.query(sql);
+  return Array.isArray(result)
+    ? (result as Row[])
+    : ((result as { rows?: Row[] }).rows ?? []);
+}
+
+async function indexNames(
+  db: DatabaseInterface,
+  tableName: string,
+): Promise<string[]> {
+  const result = await rows(
+    db,
+    `SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = '${tableName}'`,
+  );
+  return result.map((row) => String(row.name));
+}
+
+describe('read-path lookup indexes reach the production manifest schema path (#2364)', () => {
+  let baseDb: DatabaseInterface;
+  let cleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    ({ baseDb, cleanup } = await createIsolatedTestDbFromManifest({
+      includeObjects: ['User', 'UsersCliAuthRequest'],
+    }));
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  it('indexes `users.email` — `findByEmail()`s raw lookup column, distinct from the `email_key` uniqueness constraint', async () => {
+    const names = await indexNames(baseDb, 'users');
+    expect(names).toContain('users_email_idx');
+  });
+
+  it('indexes the CLI device-code grant lookups on `users_cli_auth_requests`', async () => {
+    const names = await indexNames(baseDb, 'users_cli_auth_requests');
+    // `findByUserCode()` — the browser-side approval lookup.
+    expect(names).toContain('users_cli_auth_requests_user_code_idx');
+    // `findByDeviceCodeHash()` — the CLI's polling key.
+    expect(names).toContain('users_cli_auth_requests_device_code_hash_idx');
+  });
+});

--- a/packages/users/src/__tests__/issue-2364-hot-predicate-indexes.test.ts
+++ b/packages/users/src/__tests__/issue-2364-hot-predicate-indexes.test.ts
@@ -48,7 +48,7 @@ describe('read-path lookup indexes reach the production manifest schema path (#2
     await cleanup();
   });
 
-  it('indexes `users.email` — `findByEmail()`s raw lookup column, distinct from the `email_key` uniqueness constraint', async () => {
+  it("indexes `users.email` — `findByEmail()`'s raw lookup column, distinct from the `email_key` uniqueness constraint", async () => {
     const names = await indexNames(baseDb, 'users');
     expect(names).toContain('users_email_idx');
   });

--- a/packages/users/src/models/CliAuthRequest.ts
+++ b/packages/users/src/models/CliAuthRequest.ts
@@ -25,12 +25,22 @@ export type CliAuthRequestStatus = 'pending' | 'approved' | 'expired';
   mcp: { include: [] },
 })
 export class UsersCliAuthRequest extends SmrtObject {
-  /** Short, human-typeable code the user enters in the browser to approve the session. */
-  @field({ type: 'text' })
+  /**
+   * Short, human-typeable code the user enters in the browser to approve the session.
+   *
+   * Indexed: `findByUserCode()` looks requests up by this column (#2364,
+   * epic #2382 finding A3).
+   */
+  @field({ type: 'text', indexed: true })
   userCode = '';
 
-  /** SHA-256 hash of the long device code the CLI keeps secret. */
-  @field({ type: 'text' })
+  /**
+   * SHA-256 hash of the long device code the CLI keeps secret.
+   *
+   * Indexed: `findByDeviceCodeHash()` — the CLI's poll loop — looks requests
+   * up by this column (#2364, epic #2382 finding A3).
+   */
+  @field({ type: 'text', indexed: true })
   deviceCodeHash = '';
 
   /** Lifecycle state — `pending` → `approved` | `expired`. */

--- a/packages/users/src/models/User.ts
+++ b/packages/users/src/models/User.ts
@@ -81,8 +81,15 @@ export class User extends SmrtObject implements UserContract {
   profileId: string = '';
 
   /**
-   * User's email address (unique, used for lookup)
+   * User's email address (unique, used for lookup).
+   *
+   * Indexed: `findByEmail()` filters on this raw column directly (#2364,
+   * epic #2382 finding A3). Distinct from `emailKey`'s unique index below —
+   * `emailKey` is a separately normalized column (`normalizeIdentityEmail()`)
+   * that arbitrates cross-connection uniqueness, and its index does not serve
+   * a read path that filters on `email` itself.
    */
+  @field({ indexed: true })
   email: string = '';
 
   /** Durable normalized key for cross-connection email uniqueness. */


### PR DESCRIPTION
## Summary

Closes #2364 (epic #2382, finding A3). Indexes the hot poll and auth-lookup
predicates identified by the 2026-08-17 database-layer assessment.

**Indexed:**
- `_smrt_jobs (status, run_at)` — the claim-loop predicate `claimReady()`/
  `listReady()` poll every ~1s per runner. Composite plus `indexed: true` on
  both columns individually.
- `_smrt_forge_deliveries` — two composites, one per OR-branch of
  `claimReady()`'s WHERE clause: `(status, next_attempt_at)` (ready-to-run)
  and `(status, lease_expires_at)` (expired-lease reclaim).
- `_smrt_agent_schedules (enabled, status, next_run)` — `ScheduleRunner.poll()`,
  every 60s.
- `magic_link_tokens.token_hash` — `MagicLinkToken.verify()`'s lookup.
- `users.email` — `findByEmail()`'s raw lookup column, distinct from
  `email_key`'s separate normalized-uniqueness index.
- `users_cli_auth_requests.user_code` / `.device_code_hash` — the device-code
  grant flow's two lookups.
- `nostr_identities.pubkey`, `api_keys.key_hash` — named in the issue's
  Change section alongside `magic_link_tokens.token_hash`; same pattern, same
  package, low cost to close out with the rest of the auth-lookup sweep.

**Core generator rule — polymorphic association owner lookup:**
`SmrtPolymorphicAssociation` contributes `metaType`/`metaId`/`role` to a
concrete subclass's manifest (e.g. `AssetAssociation`), but the abstract base
carries no `@smrt()` decorator to hang a declared index on, and the class's
own conflict key leads with its own FK — `meta_type`/`meta_id` sit in the
middle of that index. A lookup like `AssetAssociationCollection.byLeft
(metaType, metaId)` ("what points at this target") therefore had no serving
index. Added `ensurePolymorphicAssociationIndex()` to `SchemaGenerator`,
detected structurally with the same three-field test `cascade.ts`'s
`isPolymorphicAssociationClass` already uses, so it applies to every current
and future `SmrtPolymorphicAssociation` subclass with zero per-package
changes. Runs on all five schema-generation entry points, ahead of the
reference-column pass, alongside the #2363 default-ordering rule.

**Junction `byRight()` needed no change.** The issue's evidence
(`content_assets`, `event_participants`, `fact_contents`) all have their
right-side column typed `@foreignKey`/`@crossPackageRef`, not leading the
class's conflict index — exactly the shape #2359's reference-column indexing
already covers. Verified against the *pre-existing* `ParityLink` fixture in
`schema-path-parity.test.ts` (`junction-shaped conflict key: leading FK
suppressed, trailing FK indexed` → asserts `parity_links_right_id_idx`
already exists on every path) and confirmed by inspecting all three real
models — none required a code change. This is the "check current source
before assuming the finding is still accurate" case the epic's coordination
notes called out for `users.email`; it turned out to also apply here.

## Validation

Every declared/opted-in index is proven emitted on the **production manifest
schema path**, not just declared:

- New fixture (`ParityAssociation`) in `packages/core/src/schema/schema-path-parity.test.ts`
  proves the polymorphic-association composite on manifest STI, manifest
  CTI, and registry paths.
- Per-package tests (`createIsolatedTestDbFromManifest()`, no explicit
  path — auto-detects each package's own freshly generated manifest) prove
  the real shipped classes: `packages/jobs/src/__tests__/issue-2364-hot-predicate-indexes.test.ts`
  (`SmrtJob`, `ForgeDelivery`), `packages/agents/src/issue-2364-hot-predicate-index.test.ts`
  (`AgentSchedule`), `packages/profiles/src/__tests__/issue-2364-hot-predicate-indexes.test.ts`
  (`MagicLinkToken`, `NostrIdentity`, `ApiKey`),
  `packages/users/src/__tests__/issue-2364-hot-predicate-indexes.test.ts`
  (`User`, `UsersCliAuthRequest`).
- `packages/core/src/schema/issue-2364-jobs-claim-index-postgres.optional.test.ts`
  (new, PostgreSQL-lane): builds the claim-predicate table shape through
  `SchemaGenerator` directly (mirroring `issue-2363-list-ordering-index-postgres
  .optional.test.ts`'s approach, since `smrt-core` cannot depend on
  `smrt-jobs`), seeds 10k rows across every job status, and `EXPLAIN`s the
  real `claimReady()` candidate-select — asserts an Index Scan using the new
  index, never a Seq Scan. Run locally against a fresh `postgres:17-alpine`
  container (not just skipped): passes.

Full suites, not just touched files:
- `packages/core` `pnpm test`: 291 files / 3879 tests passed, 0 failed
  (104 skipped are `*.optional.test.ts` PostgreSQL-lane files).
- `packages/jobs` `pnpm test`: 21 files / 141 tests passed, 0 failed.
- `packages/agents` `pnpm test`: 25 files / 246 tests passed, 0 failed.
- `packages/profiles` `pnpm test`: 18 files / 218 tests passed, 0 failed.
- `packages/users` `pnpm test`: 31 files / 464 tests passed, 0 failed (24
  skipped).
- `pnpm typecheck`: clean on core, jobs, agents, profiles, users.
- `npx biome check`: clean on every touched/new file.
- `pnpm smrt dev:knowledge-check`: fresh, 0 errors (15 pre-existing `.smrt/`
  local-cache staleness warnings, unrelated to this change).
- `packages/core` `test:postgres` (`optional.test.ts` filter) against a local
  `postgres:17-alpine` container: the new #2364 test plus the pre-existing
  #2363/#2374/#2362 PG-lane tests all green.
- Rebuilt `core`, `jobs`, `agents`, `profiles`, `users` before pushing;
  checked built `dist/**/*.d.ts` for paths escaping `dist/` (none — no new
  cross-package import edges).

`packages/cli`: no CLI-auth code lives there (it's `UsersCliAuthRequest` in
`packages/users`); no changes needed, so its suite wasn't run.

## Deployment

**Roll this out with `smrt db:migrate --postgres-safe`** (concurrent-index
mode, #2362), not a plain atomic `db:migrate` — same requirement #2359/#2360/
#2363 documented for their index waves, and it applies with extra weight
here:

- `_smrt_jobs` is under continuous write load — every `claimReady()` claim is
  an `UPDATE`. A plain atomic batch takes an ACCESS EXCLUSIVE lock for the
  `CREATE INDEX` on `(status, run_at)`, which would stall job claiming for the
  build duration on a busy deployment. `--postgres-safe` builds it
  `CONCURRENTLY` instead.
- `ensurePolymorphicAssociationIndex()` (the new core generator rule) widens
  the blast radius beyond the models this PR touches: on the next
  `db:migrate`, **every** `SmrtPolymorphicAssociation` subclass across every
  package that hasn't already got an unqualified index leading with
  `(meta_type, meta_id)` picks up the new composite — not just the ones
  edited here.

## Coordination

`packages/jobs/src/system/compatibility.ts`'s `ensureJobsSystemTableCompatibility()`
(#2375/#2376's jobs-compat path) was read but not extended — it exists to
retrofit legacy `_smrt_jobs` tables predating a column/index on databases
where the manifest hasn't migrated yet, not as the default route for a new
performance index on a normal decorated class. The `(status, run_at)`
composite here goes through the standard `@smrt({ indexes })` declaration, so
it reaches every schema path the ordinary way and rolls out on the next
`smrt db:migrate`, same as every other index this epic has added.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"claude","session":"2e828b4a-bf86-463b-8159-3ee4e9f1275f","issue":2364,"policy_revision":"1.0.0","status":"complete","validation":["packages/core pnpm test: 291 files / 3879 tests passed","packages/jobs pnpm test: 21 files / 141 tests passed","packages/agents pnpm test: 25 files / 246 tests passed","packages/profiles pnpm test: 18 files / 218 tests passed","packages/users pnpm test: 31 files / 464 tests passed","pnpm typecheck: clean on core/jobs/agents/profiles/users","npx biome check: clean on every touched file","pnpm smrt dev:knowledge-check: fresh, 0 errors","packages/core test:postgres against postgres:17-alpine: green, including new EXPLAIN index-scan proof"]}
```

