### PR TITLE
feat(smrt-ui): add report-grade DataTable layout

### DIFF
--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -218,16 +218,14 @@ $effect(() => {
 
   localController.setControlled(controlledState !== undefined);
   localController.setModes(legacyModes());
-  localController.setColumnIds(
-    columns.map((column) => column.id),
-    columns
-      .filter(
-        (column) =>
-          column.hidden ||
-          (visibleColumnIds !== undefined && !visibleColumnIds.has(column.id)),
-      )
-      .map((column) => column.id),
-  );
+  const columnIds = columns.map((column) => column.id);
+  const hiddenColumnIds = columns
+    .filter(
+      (column) =>
+        column.hidden ||
+        (visibleColumnIds !== undefined && !visibleColumnIds.has(column.id)),
+    )
+    .map((column) => column.id);
 
   if (!localControllerInitialized) {
     localControllerInitialized = true;
@@ -236,8 +234,11 @@ $effect(() => {
       ...initialState,
     };
     localController.replaceState(nextState);
+    localController.setColumnIds(columnIds, hiddenColumnIds);
     return;
   }
+
+  localController.setColumnIds(columnIds, hiddenColumnIds);
 
   if (controlledState !== undefined) {
     localController.replaceState(controlledState);
@@ -283,6 +284,15 @@ $effect(() => {
 
 const tableState = $derived(controllerSnapshot.state);
 const tableModes = $derived(controllerSnapshot.modes);
+const constrainedLayoutState = $derived.by(() => ({
+  ...tableState,
+  columnWidths: tableState.columnWidths.map((entry) => {
+    const column = columns.find((candidate) => candidate.id === entry.columnId);
+    return column
+      ? { ...entry, width: clampedColumnWidth(column, entry.width) }
+      : entry;
+  }),
+}));
 const requiresStableRowIdentity = $derived(
   selectable ||
     Boolean(expandedContent) ||
@@ -479,7 +489,7 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
 }
 
 const dataTableLayout = $derived(
-  resolveDataTableLayout(columns, tableState, measuredColumnWidths),
+  resolveDataTableLayout(columns, constrainedLayoutState, measuredColumnWidths),
 );
 const visibleColumns = $derived(dataTableLayout.columns);
 const dataBodyStructuralRows = $derived(
@@ -885,8 +895,17 @@ function observeColumnWidth(node: HTMLElement, initialColumnId: string) {
 
 function numberFromCssPixels(value: string | undefined): number | undefined {
   if (!value) return undefined;
-  const match = /^(\d+(?:\.\d+)?)px$/.exec(value.trim());
-  return match ? Number(match[1]) : undefined;
+  const match = /^(\d+(?:\.\d+)?)(px|rem)$/.exec(value.trim());
+  if (!match) return undefined;
+  const number = Number(match[1]);
+  if (match[2] === 'px') return number;
+  const rootFontSize =
+    typeof document === 'undefined'
+      ? undefined
+      : /^\d+(?:\.\d+)?px$/.exec(
+          getComputedStyle(document.documentElement).fontSize.trim(),
+        );
+  return number * (rootFontSize ? Number(rootFontSize[0].slice(0, -2)) : 16);
 }
 
 function minimumWidth(column: DataTableColumn<T>): number {
@@ -909,6 +928,8 @@ function currentColumnWidth(
   resolved: DataTableResolvedColumn<T>,
   target?: EventTarget | null,
 ): number {
+  const measuredWidth = measuredColumnWidths[resolved.column.id];
+  if (measuredWidth !== undefined && measuredWidth > 0) return measuredWidth;
   if (resolved.width !== undefined) return resolved.width;
   const staticWidth = numberFromCssPixels(resolved.column.width);
   if (staticWidth !== undefined) return staticWidth;
@@ -1133,7 +1154,9 @@ $effect(() => {
                 style:text-align={column.align}
                 scope="col"
                 rowspan={headerCell.rowspan}
-                aria-label={column.resizable ? column.label : undefined}
+                aria-label={column.resizable && !column.header
+                  ? column.label
+                  : undefined}
                 aria-sort={currentSort.columnId === column.id
                   ? currentSort.direction === 'asc'
                     ? 'ascending'

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -31,11 +31,20 @@ import {
 } from './DataTableController.js';
 import { resolveDataTableRows } from './DataTableIdentity.js';
 import {
+  type DataTableResolvedColumn,
+  resolveDataTableLayout,
+} from './DataTableLayout.js';
+import {
   maximumDataTableVirtualScrollTop,
   resolveDataTableVirtualWindow,
   scrollTopForDataTableRow,
 } from './DataTableVirtualization.js';
-import type { DataTableColumn, DataTableProps, SortState } from './types.js';
+import type {
+  DataTableColumn,
+  DataTableProps,
+  DataTableStructuralRow,
+  SortState,
+} from './types.js';
 import { defaultSort, getNestedValue } from './types.js';
 
 const { t } = useI18n();
@@ -74,6 +83,7 @@ let {
   expandedContent,
   toolbar,
   footer,
+  structuralRows = [],
   visibleColumnIds,
   loading = false,
   refreshing = false,
@@ -108,21 +118,23 @@ function legacyModes(): DataTableModes {
 }
 
 function legacyViewState(): Partial<DataTableViewState> {
-  return {
+  const next: Partial<DataTableViewState> = {
     sorting:
       sort.columnId && sort.direction
         ? [{ columnId: sort.columnId, direction: sort.direction }]
         : [],
     page,
     pageSize: pageSize ?? null,
-    columnOrder: columns.map((column) => column.id),
-    columnVisibility: columns.map((column) => ({
-      columnId: column.id,
-      visible: !visibleColumnIds || visibleColumnIds.has(column.id),
-    })),
     selectedRowIds: [...selected],
     expandedRowIds: [...expanded],
   };
+  if (visibleColumnIds) {
+    next.columnVisibility = columns.map((column) => ({
+      columnId: column.id,
+      visible: visibleColumnIds.has(column.id),
+    }));
+  }
+  return next;
 }
 
 function mergedLegacyState(): Omit<DataTableViewState, 'selection'> {
@@ -136,6 +148,7 @@ const localController = createDataTableController({
 });
 
 let controllerSnapshot = $state<DataTableSnapshot>(localController.snapshot());
+let measuredColumnWidths = $state<Record<string, number>>({});
 let publishedLegacySignature: string | undefined;
 let localControllerInitialized = false;
 let hasHorizontalOverflow = $state(false);
@@ -205,7 +218,16 @@ $effect(() => {
 
   localController.setControlled(controlledState !== undefined);
   localController.setModes(legacyModes());
-  localController.setColumnIds(columns.map((column) => column.id));
+  localController.setColumnIds(
+    columns.map((column) => column.id),
+    columns
+      .filter(
+        (column) =>
+          column.hidden ||
+          (visibleColumnIds !== undefined && !visibleColumnIds.has(column.id)),
+      )
+      .map((column) => column.id),
+  );
 
   if (!localControllerInitialized) {
     localControllerInitialized = true;
@@ -232,7 +254,16 @@ $effect(() => {
 
 $effect(() => {
   const current = activeController();
-  current.setColumnIds(columns.map((column) => column.id));
+  current.setColumnIds(
+    columns.map((column) => column.id),
+    columns
+      .filter(
+        (column) =>
+          column.hidden ||
+          (visibleColumnIds !== undefined && !visibleColumnIds.has(column.id)),
+      )
+      .map((column) => column.id),
+  );
   controllerSnapshot = current.snapshot();
   return current.subscribe((transition) => {
     controllerSnapshot = transition.next;
@@ -447,23 +478,22 @@ function setIndeterminate(node: HTMLInputElement, value: boolean) {
   };
 }
 
-const visibleColumns = $derived.by(() => {
-  const configuredOrder = new Map(
-    tableState.columnOrder.map((id, index) => [id, index]),
-  );
-  const visibility = new Map(
-    tableState.columnVisibility.map((entry) => [entry.columnId, entry.visible]),
-  );
-  return columns
-    .filter((column) => !column.hidden && visibility.get(column.id) !== false)
-    .slice()
-    .sort((left, right) => {
-      const leftOrder = configuredOrder.get(left.id) ?? Number.MAX_SAFE_INTEGER;
-      const rightOrder =
-        configuredOrder.get(right.id) ?? Number.MAX_SAFE_INTEGER;
-      return leftOrder - rightOrder;
-    });
-});
+const dataTableLayout = $derived(
+  resolveDataTableLayout(columns, tableState, measuredColumnWidths),
+);
+const visibleColumns = $derived(dataTableLayout.columns);
+const dataBodyStructuralRows = $derived(
+  structuralRows.filter((row) => row.kind !== 'footer'),
+);
+const footerStructuralRows = $derived(
+  structuralRows.filter((row) => row.kind === 'footer'),
+);
+const structuralRowCount = $derived(
+  dataBodyStructuralRows.length +
+    footerStructuralRows.length +
+    (footer ? 1 : 0),
+);
+const headerRowCount = $derived(dataTableLayout.headerRows.length);
 
 function sameFilterValue(value: unknown, expected: unknown): boolean {
   return Object.is(value, expected);
@@ -602,6 +632,7 @@ let tableContainer: HTMLDivElement | undefined = $state();
 let tableCaption: HTMLTableCaptionElement | undefined = $state();
 let tableHead: HTMLTableSectionElement | undefined = $state();
 let tableBody: HTMLTableSectionElement | undefined = $state();
+let tableStructuralBody: HTMLTableSectionElement | undefined = $state();
 let tableFooter: HTMLTableSectionElement | undefined = $state();
 let virtualScrollTop = $state(0);
 let virtualStructuralHeight = $state(0);
@@ -616,8 +647,8 @@ const virtualizationWindow = $derived.by(() =>
     rowCount: displayRows.length,
     scrollTop: virtualization?.scrollTop ?? virtualScrollTop,
     hasVariableRowHeight: Boolean(expandedContent),
-    headerRowCount: 1,
-    summaryRowCount: footer ? 1 : 0,
+    headerRowCount,
+    summaryRowCount: structuralRowCount,
   }),
 );
 const renderedRows = $derived.by(() =>
@@ -741,11 +772,13 @@ $effect(() => {
   const body = tableBody;
   const captionElement = tableCaption;
   const head = tableHead;
+  const structuralBody = tableStructuralBody;
   const footerElement = tableFooter;
   const measureStructure = () => {
     virtualStructuralHeight = body.offsetTop;
     virtualCaptionHeight = captionElement?.offsetHeight ?? 0;
-    virtualFooterHeight = footerElement?.offsetHeight ?? 0;
+    virtualFooterHeight =
+      (structuralBody?.offsetHeight ?? 0) + (footerElement?.offsetHeight ?? 0);
   };
   measureStructure();
   if (typeof ResizeObserver === 'undefined') return;
@@ -753,6 +786,7 @@ $effect(() => {
   const observer = new ResizeObserver(measureStructure);
   if (captionElement) observer.observe(captionElement);
   if (head) observer.observe(head);
+  if (structuralBody) observer.observe(structuralBody);
   if (footerElement) observer.observe(footerElement);
   return () => observer.disconnect();
 });
@@ -821,6 +855,154 @@ function getCellValue(row: T, column: DataTableColumn<T>): unknown {
   return getNestedValue(row, String(accessor));
 }
 
+function widthForColumn(
+  column: DataTableResolvedColumn<T>,
+): string | undefined {
+  return column.width === undefined ? column.column.width : `${column.width}px`;
+}
+
+function observeColumnWidth(node: HTMLElement, initialColumnId: string) {
+  let columnId = initialColumnId;
+  const recordWidth = () => {
+    const width = Math.ceil(node.getBoundingClientRect().width);
+    if (width <= 0 || measuredColumnWidths[columnId] === width) return;
+    measuredColumnWidths = { ...measuredColumnWidths, [columnId]: width };
+  };
+  recordWidth();
+  if (typeof ResizeObserver === 'undefined') return;
+  const observer = new ResizeObserver(recordWidth);
+  observer.observe(node);
+  return {
+    update(nextColumnId: string) {
+      columnId = nextColumnId;
+      recordWidth();
+    },
+    destroy() {
+      observer.disconnect();
+    },
+  };
+}
+
+function numberFromCssPixels(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const match = /^(\d+(?:\.\d+)?)px$/.exec(value.trim());
+  return match ? Number(match[1]) : undefined;
+}
+
+function minimumWidth(column: DataTableColumn<T>): number {
+  return numberFromCssPixels(column.minWidth) ?? 40;
+}
+
+function maximumWidth(column: DataTableColumn<T>): number | undefined {
+  return numberFromCssPixels(column.maxWidth);
+}
+
+function clampedColumnWidth(column: DataTableColumn<T>, width: number): number {
+  const maximum = maximumWidth(column);
+  return Math.min(
+    Math.max(minimumWidth(column), Math.round(width)),
+    maximum ?? Infinity,
+  );
+}
+
+function currentColumnWidth(
+  resolved: DataTableResolvedColumn<T>,
+  target?: EventTarget | null,
+): number {
+  if (resolved.width !== undefined) return resolved.width;
+  const staticWidth = numberFromCssPixels(resolved.column.width);
+  if (staticWidth !== undefined) return staticWidth;
+  const header = target instanceof Element ? target.closest('th') : undefined;
+  return header?.getBoundingClientRect().width ?? 160;
+}
+
+function setColumnWidth(column: DataTableColumn<T>, width: number) {
+  dispatch({
+    type: 'setColumnWidth',
+    columnId: column.id,
+    width: clampedColumnWidth(column, width),
+  });
+}
+
+function handleResizeKeydown(
+  event: KeyboardEvent,
+  resolved: DataTableResolvedColumn<T>,
+) {
+  const step = event.shiftKey ? 32 : 8;
+  const current = currentColumnWidth(resolved, event.currentTarget);
+  const maximum = maximumWidth(resolved.column);
+  const next =
+    event.key === 'ArrowLeft'
+      ? current - step
+      : event.key === 'ArrowRight'
+        ? current + step
+        : event.key === 'Home'
+          ? minimumWidth(resolved.column)
+          : event.key === 'End' && maximum !== undefined
+            ? maximum
+            : undefined;
+  if (next === undefined) return;
+  event.preventDefault();
+  setColumnWidth(resolved.column, next);
+}
+
+function handleResizePointerDown(
+  event: PointerEvent,
+  resolved: DataTableResolvedColumn<T>,
+) {
+  if (event.button !== 0) return;
+  event.preventDefault();
+  event.stopPropagation();
+  const handle = event.currentTarget as HTMLElement;
+  const startX = event.clientX;
+  const startWidth = currentColumnWidth(resolved, handle);
+  handle.setPointerCapture?.(event.pointerId);
+  const update = (nextEvent: PointerEvent) =>
+    setColumnWidth(resolved.column, startWidth + nextEvent.clientX - startX);
+  const finish = () => {
+    handle.removeEventListener('pointermove', update);
+    handle.removeEventListener('pointerup', finish);
+    handle.removeEventListener('pointercancel', finish);
+  };
+  handle.addEventListener('pointermove', update);
+  handle.addEventListener('pointerup', finish, { once: true });
+  handle.addEventListener('pointercancel', finish, { once: true });
+}
+
+function structuralLabelColumnId(
+  row: DataTableStructuralRow<T>,
+): string | undefined {
+  if (
+    row.labelColumnId &&
+    visibleColumns.some((column) => column.column.id === row.labelColumnId)
+  ) {
+    return row.labelColumnId;
+  }
+  return visibleColumns[0]?.column.id;
+}
+
+function structuralRowLabel(row: DataTableStructuralRow<T>): string {
+  const kind =
+    row.kind === 'summary'
+      ? t(M['ui.data_table.summary'])
+      : row.kind === 'subtotal'
+        ? t(M['ui.data_table.subtotal'])
+        : row.kind === 'aggregate'
+          ? t(M['ui.data_table.aggregate'])
+          : t(M['ui.data_table.footer_row']);
+  return t(M['ui.data_table.structural_row'], { kind, label: row.label });
+}
+
+function structuralCellValue(
+  row: DataTableStructuralRow<T>,
+  column: DataTableColumn<T>,
+): unknown {
+  return (
+    row.values?.[column.id] ??
+    (column.id === structuralLabelColumnId(row) ? row.label : '')
+  );
+}
+
 const sizeClasses = {
   sm: 'data-table--sm',
   md: 'data-table--md',
@@ -886,7 +1068,7 @@ $effect(() => {
     class:data-table--loading={isInitialLoading}
     aria-busy={isBusy}
     aria-rowcount={virtualizationWindow.enabled
-      ? virtualRowCount + 1 + (footer ? 1 : 0)
+      ? virtualRowCount + headerRowCount + structuralRowCount
       : undefined}
     style={`--data-table-caption-height: ${virtualCaptionHeight}px`}
   >
@@ -895,81 +1077,130 @@ $effect(() => {
     {/if}
 
     <thead bind:this={tableHead} class="data-table__head">
-      <tr class="data-table__row data-table__row--header">
-        {#if expandedContent}<th class="data-table__cell data-table__cell--expand" scope="col"><span class="sr-only"><Trans key={M['ui.data_table.expand']} /></span></th>{/if}
-        {#if selectable}
-          <th class="data-table__cell data-table__cell--checkbox" scope="col">
-            <input
-              type="checkbox"
-              checked={allSelected}
-              use:setIndeterminate={someSelected}
-              onchange={handleSelectAll}
-              aria-label={t(M['ui.data_table.select_current_page'])}
-              class="data-table__checkbox"
-            />
-          </th>
-        {/if}
+      {#each dataTableLayout.headerRows as headerRow, headerIndex (headerIndex)}
+        <tr class="data-table__row data-table__row--header">
+          {#if headerIndex === 0 && expandedContent}
+            <th class="data-table__cell data-table__cell--expand" scope="col" rowspan={headerRowCount}>
+              <span class="sr-only"><Trans key={M['ui.data_table.expand']} /></span>
+            </th>
+          {/if}
+          {#if headerIndex === 0 && selectable}
+            <th class="data-table__cell data-table__cell--checkbox" scope="col" rowspan={headerRowCount}>
+              <input
+                type="checkbox"
+                checked={allSelected}
+                use:setIndeterminate={someSelected}
+                onchange={handleSelectAll}
+                aria-label={t(M['ui.data_table.select_current_page'])}
+                class="data-table__checkbox"
+              />
+            </th>
+          {/if}
 
-        {#each visibleColumns as column (column.id)}
-          <th
-            class="data-table__cell data-table__cell--header"
-            class:data-table__cell--sortable={usesAutomaticSortButton(column)}
-            class:data-table__cell--sorted={currentSort.columnId === column.id}
-            style:width={column.width}
-            style:min-width={column.minWidth}
-            style:max-width={column.maxWidth}
-            style:text-align={column.align}
-            scope="col"
-            aria-sort={currentSort.columnId === column.id
-              ? currentSort.direction === 'asc'
-                ? 'ascending'
-                : 'descending'
-              : undefined}
-          >
-            {#if usesAutomaticSortButton(column)}
-              {#if column.header}
-                <div class="data-table__header-content">
-                  {@render column.header({ column })}
-                  <button
-                    type="button"
-                    class="data-table__sort-button"
-                    onclick={(event) => handleSort(column, event)}
-                    aria-label={sortActionLabel(column)}
-                  >
-                    <span class="data-table__sort-icon" aria-hidden="true">
-                      {#if currentSort.columnId === column.id}
-                        {currentSort.direction === 'asc' ? '↑' : '↓'}
-                      {:else}
-                        ↕
-                      {/if}
-                    </span>
-                  </button>
-                </div>
-              {:else}
-                <button
-                  type="button"
-                  class="data-table__sort-button"
-                  onclick={(event) => handleSort(column, event)}
-                  aria-label={sortActionLabel(column)}
-                >
-                  <span>{column.label}</span>
-                  <span class="data-table__sort-icon" aria-hidden="true">
-                    {#if currentSort.columnId === column.id}
-                      {currentSort.direction === 'asc' ? '↑' : '↓'}
-                    {:else}
-                      ↕
-                    {/if}
-                  </span>
-                </button>
-              {/if}
-            {:else if column.header}
-              {@render column.header({ column })}
+          {#each headerRow as headerCell, cellIndex (`${headerIndex}:${cellIndex}`)}
+            {#if headerCell.kind === 'group'}
+              <th
+                class="data-table__cell data-table__cell--header data-table__cell--header-group"
+                class:data-table__cell--pinned-start={headerCell.pin === 'start'}
+                class:data-table__cell--pinned-end={headerCell.pin === 'end'}
+                scope="colgroup"
+                colspan={headerCell.colspan}
+                rowspan={headerCell.rowspan}
+                style:left={headerCell.pin === 'start' ? headerCell.stickyOffset : undefined}
+                style:right={headerCell.pin === 'end' ? headerCell.stickyOffset : undefined}
+              >
+                {headerCell.label}
+              </th>
             {:else}
-              {column.label}
+              {@const resolvedColumn = headerCell.column}
+              {@const column = resolvedColumn.column}
+              <th
+                class="data-table__cell data-table__cell--header"
+                class:data-table__cell--sortable={usesAutomaticSortButton(column)}
+                class:data-table__cell--sorted={currentSort.columnId === column.id}
+                class:data-table__cell--pinned-start={resolvedColumn.pin === 'start'}
+                class:data-table__cell--pinned-end={resolvedColumn.pin === 'end'}
+                data-column-id={column.id}
+                data-column-role={column.role}
+                data-responsive-priority={column.responsive?.priority}
+                data-keep-visible={column.responsive?.keepVisible ? 'true' : undefined}
+                use:observeColumnWidth={column.id}
+                style:width={widthForColumn(resolvedColumn)}
+                style:min-width={column.minWidth}
+                style:max-width={column.maxWidth}
+                style:left={resolvedColumn.pin === 'start' ? resolvedColumn.stickyOffset : undefined}
+                style:right={resolvedColumn.pin === 'end' ? resolvedColumn.stickyOffset : undefined}
+                style:text-align={column.align}
+                scope="col"
+                rowspan={headerCell.rowspan}
+                aria-label={column.resizable ? column.label : undefined}
+                aria-sort={currentSort.columnId === column.id
+                  ? currentSort.direction === 'asc'
+                    ? 'ascending'
+                    : 'descending'
+                  : undefined}
+              >
+                {#if usesAutomaticSortButton(column)}
+                  {#if column.header}
+                    <div class="data-table__header-content">
+                      {@render column.header({ column })}
+                      <button
+                        type="button"
+                        class="data-table__sort-button"
+                        onclick={(event) => handleSort(column, event)}
+                        aria-label={sortActionLabel(column)}
+                      >
+                        <span class="data-table__sort-icon" aria-hidden="true">
+                          {#if currentSort.columnId === column.id}
+                            {currentSort.direction === 'asc' ? '↑' : '↓'}
+                          {:else}
+                            ↕
+                          {/if}
+                        </span>
+                      </button>
+                    </div>
+                  {:else}
+                    <button
+                      type="button"
+                      class="data-table__sort-button"
+                      onclick={(event) => handleSort(column, event)}
+                      aria-label={sortActionLabel(column)}
+                    >
+                      <span>{column.label}</span>
+                      <span class="data-table__sort-icon" aria-hidden="true">
+                        {#if currentSort.columnId === column.id}
+                          {currentSort.direction === 'asc' ? '↑' : '↓'}
+                        {:else}
+                          ↕
+                        {/if}
+                      </span>
+                    </button>
+                  {/if}
+                {:else if column.header}
+                  {@render column.header({ column })}
+                {:else}
+                  {column.label}
+                {/if}
+                {#if column.resizable}
+                  <!-- svelte-ignore a11y_no_noninteractive_element_interactions: a focusable ARIA separator is the resize control. -->
+                  <span
+                    class="data-table__resize-handle"
+                    role="separator"
+                    aria-orientation="vertical"
+                    aria-label={t(M['ui.data_table.resize_column'], { column: column.label })}
+                    aria-valuemin={minimumWidth(column)}
+                    aria-valuemax={maximumWidth(column)}
+                    aria-valuenow={Math.round(currentColumnWidth(resolvedColumn))}
+                    tabindex="0"
+                    onpointerdown={(event) => handleResizePointerDown(event, resolvedColumn)}
+                    onkeydown={(event) => handleResizeKeydown(event, resolvedColumn)}
+                  ></span>
+                {/if}
+              </th>
             {/if}
-          </th>
-        {/each}
-      </tr>
+          {/each}
+        </tr>
+      {/each}
     </thead>
 
     <tbody bind:this={tableBody} class="data-table__body">
@@ -1038,7 +1269,7 @@ $effect(() => {
             class:data-table__row--interactive={Boolean(onRowClick)}
             data-row-id={dataTableRowIdKey(key)}
             aria-rowindex={virtualizationWindow.enabled
-              ? virtualRowOffset + displayIndex + 2
+              ? virtualRowOffset + displayIndex + headerRowCount + 1
               : undefined}
             onclick={(event) => handleRowActivation(event, row, displayIndex)}
             tabindex={onRowClick || virtualizationWindow.enabled ? 0 : undefined}
@@ -1063,10 +1294,22 @@ $effect(() => {
               </td>
             {/if}
 
-            {#each visibleColumns as column (column.id)}
+            {#each visibleColumns as resolvedColumn (resolvedColumn.column.id)}
+              {@const column = resolvedColumn.column}
               {@const value = getCellValue(row, column)}
               <td
                 class="data-table__cell {column.className ?? ''}"
+                class:data-table__cell--pinned-start={resolvedColumn.pin === 'start'}
+                class:data-table__cell--pinned-end={resolvedColumn.pin === 'end'}
+                data-column-id={column.id}
+                data-column-role={column.role}
+                data-responsive-priority={column.responsive?.priority}
+                data-keep-visible={column.responsive?.keepVisible ? 'true' : undefined}
+                style:width={widthForColumn(resolvedColumn)}
+                style:min-width={column.minWidth}
+                style:max-width={column.maxWidth}
+                style:left={resolvedColumn.pin === 'start' ? resolvedColumn.stickyOffset : undefined}
+                style:right={resolvedColumn.pin === 'end' ? resolvedColumn.stickyOffset : undefined}
                 style:text-align={column.align}
               >
                 {#if cell}
@@ -1092,8 +1335,143 @@ $effect(() => {
         {/if}
       {/if}
     </tbody>
-    {#if footer}
-      <tfoot bind:this={tableFooter}><tr aria-rowindex={virtualizationWindow.enabled ? virtualRowCount + 2 : undefined}><td class="data-table__cell data-table__footer" colspan={columnCount}>{@render footer({ rows: displayRows.map(({ row }) => row) })}</td></tr></tfoot>
+    {#if dataBodyStructuralRows.length > 0}
+      <tbody
+        bind:this={tableStructuralBody}
+        class="data-table__body data-table__body--structural"
+      >
+        {#each dataBodyStructuralRows as structuralRow, structuralIndex (structuralRow.id)}
+          {@const labelColumnId = structuralLabelColumnId(structuralRow)}
+          <tr
+            class="data-table__row data-table__row--structural"
+            data-row-kind={structuralRow.kind}
+            aria-label={structuralRowLabel(structuralRow)}
+            aria-rowindex={virtualizationWindow.enabled
+              ? virtualRowOffset + displayRows.length + headerRowCount + structuralIndex + 1
+              : undefined}
+          >
+            {#if expandedContent}<td class="data-table__cell data-table__cell--expand"></td>{/if}
+            {#if selectable}<td class="data-table__cell data-table__cell--checkbox"></td>{/if}
+            {#each visibleColumns as resolvedColumn (resolvedColumn.column.id)}
+              {@const column = resolvedColumn.column}
+              {@const value = structuralCellValue(structuralRow, column)}
+              {#if column.id === labelColumnId}
+                <th
+                  class="data-table__cell data-table__cell--structural-label {column.className ?? ''}"
+                  class:data-table__cell--pinned-start={resolvedColumn.pin === 'start'}
+                  class:data-table__cell--pinned-end={resolvedColumn.pin === 'end'}
+                  scope="row"
+                  data-column-id={column.id}
+                  style:width={widthForColumn(resolvedColumn)}
+                  style:min-width={column.minWidth}
+                  style:max-width={column.maxWidth}
+                  style:left={resolvedColumn.pin === 'start' ? resolvedColumn.stickyOffset : undefined}
+                  style:right={resolvedColumn.pin === 'end' ? resolvedColumn.stickyOffset : undefined}
+                  style:text-align={column.align}
+                >
+                  <span class="sr-only">{structuralRowLabel(structuralRow)}: </span>
+                  {#if structuralRow.cell}
+                    {@render structuralRow.cell({ row: structuralRow, column, value })}
+                  {:else}
+                    {value ?? ''}
+                  {/if}
+                </th>
+              {:else}
+                <td
+                  class="data-table__cell {column.className ?? ''}"
+                  class:data-table__cell--pinned-start={resolvedColumn.pin === 'start'}
+                  class:data-table__cell--pinned-end={resolvedColumn.pin === 'end'}
+                  data-column-id={column.id}
+                  style:width={widthForColumn(resolvedColumn)}
+                  style:min-width={column.minWidth}
+                  style:max-width={column.maxWidth}
+                  style:left={resolvedColumn.pin === 'start' ? resolvedColumn.stickyOffset : undefined}
+                  style:right={resolvedColumn.pin === 'end' ? resolvedColumn.stickyOffset : undefined}
+                  style:text-align={column.align}
+                >
+                  {#if structuralRow.cell}
+                    {@render structuralRow.cell({ row: structuralRow, column, value })}
+                  {:else}
+                    {value ?? ''}
+                  {/if}
+                </td>
+              {/if}
+            {/each}
+          </tr>
+        {/each}
+      </tbody>
+    {/if}
+    {#if footer || footerStructuralRows.length > 0}
+      <tfoot bind:this={tableFooter}>
+        {#each footerStructuralRows as structuralRow, structuralIndex (structuralRow.id)}
+          {@const labelColumnId = structuralLabelColumnId(structuralRow)}
+          <tr
+            class="data-table__row data-table__row--structural data-table__row--footer"
+            data-row-kind={structuralRow.kind}
+            aria-label={structuralRowLabel(structuralRow)}
+            aria-rowindex={virtualizationWindow.enabled
+              ? virtualRowCount + headerRowCount + dataBodyStructuralRows.length + structuralIndex + 1
+              : undefined}
+          >
+            {#if expandedContent}<td class="data-table__cell data-table__cell--expand"></td>{/if}
+            {#if selectable}<td class="data-table__cell data-table__cell--checkbox"></td>{/if}
+            {#each visibleColumns as resolvedColumn (resolvedColumn.column.id)}
+              {@const column = resolvedColumn.column}
+              {@const value = structuralCellValue(structuralRow, column)}
+              {#if column.id === labelColumnId}
+                <th
+                  class="data-table__cell data-table__cell--structural-label {column.className ?? ''}"
+                  class:data-table__cell--pinned-start={resolvedColumn.pin === 'start'}
+                  class:data-table__cell--pinned-end={resolvedColumn.pin === 'end'}
+                  scope="row"
+                  data-column-id={column.id}
+                  style:width={widthForColumn(resolvedColumn)}
+                  style:min-width={column.minWidth}
+                  style:max-width={column.maxWidth}
+                  style:left={resolvedColumn.pin === 'start' ? resolvedColumn.stickyOffset : undefined}
+                  style:right={resolvedColumn.pin === 'end' ? resolvedColumn.stickyOffset : undefined}
+                  style:text-align={column.align}
+                >
+                  <span class="sr-only">{structuralRowLabel(structuralRow)}: </span>
+                  {#if structuralRow.cell}
+                    {@render structuralRow.cell({ row: structuralRow, column, value })}
+                  {:else}
+                    {value ?? ''}
+                  {/if}
+                </th>
+              {:else}
+                <td
+                  class="data-table__cell {column.className ?? ''}"
+                  class:data-table__cell--pinned-start={resolvedColumn.pin === 'start'}
+                  class:data-table__cell--pinned-end={resolvedColumn.pin === 'end'}
+                  data-column-id={column.id}
+                  style:width={widthForColumn(resolvedColumn)}
+                  style:min-width={column.minWidth}
+                  style:max-width={column.maxWidth}
+                  style:left={resolvedColumn.pin === 'start' ? resolvedColumn.stickyOffset : undefined}
+                  style:right={resolvedColumn.pin === 'end' ? resolvedColumn.stickyOffset : undefined}
+                  style:text-align={column.align}
+                >
+                  {#if structuralRow.cell}
+                    {@render structuralRow.cell({ row: structuralRow, column, value })}
+                  {:else}
+                    {value ?? ''}
+                  {/if}
+                </td>
+              {/if}
+            {/each}
+          </tr>
+        {/each}
+        {#if footer}
+          <tr aria-rowindex={virtualizationWindow.enabled
+            ? virtualRowCount + headerRowCount + structuralRowCount
+            : undefined}>
+            <td class="data-table__cell data-table__footer" colspan={columnCount}>
+              {@render footer({ rows: displayRows.map(({ row }) => row) })}
+            </td>
+          </tr>
+        {/if}
+      </tfoot>
     {/if}
   </table>
   {#if errorMessage && hasRenderedRows}
@@ -1205,6 +1583,7 @@ $effect(() => {
   }
 
   .data-table__cell--header {
+    position: relative;
     padding: var(--smrt-spacing-3, 0.75rem) var(--smrt-spacing-4, 1rem);
     font-weight: var(--smrt-typography-weight-semibold, 600);
     text-align: left;
@@ -1234,6 +1613,39 @@ $effect(() => {
     display: inline-flex;
     align-items: center;
     gap: var(--smrt-spacing-1, 0.25rem);
+  }
+
+  .data-table__cell--header-group {
+    color: var(--smrt-color-on-surface-variant, #6b7280);
+    font: var(--smrt-typography-label-medium-font);
+    letter-spacing: 0.02em;
+  }
+
+  .data-table__resize-handle {
+    position: absolute;
+    top: 0;
+    right: -0.35rem;
+    z-index: 3;
+    display: block;
+    width: 0.7rem;
+    height: 100%;
+    cursor: col-resize;
+    touch-action: none;
+  }
+
+  .data-table__resize-handle::after {
+    position: absolute;
+    top: 20%;
+    right: 0.3rem;
+    width: 1px;
+    height: 60%;
+    background: var(--smrt-color-outline, #9ca3af);
+    content: '';
+  }
+
+  .data-table__resize-handle:focus-visible {
+    outline: 2px solid var(--smrt-color-primary, #3b82f6);
+    outline-offset: -2px;
   }
 
   .data-table__sort-button:hover {
@@ -1297,6 +1709,24 @@ $effect(() => {
     vertical-align: middle;
   }
 
+  .data-table__cell--pinned-start,
+  .data-table__cell--pinned-end {
+    position: sticky;
+    z-index: 1;
+    background: var(--smrt-color-surface, #ffffff);
+  }
+
+  .data-table__cell--header.data-table__cell--pinned-start,
+  .data-table__cell--header.data-table__cell--pinned-end {
+    z-index: 3;
+    background: var(--smrt-color-surface-container, #f3f4f6);
+  }
+
+  .data-table__row--selected .data-table__cell--pinned-start,
+  .data-table__row--selected .data-table__cell--pinned-end {
+    background: var(--smrt-color-primary-container, #dbeafe);
+  }
+
   .data-table__cell--checkbox {
     width: 48px;
     text-align: center;
@@ -1307,6 +1737,9 @@ $effect(() => {
   .data-table__expand-button:focus-visible { outline: 2px solid var(--smrt-color-primary); outline-offset: 2px; }
   .data-table__cell--expanded { padding: var(--smrt-spacing-4); background: var(--smrt-color-surface-container-low); }
   .data-table__footer { border-top: 2px solid var(--smrt-color-outline-variant); font-weight: var(--smrt-typography-weight-medium); }
+  .data-table__row--structural { background: var(--smrt-color-surface-container-low, #f9fafb); }
+  .data-table__row--footer { border-top: 2px solid var(--smrt-color-outline-variant); }
+  .data-table__cell--structural-label { font-weight: var(--smrt-typography-weight-semibold, 600); }
 
   .data-table__checkbox {
     width: 18px;

--- a/packages/smrt-ui/src/components/data/DataTableController.ts
+++ b/packages/smrt-ui/src/components/data/DataTableController.ts
@@ -71,6 +71,18 @@ export interface DataTableColumnVisibility {
   visible: boolean;
 }
 
+/** A persisted width in CSS pixels. Static column widths remain presentation defaults. */
+export interface DataTableColumnWidth {
+  columnId: string;
+  width: number;
+}
+
+/** A persisted edge pin. Column order is retained within each pin partition. */
+export interface DataTableColumnPinning {
+  columnId: string;
+  position: 'start' | 'end';
+}
+
 /**
  * The JSON-safe, persistable portion of a table view. Selection and expansion
  * are serialized as canonical arrays rather than Sets.
@@ -83,6 +95,8 @@ export interface DataTableViewState {
   pageSize: number | null;
   columnOrder: string[];
   columnVisibility: DataTableColumnVisibility[];
+  columnWidths: DataTableColumnWidth[];
+  columnPinning: DataTableColumnPinning[];
   selection: DataTableSelection;
   /**
    * Legacy shorthand for row-ID selections. It is always derived from
@@ -93,16 +107,23 @@ export interface DataTableViewState {
 }
 
 /**
- * Accepts a version-1 controlled state while the controller always emits the
- * normalized version-2 `DataTableViewState` with an explicit selection.
+ * Accepts version-1 and version-2 controlled state while the controller emits
+ * normalized version-3 state with explicit selection and column layout.
  */
-export type DataTableViewStateInput = Omit<DataTableViewState, 'selection'> & {
+export type DataTableViewStateInput = Omit<
+  DataTableViewState,
+  'selection' | 'columnWidths' | 'columnPinning'
+> & {
   selection?: DataTableSelection;
+  /** Optional while restoring version-1 or version-2 state. */
+  columnWidths?: DataTableColumnWidth[];
+  /** Optional while restoring version-1 or version-2 state. */
+  columnPinning?: DataTableColumnPinning[];
 };
 
 /** The stable envelope intended for URL and saved-view adapters. */
 export interface DataTableSnapshot {
-  version: 2;
+  version: 3;
   modes: DataTableModes;
   state: DataTableViewState;
 }
@@ -117,6 +138,14 @@ export type DataTableCommand =
   | { type: 'setPageSize'; pageSize: number | null }
   | { type: 'setColumnOrder'; columnIds: string[] }
   | { type: 'setColumnVisibility'; columns: DataTableColumnVisibility[] }
+  | { type: 'setColumnWidths'; columns: DataTableColumnWidth[] }
+  | { type: 'setColumnWidth'; columnId: string; width: number | null }
+  | { type: 'setColumnPinning'; columns: DataTableColumnPinning[] }
+  | {
+      type: 'setColumnPin';
+      columnId: string;
+      position: DataTableColumnPinning['position'] | null;
+    }
   | { type: 'setSelection'; selection: DataTableSelection }
   | { type: 'setPageSelection'; rowIds: DataTableRowId[] }
   | ({
@@ -144,6 +173,8 @@ export interface DataTableControllerOptions {
   modes?: Partial<DataTableModes>;
   /** Optional known columns let the controller ignore stale saved-view fields. */
   columnIds?: readonly string[];
+  /** Static schema constraints that saved or controlled state may not override. */
+  hiddenColumnIds?: readonly string[];
   onStateChange?: (
     state: DataTableViewState,
     command: DataTableCommand,
@@ -166,6 +197,8 @@ const DEFAULT_STATE: DataTableViewState = {
   pageSize: null,
   columnOrder: [],
   columnVisibility: [],
+  columnWidths: [],
+  columnPinning: [],
   selection: { scope: 'explicit', rowIds: [] },
   selectedRowIds: [],
   expandedRowIds: [],
@@ -508,6 +541,44 @@ function normalizeVisibility(
     .map(([columnId, visible]) => ({ columnId, visible }));
 }
 
+function normalizeWidths(
+  values: readonly DataTableColumnWidth[],
+): DataTableColumnWidth[] {
+  const entries = new Map<string, number>();
+  for (const entry of values) {
+    const columnId = assertColumnId(entry?.columnId, 'width column id');
+    if (
+      typeof entry?.width !== 'number' ||
+      !Number.isFinite(entry.width) ||
+      entry.width <= 0
+    ) {
+      throw new TypeError(
+        'DataTable column widths must be positive finite numbers',
+      );
+    }
+    entries.set(columnId, entry.width);
+  }
+  return [...entries.entries()]
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([columnId, width]) => ({ columnId, width }));
+}
+
+function normalizePinning(
+  values: readonly DataTableColumnPinning[],
+): DataTableColumnPinning[] {
+  const entries = new Map<string, DataTableColumnPinning['position']>();
+  for (const entry of values) {
+    const columnId = assertColumnId(entry?.columnId, 'pin column id');
+    if (entry?.position !== 'start' && entry?.position !== 'end') {
+      throw new TypeError('DataTable column pins must be start or end');
+    }
+    entries.set(columnId, entry.position);
+  }
+  return [...entries.entries()]
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([columnId, position]) => ({ columnId, position }));
+}
+
 function normalizeModes(
   modes: Partial<DataTableModes> | undefined,
 ): DataTableModes {
@@ -523,6 +594,7 @@ function normalizeModes(
 function normalizeState(
   state: Partial<DataTableViewState> | undefined,
   columnIds?: readonly string[],
+  hiddenColumnIds?: readonly string[],
 ): DataTableViewState {
   const input = state ?? {};
   const selection = normalizeSelection(
@@ -532,6 +604,11 @@ function normalizeState(
   const knownColumns = columnIds ? normalizeUniqueColumnIds(columnIds) : null;
   const allowed = knownColumns ? new Set(knownColumns) : null;
   const keepKnown = (columnId: string) => !allowed || allowed.has(columnId);
+  const hidden = new Set(
+    (hiddenColumnIds ? normalizeUniqueColumnIds(hiddenColumnIds) : []).filter(
+      keepKnown,
+    ),
+  );
   const visibility = normalizeVisibility(
     input.columnVisibility ?? DEFAULT_STATE.columnVisibility,
   ).filter((entry) => keepKnown(entry.columnId));
@@ -544,6 +621,7 @@ function normalizeState(
       if (!knownVisibility.has(columnId)) knownVisibility.set(columnId, true);
     }
   }
+  for (const columnId of hidden) knownVisibility.set(columnId, false);
 
   const columnOrder = normalizeUniqueColumnIds(
     input.columnOrder ?? DEFAULT_STATE.columnOrder,
@@ -553,6 +631,13 @@ function normalizeState(
       if (!columnOrder.includes(columnId)) columnOrder.push(columnId);
     }
   }
+
+  const columnWidths = normalizeWidths(
+    input.columnWidths ?? DEFAULT_STATE.columnWidths,
+  ).filter((entry) => keepKnown(entry.columnId));
+  const columnPinning = normalizePinning(
+    input.columnPinning ?? DEFAULT_STATE.columnPinning,
+  ).filter((entry) => keepKnown(entry.columnId));
 
   return {
     search:
@@ -572,6 +657,8 @@ function normalizeState(
         visible,
       })),
     ),
+    columnWidths,
+    columnPinning,
     selection,
     selectedRowIds: selectedRowIdsFor(selection),
     expandedRowIds: normalizeRowIds(
@@ -686,6 +773,63 @@ export function transitionDataTableState(
         columnVisibility: normalizeVisibility(command.columns),
       };
       break;
+    case 'setColumnWidths':
+      next = {
+        ...current,
+        columnWidths: normalizeWidths(command.columns),
+      };
+      break;
+    case 'setColumnWidth': {
+      const columnId = assertColumnId(command.columnId, 'width column id');
+      const widths = new Map(
+        current.columnWidths.map((entry) => [entry.columnId, entry.width]),
+      );
+      if (command.width === null) {
+        widths.delete(columnId);
+      } else {
+        const normalized = normalizeWidths([
+          { columnId, width: command.width },
+        ]);
+        widths.set(columnId, normalized[0].width);
+      }
+      next = {
+        ...current,
+        columnWidths: normalizeWidths(
+          [...widths.entries()].map(([id, width]) => ({ columnId: id, width })),
+        ),
+      };
+      break;
+    }
+    case 'setColumnPinning':
+      next = {
+        ...current,
+        columnPinning: normalizePinning(command.columns),
+      };
+      break;
+    case 'setColumnPin': {
+      const columnId = assertColumnId(command.columnId, 'pin column id');
+      const pins = new Map(
+        current.columnPinning.map((entry) => [entry.columnId, entry.position]),
+      );
+      if (command.position === null) {
+        pins.delete(columnId);
+      } else {
+        const normalized = normalizePinning([
+          { columnId, position: command.position },
+        ]);
+        pins.set(columnId, normalized[0].position);
+      }
+      next = {
+        ...current,
+        columnPinning: normalizePinning(
+          [...pins.entries()].map(([id, position]) => ({
+            columnId: id,
+            position,
+          })),
+        ),
+      };
+      break;
+    }
     case 'setSelection':
       next = withSelection(current, command.selection);
       break;
@@ -763,10 +907,10 @@ export function hydrateDataTableSnapshot(value: unknown): DataTableSnapshot {
     throw new TypeError('DataTable snapshot must be a plain object');
   }
   const input = value as Record<string, unknown>;
-  if (input.version !== 1 && input.version !== 2)
+  if (input.version !== 1 && input.version !== 2 && input.version !== 3)
     throw new TypeError('Unsupported DataTable snapshot version');
   return {
-    version: 2,
+    version: 3,
     modes: normalizeModes(input.modes as Partial<DataTableModes>),
     state: normalizeState(input.state as Partial<DataTableViewState>),
   };
@@ -777,6 +921,7 @@ export class DataTableController {
   private state: DataTableViewState;
   private modes: DataTableModes;
   private columnIds?: string[];
+  private hiddenColumnIds?: string[];
   private controlled: boolean;
   private readonly listeners = new Set<DataTableStateListener>();
   private readonly onStateChange?: DataTableControllerOptions['onStateChange'];
@@ -786,10 +931,14 @@ export class DataTableController {
     this.columnIds = options.columnIds
       ? normalizeUniqueColumnIds(options.columnIds)
       : undefined;
+    this.hiddenColumnIds = options.hiddenColumnIds
+      ? normalizeUniqueColumnIds(options.hiddenColumnIds)
+      : undefined;
     this.controlled = options.state !== undefined;
     this.state = normalizeState(
       options.state ?? options.initialState,
       this.columnIds,
+      this.hiddenColumnIds,
     );
     this.modes = normalizeModes(options.modes);
     this.onStateChange = options.onStateChange;
@@ -804,7 +953,7 @@ export class DataTableController {
   }
 
   snapshot(): DataTableSnapshot {
-    return { version: 2, modes: this.getModes(), state: this.getState() };
+    return { version: 3, modes: this.getModes(), state: this.getState() };
   }
 
   subscribe(listener: DataTableStateListener): () => void {
@@ -818,9 +967,10 @@ export class DataTableController {
     const candidate = normalizeState(
       transitionDataTableState(this.state, command),
       this.columnIds,
+      this.hiddenColumnIds,
     );
     const next = {
-      version: 2 as const,
+      version: 3 as const,
       modes: this.getModes(),
       state: candidate,
     };
@@ -851,9 +1001,13 @@ export class DataTableController {
   /** Supplies state from a controlled host or an external persistence adapter. */
   replaceState(state: DataTableViewStateInput): DataTableTransition {
     const previous = this.snapshot();
-    const nextState = normalizeState(state, this.columnIds);
+    const nextState = normalizeState(
+      state,
+      this.columnIds,
+      this.hiddenColumnIds,
+    );
     const next = {
-      version: 2 as const,
+      version: 3 as const,
       modes: this.getModes(),
       state: nextState,
     };
@@ -888,10 +1042,18 @@ export class DataTableController {
   }
 
   /** Reconciles stale saved-view column IDs with the renderer's current columns. */
-  setColumnIds(columnIds: readonly string[]): DataTableTransition {
+  setColumnIds(
+    columnIds: readonly string[],
+    hiddenColumnIds: readonly string[] = [],
+  ): DataTableTransition {
     const previous = this.snapshot();
     this.columnIds = normalizeUniqueColumnIds(columnIds);
-    this.state = normalizeState(this.state, this.columnIds);
+    this.hiddenColumnIds = normalizeUniqueColumnIds(hiddenColumnIds);
+    this.state = normalizeState(
+      this.state,
+      this.columnIds,
+      this.hiddenColumnIds,
+    );
     const next = this.snapshot();
     const changed = snapshotSignature(previous) !== snapshotSignature(next);
     const transition = { command: null, previous, next, changed };

--- a/packages/smrt-ui/src/components/data/DataTableController.ts
+++ b/packages/smrt-ui/src/components/data/DataTableController.ts
@@ -922,6 +922,12 @@ export class DataTableController {
   private modes: DataTableModes;
   private columnIds?: string[];
   private hiddenColumnIds?: string[];
+  /**
+   * Static schema visibility is a rendering constraint, not a saved-view
+   * preference. Keep the latter while a column is constrained so removing the
+   * constraint restores the caller's prior intent.
+   */
+  private readonly visibilityBeforeStaticHide = new Map<string, boolean>();
   private controlled: boolean;
   private readonly listeners = new Set<DataTableStateListener>();
   private readonly onStateChange?: DataTableControllerOptions['onStateChange'];
@@ -934,6 +940,10 @@ export class DataTableController {
     this.hiddenColumnIds = options.hiddenColumnIds
       ? normalizeUniqueColumnIds(options.hiddenColumnIds)
       : undefined;
+    this.rememberStaticVisibility(
+      options.state ?? options.initialState ?? {},
+      this.hiddenColumnIds ?? [],
+    );
     this.controlled = options.state !== undefined;
     this.state = normalizeState(
       options.state ?? options.initialState,
@@ -1001,6 +1011,9 @@ export class DataTableController {
   /** Supplies state from a controlled host or an external persistence adapter. */
   replaceState(state: DataTableViewStateInput): DataTableTransition {
     const previous = this.snapshot();
+    if (this.controlled) {
+      this.rememberStaticVisibility(state, this.hiddenColumnIds ?? [], true);
+    }
     const nextState = normalizeState(
       state,
       this.columnIds,
@@ -1047,10 +1060,39 @@ export class DataTableController {
     hiddenColumnIds: readonly string[] = [],
   ): DataTableTransition {
     const previous = this.snapshot();
+    const previousHidden = new Set(this.hiddenColumnIds ?? []);
     this.columnIds = normalizeUniqueColumnIds(columnIds);
     this.hiddenColumnIds = normalizeUniqueColumnIds(hiddenColumnIds);
-    this.state = normalizeState(
+    this.rememberStaticVisibility(
       this.state,
+      this.hiddenColumnIds.filter((columnId) => !previousHidden.has(columnId)),
+    );
+
+    const restoredVisibility = new Map(
+      this.state.columnVisibility.map((entry) => [
+        entry.columnId,
+        entry.visible,
+      ]),
+    );
+    for (const columnId of previousHidden) {
+      if (this.hiddenColumnIds.includes(columnId)) continue;
+      const visible = this.visibilityBeforeStaticHide.get(columnId);
+      if (visible !== undefined) restoredVisibility.set(columnId, visible);
+      this.visibilityBeforeStaticHide.delete(columnId);
+    }
+    const knownColumns = new Set(this.columnIds);
+    for (const columnId of this.visibilityBeforeStaticHide.keys()) {
+      if (!knownColumns.has(columnId)) {
+        this.visibilityBeforeStaticHide.delete(columnId);
+      }
+    }
+    this.state = normalizeState(
+      {
+        ...this.state,
+        columnVisibility: [...restoredVisibility.entries()].map(
+          ([columnId, visible]) => ({ columnId, visible }),
+        ),
+      },
       this.columnIds,
       this.hiddenColumnIds,
     );
@@ -1059,6 +1101,30 @@ export class DataTableController {
     const transition = { command: null, previous, next, changed };
     if (changed) this.emit(transition);
     return transition;
+  }
+
+  private rememberStaticVisibility(
+    state: Partial<DataTableViewState>,
+    hiddenColumnIds: readonly string[],
+    overwrite = false,
+  ): void {
+    const visibility = new Map(
+      normalizeVisibility(state.columnVisibility ?? []).map((entry) => [
+        entry.columnId,
+        entry.visible,
+      ]),
+    );
+    for (const columnId of hiddenColumnIds) {
+      const visible = visibility.get(columnId);
+      if (
+        visible !== undefined &&
+        (overwrite || !this.visibilityBeforeStaticHide.has(columnId))
+      ) {
+        this.visibilityBeforeStaticHide.set(columnId, visible);
+      } else if (!this.visibilityBeforeStaticHide.has(columnId)) {
+        this.visibilityBeforeStaticHide.set(columnId, true);
+      }
+    }
   }
 
   /** Clamp against a reliable total. A missing total intentionally does not guess. */

--- a/packages/smrt-ui/src/components/data/DataTableLayout.ts
+++ b/packages/smrt-ui/src/components/data/DataTableLayout.ts
@@ -1,0 +1,219 @@
+import type {
+  DataTableColumnPinning,
+  DataTableViewState,
+} from './DataTableController.js';
+import type { DataTableColumn, DataTableHeaderPathSegment } from './types.js';
+
+export interface DataTableResolvedColumn<T> {
+  column: DataTableColumn<T>;
+  pin?: DataTableColumnPinning['position'];
+  /** A persisted pixel width supersedes the column's presentational default. */
+  width?: number;
+  /** CSS-safe width used for a sticky offset when one is available. */
+  offsetWidth: string;
+  stickyOffset?: string;
+}
+
+export interface DataTableHeaderGroupCell {
+  kind: 'group';
+  key: string;
+  label: string;
+  colspan: number;
+  rowspan: number;
+  pin?: DataTableColumnPinning['position'];
+  stickyOffset?: string;
+}
+
+export interface DataTableHeaderLeafCell<T> {
+  kind: 'leaf';
+  column: DataTableResolvedColumn<T>;
+  rowspan: number;
+}
+
+export type DataTableHeaderCell<T> =
+  | DataTableHeaderGroupCell
+  | DataTableHeaderLeafCell<T>;
+
+export interface DataTableLayout<T> {
+  columns: DataTableResolvedColumn<T>[];
+  headerRows: DataTableHeaderCell<T>[][];
+}
+
+function compareOrder<T>(
+  left: DataTableColumn<T>,
+  right: DataTableColumn<T>,
+  order: ReadonlyMap<string, number>,
+): number {
+  const leftOrder = order.get(left.id) ?? Number.MAX_SAFE_INTEGER;
+  const rightOrder = order.get(right.id) ?? Number.MAX_SAFE_INTEGER;
+  return leftOrder === rightOrder ? 0 : leftOrder - rightOrder;
+}
+
+function headerPath<T>(
+  column: DataTableColumn<T>,
+): readonly DataTableHeaderPathSegment[] {
+  const path = column.headerPath ?? [];
+  for (const segment of path) {
+    if (
+      !segment ||
+      typeof segment.id !== 'string' ||
+      segment.id.length === 0 ||
+      typeof segment.label !== 'string' ||
+      segment.label.length === 0
+    ) {
+      throw new TypeError(
+        `DataTable headerPath entries for ${column.id} require non-empty id and label`,
+      );
+    }
+  }
+  return path;
+}
+
+function offsetWidth<T>(
+  column: DataTableColumn<T>,
+  width?: number,
+  measuredWidth?: number,
+): string {
+  if (width !== undefined) return `${width}px`;
+  if (measuredWidth !== undefined && measuredWidth > 0) {
+    return `${measuredWidth}px`;
+  }
+  return column.width ?? column.minWidth ?? '0px';
+}
+
+function resolveHeaderRows<T>(
+  columns: readonly DataTableResolvedColumn<T>[],
+): DataTableHeaderCell<T>[][] {
+  const paths = columns.map(({ column }) => headerPath(column));
+  const groupDepth = Math.max(0, ...paths.map((path) => path.length));
+  if (groupDepth === 0) {
+    return [columns.map((column) => ({ kind: 'leaf', column, rowspan: 1 }))];
+  }
+
+  const rows: DataTableHeaderCell<T>[][] = Array.from(
+    { length: groupDepth + 1 },
+    () => [],
+  );
+  for (let level = 0; level <= groupDepth; level += 1) {
+    let index = 0;
+    while (index < columns.length) {
+      const path = paths[index];
+      if (path.length < level) {
+        index += 1;
+        continue;
+      }
+      if (path.length === level) {
+        rows[level].push({
+          kind: 'leaf',
+          column: columns[index],
+          rowspan: groupDepth - level + 1,
+        });
+        index += 1;
+        continue;
+      }
+
+      const segment = path[level];
+
+      let end = index + 1;
+      while (
+        end < columns.length &&
+        paths[end][level]?.id === segment.id &&
+        paths[end][level]?.label === segment.label
+      ) {
+        end += 1;
+      }
+      rows[level].push({
+        kind: 'group',
+        key: `${level}:${index}:${segment.id}`,
+        label: segment.label,
+        colspan: end - index,
+        rowspan: 1,
+        ...resolveGroupPin(columns.slice(index, end)),
+      });
+      index = end;
+    }
+  }
+  return rows;
+}
+
+function resolveGroupPin<T>(
+  columns: readonly DataTableResolvedColumn<T>[],
+): Pick<DataTableHeaderGroupCell, 'pin' | 'stickyOffset'> {
+  const pin = columns[0]?.pin;
+  if (!pin || !columns.every((column) => column.pin === pin)) return {};
+  const edge = pin === 'start' ? columns[0] : columns.at(-1);
+  return { pin, stickyOffset: edge?.stickyOffset };
+}
+
+/**
+ * Resolve a DOM-safe table layout from canonical controller state. Pinning is
+ * a partition of the configured order so the visual and assistive orders stay
+ * aligned. Header groups are then rebuilt from the final visible leaf order.
+ */
+export function resolveDataTableLayout<T>(
+  columns: readonly DataTableColumn<T>[],
+  state: Pick<
+    DataTableViewState,
+    'columnOrder' | 'columnVisibility' | 'columnWidths' | 'columnPinning'
+  >,
+  measuredWidths: Readonly<Record<string, number>> = {},
+): DataTableLayout<T> {
+  const order = new Map(state.columnOrder.map((id, index) => [id, index]));
+  const visibility = new Map(
+    state.columnVisibility.map((entry) => [entry.columnId, entry.visible]),
+  );
+  const widths = new Map(
+    state.columnWidths.map((entry) => [entry.columnId, entry.width]),
+  );
+  const pinning = new Map(
+    state.columnPinning.map((entry) => [entry.columnId, entry.position]),
+  );
+  const ordered = columns
+    .filter((column) => !column.hidden && visibility.get(column.id) !== false)
+    .slice()
+    .sort((left, right) => compareOrder(left, right, order));
+  const partitions = {
+    start: ordered.filter((column) => pinning.get(column.id) === 'start'),
+    center: ordered.filter((column) => !pinning.has(column.id)),
+    end: ordered.filter((column) => pinning.get(column.id) === 'end'),
+  };
+  const resolved: DataTableResolvedColumn<T>[] = [];
+  let startOffset = '0px';
+  for (const column of partitions.start) {
+    const width = widths.get(column.id);
+    const offset = offsetWidth(column, width, measuredWidths[column.id]);
+    resolved.push({
+      column,
+      pin: 'start',
+      width,
+      offsetWidth: offset,
+      stickyOffset: startOffset,
+    });
+    startOffset = `calc(${startOffset} + ${offset})`;
+  }
+  for (const column of partitions.center) {
+    const width = widths.get(column.id);
+    resolved.push({
+      column,
+      width,
+      offsetWidth: offsetWidth(column, width, measuredWidths[column.id]),
+    });
+  }
+  let endOffset = '0px';
+  const endColumns: DataTableResolvedColumn<T>[] = [];
+  for (const column of partitions.end.slice().reverse()) {
+    const width = widths.get(column.id);
+    const offset = offsetWidth(column, width, measuredWidths[column.id]);
+    endColumns.unshift({
+      column,
+      pin: 'end',
+      width,
+      offsetWidth: offset,
+      stickyOffset: endOffset,
+    });
+    endOffset = `calc(${endOffset} + ${offset})`;
+  }
+  resolved.push(...endColumns);
+
+  return { columns: resolved, headerRows: resolveHeaderRows(resolved) };
+}

--- a/packages/smrt-ui/src/components/data/DataTableLayout.ts
+++ b/packages/smrt-ui/src/components/data/DataTableLayout.ts
@@ -74,10 +74,10 @@ function offsetWidth<T>(
   width?: number,
   measuredWidth?: number,
 ): string {
-  if (width !== undefined) return `${width}px`;
   if (measuredWidth !== undefined && measuredWidth > 0) {
     return `${measuredWidth}px`;
   }
+  if (width !== undefined) return `${width}px`;
   return column.width ?? column.minWidth ?? '0px';
 }
 

--- a/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
@@ -696,6 +696,163 @@ describe('DataTable', () => {
     expect(tableContainer.scrollLeft).toBe(0);
   });
 
+  it('renders grouped headers from final visible leaf columns without losing leaf sort controls', async () => {
+    const groupedColumns = [
+      {
+        ...columns[0],
+        headerPath: [{ id: 'identity', label: 'Identity' }],
+      },
+      {
+        ...columns[1],
+        sortable: true,
+        headerPath: [{ id: 'measures', label: 'Measures' }],
+      },
+    ];
+    render(DataTable, {
+      props: { data, columns: groupedColumns, sortable: true },
+    });
+
+    const identity = screen.getByRole('columnheader', { name: 'Identity' });
+    expect(identity).toHaveAttribute('scope', 'colgroup');
+    expect(identity).toHaveAttribute('colspan', '1');
+    expect(screen.getAllByRole('row')).toHaveLength(data.length + 2);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Sort Name ascending' }),
+    );
+    expect(screen.getByRole('columnheader', { name: 'Name' })).toHaveAttribute(
+      'aria-sort',
+      'ascending',
+    );
+  });
+
+  it('keeps a group header aligned when all of its leaves are pinned', () => {
+    const controller = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+      initialState: {
+        columnPinning: [
+          { columnId: 'name', position: 'start' },
+          { columnId: 'age', position: 'start' },
+        ],
+      },
+    });
+    render(DataTable, {
+      props: {
+        data,
+        controller,
+        columns: columns.map((column) => ({
+          ...column,
+          headerPath: [{ id: 'detail', label: 'Detail' }],
+        })),
+      },
+    });
+
+    const group = screen.getByRole('columnheader', { name: 'Detail' });
+    expect(group).toHaveClass('data-table__cell--pinned-start');
+    expect(group).toHaveStyle({ left: '0px' });
+  });
+
+  it('keeps report structural rows semantic and outside data-row selection', () => {
+    const { container } = render(DataTable, {
+      props: {
+        data,
+        columns,
+        rowKey: 'id',
+        selectable: true,
+        structuralRows: [
+          {
+            id: 'subtotal',
+            kind: 'subtotal',
+            label: 'Current page total',
+            values: { age: 90 },
+          },
+          {
+            id: 'footer',
+            kind: 'footer',
+            label: 'All people',
+            values: { age: 90 },
+          },
+        ],
+      },
+    });
+
+    expect(
+      screen.getByRole('rowheader', { name: /Subtotal: Current page total/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('rowheader', { name: /Footer: All people/ }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('checkbox')).toHaveLength(data.length + 1);
+    expect(
+      container.querySelectorAll('tbody.data-table__body--structural input'),
+    ).toHaveLength(0);
+    expect(container.querySelector('tfoot')).toContainElement(
+      screen.getByRole('rowheader', { name: /Footer: All people/ }),
+    );
+  });
+
+  it('uses controlled width and pin state for the accessible header resize control', async () => {
+    const controller = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+      initialState: {
+        columnWidths: [{ columnId: 'name', width: 120 }],
+        columnPinning: [{ columnId: 'name', position: 'start' }],
+      },
+    });
+    const { container } = render(DataTable, {
+      props: {
+        data,
+        columns: [{ ...columns[0], resizable: true }, columns[1]],
+        controller,
+      },
+    });
+
+    const nameHeader = screen.getByRole('columnheader', { name: 'Name' });
+    expect(nameHeader).toHaveClass('data-table__cell--pinned-start');
+    expect(nameHeader).toHaveStyle({ width: '120px', left: '0px' });
+    expect(nameHeader).toHaveAttribute('data-column-id', 'name');
+    const separator = screen.getByRole('separator', { name: 'Resize Name' });
+    separator.focus();
+    await userEvent.keyboard('{ArrowRight}');
+    expect(controller.getState().columnWidths).toContainEqual({
+      columnId: 'name',
+      width: 128,
+    });
+    expect(container.querySelector('[data-column-id="name"]')).toHaveAttribute(
+      'data-column-id',
+      'name',
+    );
+  });
+
+  it('keeps statically hidden columns hidden when a controller restores them visible', async () => {
+    const controller = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+      initialState: {
+        columnVisibility: [
+          { columnId: 'name', visible: true },
+          { columnId: 'age', visible: true },
+        ],
+      },
+    });
+    render(DataTable, {
+      props: {
+        data,
+        columns: [columns[0], { ...columns[1], hidden: true }],
+        controller,
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(controller.getState().columnVisibility).toContainEqual({
+        columnId: 'age',
+        visible: false,
+      }),
+    );
+    expect(
+      screen.queryByRole('columnheader', { name: 'Age' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('is axe-clean', async () => {
     const { container } = render(DataTable, {
       props: { data, columns, caption: 'People' },

--- a/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTable.test.ts
@@ -824,6 +824,88 @@ describe('DataTable', () => {
     );
   });
 
+  it('uses rem constraints and rendered header widths for resize announcements', async () => {
+    const getBoundingClientRect = vi
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockReturnValue({ width: 208 } as DOMRect);
+    const originalRootFontSize = document.documentElement.style.fontSize;
+    try {
+      document.documentElement.style.fontSize = '16px';
+      const controller = createDataTableController({
+        columnIds: columns.map((column) => column.id),
+      });
+      render(DataTable, {
+        props: {
+          data,
+          controller,
+          columns: [
+            { ...columns[0], minWidth: '13rem', resizable: true },
+            columns[1],
+          ],
+        },
+      });
+
+      const separator = screen.getByRole('separator', { name: 'Resize Name' });
+      await vi.waitFor(() =>
+        expect(separator).toHaveAttribute('aria-valuenow', '208'),
+      );
+      separator.focus();
+      await userEvent.keyboard('{Home}');
+      expect(controller.getState().columnWidths).toContainEqual({
+        columnId: 'name',
+        width: 208,
+      });
+    } finally {
+      getBoundingClientRect.mockRestore();
+      document.documentElement.style.fontSize = originalRootFontSize;
+    }
+  });
+
+  it('clamps restored widths to the declared header constraints', () => {
+    const controller = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+      initialState: {
+        columnWidths: [{ columnId: 'name', width: 200 }],
+      },
+    });
+    render(DataTable, {
+      props: {
+        data,
+        controller,
+        columns: [
+          { ...columns[0], maxWidth: '100px', resizable: true },
+          columns[1],
+        ],
+      },
+    });
+
+    expect(screen.getByRole('columnheader', { name: 'Name' })).toHaveStyle({
+      width: '100px',
+    });
+    expect(
+      screen.getByRole('separator', { name: 'Resize Name' }),
+    ).toHaveAttribute('aria-valuenow', '100');
+  });
+
+  it('keeps custom resizable header content as the header name', () => {
+    const customHeader = createRawSnippet(() => ({
+      render: () => '<span>Account total in USD</span>',
+    }));
+    render(DataTable, {
+      props: {
+        data,
+        columns: [
+          { ...columns[0], header: customHeader, resizable: true },
+          columns[1],
+        ],
+      },
+    });
+
+    expect(
+      screen.getByRole('columnheader', { name: /Account total in USD/ }),
+    ).toBeInTheDocument();
+  });
+
   it('keeps statically hidden columns hidden when a controller restores them visible', async () => {
     const controller = createDataTableController({
       columnIds: columns.map((column) => column.id),

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableController.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableController.test.ts
@@ -318,6 +318,31 @@ describe('DataTableController', () => {
     });
   });
 
+  it('restores the saved visibility when a static hidden constraint is removed', () => {
+    const controller = createDataTableController({
+      columnIds: ['name', 'internal'],
+      initialState: {
+        ...state,
+        columnVisibility: [
+          { columnId: 'name', visible: true },
+          { columnId: 'internal', visible: true },
+        ],
+      },
+    });
+
+    controller.setColumnIds(['name', 'internal'], ['internal']);
+    expect(controller.getState().columnVisibility).toContainEqual({
+      columnId: 'internal',
+      visible: false,
+    });
+
+    controller.setColumnIds(['name', 'internal']);
+    expect(controller.getState().columnVisibility).toContainEqual({
+      columnId: 'internal',
+      visible: true,
+    });
+  });
+
   it('models current-page and explicit row selections separately', () => {
     const controller = createDataTableController({ initialState: state });
 

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableController.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableController.test.ts
@@ -18,6 +18,8 @@ const state: DataTableViewState = {
     { columnId: 'age', visible: true },
     { columnId: 'name', visible: true },
   ],
+  columnWidths: [],
+  columnPinning: [],
   selection: { scope: 'explicit', rowIds: [] },
   selectedRowIds: [],
   expandedRowIds: [],
@@ -198,10 +200,10 @@ describe('DataTableController', () => {
         state: legacyState,
       }),
     ).toMatchObject({
-      version: 2,
+      version: 3,
       state: { selection: { scope: 'explicit', rowIds: [] } },
     });
-    expect(() => hydrateDataTableSnapshot({ version: 3 })).toThrow(/version/);
+    expect(() => hydrateDataTableSnapshot({ version: 4 })).toThrow(/version/);
     expect(() =>
       transitionDataTableState(state, { type: 'setPageSize', pageSize: 0 }),
     ).toThrow(/pageSize/);
@@ -210,6 +212,110 @@ describe('DataTableController', () => {
         transitionDataTableState(state, { type: 'setPage', page }),
       ).toThrow(/page/);
     }
+  });
+
+  it('persists canonical column widths and pinning without resetting the table order', () => {
+    const controller = createDataTableController({
+      columnIds: ['name', 'age', 'status'],
+      initialState: {
+        ...state,
+        columnOrder: ['status', 'name', 'age'],
+        columnWidths: [
+          { columnId: 'status', width: 96 },
+          { columnId: 'name', width: 220 },
+        ],
+        columnPinning: [
+          { columnId: 'status', position: 'end' },
+          { columnId: 'name', position: 'start' },
+        ],
+      },
+    });
+
+    expect(controller.snapshot()).toMatchObject({
+      version: 3,
+      state: {
+        columnOrder: ['status', 'name', 'age'],
+        columnWidths: [
+          { columnId: 'name', width: 220 },
+          { columnId: 'status', width: 96 },
+        ],
+        columnPinning: [
+          { columnId: 'name', position: 'start' },
+          { columnId: 'status', position: 'end' },
+        ],
+      },
+    });
+
+    controller.dispatch({ type: 'setColumnWidth', columnId: 'age', width: 80 });
+    controller.dispatch({
+      type: 'setColumnPin',
+      columnId: 'age',
+      position: 'start',
+    });
+    expect(controller.getState().columnWidths).toEqual([
+      { columnId: 'age', width: 80 },
+      { columnId: 'name', width: 220 },
+      { columnId: 'status', width: 96 },
+    ]);
+    expect(controller.getState().columnPinning).toEqual([
+      { columnId: 'age', position: 'start' },
+      { columnId: 'name', position: 'start' },
+      { columnId: 'status', position: 'end' },
+    ]);
+
+    controller.dispatch({
+      type: 'setColumnWidth',
+      columnId: 'age',
+      width: null,
+    });
+    controller.dispatch({
+      type: 'setColumnPin',
+      columnId: 'age',
+      position: null,
+    });
+    expect(controller.getState().columnWidths).not.toContainEqual({
+      columnId: 'age',
+      width: 80,
+    });
+    expect(controller.getState().columnPinning).not.toContainEqual({
+      columnId: 'age',
+      position: 'start',
+    });
+  });
+
+  it('never restores or commands a static hidden column visible', () => {
+    const controller = createDataTableController({
+      columnIds: ['name', 'internal', 'age'],
+      hiddenColumnIds: ['internal'],
+      initialState: {
+        ...state,
+        columnVisibility: [
+          { columnId: 'internal', visible: true },
+          { columnId: 'name', visible: true },
+        ],
+      },
+    });
+
+    expect(controller.getState().columnVisibility).toContainEqual({
+      columnId: 'internal',
+      visible: false,
+    });
+    controller.dispatch({
+      type: 'setColumnVisibility',
+      columns: [{ columnId: 'internal', visible: true }],
+    });
+    expect(controller.getState().columnVisibility).toContainEqual({
+      columnId: 'internal',
+      visible: false,
+    });
+    controller.replaceState({
+      ...controller.getState(),
+      columnVisibility: [{ columnId: 'internal', visible: true }],
+    });
+    expect(controller.getState().columnVisibility).toContainEqual({
+      columnId: 'internal',
+      visible: false,
+    });
   });
 
   it('models current-page and explicit row selections separately', () => {

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableLayout.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableLayout.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import type { DataTableViewState } from '../DataTableController.js';
+import { resolveDataTableLayout } from '../DataTableLayout.js';
+import type { DataTableColumn } from '../types.js';
+
+interface ReportRow {
+  account: string;
+  actual: number;
+  budget: number;
+  status: string;
+}
+
+const columns: DataTableColumn<ReportRow>[] = [
+  {
+    id: 'account',
+    label: 'Account',
+    accessor: 'account',
+    width: '180px',
+  },
+  {
+    id: 'actual',
+    label: 'Actual',
+    accessor: 'actual',
+    headerPath: [{ id: 'measures', label: 'Measures' }],
+  },
+  {
+    id: 'budget',
+    label: 'Budget',
+    accessor: 'budget',
+    headerPath: [{ id: 'measures', label: 'Measures' }],
+  },
+  {
+    id: 'status',
+    label: 'Status',
+    accessor: 'status',
+    role: 'status',
+    responsive: { keepVisible: true, priority: 10 },
+  },
+];
+
+const state: DataTableViewState = {
+  search: '',
+  filters: [],
+  sorting: [],
+  page: 1,
+  pageSize: null,
+  columnOrder: ['account', 'actual', 'budget', 'status'],
+  columnVisibility: columns.map((column) => ({
+    columnId: column.id,
+    visible: true,
+  })),
+  columnWidths: [],
+  columnPinning: [],
+  selection: { scope: 'explicit', rowIds: [] },
+  selectedRowIds: [],
+  expandedRowIds: [],
+};
+
+describe('resolveDataTableLayout', () => {
+  it('rebuilds grouped headers after visibility, order, and pinning are resolved', () => {
+    const layout = resolveDataTableLayout(columns, {
+      ...state,
+      columnOrder: ['budget', 'account', 'actual', 'status'],
+      columnVisibility: state.columnVisibility.map((entry) =>
+        entry.columnId === 'actual' ? { ...entry, visible: false } : entry,
+      ),
+      columnPinning: [
+        { columnId: 'account', position: 'start' },
+        { columnId: 'status', position: 'end' },
+      ],
+      columnWidths: [{ columnId: 'account', width: 220 }],
+    });
+
+    expect(layout.columns.map(({ column }) => column.id)).toEqual([
+      'account',
+      'budget',
+      'status',
+    ]);
+    expect(layout.columns[0]).toMatchObject({
+      pin: 'start',
+      width: 220,
+      stickyOffset: '0px',
+    });
+    expect(layout.columns[2]).toMatchObject({
+      pin: 'end',
+      stickyOffset: '0px',
+    });
+    expect(layout.headerRows).toHaveLength(2);
+    expect(layout.headerRows[0]).toEqual([
+      expect.objectContaining({ kind: 'leaf', rowspan: 2 }),
+      expect.objectContaining({
+        kind: 'group',
+        label: 'Measures',
+        colspan: 1,
+      }),
+      expect.objectContaining({ kind: 'leaf', rowspan: 2 }),
+    ]);
+    expect(layout.headerRows[1]).toEqual([
+      expect.objectContaining({
+        kind: 'leaf',
+        column: expect.objectContaining({
+          column: expect.objectContaining({ id: 'budget' }),
+        }),
+      }),
+    ]);
+  });
+
+  it('splits a repeated group when restored order separates its leaves', () => {
+    const layout = resolveDataTableLayout(columns, {
+      ...state,
+      columnOrder: ['actual', 'status', 'budget', 'account'],
+    });
+
+    const groups = layout.headerRows[0].filter((cell) => cell.kind === 'group');
+    expect(groups).toHaveLength(2);
+    expect(groups).toEqual([
+      expect.objectContaining({ label: 'Measures', colspan: 1 }),
+      expect.objectContaining({ label: 'Measures', colspan: 1 }),
+    ]);
+  });
+
+  it('keeps an uneven header path rectangular with leaf row spans', () => {
+    const layout = resolveDataTableLayout(
+      [
+        columns[0],
+        {
+          ...columns[1],
+          headerPath: [{ id: 'performance', label: 'Performance' }],
+        },
+        {
+          ...columns[2],
+          headerPath: [
+            { id: 'performance', label: 'Performance' },
+            { id: 'plan', label: 'Plan' },
+          ],
+        },
+      ],
+      {
+        ...state,
+        columnOrder: ['account', 'actual', 'budget'],
+        columnVisibility: [
+          { columnId: 'account', visible: true },
+          { columnId: 'actual', visible: true },
+          { columnId: 'budget', visible: true },
+        ],
+      },
+    );
+
+    expect(layout.headerRows).toHaveLength(3);
+    expect(layout.headerRows[0]).toEqual([
+      expect.objectContaining({ kind: 'leaf', rowspan: 3 }),
+      expect.objectContaining({
+        kind: 'group',
+        label: 'Performance',
+        colspan: 2,
+        rowspan: 1,
+      }),
+    ]);
+    expect(layout.headerRows[1]).toEqual([
+      expect.objectContaining({ kind: 'leaf', rowspan: 2 }),
+      expect.objectContaining({ kind: 'group', label: 'Plan' }),
+    ]);
+    expect(layout.headerRows[2]).toEqual([
+      expect.objectContaining({ kind: 'leaf', rowspan: 1 }),
+    ]);
+  });
+
+  it('uses measured auto widths for sibling pins and keeps an all-pinned group aligned', () => {
+    const layout = resolveDataTableLayout(
+      [columns[1], columns[2], columns[0]],
+      {
+        ...state,
+        columnOrder: ['actual', 'budget', 'account'],
+        columnVisibility: [
+          { columnId: 'actual', visible: true },
+          { columnId: 'budget', visible: true },
+          { columnId: 'account', visible: true },
+        ],
+        columnPinning: [
+          { columnId: 'actual', position: 'start' },
+          { columnId: 'budget', position: 'start' },
+        ],
+      },
+      { actual: 104, budget: 116 },
+    );
+
+    expect(layout.columns[0]).toMatchObject({
+      column: { id: 'actual' },
+      pin: 'start',
+      stickyOffset: '0px',
+    });
+    expect(layout.columns[1]).toMatchObject({
+      column: { id: 'budget' },
+      pin: 'start',
+      stickyOffset: 'calc(0px + 104px)',
+    });
+    expect(layout.headerRows[0]).toContainEqual(
+      expect.objectContaining({
+        kind: 'group',
+        label: 'Measures',
+        pin: 'start',
+        stickyOffset: '0px',
+      }),
+    );
+  });
+});

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableLayout.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableLayout.test.ts
@@ -203,4 +203,29 @@ describe('resolveDataTableLayout', () => {
       }),
     );
   });
+
+  it('uses a rendered width before a restored width for pinned offsets', () => {
+    const layout = resolveDataTableLayout(
+      [columns[1], columns[2]],
+      {
+        ...state,
+        columnOrder: ['actual', 'budget'],
+        columnVisibility: [
+          { columnId: 'actual', visible: true },
+          { columnId: 'budget', visible: true },
+        ],
+        columnPinning: [
+          { columnId: 'actual', position: 'start' },
+          { columnId: 'budget', position: 'start' },
+        ],
+        columnWidths: [{ columnId: 'actual', width: 80 }],
+      },
+      { actual: 200, budget: 120 },
+    );
+
+    expect(layout.columns[1]).toMatchObject({
+      column: { id: 'budget' },
+      stickyOffset: 'calc(0px + 200px)',
+    });
+  });
 });

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualizationComponent.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableVirtualizationComponent.test.ts
@@ -239,6 +239,62 @@ describe('DataTable virtualization seam', () => {
     }
   });
 
+  it('accounts for grouped headers and structural summary rows in virtual context', async () => {
+    const offsetHeight = vi
+      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockImplementation(function () {
+        if (this.tagName === 'TFOOT') return 24;
+        if (
+          this.tagName === 'TBODY' &&
+          this.classList.contains('data-table__body--structural')
+        ) {
+          return 20;
+        }
+        return 0;
+      });
+    const groupedColumns = [
+      {
+        ...columns[0],
+        headerPath: [{ id: 'identity', label: 'Identity' }],
+      },
+    ];
+
+    try {
+      const { container } = render(DataTable, {
+        props: {
+          data: rows,
+          columns: groupedColumns,
+          rowKey: 'id',
+          structuralRows: [
+            { id: 'subtotal', kind: 'subtotal', label: 'Current page' },
+            { id: 'footer', kind: 'footer', label: 'All rows' },
+          ],
+          virtualization,
+        },
+      });
+      const scrollContainer = getScrollContainer(container);
+
+      expect(screen.getByRole('table')).toHaveAttribute('aria-rowcount', '104');
+      expect(screen.getByText('Record 00000').closest('tr')).toHaveAttribute(
+        'aria-rowindex',
+        '3',
+      );
+      expect(screen.getByText('Current page').closest('tr')).toHaveAttribute(
+        'aria-rowindex',
+        '103',
+      );
+      expect(screen.getByText('All rows').closest('tr')).toHaveAttribute(
+        'aria-rowindex',
+        '104',
+      );
+
+      await fireEvent.keyDown(scrollContainer, { key: 'End' });
+      expect(scrollContainer.scrollTop).toBe(1_944);
+    } finally {
+      offsetHeight.mockRestore();
+    }
+  });
+
   it('falls back for expansion without virtual scroll behavior', async () => {
     const expandedContent = createRawSnippet(() => ({
       render: () => '<p>Variable detail</p>',

--- a/packages/smrt-ui/src/components/data/types.ts
+++ b/packages/smrt-ui/src/components/data/types.ts
@@ -14,6 +14,54 @@ import type {
 import type { DataTableRowKey } from './DataTableIdentity.js';
 import type { DataTableVirtualizationOptions } from './DataTableVirtualization.js';
 
+/** A group segment owned by a leaf column so restored order can stay valid. */
+export interface DataTableHeaderPathSegment {
+  /** Stable group identity within its header level. */
+  id: string;
+  /** Human-readable group header. */
+  label: string;
+}
+
+/** Presentation metadata for responsive adapters. */
+export interface DataTableColumnResponsive {
+  /** Higher values are more important when an adapter collapses columns. */
+  priority?: number;
+  /** Keep this column visible when an adapter performs responsive collapse. */
+  keepVisible?: boolean;
+}
+
+export type DataTableColumnRole = 'data' | 'status' | 'action';
+
+export type DataTableStructuralRowKind =
+  | 'summary'
+  | 'subtotal'
+  | 'aggregate'
+  | 'footer';
+
+/** A non-data row rendered outside the selectable, virtualized data body. */
+export interface DataTableStructuralRow<T> {
+  /** Stable identifier for a structural row. */
+  id: string;
+  /** Distinguishes report structure without importing report-domain semantics. */
+  kind: DataTableStructuralRowKind;
+  /** Row-header content announced to assistive technology. */
+  label: string;
+  /** Column that receives the row header. Defaults to the first visible column. */
+  labelColumnId?: string;
+  /** Plain values keyed by column id. */
+  values?: Readonly<Record<string, unknown>>;
+  /** Optional cell renderer for this one structural row. */
+  cell?: Snippet<
+    [
+      {
+        row: DataTableStructuralRow<T>;
+        column: DataTableColumn<T>;
+        value: unknown;
+      },
+    ]
+  >;
+}
+
 /**
  * Column definition for DataTable
  */
@@ -28,6 +76,8 @@ export interface DataTableColumn<T> {
   cell?: Snippet<[{ row: T; value: unknown; index: number }]>;
   /** Custom header renderer */
   header?: Snippet<[{ column: DataTableColumn<T> }]>;
+  /** Optional group ancestry. Groups are resolved from the final visible layout. */
+  headerPath?: readonly DataTableHeaderPathSegment[];
   /**
    * How a custom header participates in sorting. `automatic` (the default)
    * renders a separate action-labelled sort button alongside the custom header,
@@ -45,6 +95,12 @@ export interface DataTableColumn<T> {
   minWidth?: string;
   /** Maximum width (CSS value) */
   maxWidth?: string;
+  /** Enables the accessible header resize separator for this column. */
+  resizable?: boolean;
+  /** Semantic metadata for generic responsive adapters. */
+  role?: DataTableColumnRole;
+  /** Metadata consumed by responsive adapters without domain coupling. */
+  responsive?: DataTableColumnResponsive;
   /** Text alignment */
   align?: 'left' | 'center' | 'right';
   /** Whether column is hidden */
@@ -142,6 +198,8 @@ export interface DataTableProps<T> {
   toolbar?: Snippet;
   /** Optional full-width table footer content. */
   footer?: Snippet<[{ rows: T[] }]>;
+  /** Generic report-like rows rendered independently from data row interactions. */
+  structuralRows?: readonly DataTableStructuralRow<T>[];
   /** Controlled visible column ids. Column.hidden is still respected. */
   visibleColumnIds?: Set<string>;
   /**

--- a/packages/smrt-ui/src/i18n/strings.ts
+++ b/packages/smrt-ui/src/i18n/strings.ts
@@ -39,4 +39,10 @@ export const M = defineMessages({
   'ui.data_table.default_overflow_region':
     'Data table, scroll horizontally to view more columns',
   'ui.data_table.more_columns': 'More columns',
+  'ui.data_table.resize_column': 'Resize {column}',
+  'ui.data_table.structural_row': '{kind}: {label}',
+  'ui.data_table.summary': 'Summary',
+  'ui.data_table.subtotal': 'Subtotal',
+  'ui.data_table.aggregate': 'Aggregate',
+  'ui.data_table.footer_row': 'Footer',
 });

--- a/packages/smrt-ui/src/svelte/playground/DataTablePreview.svelte
+++ b/packages/smrt-ui/src/svelte/playground/DataTablePreview.svelte
@@ -2,7 +2,10 @@
 import { onMount } from 'svelte';
 import DataTable from '../../components/data/DataTable.svelte';
 import { createDataTableController } from '../../components/data/DataTableController.js';
-import type { DataTableColumn } from '../../components/data/types.js';
+import type {
+  DataTableColumn,
+  DataTableStructuralRow,
+} from '../../components/data/types.js';
 import Toggle from '../../components/forms/Toggle.svelte';
 import Badge from '../../components/ui/Badge.svelte';
 import Button from '../../components/ui/Button.svelte';
@@ -14,6 +17,16 @@ interface WorkspaceUser {
   role: string;
   status: string;
   lastSeen: string;
+}
+
+interface ReportLine {
+  id: string;
+  account: string;
+  actual: number;
+  forecast: number;
+  variance: number;
+  status: string;
+  action: string;
 }
 
 const users: WorkspaceUser[] = [
@@ -67,11 +80,104 @@ const columns: DataTableColumn<WorkspaceUser>[] = [
   { id: 'lastSeen', label: 'Last seen', sortable: true, align: 'right' },
 ];
 
+const reportRows: ReportLine[] = [
+  {
+    id: 'revenue',
+    account: 'Subscription revenue',
+    actual: 182400,
+    forecast: 176000,
+    variance: 6400,
+    status: 'On track',
+    action: 'Review',
+  },
+  {
+    id: 'services',
+    account: 'Professional services',
+    actual: 48300,
+    forecast: 52000,
+    variance: -3700,
+    status: 'Watch',
+    action: 'Review',
+  },
+];
+
+const reportColumns: DataTableColumn<ReportLine>[] = [
+  {
+    id: 'account',
+    label: 'Account',
+    headerPath: [{ id: 'dimension', label: 'Dimensions' }],
+    minWidth: '13rem',
+    resizable: true,
+  },
+  {
+    id: 'actual',
+    label: 'Actual',
+    headerPath: [{ id: 'performance', label: 'Performance' }],
+    align: 'right',
+    resizable: true,
+  },
+  {
+    id: 'forecast',
+    label: 'Forecast',
+    headerPath: [{ id: 'performance', label: 'Performance' }],
+    align: 'right',
+    resizable: true,
+  },
+  {
+    id: 'variance',
+    label: 'Variance',
+    headerPath: [{ id: 'performance', label: 'Performance' }],
+    align: 'right',
+  },
+  {
+    id: 'status',
+    label: 'Status',
+    role: 'status',
+    responsive: { keepVisible: true, priority: 10 },
+  },
+  {
+    id: 'action',
+    label: 'Action',
+    role: 'action',
+    responsive: { keepVisible: true, priority: 10 },
+  },
+];
+
+const reportStructuralRows: DataTableStructuralRow<ReportLine>[] = [
+  {
+    id: 'forecast-subtotal',
+    kind: 'subtotal',
+    label: 'Current forecast',
+    values: { actual: 230700, forecast: 228000, variance: 2700 },
+  },
+  {
+    id: 'forecast-total',
+    kind: 'footer',
+    label: 'All accounts',
+    values: { actual: 230700, forecast: 228000, variance: 2700 },
+  },
+];
+
 let loading = $state(false);
 let dense = $state(false);
 const tableController = createDataTableController({
   columnIds: columns.map((column) => column.id),
   initialState: { pageSize: 3 },
+});
+const reportController = createDataTableController({
+  columnIds: reportColumns.map((column) => column.id),
+  initialState: {
+    columnOrder: reportColumns.map((column) => column.id),
+    columnWidths: [
+      { columnId: 'account', width: 240 },
+      { columnId: 'actual', width: 112 },
+      { columnId: 'forecast', width: 112 },
+    ],
+    columnPinning: [
+      { columnId: 'account', position: 'start' },
+      { columnId: 'action', position: 'end' },
+    ],
+  },
 });
 let tableState = $state(tableController.getState());
 
@@ -91,6 +197,26 @@ function toggleActiveFilter() {
     filters: tableState.filters.length
       ? []
       : [{ columnId: 'status', operator: 'equals', value: 'Active' }],
+  });
+}
+
+function restoreReportLayout() {
+  reportController.replaceState({
+    ...reportController.getState(),
+    columnOrder: reportColumns.map((column) => column.id),
+    columnVisibility: reportColumns.map((column) => ({
+      columnId: column.id,
+      visible: true,
+    })),
+    columnWidths: [
+      { columnId: 'account', width: 240 },
+      { columnId: 'actual', width: 112 },
+      { columnId: 'forecast', width: 112 },
+    ],
+    columnPinning: [
+      { columnId: 'account', position: 'start' },
+      { columnId: 'action', position: 'end' },
+    ],
   });
 }
 </script>
@@ -148,6 +274,33 @@ function toggleActiveFilter() {
       caption="Workspace users"
     />
   </div>
+
+  <section class="report-fixture" aria-labelledby="report-fixture-title">
+    <div class="report-fixture__header">
+      <div>
+        <p class="eyebrow">Report structure</p>
+        <h4 id="report-fixture-title">Forecast report</h4>
+        <p class="supporting">
+          Grouped headers, structural totals, restored widths, and pinned status/action columns.
+        </p>
+      </div>
+      <Button variant="ghost" size="sm" onclick={restoreReportLayout}>
+        Restore saved layout
+      </Button>
+    </div>
+    <div class="table-frame">
+      <DataTable
+        data={reportRows}
+        columns={reportColumns}
+        rowKey="id"
+        structuralRows={reportStructuralRows}
+        controller={reportController}
+        caption="Forecast report"
+        hoverable
+        stickyHeader
+      />
+    </div>
+  </section>
 
   <div class="empty-state">
     <div>
@@ -243,6 +396,20 @@ function toggleActiveFilter() {
     border-top: 1px solid var(--smrt-color-outline-variant);
   }
 
+  .report-fixture {
+    display: grid;
+    gap: var(--smrt-spacing-3);
+    padding-top: var(--smrt-spacing-4);
+    border-top: 1px solid var(--smrt-color-outline-variant);
+  }
+
+  .report-fixture__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--smrt-spacing-4);
+  }
+
   .empty-state > div:first-child {
     justify-content: space-between;
     gap: var(--smrt-spacing-4);
@@ -255,6 +422,7 @@ function toggleActiveFilter() {
 
   @media (max-width: 760px) {
     .workbench__header,
+    .report-fixture__header,
     .empty-state > div:first-child {
       align-items: flex-start;
       flex-direction: column;


### PR DESCRIPTION
## Summary

- Add grouped, report-grade headers derived from final visible, ordered, and pinned leaves.
- Add semantic summary, subtotal, aggregate, and footer structural rows that remain outside data-row interactions.
- Persist canonical column width and pin layout state in controller snapshot v3, with v1/v2 hydration and static-visibility enforcement.
- Add accessible resizing, pinned-column geometry, regression coverage, and one report-shaped component preview.
- Resolve review feedback for rendered width bounds, rem constraints, custom header names, sticky geometry, and temporary static-visibility constraints.

## Validation

- `pnpm --filter @happyvertical/smrt-ui test` (62 files, 610 tests)
- `pnpm --filter @happyvertical/smrt-ui typecheck`
- `pnpm --filter @happyvertical/smrt-ui build`
- `pnpm --filter @happyvertical/smrt-ui verify:pack`
- `pnpm run check:svelte-tokens`
- Pre-commit knowledge freshness and formatting

## Review

- Independent Luna preliminary review found and verified one restored-width constraint issue.
- Independent Terra final full-diff review: clean.
- Claude Sonnet was attempted first for cross-family review but is currently quota-blocked.

Closes #2439

Parent: #899

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-datatable-2439-review-5c97685c-0e09-4d0b-9c93-f816379e3eaf",
  "issue": 2439,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm --filter @happyvertical/smrt-ui test (62 files, 610 tests)",
    "pnpm --filter @happyvertical/smrt-ui typecheck",
    "pnpm --filter @happyvertical/smrt-ui build",
    "pnpm --filter @happyvertical/smrt-ui verify:pack",
    "pnpm run check:svelte-tokens",
    "pre-commit knowledge freshness and formatting"
  ]
}