### PR TITLE
fix(vitest): provision change feed before isolated transactions

### DIFF
--- a/packages/vitest/AGENTS.md
+++ b/packages/vitest/AGENTS.md
@@ -83,6 +83,12 @@ string is a CREATE TABLE preview and is merged in only for a table whose
 contributors expose no `columns` (hand-authored manifests). Do not add a
 private DDL/index renderer here; extend the core strategy instead.
 
+On PostgreSQL, the isolated factories provision the canonical change-feed
+table and `_smrt_append_change` helper on the base connection before opening
+the test transaction. Transaction handles are treated as already initialized
+by SMRT objects, so moving this provisioning into the transaction would leave
+the first interceptor-driven write without its required function (#2427).
+
 For local file-backed SQLite, identical schemas are prepared once per Vitest
 process and cloned from an immutable schema-only template for later databases.
 The cache key is the full generated DDL, concurrent first callers share one

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -40,7 +40,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run",
-    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/__tests__/issue-2069-postgres-manifest.optional.test.ts",
+    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/__tests__/issue-2069-postgres-manifest.optional.test.ts src/__tests__/issue-2427-postgres-change-feed.optional.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/packages/vitest/src/__tests__/issue-2427-postgres-change-feed.optional.test.ts
+++ b/packages/vitest/src/__tests__/issue-2427-postgres-change-feed.optional.test.ts
@@ -66,9 +66,9 @@ postgresDescribe('PostgreSQL isolated change-feed bootstrap (#2427)', () => {
         ? feedResult
         : ((feedResult as { rows?: Array<Record<string, unknown>> }).rows ??
           []);
-      expect(feedRows).toEqual([
-        expect.objectContaining({ seq: '1', table_name: tableName }),
-      ]);
+      expect(feedRows).toHaveLength(1);
+      expect(Number(feedRows[0]?.seq)).toBe(1);
+      expect(feedRows[0]?.table_name).toBe(tableName);
 
       // A missing helper raises 42883 and aborts the surrounding transaction.
       // This probe proves the write succeeded without leaving it in 25P02.

--- a/packages/vitest/src/__tests__/issue-2427-postgres-change-feed.optional.test.ts
+++ b/packages/vitest/src/__tests__/issue-2427-postgres-change-feed.optional.test.ts
@@ -1,0 +1,85 @@
+/**
+ * PostgreSQL isolated-test bootstrap contract for issue #2427.
+ *
+ * The isolated factory applies schema before opening its transaction. SMRT
+ * objects treat that transaction handle as already initialized, so the factory
+ * must also provision the PostgreSQL change-feed helper their writes require.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { describe, expect, it } from 'vitest';
+import { createIsolatedTestDb } from '../test-db.js';
+
+const postgresDescribe = process.env.SMRT_TEST_POSTGRES_URL
+  ? describe.sequential
+  : describe.skip;
+
+const tableSuffix = randomUUID().replaceAll('-', '').slice(0, 12);
+const tableName = `issue_2427_widget_${tableSuffix}`;
+
+class Issue2427Widget extends SmrtObject {
+  name: string = '';
+}
+smrt({ tableName })(Issue2427Widget);
+
+postgresDescribe('PostgreSQL isolated change-feed bootstrap (#2427)', () => {
+  it('provisions the append helper before the first transaction-scoped write', async () => {
+    const result = await createIsolatedTestDb({
+      schema: `CREATE TABLE "${tableName}" (
+        id UUID PRIMARY KEY NOT NULL,
+        slug TEXT NOT NULL,
+        context TEXT NOT NULL DEFAULT '',
+        created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+        updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+        name TEXT,
+        UNIQUE (slug, context)
+      )`,
+      prefix: 'issue-2427-change-feed',
+    });
+
+    try {
+      const helperResult = await result.db.query(
+        `SELECT to_regprocedure(
+          '_smrt_append_change(text,text,text,text,timestamp with time zone)'
+        ) AS helper`,
+      );
+      const helperRows = Array.isArray(helperResult)
+        ? helperResult
+        : ((helperResult as { rows?: Array<{ helper: string | null }> }).rows ??
+          []);
+      expect(helperRows[0]).toEqual(
+        expect.objectContaining({ helper: expect.any(String) }),
+      );
+
+      const widget = new Issue2427Widget({
+        db: result.db,
+        name: 'first transaction-scoped write',
+      });
+      await widget.initialize();
+      await expect(widget.save()).resolves.toBeDefined();
+
+      const feedResult = await result.db.query(
+        'SELECT seq, table_name FROM _smrt_changes ORDER BY seq ASC',
+      );
+      const feedRows = Array.isArray(feedResult)
+        ? feedResult
+        : ((feedResult as { rows?: Array<Record<string, unknown>> }).rows ??
+          []);
+      expect(feedRows).toEqual([
+        expect.objectContaining({ seq: '1', table_name: tableName }),
+      ]);
+
+      // A missing helper raises 42883 and aborts the surrounding transaction.
+      // This probe proves the write succeeded without leaving it in 25P02.
+      await expect(
+        result.db.query('SELECT 1 AS transaction_ok'),
+      ).resolves.toBeDefined();
+
+      await result.db.rollback();
+      await result.baseDb.query(`DROP TABLE IF EXISTS "${tableName}"`);
+    } finally {
+      await result.cleanup();
+    }
+  });
+});

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -41,7 +41,10 @@ import { join } from 'node:path';
 // that only knew `SmrtCollection`, so junction Collections filtered through
 // `createIsolatedTestDbFromManifest({ includeObjects: [...] })` were still
 // misclassified as table-bearing and lost their FK/junction columns.
-import { isSmrtCollectionExtendsName } from '@happyvertical/smrt-core';
+import {
+  ensureChangeFeedTable,
+  isSmrtCollectionExtendsName,
+} from '@happyvertical/smrt-core';
 import {
   type CollectedManifestTable,
   collectManifestTables,
@@ -504,6 +507,15 @@ export async function createIsolatedTestDb(
   // Sync schema if provided (must be done before transaction for DDL)
   if (schema && config.type !== 'sqlite') {
     await syncSchema({ db: baseDb, schema });
+  }
+
+  // Transaction handles are passed to SMRT objects as already-initialized
+  // databases, so they intentionally skip the normal SmrtClass bootstrap.
+  // PostgreSQL's change-feed writer depends on a framework-owned function;
+  // provision the canonical feed schema on the base connection before opening
+  // the test transaction so the first model write cannot abort that transaction.
+  if (config.type === 'postgres') {
+    await ensureChangeFeedTable(baseDb);
   }
 
   // Begin transaction for isolation


### PR DESCRIPTION
## Summary

- provision the canonical PostgreSQL change-feed schema on the isolated test base connection before opening its transaction
- add a real PostgreSQL 17 regression that saves a SMRT model through the change-feed interceptor and proves the transaction remains usable
- document the isolated-factory invariant and include the regression in `smrt-vitest`'s PostgreSQL lane

## Root cause

`createIsolatedTestDb` applied only application DDL and then returned a transaction handle. SMRT objects correctly treat that supplied transaction as already initialized, so normal class-level system-table bootstrap is bypassed. Since 0.42.0, the change-feed interceptor calls PostgreSQL's `_smrt_append_change` helper after a model save; on a fresh schema that helper did not exist, raising 42883 and aborting the test transaction.

The factory now calls the public, idempotent `ensureChangeFeedTable` initializer on the base connection before `beginTransaction()`. This preserves production initialization and reuses the existing advisory-lock concurrency semantics.

## Validation

- fresh PostgreSQL 17 reproduction without the fix: regression fails with `_smrt_append_change` absent
- fresh PostgreSQL 17 with fix: model save, feed-row assertion, and post-save transaction probe pass
- `pnpm --dir packages/vitest test:postgres` (3/3)
- `pnpm --dir packages/vitest test`
- `pnpm --dir packages/vitest typecheck`
- `pnpm --dir packages/core test` (3902 passed, 107 skipped)
- `pnpm build`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format-check`
- `pnpm check:standards`
- `pnpm audit:policy`
- `pnpm knowledge:check`
- bounded independent review cycle: PASS after strengthening the regression to an actual model/interceptor save

## Release intent

Release automation should generate a patch release for `@happyvertical/smrt-vitest`; no manual changeset is included per repository policy. From the current 0.42.0 cohort, the expected coordinated patch cohort is 0.42.1.

Closes #2427

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"root-smrt-2427","issue":"2427","policy_revision":"1.0.0","validation":["postgres17-model-regression","smrt-vitest-postgres","smrt-vitest-test","smrt-vitest-typecheck","core-test","root-build","root-test","root-typecheck","lint","format-check","standards","audit-policy","knowledge-check","review-cycle"]}
```
