### PR TITLE
fix(users): harden terminal device credentials

### DIFF
--- a/packages/users/agents/retention.md
+++ b/packages/users/agents/retention.md
@@ -44,3 +44,9 @@ reap them.
 - **`expiresAt` is `@field({ indexed: true })`** on `Session`,
   `UsersMagicLinkToken` and `UsersCliAuthRequest`: the prune predicate scans
   that column on every pass.
+- **CLI bearer handoff is single-use.** An approved request becomes `consumed`
+  and clears its `sessionId` when one poller wins the exchange. The CLI
+  retention task deletes pending requests past their TTL, requests already
+  marked `expired` by lazy expiry, and consumed history; it retains approved
+  requests until exchange so a near-expiry approval cannot orphan its bearer
+  session.

--- a/packages/users/package.json
+++ b/packages/users/package.json
@@ -43,7 +43,7 @@
     "dev": "npm run build:watch",
     "prepack": "node ../../scripts/prepack-package.js",
     "test": "vitest run",
-    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/__tests__/permission-postgres-rls.test.ts src/__tests__/principal-permission-context-postgres.test.ts src/__tests__/oidc-provisioning-postgres.test.ts",
+    "test:postgres": "node ../../scripts/run-with-ci-postgres.mjs -- pnpm exec vitest run src/__tests__/permission-postgres-rls.test.ts src/__tests__/principal-permission-context-postgres.test.ts src/__tests__/oidc-provisioning-postgres.test.ts src/__tests__/terminal-auth-postgres.test.ts",
     "typecheck": "tsc --noEmit && node ../../scripts/svelte-check-a11y.mjs --tsconfig ./tsconfig.svelte.json",
     "check": "pnpm exec svelte-check --tsconfig ./tsconfig.svelte.json",
     "verify:pack": "node ../../scripts/verify-package-types-exports.js ."

--- a/packages/users/src/__tests__/credential-retention.test.ts
+++ b/packages/users/src/__tests__/credential-retention.test.ts
@@ -128,6 +128,32 @@ describe('deleteExpired dry runs (#2375)', () => {
     expect(await requests.deleteExpired()).toBe(1);
     expect(await countRows('users_cli_auth_requests')).toBe(0);
   });
+
+  it('reaps consumed CLI auth requests after their approval window', async () => {
+    const request = await requests.create({
+      userCode: 'USED-CODE',
+      deviceCodeHash: 'hash-consumed',
+      status: 'consumed',
+      expiresAt: new Date(Date.now() - MINUTE_MS),
+    });
+    await request.save();
+
+    expect(await requests.deleteExpired()).toBe(1);
+    expect(await countRows('users_cli_auth_requests')).toBe(0);
+  });
+
+  it('reaps requests already marked expired by lazy expiry', async () => {
+    const request = await requests.create({
+      userCode: 'GONE-CODE',
+      deviceCodeHash: 'hash-expired',
+      status: 'expired',
+      expiresAt: new Date(Date.now() - MINUTE_MS),
+    });
+    await request.save();
+
+    expect(await requests.deleteExpired()).toBe(1);
+    expect(await countRows('users_cli_auth_requests')).toBe(0);
+  });
 });
 
 describe('user retention tasks (#2375)', () => {

--- a/packages/users/src/__tests__/issue-2364-hot-predicate-indexes.test.ts
+++ b/packages/users/src/__tests__/issue-2364-hot-predicate-indexes.test.ts
@@ -34,6 +34,23 @@ async function indexNames(
   return result.map((row) => String(row.name));
 }
 
+async function uniqueIndexColumns(
+  db: DatabaseInterface,
+  tableName: string,
+): Promise<string[][]> {
+  const indexes = await rows(db, `PRAGMA index_list('${tableName}')`);
+  const uniqueIndexes = indexes.filter((row) => Number(row.unique) === 1);
+  return await Promise.all(
+    uniqueIndexes.map(async (index) => {
+      const columns = await rows(
+        db,
+        `PRAGMA index_info('${String(index.name)}')`,
+      );
+      return columns.map((column) => String(column.name));
+    }),
+  );
+}
+
 describe('read-path lookup indexes reach the production manifest schema path (#2364)', () => {
   let baseDb: DatabaseInterface;
   let cleanup: () => Promise<void>;
@@ -54,10 +71,13 @@ describe('read-path lookup indexes reach the production manifest schema path (#2
   });
 
   it('indexes the CLI device-code grant lookups on `users_cli_auth_requests`', async () => {
-    const names = await indexNames(baseDb, 'users_cli_auth_requests');
-    // `findByUserCode()` — the browser-side approval lookup.
-    expect(names).toContain('users_cli_auth_requests_user_code_idx');
-    // `findByDeviceCodeHash()` — the CLI's polling key.
-    expect(names).toContain('users_cli_auth_requests_device_code_hash_idx');
+    const uniqueColumns = await uniqueIndexColumns(
+      baseDb,
+      'users_cli_auth_requests',
+    );
+    // These unique indexes both accelerate the hot lookups and arbitrate
+    // concurrent request issuance.
+    expect(uniqueColumns).toContainEqual(['user_code']);
+    expect(uniqueColumns).toContainEqual(['device_code_hash']);
   });
 });

--- a/packages/users/src/__tests__/terminal-auth-postgres.test.ts
+++ b/packages/users/src/__tests__/terminal-auth-postgres.test.ts
@@ -1,0 +1,82 @@
+import {
+  createIsolatedTestDbFromManifest,
+  type IsolatedTestDbResult,
+  isPostgresAvailable,
+} from '@happyvertical/smrt-vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { UsersCliAuthRequestCollection } from '../collections/CliAuthRequestCollection.js';
+import { SessionCollection } from '../collections/SessionCollection.js';
+import { TenantCollection } from '../collections/TenantCollection.js';
+import { UserCollection } from '../collections/UserCollection.js';
+import { TerminalAuthService } from '../services/TerminalAuthService.js';
+
+const describePostgres = isPostgresAvailable() ? describe : describe.skip;
+
+describePostgres('TerminalAuthService on PostgreSQL', () => {
+  let isolated: IsolatedTestDbResult | undefined;
+
+  afterEach(async () => {
+    await isolated?.cleanup();
+    isolated = undefined;
+  });
+
+  it('uses UUID references and permits exactly one concurrent token exchange', async () => {
+    isolated = await createIsolatedTestDbFromManifest({
+      includeObjects: ['User', 'Tenant', 'Session', 'UsersCliAuthRequest'],
+    });
+    if (isolated.config.type !== 'postgres') {
+      throw new Error('Expected a PostgreSQL test database.');
+    }
+    const options = { db: isolated.config };
+    const users = await UserCollection.create(options);
+    const tenants = await TenantCollection.create(options);
+    const requests = await UsersCliAuthRequestCollection.create(options);
+    const sessions = await SessionCollection.create(options);
+    const service = await TerminalAuthService.create({
+      ...options,
+      requestTtlSeconds: 60,
+      sessionTtlSeconds: 3600,
+    });
+
+    const user = await users.create({ email: 'terminal-postgres@example.com' });
+    await user.save();
+    const tenant = await tenants.create({ name: 'Terminal PostgreSQL' });
+    await tenant.save();
+    const userId = user.id;
+    const tenantId = tenant.id;
+    if (!userId || !tenantId) {
+      throw new Error('Expected persisted terminal user and tenant.');
+    }
+    const started = await service.createRequest('https://example.com');
+    const approvals = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        service.approveRequest({
+          userCode: started.userCode,
+          user: { id: userId, email: user.email },
+          tenantId,
+        }),
+      ),
+    );
+    expect(new Set(approvals.map((approval) => approval.sessionId))).toEqual(
+      new Set([approvals[0]?.sessionId]),
+    );
+    expect(await sessions.findByUser(userId)).toHaveLength(1);
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        service.exchangeDeviceCode(started.deviceCode),
+      ),
+    );
+    expect(
+      results.filter((result) => result.status === 'approved'),
+    ).toHaveLength(1);
+    expect(
+      results.filter((result) => result.status === 'expired'),
+    ).toHaveLength(7);
+    const stored = await requests.findByUserCode(started.userCode);
+    expect(stored?.userId).toBe(userId);
+    expect(stored?.tenantId).toBe(tenantId);
+    expect(stored?.status).toBe('consumed');
+    expect(stored?.sessionId).toBeNull();
+  });
+});

--- a/packages/users/src/__tests__/terminal-auth-postgres.test.ts
+++ b/packages/users/src/__tests__/terminal-auth-postgres.test.ts
@@ -8,7 +8,11 @@ import { UsersCliAuthRequestCollection } from '../collections/CliAuthRequestColl
 import { SessionCollection } from '../collections/SessionCollection.js';
 import { TenantCollection } from '../collections/TenantCollection.js';
 import { UserCollection } from '../collections/UserCollection.js';
-import { TerminalAuthService } from '../services/TerminalAuthService.js';
+import {
+  TerminalAuthError,
+  TerminalAuthRateLimitError,
+  TerminalAuthService,
+} from '../services/TerminalAuthService.js';
 
 const describePostgres = isPostgresAvailable() ? describe : describe.skip;
 
@@ -22,7 +26,13 @@ describePostgres('TerminalAuthService on PostgreSQL', () => {
 
   it('uses UUID references and permits exactly one concurrent token exchange', async () => {
     isolated = await createIsolatedTestDbFromManifest({
-      includeObjects: ['User', 'Tenant', 'Session', 'UsersCliAuthRequest'],
+      includeObjects: [
+        'User',
+        'Tenant',
+        'Session',
+        'UsersCliAuthApproveLimit',
+        'UsersCliAuthRequest',
+      ],
     });
     if (isolated.config.type !== 'postgres') {
       throw new Error('Expected a PostgreSQL test database.');
@@ -78,5 +88,43 @@ describePostgres('TerminalAuthService on PostgreSQL', () => {
     expect(stored?.tenantId).toBe(tenantId);
     expect(stored?.status).toBe('consumed');
     expect(stored?.sessionId).toBeNull();
+
+    const limitedA = await TerminalAuthService.create({
+      ...options,
+      maxApproveAttempts: 3,
+      approveAttemptWindowSeconds: 60,
+    });
+    const limitedB = await TerminalAuthService.create({
+      ...options,
+      maxApproveAttempts: 3,
+      approveAttemptWindowSeconds: 60,
+    });
+    const attacker = await users.create({
+      email: 'terminal-postgres-attacker@example.com',
+    });
+    await attacker.save();
+    const attackerId = attacker.id;
+    if (!attackerId) throw new Error('Expected persisted attacker user.');
+
+    const attackResults = await Promise.allSettled(
+      Array.from({ length: 10 }, (_, index) =>
+        (index % 2 === 0 ? limitedA : limitedB).approveRequest({
+          userCode: 'BOGUS-PARALLEL-CODE',
+          user: { id: attackerId, email: attacker.email },
+          tenantId,
+        }),
+      ),
+    );
+    const attackErrors = attackResults.map((result) =>
+      result.status === 'rejected' ? result.reason : null,
+    );
+    expect(
+      attackErrors.filter((error) => error instanceof TerminalAuthError),
+    ).toHaveLength(10);
+    expect(
+      attackErrors.filter(
+        (error) => error instanceof TerminalAuthRateLimitError,
+      ),
+    ).toHaveLength(7);
   });
 });

--- a/packages/users/src/__tests__/terminal-auth.test.ts
+++ b/packages/users/src/__tests__/terminal-auth.test.ts
@@ -10,6 +10,7 @@ import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UsersCliAuthApproveLimitCollection } from '../collections/CliAuthApproveLimitCollection.js';
 import { UsersCliAuthRequestCollection } from '../collections/CliAuthRequestCollection.js';
 import { SessionCollection } from '../collections/SessionCollection.js';
 import { UserCollection } from '../collections/UserCollection.js';
@@ -232,6 +233,31 @@ describe('TerminalAuthService', () => {
     expect(second.sessionId).toBe(first.sessionId);
   });
 
+  it('keeps approval idempotent after the CLI already consumed the token', async () => {
+    const user = await users.create({ email: 'consumed-approval@example.com' });
+    await user.save();
+    const userId = user.id;
+    if (!userId) throw new Error('Expected persisted terminal user.');
+    const started = await service.createRequest('https://example.com');
+    await service.approveRequest({
+      userCode: started.userCode,
+      user: { id: userId, email: user.email },
+      tenantId: 'tenant-1',
+    });
+    expect((await service.exchangeDeviceCode(started.deviceCode)).status).toBe(
+      'approved',
+    );
+
+    const repeated = await service.approveRequest({
+      userCode: started.userCode,
+      user: { id: userId, email: user.email },
+      tenantId: 'tenant-1',
+    });
+
+    expect(repeated.status).toBe('consumed');
+    expect(repeated.sessionId).toBeNull();
+  });
+
   it('allows exactly one concurrent approval session to be minted', async () => {
     const user = await users.create({ email: 'approval-race@example.com' });
     await user.save();
@@ -415,7 +441,7 @@ describe('TerminalAuthService', () => {
     }
   });
 
-  it('resets the failed-approve counter after a successful approval', async () => {
+  it('does not let a successful approval reset the failed-approve budget', async () => {
     const limited = await TerminalAuthService.create({
       db: { type: 'sqlite', url: dbPath },
       requestTtlSeconds: 60,
@@ -436,7 +462,7 @@ describe('TerminalAuthService', () => {
       ).rejects.toBeInstanceOf(TerminalAuthError);
     }
 
-    // Successful approve resets the counter.
+    // A successful approve must not reset failures in the current window.
     const started = await limited.createRequest('https://example.com');
     await limited.approveRequest({
       userCode: started.userCode,
@@ -444,21 +470,123 @@ describe('TerminalAuthService', () => {
       tenantId: 'tenant-1',
     });
 
-    // 3 more failures should now all be plain TerminalAuthError, not
-    // TerminalAuthRateLimitError — the counter was reset.
-    for (let i = 0; i < 3; i++) {
-      try {
-        await limited.approveRequest({
-          userCode: 'BOGUS-CODE',
+    await expect(
+      limited.approveRequest({
+        userCode: 'BOGUS-CODE',
+        user: { id: user.id!, email: user.email },
+        tenantId: 'tenant-1',
+      }),
+    ).rejects.toBeInstanceOf(TerminalAuthError);
+
+    // Replaying the known valid code cannot bypass the exhausted budget.
+    await expect(
+      limited.approveRequest({
+        userCode: started.userCode,
+        user: { id: user.id!, email: user.email },
+        tenantId: 'tenant-1',
+      }),
+    ).rejects.toBeInstanceOf(TerminalAuthRateLimitError);
+  });
+
+  it('enforces the failed-approve budget across parallel attempts', async () => {
+    const limited = await TerminalAuthService.create({
+      db: { type: 'sqlite', url: dbPath },
+      requestTtlSeconds: 60,
+      maxApproveAttempts: 3,
+      approveAttemptWindowSeconds: 60,
+    });
+    const secondLimited = await TerminalAuthService.create({
+      db: { type: 'sqlite', url: dbPath },
+      requestTtlSeconds: 60,
+      maxApproveAttempts: 3,
+      approveAttemptWindowSeconds: 60,
+    });
+    const user = await users.create({ email: 'parallel@example.com' });
+    await user.save();
+
+    const attempts = await Promise.allSettled(
+      Array.from({ length: 10 }, (_, index) =>
+        (index % 2 === 0 ? limited : secondLimited).approveRequest({
+          userCode: 'BOGUS-PARALLEL-CODE',
           user: { id: user.id!, email: user.email },
           tenantId: 'tenant-1',
-        });
-        throw new Error('expected approveRequest to throw');
-      } catch (error) {
-        expect(error).toBeInstanceOf(TerminalAuthError);
-        expect(error).not.toBeInstanceOf(TerminalAuthRateLimitError);
-      }
+        }),
+      ),
+    );
+    const failures = attempts.map((attempt) =>
+      attempt.status === 'rejected' ? attempt.reason : null,
+    );
+
+    expect(
+      failures.filter((error) => error instanceof TerminalAuthError),
+    ).toHaveLength(10);
+    expect(
+      failures.filter((error) => error instanceof TerminalAuthRateLimitError),
+    ).toHaveLength(7);
+  });
+
+  it('does not let an old-window release erase a new-window failure', async () => {
+    const limits = await UsersCliAuthApproveLimitCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+    const user = await users.create({ email: 'rollover@example.com' });
+    await user.save();
+    if (!user.id) throw new Error('Expected persisted rollover user.');
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-08-23T07:00:00.000Z'));
+      const oldWindow = await limits.reserveAttempt({
+        maxAttempts: 1,
+        userId: user.id,
+        windowMs: 1_000,
+      });
+      expect(oldWindow.allowed).toBe(true);
+      if (!oldWindow.allowed) throw new Error('Expected first reservation.');
+
+      vi.advanceTimersByTime(1_001);
+      const newWindow = await limits.reserveAttempt({
+        maxAttempts: 1,
+        userId: user.id,
+        windowMs: 1_000,
+      });
+      expect(newWindow.allowed).toBe(true);
+
+      await limits.releaseAttempt(user.id, oldWindow.windowStartedAt);
+      const blocked = await limits.reserveAttempt({
+        maxAttempts: 1,
+        userId: user.id,
+        windowMs: 1_000,
+      });
+      expect(blocked.allowed).toBe(false);
+    } finally {
+      vi.useRealTimers();
     }
+  });
+
+  it('preserves a committed approval when limiter cleanup fails', async () => {
+    const user = await users.create({ email: 'cleanup-failure@example.com' });
+    await user.save();
+    if (!user.id) throw new Error('Expected persisted cleanup-failure user.');
+    const started = await service.createRequest('https://example.com');
+    const internals = service as unknown as {
+      approveLimitCollection: UsersCliAuthApproveLimitCollection;
+    };
+    vi.spyOn(
+      internals.approveLimitCollection,
+      'releaseAttempt',
+    ).mockRejectedValue(new Error('simulated limiter cleanup outage'));
+
+    const approved = await service.approveRequest({
+      userCode: started.userCode,
+      user: { id: user.id, email: user.email },
+      tenantId: 'tenant-1',
+    });
+
+    expect(approved.status).toBe('approved');
+    expect(await service.exchangeDeviceCode(started.deviceCode)).toMatchObject({
+      status: 'approved',
+    });
   });
 
   it('lets the rate-limit window expire and accepts attempts again', async () => {

--- a/packages/users/src/__tests__/terminal-auth.test.ts
+++ b/packages/users/src/__tests__/terminal-auth.test.ts
@@ -9,8 +9,9 @@
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UsersCliAuthRequestCollection } from '../collections/CliAuthRequestCollection.js';
+import { SessionCollection } from '../collections/SessionCollection.js';
 import { UserCollection } from '../collections/UserCollection.js';
 import { UsersCliAuthRequest } from '../models/CliAuthRequest.js';
 import {
@@ -25,6 +26,7 @@ describe('TerminalAuthService', () => {
   let service: TerminalAuthService;
   let users: UserCollection;
   let requests: UsersCliAuthRequestCollection;
+  let sessions: SessionCollection;
 
   beforeEach(async () => {
     dbPath = join(
@@ -42,9 +44,11 @@ describe('TerminalAuthService', () => {
     });
     users = await UserCollection.create(options);
     requests = await UsersCliAuthRequestCollection.create(options);
+    sessions = await SessionCollection.create(options);
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     if (existsSync(dbPath)) {
       try {
         rmSync(dbPath, { force: true });
@@ -76,6 +80,31 @@ describe('TerminalAuthService', () => {
     expect(stored?.deviceCodeHash.length).toBe(64);
   });
 
+  it('retries when a concurrent issuer wins the durable user-code constraint', async () => {
+    const existing = await requests.create({
+      deviceCodeHash: 'a'.repeat(64),
+      expiresAt: new Date(Date.now() + 60_000),
+      status: 'pending',
+      userCode: 'WG-DEADBEEF',
+    });
+    await existing.save();
+    const internals = service as unknown as {
+      makeUserCode: () => string;
+      requestCollection: UsersCliAuthRequestCollection;
+    };
+    vi.spyOn(internals, 'makeUserCode')
+      .mockReturnValueOnce('WG-DEADBEEF')
+      .mockReturnValueOnce('WG-FEEDBEEF');
+    vi.spyOn(internals.requestCollection, 'findByUserCode').mockResolvedValue(
+      null,
+    );
+
+    const started = await service.createRequest('https://example.com');
+
+    expect(started.userCode).toBe('WG-FEEDBEEF');
+    expect(await requests.findByUserCode('WG-FEEDBEEF')).not.toBeNull();
+  });
+
   it('approves a pending request and mints a session bound to the user', async () => {
     const user = await users.create({ email: 'cli@example.com' });
     await user.save();
@@ -94,18 +123,94 @@ describe('TerminalAuthService', () => {
     expect(approved.userId).toBe(user.id);
     expect(approved.tenantId).toBe('tenant-1');
     expect(approved.sessionId).toBeTruthy();
+    const sessionId = approved.sessionId;
+    if (!sessionId) throw new Error('Expected terminal approval session.');
 
     const token = await service.exchangeDeviceCode(started.deviceCode);
     expect(token.status).toBe('approved');
     if (token.status === 'approved') {
       expect(token.tokenType).toBe('Bearer');
-      expect(token.accessToken).toBe(approved.sessionId);
+      expect(token.accessToken).toBe(sessionId);
       expect(token.expiresIn).toBe(3600);
     }
 
-    const context = await service.loadBearerSession(approved.sessionId);
+    const consumed = await requests.findByUserCode(started.userCode);
+    expect(consumed?.status).toBe('consumed');
+    expect(consumed?.sessionId).toBeNull();
+    expect(await service.exchangeDeviceCode(started.deviceCode)).toEqual({
+      status: 'expired',
+    });
+
+    const context = await service.loadBearerSession(sessionId);
     expect(context?.user.id).toBe(user.id);
     expect(context?.tenantId).toBe('tenant-1');
+  });
+
+  it('allows exactly one concurrent exchange of an approved device code', async () => {
+    const user = await users.create({ email: 'concurrent-cli@example.com' });
+    await user.save();
+    const userId = user.id;
+    if (!userId) throw new Error('Expected persisted terminal user.');
+    const started = await service.createRequest('https://example.com');
+    await service.approveRequest({
+      userCode: started.userCode,
+      user: { id: userId, email: user.email },
+      tenantId: 'tenant-1',
+    });
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        service.exchangeDeviceCode(started.deviceCode),
+      ),
+    );
+    expect(
+      results.filter((result) => result.status === 'approved'),
+    ).toHaveLength(1);
+    expect(
+      results.filter((result) => result.status === 'expired'),
+    ).toHaveLength(7);
+    const stored = await requests.findByUserCode(started.userCode);
+    expect(stored?.status).toBe('consumed');
+    expect(stored?.sessionId).toBeNull();
+  });
+
+  it('reports approval success when token exchange wins the post-commit race', async () => {
+    const user = await users.create({
+      email: 'approval-exchange-race@example.com',
+    });
+    await user.save();
+    const userId = user.id;
+    if (!userId) throw new Error('Expected persisted terminal user.');
+    const started = await service.createRequest('https://example.com');
+    const originalTransaction = requests.db.transaction?.bind(requests.db);
+    if (!originalTransaction) {
+      throw new Error('Expected transactional test database.');
+    }
+    let interceptApprovalCommit = true;
+    let exchanged:
+      | Awaited<ReturnType<typeof service.exchangeDeviceCode>>
+      | undefined;
+    requests.db.transaction = async (callback) => {
+      const result = await originalTransaction(callback);
+      if (interceptApprovalCommit) {
+        interceptApprovalCommit = false;
+        exchanged = await service.exchangeDeviceCode(started.deviceCode);
+      }
+      return result;
+    };
+
+    const approved = await service.approveRequest({
+      userCode: started.userCode,
+      user: { id: userId, email: user.email },
+      tenantId: 'tenant-1',
+    });
+
+    expect(approved.status).toBe('approved');
+    expect(approved.sessionId).toBeTruthy();
+    expect(exchanged?.status).toBe('approved');
+    expect((await requests.findByUserCode(started.userCode))?.status).toBe(
+      'consumed',
+    );
   });
 
   it('keeps approval idempotent — re-approving a request is a no-op', async () => {
@@ -125,6 +230,58 @@ describe('TerminalAuthService', () => {
     });
 
     expect(second.sessionId).toBe(first.sessionId);
+  });
+
+  it('allows exactly one concurrent approval session to be minted', async () => {
+    const user = await users.create({ email: 'approval-race@example.com' });
+    await user.save();
+    const userId = user.id;
+    if (!userId) throw new Error('Expected persisted terminal user.');
+    const started = await service.createRequest('https://example.com');
+
+    const approvals = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        service.approveRequest({
+          userCode: started.userCode,
+          user: { id: userId, email: user.email },
+          tenantId: 'tenant-1',
+        }),
+      ),
+    );
+
+    expect(new Set(approvals.map((approval) => approval.sessionId))).toEqual(
+      new Set([approvals[0]?.sessionId]),
+    );
+    expect(await sessions.findByUser(userId)).toHaveLength(1);
+  });
+
+  it('rolls a minted session back when approval persistence fails', async () => {
+    const user = await users.create({ email: 'approval-rollback@example.com' });
+    await user.save();
+    const userId = user.id;
+    if (!userId) throw new Error('Expected persisted terminal user.');
+    const started = await service.createRequest('https://example.com');
+    await requests.db.query(
+      `CREATE TRIGGER reject_terminal_approval
+       BEFORE UPDATE ON users_cli_auth_requests
+       WHEN NEW.status = 'approved'
+       BEGIN
+         SELECT RAISE(ABORT, 'forced approval persistence failure');
+       END`,
+    );
+
+    await expect(
+      service.approveRequest({
+        userCode: started.userCode,
+        user: { id: userId, email: user.email },
+        tenantId: 'tenant-1',
+      }),
+    ).rejects.toThrow();
+
+    expect(await sessions.findByUser(userId)).toHaveLength(0);
+    expect((await requests.findByUserCode(started.userCode))?.status).toBe(
+      'pending',
+    );
   });
 
   it('rejects approval without an authenticated user/tenant', async () => {
@@ -156,6 +313,8 @@ describe('TerminalAuthService', () => {
 
     const lookup = await service.getRequestForUserCode(started.userCode);
     expect(lookup?.status).toBe('expired');
+    expect(await requests.deleteExpired()).toBe(1);
+    expect(await requests.findByUserCode(started.userCode)).toBeNull();
 
     const tokenResult = await service.exchangeDeviceCode(started.deviceCode);
     expect(tokenResult.status).toBe('expired');
@@ -189,13 +348,15 @@ describe('TerminalAuthService', () => {
       tenantId: 'tenant-1',
     });
 
-    const before = await service.loadBearerSession(approved.sessionId);
-    expect(before?.sessionId).toBe(approved.sessionId);
+    const sessionId = approved.sessionId;
+    if (!sessionId) throw new Error('Expected terminal approval session.');
+    const before = await service.loadBearerSession(sessionId);
+    expect(before?.sessionId).toBe(sessionId);
 
-    const destroyed = await service.destroyBearerSession(approved.sessionId);
+    const destroyed = await service.destroyBearerSession(sessionId);
     expect(destroyed).toBe(true);
 
-    const after = await service.loadBearerSession(approved.sessionId);
+    const after = await service.loadBearerSession(sessionId);
     expect(after).toBeNull();
   });
 

--- a/packages/users/src/collections/CliAuthApproveLimitCollection.ts
+++ b/packages/users/src/collections/CliAuthApproveLimitCollection.ts
@@ -1,0 +1,111 @@
+/**
+ * Atomic shared-storage limiter for terminal device-code approvals.
+ *
+ * @packageDocumentation
+ */
+
+import { randomUUID } from 'node:crypto';
+import { SmrtCollection } from '@happyvertical/smrt-core';
+import { UsersCliAuthApproveLimit } from '../models/CliAuthApproveLimit.js';
+
+export type CliAuthApproveReservation =
+  | { allowed: true; windowStartedAt: string }
+  | { allowed: false; retryAfterSeconds: number };
+
+export class UsersCliAuthApproveLimitCollection extends SmrtCollection<UsersCliAuthApproveLimit> {
+  static readonly _itemClass = UsersCliAuthApproveLimit;
+
+  /**
+   * Atomically reserve one attempt across every process using this database.
+   * Failed attempts retain their reservation; successful attempts release it.
+   */
+  async reserveAttempt(input: {
+    maxAttempts: number;
+    userId: string;
+    windowMs: number;
+  }): Promise<CliAuthApproveReservation> {
+    const now = new Date();
+    const nowIso = now.toISOString();
+    const windowFloorIso = new Date(
+      now.getTime() - input.windowMs,
+    ).toISOString();
+    const reserved = await this.db.query(
+      `INSERT INTO ${this.tableName} (
+         id, slug, context, user_id, attempt_count, window_started_at,
+         created_at, updated_at
+       ) VALUES (?, ?, '', ?, 1, ?, ?, ?)
+       ON CONFLICT (user_id) DO UPDATE SET
+         attempt_count = CASE
+           WHEN ${this.tableName}.window_started_at <= ? THEN 1
+           ELSE ${this.tableName}.attempt_count + 1
+         END,
+         window_started_at = CASE
+           WHEN ${this.tableName}.window_started_at <= ?
+             THEN excluded.window_started_at
+           ELSE ${this.tableName}.window_started_at
+         END,
+         updated_at = excluded.updated_at
+       WHERE ${this.tableName}.window_started_at <= ?
+          OR ${this.tableName}.attempt_count < ?
+       RETURNING attempt_count, window_started_at`,
+      randomUUID(),
+      `terminal-auth-${input.userId}`,
+      input.userId,
+      nowIso,
+      nowIso,
+      nowIso,
+      windowFloorIso,
+      windowFloorIso,
+      windowFloorIso,
+      input.maxAttempts,
+    );
+    if (reserved.rows.length === 1) {
+      const reservedWindow = reserved.rows[0]?.window_started_at;
+      const windowStartedAt =
+        reservedWindow instanceof Date
+          ? reservedWindow.toISOString()
+          : new Date(String(reservedWindow)).toISOString();
+      return { allowed: true, windowStartedAt };
+    }
+
+    const current = await this.db.query(
+      `SELECT window_started_at FROM ${this.tableName}
+        WHERE user_id = ? LIMIT 1`,
+      input.userId,
+    );
+    const windowStartedAt = current.rows[0]?.window_started_at;
+    const startedMs =
+      windowStartedAt instanceof Date
+        ? windowStartedAt.getTime()
+        : new Date(String(windowStartedAt)).getTime();
+    const remainingMs = Number.isFinite(startedMs)
+      ? startedMs + input.windowMs - now.getTime()
+      : input.windowMs;
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(1, Math.ceil(remainingMs / 1000)),
+    };
+  }
+
+  /** Release the reservation for an attempt that did not fail authentication. */
+  async releaseAttempt(userId: string, windowStartedAt: string): Promise<void> {
+    await this.db.query(
+      `UPDATE ${this.tableName}
+          SET attempt_count = CASE
+                WHEN attempt_count > 0 THEN attempt_count - 1
+                ELSE 0
+              END,
+              updated_at = ?
+        WHERE user_id = ? AND window_started_at = ?`,
+      new Date().toISOString(),
+      userId,
+      windowStartedAt,
+    );
+    await this.db.query(
+      `DELETE FROM ${this.tableName}
+        WHERE user_id = ? AND window_started_at = ? AND attempt_count = 0`,
+      userId,
+      windowStartedAt,
+    );
+  }
+}

--- a/packages/users/src/collections/CliAuthRequestCollection.ts
+++ b/packages/users/src/collections/CliAuthRequestCollection.ts
@@ -73,13 +73,14 @@ export class UsersCliAuthRequestCollection extends SmrtCollection<UsersCliAuthRe
         const approved = await tx.query(
           `UPDATE ${this.tableName}
            SET approved_at = ?, session_id = ?, status = 'approved',
-               tenant_id = ?, user_id = ?, updated_at = CURRENT_TIMESTAMP
+               tenant_id = ?, user_id = ?, updated_at = ?
            WHERE user_code = ? AND status = 'pending' AND expires_at > ?
            RETURNING id`,
           now,
           createdSessionId,
           input.tenantId,
           input.userId,
+          now,
           input.userCode.trim().toUpperCase(),
           now,
         );
@@ -134,9 +135,10 @@ export class UsersCliAuthRequestCollection extends SmrtCollection<UsersCliAuthRe
 
       const consumed = await tx.query(
         `UPDATE ${this.tableName}
-         SET status = 'consumed', session_id = NULL, updated_at = CURRENT_TIMESTAMP
+         SET status = 'consumed', session_id = NULL, updated_at = ?
          WHERE id = ? AND status = 'approved' AND session_id = ?
          RETURNING id`,
+        new Date().toISOString(),
         id,
         sessionId,
       );

--- a/packages/users/src/collections/CliAuthRequestCollection.ts
+++ b/packages/users/src/collections/CliAuthRequestCollection.ts
@@ -6,9 +6,143 @@
 
 import { SmrtCollection } from '@happyvertical/smrt-core';
 import { UsersCliAuthRequest } from '../models/CliAuthRequest.js';
+import { SessionCollection } from './SessionCollection.js';
+
+export interface ApprovePendingCliAuthRequestInput {
+  approvedBy: string;
+  ipAddress?: string;
+  sessionTtlSeconds: number;
+  tenantId: string;
+  userAgent?: string;
+  userCode: string;
+  userId: string;
+}
+
+export interface ApprovedCliAuthRequestSnapshot {
+  approvedAt: Date;
+  id: string;
+  sessionId: string;
+  tenantId: string;
+  userId: string;
+}
+
+class CliAuthApprovalLostError extends Error {}
 
 export class UsersCliAuthRequestCollection extends SmrtCollection<UsersCliAuthRequest> {
   static readonly _itemClass = UsersCliAuthRequest;
+
+  /**
+   * Atomically approve one pending request and mint its bearer session.
+   *
+   * The session is created inside the same transaction as the conditional
+   * pending-to-approved transition. If another approver wins, or persisting
+   * the approval fails, throwing rolls the losing session back with the
+   * request write so no usable orphan credential can remain.
+   */
+  async approvePendingRequest(
+    input: ApprovePendingCliAuthRequestInput,
+  ): Promise<ApprovedCliAuthRequestSnapshot | null> {
+    const transaction = this.db.transaction?.bind(this.db);
+    if (!transaction) {
+      throw new Error(
+        'Terminal approval requires database transaction support.',
+      );
+    }
+
+    try {
+      return await transaction(async (tx) => {
+        const sessions = await SessionCollection.create({ db: tx });
+        const session = await sessions.createSession({
+          data: {
+            approvedBy: input.approvedBy,
+            kind: 'terminal',
+          },
+          ipAddress: input.ipAddress,
+          tenantId: input.tenantId,
+          ttl: input.sessionTtlSeconds,
+          userAgent: input.userAgent,
+          userId: input.userId,
+        });
+        const createdSessionId = session.id;
+        if (!createdSessionId) {
+          throw new Error('Terminal approval failed to mint a session.');
+        }
+
+        const approvedAt = new Date();
+        const now = approvedAt.toISOString();
+        const approved = await tx.query(
+          `UPDATE ${this.tableName}
+           SET approved_at = ?, session_id = ?, status = 'approved',
+               tenant_id = ?, user_id = ?, updated_at = CURRENT_TIMESTAMP
+           WHERE user_code = ? AND status = 'pending' AND expires_at > ?
+           RETURNING id`,
+          now,
+          createdSessionId,
+          input.tenantId,
+          input.userId,
+          input.userCode.trim().toUpperCase(),
+          now,
+        );
+        if (approved.rows?.length !== 1) {
+          throw new CliAuthApprovalLostError();
+        }
+        const id = approved.rows[0]?.id;
+        if (typeof id !== 'string') {
+          throw new Error('Terminal approval did not return its request id.');
+        }
+        return {
+          approvedAt,
+          id,
+          sessionId: createdSessionId,
+          tenantId: input.tenantId,
+          userId: input.userId,
+        };
+      });
+    } catch (error) {
+      if (error instanceof CliAuthApprovalLostError) return null;
+      throw error;
+    }
+  }
+
+  /**
+   * Atomically consume the bearer session attached to an approved request.
+   *
+   * The conditional update is the arbiter: concurrent exchangers may observe
+   * the same candidate, but only one can change `approved` to `consumed` while
+   * matching the same session id. The winning transaction returns the token
+   * from its locked candidate and clears it from durable storage.
+   */
+  async consumeApprovedSession(deviceCodeHash: string): Promise<string | null> {
+    const transaction = this.db.transaction?.bind(this.db);
+    if (!transaction) {
+      throw new Error(
+        'Terminal device exchange requires database transaction support.',
+      );
+    }
+    return transaction(async (tx) => {
+      const selected = await tx.query(
+        `SELECT id, session_id FROM ${this.tableName}
+         WHERE device_code_hash = ? AND status = 'approved' AND session_id IS NOT NULL
+         LIMIT 1`,
+        deviceCodeHash,
+      );
+      const candidate = selected.rows?.[0];
+      const id = typeof candidate?.id === 'string' ? candidate.id : null;
+      const sessionId =
+        typeof candidate?.session_id === 'string' ? candidate.session_id : null;
+      if (!id || !sessionId) return null;
+
+      const consumed = await tx.query(
+        `UPDATE ${this.tableName}
+         SET status = 'consumed', session_id = NULL, updated_at = CURRENT_TIMESTAMP
+         WHERE id = ? AND status = 'approved' AND session_id = ?
+         RETURNING id`,
+        id,
+        sessionId,
+      );
+      return consumed.rows?.length === 1 ? sessionId : null;
+    });
+  }
 
   /**
    * Look up a pending or completed request by the short user code shown in the CLI.
@@ -35,7 +169,7 @@ export class UsersCliAuthRequestCollection extends SmrtCollection<UsersCliAuthRe
   }
 
   /**
-   * Delete expired pending requests (cleanup job).
+   * Delete expired pending, lazily-expired, or already-consumed requests.
    *
    * Scheduled by the framework retention sweep (#2375); `expiresAt` carries an
    * index for this predicate.
@@ -50,7 +184,8 @@ export class UsersCliAuthRequestCollection extends SmrtCollection<UsersCliAuthRe
     // a per-row delete that throws part-way leaves the rest of the expired
     // requests un-reaped. It also avoids hydrating every row just to delete it.
     const now = new Date().toISOString();
-    const predicate = "status = 'pending' AND expires_at < ?";
+    const predicate =
+      "status IN ('pending', 'expired', 'consumed') AND expires_at < ?";
 
     const counted = await this.db.query(
       `SELECT COUNT(*) AS total FROM ${this.tableName} WHERE ${predicate}`,

--- a/packages/users/src/models/CliAuthApproveLimit.ts
+++ b/packages/users/src/models/CliAuthApproveLimit.ts
@@ -1,0 +1,28 @@
+/**
+ * Durable per-user failed-approval budget for terminal device codes.
+ *
+ * @packageDocumentation
+ */
+
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
+
+/** Private database arbiter shared by every terminal-auth process. */
+@smrt({
+  tableName: 'users_cli_auth_approve_limits',
+  api: false,
+  cli: false,
+  mcp: false,
+})
+export class UsersCliAuthApproveLimit extends SmrtObject {
+  /** Approving browser user whose budget this row protects. */
+  @foreignKey('User', { required: true, unique: true })
+  userId = '';
+
+  /** Failed attempts plus currently reserved attempts inside the window. */
+  @field({ type: 'integer', required: true, default: 0 })
+  attemptCount = 0;
+
+  /** Beginning of the current failed-attempt window. */
+  @field({ type: 'datetime', required: true })
+  windowStartedAt = new Date();
+}

--- a/packages/users/src/models/CliAuthRequest.ts
+++ b/packages/users/src/models/CliAuthRequest.ts
@@ -11,12 +11,16 @@
  * @packageDocumentation
  */
 
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import { field, foreignKey, SmrtObject, smrt } from '@happyvertical/smrt-core';
 
 /**
  * CLI auth request lifecycle states.
  */
-export type CliAuthRequestStatus = 'pending' | 'approved' | 'expired';
+export type CliAuthRequestStatus =
+  | 'pending'
+  | 'approved'
+  | 'consumed'
+  | 'expired';
 
 @smrt({
   tableName: 'users_cli_auth_requests',
@@ -31,7 +35,7 @@ export class UsersCliAuthRequest extends SmrtObject {
    * Indexed: `findByUserCode()` looks requests up by this column (#2364,
    * epic #2382 finding A3).
    */
-  @field({ type: 'text', indexed: true })
+  @field({ type: 'text', required: true, unique: true })
   userCode = '';
 
   /**
@@ -40,24 +44,24 @@ export class UsersCliAuthRequest extends SmrtObject {
    * Indexed: `findByDeviceCodeHash()` — the CLI's poll loop — looks requests
    * up by this column (#2364, epic #2382 finding A3).
    */
-  @field({ type: 'text', indexed: true })
+  @field({ type: 'text', required: true, unique: true })
   deviceCodeHash = '';
 
-  /** Lifecycle state — `pending` → `approved` | `expired`. */
+  /** Lifecycle state — `pending` → `approved` → `consumed`, or `expired`. */
   @field({ type: 'text' })
   status: CliAuthRequestStatus = 'pending';
 
   /** User id of the human who approved the request (set on approval). */
-  @field({ type: 'text' })
-  userId = '';
+  @foreignKey('User', { nullable: true })
+  userId: string | null = null;
 
   /** Tenant id captured from the approving session (set on approval). */
-  @field({ type: 'text' })
-  tenantId = '';
+  @foreignKey('Tenant', { nullable: true })
+  tenantId: string | null = null;
 
-  /** Session id minted on approval — handed to the CLI as its bearer token. */
-  @field({ type: 'text' })
-  sessionId = '';
+  /** Session id minted on approval; cleared by the winning single-use exchange. */
+  @foreignKey('Session', { nullable: true })
+  sessionId: string | null = null;
 
   /**
    * When the pending request stops accepting approvals.

--- a/packages/users/src/retention.ts
+++ b/packages/users/src/retention.ts
@@ -79,7 +79,8 @@ export function registerUserRetentionTasks(): void {
 
   registerRetentionTask({
     name: CLI_AUTH_RETENTION_TASK,
-    description: 'Delete expired pending CLI auth requests',
+    description:
+      'Delete expired pending, lazily-expired, and consumed CLI auth requests',
     run: async (db, context) => {
       const requests = await UsersCliAuthRequestCollection.create({ db });
       return requests.deleteExpired({ dryRun: context.dryRun });

--- a/packages/users/src/services/TerminalAuthService.ts
+++ b/packages/users/src/services/TerminalAuthService.ts
@@ -19,7 +19,10 @@
  */
 
 import { createHash, randomBytes } from 'node:crypto';
-import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import {
+  isUniqueViolationError,
+  type SmrtClassOptions,
+} from '@happyvertical/smrt-core';
 import { UsersCliAuthRequestCollection } from '../collections/CliAuthRequestCollection.js';
 import type {
   CliAuthRequestStatus,
@@ -203,18 +206,15 @@ export class TerminalAuthService {
   }
 
   /**
-   * Generate a user code that is not currently in use by another *active*
-   * (pending or approved-but-unclaimed) request. Collisions are vanishingly
-   * rare (1 in 2^32 per attempt) but happen at scale; retrying keeps the
-   * affected CLI from being locked out.
+   * Generate a user code that is not present in durable request history.
+   * Collisions are vanishingly rare (1 in 2^32 per attempt) but happen at
+   * scale; retrying keeps the affected CLI from being locked out.
    */
   private async makeUniqueUserCode(maxAttempts = 5): Promise<string> {
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       const candidate = this.makeUserCode();
       const existing = await this.requestCollection.findByUserCode(candidate);
-      if (!existing || existing.status === 'expired') {
-        return candidate;
-      }
+      if (!existing) return candidate;
     }
     throw new TerminalAuthError(
       'Unable to generate a unique terminal user code; try again.',
@@ -228,26 +228,36 @@ export class TerminalAuthService {
    */
   async createRequest(origin: string): Promise<CliAuthStartResult> {
     const trimmedOrigin = origin.replace(/\/+$/u, '');
-    const deviceCode = base64url(randomBytes(32));
-    const userCode = await this.makeUniqueUserCode();
-    const expiresAt = new Date(Date.now() + this.requestTtlSeconds * 1000);
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const deviceCode = base64url(randomBytes(32));
+      const userCode = await this.makeUniqueUserCode();
+      const expiresAt = new Date(Date.now() + this.requestTtlSeconds * 1000);
 
-    const request = await this.requestCollection.create({
-      deviceCodeHash: hashDeviceCode(deviceCode),
-      expiresAt,
-      status: 'pending',
-      userCode,
-    });
-    await request.save();
+      try {
+        await this.requestCollection.create({
+          deviceCodeHash: hashDeviceCode(deviceCode),
+          expiresAt,
+          status: 'pending',
+          userCode,
+        });
+      } catch (error) {
+        if (isUniqueViolationError(error) && attempt < 4) continue;
+        throw error;
+      }
 
-    return {
-      deviceCode,
-      expiresAt: expiresAt.toISOString(),
-      interval: this.pollIntervalSeconds,
-      issuer: trimmedOrigin,
-      userCode,
-      verificationUrl: `${trimmedOrigin}${this.verificationPath}?code=${encodeURIComponent(userCode)}`,
-    };
+      return {
+        deviceCode,
+        expiresAt: expiresAt.toISOString(),
+        interval: this.pollIntervalSeconds,
+        issuer: trimmedOrigin,
+        userCode,
+        verificationUrl: `${trimmedOrigin}${this.verificationPath}?code=${encodeURIComponent(userCode)}`,
+      };
+    }
+
+    throw new TerminalAuthError(
+      'Unable to create a unique terminal login request; try again.',
+    );
   }
 
   /**
@@ -300,27 +310,29 @@ export class TerminalAuthService {
       throw new TerminalAuthError('Terminal login request has expired.');
     }
 
-    const sessionId = await this.sessionService.createSession(
-      input.user.id,
-      input.tenantId,
-      {
-        data: {
-          approvedBy: input.user.email ?? input.user.id,
-          kind: 'terminal',
-        },
-        ipAddress: input.ipAddress,
-        ttl: this.sessionTtlSeconds,
-        userAgent: input.userAgent,
-      },
-    );
-
-    request.approvedAt = new Date();
-    request.sessionId = sessionId;
-    request.status = 'approved';
-    request.tenantId = input.tenantId;
-    request.userId = input.user.id;
-    await request.save();
+    const approved = await this.requestCollection.approvePendingRequest({
+      approvedBy: input.user.email ?? input.user.id,
+      ipAddress: input.ipAddress,
+      sessionTtlSeconds: this.sessionTtlSeconds,
+      tenantId: input.tenantId,
+      userAgent: input.userAgent,
+      userCode: input.userCode,
+      userId: input.user.id,
+    });
+    if (!approved) {
+      const concurrent = await this.getRequestForUserCode(input.userCode);
+      if (concurrent?.status === 'approved') {
+        return concurrent;
+      }
+      this.recordFailedApprove(input.user.id);
+      throw new TerminalAuthError('Terminal login request has expired.');
+    }
     this.failedApprovesByUser.delete(input.user.id);
+    request.approvedAt = approved.approvedAt;
+    request.sessionId = approved.sessionId;
+    request.status = 'approved';
+    request.tenantId = approved.tenantId;
+    request.userId = approved.userId;
     return request;
   }
 
@@ -370,9 +382,9 @@ export class TerminalAuthService {
    * was never approved within its TTL.
    */
   async exchangeDeviceCode(deviceCode: string): Promise<CliAuthTokenResult> {
-    const request = await this.requestCollection.findByDeviceCodeHash(
-      hashDeviceCode(deviceCode),
-    );
+    const deviceCodeHash = hashDeviceCode(deviceCode);
+    const request =
+      await this.requestCollection.findByDeviceCodeHash(deviceCodeHash);
     if (!request) {
       return { status: 'expired' };
     }
@@ -382,8 +394,11 @@ export class TerminalAuthService {
     // after approval but after `expiresAt`. Check this before TTL expiry so
     // freshly minted sessions don't get orphaned.
     if (request.status === 'approved' && request.sessionId) {
+      const accessToken =
+        await this.requestCollection.consumeApprovedSession(deviceCodeHash);
+      if (!accessToken) return { status: 'expired' };
       return {
-        accessToken: request.sessionId,
+        accessToken,
         expiresIn: this.sessionTtlSeconds,
         status: 'approved',
         tokenType: 'Bearer',
@@ -427,7 +442,7 @@ export class TerminalAuthService {
   }
 
   /**
-   * Delete expired pending requests (cleanup job).
+   * Delete expired pending or already-consumed requests (cleanup job).
    */
   async cleanupExpiredRequests(): Promise<number> {
     return this.requestCollection.deleteExpired();

--- a/packages/users/src/services/TerminalAuthService.ts
+++ b/packages/users/src/services/TerminalAuthService.ts
@@ -23,6 +23,7 @@ import {
   isUniqueViolationError,
   type SmrtClassOptions,
 } from '@happyvertical/smrt-core';
+import { UsersCliAuthApproveLimitCollection } from '../collections/CliAuthApproveLimitCollection.js';
 import { UsersCliAuthRequestCollection } from '../collections/CliAuthRequestCollection.js';
 import type {
   CliAuthRequestStatus,
@@ -150,10 +151,8 @@ export class TerminalAuthService {
   private readonly verificationPath: string;
   private readonly maxApproveAttempts: number;
   private readonly approveAttemptWindowMs: number;
-  private readonly failedApprovesByUser = new Map<
-    string,
-    { count: number; firstAttemptAt: number }
-  >();
+  private readonly approveQueuesByUser = new Map<string, Promise<void>>();
+  private approveLimitCollection!: UsersCliAuthApproveLimitCollection;
   private requestCollection!: UsersCliAuthRequestCollection;
   private sessionService!: SessionService;
 
@@ -181,6 +180,8 @@ export class TerminalAuthService {
   }
 
   async initialize(): Promise<void> {
+    this.approveLimitCollection =
+      await UsersCliAuthApproveLimitCollection.create(this.options);
     this.requestCollection = await UsersCliAuthRequestCollection.create(
       this.options,
     );
@@ -291,88 +292,110 @@ export class TerminalAuthService {
         'An authenticated tenant session is required.',
       );
     }
+    const userId = input.user.id;
+    const tenantId = input.tenantId;
 
-    this.assertApproveRateLimit(input.user.id);
-
-    const request = await this.getRequestForUserCode(input.userCode);
-    if (!request) {
-      this.recordFailedApprove(input.user.id);
-      throw new TerminalAuthError('Terminal login request not found.');
-    }
-    if (request.status === 'approved') {
-      // Idempotent success — don't penalize a re-approval.
-      return request;
-    }
-    if (request.status !== 'pending' || isExpired(request)) {
-      request.status = 'expired';
-      await request.save();
-      this.recordFailedApprove(input.user.id);
-      throw new TerminalAuthError('Terminal login request has expired.');
-    }
-
-    const approved = await this.requestCollection.approvePendingRequest({
-      approvedBy: input.user.email ?? input.user.id,
-      ipAddress: input.ipAddress,
-      sessionTtlSeconds: this.sessionTtlSeconds,
-      tenantId: input.tenantId,
-      userAgent: input.userAgent,
-      userCode: input.userCode,
-      userId: input.user.id,
-    });
-    if (!approved) {
-      const concurrent = await this.getRequestForUserCode(input.userCode);
-      if (concurrent?.status === 'approved') {
-        return concurrent;
+    return await this.withSerializedApprove(userId, async () => {
+      const reservation = await this.approveLimitCollection.reserveAttempt({
+        maxAttempts: this.maxApproveAttempts,
+        userId,
+        windowMs: this.approveAttemptWindowMs,
+      });
+      if (!reservation.allowed) {
+        throw new TerminalAuthRateLimitError(
+          'Too many failed terminal-login attempts. Try again later.',
+          reservation.retryAfterSeconds,
+        );
       }
-      this.recordFailedApprove(input.user.id);
-      throw new TerminalAuthError('Terminal login request has expired.');
-    }
-    this.failedApprovesByUser.delete(input.user.id);
-    request.approvedAt = approved.approvedAt;
-    request.sessionId = approved.sessionId;
-    request.status = 'approved';
-    request.tenantId = approved.tenantId;
-    request.userId = approved.userId;
-    return request;
+      let retainReservation = false;
+
+      try {
+        const request = await this.getRequestForUserCode(input.userCode);
+        if (!request) {
+          retainReservation = true;
+          throw new TerminalAuthError('Terminal login request not found.');
+        }
+        if (request.status === 'approved' || request.status === 'consumed') {
+          // Idempotent success — don't penalize a re-approval or a double-click
+          // after the CLI already exchanged the approved token.
+          return request;
+        }
+        if (request.status !== 'pending' || isExpired(request)) {
+          request.status = 'expired';
+          await request.save();
+          retainReservation = true;
+          throw new TerminalAuthError('Terminal login request has expired.');
+        }
+
+        const approved = await this.requestCollection.approvePendingRequest({
+          approvedBy: input.user.email ?? userId,
+          ipAddress: input.ipAddress,
+          sessionTtlSeconds: this.sessionTtlSeconds,
+          tenantId,
+          userAgent: input.userAgent,
+          userCode: input.userCode,
+          userId,
+        });
+        if (!approved) {
+          const concurrent = await this.getRequestForUserCode(input.userCode);
+          if (
+            concurrent?.status === 'approved' ||
+            concurrent?.status === 'consumed'
+          ) {
+            return concurrent;
+          }
+          retainReservation = true;
+          throw new TerminalAuthError('Terminal login request has expired.');
+        }
+        request.approvedAt = approved.approvedAt;
+        request.sessionId = approved.sessionId;
+        request.status = 'approved';
+        request.tenantId = approved.tenantId;
+        request.userId = approved.userId;
+        return request;
+      } finally {
+        if (!retainReservation) {
+          try {
+            await this.approveLimitCollection.releaseAttempt(
+              userId,
+              reservation.windowStartedAt,
+            );
+          } catch {
+            // The reservation is fail-closed and expires with its window. A
+            // cleanup outage must not turn a committed approval/session into
+            // an apparent browser failure while the CLI can already exchange
+            // the credential. Retaining it is the safe fallback.
+          }
+        }
+      }
+    });
   }
 
   /**
-   * Throw {@link TerminalAuthRateLimitError} if the user has exceeded the
-   * configured failed-approve budget inside the current sliding window.
+   * Serialize approval attempts per user so parallel requests cannot all pass
+   * the failed-attempt check before any one of them records its failure.
    */
-  private assertApproveRateLimit(userId: string): void {
-    const tracking = this.failedApprovesByUser.get(userId);
-    if (!tracking) return;
+  private async withSerializedApprove<T>(
+    userId: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.approveQueuesByUser.get(userId) ?? Promise.resolve();
+    let release = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => gate);
+    this.approveQueuesByUser.set(userId, tail);
 
-    const elapsedMs = Date.now() - tracking.firstAttemptAt;
-    if (elapsedMs >= this.approveAttemptWindowMs) {
-      this.failedApprovesByUser.delete(userId);
-      return;
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.approveQueuesByUser.get(userId) === tail) {
+        this.approveQueuesByUser.delete(userId);
+      }
     }
-
-    if (tracking.count >= this.maxApproveAttempts) {
-      const retryAfterSeconds = Math.max(
-        1,
-        Math.ceil((this.approveAttemptWindowMs - elapsedMs) / 1000),
-      );
-      throw new TerminalAuthRateLimitError(
-        'Too many failed terminal-login attempts. Try again later.',
-        retryAfterSeconds,
-      );
-    }
-  }
-
-  /** Increment the failed-approve counter for `userId`, starting the window if needed. */
-  private recordFailedApprove(userId: string): void {
-    const tracking = this.failedApprovesByUser.get(userId);
-    if (!tracking) {
-      this.failedApprovesByUser.set(userId, {
-        count: 1,
-        firstAttemptAt: Date.now(),
-      });
-      return;
-    }
-    tracking.count += 1;
   }
 
   /**


### PR DESCRIPTION
Canonical tracker: Work item HV-3.
Compatibility closing issue: Closes #2478.

## Summary

- make terminal approval and device exchange single-use under concurrent callers
- enforce durable unique device codes and UUID reference columns
- enforce the terminal approval budget atomically across processes and pods
- retain no expired device-code credentials and cover SQLite/PostgreSQL concurrency

## Validation

- users package: 475 passed, 25 skipped
- isolated PostgreSQL terminal-auth suite: 1 passed, including shared cross-instance limiter concurrency
- package build and typecheck: green
- full monorepo build, typecheck, and test: green before final review fixes
- strict SMRT knowledge and pre-push policy checks: green
- exact-head Terra and Sol reviews: CLEAN

## Deployment note

The consuming Work app includes a fail-closed pre-schema migration for the existing nullable text terminal-auth columns before adopting this release. SMRT remains GitHub-authoritative during the flagship Wave B transition; HV-3 and its live Work claim remain canonical.

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-01a02a23-389d-7371-9af0-bdd48c9df71d",
  "issue": 2478,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "users package: 475 passed, 25 skipped",
    "isolated PostgreSQL terminal-auth: 1 passed with shared limiter concurrency",
    "package build and typecheck",
    "strict SMRT knowledge and pre-push checks",
    "exact-head Terra and Sol reviews CLEAN"
  ]
}