### PR TITLE
fix(core): require boolean tenant manifest columns

### DIFF
--- a/packages/core/src/generators/conditional-get.spec.ts
+++ b/packages/core/src/generators/conditional-get.spec.ts
@@ -355,9 +355,16 @@ describe('REST conditional GET + cache-control policy (#1757)', () => {
     });
 
     it('tenant-scoped models NEVER emit shared-cache headers, even public + sMaxage (#1757 review)', async () => {
-      const created = await create('tenantscoped', { name: 'tenant-a-row' });
-      expect(created.status).toBe(201);
-      const id = ((await created.json()) as any).id;
+      // The REST transport treats tenantId as server-owned, so seed through the
+      // scoped collection with an explicit tenant. This suite deliberately
+      // leaves tenancy disabled while it exercises cache headers.
+      const collection = await CondGetTenantScopedCollection.create({ db });
+      const item = await collection.create({
+        name: 'tenant-a-row',
+        tenantId: 'tenant-a',
+      });
+      await item.save();
+      const id = item.id;
 
       for (const path of ['tenantscoped', `tenantscoped/${id}`]) {
         const res = await handler(new Request(`http://local/api/v1/${path}`));

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -2187,7 +2187,7 @@ export class SmrtObject extends SmrtClass {
     // This is the fastest path - rules are serializable and don't require closures
     const validationRules = ObjectRegistry.getValidationRules(className);
 
-    if (validationRules && validationRules.length > 0) {
+    if (validationRules !== undefined) {
       const errors = await ObjectRegistry.validateWithRules(
         this,
         validationRules,

--- a/packages/core/src/registry.test.ts
+++ b/packages/core/src/registry.test.ts
@@ -7,11 +7,13 @@ import {
   TestOrder,
 } from './__tests__/fixtures/registry-test-classes.js';
 import { SmrtCollection } from './collection';
-import { ConfigurationError } from './errors';
+import { ConfigurationError, ValidationError } from './errors';
+import { GlobalInterceptors } from './interceptors';
 import { SmrtObject } from './object';
 import { ObjectRegistry, smrt } from './registry';
 import type { FieldDefinition } from './scanner/types.js';
 import { snapshotObjectRegistryState } from './test-utils.js';
+import { getTestDatabase } from './testing/database.js';
 import { tableNameFromClass } from './utils';
 
 // Helper class to create field definitions for manual registration
@@ -1687,6 +1689,85 @@ describe('ObjectRegistry', () => {
 
       const rules = ObjectRegistry.getValidationRules('NoRulesClass');
       expect(rules).toBeUndefined();
+    });
+
+    it('treats an explicit empty manifest rule list as authoritative', () => {
+      ObjectRegistry.registerFromManifest('AutoPopulatedTenantValidation', {
+        className: 'AutoPopulatedTenantValidation',
+        fields: {
+          tenantId: {
+            type: 'foreignKey',
+            required: true,
+            _meta: {
+              __tenancy: {
+                isTenantIdField: true,
+                autoPopulate: true,
+              },
+            },
+          },
+        },
+        methods: {},
+        validationRules: [],
+      });
+
+      expect(
+        ObjectRegistry.getValidationRules('AutoPopulatedTenantValidation'),
+      ).toEqual([]);
+      expect(
+        ObjectRegistry.getValidators('AutoPopulatedTenantValidation'),
+      ).toBeUndefined();
+    });
+
+    it('allows a beforeSave hook to populate a manifest-required tenant field', async () => {
+      @smrt({ tenantScoped: true })
+      class AutoPopulatedTenantSave extends SmrtObject {
+        title = '';
+      }
+
+      class AutoPopulatedTenantSaveCollection extends SmrtCollection<AutoPopulatedTenantSave> {
+        static readonly _itemClass = AutoPopulatedTenantSave;
+      }
+
+      const registered = ObjectRegistry.getClass('AutoPopulatedTenantSave');
+      if (!registered) {
+        throw new Error('Expected tenant-scoped class registration');
+      }
+      // Generated manifests intentionally leave this list empty: tenantId is
+      // required in storage but populated by beforeSave.
+      registered.validationRules = [];
+      // A stale fallback validator must not run once the manifest supplied an
+      // explicit rule list, even one with no rules.
+      registered.validators = [
+        async () =>
+          ValidationError.requiredField('tenantId', 'AutoPopulatedTenantSave'),
+      ];
+
+      GlobalInterceptors.register({
+        name: 'tenant-auto-populate',
+        beforeSave(instance) {
+          (
+            instance as AutoPopulatedTenantSave & { tenantId?: string }
+          ).tenantId = 'tenant-save';
+        },
+      });
+
+      const db = await getTestDatabase({
+        type: 'sqlite',
+        url: ':memory:',
+        classes: ['AutoPopulatedTenantSave'],
+      });
+      try {
+        const collection = await AutoPopulatedTenantSaveCollection.create({
+          db,
+        });
+        const doc = await collection.create({ title: 'saved' });
+        await doc.save();
+
+        expect(doc.tenantId).toBe('tenant-save');
+      } finally {
+        GlobalInterceptors.clear();
+        await db.close();
+      }
     });
 
     it('should validate required fields with validateWithRules()', async () => {

--- a/packages/core/src/registry/class-registration.ts
+++ b/packages/core/src/registry/class-registration.ts
@@ -1167,7 +1167,7 @@ export function register(
   let validators: ValidatorFunction[] | undefined;
 
   // Only compile validators if no pre-computed rules exist
-  if (!validationRules || validationRules.length === 0) {
+  if (validationRules === undefined) {
     validators = compileValidators(name, fields);
   } else {
     verboseLog(
@@ -1877,7 +1877,7 @@ export function registerFromManifest(
 
   // Only compile validators if no pre-computed rules exist
   // (backward compatibility for older manifests)
-  if (!validationRules || validationRules.length === 0) {
+  if (validationRules === undefined) {
     validators = compileValidators(name, fields);
     verboseLog(
       `[registry] No pre-computed rules for ${name}, compiled ${validators.length} validators`,

--- a/packages/core/src/scanner/__tests__/manifest-generator.test.ts
+++ b/packages/core/src/scanner/__tests__/manifest-generator.test.ts
@@ -445,6 +445,7 @@ describe('ManifestGenerator', () => {
       expect(secret.fields.tenantId).toEqual(
         expect.objectContaining({
           type: 'text',
+          required: true,
           _meta: expect.objectContaining({
             sqlType: 'UUID',
             __tenancy: expect.objectContaining({
@@ -456,8 +457,72 @@ describe('ManifestGenerator', () => {
         }),
       );
       expect(secret.schema?.columns.tenant_id).toEqual(
-        expect.objectContaining({ type: 'UUID', referenceKind: 'tenantId' }),
+        expect.objectContaining({
+          type: 'UUID',
+          referenceKind: 'tenantId',
+          notNull: true,
+        }),
       );
+    });
+
+    it.each([
+      [{ mode: 'required' }, true, true],
+      [{ mode: 'optional' }, false, false],
+    ] as const)('uses the normalized %o tenant mode for field and schema nullability', (tenantScoped, required, notNull) => {
+      const generator = new ManifestGenerator();
+      const manifest = generator.generateManifest([
+        {
+          filePath: '/path/to/scoped-object.ts',
+          objects: [
+            {
+              name: 'scopedObject',
+              className: 'ScopedObject',
+              collection: 'scoped_objects',
+              filePath: '/path/to/scoped-object.ts',
+              fields: {},
+              methods: {},
+              decoratorConfig: { tenantScoped },
+              exportName: 'ScopedObject',
+              collectionExportName: 'ScopedObjectCollection',
+            },
+          ],
+          imports: [],
+          exports: [],
+        },
+      ]);
+
+      const scopedObject = manifest.objects.scopedObject;
+      expect(scopedObject.fields.tenantId?.required).toBe(required);
+      expect(scopedObject.schema?.columns.tenant_id.notNull).toBe(notNull);
+    });
+
+    it('does not inject a tenant field when tenant scoping is disabled', () => {
+      const generator = new ManifestGenerator();
+      const manifest = generator.generateManifest([
+        {
+          filePath: '/path/to/unscoped-object.ts',
+          objects: [
+            {
+              name: 'unscopedObject',
+              className: 'UnscopedObject',
+              collection: 'unscoped_objects',
+              filePath: '/path/to/unscoped-object.ts',
+              fields: {},
+              methods: {},
+              decoratorConfig: { tenantScoped: false },
+              exportName: 'UnscopedObject',
+              collectionExportName: 'UnscopedObjectCollection',
+            },
+          ],
+          imports: [],
+          exports: [],
+        },
+      ]);
+
+      expect(manifest.objects.unscopedObject.fields.tenantId).toBeUndefined();
+      expect(
+        manifest.objects.unscopedObject.schema?.columns.tenant_id,
+      ).toBeUndefined();
     });
 
     it('preserves explicit tenantId fields while adding tenancy metadata', () => {

--- a/packages/core/src/scanner/__tests__/manifest-generator.test.ts
+++ b/packages/core/src/scanner/__tests__/manifest-generator.test.ts
@@ -463,6 +463,48 @@ describe('ManifestGenerator', () => {
           notNull: true,
         }),
       );
+      expect(secret.validationRules).toEqual([]);
+    });
+
+    it.each([
+      [true, false],
+      [{ mode: 'required' }, false],
+      [{ mode: 'required', autoPopulate: false }, true],
+      [{ mode: 'optional' }, false],
+    ] as const)('keeps required validation aligned with tenant auto-population for %o', (tenantScoped, includesTenantRequiredRule) => {
+      const generator = new ManifestGenerator();
+      const manifest = generator.generateManifest([
+        {
+          filePath: '/path/to/tenant-validation.ts',
+          objects: [
+            {
+              name: 'tenantValidation',
+              className: 'TenantValidation',
+              collection: 'tenant_validations',
+              filePath: '/path/to/tenant-validation.ts',
+              fields: { title: { type: 'text', required: true } },
+              methods: {},
+              decoratorConfig: { tenantScoped },
+              exportName: 'TenantValidation',
+              collectionExportName: 'TenantValidationCollection',
+            },
+          ],
+          imports: [],
+          exports: [],
+        },
+      ]);
+
+      const rules = manifest.objects.tenantValidation.validationRules ?? [];
+      expect(
+        rules.some(
+          (rule) => rule.field === 'tenantId' && rule.rule === 'required',
+        ),
+      ).toBe(includesTenantRequiredRule);
+      expect(
+        rules.some(
+          (rule) => rule.field === 'title' && rule.rule === 'required',
+        ),
+      ).toBe(true);
     });
 
     it.each([

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -343,8 +343,7 @@ export class ManifestGenerator {
       return;
     }
 
-    const { tenantConfig, tenantOptions } =
-      this.normalizeTenantScopedConfig(tenantScoped);
+    const { tenantConfig } = this.normalizeTenantScopedConfig(tenantScoped);
     const fieldName = tenantConfig.field;
     const existingField = objectDef.fields[fieldName];
     const tenancyMeta = {
@@ -376,10 +375,9 @@ export class ManifestGenerator {
 
     objectDef.fields[fieldName] = {
       type: 'text',
-      // Preserve legacy migration behavior: boolean `tenantScoped: true`
-      // enables required-mode runtime scoping, but does not add a NOT NULL
-      // column to existing tables unless mode is explicitly set.
-      required: tenantOptions.mode === 'required',
+      // Use the normalized tenant mode so the boolean shorthand has the same
+      // requiredness in manifests as it does during runtime registration.
+      required: tenantConfig.mode === 'required',
       _meta: {
         generated: true,
         source: 'tenantScoped_decorator',
@@ -493,7 +491,6 @@ export class ManifestGenerator {
   }
 
   private normalizeTenantScopedConfig(tenantScoped: unknown): {
-    tenantOptions: TenantScopedOptions;
     tenantConfig: {
       mode: string;
       field: string;
@@ -508,7 +505,6 @@ export class ManifestGenerator {
         : (tenantScoped as TenantScopedOptions);
 
     return {
-      tenantOptions,
       tenantConfig: {
         mode: tenantOptions.mode ?? 'required',
         field: tenantOptions.field ?? 'tenantId',

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -529,6 +529,7 @@ export class ManifestGenerator {
   generateValidationRules(manifest: SmartObjectManifest): void {
     for (const [name, obj] of Object.entries(manifest.objects)) {
       const rules: ValidationRule[] = [];
+      let skippedAutoPopulatedTenantRequiredRule = false;
 
       for (const [fieldName, field] of Object.entries(obj.fields)) {
         // Skip transient fields (they're not persisted, so no validation needed)
@@ -539,12 +540,26 @@ export class ManifestGenerator {
         const options = field._meta || {};
 
         // Required field rule
-        if (options.required || field.required) {
+        const isAutoPopulatedTenantField =
+          options.__tenancy?.isTenantIdField === true &&
+          options.__tenancy.autoPopulate !== false;
+        if (
+          (options.required || field.required) &&
+          !isAutoPopulatedTenantField
+        ) {
           rules.push({
             field: fieldName,
             rule: 'required',
             fieldType: field.type,
           });
+        } else if (
+          isAutoPopulatedTenantField &&
+          (options.required || field.required)
+        ) {
+          // Tenant IDs can be required in the manifest and database while still
+          // being absent at this pre-interceptor validation stage. Tenancy's
+          // beforeSave hook stamps them from the active context before writing.
+          skippedAutoPopulatedTenantRequiredRule = true;
         }
 
         // Numeric range rules (for integer, decimal fields)
@@ -615,8 +630,10 @@ export class ManifestGenerator {
         }
       }
 
-      // Only add validationRules if there are any rules
-      if (rules.length > 0) {
+      // An explicit empty list is meaningful when the sole required field is
+      // auto-populated by tenancy: it prevents runtime registration from
+      // recompiling a pre-interceptor required validator for that field.
+      if (rules.length > 0 || skippedAutoPopulatedTenantRequiredRule) {
         obj.validationRules = rules;
       }
     }

--- a/packages/core/src/scanner/types.ts
+++ b/packages/core/src/scanner/types.ts
@@ -86,6 +86,8 @@ export interface FieldMeta {
   /** Tenancy metadata injected for tenant-scoped models. */
   __tenancy?: {
     isTenantIdField?: boolean;
+    /** Populated by the tenancy beforeSave interceptor when enabled. */
+    autoPopulate?: boolean;
     [key: string]: unknown;
   };
   /** Report-aggregate metadata injected by the report normalizer. */

--- a/packages/core/src/vite-plugin/local-manifest.test.ts
+++ b/packages/core/src/vite-plugin/local-manifest.test.ts
@@ -502,6 +502,7 @@ describe('smrtPlugin local manifest writing (Issue #963)', () => {
     expect(tenantScopedThing?.fields.tenantId).toEqual(
       expect.objectContaining({
         type: 'text',
+        required: true,
         _meta: expect.objectContaining({
           sqlType: 'UUID',
           __tenancy: expect.objectContaining({
@@ -512,7 +513,11 @@ describe('smrtPlugin local manifest writing (Issue #963)', () => {
       }),
     );
     expect(tenantScopedThing?.schema?.columns.tenant_id).toEqual(
-      expect.objectContaining({ type: 'UUID', referenceKind: 'tenantId' }),
+      expect.objectContaining({
+        type: 'UUID',
+        referenceKind: 'tenantId',
+        notNull: true,
+      }),
     );
   });
 

--- a/packages/messages/src/__tests__/small-models.test.ts
+++ b/packages/messages/src/__tests__/small-models.test.ts
@@ -19,6 +19,7 @@ import { EmailFolder } from '../models/EmailFolder';
 import { Whitelist } from '../models/Whitelist';
 
 let db: DatabaseInterface;
+const TEST_TENANT_ID = 'test-messaging-tenant';
 
 beforeEach(async () => {
   db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
@@ -71,6 +72,7 @@ describe('Whitelist.matches()', () => {
     const entry = new Whitelist({
       pattern: 'allow@example.com',
       type: 'email',
+      tenantId: TEST_TENANT_ID,
       db,
     });
     entry.category = 'newsletter';
@@ -92,6 +94,7 @@ describe('Whitelist.matches()', () => {
     const scoped = new Whitelist({
       pattern: 'support@vendor.com',
       type: 'email',
+      tenantId: TEST_TENANT_ID,
       db,
     });
     scoped.category = 'billing';
@@ -150,6 +153,7 @@ describe('Blacklist.matches()', () => {
     const entry = new Blacklist({
       pattern: 'evil.com',
       type: 'domain',
+      tenantId: TEST_TENANT_ID,
       db,
     });
     entry.reason = 'known spammer';

--- a/packages/tenancy/src/__tests__/issue-2431-manifest-auto-populate.test.ts
+++ b/packages/tenancy/src/__tests__/issue-2431-manifest-auto-populate.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Regression for boolean tenantScoped manifests requiring tenant_id before the
+ * tenancy beforeSave hook can auto-populate it.
+ */
+
+import {
+  field,
+  ObjectRegistry,
+  SmrtCollection,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
+import { ManifestGenerator } from '@happyvertical/smrt-core/scanner';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { withTenant } from '../context.js';
+import { disableTenancy, enableTenancy } from '../interceptor.js';
+
+afterEach(() => {
+  disableTenancy();
+  ObjectRegistry.clear();
+});
+
+describe('boolean tenantScoped manifest auto-population (#2431)', () => {
+  it('stamps a manifest-required tenantId before saving inside withTenant()', async () => {
+    const manifest = new ManifestGenerator().generateManifest([
+      {
+        filePath: '/fixtures/manifest-tenant-doc-2431.ts',
+        objects: [
+          {
+            name: 'manifestTenantDoc2431',
+            className: 'ManifestTenantDoc2431',
+            collection: 'manifest_tenant_docs_2431',
+            filePath: '/fixtures/manifest-tenant-doc-2431.ts',
+            fields: { title: { type: 'text', required: true } },
+            methods: {},
+            decoratorConfig: { tenantScoped: true },
+            exportName: 'ManifestTenantDoc2431',
+            collectionExportName: 'ManifestTenantDoc2431Collection',
+          },
+        ],
+        imports: [],
+        exports: [],
+      },
+    ]);
+    const definition = manifest.objects.manifestTenantDoc2431;
+
+    expect(definition.fields.tenantId?.required).toBe(true);
+    expect(definition.schema?.columns.tenant_id.notNull).toBe(true);
+    expect(
+      definition.validationRules?.some(
+        (rule) => rule.field === 'tenantId' && rule.rule === 'required',
+      ),
+    ).toBe(false);
+
+    // This is the runtime production path: a manifest stub is registered first
+    // and is then promoted when the application loads the real decorator class.
+    ObjectRegistry.registerFromManifest('ManifestTenantDoc2431', definition);
+
+    @smrt({ tenantScoped: true })
+    class ManifestTenantDoc2431 extends SmrtObject {
+      @field({ type: 'text' })
+      title = '';
+    }
+
+    class ManifestTenantDoc2431Collection extends SmrtCollection<ManifestTenantDoc2431> {
+      static readonly _itemClass = ManifestTenantDoc2431;
+    }
+
+    ObjectRegistry.registerCollection(
+      'ManifestTenantDoc2431',
+      ManifestTenantDoc2431Collection,
+    );
+
+    const registered = ObjectRegistry.getClass('ManifestTenantDoc2431');
+    expect(registered?.validationRules).toEqual(definition.validationRules);
+    expect(registered?.validators).toBeUndefined();
+
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['ManifestTenantDoc2431'],
+    });
+    try {
+      enableTenancy();
+      const collection = await ManifestTenantDoc2431Collection.create({ db });
+      const doc = await withTenant({ tenantId: 'tenant-2431' }, async () => {
+        const created = await collection.create({ title: 'Scoped document' });
+        await created.save();
+        return created;
+      });
+
+      expect(doc.tenantId).toBe('tenant-2431');
+      await withTenant({ tenantId: 'tenant-2431' }, async () => {
+        const persisted = await collection.get(doc.id as string);
+        expect(persisted?.tenantId).toBe('tenant-2431');
+      });
+    } finally {
+      await db.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- derive manifest tenant-column requiredness from canonical normalized tenancy configuration
- preserve required manifest/database storage while letting tenancy auto-populate beforeSave fields
- cover boolean shorthand, explicit required/optional modes, disabled tenancy, and autoPopulate false
- update tenant-scoped core and messages test fixtures to provide their required tenant identity

Fixes #2431

## Validation

- focused manifest/registry/save-path and real tenancy withTenant SQLite regressions
- core and tenancy typechecks; tenancy suite: 166 passed
- workspace build/typecheck/test and PostgreSQL core validation from the initial exact-head release cycle
- independent review-cycle clean

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-tenant-manifest-required-autopopulate-20260820","issue":"2431","policy_revision":"1.0.0","validation":["focused manifest/registry/save-path and real tenancy withTenant SQLite regressions","core and tenancy typechecks; tenancy suite: 166 passed","strict changed knowledge check","independent review-cycle clean"]}