### PR TITLE
feat(marketing): add tenant-scoped Customer campaigns

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -227,6 +227,7 @@ production never gets: the suite runs on a richer schema than it ships.
 ## Gotchas
 
 - **Filesystem support is a lazy boundary (#1979)**: `SmrtClass` acquires `options.fs` adapters via `createFilesystemAdapter()` (`src/filesystem-loader.ts`), never a static `@happyvertical/files` import — the files SDK statically pulls @aws-sdk/client-s3 and reaches googleapis, and a static edge here would land it in every downstream SSR bundle. Node/tsx/vite-dev runtimes resolve it on first use; fully-bundled deployments import `@happyvertical/smrt-core/filesystem` at startup. Use `importOptionalDependency()` (`src/lazy-external.ts`) for any similar optional heavyweight dependency.
+- **Transaction-bound instances**: `SmrtClass.withDatabase(db, callback)` temporarily binds an initialized instance (including its public `options.db`) to a supplied transaction database and restores the original binding on success or failure. Use it when domain validation and persistence must share one transaction; never reach into `_db`, and do not use the same instance concurrently during the callback.
 - **Never override toJSON()** — handles STI discriminator + meta field extraction. Use `transformJSON()`
 - **Property init order**: TypeScript initializers run first, then `initialize()` applies option values (options win)
 - **No runtime schema creation**: application tables must be prepared explicitly via migrations/tooling; runtime verification is `tableExists()` only (`src/schema/table-verifier.ts`) — no column, type, or index check

--- a/packages/core/src/__tests__/with-database.test.ts
+++ b/packages/core/src/__tests__/with-database.test.ts
@@ -1,0 +1,54 @@
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SmrtClass } from '../class.js';
+import { getTestDatabase } from '../testing/database.js';
+
+describe('SmrtClass.withDatabase', () => {
+  const databases: DatabaseInterface[] = [];
+
+  afterEach(async () => {
+    await Promise.all(databases.splice(0).map((db) => db.close?.()));
+  });
+
+  async function database(): Promise<DatabaseInterface> {
+    const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    databases.push(db);
+    return db;
+  }
+
+  it('uses the bound database and restores the original after success', async () => {
+    const root = await database();
+    const transaction = await database();
+    const instance = new SmrtClass({ db: root });
+    await instance.initialize();
+
+    const result = await instance.withDatabase(transaction, async (bound) => {
+      expect(bound).toBe(instance);
+      expect(bound.db).toBe(transaction);
+      expect(bound.options.db).toBe(transaction);
+      return 'bound-result';
+    });
+
+    expect(result).toBe('bound-result');
+    expect(instance.db).toBe(root);
+    expect(instance.options.db).toBe(root);
+  });
+
+  it('restores the original database when the callback throws', async () => {
+    const root = await database();
+    const transaction = await database();
+    const instance = new SmrtClass({ db: root });
+    await instance.initialize();
+    const failure = new Error('transaction callback failed');
+
+    await expect(
+      instance.withDatabase(transaction, async (bound) => {
+        expect(bound.db).toBe(transaction);
+        throw failure;
+      }),
+    ).rejects.toBe(failure);
+
+    expect(instance.db).toBe(root);
+    expect(instance.options.db).toBe(root);
+  });
+});

--- a/packages/core/src/class.ts
+++ b/packages/core/src/class.ts
@@ -1122,6 +1122,33 @@ export class SmrtClass {
   }
 
   /**
+   * Temporarily bind this initialized instance to another database interface.
+   *
+   * This is intended for transaction-scoped work where a caller must ensure
+   * that every nested SMRT read and write uses the transaction database passed
+   * to its callback. The original database is restored whether the callback
+   * succeeds or throws. Do not use the same instance concurrently while it is
+   * temporarily bound.
+   */
+  async withDatabase<T>(
+    db: DatabaseInterface,
+    operation: (bound: this) => Promise<T>,
+  ): Promise<T> {
+    // Read through the public getter so an uninitialized instance fails with
+    // the normal, actionable SmrtClass error before any state is mutated.
+    const previousDb = this.db;
+    const previousOptionDb = this.options.db;
+    this._db = db;
+    this.options.db = db;
+    try {
+      return await operation(this);
+    } finally {
+      this._db = previousDb;
+      this.options.db = previousOptionDb;
+    }
+  }
+
+  /**
    * Gets the AI client instance
    */
   get ai() {

--- a/packages/marketing/AGENTS.md
+++ b/packages/marketing/AGENTS.md
@@ -20,7 +20,8 @@ publish-surface changes.
 
 - **Campaign**: optional-tenant umbrella with stable natural key
   `(tenant_id, campaign_key)`, open objective, integer-cent budget, currency,
-  schedule, guarded metadata helpers, and lifecycle
+  schedule, optional native UUID reference to the canonical commerce Customer,
+  guarded metadata helpers, and lifecycle
   `draft → scheduled → active ↔ paused → completed → archived`. Raw saves are
   protected by an authoritative prior-status re-read; use
   `CampaignLifecycleService` for lifecycle writes.
@@ -52,6 +53,11 @@ All generated surfaces are explicit; never omit `api`, `mcp`, or `cli` config.
   pacing prefers campaign rollups and otherwise sums channel snapshots,
   preventing double counting without dropping channel-only periods. Status
   uses a five-percent budget tolerance around schedule-derived expected spend.
+- **CampaignCollection** exposes bounded, tenant-and-Customer-scoped cursor
+  pages ordered by `start_at DESC, id DESC` and bounded batch summaries for
+  total count, active count, and latest start time. Customer scope is validated
+  through runtime relationship metadata; there is no static commerce import or
+  tenant-wide campaign materialization.
 
 ## Svelte
 
@@ -66,6 +72,10 @@ render time.
 
 - Runtime dependencies stay limited to `smrt-core`, `smrt-tenancy`, and
   `smrt-ui`. Never statically import sibling domain packages.
+- `Campaign.customerId` targets `@happyvertical/smrt-commerce:Customer` through
+  `@crossPackageRef`. Saves and customer-scoped reads require exact tenant
+  agreement (including global-to-global only) and fail without revealing
+  whether a Customer is absent or belongs elsewhere.
 - Lead loop-closing is conventional: CRM stores `sourceKind: 'campaign'` and a
   campaign key in `sourceId`; marketing does not import or mutate Lead.
 - Attribution math remains in sales/referrals. Marketing stores performance

--- a/packages/marketing/AGENTS.md
+++ b/packages/marketing/AGENTS.md
@@ -75,7 +75,10 @@ render time.
 - `Campaign.customerId` targets `@happyvertical/smrt-commerce:Customer` through
   `@crossPackageRef`. Saves and customer-scoped reads require exact tenant
   agreement (including global-to-global only) and fail without revealing
-  whether a Customer is absent or belongs elsewhere.
+  whether a Customer is absent or belongs elsewhere. Associated saves validate
+  and persist through one transaction-bound Campaign instance; scoped reads
+  validate and query through one fresh transaction-bound collection. PostgreSQL
+  locks the validated Customer rows for the duration of each operation.
 - Lead loop-closing is conventional: CRM stores `sourceKind: 'campaign'` and a
   campaign key in `sourceId`; marketing does not import or mutate Lead.
 - Attribution math remains in sales/referrals. Marketing stores performance

--- a/packages/marketing/README.md
+++ b/packages/marketing/README.md
@@ -65,7 +65,9 @@ console.log(await pacing.getCampaignPacing(campaign.id));
 `Campaign.customerId` is the native UUID relationship to the canonical
 `@happyvertical/smrt-commerce:Customer`. A campaign and its Customer must have
 exactly the same tenant, and customer-scoped reads require that tenant
-explicitly. Missing and cross-tenant Customers fail with
+explicitly (`null` selects the global/global scope). Associated Campaign saves
+validate and persist in one transaction; customer-scoped reads validate and
+query in one transaction. Missing and cross-tenant Customers fail with
 `CampaignCustomerScopeError` without disclosing which condition occurred.
 
 ```ts

--- a/packages/marketing/README.md
+++ b/packages/marketing/README.md
@@ -19,6 +19,7 @@ const campaigns = await CampaignCollection.create({ db });
 const channels = await CampaignChannelCollection.create({ db });
 const campaign = await campaigns.create({
   tenantId,
+  customerId,
   campaignKey: 'summer-demand-2026',
   name: 'Summer demand 2026',
   objective: 'demand_generation',
@@ -58,6 +59,48 @@ await ingestion.ingest({
 const pacing = await BudgetPacingService.create({ db });
 console.log(await pacing.getCampaignPacing(campaign.id));
 ```
+
+## Customer-scoped campaign reads
+
+`Campaign.customerId` is the native UUID relationship to the canonical
+`@happyvertical/smrt-commerce:Customer`. A campaign and its Customer must have
+exactly the same tenant, and customer-scoped reads require that tenant
+explicitly. Missing and cross-tenant Customers fail with
+`CampaignCustomerScopeError` without disclosing which condition occurred.
+
+```ts
+const firstPage = await campaigns.listByCustomer(tenantId, customerId, {
+  limit: 50,
+});
+const secondPage = firstPage.nextCursor
+  ? await campaigns.listByCustomer(tenantId, customerId, {
+      limit: 50,
+      after: firstPage.nextCursor,
+    })
+  : null;
+
+const summaries = await campaigns.summarizeByCustomers(tenantId, customerIds);
+// [{ customerId, totalCount, activeCount, latestStartAt }]
+```
+
+Pages and summary batches are capped at 100 items and reject larger inputs.
+Pagination is newest-first by `startAt`, then UUID; campaigns without a start
+time follow scheduled campaigns. Summary resolution uses a bounded grouped
+query rather than loading tenant campaigns or issuing one query per Customer.
+
+### Migrating metadata-backed associations
+
+1. Apply the generated schema migration that adds nullable native-UUID
+   `campaigns.customer_id` and the
+   `(tenant_id, customer_id, start_at, id)` index.
+2. In an operator-owned data migration, extract the old metadata Customer id,
+   validate that it exists in commerce and has the exact same `tenant_id`, then
+   write `customer_id`. Stop on missing, malformed, or mismatched values.
+3. Verify every expected association through `listByCustomer()` or
+   `summarizeByCustomers()`, then update consumers to use these APIs.
+4. Remove the old metadata key after verification. Marketing never reads it as
+   a compatibility fallback, so there is no tenant-wide JSON or raw-SQL path to
+   keep in sync.
 
 Svelte components are exported from `@happyvertical/smrt-marketing/svelte`.
 They are presentational and accept plain view models; consumers remain in

--- a/packages/marketing/package.json
+++ b/packages/marketing/package.json
@@ -45,6 +45,7 @@
     "svelte": "^5.56.4"
   },
   "devDependencies": {
+    "@happyvertical/smrt-commerce": "workspace:*",
     "@happyvertical/smrt-vitest": "workspace:*",
     "@happyvertical/sql": "catalog:",
     "@sveltejs/package": "^2.5.8",

--- a/packages/marketing/src/__tests__/campaign-customer.test.ts
+++ b/packages/marketing/src/__tests__/campaign-customer.test.ts
@@ -1,0 +1,272 @@
+import { randomUUID } from 'node:crypto';
+import { CustomerCollection } from '@happyvertical/smrt-commerce';
+import { getTestDatabase, ObjectRegistry } from '@happyvertical/smrt-core';
+import {
+  disableTenancy,
+  enableTenancy,
+  TenantIsolationError,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  CampaignCollection,
+  MAX_CAMPAIGN_CUSTOMER_BATCH_SIZE,
+} from '../collections/CampaignCollection.js';
+import { CampaignCustomerScopeError } from '../errors.js';
+import * as marketing from '../index.js';
+import type { CampaignCustomerCursor } from '../types.js';
+
+describe('Campaign customer scope', () => {
+  let db: DatabaseInterface;
+  let campaigns: CampaignCollection;
+  let customers: CustomerCollection;
+
+  beforeEach(async () => {
+    enableTenancy();
+    db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    customers = await CustomerCollection.create({ db });
+    campaigns = await CampaignCollection.create({ db });
+  });
+
+  afterEach(async () => {
+    disableTenancy();
+    vi.restoreAllMocks();
+    await db?.close?.();
+  });
+
+  it('publishes a native Customer UUID and the bounded composite index', () => {
+    const schema = ObjectRegistry.getSchema('Campaign');
+    expect(schema?.columns.customer_id).toMatchObject({
+      type: 'UUID',
+      referenceKind: 'crossPackageRef',
+    });
+    expect(schema?.columns.customer_id?.required).not.toBe(true);
+    expect(
+      schema?.indexes.find(
+        (index) =>
+          index.name === 'campaigns_tenant_id_customer_id_start_at_id_idx',
+      ),
+    ).toMatchObject({
+      columns: ['tenant_id', 'customer_id', 'start_at', 'id'],
+    });
+    expect(marketing.CampaignCustomerScopeError).toBe(
+      CampaignCustomerScopeError,
+    );
+    expect(marketing.MAX_CAMPAIGN_CUSTOMER_BATCH_SIZE).toBe(100);
+    expect(typeof marketing.CampaignCollection.prototype.listByCustomer).toBe(
+      'function',
+    );
+    expect(
+      typeof marketing.CampaignCollection.prototype.summarizeByCustomers,
+    ).toBe('function');
+  });
+
+  it('requires exact Campaign and Customer tenant agreement before save', async () => {
+    const tenantA = randomUUID();
+    const tenantB = randomUUID();
+    const customerA = await customers.create({ tenantId: tenantA });
+    const customerB = await customers.create({ tenantId: tenantB });
+    const globalCustomer = await customers.create({});
+
+    const saved = await campaigns.create({
+      tenantId: tenantA,
+      customerId: customerA.id,
+      campaignKey: 'tenant-a-campaign',
+      name: 'Tenant A campaign',
+    });
+    expect(saved.customerId).toBe(customerA.id);
+    const globalSaved = await campaigns.create({
+      customerId: globalCustomer.id,
+      campaignKey: 'global-campaign',
+      name: 'Global campaign',
+    });
+    expect(globalSaved.tenantId).toBeNull();
+
+    for (const input of [
+      { tenantId: tenantA, customerId: customerB.id },
+      { tenantId: tenantA, customerId: globalCustomer.id },
+      { tenantId: null, customerId: customerA.id },
+      { tenantId: tenantA, customerId: randomUUID() },
+    ]) {
+      await expect(
+        campaigns.create({
+          ...input,
+          campaignKey: randomUUID(),
+          name: 'Rejected campaign',
+        }),
+      ).rejects.toBeInstanceOf(CampaignCustomerScopeError);
+    }
+  });
+
+  it('paginates equal and null start times without duplicates', async () => {
+    const tenantId = randomUUID();
+    const customer = await customers.create({ tenantId });
+    const otherCustomer = await customers.create({ tenantId });
+    const tiedStart = new Date('2026-08-01T00:00:00.000Z');
+    const tied = [];
+    for (let index = 0; index < 5; index += 1) {
+      tied.push(
+        await campaigns.create({
+          tenantId,
+          customerId: customer.id,
+          campaignKey: `tied-${index}`,
+          name: `Tied ${index}`,
+          startAt: tiedStart,
+        }),
+      );
+    }
+    const nullStart = await campaigns.create({
+      tenantId,
+      customerId: customer.id,
+      campaignKey: 'null-start',
+      name: 'Null start',
+    });
+    const olderStart = new Date('2026-07-01T00:00:00.000Z');
+    const older = await campaigns.create({
+      tenantId,
+      customerId: customer.id,
+      campaignKey: 'older-start',
+      name: 'Older start',
+      startAt: olderStart,
+    });
+    await campaigns.create({
+      tenantId,
+      customerId: otherCustomer.id,
+      campaignKey: 'other-customer',
+      name: 'Other customer',
+      startAt: tiedStart,
+    });
+
+    const seen = [];
+    let after: CampaignCustomerCursor | undefined;
+    do {
+      const page = await campaigns.listByCustomer(tenantId, customer.id ?? '', {
+        limit: 2,
+        after,
+      });
+      seen.push(...page.items);
+      after = page.nextCursor ?? undefined;
+    } while (after);
+
+    const expectedTiedIds = tied
+      .map((campaign) => campaign.id ?? '')
+      .sort((left, right) => right.localeCompare(left));
+    expect(seen.map((campaign) => campaign.id)).toEqual([
+      ...expectedTiedIds,
+      older.id,
+      nullStart.id,
+    ]);
+    expect(new Set(seen.map((campaign) => campaign.id)).size).toBe(7);
+  });
+
+  it('resolves multi-Customer summaries in two bounded queries', async () => {
+    const tenantId = randomUUID();
+    const customerA = await customers.create({ tenantId });
+    const customerB = await customers.create({ tenantId });
+    const emptyCustomer = await customers.create({ tenantId });
+    const startEarly = new Date('2026-07-01T00:00:00.000Z');
+    const startLatest = new Date('2026-08-01T00:00:00.000Z');
+    await campaigns.create({
+      tenantId,
+      customerId: customerA.id,
+      campaignKey: 'a-active',
+      name: 'A active',
+      status: 'active',
+      startAt: startEarly,
+    });
+    await campaigns.create({
+      tenantId,
+      customerId: customerA.id,
+      campaignKey: 'a-draft',
+      name: 'A draft',
+      startAt: startLatest,
+    });
+    await campaigns.create({
+      tenantId,
+      customerId: customerB.id,
+      campaignKey: 'b-active',
+      name: 'B active',
+      status: 'active',
+      startAt: startEarly,
+    });
+
+    const query = vi.spyOn(db, 'query');
+    query.mockClear();
+    const summaries = await campaigns.summarizeByCustomers(tenantId, [
+      customerA.id ?? '',
+      customerB.id ?? '',
+      emptyCustomer.id ?? '',
+      customerA.id ?? '',
+    ]);
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(summaries).toEqual([
+      {
+        customerId: customerA.id,
+        totalCount: 2,
+        activeCount: 1,
+        latestStartAt: startLatest,
+      },
+      {
+        customerId: customerB.id,
+        totalCount: 1,
+        activeCount: 1,
+        latestStartAt: startEarly,
+      },
+      {
+        customerId: emptyCustomer.id,
+        totalCount: 0,
+        activeCount: 0,
+        latestStartAt: null,
+      },
+    ]);
+  });
+
+  it('fails closed for cross-tenant lookup and rejects oversized inputs', async () => {
+    const tenantA = randomUUID();
+    const tenantB = randomUUID();
+    const customerA = await customers.create({ tenantId: tenantA });
+
+    await expect(
+      campaigns.listByCustomer(tenantB, customerA.id ?? ''),
+    ).rejects.toBeInstanceOf(CampaignCustomerScopeError);
+    await expect(
+      campaigns.summarizeByCustomers(tenantB, [customerA.id ?? '']),
+    ).rejects.toBeInstanceOf(CampaignCustomerScopeError);
+    await expect(
+      withTenant({ tenantId: tenantA }, () =>
+        campaigns.listByCustomer(tenantB, customerA.id ?? ''),
+      ),
+    ).rejects.toBeInstanceOf(TenantIsolationError);
+
+    await expect(
+      campaigns.listByCustomer(tenantA, customerA.id ?? '', { limit: 101 }),
+    ).rejects.toThrow(/must not exceed 100/);
+    await expect(
+      campaigns.listByCustomer(tenantA, customerA.id ?? '', { limit: 0 }),
+    ).rejects.toThrow(/at least 1/);
+    await expect(
+      campaigns.summarizeByCustomers(
+        tenantA,
+        Array.from(
+          { length: MAX_CAMPAIGN_CUSTOMER_BATCH_SIZE + 1 },
+          () => customerA.id ?? '',
+        ),
+      ),
+    ).rejects.toThrow(/at most 100/);
+
+    const query = vi.spyOn(db, 'query');
+    query.mockClear();
+    await expect(
+      campaigns.listByCustomer(tenantA, customerA.id ?? '', {
+        limit: Number.NaN,
+      }),
+    ).rejects.toThrow(/non-negative integer/);
+    await expect(
+      campaigns.listByCustomer(tenantA, customerA.id ?? '', {
+        after: { id: randomUUID(), startAt: 'not-a-date' },
+      }),
+    ).rejects.toThrow(/cursor startAt is invalid/);
+    expect(query).not.toHaveBeenCalled();
+  });
+});

--- a/packages/marketing/src/__tests__/campaign-customer.test.ts
+++ b/packages/marketing/src/__tests__/campaign-customer.test.ts
@@ -68,6 +68,7 @@ describe('Campaign customer scope', () => {
     const customerA = await customers.create({ tenantId: tenantA });
     const customerB = await customers.create({ tenantId: tenantB });
     const globalCustomer = await customers.create({});
+    const emptyGlobalCustomer = await customers.create({});
 
     const saved = await campaigns.create({
       tenantId: tenantA,
@@ -82,6 +83,35 @@ describe('Campaign customer scope', () => {
       name: 'Global campaign',
     });
     expect(globalSaved.tenantId).toBeNull();
+    expect(
+      (await campaigns.listByCustomer(null, globalCustomer.id ?? '')).items.map(
+        (campaign) => campaign.id,
+      ),
+    ).toEqual([globalSaved.id]);
+    expect(
+      await campaigns.summarizeByCustomers(null, [
+        globalCustomer.id ?? '',
+        emptyGlobalCustomer.id ?? '',
+      ]),
+    ).toEqual([
+      {
+        customerId: globalCustomer.id,
+        totalCount: 1,
+        activeCount: 0,
+        latestStartAt: null,
+      },
+      {
+        customerId: emptyGlobalCustomer.id,
+        totalCount: 0,
+        activeCount: 0,
+        latestStartAt: null,
+      },
+    ]);
+    await expect(
+      withTenant({ tenantId: tenantA }, () =>
+        campaigns.listByCustomer(null, globalCustomer.id ?? ''),
+      ),
+    ).rejects.toBeInstanceOf(TenantIsolationError);
 
     const contextSaved = await withTenant({ tenantId: tenantA }, () =>
       campaigns.create({
@@ -115,6 +145,106 @@ describe('Campaign customer scope', () => {
         }),
       ).rejects.toBeInstanceOf(CampaignCustomerScopeError);
     }
+    await expect(
+      campaigns.create({
+        tenantId: tenantA,
+        customerId: 'not-a-uuid',
+        campaignKey: 'invalid-customer-id',
+        name: 'Invalid Customer id',
+      }),
+    ).rejects.toBeInstanceOf(CampaignCustomerScopeError);
+    await expect(
+      campaigns.create({
+        tenantId: 'not-a-uuid',
+        customerId: customerA.id,
+        campaignKey: 'invalid-tenant-id',
+        name: 'Invalid tenant id',
+      }),
+    ).rejects.toBeInstanceOf(CampaignCustomerScopeError);
+  });
+
+  it('validates and persists a Campaign on the same transaction database', async () => {
+    const tenantId = randomUUID();
+    const customer = await customers.create({ tenantId });
+    const rootGet = vi.spyOn(db, 'get');
+    const rootQuery = vi.spyOn(db, 'query');
+    const rootUpsert = vi.spyOn(db, 'upsert');
+    const originalTransaction = db.transaction?.bind(db);
+    expect(originalTransaction).toBeTypeOf('function');
+    let transactionDb: DatabaseInterface | undefined;
+    let transactionGet: ReturnType<typeof vi.spyOn> | undefined;
+    let transactionQuery: ReturnType<typeof vi.spyOn> | undefined;
+    let transactionUpsert: ReturnType<typeof vi.spyOn> | undefined;
+    const transaction = vi
+      .spyOn(db, 'transaction')
+      .mockImplementation(async (operation) =>
+        originalTransaction?.(async (tx) => {
+          transactionDb = tx;
+          transactionGet = vi.spyOn(tx, 'get');
+          transactionQuery = vi.spyOn(tx, 'query');
+          transactionUpsert = vi.spyOn(tx, 'upsert');
+          return operation(tx);
+        }),
+      );
+
+    const saved = await campaigns.create({
+      tenantId,
+      customerId: customer.id,
+      campaignKey: 'atomic-customer-scope',
+      name: 'Atomic customer scope',
+    });
+
+    expect(transaction).toHaveBeenCalledOnce();
+    expect(transactionDb).toBeDefined();
+    expect(transactionDb).not.toBe(db);
+    expect(
+      transactionGet?.mock.calls.some(([table]) => table === 'campaigns'),
+    ).toBe(true);
+    expect(
+      transactionQuery?.mock.calls.some(
+        ([sql]) =>
+          typeof sql === 'string' &&
+          sql.includes('FROM customers') &&
+          sql.includes('WHERE id IN'),
+      ),
+    ).toBe(true);
+    expect(
+      transactionUpsert?.mock.calls.some(([table]) => table === 'campaigns'),
+    ).toBe(true);
+    expect(rootGet).not.toHaveBeenCalled();
+    expect(rootQuery).not.toHaveBeenCalled();
+    expect(rootUpsert).not.toHaveBeenCalled();
+    expect(saved.db).toBe(db);
+    expect(saved.options.db).toBe(db);
+  });
+
+  it('preserves unassociated saves while failing closed without transactions', async () => {
+    const noTransactionDb = new Proxy(db, {
+      get(target, property, receiver) {
+        if (property === 'transaction') return undefined;
+        const value = Reflect.get(target, property, receiver) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+    const unassociatedCampaigns = await CampaignCollection.create({
+      db: noTransactionDb,
+    });
+    const saved = await unassociatedCampaigns.create({
+      campaignKey: 'unassociated-no-transaction',
+      name: 'Unassociated without transaction',
+    });
+    expect(saved.id).toBeDefined();
+
+    const tenantId = randomUUID();
+    const customer = await customers.create({ tenantId });
+    await expect(
+      unassociatedCampaigns.create({
+        tenantId,
+        customerId: customer.id,
+        campaignKey: 'associated-no-transaction',
+        name: 'Associated without transaction',
+      }),
+    ).rejects.toThrow(/requires a database adapter with transaction support/);
   });
 
   it('paginates equal and null start times without duplicates', async () => {
@@ -176,6 +306,26 @@ describe('Campaign customer scope', () => {
       nullStart.id,
     ]);
     expect(new Set(seen.map((campaign) => campaign.id)).size).toBe(7);
+
+    const numericFirst = await campaigns.listByCustomer(
+      tenantId.toUpperCase(),
+      (customer.id ?? '').toUpperCase(),
+      { limit: 1 },
+    );
+    const numericCursor = numericFirst.nextCursor;
+    expect(numericCursor?.startAt).toBeInstanceOf(Date);
+    const numericSecond = await campaigns.listByCustomer(
+      tenantId.toUpperCase(),
+      (customer.id ?? '').toUpperCase(),
+      {
+        limit: 1,
+        after: {
+          id: (numericCursor?.id ?? '').toUpperCase(),
+          startAt: numericCursor?.startAt?.getTime() ?? Number.NaN,
+        },
+      },
+    );
+    expect(numericSecond.items[0]?.id).toBe(expectedTiedIds[1]);
   });
 
   it('resolves multi-Customer summaries in two bounded queries', async () => {
@@ -209,15 +359,36 @@ describe('Campaign customer scope', () => {
       startAt: startEarly,
     });
 
-    const query = vi.spyOn(db, 'query');
-    query.mockClear();
+    const originalTransaction = db.transaction?.bind(db);
+    expect(originalTransaction).toBeTypeOf('function');
+    let transactionDb: DatabaseInterface | undefined;
+    let transactionQuery: ReturnType<typeof vi.spyOn> | undefined;
+    const transaction = vi
+      .spyOn(db, 'transaction')
+      .mockImplementation(async (operation) =>
+        originalTransaction?.(async (tx) => {
+          transactionDb = tx;
+          transactionQuery = vi.spyOn(tx, 'query');
+          return operation(tx);
+        }),
+      );
     const summaries = await campaigns.summarizeByCustomers(tenantId, [
       customerA.id ?? '',
       customerB.id ?? '',
       emptyCustomer.id ?? '',
       customerA.id ?? '',
     ]);
-    expect(query).toHaveBeenCalledTimes(2);
+    expect(transaction).toHaveBeenCalledOnce();
+    expect(transactionDb).not.toBe(db);
+    const transactionSql =
+      transactionQuery?.mock.calls.map(([sql]) => String(sql)) ?? [];
+    expect(transactionSql).toHaveLength(6);
+    expect(
+      transactionSql.filter(
+        (sql) =>
+          sql.includes('FROM customers') || sql.includes('FROM campaigns'),
+      ),
+    ).toHaveLength(2);
     expect(summaries).toEqual([
       {
         customerId: customerA.id,
@@ -249,11 +420,18 @@ describe('Campaign customer scope', () => {
   it('keeps framework cross-package failures behind the typed scope error', async () => {
     const tenantId = randomUUID();
     const customer = await customers.create({ tenantId });
-    const originalGet = db.get.bind(db);
-    vi.spyOn(db, 'get').mockImplementation(async (table, where) => {
-      if (table === 'customers') return null;
-      return originalGet(table, where);
-    });
+    const originalTransaction = db.transaction?.bind(db);
+    expect(originalTransaction).toBeTypeOf('function');
+    vi.spyOn(db, 'transaction').mockImplementation(async (operation) =>
+      originalTransaction?.(async (tx) => {
+        const originalGet = tx.get.bind(tx);
+        vi.spyOn(tx, 'get').mockImplementation(async (table, where) => {
+          if (table === 'customers') return null;
+          return originalGet(table, where);
+        });
+        return operation(tx);
+      }),
+    );
 
     const save = campaigns.create({
       tenantId,

--- a/packages/marketing/src/__tests__/campaign-customer.test.ts
+++ b/packages/marketing/src/__tests__/campaign-customer.test.ts
@@ -304,6 +304,19 @@ describe('Campaign customer scope', () => {
     expect(scheduled.status).toBe('scheduled');
   });
 
+  it('allows a new initialized Campaign to choose its first persisted status', async () => {
+    const campaign = new marketing.Campaign({
+      db,
+      campaignKey: 'new-initialized-status',
+      name: 'New initialized status',
+    });
+    await campaign.initialize();
+    expect(campaign.isPersisted).toBe(false);
+    campaign.status = 'active';
+
+    await expect(campaign.save()).resolves.toMatchObject({ status: 'active' });
+  });
+
   it('rejects Campaign IDs owned by a different tenant or global lane', async () => {
     const tenantA = randomUUID();
     const tenantB = randomUUID();

--- a/packages/marketing/src/__tests__/campaign-customer.test.ts
+++ b/packages/marketing/src/__tests__/campaign-customer.test.ts
@@ -5,6 +5,7 @@ import {
   disableTenancy,
   enableTenancy,
   TenantIsolationError,
+  withSystemContext,
   withTenant,
 } from '@happyvertical/smrt-tenancy';
 import type { DatabaseInterface } from '@happyvertical/sql';
@@ -15,6 +16,7 @@ import {
 } from '../collections/CampaignCollection.js';
 import { CampaignCustomerScopeError } from '../errors.js';
 import * as marketing from '../index.js';
+import { CampaignLifecycleService } from '../services/CampaignLifecycleService.js';
 import type { CampaignCustomerCursor } from '../types.js';
 
 describe('Campaign customer scope', () => {
@@ -107,6 +109,13 @@ describe('Campaign customer scope', () => {
         latestStartAt: null,
       },
     ]);
+    expect(
+      (
+        await withSystemContext(() =>
+          campaigns.listByCustomer(null, globalCustomer.id ?? ''),
+        )
+      ).items.map((campaign) => campaign.id),
+    ).toEqual([globalSaved.id]);
     await expect(
       withTenant({ tenantId: tenantA }, () =>
         campaigns.listByCustomer(null, globalCustomer.id ?? ''),
@@ -121,6 +130,44 @@ describe('Campaign customer scope', () => {
       }),
     );
     expect(contextSaved.tenantId).toBe(tenantA);
+    const uppercaseContextSaved = await withTenant(
+      { tenantId: tenantA.toUpperCase() },
+      () =>
+        campaigns.create({
+          customerId: customerA.id,
+          campaignKey: 'uppercase-context-campaign',
+          name: 'Uppercase context campaign',
+        }),
+    );
+    expect(uppercaseContextSaved.tenantId).toBe(tenantA);
+    expect(
+      await withTenant({ tenantId: tenantA.toUpperCase() }, () =>
+        campaigns.get({ id: uppercaseContextSaved.id?.toUpperCase() }),
+      ),
+    ).toMatchObject({ id: uppercaseContextSaved.id });
+    expect(
+      await withTenant({ tenantId: tenantA.toUpperCase() }, () =>
+        campaigns.list({
+          where: { id: [uppercaseContextSaved.id?.toUpperCase()] },
+          select: ['id', 'tenantId'] as const,
+        }),
+      ),
+    ).toEqual([{ id: uppercaseContextSaved.id, tenantId: tenantA }]);
+    expect(
+      await withTenant({ tenantId: tenantA.toUpperCase() }, () =>
+        campaigns.findByCampaignKey('uppercase-context-campaign'),
+      ),
+    ).toMatchObject({ id: uppercaseContextSaved.id });
+    expect(
+      (
+        await withTenant({ tenantId: tenantA.toUpperCase() }, () =>
+          campaigns.listByCustomer(
+            tenantA.toUpperCase(),
+            (customerA.id ?? '').toUpperCase(),
+          ),
+        )
+      ).items.map((campaign) => campaign.id),
+    ).toContain(uppercaseContextSaved.id);
     await expect(
       withTenant({ tenantId: tenantA }, () =>
         campaigns.create({
@@ -130,6 +177,52 @@ describe('Campaign customer scope', () => {
         }),
       ),
     ).rejects.toBeInstanceOf(CampaignCustomerScopeError);
+    await expect(
+      campaigns.create({
+        tenantId: tenantA,
+        customerId: customerB.id,
+        campaignKey: 'tenant-a-campaign',
+        name: 'Rejected scope before lifecycle',
+        status: 'active',
+      }),
+    ).rejects.toBeInstanceOf(CampaignCustomerScopeError);
+
+    const rootGet = vi.spyOn(db, 'get');
+    rootGet.mockClear();
+    await expect(
+      withTenant({ tenantId: tenantA }, () =>
+        campaigns.create({
+          tenantId: tenantB,
+          campaignKey: 'unassociated-context-cross-tenant',
+          name: 'Rejected unassociated cross-tenant campaign',
+        }),
+      ),
+    ).rejects.toBeInstanceOf(TenantIsolationError);
+    expect(rootGet).not.toHaveBeenCalled();
+
+    const originalTransaction = db.transaction?.bind(db);
+    expect(originalTransaction).toBeTypeOf('function');
+    let transactionGet: ReturnType<typeof vi.spyOn> | undefined;
+    let transactionQuery: ReturnType<typeof vi.spyOn> | undefined;
+    vi.spyOn(db, 'transaction').mockImplementation(async (operation) =>
+      originalTransaction?.(async (tx) => {
+        transactionGet = vi.spyOn(tx, 'get');
+        transactionQuery = vi.spyOn(tx, 'query');
+        return operation(tx);
+      }),
+    );
+    await expect(
+      withTenant({ tenantId: tenantA }, () =>
+        campaigns.create({
+          tenantId: tenantB,
+          customerId: customerB.id,
+          campaignKey: 'context-cross-tenant-campaign',
+          name: 'Rejected cross-tenant context campaign',
+        }),
+      ),
+    ).rejects.toBeInstanceOf(TenantIsolationError);
+    expect(transactionGet).not.toHaveBeenCalled();
+    expect(transactionQuery).not.toHaveBeenCalled();
 
     for (const input of [
       { tenantId: tenantA, customerId: customerB.id },
@@ -161,6 +254,100 @@ describe('Campaign customer scope', () => {
         name: 'Invalid tenant id',
       }),
     ).rejects.toBeInstanceOf(CampaignCustomerScopeError);
+  });
+
+  it('resolves natural-key lifecycle state within the effective tenant', async () => {
+    const tenantId = randomUUID();
+    const customer = await customers.create({ tenantId });
+    const customerCampaign = await withTenant({ tenantId }, () =>
+      campaigns.create({
+        customerId: customer.id,
+        campaignKey: 'context-natural-key',
+        name: 'Context natural key',
+        status: 'draft',
+      }),
+    );
+
+    await expect(
+      withTenant({ tenantId }, () =>
+        campaigns.create({
+          customerId: customer.id,
+          campaignKey: 'context-natural-key',
+          name: 'Context natural key replay',
+          status: 'active',
+        }),
+      ),
+    ).rejects.toThrow(/illegal status transition 'draft' → 'active'/);
+
+    await withTenant({ tenantId }, () =>
+      campaigns.create({
+        campaignKey: 'unassociated-context-natural-key',
+        name: 'Unassociated context natural key',
+        status: 'draft',
+      }),
+    );
+    await expect(
+      withTenant({ tenantId }, () =>
+        campaigns.create({
+          campaignKey: 'unassociated-context-natural-key',
+          name: 'Unassociated context natural key replay',
+          status: 'active',
+        }),
+      ),
+    ).rejects.toThrow(/illegal status transition 'draft' → 'active'/);
+
+    const lifecycle = await CampaignLifecycleService.create({ db });
+    const scheduled = await withTenant(
+      { tenantId: tenantId.toUpperCase() },
+      () => lifecycle.schedule((customerCampaign.id ?? '').toUpperCase()),
+    );
+    expect(scheduled.status).toBe('scheduled');
+  });
+
+  it('rejects Campaign IDs owned by a different tenant or global lane', async () => {
+    const tenantA = randomUUID();
+    const tenantB = randomUUID();
+    const customerA = await customers.create({ tenantId: tenantA });
+    const customerB = await customers.create({ tenantId: tenantB });
+    const globalCustomer = await customers.create({});
+    const tenantBCampaign = await campaigns.create({
+      tenantId: tenantB,
+      customerId: customerB.id,
+      campaignKey: 'tenant-b-owned-id',
+      name: 'Tenant B owned ID',
+      status: 'draft',
+    });
+    const globalCampaign = await campaigns.create({
+      customerId: globalCustomer.id,
+      campaignKey: 'global-owned-id',
+      name: 'Global owned ID',
+      status: 'scheduled',
+    });
+
+    for (const id of [
+      tenantBCampaign.id?.toUpperCase(),
+      globalCampaign.id?.toUpperCase(),
+    ]) {
+      await expect(
+        withTenant({ tenantId: tenantA }, () =>
+          campaigns.create({
+            id,
+            customerId: customerA.id,
+            campaignKey: `local-replay-${id}`,
+            name: 'Rejected foreign ID replay',
+            status: 'active',
+          }),
+        ),
+      ).rejects.toBeInstanceOf(CampaignCustomerScopeError);
+    }
+
+    expect(await db.get('campaigns', { id: tenantBCampaign.id })).toMatchObject(
+      { tenant_id: tenantB, status: 'draft' },
+    );
+    expect(await db.get('campaigns', { id: globalCampaign.id })).toMatchObject({
+      tenant_id: null,
+      status: 'scheduled',
+    });
   });
 
   it('validates and persists a Campaign on the same transaction database', async () => {
@@ -306,6 +493,18 @@ describe('Campaign customer scope', () => {
       nullStart.id,
     ]);
     expect(new Set(seen.map((campaign) => campaign.id)).size).toBe(7);
+
+    const boundedCampaigns = await CampaignCollection.create({
+      db,
+      maxListLimit: 2,
+    });
+    const boundedFirst = await boundedCampaigns.listByCustomer(
+      tenantId,
+      customer.id ?? '',
+      { limit: 2 },
+    );
+    expect(boundedFirst.items).toHaveLength(2);
+    expect(boundedFirst.nextCursor).not.toBeNull();
 
     const numericFirst = await campaigns.listByCustomer(
       tenantId.toUpperCase(),

--- a/packages/marketing/src/__tests__/campaign-customer.test.ts
+++ b/packages/marketing/src/__tests__/campaign-customer.test.ts
@@ -147,12 +147,69 @@ describe('Campaign customer scope', () => {
     ).toMatchObject({ id: uppercaseContextSaved.id });
     expect(
       await withTenant({ tenantId: tenantA.toUpperCase() }, () =>
-        campaigns.list({
-          where: { id: [uppercaseContextSaved.id?.toUpperCase()] },
-          select: ['id', 'tenantId'] as const,
+        campaigns.get({
+          tenantId: tenantA.toUpperCase(),
+          customerId: customerA.id?.toUpperCase(),
+          id: uppercaseContextSaved.id?.toUpperCase(),
         }),
       ),
-    ).toEqual([{ id: uppercaseContextSaved.id, tenantId: tenantA }]);
+    ).toMatchObject({
+      id: uppercaseContextSaved.id,
+      tenantId: tenantA,
+      customerId: customerA.id,
+    });
+    expect(
+      await withTenant({ tenantId: tenantA.toUpperCase() }, () =>
+        campaigns.list({
+          where: [
+            [
+              {
+                'id in': [uppercaseContextSaved.id?.toUpperCase()],
+                'customerId =': customerA.id?.toUpperCase(),
+                'tenantId in': [tenantA.toUpperCase()],
+              },
+            ],
+          ],
+          select: ['id', 'tenantId', 'customerId'] as const,
+        }),
+      ),
+    ).toEqual([
+      {
+        id: uppercaseContextSaved.id,
+        tenantId: tenantA,
+        customerId: customerA.id,
+      },
+    ]);
+    expect(
+      await withSystemContext(() =>
+        campaigns.get({
+          tenantId: null,
+          customerId: globalCustomer.id?.toUpperCase(),
+          id: globalSaved.id?.toUpperCase(),
+        }),
+      ),
+    ).toMatchObject({
+      id: globalSaved.id,
+      tenantId: null,
+      customerId: globalCustomer.id,
+    });
+    expect(
+      await withSystemContext(() =>
+        campaigns.list({
+          where: {
+            tenantId: null,
+            'customerId in': [globalCustomer.id?.toUpperCase()],
+          },
+          select: ['id', 'tenantId', 'customerId'] as const,
+        }),
+      ),
+    ).toEqual([
+      {
+        id: globalSaved.id,
+        tenantId: null,
+        customerId: globalCustomer.id,
+      },
+    ]);
     expect(
       await withTenant({ tenantId: tenantA.toUpperCase() }, () =>
         campaigns.findByCampaignKey('uppercase-context-campaign'),

--- a/packages/marketing/src/__tests__/campaign-customer.test.ts
+++ b/packages/marketing/src/__tests__/campaign-customer.test.ts
@@ -83,6 +83,24 @@ describe('Campaign customer scope', () => {
     });
     expect(globalSaved.tenantId).toBeNull();
 
+    const contextSaved = await withTenant({ tenantId: tenantA }, () =>
+      campaigns.create({
+        customerId: customerA.id,
+        campaignKey: 'context-tenant-campaign',
+        name: 'Context tenant campaign',
+      }),
+    );
+    expect(contextSaved.tenantId).toBe(tenantA);
+    await expect(
+      withTenant({ tenantId: tenantA }, () =>
+        campaigns.create({
+          customerId: globalCustomer.id,
+          campaignKey: 'context-global-campaign',
+          name: 'Rejected context global campaign',
+        }),
+      ),
+    ).rejects.toBeInstanceOf(CampaignCustomerScopeError);
+
     for (const input of [
       { tenantId: tenantA, customerId: customerB.id },
       { tenantId: tenantA, customerId: globalCustomer.id },
@@ -219,7 +237,33 @@ describe('Campaign customer scope', () => {
         activeCount: 0,
         latestStartAt: null,
       },
+      {
+        customerId: customerA.id,
+        totalCount: 2,
+        activeCount: 1,
+        latestStartAt: startLatest,
+      },
     ]);
+  });
+
+  it('keeps framework cross-package failures behind the typed scope error', async () => {
+    const tenantId = randomUUID();
+    const customer = await customers.create({ tenantId });
+    const originalGet = db.get.bind(db);
+    vi.spyOn(db, 'get').mockImplementation(async (table, where) => {
+      if (table === 'customers') return null;
+      return originalGet(table, where);
+    });
+
+    const save = campaigns.create({
+      tenantId,
+      customerId: customer.id,
+      campaignKey: 'customer-race',
+      name: 'Customer race',
+    });
+    await expect(save).rejects.toBeInstanceOf(CampaignCustomerScopeError);
+    await expect(save).rejects.not.toThrow(customer.id);
+    await expect(save).rejects.not.toThrow(/no such row exists/);
   });
 
   it('fails closed for cross-tenant lookup and rejects oversized inputs', async () => {

--- a/packages/marketing/src/__tests__/marketing.postgres.test.ts
+++ b/packages/marketing/src/__tests__/marketing.postgres.test.ts
@@ -6,7 +6,7 @@ import {
   isPostgresAvailable,
 } from '@happyvertical/smrt-vitest';
 import type { DatabaseInterface } from '@happyvertical/sql';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   CampaignCollection,
   CampaignMetricSnapshotCollection,
@@ -39,6 +39,7 @@ describePostgres('marketing natural keys on PostgreSQL', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await isolated?.cleanup();
     isolated = undefined;
   });
@@ -110,6 +111,23 @@ describePostgres('marketing natural keys on PostgreSQL', () => {
     const tenantB = randomUUID();
     const customerA = await customers.create({ tenantId: tenantA });
     const customerB = await customers.create({ tenantId: tenantB });
+    const transactionSql: string[] = [];
+    const originalTransaction = db.transaction?.bind(db);
+    expect(originalTransaction).toBeTypeOf('function');
+    vi.spyOn(db, 'transaction').mockImplementation(async (operation) =>
+      originalTransaction?.(async (tx) => {
+        const query = vi.spyOn(tx, 'query');
+        try {
+          return await operation(tx);
+        } finally {
+          transactionSql.push(
+            ...query.mock.calls
+              .map(([sql]) => sql)
+              .filter((sql): sql is string => typeof sql === 'string'),
+          );
+        }
+      }),
+    );
     const tiedStart = new Date('2026-08-01T00:00:00.000Z');
     const created = [];
     for (let index = 0; index < 3; index += 1) {
@@ -147,6 +165,16 @@ describePostgres('marketing natural keys on PostgreSQL', () => {
         latestStartAt: tiedStart,
       },
     ]);
+    expect(
+      transactionSql.some(
+        (sql) => sql.includes('FROM customers') && sql.endsWith('FOR UPDATE'),
+      ),
+    ).toBe(true);
+    expect(
+      transactionSql.some(
+        (sql) => sql.includes('FROM customers') && sql.endsWith('FOR SHARE'),
+      ),
+    ).toBe(true);
     await expect(
       campaigns.listByCustomer(tenantA, customerB.id ?? ''),
     ).rejects.toBeInstanceOf(CampaignCustomerScopeError);

--- a/packages/marketing/src/__tests__/marketing.postgres.test.ts
+++ b/packages/marketing/src/__tests__/marketing.postgres.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { CustomerCollection } from '@happyvertical/smrt-commerce';
 import {
   createIsolatedTestDbFromManifest,
   type IsolatedTestDbResult,
@@ -10,6 +11,7 @@ import {
   CampaignCollection,
   CampaignMetricSnapshotCollection,
 } from '../collections/index.js';
+import { CampaignCustomerScopeError } from '../errors.js';
 import { MetricIngestionService } from '../services/MetricIngestionService.js';
 
 const describePostgres = isPostgresAvailable() ? describe : describe.skip;
@@ -18,13 +20,20 @@ describePostgres('marketing natural keys on PostgreSQL', () => {
   let isolated: IsolatedTestDbResult | undefined;
   let db: DatabaseInterface;
   let campaigns: CampaignCollection;
+  let customers: CustomerCollection;
   let snapshots: CampaignMetricSnapshotCollection;
 
   beforeEach(async () => {
     isolated = await createIsolatedTestDbFromManifest({
-      includeObjects: ['Campaign', 'CampaignChannel', 'CampaignMetricSnapshot'],
+      includeObjects: [
+        'Customer',
+        'Campaign',
+        'CampaignChannel',
+        'CampaignMetricSnapshot',
+      ],
     });
     db = isolated.db;
+    customers = await CustomerCollection.create({ db });
     campaigns = await CampaignCollection.create({ db });
     snapshots = await CampaignMetricSnapshotCollection.create({ db });
   });
@@ -94,5 +103,61 @@ describePostgres('marketing natural keys on PostgreSQL', () => {
     expect(replay.created).toBe(false);
     expect(replay.snapshot.id).toBe(first.snapshot.id);
     expect(replay.snapshot.spendCents).toBe(1_000);
+  });
+
+  it('keeps native Customer scope, pagination, and summaries on PostgreSQL', async () => {
+    const tenantA = randomUUID();
+    const tenantB = randomUUID();
+    const customerA = await customers.create({ tenantId: tenantA });
+    const customerB = await customers.create({ tenantId: tenantB });
+    const tiedStart = new Date('2026-08-01T00:00:00.000Z');
+    const created = [];
+    for (let index = 0; index < 3; index += 1) {
+      created.push(
+        await campaigns.create({
+          tenantId: tenantA,
+          customerId: customerA.id,
+          campaignKey: `postgres-customer-${index}`,
+          name: `PostgreSQL customer campaign ${index}`,
+          status: index === 0 ? 'active' : 'draft',
+          startAt: tiedStart,
+        }),
+      );
+    }
+
+    const first = await campaigns.listByCustomer(tenantA, customerA.id ?? '', {
+      limit: 2,
+    });
+    const second = await campaigns.listByCustomer(tenantA, customerA.id ?? '', {
+      limit: 2,
+      after: first.nextCursor ?? undefined,
+    });
+    expect([...first.items, ...second.items].map((row) => row.id)).toEqual(
+      created
+        .map((row) => row.id ?? '')
+        .sort((left, right) => right.localeCompare(left)),
+    );
+    expect(
+      await campaigns.summarizeByCustomers(tenantA, [customerA.id ?? '']),
+    ).toEqual([
+      {
+        customerId: customerA.id,
+        totalCount: 3,
+        activeCount: 1,
+        latestStartAt: tiedStart,
+      },
+    ]);
+    await expect(
+      campaigns.listByCustomer(tenantA, customerB.id ?? ''),
+    ).rejects.toBeInstanceOf(CampaignCustomerScopeError);
+
+    const column = await db.query(
+      `SELECT data_type
+       FROM information_schema.columns
+       WHERE table_schema = current_schema()
+         AND table_name = 'campaigns'
+         AND column_name = 'customer_id'`,
+    );
+    expect(column.rows).toEqual([{ data_type: 'uuid' }]);
   });
 });

--- a/packages/marketing/src/collections/CampaignCollection.ts
+++ b/packages/marketing/src/collections/CampaignCollection.ts
@@ -413,7 +413,7 @@ function withCanonicalActiveTenant<T>(operation: () => Promise<T>): Promise<T> {
 function normalizeCampaignGetFilter(
   filter: string | SmrtWhereClause<Campaign>,
 ): string | SmrtWhereClause<Campaign> {
-  if (typeof filter !== 'string') return normalizeCampaignIdWhere(filter);
+  if (typeof filter !== 'string') return normalizeCampaignUuidWhere(filter);
   try {
     return normalizeUuid(filter, 'campaign id');
   } catch {
@@ -426,27 +426,35 @@ function normalizeCampaignListOptions(
 ): SmrtListOptions<Campaign> {
   return options.where === undefined
     ? options
-    : { ...options, where: normalizeCampaignIdWhere(options.where) };
+    : { ...options, where: normalizeCampaignUuidWhere(options.where) };
 }
 
-function normalizeCampaignIdWhere<T>(where: T): T {
+function normalizeCampaignUuidWhere<T>(where: T): T {
   if (Array.isArray(where)) {
-    return where.map((entry) => normalizeCampaignIdWhere(entry)) as T;
+    return where.map((entry) => normalizeCampaignUuidWhere(entry)) as T;
   }
   if (!where || typeof where !== 'object') return where;
 
   const normalized: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(where)) {
     const field = key.trim().split(/\s+/u)[0];
-    if (field !== 'id') {
+    const label =
+      field === 'id'
+        ? 'campaign id'
+        : field === 'customerId'
+          ? 'customerId'
+          : field === 'tenantId'
+            ? 'tenantId'
+            : null;
+    if (!label) {
       normalized[key] = value;
     } else if (Array.isArray(value)) {
-      normalized[key] = value.map((id) =>
-        typeof id === 'string' ? normalizeUuid(id, 'campaign id') : id,
+      normalized[key] = value.map((uuid) =>
+        typeof uuid === 'string' ? normalizeUuid(uuid, label) : uuid,
       );
     } else {
       normalized[key] =
-        typeof value === 'string' ? normalizeUuid(value, 'campaign id') : value;
+        typeof value === 'string' ? normalizeUuid(value, label) : value;
     }
   }
   return normalized as T;

--- a/packages/marketing/src/collections/CampaignCollection.ts
+++ b/packages/marketing/src/collections/CampaignCollection.ts
@@ -1,9 +1,18 @@
-import { resolveListLimit, SmrtCollection } from '@happyvertical/smrt-core';
 import {
-  assertTenantReadAllowed,
+  type CollectionCacheConfig,
+  resolveListLimit,
+  SmrtCollection,
+  type SmrtListOptions,
+  type SmrtSelectedRow,
+  type SmrtSelectField,
+  type SmrtWhereClause,
+} from '@happyvertical/smrt-core';
+import {
   getCurrentTenant,
   isSuperAdminBypass,
+  isSystemContext,
   TenantIsolationError,
+  withTenant,
 } from '@happyvertical/smrt-tenancy';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import {
@@ -25,6 +34,36 @@ export const MAX_CAMPAIGN_CUSTOMER_BATCH_SIZE = 100;
 
 export class CampaignCollection extends SmrtCollection<Campaign> {
   static readonly _itemClass = Campaign;
+
+  override async get(
+    filter: string | SmrtWhereClause<Campaign>,
+    options: { cache?: CollectionCacheConfig | false } = {},
+  ): Promise<Campaign | null> {
+    return withCanonicalActiveTenant(() =>
+      super.get(normalizeCampaignGetFilter(filter), options),
+    );
+  }
+
+  override async list<
+    const Select extends readonly SmrtSelectField<Campaign>[],
+  >(
+    options: SmrtListOptions<Campaign> & { select: Select; include?: never },
+  ): Promise<SmrtSelectedRow<Campaign, Select>[]>;
+  override async list(
+    options?: Omit<SmrtListOptions<Campaign>, 'select'> & {
+      select?: undefined;
+    },
+  ): Promise<Campaign[]>;
+  override async list(
+    options: SmrtListOptions<Campaign> = {},
+  ): Promise<Campaign[] | Record<string, unknown>[]> {
+    return withCanonicalActiveTenant(
+      () =>
+        super.list(normalizeCampaignListOptions(options) as never) as Promise<
+          Campaign[] | Record<string, unknown>[]
+        >,
+    );
+  }
 
   async findByCampaignKey(
     campaignKey: string,
@@ -72,12 +111,14 @@ export class CampaignCollection extends SmrtCollection<Campaign> {
       throw new Error('Campaign customer page limit must be at least 1.');
     }
     const cursor = normalizeCursor(options.after);
-    return this.inCustomerReadTransaction(async (bound) =>
-      bound.listByCustomerInTransaction(
-        normalizedTenantId,
-        normalizedCustomerId,
-        limit,
-        cursor,
+    return withCanonicalTenantContext(normalizedTenantId, () =>
+      this.inCustomerReadTransaction(async (bound) =>
+        bound.listByCustomerInTransaction(
+          normalizedTenantId,
+          normalizedCustomerId,
+          limit,
+          cursor,
+        ),
       ),
     );
   }
@@ -137,11 +178,13 @@ export class CampaignCollection extends SmrtCollection<Campaign> {
     const uniqueIds = [...new Set(normalizedCustomerIds)];
     if (uniqueIds.length === 0) return [];
 
-    return this.inCustomerReadTransaction(async (bound) =>
-      bound.summarizeByCustomersInTransaction(
-        normalizedTenantId,
-        normalizedCustomerIds,
-        uniqueIds,
+    return withCanonicalTenantContext(normalizedTenantId, () =>
+      this.inCustomerReadTransaction(async (bound) =>
+        bound.summarizeByCustomersInTransaction(
+          normalizedTenantId,
+          normalizedCustomerIds,
+          uniqueIds,
+        ),
       ),
     );
   }
@@ -209,6 +252,8 @@ export class CampaignCollection extends SmrtCollection<Campaign> {
       const bound = await CampaignCollection.create({
         ...this.options,
         db: transactionDb,
+        defaultListLimit: undefined,
+        maxListLimit: undefined,
       });
       return operation(bound);
     });
@@ -319,17 +364,92 @@ function normalizeTenantScope(
 ): string | null {
   if (tenantId !== null) {
     const normalized = normalizeUuid(tenantId, 'tenantId');
-    assertTenantReadAllowed(normalized, label);
+    const tenantContext = getCurrentTenant();
+    if (tenantContext && !isSuperAdminBypass()) {
+      const contextTenantId = normalizeUuid(tenantContext.tenantId, 'tenantId');
+      if (normalized !== contextTenantId) {
+        throw new TenantIsolationError(
+          `Tenant isolation violation in ${label}.`,
+          { tenantId: contextTenantId, attemptedTenantId: normalized },
+        );
+      }
+    }
     return normalized;
   }
   const tenantContext = getCurrentTenant();
-  if (tenantContext && !isSuperAdminBypass()) {
+  if (tenantContext && !isSuperAdminBypass() && !isSystemContext()) {
     throw new TenantIsolationError(
       `Tenant isolation violation in ${label}: tenant context cannot read global Campaign rows.`,
       { tenantId: tenantContext.tenantId, attemptedTenantId: 'global' },
     );
   }
   return null;
+}
+
+function withCanonicalTenantContext<T>(
+  tenantId: string | null,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const tenantContext = getCurrentTenant();
+  return tenantId !== null &&
+    tenantContext &&
+    !isSuperAdminBypass() &&
+    !isSystemContext()
+    ? withTenant({ ...tenantContext, tenantId }, operation)
+    : operation();
+}
+
+function withCanonicalActiveTenant<T>(operation: () => Promise<T>): Promise<T> {
+  const tenantContext = getCurrentTenant();
+  if (!tenantContext || isSuperAdminBypass() || isSystemContext()) {
+    return operation();
+  }
+  const normalizedTenantId = normalizeUuid(tenantContext.tenantId, 'tenantId');
+  return normalizedTenantId === tenantContext.tenantId
+    ? operation()
+    : withTenant({ ...tenantContext, tenantId: normalizedTenantId }, operation);
+}
+
+function normalizeCampaignGetFilter(
+  filter: string | SmrtWhereClause<Campaign>,
+): string | SmrtWhereClause<Campaign> {
+  if (typeof filter !== 'string') return normalizeCampaignIdWhere(filter);
+  try {
+    return normalizeUuid(filter, 'campaign id');
+  } catch {
+    return filter;
+  }
+}
+
+function normalizeCampaignListOptions(
+  options: SmrtListOptions<Campaign>,
+): SmrtListOptions<Campaign> {
+  return options.where === undefined
+    ? options
+    : { ...options, where: normalizeCampaignIdWhere(options.where) };
+}
+
+function normalizeCampaignIdWhere<T>(where: T): T {
+  if (Array.isArray(where)) {
+    return where.map((entry) => normalizeCampaignIdWhere(entry)) as T;
+  }
+  if (!where || typeof where !== 'object') return where;
+
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(where)) {
+    const field = key.trim().split(/\s+/u)[0];
+    if (field !== 'id') {
+      normalized[key] = value;
+    } else if (Array.isArray(value)) {
+      normalized[key] = value.map((id) =>
+        typeof id === 'string' ? normalizeUuid(id, 'campaign id') : id,
+      );
+    } else {
+      normalized[key] =
+        typeof value === 'string' ? normalizeUuid(value, 'campaign id') : value;
+    }
+  }
+  return normalized as T;
 }
 
 export default CampaignCollection;

--- a/packages/marketing/src/collections/CampaignCollection.ts
+++ b/packages/marketing/src/collections/CampaignCollection.ts
@@ -137,7 +137,7 @@ export class CampaignCollection extends SmrtCollection<Campaign> {
     const byCustomer = new Map(
       result.rows.map((row) => [String(row.customer_id), row]),
     );
-    return uniqueIds.map((customerId) => {
+    return customerIds.map((customerId) => {
       const row = byCustomer.get(customerId);
       return {
         customerId,

--- a/packages/marketing/src/collections/CampaignCollection.ts
+++ b/packages/marketing/src/collections/CampaignCollection.ts
@@ -1,6 +1,21 @@
-import { SmrtCollection } from '@happyvertical/smrt-core';
+import { resolveListLimit, SmrtCollection } from '@happyvertical/smrt-core';
+import { assertTenantReadAllowed } from '@happyvertical/smrt-tenancy';
+import { assertCustomersBelongToTenant } from '../customer-scope.js';
 import { Campaign } from '../models/Campaign.js';
-import type { CampaignStatus } from '../types.js';
+import type {
+  CampaignCustomerCursor,
+  CampaignCustomerCursorInput,
+  CampaignCustomerPage,
+  CampaignCustomerSummary,
+  CampaignStatus,
+  ListCampaignsByCustomerOptions,
+} from '../types.js';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+
+export const MAX_CAMPAIGN_CUSTOMER_PAGE_SIZE = 100;
+export const MAX_CAMPAIGN_CUSTOMER_BATCH_SIZE = 100;
 
 export class CampaignCollection extends SmrtCollection<Campaign> {
   static readonly _itemClass = Campaign;
@@ -22,6 +37,221 @@ export class CampaignCollection extends SmrtCollection<Campaign> {
       orderBy: 'start_at ASC',
     });
   }
+
+  /**
+   * List one tenant/customer lane newest-first using a stable UUID tiebreaker.
+   * Null start times follow all scheduled rows on every supported database.
+   */
+  async listByCustomer(
+    tenantId: string,
+    customerId: string,
+    options: ListCampaignsByCustomerOptions = {},
+  ): Promise<CampaignCustomerPage> {
+    assertUuid(tenantId, 'tenantId');
+    assertUuid(customerId, 'customerId');
+    assertTenantReadAllowed(tenantId, 'CampaignCollection.listByCustomer');
+    const limit = resolveListLimit(options.limit, {
+      defaultValue: 50,
+      maxValue: Number.MAX_SAFE_INTEGER,
+      parameterName: 'campaign customer page limit',
+    });
+    if (limit > MAX_CAMPAIGN_CUSTOMER_PAGE_SIZE) {
+      throw new Error(
+        `Campaign customer page limit must not exceed ${MAX_CAMPAIGN_CUSTOMER_PAGE_SIZE}.`,
+      );
+    }
+    if (limit < 1) {
+      throw new Error('Campaign customer page limit must be at least 1.');
+    }
+    const cursor = normalizeCursor(options.after);
+    await assertCustomersBelongToTenant(
+      this.options,
+      tenantId,
+      [customerId],
+      'CampaignCollection.listByCustomer',
+    );
+    const items =
+      cursor?.startAt === null
+        ? await this.listNullStartLane(tenantId, customerId, limit + 1, cursor)
+        : await this.listScheduledLane(tenantId, customerId, limit, cursor);
+    const hasMore = items.length > limit;
+    const pageItems = hasMore ? items.slice(0, limit) : items;
+    return {
+      items: pageItems,
+      nextCursor: hasMore
+        ? cursorFromCampaign(pageItems[pageItems.length - 1])
+        : null,
+    };
+  }
+
+  /**
+   * Summarize a bounded customer batch with one scope check and one grouped
+   * aggregate query. Every requested customer receives a row, including zeros.
+   */
+  async summarizeByCustomers(
+    tenantId: string,
+    customerIds: string[],
+  ): Promise<CampaignCustomerSummary[]> {
+    assertUuid(tenantId, 'tenantId');
+    assertTenantReadAllowed(
+      tenantId,
+      'CampaignCollection.summarizeByCustomers',
+    );
+    if (!Array.isArray(customerIds)) {
+      throw new Error(
+        'Campaign customer summary customerIds must be an array.',
+      );
+    }
+    if (customerIds.length > MAX_CAMPAIGN_CUSTOMER_BATCH_SIZE) {
+      throw new Error(
+        `Campaign customer summary accepts at most ${MAX_CAMPAIGN_CUSTOMER_BATCH_SIZE} customerIds.`,
+      );
+    }
+    const uniqueIds = [...new Set(customerIds)];
+    for (const customerId of uniqueIds) assertUuid(customerId, 'customerId');
+    if (uniqueIds.length === 0) return [];
+
+    await assertCustomersBelongToTenant(
+      this.options,
+      tenantId,
+      uniqueIds,
+      'CampaignCollection.summarizeByCustomers',
+    );
+    const db = requireDatabase(this.options);
+    const placeholders = uniqueIds.map(() => '?').join(', ');
+    const result = await db.query(
+      `SELECT customer_id,
+              COUNT(*) AS total_count,
+              SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) AS active_count,
+              MAX(start_at) AS latest_start_at
+       FROM ${this.tableName}
+       WHERE tenant_id = ? AND customer_id IN (${placeholders})
+       GROUP BY customer_id
+       ORDER BY customer_id ASC
+       LIMIT ?`,
+      'active',
+      tenantId,
+      ...uniqueIds,
+      uniqueIds.length,
+    );
+    const byCustomer = new Map(
+      result.rows.map((row) => [String(row.customer_id), row]),
+    );
+    return uniqueIds.map((customerId) => {
+      const row = byCustomer.get(customerId);
+      return {
+        customerId,
+        totalCount: row
+          ? toSafeCount(row.total_count, 'Campaign customer total count')
+          : 0,
+        activeCount: row
+          ? toSafeCount(row.active_count, 'Campaign customer active count')
+          : 0,
+        latestStartAt: row ? coerceDate(row.latest_start_at) : null,
+      };
+    });
+  }
+
+  private async listScheduledLane(
+    tenantId: string,
+    customerId: string,
+    limit: number,
+    cursor: CampaignCustomerCursor | null,
+  ): Promise<Campaign[]> {
+    const base = [{ tenantId }, { customerId }, { 'startAt !=': null }];
+    const where = cursor
+      ? [
+          [...base, { 'startAt <': cursor.startAt }],
+          [...base, { startAt: cursor.startAt }, { 'id <': cursor.id }],
+        ]
+      : { tenantId, customerId, 'startAt !=': null };
+    const scheduled = await this.list({
+      where,
+      orderBy: ['start_at DESC', 'id DESC'],
+      limit: limit + 1,
+    });
+    if (scheduled.length > limit) return scheduled;
+    const nullRows = await this.listNullStartLane(
+      tenantId,
+      customerId,
+      limit - scheduled.length + 1,
+      null,
+    );
+    return [...scheduled, ...nullRows];
+  }
+
+  private async listNullStartLane(
+    tenantId: string,
+    customerId: string,
+    limit: number,
+    cursor: CampaignCustomerCursor | null,
+  ): Promise<Campaign[]> {
+    return this.list({
+      where: {
+        tenantId,
+        customerId,
+        startAt: null,
+        ...(cursor ? { 'id <': cursor.id } : {}),
+      },
+      orderBy: 'id DESC',
+      limit,
+    });
+  }
+}
+
+interface QueryDatabase {
+  query(
+    sql: string,
+    ...params: unknown[]
+  ): Promise<{ rows: Array<Record<string, unknown>> }>;
+}
+
+function requireDatabase(options: { db?: unknown }): QueryDatabase {
+  const db = options.db;
+  if (!db || typeof db !== 'object' || !('query' in db)) {
+    throw new Error(
+      'Campaign customer summaries require an initialized database connection.',
+    );
+  }
+  return db as QueryDatabase;
+}
+
+function assertUuid(value: string, label: string): void {
+  if (!UUID_RE.test(value)) {
+    throw new Error(`${label} must be a canonical UUID.`);
+  }
+}
+
+function coerceDate(value: unknown): Date | null {
+  if (value == null) return null;
+  const date = value instanceof Date ? value : new Date(String(value));
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function toSafeCount(value: unknown, label: string): number {
+  const count = Number(value);
+  if (!Number.isSafeInteger(count) || count < 0) {
+    throw new Error(`${label} is outside the safe integer range.`);
+  }
+  return count;
+}
+
+function normalizeCursor(
+  cursor: CampaignCustomerCursorInput | undefined,
+): CampaignCustomerCursor | null {
+  if (!cursor) return null;
+  assertUuid(cursor.id, 'campaign customer cursor id');
+  if (cursor.startAt === null) return { id: cursor.id, startAt: null };
+  const startAt = coerceDate(cursor.startAt);
+  if (!startAt) throw new Error('campaign customer cursor startAt is invalid.');
+  return { id: cursor.id, startAt };
+}
+
+function cursorFromCampaign(
+  campaign: Campaign | undefined,
+): CampaignCustomerCursor | null {
+  if (!campaign?.id) return null;
+  return { id: campaign.id, startAt: campaign.startAt };
 }
 
 export default CampaignCollection;

--- a/packages/marketing/src/collections/CampaignCollection.ts
+++ b/packages/marketing/src/collections/CampaignCollection.ts
@@ -1,6 +1,15 @@
 import { resolveListLimit, SmrtCollection } from '@happyvertical/smrt-core';
-import { assertTenantReadAllowed } from '@happyvertical/smrt-tenancy';
-import { assertCustomersBelongToTenant } from '../customer-scope.js';
+import {
+  assertTenantReadAllowed,
+  getCurrentTenant,
+  isSuperAdminBypass,
+  TenantIsolationError,
+} from '@happyvertical/smrt-tenancy';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import {
+  assertCustomersBelongToTenant,
+  normalizeUuid,
+} from '../customer-scope.js';
 import { Campaign } from '../models/Campaign.js';
 import type {
   CampaignCustomerCursor,
@@ -10,9 +19,6 @@ import type {
   CampaignStatus,
   ListCampaignsByCustomerOptions,
 } from '../types.js';
-
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 
 export const MAX_CAMPAIGN_CUSTOMER_PAGE_SIZE = 100;
 export const MAX_CAMPAIGN_CUSTOMER_BATCH_SIZE = 100;
@@ -43,13 +49,15 @@ export class CampaignCollection extends SmrtCollection<Campaign> {
    * Null start times follow all scheduled rows on every supported database.
    */
   async listByCustomer(
-    tenantId: string,
+    tenantId: string | null,
     customerId: string,
     options: ListCampaignsByCustomerOptions = {},
   ): Promise<CampaignCustomerPage> {
-    assertUuid(tenantId, 'tenantId');
-    assertUuid(customerId, 'customerId');
-    assertTenantReadAllowed(tenantId, 'CampaignCollection.listByCustomer');
+    const normalizedTenantId = normalizeTenantScope(
+      tenantId,
+      'CampaignCollection.listByCustomer',
+    );
+    const normalizedCustomerId = normalizeUuid(customerId, 'customerId');
     const limit = resolveListLimit(options.limit, {
       defaultValue: 50,
       maxValue: Number.MAX_SAFE_INTEGER,
@@ -64,11 +72,28 @@ export class CampaignCollection extends SmrtCollection<Campaign> {
       throw new Error('Campaign customer page limit must be at least 1.');
     }
     const cursor = normalizeCursor(options.after);
+    return this.inCustomerReadTransaction(async (bound) =>
+      bound.listByCustomerInTransaction(
+        normalizedTenantId,
+        normalizedCustomerId,
+        limit,
+        cursor,
+      ),
+    );
+  }
+
+  private async listByCustomerInTransaction(
+    tenantId: string | null,
+    customerId: string,
+    limit: number,
+    cursor: CampaignCustomerCursor | null,
+  ): Promise<CampaignCustomerPage> {
     await assertCustomersBelongToTenant(
       this.options,
       tenantId,
       [customerId],
       'CampaignCollection.listByCustomer',
+      'share',
     );
     const items =
       cursor?.startAt === null
@@ -89,11 +114,10 @@ export class CampaignCollection extends SmrtCollection<Campaign> {
    * aggregate query. Every requested customer receives a row, including zeros.
    */
   async summarizeByCustomers(
-    tenantId: string,
+    tenantId: string | null,
     customerIds: string[],
   ): Promise<CampaignCustomerSummary[]> {
-    assertUuid(tenantId, 'tenantId');
-    assertTenantReadAllowed(
+    const normalizedTenantId = normalizeTenantScope(
       tenantId,
       'CampaignCollection.summarizeByCustomers',
     );
@@ -107,37 +131,57 @@ export class CampaignCollection extends SmrtCollection<Campaign> {
         `Campaign customer summary accepts at most ${MAX_CAMPAIGN_CUSTOMER_BATCH_SIZE} customerIds.`,
       );
     }
-    const uniqueIds = [...new Set(customerIds)];
-    for (const customerId of uniqueIds) assertUuid(customerId, 'customerId');
+    const normalizedCustomerIds = customerIds.map((customerId) =>
+      normalizeUuid(customerId, 'customerId'),
+    );
+    const uniqueIds = [...new Set(normalizedCustomerIds)];
     if (uniqueIds.length === 0) return [];
 
+    return this.inCustomerReadTransaction(async (bound) =>
+      bound.summarizeByCustomersInTransaction(
+        normalizedTenantId,
+        normalizedCustomerIds,
+        uniqueIds,
+      ),
+    );
+  }
+
+  private async summarizeByCustomersInTransaction(
+    tenantId: string | null,
+    requestedCustomerIds: string[],
+    uniqueIds: string[],
+  ): Promise<CampaignCustomerSummary[]> {
     await assertCustomersBelongToTenant(
       this.options,
       tenantId,
       uniqueIds,
       'CampaignCollection.summarizeByCustomers',
+      'share',
     );
     const db = requireDatabase(this.options);
     const placeholders = uniqueIds.map(() => '?').join(', ');
+    const tenantPredicate =
+      tenantId === null ? 'tenant_id IS NULL' : 'tenant_id = ?';
+    const tenantParams = tenantId === null ? [] : [tenantId];
     const result = await db.query(
       `SELECT customer_id,
               COUNT(*) AS total_count,
               SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) AS active_count,
               MAX(start_at) AS latest_start_at
        FROM ${this.tableName}
-       WHERE tenant_id = ? AND customer_id IN (${placeholders})
+       WHERE ${tenantPredicate} AND customer_id IN (${placeholders})
        GROUP BY customer_id
        ORDER BY customer_id ASC
        LIMIT ?`,
       'active',
-      tenantId,
+      ...tenantParams,
       ...uniqueIds,
       uniqueIds.length,
     );
     const byCustomer = new Map(
-      result.rows.map((row) => [String(row.customer_id), row]),
+      result.rows.map((row) => [String(row.customer_id).toLowerCase(), row]),
     );
-    return customerIds.map((customerId) => {
+    return requestedCustomerIds.map((customerId) => {
       const row = byCustomer.get(customerId);
       return {
         customerId,
@@ -152,8 +196,26 @@ export class CampaignCollection extends SmrtCollection<Campaign> {
     });
   }
 
+  private async inCustomerReadTransaction<T>(
+    operation: (bound: CampaignCollection) => Promise<T>,
+  ): Promise<T> {
+    const db = this.db as DatabaseInterface;
+    if (typeof db.transaction !== 'function') {
+      throw new Error(
+        'Campaign customer reads require a database adapter with transaction support.',
+      );
+    }
+    return db.transaction(async (transactionDb) => {
+      const bound = await CampaignCollection.create({
+        ...this.options,
+        db: transactionDb,
+      });
+      return operation(bound);
+    });
+  }
+
   private async listScheduledLane(
-    tenantId: string,
+    tenantId: string | null,
     customerId: string,
     limit: number,
     cursor: CampaignCustomerCursor | null,
@@ -181,7 +243,7 @@ export class CampaignCollection extends SmrtCollection<Campaign> {
   }
 
   private async listNullStartLane(
-    tenantId: string,
+    tenantId: string | null,
     customerId: string,
     limit: number,
     cursor: CampaignCustomerCursor | null,
@@ -216,15 +278,12 @@ function requireDatabase(options: { db?: unknown }): QueryDatabase {
   return db as QueryDatabase;
 }
 
-function assertUuid(value: string, label: string): void {
-  if (!UUID_RE.test(value)) {
-    throw new Error(`${label} must be a canonical UUID.`);
-  }
-}
-
 function coerceDate(value: unknown): Date | null {
   if (value == null) return null;
-  const date = value instanceof Date ? value : new Date(String(value));
+  const date =
+    value instanceof Date
+      ? value
+      : new Date(typeof value === 'number' ? value : String(value));
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
@@ -240,11 +299,11 @@ function normalizeCursor(
   cursor: CampaignCustomerCursorInput | undefined,
 ): CampaignCustomerCursor | null {
   if (!cursor) return null;
-  assertUuid(cursor.id, 'campaign customer cursor id');
-  if (cursor.startAt === null) return { id: cursor.id, startAt: null };
+  const id = normalizeUuid(cursor.id, 'campaign customer cursor id');
+  if (cursor.startAt === null) return { id, startAt: null };
   const startAt = coerceDate(cursor.startAt);
   if (!startAt) throw new Error('campaign customer cursor startAt is invalid.');
-  return { id: cursor.id, startAt };
+  return { id, startAt };
 }
 
 function cursorFromCampaign(
@@ -252,6 +311,25 @@ function cursorFromCampaign(
 ): CampaignCustomerCursor | null {
   if (!campaign?.id) return null;
   return { id: campaign.id, startAt: campaign.startAt };
+}
+
+function normalizeTenantScope(
+  tenantId: string | null,
+  label: string,
+): string | null {
+  if (tenantId !== null) {
+    const normalized = normalizeUuid(tenantId, 'tenantId');
+    assertTenantReadAllowed(normalized, label);
+    return normalized;
+  }
+  const tenantContext = getCurrentTenant();
+  if (tenantContext && !isSuperAdminBypass()) {
+    throw new TenantIsolationError(
+      `Tenant isolation violation in ${label}: tenant context cannot read global Campaign rows.`,
+      { tenantId: tenantContext.tenantId, attemptedTenantId: 'global' },
+    );
+  }
+  return null;
 }
 
 export default CampaignCollection;

--- a/packages/marketing/src/customer-scope.ts
+++ b/packages/marketing/src/customer-scope.ts
@@ -1,0 +1,81 @@
+import {
+  ObjectRegistry,
+  type SmrtObject,
+  type SmrtObjectOptions,
+} from '@happyvertical/smrt-core';
+import { CampaignCustomerScopeError } from './errors.js';
+
+const CUSTOMER_QUALIFIED_NAME = '@happyvertical/smrt-commerce:Customer';
+const SAFE_SQL_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+
+interface QueryResult {
+  rows: Array<Record<string, unknown>>;
+}
+
+interface QueryDatabase {
+  query(sql: string, ...params: unknown[]): Promise<QueryResult>;
+}
+
+interface DatabaseOptions {
+  db?: SmrtObjectOptions['db'];
+}
+
+function requireDatabase(options: DatabaseOptions): QueryDatabase {
+  const db = options.db;
+  if (!db || typeof db !== 'object' || !('query' in db)) {
+    throw new Error(
+      'Campaign customer queries require an initialized database connection.',
+    );
+  }
+  return db as QueryDatabase;
+}
+
+async function resolveCustomerTable(options: DatabaseOptions): Promise<string> {
+  await ObjectRegistry.ensureManifestLoaded(CUSTOMER_QUALIFIED_NAME);
+  const target =
+    ObjectRegistry.getClassByQualifiedName(CUSTOMER_QUALIFIED_NAME) ??
+    ObjectRegistry.getClass(CUSTOMER_QUALIFIED_NAME);
+  if (!target) {
+    throw new Error(
+      'Campaign customer queries require @happyvertical/smrt-commerce:Customer to be registered.',
+    );
+  }
+
+  const probe = new target.constructor(options) as SmrtObject;
+  const tableName = probe.tableName;
+  if (!SAFE_SQL_IDENTIFIER.test(tableName)) {
+    throw new Error('Campaign customer table has an invalid identifier.');
+  }
+  return tableName;
+}
+
+/**
+ * Verify a bounded set of canonical commerce Customers in one database read.
+ * The generic failure deliberately does not reveal whether an id is missing or
+ * belongs to another tenant.
+ */
+export async function assertCustomersBelongToTenant(
+  options: DatabaseOptions,
+  tenantId: string | null,
+  customerIds: readonly string[],
+  label: string,
+): Promise<void> {
+  if (customerIds.length === 0) return;
+  const db = requireDatabase(options);
+  const tableName = await resolveCustomerTable(options);
+  const placeholders = customerIds.map(() => '?').join(', ');
+  const result = await db.query(
+    `SELECT id, tenant_id FROM ${tableName} WHERE id IN (${placeholders})`,
+    ...customerIds,
+  );
+  const tenantById = new Map(
+    result.rows.map((row) => [String(row.id), row.tenant_id ?? null]),
+  );
+  const valid = customerIds.every(
+    (customerId) =>
+      tenantById.has(customerId) && tenantById.get(customerId) === tenantId,
+  );
+  if (!valid) {
+    throw new CampaignCustomerScopeError(label);
+  }
+}

--- a/packages/marketing/src/customer-scope.ts
+++ b/packages/marketing/src/customer-scope.ts
@@ -3,18 +3,15 @@ import {
   type SmrtObject,
   type SmrtObjectOptions,
 } from '@happyvertical/smrt-core';
+import type { DatabaseInterface } from '@happyvertical/sql';
 import { CampaignCustomerScopeError } from './errors.js';
 
 const CUSTOMER_QUALIFIED_NAME = '@happyvertical/smrt-commerce:Customer';
 const SAFE_SQL_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 
-interface QueryResult {
-  rows: Array<Record<string, unknown>>;
-}
-
-interface QueryDatabase {
-  query(sql: string, ...params: unknown[]): Promise<QueryResult>;
-}
+type QueryDatabase = Pick<DatabaseInterface, 'query' | 'url'>;
 
 interface DatabaseOptions {
   db?: SmrtObjectOptions['db'];
@@ -59,23 +56,53 @@ export async function assertCustomersBelongToTenant(
   tenantId: string | null,
   customerIds: readonly string[],
   label: string,
+  lock: 'none' | 'share' | 'update' = 'none',
 ): Promise<void> {
   if (customerIds.length === 0) return;
+  const normalizedCustomerIds = customerIds.map((customerId) => {
+    try {
+      return normalizeUuid(customerId, 'customerId');
+    } catch {
+      throw new CampaignCustomerScopeError(label);
+    }
+  });
+  const normalizedTenantId = tenantId?.toLowerCase() ?? null;
   const db = requireDatabase(options);
   const tableName = await resolveCustomerTable(options);
-  const placeholders = customerIds.map(() => '?').join(', ');
+  const placeholders = normalizedCustomerIds.map(() => '?').join(', ');
+  const lockClause = postgresLockClause(db, lock);
   const result = await db.query(
-    `SELECT id, tenant_id FROM ${tableName} WHERE id IN (${placeholders})`,
-    ...customerIds,
+    `SELECT id, tenant_id FROM ${tableName} WHERE id IN (${placeholders})${lockClause}`,
+    ...normalizedCustomerIds,
   );
   const tenantById = new Map(
-    result.rows.map((row) => [String(row.id), row.tenant_id ?? null]),
+    result.rows.map((row) => [
+      String(row.id).toLowerCase(),
+      row.tenant_id == null ? null : String(row.tenant_id).toLowerCase(),
+    ]),
   );
-  const valid = customerIds.every(
+  const valid = normalizedCustomerIds.every(
     (customerId) =>
-      tenantById.has(customerId) && tenantById.get(customerId) === tenantId,
+      tenantById.has(customerId) &&
+      tenantById.get(customerId) === normalizedTenantId,
   );
   if (!valid) {
     throw new CampaignCustomerScopeError(label);
   }
+}
+
+function postgresLockClause(
+  db: QueryDatabase,
+  lock: 'none' | 'share' | 'update',
+): string {
+  if (lock === 'none' || !/^postgres(?:ql)?:/iu.test(db.url)) return '';
+  return lock === 'update' ? ' FOR UPDATE' : ' FOR SHARE';
+}
+
+/** Parse and canonicalize one UUID without echoing the rejected value. */
+export function normalizeUuid(value: string, label: string): string {
+  if (!UUID_RE.test(value)) {
+    throw new Error(`${label} must be a canonical UUID.`);
+  }
+  return value.toLowerCase();
 }

--- a/packages/marketing/src/errors.ts
+++ b/packages/marketing/src/errors.ts
@@ -1,0 +1,9 @@
+/** Fail-closed customer/tenant mismatch without revealing row existence. */
+export class CampaignCustomerScopeError extends Error {
+  readonly code = 'CAMPAIGN_CUSTOMER_SCOPE';
+
+  constructor(label: string) {
+    super(`${label}: customer scope validation failed.`);
+    this.name = 'CampaignCustomerScopeError';
+  }
+}

--- a/packages/marketing/src/index.ts
+++ b/packages/marketing/src/index.ts
@@ -3,6 +3,7 @@
 import './__smrt-register__.js';
 
 export * from './collections/index.js';
+export * from './errors.js';
 export * from './models/index.js';
 export * from './services/index.js';
 export * from './types.js';

--- a/packages/marketing/src/models/Campaign.ts
+++ b/packages/marketing/src/models/Campaign.ts
@@ -5,9 +5,17 @@ import {
   field,
   SmrtObject,
   smrt,
+  ValidationError,
 } from '@happyvertical/smrt-core';
-import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import {
+  getCurrentTenant,
+  isSuperAdminBypass,
+  isSystemContext,
+  TenantScoped,
+  tenantId,
+} from '@happyvertical/smrt-tenancy';
 import { assertCustomersBelongToTenant } from '../customer-scope.js';
+import { CampaignCustomerScopeError } from '../errors.js';
 import {
   CAMPAIGN_STATUSES,
   type CampaignOptions,
@@ -108,14 +116,32 @@ export class Campaign extends SmrtObject {
     this.assertStatusTransition(prior);
     this.assertSchedule();
     if (this.customerId !== null) {
+      const tenantContext =
+        isSystemContext() || isSuperAdminBypass()
+          ? undefined
+          : getCurrentTenant();
+      const effectiveTenantId =
+        this.tenantId || tenantContext?.tenantId || null;
       await assertCustomersBelongToTenant(
         this.options,
-        this.tenantId,
+        effectiveTenantId,
         [this.customerId],
         'Campaign.save',
       );
     }
-    const result = (await super.save()) as this;
+    let result: this;
+    try {
+      result = (await super.save()) as this;
+    } catch (error) {
+      if (
+        error instanceof ValidationError &&
+        (error.code === 'VALIDATION_CROSS_PACKAGE_REF_MISSING' ||
+          error.code === 'VALIDATION_CROSS_PACKAGE_REF_UNREGISTERED')
+      ) {
+        throw new CampaignCustomerScopeError('Campaign.save');
+      }
+      throw error;
+    }
     loadedCampaignStatus.set(this, this.status);
     return result;
   }

--- a/packages/marketing/src/models/Campaign.ts
+++ b/packages/marketing/src/models/Campaign.ts
@@ -14,7 +14,10 @@ import {
   TenantScoped,
   tenantId,
 } from '@happyvertical/smrt-tenancy';
-import { assertCustomersBelongToTenant } from '../customer-scope.js';
+import {
+  assertCustomersBelongToTenant,
+  normalizeUuid,
+} from '../customer-scope.js';
 import { CampaignCustomerScopeError } from '../errors.js';
 import {
   CAMPAIGN_STATUSES,
@@ -112,21 +115,44 @@ export class Campaign extends SmrtObject {
   }
 
   override async save(): Promise<this> {
+    if (this.customerId === null) return this.saveLifecycle();
+
+    const db = this.db;
+    if (typeof db.transaction !== 'function') {
+      throw new Error(
+        'Campaign.save requires a database adapter with transaction support.',
+      );
+    }
+    return db.transaction(async (transactionDb) =>
+      this.withDatabase(transactionDb, async (bound) => bound.saveLifecycle()),
+    );
+  }
+
+  private async saveLifecycle(): Promise<this> {
     const prior = await this.resolvePriorStatus();
     this.assertStatusTransition(prior);
     this.assertSchedule();
     if (this.customerId !== null) {
+      try {
+        this.customerId = normalizeUuid(this.customerId, 'customerId');
+        if (this.tenantId !== null) {
+          this.tenantId = normalizeUuid(this.tenantId, 'tenantId');
+        }
+      } catch {
+        throw new CampaignCustomerScopeError('Campaign.save');
+      }
       const tenantContext =
         isSystemContext() || isSuperAdminBypass()
           ? undefined
           : getCurrentTenant();
       const effectiveTenantId =
-        this.tenantId || tenantContext?.tenantId || null;
+        this.tenantId ?? tenantContext?.tenantId ?? null;
       await assertCustomersBelongToTenant(
         this.options,
         effectiveTenantId,
         [this.customerId],
         'Campaign.save',
+        'update',
       );
     }
     let result: this;

--- a/packages/marketing/src/models/Campaign.ts
+++ b/packages/marketing/src/models/Campaign.ts
@@ -120,7 +120,7 @@ export class Campaign extends SmrtObject {
     await super.initialize();
     this.startAt = Campaign.coerceDate(this.startAt);
     this.endAt = Campaign.coerceDate(this.endAt);
-    loadedCampaignStatus.set(this, this.status);
+    if (this.isPersisted) loadedCampaignStatus.set(this, this.status);
     return this;
   }
 

--- a/packages/marketing/src/models/Campaign.ts
+++ b/packages/marketing/src/models/Campaign.ts
@@ -1,7 +1,13 @@
 /** Campaign identity, budget, schedule, and guarded lifecycle. */
 
-import { field, SmrtObject, smrt } from '@happyvertical/smrt-core';
+import {
+  crossPackageRef,
+  field,
+  SmrtObject,
+  smrt,
+} from '@happyvertical/smrt-core';
 import { TenantScoped, tenantId } from '@happyvertical/smrt-tenancy';
+import { assertCustomersBelongToTenant } from '../customer-scope.js';
 import {
   CAMPAIGN_STATUSES,
   type CampaignOptions,
@@ -23,6 +29,12 @@ const loadedCampaignStatus = new WeakMap<Campaign, CampaignStatus>();
 @smrt({
   tableName: 'campaigns',
   conflictColumns: ['tenant_id', 'campaign_key'],
+  indexes: [
+    {
+      name: 'campaigns_tenant_id_customer_id_start_at_id_idx',
+      columns: ['tenantId', 'customerId', 'startAt', 'id'],
+    },
+  ],
   api: { include: ['list', 'get', 'create', 'update'] },
   mcp: { include: ['list', 'get', 'create', 'update'] },
   cli: { include: ['list', 'get', 'create', 'update'] },
@@ -30,6 +42,13 @@ const loadedCampaignStatus = new WeakMap<Campaign, CampaignStatus>();
 export class Campaign extends SmrtObject {
   @tenantId({ nullable: true })
   tenantId: string | null = null;
+
+  /** Canonical commerce Customer that owns this campaign, when assigned. */
+  @crossPackageRef('@happyvertical/smrt-commerce:Customer', {
+    nullable: true,
+    validate: true,
+  })
+  customerId: string | null = null;
 
   /** Stable caller-defined key used by CRM/referral systems. */
   @field({ required: true })
@@ -58,6 +77,7 @@ export class Campaign extends SmrtObject {
   constructor(options: CampaignOptions = {}) {
     super(options);
     if (options.tenantId !== undefined) this.tenantId = options.tenantId;
+    if (options.customerId !== undefined) this.customerId = options.customerId;
     if (options.campaignKey !== undefined)
       this.campaignKey = options.campaignKey;
     if (options.name !== undefined) this.name = options.name;
@@ -87,6 +107,14 @@ export class Campaign extends SmrtObject {
     const prior = await this.resolvePriorStatus();
     this.assertStatusTransition(prior);
     this.assertSchedule();
+    if (this.customerId !== null) {
+      await assertCustomersBelongToTenant(
+        this.options,
+        this.tenantId,
+        [this.customerId],
+        'Campaign.save',
+      );
+    }
     const result = (await super.save()) as this;
     loadedCampaignStatus.set(this, this.status);
     return result;

--- a/packages/marketing/src/models/Campaign.ts
+++ b/packages/marketing/src/models/Campaign.ts
@@ -11,8 +11,10 @@ import {
   getCurrentTenant,
   isSuperAdminBypass,
   isSystemContext,
+  TenantIsolationError,
   TenantScoped,
   tenantId,
+  withTenant,
 } from '@happyvertical/smrt-tenancy';
 import {
   assertCustomersBelongToTenant,
@@ -105,12 +107,20 @@ export class Campaign extends SmrtObject {
   }
 
   override async initialize(): Promise<this> {
+    if (this.id) {
+      try {
+        this.id = normalizeUuid(this.id, 'id');
+      } catch (error) {
+        if (this.customerId !== null) {
+          throw new CampaignCustomerScopeError('Campaign.initialize');
+        }
+        throw error;
+      }
+    }
     await super.initialize();
     this.startAt = Campaign.coerceDate(this.startAt);
     this.endAt = Campaign.coerceDate(this.endAt);
-    if (await this.isSaved()) {
-      loadedCampaignStatus.set(this, this.status);
-    }
+    loadedCampaignStatus.set(this, this.status);
     return this;
   }
 
@@ -129,35 +139,35 @@ export class Campaign extends SmrtObject {
   }
 
   private async saveLifecycle(): Promise<this> {
-    const prior = await this.resolvePriorStatus();
-    this.assertStatusTransition(prior);
-    this.assertSchedule();
+    this.prepareIdentityForSave();
     if (this.customerId !== null) {
-      try {
-        this.customerId = normalizeUuid(this.customerId, 'customerId');
-        if (this.tenantId !== null) {
-          this.tenantId = normalizeUuid(this.tenantId, 'tenantId');
-        }
-      } catch {
-        throw new CampaignCustomerScopeError('Campaign.save');
-      }
-      const tenantContext =
-        isSystemContext() || isSuperAdminBypass()
-          ? undefined
-          : getCurrentTenant();
-      const effectiveTenantId =
-        this.tenantId ?? tenantContext?.tenantId ?? null;
       await assertCustomersBelongToTenant(
         this.options,
-        effectiveTenantId,
+        this.tenantId,
         [this.customerId],
         'Campaign.save',
         'update',
       );
     }
+    const prior = await this.resolvePriorStatus();
+    this.assertStatusTransition(prior);
+    this.assertSchedule();
     let result: this;
     try {
-      result = (await super.save()) as this;
+      const persist = async () => (await super.save()) as this;
+      const tenantContext =
+        isSystemContext() || isSuperAdminBypass()
+          ? undefined
+          : getCurrentTenant();
+      result = tenantContext
+        ? await withTenant(
+            {
+              ...tenantContext,
+              tenantId: this.tenantId ?? tenantContext.tenantId,
+            },
+            persist,
+          )
+        : await persist();
     } catch (error) {
       if (
         error instanceof ValidationError &&
@@ -170,6 +180,45 @@ export class Campaign extends SmrtObject {
     }
     loadedCampaignStatus.set(this, this.status);
     return result;
+  }
+
+  /** Canonicalize and authorize identity before any status or scope read. */
+  private prepareIdentityForSave(): void {
+    try {
+      if (this.id) this.id = normalizeUuid(this.id, 'id');
+      if (this.customerId !== null) {
+        this.customerId = normalizeUuid(this.customerId, 'customerId');
+      }
+      if (this.tenantId !== null) {
+        this.tenantId = normalizeUuid(this.tenantId, 'tenantId');
+      }
+    } catch (error) {
+      if (this.customerId !== null) {
+        throw new CampaignCustomerScopeError('Campaign.save');
+      }
+      throw error;
+    }
+
+    if (isSystemContext() || isSuperAdminBypass()) return;
+    const tenantContext = getCurrentTenant();
+    if (!tenantContext) return;
+
+    let contextTenantId: string;
+    try {
+      contextTenantId = normalizeUuid(tenantContext.tenantId, 'tenantId');
+    } catch (error) {
+      if (this.customerId !== null) {
+        throw new CampaignCustomerScopeError('Campaign.save');
+      }
+      throw error;
+    }
+    if (this.tenantId !== null && this.tenantId !== contextTenantId) {
+      throw new TenantIsolationError(
+        'Tenant isolation violation in Campaign.save.',
+        { tenantId: contextTenantId, attemptedTenantId: this.tenantId },
+      );
+    }
+    this.tenantId = contextTenantId;
   }
 
   /** Apply one legal transition in memory; callers choose the save boundary. */
@@ -217,11 +266,29 @@ export class Campaign extends SmrtObject {
 
   private async resolvePriorStatus(): Promise<CampaignStatus | undefined> {
     if (this.id) {
+      let scopedRow: Record<string, unknown> | null = null;
       try {
-        const row = await this.db.get(this.tableName, { id: this.id });
-        if (row && row.status != null) return row.status as CampaignStatus;
+        scopedRow = await this.db.get(this.tableName, {
+          id: this.id,
+          tenant_id: this.tenantId,
+        });
       } catch {
         // DB not ready / table absent; fall through to the hydrated state.
+      }
+      if (scopedRow?.status != null) {
+        return scopedRow.status as CampaignStatus;
+      }
+
+      // A caller-supplied ID already owned by another lane must not expose its
+      // lifecycle state or be repurposed by an upsert.
+      let rowInAnotherLane: Record<string, unknown> | null = null;
+      try {
+        rowInAnotherLane = await this.db.get(this.tableName, { id: this.id });
+      } catch {
+        // DB not ready / table absent; fall through to the hydrated state.
+      }
+      if (rowInAnotherLane) {
+        throw new CampaignCustomerScopeError('Campaign.save');
       }
     }
     if (this.campaignKey) {

--- a/packages/marketing/src/types.ts
+++ b/packages/marketing/src/types.ts
@@ -1,6 +1,7 @@
 /** Shared model and service contracts for @happyvertical/smrt-marketing. */
 
 import type { SmrtObjectOptions } from '@happyvertical/smrt-core';
+import type { Campaign } from './models/Campaign.js';
 
 export const CAMPAIGN_STATUSES = [
   'draft',
@@ -39,6 +40,7 @@ export type CampaignChannelStatus = (typeof CAMPAIGN_CHANNEL_STATUSES)[number];
 
 export interface CampaignOptions extends SmrtObjectOptions {
   tenantId?: string | null;
+  customerId?: string | null;
   campaignKey?: string;
   name?: string;
   objective?: string;
@@ -48,6 +50,33 @@ export interface CampaignOptions extends SmrtObjectOptions {
   budgetCents?: number;
   currency?: string;
   metadata?: string;
+}
+
+export interface CampaignCustomerCursorInput {
+  startAt: Date | string | number | null;
+  id: string;
+}
+
+export interface CampaignCustomerCursor {
+  startAt: Date | null;
+  id: string;
+}
+
+export interface ListCampaignsByCustomerOptions {
+  limit?: number;
+  after?: CampaignCustomerCursorInput;
+}
+
+export interface CampaignCustomerPage {
+  items: Campaign[];
+  nextCursor: CampaignCustomerCursor | null;
+}
+
+export interface CampaignCustomerSummary {
+  customerId: string;
+  totalCount: number;
+  activeCount: number;
+  latestStartAt: Date | null;
 }
 
 export interface CampaignChannelOptions extends SmrtObjectOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1444,6 +1444,9 @@ importers:
         specifier: workspace:*
         version: link:../smrt-ui
     devDependencies:
+      '@happyvertical/smrt-commerce':
+        specifier: workspace:*
+        version: link:../commerce
       '@happyvertical/smrt-vitest':
         specifier: workspace:*
         version: link:../vitest


### PR DESCRIPTION
## Summary

- add native optional Customer ownership to Campaign with fail-closed tenant agreement validation
- make associated Campaign saves atomic and add bounded tenant/customer cursor pages and batch summaries
- canonicalize UUID query boundaries, preserve lifecycle compatibility, and document migration away from metadata account IDs
- add the minimal public `SmrtClass.withDatabase()` transaction binding API

## Validation

- `pnpm --filter @happyvertical/smrt-marketing exec vitest run src/__tests__/campaign-customer.test.ts` — 11 passed
- `pnpm --filter @happyvertical/smrt-marketing test` — 26 passed, 2 PostgreSQL tests skipped; Svelte 5 passed
- `pnpm --filter @happyvertical/smrt-core exec vitest run src/__tests__/with-database.test.ts` — 2 passed
- `pnpm --filter @happyvertical/smrt-marketing typecheck`
- `pnpm --filter @happyvertical/smrt-marketing build`
- `pnpm --filter @happyvertical/smrt-marketing verify:pack`
- `pnpm exec biome check <changed files>`
- `pnpm knowledge:check -- --strict`
- pre-push repository checks
- independent high-risk review: CLEAN on `e53a4aaea7481c43e5e63590915928d5749f7e75`

Closes #2496

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "16C01785-A57D-458F-993C-6C93723EB107",
  "issue": 2496,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm --filter @happyvertical/smrt-marketing test",
    "pnpm --filter @happyvertical/smrt-marketing typecheck",
    "pnpm --filter @happyvertical/smrt-marketing build",
    "pnpm --filter @happyvertical/smrt-marketing verify:pack",
    "pnpm knowledge:check -- --strict"
  ]
}
