### PR TITLE
fix(vitest): provision system tables before transactions

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -207,6 +207,11 @@ local development and watch mode.
 
 ## Schema paths (#2382)
 
+`ensureSystemTables(db, typeHint?)` is the public, idempotent provisioning
+boundary for framework-owned `_smrt_*` tables. Call it on a base PostgreSQL
+connection before opening a caller-owned transaction; its advisory-locked
+bootstrap prevents missing-table probes from poisoning that transaction.
+
 Production DDL comes from the **manifest** paths
 (`generateSTISchemaFromManifest`/`generateCTISchemaFromManifest`, selected in
 `src/scanner/manifest-generator.ts` → registered `schema` → `db:migrate`). The

--- a/packages/core/src/__tests__/issue-2429-system-bootstrap-export.test.ts
+++ b/packages/core/src/__tests__/issue-2429-system-bootstrap-export.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { ensureSystemTables } from '../index.js';
+
+describe('system-table bootstrap public surface (#2429)', () => {
+  it('exports the canonical provisioning boundary from smrt-core', () => {
+    expect(ensureSystemTables).toBeTypeOf('function');
+  });
+});

--- a/packages/core/src/class.ts
+++ b/packages/core/src/class.ts
@@ -16,20 +16,13 @@ import type {
   SmrtAiUsageEvent,
   SmrtAiUsageRecord,
 } from '@happyvertical/smrt-types';
-import {
-  type DatabaseInterface,
-  getDatabase,
-  type TransactionHandle,
-} from '@happyvertical/sql';
+import { type DatabaseInterface, getDatabase } from '@happyvertical/sql';
 import {
   AiUsageCollector,
   AiUsagePersistenceHandler,
 } from './adapters/ai-usage.js';
 import { estimateAiUsageCost } from './adapters/cost-rates.js';
-import {
-  ensurePostgresChangeFeedAppendFunction,
-  registerChangeFeedWriter,
-} from './change-feed.js';
+import { registerChangeFeedWriter } from './change-feed.js';
 import type {
   AIConfig,
   AiUsageConfig,
@@ -43,46 +36,19 @@ import { createFilesystemAdapter } from './filesystem-loader.js';
 import { applyPostgresRuntimeTimeouts } from './postgres-timeouts.js';
 import { detectEngine } from './schema/ddl/index.js';
 import { SignalBus } from './signals/bus.js';
+import { ensureSystemTables as ensureFrameworkSystemTables } from './system/bootstrap.js';
 import {
-  assertPostgresSystemTimestampsCurrent,
-  ensureBootstrapSystemTableCompatibility,
   ensureDeferredSystemTableCompatibility,
   tableExists,
 } from './system/compatibility.js';
-import { getSystemTableDDL, SMRT_SCHEMA_VERSION } from './system/schema.js';
+import { SMRT_SCHEMA_VERSION } from './system/schema.js';
 import { toSafeInteger } from './utils/safe-integer.js';
-
-const SYSTEM_TABLE_BOOTSTRAP_LOCK_SQL =
-  "SELECT pg_advisory_xact_lock(hashtext('smrt'), hashtext('system-tables'))";
 
 /**
  * `_smrt_migrations.version` suffix marking that the deferred (manifest-created)
  * system tables have been through their compatibility pass (issue #2376).
  */
 const DEFERRED_COMPATIBILITY_VERSION_SUFFIX = '+deferred-compat';
-
-/**
- * Timeout budget for the PostgreSQL system-table bootstrap transaction.
- *
- * The runtime pool's session `lock_timeout`/`statement_timeout` (#2377) are
- * sized for request work. This transaction is not request work: it holds the
- * advisory lock across up to 29 sequential DDL round-trips — ~18.85 s on the
- * high-latency link `bootstrapSystemTables` documents — and a second replica
- * cold-starting against the same fresh database *waits* on that lock. Both GUCs
- * bound that wait, because `pg_advisory_xact_lock` is an ordinary statement in
- * the lock manager, so at the runtime defaults the second replica would abort
- * with "canceling statement due to lock timeout" where it previously waited and
- * succeeded.
- *
- * Five minutes is an order of magnitude above the documented worst case and
- * still bounded — this is a raise, not a disable. `SET LOCAL` scopes it to this
- * transaction, the same lever migrations use for the same reason (#2362).
- */
-const SYSTEM_TABLE_BOOTSTRAP_TIMEOUT_MS = 300_000;
-const SYSTEM_TABLE_BOOTSTRAP_TIMEOUT_SQL = [
-  `SET LOCAL lock_timeout = '${SYSTEM_TABLE_BOOTSTRAP_TIMEOUT_MS}ms'`,
-  `SET LOCAL statement_timeout = '${SYSTEM_TABLE_BOOTSTRAP_TIMEOUT_MS}ms'`,
-];
 
 const logger = createLogger({ level: 'info' });
 
@@ -92,13 +58,6 @@ type DatabaseWithConfig = DatabaseInterface & {
     url?: string;
   };
   type?: string;
-};
-
-type TransactionCapableDatabase = DatabaseInterface & {
-  transaction?: <T>(
-    this: DatabaseInterface,
-    callback: (tx: DatabaseInterface) => Promise<T>,
-  ) => Promise<T>;
 };
 
 interface ResolvedAiUsageConfig {
@@ -899,9 +858,7 @@ export class SmrtClass {
     }
 
     try {
-      await this.withSystemTableBootstrapLock((db) =>
-        this.bootstrapSystemTables(db),
-      );
+      await ensureFrameworkSystemTables(this._db, this._dbEngineHint);
       await this.settleDeferredSystemTableCompatibility(this._db);
       await this.ensureNativeVectorStorage();
 
@@ -919,139 +876,6 @@ export class SmrtClass {
         { cause: error },
       );
     }
-  }
-
-  private async withSystemTableBootstrapLock<T>(
-    callback: (db: DatabaseInterface) => Promise<T>,
-  ): Promise<T> {
-    if (!this._db) {
-      throw new Error('Database is not initialized');
-    }
-
-    const beginTransaction = this._db.beginTransaction;
-    const transaction = (this._db as TransactionCapableDatabase).transaction;
-    const shouldUsePostgresLock =
-      detectEngine(getDatabaseUrl(this._db), this._dbEngineHint) === 'postgres';
-
-    if (!shouldUsePostgresLock) {
-      return callback(this._db);
-    }
-
-    if (typeof beginTransaction === 'function') {
-      const tx = await beginTransaction.call(this._db);
-      if (!tx) {
-        throw new Error('Database transaction could not be started');
-      }
-
-      try {
-        // Raise the budget before taking the lock — the wait itself is what the
-        // runtime session timeouts would otherwise cancel (#2377).
-        for (const sql of SYSTEM_TABLE_BOOTSTRAP_TIMEOUT_SQL) {
-          await tx.query(sql);
-        }
-        await tx.query(SYSTEM_TABLE_BOOTSTRAP_LOCK_SQL);
-        const result = await callback(tx);
-        await tx.commit();
-        return result;
-      } catch (error) {
-        await this.rollbackSystemTableBootstrap(tx);
-        throw error;
-      }
-    }
-
-    if (typeof transaction === 'function') {
-      const runInTransaction = transaction.bind(this._db) as <R>(
-        callback: (tx: DatabaseInterface) => Promise<R>,
-      ) => Promise<R>;
-
-      return runInTransaction(async (tx) => {
-        for (const sql of SYSTEM_TABLE_BOOTSTRAP_TIMEOUT_SQL) {
-          await tx.query(sql);
-        }
-        await tx.query(SYSTEM_TABLE_BOOTSTRAP_LOCK_SQL);
-        return callback(tx);
-      });
-    }
-
-    throw new Error(
-      'Postgres system table bootstrap requires a transaction-capable database adapter',
-    );
-  }
-
-  private async rollbackSystemTableBootstrap(
-    tx: TransactionHandle,
-  ): Promise<void> {
-    try {
-      if (typeof tx.isActive !== 'function' || tx.isActive()) {
-        await tx.rollback();
-      }
-    } catch (rollbackError) {
-      logger.warn(
-        `[smrt] Failed to rollback system table bootstrap transaction: ${rollbackError instanceof Error ? rollbackError.message : String(rollbackError)}`,
-      );
-    }
-  }
-
-  private async bootstrapSystemTables(db: DatabaseInterface): Promise<void> {
-    // Fast path: check if system tables already exist by querying _smrt_migrations.
-    // This avoids 29 sequential DDL round-trips on high-latency connections
-    // (e.g. remote Postgres over Tailscale where each round-trip is ~650ms).
-    // For Postgres, this runs after acquiring the advisory lock so concurrent
-    // initializers can observe a completed bootstrap and skip replaying DDL.
-    const version = SMRT_SCHEMA_VERSION;
-    if (await this.isSystemSchemaVersionApplied(db, version)) {
-      return;
-    }
-
-    // Older installs can have a subset of system columns already created.
-    // Upgrade those tables before replaying idempotent DDL so index creation
-    // does not fail on missing legacy columns. Only the tables this DDL creates
-    // are reshaped here — the manifest-owned deferred tables are settled after
-    // the lock releases, so a failure against a table the framework does not
-    // own cannot roll back system-table creation (issue #2376).
-    await ensureBootstrapSystemTableCompatibility(db, this._dbEngineHint);
-
-    // Create all system tables
-    // Split multi-statement SQL into individual statements to avoid race conditions
-    // Each entry contains CREATE TABLE + CREATE INDEX statements.
-    const engine = detectEngine(getDatabaseUrl(db), this._dbEngineHint);
-    const allStatements: string[] = [];
-    for (const multiStatementSQL of getSystemTableDDL(engine)) {
-      // Split on semicolon, filter out empty statements
-      const statements = multiStatementSQL
-        .split(';')
-        .map((s) => s.trim())
-        .filter((s) => s.length > 0);
-      allStatements.push(...statements);
-    }
-
-    // Use db.query() for system tables — they use CREATE TABLE/INDEX IF NOT EXISTS
-    // which databases handle natively in a single round-trip. The syncSchema()
-    // approach does per-column existence checks (multiple round-trips per table)
-    // which is unnecessary for framework-owned system tables and extremely slow
-    // on high-latency connections (e.g. remote postgres over Tailscale).
-    for (const statement of allStatements) {
-      await db.query(statement);
-    }
-
-    await ensurePostgresChangeFeedAppendFunction(db, {
-      typeHint: this._dbEngineHint,
-    });
-
-    // Never stamp the current version while a partial legacy installation
-    // still has timezone-naive framework timestamps. The explicit migration
-    // requires operator confirmation of historical UTC provenance.
-    await assertPostgresSystemTimestampsCurrent(db, this._dbEngineHint);
-
-    // Record current schema version
-    // Use ON CONFLICT for DuckDB compatibility (not INSERT OR IGNORE)
-    const id = crypto.randomUUID();
-    const description = 'Initial SMRT system tables';
-    await db.execute`
-      INSERT INTO _smrt_migrations (id, version, description)
-      VALUES (${id}, ${version}, ${description})
-      ON CONFLICT(version) DO NOTHING
-    `;
   }
 
   /**

--- a/packages/core/src/system/bootstrap.ts
+++ b/packages/core/src/system/bootstrap.ts
@@ -1,0 +1,166 @@
+/** Canonical, idempotent SMRT system-table provisioning. */
+
+import { createLogger } from '@happyvertical/logger';
+import type { DatabaseInterface, TransactionHandle } from '@happyvertical/sql';
+import { ensurePostgresChangeFeedAppendFunction } from '../change-feed.js';
+import {
+  assertPostgresSystemTimestampsCurrent,
+  ensureBootstrapSystemTableCompatibility,
+  getDatabaseEngine,
+  tableExists,
+} from './compatibility.js';
+import { getSystemTableDDL, SMRT_SCHEMA_VERSION } from './schema.js';
+
+const SYSTEM_TABLE_BOOTSTRAP_LOCK_SQL =
+  "SELECT pg_advisory_xact_lock(hashtext('smrt'), hashtext('system-tables'))";
+
+/**
+ * Timeout budget for the PostgreSQL system-table bootstrap transaction.
+ *
+ * The runtime pool's session `lock_timeout`/`statement_timeout` (#2377) are
+ * sized for request work. This transaction is not request work: it holds the
+ * advisory lock across up to 29 sequential DDL round-trips — ~18.85 s on a
+ * high-latency link at 650 ms per round trip — and a second replica cold-starting
+ * against the same fresh database *waits* on that lock. Both GUCs bound that
+ * wait, because `pg_advisory_xact_lock` is an ordinary statement in the lock
+ * manager, so at the runtime defaults the second replica would abort with
+ * "canceling statement due to lock timeout" where it previously waited and
+ * succeeded.
+ *
+ * Five minutes is an order of magnitude above the documented worst case and
+ * still bounded — this is a raise, not a disable. `SET LOCAL` scopes it to this
+ * transaction, the same lever migrations use for the same reason (#2362).
+ */
+const SYSTEM_TABLE_BOOTSTRAP_TIMEOUT_SQL = [
+  "SET LOCAL lock_timeout = '300000ms'",
+  "SET LOCAL statement_timeout = '300000ms'",
+];
+const logger = createLogger({ level: 'info' });
+
+type TransactionCapableDatabase = DatabaseInterface & {
+  transaction?: <T>(
+    this: DatabaseInterface,
+    callback: (tx: DatabaseInterface) => Promise<T>,
+  ) => Promise<T>;
+};
+
+function getQueryRows(result: unknown): Record<string, unknown>[] {
+  if (Array.isArray(result)) return result as Record<string, unknown>[];
+  if (result && typeof result === 'object' && 'rows' in result) {
+    const rows = (result as { rows?: unknown }).rows;
+    if (Array.isArray(rows)) return rows as Record<string, unknown>[];
+  }
+  return [];
+}
+
+async function isSystemSchemaVersionApplied(
+  db: DatabaseInterface,
+  typeHint?: string,
+): Promise<boolean> {
+  const engine = getDatabaseEngine(db, typeHint);
+  if (
+    engine === 'postgres' &&
+    !(await tableExists(db, '_smrt_migrations', typeHint))
+  ) {
+    return false;
+  }
+  try {
+    const versionParam = engine === 'postgres' ? '$1' : '?';
+    const rows = await db.query(
+      `SELECT 1 FROM _smrt_migrations WHERE version = ${versionParam} LIMIT 1`,
+      SMRT_SCHEMA_VERSION,
+    );
+    return getQueryRows(rows).length > 0;
+  } catch (error) {
+    if (engine === 'postgres') throw error;
+    return false;
+  }
+}
+
+async function bootstrapSystemTables(
+  db: DatabaseInterface,
+  typeHint?: string,
+): Promise<void> {
+  if (await isSystemSchemaVersionApplied(db, typeHint)) return;
+
+  await ensureBootstrapSystemTableCompatibility(db, typeHint);
+  const engine = getDatabaseEngine(db, typeHint);
+  for (const ddl of getSystemTableDDL(engine)) {
+    for (const statement of ddl
+      .split(';')
+      .map((value) => value.trim())
+      .filter(Boolean)) {
+      await db.query(statement);
+    }
+  }
+  await ensurePostgresChangeFeedAppendFunction(db, { typeHint });
+  await assertPostgresSystemTimestampsCurrent(db, typeHint);
+
+  const id = crypto.randomUUID();
+  const description = 'Initial SMRT system tables';
+  await db.execute`
+    INSERT INTO _smrt_migrations (id, version, description)
+    VALUES (${id}, ${SMRT_SCHEMA_VERSION}, ${description})
+    ON CONFLICT(version) DO NOTHING
+  `;
+}
+
+async function rollbackBootstrap(tx: TransactionHandle): Promise<void> {
+  try {
+    if (typeof tx.isActive !== 'function' || tx.isActive()) await tx.rollback();
+  } catch (error) {
+    logger.warn(
+      `[smrt] Failed to rollback system table bootstrap transaction: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+/**
+ * Ensure every framework-owned SMRT system table exists before use.
+ *
+ * PostgreSQL provisioning is serialized in a bounded advisory-locked
+ * transaction; other engines use the schema's idempotent DDL directly.
+ */
+export async function ensureSystemTables(
+  db: DatabaseInterface,
+  typeHint?: string,
+): Promise<void> {
+  if (getDatabaseEngine(db, typeHint) !== 'postgres') {
+    await bootstrapSystemTables(db, typeHint);
+    return;
+  }
+
+  const beginTransaction = db.beginTransaction;
+  const transaction = (db as TransactionCapableDatabase).transaction;
+  if (typeof beginTransaction === 'function') {
+    const tx = await beginTransaction.call(db);
+    if (!tx) throw new Error('Database transaction could not be started');
+    try {
+      // Raise the budget before taking the lock — the wait itself is what the
+      // runtime session timeouts would otherwise cancel (#2377).
+      for (const sql of SYSTEM_TABLE_BOOTSTRAP_TIMEOUT_SQL) await tx.query(sql);
+      await tx.query(SYSTEM_TABLE_BOOTSTRAP_LOCK_SQL);
+      await bootstrapSystemTables(tx, typeHint);
+      await tx.commit();
+      return;
+    } catch (error) {
+      await rollbackBootstrap(tx);
+      throw error;
+    }
+  }
+
+  if (typeof transaction === 'function') {
+    await transaction.call(db, async (tx) => {
+      for (const sql of SYSTEM_TABLE_BOOTSTRAP_TIMEOUT_SQL) await tx.query(sql);
+      await tx.query(SYSTEM_TABLE_BOOTSTRAP_LOCK_SQL);
+      await bootstrapSystemTables(tx, typeHint);
+    });
+    return;
+  }
+
+  throw new Error(
+    'Postgres system table bootstrap requires a transaction-capable database adapter',
+  );
+}

--- a/packages/core/src/system/index.ts
+++ b/packages/core/src/system/index.ts
@@ -5,7 +5,7 @@
  * All tables use _smrt_ prefix and share the application's database.
  */
 
-// Only export types - schema SQL strings are internal implementation details
+// Export the public runtime helpers and types; schema SQL stays internal.
 export { ensureSystemTables } from './bootstrap.js';
 export * from './compatibility.js';
 export * from './retention.js';

--- a/packages/core/src/system/index.ts
+++ b/packages/core/src/system/index.ts
@@ -6,6 +6,7 @@
  */
 
 // Only export types - schema SQL strings are internal implementation details
+export { ensureSystemTables } from './bootstrap.js';
 export * from './compatibility.js';
 export * from './retention.js';
 export * from './types.js';

--- a/packages/vitest/AGENTS.md
+++ b/packages/vitest/AGENTS.md
@@ -63,6 +63,11 @@ same `retry` policy inline in their own `vitest.config.ts`.
 
 ## Test Database Utilities
 
+PostgreSQL isolated factories provision all canonical framework-owned system
+tables on the base connection before opening the per-test transaction. A
+missing-table probe aborts the transaction even when optional-table logic
+catches the original error.
+
 | Function | Use Case |
 |----------|----------|
 | `createIsolatedTestDbFromManifest()` | Multi-table tests — auto-creates schema from manifest with FK ordering and STI dedup |

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -40,7 +40,7 @@
     "build": "tsc",
     "clean": "rm -rf dist",
     "test": "vitest run",
-    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/__tests__/issue-2069-postgres-manifest.optional.test.ts src/__tests__/issue-2427-postgres-change-feed.optional.test.ts",
+    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/__tests__/issue-2069-postgres-manifest.optional.test.ts src/__tests__/issue-2427-postgres-change-feed.optional.test.ts src/__tests__/issue-2429-postgres-system-tables.optional.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [

--- a/packages/vitest/src/__tests__/issue-2429-postgres-system-tables.optional.test.ts
+++ b/packages/vitest/src/__tests__/issue-2429-postgres-system-tables.optional.test.ts
@@ -1,0 +1,124 @@
+/**
+ * PostgreSQL isolated-test system bootstrap contract for issue #2429.
+ *
+ * Transaction handles intentionally bypass SmrtClass's connection bootstrap.
+ * The isolated factory therefore has to provision every framework-owned
+ * system table on the base connection before opening the transaction.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { createDispatchBus, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { describe, expect, it } from 'vitest';
+import { createIsolatedTestDb } from '../test-db.js';
+
+const postgresDescribe = process.env.SMRT_TEST_POSTGRES_URL
+  ? describe.sequential
+  : describe.skip;
+
+const tableSuffix = randomUUID().replaceAll('-', '').slice(0, 12);
+const tableName = `issue_2429_widget_${tableSuffix}`;
+
+class Issue2429Widget extends SmrtObject {
+  name: string = '';
+}
+smrt({ tableName })(Issue2429Widget);
+
+postgresDescribe('PostgreSQL isolated system-table bootstrap (#2429)', () => {
+  it('keeps context and embedding cascade cleanup transaction-safe', async () => {
+    const result = await createIsolatedTestDb({
+      schema: `CREATE TABLE "${tableName}" (
+        id UUID PRIMARY KEY NOT NULL,
+        slug TEXT NOT NULL,
+        context TEXT NOT NULL DEFAULT '',
+        created_at TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+        name TEXT,
+        UNIQUE (slug, context)
+      )`,
+      prefix: 'issue-2429-cascade',
+    });
+
+    try {
+      const tableResult = await result.db.query(
+        `SELECT to_regclass('_smrt_contexts') AS contexts,
+                to_regclass('_smrt_embeddings') AS embeddings`,
+      );
+      const tableRows = Array.isArray(tableResult)
+        ? tableResult
+        : ((
+            tableResult as {
+              rows?: Array<{
+                contexts: string | null;
+                embeddings: string | null;
+              }>;
+            }
+          ).rows ?? []);
+      expect(tableRows[0]).toEqual({
+        contexts: '_smrt_contexts',
+        embeddings: '_smrt_embeddings',
+      });
+
+      const widget = new Issue2429Widget({ db: result.db, name: 'cascade' });
+      await widget.initialize();
+      await widget.save();
+
+      await result.db.insert('_smrt_contexts', {
+        id: randomUUID(),
+        owner_class: 'Issue2429Widget',
+        owner_id: widget.id,
+        scope: 'test',
+        key: 'context',
+        value: '{}',
+      });
+      await result.db.insert('_smrt_embeddings', {
+        id: randomUUID(),
+        object_class: 'Issue2429Widget',
+        object_id: widget.id,
+        field_name: 'name',
+        content_hash: 'issue-2429',
+        embedding: '[]',
+        model: 'test',
+        dimensions: 0,
+      });
+
+      await expect(widget.delete()).resolves.toBeUndefined();
+      expect(
+        await result.db.count('_smrt_contexts', { owner_id: widget.id }),
+      ).toBe(0);
+      expect(
+        await result.db.count('_smrt_embeddings', { object_id: widget.id }),
+      ).toBe(0);
+      await expect(
+        result.db.query('SELECT 1 AS transaction_ok'),
+      ).resolves.toBeDefined();
+
+      await result.db.rollback();
+      await result.baseDb.query(`DROP TABLE IF EXISTS "${tableName}"`);
+    } finally {
+      await result.cleanup();
+    }
+  });
+
+  it('initializes dispatch without poisoning the isolated transaction', async () => {
+    const result = await createIsolatedTestDb({
+      prefix: 'issue-2429-dispatch',
+    });
+
+    try {
+      const bus = await createDispatchBus({ db: result.db });
+      const dispatch = await bus.emit(
+        'issue-2429.transaction-probe',
+        { ready: true },
+        { source: 'smrt-vitest' },
+      );
+      expect(await result.db.count('_smrt_dispatch', { id: dispatch.id })).toBe(
+        1,
+      );
+      await expect(
+        result.db.query('SELECT 1 AS transaction_ok'),
+      ).resolves.toBeDefined();
+    } finally {
+      await result.cleanup();
+    }
+  });
+});

--- a/packages/vitest/src/__tests__/issue-2429-postgres-system-tables.optional.test.ts
+++ b/packages/vitest/src/__tests__/issue-2429-postgres-system-tables.optional.test.ts
@@ -91,11 +91,13 @@ postgresDescribe('PostgreSQL isolated system-table bootstrap (#2429)', () => {
       await expect(
         result.db.query('SELECT 1 AS transaction_ok'),
       ).resolves.toBeDefined();
-
-      await result.db.rollback();
-      await result.baseDb.query(`DROP TABLE IF EXISTS "${tableName}"`);
     } finally {
-      await result.cleanup();
+      try {
+        if (result.db.isActive()) await result.db.rollback();
+        await result.baseDb.query(`DROP TABLE IF EXISTS "${tableName}"`);
+      } finally {
+        await result.cleanup();
+      }
     }
   });
 

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -42,7 +42,7 @@ import { join } from 'node:path';
 // `createIsolatedTestDbFromManifest({ includeObjects: [...] })` were still
 // misclassified as table-bearing and lost their FK/junction columns.
 import {
-  ensureChangeFeedTable,
+  ensureSystemTables,
   isSmrtCollectionExtendsName,
 } from '@happyvertical/smrt-core';
 import {
@@ -511,11 +511,11 @@ export async function createIsolatedTestDb(
 
   // Transaction handles are passed to SMRT objects as already-initialized
   // databases, so they intentionally skip the normal SmrtClass bootstrap.
-  // PostgreSQL's change-feed writer depends on a framework-owned function;
-  // provision the canonical feed schema on the base connection before opening
-  // the test transaction so the first model write cannot abort that transaction.
+  // A missing-table probe aborts a PostgreSQL transaction even when the caller
+  // catches the error. Provision every framework-owned system table on the base
+  // connection before opening the isolated transaction.
   if (config.type === 'postgres') {
-    await ensureChangeFeedTable(baseDb);
+    await ensureSystemTables(baseDb, config.type);
   }
 
   // Begin transaction for isolation


### PR DESCRIPTION
## Summary

- extract canonical, public `ensureSystemTables()` provisioning from `SmrtClass` without changing its advisory-lock, compatibility, timestamp, or bounded timeout behavior
- provision all framework-owned PostgreSQL system tables on the base connection before the isolated Vitest transaction starts
- cover the public root export and real PostgreSQL context/embedding cascade plus persisted dispatch behavior

## Validation

- `pnpm test`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm knowledge:check`
- `pnpm --dir packages/core test` (294 files passed; 3,902 tests passed)
- `pnpm --dir packages/vitest test` (7 files passed; 57 tests passed)
- `pnpm --dir packages/vitest test:postgres` (3 files passed; 5 tests passed on PostgreSQL 17)
- focused #2429 PostgreSQL 17 regression on a fresh database (2/2 passed)
- `pnpm --dir packages/core verify:exports`
- two-perspective review cycle; no material findings remain

## PostgreSQL lane note

The broader core optional PostgreSQL lane retains two independently reproduced baseline failures outside this diff: the #2069 SQL-adapter error wrapper assertion and the #1758 five-second concurrency barrier. Both fail in isolation on clean databases; the focused and `smrt-vitest` PostgreSQL lanes are green.

## Release intent

Release automation should generate the coordinated patch cohort; no manual changeset is included per repository policy.

Closes #2429

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-smrt-2429-20260820-reviewfix","issue":"2429","policy_revision":"1.0.0","validation":["postgres17-system-table-regression","smrt-vitest-postgres","smrt-vitest-test","smrt-vitest-typecheck","core-test","root-build","root-test","root-typecheck","lint","knowledge-check","verify-exports","review-cycle"]}
```