### PR TITLE
feat(smrt-svelte): add lifecycle-aware WebMCP tools

### DIFF
--- a/packages/products/src/app/pages/LiveProductsPage.svelte
+++ b/packages/products/src/app/pages/LiveProductsPage.svelte
@@ -16,6 +16,7 @@
  * `scripts/check-web-engine-code-split.mjs` assertion proves the split holds.
  */
 
+import Provider from '@happyvertical/smrt-svelte';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import type { Component } from 'svelte';
 import { onMount } from 'svelte';
@@ -53,8 +54,9 @@ onMount(async () => {
 });
 </script>
 
-<AppLayout>
-  {#snippet children()}
+<Provider webmcp={{ definitions: definition ? [definition] : [] }}>
+  <AppLayout>
+    {#snippet children()}
     <div class="live-products-page">
       <div class="page-header">
         <h1>{t(M['products.live_page.title'])}</h1>
@@ -73,8 +75,9 @@ onMount(async () => {
         </p>
       {/if}
     </div>
-  {/snippet}
-</AppLayout>
+    {/snippet}
+  </AppLayout>
+</Provider>
 
 <style>
   .live-products-page {

--- a/packages/products/src/app/pages/LiveProductsPage.svelte
+++ b/packages/products/src/app/pages/LiveProductsPage.svelte
@@ -16,7 +16,7 @@
  * `scripts/check-web-engine-code-split.mjs` assertion proves the split holds.
  */
 
-import Provider from '@happyvertical/smrt-svelte';
+import { Provider } from '@happyvertical/smrt-svelte';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import type { Component } from 'svelte';
 import { onMount } from 'svelte';

--- a/packages/products/src/lib/components/LiveProductList.svelte
+++ b/packages/products/src/lib/components/LiveProductList.svelte
@@ -17,8 +17,9 @@
  * entry bundle and breaks the code-split (ratified condition ① of #1761).
  */
 
+import { useWebMcpTool } from '@happyvertical/smrt-svelte';
+import { Form, TextInput } from '@happyvertical/smrt-svelte/forms';
 import { liveCollection } from '@happyvertical/smrt-svelte/web';
-import { Form, Input } from '@happyvertical/smrt-ui/forms';
 import { useI18n } from '@happyvertical/smrt-ui/i18n';
 import { Button } from '@happyvertical/smrt-ui/ui';
 import { M } from '../i18n.js';
@@ -52,8 +53,31 @@ const products = createProductCollection(definition, { basePath });
 const view = liveCollection<ProductData>(products);
 
 let newName = $state('');
+let filterQuery = $state('');
 let submitting = $state(false);
 let lastError = $state<string | null>(null);
+
+// Bespoke, client-only intent: this is the one place the reference store owns
+// live UI state, so it needs one small hand-written tool. CRUD tools come from
+// the Provider's `webmcp` opt-in and the submit tool comes from `<Form>`.
+useWebMcpTool(() => ({
+  name: 'filter_products',
+  description: 'Filter the products currently loaded in this browser surface',
+  inputSchema: {
+    type: 'object',
+    properties: { query: { type: 'string' } },
+  },
+  annotations: { readOnlyHint: true },
+  execute: (args) => {
+    filterQuery = typeof args.query === 'string' ? args.query : filterQuery;
+    const query = filterQuery.trim().toLowerCase();
+    return JSON.stringify(
+      view.rows.filter(
+        (row) => !query || row.name?.toLowerCase().includes(query),
+      ),
+    );
+  },
+}));
 
 async function addProduct() {
   const name = newName.trim();
@@ -85,19 +109,17 @@ async function addProduct() {
   </header>
 
   <Form
-    onsubmit={(e: Event) => {
-      e.preventDefault();
-      addProduct();
-    }}
+    collection="products"
+    webmcp={{ name: 'create_product', description: 'Create a product from this form' }}
+    onsubmit={() => addProduct()}
     class="live-products__form"
   >
-    <Input
-      type="text"
+    <TextInput
+      name="name"
       bind:value={newName}
       placeholder={t(M['products.live_list.name_placeholder'])}
       aria-label={t(M['products.live_list.name_placeholder'])}
       disabled={submitting}
-      class="live-products__name"
     />
     <Button type="submit" variant="primary" disabled={submitting || !newName.trim()}>
       {submitting ? t(M['products.live_list.adding']) : t(M['products.live_list.add'])}

--- a/packages/smrt-svelte/src/Provider.svelte
+++ b/packages/smrt-svelte/src/Provider.svelte
@@ -4,6 +4,11 @@ import {
   type I18nSnapshot,
   setI18nContext,
 } from '@happyvertical/smrt-ui/i18n';
+import {
+  type RegisterWebMcpToolsOptions,
+  type SmrtWebClient,
+  type SmrtWebCollectionDefinition,
+} from '@happyvertical/smrt-web';
 import type { Snippet } from 'svelte';
 import { onDestroy, untrack } from 'svelte';
 import { logger } from './internal/logger.js';
@@ -79,9 +84,24 @@ interface Props {
    */
   i18n?: I18nSnapshot;
   /**
+   * Opt in to the generated collection tools for this browser surface.
+   * WebMCP is feature-detected by smrt-web, so this is safe during SSR and on
+   * browsers that do not expose `document.modelContext`.
+   */
+  webmcp?: boolean | WebMcpProviderConfig;
+  /**
    * Children to render
    */
   children: Snippet;
+}
+
+export interface WebMcpProviderConfig {
+  definitions?: SmrtWebCollectionDefinition[];
+  client?: SmrtWebClient;
+  basePath?: string;
+  fetchFn?: typeof fetch;
+  scope?: string;
+  filter?: RegisterWebMcpToolsOptions['filter'];
 }
 
 const {
@@ -95,6 +115,7 @@ const {
   onModeChange,
   onAILoadingChange,
   i18n,
+  webmcp,
   children,
 }: Props = $props();
 
@@ -126,6 +147,34 @@ $effect(() => {
       autoEnableSmrt,
     },
   });
+});
+
+// Keep generated data-plane tools scoped to this Provider. The registrar
+// feature-detects WebMCP itself; effects do not run during SSR.
+$effect(() => {
+  if (typeof window === 'undefined' || !webmcp) return;
+
+  const config = typeof webmcp === 'object' ? webmcp : {};
+  let cancelled = false;
+  let dispose = () => {};
+
+  // Keep the data-plane engine out of applications that do not opt in. The
+  // dynamic import also means SSR never evaluates browser-only engine code.
+  void import('@happyvertical/smrt-web').then(({ registerWebMcpTools }) => {
+    if (cancelled) return;
+    dispose = registerWebMcpTools(config.definitions ?? [], {
+      ...(config.client ? { client: config.client } : {}),
+      ...(config.basePath ? { basePath: config.basePath } : {}),
+      ...(config.fetchFn ? { fetchFn: config.fetchFn } : {}),
+      ...(config.scope ? { scope: config.scope } : {}),
+      ...(config.filter ? { filter: config.filter } : {}),
+    });
+  });
+
+  return () => {
+    cancelled = true;
+    dispose();
+  };
 });
 
 $effect(() => {

--- a/packages/smrt-svelte/src/components/forms/AddressInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/AddressInput.svelte
@@ -239,7 +239,7 @@ onMount(() => {
         properties: Object.fromEntries(
           fields.map((field) => [field, { type: 'string' }]),
         ),
-        required: [...fields],
+        ...(required ? { required: [...fields] } : {}),
       },
       validate: () =>
         !required ||

--- a/packages/smrt-svelte/src/components/forms/AddressInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/AddressInput.svelte
@@ -233,6 +233,16 @@ onMount(() => {
         }
       },
       getValue: () => value,
+      constraints: { required },
+      validate: () =>
+        !required ||
+        [
+          value.street,
+          value.city,
+          value.province,
+          value.postalCode,
+          value.country,
+        ].every((part) => String(part ?? '').trim().length > 0),
     };
     formContext.registerField(fieldDef);
   }

--- a/packages/smrt-svelte/src/components/forms/AddressInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/AddressInput.svelte
@@ -234,15 +234,16 @@ onMount(() => {
       },
       getValue: () => value,
       constraints: { required },
+      webMcpSchema: {
+        type: 'object',
+        properties: Object.fromEntries(
+          fields.map((field) => [field, { type: 'string' }]),
+        ),
+        required: [...fields],
+      },
       validate: () =>
         !required ||
-        [
-          value.street,
-          value.city,
-          value.province,
-          value.postalCode,
-          value.country,
-        ].every((part) => String(part ?? '').trim().length > 0),
+        fields.every((field) => String(value[field] ?? '').trim().length > 0),
     };
     formContext.registerField(fieldDef);
   }

--- a/packages/smrt-svelte/src/components/forms/CheckboxInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/CheckboxInput.svelte
@@ -64,6 +64,8 @@ onMount(() => {
         }
       },
       getValue: () => checked,
+      constraints: { required },
+      validate: () => !required || checked,
     };
     formContext.registerField(fieldDef);
   }

--- a/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateRangeInput.svelte
@@ -206,6 +206,9 @@ onMount(() => {
           .catch(() => {});
       },
       getValue: () => ({ startDate, endDate }),
+      constraints: { required },
+      validate: () =>
+        !required || (startDate.trim().length > 0 && endDate.trim().length > 0),
     };
     formContext.registerField(fieldDef);
   }

--- a/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/DateTimeInput.svelte
@@ -122,6 +122,8 @@ onMount(() => {
         updateValue(String(v ?? ''));
       },
       getValue: () => value,
+      constraints: { required },
+      validate: () => !required || value.trim().length > 0,
     };
     formContext.registerField(fieldDef);
   }

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -18,6 +18,7 @@ import {
   type SMRTFormContext,
   setFormContext,
 } from '../../state/form-context.js';
+import { useWebMcpTool } from '../../web/webmcp.svelte.js';
 import type { LLMModelId, STTAdapterType } from './types.js';
 
 const { t } = useI18n();
@@ -36,7 +37,11 @@ export interface Props {
   /** LLM model for extraction (or 'none' for regex-only) */
   llmModel?: LLMModelId;
   /** Called when form is submitted (if provided, prevents native submission) */
-  onsubmit?: (data: Record<string, unknown>) => void;
+  onsubmit?: (data: Record<string, unknown>) => void | Promise<void>;
+  /** Expose this form's submit intent to WebMCP. */
+  webmcp?: boolean | { name?: string; description?: string };
+  /** Collection/model identity used when naming the generated intent. */
+  collection?: string;
   /** HTTP method for native form submission (default: GET) */
   method?: 'GET' | 'POST';
   /** Form action URL for native form submission */
@@ -58,6 +63,8 @@ const {
   sttAdapter = 'whisper-wasm',
   llmModel = 'none',
   onsubmit,
+  webmcp,
+  collection,
   method,
   action,
   formId,
@@ -187,8 +194,107 @@ const formContext: SMRTFormContext = {
   },
 };
 
+function webMcpFieldType(type: FieldDefinition['type']): string {
+  switch (type) {
+    case 'number':
+    case 'money':
+    case 'measurement':
+      return 'number';
+    case 'checkbox':
+      return 'boolean';
+    case 'daterange':
+      return 'array';
+    default:
+      return 'string';
+  }
+}
+
+function formInputSchema(): Record<string, unknown> {
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+
+  for (const field of fields.values()) {
+    properties[field.name] = {
+      type: webMcpFieldType(field.type),
+      ...(field.label ? { title: field.label } : {}),
+      ...(field.description ? { description: field.description } : {}),
+      ...(field.options
+        ? { enum: field.options.map((option) => option.value) }
+        : {}),
+      ...(field.constraints?.min !== undefined
+        ? { minimum: Number(field.constraints.min) }
+        : {}),
+      ...(field.constraints?.max !== undefined
+        ? { maximum: Number(field.constraints.max) }
+        : {}),
+      ...(field.constraints?.minLength !== undefined
+        ? { minLength: field.constraints.minLength }
+        : {}),
+      ...(field.constraints?.maxLength !== undefined
+        ? { maxLength: field.constraints.maxLength }
+        : {}),
+      ...(field.constraints?.pattern
+        ? { pattern: field.constraints.pattern }
+        : {}),
+    };
+    if (field.constraints?.required) required.push(field.name);
+  }
+
+  return {
+    type: 'object',
+    properties,
+    ...(required.length > 0 ? { required } : {}),
+  };
+}
+
 // Provide context to children
 setFormContext(formContext);
+
+async function submitForWebMcp(args: Record<string, unknown>): Promise<string> {
+  // Stage tool arguments through the same field setters used by native input
+  // controls, then run the shared validation and submit path.
+  for (const [name, value] of Object.entries(args)) {
+    fields.get(name)?.setValue(value);
+  }
+
+  const data: Record<string, unknown> = {};
+  let valid = true;
+  for (const [name, field] of fields) {
+    data[name] = field.getValue();
+    if (
+      field.constraints?.required &&
+      (data[name] === '' || data[name] == null)
+    ) {
+      valid = false;
+    }
+    if (field.validate) {
+      try {
+        valid = field.validate() && valid;
+      } catch {
+        valid = false;
+      }
+    }
+  }
+  if (!valid) return 'Validation failed';
+  if (!onsubmit) return 'No submit handler configured';
+
+  await onsubmit(data);
+  return 'Submitted successfully';
+}
+
+useWebMcpTool(() => {
+  if (!webmcp) return null;
+  const options = typeof webmcp === 'object' ? webmcp : {};
+  return {
+    name: options.name ?? `${collection ?? resolvedFormId}_submit`,
+    description:
+      options.description ??
+      `Submit the ${collection ?? name ?? resolvedFormId} form after validating its fields`,
+    inputSchema: formInputSchema(),
+    annotations: { readOnlyHint: false },
+    execute: submitForWebMcp,
+  };
+});
 
 // Clean up extracted values based on field type
 function cleanValue(value: unknown, fieldType: string): unknown {
@@ -608,11 +714,9 @@ function handleSubmit(e: Event) {
   // This allows native form submission for SvelteKit form actions
   if (onsubmit) {
     e.preventDefault();
-    const data: Record<string, unknown> = {};
-    for (const [name, field] of fields) {
-      data[name] = field.getValue();
-    }
-    onsubmit(data);
+    void submitForWebMcp({}).catch((error) => {
+      logger.error('Form submit failed', { error });
+    });
   }
   // Otherwise, let native form submission happen (e.g., for SvelteKit use:enhance)
 }

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -196,60 +196,64 @@ const formContext: SMRTFormContext = {
 
 function webMcpFieldSchema(field: FieldDefinition): Record<string, unknown> {
   let schema: Record<string, unknown>;
-  switch (field.type) {
-    case 'measurement':
-      schema = {
-        type: 'object',
-        properties: {
-          value: {
-            type: 'number',
-            ...(field.constraints?.min !== undefined
-              ? { minimum: Number(field.constraints.min) }
-              : {}),
-            ...(field.constraints?.max !== undefined
-              ? { maximum: Number(field.constraints.max) }
-              : {}),
+  if (field.webMcpSchema) {
+    schema = { ...field.webMcpSchema };
+  } else {
+    switch (field.type) {
+      case 'measurement':
+        schema = {
+          type: 'object',
+          properties: {
+            value: {
+              type: 'number',
+              ...(field.constraints?.min !== undefined
+                ? { minimum: Number(field.constraints.min) }
+                : {}),
+              ...(field.constraints?.max !== undefined
+                ? { maximum: Number(field.constraints.max) }
+                : {}),
+            },
+            unit: {
+              type: 'string',
+              enum: ['ft', 'in', 'm', 'cm', 'mm', 'yd'],
+            },
           },
-          unit: {
-            type: 'string',
-            enum: ['ft', 'in', 'm', 'cm', 'mm', 'yd'],
+          required: ['value', 'unit'],
+        };
+        break;
+      case 'daterange':
+        schema = {
+          type: 'object',
+          properties: {
+            startDate: { type: 'string' },
+            endDate: { type: 'string' },
           },
-        },
-        required: ['value', 'unit'],
-      };
-      break;
-    case 'daterange':
-      schema = {
-        type: 'object',
-        properties: {
-          startDate: { type: 'string' },
-          endDate: { type: 'string' },
-        },
-        required: ['startDate', 'endDate'],
-      };
-      break;
-    case 'address':
-      schema = {
-        type: 'object',
-        properties: {
-          street: { type: 'string' },
-          city: { type: 'string' },
-          province: { type: 'string' },
-          postalCode: { type: 'string' },
-          country: { type: 'string' },
-        },
-        required: ['street', 'city', 'province', 'postalCode', 'country'],
-      };
-      break;
-    case 'number':
-    case 'money':
-      schema = { type: 'number' };
-      break;
-    case 'checkbox':
-      schema = { type: 'boolean' };
-      break;
-    default:
-      schema = { type: 'string' };
+          required: ['startDate', 'endDate'],
+        };
+        break;
+      case 'address':
+        schema = {
+          type: 'object',
+          properties: {
+            street: { type: 'string' },
+            city: { type: 'string' },
+            province: { type: 'string' },
+            postalCode: { type: 'string' },
+            country: { type: 'string' },
+          },
+          required: ['street', 'city', 'province', 'postalCode', 'country'],
+        };
+        break;
+      case 'number':
+      case 'money':
+        schema = { type: 'number' };
+        break;
+      case 'checkbox':
+        schema = { type: 'boolean' };
+        break;
+      default:
+        schema = { type: 'string' };
+    }
   }
 
   if (field.label) schema.title = field.label;

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -194,19 +194,85 @@ const formContext: SMRTFormContext = {
   },
 };
 
-function webMcpFieldType(type: FieldDefinition['type']): string {
-  switch (type) {
+function webMcpFieldSchema(field: FieldDefinition): Record<string, unknown> {
+  let schema: Record<string, unknown>;
+  switch (field.type) {
+    case 'measurement':
+      schema = {
+        type: 'object',
+        properties: {
+          value: {
+            type: 'number',
+            ...(field.constraints?.min !== undefined
+              ? { minimum: Number(field.constraints.min) }
+              : {}),
+            ...(field.constraints?.max !== undefined
+              ? { maximum: Number(field.constraints.max) }
+              : {}),
+          },
+          unit: {
+            type: 'string',
+            enum: ['ft', 'in', 'm', 'cm', 'mm', 'yd'],
+          },
+        },
+        required: ['value', 'unit'],
+      };
+      break;
+    case 'daterange':
+      schema = {
+        type: 'object',
+        properties: {
+          startDate: { type: 'string' },
+          endDate: { type: 'string' },
+        },
+        required: ['startDate', 'endDate'],
+      };
+      break;
+    case 'address':
+      schema = {
+        type: 'object',
+        properties: {
+          street: { type: 'string' },
+          city: { type: 'string' },
+          province: { type: 'string' },
+          postalCode: { type: 'string' },
+          country: { type: 'string' },
+        },
+        required: ['street', 'city', 'province', 'postalCode', 'country'],
+      };
+      break;
     case 'number':
     case 'money':
-    case 'measurement':
-      return 'number';
+      schema = { type: 'number' };
+      break;
     case 'checkbox':
-      return 'boolean';
-    case 'daterange':
-      return 'array';
+      schema = { type: 'boolean' };
+      break;
     default:
-      return 'string';
+      schema = { type: 'string' };
   }
+
+  if (field.label) schema.title = field.label;
+  if (field.description) schema.description = field.description;
+  if (field.options) {
+    schema.enum = field.options.map((option) => option.value);
+  }
+  if (schema.type === 'number' && field.constraints?.min !== undefined) {
+    schema.minimum = Number(field.constraints.min);
+  }
+  if (schema.type === 'number' && field.constraints?.max !== undefined) {
+    schema.maximum = Number(field.constraints.max);
+  }
+  if (schema.type === 'string' && field.constraints?.minLength !== undefined) {
+    schema.minLength = field.constraints.minLength;
+  }
+  if (schema.type === 'string' && field.constraints?.maxLength !== undefined) {
+    schema.maxLength = field.constraints.maxLength;
+  }
+  if (schema.type === 'string' && field.constraints?.pattern) {
+    schema.pattern = field.constraints.pattern;
+  }
+  return schema;
 }
 
 function formInputSchema(): Record<string, unknown> {
@@ -214,29 +280,7 @@ function formInputSchema(): Record<string, unknown> {
   const required: string[] = [];
 
   for (const field of fields.values()) {
-    properties[field.name] = {
-      type: webMcpFieldType(field.type),
-      ...(field.label ? { title: field.label } : {}),
-      ...(field.description ? { description: field.description } : {}),
-      ...(field.options
-        ? { enum: field.options.map((option) => option.value) }
-        : {}),
-      ...(field.constraints?.min !== undefined
-        ? { minimum: Number(field.constraints.min) }
-        : {}),
-      ...(field.constraints?.max !== undefined
-        ? { maximum: Number(field.constraints.max) }
-        : {}),
-      ...(field.constraints?.minLength !== undefined
-        ? { minLength: field.constraints.minLength }
-        : {}),
-      ...(field.constraints?.maxLength !== undefined
-        ? { maxLength: field.constraints.maxLength }
-        : {}),
-      ...(field.constraints?.pattern
-        ? { pattern: field.constraints.pattern }
-        : {}),
-    };
+    properties[field.name] = webMcpFieldSchema(field);
     if (field.constraints?.required) required.push(field.name);
   }
 

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -218,7 +218,9 @@ function webMcpFieldSchema(field: FieldDefinition): Record<string, unknown> {
               enum: ['ft', 'in', 'm', 'cm', 'mm', 'yd'],
             },
           },
-          required: ['value', 'unit'],
+          ...(field.constraints?.required
+            ? { required: ['value', 'unit'] }
+            : {}),
         };
         break;
       case 'daterange':
@@ -228,7 +230,9 @@ function webMcpFieldSchema(field: FieldDefinition): Record<string, unknown> {
             startDate: { type: 'string' },
             endDate: { type: 'string' },
           },
-          required: ['startDate', 'endDate'],
+          ...(field.constraints?.required
+            ? { required: ['startDate', 'endDate'] }
+            : {}),
         };
         break;
       case 'address':
@@ -241,7 +245,17 @@ function webMcpFieldSchema(field: FieldDefinition): Record<string, unknown> {
             postalCode: { type: 'string' },
             country: { type: 'string' },
           },
-          required: ['street', 'city', 'province', 'postalCode', 'country'],
+          ...(field.constraints?.required
+            ? {
+                required: [
+                  'street',
+                  'city',
+                  'province',
+                  'postalCode',
+                  'country',
+                ],
+              }
+            : {}),
         };
         break;
       case 'number':

--- a/packages/smrt-svelte/src/components/forms/MeasurementInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/MeasurementInput.svelte
@@ -302,6 +302,9 @@ onMount(() => {
         }
       },
       getValue: () => (value !== null ? { value, unit } : null),
+      constraints: { required, min, max },
+      validate: () =>
+        value === null ? !required : Number.isFinite(value) && isInRange,
     };
     formContext.registerField(fieldDef);
   }

--- a/packages/smrt-svelte/src/components/forms/MoneyInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/MoneyInput.svelte
@@ -252,6 +252,9 @@ onMount(() => {
         }
       },
       getValue: () => value,
+      constraints: { required, min, max },
+      validate: () =>
+        value === null ? !required : Number.isFinite(value) && isInRange,
     };
     formContext.registerField(fieldDef);
   }

--- a/packages/smrt-svelte/src/components/forms/NumberInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/NumberInput.svelte
@@ -175,6 +175,9 @@ onMount(() => {
         }
       },
       getValue: () => value,
+      constraints: { required, min, max, step },
+      validate: () =>
+        value === null ? !required : Number.isFinite(value) && isInRange,
     };
     formContext.registerField(fieldDef);
   }

--- a/packages/smrt-svelte/src/components/forms/PhoneInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/PhoneInput.svelte
@@ -149,6 +149,8 @@ onMount(() => {
         updateValue(formatted);
       },
       getValue: () => value,
+      constraints: { required },
+      validate: () => !required || value.trim().length > 0,
     };
     formContext.registerField(fieldDef);
   }

--- a/packages/smrt-svelte/src/components/forms/SelectInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/SelectInput.svelte
@@ -77,6 +77,12 @@ onMount(() => {
         }
       },
       getValue: () => value,
+      constraints: { required },
+      options: options.map((option) => ({
+        value: option.value,
+        label: option.label,
+      })),
+      validate: () => !required || value.trim().length > 0,
     };
     formContext.registerField(fieldDef);
   }

--- a/packages/smrt-svelte/src/components/forms/TextInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/TextInput.svelte
@@ -102,6 +102,10 @@ onMount(() => {
         updateValue(String(v ?? ''));
       },
       getValue: () => value,
+      constraints: { required },
+      validate: () =>
+        (!required || value.trim().length > 0) &&
+        (type !== 'email' || value.length === 0 || isValidEmail),
     };
     formContext.registerField(fieldDef);
   }

--- a/packages/smrt-svelte/src/components/forms/TextareaInput.svelte
+++ b/packages/smrt-svelte/src/components/forms/TextareaInput.svelte
@@ -90,6 +90,8 @@ onMount(() => {
         }
       },
       getValue: () => value,
+      constraints: { required },
+      validate: () => !required || value.trim().length > 0,
     };
     formContext.registerField(fieldDef);
   }

--- a/packages/smrt-svelte/src/components/forms/__tests__/Form.webmcp.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/Form.webmcp.test.ts
@@ -177,6 +177,58 @@ describe('Form WebMCP submit intent', () => {
         country: 'CA',
       },
     };
+    expect(
+      await registered[0].execute({
+        ...values,
+        address: {},
+      }),
+    ).toBe('Validation failed');
+    expect(onsubmit).not.toHaveBeenCalled();
+
+    expect(await registered[0].execute(values)).toBe('Submitted successfully');
+    expect(onsubmit).toHaveBeenCalledWith(values);
+  });
+
+  it('limits the address schema and payload to configured fields', async () => {
+    const registered: Array<{
+      inputSchema: Record<string, unknown>;
+      execute: (args: Record<string, unknown>) => Promise<string>;
+    }> = [];
+    document.modelContext = {
+      registerTool(tool) {
+        registered.push(tool as (typeof registered)[number]);
+      },
+    };
+    const onsubmit = vi.fn();
+    render(FormWithStructuredFields, {
+      props: {
+        webmcp: true,
+        addressFields: ['city', 'country'],
+        onsubmit,
+      },
+    });
+    await tick();
+    await tick();
+
+    expect(registered).toHaveLength(1);
+    const schema = registered[0].inputSchema as {
+      properties: Record<string, Record<string, unknown>>;
+    };
+    expect(schema.properties.address).toMatchObject({
+      type: 'object',
+      properties: {
+        city: { type: 'string' },
+        country: { type: 'string' },
+      },
+      required: ['city', 'country'],
+    });
+    expect(schema.properties.address.properties).not.toHaveProperty('street');
+
+    const values = {
+      measurement: { value: 1.5, unit: 'm' },
+      dates: { startDate: '2026-01-01', endDate: '2026-01-02' },
+      address: { city: 'Edmonton', country: 'CA' },
+    };
     expect(await registered[0].execute(values)).toBe('Submitted successfully');
     expect(onsubmit).toHaveBeenCalledWith(values);
   });

--- a/packages/smrt-svelte/src/components/forms/__tests__/Form.webmcp.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/Form.webmcp.test.ts
@@ -61,6 +61,54 @@ describe('Form WebMCP submit intent', () => {
     });
   });
 
+  it('publishes required and numeric constraints and validates them before submit', async () => {
+    const registered: Array<{
+      inputSchema: Record<string, unknown>;
+      execute: (args: Record<string, unknown>) => Promise<string>;
+    }> = [];
+    document.modelContext = {
+      registerTool(tool) {
+        registered.push(tool as (typeof registered)[number]);
+      },
+    };
+    const onsubmit = vi.fn();
+    render(FormWithFields, {
+      props: {
+        webmcp: true,
+        textRequired: true,
+        ageRequired: true,
+        ageMin: 18,
+        ageMax: 65,
+        onsubmit,
+      },
+    });
+    await tick();
+    await tick();
+
+    expect(registered).toHaveLength(1);
+    const schema = registered[0].inputSchema as {
+      required?: string[];
+      properties: Record<string, Record<string, unknown>>;
+    };
+    expect(schema.required).toEqual(['fullname', 'age']);
+    expect(schema.properties.age).toMatchObject({
+      type: 'number',
+      minimum: 18,
+      maximum: 65,
+    });
+
+    expect(await registered[0].execute({ age: 17 })).toBe('Validation failed');
+    expect(await registered[0].execute({ fullname: 'Ada', age: 66 })).toBe(
+      'Validation failed',
+    );
+    expect(onsubmit).not.toHaveBeenCalled();
+
+    expect(await registered[0].execute({ fullname: 'Ada', age: 36 })).toBe(
+      'Submitted successfully',
+    );
+    expect(onsubmit).toHaveBeenCalledWith({ fullname: 'Ada', age: 36 });
+  });
+
   it('keeps the browser path a no-op without WebMCP', async () => {
     const onsubmit = vi.fn();
     const view = render(FormWithFields, { props: { onsubmit } });

--- a/packages/smrt-svelte/src/components/forms/__tests__/Form.webmcp.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/Form.webmcp.test.ts
@@ -21,6 +21,7 @@ vi.mock('../../../hooks/useSTT.svelte.js', () => ({
 }));
 
 import FormWithFields from './form-with-fields.fixture.svelte';
+import FormWithStructuredFields from './form-with-structured-fields.fixture.svelte';
 
 afterEach(() => {
   delete document.modelContext;
@@ -114,5 +115,69 @@ describe('Form WebMCP submit intent', () => {
     const view = render(FormWithFields, { props: { onsubmit } });
     await userEvent.click(view.getByRole('button', { name: 'Submit' }));
     expect(onsubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes and accepts structured measurement, date range, and address fields', async () => {
+    const registered: Array<{
+      inputSchema: Record<string, unknown>;
+      execute: (args: Record<string, unknown>) => Promise<string>;
+    }> = [];
+    document.modelContext = {
+      registerTool(tool) {
+        registered.push(tool as (typeof registered)[number]);
+      },
+    };
+    const onsubmit = vi.fn();
+    render(FormWithStructuredFields, { props: { webmcp: true, onsubmit } });
+    await tick();
+    await tick();
+
+    expect(registered).toHaveLength(1);
+    const schema = registered[0].inputSchema as {
+      required?: string[];
+      properties: Record<string, Record<string, unknown>>;
+    };
+    expect(schema.required).toEqual(['measurement', 'dates', 'address']);
+    expect(schema.properties.measurement).toMatchObject({
+      type: 'object',
+      properties: {
+        value: { type: 'number' },
+        unit: { type: 'string' },
+      },
+      required: ['value', 'unit'],
+    });
+    expect(schema.properties.dates).toMatchObject({
+      type: 'object',
+      properties: {
+        startDate: { type: 'string' },
+        endDate: { type: 'string' },
+      },
+      required: ['startDate', 'endDate'],
+    });
+    expect(schema.properties.address).toMatchObject({
+      type: 'object',
+      properties: {
+        street: { type: 'string' },
+        city: { type: 'string' },
+        province: { type: 'string' },
+        postalCode: { type: 'string' },
+        country: { type: 'string' },
+      },
+      required: ['street', 'city', 'province', 'postalCode', 'country'],
+    });
+
+    const values = {
+      measurement: { value: 1.5, unit: 'm' },
+      dates: { startDate: '2026-01-01', endDate: '2026-01-02' },
+      address: {
+        street: '1 Main St',
+        city: 'Edmonton',
+        province: 'AB',
+        postalCode: 'T1A 1A1',
+        country: 'CA',
+      },
+    };
+    expect(await registered[0].execute(values)).toBe('Submitted successfully');
+    expect(onsubmit).toHaveBeenCalledWith(values);
   });
 });

--- a/packages/smrt-svelte/src/components/forms/__tests__/Form.webmcp.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/Form.webmcp.test.ts
@@ -1,0 +1,70 @@
+import { render } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { tick } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../hooks/useAppState.svelte.js', () => ({
+  useAppState: () => ({ state: { mode: 'default' }, setMode: vi.fn() }),
+}));
+vi.mock('../../../hooks/useSTT.svelte.js', () => ({
+  useSTT: () => ({
+    isListening: false,
+    lastResult: '',
+    isReady: false,
+    adapterType: null,
+    isInitializing: false,
+    downloadProgress: 0,
+    initialize: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+import FormWithFields from './form-with-fields.fixture.svelte';
+
+afterEach(() => {
+  delete document.modelContext;
+});
+
+describe('Form WebMCP submit intent', () => {
+  it('registers a field-derived tool and dispatches validation + submit', async () => {
+    const registered: Array<{
+      name: string;
+      inputSchema: Record<string, unknown>;
+      execute: (args: Record<string, unknown>) => Promise<string>;
+    }> = [];
+    document.modelContext = {
+      registerTool(tool) {
+        registered.push(tool as (typeof registered)[number]);
+      },
+    };
+    const onsubmit = vi.fn();
+    render(FormWithFields, { props: { webmcp: true, onsubmit } });
+    await tick();
+    await tick();
+
+    expect(registered).toHaveLength(1);
+    expect(registered[0].inputSchema).toMatchObject({
+      type: 'object',
+      properties: { fullname: { type: 'string' }, age: { type: 'number' } },
+    });
+    expect(registered[0].name).toContain('submit');
+
+    const result = await registered[0].execute({
+      fullname: 'Ada Lovelace',
+      age: 36,
+    });
+    expect(result).toBe('Submitted successfully');
+    expect(onsubmit).toHaveBeenCalledWith({
+      fullname: 'Ada Lovelace',
+      age: 36,
+    });
+  });
+
+  it('keeps the browser path a no-op without WebMCP', async () => {
+    const onsubmit = vi.fn();
+    const view = render(FormWithFields, { props: { onsubmit } });
+    await userEvent.click(view.getByRole('button', { name: 'Submit' }));
+    expect(onsubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/smrt-svelte/src/components/forms/__tests__/Form.webmcp.test.ts
+++ b/packages/smrt-svelte/src/components/forms/__tests__/Form.webmcp.test.ts
@@ -232,4 +232,40 @@ describe('Form WebMCP submit intent', () => {
     expect(await registered[0].execute(values)).toBe('Submitted successfully');
     expect(onsubmit).toHaveBeenCalledWith(values);
   });
+
+  it('allows partial payloads for optional structured fields', async () => {
+    const registered: Array<{
+      inputSchema: Record<string, unknown>;
+      execute: (args: Record<string, unknown>) => Promise<string>;
+    }> = [];
+    document.modelContext = {
+      registerTool(tool) {
+        registered.push(tool as (typeof registered)[number]);
+      },
+    };
+    const onsubmit = vi.fn();
+    render(FormWithStructuredFields, {
+      props: { webmcp: true, structuredRequired: false, onsubmit },
+    });
+    await tick();
+    await tick();
+
+    expect(registered).toHaveLength(1);
+    const schema = registered[0].inputSchema as {
+      properties: Record<string, Record<string, unknown>>;
+    };
+    expect(schema.properties.measurement).not.toHaveProperty('required');
+    expect(schema.properties.dates).not.toHaveProperty('required');
+    expect(schema.properties.address).not.toHaveProperty('required');
+
+    const partialValues = {
+      measurement: { value: 1.5 },
+      dates: { startDate: '2026-01-01' },
+      address: { city: 'Edmonton' },
+    };
+    expect(await registered[0].execute(partialValues)).toBe(
+      'Submitted successfully',
+    );
+    expect(onsubmit).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/smrt-svelte/src/components/forms/__tests__/form-with-fields.fixture.svelte
+++ b/packages/smrt-svelte/src/components/forms/__tests__/form-with-fields.fixture.svelte
@@ -14,6 +14,7 @@ let {
   textValue = '',
   numberValue = null,
   showAge = true,
+  webmcp = false,
 }: {
   onsubmit?: (data: Record<string, unknown>) => void;
   method?: 'GET' | 'POST';
@@ -21,10 +22,11 @@ let {
   textValue?: string;
   numberValue?: number | null;
   showAge?: boolean;
+  webmcp?: boolean;
 } = $props();
 </script>
 
-<Form {onsubmit} {method} {action}>
+<Form {onsubmit} {method} {action} {webmcp}>
 	<TextInput name="fullname" label="Full name" bind:value={textValue} />
 	{#if showAge}
 		<NumberInput name="age" label="Age" bind:value={numberValue} />

--- a/packages/smrt-svelte/src/components/forms/__tests__/form-with-fields.fixture.svelte
+++ b/packages/smrt-svelte/src/components/forms/__tests__/form-with-fields.fixture.svelte
@@ -15,6 +15,10 @@ let {
   numberValue = null,
   showAge = true,
   webmcp = false,
+  textRequired = false,
+  ageRequired = false,
+  ageMin = undefined,
+  ageMax = undefined,
 }: {
   onsubmit?: (data: Record<string, unknown>) => void;
   method?: 'GET' | 'POST';
@@ -23,13 +27,29 @@ let {
   numberValue?: number | null;
   showAge?: boolean;
   webmcp?: boolean;
+  textRequired?: boolean;
+  ageRequired?: boolean;
+  ageMin?: number;
+  ageMax?: number;
 } = $props();
 </script>
 
 <Form {onsubmit} {method} {action} {webmcp}>
-	<TextInput name="fullname" label="Full name" bind:value={textValue} />
+	<TextInput
+		name="fullname"
+		label="Full name"
+		required={textRequired}
+		bind:value={textValue}
+	/>
 	{#if showAge}
-		<NumberInput name="age" label="Age" bind:value={numberValue} />
+		<NumberInput
+			name="age"
+			label="Age"
+			required={ageRequired}
+			min={ageMin}
+			max={ageMax}
+			bind:value={numberValue}
+		/>
 	{/if}
 	<button type="submit">Submit</button>
 </Form>

--- a/packages/smrt-svelte/src/components/forms/__tests__/form-with-structured-fields.fixture.svelte
+++ b/packages/smrt-svelte/src/components/forms/__tests__/form-with-structured-fields.fixture.svelte
@@ -8,23 +8,33 @@ let {
   onsubmit = undefined,
   webmcp = false,
   addressFields = ['street', 'city', 'province', 'postalCode', 'country'],
+  structuredRequired = true,
 }: {
   onsubmit?: (data: Record<string, unknown>) => void;
   webmcp?: boolean;
   addressFields?: Array<
     'street' | 'city' | 'province' | 'postalCode' | 'country'
   >;
+  structuredRequired?: boolean;
 } = $props();
 </script>
 
 <Form {onsubmit} {webmcp}>
-	<MeasurementInput name="measurement" label="Measurement" required />
-	<DateRangeInput name="dates" label="Dates" required />
+	<MeasurementInput
+		name="measurement"
+		label="Measurement"
+		required={structuredRequired}
+	/>
+	<DateRangeInput
+		name="dates"
+		label="Dates"
+		required={structuredRequired}
+	/>
 	<AddressInput
 		name="address"
 		label="Address"
 		fields={addressFields}
-		required
+		required={structuredRequired}
 	/>
 	<button type="submit">Submit</button>
 </Form>

--- a/packages/smrt-svelte/src/components/forms/__tests__/form-with-structured-fields.fixture.svelte
+++ b/packages/smrt-svelte/src/components/forms/__tests__/form-with-structured-fields.fixture.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+import AddressInput from '../AddressInput.svelte';
+import DateRangeInput from '../DateRangeInput.svelte';
+import Form from '../Form.svelte';
+import MeasurementInput from '../MeasurementInput.svelte';
+
+let {
+  onsubmit = undefined,
+  webmcp = false,
+}: {
+  onsubmit?: (data: Record<string, unknown>) => void;
+  webmcp?: boolean;
+} = $props();
+</script>
+
+<Form {onsubmit} {webmcp}>
+	<MeasurementInput name="measurement" label="Measurement" required />
+	<DateRangeInput name="dates" label="Dates" required />
+	<AddressInput name="address" label="Address" required />
+	<button type="submit">Submit</button>
+</Form>

--- a/packages/smrt-svelte/src/components/forms/__tests__/form-with-structured-fields.fixture.svelte
+++ b/packages/smrt-svelte/src/components/forms/__tests__/form-with-structured-fields.fixture.svelte
@@ -7,15 +7,24 @@ import MeasurementInput from '../MeasurementInput.svelte';
 let {
   onsubmit = undefined,
   webmcp = false,
+  addressFields = ['street', 'city', 'province', 'postalCode', 'country'],
 }: {
   onsubmit?: (data: Record<string, unknown>) => void;
   webmcp?: boolean;
+  addressFields?: Array<
+    'street' | 'city' | 'province' | 'postalCode' | 'country'
+  >;
 } = $props();
 </script>
 
 <Form {onsubmit} {webmcp}>
 	<MeasurementInput name="measurement" label="Measurement" required />
 	<DateRangeInput name="dates" label="Dates" required />
-	<AddressInput name="address" label="Address" required />
+	<AddressInput
+		name="address"
+		label="Address"
+		fields={addressFields}
+		required
+	/>
 	<button type="submit">Submit</button>
 </Form>

--- a/packages/smrt-svelte/src/index.ts
+++ b/packages/smrt-svelte/src/index.ts
@@ -1,3 +1,5 @@
+/// <reference path="./web/webmcp.d.ts" />
+
 /**
  * @happyvertical/smrt-svelte
  *
@@ -24,3 +26,5 @@ export * from './hooks/index.js';
 export { default as Provider } from './Provider.svelte';
 // State management
 export * from './state/index.js';
+// Opt-in browser WebMCP lifecycle primitive.
+export { useWebMcpTool, type WebMcpToolSpec } from './web/webmcp.svelte.js';

--- a/packages/smrt-svelte/src/state/form-context.ts
+++ b/packages/smrt-svelte/src/state/form-context.ts
@@ -50,6 +50,8 @@ export interface FieldDefinition {
   readable?: boolean;
   writable?: boolean;
   constraints?: ControlConstraints;
+  /** Optional WebMCP schema override for structured field values. */
+  webMcpSchema?: Record<string, unknown>;
   options?: ControlOption[];
   unit?: string;
   clear?: () => void;

--- a/packages/smrt-svelte/src/web/__tests__/webmcp-harness.svelte
+++ b/packages/smrt-svelte/src/web/__tests__/webmcp-harness.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+import { useWebMcpTool } from '../webmcp.svelte.js';
+
+let { version = 1 }: { version?: number } = $props();
+
+useWebMcpTool(() => ({
+  name: `harness_tool_${version}`,
+  description: 'A lifecycle test tool',
+  inputSchema: { type: 'object' },
+  execute: () => String(version),
+}));
+</script>
+
+<span>{version}</span>

--- a/packages/smrt-svelte/src/web/__tests__/webmcp.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/webmcp.test.ts
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import Harness from './webmcp-harness.svelte';
+
+function installModelContext() {
+  const registered: Array<{
+    name: string;
+    signal?: AbortSignal;
+  }> = [];
+  document.modelContext = {
+    registerTool(tool: { name: string }, options?: { signal?: AbortSignal }) {
+      registered.push({ name: tool.name, signal: options?.signal });
+    },
+  };
+  return registered;
+}
+
+afterEach(() => {
+  delete document.modelContext;
+});
+
+describe('useWebMcpTool', () => {
+  it('registers on mount, aborts on spec changes, and aborts on unmount', async () => {
+    const registered = installModelContext();
+    const view = render(Harness, { props: { version: 1 } });
+    await tick();
+
+    expect(registered).toHaveLength(1);
+    expect(registered[0].name).toBe('harness_tool_1');
+    expect(registered[0].signal?.aborted).toBe(false);
+
+    await view.rerender({ version: 2 });
+    await tick();
+    expect(registered).toHaveLength(2);
+    expect(registered[0].signal?.aborted).toBe(true);
+    expect(registered[1].name).toBe('harness_tool_2');
+
+    view.unmount();
+    expect(registered[1].signal?.aborted).toBe(true);
+  });
+
+  it('is a no-op when WebMCP is unavailable', async () => {
+    const view = render(Harness);
+    await tick();
+    expect(view.container).toHaveTextContent('1');
+    view.unmount();
+  });
+});

--- a/packages/smrt-svelte/src/web/webmcp.d.ts
+++ b/packages/smrt-svelte/src/web/webmcp.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Ambient WebMCP types. Chrome currently exposes this origin-trial API without
+ * shipping it in TypeScript's DOM library.
+ */
+
+import type { WebMcpToolSpec } from './webmcp.svelte.js';
+
+declare global {
+  interface Document {
+    modelContext?: WebMcpModelContext;
+  }
+
+  interface WebMcpModelContext {
+    registerTool(
+      tool: WebMcpToolSpec,
+      options?: { signal?: AbortSignal },
+    ): void;
+  }
+}
+
+export {};

--- a/packages/smrt-svelte/src/web/webmcp.svelte.ts
+++ b/packages/smrt-svelte/src/web/webmcp.svelte.ts
@@ -1,0 +1,57 @@
+/** A tool exposed to the browser's WebMCP model context. */
+export interface WebMcpToolSpec {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: {
+    readOnlyHint?: boolean;
+    untrustedContentHint?: boolean;
+  };
+  execute: (args: Record<string, unknown>) => string | Promise<string>;
+}
+
+// Keep the ambient contract on the public hook declaration too, so consumers
+// importing only the package root still receive `document.modelContext` types.
+declare global {
+  interface Document {
+    modelContext?: WebMcpModelContext;
+  }
+
+  interface WebMcpModelContext {
+    registerTool(
+      tool: WebMcpToolSpec,
+      options?: { signal?: AbortSignal },
+    ): void;
+  }
+}
+
+function getModelContext(): WebMcpModelContext | undefined {
+  // Do not read `document` at module evaluation time: this module is imported
+  // by SSR bundles and by browsers without the WebMCP origin trial.
+  const documentLike = (globalThis as { document?: Document }).document;
+  const context = documentLike?.modelContext;
+  return context && typeof context.registerTool === 'function'
+    ? context
+    : undefined;
+}
+
+/**
+ * Register a component-owned WebMCP intent for exactly that component's
+ * lifetime. The factory runs inside the effect so rune dependencies used by a
+ * bespoke intent cause the tool to be replaced when its spec changes.
+ */
+export function useWebMcpTool(
+  factory: () => WebMcpToolSpec | null | undefined,
+): void {
+  $effect(() => {
+    const context = getModelContext();
+    if (!context) return;
+
+    const spec = factory();
+    if (!spec) return;
+    const controller = new AbortController();
+    context.registerTool(spec, { signal: controller.signal });
+
+    return () => controller.abort();
+  });
+}


### PR DESCRIPTION
## Summary

- add SSR-safe lifecycle registration with `useWebMcpTool` and Provider opt-in wiring
- expose Form submit intents with field-aware schemas, validation, and structured object payloads
- add required/range constraints, address active-field handling, and reference products integration

## Validation

- `pnpm --dir packages/smrt-svelte test` (59 files, 571 tests)
- `pnpm --dir packages/smrt-svelte run typecheck`
- `pnpm --dir packages/smrt-svelte run build`
- `pnpm --dir packages/products run build:all`
- `pnpm --dir packages/smrt-web test` (156 tests)
- core WebMCP integration tests (77 tests)
- strict knowledge freshness, Biome, diff check, and pre-push checks
- final review clear on `bb36995d0d64ee9a8e7bc7b4eb739ea31f844c95`

Closes #1813

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "545ce256-6368-4908-a67a-e8ada77ff66e",
  "issue": 1813,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "smrt-svelte test (59 files, 571 tests)",
    "smrt-svelte typecheck",
    "smrt-svelte build",
    "products build:all",
    "smrt-web test (156 tests)",
    "core WebMCP integration tests (77 tests)",
    "strict knowledge freshness",
    "Biome and diff checks",
    "pre-push checks",
    "final review clear"
  ]
}
