### PR TITLE
feat(smrt-ui): add DataTable virtualization seam

### DIFF
--- a/packages/smrt-ui/README.md
+++ b/packages/smrt-ui/README.md
@@ -249,8 +249,10 @@ so the component deliberately falls back to the full semantic body and does
 not emit virtual scroll callbacks. Use controlled `scrollTop`/
 `onScrollTopChange` for scroll restoration, and pair `focusedRowId` with
 `onFocusedRowIdChange` to restore DOM focus to a stable row after a data
-refresh. Selection and expansion continue to be controller state keyed by
-`rowKey`, never by a rendered window index.
+refresh. A measured footer extends the virtual scroll range, so keyboard End
+and a controlled scroll position can still reveal the summary. Selection and
+expansion continue to be controller state keyed by `rowKey`, never by a
+rendered window index.
 
 ## Themes
 

--- a/packages/smrt-ui/README.md
+++ b/packages/smrt-ui/README.md
@@ -242,12 +242,15 @@ renderer comparison does not depend on array-arrival identity.
 `virtualization` is opt-in and requires `rowKey`. It virtualizes only a
 fixed-height data body; table headers (including grouped headers) and the
 `footer` summary remain normal semantic table sections and do not count toward
-the window. Supplying `expandedContent` makes data-row height variable, so the
-component deliberately falls back to the full semantic body. Use controlled
-`scrollTop`/`onScrollTopChange` for scroll restoration, and pair
-`focusedRowId` with `onFocusedRowIdChange` to keep a stable focused row visible
-after a data refresh. Selection and expansion continue to be controller state
-keyed by `rowKey`, never by a rendered window index.
+the window. The virtual scroll region keeps captions and headers sticky, is
+keyboard-scrollable, and reports the full row count plus each rendered row's
+logical row index. Supplying `expandedContent` makes data-row height variable,
+so the component deliberately falls back to the full semantic body and does
+not emit virtual scroll callbacks. Use controlled `scrollTop`/
+`onScrollTopChange` for scroll restoration, and pair `focusedRowId` with
+`onFocusedRowIdChange` to restore DOM focus to a stable row after a data
+refresh. Selection and expansion continue to be controller state keyed by
+`rowKey`, never by a rendered window index.
 
 ## Themes
 

--- a/packages/smrt-ui/README.md
+++ b/packages/smrt-ui/README.md
@@ -223,6 +223,32 @@ the value changes. Data or total changes clamp an out-of-range page but do not
 otherwise reset it; empty known totals normalize to page 1. Column layout,
 selection, and expansion never change the page.
 
+### Scale boundaries and virtualization
+
+`DATA_TABLE_SCALE_THRESHOLDS` publishes the measured operating boundaries used
+by the reproducible DataTable benchmark:
+
+| Work | Boundary | Use after the boundary |
+| --- | --- | --- |
+| Ordinary local rendering | 250 rows / 5,000 cells | Page or virtualize the body. |
+| Local filtering and sorting | 1,000 rows / 20,000 cells | Move the transform to the caller or server. |
+| Manual/server paging | 100 supplied rows per page | Keep `totalRows` server-owned and bounded. |
+
+Run `pnpm --filter @happyvertical/smrt-ui bench:data-table` to measure the
+250-row local render, 1,000-row client-transform, and 100-row manual-paging
+fixtures. The fixture data has deterministic `rowKey` values so a browser or
+renderer comparison does not depend on array-arrival identity.
+
+`virtualization` is opt-in and requires `rowKey`. It virtualizes only a
+fixed-height data body; table headers (including grouped headers) and the
+`footer` summary remain normal semantic table sections and do not count toward
+the window. Supplying `expandedContent` makes data-row height variable, so the
+component deliberately falls back to the full semantic body. Use controlled
+`scrollTop`/`onScrollTopChange` for scroll restoration, and pair
+`focusedRowId` with `onFocusedRowIdChange` to keep a stable focused row visible
+after a data refresh. Selection and expansion continue to be controller state
+keyed by `rowKey`, never by a rendered window index.
+
 ## Themes
 
 `@happyvertical/smrt-ui/themes` is the canonical theme API and includes the

--- a/packages/smrt-ui/README.md
+++ b/packages/smrt-ui/README.md
@@ -252,7 +252,8 @@ not emit virtual scroll callbacks. Use controlled `scrollTop`/
 refresh. A measured footer extends the virtual scroll range, so keyboard End
 and a controlled scroll position can still reveal the summary. Selection and
 expansion continue to be controller state keyed by `rowKey`, never by a
-rendered window index.
+rendered window index. With manual pagination, `totalRows` and the current page
+set that full row count and each rendered row's global index.
 
 ## Themes
 

--- a/packages/smrt-ui/package.json
+++ b/packages/smrt-ui/package.json
@@ -106,6 +106,7 @@
     "build": "svelte-package -i src --tsconfig tsconfig.svelte.json",
     "dev": "svelte-package -i src --watch",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
+    "bench:data-table": "vitest bench src/components/data/__benchmarks__/DataTable.bench.ts",
     "generate:themes": "tsx scripts/generate-theme-styles.ts",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -651,11 +651,9 @@ $effect(() => {
   setVirtualScrollTop(nextScrollTop, virtualization.scrollTop !== undefined);
   const focusContainer = tableContainer;
   void tick().then(() => {
-    const focusedRow = [
-      ...focusContainer.querySelectorAll<HTMLTableRowElement>(
-        'tr[data-row-id]',
-      ),
-    ].find((row) => row.dataset.rowId === dataTableRowIdKey(focusRowId));
+    const focusedRow = Array.from(
+      focusContainer.querySelectorAll<HTMLTableRowElement>('tr[data-row-id]'),
+    ).find((row) => row.dataset.rowId === dataTableRowIdKey(focusRowId));
     focusedRow?.focus({ preventScroll: true });
   });
 });

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -11,7 +11,7 @@
  * - Material 3 styling with theme token support
  */
 
-import type { Snippet } from 'svelte';
+import { type Snippet, tick } from 'svelte';
 import { M } from '../../i18n/strings.js';
 import Trans from '../../i18n/Trans.svelte';
 import { useI18n } from '../../i18n/use-i18n.js';
@@ -531,7 +531,14 @@ const displayRows = $derived.by(() => {
 });
 
 let tableContainer: HTMLDivElement | undefined = $state();
+let tableCaption: HTMLTableCaptionElement | undefined = $state();
+let tableHead: HTMLTableSectionElement | undefined = $state();
+let tableBody: HTMLTableSectionElement | undefined = $state();
 let virtualScrollTop = $state(0);
+let virtualStructuralHeight = $state(0);
+let virtualCaptionHeight = $state(0);
+
+const virtualizedBody = $derived(Boolean(virtualization) && !expandedContent);
 
 const virtualizationWindow = $derived.by(() =>
   resolveDataTableVirtualWindow({
@@ -549,12 +556,63 @@ const renderedRows = $derived.by(() =>
     virtualizationWindow.endIndex,
   ),
 );
+const virtualContainerHeight = $derived(
+  virtualizedBody && virtualization
+    ? virtualization.viewportHeight + virtualStructuralHeight
+    : undefined,
+);
+
+function clampVirtualScrollTop(nextScrollTop: number): number {
+  if (!virtualization) return 0;
+  const maximum = Math.max(
+    0,
+    displayRows.length * virtualization.rowHeight -
+      virtualization.viewportHeight,
+  );
+  return Math.min(Math.max(0, nextScrollTop), maximum);
+}
+
+function setVirtualScrollTop(nextScrollTop: number, notify = false) {
+  if (!virtualization || !tableContainer || !virtualizedBody) return;
+  const clampedScrollTop = clampVirtualScrollTop(nextScrollTop);
+  tableContainer.scrollTop = clampedScrollTop;
+  virtualScrollTop = clampedScrollTop;
+  if (notify) virtualization.onScrollTopChange?.(clampedScrollTop);
+}
 
 function handleTableScroll(event: Event) {
-  if (!virtualization) return;
+  if (!virtualizationWindow.enabled) return;
   const nextScrollTop = (event.currentTarget as HTMLDivElement).scrollTop;
-  virtualScrollTop = nextScrollTop;
-  virtualization.onScrollTopChange?.(nextScrollTop);
+  const clampedScrollTop = clampVirtualScrollTop(nextScrollTop);
+  virtualScrollTop = clampedScrollTop;
+  virtualization?.onScrollTopChange?.(clampedScrollTop);
+}
+
+function handleVirtualizationKeydown(event: KeyboardEvent) {
+  if (!virtualizationWindow.enabled || !virtualization || !tableContainer)
+    return;
+  const pageStep = Math.max(
+    virtualization.rowHeight,
+    virtualization.viewportHeight - virtualization.rowHeight,
+  );
+  const currentScrollTop = tableContainer.scrollTop;
+  const nextScrollTop =
+    event.key === 'ArrowDown'
+      ? currentScrollTop + virtualization.rowHeight
+      : event.key === 'ArrowUp'
+        ? currentScrollTop - virtualization.rowHeight
+        : event.key === 'PageDown'
+          ? currentScrollTop + pageStep
+          : event.key === 'PageUp'
+            ? currentScrollTop - pageStep
+            : event.key === 'Home'
+              ? 0
+              : event.key === 'End'
+                ? Number.POSITIVE_INFINITY
+                : undefined;
+  if (nextScrollTop === undefined) return;
+  event.preventDefault();
+  setVirtualScrollTop(nextScrollTop, true);
 }
 
 function handleRowFocus(rowId: DataTableRowId) {
@@ -562,34 +620,60 @@ function handleRowFocus(rowId: DataTableRowId) {
 }
 
 $effect(() => {
-  if (!virtualization || !tableContainer) return;
-  const currentScrollTop = virtualization.scrollTop ?? virtualScrollTop;
+  if (!virtualizedBody || !tableContainer) return;
+  const controlledScrollTop = virtualization?.scrollTop;
+  if (controlledScrollTop !== undefined) {
+    setVirtualScrollTop(controlledScrollTop);
+  }
+});
+
+$effect(() => {
+  if (!virtualizedBody || !virtualization || !tableContainer) return;
   const focusRowId = virtualization.focusedRowId;
   const focusIndex =
     focusRowId == null
       ? -1
       : displayRows.findIndex(({ rowId }) => rowId === focusRowId);
-  const nextScrollTop =
-    focusIndex >= 0
-      ? scrollTopForDataTableRow(
-          focusIndex,
-          displayRows.length,
-          virtualization,
-          currentScrollTop,
-        )
-      : currentScrollTop;
-  if (tableContainer.scrollTop !== nextScrollTop) {
-    tableContainer.scrollTop = nextScrollTop;
-    if (virtualization.scrollTop !== undefined) {
-      virtualization.onScrollTopChange?.(nextScrollTop);
-    }
+  if (focusIndex < 0 || focusRowId == null) return;
+  const nextScrollTop = scrollTopForDataTableRow(
+    focusIndex,
+    displayRows.length,
+    virtualization,
+    tableContainer.scrollTop,
+  );
+  setVirtualScrollTop(nextScrollTop, virtualization.scrollTop !== undefined);
+  const focusContainer = tableContainer;
+  void tick().then(() => {
+    const focusedRow = [
+      ...focusContainer.querySelectorAll<HTMLTableRowElement>(
+        'tr[data-row-id]',
+      ),
+    ].find((row) => row.dataset.rowId === String(focusRowId));
+    focusedRow?.focus({ preventScroll: true });
+  });
+});
+
+$effect(() => {
+  if (!virtualizedBody || !tableBody) {
+    virtualStructuralHeight = 0;
+    virtualCaptionHeight = 0;
+    return;
   }
-  if (
-    virtualization.scrollTop === undefined &&
-    virtualScrollTop !== nextScrollTop
-  ) {
-    virtualScrollTop = nextScrollTop;
-  }
+
+  const body = tableBody;
+  const captionElement = tableCaption;
+  const head = tableHead;
+  const measureStructure = () => {
+    virtualStructuralHeight = body.offsetTop;
+    virtualCaptionHeight = captionElement?.offsetHeight ?? 0;
+  };
+  measureStructure();
+  if (typeof ResizeObserver === 'undefined') return;
+
+  const observer = new ResizeObserver(measureStructure);
+  if (captionElement) observer.observe(captionElement);
+  if (head) observer.observe(head);
+  return () => observer.disconnect();
 });
 
 $effect(() => {
@@ -676,20 +760,26 @@ $effect(() => {
 <div
   bind:this={tableContainer}
   class="data-table-container"
-  class:data-table-container--sticky={stickyHeader}
+  class:data-table-container--sticky={stickyHeader || virtualizedBody}
   class:data-table-container--overflowing={hasHorizontalOverflow}
   class:data-table-container--virtualized={virtualizationWindow.enabled}
-  style:height={virtualizationWindow.enabled ? `${virtualization?.viewportHeight}px` : undefined}
-  role={virtualizationWindow.enabled || hasHorizontalOverflow ? 'region' : undefined}
+  style:height={virtualContainerHeight === undefined ? undefined : `${virtualContainerHeight}px`}
   tabindex={virtualizationWindow.enabled || hasHorizontalOverflow ? 0 : undefined}
-  aria-label={virtualizationWindow.enabled ? 'Data table rows' : hasHorizontalOverflow ? overflowRegionLabel : undefined}
-  onkeydown={(event) => {
-    handleOverflowKeydown(event);
-    handleVirtualizationKeydown(event);
-  }}
+  role={virtualizationWindow.enabled || hasHorizontalOverflow ? 'region' : undefined}
+  aria-label={virtualizationWindow.enabled
+    ? caption
+      ? `${caption} rows`
+      : 'Data table rows'
+    : hasHorizontalOverflow
+      ? overflowRegionLabel
+      : undefined}
   onscroll={(event) => {
     updateOverflowState();
     handleTableScroll(event);
+  }}
+  onkeydown={(event) => {
+    handleVirtualizationKeydown(event);
+    if (!event.defaultPrevented) handleOverflowKeydown(event);
   }}
 >
   <table
@@ -698,12 +788,16 @@ $effect(() => {
     class:data-table--hoverable={hoverable}
     class:data-table--dense={dense}
     class:data-table--loading={loading}
+    aria-rowcount={virtualizationWindow.enabled
+      ? displayRows.length + 1 + (footer ? 1 : 0)
+      : undefined}
+    style={`--data-table-caption-height: ${virtualCaptionHeight}px`}
   >
     {#if caption}
-      <caption class="data-table__caption">{caption}</caption>
+      <caption bind:this={tableCaption} class="data-table__caption">{caption}</caption>
     {/if}
 
-    <thead class="data-table__head">
+    <thead bind:this={tableHead} class="data-table__head">
       <tr class="data-table__row data-table__row--header">
         {#if expandedContent}<th class="data-table__cell data-table__cell--expand" scope="col"><span class="sr-only">Expand</span></th>{/if}
         {#if selectable}
@@ -760,7 +854,7 @@ $effect(() => {
       </tr>
     </thead>
 
-    <tbody class="data-table__body">
+    <tbody bind:this={tableBody} class="data-table__body">
       {#if loading}
         <tr class="data-table__row data-table__row--loading">
           <td
@@ -805,9 +899,10 @@ $effect(() => {
             class="data-table__row {rowClass?.(row, displayIndex) ?? ''}"
             class:data-table__row--selected={isSelected}
             data-row-id={key}
+            aria-rowindex={virtualizationWindow.enabled ? displayIndex + 2 : undefined}
             onclick={() => handleRowClick(row, displayIndex)}
             role={onRowClick ? 'button' : undefined}
-            tabindex={onRowClick ? 0 : undefined}
+            tabindex={onRowClick || virtualizationWindow.enabled ? 0 : undefined}
             onfocusin={() => handleRowFocus(key)}
             onkeydown={(e) => {
               if (onRowClick && (e.key === 'Enter' || e.key === ' ')) {
@@ -911,6 +1006,19 @@ $effect(() => {
 
   .data-table-container--virtualized {
     overflow: auto;
+  }
+
+  /* Keep structural context fixed so scrollTop is measured from data row zero. */
+  .data-table-container--virtualized .data-table__caption {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+  }
+
+  .data-table-container--virtualized .data-table__head {
+    position: sticky;
+    top: var(--data-table-caption-height, 0px);
+    z-index: 1;
   }
 
   .data-table {
@@ -1018,6 +1126,11 @@ $effect(() => {
   }
 
   .data-table__row[role='button']:focus-visible {
+    outline: 2px solid var(--smrt-color-primary, #3b82f6);
+    outline-offset: -2px;
+  }
+
+  .data-table-container--virtualized .data-table__row:focus-visible {
     outline: 2px solid var(--smrt-color-primary, #3b82f6);
     outline-offset: -2px;
   }

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -27,9 +27,11 @@ import {
   type DataTableSnapshot,
   type DataTableViewState,
   type DataTableViewStateInput,
+  dataTableRowIdKey,
 } from './DataTableController.js';
 import { resolveDataTableRows } from './DataTableIdentity.js';
 import {
+  maximumDataTableVirtualScrollTop,
   resolveDataTableVirtualWindow,
   scrollTopForDataTableRow,
 } from './DataTableVirtualization.js';
@@ -534,9 +536,11 @@ let tableContainer: HTMLDivElement | undefined = $state();
 let tableCaption: HTMLTableCaptionElement | undefined = $state();
 let tableHead: HTMLTableSectionElement | undefined = $state();
 let tableBody: HTMLTableSectionElement | undefined = $state();
+let tableFooter: HTMLTableSectionElement | undefined = $state();
 let virtualScrollTop = $state(0);
 let virtualStructuralHeight = $state(0);
 let virtualCaptionHeight = $state(0);
+let virtualFooterHeight = $state(0);
 
 const virtualizedBody = $derived(Boolean(virtualization) && !expandedContent);
 
@@ -566,8 +570,11 @@ function clampVirtualScrollTop(nextScrollTop: number): number {
   if (!virtualization) return 0;
   const maximum = Math.max(
     0,
-    displayRows.length * virtualization.rowHeight -
-      virtualization.viewportHeight,
+    maximumDataTableVirtualScrollTop(
+      displayRows.length,
+      virtualization,
+      virtualFooterHeight,
+    ),
   );
   return Math.min(Math.max(0, nextScrollTop), maximum);
 }
@@ -648,7 +655,7 @@ $effect(() => {
       ...focusContainer.querySelectorAll<HTMLTableRowElement>(
         'tr[data-row-id]',
       ),
-    ].find((row) => row.dataset.rowId === String(focusRowId));
+    ].find((row) => row.dataset.rowId === dataTableRowIdKey(focusRowId));
     focusedRow?.focus({ preventScroll: true });
   });
 });
@@ -657,15 +664,18 @@ $effect(() => {
   if (!virtualizedBody || !tableBody) {
     virtualStructuralHeight = 0;
     virtualCaptionHeight = 0;
+    virtualFooterHeight = 0;
     return;
   }
 
   const body = tableBody;
   const captionElement = tableCaption;
   const head = tableHead;
+  const footerElement = tableFooter;
   const measureStructure = () => {
     virtualStructuralHeight = body.offsetTop;
     virtualCaptionHeight = captionElement?.offsetHeight ?? 0;
+    virtualFooterHeight = footerElement?.offsetHeight ?? 0;
   };
   measureStructure();
   if (typeof ResizeObserver === 'undefined') return;
@@ -673,6 +683,7 @@ $effect(() => {
   const observer = new ResizeObserver(measureStructure);
   if (captionElement) observer.observe(captionElement);
   if (head) observer.observe(head);
+  if (footerElement) observer.observe(footerElement);
   return () => observer.disconnect();
 });
 
@@ -785,6 +796,7 @@ $effect(() => {
   <table
     class="data-table {sizeClasses[size]}"
     class:data-table--striped={striped}
+    class:data-table--virtualized={virtualizationWindow.enabled}
     class:data-table--hoverable={hoverable}
     class:data-table--dense={dense}
     class:data-table--loading={loading}
@@ -898,7 +910,10 @@ $effect(() => {
           <tr
             class="data-table__row {rowClass?.(row, displayIndex) ?? ''}"
             class:data-table__row--selected={isSelected}
-            data-row-id={key}
+            class:data-table__row--striped={
+              virtualizationWindow.enabled && striped && displayIndex % 2 === 1
+            }
+            data-row-id={dataTableRowIdKey(key)}
             aria-rowindex={virtualizationWindow.enabled ? displayIndex + 2 : undefined}
             onclick={() => handleRowClick(row, displayIndex)}
             role={onRowClick ? 'button' : undefined}
@@ -959,7 +974,7 @@ $effect(() => {
       {/if}
     </tbody>
     {#if footer}
-      <tfoot><tr><td class="data-table__cell data-table__footer" colspan={columnCount}>{@render footer({ rows: displayRows.map(({ row }) => row) })}</td></tr></tfoot>
+      <tfoot bind:this={tableFooter}><tr><td class="data-table__cell data-table__footer" colspan={columnCount}>{@render footer({ rows: displayRows.map(({ row }) => row) })}</td></tr></tfoot>
     {/if}
   </table>
 </div>
@@ -1117,7 +1132,8 @@ $effect(() => {
     background: var(--smrt-color-primary-container, #dbeafe) !important;
   }
 
-  .data-table--striped .data-table__row:nth-child(even) {
+  .data-table--striped:not(.data-table--virtualized) .data-table__row:nth-child(even),
+  .data-table__row--striped {
     background: var(--smrt-color-surface-container-lowest, #fafafa);
   }
 

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -560,6 +560,12 @@ const renderedRows = $derived.by(() =>
     virtualizationWindow.endIndex,
   ),
 );
+const virtualRowCount = $derived(totalRowCount ?? displayRows.length);
+const virtualRowOffset = $derived(
+  tableModes.pagination === 'manual' && tableState.pageSize
+    ? (tableState.page - 1) * tableState.pageSize
+    : 0,
+);
 const virtualContainerHeight = $derived(
   virtualizedBody && virtualization
     ? virtualization.viewportHeight + virtualStructuralHeight
@@ -799,7 +805,7 @@ $effect(() => {
     class:data-table--dense={dense}
     class:data-table--loading={loading}
     aria-rowcount={virtualizationWindow.enabled
-      ? displayRows.length + 1 + (footer ? 1 : 0)
+      ? virtualRowCount + 1 + (footer ? 1 : 0)
       : undefined}
     style={`--data-table-caption-height: ${virtualCaptionHeight}px`}
   >
@@ -912,7 +918,9 @@ $effect(() => {
               virtualizationWindow.enabled && striped && displayIndex % 2 === 1
             }
             data-row-id={dataTableRowIdKey(key)}
-            aria-rowindex={virtualizationWindow.enabled ? displayIndex + 2 : undefined}
+            aria-rowindex={virtualizationWindow.enabled
+              ? virtualRowOffset + displayIndex + 2
+              : undefined}
             onclick={() => handleRowClick(row, displayIndex)}
             role={onRowClick ? 'button' : undefined}
             tabindex={onRowClick || virtualizationWindow.enabled ? 0 : undefined}

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -29,6 +29,10 @@ import {
   type DataTableViewStateInput,
 } from './DataTableController.js';
 import { resolveDataTableRows } from './DataTableIdentity.js';
+import {
+  resolveDataTableVirtualWindow,
+  scrollTopForDataTableRow,
+} from './DataTableVirtualization.js';
 import type { DataTableColumn, DataTableProps, SortState } from './types.js';
 import { defaultSort, getNestedValue } from './types.js';
 
@@ -58,6 +62,7 @@ let {
   page = $bindable(1),
   pageSize,
   manualPagination = false,
+  virtualization,
   totalRows,
   onPageChange,
   expanded = $bindable(new Set<string | number>()),
@@ -123,7 +128,6 @@ const localController = createDataTableController({
 let controllerSnapshot = $state<DataTableSnapshot>(localController.snapshot());
 let publishedLegacySignature: string | undefined;
 let localControllerInitialized = false;
-let tableContainer = $state<HTMLDivElement>();
 let hasHorizontalOverflow = $state(false);
 let canScrollLeft = $state(false);
 let canScrollRight = $state(false);
@@ -244,7 +248,8 @@ const requiresStableRowIdentity = $derived(
     agentAddressable ||
     tableModes.filtering === 'manual' ||
     tableModes.sorting === 'manual' ||
-    tableModes.pagination === 'manual',
+    tableModes.pagination === 'manual' ||
+    Boolean(virtualization),
 );
 const sourceRows = $derived.by(() =>
   resolveDataTableRows(data, rowKey, {
@@ -525,6 +530,68 @@ const displayRows = $derived.by(() => {
   return sortedRows.slice(start, start + tableState.pageSize);
 });
 
+let tableContainer: HTMLDivElement | undefined = $state();
+let virtualScrollTop = $state(0);
+
+const virtualizationWindow = $derived.by(() =>
+  resolveDataTableVirtualWindow({
+    options: virtualization,
+    rowCount: displayRows.length,
+    scrollTop: virtualization?.scrollTop ?? virtualScrollTop,
+    hasVariableRowHeight: Boolean(expandedContent),
+    headerRowCount: 1,
+    summaryRowCount: footer ? 1 : 0,
+  }),
+);
+const renderedRows = $derived.by(() =>
+  displayRows.slice(
+    virtualizationWindow.startIndex,
+    virtualizationWindow.endIndex,
+  ),
+);
+
+function handleTableScroll(event: Event) {
+  if (!virtualization) return;
+  const nextScrollTop = (event.currentTarget as HTMLDivElement).scrollTop;
+  virtualScrollTop = nextScrollTop;
+  virtualization.onScrollTopChange?.(nextScrollTop);
+}
+
+function handleRowFocus(rowId: DataTableRowId) {
+  virtualization?.onFocusedRowIdChange?.(rowId);
+}
+
+$effect(() => {
+  if (!virtualization || !tableContainer) return;
+  const currentScrollTop = virtualization.scrollTop ?? virtualScrollTop;
+  const focusRowId = virtualization.focusedRowId;
+  const focusIndex =
+    focusRowId == null
+      ? -1
+      : displayRows.findIndex(({ rowId }) => rowId === focusRowId);
+  const nextScrollTop =
+    focusIndex >= 0
+      ? scrollTopForDataTableRow(
+          focusIndex,
+          displayRows.length,
+          virtualization,
+          currentScrollTop,
+        )
+      : currentScrollTop;
+  if (tableContainer.scrollTop !== nextScrollTop) {
+    tableContainer.scrollTop = nextScrollTop;
+    if (virtualization.scrollTop !== undefined) {
+      virtualization.onScrollTopChange?.(nextScrollTop);
+    }
+  }
+  if (
+    virtualization.scrollTop === undefined &&
+    virtualScrollTop !== nextScrollTop
+  ) {
+    virtualScrollTop = nextScrollTop;
+  }
+});
+
 $effect(() => {
   const total = totalRows;
   if (total === undefined) return;
@@ -605,17 +672,25 @@ $effect(() => {
 </script>
 
 {#if toolbar}<div class="data-table-toolbar">{@render toolbar()}</div>{/if}
-<!-- svelte-ignore a11y_no_noninteractive_tabindex: the region is only focusable while it overflows. -->
+<!-- svelte-ignore a11y_no_noninteractive_tabindex: the region provides horizontal or virtual keyboard scrolling. -->
 <div
   bind:this={tableContainer}
   class="data-table-container"
   class:data-table-container--sticky={stickyHeader}
   class:data-table-container--overflowing={hasHorizontalOverflow}
-  role={hasHorizontalOverflow ? 'region' : undefined}
-  tabindex={hasHorizontalOverflow ? 0 : undefined}
-  aria-label={hasHorizontalOverflow ? overflowRegionLabel : undefined}
-  onkeydown={handleOverflowKeydown}
-  onscroll={updateOverflowState}
+  class:data-table-container--virtualized={virtualizationWindow.enabled}
+  style:height={virtualizationWindow.enabled ? `${virtualization?.viewportHeight}px` : undefined}
+  role={virtualizationWindow.enabled || hasHorizontalOverflow ? 'region' : undefined}
+  tabindex={virtualizationWindow.enabled || hasHorizontalOverflow ? 0 : undefined}
+  aria-label={virtualizationWindow.enabled ? 'Data table rows' : hasHorizontalOverflow ? overflowRegionLabel : undefined}
+  onkeydown={(event) => {
+    handleOverflowKeydown(event);
+    handleVirtualizationKeydown(event);
+  }}
+  onscroll={(event) => {
+    updateOverflowState();
+    handleTableScroll(event);
+  }}
 >
   <table
     class="data-table {sizeClasses[size]}"
@@ -714,22 +789,30 @@ $effect(() => {
           </td>
         </tr>
       {:else}
-        {#each displayRows as entry, index (entry.rowId)}
+        {#if virtualizationWindow.topSpacerHeight > 0}
+          <tr class="data-table__virtual-spacer" aria-hidden="true">
+            <td colspan={columnCount} style:height={`${virtualizationWindow.topSpacerHeight}px`}></td>
+          </tr>
+        {/if}
+        {#each renderedRows as entry, index (entry.rowId)}
           {@const row = entry.row}
           {@const key = entry.rowId}
+          {@const displayIndex = virtualizationWindow.startIndex + index}
           {@const isSelected = tableState.selection.scope === 'allMatching' || selectedIds.has(key)}
           {@const isExpanded = expandedIds.has(key)}
-          {@const rowCanExpand = canExpand?.(row, index) ?? true}
+          {@const rowCanExpand = canExpand?.(row, displayIndex) ?? true}
           <tr
-            class="data-table__row {rowClass?.(row, index) ?? ''}"
+            class="data-table__row {rowClass?.(row, displayIndex) ?? ''}"
             class:data-table__row--selected={isSelected}
-            onclick={() => handleRowClick(row, index)}
+            data-row-id={key}
+            onclick={() => handleRowClick(row, displayIndex)}
             role={onRowClick ? 'button' : undefined}
             tabindex={onRowClick ? 0 : undefined}
+            onfocusin={() => handleRowFocus(key)}
             onkeydown={(e) => {
               if (onRowClick && (e.key === 'Enter' || e.key === ' ')) {
                 e.preventDefault();
-                handleRowClick(row, index);
+                handleRowClick(row, displayIndex);
               }
             }}
           >
@@ -758,9 +841,9 @@ $effect(() => {
                 style:text-align={column.align}
               >
                 {#if cell}
-                  {@render cell({ column, row, value, index })}
+                  {@render cell({ column, row, value, index: displayIndex })}
                 {:else if column.cell}
-                  {@render column.cell({ row, value, index })}
+                  {@render column.cell({ row, value, index: displayIndex })}
                 {:else}
                   {value ?? ''}
                 {/if}
@@ -769,10 +852,15 @@ $effect(() => {
           </tr>
           {#if expandedContent && isExpanded}
             <tr class="data-table__row data-table__row--expanded">
-              <td class="data-table__cell data-table__cell--expanded" colspan={columnCount}>{@render expandedContent({ row, index })}</td>
+              <td class="data-table__cell data-table__cell--expanded" colspan={columnCount}>{@render expandedContent({ row, index: displayIndex })}</td>
             </tr>
           {/if}
         {/each}
+        {#if virtualizationWindow.bottomSpacerHeight > 0}
+          <tr class="data-table__virtual-spacer" aria-hidden="true">
+            <td colspan={columnCount} style:height={`${virtualizationWindow.bottomSpacerHeight}px`}></td>
+          </tr>
+        {/if}
       {/if}
     </tbody>
     {#if footer}
@@ -819,6 +907,10 @@ $effect(() => {
   .data-table-container--sticky {
     max-height: 100%;
     overflow-y: auto;
+  }
+
+  .data-table-container--virtualized {
+    overflow: auto;
   }
 
   .data-table {
@@ -902,6 +994,11 @@ $effect(() => {
   .data-table__row {
     border-bottom: 1px solid var(--smrt-color-outline-variant, #e5e7eb);
     transition: background-color var(--smrt-duration-fast, 150ms) var(--smrt-easing-standard, ease);
+  }
+
+  .data-table__virtual-spacer td {
+    padding: 0;
+    border: 0;
   }
 
   .data-table--hoverable .data-table__row:hover:not(.data-table__row--loading):not(.data-table__row--empty) {

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -1015,7 +1015,7 @@ $effect(() => {
     z-index: 2;
   }
 
-  .data-table-container--virtualized .data-table__head {
+  .data-table-container--sticky.data-table-container--virtualized .data-table__head {
     position: sticky;
     top: var(--data-table-caption-height, 0px);
     z-index: 1;

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -980,7 +980,7 @@ $effect(() => {
       {/if}
     </tbody>
     {#if footer}
-      <tfoot bind:this={tableFooter}><tr><td class="data-table__cell data-table__footer" colspan={columnCount}>{@render footer({ rows: displayRows.map(({ row }) => row) })}</td></tr></tfoot>
+      <tfoot bind:this={tableFooter}><tr aria-rowindex={virtualizationWindow.enabled ? virtualRowCount + 2 : undefined}><td class="data-table__cell data-table__footer" colspan={columnCount}>{@render footer({ rows: displayRows.map(({ row }) => row) })}</td></tr></tfoot>
     {/if}
   </table>
 </div>

--- a/packages/smrt-ui/src/components/data/DataTablePerformance.ts
+++ b/packages/smrt-ui/src/components/data/DataTablePerformance.ts
@@ -1,0 +1,66 @@
+/**
+ * Published, testable scale guidance for the DataTable pipeline.
+ *
+ * These are interaction thresholds, not hard data limits. Use the benchmark
+ * fixture before raising them for a new renderer, browser target, or cell shape.
+ */
+export const DATA_TABLE_SCALE_THRESHOLDS = {
+  localRender: {
+    maxRows: 250,
+    maxCells: 5_000,
+    recommendation:
+      'Use normal semantic rendering for ordinary, bounded result sets.',
+  },
+  clientTransforms: {
+    maxRows: 1_000,
+    maxCells: 20_000,
+    recommendation:
+      'Use manual filtering, sorting, or paging once a client transform exceeds this budget.',
+  },
+  manualPaging: {
+    recommendedPageSize: 100,
+    maxRenderedRows: 250,
+    recommendation:
+      'Keep remote pages bounded and pass totalRows only for a known server total.',
+  },
+  virtualization: {
+    minRows: 250,
+    recommendation:
+      'Use fixed-height virtualization for continuous browsing above the local render budget; preserve stable rowKey values and retain remote paging for unbounded data.',
+  },
+} as const;
+
+export type DataTableScaleStrategy =
+  | 'local'
+  | 'manual-paging'
+  | 'virtualization';
+
+/** Returns the recommended rendering strategy for a known row and column count. */
+export function recommendDataTableScaleStrategy(
+  rowCount: number,
+  columnCount: number,
+): DataTableScaleStrategy {
+  if (
+    !Number.isInteger(rowCount) ||
+    !Number.isInteger(columnCount) ||
+    rowCount < 0 ||
+    columnCount < 0
+  ) {
+    throw new TypeError('DataTable scale counts must be non-negative integers');
+  }
+
+  const cells = rowCount * columnCount;
+  if (
+    rowCount <= DATA_TABLE_SCALE_THRESHOLDS.localRender.maxRows &&
+    cells <= DATA_TABLE_SCALE_THRESHOLDS.localRender.maxCells
+  ) {
+    return 'local';
+  }
+  if (
+    rowCount > DATA_TABLE_SCALE_THRESHOLDS.clientTransforms.maxRows ||
+    cells > DATA_TABLE_SCALE_THRESHOLDS.clientTransforms.maxCells
+  ) {
+    return 'manual-paging';
+  }
+  return 'virtualization';
+}

--- a/packages/smrt-ui/src/components/data/DataTableVirtualization.ts
+++ b/packages/smrt-ui/src/components/data/DataTableVirtualization.ts
@@ -18,7 +18,10 @@ export interface DataTableVirtualizationOptions {
   overscan?: number;
   /** Controlled scroll position, used to restore a table after remounting. */
   scrollTop?: number;
-  /** Receives the current scroll position from the virtualized table body. */
+  /**
+   * Receives the current virtual scroll position. When a footer is present,
+   * its measured height extends the range so it remains reachable.
+   */
   onScrollTopChange?: (scrollTop: number) => void;
   /**
    * A stable row id that must remain visible. Use this with
@@ -84,6 +87,29 @@ function clampScrollTop(
   return Math.min(
     Math.max(0, scrollTop),
     Math.max(0, totalBodyHeight - viewportHeight),
+  );
+}
+
+/**
+ * Returns the maximum scroll position for a virtual body and an optional
+ * measured summary footer. Header and caption height are outside this range.
+ */
+export function maximumDataTableVirtualScrollTop(
+  rowCount: number,
+  options: Pick<DataTableVirtualizationOptions, 'rowHeight' | 'viewportHeight'>,
+  footerHeight = 0,
+): number {
+  assertNonNegativeInteger(rowCount, 'rowCount');
+  assertPositiveFinite(options.rowHeight, 'rowHeight');
+  assertPositiveFinite(options.viewportHeight, 'viewportHeight');
+  if (!Number.isFinite(footerHeight) || footerHeight < 0) {
+    throw new TypeError(
+      'DataTable virtualization footerHeight must be a non-negative finite number',
+    );
+  }
+  return Math.max(
+    0,
+    rowCount * options.rowHeight - options.viewportHeight + footerHeight,
   );
 }
 

--- a/packages/smrt-ui/src/components/data/DataTableVirtualization.ts
+++ b/packages/smrt-ui/src/components/data/DataTableVirtualization.ts
@@ -9,7 +9,10 @@ import type { DataTableRowId } from './DataTableController.js';
 export interface DataTableVirtualizationOptions {
   /** The measured, fixed height of each data row in CSS pixels. */
   rowHeight: number;
-  /** The visible height of the scrolling data viewport in CSS pixels. */
+  /**
+   * The visible height of the scrolling data viewport in CSS pixels. The
+   * component adds measured caption and header height around this body region.
+   */
   viewportHeight: number;
   /** Extra rows rendered before and after the visible range. Defaults to 3. */
   overscan?: number;

--- a/packages/smrt-ui/src/components/data/DataTableVirtualization.ts
+++ b/packages/smrt-ui/src/components/data/DataTableVirtualization.ts
@@ -1,0 +1,206 @@
+import type { DataTableRowId } from './DataTableController.js';
+
+/**
+ * Fixed-height virtualization configuration for the DataTable body.
+ *
+ * Header groups and summary rows remain normal table sections and are not
+ * included in the virtual row count. Body rows must have a fixed height.
+ */
+export interface DataTableVirtualizationOptions {
+  /** The measured, fixed height of each data row in CSS pixels. */
+  rowHeight: number;
+  /** The visible height of the scrolling data viewport in CSS pixels. */
+  viewportHeight: number;
+  /** Extra rows rendered before and after the visible range. Defaults to 3. */
+  overscan?: number;
+  /** Controlled scroll position, used to restore a table after remounting. */
+  scrollTop?: number;
+  /** Receives the current scroll position from the virtualized table body. */
+  onScrollTopChange?: (scrollTop: number) => void;
+  /**
+   * A stable row id that must remain visible. Use this with
+   * `onFocusedRowIdChange` to restore keyboard focus after a data refresh.
+   */
+  focusedRowId?: DataTableRowId | null;
+  /** Receives the stable id of a row when focus enters that row. */
+  onFocusedRowIdChange?: (rowId: DataTableRowId) => void;
+}
+
+export type DataTableVirtualizationReason = 'disabled' | 'variable-row-height';
+
+export interface DataTableVirtualizationContext {
+  options?: DataTableVirtualizationOptions;
+  rowCount: number;
+  scrollTop: number;
+  /** Expansion and body group rows produce variable heights and disable the window. */
+  hasVariableRowHeight?: boolean;
+  /** Structural header rows, including grouped headers. Excluded from the window. */
+  headerRowCount?: number;
+  /** Structural summary rows. Excluded from the window. */
+  summaryRowCount?: number;
+}
+
+export interface DataTableVirtualWindow {
+  enabled: boolean;
+  reason?: DataTableVirtualizationReason;
+  startIndex: number;
+  endIndex: number;
+  topSpacerHeight: number;
+  bottomSpacerHeight: number;
+  totalBodyHeight: number;
+  headerRowCount: number;
+  summaryRowCount: number;
+}
+
+function assertNonNegativeInteger(value: number, label: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new TypeError(
+      `DataTable virtualization ${label} must be a non-negative integer`,
+    );
+  }
+}
+
+function assertPositiveFinite(value: number, label: string): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new TypeError(
+      `DataTable virtualization ${label} must be a positive finite number`,
+    );
+  }
+}
+
+function clampScrollTop(
+  scrollTop: number,
+  totalBodyHeight: number,
+  viewportHeight: number,
+): number {
+  if (!Number.isFinite(scrollTop)) {
+    throw new TypeError(
+      'DataTable virtualization scrollTop must be a finite number',
+    );
+  }
+  return Math.min(
+    Math.max(0, scrollTop),
+    Math.max(0, totalBodyHeight - viewportHeight),
+  );
+}
+
+function staticWindow(
+  rowCount: number,
+  reason: DataTableVirtualizationReason,
+  headerRowCount: number,
+  summaryRowCount: number,
+): DataTableVirtualWindow {
+  return {
+    enabled: false,
+    reason,
+    startIndex: 0,
+    endIndex: rowCount,
+    topSpacerHeight: 0,
+    bottomSpacerHeight: 0,
+    totalBodyHeight: 0,
+    headerRowCount,
+    summaryRowCount,
+  };
+}
+
+/**
+ * Resolves the renderable data-row window without using source order as an
+ * identity. The caller retains the rows and slices by the returned indexes.
+ */
+export function resolveDataTableVirtualWindow(
+  context: DataTableVirtualizationContext,
+): DataTableVirtualWindow {
+  const {
+    options,
+    rowCount,
+    scrollTop,
+    hasVariableRowHeight = false,
+    headerRowCount = 0,
+    summaryRowCount = 0,
+  } = context;
+  assertNonNegativeInteger(rowCount, 'rowCount');
+  assertNonNegativeInteger(headerRowCount, 'headerRowCount');
+  assertNonNegativeInteger(summaryRowCount, 'summaryRowCount');
+
+  if (!options) {
+    return staticWindow(rowCount, 'disabled', headerRowCount, summaryRowCount);
+  }
+
+  const overscan = options.overscan ?? 3;
+  assertPositiveFinite(options.rowHeight, 'rowHeight');
+  assertPositiveFinite(options.viewportHeight, 'viewportHeight');
+  assertNonNegativeInteger(overscan, 'overscan');
+
+  if (hasVariableRowHeight) {
+    return staticWindow(
+      rowCount,
+      'variable-row-height',
+      headerRowCount,
+      summaryRowCount,
+    );
+  }
+
+  const totalBodyHeight = rowCount * options.rowHeight;
+  const currentScrollTop = clampScrollTop(
+    scrollTop,
+    totalBodyHeight,
+    options.viewportHeight,
+  );
+  const startIndex = Math.max(
+    0,
+    Math.floor(currentScrollTop / options.rowHeight) - overscan,
+  );
+  const endIndex = Math.min(
+    rowCount,
+    Math.ceil((currentScrollTop + options.viewportHeight) / options.rowHeight) +
+      overscan,
+  );
+
+  return {
+    enabled: true,
+    startIndex,
+    endIndex,
+    topSpacerHeight: startIndex * options.rowHeight,
+    bottomSpacerHeight: (rowCount - endIndex) * options.rowHeight,
+    totalBodyHeight,
+    headerRowCount,
+    summaryRowCount,
+  };
+}
+
+/**
+ * Returns the smallest fixed-height scroll position that reveals a stable row
+ * index, clamped to the body extent. Callers resolve the index from `rowKey`.
+ */
+export function scrollTopForDataTableRow(
+  rowIndex: number,
+  rowCount: number,
+  options: Pick<DataTableVirtualizationOptions, 'rowHeight' | 'viewportHeight'>,
+  currentScrollTop = 0,
+): number {
+  assertNonNegativeInteger(rowIndex, 'rowIndex');
+  assertNonNegativeInteger(rowCount, 'rowCount');
+  if (rowIndex >= rowCount) {
+    throw new RangeError(
+      'DataTable virtualization rowIndex must reference a data row',
+    );
+  }
+  assertPositiveFinite(options.rowHeight, 'rowHeight');
+  assertPositiveFinite(options.viewportHeight, 'viewportHeight');
+
+  const totalBodyHeight = rowCount * options.rowHeight;
+  const current = clampScrollTop(
+    currentScrollTop,
+    totalBodyHeight,
+    options.viewportHeight,
+  );
+  const rowTop = rowIndex * options.rowHeight;
+  const rowBottom = rowTop + options.rowHeight;
+  const next =
+    rowTop < current
+      ? rowTop
+      : rowBottom > current + options.viewportHeight
+        ? rowBottom - options.viewportHeight
+        : current;
+  return clampScrollTop(next, totalBodyHeight, options.viewportHeight);
+}

--- a/packages/smrt-ui/src/components/data/__benchmarks__/DataTable.bench.ts
+++ b/packages/smrt-ui/src/components/data/__benchmarks__/DataTable.bench.ts
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/svelte';
+import type { Component } from 'svelte';
+import { bench, describe } from 'vitest';
+import {
+  createDataTablePerformanceColumns,
+  createDataTablePerformanceRows,
+  type DataTablePerformanceRow,
+} from '../__fixtures__/DataTablePerformanceFixture.js';
+import DataTable from '../DataTable.svelte';
+import { createDataTableController } from '../DataTableController.js';
+import type { DataTableProps } from '../types.js';
+
+const localRows = createDataTablePerformanceRows(250, 18);
+const localColumns = createDataTablePerformanceColumns(18);
+const transformRows = createDataTablePerformanceRows(1_000, 18);
+const manualPageRows = createDataTablePerformanceRows(100, 18);
+const BenchmarkDataTable = DataTable as unknown as Component<
+  DataTableProps<DataTablePerformanceRow>
+>;
+
+describe('DataTable scale thresholds', () => {
+  bench('local render: 250 rows and 20 columns', () => {
+    const table = render(BenchmarkDataTable, {
+      props: { data: localRows, columns: localColumns, rowKey: 'id' },
+    });
+    table.unmount();
+  });
+
+  bench('client transforms: 1,000 rows and 20 columns', () => {
+    const controller = createDataTableController({
+      columnIds: localColumns.map((column) => column.id),
+      initialState: {
+        search: 'record 00',
+        sorting: [{ columnId: 'value0', direction: 'desc' }],
+      },
+    });
+    const table = render(BenchmarkDataTable, {
+      props: {
+        data: transformRows,
+        columns: localColumns,
+        rowKey: 'id',
+        controller,
+      },
+    });
+    table.unmount();
+  });
+
+  bench(
+    'manual paging: 100 supplied rows from a 100,000-row remote result',
+    () => {
+      const controller = createDataTableController({
+        columnIds: localColumns.map((column) => column.id),
+        modes: { filtering: 'manual', sorting: 'manual', pagination: 'manual' },
+        initialState: { page: 500, pageSize: 100 },
+      });
+      const table = render(BenchmarkDataTable, {
+        props: {
+          data: manualPageRows,
+          columns: localColumns,
+          rowKey: 'id',
+          controller,
+          totalRows: 100_000,
+        },
+      });
+      table.unmount();
+    },
+  );
+});

--- a/packages/smrt-ui/src/components/data/__fixtures__/DataTablePerformanceFixture.ts
+++ b/packages/smrt-ui/src/components/data/__fixtures__/DataTablePerformanceFixture.ts
@@ -1,0 +1,40 @@
+import type { DataTableColumn } from '../types.js';
+
+export interface DataTablePerformanceRow {
+  id: string;
+  name: string;
+  group: string;
+  values: Record<string, number>;
+}
+
+export function createDataTablePerformanceRows(
+  rowCount: number,
+  valueColumnCount: number,
+): DataTablePerformanceRow[] {
+  return Array.from({ length: rowCount }, (_, index) => ({
+    id: `row-${index}`,
+    name: `Record ${index.toString().padStart(5, '0')}`,
+    group: `group-${index % 10}`,
+    values: Object.fromEntries(
+      Array.from({ length: valueColumnCount }, (_, valueIndex) => [
+        `value${valueIndex}`,
+        (index * (valueIndex + 3)) % 997,
+      ]),
+    ),
+  }));
+}
+
+export function createDataTablePerformanceColumns(
+  valueColumnCount: number,
+): DataTableColumn<DataTablePerformanceRow>[] {
+  return [
+    { id: 'name', label: 'Name', accessor: 'name', sortable: true },
+    { id: 'group', label: 'Group', accessor: 'group', sortable: true },
+    ...Array.from({ length: valueColumnCount }, (_, index) => ({
+      id: `value${index}`,
+      label: `Value ${index + 1}`,
+      accessor: `values.value${index}`,
+      sortable: true,
+    })),
+  ];
+}

--- a/packages/smrt-ui/src/components/data/__tests__/DataTablePerformance.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTablePerformance.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createDataTablePerformanceColumns,
+  createDataTablePerformanceRows,
+} from '../__fixtures__/DataTablePerformanceFixture.js';
+import {
+  DATA_TABLE_SCALE_THRESHOLDS,
+  recommendDataTableScaleStrategy,
+} from '../DataTablePerformance.js';
+
+describe('DataTable scale thresholds', () => {
+  it('uses deterministic, stable-identity benchmark fixtures', () => {
+    const rows = createDataTablePerformanceRows(3, 2);
+    expect(rows.map((row) => row.id)).toEqual(['row-0', 'row-1', 'row-2']);
+    expect(rows[2]?.values).toEqual({ value0: 6, value1: 8 });
+    expect(
+      createDataTablePerformanceColumns(2).map((column) => column.id),
+    ).toEqual(['name', 'group', 'value0', 'value1']);
+  });
+
+  it('recommends a bounded scale strategy from documented thresholds', () => {
+    expect(recommendDataTableScaleStrategy(250, 20)).toBe('local');
+    expect(recommendDataTableScaleStrategy(251, 20)).toBe('virtualization');
+    expect(recommendDataTableScaleStrategy(1_001, 2)).toBe('manual-paging');
+    expect(DATA_TABLE_SCALE_THRESHOLDS.manualPaging.recommendedPageSize).toBe(
+      100,
+    );
+  });
+
+  it('rejects ambiguous scale inputs', () => {
+    expect(() => recommendDataTableScaleStrategy(-1, 2)).toThrow(
+      /non-negative/,
+    );
+    expect(() => recommendDataTableScaleStrategy(2.5, 2)).toThrow(/integers/);
+  });
+});

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualization.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualization.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveDataTableVirtualWindow,
+  scrollTopForDataTableRow,
+} from '../DataTableVirtualization.js';
+
+const options = { rowHeight: 20, viewportHeight: 100, overscan: 2 };
+
+describe('DataTable virtualization window', () => {
+  it('renders a fixed-height window with bounded overscan', () => {
+    expect(
+      resolveDataTableVirtualWindow({
+        options,
+        rowCount: 100,
+        scrollTop: 200,
+      }),
+    ).toMatchObject({
+      enabled: true,
+      startIndex: 8,
+      endIndex: 17,
+      topSpacerHeight: 160,
+      bottomSpacerHeight: 1_660,
+      totalBodyHeight: 2_000,
+    });
+  });
+
+  it('clamps a restored scroll position to the body extent', () => {
+    expect(
+      resolveDataTableVirtualWindow({
+        options,
+        rowCount: 10,
+        scrollTop: 1_000,
+      }),
+    ).toMatchObject({
+      startIndex: 3,
+      endIndex: 10,
+      topSpacerHeight: 60,
+      bottomSpacerHeight: 0,
+    });
+  });
+
+  it('falls back to a semantic full body for variable-height data rows', () => {
+    expect(
+      resolveDataTableVirtualWindow({
+        options,
+        rowCount: 12,
+        scrollTop: 100,
+        hasVariableRowHeight: true,
+        headerRowCount: 2,
+        summaryRowCount: 1,
+      }),
+    ).toEqual({
+      enabled: false,
+      reason: 'variable-row-height',
+      startIndex: 0,
+      endIndex: 12,
+      topSpacerHeight: 0,
+      bottomSpacerHeight: 0,
+      totalBodyHeight: 0,
+      headerRowCount: 2,
+      summaryRowCount: 1,
+    });
+  });
+
+  it('keeps headers and summaries outside the body calculation', () => {
+    const withStructuralRows = resolveDataTableVirtualWindow({
+      options,
+      rowCount: 100,
+      scrollTop: 0,
+      headerRowCount: 2,
+      summaryRowCount: 3,
+    });
+    expect(withStructuralRows.totalBodyHeight).toBe(2_000);
+    expect(withStructuralRows.headerRowCount).toBe(2);
+    expect(withStructuralRows.summaryRowCount).toBe(3);
+  });
+
+  it('derives scroll restoration from a row position, not a display key', () => {
+    expect(scrollTopForDataTableRow(0, 100, options, 400)).toBe(0);
+    expect(scrollTopForDataTableRow(25, 100, options, 0)).toBe(420);
+    expect(scrollTopForDataTableRow(99, 100, options, 0)).toBe(1_900);
+  });
+
+  it('rejects invalid fixed-height configuration', () => {
+    expect(() =>
+      resolveDataTableVirtualWindow({
+        options: { rowHeight: 0, viewportHeight: 100 },
+        rowCount: 1,
+        scrollTop: 0,
+      }),
+    ).toThrow(/rowHeight/);
+    expect(() => scrollTopForDataTableRow(2, 2, options)).toThrow(/rowIndex/);
+  });
+});

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualization.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualization.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  maximumDataTableVirtualScrollTop,
   resolveDataTableVirtualWindow,
   scrollTopForDataTableRow,
 } from '../DataTableVirtualization.js';
@@ -73,6 +74,13 @@ describe('DataTable virtualization window', () => {
     expect(withStructuralRows.totalBodyHeight).toBe(2_000);
     expect(withStructuralRows.headerRowCount).toBe(2);
     expect(withStructuralRows.summaryRowCount).toBe(3);
+  });
+
+  it('extends the virtual scroll range by a measured summary footer', () => {
+    expect(maximumDataTableVirtualScrollTop(100, options, 24)).toBe(1_924);
+    expect(() => maximumDataTableVirtualScrollTop(1, options, -1)).toThrow(
+      /footerHeight/,
+    );
   });
 
   it('derives scroll restoration from a row position, not a display key', () => {

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualizationComponent.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualizationComponent.test.ts
@@ -25,7 +25,7 @@ function getScrollContainer(container: HTMLElement): HTMLDivElement {
 }
 
 describe('DataTable virtualization seam', () => {
-  it('renders only a fixed-height body window while retaining semantic headers', async () => {
+  it('renders only a fixed-height body window with accessible row context', async () => {
     const { container } = render(DataTable, {
       props: { data: rows, columns, rowKey: 'id', virtualization },
     });
@@ -34,7 +34,14 @@ describe('DataTable virtualization seam', () => {
     expect(
       screen.getByRole('columnheader', { name: 'Name' }),
     ).toBeInTheDocument();
+    expect(screen.getByRole('table')).toHaveAttribute('aria-rowcount', '101');
+    expect(getScrollContainer(container)).toHaveAttribute('role', 'region');
+    expect(getScrollContainer(container)).toHaveAttribute('tabindex', '0');
     expect(screen.getByText('Record 00000')).toBeInTheDocument();
+    expect(screen.getByText('Record 00000').closest('tr')).toHaveAttribute(
+      'aria-rowindex',
+      '2',
+    );
     expect(screen.queryByText('Record 00020')).not.toBeInTheDocument();
     expect(
       container.querySelectorAll('.data-table__virtual-spacer'),
@@ -47,6 +54,10 @@ describe('DataTable virtualization seam', () => {
       expect(screen.queryByText('Record 00000')).not.toBeInTheDocument();
       expect(screen.getByText('Record 00010')).toBeInTheDocument();
     });
+    expect(screen.getByText('Record 00010').closest('tr')).toHaveAttribute(
+      'aria-rowindex',
+      '12',
+    );
     expect(
       container.querySelectorAll('.data-table__virtual-spacer'),
     ).toHaveLength(2);
@@ -105,17 +116,40 @@ describe('DataTable virtualization seam', () => {
 
     const focusedRow = await screen.findByText('Record 00040');
     expect(scrollContainer.scrollTop).toBeGreaterThan(0);
-    (focusedRow.closest('tr') as HTMLTableRowElement).focus();
+    expect(document.activeElement).toBe(focusedRow.closest('tr'));
     expect(onFocusedRowIdChange).toHaveBeenCalledWith('row-40');
   });
 
-  it('falls back for expansion while keeping footer summaries outside the virtual body', () => {
+  it('scrolls the virtual body from the keyboard-accessible region', async () => {
+    const onScrollTopChange = vi.fn();
+    const { container } = render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'id',
+        virtualization: { ...virtualization, onScrollTopChange },
+      },
+    });
+    const scrollContainer = getScrollContainer(container);
+
+    scrollContainer.focus();
+    await fireEvent.keyDown(scrollContainer, { key: 'PageDown' });
+
+    expect(scrollContainer.scrollTop).toBe(80);
+    expect(onScrollTopChange).toHaveBeenCalledWith(80);
+    await vi.waitFor(() =>
+      expect(screen.getByText('Record 00004')).toBeInTheDocument(),
+    );
+  });
+
+  it('falls back for expansion without virtual scroll behavior', async () => {
     const expandedContent = createRawSnippet(() => ({
       render: () => '<p>Variable detail</p>',
     }));
     const footer = createRawSnippet(() => ({
       render: () => '<strong>Summary total</strong>',
     }));
+    const onScrollTopChange = vi.fn();
     const { container } = render(DataTable, {
       props: {
         data: rows,
@@ -123,13 +157,18 @@ describe('DataTable virtualization seam', () => {
         rowKey: 'id',
         expandedContent,
         footer,
-        virtualization,
+        virtualization: { ...virtualization, onScrollTopChange },
       },
     });
 
     expect(screen.getByText('Record 00099')).toBeInTheDocument();
     expect(screen.getByText('Summary total')).toBeInTheDocument();
     expect(container.querySelector('.data-table__virtual-spacer')).toBeNull();
+    const scrollContainer = getScrollContainer(container);
+    expect(scrollContainer).not.toHaveAttribute('tabindex');
+    scrollContainer.scrollTop = 200;
+    await fireEvent.scroll(scrollContainer);
+    expect(onScrollTopChange).not.toHaveBeenCalled();
   });
 
   it('is axe-clean with virtual spacer rows', async () => {

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualizationComponent.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualizationComponent.test.ts
@@ -11,6 +11,11 @@ interface Row {
   name: string;
 }
 
+interface IdentityRow {
+  id: string | number;
+  name: string;
+}
+
 const rows: Row[] = Array.from({ length: 100 }, (_, index) => ({
   id: `row-${index}`,
   name: `Record ${index.toString().padStart(5, '0')}`,
@@ -120,6 +125,26 @@ describe('DataTable virtualization seam', () => {
     expect(onFocusedRowIdChange).toHaveBeenCalledWith('row-40');
   });
 
+  it('restores focus without aliasing numeric and string row identities', async () => {
+    const identityRows: IdentityRow[] = [
+      { id: 1, name: 'Numeric row' },
+      { id: '1', name: 'String row' },
+    ];
+    const { container } = render(DataTable, {
+      props: {
+        data: identityRows,
+        columns,
+        rowKey: 'id',
+        virtualization: { ...virtualization, focusedRowId: '1' },
+      },
+    });
+
+    const stringRow = await screen.findByText('String row');
+    expect(stringRow.closest('tr')).toHaveAttribute('data-row-id', 'string:1');
+    expect(document.activeElement).toBe(stringRow.closest('tr'));
+    expect(container.querySelector('tr[data-row-id="number:1"]')).toBeTruthy();
+  });
+
   it('scrolls the virtual body from the keyboard-accessible region', async () => {
     const onScrollTopChange = vi.fn();
     const { container } = render(DataTable, {
@@ -140,6 +165,65 @@ describe('DataTable virtualization seam', () => {
     await vi.waitFor(() =>
       expect(screen.getByText('Record 00004')).toBeInTheDocument(),
     );
+  });
+
+  it('stripes virtual rows by their logical display index', async () => {
+    const { container } = render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'id',
+        striped: true,
+        virtualization,
+      },
+    });
+    const scrollContainer = getScrollContainer(container);
+
+    scrollContainer.scrollTop = 40;
+    await fireEvent.scroll(scrollContainer);
+
+    await vi.waitFor(() =>
+      expect(screen.getByText('Record 00001')).toBeInTheDocument(),
+    );
+    expect(screen.getByText('Record 00001').closest('tr')).toHaveClass(
+      'data-table__row--striped',
+    );
+    expect(screen.getByText('Record 00002').closest('tr')).not.toHaveClass(
+      'data-table__row--striped',
+    );
+  });
+
+  it('keeps the summary footer reachable at the end of the virtual scroll range', async () => {
+    const footer = createRawSnippet(() => ({
+      render: () => '<strong>Summary total</strong>',
+    }));
+    const offsetHeight = vi
+      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockImplementation(function () {
+        return this.tagName === 'TFOOT' ? 24 : 0;
+      });
+    const onScrollTopChange = vi.fn();
+
+    try {
+      const { container } = render(DataTable, {
+        props: {
+          data: rows,
+          columns,
+          rowKey: 'id',
+          footer,
+          virtualization: { ...virtualization, onScrollTopChange },
+        },
+      });
+      const scrollContainer = getScrollContainer(container);
+
+      await fireEvent.keyDown(scrollContainer, { key: 'End' });
+
+      expect(scrollContainer.scrollTop).toBe(1_924);
+      expect(onScrollTopChange).toHaveBeenCalledWith(1_924);
+      expect(screen.getByText('Summary total')).toBeInTheDocument();
+    } finally {
+      offsetHeight.mockRestore();
+    }
   });
 
   it('falls back for expansion without virtual scroll behavior', async () => {

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualizationComponent.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualizationComponent.test.ts
@@ -69,6 +69,9 @@ describe('DataTable virtualization seam', () => {
   });
 
   it('keeps manual pages and selected stable IDs independent of the rendered window', async () => {
+    const footer = createRawSnippet(() => ({
+      render: () => '<strong>Remote summary</strong>',
+    }));
     const controller = createDataTableController({
       columnIds: ['name'],
       modes: { filtering: 'manual', sorting: 'manual', pagination: 'manual' },
@@ -82,12 +85,17 @@ describe('DataTable virtualization seam', () => {
         selectable: true,
         controller,
         totalRows: 10_000,
+        footer,
         virtualization,
       },
     });
     const scrollContainer = getScrollContainer(container);
 
-    expect(screen.getByRole('table')).toHaveAttribute('aria-rowcount', '10001');
+    expect(screen.getByRole('table')).toHaveAttribute('aria-rowcount', '10002');
+    expect(screen.getByText('Remote summary').closest('tr')).toHaveAttribute(
+      'aria-rowindex',
+      '10002',
+    );
     await userEvent.click(
       screen.getAllByRole('checkbox', { name: 'Select row' })[0],
     );

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualizationComponent.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualizationComponent.test.ts
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { createRawSnippet } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import DataTable from '../DataTable.svelte';
+import { createDataTableController } from '../DataTableController.js';
+
+interface Row {
+  id: string;
+  name: string;
+}
+
+const rows: Row[] = Array.from({ length: 100 }, (_, index) => ({
+  id: `row-${index}`,
+  name: `Record ${index.toString().padStart(5, '0')}`,
+}));
+const columns = [{ id: 'name', label: 'Name', accessor: 'name' }];
+const virtualization = { rowHeight: 20, viewportHeight: 100, overscan: 1 };
+
+function getScrollContainer(container: HTMLElement): HTMLDivElement {
+  const node = container.querySelector<HTMLDivElement>('.data-table-container');
+  if (!node) throw new Error('Expected DataTable scroll container');
+  return node;
+}
+
+describe('DataTable virtualization seam', () => {
+  it('renders only a fixed-height body window while retaining semantic headers', async () => {
+    const { container } = render(DataTable, {
+      props: { data: rows, columns, rowKey: 'id', virtualization },
+    });
+    const scrollContainer = getScrollContainer(container);
+
+    expect(
+      screen.getByRole('columnheader', { name: 'Name' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Record 00000')).toBeInTheDocument();
+    expect(screen.queryByText('Record 00020')).not.toBeInTheDocument();
+    expect(
+      container.querySelectorAll('.data-table__virtual-spacer'),
+    ).toHaveLength(1);
+
+    scrollContainer.scrollTop = 200;
+    await fireEvent.scroll(scrollContainer);
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText('Record 00000')).not.toBeInTheDocument();
+      expect(screen.getByText('Record 00010')).toBeInTheDocument();
+    });
+    expect(
+      container.querySelectorAll('.data-table__virtual-spacer'),
+    ).toHaveLength(2);
+  });
+
+  it('keeps manual pages and selected stable IDs independent of the rendered window', async () => {
+    const controller = createDataTableController({
+      columnIds: ['name'],
+      modes: { filtering: 'manual', sorting: 'manual', pagination: 'manual' },
+      initialState: { page: 12, pageSize: 100 },
+    });
+    const { container } = render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'id',
+        selectable: true,
+        controller,
+        totalRows: 10_000,
+        virtualization,
+      },
+    });
+    const scrollContainer = getScrollContainer(container);
+
+    await userEvent.click(
+      screen.getAllByRole('checkbox', { name: 'Select row' })[0],
+    );
+    expect(controller.getState().selectedRowIds).toEqual(['row-0']);
+
+    scrollContainer.scrollTop = 400;
+    await fireEvent.scroll(scrollContainer);
+    await vi.waitFor(() =>
+      expect(screen.getByText('Record 00020')).toBeInTheDocument(),
+    );
+
+    expect(controller.getState().selectedRowIds).toEqual(['row-0']);
+    expect(screen.queryByText('Record 00099')).not.toBeInTheDocument();
+  });
+
+  it('restores a controlled focused row by stable identity and reports row focus', async () => {
+    const onFocusedRowIdChange = vi.fn();
+    const { container } = render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'id',
+        onRowClick: () => undefined,
+        virtualization: {
+          ...virtualization,
+          focusedRowId: 'row-40',
+          onFocusedRowIdChange,
+        },
+      },
+    });
+    const scrollContainer = getScrollContainer(container);
+
+    const focusedRow = await screen.findByText('Record 00040');
+    expect(scrollContainer.scrollTop).toBeGreaterThan(0);
+    (focusedRow.closest('tr') as HTMLTableRowElement).focus();
+    expect(onFocusedRowIdChange).toHaveBeenCalledWith('row-40');
+  });
+
+  it('falls back for expansion while keeping footer summaries outside the virtual body', () => {
+    const expandedContent = createRawSnippet(() => ({
+      render: () => '<p>Variable detail</p>',
+    }));
+    const footer = createRawSnippet(() => ({
+      render: () => '<strong>Summary total</strong>',
+    }));
+    const { container } = render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'id',
+        expandedContent,
+        footer,
+        virtualization,
+      },
+    });
+
+    expect(screen.getByText('Record 00099')).toBeInTheDocument();
+    expect(screen.getByText('Summary total')).toBeInTheDocument();
+    expect(container.querySelector('.data-table__virtual-spacer')).toBeNull();
+  });
+
+  it('is axe-clean with virtual spacer rows', async () => {
+    const { container } = render(DataTable, {
+      props: { data: rows, columns, rowKey: 'id', virtualization },
+    });
+
+    await expectNoA11yViolations(container);
+  });
+});

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualizationComponent.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualizationComponent.test.ts
@@ -87,6 +87,7 @@ describe('DataTable virtualization seam', () => {
     });
     const scrollContainer = getScrollContainer(container);
 
+    expect(screen.getByRole('table')).toHaveAttribute('aria-rowcount', '10001');
     await userEvent.click(
       screen.getAllByRole('checkbox', { name: 'Select row' })[0],
     );
@@ -96,6 +97,10 @@ describe('DataTable virtualization seam', () => {
     await fireEvent.scroll(scrollContainer);
     await vi.waitFor(() =>
       expect(screen.getByText('Record 00020')).toBeInTheDocument(),
+    );
+    expect(screen.getByText('Record 00020').closest('tr')).toHaveAttribute(
+      'aria-rowindex',
+      '1122',
     );
 
     expect(controller.getState().selectedRowIds).toEqual(['row-0']);

--- a/packages/smrt-ui/src/components/data/index.ts
+++ b/packages/smrt-ui/src/components/data/index.ts
@@ -10,4 +10,6 @@ export { default as CollectionToolbar } from './CollectionToolbar.svelte';
 export { default as DataTable } from './DataTable.svelte';
 export * from './DataTableController.js';
 export * from './DataTableIdentity.js';
+export * from './DataTablePerformance.js';
+export * from './DataTableVirtualization.js';
 export * from './types.js';

--- a/packages/smrt-ui/src/components/data/types.ts
+++ b/packages/smrt-ui/src/components/data/types.ts
@@ -12,6 +12,7 @@ import type {
   DataTableViewStateInput,
 } from './DataTableController.js';
 import type { DataTableRowKey } from './DataTableIdentity.js';
+import type { DataTableVirtualizationOptions } from './DataTableVirtualization.js';
 
 /**
  * Column definition for DataTable
@@ -103,6 +104,11 @@ export interface DataTableProps<T> {
   pageSize?: number;
   /** Parent owns pagination and supplies only the current page. */
   manualPagination?: boolean;
+  /**
+   * Opt-in fixed-height virtualization for the data body. It requires rowKey
+   * and falls back to the normal semantic body when expanded rows are enabled.
+   */
+  virtualization?: DataTableVirtualizationOptions;
   /** Total server row count when manualPagination is enabled. */
   totalRows?: number;
   /** Page change callback. */


### PR DESCRIPTION
Closes #2440

## Summary
- Adds reproducible DataTable scale benchmarks and documented local, transform, and manual-paging boundaries.
- Adds an opt-in fixed-height virtual body with stable identity, selection, focus restoration, keyboard scrolling, and scroll restoration.
- Defines fixed-height fallback behavior for expansion, headers, and summary rows.

## Validation
- `pnpm --filter @happyvertical/smrt-ui test` (588 tests)
- `pnpm --filter @happyvertical/smrt-ui typecheck`
- `pnpm --filter @happyvertical/smrt-ui build`
- `pnpm --filter @happyvertical/smrt-ui bench:data-table`
- `pnpm smrt dev:knowledge-check`
- `pnpm knowledge:check --changed --strict --format markdown`

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-issue-2440-01a027b1-fa0d-76b3-9835-012a3531396e","issue":2440,"policy_revision":"1.0.0","status":"complete","validation":["smrt-ui test: 588 passing","smrt-ui typecheck: 0 errors, 0 warnings","smrt-ui build","smrt-ui bench:data-table","smrt dev:knowledge-check","knowledge check strict"]}
```