### PR TITLE
feat(agents): add principal-bound data-surface actions

### DIFF
--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -138,6 +138,24 @@ such as `MessagingSettingsService`.
 | `QueryFn` | Query function type |
 | `AgentWithInterestsOptions` | Agent options with interests |
 
+### Server Export (`@happyvertical/smrt-agents/server`)
+
+`createDataSurfaceActionAdapter()` provides server-only preview and confirmed
+apply orchestration for the `smrt-ui` data-surface action contract. Browser
+selections and action payloads are hints, never authority: each action declares
+its input validator, confirmation policy, principal tool/RBAC operation, fresh
+authorization and row-eligibility checks, and foreground or injected-background
+execution.
+
+Preview issues a short-lived opaque token bound to the principal, tenant,
+surface/action, selection, query fingerprint, and revision. Apply verifies that
+binding and repeats its principal-bound checks before returning accepted,
+skipped, and failed row outcomes. Callers must supply a durable shared
+`DataSurfaceActionStateStore` with atomic token and idempotency operations.
+`InMemoryDataSurfaceActionStateStore` is for single-process test harnesses only.
+Background queues must invoke the supplied job `run()` callback so checks are
+repeated at execution time.
+
 ### UI Export (`@happyvertical/smrt-agents/ui`)
 
 | Export | Description |

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -149,8 +149,10 @@ execution.
 
 Preview issues a short-lived opaque token bound to the principal, tenant,
 surface/action, selection, query fingerprint, and revision. Apply verifies that
-binding and repeats its principal-bound checks before returning accepted,
-skipped, and failed row outcomes. Callers must supply a durable shared
+binding for confirmation-required actions and repeats its principal-bound checks
+before returning accepted, skipped, and failed row outcomes. Actions declared
+with `confirmation: 'none'` may apply directly with an idempotency key; every
+other apply must include its current preview token. Callers must supply a durable shared
 `DataSurfaceActionStateStore` with atomic token and idempotency operations.
 `InMemoryDataSurfaceActionStateStore` is for single-process test harnesses only.
 Background queues must invoke the supplied job `run()` callback so checks are

--- a/packages/agents/src/server/data-surface-actions.test.ts
+++ b/packages/agents/src/server/data-surface-actions.test.ts
@@ -426,6 +426,32 @@ describe('data-surface action adapter', () => {
     expect(applyRow).toHaveBeenCalledTimes(2);
   });
 
+  it('deduplicates authoritative resolved rows before confirmation and execution', async () => {
+    const applyRow = vi.fn();
+    const setup = harness({
+      apply: applyRow,
+      rowIds: () => ['one', 'two', 'two'],
+    });
+    const preview = await setup.adapter.preview(
+      request('preview'),
+      setup.context,
+    );
+
+    expect(preview).toMatchObject({
+      ok: true,
+      details: { count: 2, accepted: 2 },
+    });
+    if (!preview.confirmationToken) throw new Error('preview token missing');
+
+    await expect(
+      setup.adapter.apply(
+        request('apply', { confirmationToken: preview.confirmationToken }),
+        setup.context,
+      ),
+    ).resolves.toMatchObject({ ok: true, details: { accepted: 2 } });
+    expect(applyRow).toHaveBeenCalledTimes(2);
+  });
+
   it('does not bind confirmation identity to a subject display label', async () => {
     const previewIdentity: DataSurfaceIdentity = {
       ...identity,

--- a/packages/agents/src/server/data-surface-actions.test.ts
+++ b/packages/agents/src/server/data-surface-actions.test.ts
@@ -1,0 +1,587 @@
+import type {
+  DataSurfaceActionDescriptor,
+  DataSurfaceDescriptor,
+  DataSurfaceIdentity,
+} from '@happyvertical/smrt-ui';
+import { registerPermissionDefinitions } from '@happyvertical/smrt-users';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  ExecuteAsPrincipalOptions,
+  PrincipalRun,
+} from '../execute-as-principal.js';
+import { executeAsPrincipal } from '../execute-as-principal.js';
+import {
+  createDataSurfaceActionAdapter,
+  type DataSurfaceActionStateStore,
+  type DataSurfaceBackgroundActionJob,
+  type DataSurfaceServerActionDefinition,
+  type DataSurfaceServerActionRequest,
+  InMemoryDataSurfaceActionStateStore,
+} from './data-surface-actions.js';
+
+const identity: DataSurfaceIdentity = {
+  surfaceId: 'orders',
+  kind: 'table',
+  subject: { type: 'tenant', id: 'tenant-a' },
+};
+
+const actionDescriptor: DataSurfaceActionDescriptor = {
+  id: 'archive',
+  label: 'Archive',
+  selectionScopes: ['explicit-ids', 'all-matching'],
+  requiresConfirmation: true,
+};
+
+const descriptor: DataSurfaceDescriptor = {
+  version: 1,
+  identity,
+  schemaVersion: 1,
+  label: 'Orders',
+  rowKey: 'id',
+  columns: [{ id: 'id', label: 'ID', capabilities: ['read'] }],
+  query: { modes: ['rows'], projectableColumnIds: ['id'] },
+  controls: [],
+  actions: [actionDescriptor],
+  limits: { maxQueryRows: 100, maxQueryBytes: 10_000, maxSelectionSize: 10 },
+};
+
+function request(
+  phase: 'preview' | 'apply',
+  overrides: Partial<DataSurfaceServerActionRequest> = {},
+): DataSurfaceServerActionRequest {
+  return {
+    version: 1,
+    requestId: `${phase}-1`,
+    identity,
+    actionId: 'archive',
+    phase,
+    selection: { scope: 'explicit-ids', rowIds: ['one', 'two'] },
+    expectedRevision: 7,
+    ...(phase === 'apply' ? { idempotencyKey: 'apply-1' } : {}),
+    ...overrides,
+  };
+}
+
+function harness(options: {
+  now?: () => number;
+  authorize?: () => boolean;
+  eligible?: (rowId: string | number) => { eligible: boolean; reason?: string };
+  apply?: (rowId: string | number) => Promise<void> | void;
+  revision?: () => number;
+  queryFingerprint?: () => string;
+  rowIds?: () => Array<string | number>;
+  execution?: 'foreground' | 'background';
+  enqueue?: (job: DataSurfaceBackgroundActionJob) => Promise<{ jobId: string }>;
+  state?: DataSurfaceActionStateStore;
+  runAsPrincipal?: typeof executeAsPrincipal;
+}) {
+  const calls: ExecuteAsPrincipalOptions[] = [];
+  const allowedTools = ['orders.archive'];
+  const assertOperation = vi.fn();
+  const run: PrincipalRun = {
+    context: {} as PrincipalRun['context'],
+    permissions: ['orders:update'],
+    allowedTools,
+    isToolAllowed: (tool) => allowedTools.includes(tool),
+    assertToolAllowed(tool) {
+      if (!allowedTools.includes(tool)) throw new Error('tool denied');
+    },
+    assertOperation,
+  };
+  const runAsPrincipal = (async <T>(
+    principalOptions: ExecuteAsPrincipalOptions,
+    fn: (principalRun: PrincipalRun) => Promise<T>,
+  ): Promise<T> => {
+    calls.push(principalOptions);
+    return fn(run);
+  }) as typeof import('../execute-as-principal.js').executeAsPrincipal;
+  const definition: DataSurfaceServerActionDefinition = {
+    descriptor: actionDescriptor,
+    inputSchema: { type: 'object', required: ['reason'] },
+    validatePayload: (payload) =>
+      payload === undefined ||
+      (typeof payload === 'object' &&
+        payload !== null &&
+        !Array.isArray(payload) &&
+        typeof payload.reason === 'string')
+        ? { valid: true }
+        : { valid: false, reason: 'invalid_payload' },
+    confirmation: 'required',
+    execution: options.execution ?? 'foreground',
+    tool: 'orders.archive',
+    operation: {
+      id: 'orders:update',
+      collection: 'orders',
+      action: 'update',
+    },
+    authorize: () => options.authorize?.() ?? true,
+    eligible: (_invocation, rowId) =>
+      options.eligible?.(rowId) ?? { eligible: true },
+    apply: async (_invocation, rowId) => {
+      await options.apply?.(rowId);
+      return undefined;
+    },
+  };
+  const adapter = createDataSurfaceActionAdapter({
+    state: options.state ?? new InMemoryDataSurfaceActionStateStore(),
+    now: options.now,
+    createToken: () => 'opaque-preview-token',
+    runAsPrincipal: options.runAsPrincipal ?? runAsPrincipal,
+    resolveSurface: async () => ({
+      descriptor,
+      revision: options.revision?.() ?? 7,
+      actions: { archive: definition },
+    }),
+    resolveSelection: async (_invocation, selection) => ({
+      revision: options.revision?.() ?? 7,
+      queryFingerprint: options.queryFingerprint?.() ?? 'query-v1',
+      rowIds:
+        options.rowIds?.() ??
+        (selection.scope === 'explicit-ids'
+          ? selection.rowIds
+          : ['one', 'two']),
+    }),
+    ...(options.enqueue
+      ? { backgroundQueue: { enqueue: options.enqueue } }
+      : {}),
+  });
+  const context = {
+    principal: {
+      db: 'test.db',
+      principal: {
+        runAsUserId: 'principal-a',
+        tenantId: 'tenant-a',
+        allowedTools,
+      },
+      onBehalfOfUserId: 'originator-a',
+      audit: vi.fn(),
+    },
+  };
+  return { adapter, assertOperation, calls, context };
+}
+
+async function previewToken(
+  setup: ReturnType<typeof harness>,
+): Promise<string> {
+  const preview = await setup.adapter.preview(
+    request('preview'),
+    setup.context,
+  );
+  expect(preview.ok).toBe(true);
+  expect(preview.details).toMatchObject({ count: 2, accepted: 2 });
+  if (!preview.confirmationToken) throw new Error('preview token missing');
+  return preview.confirmationToken;
+}
+
+describe('data-surface action adapter', () => {
+  it('binds an opaque preview to the principal and emits attributed audit metadata', async () => {
+    const setup = harness({});
+    const token = await previewToken(setup);
+
+    expect(token).toBe('opaque-preview-token');
+    expect(token).not.toContain('principal-a');
+    expect(setup.calls[0]).toMatchObject({
+      action: 'data_surface.action.preview',
+      onBehalfOfUserId: 'originator-a',
+      auditMetadata: {
+        surfaceId: 'orders',
+        actionId: 'archive',
+        requestId: 'preview-1',
+      },
+    });
+    expect(setup.assertOperation).toHaveBeenCalledWith('orders', 'update');
+
+    const apply = request('apply', { confirmationToken: token });
+    const otherPrincipal = {
+      ...setup.context,
+      principal: {
+        ...setup.context.principal,
+        principal: {
+          ...setup.context.principal.principal,
+          runAsUserId: 'principal-b',
+        },
+      },
+    };
+    await expect(
+      setup.adapter.apply(apply, otherPrincipal),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: 'confirmation_mismatch',
+    });
+  });
+
+  it('rejects confirmation reuse by a different originator or acting profile', async () => {
+    const setup = harness({});
+    const boundContext = {
+      principal: {
+        ...setup.context.principal,
+        principal: {
+          ...setup.context.principal.principal,
+          actsAsProfileId: 'profile-a',
+        },
+      },
+    };
+    const preview = await setup.adapter.preview(
+      request('preview'),
+      boundContext,
+    );
+    if (!preview.confirmationToken) throw new Error('preview token missing');
+    const applyRequest = request('apply', {
+      confirmationToken: preview.confirmationToken,
+    });
+
+    await expect(
+      setup.adapter.apply(applyRequest, {
+        principal: {
+          ...boundContext.principal,
+          onBehalfOfUserId: 'originator-b',
+        },
+      }),
+    ).resolves.toMatchObject({ ok: false, reason: 'confirmation_mismatch' });
+    await expect(
+      setup.adapter.apply(applyRequest, {
+        principal: {
+          ...boundContext.principal,
+          principal: {
+            ...boundContext.principal.principal,
+            actsAsProfileId: 'profile-b',
+          },
+        },
+      }),
+    ).resolves.toMatchObject({ ok: false, reason: 'confirmation_mismatch' });
+  });
+
+  it('emits the bound attribution through the actual PrincipalAuditSink', async () => {
+    const unregister = registerPermissionDefinitions([
+      { slug: 'orders.update' },
+    ]);
+    const audit = vi.fn();
+    const setup = harness({ runAsPrincipal: executeAsPrincipal });
+    const realContext = {
+      principal: {
+        ...setup.context.principal,
+        db: { type: 'sqlite' as const, url: ':memory:' },
+        permissions: ['orders.update'],
+        enterTenantContext: false,
+        audit,
+      },
+    };
+
+    try {
+      await expect(
+        setup.adapter.preview(request('preview'), realContext),
+      ).resolves.toMatchObject({ ok: true });
+      expect(audit).toHaveBeenCalledWith({
+        action: 'data_surface.action.preview',
+        actorUserId: 'principal-a',
+        onBehalfOfUserId: 'originator-a',
+        tenantId: 'tenant-a',
+        actsAsProfileId: null,
+        metadata: {
+          surfaceId: 'orders',
+          actionId: 'archive',
+          requestId: 'preview-1',
+        },
+      });
+    } finally {
+      unregister();
+    }
+  });
+
+  it('fails closed on payloads that do not satisfy the declared input schema', async () => {
+    const setup = harness({});
+    await expect(
+      setup.adapter.preview(
+        request('preview', { payload: { unexpected: true } }),
+        setup.context,
+      ),
+    ).resolves.toMatchObject({ ok: false, reason: 'invalid_payload' });
+  });
+
+  it('rejects forged and expired confirmation tokens', async () => {
+    let now = 10;
+    const setup = harness({ now: () => now });
+    await expect(
+      setup.adapter.apply(request('apply'), setup.context),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: 'confirmation_required',
+    });
+    await expect(
+      setup.adapter.apply(
+        request('apply', { confirmationToken: 'forged' }),
+        setup.context,
+      ),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: 'invalid_or_expired_confirmation',
+    });
+
+    const token = await previewToken(setup);
+    now += 5 * 60 * 1_000;
+    await expect(
+      setup.adapter.apply(
+        request('apply', { confirmationToken: token }),
+        setup.context,
+      ),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: 'invalid_or_expired_confirmation',
+    });
+  });
+
+  it('rechecks authorization, revision, query fingerprint, and resolved rows at apply', async () => {
+    let authorized = true;
+    let revision = 7;
+    let queryFingerprint = 'query-v1';
+    let rows = ['one', 'two'];
+    const setup = harness({
+      authorize: () => authorized,
+      revision: () => revision,
+      queryFingerprint: () => queryFingerprint,
+      rowIds: () => rows,
+    });
+    const token = await previewToken(setup);
+    authorized = false;
+    await expect(
+      setup.adapter.apply(
+        request('apply', { confirmationToken: token }),
+        setup.context,
+      ),
+    ).resolves.toMatchObject({ ok: false, reason: 'denied' });
+
+    authorized = true;
+    revision = 8;
+    const revisionSetup = harness({ revision: () => revision });
+    revision = 7;
+    const revisionToken = await previewToken(revisionSetup);
+    revision = 8;
+    await expect(
+      revisionSetup.adapter.apply(
+        request('apply', { confirmationToken: revisionToken }),
+        revisionSetup.context,
+      ),
+    ).resolves.toMatchObject({ ok: false, reason: 'stale_preview' });
+
+    const driftSetup = harness({
+      queryFingerprint: () => queryFingerprint,
+      rowIds: () => rows,
+    });
+    queryFingerprint = 'query-v1';
+    rows = ['one', 'two'];
+    const driftToken = await previewToken(driftSetup);
+    rows = ['one'];
+    await expect(
+      driftSetup.adapter.apply(
+        request('apply', { confirmationToken: driftToken }),
+        driftSetup.context,
+      ),
+    ).resolves.toMatchObject({ ok: false, reason: 'stale_preview' });
+  });
+
+  it('returns partial outcomes after fresh eligibility and domain execution checks', async () => {
+    let applying = false;
+    const mutated: Array<string | number> = [];
+    const setup = harness({
+      eligible: (rowId) =>
+        applying && rowId === 'two'
+          ? { eligible: false, reason: 'already archived' }
+          : { eligible: true },
+      apply: async (rowId) => {
+        if (rowId === 'one') mutated.push(rowId);
+      },
+    });
+    const token = await previewToken(setup);
+    applying = true;
+    const applied = await setup.adapter.apply(
+      request('apply', { confirmationToken: token }),
+      setup.context,
+    );
+
+    expect(mutated).toEqual(['one']);
+    expect(applied).toMatchObject({
+      ok: true,
+      details: {
+        accepted: 1,
+        skipped: 1,
+        failed: 0,
+        outcomes: [
+          { rowId: 'one', status: 'accepted' },
+          { rowId: 'two', status: 'skipped', reason: 'already archived' },
+        ],
+      },
+    });
+  });
+
+  it('records a thrown row mutation as a failed partial outcome', async () => {
+    const setup = harness({
+      apply: async (rowId) => {
+        if (rowId === 'two') throw new Error('sensitive internal failure');
+      },
+    });
+    const token = await previewToken(setup);
+    const applied = await setup.adapter.apply(
+      request('apply', { confirmationToken: token }),
+      setup.context,
+    );
+
+    expect(applied).toMatchObject({
+      ok: true,
+      details: {
+        accepted: 1,
+        skipped: 0,
+        failed: 1,
+        outcomes: [
+          { rowId: 'one', status: 'accepted' },
+          { rowId: 'two', status: 'failed', reason: 'execution_failed' },
+        ],
+      },
+    });
+    expect(JSON.stringify(applied)).not.toContain('sensitive internal failure');
+  });
+
+  it('replays identical idempotent applies and rejects token replay under a new key', async () => {
+    const applyRow = vi.fn();
+    const setup = harness({ apply: applyRow });
+    const token = await previewToken(setup);
+    const firstRequest = request('apply', { confirmationToken: token });
+    const first = await setup.adapter.apply(firstRequest, setup.context);
+    const retry = await setup.adapter.apply(firstRequest, setup.context);
+    const replay = await setup.adapter.apply(
+      request('apply', {
+        confirmationToken: token,
+        idempotencyKey: 'apply-2',
+      }),
+      setup.context,
+    );
+
+    expect(first.ok).toBe(true);
+    expect(retry).toEqual(first);
+    expect(applyRow).toHaveBeenCalledTimes(2);
+    expect(replay).toMatchObject({
+      ok: false,
+      reason: 'confirmation_replayed',
+    });
+  });
+
+  it('starts side effects once across two adapters sharing durable state', async () => {
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const applyRow = vi.fn(async (rowId: string | number) => {
+      if (rowId === 'one') await firstGate;
+    });
+    const state = new InMemoryDataSurfaceActionStateStore();
+    const firstAdapter = harness({ apply: applyRow, state });
+    const secondAdapter = harness({ apply: applyRow, state });
+    const token = await previewToken(firstAdapter);
+    const applyRequest = request('apply', { confirmationToken: token });
+
+    const first = firstAdapter.adapter.apply(
+      applyRequest,
+      firstAdapter.context,
+    );
+    const concurrent = secondAdapter.adapter.apply(
+      applyRequest,
+      secondAdapter.context,
+    );
+    await vi.waitFor(() => expect(applyRow).toHaveBeenCalledTimes(1));
+    releaseFirst?.();
+
+    const [firstResult, concurrentResult] = await Promise.all([
+      first,
+      concurrent,
+    ]);
+    expect(concurrentResult).toEqual(firstResult);
+    expect(applyRow).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports idempotency conflicts for a changed request under the same key', async () => {
+    const setup = harness({});
+    const token = await previewToken(setup);
+    await setup.adapter.apply(
+      request('apply', { confirmationToken: token }),
+      setup.context,
+    );
+    const conflict = await setup.adapter.apply(
+      request('apply', {
+        confirmationToken: token,
+        payload: { changed: true },
+      }),
+      setup.context,
+    );
+    expect(conflict).toMatchObject({
+      ok: false,
+      reason: 'idempotency_conflict',
+    });
+  });
+
+  it('allows the same idempotency key to retry after a non-terminal adapter failure', async () => {
+    let applyAuthorizationAttempts = 0;
+    const setup = harness({
+      authorize: () => {
+        applyAuthorizationAttempts += 1;
+        if (applyAuthorizationAttempts === 2)
+          throw new Error('temporary outage');
+        return true;
+      },
+    });
+    const token = await previewToken(setup);
+    const applyRequest = request('apply', { confirmationToken: token });
+
+    await expect(
+      setup.adapter.apply(applyRequest, setup.context),
+    ).rejects.toThrow('temporary outage');
+    await expect(
+      setup.adapter.apply(applyRequest, setup.context),
+    ).resolves.toMatchObject({ ok: true, details: { accepted: 2 } });
+  });
+
+  it('accepts background work through the injected queue and rechecks on execution', async () => {
+    let queued: DataSurfaceBackgroundActionJob | undefined;
+    let releaseExecution: (() => void) | undefined;
+    const executionGate = new Promise<void>((resolve) => {
+      releaseExecution = resolve;
+    });
+    const applyRow = vi.fn(async (rowId: string | number) => {
+      if (rowId === 'one') await executionGate;
+    });
+    const setup = harness({
+      execution: 'background',
+      apply: applyRow,
+      enqueue: async (job) => {
+        queued = job;
+        return { jobId: 'job-1' };
+      },
+    });
+    const token = await previewToken(setup);
+    const accepted = await setup.adapter.apply(
+      request('apply', { confirmationToken: token }),
+      setup.context,
+    );
+
+    expect(accepted).toMatchObject({
+      ok: true,
+      details: { background: true, jobId: 'job-1', accepted: 2 },
+    });
+    expect(applyRow).not.toHaveBeenCalled();
+    expect(setup.calls).toHaveLength(2);
+
+    if (!queued) throw new Error('background job was not queued');
+    const firstDelivery = queued.run();
+    const concurrentDelivery = queued.run();
+    await vi.waitFor(() => expect(applyRow).toHaveBeenCalledTimes(1));
+    releaseExecution?.();
+    const [completed, concurrent] = await Promise.all([
+      firstDelivery,
+      concurrentDelivery,
+    ]);
+    const redelivery = await queued.run();
+    expect(completed).toMatchObject({ ok: true, details: { accepted: 2 } });
+    expect(concurrent).toEqual(completed);
+    expect(redelivery).toEqual(completed);
+    expect(applyRow).toHaveBeenCalledTimes(2);
+    expect(setup.calls).toHaveLength(3);
+  });
+});

--- a/packages/agents/src/server/data-surface-actions.test.ts
+++ b/packages/agents/src/server/data-surface-actions.test.ts
@@ -360,6 +360,25 @@ describe('data-surface action adapter', () => {
     });
   });
 
+  it('allows a required-confirmation retry with the same key after previewing', async () => {
+    const applyRow = vi.fn();
+    const setup = harness({ apply: applyRow });
+    const idempotencyKey = 'retry-after-preview';
+
+    await expect(
+      setup.adapter.apply(request('apply', { idempotencyKey }), setup.context),
+    ).resolves.toMatchObject({ ok: false, reason: 'confirmation_required' });
+
+    const token = await previewToken(setup);
+    await expect(
+      setup.adapter.apply(
+        request('apply', { confirmationToken: token, idempotencyKey }),
+        setup.context,
+      ),
+    ).resolves.toMatchObject({ ok: true, details: { accepted: 2 } });
+    expect(applyRow).toHaveBeenCalledTimes(2);
+  });
+
   it('replays a completed idempotent apply after its confirmation token expires', async () => {
     let now = 10;
     const applyRow = vi.fn();

--- a/packages/agents/src/server/data-surface-actions.test.ts
+++ b/packages/agents/src/server/data-surface-actions.test.ts
@@ -3,7 +3,7 @@ import type {
   DataSurfaceDescriptor,
   DataSurfaceIdentity,
   DataSurfaceSelectionReference,
-} from '@happyvertical/smrt-ui';
+} from '@happyvertical/smrt-ui/data';
 import { registerPermissionDefinitions } from '@happyvertical/smrt-users';
 import { describe, expect, it, vi } from 'vitest';
 import type {

--- a/packages/agents/src/server/data-surface-actions.test.ts
+++ b/packages/agents/src/server/data-surface-actions.test.ts
@@ -2,6 +2,7 @@ import type {
   DataSurfaceActionDescriptor,
   DataSurfaceDescriptor,
   DataSurfaceIdentity,
+  DataSurfaceSelectionReference,
 } from '@happyvertical/smrt-ui';
 import { registerPermissionDefinitions } from '@happyvertical/smrt-users';
 import { describe, expect, it, vi } from 'vitest';
@@ -74,8 +75,11 @@ function harness(options: {
   enqueue?: (job: DataSurfaceBackgroundActionJob) => Promise<{ jobId: string }>;
   state?: DataSurfaceActionStateStore;
   runAsPrincipal?: typeof executeAsPrincipal;
+  confirmation?: DataSurfaceServerActionDefinition['confirmation'];
+  surfaceIdentity?: DataSurfaceIdentity;
 }) {
   const calls: ExecuteAsPrincipalOptions[] = [];
+  const resolveSelectionCalls: DataSurfaceSelectionReference[] = [];
   const allowedTools = ['orders.archive'];
   const assertOperation = vi.fn();
   const run: PrincipalRun = {
@@ -96,7 +100,10 @@ function harness(options: {
     return fn(run);
   }) as typeof import('../execute-as-principal.js').executeAsPrincipal;
   const definition: DataSurfaceServerActionDefinition = {
-    descriptor: actionDescriptor,
+    descriptor: {
+      ...actionDescriptor,
+      requiresConfirmation: (options.confirmation ?? 'required') === 'required',
+    },
     inputSchema: { type: 'object', required: ['reason'] },
     validatePayload: (payload) =>
       payload === undefined ||
@@ -106,7 +113,7 @@ function harness(options: {
         typeof payload.reason === 'string')
         ? { valid: true }
         : { valid: false, reason: 'invalid_payload' },
-    confirmation: 'required',
+    confirmation: options.confirmation ?? 'required',
     execution: options.execution ?? 'foreground',
     tool: 'orders.archive',
     operation: {
@@ -128,19 +135,26 @@ function harness(options: {
     createToken: () => 'opaque-preview-token',
     runAsPrincipal: options.runAsPrincipal ?? runAsPrincipal,
     resolveSurface: async () => ({
-      descriptor,
+      descriptor: {
+        ...descriptor,
+        identity: options.surfaceIdentity ?? descriptor.identity,
+        actions: [definition.descriptor],
+      },
       revision: options.revision?.() ?? 7,
       actions: { archive: definition },
     }),
-    resolveSelection: async (_invocation, selection) => ({
-      revision: options.revision?.() ?? 7,
-      queryFingerprint: options.queryFingerprint?.() ?? 'query-v1',
-      rowIds:
-        options.rowIds?.() ??
-        (selection.scope === 'explicit-ids'
-          ? selection.rowIds
-          : ['one', 'two']),
-    }),
+    resolveSelection: async (_invocation, selection) => {
+      resolveSelectionCalls.push(selection);
+      return {
+        revision: options.revision?.() ?? 7,
+        queryFingerprint: options.queryFingerprint?.() ?? 'query-v1',
+        rowIds:
+          options.rowIds?.() ??
+          (selection.scope === 'explicit-ids'
+            ? selection.rowIds
+            : ['one', 'two']),
+      };
+    },
     ...(options.enqueue
       ? { backgroundQueue: { enqueue: options.enqueue } }
       : {}),
@@ -157,7 +171,7 @@ function harness(options: {
       audit: vi.fn(),
     },
   };
-  return { adapter, assertOperation, calls, context };
+  return { adapter, assertOperation, calls, context, resolveSelectionCalls };
 }
 
 async function previewToken(
@@ -298,11 +312,27 @@ describe('data-surface action adapter', () => {
     ).resolves.toMatchObject({ ok: false, reason: 'invalid_payload' });
   });
 
+  it('applies actions with confirmation:none without a preview token', async () => {
+    const applyRow = vi.fn();
+    const setup = harness({ confirmation: 'none', apply: applyRow });
+
+    const applied = await setup.adapter.apply(request('apply'), setup.context);
+
+    expect(applied).toMatchObject({
+      ok: true,
+      details: { accepted: 2, skipped: 0, failed: 0 },
+    });
+    expect(applyRow).toHaveBeenCalledTimes(2);
+  });
+
   it('rejects forged and expired confirmation tokens', async () => {
     let now = 10;
     const setup = harness({ now: () => now });
     await expect(
-      setup.adapter.apply(request('apply'), setup.context),
+      setup.adapter.apply(
+        request('apply', { idempotencyKey: 'missing-confirmation' }),
+        setup.context,
+      ),
     ).resolves.toMatchObject({
       ok: false,
       reason: 'confirmation_required',
@@ -328,6 +358,96 @@ describe('data-surface action adapter', () => {
       ok: false,
       reason: 'invalid_or_expired_confirmation',
     });
+  });
+
+  it('replays a completed idempotent apply after its confirmation token expires', async () => {
+    let now = 10;
+    const applyRow = vi.fn();
+    const setup = harness({ now: () => now, apply: applyRow });
+    const token = await previewToken(setup);
+    const applyRequest = request('apply', { confirmationToken: token });
+
+    const first = await setup.adapter.apply(applyRequest, setup.context);
+    now += 5 * 60 * 1_000;
+    const retry = await setup.adapter.apply(applyRequest, setup.context);
+
+    expect(first).toMatchObject({ ok: true, details: { accepted: 2 } });
+    expect(retry).toEqual(first);
+    expect(applyRow).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats reordered and duplicated explicit ids as equivalent for a confirmation-bound apply', async () => {
+    const applyRow = vi.fn();
+    const setup = harness({
+      apply: applyRow,
+    });
+    const previewSelection = {
+      scope: 'explicit-ids' as const,
+      rowIds: ['two', 'one', 'one'],
+    };
+    const preview = await setup.adapter.preview(
+      request('preview', { selection: previewSelection }),
+      setup.context,
+    );
+    expect(preview.ok).toBe(true);
+    if (!preview.confirmationToken) throw new Error('preview token missing');
+
+    const applied = await setup.adapter.apply(
+      request('apply', {
+        confirmationToken: preview.confirmationToken,
+        selection: { scope: 'explicit-ids', rowIds: ['one', 'two'] },
+      }),
+      setup.context,
+    );
+
+    expect(applied).toMatchObject({
+      ok: true,
+      details: { accepted: 2, skipped: 0, failed: 0 },
+    });
+    expect(applyRow).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not bind confirmation identity to a subject display label', async () => {
+    const previewIdentity: DataSurfaceIdentity = {
+      ...identity,
+      subject: { type: 'tenant', id: 'tenant-a', label: 'Orders A' },
+    };
+    const applyIdentity: DataSurfaceIdentity = {
+      ...identity,
+      subject: { type: 'tenant', id: 'tenant-a', label: 'Orders B' },
+    };
+    const setup = harness({ surfaceIdentity: previewIdentity });
+    const preview = await setup.adapter.preview(
+      request('preview', { identity: previewIdentity }),
+      setup.context,
+    );
+    expect(preview.ok).toBe(true);
+    if (!preview.confirmationToken) throw new Error('preview token missing');
+
+    const applied = await setup.adapter.apply(
+      request('apply', {
+        identity: applyIdentity,
+        confirmationToken: preview.confirmationToken,
+      }),
+      setup.context,
+    );
+
+    expect(applied).toMatchObject({ ok: true, details: { accepted: 2 } });
+  });
+
+  it('caps explicit ids before resolving the authoritative selection', async () => {
+    const setup = harness({});
+    const rowIds = Array.from({ length: 1_001 }, (_, index) => `row-${index}`);
+
+    const preview = await setup.adapter.preview(
+      request('preview', {
+        selection: { scope: 'explicit-ids', rowIds },
+      }),
+      setup.context,
+    );
+
+    expect(preview).toMatchObject({ ok: false, reason: 'invalid_request' });
+    expect(setup.resolveSelectionCalls).toHaveLength(0);
   });
 
   it('rechecks authorization, revision, query fingerprint, and resolved rows at apply', async () => {
@@ -438,6 +558,40 @@ describe('data-surface action adapter', () => {
       },
     });
     expect(JSON.stringify(applied)).not.toContain('sensitive internal failure');
+  });
+
+  it('persists a partial result when eligibility throws after an earlier mutation', async () => {
+    let applying = false;
+    const applyRow = vi.fn();
+    const setup = harness({
+      eligible: (rowId) => {
+        if (applying && rowId === 'two')
+          throw new Error('internal eligibility');
+        return { eligible: true };
+      },
+      apply: applyRow,
+    });
+    const token = await previewToken(setup);
+    applying = true;
+    const applyRequest = request('apply', { confirmationToken: token });
+
+    const first = await setup.adapter.apply(applyRequest, setup.context);
+    const retry = await setup.adapter.apply(applyRequest, setup.context);
+
+    expect(first).toMatchObject({
+      ok: true,
+      details: {
+        accepted: 1,
+        skipped: 0,
+        failed: 1,
+        outcomes: [
+          { rowId: 'one', status: 'accepted' },
+          { rowId: 'two', status: 'failed' },
+        ],
+      },
+    });
+    expect(retry).toEqual(first);
+    expect(applyRow).toHaveBeenCalledTimes(1);
   });
 
   it('replays identical idempotent applies and rejects token replay under a new key', async () => {

--- a/packages/agents/src/server/data-surface-actions.ts
+++ b/packages/agents/src/server/data-surface-actions.ts
@@ -17,7 +17,7 @@ import type {
   DataSurfaceJsonValue,
   DataSurfaceRowId,
   DataSurfaceSelectionReference,
-} from '@happyvertical/smrt-ui';
+} from '@happyvertical/smrt-ui/data';
 import {
   type ExecuteAsPrincipalOptions,
   executeAsPrincipal,

--- a/packages/agents/src/server/data-surface-actions.ts
+++ b/packages/agents/src/server/data-surface-actions.ts
@@ -593,10 +593,14 @@ export function createDataSurfaceActionAdapter(
       descriptor: surface.descriptor,
       action,
     };
-    const selection = await options.resolveSelection(
+    const resolvedSelection = await options.resolveSelection(
       base,
       canonicalSelection(request.selection),
     );
+    const selection = {
+      ...resolvedSelection,
+      rowIds: canonicalRowIds(resolvedSelection.rowIds),
+    };
     const invocation = { ...base, selection };
     if (!(await action.authorize(invocation))) {
       return result(request, false, 'denied');

--- a/packages/agents/src/server/data-surface-actions.ts
+++ b/packages/agents/src/server/data-surface-actions.ts
@@ -1,0 +1,884 @@
+/**
+ * Principal-bound preview/apply orchestration for data-surface actions.
+ *
+ * Browser state is treated only as an input hint. Every preview and apply is
+ * executed under the bound principal, resolves the surface and selection
+ * afresh, and delegates durable work only after authorization and eligibility
+ * checks have passed.
+ */
+import { createHash, randomBytes } from 'node:crypto';
+import type {
+  DataSurfaceActionDescriptor,
+  DataSurfaceActionRequest,
+  DataSurfaceActionResult,
+  DataSurfaceDescriptor,
+  DataSurfaceIdentity,
+  DataSurfaceJsonObject,
+  DataSurfaceJsonValue,
+  DataSurfaceRowId,
+  DataSurfaceSelectionReference,
+} from '@happyvertical/smrt-ui';
+import {
+  type ExecuteAsPrincipalOptions,
+  executeAsPrincipal,
+  type PrincipalRun,
+} from '../execute-as-principal.js';
+
+export type DataSurfaceConfirmationPolicy = 'required' | 'none';
+export type DataSurfaceActionExecution = 'foreground' | 'background';
+
+export interface DataSurfaceActionEligibility {
+  eligible: boolean;
+  reason?: string;
+}
+
+export type DataSurfaceActionPayloadValidation =
+  | { valid: true }
+  | { valid: false; reason?: string };
+
+export interface DataSurfaceActionRowOutcome {
+  rowId: DataSurfaceRowId;
+  status: 'accepted' | 'skipped' | 'failed';
+  reason?: string;
+}
+
+export interface ResolvedDataSurfaceSelection {
+  /** Fresh server-side revision of the selected surface/query. */
+  revision: number;
+  /** Canonical fingerprint of the frozen query represented by the selection. */
+  queryFingerprint: string;
+  /** Authoritatively resolved row ids. Browser-provided ids are only hints. */
+  rowIds: DataSurfaceRowId[];
+}
+
+export interface DataSurfaceActionInvocation {
+  run: PrincipalRun;
+  request: DataSurfaceServerActionRequest;
+  descriptor: DataSurfaceDescriptor;
+  action: DataSurfaceServerActionDefinition;
+  selection: ResolvedDataSurfaceSelection;
+}
+
+export interface DataSurfaceServerActionDefinition {
+  descriptor: DataSurfaceActionDescriptor;
+  /** Serializable declaration for transport/schema generators; null means no input. */
+  inputSchema: DataSurfaceJsonObject | null;
+  /** Runtime enforcement for the declared schema; absence is never permissive. */
+  validatePayload(
+    payload: DataSurfaceJsonValue | undefined,
+  ):
+    | DataSurfaceActionPayloadValidation
+    | Promise<DataSurfaceActionPayloadValidation>;
+  /** Explicit for every action, including sensitive/public/destructive ones. */
+  confirmation: DataSurfaceConfirmationPolicy;
+  execution: DataSurfaceActionExecution;
+  /** Fail-closed persona capability checked by PrincipalRun. */
+  tool: string;
+  /** Explicit RBAC catalog gate, enforced independently of callback convention. */
+  operation: {
+    id: string;
+    collection: Parameters<PrincipalRun['assertOperation']>[0];
+    action: string;
+  };
+  /** Fresh permission/domain authorization check, run for preview and apply. */
+  authorize(
+    invocation: DataSurfaceActionInvocation,
+  ): boolean | Promise<boolean>;
+  /** Fresh per-row domain precondition check, repeated at apply time. */
+  eligible(
+    invocation: DataSurfaceActionInvocation,
+    rowId: DataSurfaceRowId,
+  ): DataSurfaceActionEligibility | Promise<DataSurfaceActionEligibility>;
+  /** Foreground mutation. Background definitions are run by the injected queue. */
+  apply(
+    invocation: DataSurfaceActionInvocation,
+    rowId: DataSurfaceRowId,
+  ):
+    | undefined
+    | DataSurfaceJsonValue
+    | Promise<undefined | DataSurfaceJsonValue>;
+}
+
+export interface ResolvedDataSurfaceActions {
+  descriptor: DataSurfaceDescriptor;
+  /** Current server-side revision, never trusted from the browser. */
+  revision: number;
+  actions: Record<string, DataSurfaceServerActionDefinition>;
+}
+
+export interface DataSurfaceServerActionRequest
+  extends DataSurfaceActionRequest {
+  /** Required on apply and bound into the preview token. */
+  expectedRevision: number;
+  /** Required on apply. Identical retries replay the first terminal result. */
+  idempotencyKey?: string;
+}
+
+export interface DataSurfaceActionContext {
+  principal: ExecuteAsPrincipalOptions;
+}
+
+export interface DataSurfaceBackgroundActionJob {
+  idempotencyKey: string;
+  identity: DataSurfaceIdentity;
+  actionId: string;
+  rowIds: DataSurfaceRowId[];
+  /**
+   * The queue must call this task to perform the work. It re-enters the bound
+   * principal and repeats descriptor, authorization, selection, and eligibility
+   * checks before any mutation.
+   */
+  run: () => Promise<DataSurfaceActionResult>;
+}
+
+export interface DataSurfaceBackgroundQueue {
+  enqueue(
+    job: DataSurfaceBackgroundActionJob,
+  ): Promise<{ jobId: string; details?: DataSurfaceJsonObject }>;
+}
+
+export interface DataSurfacePreviewTokenRecord {
+  expiresAt: number;
+  actorUserId: string;
+  tenantId: string | null;
+  onBehalfOfUserId: string | null;
+  actsAsProfileId: string | null;
+  identityKey: string;
+  actionId: string;
+  actionFingerprint: string;
+  revision: number;
+  queryFingerprint: string;
+  selectionFingerprint: string;
+  resolvedRowsFingerprint: string;
+  requestFingerprint: string;
+  consumedBy?: string;
+}
+
+export type DataSurfaceIdempotencyRecord =
+  | {
+      status: 'reserved';
+      requestFingerprint: string;
+      ownerToken: string;
+      reservedAt: number;
+    }
+  | {
+      status: 'completed';
+      requestFingerprint: string;
+      result: DataSurfaceActionResult;
+    };
+
+export interface DataSurfaceIdempotencyReservation {
+  requestFingerprint: string;
+  ownerToken: string;
+  reservedAt: number;
+}
+
+export interface DataSurfaceActionStateStore {
+  putToken(
+    token: string,
+    record: DataSurfacePreviewTokenRecord,
+  ): Promise<void> | void;
+  getToken(
+    token: string,
+  ):
+    | Promise<DataSurfacePreviewTokenRecord | undefined>
+    | DataSurfacePreviewTokenRecord
+    | undefined;
+  markTokenConsumed(
+    token: string,
+    idempotencyKey: string,
+  ): Promise<boolean> | boolean;
+  getIdempotency(
+    key: string,
+  ):
+    | Promise<DataSurfaceIdempotencyRecord | undefined>
+    | DataSurfaceIdempotencyRecord
+    | undefined;
+  /** Atomically create a durable reservation or return the existing record. */
+  reserveIdempotency(
+    key: string,
+    reservation: DataSurfaceIdempotencyReservation,
+  ): Promise<DataSurfaceIdempotencyRecord> | DataSurfaceIdempotencyRecord;
+  completeIdempotency(
+    key: string,
+    ownerToken: string,
+    result: DataSurfaceActionResult,
+  ): Promise<boolean> | boolean;
+  releaseIdempotency(
+    key: string,
+    ownerToken: string,
+  ): Promise<boolean> | boolean;
+}
+
+/** Explicit single-process/testing store; production callers inject shared state. */
+export class InMemoryDataSurfaceActionStateStore
+  implements DataSurfaceActionStateStore
+{
+  private readonly tokens = new Map<string, DataSurfacePreviewTokenRecord>();
+  private readonly idempotency = new Map<
+    string,
+    DataSurfaceIdempotencyRecord
+  >();
+
+  putToken(token: string, record: DataSurfacePreviewTokenRecord): void {
+    this.tokens.set(token, record);
+  }
+
+  getToken(token: string): DataSurfacePreviewTokenRecord | undefined {
+    return this.tokens.get(token);
+  }
+
+  markTokenConsumed(token: string, idempotencyKey: string): boolean {
+    const record = this.tokens.get(token);
+    if (!record) return false;
+    if (record.consumedBy && record.consumedBy !== idempotencyKey) return false;
+    record.consumedBy = idempotencyKey;
+    return true;
+  }
+
+  getIdempotency(key: string): DataSurfaceIdempotencyRecord | undefined {
+    return this.idempotency.get(key);
+  }
+
+  reserveIdempotency(
+    key: string,
+    reservation: DataSurfaceIdempotencyReservation,
+  ): DataSurfaceIdempotencyRecord {
+    const existing = this.idempotency.get(key);
+    if (existing) return existing;
+    const record: DataSurfaceIdempotencyRecord = {
+      status: 'reserved',
+      ...reservation,
+    };
+    this.idempotency.set(key, record);
+    return record;
+  }
+
+  completeIdempotency(
+    key: string,
+    ownerToken: string,
+    result: DataSurfaceActionResult,
+  ): boolean {
+    const existing = this.idempotency.get(key);
+    if (existing?.status !== 'reserved' || existing.ownerToken !== ownerToken)
+      return false;
+    this.idempotency.set(key, {
+      status: 'completed',
+      requestFingerprint: existing.requestFingerprint,
+      result,
+    });
+    return true;
+  }
+
+  releaseIdempotency(key: string, ownerToken: string): boolean {
+    const existing = this.idempotency.get(key);
+    if (existing?.status !== 'reserved' || existing.ownerToken !== ownerToken)
+      return false;
+    return this.idempotency.delete(key);
+  }
+}
+
+export interface DataSurfaceActionAdapterOptions {
+  resolveSurface(
+    run: PrincipalRun,
+    identity: DataSurfaceIdentity,
+  ): Promise<ResolvedDataSurfaceActions>;
+  resolveSelection(
+    invocation: Omit<DataSurfaceActionInvocation, 'selection'>,
+    selection: DataSurfaceSelectionReference,
+  ): Promise<ResolvedDataSurfaceSelection>;
+  backgroundQueue?: DataSurfaceBackgroundQueue;
+  /** Required durable, shared backend in production; memory storage is opt-in. */
+  state: DataSurfaceActionStateStore;
+  tokenTtlMs?: number;
+  now?: () => number;
+  createToken?: () => string;
+  runAsPrincipal?: typeof executeAsPrincipal;
+  idempotencyPollIntervalMs?: number;
+  idempotencyWaitTimeoutMs?: number;
+}
+
+export interface DataSurfaceActionAdapter {
+  preview(
+    request: DataSurfaceServerActionRequest,
+    context: DataSurfaceActionContext,
+  ): Promise<DataSurfaceActionResult>;
+  apply(
+    request: DataSurfaceServerActionRequest,
+    context: DataSurfaceActionContext,
+  ): Promise<DataSurfaceActionResult>;
+}
+
+const DEFAULT_TOKEN_TTL_MS = 5 * 60 * 1_000;
+const MAX_IDENTIFIER_LENGTH = 256;
+const MAX_JSON_DEPTH = 16;
+const MAX_JSON_ITEMS = 1_000;
+const FORBIDDEN_JSON_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function isBoundedJsonValue(
+  value: unknown,
+  depth = 0,
+  seen = new Set<object>(),
+): value is DataSurfaceJsonValue {
+  if (value === null) return true;
+  if (['string', 'boolean'].includes(typeof value)) return true;
+  if (typeof value === 'number') return Number.isFinite(value);
+  if (typeof value !== 'object' || depth >= MAX_JSON_DEPTH || seen.has(value))
+    return false;
+  seen.add(value);
+  if (Array.isArray(value)) {
+    if (value.length > MAX_JSON_ITEMS) return false;
+    return value.every((item) => isBoundedJsonValue(item, depth + 1, seen));
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) return false;
+  const entries = Object.entries(value);
+  if (entries.length > MAX_JSON_ITEMS) return false;
+  return entries.every(
+    ([key, item]) =>
+      !FORBIDDEN_JSON_KEYS.has(key) &&
+      isBoundedJsonValue(item, depth + 1, seen),
+  );
+}
+
+function validIdentifier(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= MAX_IDENTIFIER_LENGTH
+  );
+}
+
+function validSelection(
+  selection: unknown,
+): selection is DataSurfaceSelectionReference {
+  if (!selection || typeof selection !== 'object') return false;
+  const candidate = selection as Record<string, unknown>;
+  if (candidate.scope === 'current-page') return true;
+  if (candidate.scope === 'all-matching')
+    return validIdentifier(candidate.queryFingerprint);
+  if (candidate.scope !== 'explicit-ids' || !Array.isArray(candidate.rowIds))
+    return false;
+  return candidate.rowIds.every(
+    (rowId) =>
+      (typeof rowId === 'string' && rowId.length > 0) ||
+      (typeof rowId === 'number' && Number.isFinite(rowId)),
+  );
+}
+
+function stable(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`;
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, item]) => `${JSON.stringify(key)}:${stable(item)}`)
+    .join(',')}}`;
+}
+
+function fingerprint(value: unknown): string {
+  return createHash('sha256').update(stable(value)).digest('hex');
+}
+
+function identityKey(identity: DataSurfaceIdentity): string {
+  return stable(identity);
+}
+
+function actionFingerprint(action: DataSurfaceServerActionDefinition): string {
+  return fingerprint({
+    descriptor: action.descriptor,
+    inputSchema: action.inputSchema,
+    confirmation: action.confirmation,
+    execution: action.execution,
+    tool: action.tool,
+    operationId: action.operation.id,
+    operationCollection: action.operation.collection,
+    operationAction: action.operation.action,
+  });
+}
+
+function result(
+  request: DataSurfaceServerActionRequest,
+  ok: boolean,
+  reason?: string,
+  details?: DataSurfaceJsonObject,
+  confirmationToken?: string,
+): DataSurfaceActionResult {
+  return {
+    version: 1,
+    requestId: request.requestId,
+    identity: request.identity,
+    actionId: request.actionId,
+    phase: request.phase,
+    ok,
+    ...(reason ? { reason } : {}),
+    ...(details ? { details } : {}),
+    ...(confirmationToken ? { confirmationToken } : {}),
+  };
+}
+
+function outcomesDetails(
+  outcomes: DataSurfaceActionRowOutcome[],
+  extra: DataSurfaceJsonObject = {},
+): DataSurfaceJsonObject {
+  const accepted = outcomes.filter(
+    ({ status }) => status === 'accepted',
+  ).length;
+  const skipped = outcomes.filter(({ status }) => status === 'skipped').length;
+  const failed = outcomes.filter(({ status }) => status === 'failed').length;
+  return {
+    accepted,
+    skipped,
+    failed,
+    outcomes: outcomes.map(({ rowId, status, reason }) => ({
+      rowId,
+      status,
+      ...(reason ? { reason } : {}),
+    })),
+    ...extra,
+  };
+}
+
+function validateRequest(
+  request: DataSurfaceServerActionRequest,
+  phase: 'preview' | 'apply',
+): string | undefined {
+  if (!request || typeof request !== 'object') return 'invalid_request';
+  if (request.version !== 1 || request.phase !== phase)
+    return 'invalid_request';
+  if (
+    !validIdentifier(request.requestId) ||
+    !validIdentifier(request.actionId) ||
+    !validIdentifier(request.identity?.surfaceId) ||
+    !['table', 'list', 'report', 'custom'].includes(request.identity?.kind) ||
+    !validSelection(request.selection) ||
+    (request.payload !== undefined && !isBoundedJsonValue(request.payload))
+  )
+    return 'invalid_request';
+  if (
+    !Number.isSafeInteger(request.expectedRevision) ||
+    request.expectedRevision < 0
+  )
+    return 'invalid_request';
+  if (
+    phase === 'apply' &&
+    (!validIdentifier(request.idempotencyKey) ||
+      !validIdentifier(request.confirmationToken))
+  )
+    return 'confirmation_required';
+  return undefined;
+}
+
+/** Create a transport-neutral, principal-bound data-surface action adapter. */
+export function createDataSurfaceActionAdapter(
+  options: DataSurfaceActionAdapterOptions,
+): DataSurfaceActionAdapter {
+  const state = options.state;
+  const now = options.now ?? Date.now;
+  const createToken =
+    options.createToken ?? (() => randomBytes(32).toString('base64url'));
+  const tokenTtlMs = options.tokenTtlMs ?? DEFAULT_TOKEN_TTL_MS;
+  const runAsPrincipal = options.runAsPrincipal ?? executeAsPrincipal;
+  const idempotencyPollIntervalMs = Math.max(
+    1,
+    options.idempotencyPollIntervalMs ?? 10,
+  );
+  const idempotencyWaitTimeoutMs = Math.max(
+    0,
+    options.idempotencyWaitTimeoutMs ?? 5_000,
+  );
+
+  async function resolveInvocation(
+    request: DataSurfaceServerActionRequest,
+    run: PrincipalRun,
+  ): Promise<DataSurfaceActionInvocation | DataSurfaceActionResult> {
+    const surface = await options.resolveSurface(run, request.identity);
+    if (
+      identityKey(surface.descriptor.identity) !== identityKey(request.identity)
+    ) {
+      return result(request, false, 'not_found');
+    }
+    const action = surface.actions[request.actionId];
+    const declared = surface.descriptor.actions.find(
+      ({ id }) => id === request.actionId,
+    );
+    if (
+      !action ||
+      !declared ||
+      action.descriptor.id !== declared.id ||
+      Boolean(declared.requiresConfirmation) !==
+        (action.confirmation === 'required')
+    ) {
+      return result(request, false, 'unsupported');
+    }
+    if (
+      !action.tool ||
+      !validIdentifier(action.operation?.id) ||
+      !validIdentifier(action.operation?.action)
+    )
+      return result(request, false, 'denied');
+    run.assertToolAllowed(action.tool);
+    await run.assertOperation(
+      action.operation.collection,
+      action.operation.action,
+    );
+    const payloadValidation = await action.validatePayload(request.payload);
+    if (!payloadValidation.valid)
+      return result(
+        request,
+        false,
+        payloadValidation.reason ?? 'invalid_payload',
+      );
+    if (!action.descriptor.selectionScopes.includes(request.selection.scope)) {
+      return result(request, false, 'selection_not_supported');
+    }
+    const base = {
+      run,
+      request,
+      descriptor: surface.descriptor,
+      action,
+    };
+    const selection = await options.resolveSelection(base, request.selection);
+    const invocation = { ...base, selection };
+    if (!(await action.authorize(invocation))) {
+      return result(request, false, 'denied');
+    }
+    if (selection.rowIds.length > surface.descriptor.limits.maxSelectionSize) {
+      return result(request, false, 'limit_exceeded');
+    }
+    return invocation;
+  }
+
+  async function preview(
+    request: DataSurfaceServerActionRequest,
+    context: DataSurfaceActionContext,
+  ): Promise<DataSurfaceActionResult> {
+    const invalid = validateRequest(request, 'preview');
+    if (invalid) return result(request, false, invalid);
+    return runAsPrincipal(
+      {
+        ...context.principal,
+        action: 'data_surface.action.preview',
+        auditMetadata: {
+          ...context.principal.auditMetadata,
+          surfaceId: request.identity.surfaceId,
+          actionId: request.actionId,
+          requestId: request.requestId,
+        },
+      },
+      async (run) => {
+        const invocation = await resolveInvocation(request, run);
+        if ('ok' in invocation) return invocation;
+        if (invocation.selection.revision !== request.expectedRevision) {
+          return result(request, false, 'stale_revision');
+        }
+        const outcomes: DataSurfaceActionRowOutcome[] = [];
+        for (const rowId of invocation.selection.rowIds) {
+          const eligibility = await invocation.action.eligible(
+            invocation,
+            rowId,
+          );
+          outcomes.push({
+            rowId,
+            status: eligibility.eligible ? 'accepted' : 'skipped',
+            ...(eligibility.reason ? { reason: eligibility.reason } : {}),
+          });
+        }
+        const confirmationToken = createToken();
+        const selectionFingerprint = fingerprint(request.selection);
+        const requestFingerprint = fingerprint({
+          identity: request.identity,
+          actionId: request.actionId,
+          selection: request.selection,
+          payload: request.payload,
+          expectedRevision: request.expectedRevision,
+        });
+        const expiresAt = now() + tokenTtlMs;
+        await state.putToken(confirmationToken, {
+          expiresAt,
+          actorUserId: context.principal.principal.runAsUserId,
+          tenantId: context.principal.principal.tenantId,
+          onBehalfOfUserId: context.principal.onBehalfOfUserId ?? null,
+          actsAsProfileId: context.principal.principal.actsAsProfileId ?? null,
+          identityKey: identityKey(request.identity),
+          actionId: request.actionId,
+          actionFingerprint: actionFingerprint(invocation.action),
+          revision: invocation.selection.revision,
+          queryFingerprint: invocation.selection.queryFingerprint,
+          selectionFingerprint,
+          resolvedRowsFingerprint: fingerprint(invocation.selection.rowIds),
+          requestFingerprint,
+        });
+        return result(
+          request,
+          true,
+          undefined,
+          outcomesDetails(outcomes, {
+            count: invocation.selection.rowIds.length,
+            revision: invocation.selection.revision,
+            queryFingerprint: invocation.selection.queryFingerprint,
+            expiresAt,
+          }),
+          confirmationToken,
+        );
+      },
+    );
+  }
+
+  async function executeForeground(
+    request: DataSurfaceServerActionRequest,
+    invocation: DataSurfaceActionInvocation,
+  ): Promise<DataSurfaceActionResult> {
+    const outcomes: DataSurfaceActionRowOutcome[] = [];
+    for (const rowId of invocation.selection.rowIds) {
+      const eligibility = await invocation.action.eligible(invocation, rowId);
+      if (!eligibility.eligible) {
+        outcomes.push({ rowId, status: 'skipped', reason: eligibility.reason });
+        continue;
+      }
+      try {
+        await invocation.action.apply(invocation, rowId);
+        outcomes.push({ rowId, status: 'accepted' });
+      } catch {
+        outcomes.push({
+          rowId,
+          status: 'failed',
+          reason: 'execution_failed',
+        });
+      }
+    }
+    return result(request, true, undefined, outcomesDetails(outcomes));
+  }
+
+  async function executeBackgroundOnce(
+    request: DataSurfaceServerActionRequest,
+    context: DataSurfaceActionContext,
+    token: DataSurfacePreviewTokenRecord,
+  ): Promise<DataSurfaceActionResult> {
+    const ownerToken = randomBytes(16).toString('base64url');
+    const executionFingerprint = fingerprint({
+      kind: 'background-execution',
+      request: token.requestFingerprint,
+      action: token.actionFingerprint,
+    });
+    const executionScope = fingerprint({
+      kind: 'background-execution',
+      actorUserId: token.actorUserId,
+      tenantId: token.tenantId,
+      onBehalfOfUserId: token.onBehalfOfUserId,
+      actsAsProfileId: token.actsAsProfileId,
+      identity: request.identity,
+      actionId: request.actionId,
+      idempotencyKey: request.idempotencyKey,
+    });
+    const maxPolls = Math.max(
+      1,
+      Math.ceil(idempotencyWaitTimeoutMs / idempotencyPollIntervalMs),
+    );
+    for (let poll = 0; poll <= maxPolls; poll += 1) {
+      const winner = await state.reserveIdempotency(executionScope, {
+        requestFingerprint: executionFingerprint,
+        ownerToken,
+        reservedAt: now(),
+      });
+      if (winner.requestFingerprint !== executionFingerprint)
+        return result(request, false, 'idempotency_conflict');
+      if (winner.status === 'completed') return winner.result;
+      if (winner.ownerToken === ownerToken) {
+        let executed: DataSurfaceActionResult;
+        try {
+          executed = await authorizedApply(request, context, token, false);
+        } catch (error) {
+          await state.releaseIdempotency(executionScope, ownerToken);
+          throw error;
+        }
+        if (
+          !(await state.completeIdempotency(
+            executionScope,
+            ownerToken,
+            executed,
+          ))
+        ) {
+          throw new Error('Lost background action idempotency reservation');
+        }
+        return executed;
+      }
+      if (poll < maxPolls) {
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, idempotencyPollIntervalMs),
+        );
+        const current = await state.getIdempotency(executionScope);
+        if (current?.status === 'completed') return current.result;
+      }
+    }
+    return result(request, false, 'idempotency_in_progress');
+  }
+
+  async function authorizedApply(
+    request: DataSurfaceServerActionRequest,
+    context: DataSurfaceActionContext,
+    token: DataSurfacePreviewTokenRecord,
+    allowBackground: boolean,
+  ): Promise<DataSurfaceActionResult> {
+    const idempotencyKey = request.idempotencyKey;
+    if (!idempotencyKey) return result(request, false, 'invalid_request');
+    return runAsPrincipal(
+      {
+        ...context.principal,
+        action: 'data_surface.action.apply',
+        auditMetadata: {
+          ...context.principal.auditMetadata,
+          surfaceId: request.identity.surfaceId,
+          actionId: request.actionId,
+          requestId: request.requestId,
+          idempotencyKey: request.idempotencyKey,
+        },
+      },
+      async (run) => {
+        const invocation = await resolveInvocation(request, run);
+        if ('ok' in invocation) return invocation;
+        if (
+          invocation.selection.revision !== token.revision ||
+          invocation.selection.revision !== request.expectedRevision ||
+          invocation.selection.queryFingerprint !== token.queryFingerprint ||
+          fingerprint(request.selection) !== token.selectionFingerprint ||
+          actionFingerprint(invocation.action) !== token.actionFingerprint ||
+          fingerprint(invocation.selection.rowIds) !==
+            token.resolvedRowsFingerprint
+        ) {
+          return result(request, false, 'stale_preview');
+        }
+        if (
+          invocation.action.confirmation === 'required' &&
+          !request.confirmationToken
+        ) {
+          return result(request, false, 'confirmation_required');
+        }
+        if (invocation.action.execution === 'background' && allowBackground) {
+          if (!options.backgroundQueue) {
+            return result(request, false, 'background_unavailable');
+          }
+          const queued = await options.backgroundQueue.enqueue({
+            idempotencyKey,
+            identity: request.identity,
+            actionId: request.actionId,
+            rowIds: invocation.selection.rowIds,
+            run: () => executeBackgroundOnce(request, context, token),
+          });
+          return result(request, true, undefined, {
+            accepted: invocation.selection.rowIds.length,
+            skipped: 0,
+            failed: 0,
+            background: true,
+            jobId: queued.jobId,
+            ...(queued.details ?? {}),
+          });
+        }
+        return executeForeground(request, invocation);
+      },
+    );
+  }
+
+  async function apply(
+    request: DataSurfaceServerActionRequest,
+    context: DataSurfaceActionContext,
+  ): Promise<DataSurfaceActionResult> {
+    const invalid = validateRequest(request, 'apply');
+    if (invalid) return result(request, false, invalid);
+    const confirmationToken = request.confirmationToken;
+    const idempotencyKey = request.idempotencyKey;
+    if (!confirmationToken || !idempotencyKey)
+      return result(request, false, 'invalid_request');
+    const token = await state.getToken(confirmationToken);
+    if (!token || token.expiresAt <= now()) {
+      return result(request, false, 'invalid_or_expired_confirmation');
+    }
+    const actorUserId = context.principal.principal.runAsUserId;
+    const tenantId = context.principal.principal.tenantId;
+    const onBehalfOfUserId = context.principal.onBehalfOfUserId ?? null;
+    const actsAsProfileId = context.principal.principal.actsAsProfileId ?? null;
+    const requestFingerprint = fingerprint({
+      identity: request.identity,
+      actionId: request.actionId,
+      selection: request.selection,
+      payload: request.payload,
+      expectedRevision: request.expectedRevision,
+    });
+    if (
+      token.actorUserId !== actorUserId ||
+      token.tenantId !== tenantId ||
+      token.onBehalfOfUserId !== onBehalfOfUserId ||
+      token.actsAsProfileId !== actsAsProfileId ||
+      token.identityKey !== identityKey(request.identity) ||
+      token.actionId !== request.actionId
+    ) {
+      return result(request, false, 'confirmation_mismatch');
+    }
+    const idempotencyScope = fingerprint({
+      actorUserId,
+      tenantId,
+      onBehalfOfUserId,
+      actsAsProfileId,
+      identity: request.identity,
+      actionId: request.actionId,
+      idempotencyKey: request.idempotencyKey,
+    });
+    const prior = await state.getIdempotency(idempotencyScope);
+    if (prior && prior.requestFingerprint !== requestFingerprint)
+      return result(request, false, 'idempotency_conflict');
+    if (token.requestFingerprint !== requestFingerprint) {
+      return result(request, false, 'confirmation_mismatch');
+    }
+    if (!(await state.markTokenConsumed(confirmationToken, idempotencyKey))) {
+      return result(request, false, 'confirmation_replayed');
+    }
+    // Ownership is an internal compare-and-set nonce. Keep it independent of
+    // the injectable preview-token factory, which tests or callers may make
+    // deterministic without weakening concurrent winner selection.
+    const ownerToken = randomBytes(16).toString('base64url');
+    const maxPolls = Math.max(
+      1,
+      Math.ceil(idempotencyWaitTimeoutMs / idempotencyPollIntervalMs),
+    );
+    for (let poll = 0; poll <= maxPolls; poll += 1) {
+      const winner = await state.reserveIdempotency(idempotencyScope, {
+        requestFingerprint,
+        ownerToken,
+        reservedAt: now(),
+      });
+      if (winner.requestFingerprint !== requestFingerprint)
+        return result(request, false, 'idempotency_conflict');
+      if (winner.status === 'completed') return winner.result;
+      if (winner.ownerToken === ownerToken) {
+        let applied: DataSurfaceActionResult;
+        try {
+          applied = await authorizedApply(request, context, token, true);
+        } catch (error) {
+          await state.releaseIdempotency(idempotencyScope, ownerToken);
+          throw error;
+        }
+        // Once execution returns, never release on a persistence failure: a
+        // durable reservation is safer than allowing duplicate side effects.
+        if (
+          !(await state.completeIdempotency(
+            idempotencyScope,
+            ownerToken,
+            applied,
+          ))
+        ) {
+          throw new Error('Lost data-surface idempotency reservation');
+        }
+        return applied;
+      }
+      if (poll < maxPolls) {
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, idempotencyPollIntervalMs),
+        );
+        const current = await state.getIdempotency(idempotencyScope);
+        if (current?.status === 'completed') return current.result;
+      }
+    }
+    return result(request, false, 'idempotency_in_progress');
+  }
+
+  return { preview, apply };
+}

--- a/packages/agents/src/server/data-surface-actions.ts
+++ b/packages/agents/src/server/data-surface-actions.ts
@@ -359,6 +359,7 @@ function validSelection(
     return validIdentifier(candidate.queryFingerprint);
   if (candidate.scope !== 'explicit-ids' || !Array.isArray(candidate.rowIds))
     return false;
+  if (candidate.rowIds.length > MAX_JSON_ITEMS) return false;
   return candidate.rowIds.every(
     (rowId) =>
       (typeof rowId === 'string' && rowId.length > 0) ||
@@ -370,7 +371,7 @@ function stable(value: unknown): string {
   if (value === null || typeof value !== 'object') return JSON.stringify(value);
   if (Array.isArray(value)) return `[${value.map(stable).join(',')}]`;
   return `{${Object.entries(value as Record<string, unknown>)
-    .sort(([left], [right]) => left.localeCompare(right))
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
     .map(([key, item]) => `${JSON.stringify(key)}:${stable(item)}`)
     .join(',')}}`;
 }
@@ -380,7 +381,61 @@ function fingerprint(value: unknown): string {
 }
 
 function identityKey(identity: DataSurfaceIdentity): string {
-  return stable(identity);
+  return stable(canonicalIdentity(identity));
+}
+
+function canonicalIdentity(identity: DataSurfaceIdentity): DataSurfaceIdentity {
+  return {
+    kind: identity.kind,
+    surfaceId: identity.surfaceId,
+    ...(identity.subject
+      ? {
+          subject: {
+            type: identity.subject.type,
+            id: identity.subject.id,
+          },
+        }
+      : {}),
+  };
+}
+
+function rowIdKey(rowId: DataSurfaceRowId): string {
+  return `${typeof rowId}:${String(rowId)}`;
+}
+
+function compareRowIds(
+  left: DataSurfaceRowId,
+  right: DataSurfaceRowId,
+): number {
+  if (typeof left !== typeof right) return typeof left === 'number' ? -1 : 1;
+  if (typeof left === 'number' && typeof right === 'number')
+    return left - right;
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function canonicalRowIds(
+  rowIds: readonly DataSurfaceRowId[],
+): DataSurfaceRowId[] {
+  const ids = new Map<string, DataSurfaceRowId>();
+  for (const rowId of rowIds) ids.set(rowIdKey(rowId), rowId);
+  return [...ids.values()].sort(compareRowIds);
+}
+
+function canonicalSelection(
+  selection: DataSurfaceSelectionReference,
+): DataSurfaceSelectionReference {
+  if (selection.scope !== 'explicit-ids') return selection;
+  return { scope: selection.scope, rowIds: canonicalRowIds(selection.rowIds) };
+}
+
+function requestFingerprint(request: DataSurfaceServerActionRequest): string {
+  return fingerprint({
+    identity: canonicalIdentity(request.identity),
+    actionId: request.actionId,
+    selection: canonicalSelection(request.selection),
+    payload: request.payload,
+    expectedRevision: request.expectedRevision,
+  });
 }
 
 function actionFingerprint(action: DataSurfaceServerActionDefinition): string {
@@ -462,9 +517,10 @@ function validateRequest(
   if (
     phase === 'apply' &&
     (!validIdentifier(request.idempotencyKey) ||
-      !validIdentifier(request.confirmationToken))
+      (request.confirmationToken !== undefined &&
+        !validIdentifier(request.confirmationToken)))
   )
-    return 'confirmation_required';
+    return 'invalid_request';
   return undefined;
 }
 
@@ -537,7 +593,10 @@ export function createDataSurfaceActionAdapter(
       descriptor: surface.descriptor,
       action,
     };
-    const selection = await options.resolveSelection(base, request.selection);
+    const selection = await options.resolveSelection(
+      base,
+      canonicalSelection(request.selection),
+    );
     const invocation = { ...base, selection };
     if (!(await action.authorize(invocation))) {
       return result(request, false, 'denied');
@@ -584,14 +643,10 @@ export function createDataSurfaceActionAdapter(
           });
         }
         const confirmationToken = createToken();
-        const selectionFingerprint = fingerprint(request.selection);
-        const requestFingerprint = fingerprint({
-          identity: request.identity,
-          actionId: request.actionId,
-          selection: request.selection,
-          payload: request.payload,
-          expectedRevision: request.expectedRevision,
-        });
+        const selectionFingerprint = fingerprint(
+          canonicalSelection(request.selection),
+        );
+        const requestFingerprintValue = requestFingerprint(request);
         const expiresAt = now() + tokenTtlMs;
         await state.putToken(confirmationToken, {
           expiresAt,
@@ -605,8 +660,10 @@ export function createDataSurfaceActionAdapter(
           revision: invocation.selection.revision,
           queryFingerprint: invocation.selection.queryFingerprint,
           selectionFingerprint,
-          resolvedRowsFingerprint: fingerprint(invocation.selection.rowIds),
-          requestFingerprint,
+          resolvedRowsFingerprint: fingerprint(
+            canonicalRowIds(invocation.selection.rowIds),
+          ),
+          requestFingerprint: requestFingerprintValue,
         });
         return result(
           request,
@@ -630,12 +687,16 @@ export function createDataSurfaceActionAdapter(
   ): Promise<DataSurfaceActionResult> {
     const outcomes: DataSurfaceActionRowOutcome[] = [];
     for (const rowId of invocation.selection.rowIds) {
-      const eligibility = await invocation.action.eligible(invocation, rowId);
-      if (!eligibility.eligible) {
-        outcomes.push({ rowId, status: 'skipped', reason: eligibility.reason });
-        continue;
-      }
       try {
+        const eligibility = await invocation.action.eligible(invocation, rowId);
+        if (!eligibility.eligible) {
+          outcomes.push({
+            rowId,
+            status: 'skipped',
+            ...(eligibility.reason ? { reason: eligibility.reason } : {}),
+          });
+          continue;
+        }
         await invocation.action.apply(invocation, rowId);
         outcomes.push({ rowId, status: 'accepted' });
       } catch {
@@ -652,21 +713,26 @@ export function createDataSurfaceActionAdapter(
   async function executeBackgroundOnce(
     request: DataSurfaceServerActionRequest,
     context: DataSurfaceActionContext,
-    token: DataSurfacePreviewTokenRecord,
+    token: DataSurfacePreviewTokenRecord | undefined,
   ): Promise<DataSurfaceActionResult> {
     const ownerToken = randomBytes(16).toString('base64url');
     const executionFingerprint = fingerprint({
       kind: 'background-execution',
-      request: token.requestFingerprint,
-      action: token.actionFingerprint,
+      request: token?.requestFingerprint ?? requestFingerprint(request),
+      action: token?.actionFingerprint ?? request.actionId,
     });
     const executionScope = fingerprint({
       kind: 'background-execution',
-      actorUserId: token.actorUserId,
-      tenantId: token.tenantId,
-      onBehalfOfUserId: token.onBehalfOfUserId,
-      actsAsProfileId: token.actsAsProfileId,
-      identity: request.identity,
+      actorUserId:
+        token?.actorUserId ?? context.principal.principal.runAsUserId,
+      tenantId: token?.tenantId ?? context.principal.principal.tenantId,
+      onBehalfOfUserId:
+        token?.onBehalfOfUserId ?? context.principal.onBehalfOfUserId ?? null,
+      actsAsProfileId:
+        token?.actsAsProfileId ??
+        context.principal.principal.actsAsProfileId ??
+        null,
+      identity: canonicalIdentity(request.identity),
       actionId: request.actionId,
       idempotencyKey: request.idempotencyKey,
     });
@@ -716,7 +782,7 @@ export function createDataSurfaceActionAdapter(
   async function authorizedApply(
     request: DataSurfaceServerActionRequest,
     context: DataSurfaceActionContext,
-    token: DataSurfacePreviewTokenRecord,
+    token: DataSurfacePreviewTokenRecord | undefined,
     allowBackground: boolean,
   ): Promise<DataSurfaceActionResult> {
     const idempotencyKey = request.idempotencyKey;
@@ -736,22 +802,23 @@ export function createDataSurfaceActionAdapter(
       async (run) => {
         const invocation = await resolveInvocation(request, run);
         if ('ok' in invocation) return invocation;
-        if (
-          invocation.selection.revision !== token.revision ||
-          invocation.selection.revision !== request.expectedRevision ||
-          invocation.selection.queryFingerprint !== token.queryFingerprint ||
-          fingerprint(request.selection) !== token.selectionFingerprint ||
-          actionFingerprint(invocation.action) !== token.actionFingerprint ||
-          fingerprint(invocation.selection.rowIds) !==
-            token.resolvedRowsFingerprint
-        ) {
-          return result(request, false, 'stale_preview');
-        }
-        if (
-          invocation.action.confirmation === 'required' &&
-          !request.confirmationToken
-        ) {
+        if (token) {
+          if (
+            invocation.selection.revision !== token.revision ||
+            invocation.selection.revision !== request.expectedRevision ||
+            invocation.selection.queryFingerprint !== token.queryFingerprint ||
+            fingerprint(canonicalSelection(request.selection)) !==
+              token.selectionFingerprint ||
+            actionFingerprint(invocation.action) !== token.actionFingerprint ||
+            fingerprint(canonicalRowIds(invocation.selection.rowIds)) !==
+              token.resolvedRowsFingerprint
+          ) {
+            return result(request, false, 'stale_preview');
+          }
+        } else if (invocation.action.confirmation === 'required') {
           return result(request, false, 'confirmation_required');
+        } else if (invocation.selection.revision !== request.expectedRevision) {
+          return result(request, false, 'stale_revision');
         }
         if (invocation.action.execution === 'background' && allowBackground) {
           if (!options.backgroundQueue) {
@@ -786,50 +853,48 @@ export function createDataSurfaceActionAdapter(
     if (invalid) return result(request, false, invalid);
     const confirmationToken = request.confirmationToken;
     const idempotencyKey = request.idempotencyKey;
-    if (!confirmationToken || !idempotencyKey)
-      return result(request, false, 'invalid_request');
-    const token = await state.getToken(confirmationToken);
-    if (!token || token.expiresAt <= now()) {
-      return result(request, false, 'invalid_or_expired_confirmation');
-    }
+    if (!idempotencyKey) return result(request, false, 'invalid_request');
     const actorUserId = context.principal.principal.runAsUserId;
     const tenantId = context.principal.principal.tenantId;
     const onBehalfOfUserId = context.principal.onBehalfOfUserId ?? null;
     const actsAsProfileId = context.principal.principal.actsAsProfileId ?? null;
-    const requestFingerprint = fingerprint({
-      identity: request.identity,
-      actionId: request.actionId,
-      selection: request.selection,
-      payload: request.payload,
-      expectedRevision: request.expectedRevision,
-    });
-    if (
-      token.actorUserId !== actorUserId ||
-      token.tenantId !== tenantId ||
-      token.onBehalfOfUserId !== onBehalfOfUserId ||
-      token.actsAsProfileId !== actsAsProfileId ||
-      token.identityKey !== identityKey(request.identity) ||
-      token.actionId !== request.actionId
-    ) {
-      return result(request, false, 'confirmation_mismatch');
-    }
+    const requestFingerprintValue = requestFingerprint(request);
     const idempotencyScope = fingerprint({
       actorUserId,
       tenantId,
       onBehalfOfUserId,
       actsAsProfileId,
-      identity: request.identity,
+      identity: canonicalIdentity(request.identity),
       actionId: request.actionId,
-      idempotencyKey: request.idempotencyKey,
+      idempotencyKey,
     });
     const prior = await state.getIdempotency(idempotencyScope);
-    if (prior && prior.requestFingerprint !== requestFingerprint)
+    if (prior && prior.requestFingerprint !== requestFingerprintValue)
       return result(request, false, 'idempotency_conflict');
-    if (token.requestFingerprint !== requestFingerprint) {
-      return result(request, false, 'confirmation_mismatch');
-    }
-    if (!(await state.markTokenConsumed(confirmationToken, idempotencyKey))) {
-      return result(request, false, 'confirmation_replayed');
+    // A completed durable result is safe to replay from its actor/tenant-bound
+    // idempotency scope even when the one-time confirmation has expired.
+    if (prior?.status === 'completed') return prior.result;
+
+    let token: DataSurfacePreviewTokenRecord | undefined;
+    if (confirmationToken) {
+      token = await state.getToken(confirmationToken);
+      if (!token || token.expiresAt <= now()) {
+        return result(request, false, 'invalid_or_expired_confirmation');
+      }
+      if (
+        token.actorUserId !== actorUserId ||
+        token.tenantId !== tenantId ||
+        token.onBehalfOfUserId !== onBehalfOfUserId ||
+        token.actsAsProfileId !== actsAsProfileId ||
+        token.identityKey !== identityKey(request.identity) ||
+        token.actionId !== request.actionId ||
+        token.requestFingerprint !== requestFingerprintValue
+      ) {
+        return result(request, false, 'confirmation_mismatch');
+      }
+      if (!(await state.markTokenConsumed(confirmationToken, idempotencyKey))) {
+        return result(request, false, 'confirmation_replayed');
+      }
     }
     // Ownership is an internal compare-and-set nonce. Keep it independent of
     // the injectable preview-token factory, which tests or callers may make
@@ -841,11 +906,11 @@ export function createDataSurfaceActionAdapter(
     );
     for (let poll = 0; poll <= maxPolls; poll += 1) {
       const winner = await state.reserveIdempotency(idempotencyScope, {
-        requestFingerprint,
+        requestFingerprint: requestFingerprintValue,
         ownerToken,
         reservedAt: now(),
       });
-      if (winner.requestFingerprint !== requestFingerprint)
+      if (winner.requestFingerprint !== requestFingerprintValue)
         return result(request, false, 'idempotency_conflict');
       if (winner.status === 'completed') return winner.result;
       if (winner.ownerToken === ownerToken) {

--- a/packages/agents/src/server/data-surface-actions.ts
+++ b/packages/agents/src/server/data-surface-actions.ts
@@ -921,6 +921,13 @@ export function createDataSurfaceActionAdapter(
           await state.releaseIdempotency(idempotencyScope, ownerToken);
           throw error;
         }
+        // A confirmation-required request without a token is a recoverable
+        // precondition failure. Do not consume its idempotency key: the caller
+        // may preview and retry with the same key.
+        if (!applied.ok && applied.reason === 'confirmation_required') {
+          await state.releaseIdempotency(idempotencyScope, ownerToken);
+          return applied;
+        }
         // Once execution returns, never release on a persistence failure: a
         // durable reservation is safer than allowing duplicate side effects.
         if (

--- a/packages/agents/src/server/index.ts
+++ b/packages/agents/src/server/index.ts
@@ -40,6 +40,28 @@ export {
 } from './api-routes.js';
 export { loadSlotConfigs } from './config-loader.js';
 export {
+  createDataSurfaceActionAdapter,
+  type DataSurfaceActionAdapter,
+  type DataSurfaceActionAdapterOptions,
+  type DataSurfaceActionContext as DataSurfaceServerActionContext,
+  type DataSurfaceActionEligibility,
+  type DataSurfaceActionExecution,
+  type DataSurfaceActionPayloadValidation,
+  type DataSurfaceActionRowOutcome,
+  type DataSurfaceActionStateStore,
+  type DataSurfaceBackgroundActionJob,
+  type DataSurfaceBackgroundQueue,
+  type DataSurfaceConfirmationPolicy,
+  type DataSurfaceIdempotencyRecord,
+  type DataSurfaceIdempotencyReservation,
+  type DataSurfacePreviewTokenRecord,
+  type DataSurfaceServerActionDefinition,
+  type DataSurfaceServerActionRequest,
+  InMemoryDataSurfaceActionStateStore,
+  type ResolvedDataSurfaceActions,
+  type ResolvedDataSurfaceSelection,
+} from './data-surface-actions.js';
+export {
   extractAgentManifest,
   extractAgentPackagesFromConfig,
   loadManifestsFromConfig,

--- a/packages/agents/vite.config.ts
+++ b/packages/agents/vite.config.ts
@@ -2,6 +2,7 @@ import { createPackageConfig } from '../../vite.config.base.js';
 
 export default createPackageConfig('agents', {
   svelte: 'svelte',
+  dtsAliasesExclude: ['@happyvertical/smrt-ui/data'],
   entries: [
     'playground',
     'summary-article',

--- a/tsconfig.package-build.json
+++ b/tsconfig.package-build.json
@@ -10,6 +10,8 @@
       "@happyvertical/smrt-mobile-contract/*": [
         "packages/smrt-mobile-contract/src/*"
       ],
+      "@happyvertical/smrt-ui": ["packages/smrt-ui/src/index.ts"],
+      "@happyvertical/smrt-ui/*": ["packages/smrt-ui/src/*"],
       "@happyvertical/smrt-*": ["packages/*/src/index.ts"],
       "@happyvertical/smrt-types": ["packages/types/src/index.ts"],
       "@happyvertical/smrt-types/*": ["packages/types/src/*"],

--- a/tsconfig.package-build.json
+++ b/tsconfig.package-build.json
@@ -10,8 +10,6 @@
       "@happyvertical/smrt-mobile-contract/*": [
         "packages/smrt-mobile-contract/src/*"
       ],
-      "@happyvertical/smrt-ui": ["packages/smrt-ui/src/index.ts"],
-      "@happyvertical/smrt-ui/*": ["packages/smrt-ui/src/*"],
       "@happyvertical/smrt-*": ["packages/*/src/index.ts"],
       "@happyvertical/smrt-types": ["packages/types/src/index.ts"],
       "@happyvertical/smrt-types/*": ["packages/types/src/*"],

--- a/vite.config.base.ts
+++ b/vite.config.base.ts
@@ -36,6 +36,11 @@ interface PackageConfigOptions {
    */
   dtsExclude?: string[];
   /**
+   * Public package specifiers that must remain intact in generated
+   * declarations instead of being rewritten through workspace source aliases.
+   */
+  dtsAliasesExclude?: (string | RegExp)[];
+  /**
    * When true, abort the build if `vite-plugin-dts` surfaces any
    * TypeScript error-level diagnostics while generating `.d.ts` files.
    *
@@ -486,6 +491,7 @@ export function createPackageConfig(
           // Prefer a package-specific build tsconfig when present so workspace
           // source resolution stays clean without requiring sibling dist output.
           tsconfigPath,
+          aliasesExclude: options.dtsAliasesExclude,
           // Fail the build on TS error-level diagnostics during dts
           // generation when opted in. Without this, `vite-plugin-dts`
           // prints errors to stderr but still emits and exits 0, which


### PR DESCRIPTION
## Summary

- add a principal-bound server adapter for declarative data-surface actions
- bind opaque confirmation tokens to the full actor, tenant, attribution, canonical selection, revision, and query context
- harden foreground and background execution with durable idempotency, canonical resolver rows, terminal partial outcomes, and direct no-confirmation support

## Validation

- `pnpm test`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @happyvertical/smrt-agents test -- data-surface-actions.test.ts` (267 tests)
- `pnpm --filter @happyvertical/smrt-agents build`
- `pnpm --filter @happyvertical/smrt-agents typecheck`
- `node ../../scripts/verify-package-types-exports.js .` (packed exports)
- `pnpm exec biome check packages/agents/src/server/data-surface-actions.ts packages/agents/src/server/data-surface-actions.test.ts`
- `pnpm knowledge:check --strict --format markdown`

Closes #2448

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-2448-data-surface-actions-packfix-20260823",
  "issue": 2448,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm test",
    "pnpm build",
    "pnpm typecheck",
    "pnpm lint",
    "pnpm --filter @happyvertical/smrt-agents test -- data-surface-actions.test.ts",
    "pnpm --filter @happyvertical/smrt-agents build",
    "pnpm --filter @happyvertical/smrt-agents typecheck",
    "node ../../scripts/verify-package-types-exports.js .",
    "pnpm knowledge:check --strict --format markdown"
  ]
}
