### PR TITLE
feat(smrt-web): add reactive remote query binding

### DIFF
--- a/packages/smrt-svelte/AGENTS.md
+++ b/packages/smrt-svelte/AGENTS.md
@@ -15,6 +15,7 @@ subpath you are editing. This file keeps what holds in every module.
 | `src/test-support/` + `__tests__/` | the golden-test harness and pattern for Svelte component tests | [agents/testing.md](agents/testing.md) |
 | `src/components/settings/` (`./settings`) | `SettingsCatalog`, `paginateSettingsCatalog`, and the summary-vs-detail scalability contract | [agents/settings.md](agents/settings.md) |
 | `src/components/workspace/` (`./workspace` + `./web`) | the AdminShell family and its principles, the legacy ToolsDock surface, the `./web` activity-feed and `updateAvailable` adapters, and server-side dock gates | [agents/workspace.md](agents/workspace.md) |
+| `src/web/remote-query.svelte.ts` | Svelte 5 binding for query-shaped remote pages: rows, page, totals, loading/refreshing/stale/error, retry, last-updated, and query-scoped live subscriptions (#2445) | — |
 
 ## The UI split — primitive-adoption contract (#1589)
 

--- a/packages/smrt-svelte/README.md
+++ b/packages/smrt-svelte/README.md
@@ -60,6 +60,23 @@ state.
 
 ## Usage
 
+### Query-backed data surfaces
+
+Use the web binding when a table should render one remote page instead of
+hydrating its whole collection. It exposes `rows`, `page`, `total`,
+`loading`, `refreshing`, `stale`, `error`, `retry`, and `lastUpdated`.
+
+```svelte
+<script lang="ts">
+  import { remoteQuery } from '@happyvertical/smrt-svelte/web';
+  const view = remoteQuery(collection, transport);
+  void view.execute(request);
+</script>
+
+{#if view.loading}<p>Loading…</p>{/if}
+{#each view.rows as row (row.id)}<div>{row.name}</div>{/each}
+```
+
 ### Provider Setup
 
 ```svelte

--- a/packages/smrt-svelte/src/web/index.ts
+++ b/packages/smrt-svelte/src/web/index.ts
@@ -30,6 +30,12 @@ export {
   liveCollection,
 } from './live-collection.svelte.js';
 export {
+  createRemoteQueryBinding,
+  queryBinding,
+  type RemoteQueryBinding,
+  remoteQuery,
+} from './remote-query.svelte.js';
+export {
   type UpdateAvailableView,
   type UseUpdateAvailableOptions,
   useUpdateAvailable,

--- a/packages/smrt-svelte/src/web/index.ts
+++ b/packages/smrt-svelte/src/web/index.ts
@@ -30,8 +30,6 @@ export {
   liveCollection,
 } from './live-collection.svelte.js';
 export {
-  createRemoteQueryBinding,
-  queryBinding,
   type RemoteQueryBinding,
   remoteQuery,
 } from './remote-query.svelte.js';

--- a/packages/smrt-svelte/src/web/remote-query.svelte.ts
+++ b/packages/smrt-svelte/src/web/remote-query.svelte.ts
@@ -1,0 +1,100 @@
+import {
+  createSmrtWebQuery,
+  type SmrtWebCollection,
+  type SmrtWebDataQueryRequest,
+  type SmrtWebDataQueryResult,
+  type SmrtWebQuery,
+  type SmrtWebQueryLiveSubscription,
+  type SmrtWebQueryRunOptions,
+  type SmrtWebQueryState,
+  type SmrtWebQueryTransport,
+} from '@happyvertical/smrt-web';
+
+export interface RemoteQueryBinding<TData extends object = object> {
+  readonly rows: ReadonlyArray<TData>;
+  readonly page: SmrtWebQueryState<TData>['page'];
+  readonly total: SmrtWebQueryState<TData>['total'];
+  readonly loading: boolean;
+  readonly refreshing: boolean;
+  readonly stale: boolean;
+  readonly error: unknown;
+  readonly lastUpdated: number | undefined;
+  readonly request: SmrtWebDataQueryRequest | undefined;
+  execute(
+    request: SmrtWebDataQueryRequest,
+    options?: SmrtWebQueryRunOptions,
+  ): Promise<SmrtWebDataQueryResult>;
+  refresh(
+    options?: Omit<SmrtWebQueryRunOptions, 'mode' | 'force'>,
+  ): Promise<SmrtWebDataQueryResult | undefined>;
+  retry(): Promise<SmrtWebDataQueryResult | undefined>;
+  subscribeLive(): SmrtWebQueryLiveSubscription | undefined;
+  dispose(): void;
+}
+
+/**
+ * Bind a canonical remote query to Svelte 5 state. The binding is query
+ * shaped: rows are only the requested page and never the entire collection.
+ * Call during component initialization so cleanup follows the component.
+ */
+export function remoteQuery<TData extends object>(
+  collection: SmrtWebCollection<TData>,
+  transport: SmrtWebQueryTransport,
+  options?: { staleTimeMs?: number },
+): RemoteQueryBinding<TData> {
+  const query: SmrtWebQuery<TData> = createSmrtWebQuery(
+    collection,
+    transport,
+    options,
+  );
+  let snapshot = $state<SmrtWebQueryState<TData>>(query.state);
+  const unsubscribe = query.subscribe((next) => {
+    snapshot = next;
+  });
+  $effect(() => () => {
+    unsubscribe();
+    query.dispose();
+  });
+  const binding: RemoteQueryBinding<TData> = {
+    get rows() {
+      return snapshot.rows;
+    },
+    get page() {
+      return snapshot.page;
+    },
+    get total() {
+      return snapshot.total;
+    },
+    get loading() {
+      return snapshot.loading;
+    },
+    get refreshing() {
+      return snapshot.refreshing;
+    },
+    get stale() {
+      return snapshot.stale;
+    },
+    get error() {
+      return snapshot.error;
+    },
+    get lastUpdated() {
+      return snapshot.lastUpdated;
+    },
+    get request() {
+      return query.request;
+    },
+    execute: (request, runOptions) => query.execute(request, runOptions),
+    refresh: (runOptions) => query.refresh(runOptions),
+    retry: () => query.retry(),
+    subscribeLive: () => query.subscribeLive(),
+    dispose: () => {
+      unsubscribe();
+      query.dispose();
+    },
+  };
+  return binding;
+}
+
+/** Explicit alias for consumers that prefer the data-source terminology. */
+export const createRemoteQueryBinding = remoteQuery;
+export const queryBinding = remoteQuery;

--- a/packages/smrt-svelte/src/web/remote-query.svelte.ts
+++ b/packages/smrt-svelte/src/web/remote-query.svelte.ts
@@ -94,7 +94,3 @@ export function remoteQuery<TData extends object>(
   };
   return binding;
 }
-
-/** Explicit alias for consumers that prefer the data-source terminology. */
-export const createRemoteQueryBinding = remoteQuery;
-export const queryBinding = remoteQuery;

--- a/packages/smrt-web/AGENTS.md
+++ b/packages/smrt-web/AGENTS.md
@@ -41,6 +41,7 @@ module you are editing. This file keeps what holds in every module.
 | `webmcp.ts` | framework-agnostic WebMCP registrar; registers generated collection tools and routes mutations through shared smrt-web cache state | — |
 | `persistence/` + `update-state.ts` | the read-cache rehydrate capability and the framework-free `updateAvailable` primitive (bundle + contract signals) | [agents/version-persistence.md](agents/version-persistence.md) |
 | `data-query.ts` | dependency-free browser mirror and defensive response normalizer for the canonical bounded data-query envelope (#2444) | — |
+| `remote-query.ts` | query-shaped remote pages over a `SmrtWebCollection`, with keyed stale cache, execution modes, cancellation/latest-query-wins, and optional query-scoped live subscriptions (#2445) | — |
 
 ## The engine-absorption boundary (ratified conditions, #1761)
 

--- a/packages/smrt-web/README.md
+++ b/packages/smrt-web/README.md
@@ -125,7 +125,7 @@ core.
 | Group | Main exports |
 | --- | --- |
 | Collections | `createSmrtCollection`, `createSmrtWebClient`, `newLocalId` |
-| Remote queries | `createSmrtWebQuery`, `createSmrtDataQuery`, `SmrtWebQueryTransport` |
+| Remote queries | `createSmrtWebQuery`, `SmrtWebQueryTransport` |
 | HTTP | `createDefinitionFetchers`, `unwrapListResult`, `unwrapItemResult` |
 | Offline | `offlineOutbox`, `getOutboxHandle` |
 | Persistence | `persistCollection`, `wipeDurableStore` |

--- a/packages/smrt-web/README.md
+++ b/packages/smrt-web/README.md
@@ -9,6 +9,12 @@ Use it for browser-side collection state, shared request deduplication, offline
 writes, persisted read caches, and live invalidation. Svelte bindings live in
 [`@happyvertical/smrt-svelte/web`](../smrt-svelte/README.md).
 
+Query-backed surfaces can use `createSmrtWebQuery(collection, transport)` to
+fetch one canonical bounded page. Visible runs update state; `background`,
+`prefetch`, and `silent` runs stay out of visible state. The controller keeps
+stale rows available while refreshing, cancels superseded visible runs, and can
+attach a query-scoped live subscription.
+
 ## Installation
 
 ```bash
@@ -119,6 +125,7 @@ core.
 | Group | Main exports |
 | --- | --- |
 | Collections | `createSmrtCollection`, `createSmrtWebClient`, `newLocalId` |
+| Remote queries | `createSmrtWebQuery`, `createSmrtDataQuery`, `SmrtWebQueryTransport` |
 | HTTP | `createDefinitionFetchers`, `unwrapListResult`, `unwrapItemResult` |
 | Offline | `offlineOutbox`, `getOutboxHandle` |
 | Persistence | `persistCollection`, `wipeDurableStore` |

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -121,6 +121,20 @@ export {
   DEFAULT_PERSIST_DEBOUNCE_MS,
   persistCollection,
 } from './persistence.js';
+export type {
+  SmrtWebQuery,
+  SmrtWebQueryLiveSubscription,
+  SmrtWebQueryMode,
+  SmrtWebQueryPage,
+  SmrtWebQueryRunOptions,
+  SmrtWebQueryState,
+  SmrtWebQueryTransport,
+} from './remote-query.js';
+export {
+  createSmrtDataQuery,
+  createSmrtQuery,
+  createSmrtWebQuery,
+} from './remote-query.js';
 // Live-updates subscriber (#1763-client): the ONE app-wide SSE `_events`
 // subscriber (with `_changes` polling fallback) and the thin per-collection
 // `liveInvalidation` capability that wires a collection's `ctx.invalidate()` to

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -130,11 +130,7 @@ export type {
   SmrtWebQueryState,
   SmrtWebQueryTransport,
 } from './remote-query.js';
-export {
-  createSmrtDataQuery,
-  createSmrtQuery,
-  createSmrtWebQuery,
-} from './remote-query.js';
+export { createSmrtWebQuery } from './remote-query.js';
 // Live-updates subscriber (#1763-client): the ONE app-wide SSE `_events`
 // subscriber (with `_changes` polling fallback) and the thin per-collection
 // `liveInvalidation` capability that wires a collection's `ctx.invalidate()` to

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -333,4 +333,33 @@ describe('remote query controller', () => {
     query.dispose();
     await collection.cleanup();
   });
+
+  it('rejects a delayed transport result after its signal is aborted', async () => {
+    const caller = new AbortController();
+    let release!: (result: unknown) => void;
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        if (calls > 1) return envelope(received, 'cancelled');
+        return await new Promise<unknown>((resolve) => {
+          release = resolve;
+        });
+      },
+    });
+    const pending = query.execute(request, { signal: caller.signal });
+    caller.abort();
+    release(envelope(request, 'cancelled'));
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(query.state.rows).toEqual([]);
+
+    await query.execute(request);
+    expect(calls).toBe(2);
+    expect(query.state.rows[0]?.name).toBe('cancelled');
+    query.dispose();
+    await collection.cleanup();
+  });
 });

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -275,6 +275,77 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('keeps a live result newer than an older forced flight', async () => {
+    let resolveOld!: (result: unknown) => void;
+    let onLive: ((value: unknown) => void) | undefined;
+    let queryCalls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        queryCalls += 1;
+        if (queryCalls === 1) return envelope(received, 'initial');
+        return await new Promise((resolve) => {
+          resolveOld = resolve;
+        });
+      },
+      subscribe: (_received, callback) => {
+        onLive = callback;
+        return { unsubscribe: () => undefined };
+      },
+    });
+    await query.execute(request);
+    query.subscribeLive();
+    const oldFlight = query.execute(request, {
+      mode: 'background',
+      force: true,
+    });
+    await vi.waitFor(() => expect(queryCalls).toBe(2));
+    onLive?.(envelope(request, 'live'));
+    await vi.waitFor(() => expect(query.state.rows[0]?.name).toBe('live'));
+    resolveOld(envelope(request, 'old'));
+    await oldFlight;
+
+    await query.execute(request);
+    expect(queryCalls).toBe(2);
+    expect(query.state.rows[0]?.name).toBe('live');
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('does not let a pending flight repopulate cache after dispose', async () => {
+    let resolvePending!: (result: unknown) => void;
+    let queryCalls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        queryCalls += 1;
+        if (queryCalls === 1) return envelope(received, 'initial');
+        if (queryCalls === 2) {
+          return await new Promise((resolve) => {
+            resolvePending = resolve;
+          });
+        }
+        return envelope(received, 'after-dispose');
+      },
+    });
+    await query.execute(request);
+    const pending = query.refresh();
+    await vi.waitFor(() => expect(queryCalls).toBe(2));
+    query.dispose();
+    resolvePending(envelope(request, 'disposed-flight'));
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(query.state.rows[0]?.name).toBe('initial');
+
+    await query.execute(request, { mode: 'background' });
+    expect(queryCalls).toBe(3);
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('prefetches into the keyed cache without changing visible state, then refreshes coherently', async () => {
     let value = 'prefetched';
     const collection = createSmrtCollection(definition, {

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createSmrtCollection,
+  createSmrtWebQuery,
+  type SmrtWebCollectionDefinition,
+  type SmrtWebDataQueryRequest,
+} from './index.js';
+
+interface Row {
+  id?: string;
+  name: string;
+}
+
+const definition: SmrtWebCollectionDefinition<Row> = {
+  name: 'remote-products',
+  className: 'Product',
+  endpoint: '/products',
+  idField: 'id',
+  actions: ['list'],
+  fields: { name: { type: 'text' } },
+};
+const request: SmrtWebDataQueryRequest = {
+  version: 1,
+  requestId: 'request-1',
+  mode: 'rows',
+  page: { kind: 'offset', offset: 0, limit: 10 },
+};
+
+function envelope(received: SmrtWebDataQueryRequest, name: string) {
+  return {
+    version: 1,
+    requestId: received.requestId,
+    queryFingerprint: 'dq1_products',
+    identityField: 'id',
+    rows: [{ id: name, name }],
+    page: { kind: 'offset', offset: 0, limit: 10, hasMore: false },
+    total: { kind: 'exact', value: 1 },
+    freshness: { state: 'fresh' },
+    warnings: [],
+    truncated: false,
+  };
+}
+
+describe('remote query controller', () => {
+  it('loads one page without hydrating the base collection and exposes table state', async () => {
+    let listCalls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: {
+        list: async () => {
+          listCalls += 1;
+          return [];
+        },
+        create: async () => ({}),
+      },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => envelope(received, 'Ada'),
+    });
+
+    await query.execute(request);
+    expect(listCalls).toBe(0);
+    expect(query.state.rows).toEqual([{ id: 'Ada', name: 'Ada' }]);
+    expect(query.state.page?.kind).toBe('offset');
+    expect(query.state.total).toEqual({ kind: 'exact', value: 1 });
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('suppresses an older visible response and never exposes its error', async () => {
+    let releaseFirst!: () => void;
+    const first = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let call = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        call += 1;
+        if (call === 1) await first;
+        return envelope(received, call === 1 ? 'old' : 'new');
+      },
+    });
+    const older = query.execute(request).catch(() => undefined);
+    const newerRequest = {
+      ...request,
+      requestId: 'request-2',
+      page: { kind: 'offset' as const, offset: 10, limit: 10 },
+    };
+    await query.execute(newerRequest);
+    releaseFirst();
+    await older;
+    expect(query.state.rows).toEqual([{ id: 'new', name: 'new' }]);
+    expect(query.state.error).toBeNull();
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('prefetches into the keyed cache without changing visible state, then refreshes coherently', async () => {
+    let value = 'prefetched';
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => envelope(received, value),
+    });
+    await query.execute(request, { mode: 'prefetch' });
+    expect(query.state.rows).toEqual([]);
+    await query.execute(request);
+    expect(query.state.rows[0]?.name).toBe('prefetched');
+    value = 'fresh';
+    await query.refresh();
+    expect(query.state.rows[0]?.name).toBe('fresh');
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('subscribes to the exact query and applies matching live pages', async () => {
+    let onResult: ((value: unknown) => void) | undefined;
+    let unsubscribed = false;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => envelope(received, 'initial'),
+      subscribe: (received, callback) => {
+        expect(received.page).toEqual(request.page);
+        onResult = callback;
+        return {
+          unsubscribe: () => {
+            unsubscribed = true;
+          },
+        };
+      },
+    });
+    await query.execute(request);
+    const live = query.subscribeLive();
+    onResult?.(envelope(request, 'live'));
+    await vi.waitFor(() => expect(query.state.rows[0]?.name).toBe('live'));
+    live?.unsubscribe();
+    expect(unsubscribed).toBe(true);
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('passes deadline cancellation through without surfacing an abort as a query error', async () => {
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (_received, options) => {
+        if (options?.signal?.aborted) throw options.signal.reason;
+        return await new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => reject(options.signal?.reason),
+            { once: true },
+          );
+        });
+      },
+    });
+    await expect(
+      query.execute(request, { deadlineMs: 0 }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(query.state.error).toBeNull();
+    query.dispose();
+    await collection.cleanup();
+  });
+});

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -329,6 +329,41 @@ describe('remote query controller', () => {
     await expect(
       query.execute(request, { deadlineMs: 0 }),
     ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(query.state.loading).toBe(false);
+    expect(query.state.refreshing).toBe(false);
+    expect(query.state.error).toBeNull();
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('clears refreshing after the current refresh is cancelled', async () => {
+    const caller = new AbortController();
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received, options) => {
+        calls += 1;
+        if (calls === 1) return envelope(received, 'cached');
+        return await new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => reject(options.signal?.reason),
+            { once: true },
+          );
+        });
+      },
+    });
+    await query.execute(request);
+    const pending = query.refresh({ signal: caller.signal });
+    await vi.waitFor(() => expect(query.state.refreshing).toBe(true));
+    caller.abort();
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(query.state.rows[0]?.name).toBe('cached');
+    expect(query.state.loading).toBe(false);
+    expect(query.state.refreshing).toBe(false);
+    expect(query.state.stale).toBe(true);
     expect(query.state.error).toBeNull();
     query.dispose();
     await collection.cleanup();

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -485,6 +485,35 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('treats a transport custom error after abort as cancellation', async () => {
+    const caller = new AbortController();
+    let started = false;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (_received, options) => {
+        started = true;
+        return await new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => reject(new Error('transport cancellation')),
+            { once: true },
+          );
+        });
+      },
+    });
+    const pending = query.execute(request, { signal: caller.signal });
+    await vi.waitFor(() => expect(started).toBe(true));
+    caller.abort();
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(query.state.error).toBeNull();
+    expect(query.state.loading).toBe(false);
+    expect(query.state.refreshing).toBe(false);
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('clears refreshing after the current refresh is cancelled', async () => {
     const caller = new AbortController();
     let calls = 0;

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -128,6 +128,45 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it("does not let an earlier caller's abort cancel its visible successor", async () => {
+    const callerA = new AbortController();
+    const calls: string[] = [];
+    let resolveB!: (result: unknown) => void;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received, options) => {
+        calls.push(received.requestId);
+        if (received.requestId === 'request-1') {
+          return await new Promise<never>((_resolve, reject) => {
+            options?.signal?.addEventListener(
+              'abort',
+              () => reject(options.signal?.reason),
+              { once: true },
+            );
+          });
+        }
+        return await new Promise((resolve) => {
+          resolveB = resolve;
+        });
+      },
+    });
+    const first = query
+      .execute(request, { signal: callerA.signal })
+      .catch(() => undefined);
+    await vi.waitFor(() => expect(calls).toEqual(['request-1']));
+    const second = query.execute({ ...request, requestId: 'request-2' });
+    await vi.waitFor(() => expect(calls).toEqual(['request-1', 'request-2']));
+    callerA.abort();
+    resolveB(envelope({ ...request, requestId: 'request-2' }, 'successor'));
+    await second;
+    await first;
+    expect(query.state.rows[0]?.name).toBe('successor');
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('keeps the forced successor in the in-flight map until it settles', async () => {
     const releases: Array<() => void> = [];
     let calls = 0;
@@ -226,6 +265,7 @@ describe('remote query controller', () => {
     await query.execute(request);
     const live = query.subscribeLive();
     const oldCallback = callbacks[0];
+    oldCallback?.(envelope(request, 'late-before-reconnect'));
     live?.reconnect();
     await vi.waitFor(() => expect(subscriptions).toBe(2));
     expect(queryCalls).toBe(2);

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -514,6 +514,35 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('normalizes an arbitrary caller abort reason', async () => {
+    const caller = new AbortController();
+    let started = false;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (_received, options) => {
+        started = true;
+        return await new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => reject(options.signal?.reason),
+            { once: true },
+          );
+        });
+      },
+    });
+    const pending = query.execute(request, { signal: caller.signal });
+    await vi.waitFor(() => expect(started).toBe(true));
+    caller.abort('caller reason');
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(query.state.error).toBeNull();
+    expect(query.state.loading).toBe(false);
+    expect(query.state.refreshing).toBe(false);
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('clears refreshing after the current refresh is cancelled', async () => {
     const caller = new AbortController();
     let calls = 0;

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -197,6 +197,40 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('keeps an older forced flight from overwriting a newer cached result', async () => {
+    const releases: Array<() => void> = [];
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        const name = calls === 1 ? 'A' : 'B';
+        return await new Promise((resolve) => {
+          releases.push(() => resolve(envelope(received, name)));
+        });
+      },
+    });
+    const first = query.execute(request, { mode: 'background' });
+    await vi.waitFor(() => expect(calls).toBe(1));
+    const second = query.execute(request, {
+      mode: 'background',
+      force: true,
+    });
+    await vi.waitFor(() => expect(calls).toBe(2));
+    releases[1]?.();
+    await second;
+    releases[0]?.();
+    await first;
+
+    await query.execute(request);
+    expect(calls).toBe(2);
+    expect(query.state.rows[0]?.name).toBe('B');
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('prefetches into the keyed cache without changing visible state, then refreshes coherently', async () => {
     let value = 'prefetched';
     const collection = createSmrtCollection(definition, {

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -97,6 +97,67 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('starts a new same-key visible request after aborting its predecessor', async () => {
+    const calls: string[] = [];
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received, options) => {
+        calls.push(received.requestId);
+        if (calls.length === 1) {
+          return await new Promise<never>((_resolve, reject) => {
+            options?.signal?.addEventListener(
+              'abort',
+              () => reject(options.signal?.reason),
+              { once: true },
+            );
+          });
+        }
+        return envelope(received, 'replacement');
+      },
+    });
+    const predecessor = query.execute(request).catch(() => undefined);
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+    const successor = query.execute({ ...request, requestId: 'same-key-2' });
+    await successor;
+    await predecessor;
+    expect(calls).toEqual(['request-1', 'same-key-2']);
+    expect(query.state.rows[0]?.name).toBe('replacement');
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('keeps the forced successor in the in-flight map until it settles', async () => {
+    const releases: Array<() => void> = [];
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        await new Promise<void>((resolve) => releases.push(resolve));
+        return envelope(received, `flight-${calls}`);
+      },
+    });
+    const predecessor = query.execute(request, { mode: 'background' });
+    await vi.waitFor(() => expect(calls).toBe(1));
+    const successor = query.execute(request, {
+      mode: 'background',
+      force: true,
+    });
+    await vi.waitFor(() => expect(calls).toBe(2));
+    releases[0]?.();
+    await predecessor;
+    const deduped = query.execute(request, { mode: 'background' });
+    expect(calls).toBe(2);
+    releases[1]?.();
+    await Promise.all([successor, deduped]);
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('prefetches into the keyed cache without changing visible state, then refreshes coherently', async () => {
     let value = 'prefetched';
     const collection = createSmrtCollection(definition, {
@@ -140,6 +201,71 @@ describe('remote query controller', () => {
     await vi.waitFor(() => expect(query.state.rows[0]?.name).toBe('live'));
     live?.unsubscribe();
     expect(unsubscribed).toBe(true);
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('refetches before fallback reconnect, resubscribes, and ignores old callbacks', async () => {
+    const callbacks: Array<(value: unknown) => void> = [];
+    let queryCalls = 0;
+    let subscriptions = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        queryCalls += 1;
+        return envelope(received, queryCalls === 1 ? 'initial' : 'resynced');
+      },
+      subscribe: (_received, callback) => {
+        subscriptions += 1;
+        callbacks.push(callback);
+        return { unsubscribe: () => undefined };
+      },
+    });
+    await query.execute(request);
+    const live = query.subscribeLive();
+    const oldCallback = callbacks[0];
+    live?.reconnect();
+    await vi.waitFor(() => expect(subscriptions).toBe(2));
+    expect(queryCalls).toBe(2);
+    oldCallback?.(envelope(request, 'late-old'));
+    await Promise.resolve();
+    expect(query.state.rows[0]?.name).toBe('initial');
+    callbacks[1]?.(envelope(request, 'reconnected'));
+    await vi.waitFor(() =>
+      expect(query.state.rows[0]?.name).toBe('reconnected'),
+    );
+    live?.unsubscribe();
+    callbacks[1]?.(envelope(request, 'late-unsubscribed'));
+    await Promise.resolve();
+    expect(query.state.rows[0]?.name).toBe('reconnected');
+    query.dispose();
+    callbacks[1]?.(envelope(request, 'late-disposed'));
+    await Promise.resolve();
+    expect(query.state.rows[0]?.name).toBe('reconnected');
+    await collection.cleanup();
+  });
+
+  it('marks invalidated data stale and retains rows when the next request is offline', async () => {
+    let offline = false;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        if (offline) throw new TypeError('offline');
+        return envelope(received, 'cached');
+      },
+    });
+    await query.execute(request);
+    query.invalidate();
+    expect(query.state.stale).toBe(true);
+    offline = true;
+    await expect(query.refresh()).rejects.toThrow('offline');
+    expect(query.state.rows[0]?.name).toBe('cached');
+    expect(query.state.stale).toBe(true);
+    expect(query.state.error).toBeInstanceOf(TypeError);
     query.dispose();
     await collection.cleanup();
   });

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -231,6 +231,50 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('retains an older result when its forced successor aborts', async () => {
+    const caller = new AbortController();
+    let resolveA!: (result: unknown) => void;
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received, options) => {
+        calls += 1;
+        if (calls === 1) {
+          return await new Promise((resolve) => {
+            resolveA = resolve;
+          });
+        }
+        return await new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => reject(options.signal?.reason),
+            { once: true },
+          );
+        });
+      },
+    });
+    const first = query.execute(request, { mode: 'background' });
+    await vi.waitFor(() => expect(calls).toBe(1));
+    const second = query.execute(request, {
+      mode: 'background',
+      force: true,
+      signal: caller.signal,
+    });
+    await vi.waitFor(() => expect(calls).toBe(2));
+    caller.abort();
+    await expect(second).rejects.toMatchObject({ name: 'AbortError' });
+    resolveA(envelope(request, 'A'));
+    await first;
+
+    await query.execute(request);
+    expect(calls).toBe(2);
+    expect(query.state.rows[0]?.name).toBe('A');
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('prefetches into the keyed cache without changing visible state, then refreshes coherently', async () => {
     let value = 'prefetched';
     const collection = createSmrtCollection(definition, {

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -1,0 +1,354 @@
+import {
+  executeSmrtWebDataQuery,
+  type SmrtWebDataQueryRequest,
+  type SmrtWebDataQueryResult,
+  type SmrtWebDataQueryTransport,
+} from './data-query.js';
+import type { SmrtWebCollection } from './index.js';
+
+/** How a query run is allowed to affect the visible query state. */
+export type SmrtWebQueryMode = 'visible' | 'background' | 'prefetch' | 'silent';
+
+export interface SmrtWebQueryRunOptions {
+  mode?: SmrtWebQueryMode;
+  signal?: AbortSignal;
+  /** Cancel this run after the given number of milliseconds. */
+  deadlineMs?: number;
+  /** Bypass the keyed cache and execute a fresh request (used by refresh). */
+  force?: boolean;
+}
+
+export interface SmrtWebQueryPage {
+  kind: 'offset' | 'cursor';
+  limit: number;
+  offset?: number;
+  nextCursor?: string;
+  hasMore: boolean;
+}
+
+export interface SmrtWebQueryState<TData extends object = object> {
+  readonly rows: ReadonlyArray<TData>;
+  readonly page: SmrtWebQueryPage | undefined;
+  readonly total: SmrtWebDataQueryResult['total'] | undefined;
+  readonly loading: boolean;
+  readonly refreshing: boolean;
+  readonly stale: boolean;
+  readonly error: unknown;
+  readonly lastUpdated: number | undefined;
+  readonly result: SmrtWebDataQueryResult | undefined;
+}
+
+export interface SmrtWebQueryLiveSubscription {
+  unsubscribe(): void;
+  reconnect(): void;
+}
+
+export interface SmrtWebQueryTransport extends SmrtWebDataQueryTransport {
+  /** Subscribe to changes for this exact query, not the entire collection. */
+  subscribe?(
+    request: SmrtWebDataQueryRequest,
+    onResult: (result: unknown) => void,
+    options?: { signal?: AbortSignal },
+  ): SmrtWebQueryLiveSubscription | { unsubscribe(): void };
+}
+
+export interface SmrtWebQuery<TData extends object = object> {
+  readonly state: SmrtWebQueryState<TData>;
+  readonly request: SmrtWebDataQueryRequest | undefined;
+  execute(
+    request: SmrtWebDataQueryRequest,
+    options?: SmrtWebQueryRunOptions,
+  ): Promise<SmrtWebDataQueryResult>;
+  refresh(
+    options?: Omit<SmrtWebQueryRunOptions, 'mode' | 'force'>,
+  ): Promise<SmrtWebDataQueryResult | undefined>;
+  retry(): Promise<SmrtWebDataQueryResult | undefined>;
+  subscribe(listener: (state: SmrtWebQueryState<TData>) => void): () => void;
+  subscribeLive(): SmrtWebQueryLiveSubscription | undefined;
+  invalidate(): void;
+  dispose(): void;
+}
+
+interface CacheEntry {
+  result: SmrtWebDataQueryResult;
+  updatedAt: number;
+}
+
+function keyFor(request: SmrtWebDataQueryRequest): string {
+  // requestId is correlation metadata, not query identity. Removing it allows
+  // refreshes and independently-created equivalent requests to share a result.
+  const { requestId: _requestId, ...semantic } = request;
+  return JSON.stringify(semantic);
+}
+
+function abortError(): DOMException | Error {
+  if (typeof DOMException !== 'undefined')
+    return new DOMException('The operation was aborted', 'AbortError');
+  const error = new Error('The operation was aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+function isAbort(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    (error as { name?: unknown }).name === 'AbortError'
+  );
+}
+
+function pageOf(result: SmrtWebDataQueryResult): SmrtWebQueryPage | undefined {
+  if (!result.page) return undefined;
+  return result.page.kind === 'offset'
+    ? { ...result.page }
+    : { ...result.page };
+}
+
+/**
+ * Create a query controller over one SMRT collection. Query rows stay in a
+ * separate keyed cache; the collection's full list is never loaded.
+ */
+export function createSmrtWebQuery<TData extends object>(
+  _collection: SmrtWebCollection<TData>,
+  transport: SmrtWebQueryTransport,
+  options: { staleTimeMs?: number } = {},
+): SmrtWebQuery<TData> {
+  const staleTimeMs = options.staleTimeMs ?? 30_000;
+  const cache = new Map<string, CacheEntry>();
+  const inFlight = new Map<string, Promise<SmrtWebDataQueryResult>>();
+  const listeners = new Set<(state: SmrtWebQueryState<TData>) => void>();
+  let request: SmrtWebDataQueryRequest | undefined;
+  let visibleController: AbortController | undefined;
+  let generation = 0;
+  let live: SmrtWebQueryLiveSubscription | undefined;
+  let state: SmrtWebQueryState<TData> = {
+    rows: [],
+    page: undefined,
+    total: undefined,
+    loading: false,
+    refreshing: false,
+    stale: false,
+    error: null,
+    lastUpdated: undefined,
+    result: undefined,
+  };
+
+  const publish = (next: SmrtWebQueryState<TData>): void => {
+    state = next;
+    for (const listener of listeners) listener(state);
+  };
+  const cached = (key: string): CacheEntry | undefined => cache.get(key);
+  const apply = (
+    result: SmrtWebDataQueryResult,
+    candidate: SmrtWebDataQueryRequest,
+    updatedAt = Date.now(),
+  ): void => {
+    const entry = { result, updatedAt };
+    cache.set(keyFor(candidate), entry);
+    publish({
+      rows: result.rows as TData[],
+      page: pageOf(result),
+      total: result.total,
+      loading: false,
+      refreshing: false,
+      stale: result.freshness.state === 'stale',
+      error: null,
+      lastUpdated: updatedAt,
+      result,
+    });
+  };
+  const runTransport = async (
+    candidate: SmrtWebDataQueryRequest,
+    runOptions: SmrtWebQueryRunOptions,
+  ): Promise<SmrtWebDataQueryResult> => {
+    const controller = new AbortController();
+    const cleanups: Array<() => void> = [];
+    const abortFrom = (signal: AbortSignal | undefined): void => {
+      if (!signal) return;
+      if (signal.aborted) controller.abort(signal.reason);
+      else {
+        const abort = () => controller.abort(signal.reason);
+        signal.addEventListener('abort', abort, { once: true });
+        cleanups.push(() => signal.removeEventListener('abort', abort));
+      }
+    };
+    abortFrom(runOptions.signal);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    if (runOptions.deadlineMs !== undefined) {
+      if (runOptions.deadlineMs <= 0) controller.abort(abortError());
+      else
+        timer = setTimeout(
+          () => controller.abort(abortError()),
+          runOptions.deadlineMs,
+        );
+    }
+    try {
+      return await executeSmrtWebDataQuery(transport, candidate, {
+        signal: controller.signal,
+      });
+    } finally {
+      if (timer) clearTimeout(timer);
+      for (const cleanup of cleanups) cleanup();
+    }
+  };
+  const execute = async (
+    candidate: SmrtWebDataQueryRequest,
+    runOptions: SmrtWebQueryRunOptions = {},
+  ): Promise<SmrtWebDataQueryResult> => {
+    const mode = runOptions.mode ?? 'visible';
+    const key = keyFor(candidate);
+    const entry = cached(key);
+    const fresh =
+      entry !== undefined && Date.now() - entry.updatedAt < staleTimeMs;
+    if (mode !== 'visible' && !runOptions.force && fresh) return entry.result;
+    if (mode === 'visible' && !runOptions.force && fresh) {
+      generation += 1;
+      visibleController?.abort(abortError());
+      visibleController = undefined;
+      request = candidate;
+      apply(entry.result, candidate, entry.updatedAt);
+      return entry.result;
+    }
+    if (mode === 'visible') {
+      generation += 1;
+      visibleController?.abort(abortError());
+      visibleController = new AbortController();
+      request = candidate;
+      const current = generation;
+      const signal = runOptions.signal;
+      if (signal?.aborted) visibleController.abort(signal.reason);
+      else if (signal)
+        signal.addEventListener(
+          'abort',
+          () => visibleController?.abort(signal.reason),
+          { once: true },
+        );
+      publish({
+        ...state,
+        loading: entry === undefined,
+        refreshing: entry !== undefined,
+        stale: entry !== undefined,
+        error: null,
+      });
+      runOptions = { ...runOptions, signal: visibleController.signal };
+      try {
+        const result = await runShared(candidate, key, runOptions);
+        if (current === generation) apply(result, candidate);
+        return result;
+      } catch (error) {
+        if (current === generation && !isAbort(error)) {
+          publish({
+            ...state,
+            loading: false,
+            refreshing: false,
+            stale: entry !== undefined,
+            error,
+          });
+        }
+        throw error;
+      }
+    }
+    return runShared(candidate, key, runOptions);
+  };
+  const runShared = async (
+    candidate: SmrtWebDataQueryRequest,
+    key: string,
+    runOptions: SmrtWebQueryRunOptions,
+  ): Promise<SmrtWebDataQueryResult> => {
+    if (!runOptions.force) {
+      const running = inFlight.get(key);
+      if (running) return running;
+    }
+    const running = runTransport(candidate, runOptions)
+      .then((result) => {
+        cache.set(key, { result, updatedAt: Date.now() });
+        return result;
+      })
+      .finally(() => inFlight.delete(key));
+    inFlight.set(key, running);
+    return running;
+  };
+  const refresh = (
+    refreshOptions: Omit<SmrtWebQueryRunOptions, 'mode' | 'force'> = {},
+  ) => {
+    if (!request) return Promise.resolve(undefined);
+    return execute(request, {
+      ...refreshOptions,
+      mode: 'visible',
+      force: true,
+    });
+  };
+  const subscribeLive = (): SmrtWebQueryLiveSubscription | undefined => {
+    if (!request || !transport.subscribe) return undefined;
+    live?.unsubscribe();
+    const candidate = request;
+    const controller = new AbortController();
+    const subscription = transport.subscribe(
+      candidate,
+      (raw) => {
+        void (async () => {
+          const result = await executeSmrtWebDataQuery(
+            { query: async () => raw },
+            candidate,
+          );
+          if (request && keyFor(request) === keyFor(candidate))
+            apply(result, candidate);
+        })().catch((error) => {
+          if (!isAbort(error)) publish({ ...state, error });
+        });
+      },
+      { signal: controller.signal },
+    );
+    const reconnect =
+      'reconnect' in subscription &&
+      typeof subscription.reconnect === 'function'
+        ? () => (subscription as SmrtWebQueryLiveSubscription).reconnect()
+        : () => {
+            controller.abort();
+            void execute(candidate, { mode: 'background', force: true });
+          };
+    live = {
+      unsubscribe: () => {
+        controller.abort();
+        subscription.unsubscribe();
+      },
+      reconnect,
+    };
+    return live;
+  };
+  return {
+    get state() {
+      return state;
+    },
+    get request() {
+      return request;
+    },
+    execute,
+    refresh,
+    retry: () => refresh(),
+    subscribe(listener) {
+      listeners.add(listener);
+      listener(state);
+      return () => listeners.delete(listener);
+    },
+    subscribeLive,
+    invalidate() {
+      if (!request) return;
+      cache.delete(keyFor(request));
+      publish({ ...state, stale: true });
+    },
+    dispose() {
+      generation += 1;
+      visibleController?.abort(abortError());
+      live?.unsubscribe();
+      listeners.clear();
+      cache.clear();
+      inFlight.clear();
+    },
+  };
+}
+
+// Naming aliases keep the capability discoverable for consumers that call the
+// feature a data query or a remote query; all aliases share the same controller.
+export const createSmrtDataQuery = createSmrtWebQuery;
+export const createSmrtQuery = createSmrtWebQuery;

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -116,6 +116,8 @@ export function createSmrtWebQuery<TData extends object>(
   const staleTimeMs = options.staleTimeMs ?? 30_000;
   const cache = new Map<string, CacheEntry>();
   const inFlight = new Map<string, Promise<SmrtWebDataQueryResult>>();
+  const latestSuccessfulFlight = new Map<string, number>();
+  let flightSequence = 0;
   const listeners = new Set<(state: SmrtWebQueryState<TData>) => void>();
   let request: SmrtWebDataQueryRequest | undefined;
   let visibleController: AbortController | undefined;
@@ -286,10 +288,13 @@ export function createSmrtWebQuery<TData extends object>(
       const running = inFlight.get(key);
       if (running) return running;
     }
+    const flight = ++flightSequence;
     const running = runTransport(candidate, runOptions).then((result) => {
-      // A forced successor can replace this flight before the predecessor
-      // settles. Only the current owner may publish to the keyed cache.
-      if (inFlight.get(key) === running) {
+      // A failed or aborted successor must not suppress an older valid result,
+      // but a successful successor must win over any later predecessor.
+      const latest = latestSuccessfulFlight.get(key);
+      if (latest === undefined || flight > latest) {
+        latestSuccessfulFlight.set(key, flight);
         cache.set(key, { result, updatedAt: Date.now() });
       }
       return result;

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -121,6 +121,8 @@ export function createSmrtWebQuery<TData extends object>(
   let visibleController: AbortController | undefined;
   let generation = 0;
   let live: SmrtWebQueryLiveSubscription | undefined;
+  let liveGeneration = 0;
+  let disposed = false;
   let state: SmrtWebQueryState<TData> = {
     rows: [],
     page: undefined,
@@ -230,7 +232,13 @@ export function createSmrtWebQuery<TData extends object>(
         stale: entry !== undefined,
         error: null,
       });
-      runOptions = { ...runOptions, signal: visibleController.signal };
+      // A visible run is a successor boundary: it must never adopt an older
+      // same-key shared promise whose signal was just aborted above.
+      runOptions = {
+        ...runOptions,
+        signal: visibleController.signal,
+        force: true,
+      };
       try {
         const result = await runShared(candidate, key, runOptions);
         if (current === generation) apply(result, candidate);
@@ -259,13 +267,22 @@ export function createSmrtWebQuery<TData extends object>(
       const running = inFlight.get(key);
       if (running) return running;
     }
-    const running = runTransport(candidate, runOptions)
-      .then((result) => {
-        cache.set(key, { result, updatedAt: Date.now() });
-        return result;
-      })
-      .finally(() => inFlight.delete(key));
+    const running = runTransport(candidate, runOptions).then((result) => {
+      cache.set(key, { result, updatedAt: Date.now() });
+      return result;
+    });
     inFlight.set(key, running);
+    // A forced successor may replace this map entry while the predecessor is
+    // still settling. Only the promise that currently owns the key may delete
+    // it, otherwise a third caller can miss the active successor flight.
+    void running.then(
+      () => {
+        if (inFlight.get(key) === running) inFlight.delete(key);
+      },
+      () => {
+        if (inFlight.get(key) === running) inFlight.delete(key);
+      },
+    );
     return running;
   };
   const refresh = (
@@ -279,42 +296,85 @@ export function createSmrtWebQuery<TData extends object>(
     });
   };
   const subscribeLive = (): SmrtWebQueryLiveSubscription | undefined => {
-    if (!request || !transport.subscribe) return undefined;
+    if (disposed || !request || !transport.subscribe) return undefined;
     live?.unsubscribe();
     const candidate = request;
-    const controller = new AbortController();
-    const subscription = transport.subscribe(
-      candidate,
-      (raw) => {
-        void (async () => {
-          const result = await executeSmrtWebDataQuery(
-            { query: async () => raw },
-            candidate,
-          );
-          if (request && keyFor(request) === keyFor(candidate))
-            apply(result, candidate);
-        })().catch((error) => {
-          if (!isAbort(error)) publish({ ...state, error });
-        });
-      },
-      { signal: controller.signal },
-    );
-    const reconnect =
-      'reconnect' in subscription &&
-      typeof subscription.reconnect === 'function'
-        ? () => (subscription as SmrtWebQueryLiveSubscription).reconnect()
-        : () => {
-            controller.abort();
-            void execute(candidate, { mode: 'background', force: true });
-          };
-    live = {
-      unsubscribe: () => {
-        controller.abort();
-        subscription.unsubscribe();
-      },
-      reconnect,
+    const currentGeneration = ++liveGeneration;
+    let connectionGeneration = 0;
+    let controller: AbortController | undefined;
+    let subscription: SmrtWebQueryLiveSubscription | { unsubscribe(): void };
+    let active = true;
+    let handle: SmrtWebQueryLiveSubscription;
+    const connect = (): void => {
+      if (!active || disposed || currentGeneration !== liveGeneration) return;
+      controller = new AbortController();
+      const connection = ++connectionGeneration;
+      const subscribe = transport.subscribe;
+      if (!subscribe) return;
+      subscription = subscribe(
+        candidate,
+        (raw) => {
+          if (
+            !active ||
+            disposed ||
+            currentGeneration !== liveGeneration ||
+            connection !== connectionGeneration ||
+            controller?.signal.aborted
+          )
+            return;
+          void (async () => {
+            const result = await executeSmrtWebDataQuery(
+              { query: async () => raw },
+              candidate,
+            );
+            if (
+              active &&
+              !disposed &&
+              currentGeneration === liveGeneration &&
+              connection === connectionGeneration &&
+              request &&
+              keyFor(request) === keyFor(candidate)
+            )
+              apply(result, candidate);
+          })().catch((error) => {
+            if (
+              !isAbort(error) &&
+              active &&
+              !disposed &&
+              currentGeneration === liveGeneration &&
+              connection === connectionGeneration
+            )
+              publish({ ...state, error });
+          });
+        },
+        { signal: controller.signal },
+      );
     };
-    return live;
+    const unsubscribe = (): void => {
+      if (!active) return;
+      active = false;
+      liveGeneration += 1;
+      controller?.abort();
+      subscription.unsubscribe();
+      if (live === handle) live = undefined;
+    };
+    const reconnect = (): void => {
+      if (!active || disposed || currentGeneration !== liveGeneration) return;
+      controller?.abort();
+      subscription.unsubscribe();
+      // Refresh the exact page first, then replace the old subscription. This
+      // avoids reconnecting against a stale cursor or cached snapshot.
+      void execute(candidate, { mode: 'background', force: true })
+        .catch(() => undefined)
+        .finally(() => {
+          if (active && !disposed && currentGeneration === liveGeneration)
+            connect();
+        });
+    };
+    handle = { unsubscribe, reconnect };
+    connect();
+    live = handle;
+    return handle;
   };
   return {
     get state() {
@@ -334,21 +394,22 @@ export function createSmrtWebQuery<TData extends object>(
     subscribeLive,
     invalidate() {
       if (!request) return;
-      cache.delete(keyFor(request));
+      const key = keyFor(request);
+      const entry = cache.get(key);
+      if (entry) cache.set(key, { ...entry, updatedAt: 0 });
       publish({ ...state, stale: true });
     },
     dispose() {
+      disposed = true;
       generation += 1;
+      liveGeneration += 1;
       visibleController?.abort(abortError());
       live?.unsubscribe();
+      live = undefined;
+      request = undefined;
       listeners.clear();
       cache.clear();
       inFlight.clear();
     },
   };
 }
-
-// Naming aliases keep the capability discoverable for consumers that call the
-// feature a data query or a remote query; all aliases share the same controller.
-export const createSmrtDataQuery = createSmrtWebQuery;
-export const createSmrtQuery = createSmrtWebQuery;

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -214,17 +214,19 @@ export function createSmrtWebQuery<TData extends object>(
     if (mode === 'visible') {
       generation += 1;
       visibleController?.abort(abortError());
-      visibleController = new AbortController();
+      const invocationController = new AbortController();
+      visibleController = invocationController;
       request = candidate;
       const current = generation;
       const signal = runOptions.signal;
-      if (signal?.aborted) visibleController.abort(signal.reason);
-      else if (signal)
-        signal.addEventListener(
-          'abort',
-          () => visibleController?.abort(signal.reason),
-          { once: true },
-        );
+      let removeCallerAbort: (() => void) | undefined;
+      if (signal?.aborted) invocationController.abort(signal.reason);
+      else if (signal) {
+        const abortCaller = () => invocationController.abort(signal.reason);
+        signal.addEventListener('abort', abortCaller, { once: true });
+        removeCallerAbort = () =>
+          signal.removeEventListener('abort', abortCaller);
+      }
       publish({
         ...state,
         loading: entry === undefined,
@@ -236,7 +238,7 @@ export function createSmrtWebQuery<TData extends object>(
       // same-key shared promise whose signal was just aborted above.
       runOptions = {
         ...runOptions,
-        signal: visibleController.signal,
+        signal: invocationController.signal,
         force: true,
       };
       try {
@@ -254,6 +256,10 @@ export function createSmrtWebQuery<TData extends object>(
           });
         }
         throw error;
+      } finally {
+        removeCallerAbort?.();
+        if (visibleController === invocationController)
+          visibleController = undefined;
       }
     }
     return runShared(candidate, key, runOptions);
@@ -360,6 +366,10 @@ export function createSmrtWebQuery<TData extends object>(
     };
     const reconnect = (): void => {
       if (!active || disposed || currentGeneration !== liveGeneration) return;
+      // Invalidate callbacks that already entered envelope validation before
+      // aborting this connection; the replacement is installed only after the
+      // background refetch settles.
+      connectionGeneration += 1;
       controller?.abort();
       subscription.unsubscribe();
       // Refresh the exact page first, then replace the old subscription. This

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -211,6 +211,13 @@ export function createSmrtWebQuery<TData extends object>(
         throw controller.signal.reason ?? abortError();
       }
       return result;
+    } catch (error) {
+      // A transport may reject with its own error instead of propagating the
+      // abort reason. Once cancelled, that transport error is not query state.
+      if (controller.signal.aborted) {
+        throw controller.signal.reason ?? abortError();
+      }
+      throw error;
     } finally {
       if (timer) clearTimeout(timer);
       for (const cleanup of cleanups) cleanup();

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -208,14 +208,14 @@ export function createSmrtWebQuery<TData extends object>(
       // authoritative after they resolve, so their result must not reach the
       // cache or visible state.
       if (controller.signal.aborted) {
-        throw controller.signal.reason ?? abortError();
+        throw abortError();
       }
       return result;
     } catch (error) {
       // A transport may reject with its own error instead of propagating the
       // abort reason. Once cancelled, that transport error is not query state.
       if (controller.signal.aborted) {
-        throw controller.signal.reason ?? abortError();
+        throw abortError();
       }
       throw error;
     } finally {

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -185,9 +185,16 @@ export function createSmrtWebQuery<TData extends object>(
         );
     }
     try {
-      return await executeSmrtWebDataQuery(transport, candidate, {
+      const result = await executeSmrtWebDataQuery(transport, candidate, {
         signal: controller.signal,
       });
+      // Some transports cannot observe AbortSignal. Cancellation remains
+      // authoritative after they resolve, so their result must not reach the
+      // cache or visible state.
+      if (controller.signal.aborted) {
+        throw controller.signal.reason ?? abortError();
+      }
+      return result;
     } finally {
       if (timer) clearTimeout(timer);
       for (const cleanup of cleanups) cleanup();

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -142,13 +142,27 @@ export function createSmrtWebQuery<TData extends object>(
     for (const listener of listeners) listener(state);
   };
   const cached = (key: string): CacheEntry | undefined => cache.get(key);
+  const cacheSuccess = (
+    key: string,
+    result: SmrtWebDataQueryResult,
+    sequence: number,
+    updatedAt = Date.now(),
+  ): void => {
+    if (disposed) return;
+    const latest = latestSuccessfulFlight.get(key);
+    if (latest === undefined || sequence > latest) {
+      latestSuccessfulFlight.set(key, sequence);
+      cache.set(key, { result, updatedAt });
+    }
+  };
   const apply = (
     result: SmrtWebDataQueryResult,
     candidate: SmrtWebDataQueryRequest,
     updatedAt = Date.now(),
+    successSequence?: number,
   ): void => {
-    const entry = { result, updatedAt };
-    cache.set(keyFor(candidate), entry);
+    if (successSequence !== undefined)
+      cacheSuccess(keyFor(candidate), result, successSequence, updatedAt);
     publish({
       rows: result.rows as TData[],
       page: pageOf(result),
@@ -292,11 +306,7 @@ export function createSmrtWebQuery<TData extends object>(
     const running = runTransport(candidate, runOptions).then((result) => {
       // A failed or aborted successor must not suppress an older valid result,
       // but a successful successor must win over any later predecessor.
-      const latest = latestSuccessfulFlight.get(key);
-      if (latest === undefined || flight > latest) {
-        latestSuccessfulFlight.set(key, flight);
-        cache.set(key, { result, updatedAt: Date.now() });
-      }
+      cacheSuccess(key, result, flight);
       return result;
     });
     inFlight.set(key, running);
@@ -363,7 +373,7 @@ export function createSmrtWebQuery<TData extends object>(
               request &&
               keyFor(request) === keyFor(candidate)
             )
-              apply(result, candidate);
+              apply(result, candidate, Date.now(), ++flightSequence);
           })().catch((error) => {
             if (
               !isAbort(error) &&
@@ -441,6 +451,7 @@ export function createSmrtWebQuery<TData extends object>(
       request = undefined;
       listeners.clear();
       cache.clear();
+      latestSuccessfulFlight.clear();
       inFlight.clear();
     },
   };

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -287,7 +287,11 @@ export function createSmrtWebQuery<TData extends object>(
       if (running) return running;
     }
     const running = runTransport(candidate, runOptions).then((result) => {
-      cache.set(key, { result, updatedAt: Date.now() });
+      // A forced successor can replace this flight before the predecessor
+      // settles. Only the current owner may publish to the keyed cache.
+      if (inFlight.get(key) === running) {
+        cache.set(key, { result, updatedAt: Date.now() });
+      }
       return result;
     });
     inFlight.set(key, running);

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -253,14 +253,20 @@ export function createSmrtWebQuery<TData extends object>(
         if (current === generation) apply(result, candidate);
         return result;
       } catch (error) {
-        if (current === generation && !isAbort(error)) {
-          publish({
-            ...state,
-            loading: false,
-            refreshing: false,
-            stale: entry !== undefined,
-            error,
-          });
+        if (current === generation) {
+          if (isAbort(error)) {
+            // Cancellation is not an error, but the current invocation must
+            // still release its busy state. Preserve all other state fields.
+            publish({ ...state, loading: false, refreshing: false });
+          } else {
+            publish({
+              ...state,
+              loading: false,
+              refreshing: false,
+              stale: entry !== undefined,
+              error,
+            });
+          }
         }
         throw error;
       } finally {


### PR DESCRIPTION
## Summary

- Add the canonical remote query controller and Svelte binding for bounded collection queries.
- Coordinate visible, background, prefetch, silent, live, cache, cancellation, and lifecycle behavior.
- Add focused regressions for ordering, cancellation, reconnect, and disposal races.

Closes #2445

## Validation

- `pnpm --filter @happyvertical/smrt-web test` (174 passed)
- `pnpm --filter @happyvertical/smrt-web typecheck`
- `pnpm --filter @happyvertical/smrt-web build`
- `pnpm --filter @happyvertical/smrt-svelte typecheck`
- `pnpm --filter @happyvertical/smrt-svelte build`
- `pnpm --filter @happyvertical/smrt-core build`
- `pnpm knowledge:check --strict`

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "01a02d67-fb94-79f3-bc17-2c4b2a776164",
  "issue": 2445,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm --filter @happyvertical/smrt-web test",
    "pnpm --filter @happyvertical/smrt-web typecheck",
    "pnpm --filter @happyvertical/smrt-web build",
    "pnpm --filter @happyvertical/smrt-svelte typecheck",
    "pnpm --filter @happyvertical/smrt-svelte build",
    "pnpm --filter @happyvertical/smrt-core build",
    "pnpm knowledge:check --strict"
  ]
}