### PR TITLE
fix(users): export terminal auth approval limit

### DIFF
--- a/packages/users/src/__tests__/terminal-auth-public-exports.test.ts
+++ b/packages/users/src/__tests__/terminal-auth-public-exports.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  UsersCliAuthApproveLimit,
+  UsersCliAuthApproveLimitCollection,
+} from '../index.js';
+
+describe('terminal auth public exports', () => {
+  it('exports every approval-limit class advertised by the package manifest', () => {
+    expect(UsersCliAuthApproveLimit).toBeTypeOf('function');
+    expect(UsersCliAuthApproveLimitCollection).toBeTypeOf('function');
+  });
+});

--- a/packages/users/src/collections/index.ts
+++ b/packages/users/src/collections/index.ts
@@ -7,6 +7,10 @@
 export { AccessRequestCollection } from './AccessRequestCollection.js';
 // CLI / terminal auth
 export {
+  type CliAuthApproveReservation,
+  UsersCliAuthApproveLimitCollection,
+} from './CliAuthApproveLimitCollection.js';
+export {
   CliAuthRequestCollection,
   UsersCliAuthRequestCollection,
 } from './CliAuthRequestCollection.js';

--- a/packages/users/src/index.ts
+++ b/packages/users/src/index.ts
@@ -70,6 +70,7 @@ registerUserRetentionTasks();
 // Collections
 export {
   AccessRequestCollection,
+  type CliAuthApproveReservation,
   CliAuthRequestCollection,
   type CreateChildTenantOptions,
   type CreateSessionOptions,
@@ -105,6 +106,7 @@ export {
   TenantPermissionOverrideCollection,
   type TenantPermissionOverrideResult,
   UserCollection,
+  UsersCliAuthApproveLimitCollection,
   UsersCliAuthRequestCollection,
   UsersMagicLinkTokenCollection,
 } from './collections/index.js';
@@ -144,6 +146,7 @@ export {
   type TenantIntegrationStatus,
   TenantPermissionOverride,
   User,
+  UsersCliAuthApproveLimit,
   UsersCliAuthRequest,
   UsersMagicLinkToken,
 } from './models/index.js';

--- a/packages/users/src/models/index.ts
+++ b/packages/users/src/models/index.ts
@@ -6,6 +6,7 @@
 // Access requests (request access / waitlist)
 export { AccessRequest, type AccessRequestOptions } from './AccessRequest.js';
 // CLI / terminal auth (device code grant)
+export { UsersCliAuthApproveLimit } from './CliAuthApproveLimit.js';
 export {
   CliAuthRequest,
   type CliAuthRequestStatus,


### PR DESCRIPTION
## Summary

- export the terminal-auth approval-limit model from the users model barrel and package root
- export its reservation type and collection from the collection barrel and package root
- add a regression test that imports the advertised runtime classes from the public package entry

## Validation

- pnpm build
- pnpm --filter @happyvertical/smrt-users typecheck
- pnpm --filter @happyvertical/smrt-users test
- pnpm --filter @happyvertical/smrt-users check
- pnpm format
- pnpm smrt dev:knowledge-check
- lefthook pre-push
- standard review-cycle: preliminary codex-luna clean; final codex-terra clean; configured Claude targets unavailable due quota

Closes #2489

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex-desktop",
  "session": "codex-01a02a23-389d-7371-9af0-bdd48c9df71d",
  "issue": 2489,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm build",
    "pnpm --filter @happyvertical/smrt-users typecheck",
    "pnpm --filter @happyvertical/smrt-users test",
    "pnpm --filter @happyvertical/smrt-users check",
    "pnpm format",
    "pnpm smrt dev:knowledge-check",
    "lefthook pre-push",
    "review-cycle standard final"
  ]
}
