### PR TITLE
feat(core): add scoped facets and counts

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -78,6 +78,11 @@ as `select`. Array/string-list fields are grouped by their stored value — SMRT
 does not split or unnest them — so consumers needing per-member options should
 use a scalar join table or consumer-specific query.
 
+Facet tests cover SQLite and DuckDB locally. Scalar PostgreSQL coverage is in
+the optional `test:postgres` lane and runs only when `SMRT_TEST_POSTGRES_URL` is
+configured; the local suite does not claim PostgreSQL parity for array/JSON
+encoding.
+
 **WHERE operators**: `=`, `>`, `<`, `>=`, `<=`, `!=`, `in`, `not in`, `like`.
 Arrays auto-detect `IN`. NULL is a value, not an operator: `{ deletedAt: null }`
 renders `IS NULL` and `{ 'deletedAt !=': null }` renders `IS NOT NULL`.

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -62,6 +62,18 @@ an `initialize()` hook may query through the same transaction-bound PostgreSQL
 client. Keep this serialization invariant; use `select` when callers need plain
 rows without model hydration.
 
+Database-backed facets and scoped counts are available through
+`collection.facets({ fields, where })` and
+`collection.counts({ where })`. Facets return `{ field, values }` entries whose
+values contain `{ value, count }`, run the same `beforeList`/tenant interceptors
+as list reads, and execute one `GROUP BY` query per requested field. They never
+hydrate model instances. `counts()` returns `{ total, filtered }` using two
+`COUNT(*)` queries; both counts retain the active read scope. Facet fields must
+be column-backed and obey the same sensitive/read-permission restrictions as
+`select`. Array/string-list fields are grouped by their stored value — SMRT does
+not split or unnest them — so consumers needing per-member options should use a
+scalar join table or consumer-specific query.
+
 **WHERE operators**: `=`, `>`, `<`, `>=`, `<=`, `!=`, `in`, `not in`, `like`.
 Arrays auto-detect `IN`. NULL is a value, not an operator: `{ deletedAt: null }`
 renders `IS NULL` and `{ 'deletedAt !=': null }` renders `IS NOT NULL`.

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -66,13 +66,17 @@ Database-backed facets and scoped counts are available through
 `collection.facets({ fields, where })` and
 `collection.counts({ where })`. Facets return `{ field, values }` entries whose
 values contain `{ value, count }`, run the same `beforeList`/tenant interceptors
-as list reads, and execute one `GROUP BY` query per requested field. They never
-hydrate model instances. `counts()` returns `{ total, filtered }` using two
-`COUNT(*)` queries; both counts retain the active read scope. Facet fields must
-be column-backed and obey the same sensitive/read-permission restrictions as
-`select`. Array/string-list fields are grouped by their stored value — SMRT does
-not split or unnest them — so consumers needing per-member options should use a
-scalar join table or consumer-specific query.
+as list reads, and execute one bounded `GROUP BY` query per requested field.
+Each call accepts at most 20 fields. A requested value limit is clamped to the
+hard maximum of 1,000 and to `maxListLimit` when configured. If omitted, the
+limit defaults to `defaultListLimit` or 50, then the same ceilings apply; facet
+queries are therefore never unbounded even when list bounds are unset. They
+never hydrate model instances. `counts()` returns `{ total, filtered }` using
+two `COUNT(*)` queries; both counts retain the active read scope. Facet fields
+must be column-backed and obey the same sensitive/read-permission restrictions
+as `select`. Array/string-list fields are grouped by their stored value — SMRT
+does not split or unnest them — so consumers needing per-member options should
+use a scalar join table or consumer-specific query.
 
 **WHERE operators**: `=`, `>`, `<`, `>=`, `<=`, `!=`, `in`, `not in`, `like`.
 Arrays auto-detect `IN`. NULL is a value, not an operator: `{ deletedAt: null }`

--- a/packages/core/src/__tests__/collection-facets-postgres.optional.test.ts
+++ b/packages/core/src/__tests__/collection-facets-postgres.optional.test.ts
@@ -1,0 +1,82 @@
+/**
+ * PostgreSQL scalar facet coverage for issue #1904.
+ *
+ * This file runs only in the disposable `test:postgres` lane. The regular
+ * in-memory facet suite covers SQLite and DuckDB; without
+ * SMRT_TEST_POSTGRES_URL this adapter-specific evidence is intentionally
+ * skipped rather than inferred from the other backends.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { getDatabase } from '@happyvertical/sql';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection.js';
+import { field, SmrtObject, smrt } from '../index.js';
+import { ObjectRegistry } from '../registry.js';
+
+const pgUrl = process.env.SMRT_TEST_POSTGRES_URL;
+const TABLE = 'issue_1904_postgres_facets';
+
+@smrt({ tableName: 'issue_1904_postgres_facets' })
+class Issue1904PostgresFacet extends SmrtObject {
+  @field({ type: 'text' })
+  status = '';
+}
+
+class Issue1904PostgresFacetCollection extends SmrtCollection<Issue1904PostgresFacet> {
+  static readonly _itemClass = Issue1904PostgresFacet;
+}
+
+describe.skipIf(!pgUrl)('PostgreSQL facets (#1904)', () => {
+  let db: DatabaseInterface;
+  let collection: Issue1904PostgresFacetCollection;
+
+  beforeAll(async () => {
+    db = (await getDatabase({
+      type: 'postgres',
+      url: pgUrl,
+      dbid: `smrt-test-1904-facets-${randomUUID()}`,
+    } as Parameters<typeof getDatabase>[0])) as DatabaseInterface;
+
+    await db.query(`DROP TABLE IF EXISTS "${TABLE}"`);
+    const registration = ObjectRegistry.getClassByConstructor(
+      Issue1904PostgresFacet,
+    );
+    const className =
+      registration?.qualifiedName ||
+      registration?.name ||
+      Issue1904PostgresFacet.name;
+    const ddl = ObjectRegistry.getSchemaDDL(className, 'postgres');
+    if (!ddl) throw new Error(`Missing schema DDL for ${className}`);
+    await db.query(ddl);
+  }, 60_000);
+
+  afterAll(async () => {
+    try {
+      await db?.query(`DROP TABLE IF EXISTS "${TABLE}"`);
+    } finally {
+      await db?.close?.();
+    }
+  });
+
+  beforeEach(async () => {
+    await db.query(`TRUNCATE TABLE "${TABLE}"`);
+    collection = await Issue1904PostgresFacetCollection.create({ db });
+  });
+
+  it('groups scalar values and applies a per-field limit', async () => {
+    await collection.create({ status: 'open' });
+    await collection.create({ status: 'closed' });
+    await collection.create({ status: 'open' });
+
+    await expect(
+      collection.facets({ fields: [{ field: 'status', limit: 1 }] }),
+    ).resolves.toEqual([
+      {
+        field: 'status',
+        values: [{ value: 'open', count: 2 }],
+      },
+    ]);
+  });
+});

--- a/packages/core/src/__tests__/collection-facets-postgres.optional.test.ts
+++ b/packages/core/src/__tests__/collection-facets-postgres.optional.test.ts
@@ -20,8 +20,8 @@ const TABLE = 'issue_1904_postgres_facets';
 
 @smrt({ tableName: 'issue_1904_postgres_facets' })
 class Issue1904PostgresFacet extends SmrtObject {
-  @field({ type: 'text' })
-  status = '';
+  @field({ type: 'text', nullable: true })
+  status: string | null = null;
 }
 
 class Issue1904PostgresFacetCollection extends SmrtCollection<Issue1904PostgresFacet> {
@@ -65,10 +65,22 @@ describe.skipIf(!pgUrl)('PostgreSQL facets (#1904)', () => {
     collection = await Issue1904PostgresFacetCollection.create({ db });
   });
 
-  it('groups scalar values and applies a per-field limit', async () => {
+  it('groups scalar values with portable null ordering', async () => {
     await collection.create({ status: 'open' });
     await collection.create({ status: 'closed' });
     await collection.create({ status: 'open' });
+    await collection.create({ status: null });
+
+    await expect(collection.facets({ fields: ['status'] })).resolves.toEqual([
+      {
+        field: 'status',
+        values: [
+          { value: 'open', count: 2 },
+          { value: 'closed', count: 1 },
+          { value: null, count: 1 },
+        ],
+      },
+    ]);
 
     await expect(
       collection.facets({ fields: [{ field: 'status', limit: 1 }] }),

--- a/packages/core/src/__tests__/collection-facets.test.ts
+++ b/packages/core/src/__tests__/collection-facets.test.ts
@@ -1,6 +1,12 @@
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { SmrtCollection, type SmrtFacetResult } from '../collection.js';
+import {
+  DEFAULT_FACET_LIMIT,
+  MAX_FACET_FIELDS,
+  MAX_FACET_LIMIT,
+  SmrtCollection,
+  type SmrtFacetResult,
+} from '../collection.js';
 import { field, SmrtObject, smrt } from '../index.js';
 import { GlobalInterceptors } from '../interceptors.js';
 import { getTestDatabase } from '../testing/database.js';
@@ -106,6 +112,59 @@ describe('SmrtCollection database-backed facets and counts (#1904)', () => {
     expect(facetQueries[0]).not.toContain('SELECT *');
   });
 
+  it('keeps omitted and explicit limits bounded, including empty strings', async () => {
+    await opportunities.create({
+      status: '',
+      workMode: 'remote',
+      skills: null,
+      tenantId: 'tenant-a',
+    });
+
+    const queries: Array<{ sql: string; params: unknown[] }> = [];
+    const originalQuery = db.query.bind(db);
+    db.query = (async (sql: string, ...params: unknown[]) => {
+      queries.push({ sql, params });
+      return originalQuery(sql, ...params);
+    }) as DatabaseInterface['query'];
+
+    const result = await opportunities.facets({
+      fields: [{ field: 'status', limit: MAX_FACET_LIMIT + 1 }],
+    });
+
+    expect(result[0]?.values).toContainEqual({ value: '', count: 1 });
+    expect(queries.at(-1)?.sql).toContain('LIMIT $1');
+    expect(queries.at(-1)?.params).toEqual([MAX_FACET_LIMIT]);
+
+    await opportunities.facets({ fields: ['status'] });
+    expect(queries.at(-1)?.params).toEqual([DEFAULT_FACET_LIMIT]);
+
+    const boundedCollection = await FacetOpportunityCollection.create({
+      db,
+      defaultListLimit: 1,
+    });
+    const bounded = await boundedCollection.facets({ fields: ['status'] });
+    expect(bounded[0]?.values).toHaveLength(1);
+
+    const cappedCollection = await FacetOpportunityCollection.create({
+      db,
+      maxListLimit: 1,
+    });
+    const capped = await cappedCollection.facets({
+      fields: [{ field: 'status', limit: MAX_FACET_LIMIT }],
+    });
+    expect(capped[0]?.values).toHaveLength(1);
+
+    await expect(
+      opportunities.facets({
+        fields: Array.from(
+          { length: MAX_FACET_FIELDS + 1 },
+          (_, index) => `field${index}` as never,
+        ),
+      }),
+    ).rejects.toThrow(`at most ${MAX_FACET_FIELDS} fields`);
+    expect(DEFAULT_FACET_LIMIT).toBe(50);
+  });
+
   it('composes facets with where and groups array fields by stored value', async () => {
     await seed();
 
@@ -172,5 +231,45 @@ describe('SmrtCollection database-backed facets and counts (#1904)', () => {
         fields: [{ field: 'status', limit: -1 }],
       }),
     ).rejects.toThrow(/facet limit/);
+  });
+
+  it.each([
+    { name: 'SQLite', type: 'sqlite' as const },
+    { name: 'DuckDB', type: 'duckdb' as const },
+  ])('runs portable scalar facets on $name', async ({ type }) => {
+    const portableDb = await getTestDatabase({
+      type,
+      url: ':memory:',
+      classes: ['FacetOpportunity'],
+    });
+    try {
+      const portable = await FacetOpportunityCollection.create({
+        db: portableDb,
+      });
+      await portable.create({
+        status: 'open',
+        workMode: 'remote',
+        skills: null,
+        tenantId: 'tenant-a',
+      });
+      await portable.create({
+        status: 'closed',
+        workMode: 'remote',
+        skills: null,
+        tenantId: 'tenant-a',
+      });
+
+      await expect(portable.facets({ fields: ['status'] })).resolves.toEqual([
+        {
+          field: 'status',
+          values: [
+            { value: 'closed', count: 1 },
+            { value: 'open', count: 1 },
+          ],
+        },
+      ]);
+    } finally {
+      await portableDb.close?.();
+    }
   });
 });

--- a/packages/core/src/__tests__/collection-facets.test.ts
+++ b/packages/core/src/__tests__/collection-facets.test.ts
@@ -46,6 +46,7 @@ describe('SmrtCollection database-backed facets and counts (#1904)', () => {
 
   afterEach(async () => {
     GlobalInterceptors.unregister('facet-opportunity-tenant');
+    GlobalInterceptors.unregister('facet-opportunity-rewrite-fields');
     await db?.close?.();
   });
 
@@ -94,8 +95,8 @@ describe('SmrtCollection database-backed facets and counts (#1904)', () => {
         field: 'status',
         values: [
           { value: 'open', count: 2 },
-          { value: null, count: 1 },
           { value: 'closed', count: 1 },
+          { value: null, count: 1 },
         ],
       },
       {
@@ -221,6 +222,32 @@ describe('SmrtCollection database-backed facets and counts (#1904)', () => {
     ).resolves.toEqual({ total: 3, filtered: 2 });
   });
 
+  it('uses fields rewritten by beforeList interceptors', async () => {
+    await seed();
+    GlobalInterceptors.register({
+      name: 'facet-opportunity-rewrite-fields',
+      beforeList(_className, options) {
+        return {
+          ...options,
+          fields: ['workMode'],
+        } as never;
+      },
+    });
+
+    await expect(opportunities.facets({ fields: ['status'] })).resolves.toEqual(
+      [
+        {
+          field: 'workMode',
+          values: [
+            { value: 'remote', count: 2 },
+            { value: 'hybrid', count: 1 },
+            { value: null, count: 1 },
+          ],
+        },
+      ],
+    );
+  });
+
   it('rejects duplicate, unknown, and invalid facet requests', async () => {
     await expect(
       opportunities.facets({ fields: ['status', 'status'] }),
@@ -260,6 +287,12 @@ describe('SmrtCollection database-backed facets and counts (#1904)', () => {
         skills: null,
         tenantId: 'tenant-a',
       });
+      await portable.create({
+        status: null,
+        workMode: 'remote',
+        skills: null,
+        tenantId: 'tenant-a',
+      });
 
       await expect(portable.facets({ fields: ['status'] })).resolves.toEqual([
         {
@@ -267,6 +300,7 @@ describe('SmrtCollection database-backed facets and counts (#1904)', () => {
           values: [
             { value: 'closed', count: 1 },
             { value: 'open', count: 1 },
+            { value: null, count: 1 },
           ],
         },
       ]);

--- a/packages/core/src/__tests__/collection-facets.test.ts
+++ b/packages/core/src/__tests__/collection-facets.test.ts
@@ -1,0 +1,176 @@
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SmrtCollection, type SmrtFacetResult } from '../collection.js';
+import { field, SmrtObject, smrt } from '../index.js';
+import { GlobalInterceptors } from '../interceptors.js';
+import { getTestDatabase } from '../testing/database.js';
+
+@smrt({
+  tenantScoped: { mode: 'optional', autoPopulate: false },
+})
+class FacetOpportunity extends SmrtObject {
+  @field({ type: 'text', nullable: true })
+  status: string | null = null;
+
+  @field({ type: 'text', nullable: true })
+  workMode: string | null = null;
+
+  @field({ type: 'json', nullable: true })
+  skills: string[] | null = null;
+
+  tenantId: string | null = null;
+}
+
+class FacetOpportunityCollection extends SmrtCollection<FacetOpportunity> {
+  static readonly _itemClass = FacetOpportunity;
+}
+
+describe('SmrtCollection database-backed facets and counts (#1904)', () => {
+  let db: DatabaseInterface;
+  let opportunities: FacetOpportunityCollection;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({
+      type: 'sqlite',
+      url: ':memory:',
+      classes: ['FacetOpportunity'],
+    });
+    opportunities = await FacetOpportunityCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    GlobalInterceptors.unregister('facet-opportunity-tenant');
+    await db?.close?.();
+  });
+
+  async function seed() {
+    await opportunities.create({
+      status: 'open',
+      workMode: 'remote',
+      skills: ['typescript', 'sql'],
+      tenantId: 'tenant-a',
+    });
+    await opportunities.create({
+      status: 'open',
+      workMode: 'hybrid',
+      skills: ['typescript'],
+      tenantId: 'tenant-a',
+    });
+    await opportunities.create({
+      status: 'closed',
+      workMode: 'remote',
+      skills: ['sql'],
+      tenantId: 'tenant-b',
+    });
+    await opportunities.create({
+      status: null,
+      workMode: null,
+      skills: null,
+      tenantId: 'tenant-a',
+    });
+  }
+
+  it('returns scalar value counts for multiple fields without hydration', async () => {
+    await seed();
+    const queries: string[] = [];
+    const originalQuery = db.query.bind(db);
+    db.query = (async (sql: string, ...params: unknown[]) => {
+      queries.push(sql);
+      return originalQuery(sql, ...params);
+    }) as DatabaseInterface['query'];
+
+    const result = await opportunities.facets({
+      fields: ['status', { field: 'workMode', limit: 1 }],
+    });
+
+    expect(result).toEqual([
+      {
+        field: 'status',
+        values: [
+          { value: 'open', count: 2 },
+          { value: null, count: 1 },
+          { value: 'closed', count: 1 },
+        ],
+      },
+      {
+        field: 'workMode',
+        values: [{ value: 'remote', count: 2 }],
+      },
+    ] satisfies SmrtFacetResult[]);
+
+    const facetQueries = queries.filter((sql) =>
+      sql.includes(`FROM ${opportunities.tableName}`),
+    );
+    expect(facetQueries).toHaveLength(2);
+    expect(facetQueries[0]).toContain('GROUP BY "status"');
+    expect(facetQueries[0]).not.toContain('SELECT *');
+  });
+
+  it('composes facets with where and groups array fields by stored value', async () => {
+    await seed();
+
+    const result = await opportunities.facets({
+      where: { workMode: 'remote' },
+      fields: ['status', 'skills'],
+    });
+
+    expect(result[0]).toEqual({
+      field: 'status',
+      values: [
+        { value: 'closed', count: 1 },
+        { value: 'open', count: 1 },
+      ],
+    });
+    // JSON/string-list fields are not unnested. Each stored JSON value is one
+    // facet, which keeps behavior consistent across SQLite, DuckDB, and PG.
+    expect(result[1]).toEqual({
+      field: 'skills',
+      values: [
+        { value: ['sql'], count: 1 },
+        { value: ['typescript', 'sql'], count: 1 },
+      ],
+    });
+  });
+
+  it('returns tenant-scoped total and filtered counts', async () => {
+    await seed();
+    GlobalInterceptors.register({
+      name: 'facet-opportunity-tenant',
+      beforeList(_className, options) {
+        return {
+          ...options,
+          where: { ...options.where, tenantId: 'tenant-a' },
+        };
+      },
+    });
+
+    await expect(opportunities.facets({ fields: ['status'] })).resolves.toEqual(
+      [
+        {
+          field: 'status',
+          values: [
+            { value: 'open', count: 2 },
+            { value: null, count: 1 },
+          ],
+        },
+      ],
+    );
+    await expect(
+      opportunities.counts({ where: { status: 'open' } }),
+    ).resolves.toEqual({ total: 3, filtered: 2 });
+  });
+
+  it('rejects duplicate, unknown, and invalid facet requests', async () => {
+    await expect(
+      opportunities.facets({ fields: ['status', 'status'] }),
+    ).rejects.toThrow(/requested more than once/);
+    await expect(
+      opportunities.facets({ fields: ['missing' as never] }),
+    ).rejects.toThrow(/Invalid select field: 'missing'/);
+    await expect(
+      opportunities.facets({
+        fields: [{ field: 'status', limit: -1 }],
+      }),
+    ).rejects.toThrow(/facet limit/);
+  });
+});

--- a/packages/core/src/__tests__/collection-facets.test.ts
+++ b/packages/core/src/__tests__/collection-facets.test.ts
@@ -181,7 +181,9 @@ describe('SmrtCollection database-backed facets and counts (#1904)', () => {
       ],
     });
     // JSON/string-list fields are not unnested. Each stored JSON value is one
-    // facet, which keeps behavior consistent across SQLite, DuckDB, and PG.
+    // facet. This encoding assertion is intentionally scoped to SQLite; the
+    // portable scalar adapter cases below cover SQLite and DuckDB, while the
+    // optional PostgreSQL test covers scalar grouping only.
     expect(result[1]).toEqual({
       field: 'skills',
       values: [

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -289,6 +289,40 @@ export type SmrtSelectedRow<
       : unknown;
 };
 
+/** A field requested by {@link SmrtCollection.facets}. */
+export interface SmrtFacetRequest<T extends SmrtObject> {
+  /** A column-backed SMRT field name (for example, `status`). */
+  field: SmrtSelectField<T>;
+  /** Maximum number of values to return. Omit to return every value. */
+  limit?: number;
+}
+
+/** One distinct facet value and the number of matching rows containing it. */
+export interface SmrtFacetValue {
+  value: unknown;
+  count: number;
+}
+
+/** Database-backed values returned for one requested facet field. */
+export interface SmrtFacetResult {
+  field: string;
+  values: SmrtFacetValue[];
+}
+
+/** Options for a database-backed facet query. */
+export interface SmrtFacetOptions<T extends SmrtObject> {
+  /** One or more fields. Each field may optionally carry its own value limit. */
+  fields: readonly (SmrtSelectField<T> | SmrtFacetRequest<T>)[];
+  /** The same SMRT WHERE syntax accepted by {@link SmrtCollection.list}. */
+  where?: SmrtWhereClause<T>;
+}
+
+/** Exact unfiltered and filtered row counts for a list scope. */
+export interface SmrtCollectionCounts {
+  total: number;
+  filtered: number;
+}
+
 export interface SmrtListOptions<ModelType extends SmrtObject> {
   where?: SmrtWhereClause<ModelType>;
   offset?: number;
@@ -3112,6 +3146,162 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     );
 
     return toSafeInteger(result.rows[0].count, 'Collection count');
+  }
+
+  /**
+   * Return database-backed distinct values and row counts for one or more
+   * column-backed fields.
+   *
+   * Each requested field is executed as a bounded `GROUP BY` query. Keeping
+   * one query per field works on every supported adapter (SQLite, DuckDB and
+   * PostgreSQL) while avoiding a full collection read or model hydration.
+   * The same `beforeList` interceptors as `list()` and `count()` run first,
+   * so tenancy and other read scopes are applied to every facet query.
+   *
+   * Facets group by the value stored in the column. SMRT does not split,
+   * unnest, or otherwise interpret array/string-list fields; consumers that
+   * need a facet per array member should maintain a scalar join table or use
+   * a consumer-specific query. JSON fields are grouped by their stored JSON
+   * value and decoded in the returned `value` when the field metadata allows
+   * it.
+   *
+   * @param options.fields One or more fields, optionally with per-field limits
+   * @param options.where Filter conditions using the same syntax as `list()`
+   * @returns One value/count list per requested field, in request order
+   */
+  public async facets(
+    options: SmrtFacetOptions<ModelType>,
+  ): Promise<SmrtFacetResult[]> {
+    await this.ensureStorageReady();
+
+    if (!options || !Array.isArray(options.fields)) {
+      throw new Error('Invalid facets option: fields must be an array.');
+    }
+    if (options.fields.length === 0) {
+      throw new Error('Invalid facets option: at least one field is required.');
+    }
+
+    const itemClassName = this.getResolvedItemClassName();
+    const itemQualifiedName = this.getResolvedItemQualifiedName();
+    const interceptorContext = createInterceptorContext(
+      itemClassName,
+      'list',
+      this.constructor.name,
+    );
+    const interceptedOptions =
+      (await GlobalInterceptors.executeBeforeList(
+        itemClassName,
+        options as unknown as InterceptorListOptions,
+        interceptorContext,
+      )) ??
+      (options as unknown as InterceptorListOptions) ??
+      {};
+
+    let { where } =
+      interceptedOptions as unknown as SmrtFacetOptions<ModelType>;
+    const tableStrategy = ObjectRegistry.getTableStrategy(itemQualifiedName);
+    const isSTI = tableStrategy === 'sti';
+    if (isSTI) {
+      const stiBase = ObjectRegistry.getSTIBase(itemQualifiedName);
+      if (stiBase && stiBase !== itemQualifiedName) {
+        where = {
+          _meta_type: itemQualifiedName,
+          ...(where || {}),
+        };
+      }
+    }
+    where = resolveMetaTypeInWhere(where);
+
+    const { sql: whereSql, values: whereValues } = buildWhere(
+      this.convertWhereKeys(where || {}),
+    );
+    const fields = this.getFieldsSync();
+    const requested = options.fields.map((entry) =>
+      typeof entry === 'string' ? { field: entry } : entry,
+    );
+    const seen = new Set<string>();
+    const results: SmrtFacetResult[] = [];
+
+    for (const request of requested) {
+      if (!request || typeof request.field !== 'string') {
+        throw new Error(
+          'Invalid facet field: expected a string or { field, limit }.',
+        );
+      }
+      const field = request.field;
+      if (seen.has(field)) {
+        throw new Error(
+          `Invalid facet field: '${field}' was requested more than once.`,
+        );
+      }
+      seen.add(field);
+
+      // Reuse projection validation so facets cannot expose sensitive,
+      // readPermission-gated, relationship-only, transient, or unknown
+      // fields. The returned SQL is intentionally not used: aggregation needs
+      // the same safe column identifier without hydrating a projection row.
+      this.resolveProjectionSelect([field], fields, isSTI);
+
+      const columnName = this.toDbColumnName(field);
+      const quotedColumn = this.quoteProjectionIdentifier(columnName);
+      const quotedField = this.quoteProjectionIdentifier(field);
+      const requestedLimit = request.limit;
+      const limit =
+        requestedLimit === undefined
+          ? undefined
+          : this.applyListBounds(
+              assertQueryBound(requestedLimit, `facet limit for '${field}'`),
+            );
+      const limitSql =
+        limit === undefined ? '' : ` LIMIT $${whereValues.length + 1}`;
+      const sql =
+        `SELECT ${quotedColumn} AS ${quotedField}, ` +
+        `COUNT(*) AS "__smrt_facet_count" FROM ${this.tableName} ` +
+        `${whereSql} GROUP BY ${quotedColumn} ` +
+        `ORDER BY "__smrt_facet_count" DESC, ${quotedColumn} ASC${limitSql}`;
+      const params =
+        limit === undefined ? whereValues : [...whereValues, limit];
+      const queryResult = await this.db.query(sql, ...params);
+
+      results.push({
+        field,
+        values: queryResult.rows.map((row) => {
+          const rawValue = row[field];
+          const formatted = formatDataJs({ [columnName]: rawValue }, fields);
+          const formattedKey = Object.hasOwn(formatted, field)
+            ? field
+            : toCamelCase(field);
+          const value = Object.hasOwn(formatted, formattedKey)
+            ? formatted[formattedKey]
+            : rawValue;
+          return {
+            value,
+            count: toSafeInteger(
+              row.__smrt_facet_count,
+              `Facet count for '${field}'`,
+            ),
+          };
+        }),
+      });
+    }
+
+    return results;
+  }
+
+  /**
+   * Return both the tenant/read-scoped total and a filtered count.
+   *
+   * This intentionally issues two `COUNT(*)` queries rather than reading
+   * rows into application memory. `count()` applies `beforeList` for each
+   * query, so the unfiltered total remains tenant-scoped while the filtered
+   * count adds the caller's `where` conditions.
+   */
+  public async counts(
+    options: { where?: SmrtWhereClause<ModelType> } = {},
+  ): Promise<SmrtCollectionCounts> {
+    const total = await this.count();
+    const filtered = await this.count(options);
+    return { total, filtered };
   }
 
   /**

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -3253,7 +3253,21 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       this.convertWhereKeys(where || {}),
     );
     const fields = this.getFieldsSync();
-    const requested = options.fields.map((entry) =>
+    const interceptedFields = (
+      interceptedOptions as unknown as Partial<SmrtFacetOptions<ModelType>>
+    ).fields;
+    const effectiveFields = interceptedFields ?? options.fields;
+    if (!Array.isArray(effectiveFields) || effectiveFields.length === 0) {
+      throw new Error(
+        'Invalid facets option: at least one field is required after interception.',
+      );
+    }
+    if (effectiveFields.length > MAX_FACET_FIELDS) {
+      throw new Error(
+        `Invalid facets option: at most ${MAX_FACET_FIELDS} fields are allowed after interception.`,
+      );
+    }
+    const requested = effectiveFields.map((entry) =>
       typeof entry === 'string' ? { field: entry } : entry,
     );
     const seen = new Set<string>();
@@ -3296,7 +3310,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
         `SELECT ${quotedColumn} AS ${quotedField}, ` +
         `COUNT(*) AS "__smrt_facet_count" FROM ${this.tableName} ` +
         `${whereSql} GROUP BY ${quotedColumn} ` +
-        `ORDER BY "__smrt_facet_count" DESC, ${quotedColumn} ASC ` +
+        `ORDER BY "__smrt_facet_count" DESC, ` +
+        `CASE WHEN ${quotedColumn} IS NULL THEN 1 ELSE 0 END ASC, ` +
+        `${quotedColumn} ASC ` +
         `LIMIT $${whereValues.length + 1}`;
       const params = [...whereValues, limit];
       const queryResult = await this.db.query(sql, ...params);

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -307,7 +307,11 @@ export type SmrtSelectedRow<
 export interface SmrtFacetRequest<T extends SmrtObject> {
   /** A column-backed SMRT field name (for example, `status`). */
   field: SmrtSelectField<T>;
-  /** Maximum number of values to return. Omit to return every value. */
+  /**
+   * Maximum number of values to return. Omit to use the collection's
+   * `defaultListLimit` or 50, subject to `maxListLimit` and the hard maximum
+   * facet limit.
+   */
   limit?: number;
 }
 
@@ -3170,8 +3174,10 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    * column-backed fields.
    *
    * Each requested field is executed as a bounded `GROUP BY` query. Keeping
-   * one query per field works on every supported adapter (SQLite, DuckDB and
-   * PostgreSQL) while avoiding a full collection read or model hydration.
+   * one query per field uses standard SQL while avoiding a full collection
+   * read or model hydration. Scalar facet behavior is covered on SQLite and
+   * DuckDB; optional PostgreSQL scalar coverage runs in the `test:postgres`
+   * lane when `SMRT_TEST_POSTGRES_URL` is configured.
    * The same `beforeList` interceptors as `list()` and `count()` run first,
    * so tenancy and other read scopes are applied to every facet query.
    *
@@ -3180,7 +3186,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    * need a facet per array member should maintain a scalar join table or use
    * a consumer-specific query. JSON fields are grouped by their stored JSON
    * value and decoded in the returned `value` when the field metadata allows
-   * it.
+   * it. Array/JSON encoding behavior is adapter-specific and is covered by
+   * the SQLite/DuckDB tests only; the optional PostgreSQL test covers scalar
+   * grouping.
    *
    * @param options.fields One or more fields, optionally with per-field limits
    * @param options.where Filter conditions using the same syntax as `list()`

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -30,7 +30,12 @@ import {
   resolveGetStringFilter,
 } from './interceptors';
 import type { SmrtObject } from './object';
-import { QueryBoundsError, QueryOrderByError } from './query-bounds';
+import {
+  DEFAULT_LIST_LIMIT,
+  MAX_LIST_LIMIT,
+  QueryBoundsError,
+  QueryOrderByError,
+} from './query-bounds';
 import { ObjectRegistry } from './registry';
 import type { SmrtObjectConstructor } from './registry/types';
 import { verifyPersistenceTable } from './schema/table-verifier';
@@ -53,6 +58,15 @@ const logger = createLogger({ level: 'info' });
  * see {@link SmrtCollection.resolveCollectionMemoryOwnerId} (#2365).
  */
 const COLLECTION_MEMORY_OWNER_ID = '__collection__';
+
+/** Maximum number of independent facet fields accepted by one call. */
+export const MAX_FACET_FIELDS = 20;
+
+/** Default number of distinct values returned for each facet field. */
+export const DEFAULT_FACET_LIMIT = DEFAULT_LIST_LIMIT;
+
+/** Hard ceiling for distinct values returned for one facet field. */
+export const MAX_FACET_LIMIT = MAX_LIST_LIMIT;
 
 /**
  * Validate an optional collection-level list bound (#2367).
@@ -311,7 +325,10 @@ export interface SmrtFacetResult {
 
 /** Options for a database-backed facet query. */
 export interface SmrtFacetOptions<T extends SmrtObject> {
-  /** One or more fields. Each field may optionally carry its own value limit. */
+  /**
+   * One or more fields (at most {@link MAX_FACET_FIELDS}). Each field may
+   * optionally carry its own value limit.
+   */
   fields: readonly (SmrtSelectField<T> | SmrtFacetRequest<T>)[];
   /** The same SMRT WHERE syntax accepted by {@link SmrtCollection.list}. */
   where?: SmrtWhereClause<T>;
@@ -3168,6 +3185,13 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    * @param options.fields One or more fields, optionally with per-field limits
    * @param options.where Filter conditions using the same syntax as `list()`
    * @returns One value/count list per requested field, in request order
+   *
+   * Limits are always bounded: an explicit per-field limit is clamped to
+   * {@link MAX_FACET_LIMIT}, the collection's `maxListLimit` when configured,
+   * and the lower of those ceilings. When omitted, the effective limit is the
+   * collection's `defaultListLimit` or {@link DEFAULT_FACET_LIMIT}, subject to
+   * the same ceilings. This keeps facet queries bounded even when collection
+   * list bounds are unset.
    */
   public async facets(
     options: SmrtFacetOptions<ModelType>,
@@ -3179,6 +3203,11 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     }
     if (options.fields.length === 0) {
       throw new Error('Invalid facets option: at least one field is required.');
+    }
+    if (options.fields.length > MAX_FACET_FIELDS) {
+      throw new Error(
+        `Invalid facets option: at most ${MAX_FACET_FIELDS} fields are allowed.`,
+      );
     }
 
     const itemClassName = this.getResolvedItemClassName();
@@ -3245,22 +3274,23 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       const columnName = this.toDbColumnName(field);
       const quotedColumn = this.quoteProjectionIdentifier(columnName);
       const quotedField = this.quoteProjectionIdentifier(field);
-      const requestedLimit = request.limit;
-      const limit =
-        requestedLimit === undefined
-          ? undefined
-          : this.applyListBounds(
-              assertQueryBound(requestedLimit, `facet limit for '${field}'`),
-            );
-      const limitSql =
-        limit === undefined ? '' : ` LIMIT $${whereValues.length + 1}`;
+      const requestedLimit =
+        request.limit === undefined
+          ? (this._defaultListLimit ?? DEFAULT_FACET_LIMIT)
+          : assertQueryBound(request.limit, `facet limit for '${field}'`);
+      const collectionLimit = this._maxListLimit ?? MAX_FACET_LIMIT;
+      const limit = Math.min(
+        requestedLimit ?? DEFAULT_FACET_LIMIT,
+        collectionLimit,
+        MAX_FACET_LIMIT,
+      );
       const sql =
         `SELECT ${quotedColumn} AS ${quotedField}, ` +
         `COUNT(*) AS "__smrt_facet_count" FROM ${this.tableName} ` +
         `${whereSql} GROUP BY ${quotedColumn} ` +
-        `ORDER BY "__smrt_facet_count" DESC, ${quotedColumn} ASC${limitSql}`;
-      const params =
-        limit === undefined ? whereValues : [...whereValues, limit];
+        `ORDER BY "__smrt_facet_count" DESC, ${quotedColumn} ASC ` +
+        `LIMIT $${whereValues.length + 1}`;
+      const params = [...whereValues, limit];
       const queryResult = await this.db.query(sql, ...params);
 
       results.push({


### PR DESCRIPTION
## Summary

- Add bounded, database-backed collection facets with grouped value counts.
- Add scoped total and filtered counts without object hydration.
- Document adapter and optional PostgreSQL test coverage.

## Validation

- core suite: 297 files, 3,929 tests passed (108 skipped)
- focused facets: 7 passed across SQLite and DuckDB
- core typecheck, Biome, knowledge freshness, diff and commit hooks
- preliminary and final high-risk review clean on the exact head
- PostgreSQL scalar facet lane is wired and skipped locally because `SMRT_TEST_POSTGRES_URL` is unavailable

Closes #1904

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-1904-review-fixes-20260823",
  "issue": 1904,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "core suite: 297 files, 3,929 tests passed (108 skipped)",
    "focused SQLite and DuckDB facet suite: 7 tests passed",
    "core typecheck and Biome",
    "knowledge freshness, diff check, and commit hooks",
    "pre-push policy checks",
    "review-cycle: preliminary and final high-risk reviews clean on exact head",
    "optional PostgreSQL scalar facet lane wired; skipped locally because SMRT_TEST_POSTGRES_URL is unavailable"
  ]
}