### PR TITLE
feat(core): add paged latest-related list hydration

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -18,8 +18,8 @@ subsystem you are editing. This file keeps what holds across all of them.
 | `src/change-signals.ts` + the generated `_events` SSE route | the push companion to the change feed — the signal bus, cross-replica fan-out, the SSE route, and its documented gaps | [agents/change-signals.md](agents/change-signals.md) |
 | `src/generators/` + `src/vite-plugin/web-collections.ts` | REST/CLI/MCP/web-collection generation, the `manifestHash` emission sites, and generated conditional-GET / ETag v2 semantics | [agents/generators.md](agents/generators.md) |
 | `src/schema/` | the four `SchemaGenerator` entry points, which two reach production, why schema drift stayed invisible, and the #2382 index/tenancy rules | [agents/schema-paths.md](agents/schema-paths.md) |
-| `src/data-query.ts` | canonical bounded data-query normalizer: allowlisted fields, deterministic fingerprints, output validation, and transport-neutral envelope (#2444) | — |
-| `src/collection.ts` | latest-related bounded parent/child reads and their adapter, alias, and primary-key invariants (#1903) | [agents/latest-related.md](agents/latest-related.md) |
+| `src/data-query.ts` | canonical bounded data-query normalizer and transport-neutral envelope (#2444) | [agents/data-query.md](agents/data-query.md) |
+| `src/collection.ts` | bounded collection reads, projections, latest-related hydration, facets, counts, and read plans | [agents/collection-reads.md](agents/collection-reads.md) |
 
 ## SmrtObject Lifecycle
 
@@ -38,7 +38,8 @@ subsystem you are editing. This file keeps what holds across all of them.
 `_smrt_contexts` plus optional injected semantic search. `capture()` reinforces
 successes and decays failures while updating outcome counters; `recall()`
 applies confidence, expiry, time-decay, and hierarchical-scope filters and
-refreshes `last_used_at`. Keep semantic search behind the
+refreshes `last_used_at`. Detailed persistence and search semantics are in
+[agents/memory.md](agents/memory.md). Keep semantic search behind the
 `SmrtCollection.semanticSearch`-compatible injection boundary.
 
 ## SmrtCollection Query
@@ -50,43 +51,13 @@ await collection.list({
 });
 ```
 
-Projection primitive (#1902): pass `select: ['id', 'title', 'tenantId']` to
-`list()` when an admin/list workflow needs compact rows. `select` uses SMRT
-field names, maps them to DB columns internally, and returns plain objects keyed
-by the same SMRT field names without hydrating `SmrtObject` instances. It
-composes with `where`, `orderBy`, `limit`, and `offset`; `beforeList`
-interceptors still run. It is for column-backed fields only and cannot combine
-with `include`/relationship eager loading.
-
-Latest-related primitive (#1903): `SmrtCollection.listWithLatestRelated()` is
-documented in [agents/latest-related.md](agents/latest-related.md), including
-its primary-key, dialect, alias, and cleanup invariants.
+Projection, latest-related, facets, counts, and bounded read plans are
+documented in [agents/collection-reads.md](agents/collection-reads.md).
 
 `list()` and `query()` hydrate model instances serially in result order because
 an `initialize()` hook may query through the same transaction-bound PostgreSQL
 client. Keep this serialization invariant; use `select` when callers need plain
 rows without model hydration.
-
-Database-backed facets and scoped counts are available through
-`collection.facets({ fields, where })` and
-`collection.counts({ where })`. Facets return `{ field, values }` entries whose
-values contain `{ value, count }`, run the same `beforeList`/tenant interceptors
-as list reads, and execute one bounded `GROUP BY` query per requested field.
-Each call accepts at most 20 fields. A requested value limit is clamped to the
-hard maximum of 1,000 and to `maxListLimit` when configured. If omitted, the
-limit defaults to `defaultListLimit` or 50, then the same ceilings apply; facet
-queries are therefore never unbounded even when list bounds are unset. They
-never hydrate model instances. `counts()` returns `{ total, filtered }` using
-two `COUNT(*)` queries; both counts retain the active read scope. Facet fields
-must be column-backed and obey the same sensitive/read-permission restrictions
-as `select`. Array/string-list fields are grouped by their stored value — SMRT
-does not split or unnest them — so consumers needing per-member options should
-use a scalar join table or consumer-specific query.
-
-Facet tests cover SQLite and DuckDB locally. Scalar PostgreSQL coverage is in
-the optional `test:postgres` lane and runs only when `SMRT_TEST_POSTGRES_URL` is
-configured; the local suite does not claim PostgreSQL parity for array/JSON
-encoding.
 
 **WHERE operators**: `=`, `>`, `<`, `>=`, `<=`, `!=`, `in`, `not in`, `like`.
 Arrays auto-detect `IN`. NULL is a value, not an operator: `{ deletedAt: null }`
@@ -105,43 +76,18 @@ operator against a database to keep the two in step.
 
 STI child collections auto-filter by `_meta_type`. Query bounds — `LIMIT 1` on `get()`, the `limit`/`offset` parser, the `orderBy` whitelist and sensitive/permission refusals, and the deterministic generated-list ordering (#2367) — are in [agents/query-bounds.md](agents/query-bounds.md).
 
-## Bounded Collection Read Plans
-
-Use `executeCollectionReadPlan()` when one operation needs several independent
-collections. It bounds top-level `collection.list()` concurrency while keeping
-all reads on the normal registry/collection path. Callers must choose an
-explicit positive `maxConcurrency` and pass their normal shared
-`collectionOptions` when database or tenant context matters.
-
-The executor deliberately does not compose SQL, cache the plan, or change pool
-defaults. On failure it stops starting queued entries, drains operations already
-in flight, and rethrows the first error.
-
 ## Canonical Bounded Data Queries (#2444)
 
-`normalizeDataQueryRequest()` and `normalizeDataQueryResult()` are the trust
-boundary for the transport-neutral table/report/content query envelope. An
-authenticated adapter supplies a trusted `DataQuerySchema`; the caller only
-gets its declared projectable/sortable/filterable/facetable fields. The helpers
-never execute a query or decide tenant/principal access.
-
-Use `createDataQueryFingerprint()` for cache and result correlation. It omits
-the request id and page position, canonicalizes equivalent filter/projection/
-facet forms, and adds the identity sort tie-break. Keep data-query values
-scalar, requests/pages/facets positive and bounded, results within the schema
-byte cap with declared field types preserved. Datetimes must be valid RFC 3339
-instants, identity fields must be string/number/datetime-compatible, and JSON
-result fields are depth/container/string/byte bounded before cloning. Return
-only normalized `DataQueryResult` envelopes to REST, MCP,
-WebMCP, and browser consumers. Adapter-specific report/content context wraps
-the base envelope; it does not add unsafe fields or SQL-like controls to it.
+The normalizers and fingerprint are the trust boundary for the
+transport-neutral query envelope; full bounds, schema, and output rules live in
+[agents/data-query.md](agents/data-query.md). Adapters own tenant/principal
+access and query execution.
 
 ## Object Memory & Semantic Search
 
-Two persistence primitives every `SmrtObject`/`SmrtCollection` inherits — load-bearing for learning agents, usable by any object. Full guide: `docs/content/core.md` → "Context Memory System".
-
-- **Context memory** (`remember`/`recall`/`recallAll`/`forget`/`forgetScope`, table `_smrt_contexts`): stores any JSON value keyed by `(owner_class, owner_id, scope, key, version)` with a `confidence` score (0–1) and a stored `expiresAt` (metadata — `recall()` does **not** filter expired rows; expiry is caller-managed). `recall()` returns the highest-confidence match with an optional `minConfidence` floor and **opt-in** hierarchical scope fallback (`includeAncestors: true` → `'a/b/c' → 'a/b' → 'a' → 'global'`; default off); `recallAll()` returns a `Map`. Typical use: cache a learned strategy (e.g. a working selector per host) and reuse it across sessions. `success_count`/`failure_count` columns exist for outcome-weighting: `SmrtObject.remember()` leaves them untouched, `SmrtCollection.remember()` resets them to zero, and neither recall path updates them. `LearningMemory` is the layer that maintains them (and that does filter expired rows).
-- **Semantic search** (on `SmrtCollection`, table `_smrt_embeddings`): `semanticSearch(query)`, `findSimilar(object)`, `findSimilarToEmbedding(vector)` — cosine ranking over embeddings of the fields declared in `@smrt({ embeddings })`. Native pgvector/HNSW when configured, in-memory `CosineSimilarity` fallback otherwise; default local model `Xenova/bge-base-en-v1.5` (768-dim) or AI `text-embedding-3-small`. Hits hydrate via `list({ 'id in': … })`, so `@TenantScoped` isolation applies to results.
+Context memory and semantic search are persistence primitives inherited by
+`SmrtObject`/`SmrtCollection`; their storage, scope, expiry, and tenant
+invariants are in [agents/memory.md](agents/memory.md).
 
 ## @smrt() Decorator Options
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -57,6 +57,17 @@ composes with `where`, `orderBy`, `limit`, and `offset`; `beforeList`
 interceptors still run. It is for column-backed fields only and cannot combine
 with `include`/relationship eager loading.
 
+Latest-related primitive (#1903): use `listWithLatestRelated()` when a page
+needs one row from a declared `@oneToMany` relationship without N+1 queries or
+hydrating unrelated children. `latestRelated.orderBy` ranks rows within each
+parent, `select` chooses the returned child fields (default `['id']`), and an
+optional `sortBy` orders parents by the winning child before the parent
+`limit`/`offset` are applied. The result is `{ parent, latestRelated }`, where
+`parent` is hydrated and `latestRelated` is a plain projection or `null` when
+the parent has no child. Ranking uses a portable `ROW_NUMBER()` CTE with an
+`id` tie-break and explicit null-last ordering across SQLite, DuckDB, and
+PostgreSQL; only the visible parent page is hydrated.
+
 `list()` and `query()` hydrate model instances serially in result order because
 an `initialize()` hook may query through the same transaction-bound PostgreSQL
 client. Keep this serialization invariant; use `select` when callers need plain

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -19,6 +19,7 @@ subsystem you are editing. This file keeps what holds across all of them.
 | `src/generators/` + `src/vite-plugin/web-collections.ts` | REST/CLI/MCP/web-collection generation, the `manifestHash` emission sites, and generated conditional-GET / ETag v2 semantics | [agents/generators.md](agents/generators.md) |
 | `src/schema/` | the four `SchemaGenerator` entry points, which two reach production, why schema drift stayed invisible, and the #2382 index/tenancy rules | [agents/schema-paths.md](agents/schema-paths.md) |
 | `src/data-query.ts` | canonical bounded data-query normalizer: allowlisted fields, deterministic fingerprints, output validation, and transport-neutral envelope (#2444) | — |
+| `src/collection.ts` | latest-related bounded parent/child reads and their adapter, alias, and primary-key invariants (#1903) | [agents/latest-related.md](agents/latest-related.md) |
 
 ## SmrtObject Lifecycle
 
@@ -57,17 +58,9 @@ composes with `where`, `orderBy`, `limit`, and `offset`; `beforeList`
 interceptors still run. It is for column-backed fields only and cannot combine
 with `include`/relationship eager loading.
 
-Latest-related primitive (#1903): use `listWithLatestRelated()` when a page
-needs one row from a declared `@oneToMany` relationship without N+1 queries or
-hydrating unrelated children. `latestRelated.orderBy` ranks rows within each
-parent, `select` chooses the returned child fields (defaulting to the related
-model's declared primary key), and an
-optional `sortBy` orders parents by the winning child before the parent
-`limit`/`offset` are applied. The result is `{ parent, latestRelated }`, where
-`parent` is hydrated and `latestRelated` is a plain projection or `null` when
-the parent has no child. Ranking uses a portable `ROW_NUMBER()` CTE with an
-declared related-primary-key tie-break and explicit null-last ordering across SQLite, DuckDB, and
-PostgreSQL; only the visible parent page is hydrated.
+Latest-related primitive (#1903): `SmrtCollection.listWithLatestRelated()` is
+documented in [agents/latest-related.md](agents/latest-related.md), including
+its primary-key, dialect, alias, and cleanup invariants.
 
 `list()` and `query()` hydrate model instances serially in result order because
 an `initialize()` hook may query through the same transaction-bound PostgreSQL

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -60,12 +60,13 @@ with `include`/relationship eager loading.
 Latest-related primitive (#1903): use `listWithLatestRelated()` when a page
 needs one row from a declared `@oneToMany` relationship without N+1 queries or
 hydrating unrelated children. `latestRelated.orderBy` ranks rows within each
-parent, `select` chooses the returned child fields (default `['id']`), and an
+parent, `select` chooses the returned child fields (defaulting to the related
+model's declared primary key), and an
 optional `sortBy` orders parents by the winning child before the parent
 `limit`/`offset` are applied. The result is `{ parent, latestRelated }`, where
 `parent` is hydrated and `latestRelated` is a plain projection or `null` when
 the parent has no child. Ranking uses a portable `ROW_NUMBER()` CTE with an
-`id` tie-break and explicit null-last ordering across SQLite, DuckDB, and
+declared related-primary-key tie-break and explicit null-last ordering across SQLite, DuckDB, and
 PostgreSQL; only the visible parent page is hydrated.
 
 `list()` and `query()` hydrate model instances serially in result order because

--- a/packages/core/agents/collection-reads.md
+++ b/packages/core/agents/collection-reads.md
@@ -1,0 +1,40 @@
+<!-- Module doc for packages/core/AGENTS.md. Linked from the Modules table there. -->
+
+# Collection reads
+
+This module covers bounded collection reads beyond the basic query contract in
+`packages/core/AGENTS.md`.
+
+## Projections and related rows
+
+`list({ select })` uses SMRT field names, maps them to database columns, and
+returns plain rows without hydrating objects. It composes with `where`,
+`orderBy`, `limit`, and `offset`, runs normal `beforeList`/tenant interceptors,
+and is limited to column-backed fields; it cannot combine with `include`.
+
+For one child per parent, use
+[`latest-related.md`](latest-related.md). It uses a portable ranked CTE,
+declared primary keys, adapter-specific offset-only syntax, explicit aliases,
+and hydrates only the visible parent page.
+
+## Facets, counts, and read plans
+
+`collection.facets({ fields, where })` runs one bounded `GROUP BY` per requested
+field and returns `{ field, values: [{ value, count }] }`. It accepts at most 20
+fields, clamps value limits to 1,000 and the collection ceiling, never hydrates
+objects, and applies the same read/tenant/sensitive-field rails as `select`.
+Stored array/string-list values are grouped as stored; they are not unnested.
+`collection.counts({ where })` returns `{ total, filtered }` through two scoped
+`COUNT(*)` queries. Local coverage is SQLite/DuckDB; optional scalar PostgreSQL
+coverage requires `SMRT_TEST_POSTGRES_URL`.
+
+`executeCollectionReadPlan()` bounds concurrent reads across independent
+collections while preserving the normal registry and collection options. The
+caller supplies a positive `maxConcurrency`; the executor does not compose SQL,
+cache, or alter pool defaults, and drains already-started work before returning
+the first error.
+
+`where` operators must remain aligned with `@happyvertical/sql`'s `buildWhere`:
+`=`, `>`, `<`, `>=`, `<=`, `!=`, `in`, `not in`, and `like`. Arrays imply `IN`,
+and null values render `IS NULL`/`IS NOT NULL`. `contains` and dot-notation JSON
+paths are intentionally rejected until the SQL layer supports them.

--- a/packages/core/agents/data-query.md
+++ b/packages/core/agents/data-query.md
@@ -1,0 +1,21 @@
+<!-- Module doc for packages/core/AGENTS.md. Linked from the Modules table there. -->
+
+# Bounded data queries (#2444)
+
+`normalizeDataQueryRequest()` and `normalizeDataQueryResult()` define the trust
+boundary for the transport-neutral table/report/content query envelope. A
+trusted adapter supplies `DataQuerySchema`; callers receive only its declared
+projectable, sortable, filterable, and facetable fields. The helpers validate
+and normalize but never execute SQL or decide tenant/principal access.
+
+Use `createDataQueryFingerprint()` for cache and result correlation. It omits
+request id and page position, canonicalizes equivalent filter/projection/facet
+forms, and adds the identity sort tie-break. Keep values scalar and request,
+page, and facet sizes positive and bounded. Results must stay within the schema
+byte cap with declared field types preserved; datetimes are RFC 3339 instants,
+identity fields are string/number/datetime-compatible, and JSON values are
+bounded by depth, container count, string size, and bytes before cloning.
+
+Only normalized `DataQueryResult` envelopes cross REST, MCP, WebMCP, and browser
+boundaries. Adapter-specific report/content context wraps the base envelope; it
+does not add unsafe fields or SQL-like controls.

--- a/packages/core/agents/latest-related.md
+++ b/packages/core/agents/latest-related.md
@@ -1,0 +1,35 @@
+<!-- Module doc for packages/core/AGENTS.md. Linked from the Modules table there. -->
+
+# Latest-related reads (#1903)
+
+Use `SmrtCollection.listWithLatestRelated()` when a page needs one row from a
+declared `@oneToMany` relationship without N+1 queries or hydrating unrelated
+children. `latestRelated.orderBy` ranks rows within each parent, `select`
+chooses the returned child fields (defaulting to the related model's declared
+primary key), and an optional `sortBy` orders parents by the winning child
+before the parent `limit`/`offset` are applied. The result is
+`{ parent, latestRelated }`: `parent` is hydrated and `latestRelated` is a
+plain projection or `null` when the parent has no child.
+
+The read plan uses a portable `ROW_NUMBER()` CTE with explicit null-last
+ordering and the declared primary keys for every tie-break, join, and result
+map. The parent primary key is never assumed to be `id`; the related primary
+key is the default projection when `select` is omitted. Only the visible
+parent page is hydrated.
+
+Pagination is adapter-aware: SQLite uses `LIMIT -1` for offset-only reads,
+while DuckDB and PostgreSQL use `LIMIT ALL`. In-memory DuckDB and JSON adapters
+retain their engine hint even when no URL or database type is present, so the
+generated syntax remains legal for the actual driver.
+
+Internal result aliases are bounded `__smrt_lr_N` identifiers. The allocator
+reserves declared and live parent table columns, and parent columns are
+projected explicitly (using the public table-schema API where available) rather
+than `parent.*`, so externally added columns cannot collide or corrupt the
+latest-related projection. JSON adapters without live schema introspection use
+the declared schema as their fallback.
+
+The primitive preserves normal read interceptors, tenant and STI scope, and
+does not expose a cache option until cache invalidation is implemented. Tests
+cover custom primary keys, SQLite/DuckDB offset-only pagination, long field
+names, external alias collisions, and cleanup of temporary database files.

--- a/packages/core/agents/memory.md
+++ b/packages/core/agents/memory.md
@@ -1,0 +1,16 @@
+<!-- Module doc for packages/core/AGENTS.md. Linked from the Modules table there. -->
+
+# Object memory and semantic search
+
+Context memory (`remember`, `recall`, `recallAll`, `forget`, `forgetScope`) is
+stored in `_smrt_contexts`, keyed by owner, scope, key, and version. Values have
+a 0–1 confidence and optional expiry metadata; `recall()` does not filter
+expired rows. Ancestor fallback is opt-in (`includeAncestors: true`) and walks
+`a/b/c → a/b → a → global`. `LearningMemory` owns outcome counters and expiry
+filtering; object/collection recall does not update them.
+
+Semantic search uses `_smrt_embeddings` and cosine ranking over fields declared
+by `@smrt({ embeddings })`, with native pgvector/HNSW or an in-memory fallback.
+Results hydrate through `list({ 'id in': … })`, so normal tenant isolation still
+applies. Keep injected search behind the `SmrtCollection.semanticSearch`
+boundary.

--- a/packages/core/src/__tests__/collection-latest-related.test.ts
+++ b/packages/core/src/__tests__/collection-latest-related.test.ts
@@ -67,6 +67,9 @@ class LatestRelatedEvaluation extends SmrtObject {
 
   @field()
   note = '';
+
+  @field()
+  thisIsAnExtremelyLongLatestRelatedFieldNameForPostgresAliasCoverage = '';
 }
 
 class LatestRelatedParentCollection extends SmrtCollection<LatestRelatedParent> {
@@ -75,6 +78,41 @@ class LatestRelatedParentCollection extends SmrtCollection<LatestRelatedParent> 
 
 class LatestRelatedEvaluationCollection extends SmrtCollection<LatestRelatedEvaluation> {
   static readonly _itemClass = LatestRelatedEvaluation;
+}
+
+@smrt()
+class LatestRelatedCustomParent extends SmrtObject {
+  @field({ required: true, primaryKey: true })
+  parentKey = '';
+
+  @field()
+  name = '';
+
+  @oneToMany('LatestRelatedCustomEvaluation')
+  evaluations: LatestRelatedCustomEvaluation[] = [];
+}
+
+@smrt()
+class LatestRelatedCustomEvaluation extends SmrtObject {
+  @field({ required: true, primaryKey: true })
+  evaluationKey = '';
+
+  @foreignKey(LatestRelatedCustomParent)
+  parentKey = '';
+
+  @field()
+  sequence = 0;
+
+  @field()
+  note = '';
+}
+
+class LatestRelatedCustomParentCollection extends SmrtCollection<LatestRelatedCustomParent> {
+  static readonly _itemClass = LatestRelatedCustomParent;
+}
+
+class LatestRelatedCustomEvaluationCollection extends SmrtCollection<LatestRelatedCustomEvaluation> {
+  static readonly _itemClass = LatestRelatedCustomEvaluation;
 }
 
 @smrt()
@@ -113,14 +151,16 @@ class LatestRelatedStiScoreEvaluationCollection extends SmrtCollection<LatestRel
 
 describe('SmrtCollection.listWithLatestRelated()', () => {
   let db: DatabaseInterface;
+  let sqlitePath: string;
   let parents: LatestRelatedParentCollection;
   let evaluations: LatestRelatedEvaluationCollection;
 
   beforeEach(async () => {
     resetInitializationEvidence();
+    sqlitePath = join(tmpdir(), `latest-related-${randomUUID()}.db`);
     db = await getTestDatabase({
       type: 'sqlite',
-      url: join(tmpdir(), `latest-related-${randomUUID()}.db`),
+      url: sqlitePath,
     });
     parents = await LatestRelatedParentCollection.create({ db });
     evaluations = await LatestRelatedEvaluationCollection.create({ db });
@@ -130,6 +170,9 @@ describe('SmrtCollection.listWithLatestRelated()', () => {
     GlobalInterceptors.unregister('latest-related-transform');
     GlobalInterceptors.unregister('latest-related-scope');
     await db.close?.();
+    if (existsSync(sqlitePath)) {
+      rmSync(sqlitePath, { force: true });
+    }
   });
 
   it('selects one latest row per parent and sorts before pagination', async () => {
@@ -192,6 +235,102 @@ describe('SmrtCollection.listWithLatestRelated()', () => {
     expect(nextPage[0].latestRelated).toBeNull();
     expect(initializationOrder).toEqual(['first', 'second', 'third']);
     expect(maximumActiveInitializers).toBe(1);
+  });
+
+  it('supports offset-only pagination on SQLite', async () => {
+    await parents.create({ name: 'first' });
+    await parents.create({ name: 'second' });
+
+    const page = await parents.listWithLatestRelated({
+      latestRelated: {
+        relation: 'evaluations',
+        orderBy: 'sequence DESC',
+        select: ['note'],
+      },
+      orderBy: 'name ASC',
+      offset: 1,
+    });
+
+    expect(page).toHaveLength(1);
+    expect(page[0].parent.name).toBe('second');
+  });
+
+  it('uses declared primary keys for parent and related rows', async () => {
+    const customParents = await LatestRelatedCustomParentCollection.create({
+      db,
+    });
+    const customEvaluations =
+      await LatestRelatedCustomEvaluationCollection.create({ db });
+    // Build the contract represented by @field({ primaryKey: true })
+    // directly: the production schema path omits synthetic id/slug/context
+    // columns for these models, while this test's manifest fixture includes
+    // them for unrelated collection tests.
+    await db.query('DROP TABLE latest_related_custom_evaluations');
+    await db.query('DROP TABLE latest_related_custom_parents');
+    await db.query(
+      'CREATE TABLE latest_related_custom_parents (parent_key TEXT PRIMARY KEY NOT NULL, name TEXT)',
+    );
+    await db.query(
+      'CREATE TABLE latest_related_custom_evaluations (evaluation_key TEXT PRIMARY KEY NOT NULL, parent_key TEXT NOT NULL, sequence INTEGER NOT NULL, note TEXT)',
+    );
+    await db.query(
+      'INSERT INTO latest_related_custom_parents (parent_key, name) VALUES ($1, $2)',
+      'parent-one',
+      'custom parent',
+    );
+    await db.query(
+      'INSERT INTO latest_related_custom_evaluations (evaluation_key, parent_key, sequence, note) VALUES ($1, $2, $3, $4)',
+      'evaluation-old',
+      'parent-one',
+      1,
+      'old',
+    );
+    await db.query(
+      'INSERT INTO latest_related_custom_evaluations (evaluation_key, parent_key, sequence, note) VALUES ($1, $2, $3, $4)',
+      'evaluation-new',
+      'parent-one',
+      2,
+      'new',
+    );
+
+    const rows = await customParents.listWithLatestRelated({
+      latestRelated: {
+        relation: 'evaluations',
+        orderBy: 'sequence DESC',
+      },
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].parent.parentKey).toBe('parent-one');
+    expect(rows[0].latestRelated).toEqual({
+      evaluationKey: 'evaluation-new',
+    });
+  });
+
+  it('maps long related field names through bounded internal aliases', async () => {
+    const parent = await parents.create({ name: 'long alias parent' });
+    await evaluations.create({
+      parentId: parent.id,
+      sequence: 1,
+      note: 'long alias',
+      thisIsAnExtremelyLongLatestRelatedFieldNameForPostgresAliasCoverage:
+        'preserved',
+    });
+
+    const rows = await parents.listWithLatestRelated({
+      latestRelated: {
+        relation: 'evaluations',
+        orderBy: 'sequence DESC',
+        select: [
+          'thisIsAnExtremelyLongLatestRelatedFieldNameForPostgresAliasCoverage',
+        ],
+      },
+    });
+
+    expect(rows[0].latestRelated).toEqual({
+      thisIsAnExtremelyLongLatestRelatedFieldNameForPostgresAliasCoverage:
+        'preserved',
+    });
   });
 
   it('keeps related rows paired when afterList filters and reorders parents', async () => {

--- a/packages/core/src/__tests__/collection-latest-related.test.ts
+++ b/packages/core/src/__tests__/collection-latest-related.test.ts
@@ -1,0 +1,224 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection';
+import { field, foreignKey, oneToMany } from '../decorators';
+import { SmrtObject } from '../object';
+import { smrt } from '../registry';
+import { getTestDatabase } from '../testing/database';
+
+@smrt()
+class LatestRelatedParent extends SmrtObject {
+  name = '';
+
+  @oneToMany('LatestRelatedEvaluation')
+  evaluations: LatestRelatedEvaluation[] = [];
+}
+
+@smrt()
+class LatestRelatedEvaluation extends SmrtObject {
+  @foreignKey(LatestRelatedParent)
+  parentId = '';
+
+  @field()
+  sequence = 0;
+
+  @field()
+  score = 0.0;
+
+  @field()
+  evaluationScore = 0.0;
+
+  @field()
+  note = '';
+}
+
+class LatestRelatedParentCollection extends SmrtCollection<LatestRelatedParent> {
+  static readonly _itemClass = LatestRelatedParent;
+}
+
+class LatestRelatedEvaluationCollection extends SmrtCollection<LatestRelatedEvaluation> {
+  static readonly _itemClass = LatestRelatedEvaluation;
+}
+
+describe('SmrtCollection.listWithLatestRelated()', () => {
+  let db: DatabaseInterface;
+  let parents: LatestRelatedParentCollection;
+  let evaluations: LatestRelatedEvaluationCollection;
+
+  beforeEach(async () => {
+    db = await getTestDatabase({
+      type: 'sqlite',
+      url: join(tmpdir(), `latest-related-${randomUUID()}.db`),
+    });
+    parents = await LatestRelatedParentCollection.create({ db });
+    evaluations = await LatestRelatedEvaluationCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    await db.close?.();
+  });
+
+  it('selects one latest row per parent and sorts before pagination', async () => {
+    const first = await parents.create({ name: 'first' });
+    const second = await parents.create({ name: 'second' });
+    const third = await parents.create({ name: 'third' });
+
+    await evaluations.create({
+      parentId: first.id,
+      sequence: 1,
+      score: 1.0,
+      evaluationScore: 1.0,
+      note: 'old first',
+    });
+    await evaluations.create({
+      parentId: first.id,
+      sequence: 2,
+      score: 9.0,
+      evaluationScore: 9.0,
+      note: 'latest first',
+    });
+    await evaluations.create({
+      parentId: second.id,
+      sequence: 1,
+      score: 4.0,
+      evaluationScore: 4.0,
+      note: 'latest second',
+    });
+    // Third intentionally has no related row.
+
+    const page = await parents.listWithLatestRelated({
+      latestRelated: {
+        relation: 'evaluations',
+        orderBy: 'sequence DESC',
+        select: ['score', 'note'],
+        sortBy: 'evaluationScore DESC',
+      },
+      limit: 2,
+      offset: 0,
+    });
+
+    expect(page).toHaveLength(2);
+    expect(page.map((row) => row.parent.name)).toEqual(['first', 'second']);
+    expect(page[0].latestRelated).toEqual({ score: 9, note: 'latest first' });
+    expect(page[1].latestRelated).toEqual({ score: 4, note: 'latest second' });
+
+    const nextPage = await parents.listWithLatestRelated({
+      latestRelated: {
+        relation: 'evaluations',
+        orderBy: 'sequence DESC',
+        select: ['score'],
+        sortBy: 'evaluationScore DESC',
+      },
+      limit: 2,
+      offset: 2,
+    });
+    expect(nextPage).toHaveLength(1);
+    expect(nextPage[0].parent.name).toBe('third');
+    expect(nextPage[0].latestRelated).toBeNull();
+  });
+
+  it('uses the declared relation and rejects unrelated fields', async () => {
+    await parents.create({ name: 'only parent' });
+
+    await expect(
+      parents.listWithLatestRelated({
+        latestRelated: {
+          relation: 'missing',
+          orderBy: 'sequence DESC',
+        },
+      }),
+    ).rejects.toThrow("latestRelated.relation 'missing'");
+
+    await expect(
+      parents.listWithLatestRelated({
+        latestRelated: {
+          relation: 'evaluations',
+          orderBy: 'notAField DESC',
+        },
+      }),
+    ).rejects.toThrow(/Invalid orderBy field/);
+  });
+
+  it('uses the same window-query shape on DuckDB', async () => {
+    const duckDb = await getTestDatabase({
+      type: 'duckdb',
+      url: join(tmpdir(), `latest-related-${randomUUID()}.duckdb`),
+    });
+    try {
+      const duckParents = await LatestRelatedParentCollection.create({
+        db: duckDb,
+      });
+      const duckEvaluations = await LatestRelatedEvaluationCollection.create({
+        db: duckDb,
+      });
+      const parent = await duckParents.create({ name: 'duck parent' });
+      await duckEvaluations.create({
+        parentId: parent.id,
+        sequence: 1,
+        score: 7.0,
+        evaluationScore: 7.0,
+        note: 'duck latest',
+      });
+
+      const rows = await duckParents.listWithLatestRelated({
+        latestRelated: {
+          relation: 'evaluations',
+          orderBy: 'sequence DESC',
+          select: ['score', 'note'],
+        },
+      });
+      expect(rows[0].latestRelated).toEqual({
+        score: 7,
+        note: 'duck latest',
+      });
+    } finally {
+      await duckDb.close?.();
+    }
+  });
+
+  it('uses the same window-query shape on JSON-on-DuckDB', async () => {
+    const jsonPath = join(tmpdir(), `latest-related-${randomUUID()}`);
+    const jsonDb = await getTestDatabase({
+      type: 'json',
+      url: jsonPath,
+      classes: ['LatestRelatedParent', 'LatestRelatedEvaluation'],
+    });
+    try {
+      const jsonParents = await LatestRelatedParentCollection.create({
+        db: jsonDb,
+      });
+      const jsonEvaluations = await LatestRelatedEvaluationCollection.create({
+        db: jsonDb,
+      });
+      const parent = await jsonParents.create({ name: 'json parent' });
+      await jsonEvaluations.create({
+        parentId: parent.id,
+        sequence: 1,
+        score: 8.0,
+        evaluationScore: 8.0,
+        note: 'json latest',
+      });
+
+      const rows = await jsonParents.listWithLatestRelated({
+        latestRelated: {
+          relation: 'evaluations',
+          orderBy: 'sequence DESC',
+          select: ['score', 'note'],
+        },
+      });
+      expect(rows[0].latestRelated).toEqual({
+        score: 8,
+        note: 'json latest',
+      });
+    } finally {
+      await jsonDb.close?.();
+      if (existsSync(jsonPath)) {
+        rmSync(jsonPath, { recursive: true, force: true });
+      }
+    }
+  });
+});

--- a/packages/core/src/__tests__/collection-latest-related.test.ts
+++ b/packages/core/src/__tests__/collection-latest-related.test.ts
@@ -6,9 +6,20 @@ import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SmrtCollection } from '../collection';
 import { field, foreignKey, oneToMany } from '../decorators';
+import { GlobalInterceptors } from '../interceptors';
 import { SmrtObject } from '../object';
 import { smrt } from '../registry';
 import { getTestDatabase } from '../testing/database';
+
+let activeInitializers = 0;
+let maximumActiveInitializers = 0;
+let initializationOrder: string[] = [];
+
+function resetInitializationEvidence(): void {
+  activeInitializers = 0;
+  maximumActiveInitializers = 0;
+  initializationOrder = [];
+}
 
 @smrt()
 class LatestRelatedParent extends SmrtObject {
@@ -16,6 +27,25 @@ class LatestRelatedParent extends SmrtObject {
 
   @oneToMany('LatestRelatedEvaluation')
   evaluations: LatestRelatedEvaluation[] = [];
+
+  override async initialize(): Promise<this> {
+    await super.initialize();
+    if (!this.isPersisted || !this.id) return this;
+
+    activeInitializers += 1;
+    maximumActiveInitializers = Math.max(
+      maximumActiveInitializers,
+      activeInitializers,
+    );
+    initializationOrder.push(this.name);
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      await this.db.get(this.tableName, { id: this.id });
+    } finally {
+      activeInitializers -= 1;
+    }
+    return this;
+  }
 }
 
 @smrt()
@@ -33,6 +63,9 @@ class LatestRelatedEvaluation extends SmrtObject {
   evaluationScore = 0.0;
 
   @field()
+  tenantId = '';
+
+  @field()
   note = '';
 }
 
@@ -44,12 +77,47 @@ class LatestRelatedEvaluationCollection extends SmrtCollection<LatestRelatedEval
   static readonly _itemClass = LatestRelatedEvaluation;
 }
 
+@smrt()
+class LatestRelatedStiParent extends SmrtObject {
+  name = '';
+
+  @oneToMany('LatestRelatedStiScoreEvaluation')
+  evaluations: LatestRelatedStiScoreEvaluation[] = [];
+}
+
+@smrt({ tableStrategy: 'sti' })
+class LatestRelatedStiEvaluation extends SmrtObject {
+  @field()
+  sequence = 0;
+
+  @field()
+  note = '';
+}
+
+@smrt()
+class LatestRelatedStiScoreEvaluation extends LatestRelatedStiEvaluation {
+  @foreignKey(LatestRelatedStiParent)
+  parentId = '';
+
+  @field()
+  score = 0.0;
+}
+
+class LatestRelatedStiParentCollection extends SmrtCollection<LatestRelatedStiParent> {
+  static readonly _itemClass = LatestRelatedStiParent;
+}
+
+class LatestRelatedStiScoreEvaluationCollection extends SmrtCollection<LatestRelatedStiScoreEvaluation> {
+  static readonly _itemClass = LatestRelatedStiScoreEvaluation;
+}
+
 describe('SmrtCollection.listWithLatestRelated()', () => {
   let db: DatabaseInterface;
   let parents: LatestRelatedParentCollection;
   let evaluations: LatestRelatedEvaluationCollection;
 
   beforeEach(async () => {
+    resetInitializationEvidence();
     db = await getTestDatabase({
       type: 'sqlite',
       url: join(tmpdir(), `latest-related-${randomUUID()}.db`),
@@ -59,6 +127,8 @@ describe('SmrtCollection.listWithLatestRelated()', () => {
   });
 
   afterEach(async () => {
+    GlobalInterceptors.unregister('latest-related-transform');
+    GlobalInterceptors.unregister('latest-related-scope');
     await db.close?.();
   });
 
@@ -89,6 +159,7 @@ describe('SmrtCollection.listWithLatestRelated()', () => {
       note: 'latest second',
     });
     // Third intentionally has no related row.
+    resetInitializationEvidence();
 
     const page = await parents.listWithLatestRelated({
       latestRelated: {
@@ -119,6 +190,176 @@ describe('SmrtCollection.listWithLatestRelated()', () => {
     expect(nextPage).toHaveLength(1);
     expect(nextPage[0].parent.name).toBe('third');
     expect(nextPage[0].latestRelated).toBeNull();
+    expect(initializationOrder).toEqual(['first', 'second', 'third']);
+    expect(maximumActiveInitializers).toBe(1);
+  });
+
+  it('keeps related rows paired when afterList filters and reorders parents', async () => {
+    const first = await parents.create({ name: 'first' });
+    const second = await parents.create({ name: 'second' });
+    const third = await parents.create({ name: 'third' });
+
+    await evaluations.create({
+      parentId: first.id,
+      sequence: 1,
+      score: 1.0,
+      evaluationScore: 1.0,
+      note: 'first related',
+    });
+    await evaluations.create({
+      parentId: second.id,
+      sequence: 1,
+      score: 2.0,
+      evaluationScore: 2.0,
+      note: 'second related',
+    });
+    await evaluations.create({
+      parentId: third.id,
+      sequence: 1,
+      score: 3.0,
+      evaluationScore: 3.0,
+      note: 'third related',
+    });
+    resetInitializationEvidence();
+
+    GlobalInterceptors.register({
+      name: 'latest-related-transform',
+      afterList(_className, results: LatestRelatedParent[]) {
+        return results
+          .filter((parent) => parent.name !== 'second')
+          .sort((left, right) => right.name.localeCompare(left.name));
+      },
+    });
+
+    const rows = await parents.listWithLatestRelated({
+      latestRelated: {
+        relation: 'evaluations',
+        orderBy: 'sequence DESC',
+        select: ['note'],
+      },
+    });
+
+    expect(rows.map((row) => row.parent.name)).toEqual(['third', 'first']);
+    expect(rows.map((row) => row.latestRelated?.note)).toEqual([
+      'third related',
+      'first related',
+    ]);
+  });
+
+  it("applies the related collection's tenant scope inside the CTE", async () => {
+    const parent = await parents.create({ name: 'scoped parent' });
+    await evaluations.create({
+      parentId: parent.id,
+      sequence: 2,
+      score: 9.0,
+      evaluationScore: 9.0,
+      tenantId: 'tenant-b',
+      note: 'blocked related',
+    });
+    await evaluations.create({
+      parentId: parent.id,
+      sequence: 1,
+      score: 1.0,
+      evaluationScore: 1.0,
+      tenantId: 'tenant-a',
+      note: 'allowed related',
+    });
+
+    GlobalInterceptors.register({
+      name: 'latest-related-scope',
+      beforeList(className, options) {
+        if (className !== 'LatestRelatedEvaluation') return;
+        return {
+          ...options,
+          where: { ...options.where, tenantId: 'tenant-a' },
+        };
+      },
+    });
+
+    const rows = await parents.listWithLatestRelated({
+      latestRelated: {
+        relation: 'evaluations',
+        orderBy: 'sequence DESC',
+        select: ['note'],
+      },
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].latestRelated).toEqual({ note: 'allowed related' });
+  });
+
+  it('keeps tied latest rows and null parent sorting stable across pages', async () => {
+    const high = await parents.create({ name: 'high' });
+    const tied = await parents.create({ name: 'tied' });
+    await parents.create({ name: 'empty' });
+
+    await evaluations.create({
+      parentId: high.id,
+      sequence: 1,
+      score: 9.0,
+      evaluationScore: 9.0,
+      note: 'high',
+    });
+    for (const note of ['tie-a', 'tie-b']) {
+      await evaluations.create({
+        parentId: tied.id,
+        sequence: 1,
+        score: 4.0,
+        evaluationScore: 4.0,
+        note,
+      });
+    }
+
+    const readPage = () =>
+      parents.listWithLatestRelated({
+        latestRelated: {
+          relation: 'evaluations',
+          orderBy: 'sequence DESC',
+          select: ['note'],
+          sortBy: 'score DESC',
+        },
+        limit: 3,
+        offset: 0,
+      });
+    const firstPage = await readPage();
+    const secondPage = await readPage();
+
+    expect(firstPage.map((row) => row.parent.name)).toEqual([
+      'high',
+      'tied',
+      'empty',
+    ]);
+    expect(firstPage.map((row) => row.latestRelated?.note ?? null)).toEqual(
+      secondPage.map((row) => row.latestRelated?.note ?? null),
+    );
+    expect(firstPage[2].latestRelated).toBeNull();
+  });
+
+  it('filters an STI related collection to its declared child type', async () => {
+    const stiParents = await LatestRelatedStiParentCollection.create({ db });
+    const stiEvaluations =
+      await LatestRelatedStiScoreEvaluationCollection.create({ db });
+    const parent = await stiParents.create({ name: 'sti parent' });
+    await stiEvaluations.create({
+      parentId: parent.id,
+      sequence: 1,
+      score: 7.0,
+      note: 'sti latest',
+    });
+
+    const rows = await stiParents.listWithLatestRelated({
+      latestRelated: {
+        relation: 'evaluations',
+        orderBy: 'sequence DESC',
+        select: ['score', 'note'],
+      },
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].latestRelated).toEqual({
+      score: 7,
+      note: 'sti latest',
+    });
   });
 
   it('uses the declared relation and rejects unrelated fields', async () => {

--- a/packages/core/src/__tests__/collection-latest-related.test.ts
+++ b/packages/core/src/__tests__/collection-latest-related.test.ts
@@ -25,6 +25,9 @@ function resetInitializationEvidence(): void {
 class LatestRelatedParent extends SmrtObject {
   name = '';
 
+  @field()
+  __smrt_lr_0 = '';
+
   @oneToMany('LatestRelatedEvaluation')
   evaluations: LatestRelatedEvaluation[] = [];
 
@@ -309,6 +312,17 @@ describe('SmrtCollection.listWithLatestRelated()', () => {
 
   it('maps long related field names through bounded internal aliases', async () => {
     const parent = await parents.create({ name: 'long alias parent' });
+    // Simulate a legacy/externally-managed column using the reserved-looking
+    // alias. The materializer must preserve it while also returning related
+    // data, so aliases must avoid all legitimate parent identifiers.
+    await db.query(
+      'ALTER TABLE latest_related_parents ADD COLUMN "__smrt_lr_0" TEXT',
+    );
+    await db.query(
+      'UPDATE latest_related_parents SET "__smrt_lr_0" = $1 WHERE id = $2',
+      'parent marker',
+      parent.id,
+    );
     await evaluations.create({
       parentId: parent.id,
       sequence: 1,
@@ -331,6 +345,7 @@ describe('SmrtCollection.listWithLatestRelated()', () => {
       thisIsAnExtremelyLongLatestRelatedFieldNameForPostgresAliasCoverage:
         'preserved',
     });
+    expect(rows[0].parent.__smrt_lr_0).toBe('parent marker');
   });
 
   it('keeps related rows paired when afterList filters and reorders parents', async () => {
@@ -536,12 +551,22 @@ describe('SmrtCollection.listWithLatestRelated()', () => {
         db: duckDb,
       });
       const parent = await duckParents.create({ name: 'duck parent' });
+      const secondParent = await duckParents.create({
+        name: 'duck second parent',
+      });
       await duckEvaluations.create({
         parentId: parent.id,
         sequence: 1,
         score: 7.0,
         evaluationScore: 7.0,
         note: 'duck latest',
+      });
+      await duckEvaluations.create({
+        parentId: secondParent.id,
+        sequence: 1,
+        score: 8.0,
+        evaluationScore: 8.0,
+        note: 'duck second latest',
       });
 
       const rows = await duckParents.listWithLatestRelated({
@@ -550,10 +575,13 @@ describe('SmrtCollection.listWithLatestRelated()', () => {
           orderBy: 'sequence DESC',
           select: ['score', 'note'],
         },
+        orderBy: 'name ASC',
+        offset: 1,
       });
+      expect(rows[0].parent.name).toBe('duck second parent');
       expect(rows[0].latestRelated).toEqual({
-        score: 7,
-        note: 'duck latest',
+        score: 8,
+        note: 'duck second latest',
       });
     } finally {
       await duckDb.close?.();

--- a/packages/core/src/__tests__/collection-latest-related.test.ts
+++ b/packages/core/src/__tests__/collection-latest-related.test.ts
@@ -541,7 +541,7 @@ describe('SmrtCollection.listWithLatestRelated()', () => {
   it('uses the same window-query shape on DuckDB', async () => {
     const duckDb = await getTestDatabase({
       type: 'duckdb',
-      url: join(tmpdir(), `latest-related-${randomUUID()}.duckdb`),
+      url: ':memory:',
     });
     try {
       const duckParents = await LatestRelatedParentCollection.create({
@@ -603,12 +603,22 @@ describe('SmrtCollection.listWithLatestRelated()', () => {
         db: jsonDb,
       });
       const parent = await jsonParents.create({ name: 'json parent' });
+      const secondParent = await jsonParents.create({
+        name: 'json second parent',
+      });
       await jsonEvaluations.create({
         parentId: parent.id,
         sequence: 1,
         score: 8.0,
         evaluationScore: 8.0,
         note: 'json latest',
+      });
+      await jsonEvaluations.create({
+        parentId: secondParent.id,
+        sequence: 1,
+        score: 9.0,
+        evaluationScore: 9.0,
+        note: 'json second latest',
       });
 
       const rows = await jsonParents.listWithLatestRelated({
@@ -617,10 +627,13 @@ describe('SmrtCollection.listWithLatestRelated()', () => {
           orderBy: 'sequence DESC',
           select: ['score', 'note'],
         },
+        orderBy: 'name ASC',
+        offset: 1,
       });
+      expect(rows[0].parent.name).toBe('json second parent');
       expect(rows[0].latestRelated).toEqual({
-        score: 8,
-        note: 'json latest',
+        score: 9,
+        note: 'json second latest',
       });
     } finally {
       await jsonDb.close?.();

--- a/packages/core/src/class.ts
+++ b/packages/core/src/class.ts
@@ -976,6 +976,16 @@ export class SmrtClass {
   }
 
   /**
+   * Return the database engine hint captured from the caller's configuration.
+   * Adapters may not expose their original type after construction (notably
+   * in-memory DuckDB/JSON connections), so query helpers can combine this
+   * hint with their public connection capabilities.
+   */
+  protected getDatabaseEngineHint(): string | undefined {
+    return this._dbEngineHint;
+  }
+
+  /**
    * Initialize signal bus and adapters
    *
    * Merges global configuration with instance-specific overrides.

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@happyvertical/logger';
-import { buildWhere } from '@happyvertical/sql';
+import { buildWhere, type DatabaseInterface } from '@happyvertical/sql';
 import type { SmrtClassOptions } from './class';
 import { SmrtClass } from './class';
 import {
@@ -38,6 +38,7 @@ import {
 } from './query-bounds';
 import { ObjectRegistry } from './registry';
 import type { SmrtObjectConstructor } from './registry/types';
+import { detectEngine } from './schema/ddl/index';
 import { verifyPersistenceTable } from './schema/table-verifier';
 import {
   classnameToTablename,
@@ -378,7 +379,7 @@ export interface SmrtLatestRelatedOptions {
   relation: string;
   /** Related field(s) used to select the latest row, e.g. `createdAt DESC`. */
   orderBy: string | string[];
-  /** Column-backed related fields returned in `latestRelated`. Defaults to `id`. */
+  /** Column-backed related fields returned in `latestRelated`. Defaults to the declared related primary key. */
   select?: readonly string[];
   /** Related field(s) used to order parent rows by the selected latest row. */
   sortBy?: string | string[];
@@ -1288,6 +1289,17 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     return { field, column: this.toDbColumnName(field) };
   }
 
+  private getDatabaseEngine(): ReturnType<typeof detectEngine> {
+    const db = this.db as DatabaseInterface & {
+      config?: { type?: string; url?: string };
+      type?: string;
+    };
+    return detectEngine(
+      db.url || db.config?.url || '',
+      db.type || db.config?.type,
+    );
+  }
+
   private isOmittedCustomPrimaryKeySystemField(
     fieldName: string,
     hasCustomPrimaryKey: boolean,
@@ -1697,12 +1709,28 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
         term.column,
       ]),
     );
-    const relatedFieldAliases = new Map(
-      Array.from(relatedOutputFields).map((fieldName, index) => [
-        fieldName,
-        `__smrt_lr_${index}`,
-      ]),
-    );
+    const parentSchema =
+      ObjectRegistry.getSchema(itemQualifiedName) ??
+      ObjectRegistry.getSchema(itemClassName);
+    const occupiedParentIdentifiers = new Set([
+      ...Object.keys(parentFields),
+      ...Object.keys(parentFields).map((fieldName) =>
+        this.toDbColumnName(fieldName),
+      ),
+      ...Object.keys(parentSchema?.columns ?? {}),
+    ]);
+    const relatedFieldAliases = new Map<string, string>();
+    let nextAliasIndex = 0;
+    for (const fieldName of relatedOutputFields) {
+      let alias: string;
+      do {
+        alias = `__smrt_lr_${nextAliasIndex++}`;
+      } while (
+        occupiedParentIdentifiers.has(alias) ||
+        [...relatedFieldAliases.values()].includes(alias)
+      );
+      relatedFieldAliases.set(fieldName, alias);
+    }
     const relatedAlias = (fieldName: string): string => {
       const alias = relatedFieldAliases.get(fieldName);
       if (!alias) {
@@ -1796,9 +1824,10 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     }
     if (boundedOffset !== undefined) {
       if (boundedLimit === undefined) {
-        // SQLite requires LIMIT before OFFSET. LIMIT -1 is the portable
-        // unlimited form accepted by SQLite, DuckDB, and PostgreSQL.
-        limitOffsetSql += ' LIMIT -1';
+        // SQLite requires LIMIT before OFFSET. SQLite uses -1 for an
+        // unlimited limit; DuckDB and PostgreSQL use the standard LIMIT ALL.
+        limitOffsetSql +=
+          this.getDatabaseEngine() === 'sqlite' ? ' LIMIT -1' : ' LIMIT ALL';
       }
       limitOffsetSql += ` OFFSET $${nextParameter++}`;
       limitOffsetValues.push(boundedOffset);

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -1293,10 +1293,21 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     const db = this.db as DatabaseInterface & {
       config?: { type?: string; url?: string };
       type?: string;
+      client?: { constructor?: { name?: string }; connection?: unknown };
+      exportTable?: unknown;
     };
+    const clientName = db.client?.constructor?.name?.toLowerCase() ?? '';
+    const isDuckDbConnection =
+      clientName.includes('duckdb') ||
+      (typeof db.exportTable === 'function' &&
+        db.client !== undefined &&
+        'connection' in db.client);
     return detectEngine(
       db.url || db.config?.url || '',
-      db.type || db.config?.type,
+      this.getDatabaseEngineHint() ||
+        db.type ||
+        db.config?.type ||
+        (isDuckDbConnection ? 'duckdb' : undefined),
     );
   }
 
@@ -1712,11 +1723,19 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     const parentSchema =
       ObjectRegistry.getSchema(itemQualifiedName) ??
       ObjectRegistry.getSchema(itemClassName);
+    const liveParentSchema =
+      typeof this.db.getTableSchema === 'function'
+        ? await this.db.getTableSchema(this.tableName)
+        : undefined;
+    const parentColumnNames = Object.keys(
+      liveParentSchema?.columns ?? parentSchema?.columns ?? {},
+    );
     const occupiedParentIdentifiers = new Set([
       ...Object.keys(parentFields),
       ...Object.keys(parentFields).map((fieldName) =>
         this.toDbColumnName(fieldName),
       ),
+      ...parentColumnNames,
       ...Object.keys(parentSchema?.columns ?? {}),
     ]);
     const relatedFieldAliases = new Map<string, string>();
@@ -1731,6 +1750,12 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       );
       relatedFieldAliases.set(fieldName, alias);
     }
+    const parentSelectSql =
+      parentColumnNames.length > 0
+        ? parentColumnNames
+            .map((columnName) => this.quoteProjectionIdentifier(columnName))
+            .join(', ')
+        : '*';
     const relatedAlias = (fieldName: string): string => {
       const alias = relatedFieldAliases.get(fieldName);
       if (!alias) {
@@ -1833,7 +1858,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       limitOffsetValues.push(boundedOffset);
     }
 
-    const sql = `${relatedCte}SELECT ${this.quoteProjectionIdentifier(this.tableName)}.*, ${Array.from(
+    const sql = `${relatedCte}SELECT ${parentSelectSql}, ${Array.from(
       relatedOutputFields,
     )
       .map(

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -1598,10 +1598,43 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     );
     await relatedCollection.ensureStorageReady();
     const relatedFields = relatedCollection.getFieldsSync();
+    const relatedItemClassName = relatedCollection.getResolvedItemClassName();
     const relatedQualifiedName =
       relatedCollection.getResolvedItemQualifiedName();
     const relatedIsSTI =
       ObjectRegistry.getTableStrategy(relatedQualifiedName) === 'sti';
+
+    // Run the related collection's read-scope interceptors as well as the
+    // parent's. Relation targets can have their own tenant or authorization
+    // policy; omitting this scope would make the CTE a raw bypass of the
+    // target collection's normal list contract.
+    const relatedInterceptorContext = createInterceptorContext(
+      relatedItemClassName,
+      'list',
+      relatedCollection.constructor.name,
+    );
+    const relatedInterceptedOptions =
+      (await GlobalInterceptors.executeBeforeList(
+        relatedItemClassName,
+        { where: {} } as InterceptorListOptions,
+        relatedInterceptorContext,
+      )) ?? ({ where: {} } as InterceptorListOptions);
+    let relatedWhere = (
+      relatedInterceptedOptions as SmrtListOptions<SmrtObject>
+    ).where;
+    if (relatedIsSTI) {
+      const relatedStiBase = ObjectRegistry.getSTIBase(relatedQualifiedName);
+      if (relatedStiBase && relatedStiBase !== relatedQualifiedName) {
+        relatedWhere = {
+          _meta_type: relatedQualifiedName,
+          ...(relatedWhere || {}),
+        };
+      }
+    }
+    relatedWhere = resolveMetaTypeInWhere(relatedWhere);
+    const { sql: relatedWhereSql, values: relatedWhereValues } = buildWhere(
+      relatedCollection.convertWhereKeys(relatedWhere || {}),
+    );
     const relatedSelect = latestOptions.select ?? ['id'];
     const relatedProjection = relatedCollection.resolveProjectionSelect(
       relatedSelect,
@@ -1652,18 +1685,17 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     ]
       .filter(Boolean)
       .join(', ');
-    const relatedStiChildMetaType = relatedCollection.getStiChildMetaType();
-    const relatedWhereValues = relatedStiChildMetaType
-      ? [relatedStiChildMetaType]
-      : [];
-    const relatedWhereSql = relatedStiChildMetaType
-      ? ` WHERE r.${relatedCollection.quoteProjectionIdentifier('_meta_type')} = $1`
-      : '';
+    const latestRankAlias =
+      relatedCollection.quoteProjectionIdentifier('__smrt_latest_rank');
+    const latestRelatedAlias = (fieldName: string): string =>
+      relatedCollection.quoteProjectionIdentifier(
+        `__smrt_latest_related__${fieldName}`,
+      );
     const relatedCte = `WITH ranked_latest_related AS (SELECT ${relatedSelectExpressions
       .map((expression) => `r.${expression}`)
       .join(
         ', ',
-      )}, ROW_NUMBER() OVER (PARTITION BY r.${relatedCollection.quoteProjectionIdentifier(relatedCollection.toDbColumnName(inverseForeignKey.fieldName))} ORDER BY ${relatedRankOrder}) AS __smrt_latest_rank FROM ${relatedCollection.tableName} r${relatedWhereSql}) `;
+      )}, ROW_NUMBER() OVER (PARTITION BY r.${relatedCollection.quoteProjectionIdentifier(relatedCollection.toDbColumnName(inverseForeignKey.fieldName))} ORDER BY ${relatedRankOrder}) AS ${latestRankAlias} FROM ${relatedCollection.tableName} r${relatedWhereSql ? ` ${relatedWhereSql}` : ''}) `;
 
     const parentWhere = this.convertWhereKeys(where || {});
     const { sql: rawWhereSql, values: parentWhereValues } =
@@ -1674,12 +1706,12 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
         `$${Number(index) + relatedWhereValues.length}`,
     );
     const relatedJoinConditions = [
-      `rr.__smrt_latest_rank = 1`,
-      `rr.__smrt_latest_related__${inverseForeignKey.fieldName} = ${this.quoteProjectionIdentifier('id')}`,
+      `rr.${latestRankAlias} = 1`,
+      `rr.${latestRelatedAlias(inverseForeignKey.fieldName)} = ${this.quoteProjectionIdentifier('id')}`,
     ];
     if (parentFields.tenantId && relatedFields.tenantId) {
       relatedJoinConditions.push(
-        `(rr.__smrt_latest_related__tenantId = ${this.quoteProjectionIdentifier('tenant_id')} OR (rr.__smrt_latest_related__tenantId IS NULL AND ${this.quoteProjectionIdentifier('tenant_id')} IS NULL))`,
+        `(rr.${latestRelatedAlias('tenantId')} = ${this.quoteProjectionIdentifier('tenant_id')} OR (rr.${latestRelatedAlias('tenantId')} IS NULL AND ${this.quoteProjectionIdentifier('tenant_id')} IS NULL))`,
       );
     }
 
@@ -1732,7 +1764,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     )
       .map(
         (fieldName) =>
-          `rr.__smrt_latest_related__${fieldName} AS ${this.quoteProjectionIdentifier(`__smrt_latest_related__${fieldName}`)}`,
+          `rr.${latestRelatedAlias(fieldName)} AS ${this.quoteProjectionIdentifier(`__smrt_latest_related__${fieldName}`)}`,
       )
       .join(
         ', ',
@@ -1744,24 +1776,30 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       ...limitOffsetValues,
     );
 
-    const instances = await Promise.all(
-      rows.rows.map((row: Record<string, unknown>) => {
-        const parentRow = Object.fromEntries(
-          Object.entries(row).filter(
-            ([key]) => !key.startsWith('__smrt_latest_related__'),
-          ),
-        );
-        return this.hydrateResultRow(parentRow, parentFields, isSTI);
-      }),
-    );
-    const finalInstances = await GlobalInterceptors.executeAfterList(
-      itemClassName,
-      instances,
-      interceptorContext,
-    );
+    // Hydrate in result order. initialize() hooks may issue queries through
+    // the same transaction-bound PostgreSQL client, so overlapping hydration
+    // would violate the collection-wide serial hydration invariant.
+    const instances: ModelType[] = [];
+    for (const row of rows.rows as Record<string, unknown>[]) {
+      const parentRow = Object.fromEntries(
+        Object.entries(row).filter(
+          ([key]) => !key.startsWith('__smrt_latest_related__'),
+        ),
+      );
+      instances.push(
+        await this.hydrateResultRow(parentRow, parentFields, isSTI),
+      );
+    }
 
-    return finalInstances.map((parent, index) => {
-      const row = rows.rows[index] as Record<string, unknown>;
+    // Materialize the related projection by the parent primary key before
+    // afterList hooks run. Hooks may filter or reorder hydrated parents; an
+    // array-index pairing after those hooks could attach one parent's related
+    // data to another parent.
+    const relatedByParentId = new Map<string, Record<string, unknown> | null>();
+    for (const row of rows.rows as Record<string, unknown>[]) {
+      const parentId = row.id;
+      if (parentId === null || parentId === undefined) continue;
+
       const relatedRow = Object.fromEntries(
         relatedProjection.outputFields.map((fieldName) => [
           fieldName,
@@ -1769,15 +1807,30 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
         ]),
       );
       const relatedId = row.__smrt_latest_related__id;
+      relatedByParentId.set(
+        String(parentId),
+        relatedId === null || relatedId === undefined
+          ? null
+          : relatedCollection.formatProjectionRow(
+              relatedRow,
+              relatedFields,
+              relatedProjection.outputFields,
+            ),
+      );
+    }
+
+    const finalInstances = await GlobalInterceptors.executeAfterList(
+      itemClassName,
+      instances,
+      interceptorContext,
+    );
+
+    return finalInstances.map((parent) => {
       return {
         latestRelated:
-          relatedId === null || relatedId === undefined
+          parent.id === null || parent.id === undefined
             ? null
-            : relatedCollection.formatProjectionRow(
-                relatedRow,
-                relatedFields,
-                relatedProjection.outputFields,
-              ),
+            : (relatedByParentId.get(String(parent.id)) ?? null),
         parent,
       };
     });

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -387,7 +387,7 @@ export interface SmrtLatestRelatedOptions {
 /** Options accepted by {@link SmrtCollection.listWithLatestRelated}. */
 export type SmrtLatestRelatedListOptions<ModelType extends SmrtObject> = Omit<
   SmrtListOptions<ModelType>,
-  'select' | 'include'
+  'select' | 'include' | 'cache'
 > & {
   latestRelated: SmrtLatestRelatedOptions;
 };
@@ -1269,6 +1269,25 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     );
   }
 
+  private resolvePrimaryKeyField(
+    fields: Record<string, CollectionFieldDefinition>,
+    label: string,
+  ): { field: string; column: string } {
+    const declared = Object.entries(fields)
+      .filter(
+        ([, fieldDef]) =>
+          fieldDef.primaryKey === true || fieldDef._meta?.primaryKey === true,
+      )
+      .map(([field]) => field);
+    if (declared.length > 1) {
+      throw new Error(
+        `${label} declares multiple primary-key fields (${declared.join(', ')}); listWithLatestRelated requires a single primary key.`,
+      );
+    }
+    const field = declared[0] ?? 'id';
+    return { field, column: this.toDbColumnName(field) };
+  }
+
   private isOmittedCustomPrimaryKeySystemField(
     fieldName: string,
     hasCustomPrimaryKey: boolean,
@@ -1635,7 +1654,11 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     const { sql: relatedWhereSql, values: relatedWhereValues } = buildWhere(
       relatedCollection.convertWhereKeys(relatedWhere || {}),
     );
-    const relatedSelect = latestOptions.select ?? ['id'];
+    const relatedPrimaryKey = relatedCollection.resolvePrimaryKeyField(
+      relatedFields,
+      `Related model ${relatedItemClassName}`,
+    );
+    const relatedSelect = latestOptions.select ?? [relatedPrimaryKey.field];
     const relatedProjection = relatedCollection.resolveProjectionSelect(
       relatedSelect,
       relatedFields,
@@ -1655,8 +1678,12 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       : [];
 
     const parentFields = this.getFieldsSync();
+    const parentPrimaryKey = this.resolvePrimaryKeyField(
+      parentFields,
+      `Parent model ${itemClassName}`,
+    );
     const relatedOutputFields = new Set(relatedProjection.outputFields);
-    relatedOutputFields.add('id');
+    relatedOutputFields.add(relatedPrimaryKey.field);
     relatedOutputFields.add(inverseForeignKey.fieldName);
     if (parentFields.tenantId && relatedFields.tenantId) {
       relatedOutputFields.add('tenantId');
@@ -1670,27 +1697,38 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
         term.column,
       ]),
     );
+    const relatedFieldAliases = new Map(
+      Array.from(relatedOutputFields).map((fieldName, index) => [
+        fieldName,
+        `__smrt_lr_${index}`,
+      ]),
+    );
+    const relatedAlias = (fieldName: string): string => {
+      const alias = relatedFieldAliases.get(fieldName);
+      if (!alias) {
+        throw new Error(`Missing latest-related alias for '${fieldName}'.`);
+      }
+      return alias;
+    };
     const relatedSelectExpressions = Array.from(relatedOutputFields).map(
       (fieldName) => {
         const column =
           relatedFieldColumns.get(fieldName) ??
           relatedCollection.toDbColumnName(fieldName);
-        const alias = `__smrt_latest_related__${fieldName}`;
+        const alias = relatedAlias(fieldName);
         return `${relatedCollection.quoteProjectionIdentifier(column)} AS ${relatedCollection.quoteProjectionIdentifier(alias)}`;
       },
     );
     const relatedRankOrder = [
       relatedCollection.qualifyLatestOrderTerms('r', relatedOrderTerms),
-      `r.${relatedCollection.quoteProjectionIdentifier('id')} DESC`,
+      `r.${relatedCollection.quoteProjectionIdentifier(relatedPrimaryKey.column)} DESC`,
     ]
       .filter(Boolean)
       .join(', ');
     const latestRankAlias =
       relatedCollection.quoteProjectionIdentifier('__smrt_latest_rank');
     const latestRelatedAlias = (fieldName: string): string =>
-      relatedCollection.quoteProjectionIdentifier(
-        `__smrt_latest_related__${fieldName}`,
-      );
+      relatedCollection.quoteProjectionIdentifier(relatedAlias(fieldName));
     const relatedCte = `WITH ranked_latest_related AS (SELECT ${relatedSelectExpressions
       .map((expression) => `r.${expression}`)
       .join(
@@ -1707,7 +1745,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     );
     const relatedJoinConditions = [
       `rr.${latestRankAlias} = 1`,
-      `rr.${latestRelatedAlias(inverseForeignKey.fieldName)} = ${this.quoteProjectionIdentifier('id')}`,
+      `rr.${latestRelatedAlias(inverseForeignKey.fieldName)} = ${this.quoteProjectionIdentifier(parentPrimaryKey.column)}`,
     ];
     if (parentFields.tenantId && relatedFields.tenantId) {
       relatedJoinConditions.push(
@@ -1722,7 +1760,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
           'rr',
           relatedSortTerms.map((term) => ({
             ...term,
-            column: `__smrt_latest_related__${term.field}`,
+            column: relatedAlias(term.field),
           })),
         ),
       );
@@ -1742,7 +1780,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
           .join(', '),
       );
     }
-    orderFragments.push(`${this.quoteProjectionIdentifier('id')} ASC`);
+    orderFragments.push(
+      `${this.quoteProjectionIdentifier(parentPrimaryKey.column)} ASC`,
+    );
 
     const boundedLimit = this.applyListBounds(assertQueryBound(limit, 'limit'));
     const boundedOffset = assertQueryBound(offset, 'offset');
@@ -1755,6 +1795,11 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       limitOffsetValues.push(boundedLimit);
     }
     if (boundedOffset !== undefined) {
+      if (boundedLimit === undefined) {
+        // SQLite requires LIMIT before OFFSET. LIMIT -1 is the portable
+        // unlimited form accepted by SQLite, DuckDB, and PostgreSQL.
+        limitOffsetSql += ' LIMIT -1';
+      }
       limitOffsetSql += ` OFFSET $${nextParameter++}`;
       limitOffsetValues.push(boundedOffset);
     }
@@ -1764,7 +1809,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     )
       .map(
         (fieldName) =>
-          `rr.${latestRelatedAlias(fieldName)} AS ${this.quoteProjectionIdentifier(`__smrt_latest_related__${fieldName}`)}`,
+          `rr.${latestRelatedAlias(fieldName)} AS ${this.quoteProjectionIdentifier(relatedAlias(fieldName))}`,
       )
       .join(
         ', ',
@@ -1780,11 +1825,10 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     // the same transaction-bound PostgreSQL client, so overlapping hydration
     // would violate the collection-wide serial hydration invariant.
     const instances: ModelType[] = [];
+    const relatedAliasNames = new Set(relatedFieldAliases.values());
     for (const row of rows.rows as Record<string, unknown>[]) {
       const parentRow = Object.fromEntries(
-        Object.entries(row).filter(
-          ([key]) => !key.startsWith('__smrt_latest_related__'),
-        ),
+        Object.entries(row).filter(([key]) => !relatedAliasNames.has(key)),
       );
       instances.push(
         await this.hydrateResultRow(parentRow, parentFields, isSTI),
@@ -1797,16 +1841,16 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     // data to another parent.
     const relatedByParentId = new Map<string, Record<string, unknown> | null>();
     for (const row of rows.rows as Record<string, unknown>[]) {
-      const parentId = row.id;
+      const parentId = row[parentPrimaryKey.column];
       if (parentId === null || parentId === undefined) continue;
 
       const relatedRow = Object.fromEntries(
         relatedProjection.outputFields.map((fieldName) => [
           fieldName,
-          row[`__smrt_latest_related__${fieldName}`],
+          row[relatedAlias(fieldName)],
         ]),
       );
-      const relatedId = row.__smrt_latest_related__id;
+      const relatedId = row[relatedAlias(relatedPrimaryKey.field)];
       relatedByParentId.set(
         String(parentId),
         relatedId === null || relatedId === undefined
@@ -1828,9 +1872,20 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     return finalInstances.map((parent) => {
       return {
         latestRelated:
-          parent.id === null || parent.id === undefined
+          (parent as unknown as Record<string, unknown>)[
+            parentPrimaryKey.field
+          ] === null ||
+          (parent as unknown as Record<string, unknown>)[
+            parentPrimaryKey.field
+          ] === undefined
             ? null
-            : (relatedByParentId.get(String(parent.id)) ?? null),
+            : (relatedByParentId.get(
+                String(
+                  (parent as unknown as Record<string, unknown>)[
+                    parentPrimaryKey.field
+                  ],
+                ),
+              ) ?? null),
         parent,
       };
     });

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -365,6 +365,40 @@ export interface SmrtListOptions<ModelType extends SmrtObject> {
 }
 
 /**
+ * Declarative latest-row configuration for a declared `@oneToMany` relation.
+ *
+ * `orderBy` determines which related row wins for each parent. `sortBy`, when
+ * supplied, orders parent rows by a field on that winning row before the
+ * parent's own `limit`/`offset` are applied. Related rows are returned as
+ * plain selected data rather than hydrated objects so this remains a bounded
+ * read primitive.
+ */
+export interface SmrtLatestRelatedOptions {
+  /** The `@oneToMany` field on the parent collection's item class. */
+  relation: string;
+  /** Related field(s) used to select the latest row, e.g. `createdAt DESC`. */
+  orderBy: string | string[];
+  /** Column-backed related fields returned in `latestRelated`. Defaults to `id`. */
+  select?: readonly string[];
+  /** Related field(s) used to order parent rows by the selected latest row. */
+  sortBy?: string | string[];
+}
+
+/** Options accepted by {@link SmrtCollection.listWithLatestRelated}. */
+export type SmrtLatestRelatedListOptions<ModelType extends SmrtObject> = Omit<
+  SmrtListOptions<ModelType>,
+  'select' | 'include'
+> & {
+  latestRelated: SmrtLatestRelatedOptions;
+};
+
+/** A hydrated parent paired with its selected latest related row, if present. */
+export interface SmrtLatestRelatedRow<ModelType extends SmrtObject> {
+  parent: ModelType;
+  latestRelated: Record<string, unknown> | null;
+}
+
+/**
  * Minimal runtime shape of a field definition as consumed by the collection's
  * query/hydration helpers (`getFieldsSync()`, `convertWhereKeys()`,
  * `formatDataJs()`). These come from `fieldsFromClass()` /
@@ -1361,6 +1395,392 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       sql: selectExpressions.join(', '),
       outputFields,
     };
+  }
+
+  /**
+   * Parse and validate order terms while retaining the resolved database
+   * column. The normal list order builder remains the source of truth for
+   * field, sensitive-field, and permission validation; this companion shape
+   * lets the latest-row CTE qualify the same safe identifiers with its alias.
+   */
+  private resolveOrderByTerms(
+    orderBy: string | string[],
+    fields: Record<string, CollectionFieldDefinition>,
+    label: string,
+  ): Array<{ field: string; column: string; direction: 'ASC' | 'DESC' }> {
+    const validatedSql = this.buildOrderBySql(orderBy, fields);
+    const items = Array.isArray(orderBy) ? orderBy : [orderBy];
+    if (items.length === 0) {
+      throw new Error(
+        `Invalid ${label}: at least one order field is required.`,
+      );
+    }
+
+    const validatedTerms = validatedSql
+      .replace(/^ ORDER BY /, '')
+      .split(', ')
+      .map((term) => term.split(/\s+/));
+
+    return items.map((item, index) => {
+      const [field, direction = 'ASC'] = String(item).trim().split(/\s+/);
+      if (!field) {
+        throw new Error(`Invalid ${label}: an order field is required.`);
+      }
+      const normalizedDirection = direction.toUpperCase();
+      if (normalizedDirection !== 'ASC' && normalizedDirection !== 'DESC') {
+        throw new Error(
+          `Invalid ${label} direction: ${direction}. Must be ASC or DESC.`,
+        );
+      }
+
+      return {
+        column: validatedTerms[index]?.[0] ?? this.toDbColumnName(field),
+        direction: normalizedDirection,
+        field,
+      };
+    });
+  }
+
+  private qualifyLatestOrderTerms(
+    alias: string,
+    terms: ReadonlyArray<{
+      column: string;
+      direction: 'ASC' | 'DESC';
+    }>,
+  ): string {
+    return terms
+      .flatMap((term) => {
+        const column = `${alias}.${this.quoteProjectionIdentifier(term.column)}`;
+        // Explicit NULLS LAST keeps ranking and parent sorting identical on
+        // PostgreSQL, SQLite, DuckDB, and JSON-on-DuckDB.
+        return [
+          `CASE WHEN ${column} IS NULL THEN 1 ELSE 0 END ASC`,
+          `${column} ${term.direction}`,
+        ];
+      })
+      .join(', ');
+  }
+
+  private qualifyLatestParentOrderTerms(
+    alias: string,
+    terms: ReadonlyArray<{
+      column: string;
+      direction: 'ASC' | 'DESC';
+    }>,
+  ): string {
+    return terms
+      .flatMap((term) => {
+        const column = `${alias}.${this.quoteProjectionIdentifier(term.column)}`;
+        return [
+          `CASE WHEN ${column} IS NULL THEN 1 ELSE 0 END ASC`,
+          `${column} ${term.direction}`,
+        ];
+      })
+      .join(', ');
+  }
+
+  private resolveOneToManyInverseForeignKey(
+    relationship: import('./registry').RelationshipMetadata,
+  ): import('./registry').RelationshipMetadata {
+    const inverseCandidates = ObjectRegistry.getInverseRelationshipsForSelf(
+      this._itemClass.name,
+    ).filter(
+      (candidate) =>
+        candidate.sourceClass === relationship.targetClass &&
+        candidate.type === 'foreignKey',
+    );
+    const explicitForeignKey = relationship.options?.foreignKey as
+      | string
+      | undefined;
+    const matchedForeignKey = explicitForeignKey
+      ? inverseCandidates.find(
+          (candidate) => candidate.fieldName === explicitForeignKey,
+        )
+      : undefined;
+    if (explicitForeignKey && !matchedForeignKey) {
+      throw new Error(
+        `oneToMany ${relationship.fieldName} specifies foreignKey '${explicitForeignKey}', but ${relationship.targetClass} has no matching inverse foreignKey. Candidates: ${inverseCandidates.map((candidate) => candidate.fieldName).join(', ') || '(none)'}`,
+      );
+    }
+
+    const inverseForeignKey =
+      matchedForeignKey ??
+      inverseCandidates.find(
+        (candidate) => candidate.targetClass === this._itemClass.name,
+      ) ??
+      inverseCandidates[0];
+    if (!inverseForeignKey) {
+      throw new Error(
+        `Could not find inverse foreignKey on ${relationship.targetClass} for oneToMany relationship ${relationship.fieldName}`,
+      );
+    }
+    return inverseForeignKey;
+  }
+
+  /**
+   * Load a page of hydrated parents with one selected latest row from a
+   * declared `@oneToMany` relation. The parent page is sliced only after the
+   * latest-row join and optional related sort are applied, so unrelated rows
+   * are never hydrated in application code.
+   *
+   * Missing related rows return `latestRelated: null`. Related order and sort
+   * fields place null values after non-null values consistently on all
+   * supported adapters. The related row is a plain projection and is never a
+   * full `SmrtObject` hydration.
+   *
+   * @example
+   * ```typescript
+   * const page = await opportunities.listWithLatestRelated({
+   *   latestRelated: {
+   *     relation: 'evaluations',
+   *     orderBy: 'evaluatedAt DESC',
+   *     select: ['score', 'evaluatedAt'],
+   *     sortBy: 'score DESC',
+   *   },
+   *   limit: 25,
+   *   offset: 0,
+   * });
+   * console.log(page[0].parent, page[0].latestRelated?.score);
+   * ```
+   */
+  public async listWithLatestRelated(
+    options: SmrtLatestRelatedListOptions<ModelType>,
+  ): Promise<SmrtLatestRelatedRow<ModelType>[]> {
+    await this.ensureStorageReady();
+    const itemClassName = this.getResolvedItemClassName();
+    const itemQualifiedName = this.getResolvedItemQualifiedName();
+
+    const interceptorContext = createInterceptorContext(
+      itemClassName,
+      'list',
+      this.constructor.name,
+    );
+    const interceptedOptions =
+      (await GlobalInterceptors.executeBeforeList(
+        itemClassName,
+        options as InterceptorListOptions,
+        interceptorContext,
+      )) ?? (options as InterceptorListOptions);
+
+    let { where, offset, limit, orderBy } =
+      interceptedOptions as SmrtListOptions<ModelType>;
+    const latestOptions =
+      (interceptedOptions as SmrtLatestRelatedListOptions<ModelType>)
+        .latestRelated ?? options.latestRelated;
+    const tableStrategy = ObjectRegistry.getTableStrategy(itemQualifiedName);
+    const isSTI = tableStrategy === 'sti';
+    if (isSTI) {
+      const stiBase = ObjectRegistry.getSTIBase(itemQualifiedName);
+      if (stiBase && stiBase !== itemQualifiedName) {
+        where = { _meta_type: itemQualifiedName, ...(where || {}) };
+      }
+    }
+    where = resolveMetaTypeInWhere(where);
+
+    const relationship = ObjectRegistry.getRelationships(
+      this._itemClass.name,
+    ).find(
+      (candidate) =>
+        candidate.fieldName === latestOptions.relation &&
+        candidate.type === 'oneToMany',
+    );
+    if (!relationship) {
+      throw new Error(
+        `latestRelated.relation '${latestOptions.relation}' is not a declared oneToMany relationship on ${itemClassName}.`,
+      );
+    }
+
+    const inverseForeignKey =
+      this.resolveOneToManyInverseForeignKey(relationship);
+    const relatedCollection = await ObjectRegistry.getCollection(
+      relationship.targetClass,
+      this.options,
+    );
+    await relatedCollection.ensureStorageReady();
+    const relatedFields = relatedCollection.getFieldsSync();
+    const relatedQualifiedName =
+      relatedCollection.getResolvedItemQualifiedName();
+    const relatedIsSTI =
+      ObjectRegistry.getTableStrategy(relatedQualifiedName) === 'sti';
+    const relatedSelect = latestOptions.select ?? ['id'];
+    const relatedProjection = relatedCollection.resolveProjectionSelect(
+      relatedSelect,
+      relatedFields,
+      relatedIsSTI,
+    );
+    const relatedOrderTerms = relatedCollection.resolveOrderByTerms(
+      latestOptions.orderBy,
+      relatedFields,
+      'latestRelated.orderBy',
+    );
+    const relatedSortTerms = latestOptions.sortBy
+      ? relatedCollection.resolveOrderByTerms(
+          latestOptions.sortBy,
+          relatedFields,
+          'latestRelated.sortBy',
+        )
+      : [];
+
+    const parentFields = this.getFieldsSync();
+    const relatedOutputFields = new Set(relatedProjection.outputFields);
+    relatedOutputFields.add('id');
+    relatedOutputFields.add(inverseForeignKey.fieldName);
+    if (parentFields.tenantId && relatedFields.tenantId) {
+      relatedOutputFields.add('tenantId');
+    }
+    for (const term of [...relatedOrderTerms, ...relatedSortTerms]) {
+      relatedOutputFields.add(term.field);
+    }
+    const relatedFieldColumns = new Map(
+      [...relatedOrderTerms, ...relatedSortTerms].map((term) => [
+        term.field,
+        term.column,
+      ]),
+    );
+    const relatedSelectExpressions = Array.from(relatedOutputFields).map(
+      (fieldName) => {
+        const column =
+          relatedFieldColumns.get(fieldName) ??
+          relatedCollection.toDbColumnName(fieldName);
+        const alias = `__smrt_latest_related__${fieldName}`;
+        return `${relatedCollection.quoteProjectionIdentifier(column)} AS ${relatedCollection.quoteProjectionIdentifier(alias)}`;
+      },
+    );
+    const relatedRankOrder = [
+      relatedCollection.qualifyLatestOrderTerms('r', relatedOrderTerms),
+      `r.${relatedCollection.quoteProjectionIdentifier('id')} DESC`,
+    ]
+      .filter(Boolean)
+      .join(', ');
+    const relatedStiChildMetaType = relatedCollection.getStiChildMetaType();
+    const relatedWhereValues = relatedStiChildMetaType
+      ? [relatedStiChildMetaType]
+      : [];
+    const relatedWhereSql = relatedStiChildMetaType
+      ? ` WHERE r.${relatedCollection.quoteProjectionIdentifier('_meta_type')} = $1`
+      : '';
+    const relatedCte = `WITH ranked_latest_related AS (SELECT ${relatedSelectExpressions
+      .map((expression) => `r.${expression}`)
+      .join(
+        ', ',
+      )}, ROW_NUMBER() OVER (PARTITION BY r.${relatedCollection.quoteProjectionIdentifier(relatedCollection.toDbColumnName(inverseForeignKey.fieldName))} ORDER BY ${relatedRankOrder}) AS __smrt_latest_rank FROM ${relatedCollection.tableName} r${relatedWhereSql}) `;
+
+    const parentWhere = this.convertWhereKeys(where || {});
+    const { sql: rawWhereSql, values: parentWhereValues } =
+      buildWhere(parentWhere);
+    const parentWhereSql = rawWhereSql.replace(
+      /\$(\d+)/g,
+      (_match, index: string) =>
+        `$${Number(index) + relatedWhereValues.length}`,
+    );
+    const relatedJoinConditions = [
+      `rr.__smrt_latest_rank = 1`,
+      `rr.__smrt_latest_related__${inverseForeignKey.fieldName} = ${this.quoteProjectionIdentifier('id')}`,
+    ];
+    if (parentFields.tenantId && relatedFields.tenantId) {
+      relatedJoinConditions.push(
+        `(rr.__smrt_latest_related__tenantId = ${this.quoteProjectionIdentifier('tenant_id')} OR (rr.__smrt_latest_related__tenantId IS NULL AND ${this.quoteProjectionIdentifier('tenant_id')} IS NULL))`,
+      );
+    }
+
+    const orderFragments: string[] = [];
+    if (relatedSortTerms.length > 0) {
+      orderFragments.push(
+        relatedCollection.qualifyLatestParentOrderTerms(
+          'rr',
+          relatedSortTerms.map((term) => ({
+            ...term,
+            column: `__smrt_latest_related__${term.field}`,
+          })),
+        ),
+      );
+    }
+    if (orderBy) {
+      const parentOrderTerms = this.resolveOrderByTerms(
+        orderBy,
+        parentFields,
+        'orderBy',
+      );
+      orderFragments.push(
+        parentOrderTerms
+          .map(
+            (term) =>
+              `${this.quoteProjectionIdentifier(term.column)} ${term.direction}`,
+          )
+          .join(', '),
+      );
+    }
+    orderFragments.push(`${this.quoteProjectionIdentifier('id')} ASC`);
+
+    const boundedLimit = this.applyListBounds(assertQueryBound(limit, 'limit'));
+    const boundedOffset = assertQueryBound(offset, 'offset');
+    let limitOffsetSql = '';
+    const limitOffsetValues: number[] = [];
+    let nextParameter =
+      relatedWhereValues.length + parentWhereValues.length + 1;
+    if (boundedLimit !== undefined) {
+      limitOffsetSql += ` LIMIT $${nextParameter++}`;
+      limitOffsetValues.push(boundedLimit);
+    }
+    if (boundedOffset !== undefined) {
+      limitOffsetSql += ` OFFSET $${nextParameter++}`;
+      limitOffsetValues.push(boundedOffset);
+    }
+
+    const sql = `${relatedCte}SELECT ${this.quoteProjectionIdentifier(this.tableName)}.*, ${Array.from(
+      relatedOutputFields,
+    )
+      .map(
+        (fieldName) =>
+          `rr.__smrt_latest_related__${fieldName} AS ${this.quoteProjectionIdentifier(`__smrt_latest_related__${fieldName}`)}`,
+      )
+      .join(
+        ', ',
+      )} FROM ${this.quoteProjectionIdentifier(this.tableName)} LEFT JOIN ranked_latest_related rr ON ${relatedJoinConditions.join(' AND ')} ${parentWhereSql} ${orderFragments.length > 0 ? `ORDER BY ${orderFragments.join(', ')}` : ''}${limitOffsetSql}`;
+    const rows = await this.db.query(
+      sql,
+      ...relatedWhereValues,
+      ...parentWhereValues,
+      ...limitOffsetValues,
+    );
+
+    const instances = await Promise.all(
+      rows.rows.map((row: Record<string, unknown>) => {
+        const parentRow = Object.fromEntries(
+          Object.entries(row).filter(
+            ([key]) => !key.startsWith('__smrt_latest_related__'),
+          ),
+        );
+        return this.hydrateResultRow(parentRow, parentFields, isSTI);
+      }),
+    );
+    const finalInstances = await GlobalInterceptors.executeAfterList(
+      itemClassName,
+      instances,
+      interceptorContext,
+    );
+
+    return finalInstances.map((parent, index) => {
+      const row = rows.rows[index] as Record<string, unknown>;
+      const relatedRow = Object.fromEntries(
+        relatedProjection.outputFields.map((fieldName) => [
+          fieldName,
+          row[`__smrt_latest_related__${fieldName}`],
+        ]),
+      );
+      const relatedId = row.__smrt_latest_related__id;
+      return {
+        latestRelated:
+          relatedId === null || relatedId === undefined
+            ? null
+            : relatedCollection.formatProjectionRow(
+                relatedRow,
+                relatedFields,
+                relatedProjection.outputFields,
+              ),
+        parent,
+      };
+    });
   }
 
   private formatProjectionRow(


### PR DESCRIPTION
## Summary
- Adds `SmrtCollection.listWithLatestRelated()` for paged parent rows with one latest declared related row.
- Uses a bounded, adapter-safe ranked CTE with deterministic null/tie order and policy-aware related scope.
- Preserves tenant/STI constraints, serial parent hydration, and post-list interceptor identity mapping.

## Validation
- merge-group repair rebased cleanly onto current `origin/main`
- core latest-related and knowledge tests: 25 tests passed
- core typecheck and build
- strict agents-chain check: 4,525-byte headroom on the core chain
- strict knowledge freshness and pre-push policy checks passed

Closes #1903

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-1903-merge-repair-20260823",
  "issue": 1903,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "merge-group repair rebased cleanly onto current origin/main",
    "core latest-related and knowledge tests: 25 tests passed",
    "core typecheck and build",
    "strict agents-chain check: 4525-byte headroom on the core chain",
    "strict knowledge freshness and pre-push policy checks passed"
  ]
}