### PR TITLE
feat(smrt-ui): complete DataTable release conformance

### DIFF
--- a/packages/smrt-ui/README.md
+++ b/packages/smrt-ui/README.md
@@ -135,9 +135,9 @@ transition path.
 <DataTable {controller} data={rows} {columns} rowKey="id" sortable selectable />
 ```
 
-`controller.snapshot()` returns the canonical JSON-safe version-2 `{ version,
-modes, state }` envelope. `hydrateDataTableSnapshot()` accepts version 1 and
-migrates it to version 2. The envelope contains no rows, callbacks, snippets,
+`controller.snapshot()` returns the canonical JSON-safe version-3 `{ version,
+modes, state }` envelope. `hydrateDataTableSnapshot()` accepts versions 1, 2,
+and 3 and normalizes them to version 3. The envelope contains no rows, callbacks, snippets,
 storage handles, tenant/principal data, query objects, or authority. URL and
 saved-view adapters remain application-owned: persist the snapshot (normally
 excluding selection and expansion IDs), validate it with
@@ -166,6 +166,26 @@ An explicit `controller` takes precedence over `state` and legacy bindables.
 Without one, the component creates an internal controller and maps the legacy
 props. Multi-column sorting and persisted layouts use the controller state;
 the legacy `SortState` remains intentionally single-column.
+
+### Public surface and supported combinations
+
+`DataTable` supports the following contracts. These are intentionally composed
+through the controller rather than through a separate report or remote-table
+component.
+
+| Need | Public API | Important constraint |
+| --- | --- | --- |
+| Stable row interaction | `rowKey`, `selectable`, `expanded`, `onRowClick`, `agentAddressable` | `rowKey` is mandatory whenever a row has durable or remote identity. |
+| Declarative view state | `controller`, `state`, `initialState`, `onStateChange` | A supplied `controller` wins over controlled state and legacy bindables. |
+| Local or remote transformations | `modes`, `manualSorting`, `manualPagination`, `filterFn`, `totalRows` | A manual stage never runs locally; never mix a local transform with an already transformed remote result. |
+| Query lifecycle | `loading`, `refreshing`, `stale`, `partialResults`, `error`, `onRetry` | The caller owns request cancellation and revision checks; the table only presents the supplied result state. |
+| Report layout | column `headerPath`, `resizable`, `role`, `responsive`; `structuralRows`; controller widths/pinning | Group structure follows final visible leaf columns. Structural rows are never selectable or virtualized. |
+| Narrow screens | `visibleColumnIds` and responsive column metadata | The table preserves its semantic columns behind a named, keyboard-scrollable horizontal overflow region; it does not silently collapse content. |
+| Continuous browsing | `virtualization` | Requires `rowKey` and a fixed-height body. Expanded rows deliberately use the normal semantic body. |
+
+The interactive workbench's **Data Table** entry contains a release conformance
+fixture for each row in this table: local interaction, manual query lifecycle,
+responsive overflow, report layout, and virtualization.
 
 ### Row identity and selection
 
@@ -223,6 +243,42 @@ the value changes. Data or total changes clamp an out-of-range page but do not
 otherwise reset it; empty known totals normalize to page 1. Column layout,
 selection, and expansion never change the page.
 
+### Manual query, retry, and race contract
+
+When any stage is `manual`, the host owns the request and result lifecycle. On
+each query-shape change, derive a stable `queryFingerprint` and monotonically
+increasing `queryRevision`; start the request, retain the currently displayed
+rows with `refreshing`/`stale` as appropriate, and only commit a response when
+both values still match. A late response is discarded by the host, not merged
+by `DataTable`.
+
+```ts
+const query = { queryFingerprint: filterHash, queryRevision: String(revision) };
+const result = await loadRows(query);
+
+if (query.queryRevision === String(revision) && query.queryFingerprint === filterHash) {
+  rows = result.rows;
+  totalRows = result.totalRows;
+}
+```
+
+Set `error` without clearing a usable page, and make `onRetry` create a new
+revision. For query-wide actions, dispatch `selectAllMatching` with the same
+fingerprint/revision and call `assertDataTableSelectionCurrent` directly before
+the destructive request. This gives ContentList, reporting, admin, and agent
+surfaces the same stale-result and selection guardrail.
+
+### Saved layout and report guidance
+
+Use `headerPath` on every leaf that belongs to a grouped heading; matching IDs
+at a given depth form a column group after visibility and restored column order
+are applied. Keep report totals in `structuralRows` or `footer`, not in the
+data array. Persist `controller.snapshot()` only after removing tenant-specific
+selection and expansion IDs, then hydrate it before creating the next
+controller. The version-3 snapshot includes `columnOrder`,
+`columnVisibility`, `columnWidths`, and `columnPinning`, so a report can safely
+restore layout without persisting row data or query authority.
+
 ### Scale boundaries and virtualization
 
 `DATA_TABLE_SCALE_THRESHOLDS` publishes the measured operating boundaries used
@@ -269,6 +325,7 @@ hand-authored, and every text pairing clears WCAG AA.
 ```svelte
 <script>
   import { ThemeProvider } from '@happyvertical/smrt-ui/themes';
+  import '@happyvertical/smrt-ui/themes/styles/all.css';
   import '@happyvertical/smrt-ui/themes/styles/fonts.css';
 </script>
 

--- a/packages/smrt-ui/README.md
+++ b/packages/smrt-ui/README.md
@@ -246,17 +246,19 @@ selection, and expansion never change the page.
 ### Manual query, retry, and race contract
 
 When any stage is `manual`, the host owns the request and result lifecycle. On
-each query-shape change, derive a stable `queryFingerprint` and monotonically
-increasing `queryRevision`; start the request, retain the currently displayed
-rows with `refreshing`/`stale` as appropriate, and only commit a response when
-both values still match. A late response is discarded by the host, not merged
-by `DataTable`.
+each query-shape change, derive a stable `queryFingerprint` from every
+server-owned input (search, filters, sort rules, page, and page size) and a
+monotonically increasing `queryRevision`; start the request, retain the
+currently displayed rows with `refreshing`/`stale` as appropriate, and only
+commit a response when both values still match. A late response is discarded by
+the host, not merged by `DataTable`.
 
 ```ts
-const query = { queryFingerprint: filterHash, queryRevision: String(revision) };
+const queryFingerprint = JSON.stringify({ search, filters, sorting, page, pageSize });
+const query = { queryFingerprint, queryRevision: String(revision) };
 const result = await loadRows(query);
 
-if (query.queryRevision === String(revision) && query.queryFingerprint === filterHash) {
+if (query.queryRevision === String(revision) && query.queryFingerprint === currentQueryFingerprint()) {
   rows = result.rows;
   totalRows = result.totalRows;
 }

--- a/packages/smrt-ui/src/components/data/__fixtures__/DataTableConformanceFixture.ts
+++ b/packages/smrt-ui/src/components/data/__fixtures__/DataTableConformanceFixture.ts
@@ -1,0 +1,181 @@
+import type { DataTableColumn, DataTableStructuralRow } from '../types.js';
+
+/**
+ * Shared, domain-neutral data used to exercise the documented DataTable
+ * contracts in component tests and the interactive workbench preview.
+ */
+export interface DataTableConformanceRow {
+  id: string;
+  account: string;
+  team: string;
+  actual: number;
+  forecast: number;
+  variance: number;
+  status: 'On track' | 'Watch';
+  action: string;
+}
+
+export const dataTableConformanceRows: DataTableConformanceRow[] = [
+  {
+    id: 'revenue',
+    account: 'Subscription revenue',
+    team: 'Growth',
+    actual: 182_400,
+    forecast: 176_000,
+    variance: 6_400,
+    status: 'On track',
+    action: 'Review',
+  },
+  {
+    id: 'services',
+    account: 'Professional services',
+    team: 'Delivery',
+    actual: 48_300,
+    forecast: 52_000,
+    variance: -3_700,
+    status: 'Watch',
+    action: 'Review',
+  },
+];
+
+export const dataTableConformanceColumns: DataTableColumn<DataTableConformanceRow>[] =
+  [
+    {
+      id: 'account',
+      label: 'Account',
+      headerPath: [{ id: 'dimensions', label: 'Dimensions' }],
+      minWidth: '13rem',
+      resizable: true,
+      sortable: true,
+    },
+    {
+      id: 'team',
+      label: 'Team',
+      headerPath: [{ id: 'dimensions', label: 'Dimensions' }],
+      minWidth: '9rem',
+    },
+    {
+      id: 'actual',
+      label: 'Actual',
+      headerPath: [{ id: 'performance', label: 'Performance' }],
+      align: 'right',
+      resizable: true,
+    },
+    {
+      id: 'forecast',
+      label: 'Forecast',
+      headerPath: [{ id: 'performance', label: 'Performance' }],
+      align: 'right',
+      resizable: true,
+    },
+    {
+      id: 'variance',
+      label: 'Variance',
+      headerPath: [{ id: 'performance', label: 'Performance' }],
+      align: 'right',
+    },
+    {
+      id: 'status',
+      label: 'Status',
+      role: 'status',
+      responsive: { keepVisible: true, priority: 10 },
+    },
+    {
+      id: 'action',
+      label: 'Action',
+      role: 'action',
+      responsive: { keepVisible: true, priority: 10 },
+    },
+  ];
+
+export const dataTableConformanceStructuralRows: DataTableStructuralRow<DataTableConformanceRow>[] =
+  [
+    {
+      id: 'forecast-subtotal',
+      kind: 'subtotal',
+      label: 'Current forecast',
+      values: { actual: 230_700, forecast: 228_000, variance: 2_700 },
+    },
+    {
+      id: 'forecast-total',
+      kind: 'footer',
+      label: 'All accounts',
+      values: { actual: 230_700, forecast: 228_000, variance: 2_700 },
+    },
+  ];
+
+/** The release-level scenarios that must remain represented in tests and the playground. */
+export interface DataTableConformanceScenario {
+  id:
+    | 'semantic-interaction'
+    | 'manual-query'
+    | 'async-lifecycle'
+    | 'responsive-overflow'
+    | 'report-layout'
+    | 'scale-virtualization';
+  title: string;
+  contracts: readonly string[];
+}
+
+export const dataTableConformanceScenarios: readonly DataTableConformanceScenario[] =
+  [
+    {
+      id: 'semantic-interaction',
+      title: 'Semantic interaction',
+      contracts: ['caption', 'rowKey', 'selection', 'keyboard row actions'],
+    },
+    {
+      id: 'manual-query',
+      title: 'Manual query ownership',
+      contracts: [
+        'modes',
+        'totalRows',
+        'query revision',
+        'allMatching selection',
+      ],
+    },
+    {
+      id: 'async-lifecycle',
+      title: 'Async lifecycle',
+      contracts: ['loading', 'refreshing', 'stale', 'partial results', 'retry'],
+    },
+    {
+      id: 'responsive-overflow',
+      title: 'Responsive overflow',
+      contracts: [
+        'responsive metadata',
+        'named overflow region',
+        'keyboard scroll',
+      ],
+    },
+    {
+      id: 'report-layout',
+      title: 'Report layout',
+      contracts: ['grouped headers', 'structural rows', 'widths', 'pinning'],
+    },
+    {
+      id: 'scale-virtualization',
+      title: 'Scale and virtualization',
+      contracts: [
+        'rowKey',
+        'virtual body',
+        'stable focus',
+        'footer reachability',
+      ],
+    },
+  ];
+
+export function createDataTableConformanceRows(
+  rowCount: number,
+): DataTableConformanceRow[] {
+  return Array.from({ length: rowCount }, (_, index) => {
+    const source =
+      dataTableConformanceRows[index % dataTableConformanceRows.length];
+    const rowNumber = index + 1;
+    return {
+      ...source,
+      id: `conformance-${rowNumber}`,
+      account: `${source.account} ${rowNumber}`,
+    };
+  });
+}

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableConformance.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableConformance.test.ts
@@ -1,0 +1,275 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { expectNoA11yViolations } from '../../../test-support/a11y';
+import {
+  createDataTableConformanceRows,
+  type DataTableConformanceRow,
+  dataTableConformanceColumns,
+  dataTableConformanceRows,
+  dataTableConformanceScenarios,
+  dataTableConformanceStructuralRows,
+} from '../__fixtures__/DataTableConformanceFixture.js';
+import DataTable from '../DataTable.svelte';
+import {
+  createDataTableController,
+  type DataTableCommand,
+  type DataTableViewState,
+} from '../DataTableController.js';
+
+interface ManualQueryToken {
+  queryFingerprint: string;
+  queryRevision: string;
+}
+
+function isManualQueryCommand(command: DataTableCommand | undefined) {
+  return (
+    command?.type === 'setFilters' ||
+    command?.type === 'toggleSorting' ||
+    command?.type === 'setPage' ||
+    command?.type === 'setPageSize'
+  );
+}
+
+/**
+ * A deterministic consumer-side model for the guide's manual-query contract.
+ * The table owns the query state; the consumer owns matching results and never
+ * lets a late response replace the current query's rows.
+ */
+function createManualQueryHost(initialRows: DataTableConformanceRow[]) {
+  let revision = 0;
+  let current: ManualQueryToken = {
+    queryFingerprint: '',
+    queryRevision: 'revision-0',
+  };
+  let rows = initialRows;
+
+  return {
+    begin(state: DataTableViewState): ManualQueryToken {
+      revision += 1;
+      current = {
+        queryFingerprint: JSON.stringify({
+          filters: state.filters,
+          sorting: state.sorting,
+          page: state.page,
+          pageSize: state.pageSize,
+        }),
+        queryRevision: `revision-${revision}`,
+      };
+      return { ...current };
+    },
+    resolve(response: ManualQueryToken & { rows: DataTableConformanceRow[] }) {
+      if (
+        response.queryFingerprint !== current.queryFingerprint ||
+        response.queryRevision !== current.queryRevision
+      ) {
+        return false;
+      }
+      rows = response.rows;
+      return true;
+    },
+    rows: () => rows,
+  };
+}
+
+function setHorizontalOverflow(
+  container: HTMLDivElement,
+  clientWidth: number,
+  scrollWidth: number,
+) {
+  Object.defineProperties(container, {
+    clientWidth: { configurable: true, value: clientWidth },
+    scrollWidth: { configurable: true, value: scrollWidth },
+    scrollLeft: { configurable: true, value: 0, writable: true },
+  });
+  window.dispatchEvent(new Event('resize'));
+}
+
+describe('DataTable release conformance', () => {
+  it('keeps every release scenario available to both tests and the playground', () => {
+    expect(
+      dataTableConformanceScenarios.map((scenario) => scenario.id),
+    ).toEqual([
+      'semantic-interaction',
+      'manual-query',
+      'async-lifecycle',
+      'responsive-overflow',
+      'report-layout',
+      'scale-virtualization',
+    ]);
+    expect(
+      dataTableConformanceScenarios.every(
+        (scenario) => scenario.contracts.length > 0,
+      ),
+    ).toBe(true);
+  });
+
+  it('renders an axe-clean report with grouped headers and structural summaries', async () => {
+    const controller = createDataTableController({
+      columnIds: dataTableConformanceColumns.map((column) => column.id),
+      initialState: {
+        columnWidths: [{ columnId: 'account', width: 240 }],
+        columnPinning: [{ columnId: 'account', position: 'start' }],
+      },
+    });
+    const { container } = render(DataTable, {
+      props: {
+        data: dataTableConformanceRows,
+        columns: dataTableConformanceColumns,
+        rowKey: 'id',
+        controller,
+        structuralRows: dataTableConformanceStructuralRows,
+        caption: 'Conformance forecast report',
+      },
+    });
+
+    expect(
+      screen.getByRole('columnheader', { name: 'Dimensions' }),
+    ).toHaveAttribute('scope', 'colgroup');
+    expect(
+      screen.getByRole('rowheader', { name: /Current forecast/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('rowheader', { name: /All accounts/ }),
+    ).toBeInTheDocument();
+    await expectNoA11yViolations(container);
+  });
+
+  it('keeps a manual query usable through stale, failed, and retry states', async () => {
+    const onRetry = vi.fn();
+    const controller = createDataTableController({
+      columnIds: dataTableConformanceColumns.map((column) => column.id),
+      modes: { filtering: 'manual', sorting: 'manual', pagination: 'manual' },
+      initialState: { page: 2, pageSize: 25 },
+    });
+    const props = {
+      data: dataTableConformanceRows,
+      columns: dataTableConformanceColumns,
+      rowKey: 'id' as const,
+      controller,
+      totalRows: 120,
+      loading: true,
+      stale: true,
+      partialResults: true,
+      onRetry,
+      caption: 'Manual query results',
+    };
+    const { rerender } = render(DataTable, { props });
+
+    expect(
+      screen.getByRole('cell', { name: 'Subscription revenue' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'Showing stale results',
+    );
+    expect(screen.getByRole('table')).toHaveAttribute('aria-busy', 'true');
+
+    await rerender({ ...props, loading: false, error: 'Request failed' });
+    expect(screen.getByRole('alert')).toHaveTextContent('Request failed');
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('commits only the current manually owned sort, filter, and page response', async () => {
+    const controller = createDataTableController({
+      columnIds: dataTableConformanceColumns.map((column) => column.id),
+      modes: { filtering: 'manual', sorting: 'manual', pagination: 'manual' },
+      initialState: { page: 1, pageSize: 1 },
+    });
+    const host = createManualQueryHost(dataTableConformanceRows);
+    const requests: ManualQueryToken[] = [];
+    const unsubscribe = controller.subscribe((transition) => {
+      if (isManualQueryCommand(transition.command)) {
+        requests.push(host.begin(transition.next.state));
+      }
+    });
+    render(DataTable, {
+      props: {
+        data: dataTableConformanceRows,
+        columns: dataTableConformanceColumns,
+        rowKey: 'id',
+        controller,
+        sortable: true,
+        totalRows: 2,
+        caption: 'Manual host results',
+      },
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Sort Account ascending' }),
+    );
+    controller.dispatch({
+      type: 'setFilters',
+      filters: [{ columnId: 'status', operator: 'equals', value: 'On track' }],
+    });
+    await userEvent.click(screen.getByRole('button', { name: 'Next page' }));
+
+    expect(requests).toHaveLength(3);
+    expect(requests[0]).not.toEqual(requests[2]);
+    expect(
+      host.resolve({
+        ...requests[0],
+        rows: [dataTableConformanceRows[1]],
+      }),
+    ).toBe(false);
+    expect(host.rows()).toEqual(dataTableConformanceRows);
+    expect(
+      host.resolve({
+        ...requests[2],
+        rows: [dataTableConformanceRows[0]],
+      }),
+    ).toBe(true);
+    expect(host.rows()).toEqual([dataTableConformanceRows[0]]);
+    unsubscribe();
+  });
+
+  it('exposes only real horizontal overflow as a named keyboard-scroll region', async () => {
+    const { container } = render(DataTable, {
+      props: {
+        data: dataTableConformanceRows,
+        columns: dataTableConformanceColumns,
+        rowKey: 'id',
+        caption: 'Responsive conformance report',
+      },
+    });
+    const tableContainer = container.querySelector(
+      '.data-table-container',
+    ) as HTMLDivElement;
+    setHorizontalOverflow(tableContainer, 320, 960);
+
+    await vi.waitFor(() =>
+      expect(tableContainer).toHaveAttribute(
+        'aria-label',
+        'Responsive conformance report table, scroll horizontally to view more columns',
+      ),
+    );
+    tableContainer.focus();
+    await fireEvent.keyDown(tableContainer, { key: 'End' });
+    expect(tableContainer.scrollLeft).toBe(640);
+    await expectNoA11yViolations(container);
+  });
+
+  it('keeps virtual rows keyed independently from their rendered window', async () => {
+    const rows = createDataTableConformanceRows(120);
+    const { container } = render(DataTable, {
+      props: {
+        data: rows,
+        columns: dataTableConformanceColumns.slice(0, 2),
+        rowKey: 'id',
+        virtualization: { rowHeight: 24, viewportHeight: 96, overscan: 1 },
+        caption: 'Virtual conformance rows',
+      },
+    });
+    const tableContainer = container.querySelector(
+      '.data-table-container',
+    ) as HTMLDivElement;
+
+    expect(screen.getByRole('table')).toHaveAttribute('aria-rowcount', '122');
+    expect(screen.getByText('Subscription revenue 1')).toBeInTheDocument();
+    tableContainer.scrollTop = 240;
+    await fireEvent.scroll(tableContainer);
+    await vi.waitFor(() =>
+      expect(screen.getByText('Subscription revenue 11')).toBeInTheDocument(),
+    );
+  });
+});

--- a/packages/smrt-ui/src/components/data/__tests__/DataTableConformance.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/DataTableConformance.test.ts
@@ -24,7 +24,9 @@ interface ManualQueryToken {
 
 function isManualQueryCommand(command: DataTableCommand | undefined) {
   return (
+    command?.type === 'setSearch' ||
     command?.type === 'setFilters' ||
+    command?.type === 'setSorting' ||
     command?.type === 'toggleSorting' ||
     command?.type === 'setPage' ||
     command?.type === 'setPageSize'
@@ -49,6 +51,7 @@ function createManualQueryHost(initialRows: DataTableConformanceRow[]) {
       revision += 1;
       current = {
         queryFingerprint: JSON.stringify({
+          search: state.search,
           filters: state.filters,
           sorting: state.sorting,
           page: state.page,
@@ -170,7 +173,7 @@ describe('DataTable release conformance', () => {
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
-  it('commits only the current manually owned sort, filter, and page response', async () => {
+  it('commits only the current manually owned search, sort, filter, and page response', async () => {
     const controller = createDataTableController({
       columnIds: dataTableConformanceColumns.map((column) => column.id),
       modes: { filtering: 'manual', sorting: 'manual', pagination: 'manual' },
@@ -198,14 +201,22 @@ describe('DataTable release conformance', () => {
     await userEvent.click(
       screen.getByRole('button', { name: 'Sort Account ascending' }),
     );
+    controller.dispatch({ type: 'setSearch', search: 'Growth' });
+    controller.dispatch({
+      type: 'setSorting',
+      sorting: [{ columnId: 'account', direction: 'desc' }],
+    });
     controller.dispatch({
       type: 'setFilters',
       filters: [{ columnId: 'status', operator: 'equals', value: 'On track' }],
     });
     await userEvent.click(screen.getByRole('button', { name: 'Next page' }));
 
-    expect(requests).toHaveLength(3);
-    expect(requests[0]).not.toEqual(requests[2]);
+    expect(requests).toHaveLength(5);
+    expect(JSON.parse(requests[1].queryFingerprint)).toMatchObject({
+      search: 'Growth',
+    });
+    expect(requests[0]).not.toEqual(requests[4]);
     expect(
       host.resolve({
         ...requests[0],
@@ -215,7 +226,7 @@ describe('DataTable release conformance', () => {
     expect(host.rows()).toEqual(dataTableConformanceRows);
     expect(
       host.resolve({
-        ...requests[2],
+        ...requests[4],
         rows: [dataTableConformanceRows[0]],
       }),
     ).toBe(true);

--- a/packages/smrt-ui/src/svelte/playground.ts
+++ b/packages/smrt-ui/src/svelte/playground.ts
@@ -60,10 +60,10 @@ export default {
       id: 'data-table',
       title: 'Data Table',
       description:
-        'Sortable and selectable tabular data with loading, density, and empty states.',
+        'Accessible local and manual tables with query lifecycle states, grouped reports, saved layout, responsive overflow, and virtualization.',
       loadComponent: loadDataTable,
       order: 5,
-      tags: ['data', 'table', 'grid'],
+      tags: ['data', 'table', 'manual-query', 'reporting', 'accessibility'],
       modes: {
         mock: {
           label: 'Interactive',

--- a/packages/smrt-ui/src/svelte/playground/DataTablePreview.svelte
+++ b/packages/smrt-ui/src/svelte/playground/DataTablePreview.svelte
@@ -194,7 +194,9 @@ const virtualRows = createDataTableConformanceRows(120);
 const virtualColumns = dataTableConformanceColumns.slice(0, 2);
 const virtualization = { rowHeight: 32, viewportHeight: 176, overscan: 3 };
 const manualQueryCommands = new Set([
+  'setSearch',
   'setFilters',
+  'setSorting',
   'toggleSorting',
   'setPage',
   'setPageSize',
@@ -205,6 +207,15 @@ let manualLifecycle = $state<'ready' | 'refreshing' | 'stale' | 'error'>(
   'ready',
 );
 let manualQueryRevision = $state(1);
+const manualQueryFingerprint = $derived(
+  JSON.stringify({
+    search: manualState.search,
+    filters: manualState.filters,
+    sorting: manualState.sorting,
+    page: manualState.page,
+    pageSize: manualState.pageSize,
+  }),
+);
 
 onMount(() => {
   const unsubscribeTable = tableController.subscribe((transition) => {
@@ -289,7 +300,7 @@ function toggleManualFilter() {
 function selectAllMatching() {
   manualController.dispatch({
     type: 'selectAllMatching',
-    queryFingerprint: 'workspace-report:active',
+    queryFingerprint: manualQueryFingerprint,
     queryRevision: `revision-${manualQueryRevision}`,
     expectedCount: 120,
   });

--- a/packages/smrt-ui/src/svelte/playground/DataTablePreview.svelte
+++ b/packages/smrt-ui/src/svelte/playground/DataTablePreview.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
 import { onMount } from 'svelte';
+import {
+  createDataTableConformanceRows,
+  dataTableConformanceColumns,
+  dataTableConformanceRows,
+  dataTableConformanceScenarios,
+} from '../../components/data/__fixtures__/DataTableConformanceFixture.js';
 import DataTable from '../../components/data/DataTable.svelte';
 import { createDataTableController } from '../../components/data/DataTableController.js';
 import type {
@@ -179,13 +185,46 @@ const reportController = createDataTableController({
     ],
   },
 });
+const manualController = createDataTableController({
+  columnIds: dataTableConformanceColumns.map((column) => column.id),
+  modes: { filtering: 'manual', sorting: 'manual', pagination: 'manual' },
+  initialState: { page: 2, pageSize: 25 },
+});
+const virtualRows = createDataTableConformanceRows(120);
+const virtualColumns = dataTableConformanceColumns.slice(0, 2);
+const virtualization = { rowHeight: 32, viewportHeight: 176, overscan: 3 };
+const manualQueryCommands = new Set([
+  'setFilters',
+  'toggleSorting',
+  'setPage',
+  'setPageSize',
+]);
 let tableState = $state(tableController.getState());
-
-onMount(() =>
-  tableController.subscribe((transition) => {
-    tableState = transition.next.state;
-  }),
+let manualState = $state(manualController.getState());
+let manualLifecycle = $state<'ready' | 'refreshing' | 'stale' | 'error'>(
+  'ready',
 );
+let manualQueryRevision = $state(1);
+
+onMount(() => {
+  const unsubscribeTable = tableController.subscribe((transition) => {
+    tableState = transition.next.state;
+  });
+  const unsubscribeManual = manualController.subscribe((transition) => {
+    manualState = transition.next.state;
+    if (
+      transition.command &&
+      manualQueryCommands.has(transition.command.type)
+    ) {
+      manualQueryRevision += 1;
+      manualLifecycle = 'refreshing';
+    }
+  });
+  return () => {
+    unsubscribeTable();
+    unsubscribeManual();
+  };
+});
 
 function clearSelection() {
   tableController.dispatch({ type: 'setSelectedRows', rowIds: [] });
@@ -217,6 +256,42 @@ function restoreReportLayout() {
       { columnId: 'account', position: 'start' },
       { columnId: 'action', position: 'end' },
     ],
+  });
+}
+
+function showStaleManualResult() {
+  manualQueryRevision += 1;
+  manualLifecycle = 'stale';
+}
+
+function resolveManualQuery() {
+  manualLifecycle = 'ready';
+}
+
+function retryManualQuery() {
+  manualLifecycle = 'refreshing';
+  manualQueryRevision += 1;
+}
+
+function showManualFailure() {
+  manualLifecycle = 'error';
+}
+
+function toggleManualFilter() {
+  manualController.dispatch({
+    type: 'setFilters',
+    filters: manualState.filters.length
+      ? []
+      : [{ columnId: 'status', operator: 'equals', value: 'On track' }],
+  });
+}
+
+function selectAllMatching() {
+  manualController.dispatch({
+    type: 'selectAllMatching',
+    queryFingerprint: 'workspace-report:active',
+    queryRevision: `revision-${manualQueryRevision}`,
+    expectedCount: 120,
   });
 }
 </script>
@@ -300,6 +375,94 @@ function restoreReportLayout() {
         stickyHeader
       />
     </div>
+  </section>
+
+  <section class="manual-fixture" aria-labelledby="manual-fixture-title">
+    <div class="report-fixture__header">
+      <div>
+        <p class="eyebrow">Manual query and async states</p>
+        <h4 id="manual-fixture-title">Server-owned results</h4>
+        <p class="supporting">
+          Supplied rows remain usable through refresh, stale, and error states. The caller owns
+          query revisions and discards late responses.
+        </p>
+      </div>
+      <Badge variant={manualLifecycle === 'error' ? 'error' : 'default'}>
+        Revision {manualQueryRevision}
+      </Badge>
+    </div>
+    <div class="table-controls" aria-label="Manual query controls">
+      <Button variant="ghost" size="sm" onclick={showStaleManualResult}>
+        Show stale result
+      </Button>
+      <Button variant="ghost" size="sm" onclick={resolveManualQuery}>
+        Accept newer result
+      </Button>
+      <Button variant="ghost" size="sm" onclick={showManualFailure}>
+        Show failure
+      </Button>
+      <Button variant="ghost" size="sm" onclick={toggleManualFilter}>
+        {manualState.filters.length ? 'Clear manual filter' : 'Request manual filter'}
+      </Button>
+      <Button variant="ghost" size="sm" onclick={selectAllMatching}>
+        Select all 120 matching
+      </Button>
+      {#if manualState.selection.scope === 'allMatching'}
+        <span>All matching selection is bound to {manualState.selection.queryRevision}.</span>
+      {/if}
+    </div>
+    <div class="table-frame">
+      <DataTable
+        data={dataTableConformanceRows}
+        columns={dataTableConformanceColumns}
+        rowKey="id"
+        selectable
+        controller={manualController}
+        sortable
+        totalRows={120}
+        refreshing={manualLifecycle === 'refreshing'}
+        stale={manualLifecycle === 'stale'}
+        partialResults={manualLifecycle === 'stale'}
+        error={manualLifecycle === 'error' ? 'The query failed. Retry to request the current revision.' : null}
+        onRetry={retryManualQuery}
+        caption="Manual workspace report"
+        stickyHeader
+      />
+    </div>
+  </section>
+
+  <section class="scale-fixture" aria-labelledby="scale-fixture-title">
+    <div>
+      <p class="eyebrow">Scale boundary</p>
+      <h4 id="scale-fixture-title">Virtualized result window</h4>
+      <p class="supporting">
+        A fixed-height, keyboard-scrollable body renders a stable row-key window while its
+        semantic header remains visible.
+      </p>
+    </div>
+    <div class="table-frame table-frame--virtual">
+      <DataTable
+        data={virtualRows}
+        columns={virtualColumns}
+        rowKey="id"
+        {virtualization}
+        caption="Virtual workspace report"
+        striped
+        stickyHeader
+      />
+    </div>
+  </section>
+
+  <section class="coverage-fixture" aria-labelledby="coverage-fixture-title">
+    <div>
+      <p class="eyebrow">Release conformance</p>
+      <h4 id="coverage-fixture-title">Every supported DataTable surface</h4>
+    </div>
+    <ul>
+      {#each dataTableConformanceScenarios as scenario}
+        <li><strong>{scenario.title}:</strong> {scenario.contracts.join(', ')}</li>
+      {/each}
+    </ul>
   </section>
 
   <div class="empty-state">
@@ -401,6 +564,33 @@ function restoreReportLayout() {
     gap: var(--smrt-spacing-3);
     padding-top: var(--smrt-spacing-4);
     border-top: 1px solid var(--smrt-color-outline-variant);
+  }
+
+  .manual-fixture,
+  .scale-fixture,
+  .coverage-fixture {
+    display: grid;
+    gap: var(--smrt-spacing-3);
+    padding-top: var(--smrt-spacing-4);
+    border-top: 1px solid var(--smrt-color-outline-variant);
+  }
+
+  .table-frame--virtual {
+    max-height: 20rem;
+  }
+
+  .coverage-fixture ul {
+    display: grid;
+    gap: var(--smrt-spacing-2);
+    padding: 0;
+    margin: 0;
+    color: var(--smrt-color-on-surface-variant);
+    font: var(--smrt-typography-body-small-font);
+    list-style: none;
+  }
+
+  .coverage-fixture strong {
+    color: var(--smrt-color-on-surface);
   }
 
   .report-fixture__header {

--- a/packages/smrt-workbench/host/src/routes/+page.svelte
+++ b/packages/smrt-workbench/host/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import '@happyvertical/smrt-ui/themes/styles/all.css';
 import '@happyvertical/smrt-ui/themes/styles/fonts.css';
 import { WorkbenchHost } from '@happyvertical/smrt-workbench/svelte';
 import {


### PR DESCRIPTION
## Summary

- adds reusable DataTable release-conformance fixtures and deterministic coverage for semantics, manual-query races, async states, responsive overflow, report layouts, and virtualized scale
- documents the controller, manual-query revision contract, saved layouts, report patterns, and consumer adoption checklist
- completes the DataTable workbench with server-owned lifecycle controls, report and virtualized examples, and the shared theme stylesheet host import
- keeps manual search, sort, filter, and pagination revisions plus query-wide selection bound to the same active query fingerprint

Closes #2441

## Validation

- `pnpm --filter @happyvertical/smrt-ui test` — 63 files, 616 tests
- `pnpm --filter @happyvertical/smrt-ui typecheck`
- `pnpm --filter @happyvertical/smrt-ui build`
- `pnpm --filter @happyvertical/smrt-ui verify:pack`
- `pnpm --dir packages/smrt-workbench/host build`
- `pnpm knowledge:check --strict --format markdown`
- `pnpm check:mcp-protocol-hygiene`
- protected pre-push checks

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-datatable-2441-3fd7c187-6831-43cc-8626-74dc89cc4543",
  "issue": 2441,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm --filter @happyvertical/smrt-ui test (63 files, 616 tests)",
    "pnpm --filter @happyvertical/smrt-ui typecheck",
    "pnpm --filter @happyvertical/smrt-ui build",
    "pnpm --filter @happyvertical/smrt-ui verify:pack",
    "pnpm --dir packages/smrt-workbench/host build",
    "pnpm knowledge:check --strict --format markdown",
    "pnpm check:mcp-protocol-hygiene",
    "protected pre-push checks",
    "review-cycle standard: fastest preliminary and balanced final clean on 3724220804621b5c7acacec0358f5d043eaf3e33"
  ]
}