### PR TITLE
feat(smrt-ui): add DataTable view controller

### DIFF
--- a/packages/smrt-ui/README.md
+++ b/packages/smrt-ui/README.md
@@ -102,6 +102,99 @@ apply, clear, or undo. Agent mutations are denied for secret/read-only controls
 and require explicit confirmation before apply, clear, or undo. Staging is
 separate so the UI can show a proposal before it changes user state.
 
+## DataTable controller
+
+`DataTable` can share one headless `DataTableController` between rendered
+controls and a programmatic adapter. Search, declarative filters, ordered
+multi-column sorting, pagination, columns, selection, and expansion all become
+plain-data commands; a header click and `controller.dispatch()` take the same
+transition path.
+
+```svelte
+<script lang="ts">
+  import {
+    createDataTableController,
+    DataTable,
+    type DataTableColumn,
+  } from '@happyvertical/smrt-ui/data';
+
+  const controller = createDataTableController({
+    columnIds: ['name', 'status'],
+    initialState: {
+      pageSize: 25,
+      sorting: [{ columnId: 'name', direction: 'asc' }],
+    },
+  });
+
+  controller.dispatch({
+    type: 'setFilters',
+    filters: [{ columnId: 'status', operator: 'equals', value: 'active' }],
+  });
+</script>
+
+<DataTable {controller} data={rows} {columns} rowKey="id" sortable selectable />
+```
+
+`controller.snapshot()` returns a canonical JSON-safe `{ version, modes,
+state }` envelope. It contains no rows, callbacks, snippets, storage handles,
+tenant/principal data, query objects, or authority. URL and saved-view adapters
+remain application-owned: persist the snapshot (normally excluding selection
+and expansion IDs), validate it with `hydrateDataTableSnapshot`, and feed the
+state into a new controller or `replaceState`. `smrt-ui` does not read or write
+the URL, browser storage, or a database.
+
+### Controlled and migration use
+
+Pass `state` plus `onStateChange` for controlled state. A controlled controller
+emits a candidate and waits for the host to call `replaceState`; an
+uncontrolled controller owns the state initialized by `initialState`.
+
+The existing Svelte bindables remain supported during migration:
+
+| Existing prop | Controller state |
+| --- | --- |
+| `bind:sort` | first entry of ordered `sorting` (single-sort compatibility) |
+| `bind:page`, `pageSize` | `page`, `pageSize` |
+| `bind:selected`, `bind:expanded` | canonical `selectedRowIds`, `expandedRowIds` arrays |
+| `visibleColumnIds` | `columnVisibility` intersected with static `column.hidden` |
+| `manualSorting`, `manualPagination` | sorting/pagination entries in `modes` |
+| `filterFn` | local-only legacy predicate; never serialized |
+
+An explicit `controller` takes precedence over `state` and legacy bindables.
+Without one, the component creates an internal controller and maps the legacy
+props. Multi-column sorting and persisted layouts use the controller state;
+the legacy `SortState` remains intentionally single-column.
+
+Use a stable `rowKey` when selected or expanded state can survive a sort,
+filter, refresh, or page change. The historical index fallback remains only
+for local presentational compatibility; it is not portable across remote data
+or persisted/agent-controlled views. Select-all means the currently rendered
+page. Query-wide "all matching" selection belongs to the data-surface layer.
+
+### Transformation ownership and page rules
+
+`modes` makes each stage explicit. A `manual` stage renders caller-supplied
+results and bypasses that local stage, so rows are never double-filtered,
+double-sorted, or double-paged.
+
+| Filtering | Sorting | Pagination | Renderer behavior |
+| --- | --- | --- | --- |
+| `local` | `local` | `local` | filter → ordered multi-sort → slice |
+| `manual` | `local` | `local` | sort and slice supplied rows |
+| `local` | `manual` | `local` | filter and slice supplied rows |
+| `local` | `local` | `manual` | filter and sort supplied page; never slice it |
+| `manual` | `manual` | `manual` | render supplied rows unchanged |
+
+Every combination follows the same rule per column in the table: each local
+stage runs once and each manual stage runs zero times. For manual pagination,
+`totalRows` supplies the total; when it is unknown the component does not guess
+the last page or render misleading pagination controls.
+
+Changing search, filters, sorting, or page size resets the page to 1 only when
+the value changes. Data or total changes clamp an out-of-range page but do not
+otherwise reset it; empty known totals normalize to page 1. Column layout,
+selection, and expansion never change the page.
+
 ## Themes
 
 `@happyvertical/smrt-ui/themes` is the canonical theme API and includes the

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -333,7 +333,7 @@ function matchesFilter(
   column: DataTableColumn<T>,
   filter: DataTableFilter,
 ): boolean {
-  if (column.filterable === false) return false;
+  if (column.filterable === false) return true;
   const value = getCellValue(row, column);
   if (column.filterFn) return column.filterFn(row, value, filter);
   const expected = filter.value;
@@ -448,6 +448,8 @@ const displayIndexOffset = $derived(
 );
 
 $effect(() => {
+  void tableState.page;
+  void tableState.pageSize;
   activeController().clampPage(totalRowCount);
 });
 

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -16,12 +16,17 @@ import { M } from '../../i18n/strings.js';
 import Trans from '../../i18n/Trans.svelte';
 import { useI18n } from '../../i18n/use-i18n.js';
 import Pagination from '../ui/Pagination.svelte';
-import type {
-  DataTableColumn,
-  DataTableProps,
-  SortDirection,
-  SortState,
-} from './types.js';
+import {
+  createDataTableController,
+  type DataTableCommand,
+  type DataTableController,
+  type DataTableFilter,
+  type DataTableModes,
+  type DataTableRowId,
+  type DataTableSnapshot,
+  type DataTableViewState,
+} from './DataTableController.js';
+import type { DataTableColumn, DataTableProps, SortState } from './types.js';
 import { defaultSort, getNestedValue } from './types.js';
 
 const { t } = useI18n();
@@ -68,85 +73,208 @@ let {
   caption,
   dense = false,
   cell,
+  controller,
+  state: controlledState,
+  initialState,
+  onStateChange,
+  modes,
 }: ExtendedProps<T> = $props();
 
-// Get row key value
-function getRowKey(row: T, index: number): string | number {
-  if (!rowKey) return index;
-  if (typeof rowKey === 'function') return rowKey(row);
-  return row[rowKey] as string | number;
+function legacyModes(): DataTableModes {
+  return {
+    filtering: modes?.filtering ?? 'local',
+    sorting: modes?.sorting ?? (manualSorting ? 'manual' : 'local'),
+    pagination: modes?.pagination ?? (manualPagination ? 'manual' : 'local'),
+  };
 }
 
-function getDisplayRowKey(row: T, index: number): string | number {
+function legacyViewState(): Partial<DataTableViewState> {
+  return {
+    sorting:
+      sort.columnId && sort.direction
+        ? [{ columnId: sort.columnId, direction: sort.direction }]
+        : [],
+    page,
+    pageSize: pageSize ?? null,
+    columnOrder: columns.map((column) => column.id),
+    columnVisibility: columns.map((column) => ({
+      columnId: column.id,
+      visible: !visibleColumnIds || visibleColumnIds.has(column.id),
+    })),
+    selectedRowIds: [...selected],
+    expandedRowIds: [...expanded],
+  };
+}
+
+const localController = createDataTableController({
+  onStateChange: (next, command) => onStateChange?.(next, command),
+});
+
+let controllerSnapshot = $state<DataTableSnapshot>(localController.snapshot());
+let publishedLegacySignature: string | undefined;
+let localControllerInitialized = false;
+
+function activeController(): DataTableController {
+  return controller ?? localController;
+}
+
+function legacySignature(): string {
+  const legacy = legacyViewState();
+  return JSON.stringify({
+    sorting: legacy.sorting,
+    page: legacy.page,
+    pageSize: legacy.pageSize,
+    columnVisibility: legacy.columnVisibility,
+    selectedRowIds: [...(legacy.selectedRowIds ?? [])].sort(),
+    expandedRowIds: [...(legacy.expandedRowIds ?? [])].sort(),
+  });
+}
+
+function legacySort(next: DataTableViewState): SortState {
+  const rule = next.sorting[0];
+  return rule
+    ? { columnId: rule.columnId, direction: rule.direction }
+    : { columnId: null, direction: null };
+}
+
+function publishLegacyState(
+  next: DataTableViewState,
+  command: DataTableCommand,
+  previous: DataTableViewState,
+) {
+  const nextSort = legacySort(next);
+  const previousSort = legacySort(previous);
+  sort = nextSort;
+  page = next.page;
+  selected = new Set(next.selectedRowIds);
+  expanded = new Set(next.expandedRowIds);
+  publishedLegacySignature = legacySignature();
+
+  if (
+    nextSort.columnId !== previousSort.columnId ||
+    nextSort.direction !== previousSort.direction
+  ) {
+    onSortChange?.(nextSort);
+  }
+  if (
+    JSON.stringify(next.selectedRowIds) !==
+    JSON.stringify(previous.selectedRowIds)
+  ) {
+    onSelectionChange?.(new Set(next.selectedRowIds));
+  }
+  if (
+    JSON.stringify(next.expandedRowIds) !==
+    JSON.stringify(previous.expandedRowIds)
+  ) {
+    onExpandedChange?.(new Set(next.expandedRowIds));
+  }
+  if (next.page !== previous.page) onPageChange?.(next.page);
+  void command;
+}
+
+$effect(() => {
+  if (controller) return;
+
+  localController.setControlled(controlledState !== undefined);
+  localController.setModes(legacyModes());
+  localController.setColumnIds(columns.map((column) => column.id));
+
+  if (!localControllerInitialized) {
+    localControllerInitialized = true;
+    localController.replaceState({
+      ...localController.getState(),
+      ...(controlledState ?? { ...legacyViewState(), ...initialState }),
+    });
+    return;
+  }
+
+  if (controlledState !== undefined) {
+    localController.replaceState(controlledState);
+    return;
+  }
+
+  const signature = legacySignature();
+  if (signature === publishedLegacySignature) {
+    publishedLegacySignature = undefined;
+    return;
+  }
+  localController.replaceState({
+    ...localController.getState(),
+    ...legacyViewState(),
+  });
+});
+
+$effect(() => {
+  const current = activeController();
+  current.setColumnIds(columns.map((column) => column.id));
+  controllerSnapshot = current.snapshot();
+  return current.subscribe((transition) => {
+    controllerSnapshot = transition.next;
+    if (
+      current === localController &&
+      controlledState === undefined &&
+      transition.command
+    ) {
+      publishLegacyState(
+        transition.next.state,
+        transition.command,
+        transition.previous.state,
+      );
+    }
+  });
+});
+
+const tableState = $derived(controllerSnapshot.state);
+const tableModes = $derived(controllerSnapshot.modes);
+
+function getRowKey(row: T, index: number): DataTableRowId {
+  if (!rowKey) return index;
+  if (typeof rowKey === 'function') return rowKey(row);
+  return row[rowKey] as DataTableRowId;
+}
+
+function getDisplayRowKey(row: T, index: number): DataTableRowId {
   return getRowKey(row, displayIndexOffset + index);
 }
 
-// Handle sort click
-function handleSort(column: DataTableColumn<T>) {
+function dispatch(command: DataTableCommand) {
+  activeController().dispatch(command);
+}
+
+function handleSort(column: DataTableColumn<T>, event: MouseEvent) {
   if (!sortable || !column.sortable) return;
-
-  const newSort: SortState = {
+  dispatch({
+    type: 'toggleSorting',
     columnId: column.id,
-    direction:
-      sort.columnId === column.id
-        ? sort.direction === 'asc'
-          ? 'desc'
-          : sort.direction === 'desc'
-            ? null
-            : 'asc'
-        : 'asc',
-  };
-
-  if (newSort.direction === null) {
-    newSort.columnId = null;
-  }
-
-  sort = newSort;
-  onSortChange?.(newSort);
+    multi: event.shiftKey,
+  });
 }
 
-// Handle row selection
-function handleRowSelect(key: string | number, event: Event) {
+function handleRowSelect(key: DataTableRowId, event: Event) {
   event.stopPropagation();
-  const newSelected = new Set(selected);
-
-  if (newSelected.has(key)) {
-    newSelected.delete(key);
-  } else {
-    newSelected.add(key);
-  }
-
-  selected = newSelected;
-  onSelectionChange?.(newSelected);
+  dispatch({ type: 'toggleRowSelection', rowId: key });
 }
 
-// Handle select all
 function handleSelectAll() {
+  const selectedIds = new Set(tableState.selectedRowIds);
+  const visibleIds = displayData.map((row, index) =>
+    getDisplayRowKey(row, index),
+  );
   if (allSelected) {
-    const visibleKeys = new Set(
-      displayData.map((row, i) => getDisplayRowKey(row, i)),
-    );
-    selected = new Set([...selected].filter((key) => !visibleKeys.has(key)));
+    for (const key of visibleIds) selectedIds.delete(key);
   } else {
-    selected = new Set([
-      ...selected,
-      ...displayData.map((row, i) => getDisplayRowKey(row, i)),
-    ]);
+    for (const key of visibleIds) selectedIds.add(key);
   }
-  onSelectionChange?.(selected);
+  dispatch({ type: 'setSelectedRows', rowIds: [...selectedIds] });
 }
 
-function handleExpanded(key: string | number, event: Event) {
+function handleExpanded(key: DataTableRowId, event: Event) {
   event.stopPropagation();
-  const next = new Set(expanded);
-  next.has(key) ? next.delete(key) : next.add(key);
-  expanded = next;
-  onExpandedChange?.(next);
+  dispatch({ type: 'toggleRowExpansion', rowId: key });
 }
 
 function handlePageChange(next: number) {
-  page = Math.min(Math.max(1, next), totalPages);
-  onPageChange?.(page);
+  dispatch({ type: 'setPage', page: next });
 }
 
 // Handle row click
@@ -164,55 +292,175 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
   };
 }
 
-// Get visible columns
-const visibleColumns = $derived(
-  columns.filter(
-    (col) => !col.hidden && (!visibleColumnIds || visibleColumnIds.has(col.id)),
-  ),
-);
+const visibleColumns = $derived.by(() => {
+  const configuredOrder = new Map(
+    tableState.columnOrder.map((id, index) => [id, index]),
+  );
+  const visibility = new Map(
+    tableState.columnVisibility.map((entry) => [entry.columnId, entry.visible]),
+  );
+  return columns
+    .filter((column) => !column.hidden && visibility.get(column.id) !== false)
+    .slice()
+    .sort((left, right) => {
+      const leftOrder = configuredOrder.get(left.id) ?? Number.MAX_SAFE_INTEGER;
+      const rightOrder =
+        configuredOrder.get(right.id) ?? Number.MAX_SAFE_INTEGER;
+      return leftOrder - rightOrder;
+    });
+});
 
-const filteredData = $derived(filterFn ? data.filter(filterFn) : data);
+function sameFilterValue(value: unknown, expected: unknown): boolean {
+  return Object.is(value, expected);
+}
 
-// Sort data
-const sortedData = $derived.by(() => {
-  if (manualSorting || !sort.columnId || !sort.direction) return filteredData;
+function textValue(value: unknown): string {
+  return String(value ?? '').toLowerCase();
+}
 
-  const column = columns.find((c) => c.id === sort.columnId);
-  if (!column) return filteredData;
+function compareFilterValues(left: unknown, right: unknown): number {
+  const leftValue = left instanceof Date ? left.getTime() : left;
+  const rightValue = right instanceof Date ? right.getTime() : right;
+  if (typeof leftValue === 'number' && typeof rightValue === 'number')
+    return leftValue - rightValue;
+  const a = String(leftValue ?? '');
+  const b = String(rightValue ?? '');
+  return a < b ? -1 : a > b ? 1 : 0;
+}
 
-  const accessor = column.accessor ?? column.id;
-  const direction = sort.direction;
+function matchesFilter(
+  row: T,
+  column: DataTableColumn<T>,
+  filter: DataTableFilter,
+): boolean {
+  if (column.filterable === false) return false;
+  const value = getCellValue(row, column);
+  if (column.filterFn) return column.filterFn(row, value, filter);
+  const expected = filter.value;
+  const valueText = textValue(value);
+  const expectedText = textValue(expected);
+  switch (filter.operator) {
+    case 'equals':
+      return sameFilterValue(value, expected);
+    case 'notEquals':
+      return !sameFilterValue(value, expected);
+    case 'contains':
+      return valueText.includes(expectedText);
+    case 'notContains':
+      return !valueText.includes(expectedText);
+    case 'startsWith':
+      return valueText.startsWith(expectedText);
+    case 'endsWith':
+      return valueText.endsWith(expectedText);
+    case 'in':
+      return (
+        Array.isArray(expected) &&
+        expected.some((entry) => sameFilterValue(value, entry))
+      );
+    case 'notIn':
+      return (
+        Array.isArray(expected) &&
+        !expected.some((entry) => sameFilterValue(value, entry))
+      );
+    case 'gt':
+      return compareFilterValues(value, expected) > 0;
+    case 'gte':
+      return compareFilterValues(value, expected) >= 0;
+    case 'lt':
+      return compareFilterValues(value, expected) < 0;
+    case 'lte':
+      return compareFilterValues(value, expected) <= 0;
+    case 'isNull':
+      return value == null;
+    case 'isNotNull':
+      return value != null;
+  }
+}
 
-  return [...filteredData].sort((a, b) => {
-    if (column.sortFn) {
-      return column.sortFn(a, b, direction);
+const filteredData = $derived.by(() => {
+  if (tableModes.filtering === 'manual') return data;
+  const search = tableState.search.toLowerCase();
+  return data.filter((row, index) => {
+    if (filterFn && !filterFn(row, index)) return false;
+    if (
+      search &&
+      !columns.some(
+        (column) =>
+          column.searchable !== false &&
+          textValue(getCellValue(row, column)).includes(search),
+      )
+    ) {
+      return false;
     }
-    return defaultSort(a, b, String(accessor), direction);
+    return tableState.filters.every((filter) => {
+      const column = columns.find(
+        (candidate) => candidate.id === filter.columnId,
+      );
+      return Boolean(column && matchesFilter(row, column, filter));
+    });
   });
 });
 
-const totalRowCount = $derived(totalRows ?? sortedData.length);
+const sortedData = $derived.by(() => {
+  if (tableModes.sorting === 'manual' || tableState.sorting.length === 0)
+    return filteredData;
+  return filteredData
+    .map((row, index) => ({ row, index }))
+    .sort((left, right) => {
+      for (const rule of tableState.sorting) {
+        const column = columns.find(
+          (candidate) => candidate.id === rule.columnId,
+        );
+        if (!column) continue;
+        const result = column.sortFn
+          ? column.sortFn(left.row, right.row, rule.direction)
+          : defaultSort(
+              left.row,
+              right.row,
+              String(column.accessor ?? column.id),
+              rule.direction,
+            );
+        if (result !== 0) return result;
+      }
+      return left.index - right.index;
+    })
+    .map(({ row }) => row);
+});
+
+const totalRowCount = $derived(
+  tableModes.pagination === 'manual' ? totalRows : sortedData.length,
+);
 const totalPages = $derived(
-  pageSize ? Math.max(1, Math.ceil(totalRowCount / pageSize)) : 1,
+  tableState.pageSize
+    ? totalRowCount === undefined
+      ? null
+      : Math.max(1, Math.ceil(totalRowCount / tableState.pageSize))
+    : 1,
 );
 const displayData = $derived.by(() => {
-  if (!pageSize || manualPagination) return sortedData;
-  const start = (page - 1) * pageSize;
-  return sortedData.slice(start, start + pageSize);
+  if (!tableState.pageSize || tableModes.pagination === 'manual')
+    return sortedData;
+  const start = (tableState.page - 1) * tableState.pageSize;
+  return sortedData.slice(start, start + tableState.pageSize);
 });
-const displayIndexOffset = $derived(pageSize ? (page - 1) * pageSize : 0);
+const displayIndexOffset = $derived(
+  tableState.pageSize ? (tableState.page - 1) * tableState.pageSize : 0,
+);
 
 $effect(() => {
-  if (page > totalPages) handlePageChange(totalPages);
+  activeController().clampPage(totalRowCount);
 });
 
-// Selection state
+const selectedIds = $derived(new Set(tableState.selectedRowIds));
+const expandedIds = $derived(new Set(tableState.expandedRowIds));
+const currentSort = $derived(legacySort(tableState));
+
 const allSelected = $derived(
   displayData.length > 0 &&
-    displayData.every((row, i) => selected.has(getDisplayRowKey(row, i))),
+    displayData.every((row, i) => selectedIds.has(getDisplayRowKey(row, i))),
 );
 const someSelected = $derived(
-  displayData.some((row, i) => selected.has(getDisplayRowKey(row, i))) &&
+  displayData.some((row, i) => selectedIds.has(getDisplayRowKey(row, i))) &&
     !allSelected,
 );
 
@@ -220,13 +468,11 @@ const columnCount = $derived(
   visibleColumns.length + (selectable ? 1 : 0) + (expandedContent ? 1 : 0),
 );
 
-// Get cell value
 function getCellValue(row: T, column: DataTableColumn<T>): unknown {
   const accessor = column.accessor ?? column.id;
   return getNestedValue(row, String(accessor));
 }
 
-// Size classes
 const sizeClasses = {
   sm: 'data-table--sm',
   md: 'data-table--md',
@@ -267,14 +513,14 @@ const sizeClasses = {
           <th
             class="data-table__cell data-table__cell--header"
             class:data-table__cell--sortable={sortable && column.sortable}
-            class:data-table__cell--sorted={sort.columnId === column.id}
+            class:data-table__cell--sorted={currentSort.columnId === column.id}
             style:width={column.width}
             style:min-width={column.minWidth}
             style:max-width={column.maxWidth}
             style:text-align={column.align}
             scope="col"
-            aria-sort={sort.columnId === column.id
-              ? sort.direction === 'asc'
+            aria-sort={currentSort.columnId === column.id
+              ? currentSort.direction === 'asc'
                 ? 'ascending'
                 : 'descending'
               : undefined}
@@ -285,12 +531,12 @@ const sizeClasses = {
               <button
                 type="button"
                 class="data-table__sort-button"
-                onclick={() => handleSort(column)}
+                onclick={(event) => handleSort(column, event)}
               >
                 <span>{column.label}</span>
                 <span class="data-table__sort-icon" aria-hidden="true">
-                  {#if sort.columnId === column.id}
-                    {sort.direction === 'asc' ? '↑' : '↓'}
+                  {#if currentSort.columnId === column.id}
+                    {currentSort.direction === 'asc' ? '↑' : '↓'}
                   {:else}
                     ↕
                   {/if}
@@ -335,8 +581,8 @@ const sizeClasses = {
       {:else}
         {#each displayData as row, index (getDisplayRowKey(row, index))}
           {@const key = getDisplayRowKey(row, index)}
-          {@const isSelected = selected.has(key)}
-          {@const isExpanded = expanded.has(key)}
+          {@const isSelected = selectedIds.has(key)}
+          {@const isExpanded = expandedIds.has(key)}
           {@const rowCanExpand = canExpand?.(row, index) ?? true}
           <tr
             class="data-table__row {rowClass?.(row, index) ?? ''}"
@@ -397,7 +643,7 @@ const sizeClasses = {
     {/if}
   </table>
 </div>
-{#if pageSize && totalPages > 1}<Pagination currentPage={page} {totalPages} onPageChange={handlePageChange} aria-label="Table pages" />{/if}
+{#if tableState.pageSize && totalPages && totalPages > 1}<Pagination currentPage={tableState.page} {totalPages} onPageChange={handlePageChange} aria-label="Table pages" />{/if}
 
 <style>
   .data-table-container {

--- a/packages/smrt-ui/src/components/data/DataTableController.ts
+++ b/packages/smrt-ui/src/components/data/DataTableController.ts
@@ -1,0 +1,749 @@
+/**
+ * Headless, transport-neutral state for DataTable.
+ *
+ * The controller intentionally stores only view preferences. It never stores
+ * rows, callbacks, query objects, principals, or persistence adapters.
+ */
+
+export type DataTableRowId = string | number;
+
+export type DataTableJsonPrimitive = string | number | boolean | null;
+export type DataTableJsonValue =
+  | DataTableJsonPrimitive
+  | DataTableJsonValue[]
+  | { [key: string]: DataTableJsonValue };
+
+export type DataTableOperationMode = 'local' | 'manual';
+
+/** Which layer owns each transformation. `manual` means the caller supplied it. */
+export interface DataTableModes {
+  filtering: DataTableOperationMode;
+  sorting: DataTableOperationMode;
+  pagination: DataTableOperationMode;
+}
+
+export interface DataTableSortRule {
+  columnId: string;
+  direction: 'asc' | 'desc';
+}
+
+export type DataTableFilterOperator =
+  | 'equals'
+  | 'notEquals'
+  | 'contains'
+  | 'notContains'
+  | 'startsWith'
+  | 'endsWith'
+  | 'in'
+  | 'notIn'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'isNull'
+  | 'isNotNull';
+
+/** A serializable, declarative filter. Filters are combined with AND semantics. */
+export interface DataTableFilter {
+  columnId: string;
+  operator: DataTableFilterOperator;
+  value?: DataTableJsonValue;
+}
+
+/** A column visibility entry. The array form keeps snapshots JSON-safe. */
+export interface DataTableColumnVisibility {
+  columnId: string;
+  visible: boolean;
+}
+
+/**
+ * The JSON-safe, persistable portion of a table view. Selection and expansion
+ * are serialized as canonical arrays rather than Sets.
+ */
+export interface DataTableViewState {
+  search: string;
+  filters: DataTableFilter[];
+  sorting: DataTableSortRule[];
+  page: number;
+  pageSize: number | null;
+  columnOrder: string[];
+  columnVisibility: DataTableColumnVisibility[];
+  selectedRowIds: DataTableRowId[];
+  expandedRowIds: DataTableRowId[];
+}
+
+/** The stable envelope intended for URL and saved-view adapters. */
+export interface DataTableSnapshot {
+  version: 1;
+  modes: DataTableModes;
+  state: DataTableViewState;
+}
+
+/** Every mutable table interaction has a plain-data command representation. */
+export type DataTableCommand =
+  | { type: 'setSearch'; search: string }
+  | { type: 'setFilters'; filters: DataTableFilter[] }
+  | { type: 'setSorting'; sorting: DataTableSortRule[] }
+  | { type: 'toggleSorting'; columnId: string; multi?: boolean }
+  | { type: 'setPage'; page: number }
+  | { type: 'setPageSize'; pageSize: number | null }
+  | { type: 'setColumnOrder'; columnIds: string[] }
+  | { type: 'setColumnVisibility'; columns: DataTableColumnVisibility[] }
+  | { type: 'setSelectedRows'; rowIds: DataTableRowId[] }
+  | { type: 'toggleRowSelection'; rowId: DataTableRowId }
+  | { type: 'setExpandedRows'; rowIds: DataTableRowId[] }
+  | { type: 'toggleRowExpansion'; rowId: DataTableRowId }
+  | { type: 'reset' };
+
+export interface DataTableTransition {
+  command: DataTableCommand | null;
+  previous: DataTableSnapshot;
+  next: DataTableSnapshot;
+  changed: boolean;
+}
+
+export interface DataTableControllerOptions {
+  /** Used by uncontrolled controllers. */
+  initialState?: Partial<DataTableViewState>;
+  /** Makes transitions proposals until `replaceState` supplies the next value. */
+  state?: DataTableViewState;
+  modes?: Partial<DataTableModes>;
+  /** Optional known columns let the controller ignore stale saved-view fields. */
+  columnIds?: readonly string[];
+  onStateChange?: (
+    state: DataTableViewState,
+    command: DataTableCommand,
+  ) => void;
+}
+
+export type DataTableStateListener = (transition: DataTableTransition) => void;
+
+const DEFAULT_MODES: DataTableModes = {
+  filtering: 'local',
+  sorting: 'local',
+  pagination: 'local',
+};
+
+const DEFAULT_STATE: DataTableViewState = {
+  search: '',
+  filters: [],
+  sorting: [],
+  page: 1,
+  pageSize: null,
+  columnOrder: [],
+  columnVisibility: [],
+  selectedRowIds: [],
+  expandedRowIds: [],
+};
+
+const FILTER_OPERATORS = new Set<DataTableFilterOperator>([
+  'equals',
+  'notEquals',
+  'contains',
+  'notContains',
+  'startsWith',
+  'endsWith',
+  'in',
+  'notIn',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'isNull',
+  'isNotNull',
+]);
+
+function assertColumnId(value: unknown, label = 'column id'): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new TypeError(`DataTable ${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function assertRowId(value: unknown): DataTableRowId {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' && Number.isFinite(value))
+    return value === 0 ? 0 : value;
+  throw new TypeError('DataTable row ids must be finite strings or numbers');
+}
+
+function assertPage(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new TypeError('DataTable page must be a finite number');
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+function assertPageSize(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value <= 0
+  ) {
+    throw new TypeError(
+      'DataTable pageSize must be a positive integer or null',
+    );
+  }
+  return value;
+}
+
+function canonicalJson(
+  value: unknown,
+  ancestors = new Set<object>(),
+): DataTableJsonValue {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new TypeError(
+        'DataTable values must not contain non-finite numbers',
+      );
+    }
+    return value === 0 ? 0 : value;
+  }
+  if (Array.isArray(value)) {
+    if (ancestors.has(value))
+      throw new TypeError('DataTable values must not be circular');
+    ancestors.add(value);
+    const result = value.map((entry) => canonicalJson(entry, ancestors));
+    ancestors.delete(value);
+    return result;
+  }
+  if (
+    value &&
+    typeof value === 'object' &&
+    Object.getPrototypeOf(value) === Object.prototype
+  ) {
+    if (ancestors.has(value))
+      throw new TypeError('DataTable values must not be circular');
+    ancestors.add(value);
+    const result: { [key: string]: DataTableJsonValue } = {};
+    for (const key of Object.keys(value).sort()) {
+      result[key] = canonicalJson(
+        (value as Record<string, unknown>)[key],
+        ancestors,
+      );
+    }
+    ancestors.delete(value);
+    return result;
+  }
+  throw new TypeError('DataTable values must be JSON-safe plain data');
+}
+
+function jsonSignature(value: unknown): string {
+  return JSON.stringify(canonicalJson(value));
+}
+
+function compareRowIds(left: DataTableRowId, right: DataTableRowId): number {
+  if (typeof left !== typeof right) return typeof left === 'number' ? -1 : 1;
+  if (typeof left === 'number' && typeof right === 'number')
+    return left - right;
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function rowIdKey(value: DataTableRowId): string {
+  return `${typeof value}:${String(value)}`;
+}
+
+function normalizeRowIds(values: readonly DataTableRowId[]): DataTableRowId[] {
+  const ids = new Map<string, DataTableRowId>();
+  for (const value of values) {
+    const id = assertRowId(value);
+    ids.set(rowIdKey(id), id);
+  }
+  return [...ids.values()].sort(compareRowIds);
+}
+
+function normalizeUniqueColumnIds(values: readonly string[]): string[] {
+  const ids = new Set<string>();
+  for (const value of values) ids.add(assertColumnId(value));
+  return [...ids];
+}
+
+function normalizeFilters(
+  values: readonly DataTableFilter[],
+): DataTableFilter[] {
+  const filters = values.map((filter) => {
+    const columnId = assertColumnId(filter?.columnId, 'filter column id');
+    if (!FILTER_OPERATORS.has(filter?.operator)) {
+      throw new TypeError(
+        `Unsupported DataTable filter operator: ${String(filter?.operator)}`,
+      );
+    }
+    const needsValue =
+      filter.operator !== 'isNull' && filter.operator !== 'isNotNull';
+    if (needsValue && !Object.hasOwn(filter, 'value')) {
+      throw new TypeError(
+        `DataTable filter ${filter.operator} requires a value`,
+      );
+    }
+    const value = Object.hasOwn(filter, 'value')
+      ? canonicalJson(filter.value)
+      : undefined;
+    return value === undefined
+      ? { columnId, operator: filter.operator }
+      : { columnId, operator: filter.operator, value };
+  });
+  return filters.sort((left, right) => {
+    const leftKey = `${left.columnId}\u0000${left.operator}\u0000${jsonSignature(
+      Object.hasOwn(left, 'value') ? (left.value as DataTableJsonValue) : null,
+    )}`;
+    const rightKey = `${right.columnId}\u0000${right.operator}\u0000${jsonSignature(
+      Object.hasOwn(right, 'value')
+        ? (right.value as DataTableJsonValue)
+        : null,
+    )}`;
+    return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+  });
+}
+
+function normalizeSorting(
+  values: readonly DataTableSortRule[],
+): DataTableSortRule[] {
+  const seen = new Set<string>();
+  const result: DataTableSortRule[] = [];
+  for (const rule of values) {
+    const columnId = assertColumnId(rule?.columnId, 'sort column id');
+    if (rule?.direction !== 'asc' && rule?.direction !== 'desc') {
+      throw new TypeError('DataTable sort directions must be asc or desc');
+    }
+    if (!seen.has(columnId)) {
+      seen.add(columnId);
+      result.push({ columnId, direction: rule.direction });
+    }
+  }
+  return result;
+}
+
+function normalizeVisibility(
+  values: readonly DataTableColumnVisibility[],
+): DataTableColumnVisibility[] {
+  const entries = new Map<string, boolean>();
+  for (const entry of values) {
+    const columnId = assertColumnId(entry?.columnId, 'visibility column id');
+    if (typeof entry?.visible !== 'boolean') {
+      throw new TypeError('DataTable column visibility must be boolean');
+    }
+    entries.set(columnId, entry.visible);
+  }
+  return [...entries.entries()]
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([columnId, visible]) => ({ columnId, visible }));
+}
+
+function normalizeModes(
+  modes: Partial<DataTableModes> | undefined,
+): DataTableModes {
+  const result = { ...DEFAULT_MODES, ...modes };
+  for (const mode of Object.values(result)) {
+    if (mode !== 'local' && mode !== 'manual') {
+      throw new TypeError('DataTable modes must be local or manual');
+    }
+  }
+  return result;
+}
+
+function normalizeState(
+  state: Partial<DataTableViewState> | undefined,
+  columnIds?: readonly string[],
+): DataTableViewState {
+  const input = state ?? {};
+  const knownColumns = columnIds ? normalizeUniqueColumnIds(columnIds) : null;
+  const allowed = knownColumns ? new Set(knownColumns) : null;
+  const keepKnown = (columnId: string) => !allowed || allowed.has(columnId);
+  const visibility = normalizeVisibility(
+    input.columnVisibility ?? DEFAULT_STATE.columnVisibility,
+  ).filter((entry) => keepKnown(entry.columnId));
+  const knownVisibility = new Map(
+    visibility.map((entry) => [entry.columnId, entry.visible]),
+  );
+
+  if (knownColumns) {
+    for (const columnId of knownColumns) {
+      if (!knownVisibility.has(columnId)) knownVisibility.set(columnId, true);
+    }
+  }
+
+  const columnOrder = normalizeUniqueColumnIds(
+    input.columnOrder ?? DEFAULT_STATE.columnOrder,
+  ).filter(keepKnown);
+  if (knownColumns) {
+    for (const columnId of knownColumns) {
+      if (!columnOrder.includes(columnId)) columnOrder.push(columnId);
+    }
+  }
+
+  return {
+    search:
+      typeof input.search === 'string' ? input.search : DEFAULT_STATE.search,
+    filters: normalizeFilters(input.filters ?? DEFAULT_STATE.filters).filter(
+      (filter) => keepKnown(filter.columnId),
+    ),
+    sorting: normalizeSorting(input.sorting ?? DEFAULT_STATE.sorting).filter(
+      (sort) => keepKnown(sort.columnId),
+    ),
+    page: assertPage(input.page ?? DEFAULT_STATE.page),
+    pageSize: assertPageSize(input.pageSize ?? DEFAULT_STATE.pageSize),
+    columnOrder,
+    columnVisibility: normalizeVisibility(
+      [...knownVisibility.entries()].map(([columnId, visible]) => ({
+        columnId,
+        visible,
+      })),
+    ),
+    selectedRowIds: normalizeRowIds(
+      input.selectedRowIds ?? DEFAULT_STATE.selectedRowIds,
+    ),
+    expandedRowIds: normalizeRowIds(
+      input.expandedRowIds ?? DEFAULT_STATE.expandedRowIds,
+    ),
+  };
+}
+
+function stateSignature(state: DataTableViewState): string {
+  return jsonSignature(canonicalJson(state));
+}
+
+function snapshotSignature(snapshot: DataTableSnapshot): string {
+  return jsonSignature(canonicalJson(snapshot));
+}
+
+function cloneState(state: DataTableViewState): DataTableViewState {
+  return canonicalJson(state) as unknown as DataTableViewState;
+}
+
+function cloneSnapshot(snapshot: DataTableSnapshot): DataTableSnapshot {
+  return canonicalJson(snapshot) as unknown as DataTableSnapshot;
+}
+
+function resetPage(
+  state: DataTableViewState,
+  changed: boolean,
+): DataTableViewState {
+  return changed && state.page !== 1 ? { ...state, page: 1 } : state;
+}
+
+/** Apply one command without mutating the supplied state. */
+export function transitionDataTableState(
+  state: DataTableViewState,
+  command: DataTableCommand,
+): DataTableViewState {
+  const current = normalizeState(state);
+  let next: DataTableViewState;
+
+  switch (command.type) {
+    case 'setSearch': {
+      if (typeof command.search !== 'string')
+        throw new TypeError('DataTable search must be a string');
+      next = resetPage(
+        { ...current, search: command.search },
+        command.search !== current.search,
+      );
+      break;
+    }
+    case 'setFilters': {
+      const filters = normalizeFilters(command.filters);
+      const changed = jsonSignature(filters) !== jsonSignature(current.filters);
+      next = resetPage({ ...current, filters }, changed);
+      break;
+    }
+    case 'setSorting': {
+      const sorting = normalizeSorting(command.sorting);
+      const changed = jsonSignature(sorting) !== jsonSignature(current.sorting);
+      next = resetPage({ ...current, sorting }, changed);
+      break;
+    }
+    case 'toggleSorting': {
+      const columnId = assertColumnId(command.columnId, 'sort column id');
+      const index = current.sorting.findIndex(
+        (rule) => rule.columnId === columnId,
+      );
+      const previous = index >= 0 ? current.sorting[index] : undefined;
+      const toggled: DataTableSortRule | null = !previous
+        ? { columnId, direction: 'asc' }
+        : previous.direction === 'asc'
+          ? { columnId, direction: 'desc' }
+          : null;
+      const sorting = command.multi
+        ? previous
+          ? toggled
+            ? current.sorting.map((rule, ruleIndex) =>
+                ruleIndex === index ? toggled : rule,
+              )
+            : current.sorting.filter((rule) => rule.columnId !== columnId)
+          : [...current.sorting, toggled as DataTableSortRule]
+        : toggled
+          ? [toggled]
+          : [];
+      next = resetPage(
+        { ...current, sorting },
+        jsonSignature(sorting) !== jsonSignature(current.sorting),
+      );
+      break;
+    }
+    case 'setPage':
+      next = { ...current, page: assertPage(command.page) };
+      break;
+    case 'setPageSize': {
+      const pageSize = assertPageSize(command.pageSize);
+      next = resetPage({ ...current, pageSize }, pageSize !== current.pageSize);
+      break;
+    }
+    case 'setColumnOrder':
+      next = {
+        ...current,
+        columnOrder: normalizeUniqueColumnIds(command.columnIds),
+      };
+      break;
+    case 'setColumnVisibility':
+      next = {
+        ...current,
+        columnVisibility: normalizeVisibility(command.columns),
+      };
+      break;
+    case 'setSelectedRows':
+      next = { ...current, selectedRowIds: normalizeRowIds(command.rowIds) };
+      break;
+    case 'toggleRowSelection': {
+      const rowId = assertRowId(command.rowId);
+      const ids = new Map(
+        current.selectedRowIds.map((id) => [rowIdKey(id), id]),
+      );
+      ids.has(rowIdKey(rowId))
+        ? ids.delete(rowIdKey(rowId))
+        : ids.set(rowIdKey(rowId), rowId);
+      next = { ...current, selectedRowIds: normalizeRowIds([...ids.values()]) };
+      break;
+    }
+    case 'setExpandedRows':
+      next = { ...current, expandedRowIds: normalizeRowIds(command.rowIds) };
+      break;
+    case 'toggleRowExpansion': {
+      const rowId = assertRowId(command.rowId);
+      const ids = new Map(
+        current.expandedRowIds.map((id) => [rowIdKey(id), id]),
+      );
+      ids.has(rowIdKey(rowId))
+        ? ids.delete(rowIdKey(rowId))
+        : ids.set(rowIdKey(rowId), rowId);
+      next = { ...current, expandedRowIds: normalizeRowIds([...ids.values()]) };
+      break;
+    }
+    case 'reset':
+      next = { ...DEFAULT_STATE };
+      break;
+    default:
+      throw new TypeError(
+        `Unsupported DataTable command: ${String((command as { type?: unknown }).type)}`,
+      );
+  }
+
+  return normalizeState(next);
+}
+
+/** Parse persisted state defensively before an external adapter restores it. */
+export function hydrateDataTableSnapshot(value: unknown): DataTableSnapshot {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    Object.getPrototypeOf(value) !== Object.prototype
+  ) {
+    throw new TypeError('DataTable snapshot must be a plain object');
+  }
+  const input = value as Record<string, unknown>;
+  if (input.version !== 1)
+    throw new TypeError('Unsupported DataTable snapshot version');
+  return {
+    version: 1,
+    modes: normalizeModes(input.modes as Partial<DataTableModes>),
+    state: normalizeState(input.state as Partial<DataTableViewState>),
+  };
+}
+
+/** A headless state owner used by both rendered controls and programmatic commands. */
+export class DataTableController {
+  private state: DataTableViewState;
+  private modes: DataTableModes;
+  private columnIds?: string[];
+  private controlled: boolean;
+  private readonly listeners = new Set<DataTableStateListener>();
+  private readonly onStateChange?: DataTableControllerOptions['onStateChange'];
+  private pendingControlledState?: string;
+
+  constructor(options: DataTableControllerOptions = {}) {
+    this.columnIds = options.columnIds
+      ? normalizeUniqueColumnIds(options.columnIds)
+      : undefined;
+    this.controlled = options.state !== undefined;
+    this.state = normalizeState(
+      options.state ?? options.initialState,
+      this.columnIds,
+    );
+    this.modes = normalizeModes(options.modes);
+    this.onStateChange = options.onStateChange;
+  }
+
+  getState(): DataTableViewState {
+    return cloneState(this.state);
+  }
+
+  getModes(): DataTableModes {
+    return { ...this.modes };
+  }
+
+  snapshot(): DataTableSnapshot {
+    return { version: 1, modes: this.getModes(), state: this.getState() };
+  }
+
+  subscribe(listener: DataTableStateListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** Dispatches a serializable command. Controlled controllers emit a proposal only. */
+  dispatch(command: DataTableCommand): DataTableTransition {
+    const previous = this.snapshot();
+    const candidate = normalizeState(
+      transitionDataTableState(this.state, command),
+      this.columnIds,
+    );
+    const next = {
+      version: 1 as const,
+      modes: this.getModes(),
+      state: candidate,
+    };
+    const changed = snapshotSignature(previous) !== snapshotSignature(next);
+    const transition = {
+      command,
+      previous,
+      next: cloneSnapshot(next),
+      changed,
+    };
+    if (!changed) return transition;
+
+    if (this.controlled) {
+      const signature = stateSignature(candidate);
+      if (this.pendingControlledState === signature) return transition;
+      this.pendingControlledState = signature;
+      this.onStateChange?.(cloneState(candidate), command);
+      return transition;
+    }
+
+    this.state = candidate;
+    this.pendingControlledState = undefined;
+    this.onStateChange?.(cloneState(candidate), command);
+    this.emit(transition);
+    return transition;
+  }
+
+  /** Supplies state from a controlled host or an external persistence adapter. */
+  replaceState(state: DataTableViewState): DataTableTransition {
+    const previous = this.snapshot();
+    const nextState = normalizeState(state, this.columnIds);
+    const next = {
+      version: 1 as const,
+      modes: this.getModes(),
+      state: nextState,
+    };
+    const changed = snapshotSignature(previous) !== snapshotSignature(next);
+    const transition = {
+      command: null,
+      previous,
+      next: cloneSnapshot(next),
+      changed,
+    };
+    this.state = nextState;
+    this.pendingControlledState = undefined;
+    if (changed) this.emit(transition);
+    return transition;
+  }
+
+  /** Changes ownership without treating it as a user command. */
+  setControlled(controlled: boolean): void {
+    this.controlled = controlled;
+    if (!controlled) this.pendingControlledState = undefined;
+  }
+
+  /** Configures transformation ownership; this remains outside persisted state. */
+  setModes(modes: Partial<DataTableModes>): DataTableTransition {
+    const previous = this.snapshot();
+    this.modes = normalizeModes(modes);
+    const next = this.snapshot();
+    const changed = snapshotSignature(previous) !== snapshotSignature(next);
+    const transition = { command: null, previous, next, changed };
+    if (changed) this.emit(transition);
+    return transition;
+  }
+
+  /** Reconciles stale saved-view column IDs with the renderer's current columns. */
+  setColumnIds(columnIds: readonly string[]): DataTableTransition {
+    const previous = this.snapshot();
+    this.columnIds = normalizeUniqueColumnIds(columnIds);
+    this.state = normalizeState(this.state, this.columnIds);
+    const next = this.snapshot();
+    const changed = snapshotSignature(previous) !== snapshotSignature(next);
+    const transition = { command: null, previous, next, changed };
+    if (changed) this.emit(transition);
+    return transition;
+  }
+
+  /** Clamp against a reliable total. A missing total intentionally does not guess. */
+  clampPage(totalRows: number | null | undefined): DataTableTransition {
+    if (totalRows === null || totalRows === undefined) {
+      const snapshot = this.snapshot();
+      return {
+        command: null,
+        previous: snapshot,
+        next: snapshot,
+        changed: false,
+      };
+    }
+    if (!Number.isFinite(totalRows) || totalRows < 0) {
+      throw new TypeError(
+        'DataTable totalRows must be a non-negative finite number',
+      );
+    }
+    const pageCount = this.state.pageSize
+      ? Math.max(1, Math.ceil(totalRows / this.state.pageSize))
+      : 1;
+    if (this.state.page <= pageCount) {
+      const snapshot = this.snapshot();
+      return {
+        command: null,
+        previous: snapshot,
+        next: snapshot,
+        changed: false,
+      };
+    }
+    return this.dispatch({ type: 'setPage', page: pageCount });
+  }
+
+  private emit(transition: DataTableTransition): void {
+    for (const listener of [...this.listeners])
+      listener(cloneTransition(transition));
+  }
+}
+
+function cloneTransition(transition: DataTableTransition): DataTableTransition {
+  return {
+    command: transition.command
+      ? (canonicalJson(transition.command) as DataTableCommand)
+      : null,
+    previous: cloneSnapshot(transition.previous),
+    next: cloneSnapshot(transition.next),
+    changed: transition.changed,
+  };
+}
+
+export function createDataTableController(
+  options: DataTableControllerOptions = {},
+): DataTableController {
+  return new DataTableController(options);
+}

--- a/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
@@ -114,6 +114,38 @@ describe('DataTable', () => {
     expect(screen.getByRole('cell', { name: 'Grace' })).toBeInTheDocument();
   });
 
+  it('ignores local filters targeting a non-filterable column', () => {
+    const controller = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+      initialState: {
+        filters: [{ columnId: 'age', operator: 'gte', value: 40 }],
+      },
+    });
+    render(DataTable, {
+      props: {
+        data,
+        columns: [columns[0], { ...columns[1], filterable: false }],
+        controller,
+      },
+    });
+
+    expect(screen.getByRole('cell', { name: 'Ada' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'Linus' })).toBeInTheDocument();
+  });
+
+  it('clamps a controller page changed after mount against the current total', async () => {
+    const controller = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+      initialState: { page: 1, pageSize: 1 },
+    });
+    render(DataTable, { props: { data, columns, controller } });
+
+    controller.replaceState({ ...controller.getState(), page: 4 });
+
+    await vi.waitFor(() => expect(controller.getState().page).toBe(2));
+    expect(screen.getByRole('cell', { name: 'Linus' })).toBeInTheDocument();
+  });
+
   it.each([
     [
       'local/local/local',

--- a/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
@@ -5,12 +5,17 @@
  * headers, cells, row count), the empty state, sortable-header interaction
  * (aria-sort transition), and axe-cleanliness.
  */
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { createRawSnippet } from 'svelte';
 import { describe, expect, it, vi } from 'vitest';
 import { expectNoA11yViolations } from '../../../test-support/a11y';
 import DataTable from '../DataTable.svelte';
+import {
+  createDataTableController,
+  type DataTableModes,
+  transitionDataTableState,
+} from '../DataTableController.js';
 
 interface Person {
   name: string;
@@ -52,6 +57,46 @@ describe('DataTable', () => {
     expect(nameHeader).toHaveAttribute('aria-sort', 'ascending');
   });
 
+  it('routes a human sort click through the same controller transition as a command', async () => {
+    const controller = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+    });
+    const before = controller.getState();
+    render(DataTable, { props: { data, columns, sortable: true, controller } });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Name' }));
+
+    expect(controller.getState()).toEqual(
+      transitionDataTableState(before, {
+        type: 'toggleSorting',
+        columnId: 'name',
+        multi: false,
+      }),
+    );
+  });
+
+  it('waits for a controlled controller host before rendering a proposed interaction', async () => {
+    const initialState = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+    }).getState();
+    const onStateChange = vi.fn();
+    const controller = createDataTableController({
+      state: initialState,
+      columnIds: columns.map((column) => column.id),
+      onStateChange,
+    });
+    render(DataTable, { props: { data, columns, sortable: true, controller } });
+
+    const nameHeader = screen.getByRole('columnheader', { name: 'Name' });
+    await userEvent.click(screen.getByRole('button', { name: 'Name' }));
+    expect(nameHeader).not.toHaveAttribute('aria-sort');
+
+    controller.replaceState(onStateChange.mock.calls[0][0]);
+    await vi.waitFor(() =>
+      expect(nameHeader).toHaveAttribute('aria-sort', 'ascending'),
+    );
+  });
+
   it('filters and paginates client-side rows', async () => {
     render(DataTable, {
       props: {
@@ -67,6 +112,75 @@ describe('DataTable', () => {
     ).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: 'Next page' }));
     expect(screen.getByRole('cell', { name: 'Grace' })).toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      'local/local/local',
+      { filtering: 'local', sorting: 'local', pagination: 'local' },
+      ['Grace'],
+    ],
+    [
+      'local/local/manual',
+      { filtering: 'local', sorting: 'local', pagination: 'manual' },
+      ['Grace', 'Linus'],
+    ],
+    [
+      'local/manual/local',
+      { filtering: 'local', sorting: 'manual', pagination: 'local' },
+      ['Linus'],
+    ],
+    [
+      'local/manual/manual',
+      { filtering: 'local', sorting: 'manual', pagination: 'manual' },
+      ['Linus', 'Grace'],
+    ],
+    [
+      'manual/local/local',
+      { filtering: 'manual', sorting: 'local', pagination: 'local' },
+      ['Grace'],
+    ],
+    [
+      'manual/local/manual',
+      { filtering: 'manual', sorting: 'local', pagination: 'manual' },
+      ['Grace', 'Linus', 'Ada'],
+    ],
+    [
+      'manual/manual/local',
+      { filtering: 'manual', sorting: 'manual', pagination: 'local' },
+      ['Ada'],
+    ],
+    [
+      'manual/manual/manual',
+      { filtering: 'manual', sorting: 'manual', pagination: 'manual' },
+      ['Ada', 'Linus', 'Grace'],
+    ],
+  ] as Array<
+    [string, DataTableModes, string[]]
+  >)('applies each local/manual mode combination exactly once (%s)', (_name, modes, expected) => {
+    const controller = createDataTableController({
+      modes,
+      initialState: {
+        filters: [{ columnId: 'age', operator: 'gte', value: 40 }],
+        sorting: [{ columnId: 'age', direction: 'desc' }],
+        page: 1,
+        pageSize: 1,
+      },
+      columnIds: columns.map((column) => column.id),
+    });
+    render(DataTable, {
+      props: {
+        data: [...data, { name: 'Grace', age: 85 }],
+        columns,
+        controller,
+      },
+    });
+
+    const names = screen
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => within(row).getAllByRole('cell')[0].textContent);
+    expect(names).toEqual(expected);
   });
 
   it('keeps fallback selection keys unique across pages', async () => {

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableController.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableController.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createDataTableController,
+  type DataTableViewState,
+  hydrateDataTableSnapshot,
+  transitionDataTableState,
+} from '../DataTableController.js';
+
+const state: DataTableViewState = {
+  search: '',
+  filters: [],
+  sorting: [],
+  page: 3,
+  pageSize: 10,
+  columnOrder: ['name', 'age'],
+  columnVisibility: [
+    { columnId: 'age', visible: true },
+    { columnId: 'name', visible: true },
+  ],
+  selectedRowIds: [],
+  expandedRowIds: [],
+};
+
+describe('DataTableController', () => {
+  it('uses canonical JSON-safe snapshots regardless of insertion order', () => {
+    const first = createDataTableController({
+      initialState: {
+        ...state,
+        filters: [
+          {
+            columnId: 'age',
+            operator: 'gte',
+            value: { minimum: 18, maximum: 65 },
+          },
+          { columnId: 'name', operator: 'contains', value: 'a' },
+        ],
+        selectedRowIds: ['2', 1, '1', 2],
+        expandedRowIds: [3, '3', 1],
+      },
+    });
+    const second = createDataTableController({
+      initialState: {
+        ...state,
+        filters: [
+          { columnId: 'name', operator: 'contains', value: 'a' },
+          {
+            columnId: 'age',
+            operator: 'gte',
+            value: { maximum: 65, minimum: 18 },
+          },
+        ],
+        selectedRowIds: [2, '1', 1, '2'],
+        expandedRowIds: [1, '3', 3],
+      },
+    });
+
+    expect(JSON.stringify(first.snapshot())).toBe(
+      JSON.stringify(second.snapshot()),
+    );
+    expect(JSON.parse(JSON.stringify(first.snapshot()))).toEqual(
+      first.snapshot(),
+    );
+  });
+
+  it('resets page only when a query-shape value changes and clamps reliable totals', () => {
+    const controller = createDataTableController({ initialState: state });
+
+    expect(controller.dispatch({ type: 'setSearch', search: '' }).changed).toBe(
+      false,
+    );
+    expect(controller.snapshot().state.page).toBe(3);
+
+    controller.dispatch({ type: 'setSearch', search: 'ada' });
+    expect(controller.snapshot().state.page).toBe(1);
+
+    controller.replaceState({ ...controller.getState(), page: 4 });
+    controller.dispatch({ type: 'setColumnOrder', columnIds: ['age', 'name'] });
+    expect(controller.snapshot().state.page).toBe(4);
+
+    controller.clampPage(11);
+    expect(controller.snapshot().state.page).toBe(2);
+    controller.clampPage(0);
+    expect(controller.snapshot().state.page).toBe(1);
+  });
+
+  it('keeps multi-sort priority while cycling a column through asc, desc, and clear', () => {
+    const controller = createDataTableController({ initialState: state });
+
+    controller.dispatch({ type: 'toggleSorting', columnId: 'name' });
+    controller.dispatch({
+      type: 'toggleSorting',
+      columnId: 'age',
+      multi: true,
+    });
+    expect(controller.snapshot().state.sorting).toEqual([
+      { columnId: 'name', direction: 'asc' },
+      { columnId: 'age', direction: 'asc' },
+    ]);
+
+    controller.dispatch({
+      type: 'toggleSorting',
+      columnId: 'name',
+      multi: true,
+    });
+    expect(controller.snapshot().state.sorting).toEqual([
+      { columnId: 'name', direction: 'desc' },
+      { columnId: 'age', direction: 'asc' },
+    ]);
+    controller.dispatch({
+      type: 'toggleSorting',
+      columnId: 'name',
+      multi: true,
+    });
+    expect(controller.snapshot().state.sorting).toEqual([
+      { columnId: 'age', direction: 'asc' },
+    ]);
+  });
+
+  it('proposes controlled transitions without mutating until the host reconciles state', () => {
+    const onStateChange = vi.fn();
+    const controller = createDataTableController({ state, onStateChange });
+
+    const transition = controller.dispatch({ type: 'setPage', page: 2 });
+    expect(transition.next.state.page).toBe(2);
+    expect(controller.snapshot().state.page).toBe(3);
+    expect(onStateChange).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 2 }),
+      { type: 'setPage', page: 2 },
+    );
+
+    controller.replaceState(transition.next.state);
+    expect(controller.snapshot().state.page).toBe(2);
+  });
+
+  it('notifies subscribers with defensive selection and expansion snapshots', () => {
+    const controller = createDataTableController({ initialState: state });
+    const listener = vi.fn();
+    const unsubscribe = controller.subscribe(listener);
+
+    controller.dispatch({ type: 'toggleRowSelection', rowId: 'row-1' });
+    controller.dispatch({ type: 'toggleRowExpansion', rowId: 2 });
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener.mock.calls[1][0].next.state).toMatchObject({
+      selectedRowIds: ['row-1'],
+      expandedRowIds: [2],
+    });
+    listener.mock.calls[1][0].next.state.selectedRowIds.push('mutated');
+    expect(controller.snapshot().state.selectedRowIds).toEqual(['row-1']);
+
+    unsubscribe();
+    controller.dispatch({ type: 'setSearch', search: 'Ada' });
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('defensively copies state and validates persisted snapshots', () => {
+    const controller = createDataTableController({ initialState: state });
+    const snapshot = controller.snapshot();
+    snapshot.state.selectedRowIds.push('unexpected');
+    expect(controller.snapshot().state.selectedRowIds).toEqual([]);
+
+    expect(
+      hydrateDataTableSnapshot(
+        JSON.parse(JSON.stringify(controller.snapshot())),
+      ),
+    ).toEqual(controller.snapshot());
+    expect(() => hydrateDataTableSnapshot({ version: 2 })).toThrow(/version/);
+    expect(() =>
+      transitionDataTableState(state, { type: 'setPageSize', pageSize: 0 }),
+    ).toThrow(/pageSize/);
+  });
+});

--- a/packages/smrt-ui/src/components/data/index.ts
+++ b/packages/smrt-ui/src/components/data/index.ts
@@ -8,4 +8,5 @@ export {
 } from './CollectionList.svelte';
 export { default as CollectionToolbar } from './CollectionToolbar.svelte';
 export { default as DataTable } from './DataTable.svelte';
+export * from './DataTableController.js';
 export * from './types.js';

--- a/packages/smrt-ui/src/components/data/types.ts
+++ b/packages/smrt-ui/src/components/data/types.ts
@@ -3,6 +3,13 @@
  */
 
 import type { Snippet } from 'svelte';
+import type {
+  DataTableCommand,
+  DataTableController,
+  DataTableFilter,
+  DataTableModes,
+  DataTableViewState,
+} from './DataTableController.js';
 
 /**
  * Column definition for DataTable
@@ -32,6 +39,12 @@ export interface DataTableColumn<T> {
   hidden?: boolean;
   /** Custom sort function */
   sortFn?: (a: T, b: T, direction: SortDirection) => number;
+  /** Opt out of the controller's built-in local text search. */
+  searchable?: boolean;
+  /** Opt out of declarative local filters for this column. */
+  filterable?: boolean;
+  /** Optional local-only evaluator for a serializable declarative filter. */
+  filterFn?: (row: T, value: unknown, filter: DataTableFilter) => boolean;
   /** Column class name */
   className?: string;
 }
@@ -101,6 +114,22 @@ export interface DataTableProps<T> {
   footer?: Snippet<[{ rows: T[] }]>;
   /** Controlled visible column ids. Column.hidden is still respected. */
   visibleColumnIds?: Set<string>;
+  /**
+   * Headless controller used by rendered interactions and programmatic commands.
+   * When supplied, it takes precedence over `state` and the legacy bindables.
+   */
+  controller?: DataTableController;
+  /** Explicit controlled serializable state when no external controller is supplied. */
+  state?: DataTableViewState;
+  /** Initial serializable state for uncontrolled controller-backed tables. */
+  initialState?: Partial<DataTableViewState>;
+  /** Called after a controller command proposes or applies a new state. */
+  onStateChange?: (
+    state: DataTableViewState,
+    command: DataTableCommand,
+  ) => void;
+  /** Explicit ownership for local or caller-supplied filtering, sorting, and paging. */
+  modes?: Partial<DataTableModes>;
   /** Loading state */
   loading?: boolean;
   /** Empty state content */

--- a/packages/smrt-ui/src/components/data/types.ts
+++ b/packages/smrt-ui/src/components/data/types.ts
@@ -39,9 +39,9 @@ export interface DataTableColumn<T> {
   hidden?: boolean;
   /** Custom sort function */
   sortFn?: (a: T, b: T, direction: SortDirection) => number;
-  /** Opt out of the controller's built-in local text search. */
+  /** Local text search is enabled by default; set `false` to opt out. */
   searchable?: boolean;
-  /** Opt out of declarative local filters for this column. */
+  /** Declarative local filters are enabled by default; set `false` to opt out. */
   filterable?: boolean;
   /** Optional local-only evaluator for a serializable declarative filter. */
   filterFn?: (row: T, value: unknown, filter: DataTableFilter) => boolean;

--- a/packages/smrt-ui/src/svelte/playground/DataTablePreview.svelte
+++ b/packages/smrt-ui/src/svelte/playground/DataTablePreview.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
+import { onMount } from 'svelte';
 import DataTable from '../../components/data/DataTable.svelte';
-import type {
-  DataTableColumn,
-  SortState,
-} from '../../components/data/types.js';
+import { createDataTableController } from '../../components/data/DataTableController.js';
+import type { DataTableColumn } from '../../components/data/types.js';
 import Toggle from '../../components/forms/Toggle.svelte';
 import Badge from '../../components/ui/Badge.svelte';
 import Button from '../../components/ui/Button.svelte';
@@ -68,13 +67,31 @@ const columns: DataTableColumn<WorkspaceUser>[] = [
   { id: 'lastSeen', label: 'Last seen', sortable: true, align: 'right' },
 ];
 
-let selected = $state<Set<string | number>>(new Set());
-let sort = $state<SortState>({ columnId: null, direction: null });
 let loading = $state(false);
 let dense = $state(false);
+const tableController = createDataTableController({
+  columnIds: columns.map((column) => column.id),
+  initialState: { pageSize: 3 },
+});
+let tableState = $state(tableController.getState());
+
+onMount(() =>
+  tableController.subscribe((transition) => {
+    tableState = transition.next.state;
+  }),
+);
 
 function clearSelection() {
-  selected = new Set();
+  tableController.dispatch({ type: 'setSelectedRows', rowIds: [] });
+}
+
+function toggleActiveFilter() {
+  tableController.dispatch({
+    type: 'setFilters',
+    filters: tableState.filters.length
+      ? []
+      : [{ columnId: 'status', operator: 'equals', value: 'Active' }],
+  });
 }
 </script>
 
@@ -88,13 +105,13 @@ function clearSelection() {
       </p>
     </div>
     <div class="summary" aria-live="polite">
-      <Badge variant={selected.size > 0 ? 'primary' : 'default'}>
-        {selected.size} selected
+      <Badge variant={tableState.selectedRowIds.length > 0 ? 'primary' : 'default'}>
+        {tableState.selectedRowIds.length} selected
       </Badge>
       <Button
         variant="ghost"
         size="sm"
-        disabled={selected.size === 0}
+        disabled={tableState.selectedRowIds.length === 0}
         onclick={clearSelection}
       >
         Clear
@@ -105,8 +122,13 @@ function clearSelection() {
   <div class="table-controls" aria-label="Table display controls">
     <Toggle label="Dense rows" size="sm" bind:checked={dense} />
     <Toggle label="Loading state" size="sm" bind:checked={loading} />
+    <Button variant="ghost" size="sm" onclick={toggleActiveFilter}>
+      {tableState.filters.length ? 'Clear active filter' : 'Show active'}
+    </Button>
     <span>
-      Sort: {sort.columnId ? `${sort.columnId} ${sort.direction}` : 'none'}
+      Sort: {tableState.sorting.length
+        ? tableState.sorting.map((rule) => `${rule.columnId} ${rule.direction}`).join(', ')
+        : 'none'}
     </span>
   </div>
 
@@ -122,8 +144,7 @@ function clearSelection() {
       stickyHeader
       {loading}
       {dense}
-      bind:selected
-      bind:sort
+      controller={tableController}
       caption="Workspace users"
     />
   </div>


### PR DESCRIPTION
## Summary

- Add a headless, serializable DataTable controller for search, filters, multi-column sorting, pagination, visibility/order, selection, and expansion.
- Bind the existing Svelte DataTable and toolbar to the same controller transitions while preserving their migration path.
- Document controlled/uncontrolled usage, local/manual modes, and persistence snapshots; add controller and component coverage.
- Resolve review feedback for opt-out filters, post-mount page clamping, and the public `false` opt-out documentation.

## Validation

- `pnpm --filter @happyvertical/smrt-ui test -- DataTable` (57 files, 557 tests)
- `pnpm --filter @happyvertical/smrt-ui typecheck`
- `pnpm --filter @happyvertical/smrt-ui build`
- `pnpm --filter @happyvertical/smrt-ui verify:pack`
- `pnpm biome check` for the changed source and test files
- `pnpm smrt dev:knowledge-check`
- pre-push validation suite

## Independent review

Standard behavior change; current revision `78084d2c27166f2f0796739bc987d6316b89e38f`.

- Initial preliminary: `codex-luna` — CLEAN
- Initial final: `codex-terra` — CLEAN
- Review-fix preliminary: `codex-luna` — CLEAN
- Review-fix final: `codex-terra` — CLEAN
- Claude Haiku and Sonnet were attempted first but unavailable because the account weekly limit is exhausted. Kimi K3 was also attempted but its local CLI has no configured LLM provider.

Closes #2436

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-2436-datatable-controller-20260821",
  "issue": 2436,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "smrt-ui DataTable test suite (557 tests)",
    "smrt-ui typecheck",
    "smrt-ui build",
    "smrt-ui packed-export verification",
    "Biome changed-file check",
    "SMRT knowledge freshness check",
    "pre-push validation suite",
    "review-cycle: Luna preliminary clean and Terra final clean"
  ]
}
```