### PR TITLE
feat(smrt-web): register generated WebMCP tools

### DIFF
--- a/packages/core/src/generators/rest-custom-actions.spec.ts
+++ b/packages/core/src/generators/rest-custom-actions.spec.ts
@@ -24,9 +24,10 @@ import { APIGenerator } from './rest';
 @smrt({
   api: {
     public: true,
-    include: ['create', 'list', 'get', 'quote', 'ping', 'refuse'],
+    include: ['create', 'list', 'get', 'quote', 'inspect', 'ping', 'refuse'],
     routes: {
       quote: { method: 'POST', path: 'quote' },
+      inspect: { method: 'GET', path: 'inspect' },
       ping: { method: 'POST', path: 'ping' },
       refuse: { method: 'POST', path: 'refuse' },
     },
@@ -48,6 +49,15 @@ class ActionWidgetCollection extends SmrtCollection<ActionWidget> {
   /** Single `options` bag — the common shape, passed straight through. */
   async quote(options: { symbol?: string } = {}): Promise<{ symbol: string }> {
     return { symbol: options.symbol ?? 'none' };
+  }
+
+  /** GET options preserve omitted and explicit null values across the route. */
+  async inspect(
+    options?: { symbol?: string } | null,
+  ): Promise<{ value: string }> {
+    if (options === undefined) return { value: 'undefined' };
+    if (options === null) return { value: 'null' };
+    return { value: options.symbol ?? 'object' };
   }
 
   /** Zero parameters — must dispatch with NO request body at all. */
@@ -97,6 +107,9 @@ describe('runtime REST custom collection actions (#2047)', () => {
       }),
     );
 
+  const get = (path: string): Promise<Response> =>
+    handler(new Request(`http://localhost/api/v1/actionwidgets/${path}`));
+
   it('dispatches an action whose route omits an explicit scope', async () => {
     const response = await post('quote', { symbol: 'HV' });
     expect(response.status).toBe(200);
@@ -126,6 +139,23 @@ describe('runtime REST custom collection actions (#2047)', () => {
     };
     expect(payload.action).toBe('ping');
     expect(payload.result.pong).toBe(true);
+  });
+
+  it('preserves omitted, null, and object GET options', async () => {
+    const omitted = await get('inspect');
+    expect(
+      ((await omitted.json()) as { result: { value: string } }).result,
+    ).toEqual({ value: 'undefined' });
+
+    const explicitNull = await get('inspect?__smrt_options=null');
+    expect(
+      ((await explicitNull.json()) as { result: { value: string } }).result,
+    ).toEqual({ value: 'null' });
+
+    const object = await get('inspect?symbol=HV');
+    expect(
+      ((await object.json()) as { result: { value: string } }).result,
+    ).toEqual({ value: 'HV' });
   });
 
   it('maps a returned failure to its status and redacts the payload', async () => {

--- a/packages/core/src/generators/rest.ts
+++ b/packages/core/src/generators/rest.ts
@@ -849,7 +849,20 @@ export class APIGenerator {
       // write. GET reads the query string instead.
       let options: unknown;
       if (routeMethod === 'GET') {
-        options = Object.fromEntries(url.searchParams.entries());
+        const optionsMarker = url.searchParams.get('__smrt_options');
+        if (optionsMarker === 'undefined') {
+          options = undefined;
+        } else if (optionsMarker === 'null') {
+          options = null;
+        } else if (optionsMarker === 'object') {
+          options = {};
+        } else {
+          const entries = [...url.searchParams.entries()].filter(
+            ([key]) => key !== '__smrt_options',
+          );
+          options =
+            entries.length > 0 ? Object.fromEntries(entries) : undefined;
+        }
       } else {
         let rawBody = '';
         try {

--- a/packages/core/src/generators/tool-schema.ts
+++ b/packages/core/src/generators/tool-schema.ts
@@ -164,6 +164,8 @@ export interface ToolRouteDescriptor {
   scope: 'item' | 'collection';
   /** Route segments below the collection endpoint. Dynamic segments use `[x]`. */
   path: string[];
+  /** Transport names rewritten by the tool schema (e.g. `actionId` → `id`). */
+  parameterAliases?: Record<string, string>;
 }
 
 /** A single generated tool descriptor — the WebMCP / MCP tool shape. */

--- a/packages/core/src/generators/tool-schema.ts
+++ b/packages/core/src/generators/tool-schema.ts
@@ -157,6 +157,15 @@ export type ToolIdType = 'uuid' | 'text';
 /** The CRUD verbs with dedicated input-schema skeletons; anything else is custom. */
 const CRUD_ACTIONS = new Set(['list', 'get', 'create', 'update', 'delete']);
 
+export interface ToolRouteDescriptor {
+  /** HTTP method emitted for the route. */
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  /** Whether the route targets one item or the whole collection. */
+  scope: 'item' | 'collection';
+  /** Route segments below the collection endpoint. Dynamic segments use `[x]`. */
+  path: string[];
+}
+
 /** A single generated tool descriptor — the WebMCP / MCP tool shape. */
 export interface ToolDescriptor {
   /** The action this tool performs (`list` | `get` | … | a custom method name). */
@@ -167,6 +176,8 @@ export interface ToolDescriptor {
   inputSchema: ToolJsonSchema;
   /** True for non-mutating reads (`list`/`get`) → WebMCP `annotations.readOnlyHint`. */
   readOnly: boolean;
+  /** Generated custom-route transport metadata, when the action has a route. */
+  route?: ToolRouteDescriptor;
 }
 
 /**

--- a/packages/core/src/generators/tool-schema.ts
+++ b/packages/core/src/generators/tool-schema.ts
@@ -166,6 +166,8 @@ export interface ToolRouteDescriptor {
   path: string[];
   /** Transport names rewritten by the tool schema (e.g. `actionId` → `id`). */
   parameterAliases?: Record<string, string>;
+  /** The generated method accepts one `options` bag as its sole argument. */
+  optionsBag?: boolean;
 }
 
 /** A single generated tool descriptor — the WebMCP / MCP tool shape. */

--- a/packages/core/src/prebuild/index.ts
+++ b/packages/core/src/prebuild/index.ts
@@ -374,6 +374,7 @@ declare module '@smrt/web' {
     method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
     scope: 'item' | 'collection';
     path: string[];
+    parameterAliases?: Record<string, string>;
   }
 
   /** A WebMCP/MCP tool descriptor for one collection action (#1812). */

--- a/packages/core/src/prebuild/index.ts
+++ b/packages/core/src/prebuild/index.ts
@@ -370,6 +370,12 @@ declare module '@smrt/web' {
     relatedCollection: string;
   }
 
+  export interface WebToolRouteDescriptor {
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+    scope: 'item' | 'collection';
+    path: string[];
+  }
+
   /** A WebMCP/MCP tool descriptor for one collection action (#1812). */
   export interface WebToolDescriptor {
     action: string;
@@ -377,6 +383,7 @@ declare module '@smrt/web' {
     description: string;
     inputSchema: Record<string, unknown>;
     readOnly: boolean;
+    route?: WebToolRouteDescriptor;
   }
 
   export interface SmrtWebCollectionDefinition<TData = Record<string, unknown>> {

--- a/packages/core/src/prebuild/index.ts
+++ b/packages/core/src/prebuild/index.ts
@@ -375,6 +375,7 @@ declare module '@smrt/web' {
     scope: 'item' | 'collection';
     path: string[];
     parameterAliases?: Record<string, string>;
+    optionsBag?: boolean;
   }
 
   /** A WebMCP/MCP tool descriptor for one collection action (#1812). */

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -1885,6 +1885,7 @@ declare module '@happyvertical/smrt-virt-web' {
     scope: 'item' | 'collection';
     path: string[];
     parameterAliases?: Record<string, string>;
+    optionsBag?: boolean;
   }
 
   /** A WebMCP/MCP tool descriptor for one collection action (#1812). */

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -1884,6 +1884,7 @@ declare module '@happyvertical/smrt-virt-web' {
     method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
     scope: 'item' | 'collection';
     path: string[];
+    parameterAliases?: Record<string, string>;
   }
 
   /** A WebMCP/MCP tool descriptor for one collection action (#1812). */

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -951,7 +951,9 @@ export function smrtPlugin(options: SmrtPluginOptions = {}): Plugin {
         case 'smrt:web':
           // Web collection definitions for the browser client data runtime
           // (@happyvertical/smrt-web, #1761)
-          return generateWebModule(manifest);
+          return generateWebModule(manifest, {
+            kebabRoutes: svelteKit.kebabRoutes ?? false,
+          });
 
         default:
           return null;
@@ -1300,7 +1302,10 @@ export { setupRoutes as default };
  * {@link buildWebCollectionDefinition} so this value emission, the matching d.ts
  * type emission, and the #1764 shape digest cannot drift.
  */
-function generateWebModule(manifest: SmartObjectManifest): string {
+function generateWebModule(
+  manifest: SmartObjectManifest,
+  options: { kebabRoutes?: boolean } = {},
+): string {
   const definitions: Record<string, unknown> = {};
 
   // Emit one definition per MATERIALIZABLE collection (list-exposed), built via
@@ -1314,7 +1319,7 @@ function generateWebModule(manifest: SmartObjectManifest): string {
       // WebMCP/MCP tool descriptors (#1812) — layered ON TOP of the shared shape
       // so the #1764 shape digest (computeWebManifestHash, which calls
       // buildWebCollectionDefinition directly) keeps hashing only the row shape.
-      toolDescriptors: buildWebToolDescriptors(entry),
+      toolDescriptors: buildWebToolDescriptors(entry, options),
     };
   }
 
@@ -1875,6 +1880,12 @@ declare module '@happyvertical/smrt-virt-web' {
     relatedCollection: string;
   }
 
+  export interface WebToolRouteDescriptor {
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+    scope: 'item' | 'collection';
+    path: string[];
+  }
+
   /** A WebMCP/MCP tool descriptor for one collection action (#1812). */
   export interface WebToolDescriptor {
     action: string;
@@ -1882,6 +1893,7 @@ declare module '@happyvertical/smrt-virt-web' {
     description: string;
     inputSchema: Record<string, unknown>;
     readOnly: boolean;
+    route?: WebToolRouteDescriptor;
   }
 
   export interface SmrtWebCollectionDefinition<TData = Record<string, unknown>> {

--- a/packages/core/src/vite-plugin/sveltekit-generator.runtime.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.runtime.test.ts
@@ -125,6 +125,7 @@ function writeWorkspaceCoreShim(projectRoot: string): void {
       'export async function getTableVersion() { return 1; }',
       'export function ifNoneMatchHasConcreteMatch() { return false; }',
       'export function ifNoneMatchSatisfied() { return false; }',
+      'export function normalizeCustomActionFailure() { return undefined; }',
       'export function normalizeTypedHttpError(error) {',
       "  if (!error || typeof error !== 'object' || !Number.isInteger(error.status) || error.status < 400 || error.status > 499) return undefined;",
       "  const code = typeof error.code === 'string' ? error.code : error.status === 403 ? 'permission_denied' : 'request_rejected';",
@@ -285,6 +286,40 @@ describe('generated SvelteKit helper runtime', () => {
     );
   }
 
+  async function importGeneratedItemActionPost() {
+    const objectFilePath = join(projectRoot, 'src/lib/objects/Widget.ts');
+    const manifest = createManifest(projectRoot, objectFilePath, ['inspect']);
+    manifest.objects.Widget.methods = {
+      inspect: {
+        isPublic: true,
+        name: 'inspect',
+        parameters: [{ name: 'options', type: 'any' }],
+        returnType: 'Promise<unknown>',
+      },
+    };
+    manifest.objects.Widget.decoratorConfig = {
+      api: {
+        include: ['inspect'],
+        routes: {
+          inspect: { method: 'POST', path: 'inspect' },
+        },
+      },
+    };
+
+    await generateSvelteKitRoutes(projectRoot, manifest, {
+      configFileName: 'smrt.ts',
+      configPath: 'src/lib/server',
+      enabled: true,
+      objectsDir: 'src/lib/objects',
+      routesDir: 'src/routes/api',
+    });
+
+    return await bundleGeneratedRoute(
+      'src/routes/api/widgets/[id]/inspect/+server.ts',
+      'generated-item-action-post-route.mjs',
+    );
+  }
+
   async function importGeneratedCollectionList(
     fields: SmartObjectManifest['objects'][string]['fields'] = {},
   ) {
@@ -430,6 +465,39 @@ describe('generated SvelteKit helper runtime', () => {
     await expect(failed.json()).resolves.toEqual({
       error: 'Internal server error',
     });
+  });
+
+  it.each([
+    ['absent', undefined, undefined],
+    ['null', 'null', null],
+    ['empty object', '{}', {}],
+    ['populated object', JSON.stringify({ symbol: 'HV' }), { symbol: 'HV' }],
+  ])('preserves %s custom POST options in generated routes', async (_label, rawBody, expectedOptions) => {
+    const route = await importGeneratedItemActionPost();
+    const routeCollection = globalThis as Record<string, unknown>;
+    let receivedOptions: unknown = 'not-called';
+    routeCollection.__smrtGeneratedRouteCollection = {
+      get: async () => ({
+        inspect: async (options: unknown) => {
+          receivedOptions = options;
+          return { received: options };
+        },
+      }),
+    };
+
+    const response = await route.POST({
+      locals: { user: { id: 'user-1' } },
+      params: { id: 'widget-1' },
+      request: new Request('http://localhost/api/widgets/widget-1/inspect', {
+        ...(rawBody === undefined
+          ? {}
+          : { body: rawBody, headers: { 'content-type': 'application/json' } }),
+        method: 'POST',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(receivedOptions).toEqual(expectedOptions);
   });
 
   it('executes emitted DELETE routes with safe typed 4xx errors and opaque 5xx errors', async () => {

--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -989,6 +989,9 @@ describe('SvelteKit Route Generator', () => {
         "const optionsMarker = searchParams.get('__smrt_options');",
       );
       expect(content).toContain("optionsMarker === 'undefined'");
+      expect(content).not.toMatch(
+        /Object\.fromEntries\([\s\S]*\),\n\s*\) as ActionArgs\[0\];/,
+      );
       expect(content).toContain("ObjectRegistry.getClass('Document')");
       expect(content).toContain('await ClassRef.browseFacts(options)');
       expect(content).not.toContain('params.id');

--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -985,9 +985,10 @@ describe('SvelteKit Route Generator', () => {
         "import { ObjectRegistry } from '@happyvertical/smrt-core'",
       );
       expect(content).toContain('export const GET: RequestHandler');
-      expect(content).toMatch(
-        /Object\.fromEntries\(\s*new URL\(request\.url\)\.searchParams\.entries\(\),?\s*\)/,
+      expect(content).toContain(
+        "const optionsMarker = searchParams.get('__smrt_options');",
       );
+      expect(content).toContain("optionsMarker === 'undefined'");
       expect(content).toContain("ObjectRegistry.getClass('Document')");
       expect(content).toContain('await ClassRef.browseFacts(options)');
       expect(content).not.toContain('params.id');

--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -1183,7 +1183,10 @@ describe('SvelteKit Route Generator', () => {
       expect(content).toContain('type ActionArgs = Parameters<');
       expect(content).toContain("from '@happyvertical/smrt-tenancy'");
       expect(content).toContain('establishTenantContext(locals);');
-      expect(content).toContain('const body: unknown = await request.json();');
+      expect(content).toContain('const rawBody = await request.text();');
+      expect(content).toContain(
+        "const body: unknown = rawBody.trim() === '' ? undefined : JSON.parse(rawBody);",
+      );
       expect(content).toContain(
         'const options = readJsonRecord(body) as ActionOptions;',
       );

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -1148,7 +1148,7 @@ function buildActionOptionsLoad(
               '              [...searchParams.entries()].filter(',
               "                ([key]) => key !== '__smrt_options',",
               '              ),',
-              '            ),',
+              '            )',
               '  ) as ActionArgs[0];',
             ]
           : [

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -1132,9 +1132,30 @@ function buildActionOptionsLoad(
       );
     } else {
       lines.push(
-        '  const options = Object.fromEntries(',
-        '    new URL(request.url).searchParams.entries(),',
-        `  ) as ${isSingleOptionsParameter ? 'ActionArgs[0]' : 'ActionOptions'};`,
+        ...(isSingleOptionsParameter
+          ? [
+              '  const searchParams = new URL(request.url).searchParams;',
+              "  const optionsMarker = searchParams.get('__smrt_options');",
+              '  const options = (',
+              "    optionsMarker === 'undefined' ||",
+              '    (optionsMarker === null && searchParams.size === 0)',
+              '      ? undefined',
+              "      : optionsMarker === 'null'",
+              '        ? null',
+              "        : optionsMarker === 'object'",
+              '          ? {}',
+              '          : Object.fromEntries(',
+              '              [...searchParams.entries()].filter(',
+              "                ([key]) => key !== '__smrt_options',",
+              '              ),',
+              '            ),',
+              '  ) as ActionArgs[0];',
+            ]
+          : [
+              '  const options = Object.fromEntries(',
+              '    new URL(request.url).searchParams.entries(),',
+              '  ) as ActionOptions;',
+            ]),
         '',
       );
     }

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -1165,7 +1165,8 @@ function buildActionOptionsLoad(
   if (hasPathParams) {
     lines.push(
       `  const pathParams = ${pathParamsObjectLiteral};`,
-      '  const body: unknown = await request.json();',
+      '  const rawBody = await request.text();',
+      "  const body: unknown = rawBody.trim() === '' ? undefined : JSON.parse(rawBody);",
       '  const options = {',
       '    ...readJsonRecord(body),',
       '    ...pathParams,',
@@ -1175,7 +1176,10 @@ function buildActionOptionsLoad(
     return lines.join('\n');
   }
 
-  lines.push('  const body: unknown = await request.json();');
+  lines.push(
+    '  const rawBody = await request.text();',
+    "  const body: unknown = rawBody.trim() === '' ? undefined : JSON.parse(rawBody);",
+  );
   if (isSingleOptionsParameter) {
     lines.push('  const options = body as ActionArgs[0];', '');
   } else {

--- a/packages/core/src/vite-plugin/web-collections.test.ts
+++ b/packages/core/src/vite-plugin/web-collections.test.ts
@@ -373,7 +373,7 @@ describe('buildWebToolDescriptors', () => {
               isStatic: false,
               async: true,
               returnType: 'Promise<void>',
-              parameters: [],
+              parameters: [{ name: 'id', type: 'string', optional: false }],
             },
           },
           decoratorConfig: {
@@ -389,6 +389,7 @@ describe('buildWebToolDescriptors', () => {
       method: 'POST',
       scope: 'item',
       path: ['publish-now'],
+      parameterAliases: { actionId: 'id' },
     });
   });
 

--- a/packages/core/src/vite-plugin/web-collections.test.ts
+++ b/packages/core/src/vite-plugin/web-collections.test.ts
@@ -329,7 +329,13 @@ describe('buildWebToolDescriptors', () => {
               include: ['list', 'apply'],
               // A config-only collection override cannot change this instance
               // method's receiver.
-              routes: { apply: { scope: 'collection' } },
+              routes: {
+                apply: {
+                  scope: 'collection',
+                  method: 'PATCH',
+                  path: 'publish-now',
+                },
+              },
             },
           } as SmartObjectDefinition['decoratorConfig'],
         }),
@@ -346,6 +352,43 @@ describe('buildWebToolDescriptors', () => {
         expectedVersion: { type: 'number' },
       },
       required: ['id', 'idempotencyKey'],
+    });
+    expect(descriptor?.route).toEqual({
+      method: 'PATCH',
+      scope: 'item',
+      path: ['publish-now'],
+    });
+  });
+
+  it('emits kebab-case custom route segments when configured', () => {
+    const entry = selectWebCollectionEntries(
+      manifest(
+        obj({
+          className: 'Product',
+          collection: 'products',
+          methods: {
+            publishNow: {
+              name: 'publishNow',
+              isPublic: true,
+              isStatic: false,
+              async: true,
+              returnType: 'Promise<void>',
+              parameters: [],
+            },
+          },
+          decoratorConfig: {
+            api: { include: ['list', 'publishNow'] },
+          } as SmartObjectDefinition['decoratorConfig'],
+        }),
+      ),
+    )[0];
+    const descriptor = buildWebToolDescriptors(entry, {
+      kebabRoutes: true,
+    }).find((tool) => tool.action === 'publishNow');
+    expect(descriptor?.route).toEqual({
+      method: 'POST',
+      scope: 'item',
+      path: ['publish-now'],
     });
   });
 

--- a/packages/core/src/vite-plugin/web-collections.test.ts
+++ b/packages/core/src/vite-plugin/web-collections.test.ts
@@ -393,6 +393,36 @@ describe('buildWebToolDescriptors', () => {
     });
   });
 
+  it('marks a generated single-options action for direct transport unwrapping', () => {
+    const entry = selectWebCollectionEntries(
+      manifest(
+        obj({
+          className: 'Product',
+          collection: 'products',
+          methods: {
+            publish: {
+              name: 'publish',
+              isPublic: true,
+              isStatic: false,
+              async: true,
+              returnType: 'Promise<void>',
+              parameters: [{ name: 'options', type: 'object', optional: true }],
+            },
+          },
+          decoratorConfig: {
+            api: { include: ['list', 'publish'] },
+          } as SmartObjectDefinition['decoratorConfig'],
+        }),
+      ),
+    )[0];
+
+    const descriptor = buildWebToolDescriptors(entry).find(
+      (tool) => tool.action === 'publish',
+    );
+    expect(descriptor?.inputSchema.properties).toHaveProperty('options');
+    expect(descriptor?.route).toMatchObject({ optionsBag: true });
+  });
+
   it('stays OUT of buildWebCollectionDefinition, so the #1764 shape digest never covers it', () => {
     const m = manifest(
       obj({

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -796,6 +796,11 @@ export function buildWebToolDescriptors(
         method: route.method,
         scope: route.scope,
         path: route.pathSegments,
+        ...(metadata.parameters === undefined ||
+        (metadata.parameters.length === 1 &&
+          metadata.parameters[0]?.name === 'options')
+          ? { optionsBag: true }
+          : {}),
         ...(Object.keys(parameterAliases).length > 0
           ? { parameterAliases }
           : {}),

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -24,7 +24,10 @@
  */
 
 import { createHash } from 'node:crypto';
-import { resolveCustomActionMetadata } from '../generators/custom-action.js';
+import {
+  customActionParameterInputName,
+  resolveCustomActionMetadata,
+} from '../generators/custom-action.js';
 import {
   buildToolDescriptors,
   isCrudAction,
@@ -767,11 +770,25 @@ export function buildWebToolDescriptors(
 
   return descriptors.map((descriptor) => {
     if (isCrudAction(descriptor.action)) return descriptor;
+    const method = entry.obj.methods?.[descriptor.action];
     const route = resolveApiActionRouteConfig(
       descriptor.action,
-      entry.obj.methods?.[descriptor.action] ?? {},
+      method ?? {},
       entry.obj.decoratorConfig?.api,
       { kebabRoutes: options.kebabRoutes },
+    );
+    const metadata = resolveCustomActionMetadata({
+      actionName: descriptor.action,
+      method,
+      apiConfig: entry.obj.decoratorConfig?.api,
+    });
+    const parameterAliases = Object.fromEntries(
+      (method?.parameters ?? [])
+        .map((parameter) => [
+          customActionParameterInputName(metadata, parameter.name),
+          parameter.name,
+        ])
+        .filter(([inputName, parameterName]) => inputName !== parameterName),
     );
     return {
       ...descriptor,
@@ -779,6 +796,9 @@ export function buildWebToolDescriptors(
         method: route.method,
         scope: route.scope,
         path: route.pathSegments,
+        ...(Object.keys(parameterAliases).length > 0
+          ? { parameterAliases }
+          : {}),
       },
     };
   });

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -27,6 +27,7 @@ import { createHash } from 'node:crypto';
 import { resolveCustomActionMetadata } from '../generators/custom-action.js';
 import {
   buildToolDescriptors,
+  isCrudAction,
   type ToolDescriptor,
   type ToolFieldMeta,
 } from '../generators/tool-schema.js';
@@ -36,7 +37,10 @@ import type {
   SmartObjectDefinition,
   SmartObjectManifest,
 } from '../scanner/types.js';
-import { resolveApiActionSet } from './sveltekit-generator.js';
+import {
+  resolveApiActionRouteConfig,
+  resolveApiActionSet,
+} from './sveltekit-generator.js';
 
 /**
  * Field types that are relationship pseudo-columns rather than persisted
@@ -726,6 +730,7 @@ export function buildWebRelationships(
  */
 export function buildWebToolDescriptors(
   entry: WebCollectionEntry,
+  options: { kebabRoutes?: boolean } = {},
 ): ToolDescriptor[] {
   const webFields = buildWebFieldDefinitions(entry.obj);
   const fields: ToolFieldMeta[] = Object.entries(webFields).map(
@@ -743,7 +748,7 @@ export function buildWebToolDescriptors(
         : {}),
     }),
   );
-  return buildToolDescriptors({
+  const descriptors = buildToolDescriptors({
     className: entry.obj.className,
     fields,
     actions: entry.actions,
@@ -758,6 +763,24 @@ export function buildWebToolDescriptors(
       ]),
     ),
     idType: entry.obj.decoratorConfig.idType,
+  });
+
+  return descriptors.map((descriptor) => {
+    if (isCrudAction(descriptor.action)) return descriptor;
+    const route = resolveApiActionRouteConfig(
+      descriptor.action,
+      entry.obj.methods?.[descriptor.action] ?? {},
+      entry.obj.decoratorConfig?.api,
+      { kebabRoutes: options.kebabRoutes },
+    );
+    return {
+      ...descriptor,
+      route: {
+        method: route.method,
+        scope: route.scope,
+        path: route.pathSegments,
+      },
+    };
   });
 }
 

--- a/packages/smrt-web/AGENTS.md
+++ b/packages/smrt-web/AGENTS.md
@@ -38,6 +38,7 @@ module you are editing. This file keeps what holds in every module.
 | `index.ts` hooks + `durable-store.ts` | the six capability hook points, hook error isolation, the no-op guarantee, and the shared durable-store namespacing/wipe registry | [agents/capability-seam.md](agents/capability-seam.md) |
 | `offline/` | durable offline writes — config, sync-apply-only replay, idempotency, the shared namespace-keyed engine, and Web Locks leader election | [agents/offline-outbox.md](agents/offline-outbox.md) |
 | `sse-client.ts` | the client half of live cache invalidation — the app-wide subscriber, the wire contract it consumes, and SSE-vs-polling behaviour | [agents/live-invalidation.md](agents/live-invalidation.md) |
+| `webmcp.ts` | framework-agnostic WebMCP registrar; registers generated collection tools and routes mutations through shared smrt-web cache state | — |
 | `persistence/` + `update-state.ts` | the read-cache rehydrate capability and the framework-free `updateAvailable` primitive (bundle + contract signals) | [agents/version-persistence.md](agents/version-persistence.md) |
 | `data-query.ts` | dependency-free browser mirror and defensive response normalizer for the canonical bounded data-query envelope (#2444) | — |
 

--- a/packages/smrt-web/package.json
+++ b/packages/smrt-web/package.json
@@ -16,6 +16,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./webmcp": {
+      "types": "./dist/webmcp.d.ts",
+      "import": "./dist/webmcp.js"
     }
   },
   "dependencies": {

--- a/packages/smrt-web/src/collection.test.ts
+++ b/packages/smrt-web/src/collection.test.ts
@@ -259,6 +259,50 @@ describe('createSmrtCollection', () => {
     await collection.cleanup();
   });
 
+  it('keeps the public row id stable and reports missing mutation fetchers clearly', async () => {
+    const updateCalls: Array<{ id: string; data: Record<string, unknown> }> =
+      [];
+    const collection = createSmrtCollection(productDefinition('products-id'), {
+      fetchers: {
+        list: async () => [{ id: 'p1', name: 'Widget' }],
+        create: async (data) => ({ ...data, id: 'p2' }),
+        update: async (id, data) => {
+          updateCalls.push({ id, data });
+          return { id, ...data };
+        },
+      },
+    });
+    await collection.preload();
+
+    const transaction = collection.update('p1', {
+      id: 'p2',
+      name: 'Updated',
+    } as unknown as Omit<Partial<ProductData>, 'id'>);
+    await transaction.isPersisted.promise;
+    expect(updateCalls).toEqual([{ id: 'p1', data: { name: 'Updated' } }]);
+    expect(collection.get('p1')?.id).toBe('p1');
+    expect(collection.has('p2')).toBe(false);
+
+    const noUpdate = createSmrtCollection(
+      productDefinition('products-no-update'),
+      {
+        fetchers: {
+          list: async () => [{ id: 'p1', name: 'Widget' }],
+          create: async (data) => ({ ...data, id: 'p2' }),
+        },
+      },
+    );
+    await noUpdate.preload();
+    expect(() => noUpdate.update('p1', { name: 'Updated' })).toThrow(
+      'products-no-update has no update action',
+    );
+    expect(() => noUpdate.delete('p1')).toThrow(
+      'products-no-update has no delete action',
+    );
+
+    await Promise.all([collection.cleanup(), noUpdate.cleanup()]);
+  });
+
   it('accepts a shared client handle without leaking the engine', async () => {
     const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
     const client = createSmrtWebClient();

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -300,6 +300,8 @@ export interface SmrtCrudFetchers {
   create(data: Record<string, unknown>): Promise<unknown>;
   update?(id: string, data: Record<string, unknown>): Promise<unknown>;
   delete?(id: string): Promise<unknown>;
+  /** Invoke a generated custom action route. */
+  custom?(action: string, args: Record<string, unknown>): Promise<unknown>;
 }
 
 /**
@@ -551,6 +553,24 @@ export function createDefinitionFetchers(
       }
       return true;
     },
+    custom: async (action, args) => {
+      // Generated custom routes use the action name as their default path
+      // segment. Item actions carry the identifier in the path; collection
+      // actions receive the arguments as the JSON body. Explicit route
+      // overrides remain available through a caller-supplied fetcher.
+      const { id, ...body } = args;
+      const path =
+        typeof id === 'string' && id.length > 0
+          ? `${collectionUrl}/${encodeURIComponent(id)}/${action}`
+          : `${collectionUrl}/${action}`;
+      return parse(
+        await fetchFn(path, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(body),
+        }),
+      );
+    },
   };
 }
 
@@ -690,6 +710,10 @@ export interface SmrtWebCollection<TData extends object> {
    * server outcome (see {@link SmrtWebTransaction}).
    */
   insert(row: SmrtWebRow<TData>): SmrtWebTransaction;
+  /** Optimistically update a row and persist it through the REST surface. */
+  update(key: string, changes: Partial<SmrtWebRow<TData>>): SmrtWebTransaction;
+  /** Optimistically delete a row and persist it through the REST surface. */
+  delete(key: string): SmrtWebTransaction;
 }
 
 /** Extract a row's server revision timestamp for sync/apply conflict guards. */
@@ -1290,6 +1314,23 @@ export function createSmrtCollection<TData extends object>(
     },
     insert(row) {
       return collection.insert(row) as unknown as SmrtWebTransaction;
+    },
+    update(key, changes) {
+      const engine = collection as unknown as {
+        update: (
+          key: string,
+          updater: (draft: Record<string, unknown>) => void,
+        ) => unknown;
+      };
+      return engine.update(key, (draft) => {
+        Object.assign(draft, changes);
+      }) as SmrtWebTransaction;
+    },
+    delete(key) {
+      const engine = collection as unknown as {
+        delete: (key: string) => unknown;
+      };
+      return engine.delete(key) as SmrtWebTransaction;
     },
   };
 

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -242,6 +242,15 @@ export interface WebToolDescriptor {
   inputSchema: Record<string, unknown>;
   /** True for non-mutating reads → WebMCP `annotations.readOnlyHint`. */
   readOnly: boolean;
+  /** Generated custom-route transport metadata. */
+  route?: SmrtWebToolRouteDescriptor;
+}
+
+export interface SmrtWebToolRouteDescriptor {
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  scope: 'item' | 'collection';
+  /** Route segments below the collection endpoint; dynamic segments use `[x]`. */
+  path: string[];
 }
 
 export interface SmrtWebCollectionDefinition<TData extends object = object> {
@@ -301,7 +310,11 @@ export interface SmrtCrudFetchers {
   update?(id: string, data: Record<string, unknown>): Promise<unknown>;
   delete?(id: string): Promise<unknown>;
   /** Invoke a generated custom action route. */
-  custom?(action: string, args: Record<string, unknown>): Promise<unknown>;
+  custom?(
+    action: string,
+    args: Record<string, unknown>,
+    route?: SmrtWebToolRouteDescriptor,
+  ): Promise<unknown>;
 }
 
 /**
@@ -553,23 +566,68 @@ export function createDefinitionFetchers(
       }
       return true;
     },
-    custom: async (action, args) => {
-      // Generated custom routes use the action name as their default path
-      // segment. Item actions carry the identifier in the path; collection
-      // actions receive the arguments as the JSON body. Explicit route
-      // overrides remain available through a caller-supplied fetcher.
-      const { id, ...body } = args;
-      const path =
-        typeof id === 'string' && id.length > 0
-          ? `${collectionUrl}/${encodeURIComponent(id)}/${action}`
-          : `${collectionUrl}/${action}`;
-      return parse(
-        await fetchFn(path, {
-          method: 'POST',
-          headers,
-          body: JSON.stringify(body),
-        }),
+    custom: async (action, args, route) => {
+      const customRoute = route ?? {
+        method: 'POST' as const,
+        scope:
+          typeof args.id === 'string'
+            ? ('item' as const)
+            : ('collection' as const),
+        path: [action],
+      };
+      const pathArgs = new Set(
+        customRoute.path
+          .filter((segment) => /^\[[^\]]+\]$/.test(segment))
+          .map((segment) => segment.slice(1, -1)),
       );
+      const id = customRoute.scope === 'item' ? args.id : undefined;
+      if (customRoute.scope === 'item' && typeof id !== 'string') {
+        throw new Error(
+          `${definition.name} custom action '${action}' requires an id`,
+        );
+      }
+      for (const name of pathArgs) {
+        if (args[name] === undefined || args[name] === null) {
+          throw new Error(
+            `${definition.name} custom action '${action}' requires '${name}'`,
+          );
+        }
+      }
+      const body = Object.fromEntries(
+        Object.entries(args).filter(
+          ([key]) => key !== 'id' && !pathArgs.has(key),
+        ),
+      );
+      const segments = [
+        collectionUrl,
+        ...(customRoute.scope === 'item'
+          ? [encodeURIComponent(String(id))]
+          : []),
+        ...customRoute.path.map((segment) =>
+          /^\[[^\]]+\]$/.test(segment)
+            ? encodeURIComponent(String(args[segment.slice(1, -1)] ?? ''))
+            : segment,
+        ),
+      ];
+      const requestPath = `${segments.join('/')}`;
+      const init: RequestInit = { method: customRoute.method, headers };
+      if (customRoute.method !== 'GET') {
+        init.body = JSON.stringify(body);
+      } else {
+        const queryParams = new URLSearchParams();
+        for (const [key, value] of Object.entries(body)) {
+          if (value === undefined || value === null) continue;
+          queryParams.set(
+            key,
+            typeof value === 'object' ? JSON.stringify(value) : String(value),
+          );
+        }
+        const query = queryParams.toString()
+          ? `?${queryParams.toString()}`
+          : '';
+        return parse(await fetchFn(`${requestPath}${query}`, { ...init }));
+      }
+      return parse(await fetchFn(requestPath, init));
     },
   };
 }
@@ -714,6 +772,12 @@ export interface SmrtWebCollection<TData extends object> {
   update(key: string, changes: Partial<SmrtWebRow<TData>>): SmrtWebTransaction;
   /** Optimistically delete a row and persist it through the REST surface. */
   delete(key: string): SmrtWebTransaction;
+  /** Execute a custom action and invalidate this collection's related caches. */
+  action(
+    action: string,
+    args: Record<string, unknown>,
+    route?: SmrtWebToolRouteDescriptor,
+  ): Promise<unknown>;
 }
 
 /** Extract a row's server revision timestamp for sync/apply conflict guards. */
@@ -1331,6 +1395,17 @@ export function createSmrtCollection<TData extends object>(
         delete: (key: string) => unknown;
       };
       return engine.delete(key) as SmrtWebTransaction;
+    },
+    async action(action, args, route) {
+      if (!fetchers.custom) {
+        throw new Error(`${definition.name} has no custom action fetcher`);
+      }
+      const result =
+        route === undefined
+          ? await fetchers.custom(action, args)
+          : await fetchers.custom(action, args, route);
+      invalidateRelated();
+      return result;
     },
   };
 

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -45,7 +45,10 @@ import type {
   SmrtWebMutationEnvelope,
 } from './capability.js';
 import { runWrapMutation } from './capability.js';
-import { persistedMutationResults } from './internal.js';
+import {
+  mutationTargetHydrators,
+  persistedMutationResults,
+} from './internal.js';
 
 // Re-export the capability seam (#1755) and the shared durable-store foundation
 // through this single entry — the package ships one export subpath, so both are
@@ -582,14 +585,12 @@ export function createDefinitionFetchers(
       // A generated method with one `options` parameter receives that object
       // directly on the server. Keep receiver/path arguments outside the
       // transport body and unwrap the WebMCP schema's `{ options: ... }` bag.
+      const optionsBag = customRoute.optionsBag === true;
+      const optionsValue = optionsBag ? args.options : undefined;
       const transportArgs =
-        customRoute.optionsBag === true &&
-        args.options !== null &&
-        typeof args.options === 'object'
-          ? (args.options as Record<string, unknown>)
-          : customRoute.optionsBag === true
-            ? {}
-            : args;
+        optionsBag && optionsValue !== null && typeof optionsValue === 'object'
+          ? (optionsValue as Record<string, unknown>)
+          : args;
       const pathArgs = new Set(
         customRoute.path
           .filter((segment) => /^\[[^\]]+\]$/.test(segment))
@@ -621,35 +622,41 @@ export function createDefinitionFetchers(
         [...pathArgs].map((name) => inputNameFor(name)),
       );
       const aliasedInputs = new Set(Object.keys(parameterAliases));
-      const body = Object.fromEntries(
-        Object.entries(transportArgs).filter(
-          ([key]) =>
-            key !== 'id' &&
-            !pathArgs.has(key) &&
-            !consumedInputs.has(key) &&
-            !aliasedInputs.has(key),
-        ),
-      );
-      for (const [inputName, originalName] of Object.entries(
-        parameterAliases,
-      )) {
-        if (
-          !consumedInputs.has(inputName) &&
-          transportArgs[inputName] !== undefined &&
-          originalName !== 'id'
-        ) {
-          body[originalName] = transportArgs[inputName];
+      const body: unknown = optionsBag
+        ? optionsValue
+        : Object.fromEntries(
+            Object.entries(transportArgs).filter(
+              ([key]) =>
+                key !== 'id' &&
+                !pathArgs.has(key) &&
+                !consumedInputs.has(key) &&
+                !aliasedInputs.has(key),
+            ),
+          );
+      if (!optionsBag) {
+        for (const [inputName, originalName] of Object.entries(
+          parameterAliases,
+        )) {
+          if (
+            !consumedInputs.has(inputName) &&
+            transportArgs[inputName] !== undefined &&
+            originalName !== 'id'
+          ) {
+            (body as Record<string, unknown>)[originalName] =
+              transportArgs[inputName];
+          }
         }
       }
       const idAlias = Object.entries(parameterAliases).find(
         ([, originalName]) => originalName === 'id',
       )?.[0];
       if (
+        !optionsBag &&
         idAlias &&
         !consumedInputs.has(idAlias) &&
         transportArgs[idAlias] !== undefined
       ) {
-        body.id = transportArgs[idAlias];
+        (body as Record<string, unknown>).id = transportArgs[idAlias];
       }
       const segments = [
         collectionUrl,
@@ -670,7 +677,11 @@ export function createDefinitionFetchers(
         init.body = JSON.stringify(body);
       } else {
         const queryParams = new URLSearchParams();
-        for (const [key, value] of Object.entries(body)) {
+        const queryBody =
+          body !== null && typeof body === 'object' && !Array.isArray(body)
+            ? (body as Record<string, unknown>)
+            : {};
+        for (const [key, value] of Object.entries(queryBody)) {
           if (value === undefined || value === null) continue;
           queryParams.set(
             key,
@@ -1479,6 +1490,10 @@ export function createSmrtCollection<TData extends object>(
   };
 
   persistedMutationResults.set(handle as object, mutationResults);
+  mutationTargetHydrators.set(handle as object, async (row) => {
+    await collection.preload();
+    collection.utils.writeUpsert(row as Partial<Row>);
+  });
 
   engineCollections.set(handle, collection);
 

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -260,6 +260,9 @@ export interface SmrtWebToolRouteDescriptor {
   optionsBag?: boolean;
 }
 
+/** Reserved GET query marker for preserving an options bag's nullish value. */
+const CUSTOM_OPTIONS_QUERY_MARKER = '__smrt_options';
+
 export interface SmrtWebCollectionDefinition<TData extends object = object> {
   /** REST collection name (e.g. `products`). */
   name: string;
@@ -677,16 +680,43 @@ export function createDefinitionFetchers(
         init.body = JSON.stringify(body);
       } else {
         const queryParams = new URLSearchParams();
-        const queryBody =
-          body !== null && typeof body === 'object' && !Array.isArray(body)
-            ? (body as Record<string, unknown>)
-            : {};
-        for (const [key, value] of Object.entries(queryBody)) {
-          if (value === undefined || value === null) continue;
-          queryParams.set(
-            key,
-            typeof value === 'object' ? JSON.stringify(value) : String(value),
-          );
+        if (optionsBag) {
+          if (optionsValue === undefined) {
+            queryParams.set(CUSTOM_OPTIONS_QUERY_MARKER, 'undefined');
+          } else if (optionsValue === null) {
+            queryParams.set(CUSTOM_OPTIONS_QUERY_MARKER, 'null');
+          } else {
+            const queryBody =
+              typeof optionsValue === 'object' && !Array.isArray(optionsValue)
+                ? (optionsValue as Record<string, unknown>)
+                : {};
+            const entries = Object.entries(queryBody).filter(
+              ([, value]) => value !== undefined && value !== null,
+            );
+            for (const [key, value] of entries) {
+              queryParams.set(
+                key,
+                typeof value === 'object'
+                  ? JSON.stringify(value)
+                  : String(value),
+              );
+            }
+            if (entries.length === 0) {
+              queryParams.set(CUSTOM_OPTIONS_QUERY_MARKER, 'object');
+            }
+          }
+        } else {
+          const queryBody =
+            body !== null && typeof body === 'object' && !Array.isArray(body)
+              ? (body as Record<string, unknown>)
+              : {};
+          for (const [key, value] of Object.entries(queryBody)) {
+            if (value === undefined || value === null) continue;
+            queryParams.set(
+              key,
+              typeof value === 'object' ? JSON.stringify(value) : String(value),
+            );
+          }
         }
         const query = queryParams.toString()
           ? `?${queryParams.toString()}`

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -251,6 +251,8 @@ export interface SmrtWebToolRouteDescriptor {
   scope: 'item' | 'collection';
   /** Route segments below the collection endpoint; dynamic segments use `[x]`. */
   path: string[];
+  /** Transport names rewritten by the tool schema (e.g. `actionId` → `id`). */
+  parameterAliases?: Record<string, string>;
 }
 
 export interface SmrtWebCollectionDefinition<TData extends object = object> {
@@ -580,6 +582,15 @@ export function createDefinitionFetchers(
           .filter((segment) => /^\[[^\]]+\]$/.test(segment))
           .map((segment) => segment.slice(1, -1)),
       );
+      const parameterAliases = customRoute.parameterAliases ?? {};
+      const inputNameFor = (parameterName: string): string =>
+        Object.entries(parameterAliases).find(
+          ([, originalName]) => originalName === parameterName,
+        )?.[0] ?? parameterName;
+      const valueForPath = (parameterName: string): unknown => {
+        const inputName = inputNameFor(parameterName);
+        return args[inputName] ?? args[parameterName];
+      };
       const id = customRoute.scope === 'item' ? args.id : undefined;
       if (customRoute.scope === 'item' && typeof id !== 'string') {
         throw new Error(
@@ -587,17 +598,46 @@ export function createDefinitionFetchers(
         );
       }
       for (const name of pathArgs) {
-        if (args[name] === undefined || args[name] === null) {
+        if (valueForPath(name) === undefined || valueForPath(name) === null) {
           throw new Error(
             `${definition.name} custom action '${action}' requires '${name}'`,
           );
         }
       }
+      const consumedInputs = new Set(
+        [...pathArgs].map((name) => inputNameFor(name)),
+      );
+      const aliasedInputs = new Set(Object.keys(parameterAliases));
       const body = Object.fromEntries(
         Object.entries(args).filter(
-          ([key]) => key !== 'id' && !pathArgs.has(key),
+          ([key]) =>
+            key !== 'id' &&
+            !pathArgs.has(key) &&
+            !consumedInputs.has(key) &&
+            !aliasedInputs.has(key),
         ),
       );
+      for (const [inputName, originalName] of Object.entries(
+        parameterAliases,
+      )) {
+        if (
+          !consumedInputs.has(inputName) &&
+          args[inputName] !== undefined &&
+          originalName !== 'id'
+        ) {
+          body[originalName] = args[inputName];
+        }
+      }
+      const idAlias = Object.entries(parameterAliases).find(
+        ([, originalName]) => originalName === 'id',
+      )?.[0];
+      if (
+        idAlias &&
+        !consumedInputs.has(idAlias) &&
+        args[idAlias] !== undefined
+      ) {
+        body.id = args[idAlias];
+      }
       const segments = [
         collectionUrl,
         ...(customRoute.scope === 'item'
@@ -605,7 +645,9 @@ export function createDefinitionFetchers(
           : []),
         ...customRoute.path.map((segment) =>
           /^\[[^\]]+\]$/.test(segment)
-            ? encodeURIComponent(String(args[segment.slice(1, -1)] ?? ''))
+            ? encodeURIComponent(
+                String(valueForPath(segment.slice(1, -1)) ?? ''),
+              )
             : segment,
         ),
       ];

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -39,13 +39,13 @@
 import { createCollection } from '@tanstack/db';
 import { QueryClient } from '@tanstack/query-core';
 import { queryCollectionOptions } from '@tanstack/query-db-collection';
-
 import type {
   SmrtWebCapability,
   SmrtWebCapabilityContext,
   SmrtWebMutationEnvelope,
 } from './capability.js';
 import { runWrapMutation } from './capability.js';
+import { persistedMutationResults } from './internal.js';
 
 // Re-export the capability seam (#1755) and the shared durable-store foundation
 // through this single entry — the package ships one export subpath, so both are
@@ -253,6 +253,8 @@ export interface SmrtWebToolRouteDescriptor {
   path: string[];
   /** Transport names rewritten by the tool schema (e.g. `actionId` → `id`). */
   parameterAliases?: Record<string, string>;
+  /** The generated method accepts one `options` bag as its sole argument. */
+  optionsBag?: boolean;
 }
 
 export interface SmrtWebCollectionDefinition<TData extends object = object> {
@@ -577,6 +579,17 @@ export function createDefinitionFetchers(
             : ('collection' as const),
         path: [action],
       };
+      // A generated method with one `options` parameter receives that object
+      // directly on the server. Keep receiver/path arguments outside the
+      // transport body and unwrap the WebMCP schema's `{ options: ... }` bag.
+      const transportArgs =
+        customRoute.optionsBag === true &&
+        args.options !== null &&
+        typeof args.options === 'object'
+          ? (args.options as Record<string, unknown>)
+          : customRoute.optionsBag === true
+            ? {}
+            : args;
       const pathArgs = new Set(
         customRoute.path
           .filter((segment) => /^\[[^\]]+\]$/.test(segment))
@@ -609,7 +622,7 @@ export function createDefinitionFetchers(
       );
       const aliasedInputs = new Set(Object.keys(parameterAliases));
       const body = Object.fromEntries(
-        Object.entries(args).filter(
+        Object.entries(transportArgs).filter(
           ([key]) =>
             key !== 'id' &&
             !pathArgs.has(key) &&
@@ -622,10 +635,10 @@ export function createDefinitionFetchers(
       )) {
         if (
           !consumedInputs.has(inputName) &&
-          args[inputName] !== undefined &&
+          transportArgs[inputName] !== undefined &&
           originalName !== 'id'
         ) {
-          body[originalName] = args[inputName];
+          body[originalName] = transportArgs[inputName];
         }
       }
       const idAlias = Object.entries(parameterAliases).find(
@@ -634,9 +647,9 @@ export function createDefinitionFetchers(
       if (
         idAlias &&
         !consumedInputs.has(idAlias) &&
-        args[idAlias] !== undefined
+        transportArgs[idAlias] !== undefined
       ) {
-        body.id = args[idAlias];
+        body.id = transportArgs[idAlias];
       }
       const segments = [
         collectionUrl,
@@ -811,7 +824,10 @@ export interface SmrtWebCollection<TData extends object> {
    */
   insert(row: SmrtWebRow<TData>): SmrtWebTransaction;
   /** Optimistically update a row and persist it through the REST surface. */
-  update(key: string, changes: Partial<SmrtWebRow<TData>>): SmrtWebTransaction;
+  update(
+    key: string,
+    changes: Omit<Partial<SmrtWebRow<TData>>, 'id'>,
+  ): SmrtWebTransaction;
   /** Optimistically delete a row and persist it through the REST surface. */
   delete(key: string): SmrtWebTransaction;
   /** Execute a custom action and invalidate this collection's related caches. */
@@ -989,6 +1005,7 @@ export function createSmrtCollection<TData extends object>(
     createDefinitionFetchers(definition, options.basePath, options.fetchFn);
   const queryClient = resolveQueryClient(options.client);
   const idField = definition.idField || 'id';
+  const mutationResults = new Map<string, unknown>();
 
   // Scope discriminates the cache key so a shared client can materialize the
   // same collection against different backends without cross-serving reads.
@@ -1292,6 +1309,7 @@ export function createSmrtCollection<TData extends object>(
               `create(${definition.name})`,
             );
           });
+          mutationResults.set(envelope.key, outcome.result);
           anyHandled = anyHandled || outcome.handled;
         }
         // If a capability handled the write offline (#1762) it never reached the
@@ -1325,6 +1343,7 @@ export function createSmrtCollection<TData extends object>(
                   `update(${definition.name})`,
                 ),
               );
+              mutationResults.set(envelope.key, outcome.result);
               anyHandled = anyHandled || outcome.handled;
             }
             if (anyHandled) return { refetch: false };
@@ -1346,6 +1365,7 @@ export function createSmrtCollection<TData extends object>(
                 // biome-ignore lint/style/noNonNullAssertion: guarded by the surrounding ternary
                 fetchers.delete!(key),
               );
+              mutationResults.set(envelope.key, outcome.result);
               anyHandled = anyHandled || outcome.handled;
             }
             if (anyHandled) return { refetch: false };
@@ -1422,6 +1442,10 @@ export function createSmrtCollection<TData extends object>(
       return collection.insert(row) as unknown as SmrtWebTransaction;
     },
     update(key, changes) {
+      if (!fetchers.update) {
+        throw new Error(`${definition.name} has no update action`);
+      }
+      const { id: _id, ...safeChanges } = changes as Record<string, unknown>;
       const engine = collection as unknown as {
         update: (
           key: string,
@@ -1429,10 +1453,13 @@ export function createSmrtCollection<TData extends object>(
         ) => unknown;
       };
       return engine.update(key, (draft) => {
-        Object.assign(draft, changes);
+        Object.assign(draft, safeChanges);
       }) as SmrtWebTransaction;
     },
     delete(key) {
+      if (!fetchers.delete) {
+        throw new Error(`${definition.name} has no delete action`);
+      }
       const engine = collection as unknown as {
         delete: (key: string) => unknown;
       };
@@ -1450,6 +1477,8 @@ export function createSmrtCollection<TData extends object>(
       return result;
     },
   };
+
+  persistedMutationResults.set(handle as object, mutationResults);
 
   engineCollections.set(handle, collection);
 

--- a/packages/smrt-web/src/internal.ts
+++ b/packages/smrt-web/src/internal.ts
@@ -1,0 +1,12 @@
+/** Internal coordination state shared by the smrt-web runtime modules. */
+
+/**
+ * TanStack transactions resolve with an opaque transaction object rather than
+ * the value returned by the REST mutation handler. Keep the latter beside the
+ * public collection handle so WebMCP can return the server's canonical row
+ * without exposing engine internals.
+ */
+export const persistedMutationResults = new WeakMap<
+  object,
+  Map<string, unknown>
+>();

--- a/packages/smrt-web/src/internal.ts
+++ b/packages/smrt-web/src/internal.ts
@@ -10,3 +10,13 @@ export const persistedMutationResults = new WeakMap<
   object,
   Map<string, unknown>
 >();
+
+/**
+ * Engine-owned hydration boundary. The implementation registers this callback
+ * where the typed query-collection API is available; WebMCP only asks the
+ * boundary to hydrate a row and never reaches into engine internals.
+ */
+export const mutationTargetHydrators = new WeakMap<
+  object,
+  (row: Record<string, unknown>) => Promise<void>
+>();

--- a/packages/smrt-web/src/invalidation.test.ts
+++ b/packages/smrt-web/src/invalidation.test.ts
@@ -102,7 +102,7 @@ function tagsDefinition(): SmrtWebCollectionDefinition<TagData> {
  */
 function makeScriptedFetchers(initialRows: Array<Record<string, unknown>>) {
   const serverRows = [...initialRows];
-  const calls = { list: 0, create: 0, update: 0, delete: 0 };
+  const calls = { list: 0, create: 0, update: 0, delete: 0, custom: 0 };
 
   const fetchers: SmrtCrudFetchers = {
     list: async () => {
@@ -122,6 +122,10 @@ function makeScriptedFetchers(initialRows: Array<Record<string, unknown>>) {
     delete: async () => {
       calls.delete += 1;
       return true;
+    },
+    custom: async () => {
+      calls.custom += 1;
+      return { ok: true };
     },
   };
 
@@ -240,6 +244,40 @@ describe('relationship-derived invalidation (shared client)', () => {
     expect(tagsBackend.calls.list).toBeGreaterThanOrEqual(2);
 
     tagsSub.unsubscribe();
+  });
+
+  it('refetches related collections after a custom action settles', async () => {
+    const client = createSmrtWebClient();
+    const commentsBackend = makeScriptedFetchers([
+      { id: 'c1', body: 'first', articleId: 'a1' },
+    ]);
+    const articlesBackend = makeScriptedFetchers([
+      { id: 'a1', title: 'Hello' },
+    ]);
+    const comments = track(
+      createSmrtCollection(commentsDefinition(), {
+        fetchers: commentsBackend.fetchers,
+        client,
+        staleTimeMs: 60_000,
+      }),
+    );
+    const articles = track(
+      createSmrtCollection(articlesDefinition(), {
+        fetchers: articlesBackend.fetchers,
+        client,
+        staleTimeMs: 60_000,
+      }),
+    );
+    const articlesSub = articles.subscribeChanges(() => {});
+    await Promise.all([comments.preload(), articles.preload()]);
+    expect(articlesBackend.calls.list).toBe(1);
+
+    await comments.action('publish', { id: 'c1' });
+
+    await waitFor(() => articlesBackend.calls.list >= 2);
+    expect(commentsBackend.calls.custom).toBe(1);
+    expect(articlesBackend.calls.list).toBeGreaterThanOrEqual(2);
+    articlesSub.unsubscribe();
   });
 
   it('does not refetch an UNRELATED collection sharing the same client', async () => {

--- a/packages/smrt-web/src/webmcp.test.ts
+++ b/packages/smrt-web/src/webmcp.test.ts
@@ -178,8 +178,10 @@ describe('registerWebMcpTools', () => {
       name: 'Gadget',
       price: 9.99,
     });
-    expect(JSON.parse(result as string)).toMatchObject({ name: 'Gadget' });
-    expect(JSON.parse(result as string).id).toEqual(expect.any(String));
+    expect(JSON.parse(result as string)).toMatchObject({
+      id: 'p2',
+      name: 'Gadget',
+    });
   });
 
   it('routes custom actions through the collection fetcher', async () => {
@@ -208,12 +210,13 @@ describe('registerWebMcpTools', () => {
 
     const updateTool = registry.tools.find((t) => t.name === 'product_update');
     const deleteTool = registry.tools.find((t) => t.name === 'product_delete');
-    await updateTool?.execute({ id: 'p1', name: 'Updated' });
-    await deleteTool?.execute({ id: 'p1' });
+    await updateTool?.execute({ id: 'p99', name: 'Updated' });
+    await deleteTool?.execute({ id: 'p99' });
 
     expect(fetchers.list.mock.calls.length).toBeGreaterThanOrEqual(1);
-    expect(fetchers.update).toHaveBeenCalledWith('p1', { name: 'Updated' });
-    expect(fetchers.delete).toHaveBeenCalledWith('p1');
+    expect(fetchers.get).toHaveBeenCalledWith('p99');
+    expect(fetchers.update).toHaveBeenCalledWith('p99', { name: 'Updated' });
+    expect(fetchers.delete).toHaveBeenCalledWith('p99');
   });
 
   it('deregisters every registered tool when disposed', () => {
@@ -317,6 +320,63 @@ describe('registerWebMcpTools', () => {
     expect(calls[0]?.url).toBe('/api/v1/products/p1/publish-now');
     expect(calls[0]?.init?.method).toBe('PATCH');
     expect(calls[0]?.init?.body).toBe(JSON.stringify({ reason: 'agent' }));
+  });
+
+  it('unwraps a generated single-options bag for POST and GET custom routes', async () => {
+    const registry = installModelContext();
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchFn = (async (url: string | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      } as Response;
+    }) as unknown as typeof fetch;
+    const definition: SmrtWebCollectionDefinition = {
+      ...PRODUCT_DEF,
+      toolDescriptors: [
+        {
+          action: 'publish',
+          name: 'product_publish',
+          description: 'Publish a Product',
+          inputSchema: { type: 'object' },
+          readOnly: false,
+          route: {
+            method: 'PATCH',
+            scope: 'item',
+            path: ['publish-now'],
+            optionsBag: true,
+          },
+        },
+        {
+          action: 'preview',
+          name: 'product_preview',
+          description: 'Preview a Product',
+          inputSchema: { type: 'object' },
+          readOnly: true,
+          route: {
+            method: 'GET',
+            scope: 'collection',
+            path: ['preview'],
+            optionsBag: true,
+          },
+        },
+      ],
+    };
+    registerWebMcpTools([definition], { basePath: '/api/v1', fetchFn });
+    const publishTool = registry.tools.find(
+      (t) => t.name === 'product_publish',
+    );
+    const previewTool = registry.tools.find(
+      (t) => t.name === 'product_preview',
+    );
+    await publishTool?.execute({ id: 'p1', options: { reason: 'agent' } });
+    await previewTool?.execute({ options: { format: 'summary' } });
+
+    expect(calls[0]?.url).toBe('/api/v1/products/p1/publish-now');
+    expect(calls[0]?.init?.body).toBe(JSON.stringify({ reason: 'agent' }));
+    expect(calls[1]?.url).toBe('/api/v1/products/preview?format=summary');
   });
 
   it('maps actionId aliases for item bodies and collection path parameters', async () => {

--- a/packages/smrt-web/src/webmcp.test.ts
+++ b/packages/smrt-web/src/webmcp.test.ts
@@ -73,6 +73,26 @@ const PRODUCT_DEF: SmrtWebCollectionDefinition = {
   ],
 };
 
+const MUTATION_DEF: SmrtWebCollectionDefinition = {
+  ...PRODUCT_DEF,
+  toolDescriptors: [
+    {
+      action: 'update',
+      name: 'product_update',
+      description: 'Update an existing Product',
+      inputSchema: { type: 'object', properties: { id: { type: 'string' } } },
+      readOnly: false,
+    },
+    {
+      action: 'delete',
+      name: 'product_delete',
+      description: 'Delete a Product by ID',
+      inputSchema: { type: 'object', properties: { id: { type: 'string' } } },
+      readOnly: false,
+    },
+  ],
+};
+
 function mockFetchers(overrides: Partial<SmrtCrudFetchers> = {}) {
   return {
     list: vi.fn(async () => [{ id: 'p1', name: 'Widget' }]),
@@ -86,6 +106,10 @@ function mockFetchers(overrides: Partial<SmrtCrudFetchers> = {}) {
       ...data,
     })),
     delete: vi.fn(async () => true),
+    custom: vi.fn(async (action: string, args: Record<string, unknown>) => ({
+      action,
+      result: args,
+    })),
     ...overrides,
   } satisfies SmrtCrudFetchers;
 }
@@ -142,7 +166,7 @@ describe('registerWebMcpTools', () => {
     ]);
   });
 
-  it('routes a create tool call through the fetchers with the tool args as the body', async () => {
+  it('routes a create tool call through the shared collection mutation path', async () => {
     const registry = installModelContext();
     const fetchers = mockFetchers();
     registerWebMcpTools([PRODUCT_DEF], { resolveFetchers: () => fetchers });
@@ -154,16 +178,15 @@ describe('registerWebMcpTools', () => {
       name: 'Gadget',
       price: 9.99,
     });
-    expect(JSON.parse(result as string)).toMatchObject({
-      id: 'p2',
-      name: 'Gadget',
-    });
+    expect(JSON.parse(result as string)).toMatchObject({ name: 'Gadget' });
+    expect(JSON.parse(result as string).id).toEqual(expect.any(String));
   });
 
-  it('returns a clear not-wired payload for custom actions (tracer scope)', async () => {
+  it('routes custom actions through the collection fetcher', async () => {
     const registry = installModelContext();
+    const fetchers = mockFetchers();
     registerWebMcpTools([PRODUCT_DEF], {
-      resolveFetchers: () => mockFetchers(),
+      resolveFetchers: () => fetchers,
     });
 
     const publishTool = registry.tools.find(
@@ -172,8 +195,25 @@ describe('registerWebMcpTools', () => {
     const parsed = JSON.parse(
       (await publishTool?.execute({ id: 'p1' })) as string,
     );
-    expect(parsed.error).toMatch(/not wired/i);
-    expect(parsed.action).toBe('publish');
+    expect(fetchers.custom).toHaveBeenCalledWith('publish', { id: 'p1' });
+    expect(parsed).toEqual({ action: 'publish', result: { id: 'p1' } });
+  });
+
+  it('hydrates the shared collection before update and delete mutations', async () => {
+    const registry = installModelContext();
+    const fetchers = mockFetchers();
+    registerWebMcpTools([MUTATION_DEF], {
+      resolveFetchers: () => fetchers,
+    });
+
+    const updateTool = registry.tools.find((t) => t.name === 'product_update');
+    const deleteTool = registry.tools.find((t) => t.name === 'product_delete');
+    await updateTool?.execute({ id: 'p1', name: 'Updated' });
+    await deleteTool?.execute({ id: 'p1' });
+
+    expect(fetchers.list.mock.calls.length).toBeGreaterThanOrEqual(1);
+    expect(fetchers.update).toHaveBeenCalledWith('p1', { name: 'Updated' });
+    expect(fetchers.delete).toHaveBeenCalledWith('p1');
   });
 
   it('deregisters every registered tool when disposed', () => {

--- a/packages/smrt-web/src/webmcp.test.ts
+++ b/packages/smrt-web/src/webmcp.test.ts
@@ -319,6 +319,74 @@ describe('registerWebMcpTools', () => {
     expect(calls[0]?.init?.body).toBe(JSON.stringify({ reason: 'agent' }));
   });
 
+  it('maps actionId aliases for item bodies and collection path parameters', async () => {
+    const registry = installModelContext();
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchFn = (async (url: string | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      } as Response;
+    }) as unknown as typeof fetch;
+    const definition: SmrtWebCollectionDefinition = {
+      ...PRODUCT_DEF,
+      toolDescriptors: [
+        {
+          action: 'archive',
+          name: 'product_archive',
+          description: 'Archive a Product',
+          inputSchema: { type: 'object' },
+          readOnly: false,
+          route: {
+            method: 'PATCH',
+            scope: 'item',
+            path: ['archive'],
+            parameterAliases: { actionId: 'id' },
+          },
+        },
+        {
+          action: 'archiveCollection',
+          name: 'product_archiveCollection',
+          description: 'Archive a Product by alternate ID',
+          inputSchema: { type: 'object' },
+          readOnly: false,
+          route: {
+            method: 'PATCH',
+            scope: 'collection',
+            path: ['by-id', '[id]'],
+            parameterAliases: { actionId: 'id' },
+          },
+        },
+      ],
+    };
+    registerWebMcpTools([definition], { basePath: '/api/v1', fetchFn });
+    const itemTool = registry.tools.find((t) => t.name === 'product_archive');
+    const collectionTool = registry.tools.find(
+      (t) => t.name === 'product_archiveCollection',
+    );
+    await itemTool?.execute({
+      id: 'receiver-1',
+      actionId: 'target-7',
+      reason: 'item',
+    });
+    await collectionTool?.execute({
+      actionId: 'target-7',
+      reason: 'collection',
+    });
+
+    expect(calls[0]?.url).toBe('/api/v1/products/receiver-1/archive');
+    expect(JSON.parse(calls[0]?.init?.body as string)).toEqual({
+      id: 'target-7',
+      reason: 'item',
+    });
+    expect(calls[1]?.url).toBe('/api/v1/products/by-id/target-7');
+    expect(JSON.parse(calls[1]?.init?.body as string)).toEqual({
+      reason: 'collection',
+    });
+  });
+
   it('resolves a get tool by slug when no id is provided', async () => {
     const registry = installModelContext();
     const fetchers = mockFetchers();

--- a/packages/smrt-web/src/webmcp.test.ts
+++ b/packages/smrt-web/src/webmcp.test.ts
@@ -375,12 +375,18 @@ describe('registerWebMcpTools', () => {
     await publishTool?.execute({ id: 'p1' });
     await publishTool?.execute({ id: 'p1', options: null });
     await previewTool?.execute({ options: { format: 'summary' } });
+    await previewTool?.execute({});
+    await previewTool?.execute({ options: null });
 
     expect(calls[0]?.url).toBe('/api/v1/products/p1/publish-now');
     expect(calls[0]?.init?.body).toBe(JSON.stringify({ reason: 'agent' }));
     expect(calls[1]?.init?.body).toBeUndefined();
     expect(calls[2]?.init?.body).toBe('null');
     expect(calls[3]?.url).toBe('/api/v1/products/preview?format=summary');
+    expect(calls[4]?.url).toBe(
+      '/api/v1/products/preview?__smrt_options=undefined',
+    );
+    expect(calls[5]?.url).toBe('/api/v1/products/preview?__smrt_options=null');
   });
 
   it('maps actionId aliases for item bodies and collection path parameters', async () => {

--- a/packages/smrt-web/src/webmcp.test.ts
+++ b/packages/smrt-web/src/webmcp.test.ts
@@ -372,11 +372,15 @@ describe('registerWebMcpTools', () => {
       (t) => t.name === 'product_preview',
     );
     await publishTool?.execute({ id: 'p1', options: { reason: 'agent' } });
+    await publishTool?.execute({ id: 'p1' });
+    await publishTool?.execute({ id: 'p1', options: null });
     await previewTool?.execute({ options: { format: 'summary' } });
 
     expect(calls[0]?.url).toBe('/api/v1/products/p1/publish-now');
     expect(calls[0]?.init?.body).toBe(JSON.stringify({ reason: 'agent' }));
-    expect(calls[1]?.url).toBe('/api/v1/products/preview?format=summary');
+    expect(calls[1]?.init?.body).toBeUndefined();
+    expect(calls[2]?.init?.body).toBe('null');
+    expect(calls[3]?.url).toBe('/api/v1/products/preview?format=summary');
   });
 
   it('maps actionId aliases for item bodies and collection path parameters', async () => {

--- a/packages/smrt-web/src/webmcp.test.ts
+++ b/packages/smrt-web/src/webmcp.test.ts
@@ -279,6 +279,46 @@ describe('registerWebMcpTools', () => {
     expect(calls[0]).toContain('status=active');
   });
 
+  it('uses generated custom route method and path metadata', async () => {
+    const registry = installModelContext();
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchFn = (async (url: string | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ action: 'publish', result: { id: 'p1' } }),
+      } as Response;
+    }) as unknown as typeof fetch;
+    const definition: SmrtWebCollectionDefinition = {
+      ...PRODUCT_DEF,
+      toolDescriptors: [
+        {
+          action: 'publish',
+          name: 'product_publish',
+          description: 'Publish a Product',
+          inputSchema: { type: 'object' },
+          readOnly: false,
+          route: {
+            method: 'PATCH',
+            scope: 'item',
+            path: ['publish-now'],
+          },
+        },
+      ],
+    };
+    registerWebMcpTools([definition], { basePath: '/api/v1', fetchFn });
+    const publishTool = registry.tools.find(
+      (t) => t.name === 'product_publish',
+    );
+    await publishTool?.execute({ id: 'p1', reason: 'agent' });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe('/api/v1/products/p1/publish-now');
+    expect(calls[0]?.init?.method).toBe('PATCH');
+    expect(calls[0]?.init?.body).toBe(JSON.stringify({ reason: 'agent' }));
+  });
+
   it('resolves a get tool by slug when no id is provided', async () => {
     const registry = installModelContext();
     const fetchers = mockFetchers();

--- a/packages/smrt-web/src/webmcp.ts
+++ b/packages/smrt-web/src/webmcp.ts
@@ -25,6 +25,7 @@ import {
   type SmrtWebTransaction,
   unwrapItemResult,
   unwrapListResult,
+  type WebToolDescriptor,
 } from './index.js';
 
 /** The subset of Chrome's WebMCP `registerTool` input this tracer emits. */
@@ -140,6 +141,7 @@ export function registerWebMcpTools(
               collection,
               definition,
               descriptor.action,
+              descriptor.route,
               args ?? {},
             ),
         },
@@ -199,6 +201,7 @@ async function dispatch(
   collection: SmrtWebCollection<Record<string, unknown>>,
   definition: SmrtWebCollectionDefinition,
   action: string,
+  route: WebToolDescriptor['route'],
   args: Record<string, unknown>,
 ): Promise<string> {
   switch (action) {
@@ -267,7 +270,7 @@ async function dispatch(
       if (!fetchers.custom) {
         throw new Error(`${definition.name} has no custom action fetcher`);
       }
-      return JSON.stringify(await fetchers.custom(action, args));
+      return JSON.stringify(await collection.action(action, args, route));
   }
 }
 

--- a/packages/smrt-web/src/webmcp.ts
+++ b/packages/smrt-web/src/webmcp.ts
@@ -17,7 +17,6 @@
 import {
   createDefinitionFetchers,
   createSmrtCollection,
-  getEngineCollection,
   newLocalId,
   type SmrtCrudFetchers,
   type SmrtWebClient,
@@ -28,7 +27,10 @@ import {
   unwrapListResult,
   type WebToolDescriptor,
 } from './index.js';
-import { persistedMutationResults } from './internal.js';
+import {
+  mutationTargetHydrators,
+  persistedMutationResults,
+} from './internal.js';
 
 /** The subset of Chrome's WebMCP `registerTool` input this tracer emits. */
 interface WebMcpToolRegistration {
@@ -315,14 +317,11 @@ async function hydrateMutationTarget(
     await fetchers.get(id),
     `get(${definition.name})`,
   ) as Record<string, unknown>;
-  await collection.preload();
-  const engine = getEngineCollection(collection) as {
-    utils?: { writeUpsert?: (value: Record<string, unknown>) => void };
-  };
-  if (typeof engine.utils?.writeUpsert !== 'function') {
+  const hydrate = mutationTargetHydrators.get(collection as object);
+  if (!hydrate) {
     throw new Error(
       `${definition.name} cannot hydrate mutation target '${id}'`,
     );
   }
-  engine.utils.writeUpsert(row);
+  await hydrate(row);
 }

--- a/packages/smrt-web/src/webmcp.ts
+++ b/packages/smrt-web/src/webmcp.ts
@@ -17,6 +17,7 @@
 import {
   createDefinitionFetchers,
   createSmrtCollection,
+  getEngineCollection,
   newLocalId,
   type SmrtCrudFetchers,
   type SmrtWebClient,
@@ -27,6 +28,7 @@ import {
   unwrapListResult,
   type WebToolDescriptor,
 } from './index.js';
+import { persistedMutationResults } from './internal.js';
 
 /** The subset of Chrome's WebMCP `registerTool` input this tracer emits. */
 interface WebMcpToolRegistration {
@@ -153,7 +155,11 @@ export function registerWebMcpTools(
   return () => {
     controller.abort();
     for (const collection of collections.values()) {
-      void collection.cleanup();
+      // Disposal is intentionally synchronous for WebMCP callers, but cleanup
+      // is async because the underlying cache may close durable resources.
+      // Consume a rejection so a failed engine teardown cannot become an
+      // unhandled promise rejection in the host page.
+      void collection.cleanup().catch(() => undefined);
     }
   };
 }
@@ -238,10 +244,12 @@ async function dispatch(
         throw new Error(`${definition.name} has no update action`);
       }
       const { id: _id, ...body } = args;
-      // The browser agent may target a row that is not currently materialized
-      // in this collection instance. Hydrate the shared cache before asking the
-      // collection engine to apply its optimistic update.
-      await collection.preload();
+      await hydrateMutationTarget(
+        fetchers,
+        collection,
+        definition,
+        requireId(args, 'update'),
+      );
       const row = unwrapItemResult(
         await settleTransaction(
           collection.update(requireId(args, 'update'), body),
@@ -259,9 +267,7 @@ async function dispatch(
         throw new Error(`${definition.name} has no delete action`);
       }
       const id = requireId(args, 'delete');
-      // Delete requires the engine to know the current row so its optimistic
-      // transaction can roll back if the REST request fails.
-      await collection.preload();
+      await hydrateMutationTarget(fetchers, collection, definition, id);
       await settleTransaction(collection.delete(id), collection, id, {});
       return JSON.stringify({ success: true, id });
     }
@@ -281,17 +287,42 @@ async function settleTransaction(
   key: string,
   fallback: Record<string, unknown>,
 ): Promise<unknown> {
-  const result = await transaction.isPersisted.promise;
-  if (result !== undefined && result !== null) {
-    // TanStack's transaction promise resolves with its internal collection
-    // object, which is intentionally opaque and circular. Never leak that
-    // engine value into WebMCP's JSON string contract.
-    try {
-      JSON.stringify(result);
-      return result;
-    } catch {
-      // Fall through to the plain row/fallback below.
-    }
-  }
+  await transaction.isPersisted.promise;
+  const persisted = persistedMutationResults
+    .get(collection as object)
+    ?.get(key);
+  if (persisted !== undefined) return persisted;
   return collection.get(key) ?? { ...fallback, id: key };
+}
+
+/**
+ * Fetch and materialize a mutation target before asking TanStack DB to apply
+ * its optimistic operation. `preload()` only covers the collection's bounded
+ * first page; the keyed fetch is what makes arbitrary IDs reliable.
+ */
+async function hydrateMutationTarget(
+  fetchers: SmrtCrudFetchers,
+  collection: SmrtWebCollection<Record<string, unknown>>,
+  definition: SmrtWebCollectionDefinition,
+  id: string,
+): Promise<void> {
+  if (!fetchers.get) {
+    throw new Error(
+      `${definition.name} has no get action; cannot hydrate mutation target '${id}'`,
+    );
+  }
+  const row = unwrapItemResult(
+    await fetchers.get(id),
+    `get(${definition.name})`,
+  ) as Record<string, unknown>;
+  await collection.preload();
+  const engine = getEngineCollection(collection) as {
+    utils?: { writeUpsert?: (value: Record<string, unknown>) => void };
+  };
+  if (typeof engine.utils?.writeUpsert !== 'function') {
+    throw new Error(
+      `${definition.name} cannot hydrate mutation target '${id}'`,
+    );
+  }
+  engine.utils.writeUpsert(row);
 }

--- a/packages/smrt-web/src/webmcp.ts
+++ b/packages/smrt-web/src/webmcp.ts
@@ -1,29 +1,28 @@
 /**
- * WebMCP browser tool registration (#1812, tracer).
+ * WebMCP browser tool registration (#1812).
  *
  * Registers each collection's generated {@link WebToolDescriptor}s with the
  * browser's WebMCP registry (`document.modelContext.registerTool`) so an
  * in-page AI agent can discover and invoke them — see
  * https://developer.chrome.com/docs/ai/webmcp. Each tool's `execute` runs
- * through the collection's REST fetchers AS THE PAGE'S AUTHENTICATED USER, so
+ * through the shared smrt-web collection AS THE PAGE'S AUTHENTICATED USER, so
  * the generated REST guards (auth, tenant gate #1554, writable + sensitive-field
  * policy #1540) are the security boundary — nothing is re-implemented here.
  *
- * Framework-agnostic and engine-free: this module imports no UI framework and no
- * client-data engine. `document.modelContext` is a browser global, not a
- * dependency. Reads/writes go through {@link createDefinitionFetchers} (plain
- * fetch), so registering tools never drags the TanStack engine onto a page.
- *
- * TRACER SCOPE: CRUD actions (list/get/create/update/delete) are fully wired;
- * custom actions return a clear "not wired" payload. The full slice can route
- * `execute` through the shared-client collection instead of raw fetchers so
- * agent mutations reflect in on-page live collections (cache coherence).
+ * Framework-agnostic: this module imports no UI framework. `document.modelContext`
+ * is a browser global, not a dependency. Mutation actions use the same
+ * optimistic/invalidation path as page code through `createSmrtCollection`.
  */
 
 import {
   createDefinitionFetchers,
+  createSmrtCollection,
+  newLocalId,
   type SmrtCrudFetchers,
+  type SmrtWebClient,
+  type SmrtWebCollection,
   type SmrtWebCollectionDefinition,
+  type SmrtWebTransaction,
   unwrapItemResult,
   unwrapListResult,
 } from './index.js';
@@ -66,6 +65,10 @@ export interface RegisterWebMcpToolsOptions {
   basePath?: string;
   /** Injectable fetch (tests / SSR-safe wrappers). */
   fetchFn?: typeof fetch;
+  /** Shared smrt-web cache handle used by page collections. */
+  client?: SmrtWebClient;
+  /** Optional cache scope matching the page collection's scope. */
+  scope?: string;
   /**
    * Override how a definition's CRUD fetchers are built. Defaults to
    * {@link createDefinitionFetchers}; the primary seam for testing `execute`
@@ -101,6 +104,10 @@ export function registerWebMcpTools(
   // tool when the signal it was registered with aborts, so the returned disposer
   // simply aborts. Idempotent — a second call is a harmless no-op.
   const controller = new AbortController();
+  const collections = new Map<
+    SmrtWebCollectionDefinition,
+    SmrtWebCollection<Record<string, unknown>>
+  >();
 
   for (const definition of definitions) {
     const descriptors = definition.toolDescriptors;
@@ -109,6 +116,14 @@ export function registerWebMcpTools(
     const fetchers = options.resolveFetchers
       ? options.resolveFetchers(definition)
       : createDefinitionFetchers(definition, basePath, options.fetchFn);
+    const collection = createSmrtCollection(definition, {
+      fetchers,
+      basePath,
+      fetchFn: options.fetchFn,
+      ...(options.client ? { client: options.client } : {}),
+      ...(options.scope ? { scope: options.scope } : {}),
+    }) as SmrtWebCollection<Record<string, unknown>>;
+    collections.set(definition, collection);
 
     for (const descriptor of descriptors) {
       if (options.filter && !options.filter(definition, descriptor)) continue;
@@ -120,14 +135,25 @@ export function registerWebMcpTools(
           inputSchema: descriptor.inputSchema,
           annotations: { readOnlyHint: descriptor.readOnly },
           execute: (args) =>
-            dispatch(fetchers, definition, descriptor.action, args ?? {}),
+            dispatch(
+              fetchers,
+              collection,
+              definition,
+              descriptor.action,
+              args ?? {},
+            ),
         },
         { signal: controller.signal },
       );
     }
   }
 
-  return () => controller.abort();
+  return () => {
+    controller.abort();
+    for (const collection of collections.values()) {
+      void collection.cleanup();
+    }
+  };
 }
 
 /** Require and return a string `id` from tool args, or throw a clear error. */
@@ -170,6 +196,7 @@ function listParams(args: Record<string, unknown>): Record<string, unknown> {
  */
 async function dispatch(
   fetchers: SmrtCrudFetchers,
+  collection: SmrtWebCollection<Record<string, unknown>>,
   definition: SmrtWebCollectionDefinition,
   action: string,
   args: Record<string, unknown>,
@@ -194,8 +221,10 @@ async function dispatch(
     }
 
     case 'create': {
+      const localId = newLocalId();
+      const transaction = collection.insert({ ...args, id: localId });
       const row = unwrapItemResult(
-        await fetchers.create(args),
+        await settleTransaction(transaction, collection, localId, args),
         `create(${definition.name})`,
       );
       return JSON.stringify(row);
@@ -206,8 +235,17 @@ async function dispatch(
         throw new Error(`${definition.name} has no update action`);
       }
       const { id: _id, ...body } = args;
+      // The browser agent may target a row that is not currently materialized
+      // in this collection instance. Hydrate the shared cache before asking the
+      // collection engine to apply its optimistic update.
+      await collection.preload();
       const row = unwrapItemResult(
-        await fetchers.update(requireId(args, 'update'), body),
+        await settleTransaction(
+          collection.update(requireId(args, 'update'), body),
+          collection,
+          requireId(args, 'update'),
+          body,
+        ),
         `update(${definition.name})`,
       );
       return JSON.stringify(row);
@@ -217,17 +255,40 @@ async function dispatch(
       if (!fetchers.delete) {
         throw new Error(`${definition.name} has no delete action`);
       }
-      await fetchers.delete(requireId(args, 'delete'));
-      return JSON.stringify({ success: true });
+      const id = requireId(args, 'delete');
+      // Delete requires the engine to know the current row so its optimistic
+      // transaction can roll back if the REST request fails.
+      await collection.preload();
+      await settleTransaction(collection.delete(id), collection, id, {});
+      return JSON.stringify({ success: true, id });
     }
 
     default:
-      // Custom actions (e.g. invoice_record_payment) hit bespoke REST routes not
-      // covered by the CRUD fetchers. Wired in the full slice (#1812).
-      return JSON.stringify({
-        error: `WebMCP custom action '${action}' is not wired in the tracer`,
-        action,
-        collection: definition.name,
-      });
+      if (!fetchers.custom) {
+        throw new Error(`${definition.name} has no custom action fetcher`);
+      }
+      return JSON.stringify(await fetchers.custom(action, args));
   }
+}
+
+/** Await the shared collection mutation lifecycle and return its server value. */
+async function settleTransaction(
+  transaction: SmrtWebTransaction,
+  collection: SmrtWebCollection<Record<string, unknown>>,
+  key: string,
+  fallback: Record<string, unknown>,
+): Promise<unknown> {
+  const result = await transaction.isPersisted.promise;
+  if (result !== undefined && result !== null) {
+    // TanStack's transaction promise resolves with its internal collection
+    // object, which is intentionally opaque and circular. Never leak that
+    // engine value into WebMCP's JSON string contract.
+    try {
+      JSON.stringify(result);
+      return result;
+    } catch {
+      // Fall through to the plain row/fallback below.
+    }
+  }
+  return collection.get(key) ?? { ...fallback, id: key };
 }

--- a/packages/smrt-web/vite.config.ts
+++ b/packages/smrt-web/vite.config.ts
@@ -1,3 +1,3 @@
 import { createPackageConfig } from '../../vite.config.base.js';
 
-export default createPackageConfig('smrt-web');
+export default createPackageConfig('smrt-web', { entries: ['webmcp'] });


### PR DESCRIPTION
## Summary
- Adds a framework-independent WebMCP registrar for generated SMRT web collection tools.
- Preserves generated custom action route/method/schema semantics, including aliased action parameters.
- Routes mutating calls through shared collection APIs for cache-coherent invalidation.

## Validation
- smrt-web: 154 tests; core WebMCP-related: 103 targeted tests
- smrt-web and core typecheck/build; package exports and engine-boundary guard
- Biome, diff check, strict knowledge freshness, and pre-push policy checks
- review-cycle: preliminary and final security reviews clean on this head

Closes #1812

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-1812-webmcp-reviewfix-20260823-r3",
  "issue": 1812,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "smrt-web 154 tests and core WebMCP-related 103 targeted tests",
    "smrt-web and core typecheck/build; package exports and engine-boundary guard",
    "Biome, diff check, strict knowledge freshness, and pre-push policy checks",
    "review-cycle: preliminary and final security reviews clean on exact head"
  ]
}