### PR TITLE
feat(chat): bridge authenticated data surface commands

### DIFF
--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -18,7 +18,8 @@ bound WebSocket session or origin-checked `postMessage` peer). Never copy
 `send` only to the authenticated peer.
 
 The bridge validates and bounds every command, acknowledgement, and event
-before it crosses the server boundary. `authorize` remains the application’s
+before it crosses the server boundary, using the shared identifier limit from
+`@happyvertical/smrt-ui/data-surface`. `authorize` remains the application’s
 responsibility and must fail closed. Commands are scoped to the configured
 session/source, expire by TTL, and are idempotent by command ID plus command
 signature; replay retention is bounded and capacity exhaustion returns an

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -8,6 +8,24 @@ Chat rooms, DMs, threads, and agent conversations for the s-m-r-t framework. Sup
 pnpm add @happyvertical/smrt-chat
 ```
 
+## Data-surface bridge security
+
+The `./data-surface-bridge` entry point is the server half of the browser data-
+surface protocol. Supply a transport adapter whose `subscribe` callback
+provides peer metadata derived from authenticated connection state (such as a
+bound WebSocket session or origin-checked `postMessage` peer). Never copy
+`sessionId` or `source` from an untrusted message into that metadata, and route
+`send` only to the authenticated peer.
+
+The bridge validates and bounds every command, acknowledgement, and event
+before it crosses the server boundary. `authorize` remains the application’s
+responsibility and must fail closed. Commands are scoped to the configured
+session/source, expire by TTL, and are idempotent by command ID plus command
+signature; replay retention is bounded and capacity exhaustion returns an
+explicit `replay_capacity_exceeded` outcome. Invalid, stale, disconnected, or
+transport-failed work resolves with a protocol failure reason rather than
+trusting browser data or throwing raw transport errors.
+
 ## Usage
 
 ### Local dev server

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -15,6 +15,14 @@
       "types": "./dist/client.d.ts",
       "import": "./dist/client.js"
     },
+    "./data-surface-bridge": {
+      "types": "./dist/data-surface-bridge.d.ts",
+      "import": "./dist/data-surface-bridge.js"
+    },
+    "./data-surface": {
+      "types": "./dist/data-surface-bridge.d.ts",
+      "import": "./dist/data-surface-bridge.js"
+    },
     "./ui": {
       "types": "./dist/ui.d.ts",
       "import": "./dist/ui.js"

--- a/packages/chat/src/data-surface-bridge.test.ts
+++ b/packages/chat/src/data-surface-bridge.test.ts
@@ -182,7 +182,11 @@ describe('server data-surface bridge', () => {
       ttlMs: 1_000,
       timeoutMs: 500,
     });
-    const pending = bridge.send(command);
+    let settled = false;
+    const pending = bridge.send(command).then((result) => {
+      settled = true;
+      return result;
+    });
     await Promise.resolve();
     const request = link.sent[0] as DataSurfaceCommandRequest;
     link.receive(
@@ -240,6 +244,8 @@ describe('server data-surface bridge', () => {
     link.receive(ack(request), { sessionId: 'session-1', source: 'attacker' });
     link.receive(ack(request), { sessionId: 'attacker', source: 'browser-1' });
     expect(link.sent).toHaveLength(1);
+    await Promise.resolve();
+    expect(settled).toBe(false);
 
     link.receive(ack(request));
     await expect(pending).resolves.toMatchObject({
@@ -247,6 +253,7 @@ describe('server data-surface bridge', () => {
       commandId: request.commandId,
       identity,
       expiresAt: request.expiresAt,
+      snapshot,
     });
     bridge.dispose();
   });

--- a/packages/chat/src/data-surface-bridge.test.ts
+++ b/packages/chat/src/data-surface-bridge.test.ts
@@ -1,0 +1,167 @@
+import type {
+  DataSurfaceIdentity,
+  DataSurfaceVisibleCommand,
+} from '@happyvertical/smrt-ui/data';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createDataSurfaceCommandBridge,
+  type DataSurfaceBridgeMessage,
+  type DataSurfaceCommandRequest,
+} from './data-surface-bridge.js';
+
+const identity: DataSurfaceIdentity = { surfaceId: 'orders', kind: 'table' };
+const command: DataSurfaceVisibleCommand = {
+  version: 1,
+  commandId: 'command-1',
+  identity,
+  expectedRevision: 3,
+  controlId: 'refresh',
+};
+
+function transport() {
+  const listeners = new Set<(message: unknown) => void>();
+  const statuses = new Set<
+    (state: 'connected' | 'disconnected' | 'reconnecting') => void
+  >();
+  const sent: DataSurfaceBridgeMessage[] = [];
+  return {
+    sent,
+    send: vi.fn((message: DataSurfaceBridgeMessage) => sent.push(message)),
+    subscribe(listener: (message: unknown) => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    subscribeStatus(
+      listener: (state: 'connected' | 'disconnected' | 'reconnecting') => void,
+    ) {
+      statuses.add(listener);
+      return () => statuses.delete(listener);
+    },
+    receive(message: unknown) {
+      for (const listener of listeners) listener(message);
+    },
+    status(state: 'connected' | 'disconnected' | 'reconnecting') {
+      for (const listener of statuses) listener(state);
+    },
+  };
+}
+
+function ack(
+  request: DataSurfaceCommandRequest,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    type: 'data-surface.ack' as const,
+    version: 1 as const,
+    commandId: request.commandId,
+    sessionId: request.sessionId,
+    source: 'browser-1',
+    expiresAt: request.expiresAt,
+    identity,
+    expectedRevision: request.expectedRevision,
+    ok: true,
+    revision: request.expectedRevision + 1,
+    ...overrides,
+  };
+}
+
+describe('server data-surface bridge', () => {
+  it('does not send until server authorization succeeds and resolves on browser ack', async () => {
+    const link = transport();
+    const bridge = createDataSurfaceCommandBridge({
+      transport: link,
+      sessionId: 'session-1',
+      source: 'server-1',
+      peerSource: 'browser-1',
+      authorize: vi.fn(async (next) => next.identity.surfaceId === 'orders'),
+      now: () => 1_000,
+      ttlMs: 1_000,
+      timeoutMs: 500,
+    });
+    const pending = bridge.send(command);
+    await Promise.resolve();
+    const request = link.sent[0] as DataSurfaceCommandRequest;
+    expect(request).toMatchObject({
+      sessionId: 'session-1',
+      source: 'server-1',
+    });
+    link.receive(ack(request));
+    await expect(pending).resolves.toMatchObject({ ok: true, revision: 4 });
+    await expect(
+      bridge.send({
+        ...command,
+        identity: { surfaceId: 'other', kind: 'table' },
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: 'denied',
+    });
+  });
+
+  it('returns bounded timeout and disconnect outcomes, and accepts a reconnect retry', async () => {
+    vi.useFakeTimers();
+    try {
+      const link = transport();
+      const bridge = createDataSurfaceCommandBridge({
+        transport: link,
+        sessionId: 'session-1',
+        source: 'server-1',
+        peerSource: 'browser-1',
+        authorize: () => true,
+        now: () => 1_000,
+        ttlMs: 1_000,
+        timeoutMs: 50,
+      });
+      const timedOut = bridge.send(command);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(50);
+      await expect(timedOut).resolves.toMatchObject({
+        ok: false,
+        reason: 'timeout',
+      });
+
+      const disconnected = bridge.send({ ...command, commandId: 'command-2' });
+      await Promise.resolve();
+      link.status('disconnected');
+      await expect(disconnected).resolves.toMatchObject({
+        ok: false,
+        reason: 'disconnected',
+      });
+
+      link.status('connected');
+      const retry = bridge.send({ ...command, commandId: 'command-3' });
+      await Promise.resolve();
+      const retriedRequest = link.sent.at(-1) as DataSurfaceCommandRequest;
+      link.receive(ack(retriedRequest));
+      await expect(retry).resolves.toMatchObject({ ok: true });
+      bridge.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('coalesces concurrent replay of one command id', async () => {
+    const link = transport();
+    const bridge = createDataSurfaceCommandBridge({
+      transport: link,
+      sessionId: 'session-1',
+      source: 'server-1',
+      peerSource: 'browser-1',
+      authorize: () => true,
+      now: () => 1_000,
+      ttlMs: 1_000,
+      timeoutMs: 500,
+    });
+    const first = bridge.send(command);
+    await Promise.resolve();
+    const second = bridge.send(command);
+    await Promise.resolve();
+    expect(link.sent).toHaveLength(1);
+    link.receive(ack(link.sent[0] as DataSurfaceCommandRequest));
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({ ok: true }),
+      expect.objectContaining({ ok: true }),
+    ]);
+    bridge.dispose();
+  });
+});

--- a/packages/chat/src/data-surface-bridge.test.ts
+++ b/packages/chat/src/data-surface-bridge.test.ts
@@ -193,6 +193,50 @@ describe('server data-surface bridge', () => {
     );
     link.receive(ack(request, { expiresAt: request.expiresAt + 1 }));
     link.receive(ack(request, { snapshot: {} }));
+    link.receive(
+      ack(request, {
+        snapshot: {
+          ...snapshot,
+          descriptor: {
+            ...snapshot.descriptor,
+            columns: [{ id: 'id', label: 'ID', capabilities: ['invalid'] }],
+          },
+        },
+      }),
+    );
+    link.receive(
+      ack(request, {
+        snapshot: {
+          ...snapshot,
+          descriptor: {
+            ...snapshot.descriptor,
+            limits: { ...snapshot.descriptor.limits, maxQueryRows: 0 },
+          },
+        },
+      }),
+    );
+    link.receive(
+      ack(request, {
+        snapshot: {
+          ...snapshot,
+          descriptor: {
+            ...snapshot.descriptor,
+            query: { modes: ['rows'], projectableColumnIds: ['unknown'] },
+          },
+        },
+      }),
+    );
+    link.receive(
+      ack(request, {
+        snapshot: { ...snapshot, selection: { scope: 'explicit-ids' } },
+      }),
+    );
+    link.receive(
+      ack(request, {
+        snapshot: { ...snapshot, state: { auth: 'secret' } },
+      }),
+    );
+    link.receive(ack(request, { snapshot: { ...snapshot, extra: true } }));
     link.receive(ack(request), { sessionId: 'session-1', source: 'attacker' });
     link.receive(ack(request), { sessionId: 'attacker', source: 'browser-1' });
     expect(link.sent).toHaveLength(1);

--- a/packages/chat/src/data-surface-bridge.test.ts
+++ b/packages/chat/src/data-surface-bridge.test.ts
@@ -241,6 +241,14 @@ describe('server data-surface bridge', () => {
       }),
     );
     link.receive(ack(request, { snapshot: { ...snapshot, extra: true } }));
+    link.receive(
+      ack(request, {
+        snapshot: {
+          ...snapshot,
+          state: { oversized: 'x'.repeat(100_001) },
+        },
+      }),
+    );
     link.receive(ack(request), { sessionId: 'session-1', source: 'attacker' });
     link.receive(ack(request), { sessionId: 'attacker', source: 'browser-1' });
     expect(link.sent).toHaveLength(1);

--- a/packages/chat/src/data-surface-bridge.test.ts
+++ b/packages/chat/src/data-surface-bridge.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   createDataSurfaceCommandBridge,
   type DataSurfaceBridgeMessage,
+  type DataSurfaceBridgePeer,
   type DataSurfaceCommandRequest,
 } from './data-surface-bridge.js';
 
@@ -17,9 +18,29 @@ const command: DataSurfaceVisibleCommand = {
   expectedRevision: 3,
   controlId: 'refresh',
 };
+const snapshot = {
+  version: 1 as const,
+  descriptor: {
+    version: 1 as const,
+    identity,
+    schemaVersion: 1,
+    label: 'Orders',
+    rowKey: 'id',
+    columns: [{ id: 'id', label: 'ID', capabilities: ['read' as const] }],
+    query: { modes: ['rows' as const], projectableColumnIds: ['id'] },
+    controls: [{ id: 'refresh', label: 'Refresh' }],
+    actions: [],
+    limits: { maxQueryRows: 10, maxQueryBytes: 1000, maxSelectionSize: 10 },
+  },
+  revision: 4,
+  state: {},
+  selection: null,
+};
 
 function transport() {
-  const listeners = new Set<(message: unknown) => void>();
+  const listeners = new Set<
+    (message: unknown, peer: DataSurfaceBridgePeer) => void
+  >();
   const statuses = new Set<
     (state: 'connected' | 'disconnected' | 'reconnecting') => void
   >();
@@ -27,7 +48,9 @@ function transport() {
   return {
     sent,
     send: vi.fn((message: DataSurfaceBridgeMessage) => sent.push(message)),
-    subscribe(listener: (message: unknown) => void) {
+    subscribe(
+      listener: (message: unknown, peer: DataSurfaceBridgePeer) => void,
+    ) {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
@@ -37,8 +60,14 @@ function transport() {
       statuses.add(listener);
       return () => statuses.delete(listener);
     },
-    receive(message: unknown) {
-      for (const listener of listeners) listener(message);
+    receive(
+      message: unknown,
+      peer: DataSurfaceBridgePeer = {
+        sessionId: 'session-1',
+        source: 'browser-1',
+      },
+    ) {
+      for (const listener of listeners) listener(message, peer);
     },
     status(state: 'connected' | 'disconnected' | 'reconnecting') {
       for (const listener of statuses) listener(state);
@@ -61,6 +90,7 @@ function ack(
     expectedRevision: request.expectedRevision,
     ok: true,
     revision: request.expectedRevision + 1,
+    snapshot,
     ...overrides,
   };
 }
@@ -138,6 +168,43 @@ describe('server data-surface bridge', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('discards mismatched, malformed, and unauthenticated acknowledgements', async () => {
+    const link = transport();
+    const bridge = createDataSurfaceCommandBridge({
+      transport: link,
+      sessionId: 'session-1',
+      source: 'server-1',
+      peerSource: 'browser-1',
+      authorize: () => true,
+      now: () => 1_000,
+      ttlMs: 1_000,
+      timeoutMs: 500,
+    });
+    const pending = bridge.send(command);
+    await Promise.resolve();
+    const request = link.sent[0] as DataSurfaceCommandRequest;
+    link.receive(
+      ack(request, { identity: { surfaceId: 'other', kind: 'table' } }),
+    );
+    link.receive(
+      ack(request, { expectedRevision: request.expectedRevision + 1 }),
+    );
+    link.receive(ack(request, { expiresAt: request.expiresAt + 1 }));
+    link.receive(ack(request, { snapshot: {} }));
+    link.receive(ack(request), { sessionId: 'session-1', source: 'attacker' });
+    link.receive(ack(request), { sessionId: 'attacker', source: 'browser-1' });
+    expect(link.sent).toHaveLength(1);
+
+    link.receive(ack(request));
+    await expect(pending).resolves.toMatchObject({
+      ok: true,
+      commandId: request.commandId,
+      identity,
+      expiresAt: request.expiresAt,
+    });
+    bridge.dispose();
   });
 
   it('coalesces concurrent replay of one command id', async () => {

--- a/packages/chat/src/data-surface-bridge.test.ts
+++ b/packages/chat/src/data-surface-bridge.test.ts
@@ -5,6 +5,7 @@ import type {
 import { describe, expect, it, vi } from 'vitest';
 import {
   createDataSurfaceCommandBridge,
+  DATA_SURFACE_IDENTIFIER_MAX_LENGTH,
   type DataSurfaceBridgeMessage,
   type DataSurfaceBridgePeer,
   type DataSurfaceCommandRequest,
@@ -201,6 +202,60 @@ describe('server data-surface bridge', () => {
     }
   });
 
+  it('converts a synchronous transport send throw into a disconnected outcome', async () => {
+    const link = transport();
+    link.send.mockImplementation(() => {
+      throw new Error('transport unavailable');
+    });
+    const bridge = createDataSurfaceCommandBridge({
+      transport: link,
+      sessionId: 'session-1',
+      source: 'server-1',
+      peerSource: 'browser-1',
+      authorize: () => true,
+    });
+    await expect(bridge.send(command)).resolves.toMatchObject({
+      ok: false,
+      reason: 'disconnected',
+    });
+
+    link.send.mockImplementation((message) => {
+      link.sent.push(message);
+    });
+    const retry = bridge.send(command);
+    await Promise.resolve();
+    const request = link.sent[0] as DataSurfaceCommandRequest;
+    link.receive(ack(request));
+    await expect(retry).resolves.toMatchObject({ ok: true });
+    bridge.dispose();
+  });
+
+  it('rejects identifiers longer than the shared bridge contract', async () => {
+    const link = transport();
+    const bridge = createDataSurfaceCommandBridge({
+      transport: link,
+      sessionId: 'session-1',
+      source: 'server-1',
+      peerSource: 'browser-1',
+      authorize: () => true,
+    });
+    const tooLong = 'x'.repeat(DATA_SURFACE_IDENTIFIER_MAX_LENGTH + 1);
+    await expect(
+      bridge.send({ ...command, commandId: tooLong }),
+    ).resolves.toMatchObject({ ok: false, reason: 'invalid_request' });
+    await expect(
+      bridge.send({ ...command, controlId: tooLong }),
+    ).resolves.toMatchObject({ ok: false, reason: 'invalid_request' });
+    await expect(
+      bridge.send({
+        ...command,
+        identity: { surfaceId: tooLong, kind: 'table' },
+      }),
+    ).resolves.toMatchObject({ ok: false, reason: 'invalid_request' });
+    expect(link.sent).toHaveLength(0);
+    bridge.dispose();
+  });
+
   it('discards mismatched, malformed, and unauthenticated acknowledgements', async () => {
     const link = transport();
     const bridge = createDataSurfaceCommandBridge({
@@ -227,6 +282,12 @@ describe('server data-surface bridge', () => {
       ack(request, { expectedRevision: request.expectedRevision + 1 }),
     );
     link.receive(ack(request, { expiresAt: request.expiresAt + 1 }));
+    link.receive(
+      ack(request, {
+        revision: request.expectedRevision - 1,
+        snapshot: { ...snapshot, revision: request.expectedRevision - 1 },
+      }),
+    );
     link.receive(ack(request, { snapshot: {} }));
     link.receive(
       ack(request, {
@@ -386,6 +447,17 @@ describe('server data-surface bridge', () => {
       },
     });
     link.receive({ ...event, revision: 5 });
+    link.receive({
+      ...event,
+      result: { ...event.result, ok: false, reason: 'timeout' },
+    });
+    link.receive({
+      ...event,
+      event: 'registered' as const,
+      revision: -1,
+      command: undefined,
+      result: undefined,
+    });
     expect(events).toHaveLength(0);
     link.receive(event);
     expect(events).toHaveLength(1);

--- a/packages/chat/src/data-surface-bridge.test.ts
+++ b/packages/chat/src/data-surface-bridge.test.ts
@@ -385,6 +385,7 @@ describe('server data-surface bridge', () => {
         snapshot: { ...snapshot, state: { oversized: 'x'.repeat(100_001) } },
       },
     });
+    link.receive({ ...event, revision: 5 });
     expect(events).toHaveLength(0);
     link.receive(event);
     expect(events).toHaveLength(1);

--- a/packages/chat/src/data-surface-bridge.test.ts
+++ b/packages/chat/src/data-surface-bridge.test.ts
@@ -170,6 +170,37 @@ describe('server data-surface bridge', () => {
     }
   });
 
+  it('does not send when authorization loses its connection before it returns', async () => {
+    for (const transition of ['disconnect', 'dispose'] as const) {
+      const link = transport();
+      let releaseAuthorization!: (allowed: boolean) => void;
+      const authorization = new Promise<boolean>((resolve) => {
+        releaseAuthorization = resolve;
+      });
+      const bridge = createDataSurfaceCommandBridge({
+        transport: link,
+        sessionId: 'session-1',
+        source: 'server-1',
+        peerSource: 'browser-1',
+        authorize: () => authorization,
+      });
+      const pending = bridge.send({
+        ...command,
+        commandId: `auth-${transition}`,
+      });
+      await Promise.resolve();
+      if (transition === 'disconnect') link.status('disconnected');
+      else bridge.dispose();
+      releaseAuthorization(true);
+      await expect(pending).resolves.toMatchObject({
+        ok: false,
+        reason: 'disconnected',
+      });
+      expect(link.sent).toHaveLength(0);
+      bridge.dispose();
+    }
+  });
+
   it('discards mismatched, malformed, and unauthenticated acknowledgements', async () => {
     const link = transport();
     const bridge = createDataSurfaceCommandBridge({
@@ -262,6 +293,130 @@ describe('server data-surface bridge', () => {
       identity,
       expiresAt: request.expiresAt,
       snapshot,
+    });
+    bridge.dispose();
+  });
+
+  it('binds acknowledgements to stable identity fields while tolerating labels', async () => {
+    const link = transport();
+    const bridge = createDataSurfaceCommandBridge({
+      transport: link,
+      sessionId: 'session-1',
+      source: 'server-1',
+      peerSource: 'browser-1',
+      authorize: () => true,
+    });
+    const addressedIdentity = {
+      surfaceId: 'orders',
+      kind: 'table' as const,
+      subject: { type: 'tenant', id: 'tenant-1', label: 'Orders' },
+    };
+    const pending = bridge.send({
+      ...command,
+      commandId: 'subject-command',
+      identity: addressedIdentity,
+    });
+    await Promise.resolve();
+    const request = link.sent[0] as DataSurfaceCommandRequest;
+    link.receive(
+      ack(request, {
+        identity: {
+          surfaceId: 'orders',
+          kind: 'table',
+          subject: { type: 'tenant', id: 'tenant-1' },
+        },
+        snapshot: {
+          ...snapshot,
+          descriptor: {
+            ...snapshot.descriptor,
+            identity: {
+              surfaceId: 'orders',
+              kind: 'table',
+              subject: { type: 'tenant', id: 'tenant-1' },
+            },
+          },
+        },
+      }),
+    );
+    await expect(pending).resolves.toMatchObject({
+      ok: true,
+      identity: addressedIdentity,
+    });
+    bridge.dispose();
+  });
+
+  it('rejects invalid or oversized event payloads before notifying listeners', () => {
+    const link = transport();
+    const bridge = createDataSurfaceCommandBridge({
+      transport: link,
+      sessionId: 'session-1',
+      source: 'server-1',
+      peerSource: 'browser-1',
+      authorize: () => true,
+    });
+    const events: unknown[] = [];
+    bridge.subscribe((event) => events.push(event));
+    const event = {
+      type: 'data-surface.event' as const,
+      version: 1 as const,
+      sessionId: 'session-1',
+      source: 'browser-1',
+      sequence: 1,
+      identity,
+      revision: 4,
+      event: 'command' as const,
+      command,
+      result: {
+        ok: true,
+        commandId: command.commandId,
+        identity,
+        revision: 4,
+        snapshot,
+      },
+    };
+    link.receive({
+      ...event,
+      command: { ...command, payload: { oversized: 'x'.repeat(100_001) } },
+    });
+    link.receive({
+      ...event,
+      result: {
+        ...event.result,
+        snapshot: { ...snapshot, state: { oversized: 'x'.repeat(100_001) } },
+      },
+    });
+    expect(events).toHaveLength(0);
+    link.receive(event);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ command, result: { snapshot } });
+    bridge.dispose();
+  });
+
+  it('accepts a canonical snapshot at the byte ceiling when it fits', async () => {
+    const link = transport();
+    const bridge = createDataSurfaceCommandBridge({
+      transport: link,
+      sessionId: 'session-1',
+      source: 'server-1',
+      peerSource: 'browser-1',
+      authorize: () => true,
+    });
+    const base = { ...snapshot, state: { canonicalJson: '' } };
+    const baseBytes = new TextEncoder().encode(JSON.stringify(base)).byteLength;
+    const nearLimitSnapshot = {
+      ...snapshot,
+      state: { canonicalJson: 'x'.repeat(100_000 - baseBytes - 1) },
+    };
+    expect(
+      new TextEncoder().encode(JSON.stringify(nearLimitSnapshot)).byteLength,
+    ).toBe(99_999);
+    const pending = bridge.send({ ...command, commandId: 'near-limit' });
+    await Promise.resolve();
+    const request = link.sent[0] as DataSurfaceCommandRequest;
+    link.receive(ack(request, { snapshot: nearLimitSnapshot }));
+    await expect(pending).resolves.toMatchObject({
+      ok: true,
+      snapshot: nearLimitSnapshot,
     });
     bridge.dispose();
   });

--- a/packages/chat/src/data-surface-bridge.test.ts
+++ b/packages/chat/src/data-surface-bridge.test.ts
@@ -2,10 +2,10 @@ import type {
   DataSurfaceIdentity,
   DataSurfaceVisibleCommand,
 } from '@happyvertical/smrt-ui/data';
+import { DATA_SURFACE_IDENTIFIER_MAX_LENGTH } from '@happyvertical/smrt-ui/data-surface';
 import { describe, expect, it, vi } from 'vitest';
 import {
   createDataSurfaceCommandBridge,
-  DATA_SURFACE_IDENTIFIER_MAX_LENGTH,
   type DataSurfaceBridgeMessage,
   type DataSurfaceBridgePeer,
   type DataSurfaceCommandRequest,
@@ -252,6 +252,26 @@ describe('server data-surface bridge', () => {
         identity: { surfaceId: tooLong, kind: 'table' },
       }),
     ).resolves.toMatchObject({ ok: false, reason: 'invalid_request' });
+    await expect(
+      bridge.send({
+        ...command,
+        identity: {
+          surfaceId: 'orders',
+          kind: 'table',
+          subject: { type: tooLong, id: 'docs' },
+        },
+      }),
+    ).resolves.toMatchObject({ ok: false, reason: 'invalid_request' });
+    await expect(
+      bridge.send({
+        ...command,
+        identity: {
+          surfaceId: 'orders',
+          kind: 'table',
+          subject: { type: 'site', id: tooLong },
+        },
+      }),
+    ).resolves.toMatchObject({ ok: false, reason: 'invalid_request' });
     expect(link.sent).toHaveLength(0);
     bridge.dispose();
   });
@@ -462,6 +482,52 @@ describe('server data-surface bridge', () => {
     link.receive(event);
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({ command, result: { snapshot } });
+    link.receive({
+      ...event,
+      sequence: 2,
+      revision: 1,
+      result: {
+        ok: false,
+        commandId: command.commandId,
+        identity,
+        revision: 1,
+        reason: 'stale_revision',
+      },
+    });
+    expect(events).toHaveLength(2);
+    bridge.dispose();
+  });
+
+  it('accepts a bound stale-revision failure below the requested revision', async () => {
+    const link = transport();
+    const bridge = createDataSurfaceCommandBridge({
+      transport: link,
+      sessionId: 'session-1',
+      source: 'server-1',
+      peerSource: 'browser-1',
+      authorize: () => true,
+      timeoutMs: 500,
+    });
+    const pending = bridge.send({
+      ...command,
+      commandId: 'stale-revision',
+      expectedRevision: 99,
+    });
+    await Promise.resolve();
+    const request = link.sent[0] as DataSurfaceCommandRequest;
+    link.receive(
+      ack(request, {
+        ok: false,
+        reason: 'stale_revision',
+        revision: 1,
+        snapshot: undefined,
+      }),
+    );
+    await expect(pending).resolves.toMatchObject({
+      ok: false,
+      reason: 'stale_revision',
+      revision: 1,
+    });
     bridge.dispose();
   });
 

--- a/packages/chat/src/data-surface-bridge.ts
+++ b/packages/chat/src/data-surface-bridge.ts
@@ -10,12 +10,15 @@
 
 import {
   assertDataSurfaceEnvelope,
+  DATA_SURFACE_IDENTIFIER_MAX_LENGTH,
   normalizeDataSurfaceSnapshot,
   normalizeDataSurfaceVisibleCommand,
 } from './data-surface-normalizer.js';
 
-// Keep the wire contract self-contained in this package's declarations. The
-// These serializable shapes intentionally mirror #2442. Runtime validation is
+export { DATA_SURFACE_IDENTIFIER_MAX_LENGTH } from './data-surface-normalizer.js';
+
+// Keep the wire contract self-contained in this package's declarations. These
+// serializable shapes intentionally mirror #2442. Runtime validation is
 // kept in this package's Node-safe local normalizer so this server entry has no
 // Svelte-bearing dependency.
 export type DataSurfaceJsonPrimitive = string | number | boolean | null;
@@ -34,6 +37,15 @@ export interface DataSurfaceIdentity {
   kind: DataSurfaceKind;
   subject?: DataSurfaceSubject;
 }
+
+export type DataSurfaceCommandResultReason =
+  | 'not_found'
+  | 'unsupported'
+  | 'stale_revision'
+  | 'idempotency_conflict'
+  | 'denied'
+  | 'execution_failed'
+  | 'non_monotonic_revision';
 export interface DataSurfaceDescriptor {
   version: 1;
   identity: DataSurfaceIdentity;
@@ -92,14 +104,7 @@ export interface DataSurfaceCommandResult {
   identity: DataSurfaceIdentity;
   revision?: number;
   snapshot?: DataSurfaceSnapshot;
-  reason?:
-    | 'not_found'
-    | 'unsupported'
-    | 'stale_revision'
-    | 'idempotency_conflict'
-    | 'denied'
-    | 'execution_failed'
-    | 'non_monotonic_revision';
+  reason?: DataSurfaceCommandResultReason;
 }
 
 export const DATA_SURFACE_BRIDGE_VERSION = 1 as const;
@@ -222,7 +227,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isString(value: unknown): value is string {
-  return typeof value === 'string' && value.length > 0 && value.length <= 256;
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= DATA_SURFACE_IDENTIFIER_MAX_LENGTH
+  );
 }
 
 function isPeer(value: unknown): value is DataSurfaceBridgePeer {
@@ -251,6 +260,20 @@ function isFailureReason(
     value === 'source_mismatch' ||
     value === 'session_mismatch' ||
     value === 'replay_capacity_exceeded'
+  );
+}
+
+function isCommandResultReason(
+  value: unknown,
+): value is DataSurfaceCommandResultReason {
+  return (
+    value === 'not_found' ||
+    value === 'unsupported' ||
+    value === 'stale_revision' ||
+    value === 'idempotency_conflict' ||
+    value === 'denied' ||
+    value === 'execution_failed' ||
+    value === 'non_monotonic_revision'
   );
 }
 
@@ -348,6 +371,7 @@ function isEvent(value: unknown): value is DataSurfaceBridgeEvent {
       identityOf(value.identity) &&
       typeof value.revision === 'number' &&
       Number.isSafeInteger(value.revision) &&
+      value.revision >= 0 &&
       (value.event === 'registered' ||
         value.event === 'unregistered' ||
         value.event === 'command'),
@@ -376,7 +400,7 @@ function resultOf(value: unknown): DataSurfaceCommandResult | undefined {
   }
   if (value.ok) {
     if (value.reason !== undefined) return undefined;
-  } else if (!isFailureReason(value.reason)) {
+  } else if (!isCommandResultReason(value.reason)) {
     return undefined;
   }
   let snapshot: DataSurfaceSnapshot | undefined;
@@ -420,7 +444,9 @@ function eventOf(value: unknown): DataSurfaceBridgeEvent | undefined {
     if (value.event !== 'command' && (command || result)) return undefined;
     if (
       value.event === 'command' &&
-      (result?.revision === undefined || value.revision !== result.revision)
+      (result?.revision === undefined ||
+        value.revision !== result.revision ||
+        result.revision < (command?.expectedRevision ?? 0))
     ) {
       return undefined;
     }
@@ -562,7 +588,8 @@ export function createDataSurfaceCommandBridge(
       if (
         value.reason !== undefined ||
         value.revision === undefined ||
-        value.snapshot === undefined
+        value.snapshot === undefined ||
+        value.revision < request.expectedRevision
       ) {
         return undefined;
       }
@@ -576,6 +603,7 @@ export function createDataSurfaceCommandBridge(
       if (
         identitySignature(snapshot.descriptor.identity) !==
           identitySignature(request.identity) ||
+        snapshot.revision < request.expectedRevision ||
         (value.revision !== undefined && snapshot.revision !== value.revision)
       ) {
         return undefined;
@@ -750,7 +778,7 @@ export function createDataSurfaceCommandBridge(
         resolve,
         timer,
       });
-      Promise.resolve(options.transport.send(request)).catch(() => {
+      const handleSendFailure = () => {
         if (!pending.delete(normalized.commandId)) return;
         inflight.delete(normalized.commandId);
         clearTimeout(timer);
@@ -763,7 +791,14 @@ export function createDataSurfaceCommandBridge(
             expiresAt,
           ),
         );
-      });
+      };
+      try {
+        Promise.resolve(options.transport.send(request)).catch(
+          handleSendFailure,
+        );
+      } catch {
+        handleSendFailure();
+      }
     });
     inflight.set(normalized.commandId, { signature, promise });
     if (!pending.has(normalized.commandId))

--- a/packages/chat/src/data-surface-bridge.ts
+++ b/packages/chat/src/data-surface-bridge.ts
@@ -114,7 +114,8 @@ export type DataSurfaceBridgeFailureReason =
   | 'disconnected'
   | 'invalid_request'
   | 'source_mismatch'
-  | 'session_mismatch';
+  | 'session_mismatch'
+  | 'replay_capacity_exceeded';
 
 export interface DataSurfaceCommandRequest {
   type: 'data-surface.command';
@@ -162,6 +163,17 @@ export type DataSurfaceBridgeMessage =
   | DataSurfaceCommandAck
   | DataSurfaceBridgeEvent;
 
+/**
+ * Identity verified by the transport adapter, outside the wire message.
+ * Adapters must derive this from authenticated connection state (for example,
+ * a bound WebSocket session or an origin-checked postMessage peer), never
+ * from fields in `message`. `send` must route only to that bound peer.
+ */
+export interface DataSurfaceBridgePeer {
+  sessionId: string;
+  source: string;
+}
+
 export type DataSurfaceBridgeConnectionState =
   | 'connected'
   | 'disconnected'
@@ -169,7 +181,9 @@ export type DataSurfaceBridgeConnectionState =
 
 export interface DataSurfaceBridgeTransport {
   send(message: DataSurfaceBridgeMessage): void | Promise<void>;
-  subscribe(listener: (message: unknown) => void): () => void;
+  subscribe(
+    listener: (message: unknown, peer: DataSurfaceBridgePeer) => void,
+  ): () => void;
   subscribeStatus?: (
     listener: (state: DataSurfaceBridgeConnectionState) => void,
   ) => () => void;
@@ -207,6 +221,35 @@ function isString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0 && value.length <= 256;
 }
 
+function isPeer(value: unknown): value is DataSurfaceBridgePeer {
+  return isRecord(value) && isString(value.sessionId) && isString(value.source);
+}
+
+function isFiniteInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value);
+}
+
+function isFailureReason(
+  value: unknown,
+): value is DataSurfaceBridgeFailureReason {
+  return (
+    value === 'not_found' ||
+    value === 'unsupported' ||
+    value === 'stale_revision' ||
+    value === 'idempotency_conflict' ||
+    value === 'denied' ||
+    value === 'execution_failed' ||
+    value === 'non_monotonic_revision' ||
+    value === 'expired' ||
+    value === 'timeout' ||
+    value === 'disconnected' ||
+    value === 'invalid_request' ||
+    value === 'source_mismatch' ||
+    value === 'session_mismatch' ||
+    value === 'replay_capacity_exceeded'
+  );
+}
+
 function identityOf(value: unknown): DataSurfaceIdentity | undefined {
   if (!isRecord(value) || !isString(value.surfaceId) || !isString(value.kind))
     return undefined;
@@ -218,6 +261,53 @@ function identityOf(value: unknown): DataSurfaceIdentity | undefined {
   )
     return undefined;
   return value as unknown as DataSurfaceIdentity;
+}
+
+function identitySignature(identity: DataSurfaceIdentity): string {
+  return JSON.stringify({
+    surfaceId: identity.surfaceId,
+    kind: identity.kind,
+    ...(identity.subject
+      ? {
+          subject: {
+            type: identity.subject.type,
+            id: identity.subject.id,
+            ...(identity.subject.label === undefined
+              ? {}
+              : { label: identity.subject.label }),
+          },
+        }
+      : {}),
+  });
+}
+
+function snapshotOf(value: unknown): DataSurfaceSnapshot | undefined {
+  if (!isRecord(value) || value.version !== 1 || !isRecord(value.descriptor))
+    return undefined;
+  const descriptor = value.descriptor;
+  if (
+    descriptor.version !== 1 ||
+    identityOf(descriptor.identity) === undefined ||
+    !isFiniteInteger(descriptor.schemaVersion) ||
+    descriptor.schemaVersion < 0 ||
+    !isString(descriptor.label) ||
+    !isString(descriptor.rowKey) ||
+    !Array.isArray(descriptor.columns) ||
+    !isRecord(descriptor.query) ||
+    !Array.isArray(descriptor.controls) ||
+    !Array.isArray(descriptor.actions) ||
+    !isRecord(descriptor.limits) ||
+    !isFiniteInteger(value.revision) ||
+    value.revision < 0 ||
+    !isRecord(value.state) ||
+    !('selection' in value)
+  )
+    return undefined;
+  try {
+    return JSON.parse(JSON.stringify(value)) as DataSurfaceSnapshot;
+  } catch {
+    return undefined;
+  }
 }
 
 function isAck(value: unknown): value is DataSurfaceCommandAck {
@@ -233,6 +323,7 @@ function isAck(value: unknown): value is DataSurfaceCommandAck {
       identityOf(value.identity) &&
       typeof value.expectedRevision === 'number' &&
       Number.isSafeInteger(value.expectedRevision) &&
+      value.expectedRevision >= 0 &&
       typeof value.ok === 'boolean',
   );
 }
@@ -311,6 +402,7 @@ export function createDataSurfaceCommandBridge(
 
   type Pending = {
     command: DataSurfaceVisibleCommand;
+    request: DataSurfaceCommandRequest;
     expiresAt: number;
     resolve: (ack: DataSurfaceCommandAck) => void;
     timer: ReturnType<typeof setTimeout>;
@@ -342,8 +434,74 @@ export function createDataSurfaceCommandBridge(
     }
   };
 
-  const receive = (value: unknown) => {
-    if (disposed) return;
+  const validateAck = (
+    value: DataSurfaceCommandAck,
+    item: Pending,
+  ): DataSurfaceCommandAck | undefined => {
+    const request = item.request;
+    if (
+      value.commandId !== request.commandId ||
+      value.sessionId !== request.sessionId ||
+      value.source !== options.peerSource ||
+      value.expiresAt !== request.expiresAt ||
+      value.expectedRevision !== request.expectedRevision ||
+      identitySignature(value.identity) !== identitySignature(request.identity)
+    ) {
+      return undefined;
+    }
+    if (
+      value.revision !== undefined &&
+      (!isFiniteInteger(value.revision) || value.revision < 0)
+    ) {
+      return undefined;
+    }
+    if (value.ok) {
+      if (
+        value.reason !== undefined ||
+        value.revision === undefined ||
+        value.snapshot === undefined
+      ) {
+        return undefined;
+      }
+    } else if (!isFailureReason(value.reason)) {
+      return undefined;
+    }
+    let snapshot: DataSurfaceSnapshot | undefined;
+    if (value.snapshot !== undefined) {
+      snapshot = snapshotOf(value.snapshot);
+      if (snapshot === undefined) return undefined;
+      if (
+        identitySignature(snapshot.descriptor.identity) !==
+          identitySignature(request.identity) ||
+        (value.revision !== undefined && snapshot.revision !== value.revision)
+      ) {
+        return undefined;
+      }
+    }
+    return {
+      type: 'data-surface.ack',
+      version: 1,
+      commandId: request.commandId,
+      sessionId: request.sessionId,
+      source: options.peerSource,
+      expiresAt: request.expiresAt,
+      identity: request.identity,
+      expectedRevision: request.expectedRevision,
+      ok: value.ok,
+      ...(value.revision === undefined ? {} : { revision: value.revision }),
+      ...(snapshot === undefined ? {} : { snapshot }),
+      ...(value.reason === undefined ? {} : { reason: value.reason }),
+    };
+  };
+
+  const receive = (value: unknown, peer: DataSurfaceBridgePeer) => {
+    if (
+      disposed ||
+      !isPeer(peer) ||
+      peer.sessionId !== options.sessionId ||
+      peer.source !== options.peerSource
+    )
+      return;
     if (isAck(value)) {
       if (
         value.sessionId !== options.sessionId ||
@@ -352,6 +510,8 @@ export function createDataSurfaceCommandBridge(
         return;
       const item = pending.get(value.commandId);
       if (!item) return;
+      const validated = validateAck(value, item);
+      if (!validated) return;
       pending.delete(value.commandId);
       inflight.delete(value.commandId);
       clearTimeout(item.timer);
@@ -363,11 +523,11 @@ export function createDataSurfaceCommandBridge(
             options.sessionId,
             options.peerSource,
             'expired',
-            value.expiresAt,
+            item.expiresAt,
           ),
         );
       } else {
-        item.resolve(value);
+        item.resolve(validated);
       }
       return;
     }
@@ -455,12 +615,6 @@ export function createDataSurfaceCommandBridge(
           ),
         );
       }, timeoutMs);
-      pending.set(normalized.commandId, {
-        command: normalized,
-        expiresAt,
-        resolve,
-        timer,
-      });
       const request: DataSurfaceCommandRequest = {
         type: 'data-surface.command',
         version: 1,
@@ -475,6 +629,13 @@ export function createDataSurfaceCommandBridge(
           ? {}
           : { payload: normalized.payload }),
       };
+      pending.set(normalized.commandId, {
+        command: normalized,
+        request,
+        expiresAt,
+        resolve,
+        timer,
+      });
       Promise.resolve(options.transport.send(request)).catch(() => {
         if (!pending.delete(normalized.commandId)) return;
         inflight.delete(normalized.commandId);

--- a/packages/chat/src/data-surface-bridge.ts
+++ b/packages/chat/src/data-surface-bridge.ts
@@ -419,6 +419,12 @@ function eventOf(value: unknown): DataSurfaceBridgeEvent | undefined {
     if (value.event === 'command' && (!command || !result)) return undefined;
     if (value.event !== 'command' && (command || result)) return undefined;
     if (
+      value.event === 'command' &&
+      (result?.revision === undefined || value.revision !== result.revision)
+    ) {
+      return undefined;
+    }
+    if (
       (command &&
         identitySignature(command.identity) !== identitySignature(identity)) ||
       (result &&

--- a/packages/chat/src/data-surface-bridge.ts
+++ b/packages/chat/src/data-surface-bridge.ts
@@ -9,15 +9,15 @@
  */
 
 import {
-  DATA_SURFACE_MAX_REQUEST_BYTES,
+  assertDataSurfaceEnvelope,
   normalizeDataSurfaceSnapshot,
   normalizeDataSurfaceVisibleCommand,
-} from '@happyvertical/smrt-ui/data';
+} from './data-surface-normalizer.js';
 
 // Keep the wire contract self-contained in this package's declarations. The
-// runtime normalizer still comes from smrt-ui, but importing its source-backed
-// declaration path would make the generated chat subpath point outside the
-// published artifact. These serializable shapes intentionally mirror #2442.
+// These serializable shapes intentionally mirror #2442. Runtime validation is
+// kept in this package's Node-safe local normalizer so this server entry has no
+// Svelte-bearing dependency.
 export type DataSurfaceJsonPrimitive = string | number | boolean | null;
 export type DataSurfaceJsonValue =
   | DataSurfaceJsonPrimitive
@@ -264,7 +264,29 @@ function identityOf(value: unknown): DataSurfaceIdentity | undefined {
     value.kind !== 'custom'
   )
     return undefined;
-  return value as unknown as DataSurfaceIdentity;
+  let subject: DataSurfaceIdentity['subject'];
+  if (value.subject !== undefined) {
+    if (
+      !isRecord(value.subject) ||
+      !isString(value.subject.type) ||
+      !isString(value.subject.id) ||
+      (value.subject.label !== undefined && !isString(value.subject.label))
+    ) {
+      return undefined;
+    }
+    subject = {
+      type: value.subject.type,
+      id: value.subject.id,
+      ...(value.subject.label === undefined
+        ? {}
+        : { label: value.subject.label }),
+    };
+  }
+  return {
+    surfaceId: value.surfaceId,
+    kind: value.kind,
+    ...(subject ? { subject } : {}),
+  } as DataSurfaceIdentity;
 }
 
 function identitySignature(identity: DataSurfaceIdentity): string {
@@ -276,135 +298,17 @@ function identitySignature(identity: DataSurfaceIdentity): string {
           subject: {
             type: identity.subject.type,
             id: identity.subject.id,
-            ...(identity.subject.label === undefined
-              ? {}
-              : { label: identity.subject.label }),
           },
         }
       : {}),
   });
 }
 
-const MAX_SNAPSHOT_JSON_DEPTH = 16;
-const MAX_SNAPSHOT_CONTAINER_ITEMS = 1_000;
-
-function addSnapshotEnvelopeBytes(
-  budget: { used: number },
-  bytes: number,
-): boolean {
-  budget.used += bytes;
-  return budget.used <= DATA_SURFACE_MAX_REQUEST_BYTES;
-}
-
-function addSnapshotEnvelopeString(
-  value: string,
-  budget: { used: number },
-): boolean {
-  if (!addSnapshotEnvelopeBytes(budget, 2)) return false;
-  for (let index = 0; index < value.length; index += 1) {
-    const codeUnit = value.charCodeAt(index);
-    let bytes: number;
-    if (codeUnit === 0x22 || codeUnit === 0x5c) {
-      bytes = 2;
-    } else if (codeUnit === 0x08 || codeUnit === 0x09) {
-      bytes = 2;
-    } else if (codeUnit === 0x0a || codeUnit === 0x0c || codeUnit === 0x0d) {
-      bytes = 2;
-    } else if (codeUnit <= 0x1f) {
-      bytes = 6;
-    } else if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
-      const next = value.charCodeAt(index + 1);
-      if (next >= 0xdc00 && next <= 0xdfff) {
-        bytes = 4;
-        index += 1;
-      } else {
-        bytes = 6;
-      }
-    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
-      bytes = 6;
-    } else if (codeUnit <= 0x7f) {
-      bytes = 1;
-    } else if (codeUnit <= 0x7ff) {
-      bytes = 2;
-    } else {
-      bytes = 3;
-    }
-    if (!addSnapshotEnvelopeBytes(budget, bytes)) return false;
-  }
-  return addSnapshotEnvelopeBytes(budget, 1);
-}
-
-function fitsSnapshotEnvelope(
-  value: unknown,
-  ancestors = new Set<object>(),
-  depth = 0,
-  budget = { used: 0 },
-): boolean {
-  if (depth > MAX_SNAPSHOT_JSON_DEPTH) return false;
-  if (value === null) return addSnapshotEnvelopeBytes(budget, 4);
-  if (typeof value === 'string') {
-    return addSnapshotEnvelopeString(value, budget);
-  }
-  if (typeof value === 'boolean') {
-    return addSnapshotEnvelopeBytes(budget, value ? 4 : 5);
-  }
-  if (typeof value === 'number') {
-    return (
-      Number.isFinite(value) &&
-      addSnapshotEnvelopeBytes(budget, String(value === 0 ? 0 : value).length)
-    );
-  }
-  if (!value || typeof value !== 'object' || ancestors.has(value)) {
-    return false;
-  }
-  if (Array.isArray(value)) {
-    if (value.length > MAX_SNAPSHOT_CONTAINER_ITEMS) return false;
-    ancestors.add(value);
-    try {
-      if (!addSnapshotEnvelopeBytes(budget, 1)) return false;
-      for (const [index, item] of value.entries()) {
-        if (index > 0 && !addSnapshotEnvelopeBytes(budget, 1)) return false;
-        if (!fitsSnapshotEnvelope(item, ancestors, depth + 1, budget)) {
-          return false;
-        }
-      }
-      return addSnapshotEnvelopeBytes(budget, 1);
-    } finally {
-      ancestors.delete(value);
-    }
-  }
-  if (Object.getPrototypeOf(value) !== Object.prototype) return false;
-  const keys = Object.keys(value);
-  if (keys.length > MAX_SNAPSHOT_CONTAINER_ITEMS) return false;
-  ancestors.add(value);
-  try {
-    if (!addSnapshotEnvelopeBytes(budget, 1)) return false;
-    for (const [index, key] of keys.entries()) {
-      if (index > 0 && !addSnapshotEnvelopeBytes(budget, 1)) return false;
-      if (
-        !addSnapshotEnvelopeString(key, budget) ||
-        !addSnapshotEnvelopeBytes(budget, 1) ||
-        !fitsSnapshotEnvelope(
-          (value as Record<string, unknown>)[key],
-          ancestors,
-          depth + 1,
-          budget,
-        )
-      ) {
-        return false;
-      }
-    }
-    return addSnapshotEnvelopeBytes(budget, 1);
-  } finally {
-    ancestors.delete(value);
-  }
-}
-
 function snapshotOf(value: unknown): DataSurfaceSnapshot | undefined {
   try {
     // The normalizer defensively clones state and descriptor arrays. Bound the
     // untrusted wire envelope before it can do that work on a browser ACK.
-    if (!fitsSnapshotEnvelope(value)) return undefined;
+    assertDataSurfaceEnvelope(value);
     return normalizeDataSurfaceSnapshot(
       value as Parameters<typeof normalizeDataSurfaceSnapshot>[0],
     ) as DataSurfaceSnapshot;
@@ -448,6 +352,96 @@ function isEvent(value: unknown): value is DataSurfaceBridgeEvent {
         value.event === 'unregistered' ||
         value.event === 'command'),
   );
+}
+
+function resultOf(value: unknown): DataSurfaceCommandResult | undefined {
+  if (!isRecord(value) || typeof value.ok !== 'boolean') return undefined;
+  const allowed = new Set([
+    'ok',
+    'commandId',
+    'identity',
+    'revision',
+    'snapshot',
+    'reason',
+  ]);
+  if (Object.keys(value).some((key) => !allowed.has(key))) return undefined;
+  if (!isString(value.commandId)) return undefined;
+  const identity = identityOf(value.identity);
+  if (!identity) return undefined;
+  if (
+    value.revision !== undefined &&
+    (!isFiniteInteger(value.revision) || value.revision < 0)
+  ) {
+    return undefined;
+  }
+  if (value.ok) {
+    if (value.reason !== undefined) return undefined;
+  } else if (!isFailureReason(value.reason)) {
+    return undefined;
+  }
+  let snapshot: DataSurfaceSnapshot | undefined;
+  if (value.snapshot !== undefined) {
+    snapshot = snapshotOf(value.snapshot);
+    if (!snapshot) return undefined;
+    if (
+      identitySignature(snapshot.descriptor.identity) !==
+        identitySignature(identity) ||
+      (value.revision !== undefined && snapshot.revision !== value.revision)
+    ) {
+      return undefined;
+    }
+  }
+  return {
+    ok: value.ok,
+    commandId: value.commandId,
+    identity,
+    ...(value.revision === undefined ? {} : { revision: value.revision }),
+    ...(snapshot === undefined ? {} : { snapshot }),
+    ...(value.reason === undefined ? {} : { reason: value.reason }),
+  } as DataSurfaceCommandResult;
+}
+
+function eventOf(value: unknown): DataSurfaceBridgeEvent | undefined {
+  if (!isEvent(value)) return undefined;
+  try {
+    assertDataSurfaceEnvelope(value);
+    const identity = identityOf(value.identity);
+    if (!identity) return undefined;
+    let command: DataSurfaceVisibleCommand | undefined;
+    if (value.command !== undefined) {
+      command = normalizeDataSurfaceVisibleCommand(
+        value.command,
+      ) as DataSurfaceVisibleCommand;
+    }
+    const result =
+      value.result === undefined ? undefined : resultOf(value.result);
+    if (value.result !== undefined && result === undefined) return undefined;
+    if (value.event === 'command' && (!command || !result)) return undefined;
+    if (value.event !== 'command' && (command || result)) return undefined;
+    if (
+      (command &&
+        identitySignature(command.identity) !== identitySignature(identity)) ||
+      (result &&
+        (identitySignature(result.identity) !== identitySignature(identity) ||
+          (command !== undefined && result.commandId !== command.commandId)))
+    ) {
+      return undefined;
+    }
+    return {
+      type: 'data-surface.event',
+      version: 1,
+      sessionId: value.sessionId,
+      source: value.source,
+      sequence: value.sequence,
+      identity,
+      revision: value.revision,
+      ...(command === undefined ? {} : { command }),
+      ...(result === undefined ? {} : { result }),
+      event: value.event,
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 function fallbackAck(
@@ -634,15 +628,16 @@ export function createDataSurfaceCommandBridge(
       }
       return;
     }
-    if (!isEvent(value)) return;
+    const event = eventOf(value);
+    if (!event) return;
     if (
-      value.sessionId !== options.sessionId ||
-      value.source !== options.peerSource ||
-      value.sequence <= lastSequence
+      event.sessionId !== options.sessionId ||
+      event.source !== options.peerSource ||
+      event.sequence <= lastSequence
     )
       return;
-    lastSequence = value.sequence;
-    for (const listener of listeners) listener(value);
+    lastSequence = event.sequence;
+    for (const listener of listeners) listener(event);
   };
 
   const unsubscribeTransport = options.transport.subscribe(receive);
@@ -656,7 +651,9 @@ export function createDataSurfaceCommandBridge(
   ): Promise<DataSurfaceCommandAck> => {
     let normalized: DataSurfaceVisibleCommand;
     try {
-      normalized = normalizeDataSurfaceVisibleCommand(command);
+      normalized = normalizeDataSurfaceVisibleCommand(
+        command,
+      ) as DataSurfaceVisibleCommand;
     } catch {
       return fallbackAck(
         command,
@@ -680,6 +677,14 @@ export function createDataSurfaceCommandBridge(
     } catch {
       allowed = false;
     }
+    if (disposed || state !== 'connected')
+      return fallbackAck(
+        normalized,
+        options.sessionId,
+        options.peerSource,
+        'disconnected',
+        now(),
+      );
     if (!allowed)
       return fallbackAck(
         normalized,

--- a/packages/chat/src/data-surface-bridge.ts
+++ b/packages/chat/src/data-surface-bridge.ts
@@ -8,7 +8,10 @@
  * server-bound session context, never authority supplied by the command.
  */
 
-import { normalizeDataSurfaceVisibleCommand } from '@happyvertical/smrt-ui/data';
+import {
+  normalizeDataSurfaceSnapshot,
+  normalizeDataSurfaceVisibleCommand,
+} from '@happyvertical/smrt-ui/data';
 
 // Keep the wire contract self-contained in this package's declarations. The
 // runtime normalizer still comes from smrt-ui, but importing its source-backed
@@ -282,29 +285,10 @@ function identitySignature(identity: DataSurfaceIdentity): string {
 }
 
 function snapshotOf(value: unknown): DataSurfaceSnapshot | undefined {
-  if (!isRecord(value) || value.version !== 1 || !isRecord(value.descriptor))
-    return undefined;
-  const descriptor = value.descriptor;
-  if (
-    descriptor.version !== 1 ||
-    identityOf(descriptor.identity) === undefined ||
-    !isFiniteInteger(descriptor.schemaVersion) ||
-    descriptor.schemaVersion < 0 ||
-    !isString(descriptor.label) ||
-    !isString(descriptor.rowKey) ||
-    !Array.isArray(descriptor.columns) ||
-    !isRecord(descriptor.query) ||
-    !Array.isArray(descriptor.controls) ||
-    !Array.isArray(descriptor.actions) ||
-    !isRecord(descriptor.limits) ||
-    !isFiniteInteger(value.revision) ||
-    value.revision < 0 ||
-    !isRecord(value.state) ||
-    !('selection' in value)
-  )
-    return undefined;
   try {
-    return JSON.parse(JSON.stringify(value)) as DataSurfaceSnapshot;
+    return normalizeDataSurfaceSnapshot(
+      value as Parameters<typeof normalizeDataSurfaceSnapshot>[0],
+    ) as DataSurfaceSnapshot;
   } catch {
     return undefined;
   }

--- a/packages/chat/src/data-surface-bridge.ts
+++ b/packages/chat/src/data-surface-bridge.ts
@@ -8,14 +8,12 @@
  * server-bound session context, never authority supplied by the command.
  */
 
+import { DATA_SURFACE_IDENTIFIER_MAX_LENGTH } from '@happyvertical/smrt-ui/data-surface';
 import {
   assertDataSurfaceEnvelope,
-  DATA_SURFACE_IDENTIFIER_MAX_LENGTH,
   normalizeDataSurfaceSnapshot,
   normalizeDataSurfaceVisibleCommand,
 } from './data-surface-normalizer.js';
-
-export { DATA_SURFACE_IDENTIFIER_MAX_LENGTH } from './data-surface-normalizer.js';
 
 // Keep the wire contract self-contained in this package's declarations. These
 // serializable shapes intentionally mirror #2442. Runtime validation is
@@ -234,6 +232,10 @@ function isString(value: unknown): value is string {
   );
 }
 
+function isDisplayString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
 function isPeer(value: unknown): value is DataSurfaceBridgePeer {
   return isRecord(value) && isString(value.sessionId) && isString(value.source);
 }
@@ -293,7 +295,8 @@ function identityOf(value: unknown): DataSurfaceIdentity | undefined {
       !isRecord(value.subject) ||
       !isString(value.subject.type) ||
       !isString(value.subject.id) ||
-      (value.subject.label !== undefined && !isString(value.subject.label))
+      (value.subject.label !== undefined &&
+        !isDisplayString(value.subject.label))
     ) {
       return undefined;
     }
@@ -446,7 +449,7 @@ function eventOf(value: unknown): DataSurfaceBridgeEvent | undefined {
       value.event === 'command' &&
       (result?.revision === undefined ||
         value.revision !== result.revision ||
-        result.revision < (command?.expectedRevision ?? 0))
+        (result.ok && result.revision < (command?.expectedRevision ?? 0)))
     ) {
       return undefined;
     }
@@ -589,7 +592,7 @@ export function createDataSurfaceCommandBridge(
         value.reason !== undefined ||
         value.revision === undefined ||
         value.snapshot === undefined ||
-        value.revision < request.expectedRevision
+        (value.ok && value.revision < request.expectedRevision)
       ) {
         return undefined;
       }
@@ -603,7 +606,7 @@ export function createDataSurfaceCommandBridge(
       if (
         identitySignature(snapshot.descriptor.identity) !==
           identitySignature(request.identity) ||
-        snapshot.revision < request.expectedRevision ||
+        (value.ok && snapshot.revision < request.expectedRevision) ||
         (value.revision !== undefined && snapshot.revision !== value.revision)
       ) {
         return undefined;

--- a/packages/chat/src/data-surface-bridge.ts
+++ b/packages/chat/src/data-surface-bridge.ts
@@ -1,0 +1,524 @@
+/**
+ * Server-side half of the authenticated data-surface bridge.
+ *
+ * This module is transport-neutral on purpose. An application supplies its
+ * authenticated WebSocket/postMessage adapter and an authorization callback;
+ * the chat package never treats browser acknowledgement as persistence or
+ * server authorization. The callback is required and receives only the
+ * server-bound session context, never authority supplied by the command.
+ */
+
+import { normalizeDataSurfaceVisibleCommand } from '@happyvertical/smrt-ui/data';
+
+// Keep the wire contract self-contained in this package's declarations. The
+// runtime normalizer still comes from smrt-ui, but importing its source-backed
+// declaration path would make the generated chat subpath point outside the
+// published artifact. These serializable shapes intentionally mirror #2442.
+export type DataSurfaceJsonPrimitive = string | number | boolean | null;
+export type DataSurfaceJsonValue =
+  | DataSurfaceJsonPrimitive
+  | DataSurfaceJsonValue[]
+  | { [key: string]: DataSurfaceJsonValue };
+export type DataSurfaceKind = 'table' | 'list' | 'report' | 'custom';
+export interface DataSurfaceSubject {
+  type: string;
+  id: string;
+  label?: string;
+}
+export interface DataSurfaceIdentity {
+  surfaceId: string;
+  kind: DataSurfaceKind;
+  subject?: DataSurfaceSubject;
+}
+export interface DataSurfaceDescriptor {
+  version: 1;
+  identity: DataSurfaceIdentity;
+  schemaVersion: number;
+  label: string;
+  description?: string;
+  rowKey: string;
+  columns: Array<{
+    id: string;
+    label: string;
+    description?: string;
+    sensitivity?: 'public' | 'personal' | 'sensitive' | 'secret';
+    capabilities: Array<'read' | 'search' | 'filter' | 'sort' | 'project'>;
+  }>;
+  query: {
+    modes: Array<'rows' | 'count' | 'facets'>;
+    projectableColumnIds: string[];
+  };
+  controls: Array<{ id: string; label: string; description?: string }>;
+  actions: Array<{
+    id: string;
+    label: string;
+    description?: string;
+    sensitivity?: 'public' | 'personal' | 'sensitive' | 'secret';
+    selectionScopes: Array<'current-page' | 'explicit-ids' | 'all-matching'>;
+    requiresConfirmation?: boolean;
+  }>;
+  limits: {
+    maxQueryRows: number;
+    maxQueryBytes: number;
+    maxSelectionSize: number;
+  };
+}
+export type DataSurfaceSelectionReference =
+  | { scope: 'current-page' }
+  | { scope: 'explicit-ids'; rowIds: Array<string | number> }
+  | { scope: 'all-matching'; queryFingerprint: string };
+export interface DataSurfaceSnapshot {
+  version: 1;
+  descriptor: DataSurfaceDescriptor;
+  revision: number;
+  state: { [key: string]: DataSurfaceJsonValue };
+  selection: DataSurfaceSelectionReference | null;
+}
+export interface DataSurfaceVisibleCommand {
+  version: 1;
+  commandId: string;
+  identity: DataSurfaceIdentity;
+  expectedRevision: number;
+  controlId: string;
+  payload?: DataSurfaceJsonValue;
+}
+export interface DataSurfaceCommandResult {
+  ok: boolean;
+  commandId: string;
+  identity: DataSurfaceIdentity;
+  revision?: number;
+  snapshot?: DataSurfaceSnapshot;
+  reason?:
+    | 'not_found'
+    | 'unsupported'
+    | 'stale_revision'
+    | 'idempotency_conflict'
+    | 'denied'
+    | 'execution_failed'
+    | 'non_monotonic_revision';
+}
+
+export const DATA_SURFACE_BRIDGE_VERSION = 1 as const;
+export const DEFAULT_DATA_SURFACE_BRIDGE_TTL_MS = 30_000;
+
+export type DataSurfaceBridgeFailureReason =
+  | 'not_found'
+  | 'unsupported'
+  | 'stale_revision'
+  | 'idempotency_conflict'
+  | 'denied'
+  | 'execution_failed'
+  | 'non_monotonic_revision'
+  | 'expired'
+  | 'timeout'
+  | 'disconnected'
+  | 'invalid_request'
+  | 'source_mismatch'
+  | 'session_mismatch';
+
+export interface DataSurfaceCommandRequest {
+  type: 'data-surface.command';
+  version: typeof DATA_SURFACE_BRIDGE_VERSION;
+  commandId: string;
+  sessionId: string;
+  source: string;
+  expiresAt: number;
+  identity: DataSurfaceIdentity;
+  expectedRevision: number;
+  controlId: string;
+  payload?: DataSurfaceVisibleCommand['payload'];
+}
+
+export interface DataSurfaceCommandAck {
+  type: 'data-surface.ack';
+  version: typeof DATA_SURFACE_BRIDGE_VERSION;
+  commandId: string;
+  sessionId: string;
+  source: string;
+  expiresAt: number;
+  identity: DataSurfaceIdentity;
+  expectedRevision: number;
+  ok: boolean;
+  revision?: number;
+  snapshot?: DataSurfaceSnapshot;
+  reason?: DataSurfaceBridgeFailureReason;
+}
+
+export interface DataSurfaceBridgeEvent {
+  type: 'data-surface.event';
+  version: typeof DATA_SURFACE_BRIDGE_VERSION;
+  sessionId: string;
+  source: string;
+  sequence: number;
+  identity: DataSurfaceIdentity;
+  revision: number;
+  event: 'registered' | 'unregistered' | 'command';
+  command?: DataSurfaceVisibleCommand;
+  result?: DataSurfaceCommandResult;
+}
+
+export type DataSurfaceBridgeMessage =
+  | DataSurfaceCommandRequest
+  | DataSurfaceCommandAck
+  | DataSurfaceBridgeEvent;
+
+export type DataSurfaceBridgeConnectionState =
+  | 'connected'
+  | 'disconnected'
+  | 'reconnecting';
+
+export interface DataSurfaceBridgeTransport {
+  send(message: DataSurfaceBridgeMessage): void | Promise<void>;
+  subscribe(listener: (message: unknown) => void): () => void;
+  subscribeStatus?: (
+    listener: (state: DataSurfaceBridgeConnectionState) => void,
+  ) => () => void;
+}
+
+export interface DataSurfaceCommandBridgeOptions {
+  transport: DataSurfaceBridgeTransport;
+  /** Server-authenticated browser session binding. */
+  sessionId: string;
+  /** Server source id placed on requests. */
+  source: string;
+  /** Browser source id accepted for acknowledgements/events. */
+  peerSource: string;
+  /** Must enforce application authorization; no default permit path exists. */
+  authorize: (command: DataSurfaceVisibleCommand) => boolean | Promise<boolean>;
+  now?: () => number;
+  ttlMs?: number;
+  timeoutMs?: number;
+}
+
+export interface DataSurfaceCommandBridge {
+  readonly sessionId: string;
+  readonly source: string;
+  readonly state: DataSurfaceBridgeConnectionState;
+  send(command: DataSurfaceVisibleCommand): Promise<DataSurfaceCommandAck>;
+  subscribe(listener: (event: DataSurfaceBridgeEvent) => void): () => void;
+  dispose(): void;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= 256;
+}
+
+function identityOf(value: unknown): DataSurfaceIdentity | undefined {
+  if (!isRecord(value) || !isString(value.surfaceId) || !isString(value.kind))
+    return undefined;
+  if (
+    value.kind !== 'table' &&
+    value.kind !== 'list' &&
+    value.kind !== 'report' &&
+    value.kind !== 'custom'
+  )
+    return undefined;
+  return value as unknown as DataSurfaceIdentity;
+}
+
+function isAck(value: unknown): value is DataSurfaceCommandAck {
+  return Boolean(
+    isRecord(value) &&
+      value.type === 'data-surface.ack' &&
+      value.version === 1 &&
+      isString(value.commandId) &&
+      isString(value.sessionId) &&
+      isString(value.source) &&
+      typeof value.expiresAt === 'number' &&
+      Number.isFinite(value.expiresAt) &&
+      identityOf(value.identity) &&
+      typeof value.expectedRevision === 'number' &&
+      Number.isSafeInteger(value.expectedRevision) &&
+      typeof value.ok === 'boolean',
+  );
+}
+
+function isEvent(value: unknown): value is DataSurfaceBridgeEvent {
+  return Boolean(
+    isRecord(value) &&
+      value.type === 'data-surface.event' &&
+      value.version === 1 &&
+      isString(value.sessionId) &&
+      isString(value.source) &&
+      typeof value.sequence === 'number' &&
+      Number.isSafeInteger(value.sequence) &&
+      value.sequence > 0 &&
+      identityOf(value.identity) &&
+      typeof value.revision === 'number' &&
+      Number.isSafeInteger(value.revision) &&
+      (value.event === 'registered' ||
+        value.event === 'unregistered' ||
+        value.event === 'command'),
+  );
+}
+
+function fallbackAck(
+  command: DataSurfaceVisibleCommand,
+  sessionId: string,
+  source: string,
+  reason: DataSurfaceBridgeFailureReason,
+  expiresAt: number,
+): DataSurfaceCommandAck {
+  return {
+    type: 'data-surface.ack',
+    version: 1,
+    commandId: command.commandId,
+    sessionId,
+    source,
+    expiresAt,
+    identity: command.identity,
+    expectedRevision: command.expectedRevision,
+    ok: false,
+    reason,
+  };
+}
+
+function commandSignature(command: DataSurfaceVisibleCommand): string {
+  return JSON.stringify(command);
+}
+
+/**
+ * Send browser-visible commands from an already-authenticated server turn.
+ * `send()` deliberately requires a server callback before any bytes leave the
+ * process. It does not accept actor, tenant, or role fields from the caller.
+ */
+export function createDataSurfaceCommandBridge(
+  options: DataSurfaceCommandBridgeOptions,
+): DataSurfaceCommandBridge {
+  if (
+    !isString(options.sessionId) ||
+    !isString(options.source) ||
+    !isString(options.peerSource)
+  ) {
+    throw new TypeError('DataSurface bridge session/source ids are required');
+  }
+  const now = options.now ?? (() => Date.now());
+  const ttlMs = options.ttlMs ?? DEFAULT_DATA_SURFACE_BRIDGE_TTL_MS;
+  const timeoutMs = options.timeoutMs ?? ttlMs;
+  if (
+    !Number.isSafeInteger(ttlMs) ||
+    ttlMs <= 0 ||
+    !Number.isSafeInteger(timeoutMs) ||
+    timeoutMs <= 0 ||
+    timeoutMs > ttlMs
+  ) {
+    throw new RangeError('Invalid DataSurface bridge bounds');
+  }
+
+  type Pending = {
+    command: DataSurfaceVisibleCommand;
+    expiresAt: number;
+    resolve: (ack: DataSurfaceCommandAck) => void;
+    timer: ReturnType<typeof setTimeout>;
+  };
+  const pending = new Map<string, Pending>();
+  const inflight = new Map<
+    string,
+    { signature: string; promise: Promise<DataSurfaceCommandAck> }
+  >();
+  const listeners = new Set<(event: DataSurfaceBridgeEvent) => void>();
+  let state: DataSurfaceBridgeConnectionState = 'connected';
+  let disposed = false;
+  let lastSequence = 0;
+
+  const rejectPending = (reason: 'timeout' | 'disconnected') => {
+    for (const [commandId, item] of pending) {
+      clearTimeout(item.timer);
+      pending.delete(commandId);
+      inflight.delete(commandId);
+      item.resolve(
+        fallbackAck(
+          item.command,
+          options.sessionId,
+          options.peerSource,
+          reason,
+          item.expiresAt,
+        ),
+      );
+    }
+  };
+
+  const receive = (value: unknown) => {
+    if (disposed) return;
+    if (isAck(value)) {
+      if (
+        value.sessionId !== options.sessionId ||
+        value.source !== options.peerSource
+      )
+        return;
+      const item = pending.get(value.commandId);
+      if (!item) return;
+      pending.delete(value.commandId);
+      inflight.delete(value.commandId);
+      clearTimeout(item.timer);
+      // A late success cannot outlive the server-side envelope.
+      if (value.expiresAt <= now()) {
+        item.resolve(
+          fallbackAck(
+            item.command,
+            options.sessionId,
+            options.peerSource,
+            'expired',
+            value.expiresAt,
+          ),
+        );
+      } else {
+        item.resolve(value);
+      }
+      return;
+    }
+    if (!isEvent(value)) return;
+    if (
+      value.sessionId !== options.sessionId ||
+      value.source !== options.peerSource ||
+      value.sequence <= lastSequence
+    )
+      return;
+    lastSequence = value.sequence;
+    for (const listener of listeners) listener(value);
+  };
+
+  const unsubscribeTransport = options.transport.subscribe(receive);
+  const unsubscribeStatus = options.transport.subscribeStatus?.((next) => {
+    state = next;
+    if (next === 'disconnected') rejectPending('disconnected');
+  });
+
+  const send = async (
+    command: DataSurfaceVisibleCommand,
+  ): Promise<DataSurfaceCommandAck> => {
+    let normalized: DataSurfaceVisibleCommand;
+    try {
+      normalized = normalizeDataSurfaceVisibleCommand(command);
+    } catch {
+      return fallbackAck(
+        command,
+        options.sessionId,
+        options.peerSource,
+        'invalid_request',
+        now(),
+      );
+    }
+    if (disposed || state !== 'connected')
+      return fallbackAck(
+        normalized,
+        options.sessionId,
+        options.peerSource,
+        'disconnected',
+        now(),
+      );
+    let allowed = false;
+    try {
+      allowed = await options.authorize(normalized);
+    } catch {
+      allowed = false;
+    }
+    if (!allowed)
+      return fallbackAck(
+        normalized,
+        options.sessionId,
+        options.peerSource,
+        'denied',
+        now(),
+      );
+
+    const signature = commandSignature(normalized);
+    const existing = inflight.get(normalized.commandId);
+    if (existing) {
+      return existing.signature === signature
+        ? existing.promise
+        : fallbackAck(
+            normalized,
+            options.sessionId,
+            options.peerSource,
+            'idempotency_conflict',
+            now(),
+          );
+    }
+
+    const expiresAt = now() + ttlMs;
+    const promise = new Promise<DataSurfaceCommandAck>((resolve) => {
+      const timer = setTimeout(() => {
+        if (!pending.delete(normalized.commandId)) return;
+        inflight.delete(normalized.commandId);
+        resolve(
+          fallbackAck(
+            normalized,
+            options.sessionId,
+            options.peerSource,
+            'timeout',
+            expiresAt,
+          ),
+        );
+      }, timeoutMs);
+      pending.set(normalized.commandId, {
+        command: normalized,
+        expiresAt,
+        resolve,
+        timer,
+      });
+      const request: DataSurfaceCommandRequest = {
+        type: 'data-surface.command',
+        version: 1,
+        commandId: normalized.commandId,
+        sessionId: options.sessionId,
+        source: options.source,
+        expiresAt,
+        identity: normalized.identity,
+        expectedRevision: normalized.expectedRevision,
+        controlId: normalized.controlId,
+        ...(normalized.payload === undefined
+          ? {}
+          : { payload: normalized.payload }),
+      };
+      Promise.resolve(options.transport.send(request)).catch(() => {
+        if (!pending.delete(normalized.commandId)) return;
+        inflight.delete(normalized.commandId);
+        clearTimeout(timer);
+        resolve(
+          fallbackAck(
+            normalized,
+            options.sessionId,
+            options.peerSource,
+            'disconnected',
+            expiresAt,
+          ),
+        );
+      });
+    });
+    inflight.set(normalized.commandId, { signature, promise });
+    if (!pending.has(normalized.commandId))
+      inflight.delete(normalized.commandId);
+    return promise;
+  };
+
+  return {
+    sessionId: options.sessionId,
+    source: options.source,
+    get state() {
+      return state;
+    },
+    send,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      unsubscribeTransport();
+      unsubscribeStatus?.();
+      rejectPending('disconnected');
+      inflight.clear();
+      listeners.clear();
+    },
+  };
+}
+
+/** Explicit alias for consumers that want to name the server role. */
+export const createServerDataSurfaceBridge = createDataSurfaceCommandBridge;
+export const createDataSurfaceBridge = createDataSurfaceCommandBridge;

--- a/packages/chat/src/data-surface-bridge.ts
+++ b/packages/chat/src/data-surface-bridge.ts
@@ -9,6 +9,7 @@
  */
 
 import {
+  DATA_SURFACE_MAX_REQUEST_BYTES,
   normalizeDataSurfaceSnapshot,
   normalizeDataSurfaceVisibleCommand,
 } from '@happyvertical/smrt-ui/data';
@@ -284,8 +285,126 @@ function identitySignature(identity: DataSurfaceIdentity): string {
   });
 }
 
+const MAX_SNAPSHOT_JSON_DEPTH = 16;
+const MAX_SNAPSHOT_CONTAINER_ITEMS = 1_000;
+
+function addSnapshotEnvelopeBytes(
+  budget: { used: number },
+  bytes: number,
+): boolean {
+  budget.used += bytes;
+  return budget.used <= DATA_SURFACE_MAX_REQUEST_BYTES;
+}
+
+function addSnapshotEnvelopeString(
+  value: string,
+  budget: { used: number },
+): boolean {
+  if (!addSnapshotEnvelopeBytes(budget, 2)) return false;
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    let bytes: number;
+    if (codeUnit === 0x22 || codeUnit === 0x5c) {
+      bytes = 2;
+    } else if (codeUnit === 0x08 || codeUnit === 0x09) {
+      bytes = 2;
+    } else if (codeUnit === 0x0a || codeUnit === 0x0c || codeUnit === 0x0d) {
+      bytes = 2;
+    } else if (codeUnit <= 0x1f) {
+      bytes = 6;
+    } else if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes = 4;
+        index += 1;
+      } else {
+        bytes = 6;
+      }
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      bytes = 6;
+    } else if (codeUnit <= 0x7f) {
+      bytes = 1;
+    } else if (codeUnit <= 0x7ff) {
+      bytes = 2;
+    } else {
+      bytes = 3;
+    }
+    if (!addSnapshotEnvelopeBytes(budget, bytes)) return false;
+  }
+  return addSnapshotEnvelopeBytes(budget, 1);
+}
+
+function fitsSnapshotEnvelope(
+  value: unknown,
+  ancestors = new Set<object>(),
+  depth = 0,
+  budget = { used: 0 },
+): boolean {
+  if (depth > MAX_SNAPSHOT_JSON_DEPTH) return false;
+  if (value === null) return addSnapshotEnvelopeBytes(budget, 4);
+  if (typeof value === 'string') {
+    return addSnapshotEnvelopeString(value, budget);
+  }
+  if (typeof value === 'boolean') {
+    return addSnapshotEnvelopeBytes(budget, value ? 4 : 5);
+  }
+  if (typeof value === 'number') {
+    return (
+      Number.isFinite(value) &&
+      addSnapshotEnvelopeBytes(budget, String(value === 0 ? 0 : value).length)
+    );
+  }
+  if (!value || typeof value !== 'object' || ancestors.has(value)) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    if (value.length > MAX_SNAPSHOT_CONTAINER_ITEMS) return false;
+    ancestors.add(value);
+    try {
+      if (!addSnapshotEnvelopeBytes(budget, 1)) return false;
+      for (const [index, item] of value.entries()) {
+        if (index > 0 && !addSnapshotEnvelopeBytes(budget, 1)) return false;
+        if (!fitsSnapshotEnvelope(item, ancestors, depth + 1, budget)) {
+          return false;
+        }
+      }
+      return addSnapshotEnvelopeBytes(budget, 1);
+    } finally {
+      ancestors.delete(value);
+    }
+  }
+  if (Object.getPrototypeOf(value) !== Object.prototype) return false;
+  const keys = Object.keys(value);
+  if (keys.length > MAX_SNAPSHOT_CONTAINER_ITEMS) return false;
+  ancestors.add(value);
+  try {
+    if (!addSnapshotEnvelopeBytes(budget, 1)) return false;
+    for (const [index, key] of keys.entries()) {
+      if (index > 0 && !addSnapshotEnvelopeBytes(budget, 1)) return false;
+      if (
+        !addSnapshotEnvelopeString(key, budget) ||
+        !addSnapshotEnvelopeBytes(budget, 1) ||
+        !fitsSnapshotEnvelope(
+          (value as Record<string, unknown>)[key],
+          ancestors,
+          depth + 1,
+          budget,
+        )
+      ) {
+        return false;
+      }
+    }
+    return addSnapshotEnvelopeBytes(budget, 1);
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
 function snapshotOf(value: unknown): DataSurfaceSnapshot | undefined {
   try {
+    // The normalizer defensively clones state and descriptor arrays. Bound the
+    // untrusted wire envelope before it can do that work on a browser ACK.
+    if (!fitsSnapshotEnvelope(value)) return undefined;
     return normalizeDataSurfaceSnapshot(
       value as Parameters<typeof normalizeDataSurfaceSnapshot>[0],
     ) as DataSurfaceSnapshot;

--- a/packages/chat/src/data-surface-normalizer.ts
+++ b/packages/chat/src/data-surface-normalizer.ts
@@ -6,8 +6,8 @@
  */
 
 const MAX_REQUEST_BYTES = 100_000;
+export const DATA_SURFACE_IDENTIFIER_MAX_LENGTH = 256;
 const MAX_QUERY_LIMIT = 1_000;
-const MAX_REQUEST_ID_LENGTH = 256;
 const MAX_JSON_DEPTH = 16;
 const MAX_JSON_CONTAINER_ITEMS = 1_000;
 const PROTOTYPE_POLLUTION_KEYS = new Set([
@@ -94,6 +94,14 @@ function stringValue(value: unknown, label: string): string {
     throw new TypeError(`${label} must be a non-empty string`);
   }
   return value;
+}
+
+function identifierValue(value: unknown, label: string): string {
+  const result = stringValue(value, label);
+  if (result.length > DATA_SURFACE_IDENTIFIER_MAX_LENGTH) {
+    throw new TypeError(`${label} is too long`);
+  }
+  return result;
 }
 
 function optionalString(value: unknown, label: string): string | undefined {
@@ -289,15 +297,15 @@ function normalizeIdentity(value: unknown): Record<string, unknown> {
     const source = plainObject(object.subject, 'DataSurface subject');
     exactKeys(source, ['type', 'id', 'label'], 'DataSurface subject');
     subject = {
-      type: stringValue(source.type, 'DataSurface subject type'),
-      id: stringValue(source.id, 'DataSurface subject id'),
+      type: identifierValue(source.type, 'DataSurface subject type'),
+      id: identifierValue(source.id, 'DataSurface subject id'),
       ...(source.label === undefined
         ? {}
         : { label: stringValue(source.label, 'DataSurface subject label') }),
     };
   }
   return {
-    surfaceId: stringValue(object.surfaceId, 'DataSurface surface id'),
+    surfaceId: identifierValue(object.surfaceId, 'DataSurface surface id'),
     kind,
     ...(subject ? { subject } : {}),
   };
@@ -316,6 +324,16 @@ function normalizeStringArray(
     throw new TypeError(`${label} cannot contain duplicates`);
   }
   return sort ? values.sort() : values;
+}
+
+function normalizeIdentifierArray(
+  value: unknown,
+  label: string,
+  sort = false,
+): string[] {
+  return normalizeStringArray(value, label, sort).map((entry) =>
+    identifierValue(entry, label),
+  );
 }
 
 function normalizeSensitivity(
@@ -431,7 +449,7 @@ export function normalizeDataSurfaceDescriptor(value: unknown): unknown {
       throw new TypeError('Unsupported DataSurface column capability');
     }
     return {
-      id: stringValue(column.id, 'DataSurface column id'),
+      id: identifierValue(column.id, 'DataSurface column id'),
       label: stringValue(column.label, 'DataSurface column label'),
       ...(column.description === undefined
         ? {}
@@ -467,7 +485,7 @@ export function normalizeDataSurfaceDescriptor(value: unknown): unknown {
   );
   if (modes.some((mode) => !QUERY_MODES.has(mode)))
     throw new TypeError('Unsupported DataSurface query mode');
-  const projectableColumnIds = normalizeStringArray(
+  const projectableColumnIds = normalizeIdentifierArray(
     query.projectableColumnIds,
     'DataSurface projectable column ids',
     true,
@@ -484,7 +502,7 @@ export function normalizeDataSurfaceDescriptor(value: unknown): unknown {
     const control = plainObject(value, 'DataSurface control');
     exactKeys(control, ['id', 'label', 'description'], 'DataSurface control');
     return {
-      id: stringValue(control.id, 'DataSurface control id'),
+      id: identifierValue(control.id, 'DataSurface control id'),
       label: stringValue(control.label, 'DataSurface control label'),
       ...(control.description === undefined
         ? {}
@@ -532,7 +550,7 @@ export function normalizeDataSurfaceDescriptor(value: unknown): unknown {
     if (selectionScopes.some((scope) => !SELECTION_SCOPES.has(scope)))
       throw new TypeError('Unsupported DataSurface action selection scope');
     return {
-      id: stringValue(action.id, 'DataSurface action id'),
+      id: identifierValue(action.id, 'DataSurface action id'),
       label: stringValue(action.label, 'DataSurface action label'),
       ...(action.description === undefined
         ? {}
@@ -570,7 +588,7 @@ export function normalizeDataSurfaceDescriptor(value: unknown): unknown {
   );
   if (maxQueryRows > MAX_QUERY_LIMIT)
     throw new TypeError('DataSurface maxQueryRows exceeds its limit');
-  const rowKey = stringValue(object.rowKey, 'DataSurface row key');
+  const rowKey = identifierValue(object.rowKey, 'DataSurface row key');
   if (!knownColumns.has(rowKey))
     throw new TypeError('DataSurface rowKey must name a declared column');
   return {
@@ -645,15 +663,13 @@ export function normalizeDataSurfaceVisibleCommand(value: unknown): unknown {
   );
   if (object.version !== 1)
     throw new TypeError('Unsupported DataSurface visible command version');
-  const commandId = stringValue(object.commandId, 'DataSurface command id');
-  if (commandId.length > MAX_REQUEST_ID_LENGTH)
-    throw new TypeError('DataSurface command id is too long');
+  const commandId = identifierValue(object.commandId, 'DataSurface command id');
   const normalized = {
     version: 1 as const,
     commandId,
     identity: normalizeIdentity(object.identity),
     expectedRevision: revisionNumber(object.expectedRevision),
-    controlId: stringValue(object.controlId, 'DataSurface control id'),
+    controlId: identifierValue(object.controlId, 'DataSurface control id'),
     ...(object.payload === undefined
       ? {}
       : { payload: boundarySafe(object.payload) }),

--- a/packages/chat/src/data-surface-normalizer.ts
+++ b/packages/chat/src/data-surface-normalizer.ts
@@ -5,9 +5,11 @@
  * includes component modules and is not safe to load from a plain Node server.
  */
 
-import { DATA_SURFACE_IDENTIFIER_MAX_LENGTH } from '@happyvertical/smrt-ui/data-surface';
+import {
+  DATA_SURFACE_IDENTIFIER_MAX_LENGTH,
+  DATA_SURFACE_MAX_REQUEST_BYTES,
+} from '@happyvertical/smrt-ui/data-surface';
 
-const MAX_REQUEST_BYTES = 100_000;
 const MAX_QUERY_LIMIT = 1_000;
 const MAX_JSON_DEPTH = 16;
 const MAX_JSON_CONTAINER_ITEMS = 1_000;
@@ -249,7 +251,7 @@ function canonicalJson(
 function assertRequestByteLimit(value: unknown): void {
   canonicalJson(value, new Set<object>(), 0, {
     used: 0,
-    limit: MAX_REQUEST_BYTES,
+    limit: DATA_SURFACE_MAX_REQUEST_BYTES,
   });
 }
 

--- a/packages/chat/src/data-surface-normalizer.ts
+++ b/packages/chat/src/data-surface-normalizer.ts
@@ -5,8 +5,9 @@
  * includes component modules and is not safe to load from a plain Node server.
  */
 
+import { DATA_SURFACE_IDENTIFIER_MAX_LENGTH } from '@happyvertical/smrt-ui/data-surface';
+
 const MAX_REQUEST_BYTES = 100_000;
-export const DATA_SURFACE_IDENTIFIER_MAX_LENGTH = 256;
 const MAX_QUERY_LIMIT = 1_000;
 const MAX_JSON_DEPTH = 16;
 const MAX_JSON_CONTAINER_ITEMS = 1_000;
@@ -378,7 +379,12 @@ function normalizeSelection(value: unknown): Record<string, unknown> {
           'DataSurface row ids must be finite strings or numbers',
         );
       }
-      const normalized = typeof rowId === 'number' && rowId === 0 ? 0 : rowId;
+      const normalized =
+        typeof rowId === 'string'
+          ? identifierValue(rowId, 'DataSurface row id')
+          : rowId === 0
+            ? 0
+            : rowId;
       rowIds.set(`${typeof normalized}:${String(normalized)}`, normalized);
     }
     return {
@@ -399,7 +405,7 @@ function normalizeSelection(value: unknown): Record<string, unknown> {
   );
   return {
     scope,
-    queryFingerprint: stringValue(
+    queryFingerprint: identifierValue(
       object.queryFingerprint,
       'DataSurface query fingerprint',
     ),

--- a/packages/chat/src/data-surface-normalizer.ts
+++ b/packages/chat/src/data-surface-normalizer.ts
@@ -1,0 +1,664 @@
+/**
+ * Node-safe canonical validation for the server-side data-surface bridge.
+ *
+ * Keep this leaf free of Svelte imports. The browser-facing smrt-ui barrel
+ * includes component modules and is not safe to load from a plain Node server.
+ */
+
+const MAX_REQUEST_BYTES = 100_000;
+const MAX_QUERY_LIMIT = 1_000;
+const MAX_REQUEST_ID_LENGTH = 256;
+const MAX_JSON_DEPTH = 16;
+const MAX_JSON_CONTAINER_ITEMS = 1_000;
+const PROTOTYPE_POLLUTION_KEYS = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+]);
+const FORBIDDEN_BOUNDARY_KEYS = new Set([
+  'tenant',
+  'tenantid',
+  'principalid',
+  'principal',
+  'actorid',
+  'auth',
+  'authtoken',
+  'authorization',
+  'authorizationtoken',
+  'authorizationheader',
+  'authentication',
+  'authenticationtoken',
+  'accesstoken',
+  'token',
+  'bearer',
+  'bearertoken',
+  'apikey',
+  'sessiontoken',
+  'credential',
+  'credentials',
+  'sql',
+  'rawsql',
+  'rawquery',
+  'where',
+]);
+const KINDS = new Set(['table', 'list', 'report', 'custom']);
+const SENSITIVITIES = new Set(['public', 'personal', 'sensitive', 'secret']);
+const CAPABILITIES = new Set(['read', 'search', 'filter', 'sort', 'project']);
+const QUERY_MODES = new Set(['rows', 'count', 'facets']);
+const SELECTION_SCOPES = new Set([
+  'current-page',
+  'explicit-ids',
+  'all-matching',
+]);
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+interface Budget {
+  used: number;
+  limit: number;
+}
+
+function plainObject(value: unknown, label: string): Record<string, unknown> {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    Array.isArray(value) ||
+    Object.getPrototypeOf(value) !== Object.prototype
+  ) {
+    throw new TypeError(`${label} must be a plain object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+  label: string,
+): void {
+  const accepted = new Set(allowed);
+  for (const key of Object.keys(value)) {
+    if (!accepted.has(key)) {
+      throw new TypeError(`${label} contains unsupported field: ${key}`);
+    }
+  }
+}
+
+function stringValue(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new TypeError(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown, label: string): string | undefined {
+  return value === undefined ? undefined : stringValue(value, label);
+}
+
+function positiveInteger(value: unknown, label: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    throw new TypeError(`${label} must be a positive safe integer`);
+  }
+  return value;
+}
+
+function revisionNumber(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError('DataSurface revision must be a non-negative integer');
+  }
+  return value;
+}
+
+function addBytes(budget: Budget | undefined, bytes: number): void {
+  if (!budget) return;
+  if (bytes > budget.limit - budget.used) {
+    throw new TypeError(
+      `DataSurface envelope cannot exceed ${budget.limit} UTF-8 bytes`,
+    );
+  }
+  budget.used += bytes;
+}
+
+function jsonStringByteLength(value: string, budget?: Budget): number {
+  let bytes = 2;
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit === 0x22 || codeUnit === 0x5c) bytes += 2;
+    else if (
+      codeUnit === 0x08 ||
+      codeUnit === 0x09 ||
+      codeUnit === 0x0a ||
+      codeUnit === 0x0c ||
+      codeUnit === 0x0d
+    )
+      bytes += 2;
+    else if (codeUnit <= 0x1f) bytes += 6;
+    else if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        index += 1;
+      } else bytes += 6;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) bytes += 6;
+    else if (codeUnit <= 0x7f) bytes += 1;
+    else if (codeUnit <= 0x7ff) bytes += 2;
+    else bytes += 3;
+    if (budget && bytes > budget.limit - budget.used) {
+      throw new TypeError(
+        `DataSurface envelope cannot exceed ${budget.limit} UTF-8 bytes`,
+      );
+    }
+  }
+  addBytes(budget, bytes);
+  return bytes;
+}
+
+function canonicalJson(
+  value: unknown,
+  ancestors = new Set<object>(),
+  depth = 0,
+  budget?: Budget,
+): JsonValue {
+  if (depth > MAX_JSON_DEPTH) {
+    throw new TypeError(
+      `DataSurface values cannot exceed ${MAX_JSON_DEPTH} levels`,
+    );
+  }
+  if (value === null) {
+    addBytes(budget, 4);
+    return null;
+  }
+  if (typeof value === 'string') {
+    jsonStringByteLength(value, budget);
+    return value;
+  }
+  if (typeof value === 'boolean') {
+    addBytes(budget, value ? 4 : 5);
+    return value;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new TypeError(
+        'DataSurface values cannot contain non-finite numbers',
+      );
+    }
+    const normalized = value === 0 ? 0 : value;
+    addBytes(budget, String(normalized).length);
+    return normalized;
+  }
+  if (!value || typeof value !== 'object') {
+    throw new TypeError('DataSurface values must be JSON-safe plain data');
+  }
+  if (ancestors.has(value)) {
+    throw new TypeError('DataSurface values cannot be circular');
+  }
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      if (value.length > MAX_JSON_CONTAINER_ITEMS) {
+        throw new TypeError('DataSurface arrays contain too many items');
+      }
+      addBytes(budget, 1);
+      const clone: JsonValue[] = [];
+      for (const [index, entry] of value.entries()) {
+        if (index > 0) addBytes(budget, 1);
+        clone.push(canonicalJson(entry, ancestors, depth + 1, budget));
+      }
+      addBytes(budget, 1);
+      return clone;
+    }
+    const object = plainObject(value, 'DataSurface value');
+    const clone: { [key: string]: JsonValue } = {};
+    const keys = Object.keys(object).sort();
+    if (keys.length > MAX_JSON_CONTAINER_ITEMS) {
+      throw new TypeError('DataSurface objects contain too many keys');
+    }
+    addBytes(budget, 1);
+    for (const [index, key] of keys.entries()) {
+      if (index > 0) addBytes(budget, 1);
+      if (PROTOTYPE_POLLUTION_KEYS.has(key)) {
+        throw new TypeError(
+          `DataSurface values cannot contain prototype key: ${key}`,
+        );
+      }
+      jsonStringByteLength(key, budget);
+      addBytes(budget, 1);
+      clone[key] = canonicalJson(object[key], ancestors, depth + 1, budget);
+    }
+    addBytes(budget, 1);
+    return clone;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function assertRequestByteLimit(value: unknown): void {
+  canonicalJson(value, new Set<object>(), 0, {
+    used: 0,
+    limit: MAX_REQUEST_BYTES,
+  });
+}
+
+export function assertDataSurfaceEnvelope(value: unknown): void {
+  assertRequestByteLimit(value);
+}
+
+function boundarySafe(value: unknown): JsonValue {
+  const clone = canonicalJson(value);
+  const inspect = (entry: JsonValue): void => {
+    if (Array.isArray(entry)) {
+      for (const item of entry) inspect(item);
+    } else if (entry && typeof entry === 'object') {
+      for (const [key, item] of Object.entries(entry)) {
+        if (
+          FORBIDDEN_BOUNDARY_KEYS.has(key.replaceAll(/[-_]/g, '').toLowerCase())
+        ) {
+          throw new TypeError(
+            `DataSurface boundary field is forbidden: ${key}`,
+          );
+        }
+        inspect(item);
+      }
+    }
+  };
+  inspect(clone);
+  return clone;
+}
+
+function boundarySafeObject(value: unknown): { [key: string]: JsonValue } {
+  const clone = boundarySafe(value);
+  if (!clone || Array.isArray(clone) || typeof clone !== 'object') {
+    throw new TypeError('DataSurface snapshot state must be an object');
+  }
+  return clone;
+}
+
+function normalizeIdentity(value: unknown): Record<string, unknown> {
+  const object = plainObject(value, 'DataSurface identity');
+  exactKeys(object, ['surfaceId', 'kind', 'subject'], 'DataSurface identity');
+  const kind = stringValue(object.kind, 'DataSurface kind');
+  if (!KINDS.has(kind))
+    throw new TypeError(`Unsupported DataSurface kind: ${kind}`);
+  let subject: Record<string, string> | undefined;
+  if (object.subject !== undefined) {
+    const source = plainObject(object.subject, 'DataSurface subject');
+    exactKeys(source, ['type', 'id', 'label'], 'DataSurface subject');
+    subject = {
+      type: stringValue(source.type, 'DataSurface subject type'),
+      id: stringValue(source.id, 'DataSurface subject id'),
+      ...(source.label === undefined
+        ? {}
+        : { label: stringValue(source.label, 'DataSurface subject label') }),
+    };
+  }
+  return {
+    surfaceId: stringValue(object.surfaceId, 'DataSurface surface id'),
+    kind,
+    ...(subject ? { subject } : {}),
+  };
+}
+
+function normalizeStringArray(
+  value: unknown,
+  label: string,
+  sort = false,
+): string[] {
+  if (!Array.isArray(value) || value.length > MAX_JSON_CONTAINER_ITEMS) {
+    throw new TypeError(`${label} must be a bounded array`);
+  }
+  const values = value.map((entry) => stringValue(entry, label));
+  if (new Set(values).size !== values.length) {
+    throw new TypeError(`${label} cannot contain duplicates`);
+  }
+  return sort ? values.sort() : values;
+}
+
+function normalizeSensitivity(
+  value: unknown,
+  label: string,
+): string | undefined {
+  if (value === undefined) return undefined;
+  const sensitivity = stringValue(value, label);
+  if (!SENSITIVITIES.has(sensitivity)) {
+    throw new TypeError(`Unsupported DataSurface sensitivity: ${sensitivity}`);
+  }
+  return sensitivity;
+}
+
+function normalizeSelection(value: unknown): Record<string, unknown> {
+  const object = plainObject(value, 'DataSurface selection');
+  const scope = stringValue(object.scope, 'DataSurface selection scope');
+  if (!SELECTION_SCOPES.has(scope)) {
+    throw new TypeError(`Unsupported DataSurface selection scope: ${scope}`);
+  }
+  if (scope === 'current-page') {
+    exactKeys(object, ['scope'], 'DataSurface current-page selection');
+    return { scope };
+  }
+  if (scope === 'explicit-ids') {
+    exactKeys(object, ['scope', 'rowIds'], 'DataSurface explicit selection');
+    if (
+      !Array.isArray(object.rowIds) ||
+      object.rowIds.length > MAX_JSON_CONTAINER_ITEMS
+    ) {
+      throw new TypeError(
+        'DataSurface explicit selection rowIds must be bounded',
+      );
+    }
+    const rowIds = new Map<string, string | number>();
+    for (const rowId of object.rowIds) {
+      if (
+        typeof rowId !== 'string' &&
+        (typeof rowId !== 'number' || !Number.isFinite(rowId))
+      ) {
+        throw new TypeError(
+          'DataSurface row ids must be finite strings or numbers',
+        );
+      }
+      const normalized = typeof rowId === 'number' && rowId === 0 ? 0 : rowId;
+      rowIds.set(`${typeof normalized}:${String(normalized)}`, normalized);
+    }
+    return {
+      scope,
+      rowIds: [...rowIds.values()].sort((left, right) => {
+        if (typeof left !== typeof right)
+          return typeof left === 'number' ? -1 : 1;
+        if (typeof left === 'number' && typeof right === 'number')
+          return left - right;
+        return left < right ? -1 : left > right ? 1 : 0;
+      }),
+    };
+  }
+  exactKeys(
+    object,
+    ['scope', 'queryFingerprint'],
+    'DataSurface all-matching selection',
+  );
+  return {
+    scope,
+    queryFingerprint: stringValue(
+      object.queryFingerprint,
+      'DataSurface query fingerprint',
+    ),
+  };
+}
+
+export function normalizeDataSurfaceDescriptor(value: unknown): unknown {
+  const object = plainObject(value, 'DataSurface descriptor');
+  exactKeys(
+    object,
+    [
+      'version',
+      'identity',
+      'schemaVersion',
+      'label',
+      'description',
+      'rowKey',
+      'columns',
+      'query',
+      'controls',
+      'actions',
+      'limits',
+    ],
+    'DataSurface descriptor',
+  );
+  if (object.version !== 1)
+    throw new TypeError('Unsupported DataSurface descriptor version');
+  if (
+    !Array.isArray(object.columns) ||
+    object.columns.length > MAX_JSON_CONTAINER_ITEMS
+  ) {
+    throw new TypeError('DataSurface descriptor columns must be bounded');
+  }
+  const columns = object.columns.map((value) => {
+    const column = plainObject(value, 'DataSurface column');
+    exactKeys(
+      column,
+      ['id', 'label', 'description', 'sensitivity', 'capabilities'],
+      'DataSurface column',
+    );
+    const capabilities = normalizeStringArray(
+      column.capabilities,
+      'DataSurface column capabilities',
+      true,
+    );
+    if (capabilities.some((capability) => !CAPABILITIES.has(capability))) {
+      throw new TypeError('Unsupported DataSurface column capability');
+    }
+    return {
+      id: stringValue(column.id, 'DataSurface column id'),
+      label: stringValue(column.label, 'DataSurface column label'),
+      ...(column.description === undefined
+        ? {}
+        : {
+            description: stringValue(
+              column.description,
+              'DataSurface column description',
+            ),
+          }),
+      ...(column.sensitivity === undefined
+        ? {}
+        : {
+            sensitivity: normalizeSensitivity(
+              column.sensitivity,
+              'DataSurface column sensitivity',
+            ),
+          }),
+      capabilities,
+    };
+  });
+  if (new Set(columns.map((column) => column.id)).size !== columns.length)
+    throw new TypeError('DataSurface descriptor column ids must be unique');
+  const query = plainObject(object.query, 'DataSurface query capabilities');
+  exactKeys(
+    query,
+    ['modes', 'projectableColumnIds'],
+    'DataSurface query capabilities',
+  );
+  const modes = normalizeStringArray(
+    query.modes,
+    'DataSurface query modes',
+    true,
+  );
+  if (modes.some((mode) => !QUERY_MODES.has(mode)))
+    throw new TypeError('Unsupported DataSurface query mode');
+  const projectableColumnIds = normalizeStringArray(
+    query.projectableColumnIds,
+    'DataSurface projectable column ids',
+    true,
+  );
+  const knownColumns = new Set(columns.map((column) => column.id));
+  if (projectableColumnIds.some((columnId) => !knownColumns.has(columnId)))
+    throw new TypeError('Unknown projectable DataSurface column');
+  if (
+    !Array.isArray(object.controls) ||
+    object.controls.length > MAX_JSON_CONTAINER_ITEMS
+  )
+    throw new TypeError('DataSurface controls must be bounded');
+  const controls = object.controls.map((value) => {
+    const control = plainObject(value, 'DataSurface control');
+    exactKeys(control, ['id', 'label', 'description'], 'DataSurface control');
+    return {
+      id: stringValue(control.id, 'DataSurface control id'),
+      label: stringValue(control.label, 'DataSurface control label'),
+      ...(control.description === undefined
+        ? {}
+        : {
+            description: stringValue(
+              control.description,
+              'DataSurface control description',
+            ),
+          }),
+    };
+  });
+  if (new Set(controls.map((control) => control.id)).size !== controls.length)
+    throw new TypeError('DataSurface control ids must be unique');
+  if (
+    !Array.isArray(object.actions) ||
+    object.actions.length > MAX_JSON_CONTAINER_ITEMS
+  )
+    throw new TypeError('DataSurface actions must be bounded');
+  const actions = object.actions.map((value) => {
+    const action = plainObject(value, 'DataSurface action');
+    exactKeys(
+      action,
+      [
+        'id',
+        'label',
+        'description',
+        'sensitivity',
+        'selectionScopes',
+        'requiresConfirmation',
+      ],
+      'DataSurface action',
+    );
+    if (
+      action.requiresConfirmation !== undefined &&
+      typeof action.requiresConfirmation !== 'boolean'
+    )
+      throw new TypeError(
+        'DataSurface action requiresConfirmation must be boolean',
+      );
+    const selectionScopes = normalizeStringArray(
+      action.selectionScopes,
+      'DataSurface action selection scopes',
+      true,
+    );
+    if (selectionScopes.some((scope) => !SELECTION_SCOPES.has(scope)))
+      throw new TypeError('Unsupported DataSurface action selection scope');
+    return {
+      id: stringValue(action.id, 'DataSurface action id'),
+      label: stringValue(action.label, 'DataSurface action label'),
+      ...(action.description === undefined
+        ? {}
+        : {
+            description: stringValue(
+              action.description,
+              'DataSurface action description',
+            ),
+          }),
+      ...(action.sensitivity === undefined
+        ? {}
+        : {
+            sensitivity: normalizeSensitivity(
+              action.sensitivity,
+              'DataSurface action sensitivity',
+            ),
+          }),
+      selectionScopes,
+      ...(action.requiresConfirmation === undefined
+        ? {}
+        : { requiresConfirmation: action.requiresConfirmation }),
+    };
+  });
+  if (new Set(actions.map((action) => action.id)).size !== actions.length)
+    throw new TypeError('DataSurface action ids must be unique');
+  const limits = plainObject(object.limits, 'DataSurface limits');
+  exactKeys(
+    limits,
+    ['maxQueryRows', 'maxQueryBytes', 'maxSelectionSize'],
+    'DataSurface limits',
+  );
+  const maxQueryRows = positiveInteger(
+    limits.maxQueryRows,
+    'DataSurface maxQueryRows',
+  );
+  if (maxQueryRows > MAX_QUERY_LIMIT)
+    throw new TypeError('DataSurface maxQueryRows exceeds its limit');
+  const rowKey = stringValue(object.rowKey, 'DataSurface row key');
+  if (!knownColumns.has(rowKey))
+    throw new TypeError('DataSurface rowKey must name a declared column');
+  return {
+    version: 1,
+    identity: normalizeIdentity(object.identity),
+    schemaVersion: positiveInteger(
+      object.schemaVersion,
+      'DataSurface schema version',
+    ),
+    label: stringValue(object.label, 'DataSurface label'),
+    ...(object.description === undefined
+      ? {}
+      : {
+          description: stringValue(
+            object.description,
+            'DataSurface description',
+          ),
+        }),
+    rowKey,
+    columns,
+    query: { modes, projectableColumnIds },
+    controls,
+    actions,
+    limits: {
+      maxQueryRows,
+      maxQueryBytes: positiveInteger(
+        limits.maxQueryBytes,
+        'DataSurface maxQueryBytes',
+      ),
+      maxSelectionSize: positiveInteger(
+        limits.maxSelectionSize,
+        'DataSurface maxSelectionSize',
+      ),
+    },
+  };
+}
+
+export function normalizeDataSurfaceSnapshot(value: unknown): unknown {
+  const object = plainObject(value, 'DataSurface snapshot');
+  exactKeys(
+    object,
+    ['version', 'descriptor', 'revision', 'state', 'selection'],
+    'DataSurface snapshot',
+  );
+  if (object.version !== 1)
+    throw new TypeError('Unsupported DataSurface snapshot version');
+  return {
+    version: 1,
+    descriptor: normalizeDataSurfaceDescriptor(object.descriptor),
+    revision: revisionNumber(object.revision),
+    state: boundarySafeObject(object.state),
+    selection:
+      object.selection === null || object.selection === undefined
+        ? null
+        : normalizeSelection(object.selection),
+  };
+}
+
+export function normalizeDataSurfaceVisibleCommand(value: unknown): unknown {
+  const object = plainObject(value, 'DataSurface visible command');
+  exactKeys(
+    object,
+    [
+      'version',
+      'commandId',
+      'identity',
+      'expectedRevision',
+      'controlId',
+      'payload',
+    ],
+    'DataSurface visible command',
+  );
+  if (object.version !== 1)
+    throw new TypeError('Unsupported DataSurface visible command version');
+  const commandId = stringValue(object.commandId, 'DataSurface command id');
+  if (commandId.length > MAX_REQUEST_ID_LENGTH)
+    throw new TypeError('DataSurface command id is too long');
+  const normalized = {
+    version: 1 as const,
+    commandId,
+    identity: normalizeIdentity(object.identity),
+    expectedRevision: revisionNumber(object.expectedRevision),
+    controlId: stringValue(object.controlId, 'DataSurface control id'),
+    ...(object.payload === undefined
+      ? {}
+      : { payload: boundarySafe(object.payload) }),
+  };
+  assertRequestByteLimit(value);
+  assertRequestByteLimit(normalized);
+  return normalized;
+}

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -92,9 +92,6 @@ export {
   type RunChatConversationStreamOptions,
   runChatConversationStream,
 } from './chat-stream.js';
-// Principal-bound data discovery/inspection/query tools are offered through
-// the same `extraTools` seam as invoke-agent; authority remains in agents.
-export * from './data-surface-tools.js';
 // Authenticated browser data-surface command/ack/event bridge. This adapter is
 // transport-neutral; the consuming app supplies its authorized transport.
 export {
@@ -113,6 +110,9 @@ export {
   type DataSurfaceCommandRequest,
   DEFAULT_DATA_SURFACE_BRIDGE_TTL_MS,
 } from './data-surface-bridge.js';
+// Principal-bound data discovery/inspection/query tools are offered through
+// the same `extraTools` seam as invoke-agent; authority remains in agents.
+export * from './data-surface-tools.js';
 // Models
 export {
   AgentSession,

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -95,6 +95,24 @@ export {
 // Principal-bound data discovery/inspection/query tools are offered through
 // the same `extraTools` seam as invoke-agent; authority remains in agents.
 export * from './data-surface-tools.js';
+// Authenticated browser data-surface command/ack/event bridge. This adapter is
+// transport-neutral; the consuming app supplies its authorized transport.
+export {
+  createDataSurfaceBridge,
+  createDataSurfaceCommandBridge,
+  createServerDataSurfaceBridge,
+  DATA_SURFACE_BRIDGE_VERSION,
+  type DataSurfaceBridgeConnectionState,
+  type DataSurfaceBridgeEvent,
+  type DataSurfaceBridgeFailureReason,
+  type DataSurfaceBridgeMessage,
+  type DataSurfaceBridgeTransport,
+  type DataSurfaceCommandAck,
+  type DataSurfaceCommandBridge,
+  type DataSurfaceCommandBridgeOptions,
+  type DataSurfaceCommandRequest,
+  DEFAULT_DATA_SURFACE_BRIDGE_TTL_MS,
+} from './data-surface-bridge.js';
 // Models
 export {
   AgentSession,

--- a/packages/chat/vite.config.ts
+++ b/packages/chat/vite.config.ts
@@ -19,6 +19,8 @@ export default defineConfig(async ({ command, mode }) => {
         // side of chat-stream.ts's contract). Dedicated subpath so widget
         // hosts never pull the server runtime into their bundle.
         'client',
+        // Authenticated data-surface command/ack/event transport adapter.
+        'data-surface-bridge',
         // Internal agent-runtime surface (S5 #1392): emitted under a dedicated
         // subpath, NOT folded into the package index, so only trusted in-process
         // agent runtimes opt into `sendAgentReply`.

--- a/packages/smrt-svelte/README.md
+++ b/packages/smrt-svelte/README.md
@@ -53,8 +53,10 @@ calling the registry. The registry remains the authority for command
 authorization and execution. Command IDs are idempotent while their bounded
 replay entries are retained; concurrent same-signature requests coalesce, a
 conflicting signature is rejected, and replay-capacity exhaustion is reported
-explicitly. TTL, disconnect, invalid-request, and transport failures produce
-protocol outcomes without exposing registry state.
+explicitly. Malformed requests and unauthenticated peers are ignored before an
+acknowledgement; valid requests that expire or encounter disconnect and
+transport failures produce bounded protocol outcomes without exposing registry
+state.
 
 ## Usage
 

--- a/packages/smrt-svelte/README.md
+++ b/packages/smrt-svelte/README.md
@@ -38,6 +38,23 @@ Svelte 5 component library for the s-m-r-t framework. Provides UI components, br
 pnpm add @happyvertical/smrt-svelte
 ```
 
+## Data-surface browser bridge security
+
+The browser bridge is a transport adapter, not an authentication system.
+Configure it only with a session/source binding established by the server and
+use a transport that supplies verified peer metadata. It accepts commands only
+from the configured server peer and emits acknowledgements/events only on the
+bound route; wire `sessionId` and `source` fields must never be treated as
+proof of identity.
+
+The adapter canonicalizes requests and bounds identifiers and envelopes before
+calling the registry. The registry remains the authority for command
+authorization and execution. Command IDs are idempotent while their bounded
+replay entries are retained; concurrent same-signature requests coalesce, a
+conflicting signature is rejected, and replay-capacity exhaustion is reported
+explicitly. TTL, disconnect, invalid-request, and transport failures produce
+protocol outcomes without exposing registry state.
+
 ## Usage
 
 ### Provider Setup

--- a/packages/smrt-svelte/README.md
+++ b/packages/smrt-svelte/README.md
@@ -47,7 +47,8 @@ from the configured server peer and emits acknowledgements/events only on the
 bound route; wire `sessionId` and `source` fields must never be treated as
 proof of identity.
 
-The adapter canonicalizes requests and bounds identifiers and envelopes before
+The adapter canonicalizes requests and applies the shared identifier limit
+from `@happyvertical/smrt-ui/data-surface` along with bounded envelopes before
 calling the registry. The registry remains the authority for command
 authorization and execution. Command IDs are idempotent while their bounded
 replay entries are retained; concurrent same-signature requests coalesce, a

--- a/packages/smrt-svelte/package.json
+++ b/packages/smrt-svelte/package.json
@@ -76,6 +76,18 @@
       "svelte": "./dist/web/index.js",
       "import": "./dist/web/index.js",
       "default": "./dist/web/index.js"
+    },
+    "./data-surface": {
+      "types": "./dist/data-surface.d.ts",
+      "svelte": "./dist/data-surface.js",
+      "import": "./dist/data-surface.js",
+      "default": "./dist/data-surface.js"
+    },
+    "./data": {
+      "types": "./dist/data-surface.d.ts",
+      "svelte": "./dist/data-surface.js",
+      "import": "./dist/data-surface.js",
+      "default": "./dist/data-surface.js"
     }
   },
   "files": [

--- a/packages/smrt-svelte/src/__tests__/data-surface-bridge.test.ts
+++ b/packages/smrt-svelte/src/__tests__/data-surface-bridge.test.ts
@@ -112,9 +112,10 @@ describe('data-surface browser bridge', () => {
       ok: true,
     });
 
-    await link.receive(request({ expiresAt: 2_000 }));
+    await link.receive(request({ expiresAt: 5_000 }));
     await drain();
     expect(execute).toHaveBeenCalledTimes(1);
+    expect(link.messages.at(-1)).toMatchObject({ expiresAt: 5_000 });
   });
 
   it('does not execute stale, expired, or cross-session/source commands', async () => {
@@ -342,6 +343,80 @@ describe('data-surface browser bridge', () => {
       commandId: 'after-error',
       ok: true,
     });
+  });
+
+  it('releases replay capacity when execution never settles before expiry', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_000);
+      const registry = createDataSurfaceRegistry();
+      let finishHung!: () => void;
+      const execute = vi
+        .fn<() => Promise<void> | void>()
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>((resolve) => {
+              finishHung = resolve;
+            }),
+        )
+        .mockImplementationOnce(() => undefined);
+      registry.register({
+        descriptor,
+        getSnapshot: () => ({ revision: 1, state: {} }),
+        execute,
+      });
+      registry.register({
+        descriptor: {
+          ...descriptor,
+          identity: { surfaceId: 'invoices', kind: 'table' },
+        },
+        getSnapshot: () => ({ revision: 1, state: {} }),
+        execute,
+      });
+      const link = transport();
+      createDataSurfaceBrowserBridge({
+        registry,
+        transport: link,
+        sessionId: 'session-1',
+        source: 'browser-1',
+        peerSource: 'server-1',
+        maxReplayEntries: 1,
+      });
+
+      const first = link.receive(
+        request({ commandId: 'hung', expiresAt: 1_100 }),
+      );
+      await vi.advanceTimersByTimeAsync(100);
+      await first;
+      expect(link.messages.at(-1)).toMatchObject({
+        commandId: 'hung',
+        reason: 'expired',
+      });
+      finishHung();
+      await vi.runOnlyPendingTimersAsync();
+      expect(
+        link.messages.filter(
+          (message) =>
+            message.type === 'data-surface.ack' && message.commandId === 'hung',
+        ),
+      ).toHaveLength(1);
+
+      await link.receive(
+        request({
+          commandId: 'after-hung',
+          expiresAt: 5_000,
+          identity: { surfaceId: 'invoices', kind: 'table' },
+        }),
+      );
+      await vi.runOnlyPendingTimersAsync();
+      expect(execute).toHaveBeenCalledTimes(2);
+      expect(link.messages.at(-1)).toMatchObject({
+        commandId: 'after-hung',
+        ok: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('forwards only monotonic registry events', async () => {

--- a/packages/smrt-svelte/src/__tests__/data-surface-bridge.test.ts
+++ b/packages/smrt-svelte/src/__tests__/data-surface-bridge.test.ts
@@ -7,6 +7,7 @@ import {
 import { describe, expect, it, vi } from 'vitest';
 import {
   createDataSurfaceBrowserBridge,
+  DATA_SURFACE_IDENTIFIER_MAX_LENGTH,
   type DataSurfaceBridgeMessage,
   type DataSurfaceBridgePeer,
   type DataSurfaceCommandRequest,
@@ -168,6 +169,27 @@ describe('data-surface browser bridge', () => {
       sessionId: 'attacker',
       source: 'server-1',
     });
+    expect(execute).not.toHaveBeenCalled();
+    expect(link.messages).toHaveLength(0);
+  });
+
+  it('rejects identifiers longer than the shared bridge contract', async () => {
+    const { registry, execute } = fixture();
+    const link = transport();
+    createDataSurfaceBrowserBridge({
+      registry,
+      transport: link,
+      sessionId: 'session-1',
+      source: 'browser-1',
+      peerSource: 'server-1',
+      now: () => 1_000,
+    });
+    const tooLong = 'x'.repeat(DATA_SURFACE_IDENTIFIER_MAX_LENGTH + 1);
+    await link.receive(request({ commandId: tooLong }));
+    await link.receive(request({ controlId: tooLong }));
+    await link.receive(
+      request({ identity: { surfaceId: tooLong, kind: 'table' } }),
+    );
     expect(execute).not.toHaveBeenCalled();
     expect(link.messages).toHaveLength(0);
   });

--- a/packages/smrt-svelte/src/__tests__/data-surface-bridge.test.ts
+++ b/packages/smrt-svelte/src/__tests__/data-surface-bridge.test.ts
@@ -1,0 +1,162 @@
+import {
+  createDataSurfaceRegistry,
+  type DataSurfaceDescriptor,
+  type DataSurfaceIdentity,
+  type DataSurfaceVisibleCommand,
+} from '@happyvertical/smrt-ui/data';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createDataSurfaceBrowserBridge,
+  type DataSurfaceBridgeMessage,
+  type DataSurfaceCommandRequest,
+} from '../data-surface.js';
+
+const identity: DataSurfaceIdentity = { surfaceId: 'orders', kind: 'table' };
+const descriptor: DataSurfaceDescriptor = {
+  version: 1,
+  identity,
+  schemaVersion: 1,
+  label: 'Orders',
+  rowKey: 'id',
+  columns: [{ id: 'id', label: 'ID', capabilities: ['read'] }],
+  query: { modes: ['rows'], projectableColumnIds: ['id'] },
+  controls: [{ id: 'refresh', label: 'Refresh' }],
+  actions: [],
+  limits: { maxQueryRows: 10, maxQueryBytes: 1000, maxSelectionSize: 10 },
+};
+
+function request(
+  overrides: Partial<DataSurfaceCommandRequest> = {},
+): DataSurfaceCommandRequest {
+  return {
+    type: 'data-surface.command',
+    version: 1,
+    commandId: 'command-1',
+    sessionId: 'session-1',
+    source: 'server-1',
+    expiresAt: 10_000,
+    identity,
+    expectedRevision: 1,
+    controlId: 'refresh',
+    ...overrides,
+  };
+}
+
+function transport() {
+  const messages: DataSurfaceBridgeMessage[] = [];
+  const listeners = new Set<(message: unknown) => void>();
+  return {
+    messages,
+    send: vi.fn((message: DataSurfaceBridgeMessage) => {
+      messages.push(message);
+    }),
+    subscribe(listener: (message: unknown) => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    receive(message: unknown) {
+      for (const listener of listeners) listener(message);
+    },
+  };
+}
+
+function fixture() {
+  let revision = 1;
+  const execute = vi.fn(() => {
+    revision += 1;
+  });
+  const registry = createDataSurfaceRegistry();
+  registry.register({
+    descriptor,
+    getSnapshot: () => ({ revision, state: { refreshed: revision > 1 } }),
+    execute,
+  });
+  return { registry, execute };
+}
+
+const drain = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe('data-surface browser bridge', () => {
+  it('requires the bound session/source and acknowledges a successful command', async () => {
+    const { registry, execute } = fixture();
+    const link = transport();
+    createDataSurfaceBrowserBridge({
+      registry,
+      transport: link,
+      sessionId: 'session-1',
+      source: 'browser-1',
+      peerSource: 'server-1',
+      now: () => 1_000,
+    });
+
+    await link.receive(request({ expiresAt: 2_000 }));
+    await drain();
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(link.messages.at(-1)).toMatchObject({
+      type: 'data-surface.ack',
+      commandId: 'command-1',
+      sessionId: 'session-1',
+      source: 'browser-1',
+      ok: true,
+    });
+
+    await link.receive(request({ expiresAt: 2_000 }));
+    await drain();
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not execute stale, expired, or cross-session/source commands', async () => {
+    const { registry, execute } = fixture();
+    const link = transport();
+    createDataSurfaceBrowserBridge({
+      registry,
+      transport: link,
+      sessionId: 'session-1',
+      source: 'browser-1',
+      peerSource: 'server-1',
+      now: () => 1_000,
+    });
+
+    await link.receive(request({ commandId: 'stale', expectedRevision: 99 }));
+    await link.receive(request({ commandId: 'expired', expiresAt: 500 }));
+    await link.receive(request({ commandId: 'session', sessionId: 'other' }));
+    await link.receive(request({ commandId: 'source', source: 'other' }));
+    await drain();
+    expect(execute).not.toHaveBeenCalled();
+    expect(
+      link.messages
+        .filter((message) => message.type === 'data-surface.ack')
+        .map((message) => message.reason),
+    ).toEqual(
+      expect.arrayContaining([
+        'stale_revision',
+        'expired',
+        'session_mismatch',
+        'source_mismatch',
+      ]),
+    );
+  });
+
+  it('forwards only monotonic registry events', async () => {
+    const { registry } = fixture();
+    const link = transport();
+    createDataSurfaceBrowserBridge({
+      registry,
+      transport: link,
+      sessionId: 'session-1',
+      source: 'browser-1',
+      peerSource: 'server-1',
+    });
+    await link.receive(
+      request({ commandId: 'event-command', expiresAt: Date.now() + 1000 }),
+    );
+    await drain();
+    const events = link.messages.filter(
+      (message) => message.type === 'data-surface.event',
+    );
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.map((event) => event.sequence)).toEqual(
+      [...events].map((event) => event.sequence).sort((a, b) => a - b),
+    );
+  });
+});

--- a/packages/smrt-svelte/src/__tests__/data-surface-bridge.test.ts
+++ b/packages/smrt-svelte/src/__tests__/data-surface-bridge.test.ts
@@ -190,6 +190,24 @@ describe('data-surface browser bridge', () => {
     await link.receive(
       request({ identity: { surfaceId: tooLong, kind: 'table' } }),
     );
+    await link.receive(
+      request({
+        identity: {
+          surfaceId: 'orders',
+          kind: 'table',
+          subject: { type: tooLong, id: 'docs' },
+        },
+      }),
+    );
+    await link.receive(
+      request({
+        identity: {
+          surfaceId: 'orders',
+          kind: 'table',
+          subject: { type: 'site', id: tooLong },
+        },
+      }),
+    );
     expect(execute).not.toHaveBeenCalled();
     expect(link.messages).toHaveLength(0);
   });

--- a/packages/smrt-svelte/src/__tests__/data-surface-bridge.test.ts
+++ b/packages/smrt-svelte/src/__tests__/data-surface-bridge.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   createDataSurfaceBrowserBridge,
   type DataSurfaceBridgeMessage,
+  type DataSurfaceBridgePeer,
   type DataSurfaceCommandRequest,
 } from '../data-surface.js';
 
@@ -44,18 +45,28 @@ function request(
 
 function transport() {
   const messages: DataSurfaceBridgeMessage[] = [];
-  const listeners = new Set<(message: unknown) => void>();
+  const listeners = new Set<
+    (message: unknown, peer: DataSurfaceBridgePeer) => void
+  >();
   return {
     messages,
     send: vi.fn((message: DataSurfaceBridgeMessage) => {
       messages.push(message);
     }),
-    subscribe(listener: (message: unknown) => void) {
+    subscribe(
+      listener: (message: unknown, peer: DataSurfaceBridgePeer) => void,
+    ) {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
-    receive(message: unknown) {
-      for (const listener of listeners) listener(message);
+    receive(
+      message: unknown,
+      peer: DataSurfaceBridgePeer = {
+        sessionId: 'session-1',
+        source: 'server-1',
+      },
+    ) {
+      for (const listener of listeners) listener(message, peer);
     },
   };
 }
@@ -135,6 +146,64 @@ describe('data-surface browser bridge', () => {
         'source_mismatch',
       ]),
     );
+  });
+
+  it('rejects a command whose wire identity is accompanied by an unauthenticated peer', async () => {
+    const { registry, execute } = fixture();
+    const link = transport();
+    createDataSurfaceBrowserBridge({
+      registry,
+      transport: link,
+      sessionId: 'session-1',
+      source: 'browser-1',
+      peerSource: 'server-1',
+      now: () => 1_000,
+    });
+
+    await link.receive(request(), {
+      sessionId: 'session-1',
+      source: 'attacker',
+    });
+    await link.receive(request({ commandId: 'session-spoof' }), {
+      sessionId: 'attacker',
+      source: 'server-1',
+    });
+    expect(execute).not.toHaveBeenCalled();
+    expect(link.messages).toHaveLength(0);
+  });
+
+  it('retains every unexpired replay outcome and refuses new commands at capacity', async () => {
+    const { registry, execute } = fixture();
+    const link = transport();
+    createDataSurfaceBrowserBridge({
+      registry,
+      transport: link,
+      sessionId: 'session-1',
+      source: 'browser-1',
+      peerSource: 'server-1',
+      now: () => 1_000,
+      maxReplayEntries: 2,
+    });
+
+    await link.receive(request({ commandId: 'one', expiresAt: 5_000 }));
+    await drain();
+    await link.receive(
+      request({ commandId: 'two', expectedRevision: 2, expiresAt: 5_000 }),
+    );
+    await drain();
+    await link.receive(
+      request({ commandId: 'three', expectedRevision: 3, expiresAt: 5_000 }),
+    );
+    await drain();
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(link.messages.at(-1)).toMatchObject({
+      commandId: 'three',
+      reason: 'replay_capacity_exceeded',
+    });
+
+    await link.receive(request({ commandId: 'one', expiresAt: 5_000 }));
+    await drain();
+    expect(execute).toHaveBeenCalledTimes(2);
   });
 
   it('forwards only monotonic registry events', async () => {

--- a/packages/smrt-svelte/src/__tests__/data-surface-bridge.test.ts
+++ b/packages/smrt-svelte/src/__tests__/data-surface-bridge.test.ts
@@ -206,6 +206,104 @@ describe('data-surface browser bridge', () => {
     expect(execute).toHaveBeenCalledTimes(2);
   });
 
+  it('atomically reserves replay capacity while concurrent executions are held', async () => {
+    const registry = createDataSurfaceRegistry();
+    const releases: Array<() => void> = [];
+    const execute = vi.fn(
+      () => new Promise<void>((resolve) => releases.push(resolve)),
+    );
+    registry.register({
+      descriptor,
+      getSnapshot: () => ({ revision: 1, state: {} }),
+      execute,
+    });
+    const link = transport();
+    createDataSurfaceBrowserBridge({
+      registry,
+      transport: link,
+      sessionId: 'session-1',
+      source: 'browser-1',
+      peerSource: 'server-1',
+      now: () => 1_000,
+      maxReplayEntries: 2,
+    });
+
+    void link.receive(request({ commandId: 'held-one', expiresAt: 5_000 }));
+    void link.receive(request({ commandId: 'held-two', expiresAt: 5_000 }));
+    void link.receive(request({ commandId: 'held-three', expiresAt: 5_000 }));
+    for (
+      let attempt = 0;
+      attempt < 5 && execute.mock.calls.length < 1;
+      attempt++
+    ) {
+      await drain();
+    }
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(link.messages).toContainEqual(
+      expect.objectContaining({
+        type: 'data-surface.ack',
+        commandId: 'held-three',
+        reason: 'replay_capacity_exceeded',
+      }),
+    );
+
+    releases[0]?.();
+    for (
+      let attempt = 0;
+      attempt < 5 && execute.mock.calls.length < 2;
+      attempt++
+    ) {
+      await drain();
+    }
+    releases[1]?.();
+    await drain();
+    await drain();
+    expect(
+      link.messages.filter(
+        (message) => message.type === 'data-surface.ack' && message.ok === true,
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('releases replay reservations when execution errors after expiry', async () => {
+    let current = 1_000;
+    const registry = createDataSurfaceRegistry();
+    const execute = vi
+      .fn<() => void>()
+      .mockImplementationOnce(() => {
+        throw new Error('boom');
+      })
+      .mockImplementationOnce(() => undefined);
+    registry.register({
+      descriptor,
+      getSnapshot: () => ({ revision: 1, state: {} }),
+      execute,
+    });
+    const link = transport();
+    createDataSurfaceBrowserBridge({
+      registry,
+      transport: link,
+      sessionId: 'session-1',
+      source: 'browser-1',
+      peerSource: 'server-1',
+      now: () => current,
+      maxReplayEntries: 1,
+    });
+
+    await link.receive(
+      request({ commandId: 'expired-error', expiresAt: 1_100 }),
+    );
+    await drain();
+    current = 1_200;
+    await link.receive(request({ commandId: 'after-error', expiresAt: 5_000 }));
+    await drain();
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(link.messages.at(-1)).toMatchObject({
+      commandId: 'after-error',
+      ok: true,
+    });
+  });
+
   it('forwards only monotonic registry events', async () => {
     const { registry } = fixture();
     const link = transport();

--- a/packages/smrt-svelte/src/data-surface.ts
+++ b/packages/smrt-svelte/src/data-surface.ts
@@ -17,11 +17,12 @@ import {
   type DataSurfaceVisibleCommand,
   normalizeDataSurfaceVisibleCommand,
 } from '@happyvertical/smrt-ui/data';
+import { DATA_SURFACE_IDENTIFIER_MAX_LENGTH } from '@happyvertical/smrt-ui/data-surface';
 
 export const DATA_SURFACE_BRIDGE_VERSION = 1 as const;
 export const DEFAULT_DATA_SURFACE_BRIDGE_TTL_MS = 30_000;
 export const DEFAULT_DATA_SURFACE_BRIDGE_REPLAY_ENTRIES = 100;
-export const DATA_SURFACE_IDENTIFIER_MAX_LENGTH = 256;
+export { DATA_SURFACE_IDENTIFIER_MAX_LENGTH } from '@happyvertical/smrt-ui/data-surface';
 
 export type DataSurfaceBridgeFailureReason =
   | 'not_found'
@@ -147,6 +148,10 @@ function isString(value: unknown): value is string {
   );
 }
 
+function isDisplayString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
 function isPeer(value: unknown): value is DataSurfaceBridgePeer {
   return isRecord(value) && isString(value.sessionId) && isString(value.source);
 }
@@ -172,7 +177,8 @@ function identityOf(value: unknown): DataSurfaceIdentity | undefined {
       !isRecord(value.subject) ||
       !isString(value.subject.type) ||
       !isString(value.subject.id) ||
-      (value.subject.label !== undefined && !isString(value.subject.label))
+      (value.subject.label !== undefined &&
+        !isDisplayString(value.subject.label))
     ) {
       return undefined;
     }

--- a/packages/smrt-svelte/src/data-surface.ts
+++ b/packages/smrt-svelte/src/data-surface.ts
@@ -1,0 +1,377 @@
+/**
+ * Authenticated browser bridge for mounted data surfaces.
+ *
+ * `smrt-ui` owns the local registry and deliberately knows nothing about
+ * transports or authentication. This adapter is the browser-side trust
+ * boundary: only a request carrying the configured session and peer source is
+ * delivered to the registry. A command is successful only after its ack has
+ * travelled back through the transport.
+ */
+
+import {
+  type DataSurfaceCommandResult,
+  type DataSurfaceIdentity,
+  type DataSurfaceRegistry,
+  type DataSurfaceRegistryEvent,
+  type DataSurfaceSnapshot,
+  type DataSurfaceVisibleCommand,
+  normalizeDataSurfaceVisibleCommand,
+} from '@happyvertical/smrt-ui/data';
+
+export const DATA_SURFACE_BRIDGE_VERSION = 1 as const;
+export const DEFAULT_DATA_SURFACE_BRIDGE_TTL_MS = 30_000;
+export const DEFAULT_DATA_SURFACE_BRIDGE_REPLAY_ENTRIES = 100;
+
+export type DataSurfaceBridgeFailureReason =
+  | 'not_found'
+  | 'unsupported'
+  | 'stale_revision'
+  | 'idempotency_conflict'
+  | 'denied'
+  | 'execution_failed'
+  | 'non_monotonic_revision'
+  | 'expired'
+  | 'timeout'
+  | 'disconnected'
+  | 'invalid_request'
+  | 'source_mismatch'
+  | 'session_mismatch';
+
+export interface DataSurfaceCommandRequest {
+  type: 'data-surface.command';
+  version: typeof DATA_SURFACE_BRIDGE_VERSION;
+  commandId: string;
+  sessionId: string;
+  /** Authenticated peer/source id, never a profile or tenant authority. */
+  source: string;
+  expiresAt: number;
+  identity: DataSurfaceIdentity;
+  expectedRevision: number;
+  controlId: string;
+  payload?: DataSurfaceVisibleCommand['payload'];
+}
+
+export interface DataSurfaceCommandAck {
+  type: 'data-surface.ack';
+  version: typeof DATA_SURFACE_BRIDGE_VERSION;
+  commandId: string;
+  sessionId: string;
+  source: string;
+  expiresAt: number;
+  identity: DataSurfaceIdentity;
+  expectedRevision: number;
+  ok: boolean;
+  revision?: number;
+  snapshot?: DataSurfaceSnapshot;
+  reason?: DataSurfaceBridgeFailureReason;
+}
+
+export interface DataSurfaceBridgeEvent {
+  type: 'data-surface.event';
+  version: typeof DATA_SURFACE_BRIDGE_VERSION;
+  sessionId: string;
+  source: string;
+  sequence: number;
+  identity: DataSurfaceIdentity;
+  revision: number;
+  event: DataSurfaceRegistryEvent['type'];
+  command?: DataSurfaceVisibleCommand;
+  result?: DataSurfaceCommandResult;
+}
+
+export type DataSurfaceBridgeMessage =
+  | DataSurfaceCommandRequest
+  | DataSurfaceCommandAck
+  | DataSurfaceBridgeEvent;
+
+export type DataSurfaceBridgeConnectionState =
+  | 'connected'
+  | 'disconnected'
+  | 'reconnecting';
+
+/** A deliberately tiny adapter for WebSocket, SSE, postMessage, or a test. */
+export interface DataSurfaceBridgeTransport {
+  send(message: DataSurfaceBridgeMessage): void | Promise<void>;
+  subscribe(listener: (message: unknown) => void): () => void;
+  subscribeStatus?: (
+    listener: (state: DataSurfaceBridgeConnectionState) => void,
+  ) => () => void;
+}
+
+export interface DataSurfaceBrowserBridgeOptions {
+  registry: DataSurfaceRegistry;
+  transport: DataSurfaceBridgeTransport;
+  sessionId: string;
+  /** This browser's source id, placed on acknowledgements/events. */
+  source: string;
+  /** The only server source accepted for commands. */
+  peerSource: string;
+  now?: () => number;
+  maxTtlMs?: number;
+  maxReplayEntries?: number;
+}
+
+export interface DataSurfaceBrowserBridge {
+  readonly sessionId: string;
+  readonly source: string;
+  /** Stop receiving transport messages and registry events. */
+  dispose(): void;
+  /** Handle a message directly; useful for transports that batch delivery. */
+  receive(message: unknown): Promise<void>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= 256;
+}
+
+function isFiniteInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value);
+}
+
+function identityOf(value: unknown): DataSurfaceIdentity | undefined {
+  if (!isRecord(value) || !isString(value.surfaceId) || !isString(value.kind)) {
+    return undefined;
+  }
+  if (
+    value.kind !== 'table' &&
+    value.kind !== 'list' &&
+    value.kind !== 'report' &&
+    value.kind !== 'custom'
+  ) {
+    return undefined;
+  }
+  return value as unknown as DataSurfaceIdentity;
+}
+
+function isRequest(value: unknown): value is DataSurfaceCommandRequest {
+  if (
+    !isRecord(value) ||
+    value.type !== 'data-surface.command' ||
+    value.version !== 1
+  ) {
+    return false;
+  }
+  return (
+    isString(value.commandId) &&
+    isString(value.sessionId) &&
+    isString(value.source) &&
+    typeof value.expiresAt === 'number' &&
+    Number.isFinite(value.expiresAt) &&
+    identityOf(value.identity) !== undefined &&
+    isFiniteInteger(value.expectedRevision) &&
+    value.expectedRevision >= 0 &&
+    isString(value.controlId)
+  );
+}
+
+function identityKey(identity: DataSurfaceIdentity): string {
+  return JSON.stringify(identity);
+}
+
+function commandSignature(request: DataSurfaceCommandRequest): string {
+  return JSON.stringify({
+    sessionId: request.sessionId,
+    source: request.source,
+    expiresAt: request.expiresAt,
+    identity: request.identity,
+    expectedRevision: request.expectedRevision,
+    controlId: request.controlId,
+    payload: request.payload,
+  });
+}
+
+function cloneMessage<T>(message: T): T {
+  return JSON.parse(JSON.stringify(message)) as T;
+}
+
+/**
+ * Attach a mounted registry to an authenticated browser transport.
+ * Invalid, expired, cross-session, and cross-source messages are acknowledged
+ * without exposing a registry snapshot. Replays return the original ack and do
+ * not invoke the mounted surface a second time.
+ */
+export function createDataSurfaceBrowserBridge(
+  options: DataSurfaceBrowserBridgeOptions,
+): DataSurfaceBrowserBridge {
+  if (
+    !isString(options.sessionId) ||
+    !isString(options.source) ||
+    !isString(options.peerSource)
+  ) {
+    throw new TypeError('DataSurface bridge session/source ids are required');
+  }
+  const now = options.now ?? (() => Date.now());
+  const maxTtlMs = options.maxTtlMs ?? DEFAULT_DATA_SURFACE_BRIDGE_TTL_MS;
+  const maxReplayEntries =
+    options.maxReplayEntries ?? DEFAULT_DATA_SURFACE_BRIDGE_REPLAY_ENTRIES;
+  if (
+    !Number.isFinite(maxTtlMs) ||
+    maxTtlMs <= 0 ||
+    !Number.isSafeInteger(maxReplayEntries) ||
+    maxReplayEntries <= 0
+  ) {
+    throw new RangeError('Invalid DataSurface bridge bounds');
+  }
+
+  const replay = new Map<
+    string,
+    { signature: string; ack: DataSurfaceCommandAck }
+  >();
+  let disposed = false;
+  let lastSequence = 0;
+
+  const remember = (
+    request: DataSurfaceCommandRequest,
+    ack: DataSurfaceCommandAck,
+  ) => {
+    replay.delete(request.commandId);
+    replay.set(request.commandId, {
+      signature: commandSignature(request),
+      ack: cloneMessage(ack),
+    });
+    while (replay.size > maxReplayEntries) {
+      const oldest = replay.keys().next().value as string | undefined;
+      if (!oldest) break;
+      replay.delete(oldest);
+    }
+  };
+
+  const sendAck = async (ack: DataSurfaceCommandAck) => {
+    if (disposed) return;
+    try {
+      await options.transport.send(cloneMessage(ack));
+    } catch {
+      // A disconnected browser cannot repair delivery. The server-side
+      // bridge reports the bounded disconnect/timeout outcome to its caller.
+    }
+  };
+
+  const rejected = (
+    request: Partial<DataSurfaceCommandRequest>,
+    reason: DataSurfaceBridgeFailureReason,
+  ): DataSurfaceCommandAck => ({
+    type: 'data-surface.ack',
+    version: 1,
+    commandId:
+      typeof request.commandId === 'string' ? request.commandId : 'invalid',
+    sessionId: options.sessionId,
+    source: options.source,
+    expiresAt:
+      typeof request.expiresAt === 'number' ? request.expiresAt : now(),
+    identity: identityOf(request.identity) ?? {
+      surfaceId: 'unknown',
+      kind: 'custom',
+    },
+    expectedRevision:
+      isFiniteInteger(request.expectedRevision) && request.expectedRevision >= 0
+        ? request.expectedRevision
+        : 0,
+    ok: false,
+    reason,
+  });
+
+  const receive = async (value: unknown): Promise<void> => {
+    if (disposed || !isRequest(value)) return;
+    const request = value;
+    const existing = replay.get(request.commandId);
+    const signature = commandSignature(request);
+    if (existing) {
+      await sendAck(
+        existing.signature === signature
+          ? existing.ack
+          : rejected(request, 'idempotency_conflict'),
+      );
+      return;
+    }
+
+    let ack: DataSurfaceCommandAck;
+    if (request.sessionId !== options.sessionId) {
+      ack = rejected(request, 'session_mismatch');
+    } else if (request.source !== options.peerSource) {
+      ack = rejected(request, 'source_mismatch');
+    } else if (
+      request.expiresAt <= now() ||
+      request.expiresAt - now() > maxTtlMs
+    ) {
+      ack = rejected(request, 'expired');
+    } else {
+      let command: DataSurfaceVisibleCommand;
+      try {
+        command = normalizeDataSurfaceVisibleCommand({
+          version: 1,
+          commandId: request.commandId,
+          identity: request.identity,
+          expectedRevision: request.expectedRevision,
+          controlId: request.controlId,
+          ...(request.payload === undefined
+            ? {}
+            : { payload: request.payload }),
+        });
+        const result = await options.registry.execute(command);
+        ack = {
+          type: 'data-surface.ack',
+          version: 1,
+          commandId: request.commandId,
+          sessionId: options.sessionId,
+          source: options.source,
+          expiresAt: request.expiresAt,
+          identity: result.identity,
+          expectedRevision: request.expectedRevision,
+          ok: result.ok,
+          revision: result.revision,
+          snapshot: result.snapshot,
+          reason: result.reason,
+        };
+      } catch {
+        ack = rejected(request, 'invalid_request');
+      }
+    }
+    remember(request, ack);
+    await sendAck(ack);
+  };
+
+  const emit = (event: DataSurfaceRegistryEvent) => {
+    if (disposed || event.sequence <= lastSequence) return;
+    lastSequence = event.sequence;
+    const message: DataSurfaceBridgeEvent = {
+      type: 'data-surface.event',
+      version: 1,
+      sessionId: options.sessionId,
+      source: options.source,
+      sequence: event.sequence,
+      identity: event.identity,
+      revision: event.revision,
+      event: event.type,
+      ...(event.command ? { command: event.command } : {}),
+      ...(event.result ? { result: event.result } : {}),
+    };
+    void Promise.resolve(options.transport.send(cloneMessage(message))).catch(
+      () => undefined,
+    );
+  };
+
+  const unsubscribeTransport = options.transport.subscribe((message) => {
+    void receive(message);
+  });
+  const unsubscribeRegistry = options.registry.subscribe(emit);
+
+  return {
+    sessionId: options.sessionId,
+    source: options.source,
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      unsubscribeTransport();
+      unsubscribeRegistry();
+      replay.clear();
+    },
+    receive,
+  };
+}
+
+/** Compatibility alias that makes the browser role explicit at call sites. */
+export const createDataSurfaceBridge = createDataSurfaceBrowserBridge;

--- a/packages/smrt-svelte/src/data-surface.ts
+++ b/packages/smrt-svelte/src/data-surface.ts
@@ -21,6 +21,7 @@ import {
 export const DATA_SURFACE_BRIDGE_VERSION = 1 as const;
 export const DEFAULT_DATA_SURFACE_BRIDGE_TTL_MS = 30_000;
 export const DEFAULT_DATA_SURFACE_BRIDGE_REPLAY_ENTRIES = 100;
+export const DATA_SURFACE_IDENTIFIER_MAX_LENGTH = 256;
 
 export type DataSurfaceBridgeFailureReason =
   | 'not_found'
@@ -139,7 +140,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isString(value: unknown): value is string {
-  return typeof value === 'string' && value.length > 0 && value.length <= 256;
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= DATA_SURFACE_IDENTIFIER_MAX_LENGTH
+  );
 }
 
 function isPeer(value: unknown): value is DataSurfaceBridgePeer {
@@ -161,6 +166,16 @@ function identityOf(value: unknown): DataSurfaceIdentity | undefined {
     value.kind !== 'custom'
   ) {
     return undefined;
+  }
+  if (value.subject !== undefined) {
+    if (
+      !isRecord(value.subject) ||
+      !isString(value.subject.type) ||
+      !isString(value.subject.id) ||
+      (value.subject.label !== undefined && !isString(value.subject.label))
+    ) {
+      return undefined;
+    }
   }
   return value as unknown as DataSurfaceIdentity;
 }

--- a/packages/smrt-svelte/src/data-surface.ts
+++ b/packages/smrt-svelte/src/data-surface.ts
@@ -35,7 +35,8 @@ export type DataSurfaceBridgeFailureReason =
   | 'disconnected'
   | 'invalid_request'
   | 'source_mismatch'
-  | 'session_mismatch';
+  | 'session_mismatch'
+  | 'replay_capacity_exceeded';
 
 export interface DataSurfaceCommandRequest {
   type: 'data-surface.command';
@@ -84,6 +85,17 @@ export type DataSurfaceBridgeMessage =
   | DataSurfaceCommandAck
   | DataSurfaceBridgeEvent;
 
+/**
+ * Identity verified by the transport adapter, outside the wire message.
+ * Adapters must derive this from authenticated connection state (for example,
+ * a bound WebSocket session or an origin-checked postMessage peer), never
+ * from fields in `message`. `send` must route only to that bound peer.
+ */
+export interface DataSurfaceBridgePeer {
+  sessionId: string;
+  source: string;
+}
+
 export type DataSurfaceBridgeConnectionState =
   | 'connected'
   | 'disconnected'
@@ -92,7 +104,9 @@ export type DataSurfaceBridgeConnectionState =
 /** A deliberately tiny adapter for WebSocket, SSE, postMessage, or a test. */
 export interface DataSurfaceBridgeTransport {
   send(message: DataSurfaceBridgeMessage): void | Promise<void>;
-  subscribe(listener: (message: unknown) => void): () => void;
+  subscribe(
+    listener: (message: unknown, peer: DataSurfaceBridgePeer) => void,
+  ): () => void;
   subscribeStatus?: (
     listener: (state: DataSurfaceBridgeConnectionState) => void,
   ) => () => void;
@@ -117,7 +131,7 @@ export interface DataSurfaceBrowserBridge {
   /** Stop receiving transport messages and registry events. */
   dispose(): void;
   /** Handle a message directly; useful for transports that batch delivery. */
-  receive(message: unknown): Promise<void>;
+  receive(message: unknown, peer: DataSurfaceBridgePeer): Promise<void>;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -126,6 +140,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0 && value.length <= 256;
+}
+
+function isPeer(value: unknown): value is DataSurfaceBridgePeer {
+  return isRecord(value) && isString(value.sessionId) && isString(value.source);
 }
 
 function isFiniteInteger(value: unknown): value is number {
@@ -219,25 +237,27 @@ export function createDataSurfaceBrowserBridge(
 
   const replay = new Map<
     string,
-    { signature: string; ack: DataSurfaceCommandAck }
+    { signature: string; ack: DataSurfaceCommandAck; expiresAt: number }
   >();
   let disposed = false;
   let lastSequence = 0;
+
+  const pruneReplay = () => {
+    const current = now();
+    for (const [commandId, entry] of replay) {
+      if (entry.expiresAt <= current) replay.delete(commandId);
+    }
+  };
 
   const remember = (
     request: DataSurfaceCommandRequest,
     ack: DataSurfaceCommandAck,
   ) => {
-    replay.delete(request.commandId);
     replay.set(request.commandId, {
       signature: commandSignature(request),
       ack: cloneMessage(ack),
+      expiresAt: request.expiresAt,
     });
-    while (replay.size > maxReplayEntries) {
-      const oldest = replay.keys().next().value as string | undefined;
-      if (!oldest) break;
-      replay.delete(oldest);
-    }
   };
 
   const sendAck = async (ack: DataSurfaceCommandAck) => {
@@ -274,9 +294,20 @@ export function createDataSurfaceBrowserBridge(
     reason,
   });
 
-  const receive = async (value: unknown): Promise<void> => {
-    if (disposed || !isRequest(value)) return;
+  const receive = async (
+    value: unknown,
+    peer: DataSurfaceBridgePeer,
+  ): Promise<void> => {
+    if (
+      disposed ||
+      !isRequest(value) ||
+      !isPeer(peer) ||
+      peer.sessionId !== options.sessionId ||
+      peer.source !== options.peerSource
+    )
+      return;
     const request = value;
+    pruneReplay();
     const existing = replay.get(request.commandId);
     const signature = commandSignature(request);
     if (existing) {
@@ -288,7 +319,7 @@ export function createDataSurfaceBrowserBridge(
       return;
     }
 
-    let ack: DataSurfaceCommandAck;
+    let ack: DataSurfaceCommandAck | undefined;
     if (request.sessionId !== options.sessionId) {
       ack = rejected(request, 'session_mismatch');
     } else if (request.source !== options.peerSource) {
@@ -298,6 +329,8 @@ export function createDataSurfaceBrowserBridge(
       request.expiresAt - now() > maxTtlMs
     ) {
       ack = rejected(request, 'expired');
+    } else if (replay.size >= maxReplayEntries) {
+      ack = rejected(request, 'replay_capacity_exceeded');
     } else {
       let command: DataSurfaceVisibleCommand;
       try {
@@ -330,6 +363,16 @@ export function createDataSurfaceBrowserBridge(
         ack = rejected(request, 'invalid_request');
       }
     }
+    if (
+      ack === undefined ||
+      request.sessionId !== options.sessionId ||
+      request.source !== options.peerSource ||
+      request.expiresAt <= now() ||
+      ack.reason === 'replay_capacity_exceeded'
+    ) {
+      if (ack !== undefined) await sendAck(ack);
+      return;
+    }
     remember(request, ack);
     await sendAck(ack);
   };
@@ -354,8 +397,8 @@ export function createDataSurfaceBrowserBridge(
     );
   };
 
-  const unsubscribeTransport = options.transport.subscribe((message) => {
-    void receive(message);
+  const unsubscribeTransport = options.transport.subscribe((message, peer) => {
+    void receive(message, peer);
   });
   const unsubscribeRegistry = options.registry.subscribe(emit);
 

--- a/packages/smrt-svelte/src/data-surface.ts
+++ b/packages/smrt-svelte/src/data-surface.ts
@@ -207,15 +207,10 @@ function isRequest(value: unknown): value is DataSurfaceCommandRequest {
   );
 }
 
-function identityKey(identity: DataSurfaceIdentity): string {
-  return JSON.stringify(identity);
-}
-
 function commandSignature(request: DataSurfaceCommandRequest): string {
   return JSON.stringify({
     sessionId: request.sessionId,
     source: request.source,
-    expiresAt: request.expiresAt,
     identity: request.identity,
     expectedRevision: request.expectedRevision,
     controlId: request.controlId,
@@ -229,9 +224,11 @@ function cloneMessage<T>(message: T): T {
 
 /**
  * Attach a mounted registry to an authenticated browser transport.
- * Invalid, expired, cross-session, and cross-source messages are acknowledged
- * without exposing a registry snapshot. Replays return the original ack and do
- * not invoke the mounted surface a second time.
+ * Malformed requests and messages from unauthenticated peers are ignored before
+ * acknowledgement. Valid requests from the bound peer that are expired,
+ * cross-session, or cross-source are acknowledged without exposing a registry
+ * snapshot. Replays return the original ack and do not invoke the mounted
+ * surface a second time.
  */
 export function createDataSurfaceBrowserBridge(
   options: DataSurfaceBrowserBridgeOptions,
@@ -263,7 +260,13 @@ export function createDataSurfaceBrowserBridge(
   const reservations = new Set<string>();
   const inflight = new Map<
     string,
-    { signature: string; promise: Promise<void> }
+    {
+      signature: string;
+      promise: Promise<void>;
+      expiry: Promise<void>;
+      expired: boolean;
+      expiryTimer: ReturnType<typeof setTimeout>;
+    }
   >();
   let disposed = false;
   let lastSequence = 0;
@@ -285,6 +288,14 @@ export function createDataSurfaceBrowserBridge(
       expiresAt: request.expiresAt,
     });
   };
+
+  const replayAck = (
+    request: DataSurfaceCommandRequest,
+    ack: DataSurfaceCommandAck,
+  ): DataSurfaceCommandAck => ({
+    ...cloneMessage(ack),
+    expiresAt: request.expiresAt,
+  });
 
   const sendAck = async (ack: DataSurfaceCommandAck) => {
     if (disposed) return;
@@ -334,12 +345,20 @@ export function createDataSurfaceBrowserBridge(
       return;
     const request = value;
     pruneReplay();
+    const current = now();
+    if (
+      request.expiresAt <= current ||
+      request.expiresAt - current > maxTtlMs
+    ) {
+      await sendAck(rejected(request, 'expired'));
+      return;
+    }
     const existing = replay.get(request.commandId);
     const signature = commandSignature(request);
     if (existing) {
       await sendAck(
         existing.signature === signature
-          ? existing.ack
+          ? replayAck(request, existing.ack)
           : rejected(request, 'idempotency_conflict'),
       );
       return;
@@ -350,11 +369,11 @@ export function createDataSurfaceBrowserBridge(
         await sendAck(rejected(request, 'idempotency_conflict'));
         return;
       }
-      await active.promise;
+      await Promise.race([active.promise, active.expiry]);
       const completed = replay.get(request.commandId);
       if (completed?.signature === signature) {
-        await sendAck(completed.ack);
-      } else if (request.expiresAt <= now()) {
+        await sendAck(replayAck(request, completed.ack));
+      } else if (active.expired || request.expiresAt <= now()) {
         await sendAck(rejected(request, 'expired'));
       }
       return;
@@ -365,16 +384,24 @@ export function createDataSurfaceBrowserBridge(
       ack = rejected(request, 'session_mismatch');
     } else if (request.source !== options.peerSource) {
       ack = rejected(request, 'source_mismatch');
-    } else if (
-      request.expiresAt <= now() ||
-      request.expiresAt - now() > maxTtlMs
-    ) {
-      ack = rejected(request, 'expired');
     } else if (replay.size + reservations.size >= maxReplayEntries) {
       ack = rejected(request, 'replay_capacity_exceeded');
     } else {
       reservations.add(request.commandId);
-      const promise = (async () => {
+      let resolveExpiry!: () => void;
+      const expiry = new Promise<void>((resolve) => {
+        resolveExpiry = resolve;
+      });
+      const active = {
+        signature,
+        promise: Promise.resolve(),
+        expiry,
+        expired: false,
+        expiryAckSent: false,
+        expiryTimer: undefined as unknown as ReturnType<typeof setTimeout>,
+      };
+      let promise!: Promise<void>;
+      promise = (async () => {
         try {
           let resultAck: DataSurfaceCommandAck;
           try {
@@ -406,18 +433,53 @@ export function createDataSurfaceBrowserBridge(
           } catch {
             resultAck = rejected(request, 'invalid_request');
           }
-          if (request.expiresAt <= now()) {
-            resultAck = rejected(request, 'expired');
+          if (active.expired || request.expiresAt <= now()) {
+            active.expired = true;
+            reservations.delete(request.commandId);
+            if (inflight.get(request.commandId)?.promise === promise) {
+              inflight.delete(request.commandId);
+            }
+            clearTimeout(active.expiryTimer);
+            resolveExpiry();
+            if (!active.expiryAckSent) {
+              active.expiryAckSent = true;
+              await sendAck(rejected(request, 'expired'));
+            }
+            return;
           }
           remember(request, resultAck);
+          reservations.delete(request.commandId);
+          if (inflight.get(request.commandId)?.promise === promise) {
+            inflight.delete(request.commandId);
+          }
+          clearTimeout(active.expiryTimer);
+          resolveExpiry();
           await sendAck(resultAck);
         } finally {
           reservations.delete(request.commandId);
+          if (inflight.get(request.commandId)?.promise === promise) {
+            inflight.delete(request.commandId);
+          }
+          clearTimeout(active.expiryTimer);
+          resolveExpiry();
         }
       })();
-      inflight.set(request.commandId, { signature, promise });
+      active.promise = promise;
+      active.expiryTimer = setTimeout(
+        () => {
+          if (inflight.get(request.commandId)?.promise !== promise) return;
+          active.expired = true;
+          reservations.delete(request.commandId);
+          inflight.delete(request.commandId);
+          resolveExpiry();
+          active.expiryAckSent = true;
+          void sendAck(rejected(request, 'expired'));
+        },
+        Math.max(0, request.expiresAt - current),
+      );
+      inflight.set(request.commandId, active);
       try {
-        await promise;
+        await Promise.race([promise, expiry]);
       } finally {
         if (inflight.get(request.commandId)?.promise === promise) {
           inflight.delete(request.commandId);

--- a/packages/smrt-svelte/src/data-surface.ts
+++ b/packages/smrt-svelte/src/data-surface.ts
@@ -239,6 +239,11 @@ export function createDataSurfaceBrowserBridge(
     string,
     { signature: string; ack: DataSurfaceCommandAck; expiresAt: number }
   >();
+  const reservations = new Set<string>();
+  const inflight = new Map<
+    string,
+    { signature: string; promise: Promise<void> }
+  >();
   let disposed = false;
   let lastSequence = 0;
 
@@ -318,6 +323,21 @@ export function createDataSurfaceBrowserBridge(
       );
       return;
     }
+    const active = inflight.get(request.commandId);
+    if (active) {
+      if (active.signature !== signature) {
+        await sendAck(rejected(request, 'idempotency_conflict'));
+        return;
+      }
+      await active.promise;
+      const completed = replay.get(request.commandId);
+      if (completed?.signature === signature) {
+        await sendAck(completed.ack);
+      } else if (request.expiresAt <= now()) {
+        await sendAck(rejected(request, 'expired'));
+      }
+      return;
+    }
 
     let ack: DataSurfaceCommandAck | undefined;
     if (request.sessionId !== options.sessionId) {
@@ -329,52 +349,62 @@ export function createDataSurfaceBrowserBridge(
       request.expiresAt - now() > maxTtlMs
     ) {
       ack = rejected(request, 'expired');
-    } else if (replay.size >= maxReplayEntries) {
+    } else if (replay.size + reservations.size >= maxReplayEntries) {
       ack = rejected(request, 'replay_capacity_exceeded');
     } else {
-      let command: DataSurfaceVisibleCommand;
+      reservations.add(request.commandId);
+      const promise = (async () => {
+        try {
+          let resultAck: DataSurfaceCommandAck;
+          try {
+            const command = normalizeDataSurfaceVisibleCommand({
+              version: 1,
+              commandId: request.commandId,
+              identity: request.identity,
+              expectedRevision: request.expectedRevision,
+              controlId: request.controlId,
+              ...(request.payload === undefined
+                ? {}
+                : { payload: request.payload }),
+            });
+            const result = await options.registry.execute(command);
+            resultAck = {
+              type: 'data-surface.ack',
+              version: 1,
+              commandId: request.commandId,
+              sessionId: options.sessionId,
+              source: options.source,
+              expiresAt: request.expiresAt,
+              identity: result.identity,
+              expectedRevision: request.expectedRevision,
+              ok: result.ok,
+              revision: result.revision,
+              snapshot: result.snapshot,
+              reason: result.reason,
+            };
+          } catch {
+            resultAck = rejected(request, 'invalid_request');
+          }
+          if (request.expiresAt <= now()) {
+            resultAck = rejected(request, 'expired');
+          }
+          remember(request, resultAck);
+          await sendAck(resultAck);
+        } finally {
+          reservations.delete(request.commandId);
+        }
+      })();
+      inflight.set(request.commandId, { signature, promise });
       try {
-        command = normalizeDataSurfaceVisibleCommand({
-          version: 1,
-          commandId: request.commandId,
-          identity: request.identity,
-          expectedRevision: request.expectedRevision,
-          controlId: request.controlId,
-          ...(request.payload === undefined
-            ? {}
-            : { payload: request.payload }),
-        });
-        const result = await options.registry.execute(command);
-        ack = {
-          type: 'data-surface.ack',
-          version: 1,
-          commandId: request.commandId,
-          sessionId: options.sessionId,
-          source: options.source,
-          expiresAt: request.expiresAt,
-          identity: result.identity,
-          expectedRevision: request.expectedRevision,
-          ok: result.ok,
-          revision: result.revision,
-          snapshot: result.snapshot,
-          reason: result.reason,
-        };
-      } catch {
-        ack = rejected(request, 'invalid_request');
+        await promise;
+      } finally {
+        if (inflight.get(request.commandId)?.promise === promise) {
+          inflight.delete(request.commandId);
+        }
       }
-    }
-    if (
-      ack === undefined ||
-      request.sessionId !== options.sessionId ||
-      request.source !== options.peerSource ||
-      request.expiresAt <= now() ||
-      ack.reason === 'replay_capacity_exceeded'
-    ) {
-      if (ack !== undefined) await sendAck(ack);
       return;
     }
-    remember(request, ack);
-    await sendAck(ack);
+    if (ack !== undefined) await sendAck(ack);
   };
 
   const emit = (event: DataSurfaceRegistryEvent) => {

--- a/packages/smrt-svelte/src/index.ts
+++ b/packages/smrt-svelte/src/index.ts
@@ -16,6 +16,8 @@
 export * from './components/forms/index.js';
 // Module components (for dynamic module UI rendering)
 export * from './components/module/index.js';
+// Authenticated browser-side data-surface command/ack/event bridge
+export * from './data-surface.js';
 // Hooks
 export * from './hooks/index.js';
 // Core - App wrapper/provider

--- a/packages/smrt-ui/README.md
+++ b/packages/smrt-ui/README.md
@@ -39,8 +39,10 @@ pnpm add @happyvertical/smrt-ui
 | Collections | `CollectionToolbar`, `CollectionList`/`ContentList`, `DataTable`, `Pagination` |
 | Layout and navigation | `Container`, `Grid`, `Header`, `Footer`, `PageHeader`, `EmptyState`, `Tabs`, `FilterChips` |
 
-Use the focused subpaths (`/forms`, `/ui`, `/feedback`, `/data`, `/layout`,
-`/themes`) to keep imports explicit. The package root remains a compatibility
+Use the focused subpaths (`/forms`, `/ui`, `/feedback`, `/data`,
+`/data-surface`, `/layout`, `/themes`) to keep imports explicit. The
+Svelte-free `/data-surface` entry exposes the registry contracts and shared
+protocol limits for server adapters. The package root remains a compatibility
 barrel.
 
 ## Component standard

--- a/packages/smrt-ui/package.json
+++ b/packages/smrt-ui/package.json
@@ -35,6 +35,11 @@
       "import": "./dist/components/data/index.js",
       "default": "./dist/components/data/index.js"
     },
+    "./data-surface": {
+      "types": "./dist/components/data/data-surface.d.ts",
+      "import": "./dist/components/data/data-surface.js",
+      "default": "./dist/components/data/data-surface.js"
+    },
     "./layout": {
       "types": "./dist/components/layout/index.d.ts",
       "svelte": "./dist/components/layout/index.js",

--- a/packages/smrt-ui/src/components/data/__tests__/data-surface.test.ts
+++ b/packages/smrt-ui/src/components/data/__tests__/data-surface.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   createDataSurfaceRegistry,
+  DATA_SURFACE_IDENTIFIER_MAX_LENGTH,
   DATA_SURFACE_MAX_REPLAY_ENTRIES,
   DATA_SURFACE_MAX_REQUEST_BYTES,
   type DataSurfaceDescriptor,
@@ -743,6 +744,68 @@ describe('data surface registry', () => {
     ).toThrow('authority or SQL');
   });
 
+  it('enforces the shared identifier bound at registry boundaries', () => {
+    const tooLong = 'x'.repeat(DATA_SURFACE_IDENTIFIER_MAX_LENGTH + 1);
+    const identifiers = [
+      ['command id', command({ commandId: tooLong })],
+      ['control id', command({ controlId: tooLong })],
+      [
+        'surface id',
+        command({ identity: { ...identity, surfaceId: tooLong } }),
+      ],
+      [
+        'subject type',
+        command({
+          identity: {
+            ...identity,
+            subject: { type: tooLong, id: 'docs' },
+          },
+        }),
+      ],
+      [
+        'subject id',
+        command({
+          identity: {
+            ...identity,
+            subject: { type: 'site', id: tooLong },
+          },
+        }),
+      ],
+    ] as const;
+
+    for (const [label, value] of identifiers) {
+      expect(() => normalizeDataSurfaceVisibleCommand(value), label).toThrow();
+    }
+    expect(() =>
+      normalizeDataSurfaceActionRequest({
+        version: 1,
+        requestId: tooLong,
+        identity,
+        actionId: 'archive',
+        phase: 'preview',
+        selection: { scope: 'current-page' },
+      }),
+    ).toThrow();
+    expect(() =>
+      normalizeDataSurfaceActionRequest({
+        version: 1,
+        requestId: 'row-id',
+        identity,
+        actionId: 'archive',
+        phase: 'preview',
+        selection: { scope: 'explicit-ids', rowIds: [tooLong] },
+      }),
+    ).toThrow();
+    expect(() =>
+      createDataSurfaceRegistry().register({
+        descriptor: descriptor({
+          identity: { ...identity, surfaceId: tooLong },
+        }),
+        getSnapshot: () => ({ revision: 0, state: {} }),
+      }),
+    ).toThrow();
+  });
+
   it('rejects parsed prototype keys at every browser-contract boundary', () => {
     const prototypePayload = JSON.parse('{"__proto__":{"tenantId":"other"}}');
     expect(() =>
@@ -833,14 +896,22 @@ describe('data surface registry', () => {
       identity,
       kind: 'rows' as const,
       limit: 1,
-      projection: [''],
+      projection: Array.from(
+        { length: 394 },
+        (_, index) => `${String(index).padStart(3, '0')}${'x'.repeat(247)}`,
+      ),
     };
-    const baseLength = new TextEncoder().encode(
-      JSON.stringify(request),
-    ).byteLength;
+    const withEmpty = { ...request, projection: [...request.projection, ''] };
+    const overhead =
+      new TextEncoder().encode(JSON.stringify(withEmpty)).byteLength -
+      new TextEncoder().encode(JSON.stringify(request)).byteLength;
+    const finalLength =
+      DATA_SURFACE_MAX_REQUEST_BYTES -
+      new TextEncoder().encode(JSON.stringify(request)).byteLength -
+      overhead;
     const exactLimit = {
       ...request,
-      projection: ['x'.repeat(DATA_SURFACE_MAX_REQUEST_BYTES - baseLength)],
+      projection: [...request.projection, 'x'.repeat(finalLength)],
     };
 
     expect(

--- a/packages/smrt-ui/src/components/data/data-surface.ts
+++ b/packages/smrt-ui/src/components/data/data-surface.ts
@@ -292,11 +292,13 @@ export interface DataSurfaceRegistry {
 /** Generic browser-transport ceiling for normalized command/action envelopes. */
 export const DATA_SURFACE_MAX_REQUEST_BYTES = 100_000;
 
+/** Maximum length shared by every DataSurface protocol identifier. */
+export const DATA_SURFACE_IDENTIFIER_MAX_LENGTH = 256;
+
 /** Per-surface LRU capacity for command acknowledgement replay. */
 export const DATA_SURFACE_MAX_REPLAY_ENTRIES = 100;
 
 const MAX_QUERY_LIMIT = 1_000;
-const MAX_REQUEST_ID_LENGTH = 256;
 const MAX_CURSOR_LENGTH = 2_048;
 const MAX_JSON_DEPTH = 16;
 const MAX_JSON_CONTAINER_ITEMS = 1_000;
@@ -385,6 +387,16 @@ function stringValue(value: unknown, label: string): string {
     throw new TypeError(`${label} must be a non-empty string`);
   }
   return value;
+}
+
+function identifierValue(value: unknown, label: string): string {
+  const result = stringValue(value, label);
+  if (result.length > DATA_SURFACE_IDENTIFIER_MAX_LENGTH) {
+    throw new TypeError(
+      `${label} cannot exceed ${DATA_SURFACE_IDENTIFIER_MAX_LENGTH} characters`,
+    );
+  }
+  return result;
 }
 
 function optionalString(value: unknown, label: string): string | undefined {
@@ -662,13 +674,13 @@ function normalizeIdentity(value: unknown): DataSurfaceIdentity {
     exactKeys(source, ['type', 'id', 'label'], 'DataSurface subject');
     const label = optionalString(source.label, 'DataSurface subject label');
     subject = {
-      type: stringValue(source.type, 'DataSurface subject type'),
-      id: stringValue(source.id, 'DataSurface subject id'),
+      type: identifierValue(source.type, 'DataSurface subject type'),
+      id: identifierValue(source.id, 'DataSurface subject id'),
       ...(label ? { label } : {}),
     };
   }
   return {
-    surfaceId: stringValue(object.surfaceId, 'DataSurface surface id'),
+    surfaceId: identifierValue(object.surfaceId, 'DataSurface surface id'),
     kind,
     ...(subject ? { subject } : {}),
   };
@@ -702,6 +714,16 @@ function normalizeStringArray(
     throw new TypeError(`${label} cannot contain duplicates`);
   }
   return options.sort ? values.sort() : values;
+}
+
+function normalizeIdentifierArray(
+  value: unknown,
+  label: string,
+  options: { sort?: boolean } = {},
+): string[] {
+  return normalizeStringArray(value, label, options).map((entry) =>
+    identifierValue(entry, label),
+  );
 }
 
 function normalizeCapabilityArray(
@@ -766,7 +788,12 @@ function normalizeSelection(value: unknown): DataSurfaceSelectionReference {
           'DataSurface row ids must be finite strings or numbers',
         );
       }
-      const normalized = typeof rowId === 'number' && rowId === 0 ? 0 : rowId;
+      const normalized =
+        typeof rowId === 'string'
+          ? identifierValue(rowId, 'DataSurface row id')
+          : rowId === 0
+            ? 0
+            : rowId;
       rowIds.set(`${typeof normalized}:${String(normalized)}`, normalized);
     }
     return {
@@ -787,7 +814,7 @@ function normalizeSelection(value: unknown): DataSurfaceSelectionReference {
   );
   return {
     scope,
-    queryFingerprint: stringValue(
+    queryFingerprint: identifierValue(
       object.queryFingerprint,
       'DataSurface query fingerprint',
     ),
@@ -837,7 +864,7 @@ export function normalizeDataSurfaceDescriptor(
       'DataSurface column description',
     );
     return {
-      id: stringValue(column.id, 'DataSurface column id'),
+      id: identifierValue(column.id, 'DataSurface column id'),
       label: stringValue(column.label, 'DataSurface column label'),
       ...(description ? { description } : {}),
       ...(sensitivity ? { sensitivity } : {}),
@@ -865,7 +892,7 @@ export function normalizeDataSurfaceDescriptor(
       throw new TypeError(`Unsupported DataSurface query mode: ${mode}`);
     }
   }
-  const projectableColumnIds = normalizeStringArray(
+  const projectableColumnIds = normalizeIdentifierArray(
     query.projectableColumnIds,
     'DataSurface projectable column ids',
     { sort: true },
@@ -890,7 +917,7 @@ export function normalizeDataSurfaceDescriptor(
       'DataSurface control description',
     );
     return {
-      id: stringValue(control.id, 'DataSurface control id'),
+      id: identifierValue(control.id, 'DataSurface control id'),
       label: stringValue(control.label, 'DataSurface control label'),
       ...(description ? { description } : {}),
     };
@@ -945,7 +972,7 @@ export function normalizeDataSurfaceDescriptor(
       'DataSurface action description',
     );
     return {
-      id: stringValue(action.id, 'DataSurface action id'),
+      id: identifierValue(action.id, 'DataSurface action id'),
       label: stringValue(action.label, 'DataSurface action label'),
       ...(description ? { description } : {}),
       ...(sensitivity ? { sensitivity } : {}),
@@ -974,7 +1001,7 @@ export function normalizeDataSurfaceDescriptor(
       `DataSurface maxQueryRows cannot exceed ${MAX_QUERY_LIMIT}`,
     );
   }
-  const rowKey = stringValue(object.rowKey, 'DataSurface row key');
+  const rowKey = identifierValue(object.rowKey, 'DataSurface row key');
   if (!knownColumns.has(rowKey)) {
     throw new TypeError('DataSurface rowKey must name a declared column');
   }
@@ -1056,13 +1083,10 @@ export function normalizeDataSurfaceVisibleCommand(
   if (object.version !== 1) {
     throw new TypeError('Unsupported DataSurface visible command version');
   }
-  const commandId = stringValue(object.commandId, 'DataSurface command id');
-  if (commandId.length > MAX_REQUEST_ID_LENGTH) {
-    throw new TypeError('DataSurface command id is too long');
-  }
+  const commandId = identifierValue(object.commandId, 'DataSurface command id');
   const commandIdentity = normalizeIdentity(object.identity);
   const expectedRevision = revisionNumber(object.expectedRevision);
-  const controlId = stringValue(object.controlId, 'DataSurface control id');
+  const controlId = identifierValue(object.controlId, 'DataSurface control id');
   assertRequestByteLimit(value, 'DataSurface visible command');
   const normalized: DataSurfaceVisibleCommand = {
     version: 1,
@@ -1088,13 +1112,10 @@ export function normalizeDataSurfaceQueryRequest(
   if (object.version !== 1) {
     throw new TypeError('Unsupported DataSurface query request version');
   }
-  const requestId = stringValue(
+  const requestId = identifierValue(
     object.requestId,
     'DataSurface query request id',
   );
-  if (requestId.length > MAX_REQUEST_ID_LENGTH) {
-    throw new TypeError('DataSurface query request id is too long');
-  }
   const identity = normalizeIdentity(object.identity);
   if (kind === 'rows') {
     exactKeys(
@@ -1134,7 +1155,7 @@ export function normalizeDataSurfaceQueryRequest(
       ...(object.projection === undefined
         ? {}
         : {
-            projection: normalizeStringArray(
+            projection: normalizeIdentifierArray(
               object.projection,
               'DataSurface query projection',
               { sort: true },
@@ -1172,7 +1193,7 @@ export function normalizeDataSurfaceQueryRequest(
       requestId,
       identity,
       kind,
-      columnId: stringValue(
+      columnId: identifierValue(
         object.columnId,
         'DataSurface facets query column id',
       ),
@@ -1203,13 +1224,10 @@ export function normalizeDataSurfaceActionRequest(
   if (object.version !== 1) {
     throw new TypeError('Unsupported DataSurface action request version');
   }
-  const requestId = stringValue(
+  const requestId = identifierValue(
     object.requestId,
     'DataSurface action request id',
   );
-  if (requestId.length > MAX_REQUEST_ID_LENGTH) {
-    throw new TypeError('DataSurface action request id is too long');
-  }
   const phase = stringValue(object.phase, 'DataSurface action phase');
   if (phase !== 'preview' && phase !== 'apply') {
     throw new TypeError(`Unsupported DataSurface action phase: ${phase}`);
@@ -1219,7 +1237,7 @@ export function normalizeDataSurfaceActionRequest(
     'DataSurface confirmation token',
   );
   const actionIdentity = normalizeIdentity(object.identity);
-  const actionId = stringValue(object.actionId, 'DataSurface action id');
+  const actionId = identifierValue(object.actionId, 'DataSurface action id');
   const selection = normalizeSelection(object.selection);
   assertRequestByteLimit(value, 'DataSurface action request');
   const normalized: DataSurfaceActionRequest = {


### PR DESCRIPTION
## Summary
- Adds the authenticated DataSurface bridge between the server, browser transport, and mounted registry.
- Enforces canonical identifiers, bounded replay-safe commands, revision-safe acknowledgements, and explicit failure semantics.
- Documents protocol trust boundaries and verifies Node-safe package exports.

## Validation
- smrt-ui registry: 27 tests; chat bridge: 11 tests; smrt-svelte bridge: 8 tests
- smrt-ui, chat, and smrt-svelte builds plus packed-export verification
- Node-only bridge/subpath imports, Biome, diff check, strict knowledge freshness, and pre-push checks
- review-cycle: preliminary and final high-risk reviews clean on this head

Closes #2446

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-2446-rebase-fix-20260823",
  "issue": 2446,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "smrt-ui registry 27 tests; chat bridge 11 tests; smrt-svelte bridge 8 tests",
    "smrt-ui, chat, and smrt-svelte builds plus packed-export verification",
    "Node-only bridge/subpath imports, Biome, diff check, strict knowledge freshness, and pre-push checks",
    "review-cycle: preliminary and final high-risk reviews clean on exact head"
  ]
}