### PR TITLE
feat(reports): add materialized report adapter

### DIFF
--- a/packages/reports/AGENTS.md
+++ b/packages/reports/AGENTS.md
@@ -13,6 +13,35 @@ Materialized aggregate report models for SMRT.
 | refresh | Rebuild and incremental refresh engine with run tracking, watermarks, locks, and tenant scoping |
 | state | Internal `_smrt_report_*` system models for runs, watermarks, locks, schedules, and refresh tasks |
 | scheduler | Cron schedule runner, durable refresh job enqueueing, and `onChange` interceptor registration |
+| adapter | Transport-neutral report descriptor, canonical materialized-row reads, and stable `id` row identity |
+
+## Adapter contract
+
+- `buildReportAdapterDescriptor()` returns deterministic, serializable metadata
+  for a report surface: a stable resource id, typed persisted report columns,
+  the canonical `DataQuerySchema`, and UI-neutral DataTable hints. It must not
+  import `smrt-ui` or expose a report-domain class to the consumer.
+- `queryReportMaterializedRows()` owns only the bounded read slice for rows that
+  are already materialized. It supports projection, offset/limit paging, and
+  deterministic `id` ordering. Filters, `WHERE`/`HAVING` translation, facets,
+  and dimension/measure ordering are reserved for later adapter slices.
+- `id` is the only row identity. It must be a non-empty persisted string and is
+  never replaced by a display index or page position.
+- The descriptor is an exposure boundary. Sensitive/secret fields, fields with
+  `readPermission`, and transient, system, or non-column fields fail closed and
+  do not become public columns when no principal is available.
+- `tenantScoped`/`tenantField` reflect actual registered tenant metadata. A
+  `tenantScope` option only contributes to the stable resource id; it is not
+  authorization. The default query path resolves the registered collection via
+  `ObjectRegistry`, so normal collection tenancy interceptors apply. An injected
+  collection is application-owned and must preserve the same boundary.
+- `refresh` is a declaration, not execution. It describes configured mode,
+  triggers, positive-TTL stale-read behavior, and a permissioned/audited action
+  with preview/apply phases. The adapter does not authorize, audit, mutate, or
+  track refresh runs; issue #2460 owns that lifecycle. Generic collection reads
+  remain read-only with unknown freshness. Only a registered
+  `SmrtReportCollection` may synchronously refresh stale reads, when its TTL is
+  positive and the report is not manual.
 
 ## Conventions
 

--- a/packages/reports/README.md
+++ b/packages/reports/README.md
@@ -101,6 +101,64 @@ helpers:
 @happyvertical/smrt-reports/aggregate
 ```
 
+## Report adapter
+
+The package also exports a transport-neutral adapter for report surfaces:
+
+```ts
+import {
+  buildReportAdapterDescriptor,
+  queryReportMaterializedRows,
+  reportMaterializedRowKey,
+} from '@happyvertical/smrt-reports';
+
+const descriptor = await buildReportAdapterDescriptor(MonthlyRevenue, {
+  tenantScope: 'current',
+});
+const result = await queryReportMaterializedRows(MonthlyRevenue, {
+  version: 1,
+  requestId: 'monthly-revenue-first-page',
+  mode: 'rows',
+  projection: ['id', 'customer_id', 'revenue'],
+  page: { kind: 'offset', offset: 0, limit: 25 },
+  sort: [{ field: 'id', direction: 'asc' }],
+});
+const rowKey = reportMaterializedRowKey(result.rows[0]);
+```
+
+`ReportAdapterDescriptor` is deterministic JSON with a stable resource id,
+`id` as the identity field, typed report columns, a canonical `DataQuerySchema`,
+and structural DataTable hints. The hints are deliberately not a `smrt-ui`
+dependency. Consumers may map the descriptor to their own presentation layer.
+The adapter exposes only persisted report columns and the primary key: transient,
+system, and non-column fields are not surfaced. Sensitive/secret fields and
+fields with a `readPermission` are excluded without a principal, so the
+descriptor fails closed.
+
+`queryReportMaterializedRows()` is the bounded read slice for already-materialized
+rows. It supports projection, offset/limit paging (default limit 50), and
+deterministic ordering by the stable `id` identity. Dimension/measure filters,
+`WHERE`/`HAVING` mapping, facets, and caller-selected dimension/measure ordering
+are intentionally not part of this adapter contract. Every returned row must
+have a non-empty string `id`; use that value, never a display or page index, for
+row identity.
+
+When no collection is injected, reads resolve the registered report collection
+through `ObjectRegistry`, allowing normal SMRT collection interceptors to enforce
+tenant filtering. `tenantScoped` and `tenantField` in the descriptor are true
+only when the report is actually registered with tenant metadata; a scope string
+alone is not an authority boundary. An injected collection is application-owned
+and must provide the equivalent tenant boundary. Raw aggregate refreshes still
+need explicit tenant predicates as described above.
+
+The descriptor's `refresh` section declares mode, triggers, stale-read behavior,
+and a permissioned, audited `refresh` action with `preview` and `apply` phases.
+It does not perform a refresh, authorize a caller, write audit records, or track
+run state. Those lifecycle responsibilities belong to the follow-up refresh
+adapter in issue #2460. Generic collection reads remain read-only and report
+unknown freshness; only a registered `SmrtReportCollection` can synchronously
+refresh a stale read, and only when its TTL policy is positive and not manual.
+
 ## Development
 
 ```bash

--- a/packages/reports/README.md
+++ b/packages/reports/README.md
@@ -144,7 +144,7 @@ have a non-empty string `id`; use that value, never a display or page index, for
 row identity.
 
 When no collection is injected, reads resolve the registered report collection
-through `ObjectRegistry`, allowing normal SMRT collection interceptors to enforce
+through `ObjectRegistry`, allowing normal s-m-r-t collection interceptors to enforce
 tenant filtering. `tenantScoped` and `tenantField` in the descriptor are true
 only when the report is actually registered with tenant metadata; a scope string
 alone is not an authority boundary. An injected collection is application-owned

--- a/packages/reports/README.md
+++ b/packages/reports/README.md
@@ -115,14 +115,19 @@ import {
 const descriptor = await buildReportAdapterDescriptor(MonthlyRevenue, {
   tenantScope: 'current',
 });
-const result = await queryReportMaterializedRows(MonthlyRevenue, {
-  version: 1,
-  requestId: 'monthly-revenue-first-page',
-  mode: 'rows',
-  projection: ['id', 'customer_id', 'revenue'],
-  page: { kind: 'offset', offset: 0, limit: 25 },
-  sort: [{ field: 'id', direction: 'asc' }],
-});
+const reports = await MonthlyRevenueCollection.create({ db: 'app.db' });
+const result = await queryReportMaterializedRows(
+  MonthlyRevenue,
+  {
+    version: 1,
+    requestId: 'monthly-revenue-first-page',
+    mode: 'rows',
+    projection: ['id', 'customer_id', 'revenue'],
+    page: { kind: 'offset', offset: 0, limit: 25 },
+    sort: [{ field: 'id', direction: 'asc' }],
+  },
+  { collection: reports },
+);
 const rowKey = reportMaterializedRowKey(result.rows[0]);
 ```
 

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@happyvertical/smrt-core": "workspace:*",
     "@happyvertical/smrt-jobs": "workspace:*",
+    "@happyvertical/smrt-types": "workspace:*",
     "@happyvertical/smrt-tenancy": "workspace:*",
     "@happyvertical/sql": "catalog:"
   },

--- a/packages/reports/src/__tests__/adapter.test.ts
+++ b/packages/reports/src/__tests__/adapter.test.ts
@@ -430,6 +430,35 @@ describe('report adapter', () => {
     expect(result.freshness).toEqual({ state: 'unknown' });
   });
 
+  it('rejects bigint values that cannot be represented safely in JSON', async () => {
+    const collection = {
+      async list() {
+        return [
+          {
+            id: 'row-bigint',
+            revenue: 9_007_199_254_740_993n,
+          },
+        ];
+      },
+      async count() {
+        return 1;
+      },
+    };
+
+    await expect(
+      queryReportMaterializedRows(
+        AdapterReport,
+        {
+          version: 1,
+          requestId: 'request-bigint-precision',
+          mode: 'rows',
+          projection: ['revenue'],
+        },
+        { collection },
+      ),
+    ).rejects.toThrow(/safely representable/);
+  });
+
   it('honors the bounded identity sort declared in its canonical schema', async () => {
     let listOptions: Record<string, unknown> | undefined;
     const collection = {

--- a/packages/reports/src/__tests__/adapter.test.ts
+++ b/packages/reports/src/__tests__/adapter.test.ts
@@ -1,0 +1,618 @@
+import {
+  getTestDatabase,
+  ObjectRegistry,
+  SmrtObject,
+} from '@happyvertical/smrt-core';
+import {
+  disableTenancy,
+  enableTenancy,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildReportAdapterDescriptor,
+  queryReportMaterializedRows,
+  reportMaterializedRowKey,
+} from '../adapter.js';
+import { reportRowIdentity } from '../refresh.js';
+
+class AdapterInvoice extends SmrtObject {}
+class AdapterReport extends SmrtObject {}
+class ManualRefreshReport extends SmrtObject {}
+class UnscopedTenantMarkedReport extends SmrtObject {}
+
+function registerFixture() {
+  ObjectRegistry.registerFromManifest(
+    'AdapterInvoice',
+    {
+      className: 'AdapterInvoice',
+      fields: { tenantId: { type: 'text' } },
+      methods: {},
+      decoratorConfig: { tableName: 'adapter_invoices' },
+      schema: {
+        tableName: 'adapter_invoices',
+        ddl: '',
+        columns: {},
+        indexes: [],
+        version: 'test',
+      },
+    },
+    '@test/reports',
+  );
+  ObjectRegistry.registerFromManifest(
+    'AdapterReport',
+    {
+      className: 'AdapterReport',
+      fields: {
+        tenantId: {
+          type: 'text',
+          _meta: { __tenancy: { isTenantIdField: true } },
+        },
+        customerId: {
+          type: 'text',
+          description: 'Customer',
+          _meta: {
+            __report: { kind: 'group', sourceColumn: 'customerId' },
+            format: 'text',
+            sensitivity: 'personal',
+            capabilities: ['read', 'project', 'filter', 'sort', 'group'],
+          },
+        },
+        issuedMonth: {
+          type: 'datetime',
+          _meta: {
+            __report: {
+              kind: 'bucket',
+              unit: 'month',
+              sourceColumn: 'issuedAt',
+            },
+          },
+        },
+        revenue: {
+          type: 'decimal',
+          _meta: {
+            __report: { kind: 'aggregate', fn: 'sum', column: 'totalAmount' },
+          },
+        },
+        secretTotal: {
+          type: 'decimal',
+          _meta: {
+            sensitive: true,
+            __report: { kind: 'aggregate', fn: 'sum', column: 'secretTotal' },
+          },
+        },
+        restrictedTotal: {
+          type: 'decimal',
+          _meta: {
+            readPermission: 'reports:read-restricted',
+            __report: {
+              kind: 'aggregate',
+              fn: 'sum',
+              column: 'restrictedTotal',
+            },
+          },
+        },
+        transientTotal: {
+          type: 'decimal',
+          transient: true,
+          _meta: {
+            transient: true,
+            __report: {
+              kind: 'aggregate',
+              fn: 'sum',
+              column: 'transientTotal',
+            },
+          },
+        },
+        relatedTotal: {
+          type: 'oneToMany',
+          _meta: {
+            __report: { kind: 'aggregate', fn: 'sum', column: 'relatedTotal' },
+          },
+        },
+        refreshedAt: { type: 'datetime' },
+      },
+      methods: {},
+      decoratorConfig: {
+        tableName: 'adapter_reports',
+        tenantScoped: { field: 'tenantId', mode: 'optional' },
+        report: {
+          source: 'AdapterInvoice',
+          refresh: {
+            mode: 'incremental',
+            ttl: 30_000,
+            onChange: ['AdapterInvoice'],
+          },
+        },
+      },
+      schema: {
+        tableName: 'adapter_reports',
+        ddl: '',
+        columns: {},
+        indexes: [],
+        version: 'test',
+      },
+    },
+    '@test/reports',
+  );
+}
+
+function registerRefreshAndTenancyDescriptorFixtures() {
+  ObjectRegistry.registerFromManifest(
+    'ManualRefreshReport',
+    {
+      className: 'ManualRefreshReport',
+      fields: {
+        revenue: {
+          type: 'decimal',
+          _meta: {
+            __report: { kind: 'aggregate', fn: 'sum', column: 'totalAmount' },
+          },
+        },
+      },
+      methods: {},
+      decoratorConfig: {
+        tableName: 'manual_refresh_reports',
+        report: {
+          source: 'AdapterInvoice',
+          refresh: {
+            manual: true,
+            mode: 'incremental',
+            ttl: 30_000,
+            schedule: '0 * * * *',
+            onChange: ['AdapterInvoice'],
+          },
+        },
+      },
+      schema: {
+        tableName: 'manual_refresh_reports',
+        ddl: '',
+        columns: {},
+        indexes: [],
+        version: 'test',
+      },
+    },
+    '@test/reports',
+  );
+  ObjectRegistry.registerFromManifest(
+    'UnscopedTenantMarkedReport',
+    {
+      className: 'UnscopedTenantMarkedReport',
+      fields: {
+        tenantId: {
+          type: 'text',
+          _meta: { __tenancy: { isTenantIdField: true } },
+        },
+        revenue: {
+          type: 'decimal',
+          _meta: {
+            __report: { kind: 'aggregate', fn: 'sum', column: 'totalAmount' },
+          },
+        },
+      },
+      methods: {},
+      decoratorConfig: {
+        tableName: 'unscoped_tenant_marked_reports',
+        report: { source: 'AdapterInvoice' },
+      },
+      schema: {
+        tableName: 'unscoped_tenant_marked_reports',
+        ddl: '',
+        columns: {},
+        indexes: [],
+        version: 'test',
+      },
+    },
+    '@test/reports',
+  );
+}
+
+function registerRuntimeTenantFixture() {
+  ObjectRegistry.registerFieldDecorator('AdapterInvoice', 'tenantId', {
+    type: 'text',
+    _meta: { __tenancy: { isTenantIdField: true } },
+  });
+  ObjectRegistry.register(AdapterInvoice, { tableName: 'adapter_invoices' });
+
+  ObjectRegistry.registerFieldDecorator('AdapterReport', 'tenantId', {
+    type: 'text',
+    _meta: { __tenancy: { isTenantIdField: true } },
+  });
+  ObjectRegistry.registerFieldDecorator('AdapterReport', 'customerId', {
+    type: 'text',
+    __report: { kind: 'group', sourceColumn: 'customerId' },
+  });
+  ObjectRegistry.registerFieldDecorator('AdapterReport', 'revenue', {
+    type: 'decimal',
+    __report: { kind: 'aggregate', fn: 'sum', column: 'totalAmount' },
+  });
+  ObjectRegistry.register(AdapterReport, {
+    tableName: 'adapter_reports',
+    tenantScoped: { field: 'tenantId', mode: 'optional' },
+    report: { source: 'AdapterInvoice' },
+  });
+}
+
+describe('report adapter', () => {
+  beforeEach(() => {
+    ObjectRegistry.clear();
+    registerFixture();
+    registerRefreshAndTenancyDescriptorFixtures();
+  });
+
+  afterEach(() => ObjectRegistry.clear());
+
+  it('builds deterministic schema and report column descriptors', async () => {
+    const first = await buildReportAdapterDescriptor(AdapterReport);
+    const second = await buildReportAdapterDescriptor(AdapterReport);
+
+    expect(
+      JSON.stringify({
+        columns: first.columns,
+        schema: first.schema,
+        dataTable: first.dataTable,
+        refresh: first.refresh,
+      }),
+    ).toBe(
+      JSON.stringify({
+        columns: second.columns,
+        schema: second.schema,
+        dataTable: second.dataTable,
+        refresh: second.refresh,
+      }),
+    );
+    expect(first.identityField).toBe('id');
+    expect(first.schema.identityField).toBe('id');
+    expect(first.schema.fields[0].id).toBe('customer_id');
+    expect(first.columns.map((column) => column.id)).toEqual([
+      'customer_id',
+      'id',
+      'issued_month',
+      'revenue',
+    ]);
+    expect(
+      first.columns.find((column) => column.id === 'customer_id'),
+    ).toMatchObject({
+      kind: 'group',
+      type: 'string',
+      format: 'text',
+      sensitivity: 'personal',
+    });
+    expect(first.tenantScoped).toBe(true);
+    expect(first.tenantField).toBe('tenant_id');
+    expect(first.refresh).toMatchObject({
+      mode: 'incremental',
+      mayRefreshOnRead: true,
+      ttlMs: 30_000,
+      action: {
+        id: 'refresh',
+        scope: 'surface',
+        phases: ['preview', 'apply'],
+        requiresPermission: true,
+        requiredPermission: 'reports.refresh',
+        auditRequired: true,
+      },
+    });
+    expect(first.columns.some((column) => column.id === 'secret_total')).toBe(
+      false,
+    );
+    expect(
+      first.columns.some((column) => column.id === 'restricted_total'),
+    ).toBe(false);
+    expect(
+      first.columns.some((column) => column.id === 'transient_total'),
+    ).toBe(false);
+    expect(first.columns.some((column) => column.id === 'related_total')).toBe(
+      false,
+    );
+    expect(first.refresh.triggers).toEqual(['manual', 'change', 'ttl', 'job']);
+    expect(first.dataTable).toMatchObject({
+      rowKey: 'id',
+      manualPagination: true,
+      manualSorting: true,
+      enableFiltering: false,
+      enableSearch: false,
+    });
+    expect(
+      first.dataTable.columns.every(
+        (column) => column.searchable === false && column.filterable === false,
+      ),
+    ).toBe(true);
+    expect(
+      first.schema.fields.every((field) => field.filterOperators === undefined),
+    ).toBe(true);
+    expect(
+      first.schema.fields.filter((field) => field.id === 'id')[0]?.sortable,
+    ).toBe(true);
+    expect(
+      first.schema.fields
+        .filter((field) => field.id !== 'id')
+        .every(
+          (field) => field.sortable === false && field.facetable === false,
+        ),
+    ).toBe(true);
+    expect(first.schema.supports?.facets).toBe(false);
+    expect(
+      first.columns
+        .filter((column) => column.kind !== 'identity')
+        .every(
+          (column) =>
+            column.sortable === false &&
+            column.facetable === false &&
+            column.capabilities.join(',') === 'project,read',
+        ),
+    ).toBe(true);
+    expect(
+      first.columns.find((column) => column.id === 'id')?.capabilities,
+    ).toEqual(['project', 'read', 'sort']);
+    expect(() => JSON.stringify(first)).not.toThrow();
+  });
+
+  it('does not describe a tenant-like field as a tenant boundary without registration', async () => {
+    const descriptor = await buildReportAdapterDescriptor(
+      UnscopedTenantMarkedReport,
+    );
+
+    expect(descriptor.tenantScoped).toBe(false);
+    expect(descriptor.tenantField).toBeUndefined();
+  });
+
+  it('suppresses automatic refresh triggers for manual reports', async () => {
+    const descriptor = await buildReportAdapterDescriptor(ManualRefreshReport);
+
+    expect(descriptor.refresh).toMatchObject({ mayRefreshOnRead: false });
+    expect(descriptor.refresh.triggers).toEqual(['manual']);
+  });
+
+  it('requires a materialized identity and preserves reportRowIdentity', async () => {
+    const descriptor = await buildReportAdapterDescriptor(AdapterReport);
+    expect(reportMaterializedRowKey({ id: 'materialized-row' })).toBe(
+      'materialized-row',
+    );
+    expect(() => reportMaterializedRowKey({})).toThrow(
+      /require a non-empty string id/,
+    );
+
+    const definition = {
+      reportClassName: 'AdapterReport',
+      sourceClassName: 'AdapterInvoice',
+      sourceTable: 'adapter_invoices',
+      fields: [
+        {
+          fieldName: 'customerId',
+          columnName: 'customer_id',
+          report: { kind: 'group' as const, sourceColumn: 'customerId' },
+        },
+      ],
+    };
+    expect(reportRowIdentity({ customer_id: 'customer-1' }, definition)).toBe(
+      reportRowIdentity({ customer_id: 'customer-1' }, definition),
+    );
+    expect(descriptor.schema.identityField).toBe('id');
+  });
+
+  it('projects and pages materialized rows through the canonical result envelope', async () => {
+    let listOptions: Record<string, unknown> | undefined;
+    const collection = {
+      async list(options: Record<string, unknown>) {
+        listOptions = options;
+        return [{ id: 'row-2', customerId: 'customer-2' }];
+      },
+      async count() {
+        return 2;
+      },
+    };
+    const result = await queryReportMaterializedRows(
+      AdapterReport,
+      {
+        version: 1,
+        requestId: 'request-1',
+        mode: 'rows',
+        projection: ['customer_id'],
+        page: { kind: 'offset', offset: 1, limit: 1 },
+      },
+      { collection },
+    );
+    expect(listOptions).toMatchObject({
+      select: ['customerId', 'id'],
+      offset: 1,
+      limit: 1,
+      orderBy: 'id ASC',
+    });
+    expect(result.rows).toEqual([{ customer_id: 'customer-2', id: 'row-2' }]);
+    expect(result.page).toEqual({
+      kind: 'offset',
+      offset: 1,
+      limit: 1,
+      hasMore: false,
+    });
+    expect(result.total).toEqual({ kind: 'exact', value: 2 });
+    expect(result.freshness).toEqual({ state: 'unknown' });
+  });
+
+  it('honors the bounded identity sort declared in its canonical schema', async () => {
+    let listOptions: Record<string, unknown> | undefined;
+    const collection = {
+      async list(options: Record<string, unknown>) {
+        listOptions = options;
+        return [{ id: 'row-2' }];
+      },
+      async count() {
+        return 1;
+      },
+    };
+
+    await queryReportMaterializedRows(
+      AdapterReport,
+      {
+        version: 1,
+        requestId: 'request-descending-id',
+        mode: 'rows',
+        sort: [{ field: 'id', direction: 'desc' }],
+      },
+      { collection },
+    );
+
+    expect(listOptions).toMatchObject({ orderBy: 'id DESC' });
+  });
+
+  it('calculates totals after the read lifecycle has refreshed materialized rows', async () => {
+    const calls: string[] = [];
+    let refreshed = false;
+    const collection = {
+      async list() {
+        calls.push('list');
+        refreshed = true;
+        return [{ id: 'row-after-refresh' }];
+      },
+      async count() {
+        calls.push('count');
+        return refreshed ? 2 : 1;
+      },
+    };
+
+    const result = await queryReportMaterializedRows(
+      AdapterReport,
+      {
+        version: 1,
+        requestId: 'request-refresh-consistent-total',
+        mode: 'rows',
+        page: { kind: 'offset', offset: 0, limit: 1 },
+      },
+      { collection },
+    );
+
+    expect(calls).toEqual(['list', 'count']);
+    expect(result.total).toEqual({ kind: 'exact', value: 2 });
+    expect(result.page).toMatchObject({ hasMore: true });
+  });
+
+  it('runs the read lifecycle before a count-only materialized query', async () => {
+    const calls: string[] = [];
+    let refreshed = false;
+    const collection = {
+      async list() {
+        calls.push('list');
+        refreshed = true;
+        return [];
+      },
+      async count() {
+        calls.push('count');
+        return refreshed ? 2 : 1;
+      },
+    };
+
+    const result = await queryReportMaterializedRows(
+      AdapterReport,
+      {
+        version: 1,
+        requestId: 'request-count-refresh-consistent-total',
+        mode: 'count',
+      },
+      { collection },
+    );
+
+    expect(calls).toEqual(['list', 'count']);
+    expect(result.rows).toEqual([]);
+    expect(result.total).toEqual({ kind: 'exact', value: 2 });
+  });
+
+  it('rejects caller filters until report-specific semantics exist', async () => {
+    const collection = {
+      async list() {
+        return [];
+      },
+      async count() {
+        return 0;
+      },
+    };
+    await expect(
+      queryReportMaterializedRows(
+        AdapterReport,
+        {
+          version: 1,
+          requestId: 'request-2',
+          mode: 'rows',
+          filter: {
+            kind: 'condition',
+            field: 'customer_id',
+            operator: 'eq',
+            value: 'customer-1',
+          },
+        },
+        { collection },
+      ),
+    ).rejects.toThrow(/not allowed|do not support filter or sort/);
+  });
+
+  it('resolves the default collection through ObjectRegistry for tenant-bound reads', async () => {
+    const collection = {
+      async list() {
+        return [{ id: 'row-1', customerId: 'customer-1' }];
+      },
+      async count() {
+        return 1;
+      },
+    };
+    const resolve = vi
+      .spyOn(ObjectRegistry, 'getCollection')
+      .mockResolvedValue(collection as never);
+    try {
+      await queryReportMaterializedRows(AdapterReport, {
+        version: 1,
+        requestId: 'request-default-collection',
+        mode: 'count',
+      });
+      expect(resolve).toHaveBeenCalledWith(
+        expect.stringMatching(/AdapterReport$/),
+        { db: undefined },
+      );
+    } finally {
+      resolve.mockRestore();
+    }
+  });
+
+  it('reads only the active tenant through the default materialized collection', async () => {
+    ObjectRegistry.clear();
+    registerRuntimeTenantFixture();
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      classes: ['AdapterReport'],
+    });
+    try {
+      await db.insert('adapter_reports', {
+        id: 'tenant-a-row',
+        slug: 'tenant-a-row',
+        tenant_id: 'tenant-a',
+        customer_id: 'customer-a',
+        revenue: 10,
+      });
+      await db.insert('adapter_reports', {
+        id: 'tenant-b-row',
+        slug: 'tenant-b-row',
+        tenant_id: 'tenant-b',
+        customer_id: 'customer-b',
+        revenue: 90,
+      });
+      enableTenancy();
+
+      const result = await withTenant({ tenantId: 'tenant-a' }, () =>
+        queryReportMaterializedRows(
+          AdapterReport,
+          {
+            version: 1,
+            requestId: 'request-tenant-a',
+            mode: 'rows',
+          },
+          { db },
+        ),
+      );
+
+      expect(result.rows).toEqual([{ id: 'tenant-a-row' }]);
+      expect(result.total).toEqual({ kind: 'exact', value: 1 });
+    } finally {
+      disableTenancy();
+      if (typeof db.close === 'function') await db.close();
+    }
+  });
+});

--- a/packages/reports/src/adapter.ts
+++ b/packages/reports/src/adapter.ts
@@ -1,0 +1,551 @@
+import {
+  createDataQueryFingerprint,
+  normalizeDataQueryRequest,
+  normalizeDataQueryResult,
+  ObjectRegistry,
+  type SmrtObject,
+} from '@happyvertical/smrt-core';
+import { toSnakeCase } from '@happyvertical/smrt-core/utils';
+import type {
+  DataQueryFieldDescriptor,
+  DataQueryResult,
+  DataQuerySchema,
+} from '@happyvertical/smrt-types';
+import { buildReportDefinition } from './compiler.js';
+import type {
+  ReportAggregateFn,
+  ReportDefinition,
+  ReportFieldDefinition,
+  ReportRefreshConfig,
+  ReportTimeBucketUnit,
+} from './types.js';
+
+/** Presentation and policy metadata understood by the report adapter. */
+export type ReportColumnSensitivity =
+  | 'public'
+  | 'personal'
+  | 'sensitive'
+  | 'secret';
+
+export type ReportColumnCapability =
+  | 'read'
+  | 'project'
+  | 'filter'
+  | 'sort'
+  | 'facet'
+  | 'group'
+  | 'aggregate';
+
+export type ReportColumnKind = 'identity' | 'group' | 'bucket' | 'aggregate';
+
+export interface ReportColumnDescriptor extends DataQueryFieldDescriptor {
+  /** Stable output column id (never a property path). */
+  id: string;
+  fieldName: string;
+  label: string;
+  kind: ReportColumnKind;
+  /** Capabilities available from this adapter revision. */
+  capabilities: ReportColumnCapability[];
+  format?: string;
+  sensitivity?: ReportColumnSensitivity;
+  sourceColumn?: string;
+  bucket?: ReportTimeBucketUnit;
+  aggregate?: ReportAggregateFn;
+  distinct?: boolean;
+}
+
+export interface ReportRefreshDescriptor {
+  mode: 'rebuild' | 'incremental';
+  /**
+   * Whether the report configuration lets a registered SmrtReportCollection
+   * synchronously refresh a stale read. Generic collection reads stay
+   * read-only and report unknown freshness until the lifecycle adapter runs.
+   */
+  mayRefreshOnRead: boolean;
+  ttlMs?: number;
+  triggers: Array<'manual' | 'schedule' | 'change' | 'ttl' | 'job'>;
+  /** Declared only; the lifecycle adapter owns authorization, audit, and run state. */
+  action: ReportRefreshActionDescriptor;
+}
+
+/** A report-wide lifecycle action, never a mutation performed by this adapter. */
+export interface ReportRefreshActionDescriptor {
+  id: 'refresh';
+  label: 'Refresh report';
+  scope: 'surface';
+  phases: Array<'preview' | 'apply'>;
+  requiresPermission: true;
+  requiredPermission: string;
+  auditRequired: true;
+}
+
+/**
+ * The report-owned, transport-neutral descriptor. Consumers can map `schema`
+ * to the canonical data-query runtime and `columns` to their presentation
+ * contract without importing smrt-ui or a report domain class.
+ */
+export interface ReportAdapterDescriptor {
+  version: 1;
+  resourceId: string;
+  reportClassName: string;
+  sourceClassName: string;
+  tenantScoped: boolean;
+  tenantField?: string;
+  identityField: 'id';
+  columns: ReportColumnDescriptor[];
+  schema: DataQuerySchema;
+  dataTable: ReportDataTableDescriptor;
+  refresh: ReportRefreshDescriptor;
+}
+
+/** Structural DataTable view hints; deliberately not a smrt-ui dependency. */
+export interface ReportDataTableColumn {
+  id: string;
+  label: string;
+  accessor: string;
+  sortable: boolean;
+  searchable: false;
+  filterable: false;
+}
+
+export interface ReportDataTableDescriptor {
+  rowKey: 'id';
+  manualPagination: true;
+  manualSorting: true;
+  enableFiltering: false;
+  enableSearch: false;
+  columns: ReportDataTableColumn[];
+}
+
+export interface ReportAdapterOptions {
+  /** Scope used only to make a stable resource id; it is not authority. */
+  tenantScope?: 'current' | 'global' | 'tenant';
+  /** Permission that a lifecycle action host must require before refresh. */
+  refreshPermission?: string;
+}
+
+export interface ReportQueryOptions {
+  /** Injected collection seam for tests and application-owned adapters. */
+  collection?: {
+    list(
+      options: Record<string, unknown>,
+    ): Promise<Array<Record<string, unknown>>>;
+    count(options?: Record<string, unknown>): Promise<number>;
+  };
+  db?: import('@happyvertical/sql').DatabaseInterface;
+}
+
+type RegistryField = {
+  type?: string;
+  transient?: boolean;
+  description?: string;
+  sensitive?: boolean;
+  readPermission?: string;
+  format?: unknown;
+  sensitivity?: unknown;
+  _meta?: Record<string, unknown>;
+};
+const SENSITIVITIES = new Set<ReportColumnSensitivity>([
+  'public',
+  'personal',
+  'sensitive',
+  'secret',
+]);
+
+function registeredClass(
+  ctor: new (...args: any[]) => SmrtObject,
+): ReturnType<typeof ObjectRegistry.getClassByConstructor> {
+  return (
+    ObjectRegistry.getClassByConstructor(ctor) ??
+    ObjectRegistry.getClass(ctor.name)
+  );
+}
+
+function fieldPolicy(field: RegistryField | undefined): {
+  sensitive: boolean;
+  readPermission?: string;
+} {
+  const meta = field?._meta ?? {};
+  const sensitivity = [field?.sensitivity, meta.sensitivity].find(
+    (value): value is string => typeof value === 'string',
+  );
+  return {
+    sensitive:
+      field?.sensitive === true ||
+      meta.sensitive === true ||
+      sensitivity === 'sensitive' ||
+      sensitivity === 'secret',
+    readPermission:
+      typeof field?.readPermission === 'string'
+        ? field.readPermission
+        : typeof meta.readPermission === 'string'
+          ? meta.readPermission
+          : undefined,
+  };
+}
+
+function descriptorMetadata(field: RegistryField | undefined): {
+  format?: string;
+  sensitivity?: ReportColumnSensitivity;
+} {
+  const metadata = field?._meta ?? {};
+  const format = [field?.format, metadata.format].find(
+    (value): value is string => typeof value === 'string' && value.length > 0,
+  );
+  const rawSensitivity = [field?.sensitivity, metadata.sensitivity].find(
+    (value): value is string =>
+      typeof value === 'string' &&
+      SENSITIVITIES.has(value as ReportColumnSensitivity),
+  );
+  return {
+    ...(format ? { format } : {}),
+    ...(rawSensitivity
+      ? { sensitivity: rawSensitivity as ReportColumnSensitivity }
+      : {}),
+  };
+}
+
+function labelFor(fieldName: string): string {
+  return fieldName
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/^./, (value) => value.toUpperCase());
+}
+
+function queryType(type: string | undefined): DataQueryFieldDescriptor['type'] {
+  switch (type) {
+    case 'integer':
+    case 'decimal':
+      return 'number';
+    case 'boolean':
+      return 'boolean';
+    case 'datetime':
+      return 'datetime';
+    case 'json':
+      return 'json';
+    default:
+      return 'string';
+  }
+}
+
+function configuredTenantField(configured?: string): string | undefined {
+  return configured ? toSnakeCase(configured) : undefined;
+}
+
+function isColumnBackedField(field: RegistryField | undefined): boolean {
+  if (!field) return false;
+  if (field.transient === true || field._meta?.transient === true) return false;
+  return !['meta', 'oneToMany', 'manyToMany'].includes(field.type ?? '');
+}
+
+function reportColumn(
+  field: ReportFieldDefinition,
+  registryField: RegistryField | undefined,
+): ReportColumnDescriptor | undefined {
+  const policy = fieldPolicy(registryField);
+  // A descriptor is an exposure boundary. Without a principal/permission
+  // context, sensitive, permission-gated, and non-column fields fail closed.
+  if (
+    policy.sensitive ||
+    policy.readPermission ||
+    !isColumnBackedField(registryField)
+  ) {
+    return undefined;
+  }
+
+  const id = field.columnName ?? toSnakeCase(field.fieldName);
+  const report = field.report;
+  if (!report) return undefined;
+  const type = queryType(field.type ?? registryField?.type);
+  const base: ReportColumnDescriptor = {
+    id,
+    fieldName: field.fieldName,
+    label: registryField?.description || labelFor(field.fieldName),
+    kind: report.kind,
+    type,
+    projectable: true,
+    sortable: false,
+    facetable: false,
+    capabilities: ['project', 'read'],
+    ...(report.kind === 'group'
+      ? { sourceColumn: toSnakeCase(report.sourceColumn ?? field.fieldName) }
+      : {}),
+    ...(report.kind === 'bucket'
+      ? { bucket: report.unit, sourceColumn: toSnakeCase(report.sourceColumn) }
+      : {}),
+    ...(report.kind === 'aggregate'
+      ? {
+          aggregate: report.fn,
+          ...(report.column
+            ? { sourceColumn: toSnakeCase(report.column) }
+            : {}),
+          ...(report.distinct === undefined
+            ? {}
+            : { distinct: report.distinct }),
+        }
+      : {}),
+    ...descriptorMetadata(registryField),
+  };
+  return base;
+}
+
+function identityColumn(): ReportColumnDescriptor {
+  return {
+    id: 'id',
+    fieldName: 'id',
+    label: 'ID',
+    kind: 'identity',
+    type: 'string',
+    projectable: true,
+    sortable: true,
+    capabilities: ['project', 'read', 'sort'],
+  };
+}
+
+function toQueryField(
+  column: ReportColumnDescriptor,
+): DataQueryFieldDescriptor {
+  return {
+    id: column.id,
+    type: column.type,
+    ...(column.projectable === undefined
+      ? {}
+      : { projectable: column.projectable }),
+    sortable: column.id === 'id',
+    facetable: false,
+  };
+}
+
+function refreshDescriptor(
+  refresh?: ReportRefreshConfig,
+  refreshPermission = 'reports.refresh',
+): ReportRefreshDescriptor {
+  const config = refresh ?? {};
+  const triggers = new Set<ReportRefreshDescriptor['triggers'][number]>([
+    'manual',
+  ]);
+  if (!config.manual) {
+    const hasSchedule = Boolean(config.schedule || config.fullRebuildSchedule);
+    const hasChangeTrigger = Boolean(config.onChange?.length);
+    if (hasSchedule) triggers.add('schedule');
+    if (hasChangeTrigger) triggers.add('change');
+    if (config.ttl !== undefined && config.ttl > 0) triggers.add('ttl');
+    // Scheduler and on-change refreshes enqueue a durable job in either mode;
+    // incremental mode alone is not itself a trigger.
+    if (hasSchedule || hasChangeTrigger) triggers.add('job');
+  }
+  return {
+    mode: config.mode ?? 'rebuild',
+    mayRefreshOnRead:
+      config.ttl !== undefined && config.ttl > 0 && !config.manual,
+    ...(config.ttl === undefined ? {} : { ttlMs: config.ttl }),
+    triggers: [...triggers],
+    action: {
+      id: 'refresh',
+      label: 'Refresh report',
+      scope: 'surface',
+      phases: ['preview', 'apply'],
+      requiresPermission: true,
+      requiredPermission:
+        refreshPermission.trim().length > 0
+          ? refreshPermission
+          : 'reports.refresh',
+      auditRequired: true,
+    },
+  };
+}
+
+function resourceId(
+  definition: ReportDefinition,
+  scope: ReportAdapterOptions['tenantScope'],
+): string {
+  return `${definition.reportClassName}#${scope ?? 'current'}`;
+}
+
+export async function buildReportAdapterDescriptor(
+  reportCtor: new (...args: any[]) => SmrtObject,
+  options: ReportAdapterOptions = {},
+): Promise<ReportAdapterDescriptor> {
+  const definition = await buildReportDefinition(reportCtor);
+  const registered = registeredClass(reportCtor);
+  const fields = (await ObjectRegistry.getAllFields(
+    definition.reportClassName,
+  )) as Map<string, RegistryField>;
+  // A tenant-looking field is not an isolation boundary. Only registered
+  // tenant scoping installs the collection interceptor used by the executor.
+  const tenantField = configuredTenantField(
+    registered?.tenantScopedConfig?.field,
+  );
+  const columns = [
+    identityColumn(),
+    ...definition.fields
+      .map((field) => reportColumn(field, fields.get(field.fieldName)))
+      .filter((field): field is ReportColumnDescriptor => Boolean(field)),
+  ].sort((left, right) => left.id.localeCompare(right.id));
+  const schema: DataQuerySchema = {
+    version: 1,
+    identityField: 'id',
+    fields: columns.map(toQueryField),
+    defaultSort: [{ field: 'id', direction: 'asc' }],
+    supports: { cursorPagination: false, consistency: false, facets: false },
+  };
+  const dataTable: ReportDataTableDescriptor = {
+    rowKey: 'id',
+    manualPagination: true,
+    manualSorting: true,
+    enableFiltering: false,
+    enableSearch: false,
+    columns: columns.map((column) => ({
+      id: column.id,
+      label: column.label,
+      accessor: column.id,
+      sortable: column.id === 'id',
+      searchable: false,
+      filterable: false,
+    })),
+  };
+  return {
+    version: 1,
+    resourceId: resourceId(definition, options.tenantScope),
+    reportClassName: definition.reportClassName,
+    sourceClassName: definition.sourceClassName,
+    tenantScoped: Boolean(registered?.tenantScopedConfig),
+    ...(tenantField ? { tenantField } : {}),
+    identityField: 'id',
+    columns,
+    schema,
+    dataTable,
+    refresh: refreshDescriptor(definition.refresh, options.refreshPermission),
+  };
+}
+
+function publicFieldMap(
+  descriptor: ReportAdapterDescriptor,
+): Map<string, string> {
+  return new Map(
+    descriptor.columns.map((column) => [column.id, column.fieldName]),
+  );
+}
+
+function jsonSafeValue(value: unknown): unknown {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'bigint') return Number(value);
+  if (Array.isArray(value)) return value.map(jsonSafeValue);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, jsonSafeValue(entry)]),
+    );
+  }
+  return value;
+}
+
+function mapMaterializedRow(
+  row: Record<string, unknown>,
+  projection: readonly string[],
+  fieldMap: Map<string, string>,
+): Record<string, unknown> {
+  const mapped: Record<string, unknown> = {};
+  for (const id of projection) {
+    const sourceField = fieldMap.get(id) ?? id;
+    if (sourceField in row) mapped[id] = jsonSafeValue(row[sourceField]);
+  }
+  return mapped;
+}
+
+/**
+ * Execute the bounded materialized-read slice owned by #2457.
+ *
+ * Dimension/measure filters, HAVING/WHERE mapping, facets, and caller-selected
+ * dimension/measure ordering intentionally remain unsupported until their
+ * report-specific adapter slice lands. Identity ordering stays available for
+ * deterministic paging. The collection is the tenant boundary: callers may
+ * inject one, but the default path resolves it through ObjectRegistry so the
+ * normal SMRT tenancy interceptors apply.
+ */
+export async function queryReportMaterializedRows(
+  reportCtor: new (...args: any[]) => SmrtObject,
+  input: unknown,
+  options: ReportQueryOptions = {},
+): Promise<DataQueryResult> {
+  const descriptor = await buildReportAdapterDescriptor(reportCtor);
+  const request = normalizeDataQueryRequest(input, descriptor.schema);
+  if (request.mode === 'facets') {
+    throw new Error('Report materialized reads do not support facets yet');
+  }
+  const fieldMap = publicFieldMap(descriptor);
+  const collection: NonNullable<ReportQueryOptions['collection']> =
+    options.collection ??
+    ((await ObjectRegistry.getCollection(descriptor.reportClassName, {
+      db: options.db,
+    })) as unknown as NonNullable<ReportQueryOptions['collection']>);
+  let rows: Record<string, unknown>[] = [];
+  let page: DataQueryResult['page'];
+  let total: number;
+  if (request.mode === 'rows') {
+    const projection = request.projection ?? [descriptor.identityField];
+    const select = projection.map((id) => fieldMap.get(id) ?? id);
+    const offset = request.page?.kind === 'offset' ? request.page.offset : 0;
+    const limit = request.page?.limit ?? 50;
+    const orderBy = request.sort?.map(
+      ({ field, direction }) =>
+        `${fieldMap.get(field) ?? field} ${direction.toUpperCase()}`,
+    );
+    const materialized = await collection.list({
+      select,
+      offset,
+      limit,
+      orderBy: orderBy?.length === 1 ? orderBy[0] : orderBy,
+    });
+    rows = materialized.map((row) =>
+      mapMaterializedRow(row, projection, fieldMap),
+    );
+    rows.forEach((row) => {
+      if (typeof row.id !== 'string' || row.id.length === 0) {
+        throw new Error(
+          'Materialized report rows require a non-empty string id',
+        );
+      }
+    });
+    // SmrtReportCollection performs an eligible TTL refresh from list(). Count
+    // must follow that operation so total/hasMore describe the same snapshot.
+    total = await collection.count();
+    page = {
+      kind: 'offset',
+      offset,
+      limit,
+      hasMore: offset + rows.length < total,
+    };
+  } else {
+    // Count-only reads still enter SmrtReportCollection's list lifecycle to
+    // refresh an eligible stale report before calculating its exact total.
+    await collection.list({
+      select: ['id'],
+      offset: 0,
+      limit: 1,
+      orderBy: 'id ASC',
+    });
+    total = await collection.count();
+  }
+  const result = {
+    version: 1 as const,
+    requestId: request.requestId,
+    queryFingerprint: createDataQueryFingerprint(request, descriptor.schema),
+    identityField: descriptor.identityField,
+    rows,
+    ...(page ? { page } : {}),
+    total: { kind: 'exact' as const, value: total },
+    freshness: { state: 'unknown' as const },
+    warnings: [],
+    truncated: false,
+  };
+  return normalizeDataQueryResult(result, request, descriptor.schema);
+}
+
+/** Read the already-materialized primary key; never use a display/page index. */
+export function reportMaterializedRowKey(row: Record<string, unknown>): string {
+  const id = row.id;
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new Error('Materialized report rows require a non-empty string id');
+  }
+  return id;
+}

--- a/packages/reports/src/adapter.ts
+++ b/packages/reports/src/adapter.ts
@@ -429,7 +429,15 @@ function publicFieldMap(
 
 function jsonSafeValue(value: unknown): unknown {
   if (value instanceof Date) return value.toISOString();
-  if (typeof value === 'bigint') return Number(value);
+  if (typeof value === 'bigint') {
+    const numeric = Number(value);
+    if (!Number.isSafeInteger(numeric)) {
+      throw new RangeError(
+        'Materialized bigint values must be safely representable as numbers',
+      );
+    }
+    return numeric;
+  }
   if (Array.isArray(value)) return value.map(jsonSafeValue);
   if (value && typeof value === 'object') {
     return Object.fromEntries(

--- a/packages/reports/src/index.ts
+++ b/packages/reports/src/index.ts
@@ -1,3 +1,21 @@
+export type {
+  ReportAdapterDescriptor,
+  ReportAdapterOptions,
+  ReportColumnCapability,
+  ReportColumnDescriptor,
+  ReportColumnKind,
+  ReportColumnSensitivity,
+  ReportDataTableColumn,
+  ReportDataTableDescriptor,
+  ReportQueryOptions,
+  ReportRefreshActionDescriptor,
+  ReportRefreshDescriptor,
+} from './adapter.js';
+export {
+  buildReportAdapterDescriptor,
+  queryReportMaterializedRows,
+  reportMaterializedRowKey,
+} from './adapter.js';
 export {
   bucketExpr,
   buildAggregate,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1996,6 +1996,9 @@ importers:
       '@happyvertical/smrt-jobs':
         specifier: workspace:*
         version: link:../jobs
+      '@happyvertical/smrt-types':
+        specifier: workspace:*
+        version: link:../types
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy


### PR DESCRIPTION
## Summary
- Add a UI-neutral reports adapter that produces stable, serializable descriptor, DataTable, refresh-declaration, and bounded query-execution contracts.
- Enforce fail-closed projection and capability metadata, registered tenant scoping, deterministic persisted row identity, and refresh-aware totals.
- Document the public surface and its ownership boundaries.

## Boundaries
- Refresh remains a declared, permissioned and audited action only; lifecycle authorization, execution, and run state belong to #2460, which stays open.
- Filtering, facets, and dimensional sort support remain deliberately unavailable pending their prerequisite work.

## Validation
- pnpm test — 126 packages successful.
- pnpm typecheck — 125 packages successful.
- pnpm build — 64 packages successful.
- pnpm --filter @happyvertical/smrt-reports test — 5 files, 30 tests passed.
- Strict knowledge and all pre-push repository gates passed.
- Independent high-risk final exact-commit review: CLEAN.
- Follow-up bigint precision and injected-collection review feedback resolved with regression coverage.
- README validation passes with the required s-m-r-t prose.

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-2457-report-adapter-reviewfix-20260823",
  "issue": 2457,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm test",
    "pnpm typecheck",
    "pnpm build",
    "pnpm --filter @happyvertical/smrt-reports test",
    "pnpm check:readmes",
    "pre-push repository gates",
    "independent exact-commit review"
  ]
}

Closes #2457