### PR TITLE
feat(reports): expose report lifecycle state

### DIFF
--- a/packages/reports/AGENTS.md
+++ b/packages/reports/AGENTS.md
@@ -14,6 +14,7 @@ Materialized aggregate report models for SMRT.
 | state | Internal `_smrt_report_*` system models for runs, watermarks, locks, schedules, and refresh tasks |
 | scheduler | Cron schedule runner, durable refresh job enqueueing, and `onChange` interceptor registration |
 | adapter | Transport-neutral report descriptor, canonical materialized-row reads, and stable `id` row identity |
+| lifecycle | Tenant-safe freshness, run, lock, failure, and manual refresh preview/apply surfaces |
 
 ## Adapter contract
 
@@ -37,9 +38,10 @@ Materialized aggregate report models for SMRT.
   collection is application-owned and must preserve the same boundary.
 - `refresh` is a declaration, not execution. It describes configured mode,
   triggers, positive-TTL stale-read behavior, and a permissioned/audited action
-  with preview/apply phases. The adapter does not authorize, audit, mutate, or
-  track refresh runs; issue #2460 owns that lifecycle. Generic collection reads
-  remain read-only with unknown freshness. Only a registered
+  with preview/apply phases. The adapter remains read-only, while
+  `getReportLifecycle()` provides an explicit, tenant-safe lifecycle snapshot
+  and `previewReportRefresh()` / `applyReportRefresh()` delegate authorization,
+  audit, and queueing through an application action host. Only a registered
   `SmrtReportCollection` may synchronously refresh stale reads, when its TTL is
   positive and the report is not manual.
 

--- a/packages/reports/README.md
+++ b/packages/reports/README.md
@@ -170,11 +170,16 @@ need explicit tenant predicates as described above.
 
 The descriptor's `refresh` section declares mode, triggers, stale-read behavior,
 and a permissioned, audited `refresh` action with `preview` and `apply` phases.
-It does not perform a refresh, authorize a caller, write audit records, or track
-run state. Those lifecycle responsibilities belong to the follow-up refresh
-adapter in issue #2460. Generic collection reads remain read-only and report
-unknown freshness; only a registered `SmrtReportCollection` can synchronously
-refresh a stale read, and only when its TTL policy is positive and not manual.
+The adapter itself stays read-only. Call `getReportLifecycle()` for a tenant-safe
+snapshot of current, stale, refreshing, lock-skipped, or failed materialization
+state; it redacts lock owners, raw errors, and tenant-fanout identifiers. Pass a
+`lifecycle` option to `queryReportMaterializedRows()` only when a consumer needs
+that context; the result then distinguishes a current, stale, or read-triggered
+refresh. `previewReportRefresh()` and `applyReportRefresh()` require an
+application action host to authorize and audit the caller before a durable
+report-refresh job is queued. Only a registered `SmrtReportCollection` can
+synchronously refresh a stale read, and only when its TTL policy is positive and
+not manual.
 
 ## Development
 

--- a/packages/reports/src/__tests__/lifecycle.test.ts
+++ b/packages/reports/src/__tests__/lifecycle.test.ts
@@ -1,0 +1,479 @@
+import {
+  getTestDatabase,
+  ObjectRegistry,
+  SmrtObject,
+} from '@happyvertical/smrt-core';
+import {
+  disableTenancy,
+  enableTenancy,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildReportAdapterDescriptor,
+  queryReportMaterializedRows,
+} from '../adapter.js';
+import { buildReportDefinition } from '../compiler.js';
+import {
+  applyReportRefresh,
+  getReportLifecycle,
+  previewReportRefresh,
+  reportRefreshOutcome,
+} from '../lifecycle.js';
+
+class LifecycleInvoice extends SmrtObject {}
+class LifecycleReport extends SmrtObject {}
+
+const NOW = new Date('2026-08-23T16:30:00.000Z');
+
+function registerFixture() {
+  ObjectRegistry.registerFromManifest(
+    'LifecycleInvoice',
+    {
+      className: 'LifecycleInvoice',
+      fields: { tenantId: { type: 'text' } },
+      methods: {},
+      decoratorConfig: { tableName: 'lifecycle_invoices' },
+      schema: {
+        tableName: 'lifecycle_invoices',
+        ddl: '',
+        columns: {},
+        indexes: [],
+        version: 'test',
+      },
+    },
+    '@test/reports',
+  );
+  ObjectRegistry.registerFromManifest(
+    'LifecycleReport',
+    {
+      className: 'LifecycleReport',
+      fields: {
+        tenantId: {
+          type: 'text',
+          _meta: { __tenancy: { isTenantIdField: true } },
+        },
+        revenue: {
+          type: 'decimal',
+          _meta: {
+            __report: { kind: 'aggregate', fn: 'sum', column: 'totalAmount' },
+          },
+        },
+        refreshedAt: { type: 'datetime' },
+      },
+      methods: {},
+      decoratorConfig: {
+        tableName: 'lifecycle_reports',
+        tenantScoped: { field: 'tenantId', mode: 'optional' },
+        report: {
+          source: 'LifecycleInvoice',
+          refresh: { mode: 'incremental', ttl: 60_000 },
+        },
+      },
+      schema: {
+        tableName: 'lifecycle_reports',
+        ddl: '',
+        columns: {},
+        indexes: [],
+        version: 'test',
+      },
+    },
+    '@test/reports',
+  );
+}
+
+function registerJobsManifest() {
+  for (const manifestUrl of [
+    new URL('../../../jobs/dist/manifest.json', import.meta.url),
+    new URL('../../../jobs/.smrt/manifest.json', import.meta.url),
+  ]) {
+    if (ObjectRegistry.registerPackageManifest(manifestUrl).loaded) return;
+  }
+}
+
+async function lifecycleClassName(): Promise<string> {
+  await buildReportDefinition(LifecycleReport);
+  const registered =
+    ObjectRegistry.getClassByConstructor(LifecycleReport) ??
+    ObjectRegistry.getClass(LifecycleReport.name);
+  return registered?.qualifiedName ?? registered?.name ?? LifecycleReport.name;
+}
+
+async function setupDb(): Promise<DatabaseInterface> {
+  const db = await getTestDatabase({
+    type: 'sqlite',
+    url: ':memory:',
+    classes: [],
+  });
+  await db.query(`
+    CREATE TABLE lifecycle_reports (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT,
+      revenue REAL,
+      refreshed_at TEXT
+    )
+  `);
+  await db.query(`
+    CREATE TABLE _smrt_report_runs (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT,
+      scope_key TEXT NOT NULL,
+      report_class TEXT NOT NULL,
+      source_class TEXT NOT NULL,
+      mode TEXT NOT NULL,
+      trigger TEXT NOT NULL,
+      status TEXT NOT NULL,
+      started_at TEXT,
+      completed_at TEXT,
+      row_count INTEGER,
+      changed_group_count INTEGER,
+      created_at TEXT
+    )
+  `);
+  await db.query(`
+    CREATE TABLE _smrt_report_locks (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT,
+      scope_key TEXT NOT NULL,
+      report_class TEXT NOT NULL,
+      owner_id TEXT,
+      expires_at TEXT
+    )
+  `);
+  await db.query(`
+    CREATE TABLE _smrt_jobs (
+      id TEXT PRIMARY KEY,
+      slug TEXT,
+      context TEXT,
+      tenant_id TEXT,
+      queue TEXT NOT NULL,
+      object_type TEXT NOT NULL,
+      object_id TEXT,
+      method TEXT NOT NULL,
+      args TEXT,
+      run_at TEXT NOT NULL,
+      priority INTEGER NOT NULL,
+      status TEXT NOT NULL,
+      attempts INTEGER NOT NULL,
+      max_attempts INTEGER NOT NULL,
+      timeout INTEGER NOT NULL,
+      timeout_behavior TEXT NOT NULL,
+      started_at TEXT,
+      completed_at TEXT,
+      last_error TEXT,
+      result_pointer TEXT,
+      retry_strategy TEXT,
+      worker_id TEXT,
+      worker_heartbeat TEXT,
+      created_at TEXT,
+      updated_at TEXT
+    )
+  `);
+  await db.query(
+    'CREATE UNIQUE INDEX lifecycle_jobs_slug_context_idx ON _smrt_jobs (tenant_id, slug, context)',
+  );
+  return db;
+}
+
+async function insertRun(
+  db: DatabaseInterface,
+  values: Partial<Record<string, string | number>> & { id: string },
+) {
+  await db.insert('_smrt_report_runs', {
+    tenant_id: 'tenant-a',
+    scope_key: 'tenant:tenant-a',
+    report_class: await lifecycleClassName(),
+    source_class: 'LifecycleInvoice',
+    mode: 'incremental',
+    trigger: 'manual',
+    status: 'success',
+    started_at: '2026-08-23T16:28:00.000Z',
+    completed_at: '2026-08-23T16:29:00.000Z',
+    row_count: 2,
+    changed_group_count: 1,
+    created_at: '2026-08-23T16:29:00.000Z',
+    ...values,
+  });
+}
+
+describe('report lifecycle', () => {
+  beforeEach(() => {
+    ObjectRegistry.clear();
+    registerFixture();
+    registerJobsManifest();
+    enableTenancy();
+  });
+
+  afterEach(() => {
+    disableTenancy();
+    ObjectRegistry.clear();
+  });
+
+  it('returns only the ambient tenant lifecycle and redacts lock/error internals', async () => {
+    const db = await setupDb();
+    try {
+      await db.insert('lifecycle_reports', {
+        id: 'tenant-a-row',
+        tenant_id: 'tenant-a',
+        revenue: 12,
+        refreshed_at: '2026-08-23T16:29:30.000Z',
+      });
+      await insertRun(db, { id: 'run-a' });
+      await db.insert('_smrt_report_locks', {
+        id: 'lock-a',
+        tenant_id: 'tenant-a',
+        scope_key: 'tenant:tenant-a',
+        report_class: await lifecycleClassName(),
+        expires_at: '2026-08-23T16:31:00.000Z',
+        owner_id: 'private-worker-id',
+      });
+      await insertRun(db, {
+        id: 'run-b',
+        tenant_id: 'tenant-b',
+        scope_key: 'tenant:tenant-b',
+        status: 'failed',
+        completed_at: '2026-08-23T16:29:45.000Z',
+      });
+
+      const tenantA = await withTenant({ tenantId: 'tenant-a' }, () =>
+        getReportLifecycle(LifecycleReport, { db, now: NOW }),
+      );
+      const tenantB = await withTenant({ tenantId: 'tenant-b' }, () =>
+        getReportLifecycle(LifecycleReport, { db, now: NOW }),
+      );
+
+      expect(tenantA).toMatchObject({
+        state: 'refreshing',
+        hasUsableRows: true,
+        mode: 'incremental',
+        run: { id: 'run-a', status: 'success', rowCount: 2 },
+        lock: { held: true, expiresAt: '2026-08-23T16:31:00.000Z' },
+      });
+      expect(JSON.stringify(tenantA)).not.toContain('private-worker-id');
+      expect(tenantB).toMatchObject({
+        state: 'failed',
+        hasUsableRows: false,
+        run: { id: 'run-b', status: 'failed', mayRetry: true },
+        failure: { code: 'refresh_failed', retryable: true },
+      });
+      expect(JSON.stringify(tenantB)).not.toContain('tenant-a');
+    } finally {
+      if (typeof db.close === 'function') await db.close();
+    }
+  });
+
+  it('distinguishes stale, lock-skipped, and failed lifecycle states', async () => {
+    const db = await setupDb();
+    try {
+      const stale = await withTenant({ tenantId: 'tenant-a' }, () =>
+        getReportLifecycle(LifecycleReport, { db, now: NOW }),
+      );
+      expect(stale).toMatchObject({ state: 'stale', hasUsableRows: false });
+
+      await insertRun(db, { id: 'skipped-run', status: 'skipped' });
+      const skipped = await withTenant({ tenantId: 'tenant-a' }, () =>
+        getReportLifecycle(LifecycleReport, { db, now: NOW }),
+      );
+      expect(skipped).toMatchObject({
+        state: 'lock-skipped',
+        run: { status: 'skipped', mayRetry: false },
+      });
+
+      await insertRun(db, {
+        id: 'failed-run',
+        status: 'failed',
+        started_at: '2026-08-23T16:29:30.000Z',
+      });
+      const failed = await withTenant({ tenantId: 'tenant-a' }, () =>
+        getReportLifecycle(LifecycleReport, { db, now: NOW }),
+      );
+      expect(failed).toMatchObject({
+        state: 'failed',
+        run: { id: 'failed-run', mayRetry: true },
+        failure: { code: 'refresh_failed', retryable: true },
+      });
+    } finally {
+      if (typeof db.close === 'function') await db.close();
+    }
+  });
+
+  it('maps an explicit lifecycle read into the canonical query freshness', async () => {
+    const db = await setupDb();
+    try {
+      await db.insert('lifecycle_reports', {
+        id: 'tenant-a-row',
+        tenant_id: 'tenant-a',
+        revenue: 12,
+        refreshed_at: '2026-08-23T16:29:30.000Z',
+      });
+      await insertRun(db, { id: 'run-a' });
+      const result = await withTenant({ tenantId: 'tenant-a' }, () =>
+        queryReportMaterializedRows(
+          LifecycleReport,
+          { version: 1, requestId: 'lifecycle-read', mode: 'rows' },
+          {
+            db,
+            lifecycle: { now: NOW },
+            collection: {
+              async list() {
+                return [{ id: 'tenant-a-row' }];
+              },
+              async count() {
+                return 1;
+              },
+            },
+          },
+        ),
+      );
+
+      expect(result.freshness).toEqual({
+        state: 'fresh',
+        asOf: '2026-08-23T16:29:30.000Z',
+      });
+      expect(result.reportLifecycle).toMatchObject({
+        read: 'current',
+        snapshot: { state: 'current', hasUsableRows: true },
+      });
+    } finally {
+      if (typeof db.close === 'function') await db.close();
+    }
+  });
+
+  it('discloses when a collection read turns a stale materialization current', async () => {
+    const db = await setupDb();
+    try {
+      const result = await withTenant({ tenantId: 'tenant-a' }, () =>
+        queryReportMaterializedRows(
+          LifecycleReport,
+          { version: 1, requestId: 'lifecycle-read-refresh', mode: 'rows' },
+          {
+            db,
+            lifecycle: { now: NOW },
+            collection: {
+              async list() {
+                await db.insert('lifecycle_reports', {
+                  id: 'tenant-a-refreshed-row',
+                  tenant_id: 'tenant-a',
+                  revenue: 12,
+                  refreshed_at: '2026-08-23T16:29:30.000Z',
+                });
+                await insertRun(db, { id: 'refresh-triggered-run' });
+                return [{ id: 'tenant-a-refreshed-row' }];
+              },
+              async count() {
+                return 1;
+              },
+            },
+          },
+        ),
+      );
+
+      expect(result.freshness).toEqual({
+        state: 'fresh',
+        asOf: '2026-08-23T16:29:30.000Z',
+      });
+      expect(result.reportLifecycle).toMatchObject({
+        read: 'refresh-triggered',
+        snapshot: { state: 'current', hasUsableRows: true },
+      });
+    } finally {
+      if (typeof db.close === 'function') await db.close();
+    }
+  });
+
+  it('requires host authorization and audit before previewing or queueing refreshes', async () => {
+    const db = await setupDb();
+    const authorize = vi.fn();
+    const audit = vi.fn();
+    const host = { authorize, audit };
+    try {
+      const descriptor = await buildReportAdapterDescriptor(LifecycleReport, {
+        refreshPermission: 'reports.rebuild',
+      });
+      const preview = await withTenant({ tenantId: 'tenant-a' }, () =>
+        previewReportRefresh(LifecycleReport, {
+          db,
+          host,
+          refreshAction: descriptor.refresh.action,
+        }),
+      );
+      const applied = await withTenant({ tenantId: 'tenant-a' }, () =>
+        applyReportRefresh(LifecycleReport, {
+          db,
+          host,
+          priority: 90,
+          refreshAction: descriptor.refresh.action,
+        }),
+      );
+
+      expect(preview).toMatchObject({
+        phase: 'preview',
+        execution: 'background',
+        action: {
+          phase: 'preview',
+          reportClassName: expect.stringMatching(/LifecycleReport$/),
+          tenantScope: 'ambient',
+          requiredPermission: 'reports.rebuild',
+        },
+      });
+      expect(applied).toMatchObject({
+        phase: 'apply',
+        job: { status: 'pending', attempts: 0, maxAttempts: 3 },
+      });
+      expect(authorize).toHaveBeenCalledTimes(2);
+      expect(audit).toHaveBeenCalledTimes(2);
+      expect(authorize).toHaveBeenCalledWith(
+        expect.objectContaining({ requiredPermission: 'reports.rebuild' }),
+      );
+      const jobs = await db.query(
+        'SELECT tenant_id, queue, method, priority FROM _smrt_jobs',
+      );
+      expect(jobs.rows).toEqual([
+        {
+          tenant_id: 'tenant-a',
+          queue: 'reports',
+          method: 'run',
+          priority: 90,
+        },
+      ]);
+    } finally {
+      if (typeof db.close === 'function') await db.close();
+    }
+  });
+
+  it('returns fanout outcomes without tenant identifiers', () => {
+    const outcome = reportRefreshOutcome({
+      rowCount: 3,
+      changedGroupCount: 2,
+      refreshedAt: NOW,
+      mode: 'incremental',
+      tenantResults: [
+        {
+          rowCount: 2,
+          refreshedAt: NOW,
+          mode: 'incremental',
+          tenantId: 'tenant-a',
+        },
+        {
+          rowCount: 1,
+          refreshedAt: NOW,
+          mode: 'incremental',
+          tenantId: 'tenant-b',
+          skipped: true,
+        },
+      ],
+    });
+
+    expect(outcome).toEqual({
+      state: 'partial',
+      rowCount: 3,
+      changedGroupCount: 2,
+      completedScopes: 1,
+      lockSkippedScopes: 1,
+      mode: 'incremental',
+      refreshedAt: NOW.toISOString(),
+    });
+    expect(JSON.stringify(outcome)).not.toContain('tenant-');
+  });
+});

--- a/packages/reports/src/__tests__/lifecycle.test.ts
+++ b/packages/reports/src/__tests__/lifecycle.test.ts
@@ -24,6 +24,7 @@ import {
 
 class LifecycleInvoice extends SmrtObject {}
 class LifecycleReport extends SmrtObject {}
+class GlobalLifecycleReport extends SmrtObject {}
 
 const NOW = new Date('2026-08-23T16:30:00.000Z');
 
@@ -73,6 +74,37 @@ function registerFixture() {
       },
       schema: {
         tableName: 'lifecycle_reports',
+        ddl: '',
+        columns: {},
+        indexes: [],
+        version: 'test',
+      },
+    },
+    '@test/reports',
+  );
+  ObjectRegistry.registerFromManifest(
+    'GlobalLifecycleReport',
+    {
+      className: 'GlobalLifecycleReport',
+      fields: {
+        revenue: {
+          type: 'decimal',
+          _meta: {
+            __report: { kind: 'aggregate', fn: 'sum', column: 'totalAmount' },
+          },
+        },
+        refreshedAt: { type: 'datetime' },
+      },
+      methods: {},
+      decoratorConfig: {
+        tableName: 'global_lifecycle_reports',
+        report: {
+          source: 'LifecycleInvoice',
+          refresh: { mode: 'incremental', ttl: 60_000 },
+        },
+      },
+      schema: {
+        tableName: 'global_lifecycle_reports',
         ddl: '',
         columns: {},
         indexes: [],
@@ -272,6 +304,14 @@ describe('report lifecycle', () => {
       expect(stale).toMatchObject({ state: 'stale', hasUsableRows: false });
 
       await insertRun(db, { id: 'skipped-run', status: 'skipped' });
+      await db.insert('_smrt_report_locks', {
+        id: 'lock-for-skipped-run',
+        tenant_id: 'tenant-a',
+        scope_key: 'tenant:tenant-a',
+        report_class: await lifecycleClassName(),
+        owner_id: 'worker',
+        expires_at: '2026-08-23T16:31:00.000Z',
+      });
       const skipped = await withTenant({ tenantId: 'tenant-a' }, () =>
         getReportLifecycle(LifecycleReport, { db, now: NOW }),
       );
@@ -285,6 +325,18 @@ describe('report lifecycle', () => {
         status: 'failed',
         started_at: '2026-08-23T16:29:30.000Z',
       });
+      const retryingFailed = await withTenant({ tenantId: 'tenant-a' }, () =>
+        getReportLifecycle(LifecycleReport, { db, now: NOW }),
+      );
+      expect(retryingFailed).toMatchObject({
+        state: 'refreshing',
+        run: { id: 'failed-run', status: 'failed' },
+        lock: { held: true },
+      });
+
+      await db.delete('_smrt_report_locks', {
+        id: 'lock-for-skipped-run',
+      });
       const failed = await withTenant({ tenantId: 'tenant-a' }, () =>
         getReportLifecycle(LifecycleReport, { db, now: NOW }),
       );
@@ -292,6 +344,63 @@ describe('report lifecycle', () => {
         state: 'failed',
         run: { id: 'failed-run', mayRetry: true },
         failure: { code: 'refresh_failed', retryable: true },
+      });
+    } finally {
+      if (typeof db.close === 'function') await db.close();
+    }
+  });
+
+  it('uses the newest successful lifecycle signal', async () => {
+    const db = await setupDb();
+    try {
+      await db.insert('lifecycle_reports', {
+        id: 'tenant-a-row',
+        tenant_id: 'tenant-a',
+        revenue: 12,
+        refreshed_at: '2026-08-23T16:00:00.000Z',
+      });
+      await insertRun(db, {
+        id: 'successful-noop-run',
+        completed_at: '2026-08-23T16:29:30.000Z',
+      });
+
+      const completedNoop = await withTenant({ tenantId: 'tenant-a' }, () =>
+        getReportLifecycle(LifecycleReport, { db, now: NOW }),
+      );
+      expect(completedNoop).toMatchObject({
+        state: 'current',
+        asOf: '2026-08-23T16:29:30.000Z',
+        refreshedAt: '2026-08-23T16:00:00.000Z',
+      });
+    } finally {
+      if (typeof db.close === 'function') await db.close();
+    }
+  });
+
+  it('does not retain abandoned running work as refreshing', async () => {
+    const db = await setupDb();
+    try {
+      await db.insert('lifecycle_reports', {
+        id: 'tenant-a-row',
+        tenant_id: 'tenant-a',
+        revenue: 12,
+        refreshed_at: '2026-08-23T16:29:30.000Z',
+      });
+      await insertRun(db, {
+        id: 'abandoned-running-run',
+        status: 'running',
+        started_at: '2026-08-23T16:10:00.000Z',
+        completed_at: null,
+      });
+
+      const abandoned = await withTenant({ tenantId: 'tenant-a' }, () =>
+        getReportLifecycle(LifecycleReport, { db, now: NOW }),
+      );
+      expect(abandoned).toMatchObject({
+        state: 'stale',
+        asOf: '2026-08-23T16:29:30.000Z',
+        run: { id: 'abandoned-running-run', status: 'running' },
+        lock: { held: false },
       });
     } finally {
       if (typeof db.close === 'function') await db.close();
@@ -437,6 +546,24 @@ describe('report lifecycle', () => {
           priority: 90,
         },
       ]);
+    } finally {
+      if (typeof db.close === 'function') await db.close();
+    }
+  });
+
+  it('queues global reports outside an ambient tenant scope', async () => {
+    const db = await setupDb();
+    const host = { authorize: vi.fn(), audit: vi.fn() };
+    try {
+      await withTenant({ tenantId: 'tenant-a' }, () =>
+        applyReportRefresh(GlobalLifecycleReport, { db, host }),
+      );
+
+      const jobs = await db.query('SELECT tenant_id, args FROM _smrt_jobs');
+      expect(jobs.rows).toEqual([expect.objectContaining({ tenant_id: null })]);
+      expect(JSON.parse(String(jobs.rows[0]?.args))).toMatchObject({
+        tenantId: null,
+      });
     } finally {
       if (typeof db.close === 'function') await db.close();
     }

--- a/packages/reports/src/adapter.ts
+++ b/packages/reports/src/adapter.ts
@@ -8,10 +8,16 @@ import {
 import { toSnakeCase } from '@happyvertical/smrt-core/utils';
 import type {
   DataQueryFieldDescriptor,
+  DataQueryFreshness,
   DataQueryResult,
   DataQuerySchema,
 } from '@happyvertical/smrt-types';
 import { buildReportDefinition } from './compiler.js';
+import {
+  getReportLifecycle,
+  type ReportLifecycleOptions,
+  type ReportLifecycleSnapshot,
+} from './lifecycle.js';
 import type {
   ReportAggregateFn,
   ReportDefinition,
@@ -220,6 +226,22 @@ export interface ReportQueryOptions {
     count(options?: Record<string, unknown>): Promise<number>;
   };
   db?: import('@happyvertical/sql').DatabaseInterface;
+  /**
+   * Opt in to a tenant-safe lifecycle snapshot alongside this materialized
+   * read. It never makes a generic read mutate.
+   */
+  lifecycle?: Omit<ReportLifecycleOptions, 'db'>;
+}
+
+/** Lifecycle context attached only when a caller explicitly opts in. */
+export interface ReportMaterializedReadLifecycle {
+  snapshot: ReportLifecycleSnapshot;
+  /** Whether this collection read appears to have completed a TTL refresh. */
+  read: 'current' | 'stale' | 'refresh-triggered';
+}
+
+export interface ReportDataQueryResult extends DataQueryResult {
+  reportLifecycle?: ReportMaterializedReadLifecycle;
 }
 
 type RegistryField = {
@@ -816,6 +838,32 @@ function mapMaterializedRow(
   return mapped;
 }
 
+function queryFreshness(
+  lifecycle: ReportLifecycleSnapshot,
+): DataQueryFreshness {
+  switch (lifecycle.state) {
+    case 'current':
+      return {
+        state: 'fresh',
+        ...(lifecycle.asOf ? { asOf: lifecycle.asOf } : {}),
+      };
+    case 'stale':
+    case 'lock-skipped':
+    case 'failed':
+      return {
+        state: 'stale',
+        ...(lifecycle.asOf ? { asOf: lifecycle.asOf } : {}),
+      };
+    case 'refreshing':
+      return lifecycle.hasUsableRows
+        ? {
+            state: 'stale',
+            ...(lifecycle.asOf ? { asOf: lifecycle.asOf } : {}),
+          }
+        : { state: 'unknown' };
+  }
+}
+
 /**
  * Execute the bounded materialized-read slice owned by #2457.
  *
@@ -830,12 +878,23 @@ export async function queryReportMaterializedRows(
   reportCtor: new (...args: any[]) => SmrtObject,
   input: unknown,
   options: ReportQueryOptions = {},
-): Promise<DataQueryResult> {
+): Promise<ReportDataQueryResult> {
   const descriptor = await buildReportAdapterDescriptor(reportCtor);
   const request = normalizeDataQueryRequest(input, descriptor.schema);
   if (request.mode === 'facets') {
     throw new Error('Report materialized reads do not support facets yet');
   }
+  const lifecycleDb = options.db;
+  if (options.lifecycle && !lifecycleDb) {
+    throw new Error('Report lifecycle disclosure requires a database handle');
+  }
+  const lifecycleOptions =
+    options.lifecycle && lifecycleDb
+      ? { db: lifecycleDb, ...options.lifecycle }
+      : undefined;
+  const lifecycleBefore = lifecycleOptions
+    ? await getReportLifecycle(reportCtor, lifecycleOptions)
+    : undefined;
   const fieldMap = publicFieldMap(descriptor);
   const collection: NonNullable<ReportQueryOptions['collection']> =
     options.collection ??
@@ -902,7 +961,28 @@ export async function queryReportMaterializedRows(
     warnings: [],
     truncated: false,
   };
-  return normalizeDataQueryResult(result, request, descriptor.schema);
+  const normalized = normalizeDataQueryResult(
+    result,
+    request,
+    descriptor.schema,
+  );
+  if (!lifecycleBefore || !lifecycleOptions) return normalized;
+
+  const lifecycleAfter = await getReportLifecycle(reportCtor, lifecycleOptions);
+  return {
+    ...normalized,
+    freshness: queryFreshness(lifecycleAfter),
+    reportLifecycle: {
+      snapshot: lifecycleAfter,
+      read:
+        lifecycleBefore.state !== 'current' &&
+        lifecycleAfter.state === 'current'
+          ? 'refresh-triggered'
+          : lifecycleAfter.state === 'current'
+            ? 'current'
+            : 'stale',
+    },
+  };
 }
 
 /** Read the already-materialized primary key; never use a display/page index. */

--- a/packages/reports/src/index.ts
+++ b/packages/reports/src/index.ts
@@ -5,6 +5,7 @@ export type {
   ReportColumnDescriptor,
   ReportColumnKind,
   ReportColumnSensitivity,
+  ReportDataQueryResult,
   ReportDataTableColumn,
   ReportDataTableColumnOverride,
   ReportDataTableColumnResponsive,
@@ -16,6 +17,7 @@ export type {
   ReportDataTableStructuralRowInput,
   ReportDataTableStructuralRowKind,
   ReportDataTableValueFormat,
+  ReportMaterializedReadLifecycle,
   ReportQueryOptions,
   ReportRefreshActionDescriptor,
   ReportRefreshDescriptor,
@@ -53,6 +55,26 @@ export {
   week,
   year,
 } from './decorators.js';
+export type {
+  AppliedReportRefresh,
+  ApplyReportRefreshOptions,
+  PreviewReportRefreshOptions,
+  ReportLifecycleOptions,
+  ReportLifecycleRun,
+  ReportLifecycleSnapshot,
+  ReportLifecycleState,
+  ReportRefreshActionContext,
+  ReportRefreshActionHost,
+  ReportRefreshJobHandle,
+  ReportRefreshOutcome,
+  ReportRefreshPreview,
+} from './lifecycle.js';
+export {
+  applyReportRefresh,
+  getReportLifecycle,
+  previewReportRefresh,
+  reportRefreshOutcome,
+} from './lifecycle.js';
 export {
   refreshReport,
   reportRowIdentity,

--- a/packages/reports/src/lifecycle.ts
+++ b/packages/reports/src/lifecycle.ts
@@ -1,0 +1,464 @@
+import { ObjectRegistry, type SmrtObject } from '@happyvertical/smrt-core';
+import { getTenantId } from '@happyvertical/smrt-tenancy';
+import {
+  type DatabaseInterface,
+  tableExists,
+  validateColumnName,
+} from '@happyvertical/sql';
+import type { ReportRefreshActionDescriptor } from './adapter.js';
+import { buildReportDefinition } from './compiler.js';
+import { enqueueReportRefresh } from './scheduler.js';
+import {
+  assertReportTablesReady,
+  REPORT_LOCKS_TABLE,
+  REPORT_RUNS_TABLE,
+  scopeKeyForTenant,
+} from './state.js';
+import type {
+  ReportRefreshMode,
+  ReportRefreshResult,
+  ReportRefreshTrigger,
+} from './types.js';
+
+type ReportCtor = new (...args: any[]) => SmrtObject;
+
+export type ReportLifecycleState =
+  | 'current'
+  | 'stale'
+  | 'refreshing'
+  | 'lock-skipped'
+  | 'failed';
+
+export interface ReportLifecycleRun {
+  id: string;
+  status: 'running' | 'success' | 'failed' | 'skipped';
+  mode: ReportRefreshMode;
+  trigger: ReportRefreshTrigger;
+  startedAt?: string;
+  completedAt?: string;
+  rowCount: number;
+  changedGroupCount: number;
+  /** A failed run is safe to retry through the separately permissioned action. */
+  mayRetry: boolean;
+}
+
+/**
+ * Transport-neutral report lifecycle state. It deliberately never includes a
+ * lock owner, a raw failure message, or tenant fanout identifiers.
+ */
+export interface ReportLifecycleSnapshot {
+  version: 1;
+  state: ReportLifecycleState;
+  asOf?: string;
+  refreshedAt?: string;
+  /** Whether existing materialized rows can remain visible while work changes state. */
+  hasUsableRows: boolean;
+  mode: ReportRefreshMode;
+  run?: ReportLifecycleRun;
+  /** A stable, redacted failure signal; raw executor errors stay server-side. */
+  failure?: {
+    code: 'refresh_failed';
+    retryable: true;
+  };
+  lock: {
+    held: boolean;
+    expiresAt?: string;
+  };
+}
+
+export interface ReportLifecycleOptions {
+  db: DatabaseInterface;
+  /** Test seam; production callers use the current clock. */
+  now?: Date;
+}
+
+export interface ReportRefreshJobHandle {
+  jobId: string;
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+  attempts: number;
+  maxAttempts: number;
+  /** Bounded polling guidance; this API does not create a second queue. */
+  pollAfterMs: number;
+}
+
+export interface ReportRefreshActionContext {
+  phase: 'preview' | 'apply';
+  reportClassName: string;
+  /** The action always applies to the caller's already-bound tenant scope. */
+  tenantScope: 'ambient';
+  mode: ReportRefreshMode;
+  requiredPermission: string;
+}
+
+/** Authority and audit stay with the application action host, not reports. */
+export interface ReportRefreshActionHost {
+  authorize(context: ReportRefreshActionContext): Promise<void> | void;
+  audit(context: ReportRefreshActionContext): Promise<void> | void;
+}
+
+export interface PreviewReportRefreshOptions extends ReportLifecycleOptions {
+  host: ReportRefreshActionHost;
+  mode?: ReportRefreshMode;
+  /**
+   * Pass `descriptor.refresh.action` when the adapter declares a custom
+   * refresh permission, so the displayed and enforced action stay aligned.
+   */
+  refreshAction?: Pick<ReportRefreshActionDescriptor, 'requiredPermission'>;
+}
+
+export interface ReportRefreshPreview {
+  phase: 'preview';
+  lifecycle: ReportLifecycleSnapshot;
+  action: ReportRefreshActionContext;
+  execution: 'background';
+}
+
+export interface ApplyReportRefreshOptions extends PreviewReportRefreshOptions {
+  queue?: string;
+  priority?: number;
+  timeout?: number;
+  maxAttempts?: number;
+  tenantJobCap?: number;
+}
+
+export interface AppliedReportRefresh {
+  phase: 'apply';
+  job: ReportRefreshJobHandle;
+}
+
+export interface ReportRefreshOutcome {
+  state: 'current' | 'lock-skipped' | 'partial';
+  rowCount: number;
+  changedGroupCount: number;
+  completedScopes: number;
+  lockSkippedScopes: number;
+  mode: ReportRefreshMode;
+  refreshedAt: string;
+  runId?: string;
+}
+
+function canonicalClassName(reportCtor: ReportCtor): string {
+  const registered =
+    ObjectRegistry.getClassByConstructor(reportCtor) ??
+    ObjectRegistry.getClass(reportCtor.name);
+  return registered?.qualifiedName ?? registered?.name ?? reportCtor.name;
+}
+
+function reportTableName(reportCtor: ReportCtor): string {
+  const reportClassName = canonicalClassName(reportCtor);
+  const tableName = ObjectRegistry.getTableName(reportClassName);
+  if (!tableName) {
+    throw new Error(`No report table registered for ${reportCtor.name}`);
+  }
+  return validateColumnName(tableName);
+}
+
+async function reportColumnName(
+  reportClassName: string,
+  fieldName: string,
+): Promise<string> {
+  const fields = await ObjectRegistry.getAllFields(reportClassName);
+  const direct = fields.get(fieldName) as
+    | { columnName?: string; _meta?: { columnName?: string } }
+    | undefined;
+  return validateColumnName(
+    direct?.columnName ??
+      direct?._meta?.columnName ??
+      fieldName.replace(/([A-Z])/g, '_$1').toLowerCase(),
+  );
+}
+
+function toIso(value: unknown): string | undefined {
+  if (!value) return undefined;
+  const date = value instanceof Date ? value : new Date(String(value));
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function numberValue(value: unknown): number {
+  const numeric = Number(value ?? 0);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function rowWhere(
+  reportClassName: string,
+  scopeKey: string,
+  tenantId: string | null,
+): { sql: string; values: unknown[] } {
+  if (tenantId) {
+    return {
+      sql: 'report_class = ? AND scope_key = ? AND tenant_id = ?',
+      values: [reportClassName, scopeKey, tenantId],
+    };
+  }
+  return {
+    sql: 'report_class = ? AND scope_key = ? AND tenant_id IS NULL',
+    values: [reportClassName, scopeKey],
+  };
+}
+
+function runFromRow(
+  row: Record<string, unknown> | undefined,
+): ReportLifecycleRun | undefined {
+  if (!row || typeof row.id !== 'string') return undefined;
+  const status = row.status;
+  if (
+    status !== 'running' &&
+    status !== 'success' &&
+    status !== 'failed' &&
+    status !== 'skipped'
+  ) {
+    return undefined;
+  }
+  const mode: ReportRefreshMode =
+    row.mode === 'incremental' ? 'incremental' : 'rebuild';
+  const trigger: ReportRefreshTrigger =
+    row.trigger === 'schedule' ||
+    row.trigger === 'change' ||
+    row.trigger === 'ttl' ||
+    row.trigger === 'job'
+      ? row.trigger
+      : 'manual';
+  return {
+    id: row.id,
+    status,
+    mode,
+    trigger,
+    ...(toIso(row.started_at) ? { startedAt: toIso(row.started_at) } : {}),
+    ...(toIso(row.completed_at)
+      ? { completedAt: toIso(row.completed_at) }
+      : {}),
+    rowCount: numberValue(row.row_count),
+    changedGroupCount: numberValue(row.changed_group_count),
+    mayRetry: status === 'failed',
+  };
+}
+
+function jobHandle(job: {
+  id?: unknown;
+  status: ReportRefreshJobHandle['status'];
+  attempts: number;
+  maxAttempts: number;
+}): ReportRefreshJobHandle {
+  if (typeof job.id !== 'string' || job.id.length === 0) {
+    throw new Error('Queued report refresh is missing its job id');
+  }
+  return {
+    jobId: job.id,
+    status: job.status,
+    attempts: job.attempts,
+    maxAttempts: job.maxAttempts,
+    pollAfterMs: 1_000,
+  };
+}
+
+/**
+ * Read only the ambient tenant's report state. The caller cannot supply a
+ * tenant selector, which prevents lifecycle lookup from becoming a tenant
+ * enumeration surface.
+ */
+export async function getReportLifecycle(
+  reportCtor: ReportCtor,
+  options: ReportLifecycleOptions,
+): Promise<ReportLifecycleSnapshot> {
+  await assertReportTablesReady(options.db, [
+    REPORT_RUNS_TABLE,
+    REPORT_LOCKS_TABLE,
+  ]);
+
+  const definition = await buildReportDefinition(reportCtor);
+  const reportClassName = canonicalClassName(reportCtor);
+  const tenantId = getTenantId() ?? null;
+  const scopeKey = scopeKeyForTenant(tenantId);
+  const where = rowWhere(reportClassName, scopeKey, tenantId);
+  const now = options.now ?? new Date();
+
+  const [runResult, lockResult] = await Promise.all([
+    options.db.query(
+      `SELECT id, mode, trigger, status, started_at, completed_at, row_count, changed_group_count
+         FROM ${REPORT_RUNS_TABLE}
+        WHERE ${where.sql}
+        ORDER BY started_at DESC, created_at DESC, id DESC
+        LIMIT 1`,
+      ...where.values,
+    ),
+    options.db.query(
+      `SELECT expires_at
+         FROM ${REPORT_LOCKS_TABLE}
+        WHERE ${where.sql} AND expires_at > ?
+        LIMIT 1`,
+      ...where.values,
+      now.toISOString(),
+    ),
+  ]);
+
+  const tableName = reportTableName(reportCtor);
+  if (!(await tableExists(options.db, tableName))) {
+    throw new Error(
+      `Report table '${tableName}' does not exist for ${reportClassName}`,
+    );
+  }
+  const refreshedAtColumn = await reportColumnName(
+    reportClassName,
+    'refreshedAt',
+  );
+  const registered =
+    ObjectRegistry.getClassByConstructor(reportCtor) ??
+    ObjectRegistry.getClass(reportCtor.name);
+  const configuredTenantField = registered?.tenantScopedConfig?.field;
+  const tenantColumn = configuredTenantField
+    ? await reportColumnName(reportClassName, configuredTenantField)
+    : undefined;
+  const materialized = tenantColumn
+    ? await options.db.query(
+        `SELECT MAX(${refreshedAtColumn}) AS refreshed_at FROM ${tableName} WHERE ${tenantColumn} ${tenantId ? '= ?' : 'IS NULL'}`,
+        ...(tenantId ? [tenantId] : []),
+      )
+    : await options.db.query(
+        `SELECT MAX(${refreshedAtColumn}) AS refreshed_at FROM ${tableName}`,
+      );
+
+  const run = runFromRow(
+    runResult.rows[0] as Record<string, unknown> | undefined,
+  );
+  const refreshedAt = toIso(materialized.rows[0]?.refreshed_at);
+  const completedAt = run?.status === 'success' ? run.completedAt : undefined;
+  const asOf = refreshedAt ?? completedAt;
+  const ttlMs = definition.refresh?.ttl;
+  const isStale =
+    !asOf ||
+    (ttlMs !== undefined && now.getTime() - new Date(asOf).getTime() > ttlMs);
+  const lockExpiresAt = toIso(lockResult.rows[0]?.expires_at);
+  const lockHeld = Boolean(lockExpiresAt);
+  const state: ReportLifecycleState =
+    run?.status === 'running' || lockHeld
+      ? 'refreshing'
+      : run?.status === 'skipped'
+        ? 'lock-skipped'
+        : run?.status === 'failed'
+          ? 'failed'
+          : isStale
+            ? 'stale'
+            : 'current';
+
+  return {
+    version: 1,
+    state,
+    ...(asOf ? { asOf } : {}),
+    ...(refreshedAt ? { refreshedAt } : {}),
+    hasUsableRows: Boolean(refreshedAt),
+    mode: run?.mode ?? definition.refresh?.mode ?? 'rebuild',
+    ...(run ? { run } : {}),
+    ...(run?.status === 'failed'
+      ? { failure: { code: 'refresh_failed' as const, retryable: true } }
+      : {}),
+    lock: {
+      held: lockHeld,
+      ...(lockExpiresAt ? { expiresAt: lockExpiresAt } : {}),
+    },
+  };
+}
+
+function actionContext(
+  reportCtor: ReportCtor,
+  phase: ReportRefreshActionContext['phase'],
+  mode: ReportRefreshMode,
+  refreshAction:
+    | Pick<ReportRefreshActionDescriptor, 'requiredPermission'>
+    | undefined,
+): ReportRefreshActionContext {
+  return {
+    phase,
+    reportClassName: canonicalClassName(reportCtor),
+    tenantScope: 'ambient',
+    mode,
+    requiredPermission:
+      refreshAction?.requiredPermission &&
+      refreshAction.requiredPermission.trim().length > 0
+        ? refreshAction.requiredPermission
+        : 'reports.refresh',
+  };
+}
+
+async function actionMode(
+  reportCtor: ReportCtor,
+  requested: ReportRefreshMode | undefined,
+): Promise<ReportRefreshMode> {
+  if (requested) return requested;
+  const definition = await buildReportDefinition(reportCtor);
+  return definition.refresh?.mode ?? 'rebuild';
+}
+
+/** Preview only declares a separately authorized and audited refresh request. */
+export async function previewReportRefresh(
+  reportCtor: ReportCtor,
+  options: PreviewReportRefreshOptions,
+): Promise<ReportRefreshPreview> {
+  const mode = await actionMode(reportCtor, options.mode);
+  const action = actionContext(
+    reportCtor,
+    'preview',
+    mode,
+    options.refreshAction,
+  );
+  await options.host.authorize(action);
+  await options.host.audit(action);
+  return {
+    phase: 'preview',
+    lifecycle: await getReportLifecycle(reportCtor, options),
+    action,
+    execution: 'background',
+  };
+}
+
+/** Queue a manual refresh only after the action host authorizes and audits it. */
+export async function applyReportRefresh(
+  reportCtor: ReportCtor,
+  options: ApplyReportRefreshOptions,
+): Promise<AppliedReportRefresh> {
+  const mode = await actionMode(reportCtor, options.mode);
+  const action = actionContext(
+    reportCtor,
+    'apply',
+    mode,
+    options.refreshAction,
+  );
+  await options.host.authorize(action);
+  await options.host.audit(action);
+  const job = await enqueueReportRefresh({
+    db: options.db,
+    reportClass: canonicalClassName(reportCtor),
+    mode,
+    trigger: 'manual',
+    tenantId: getTenantId() ?? null,
+    queue: options.queue,
+    priority: options.priority,
+    timeout: options.timeout,
+    maxAttempts: options.maxAttempts,
+    tenantJobCap: options.tenantJobCap,
+  });
+  return { phase: 'apply', job: jobHandle(job) };
+}
+
+/** Normalize executor results without exposing the tenant identifiers in a fanout. */
+export function reportRefreshOutcome(
+  result: ReportRefreshResult,
+): ReportRefreshOutcome {
+  const scopes = result.tenantResults ?? [result];
+  const lockSkippedScopes = scopes.filter((scope) => scope.skipped).length;
+  const completedScopes = scopes.length - lockSkippedScopes;
+  return {
+    state:
+      scopes.length > 1 && lockSkippedScopes > 0
+        ? 'partial'
+        : lockSkippedScopes > 0
+          ? 'lock-skipped'
+          : 'current',
+    rowCount: result.rowCount,
+    changedGroupCount: result.changedGroupCount ?? 0,
+    completedScopes,
+    lockSkippedScopes,
+    mode: result.mode,
+    refreshedAt: result.refreshedAt.toISOString(),
+    ...(result.runId ? { runId: result.runId } : {}),
+  };
+}

--- a/packages/reports/src/lifecycle.ts
+++ b/packages/reports/src/lifecycle.ts
@@ -1,5 +1,5 @@
 import { ObjectRegistry, type SmrtObject } from '@happyvertical/smrt-core';
-import { getTenantId } from '@happyvertical/smrt-tenancy';
+import { getTenantId, withSystemContext } from '@happyvertical/smrt-tenancy';
 import {
   type DatabaseInterface,
   tableExists,
@@ -21,6 +21,13 @@ import type {
 } from './types.js';
 
 type ReportCtor = new (...args: any[]) => SmrtObject;
+
+function registeredReport(reportCtor: ReportCtor) {
+  return (
+    ObjectRegistry.getClassByConstructor(reportCtor) ??
+    ObjectRegistry.getClass(reportCtor.name)
+  );
+}
 
 export type ReportLifecycleState =
   | 'current'
@@ -138,9 +145,7 @@ export interface ReportRefreshOutcome {
 }
 
 function canonicalClassName(reportCtor: ReportCtor): string {
-  const registered =
-    ObjectRegistry.getClassByConstructor(reportCtor) ??
-    ObjectRegistry.getClass(reportCtor.name);
+  const registered = registeredReport(reportCtor);
   return registered?.qualifiedName ?? registered?.name ?? reportCtor.name;
 }
 
@@ -172,6 +177,23 @@ function toIso(value: unknown): string | undefined {
   if (!value) return undefined;
   const date = value instanceof Date ? value : new Date(String(value));
   return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function latestIso(
+  first: string | undefined,
+  second: string | undefined,
+): string | undefined {
+  if (!first) return second;
+  if (!second) return first;
+  return new Date(first).getTime() >= new Date(second).getTime()
+    ? first
+    : second;
+}
+
+function lifecycleTenantId(reportCtor: ReportCtor): string | null {
+  return registeredReport(reportCtor)?.tenantScopedConfig
+    ? (getTenantId() ?? null)
+    : null;
 }
 
 function numberValue(value: unknown): number {
@@ -267,7 +289,7 @@ export async function getReportLifecycle(
 
   const definition = await buildReportDefinition(reportCtor);
   const reportClassName = canonicalClassName(reportCtor);
-  const tenantId = getTenantId() ?? null;
+  const tenantId = lifecycleTenantId(reportCtor);
   const scopeKey = scopeKeyForTenant(tenantId);
   const where = rowWhere(reportClassName, scopeKey, tenantId);
   const now = options.now ?? new Date();
@@ -301,9 +323,7 @@ export async function getReportLifecycle(
     reportClassName,
     'refreshedAt',
   );
-  const registered =
-    ObjectRegistry.getClassByConstructor(reportCtor) ??
-    ObjectRegistry.getClass(reportCtor.name);
+  const registered = registeredReport(reportCtor);
   const configuredTenantField = registered?.tenantScopedConfig?.field;
   const tenantColumn = configuredTenantField
     ? await reportColumnName(reportClassName, configuredTenantField)
@@ -322,7 +342,7 @@ export async function getReportLifecycle(
   );
   const refreshedAt = toIso(materialized.rows[0]?.refreshed_at);
   const completedAt = run?.status === 'success' ? run.completedAt : undefined;
-  const asOf = refreshedAt ?? completedAt;
+  const asOf = latestIso(refreshedAt, completedAt);
   const ttlMs = definition.refresh?.ttl;
   const isStale =
     !asOf ||
@@ -330,15 +350,17 @@ export async function getReportLifecycle(
   const lockExpiresAt = toIso(lockResult.rows[0]?.expires_at);
   const lockHeld = Boolean(lockExpiresAt);
   const state: ReportLifecycleState =
-    run?.status === 'running' || lockHeld
-      ? 'refreshing'
-      : run?.status === 'skipped'
-        ? 'lock-skipped'
+    run?.status === 'skipped'
+      ? 'lock-skipped'
+      : lockHeld
+        ? 'refreshing'
         : run?.status === 'failed'
           ? 'failed'
-          : isStale
+          : run?.status === 'running'
             ? 'stale'
-            : 'current';
+            : isStale
+              ? 'stale'
+              : 'current';
 
   return {
     version: 1,
@@ -424,18 +446,24 @@ export async function applyReportRefresh(
   );
   await options.host.authorize(action);
   await options.host.audit(action);
-  const job = await enqueueReportRefresh({
-    db: options.db,
-    reportClass: canonicalClassName(reportCtor),
-    mode,
-    trigger: 'manual',
-    tenantId: getTenantId() ?? null,
-    queue: options.queue,
-    priority: options.priority,
-    timeout: options.timeout,
-    maxAttempts: options.maxAttempts,
-    tenantJobCap: options.tenantJobCap,
-  });
+  const tenantId = lifecycleTenantId(reportCtor);
+  const enqueue = () =>
+    enqueueReportRefresh({
+      db: options.db,
+      reportClass: canonicalClassName(reportCtor),
+      mode,
+      trigger: 'manual',
+      tenantId,
+      queue: options.queue,
+      priority: options.priority,
+      timeout: options.timeout,
+      maxAttempts: options.maxAttempts,
+      tenantJobCap: options.tenantJobCap,
+    });
+  const job =
+    tenantId === null && getTenantId()
+      ? await withSystemContext(enqueue)
+      : await enqueue();
   return { phase: 'apply', job: jobHandle(job) };
 }
 


### PR DESCRIPTION
## Summary

- add a tenant-safe, transport-neutral report lifecycle snapshot for freshness, runs, locks, failure/retry, and materialization state
- disclose lifecycle context only when materialized reads explicitly opt in, including stale versus read-triggered refresh results
- add separately authorized/audited manual refresh preview and queueing that reuses report jobs and safely summarizes tenant fanout

## Validation

- `pnpm --filter @happyvertical/smrt-reports test`
- `pnpm --filter @happyvertical/smrt-reports typecheck`
- `pnpm --filter @happyvertical/smrt-reports... build`
- `pnpm --filter @happyvertical/smrt-reports verify:pack`
- `pnpm exec smrt dev:knowledge-check --scope package --package @happyvertical/smrt-reports --format markdown`
- pre-push checks
- independent lifecycle review clear at `dc7146cd8fcba66c19d39a7931e56e91ff0660f1`

Closes #2460

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-2460-report-lifecycle-20260823",
  "issue": 2460,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm --filter @happyvertical/smrt-reports test",
    "pnpm --filter @happyvertical/smrt-reports typecheck",
    "pnpm --filter @happyvertical/smrt-reports... build",
    "pnpm --filter @happyvertical/smrt-reports verify:pack",
    "pnpm exec smrt dev:knowledge-check --scope package --package @happyvertical/smrt-reports --format markdown",
    "pre-push"
  ]
}