### PR TITLE
feat(reports): add materialized query contracts

### DIFF
--- a/packages/core/src/__tests__/collection-coverage.test.ts
+++ b/packages/core/src/__tests__/collection-coverage.test.ts
@@ -94,6 +94,25 @@ describe('SmrtCollection.count', () => {
     await widgets.create({ name: 'c', category: 'drop' });
     expect(await widgets.count({ where: { category: 'keep' } })).toBe(2);
   });
+
+  it('counts rows matching a bounded DNF where clause', async () => {
+    await widgets.create({ name: 'a', category: 'keep' });
+    await widgets.create({ name: 'b', category: 'also-keep' });
+    await widgets.create({ name: 'c', category: 'drop' });
+
+    const where = [[{ category: 'keep' }], [{ category: 'also-keep' }]];
+    expect(await widgets.count({ where })).toBe(2);
+    expect(await widgets.list({ where })).toHaveLength(2);
+  });
+
+  it('rejects empty DNF branches instead of treating them as unfiltered reads', async () => {
+    await expect(widgets.list({ where: [] })).rejects.toThrow(
+      /Invalid DNF where clause/,
+    );
+    await expect(widgets.count({ where: [[]] })).rejects.toThrow(
+      /Invalid DNF where clause/,
+    );
+  });
 });
 
 describe('SmrtCollection.getDiff', () => {

--- a/packages/core/src/__tests__/sti-polymorphic-queries.test.ts
+++ b/packages/core/src/__tests__/sti-polymorphic-queries.test.ts
@@ -387,8 +387,11 @@ describe('STI Polymorphic Queries', () => {
       });
       await concert.save();
 
-      // Query via MeetingCollection - should only get meetings
-      const meetings = await meetingCollection.list({});
+      // A caller cannot replace the child collection's enforced discriminator
+      // with a sibling subtype filter.
+      const meetings = await meetingCollection.list({
+        where: { _meta_type: '@happyvertical/smrt-core:PolyConcert' },
+      });
 
       expect(meetings).toHaveLength(2);
       expect(meetings.every((m) => m instanceof PolyMeeting)).toBe(true);

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -127,8 +127,13 @@ function assertQueryBound(
  * @returns Modified WHERE clause with qualified _meta_type, or original if no resolution needed
  */
 function resolveMetaTypeInWhere<T extends Record<string, unknown>>(
-  where: T | undefined,
-): T | undefined {
+  where: T | T[][] | undefined,
+): T | T[][] | undefined {
+  if (Array.isArray(where)) {
+    return where.map((group) =>
+      group.map((condition) => resolveMetaTypeInWhere(condition) as T),
+    );
+  }
   if (!where?._meta_type || typeof where._meta_type !== 'string') {
     return where;
   }
@@ -149,6 +154,17 @@ function resolveMetaTypeInWhere<T extends Record<string, unknown>>(
   }
 
   return where;
+}
+
+/** Add an AND predicate without collapsing a caller's DNF OR branches. */
+function andWhereCondition<T extends Record<string, unknown>>(
+  where: T | T[][] | undefined,
+  condition: T,
+): T | T[][] {
+  if (Array.isArray(where)) {
+    return where.map((group) => [condition, ...group]);
+  }
+  return { ...condition, ...(where ?? {}) } as T;
 }
 
 /**
@@ -246,7 +262,7 @@ export type SmrtCreateInput<T extends SmrtObject> = Partial<
 };
 
 /**
- * WHERE clause type for `collection.list()`.
+ * Basic WHERE clause type for point lookups and AND-only collection reads.
  *
  * Uses `Record<string, unknown>` because WHERE keys often include operator
  * suffixes (e.g., `'price >'`, `'name like'`, `'status in'`) which can't be
@@ -254,6 +270,16 @@ export type SmrtCreateInput<T extends SmrtObject> = Partial<
  * `convertWhereKeys()` handles field and operator checking.
  */
 export type SmrtWhereClause<T extends SmrtObject> = Record<string, unknown>;
+
+/**
+ * Bounded disjunctive-normal-form WHERE clause for collection list/count/facet
+ * reads. Inner arrays are ANDed and outer arrays are ORed by the SQL adapter.
+ * Keeping this at the collection boundary preserves field validation, STI, and
+ * tenant interception for callers that need an allowlisted `any` filter.
+ */
+export type SmrtListWhereClause<T extends SmrtObject> =
+  | SmrtWhereClause<T>
+  | SmrtWhereClause<T>[][];
 
 type SmrtModelData<T extends SmrtObject> = Omit<
   {
@@ -336,7 +362,7 @@ export interface SmrtFacetOptions<T extends SmrtObject> {
    */
   fields: readonly (SmrtSelectField<T> | SmrtFacetRequest<T>)[];
   /** The same SMRT WHERE syntax accepted by {@link SmrtCollection.list}. */
-  where?: SmrtWhereClause<T>;
+  where?: SmrtListWhereClause<T>;
 }
 
 /** Exact unfiltered and filtered row counts for a list scope. */
@@ -346,7 +372,7 @@ export interface SmrtCollectionCounts {
 }
 
 export interface SmrtListOptions<ModelType extends SmrtObject> {
-  where?: SmrtWhereClause<ModelType>;
+  where?: SmrtListWhereClause<ModelType>;
   offset?: number;
   limit?: number;
   orderBy?: string | string[];
@@ -888,6 +914,25 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    * ```
    */
   private convertWhereKeys(
+    where: SmrtListWhereClause<ModelType>,
+  ): SmrtListWhereClause<ModelType> {
+    if (Array.isArray(where)) {
+      if (
+        where.length === 0 ||
+        where.some((group) => !Array.isArray(group) || group.length === 0)
+      ) {
+        throw new Error(
+          'Invalid DNF where clause: each OR branch must contain at least one condition.',
+        );
+      }
+      return where.map((group) =>
+        group.map((condition) => this.convertWhereKeysRecord(condition)),
+      );
+    }
+    return this.convertWhereKeysRecord(where);
+  }
+
+  private convertWhereKeysRecord(
     where: Record<string, unknown>,
   ): Record<string, unknown> {
     // Whitelist of allowed SQL operators.
@@ -2649,10 +2694,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     if (isSTI) {
       const stiBase = ObjectRegistry.getSTIBase(itemQualifiedName);
       if (stiBase && stiBase !== itemQualifiedName) {
-        where = {
+        where = andWhereCondition(where, {
           _meta_type: itemQualifiedName,
-          ...(where || {}),
-        };
+        });
       }
     }
 
@@ -3692,7 +3736,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    *
    * @see {@link list} for retrieving the actual records
    */
-  public async count(options: { where?: SmrtWhereClause<ModelType> } = {}) {
+  public async count(options: { where?: SmrtListWhereClause<ModelType> } = {}) {
     await this.ensureStorageReady();
     const itemQualifiedName = this.getResolvedItemQualifiedName();
     const itemClassName = this.getResolvedItemClassName();
@@ -3728,10 +3772,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     if (isSTI) {
       const stiBase = ObjectRegistry.getSTIBase(itemQualifiedName);
       if (stiBase && stiBase !== itemQualifiedName) {
-        where = {
+        where = andWhereCondition(where, {
           _meta_type: itemQualifiedName,
-          ...(where || {}),
-        };
+        });
       }
     }
 
@@ -3823,10 +3866,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     if (isSTI) {
       const stiBase = ObjectRegistry.getSTIBase(itemQualifiedName);
       if (stiBase && stiBase !== itemQualifiedName) {
-        where = {
+        where = andWhereCondition(where, {
           _meta_type: itemQualifiedName,
-          ...(where || {}),
-        };
+        });
       }
     }
     where = resolveMetaTypeInWhere(where);
@@ -3933,7 +3975,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    * count adds the caller's `where` conditions.
    */
   public async counts(
-    options: { where?: SmrtWhereClause<ModelType> } = {},
+    options: { where?: SmrtListWhereClause<ModelType> } = {},
   ): Promise<SmrtCollectionCounts> {
     const total = await this.count();
     const filtered = await this.count(options);

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -164,7 +164,10 @@ function andWhereCondition<T extends Record<string, unknown>>(
   if (Array.isArray(where)) {
     return where.map((group) => [condition, ...group]);
   }
-  return { ...condition, ...(where ?? {}) } as T;
+  // The collection-owned predicate is an enforcement boundary (for example,
+  // an STI child collection's discriminator), so it must win when a caller
+  // supplies the same key.
+  return { ...(where ?? {}), ...condition } as T;
 }
 
 /**

--- a/packages/core/src/interceptors.ts
+++ b/packages/core/src/interceptors.ts
@@ -65,7 +65,8 @@ export interface InterceptorContext {
  * Options for list operations
  */
 export interface ListOptions {
-  where?: Record<string, unknown>;
+  /** AND-only object or DNF (outer OR, inner AND) collection predicate. */
+  where?: Record<string, unknown> | Record<string, unknown>[][];
   orderBy?: string | string[];
   limit?: number;
   offset?: number;

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -52,7 +52,7 @@ export interface SmrtResponse {
 
 export interface CollectionInterface {
   list(options?: {
-    where?: Record<string, unknown>;
+    where?: Record<string, unknown> | Record<string, unknown>[][];
     orderBy?: string | string[];
     limit?: number;
     offset?: number;
@@ -67,5 +67,7 @@ export interface CollectionInterface {
 
   delete(id: string): Promise<boolean>;
 
-  count(options?: { where?: Record<string, unknown> }): Promise<number>;
+  count(options?: {
+    where?: Record<string, unknown> | Record<string, unknown>[][];
+  }): Promise<number>;
 }

--- a/packages/reports/AGENTS.md
+++ b/packages/reports/AGENTS.md
@@ -23,9 +23,11 @@ Materialized aggregate report models for SMRT.
   the canonical `DataQuerySchema`, and UI-neutral DataTable hints. It must not
   import `smrt-ui` or expose a report-domain class to the consumer.
 - `queryReportMaterializedRows()` owns only the bounded read slice for rows that
-  are already materialized. It supports projection, offset/limit paging, and
-  deterministic `id` ordering. Filters, `WHERE`/`HAVING` translation, facets,
-  and dimension/measure ordering are reserved for later adapter slices.
+  are already materialized. It supports projection, offset/limit paging,
+  validated filters, deterministic multi-sort with an `id` tie-breaker, exact
+  totals, and dimension facets. At source-query compilation,
+  dimension and bucket filters compile to `WHERE`, aggregate-measure filters
+  compile to `HAVING`, and mixed `OR`/`NOT` filter scopes fail closed.
 - `id` is the only row identity. It must be a non-empty persisted string and is
   never replaced by a display index or page position.
 - The descriptor is an exposure boundary. Sensitive/secret fields, fields with

--- a/packages/reports/README.md
+++ b/packages/reports/README.md
@@ -108,8 +108,10 @@ The package also exports a transport-neutral adapter for report surfaces:
 ```ts
 import {
   buildReportAdapterDescriptor,
+  buildReportDrilldownQuery,
   queryReportMaterializedRows,
   reportMaterializedRowKey,
+  splitReportFilterScopes,
 } from '@happyvertical/smrt-reports';
 
 const descriptor = await buildReportAdapterDescriptor(MonthlyRevenue, {
@@ -123,12 +125,30 @@ const result = await queryReportMaterializedRows(
     requestId: 'monthly-revenue-first-page',
     mode: 'rows',
     projection: ['id', 'customer_id', 'revenue'],
+    filter: {
+      kind: 'all',
+      filters: [
+        {
+          kind: 'condition',
+          field: 'customer_id',
+          operator: 'eq',
+          value: 'customer-42',
+        },
+        {
+          kind: 'condition',
+          field: 'revenue',
+          operator: 'gte',
+          value: 1000,
+        },
+      ],
+    },
     page: { kind: 'offset', offset: 0, limit: 25 },
-    sort: [{ field: 'id', direction: 'asc' }],
+    sort: [{ field: 'revenue', direction: 'desc' }],
   },
   { collection: reports },
 );
 const rowKey = reportMaterializedRowKey(result.rows[0]);
+const drilldown = await buildReportDrilldownQuery(MonthlyRevenue, result.rows[0]);
 ```
 
 `ReportAdapterDescriptor` is deterministic JSON with a stable resource id,
@@ -153,12 +173,32 @@ and `actions: 'excluded'`, and must be passed to the consumer table's structural
 row surface rather than its selectable data rows.
 
 `queryReportMaterializedRows()` is the bounded read slice for already-materialized
-rows. It supports projection, offset/limit paging (default limit 50), and
-deterministic ordering by the stable `id` identity. Dimension/measure filters,
-`WHERE`/`HAVING` mapping, facets, and caller-selected dimension/measure ordering
-are intentionally not part of this adapter contract. Every returned row must
-have a non-empty string `id`; use that value, never a display or page index, for
-row identity.
+rows. It supports projection, offset/limit paging (default limit 50),
+deterministic multi-sort (with `id` as the final tie-break), typed filters, and
+database-backed dimension facets. A descriptor marks group/time fields as
+`filterScope: 'where'` and aggregate measures as `filterScope: 'having'`; use
+`splitReportFilterScopes()` when constructing a live source query. An AND may
+combine the two scopes, but an OR or NOT cannot mix them, because moving either
+side across a source `WHERE`/`HAVING` boundary would change its meaning.
+
+The materialized collection executes the normalized, allowlisted predicate as
+parameterized SQL and applies it identically to rows, totals, and facets. It
+never accepts raw SQL, source field paths, tenant ids, or principal ids.
+The descriptor's `queryExecution` contract declares three delivery choices:
+`visible` (the default) returns rows for an already-authorized surface,
+`silent` returns the same bounded result while making no visible-surface change,
+and `background` delegates a normalized, authority-free task to the application's
+`enqueueBackgroundQuery` host. A background result is only a queue handle, never
+materialized rows. The host retains the authenticated principal, tenant, report
+definition, field policy, database, and eventual job execution; none can be
+supplied in a query request or background task.
+`buildReportDrilldownQuery()` carries only the row's declared groups/buckets
+and a fixed inheritance contract for the current principal, tenant, report
+definition, and field policy; an authenticated source adapter must enforce that
+contract before it reads source records. Time buckets remain declarative so the
+source adapter keeps the report's database/timezone semantics. Every returned
+row must have a non-empty string `id`; use that value, never a display or page
+index, for row identity.
 
 When no collection is injected, reads resolve the registered report collection
 through `ObjectRegistry`, allowing normal s-m-r-t collection interceptors to enforce

--- a/packages/reports/src/__tests__/adapter.test.ts
+++ b/packages/reports/src/__tests__/adapter.test.ts
@@ -11,8 +11,10 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildReportAdapterDescriptor,
+  buildReportDrilldownQuery,
   queryReportMaterializedRows,
   reportMaterializedRowKey,
+  splitReportFilterScopes,
 } from '../adapter.js';
 import { reportRowIdentity } from '../refresh.js';
 
@@ -208,29 +210,11 @@ function registerRefreshAndTenancyDescriptorFixtures() {
 }
 
 function registerRuntimeTenantFixture() {
-  ObjectRegistry.registerFieldDecorator('AdapterInvoice', 'tenantId', {
-    type: 'text',
-    _meta: { __tenancy: { isTenantIdField: true } },
-  });
-  ObjectRegistry.register(AdapterInvoice, { tableName: 'adapter_invoices' });
-
-  ObjectRegistry.registerFieldDecorator('AdapterReport', 'tenantId', {
-    type: 'text',
-    _meta: { __tenancy: { isTenantIdField: true } },
-  });
-  ObjectRegistry.registerFieldDecorator('AdapterReport', 'customerId', {
-    type: 'text',
-    __report: { kind: 'group', sourceColumn: 'customerId' },
-  });
-  ObjectRegistry.registerFieldDecorator('AdapterReport', 'revenue', {
-    type: 'decimal',
-    __report: { kind: 'aggregate', fn: 'sum', column: 'totalAmount' },
-  });
-  ObjectRegistry.register(AdapterReport, {
-    tableName: 'adapter_reports',
-    tenantScoped: { field: 'tenantId', mode: 'optional' },
-    report: { source: 'AdapterInvoice' },
-  });
+  // Exercise the manifest-hydrated deployment path used by the default
+  // collection resolver. Registering an unqualified test constructor here
+  // would leave its fields on a different registry entry than the qualified
+  // adapter descriptor resolves.
+  registerFixture();
 }
 
 describe('report adapter', () => {
@@ -263,6 +247,12 @@ describe('report adapter', () => {
     );
     expect(first.identityField).toBe('id');
     expect(first.schema.identityField).toBe('id');
+    expect(first.queryExecution).toEqual({
+      modes: ['visible', 'background', 'silent'],
+      visible: { delivery: 'result' },
+      background: { delivery: 'queued', requiresHost: true },
+      silent: { delivery: 'result', mutatesVisibleSurface: false },
+    });
     expect(first.schema.fields[0].id).toBe('customer_id');
     expect(first.columns.map((column) => column.id)).toEqual([
       'customer_id',
@@ -310,41 +300,50 @@ describe('report adapter', () => {
       rowKey: 'id',
       manualPagination: true,
       manualSorting: true,
-      enableFiltering: false,
+      enableFiltering: true,
       enableSearch: false,
     });
+    expect(first.dataTable.columns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'customer_id',
+          searchable: false,
+          filterable: true,
+        }),
+        expect.objectContaining({
+          id: 'revenue',
+          searchable: false,
+          filterable: true,
+        }),
+      ]),
+    );
     expect(
-      first.dataTable.columns.every(
-        (column) => column.searchable === false && column.filterable === false,
-      ),
-    ).toBe(true);
+      first.schema.fields.find((field) => field.id === 'customer_id'),
+    ).toMatchObject({
+      filterOperators: expect.arrayContaining(['eq', 'in', 'like']),
+      sortable: true,
+      facetable: true,
+    });
     expect(
-      first.schema.fields.every((field) => field.filterOperators === undefined),
-    ).toBe(true);
+      first.schema.fields.find((field) => field.id === 'revenue'),
+    ).toMatchObject({ sortable: true, facetable: false });
+    expect(first.schema.supports?.facets).toBe(true);
     expect(
-      first.schema.fields.filter((field) => field.id === 'id')[0]?.sortable,
-    ).toBe(true);
+      first.columns.find((column) => column.id === 'customer_id'),
+    ).toMatchObject({
+      filterScope: 'where',
+      sortable: true,
+      facetable: true,
+      capabilities: ['project', 'read', 'filter', 'sort', 'facet', 'group'],
+    });
     expect(
-      first.schema.fields
-        .filter((field) => field.id !== 'id')
-        .every(
-          (field) => field.sortable === false && field.facetable === false,
-        ),
-    ).toBe(true);
-    expect(first.schema.supports?.facets).toBe(false);
-    expect(
-      first.columns
-        .filter((column) => column.kind !== 'identity')
-        .every(
-          (column) =>
-            column.sortable === false &&
-            column.facetable === false &&
-            column.capabilities.join(',') === 'project,read',
-        ),
-    ).toBe(true);
-    expect(
-      first.columns.find((column) => column.id === 'id')?.capabilities,
-    ).toEqual(['project', 'read', 'sort']);
+      first.columns.find((column) => column.id === 'revenue'),
+    ).toMatchObject({
+      filterScope: 'having',
+      sortable: true,
+      facetable: false,
+      capabilities: ['project', 'read', 'filter', 'sort', 'aggregate'],
+    });
     expect(() => JSON.stringify(first)).not.toThrow();
   });
 
@@ -679,6 +678,60 @@ describe('report adapter', () => {
     expect(descriptor.schema.identityField).toBe('id');
   });
 
+  it('builds a principal-and-tenant-bound drilldown handoff from declared groups', async () => {
+    const descriptor = await buildReportAdapterDescriptor(AdapterReport);
+    expect(descriptor.drilldown).toEqual({
+      id: 'drilldown',
+      sourceClassName: 'AdapterInvoice',
+      fields: [
+        {
+          id: 'customer_id',
+          sourceColumn: 'customer_id',
+          kind: 'group',
+        },
+        {
+          id: 'issued_month',
+          sourceColumn: 'issued_at',
+          kind: 'bucket',
+          bucket: 'month',
+        },
+      ],
+      inherits: ['principal', 'tenant', 'report-definition', 'field-policy'],
+    });
+
+    await expect(
+      buildReportDrilldownQuery(AdapterReport, {
+        customer_id: 'customer-1',
+        issued_month: new Date('2026-08-01T00:00:00.000Z'),
+      }),
+    ).resolves.toEqual({
+      version: 1,
+      resourceId: '@happyvertical/smrt-reports:AdapterReport#current',
+      reportClassName: '@happyvertical/smrt-reports:AdapterReport',
+      sourceClassName: 'AdapterInvoice',
+      constraints: [
+        {
+          id: 'customer_id',
+          sourceColumn: 'customer_id',
+          kind: 'group',
+          value: 'customer-1',
+        },
+        {
+          id: 'issued_month',
+          sourceColumn: 'issued_at',
+          kind: 'bucket',
+          bucket: 'month',
+          value: '2026-08-01T00:00:00.000Z',
+        },
+      ],
+      inherits: ['principal', 'tenant', 'report-definition', 'field-policy'],
+    });
+
+    await expect(buildReportDrilldownQuery(AdapterReport, {})).rejects.toThrow(
+      /missing grouping field: customer_id/,
+    );
+  });
+
   it('projects and pages materialized rows through the canonical result envelope', async () => {
     let listOptions: Record<string, unknown> | undefined;
     const collection = {
@@ -716,6 +769,75 @@ describe('report adapter', () => {
     });
     expect(result.total).toEqual({ kind: 'exact', value: 2 });
     expect(result.freshness).toEqual({ state: 'unknown' });
+    expect(result.execution).toBe('visible');
+  });
+
+  it('executes silent reads without a visible-surface side effect', async () => {
+    const result = await queryReportMaterializedRows(
+      AdapterReport,
+      { version: 1, requestId: 'request-silent', mode: 'rows' },
+      {
+        execution: 'silent',
+        collection: {
+          async list() {
+            return [{ id: 'row-silent' }];
+          },
+          async count() {
+            return 1;
+          },
+        },
+      },
+    );
+
+    expect(result.execution).toBe('silent');
+    expect(result.rows).toEqual([{ id: 'row-silent' }]);
+  });
+
+  it('delegates background queries to a host without reading or serializing authority', async () => {
+    const list = vi.fn(async () => [{ id: 'must-not-read' }]);
+    const enqueueBackgroundQuery = vi.fn(async (task: unknown) => {
+      expect(task).toMatchObject({
+        version: 1,
+        execution: 'background',
+        resourceId: '@test/reports:AdapterReport#current',
+        reportClassName: '@test/reports:AdapterReport',
+        request: {
+          version: 1,
+          requestId: 'request-background',
+          mode: 'rows',
+          projection: ['customer_id', 'id'],
+        },
+        inherits: ['principal', 'tenant', 'report-definition', 'field-policy'],
+      });
+      expect(task).not.toHaveProperty('tenantId');
+      expect(task).not.toHaveProperty('principalId');
+      return { taskId: 'job-report-query-1' };
+    });
+
+    const result = await queryReportMaterializedRows(
+      AdapterReport,
+      {
+        version: 1,
+        requestId: 'request-background',
+        mode: 'rows',
+        projection: ['customer_id'],
+      },
+      {
+        execution: 'background',
+        collection: { list, count: async () => 1 },
+        enqueueBackgroundQuery,
+      },
+    );
+
+    expect(list).not.toHaveBeenCalled();
+    expect(enqueueBackgroundQuery).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      version: 1,
+      execution: 'background',
+      status: 'queued',
+      taskId: 'job-report-query-1',
+    });
+    expect(result).not.toHaveProperty('rows');
   });
 
   it('rejects bigint values that cannot be represented safely in JSON', async () => {
@@ -834,32 +956,208 @@ describe('report adapter', () => {
     expect(result.total).toEqual({ kind: 'exact', value: 2 });
   });
 
-  it('rejects caller filters until report-specific semantics exist', async () => {
+  it('maps declared dimension and measure filters into a bounded materialized predicate', async () => {
+    let listOptions: Record<string, unknown> | undefined;
+    let countOptions: Record<string, unknown> | undefined;
+    const collection = {
+      async list(options: Record<string, unknown>) {
+        listOptions = options;
+        return [{ id: 'row-2', customerId: 'customer-1', revenue: 25 }];
+      },
+      async count(options?: Record<string, unknown>) {
+        countOptions = options;
+        return 1;
+      },
+    };
+    const filter = {
+      kind: 'all' as const,
+      filters: [
+        {
+          kind: 'condition' as const,
+          field: 'customer_id',
+          operator: 'eq' as const,
+          value: 'customer-1',
+        },
+        {
+          kind: 'condition' as const,
+          field: 'revenue',
+          operator: 'gte' as const,
+          value: 10,
+        },
+      ],
+    };
+    const descriptor = await buildReportAdapterDescriptor(AdapterReport);
+    expect(splitReportFilterScopes(descriptor, filter)).toEqual({
+      where: filter.filters[0],
+      having: filter.filters[1],
+    });
+    expect(
+      splitReportFilterScopes(descriptor, {
+        kind: 'all',
+        filters: [
+          filter.filters[0],
+          { kind: 'all', filters: [filter.filters[0]] },
+          filter.filters[1],
+        ],
+      }),
+    ).toEqual({
+      where: { kind: 'all', filters: [filter.filters[0], filter.filters[0]] },
+      having: filter.filters[1],
+    });
+
+    const result = await queryReportMaterializedRows(
+      AdapterReport,
+      {
+        version: 1,
+        requestId: 'request-filter-and-sort',
+        mode: 'rows',
+        projection: ['customer_id', 'revenue'],
+        filter,
+        sort: [{ field: 'revenue', direction: 'desc' }],
+      },
+      { collection },
+    );
+
+    expect(listOptions).toMatchObject({
+      select: ['customerId', 'id', 'revenue'],
+      orderBy: ['revenue DESC', 'id ASC'],
+      where: [[{ customerId: 'customer-1' }, { 'revenue >=': 10 }]],
+    });
+    expect(countOptions).toEqual({
+      where: [[{ customerId: 'customer-1' }, { 'revenue >=': 10 }]],
+    });
+    expect(result.rows).toEqual([
+      { customer_id: 'customer-1', id: 'row-2', revenue: 25 },
+    ]);
+  });
+
+  it('keeps OR and null-bucket report filters parameterized and branch-bounded', async () => {
+    let listOptions: Record<string, unknown> | undefined;
+    const collection = {
+      async list(options: Record<string, unknown>) {
+        listOptions = options;
+        return [{ id: 'row-2', customerId: null }];
+      },
+      async count() {
+        return 1;
+      },
+    };
+
+    await queryReportMaterializedRows(
+      AdapterReport,
+      {
+        version: 1,
+        requestId: 'request-null-or-filter',
+        mode: 'rows',
+        projection: ['customer_id'],
+        filter: {
+          kind: 'any',
+          filters: [
+            {
+              kind: 'condition',
+              field: 'customer_id',
+              operator: 'eq',
+              value: null,
+            },
+            {
+              kind: 'condition',
+              field: 'customer_id',
+              operator: 'in',
+              value: ['customer-1', 'customer-2'],
+            },
+          ],
+        },
+      },
+      { collection },
+    );
+
+    expect(listOptions).toMatchObject({
+      where: [
+        [{ customerId: null }],
+        [{ 'customerId in': ['customer-1', 'customer-2'] }],
+      ],
+    });
+  });
+
+  it('returns database-backed dimension facets under the same report filter', async () => {
+    let facetOptions: Record<string, unknown> | undefined;
     const collection = {
       async list() {
         return [];
       },
       async count() {
-        return 0;
+        return 4;
+      },
+      async facets(options: Record<string, unknown>) {
+        facetOptions = options;
+        return [
+          {
+            field: 'customerId',
+            values: [
+              { value: 'customer-1', count: 3 },
+              { value: null, count: 1 },
+            ],
+          },
+        ];
       },
     };
-    await expect(
-      queryReportMaterializedRows(
-        AdapterReport,
-        {
-          version: 1,
-          requestId: 'request-2',
-          mode: 'rows',
-          filter: {
+
+    const result = await queryReportMaterializedRows(
+      AdapterReport,
+      {
+        version: 1,
+        requestId: 'request-dimension-facet',
+        mode: 'facets',
+        filter: {
+          kind: 'condition',
+          field: 'revenue',
+          operator: 'gte',
+          value: 10,
+        },
+        facets: [{ field: 'customer_id', limit: 2 }],
+      },
+      { collection },
+    );
+
+    expect(facetOptions).toEqual({
+      fields: [{ field: 'customerId', limit: 2 }],
+      where: [[{ 'revenue >=': 10 }]],
+    });
+    expect(result.rows).toEqual([]);
+    expect(result.total).toEqual({ kind: 'exact', value: 4 });
+    expect(result.facets).toEqual([
+      {
+        field: 'customer_id',
+        values: [
+          { value: 'customer-1', count: 3 },
+          { value: null, count: 1 },
+        ],
+        truncated: true,
+      },
+    ]);
+  });
+
+  it('rejects a mixed WHERE/HAVING OR expression before it can be miscompiled', async () => {
+    const descriptor = await buildReportAdapterDescriptor(AdapterReport);
+    expect(() =>
+      splitReportFilterScopes(descriptor, {
+        kind: 'any',
+        filters: [
+          {
             kind: 'condition',
             field: 'customer_id',
             operator: 'eq',
             value: 'customer-1',
           },
-        },
-        { collection },
-      ),
-    ).rejects.toThrow(/not allowed|do not support filter or sort/);
+          {
+            kind: 'condition',
+            field: 'revenue',
+            operator: 'gte',
+            value: 10,
+          },
+        ],
+      }),
+    ).toThrow(/WHERE and HAVING filters cannot be mixed/);
   });
 
   it('resolves the default collection through ObjectRegistry for tenant-bound reads', async () => {
@@ -926,6 +1224,67 @@ describe('report adapter', () => {
       );
 
       expect(result.rows).toEqual([{ id: 'tenant-a-row' }]);
+      expect(result.total).toEqual({ kind: 'exact', value: 1 });
+    } finally {
+      disableTenancy();
+      if (typeof db.close === 'function') await db.close();
+    }
+  });
+
+  it('applies the active tenant to every OR branch of a report query', async () => {
+    ObjectRegistry.clear();
+    registerRuntimeTenantFixture();
+    const db = await getTestDatabase({
+      type: 'sqlite',
+      classes: ['AdapterReport'],
+    });
+    try {
+      await db.insert('adapter_reports', {
+        id: 'tenant-a-customer-a',
+        slug: 'tenant-a-customer-a',
+        tenant_id: 'tenant-a',
+        customer_id: 'customer-a',
+        revenue: 10,
+      });
+      await db.insert('adapter_reports', {
+        id: 'tenant-b-customer-b',
+        slug: 'tenant-b-customer-b',
+        tenant_id: 'tenant-b',
+        customer_id: 'customer-b',
+        revenue: 90,
+      });
+      enableTenancy();
+
+      const result = await withTenant({ tenantId: 'tenant-a' }, () =>
+        queryReportMaterializedRows(
+          AdapterReport,
+          {
+            version: 1,
+            requestId: 'request-tenant-or-filter',
+            mode: 'rows',
+            filter: {
+              kind: 'any',
+              filters: [
+                {
+                  kind: 'condition',
+                  field: 'customer_id',
+                  operator: 'eq',
+                  value: 'customer-a',
+                },
+                {
+                  kind: 'condition',
+                  field: 'customer_id',
+                  operator: 'eq',
+                  value: 'customer-b',
+                },
+              ],
+            },
+          },
+          { db },
+        ),
+      );
+
+      expect(result.rows).toEqual([{ id: 'tenant-a-customer-a' }]);
       expect(result.total).toEqual({ kind: 'exact', value: 1 });
     } finally {
       disableTenancy();

--- a/packages/reports/src/adapter.ts
+++ b/packages/reports/src/adapter.ts
@@ -1,5 +1,6 @@
 import {
   createDataQueryFingerprint,
+  DataQueryValidationError,
   normalizeDataQueryRequest,
   normalizeDataQueryResult,
   ObjectRegistry,
@@ -7,8 +8,12 @@ import {
 } from '@happyvertical/smrt-core';
 import { toSnakeCase } from '@happyvertical/smrt-core/utils';
 import type {
+  DataQueryCondition,
   DataQueryFieldDescriptor,
+  DataQueryFilter,
+  DataQueryFilterOperator,
   DataQueryFreshness,
+  DataQueryRequest,
   DataQueryResult,
   DataQuerySchema,
 } from '@happyvertical/smrt-types';
@@ -44,12 +49,21 @@ export type ReportColumnCapability =
 
 export type ReportColumnKind = 'identity' | 'group' | 'bucket' | 'aggregate';
 
+/**
+ * Source-query clause a field belongs to. The materialized read executor
+ * applies both kinds through its tenant-scoped collection, but consumers use
+ * this declaration to keep dimensions/periods (WHERE) distinct from measures
+ * (HAVING) when constructing drilldowns, saved views, or a live query.
+ */
+export type ReportFilterScope = 'where' | 'having';
+
 export interface ReportColumnDescriptor extends DataQueryFieldDescriptor {
   /** Stable output column id (never a property path). */
   id: string;
   fieldName: string;
   label: string;
   kind: ReportColumnKind;
+  filterScope: ReportFilterScope;
   /** Capabilities available from this adapter revision. */
   capabilities: ReportColumnCapability[];
   format?: string;
@@ -100,8 +114,94 @@ export interface ReportAdapterDescriptor {
   identityField: 'id';
   columns: ReportColumnDescriptor[];
   schema: DataQuerySchema;
+  queryExecution: ReportQueryExecutionDescriptor;
   dataTable: ReportDataTableDescriptor;
+  drilldown: ReportDrilldownDescriptor;
   refresh: ReportRefreshDescriptor;
+}
+
+/**
+ * Delivery choices for the same bounded report query. They never add
+ * authority: a host owns visible state and background-job execution.
+ */
+export type ReportQueryExecutionMode = 'visible' | 'background' | 'silent';
+
+export interface ReportQueryExecutionDescriptor {
+  modes: ReportQueryExecutionMode[];
+  /** The caller may apply the returned rows to an already-authorized surface. */
+  visible: { delivery: 'result' };
+  /** A host queues the authority-free task and returns no materialized rows yet. */
+  background: { delivery: 'queued'; requiresHost: true };
+  /** The caller receives rows but the adapter makes no visible-surface change. */
+  silent: { delivery: 'result'; mutatesVisibleSurface: false };
+}
+
+/**
+ * The exact bounded request a background host may persist. Tenant, principal,
+ * collection, database, and display state deliberately remain with that host.
+ */
+export interface ReportBackgroundQueryTask {
+  version: 1;
+  execution: 'background';
+  resourceId: string;
+  reportClassName: string;
+  request: DataQueryRequest;
+  inherits: Array<
+    'principal' | 'tenant' | 'report-definition' | 'field-policy'
+  >;
+}
+
+/** Queuing a background query returns a handle, never rows from another scope. */
+export interface ReportBackgroundQueryResult {
+  version: 1;
+  execution: 'background';
+  status: 'queued';
+  taskId: string;
+  queryFingerprint: string;
+}
+
+/** One row value that can safely constrain a source-record drilldown. */
+export interface ReportDrilldownFieldDescriptor {
+  /** Stable report column id; never a display label. */
+  id: string;
+  /** Declared source field/column chosen by report metadata, not caller input. */
+  sourceColumn: string;
+  kind: 'group' | 'bucket';
+  /** A bucket stays declarative so the source adapter preserves report timezone semantics. */
+  bucket?: ReportTimeBucketUnit;
+}
+
+/**
+ * Declarative source-query handoff for a report row. No client can supply a
+ * principal, tenant, report definition, or arbitrary source field here.
+ */
+export interface ReportDrilldownDescriptor {
+  id: 'drilldown';
+  sourceClassName: string;
+  fields: ReportDrilldownFieldDescriptor[];
+  inherits: Array<
+    'principal' | 'tenant' | 'report-definition' | 'field-policy'
+  >;
+}
+
+export interface ReportDrilldownConstraint {
+  id: string;
+  sourceColumn: string;
+  kind: 'group' | 'bucket';
+  value: unknown;
+  bucket?: ReportTimeBucketUnit;
+}
+
+/** A server adapter uses this authority-free handoff to execute a source drilldown. */
+export interface ReportDrilldownQuery {
+  version: 1;
+  resourceId: string;
+  reportClassName: string;
+  sourceClassName: string;
+  constraints: ReportDrilldownConstraint[];
+  inherits: Array<
+    'principal' | 'tenant' | 'report-definition' | 'field-policy'
+  >;
 }
 
 /** Structural DataTable view hints; deliberately not a smrt-ui dependency. */
@@ -141,7 +241,7 @@ export interface ReportDataTableColumn {
   accessor: string;
   sortable: boolean;
   searchable: false;
-  filterable: false;
+  filterable: boolean;
   /** Group ancestry for consumers with multi-level table headers. */
   headerPath: ReportDataTableHeaderPathSegment[];
   /** Consumer-side display instruction; materialized rows remain raw. */
@@ -202,7 +302,7 @@ export interface ReportDataTableDescriptor {
   rowKey: 'id';
   manualPagination: true;
   manualSorting: true;
-  enableFiltering: false;
+  enableFiltering: true;
   enableSearch: false;
   columns: ReportDataTableColumn[];
   structuralRows: ReportDataTableStructuralRow[];
@@ -217,13 +317,22 @@ export interface ReportAdapterOptions {
   dataTable?: ReportDataTablePresentationOptions;
 }
 
-export interface ReportQueryOptions {
+interface ReportQueryCommonOptions {
   /** Injected collection seam for tests and application-owned adapters. */
   collection?: {
     list(
       options: Record<string, unknown>,
     ): Promise<Array<Record<string, unknown>>>;
     count(options?: Record<string, unknown>): Promise<number>;
+    facets?(options: Record<string, unknown>): Promise<
+      Array<{
+        field: string;
+        values: Array<{
+          value: string | number | boolean | null;
+          count: number;
+        }>;
+      }>
+    >;
   };
   db?: import('@happyvertical/sql').DatabaseInterface;
   /**
@@ -231,6 +340,19 @@ export interface ReportQueryOptions {
    * read. It never makes a generic read mutate.
    */
   lifecycle?: Omit<ReportLifecycleOptions, 'db'>;
+}
+
+/** Visible is the default; silent has identical data authority but no UI intent. */
+export interface ReportQueryOptions extends ReportQueryCommonOptions {
+  execution?: 'visible' | 'silent';
+}
+
+/** Background execution is possible only through an application-owned queue host. */
+export interface ReportBackgroundQueryOptions extends ReportQueryCommonOptions {
+  execution: 'background';
+  enqueueBackgroundQuery(
+    task: ReportBackgroundQueryTask,
+  ): Promise<{ taskId: string }>;
 }
 
 /** Lifecycle context attached only when a caller explicitly opts in. */
@@ -241,6 +363,8 @@ export interface ReportMaterializedReadLifecycle {
 }
 
 export interface ReportDataQueryResult extends DataQueryResult {
+  /** Delivery intent only; the adapter never mutates a visible surface. */
+  execution: 'visible' | 'silent';
   reportLifecycle?: ReportMaterializedReadLifecycle;
 }
 
@@ -366,16 +490,30 @@ function reportColumn(
   const report = field.report;
   if (!report) return undefined;
   const type = queryType(field.type ?? registryField?.type);
+  const filterOperators = filterOperatorsFor(type);
   const base: ReportColumnDescriptor = {
     id,
     fieldName: field.fieldName,
     label: registryField?.description || labelFor(field.fieldName),
     kind: report.kind,
+    filterScope: report.kind === 'aggregate' ? 'having' : 'where',
     type,
     projectable: true,
-    sortable: false,
-    facetable: false,
-    capabilities: ['project', 'read'],
+    sortable: true,
+    facetable: report.kind !== 'aggregate',
+    ...(filterOperators ? { filterOperators } : {}),
+    capabilities: [
+      'project',
+      'read',
+      ...(filterOperators ? (['filter'] as const) : []),
+      'sort',
+      ...(report.kind !== 'aggregate' ? (['facet'] as const) : []),
+      ...(report.kind === 'aggregate'
+        ? (['aggregate'] as const)
+        : report.kind === 'group'
+          ? (['group'] as const)
+          : []),
+    ],
     ...(report.kind === 'group'
       ? { sourceColumn: toSnakeCase(report.sourceColumn ?? field.fieldName) }
       : {}),
@@ -404,10 +542,13 @@ function identityColumn(): ReportColumnDescriptor {
     fieldName: 'id',
     label: 'ID',
     kind: 'identity',
+    filterScope: 'where',
     type: 'string',
     projectable: true,
     sortable: true,
-    capabilities: ['project', 'read', 'sort'],
+    facetable: false,
+    filterOperators: filterOperatorsFor('string'),
+    capabilities: ['project', 'read', 'filter', 'sort'],
   };
 }
 
@@ -420,9 +561,28 @@ function toQueryField(
     ...(column.projectable === undefined
       ? {}
       : { projectable: column.projectable }),
-    sortable: column.id === 'id',
-    facetable: false,
+    sortable: column.sortable === true,
+    facetable: column.facetable === true,
+    ...(column.filterOperators === undefined
+      ? {}
+      : { filterOperators: [...column.filterOperators] }),
   };
+}
+
+function filterOperatorsFor(
+  type: DataQueryFieldDescriptor['type'],
+): DataQueryFilterOperator[] | undefined {
+  switch (type) {
+    case 'string':
+      return ['eq', 'ne', 'gt', 'gte', 'lt', 'lte', 'in', 'notIn', 'like'];
+    case 'number':
+    case 'datetime':
+      return ['eq', 'ne', 'gt', 'gte', 'lt', 'lte', 'in', 'notIn'];
+    case 'boolean':
+      return ['eq', 'ne', 'in', 'notIn'];
+    case 'json':
+      return undefined;
+  }
 }
 
 function refreshDescriptor(
@@ -639,9 +799,9 @@ function dataTableColumn(
     id: column.id,
     label: override?.label ?? column.label,
     accessor: column.id,
-    sortable: column.id === 'id',
+    sortable: column.sortable === true,
     searchable: false,
-    filterable: false,
+    filterable: column.filterOperators !== undefined,
     headerPath: assertHeaderPath(column.id, path),
     valueFormat: format,
     align:
@@ -725,6 +885,36 @@ function structuralRows(
   });
 }
 
+function drilldownDescriptor(
+  columns: readonly ReportColumnDescriptor[],
+  sourceClassName: string,
+): ReportDrilldownDescriptor {
+  return {
+    id: 'drilldown',
+    sourceClassName,
+    fields: columns
+      .filter(
+        (
+          column,
+        ): column is ReportColumnDescriptor & {
+          kind: 'group' | 'bucket';
+          sourceColumn: string;
+        } =>
+          (column.kind === 'group' || column.kind === 'bucket') &&
+          typeof column.sourceColumn === 'string',
+      )
+      .map((column) => ({
+        id: column.id,
+        sourceColumn: column.sourceColumn,
+        kind: column.kind,
+        ...(column.kind === 'bucket' && column.bucket
+          ? { bucket: column.bucket }
+          : {}),
+      })),
+    inherits: ['principal', 'tenant', 'report-definition', 'field-policy'],
+  };
+}
+
 export async function buildReportAdapterDescriptor(
   reportCtor: new (...args: any[]) => SmrtObject,
   options: ReportAdapterOptions = {},
@@ -750,13 +940,13 @@ export async function buildReportAdapterDescriptor(
     identityField: 'id',
     fields: columns.map(toQueryField),
     defaultSort: [{ field: 'id', direction: 'asc' }],
-    supports: { cursorPagination: false, consistency: false, facets: false },
+    supports: { cursorPagination: false, consistency: false, facets: true },
   };
   const dataTable: ReportDataTableDescriptor = {
     rowKey: 'id',
     manualPagination: true,
     manualSorting: true,
-    enableFiltering: false,
+    enableFiltering: true,
     enableSearch: false,
     columns: columns.map((column) =>
       dataTableColumn(column, options.dataTable?.columns?.[column.id]),
@@ -776,7 +966,14 @@ export async function buildReportAdapterDescriptor(
     identityField: 'id',
     columns,
     schema,
+    queryExecution: {
+      modes: ['visible', 'background', 'silent'],
+      visible: { delivery: 'result' },
+      background: { delivery: 'queued', requiresHost: true },
+      silent: { delivery: 'result', mutatesVisibleSurface: false },
+    },
     dataTable,
+    drilldown: drilldownDescriptor(columns, definition.sourceClassName),
     refresh: refreshDescriptor(definition.refresh, options.refreshPermission),
   };
 }
@@ -787,6 +984,292 @@ function publicFieldMap(
   return new Map(
     descriptor.columns.map((column) => [column.id, column.fieldName]),
   );
+}
+
+/**
+ * Bind a materialized report row to its declared source dimensions. This is a
+ * query handoff, not an executor: an authenticated source adapter must apply
+ * the inherited principal, tenant, definition, and field policy before it
+ * reads source records.
+ */
+export async function buildReportDrilldownQuery(
+  reportCtor: new (...args: any[]) => SmrtObject,
+  row: Readonly<Record<string, unknown>>,
+  options: ReportAdapterOptions = {},
+): Promise<ReportDrilldownQuery> {
+  const descriptor = await buildReportAdapterDescriptor(reportCtor, options);
+  const constraints = descriptor.drilldown.fields.map((field) => {
+    if (!Object.hasOwn(row, field.id)) {
+      throw new DataQueryValidationError(
+        `Report drilldown row is missing grouping field: ${field.id}`,
+        'DATA_QUERY_RESULT_INVALID',
+      );
+    }
+    return {
+      id: field.id,
+      sourceColumn: field.sourceColumn,
+      kind: field.kind,
+      value: jsonSafeValue(row[field.id]),
+      ...(field.bucket ? { bucket: field.bucket } : {}),
+    };
+  });
+  return {
+    version: 1,
+    resourceId: descriptor.resourceId,
+    reportClassName: descriptor.reportClassName,
+    sourceClassName: descriptor.drilldown.sourceClassName,
+    constraints,
+    inherits: [...descriptor.drilldown.inherits],
+  };
+}
+
+type MaterializedWhere = Array<Array<Record<string, unknown>>>;
+
+/** Keep OR expansion bounded before it reaches the database collection. */
+const MAX_REPORT_FILTER_OR_GROUPS = 128;
+
+function reportFilterError(message: string): never {
+  throw new DataQueryValidationError(message, 'DATA_QUERY_UNSUPPORTED');
+}
+
+function crossProductWhere(
+  left: MaterializedWhere,
+  right: MaterializedWhere,
+): MaterializedWhere {
+  if (left.length * right.length > MAX_REPORT_FILTER_OR_GROUPS) {
+    return reportFilterError(
+      `Report filter expands beyond ${MAX_REPORT_FILTER_OR_GROUPS} OR groups`,
+    );
+  }
+  return left.flatMap((leftGroup) =>
+    right.map((rightGroup) => [...leftGroup, ...rightGroup]),
+  );
+}
+
+function inverseOperator(
+  operator: DataQueryFilterOperator,
+): DataQueryFilterOperator {
+  switch (operator) {
+    case 'eq':
+      return 'ne';
+    case 'ne':
+      return 'eq';
+    case 'gt':
+      return 'lte';
+    case 'gte':
+      return 'lt';
+    case 'lt':
+      return 'gte';
+    case 'lte':
+      return 'gt';
+    case 'in':
+      return 'notIn';
+    case 'notIn':
+      return 'in';
+    case 'like':
+      return reportFilterError(
+        'Report filters do not support negating a LIKE predicate',
+      );
+  }
+}
+
+function collectionCondition(
+  field: string,
+  operator: DataQueryFilterOperator,
+  value: DataQueryCondition['value'],
+): MaterializedWhere {
+  const keyFor = (suffix: string) => (suffix ? `${field} ${suffix}` : field);
+  const scalar = (key: string, scalarValue: unknown): MaterializedWhere => [
+    [{ [key]: scalarValue }],
+  ];
+
+  if (operator === 'in') {
+    const values = value as Array<string | number | boolean | null>;
+    const nonNull = values.filter((entry) => entry !== null);
+    if (nonNull.length === 0) return scalar(field, null);
+    if (nonNull.length === values.length) return scalar(keyFor('in'), nonNull);
+    // SQL IN does not match NULL. Model the user-visible union explicitly.
+    return [[{ [field]: null }], [{ [keyFor('in')]: nonNull }]];
+  }
+
+  if (operator === 'notIn') {
+    const values = value as Array<string | number | boolean | null>;
+    // `buildWhere()` does not have a `NOT IN` primitive. A bounded AND of
+    // inequality predicates has the same null-safe semantics and remains fully
+    // validated by the collection.
+    return [values.map((entry) => ({ [keyFor('!=')]: entry }))];
+  }
+
+  const suffix: Record<
+    Exclude<DataQueryFilterOperator, 'in' | 'notIn'>,
+    string
+  > = {
+    eq: '',
+    ne: '!=',
+    gt: '>',
+    gte: '>=',
+    lt: '<',
+    lte: '<=',
+    like: 'like',
+  };
+  return scalar(keyFor(suffix[operator]), value);
+}
+
+function materializedWhereForFilter(
+  filter: DataQueryFilter,
+  fields: Map<string, string>,
+  negate = false,
+): MaterializedWhere {
+  if (filter.kind === 'condition') {
+    const field = fields.get(filter.field);
+    if (!field) {
+      return reportFilterError(
+        `Report filter field is not declared: ${filter.field}`,
+      );
+    }
+    return collectionCondition(
+      field,
+      negate ? inverseOperator(filter.operator) : filter.operator,
+      filter.value,
+    );
+  }
+
+  if (filter.kind === 'not') {
+    return materializedWhereForFilter(filter.filter, fields, !negate);
+  }
+
+  const combineWithAnd =
+    (filter.kind === 'all' && !negate) || (filter.kind === 'any' && negate);
+  if (combineWithAnd) {
+    return filter.filters.reduce<MaterializedWhere>(
+      (combined, child) =>
+        crossProductWhere(
+          combined,
+          materializedWhereForFilter(child, fields, negate),
+        ),
+      [[]],
+    );
+  }
+
+  const groups = filter.filters.flatMap((child) =>
+    materializedWhereForFilter(child, fields, negate),
+  );
+  if (groups.length > MAX_REPORT_FILTER_OR_GROUPS) {
+    return reportFilterError(
+      `Report filter expands beyond ${MAX_REPORT_FILTER_OR_GROUPS} OR groups`,
+    );
+  }
+  return groups;
+}
+
+/**
+ * Converts a normalized report filter to collection-owned, parameterized
+ * predicates. The returned DNF form gives each OR branch a complete AND
+ * clause, so tenant interception can add its tenant predicate to every branch.
+ */
+function materializedWhere(
+  filter: DataQueryFilter | undefined,
+  fields: Map<string, string>,
+): MaterializedWhere | undefined {
+  return filter ? materializedWhereForFilter(filter, fields) : undefined;
+}
+
+function filterScopeForColumn(
+  column: ReportColumnDescriptor,
+): ReportFilterScope {
+  return column.filterScope;
+}
+
+/**
+ * Split the declared filter language by report semantics for consumers that
+ * construct a live source query. Mixed AND expressions are represented as two
+ * independent clauses; mixed OR/NOT expressions are rejected because moving
+ * either half across WHERE/HAVING would change their meaning.
+ */
+export function splitReportFilterScopes(
+  descriptor: ReportAdapterDescriptor,
+  filter: DataQueryFilter | undefined,
+): { where?: DataQueryFilter; having?: DataQueryFilter } {
+  if (!filter) return {};
+  const columns = new Map(
+    descriptor.columns.map((column) => [column.id, column]),
+  );
+  const combineAll = (
+    filters: DataQueryFilter[],
+  ): DataQueryFilter | undefined => {
+    const flattened = filters.flatMap((candidate) =>
+      candidate.kind === 'all' ? candidate.filters : [candidate],
+    );
+    return flattened.length === 0
+      ? undefined
+      : flattened.length === 1
+        ? flattened[0]
+        : { kind: 'all', filters: flattened };
+  };
+  const split = (
+    candidate: DataQueryFilter,
+  ): { where?: DataQueryFilter; having?: DataQueryFilter } => {
+    if (candidate.kind === 'condition') {
+      const column = columns.get(candidate.field);
+      if (!column) {
+        reportFilterError(
+          `Report filter field is not declared: ${candidate.field}`,
+        );
+      }
+      return filterScopeForColumn(column) === 'where'
+        ? { where: candidate }
+        : { having: candidate };
+    }
+
+    if (candidate.kind === 'all') {
+      const children = candidate.filters.map(split);
+      const where = combineAll(
+        children.flatMap((child) => (child.where ? [child.where] : [])),
+      );
+      const having = combineAll(
+        children.flatMap((child) => (child.having ? [child.having] : [])),
+      );
+      return {
+        ...(where ? { where } : {}),
+        ...(having ? { having } : {}),
+      };
+    }
+
+    const children =
+      candidate.kind === 'not'
+        ? [split(candidate.filter)]
+        : candidate.filters.map(split);
+    const scopes = new Set(
+      children.flatMap((child) => [
+        ...(child.where ? (['where'] as const) : []),
+        ...(child.having ? (['having'] as const) : []),
+      ]),
+    );
+    if (scopes.size !== 1) {
+      reportFilterError(
+        'Report WHERE and HAVING filters cannot be mixed inside one OR or NOT expression',
+      );
+    }
+    const scope = scopes.has('where') ? 'where' : 'having';
+    const filters = children.flatMap((child) => {
+      const filter = scope === 'where' ? child.where : child.having;
+      return filter ? [filter] : [];
+    });
+    if (candidate.kind === 'not') {
+      const [filter] = filters;
+      if (!filter) {
+        reportFilterError('Report NOT expressions must contain one filter');
+      }
+      return scope === 'where'
+        ? { where: { kind: 'not', filter } }
+        : { having: { kind: 'not', filter } };
+    }
+    return scope === 'where'
+      ? { where: { kind: 'any', filters } }
+      : { having: { kind: 'any', filters } };
+  };
+
+  return split(filter);
 }
 
 function jsonSafeValue(
@@ -865,25 +1348,58 @@ function queryFreshness(
 }
 
 /**
- * Execute the bounded materialized-read slice owned by #2457.
- *
- * Dimension/measure filters, HAVING/WHERE mapping, facets, and caller-selected
- * dimension/measure ordering intentionally remain unsupported until their
- * report-specific adapter slice lands. Identity ordering stays available for
- * deterministic paging. The collection is the tenant boundary: callers may
- * inject one, but the default path resolves it through ObjectRegistry so the
- * normal SMRT tenancy interceptors apply.
+ * Execute bounded materialized report reads through the canonical query
+ * envelope. Every predicate is an adapter-declared field/operator pair; the
+ * collection converts it to parameterized SQL and applies tenant interceptors
+ * to list, count, and facet reads alike.
  */
+export function queryReportMaterializedRows(
+  reportCtor: new (...args: any[]) => SmrtObject,
+  input: unknown,
+  options: ReportBackgroundQueryOptions,
+): Promise<ReportBackgroundQueryResult>;
+export function queryReportMaterializedRows(
+  reportCtor: new (...args: any[]) => SmrtObject,
+  input: unknown,
+  options?: ReportQueryOptions,
+): Promise<ReportDataQueryResult>;
 export async function queryReportMaterializedRows(
   reportCtor: new (...args: any[]) => SmrtObject,
   input: unknown,
-  options: ReportQueryOptions = {},
-): Promise<ReportDataQueryResult> {
+  options: ReportQueryOptions | ReportBackgroundQueryOptions = {},
+): Promise<ReportDataQueryResult | ReportBackgroundQueryResult> {
   const descriptor = await buildReportAdapterDescriptor(reportCtor);
   const request = normalizeDataQueryRequest(input, descriptor.schema);
-  if (request.mode === 'facets') {
-    throw new Error('Report materialized reads do not support facets yet');
+  // Validate the semantic split even though materialized-row reads execute the
+  // complete predicate against one persisted table. It prevents an adapter
+  // consumer from silently treating a mixed source WHERE/HAVING expression as
+  // either side of the aggregate boundary.
+  splitReportFilterScopes(descriptor, request.filter);
+  const queryFingerprint = createDataQueryFingerprint(
+    request,
+    descriptor.schema,
+  );
+  if (options.execution === 'background') {
+    const queued = await options.enqueueBackgroundQuery({
+      version: 1,
+      execution: 'background',
+      resourceId: descriptor.resourceId,
+      reportClassName: descriptor.reportClassName,
+      request,
+      inherits: ['principal', 'tenant', 'report-definition', 'field-policy'],
+    });
+    if (typeof queued.taskId !== 'string' || queued.taskId.length === 0) {
+      throw new Error('Background report query hosts must return a task id');
+    }
+    return {
+      version: 1,
+      execution: 'background',
+      status: 'queued',
+      taskId: queued.taskId,
+      queryFingerprint,
+    };
   }
+  const execution = options.execution ?? 'visible';
   const lifecycleDb = options.db;
   if (options.lifecycle && !lifecycleDb) {
     throw new Error('Report lifecycle disclosure requires a database handle');
@@ -896,6 +1412,7 @@ export async function queryReportMaterializedRows(
     ? await getReportLifecycle(reportCtor, lifecycleOptions)
     : undefined;
   const fieldMap = publicFieldMap(descriptor);
+  const where = materializedWhere(request.filter, fieldMap);
   const collection: NonNullable<ReportQueryOptions['collection']> =
     options.collection ??
     ((await ObjectRegistry.getCollection(descriptor.reportClassName, {
@@ -904,6 +1421,7 @@ export async function queryReportMaterializedRows(
   let rows: Record<string, unknown>[] = [];
   let page: DataQueryResult['page'];
   let total: number;
+  let facets: DataQueryResult['facets'];
   if (request.mode === 'rows') {
     const projection = request.projection ?? [descriptor.identityField];
     const select = projection.map((id) => fieldMap.get(id) ?? id);
@@ -918,6 +1436,7 @@ export async function queryReportMaterializedRows(
       offset,
       limit,
       orderBy: orderBy?.length === 1 ? orderBy[0] : orderBy,
+      ...(where === undefined ? {} : { where }),
     });
     rows = materialized.map((row) =>
       mapMaterializedRow(row, projection, fieldMap),
@@ -931,7 +1450,7 @@ export async function queryReportMaterializedRows(
     });
     // SmrtReportCollection performs an eligible TTL refresh from list(). Count
     // must follow that operation so total/hasMore describe the same snapshot.
-    total = await collection.count();
+    total = await collection.count(where === undefined ? undefined : { where });
     page = {
       kind: 'offset',
       offset,
@@ -946,17 +1465,51 @@ export async function queryReportMaterializedRows(
       offset: 0,
       limit: 1,
       orderBy: 'id ASC',
+      ...(where === undefined ? {} : { where }),
     });
-    total = await collection.count();
+    total = await collection.count(where === undefined ? undefined : { where });
+    if (request.mode === 'facets') {
+      if (!collection.facets) {
+        throw new Error(
+          'Report materialized facet reads require a collection facets() implementation',
+        );
+      }
+      const requested = request.facets ?? [];
+      const sourceFacets = await collection.facets({
+        fields: requested.map((facet) => ({
+          field: fieldMap.get(facet.field) ?? facet.field,
+          limit: facet.limit,
+        })),
+        ...(where === undefined ? {} : { where }),
+      });
+      const byField = new Map(
+        sourceFacets.map((facet) => [facet.field, facet]),
+      );
+      facets = requested.map((facet) => {
+        const sourceField = fieldMap.get(facet.field) ?? facet.field;
+        const values = byField.get(sourceField)?.values ?? [];
+        return {
+          field: facet.field,
+          values: values.map((value) => ({
+            value: value.value,
+            count: value.count,
+          })),
+          // The collection deliberately bounds this database grouping query;
+          // an exactly-full page may have more values, so report conservatively.
+          truncated: values.length >= facet.limit,
+        };
+      });
+    }
   }
   const result = {
     version: 1 as const,
     requestId: request.requestId,
-    queryFingerprint: createDataQueryFingerprint(request, descriptor.schema),
+    queryFingerprint,
     identityField: descriptor.identityField,
     rows,
     ...(page ? { page } : {}),
     total: { kind: 'exact' as const, value: total },
+    ...(facets === undefined ? {} : { facets }),
     freshness: { state: 'unknown' as const },
     warnings: [],
     truncated: false,
@@ -966,11 +1519,14 @@ export async function queryReportMaterializedRows(
     request,
     descriptor.schema,
   );
-  if (!lifecycleBefore || !lifecycleOptions) return normalized;
+  if (!lifecycleBefore || !lifecycleOptions) {
+    return { ...normalized, execution };
+  }
 
   const lifecycleAfter = await getReportLifecycle(reportCtor, lifecycleOptions);
   return {
     ...normalized,
+    execution,
     freshness: queryFreshness(lifecycleAfter),
     reportLifecycle: {
       snapshot: lifecycleAfter,

--- a/packages/reports/src/index.ts
+++ b/packages/reports/src/index.ts
@@ -1,6 +1,9 @@
 export type {
   ReportAdapterDescriptor,
   ReportAdapterOptions,
+  ReportBackgroundQueryOptions,
+  ReportBackgroundQueryResult,
+  ReportBackgroundQueryTask,
   ReportColumnCapability,
   ReportColumnDescriptor,
   ReportColumnKind,
@@ -17,15 +20,24 @@ export type {
   ReportDataTableStructuralRowInput,
   ReportDataTableStructuralRowKind,
   ReportDataTableValueFormat,
+  ReportDrilldownConstraint,
+  ReportDrilldownDescriptor,
+  ReportDrilldownFieldDescriptor,
+  ReportDrilldownQuery,
+  ReportFilterScope,
   ReportMaterializedReadLifecycle,
+  ReportQueryExecutionDescriptor,
+  ReportQueryExecutionMode,
   ReportQueryOptions,
   ReportRefreshActionDescriptor,
   ReportRefreshDescriptor,
 } from './adapter.js';
 export {
   buildReportAdapterDescriptor,
+  buildReportDrilldownQuery,
   queryReportMaterializedRows,
   reportMaterializedRowKey,
+  splitReportFilterScopes,
 } from './adapter.js';
 export {
   bucketExpr,

--- a/packages/tenancy/src/__tests__/tenancy.test.ts
+++ b/packages/tenancy/src/__tests__/tenancy.test.ts
@@ -442,6 +442,30 @@ describe('TenantInterceptor', () => {
       });
     });
 
+    it('rejects empty DNF predicates before applying tenant scope', async () => {
+      registerTenantScopedClass('Document');
+      const interceptor = createTenantInterceptor();
+      const invalidDnfWhereClauses: Array<
+        Array<Array<Record<string, unknown>>>
+      > = [[], [[]]];
+
+      await withTenant({ tenantId: 'tenant-123' }, async () => {
+        for (const where of invalidDnfWhereClauses) {
+          expect(() =>
+            interceptor.beforeList?.(
+              'Document',
+              { where },
+              {
+                className: 'Document',
+                operation: 'list',
+                timestamp: new Date(),
+              },
+            ),
+          ).toThrow(/Invalid DNF where clause/);
+        }
+      });
+    });
+
     it('should throw when context required but missing', () => {
       registerTenantScopedClass('Document', { mode: 'required' });
       const interceptor = createTenantInterceptor();

--- a/packages/tenancy/src/interceptor.ts
+++ b/packages/tenancy/src/interceptor.ts
@@ -257,6 +257,14 @@ export function createTenantInterceptor(
       // make one branch escape tenant scope, so validate direct tenant filters
       // branch-by-branch before adding the current tenant where absent.
       if (Array.isArray(where)) {
+        if (
+          where.length === 0 ||
+          where.some((andGroup) => andGroup.length === 0)
+        ) {
+          throw new Error(
+            'Invalid DNF where clause: every OR branch must contain at least one condition',
+          );
+        }
         const scopedWhere = where.map((andGroup) => {
           const directValues = andGroup.flatMap((condition) => {
             if (!Object.hasOwn(condition, tenantField)) return [];

--- a/packages/tenancy/src/interceptor.ts
+++ b/packages/tenancy/src/interceptor.ts
@@ -252,6 +252,44 @@ export function createTenantInterceptor(
       const tenantField = config?.field || 'tenantId';
       const where = listOptions.where || {};
 
+      // Preserve DNF predicates (outer OR, inner AND) by applying the tenant
+      // predicate to every branch. Flattening this shape into an object would
+      // make one branch escape tenant scope, so validate direct tenant filters
+      // branch-by-branch before adding the current tenant where absent.
+      if (Array.isArray(where)) {
+        const scopedWhere = where.map((andGroup) => {
+          const directValues = andGroup.flatMap((condition) => {
+            if (!Object.hasOwn(condition, tenantField)) return [];
+            const value = condition[tenantField];
+            return Array.isArray(value) ? value : [value];
+          });
+          const offendingIndex = directValues.findIndex(
+            (value) => value !== tenantContext.tenantId,
+          );
+          if (offendingIndex !== -1) {
+            const offending = directValues[offendingIndex];
+            opts.onIsolationViolation?.(
+              className,
+              tenantContext.tenantId,
+              String(offending),
+              context,
+            );
+            throw new TenantIsolationError(
+              `Tenant isolation violation in ${className} query: ` +
+                `context tenant is '${tenantContext.tenantId}' but query filters by '${String(offending)}'`,
+              {
+                tenantId: tenantContext.tenantId,
+                attemptedTenantId: String(offending),
+              },
+            );
+          }
+          return directValues.length > 0
+            ? andGroup
+            : [...andGroup, { [tenantField]: tenantContext.tenantId }];
+        });
+        return { ...listOptions, where: scopedWhere };
+      }
+
       // Check if tenant filter is already present
       if (tenantField in where) {
         // Validate it matches context. The filter may be a scalar


### PR DESCRIPTION
## Summary
- Add typed, tenant-safe materialized report filters, multi-sort, exact totals, dimension facets, and source drilldown contracts.
- Preserve source-query WHERE/HAVING semantics and stable identity ordering; reject empty DNF predicates before tenant interception.
- Add visible, silent, and host-queued background query delivery modes without serializing authority.

Closes #2458

## Review feedback resolved
- Collection-owned STI discriminators now override conflicting caller predicates, including every DNF branch.
- Tenant interception rejects empty outer or inner DNF branches before applying tenant scope.
- Corrected the reports adapter contract documentation for materialized filtering, source-query WHERE/HAVING partitioning, and dimension-only facets.

## Validation
- reports: 52 tests, typecheck, build, and packed-export verification
- core: STI regression tests (6) and typecheck
- tenancy: DNF regression tests (64) and typecheck
- strict knowledge freshness and full pre-push validation suite

## Review
- Preliminary tenant/data review and final independent gate clear on rebased head 418c26ffb5465b0112523f172bc3ff624ef0b6e9.
- Claude review target unavailable: local CLI is not authenticated.

<!-- hv-agent-run:v1 -->
```json
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-2458-report-query-reviewfix-20260823","issue":2458,"policy_revision":"1.0.0","status":"complete","validation":["reports test (52)","reports typecheck/build/verify:pack","core STI regression test (6) and typecheck","tenancy DNF regression test (64) and typecheck","knowledge freshness","pre-push suite","tenant/data preliminary review clear","final gate clear after rebase"]}
```
