### PR TITLE
feat(smrt-ui): stabilize DataTable row identity and selection

### DIFF
--- a/packages/smrt-svelte/playground/src/routes/data/+page.svelte
+++ b/packages/smrt-svelte/playground/src/routes/data/+page.svelte
@@ -193,7 +193,6 @@ function handleRowClick(row: User) {
     <DataTable
       data={[...users, ...users, ...users]}
       {columns}
-      rowKey={(row, i) => `${row.id}-${i}`}
       stickyHeader
     />
   </div>

--- a/packages/smrt-ui/README.md
+++ b/packages/smrt-ui/README.md
@@ -135,13 +135,15 @@ transition path.
 <DataTable {controller} data={rows} {columns} rowKey="id" sortable selectable />
 ```
 
-`controller.snapshot()` returns a canonical JSON-safe `{ version, modes,
-state }` envelope. It contains no rows, callbacks, snippets, storage handles,
-tenant/principal data, query objects, or authority. URL and saved-view adapters
-remain application-owned: persist the snapshot (normally excluding selection
-and expansion IDs), validate it with `hydrateDataTableSnapshot`, and feed the
-state into a new controller or `replaceState`. `smrt-ui` does not read or write
-the URL, browser storage, or a database.
+`controller.snapshot()` returns the canonical JSON-safe version-2 `{ version,
+modes, state }` envelope. `hydrateDataTableSnapshot()` accepts version 1 and
+migrates it to version 2. The envelope contains no rows, callbacks, snippets,
+storage handles, tenant/principal data, query objects, or authority. URL and
+saved-view adapters remain application-owned: persist the snapshot (normally
+excluding selection and expansion IDs), validate it with
+`hydrateDataTableSnapshot`, and feed the state into a new controller or
+`replaceState`. `smrt-ui` does not read or write the URL, browser storage, or a
+database.
 
 ### Controlled and migration use
 
@@ -155,7 +157,7 @@ The existing Svelte bindables remain supported during migration:
 | --- | --- |
 | `bind:sort` | first entry of ordered `sorting` (single-sort compatibility) |
 | `bind:page`, `pageSize` | `page`, `pageSize` |
-| `bind:selected`, `bind:expanded` | canonical `selectedRowIds`, `expandedRowIds` arrays |
+| `bind:selected`, `bind:expanded` | legacy explicit `selectedRowIds`, canonical `selection` and `expandedRowIds` |
 | `visibleColumnIds` | `columnVisibility` intersected with static `column.hidden` |
 | `manualSorting`, `manualPagination` | sorting/pagination entries in `modes` |
 | `filterFn` | local-only legacy predicate; never serialized |
@@ -165,11 +167,35 @@ Without one, the component creates an internal controller and maps the legacy
 props. Multi-column sorting and persisted layouts use the controller state;
 the legacy `SortState` remains intentionally single-column.
 
-Use a stable `rowKey` when selected or expanded state can survive a sort,
-filter, refresh, or page change. The historical index fallback remains only
-for local presentational compatibility; it is not portable across remote data
-or persisted/agent-controlled views. Select-all means the currently rendered
-page. Query-wide "all matching" selection belongs to the data-surface layer.
+### Row identity and selection
+
+`rowKey` is required for selectable, expandable, manual/server, and
+`agentAddressable` tables. Its values must be unique non-empty strings or finite
+numbers. This fails closed before a renderer can reuse the wrong row after a
+sort, refresh, or server-page change. The historical source-index fallback
+exists only for local presentational tables with no durable row state.
+
+The controller stores a `selection` union alongside the deprecated
+`selectedRowIds` shorthand:
+
+| Scope | Stored value | Lifecycle |
+| --- | --- | --- |
+| `page` | IDs from the current rendered page | Cleared when page, page size, search, filters, or sorting changes. |
+| `explicit` | Explicit stable IDs across pages | Persists across page and query navigation until changed by the caller. |
+| `allMatching` | `queryFingerprint`, `queryRevision`, and `expectedCount` only | Never stores loaded IDs; query-shape changes clear it. |
+
+The built-in header checkbox explicitly means **Select all rows on this page**.
+For query-wide selection, dispatch `selectAllMatching` with the caller-owned
+query fingerprint, revision, and expected count. A destructive domain action
+must call `assertDataTableSelectionCurrent(selection, currentQuery)` immediately
+before applying it; a mismatched fingerprint or revision throws rather than
+acting on stale results.
+
+`index` passed to row callbacks, cells, expansion snippets, and `rowClass` is
+the zero-based display index on the currently rendered page. The source index
+is the zero-based position in the supplied `data` array and is used only by the
+non-durable fallback. It must never be saved, sent to an agent, or used as a
+remote identity.
 
 ### Transformation ownership and page rules
 
@@ -188,7 +214,9 @@ double-sorted, or double-paged.
 Every combination follows the same rule per column in the table: each local
 stage runs once and each manual stage runs zero times. For manual pagination,
 `totalRows` supplies the total; when it is unknown the component does not guess
-the last page or render misleading pagination controls.
+the last page or render misleading pagination controls. A supplied `totalRows`
+must be a non-negative integer and is rejected unless pagination mode is
+`manual`.
 
 Changing search, filters, sorting, or page size resets the page to 1 only when
 the value changes. Data or total changes clamp an out-of-range page but do not

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -26,6 +26,7 @@ import {
   type DataTableRowId,
   type DataTableSnapshot,
   type DataTableViewState,
+  type DataTableViewStateInput,
 } from './DataTableController.js';
 import { resolveDataTableRows } from './DataTableIdentity.js';
 import type { DataTableColumn, DataTableProps, SortState } from './types.js';
@@ -109,6 +110,11 @@ function legacyViewState(): Partial<DataTableViewState> {
   };
 }
 
+function mergedLegacyState(): Omit<DataTableViewState, 'selection'> {
+  const { selection: _selection, ...current } = localController.getState();
+  return { ...current, ...legacyViewState() };
+}
+
 const localController = createDataTableController({
   modes: legacyModes(),
   onStateChange: (next, command) => onStateChange?.(next, command),
@@ -185,10 +191,11 @@ $effect(() => {
 
   if (!localControllerInitialized) {
     localControllerInitialized = true;
-    localController.replaceState({
-      ...localController.getState(),
-      ...(controlledState ?? { ...legacyViewState(), ...initialState }),
-    });
+    const nextState: DataTableViewStateInput = controlledState ?? {
+      ...mergedLegacyState(),
+      ...initialState,
+    };
+    localController.replaceState(nextState);
     return;
   }
 
@@ -202,10 +209,7 @@ $effect(() => {
     publishedLegacySignature = undefined;
     return;
   }
-  localController.replaceState({
-    ...localController.getState(),
-    ...legacyViewState(),
-  });
+  localController.replaceState(mergedLegacyState());
 });
 
 $effect(() => {

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -17,6 +17,7 @@ import Trans from '../../i18n/Trans.svelte';
 import { useI18n } from '../../i18n/use-i18n.js';
 import Pagination from '../ui/Pagination.svelte';
 import {
+  compareDataTableRowIds,
   createDataTableController,
   type DataTableCommand,
   type DataTableController,
@@ -26,6 +27,7 @@ import {
   type DataTableSnapshot,
   type DataTableViewState,
 } from './DataTableController.js';
+import { resolveDataTableRows } from './DataTableIdentity.js';
 import type { DataTableColumn, DataTableProps, SortState } from './types.js';
 import { defaultSort, getNestedValue } from './types.js';
 
@@ -42,6 +44,7 @@ let {
   data = [],
   columns = [],
   rowKey,
+  agentAddressable = false,
   selectable = false,
   selected = $bindable(new Set<string | number>()),
   onSelectionChange,
@@ -107,6 +110,7 @@ function legacyViewState(): Partial<DataTableViewState> {
 }
 
 const localController = createDataTableController({
+  modes: legacyModes(),
   onStateChange: (next, command) => onStateChange?.(next, command),
 });
 
@@ -226,16 +230,19 @@ $effect(() => {
 
 const tableState = $derived(controllerSnapshot.state);
 const tableModes = $derived(controllerSnapshot.modes);
-
-function getRowKey(row: T, index: number): DataTableRowId {
-  if (!rowKey) return index;
-  if (typeof rowKey === 'function') return rowKey(row);
-  return row[rowKey] as DataTableRowId;
-}
-
-function getDisplayRowKey(row: T, index: number): DataTableRowId {
-  return getRowKey(row, displayIndexOffset + index);
-}
+const requiresStableRowIdentity = $derived(
+  selectable ||
+    Boolean(expandedContent) ||
+    agentAddressable ||
+    tableModes.filtering === 'manual' ||
+    tableModes.sorting === 'manual' ||
+    tableModes.pagination === 'manual',
+);
+const sourceRows = $derived.by(() =>
+  resolveDataTableRows(data, rowKey, {
+    requireStableIdentity: requiresStableRowIdentity,
+  }),
+);
 
 function dispatch(command: DataTableCommand) {
   activeController().dispatch(command);
@@ -256,10 +263,22 @@ function handleRowSelect(key: DataTableRowId, event: Event) {
 }
 
 function handleSelectAll() {
+  if (tableState.selection.scope === 'allMatching') {
+    dispatch({
+      type: 'setSelection',
+      selection: { scope: 'explicit', rowIds: [] },
+    });
+    return;
+  }
   const selectedIds = new Set(tableState.selectedRowIds);
-  const visibleIds = displayData.map((row, index) =>
-    getDisplayRowKey(row, index),
-  );
+  const visibleIds = displayRows.map(({ rowId }) => rowId);
+  if (tableState.selection.scope === 'page') {
+    dispatch({
+      type: 'setPageSelection',
+      rowIds: allSelected ? [] : visibleIds,
+    });
+    return;
+  }
   if (allSelected) {
     for (const key of visibleIds) selectedIds.delete(key);
   } else {
@@ -377,11 +396,11 @@ function matchesFilter(
   }
 }
 
-const filteredData = $derived.by(() => {
-  if (tableModes.filtering === 'manual') return data;
+const filteredRows = $derived.by(() => {
+  if (tableModes.filtering === 'manual') return sourceRows;
   const search = tableState.search.toLowerCase();
-  return data.filter((row, index) => {
-    if (filterFn && !filterFn(row, index)) return false;
+  return sourceRows.filter(({ row, sourceIndex }) => {
+    if (filterFn && !filterFn(row, sourceIndex)) return false;
     if (
       search &&
       !columns.some(
@@ -401,34 +420,33 @@ const filteredData = $derived.by(() => {
   });
 });
 
-const sortedData = $derived.by(() => {
+const sortedRows = $derived.by(() => {
   if (tableModes.sorting === 'manual' || tableState.sorting.length === 0)
-    return filteredData;
-  return filteredData
-    .map((row, index) => ({ row, index }))
-    .sort((left, right) => {
-      for (const rule of tableState.sorting) {
-        const column = columns.find(
-          (candidate) => candidate.id === rule.columnId,
-        );
-        if (!column) continue;
-        const result = column.sortFn
-          ? column.sortFn(left.row, right.row, rule.direction)
-          : defaultSort(
-              left.row,
-              right.row,
-              String(column.accessor ?? column.id),
-              rule.direction,
-            );
-        if (result !== 0) return result;
-      }
-      return left.index - right.index;
-    })
-    .map(({ row }) => row);
+    return filteredRows;
+  return filteredRows.slice().sort((left, right) => {
+    for (const rule of tableState.sorting) {
+      const column = columns.find(
+        (candidate) => candidate.id === rule.columnId,
+      );
+      if (!column) continue;
+      const result = column.sortFn
+        ? column.sortFn(left.row, right.row, rule.direction)
+        : defaultSort(
+            left.row,
+            right.row,
+            String(column.accessor ?? column.id),
+            rule.direction,
+          );
+      if (result !== 0) return result;
+    }
+    return rowKey
+      ? compareDataTableRowIds(left.rowId, right.rowId)
+      : left.sourceIndex - right.sourceIndex;
+  });
 });
 
 const totalRowCount = $derived(
-  tableModes.pagination === 'manual' ? totalRows : sortedData.length,
+  tableModes.pagination === 'manual' ? totalRows : sortedRows.length,
 );
 const totalPages = $derived(
   tableState.pageSize
@@ -437,15 +455,27 @@ const totalPages = $derived(
       : Math.max(1, Math.ceil(totalRowCount / tableState.pageSize))
     : 1,
 );
-const displayData = $derived.by(() => {
+const displayRows = $derived.by(() => {
   if (!tableState.pageSize || tableModes.pagination === 'manual')
-    return sortedData;
+    return sortedRows;
   const start = (tableState.page - 1) * tableState.pageSize;
-  return sortedData.slice(start, start + tableState.pageSize);
+  return sortedRows.slice(start, start + tableState.pageSize);
 });
-const displayIndexOffset = $derived(
-  tableState.pageSize ? (tableState.page - 1) * tableState.pageSize : 0,
-);
+
+$effect(() => {
+  const total = totalRows;
+  if (total === undefined) return;
+  if (tableModes.pagination !== 'manual') {
+    throw new TypeError(
+      'DataTable totalRows is only valid when pagination mode is manual',
+    );
+  }
+  if (!Number.isFinite(total) || !Number.isInteger(total) || total < 0) {
+    throw new TypeError(
+      'DataTable totalRows must be a non-negative integer when supplied',
+    );
+  }
+});
 
 $effect(() => {
   void tableState.page;
@@ -458,11 +488,13 @@ const expandedIds = $derived(new Set(tableState.expandedRowIds));
 const currentSort = $derived(legacySort(tableState));
 
 const allSelected = $derived(
-  displayData.length > 0 &&
-    displayData.every((row, i) => selectedIds.has(getDisplayRowKey(row, i))),
+  tableState.selection.scope === 'allMatching' ||
+    (displayRows.length > 0 &&
+      displayRows.every(({ rowId }) => selectedIds.has(rowId))),
 );
 const someSelected = $derived(
-  displayData.some((row, i) => selectedIds.has(getDisplayRowKey(row, i))) &&
+  tableState.selection.scope !== 'allMatching' &&
+    displayRows.some(({ rowId }) => selectedIds.has(rowId)) &&
     !allSelected,
 );
 
@@ -505,7 +537,7 @@ const sizeClasses = {
               checked={allSelected}
               use:setIndeterminate={someSelected}
               onchange={handleSelectAll}
-              aria-label={t(M['ui.data_table.select_all'])}
+              aria-label={t(M['ui.data_table.select_current_page'])}
               class="data-table__checkbox"
             />
           </th>
@@ -565,7 +597,7 @@ const sizeClasses = {
             </div>
           </td>
         </tr>
-      {:else if displayData.length === 0}
+      {:else if displayRows.length === 0}
         <tr class="data-table__row data-table__row--empty">
           <td
             class="data-table__cell data-table__cell--empty"
@@ -581,9 +613,10 @@ const sizeClasses = {
           </td>
         </tr>
       {:else}
-        {#each displayData as row, index (getDisplayRowKey(row, index))}
-          {@const key = getDisplayRowKey(row, index)}
-          {@const isSelected = selectedIds.has(key)}
+        {#each displayRows as entry, index (entry.rowId)}
+          {@const row = entry.row}
+          {@const key = entry.rowId}
+          {@const isSelected = tableState.selection.scope === 'allMatching' || selectedIds.has(key)}
           {@const isExpanded = expandedIds.has(key)}
           {@const rowCanExpand = canExpand?.(row, index) ?? true}
           <tr
@@ -609,6 +642,7 @@ const sizeClasses = {
                 <input
                   type="checkbox"
                   checked={isSelected}
+                  disabled={tableState.selection.scope === 'allMatching'}
                   onchange={(e) => handleRowSelect(key, e)}
                   aria-label={t(M['ui.data_table.select_row'])}
                   class="data-table__checkbox"
@@ -641,7 +675,7 @@ const sizeClasses = {
       {/if}
     </tbody>
     {#if footer}
-      <tfoot><tr><td class="data-table__cell data-table__footer" colspan={columnCount}>{@render footer({ rows: displayData })}</td></tr></tfoot>
+      <tfoot><tr><td class="data-table__cell data-table__footer" colspan={columnCount}>{@render footer({ rows: displayRows.map(({ row }) => row) })}</td></tr></tfoot>
     {/if}
   </table>
 </div>

--- a/packages/smrt-ui/src/components/data/DataTableController.ts
+++ b/packages/smrt-ui/src/components/data/DataTableController.ts
@@ -453,9 +453,10 @@ function normalizeFilters(
         `DataTable filter ${filter.operator} requires a value`,
       );
     }
-    const value = Object.hasOwn(filter, 'value')
-      ? canonicalJson(filter.value)
-      : undefined;
+    const value =
+      needsValue && Object.hasOwn(filter, 'value')
+        ? canonicalJson(filter.value)
+        : undefined;
     return value === undefined
       ? { columnId, operator: filter.operator }
       : { columnId, operator: filter.operator, value };

--- a/packages/smrt-ui/src/components/data/DataTableController.ts
+++ b/packages/smrt-ui/src/components/data/DataTableController.ts
@@ -7,6 +7,21 @@
 
 export type DataTableRowId = string | number;
 
+/** A caller-owned binding for an all-matching server-side selection. */
+export interface DataTableQueryRevision {
+  queryFingerprint: string;
+  queryRevision: string;
+}
+
+/**
+ * Selection is deliberately a tagged union. `allMatching` never serializes
+ * loaded IDs: the receiving action must verify its query binding before use.
+ */
+export type DataTableSelection =
+  | { scope: 'page'; rowIds: DataTableRowId[] }
+  | { scope: 'explicit'; rowIds: DataTableRowId[] }
+  | ({ scope: 'allMatching'; expectedCount: number } & DataTableQueryRevision);
+
 export type DataTableJsonPrimitive = string | number | boolean | null;
 export type DataTableJsonValue =
   | DataTableJsonPrimitive
@@ -68,13 +83,26 @@ export interface DataTableViewState {
   pageSize: number | null;
   columnOrder: string[];
   columnVisibility: DataTableColumnVisibility[];
+  selection: DataTableSelection;
+  /**
+   * Legacy shorthand for row-ID selections. It is always derived from
+   * `selection`, and is empty for `allMatching` selections.
+   */
   selectedRowIds: DataTableRowId[];
   expandedRowIds: DataTableRowId[];
 }
 
+/**
+ * Accepts a version-1 controlled state while the controller always emits the
+ * normalized version-2 `DataTableViewState` with an explicit selection.
+ */
+export type DataTableViewStateInput = Omit<DataTableViewState, 'selection'> & {
+  selection?: DataTableSelection;
+};
+
 /** The stable envelope intended for URL and saved-view adapters. */
 export interface DataTableSnapshot {
-  version: 1;
+  version: 2;
   modes: DataTableModes;
   state: DataTableViewState;
 }
@@ -89,6 +117,12 @@ export type DataTableCommand =
   | { type: 'setPageSize'; pageSize: number | null }
   | { type: 'setColumnOrder'; columnIds: string[] }
   | { type: 'setColumnVisibility'; columns: DataTableColumnVisibility[] }
+  | { type: 'setSelection'; selection: DataTableSelection }
+  | { type: 'setPageSelection'; rowIds: DataTableRowId[] }
+  | ({
+      type: 'selectAllMatching';
+      expectedCount: number;
+    } & DataTableQueryRevision)
   | { type: 'setSelectedRows'; rowIds: DataTableRowId[] }
   | { type: 'toggleRowSelection'; rowId: DataTableRowId }
   | { type: 'setExpandedRows'; rowIds: DataTableRowId[] }
@@ -106,7 +140,7 @@ export interface DataTableControllerOptions {
   /** Used by uncontrolled controllers. */
   initialState?: Partial<DataTableViewState>;
   /** Makes transitions proposals until `replaceState` supplies the next value. */
-  state?: DataTableViewState;
+  state?: DataTableViewStateInput;
   modes?: Partial<DataTableModes>;
   /** Optional known columns let the controller ignore stale saved-view fields. */
   columnIds?: readonly string[];
@@ -132,6 +166,7 @@ const DEFAULT_STATE: DataTableViewState = {
   pageSize: null,
   columnOrder: [],
   columnVisibility: [],
+  selection: { scope: 'explicit', rowIds: [] },
   selectedRowIds: [],
   expandedRowIds: [],
 };
@@ -160,11 +195,13 @@ function assertColumnId(value: unknown, label = 'column id'): string {
   return value;
 }
 
-function assertRowId(value: unknown): DataTableRowId {
-  if (typeof value === 'string') return value;
+export function assertDataTableRowId(value: unknown): DataTableRowId {
+  if (typeof value === 'string' && value.length > 0) return value;
   if (typeof value === 'number' && Number.isFinite(value))
     return value === 0 ? 0 : value;
-  throw new TypeError('DataTable row ids must be finite strings or numbers');
+  throw new TypeError(
+    'DataTable row ids must be non-empty strings or finite numbers',
+  );
 }
 
 function assertPage(value: unknown): number {
@@ -241,24 +278,151 @@ function jsonSignature(value: unknown): string {
   return JSON.stringify(canonicalJson(value));
 }
 
-function compareRowIds(left: DataTableRowId, right: DataTableRowId): number {
+export function compareDataTableRowIds(
+  left: DataTableRowId,
+  right: DataTableRowId,
+): number {
   if (typeof left !== typeof right) return typeof left === 'number' ? -1 : 1;
   if (typeof left === 'number' && typeof right === 'number')
     return left - right;
   return left < right ? -1 : left > right ? 1 : 0;
 }
 
-function rowIdKey(value: DataTableRowId): string {
+export function dataTableRowIdKey(value: DataTableRowId): string {
   return `${typeof value}:${String(value)}`;
 }
 
 function normalizeRowIds(values: readonly DataTableRowId[]): DataTableRowId[] {
   const ids = new Map<string, DataTableRowId>();
   for (const value of values) {
-    const id = assertRowId(value);
-    ids.set(rowIdKey(id), id);
+    const id = assertDataTableRowId(value);
+    ids.set(dataTableRowIdKey(id), id);
   }
-  return [...ids.values()].sort(compareRowIds);
+  return [...ids.values()].sort(compareDataTableRowIds);
+}
+
+function assertQueryRevisionValue(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new TypeError(`DataTable ${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function normalizeQueryRevision(value: unknown): DataTableQueryRevision {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('DataTable query binding must be a plain object');
+  }
+  const input = value as Record<string, unknown>;
+  return {
+    queryFingerprint: assertQueryRevisionValue(
+      input.queryFingerprint,
+      'query fingerprint',
+    ),
+    queryRevision: assertQueryRevisionValue(
+      input.queryRevision,
+      'query revision',
+    ),
+  };
+}
+
+function normalizeSelection(
+  value: unknown,
+  legacyRowIds: readonly DataTableRowId[],
+): DataTableSelection {
+  if (value === undefined) {
+    return { scope: 'explicit', rowIds: normalizeRowIds(legacyRowIds) };
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('DataTable selection must be a plain object');
+  }
+  const input = value as Record<string, unknown>;
+  if (input.scope === 'page' || input.scope === 'explicit') {
+    if (!Array.isArray(input.rowIds)) {
+      throw new TypeError(`DataTable ${input.scope} selection requires rowIds`);
+    }
+    return { scope: input.scope, rowIds: normalizeRowIds(input.rowIds) };
+  }
+  if (input.scope === 'allMatching') {
+    if (Object.hasOwn(input, 'rowIds')) {
+      throw new TypeError(
+        'DataTable allMatching selection must not contain rowIds',
+      );
+    }
+    if (
+      typeof input.expectedCount !== 'number' ||
+      !Number.isFinite(input.expectedCount) ||
+      !Number.isInteger(input.expectedCount) ||
+      input.expectedCount < 0
+    ) {
+      throw new TypeError(
+        'DataTable allMatching expectedCount must be a non-negative integer',
+      );
+    }
+    return {
+      scope: 'allMatching',
+      ...normalizeQueryRevision(input),
+      expectedCount: input.expectedCount,
+    };
+  }
+  throw new TypeError(
+    'DataTable selection scope must be page, explicit, or allMatching',
+  );
+}
+
+function selectedRowIdsFor(selection: DataTableSelection): DataTableRowId[] {
+  return selection.scope === 'allMatching' ? [] : selection.rowIds;
+}
+
+function withSelection(
+  state: DataTableViewState,
+  selection: DataTableSelection,
+): DataTableViewState {
+  const normalized = normalizeSelection(selection, []);
+  return {
+    ...state,
+    selection: normalized,
+    selectedRowIds: selectedRowIdsFor(normalized),
+  };
+}
+
+function clearSelectionForPageChange(
+  state: DataTableViewState,
+): DataTableViewState {
+  return state.selection.scope === 'page'
+    ? withSelection(state, { scope: 'page', rowIds: [] })
+    : state;
+}
+
+function clearSelectionForQueryChange(
+  state: DataTableViewState,
+): DataTableViewState {
+  if (state.selection.scope === 'page') {
+    return withSelection(state, { scope: 'page', rowIds: [] });
+  }
+  if (state.selection.scope === 'allMatching') {
+    return withSelection(state, { scope: 'explicit', rowIds: [] });
+  }
+  return state;
+}
+
+/**
+ * Refuse an all-matching selection when the action's query has changed since
+ * selection. Domain actions must call this before a destructive operation.
+ */
+export function assertDataTableSelectionCurrent(
+  selection: DataTableSelection,
+  currentQuery: DataTableQueryRevision,
+): void {
+  if (selection.scope !== 'allMatching') return;
+  const current = normalizeQueryRevision(currentQuery);
+  if (
+    selection.queryFingerprint !== current.queryFingerprint ||
+    selection.queryRevision !== current.queryRevision
+  ) {
+    throw new TypeError(
+      'DataTable allMatching selection is stale for the current query revision',
+    );
+  }
 }
 
 function normalizeUniqueColumnIds(values: readonly string[]): string[] {
@@ -355,6 +519,10 @@ function normalizeState(
   columnIds?: readonly string[],
 ): DataTableViewState {
   const input = state ?? {};
+  const selection = normalizeSelection(
+    input.selection,
+    input.selectedRowIds ?? DEFAULT_STATE.selectedRowIds,
+  );
   const knownColumns = columnIds ? normalizeUniqueColumnIds(columnIds) : null;
   const allowed = knownColumns ? new Set(knownColumns) : null;
   const keepKnown = (columnId: string) => !allowed || allowed.has(columnId);
@@ -398,9 +566,8 @@ function normalizeState(
         visible,
       })),
     ),
-    selectedRowIds: normalizeRowIds(
-      input.selectedRowIds ?? DEFAULT_STATE.selectedRowIds,
-    ),
+    selection,
+    selectedRowIds: selectedRowIdsFor(selection),
     expandedRowIds: normalizeRowIds(
       input.expandedRowIds ?? DEFAULT_STATE.expandedRowIds,
     ),
@@ -442,22 +609,23 @@ export function transitionDataTableState(
     case 'setSearch': {
       if (typeof command.search !== 'string')
         throw new TypeError('DataTable search must be a string');
-      next = resetPage(
-        { ...current, search: command.search },
-        command.search !== current.search,
-      );
+      const changed = command.search !== current.search;
+      next = resetPage({ ...current, search: command.search }, changed);
+      if (changed) next = clearSelectionForQueryChange(next);
       break;
     }
     case 'setFilters': {
       const filters = normalizeFilters(command.filters);
       const changed = jsonSignature(filters) !== jsonSignature(current.filters);
       next = resetPage({ ...current, filters }, changed);
+      if (changed) next = clearSelectionForQueryChange(next);
       break;
     }
     case 'setSorting': {
       const sorting = normalizeSorting(command.sorting);
       const changed = jsonSignature(sorting) !== jsonSignature(current.sorting);
       next = resetPage({ ...current, sorting }, changed);
+      if (changed) next = clearSelectionForQueryChange(next);
       break;
     }
     case 'toggleSorting': {
@@ -482,18 +650,22 @@ export function transitionDataTableState(
         : toggled
           ? [toggled]
           : [];
-      next = resetPage(
-        { ...current, sorting },
-        jsonSignature(sorting) !== jsonSignature(current.sorting),
-      );
+      const changed = jsonSignature(sorting) !== jsonSignature(current.sorting);
+      next = resetPage({ ...current, sorting }, changed);
+      if (changed) next = clearSelectionForQueryChange(next);
       break;
     }
-    case 'setPage':
-      next = { ...current, page: assertPage(command.page) };
+    case 'setPage': {
+      const page = assertPage(command.page);
+      next = { ...current, page };
+      if (page !== current.page) next = clearSelectionForPageChange(next);
       break;
+    }
     case 'setPageSize': {
       const pageSize = assertPageSize(command.pageSize);
-      next = resetPage({ ...current, pageSize }, pageSize !== current.pageSize);
+      const changed = pageSize !== current.pageSize;
+      next = resetPage({ ...current, pageSize }, changed);
+      if (changed) next = clearSelectionForPageChange(next);
       break;
     }
     case 'setColumnOrder':
@@ -508,31 +680,58 @@ export function transitionDataTableState(
         columnVisibility: normalizeVisibility(command.columns),
       };
       break;
+    case 'setSelection':
+      next = withSelection(current, command.selection);
+      break;
+    case 'setPageSelection':
+      next = withSelection(current, {
+        scope: 'page',
+        rowIds: command.rowIds,
+      });
+      break;
+    case 'selectAllMatching':
+      next = withSelection(current, {
+        scope: 'allMatching',
+        ...normalizeQueryRevision(command),
+        expectedCount: command.expectedCount,
+      });
+      break;
     case 'setSelectedRows':
-      next = { ...current, selectedRowIds: normalizeRowIds(command.rowIds) };
+      next = withSelection(current, {
+        scope: 'explicit',
+        rowIds: command.rowIds,
+      });
       break;
     case 'toggleRowSelection': {
-      const rowId = assertRowId(command.rowId);
+      if (current.selection.scope === 'allMatching') {
+        throw new TypeError(
+          'DataTable cannot toggle an individual row while allMatching is active',
+        );
+      }
+      const rowId = assertDataTableRowId(command.rowId);
       const ids = new Map(
-        current.selectedRowIds.map((id) => [rowIdKey(id), id]),
+        current.selection.rowIds.map((id) => [dataTableRowIdKey(id), id]),
       );
-      ids.has(rowIdKey(rowId))
-        ? ids.delete(rowIdKey(rowId))
-        : ids.set(rowIdKey(rowId), rowId);
-      next = { ...current, selectedRowIds: normalizeRowIds([...ids.values()]) };
+      ids.has(dataTableRowIdKey(rowId))
+        ? ids.delete(dataTableRowIdKey(rowId))
+        : ids.set(dataTableRowIdKey(rowId), rowId);
+      next = withSelection(current, {
+        scope: current.selection.scope,
+        rowIds: [...ids.values()],
+      });
       break;
     }
     case 'setExpandedRows':
       next = { ...current, expandedRowIds: normalizeRowIds(command.rowIds) };
       break;
     case 'toggleRowExpansion': {
-      const rowId = assertRowId(command.rowId);
+      const rowId = assertDataTableRowId(command.rowId);
       const ids = new Map(
-        current.expandedRowIds.map((id) => [rowIdKey(id), id]),
+        current.expandedRowIds.map((id) => [dataTableRowIdKey(id), id]),
       );
-      ids.has(rowIdKey(rowId))
-        ? ids.delete(rowIdKey(rowId))
-        : ids.set(rowIdKey(rowId), rowId);
+      ids.has(dataTableRowIdKey(rowId))
+        ? ids.delete(dataTableRowIdKey(rowId))
+        : ids.set(dataTableRowIdKey(rowId), rowId);
       next = { ...current, expandedRowIds: normalizeRowIds([...ids.values()]) };
       break;
     }
@@ -558,10 +757,10 @@ export function hydrateDataTableSnapshot(value: unknown): DataTableSnapshot {
     throw new TypeError('DataTable snapshot must be a plain object');
   }
   const input = value as Record<string, unknown>;
-  if (input.version !== 1)
+  if (input.version !== 1 && input.version !== 2)
     throw new TypeError('Unsupported DataTable snapshot version');
   return {
-    version: 1,
+    version: 2,
     modes: normalizeModes(input.modes as Partial<DataTableModes>),
     state: normalizeState(input.state as Partial<DataTableViewState>),
   };
@@ -599,7 +798,7 @@ export class DataTableController {
   }
 
   snapshot(): DataTableSnapshot {
-    return { version: 1, modes: this.getModes(), state: this.getState() };
+    return { version: 2, modes: this.getModes(), state: this.getState() };
   }
 
   subscribe(listener: DataTableStateListener): () => void {
@@ -615,7 +814,7 @@ export class DataTableController {
       this.columnIds,
     );
     const next = {
-      version: 1 as const,
+      version: 2 as const,
       modes: this.getModes(),
       state: candidate,
     };
@@ -644,11 +843,11 @@ export class DataTableController {
   }
 
   /** Supplies state from a controlled host or an external persistence adapter. */
-  replaceState(state: DataTableViewState): DataTableTransition {
+  replaceState(state: DataTableViewStateInput): DataTableTransition {
     const previous = this.snapshot();
     const nextState = normalizeState(state, this.columnIds);
     const next = {
-      version: 1 as const,
+      version: 2 as const,
       modes: this.getModes(),
       state: nextState,
     };

--- a/packages/smrt-ui/src/components/data/DataTableController.ts
+++ b/packages/smrt-ui/src/components/data/DataTableController.ts
@@ -205,10 +205,15 @@ export function assertDataTableRowId(value: unknown): DataTableRowId {
 }
 
 function assertPage(value: unknown): number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new TypeError('DataTable page must be a finite number');
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value <= 0
+  ) {
+    throw new TypeError('DataTable page must be a positive integer');
   }
-  return Math.max(1, Math.floor(value));
+  return value;
 }
 
 function assertPageSize(value: unknown): number | null {
@@ -904,10 +909,12 @@ export class DataTableController {
         changed: false,
       };
     }
-    if (!Number.isFinite(totalRows) || totalRows < 0) {
-      throw new TypeError(
-        'DataTable totalRows must be a non-negative finite number',
-      );
+    if (
+      !Number.isFinite(totalRows) ||
+      !Number.isInteger(totalRows) ||
+      totalRows < 0
+    ) {
+      throw new TypeError('DataTable totalRows must be a non-negative integer');
     }
     const pageCount = this.state.pageSize
       ? Math.max(1, Math.ceil(totalRows / this.state.pageSize))

--- a/packages/smrt-ui/src/components/data/DataTableIdentity.ts
+++ b/packages/smrt-ui/src/components/data/DataTableIdentity.ts
@@ -1,0 +1,59 @@
+import {
+  assertDataTableRowId,
+  type DataTableRowId,
+  dataTableRowIdKey,
+} from './DataTableController.js';
+
+/** A stable row identity accessor. It must not depend on display position. */
+export type DataTableRowKey<T> = keyof T | ((row: T) => DataTableRowId);
+
+export interface DataTableResolvedRow<T> {
+  row: T;
+  /** Index in the `data` array supplied to DataTable before local transforms. */
+  sourceIndex: number;
+  /** Canonical key used by Svelte, selection, and expansion. */
+  rowId: DataTableRowId;
+}
+
+export interface ResolveDataTableRowsOptions {
+  /** Durable table features may not use the historical source-index fallback. */
+  requireStableIdentity?: boolean;
+}
+
+function readRowKey<T>(row: T, rowKey: DataTableRowKey<T>): unknown {
+  return typeof rowKey === 'function'
+    ? rowKey(row)
+    : (row as Record<PropertyKey, unknown>)[rowKey];
+}
+
+/**
+ * Resolve the renderer's source rows once and fail closed for missing or
+ * duplicate durable identities. The index fallback only exists for
+ * presentational local tables that have no durable row state.
+ */
+export function resolveDataTableRows<T>(
+  rows: readonly T[],
+  rowKey: DataTableRowKey<T> | undefined,
+  options: ResolveDataTableRowsOptions = {},
+): DataTableResolvedRow<T>[] {
+  if (options.requireStableIdentity && !rowKey) {
+    throw new TypeError(
+      'DataTable rowKey is required for selectable, expandable, manual, or agent-addressable tables',
+    );
+  }
+
+  const seen = new Set<string>();
+  return rows.map((row, sourceIndex) => {
+    const rowId = rowKey
+      ? assertDataTableRowId(readRowKey(row, rowKey))
+      : sourceIndex;
+    const key = dataTableRowIdKey(rowId);
+    if (seen.has(key)) {
+      throw new TypeError(
+        `DataTable rowKey must resolve to unique row ids; duplicate ${key}`,
+      );
+    }
+    seen.add(key);
+    return { row, sourceIndex, rowId };
+  });
+}

--- a/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../DataTableController.js';
 
 interface Person {
+  id: string;
   name: string;
   age: number;
 }
@@ -27,8 +28,8 @@ const columns = [
   { id: 'age', label: 'Age', accessor: 'age' },
 ];
 const data: Person[] = [
-  { name: 'Ada', age: 36 },
-  { name: 'Linus', age: 54 },
+  { id: 'ada', name: 'Ada', age: 36 },
+  { id: 'linus', name: 'Linus', age: 54 },
 ];
 
 describe('DataTable', () => {
@@ -100,7 +101,7 @@ describe('DataTable', () => {
   it('filters and paginates client-side rows', async () => {
     render(DataTable, {
       props: {
-        data: [...data, { name: 'Grace', age: 85 }],
+        data: [...data, { id: 'grace', name: 'Grace', age: 85 }],
         columns,
         filterFn: (person: Person) => person.age > 40,
         pageSize: 1,
@@ -202,9 +203,10 @@ describe('DataTable', () => {
     });
     render(DataTable, {
       props: {
-        data: [...data, { name: 'Grace', age: 85 }],
+        data: [...data, { id: 'grace', name: 'Grace', age: 85 }],
         columns,
         controller,
+        rowKey: 'id',
       },
     });
 
@@ -215,48 +217,55 @@ describe('DataTable', () => {
     expect(names).toEqual(expected);
   });
 
-  it('keeps fallback selection keys unique across pages', async () => {
+  it('keeps stable selection IDs across pages and labels the page scope', async () => {
     const onSelectionChange = vi.fn();
     render(DataTable, {
       props: {
         data,
         columns,
         pageSize: 1,
+        rowKey: 'id',
         selectable: true,
         onSelectionChange,
       },
     });
 
     await userEvent.click(
-      screen.getByRole('checkbox', { name: 'Select all rows' }),
+      screen.getByRole('checkbox', { name: 'Select all rows on this page' }),
     );
     await userEvent.click(screen.getByRole('button', { name: 'Next page' }));
     await userEvent.click(
-      screen.getByRole('checkbox', { name: 'Select all rows' }),
+      screen.getByRole('checkbox', { name: 'Select all rows on this page' }),
     );
 
-    expect(onSelectionChange).toHaveBeenLastCalledWith(new Set([0, 1]));
+    expect(onSelectionChange).toHaveBeenLastCalledWith(
+      new Set(['ada', 'linus']),
+    );
   });
 
-  it('does not carry fallback expansion keys onto the next page', async () => {
-    render(DataTable, {
-      props: {
-        data,
-        columns,
-        pageSize: 1,
-        expandedContent: createRawSnippet(() => ({
-          render: () => '<p>Row detail</p>',
-        })),
-      },
-    });
-
-    await userEvent.click(screen.getByRole('button', { name: 'Expand row' }));
-    await userEvent.click(screen.getByRole('button', { name: 'Next page' }));
-
-    expect(screen.queryByText('Row detail')).not.toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Expand row' }),
-    ).toBeInTheDocument();
+  it('fails closed when durable selection, expansion, manual, or agent modes lack a rowKey', () => {
+    expect(() =>
+      render(DataTable, { props: { data, columns, selectable: true } }),
+    ).toThrow(/rowKey is required/);
+    expect(() =>
+      render(DataTable, {
+        props: {
+          data,
+          columns,
+          expandedContent: createRawSnippet(() => ({ render: () => '' })),
+        },
+      }),
+    ).toThrow(/rowKey is required/);
+    expect(() =>
+      render(DataTable, {
+        props: { data, columns, agentAddressable: true },
+      }),
+    ).toThrow(/rowKey is required/);
+    expect(() =>
+      render(DataTable, {
+        props: { data, columns, modes: { pagination: 'manual' } },
+      }),
+    ).toThrow(/rowKey is required/);
   });
 
   it('reveals expandable row content', async () => {
@@ -264,6 +273,7 @@ describe('DataTable', () => {
       props: {
         data,
         columns,
+        rowKey: 'id',
         expandedContent: createRawSnippet(() => ({
           render: () => '<p>Row detail</p>',
         })),
@@ -273,6 +283,46 @@ describe('DataTable', () => {
       screen.getAllByRole('button', { name: 'Expand row' })[0],
     );
     expect(screen.getByText('Row detail')).toBeInTheDocument();
+  });
+
+  it('rejects duplicate stable row keys and local totals that imply server paging', () => {
+    expect(() =>
+      render(DataTable, {
+        props: {
+          data: [data[0], { ...data[1], id: 'ada' }],
+          columns,
+          rowKey: 'id',
+        },
+      }),
+    ).toThrow(/unique row ids/);
+    expect(() =>
+      render(DataTable, {
+        props: { data, columns, rowKey: 'id', totalRows: 10 },
+      }),
+    ).toThrow(/only valid when pagination mode is manual/);
+  });
+
+  it('uses stable row IDs as the final local sort tie-breaker', () => {
+    const controller = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+      initialState: { sorting: [{ columnId: 'age', direction: 'asc' }] },
+    });
+    render(DataTable, {
+      props: {
+        data: [
+          { id: 'z', name: 'Zed', age: 36 },
+          { id: 'a', name: 'Ada', age: 36 },
+        ],
+        columns,
+        rowKey: 'id',
+        controller,
+      },
+    });
+    const names = screen
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => within(row).getAllByRole('cell')[0].textContent);
+    expect(names).toEqual(['Ada', 'Zed']);
   });
 
   it('is axe-clean', async () => {

--- a/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
@@ -243,6 +243,32 @@ describe('DataTable', () => {
     );
   });
 
+  it('honors legacy selected bindings during controller reconciliation', async () => {
+    const props = {
+      data,
+      columns,
+      rowKey: 'id' as const,
+      selectable: true,
+      selected: new Set<string | number>(['ada']),
+    };
+    const { rerender } = render(DataTable, { props });
+
+    const expectSelected = (name: string) => {
+      expect(screen.getByRole('cell', { name }).closest('tr')).toHaveClass(
+        'data-table__row--selected',
+      );
+    };
+
+    await vi.waitFor(() => expectSelected('Ada'));
+    await rerender({ ...props, selected: new Set(['linus']) });
+    await vi.waitFor(() => {
+      expectSelected('Linus');
+      expect(
+        screen.getByRole('cell', { name: 'Ada' }).closest('tr'),
+      ).not.toHaveClass('data-table__row--selected');
+    });
+  });
+
   it('keeps stable selection and expansion through sort, filter, and data refresh', async () => {
     const controller = createDataTableController({
       columnIds: columns.map((column) => column.id),

--- a/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
@@ -243,6 +243,81 @@ describe('DataTable', () => {
     );
   });
 
+  it('keeps stable selection and expansion through sort, filter, and data refresh', async () => {
+    const controller = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+    });
+    const expandedContent = createRawSnippet(() => ({
+      render: () => '<p>Row detail</p>',
+    }));
+    const props = {
+      data,
+      columns,
+      rowKey: 'id' as const,
+      selectable: true,
+      expandedContent,
+      controller,
+    };
+    const { rerender } = render(DataTable, { props });
+
+    const expectAdaSelectionAndExpansion = () => {
+      const adaRow = screen.getByRole('cell', { name: 'Ada' }).closest('tr');
+      expect(adaRow).toHaveClass('data-table__row--selected');
+      expect(adaRow?.nextElementSibling).toHaveTextContent('Row detail');
+    };
+    const visibleNames = () =>
+      screen
+        .getAllByRole('row')
+        .slice(1)
+        .filter((row) => !row.classList.contains('data-table__row--expanded'))
+        .map(
+          (row) =>
+            within(row)
+              .getAllByRole('cell')
+              .find((cell) => ['Ada', 'Linus'].includes(cell.textContent ?? ''))
+              ?.textContent,
+        )
+        .filter((name): name is string => name !== undefined);
+
+    await userEvent.click(
+      screen.getAllByRole('checkbox', { name: 'Select row' })[0],
+    );
+    await userEvent.click(
+      screen.getAllByRole('button', { name: 'Expand row' })[0],
+    );
+    expectAdaSelectionAndExpansion();
+
+    controller.dispatch({
+      type: 'setSorting',
+      sorting: [{ columnId: 'age', direction: 'desc' }],
+    });
+    await vi.waitFor(() => {
+      expect(visibleNames()).toEqual(['Linus', 'Ada']);
+      expectAdaSelectionAndExpansion();
+    });
+
+    controller.dispatch({ type: 'setSearch', search: 'Ada' });
+    await vi.waitFor(() => {
+      expect(
+        screen.queryByRole('cell', { name: 'Linus' }),
+      ).not.toBeInTheDocument();
+      expectAdaSelectionAndExpansion();
+    });
+
+    controller.dispatch({ type: 'setSearch', search: '' });
+    await rerender({
+      ...props,
+      data: [
+        { id: 'linus', name: 'Linus', age: 10 },
+        { id: 'ada', name: 'Ada', age: 90 },
+      ],
+    });
+    await vi.waitFor(() => {
+      expect(visibleNames()).toEqual(['Ada', 'Linus']);
+      expectAdaSelectionAndExpansion();
+    });
+  });
+
   it('fails closed when durable selection, expansion, manual, or agent modes lack a rowKey', () => {
     expect(() =>
       render(DataTable, { props: { data, columns, selectable: true } }),

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableController.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableController.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  assertDataTableSelectionCurrent,
   createDataTableController,
   type DataTableViewState,
   hydrateDataTableSnapshot,
@@ -17,6 +18,7 @@ const state: DataTableViewState = {
     { columnId: 'age', visible: true },
     { columnId: 'name', visible: true },
   ],
+  selection: { scope: 'explicit', rowIds: [] },
   selectedRowIds: [],
   expandedRowIds: [],
 };
@@ -164,9 +166,76 @@ describe('DataTableController', () => {
         JSON.parse(JSON.stringify(controller.snapshot())),
       ),
     ).toEqual(controller.snapshot());
-    expect(() => hydrateDataTableSnapshot({ version: 2 })).toThrow(/version/);
+    const { selection: _selection, ...legacyState } = state;
+    expect(
+      hydrateDataTableSnapshot({
+        version: 1,
+        modes: controller.getModes(),
+        state: legacyState,
+      }),
+    ).toMatchObject({
+      version: 2,
+      state: { selection: { scope: 'explicit', rowIds: [] } },
+    });
+    expect(() => hydrateDataTableSnapshot({ version: 3 })).toThrow(/version/);
     expect(() =>
       transitionDataTableState(state, { type: 'setPageSize', pageSize: 0 }),
     ).toThrow(/pageSize/);
+  });
+
+  it('models current-page and explicit row selections separately', () => {
+    const controller = createDataTableController({ initialState: state });
+
+    controller.dispatch({
+      type: 'setPageSelection',
+      rowIds: ['row-2', 'row-1'],
+    });
+    expect(controller.getState().selection).toEqual({
+      scope: 'page',
+      rowIds: ['row-1', 'row-2'],
+    });
+
+    controller.dispatch({ type: 'setPage', page: 4 });
+    expect(controller.getState().selection).toEqual({
+      scope: 'page',
+      rowIds: [],
+    });
+
+    controller.dispatch({ type: 'setSelectedRows', rowIds: ['row-2'] });
+    controller.dispatch({ type: 'setPage', page: 5 });
+    expect(controller.getState().selection).toEqual({
+      scope: 'explicit',
+      rowIds: ['row-2'],
+    });
+  });
+
+  it('binds all-matching selection to an exact query revision and invalidates it on query changes', () => {
+    const controller = createDataTableController({ initialState: state });
+    controller.dispatch({
+      type: 'selectAllMatching',
+      queryFingerprint: 'dq1_example',
+      queryRevision: 'revision-7',
+      expectedCount: 42,
+    });
+
+    expect(controller.getState().selection).toEqual({
+      scope: 'allMatching',
+      queryFingerprint: 'dq1_example',
+      queryRevision: 'revision-7',
+      expectedCount: 42,
+    });
+    expect(controller.getState().selectedRowIds).toEqual([]);
+    expect(() =>
+      assertDataTableSelectionCurrent(controller.getState().selection, {
+        queryFingerprint: 'dq1_example',
+        queryRevision: 'revision-8',
+      }),
+    ).toThrow(/stale/);
+
+    controller.dispatch({ type: 'setSearch', search: 'Ada' });
+    expect(controller.getState().selection).toEqual({
+      scope: 'explicit',
+      rowIds: [],
+    });
   });
 });

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableController.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableController.test.ts
@@ -83,6 +83,7 @@ describe('DataTableController', () => {
     expect(controller.snapshot().state.page).toBe(2);
     controller.clampPage(0);
     expect(controller.snapshot().state.page).toBe(1);
+    expect(() => controller.clampPage(1.5)).toThrow(/totalRows/);
   });
 
   it('keeps multi-sort priority while cycling a column through asc, desc, and clear', () => {
@@ -181,6 +182,11 @@ describe('DataTableController', () => {
     expect(() =>
       transitionDataTableState(state, { type: 'setPageSize', pageSize: 0 }),
     ).toThrow(/pageSize/);
+    for (const page of [0, -1, 1.5]) {
+      expect(() =>
+        transitionDataTableState(state, { type: 'setPage', page }),
+      ).toThrow(/page/);
+    }
   });
 
   it('models current-page and explicit row selections separately', () => {

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableController.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableController.test.ts
@@ -64,6 +64,29 @@ describe('DataTableController', () => {
     );
   });
 
+  it('omits ignored null-check filter values from canonical snapshots', () => {
+    const withoutValue = createDataTableController({
+      initialState: {
+        ...state,
+        filters: [{ columnId: 'name', operator: 'isNull' }],
+      },
+    });
+    const withIgnoredValue = createDataTableController({
+      initialState: {
+        ...state,
+        filters: [
+          {
+            columnId: 'name',
+            operator: 'isNull',
+            value: undefined,
+          },
+        ],
+      },
+    });
+
+    expect(withIgnoredValue.snapshot()).toEqual(withoutValue.snapshot());
+  });
+
   it('resets page only when a query-shape value changes and clamps reliable totals', () => {
     const controller = createDataTableController({ initialState: state });
 

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableIdentity.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableIdentity.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { resolveDataTableRows } from '../DataTableIdentity.js';
+
+interface Row {
+  id: string;
+  name: string;
+}
+
+const rows: Row[] = [
+  { id: 'ada', name: 'Ada' },
+  { id: 'linus', name: 'Linus' },
+];
+
+describe('resolveDataTableRows', () => {
+  it('uses stable canonical IDs and preserves source indexes', () => {
+    expect(
+      resolveDataTableRows(rows, 'id', { requireStableIdentity: true }),
+    ).toEqual([
+      { row: rows[0], sourceIndex: 0, rowId: 'ada' },
+      { row: rows[1], sourceIndex: 1, rowId: 'linus' },
+    ]);
+  });
+
+  it('keeps the index fallback only for presentational local tables', () => {
+    expect(resolveDataTableRows(rows, undefined)).toEqual([
+      { row: rows[0], sourceIndex: 0, rowId: 0 },
+      { row: rows[1], sourceIndex: 1, rowId: 1 },
+    ]);
+    expect(() =>
+      resolveDataTableRows(rows, undefined, { requireStableIdentity: true }),
+    ).toThrow(/rowKey is required/);
+  });
+
+  it('rejects duplicate, empty, and non-finite stable row IDs', () => {
+    expect(() =>
+      resolveDataTableRows(
+        [
+          { id: 'same', name: 'Ada' },
+          { id: 'same', name: 'Linus' },
+        ],
+        'id',
+      ),
+    ).toThrow(/unique/);
+    expect(() => resolveDataTableRows([{ id: '', name: 'Ada' }], 'id')).toThrow(
+      /non-empty/,
+    );
+    expect(() =>
+      resolveDataTableRows([{ id: Number.NaN, name: 'Ada' }], (row) => row.id),
+    ).toThrow(/finite/);
+  });
+});

--- a/packages/smrt-ui/src/components/data/index.ts
+++ b/packages/smrt-ui/src/components/data/index.ts
@@ -9,4 +9,5 @@ export {
 export { default as CollectionToolbar } from './CollectionToolbar.svelte';
 export { default as DataTable } from './DataTable.svelte';
 export * from './DataTableController.js';
+export * from './DataTableIdentity.js';
 export * from './types.js';

--- a/packages/smrt-ui/src/components/data/types.ts
+++ b/packages/smrt-ui/src/components/data/types.ts
@@ -9,7 +9,9 @@ import type {
   DataTableFilter,
   DataTableModes,
   DataTableViewState,
+  DataTableViewStateInput,
 } from './DataTableController.js';
+import type { DataTableRowKey } from './DataTableIdentity.js';
 
 /**
  * Column definition for DataTable
@@ -71,7 +73,12 @@ export interface DataTableProps<T> {
   /** Column definitions */
   columns: DataTableColumn<T>[];
   /** Unique key accessor for rows */
-  rowKey?: keyof T | ((row: T) => string | number);
+  rowKey?: DataTableRowKey<T>;
+  /**
+   * Declares that a DataSurface or agent will address rows. Such tables must
+   * provide `rowKey`, even if they do not render selection controls.
+   */
+  agentAddressable?: boolean;
   /** Enable row selection */
   selectable?: boolean;
   /** Selected row keys */
@@ -120,7 +127,7 @@ export interface DataTableProps<T> {
    */
   controller?: DataTableController;
   /** Explicit controlled serializable state when no external controller is supplied. */
-  state?: DataTableViewState;
+  state?: DataTableViewStateInput;
   /** Initial serializable state for uncontrolled controller-backed tables. */
   initialState?: Partial<DataTableViewState>;
   /** Called after a controller command proposes or applies a new state. */

--- a/packages/smrt-ui/src/i18n/strings.ts
+++ b/packages/smrt-ui/src/i18n/strings.ts
@@ -14,6 +14,7 @@ import { defineMessages } from './registry.js';
 
 export const M = defineMessages({
   'ui.data_table.select_all': 'Select all rows',
+  'ui.data_table.select_current_page': 'Select all rows on this page',
   'ui.data_table.select_row': 'Select row',
   'ui.data_table.loading': 'Loading...',
   'ui.data_table.empty': 'No data available',


### PR DESCRIPTION
## Summary

- require canonical row keys for durable DataTable modes and bind rows, selection, expansion, and sort ties to those IDs
- model page, explicit, and query-revision-bound all-matching selection with stale-action protection
- validate page and total semantics, document the v2 snapshot migration, and preserve the legacy non-durable presentation fallback
- preserve legacy `selected` bindable updates while the controller reconciles state
- canonicalize null-check filters by discarding irrelevant values before validation
- cover identity through cross-page selection, sorting, filtering, refresh, duplicate keys, invalid pages, legacy selection reconciliation, and null-check canonicalization

## Validation

- `pnpm --filter @happyvertical/smrt-ui test` (58 files, 567 tests)
- `pnpm --filter @happyvertical/smrt-ui typecheck`
- `pnpm --filter @happyvertical/smrt-ui build`
- `pnpm exec smrt dev:knowledge-check --format markdown`
- `git diff --check`
- independent preliminary and final gate reviews for both review fixes

Closes #2437

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-2437-merge-conflict-20260822",
  "issue": 2437,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm --filter @happyvertical/smrt-ui test (58 files, 567 tests)",
    "pnpm --filter @happyvertical/smrt-ui typecheck",
    "pnpm --filter @happyvertical/smrt-ui build",
    "pnpm exec smrt dev:knowledge-check --format markdown",
    "git diff --check",
    "independent preliminary and final gate reviews for both review fixes"
  ]
}