### PR TITLE
feat(data): define bounded query protocol

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -103,8 +103,10 @@ Use `createDataQueryFingerprint()` for cache and result correlation. It omits
 the request id and page position, canonicalizes equivalent filter/projection/
 facet forms, and adds the identity sort tie-break. Keep data-query values
 scalar, requests/pages/facets positive and bounded, results within the schema
-byte cap with declared field types preserved, and return only normalized
-`DataQueryResult` envelopes to REST, MCP,
+byte cap with declared field types preserved. Datetimes must be valid RFC 3339
+instants, identity fields must be string/number/datetime-compatible, and JSON
+result fields are depth/container/string/byte bounded before cloning. Return
+only normalized `DataQueryResult` envelopes to REST, MCP,
 WebMCP, and browser consumers. Adapter-specific report/content context wraps
 the base envelope; it does not add unsafe fields or SQL-like controls to it.
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -18,6 +18,7 @@ subsystem you are editing. This file keeps what holds across all of them.
 | `src/change-signals.ts` + the generated `_events` SSE route | the push companion to the change feed — the signal bus, cross-replica fan-out, the SSE route, and its documented gaps | [agents/change-signals.md](agents/change-signals.md) |
 | `src/generators/` + `src/vite-plugin/web-collections.ts` | REST/CLI/MCP/web-collection generation, the `manifestHash` emission sites, and generated conditional-GET / ETag v2 semantics | [agents/generators.md](agents/generators.md) |
 | `src/schema/` | the four `SchemaGenerator` entry points, which two reach production, why schema drift stayed invisible, and the #2382 index/tenancy rules | [agents/schema-paths.md](agents/schema-paths.md) |
+| `src/data-query.ts` | canonical bounded data-query normalizer: allowlisted fields, deterministic fingerprints, output validation, and transport-neutral envelope (#2444) | — |
 
 ## SmrtObject Lifecycle
 
@@ -89,6 +90,23 @@ explicit positive `maxConcurrency` and pass their normal shared
 The executor deliberately does not compose SQL, cache the plan, or change pool
 defaults. On failure it stops starting queued entries, drains operations already
 in flight, and rethrows the first error.
+
+## Canonical Bounded Data Queries (#2444)
+
+`normalizeDataQueryRequest()` and `normalizeDataQueryResult()` are the trust
+boundary for the transport-neutral table/report/content query envelope. An
+authenticated adapter supplies a trusted `DataQuerySchema`; the caller only
+gets its declared projectable/sortable/filterable/facetable fields. The helpers
+never execute a query or decide tenant/principal access.
+
+Use `createDataQueryFingerprint()` for cache and result correlation. It omits
+the request id and page position, canonicalizes equivalent filter/projection/
+facet forms, and adds the identity sort tie-break. Keep data-query values
+scalar, requests/pages/facets positive and bounded, results within the schema
+byte cap with declared field types preserved, and return only normalized
+`DataQueryResult` envelopes to REST, MCP,
+WebMCP, and browser consumers. Adapter-specific report/content context wraps
+the base envelope; it does not add unsafe fields or SQL-like controls to it.
 
 ## Object Memory & Semantic Search
 

--- a/packages/core/src/data-query.test.ts
+++ b/packages/core/src/data-query.test.ts
@@ -303,7 +303,7 @@ describe('bounded data-query protocol', () => {
         ),
         schema,
       ),
-    ).toThrow(/JSON scalar/i);
+    ).toThrow(/forbidden key|JSON scalar/i);
     expect(normalizeDataQuerySchema(schema)).toEqual(
       normalizeDataQuerySchema({
         ...schema,
@@ -364,6 +364,139 @@ describe('bounded data-query protocol', () => {
         schema,
       ),
     ).toThrow(/maximum byte limit/i);
+    expect(() =>
+      normalizeDataQueryRequest(
+        rowsRequest({
+          filter: {
+            kind: 'condition',
+            field: 'name',
+            operator: 'in',
+            value: Array.from({ length: 100 }, () => 'x'.repeat(4_096)),
+          },
+        }),
+        schema,
+      ),
+    ).toThrow(/maximum byte limit/i);
+    expect(() =>
+      normalizeDataQueryRequest(
+        rowsRequest({
+          sort: Array.from({ length: 51 }, () => ({
+            field: 'name',
+            direction: 'asc',
+          })),
+        }),
+        schema,
+      ),
+    ).toThrow(/cannot exceed 50 terms/i);
+  });
+
+  it('rejects invalid instants, unusable identities, and ambiguous pagination', () => {
+    expect(() =>
+      normalizeDataQueryRequest(
+        rowsRequest({
+          consistency: { mode: 'snapshot', asOf: '2026-02-30T00:00:00Z' },
+        }),
+        schema,
+      ),
+    ).toThrow(/RFC 3339/i);
+    expect(() =>
+      normalizeDataQueryRequest(
+        rowsRequest({
+          consistency: { mode: 'snapshot', asOf: '2026-08-22T01:00:00' },
+        }),
+        schema,
+      ),
+    ).toThrow(/RFC 3339/i);
+    expect(() =>
+      normalizeDataQuerySchema({
+        ...schema,
+        identityField: 'active',
+        fields: [
+          ...schema.fields,
+          { id: 'active', type: 'boolean', projectable: true },
+        ],
+      }),
+    ).toThrow(/identity field must use/i);
+    expect(() =>
+      normalizeDataQueryRequest(
+        rowsRequest({
+          page: { kind: 'offset', offset: 1_000_001, limit: 25 },
+        }),
+        schema,
+      ),
+    ).toThrow(/offset cannot exceed/i);
+
+    const request = rowsRequest({
+      page: { kind: 'cursor', limit: 25 },
+    });
+    const result = {
+      version: 1,
+      requestId: request.requestId,
+      queryFingerprint: createDataQueryFingerprint(request, schema),
+      identityField: 'id',
+      rows: [{ id: 'person-1', name: 'Ada' }],
+      page: {
+        kind: 'cursor',
+        limit: 25,
+        offset: 0,
+        nextCursor: 'cursor-2',
+        hasMore: true,
+      },
+      total: { kind: 'exact', value: 1 },
+      freshness: { state: 'fresh' },
+      warnings: [],
+      truncated: false,
+    };
+    expect(() => normalizeDataQueryResult(result, request, schema)).toThrow(
+      /cannot return an offset/i,
+    );
+  });
+
+  it('bounds and rejects cyclic JSON result fields before cloning them', () => {
+    const jsonSchema: DataQuerySchema = {
+      ...schema,
+      fields: [
+        ...schema.fields,
+        { id: 'metadata', type: 'json', projectable: true },
+      ],
+    };
+    const request = rowsRequest({ projection: ['metadata'] });
+    const baseResult = {
+      version: 1,
+      requestId: request.requestId,
+      queryFingerprint: createDataQueryFingerprint(request, jsonSchema),
+      identityField: 'id',
+      rows: [{ id: 'person-1', metadata: [] }],
+      page: { kind: 'offset', limit: 25, offset: 0, hasMore: false },
+      total: { kind: 'exact', value: 1 },
+      freshness: { state: 'fresh' },
+      warnings: [],
+      truncated: false,
+    };
+    expect(() =>
+      normalizeDataQueryResult(
+        {
+          ...baseResult,
+          rows: [
+            {
+              id: 'person-1',
+              metadata: Array.from({ length: 1_001 }, () => 1),
+            },
+          ],
+        },
+        request,
+        jsonSchema,
+      ),
+    ).toThrow(/container-item limit/i);
+    const cyclic: unknown[] = [];
+    cyclic.push(cyclic);
+    expect(() =>
+      normalizeDataQueryResult(
+        { ...baseResult, rows: [{ id: 'person-1', metadata: cyclic }] },
+        request,
+        jsonSchema,
+      ),
+    ).toThrow(/cannot contain a cycle/i);
   });
 
   it('validates facet values against the requested field type', () => {

--- a/packages/core/src/data-query.test.ts
+++ b/packages/core/src/data-query.test.ts
@@ -1,0 +1,413 @@
+import type {
+  DataQueryRequest,
+  DataQuerySchema,
+} from '@happyvertical/smrt-types';
+import { describe, expect, it } from 'vitest';
+import {
+  createDataQueryFingerprint,
+  normalizeDataQueryRequest,
+  normalizeDataQueryResult,
+  normalizeDataQuerySchema,
+} from './data-query';
+
+const schema: DataQuerySchema = {
+  version: 1,
+  identityField: 'id',
+  fields: [
+    {
+      id: 'id',
+      type: 'string',
+      projectable: true,
+      sortable: true,
+      filterOperators: ['eq', 'in'],
+    },
+    {
+      id: 'name',
+      type: 'string',
+      projectable: true,
+      sortable: true,
+      filterOperators: ['eq', 'like', 'in'],
+    },
+    {
+      id: 'price',
+      type: 'number',
+      projectable: true,
+      sortable: true,
+      facetable: true,
+      filterOperators: ['eq', 'gt', 'gte', 'lt', 'lte', 'in'],
+    },
+    {
+      id: 'apiSecret',
+      type: 'string',
+    },
+  ],
+  defaultPageLimit: 25,
+  maxPageLimit: 100,
+  maxResultBytes: 10_000,
+  supports: { cursorPagination: true, consistency: true, facets: true },
+};
+
+function rowsRequest(
+  overrides: Partial<DataQueryRequest> = {},
+): DataQueryRequest {
+  return {
+    version: 1,
+    requestId: 'request-1',
+    mode: 'rows',
+    projection: ['name'],
+    filter: {
+      kind: 'all',
+      filters: [
+        { kind: 'condition', field: 'price', operator: 'gte', value: 10 },
+        {
+          kind: 'condition',
+          field: 'name',
+          operator: 'in',
+          value: ['Grace', 'Ada'],
+        },
+      ],
+    },
+    sort: [{ field: 'name', direction: 'asc' }],
+    page: { kind: 'offset', offset: 0, limit: 25 },
+    ...overrides,
+  };
+}
+
+describe('bounded data-query protocol', () => {
+  it('canonicalizes equivalent request structure and retains an identity tiebreak', () => {
+    const first = rowsRequest();
+    const second = rowsRequest({
+      requestId: 'request-2',
+      projection: ['name', 'name'],
+      filter: {
+        kind: 'all',
+        filters: [
+          {
+            kind: 'condition',
+            field: 'name',
+            operator: 'in',
+            value: ['Ada', 'Grace'],
+          },
+          { kind: 'condition', field: 'price', operator: 'gte', value: 10 },
+        ],
+      },
+      page: { kind: 'offset', offset: 50, limit: 10 },
+    });
+
+    const normalized = normalizeDataQueryRequest(first, schema);
+    expect(normalized).toMatchObject({
+      projection: ['id', 'name'],
+      sort: [
+        { field: 'name', direction: 'asc' },
+        { field: 'id', direction: 'asc' },
+      ],
+      page: { kind: 'offset', offset: 0, limit: 25 },
+    });
+    expect(createDataQueryFingerprint(first, schema)).toBe(
+      createDataQueryFingerprint(second, schema),
+    );
+    expect(
+      normalizeDataQueryRequest(
+        rowsRequest({
+          filter: {
+            kind: 'condition',
+            field: 'name',
+            operator: 'in',
+            value: ['ä', 'z'],
+          },
+        }),
+        schema,
+      ).filter,
+    ).toEqual({
+      kind: 'condition',
+      field: 'name',
+      operator: 'in',
+      value: ['z', 'ä'],
+    });
+    expect(
+      normalizeDataQueryRequest(
+        rowsRequest({
+          consistency: {
+            mode: 'snapshot',
+            asOf: '2026-08-21T23:00:00-06:00',
+          },
+        }),
+        schema,
+      ).consistency,
+    ).toEqual({ mode: 'snapshot', asOf: '2026-08-22T05:00:00.000Z' });
+  });
+
+  it('rejects authority, SQL, paths, and non-allowlisted fields before execution', () => {
+    expect(() =>
+      normalizeDataQueryRequest(
+        {
+          ...rowsRequest(),
+          tenantId: 'other-tenant',
+        } as unknown as DataQueryRequest,
+        schema,
+      ),
+    ).toThrow(/unsupported key/i);
+    expect(() =>
+      normalizeDataQueryRequest(
+        {
+          ...rowsRequest(),
+          filter: {
+            kind: 'condition',
+            field: 'apiSecret',
+            operator: 'eq',
+            value: 'secret',
+          },
+        },
+        schema,
+      ),
+    ).toThrow(/not allowed/i);
+    expect(() =>
+      normalizeDataQueryRequest(
+        {
+          ...rowsRequest(),
+          filter: {
+            kind: 'condition',
+            field: 'name.path',
+            operator: 'eq',
+            value: 'Ada',
+          },
+        },
+        schema,
+      ),
+    ).toThrow(/not declared/i);
+    expect(() =>
+      normalizeDataQueryRequest(
+        {
+          ...rowsRequest(),
+          sql: 'SELECT * FROM users',
+        } as unknown as DataQueryRequest,
+        schema,
+      ),
+    ).toThrow(/unsupported key/i);
+    expect(() =>
+      normalizeDataQueryRequest(
+        {
+          ...rowsRequest(),
+          filter: {
+            kind: 'condition',
+            field: 'price',
+            operator: 'gte',
+            value: 'ten',
+          },
+        },
+        schema,
+      ),
+    ).toThrow(/must be a number/i);
+  });
+
+  it('normalizes bounded facet and count requests without carrying row controls', () => {
+    expect(
+      normalizeDataQueryRequest(
+        {
+          version: 1,
+          requestId: 'facet-request',
+          mode: 'facets',
+          facets: [{ field: 'price', limit: 500 }],
+        },
+        schema,
+      ),
+    ).toMatchObject({
+      mode: 'facets',
+      facets: [{ field: 'price', limit: 100 }],
+    });
+    expect(() =>
+      normalizeDataQueryRequest(
+        {
+          version: 1,
+          requestId: 'bad-count-request',
+          mode: 'count',
+          page: { kind: 'offset', offset: 0, limit: 1 },
+        },
+        schema,
+      ),
+    ).toThrow(/cannot carry projection, sort, or page/i);
+    expect(() =>
+      normalizeDataQueryRequest(
+        rowsRequest({ page: { kind: 'offset', offset: 0, limit: 0 } }),
+        schema,
+      ),
+    ).toThrow(/positive safe integer/i);
+  });
+
+  it('validates a projected result and rejects forged fingerprints or sensitive rows', () => {
+    const request = rowsRequest();
+    const queryFingerprint = createDataQueryFingerprint(request, schema);
+    const valid = {
+      version: 1,
+      requestId: 'request-1',
+      queryFingerprint,
+      identityField: 'id',
+      rows: [{ id: 'person-1', name: 'Ada' }],
+      page: { kind: 'offset', limit: 25, offset: 0, hasMore: false },
+      total: { kind: 'exact', value: 1 },
+      freshness: { state: 'fresh' },
+      warnings: [],
+      truncated: false,
+    };
+
+    expect(normalizeDataQueryResult(valid, request, schema)).toEqual(valid);
+    expect(() =>
+      normalizeDataQueryResult(
+        { ...valid, queryFingerprint: 'dq1_forged' },
+        request,
+        schema,
+      ),
+    ).toThrow(/fingerprint/i);
+    expect(() =>
+      normalizeDataQueryResult(
+        {
+          ...valid,
+          rows: [{ id: 'person-1', name: 'Ada', apiSecret: 'never expose' }],
+        },
+        request,
+        schema,
+      ),
+    ).toThrow(/non-projected field/i);
+    expect(() =>
+      normalizeDataQueryResult(
+        { ...valid, rows: [{ id: 'person-1', name: 42 }] },
+        request,
+        schema,
+      ),
+    ).toThrow(/must be a string/i);
+    expect(() =>
+      normalizeDataQueryResult(
+        {
+          ...valid,
+          rows: [{ id: 'person-1', name: 'x'.repeat(1_000) }],
+        },
+        request,
+        { ...schema, maxResultBytes: 100 },
+      ),
+    ).toThrow(/maximum byte limit/i);
+  });
+
+  it('fails closed for prototype-bearing input and keeps schema normalization deterministic', () => {
+    expect(() =>
+      normalizeDataQueryRequest(
+        JSON.parse(
+          JSON.stringify({
+            ...rowsRequest(),
+            filter: {
+              kind: 'condition',
+              field: 'name',
+              operator: 'eq',
+              value: JSON.parse('{"__proto__":{"tenantId":"other"}}'),
+            },
+          }),
+        ),
+        schema,
+      ),
+    ).toThrow(/JSON scalar/i);
+    expect(normalizeDataQuerySchema(schema)).toEqual(
+      normalizeDataQuerySchema({
+        ...schema,
+        fields: [...schema.fields].reverse(),
+      }),
+    );
+    expect(() =>
+      normalizeDataQuerySchema({
+        ...schema,
+        maxResultBytes: 10_000_001,
+      }),
+    ).toThrow(/maximum result bytes/i);
+  });
+
+  it('bounds the total filter tree, not only any one boolean group', () => {
+    const condition = {
+      kind: 'condition' as const,
+      field: 'price',
+      operator: 'gte' as const,
+      value: 10,
+    };
+    expect(() =>
+      normalizeDataQueryRequest(
+        rowsRequest({
+          filter: {
+            kind: 'all',
+            filters: [
+              {
+                kind: 'all',
+                filters: Array.from({ length: 30 }, () => condition),
+              },
+              {
+                kind: 'all',
+                filters: Array.from({ length: 30 }, () => condition),
+              },
+            ],
+          },
+        }),
+        schema,
+      ),
+    ).toThrow(/cannot exceed 50 expressions/i);
+  });
+
+  it('bounds an otherwise-valid large request payload', () => {
+    expect(() =>
+      normalizeDataQueryRequest(
+        rowsRequest({
+          filter: {
+            kind: 'condition',
+            field: 'name',
+            operator: 'in',
+            value: Array.from(
+              { length: 30 },
+              (_, index) => `${index}-${'x'.repeat(4_090)}`,
+            ),
+          },
+        }),
+        schema,
+      ),
+    ).toThrow(/maximum byte limit/i);
+  });
+
+  it('validates facet values against the requested field type', () => {
+    const request: DataQueryRequest = {
+      version: 1,
+      requestId: 'facet-result',
+      mode: 'facets',
+      facets: [{ field: 'price', limit: 10 }],
+    };
+    const result = {
+      version: 1,
+      requestId: 'facet-result',
+      queryFingerprint: createDataQueryFingerprint(request, schema),
+      identityField: 'id',
+      rows: [],
+      total: { kind: 'unavailable' },
+      facets: [
+        {
+          field: 'price',
+          values: [{ value: 10, count: 2 }],
+          truncated: false,
+        },
+      ],
+      freshness: { state: 'fresh' },
+      warnings: [],
+      truncated: false,
+    };
+    expect(normalizeDataQueryResult(result, request, schema)).toMatchObject(
+      result,
+    );
+    expect(() =>
+      normalizeDataQueryResult(
+        {
+          ...result,
+          facets: [
+            {
+              ...result.facets[0],
+              values: [{ value: 'ten', count: 2 }],
+            },
+          ],
+        },
+        request,
+        schema,
+      ),
+    ).toThrow(/must be a number/i);
+  });
+});

--- a/packages/core/src/data-query.ts
+++ b/packages/core/src/data-query.ts
@@ -1,0 +1,1157 @@
+/**
+ * Canonical bounded data-query normalization (#2444).
+ *
+ * The shared package supplies only portable types. This server/runtime module
+ * makes the contract executable at every trust boundary: it accepts only an
+ * adapter-declared field/operator allowlist, canonicalizes equivalent
+ * requests, creates a collision-resistant match fingerprint, and validates
+ * that adapters return bounded, policy-filtered rows. It deliberately does
+ * not execute SQL or resolve tenant/principal state; authenticated domain
+ * adapters supply the schema and perform those responsibilities separately.
+ */
+
+import { createHash } from 'node:crypto';
+import type {
+  DataQueryCondition,
+  DataQueryConsistency,
+  DataQueryFacetRequest,
+  DataQueryFacetResult,
+  DataQueryFieldDescriptor,
+  DataQueryFilter,
+  DataQueryFilterOperator,
+  DataQueryFreshness,
+  DataQueryPage,
+  DataQueryRequest,
+  DataQueryResult,
+  DataQueryRow,
+  DataQueryScalar,
+  DataQuerySchema,
+  DataQuerySort,
+  DataQueryTotal,
+} from '@happyvertical/smrt-types';
+import { ValidationError } from './errors';
+
+/** Default and hard ceilings for normalized data-query input and output. */
+export const DEFAULT_DATA_QUERY_PAGE_LIMIT = 50;
+export const MAX_DATA_QUERY_PAGE_LIMIT = 1_000;
+export const DEFAULT_DATA_QUERY_RESULT_BYTES = 1_000_000;
+export const MAX_DATA_QUERY_RESULT_BYTES = 10_000_000;
+export const MAX_DATA_QUERY_REQUEST_BYTES = 100_000;
+export const MAX_DATA_QUERY_OFFSET = 1_000_000;
+export const MAX_DATA_QUERY_FILTER_DEPTH = 8;
+export const MAX_DATA_QUERY_FILTERS = 50;
+export const MAX_DATA_QUERY_IN_VALUES = 100;
+export const MAX_DATA_QUERY_FACETS = 20;
+export const MAX_DATA_QUERY_WARNINGS = 100;
+export const MAX_DATA_QUERY_CURSOR_LENGTH = 2_048;
+
+const FILTER_OPERATORS = new Set<DataQueryFilterOperator>([
+  'eq',
+  'ne',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'in',
+  'notIn',
+  'like',
+]);
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** A typed 400-class failure for malformed or policy-disallowed data queries. */
+export class DataQueryValidationError extends ValidationError {
+  readonly status = 400;
+  readonly publicMessage: string;
+
+  constructor(
+    message: string,
+    code = 'INVALID_DATA_QUERY',
+    details?: Record<string, unknown>,
+  ) {
+    super(message, code, details);
+    this.name = 'DataQueryValidationError';
+    this.publicMessage = message;
+  }
+}
+
+type JsonObject = Record<string, unknown>;
+
+function fail(
+  message: string,
+  code = 'INVALID_DATA_QUERY',
+  details?: Record<string, unknown>,
+): never {
+  throw new DataQueryValidationError(message, code, details);
+}
+
+function plainObject(value: unknown, label: string): JsonObject {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return fail(`${label} must be an object`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    return fail(`${label} must be a plain object`);
+  }
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_KEYS.has(key)) {
+      return fail(`${label} contains a forbidden key`, 'FORBIDDEN_DATA_QUERY');
+    }
+  }
+  return value as JsonObject;
+}
+
+function exactKeys(
+  object: JsonObject,
+  allowed: readonly string[],
+  label: string,
+): void {
+  const allowedKeys = new Set(allowed);
+  for (const key of Object.keys(object)) {
+    if (!allowedKeys.has(key)) {
+      fail(
+        `${label} contains unsupported key "${key}"`,
+        'FORBIDDEN_DATA_QUERY',
+      );
+    }
+  }
+}
+
+function stringValue(value: unknown, label: string, maxLength = 256): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > maxLength
+  ) {
+    return fail(
+      `${label} must be a non-empty string up to ${maxLength} characters`,
+    );
+  }
+  return value;
+}
+
+function nonNegativeInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    return fail(`${label} must be a non-negative safe integer`);
+  }
+  return value as number;
+}
+
+function positiveInteger(value: unknown, label: string): number {
+  const normalized = nonNegativeInteger(value, label);
+  if (normalized === 0) return fail(`${label} must be a positive safe integer`);
+  return normalized;
+}
+
+function normalizedInstant(value: unknown, label: string): string {
+  const input = stringValue(value, label, 128);
+  const milliseconds = Date.parse(input);
+  if (!Number.isFinite(milliseconds)) {
+    return fail(`${label} must be an RFC 3339 instant`);
+  }
+  return new Date(milliseconds).toISOString();
+}
+
+function dataQueryScalar(value: unknown, label: string): DataQueryScalar {
+  if (value === null || typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    if (value.length > 4_096) {
+      return fail(`${label} cannot exceed 4096 characters`);
+    }
+    return value;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return fail(`${label} must be a JSON scalar`);
+}
+
+function canonicalJson(value: unknown, label = 'Data query JSON'): unknown {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value))
+      return fail(`${label} cannot contain a non-finite number`);
+    return value === 0 ? 0 : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry, index) =>
+      canonicalJson(entry, `${label}[${index}]`),
+    );
+  }
+  const object = plainObject(value, label);
+  const result: JsonObject = Object.create(null) as JsonObject;
+  for (const key of Object.keys(object).sort()) {
+    Object.defineProperty(result, key, {
+      value: canonicalJson(object[key], `${label}.${key}`),
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return result;
+}
+
+function signature(value: unknown): string {
+  return JSON.stringify(canonicalJson(value));
+}
+
+/** Locale-independent ordering for canonical envelopes and fingerprints. */
+function compareCanonicalStrings(left: string, right: string): number {
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}
+
+function normalizeFieldDescriptor(value: unknown): DataQueryFieldDescriptor {
+  const object = plainObject(value, 'Data query schema field');
+  exactKeys(
+    object,
+    ['id', 'type', 'projectable', 'sortable', 'facetable', 'filterOperators'],
+    'Data query schema field',
+  );
+  const id = stringValue(object.id, 'Data query field id');
+  const type = stringValue(object.type, `Data query field ${id} type`);
+  if (!['string', 'number', 'boolean', 'datetime', 'json'].includes(type)) {
+    return fail(`Unsupported data query field type: ${type}`);
+  }
+  for (const flag of ['projectable', 'sortable', 'facetable'] as const) {
+    if (object[flag] !== undefined && typeof object[flag] !== 'boolean') {
+      fail(`Data query field ${id} ${flag} must be boolean`);
+    }
+  }
+  let filterOperators: DataQueryFilterOperator[] | undefined;
+  if (object.filterOperators !== undefined) {
+    if (!Array.isArray(object.filterOperators)) {
+      return fail(`Data query field ${id} filterOperators must be an array`);
+    }
+    filterOperators = [
+      ...new Set(
+        object.filterOperators.map((operator) => {
+          const normalized = stringValue(
+            operator,
+            `Data query field ${id} filter operator`,
+          ) as DataQueryFilterOperator;
+          if (!FILTER_OPERATORS.has(normalized)) {
+            fail(`Unsupported data query filter operator: ${normalized}`);
+          }
+          return normalized;
+        }),
+      ),
+    ].sort();
+  }
+  const projectable =
+    typeof object.projectable === 'boolean' ? object.projectable : undefined;
+  const sortable =
+    typeof object.sortable === 'boolean' ? object.sortable : undefined;
+  const facetable =
+    typeof object.facetable === 'boolean' ? object.facetable : undefined;
+  return {
+    id,
+    type: type as DataQueryFieldDescriptor['type'],
+    ...(projectable === undefined ? {} : { projectable }),
+    ...(sortable === undefined ? {} : { sortable }),
+    ...(facetable === undefined ? {} : { facetable }),
+    ...(filterOperators ? { filterOperators } : {}),
+  };
+}
+
+/** Validate and canonicalize trusted adapter query policy before use. */
+export function normalizeDataQuerySchema(value: unknown): DataQuerySchema {
+  const object = plainObject(value, 'Data query schema');
+  exactKeys(
+    object,
+    [
+      'version',
+      'identityField',
+      'fields',
+      'defaultPageLimit',
+      'maxPageLimit',
+      'maxResultBytes',
+      'defaultSort',
+      'supports',
+    ],
+    'Data query schema',
+  );
+  if (object.version !== 1)
+    return fail('Unsupported data query schema version');
+  if (!Array.isArray(object.fields) || object.fields.length === 0) {
+    return fail('Data query schema fields must be a non-empty array');
+  }
+  const fields = object.fields
+    .map(normalizeFieldDescriptor)
+    .sort((left, right) => compareCanonicalStrings(left.id, right.id));
+  if (new Set(fields.map((field) => field.id)).size !== fields.length) {
+    return fail('Data query schema field ids must be unique');
+  }
+  const identityField = stringValue(
+    object.identityField,
+    'Data query identity field',
+  );
+  const identity = fields.find((field) => field.id === identityField);
+  if (!identity) return fail('Data query identity field must be declared');
+  if (identity.projectable === false) {
+    return fail('Data query identity field must be projectable');
+  }
+  const maxPageLimit =
+    object.maxPageLimit === undefined
+      ? MAX_DATA_QUERY_PAGE_LIMIT
+      : positiveInteger(object.maxPageLimit, 'Data query maximum page limit');
+  if (maxPageLimit > MAX_DATA_QUERY_PAGE_LIMIT) {
+    return fail(
+      `Data query maximum page limit cannot exceed ${MAX_DATA_QUERY_PAGE_LIMIT}`,
+    );
+  }
+  const defaultPageLimit =
+    object.defaultPageLimit === undefined
+      ? Math.min(DEFAULT_DATA_QUERY_PAGE_LIMIT, maxPageLimit)
+      : positiveInteger(
+          object.defaultPageLimit,
+          'Data query default page limit',
+        );
+  if (defaultPageLimit > maxPageLimit) {
+    return fail(
+      'Data query default page limit cannot exceed the maximum page limit',
+    );
+  }
+  const maxResultBytes =
+    object.maxResultBytes === undefined
+      ? DEFAULT_DATA_QUERY_RESULT_BYTES
+      : positiveInteger(
+          object.maxResultBytes,
+          'Data query maximum result bytes',
+        );
+  if (maxResultBytes > MAX_DATA_QUERY_RESULT_BYTES) {
+    return fail(
+      `Data query maximum result bytes cannot exceed ${MAX_DATA_QUERY_RESULT_BYTES}`,
+    );
+  }
+  let supports: DataQuerySchema['supports'];
+  if (object.supports !== undefined) {
+    const supportObject = plainObject(
+      object.supports,
+      'Data query schema supports',
+    );
+    exactKeys(
+      supportObject,
+      ['cursorPagination', 'consistency', 'facets'],
+      'Data query schema supports',
+    );
+    for (const key of ['cursorPagination', 'consistency', 'facets'] as const) {
+      if (
+        supportObject[key] !== undefined &&
+        typeof supportObject[key] !== 'boolean'
+      ) {
+        fail(`Data query schema supports.${key} must be boolean`);
+      }
+    }
+    const cursorPagination =
+      typeof supportObject.cursorPagination === 'boolean'
+        ? supportObject.cursorPagination
+        : undefined;
+    const consistency =
+      typeof supportObject.consistency === 'boolean'
+        ? supportObject.consistency
+        : undefined;
+    const facets =
+      typeof supportObject.facets === 'boolean'
+        ? supportObject.facets
+        : undefined;
+    supports = {
+      ...(cursorPagination === undefined ? {} : { cursorPagination }),
+      ...(consistency === undefined ? {} : { consistency }),
+      ...(facets === undefined ? {} : { facets }),
+    };
+  }
+  const fieldMap = new Map(fields.map((field) => [field.id, field]));
+  const defaultSort = normalizeSort(
+    object.defaultSort,
+    fieldMap,
+    identityField,
+    'Data query default sort',
+    false,
+  );
+  return {
+    version: 1,
+    identityField,
+    fields,
+    defaultPageLimit,
+    maxPageLimit,
+    maxResultBytes,
+    ...(defaultSort.length > 0 ? { defaultSort } : {}),
+    ...(supports ? { supports } : {}),
+  };
+}
+
+interface FilterBudget {
+  nodes: number;
+}
+
+function scalarForField(
+  value: unknown,
+  descriptor: DataQueryFieldDescriptor,
+  label: string,
+): DataQueryScalar {
+  const scalar = dataQueryScalar(value, label);
+  if (scalar === null) return scalar;
+  if (descriptor.type === 'number' && typeof scalar !== 'number') {
+    return fail(`${label} must be a number for ${descriptor.id}`);
+  }
+  if (descriptor.type === 'boolean' && typeof scalar !== 'boolean') {
+    return fail(`${label} must be a boolean for ${descriptor.id}`);
+  }
+  if (descriptor.type === 'string' && typeof scalar !== 'string') {
+    return fail(`${label} must be a string for ${descriptor.id}`);
+  }
+  if (descriptor.type === 'datetime') {
+    if (typeof scalar !== 'string') {
+      return fail(`${label} must be an RFC 3339 instant for ${descriptor.id}`);
+    }
+    return normalizedInstant(scalar, label);
+  }
+  return scalar;
+}
+
+function normalizeFilter(
+  value: unknown,
+  fields: Map<string, DataQueryFieldDescriptor>,
+  depth = 0,
+  budget: FilterBudget = { nodes: 0 },
+): DataQueryFilter {
+  if (depth > MAX_DATA_QUERY_FILTER_DEPTH) {
+    return fail(
+      `Data query filter cannot exceed depth ${MAX_DATA_QUERY_FILTER_DEPTH}`,
+    );
+  }
+  budget.nodes += 1;
+  if (budget.nodes > MAX_DATA_QUERY_FILTERS) {
+    return fail(
+      `Data query filter cannot exceed ${MAX_DATA_QUERY_FILTERS} expressions`,
+    );
+  }
+  const object = plainObject(value, 'Data query filter');
+  const kind = stringValue(object.kind, 'Data query filter kind');
+  if (kind === 'condition') {
+    exactKeys(
+      object,
+      ['kind', 'field', 'operator', 'value'],
+      'Data query condition',
+    );
+    const field = stringValue(object.field, 'Data query condition field');
+    const descriptor = fields.get(field);
+    if (!descriptor)
+      return fail(
+        `Data query field is not declared: ${field}`,
+        'DATA_QUERY_FIELD_NOT_ALLOWED',
+      );
+    const operator = stringValue(
+      object.operator,
+      'Data query condition operator',
+    ) as DataQueryFilterOperator;
+    if (
+      !FILTER_OPERATORS.has(operator) ||
+      !descriptor.filterOperators?.includes(operator)
+    ) {
+      return fail(
+        `Data query operator ${operator} is not allowed for ${field}`,
+        'DATA_QUERY_OPERATOR_NOT_ALLOWED',
+      );
+    }
+    if (operator === 'in' || operator === 'notIn') {
+      if (!Array.isArray(object.value) || object.value.length === 0) {
+        return fail(`Data query ${operator} value must be a non-empty array`);
+      }
+      if (object.value.length > MAX_DATA_QUERY_IN_VALUES) {
+        return fail(
+          `Data query ${operator} value cannot exceed ${MAX_DATA_QUERY_IN_VALUES} items`,
+        );
+      }
+      const values = object.value.map((entry, index) =>
+        scalarForField(
+          entry,
+          descriptor,
+          `Data query ${operator} value ${index}`,
+        ),
+      );
+      const canonicalValues = [
+        ...new Map(values.map((entry) => [signature(entry), entry])).values(),
+      ].sort((left, right) =>
+        compareCanonicalStrings(signature(left), signature(right)),
+      );
+      return { kind: 'condition', field, operator, value: canonicalValues };
+    }
+    if (Array.isArray(object.value)) {
+      return fail(`Data query ${operator} value must be a scalar`);
+    }
+    const scalar = scalarForField(
+      object.value,
+      descriptor,
+      `Data query ${operator} value`,
+    );
+    if (operator === 'like' && descriptor.type !== 'string') {
+      return fail('Data query like is only available for string fields');
+    }
+    if (operator === 'like' && typeof scalar !== 'string') {
+      return fail('Data query like value must be a string');
+    }
+    if (
+      ['gt', 'gte', 'lt', 'lte'].includes(operator) &&
+      !['number', 'string', 'datetime'].includes(descriptor.type)
+    ) {
+      return fail(
+        `Data query ${operator} is not available for ${descriptor.type} fields`,
+      );
+    }
+    if (
+      ['gt', 'gte', 'lt', 'lte', 'like'].includes(operator) &&
+      scalar === null
+    ) {
+      return fail(`Data query ${operator} value cannot be null`);
+    }
+    return {
+      kind: 'condition',
+      field,
+      operator,
+      value: scalar,
+    } as DataQueryCondition;
+  }
+  if (kind === 'all' || kind === 'any') {
+    exactKeys(object, ['kind', 'filters'], `Data query ${kind} filter`);
+    if (!Array.isArray(object.filters) || object.filters.length === 0) {
+      return fail(`Data query ${kind} filter must contain at least one child`);
+    }
+    if (object.filters.length > MAX_DATA_QUERY_FILTERS) {
+      return fail(
+        `Data query ${kind} filter cannot exceed ${MAX_DATA_QUERY_FILTERS} children`,
+      );
+    }
+    const filters = object.filters
+      .map((filter) => normalizeFilter(filter, fields, depth + 1, budget))
+      .sort((left, right) =>
+        compareCanonicalStrings(signature(left), signature(right)),
+      );
+    return { kind, filters };
+  }
+  if (kind === 'not') {
+    exactKeys(object, ['kind', 'filter'], 'Data query not filter');
+    return {
+      kind: 'not',
+      filter: normalizeFilter(object.filter, fields, depth + 1, budget),
+    };
+  }
+  return fail(`Unsupported data query filter kind: ${kind}`);
+}
+
+function normalizeSort(
+  value: unknown,
+  fields: Map<string, DataQueryFieldDescriptor>,
+  identityField: string,
+  label: string,
+  appendIdentity: boolean,
+): DataQuerySort[] {
+  if (value === undefined)
+    return appendIdentity ? [{ field: identityField, direction: 'asc' }] : [];
+  if (!Array.isArray(value)) return fail(`${label} must be an array`);
+  const sort = value.map((entry) => {
+    const object = plainObject(entry, label);
+    exactKeys(object, ['field', 'direction'], label);
+    const field = stringValue(object.field, `${label} field`);
+    if (!fields.get(field)?.sortable && field !== identityField) {
+      fail(
+        `Data query sort field is not allowed: ${field}`,
+        'DATA_QUERY_SORT_NOT_ALLOWED',
+      );
+    }
+    const direction = stringValue(object.direction, `${label} direction`);
+    if (direction !== 'asc' && direction !== 'desc') {
+      fail(`Data query sort direction must be asc or desc`);
+    }
+    return { field, direction } as DataQuerySort;
+  });
+  if (sort.length > MAX_DATA_QUERY_FILTERS)
+    return fail(`${label} cannot exceed ${MAX_DATA_QUERY_FILTERS} terms`);
+  if (new Set(sort.map((term) => term.field)).size !== sort.length) {
+    return fail(`${label} field ids must be unique`);
+  }
+  if (appendIdentity && !sort.some((term) => term.field === identityField)) {
+    sort.push({ field: identityField, direction: 'asc' });
+  }
+  return sort;
+}
+
+function normalizePage(value: unknown, schema: DataQuerySchema): DataQueryPage {
+  if (value === undefined) {
+    return {
+      kind: 'offset',
+      offset: 0,
+      limit: schema.defaultPageLimit ?? DEFAULT_DATA_QUERY_PAGE_LIMIT,
+    };
+  }
+  const object = plainObject(value, 'Data query page');
+  const kind = stringValue(object.kind, 'Data query page kind');
+  if (kind === 'offset') {
+    exactKeys(object, ['kind', 'offset', 'limit'], 'Data query offset page');
+    return {
+      kind,
+      offset: Math.min(
+        nonNegativeInteger(object.offset, 'Data query offset'),
+        MAX_DATA_QUERY_OFFSET,
+      ),
+      limit: Math.min(
+        positiveInteger(object.limit, 'Data query page limit'),
+        schema.maxPageLimit ?? MAX_DATA_QUERY_PAGE_LIMIT,
+      ),
+    };
+  }
+  if (kind === 'cursor') {
+    if (!schema.supports?.cursorPagination) {
+      return fail(
+        'Data query cursor pagination is not supported',
+        'DATA_QUERY_UNSUPPORTED',
+      );
+    }
+    exactKeys(object, ['kind', 'after', 'limit'], 'Data query cursor page');
+    const after =
+      object.after === undefined
+        ? undefined
+        : stringValue(
+            object.after,
+            'Data query cursor',
+            MAX_DATA_QUERY_CURSOR_LENGTH,
+          );
+    return {
+      kind,
+      ...(after === undefined ? {} : { after }),
+      limit: Math.min(
+        positiveInteger(object.limit, 'Data query page limit'),
+        schema.maxPageLimit ?? MAX_DATA_QUERY_PAGE_LIMIT,
+      ),
+    };
+  }
+  return fail(`Unsupported data query page kind: ${kind}`);
+}
+
+function normalizeConsistency(
+  value: unknown,
+  schema: DataQuerySchema,
+): DataQueryConsistency | undefined {
+  if (value === undefined) return undefined;
+  if (!schema.supports?.consistency) {
+    return fail(
+      'Data query consistency options are not supported',
+      'DATA_QUERY_UNSUPPORTED',
+    );
+  }
+  const object = plainObject(value, 'Data query consistency');
+  exactKeys(object, ['mode', 'asOf'], 'Data query consistency');
+  if (object.mode !== 'eventual' && object.mode !== 'snapshot')
+    return fail('Unsupported data query consistency mode');
+  const asOf =
+    object.asOf === undefined
+      ? undefined
+      : normalizedInstant(object.asOf, 'Data query consistency asOf');
+  return {
+    mode: object.mode,
+    ...(asOf === undefined ? {} : { asOf }),
+  } as DataQueryConsistency;
+}
+
+function normalizeFacets(
+  value: unknown,
+  schema: DataQuerySchema,
+  fields: Map<string, DataQueryFieldDescriptor>,
+): DataQueryFacetRequest[] {
+  if (!schema.supports?.facets) {
+    return fail(
+      'Data query facets are not supported',
+      'DATA_QUERY_UNSUPPORTED',
+    );
+  }
+  if (!Array.isArray(value) || value.length === 0) {
+    return fail('Data query facets must be a non-empty array');
+  }
+  if (value.length > MAX_DATA_QUERY_FACETS) {
+    return fail(`Data query facets cannot exceed ${MAX_DATA_QUERY_FACETS}`);
+  }
+  const facets = value.map((entry) => {
+    const object = plainObject(entry, 'Data query facet request');
+    exactKeys(object, ['field', 'limit'], 'Data query facet request');
+    const field = stringValue(object.field, 'Data query facet field');
+    if (!fields.get(field)?.facetable) {
+      fail(
+        `Data query facet field is not allowed: ${field}`,
+        'DATA_QUERY_FACET_NOT_ALLOWED',
+      );
+    }
+    return {
+      field,
+      limit: Math.min(
+        positiveInteger(object.limit, 'Data query facet limit'),
+        schema.maxPageLimit ?? MAX_DATA_QUERY_PAGE_LIMIT,
+      ),
+    };
+  });
+  if (new Set(facets.map((facet) => facet.field)).size !== facets.length) {
+    return fail('Data query facet fields must be unique');
+  }
+  return facets.sort((left, right) =>
+    compareCanonicalStrings(left.field, right.field),
+  );
+}
+
+function boundRequestSize(request: DataQueryRequest): DataQueryRequest {
+  const bytes = new TextEncoder().encode(JSON.stringify(request)).byteLength;
+  if (bytes > MAX_DATA_QUERY_REQUEST_BYTES) {
+    return fail(
+      'Data query request exceeds its maximum byte limit',
+      'DATA_QUERY_REQUEST_TOO_LARGE',
+    );
+  }
+  return request;
+}
+
+/**
+ * Normalize an untrusted request against its trusted adapter schema. Equivalent
+ * projection/filter/facet orderings produce byte-identical output; sort order
+ * remains intact because it is semantically meaningful. The identity field is
+ * always projected even when a caller omits it.
+ */
+export function normalizeDataQueryRequest(
+  value: unknown,
+  inputSchema: unknown,
+): DataQueryRequest {
+  const schema = normalizeDataQuerySchema(inputSchema);
+  const fields = new Map(schema.fields.map((field) => [field.id, field]));
+  const object = plainObject(value, 'Data query request');
+  exactKeys(
+    object,
+    [
+      'version',
+      'requestId',
+      'mode',
+      'projection',
+      'filter',
+      'sort',
+      'page',
+      'consistency',
+      'facets',
+    ],
+    'Data query request',
+  );
+  if (object.version !== 1)
+    return fail('Unsupported data query request version');
+  const requestId = stringValue(object.requestId, 'Data query request id', 128);
+  const mode = stringValue(object.mode, 'Data query mode');
+  if (!['rows', 'count', 'facets'].includes(mode))
+    return fail(`Unsupported data query mode: ${mode}`);
+  const filter =
+    object.filter === undefined
+      ? undefined
+      : normalizeFilter(object.filter, fields);
+  const consistency = normalizeConsistency(object.consistency, schema);
+  if (mode === 'rows') {
+    if (object.facets !== undefined)
+      return fail('Rows queries cannot request facets');
+    if (object.projection !== undefined && !Array.isArray(object.projection)) {
+      return fail('Data query projection must be an array');
+    }
+    const requestedProjection = (object.projection ?? []).map((field) =>
+      stringValue(field, 'Data query projection field'),
+    );
+    for (const field of requestedProjection) {
+      if (!fields.get(field)?.projectable && field !== schema.identityField) {
+        fail(
+          `Data query projection field is not allowed: ${field}`,
+          'DATA_QUERY_PROJECTION_NOT_ALLOWED',
+        );
+      }
+    }
+    const projection = [
+      ...new Set([...requestedProjection, schema.identityField]),
+    ].sort();
+    const sort = normalizeSort(
+      object.sort === undefined ? schema.defaultSort : object.sort,
+      fields,
+      schema.identityField,
+      'Data query sort',
+      true,
+    );
+    return boundRequestSize({
+      version: 1,
+      requestId,
+      mode,
+      projection,
+      ...(filter === undefined ? {} : { filter }),
+      sort,
+      page: normalizePage(object.page, schema),
+      ...(consistency === undefined ? {} : { consistency }),
+    });
+  }
+  if (
+    object.projection !== undefined ||
+    object.sort !== undefined ||
+    object.page !== undefined
+  ) {
+    return fail(`${mode} data queries cannot carry projection, sort, or page`);
+  }
+  if (mode === 'facets') {
+    return boundRequestSize({
+      version: 1,
+      requestId,
+      mode,
+      ...(filter === undefined ? {} : { filter }),
+      ...(consistency === undefined ? {} : { consistency }),
+      facets: normalizeFacets(object.facets, schema, fields),
+    });
+  }
+  if (object.facets !== undefined)
+    return fail('Count data queries cannot request facets');
+  return boundRequestSize({
+    version: 1,
+    requestId,
+    mode: 'count',
+    ...(filter === undefined ? {} : { filter }),
+    ...(consistency === undefined ? {} : { consistency }),
+  });
+}
+
+/** Canonical match/query form used for stable fingerprints (no request id/page). */
+export function canonicalizeDataQuery(value: unknown, schema: unknown): string {
+  const request = normalizeDataQueryRequest(value, schema);
+  const { requestId: _requestId, page: _page, ...semanticQuery } = request;
+  return signature(semanticQuery);
+}
+
+/** Collision-resistant canonical fingerprint for result correlation and selection scope. */
+export function createDataQueryFingerprint(
+  value: unknown,
+  schema: unknown,
+): string {
+  return `dq1_${createHash('sha256').update(canonicalizeDataQuery(value, schema)).digest('base64url')}`;
+}
+
+function normalizeResultFieldValue(
+  value: unknown,
+  descriptor: DataQueryFieldDescriptor,
+  label: string,
+): unknown {
+  if (descriptor.type === 'json') return canonicalJson(value, label);
+  return scalarForField(value, descriptor, label);
+}
+
+function normalizeRow(
+  value: unknown,
+  projection: readonly string[],
+  identityField: string,
+  fields: Map<string, DataQueryFieldDescriptor>,
+): DataQueryRow {
+  const object = plainObject(value, 'Data query row');
+  const allowed = new Set(projection);
+  const normalized: JsonObject = Object.create(null) as JsonObject;
+  for (const key of Object.keys(object)) {
+    if (!allowed.has(key)) {
+      fail(
+        `Data query row returned a non-projected field: ${key}`,
+        'DATA_QUERY_RESULT_NOT_ALLOWED',
+      );
+    }
+    const descriptor = fields.get(key);
+    if (!descriptor) {
+      return fail(
+        `Data query row returned an undeclared field: ${key}`,
+        'DATA_QUERY_RESULT_NOT_ALLOWED',
+      );
+    }
+    normalized[key] = normalizeResultFieldValue(
+      object[key],
+      descriptor,
+      `Data query row ${key}`,
+    );
+  }
+  const identity = normalized[identityField];
+  if (
+    (typeof identity !== 'string' && typeof identity !== 'number') ||
+    identity === ''
+  ) {
+    fail(
+      'Data query row must return a string or number identity field',
+      'DATA_QUERY_RESULT_INVALID',
+    );
+  }
+  return normalized as DataQueryRow;
+}
+
+function normalizeTotal(value: unknown): DataQueryTotal {
+  const object = plainObject(value, 'Data query total');
+  const kind = stringValue(object.kind, 'Data query total kind');
+  if (kind === 'unavailable') {
+    exactKeys(object, ['kind', 'reason'], 'Data query unavailable total');
+    const reason =
+      object.reason === undefined
+        ? undefined
+        : stringValue(object.reason, 'Data query total reason');
+    return { kind, ...(reason === undefined ? {} : { reason }) };
+  }
+  if (kind !== 'exact' && kind !== 'estimated') {
+    return fail(`Unsupported data query total kind: ${kind}`);
+  }
+  exactKeys(object, ['kind', 'value', 'asOf'], 'Data query total');
+  const asOf =
+    object.asOf === undefined
+      ? undefined
+      : normalizedInstant(object.asOf, 'Data query total asOf');
+  return {
+    kind,
+    value: nonNegativeInteger(object.value, 'Data query total value'),
+    ...(asOf === undefined ? {} : { asOf }),
+  };
+}
+
+function normalizeFreshness(value: unknown): DataQueryFreshness {
+  const object = plainObject(value, 'Data query freshness');
+  exactKeys(object, ['state', 'asOf'], 'Data query freshness');
+  const state = stringValue(object.state, 'Data query freshness state');
+  if (!['fresh', 'stale', 'unknown'].includes(state)) {
+    return fail(`Unsupported data query freshness state: ${state}`);
+  }
+  const asOf =
+    object.asOf === undefined
+      ? undefined
+      : normalizedInstant(object.asOf, 'Data query freshness asOf');
+  return {
+    state: state as DataQueryFreshness['state'],
+    ...(asOf === undefined ? {} : { asOf }),
+  };
+}
+
+function normalizeFacetsResult(
+  value: unknown,
+  requested: readonly DataQueryFacetRequest[],
+  fields: Map<string, DataQueryFieldDescriptor>,
+): DataQueryFacetResult[] {
+  if (!Array.isArray(value))
+    return fail('Data query result facets must be an array');
+  if (value.length > requested.length) {
+    return fail('Data query result returned too many facets');
+  }
+  const limits = new Map(requested.map((facet) => [facet.field, facet.limit]));
+  const results = value.map((entry) => {
+    const object = plainObject(entry, 'Data query facet result');
+    exactKeys(
+      object,
+      ['field', 'values', 'truncated'],
+      'Data query facet result',
+    );
+    const field = stringValue(object.field, 'Data query facet result field');
+    const limit = limits.get(field);
+    if (limit === undefined)
+      return fail(`Data query returned an unrequested facet: ${field}`);
+    if (!Array.isArray(object.values) || object.values.length > limit) {
+      return fail(`Data query facet ${field} exceeds its requested limit`);
+    }
+    if (typeof object.truncated !== 'boolean')
+      return fail('Data query facet truncated must be boolean');
+    const descriptor = fields.get(field);
+    if (!descriptor)
+      return fail(`Data query facet field is not declared: ${field}`);
+    const values = object.values.map((candidate) => {
+      const facet = plainObject(candidate, 'Data query facet value');
+      exactKeys(facet, ['value', 'count'], 'Data query facet value');
+      return {
+        value: scalarForField(
+          facet.value,
+          descriptor,
+          `Data query facet ${field} value`,
+        ),
+        count: nonNegativeInteger(facet.count, 'Data query facet count'),
+      };
+    });
+    return { field, values, truncated: object.truncated };
+  });
+  if (new Set(results.map((facet) => facet.field)).size !== results.length) {
+    return fail('Data query result facet fields must be unique');
+  }
+  return results.sort((left, right) =>
+    compareCanonicalStrings(left.field, right.field),
+  );
+}
+
+/**
+ * Validate an adapter result against the normalized request and its schema.
+ * This is the final projection boundary: undeclared fields, malformed totals,
+ * forged fingerprints, oversized rows, and authority-shaped prototype payloads
+ * cannot cross into REST, MCP, WebMCP, or browser consumers unnoticed.
+ */
+export function normalizeDataQueryResult(
+  value: unknown,
+  inputRequest: unknown,
+  inputSchema: unknown,
+): DataQueryResult {
+  const schema = normalizeDataQuerySchema(inputSchema);
+  const request = normalizeDataQueryRequest(inputRequest, schema);
+  const fields = new Map(schema.fields.map((field) => [field.id, field]));
+  const object = plainObject(value, 'Data query result');
+  exactKeys(
+    object,
+    [
+      'version',
+      'requestId',
+      'queryFingerprint',
+      'identityField',
+      'rows',
+      'page',
+      'total',
+      'facets',
+      'freshness',
+      'warnings',
+      'truncated',
+    ],
+    'Data query result',
+  );
+  if (object.version !== 1)
+    return fail('Unsupported data query result version');
+  if (
+    stringValue(object.requestId, 'Data query result request id', 128) !==
+    request.requestId
+  ) {
+    return fail(
+      'Data query result request id does not match its request',
+      'DATA_QUERY_RESULT_INVALID',
+    );
+  }
+  const fingerprint = createDataQueryFingerprint(request, schema);
+  if (
+    stringValue(
+      object.queryFingerprint,
+      'Data query result fingerprint',
+      128,
+    ) !== fingerprint
+  ) {
+    return fail(
+      'Data query result fingerprint does not match its request',
+      'DATA_QUERY_RESULT_INVALID',
+    );
+  }
+  if (
+    stringValue(object.identityField, 'Data query result identity field') !==
+    schema.identityField
+  ) {
+    return fail(
+      'Data query result identity field does not match its schema',
+      'DATA_QUERY_RESULT_INVALID',
+    );
+  }
+  if (!Array.isArray(object.rows))
+    return fail('Data query result rows must be an array');
+  const projection =
+    request.mode === 'rows'
+      ? (request.projection ?? [schema.identityField])
+      : [];
+  const page = request.mode === 'rows' ? request.page : undefined;
+  if (request.mode !== 'rows' && object.rows.length > 0) {
+    return fail(`${request.mode} data query results cannot return rows`);
+  }
+  if (page && object.rows.length > page.limit) {
+    return fail('Data query result rows exceed its requested page limit');
+  }
+  const rows = object.rows.map((row) =>
+    normalizeRow(row, projection, schema.identityField, fields),
+  );
+  let normalizedPage: DataQueryResult['page'];
+  if (page) {
+    const pageObject = plainObject(object.page, 'Data query result page');
+    exactKeys(
+      pageObject,
+      ['kind', 'limit', 'offset', 'nextCursor', 'hasMore'],
+      'Data query result page',
+    );
+    if (
+      pageObject.kind !== page.kind ||
+      nonNegativeInteger(pageObject.limit, 'Data query result page limit') !==
+        page.limit
+    ) {
+      return fail('Data query result page does not match its request');
+    }
+    if (typeof pageObject.hasMore !== 'boolean')
+      return fail('Data query result page hasMore must be boolean');
+    if (page.kind === 'offset') {
+      if (
+        nonNegativeInteger(pageObject.offset, 'Data query result offset') !==
+        page.offset
+      ) {
+        return fail('Data query result offset does not match its request');
+      }
+      if (pageObject.nextCursor !== undefined)
+        return fail('Offset data query results cannot return a cursor');
+      normalizedPage = {
+        kind: 'offset',
+        limit: page.limit,
+        offset: page.offset,
+        hasMore: pageObject.hasMore,
+      };
+    } else {
+      const nextCursor =
+        pageObject.nextCursor === undefined
+          ? undefined
+          : stringValue(
+              pageObject.nextCursor,
+              'Data query result next cursor',
+              MAX_DATA_QUERY_CURSOR_LENGTH,
+            );
+      if (pageObject.hasMore !== Boolean(nextCursor)) {
+        return fail('Data query cursor result hasMore must match nextCursor');
+      }
+      normalizedPage = {
+        kind: 'cursor',
+        limit: page.limit,
+        hasMore: pageObject.hasMore,
+        ...(nextCursor === undefined ? {} : { nextCursor }),
+      };
+    }
+  } else if (object.page !== undefined) {
+    return fail(`${request.mode} data query results cannot return a page`);
+  }
+  const total = normalizeTotal(object.total);
+  const freshness = normalizeFreshness(object.freshness);
+  if (
+    !Array.isArray(object.warnings) ||
+    object.warnings.length > MAX_DATA_QUERY_WARNINGS ||
+    object.warnings.some(
+      (warning) => typeof warning !== 'string' || warning.length > 512,
+    )
+  ) {
+    return fail('Data query result warnings must be at most 100 short strings');
+  }
+  if (typeof object.truncated !== 'boolean')
+    return fail('Data query result truncated must be boolean');
+  const facets =
+    request.mode === 'facets'
+      ? normalizeFacetsResult(object.facets, request.facets ?? [], fields)
+      : object.facets === undefined
+        ? undefined
+        : fail(`${request.mode} data query results cannot return facets`);
+  const normalized: DataQueryResult = {
+    version: 1,
+    requestId: request.requestId,
+    queryFingerprint: fingerprint,
+    identityField: schema.identityField,
+    rows,
+    ...(normalizedPage === undefined ? {} : { page: normalizedPage }),
+    total,
+    ...(facets === undefined ? {} : { facets }),
+    freshness,
+    warnings: [...new Set(object.warnings)].sort(),
+    truncated: object.truncated,
+  };
+  const bytes = new TextEncoder().encode(JSON.stringify(normalized)).byteLength;
+  if (bytes > (schema.maxResultBytes ?? DEFAULT_DATA_QUERY_RESULT_BYTES)) {
+    return fail(
+      'Data query result exceeds its maximum byte limit',
+      'DATA_QUERY_RESULT_TOO_LARGE',
+    );
+  }
+  return normalized;
+}

--- a/packages/core/src/data-query.ts
+++ b/packages/core/src/data-query.ts
@@ -44,6 +44,9 @@ export const MAX_DATA_QUERY_IN_VALUES = 100;
 export const MAX_DATA_QUERY_FACETS = 20;
 export const MAX_DATA_QUERY_WARNINGS = 100;
 export const MAX_DATA_QUERY_CURSOR_LENGTH = 2_048;
+export const MAX_DATA_QUERY_JSON_DEPTH = 16;
+export const MAX_DATA_QUERY_JSON_CONTAINER_ITEMS = 1_000;
+export const MAX_DATA_QUERY_JSON_STRING_LENGTH = 65_536;
 
 const FILTER_OPERATORS = new Set<DataQueryFilterOperator>([
   'eq',
@@ -75,6 +78,15 @@ export class DataQueryValidationError extends ValidationError {
 }
 
 type JsonObject = Record<string, unknown>;
+
+interface JsonBudget {
+  remaining: number;
+  failureCode: string;
+}
+
+const encoder = new TextEncoder();
+const RFC_3339_INSTANT =
+  /^(\d{4})-(\d{2})-(\d{2})T([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(?:\.\d{1,9})?(?:Z|[+-](?:[01]\d|2[0-3]):[0-5]\d)$/;
 
 function fail(
   message: string,
@@ -144,6 +156,19 @@ function positiveInteger(value: unknown, label: string): number {
 
 function normalizedInstant(value: unknown, label: string): string {
   const input = stringValue(value, label, 128);
+  const match = RFC_3339_INSTANT.exec(input);
+  if (!match) return fail(`${label} must be an RFC 3339 instant`);
+  const [year, month, day] = match.slice(1, 4).map(Number);
+  const calendar = new Date(0);
+  calendar.setUTCFullYear(year, month - 1, day);
+  calendar.setUTCHours(0, 0, 0, 0);
+  if (
+    calendar.getUTCFullYear() !== year ||
+    calendar.getUTCMonth() !== month - 1 ||
+    calendar.getUTCDate() !== day
+  ) {
+    return fail(`${label} must be an RFC 3339 instant`);
+  }
   const milliseconds = Date.parse(input);
   if (!Number.isFinite(milliseconds)) {
     return fail(`${label} must be an RFC 3339 instant`);
@@ -165,39 +190,182 @@ function dataQueryScalar(value: unknown, label: string): DataQueryScalar {
   return fail(`${label} must be a JSON scalar`);
 }
 
-function canonicalJson(value: unknown, label = 'Data query JSON'): unknown {
-  if (
-    value === null ||
-    typeof value === 'string' ||
-    typeof value === 'boolean'
-  ) {
+function consumeJsonSegment(
+  budget: JsonBudget | undefined,
+  text: string,
+  label: string,
+): void {
+  if (!budget) return;
+  if (text.length > budget.remaining) {
+    fail(`${label} exceeds the maximum byte limit`, budget.failureCode);
+  }
+  const bytes = encoder.encode(text).byteLength;
+  if (bytes > budget.remaining) {
+    fail(`${label} exceeds the maximum byte limit`, budget.failureCode);
+  }
+  budget.remaining -= bytes;
+}
+
+function canonicalJson(
+  value: unknown,
+  label = 'Data query JSON',
+  budget?: JsonBudget,
+  depth = 0,
+  ancestors = new Set<object>(),
+): unknown {
+  if (depth > MAX_DATA_QUERY_JSON_DEPTH) {
+    return fail(`${label} exceeds the JSON depth limit`);
+  }
+  if (value === null || typeof value === 'boolean') {
+    consumeJsonSegment(budget, JSON.stringify(value), label);
+    return value;
+  }
+  if (typeof value === 'string') {
+    if (value.length > MAX_DATA_QUERY_JSON_STRING_LENGTH) {
+      return fail(`${label} exceeds the JSON string limit`);
+    }
+    consumeJsonSegment(budget, JSON.stringify(value), label);
     return value;
   }
   if (typeof value === 'number') {
     if (!Number.isFinite(value))
       return fail(`${label} cannot contain a non-finite number`);
-    return value === 0 ? 0 : value;
+    const normalized = value === 0 ? 0 : value;
+    consumeJsonSegment(budget, JSON.stringify(normalized), label);
+    return normalized;
   }
   if (Array.isArray(value)) {
-    return value.map((entry, index) =>
-      canonicalJson(entry, `${label}[${index}]`),
-    );
+    if (value.length > MAX_DATA_QUERY_JSON_CONTAINER_ITEMS) {
+      return fail(`${label} exceeds the JSON container-item limit`);
+    }
+    if (ancestors.has(value)) return fail(`${label} cannot contain a cycle`);
+    ancestors.add(value);
+    try {
+      const result: unknown[] = [];
+      consumeJsonSegment(budget, '[', label);
+      for (const [index, entry] of value.entries()) {
+        if (index > 0) consumeJsonSegment(budget, ',', label);
+        result.push(
+          canonicalJson(
+            entry,
+            `${label}[${index}]`,
+            budget,
+            depth + 1,
+            ancestors,
+          ),
+        );
+      }
+      consumeJsonSegment(budget, ']', label);
+      return result;
+    } finally {
+      ancestors.delete(value);
+    }
   }
   const object = plainObject(value, label);
-  const result: JsonObject = Object.create(null) as JsonObject;
-  for (const key of Object.keys(object).sort()) {
-    Object.defineProperty(result, key, {
-      value: canonicalJson(object[key], `${label}.${key}`),
-      enumerable: true,
-      configurable: true,
-      writable: true,
-    });
+  const keys = Object.keys(object).sort(compareCanonicalStrings);
+  if (keys.length > MAX_DATA_QUERY_JSON_CONTAINER_ITEMS) {
+    return fail(`${label} exceeds the JSON container-item limit`);
   }
-  return result;
+  if (ancestors.has(object)) return fail(`${label} cannot contain a cycle`);
+  ancestors.add(object);
+  try {
+    const result: JsonObject = Object.create(null) as JsonObject;
+    consumeJsonSegment(budget, '{', label);
+    for (const [index, key] of keys.entries()) {
+      if (key.length > MAX_DATA_QUERY_JSON_STRING_LENGTH) {
+        return fail(`${label}.${key} exceeds the JSON string limit`);
+      }
+      if (index > 0) consumeJsonSegment(budget, ',', label);
+      consumeJsonSegment(budget, JSON.stringify(key), `${label}.${key}`);
+      consumeJsonSegment(budget, ':', label);
+      Object.defineProperty(result, key, {
+        value: canonicalJson(
+          object[key],
+          `${label}.${key}`,
+          budget,
+          depth + 1,
+          ancestors,
+        ),
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+    consumeJsonSegment(budget, '}', label);
+    return result;
+  } finally {
+    ancestors.delete(object);
+  }
 }
 
 function signature(value: unknown): string {
   return JSON.stringify(canonicalJson(value));
+}
+
+/** Reject an over-limit raw request before canonicalization can collapse it. */
+function assertBoundedRawRequest(value: unknown): void {
+  const budget: JsonBudget = {
+    remaining: MAX_DATA_QUERY_REQUEST_BYTES,
+    failureCode: 'DATA_QUERY_REQUEST_TOO_LARGE',
+  };
+  const ancestors = new Set<object>();
+
+  const measure = (candidate: unknown, label: string, depth = 0): void => {
+    if (depth > MAX_DATA_QUERY_JSON_DEPTH) {
+      fail(`${label} exceeds the JSON depth limit`);
+    }
+    if (candidate === null || typeof candidate === 'boolean') {
+      consumeJsonSegment(budget, JSON.stringify(candidate), label);
+      return;
+    }
+    if (typeof candidate === 'string') {
+      consumeJsonSegment(budget, JSON.stringify(candidate), label);
+      return;
+    }
+    if (typeof candidate === 'number') {
+      if (!Number.isFinite(candidate)) {
+        fail(`${label} cannot contain a non-finite number`);
+      }
+      consumeJsonSegment(
+        budget,
+        JSON.stringify(candidate === 0 ? 0 : candidate),
+        label,
+      );
+      return;
+    }
+    if (Array.isArray(candidate)) {
+      if (ancestors.has(candidate)) fail(`${label} cannot contain a cycle`);
+      ancestors.add(candidate);
+      try {
+        consumeJsonSegment(budget, '[', label);
+        for (const [index, entry] of candidate.entries()) {
+          if (index > 0) consumeJsonSegment(budget, ',', label);
+          measure(entry, `${label}[${index}]`, depth + 1);
+        }
+        consumeJsonSegment(budget, ']', label);
+      } finally {
+        ancestors.delete(candidate);
+      }
+      return;
+    }
+    const object = plainObject(candidate, label);
+    if (ancestors.has(object)) fail(`${label} cannot contain a cycle`);
+    ancestors.add(object);
+    try {
+      consumeJsonSegment(budget, '{', label);
+      for (const [index, key] of Object.keys(object).entries()) {
+        if (index > 0) consumeJsonSegment(budget, ',', label);
+        consumeJsonSegment(budget, JSON.stringify(key), `${label}.${key}`);
+        consumeJsonSegment(budget, ':', label);
+        measure(object[key], `${label}.${key}`, depth + 1);
+      }
+      consumeJsonSegment(budget, '}', label);
+    } finally {
+      ancestors.delete(object);
+    }
+  };
+
+  measure(value, 'Data query request');
 }
 
 /** Locale-independent ordering for canonical envelopes and fingerprints. */
@@ -295,6 +463,11 @@ export function normalizeDataQuerySchema(value: unknown): DataQuerySchema {
   if (!identity) return fail('Data query identity field must be declared');
   if (identity.projectable === false) {
     return fail('Data query identity field must be projectable');
+  }
+  if (!['string', 'number', 'datetime'].includes(identity.type)) {
+    return fail(
+      'Data query identity field must use a string, number, or datetime type',
+    );
   }
   const maxPageLimit =
     object.maxPageLimit === undefined
@@ -555,6 +728,9 @@ function normalizeSort(
   if (value === undefined)
     return appendIdentity ? [{ field: identityField, direction: 'asc' }] : [];
   if (!Array.isArray(value)) return fail(`${label} must be an array`);
+  if (value.length > MAX_DATA_QUERY_FILTERS) {
+    return fail(`${label} cannot exceed ${MAX_DATA_QUERY_FILTERS} terms`);
+  }
   const sort = value.map((entry) => {
     const object = plainObject(entry, label);
     exactKeys(object, ['field', 'direction'], label);
@@ -571,8 +747,6 @@ function normalizeSort(
     }
     return { field, direction } as DataQuerySort;
   });
-  if (sort.length > MAX_DATA_QUERY_FILTERS)
-    return fail(`${label} cannot exceed ${MAX_DATA_QUERY_FILTERS} terms`);
   if (new Set(sort.map((term) => term.field)).size !== sort.length) {
     return fail(`${label} field ids must be unique`);
   }
@@ -594,12 +768,13 @@ function normalizePage(value: unknown, schema: DataQuerySchema): DataQueryPage {
   const kind = stringValue(object.kind, 'Data query page kind');
   if (kind === 'offset') {
     exactKeys(object, ['kind', 'offset', 'limit'], 'Data query offset page');
+    const offset = nonNegativeInteger(object.offset, 'Data query offset');
+    if (offset > MAX_DATA_QUERY_OFFSET) {
+      return fail(`Data query offset cannot exceed ${MAX_DATA_QUERY_OFFSET}`);
+    }
     return {
       kind,
-      offset: Math.min(
-        nonNegativeInteger(object.offset, 'Data query offset'),
-        MAX_DATA_QUERY_OFFSET,
-      ),
+      offset,
       limit: Math.min(
         positiveInteger(object.limit, 'Data query page limit'),
         schema.maxPageLimit ?? MAX_DATA_QUERY_PAGE_LIMIT,
@@ -726,6 +901,7 @@ export function normalizeDataQueryRequest(
   const schema = normalizeDataQuerySchema(inputSchema);
   const fields = new Map(schema.fields.map((field) => [field.id, field]));
   const object = plainObject(value, 'Data query request');
+  assertBoundedRawRequest(value);
   exactKeys(
     object,
     [
@@ -757,6 +933,14 @@ export function normalizeDataQueryRequest(
       return fail('Rows queries cannot request facets');
     if (object.projection !== undefined && !Array.isArray(object.projection)) {
       return fail('Data query projection must be an array');
+    }
+    if (
+      Array.isArray(object.projection) &&
+      object.projection.length > MAX_DATA_QUERY_FILTERS
+    ) {
+      return fail(
+        `Data query projection cannot exceed ${MAX_DATA_QUERY_FILTERS} fields`,
+      );
     }
     const requestedProjection = (object.projection ?? []).map((field) =>
       stringValue(field, 'Data query projection field'),
@@ -837,9 +1021,12 @@ function normalizeResultFieldValue(
   value: unknown,
   descriptor: DataQueryFieldDescriptor,
   label: string,
+  budget: JsonBudget,
 ): unknown {
-  if (descriptor.type === 'json') return canonicalJson(value, label);
-  return scalarForField(value, descriptor, label);
+  if (descriptor.type === 'json') return canonicalJson(value, label, budget);
+  const normalized = scalarForField(value, descriptor, label);
+  consumeJsonSegment(budget, JSON.stringify(normalized), label);
+  return normalized;
 }
 
 function normalizeRow(
@@ -847,11 +1034,13 @@ function normalizeRow(
   projection: readonly string[],
   identityField: string,
   fields: Map<string, DataQueryFieldDescriptor>,
+  budget: JsonBudget,
 ): DataQueryRow {
   const object = plainObject(value, 'Data query row');
   const allowed = new Set(projection);
   const normalized: JsonObject = Object.create(null) as JsonObject;
-  for (const key of Object.keys(object)) {
+  consumeJsonSegment(budget, '{', 'Data query row');
+  for (const [index, key] of Object.keys(object).entries()) {
     if (!allowed.has(key)) {
       fail(
         `Data query row returned a non-projected field: ${key}`,
@@ -865,12 +1054,17 @@ function normalizeRow(
         'DATA_QUERY_RESULT_NOT_ALLOWED',
       );
     }
+    if (index > 0) consumeJsonSegment(budget, ',', 'Data query row');
+    consumeJsonSegment(budget, JSON.stringify(key), `Data query row ${key}`);
+    consumeJsonSegment(budget, ':', `Data query row ${key}`);
     normalized[key] = normalizeResultFieldValue(
       object[key],
       descriptor,
       `Data query row ${key}`,
+      budget,
     );
   }
+  consumeJsonSegment(budget, '}', 'Data query row');
   const identity = normalized[identityField];
   if (
     (typeof identity !== 'string' && typeof identity !== 'number') ||
@@ -931,6 +1125,7 @@ function normalizeFacetsResult(
   value: unknown,
   requested: readonly DataQueryFacetRequest[],
   fields: Map<string, DataQueryFieldDescriptor>,
+  budget: JsonBudget,
 ): DataQueryFacetResult[] {
   if (!Array.isArray(value))
     return fail('Data query result facets must be an array');
@@ -938,7 +1133,9 @@ function normalizeFacetsResult(
     return fail('Data query result returned too many facets');
   }
   const limits = new Map(requested.map((facet) => [facet.field, facet.limit]));
-  const results = value.map((entry) => {
+  consumeJsonSegment(budget, '[', 'Data query result facets');
+  const results = value.map((entry, index) => {
+    if (index > 0) consumeJsonSegment(budget, ',', 'Data query result facets');
     const object = plainObject(entry, 'Data query facet result');
     exactKeys(
       object,
@@ -957,20 +1154,42 @@ function normalizeFacetsResult(
     const descriptor = fields.get(field);
     if (!descriptor)
       return fail(`Data query facet field is not declared: ${field}`);
-    const values = object.values.map((candidate) => {
+    consumeJsonSegment(budget, '{"field":', `Data query facet ${field}`);
+    consumeJsonSegment(
+      budget,
+      JSON.stringify(field),
+      `Data query facet ${field}`,
+    );
+    consumeJsonSegment(budget, ',"values":[', `Data query facet ${field}`);
+    const values = object.values.map((candidate, valueIndex) => {
+      if (valueIndex > 0)
+        consumeJsonSegment(budget, ',', `Data query facet ${field}`);
       const facet = plainObject(candidate, 'Data query facet value');
       exactKeys(facet, ['value', 'count'], 'Data query facet value');
+      const normalizedValue = scalarForField(
+        facet.value,
+        descriptor,
+        `Data query facet ${field} value`,
+      );
+      const count = nonNegativeInteger(facet.count, 'Data query facet count');
+      consumeJsonSegment(
+        budget,
+        `{"value":${JSON.stringify(normalizedValue)},"count":${JSON.stringify(count)}}`,
+        `Data query facet ${field} value`,
+      );
       return {
-        value: scalarForField(
-          facet.value,
-          descriptor,
-          `Data query facet ${field} value`,
-        ),
-        count: nonNegativeInteger(facet.count, 'Data query facet count'),
+        value: normalizedValue,
+        count,
       };
     });
+    consumeJsonSegment(
+      budget,
+      `],"truncated":${object.truncated}}`,
+      `Data query facet ${field}`,
+    );
     return { field, values, truncated: object.truncated };
   });
+  consumeJsonSegment(budget, ']', 'Data query result facets');
   if (new Set(results.map((facet) => facet.field)).size !== results.length) {
     return fail('Data query result facet fields must be unique');
   }
@@ -1057,9 +1276,16 @@ export function normalizeDataQueryResult(
   if (page && object.rows.length > page.limit) {
     return fail('Data query result rows exceed its requested page limit');
   }
-  const rows = object.rows.map((row) =>
-    normalizeRow(row, projection, schema.identityField, fields),
-  );
+  const budget: JsonBudget = {
+    remaining: schema.maxResultBytes ?? DEFAULT_DATA_QUERY_RESULT_BYTES,
+    failureCode: 'DATA_QUERY_RESULT_TOO_LARGE',
+  };
+  consumeJsonSegment(budget, '[', 'Data query result rows');
+  const rows = object.rows.map((row, index) => {
+    if (index > 0) consumeJsonSegment(budget, ',', 'Data query result rows');
+    return normalizeRow(row, projection, schema.identityField, fields, budget);
+  });
+  consumeJsonSegment(budget, ']', 'Data query result rows');
   let normalizedPage: DataQueryResult['page'];
   if (page) {
     const pageObject = plainObject(object.page, 'Data query result page');
@@ -1093,6 +1319,9 @@ export function normalizeDataQueryResult(
         hasMore: pageObject.hasMore,
       };
     } else {
+      if (pageObject.offset !== undefined) {
+        return fail('Cursor data query results cannot return an offset');
+      }
       const nextCursor =
         pageObject.nextCursor === undefined
           ? undefined
@@ -1120,7 +1349,10 @@ export function normalizeDataQueryResult(
     !Array.isArray(object.warnings) ||
     object.warnings.length > MAX_DATA_QUERY_WARNINGS ||
     object.warnings.some(
-      (warning) => typeof warning !== 'string' || warning.length > 512,
+      (warning) =>
+        typeof warning !== 'string' ||
+        warning.length === 0 ||
+        warning.length > 512,
     )
   ) {
     return fail('Data query result warnings must be at most 100 short strings');
@@ -1129,7 +1361,12 @@ export function normalizeDataQueryResult(
     return fail('Data query result truncated must be boolean');
   const facets =
     request.mode === 'facets'
-      ? normalizeFacetsResult(object.facets, request.facets ?? [], fields)
+      ? normalizeFacetsResult(
+          object.facets,
+          request.facets ?? [],
+          fields,
+          budget,
+        )
       : object.facets === undefined
         ? undefined
         : fail(`${request.mode} data query results cannot return facets`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,6 +96,28 @@ export type {
 } from './config';
 // Global configuration (callable function)
 export { config } from './config';
+// Canonical bounded query protocol — adapters supply their own authorization
+// and execution, while this runtime normalizes the shared envelope (#2444).
+export {
+  canonicalizeDataQuery,
+  createDataQueryFingerprint,
+  DataQueryValidationError,
+  DEFAULT_DATA_QUERY_PAGE_LIMIT,
+  DEFAULT_DATA_QUERY_RESULT_BYTES,
+  MAX_DATA_QUERY_CURSOR_LENGTH,
+  MAX_DATA_QUERY_FACETS,
+  MAX_DATA_QUERY_FILTER_DEPTH,
+  MAX_DATA_QUERY_FILTERS,
+  MAX_DATA_QUERY_IN_VALUES,
+  MAX_DATA_QUERY_OFFSET,
+  MAX_DATA_QUERY_PAGE_LIMIT,
+  MAX_DATA_QUERY_REQUEST_BYTES,
+  MAX_DATA_QUERY_RESULT_BYTES,
+  MAX_DATA_QUERY_WARNINGS,
+  normalizeDataQueryRequest,
+  normalizeDataQueryResult,
+  normalizeDataQuerySchema,
+} from './data-query';
 // Database utilities
 export {
   type DatabaseConfig,

--- a/packages/smrt-web/AGENTS.md
+++ b/packages/smrt-web/AGENTS.md
@@ -64,8 +64,9 @@ module you are editing. This file keeps what holds in every module.
 - **Data-query mirror** — `data-query.ts` mirrors the portable
   `smrt-types` request/result shape structurally because this package cannot
   depend on another SMRT package. Server adapters own authorization and full
-  query/result policy; browser code calls `executeSmrtWebDataQuery()` to reject
-  malformed or over-limit returned envelopes before they reach a UI surface.
+query/result policy; browser code calls `executeSmrtWebDataQuery()` to reject
+malformed or over-limit returned envelopes — including a response for a
+different request id — before they reach a UI surface.
 - Rows are plain DTOs with a required `id`; optimistic inserts use
   `newLocalId()` — the generated REST layer strips client ids on create
   (#1540), so the post-persist refetch reconciles server-assigned ids.

--- a/packages/smrt-web/AGENTS.md
+++ b/packages/smrt-web/AGENTS.md
@@ -39,6 +39,7 @@ module you are editing. This file keeps what holds in every module.
 | `offline/` | durable offline writes — config, sync-apply-only replay, idempotency, the shared namespace-keyed engine, and Web Locks leader election | [agents/offline-outbox.md](agents/offline-outbox.md) |
 | `sse-client.ts` | the client half of live cache invalidation — the app-wide subscriber, the wire contract it consumes, and SSE-vs-polling behaviour | [agents/live-invalidation.md](agents/live-invalidation.md) |
 | `persistence/` + `update-state.ts` | the read-cache rehydrate capability and the framework-free `updateAvailable` primitive (bundle + contract signals) | [agents/version-persistence.md](agents/version-persistence.md) |
+| `data-query.ts` | dependency-free browser mirror and defensive response normalizer for the canonical bounded data-query envelope (#2444) | — |
 
 ## The engine-absorption boundary (ratified conditions, #1761)
 
@@ -60,6 +61,11 @@ module you are editing. This file keeps what holds in every module.
 
 - **No inter-smrt dependencies** — depends only on TanStack packages
   (dependency-DAG guardrails). Definitions and fetchers arrive as arguments.
+- **Data-query mirror** — `data-query.ts` mirrors the portable
+  `smrt-types` request/result shape structurally because this package cannot
+  depend on another SMRT package. Server adapters own authorization and full
+  query/result policy; browser code calls `executeSmrtWebDataQuery()` to reject
+  malformed or over-limit returned envelopes before they reach a UI surface.
 - Rows are plain DTOs with a required `id`; optimistic inserts use
   `newLocalId()` — the generated REST layer strips client ids on create
   (#1540), so the post-persist refetch reconciles server-assigned ids.

--- a/packages/smrt-web/src/data-query.test.ts
+++ b/packages/smrt-web/src/data-query.test.ts
@@ -40,6 +40,12 @@ describe('smrt-web bounded data-query transport', () => {
       ...result,
       warnings: ['cache-hit', 'revalidated'],
     });
+    await expect(
+      executeSmrtWebDataQuery(
+        { query: async () => ({ ...result, requestId: 'other-request' }) },
+        request,
+      ),
+    ).rejects.toThrow(/request id does not match/i);
   });
 
   it('fails closed for malformed browser envelopes', () => {
@@ -110,5 +116,15 @@ describe('smrt-web bounded data-query transport', () => {
         page: { kind: 'offset', offset: 0, limit: 1_000, hasMore: false },
       }),
     ).toThrow(/maximum byte limit/i);
+    expect(
+      normalizeSmrtWebDataQueryResult({
+        ...result,
+        rows: Array.from({ length: 1_000 }, (_, index) => ({
+          id: `row-${index}`,
+          name: 'x'.repeat(9_800),
+        })),
+        page: { kind: 'offset', offset: 0, limit: 1_000, hasMore: false },
+      }).rows,
+    ).toHaveLength(1_000);
   });
 });

--- a/packages/smrt-web/src/data-query.test.ts
+++ b/packages/smrt-web/src/data-query.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  executeSmrtWebDataQuery,
+  normalizeSmrtWebDataQueryResult,
+  type SmrtWebDataQueryRequest,
+} from './data-query.js';
+
+const request: SmrtWebDataQueryRequest = {
+  version: 1,
+  requestId: 'browser-query-1',
+  mode: 'rows',
+  projection: ['name'],
+  page: { kind: 'offset', offset: 0, limit: 10 },
+};
+
+const result = {
+  version: 1,
+  requestId: 'browser-query-1',
+  queryFingerprint: 'dq1_bounded',
+  identityField: 'id',
+  rows: [{ id: 'row-1', name: 'Ada' }],
+  page: { kind: 'offset', offset: 0, limit: 10, hasMore: false },
+  total: { kind: 'exact', value: 1 },
+  freshness: { state: 'fresh' },
+  warnings: ['revalidated', 'cache-hit'],
+  truncated: false,
+};
+
+describe('smrt-web bounded data-query transport', () => {
+  it('normalizes the same result envelope returned by a server adapter', async () => {
+    await expect(
+      executeSmrtWebDataQuery(
+        {
+          query: async (received) =>
+            received.requestId === request.requestId ? result : {},
+        },
+        request,
+      ),
+    ).resolves.toEqual({
+      ...result,
+      warnings: ['cache-hit', 'revalidated'],
+    });
+  });
+
+  it('fails closed for malformed browser envelopes', () => {
+    expect(() =>
+      normalizeSmrtWebDataQueryResult({
+        ...result,
+        rows: [{ id: 'row-1', name: 'Ada', nested: () => 'unsafe' }],
+      }),
+    ).toThrow(/plain object|JSON/i);
+    expect(() =>
+      normalizeSmrtWebDataQueryResult({ ...result, tenantId: 'other' }),
+    ).toThrow(/contains tenantId/i);
+    expect(() =>
+      normalizeSmrtWebDataQueryResult({
+        ...result,
+        page: { kind: 'cursor', limit: 10, hasMore: true },
+      }),
+    ).toThrow(/hasMore/i);
+  });
+
+  it('enforces row and facet response ceilings before copying a payload', () => {
+    expect(() =>
+      normalizeSmrtWebDataQueryResult({
+        ...result,
+        rows: Array.from({ length: 1_001 }, (_, index) => ({
+          id: `row-${index}`,
+        })),
+      }),
+    ).toThrow(/rows exceed/i);
+    expect(() =>
+      normalizeSmrtWebDataQueryResult({
+        ...result,
+        facets: Array.from({ length: 21 }, (_, index) => ({
+          field: `facet-${index}`,
+          values: [],
+          truncated: false,
+        })),
+      }),
+    ).toThrow(/facets exceed/i);
+    expect(() =>
+      normalizeSmrtWebDataQueryResult({
+        ...result,
+        page: {
+          kind: 'offset',
+          offset: 1_000_001,
+          limit: 10,
+          hasMore: false,
+        },
+      }),
+    ).toThrow(/offset exceeds/i);
+    expect(() =>
+      normalizeSmrtWebDataQueryResult({
+        ...result,
+        rows: [
+          { id: 'row-1', name: 'Ada' },
+          { id: 'row-2', name: 'Grace' },
+        ],
+        page: { kind: 'offset', offset: 0, limit: 1, hasMore: true },
+      }),
+    ).toThrow(/declared page limit/i);
+    expect(() =>
+      normalizeSmrtWebDataQueryResult({
+        ...result,
+        rows: Array.from({ length: 1_000 }, (_, index) => ({
+          id: `row-${index}`,
+          name: 'x'.repeat(12_000),
+        })),
+        page: { kind: 'offset', offset: 0, limit: 1_000, hasMore: false },
+      }),
+    ).toThrow(/maximum byte limit/i);
+  });
+});

--- a/packages/smrt-web/src/data-query.ts
+++ b/packages/smrt-web/src/data-query.ts
@@ -96,7 +96,6 @@ export const MAX_SMRT_WEB_DATA_QUERY_PAGE_LIMIT = 1_000;
 export const MAX_SMRT_WEB_DATA_QUERY_OFFSET = 1_000_000;
 export const MAX_SMRT_WEB_DATA_QUERY_CONTAINER_ITEMS = 1_000;
 export const MAX_SMRT_WEB_DATA_QUERY_STRING_LENGTH = 65_536;
-const RESPONSE_METADATA_RESERVE_BYTES = 100_000;
 
 interface JsonBudget {
   remaining: number;
@@ -223,6 +222,9 @@ function jsonValue(
   >;
   consumeBytes(budget, '{', label);
   for (const [index, key] of Object.keys(object).sort().entries()) {
+    if (key.length > MAX_SMRT_WEB_DATA_QUERY_STRING_LENGTH) {
+      throw new TypeError(`${label}.${key} exceeds the string limit`);
+    }
     if (index > 0) consumeBytes(budget, ',', label);
     consumeBytes(budget, JSON.stringify(key), `${label}.${key}`);
     consumeBytes(budget, ':', label);
@@ -340,8 +342,7 @@ export function normalizeSmrtWebDataQueryResult(
     throw new TypeError('Data query rows exceed the maximum');
   }
   const budget: JsonBudget = {
-    remaining:
-      MAX_SMRT_WEB_DATA_QUERY_RESULT_BYTES - RESPONSE_METADATA_RESERVE_BYTES,
+    remaining: MAX_SMRT_WEB_DATA_QUERY_RESULT_BYTES,
   };
   const rows = result.rows.map((row, index) => {
     const normalized = jsonValue(row, `Data query row ${index}`, budget);
@@ -473,7 +474,13 @@ export async function executeSmrtWebDataQuery(
   request: SmrtWebDataQueryRequest,
   options?: { signal?: AbortSignal },
 ): Promise<SmrtWebDataQueryResult> {
-  return normalizeSmrtWebDataQueryResult(
+  const result = normalizeSmrtWebDataQueryResult(
     await transport.query(request, options),
   );
+  if (result.requestId !== request.requestId) {
+    throw new TypeError(
+      'Data query result request id does not match its request',
+    );
+  }
+  return result;
 }

--- a/packages/smrt-web/src/data-query.ts
+++ b/packages/smrt-web/src/data-query.ts
@@ -1,0 +1,479 @@
+/**
+ * Browser transport for the canonical bounded data-query envelope (#2444).
+ *
+ * This is a textual structural mirror of `@happyvertical/smrt-types` rather
+ * than an import: smrt-web deliberately has no inter-SMRT dependencies. The
+ * authenticated server adapter owns allowlist, authorization, fingerprint,
+ * and byte-limit enforcement. This module gives browser callers a stable
+ * request/result shape and rejects malformed response envelopes before they
+ * reach a mounted surface.
+ */
+
+export type SmrtWebDataQueryScalar = string | number | boolean | null;
+export type SmrtWebDataQueryFilterOperator =
+  | 'eq'
+  | 'ne'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'in'
+  | 'notIn'
+  | 'like';
+
+export type SmrtWebDataQueryFilter =
+  | {
+      kind: 'condition';
+      field: string;
+      operator: SmrtWebDataQueryFilterOperator;
+      value: SmrtWebDataQueryScalar | SmrtWebDataQueryScalar[];
+    }
+  | { kind: 'all' | 'any'; filters: SmrtWebDataQueryFilter[] }
+  | { kind: 'not'; filter: SmrtWebDataQueryFilter };
+
+export interface SmrtWebDataQueryRequest {
+  version: 1;
+  requestId: string;
+  mode: 'rows' | 'count' | 'facets';
+  projection?: string[];
+  filter?: SmrtWebDataQueryFilter;
+  sort?: Array<{ field: string; direction: 'asc' | 'desc' }>;
+  page?:
+    | { kind: 'offset'; offset: number; limit: number }
+    | { kind: 'cursor'; after?: string; limit: number };
+  consistency?: { mode: 'eventual' | 'snapshot'; asOf?: string };
+  facets?: Array<{ field: string; limit: number }>;
+}
+
+export type SmrtWebDataQueryTotal =
+  | { kind: 'exact' | 'estimated'; value: number; asOf?: string }
+  | { kind: 'unavailable'; reason?: string };
+
+export interface SmrtWebDataQueryFacetResult {
+  field: string;
+  values: Array<{ value: SmrtWebDataQueryScalar; count: number }>;
+  truncated: boolean;
+}
+
+export interface SmrtWebDataQueryResult {
+  version: 1;
+  requestId: string;
+  queryFingerprint: string;
+  identityField: string;
+  rows: Array<Record<string, unknown>>;
+  page?:
+    | { kind: 'offset'; limit: number; offset: number; hasMore: boolean }
+    | {
+        kind: 'cursor';
+        limit: number;
+        nextCursor?: string;
+        hasMore: boolean;
+      };
+  total: SmrtWebDataQueryTotal;
+  facets?: SmrtWebDataQueryFacetResult[];
+  freshness: { state: 'fresh' | 'stale' | 'unknown'; asOf?: string };
+  warnings: string[];
+  truncated: boolean;
+}
+
+/** Browser transport seam; REST, WebMCP, and test transports share it. */
+export interface SmrtWebDataQueryTransport {
+  query(
+    request: SmrtWebDataQueryRequest,
+    options?: { signal?: AbortSignal },
+  ): Promise<unknown>;
+}
+
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/** Mirrors core's hard output limits without adding an inter-SMRT dependency. */
+export const MAX_SMRT_WEB_DATA_QUERY_RESULT_BYTES = 10_000_000;
+export const MAX_SMRT_WEB_DATA_QUERY_ROWS = 1_000;
+export const MAX_SMRT_WEB_DATA_QUERY_FACETS = 20;
+export const MAX_SMRT_WEB_DATA_QUERY_FACET_VALUES = 1_000;
+export const MAX_SMRT_WEB_DATA_QUERY_WARNINGS = 100;
+export const MAX_SMRT_WEB_DATA_QUERY_PAGE_LIMIT = 1_000;
+export const MAX_SMRT_WEB_DATA_QUERY_OFFSET = 1_000_000;
+export const MAX_SMRT_WEB_DATA_QUERY_CONTAINER_ITEMS = 1_000;
+export const MAX_SMRT_WEB_DATA_QUERY_STRING_LENGTH = 65_536;
+const RESPONSE_METADATA_RESERVE_BYTES = 100_000;
+
+interface JsonBudget {
+  remaining: number;
+}
+
+function consumeBytes(budget: JsonBudget, text: string, label: string): void {
+  const bytes = new TextEncoder().encode(text).byteLength;
+  if (bytes > budget.remaining) {
+    throw new TypeError(`${label} exceeds the maximum byte limit`);
+  }
+  budget.remaining -= bytes;
+}
+
+function plainObject(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError(`${label} must be a plain object`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError(`${label} must be a plain object`);
+  }
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_KEYS.has(key)) {
+      throw new TypeError(`${label} contains a forbidden key`);
+    }
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  label: string,
+): void {
+  const keys = new Set(allowed);
+  for (const key of Object.keys(value)) {
+    if (!keys.has(key)) throw new TypeError(`${label} contains ${key}`);
+  }
+}
+
+function stringValue(value: unknown, label: string, maxLength = 2_048): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > maxLength
+  ) {
+    throw new TypeError(`${label} must be a bounded non-empty string`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new TypeError(`${label} must be a non-negative safe integer`);
+  }
+  return value as number;
+}
+
+function scalar(
+  value: unknown,
+  label: string,
+  budget: JsonBudget,
+): SmrtWebDataQueryScalar {
+  if (typeof value === 'string') {
+    if (value.length > MAX_SMRT_WEB_DATA_QUERY_STRING_LENGTH) {
+      throw new TypeError(`${label} exceeds the string limit`);
+    }
+    consumeBytes(budget, JSON.stringify(value), label);
+    return value;
+  }
+  if (
+    value === null ||
+    typeof value === 'boolean' ||
+    (typeof value === 'number' && Number.isFinite(value))
+  ) {
+    consumeBytes(budget, JSON.stringify(value), label);
+    return value;
+  }
+  throw new TypeError(`${label} must be a JSON scalar`);
+}
+
+function jsonValue(
+  value: unknown,
+  label: string,
+  budget: JsonBudget,
+  depth = 0,
+): unknown {
+  if (depth > 16) throw new TypeError(`${label} exceeds JSON depth`);
+  if (typeof value === 'string') {
+    if (value.length > MAX_SMRT_WEB_DATA_QUERY_STRING_LENGTH) {
+      throw new TypeError(`${label} exceeds the string limit`);
+    }
+    consumeBytes(budget, JSON.stringify(value), label);
+    return value;
+  }
+  if (
+    value === null ||
+    typeof value === 'boolean' ||
+    (typeof value === 'number' && Number.isFinite(value))
+  ) {
+    consumeBytes(budget, JSON.stringify(value), label);
+    return value;
+  }
+  if (Array.isArray(value)) {
+    if (value.length > MAX_SMRT_WEB_DATA_QUERY_CONTAINER_ITEMS) {
+      throw new TypeError(`${label} exceeds the container-item limit`);
+    }
+    consumeBytes(budget, '[', label);
+    const result: unknown[] = [];
+    for (const [index, item] of value.entries()) {
+      if (index > 0) consumeBytes(budget, ',', label);
+      result.push(jsonValue(item, `${label}[${index}]`, budget, depth + 1));
+    }
+    consumeBytes(budget, ']', label);
+    return result;
+  }
+  const object = plainObject(value, label);
+  if (Object.keys(object).length > MAX_SMRT_WEB_DATA_QUERY_CONTAINER_ITEMS) {
+    throw new TypeError(`${label} exceeds the container-item limit`);
+  }
+  const result: Record<string, unknown> = Object.create(null) as Record<
+    string,
+    unknown
+  >;
+  consumeBytes(budget, '{', label);
+  for (const [index, key] of Object.keys(object).sort().entries()) {
+    if (index > 0) consumeBytes(budget, ',', label);
+    consumeBytes(budget, JSON.stringify(key), `${label}.${key}`);
+    consumeBytes(budget, ':', label);
+    result[key] = jsonValue(object[key], `${label}.${key}`, budget, depth + 1);
+  }
+  consumeBytes(budget, '}', label);
+  return result;
+}
+
+function normalizeTotal(value: unknown): SmrtWebDataQueryTotal {
+  const total = plainObject(value, 'Data query total');
+  const kind = stringValue(total.kind, 'Data query total kind');
+  if (kind === 'unavailable') {
+    exactKeys(total, ['kind', 'reason'], 'Data query unavailable total');
+    return {
+      kind,
+      ...(total.reason === undefined
+        ? {}
+        : { reason: stringValue(total.reason, 'Data query total reason') }),
+    };
+  }
+  if (kind !== 'exact' && kind !== 'estimated') {
+    throw new TypeError('Data query total kind is invalid');
+  }
+  exactKeys(total, ['kind', 'value', 'asOf'], 'Data query total');
+  return {
+    kind,
+    value: nonNegativeInteger(total.value, 'Data query total value'),
+    ...(total.asOf === undefined
+      ? {}
+      : { asOf: stringValue(total.asOf, 'Data query total asOf', 128) }),
+  };
+}
+
+function normalizeFacets(
+  value: unknown,
+  budget: JsonBudget,
+): SmrtWebDataQueryFacetResult[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value))
+    throw new TypeError('Data query facets must be an array');
+  if (value.length > MAX_SMRT_WEB_DATA_QUERY_FACETS) {
+    throw new TypeError('Data query facets exceed the maximum');
+  }
+  const fields = new Set<string>();
+  return value.map((candidate, index) => {
+    const facet = plainObject(candidate, `Data query facet ${index}`);
+    exactKeys(facet, ['field', 'values', 'truncated'], 'Data query facet');
+    const field = stringValue(facet.field, 'Data query facet field');
+    if (fields.has(field))
+      throw new TypeError('Data query facet fields must be unique');
+    fields.add(field);
+    if (!Array.isArray(facet.values)) {
+      throw new TypeError('Data query facet values must be an array');
+    }
+    if (facet.values.length > MAX_SMRT_WEB_DATA_QUERY_FACET_VALUES) {
+      throw new TypeError('Data query facet values exceed the maximum');
+    }
+    if (typeof facet.truncated !== 'boolean') {
+      throw new TypeError('Data query facet truncated must be boolean');
+    }
+    return {
+      field,
+      values: facet.values.map((value, valueIndex) => {
+        const entry = plainObject(
+          value,
+          `Data query facet ${index} value ${valueIndex}`,
+        );
+        exactKeys(entry, ['value', 'count'], 'Data query facet value');
+        return {
+          value: scalar(entry.value, 'Data query facet value', budget),
+          count: nonNegativeInteger(entry.count, 'Data query facet count'),
+        };
+      }),
+      truncated: facet.truncated,
+    };
+  });
+}
+
+/**
+ * Check the server-produced, normalized result envelope before a browser
+ * surface consumes it. This validates portable shape only; the server's core
+ * normalizer remains the authorization, projection, and query-policy boundary.
+ */
+export function normalizeSmrtWebDataQueryResult(
+  value: unknown,
+): SmrtWebDataQueryResult {
+  const result = plainObject(value, 'Data query result');
+  exactKeys(
+    result,
+    [
+      'version',
+      'requestId',
+      'queryFingerprint',
+      'identityField',
+      'rows',
+      'page',
+      'total',
+      'facets',
+      'freshness',
+      'warnings',
+      'truncated',
+    ],
+    'Data query result',
+  );
+  if (result.version !== 1)
+    throw new TypeError('Unsupported data query version');
+  const identityField = stringValue(
+    result.identityField,
+    'Data query identity field',
+  );
+  if (!Array.isArray(result.rows))
+    throw new TypeError('Data query rows must be an array');
+  if (result.rows.length > MAX_SMRT_WEB_DATA_QUERY_ROWS) {
+    throw new TypeError('Data query rows exceed the maximum');
+  }
+  const budget: JsonBudget = {
+    remaining:
+      MAX_SMRT_WEB_DATA_QUERY_RESULT_BYTES - RESPONSE_METADATA_RESERVE_BYTES,
+  };
+  const rows = result.rows.map((row, index) => {
+    const normalized = jsonValue(row, `Data query row ${index}`, budget);
+    const object = plainObject(normalized, `Data query row ${index}`);
+    const identity = object[identityField];
+    if (
+      (typeof identity !== 'string' && typeof identity !== 'number') ||
+      identity === ''
+    ) {
+      throw new TypeError('Data query row is missing its stable identity');
+    }
+    return object;
+  });
+  let page: SmrtWebDataQueryResult['page'];
+  if (result.page !== undefined) {
+    const candidate = plainObject(result.page, 'Data query page');
+    exactKeys(
+      candidate,
+      ['kind', 'limit', 'offset', 'nextCursor', 'hasMore'],
+      'Data query page',
+    );
+    const kind = stringValue(candidate.kind, 'Data query page kind');
+    if (kind !== 'offset' && kind !== 'cursor') {
+      throw new TypeError('Data query page kind is invalid');
+    }
+    if (typeof candidate.hasMore !== 'boolean') {
+      throw new TypeError('Data query page hasMore must be boolean');
+    }
+    const limit = nonNegativeInteger(candidate.limit, 'Data query page limit');
+    if (limit === 0)
+      throw new TypeError('Data query page limit must be positive');
+    if (limit > MAX_SMRT_WEB_DATA_QUERY_PAGE_LIMIT) {
+      throw new TypeError('Data query page limit exceeds the maximum');
+    }
+    if (kind === 'offset') {
+      if (
+        candidate.nextCursor !== undefined ||
+        candidate.offset === undefined
+      ) {
+        throw new TypeError('Offset data query page must carry only an offset');
+      }
+      const offset = nonNegativeInteger(candidate.offset, 'Data query offset');
+      if (offset > MAX_SMRT_WEB_DATA_QUERY_OFFSET) {
+        throw new TypeError('Data query offset exceeds the maximum');
+      }
+      page = {
+        kind,
+        limit,
+        offset,
+        hasMore: candidate.hasMore,
+      };
+    } else {
+      if (candidate.offset !== undefined) {
+        throw new TypeError('Cursor data query page cannot carry an offset');
+      }
+      const nextCursor =
+        candidate.nextCursor === undefined
+          ? undefined
+          : stringValue(candidate.nextCursor, 'Data query next cursor');
+      if (candidate.hasMore !== Boolean(nextCursor)) {
+        throw new TypeError(
+          'Cursor data query page hasMore must match nextCursor',
+        );
+      }
+      page = {
+        kind,
+        limit,
+        hasMore: candidate.hasMore,
+        ...(nextCursor === undefined ? {} : { nextCursor }),
+      };
+    }
+  }
+  if (page && rows.length > page.limit) {
+    throw new TypeError('Data query rows exceed the declared page limit');
+  }
+  const freshness = plainObject(result.freshness, 'Data query freshness');
+  exactKeys(freshness, ['state', 'asOf'], 'Data query freshness');
+  const state = stringValue(freshness.state, 'Data query freshness state');
+  if (state !== 'fresh' && state !== 'stale' && state !== 'unknown') {
+    throw new TypeError('Data query freshness state is invalid');
+  }
+  if (
+    !Array.isArray(result.warnings) ||
+    result.warnings.length > MAX_SMRT_WEB_DATA_QUERY_WARNINGS ||
+    result.warnings.some((item) => typeof item !== 'string')
+  ) {
+    throw new TypeError('Data query warnings must be strings');
+  }
+  if (typeof result.truncated !== 'boolean') {
+    throw new TypeError('Data query truncated must be boolean');
+  }
+  const facets = normalizeFacets(result.facets, budget);
+  const warnings = result.warnings.map((warning) =>
+    stringValue(warning, 'Data query warning', 512),
+  );
+  const normalized: SmrtWebDataQueryResult = {
+    version: 1,
+    requestId: stringValue(result.requestId, 'Data query request id'),
+    queryFingerprint: stringValue(
+      result.queryFingerprint,
+      'Data query fingerprint',
+    ),
+    identityField,
+    rows,
+    ...(page === undefined ? {} : { page }),
+    total: normalizeTotal(result.total),
+    ...(facets === undefined ? {} : { facets }),
+    freshness: {
+      state: state as SmrtWebDataQueryResult['freshness']['state'],
+      ...(freshness.asOf === undefined
+        ? {}
+        : {
+            asOf: stringValue(freshness.asOf, 'Data query freshness asOf', 128),
+          }),
+    },
+    warnings: [...new Set(warnings)].sort(),
+    truncated: result.truncated,
+  };
+  const bytes = new TextEncoder().encode(JSON.stringify(normalized)).byteLength;
+  if (bytes > MAX_SMRT_WEB_DATA_QUERY_RESULT_BYTES) {
+    throw new TypeError('Data query result exceeds the maximum byte limit');
+  }
+  return normalized;
+}
+
+/** Run a browser transport and return the defensive normalized envelope. */
+export async function executeSmrtWebDataQuery(
+  transport: SmrtWebDataQueryTransport,
+  request: SmrtWebDataQueryRequest,
+  options?: { signal?: AbortSignal },
+): Promise<SmrtWebDataQueryResult> {
+  return normalizeSmrtWebDataQueryResult(
+    await transport.query(request, options),
+  );
+}

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -61,6 +61,31 @@ export type {
   WrapMutationOutcome,
 } from './capability.js';
 export { runWrapMutation } from './capability.js';
+// Canonical bounded data-query browser transport (#2444). This package stays
+// dependency-free; its structural mirror is validated at the browser boundary.
+export type {
+  SmrtWebDataQueryFacetResult,
+  SmrtWebDataQueryFilter,
+  SmrtWebDataQueryFilterOperator,
+  SmrtWebDataQueryRequest,
+  SmrtWebDataQueryResult,
+  SmrtWebDataQueryScalar,
+  SmrtWebDataQueryTotal,
+  SmrtWebDataQueryTransport,
+} from './data-query.js';
+export {
+  executeSmrtWebDataQuery,
+  MAX_SMRT_WEB_DATA_QUERY_CONTAINER_ITEMS,
+  MAX_SMRT_WEB_DATA_QUERY_FACET_VALUES,
+  MAX_SMRT_WEB_DATA_QUERY_FACETS,
+  MAX_SMRT_WEB_DATA_QUERY_OFFSET,
+  MAX_SMRT_WEB_DATA_QUERY_PAGE_LIMIT,
+  MAX_SMRT_WEB_DATA_QUERY_RESULT_BYTES,
+  MAX_SMRT_WEB_DATA_QUERY_ROWS,
+  MAX_SMRT_WEB_DATA_QUERY_STRING_LENGTH,
+  MAX_SMRT_WEB_DATA_QUERY_WARNINGS,
+  normalizeSmrtWebDataQueryResult,
+} from './data-query.js';
 export type { DurableResource, DurableStoreKey } from './durable-store.js';
 export {
   durableStoreNamespace,

--- a/packages/types/AGENTS.md
+++ b/packages/types/AGENTS.md
@@ -11,6 +11,7 @@ Shared TypeScript type definitions. Prevents circular dependencies between packa
 | `user.ts` | `UserStatus`, `TenantStatus`, `MembershipStatus`, `SessionStatus`, `OverrideEffect` — status enums |
 | `identity.ts` | `User`, `Tenant`, `Role`, `Membership`, `SmrtEntityFields` — cross-package identity data contracts (runtime classes live in smrt-users, which `implements` these) |
 | `knowledge.ts` | Additive schema-version-1 domain knowledge contracts shared by core generation and development tooling |
+| `data-query.ts` | Serializable bounded query request/result envelope, allowlisted schema, filters, paging, totals, freshness, and facets |
 
 ## Rules
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -39,6 +39,15 @@ import { UserStatus, TenantStatus, MembershipStatus } from '@happyvertical/smrt-
 | `ModuleUIBaseProps` | Base props interface for module UI components |
 | `ModuleUIRegistryInterface` | Registry interface for module UI registration |
 
+### Bounded Data Queries (types)
+
+| Export | Description |
+|--------|------------|
+| `DataQueryRequest` / `DataQueryResult` | Serializable, transport-neutral bounded query and normalized result envelopes |
+| `DataQuerySchema` / `DataQueryFieldDescriptor` | Trusted adapter allowlist for projection, filter, sort, and facet capabilities |
+| `DataQueryFilter` / `DataQuerySort` / `DataQueryPage` | Typed predicates, deterministic sort terms, and cursor/offset paging |
+| `DataQueryTotal` / `DataQueryFreshness` | Explicit total exactness/as-of semantics and response freshness |
+
 ### User/Tenant Status (enums — runtime values)
 
 | Export | Description |

--- a/packages/types/src/data-query.ts
+++ b/packages/types/src/data-query.ts
@@ -1,0 +1,208 @@
+/**
+ * Transport-neutral, bounded data-query contract (#2444).
+ *
+ * This module intentionally has no runtime code. The core package owns
+ * normalization, policy enforcement, canonical fingerprints, and result
+ * validation; browser, REST, MCP, WebMCP, ContentList, and report adapters
+ * share these serializable shapes without importing a server runtime.
+ *
+ * Authority is deliberately absent. A query can name only adapter-declared
+ * field ids and operators; tenant, principal, SQL, relationship paths, and
+ * execution details belong to the authenticated adapter, never this envelope.
+ */
+
+/** JSON scalar values accepted in predicates, facets, and normalized rows. */
+export type DataQueryScalar = string | number | boolean | null;
+
+/** A stable, adapter-defined field identifier. It is never a property path. */
+export type DataQueryFieldId = string;
+
+/** Operators map to an adapter's allowlisted, typed predicate implementation. */
+export type DataQueryFilterOperator =
+  | 'eq'
+  | 'ne'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'in'
+  | 'notIn'
+  | 'like';
+
+/** One typed predicate. `in` and `notIn` require a non-empty value array. */
+export interface DataQueryCondition {
+  kind: 'condition';
+  field: DataQueryFieldId;
+  operator: DataQueryFilterOperator;
+  value: DataQueryScalar | DataQueryScalar[];
+}
+
+/** Bounded, recursive filter expression with explicit boolean semantics. */
+export type DataQueryFilter =
+  | DataQueryCondition
+  | {
+      kind: 'all' | 'any';
+      filters: DataQueryFilter[];
+    }
+  | {
+      kind: 'not';
+      filter: DataQueryFilter;
+    };
+
+export type DataQuerySortDirection = 'asc' | 'desc';
+
+/** Deterministic sort precedence; earlier terms take precedence. */
+export interface DataQuerySort {
+  field: DataQueryFieldId;
+  direction: DataQuerySortDirection;
+}
+
+/** Offset pagination is explicit so callers cannot smuggle arbitrary bounds. */
+export interface DataQueryOffsetPage {
+  kind: 'offset';
+  offset: number;
+  limit: number;
+}
+
+/** Cursor values are opaque to callers and bound to a normalized query. */
+export interface DataQueryCursorPage {
+  kind: 'cursor';
+  after?: string;
+  limit: number;
+}
+
+export type DataQueryPage = DataQueryOffsetPage | DataQueryCursorPage;
+
+/** Read consistency requested by a caller; adapters decide whether they support it. */
+export type DataQueryConsistencyMode = 'eventual' | 'snapshot';
+
+export interface DataQueryConsistency {
+  /** Prefer the adapter's most recently available data. */
+  mode: DataQueryConsistencyMode;
+  /** Optional RFC 3339 instant requested by a time-travel capable adapter. */
+  asOf?: string;
+}
+
+/** A bounded request for one declared facet. */
+export interface DataQueryFacetRequest {
+  field: DataQueryFieldId;
+  limit: number;
+}
+
+/**
+ * Canonical data-query request.
+ *
+ * A request id correlates transport logs and results only; it is intentionally
+ * excluded from the semantic query fingerprint. The query does not contain
+ * authority, raw database expressions, property paths, functions, or a
+ * transport-specific filter object.
+ */
+export interface DataQueryRequest {
+  version: 1;
+  requestId: string;
+  mode: 'rows' | 'count' | 'facets';
+  projection?: DataQueryFieldId[];
+  filter?: DataQueryFilter;
+  sort?: DataQuerySort[];
+  page?: DataQueryPage;
+  consistency?: DataQueryConsistency;
+  facets?: DataQueryFacetRequest[];
+}
+
+/** An explicitly declared query field and its capability allowlist. */
+export interface DataQueryFieldDescriptor {
+  id: DataQueryFieldId;
+  type: 'string' | 'number' | 'boolean' | 'datetime' | 'json';
+  projectable?: boolean;
+  sortable?: boolean;
+  facetable?: boolean;
+  filterOperators?: DataQueryFilterOperator[];
+}
+
+/**
+ * Per-adapter execution policy. It is trusted adapter configuration, never
+ * client input, and therefore carries the field allowlists the normalizer
+ * applies to requests and returned rows.
+ */
+export interface DataQuerySchema {
+  version: 1;
+  identityField: DataQueryFieldId;
+  fields: DataQueryFieldDescriptor[];
+  defaultPageLimit?: number;
+  maxPageLimit?: number;
+  maxResultBytes?: number;
+  defaultSort?: DataQuerySort[];
+  supports?: {
+    cursorPagination?: boolean;
+    consistency?: boolean;
+    facets?: boolean;
+  };
+}
+
+/** How a returned total was obtained, including the absence of a total. */
+export type DataQueryTotal =
+  | {
+      kind: 'exact';
+      value: number;
+      asOf?: string;
+    }
+  | {
+      kind: 'estimated';
+      value: number;
+      asOf?: string;
+    }
+  | {
+      kind: 'unavailable';
+      reason?: string;
+    };
+
+/** Freshness metadata is declarative; it does not grant access to a snapshot. */
+export interface DataQueryFreshness {
+  state: 'fresh' | 'stale' | 'unknown';
+  asOf?: string;
+}
+
+/** A bounded facet value/count pair. */
+export interface DataQueryFacetValue {
+  value: DataQueryScalar;
+  count: number;
+}
+
+export interface DataQueryFacetResult {
+  field: DataQueryFieldId;
+  values: DataQueryFacetValue[];
+  truncated: boolean;
+}
+
+/** Rows use JSON-safe values; adapters must project only declared fields. */
+export type DataQueryRow = Record<string, unknown>;
+
+/**
+ * Normalized adapter result. `queryFingerprint` identifies the semantic query
+ * (not the request id or page cursor), while pagination state stays explicit.
+ */
+export interface DataQueryResult {
+  version: 1;
+  requestId: string;
+  queryFingerprint: string;
+  identityField: DataQueryFieldId;
+  rows: DataQueryRow[];
+  page?:
+    | {
+        kind: 'offset';
+        limit: number;
+        offset: number;
+        hasMore: boolean;
+      }
+    | {
+        kind: 'cursor';
+        limit: number;
+        nextCursor?: string;
+        hasMore: boolean;
+      };
+  total: DataQueryTotal;
+  facets?: DataQueryFacetResult[];
+  freshness: DataQueryFreshness;
+  warnings: string[];
+  truncated: boolean;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -20,6 +20,30 @@ export type {
 // Cross-package identity & tenancy data contracts (zero-runtime structural
 // interfaces; runtime classes live in smrt-users / smrt-profiles)
 export type {
+  DataQueryCondition,
+  DataQueryConsistency,
+  DataQueryConsistencyMode,
+  DataQueryCursorPage,
+  DataQueryFacetRequest,
+  DataQueryFacetResult,
+  DataQueryFacetValue,
+  DataQueryFieldDescriptor,
+  DataQueryFieldId,
+  DataQueryFilter,
+  DataQueryFilterOperator,
+  DataQueryFreshness,
+  DataQueryOffsetPage,
+  DataQueryPage,
+  DataQueryRequest,
+  DataQueryResult,
+  DataQueryRow,
+  DataQueryScalar,
+  DataQuerySchema,
+  DataQuerySort,
+  DataQuerySortDirection,
+  DataQueryTotal,
+} from './data-query.js';
+export type {
   Membership,
   Role,
   SmrtEntityFields,


### PR DESCRIPTION
## Summary
- add zero-runtime, public data-query request and normalized-result contracts
- add a core validator/canonicalizer enforcing typed field capabilities, bounded requests/results, and deterministic `dq1_` fingerprints
- add a dependency-free `smrt-web` transport seam and envelope normalizer that mirrors the bounded result contract
- close the automated review findings with strict request/response correlation, RFC 3339 validation, compatible identity schemas, and pre-clone JSON/request bounds

## Validation
- `pnpm --filter @happyvertical/smrt-types build`
- `pnpm --filter @happyvertical/smrt-core typecheck`
- `pnpm --filter @happyvertical/smrt-core build`
- `pnpm --filter @happyvertical/smrt-web typecheck`
- `pnpm --filter @happyvertical/smrt-web build`
- `pnpm --filter @happyvertical/smrt-core test` (296 files passed; 3,922 tests passed)
- `pnpm exec smrt dev:knowledge-check --format markdown`
- `git diff --check`

Closes #2444

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-2444-bounded-query-protocol-reviewfix-20260822",
  "issue": 2444,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm --filter @happyvertical/smrt-types build",
    "pnpm --filter @happyvertical/smrt-core typecheck",
    "pnpm --filter @happyvertical/smrt-core build",
    "pnpm --filter @happyvertical/smrt-web typecheck",
    "pnpm --filter @happyvertical/smrt-web build",
    "pnpm --filter @happyvertical/smrt-core test (296 files; 3,922 tests)",
    "pnpm exec smrt dev:knowledge-check --format markdown",
    "git diff --check"
  ]
}