### PR TITLE
feat(migrations): add explicit int8 widening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,10 @@ the Vite plugin consumes deterministic `dist/` artifacts.
 - Runtime only checks that a table exists — no column, type, or index check —
   and never creates application tables; use explicit migrations/tooling, and
   `smrt doctor --db` / `db:status --parity` to compare a live database.
+- Fresh PostgreSQL/DuckDB `INTEGER` columns materialize as BIGINT. Existing
+  int4 deployments require the explicit, maintenance-window-only
+  `smrt db:migrate-int8` flow; parity reports it as an advisory because the
+  normal differ intentionally treats int4 and int8 as equivalent (#2424).
 - Vite 8 decorators require the repository's documented Oxc legacy decorator
   configuration; do not restore obsolete Vite 7 workarounds.
 - Svelte subpath packages must run `svelte-check`, not only `tsc`.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -14,6 +14,7 @@ smrt db:migrate              # Apply migrations
 smrt db:migrate --postgres-safe # PostgreSQL concurrent-index mode (see below)
 smrt db:migrate --force-migration <exact-id> [--force-migration <exact-id>...] # Force exact generated migrations in one atomic batch
 smrt db:migrate-uuid         # Convert schema-declared UUID text columns after data remap
+smrt db:migrate-int8         # Explicitly widen pre-#2373 int4 columns after preflight
 smrt db:diff                 # Show schema differences without generating migration files
 smrt db:rollback             # Roll back migrations by executing their recorded DOWN
 smrt db:rollback --mark-only # Record-only flip; schema deliberately untouched
@@ -95,6 +96,10 @@ not from the schema definition.
   (`indexIntrospection: 'unavailable'`) rather than inventing missing indexes.
 - The check is read-only and lives in a new core module; it does not share code
   with `migrations/differ.ts`.
+- PostgreSQL/DuckDB `int4` columns created before #2373 are advisory warnings,
+  not type drift: the differ intentionally treats int4/int8 as equivalent.
+  Run `smrt db:migrate-int8 --dry-run`, schedule the reported table rewrites,
+  then run `smrt db:migrate-int8`; SQLite is already 64-bit and is a no-op.
 
 ## `db:migrate` on SQLite: type changes rebuild the table
 

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -100,6 +100,8 @@ not from the schema definition.
   not type drift: the differ intentionally treats int4/int8 as equivalent.
   Run `smrt db:migrate-int8 --dry-run`, schedule the reported table rewrites,
   then run `smrt db:migrate-int8`; SQLite is already 64-bit and is a no-op.
+  PostgreSQL uses the same bounded `migrations.postgres.lockTimeout` and
+  `statementTimeout` settings as ordinary schema migration.
 
 ## `db:migrate` on SQLite: type changes rebuild the table
 

--- a/packages/cli/src/commands/__tests__/db-migrate-uuid-handler.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-uuid-handler.test.ts
@@ -2,6 +2,7 @@ import { rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { clearCache, setConfig } from '@happyvertical/smrt-config';
+import { ObjectRegistry } from '@happyvertical/smrt-core';
 import { getDatabase } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -13,6 +14,7 @@ vi.mock('../../discovery/index.js', () => ({
   autoDiscoverAndLoad: autoDiscoverAndLoadMock,
 }));
 
+import { dbMigrateInt8Command } from '../db-migrate-int8.js';
 import { dbMigrateUuidCommand } from '../db-migrate-uuid.js';
 
 /**
@@ -109,6 +111,26 @@ describe('db:migrate-uuid handler (real SQLite, non-Postgres branches)', () => {
     await dbMigrateUuidCommand.handler([], {});
 
     expect(output()).toContain('no native uuid column type');
+  });
+
+  it('reports integer-width widening as a SQLite no-op without recording a marker', async () => {
+    vi.spyOn(ObjectRegistry, 'getAllSchemasAsDefinitions').mockReturnValue({
+      things: {
+        tableName: 'things',
+        columns: { attempts: { type: 'INTEGER' } },
+        indexes: [],
+        triggers: [],
+        foreignKeys: [],
+        dependencies: [],
+        version: '1.0.0',
+      },
+    } as never);
+
+    await dbMigrateInt8Command.handler([], { 'dry-run': true });
+
+    expect(output()).toContain('not applicable');
+    expect(output()).toContain('No widening is needed on this engine');
+    expect(errorOutput()).toBe('');
   });
 
   it('backfills an R3 rename and drops the old column on SQLite', async () => {

--- a/packages/cli/src/commands/__tests__/db-migrate-uuid.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-uuid.test.ts
@@ -2,6 +2,7 @@ import { clearCache, setConfig } from '@happyvertical/smrt-config';
 import { ObjectRegistry } from '@happyvertical/smrt-core';
 import { getDatabase } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbMigrateInt8Command } from '../db-migrate-int8.js';
 import {
   buildDeclaredUuidColumnSet,
   dbMigrateUuidCommand,
@@ -180,6 +181,15 @@ describe('db:migrate-uuid command', () => {
         'id',
       ]);
     });
+  });
+});
+
+describe('db:migrate-int8 command', () => {
+  it('is registered with a dry-run maintenance-window option', () => {
+    expect(utilityCommands['db:migrate-int8']).toBe(dbMigrateInt8Command);
+    expect(dbMigrateInt8Command.name).toBe('db:migrate-int8');
+    expect(dbMigrateInt8Command.aliases).toContain('migrate-int8');
+    expect(dbMigrateInt8Command.options?.['dry-run']).toBeDefined();
   });
 });
 

--- a/packages/cli/src/commands/db-migrate-int8.ts
+++ b/packages/cli/src/commands/db-migrate-int8.ts
@@ -1,0 +1,161 @@
+/**
+ * db:migrate-int8 Command
+ *
+ * Explicitly widens legacy PostgreSQL/DuckDB int4 columns created before
+ * #2373. This is deliberately separate from `db:migrate`: PostgreSQL rewrites
+ * each table, so an operator must review the row-count preflight and schedule
+ * a maintenance window before opting in.
+ */
+
+import { ObjectRegistry } from '@happyvertical/smrt-core';
+import {
+  buildIntegerWidthStatements,
+  collectIntegerWidthTargets,
+  preflightIntegerWidthWidening,
+  widenIntegerColumnsToBigInt,
+} from '@happyvertical/smrt-core/migrations';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import type { CLICommand } from '../cli-generator.js';
+import { autoDiscoverAndLoad } from '../discovery/index.js';
+import {
+  closeDatabaseConnection,
+  formatDatabaseDisplayUrl,
+} from './db-command-utils.js';
+
+interface DbMigrateInt8Options {
+  'dry-run'?: boolean;
+  verbose?: boolean;
+}
+
+const BACKFILL_NAME = '@happyvertical/smrt-core:integer-width:v1';
+
+export const dbMigrateInt8Command: CLICommand = {
+  name: 'db:migrate-int8',
+  description:
+    'Widen legacy SMRT int4 columns to BIGINT after reviewing the maintenance-window preflight. Run after db:migrate.',
+  aliases: ['migrate-int8', 'db-migrate-int8'],
+  args: [],
+  options: {
+    'dry-run': {
+      type: 'boolean',
+      description: 'Print the preflight and ALTER statements without writing.',
+      default: false,
+    },
+    verbose: {
+      type: 'boolean',
+      description: 'Print the full per-table preflight report.',
+      default: false,
+      short: 'v',
+    },
+  },
+  handler: async (_args: string[], options: DbMigrateInt8Options) => {
+    let db: DatabaseInterface | undefined;
+    const dryRun = Boolean(options['dry-run']);
+
+    try {
+      const { getPackageConfig } = await import('@happyvertical/smrt-config');
+      const { DEFAULT_CLI_CONFIG } = await import('../config.js');
+      const config = getPackageConfig('cli', DEFAULT_CLI_CONFIG);
+      if (!config.database?.url || config.database.url === ':memory:') {
+        throw new Error(
+          'Database configuration required for db:migrate-int8. Configure database.url in smrt.config.ts (or DATABASE_URL).',
+        );
+      }
+
+      // This is the same registry source ordinary schema migration uses. Do
+      // not guess from names: an incomplete manifest would record the global
+      // marker while leaving an owned legacy table behind.
+      await autoDiscoverAndLoad();
+      const schemas = ObjectRegistry.getAllSchemasAsDefinitions();
+      if (Object.keys(schemas).length === 0) {
+        throw new Error(
+          'No SMRT application schemas were discovered. Run this command from the project root after generating manifests.',
+        );
+      }
+
+      const dbType = config.database.type || 'sqlite';
+      const dbUrl = config.database.url;
+      const { getDatabase } = await import('@happyvertical/sql');
+      db = await getDatabase({ type: dbType, url: dbUrl });
+      console.log('\n↔️  Integer-width migration\n');
+      console.log(
+        `✓ Connected to ${formatDatabaseDisplayUrl(dbType, dbUrl)}\n`,
+      );
+
+      const targets = collectIntegerWidthTargets(schemas, {
+        includeSystemTables: true,
+      });
+      const preflight = await preflightIntegerWidthWidening(db, targets, {
+        engineHint: dbType,
+      });
+      console.log(preflight.summary);
+      if (options.verbose && preflight.supported) {
+        console.log('\nFull preflight report:');
+        for (const table of preflight.tables) {
+          const columns = table.columns
+            .map(
+              (column) =>
+                `${column.column}: ${column.declaredType ?? 'missing'} (${column.state})`,
+            )
+            .join(', ');
+          console.log(
+            `  ${table.table}: ${table.rowCount ?? 'not counted'} row(s); ${columns}`,
+          );
+        }
+      }
+
+      if (!preflight.supported) {
+        console.log('\nNo widening is needed on this engine.\n');
+        return;
+      }
+      if (preflight.unexpectedColumns > 0) {
+        throw new Error(
+          'Some schema-declared integer columns have unexpected live types. Resolve ordinary schema drift before this widening pass.',
+        );
+      }
+      if (preflight.pendingColumns === 0) {
+        console.log('\nNo legacy int4 columns remain.\n');
+        return;
+      }
+
+      const statements = preflight.tables.flatMap((table) =>
+        table.columns.flatMap((column) =>
+          column.state === 'pending'
+            ? buildIntegerWidthStatements(
+                preflight.engine,
+                table.table,
+                column.column,
+              )
+            : [],
+        ),
+      );
+      console.log(
+        `\n${dryRun ? 'DRY RUN — would execute' : 'Applying'} ${statements.length} lossless ALTER statement(s):`,
+      );
+      for (const statement of statements) console.log(`  ${statement};`);
+
+      if (dryRun) {
+        console.log('\nDry run complete — no changes applied.\n');
+        return;
+      }
+
+      const result = await widenIntegerColumnsToBigInt(db, targets, {
+        engineHint: dbType,
+        backfillName: BACKFILL_NAME,
+        packageName: '@happyvertical/smrt-core',
+      });
+      console.log(
+        result.ran
+          ? `\n✓ Widened ${result.widenedColumns.length} column(s) to BIGINT.\n`
+          : '\nNo widening was applied; this migration marker is already recorded.\n',
+      );
+    } catch (error) {
+      console.error(
+        `\n❌ int8 migration failed: ${error instanceof Error ? error.message : String(error)}\n`,
+      );
+      process.exitCode = 1;
+    } finally {
+      await closeDatabaseConnection(db);
+    }
+  },
+};

--- a/packages/cli/src/commands/db-migrate-int8.ts
+++ b/packages/cli/src/commands/db-migrate-int8.ts
@@ -9,8 +9,9 @@
 
 import { ObjectRegistry } from '@happyvertical/smrt-core';
 import {
-  buildIntegerWidthStatements,
+  buildIntegerWidthTableStatements,
   collectIntegerWidthTargets,
+  parsePostgresTimeoutMs,
   preflightIntegerWidthWidening,
   widenIntegerColumnsToBigInt,
 } from '@happyvertical/smrt-core/migrations';
@@ -28,6 +29,8 @@ interface DbMigrateInt8Options {
 }
 
 const BACKFILL_NAME = '@happyvertical/smrt-core:integer-width:v1';
+const DEFAULT_POSTGRES_LOCK_TIMEOUT_MS = 30_000;
+const DEFAULT_POSTGRES_STATEMENT_TIMEOUT_MS = 60_000;
 
 export const dbMigrateInt8Command: CLICommand = {
   name: 'db:migrate-int8',
@@ -63,8 +66,8 @@ export const dbMigrateInt8Command: CLICommand = {
       }
 
       // This is the same registry source ordinary schema migration uses. Do
-      // not guess from names: an incomplete manifest would record the global
-      // marker while leaving an owned legacy table behind.
+      // not guess targets from names; a later complete discovery safely
+      // widens any live int4 columns still pending.
       await autoDiscoverAndLoad();
       const schemas = ObjectRegistry.getAllSchemasAsDefinitions();
       if (Object.keys(schemas).length === 0) {
@@ -119,14 +122,12 @@ export const dbMigrateInt8Command: CLICommand = {
       }
 
       const statements = preflight.tables.flatMap((table) =>
-        table.columns.flatMap((column) =>
-          column.state === 'pending'
-            ? buildIntegerWidthStatements(
-                preflight.engine,
-                table.table,
-                column.column,
-              )
-            : [],
+        buildIntegerWidthTableStatements(
+          preflight.engine,
+          table.table,
+          table.columns
+            .filter((column) => column.state === 'pending')
+            .map((column) => column.column),
         ),
       );
       console.log(
@@ -139,15 +140,24 @@ export const dbMigrateInt8Command: CLICommand = {
         return;
       }
 
+      const postgresMigrationConfig = config.migrations?.postgres;
       const result = await widenIntegerColumnsToBigInt(db, targets, {
         engineHint: dbType,
         backfillName: BACKFILL_NAME,
         packageName: '@happyvertical/smrt-core',
+        lockTimeout: parsePostgresTimeoutMs(
+          postgresMigrationConfig?.lockTimeout,
+          DEFAULT_POSTGRES_LOCK_TIMEOUT_MS,
+        ),
+        statementTimeout: parsePostgresTimeoutMs(
+          postgresMigrationConfig?.statementTimeout,
+          DEFAULT_POSTGRES_STATEMENT_TIMEOUT_MS,
+        ),
       });
       console.log(
         result.ran
           ? `\n✓ Widened ${result.widenedColumns.length} column(s) to BIGINT.\n`
-          : '\nNo widening was applied; this migration marker is already recorded.\n',
+          : '\nNo widening was applied; no legacy int4 columns remain.\n',
       );
     } catch (error) {
       console.error(

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -43,6 +43,7 @@ import {
   shouldApplySchemaMigrations,
   shouldFailDbMigrate,
 } from './db-migrate-actions.js';
+import { dbMigrateInt8Command } from './db-migrate-int8.js';
 import { dbMigrateUuidCommand } from './db-migrate-uuid.js';
 import {
   formatParityReport,
@@ -2940,6 +2941,7 @@ export default testManifest;
   'db:rollback': dbRollbackCommand,
   'db:generate': dbGenerateCommand,
   'db:migrate-uuid': dbMigrateUuidCommand,
+  'db:migrate-int8': dbMigrateInt8Command,
   'db:prune': dbPruneCommand,
 
   // Configuration commands

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -39,10 +39,10 @@ import {
   fieldsFromClass,
   formatDataJs,
   toCamelCase,
+  toSafeInteger,
   toSnakeCase,
 } from './utils';
 import { chunkArray, IN_LIST_CHUNK_SIZE } from './utils/chunk';
-import { toSafeInteger } from './utils/safe-integer';
 
 const logger = createLogger({ level: 'info' });
 

--- a/packages/core/src/dispatch/bus.test.ts
+++ b/packages/core/src/dispatch/bus.test.ts
@@ -418,6 +418,22 @@ describe('DispatchSubscription Model', () => {
     expect(sub.matches('campaign.completed')).toBe(false);
   });
 
+  it('uses the system-table default for a nullable enabled flag', () => {
+    const sub = DispatchSubscription.fromRow({
+      id: 'subscription-null-enabled',
+      signal_type: 'campaign.*',
+      subscriber: 'fiscus',
+      handler: 'handleDispatch',
+      delivery: 'compete',
+      enabled: null,
+      tenant_id: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    expect(sub.enabled).toBe(true);
+  });
+
   it('should identify wildcards', () => {
     const exact = new DispatchSubscription({
       signal_type: 'test.event',

--- a/packages/core/src/dispatch/models/DispatchSubscription.ts
+++ b/packages/core/src/dispatch/models/DispatchSubscription.ts
@@ -17,7 +17,7 @@ export interface DispatchSubscriptionData {
   subscriber: string;
   handler: string;
   delivery: string;
-  enabled: number | string | bigint;
+  enabled: number | string | bigint | null;
   tenant_id: string | null;
   created_at: string;
   updated_at: string;
@@ -68,7 +68,7 @@ export class DispatchSubscription {
     this.handler = data.handler || 'handleDispatch';
     this.delivery = (data.delivery as 'compete' | 'fanout') || 'compete';
     this.enabled =
-      data.enabled !== undefined
+      data.enabled != null
         ? toSafeBooleanInteger(
             data.enabled,
             'Dispatch subscription enabled flag',

--- a/packages/core/src/migrations/__tests__/integer-width-postgres.optional.test.ts
+++ b/packages/core/src/migrations/__tests__/integer-width-postgres.optional.test.ts
@@ -1,0 +1,100 @@
+/**
+ * PostgreSQL integration coverage for the explicit #2424 int4 → int8 pass.
+ *
+ * This suite runs only in the disposable PostgreSQL lane started by
+ * `scripts/run-with-ci-postgres.mjs`. It verifies the real table rewrite,
+ * durable BackfillTracker marker, and safe rerun behavior that SQLite cannot
+ * exercise.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { getDatabase } from '@happyvertical/sql';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { BackfillTracker } from '../backfill-tracker.js';
+import {
+  preflightIntegerWidthWidening,
+  widenIntegerColumnsToBigInt,
+} from '../integer-width.js';
+
+const pgUrl = process.env.SMRT_TEST_POSTGRES_URL;
+const postgresDescribe = pgUrl ? describe.sequential : describe.skip;
+
+const prefix = `i2424_${randomUUID().slice(0, 8)}`;
+const table = `${prefix}_invoices`;
+const backfillName = `test:integer-width:${prefix}:v1`;
+
+postgresDescribe('int4 → bigint widening on real PostgreSQL (#2424)', () => {
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+
+  beforeAll(async () => {
+    db = await getDatabase({
+      type: 'postgres',
+      url: pgUrl,
+      dbid: `smrt-test-2424-${randomUUID()}`,
+    } as Parameters<typeof getDatabase>[0]);
+  });
+
+  afterEach(async () => {
+    await db.query(`DROP TABLE IF EXISTS "${table}"`);
+    await db.query('DELETE FROM _smrt_backfills WHERE name = ?', backfillName);
+  });
+
+  afterAll(async () => {
+    await db.close?.();
+  });
+
+  it('preflights and widens once, then persists its idempotency marker', async () => {
+    await db.query(`CREATE TABLE "${table}" (amount INTEGER)`);
+    await db.query(`INSERT INTO "${table}" (amount) VALUES (1), (2)`);
+
+    const targets = [{ table, columns: ['amount'] }];
+    const preflight = await preflightIntegerWidthWidening(db, targets, {
+      engineHint: 'postgres',
+    });
+    expect(preflight.tables).toContainEqual(
+      expect.objectContaining({
+        table,
+        rowCount: 2,
+        columns: [
+          expect.objectContaining({
+            column: 'amount',
+            declaredType: 'integer',
+            state: 'pending',
+          }),
+        ],
+      }),
+    );
+
+    const first = await widenIntegerColumnsToBigInt(db, targets, {
+      engineHint: 'postgres',
+      backfillName,
+    });
+    expect(first).toMatchObject({
+      ran: true,
+      widenedColumns: [{ table, column: 'amount' }],
+    });
+    const column = await db.query(
+      `SELECT data_type
+         FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = ?
+          AND column_name = 'amount'`,
+      table,
+    );
+    expect(String(column.rows[0]?.data_type).toLowerCase()).toBe('bigint');
+    expect(await new BackfillTracker({ db }).isApplied(backfillName)).toBe(
+      true,
+    );
+
+    await expect(
+      widenIntegerColumnsToBigInt(db, targets, {
+        engineHint: 'postgres',
+        backfillName,
+      }),
+    ).resolves.toMatchObject({
+      ran: false,
+      widenedColumns: [],
+      statements: [],
+    });
+  });
+});

--- a/packages/core/src/migrations/__tests__/integer-width-postgres.optional.test.ts
+++ b/packages/core/src/migrations/__tests__/integer-width-postgres.optional.test.ts
@@ -44,10 +44,14 @@ postgresDescribe('int4 → bigint widening on real PostgreSQL (#2424)', () => {
   });
 
   it('preflights and widens once, then persists its idempotency marker', async () => {
-    await db.query(`CREATE TABLE "${table}" (amount INTEGER)`);
-    await db.query(`INSERT INTO "${table}" (amount) VALUES (1), (2)`);
+    await db.query(
+      `CREATE TABLE "${table}" (amount INTEGER, attempts INTEGER)`,
+    );
+    await db.query(
+      `INSERT INTO "${table}" (amount, attempts) VALUES (1, 0), (2, 1)`,
+    );
 
-    const targets = [{ table, columns: ['amount'] }];
+    const targets = [{ table, columns: ['amount', 'attempts'] }];
     const preflight = await preflightIntegerWidthWidening(db, targets, {
       engineHint: 'postgres',
     });
@@ -55,13 +59,18 @@ postgresDescribe('int4 → bigint widening on real PostgreSQL (#2424)', () => {
       expect.objectContaining({
         table,
         rowCount: 2,
-        columns: [
+        columns: expect.arrayContaining([
           expect.objectContaining({
             column: 'amount',
             declaredType: 'integer',
             state: 'pending',
           }),
-        ],
+          expect.objectContaining({
+            column: 'attempts',
+            declaredType: 'integer',
+            state: 'pending',
+          }),
+        ]),
       }),
     );
 
@@ -71,17 +80,32 @@ postgresDescribe('int4 → bigint widening on real PostgreSQL (#2424)', () => {
     });
     expect(first).toMatchObject({
       ran: true,
-      widenedColumns: [{ table, column: 'amount' }],
+      widenedColumns: [
+        { table, column: 'amount' },
+        { table, column: 'attempts' },
+      ],
     });
-    const column = await db.query(
-      `SELECT data_type
+    expect(first.statements).toEqual([
+      `ALTER TABLE "${table}" ALTER COLUMN "amount" TYPE BIGINT, ALTER COLUMN "attempts" TYPE BIGINT`,
+    ]);
+    const columns = await db.query(
+      `SELECT column_name, data_type
          FROM information_schema.columns
         WHERE table_schema = current_schema()
           AND table_name = ?
-          AND column_name = 'amount'`,
+          AND column_name IN ('amount', 'attempts')
+        ORDER BY column_name`,
       table,
     );
-    expect(String(column.rows[0]?.data_type).toLowerCase()).toBe('bigint');
+    expect(
+      columns.rows.map((column) => [
+        String(column.column_name),
+        String(column.data_type).toLowerCase(),
+      ]),
+    ).toEqual([
+      ['amount', 'bigint'],
+      ['attempts', 'bigint'],
+    ]);
     expect(await new BackfillTracker({ db }).isApplied(backfillName)).toBe(
       true,
     );

--- a/packages/core/src/migrations/__tests__/integer-width.test.ts
+++ b/packages/core/src/migrations/__tests__/integer-width.test.ts
@@ -1,0 +1,236 @@
+import { type DatabaseInterface, getDatabase } from '@happyvertical/sql';
+import { describe, expect, it } from 'vitest';
+import {
+  buildIntegerWidthStatements,
+  collectIntegerWidthTargets,
+  preflightIntegerWidthWidening,
+  widenIntegerColumnsToBigInt,
+} from '../integer-width.js';
+
+function driverDb(input: {
+  engine: 'postgres' | 'duckdb';
+  types: Record<string, Record<string, string>>;
+  counts?: Record<string, string | bigint | number>;
+  applied?: boolean;
+}) {
+  const queries: string[] = [];
+  const db = {
+    url:
+      input.engine === 'postgres'
+        ? 'postgres://localhost/test'
+        : 'duckdb://memory',
+    query: async (sql: string, ...params: unknown[]) => {
+      queries.push(sql);
+      if (sql.includes('information_schema.columns') && params.length > 0) {
+        const table = String(params[0]);
+        return {
+          rows: Object.entries(input.types[table] ?? {}).map(
+            ([column_name, data_type]) => ({ column_name, data_type }),
+          ),
+        };
+      }
+      if (sql.startsWith('SELECT COUNT(*) AS row_count')) {
+        const match = sql.match(/FROM "([A-Za-z_][A-Za-z0-9_]*)"/);
+        return {
+          rows: [{ row_count: input.counts?.[match?.[1] ?? ''] ?? 0 }],
+        };
+      }
+      if (sql.includes('SELECT 1 FROM _smrt_backfills')) {
+        return { rows: input.applied ? [{ exists: 1 }] : [] };
+      }
+      return { rows: [] };
+    },
+  } as unknown as DatabaseInterface;
+  return { db, queries };
+}
+
+describe('integer-width widening (#2424)', () => {
+  it('collects application and hand-DDL system integer targets', () => {
+    const targets = collectIntegerWidthTargets({
+      invoices: {
+        tableName: 'invoices',
+        columns: {
+          amount: { type: 'INTEGER' },
+          rate: { type: 'REAL' },
+        },
+        indexes: [],
+        triggers: [],
+        foreignKeys: [],
+        dependencies: [],
+        version: '1.0.0',
+      },
+    });
+
+    expect(targets).toContainEqual({ table: 'invoices', columns: ['amount'] });
+    expect(
+      targets.find((target) => target.table === '_smrt_dispatch'),
+    ).toMatchObject({
+      columns: expect.arrayContaining(['attempts']),
+    });
+  });
+
+  it('reports PostgreSQL int4 columns and table row counts without writing', async () => {
+    const { db, queries } = driverDb({
+      engine: 'postgres',
+      types: {
+        invoices: { amount: 'integer', attempts: 'bigint', drift: 'text' },
+        absent: {},
+      },
+      counts: { invoices: '42' },
+    });
+
+    const result = await preflightIntegerWidthWidening(
+      db,
+      [
+        { table: 'invoices', columns: ['amount', 'attempts', 'drift'] },
+        { table: 'absent', columns: ['amount'] },
+      ],
+      { engineHint: 'postgres' },
+    );
+
+    expect(result).toMatchObject({
+      supported: true,
+      pendingColumns: 1,
+      currentColumns: 1,
+      missingColumns: 1,
+      unexpectedColumns: 1,
+      pendingTables: 1,
+    });
+    expect(
+      result.tables.find((table) => table.table === 'invoices'),
+    ).toMatchObject({
+      rowCount: 42,
+      columns: expect.arrayContaining([
+        expect.objectContaining({ column: 'amount', state: 'pending' }),
+        expect.objectContaining({ column: 'attempts', state: 'current' }),
+        expect.objectContaining({ column: 'drift', state: 'unexpected' }),
+      ]),
+    });
+    expect(result.summary).toContain('invoices: 42 row(s); amount (integer)');
+    expect(queries.some((sql) => sql.startsWith('ALTER TABLE'))).toBe(false);
+  });
+
+  it('hydrates DuckDB bigint row counts and emits lossless ALTER statements', async () => {
+    const { db } = driverDb({
+      engine: 'duckdb',
+      types: { invoices: { amount: 'INTEGER' } },
+      counts: { invoices: 7n },
+    });
+
+    const result = await preflightIntegerWidthWidening(
+      db,
+      [{ table: 'invoices', columns: ['amount'] }],
+      { engineHint: 'duckdb' },
+    );
+
+    expect(result.tables[0].rowCount).toBe(7);
+    expect(buildIntegerWidthStatements('duckdb', 'invoices', 'amount')).toEqual(
+      ['ALTER TABLE "invoices" ALTER COLUMN "amount" TYPE BIGINT'],
+    );
+  });
+
+  it('executes the full widening and marker path on real DuckDB', async () => {
+    const db = await getDatabase({ type: 'duckdb', url: ':memory:' });
+    try {
+      await db.query('CREATE TABLE invoices (amount INTEGER)');
+      await db.query('INSERT INTO invoices (amount) VALUES (1), (2)');
+
+      const result = await widenIntegerColumnsToBigInt(
+        db,
+        [{ table: 'invoices', columns: ['amount'] }],
+        { engineHint: 'duckdb', backfillName: 'test:integer-width:duckdb:v1' },
+      );
+
+      expect(result).toMatchObject({
+        ran: true,
+        widenedColumns: [{ table: 'invoices', column: 'amount' }],
+      });
+      expect(result.preflight.tables[0]?.rowCount).toBe(2);
+      const columns = await db.query(
+        `SELECT data_type FROM information_schema.columns
+          WHERE table_name = 'invoices' AND column_name = 'amount'`,
+      );
+      expect(String(columns.rows[0]?.data_type).toUpperCase()).toBe('BIGINT');
+    } finally {
+      await db.close?.();
+    }
+  });
+
+  it('widens each pending column once and records the idempotency marker', async () => {
+    const { db, queries } = driverDb({
+      engine: 'postgres',
+      types: { invoices: { amount: 'int4' } },
+      counts: { invoices: 2 },
+    });
+
+    const result = await widenIntegerColumnsToBigInt(
+      db,
+      [{ table: 'invoices', columns: ['amount'] }],
+      {
+        engineHint: 'postgres',
+        backfillName: 'test:integer-width:v1',
+      },
+    );
+
+    expect(result.ran).toBe(true);
+    expect(result.widenedColumns).toEqual([
+      { table: 'invoices', column: 'amount' },
+    ]);
+    expect(queries).toContain(
+      'ALTER TABLE "invoices" ALTER COLUMN "amount" TYPE BIGINT',
+    );
+    expect(
+      queries.some((sql) => sql.includes('INSERT INTO _smrt_backfills')),
+    ).toBe(true);
+  });
+
+  it('does not repeat a widening when its BackfillTracker marker exists', async () => {
+    const { db, queries } = driverDb({
+      engine: 'postgres',
+      types: { invoices: { amount: 'int4' } },
+      counts: { invoices: 2 },
+      applied: true,
+    });
+
+    const result = await widenIntegerColumnsToBigInt(
+      db,
+      [{ table: 'invoices', columns: ['amount'] }],
+      { engineHint: 'postgres', backfillName: 'test:integer-width:v1' },
+    );
+
+    expect(result.ran).toBe(false);
+    expect(result.widenedColumns).toEqual([]);
+    expect(queries.some((sql) => sql.startsWith('ALTER TABLE'))).toBe(false);
+  });
+
+  it('refuses to record a marker when ordinary type drift needs repair first', async () => {
+    const { db, queries } = driverDb({
+      engine: 'postgres',
+      types: { invoices: { amount: 'text' } },
+    });
+
+    await expect(
+      widenIntegerColumnsToBigInt(
+        db,
+        [{ table: 'invoices', columns: ['amount'] }],
+        { engineHint: 'postgres', backfillName: 'test:integer-width:v1' },
+      ),
+    ).rejects.toThrow('unexpected live types');
+    expect(queries.some((sql) => sql.startsWith('ALTER TABLE'))).toBe(false);
+  });
+
+  it('is a no-op on SQLite because INTEGER is already 64-bit', async () => {
+    const db = {
+      url: ':memory:',
+      query: async () => ({ rows: [] }),
+    } as unknown as DatabaseInterface;
+
+    await expect(
+      preflightIntegerWidthWidening(
+        db,
+        [{ table: 'invoices', columns: ['amount'] }],
+        { engineHint: 'sqlite' },
+      ),
+    ).resolves.toMatchObject({ supported: false, pendingColumns: 0 });
+  });
+});

--- a/packages/core/src/migrations/__tests__/integer-width.test.ts
+++ b/packages/core/src/migrations/__tests__/integer-width.test.ts
@@ -2,6 +2,7 @@ import { type DatabaseInterface, getDatabase } from '@happyvertical/sql';
 import { describe, expect, it } from 'vitest';
 import {
   buildIntegerWidthStatements,
+  buildIntegerWidthTableStatements,
   collectIntegerWidthTargets,
   preflightIntegerWidthWidening,
   widenIntegerColumnsToBigInt,
@@ -14,7 +15,8 @@ function driverDb(input: {
   applied?: boolean;
 }) {
   const queries: string[] = [];
-  const db = {
+  let db: DatabaseInterface;
+  db = {
     url:
       input.engine === 'postgres'
         ? 'postgres://localhost/test'
@@ -40,6 +42,9 @@ function driverDb(input: {
       }
       return { rows: [] };
     },
+    transaction: async <T>(
+      callback: (transactionDb: DatabaseInterface) => Promise<T>,
+    ) => callback(db),
   } as unknown as DatabaseInterface;
   return { db, queries };
 }
@@ -129,6 +134,17 @@ describe('integer-width widening (#2424)', () => {
     );
   });
 
+  it('groups PostgreSQL columns into one table rewrite', () => {
+    expect(
+      buildIntegerWidthTableStatements('postgres', 'invoices', [
+        'amount',
+        'attempts',
+      ]),
+    ).toEqual([
+      'ALTER TABLE "invoices" ALTER COLUMN "amount" TYPE BIGINT, ALTER COLUMN "attempts" TYPE BIGINT',
+    ]);
+  });
+
   it('executes the full widening and marker path on real DuckDB', async () => {
     const db = await getDatabase({ type: 'duckdb', url: ':memory:' });
     try {
@@ -179,16 +195,17 @@ describe('integer-width widening (#2424)', () => {
     expect(queries).toContain(
       'ALTER TABLE "invoices" ALTER COLUMN "amount" TYPE BIGINT',
     );
+    expect(queries).toContain(`SET LOCAL lock_timeout = '30000ms'`);
+    expect(queries).toContain(`SET LOCAL statement_timeout = '60000ms'`);
     expect(
       queries.some((sql) => sql.includes('INSERT INTO _smrt_backfills')),
     ).toBe(true);
   });
 
-  it('does not repeat a widening when its BackfillTracker marker exists', async () => {
+  it('does not repeat a widening when all columns are already BIGINT', async () => {
     const { db, queries } = driverDb({
       engine: 'postgres',
-      types: { invoices: { amount: 'int4' } },
-      counts: { invoices: 2 },
+      types: { invoices: { amount: 'bigint' } },
       applied: true,
     });
 
@@ -201,6 +218,29 @@ describe('integer-width widening (#2424)', () => {
     expect(result.ran).toBe(false);
     expect(result.widenedColumns).toEqual([]);
     expect(queries.some((sql) => sql.startsWith('ALTER TABLE'))).toBe(false);
+  });
+
+  it('does not let an earlier marker skip newly discovered pending targets', async () => {
+    const { db, queries } = driverDb({
+      engine: 'postgres',
+      types: { invoices: { amount: 'int4' } },
+      counts: { invoices: 2 },
+      applied: true,
+    });
+
+    await expect(
+      widenIntegerColumnsToBigInt(
+        db,
+        [{ table: 'invoices', columns: ['amount'] }],
+        { engineHint: 'postgres', backfillName: 'test:integer-width:v1' },
+      ),
+    ).resolves.toMatchObject({
+      ran: true,
+      widenedColumns: [{ table: 'invoices', column: 'amount' }],
+    });
+    expect(queries).toContain(
+      'ALTER TABLE "invoices" ALTER COLUMN "amount" TYPE BIGINT',
+    );
   });
 
   it('refuses to record a marker when ordinary type drift needs repair first', async () => {

--- a/packages/core/src/migrations/__tests__/tracker-branches.test.ts
+++ b/packages/core/src/migrations/__tests__/tracker-branches.test.ts
@@ -134,6 +134,45 @@ describe('MigrationTracker BIGINT hydration', () => {
     });
     expect(await tracker.getNextBatch()).toBe(10);
   });
+
+  it('uses system-table defaults for nullable legacy counters and flags', async () => {
+    const tracker = new MigrationTracker({
+      db: {
+        url: 'postgres://localhost/test',
+        query: async (sql: string) => {
+          if (sql.includes('SELECT * FROM _smrt_schema_migrations')) {
+            return {
+              rows: [
+                {
+                  id: 'migration-nullable',
+                  name: '0003_nullable',
+                  version: '1.0.0',
+                  checksum: 'checksum',
+                  applied_checksum: null,
+                  applied_at: '2026-01-01T00:00:00.000Z',
+                  execution_time_ms: null,
+                  package_name: null,
+                  source_file: null,
+                  status: 'completed',
+                  error_message: null,
+                  attempts: null,
+                  is_reversible: null,
+                  rolled_back_at: null,
+                  applied_by: null,
+                  batch: null,
+                },
+              ],
+            };
+          }
+          return { rows: [] };
+        },
+      } as any,
+    });
+
+    await expect(tracker.getAppliedMigrations()).resolves.toMatchObject([
+      { attempts: 0, is_reversible: true },
+    ]);
+  });
 });
 
 describe('MigrationTracker on real SQLite', () => {

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -50,6 +50,7 @@ export {
 // Explicit int4 → int8 deployment widening (#2424)
 export {
   buildIntegerWidthStatements,
+  buildIntegerWidthTableStatements,
   collectIntegerWidthTargets,
   type IntegerWidthColumnReport,
   type IntegerWidthColumnState,

--- a/packages/core/src/migrations/index.ts
+++ b/packages/core/src/migrations/index.ts
@@ -47,6 +47,21 @@ export {
   generateMigrationTimestamp,
   MigrationGenerator,
 } from './generator.js';
+// Explicit int4 → int8 deployment widening (#2424)
+export {
+  buildIntegerWidthStatements,
+  collectIntegerWidthTargets,
+  type IntegerWidthColumnReport,
+  type IntegerWidthColumnState,
+  type IntegerWidthOptions,
+  type IntegerWidthPreflightResult,
+  type IntegerWidthTableReport,
+  type IntegerWidthTarget,
+  type IntegerWidthWidenOptions,
+  type IntegerWidthWidenResult,
+  preflightIntegerWidthWidening,
+  widenIntegerColumnsToBigInt,
+} from './integer-width.js';
 // Money major-units → integer minor-units rescale (#2401)
 export {
   buildMinorUnitsStatements,

--- a/packages/core/src/migrations/integer-width.ts
+++ b/packages/core/src/migrations/integer-width.ts
@@ -8,11 +8,15 @@
  */
 
 import type { DatabaseInterface } from '@happyvertical/sql';
+import { parsePostgresTimeoutMs } from '../postgres-timeouts.js';
 import { detectEngine } from '../schema/ddl/index.js';
 import { getSystemTableShapes } from '../schema/system-table-shapes.js';
 import type { SchemaDefinition } from '../schema/types.js';
 import { toSafeInteger } from '../utils/safe-integer.js';
 import { BackfillTracker } from './backfill-tracker.js';
+
+const DEFAULT_POSTGRES_LOCK_TIMEOUT_MS = 30_000;
+const DEFAULT_POSTGRES_STATEMENT_TIMEOUT_MS = 60_000;
 
 /** A table and its SMRT-owned integer columns. */
 export interface IntegerWidthTarget {
@@ -68,15 +72,19 @@ export interface IntegerWidthOptions {
 
 /** Options that make the widening pass safely repeatable. */
 export interface IntegerWidthWidenOptions extends IntegerWidthOptions {
-  /** Stable `_smrt_backfills` marker, unique to this migration owner. */
+  /** Stable `_smrt_backfills` audit marker, unique to this migration owner. */
   backfillName: string;
   /** Package recorded alongside the marker. */
   packageName?: string;
+  /** PostgreSQL lock timeout in milliseconds (defaults to 30 seconds). */
+  lockTimeout?: number;
+  /** PostgreSQL statement timeout in milliseconds (defaults to 60 seconds). */
+  statementTimeout?: number;
 }
 
 /** Result of {@link widenIntegerColumnsToBigInt}. */
 export interface IntegerWidthWidenResult {
-  /** False when the marker was already recorded or the engine is unsupported. */
+  /** False when no legacy columns remain or the engine is unsupported. */
   ran: boolean;
   preflight: IntegerWidthPreflightResult;
   widenedColumns: Array<{ table: string; column: string }>;
@@ -123,12 +131,36 @@ export function buildIntegerWidthStatements(
   table: string,
   column: string,
 ): string[] {
+  return buildIntegerWidthTableStatements(engine, table, [column]);
+}
+
+/**
+ * Build lossless widening statements for every pending column in one table.
+ *
+ * PostgreSQL performs a table rewrite for an integer-width change, so all of
+ * one table's pending columns must share one ALTER TABLE and one lock window.
+ * DuckDB keeps its one-column form because its ALTER COLUMN grammar is not
+ * equivalently composable across supported adapter versions.
+ */
+export function buildIntegerWidthTableStatements(
+  engine: string,
+  table: string,
+  columns: string[],
+): string[] {
   const quotedTable = quoteIdentifier(table);
-  const quotedColumn = quoteIdentifier(column);
+  const quotedColumns = columns.map(quoteIdentifier);
+  if (quotedColumns.length === 0) return [];
   if (engine !== 'postgres' && engine !== 'duckdb') return [];
-  return [
-    `ALTER TABLE ${quotedTable} ALTER COLUMN ${quotedColumn} TYPE BIGINT`,
-  ];
+  if (engine === 'postgres') {
+    return [
+      `ALTER TABLE ${quotedTable} ${quotedColumns
+        .map((column) => `ALTER COLUMN ${column} TYPE BIGINT`)
+        .join(', ')}`,
+    ];
+  }
+  return quotedColumns.map(
+    (column) => `ALTER TABLE ${quotedTable} ALTER COLUMN ${column} TYPE BIGINT`,
+  );
 }
 
 /**
@@ -226,33 +258,80 @@ export async function widenIntegerColumnsToBigInt(
     );
   }
 
-  const tracker = new BackfillTracker({ db });
-  if (await tracker.isApplied(options.backfillName)) {
+  // Current declared widths are the idempotency guard. A fixed marker cannot
+  // safely be the guard because a later successful discovery may reveal a
+  // package/table absent from the earlier target set.
+  if (preflight.pendingColumns === 0) {
     return { ran: false, preflight, widenedColumns: [], statements: [] };
   }
 
   const statements: string[] = [];
   const widenedColumns: Array<{ table: string; column: string }> = [];
-  for (const table of preflight.tables) {
-    for (const column of table.columns) {
-      if (column.state !== 'pending') continue;
-      for (const sql of buildIntegerWidthStatements(
+  const tracker = new BackfillTracker({ db });
+  await tracker.initialize();
+
+  const applyWidening = async (writeDb: DatabaseInterface) => {
+    for (const table of preflight.tables) {
+      const pendingColumns = table.columns
+        .filter((column) => column.state === 'pending')
+        .map((column) => column.column);
+      if (pendingColumns.length === 0) continue;
+      for (const sql of buildIntegerWidthTableStatements(
         preflight.engine,
         table.table,
-        column.column,
+        pendingColumns,
       )) {
-        await db.query(sql);
+        await writeDb.query(sql);
         statements.push(sql);
       }
-      widenedColumns.push({ table: table.table, column: column.column });
+      widenedColumns.push(
+        ...pendingColumns.map((column) => ({ table: table.table, column })),
+      );
     }
-  }
 
-  await tracker.recordApplied(options.backfillName, {
-    description:
-      'Widened legacy int4 SMRT columns to BIGINT after #2373 changed fresh-schema defaults.',
-    packageName: options.packageName,
-  });
+    await new BackfillTracker({ db: writeDb }).recordApplied(
+      options.backfillName,
+      {
+        description:
+          'Widened legacy int4 SMRT columns to BIGINT after #2373 changed fresh-schema defaults.',
+        packageName: options.packageName,
+      },
+    );
+  };
+
+  if (preflight.engine === 'postgres') {
+    if (!db.transaction) {
+      throw new Error(
+        'Integer-width widening on PostgreSQL requires transaction support.',
+      );
+    }
+    const lockTimeout = parsePostgresTimeoutMs(
+      options.lockTimeout,
+      DEFAULT_POSTGRES_LOCK_TIMEOUT_MS,
+    );
+    const statementTimeout = parsePostgresTimeoutMs(
+      options.statementTimeout,
+      DEFAULT_POSTGRES_STATEMENT_TIMEOUT_MS,
+    );
+    await db.transaction(async (tx) => {
+      const txDb = {
+        ...tx,
+        transaction: async <T>(
+          callback: (transactionDb: DatabaseInterface) => Promise<T>,
+        ) => callback(tx as DatabaseInterface),
+      } as DatabaseInterface;
+      BackfillTracker.inheritInitialization(txDb, db);
+      await txDb.query(
+        `SET LOCAL lock_timeout = '${formatPostgresTimeout(lockTimeout)}'`,
+      );
+      await txDb.query(
+        `SET LOCAL statement_timeout = '${formatPostgresTimeout(statementTimeout)}'`,
+      );
+      await applyWidening(txDb);
+    });
+  } else {
+    await applyWidening(db);
+  }
 
   return { ran: true, preflight, widenedColumns, statements };
 }
@@ -284,6 +363,10 @@ function quoteIdentifier(name: string): string {
     );
   }
   return `"${name}"`;
+}
+
+function formatPostgresTimeout(milliseconds: number): string {
+  return `${milliseconds}ms`;
 }
 
 function isLegacyInt4Type(type: string): boolean {

--- a/packages/core/src/migrations/integer-width.ts
+++ b/packages/core/src/migrations/integer-width.ts
@@ -267,8 +267,7 @@ export async function widenIntegerColumnsToBigInt(
 
   const statements: string[] = [];
   const widenedColumns: Array<{ table: string; column: string }> = [];
-  const tracker = new BackfillTracker({ db });
-  await tracker.initialize();
+  await new BackfillTracker({ db }).initialize();
 
   const applyWidening = async (writeDb: DatabaseInterface) => {
     for (const table of preflight.tables) {

--- a/packages/core/src/migrations/integer-width.ts
+++ b/packages/core/src/migrations/integer-width.ts
@@ -1,0 +1,364 @@
+/**
+ * Explicit one-time widening for deployments created before #2373.
+ *
+ * Fresh PostgreSQL and DuckDB schemas now materialize SMRT's abstract
+ * `INTEGER` as `BIGINT`. The migration differ deliberately treats int4 and
+ * int8 as equivalent, so existing deployments need this separate, operator
+ * initiated maintenance-window migration rather than an automatic repair.
+ */
+
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { detectEngine } from '../schema/ddl/index.js';
+import { getSystemTableShapes } from '../schema/system-table-shapes.js';
+import type { SchemaDefinition } from '../schema/types.js';
+import { toSafeInteger } from '../utils/safe-integer.js';
+import { BackfillTracker } from './backfill-tracker.js';
+
+/** A table and its SMRT-owned integer columns. */
+export interface IntegerWidthTarget {
+  table: string;
+  columns: string[];
+}
+
+/** The width state of one declared integer column. */
+export type IntegerWidthColumnState =
+  | 'pending'
+  | 'current'
+  | 'missing'
+  | 'unexpected';
+
+/** Preflight finding for one declared integer column. */
+export interface IntegerWidthColumnReport {
+  table: string;
+  column: string;
+  state: IntegerWidthColumnState;
+  /** Live `information_schema.columns.data_type`, when the column exists. */
+  declaredType: string | null;
+}
+
+/** Preflight findings for a single SMRT-owned table. */
+export interface IntegerWidthTableReport {
+  table: string;
+  /** Number of rows when at least one column still needs widening. */
+  rowCount: number | null;
+  columns: IntegerWidthColumnReport[];
+}
+
+/** Read-only assessment of a deployment's legacy int4 columns. */
+export interface IntegerWidthPreflightResult {
+  engine: string;
+  /** False for SQLite and adapters without a native 32-bit integer width. */
+  supported: boolean;
+  tables: IntegerWidthTableReport[];
+  pendingColumns: number;
+  currentColumns: number;
+  missingColumns: number;
+  unexpectedColumns: number;
+  /** Tables that need a maintenance-window table rewrite. */
+  pendingTables: number;
+  /** Human-readable output suitable for an operator change record. */
+  summary: string;
+}
+
+/** Shared options for the read-only preflight and mutating widening pass. */
+export interface IntegerWidthOptions {
+  /** Adapter hint when its URL does not identify the engine. */
+  engineHint?: string;
+}
+
+/** Options that make the widening pass safely repeatable. */
+export interface IntegerWidthWidenOptions extends IntegerWidthOptions {
+  /** Stable `_smrt_backfills` marker, unique to this migration owner. */
+  backfillName: string;
+  /** Package recorded alongside the marker. */
+  packageName?: string;
+}
+
+/** Result of {@link widenIntegerColumnsToBigInt}. */
+export interface IntegerWidthWidenResult {
+  /** False when the marker was already recorded or the engine is unsupported. */
+  ran: boolean;
+  preflight: IntegerWidthPreflightResult;
+  widenedColumns: Array<{ table: string; column: string }>;
+  statements: string[];
+}
+
+/**
+ * Collect every integer column owned by loaded application schemas and, when
+ * requested, by hand-written core system-table DDL.
+ */
+export function collectIntegerWidthTargets(
+  schemas: Record<string, SchemaDefinition>,
+  options: { includeSystemTables?: boolean } = {},
+): IntegerWidthTarget[] {
+  const byTable = new Map<string, Set<string>>();
+  const add = (table: string, column: string) => {
+    if (!byTable.has(table)) byTable.set(table, new Set());
+    byTable.get(table)?.add(column);
+  };
+
+  for (const [key, schema] of Object.entries(schemas)) {
+    const table = schema?.tableName || key;
+    for (const [column, definition] of Object.entries(schema?.columns ?? {})) {
+      if (definition.type === 'INTEGER') add(table, column);
+    }
+  }
+
+  if (options.includeSystemTables ?? true) {
+    for (const shape of getSystemTableShapes('postgres').values()) {
+      for (const column of shape.columns) {
+        if (isBigIntType(column.type)) add(shape.tableName, column.name);
+      }
+    }
+  }
+
+  return [...byTable]
+    .map(([table, columns]) => ({ table, columns: [...columns].sort() }))
+    .sort((left, right) => left.table.localeCompare(right.table));
+}
+
+/** Build the exact, lossless ALTER statement for one target column. */
+export function buildIntegerWidthStatements(
+  engine: string,
+  table: string,
+  column: string,
+): string[] {
+  const quotedTable = quoteIdentifier(table);
+  const quotedColumn = quoteIdentifier(column);
+  if (engine !== 'postgres' && engine !== 'duckdb') return [];
+  return [
+    `ALTER TABLE ${quotedTable} ALTER COLUMN ${quotedColumn} TYPE BIGINT`,
+  ];
+}
+
+/**
+ * Inspect explicit SMRT-owned integer targets without changing the database.
+ *
+ * PostgreSQL and DuckDB expose their live widths through
+ * `information_schema.columns`. SQLite is deliberately a no-op because its
+ * INTEGER storage class already holds signed 64-bit values.
+ */
+export async function preflightIntegerWidthWidening(
+  db: DatabaseInterface,
+  targets: IntegerWidthTarget[],
+  options: IntegerWidthOptions = {},
+): Promise<IntegerWidthPreflightResult> {
+  const engine = resolveEngine(db, options.engineHint);
+  const normalizedTargets = normalizeTargets(targets);
+  if (engine !== 'postgres' && engine !== 'duckdb') {
+    const result = {
+      engine,
+      supported: false,
+      tables: [],
+      pendingColumns: 0,
+      currentColumns: 0,
+      missingColumns: 0,
+      unexpectedColumns: 0,
+      pendingTables: 0,
+    };
+    return {
+      ...result,
+      summary:
+        `Integer-width widening preflight (engine=${engine}): not applicable; ` +
+        'this engine does not expose a distinct native int4 storage type.',
+    };
+  }
+
+  const tables: IntegerWidthTableReport[] = [];
+  for (const target of normalizedTargets) {
+    const types = await readColumnTypes(db, engine, target.table);
+    const columns = target.columns.map((column) => {
+      const declaredType = types.get(column) ?? null;
+      return {
+        table: target.table,
+        column,
+        declaredType,
+        state: classifyIntegerWidth(declaredType),
+      };
+    });
+    const needsWidening = columns.some((column) => column.state === 'pending');
+    tables.push({
+      table: target.table,
+      rowCount: needsWidening ? await countRows(db, target.table) : null,
+      columns,
+    });
+  }
+
+  const allColumns = tables.flatMap((table) => table.columns);
+  const result = {
+    engine,
+    supported: true,
+    tables,
+    pendingColumns: allColumns.filter((column) => column.state === 'pending')
+      .length,
+    currentColumns: allColumns.filter((column) => column.state === 'current')
+      .length,
+    missingColumns: allColumns.filter((column) => column.state === 'missing')
+      .length,
+    unexpectedColumns: allColumns.filter(
+      (column) => column.state === 'unexpected',
+    ).length,
+    pendingTables: tables.filter((table) =>
+      table.columns.some((column) => column.state === 'pending'),
+    ).length,
+  };
+  return { ...result, summary: renderSummary(result) };
+}
+
+/**
+ * Widen legacy int4 columns to BIGINT and record a marker after every ALTER
+ * succeeds. This is intentionally never called by normal schema migration or
+ * framework bootstrap: PostgreSQL rewrites each altered table.
+ */
+export async function widenIntegerColumnsToBigInt(
+  db: DatabaseInterface,
+  targets: IntegerWidthTarget[],
+  options: IntegerWidthWidenOptions,
+): Promise<IntegerWidthWidenResult> {
+  const preflight = await preflightIntegerWidthWidening(db, targets, options);
+  if (!preflight.supported) {
+    return { ran: false, preflight, widenedColumns: [], statements: [] };
+  }
+  if (preflight.unexpectedColumns > 0) {
+    throw new Error(
+      'Integer-width widening refused because declared integer columns have unexpected live types. Resolve ordinary schema drift first.\n' +
+        preflight.summary,
+    );
+  }
+
+  const tracker = new BackfillTracker({ db });
+  if (await tracker.isApplied(options.backfillName)) {
+    return { ran: false, preflight, widenedColumns: [], statements: [] };
+  }
+
+  const statements: string[] = [];
+  const widenedColumns: Array<{ table: string; column: string }> = [];
+  for (const table of preflight.tables) {
+    for (const column of table.columns) {
+      if (column.state !== 'pending') continue;
+      for (const sql of buildIntegerWidthStatements(
+        preflight.engine,
+        table.table,
+        column.column,
+      )) {
+        await db.query(sql);
+        statements.push(sql);
+      }
+      widenedColumns.push({ table: table.table, column: column.column });
+    }
+  }
+
+  await tracker.recordApplied(options.backfillName, {
+    description:
+      'Widened legacy int4 SMRT columns to BIGINT after #2373 changed fresh-schema defaults.',
+    packageName: options.packageName,
+  });
+
+  return { ran: true, preflight, widenedColumns, statements };
+}
+
+function resolveEngine(db: DatabaseInterface, engineHint?: string): string {
+  const dbWithConfig = db as DatabaseInterface & { config?: { url?: string } };
+  return detectEngine(db.url || dbWithConfig.config?.url || '', engineHint);
+}
+
+function normalizeTargets(targets: IntegerWidthTarget[]): IntegerWidthTarget[] {
+  const byTable = new Map<string, Set<string>>();
+  for (const target of targets) {
+    quoteIdentifier(target.table);
+    if (!byTable.has(target.table)) byTable.set(target.table, new Set());
+    for (const column of target.columns) {
+      quoteIdentifier(column);
+      byTable.get(target.table)?.add(column);
+    }
+  }
+  return [...byTable]
+    .map(([table, columns]) => ({ table, columns: [...columns].sort() }))
+    .sort((left, right) => left.table.localeCompare(right.table));
+}
+
+function quoteIdentifier(name: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(
+      `Integer-width widening: '${name}' is not a plain SQL identifier.`,
+    );
+  }
+  return `"${name}"`;
+}
+
+function isLegacyInt4Type(type: string): boolean {
+  return /^(INTEGER|INT|INT4)$/i.test(type.trim());
+}
+
+function isBigIntType(type: string): boolean {
+  return /^(BIGINT|INT8)$/i.test(type.trim());
+}
+
+function classifyIntegerWidth(type: string | null): IntegerWidthColumnState {
+  if (type === null) return 'missing';
+  if (isLegacyInt4Type(type)) return 'pending';
+  if (isBigIntType(type)) return 'current';
+  return 'unexpected';
+}
+
+async function readColumnTypes(
+  db: DatabaseInterface,
+  engine: string,
+  table: string,
+): Promise<Map<string, string>> {
+  const result = await db.query(
+    engine === 'postgres'
+      ? `SELECT column_name, data_type
+           FROM information_schema.columns
+          WHERE table_schema = current_schema() AND table_name = ?`
+      : `SELECT column_name, data_type
+           FROM information_schema.columns
+          WHERE table_name = ?`,
+    table,
+  );
+  const types = new Map<string, string>();
+  for (const row of result.rows as {
+    column_name?: unknown;
+    data_type?: unknown;
+  }[]) {
+    if (typeof row.column_name === 'string') {
+      types.set(row.column_name, String(row.data_type ?? ''));
+    }
+  }
+  return types;
+}
+
+async function countRows(
+  db: DatabaseInterface,
+  table: string,
+): Promise<number> {
+  const result = await db.query(
+    `SELECT COUNT(*) AS row_count FROM ${quoteIdentifier(table)}`,
+  );
+  return toSafeInteger(
+    result.rows?.[0]?.row_count ?? 0,
+    `Integer-width row count for ${table}`,
+  );
+}
+
+function renderSummary(
+  result: Omit<IntegerWidthPreflightResult, 'summary'>,
+): string {
+  const lines = [
+    `Integer-width widening preflight (engine=${result.engine})`,
+    `  tables: ${result.pendingTables} pending`,
+    `  columns: ${result.pendingColumns} pending, ${result.currentColumns} already BIGINT, ${result.missingColumns} missing, ${result.unexpectedColumns} unexpected`,
+  ];
+  for (const table of result.tables) {
+    const pending = table.columns.filter(
+      (column) => column.state === 'pending',
+    );
+    if (pending.length === 0) continue;
+    lines.push(
+      `  - ${table.table}: ${table.rowCount ?? 0} row(s); ${pending
+        .map((column) => `${column.column} (${column.declaredType})`)
+        .join(', ')}`,
+    );
+  }
+  return lines.join('\n');
+}

--- a/packages/core/src/migrations/tracker.ts
+++ b/packages/core/src/migrations/tracker.ts
@@ -74,9 +74,9 @@ function hydrateMigrationRow(row: MigrationRow): SchemaMigrationRecord {
       row.execution_time_ms === null || row.execution_time_ms === undefined
         ? null
         : toSafeInteger(row.execution_time_ms, 'Migration execution time'),
-    attempts: toSafeInteger(row.attempts, 'Migration attempts'),
+    attempts: toSafeInteger(row.attempts ?? 0, 'Migration attempts'),
     is_reversible: toSafeBooleanInteger(
-      row.is_reversible,
+      row.is_reversible ?? 1,
       'Migration reversibility flag',
     ),
     rolled_back_at: row.rolled_back_at ? new Date(row.rolled_back_at) : null,

--- a/packages/core/src/schema/live-parity.test.ts
+++ b/packages/core/src/schema/live-parity.test.ts
@@ -88,6 +88,60 @@ function find(
 }
 
 describe('checkLiveSchemaParity (application tables)', () => {
+  it('advises on legacy PostgreSQL int4 without turning it into type drift', async () => {
+    const database = {
+      url: 'postgres://localhost/test',
+      query: async (sql: string, ...params: unknown[]) => {
+        if (sql.includes('information_schema.tables')) {
+          return { rows: [{ table_name: 'widgets' }] };
+        }
+        if (sql.includes('information_schema.columns') && params.length > 0) {
+          return {
+            rows: [{ column_name: 'attempts', data_type: 'integer' }],
+          };
+        }
+        if (sql.startsWith('SELECT COUNT(*) AS row_count')) {
+          return { rows: [{ row_count: '4' }] };
+        }
+        return { rows: [] };
+      },
+      getTableSchema: async () => ({
+        columns: {
+          attempts: {
+            type: 'integer',
+            notNull: false,
+            primaryKey: false,
+          },
+        },
+      }),
+    } as unknown as DatabaseProvider;
+
+    const report = await checkLiveSchemaParity({
+      db: database,
+      schemas: {
+        widgets: {
+          tableName: 'widgets',
+          columns: { attempts: { type: 'INTEGER' } },
+          indexes: [],
+          triggers: [],
+          foreignKeys: [],
+          dependencies: [],
+          version: '1.0.0',
+        },
+      },
+      includeSystemTables: false,
+    });
+
+    const finding = find(report.findings, 'legacy_integer_width', 'attempts');
+    expect(finding).toMatchObject({
+      severity: 'warning',
+      table: 'widgets',
+      details: { actual: 'integer', expected: 'BIGINT', rowCount: 4 },
+    });
+    expect(finding?.recommendation).toContain('db:migrate-int8');
+    expect(report.ok).toBe(true);
+  });
+
   it('reports the #2356 unindexed-tenant class and the FK-index class', async () => {
     const database = await openDatabase();
     // A schema that a manifest-oracle diff calls "in sync": every declared

--- a/packages/core/src/schema/live-parity.ts
+++ b/packages/core/src/schema/live-parity.ts
@@ -24,6 +24,10 @@
  */
 
 import type { DatabaseInterface } from '@happyvertical/sql';
+import {
+  collectIntegerWidthTargets,
+  preflightIntegerWidthWidening,
+} from '../migrations/integer-width.js';
 import { RETIRED_SYSTEM_TABLES } from '../system/schema.js';
 import { detectEngine, getDDLStrategy } from './ddl/index.js';
 import type { DatabaseEngine } from './ddl/types.js';
@@ -47,7 +51,9 @@ export type LiveParityFindingKind =
   | 'conflict_target_unindexed'
   | 'conflict_target_not_unique'
   | 'unique_constraint_missing'
-  | 'invalid_index';
+  | 'invalid_index'
+  /** Pre-#2373 PostgreSQL/DuckDB int4 column needing opt-in widening. */
+  | 'legacy_integer_width';
 
 /** One difference between the live database and the expected shape. */
 export interface LiveParityFinding {
@@ -223,6 +229,40 @@ export async function checkLiveSchemaParity(
     if (indexCatalog) {
       const liveIndexes = await indexCatalog.forTable(table.name);
       findings.push(...compareIndexes(table, liveColumns, liveIndexes));
+    }
+  }
+
+  // #2373 intentionally leaves int4/int8 equivalent to the ordinary differ
+  // (and to structural parity) so fresh BIGINT DDL does not auto-rewrite a
+  // production table. Surface the remaining 32-bit columns as advisory-only
+  // findings here, with row counts for a maintenance-window estimate.
+  const widthPreflight = await preflightIntegerWidthWidening(
+    db,
+    collectIntegerWidthTargets(schemas, { includeSystemTables }),
+    { engineHint },
+  );
+  if (widthPreflight.supported) {
+    for (const table of widthPreflight.tables) {
+      for (const column of table.columns) {
+        if (column.state !== 'pending') continue;
+        findings.push({
+          kind: 'legacy_integer_width',
+          severity: 'warning',
+          table: table.table,
+          target: column.column,
+          origin: table.table.startsWith('_smrt_') ? 'system' : 'application',
+          message:
+            `Column \`${table.table}.${column.column}\` is legacy \`${column.declaredType}\` ` +
+            `instead of BIGINT (${table.rowCount ?? 0} row(s) in the table).`,
+          recommendation:
+            'Schedule a maintenance window, run `smrt db:migrate-int8 --dry-run`, then run `smrt db:migrate-int8` after reviewing the table-rewrite plan.',
+          details: {
+            actual: column.declaredType,
+            expected: 'BIGINT',
+            rowCount: table.rowCount,
+          },
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- add an explicit, marker-backed int4-to-BIGINT maintenance migration with read-only preflight
- surface legacy widths as schema-parity advisories and expose the opt-in CLI command
- cover PostgreSQL/DuckDB behavior, safe reruns, and CLI dry-run reporting

Depends on #2425.

Closes #2424

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-32101030ec0fc553","issue":"2424","policy_revision":"1.0.0","validation":["pnpm --filter @happyvertical/smrt-core exec vitest run src/migrations/__tests__/integer-width.test.ts src/migrations/__tests__/integer-width-postgres.optional.test.ts src/schema/live-parity.test.ts --silent=true","pnpm --filter @happyvertical/smrt-cli exec vitest run src/commands/__tests__/db-migrate-uuid-handler.test.ts src/commands/__tests__/db-migrate-uuid.test.ts --silent=true","pnpm --filter @happyvertical/smrt-core typecheck","pnpm --filter @happyvertical/smrt-cli typecheck","pnpm --filter @happyvertical/smrt-core build","pnpm --filter @happyvertical/smrt-cli build","pnpm smrt dev:knowledge-check"]}
```