### PR TITLE
feat(smrt-ui): register mounted data surfaces

### DIFF
--- a/packages/smrt-ui/README.md
+++ b/packages/smrt-ui/README.md
@@ -417,6 +417,10 @@ remains toolbar-local. Descriptors may advertise row/bulk action contracts, but
 smrt-ui does not execute durable actions—the later authenticated action adapter
 owns preview, confirmation, authorization, and persistence.
 
+Toolbar snapshots also advance their revision when the host updates exposed
+uncontrolled `search` or `view` props, so a command based on an earlier view is
+rejected as stale instead of overwriting host state.
+
 ## Themes
 
 `@happyvertical/smrt-ui/themes` is the canonical theme API and includes the

--- a/packages/smrt-ui/README.md
+++ b/packages/smrt-ui/README.md
@@ -376,6 +376,45 @@ adapter, and authentication, tenancy, confirmation-token verification, and
 durable actions remain server-side. URL state and saved views also remain
 application-owned persistence adapters.
 
+### DataTable and CollectionToolbar integration
+
+Registration is opt-in. Pass `dataSurface` with an explicit descriptor and a
+registry; existing `DataTable` and `CollectionToolbar` consumers do not
+register or change behavior. A DataTable descriptor must only name effective,
+visible columns. Tables exposing selection, expansion, or declared row/bulk
+actions also require an explicit stable `rowKey`—the index fallback is never
+addressable across pages or refreshes.
+
+```svelte
+<script lang="ts">
+  import { DataTable, createDataSurfaceRegistry } from '@happyvertical/smrt-ui/data';
+
+  const registry = createDataSurfaceRegistry();
+  const dataSurface = {
+    registry,
+    descriptor: {
+      // descriptor omitted: give this mounted instance a stable identity,
+      // policy-visible columns, controls, query limits, and action descriptors
+    },
+  };
+</script>
+
+<DataTable {dataSurface} data={rows} {columns} rowKey="id" />
+```
+
+Declared controller controls include search, filters, multi-sort, page/page
+size, column layout, selection, expansion, reset, focus/reveal/highlight, and
+optional refresh/retry callbacks. The component maps controller controls to the
+same `DataTableController.dispatch()` path used by buttons and checkboxes. A
+controlled table supplies `applyControlledState(candidate, command)`; the
+registry acknowledges only after that callback settles the candidate state.
+
+`CollectionToolbar` accepts the same opt-in registration and an optional
+`controller`. Its `set-search` control shares that table controller; `set-view`
+remains toolbar-local. Descriptors may advertise row/bulk action contracts, but
+smrt-ui does not execute durable actions—the later authenticated action adapter
+owns preview, confirmation, authorization, and persistence.
+
 ## Themes
 
 `@happyvertical/smrt-ui/themes` is the canonical theme API and includes the

--- a/packages/smrt-ui/README.md
+++ b/packages/smrt-ui/README.md
@@ -380,10 +380,12 @@ application-owned persistence adapters.
 
 Registration is opt-in. Pass `dataSurface` with an explicit descriptor and a
 registry; existing `DataTable` and `CollectionToolbar` consumers do not
-register or change behavior. A DataTable descriptor must only name effective,
-visible columns. Tables exposing selection, expansion, or declared row/bulk
-actions also require an explicit stable `rowKey`—the index fallback is never
-addressable across pages or refreshes.
+register or change behavior. Registration follows reactive `dataSurface` and
+controller prop replacement, so registry commands never retain a prior mounted
+instance. A DataTable descriptor must only name effective, visible columns,
+except for its stable `rowKey`, which may remain non-rendered. Mounted tables
+always require that `rowKey` to be an explicit string field; the index fallback
+and functional key callbacks are never addressable across pages or refreshes.
 
 ```svelte
 <script lang="ts">

--- a/packages/smrt-ui/src/components/data/CollectionToolbar.svelte
+++ b/packages/smrt-ui/src/components/data/CollectionToolbar.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
-import type { Snippet } from 'svelte';
+import { onMount, type Snippet } from 'svelte';
 import Input from '../forms/Input.svelte';
 import SegmentedControl from '../forms/SegmentedControl.svelte';
+import type {
+  DataTableController,
+  DataTableViewState,
+} from './DataTableController.js';
+import type { DataSurfaceJsonValue } from './data-surface.js';
+import type { CollectionToolbarDataSurfaceOptions } from './types.js';
 
 export interface Props {
   search?: string;
@@ -16,6 +22,10 @@ export interface Props {
   bulkActions?: Snippet;
   onsearchchange?: (value: string) => void;
   onviewchange?: (view: 'list' | 'grid' | 'table') => void;
+  /** Shares search state with a DataTable controller when supplied. */
+  controller?: DataTableController;
+  /** Registers this toolbar only when explicitly supplied. */
+  dataSurface?: CollectionToolbarDataSurfaceOptions;
   class?: string;
 }
 
@@ -32,8 +42,28 @@ let {
   bulkActions,
   onsearchchange,
   onviewchange,
+  controller,
+  dataSurface,
   class: className = '',
 }: Props = $props();
+
+let controllerState = $state<DataTableViewState | undefined>(undefined);
+let toolbarElement = $state<HTMLDivElement>();
+let surfaceHighlighted = $state(false);
+let surfaceRevision = 0;
+
+$effect(() => {
+  if (!controller) {
+    controllerState = undefined;
+    return;
+  }
+  controllerState = controller.getState();
+  return controller.subscribe((transition) => {
+    if (!transition.changed) return;
+    controllerState = transition.next.state;
+    surfaceRevision += 1;
+  });
+});
 
 const viewOptions = $derived(
   views.map((value) => ({
@@ -43,14 +73,127 @@ const viewOptions = $derived(
 );
 
 function changeView(next: string | number) {
-  view = String(next) as typeof view;
+  const candidate = String(next);
+  if (!views.includes(candidate as typeof view)) return;
+  view = candidate as typeof view;
+  surfaceRevision += 1;
   onviewchange?.(view);
 }
+
+function changeSearch(next: string) {
+  if (controller) {
+    const transition = controller.dispatch({ type: 'setSearch', search: next });
+    if (!transition.changed) return;
+  } else {
+    if (search === next) return;
+    search = next;
+    surfaceRevision += 1;
+  }
+  onsearchchange?.(next);
+}
+
+function payloadObject(
+  value: DataSurfaceJsonValue | undefined,
+): Record<string, DataSurfaceJsonValue> | undefined {
+  return value && !Array.isArray(value) && typeof value === 'object'
+    ? value
+    : undefined;
+}
+
+onMount(() => {
+  if (!dataSurface) return;
+  const surface = dataSurface;
+  let highlightTimer: ReturnType<typeof setTimeout> | undefined;
+  const unregister = surface.registry.register({
+    descriptor: surface.descriptor,
+    getSnapshot: () => ({
+      revision: surfaceRevision,
+      state: { search: controllerState?.search ?? search, view },
+      selection: null,
+    }),
+    execute: async (command) => {
+      const payload = payloadObject(command.payload);
+      if (
+        command.controlId === 'set-search' &&
+        typeof payload?.search === 'string'
+      ) {
+        if (controller) {
+          const transition = controller.dispatch({
+            type: 'setSearch',
+            search: payload.search,
+          });
+          if (controller.isControlled() && transition.changed) {
+            const settled = await surface.applyControlledState?.(
+              transition.next.state,
+              { type: 'setSearch', search: payload.search },
+            );
+            if (settled) controller.replaceState(settled);
+            if (
+              JSON.stringify(controller.getState()) !==
+              JSON.stringify(transition.next.state)
+            ) {
+              return { ok: false };
+            }
+          }
+          onsearchchange?.(payload.search);
+          return;
+        }
+        changeSearch(payload.search);
+        return;
+      }
+      if (
+        command.controlId === 'set-view' &&
+        typeof payload?.view === 'string'
+      ) {
+        const prior = view;
+        changeView(payload.view);
+        return view === prior && payload.view !== prior
+          ? { ok: false }
+          : undefined;
+      }
+      switch (command.controlId) {
+        case 'focus':
+          toolbarElement?.focus();
+          return;
+        case 'reveal':
+          toolbarElement?.scrollIntoView({ block: 'nearest' });
+          return;
+        case 'highlight':
+          surfaceHighlighted = true;
+          if (highlightTimer) clearTimeout(highlightTimer);
+          highlightTimer = setTimeout(() => {
+            surfaceHighlighted = false;
+          }, 1_000);
+          return;
+        case 'refresh':
+          if (!surface.onRefresh) return { ok: false };
+          await surface.onRefresh();
+          return;
+        case 'retry':
+          if (!surface.onRetry) return { ok: false };
+          await surface.onRetry();
+          return;
+        default:
+          return { ok: false };
+      }
+    },
+  });
+  return () => {
+    if (highlightTimer) clearTimeout(highlightTimer);
+    unregister();
+  };
+});
 </script>
 
-<div class="toolbar {className}" role="search">
+<div
+  bind:this={toolbarElement}
+  class="toolbar {className}"
+  class:toolbar--highlighted={surfaceHighlighted}
+  role="search"
+  tabindex="-1"
+>
   <div class="search">
-    <Input type="search" name="collection-search" aria-label={searchLabel} placeholder={searchPlaceholder} bind:value={search} oninput={(event) => onsearchchange?.(event.currentTarget.value)} />
+    <Input type="search" name="collection-search" aria-label={searchLabel} placeholder={searchPlaceholder} value={controllerState?.search ?? search} oninput={(event) => changeSearch(event.currentTarget.value)} />
   </div>
   {#if filters}<div class="filters">{@render filters()}</div>{/if}
   {#if resultCount !== undefined}<span class="count" aria-live="polite">{resultCount} {resultCount === 1 ? 'result' : 'results'}</span>{/if}
@@ -64,6 +207,7 @@ function changeView(next: string | number) {
 
 <style>
   .toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: var(--smrt-spacing-2); padding: var(--smrt-spacing-2) 0; color: var(--smrt-color-on-surface); }
+  .toolbar--highlighted { outline: 2px solid var(--smrt-color-primary, #2563eb); outline-offset: 3px; }
   .search { flex: 1 1 14rem; max-width: 24rem; }
   .filters, .actions, .bulk { display: flex; align-items: center; gap: var(--smrt-spacing-2); }
   .bulk { padding: var(--smrt-spacing-1) var(--smrt-spacing-2); border-radius: var(--smrt-radius-small); background: var(--smrt-color-secondary-container); color: var(--smrt-color-on-secondary-container); }

--- a/packages/smrt-ui/src/components/data/CollectionToolbar.svelte
+++ b/packages/smrt-ui/src/components/data/CollectionToolbar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { onMount, type Snippet } from 'svelte';
+import type { Snippet } from 'svelte';
 import Input from '../forms/Input.svelte';
 import SegmentedControl from '../forms/SegmentedControl.svelte';
 import type {
@@ -50,7 +50,7 @@ let {
 let controllerState = $state<DataTableViewState | undefined>(undefined);
 let toolbarElement = $state<HTMLDivElement>();
 let surfaceHighlighted = $state(false);
-let surfaceRevision = 0;
+let registeredSurfaceRevision: { value: number } | undefined;
 
 $effect(() => {
   if (!controller) {
@@ -61,7 +61,7 @@ $effect(() => {
   return controller.subscribe((transition) => {
     if (!transition.changed) return;
     controllerState = transition.next.state;
-    surfaceRevision += 1;
+    if (registeredSurfaceRevision) registeredSurfaceRevision.value += 1;
   });
 });
 
@@ -76,7 +76,7 @@ function changeView(next: string | number) {
   const candidate = String(next);
   if (!views.includes(candidate as typeof view)) return;
   view = candidate as typeof view;
-  surfaceRevision += 1;
+  if (registeredSurfaceRevision) registeredSurfaceRevision.value += 1;
   onviewchange?.(view);
 }
 
@@ -87,7 +87,7 @@ function changeSearch(next: string) {
   } else {
     if (search === next) return;
     search = next;
-    surfaceRevision += 1;
+    if (registeredSurfaceRevision) registeredSurfaceRevision.value += 1;
   }
   onsearchchange?.(next);
 }
@@ -100,15 +100,18 @@ function payloadObject(
     : undefined;
 }
 
-onMount(() => {
-  if (!dataSurface) return;
+$effect(() => {
   const surface = dataSurface;
+  const surfaceController = controller;
+  if (!surface) return;
+  const revision = { value: 0 };
+  registeredSurfaceRevision = revision;
   let highlightTimer: ReturnType<typeof setTimeout> | undefined;
   const unregister = surface.registry.register({
     descriptor: surface.descriptor,
     getSnapshot: () => ({
-      revision: surfaceRevision,
-      state: { search: controllerState?.search ?? search, view },
+      revision: revision.value,
+      state: { search: surfaceController?.getState().search ?? search, view },
       selection: null,
     }),
     execute: async (command) => {
@@ -117,19 +120,19 @@ onMount(() => {
         command.controlId === 'set-search' &&
         typeof payload?.search === 'string'
       ) {
-        if (controller) {
-          const transition = controller.dispatch({
+        if (surfaceController) {
+          const transition = surfaceController.dispatch({
             type: 'setSearch',
             search: payload.search,
           });
-          if (controller.isControlled() && transition.changed) {
+          if (surfaceController.isControlled() && transition.changed) {
             const settled = await surface.applyControlledState?.(
               transition.next.state,
               { type: 'setSearch', search: payload.search },
             );
-            if (settled) controller.replaceState(settled);
+            if (settled) surfaceController.replaceState(settled);
             if (
-              JSON.stringify(controller.getState()) !==
+              JSON.stringify(surfaceController.getState()) !==
               JSON.stringify(transition.next.state)
             ) {
               return { ok: false };
@@ -180,6 +183,9 @@ onMount(() => {
   });
   return () => {
     if (highlightTimer) clearTimeout(highlightTimer);
+    if (registeredSurfaceRevision === revision) {
+      registeredSurfaceRevision = undefined;
+    }
     unregister();
   };
 });

--- a/packages/smrt-ui/src/components/data/CollectionToolbar.svelte
+++ b/packages/smrt-ui/src/components/data/CollectionToolbar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { Snippet } from 'svelte';
+import { onDestroy, type Snippet, untrack } from 'svelte';
 import Input from '../forms/Input.svelte';
 import SegmentedControl from '../forms/SegmentedControl.svelte';
 import type {
@@ -50,7 +50,13 @@ let {
 let controllerState = $state<DataTableViewState | undefined>(undefined);
 let toolbarElement = $state<HTMLDivElement>();
 let surfaceHighlighted = $state(false);
-let registeredSurfaceRevision: { value: number } | undefined;
+let surfaceRegistration:
+  | {
+      surface: CollectionToolbarDataSurfaceOptions;
+      controller: DataTableController | undefined;
+      cleanup: () => void;
+    }
+  | undefined;
 
 $effect(() => {
   if (!controller) {
@@ -61,7 +67,6 @@ $effect(() => {
   return controller.subscribe((transition) => {
     if (!transition.changed) return;
     controllerState = transition.next.state;
-    if (registeredSurfaceRevision) registeredSurfaceRevision.value += 1;
   });
 });
 
@@ -76,7 +81,6 @@ function changeView(next: string | number) {
   const candidate = String(next);
   if (!views.includes(candidate as typeof view)) return;
   view = candidate as typeof view;
-  if (registeredSurfaceRevision) registeredSurfaceRevision.value += 1;
   onviewchange?.(view);
 }
 
@@ -87,7 +91,6 @@ function changeSearch(next: string) {
   } else {
     if (search === next) return;
     search = next;
-    if (registeredSurfaceRevision) registeredSurfaceRevision.value += 1;
   }
   onsearchchange?.(next);
 }
@@ -103,92 +106,116 @@ function payloadObject(
 $effect(() => {
   const surface = dataSurface;
   const surfaceController = controller;
+  if (
+    surfaceRegistration?.surface === surface &&
+    surfaceRegistration?.controller === surfaceController
+  ) {
+    return;
+  }
+  surfaceRegistration?.cleanup();
+  surfaceRegistration = undefined;
   if (!surface) return;
-  const revision = { value: 0 };
-  registeredSurfaceRevision = revision;
-  let highlightTimer: ReturnType<typeof setTimeout> | undefined;
-  const unregister = surface.registry.register({
-    descriptor: surface.descriptor,
-    getSnapshot: () => ({
-      revision: revision.value,
-      state: { search: surfaceController?.getState().search ?? search, view },
-      selection: null,
-    }),
-    execute: async (command) => {
-      const payload = payloadObject(command.payload);
+  const cleanup = untrack(() => {
+    let revision = 0;
+    let previousStateSignature: string | undefined;
+    const readState = () => {
+      const state = {
+        search: surfaceController?.getState().search ?? search,
+        view,
+      };
+      const signature = JSON.stringify(state);
       if (
-        command.controlId === 'set-search' &&
-        typeof payload?.search === 'string'
+        previousStateSignature !== undefined &&
+        previousStateSignature !== signature
       ) {
-        if (surfaceController) {
-          const transition = surfaceController.dispatch({
-            type: 'setSearch',
-            search: payload.search,
-          });
-          if (surfaceController.isControlled() && transition.changed) {
-            const settled = await surface.applyControlledState?.(
-              transition.next.state,
-              { type: 'setSearch', search: payload.search },
-            );
-            if (settled) surfaceController.replaceState(settled);
-            if (
-              JSON.stringify(surfaceController.getState()) !==
-              JSON.stringify(transition.next.state)
-            ) {
-              return { ok: false };
+        revision += 1;
+      }
+      previousStateSignature = signature;
+      return state;
+    };
+    let highlightTimer: ReturnType<typeof setTimeout> | undefined;
+    const unregister = surface.registry.register({
+      descriptor: surface.descriptor,
+      getSnapshot: () => {
+        const state = readState();
+        return { revision, state, selection: null };
+      },
+      execute: async (command) => {
+        const payload = payloadObject(command.payload);
+        if (
+          command.controlId === 'set-search' &&
+          typeof payload?.search === 'string'
+        ) {
+          if (surfaceController) {
+            const transition = surfaceController.dispatch({
+              type: 'setSearch',
+              search: payload.search,
+            });
+            if (surfaceController.isControlled() && transition.changed) {
+              const settled = await surface.applyControlledState?.(
+                transition.next.state,
+                { type: 'setSearch', search: payload.search },
+              );
+              if (settled) surfaceController.replaceState(settled);
+              if (
+                JSON.stringify(surfaceController.getState()) !==
+                JSON.stringify(transition.next.state)
+              ) {
+                return { ok: false };
+              }
             }
+            onsearchchange?.(payload.search);
+            return;
           }
-          onsearchchange?.(payload.search);
+          changeSearch(payload.search);
           return;
         }
-        changeSearch(payload.search);
-        return;
-      }
-      if (
-        command.controlId === 'set-view' &&
-        typeof payload?.view === 'string'
-      ) {
-        const prior = view;
-        changeView(payload.view);
-        return view === prior && payload.view !== prior
-          ? { ok: false }
-          : undefined;
-      }
-      switch (command.controlId) {
-        case 'focus':
-          toolbarElement?.focus();
-          return;
-        case 'reveal':
-          toolbarElement?.scrollIntoView({ block: 'nearest' });
-          return;
-        case 'highlight':
-          surfaceHighlighted = true;
-          if (highlightTimer) clearTimeout(highlightTimer);
-          highlightTimer = setTimeout(() => {
-            surfaceHighlighted = false;
-          }, 1_000);
-          return;
-        case 'refresh':
-          if (!surface.onRefresh) return { ok: false };
-          await surface.onRefresh();
-          return;
-        case 'retry':
-          if (!surface.onRetry) return { ok: false };
-          await surface.onRetry();
-          return;
-        default:
-          return { ok: false };
-      }
-    },
+        if (
+          command.controlId === 'set-view' &&
+          typeof payload?.view === 'string'
+        ) {
+          const prior = view;
+          changeView(payload.view);
+          return view === prior && payload.view !== prior
+            ? { ok: false }
+            : undefined;
+        }
+        switch (command.controlId) {
+          case 'focus':
+            toolbarElement?.focus();
+            return;
+          case 'reveal':
+            toolbarElement?.scrollIntoView({ block: 'nearest' });
+            return;
+          case 'highlight':
+            surfaceHighlighted = true;
+            if (highlightTimer) clearTimeout(highlightTimer);
+            highlightTimer = setTimeout(() => {
+              surfaceHighlighted = false;
+            }, 1_000);
+            return;
+          case 'refresh':
+            if (!surface.onRefresh) return { ok: false };
+            await surface.onRefresh();
+            return;
+          case 'retry':
+            if (!surface.onRetry) return { ok: false };
+            await surface.onRetry();
+            return;
+          default:
+            return { ok: false };
+        }
+      },
+    });
+    return () => {
+      if (highlightTimer) clearTimeout(highlightTimer);
+      unregister();
+    };
   });
-  return () => {
-    if (highlightTimer) clearTimeout(highlightTimer);
-    if (registeredSurfaceRevision === revision) {
-      registeredSurfaceRevision = undefined;
-    }
-    unregister();
-  };
+  surfaceRegistration = { surface, controller: surfaceController, cleanup };
 });
+
+onDestroy(() => surfaceRegistration?.cleanup());
 </script>
 
 <div

--- a/packages/smrt-ui/src/components/data/CollectionToolbar.svelte
+++ b/packages/smrt-ui/src/components/data/CollectionToolbar.svelte
@@ -6,7 +6,11 @@ import type {
   DataTableController,
   DataTableViewState,
 } from './DataTableController.js';
-import type { DataSurfaceJsonValue } from './data-surface.js';
+import {
+  type DataSurfaceJsonValue,
+  type DataSurfaceRegistry,
+  normalizeDataSurfaceDescriptor,
+} from './data-surface.js';
 import type { CollectionToolbarDataSurfaceOptions } from './types.js';
 
 export interface Props {
@@ -53,6 +57,8 @@ let surfaceHighlighted = $state(false);
 let surfaceRegistration:
   | {
       surface: CollectionToolbarDataSurfaceOptions;
+      registry: DataSurfaceRegistry;
+      descriptorSignature: string;
       controller: DataTableController | undefined;
       cleanup: () => void;
     }
@@ -106,15 +112,31 @@ function payloadObject(
 $effect(() => {
   const surface = dataSurface;
   const surfaceController = controller;
+  if (!surface) {
+    surfaceRegistration?.cleanup();
+    surfaceRegistration = undefined;
+    return;
+  }
+  const descriptorSignature = JSON.stringify(
+    normalizeDataSurfaceDescriptor(surface.descriptor),
+  );
   if (
-    surfaceRegistration?.surface === surface &&
+    surfaceRegistration?.registry === surface.registry &&
+    surfaceRegistration?.descriptorSignature === descriptorSignature &&
     surfaceRegistration?.controller === surfaceController
   ) {
+    surfaceRegistration.surface = surface;
     return;
   }
   surfaceRegistration?.cleanup();
   surfaceRegistration = undefined;
-  if (!surface) return;
+  const registration = {
+    surface,
+    registry: surface.registry,
+    descriptorSignature,
+    controller: surfaceController,
+    cleanup: () => {},
+  };
   const cleanup = untrack(() => {
     let revision = 0;
     let previousStateSignature: string | undefined;
@@ -152,7 +174,7 @@ $effect(() => {
               search: payload.search,
             });
             if (surfaceController.isControlled() && transition.changed) {
-              const settled = await surface.applyControlledState?.(
+              const settled = await registration.surface.applyControlledState?.(
                 transition.next.state,
                 { type: 'setSearch', search: payload.search },
               );
@@ -195,12 +217,12 @@ $effect(() => {
             }, 1_000);
             return;
           case 'refresh':
-            if (!surface.onRefresh) return { ok: false };
-            await surface.onRefresh();
+            if (!registration.surface.onRefresh) return { ok: false };
+            await registration.surface.onRefresh();
             return;
           case 'retry':
-            if (!surface.onRetry) return { ok: false };
-            await surface.onRetry();
+            if (!registration.surface.onRetry) return { ok: false };
+            await registration.surface.onRetry();
             return;
           default:
             return { ok: false };
@@ -212,7 +234,8 @@ $effect(() => {
       unregister();
     };
   });
-  surfaceRegistration = { surface, controller: surfaceController, cleanup };
+  registration.cleanup = cleanup;
+  surfaceRegistration = registration;
 });
 
 onDestroy(() => surfaceRegistration?.cleanup());

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -375,15 +375,23 @@ function dataSurfaceSelection(
 
 function preservesDeclaredVisibleColumns(
   surface: DataTableDataSurfaceOptions,
-  command: DataTableCommand,
+  visibility: DataTableViewState['columnVisibility'],
 ): boolean {
-  if (command.type !== 'setColumnVisibility') return true;
   const requested = new Map(
-    command.columns.map((column) => [column.columnId, column.visible]),
+    visibility.map((column) => [column.columnId, column.visible]),
   );
   return surface.descriptor.columns
     .filter((column) => column.id !== surface.descriptor.rowKey)
     .every((column) => requested.get(column.id) === true);
+}
+
+function preservesDeclaredVisibleColumnsForCommand(
+  surface: DataTableDataSurfaceOptions,
+  command: DataTableCommand,
+): boolean {
+  return command.type !== 'setColumnVisibility'
+    ? true
+    : preservesDeclaredVisibleColumns(surface, command.columns);
 }
 
 $effect(() => {
@@ -394,7 +402,23 @@ $effect(() => {
   return untrack(() => {
     let revision = 0;
     let highlightTimer: ReturnType<typeof setTimeout> | undefined;
+    let restoringInvalidVisibility = false;
     const unsubscribe = surfaceController.subscribe((transition) => {
+      if (
+        !restoringInvalidVisibility &&
+        !preservesDeclaredVisibleColumns(
+          surface,
+          transition.next.state.columnVisibility,
+        )
+      ) {
+        restoringInvalidVisibility = true;
+        try {
+          surfaceController.replaceState(transition.previous.state);
+        } finally {
+          restoringInvalidVisibility = false;
+        }
+        return;
+      }
       if (transition.changed) revision += 1;
     });
     const unregister = surface.registry.register({
@@ -410,7 +434,9 @@ $effect(() => {
       execute: async (command) => {
         const tableCommand = dataTableCommandFromDataSurfaceCommand(command);
         if (tableCommand) {
-          if (!preservesDeclaredVisibleColumns(surface, tableCommand)) {
+          if (
+            !preservesDeclaredVisibleColumnsForCommand(surface, tableCommand)
+          ) {
             return { ok: false };
           }
           const transition = surfaceController.dispatch(tableCommand);

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -11,7 +11,7 @@
  * - Material 3 styling with theme token support
  */
 
-import { type Snippet, tick } from 'svelte';
+import { type Snippet, tick, untrack } from 'svelte';
 import { M } from '../../i18n/strings.js';
 import Trans from '../../i18n/Trans.svelte';
 import { useI18n } from '../../i18n/use-i18n.js';
@@ -359,12 +359,13 @@ $effect(() => {
   if (!surface) return;
   assertSurfaceDescriptorMatchesTable(surface);
   const surfaceController = activeController();
-  let revision = 0;
-  let highlightTimer: ReturnType<typeof setTimeout> | undefined;
-  const unsubscribe = surfaceController.subscribe((transition) => {
-    if (transition.changed) revision += 1;
-  });
-  const unregister = surface.registry.register({
+  return untrack(() => {
+    let revision = 0;
+    let highlightTimer: ReturnType<typeof setTimeout> | undefined;
+    const unsubscribe = surfaceController.subscribe((transition) => {
+      if (transition.changed) revision += 1;
+    });
+    const unregister = surface.registry.register({
     descriptor: surface.descriptor,
     getSnapshot: () => {
       const snapshot = surfaceController.snapshot();
@@ -425,12 +426,13 @@ $effect(() => {
           return { ok: false };
       }
     },
+    });
+    return () => {
+      if (highlightTimer) clearTimeout(highlightTimer);
+      unsubscribe();
+      unregister();
+    };
   });
-  return () => {
-    if (highlightTimer) clearTimeout(highlightTimer);
-    unsubscribe();
-    unregister();
-  };
 });
 
 function handleSort(column: DataTableColumn<T>, event: MouseEvent) {

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -11,7 +11,7 @@
  * - Material 3 styling with theme token support
  */
 
-import { type Snippet, tick } from 'svelte';
+import { onMount, type Snippet, tick } from 'svelte';
 import { M } from '../../i18n/strings.js';
 import Trans from '../../i18n/Trans.svelte';
 import { useI18n } from '../../i18n/use-i18n.js';
@@ -29,6 +29,8 @@ import {
   type DataTableViewStateInput,
   dataTableRowIdKey,
 } from './DataTableController.js';
+import type { DataSurfaceJsonValue } from './data-surface.js';
+import { dataTableCommandFromDataSurfaceCommand } from './data-table-surface.js';
 import { resolveDataTableRows } from './DataTableIdentity.js';
 import {
   type DataTableResolvedColumn,
@@ -105,6 +107,7 @@ let {
   initialState,
   onStateChange,
   modes,
+  dataSurface,
 }: ExtendedProps<T> = $props();
 
 const dataTableId = $props.id();
@@ -154,6 +157,7 @@ let localControllerInitialized = false;
 let hasHorizontalOverflow = $state(false);
 let canScrollLeft = $state(false);
 let canScrollRight = $state(false);
+let surfaceHighlighted = $state(false);
 
 function activeController(): DataTableController {
   return controller ?? localController;
@@ -311,6 +315,134 @@ const sourceRows = $derived.by(() =>
 function dispatch(command: DataTableCommand) {
   activeController().dispatch(command);
 }
+
+function assertSurfaceDescriptorMatchesTable() {
+  if (!dataSurface) return;
+  const tableController = activeController();
+  const columnState = new Map(
+    tableController
+      .getState()
+      .columnVisibility.map((entry) => [entry.columnId, entry.visible]),
+  );
+  for (const descriptorColumn of dataSurface.descriptor.columns) {
+    const column = columns.find(
+      (candidate) => candidate.id === descriptorColumn.id,
+    );
+    if (
+      !column ||
+      column.hidden ||
+      visibleColumnIds?.has(column.id) === false ||
+      columnState.get(column.id) === false
+    ) {
+      throw new Error(
+        `DataSurface descriptor exposes a non-visible DataTable column: ${descriptorColumn.id}`,
+      );
+    }
+  }
+  const durableControls = new Set([
+    'set-selected-rows',
+    'toggle-row-selection',
+    'set-expanded-rows',
+    'toggle-row-expansion',
+  ]);
+  if (
+    !rowKey &&
+    (dataSurface.descriptor.actions.length > 0 ||
+      dataSurface.descriptor.controls.some((control) =>
+        durableControls.has(control.id),
+      ))
+  ) {
+    throw new Error(
+      'DataTable requires an explicit rowKey for mounted selection, expansion, or actions',
+    );
+  }
+  if (
+    typeof rowKey === 'string' &&
+    dataSurface.descriptor.rowKey !== String(rowKey)
+  ) {
+    throw new Error(
+      'DataSurface descriptor rowKey must match the DataTable rowKey',
+    );
+  }
+}
+
+onMount(() => {
+  if (!dataSurface) return;
+  assertSurfaceDescriptorMatchesTable();
+  const surfaceController = activeController();
+  let revision = 0;
+  let highlightTimer: ReturnType<typeof setTimeout> | undefined;
+  const unsubscribe = surfaceController.subscribe((transition) => {
+    if (transition.changed) revision += 1;
+  });
+  const unregister = dataSurface.registry.register({
+    descriptor: dataSurface.descriptor,
+    getSnapshot: () => {
+      const snapshot = surfaceController.snapshot();
+      return {
+        revision,
+        state: { table: snapshot as unknown as DataSurfaceJsonValue },
+        selection:
+          snapshot.state.selectedRowIds.length > 0
+            ? {
+                scope: 'explicit-ids' as const,
+                rowIds: snapshot.state.selectedRowIds,
+              }
+            : null,
+      };
+    },
+    execute: async (command) => {
+      const tableCommand = dataTableCommandFromDataSurfaceCommand(command);
+      if (tableCommand) {
+        const transition = surfaceController.dispatch(tableCommand);
+        if (surfaceController.isControlled() && transition.changed) {
+          const settled = await dataSurface.applyControlledState?.(
+            transition.next.state,
+            tableCommand,
+          );
+          if (settled) surfaceController.replaceState(settled);
+          if (
+            JSON.stringify(surfaceController.getState()) !==
+            JSON.stringify(transition.next.state)
+          ) {
+            return { ok: false };
+          }
+        }
+        return;
+      }
+      switch (command.controlId) {
+        case 'focus':
+          tableContainer?.focus();
+          return;
+        case 'reveal':
+          tableContainer?.scrollIntoView({ block: 'nearest' });
+          return;
+        case 'highlight':
+          surfaceHighlighted = true;
+          if (highlightTimer) clearTimeout(highlightTimer);
+          highlightTimer = setTimeout(() => {
+            surfaceHighlighted = false;
+          }, 1_000);
+          return;
+        case 'refresh':
+          if (!dataSurface.onRefresh) return { ok: false };
+          await dataSurface.onRefresh();
+          return;
+        case 'retry':
+          if (!dataSurface.onRetry) return { ok: false };
+          await dataSurface.onRetry();
+          return;
+        default:
+          return { ok: false };
+      }
+    },
+  });
+  return () => {
+    if (highlightTimer) clearTimeout(highlightTimer);
+    unsubscribe();
+    unregister();
+  };
+});
 
 function handleSort(column: DataTableColumn<T>, event: MouseEvent) {
   if (!sortable || !column.sortable) return;
@@ -1061,6 +1193,7 @@ $effect(() => {
   class:data-table-container--sticky={stickyHeader || virtualizedBody}
   class:data-table-container--overflowing={hasHorizontalOverflow}
   class:data-table-container--virtualized={virtualizationWindow.enabled}
+  class:data-table-container--highlighted={surfaceHighlighted}
   style:height={virtualContainerHeight === undefined ? undefined : `${virtualContainerHeight}px`}
   tabindex={virtualizationWindow.enabled || hasHorizontalOverflow ? 0 : undefined}
   role={virtualizationWindow.enabled || hasHorizontalOverflow ? 'region' : undefined}
@@ -1532,6 +1665,11 @@ $effect(() => {
   .data-table-container--overflowing:focus-visible {
     outline: 2px solid var(--smrt-color-primary, #3b82f6);
     outline-offset: 2px;
+  }
+
+  .data-table-container--highlighted {
+    outline: 2px solid var(--smrt-color-primary, #2563eb);
+    outline-offset: 3px;
   }
 
   .data-table__overflow-cue {

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -11,7 +11,7 @@
  * - Material 3 styling with theme token support
  */
 
-import { onMount, type Snippet, tick } from 'svelte';
+import { type Snippet, tick } from 'svelte';
 import { M } from '../../i18n/strings.js';
 import Trans from '../../i18n/Trans.svelte';
 import { useI18n } from '../../i18n/use-i18n.js';
@@ -43,6 +43,7 @@ import {
 } from './DataTableVirtualization.js';
 import type {
   DataTableColumn,
+  DataTableDataSurfaceOptions,
   DataTableProps,
   DataTableStructuralRow,
   SortState,
@@ -316,15 +317,22 @@ function dispatch(command: DataTableCommand) {
   activeController().dispatch(command);
 }
 
-function assertSurfaceDescriptorMatchesTable() {
-  if (!dataSurface) return;
+function assertSurfaceDescriptorMatchesTable(
+  surface: DataTableDataSurfaceOptions,
+) {
+  if (typeof rowKey !== 'string') {
+    throw new Error(
+      'DataTable requires a string rowKey for mounted data surfaces',
+    );
+  }
   const tableController = activeController();
   const columnState = new Map(
     tableController
       .getState()
       .columnVisibility.map((entry) => [entry.columnId, entry.visible]),
   );
-  for (const descriptorColumn of dataSurface.descriptor.columns) {
+  for (const descriptorColumn of surface.descriptor.columns) {
+    if (descriptorColumn.id === surface.descriptor.rowKey) continue;
     const column = columns.find(
       (candidate) => candidate.id === descriptorColumn.id,
     );
@@ -339,44 +347,25 @@ function assertSurfaceDescriptorMatchesTable() {
       );
     }
   }
-  const durableControls = new Set([
-    'set-selected-rows',
-    'toggle-row-selection',
-    'set-expanded-rows',
-    'toggle-row-expansion',
-  ]);
-  if (
-    !rowKey &&
-    (dataSurface.descriptor.actions.length > 0 ||
-      dataSurface.descriptor.controls.some((control) =>
-        durableControls.has(control.id),
-      ))
-  ) {
-    throw new Error(
-      'DataTable requires an explicit rowKey for mounted selection, expansion, or actions',
-    );
-  }
-  if (
-    typeof rowKey === 'string' &&
-    dataSurface.descriptor.rowKey !== String(rowKey)
-  ) {
+  if (surface.descriptor.rowKey !== rowKey) {
     throw new Error(
       'DataSurface descriptor rowKey must match the DataTable rowKey',
     );
   }
 }
 
-onMount(() => {
-  if (!dataSurface) return;
-  assertSurfaceDescriptorMatchesTable();
+$effect(() => {
+  const surface = dataSurface;
+  if (!surface) return;
+  assertSurfaceDescriptorMatchesTable(surface);
   const surfaceController = activeController();
   let revision = 0;
   let highlightTimer: ReturnType<typeof setTimeout> | undefined;
   const unsubscribe = surfaceController.subscribe((transition) => {
     if (transition.changed) revision += 1;
   });
-  const unregister = dataSurface.registry.register({
-    descriptor: dataSurface.descriptor,
+  const unregister = surface.registry.register({
+    descriptor: surface.descriptor,
     getSnapshot: () => {
       const snapshot = surfaceController.snapshot();
       return {
@@ -396,7 +385,7 @@ onMount(() => {
       if (tableCommand) {
         const transition = surfaceController.dispatch(tableCommand);
         if (surfaceController.isControlled() && transition.changed) {
-          const settled = await dataSurface.applyControlledState?.(
+          const settled = await surface.applyControlledState?.(
             transition.next.state,
             tableCommand,
           );
@@ -425,12 +414,12 @@ onMount(() => {
           }, 1_000);
           return;
         case 'refresh':
-          if (!dataSurface.onRefresh) return { ok: false };
-          await dataSurface.onRefresh();
+          if (!surface.onRefresh) return { ok: false };
+          await surface.onRefresh();
           return;
         case 'retry':
-          if (!dataSurface.onRetry) return { ok: false };
-          await dataSurface.onRetry();
+          if (!surface.onRetry) return { ok: false };
+          await surface.onRetry();
           return;
         default:
           return { ok: false };

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -29,8 +29,6 @@ import {
   type DataTableViewStateInput,
   dataTableRowIdKey,
 } from './DataTableController.js';
-import type { DataSurfaceJsonValue } from './data-surface.js';
-import { dataTableCommandFromDataSurfaceCommand } from './data-table-surface.js';
 import { resolveDataTableRows } from './DataTableIdentity.js';
 import {
   type DataTableResolvedColumn,
@@ -41,6 +39,8 @@ import {
   resolveDataTableVirtualWindow,
   scrollTopForDataTableRow,
 } from './DataTableVirtualization.js';
+import type { DataSurfaceJsonValue } from './data-surface.js';
+import { dataTableCommandFromDataSurfaceCommand } from './data-table-surface.js';
 import type {
   DataTableColumn,
   DataTableDataSurfaceOptions,
@@ -366,66 +366,66 @@ $effect(() => {
       if (transition.changed) revision += 1;
     });
     const unregister = surface.registry.register({
-    descriptor: surface.descriptor,
-    getSnapshot: () => {
-      const snapshot = surfaceController.snapshot();
-      return {
-        revision,
-        state: { table: snapshot as unknown as DataSurfaceJsonValue },
-        selection:
-          snapshot.state.selectedRowIds.length > 0
-            ? {
-                scope: 'explicit-ids' as const,
-                rowIds: snapshot.state.selectedRowIds,
-              }
-            : null,
-      };
-    },
-    execute: async (command) => {
-      const tableCommand = dataTableCommandFromDataSurfaceCommand(command);
-      if (tableCommand) {
-        const transition = surfaceController.dispatch(tableCommand);
-        if (surfaceController.isControlled() && transition.changed) {
-          const settled = await surface.applyControlledState?.(
-            transition.next.state,
-            tableCommand,
-          );
-          if (settled) surfaceController.replaceState(settled);
-          if (
-            JSON.stringify(surfaceController.getState()) !==
-            JSON.stringify(transition.next.state)
-          ) {
-            return { ok: false };
+      descriptor: surface.descriptor,
+      getSnapshot: () => {
+        const snapshot = surfaceController.snapshot();
+        return {
+          revision,
+          state: { table: snapshot as unknown as DataSurfaceJsonValue },
+          selection:
+            snapshot.state.selectedRowIds.length > 0
+              ? {
+                  scope: 'explicit-ids' as const,
+                  rowIds: snapshot.state.selectedRowIds,
+                }
+              : null,
+        };
+      },
+      execute: async (command) => {
+        const tableCommand = dataTableCommandFromDataSurfaceCommand(command);
+        if (tableCommand) {
+          const transition = surfaceController.dispatch(tableCommand);
+          if (surfaceController.isControlled() && transition.changed) {
+            const settled = await surface.applyControlledState?.(
+              transition.next.state,
+              tableCommand,
+            );
+            if (settled) surfaceController.replaceState(settled);
+            if (
+              JSON.stringify(surfaceController.getState()) !==
+              JSON.stringify(transition.next.state)
+            ) {
+              return { ok: false };
+            }
           }
+          return;
         }
-        return;
-      }
-      switch (command.controlId) {
-        case 'focus':
-          tableContainer?.focus();
-          return;
-        case 'reveal':
-          tableContainer?.scrollIntoView({ block: 'nearest' });
-          return;
-        case 'highlight':
-          surfaceHighlighted = true;
-          if (highlightTimer) clearTimeout(highlightTimer);
-          highlightTimer = setTimeout(() => {
-            surfaceHighlighted = false;
-          }, 1_000);
-          return;
-        case 'refresh':
-          if (!surface.onRefresh) return { ok: false };
-          await surface.onRefresh();
-          return;
-        case 'retry':
-          if (!surface.onRetry) return { ok: false };
-          await surface.onRetry();
-          return;
-        default:
-          return { ok: false };
-      }
-    },
+        switch (command.controlId) {
+          case 'focus':
+            tableContainer?.focus();
+            return;
+          case 'reveal':
+            tableContainer?.scrollIntoView({ block: 'nearest' });
+            return;
+          case 'highlight':
+            surfaceHighlighted = true;
+            if (highlightTimer) clearTimeout(highlightTimer);
+            highlightTimer = setTimeout(() => {
+              surfaceHighlighted = false;
+            }, 1_000);
+            return;
+          case 'refresh':
+            if (!surface.onRefresh) return { ok: false };
+            await surface.onRefresh();
+            return;
+          case 'retry':
+            if (!surface.onRetry) return { ok: false };
+            await surface.onRetry();
+            return;
+          default:
+            return { ok: false };
+        }
+      },
     });
     return () => {
       if (highlightTimer) clearTimeout(highlightTimer);

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -11,7 +11,7 @@
  * - Material 3 styling with theme token support
  */
 
-import { type Snippet, tick, untrack } from 'svelte';
+import { onDestroy, type Snippet, tick, untrack } from 'svelte';
 import { M } from '../../i18n/strings.js';
 import Trans from '../../i18n/Trans.svelte';
 import { useI18n } from '../../i18n/use-i18n.js';
@@ -44,6 +44,7 @@ import type {
   DataSurfaceJsonValue,
   DataSurfaceSelectionReference,
 } from './data-surface.js';
+import { normalizeDataSurfaceDescriptor } from './data-surface.js';
 import { dataTableCommandFromDataSurfaceCommand } from './data-table-surface.js';
 import type {
   DataTableColumn,
@@ -163,6 +164,20 @@ let hasHorizontalOverflow = $state(false);
 let canScrollLeft = $state(false);
 let canScrollRight = $state(false);
 let surfaceHighlighted = $state(false);
+
+interface DataTableSurfaceRegistration<T> {
+  surface: DataTableDataSurfaceOptions;
+  registry: DataTableDataSurfaceOptions['registry'];
+  descriptorSignature: string;
+  tableBindingSignature: string;
+  controller: DataTableController;
+  columns: DataTableColumn<T>[];
+  rowKey: DataTableProps<T>['rowKey'];
+  visibleColumnIds: Set<string> | undefined;
+  cleanup: () => void;
+}
+
+let surfaceRegistration: DataTableSurfaceRegistration<T> | undefined;
 
 function activeController(): DataTableController {
   return controller ?? localController;
@@ -323,8 +338,11 @@ function dispatch(command: DataTableCommand) {
 
 function assertSurfaceDescriptorMatchesTable(
   surface: DataTableDataSurfaceOptions,
+  tableColumns: DataTableColumn<T>[],
+  tableRowKey: DataTableProps<T>['rowKey'],
+  tableVisibleColumnIds: Set<string> | undefined,
 ) {
-  if (typeof rowKey !== 'string') {
+  if (typeof tableRowKey !== 'string') {
     throw new Error(
       'DataTable requires a string rowKey for mounted data surfaces',
     );
@@ -337,13 +355,13 @@ function assertSurfaceDescriptorMatchesTable(
   );
   for (const descriptorColumn of surface.descriptor.columns) {
     if (descriptorColumn.id === surface.descriptor.rowKey) continue;
-    const column = columns.find(
+    const column = tableColumns.find(
       (candidate) => candidate.id === descriptorColumn.id,
     );
     if (
       !column ||
       column.hidden ||
-      visibleColumnIds?.has(column.id) === false ||
+      tableVisibleColumnIds?.has(column.id) === false ||
       columnState.get(column.id) === false
     ) {
       throw new Error(
@@ -351,10 +369,85 @@ function assertSurfaceDescriptorMatchesTable(
       );
     }
   }
-  if (surface.descriptor.rowKey !== rowKey) {
+  if (surface.descriptor.rowKey !== tableRowKey) {
     throw new Error(
       'DataSurface descriptor rowKey must match the DataTable rowKey',
     );
+  }
+}
+
+function descriptorColumnAllows(
+  surface: DataTableDataSurfaceOptions,
+  tableColumns: DataTableColumn<T>[],
+  columnId: string,
+  capability?: 'filter' | 'sort',
+): boolean {
+  const descriptorColumn = surface.descriptor.columns.find(
+    (column) => column.id === columnId,
+  );
+  const tableColumn = tableColumns.find((column) => column.id === columnId);
+  if (!descriptorColumn || !tableColumn) return false;
+  if (!descriptorColumn.capabilities.includes('read')) return false;
+  return capability === undefined
+    ? true
+    : descriptorColumn.capabilities.includes(capability);
+}
+
+function descriptorAllowsTableCommand(
+  surface: DataTableDataSurfaceOptions,
+  tableColumns: DataTableColumn<T>[],
+  command: DataTableCommand,
+): boolean {
+  switch (command.type) {
+    case 'setFilters':
+      return command.filters.every((filter) => {
+        const column = tableColumns.find(
+          (candidate) => candidate.id === filter.columnId,
+        );
+        return (
+          column?.filterable !== false &&
+          descriptorColumnAllows(
+            surface,
+            tableColumns,
+            filter.columnId,
+            'filter',
+          )
+        );
+      });
+    case 'setSorting':
+      return command.sorting.every((sortRule) => {
+        const column = tableColumns.find(
+          (candidate) => candidate.id === sortRule.columnId,
+        );
+        return (
+          column?.sortable === true &&
+          descriptorColumnAllows(
+            surface,
+            tableColumns,
+            sortRule.columnId,
+            'sort',
+          )
+        );
+      });
+    case 'toggleSorting': {
+      const column = tableColumns.find(
+        (candidate) => candidate.id === command.columnId,
+      );
+      return (
+        column?.sortable === true &&
+        descriptorColumnAllows(surface, tableColumns, command.columnId, 'sort')
+      );
+    }
+    case 'setColumnOrder':
+      return command.columnIds.every((columnId) =>
+        descriptorColumnAllows(surface, tableColumns, columnId),
+      );
+    case 'setColumnVisibility':
+      return command.columns.every((column) =>
+        descriptorColumnAllows(surface, tableColumns, column.columnId),
+      );
+    default:
+      return true;
   }
 }
 
@@ -396,10 +489,57 @@ function preservesDeclaredVisibleColumnsForCommand(
 
 $effect(() => {
   const surface = dataSurface;
-  if (!surface) return;
-  assertSurfaceDescriptorMatchesTable(surface);
   const surfaceController = activeController();
-  return untrack(() => {
+  if (!surface) {
+    surfaceRegistration?.cleanup();
+    surfaceRegistration = undefined;
+    return;
+  }
+  assertSurfaceDescriptorMatchesTable(
+    surface,
+    columns,
+    rowKey,
+    visibleColumnIds,
+  );
+  const descriptorSignature = JSON.stringify(
+    normalizeDataSurfaceDescriptor(surface.descriptor),
+  );
+  const tableBindingSignature = JSON.stringify({
+    rowKey,
+    visibleColumnIds: visibleColumnIds ? [...visibleColumnIds].sort() : null,
+    columns: columns.map((column) => ({
+      id: column.id,
+      hidden: column.hidden === true,
+      sortable: column.sortable === true,
+      filterable: column.filterable !== false,
+    })),
+  });
+  if (
+    surfaceRegistration?.registry === surface.registry &&
+    surfaceRegistration.descriptorSignature === descriptorSignature &&
+    surfaceRegistration.tableBindingSignature === tableBindingSignature &&
+    surfaceRegistration.controller === surfaceController
+  ) {
+    surfaceRegistration.surface = surface;
+    surfaceRegistration.columns = columns;
+    surfaceRegistration.rowKey = rowKey;
+    surfaceRegistration.visibleColumnIds = visibleColumnIds;
+    return;
+  }
+  surfaceRegistration?.cleanup();
+  surfaceRegistration = undefined;
+  const registration: DataTableSurfaceRegistration<T> = {
+    surface,
+    registry: surface.registry,
+    descriptorSignature,
+    tableBindingSignature,
+    controller: surfaceController,
+    columns,
+    rowKey,
+    visibleColumnIds,
+    cleanup: () => {},
+  };
+  const cleanup = untrack(() => {
     let revision = 0;
     let highlightTimer: ReturnType<typeof setTimeout> | undefined;
     let restoringInvalidVisibility = false;
@@ -407,7 +547,7 @@ $effect(() => {
       if (
         !restoringInvalidVisibility &&
         !preservesDeclaredVisibleColumns(
-          surface,
+          registration.surface,
           transition.next.state.columnVisibility,
         )
       ) {
@@ -422,7 +562,7 @@ $effect(() => {
       if (transition.changed) revision += 1;
     });
     const unregister = surface.registry.register({
-      descriptor: surface.descriptor,
+      descriptor: registration.surface.descriptor,
       getSnapshot: () => {
         const snapshot = surfaceController.snapshot();
         return {
@@ -435,13 +575,21 @@ $effect(() => {
         const tableCommand = dataTableCommandFromDataSurfaceCommand(command);
         if (tableCommand) {
           if (
-            !preservesDeclaredVisibleColumnsForCommand(surface, tableCommand)
+            !descriptorAllowsTableCommand(
+              registration.surface,
+              registration.columns,
+              tableCommand,
+            ) ||
+            !preservesDeclaredVisibleColumnsForCommand(
+              registration.surface,
+              tableCommand,
+            )
           ) {
             return { ok: false };
           }
           const transition = surfaceController.dispatch(tableCommand);
           if (surfaceController.isControlled() && transition.changed) {
-            const settled = await surface.applyControlledState?.(
+            const settled = await registration.surface.applyControlledState?.(
               transition.next.state,
               tableCommand,
             );
@@ -470,12 +618,12 @@ $effect(() => {
             }, 1_000);
             return;
           case 'refresh':
-            if (!surface.onRefresh) return { ok: false };
-            await surface.onRefresh();
+            if (!registration.surface.onRefresh) return { ok: false };
+            await registration.surface.onRefresh();
             return;
           case 'retry':
-            if (!surface.onRetry) return { ok: false };
-            await surface.onRetry();
+            if (!registration.surface.onRetry) return { ok: false };
+            await registration.surface.onRetry();
             return;
           default:
             return { ok: false };
@@ -488,7 +636,11 @@ $effect(() => {
       unregister();
     };
   });
+  registration.cleanup = cleanup;
+  surfaceRegistration = registration;
 });
+
+onDestroy(() => surfaceRegistration?.cleanup());
 
 function handleSort(column: DataTableColumn<T>, event: MouseEvent) {
   if (!sortable || !column.sortable) return;
@@ -1241,7 +1393,7 @@ $effect(() => {
   class:data-table-container--virtualized={virtualizationWindow.enabled}
   class:data-table-container--highlighted={surfaceHighlighted}
   style:height={virtualContainerHeight === undefined ? undefined : `${virtualContainerHeight}px`}
-  tabindex={virtualizationWindow.enabled || hasHorizontalOverflow ? 0 : undefined}
+  tabindex={virtualizationWindow.enabled || hasHorizontalOverflow ? 0 : dataSurface ? -1 : undefined}
   role={virtualizationWindow.enabled || hasHorizontalOverflow ? 'region' : undefined}
   aria-label={virtualizationWindow.enabled
     ? caption

--- a/packages/smrt-ui/src/components/data/DataTable.svelte
+++ b/packages/smrt-ui/src/components/data/DataTable.svelte
@@ -24,6 +24,7 @@ import {
   type DataTableFilter,
   type DataTableModes,
   type DataTableRowId,
+  type DataTableSelection,
   type DataTableSnapshot,
   type DataTableViewState,
   type DataTableViewStateInput,
@@ -39,7 +40,10 @@ import {
   resolveDataTableVirtualWindow,
   scrollTopForDataTableRow,
 } from './DataTableVirtualization.js';
-import type { DataSurfaceJsonValue } from './data-surface.js';
+import type {
+  DataSurfaceJsonValue,
+  DataSurfaceSelectionReference,
+} from './data-surface.js';
 import { dataTableCommandFromDataSurfaceCommand } from './data-table-surface.js';
 import type {
   DataTableColumn,
@@ -354,6 +358,34 @@ function assertSurfaceDescriptorMatchesTable(
   }
 }
 
+function dataSurfaceSelection(
+  selection: DataTableSelection,
+): DataSurfaceSelectionReference | null {
+  if (selection.scope === 'page') return { scope: 'current-page' };
+  if (selection.scope === 'allMatching') {
+    return {
+      scope: 'all-matching',
+      queryFingerprint: selection.queryFingerprint,
+    };
+  }
+  return selection.rowIds.length > 0
+    ? { scope: 'explicit-ids', rowIds: selection.rowIds }
+    : null;
+}
+
+function preservesDeclaredVisibleColumns(
+  surface: DataTableDataSurfaceOptions,
+  command: DataTableCommand,
+): boolean {
+  if (command.type !== 'setColumnVisibility') return true;
+  const requested = new Map(
+    command.columns.map((column) => [column.columnId, column.visible]),
+  );
+  return surface.descriptor.columns
+    .filter((column) => column.id !== surface.descriptor.rowKey)
+    .every((column) => requested.get(column.id) === true);
+}
+
 $effect(() => {
   const surface = dataSurface;
   if (!surface) return;
@@ -372,18 +404,15 @@ $effect(() => {
         return {
           revision,
           state: { table: snapshot as unknown as DataSurfaceJsonValue },
-          selection:
-            snapshot.state.selectedRowIds.length > 0
-              ? {
-                  scope: 'explicit-ids' as const,
-                  rowIds: snapshot.state.selectedRowIds,
-                }
-              : null,
+          selection: dataSurfaceSelection(snapshot.state.selection),
         };
       },
       execute: async (command) => {
         const tableCommand = dataTableCommandFromDataSurfaceCommand(command);
         if (tableCommand) {
+          if (!preservesDeclaredVisibleColumns(surface, tableCommand)) {
+            return { ok: false };
+          }
           const transition = surfaceController.dispatch(tableCommand);
           if (surfaceController.isControlled() && transition.changed) {
             const settled = await surface.applyControlledState?.(

--- a/packages/smrt-ui/src/components/data/DataTableController.ts
+++ b/packages/smrt-ui/src/components/data/DataTableController.ts
@@ -962,6 +962,11 @@ export class DataTableController {
     return { ...this.modes };
   }
 
+  /** Whether commands are proposals until an owning host supplies state. */
+  isControlled(): boolean {
+    return this.controlled;
+  }
+
   snapshot(): DataTableSnapshot {
     return { version: 3, modes: this.getModes(), state: this.getState() };
   }

--- a/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
@@ -94,6 +94,117 @@ describe('mounted data surfaces', () => {
     ]);
   });
 
+  it('focuses a normal mounted table through its programmatic focus target', async () => {
+    const registry = createDataSurfaceRegistry();
+    const identity: DataSurfaceIdentity = {
+      surfaceId: 'focusable-people-table',
+      kind: 'table',
+    };
+    render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'name',
+        dataSurface: {
+          registry,
+          descriptor: descriptor(identity, ['focus']),
+        },
+      },
+    });
+
+    await vi.waitFor(() => expect(registry.inspect(identity)).toBeDefined());
+    await expect(
+      registry.execute({
+        version: 1,
+        commandId: 'focus-table',
+        identity,
+        expectedRevision: 0,
+        controlId: 'focus',
+      }),
+    ).resolves.toMatchObject({ ok: true });
+    expect(document.activeElement).toBe(
+      document.querySelector('.data-table-container'),
+    );
+  });
+
+  it('enforces descriptor membership and filter/sort capabilities before dispatch', async () => {
+    const registry = createDataSurfaceRegistry();
+    const identity: DataSurfaceIdentity = {
+      surfaceId: 'policy-filtered-people-table',
+      kind: 'table',
+    };
+    const controller = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+    });
+    render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'name',
+        controller,
+        dataSurface: {
+          registry,
+          descriptor: {
+            ...descriptor(identity, [
+              'set-filters',
+              'set-sorting',
+              'toggle-sorting',
+              'set-column-order',
+              'set-column-visibility',
+            ]),
+            columns: [
+              {
+                id: 'name',
+                label: 'Name',
+                capabilities: ['read', 'sort'],
+              },
+            ],
+            query: { modes: ['rows'], projectableColumnIds: ['name'] },
+          },
+        },
+      },
+    });
+
+    await vi.waitFor(() => expect(registry.inspect(identity)).toBeDefined());
+    for (const [commandId, controlId, payload] of [
+      [
+        'hidden-age-filter',
+        'set-filters',
+        { filters: [{ columnId: 'age', operator: 'equals', value: 36 }] },
+      ],
+      [
+        'hidden-age-sort',
+        'set-sorting',
+        { sorting: [{ columnId: 'age', direction: 'asc' }] },
+      ],
+      ['hidden-age-toggle', 'toggle-sorting', { columnId: 'age' }],
+      ['hidden-age-order', 'set-column-order', { columnIds: ['name', 'age'] }],
+      [
+        'hidden-age-visibility',
+        'set-column-visibility',
+        { columns: [{ columnId: 'age', visible: true }] },
+      ],
+      [
+        'non-filterable-name',
+        'set-filters',
+        { filters: [{ columnId: 'name', operator: 'equals', value: 'Ada' }] },
+      ],
+    ] as const) {
+      await expect(
+        registry.execute({
+          version: 1,
+          commandId,
+          identity,
+          expectedRevision: 0,
+          controlId,
+          payload,
+        }),
+      ).resolves.toMatchObject({ ok: false, reason: 'denied' });
+    }
+    expect(controller.getState().filters).toEqual([]);
+    expect(controller.getState().sorting).toEqual([]);
+  });
+
   it('preserves page and all-matching selection scopes in mounted snapshots', async () => {
     const registry = createDataSurfaceRegistry();
     const pageIdentity: DataSurfaceIdentity = {
@@ -707,6 +818,66 @@ describe('mounted data surfaces', () => {
         expectedRevision: 0,
         controlId: 'set-view',
         payload: { view: 'list' },
+      }),
+    ).resolves.toMatchObject({ ok: false, reason: 'stale_revision' });
+  });
+
+  it('preserves DataTable registration and replay state for equivalent bindings', async () => {
+    const registry = createDataSurfaceRegistry();
+    const identity: DataSurfaceIdentity = {
+      surfaceId: 'equivalent-table-binding',
+      kind: 'table',
+    };
+    const equivalentColumns = () => columns.map((column) => ({ ...column }));
+    const surface = () => ({
+      registry,
+      descriptor: descriptor(identity, ['toggle-sorting']),
+    });
+    const controller = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+    });
+    const { rerender } = render(DataTable, {
+      props: {
+        data: rows,
+        columns: equivalentColumns(),
+        rowKey: 'name',
+        sortable: true,
+        controller,
+        dataSurface: surface(),
+      },
+    });
+
+    await vi.waitFor(() => expect(registry.inspect(identity)).toBeDefined());
+    await expect(
+      registry.execute({
+        version: 1,
+        commandId: 'table-sort',
+        identity,
+        expectedRevision: 0,
+        controlId: 'toggle-sorting',
+        payload: { columnId: 'name' },
+      }),
+    ).resolves.toMatchObject({ ok: true, revision: 1 });
+
+    await rerender({
+      data: rows,
+      columns: equivalentColumns(),
+      rowKey: 'name',
+      sortable: true,
+      controller,
+      dataSurface: surface(),
+    });
+    await vi.waitFor(() =>
+      expect(registry.inspect(identity)).toMatchObject({ revision: 1 }),
+    );
+    await expect(
+      registry.execute({
+        version: 1,
+        commandId: 'stale-table-sort',
+        identity,
+        expectedRevision: 0,
+        controlId: 'toggle-sorting',
+        payload: { columnId: 'name' },
       }),
     ).resolves.toMatchObject({ ok: false, reason: 'stale_revision' });
   });

--- a/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
@@ -138,6 +138,105 @@ describe('mounted data surfaces', () => {
     });
   });
 
+  it('reactively registers delayed and replacement DataTable surface props', async () => {
+    const registry = createDataSurfaceRegistry();
+    const firstIdentity: DataSurfaceIdentity = {
+      surfaceId: 'first-people-table',
+      kind: 'table',
+    };
+    const nextIdentity: DataSurfaceIdentity = {
+      surfaceId: 'next-people-table',
+      kind: 'table',
+    };
+    const firstController = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+    });
+    const nextController = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+    });
+    const { rerender } = render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'name',
+        controller: firstController,
+      },
+    });
+
+    expect(registry.inspect(firstIdentity)).toBeUndefined();
+    await rerender({
+      data: rows,
+      columns,
+      rowKey: 'name',
+      controller: firstController,
+      dataSurface: {
+        registry,
+        descriptor: descriptor(firstIdentity, ['set-search']),
+      },
+    });
+    await vi.waitFor(() =>
+      expect(registry.inspect(firstIdentity)).toBeDefined(),
+    );
+
+    await rerender({
+      data: rows,
+      columns,
+      rowKey: 'name',
+      controller: nextController,
+      dataSurface: {
+        registry,
+        descriptor: descriptor(nextIdentity, ['set-search']),
+      },
+    });
+    await vi.waitFor(() => {
+      expect(registry.inspect(firstIdentity)).toBeUndefined();
+      expect(registry.inspect(nextIdentity)).toBeDefined();
+    });
+
+    await registry.execute({
+      version: 1,
+      commandId: 'next-search',
+      identity: nextIdentity,
+      expectedRevision: 0,
+      controlId: 'set-search',
+      payload: { search: 'Grace' },
+    });
+    expect(firstController.getState().search).toBe('');
+    expect(nextController.getState().search).toBe('Grace');
+  });
+
+  it('allows a stable row key that is not a rendered column', async () => {
+    const registry = createDataSurfaceRegistry();
+    const identity: DataSurfaceIdentity = {
+      surfaceId: 'hidden-id-table',
+      kind: 'table',
+    };
+    render(DataTable, {
+      props: {
+        data: [{ id: 'ada', name: 'Ada' }],
+        columns: [{ id: 'name', label: 'Name', accessor: 'name' }],
+        rowKey: 'id',
+        dataSurface: {
+          registry,
+          descriptor: {
+            ...descriptor(identity, []),
+            rowKey: 'id',
+            columns: [
+              { id: 'id', label: 'ID', capabilities: ['read'] },
+              { id: 'name', label: 'Name', capabilities: ['read'] },
+            ],
+            query: {
+              modes: ['rows'],
+              projectableColumnIds: ['id', 'name'],
+            },
+          },
+        },
+      },
+    });
+
+    await vi.waitFor(() => expect(registry.inspect(identity)).toBeDefined());
+  });
+
   it('registers a CollectionToolbar without a hidden automation path and shares its controller search', async () => {
     const registry = createDataSurfaceRegistry();
     const identity: DataSurfaceIdentity = {
@@ -179,5 +278,57 @@ describe('mounted data surfaces', () => {
       ok: true,
       snapshot: { state: { search: 'Ada', view: 'grid' } },
     });
+  });
+
+  it('reactively registers delayed and replacement CollectionToolbar surface props', async () => {
+    const registry = createDataSurfaceRegistry();
+    const firstIdentity: DataSurfaceIdentity = {
+      surfaceId: 'first-people-toolbar',
+      kind: 'custom',
+    };
+    const nextIdentity: DataSurfaceIdentity = {
+      surfaceId: 'next-people-toolbar',
+      kind: 'custom',
+    };
+    const firstController = createDataTableController();
+    const nextController = createDataTableController();
+    const { rerender } = render(CollectionToolbar, {
+      props: { controller: firstController },
+    });
+
+    expect(registry.inspect(firstIdentity)).toBeUndefined();
+    await rerender({
+      controller: firstController,
+      dataSurface: {
+        registry,
+        descriptor: descriptor(firstIdentity, ['set-search']),
+      },
+    });
+    await vi.waitFor(() =>
+      expect(registry.inspect(firstIdentity)).toBeDefined(),
+    );
+
+    await rerender({
+      controller: nextController,
+      dataSurface: {
+        registry,
+        descriptor: descriptor(nextIdentity, ['set-search']),
+      },
+    });
+    await vi.waitFor(() => {
+      expect(registry.inspect(firstIdentity)).toBeUndefined();
+      expect(registry.inspect(nextIdentity)).toBeDefined();
+    });
+
+    await registry.execute({
+      version: 1,
+      commandId: 'next-toolbar-search',
+      identity: nextIdentity,
+      expectedRevision: 0,
+      controlId: 'set-search',
+      payload: { search: 'Grace' },
+    });
+    expect(firstController.getState().search).toBe('');
+    expect(nextController.getState().search).toBe('Grace');
   });
 });

--- a/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
@@ -66,7 +66,9 @@ describe('mounted data surfaces', () => {
     });
 
     await vi.waitFor(() => expect(registry.inspect(identity)).toBeDefined());
-    await userEvent.click(screen.getByRole('button', { name: 'Name' }));
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Sort Name ascending' }),
+    );
     const humanSnapshot = registry.inspect(identity);
 
     expect(humanSnapshot).toMatchObject({
@@ -136,6 +138,102 @@ describe('mounted data surfaces', () => {
       revision: 1,
       snapshot: { state: { table: { state: { search: 'Grace' } } } },
     });
+  });
+
+  it('denies or fails controlled commands when the host does not settle them', async () => {
+    const registry = createDataSurfaceRegistry();
+    const initial = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+    }).getState();
+    const deniedIdentity: DataSurfaceIdentity = {
+      surfaceId: 'denied-controlled-table',
+      kind: 'table',
+    };
+    const failedIdentity: DataSurfaceIdentity = {
+      surfaceId: 'failed-controlled-table',
+      kind: 'table',
+    };
+    render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'name',
+        controller: createDataTableController({
+          state: initial,
+          columnIds: columns.map((column) => column.id),
+        }),
+        dataSurface: {
+          registry,
+          descriptor: descriptor(deniedIdentity, ['set-search']),
+          applyControlledState: () => undefined,
+        },
+      },
+    });
+    render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'name',
+        controller: createDataTableController({
+          state: initial,
+          columnIds: columns.map((column) => column.id),
+        }),
+        dataSurface: {
+          registry,
+          descriptor: descriptor(failedIdentity, ['set-search']),
+          applyControlledState: () => {
+            throw new Error('host rejected state');
+          },
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(registry.inspect(deniedIdentity)).toBeDefined();
+      expect(registry.inspect(failedIdentity)).toBeDefined();
+    });
+    await expect(
+      registry.execute({
+        version: 1,
+        commandId: 'denied-search',
+        identity: deniedIdentity,
+        expectedRevision: 0,
+        controlId: 'set-search',
+        payload: { search: 'Ada' },
+      }),
+    ).resolves.toMatchObject({ ok: false, reason: 'denied' });
+    await expect(
+      registry.execute({
+        version: 1,
+        commandId: 'failed-search',
+        identity: failedIdentity,
+        expectedRevision: 0,
+        controlId: 'set-search',
+        payload: { search: 'Ada' },
+      }),
+    ).resolves.toMatchObject({ ok: false, reason: 'execution_failed' });
+  });
+
+  it('unregisters a mounted DataTable when the component unmounts', async () => {
+    const registry = createDataSurfaceRegistry();
+    const identity: DataSurfaceIdentity = {
+      surfaceId: 'unmounted-table',
+      kind: 'table',
+    };
+    const { unmount } = render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'name',
+        dataSurface: {
+          registry,
+          descriptor: descriptor(identity, ['set-search']),
+        },
+      },
+    });
+    await vi.waitFor(() => expect(registry.inspect(identity)).toBeDefined());
+    unmount();
+    expect(registry.inspect(identity)).toBeUndefined();
   });
 
   it('reactively registers delayed and replacement DataTable surface props', async () => {

--- a/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
@@ -374,4 +374,49 @@ describe('mounted data surfaces', () => {
       }),
     ).resolves.toMatchObject({ ok: false, reason: 'stale_revision' });
   });
+
+  it('preserves toolbar revisions for equivalent surface bindings', async () => {
+    const registry = createDataSurfaceRegistry();
+    const identity: DataSurfaceIdentity = {
+      surfaceId: 'equivalent-toolbar-binding',
+      kind: 'custom',
+    };
+    const surface = () => ({
+      registry,
+      descriptor: descriptor(identity, ['set-view']),
+    });
+    const { rerender } = render(CollectionToolbar, {
+      props: { dataSurface: surface() },
+    });
+
+    await vi.waitFor(() => expect(registry.inspect(identity)).toBeDefined());
+    await expect(
+      registry.execute({
+        version: 1,
+        commandId: 'change-toolbar-view',
+        identity,
+        expectedRevision: 0,
+        controlId: 'set-view',
+        payload: { view: 'grid' },
+      }),
+    ).resolves.toMatchObject({ ok: true, revision: 1 });
+
+    await rerender({ dataSurface: surface() });
+    await vi.waitFor(() =>
+      expect(registry.inspect(identity)).toMatchObject({
+        revision: 1,
+        state: { search: '', view: 'grid' },
+      }),
+    );
+    await expect(
+      registry.execute({
+        version: 1,
+        commandId: 'stale-equivalent-toolbar-command',
+        identity,
+        expectedRevision: 0,
+        controlId: 'set-view',
+        payload: { view: 'list' },
+      }),
+    ).resolves.toMatchObject({ ok: false, reason: 'stale_revision' });
+  });
 });

--- a/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
@@ -197,6 +197,44 @@ describe('mounted data surfaces', () => {
     ]);
   });
 
+  it('restores declared columns after an external controller visibility transition', async () => {
+    const registry = createDataSurfaceRegistry();
+    const identity: DataSurfaceIdentity = {
+      surfaceId: 'external-visible-columns-table',
+      kind: 'table',
+    };
+    const controller = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+    });
+    render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'name',
+        controller,
+        dataSurface: {
+          registry,
+          descriptor: descriptor(identity, []),
+        },
+      },
+    });
+    await vi.waitFor(() => expect(registry.inspect(identity)).toBeDefined());
+
+    controller.dispatch({
+      type: 'setColumnVisibility',
+      columns: [
+        { columnId: 'name', visible: true },
+        { columnId: 'age', visible: false },
+      ],
+    });
+
+    expect(controller.getState().columnVisibility).toEqual([
+      { columnId: 'age', visible: true },
+      { columnId: 'name', visible: true },
+    ]);
+    expect(registry.inspect(identity)?.descriptor.columns).toHaveLength(2);
+  });
+
   it('turns malformed table command payloads into bounded denials', async () => {
     const registry = createDataSurfaceRegistry();
     const identity: DataSurfaceIdentity = {

--- a/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
@@ -1,0 +1,183 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import CollectionToolbar from '../CollectionToolbar.svelte';
+import DataTable from '../DataTable.svelte';
+import { createDataTableController } from '../DataTableController.js';
+import {
+  createDataSurfaceRegistry,
+  type DataSurfaceDescriptor,
+  type DataSurfaceIdentity,
+} from '../data-surface.js';
+
+const columns = [
+  { id: 'name', label: 'Name', accessor: 'name', sortable: true },
+  { id: 'age', label: 'Age', accessor: 'age', sortable: true },
+];
+const rows = [
+  { name: 'Ada', age: 36 },
+  { name: 'Grace', age: 85 },
+];
+
+function descriptor(
+  identity: DataSurfaceIdentity,
+  controls: string[],
+): DataSurfaceDescriptor {
+  return {
+    version: 1,
+    identity,
+    schemaVersion: 1,
+    label: identity.surfaceId,
+    rowKey: 'name',
+    columns: columns.map((column) => ({
+      id: column.id,
+      label: column.label,
+      capabilities: ['read', 'search', 'filter', 'sort', 'project'],
+    })),
+    query: { modes: ['rows', 'count'], projectableColumnIds: ['name', 'age'] },
+    controls: controls.map((id) => ({ id, label: id })),
+    actions: [],
+    limits: { maxQueryRows: 100, maxQueryBytes: 10_000, maxSelectionSize: 10 },
+  };
+}
+
+describe('mounted data surfaces', () => {
+  it('registers a DataTable explicitly and acknowledges the same controller state used by a header click', async () => {
+    const registry = createDataSurfaceRegistry();
+    const identity: DataSurfaceIdentity = {
+      surfaceId: 'people-table',
+      kind: 'table',
+    };
+    const controller = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+    });
+    render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'name',
+        sortable: true,
+        controller,
+        dataSurface: {
+          registry,
+          descriptor: descriptor(identity, ['toggle-sorting', 'set-search']),
+        },
+      },
+    });
+
+    await vi.waitFor(() => expect(registry.inspect(identity)).toBeDefined());
+    await userEvent.click(screen.getByRole('button', { name: 'Name' }));
+    const humanSnapshot = registry.inspect(identity);
+
+    expect(humanSnapshot).toMatchObject({
+      revision: 1,
+      state: {
+        table: { state: { sorting: [{ columnId: 'name', direction: 'asc' }] } },
+      },
+    });
+
+    const result = await registry.execute({
+      version: 1,
+      commandId: 'sort-age',
+      identity,
+      expectedRevision: humanSnapshot?.revision ?? -1,
+      controlId: 'toggle-sorting',
+      payload: { columnId: 'age', multi: true },
+    });
+
+    expect(result).toMatchObject({ ok: true, revision: 2 });
+    expect(controller.getState().sorting).toEqual([
+      { columnId: 'name', direction: 'asc' },
+      { columnId: 'age', direction: 'asc' },
+    ]);
+  });
+
+  it('waits for a controlled DataTable host to settle candidate state before acknowledgement', async () => {
+    const registry = createDataSurfaceRegistry();
+    const identity: DataSurfaceIdentity = {
+      surfaceId: 'controlled-people-table',
+      kind: 'table',
+    };
+    const initial = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+    }).getState();
+    const controller = createDataTableController({
+      state: initial,
+      columnIds: columns.map((column) => column.id),
+    });
+    const applyControlledState = vi.fn((state) => state);
+    render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'name',
+        controller,
+        dataSurface: {
+          registry,
+          descriptor: descriptor(identity, ['set-search']),
+          applyControlledState,
+        },
+      },
+    });
+
+    await vi.waitFor(() => expect(registry.inspect(identity)).toBeDefined());
+    const result = await registry.execute({
+      version: 1,
+      commandId: 'search-grace',
+      identity,
+      expectedRevision: 0,
+      controlId: 'set-search',
+      payload: { search: 'Grace' },
+    });
+
+    expect(applyControlledState).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      ok: true,
+      revision: 1,
+      snapshot: { state: { table: { state: { search: 'Grace' } } } },
+    });
+  });
+
+  it('registers a CollectionToolbar without a hidden automation path and shares its controller search', async () => {
+    const registry = createDataSurfaceRegistry();
+    const identity: DataSurfaceIdentity = {
+      surfaceId: 'people-toolbar',
+      kind: 'custom',
+    };
+    const controller = createDataTableController();
+    render(CollectionToolbar, {
+      props: {
+        controller,
+        views: ['list', 'grid', 'table'],
+        dataSurface: {
+          registry,
+          descriptor: descriptor(identity, ['set-search', 'set-view']),
+        },
+      },
+    });
+
+    await vi.waitFor(() => expect(registry.inspect(identity)).toBeDefined());
+    const search = await registry.execute({
+      version: 1,
+      commandId: 'toolbar-search',
+      identity,
+      expectedRevision: 0,
+      controlId: 'set-search',
+      payload: { search: 'Ada' },
+    });
+    const view = await registry.execute({
+      version: 1,
+      commandId: 'toolbar-grid',
+      identity,
+      expectedRevision: search.revision ?? -1,
+      controlId: 'set-view',
+      payload: { view: 'grid' },
+    });
+
+    expect(controller.getState().search).toBe('Ada');
+    expect(view).toMatchObject({
+      ok: true,
+      snapshot: { state: { search: 'Ada', view: 'grid' } },
+    });
+  });
+});

--- a/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
@@ -94,6 +94,161 @@ describe('mounted data surfaces', () => {
     ]);
   });
 
+  it('preserves page and all-matching selection scopes in mounted snapshots', async () => {
+    const registry = createDataSurfaceRegistry();
+    const pageIdentity: DataSurfaceIdentity = {
+      surfaceId: 'page-selection-table',
+      kind: 'table',
+    };
+    const allMatchingIdentity: DataSurfaceIdentity = {
+      surfaceId: 'all-matching-selection-table',
+      kind: 'table',
+    };
+    const props = {
+      data: rows,
+      columns,
+      rowKey: 'name' as const,
+      dataSurface: {
+        registry,
+        descriptor: descriptor(pageIdentity, []),
+      },
+    };
+    render(DataTable, {
+      props: {
+        ...props,
+        controller: createDataTableController({
+          initialState: { selection: { scope: 'page', rowIds: ['Ada'] } },
+        }),
+      },
+    });
+    render(DataTable, {
+      props: {
+        ...props,
+        controller: createDataTableController({
+          initialState: {
+            selection: {
+              scope: 'allMatching',
+              expectedCount: 42,
+              queryFingerprint: 'people-query',
+              queryRevision: 'revision-1',
+            },
+          },
+          columnIds: columns.map((column) => column.id),
+        }),
+        dataSurface: {
+          registry,
+          descriptor: descriptor(allMatchingIdentity, []),
+        },
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(registry.inspect(pageIdentity)?.selection).toEqual({
+        scope: 'current-page',
+      });
+      expect(registry.inspect(allMatchingIdentity)?.selection).toEqual({
+        scope: 'all-matching',
+        queryFingerprint: 'people-query',
+      });
+    });
+  });
+
+  it('rejects visibility commands that would hide declared surface columns', async () => {
+    const registry = createDataSurfaceRegistry();
+    const identity: DataSurfaceIdentity = {
+      surfaceId: 'visible-columns-table',
+      kind: 'table',
+    };
+    const controller = createDataTableController({
+      columnIds: columns.map((column) => column.id),
+    });
+    render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'name',
+        controller,
+        dataSurface: {
+          registry,
+          descriptor: descriptor(identity, ['set-column-visibility']),
+        },
+      },
+    });
+    await vi.waitFor(() => expect(registry.inspect(identity)).toBeDefined());
+
+    await expect(
+      registry.execute({
+        version: 1,
+        commandId: 'hide-age',
+        identity,
+        expectedRevision: 0,
+        controlId: 'set-column-visibility',
+        payload: {
+          columns: [
+            { columnId: 'name', visible: true },
+            { columnId: 'age', visible: false },
+          ],
+        },
+      }),
+    ).resolves.toMatchObject({ ok: false, reason: 'denied' });
+    expect(controller.getState().columnVisibility).toEqual([
+      { columnId: 'age', visible: true },
+      { columnId: 'name', visible: true },
+    ]);
+  });
+
+  it('turns malformed table command payloads into bounded denials', async () => {
+    const registry = createDataSurfaceRegistry();
+    const identity: DataSurfaceIdentity = {
+      surfaceId: 'malformed-command-table',
+      kind: 'table',
+    };
+    render(DataTable, {
+      props: {
+        data: rows,
+        columns,
+        rowKey: 'name',
+        dataSurface: {
+          registry,
+          descriptor: descriptor(identity, [
+            'set-filters',
+            'set-sorting',
+            'set-column-visibility',
+          ]),
+        },
+      },
+    });
+    await vi.waitFor(() => expect(registry.inspect(identity)).toBeDefined());
+    for (const [commandId, controlId, payload] of [
+      [
+        'bad-filter',
+        'set-filters',
+        { filters: [{ columnId: 'name', operator: 'unknown' }] },
+      ],
+      [
+        'bad-sort',
+        'set-sorting',
+        { sorting: [{ columnId: 'name', direction: 'sideways' }] },
+      ],
+      [
+        'bad-visibility',
+        'set-column-visibility',
+        { columns: [{ columnId: 'name', visible: 'yes' }] },
+      ],
+    ] as const) {
+      await expect(
+        registry.execute({
+          version: 1,
+          commandId,
+          identity,
+          expectedRevision: 0,
+          controlId,
+          payload,
+        }),
+      ).resolves.toMatchObject({ ok: false, reason: 'denied' });
+    }
+  });
+
   it('waits for a controlled DataTable host to settle candidate state before acknowledgement', async () => {
     const registry = createDataSurfaceRegistry();
     const identity: DataSurfaceIdentity = {

--- a/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/mounted-data-surface.test.ts
@@ -331,4 +331,47 @@ describe('mounted data surfaces', () => {
     expect(firstController.getState().search).toBe('');
     expect(nextController.getState().search).toBe('Grace');
   });
+
+  it('revisions externally changed uncontrolled toolbar state', async () => {
+    const registry = createDataSurfaceRegistry();
+    const identity: DataSurfaceIdentity = {
+      surfaceId: 'externally-controlled-toolbar',
+      kind: 'custom',
+    };
+    const dataSurface = {
+      registry,
+      descriptor: descriptor(identity, ['set-search', 'set-view']),
+    };
+    const { rerender } = render(CollectionToolbar, {
+      props: {
+        search: 'Ada',
+        view: 'list',
+        dataSurface,
+      },
+    });
+
+    await vi.waitFor(() => expect(registry.inspect(identity)).toBeDefined());
+    await rerender({
+      search: 'Grace',
+      view: 'grid',
+      dataSurface,
+    });
+    await vi.waitFor(() =>
+      expect(registry.inspect(identity)).toMatchObject({
+        revision: 1,
+        state: { search: 'Grace', view: 'grid' },
+      }),
+    );
+
+    await expect(
+      registry.execute({
+        version: 1,
+        commandId: 'stale-toolbar-command',
+        identity,
+        expectedRevision: 0,
+        controlId: 'set-view',
+        payload: { view: 'list' },
+      }),
+    ).resolves.toMatchObject({ ok: false, reason: 'stale_revision' });
+  });
 });

--- a/packages/smrt-ui/src/components/data/data-table-surface.ts
+++ b/packages/smrt-ui/src/components/data/data-table-surface.ts
@@ -4,6 +4,8 @@ import type {
   DataTableColumnVisibility,
   DataTableCommand,
   DataTableFilter,
+  DataTableFilterOperator,
+  DataTableRowId,
   DataTableSortRule,
 } from './DataTableController.js';
 import type {
@@ -43,6 +45,121 @@ function arrayValue(
   return Array.isArray(value) ? value : undefined;
 }
 
+const FILTER_OPERATORS = [
+  'equals',
+  'notEquals',
+  'contains',
+  'notContains',
+  'startsWith',
+  'endsWith',
+  'in',
+  'notIn',
+  'gt',
+  'gte',
+  'lt',
+  'lte',
+  'isNull',
+  'isNotNull',
+] as const satisfies readonly DataTableFilterOperator[];
+
+function filterOperator(
+  value: DataSurfaceJsonValue | undefined,
+): DataTableFilterOperator | undefined {
+  return typeof value === 'string'
+    ? FILTER_OPERATORS.find((operator) => operator === value)
+    : undefined;
+}
+
+function dataTableFilter(
+  value: DataSurfaceJsonValue,
+): DataTableFilter | undefined {
+  if (!value || Array.isArray(value) || typeof value !== 'object')
+    return undefined;
+  const entry = value as Record<string, DataSurfaceJsonValue>;
+  const columnId = stringValue(entry.columnId);
+  const operator = filterOperator(entry.operator);
+  if (!columnId || !operator) return undefined;
+  const needsValue = operator !== 'isNull' && operator !== 'isNotNull';
+  if (needsValue && !Object.hasOwn(entry, 'value')) return undefined;
+  return needsValue
+    ? { columnId, operator, value: entry.value }
+    : { columnId, operator };
+}
+
+function dataTableFilters(
+  value: DataSurfaceJsonValue | undefined,
+): DataTableFilter[] | undefined {
+  const values = arrayValue(value);
+  if (!values) return undefined;
+  const filters = values.map(dataTableFilter);
+  return filters.every(
+    (filter): filter is DataTableFilter => filter !== undefined,
+  )
+    ? filters
+    : undefined;
+}
+
+function dataTableSort(
+  value: DataSurfaceJsonValue,
+): DataTableSortRule | undefined {
+  if (!value || Array.isArray(value) || typeof value !== 'object')
+    return undefined;
+  const entry = value as Record<string, DataSurfaceJsonValue>;
+  const columnId = stringValue(entry.columnId);
+  const direction = stringValue(entry.direction);
+  return columnId && (direction === 'asc' || direction === 'desc')
+    ? { columnId, direction }
+    : undefined;
+}
+
+function dataTableSorting(
+  value: DataSurfaceJsonValue | undefined,
+): DataTableSortRule[] | undefined {
+  const values = arrayValue(value);
+  if (!values) return undefined;
+  const sorting = values.map(dataTableSort);
+  return sorting.every((sort): sort is DataTableSortRule => sort !== undefined)
+    ? sorting
+    : undefined;
+}
+
+function dataTableVisibility(
+  value: DataSurfaceJsonValue,
+): DataTableColumnVisibility | undefined {
+  if (!value || Array.isArray(value) || typeof value !== 'object')
+    return undefined;
+  const entry = value as Record<string, DataSurfaceJsonValue>;
+  const columnId = stringValue(entry.columnId);
+  return columnId && typeof entry.visible === 'boolean'
+    ? { columnId, visible: entry.visible }
+    : undefined;
+}
+
+function dataTableVisibilities(
+  value: DataSurfaceJsonValue | undefined,
+): DataTableColumnVisibility[] | undefined {
+  const values = arrayValue(value);
+  if (!values) return undefined;
+  const columns = values.map(dataTableVisibility);
+  return columns.every(
+    (column): column is DataTableColumnVisibility => column !== undefined,
+  )
+    ? columns
+    : undefined;
+}
+
+function dataTableRowIds(
+  value: DataSurfaceJsonValue | undefined,
+): DataTableRowId[] | undefined {
+  const values = arrayValue(value);
+  if (!values) return undefined;
+  return values.every(
+    (rowId) => typeof rowId === 'string' || typeof rowId === 'number',
+  )
+    ? values
+    : undefined;
+}
+
 /**
  * Returns `null` for a component-local control (focus, reveal, refresh, …) or
  * an invalid table command. The mounted component owns those local controls.
@@ -57,22 +174,12 @@ export function dataTableCommandFromDataSurfaceCommand(
       return search === undefined ? null : { type: 'setSearch', search };
     }
     case 'set-filters': {
-      const filters = arrayValue(payload?.filters);
-      return filters === undefined
-        ? null
-        : {
-            type: 'setFilters',
-            filters: filters as unknown as DataTableFilter[],
-          };
+      const filters = dataTableFilters(payload?.filters);
+      return filters === undefined ? null : { type: 'setFilters', filters };
     }
     case 'set-sorting': {
-      const sorting = arrayValue(payload?.sorting);
-      return sorting === undefined
-        ? null
-        : {
-            type: 'setSorting',
-            sorting: sorting as unknown as DataTableSortRule[],
-          };
+      const sorting = dataTableSorting(payload?.sorting);
+      return sorting === undefined ? null : { type: 'setSorting', sorting };
     }
     case 'toggle-sorting': {
       const columnId = stringValue(payload?.columnId);
@@ -90,32 +197,31 @@ export function dataTableCommandFromDataSurfaceCommand(
     }
     case 'set-page-size': {
       const pageSize = payload?.pageSize;
-      return pageSize === null || numberValue(pageSize) !== undefined
-        ? { type: 'setPageSize', pageSize: pageSize as number | null }
-        : null;
+      if (pageSize === null) return { type: 'setPageSize', pageSize: null };
+      const numericPageSize = numberValue(pageSize);
+      return numericPageSize === undefined
+        ? null
+        : { type: 'setPageSize', pageSize: numericPageSize };
     }
     case 'set-column-order': {
       const columnIds = arrayValue(payload?.columnIds);
-      return columnIds?.every((value) => typeof value === 'string')
-        ? { type: 'setColumnOrder', columnIds: columnIds as string[] }
-        : null;
+      if (!columnIds?.every((value) => typeof value === 'string')) return null;
+      const ids: string[] = [];
+      for (const value of columnIds) {
+        if (typeof value !== 'string' || value.length === 0) return null;
+        ids.push(value);
+      }
+      return { type: 'setColumnOrder', columnIds: ids };
     }
     case 'set-column-visibility': {
-      const columns = arrayValue(payload?.columns);
+      const columns = dataTableVisibilities(payload?.columns);
       return columns === undefined
         ? null
-        : {
-            type: 'setColumnVisibility',
-            columns: columns as unknown as DataTableColumnVisibility[],
-          };
+        : { type: 'setColumnVisibility', columns };
     }
     case 'set-selected-rows': {
-      const rowIds = arrayValue(payload?.rowIds);
-      return rowIds?.every(
-        (value) => typeof value === 'string' || typeof value === 'number',
-      )
-        ? { type: 'setSelectedRows', rowIds: rowIds as Array<string | number> }
-        : null;
+      const rowIds = dataTableRowIds(payload?.rowIds);
+      return rowIds === undefined ? null : { type: 'setSelectedRows', rowIds };
     }
     case 'toggle-row-selection': {
       const rowId = payload?.rowId;
@@ -124,12 +230,8 @@ export function dataTableCommandFromDataSurfaceCommand(
         : null;
     }
     case 'set-expanded-rows': {
-      const rowIds = arrayValue(payload?.rowIds);
-      return rowIds?.every(
-        (value) => typeof value === 'string' || typeof value === 'number',
-      )
-        ? { type: 'setExpandedRows', rowIds: rowIds as Array<string | number> }
-        : null;
+      const rowIds = dataTableRowIds(payload?.rowIds);
+      return rowIds === undefined ? null : { type: 'setExpandedRows', rowIds };
     }
     case 'toggle-row-expansion': {
       const rowId = payload?.rowId;

--- a/packages/smrt-ui/src/components/data/data-table-surface.ts
+++ b/packages/smrt-ui/src/components/data/data-table-surface.ts
@@ -1,0 +1,145 @@
+/** Maps declared DataSurface controls onto the existing DataTable command model. */
+
+import type {
+  DataTableColumnVisibility,
+  DataTableCommand,
+  DataTableFilter,
+  DataTableSortRule,
+} from './DataTableController.js';
+import type {
+  DataSurfaceJsonValue,
+  DataSurfaceVisibleCommand,
+} from './data-surface.js';
+
+function payloadObject(
+  value: DataSurfaceJsonValue | undefined,
+): Record<string, DataSurfaceJsonValue> | undefined {
+  if (!value || Array.isArray(value) || typeof value !== 'object')
+    return undefined;
+  return value;
+}
+
+function stringValue(
+  value: DataSurfaceJsonValue | undefined,
+): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function booleanValue(
+  value: DataSurfaceJsonValue | undefined,
+): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function numberValue(
+  value: DataSurfaceJsonValue | undefined,
+): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+function arrayValue(
+  value: DataSurfaceJsonValue | undefined,
+): DataSurfaceJsonValue[] | undefined {
+  return Array.isArray(value) ? value : undefined;
+}
+
+/**
+ * Returns `null` for a component-local control (focus, reveal, refresh, …) or
+ * an invalid table command. The mounted component owns those local controls.
+ */
+export function dataTableCommandFromDataSurfaceCommand(
+  command: DataSurfaceVisibleCommand,
+): DataTableCommand | null {
+  const payload = payloadObject(command.payload);
+  switch (command.controlId) {
+    case 'set-search': {
+      const search = stringValue(payload?.search);
+      return search === undefined ? null : { type: 'setSearch', search };
+    }
+    case 'set-filters': {
+      const filters = arrayValue(payload?.filters);
+      return filters === undefined
+        ? null
+        : {
+            type: 'setFilters',
+            filters: filters as unknown as DataTableFilter[],
+          };
+    }
+    case 'set-sorting': {
+      const sorting = arrayValue(payload?.sorting);
+      return sorting === undefined
+        ? null
+        : {
+            type: 'setSorting',
+            sorting: sorting as unknown as DataTableSortRule[],
+          };
+    }
+    case 'toggle-sorting': {
+      const columnId = stringValue(payload?.columnId);
+      if (!columnId) return null;
+      const multi = booleanValue(payload?.multi);
+      return {
+        type: 'toggleSorting',
+        columnId,
+        ...(multi === undefined ? {} : { multi }),
+      };
+    }
+    case 'set-page': {
+      const page = numberValue(payload?.page);
+      return page === undefined ? null : { type: 'setPage', page };
+    }
+    case 'set-page-size': {
+      const pageSize = payload?.pageSize;
+      return pageSize === null || numberValue(pageSize) !== undefined
+        ? { type: 'setPageSize', pageSize: pageSize as number | null }
+        : null;
+    }
+    case 'set-column-order': {
+      const columnIds = arrayValue(payload?.columnIds);
+      return columnIds?.every((value) => typeof value === 'string')
+        ? { type: 'setColumnOrder', columnIds: columnIds as string[] }
+        : null;
+    }
+    case 'set-column-visibility': {
+      const columns = arrayValue(payload?.columns);
+      return columns === undefined
+        ? null
+        : {
+            type: 'setColumnVisibility',
+            columns: columns as unknown as DataTableColumnVisibility[],
+          };
+    }
+    case 'set-selected-rows': {
+      const rowIds = arrayValue(payload?.rowIds);
+      return rowIds?.every(
+        (value) => typeof value === 'string' || typeof value === 'number',
+      )
+        ? { type: 'setSelectedRows', rowIds: rowIds as Array<string | number> }
+        : null;
+    }
+    case 'toggle-row-selection': {
+      const rowId = payload?.rowId;
+      return typeof rowId === 'string' || typeof rowId === 'number'
+        ? { type: 'toggleRowSelection', rowId }
+        : null;
+    }
+    case 'set-expanded-rows': {
+      const rowIds = arrayValue(payload?.rowIds);
+      return rowIds?.every(
+        (value) => typeof value === 'string' || typeof value === 'number',
+      )
+        ? { type: 'setExpandedRows', rowIds: rowIds as Array<string | number> }
+        : null;
+    }
+    case 'toggle-row-expansion': {
+      const rowId = payload?.rowId;
+      return typeof rowId === 'string' || typeof rowId === 'number'
+        ? { type: 'toggleRowExpansion', rowId }
+        : null;
+    }
+    case 'reset':
+      return { type: 'reset' };
+    default:
+      return null;
+  }
+}

--- a/packages/smrt-ui/src/components/data/index.ts
+++ b/packages/smrt-ui/src/components/data/index.ts
@@ -13,4 +13,5 @@ export * from './DataTableIdentity.js';
 export * from './DataTablePerformance.js';
 export * from './DataTableVirtualization.js';
 export * from './data-surface.js';
+export * from './data-table-surface.js';
 export * from './types.js';

--- a/packages/smrt-ui/src/components/data/types.ts
+++ b/packages/smrt-ui/src/components/data/types.ts
@@ -11,12 +11,12 @@ import type {
   DataTableViewState,
   DataTableViewStateInput,
 } from './DataTableController.js';
+import type { DataTableRowKey } from './DataTableIdentity.js';
+import type { DataTableVirtualizationOptions } from './DataTableVirtualization.js';
 import type {
   DataSurfaceDescriptor,
   DataSurfaceRegistry,
 } from './data-surface.js';
-import type { DataTableRowKey } from './DataTableIdentity.js';
-import type { DataTableVirtualizationOptions } from './DataTableVirtualization.js';
 
 /** Opt-in mounted-surface wiring for a DataTable instance. */
 export interface DataTableDataSurfaceOptions {

--- a/packages/smrt-ui/src/components/data/types.ts
+++ b/packages/smrt-ui/src/components/data/types.ts
@@ -11,8 +11,37 @@ import type {
   DataTableViewState,
   DataTableViewStateInput,
 } from './DataTableController.js';
+import type {
+  DataSurfaceDescriptor,
+  DataSurfaceRegistry,
+} from './data-surface.js';
 import type { DataTableRowKey } from './DataTableIdentity.js';
 import type { DataTableVirtualizationOptions } from './DataTableVirtualization.js';
+
+/** Opt-in mounted-surface wiring for a DataTable instance. */
+export interface DataTableDataSurfaceOptions {
+  registry: DataSurfaceRegistry;
+  /** Explicit stable identity and effective, policy-filtered capabilities. */
+  descriptor: DataSurfaceDescriptor;
+  /** Controlled tables must settle candidate state before acknowledgement. */
+  applyControlledState?: DataTableControlledStateApplier;
+  onRefresh?: () => void | Promise<void>;
+  onRetry?: () => void | Promise<void>;
+}
+
+export type DataTableControlledStateApplier = (
+  state: DataTableViewState,
+  command: DataTableCommand,
+) => DataTableViewState | undefined | Promise<DataTableViewState | undefined>;
+
+/** Opt-in registration for a standalone search/view toolbar. */
+export interface CollectionToolbarDataSurfaceOptions {
+  registry: DataSurfaceRegistry;
+  descriptor: DataSurfaceDescriptor;
+  applyControlledState?: DataTableControlledStateApplier;
+  onRefresh?: () => void | Promise<void>;
+  onRetry?: () => void | Promise<void>;
+}
 
 /** A group segment owned by a leaf column so restored order can stay valid. */
 export interface DataTableHeaderPathSegment {
@@ -218,6 +247,8 @@ export interface DataTableProps<T> {
   ) => void;
   /** Explicit ownership for local or caller-supplied filtering, sorting, and paging. */
   modes?: Partial<DataTableModes>;
+  /** Registers this mounted instance only when explicitly supplied. */
+  dataSurface?: DataTableDataSurfaceOptions;
   /**
    * The initial loading state. When rows are already present, loading keeps
    * them interactive and is announced as a refresh instead of replacing them.


### PR DESCRIPTION
## Summary

- Register mounted DataTable and toolbar controls as safe DataSurface descriptors.
- Keep selection scopes, query fingerprints, columns, and external visibility transitions consistent.

## Validation

- smrt-ui full suite (65 files, 656 tests)
- smrt-ui focused mounted/DataTable/conformance/controller tests (71 tests)
- smrt-ui typecheck and Svelte accessibility check
- smrt-ui build and packed-export verification
- Biome/diff/conflict checks
- strict SMRT knowledge freshness
- pre-push policy checks
- review-cycle: preliminary and final reviews clean on rebased head

Closes #2443

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-2443-mounted-data-surfaces-reviewfix-20260823",
  "issue": 2443,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "smrt-ui full suite (65 files, 656 tests)",
    "smrt-ui focused mounted/DataTable/conformance/controller tests (71 tests)",
    "smrt-ui typecheck and Svelte accessibility check",
    "smrt-ui build and packed-export verification",
    "Biome/diff/conflict checks",
    "strict SMRT knowledge freshness",
    "pre-push policy checks",
    "review-cycle: preliminary and final reviews clean on rebased head"
  ]
}