### PR TITLE
fix(smrt-ui): make DataTable overflow keyboard accessible

### DIFF
--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -123,6 +123,10 @@ const localController = createDataTableController({
 let controllerSnapshot = $state<DataTableSnapshot>(localController.snapshot());
 let publishedLegacySignature: string | undefined;
 let localControllerInitialized = false;
+let tableContainer = $state<HTMLDivElement>();
+let hasHorizontalOverflow = $state(false);
+let canScrollLeft = $state(false);
+let canScrollRight = $state(false);
 
 function activeController(): DataTableController {
   return controller ?? localController;
@@ -303,6 +307,61 @@ function handlePageChange(next: number) {
 // Handle row click
 function handleRowClick(row: T, index: number) {
   onRowClick?.(row, index);
+}
+
+function updateOverflowState() {
+  const container = tableContainer;
+  if (!container) return;
+
+  const maxScrollLeft = Math.max(
+    0,
+    container.scrollWidth - container.clientWidth,
+  );
+  hasHorizontalOverflow = maxScrollLeft > 1;
+  canScrollLeft = hasHorizontalOverflow && container.scrollLeft > 1;
+  canScrollRight =
+    hasHorizontalOverflow && container.scrollLeft < maxScrollLeft - 1;
+}
+
+function handleOverflowKeydown(event: KeyboardEvent) {
+  const container = tableContainer;
+  if (!container || !hasHorizontalOverflow || event.target !== container) {
+    return;
+  }
+
+  const maxScrollLeft = Math.max(
+    0,
+    container.scrollWidth - container.clientWidth,
+  );
+  const scrollStep = Math.max(Math.floor(container.clientWidth * 0.8), 40);
+  let nextScrollLeft: number | undefined;
+
+  switch (event.key) {
+    case 'ArrowLeft':
+      nextScrollLeft = container.scrollLeft - scrollStep;
+      break;
+    case 'ArrowRight':
+      nextScrollLeft = container.scrollLeft + scrollStep;
+      break;
+    case 'Home':
+      nextScrollLeft = 0;
+      break;
+    case 'End':
+      nextScrollLeft = maxScrollLeft;
+      break;
+  }
+
+  if (nextScrollLeft === undefined) return;
+
+  const clampedScrollLeft = Math.max(
+    0,
+    Math.min(maxScrollLeft, nextScrollLeft),
+  );
+  if (clampedScrollLeft === container.scrollLeft) return;
+
+  event.preventDefault();
+  container.scrollLeft = clampedScrollLeft;
+  updateOverflowState();
 }
 
 // Action to set indeterminate state (can't be set via HTML attribute)
@@ -505,6 +564,11 @@ const someSelected = $derived(
 const columnCount = $derived(
   visibleColumns.length + (selectable ? 1 : 0) + (expandedContent ? 1 : 0),
 );
+const overflowRegionLabel = $derived(
+  caption
+    ? `${caption} table, scroll horizontally to view more columns`
+    : 'Data table, scroll horizontally to view more columns',
+);
 
 function getCellValue(row: T, column: DataTableColumn<T>): unknown {
   const accessor = column.accessor ?? column.id;
@@ -516,10 +580,43 @@ const sizeClasses = {
   md: 'data-table--md',
   lg: 'data-table--lg',
 };
+
+$effect(() => {
+  const container = tableContainer;
+  void columnCount;
+  void displayRows.length;
+  if (!container) return;
+
+  const resizeObserver =
+    typeof ResizeObserver === 'undefined'
+      ? undefined
+      : new ResizeObserver(updateOverflowState);
+  resizeObserver?.observe(container);
+  const table = container.querySelector('table');
+  if (table) resizeObserver?.observe(table);
+  window.addEventListener('resize', updateOverflowState);
+  updateOverflowState();
+
+  return () => {
+    resizeObserver?.disconnect();
+    window.removeEventListener('resize', updateOverflowState);
+  };
+});
 </script>
 
 {#if toolbar}<div class="data-table-toolbar">{@render toolbar()}</div>{/if}
-<div class="data-table-container" class:data-table-container--sticky={stickyHeader}>
+<!-- svelte-ignore a11y_no_noninteractive_tabindex: the region is only focusable while it overflows. -->
+<div
+  bind:this={tableContainer}
+  class="data-table-container"
+  class:data-table-container--sticky={stickyHeader}
+  class:data-table-container--overflowing={hasHorizontalOverflow}
+  role={hasHorizontalOverflow ? 'region' : undefined}
+  tabindex={hasHorizontalOverflow ? 0 : undefined}
+  aria-label={hasHorizontalOverflow ? overflowRegionLabel : undefined}
+  onkeydown={handleOverflowKeydown}
+  onscroll={updateOverflowState}
+>
   <table
     class="data-table {sizeClasses[size]}"
     class:data-table--striped={striped}
@@ -682,13 +779,40 @@ const sizeClasses = {
       <tfoot><tr><td class="data-table__cell data-table__footer" colspan={columnCount}>{@render footer({ rows: displayRows.map(({ row }) => row) })}</td></tr></tfoot>
     {/if}
   </table>
+  {#if hasHorizontalOverflow}
+    <div class="data-table__overflow-cue" aria-hidden="true">
+      {#if canScrollLeft}<span>← More columns</span>{/if}
+      {#if canScrollRight}<span>More columns →</span>{/if}
+    </div>
+  {/if}
 </div>
 {#if tableState.pageSize && totalPages && totalPages > 1}<Pagination currentPage={tableState.page} {totalPages} onPageChange={handlePageChange} aria-label="Table pages" />{/if}
 
 <style>
   .data-table-container {
+    position: relative;
     width: 100%;
     overflow-x: auto;
+  }
+
+  .data-table-container--overflowing:focus-visible {
+    outline: 2px solid var(--smrt-color-primary, #3b82f6);
+    outline-offset: 2px;
+  }
+
+  .data-table__overflow-cue {
+    position: sticky;
+    left: 0;
+    display: flex;
+    justify-content: space-between;
+    min-width: 100%;
+    padding: var(--smrt-spacing-2, 0.5rem) var(--smrt-spacing-3, 0.75rem);
+    border-top: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
+    background: var(--smrt-color-surface-container-low, #f9fafb);
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+    font-size: var(--smrt-typography-label-small-size, 0.75rem);
+    font-weight: var(--smrt-typography-weight-medium, 500);
+    pointer-events: none;
   }
 
   .data-table-toolbar { margin-bottom: var(--smrt-spacing-2); }

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -566,8 +566,8 @@ const columnCount = $derived(
 );
 const overflowRegionLabel = $derived(
   caption
-    ? `${caption} table, scroll horizontally to view more columns`
-    : 'Data table, scroll horizontally to view more columns',
+    ? t(M['ui.data_table.overflow_region'], { caption })
+    : t(M['ui.data_table.default_overflow_region']),
 );
 
 function getCellValue(row: T, column: DataTableColumn<T>): unknown {
@@ -779,13 +779,13 @@ $effect(() => {
       <tfoot><tr><td class="data-table__cell data-table__footer" colspan={columnCount}>{@render footer({ rows: displayRows.map(({ row }) => row) })}</td></tr></tfoot>
     {/if}
   </table>
-  {#if hasHorizontalOverflow}
-    <div class="data-table__overflow-cue" aria-hidden="true">
-      {#if canScrollLeft}<span>← More columns</span>{/if}
-      {#if canScrollRight}<span>More columns →</span>{/if}
-    </div>
-  {/if}
 </div>
+{#if hasHorizontalOverflow}
+  <div class="data-table__overflow-cue" aria-hidden="true">
+    {#if canScrollLeft}<span>← {t(M['ui.data_table.more_columns'])}</span>{/if}
+    {#if canScrollRight}<span>{t(M['ui.data_table.more_columns'])} →</span>{/if}
+  </div>
+{/if}
 {#if tableState.pageSize && totalPages && totalPages > 1}<Pagination currentPage={tableState.page} {totalPages} onPageChange={handlePageChange} aria-label="Table pages" />{/if}
 
 <style>
@@ -801,11 +801,8 @@ $effect(() => {
   }
 
   .data-table__overflow-cue {
-    position: sticky;
-    left: 0;
     display: flex;
     justify-content: space-between;
-    min-width: 100%;
     padding: var(--smrt-spacing-2, 0.5rem) var(--smrt-spacing-3, 0.75rem);
     border-top: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
     background: var(--smrt-color-surface-container-low, #f9fafb);

--- a/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
@@ -460,8 +460,18 @@ describe('DataTable', () => {
       ).toBe(tableContainer);
       expect(tableContainer).toHaveAttribute('tabindex', '0');
       expect(screen.getByText('More columns →')).toBeVisible();
+      expect(tableContainer).not.toContainElement(
+        screen.getByText('More columns →'),
+      );
     });
     await expectNoA11yViolations(container);
+
+    setHorizontalOverflow(tableContainer, 320, 320);
+    await vi.waitFor(() => {
+      expect(tableContainer).not.toHaveAttribute('role');
+      expect(tableContainer).not.toHaveAttribute('tabindex');
+      expect(screen.queryByText('More columns →')).not.toBeInTheDocument();
+    });
   });
 
   it('scrolls an overflowing narrow table with the keyboard', async () => {

--- a/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
@@ -32,6 +32,19 @@ const data: Person[] = [
   { id: 'linus', name: 'Linus', age: 54 },
 ];
 
+function setHorizontalOverflow(
+  container: HTMLDivElement,
+  clientWidth: number,
+  scrollWidth: number,
+) {
+  Object.defineProperties(container, {
+    clientWidth: { configurable: true, value: clientWidth },
+    scrollWidth: { configurable: true, value: scrollWidth },
+    scrollLeft: { configurable: true, value: 0, writable: true },
+  });
+  window.dispatchEvent(new Event('resize'));
+}
+
 describe('DataTable', () => {
   it('renders caption, headers, cells, and a row per datum', () => {
     render(DataTable, { props: { data, columns, caption: 'People' } });
@@ -424,6 +437,55 @@ describe('DataTable', () => {
       .slice(1)
       .map((row) => within(row).getAllByRole('cell')[0].textContent);
     expect(names).toEqual(['Ada', 'Zed']);
+  });
+
+  it('makes only an overflowing narrow table a named, focusable scroll region', async () => {
+    const { container } = render(DataTable, {
+      props: { data, columns, caption: 'People' },
+    });
+    const tableContainer = container.querySelector(
+      '.data-table-container',
+    ) as HTMLDivElement;
+
+    expect(tableContainer).not.toHaveAttribute('role');
+    expect(tableContainer).not.toHaveAttribute('tabindex');
+
+    setHorizontalOverflow(tableContainer, 320, 960);
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole('region', {
+          name: 'People table, scroll horizontally to view more columns',
+        }),
+      ).toBe(tableContainer);
+      expect(tableContainer).toHaveAttribute('tabindex', '0');
+      expect(screen.getByText('More columns →')).toBeVisible();
+    });
+    await expectNoA11yViolations(container);
+  });
+
+  it('scrolls an overflowing narrow table with the keyboard', async () => {
+    const user = userEvent.setup();
+    const { container } = render(DataTable, {
+      props: { data, columns, caption: 'People' },
+    });
+    const tableContainer = container.querySelector(
+      '.data-table-container',
+    ) as HTMLDivElement;
+    setHorizontalOverflow(tableContainer, 320, 960);
+
+    await vi.waitFor(() =>
+      expect(tableContainer).toHaveAttribute('role', 'region'),
+    );
+    tableContainer.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(tableContainer.scrollLeft).toBe(256);
+    expect(screen.getByText('← More columns')).toBeVisible();
+
+    await user.keyboard('{End}');
+    expect(tableContainer.scrollLeft).toBe(640);
+    await user.keyboard('{Home}');
+    expect(tableContainer.scrollLeft).toBe(0);
   });
 
   it('is axe-clean', async () => {

--- a/packages/smrt-ui/src/i18n/strings.ts
+++ b/packages/smrt-ui/src/i18n/strings.ts
@@ -18,4 +18,9 @@ export const M = defineMessages({
   'ui.data_table.select_row': 'Select row',
   'ui.data_table.loading': 'Loading...',
   'ui.data_table.empty': 'No data available',
+  'ui.data_table.overflow_region':
+    '{caption} table, scroll horizontally to view more columns',
+  'ui.data_table.default_overflow_region':
+    'Data table, scroll horizontally to view more columns',
+  'ui.data_table.more_columns': 'More columns',
 });


### PR DESCRIPTION
<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-issue-2076-accessible-overflow-20260822",
  "issue": 2076,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm --filter @happyvertical/smrt-ui test -- DataTable.test.ts",
    "pnpm --filter @happyvertical/smrt-ui typecheck",
    "pnpm --filter @happyvertical/smrt-ui build",
    "pnpm --filter @happyvertical/smrt-ui verify:pack",
    "pnpm smrt dev:knowledge-check",
    "pnpm audit:policy",
    "pre-push lifecycle hooks"
  ]
}

## Summary
- Name and focus the DataTable overflow wrapper only when horizontal overflow exists.
- Add keyboard horizontal scrolling and a visible localized overflow cue.
- Cover narrow viewport keyboard behavior, overflow transitions, and axe validation.

## Review
- Standard-risk review cycle passed on `bd5f97a4b5e0273033f33a104b65fce9660c3117`.
- Preliminary review found the cue could create overflow; the follow-up commit moves it outside the scroller and adds a regression test.

Closes #2076