### PR TITLE
feat(fields): extend field policy data-surface metadata

### DIFF
--- a/packages/fields/AGENTS.md
+++ b/packages/fields/AGENTS.md
@@ -203,6 +203,9 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
   columns. Static host restrictions are only narrowed; hidden fields are
   omitted from the descriptor (the row key remains as a non-readable identity
   column), and actions that explicitly depend on hidden columns are removed.
+  Sensitive/secret and `readable: false` columns also fail closed when omitted
+  from the resolved policy; a host must pass `authorizedColumnIds` explicitly
+  to expose a sensitive descriptor column.
 - **Two-tier context contract.** `PolicyField` alone reads the context with
   `tryGetFieldPolicyContext()`, because outside a Provider it still has the
   caller's children to render verbatim (incremental adoption). The

--- a/packages/fields/AGENTS.md
+++ b/packages/fields/AGENTS.md
@@ -199,9 +199,9 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
 - `policyToDataSurfaceDescriptor(policy, descriptor)` is the corresponding
   mounted DataSurface adapter. It carries effective labels, help text, order,
   visibility, readable/capability state, and operator/query allowlists into
-  discovery metadata while retaining computed, row-key, selection, and action
-  columns. Static host restrictions are only narrowed; hidden fields are
-  omitted from the descriptor (the row key remains as a non-readable identity
+  discovery metadata while retaining unrestricted computed, row-key, selection,
+  and action columns. Static or resolved-policy-hidden structural columns are
+  omitted from discovery (the row key remains only as a non-readable identity
   column), and actions that explicitly depend on hidden columns are removed.
   Sensitive/secret and `readable: false` columns also fail closed when omitted
   from the resolved policy; a host must pass `authorizedColumnIds` explicitly

--- a/packages/fields/AGENTS.md
+++ b/packages/fields/AGENTS.md
@@ -194,8 +194,11 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
   select-like widgets. Reference fields intentionally default to identifier
   inputs unless an app supplies a chooser.
 - `policyToVisibleColumnIds(policy, columns)` feeds smrt-ui `DataTable`'s
-  `visibleColumnIds`; it filters policy-hidden mapped fields, preserves unmapped
-  computed/action columns, and cannot reveal a static `column.hidden` column.
+  `visibleColumnIds`; it filters policy-hidden mapped fields and restricted
+  (`sensitive`/`secret` or `readable: false`) columns, preserves unrestricted
+  unmapped computed/action columns, and cannot reveal a static `column.hidden`
+  column. Pass `authorizedColumnIds` only when the host explicitly authorizes a
+  restricted column; `readable: true` alone does not override sensitivity.
 - `policyToDataSurfaceDescriptor(policy, descriptor)` is the corresponding
   mounted DataSurface adapter. It carries effective labels, help text, order,
   visibility, readable/capability state, and operator/query allowlists into

--- a/packages/fields/AGENTS.md
+++ b/packages/fields/AGENTS.md
@@ -208,7 +208,9 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
   column), and actions that explicitly depend on hidden columns are removed.
   Sensitive/secret and `readable: false` columns also fail closed when omitted
   from the resolved policy; a host must pass `authorizedColumnIds` explicitly
-  to expose a sensitive descriptor column.
+  to expose a restricted descriptor column, and authorization sets the
+  effective `readable` metadata to `true` so capabilities and query allowlists
+  cannot contradict it.
 - **Two-tier context contract.** `PolicyField` alone reads the context with
   `tryGetFieldPolicyContext()`, because outside a Provider it still has the
   caller's children to render verbatim (incremental adoption). The

--- a/packages/fields/AGENTS.md
+++ b/packages/fields/AGENTS.md
@@ -196,6 +196,13 @@ per-field `{defaultValue, visibility, help, label, order, locked}` for any
 - `policyToVisibleColumnIds(policy, columns)` feeds smrt-ui `DataTable`'s
   `visibleColumnIds`; it filters policy-hidden mapped fields, preserves unmapped
   computed/action columns, and cannot reveal a static `column.hidden` column.
+- `policyToDataSurfaceDescriptor(policy, descriptor)` is the corresponding
+  mounted DataSurface adapter. It carries effective labels, help text, order,
+  visibility, readable/capability state, and operator/query allowlists into
+  discovery metadata while retaining computed, row-key, selection, and action
+  columns. Static host restrictions are only narrowed; hidden fields are
+  omitted from the descriptor (the row key remains as a non-readable identity
+  column), and actions that explicitly depend on hidden columns are removed.
 - **Two-tier context contract.** `PolicyField` alone reads the context with
   `tryGetFieldPolicyContext()`, because outside a Provider it still has the
   caller's children to render verbatim (incremental adoption). The

--- a/packages/fields/src/data-surface.test.ts
+++ b/packages/fields/src/data-surface.test.ts
@@ -292,4 +292,116 @@ describe('field policy DataSurface adapter (#2449)', () => {
     });
     expect(result.query.projectableColumnIds).not.toContain('id');
   });
+
+  it('removes static-hidden structural columns from discovery and commands', () => {
+    const hiddenIds = ['computed', 'selection', 'actions'];
+    const searchableColumnIds = descriptor.query.searchableColumnIds ?? [];
+    const filterableColumnIds = descriptor.query.filterableColumnIds ?? [];
+    const sortableColumnIds = descriptor.query.sortableColumnIds ?? [];
+    const structuralDescriptor: DataSurfaceDescriptor = {
+      ...descriptor,
+      query: {
+        ...descriptor.query,
+        projectableColumnIds: [
+          ...descriptor.query.projectableColumnIds,
+          ...hiddenIds,
+        ],
+        searchableColumnIds: [...searchableColumnIds, ...hiddenIds],
+        filterableColumnIds: [...filterableColumnIds, ...hiddenIds],
+        sortableColumnIds: [...sortableColumnIds, ...hiddenIds],
+      },
+      actions: [
+        ...descriptor.actions,
+        {
+          id: 'run-computed',
+          label: 'Run computed',
+          selectionScopes: ['current-page'],
+          columnIds: ['computed'],
+        },
+      ],
+    };
+
+    const result = policyToDataSurfaceDescriptor(policy, structuralDescriptor, {
+      staticHiddenColumnIds: hiddenIds,
+    });
+
+    for (const id of hiddenIds) {
+      expect(result.columns.map((column) => column.id)).not.toContain(id);
+      expect(result.query.projectableColumnIds).not.toContain(id);
+      expect(result.query.searchableColumnIds).not.toContain(id);
+      expect(result.query.filterableColumnIds).not.toContain(id);
+      expect(result.query.sortableColumnIds).not.toContain(id);
+    }
+    expect(result.actions.map((action) => action.id)).not.toContain(
+      'run-computed',
+    );
+  });
+
+  it('removes policy-hidden structural columns and dependent actions', () => {
+    const hiddenIds = ['computed', 'selection', 'actions'];
+    const searchableColumnIds = descriptor.query.searchableColumnIds ?? [];
+    const filterableColumnIds = descriptor.query.filterableColumnIds ?? [];
+    const sortableColumnIds = descriptor.query.sortableColumnIds ?? [];
+    const structuralDescriptor: DataSurfaceDescriptor = {
+      ...descriptor,
+      columns: descriptor.columns.map((column) =>
+        hiddenIds.includes(column.id)
+          ? { ...column, fieldName: column.id }
+          : column,
+      ),
+      query: {
+        ...descriptor.query,
+        projectableColumnIds: [
+          ...descriptor.query.projectableColumnIds,
+          ...hiddenIds,
+        ],
+        searchableColumnIds: [...searchableColumnIds, ...hiddenIds],
+        filterableColumnIds: [...filterableColumnIds, ...hiddenIds],
+        sortableColumnIds: [...sortableColumnIds, ...hiddenIds],
+      },
+      actions: [
+        ...descriptor.actions,
+        {
+          id: 'run-selection',
+          label: 'Run selection',
+          selectionScopes: ['current-page'],
+          columnIds: ['selection'],
+        },
+      ],
+    };
+    const structuralPolicy: ResolvedObjectFieldPolicy = {
+      ...policy,
+      fields: {
+        ...policy.fields,
+        ...Object.fromEntries(
+          hiddenIds.map((fieldName) => [
+            fieldName,
+            {
+              ...policy.fields.title,
+              fieldName,
+              visibility: 'hidden' as const,
+              label: `${fieldName} label`,
+              help: `${fieldName} help`,
+            },
+          ]),
+        ),
+      },
+    };
+
+    const result = policyToDataSurfaceDescriptor(
+      structuralPolicy,
+      structuralDescriptor,
+    );
+
+    for (const id of hiddenIds) {
+      expect(result.columns.map((column) => column.id)).not.toContain(id);
+      expect(result.query.projectableColumnIds).not.toContain(id);
+      expect(result.query.searchableColumnIds).not.toContain(id);
+      expect(result.query.filterableColumnIds).not.toContain(id);
+      expect(result.query.sortableColumnIds).not.toContain(id);
+    }
+    expect(result.actions.map((action) => action.id)).not.toContain(
+      'run-selection',
+    );
+  });
 });

--- a/packages/fields/src/data-surface.test.ts
+++ b/packages/fields/src/data-surface.test.ts
@@ -37,6 +37,33 @@ const descriptor: DataSurfaceDescriptor = {
       capabilities: ['read', 'search', 'filter', 'sort', 'project'],
     },
     {
+      id: 'restricted',
+      label: 'Restricted',
+      fieldName: 'restricted',
+      sensitivity: 'sensitive',
+      capabilities: ['read', 'search', 'filter', 'sort', 'project'],
+    },
+    {
+      id: 'unreadable',
+      label: 'Unreadable',
+      fieldName: 'unreadable',
+      readable: false,
+      capabilities: ['read', 'search', 'filter', 'sort', 'project'],
+    },
+    {
+      id: 'native-hidden',
+      label: 'Native hidden',
+      fieldName: 'nativeHidden',
+      visibility: 'hidden',
+      capabilities: ['read', 'search', 'filter', 'sort', 'project'],
+    },
+    {
+      id: 'secondary',
+      label: 'Secondary',
+      fieldName: 'secondary',
+      capabilities: ['read', 'project'],
+    },
+    {
       id: 'computed',
       label: 'Computed',
       role: 'computed',
@@ -57,10 +84,35 @@ const descriptor: DataSurfaceDescriptor = {
   ],
   query: {
     modes: ['rows', 'count', 'facets'],
-    projectableColumnIds: ['id', 'title', 'secret'],
-    searchableColumnIds: ['title', 'secret'],
-    filterableColumnIds: ['title', 'secret'],
-    sortableColumnIds: ['title', 'secret'],
+    projectableColumnIds: [
+      'id',
+      'title',
+      'secret',
+      'restricted',
+      'unreadable',
+      'native-hidden',
+    ],
+    searchableColumnIds: [
+      'title',
+      'secret',
+      'restricted',
+      'unreadable',
+      'native-hidden',
+    ],
+    filterableColumnIds: [
+      'title',
+      'secret',
+      'restricted',
+      'unreadable',
+      'native-hidden',
+    ],
+    sortableColumnIds: [
+      'title',
+      'secret',
+      'restricted',
+      'unreadable',
+      'native-hidden',
+    ],
   },
   controls: [],
   actions: [
@@ -90,7 +142,7 @@ const policy: ResolvedObjectFieldPolicy = {
       visibility: 'basic',
       help: 'The public title',
       label: 'Display title',
-      order: 1,
+      order: 2,
       group: null,
       locked: false,
       required: false,
@@ -107,6 +159,18 @@ const policy: ResolvedObjectFieldPolicy = {
       locked: false,
       required: false,
     },
+    secondary: {
+      fieldName: 'secondary',
+      hasDefault: false,
+      defaultValue: undefined,
+      visibility: 'advanced',
+      help: null,
+      label: 'Secondary field',
+      order: 1,
+      group: null,
+      locked: false,
+      required: false,
+    },
   },
 };
 
@@ -115,6 +179,7 @@ describe('field policy DataSurface adapter (#2449)', () => {
     const result = policyToDataSurfaceDescriptor(policy, descriptor);
     expect(result.columns.map((column) => column.id)).toEqual([
       'id',
+      'secondary',
       'title',
       'computed',
       'selection',
@@ -126,7 +191,7 @@ describe('field policy DataSurface adapter (#2449)', () => {
       label: 'Display title',
       description: 'The public title',
       visibility: 'basic',
-      order: 1,
+      order: 2,
       operators: {
         search: ['contains'],
         filter: ['equals', 'contains'],
@@ -145,6 +210,7 @@ describe('field policy DataSurface adapter (#2449)', () => {
     const result = applyFieldPolicyToDataSurface(policy, descriptor);
     expect(result.columns.map((column) => column.id)).toEqual([
       'id',
+      'secondary',
       'title',
       'computed',
       'selection',
@@ -152,6 +218,48 @@ describe('field policy DataSurface adapter (#2449)', () => {
     ]);
     expect(result.actions.map((action) => action.id)).toEqual(['export']);
     expect(result.query.projectableColumnIds).not.toContain('secret');
+    expect(result.columns.map((column) => column.id)).not.toContain(
+      'restricted',
+    );
+    expect(result.columns.map((column) => column.id)).not.toContain(
+      'unreadable',
+    );
+    expect(result.columns.map((column) => column.id)).not.toContain(
+      'native-hidden',
+    );
+  });
+
+  it('keeps restricted fields fail-closed unless the host explicitly authorizes them', () => {
+    const restrictedDescriptor = {
+      ...descriptor,
+      columns: descriptor.columns.map((column) =>
+        column.id === 'restricted'
+          ? { ...column, visibility: undefined }
+          : column,
+      ),
+    };
+    const denied = policyToDataSurfaceDescriptor(policy, restrictedDescriptor);
+    expect(denied.columns.map((column) => column.id)).not.toContain(
+      'restricted',
+    );
+    expect(denied.query.projectableColumnIds).not.toContain('restricted');
+
+    const authorized = policyToDataSurfaceDescriptor(
+      policy,
+      restrictedDescriptor,
+      {
+        authorizedColumnIds: ['restricted'],
+      },
+    );
+    expect(authorized.columns.map((column) => column.id)).toContain(
+      'restricted',
+    );
+    expect(
+      authorized.columns.find((column) => column.id === 'restricted'),
+    ).toMatchObject({
+      readable: true,
+      capabilities: ['read', 'search', 'filter', 'sort', 'project'],
+    });
   });
 
   it('cannot broaden static hidden/readability constraints', () => {
@@ -162,5 +270,26 @@ describe('field policy DataSurface adapter (#2449)', () => {
     expect(result.query.searchableColumnIds).toEqual([]);
     expect(result.query.filterableColumnIds).toEqual([]);
     expect(result.query.sortableColumnIds).toEqual([]);
+  });
+
+  it('retains a hidden row key only as a capability-free identity column', () => {
+    const hiddenRowKey = {
+      ...descriptor,
+      columns: descriptor.columns.map((column) =>
+        column.id === 'id'
+          ? { ...column, visibility: 'hidden' as const }
+          : column,
+      ),
+    };
+
+    const result = policyToDataSurfaceDescriptor(policy, hiddenRowKey);
+    expect(result.columns[0]).toMatchObject({
+      id: 'id',
+      visibility: 'hidden',
+      readable: false,
+      capabilities: [],
+      operators: {},
+    });
+    expect(result.query.projectableColumnIds).not.toContain('id');
   });
 });

--- a/packages/fields/src/data-surface.test.ts
+++ b/packages/fields/src/data-surface.test.ts
@@ -1,0 +1,166 @@
+import type { DataSurfaceDescriptor } from '@happyvertical/smrt-ui/data';
+import { describe, expect, it } from 'vitest';
+import {
+  applyFieldPolicyToDataSurface,
+  policyToDataSurfaceDescriptor,
+} from './data-surface.js';
+import type { ResolvedObjectFieldPolicy } from './types.js';
+
+const descriptor: DataSurfaceDescriptor = {
+  version: 1,
+  identity: { surfaceId: 'library', kind: 'table' },
+  schemaVersion: 1,
+  label: 'Library',
+  rowKey: 'id',
+  columns: [
+    {
+      id: 'id',
+      label: 'ID',
+      role: 'row-key',
+      capabilities: ['read', 'project'],
+    },
+    {
+      id: 'title',
+      label: 'Title',
+      fieldName: 'title',
+      capabilities: ['read', 'search', 'filter', 'sort', 'project'],
+      operators: {
+        search: ['contains'],
+        filter: ['equals', 'contains'],
+        sort: ['asc', 'desc'],
+      },
+    },
+    {
+      id: 'secret',
+      label: 'Secret',
+      fieldName: 'secret',
+      capabilities: ['read', 'search', 'filter', 'sort', 'project'],
+    },
+    {
+      id: 'computed',
+      label: 'Computed',
+      role: 'computed',
+      capabilities: ['read'],
+    },
+    {
+      id: 'selection',
+      label: 'Select',
+      role: 'selection',
+      capabilities: [],
+    },
+    {
+      id: 'actions',
+      label: 'Actions',
+      role: 'action',
+      capabilities: [],
+    },
+  ],
+  query: {
+    modes: ['rows', 'count', 'facets'],
+    projectableColumnIds: ['id', 'title', 'secret'],
+    searchableColumnIds: ['title', 'secret'],
+    filterableColumnIds: ['title', 'secret'],
+    sortableColumnIds: ['title', 'secret'],
+  },
+  controls: [],
+  actions: [
+    {
+      id: 'export',
+      label: 'Export',
+      selectionScopes: ['current-page'],
+      columnIds: ['title'],
+    },
+    {
+      id: 'reveal-secret',
+      label: 'Reveal secret',
+      selectionScopes: ['explicit-ids'],
+      columnIds: ['secret'],
+    },
+  ],
+  limits: { maxQueryRows: 100, maxQueryBytes: 10_000, maxSelectionSize: 20 },
+};
+
+const policy: ResolvedObjectFieldPolicy = {
+  objectRef: '@test:Library',
+  fields: {
+    title: {
+      fieldName: 'title',
+      hasDefault: false,
+      defaultValue: undefined,
+      visibility: 'basic',
+      help: 'The public title',
+      label: 'Display title',
+      order: 1,
+      group: null,
+      locked: false,
+      required: false,
+    },
+    secret: {
+      fieldName: 'secret',
+      hasDefault: false,
+      defaultValue: undefined,
+      visibility: 'hidden',
+      help: 'Do not expose this value',
+      label: 'Secret value',
+      order: 99,
+      group: null,
+      locked: false,
+      required: false,
+    },
+  },
+};
+
+describe('field policy DataSurface adapter (#2449)', () => {
+  it('publishes policy labels, descriptions, ordering, visibility, and operator metadata', () => {
+    const result = policyToDataSurfaceDescriptor(policy, descriptor);
+    expect(result.columns.map((column) => column.id)).toEqual([
+      'id',
+      'title',
+      'computed',
+      'selection',
+      'actions',
+    ]);
+    expect(
+      result.columns.find((column) => column.id === 'title'),
+    ).toMatchObject({
+      label: 'Display title',
+      description: 'The public title',
+      visibility: 'basic',
+      order: 1,
+      operators: {
+        search: ['contains'],
+        filter: ['equals', 'contains'],
+        sort: ['asc', 'desc'],
+      },
+    });
+    expect(result.query).toMatchObject({
+      projectableColumnIds: ['id', 'title'],
+      searchableColumnIds: ['title'],
+      filterableColumnIds: ['title'],
+      sortableColumnIds: ['title'],
+    });
+  });
+
+  it('keeps computed, selection, and action columns while removing hidden fields and actions', () => {
+    const result = applyFieldPolicyToDataSurface(policy, descriptor);
+    expect(result.columns.map((column) => column.id)).toEqual([
+      'id',
+      'title',
+      'computed',
+      'selection',
+      'actions',
+    ]);
+    expect(result.actions.map((action) => action.id)).toEqual(['export']);
+    expect(result.query.projectableColumnIds).not.toContain('secret');
+  });
+
+  it('cannot broaden static hidden/readability constraints', () => {
+    const result = policyToDataSurfaceDescriptor(policy, descriptor, {
+      staticHiddenColumnIds: ['title'],
+    });
+    expect(result.columns.map((column) => column.id)).not.toContain('title');
+    expect(result.query.searchableColumnIds).toEqual([]);
+    expect(result.query.filterableColumnIds).toEqual([]);
+    expect(result.query.sortableColumnIds).toEqual([]);
+  });
+});

--- a/packages/fields/src/data-surface.test.ts
+++ b/packages/fields/src/data-surface.test.ts
@@ -41,6 +41,7 @@ const descriptor: DataSurfaceDescriptor = {
       label: 'Restricted',
       fieldName: 'restricted',
       sensitivity: 'sensitive',
+      readable: true,
       capabilities: ['read', 'search', 'filter', 'sort', 'project'],
     },
     {

--- a/packages/fields/src/data-surface.test.ts
+++ b/packages/fields/src/data-surface.test.ts
@@ -282,6 +282,56 @@ describe('field policy DataSurface adapter (#2449)', () => {
     expect(authorized.query.projectableColumnIds).toContain('unreadable');
   });
 
+  it('normalizes authorized sensitive structural readability and projectability', () => {
+    const structuralIds = ['id', 'computed', 'selection', 'actions'];
+    const structuralDescriptor: DataSurfaceDescriptor = {
+      ...descriptor,
+      columns: descriptor.columns.map((column) =>
+        structuralIds.includes(column.id)
+          ? {
+              ...column,
+              sensitivity: 'sensitive' as const,
+              capabilities:
+                column.id === 'id' || column.id === 'computed'
+                  ? ['read', 'project']
+                  : [],
+            }
+          : column,
+      ),
+      query: {
+        ...descriptor.query,
+        projectableColumnIds: [
+          ...descriptor.query.projectableColumnIds,
+          'computed',
+        ],
+      },
+    };
+
+    const denied = policyToDataSurfaceDescriptor(policy, structuralDescriptor);
+    expect(denied.columns.map((column) => column.id)).not.toEqual(
+      expect.arrayContaining(['computed', 'selection', 'actions']),
+    );
+    expect(denied.columns.find((column) => column.id === 'id')).toMatchObject({
+      readable: false,
+      capabilities: [],
+    });
+    expect(denied.query.projectableColumnIds).not.toContain('id');
+    expect(denied.query.projectableColumnIds).not.toContain('computed');
+
+    const authorized = policyToDataSurfaceDescriptor(
+      policy,
+      structuralDescriptor,
+      { authorizedColumnIds: structuralIds },
+    );
+    for (const id of structuralIds) {
+      expect(
+        authorized.columns.find((column) => column.id === id),
+      ).toMatchObject({ readable: true });
+    }
+    expect(authorized.query.projectableColumnIds).toContain('id');
+    expect(authorized.query.projectableColumnIds).toContain('computed');
+  });
+
   it('cannot broaden static hidden/readability constraints', () => {
     const result = policyToDataSurfaceDescriptor(policy, descriptor, {
       staticHiddenColumnIds: ['title'],

--- a/packages/fields/src/data-surface.test.ts
+++ b/packages/fields/src/data-surface.test.ts
@@ -263,6 +263,25 @@ describe('field policy DataSurface adapter (#2449)', () => {
     });
   });
 
+  it('makes explicitly authorized unreadable metadata internally consistent', () => {
+    const denied = policyToDataSurfaceDescriptor(policy, descriptor);
+    expect(
+      denied.columns.find((column) => column.id === 'unreadable'),
+    ).toBeUndefined();
+    expect(denied.query.projectableColumnIds).not.toContain('unreadable');
+
+    const authorized = policyToDataSurfaceDescriptor(policy, descriptor, {
+      authorizedColumnIds: ['unreadable'],
+    });
+    expect(
+      authorized.columns.find((column) => column.id === 'unreadable'),
+    ).toMatchObject({
+      readable: true,
+      capabilities: ['read', 'search', 'filter', 'sort', 'project'],
+    });
+    expect(authorized.query.projectableColumnIds).toContain('unreadable');
+  });
+
   it('cannot broaden static hidden/readability constraints', () => {
     const result = policyToDataSurfaceDescriptor(policy, descriptor, {
       staticHiddenColumnIds: ['title'],

--- a/packages/fields/src/data-surface.ts
+++ b/packages/fields/src/data-surface.ts
@@ -19,6 +19,8 @@ export interface FieldPolicyDataSurfaceOptions {
   staticHiddenColumnIds?: readonly string[];
   /** Structural roles are always retained when policy filters data columns. */
   roleByColumnId?: Readonly<Record<string, DataSurfaceColumnRole>>;
+  /** Explicit host authorization for otherwise restricted column ids. */
+  authorizedColumnIds?: readonly string[];
 }
 
 const POLICY_NARROWED_CAPABILITIES = new Set<DataSurfaceColumnCapability>([
@@ -43,6 +45,20 @@ function roleForColumn(
   options: FieldPolicyDataSurfaceOptions,
 ): DataSurfaceColumnRole | undefined {
   return column.role ?? options.roleByColumnId?.[column.id];
+}
+
+function isSensitiveColumn(column: DataSurfaceColumnDescriptor): boolean {
+  return column.sensitivity === 'sensitive' || column.sensitivity === 'secret';
+}
+
+function isAuthorizedColumn(
+  column: DataSurfaceColumnDescriptor,
+  options: FieldPolicyDataSurfaceOptions,
+): boolean {
+  return (
+    column.readable === true ||
+    options.authorizedColumnIds?.includes(column.id) === true
+  );
 }
 
 function isStructuralColumn(
@@ -86,19 +102,36 @@ function policyColumn(
   policy: ResolvedFieldPolicy | undefined,
   hiddenByStaticPolicy: boolean,
   structural: boolean,
+  restricted: boolean,
 ): DataSurfaceColumnDescriptor {
   // Computed, selection, action, and row-key columns have no manifest field
   // and are intentionally copied through unchanged. This is what keeps a
   // policy-aware descriptor usable by the same mounted table.
   if (structural) {
+    if (restricted) {
+      return {
+        ...column,
+        visibility: 'hidden',
+        readable: false,
+        capabilities: [],
+        operators: {},
+        searchOperators: [],
+        filterOperators: [],
+        sortOperators: [],
+      };
+    }
     return { ...column };
   }
 
   if (!policy) {
-    const unreadable = hiddenByStaticPolicy || column.readable === false;
+    const unreadable = hiddenByStaticPolicy || restricted;
     return {
       ...column,
-      ...(hiddenByStaticPolicy ? { visibility: 'hidden' as const } : {}),
+      ...(unreadable ? { visibility: 'hidden' as const } : {}),
+      ...(column.readable === undefined &&
+      (column.sensitivity === 'sensitive' || column.sensitivity === 'secret')
+        ? { readable: true }
+        : {}),
       ...(unreadable
         ? {
             readable: false,
@@ -113,7 +146,7 @@ function policyColumn(
   }
 
   const hidden = hiddenByStaticPolicy || policy.visibility === 'hidden';
-  const unreadable = hidden || column.readable === false;
+  const unreadable = hidden || restricted;
   const label = policy.label ?? column.label;
   const description = policy.help ?? column.description;
   return {
@@ -122,7 +155,7 @@ function policyColumn(
     ...(description ? { description } : {}),
     ...(policy.order === null ? {} : { order: policy.order }),
     visibility: policy.visibility,
-    readable: !hidden && column.readable !== false,
+    readable: !unreadable,
     capabilities: narrowCapabilities(column.capabilities, unreadable),
     ...(narrowOperators(column.operators, unreadable)
       ? { operators: narrowOperators(column.operators, unreadable) }
@@ -136,7 +169,7 @@ function policyColumn(
     ...(column.sortOperators
       ? { sortOperators: unreadable ? [] : [...column.sortOperators] }
       : {}),
-    ...(hiddenByStaticPolicy ? { visibility: 'hidden' as const } : {}),
+    ...(unreadable ? { visibility: 'hidden' as const } : {}),
   };
 }
 
@@ -167,13 +200,22 @@ export function policyToDataSurfaceDescriptor(
   const mapped = descriptor.columns.map((column, index) => {
     const field = policy.fields[policyFieldName(column, options)];
     const structural = isStructuralColumn(column, options);
+    const restricted =
+      (column.readable === false || isSensitiveColumn(column)) &&
+      !isAuthorizedColumn(column, options);
+    const rowKeyHidden =
+      column.id === rowKey &&
+      (staticHidden.has(column.id) ||
+        column.visibility === 'hidden' ||
+        field?.visibility === 'hidden');
     const effective = policyColumn(
       column,
       field,
-      staticHidden.has(column.id),
+      staticHidden.has(column.id) || column.visibility === 'hidden',
       structural,
+      restricted,
     );
-    return { column, effective, field, structural, index };
+    return { column, effective, field, structural, index, rowKeyHidden };
   });
 
   // A hidden data field must not be describable or restorable. The row key is
@@ -184,7 +226,9 @@ export function policyToDataSurfaceDescriptor(
     .filter(({ column, effective, structural }) => {
       const hidden =
         !structural &&
-        (staticHidden.has(column.id) || effective.visibility === 'hidden');
+        (staticHidden.has(column.id) ||
+          column.visibility === 'hidden' ||
+          effective.visibility === 'hidden');
       if (hidden) hiddenColumnIds.add(column.id);
       return !hidden || column.id === rowKey;
     })
@@ -195,8 +239,8 @@ export function policyToDataSurfaceDescriptor(
       const rightOrder = right.effective.order ?? Number.POSITIVE_INFINITY;
       return leftOrder - rightOrder || left.index - right.index;
     })
-    .map(({ effective, column }) =>
-      column.id === rowKey && hiddenColumnIds.has(column.id)
+    .map(({ effective, column, rowKeyHidden }) =>
+      column.id === rowKey && (hiddenColumnIds.has(column.id) || rowKeyHidden)
         ? {
             ...effective,
             visibility: 'hidden' as const,

--- a/packages/fields/src/data-surface.ts
+++ b/packages/fields/src/data-surface.ts
@@ -55,10 +55,7 @@ function isAuthorizedColumn(
   column: DataSurfaceColumnDescriptor,
   options: FieldPolicyDataSurfaceOptions,
 ): boolean {
-  return (
-    column.readable === true ||
-    options.authorizedColumnIds?.includes(column.id) === true
-  );
+  return options.authorizedColumnIds?.includes(column.id) === true;
 }
 
 function isStructuralColumn(

--- a/packages/fields/src/data-surface.ts
+++ b/packages/fields/src/data-surface.ts
@@ -119,9 +119,11 @@ function policyColumn(
         sortOperators: [],
       };
     }
+    const explicitlyAuthorized =
+      !restricted && (column.readable === false || isSensitiveColumn(column));
     return {
       ...column,
-      ...(column.readable === false ? { readable: true } : {}),
+      ...(explicitlyAuthorized ? { readable: true } : {}),
     };
   }
 

--- a/packages/fields/src/data-surface.ts
+++ b/packages/fields/src/data-surface.ts
@@ -1,0 +1,288 @@
+import type {
+  DataSurfaceActionDescriptor,
+  DataSurfaceColumnCapability,
+  DataSurfaceColumnDescriptor,
+  DataSurfaceColumnOperators,
+  DataSurfaceColumnRole,
+  DataSurfaceDescriptor,
+} from '@happyvertical/smrt-ui/data';
+import type {
+  ResolvedFieldPolicy,
+  ResolvedObjectFieldPolicy,
+} from './types.js';
+
+/** Optional host metadata for columns that do not come from a model field. */
+export interface FieldPolicyDataSurfaceOptions {
+  /** Map domain column ids to manifest field names without changing column ids. */
+  fieldNameByColumnId?: Readonly<Record<string, string>>;
+  /** Static visibility is a host constraint and can only be narrowed. */
+  staticHiddenColumnIds?: readonly string[];
+  /** Structural roles are always retained when policy filters data columns. */
+  roleByColumnId?: Readonly<Record<string, DataSurfaceColumnRole>>;
+}
+
+const POLICY_NARROWED_CAPABILITIES = new Set<DataSurfaceColumnCapability>([
+  'read',
+  'search',
+  'filter',
+  'sort',
+  'project',
+]);
+
+function policyFieldName(
+  column: DataSurfaceColumnDescriptor,
+  options: FieldPolicyDataSurfaceOptions,
+): string {
+  return (
+    column.fieldName ?? options.fieldNameByColumnId?.[column.id] ?? column.id
+  );
+}
+
+function roleForColumn(
+  column: DataSurfaceColumnDescriptor,
+  options: FieldPolicyDataSurfaceOptions,
+): DataSurfaceColumnRole | undefined {
+  return column.role ?? options.roleByColumnId?.[column.id];
+}
+
+function isStructuralColumn(
+  column: DataSurfaceColumnDescriptor,
+  options: FieldPolicyDataSurfaceOptions,
+): boolean {
+  const role = roleForColumn(column, options);
+  return (
+    role === 'computed' ||
+    role === 'row-key' ||
+    role === 'selection' ||
+    role === 'action'
+  );
+}
+
+function narrowOperators(
+  operators: DataSurfaceColumnOperators | undefined,
+  hidden: boolean,
+): DataSurfaceColumnOperators | undefined {
+  if (!operators) return undefined;
+  if (hidden) return {};
+  return {
+    ...(operators.search ? { search: [...operators.search] } : {}),
+    ...(operators.filter ? { filter: [...operators.filter] } : {}),
+    ...(operators.sort ? { sort: [...operators.sort] } : {}),
+  };
+}
+
+function narrowCapabilities(
+  capabilities: readonly DataSurfaceColumnCapability[],
+  hidden: boolean,
+): DataSurfaceColumnCapability[] {
+  if (hidden) return [];
+  return capabilities.filter((capability) =>
+    POLICY_NARROWED_CAPABILITIES.has(capability),
+  );
+}
+
+function policyColumn(
+  column: DataSurfaceColumnDescriptor,
+  policy: ResolvedFieldPolicy | undefined,
+  hiddenByStaticPolicy: boolean,
+  structural: boolean,
+): DataSurfaceColumnDescriptor {
+  // Computed, selection, action, and row-key columns have no manifest field
+  // and are intentionally copied through unchanged. This is what keeps a
+  // policy-aware descriptor usable by the same mounted table.
+  if (structural) {
+    return { ...column };
+  }
+
+  if (!policy) {
+    const unreadable = hiddenByStaticPolicy || column.readable === false;
+    return {
+      ...column,
+      ...(hiddenByStaticPolicy ? { visibility: 'hidden' as const } : {}),
+      ...(unreadable
+        ? {
+            readable: false,
+            capabilities: narrowCapabilities(column.capabilities, true),
+            ...(column.operators ? { operators: {} } : {}),
+            ...(column.searchOperators ? { searchOperators: [] } : {}),
+            ...(column.filterOperators ? { filterOperators: [] } : {}),
+            ...(column.sortOperators ? { sortOperators: [] } : {}),
+          }
+        : {}),
+    };
+  }
+
+  const hidden = hiddenByStaticPolicy || policy.visibility === 'hidden';
+  const unreadable = hidden || column.readable === false;
+  const label = policy.label ?? column.label;
+  const description = policy.help ?? column.description;
+  return {
+    ...column,
+    label,
+    ...(description ? { description } : {}),
+    ...(policy.order === null ? {} : { order: policy.order }),
+    visibility: policy.visibility,
+    readable: !hidden && column.readable !== false,
+    capabilities: narrowCapabilities(column.capabilities, unreadable),
+    ...(narrowOperators(column.operators, unreadable)
+      ? { operators: narrowOperators(column.operators, unreadable) }
+      : {}),
+    ...(column.searchOperators
+      ? { searchOperators: unreadable ? [] : [...column.searchOperators] }
+      : {}),
+    ...(column.filterOperators
+      ? { filterOperators: unreadable ? [] : [...column.filterOperators] }
+      : {}),
+    ...(column.sortOperators
+      ? { sortOperators: unreadable ? [] : [...column.sortOperators] }
+      : {}),
+    ...(hiddenByStaticPolicy ? { visibility: 'hidden' as const } : {}),
+  };
+}
+
+function actionUsesHiddenColumn(
+  action: DataSurfaceActionDescriptor,
+  hiddenColumnIds: ReadonlySet<string>,
+): boolean {
+  return (
+    action.columnIds?.some((columnId) => hiddenColumnIds.has(columnId)) ?? false
+  );
+}
+
+/**
+ * Apply an effective field policy to a mounted DataSurface descriptor.
+ *
+ * This adapter is deliberately outside smrt-ui: the UI contract remains
+ * domain-neutral while fields owns the policy-to-surface semantics. Static
+ * host constraints and policy restrictions only remove capabilities; they
+ * never reveal a field or rename a domain column id.
+ */
+export function policyToDataSurfaceDescriptor(
+  policy: ResolvedObjectFieldPolicy,
+  descriptor: DataSurfaceDescriptor,
+  options: FieldPolicyDataSurfaceOptions = {},
+): DataSurfaceDescriptor {
+  const staticHidden = new Set(options.staticHiddenColumnIds ?? []);
+  const rowKey = descriptor.rowKey;
+  const mapped = descriptor.columns.map((column, index) => {
+    const field = policy.fields[policyFieldName(column, options)];
+    const structural = isStructuralColumn(column, options);
+    const effective = policyColumn(
+      column,
+      field,
+      staticHidden.has(column.id),
+      structural,
+    );
+    return { column, effective, field, structural, index };
+  });
+
+  // A hidden data field must not be describable or restorable. The row key is
+  // the one technical exception: mounted surfaces must retain stable identity,
+  // but it has no read/query capabilities when policy-hidden.
+  const hiddenColumnIds = new Set<string>();
+  const columns = mapped
+    .filter(({ column, effective, structural }) => {
+      const hidden =
+        !structural &&
+        (staticHidden.has(column.id) || effective.visibility === 'hidden');
+      if (hidden) hiddenColumnIds.add(column.id);
+      return !hidden || column.id === rowKey;
+    })
+    .sort((left, right) => {
+      if (left.column.id === rowKey) return -1;
+      if (right.column.id === rowKey) return 1;
+      const leftOrder = left.effective.order ?? Number.POSITIVE_INFINITY;
+      const rightOrder = right.effective.order ?? Number.POSITIVE_INFINITY;
+      return leftOrder - rightOrder || left.index - right.index;
+    })
+    .map(({ effective, column }) =>
+      column.id === rowKey && hiddenColumnIds.has(column.id)
+        ? {
+            ...effective,
+            visibility: 'hidden' as const,
+            readable: false,
+            capabilities: [],
+            operators: {},
+            searchOperators: [],
+            filterOperators: [],
+            sortOperators: [],
+          }
+        : effective,
+    );
+
+  const visibleIds = new Set(columns.map((column) => column.id));
+  const hasCapability = (
+    columnId: string,
+    capability: DataSurfaceColumnCapability,
+  ): boolean => {
+    const column = columns.find((candidate) => candidate.id === columnId);
+    return column?.capabilities.includes(capability) ?? false;
+  };
+  const allowlist = (
+    ids: readonly string[] | undefined,
+    capability: DataSurfaceColumnCapability,
+  ): string[] | undefined =>
+    ids
+      ? ids.filter(
+          (columnId) =>
+            visibleIds.has(columnId) && hasCapability(columnId, capability),
+        )
+      : undefined;
+
+  const actions = descriptor.actions
+    .filter((action) => !actionUsesHiddenColumn(action, hiddenColumnIds))
+    .map((action) => ({
+      ...action,
+      ...(action.columnIds
+        ? {
+            columnIds: action.columnIds.filter((columnId) =>
+              visibleIds.has(columnId),
+            ),
+          }
+        : {}),
+    }));
+
+  return {
+    ...descriptor,
+    columns,
+    query: {
+      ...descriptor.query,
+      projectableColumnIds:
+        allowlist(descriptor.query.projectableColumnIds, 'project') ?? [],
+      ...(allowlist(descriptor.query.searchableColumnIds, 'search')
+        ? {
+            searchableColumnIds: allowlist(
+              descriptor.query.searchableColumnIds,
+              'search',
+            ),
+          }
+        : descriptor.query.searchableColumnIds
+          ? { searchableColumnIds: [] }
+          : {}),
+      ...(allowlist(descriptor.query.filterableColumnIds, 'filter')
+        ? {
+            filterableColumnIds: allowlist(
+              descriptor.query.filterableColumnIds,
+              'filter',
+            ),
+          }
+        : descriptor.query.filterableColumnIds
+          ? { filterableColumnIds: [] }
+          : {}),
+      ...(allowlist(descriptor.query.sortableColumnIds, 'sort')
+        ? {
+            sortableColumnIds: allowlist(
+              descriptor.query.sortableColumnIds,
+              'sort',
+            ),
+          }
+        : descriptor.query.sortableColumnIds
+          ? { sortableColumnIds: [] }
+          : {}),
+    },
+    actions,
+  };
+}
+
+/** Descriptive alias for hosts that treat policy application as a transform. */
+export const applyFieldPolicyToDataSurface = policyToDataSurfaceDescriptor;

--- a/packages/fields/src/data-surface.ts
+++ b/packages/fields/src/data-surface.ts
@@ -104,11 +104,13 @@ function policyColumn(
   structural: boolean,
   restricted: boolean,
 ): DataSurfaceColumnDescriptor {
+  const hidden = hiddenByStaticPolicy || policy?.visibility === 'hidden';
+
   // Computed, selection, action, and row-key columns have no manifest field
-  // and are intentionally copied through unchanged. This is what keeps a
-  // policy-aware descriptor usable by the same mounted table.
+  // and are intentionally copied through unchanged when unrestricted. Hidden
+  // structural columns still must not remain discoverable or executable.
   if (structural) {
-    if (restricted) {
+    if (hidden || restricted) {
       return {
         ...column,
         visibility: 'hidden',
@@ -145,7 +147,6 @@ function policyColumn(
     };
   }
 
-  const hidden = hiddenByStaticPolicy || policy.visibility === 'hidden';
   const unreadable = hidden || restricted;
   const label = policy.label ?? column.label;
   const description = policy.help ?? column.description;
@@ -223,13 +224,12 @@ export function policyToDataSurfaceDescriptor(
   // but it has no read/query capabilities when policy-hidden.
   const hiddenColumnIds = new Set<string>();
   const columns = mapped
-    .filter(({ column, effective, structural }) => {
+    .filter(({ column, effective }) => {
       const hidden =
-        !structural &&
-        (staticHidden.has(column.id) ||
-          column.visibility === 'hidden' ||
-          effective.visibility === 'hidden');
-      if (hidden) hiddenColumnIds.add(column.id);
+        staticHidden.has(column.id) ||
+        column.visibility === 'hidden' ||
+        effective.visibility === 'hidden';
+      if (hidden && column.id !== rowKey) hiddenColumnIds.add(column.id);
       return !hidden || column.id === rowKey;
     })
     .sort((left, right) => {

--- a/packages/fields/src/data-surface.ts
+++ b/packages/fields/src/data-surface.ts
@@ -119,11 +119,15 @@ function policyColumn(
         sortOperators: [],
       };
     }
-    return { ...column };
+    return {
+      ...column,
+      ...(column.readable === false ? { readable: true } : {}),
+    };
   }
 
   if (!policy) {
     const unreadable = hiddenByStaticPolicy || restricted;
+    const explicitlyAuthorized = column.readable === false && !restricted;
     return {
       ...column,
       ...(unreadable ? { visibility: 'hidden' as const } : {}),
@@ -131,6 +135,7 @@ function policyColumn(
       (column.sensitivity === 'sensitive' || column.sensitivity === 'secret')
         ? { readable: true }
         : {}),
+      ...(explicitlyAuthorized ? { readable: true } : {}),
       ...(unreadable
         ? {
             readable: false,

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -33,6 +33,11 @@ export {
   serializeHistogramSample,
 } from './collections/FieldUsageCounterCollection.js';
 export {
+  applyFieldPolicyToDataSurface,
+  type FieldPolicyDataSurfaceOptions,
+  policyToDataSurfaceDescriptor,
+} from './data-surface.js';
+export {
   assertDefaultValueMatchesFieldType,
   buildCodeSeedDelta,
   buildCodeSeedVisibility,

--- a/packages/fields/src/svelte/__tests__/ObjectForm.test.ts
+++ b/packages/fields/src/svelte/__tests__/ObjectForm.test.ts
@@ -6,6 +6,7 @@ import {
   SmrtObject,
   smrt,
 } from '@happyvertical/smrt-core';
+import type { DataSurfaceDescriptor } from '@happyvertical/smrt-ui/data';
 import {
   expectNoA11yViolations,
   fireEvent,
@@ -15,6 +16,7 @@ import {
 } from '@happyvertical/smrt-vitest/svelte';
 import { tick } from 'svelte';
 import { describe, expect, it, vi } from 'vitest';
+import { policyToDataSurfaceDescriptor } from '../../data-surface.js';
 import type { ResolvedObjectFieldPolicy } from '../../types.js';
 import FieldInput from '../components/FieldInput.svelte';
 import type { ObjectFormProps } from '../components/ObjectForm.svelte';
@@ -197,6 +199,55 @@ describe('ObjectForm selection and adapters', () => {
         { id: 'metadata', hidden: true },
       ]),
     ]).toEqual(['name', 'computed', 'actions']);
+  });
+
+  it('keeps DataTable visibility aligned with DataSurface restrictions', () => {
+    const columns = [
+      { id: 'id', readable: true },
+      { id: 'public' },
+      { id: 'sensitive', sensitivity: 'sensitive' as const, readable: true },
+      { id: 'private', readable: false },
+    ];
+    const surface: DataSurfaceDescriptor = {
+      version: 1,
+      identity: { surfaceId: 'parity', kind: 'table' },
+      schemaVersion: 1,
+      label: 'Parity',
+      rowKey: 'id',
+      columns: columns.map((column) => ({
+        ...column,
+        label: column.id,
+        capabilities: ['read', 'project'],
+      })),
+      query: {
+        modes: ['rows'],
+        projectableColumnIds: columns.map((column) => column.id),
+      },
+      controls: [],
+      actions: [],
+      limits: { maxQueryRows: 10, maxQueryBytes: 1000, maxSelectionSize: 10 },
+    };
+
+    const dataSurface = policyToDataSurfaceDescriptor(policy, surface);
+    const dataTable = policyToVisibleColumnIds(policy, columns);
+    expect([...dataTable]).toEqual(
+      dataSurface.columns.map((column) => column.id),
+    );
+
+    const authorizedDataTable = policyToVisibleColumnIds(
+      policy,
+      columns,
+      {},
+      { authorizedColumnIds: ['sensitive', 'private'] },
+    );
+    const authorizedDataSurface = policyToDataSurfaceDescriptor(
+      policy,
+      surface,
+      { authorizedColumnIds: ['sensitive', 'private'] },
+    );
+    expect([...authorizedDataTable]).toEqual(
+      authorizedDataSurface.columns.map((column) => column.id),
+    );
   });
 
   it('prefers field overrides to type overrides and keeps registries isolated per app', () => {

--- a/packages/fields/src/svelte/__tests__/ObjectForm.test.ts
+++ b/packages/fields/src/svelte/__tests__/ObjectForm.test.ts
@@ -248,6 +248,12 @@ describe('ObjectForm selection and adapters', () => {
     expect([...authorizedDataTable]).toEqual(
       authorizedDataSurface.columns.map((column) => column.id),
     );
+    expect(
+      authorizedDataSurface.columns.find((column) => column.id === 'private'),
+    ).toMatchObject({
+      readable: true,
+      capabilities: ['read', 'project'],
+    });
   });
 
   it('prefers field overrides to type overrides and keeps registries isolated per app', () => {

--- a/packages/fields/src/svelte/data-table.ts
+++ b/packages/fields/src/svelte/data-table.ts
@@ -6,6 +6,21 @@ export interface PolicyDataTableColumn {
   /** DataTable still enforces this independently; excluding it here is useful
    * to callers that inspect the returned set before rendering. */
   hidden?: boolean;
+  sensitivity?: 'sensitive' | 'secret';
+  readable?: boolean;
+}
+
+export interface PolicyDataTableOptions {
+  /** Explicit host authorization for otherwise restricted columns. */
+  authorizedColumnIds?: readonly string[];
+}
+
+function isRestrictedColumn(column: PolicyDataTableColumn): boolean {
+  return (
+    column.readable === false ||
+    column.sensitivity === 'sensitive' ||
+    column.sensitivity === 'secret'
+  );
 }
 
 /**
@@ -19,10 +34,17 @@ export function policyToVisibleColumnIds(
   policy: ResolvedObjectFieldPolicy,
   columns: readonly PolicyDataTableColumn[],
   fieldNameByColumnId: Readonly<Record<string, string>> = {},
+  options: PolicyDataTableOptions = {},
 ): Set<string> {
   const visible = new Set<string>();
   for (const column of columns) {
     if (column.hidden) continue;
+    if (
+      isRestrictedColumn(column) &&
+      !options.authorizedColumnIds?.includes(column.id)
+    ) {
+      continue;
+    }
     const fieldName = fieldNameByColumnId[column.id] ?? column.id;
     const field = policy.fields[fieldName];
     if (field?.visibility !== 'hidden') visible.add(column.id);

--- a/packages/fields/src/svelte/index.ts
+++ b/packages/fields/src/svelte/index.ts
@@ -75,6 +75,11 @@ export type FieldPolicySuggestionQueueProps = ComponentProps<
 >;
 export type PolicyFieldProps = ComponentProps<typeof PolicyField>;
 
+export {
+  applyFieldPolicyToDataSurface,
+  type FieldPolicyDataSurfaceOptions,
+  policyToDataSurfaceDescriptor,
+} from '../data-surface.js';
 export type {
   FieldPolicyCatalogObjectSummary,
   FieldPolicyDetailItem,

--- a/packages/fields/src/svelte/index.ts
+++ b/packages/fields/src/svelte/index.ts
@@ -75,11 +75,6 @@ export type FieldPolicySuggestionQueueProps = ComponentProps<
 >;
 export type PolicyFieldProps = ComponentProps<typeof PolicyField>;
 
-export {
-  applyFieldPolicyToDataSurface,
-  type FieldPolicyDataSurfaceOptions,
-  policyToDataSurfaceDescriptor,
-} from '../data-surface.js';
 export type {
   FieldPolicyCatalogObjectSummary,
   FieldPolicyDetailItem,
@@ -102,7 +97,10 @@ export {
   setFieldPolicyContext,
   tryGetFieldPolicyContext,
 } from './context.svelte.js';
-export type { PolicyDataTableColumn } from './data-table.js';
+export type {
+  PolicyDataTableColumn,
+  PolicyDataTableOptions,
+} from './data-table.js';
 export { policyToVisibleColumnIds } from './data-table.js';
 export type {
   FieldPolicyEditorAdapter,

--- a/packages/smrt-ui/README.md
+++ b/packages/smrt-ui/README.md
@@ -421,6 +421,12 @@ Toolbar snapshots also advance their revision when the host updates exposed
 uncontrolled `search` or `view` props, so a command based on an earlier view is
 rejected as stale instead of overwriting host state.
 
+DataSurface columns may also carry domain-neutral policy metadata (`fieldName`,
+`visibility`, `order`, `role`, `responsivePriority`, `readable`, and per-column
+operator allowlists). Domain packages such as `@happyvertical/smrt-fields`
+apply their effective policy above this package; `smrt-ui` validates and
+serializes the metadata without owning field authorization or policy rules.
+
 ## Themes
 
 `@happyvertical/smrt-ui/themes` is the canonical theme API and includes the

--- a/packages/smrt-ui/src/components/data/__tests__/data-surface.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/data-surface.test.ts
@@ -8,6 +8,7 @@ import {
   type DataSurfaceQueryResult,
   type DataSurfaceVisibleCommand,
   normalizeDataSurfaceActionRequest,
+  normalizeDataSurfaceDescriptor,
   normalizeDataSurfaceQueryRequest,
   normalizeDataSurfaceVisibleCommand,
 } from '../data-surface.js';
@@ -108,6 +109,23 @@ function registerFixture(
 }
 
 describe('data surface registry', () => {
+  it('identifies unknown action columns in descriptor validation errors', () => {
+    expect(() =>
+      normalizeDataSurfaceDescriptor(
+        descriptor({
+          actions: [
+            {
+              id: 'archive',
+              label: 'Archive',
+              selectionScopes: ['explicit-ids'],
+              columnIds: ['missing'],
+            },
+          ],
+        }),
+      ),
+    ).toThrow('Unknown DataSurface action column id: missing');
+  });
+
   it('aligns bounded query result shapes with each query kind', () => {
     const results = [
       {

--- a/packages/smrt-ui/src/components/data/data-surface.ts
+++ b/packages/smrt-ui/src/components/data/data-surface.ts
@@ -42,12 +42,49 @@ export type DataSurfaceColumnCapability =
   | 'sort'
   | 'project';
 
+/** Presentation tier emitted by policy-aware domain adapters. */
+export type DataSurfaceColumnVisibility = 'basic' | 'advanced' | 'hidden';
+
+/** A domain-neutral column role. Adapters use roles to protect structural columns. */
+export type DataSurfaceColumnRole =
+  | 'data'
+  | 'status'
+  | 'computed'
+  | 'row-key'
+  | 'selection'
+  | 'action';
+
+/** Operator allowlists are intentionally strings: #2444 owns query semantics. */
+export interface DataSurfaceColumnOperators {
+  search?: string[];
+  filter?: string[];
+  sort?: string[];
+}
+
 export interface DataSurfaceColumnDescriptor {
   id: string;
   label: string;
   description?: string;
   sensitivity?: DataSurfaceSensitivity;
   capabilities: DataSurfaceColumnCapability[];
+  /** Domain field identity; never accepted as a request path. */
+  fieldName?: string;
+  /** Effective policy visibility, when a domain adapter supplies one. */
+  visibility?: DataSurfaceColumnVisibility;
+  /** Stable policy order; domain column ids remain unchanged. */
+  order?: number;
+  /** Structural columns are preserved even when field policy narrows data columns. */
+  role?: DataSurfaceColumnRole;
+  /** Responsive adapters consume this without importing DataTable types. */
+  responsivePriority?: number;
+  /** Per-operation operator allowlists, narrowed by policy adapters. */
+  operators?: DataSurfaceColumnOperators;
+  /** Explicit aliases for adapters that mirror the canonical query schema. */
+  searchOperators?: string[];
+  filterOperators?: string[];
+  sortOperators?: string[];
+  /** Explicit readability is useful when read capability is policy-gated. */
+  readable?: boolean;
 }
 
 /** #2444 owns the canonical query language; this declares only its bounds. */
@@ -57,6 +94,10 @@ export interface DataSurfaceQueryCapabilities {
   modes: DataSurfaceQueryMode[];
   /** Explicit allowlist; field paths are not accepted in requests. */
   projectableColumnIds: string[];
+  /** Explicit allowlists for non-projection query operations. */
+  searchableColumnIds?: string[];
+  filterableColumnIds?: string[];
+  sortableColumnIds?: string[];
 }
 
 export interface DataSurfaceVisibleControl {
@@ -78,6 +119,8 @@ export interface DataSurfaceActionDescriptor {
   sensitivity?: DataSurfaceSensitivity;
   selectionScopes: DataSurfaceSelectionScope[];
   requiresConfirmation?: boolean;
+  /** Optional column dependencies used by field-policy adapters. */
+  columnIds?: string[];
 }
 
 /** Per-surface limits; generic envelopes use DATA_SURFACE_MAX_REQUEST_BYTES. */
@@ -330,6 +373,19 @@ const SELECTION_SCOPES = new Set<DataSurfaceSelectionScope>([
   'explicit-ids',
   'all-matching',
 ]);
+const COLUMN_VISIBILITIES = new Set<DataSurfaceColumnVisibility>([
+  'basic',
+  'advanced',
+  'hidden',
+]);
+const COLUMN_ROLES = new Set<DataSurfaceColumnRole>([
+  'data',
+  'status',
+  'computed',
+  'row-key',
+  'selection',
+  'action',
+]);
 const FORBIDDEN_BOUNDARY_KEYS = new Set([
   'tenant',
   'tenantid',
@@ -390,6 +446,17 @@ function stringValue(value: unknown, label: string): string {
 function optionalString(value: unknown, label: string): string | undefined {
   if (value === undefined) return undefined;
   return stringValue(value, label);
+}
+
+function optionalFiniteNumber(
+  value: unknown,
+  label: string,
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new TypeError(`${label} must be a finite number`);
+  }
+  return value;
 }
 
 function positiveInteger(value: unknown, label: string): number {
@@ -731,6 +798,122 @@ function normalizeSensitivity(
   return sensitivity;
 }
 
+function normalizeColumnOperators(
+  value: unknown,
+  label: string,
+): DataSurfaceColumnOperators | undefined {
+  if (value === undefined) return undefined;
+  const operators = plainObject(value, label);
+  exactKeys(operators, ['search', 'filter', 'sort'], label);
+  const search =
+    operators.search === undefined
+      ? undefined
+      : normalizeStringArray(operators.search, `${label} search operators`, {
+          sort: true,
+        });
+  const filter =
+    operators.filter === undefined
+      ? undefined
+      : normalizeStringArray(operators.filter, `${label} filter operators`, {
+          sort: true,
+        });
+  const sort =
+    operators.sort === undefined
+      ? undefined
+      : normalizeStringArray(operators.sort, `${label} sort operators`, {
+          sort: true,
+        });
+  if (!search && !filter && !sort) return {};
+  return {
+    ...(search ? { search } : {}),
+    ...(filter ? { filter } : {}),
+    ...(sort ? { sort } : {}),
+  };
+}
+
+function normalizeColumnDescriptorMetadata(
+  column: Record<string, unknown>,
+): Pick<
+  DataSurfaceColumnDescriptor,
+  | 'fieldName'
+  | 'visibility'
+  | 'order'
+  | 'role'
+  | 'responsivePriority'
+  | 'operators'
+  | 'searchOperators'
+  | 'filterOperators'
+  | 'sortOperators'
+  | 'readable'
+> {
+  const fieldName = optionalString(
+    column.fieldName,
+    'DataSurface column field name',
+  );
+  const rawVisibility = optionalString(
+    column.visibility,
+    'DataSurface column visibility',
+  );
+  if (
+    rawVisibility &&
+    !COLUMN_VISIBILITIES.has(rawVisibility as DataSurfaceColumnVisibility)
+  ) {
+    throw new TypeError(
+      `Unsupported DataSurface column visibility: ${rawVisibility}`,
+    );
+  }
+  const rawRole = optionalString(column.role, 'DataSurface column role');
+  if (rawRole && !COLUMN_ROLES.has(rawRole as DataSurfaceColumnRole)) {
+    throw new TypeError(`Unsupported DataSurface column role: ${rawRole}`);
+  }
+  if (column.readable !== undefined && typeof column.readable !== 'boolean') {
+    throw new TypeError('DataSurface column readable must be boolean');
+  }
+  const normalizeAliasOperators = (
+    key: 'searchOperators' | 'filterOperators' | 'sortOperators',
+  ): string[] | undefined =>
+    column[key] === undefined
+      ? undefined
+      : normalizeStringArray(column[key], `DataSurface column ${key}`, {
+          sort: true,
+        });
+  const searchOperators = normalizeAliasOperators('searchOperators');
+  const filterOperators = normalizeAliasOperators('filterOperators');
+  const sortOperators = normalizeAliasOperators('sortOperators');
+  return {
+    ...(fieldName ? { fieldName } : {}),
+    ...(rawVisibility
+      ? { visibility: rawVisibility as DataSurfaceColumnVisibility }
+      : {}),
+    ...(column.order === undefined
+      ? {}
+      : {
+          order: optionalFiniteNumber(column.order, 'DataSurface column order'),
+        }),
+    ...(rawRole ? { role: rawRole as DataSurfaceColumnRole } : {}),
+    ...(column.responsivePriority === undefined
+      ? {}
+      : {
+          responsivePriority: optionalFiniteNumber(
+            column.responsivePriority,
+            'DataSurface column responsive priority',
+          ),
+        }),
+    ...(column.operators === undefined
+      ? {}
+      : {
+          operators: normalizeColumnOperators(
+            column.operators,
+            'DataSurface column operators',
+          ),
+        }),
+    ...(searchOperators ? { searchOperators } : {}),
+    ...(filterOperators ? { filterOperators } : {}),
+    ...(sortOperators ? { sortOperators } : {}),
+    ...(column.readable === undefined ? {} : { readable: column.readable }),
+  };
+}
+
 function normalizeSelection(value: unknown): DataSurfaceSelectionReference {
   const object = plainObject(value, 'DataSurface selection');
   const scope = stringValue(
@@ -825,7 +1008,23 @@ export function normalizeDataSurfaceDescriptor(
     const column = plainObject(value, 'DataSurface column');
     exactKeys(
       column,
-      ['id', 'label', 'description', 'sensitivity', 'capabilities'],
+      [
+        'id',
+        'label',
+        'description',
+        'sensitivity',
+        'capabilities',
+        'fieldName',
+        'visibility',
+        'order',
+        'role',
+        'responsivePriority',
+        'operators',
+        'searchOperators',
+        'filterOperators',
+        'sortOperators',
+        'readable',
+      ],
       'DataSurface column',
     );
     const sensitivity = normalizeSensitivity(
@@ -836,6 +1035,7 @@ export function normalizeDataSurfaceDescriptor(
       column.description,
       'DataSurface column description',
     );
+    const metadata = normalizeColumnDescriptorMetadata(column);
     return {
       id: stringValue(column.id, 'DataSurface column id'),
       label: stringValue(column.label, 'DataSurface column label'),
@@ -845,6 +1045,7 @@ export function normalizeDataSurfaceDescriptor(
         column.capabilities,
         'DataSurface column capabilities',
       ),
+      ...metadata,
     };
   });
   if (new Set(columns.map((column) => column.id)).size !== columns.length) {
@@ -854,7 +1055,13 @@ export function normalizeDataSurfaceDescriptor(
   const query = plainObject(object.query, 'DataSurface query capabilities');
   exactKeys(
     query,
-    ['modes', 'projectableColumnIds'],
+    [
+      'modes',
+      'projectableColumnIds',
+      'searchableColumnIds',
+      'filterableColumnIds',
+      'sortableColumnIds',
+    ],
     'DataSurface query capabilities',
   );
   const modes = normalizeStringArray(query.modes, 'DataSurface query modes', {
@@ -878,6 +1085,31 @@ export function normalizeDataSurfaceDescriptor(
       );
     }
   }
+  const queryColumnAllowlist = (
+    value: unknown,
+    label: string,
+  ): string[] | undefined => {
+    if (value === undefined) return undefined;
+    const ids = normalizeStringArray(value, label, { sort: true });
+    for (const columnId of ids) {
+      if (!knownColumns.has(columnId)) {
+        throw new TypeError(`Unknown ${label}: ${columnId}`);
+      }
+    }
+    return ids;
+  };
+  const searchableColumnIds = queryColumnAllowlist(
+    query.searchableColumnIds,
+    'searchable DataSurface column',
+  );
+  const filterableColumnIds = queryColumnAllowlist(
+    query.filterableColumnIds,
+    'filterable DataSurface column',
+  );
+  const sortableColumnIds = queryColumnAllowlist(
+    query.sortableColumnIds,
+    'sortable DataSurface column',
+  );
 
   if (!Array.isArray(object.controls)) {
     throw new TypeError('DataSurface controls must be an array');
@@ -913,6 +1145,7 @@ export function normalizeDataSurfaceDescriptor(
         'sensitivity',
         'selectionScopes',
         'requiresConfirmation',
+        'columnIds',
       ],
       'DataSurface action',
     );
@@ -944,6 +1177,19 @@ export function normalizeDataSurfaceDescriptor(
       action.description,
       'DataSurface action description',
     );
+    const columnIds =
+      action.columnIds === undefined
+        ? undefined
+        : normalizeStringArray(
+            action.columnIds,
+            'DataSurface action column ids',
+            {
+              sort: true,
+            },
+          );
+    if (columnIds?.some((columnId) => !knownColumns.has(columnId))) {
+      throw new TypeError('Unknown DataSurface action column id');
+    }
     return {
       id: stringValue(action.id, 'DataSurface action id'),
       label: stringValue(action.label, 'DataSurface action label'),
@@ -953,6 +1199,7 @@ export function normalizeDataSurfaceDescriptor(
       ...(action.requiresConfirmation === undefined
         ? {}
         : { requiresConfirmation: action.requiresConfirmation }),
+      ...(columnIds ? { columnIds } : {}),
     };
   });
   if (new Set(actions.map((action) => action.id)).size !== actions.length) {
@@ -994,7 +1241,13 @@ export function normalizeDataSurfaceDescriptor(
     ...(description ? { description } : {}),
     rowKey,
     columns,
-    query: { modes, projectableColumnIds },
+    query: {
+      modes,
+      projectableColumnIds,
+      ...(searchableColumnIds ? { searchableColumnIds } : {}),
+      ...(filterableColumnIds ? { filterableColumnIds } : {}),
+      ...(sortableColumnIds ? { sortableColumnIds } : {}),
+    },
     controls,
     actions,
     limits: {

--- a/packages/smrt-ui/src/components/data/data-surface.ts
+++ b/packages/smrt-ui/src/components/data/data-surface.ts
@@ -1188,7 +1188,12 @@ export function normalizeDataSurfaceDescriptor(
             },
           );
     if (columnIds?.some((columnId) => !knownColumns.has(columnId))) {
-      throw new TypeError('Unknown DataSurface action column id');
+      const unknownColumnId = columnIds.find(
+        (columnId) => !knownColumns.has(columnId),
+      );
+      throw new TypeError(
+        `Unknown DataSurface action column id: ${unknownColumnId}`,
+      );
     }
     return {
       id: stringValue(action.id, 'DataSurface action id'),

--- a/tsconfig.package-build.json
+++ b/tsconfig.package-build.json
@@ -4,6 +4,9 @@
     "baseUrl": ".",
     "types": ["node", "svelte"],
     "paths": {
+      "@happyvertical/smrt-ui/data": [
+        "packages/smrt-ui/src/components/data/index.ts"
+      ],
       "@happyvertical/smrt-mobile-contract": [
         "packages/smrt-mobile-contract/src/index.ts"
       ],

--- a/vite.config.base.ts
+++ b/vite.config.base.ts
@@ -162,6 +162,17 @@ function rewriteWorkspaceDeclarationImports(
       .replace(/\.[mc]?ts$/, '')
       .replace(/\.js$/, '');
 
+    // Keep the published smrt-ui data contract stable when declaration
+    // generation resolves the workspace source path first. Its public export
+    // is `@happyvertical/smrt-ui/data`, while the source entry lives under
+    // `src/components/data/index.ts`.
+    if (
+      targetPackage.name === '@happyvertical/smrt-ui' &&
+      subpath === 'components/data/index'
+    ) {
+      return `${targetPackage.name}/data`;
+    }
+
     if (subpath === 'index') {
       return targetPackage.name;
     }


### PR DESCRIPTION
## Summary
- Applies field policy consistently to DataSurface and DataTable metadata.
- Removes denied structural fields from projections, actions, queries, and capabilities while preserving the row-key identity exception.
- Keeps explicitly authorized sensitive fields readable and capability-consistent.

## Validation
- fields: 258 tests; smrt-ui: 642 tests
- fields and smrt-ui typecheck/build
- fields and smrt-ui packed-export verification
- Biome, diff check, and strict knowledge freshness
- review-cycle: preliminary and final high-risk reviews clean on this head

Closes #2449

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-2449-conflict-repair-20260823163643",
  "issue": 2449,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "fields 258 tests and smrt-ui 642 tests",
    "fields and smrt-ui typecheck/build",
    "fields and smrt-ui packed-export verification",
    "Biome, diff check, knowledge freshness, pre-push policy checks",
    "review-cycle: preliminary and final high-risk reviews clean on exact head"
  ]
}