### PR TITLE
feat(core)!: enforce same-package foreign keys

### DIFF
--- a/packages/ads/src/__tests__/ads-tenant-isolation.test.ts
+++ b/packages/ads/src/__tests__/ads-tenant-isolation.test.ts
@@ -29,7 +29,9 @@ import {
 } from '@happyvertical/smrt-tenancy';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AdDeliveryTierCollection } from '../collections/AdDeliveryTierCollection';
 import { AdEventCollection } from '../collections/AdEventCollection';
+import { AdFormatCollection } from '../collections/AdFormatCollection';
 import { AdGroupCollection } from '../collections/AdGroupCollection';
 import { AdVariationCollection } from '../collections/AdVariationCollection';
 
@@ -38,9 +40,23 @@ const sorted = (rows: Array<Record<string, any>>, field: string): string[] =>
 
 describe('ads tenant isolation (#1600)', () => {
   let db: DatabaseInterface;
+  let tierId: string;
+  let formatId: string;
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const tiers = await AdDeliveryTierCollection.create({ db });
+    const formats = await AdFormatCollection.create({ db });
+    const tier = await tiers.create({ name: 'Test Tier', priority: 1 });
+    const format = await formats.create({
+      name: 'Test Format',
+      width: 1,
+      height: 1,
+    });
+    await tier.save();
+    await format.save();
+    tierId = tier.id;
+    formatId = format.id;
     enableTenancy(); // default rawQueryPolicy: 'throw'
   });
 
@@ -100,13 +116,13 @@ describe('ads tenant isolation (#1600)', () => {
   it('AdGroupCollection.findGlobal/findWithGlobals do not throw and stay tenant-scoped', async () => {
     const groups = await AdGroupCollection.create({ db });
     await withTenant({ tenantId: 'tenant-1' }, async () => {
-      await (await groups.create({ name: 't1-group' })).save();
+      await (await groups.create({ name: 't1-group', tierId })).save();
     });
     await withTenant({ tenantId: 'tenant-2' }, async () => {
-      await (await groups.create({ name: 't2-group' })).save();
+      await (await groups.create({ name: 't2-group', tierId })).save();
     });
     await withSystemContext(async () => {
-      await (await groups.create({ name: 'g-group' })).save();
+      await (await groups.create({ name: 'g-group', tierId })).save();
     });
 
     expect(
@@ -138,14 +154,51 @@ describe('ads tenant isolation (#1600)', () => {
 
   it('AdVariationCollection.findGlobal/findWithGlobals do not throw and stay tenant-scoped', async () => {
     const variations = await AdVariationCollection.create({ db });
+    const groups = await AdGroupCollection.create({ db });
+    const tenant1Group = await withTenant(
+      { tenantId: 'tenant-1' },
+      async () => {
+        const group = await groups.create({ name: 't1-parent', tierId });
+        return group.save();
+      },
+    );
+    const tenant2Group = await withTenant(
+      { tenantId: 'tenant-2' },
+      async () => {
+        const group = await groups.create({ name: 't2-parent', tierId });
+        return group.save();
+      },
+    );
+    const globalGroup = await withSystemContext(async () => {
+      const group = await groups.create({ name: 'global-parent', tierId });
+      return group.save();
+    });
     await withTenant({ tenantId: 'tenant-1' }, async () => {
-      await (await variations.create({ name: 't1-var' })).save();
+      await (
+        await variations.create({
+          name: 't1-var',
+          groupId: tenant1Group.id,
+          formatId,
+        })
+      ).save();
     });
     await withTenant({ tenantId: 'tenant-2' }, async () => {
-      await (await variations.create({ name: 't2-var' })).save();
+      await (
+        await variations.create({
+          name: 't2-var',
+          groupId: tenant2Group.id,
+          formatId,
+        })
+      ).save();
     });
     await withSystemContext(async () => {
-      await (await variations.create({ name: 'g-var' })).save();
+      await (
+        await variations.create({
+          name: 'g-var',
+          groupId: globalGroup.id,
+          formatId,
+        })
+      ).save();
     });
 
     expect(

--- a/packages/analytics/src/__tests__/analytics-datastream.test.ts
+++ b/packages/analytics/src/__tests__/analytics-datastream.test.ts
@@ -11,6 +11,7 @@ import {
   getAdapterDisplayName,
   getTestAdapter,
   isPostgresAvailable,
+  seedAnalyticsProperties,
 } from './helpers/index.js';
 
 // Check postgres availability at module load (top-level await)
@@ -151,8 +152,18 @@ describe.skipIf(skipTests)(
     beforeEach(async () => {
       const testDb = await createTestDb();
       cleanup = testDb.cleanup;
+      await seedAnalyticsProperties(testDb.db, [
+        'prop-123',
+        'prop-types',
+        'prop-mobile',
+        'prop-active',
+        'prop-1',
+        'prop-2',
+        'prop-test',
+        'prop-external',
+      ]);
       collection = await AnalyticsDataStreamCollection.create({
-        persistence: testDb.config,
+        db: testDb.db,
       });
     });
 

--- a/packages/analytics/src/__tests__/analytics-event.test.ts
+++ b/packages/analytics/src/__tests__/analytics-event.test.ts
@@ -11,6 +11,7 @@ import {
   getAdapterDisplayName,
   getTestAdapter,
   isPostgresAvailable,
+  seedAnalyticsProperties,
 } from './helpers/index.js';
 
 // Check postgres availability at module load (top-level await)
@@ -219,8 +220,24 @@ describe.skipIf(skipTests)(
     beforeEach(async () => {
       const testDb = await createTestDb();
       cleanup = testDb.cleanup;
+      await seedAnalyticsProperties(testDb.db, [
+        'prop-123',
+        'prop-1',
+        'prop-a',
+        'prop-b',
+        'prop-retry',
+        'prop-status',
+        'prop-stats',
+        'prop-count',
+        'prop-trend',
+        'prop-flat',
+        'prop-filter',
+        'prop-tz',
+        'prop-dst',
+        'prop-zero-baseline',
+      ]);
       collection = await AnalyticsEventCollection.create({
-        persistence: testDb.config,
+        db: testDb.db,
       });
     }, ANALYTICS_EVENT_HOOK_TIMEOUT_MS);
 

--- a/packages/analytics/src/__tests__/analytics-report.test.ts
+++ b/packages/analytics/src/__tests__/analytics-report.test.ts
@@ -11,6 +11,7 @@ import {
   getAdapterDisplayName,
   getTestAdapter,
   isPostgresAvailable,
+  seedAnalyticsProperties,
 } from './helpers/index.js';
 
 // Check postgres availability at module load (top-level await)
@@ -195,8 +196,15 @@ describe.skipIf(skipTests)(
     beforeEach(async () => {
       const testDb = await createTestDb();
       cleanup = testDb.cleanup;
+      await seedAnalyticsProperties(testDb.db, [
+        'prop-123',
+        'prop-1',
+        'prop-2',
+        'prop-status',
+        'prop-recurring',
+      ]);
       collection = await AnalyticsReportCollection.create({
-        persistence: testDb.config,
+        db: testDb.db,
       });
     });
 

--- a/packages/analytics/src/__tests__/helpers/test-db.ts
+++ b/packages/analytics/src/__tests__/helpers/test-db.ts
@@ -7,7 +7,9 @@ import { randomUUID } from 'node:crypto';
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { getTestDatabase } from '@happyvertical/smrt-core';
 import { type DatabaseInterface, getDatabase } from '@happyvertical/sql';
+import { AnalyticsPropertyCollection } from '../../collections/AnalyticsPropertyCollection.js';
 
 export type TestAdapter = 'sqlite' | 'postgres' | 'json';
 
@@ -70,6 +72,21 @@ export async function createTestDb(): Promise<{
   const config = getTestDbConfig();
   const db = await getDatabase(config);
 
+  await getTestDatabase({
+    db,
+    type: config.type,
+    classes: [
+      '@happyvertical/smrt-analytics:AnalyticsProperty',
+      '@happyvertical/smrt-analytics:AnalyticsDataStream',
+      '@happyvertical/smrt-analytics:AnalyticsEvent',
+      '@happyvertical/smrt-analytics:AnalyticsReport',
+    ],
+    // DuckDB cannot enforce the package's generated ON UPDATE CASCADE action.
+    // These adapter/query tests still prepare every table and seed real parents;
+    // physical FK enforcement remains covered by SQLite/PostgreSQL lanes.
+    omitForeignKeyConstraints: config.type === 'json',
+  });
+
   const cleanup = async () => {
     if (db && typeof (db as any).close === 'function') {
       try {
@@ -105,6 +122,22 @@ export async function createTestDb(): Promise<{
   };
 
   return { db, config, cleanup };
+}
+
+/** Seed explicit real parents for collection fixtures that exercise child rows. */
+export async function seedAnalyticsProperties(
+  db: DatabaseInterface,
+  ids: readonly string[],
+): Promise<void> {
+  const properties = await AnalyticsPropertyCollection.create({ db });
+  for (const id of ids) {
+    await properties.create({
+      id,
+      name: id,
+      displayName: id,
+      externalId: `fixture:${id}`,
+    });
+  }
 }
 
 // Cache the postgres availability check result

--- a/packages/assets/src/__tests__/asset-association.test.ts
+++ b/packages/assets/src/__tests__/asset-association.test.ts
@@ -13,8 +13,11 @@
 import { getTestDatabase } from '@happyvertical/smrt-core/testing';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import '../asset';
+import '../folder';
 import type { AssetAssociation } from '../asset-association';
 import { AssetAssociationCollection } from '../asset-associations';
+import { AssetCollection } from '../assets';
 
 describe('AssetAssociation tenant scoping', () => {
   let db: DatabaseInterface;
@@ -23,6 +26,10 @@ describe('AssetAssociation tenant scoping', () => {
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
     collection = await AssetAssociationCollection.create({ db });
+    const assets = await AssetCollection.create({ db });
+    for (const assetId of ['asset-1', 'asset-2', 'asset-3', 'asset-4']) {
+      await assets.create({ id: assetId, name: `Fixture ${assetId}` });
+    }
   });
 
   afterEach(async () => {

--- a/packages/assets/src/__tests__/asset-runtime.test.ts
+++ b/packages/assets/src/__tests__/asset-runtime.test.ts
@@ -11,6 +11,7 @@ import { join as pathJoin } from 'node:path';
 import { getTestDatabase } from '@happyvertical/smrt-core/testing';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '../folder';
 import { Asset } from '../asset';
 import { AssetAssociationCollection } from '../asset-associations';
 import { AssetCapabilitySkippedError } from '../asset-capabilities';

--- a/packages/assets/src/__tests__/asset-serving.test.ts
+++ b/packages/assets/src/__tests__/asset-serving.test.ts
@@ -11,6 +11,7 @@ import { join as pathJoin } from 'node:path';
 import { getTestDatabase } from '@happyvertical/smrt-core/testing';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import '../folder';
 import { type AssetRuntime, createAssetRuntime } from '../asset-runtime';
 import {
   AssetServeError,

--- a/packages/assets/src/__tests__/assets-collection.test.ts
+++ b/packages/assets/src/__tests__/assets-collection.test.ts
@@ -9,6 +9,7 @@ import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { Asset } from '../asset';
 import { AssetCollection } from '../assets';
+import { FolderCollection } from '../folders';
 
 describe('AssetCollection', () => {
   let db: DatabaseInterface;
@@ -107,6 +108,8 @@ describe('AssetCollection', () => {
 
     it('getByFolder / getDerivatives filter on their FK', async () => {
       const source = await seed({ name: 'source' });
+      const folders = await FolderCollection.create({ db });
+      await folders.create({ id: 'f1', name: 'Fixture folder' });
       await seed({ folderId: 'f1', name: 'inFolder' });
       await seed({ sourceAssetId: source.id, name: 'derived' });
 

--- a/packages/assets/src/__tests__/assets-tenant-isolation.test.ts
+++ b/packages/assets/src/__tests__/assets-tenant-isolation.test.ts
@@ -29,6 +29,7 @@ import {
 } from '@happyvertical/smrt-tenancy';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import '../folder';
 import { AssetCollection } from '../assets';
 
 const sorted = (rows: Array<Record<string, any>>, field: string): string[] =>

--- a/packages/chat/src/__tests__/agent-session.test.ts
+++ b/packages/chat/src/__tests__/agent-session.test.ts
@@ -5,21 +5,25 @@
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { AgentSessionCollection } from '../collections/AgentSessionCollection.js';
+import { createChatTestDatabase, seedChatRoom } from './chat-test-db.js';
 
 describe('AgentSession', () => {
   let dbPath: string;
   let sessions: AgentSessionCollection;
+  let db: DatabaseInterface;
 
   beforeEach(async () => {
     dbPath = join(tmpdir(), `smrt-agent-session-test-${Date.now()}.db`);
-    sessions = (await AgentSessionCollection.create({
-      db: { type: 'sqlite', url: dbPath },
-    })) as AgentSessionCollection;
+    db = await createChatTestDatabase(dbPath);
+    await seedChatRoom(db);
+    sessions = await AgentSessionCollection.create({ db });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await db.close?.();
     if (existsSync(dbPath)) {
       try {
         rmSync(dbPath, { force: true });

--- a/packages/chat/src/__tests__/chat-message.test.ts
+++ b/packages/chat/src/__tests__/chat-message.test.ts
@@ -5,21 +5,40 @@
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ChatMessageCollection } from '../collections/ChatMessageCollection.js';
+import {
+  createChatTestDatabase,
+  seedAgentSession,
+  seedChatMessage,
+  seedChatRoom,
+  seedChatThread,
+} from './chat-test-db.js';
 
 describe('ChatMessage', () => {
   let dbPath: string;
   let messages: ChatMessageCollection;
+  let db: DatabaseInterface;
 
   beforeEach(async () => {
     dbPath = join(tmpdir(), `smrt-chat-msg-test-${Date.now()}.db`);
-    messages = (await ChatMessageCollection.create({
-      db: { type: 'sqlite', url: dbPath },
-    })) as ChatMessageCollection;
+    db = await createChatTestDatabase(dbPath);
+    await seedChatRoom(db);
+    await seedChatRoom(db, 'room-2');
+    await seedChatRoom(db, 'room-shared');
+    await seedChatRoom(db, 'fixture-parent-room');
+    await seedChatMessage(db, 'fixture-parent-message', 'fixture-parent-room');
+    await seedChatThread(db, 'thread-1');
+    await seedChatThread(db, 'thread-2');
+    await seedChatThread(db, 'thread-shared');
+    await seedAgentSession(db, 'session-1');
+    await seedAgentSession(db, 'session-shared');
+    messages = await ChatMessageCollection.create({ db });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await db.close?.();
     if (existsSync(dbPath)) {
       try {
         rmSync(dbPath, { force: true });

--- a/packages/chat/src/__tests__/chat-participant.test.ts
+++ b/packages/chat/src/__tests__/chat-participant.test.ts
@@ -5,21 +5,32 @@
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ChatParticipantCollection } from '../collections/ChatParticipantCollection.js';
+import {
+  createChatTestDatabase,
+  seedChatMessage,
+  seedChatRoom,
+} from './chat-test-db.js';
 
 describe('ChatParticipant', () => {
   let dbPath: string;
   let participants: ChatParticipantCollection;
+  let db: DatabaseInterface;
 
   beforeEach(async () => {
     dbPath = join(tmpdir(), `smrt-chat-participant-test-${Date.now()}.db`);
-    participants = (await ChatParticipantCollection.create({
-      db: { type: 'sqlite', url: dbPath },
-    })) as ChatParticipantCollection;
+    db = await createChatTestDatabase(dbPath);
+    await seedChatRoom(db);
+    await seedChatRoom(db, 'room-2');
+    await seedChatRoom(db, 'fixture-parent-room');
+    await seedChatMessage(db, 'msg-42', 'fixture-parent-room');
+    participants = await ChatParticipantCollection.create({ db });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await db.close?.();
     if (existsSync(dbPath)) {
       try {
         rmSync(dbPath, { force: true });

--- a/packages/chat/src/__tests__/chat-reaction.test.ts
+++ b/packages/chat/src/__tests__/chat-reaction.test.ts
@@ -5,21 +5,31 @@
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ChatReactionCollection } from '../collections/ChatReactionCollection.js';
+import {
+  createChatTestDatabase,
+  seedChatMessage,
+  seedChatRoom,
+} from './chat-test-db.js';
 
 describe('ChatReaction', () => {
   let dbPath: string;
   let reactions: ChatReactionCollection;
+  let db: DatabaseInterface;
 
   beforeEach(async () => {
     dbPath = join(tmpdir(), `smrt-chat-reaction-test-${Date.now()}.db`);
-    reactions = (await ChatReactionCollection.create({
-      db: { type: 'sqlite', url: dbPath },
-    })) as ChatReactionCollection;
+    db = await createChatTestDatabase(dbPath);
+    await seedChatRoom(db);
+    await seedChatMessage(db);
+    await seedChatMessage(db, 'msg-2');
+    reactions = await ChatReactionCollection.create({ db });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await db.close?.();
     if (existsSync(dbPath)) {
       try {
         rmSync(dbPath, { force: true });

--- a/packages/chat/src/__tests__/chat-room.test.ts
+++ b/packages/chat/src/__tests__/chat-room.test.ts
@@ -5,25 +5,27 @@
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ChatParticipantCollection } from '../collections/ChatParticipantCollection.js';
 import { ChatRoomCollection } from '../collections/ChatRoomCollection.js';
+import { createChatTestDatabase } from './chat-test-db.js';
 
 describe('ChatRoom', () => {
   let dbPath: string;
   let rooms: ChatRoomCollection;
   let participants: ChatParticipantCollection;
+  let database: DatabaseInterface;
 
   beforeEach(async () => {
     dbPath = join(tmpdir(), `smrt-chat-room-test-${Date.now()}.db`);
-    const db = { type: 'sqlite' as const, url: dbPath };
-    rooms = (await ChatRoomCollection.create({ db })) as ChatRoomCollection;
-    participants = (await ChatParticipantCollection.create({
-      db,
-    })) as ChatParticipantCollection;
+    database = await createChatTestDatabase(dbPath);
+    rooms = await ChatRoomCollection.create({ db: database });
+    participants = await ChatParticipantCollection.create({ db: database });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await database.close?.();
     if (existsSync(dbPath)) {
       try {
         rmSync(dbPath, { force: true });

--- a/packages/chat/src/__tests__/chat-test-db.ts
+++ b/packages/chat/src/__tests__/chat-test-db.ts
@@ -1,0 +1,80 @@
+import { getTestDatabase } from '@happyvertical/smrt-core';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import '../index.js';
+import { AgentSessionCollection } from '../collections/AgentSessionCollection.js';
+import { ChatMessageCollection } from '../collections/ChatMessageCollection.js';
+import { ChatRoomCollection } from '../collections/ChatRoomCollection.js';
+import { ChatThreadCollection } from '../collections/ChatThreadCollection.js';
+
+const CHAT_SCHEMA_CLASSES = [
+  '@happyvertical/smrt-chat:ChatRoom',
+  '@happyvertical/smrt-chat:ChatMessage',
+  '@happyvertical/smrt-chat:ChatParticipant',
+  '@happyvertical/smrt-chat:ChatThread',
+  '@happyvertical/smrt-chat:ChatReaction',
+  '@happyvertical/smrt-chat:AgentSession',
+  '@happyvertical/smrt-chat:VoiceSession',
+];
+
+export async function createChatTestDatabase(
+  url: string,
+): Promise<DatabaseInterface> {
+  return getTestDatabase({ type: 'sqlite', url, classes: CHAT_SCHEMA_CLASSES });
+}
+
+export async function seedChatRoom(
+  db: DatabaseInterface,
+  id = 'room-1',
+): Promise<void> {
+  const rooms = await ChatRoomCollection.create({ db });
+  await rooms.create({
+    id,
+    tenantId: 'tenant-1',
+    name: `Fixture ${id}`,
+    roomType: 'public',
+    createdByProfileId: 'profile-1',
+  });
+}
+
+export async function seedChatMessage(
+  db: DatabaseInterface,
+  id = 'msg-1',
+  roomId = 'room-1',
+): Promise<void> {
+  const messages = await ChatMessageCollection.create({ db });
+  await messages.create({
+    id,
+    tenantId: 'tenant-1',
+    roomId,
+    senderProfileId: 'profile-1',
+    content: `Fixture ${id}`,
+  });
+}
+
+export async function seedChatThread(
+  db: DatabaseInterface,
+  id: string,
+  rootMessageId = 'fixture-parent-message',
+): Promise<void> {
+  const threads = await ChatThreadCollection.create({ db });
+  await threads.create({
+    id,
+    tenantId: 'tenant-1',
+    roomId: 'fixture-parent-room',
+    rootMessageId,
+  });
+}
+
+export async function seedAgentSession(
+  db: DatabaseInterface,
+  id: string,
+): Promise<void> {
+  const sessions = await AgentSessionCollection.create({ db });
+  await sessions.create({
+    id,
+    tenantId: 'tenant-1',
+    agentId: 'fixture-agent',
+    participantProfileId: 'fixture-profile',
+    chatRoomId: 'fixture-parent-room',
+  });
+}

--- a/packages/chat/src/__tests__/chat-thread.test.ts
+++ b/packages/chat/src/__tests__/chat-thread.test.ts
@@ -5,21 +5,33 @@
 import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ChatThreadCollection } from '../collections/ChatThreadCollection.js';
+import {
+  createChatTestDatabase,
+  seedChatMessage,
+  seedChatRoom,
+} from './chat-test-db.js';
 
 describe('ChatThread', () => {
   let dbPath: string;
   let threads: ChatThreadCollection;
+  let db: DatabaseInterface;
 
   beforeEach(async () => {
     dbPath = join(tmpdir(), `smrt-chat-thread-test-${Date.now()}.db`);
-    threads = (await ChatThreadCollection.create({
-      db: { type: 'sqlite', url: dbPath },
-    })) as ChatThreadCollection;
+    db = await createChatTestDatabase(dbPath);
+    await seedChatRoom(db);
+    await seedChatRoom(db, 'room-2');
+    await seedChatMessage(db);
+    await seedChatMessage(db, 'msg-2');
+    await seedChatMessage(db, 'msg-3');
+    threads = await ChatThreadCollection.create({ db });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await db.close?.();
     if (existsSync(dbPath)) {
       try {
         rmSync(dbPath, { force: true });

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -43,6 +43,18 @@ migrations are manifest-driven through registered objects and project manifests.
 
 ## `db:migrate` on PostgreSQL
 
+New tables are created in deterministic foreign-key dependency order. Mutual
+cycles are created without the cyclic clauses first, then receive named
+constraints after both tables exist. When a same-package constraint is missing
+on an existing table, `db:migrate` probes the exact child/parent columns for
+orphans before `ADD ... NOT VALID` and `VALIDATE CONSTRAINT`; orphaned data or a
+failed probe stays manual with detector/repair SQL.
+
+`db:migrate --dry-run` and deprecated `db:setup --dry-run` print the same
+engine-specific dependency plan used for execution, including exact table DDL
+and deferred PostgreSQL cycle constraints; cached per-class DDL is not a valid
+preview.
+
 `db:migrate` always bounds a PostgreSQL batch with `SET LOCAL lock_timeout` and
 `SET LOCAL statement_timeout` inside its transaction, from
 `migrations.postgres.lockTimeout` / `.statementTimeout` (defaults `30s` / `60s`;
@@ -104,6 +116,13 @@ not from the schema definition.
   `statementTimeout` settings as ordinary schema migration.
 
 ## `db:migrate` on SQLite: type changes rebuild the table
+
+SQLite can enforce generated same-package constraints on new tables, including
+cycles, but adding one to an existing table requires an explicit rebuild.
+DuckDB reports unsupported constraint shapes or `ALTER ADD CONSTRAINT` as
+manual/refused work, never as a successful no-op. Generated same-package
+constraints retain `ON UPDATE CASCADE`, which DuckDB/JSON cannot enforce, so
+those engines report an actionable refusal rather than silently stripping it.
 
 SQLite has no `ALTER COLUMN ... TYPE`, so a type-bucket change (the common one
 being a numeric default edited `0` → `0.0`) is applied as the documented table

--- a/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
@@ -274,6 +274,51 @@ describe('partitionSchemaChanges', () => {
       },
     ]);
   });
+
+  it('separates executable PostgreSQL foreign keys from manual engine repairs', () => {
+    const executable = {
+      type: 'add_foreign_key' as const,
+      table: 'children',
+      name: 'children_parent_id_parents_id_fkey',
+      sqlStatements: [
+        'ALTER TABLE "children" ADD CONSTRAINT "children_parent_id_parents_id_fkey" FOREIGN KEY ("parent_id") REFERENCES "parents" ("id") NOT VALID',
+        'ALTER TABLE "children" VALIDATE CONSTRAINT "children_parent_id_parents_id_fkey"',
+      ],
+    };
+    const manual = {
+      type: 'add_foreign_key' as const,
+      table: 'orphans',
+      name: 'orphans_parent_id_parents_id_fkey',
+      advisory: {
+        severity: 'warning' as const,
+        message: 'Repair existing orphan rows, then rerun.',
+        suggestedSql: ['SELECT parent_id FROM orphans'],
+      },
+    };
+
+    const result = partitionSchemaChanges(
+      [executable, manual],
+      (table) => `${table}:Class`,
+    );
+
+    expect(result.migrations).toEqual([
+      expect.objectContaining({
+        type: 'add_foreign_key',
+        tableName: 'children',
+        sqlStatements: executable.sqlStatements,
+      }),
+    ]);
+    expect(result.manualInterventions).toEqual([
+      expect.objectContaining({
+        type: 'add_foreign_key',
+        tableName: 'orphans',
+        advisory: manual.advisory,
+      }),
+    ]);
+    expect(getSyntheticMigrationNameForChange(executable)).toMatch(
+      /^add_foreign_key_children_[a-f0-9]{8}$/,
+    );
+  });
 });
 
 describe('shouldFailDbMigrate', () => {

--- a/packages/cli/src/commands/__tests__/db-migrate-atomic.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-atomic.test.ts
@@ -11,6 +11,7 @@ const {
   getTableNameMock,
   migrationApplyAllOptions,
   migrationAttempts,
+  planForeignKeyCreationMock,
   MockMigrationTracker,
   MockSchemaComparer,
   trackerOptions,
@@ -60,7 +61,7 @@ const {
     }
 
     async applyAll(
-      definitions: Array<{ id: string }>,
+      definitions: Array<{ id: string; up?: string[] }>,
       options: {
         atomic?: boolean;
         force?: boolean;
@@ -86,7 +87,12 @@ const {
           for (const definition of definitions) {
             migrationAttempts.push(definition.id);
 
-            if (definition.id === 'add_column_contents_second_column') {
+            if (
+              definition.id === 'add_column_contents_second_column' ||
+              definition.up?.some((sql) =>
+                sql.includes('synthetic_deferred_failure'),
+              )
+            ) {
               failedName = definition.id;
               const failed = {
                 success: false,
@@ -149,6 +155,10 @@ const {
     getTableNameMock: vi.fn(),
     migrationApplyAllOptions,
     migrationAttempts,
+    planForeignKeyCreationMock: vi.fn((schemas: unknown[]) => ({
+      schemas,
+      deferredStatements: [],
+    })),
     transactionRolledBack,
     MockMigrationTracker,
     MockSchemaComparer,
@@ -177,6 +187,12 @@ vi.mock('@happyvertical/smrt-core', () => ({
     getTableStrategy: vi.fn(() => 'cti'),
   },
   SchemaComparer: MockSchemaComparer,
+  generateDDLForEngine: vi.fn((schema: { tableName: string }) => ({
+    createTable: `CREATE TABLE "${schema.tableName}" ("id" TEXT PRIMARY KEY)`,
+    indexes: [],
+    triggers: [],
+  })),
+  planForeignKeyCreation: planForeignKeyCreationMock,
   isQualifiedName: vi.fn((value: string) => value.includes(':')),
 }));
 
@@ -205,6 +221,10 @@ describe('db:migrate atomic schema execution', () => {
     committedAppliedMigrations.length = 0;
     trackerOptions.length = 0;
     transactionRolledBack.value = false;
+    planForeignKeyCreationMock.mockImplementation((schemas: unknown[]) => ({
+      schemas,
+      deferredStatements: [],
+    }));
 
     getPackageConfigMock.mockReturnValue({
       database: {
@@ -317,6 +337,46 @@ describe('db:migrate atomic schema execution', () => {
       'add_column_contents_second_column: synthetic failure',
     );
     expect(stderr).toContain('successful steps shown above');
+  }, 15_000);
+
+  it('rolls back new tables when a deferred cycle constraint fails in the same batch', async () => {
+    compareMock.mockResolvedValue({
+      added_tables: [
+        { tableName: 'left_nodes', columns: { id: { type: 'TEXT' } } },
+        { tableName: 'right_nodes', columns: { id: { type: 'TEXT' } } },
+      ],
+      dropped_tables: [],
+      has_changes: true,
+      changes: [],
+    });
+    planForeignKeyCreationMock.mockReturnValue({
+      schemas: [
+        { tableName: 'left_nodes', columns: { id: { type: 'TEXT' } } },
+        { tableName: 'right_nodes', columns: { id: { type: 'TEXT' } } },
+      ],
+      deferredStatements: [
+        'ALTER TABLE "left_nodes" ADD CONSTRAINT "left_nodes_right_id_fkey" FOREIGN KEY ("right_id") REFERENCES "right_nodes" ("id"); -- synthetic_deferred_failure',
+      ],
+    });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { utilityCommands } = await import('../utilities.js');
+
+    await utilityCommands['db:migrate'].handler([], {});
+
+    expect(migrationAttempts.slice(0, 2)).toEqual([
+      'create_table_left_nodes',
+      'create_table_right_nodes',
+    ]);
+    expect(migrationAttempts[2]).toMatch(/^add_foreign_key_left_nodes_/);
+    expect(transactionRolledBack.value).toBe(true);
+    expect(committedAppliedMigrations).toEqual([]);
+    expect(logSpy.mock.calls.flat().join('\n')).toContain(
+      'Applying 3 schema change(s) atomically',
+    );
+    expect(errorSpy.mock.calls.flat().join('\n')).toContain(
+      'atomic schema migration failed',
+    );
   }, 15_000);
 
   it('passes an exact force target into the atomic migration batch', async () => {

--- a/packages/cli/src/commands/__tests__/utilities-handlers.test.ts
+++ b/packages/cli/src/commands/__tests__/utilities-handlers.test.ts
@@ -38,10 +38,14 @@ const h = vi.hoisted(() => {
     trackerInitialize: vi.fn(async () => {}),
     trackerGetEngine: vi.fn(() => 'sqlite'),
     trackerApplyAll: vi.fn(async () => []),
-    ensureSchema: vi.fn(async () => {}),
+    schemaManagerEnsureTables: vi.fn(async () => {}),
     generateSchema: vi.fn(async () => 'CREATE TABLE t ()'),
     schemaComparerOptions: vi.fn(),
     schemaCompare: vi.fn(async () => ({ added_tables: [], changes: [] })),
+    planForeignKeyCreation: vi.fn((schemas: unknown[]) => ({
+      schemas,
+      deferredStatements: [],
+    })),
     migratePostgresSystemTimestamps: vi.fn(async () => {}),
     planPostgresSystemTimestampMigrations: vi.fn(async () => []),
     manifestGenerate: vi.fn(async () => ({
@@ -67,10 +71,11 @@ const {
   generateSummary,
   applyFixes,
   trackerApplyAll,
-  ensureSchema,
+  schemaManagerEnsureTables,
   generateSchema,
   schemaComparerOptions,
   schemaCompare,
+  planForeignKeyCreation,
   migratePostgresSystemTimestamps,
   planPostgresSystemTimestampMigrations,
   trackerInitialize,
@@ -105,6 +110,8 @@ vi.mock('@happyvertical/smrt-core', () => ({
     indexes: [],
     triggers: [],
   })),
+  planForeignKeyCreation: (...args: unknown[]) =>
+    h.planForeignKeyCreation(...args),
   migratePostgresSystemTimestamps: (...args: unknown[]) =>
     h.migratePostgresSystemTimestamps(...args),
   planPostgresSystemTimestampMigrations: (...args: unknown[]) =>
@@ -161,8 +168,13 @@ vi.mock('@happyvertical/smrt-core/migrations', async () => {
   };
 });
 
+vi.mock('@happyvertical/smrt-core/schema', () => ({
+  createSchemaManager: vi.fn(() => ({
+    ensureTables: (...args: unknown[]) => h.schemaManagerEnsureTables(...args),
+  })),
+}));
+
 vi.mock('@happyvertical/smrt-core/schema/utils', () => ({
-  ensureSchema: (...a: unknown[]) => h.ensureSchema(...a),
   generateSchema: (...a: unknown[]) => h.generateSchema(...a),
 }));
 
@@ -225,12 +237,34 @@ describe('utility command handlers', () => {
     // defaults
     registry.getAllClasses.mockReturnValue(new Map());
     registry.getInitializationOrder.mockReturnValue([]);
-    registry.getAllSchemasAsDefinitions.mockReturnValue([]);
+    registry.getAllSchemasAsDefinitions.mockImplementation(() =>
+      Object.fromEntries(
+        registry
+          .getInitializationOrder()
+          .map((className) => registry.getTableName(className))
+          .filter((tableName): tableName is string => Boolean(tableName))
+          .map((tableName) => [
+            tableName,
+            {
+              tableName,
+              columns: {},
+              indexes: [],
+              dependencies: [],
+              foreignKeys: [],
+            },
+          ]),
+      ),
+    );
     getPackageConfig.mockReturnValue({
       database: { type: 'sqlite', url: './dev.db' },
     });
     getDatabase.mockResolvedValue({ close: vi.fn() });
     schemaCompare.mockResolvedValue({ added_tables: [], changes: [] });
+    schemaManagerEnsureTables.mockResolvedValue(undefined);
+    planForeignKeyCreation.mockImplementation((schemas: unknown[]) => ({
+      schemas,
+      deferredStatements: [],
+    }));
     planPostgresSystemTimestampMigrations.mockResolvedValue([]);
     trackerApplyAll.mockResolvedValue([]);
   });
@@ -430,7 +464,7 @@ describe('utility command handlers', () => {
       totalObjects: 1,
     });
     registry.getInitializationOrder.mockReturnValue([]);
-    registry.getAllSchemasAsDefinitions.mockReturnValue([]);
+    registry.getAllSchemasAsDefinitions.mockReturnValue({});
     // a db without getTableSchema/alterTable
     getDatabase.mockResolvedValue({ close: vi.fn() });
 
@@ -454,7 +488,7 @@ describe('utility command handlers', () => {
       name: 'Article',
       qualifiedName: '@app:Article',
     });
-    registry.getAllSchemasAsDefinitions.mockReturnValue([]);
+    registry.getAllSchemasAsDefinitions.mockReturnValue({});
     getDatabase.mockResolvedValue(migratableDb());
   }
 
@@ -574,6 +608,8 @@ describe('utility command handlers', () => {
     expect(out).toContain('Migration Preview');
     expect(out).toContain('Would create table');
     expect(out).toContain('SQL Statements');
+    expect(out).toContain('CREATE TABLE x ()');
+    expect(out).not.toContain('CREATE TABLE widgets (id TEXT)');
     // Dry-run never invokes the tracker.
     expect(trackerApplyAll).not.toHaveBeenCalled();
   });
@@ -658,7 +694,13 @@ describe('utility command handlers', () => {
     registry.getTableStrategy.mockReturnValue('cti');
     registry.getSTIBase.mockReturnValue(null);
     registry.getTableName.mockReturnValue('articles');
-    generateSchema.mockResolvedValue('CREATE TABLE articles (id TEXT)');
+    registry.getAllSchemasAsDefinitions.mockReturnValue({
+      articles: {
+        tableName: 'articles',
+        columns: { id: { type: 'TEXT' } },
+        indexes: [],
+      },
+    });
 
     await utilityCommands['db:setup'].handler([], {
       'dry-run': true,
@@ -667,7 +709,8 @@ describe('utility command handlers', () => {
 
     const out = logged();
     expect(out).toContain('SQL Preview');
-    expect(out).toContain('CREATE TABLE articles');
+    expect(out).toContain('CREATE TABLE x ()');
+    expect(generateSchema).not.toHaveBeenCalled();
     expect(out).toContain('Dry-run complete');
   });
 
@@ -689,12 +732,14 @@ describe('utility command handlers', () => {
     registry.getSTIBase.mockReturnValue(null);
     registry.getTableName.mockReturnValue('articles');
     registry.getFields.mockReturnValue(new Map([['title', {}]]));
-    ensureSchema.mockResolvedValue(undefined);
+    schemaManagerEnsureTables.mockResolvedValue(undefined);
     getDatabase.mockResolvedValue(migratableDb());
 
     await utilityCommands['db:setup'].handler([], { verbose: true });
 
-    expect(ensureSchema).toHaveBeenCalled();
+    expect(schemaManagerEnsureTables).toHaveBeenCalledWith([
+      expect.objectContaining({ tableName: 'articles' }),
+    ]);
     expect(logged()).toContain('Successfully initialized');
     expect(logged()).toContain('articles');
   });
@@ -721,6 +766,117 @@ describe('utility command handlers', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it.each([
+    'duckdb',
+    'json',
+  ])('db:setup preflights unsupported %s constraints before connecting or dropping', async (type) => {
+    getPackageConfig.mockReturnValue({
+      database: { type, url: `./test.${type}` },
+      interactive: true,
+    });
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    registry.getInitializationOrder.mockReturnValue(['Article']);
+    registry.getAllSchemasAsDefinitions.mockReturnValue({
+      Article: { tableName: 'articles', columns: {}, indexes: [] },
+    });
+    planForeignKeyCreation.mockImplementation((_schemas, engine) => {
+      throw new Error(`[DDL:${engine}] unsupported foreign key`);
+    });
+
+    await utilityCommands['db:setup'].handler([], { drop: true });
+
+    expect(planForeignKeyCreation).toHaveBeenCalledWith(
+      expect.any(Array),
+      type,
+    );
+    expect(getDatabase).not.toHaveBeenCalled();
+    expect(rlQuestion).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(errored()).toContain(`[DDL:${type}] unsupported foreign key`);
+  });
+
+  it('db:setup executes the exact preflight inputs so SchemaManager preserves deferred cycles', async () => {
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+    });
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    registry.getInitializationOrder.mockReturnValue(['Article']);
+    registry.getClass.mockReturnValue({
+      name: 'Article',
+      qualifiedName: '@app:Article',
+      constructor: class {},
+    });
+    registry.getTableStrategy.mockReturnValue('cti');
+    registry.getSTIBase.mockReturnValue(null);
+    registry.getTableName.mockReturnValue('articles');
+    const rawSchema = {
+      tableName: 'articles',
+      columns: {
+        id: { type: 'TEXT' },
+        related_id: {
+          type: 'TEXT',
+          foreignKey: { table: 'related', column: 'id' },
+        },
+      },
+      indexes: [],
+      foreignKeys: [
+        {
+          column: 'related_id',
+          referencesTable: 'related',
+          referencesColumn: 'id',
+        },
+      ],
+      dependencies: ['related'],
+    };
+    const plannedSchema = {
+      ...rawSchema,
+      columns: { id: { type: 'TEXT' }, related_id: { type: 'TEXT' } },
+      foreignKeys: [],
+    };
+    registry.getAllSchemasAsDefinitions.mockReturnValue({
+      Article: rawSchema,
+    });
+    planForeignKeyCreation.mockReturnValue({
+      schemas: [plannedSchema],
+      deferredStatements: [],
+    });
+    getDatabase.mockResolvedValue(migratableDb());
+
+    await utilityCommands['db:setup'].handler([], {});
+
+    expect(schemaManagerEnsureTables).toHaveBeenCalledWith([rawSchema]);
+    expect(logged()).toContain('Successfully initialized');
+  });
+
+  it('db:setup refuses missing structured schemas before connecting or reporting success', async () => {
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+    });
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    registry.getInitializationOrder.mockReturnValue(['LegacyArticle']);
+    registry.getTableName.mockReturnValue('legacy_articles');
+    registry.getAllSchemasAsDefinitions.mockReturnValue({});
+
+    await utilityCommands['db:setup'].handler([], {});
+
+    expect(errored()).toContain(
+      'structured schema definitions are missing for: legacy_articles',
+    );
+    expect(getDatabase).not.toHaveBeenCalled();
+    expect(schemaManagerEnsureTables).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(logged()).not.toContain('Successfully initialized');
+  });
+
   it('db:setup drops tables when --drop is confirmed interactively', async () => {
     getPackageConfig.mockReturnValue({
       database: { type: 'sqlite', url: './dev.db' },
@@ -740,20 +896,86 @@ describe('utility command handlers', () => {
     registry.getSTIBase.mockReturnValue(null);
     registry.getTableName.mockReturnValue('articles');
     registry.getFields.mockReturnValue(new Map([['title', {}]]));
-    ensureSchema.mockResolvedValue(undefined);
+    schemaManagerEnsureTables.mockResolvedValue(undefined);
     rlQuestion.mockResolvedValue('y');
-    // tagged-template execute used by the drop loop
-    const execute = vi.fn(async () => {});
-    getDatabase.mockResolvedValue(migratableDb({ execute }));
+    const query = vi.fn(async () => ({ rows: [] }));
+    getDatabase.mockResolvedValue(migratableDb({ query }));
 
     await utilityCommands['db:setup'].handler([], {
       drop: true,
       verbose: true,
     });
 
-    expect(execute).toHaveBeenCalled();
+    expect(query.mock.calls.map(([sql]) => sql)).toEqual([
+      'PRAGMA foreign_keys = OFF',
+      'DROP TABLE IF EXISTS "articles"',
+      'PRAGMA foreign_keys = ON',
+    ]);
     expect(logged()).toContain('Dropping existing tables');
     expect(logged()).toContain('Successfully initialized');
+  });
+
+  it('db:setup quotes PostgreSQL drop identifiers and uses CASCADE for cyclic constraints', async () => {
+    getPackageConfig.mockReturnValue({
+      database: { type: 'postgres', url: 'postgres://fixture/setup' },
+      interactive: true,
+    });
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    registry.getInitializationOrder.mockReturnValue(['Article']);
+    registry.getClass.mockReturnValue({
+      name: 'Article',
+      qualifiedName: '@app:Article',
+      constructor: class {},
+    });
+    registry.getTableStrategy.mockReturnValue('cti');
+    registry.getSTIBase.mockReturnValue(null);
+    registry.getTableName.mockReturnValue('Mixed"Articles');
+    registry.getFields.mockReturnValue(new Map([['title', {}]]));
+    schemaManagerEnsureTables.mockResolvedValue(undefined);
+    rlQuestion.mockResolvedValue('y');
+    const query = vi.fn(async () => ({ rows: [] }));
+    getDatabase.mockResolvedValue(migratableDb({ query }));
+
+    await utilityCommands['db:setup'].handler([], { drop: true });
+
+    expect(query).toHaveBeenCalledWith(
+      'DROP TABLE IF EXISTS "Mixed""Articles" CASCADE',
+    );
+    expect(logged()).toContain('Successfully initialized');
+  });
+
+  it('db:setup fails closed when a requested table cannot be dropped', async () => {
+    getPackageConfig.mockReturnValue({
+      database: { type: 'sqlite', url: './dev.db' },
+      interactive: true,
+    });
+    autoDiscoverAndLoad.mockResolvedValue({
+      discovered: [{ path: '/p' }],
+      totalObjects: 1,
+    });
+    registry.getInitializationOrder.mockReturnValue(['Article']);
+    registry.getTableName.mockReturnValue('articles');
+    rlQuestion.mockResolvedValue('y');
+    getDatabase.mockResolvedValue(
+      migratableDb({
+        query: vi.fn(async (sql: string) => {
+          if (sql.startsWith('DROP TABLE')) return Promise.reject('FK cycle');
+          return { rows: [] };
+        }),
+      }),
+    );
+
+    await utilityCommands['db:setup'].handler([], {
+      drop: true,
+      verbose: true,
+    });
+
+    expect(errored()).toContain('Database setup failed');
+    expect(process.exitCode).toBe(1);
+    expect(logged()).not.toContain('Successfully initialized');
   });
 
   it('db:setup aborts the drop flow when the user declines', async () => {
@@ -798,7 +1020,7 @@ describe('utility command handlers', () => {
     );
     registry.getTableName.mockReturnValue('contents');
     registry.getFields.mockReturnValue(new Map([['title', {}]]));
-    ensureSchema.mockResolvedValue(undefined);
+    schemaManagerEnsureTables.mockResolvedValue(undefined);
     getDatabase.mockResolvedValue(migratableDb());
 
     await utilityCommands['db:setup'].handler([], { verbose: true });
@@ -806,7 +1028,7 @@ describe('utility command handlers', () => {
     expect(logged()).toContain('shares table with');
   });
 
-  it('db:setup surfaces ensureSchema failures per class', async () => {
+  it('db:setup surfaces planned schema-manager failures', async () => {
     getPackageConfig.mockReturnValue({
       database: { type: 'sqlite', url: './dev.db' },
     });
@@ -823,12 +1045,15 @@ describe('utility command handlers', () => {
     registry.getTableStrategy.mockReturnValue('cti');
     registry.getSTIBase.mockReturnValue(null);
     registry.getTableName.mockReturnValue('articles');
-    ensureSchema.mockRejectedValue(new Error('ddl error'));
+    schemaManagerEnsureTables.mockRejectedValue(new Error('ddl error'));
     getDatabase.mockResolvedValue(migratableDb());
 
     await utilityCommands['db:setup'].handler([], { verbose: true });
 
     expect(errored()).toContain('ddl error');
+    expect(errored()).toContain('Database setup failed');
+    expect(process.exitCode).toBe(1);
+    expect(logged()).not.toContain('Successfully initialized');
   });
 
   // ------------------------- db:migrate (extended) ----------------------

--- a/packages/cli/src/commands/db-migrate-actions.ts
+++ b/packages/cli/src/commands/db-migrate-actions.ts
@@ -25,6 +25,7 @@ export interface MigrationAction {
     | 'add_column'
     | 'drop_column'
     | 'alter_column'
+    | 'add_foreign_key'
     | 'add_index'
     | 'drop_index'
     | 'type_mismatch'
@@ -64,6 +65,7 @@ export interface MigrationAction {
   };
   sql?: string;
   sqlStatements?: string[];
+  advisory?: SchemaChangeAdvisoryLike;
 }
 
 /**
@@ -89,6 +91,7 @@ export interface SchemaChangeLike {
     | 'drop_column'
     | 'alter_column'
     | 'orphan_column'
+    | 'add_foreign_key'
     | 'add_index'
     | 'drop_index'
     | 'orphan_index'
@@ -306,6 +309,13 @@ export function getSyntheticMigrationNameForAction(
         : `add_index_${action.index.name}`;
     }
 
+    case 'add_foreign_key': {
+      const fingerprint = sqlShapeFingerprint(action);
+      return fingerprint
+        ? `add_foreign_key_${action.tableName}_${fingerprint}`
+        : null;
+    }
+
     case 'drop_index': {
       if (!action.indexName) return null;
       const fingerprint = sqlShapeFingerprint(action);
@@ -360,6 +370,13 @@ export function getSyntheticMigrationNameForChange(
       return fingerprint
         ? `add_index_${indexName}_${fingerprint}`
         : `add_index_${indexName}`;
+    }
+
+    case 'add_foreign_key': {
+      const fingerprint = sqlShapeFingerprint(change);
+      return fingerprint
+        ? `add_foreign_key_${change.table}_${fingerprint}`
+        : null;
     }
 
     case 'drop_index': {
@@ -435,6 +452,7 @@ export function classifyFailedMigration(
     !migrationName.startsWith('add_column_') &&
     !migrationName.startsWith('drop_column_') &&
     !migrationName.startsWith('alter_column_') &&
+    !migrationName.startsWith('add_foreign_key_') &&
     !migrationName.startsWith('add_index_') &&
     !migrationName.startsWith('drop_index_') &&
     !migrationName.startsWith('type_upgrade_')
@@ -457,6 +475,7 @@ export function getUnresolvedGeneratedMigrationNames(
       change.type !== 'add_column' &&
       change.type !== 'drop_column' &&
       change.type !== 'alter_column' &&
+      change.type !== 'add_foreign_key' &&
       change.type !== 'add_index' &&
       change.type !== 'drop_index' &&
       change.type !== 'type_upgrade'
@@ -687,6 +706,25 @@ export function partitionSchemaChanges(
             ? { sqlStatements: change.sqlStatements }
             : {}),
         });
+        break;
+      }
+
+      case 'add_foreign_key': {
+        const action: MigrationAction = {
+          type: 'add_foreign_key',
+          tableName: change.table,
+          className,
+          sql: change.sql,
+          ...(change.sqlStatements
+            ? { sqlStatements: change.sqlStatements }
+            : {}),
+          advisory: change.advisory,
+        };
+        if (isAdvisoryOnlyChangeLike(change)) {
+          manualInterventions.push(action);
+        } else {
+          migrations.push(action);
+        }
         break;
       }
 

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -15,6 +15,7 @@ import {
   isQualifiedName,
   migratePostgresSystemTimestamps,
   ObjectRegistry,
+  planForeignKeyCreation,
   planPostgresSystemTimestampMigrations,
   SchemaComparer,
 } from '@happyvertical/smrt-core';
@@ -861,6 +862,33 @@ export default testManifest;
 
         // 4. Get initialization order (topological sort respecting FK dependencies)
         const initOrder = ObjectRegistry.getInitializationOrder();
+        const engine = resolveDDLPreviewEngine(dbType);
+        const schemas = Object.values(
+          ObjectRegistry.getAllSchemasAsDefinitions(),
+        );
+        const preflightTables = new Set(
+          schemas.map((schema) => schema.tableName),
+        );
+        const missingPreflightTables = [
+          ...new Set(
+            initOrder.flatMap((className) => {
+              const tableName = ObjectRegistry.getTableName(className);
+              return tableName && !preflightTables.has(tableName)
+                ? [tableName]
+                : [];
+            }),
+          ),
+        ].sort();
+        if (missingPreflightTables.length > 0) {
+          throw new Error(
+            `Cannot safely preflight database setup because structured schema definitions are missing for: ${missingPreflightTables.join(', ')}. Rebuild the package manifests before running db:setup.`,
+          );
+        }
+        // Preflight the complete graph before connecting, prompting for a
+        // destructive drop, or otherwise mutating the database. This keeps
+        // execution fail-closed on the same unsupported engine shapes that
+        // dry-run reports.
+        const plan = planForeignKeyCreation(schemas, engine);
 
         if (options.verbose) {
           console.log('📋 Initialization order (respecting dependencies):');
@@ -881,49 +909,21 @@ export default testManifest;
         if (options['dry-run']) {
           console.log('📋 SQL Preview (not executed):\n');
 
-          const { generateSchema } = await import(
-            '@happyvertical/smrt-core/schema/utils'
-          );
-
-          for (const className of initOrder) {
-            const registered = ObjectRegistry.getClass(className);
-            if (!registered) continue;
-
-            const tableStrategy = ObjectRegistry.getTableStrategy(className);
-            const stiBase = ObjectRegistry.getSTIBase(className);
-
-            // R5-canon: `getSTIBase` returns the qualified name; compare
-            // against the qualified form so an STI base isn't
-            // mis-classified as a child.
-            const qualifiedClassName =
-              registered.qualifiedName ?? registered.name ?? className;
-            const isSTIChild =
-              tableStrategy === 'sti' &&
-              !!stiBase &&
-              stiBase !== qualifiedClassName &&
-              stiBase !== className;
-            if (isSTIChild) {
-              console.log(
-                `-- Table: ${className} (Base: ${stiBase}, Strategy: STI)`,
-              );
-              console.log(`-- Shares table with ${stiBase} (STI child)\n`);
-              continue;
+          for (const schema of plan.schemas) {
+            const ddl = generateDDLForEngine(schema, engine);
+            console.log(`-- Table: ${schema.tableName}`);
+            console.log(ddl.createTable);
+            for (const statement of [...ddl.indexes, ...ddl.triggers]) {
+              console.log(statement);
             }
-
-            const schema = await generateSchema(
-              registered.constructor,
-              undefined,
-              { engine: resolveDDLPreviewEngine(dbType) },
-            );
-            if (schema && schema.trim() !== '') {
-              const tableName = ObjectRegistry.getTableName(className);
-              const strategy = tableStrategy === 'sti' ? 'STI' : 'CTI';
-              console.log(
-                `-- Table: ${tableName} (Class: ${className}, Strategy: ${strategy})`,
-              );
-              console.log(schema);
-              console.log();
+            console.log();
+          }
+          if (plan.deferredStatements.length > 0) {
+            console.log('-- Deferred foreign-key constraints');
+            for (const statement of plan.deferredStatements) {
+              console.log(statement);
             }
+            console.log();
           }
 
           console.log('✅ Dry-run complete (no changes made)\n');
@@ -975,18 +975,35 @@ export default testManifest;
 
           // Drop in reverse order (children before parents)
           const dropOrder = [...initOrder].reverse();
+          const dropEngine = resolveDDLPreviewEngine(dbType);
 
-          for (const className of dropOrder) {
-            const tableName = ObjectRegistry.getTableName(className);
-            if (!tableName) continue;
+          if (dropEngine === 'sqlite') {
+            await db.query('PRAGMA foreign_keys = OFF');
+          }
+          try {
+            for (const className of dropOrder) {
+              const tableName = ObjectRegistry.getTableName(className);
+              if (!tableName) continue;
 
-            try {
-              await db.execute`DROP TABLE IF EXISTS ${tableName}`;
-              console.log(`  ✓ Dropped ${tableName}`);
-            } catch (error) {
-              if (options.verbose) {
-                console.log(`  ⚠️  Could not drop ${tableName}: ${error}`);
+              try {
+                const cascade = dropEngine === 'postgres' ? ' CASCADE' : '';
+                await db.query(
+                  `DROP TABLE IF EXISTS ${quoteIdentifier(tableName)}${cascade}`,
+                );
+                console.log(`  ✓ Dropped ${tableName}`);
+              } catch (error) {
+                if (options.verbose) {
+                  console.log(`  ⚠️  Could not drop ${tableName}: ${error}`);
+                }
+                throw new Error(
+                  `Refusing to continue after failing to drop ${tableName}; dependency or foreign-key constraints may still be active.`,
+                  { cause: error },
+                );
               }
+            }
+          } finally {
+            if (dropEngine === 'sqlite') {
+              await db.query('PRAGMA foreign_keys = ON');
             }
           }
 
@@ -996,50 +1013,62 @@ export default testManifest;
         // 8. Create tables
         console.log('🔨 Creating tables...\n');
 
-        const { ensureSchema } = await import(
-          '@happyvertical/smrt-core/schema/utils'
+        const { createSchemaManager } = await import(
+          '@happyvertical/smrt-core/schema'
         );
+
+        const schemaManager = createSchemaManager(db, {
+          engine,
+          skipTriggers:
+            typeof (db as { exportTable?: unknown }).exportTable === 'function',
+        });
+        try {
+          // Execute the exact preflighted schema set as one dependency-aware
+          // unit. Rebuilding schemas per class after --drop could otherwise
+          // discover an unsupported shape only after destructive mutation.
+          await schemaManager.ensureTables(schemas);
+        } catch (error) {
+          console.error(`  ✗ Schema creation failed: ${error}`);
+          if (options.verbose && error instanceof Error && error.stack) {
+            console.error(`\n${error.stack}\n`);
+          }
+          throw new Error(
+            'Refusing to report database setup success after schema creation failed.',
+            { cause: error },
+          );
+        }
 
         let tablesCreated = 0;
         let tablesSkipped = 0;
 
         for (const className of initOrder) {
-          try {
-            const tableStrategy = ObjectRegistry.getTableStrategy(className);
-            const stiBase = ObjectRegistry.getSTIBase(className);
-            // R5-canon: qualified-to-qualified STI-child detection.
-            const registered = ObjectRegistry.getClass(className);
-            const qualifiedClassName =
-              registered?.qualifiedName ?? registered?.name ?? className;
+          const tableStrategy = ObjectRegistry.getTableStrategy(className);
+          const stiBase = ObjectRegistry.getSTIBase(className);
+          // R5-canon: qualified-to-qualified STI-child detection.
+          const registered = ObjectRegistry.getClass(className);
+          const qualifiedClassName =
+            registered?.qualifiedName ?? registered?.name ?? className;
 
-            // Skip STI children (schema already created by base class)
-            if (
-              tableStrategy === 'sti' &&
-              stiBase &&
-              stiBase !== qualifiedClassName &&
-              stiBase !== className
-            ) {
-              tablesSkipped++;
-              if (options.verbose) {
-                console.log(`  ⊙ ${className} (shares table with ${stiBase})`);
-              }
-              continue;
+          // Skip STI children (schema already created by base class)
+          if (
+            tableStrategy === 'sti' &&
+            stiBase &&
+            stiBase !== qualifiedClassName &&
+            stiBase !== className
+          ) {
+            tablesSkipped++;
+            if (options.verbose) {
+              console.log(`  ⊙ ${className} (shares table with ${stiBase})`);
             }
-
-            await ensureSchema(db, className);
-
-            const tableName = ObjectRegistry.getTableName(className);
-            const fields = ObjectRegistry.getFields(className);
-            const fieldCount = fields?.size || 0;
-
-            console.log(`  ✓ ${tableName} (${fieldCount} columns)`);
-            tablesCreated++;
-          } catch (error) {
-            console.error(`  ✗ ${className}: ${error}`);
-            if (options.verbose && error instanceof Error && error.stack) {
-              console.error(`\n${error.stack}\n`);
-            }
+            continue;
           }
+
+          const tableName = ObjectRegistry.getTableName(className);
+          const fields = ObjectRegistry.getFields(className);
+          const fieldCount = fields?.size || 0;
+
+          console.log(`  ✓ ${tableName} (${fieldCount} columns)`);
+          tablesCreated++;
         }
 
         // 9. Report summary
@@ -1651,6 +1680,34 @@ export default testManifest;
           postgresTimestampMigration,
         });
         const diff = await comparer.compare(manifestSchemas);
+        const engine = tracker.getEngine();
+        const tablePlan = planForeignKeyCreation(diff.added_tables, engine);
+        const plannedTableDDL = new Map(
+          tablePlan.schemas.map((schema) => [
+            schema.tableName,
+            generateDDLForEngine(schema, engine),
+          ]),
+        );
+        const deferredForeignKeyMigrations = tablePlan.deferredStatements.map(
+          (statement): MigrationAction => {
+            const parsed = statement.match(
+              /^ALTER TABLE\s+"((?:[^"]|"")+)"\s+ADD\s+CONSTRAINT\s+"((?:[^"]|"")+)"/i,
+            );
+            const unquote = (value: string | undefined, fallback: string) =>
+              value ? value.replace(/""/g, '"') : fallback;
+            const tableName = unquote(parsed?.[1], 'deferred_cycle');
+            const constraintName = unquote(
+              parsed?.[2],
+              'deferred cycle constraint',
+            );
+            return {
+              type: 'add_foreign_key',
+              tableName,
+              className: constraintName,
+              sql: statement,
+            };
+          },
+        );
 
         // Helper to get class name for a table (for reporting)
         const getClassForTable = (tableName: string): string => {
@@ -1665,15 +1722,17 @@ export default testManifest;
         // Preview new tables that don't exist yet. Actual schema changes are
         // applied below in one transaction with the generated migrations.
         if (diff.added_tables.length > 0 && isDryRun) {
-          for (const schema of diff.added_tables) {
+          for (const schema of tablePlan.schemas) {
             const className = getClassForTable(schema.tableName);
 
             const fields = Object.keys(schema.columns).length;
             console.log(
               `  📦 ${schema.tableName} (${className}): Would create table (${fields} columns)`,
             );
-            if (options.verbose && schema.ddl) {
-              console.log(`     ${schema.ddl}`);
+            if (options.verbose) {
+              console.log(
+                `     ${plannedTableDDL.get(schema.tableName)?.createTable}`,
+              );
             }
           }
 
@@ -1697,6 +1756,10 @@ export default testManifest;
             const migrationName = getSyntheticMigrationNameForAction(migration);
             return migrationName ? [migrationName] : [];
           }),
+          ...deferredForeignKeyMigrations.flatMap((migration) => {
+            const migrationName = getSyntheticMigrationNameForAction(migration);
+            return migrationName ? [migrationName] : [];
+          }),
         ]);
 
         console.log();
@@ -1707,6 +1770,15 @@ export default testManifest;
             '⚠️  Schema drift detected that requires manual intervention:\n',
           );
           for (const change of manualInterventions) {
+            if (change.type === 'add_foreign_key') {
+              console.log(
+                `   ${change.tableName}: ${change.advisory?.message ?? change.sql?.replace(/^--\s*/, '') ?? 'foreign-key constraint requires manual repair'}`,
+              );
+              for (const sql of change.advisory?.suggestedSql ?? []) {
+                console.log(`      ${sql}`);
+              }
+              continue;
+            }
             if (!change.mismatch) continue;
 
             const detail =
@@ -1784,6 +1856,9 @@ export default testManifest;
             const indexMigrations = migrations.filter(
               (m) => m.type === 'add_index',
             );
+            const foreignKeyMigrations = migrations.filter(
+              (m) => m.type === 'add_foreign_key',
+            );
             const indexDrops = migrations.filter(
               (m) => m.type === 'drop_index',
             );
@@ -1844,7 +1919,28 @@ export default testManifest;
               console.log();
             }
 
+            if (foreignKeyMigrations.length > 0) {
+              console.log(
+                `  🔗 Foreign-key constraints to add: ${foreignKeyMigrations.length}`,
+              );
+              for (const m of foreignKeyMigrations) {
+                console.log(`     ${m.tableName}`);
+              }
+              console.log();
+            }
+
             console.log('  SQL Statements:\n');
+            for (const schema of tablePlan.schemas) {
+              const ddl = plannedTableDDL.get(schema.tableName);
+              if (!ddl) continue;
+              for (const sql of [
+                ddl.createTable,
+                ...ddl.indexes,
+                ...ddl.triggers,
+              ]) {
+                console.log(`    ${sql}`);
+              }
+            }
             for (const migration of systemTimestampPreview) {
               const terminator = migration.sql.trimEnd().endsWith(';')
                 ? ''
@@ -1856,6 +1952,9 @@ export default testManifest;
               for (const sql of sqlStatements) {
                 console.log(`    ${sql};`);
               }
+            }
+            for (const sql of tablePlan.deferredStatements) {
+              console.log(`    ${sql}`);
             }
             console.log();
           }
@@ -1875,15 +1974,22 @@ export default testManifest;
         let errorCount = 0;
         let stiErrorCount = 0;
 
-        const schemaChangeCount = diff.added_tables.length + migrations.length;
+        const schemaChangeCount =
+          diff.added_tables.length +
+          migrations.length +
+          deferredForeignKeyMigrations.length;
 
         if (applySchemaMigrations && schemaChangeCount > 0) {
           const migrationDefs: MigrationDefinition[] = [];
           const migrationLogs = new Map<string, SchemaMigrationLogInfo>();
-          const engine = tracker.getEngine();
 
-          for (const schema of diff.added_tables) {
-            const ddl = generateDDLForEngine(schema, engine);
+          for (const schema of tablePlan.schemas) {
+            const ddl = plannedTableDDL.get(schema.tableName);
+            if (!ddl) {
+              throw new Error(
+                `Cannot create table ${schema.tableName}: planned DDL is unavailable.`,
+              );
+            }
             const createTableSql = ddl.createTable || schema.ddl;
             if (!createTableSql?.trim()) {
               throw new Error(
@@ -1903,6 +2009,20 @@ export default testManifest;
             });
             migrationLogs.set(migrationName, {
               successMessage: `Created table ${schema.tableName} (${fields} columns)`,
+            });
+          }
+          for (const migration of deferredForeignKeyMigrations) {
+            const migrationName = getSyntheticMigrationNameForAction(migration);
+            if (!migrationName) continue;
+            migrationDefs.push({
+              id: migrationName,
+              description: `Add deferred foreign-key constraint ${migration.className} on ${migration.tableName}`,
+              version: '1.0.0',
+              up: migration.sql ? [migration.sql] : [],
+              down: [],
+            });
+            migrationLogs.set(migrationName, {
+              successMessage: `Added deferred foreign-key constraint ${migration.className} on ${migration.tableName}`,
             });
           }
 
@@ -1939,6 +2059,9 @@ export default testManifest;
             } else if (migration.type === 'drop_index' && migration.indexName) {
               migrationSql = migration.sql || '';
               actionDesc = `Dropped index ${migration.indexName} on ${migration.tableName}`;
+            } else if (migration.type === 'add_foreign_key') {
+              migrationSql = migration.sql || '';
+              actionDesc = `Added foreign-key constraint on ${migration.tableName}`;
             } else {
               continue;
             }
@@ -1959,7 +2082,9 @@ export default testManifest;
                         ? `Upgrade column ${migration.column?.name} on ${migration.tableName} from ${migration.mismatch?.actual} to ${migration.mismatch?.expected}`
                         : migration.type === 'drop_index'
                           ? `Drop index ${migration.indexName} on ${migration.tableName}`
-                          : `Add index ${migration.index?.name} on ${migration.tableName}`,
+                          : migration.type === 'add_foreign_key'
+                            ? `Add foreign-key constraint on ${migration.tableName}`
+                            : `Add index ${migration.index?.name} on ${migration.tableName}`,
               version: '1.0.0',
               // Auto-migrations don't carry a DOWN script. Atomic execution
               // rolls back the surrounding transaction instead of relying on

--- a/packages/commerce/src/__tests__/commerce-tenant-isolation.test.ts
+++ b/packages/commerce/src/__tests__/commerce-tenant-isolation.test.ts
@@ -469,16 +469,18 @@ describe('commerce tenant isolation (#1600)', () => {
   it('PayoutCollection.findGlobal/findWithGlobals do not throw and stay tenant-scoped', async () => {
     const payments = await PaymentCollection.create({ db });
     const payouts = await PayoutCollection.create({ db });
+    const vendors = await VendorCollection.create({ db });
     // Payout.save() requires a resolvable source Payment (cap enforcement) and
     // grossAmount <= the payment's funded amount. Seed a Payment per context,
     // then a zero-amount Payout that references it.
-    const seed = async (tag: string): Promise<void> => {
+    const seed = async (tag: string, vendorId: string): Promise<void> => {
+      await (await vendors.create({ id: vendorId, name: tag })).save();
       const payment = await payments.create({ amount: 10 });
       await payment.save();
       await (
         await payouts.create({
           paymentId: payment.id ?? '',
-          vendorId: 'vendor-1',
+          vendorId,
           grossAmount: 0,
           operatorFee: 0,
           supplierNet: 0,
@@ -486,9 +488,13 @@ describe('commerce tenant isolation (#1600)', () => {
         })
       ).save();
     };
-    await withTenant({ tenantId: 'tenant-1' }, () => seed('t1-payout'));
-    await withTenant({ tenantId: 'tenant-2' }, () => seed('t2-payout'));
-    await withSystemContext(() => seed('g-payout'));
+    await withTenant({ tenantId: 'tenant-1' }, () =>
+      seed('t1-payout', 'vendor-1'),
+    );
+    await withTenant({ tenantId: 'tenant-2' }, () =>
+      seed('t2-payout', 'vendor-2'),
+    );
+    await withSystemContext(() => seed('g-payout', 'vendor-g'));
 
     expect(
       sorted(

--- a/packages/commerce/src/__tests__/foreign-key-fixtures.ts
+++ b/packages/commerce/src/__tests__/foreign-key-fixtures.ts
@@ -1,0 +1,45 @@
+import { ContractCollection } from '../collections/ContractCollection.js';
+import { CustomerCollection } from '../collections/CustomerCollection.js';
+import { VendorCollection } from '../collections/VendorCollection.js';
+
+interface CommerceForeignKeyFixtures {
+  db: { type: 'sqlite'; url: string };
+  customerIds?: string[];
+  vendorIds?: string[];
+  contractIds?: string[];
+}
+
+/** Seed only the real same-package parents referenced by a test scenario. */
+export async function seedCommerceForeignKeyFixtures({
+  db,
+  customerIds = [],
+  vendorIds = [],
+  contractIds = [],
+}: CommerceForeignKeyFixtures): Promise<void> {
+  const customers = await CustomerCollection.create({ db });
+  const vendors = await VendorCollection.create({ db });
+  const contracts = await ContractCollection.create({ db });
+  const fixtureCustomerId = '__fixture_customer__';
+  const fixtureVendorId = '__fixture_vendor__';
+
+  const requiredCustomerIds = contractIds.length
+    ? [fixtureCustomerId, ...customerIds]
+    : customerIds;
+  const requiredVendorIds = contractIds.length
+    ? [fixtureVendorId, ...vendorIds]
+    : vendorIds;
+  for (const id of new Set(requiredCustomerIds)) {
+    await customers.create({ id, name: `Fixture ${id}` });
+  }
+  for (const id of new Set(requiredVendorIds)) {
+    await vendors.create({ id, name: `Fixture ${id}` });
+  }
+  for (const id of new Set(contractIds)) {
+    await contracts.create({
+      id,
+      customerId: fixtureCustomerId,
+      vendorId: fixtureVendorId,
+      reference: `Fixture ${id}`,
+    });
+  }
+}

--- a/packages/commerce/src/__tests__/license-sale.test.ts
+++ b/packages/commerce/src/__tests__/license-sale.test.ts
@@ -22,6 +22,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ContractCollection } from '../collections/ContractCollection.js';
 import { LicenseSale } from '../models/Contract.js';
 import { ContractStatus, ContractType } from '../types/index.js';
+import { seedCommerceForeignKeyFixtures } from './foreign-key-fixtures.js';
 
 describe('LicenseSale STI subtype', () => {
   let dbPath: string;
@@ -31,6 +32,18 @@ describe('LicenseSale STI subtype', () => {
     dbPath = join(tmpdir(), `smrt-license-sale-${Date.now()}.db`);
     contracts = await ContractCollection.create({
       db: { type: 'sqlite', url: dbPath },
+    });
+    await seedCommerceForeignKeyFixtures({
+      db: { type: 'sqlite', url: dbPath },
+      customerIds: [
+        'cust-1',
+        'cust-immut',
+        'c-new-issued',
+        'c-1',
+        'c-draft',
+        'c-revoke',
+        'c-shared',
+      ],
     });
   });
 
@@ -46,6 +59,17 @@ describe('LicenseSale STI subtype', () => {
 
   it('exposes a LICENSE_SALE enum value', () => {
     expect(ContractType.LICENSE_SALE).toBe('license_sale');
+  });
+
+  it('persists omitted optional contract relationships as null', async () => {
+    const contract = await contracts.create({ reference: 'nullable-fks' });
+    await contract.save();
+
+    expect(contract.customerId).toBeNull();
+    expect(contract.vendorId).toBeNull();
+    const loaded = await contracts.get({ id: contract.id });
+    expect(loaded?.customerId).toBeNull();
+    expect(loaded?.vendorId).toBeNull();
   });
 
   it('stamps the right _meta_type and contractType', async () => {

--- a/packages/commerce/src/__tests__/payment-backend-fields.test.ts
+++ b/packages/commerce/src/__tests__/payment-backend-fields.test.ts
@@ -27,6 +27,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { PaymentCollection } from '../collections/PaymentCollection.js';
 import { PaymentMethod, PaymentStatus } from '../types/index.js';
+import { seedCommerceForeignKeyFixtures } from './foreign-key-fixtures.js';
 
 describe('Payment backend identity and USD-drift fields', () => {
   let dbPath: string;
@@ -36,6 +37,25 @@ describe('Payment backend identity and USD-drift fields', () => {
     dbPath = join(tmpdir(), `smrt-payment-backend-${Date.now()}.db`);
     payments = await PaymentCollection.create({
       db: { type: 'sqlite', url: dbPath },
+    });
+    await seedCommerceForeignKeyFixtures({
+      db: { type: 'sqlite', url: dbPath },
+      customerIds: [
+        'customer-bc-1',
+        'customer-usdc',
+        'customer-btc',
+        'customer-btc-drop',
+        'customer-fiat',
+        'customer-existing',
+      ],
+      contractIds: [
+        'contract-bc-1',
+        'contract-usdc',
+        'contract-btc',
+        'contract-btc-drop',
+        'contract-fiat',
+        'contract-existing',
+      ],
     });
   });
 
@@ -71,6 +91,17 @@ describe('Payment backend identity and USD-drift fields', () => {
     expect(loaded?.nativeCurrency).toBe('');
     expect(loaded?.usdAtQuote).toBe(0);
     expect(loaded?.usdAtConfirmation).toBe(0);
+  });
+
+  it('persists omitted optional payment relationships as null', async () => {
+    const payment = await payments.create({ amount: 100 });
+    await payment.save();
+
+    expect(payment.contractId).toBeNull();
+    expect(payment.customerId).toBeNull();
+    const loaded = await payments.get({ id: payment.id });
+    expect(loaded?.contractId).toBeNull();
+    expect(loaded?.customerId).toBeNull();
   });
 
   it('round-trips a Base-USDC stablecoin payment', async () => {

--- a/packages/commerce/src/__tests__/payment-instrument.test.ts
+++ b/packages/commerce/src/__tests__/payment-instrument.test.ts
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { PaymentInstrumentCollection } from '../collections/PaymentInstrumentCollection.js';
 import type { PaymentInstrument } from '../models/PaymentInstrument.js';
 import { PaymentInstrumentStatus } from '../types/index.js';
+import { seedCommerceForeignKeyFixtures } from './foreign-key-fixtures.js';
 
 describe('PaymentInstrument', () => {
   let dbPath: string;
@@ -27,6 +28,10 @@ describe('PaymentInstrument', () => {
     dbPath = join(tmpdir(), `smrt-payment-instrument-${Date.now()}.db`);
     instruments = await PaymentInstrumentCollection.create({
       db: { type: 'sqlite', url: dbPath },
+    });
+    await seedCommerceForeignKeyFixtures({
+      db: { type: 'sqlite', url: dbPath },
+      customerIds: ['cust-1'],
     });
   });
 

--- a/packages/commerce/src/__tests__/payment-intent.test.ts
+++ b/packages/commerce/src/__tests__/payment-intent.test.ts
@@ -27,6 +27,7 @@ import {
   type PaymentOption,
   PaymentStatus,
 } from '../types/index.js';
+import { seedCommerceForeignKeyFixtures } from './foreign-key-fixtures.js';
 
 /**
  * Create a genuinely-COMPLETED Payment row whose native amount matches the
@@ -107,6 +108,9 @@ describe('PaymentIntent', () => {
       db: { type: 'sqlite', url: dbPath },
     });
     payments = await PaymentCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+    await seedCommerceForeignKeyFixtures({
       db: { type: 'sqlite', url: dbPath },
     });
   });
@@ -419,6 +423,9 @@ describe('PaymentIntentCollection — idempotency', () => {
       db: { type: 'sqlite', url: dbPath },
     });
     payments = await PaymentCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+    await seedCommerceForeignKeyFixtures({
       db: { type: 'sqlite', url: dbPath },
     });
   });

--- a/packages/commerce/src/__tests__/payout.test.ts
+++ b/packages/commerce/src/__tests__/payout.test.ts
@@ -21,6 +21,7 @@ import { PaymentCollection } from '../collections/PaymentCollection.js';
 import { PayoutCollection } from '../collections/PayoutCollection.js';
 import type { Payout } from '../models/Payout.js';
 import { PayoutStatus } from '../types/index.js';
+import { seedCommerceForeignKeyFixtures } from './foreign-key-fixtures.js';
 
 describe('Payout', () => {
   let dbPath: string;
@@ -34,6 +35,31 @@ describe('Payout', () => {
     });
     payments = await PaymentCollection.create({
       db: { type: 'sqlite', url: dbPath },
+    });
+    await seedCommerceForeignKeyFixtures({
+      db: { type: 'sqlite', url: dbPath },
+      customerIds: ['customer-1', 'customer-tenant', 'customer-fiat'],
+      contractIds: ['contract-1', 'contract-tenant', 'contract-fiat'],
+      vendorIds: [
+        'vendor-1',
+        'vendor-tenant',
+        'vendor-fiat',
+        'vendor-x',
+        'vendor-skip',
+        'vendor-fail',
+        'vendor-reset',
+        'vendor-no-reset',
+        'vendor-bad-math',
+        'vendor-exact',
+        'vendor-off-by-one',
+        'vendor-major-units',
+        'vendor-date-strings',
+        'vendor-default',
+        'v-1',
+        'v-2',
+        'v-q',
+        'v-sum',
+      ],
     });
   });
 
@@ -397,6 +423,10 @@ describe('PayoutCollection — queries', () => {
     });
     payments = await PaymentCollection.create({
       db: { type: 'sqlite', url: dbPath },
+    });
+    await seedCommerceForeignKeyFixtures({
+      db: { type: 'sqlite', url: dbPath },
+      vendorIds: ['vendor-default', 'v-1', 'v-2', 'v-q', 'v-sum'],
     });
   });
 

--- a/packages/commerce/src/__tests__/security-audit-1390.test.ts
+++ b/packages/commerce/src/__tests__/security-audit-1390.test.ts
@@ -59,6 +59,7 @@ import {
   PaymentStatus,
   PayoutStatus,
 } from '../types/index.js';
+import { seedCommerceForeignKeyFixtures } from './foreign-key-fixtures.js';
 
 function tmpDb(tag: string): string {
   return join(
@@ -143,6 +144,9 @@ describe('Invoice save-time financial-integrity guard (#1390)', () => {
       db: { type: 'sqlite', url: dbPath },
     });
     payments = await PaymentCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+    await seedCommerceForeignKeyFixtures({
       db: { type: 'sqlite', url: dbPath },
     });
   });
@@ -445,6 +449,9 @@ describe('PaymentIntent PAID requires a verified Payment (#1390)', () => {
     payments = await PaymentCollection.create({
       db: { type: 'sqlite', url: dbPath },
     });
+    await seedCommerceForeignKeyFixtures({
+      db: { type: 'sqlite', url: dbPath },
+    });
   });
 
   afterEach(() => {
@@ -608,6 +615,9 @@ describe('PaymentAllocation integrity guard (#1390)', () => {
     payments = await PaymentCollection.create({
       db: { type: 'sqlite', url: dbPath },
     });
+    await seedCommerceForeignKeyFixtures({
+      db: { type: 'sqlite', url: dbPath },
+    });
     invoices = await InvoiceCollection.create({
       db: { type: 'sqlite', url: dbPath },
     });
@@ -705,6 +715,10 @@ describe('Payout non-negativity guard (#1390)', () => {
     });
     payments = await PaymentCollection.create({
       db: { type: 'sqlite', url: dbPath },
+    });
+    await seedCommerceForeignKeyFixtures({
+      db: { type: 'sqlite', url: dbPath },
+      vendorIds: ['vendor-neg', 'vendor-ok'],
     });
   });
 
@@ -891,6 +905,9 @@ describe('Payment COMPLETED settlement guard (#1390 round 2)', () => {
     payments = await PaymentCollection.create({
       db: { type: 'sqlite', url: dbPath },
     });
+    await seedCommerceForeignKeyFixtures({
+      db: { type: 'sqlite', url: dbPath },
+    });
   });
 
   afterEach(() => {
@@ -1005,6 +1022,9 @@ describe('PaymentIntent repoint / issued guard (#1390 round 2)', () => {
       db: { type: 'sqlite', url: dbPath },
     });
     payments = await PaymentCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+    await seedCommerceForeignKeyFixtures({
       db: { type: 'sqlite', url: dbPath },
     });
   });
@@ -1183,6 +1203,10 @@ describe('Payout state-machine + cap guard (#1390 round 2)', () => {
     });
     payments = await PaymentCollection.create({
       db: { type: 'sqlite', url: dbPath },
+    });
+    await seedCommerceForeignKeyFixtures({
+      db: { type: 'sqlite', url: dbPath },
+      vendorIds: ['vendor-skip', 'vendor-sent', 'vendor-over', 'vendor-ok'],
     });
   });
 
@@ -1538,6 +1562,10 @@ describe('Authoritative prior-status load defeats WeakMap poisoning (#1390 round
     payouts = await PayoutCollection.create({
       db: { type: 'sqlite', url: dbPath },
     });
+    await seedCommerceForeignKeyFixtures({
+      db: { type: 'sqlite', url: dbPath },
+      vendorIds: ['vendor-poison'],
+    });
   });
 
   afterEach(() => {
@@ -1634,6 +1662,10 @@ describe('Payout CONFIRMED requires txref and a SENT predecessor (#1390 round 4)
     payouts = await PayoutCollection.create({
       db: { type: 'sqlite', url: dbPath },
     });
+    await seedCommerceForeignKeyFixtures({
+      db: { type: 'sqlite', url: dbPath },
+      vendorIds: ['vendor-c', 'vendor-missing'],
+    });
   });
 
   afterEach(() => {
@@ -1727,6 +1759,9 @@ describe('Payment settled-amount freeze after COMPLETED (#1390 round 6)', () => 
   beforeEach(async () => {
     dbPath = tmpDb('payment-freeze');
     payments = await PaymentCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+    await seedCommerceForeignKeyFixtures({
       db: { type: 'sqlite', url: dbPath },
     });
   });

--- a/packages/commerce/src/__tests__/sti-extensions.test.ts
+++ b/packages/commerce/src/__tests__/sti-extensions.test.ts
@@ -17,6 +17,7 @@ import {
   WholesaleOrder,
 } from '../models/Contract.js';
 import { ContractType, CustomerType } from '../types/index.js';
+import { seedCommerceForeignKeyFixtures } from './foreign-key-fixtures.js';
 
 describe('Contract STI extensions', () => {
   let dbPath: string;
@@ -30,6 +31,11 @@ describe('Contract STI extensions', () => {
     });
     customers = await CustomerCollection.create({
       db: { type: 'sqlite', url: dbPath },
+    });
+    await seedCommerceForeignKeyFixtures({
+      db: { type: 'sqlite', url: dbPath },
+      customerIds: ['cust-guest-123', 'c1', 'c2'],
+      vendorIds: ['factory-1', 'v1'],
     });
   });
 

--- a/packages/commerce/src/models/Contract.ts
+++ b/packages/commerce/src/models/Contract.ts
@@ -117,13 +117,13 @@ export class Contract extends SmrtObject {
    * Customer ID (for sales contracts: Estimate, Order, Agreement)
    */
   @foreignKey(Customer)
-  customerId: string = '';
+  customerId: string | null = null;
 
   /**
    * Vendor ID (for purchase contracts: PurchaseOrder)
    */
   @foreignKey(Vendor)
-  vendorId: string = '';
+  vendorId: string | null = null;
 
   /**
    * Subtotal before tax, in **integer minor units** (cents, satoshis).

--- a/packages/commerce/src/models/Payment.ts
+++ b/packages/commerce/src/models/Payment.ts
@@ -145,13 +145,13 @@ export class Payment extends SmrtObject {
    * Contract this payment is for
    */
   @foreignKey('Contract')
-  contractId: string = '';
+  contractId: string | null = null;
 
   /**
    * Customer who made the payment
    */
   @foreignKey('Customer')
-  customerId: string = '';
+  customerId: string | null = null;
 
   /**
    * Payment amount, in **integer minor units** (cents, satoshis).

--- a/packages/commerce/src/types/index.ts
+++ b/packages/commerce/src/types/index.ts
@@ -386,8 +386,8 @@ export interface ContractOptions extends SmrtObjectOptions {
   tenantId?: string | null;
   contractType?: ContractType;
   status?: ContractStatus;
-  customerId?: string;
-  vendorId?: string;
+  customerId?: string | null;
+  vendorId?: string | null;
   subtotal?: number;
   taxAmount?: number;
   totalAmount?: number;
@@ -530,8 +530,8 @@ export interface FulfillmentLineItemOptions extends SmrtObjectOptions {
  */
 export interface PaymentOptions extends SmrtObjectOptions {
   tenantId?: string | null;
-  contractId?: string;
-  customerId?: string;
+  contractId?: string | null;
+  customerId?: string | null;
   amount?: number;
   currency?: string;
   method?: PaymentMethod;

--- a/packages/content/src/__tests__/content-version-kind.test.ts
+++ b/packages/content/src/__tests__/content-version-kind.test.ts
@@ -4,6 +4,8 @@ import { getTestDatabase } from '@happyvertical/smrt-core';
 import { syncSchema } from '@happyvertical/sql';
 import { describe, expect, it } from 'vitest';
 import type { ContentVersionKind } from '../content-governance';
+import '../content-feed-source';
+import { Content } from '../content';
 import { ContentVersionCollection } from '../content-versions';
 import manifest from '../manifest/manifest.json';
 import { serializeContentVersion } from '../serialization';
@@ -36,15 +38,24 @@ describe('ContentVersionKind', () => {
     const db = await getTestDatabase({
       type: 'sqlite',
       url: `file:${path.join(os.tmpdir(), `smrt-content-version-${crypto.randomUUID()}.db`)}`,
+      classes: ['ContentFeedSource', 'Content', 'ContentVersion'],
     });
     try {
       await syncSchema({ db, schema: CONTENT_VERSIONS_SCHEMA });
       const versions = await ContentVersionCollection.create({ db });
       const kind: ContentVersionKind = 'auto-generated';
+      const content = new Content({
+        db,
+        name: 'generated-version-parent',
+        title: 'Generated version parent',
+        status: 'draft',
+      });
+      await content.initialize();
+      await content.save();
 
       const created = await versions.create({
         slug: 'generated-version-v1',
-        contentId: crypto.randomUUID(),
+        contentId: content.id as string,
         version: 1,
         kind,
         summary: 'Created by planning-asset ingestion',

--- a/packages/content/src/content-contributions.test.ts
+++ b/packages/content/src/content-contributions.test.ts
@@ -650,8 +650,14 @@ describe('content contributions', () => {
     });
     await record.save();
 
+    const contributors = await ContentContributorCollection.create({ db });
+    const contributor = await contributors.findOrCreateByEmail({
+      email: 'referenced-contributor@example.com',
+      name: 'Referenced Contributor',
+      tenantId: 'tenant-1',
+    });
     const contribution = await contributions.create({
-      contributorId: 'contributor-1',
+      contributorId: contributor.id as string,
       contributionTypeKey: record.key,
       status: 'submitted',
       intakeDecision: 'accepted',

--- a/packages/content/src/content-sti.test.ts
+++ b/packages/content/src/content-sti.test.ts
@@ -11,6 +11,7 @@ import { getTestDatabase, ObjectRegistry } from '@happyvertical/smrt-core';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { Content } from './content';
+import './content-feed-source';
 import { Article, ContentDocument } from './content-types';
 
 describe('Content STI Support', () => {

--- a/packages/content/src/contents.spec.ts
+++ b/packages/content/src/contents.spec.ts
@@ -8,6 +8,7 @@ import { syncSchema } from '@happyvertical/sql';
 import { makeSlug } from '@happyvertical/utils';
 import { expect, it } from 'vitest';
 import { ContentAssetCollection } from './content-assets';
+import './content-feed-source';
 import { Contents } from './contents';
 
 const TMP_DIR = path.resolve(`${os.tmpdir()}/.have-sdk-tests/contents`);

--- a/packages/content/src/factual-content.test.ts
+++ b/packages/content/src/factual-content.test.ts
@@ -624,14 +624,29 @@ describe('Content governance', () => {
     const db: DatabaseInterface = await getTestDatabase({
       type: 'sqlite',
       url: ':memory:',
+      classes: [
+        'ContentFeedSource',
+        'Content',
+        'ContentVersion',
+        'ContentReview',
+      ],
     });
 
     try {
       await syncSchema({ db, schema: CONTENT_REVIEWS_SCHEMA });
 
       const reviews = await ContentReviewCollection.create({ db });
+      const content = new Content({
+        db,
+        name: 'content-review-parent',
+        title: 'Content review parent',
+        status: 'draft',
+        tenantId: 'tenant-1',
+      });
+      await content.initialize();
+      await content.save();
       const created = await reviews.createFromResult({
-        contentId: 'content-1',
+        contentId: content.id as string,
         kind: 'facts',
         policyKey: 'facts',
         result: {

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -214,6 +214,13 @@ agree on same-package foreign keys as well as columns and indexes:
 Natural-key references default to `CASCADE`; ordinary references default to
 immediate `NO ACTION`, matching `SmrtObject.delete()`.
 
+Same-package archival/audit identifiers that intentionally outlive their
+parent may use `@foreignKey(Target, { constraint: false })`. This explicit
+exception retains relationship loading, indexing, and application-side delete
+policy while omitting only the physical constraint and schema dependency;
+document the retention reason at the field, and keep ordinary same-package
+relationships constrained.
+
 - Change column/index emission on every shipping path, proven by the path-parity
   test `src/schema/schema-path-parity.test.ts` (#2359; index rules in the module doc). A "same as migrations" comment is a claim to check.
 - Every new query predicate ships with its index, or a reason it doesn't.

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -217,7 +217,8 @@ immediate `NO ACTION`, matching `SmrtObject.delete()`.
 Same-package archival/audit identifiers that intentionally outlive their
 parent may use `@foreignKey(Target, { constraint: false })`. This explicit
 exception retains relationship loading, indexing, and application-side delete
-policy while omitting only the physical constraint and schema dependency;
+metadata while omitting the physical constraint, schema dependency, and
+app-side cascade/preflight action so the stored identifier survives deletion;
 document the retention reason at the field, and keep ordinary same-package
 relationships constrained.
 

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -207,12 +207,27 @@ bootstrap prevents missing-table probes from poisoning that transaction.
 Production DDL comes from the **manifest** paths
 (`generateSTISchemaFromManifest`/`generateCTISchemaFromManifest`, selected in
 `src/scanner/manifest-generator.ts` → registered `schema` → `db:migrate`). The
-**registry** paths feed `getTestDatabase()` and emit foreign-key indexes
-production never gets: the suite runs on a richer schema than it ships.
+**registry** paths feed `getTestDatabase()`. Manifest and registry schemas must
+agree on same-package foreign keys as well as columns and indexes:
+`@foreignKey` emits a named physical constraint, while `@crossPackageRef` and
+`@tenantId` remain indexed runtime relationships without physical constraints.
+Natural-key references default to `CASCADE`; ordinary references default to
+immediate `NO ACTION`, matching `SmrtObject.delete()`.
 
 - Change column/index emission on every shipping path, proven by the path-parity
   test `src/schema/schema-path-parity.test.ts` (#2359; index rules in the module doc). A "same as migrations" comment is a claim to check.
 - Every new query predicate ships with its index, or a reason it doesn't.
+- Creation is dependency-planned on every entry point. PostgreSQL defers mutual
+  cycle constraints until both tables exist; SQLite keeps cycles inline;
+  DuckDB refuses unsupported cycles/actions rather than silently omitting them.
+  In particular, generated same-package constraints retain the compatibility
+  default `ON UPDATE CASCADE`; DuckDB/JSON cannot enforce that action and must
+  return an actionable refusal instead of stripping the clause.
+  PostgreSQL deferred adds are idempotent and probe the exact child/parent
+  columns for orphans before `NOT VALID` + validation. Rollback drops children
+  before parents, removes deferred PostgreSQL cycle constraints first, and
+  defers SQLite checks while dropping populated cycles. Schema aggregation that
+  deliberately filters a parent also removes the retained child's physical FK.
 - Numeric types, uuid casts, conflict targets, timestamps, migrations: run the
   `test:postgres` lane — SQLite affinity accepts what PostgreSQL rejects.
 - Read `dist/manifest.json`/regenerated schemas for what a decorator produced;

--- a/packages/core/agents/schema-paths.md
+++ b/packages/core/agents/schema-paths.md
@@ -648,30 +648,26 @@ upsert conflict target. When reading a PostgreSQL catalog array, cast it
 the array OID returns the raw `{a,b}` literal, and reading that as "no columns"
 silently inverts an index-existence decision.
 
-## Referential integrity lives in `delete()`, not in the DDL
+## Same-package referential integrity uses two matching rails
 
-No schema path emits a `FOREIGN KEY` clause on any engine — grep `schema/ddl/*`,
-`schema-manager.ts` and `differ.ts` for `REFERENCES` and you get nothing. That is
-a deliberate position, not an oversight: emitting constraints changes delete
-semantics for every consumer, requires topological table ordering in both
-migrate paths (neither orders today), and needs a plan for the orphans already in
-production databases. Emitting them is tracked separately.
-
-What `@foreignKey(..., { onDelete })` therefore means is *application* behaviour,
-applied by `SmrtObject.delete()` through `src/cascade.ts` (#2371):
+`@foreignKey(Target)` emits a physical database constraint when the target is
+in the same package and applies the same action through `SmrtObject.delete()`
+in `src/cascade.ts`. A shared delete-action resolver keeps both paths aligned;
+the established generated `ON UPDATE CASCADE` default remains unchanged:
 
 | Reference | Default when `onDelete` is absent |
 |---|---|
 | Column is part of the referencing class's `conflictColumns`, and is not a `@tenantId()` field | `CASCADE` |
 | Polymorphic `(metaType, metaId)` association row | `CASCADE` |
-| Anything else, including every `@tenantId()` field | `NO ACTION` — the row is left alone |
+| Ordinary same-package reference | `NO ACTION` — deletion is refused while references remain |
+| Every `@tenantId()` field | Excluded from physical constraints and delete cascades |
 
 The natural-key rule is what cleans junction rows up without any per-package
 annotation: a junction declares
 `@smrt({ conflictColumns: ['content_id', 'asset_id', 'relationship'] })`, so the
 row is *identified* by the content and cannot outlive it. An ordinary child
-(`Order.customerId`) is keyed by `(slug, context)` and keeps its pre-#2371
-behaviour unless it opts in explicitly.
+(`Order.customerId`) is keyed by `(slug, context)` and therefore defaults to
+immediate `NO ACTION` unless it opts in explicitly.
 
 **`@tenantId()` is excluded even though it lands in `conflictColumns`.**
 #2360 leads every tenant-scoped class's *default* natural key with the
@@ -682,8 +678,26 @@ tenant column scopes ownership; it does not identify the row the way a
 junction's foreign key does. Detected via the `__tenancy.isTenantIdField`
 marker on `FieldMeta` (`smrt-core` reads it structurally so it never depends
 on `smrt-tenancy`). `@tenantId()` exposes no `onDelete` option today, so
-this cannot currently be overridden per field — found in review before this
-landed (originally reachable, untested, and undocumented).
+this cannot currently be overridden per field.
+
+`@crossPackageRef()` remains runtime-only: it registers relationship loading
+and indexes but deliberately emits no physical constraint, avoiding circular
+package DDL. Tenant markers follow the same non-constraint rule because a
+tenant is a scope, not an ownership edge.
+
+Every schema creation entry point uses the same deterministic dependency
+planner. Parents are created before children. SQLite keeps cycle constraints
+inline because it can create them safely. PostgreSQL creates mutually dependent
+tables first and adds their named constraints afterward. DuckDB refuses cycles,
+self-references, `CASCADE`, and `SET NULL` with an actionable error because its
+current ALTER/constraint support cannot enforce those shapes safely.
+
+For existing tables, PostgreSQL checks the exact child table/column against the
+exact referenced table/column before adding a constraint as `NOT VALID` and
+then validating it. If orphans exist (or the probe cannot run), migration stops
+with detector and repair SQL. SQLite requires a deliberate table rebuild;
+DuckDB reports the unsupported ALTER path. Neither engine treats an unsupported
+constraint addition as a successful no-op.
 
 Properties to keep if you touch that module:
 

--- a/packages/core/src/__tests__/child-accessors.test.ts
+++ b/packages/core/src/__tests__/child-accessors.test.ts
@@ -354,11 +354,14 @@ describe('R10: generated @oneToMany child accessors', () => {
     const leaf = new R10MultiLeaf({ name: 'Leaf', db });
     await leaf.initialize();
     await leaf.save();
+    const other = new R10MultiLeaf({ name: 'Other', db });
+    await other.initialize();
+    await other.save();
 
     // Points at the leaf via the leaf-targeting FK (exact self).
     const viaLeaf = new R10MultiChild({
       leafRef: leaf.id,
-      baseRef: 'unrelated',
+      baseRef: other.id,
       tag: 'viaLeaf',
       db,
     });
@@ -368,7 +371,7 @@ describe('R10: generated @oneToMany child accessors', () => {
     // Points at the leaf via the base-targeting FK (ancestor) — must be ignored.
     const viaBase = new R10MultiChild({
       baseRef: leaf.id,
-      leafRef: 'unrelated',
+      leafRef: other.id,
       tag: 'viaBase',
       db,
     });

--- a/packages/core/src/__tests__/collection-facets.test.ts
+++ b/packages/core/src/__tests__/collection-facets.test.ts
@@ -11,6 +11,9 @@ import { field, SmrtObject, smrt } from '../index.js';
 import { GlobalInterceptors } from '../interceptors.js';
 import { getTestDatabase } from '../testing/database.js';
 
+const FACET_TENANT_A = '00000000-0000-4000-8000-000000000001';
+const FACET_TENANT_B = '00000000-0000-4000-8000-000000000002';
+
 @smrt({
   tenantScoped: { mode: 'optional', autoPopulate: false },
 })
@@ -55,25 +58,25 @@ describe('SmrtCollection database-backed facets and counts (#1904)', () => {
       status: 'open',
       workMode: 'remote',
       skills: ['typescript', 'sql'],
-      tenantId: 'tenant-a',
+      tenantId: FACET_TENANT_A,
     });
     await opportunities.create({
       status: 'open',
       workMode: 'hybrid',
       skills: ['typescript'],
-      tenantId: 'tenant-a',
+      tenantId: FACET_TENANT_A,
     });
     await opportunities.create({
       status: 'closed',
       workMode: 'remote',
       skills: ['sql'],
-      tenantId: 'tenant-b',
+      tenantId: FACET_TENANT_B,
     });
     await opportunities.create({
       status: null,
       workMode: null,
       skills: null,
-      tenantId: 'tenant-a',
+      tenantId: FACET_TENANT_A,
     });
   }
 
@@ -118,7 +121,7 @@ describe('SmrtCollection database-backed facets and counts (#1904)', () => {
       status: '',
       workMode: 'remote',
       skills: null,
-      tenantId: 'tenant-a',
+      tenantId: FACET_TENANT_A,
     });
 
     const queries: Array<{ sql: string; params: unknown[] }> = [];
@@ -201,7 +204,7 @@ describe('SmrtCollection database-backed facets and counts (#1904)', () => {
       beforeList(_className, options) {
         return {
           ...options,
-          where: { ...options.where, tenantId: 'tenant-a' },
+          where: { ...options.where, tenantId: FACET_TENANT_A },
         };
       },
     });
@@ -279,19 +282,19 @@ describe('SmrtCollection database-backed facets and counts (#1904)', () => {
         status: 'open',
         workMode: 'remote',
         skills: null,
-        tenantId: 'tenant-a',
+        tenantId: FACET_TENANT_A,
       });
       await portable.create({
         status: 'closed',
         workMode: 'remote',
         skills: null,
-        tenantId: 'tenant-a',
+        tenantId: FACET_TENANT_A,
       });
       await portable.create({
         status: null,
         workMode: 'remote',
         skills: null,
-        tenantId: 'tenant-a',
+        tenantId: FACET_TENANT_A,
       });
 
       await expect(portable.facets({ fields: ['status'] })).resolves.toEqual([

--- a/packages/core/src/__tests__/collection-latest-related.test.ts
+++ b/packages/core/src/__tests__/collection-latest-related.test.ts
@@ -542,6 +542,9 @@ describe('SmrtCollection.listWithLatestRelated()', () => {
     const duckDb = await getTestDatabase({
       type: 'duckdb',
       url: ':memory:',
+      // Window-query parity is the subject; DuckDB cannot enforce SMRT's
+      // generated ON UPDATE CASCADE FK action (#2413).
+      omitForeignKeyConstraints: true,
     });
     try {
       const duckParents = await LatestRelatedParentCollection.create({
@@ -594,6 +597,9 @@ describe('SmrtCollection.listWithLatestRelated()', () => {
       type: 'json',
       url: jsonPath,
       classes: ['LatestRelatedParent', 'LatestRelatedEvaluation'],
+      // Window-query parity is the subject; JSON-on-DuckDB has the same FK
+      // action limitation as native DuckDB (#2413).
+      omitForeignKeyConstraints: true,
     });
     try {
       const jsonParents = await LatestRelatedParentCollection.create({

--- a/packages/core/src/__tests__/collection-latest-related.test.ts
+++ b/packages/core/src/__tests__/collection-latest-related.test.ts
@@ -21,7 +21,9 @@ function resetInitializationEvidence(): void {
   initializationOrder = [];
 }
 
-@smrt()
+// Window-query parity is the subject of the DuckDB lane below. Use text keys
+// so native DuckDB UUID result decoding remains outside this fixture.
+@smrt({ idType: 'text' })
 class LatestRelatedParent extends SmrtObject {
   name = '';
 
@@ -51,7 +53,7 @@ class LatestRelatedParent extends SmrtObject {
   }
 }
 
-@smrt()
+@smrt({ idType: 'text' })
 class LatestRelatedEvaluation extends SmrtObject {
   @foreignKey(LatestRelatedParent)
   parentId = '';

--- a/packages/core/src/__tests__/collection-select.test.ts
+++ b/packages/core/src/__tests__/collection-select.test.ts
@@ -15,7 +15,9 @@ type Equal<Left, Right> =
     ? true
     : false;
 
-@smrt()
+// Projection SQL is the subject of this cross-adapter fixture. Keep its keys
+// text-shaped so native DuckDB UUID result decoding is not part of the lane.
+@smrt({ idType: 'text' })
 class ProjectionAccount extends SmrtObject {
   name: string = '';
 }
@@ -24,7 +26,7 @@ class ProjectionAccountCollection extends SmrtCollection<ProjectionAccount> {
   static readonly _itemClass = ProjectionAccount;
 }
 
-@smrt()
+@smrt({ idType: 'text' })
 class ProjectionOpportunity extends SmrtObject {
   title: string = '';
   status: string = '';

--- a/packages/core/src/__tests__/collection-select.test.ts
+++ b/packages/core/src/__tests__/collection-select.test.ts
@@ -138,6 +138,10 @@ describe('SmrtCollection.list({ select })', () => {
           type: adapterConfig.type,
           url: dbUrl,
           classes: ['ProjectionAccount', 'ProjectionOpportunity'],
+          // Projection behavior is the subject here. DuckDB cannot enforce
+          // SMRT's generated ON UPDATE CASCADE FK action (#2413).
+          omitForeignKeyConstraints:
+            adapterConfig.type === 'duckdb' || adapterConfig.type === 'json',
         });
         accounts = await ProjectionAccountCollection.create({ db });
         opportunities = await ProjectionOpportunityCollection.create({ db });

--- a/packages/core/src/__tests__/issue-1333-migration-circular-fk.test.ts
+++ b/packages/core/src/__tests__/issue-1333-migration-circular-fk.test.ts
@@ -3,11 +3,10 @@
  *
  * A genuine same-package foreign-key cycle (e.g. smrt-chat's
  * ChatMessage.threadId -> ChatThread and ChatThread.rootMessageId ->
- * ChatMessage) must not abort schema ordering. SMRT does not emit real DB
- * FOREIGN KEY constraints in its CREATE TABLE DDL, so a cycle has no valid
- * strict topological order — the ordering must BREAK the back-edge (standard
- * RDBMS approach: create tables first, wire cyclic references afterward)
- * instead of throwing.
+ * ChatMessage) must not abort registry ordering. A cycle has no valid strict
+ * topological order, so registry ordering breaks the back-edge and the schema
+ * planner then applies engine-specific handling (inline on SQLite, deferred on
+ * PostgreSQL, actionable refusal on DuckDB) instead of throwing here.
  *
  * Two facets are covered:
  *   1. A fresh cyclic pair must produce a usable initialization order that

--- a/packages/core/src/__tests__/issue-2371-delete-cascade-postgres.optional.test.ts
+++ b/packages/core/src/__tests__/issue-2371-delete-cascade-postgres.optional.test.ts
@@ -170,9 +170,12 @@ describe.skipIf(!pgUrl)('delete() cascade on PostgreSQL (#2371)', () => {
   });
 
   beforeEach(async () => {
-    for (const table of ALL_TABLES) {
-      await db.query(`TRUNCATE "${table}"`);
-    }
+    // PostgreSQL requires every table participating in an FK relationship to
+    // appear in the same TRUNCATE statement, even when referencing tables were
+    // already emptied by earlier statements.
+    await db.query(
+      `TRUNCATE ${ALL_TABLES.map((table) => `"${table}"`).join(', ')}`,
+    );
     docs = await PgCascadeDocCollection.create({ db });
   });
 

--- a/packages/core/src/__tests__/issue-2371-delete-cascade.test.ts
+++ b/packages/core/src/__tests__/issue-2371-delete-cascade.test.ts
@@ -1,11 +1,9 @@
 /**
  * Referential integrity on delete (#2371).
  *
- * SMRT emits no DB-level `FOREIGN KEY` constraints, so before this change
- * `delete()` removed the object's own row and left everything that pointed at
- * it behind: junction rows, polymorphic association rows, `_smrt_embeddings`
- * (which kept ranking the deleted id in `semanticSearch`) and `_smrt_contexts`.
- * `@foreignKey(..., { onDelete })` was metadata nobody read.
+ * SMRT now enforces the same same-package delete policy in generated database
+ * constraints and in `delete()`. Before #2371, `delete()` removed the object's
+ * own row and left framework-owned references behind.
  *
  * Everything here runs against real SQLite through the real model layer — the
  * point of the issue was that the framework never issued the statements, so a
@@ -115,8 +113,8 @@ class CascadeDocTagCollection extends SmrtCollection<CascadeDocTag> {
 
 /**
  * Ordinary child keyed by `(slug, context)`: `doc_id` is NOT part of the
- * natural key and declares no `onDelete`, so it keeps the pre-#2371 behaviour
- * and is left alone. Deleting a customer must not silently delete its orders.
+ * natural key and declares no `onDelete`, so it resolves to NO ACTION.
+ * Deleting a customer must be refused while orders still reference it.
  */
 @smrt({ tableName: 'cascade_2371_notes' })
 class CascadeNote extends SmrtObject {
@@ -619,7 +617,9 @@ describe('delete() referential integrity (#2371)', () => {
       await lock.save();
 
       await expect(vault.delete()).rejects.toThrow(DatabaseError);
-      await expect(vault.delete()).rejects.toThrow(/RESTRICT/);
+      await expect(vault.delete()).rejects.toThrow(
+        /declares onDelete: 'RESTRICT'/,
+      );
 
       expect(await db.count('cascade_2371_vaults', { id: vault.id })).toBe(1);
     });
@@ -644,18 +644,21 @@ describe('delete() referential integrity (#2371)', () => {
       expect(await db.count('cascade_2371_vaults')).toBe(1);
     });
 
-    it('leaves an undeclared, non-key reference untouched', async () => {
+    it('NO ACTION refuses an undeclared, non-key reference', async () => {
       const notes = await collectionOn(CascadeNoteCollection);
       const doc = await makeDoc('noted');
 
       const note = await notes.create({ docId: doc.id } as any);
       await note.save();
 
-      await doc.delete();
+      await expect(doc.delete()).rejects.toThrow(
+        /resolves to onDelete: 'NO ACTION'/,
+      );
 
       const rows = await db.list('cascade_2371_notes', {});
       expect(rows).toHaveLength(1);
       expect(rows[0]?.doc_id).toBe(doc.id);
+      expect(await db.count('cascade_2371_docs', { id: doc.id })).toBe(1);
     });
   });
 
@@ -989,13 +992,13 @@ describe('cascade plan (#2371)', () => {
     expect(normalizeOnDelete(undefined)).toBeUndefined();
   });
 
-  it('drops references that resolve to NO ACTION', () => {
+  it('records references that resolve to NO ACTION for app-side preflight', () => {
     const plan = buildCascadePlan(ObjectRegistry, 'CascadeDoc');
     expect(
       plan.references.some(
         (reference) => reference.className === 'CascadeNote',
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('records the declared actions it will apply', () => {

--- a/packages/core/src/__tests__/issue-2371-delete-cascade.test.ts
+++ b/packages/core/src/__tests__/issue-2371-delete-cascade.test.ts
@@ -132,6 +132,23 @@ class CascadeNoteCollection extends SmrtCollection<CascadeNote> {
   static readonly _itemClass = CascadeNote;
 }
 
+/** Archival row whose source identifier deliberately survives parent deletion. */
+@smrt({ tableName: 'cascade_2371_audits' })
+class CascadeAudit extends SmrtObject {
+  @foreignKey('CascadeDoc', { constraint: false })
+  docId = '';
+
+  constructor(options: any = {}) {
+    super(options);
+    if (options.docId !== undefined) this.docId = options.docId;
+  }
+}
+
+@smrt()
+class CascadeAuditCollection extends SmrtCollection<CascadeAudit> {
+  static readonly _itemClass = CascadeAudit;
+}
+
 /** Explicit opt-in cascade on a child that is not part of any natural key. */
 @smrt({ tableName: 'cascade_2371_sections' })
 class CascadeSection extends SmrtObject {
@@ -578,6 +595,19 @@ describe('delete() referential integrity (#2371)', () => {
   });
 
   describe('onDelete actions', () => {
+    it('preserves app-side-only archival identifiers after parent deletion', async () => {
+      const audits = await collectionOn(CascadeAuditCollection);
+      const doc = await makeDoc('audited');
+      const audit = await audits.create({ docId: doc.id } as any);
+      await audit.save();
+
+      await doc.delete();
+
+      const rows = await audits.list();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.docId).toBe(doc.id);
+    });
+
     it('CASCADE removes children and their own children', async () => {
       const sections = await collectionOn(CascadeSectionCollection);
       const blocks = await collectionOn(CascadeBlockCollection);
@@ -999,6 +1029,15 @@ describe('cascade plan (#2371)', () => {
         (reference) => reference.className === 'CascadeNote',
       ),
     ).toBe(true);
+  });
+
+  it('omits app-side-only archival references from delete planning', () => {
+    const plan = buildCascadePlan(ObjectRegistry, 'CascadeDoc');
+    expect(
+      plan.references.some(
+        (reference) => reference.className === 'CascadeAudit',
+      ),
+    ).toBe(false);
   });
 
   it('records the declared actions it will apply', () => {

--- a/packages/core/src/__tests__/schema-aggregator-sti-merge.test.ts
+++ b/packages/core/src/__tests__/schema-aggregator-sti-merge.test.ts
@@ -22,6 +22,172 @@ describe('SchemaAggregator STI merge', () => {
     }
   });
 
+  it('plans manifest tables parent-first and defers PostgreSQL cycles (#2413)', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'schema-aggregator-fk-'));
+    tempDirs.push(tempDir);
+
+    const manifestPath = writeManifest(tempDir, 'fk.manifest.json', {
+      packageName: '@test/fk',
+      version: '1.0.0',
+      objects: {
+        Child: {
+          className: 'Child',
+          schema: {
+            tableName: 'a_children',
+            columns: {
+              id: { type: 'TEXT', primaryKey: true },
+              parent_id: {
+                type: 'TEXT',
+                foreignKey: {
+                  table: 'z_parents',
+                  column: 'id',
+                  onDelete: 'NO ACTION',
+                  onUpdate: 'CASCADE',
+                },
+              },
+            },
+            indexes: [],
+          },
+        },
+        Parent: {
+          className: 'Parent',
+          schema: {
+            tableName: 'z_parents',
+            columns: { id: { type: 'TEXT', primaryKey: true } },
+            indexes: [],
+          },
+        },
+      },
+    });
+
+    const result = new SchemaAggregator().aggregate({
+      packages: ['@test/fk'],
+      localPaths: { '@test/fk': manifestPath },
+    });
+    expect(result.sql.indexOf('-- Table: z_parents')).toBeLessThan(
+      result.sql.indexOf('-- Table: a_children'),
+    );
+
+    const minimal = new SchemaAggregator().aggregate({
+      packages: ['@test/fk'],
+      localPaths: { '@test/fk': manifestPath },
+      minimal: true,
+      minimalSkipTables: ['z_parents'],
+    });
+    expect(minimal.sql).toContain('-- Table: a_children');
+    expect(minimal.sql).not.toContain('-- Table: z_parents');
+    expect(minimal.sql).not.toContain('FOREIGN KEY');
+    expect(minimal.sql).not.toContain('REFERENCES "z_parents"');
+    const minimalChild = minimal.tables.get('a_children');
+    expect(minimalChild?.definition.foreignKeys).toEqual([]);
+    expect(minimalChild?.definition.columns.parent_id?.foreignKey).toBe(
+      undefined,
+    );
+    expect(minimalChild?.ddl).not.toContain('FOREIGN KEY');
+
+    const cyclicPath = writeManifest(tempDir, 'cycle.manifest.json', {
+      packageName: '@test/cycle',
+      version: '1.0.0',
+      objects: {
+        Left: {
+          className: 'Left',
+          schema: {
+            tableName: 'left_nodes',
+            columns: {
+              id: { type: 'TEXT', primaryKey: true },
+              right_id: {
+                type: 'TEXT',
+                foreignKey: {
+                  table: 'right_nodes',
+                  column: 'id',
+                  onDelete: 'NO ACTION',
+                  onUpdate: 'CASCADE',
+                },
+              },
+            },
+            indexes: [],
+          },
+        },
+        Right: {
+          className: 'Right',
+          schema: {
+            tableName: 'right_nodes',
+            columns: {
+              id: { type: 'TEXT', primaryKey: true },
+              left_id: {
+                type: 'TEXT',
+                foreignKey: {
+                  table: 'left_nodes',
+                  column: 'id',
+                  onDelete: 'NO ACTION',
+                  onUpdate: 'CASCADE',
+                },
+              },
+            },
+            indexes: [],
+          },
+        },
+      },
+    });
+    const cycle = new SchemaAggregator().aggregate({
+      packages: ['@test/cycle'],
+      localPaths: { '@test/cycle': cyclicPath },
+    });
+    expect(cycle.sql.match(/ALTER TABLE .* ADD CONSTRAINT/g)).toHaveLength(2);
+    expect(
+      cycle.sql
+        .slice(0, cycle.sql.indexOf('-- Deferred foreign-key constraints'))
+        .includes('FOREIGN KEY'),
+    ).toBe(false);
+  });
+
+  it('refuses minimal output when legacy cached DDL still references a filtered table', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'schema-aggregator-legacy-fk-'));
+    tempDirs.push(tempDir);
+    const manifestPath = writeManifest(tempDir, 'legacy-fk.manifest.json', {
+      packageName: '@test/legacy-fk',
+      version: '1.0.0',
+      objects: {
+        ChildBase: {
+          className: 'ChildBase',
+          schema: {
+            tableName: 'legacy_children',
+            columns: {
+              id: { type: 'TEXT', primaryKey: true },
+              parent_id: { type: 'TEXT' },
+            },
+            indexes: [],
+          },
+        },
+        ChildLegacyContributor: {
+          className: 'ChildLegacyContributor',
+          schema: {
+            tableName: 'legacy_children',
+            ddl: 'CREATE TABLE legacy_children (id TEXT PRIMARY KEY, parent_id TEXT REFERENCES "public"."legacy_parents", sibling TEXT);',
+            indexes: [],
+          },
+        },
+        Parent: {
+          className: 'Parent',
+          schema: {
+            tableName: 'legacy_parents',
+            columns: { id: { type: 'TEXT', primaryKey: true } },
+            indexes: [],
+          },
+        },
+      },
+    });
+
+    expect(() =>
+      new SchemaAggregator().aggregate({
+        packages: ['@test/legacy-fk'],
+        localPaths: { '@test/legacy-fk': manifestPath },
+        minimal: true,
+        minimalSkipTables: ['legacy_parents'],
+      }),
+    ).toThrow(/legacy cached DDL.*references filtered table/);
+  });
+
   it('merges STI child columns across package manifests for shared tables', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'schema-aggregator-sti-'));
     tempDirs.push(tempDir);

--- a/packages/core/src/__tests__/schema-aggregator-sti-merge.test.ts
+++ b/packages/core/src/__tests__/schema-aggregator-sti-merge.test.ts
@@ -139,6 +139,15 @@ describe('SchemaAggregator STI merge', () => {
         .slice(0, cycle.sql.indexOf('-- Deferred foreign-key constraints'))
         .includes('FOREIGN KEY'),
     ).toBe(false);
+    for (const table of cycle.tables.values()) {
+      expect(table.definition.foreignKeys).toEqual([]);
+      expect(
+        Object.values(table.definition.columns).every(
+          (column) => column.foreignKey === undefined,
+        ),
+      ).toBe(true);
+      expect(table.ddl).not.toContain('FOREIGN KEY');
+    }
   });
 
   it('refuses minimal output when legacy cached DDL still references a filtered table', () => {

--- a/packages/core/src/__tests__/test-database-manifest-schema.test.ts
+++ b/packages/core/src/__tests__/test-database-manifest-schema.test.ts
@@ -1,3 +1,4 @@
+import { getDatabase } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ObjectRegistry } from '../registry.js';
 import { ensureSchema } from '../schema/utils.js';
@@ -100,6 +101,22 @@ describe('getTestDatabase manifest schemas', () => {
             },
           ],
           version: 'test-version',
+        },
+      },
+      '@test/pkg',
+    );
+  }
+
+  function registerNativeUuidThing(): void {
+    ObjectRegistry.registerFromManifest(
+      '@test/pkg:NativeUuidThing',
+      {
+        className: 'NativeUuidThing',
+        fields: {},
+        methods: {},
+        decoratorConfig: {
+          tableName: 'native_uuid_things',
+          idType: 'uuid',
         },
       },
       '@test/pkg',
@@ -361,6 +378,49 @@ describe('getTestDatabase manifest schemas', () => {
           sql.includes('json_indexed_things_slug_context_idx'),
       ),
     ).toBe(false);
+  });
+
+  it('uses native UUID DDL for an explicitly requested DuckDB database', async () => {
+    registerNativeUuidThing();
+    const db = await getTestDatabase({
+      type: 'duckdb',
+      classes: ['NativeUuidThing'],
+      includeSystemTables: false,
+    });
+
+    try {
+      const result = await db.query(
+        `SELECT data_type FROM information_schema.columns WHERE table_name = 'native_uuid_things' AND column_name = 'id'`,
+      );
+      expect(result.rows[0]?.data_type).toBe('UUID');
+    } finally {
+      await db.close?.();
+    }
+  });
+
+  it('infers native UUID DDL from an existing DuckDB database', async () => {
+    registerNativeUuidThing();
+    const db = await getDatabase({
+      type: 'duckdb',
+      url: ':memory:',
+      // This test exercises getTestDatabase's existing-adapter inference, so
+      // the Vitest wrapper must not prepare the table before that call.
+      __smrtSkipVitestSchemaPreparation: true,
+    } as Parameters<typeof getDatabase>[0]);
+
+    try {
+      await getTestDatabase({
+        db,
+        classes: ['NativeUuidThing'],
+        includeSystemTables: false,
+      });
+      const result = await db.query(
+        `SELECT data_type FROM information_schema.columns WHERE table_name = 'native_uuid_things' AND column_name = 'id'`,
+      );
+      expect(result.rows[0]?.data_type).toBe('UUID');
+    } finally {
+      await db.close?.();
+    }
   });
 
   it('creates registry schemas in foreign-key dependency order (#2413)', async () => {

--- a/packages/core/src/__tests__/test-database-manifest-schema.test.ts
+++ b/packages/core/src/__tests__/test-database-manifest-schema.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ObjectRegistry } from '../registry.js';
+import { ensureSchema } from '../schema/utils.js';
 import { snapshotObjectRegistryState } from '../test-utils.js';
 import { getTestDatabase } from '../testing/database.js';
 
@@ -360,6 +361,324 @@ describe('getTestDatabase manifest schemas', () => {
           sql.includes('json_indexed_things_slug_context_idx'),
       ),
     ).toBe(false);
+  });
+
+  it('creates registry schemas in foreign-key dependency order (#2413)', async () => {
+    const statements: string[] = [];
+    const db = {
+      query: async (sql: string) => {
+        statements.push(sql);
+        return { rows: [] };
+      },
+    };
+
+    ObjectRegistry.registerFromManifest(
+      '@test/fk:RegistryParent',
+      {
+        className: 'RegistryParent',
+        fields: {},
+        methods: {},
+        decoratorConfig: { tableName: 'z_registry_parents' },
+      },
+      '@test/fk',
+    );
+    ObjectRegistry.registerFromManifest(
+      '@test/fk:RegistryChild',
+      {
+        className: 'RegistryChild',
+        fields: {
+          parentId: {
+            type: 'foreignKey',
+            related: 'RegistryParent',
+          },
+        },
+        methods: {},
+        decoratorConfig: { tableName: 'a_registry_children' },
+      },
+      '@test/fk',
+    );
+
+    await getTestDatabase({
+      db: db as any,
+      classes: ['RegistryChild'],
+      includeSystemTables: false,
+    });
+
+    const parentCreate = statements.findIndex((sql) =>
+      sql.startsWith('CREATE TABLE IF NOT EXISTS "z_registry_parents"'),
+    );
+    const childCreate = statements.findIndex((sql) =>
+      sql.startsWith('CREATE TABLE IF NOT EXISTS "a_registry_children"'),
+    );
+    expect(parentCreate).toBeGreaterThanOrEqual(0);
+    expect(childCreate).toBeGreaterThan(parentCreate);
+    expect(statements[childCreate]).toContain(
+      'REFERENCES "z_registry_parents" ("id")',
+    );
+  });
+
+  it('fails closed when JSON-on-DuckDB cannot enforce a registry FK action (#2413)', async () => {
+    ObjectRegistry.registerFromManifest(
+      '@test/fk:DuckRegistryParent',
+      {
+        className: 'DuckRegistryParent',
+        fields: {},
+        methods: {},
+        decoratorConfig: { tableName: 'duck_registry_parents' },
+      },
+      '@test/fk',
+    );
+    ObjectRegistry.registerFromManifest(
+      '@test/fk:DuckRegistryChild',
+      {
+        className: 'DuckRegistryChild',
+        fields: {
+          parentId: {
+            type: 'foreignKey',
+            related: 'DuckRegistryParent',
+          },
+        },
+        methods: {},
+        decoratorConfig: { tableName: 'duck_registry_children' },
+      },
+      '@test/fk',
+    );
+
+    await expect(
+      getTestDatabase({
+        db: {
+          exportTable: () => undefined,
+          query: async () => ({ rows: [] }),
+        } as any,
+        classes: ['DuckRegistryChild', 'DuckRegistryParent'],
+        includeSystemTables: false,
+      }),
+    ).rejects.toThrow(/ON UPDATE CASCADE.*does not support/);
+  });
+
+  it('preserves explicit manifest FK actions in test-database DDL (#2413)', async () => {
+    ObjectRegistry.registerFromManifest(
+      '@test/fk:ActionParent',
+      {
+        className: 'ActionParent',
+        fields: {},
+        methods: {},
+        decoratorConfig: { tableName: 'action_parents' },
+        schema: {
+          tableName: 'action_parents',
+          ddl: '',
+          columns: { id: { type: 'TEXT', primaryKey: true } },
+          indexes: [],
+          triggers: [],
+          foreignKeys: [],
+          dependencies: [],
+          version: '2413',
+        },
+      },
+      '@test/fk',
+    );
+    ObjectRegistry.registerFromManifest(
+      '@test/fk:ActionChild',
+      {
+        className: 'ActionChild',
+        fields: {
+          parentId: { type: 'foreignKey', related: 'ActionParent.id' },
+        },
+        methods: {},
+        decoratorConfig: { tableName: 'action_children' },
+        schema: {
+          tableName: 'action_children',
+          ddl: '',
+          columns: {
+            id: { type: 'TEXT', primaryKey: true },
+            parent_id: {
+              type: 'TEXT',
+              foreignKey: {
+                table: 'action_parents',
+                column: 'id',
+                onDelete: 'RESTRICT',
+                onUpdate: 'NO ACTION',
+              },
+            },
+          },
+          indexes: [],
+          triggers: [],
+          foreignKeys: [],
+          dependencies: ['action_parents'],
+          version: '2413',
+        },
+      },
+      '@test/fk',
+    );
+    ObjectRegistry.registerFieldDecorator('ActionChild', 'parentId', {
+      type: 'foreignKey',
+      related: 'ActionParent.id',
+      onDelete: 'CASCADE',
+    });
+    const statements: string[] = [];
+    await getTestDatabase({
+      db: {
+        query: async (sql: string) => {
+          statements.push(sql);
+          return { rows: [] };
+        },
+      } as any,
+      classes: ['ActionChild', 'ActionParent'],
+      includeSystemTables: false,
+    });
+
+    const childDDL = statements.find((sql) =>
+      sql.startsWith('CREATE TABLE IF NOT EXISTS "action_children"'),
+    );
+    expect(childDDL).toContain('ON DELETE RESTRICT ON UPDATE NO ACTION');
+    expect(childDDL).not.toContain('ON DELETE CASCADE');
+  });
+
+  it('does not restore a physical FK excluded by the authoritative manifest (#2413)', async () => {
+    ObjectRegistry.registerFromManifest(
+      '@test/fk:RuntimeOnlyParent',
+      {
+        className: 'RuntimeOnlyParent',
+        fields: {},
+        methods: {},
+        decoratorConfig: { tableName: 'runtime_only_parents' },
+      },
+      '@test/fk',
+    );
+    ObjectRegistry.registerFromManifest(
+      '@test/fk:RuntimeOnlyChild',
+      {
+        className: 'RuntimeOnlyChild',
+        fields: {
+          parentId: {
+            type: 'foreignKey',
+            related: 'RuntimeOnlyParent.id',
+            __tenancy: { isTenantIdField: true },
+            _meta: { __tenancy: { isTenantIdField: true } },
+          },
+        },
+        methods: {},
+        decoratorConfig: { tableName: 'runtime_only_children' },
+        schema: {
+          tableName: 'runtime_only_children',
+          ddl: '',
+          columns: {
+            id: { type: 'TEXT', primaryKey: true },
+            parent_id: { type: 'TEXT' },
+          },
+          indexes: [],
+          triggers: [],
+          foreignKeys: [],
+          dependencies: [],
+          version: '2413',
+        },
+      },
+      '@test/fk',
+    );
+    const statements: string[] = [];
+    await getTestDatabase({
+      db: {
+        query: async (sql: string) => {
+          statements.push(sql);
+          return { rows: [] };
+        },
+      } as any,
+      classes: ['RuntimeOnlyChild'],
+      includeSystemTables: false,
+    });
+
+    expect(statements.join('\n')).not.toContain('FOREIGN KEY');
+    expect(statements.join('\n')).not.toContain('runtime_only_parents');
+  });
+
+  it('plans the registered dependency closure when ensureSchema starts inside a PG cycle (#2413)', async () => {
+    const registerCycle = (
+      className: string,
+      tableName: string,
+      fieldName: string,
+      targetClass: string,
+      targetTable: string,
+    ) =>
+      ObjectRegistry.registerFromManifest(
+        `@test/cycle:${className}`,
+        {
+          className,
+          fields: {
+            [fieldName]: { type: 'foreignKey', related: `${targetClass}.id` },
+          },
+          methods: {},
+          decoratorConfig: { tableName },
+          schema: {
+            tableName,
+            ddl: '',
+            columns: {
+              id: { type: 'TEXT', primaryKey: true },
+              [fieldName === 'rightId' ? 'right_id' : 'left_id']: {
+                type: 'TEXT',
+                foreignKey: {
+                  table: targetTable,
+                  column: 'id',
+                  onDelete: 'NO ACTION',
+                  onUpdate: 'CASCADE',
+                },
+              },
+            },
+            indexes: [],
+            triggers: [],
+            foreignKeys: [],
+            dependencies: [targetTable],
+            version: '2413',
+          },
+        },
+        '@test/cycle',
+      );
+    registerCycle(
+      'SetupLeft',
+      'setup_left',
+      'rightId',
+      'SetupRight',
+      'setup_right',
+    );
+    registerCycle(
+      'SetupRight',
+      'setup_right',
+      'leftId',
+      'SetupLeft',
+      'setup_left',
+    );
+
+    const tables = new Set<string>();
+    const constraints = new Set<string>();
+    const statements: string[] = [];
+    const db = {
+      url: 'postgres://localhost/test',
+      tableExists: async (name: string) => tables.has(name),
+      query: async (sql: string, params?: unknown[]) => {
+        statements.push(sql);
+        const create = sql.match(/^CREATE TABLE IF NOT EXISTS "([^"]+)"/);
+        if (create) tables.add(create[1]);
+        if (sql.includes('FROM pg_constraint')) {
+          return {
+            rows: constraints.has(String(params?.[1]))
+              ? [{ convalidated: true }]
+              : [],
+          };
+        }
+        if (sql.includes(' AS orphan_key ')) return { rows: [] };
+        const add = sql.match(/ADD CONSTRAINT "([^"]+)"/);
+        if (add) constraints.add(add[1]);
+        return { rows: [] };
+      },
+    };
+
+    await ensureSchema(db as any, 'SetupLeft');
+    expect(tables).toEqual(new Set(['setup_left', 'setup_right']));
+    expect(constraints.size).toBe(2);
+    expect(
+      statements
+        .filter((sql) => sql.startsWith('CREATE TABLE'))
+        .every((sql) => !sql.includes('FOREIGN KEY')),
+    ).toBe(true);
   });
 
   it('maps collection subclasses to their inherited STI item schema before table creation', async () => {

--- a/packages/core/src/cascade.ts
+++ b/packages/core/src/cascade.ts
@@ -1,8 +1,9 @@
 /**
  * App-side referential integrity for `SmrtObject.delete()` (#2371).
  *
- * SMRT emits **no** DB-level `FOREIGN KEY` constraints on any engine, so the
- * database will never clean up after a deleted row. Before this module,
+ * Same-package `@foreignKey` fields now emit database constraints where the
+ * engine can enforce the declared policy. Cross-package references and older
+ * schemas still rely on this application-side path. Before this module,
  * `delete()` removed the object's own row and nothing else: junction rows,
  * polymorphic association rows, `_smrt_embeddings` and `_smrt_contexts` entries
  * were all left pointing at an id that no longer resolved, and
@@ -39,14 +40,15 @@
  * |---|---|
  * | Column is part of the referencing class's `conflictColumns`, and is not a `@tenantId()` field | `CASCADE` |
  * | Polymorphic `(metaType, metaId)` association row | `CASCADE` |
- * | Anything else, including every `@tenantId()` field | `NO ACTION` (legacy behaviour — the row is left alone) |
+ * | Ordinary same-package reference | `NO ACTION` (deletion is refused while references remain) |
+ * | Every `@tenantId()` field | Excluded: tenant scope is not an ownership edge |
  *
  * The natural-key rule is what makes junction rows work without any
  * per-package annotation: a junction declares
  * `@smrt({ conflictColumns: ['content_id', 'asset_id', 'relationship'] })`, so
  * `content_id` identifies the row and the row cannot outlive the content it
  * links. An ordinary child (`Order.customerId`) is keyed by `(slug, context)`,
- * so it keeps today's behaviour unless it opts in with
+ * so it defaults to immediate `NO ACTION` unless it opts in with
  * `@foreignKey(Customer, { onDelete: 'CASCADE' })`.
  *
  * `@tenantId()` fields are excluded from the natural-key rule even though
@@ -73,6 +75,11 @@ import { ConfigurationError, DatabaseError } from './errors.js';
 // Type-only: erased at runtime, so it cannot re-enter the
 // `registry → object → cascade` import cycle.
 import type { ObjectRegistry } from './registry.js';
+import {
+  normalizeForeignKeyAction,
+  resolveForeignKeyDeleteAction,
+} from './schema/foreign-key-policy.js';
+import type { ForeignKeyAction } from './schema/types.js';
 import { chunkArray, IN_LIST_CHUNK_SIZE } from './utils/chunk.js';
 import { toSnakeCase } from './utils/naming.js';
 
@@ -81,11 +88,11 @@ const logger = createLogger({ level: 'info' });
 /**
  * Referential action applied to rows pointing at a deleted object.
  *
- * Same vocabulary as SQL's `ON DELETE`, enforced by the framework instead of
- * the engine. `NO ACTION` means "leave the rows alone" — SMRT emits no
- * constraint, so nothing raises.
+ * Same vocabulary as SQL's `ON DELETE`, enforced by the framework before the
+ * engine. `NO ACTION` is preflighted like an immediate restrictive action so
+ * application-side and database-side enforcement agree.
  */
-export type OnDeleteAction = 'CASCADE' | 'SET NULL' | 'RESTRICT' | 'NO ACTION';
+export type OnDeleteAction = ForeignKeyAction;
 
 /** Table holding framework-managed per-object memory entries. */
 const CONTEXTS_TABLE = '_smrt_contexts';
@@ -117,8 +124,8 @@ export interface CascadeReference {
   fieldName: string;
   /** Column (snake_case) holding the reference. */
   column: string;
-  /** Resolved action, never `NO ACTION` (those are dropped from the plan). */
-  action: Exclude<OnDeleteAction, 'NO ACTION'>;
+  /** Resolved action. `NO ACTION` is preflighted like an immediate RESTRICT. */
+  action: OnDeleteAction;
   /** `true` when the action was declared rather than derived from the key. */
   declared: boolean;
 }
@@ -162,13 +169,6 @@ export type CascadeRegistryView = Pick<
   | 'getDescendants'
 >;
 
-const CASCADE_ACTIONS = new Set<OnDeleteAction>([
-  'CASCADE',
-  'SET NULL',
-  'RESTRICT',
-  'NO ACTION',
-]);
-
 /**
  * Normalize a declared `onDelete` value.
  *
@@ -177,11 +177,7 @@ const CASCADE_ACTIONS = new Set<OnDeleteAction>([
  * an unset or unrecognized value so the caller can fall back to the default.
  */
 export function normalizeOnDelete(value: unknown): OnDeleteAction | undefined {
-  if (typeof value !== 'string') return undefined;
-  const normalized = value.trim().toUpperCase().replace(/_/g, ' ');
-  return CASCADE_ACTIONS.has(normalized as OnDeleteAction)
-    ? (normalized as OnDeleteAction)
-    : undefined;
+  return normalizeForeignKeyAction(value);
 }
 
 function isPolymorphicAssociationClass(fields: Map<string, unknown>): boolean {
@@ -249,8 +245,6 @@ export function buildCascadePlan(
       if (!tableName) continue;
 
       const column = toSnakeCase(relationship.fieldName);
-      const declaredAction = normalizeOnDelete(relationship.options?.onDelete);
-
       if (!conflictColumns) {
         conflictColumns = new Set(registry.getConflictColumns(sourceClass));
       }
@@ -268,14 +262,13 @@ export function buildCascadePlan(
       // is deliberate until tenant-delete cascade is an explicit decision.
       const isTenantIdField =
         relationship.options?.__tenancy?.isTenantIdField === true;
+      if (isTenantIdField) continue;
 
-      const action =
-        declaredAction ??
-        (!isTenantIdField && conflictColumns.has(column)
-          ? 'CASCADE'
-          : 'NO ACTION');
-
-      if (action === 'NO ACTION') continue;
+      const { action, declared } = resolveForeignKeyDeleteAction({
+        declared: relationship.options?.onDelete,
+        isConflictColumn: conflictColumns.has(column),
+        isTenantIdField: false,
+      });
 
       if (
         action === 'SET NULL' &&
@@ -296,7 +289,7 @@ export function buildCascadePlan(
         fieldName: relationship.fieldName,
         column,
         action,
-        declared: declaredAction !== undefined,
+        declared,
       });
     }
   }
@@ -552,9 +545,12 @@ async function resolveReferences(
 
   const plan = buildCascadePlan(ctx.registry, className);
 
-  // RESTRICT first: refuse before anything has been mutated.
+  // SQL NO ACTION is immediate on every supported SMRT migration path, so the
+  // app-side belt preflights it exactly like RESTRICT before any mutation.
   for (const reference of plan.references) {
-    if (reference.action !== 'RESTRICT') continue;
+    if (reference.action !== 'RESTRICT' && reference.action !== 'NO ACTION') {
+      continue;
+    }
     let remaining = 0;
     for (const batch of chunkArray(pending, IN_LIST_CHUNK_SIZE)) {
       remaining += await tolerateMissingTable(
@@ -564,14 +560,15 @@ async function resolveReferences(
             idPredicate(reference.column, batch),
           ),
         0,
-        { table: reference.tableName, action: 'RESTRICT check' },
+        { table: reference.tableName, action: `${reference.action} check` },
       );
       if (remaining > 0) break;
     }
     if (remaining > 0) {
       throw DatabaseError.constraintViolation(
-        `${reference.className}.${reference.fieldName} declares ` +
-          `onDelete: 'RESTRICT' and ${remaining} row(s) still reference this ` +
+        `${reference.className}.${reference.fieldName} ` +
+          `${reference.declared ? 'declares' : 'resolves to'} onDelete: ` +
+          `'${reference.action}' and ${remaining} row(s) still reference this ` +
           `${className}`,
         reference.column,
       );

--- a/packages/core/src/cascade.ts
+++ b/packages/core/src/cascade.ts
@@ -241,6 +241,17 @@ export function buildCascadePlan(
       }
       if (!targetNames.has(relationship.targetClass)) continue;
 
+      // An explicit app-side-only relationship is archival metadata, not a
+      // referential-integrity rule. Its identifier is deliberately allowed to
+      // outlive the parent, so delete planning must not block, null, or remove
+      // the retained row (#2413).
+      if (
+        relationship.type === 'foreignKey' &&
+        relationship.options?.constraint === false
+      ) {
+        continue;
+      }
+
       const tableName = registry.getTableName(sourceClass);
       if (!tableName) continue;
 

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -178,8 +178,8 @@ export interface RelationshipFieldOptions extends FieldOptions {
   /**
    * What happens to this row when the referenced object is deleted (#2371).
    *
-   * SMRT emits no DB-level `FOREIGN KEY` constraints, so this is enforced by
-   * `SmrtObject.delete()` in the application layer rather than by the engine:
+   * Same-package references emit this DB-level action and `SmrtObject.delete()`
+   * enforces the same policy in the application layer:
    *
    * - `'CASCADE'` — this row is deleted with the target.
    * - `'SET NULL'` — this column is set to `NULL`. The field must be nullable;
@@ -189,7 +189,8 @@ export interface RelationshipFieldOptions extends FieldOptions {
    *
    * When omitted, a column that is part of this class's `conflictColumns`
    * (junction and association rows, which are *identified* by the reference)
-   * defaults to `CASCADE`; every other column is left untouched on delete.
+   * defaults to `CASCADE`; every other same-package column defaults to
+   * immediate `NO ACTION`.
    * `@tenantId()` fields are the one exception: `smrt-tenancy` leads a
    * tenant-scoped class's default `conflictColumns` with the tenant column,
    * but that column scopes ownership rather than identifying the row, so it
@@ -200,7 +201,7 @@ export interface RelationshipFieldOptions extends FieldOptions {
    * hooks and interceptors do not run and no change-feed entry is written, the
    * same as a database-level `ON DELETE CASCADE`.
    */
-  onDelete?: 'CASCADE' | 'SET NULL' | 'RESTRICT';
+  onDelete?: 'CASCADE' | 'SET NULL' | 'RESTRICT' | 'NO ACTION';
 }
 
 /**
@@ -380,13 +381,11 @@ export function field(
  * or pass `include: ['fieldName']` to `collection.list()` for batch eager loading.
  *
  * Cross-package rule: Use `@foreignKey()` only for same-package references.
- * For cross-package foreign keys, use a plain `string` property instead to avoid
- * circular dependencies between packages.
+ * Use `@crossPackageRef()` for cross-package relationships.
  *
- * **No DDL constraint is emitted.** SMRT generates no `FOREIGN KEY` clause on
- * any engine — the relationship is enforced by the framework, not the database
- * (#2371). What that buys you is `loadRelated()`, eager `include:` loading, and
- * the `onDelete` behaviour applied by `SmrtObject.delete()`:
+ * A named database constraint is emitted on supported engines, and the same
+ * action is enforced by `SmrtObject.delete()` before the engine sees it. The
+ * decorator also enables `loadRelated()` and eager `include:` loading:
  *
  * ```typescript
  * @foreignKey(Order, { onDelete: 'CASCADE' })   // deleted with the order
@@ -398,7 +397,7 @@ export function field(
  *
  * Without an `onDelete`, a column that is part of this class's
  * `conflictColumns` defaults to `CASCADE` (this is what cleans up junction
- * rows); any other column is left untouched when the target is deleted.
+ * rows); any other column defaults to immediate `NO ACTION`.
  *
  * @param relatedClass - The target class constructor, its name as a string, or a
  *   `() => Target` thunk. A thunk is **invoked at decoration time**, so its
@@ -429,10 +428,11 @@ export function field(
  *   invoiceId: string = '';
  * }
  *
- * // Cross-package: use a plain string instead
+ * // Cross-package: runtime relationship, index, and loading; no physical FK
  * @smrt()
  * class Post extends SmrtObject {
- *   authorId: string = ''; // plain string — no circular dep
+ *   @crossPackageRef('@happyvertical/smrt-users:User')
+ *   authorId: string = '';
  * }
  * ```
  *
@@ -472,8 +472,8 @@ export function foreignKey(
  * Use this for relationships that point to a `SmrtObject` in a *different* package
  * (e.g. `Customer.profileId` pointing at `@happyvertical/smrt-profiles:Profile`).
  *
- * Like `@foreignKey()`, this emits **no** DDL `FOREIGN KEY` constraint — SMRT
- * does not emit them on any engine (#2371). The decorated property is a
+ * Unlike same-package `@foreignKey()`, this emits **no** DDL `FOREIGN KEY`
+ * constraint, keeping package schemas independently installable. The property is a
  * `UUID` column on PostgreSQL/DuckDB and `TEXT` on SQLite, matching the target's
  * id type; pass `{ idType: 'text' }` when the target declares
  * `@smrt({ idType: 'text' })`.
@@ -482,6 +482,8 @@ export function foreignKey(
  * - The relationship is registered with the `ObjectRegistry`, so `loadRelated()`
  *   and `Collection.list({ include })` can resolve it once the target package's
  *   manifest is loaded.
+ * - No physical database constraint is emitted; package schemas remain
+ *   independently installable.
  * - Optional save-time validation (`validate: true`) confirms the referenced
  *   object exists, catching typos and stale IDs before they hit the database.
  * - `onDelete` is honoured by `SmrtObject.delete()` when the target package's

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -202,6 +202,17 @@ export interface RelationshipFieldOptions extends FieldOptions {
    * same as a database-level `ON DELETE CASCADE`.
    */
   onDelete?: 'CASCADE' | 'SET NULL' | 'RESTRICT' | 'NO ACTION';
+  /**
+   * Set to `false` only for an app-side relationship whose target identifier
+   * must deliberately survive without a database parent row (for example an
+   * immutable audit/event record retained after its parent is pruned).
+   *
+   * The field remains a typed `foreignKey` relationship for loading, indexes,
+   * and application-side delete policy, but no physical DDL constraint or
+   * schema dependency is emitted. Ordinary same-package relationships must
+   * leave this enabled (the default).
+   */
+  constraint?: boolean;
 }
 
 /**
@@ -383,8 +394,11 @@ export function field(
  * Cross-package rule: Use `@foreignKey()` only for same-package references.
  * Use `@crossPackageRef()` for cross-package relationships.
  *
- * A named database constraint is emitted on supported engines, and the same
- * action is enforced by `SmrtObject.delete()` before the engine sees it. The
+ * A named database constraint is emitted on supported engines by default, and
+ * the same action is enforced by `SmrtObject.delete()` before the engine sees
+ * it. Exceptional archival/audit references that intentionally outlive their
+ * parent may declare `{ constraint: false }`; they retain relationship loading,
+ * indexing, and application-side policy without emitting physical DDL. The
  * decorator also enables `loadRelated()` and eager `include:` loading:
  *
  * ```typescript

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -207,10 +207,11 @@ export interface RelationshipFieldOptions extends FieldOptions {
    * must deliberately survive without a database parent row (for example an
    * immutable audit/event record retained after its parent is pruned).
    *
-   * The field remains a typed `foreignKey` relationship for loading, indexes,
-   * and application-side delete policy, but no physical DDL constraint or
-   * schema dependency is emitted. Ordinary same-package relationships must
-   * leave this enabled (the default).
+   * The field remains a typed `foreignKey` relationship for loading and
+   * indexes, but no physical DDL constraint, schema dependency, or app-side
+   * delete action is emitted. The stored identifier is deliberately preserved
+   * after the parent is deleted. Ordinary same-package relationships must leave
+   * this enabled (the default).
    */
   constraint?: boolean;
 }
@@ -397,8 +398,9 @@ export function field(
  * A named database constraint is emitted on supported engines by default, and
  * the same action is enforced by `SmrtObject.delete()` before the engine sees
  * it. Exceptional archival/audit references that intentionally outlive their
- * parent may declare `{ constraint: false }`; they retain relationship loading,
- * indexing, and application-side policy without emitting physical DDL. The
+ * parent may declare `{ constraint: false }`; they retain relationship loading
+ * and indexing while deliberately preserving the identifier after parent
+ * deletion and omitting physical DDL. The
  * decorator also enables `loadRelated()` and eager `include:` loading:
  *
  * ```typescript

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -263,6 +263,7 @@ export { smrt as smrtRegistry } from './registry';
 // Runtime utilities
 export * from './runtime/index';
 export { detectEngine, generateDDLForEngine } from './schema/ddl';
+export { planForeignKeyCreation } from './schema/foreign-key-planner';
 // Live-schema parity check (#2368) — compares a live database to the shape
 // the model layer assumes, including hand-DDL `_smrt_*` system tables.
 export {

--- a/packages/core/src/migrations/__tests__/generator-branches.test.ts
+++ b/packages/core/src/migrations/__tests__/generator-branches.test.ts
@@ -88,7 +88,7 @@ describe('MigrationGenerator branch coverage', () => {
       );
     });
 
-    it('does not emit inline FK constraints on the delegated path (orchestrator parity)', () => {
+    it('emits inline FK constraints on the delegated path (orchestrator parity)', () => {
       // The DDL strategy (and thus the delegated generateCreateTable) does not
       // emit FOREIGN KEY constraints — SMRT manages relationships via
       // cross-package refs and avoids circular DDL FKs (#1333). This matches
@@ -98,7 +98,10 @@ describe('MigrationGenerator branch coverage', () => {
         added_tables: [
           {
             tableName: 'links',
-            columns: { id: { type: 'TEXT', primaryKey: true } },
+            columns: {
+              id: { type: 'TEXT', primaryKey: true },
+              target_id: { type: 'TEXT' },
+            },
             indexes: [],
             triggers: [],
             foreignKeys: [
@@ -123,7 +126,9 @@ describe('MigrationGenerator branch coverage', () => {
 
       const up = migration.up.join('\n');
       expect(up).toContain('CREATE TABLE IF NOT EXISTS "links"');
-      expect(up).not.toContain('FOREIGN KEY');
+      expect(up).toContain(
+        'CONSTRAINT "links_target_id_targets_id_fkey" FOREIGN KEY ("target_id") REFERENCES "targets" ("id")',
+      );
     });
   });
 
@@ -337,6 +342,41 @@ describe('MigrationGenerator branch coverage', () => {
         '-- WARNING: Orphan column items.old_code (TEXT NOT NULL)',
       );
       expect(migration.down).toHaveLength(0);
+    });
+
+    it('records advisory-only foreign-key repair guidance in the migration', () => {
+      const migration = new MigrationGenerator({
+        engine: 'postgres',
+      }).generateFromDiff(
+        {
+          has_changes: true,
+          added_tables: [],
+          dropped_tables: [],
+          changes: [
+            {
+              type: 'add_foreign_key',
+              table: 'children',
+              name: 'children_parent_id_parents_id_fkey',
+              advisory: {
+                severity: 'warning',
+                message: 'Existing orphan rows block this constraint.',
+                suggestedSql: [
+                  'SELECT parent_id FROM children WHERE parent_id IS NOT NULL',
+                ],
+              },
+            },
+          ],
+        },
+        { name: '0003_foreign_key_advisory' },
+      );
+
+      expect(migration.up.join('\n')).toContain(
+        '-- WARNING: Foreign-key constraint children.children_parent_id_parents_id_fkey',
+      );
+      expect(migration.up.join('\n')).toContain(
+        '-- Existing orphan rows block this constraint.',
+      );
+      expect(migration.up.join('\n')).toContain('-- suggested: SELECT');
     });
 
     it('ignores unknown change types without emitting SQL', () => {

--- a/packages/core/src/migrations/differ.ts
+++ b/packages/core/src/migrations/differ.ts
@@ -15,7 +15,10 @@ import {
   renderForeignKeyOrphanRepair,
   schemaForeignKeys,
 } from '../schema/foreign-key-ddl.js';
-import { normalizeForeignKeyAction } from '../schema/foreign-key-policy.js';
+import {
+  normalizeForeignKeyAction,
+  requireForeignKeyAction,
+} from '../schema/foreign-key-policy.js';
 import type {
   ColumnAlteration,
   ColumnDefinition,
@@ -572,8 +575,20 @@ export class SchemaComparer {
     const changes: SchemaChange[] = [];
     const liveForeignKeys = dbSchema.foreignKeys || [];
     for (const foreignKey of schemaForeignKeys(manifest)) {
-      const expectedDelete = foreignKey.onDelete || 'NO ACTION';
-      const expectedUpdate = foreignKey.onUpdate || 'NO ACTION';
+      const expectedDelete =
+        foreignKey.onDelete === undefined
+          ? 'NO ACTION'
+          : requireForeignKeyAction(
+              foreignKey.onDelete,
+              `${tableName}.${foreignKey.column} ON DELETE`,
+            );
+      const expectedUpdate =
+        foreignKey.onUpdate === undefined
+          ? 'NO ACTION'
+          : requireForeignKeyAction(
+              foreignKey.onUpdate,
+              `${tableName}.${foreignKey.column} ON UPDATE`,
+            );
       const exact = liveForeignKeys.some(
         (live) =>
           live.column === foreignKey.column &&
@@ -627,7 +642,15 @@ export class SchemaComparer {
         continue;
       }
 
-      if (await this.foreignKeyHasOrphans(tableName, foreignKey)) {
+      // A missing child column is added earlier in this same table diff, so
+      // probing the pre-migration schema would fail and be misclassified as
+      // an orphan. The subsequent NOT VALID + VALIDATE statements remain the
+      // authoritative safety check once the prerequisite column exists.
+      const childColumnExists = Boolean(dbSchema.columns[foreignKey.column]);
+      if (
+        childColumnExists &&
+        (await this.foreignKeyHasOrphans(tableName, foreignKey))
+      ) {
         changes.push({
           type: 'add_foreign_key',
           table: tableName,

--- a/packages/core/src/migrations/differ.ts
+++ b/packages/core/src/migrations/differ.ts
@@ -8,6 +8,14 @@
 import { createLogger } from '@happyvertical/logger';
 import { detectEngine, getDDLStrategy } from '../schema/ddl/index.js';
 import type { DatabaseEngine } from '../schema/ddl/types.js';
+import {
+  foreignKeyConstraintName,
+  renderForeignKeyConstraint,
+  renderForeignKeyOrphanDetector,
+  renderForeignKeyOrphanRepair,
+  schemaForeignKeys,
+} from '../schema/foreign-key-ddl.js';
+import { normalizeForeignKeyAction } from '../schema/foreign-key-policy.js';
 import type {
   ColumnAlteration,
   ColumnDefinition,
@@ -549,8 +557,127 @@ export class SchemaComparer {
       dbIndexPredicates,
     );
     changes.push(...indexChanges);
+    changes.push(
+      ...(await this.compareForeignKeys(tableName, manifest, dbSchema)),
+    );
 
     return changes;
+  }
+
+  private async compareForeignKeys(
+    tableName: string,
+    manifest: SchemaDefinition,
+    dbSchema: SqlTableSchemaInfo,
+  ): Promise<SchemaChange[]> {
+    const changes: SchemaChange[] = [];
+    const liveForeignKeys = dbSchema.foreignKeys || [];
+    for (const foreignKey of schemaForeignKeys(manifest)) {
+      const expectedDelete = foreignKey.onDelete || 'NO ACTION';
+      const expectedUpdate = foreignKey.onUpdate || 'NO ACTION';
+      const exact = liveForeignKeys.some(
+        (live) =>
+          live.column === foreignKey.column &&
+          live.referencesTable === foreignKey.referencesTable &&
+          live.referencesColumn === foreignKey.referencesColumn &&
+          (normalizeForeignKeyAction(live.onDelete) || 'NO ACTION') ===
+            expectedDelete &&
+          (normalizeForeignKeyAction(live.onUpdate) || 'NO ACTION') ===
+            expectedUpdate,
+      );
+      if (exact) continue;
+
+      const detectorSql = renderForeignKeyOrphanDetector(tableName, foreignKey);
+      const repairSql = renderForeignKeyOrphanRepair(tableName, foreignKey);
+      const sameColumn = liveForeignKeys.some(
+        (live) => live.column === foreignKey.column,
+      );
+      if (sameColumn) {
+        changes.push({
+          type: 'add_foreign_key',
+          table: tableName,
+          name: foreignKeyConstraintName(tableName, foreignKey),
+          foreignKey,
+          advisory: {
+            severity: 'warning',
+            message:
+              `Foreign key ${tableName}.${foreignKey.column} exists with a different target or action. ` +
+              'Drop the old constraint deliberately, repair any orphan rows, then rerun the migration.',
+            suggestedSql: [detectorSql, repairSql],
+          },
+        });
+        continue;
+      }
+
+      if (this.engine !== 'postgres') {
+        const engineReason =
+          this.engine === 'sqlite'
+            ? 'SQLite requires a table rebuild to add a foreign key to an existing table.'
+            : 'DuckDB does not support ALTER TABLE ADD CONSTRAINT.';
+        changes.push({
+          type: 'add_foreign_key',
+          table: tableName,
+          name: foreignKeyConstraintName(tableName, foreignKey),
+          foreignKey,
+          advisory: {
+            severity: 'warning',
+            message: `${engineReason} Run the orphan detector, repair rows, and rebuild the table with the generated constraint.`,
+            suggestedSql: [detectorSql, repairSql],
+          },
+        });
+        continue;
+      }
+
+      if (await this.foreignKeyHasOrphans(tableName, foreignKey)) {
+        changes.push({
+          type: 'add_foreign_key',
+          table: tableName,
+          name: foreignKeyConstraintName(tableName, foreignKey),
+          foreignKey,
+          advisory: {
+            severity: 'warning',
+            message:
+              `Cannot add foreign key ${tableName}.${foreignKey.column}: existing rows do not match ` +
+              `${foreignKey.referencesTable}.${foreignKey.referencesColumn}. Repair them, then rerun.`,
+            suggestedSql: [detectorSql, repairSql],
+          },
+        });
+        continue;
+      }
+
+      const constraintName = foreignKeyConstraintName(tableName, foreignKey);
+      changes.push({
+        type: 'add_foreign_key',
+        table: tableName,
+        name: constraintName,
+        foreignKey,
+        sqlStatements: [
+          `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD ${renderForeignKeyConstraint(tableName, foreignKey)} NOT VALID`,
+          `ALTER TABLE ${this.quoteIdentifier(tableName)} VALIDATE CONSTRAINT ${this.quoteIdentifier(constraintName)}`,
+        ],
+      });
+    }
+    return changes;
+  }
+
+  private async foreignKeyHasOrphans(
+    tableName: string,
+    foreignKey: import('../schema/types.js').ForeignKeyDefinition,
+  ): Promise<boolean> {
+    try {
+      const result = await this.db.query(
+        renderForeignKeyOrphanDetector(tableName, foreignKey, {
+          limitOne: true,
+        }),
+      );
+      const rows = Array.isArray(result) ? result : result.rows || [];
+      return rows.length > 0;
+    } catch (error) {
+      logger.debug(
+        `[SchemaComparer] Foreign-key orphan probe unavailable for ${tableName}.${foreignKey.column}; refusing automatic constraint addition`,
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+      return true;
+    }
   }
 
   /**

--- a/packages/core/src/migrations/generator.ts
+++ b/packages/core/src/migrations/generator.ts
@@ -8,6 +8,10 @@
 import { createLogger } from '@happyvertical/logger';
 import { getDDLStrategy } from '../schema/ddl/index.js';
 import { materializeManifestDDLForEngine } from '../schema/ddl/materialize-manifest.js';
+import {
+  planForeignKeyCreation,
+  renderDeferredForeignKeyDrop,
+} from '../schema/foreign-key-planner.js';
 import { cachedDdlTableConstraints } from '../schema/manifest-schema.js';
 import type {
   MigrationDefinition,
@@ -108,18 +112,40 @@ export class MigrationGenerator {
   ): GeneratedMigration {
     const upStatements: string[] = [];
     const downStatements: string[] = [];
+    const addedTableDownStatements: string[] = [];
 
     // Handle new tables: CREATE TABLE plus the table's indexes and triggers,
     // exactly as the migration orchestrator emits them (#2358). The differ
     // only produces `add_index` changes for tables that already exist, so
     // there is no double emission against `diff.changes`.
-    for (const schema of diff.added_tables) {
+    const tablePlan = planForeignKeyCreation(diff.added_tables, this.engine);
+    for (const schema of tablePlan.schemas) {
       upStatements.push(this.generateCreateTable(schema));
       upStatements.push(...this.generateTableIndexes(schema));
       upStatements.push(...this.generateTableTriggers(schema));
-      if (this.includeDown || options.includeDown) {
-        downStatements.push(this.generateDropTable(schema.tableName));
+    }
+    upStatements.push(...tablePlan.deferredStatements);
+    if (this.includeDown || options.includeDown) {
+      if (this.engine === 'sqlite' && tablePlan.cyclicTables.length > 0) {
+        // SQLite cannot drop either side of a populated mutual FK cycle with
+        // immediate checks. Defer checks until the transaction commits, after
+        // every member has been removed.
+        addedTableDownStatements.push('PRAGMA defer_foreign_keys = ON');
       }
+      // PostgreSQL mutual cycles are made acyclic first; every table can then
+      // be dropped in the exact reverse of the parent-first creation order.
+      addedTableDownStatements.push(
+        ...[...tablePlan.deferredConstraints]
+          .reverse()
+          .map(({ table, foreignKey }) =>
+            renderDeferredForeignKeyDrop(table, foreignKey),
+          ),
+      );
+      addedTableDownStatements.push(
+        ...[...tablePlan.schemas]
+          .reverse()
+          .map((schema) => this.generateDropTable(schema.tableName)),
+      );
     }
 
     // Handle column and index changes
@@ -130,6 +156,11 @@ export class MigrationGenerator {
         downStatements.push(...down);
       }
     }
+
+    // Changes are applied after table creation, so undo them before removing
+    // the new tables they may reference. The table block is itself already
+    // ordered as deferred-constraint drops followed by child-first drops.
+    downStatements.push(...addedTableDownStatements);
 
     // Handle dropped tables (already in SQL form if present)
     for (const tableName of diff.dropped_tables) {
@@ -400,6 +431,24 @@ ${downStatementsStr}
         if (change.name) {
           down.push(this.generateDropIndex(change.name));
         }
+        break;
+
+      case 'add_foreign_key':
+        if (sqlStatements.length > 0) {
+          up.push(...sqlStatements);
+        } else if (change.advisory) {
+          up.push(
+            `-- ${change.advisory.severity === 'warning' ? 'WARNING' : 'NOTE'}: Foreign-key constraint ${change.table}.${change.name ?? 'unknown'}`,
+          );
+          if (change.advisory.message) {
+            up.push(`-- ${change.advisory.message}`);
+          }
+          for (const suggestion of change.advisory.suggestedSql ?? []) {
+            up.push(`-- suggested: ${suggestion}`);
+          }
+        }
+        // Constraint rollback is intentionally manual: names on older live
+        // databases may not match the deterministic current generator name.
         break;
 
       case 'drop_index':

--- a/packages/core/src/migrations/orchestrate.ts
+++ b/packages/core/src/migrations/orchestrate.ts
@@ -14,6 +14,7 @@ import type { DatabaseInterface } from '@happyvertical/sql';
 import { ObjectRegistry } from '../registry.js';
 import { detectEngine, getDDLStrategy } from '../schema/ddl/index.js';
 import type { DatabaseEngine } from '../schema/ddl/types.js';
+import { planForeignKeyCreation } from '../schema/foreign-key-planner.js';
 import type { MigrationResult, SchemaChange } from '../schema/types.js';
 import {
   generateSchemaDiff,
@@ -299,11 +300,13 @@ function collectStatementsFromDiff(
     detectEngine(resolveDatabaseUrl(db), engineHint),
   );
   const statements: string[] = [];
-  for (const schema of diff.added_tables) {
+  const tablePlan = planForeignKeyCreation(diff.added_tables, strategy.engine);
+  for (const schema of tablePlan.schemas) {
     statements.push(strategy.generateCreateTable(schema));
     statements.push(...strategy.generateIndexes(schema));
     statements.push(...strategy.generateTriggers(schema));
   }
+  statements.push(...tablePlan.deferredStatements);
   statements.push(...getSQLFromDiff(diff));
   // Drop empty and comment-only entries. SQLite type-widening upgrades
   // surface as `-- SQLite: Type upgrade for X requires table recreation`

--- a/packages/core/src/object.ts
+++ b/packages/core/src/object.ts
@@ -2829,8 +2829,8 @@ export class SmrtObject extends SmrtClass {
    *
    * ## Referential cleanup (#2371)
    *
-   * SMRT emits no DB-level `FOREIGN KEY` constraints, so step 3 enforces
-   * referential integrity in the application layer instead:
+   * Step 3 enforces the same referential policy as generated same-package
+   * database constraints:
    *
    * - `_smrt_embeddings` and `_smrt_contexts` rows owned by this object are
    *   removed, so a deleted object can no longer win a `semanticSearch` slot
@@ -2841,8 +2841,8 @@ export class SmrtObject extends SmrtClass {
    *   resolved according to their declared `onDelete` — `'CASCADE'`,
    *   `'SET NULL'` or `'RESTRICT'`. Without a declaration, a column that is
    *   part of the referencing class's `conflictColumns` (junction and
-   *   association rows) defaults to `CASCADE`; every other column is left
-   *   untouched, as before.
+   *   association rows) defaults to `CASCADE`; every other same-package
+   *   column defaults to immediate `NO ACTION`.
    *
    * Cascaded rows are removed with set-based statements: their own hooks and
    * interceptors do **not** run and no change-feed tombstone is written for

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -2242,13 +2242,11 @@ export class ObjectRegistry {
    * Foreign-key cycles (e.g. smrt-chat's ChatMessage.threadId -> ChatThread
    * and ChatThread.rootMessageId -> ChatMessage) are BROKEN rather than
    * treated as a fatal error: when a back-edge is encountered the recursion
-   * stops there, so every class still appears in the returned order. SMRT does
-   * not emit real DB `FOREIGN KEY` constraints in its generated CREATE TABLE
-   * DDL, so a table can be created before its cyclic reference target exists —
-   * the reference is satisfied once both tables are present. This mirrors the
-   * standard RDBMS approach (create tables first, wire cyclic references
-   * afterward) and matches SchemaManager.sortByDependencies, which already
-   * tolerates cycles. See issue #1333.
+   * stops there, so every class still appears in the returned order. The schema
+   * creation planner then handles physical constraints per engine: SQLite
+   * keeps cyclic constraints inline, PostgreSQL defers them until both tables
+   * exist, and DuckDB refuses unsupported cycles with actionable guidance.
+   * See issues #1333 and #2413.
    *
    * @returns Array of class names in initialization order. Every registered
    *   class appears exactly once; cycle back-edges are dropped from the
@@ -2310,7 +2308,7 @@ export class ObjectRegistry {
         `[ObjectRegistry] Foreign-key cycle(s) detected and broken for ordering: ${[
           ...cycleMembers,
         ].join(', ')}. Tables are created without strict cyclic ordering; ` +
-          'SMRT does not emit DB-level FOREIGN KEY constraints, so this is safe.',
+          'the schema creation planner will apply engine-specific cycle handling.',
       );
     }
 

--- a/packages/core/src/registry/__tests__/schema-builder-helpers.test.ts
+++ b/packages/core/src/registry/__tests__/schema-builder-helpers.test.ts
@@ -270,6 +270,20 @@ describe('schema-builder: fieldsToColumns', () => {
     expect(columns.owner_ref.foreignKey?.column).toBe('code');
   });
 
+  it('uses the shared CASCADE default for a natural-key foreign key', () => {
+    const fields = fieldMap({
+      parentId: { type: 'foreignKey', related: 'Parent' },
+      reviewerId: { type: 'foreignKey', related: 'Reviewer' },
+    });
+
+    const columns = fieldsToColumns(fields, {
+      conflictColumns: ['parent_id', 'label'],
+    });
+
+    expect(columns.parent_id.foreignKey?.onDelete).toBe('CASCADE');
+    expect(columns.reviewer_id.foreignKey?.onDelete).toBe('NO ACTION');
+  });
+
   it('maps crossPackageRef with text idType to TEXT', () => {
     const columns = fieldsToColumns(
       fieldMap({

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -395,6 +395,7 @@ function applyContributorForeignKeys(
     const column = tableSchema.columns[columnName];
     if (!column) continue;
     if (
+      field._meta?.constraint === false ||
       field._meta?.__tenancy?.isTenantIdField === true ||
       (
         field as FieldDefinition & {
@@ -1025,6 +1026,7 @@ export function fieldsToColumns(
     if (
       fieldDef.type === 'foreignKey' &&
       fieldDef.related &&
+      fieldDef._meta?.constraint !== false &&
       fieldDef._meta?.__tenancy?.isTenantIdField !== true &&
       !(
         fieldDef as FieldDefinition & {

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -619,6 +619,9 @@ function buildMergedTableSchemas(): Record<string, MergedTableSchema> {
   for (const [tableName, contributors] of contributorsByTable) {
     for (const contributor of sortTableContributors(contributors)) {
       const { registered, simpleName, isSTI } = contributor;
+      const conflictColumns = ObjectRegistry.getConflictColumns(
+        contributor.conflictKey,
+      );
 
       // The manifest schema stays authoritative for the columns it defines.
       // Runtime field metadata backfills columns the manifest never had (for
@@ -628,7 +631,7 @@ function buildMergedTableSchemas(): Record<string, MergedTableSchema> {
         simpleName,
         registered.schema?.columns,
         registered.fields,
-        { stiUnionColumns: isSTI },
+        { stiUnionColumns: isSTI, conflictColumns },
       );
 
       let tableSchema = tableSchemas[tableName];
@@ -642,9 +645,7 @@ function buildMergedTableSchemas(): Record<string, MergedTableSchema> {
           indexes: [],
           ddl: registered.schema?.ddl || '',
           isSTI,
-          conflictColumns: ObjectRegistry.getConflictColumns(
-            contributor.conflictKey,
-          ),
+          conflictColumns,
         };
         tableSchemas[tableName] = tableSchema;
       } else {
@@ -952,6 +953,12 @@ export interface FieldsToColumnsOptions {
    * Declared defaults are still emitted.
    */
   stiUnionColumns?: boolean;
+  /**
+   * Physical column names that form the table's natural conflict key.
+   * Undeclared delete actions on foreign-key members use the shared CASCADE
+   * default, matching app-side relationship cleanup.
+   */
+  conflictColumns?: readonly string[];
 }
 
 /**
@@ -975,6 +982,9 @@ export function fieldsToColumns(
   options?: FieldsToColumnsOptions,
 ): Record<string, ColumnDefinition> {
   const columns: Record<string, ColumnDefinition> = {};
+  const conflictColumns = new Set(
+    (options?.conflictColumns ?? []).map((column) => toSnakeCase(column)),
+  );
 
   for (const [fieldName, fieldDef] of fields) {
     // Skip id, timestamps - they're on the base table
@@ -1063,7 +1073,7 @@ export function fieldsToColumns(
         column: columnName,
         onDelete: resolveForeignKeyDeleteAction({
           declared: fieldMeta?.onDelete,
-          isConflictColumn: false,
+          isConflictColumn: conflictColumns.has(toSnakeCase(fieldName)),
           isTenantIdField: false,
         }).action,
         onUpdate:

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -395,7 +395,6 @@ function applyContributorForeignKeys(
     const column = tableSchema.columns[columnName];
     if (!column) continue;
     if (
-      field._meta?.constraint === false ||
       field._meta?.__tenancy?.isTenantIdField === true ||
       (
         field as FieldDefinition & {
@@ -408,6 +407,30 @@ function applyContributorForeignKeys(
     }
     const [targetName, declaredTargetColumn] = field.related.split('.');
     const targetBase = ObjectRegistry.getSTIBase(targetName) || targetName;
+    const registeredTarget = ObjectRegistry.getClass(targetBase);
+    const targetColumn =
+      declaredTargetColumn ||
+      Array.from(ObjectRegistry.getFields(targetBase).entries()).find(
+        ([, targetField]) => targetField._meta?.primaryKey === true,
+      )?.[0] ||
+      'id';
+    if (registeredTarget && !field._meta?.sqlType) {
+      const targetColumnName = toSnakeCase(targetColumn);
+      const targetColumnType =
+        registeredTarget.schema?.columns?.[targetColumnName]?.type ||
+        (targetColumnName === 'id'
+          ? registeredTarget.config.idType === 'text'
+            ? 'TEXT'
+            : 'UUID'
+          : undefined);
+      if (targetColumnType) {
+        column.type = targetColumnType;
+      }
+    }
+    if (field._meta?.constraint === false) {
+      column.foreignKey = undefined;
+      continue;
+    }
     // A manifest may carry explicit actions that predate or differ from the
     // runtime decorator defaults. Merging runtime fields must not erase them.
     // The fallback produced from runtime fields, however, must be replaced so
@@ -422,16 +445,10 @@ function applyContributorForeignKeys(
     // until that target is registered. Scanner-produced manifests clear this
     // shape too; only an explicit manifest FK above may survive unloaded
     // runtime classes (the manifest-authority contract from #1120).
-    if (!ObjectRegistry.getClass(targetBase)) {
+    if (!registeredTarget) {
       column.foreignKey = undefined;
       continue;
     }
-    const targetColumn =
-      declaredTargetColumn ||
-      Array.from(ObjectRegistry.getFields(targetBase).entries()).find(
-        ([, targetField]) => targetField._meta?.primaryKey === true,
-      )?.[0] ||
-      'id';
     const targetTable =
       ObjectRegistry.getTableName(targetBase) ||
       classnameToTablename(targetBase);

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -9,6 +9,14 @@ import type { FieldDefinition } from '../scanner/types.js';
 import { conflictIndexName } from '../schema/conflict-target.js';
 import { getDDLStrategy } from '../schema/ddl/index.js';
 import type { DatabaseEngine } from '../schema/ddl/types.js';
+import {
+  renderForeignKeyConstraint,
+  schemaForeignKeys,
+} from '../schema/foreign-key-ddl.js';
+import {
+  requireForeignKeyAction,
+  resolveForeignKeyDeleteAction,
+} from '../schema/foreign-key-policy.js';
 import { shortenIdentifier } from '../schema/index-utils.js';
 import {
   formatDefaultValue as formatDefaultValueShared,
@@ -376,6 +384,70 @@ interface MergedTableSchema {
   conflictColumns: string[];
 }
 
+function applyContributorForeignKeys(
+  tableSchema: MergedTableSchema,
+  contributor: TableContributor,
+): void {
+  const conflictColumns = new Set(tableSchema.conflictColumns);
+  for (const [fieldName, field] of contributor.registered.fields) {
+    if (field.type !== 'foreignKey' || !field.related) continue;
+    const columnName = toSnakeCase(fieldName);
+    const column = tableSchema.columns[columnName];
+    if (!column) continue;
+    if (
+      field._meta?.__tenancy?.isTenantIdField === true ||
+      (
+        field as FieldDefinition & {
+          __tenancy?: { isTenantIdField?: boolean };
+        }
+      ).__tenancy?.isTenantIdField === true
+    ) {
+      column.foreignKey = undefined;
+      continue;
+    }
+    const [targetName, declaredTargetColumn] = field.related.split('.');
+    const targetBase = ObjectRegistry.getSTIBase(targetName) || targetName;
+    // A manifest may carry explicit actions that predate or differ from the
+    // runtime decorator defaults. Merging runtime fields must not erase them.
+    // The fallback produced from runtime fields, however, must be replaced so
+    // conflict columns receive the same default CASCADE as app-side cleanup.
+    const manifestForeignKey =
+      contributor.registered.schema?.columns?.[columnName]?.foreignKey;
+    if (manifestForeignKey) {
+      column.foreignKey = manifestForeignKey;
+      continue;
+    }
+    // A decorator-only runtime field has no authoritative physical target
+    // until that target is registered. Scanner-produced manifests clear this
+    // shape too; only an explicit manifest FK above may survive unloaded
+    // runtime classes (the manifest-authority contract from #1120).
+    if (!ObjectRegistry.getClass(targetBase)) {
+      column.foreignKey = undefined;
+      continue;
+    }
+    const targetColumn =
+      declaredTargetColumn ||
+      Array.from(ObjectRegistry.getFields(targetBase).entries()).find(
+        ([, targetField]) => targetField._meta?.primaryKey === true,
+      )?.[0] ||
+      'id';
+    const targetTable =
+      ObjectRegistry.getTableName(targetBase) ||
+      classnameToTablename(targetBase);
+    const { action } = resolveForeignKeyDeleteAction({
+      declared: field._meta?.onDelete,
+      isConflictColumn: conflictColumns.has(columnName),
+      isTenantIdField: false,
+    });
+    column.foreignKey = {
+      table: targetTable,
+      column: toSnakeCase(targetColumn),
+      onDelete: action,
+      onUpdate: 'CASCADE',
+    };
+  }
+}
+
 /**
  * Resolve the physical table a registered class writes to.
  *
@@ -567,6 +639,8 @@ function buildMergedTableSchemas(): Record<string, MergedTableSchema> {
         }
       }
 
+      applyContributorForeignKeys(tableSchema, contributor);
+
       // Merge indexes, keeping the first definition of each name.
       const schemaIndexes = registered.schema?.indexes;
       if (schemaIndexes && schemaIndexes.length > 0) {
@@ -637,6 +711,10 @@ export function getAllSchemas(
       version: '',
       dependencies: [],
     };
+    mergedSchema.foreignKeys = schemaForeignKeys(mergedSchema);
+    mergedSchema.dependencies = mergedSchema.foreignKeys
+      .map((foreignKey) => foreignKey.referencesTable)
+      .filter((dependency) => dependency !== tableName);
 
     // Generate DDL from merged columns (or use original DDL if columns are empty)
     let ddl: string;
@@ -722,6 +800,10 @@ export function getAllSchemasAsDefinitions(): Record<string, SchemaDefinition> {
       tableSchema.columns,
       tableSchema.isSTI,
     );
+    const foreignKeys = schemaForeignKeys({
+      columns: tableSchema.columns,
+      foreignKeys: [],
+    });
 
     schemas[tableName] = {
       tableName,
@@ -734,9 +816,11 @@ export function getAllSchemasAsDefinitions(): Record<string, SchemaDefinition> {
         tableSchema.conflictColumns,
       ),
       triggers: [],
-      foreignKeys: [],
+      foreignKeys,
       version: '',
-      dependencies: [],
+      dependencies: foreignKeys
+        .map((foreignKey) => foreignKey.referencesTable)
+        .filter((dependency) => dependency !== tableName),
     };
   }
 
@@ -796,6 +880,9 @@ export function generateDDLFromColumns(
     }
 
     columnLines.push(parts.join(' '));
+  }
+  for (const foreignKey of schemaForeignKeys({ columns, foreignKeys: [] })) {
+    columnLines.push(`  ${renderForeignKeyConstraint(tableName, foreignKey)}`);
   }
 
   sql += columnLines.join(',\n');
@@ -935,7 +1022,16 @@ export function fieldsToColumns(
     }
 
     // Handle foreign keys
-    if (fieldDef.type === 'foreignKey' && fieldDef.related) {
+    if (
+      fieldDef.type === 'foreignKey' &&
+      fieldDef.related &&
+      fieldDef._meta?.__tenancy?.isTenantIdField !== true &&
+      !(
+        fieldDef as FieldDefinition & {
+          __tenancy?: { isTenantIdField?: boolean };
+        }
+      ).__tenancy?.isTenantIdField
+    ) {
       const [table, columnName = 'id'] = fieldDef.related.split('.');
       const fieldMeta = fieldDef._meta as
         | {
@@ -946,8 +1042,18 @@ export function fieldsToColumns(
       column.foreignKey = {
         table: classnameToTablename(table),
         column: columnName,
-        onDelete: fieldMeta?.onDelete ?? 'CASCADE',
-        onUpdate: fieldMeta?.onUpdate ?? 'CASCADE',
+        onDelete: resolveForeignKeyDeleteAction({
+          declared: fieldMeta?.onDelete,
+          isConflictColumn: false,
+          isTenantIdField: false,
+        }).action,
+        onUpdate:
+          fieldMeta?.onUpdate === undefined
+            ? 'CASCADE'
+            : requireForeignKeyAction(
+                fieldMeta.onUpdate,
+                `${fieldName} ON UPDATE`,
+              ),
       };
     }
 

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -859,6 +859,7 @@ export class ManifestGenerator {
         if (
           field.type !== 'foreignKey' ||
           !field.related ||
+          field._meta?.constraint === false ||
           field._meta?.__tenancy?.isTenantIdField === true
         ) {
           continue;

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -833,8 +833,11 @@ export class ManifestGenerator {
       { name: string; obj: SmartObjectDefinition }
     >();
     const changedSchemas = new Set<ManifestSchema>();
+    const objectsByName = new Map<string, SmartObjectDefinition>();
 
     for (const [name, obj] of Object.entries(manifest.objects)) {
+      objectsByName.set(obj.className, obj);
+      objectsByName.set(obj.className.toLowerCase(), obj);
       if (obj.schema?.tableName) {
         schemaByTable.set(obj.schema.tableName, obj.schema);
         const siblings = schemasByTable.get(obj.schema.tableName) ?? [];
@@ -894,8 +897,10 @@ export class ManifestGenerator {
           )?.[0] ||
           'id';
         const targetIdType = targetSchema.columns[targetColumn]?.type;
+        const conflictOwner =
+          this.findSTIBase(obj, objectsByName, manifest) ?? obj;
         const conflictColumns = new Set(
-          (obj.decoratorConfig?.conflictColumns || []).map((column) =>
+          (conflictOwner.decoratorConfig?.conflictColumns || []).map((column) =>
             toSnakeCase(column),
           ),
         );

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -15,6 +15,7 @@ import {
   resolveTenantColumn,
 } from '../schema/conflict-target.js';
 import type { DatabaseEngine } from '../schema/ddl/types.js';
+import { resolveForeignKeyDeleteAction } from '../schema/foreign-key-policy.js';
 import { SchemaGenerator } from '../schema/generator.js';
 import type {
   ColumnDefinition,
@@ -858,7 +859,7 @@ export class ManifestGenerator {
         if (
           field.type !== 'foreignKey' ||
           !field.related ||
-          field._meta?.sqlType
+          field._meta?.__tenancy?.isTenantIdField === true
         ) {
           continue;
         }
@@ -869,20 +870,60 @@ export class ManifestGenerator {
           manifest,
           schemaByTable,
         );
-        const targetIdType = targetSchema?.columns.id?.type;
-        if (!targetIdType) {
+        if (!targetSchema) {
+          for (const sourceSchema of sourceSchemas) {
+            const sourceColumn = sourceSchema.columns[columnName];
+            if (sourceColumn?.foreignKey) {
+              sourceSchema.columns[columnName] = {
+                ...sourceColumn,
+                foreignKey: undefined,
+              };
+              changedSchemas.add(sourceSchema);
+            }
+          }
           continue;
         }
 
+        const [, declaredTargetColumn] = field.related.split('.');
+        const targetColumn =
+          declaredTargetColumn ||
+          Object.entries(targetSchema.columns).find(
+            ([, definition]) => definition.primaryKey === true,
+          )?.[0] ||
+          'id';
+        const targetIdType = targetSchema.columns[targetColumn]?.type;
+        const conflictColumns = new Set(
+          (obj.decoratorConfig?.conflictColumns || []).map((column) =>
+            toSnakeCase(column),
+          ),
+        );
+        const { action } = resolveForeignKeyDeleteAction({
+          declared: field._meta?.onDelete,
+          isConflictColumn: conflictColumns.has(columnName),
+          isTenantIdField: false,
+        });
+
         for (const sourceSchema of sourceSchemas) {
           const sourceColumn = sourceSchema.columns[columnName];
-          if (!sourceColumn || sourceColumn.type === targetIdType) {
+          if (!sourceColumn) {
             continue;
           }
-          sourceSchema.columns[columnName] = {
+          const nextColumn = {
             ...sourceColumn,
-            type: targetIdType,
+            ...(!field._meta?.sqlType && targetIdType
+              ? { type: targetIdType }
+              : {}),
+            foreignKey: {
+              table: targetSchema.tableName,
+              column: targetColumn,
+              onDelete: action,
+              onUpdate: 'CASCADE' as const,
+            },
           };
+          if (JSON.stringify(nextColumn) === JSON.stringify(sourceColumn)) {
+            continue;
+          }
+          sourceSchema.columns[columnName] = nextColumn;
           changedSchemas.add(sourceSchema);
         }
       }
@@ -952,6 +993,7 @@ export class ManifestGenerator {
         notNull: column.notNull,
         unique: column.unique,
         defaultValue: column.default,
+        foreignKey: column.foreignKey ? { ...column.foreignKey } : undefined,
       };
     }
 
@@ -966,8 +1008,24 @@ export class ManifestGenerator {
         jsonPath: index.jsonPath,
       })),
       triggers: [],
-      foreignKeys: [],
-      dependencies: [],
+      foreignKeys: Object.entries(columns).flatMap(([column, definition]) =>
+        definition.foreignKey
+          ? [
+              {
+                column,
+                referencesTable: definition.foreignKey.table,
+                referencesColumn: definition.foreignKey.column,
+                onDelete: definition.foreignKey.onDelete,
+                onUpdate: definition.foreignKey.onUpdate,
+              },
+            ]
+          : [],
+      ),
+      dependencies: Object.values(columns)
+        .flatMap((definition) =>
+          definition.foreignKey ? [definition.foreignKey.table] : [],
+        )
+        .filter((dependency) => dependency !== schema.tableName),
       version: schema.version,
       packageName: '',
     };

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -859,11 +859,12 @@ export class ManifestGenerator {
         if (
           field.type !== 'foreignKey' ||
           !field.related ||
-          field._meta?.constraint === false ||
           field._meta?.__tenancy?.isTenantIdField === true
         ) {
           continue;
         }
+
+        const emitConstraint = field._meta?.constraint !== false;
 
         const columnName = toSnakeCase(fieldName);
         const targetSchema = this.findForeignKeyTargetSchema(
@@ -914,12 +915,14 @@ export class ManifestGenerator {
             ...(!field._meta?.sqlType && targetIdType
               ? { type: targetIdType }
               : {}),
-            foreignKey: {
-              table: targetSchema.tableName,
-              column: targetColumn,
-              onDelete: action,
-              onUpdate: 'CASCADE' as const,
-            },
+            foreignKey: emitConstraint
+              ? {
+                  table: targetSchema.tableName,
+                  column: targetColumn,
+                  onDelete: action,
+                  onUpdate: 'CASCADE' as const,
+                }
+              : undefined,
           };
           if (JSON.stringify(nextColumn) === JSON.stringify(sourceColumn)) {
             continue;

--- a/packages/core/src/scanner/types.ts
+++ b/packages/core/src/scanner/types.ts
@@ -70,6 +70,8 @@ export interface FieldMeta {
   indexed?: boolean;
   /** Foreign-key delete action carried in metadata. */
   onDelete?: 'CASCADE' | 'SET NULL' | 'RESTRICT' | 'NO ACTION';
+  /** Explicitly disables physical DDL while retaining FK relationship metadata. */
+  constraint?: boolean;
   /** Excludes the field from persistence when true. */
   transient?: boolean;
   /** Numeric/length validation bounds and pattern. */

--- a/packages/core/src/scanner/types.ts
+++ b/packages/core/src/scanner/types.ts
@@ -69,7 +69,7 @@ export interface FieldMeta {
   /** Opt-in column/JSON-path indexing flag. */
   indexed?: boolean;
   /** Foreign-key delete action carried in metadata. */
-  onDelete?: 'CASCADE' | 'SET NULL' | 'RESTRICT';
+  onDelete?: 'CASCADE' | 'SET NULL' | 'RESTRICT' | 'NO ACTION';
   /** Excludes the field from persistence when true. */
   transient?: boolean;
   /** Numeric/length validation bounds and pattern. */
@@ -184,6 +184,8 @@ export interface ManifestColumnDefinition {
   notNull?: boolean;
   unique?: boolean;
   default?: unknown;
+  /** Same-package FK only. Cross-package references never populate this. */
+  foreignKey?: import('../schema/types.js').ColumnDefinition['foreignKey'];
 }
 
 /**

--- a/packages/core/src/schema/ddl/base-strategy.ts
+++ b/packages/core/src/schema/ddl/base-strategy.ts
@@ -7,6 +7,10 @@
 
 import { createLogger } from '@happyvertical/logger';
 import {
+  renderForeignKeyConstraint,
+  schemaForeignKeys,
+} from '../foreign-key-ddl.js';
+import {
   formatDefaultValue as formatDefaultValueShared,
   isSafeIdentifier,
   isSafeIdentifierPath,
@@ -75,6 +79,10 @@ export abstract class BaseDDLStrategy implements DDLStrategy {
     if (this.requiresInlineUnique() && indexes.length > 0) {
       const uniqueConstraints = this.generateInlineUniqueConstraints(indexes);
       columnDefs.push(...uniqueConstraints);
+    }
+
+    for (const foreignKey of schemaForeignKeys(schema)) {
+      columnDefs.push(renderForeignKeyConstraint(tableName, foreignKey));
     }
 
     sql += columnDefs.map((def) => `  ${def}`).join(',\n');

--- a/packages/core/src/schema/ddl/duckdb-strategy.ts
+++ b/packages/core/src/schema/ddl/duckdb-strategy.ts
@@ -11,6 +11,7 @@
  * not with separate UNIQUE indexes. This is a known DuckDB limitation.
  */
 
+import { schemaForeignKeys } from '../foreign-key-ddl.js';
 import { isStiSubtypeUniqueIndex, renderIndexTarget } from '../index-utils.js';
 import type { SchemaDefinition, SQLDataType } from '../types.js';
 import { BaseDDLStrategy } from './base-strategy.js';
@@ -18,6 +19,34 @@ import type { DatabaseEngine } from './types.js';
 
 export class DuckDBStrategy extends BaseDDLStrategy {
   readonly engine: DatabaseEngine = 'duckdb';
+
+  override generateCreateTable(schema: SchemaDefinition): string {
+    const foreignKeys = schemaForeignKeys(schema).map((foreignKey) => {
+      if (foreignKey.referencesTable === schema.tableName) {
+        throw new Error(
+          `[DDL:duckdb] Foreign key ${schema.tableName}.${foreignKey.column} is self-referential; DuckDB cannot insert self-referencing foreign keys safely.`,
+        );
+      }
+      if (
+        foreignKey.onDelete === 'CASCADE' ||
+        foreignKey.onDelete === 'SET NULL'
+      ) {
+        throw new Error(
+          `[DDL:duckdb] Foreign key ${schema.tableName}.${foreignKey.column} uses ON DELETE ${foreignKey.onDelete}, which DuckDB does not support. Use PostgreSQL/SQLite or keep this relationship app-side only with @crossPackageRef.`,
+        );
+      }
+      if (foreignKey.onUpdate !== undefined) {
+        throw new Error(
+          `[DDL:duckdb] Foreign key ${schema.tableName}.${foreignKey.column} uses ON UPDATE ${foreignKey.onUpdate}, which DuckDB does not support. DuckDB cannot preserve SMRT's ON UPDATE CASCADE contract; use PostgreSQL/SQLite or keep this relationship app-side only with @crossPackageRef.`,
+        );
+      }
+      // DuckDB supports the immediate restrictive behavior but rejects the
+      // SQL action clause. Omitting it is SQL's default NO ACTION; RESTRICT is
+      // equivalent because DuckDB has no deferred constraints.
+      return { ...foreignKey, onDelete: undefined };
+    });
+    return super.generateCreateTable({ ...schema, foreignKeys });
+  }
 
   /**
    * Map types for DuckDB

--- a/packages/core/src/schema/foreign-key-ddl.ts
+++ b/packages/core/src/schema/foreign-key-ddl.ts
@@ -1,0 +1,89 @@
+import { requireForeignKeyAction } from './foreign-key-policy.js';
+import { shortenIdentifier } from './index-utils.js';
+import { quoteIdentifier } from './sql-identifiers.js';
+import type { ForeignKeyDefinition, SchemaDefinition } from './types.js';
+
+export function foreignKeyConstraintName(
+  tableName: string,
+  foreignKey: ForeignKeyDefinition,
+): string {
+  return shortenIdentifier(
+    `${tableName}_${foreignKey.column}_${foreignKey.referencesTable}_${foreignKey.referencesColumn}_fkey`,
+  );
+}
+
+export function renderForeignKeyConstraint(
+  tableName: string,
+  foreignKey: ForeignKeyDefinition,
+): string {
+  const action = (value: unknown, clause: 'DELETE' | 'UPDATE') => {
+    if (value === undefined) return undefined;
+    return requireForeignKeyAction(
+      value,
+      `${tableName}.${foreignKey.column} ON ${clause}`,
+    );
+  };
+  const onDelete = action(foreignKey.onDelete, 'DELETE');
+  const onUpdate = action(foreignKey.onUpdate, 'UPDATE');
+  const name = foreignKeyConstraintName(tableName, foreignKey);
+  const parts = [
+    `CONSTRAINT ${quoteIdentifier(name)}`,
+    `FOREIGN KEY (${quoteIdentifier(foreignKey.column)})`,
+    `REFERENCES ${quoteIdentifier(foreignKey.referencesTable)} (${quoteIdentifier(foreignKey.referencesColumn)})`,
+  ];
+  if (onDelete) parts.push(`ON DELETE ${onDelete}`);
+  if (onUpdate) parts.push(`ON UPDATE ${onUpdate}`);
+  return parts.join(' ');
+}
+
+export function renderForeignKeyOrphanDetector(
+  tableName: string,
+  foreignKey: ForeignKeyDefinition,
+  options: { limitOne?: boolean } = {},
+): string {
+  const childTable = quoteIdentifier(tableName);
+  const childColumn = quoteIdentifier(foreignKey.column);
+  const parentTable = quoteIdentifier(foreignKey.referencesTable);
+  const parentColumn = quoteIdentifier(foreignKey.referencesColumn);
+  return (
+    `SELECT ${childTable}.${childColumn} AS orphan_key FROM ${childTable} ` +
+    `LEFT JOIN ${parentTable} ON ${parentTable}.${parentColumn} = ${childTable}.${childColumn} ` +
+    `WHERE ${childTable}.${childColumn} IS NOT NULL AND ${parentTable}.${parentColumn} IS NULL` +
+    (options.limitOne ? ' LIMIT 1' : '')
+  );
+}
+
+export function renderForeignKeyOrphanRepair(
+  tableName: string,
+  foreignKey: ForeignKeyDefinition,
+): string {
+  const childTable = quoteIdentifier(tableName);
+  const childColumn = quoteIdentifier(foreignKey.column);
+  const parentTable = quoteIdentifier(foreignKey.referencesTable);
+  const parentColumn = quoteIdentifier(foreignKey.referencesColumn);
+  return (
+    `DELETE FROM ${childTable} WHERE ${childColumn} IS NOT NULL AND NOT EXISTS (` +
+    `SELECT 1 FROM ${parentTable} WHERE ${parentTable}.${parentColumn} = ${childTable}.${childColumn})`
+  );
+}
+
+export function schemaForeignKeys(
+  schema: Pick<SchemaDefinition, 'columns'> &
+    Partial<Pick<SchemaDefinition, 'foreignKeys'>>,
+): ForeignKeyDefinition[] {
+  if (schema.foreignKeys && schema.foreignKeys.length > 0) {
+    return schema.foreignKeys;
+  }
+  return Object.entries(schema.columns).flatMap(([column, definition]) => {
+    if (!definition.foreignKey) return [];
+    return [
+      {
+        column,
+        referencesTable: definition.foreignKey.table,
+        referencesColumn: definition.foreignKey.column,
+        onDelete: definition.foreignKey.onDelete,
+        onUpdate: definition.foreignKey.onUpdate,
+      },
+    ];
+  });
+}

--- a/packages/core/src/schema/foreign-key-planner.ts
+++ b/packages/core/src/schema/foreign-key-planner.ts
@@ -1,0 +1,224 @@
+import type { DatabaseEngine } from './ddl/types.js';
+import {
+  foreignKeyConstraintName,
+  renderForeignKeyConstraint,
+  schemaForeignKeys,
+} from './foreign-key-ddl.js';
+import { quoteIdentifier } from './sql-identifiers.js';
+import type { ForeignKeyDefinition, SchemaDefinition } from './types.js';
+
+export interface ForeignKeyCreationPlan {
+  schemas: SchemaDefinition[];
+  deferredStatements: string[];
+  /** Tables participating in a multi-table strongly connected component. */
+  cyclicTables: string[];
+  /** PostgreSQL constraints omitted from CREATE TABLE and added afterward. */
+  deferredConstraints: Array<{
+    table: string;
+    foreignKey: ForeignKeyDefinition;
+  }>;
+}
+
+/** Render the inverse of a PostgreSQL deferred ADD CONSTRAINT statement. */
+export function renderDeferredForeignKeyDrop(
+  table: string,
+  foreignKey: ForeignKeyDefinition,
+): string {
+  return `ALTER TABLE ${quoteIdentifier(table)} DROP CONSTRAINT IF EXISTS ${quoteIdentifier(
+    foreignKeyConstraintName(table, foreignKey),
+  )};`;
+}
+
+function stronglyConnectedComponents(
+  names: string[],
+  dependencies: Map<string, string[]>,
+): Map<string, number> {
+  let nextIndex = 0;
+  const indexes = new Map<string, number>();
+  const lowLinks = new Map<string, number>();
+  const stack: string[] = [];
+  const onStack = new Set<string>();
+  const componentByName = new Map<string, number>();
+  let component = 0;
+
+  const visit = (name: string): void => {
+    indexes.set(name, nextIndex);
+    lowLinks.set(name, nextIndex);
+    nextIndex++;
+    stack.push(name);
+    onStack.add(name);
+
+    for (const dependency of dependencies.get(name) || []) {
+      if (!indexes.has(dependency)) {
+        visit(dependency);
+        lowLinks.set(
+          name,
+          Math.min(lowLinks.get(name) ?? 0, lowLinks.get(dependency) ?? 0),
+        );
+      } else if (onStack.has(dependency)) {
+        lowLinks.set(
+          name,
+          Math.min(lowLinks.get(name) ?? 0, indexes.get(dependency) ?? 0),
+        );
+      }
+    }
+
+    if (lowLinks.get(name) !== indexes.get(name)) return;
+    while (stack.length > 0) {
+      const member = stack.pop() as string;
+      onStack.delete(member);
+      componentByName.set(member, component);
+      if (member === name) break;
+    }
+    component++;
+  };
+
+  for (const name of names) {
+    if (!indexes.has(name)) visit(name);
+  }
+  return componentByName;
+}
+
+function omitForeignKeys(
+  schema: SchemaDefinition,
+  omitted: Set<string>,
+): SchemaDefinition {
+  if (omitted.size === 0) return schema;
+  const columns = Object.fromEntries(
+    Object.entries(schema.columns).map(([name, definition]) => [
+      name,
+      omitted.has(name) ? { ...definition, foreignKey: undefined } : definition,
+    ]),
+  );
+  return {
+    ...schema,
+    columns,
+    foreignKeys: schemaForeignKeys(schema).filter(
+      (foreignKey) => !omitted.has(foreignKey.column),
+    ),
+  };
+}
+
+/** Deterministically order new tables and define safe behavior for FK cycles. */
+export function planForeignKeyCreation(
+  input: readonly SchemaDefinition[],
+  engine: DatabaseEngine,
+): ForeignKeyCreationPlan {
+  const byName = new Map(
+    [...input]
+      .sort((a, b) => a.tableName.localeCompare(b.tableName))
+      .map((schema) => [schema.tableName, schema]),
+  );
+  const names = [...byName.keys()];
+  const dependencies = new Map<string, string[]>();
+  for (const [name, schema] of byName) {
+    for (const foreignKey of schemaForeignKeys(schema)) {
+      // Validate externally supplied manifest actions before a dry-run can
+      // report an executable plan.
+      renderForeignKeyConstraint(name, foreignKey);
+    }
+    dependencies.set(
+      name,
+      Array.from(
+        new Set(
+          [
+            ...(schema.dependencies ?? []),
+            ...schemaForeignKeys(schema).map(
+              (foreignKey) => foreignKey.referencesTable,
+            ),
+          ].filter((target) => target !== name && byName.has(target)),
+        ),
+      ).sort(),
+    );
+  }
+
+  const components = stronglyConnectedComponents(names, dependencies);
+  const componentSizes = new Map<number, number>();
+  for (const id of components.values()) {
+    componentSizes.set(id, (componentSizes.get(id) || 0) + 1);
+  }
+  const isMutualCycle = (source: string, target: string): boolean => {
+    const component = components.get(source);
+    return (
+      source !== target &&
+      component !== undefined &&
+      component === components.get(target) &&
+      (componentSizes.get(component) || 0) > 1
+    );
+  };
+
+  if (engine === 'duckdb' || engine === 'json') {
+    for (const [source, schema] of byName) {
+      for (const foreignKey of schemaForeignKeys(schema)) {
+        if (source === foreignKey.referencesTable) {
+          throw new Error(
+            `[DDL:${engine}] Foreign key ${source}.${foreignKey.column} is self-referential; DuckDB cannot insert self-referencing foreign keys safely.`,
+          );
+        }
+        if (
+          foreignKey.onDelete === 'CASCADE' ||
+          foreignKey.onDelete === 'SET NULL'
+        ) {
+          throw new Error(
+            `[DDL:${engine}] Foreign key ${source}.${foreignKey.column} uses ON DELETE ${foreignKey.onDelete}, which DuckDB does not support. Use PostgreSQL/SQLite or keep this relationship app-side only with @crossPackageRef.`,
+          );
+        }
+        if (foreignKey.onUpdate !== undefined) {
+          throw new Error(
+            `[DDL:${engine}] Foreign key ${source}.${foreignKey.column} uses ON UPDATE ${foreignKey.onUpdate}, which DuckDB does not support. DuckDB cannot preserve SMRT's ON UPDATE CASCADE contract; use PostgreSQL/SQLite or keep this relationship app-side only with @crossPackageRef.`,
+          );
+        }
+        if (isMutualCycle(source, foreignKey.referencesTable)) {
+          throw new Error(
+            `[DDL:${engine}] Foreign-key cycle ${source}.${foreignKey.column} -> ${foreignKey.referencesTable}.${foreignKey.referencesColumn} cannot be created safely because DuckDB does not support ALTER TABLE ADD CONSTRAINT.`,
+          );
+        }
+      }
+    }
+  }
+
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+  const orderedNames: string[] = [];
+  const visit = (name: string): void => {
+    if (visited.has(name) || visiting.has(name)) return;
+    visiting.add(name);
+    for (const dependency of dependencies.get(name) || []) visit(dependency);
+    visiting.delete(name);
+    visited.add(name);
+    orderedNames.push(name);
+  };
+  for (const name of names) visit(name);
+
+  const deferred: Array<{ table: string; foreignKey: ForeignKeyDefinition }> =
+    [];
+  const schemas = orderedNames.map((name) => {
+    const schema = byName.get(name) as SchemaDefinition;
+    if (engine !== 'postgres') return schema;
+    const omitted = new Set<string>();
+    for (const foreignKey of schemaForeignKeys(schema)) {
+      if (isMutualCycle(name, foreignKey.referencesTable)) {
+        omitted.add(foreignKey.column);
+        deferred.push({ table: name, foreignKey });
+      }
+    }
+    return omitForeignKeys(schema, omitted);
+  });
+
+  deferred.sort((a, b) =>
+    `${a.table}.${a.foreignKey.column}`.localeCompare(
+      `${b.table}.${b.foreignKey.column}`,
+    ),
+  );
+  return {
+    schemas,
+    cyclicTables: names.filter(
+      (name) => (componentSizes.get(components.get(name) ?? -1) || 0) > 1,
+    ),
+    deferredConstraints: deferred,
+    deferredStatements: deferred.map(
+      ({ table, foreignKey }) =>
+        `ALTER TABLE ${quoteIdentifier(table)} ADD ${renderForeignKeyConstraint(table, foreignKey)};`,
+    ),
+  };
+}

--- a/packages/core/src/schema/foreign-key-policy.ts
+++ b/packages/core/src/schema/foreign-key-policy.ts
@@ -1,0 +1,61 @@
+import type { ForeignKeyAction } from './types.js';
+
+const FOREIGN_KEY_ACTIONS = new Set<ForeignKeyAction>([
+  'CASCADE',
+  'SET NULL',
+  'RESTRICT',
+  'NO ACTION',
+]);
+
+/** Normalize decorator action spelling into the SQL vocabulary. */
+export function normalizeForeignKeyAction(
+  value: unknown,
+): ForeignKeyAction | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim().toUpperCase().replace(/_/g, ' ');
+  return FOREIGN_KEY_ACTIONS.has(normalized as ForeignKeyAction)
+    ? (normalized as ForeignKeyAction)
+    : undefined;
+}
+
+/** Validate an externally supplied action rather than interpolating raw SQL. */
+export function requireForeignKeyAction(
+  value: unknown,
+  context: string,
+): ForeignKeyAction {
+  const normalized = normalizeForeignKeyAction(value);
+  if (!normalized) {
+    throw new Error(
+      `Invalid foreign-key action ${JSON.stringify(value)} for ${context}. Expected CASCADE, SET NULL, RESTRICT, or NO ACTION.`,
+    );
+  }
+  return normalized;
+}
+
+/**
+ * Resolve the one delete policy shared by app-side cascade and database DDL.
+ *
+ * A same-package reference that identifies the referencing row defaults to
+ * CASCADE. Tenant ids are scope markers rather than ownership edges, and all
+ * other references default to SQL NO ACTION.
+ */
+export function resolveForeignKeyDeleteAction(options: {
+  declared?: unknown;
+  isConflictColumn: boolean;
+  isTenantIdField: boolean;
+}): { action: ForeignKeyAction; declared: boolean } {
+  const declaredAction =
+    options.declared === undefined
+      ? undefined
+      : requireForeignKeyAction(options.declared, 'ON DELETE');
+  if (declaredAction) {
+    return { action: declaredAction, declared: true };
+  }
+  return {
+    action:
+      !options.isTenantIdField && options.isConflictColumn
+        ? 'CASCADE'
+        : 'NO ACTION',
+    declared: false,
+  };
+}

--- a/packages/core/src/schema/generator-branches.test.ts
+++ b/packages/core/src/schema/generator-branches.test.ts
@@ -24,6 +24,7 @@ import type {
   SmartObjectDefinition,
   SmartObjectManifest,
 } from '../scanner/types.js';
+import { generateDDLForEngine } from './ddl/index.js';
 import { SchemaGenerator } from './generator.js';
 import type { SchemaDefinition } from './types.js';
 
@@ -233,6 +234,69 @@ describe('SchemaGenerator.generateSchemaFromRegistry', () => {
     // Reference columns share one naming scheme across every path (#2359).
     expect(schema.indexes.some((i) => i.name === 'docs_owner_id_idx')).toBe(
       true,
+    );
+  });
+
+  it('keeps tenantId indexed/reference-typed without a physical foreign key', () => {
+    const fields = new Map<string, any>([
+      [
+        'tenantId',
+        {
+          type: 'foreignKey',
+          related: '@happyvertical/smrt-users:Tenant',
+          _meta: { __tenancy: { isTenantIdField: true } },
+        },
+      ],
+    ]);
+    const schema = generator.generateSchemaFromRegistry(
+      'ScopedDoc',
+      'scoped_docs',
+      fields,
+    );
+    expect(schema.columns.tenant_id.referenceKind).toBe('tenantId');
+    expect(schema.columns.tenant_id.foreignKey).toBeUndefined();
+    expect(schema.foreignKeys).toEqual([]);
+    expect(
+      schema.indexes.some((index) => index.columns[0] === 'tenant_id'),
+    ).toBe(true);
+  });
+
+  it('keeps crossPackageRef indexed without a physical foreign key', () => {
+    const fields = new Map<string, any>([
+      [
+        'profileId',
+        {
+          type: 'crossPackageRef',
+          related: '@happyvertical/smrt-profiles:Profile',
+        },
+      ],
+    ]);
+    const schema = generator.generateSchemaFromRegistry('Doc', 'docs', fields);
+    expect(schema.columns.profile_id.foreignKey).toBeUndefined();
+    expect(schema.foreignKeys).toEqual([]);
+    expect(generateDDLForEngine(schema, 'postgres').createTable).not.toContain(
+      'FOREIGN KEY',
+    );
+  });
+
+  it('keeps an unresolved same-package reference indexed without a phantom constraint', () => {
+    const fields = new Map<string, any>([
+      ['missingId', { type: 'foreignKey', related: 'MissingModel' }],
+    ]);
+    const schema = generator.generateSchemaFromRegistry('Doc', 'docs', fields, {
+      registry: {
+        getSTIBase: () => undefined,
+        getTableName: () => undefined,
+      } as any,
+    });
+    expect(schema.columns.missing_id.referenceKind).toBe('foreignKey');
+    expect(schema.columns.missing_id.foreignKey).toBeUndefined();
+    expect(schema.foreignKeys).toEqual([]);
+    expect(
+      schema.indexes.some((index) => index.columns[0] === 'missing_id'),
+    ).toBe(true);
+    expect(generateDDLForEngine(schema, 'postgres').createTable).not.toContain(
+      'FOREIGN KEY',
     );
   });
 

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -251,6 +251,11 @@ export class SchemaGenerator {
       const column = columns[columnName];
       if (!column) continue;
 
+      if (field._meta?.constraint === false) {
+        column.foreignKey = undefined;
+        continue;
+      }
+
       const isTenantIdField =
         field.__tenancy?.isTenantIdField === true ||
         field._meta?.__tenancy?.isTenantIdField === true;
@@ -1141,6 +1146,7 @@ export class SchemaGenerator {
       // Handle foreign keys
       if (
         field.type === 'foreignKey' &&
+        field._meta?.constraint !== false &&
         field._meta?.__tenancy?.isTenantIdField !== true
       ) {
         // Type cast to access relationship-specific properties
@@ -1483,6 +1489,7 @@ export class SchemaGenerator {
         // Handle foreign keys
         if (
           field.type === 'foreignKey' &&
+          field._meta?.constraint !== false &&
           field._meta?.__tenancy?.isTenantIdField !== true
         ) {
           const relatedName = field.related; // Top-level property

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -22,6 +22,7 @@ import {
 } from './conflict-target.js';
 import { getDDLStrategy } from './ddl/index.js';
 import type { DatabaseEngine } from './ddl/types.js';
+import { resolveForeignKeyDeleteAction } from './foreign-key-policy.js';
 import {
   assertIdentifierFits,
   enforceIdentifierLimits,
@@ -93,7 +94,9 @@ type SchemaGeneratorConfig = {
     getConfig?(className: string): { idType?: 'uuid' | 'text' };
     getDescendants(baseClassName: string): string[];
     getAllFields(className: string): Promise<Map<string, RegistryField>>;
+    getFields?(className: string): Map<string, RegistryField>;
     getSTIBase?(className: string): string | null;
+    getTableName?(className: string): string | undefined;
   };
 };
 
@@ -232,6 +235,56 @@ export class SchemaGenerator {
           type: targetIdType,
         };
       }
+    }
+  }
+
+  private applyRegistryForeignKeys(
+    columns: Record<string, ColumnDefinition>,
+    fields: Map<string, RegistryField>,
+    conflictColumns: readonly string[],
+    registry: SchemaGeneratorConfig['registry'] | undefined,
+  ): void {
+    const conflictSet = new Set(conflictColumns);
+    for (const [fieldName, field] of fields.entries()) {
+      if (field.type !== 'foreignKey' || !field.related) continue;
+      const columnName = this.toSnakeCase(fieldName);
+      const column = columns[columnName];
+      if (!column) continue;
+
+      const isTenantIdField =
+        field.__tenancy?.isTenantIdField === true ||
+        field._meta?.__tenancy?.isTenantIdField === true;
+      if (isTenantIdField) {
+        column.foreignKey = undefined;
+        continue;
+      }
+
+      const [targetName, declaredTargetColumn] = field.related.split('.');
+      const targetBase = registry?.getSTIBase?.(targetName) || targetName;
+      const registeredTargetTable = registry?.getTableName?.(targetBase);
+      if (registry && !registeredTargetTable) {
+        column.foreignKey = undefined;
+        continue;
+      }
+      const targetColumn =
+        declaredTargetColumn ||
+        Array.from(registry?.getFields?.(targetBase)?.entries() || []).find(
+          ([, targetField]) => targetField._meta?.primaryKey === true,
+        )?.[0] ||
+        'id';
+      const targetTable =
+        registeredTargetTable || this.classNameToTableName(targetBase);
+      const { action } = resolveForeignKeyDeleteAction({
+        declared: field._meta?.onDelete,
+        isConflictColumn: conflictSet.has(columnName),
+        isTenantIdField,
+      });
+      column.foreignKey = {
+        table: targetTable,
+        column: this.toSnakeCase(targetColumn),
+        onDelete: action,
+        onUpdate: 'CASCADE',
+      };
     }
   }
 
@@ -1086,7 +1139,10 @@ export class SchemaGenerator {
       // or with an explicit field option, not by silently changing schema semantics
 
       // Handle foreign keys
-      if (field.type === 'foreignKey') {
+      if (
+        field.type === 'foreignKey' &&
+        field._meta?.__tenancy?.isTenantIdField !== true
+      ) {
         // Type cast to access relationship-specific properties
         const relatedName = field.related; // Top-level property
         const onDeleteAction = field._meta?.onDelete;
@@ -1141,6 +1197,14 @@ export class SchemaGenerator {
       config?.registry,
     );
 
+    const resolvedConflict = this.resolveConflictTarget('cti', columns, config);
+    this.applyRegistryForeignKeys(
+      columns,
+      fields,
+      resolvedConflict.conflictColumns,
+      config?.registry,
+    );
+
     // Generate indexes. No `<table>_id_idx`: the primary key is already a
     // unique index on every engine, and the second B-tree over the same
     // random UUIDs cost writes on 238/238 tables for nothing (#2359, A5).
@@ -1150,11 +1214,7 @@ export class SchemaGenerator {
     if (!hasCustomPK) {
       // Tenant-scoped tables key on `(tenant_id, slug, context)` under the
       // stable `<table>_slug_context_idx` name (#2360).
-      const { conflictColumns, tenantColumn } = this.resolveConflictTarget(
-        'cti',
-        columns,
-        config,
-      );
+      const { conflictColumns, tenantColumn } = resolvedConflict;
       if (!this.conflictColumnsArePrimaryKey(conflictColumns, columns)) {
         indexes.push({
           name: conflictIndexName(tableName, conflictColumns, tenantColumn),
@@ -1205,7 +1265,9 @@ export class SchemaGenerator {
       indexes,
       triggers: [],
       foreignKeys: this.extractForeignKeys(columns),
-      dependencies: [],
+      dependencies: this.extractForeignKeys(columns)
+        .map((foreignKey) => foreignKey.referencesTable)
+        .filter((dependency) => dependency !== tableName),
       version: createHash('sha256')
         .update(JSON.stringify(columns))
         .digest('hex')
@@ -1419,7 +1481,10 @@ export class SchemaGenerator {
         }
 
         // Handle foreign keys
-        if (field.type === 'foreignKey') {
+        if (
+          field.type === 'foreignKey' &&
+          field._meta?.__tenancy?.isTenantIdField !== true
+        ) {
           const relatedName = field.related; // Top-level property
           const onDeleteAction = field._meta?.onDelete;
 
@@ -1462,11 +1527,18 @@ export class SchemaGenerator {
       };
     }
 
+    const resolvedConflict = this.resolveConflictTarget('sti', columns, config);
     for (const className of allClassNames) {
       const classFields = await ObjectRegistry.getAllFields(className);
       this.reconcileRegistryForeignKeyColumnTypes(
         columns,
         classFields,
+        ObjectRegistry,
+      );
+      this.applyRegistryForeignKeys(
+        columns,
+        classFields,
+        resolvedConflict.conflictColumns,
         ObjectRegistry,
       );
     }
@@ -1553,7 +1625,9 @@ export class SchemaGenerator {
       indexes,
       triggers: [],
       foreignKeys: this.extractForeignKeys(columns),
-      dependencies: [],
+      dependencies: this.extractForeignKeys(columns)
+        .map((foreignKey) => foreignKey.referencesTable)
+        .filter((dependency) => dependency !== tableName),
       version: createHash('sha256')
         .update(JSON.stringify({ columns, baseClassName, descendants }))
         .digest('hex')
@@ -1812,8 +1886,14 @@ export class SchemaGenerator {
         jsonPath: idx.jsonPath,
       })),
       triggers: [],
-      foreignKeys: [],
-      dependencies: [],
+      foreignKeys: this.extractForeignKeys(
+        this.convertManifestColumnsToSchemaColumns(columns),
+      ),
+      dependencies: this.extractForeignKeys(
+        this.convertManifestColumnsToSchemaColumns(columns),
+      )
+        .map((foreignKey) => foreignKey.referencesTable)
+        .filter((dependency) => dependency !== tableName),
       version: '',
       packageName: '',
     };
@@ -2013,8 +2093,14 @@ export class SchemaGenerator {
         jsonPath: idx.jsonPath,
       })),
       triggers: [],
-      foreignKeys: [],
-      dependencies: [],
+      foreignKeys: this.extractForeignKeys(
+        this.convertManifestColumnsToSchemaColumns(columns),
+      ),
+      dependencies: this.extractForeignKeys(
+        this.convertManifestColumnsToSchemaColumns(columns),
+      )
+        .map((foreignKey) => foreignKey.referencesTable)
+        .filter((dependency) => dependency !== tableName),
       version: '',
       packageName: '',
     };
@@ -2124,6 +2210,7 @@ export class SchemaGenerator {
         notNull: col.notNull,
         unique: col.unique,
         defaultValue: col.default,
+        foreignKey: col.foreignKey ? { ...col.foreignKey } : undefined,
       };
     }
 

--- a/packages/core/src/schema/index.ts
+++ b/packages/core/src/schema/index.ts
@@ -5,6 +5,19 @@
 export { SchemaCodeGenerator } from './code-generator.js';
 // Re-export DDL strategies for per-engine schema generation
 export * from './ddl/index.js';
+export {
+  foreignKeyConstraintName,
+  renderForeignKeyConstraint,
+  schemaForeignKeys,
+} from './foreign-key-ddl.js';
+export {
+  type ForeignKeyCreationPlan,
+  planForeignKeyCreation,
+} from './foreign-key-planner.js';
+export {
+  normalizeForeignKeyAction,
+  resolveForeignKeyDeleteAction,
+} from './foreign-key-policy.js';
 export { SchemaGenerator } from './generator.js';
 // Live-schema parity check (#2368)
 export {

--- a/packages/core/src/schema/issue-2413-foreign-keys-postgres.optional.test.ts
+++ b/packages/core/src/schema/issue-2413-foreign-keys-postgres.optional.test.ts
@@ -1,0 +1,185 @@
+import { randomUUID } from 'node:crypto';
+import { getDatabase } from '@happyvertical/sql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { MigrationGenerator } from '../migrations/generator.js';
+import { generateDDLForEngine } from './ddl/index.js';
+import { foreignKeyConstraintName } from './foreign-key-ddl.js';
+import { SchemaManager } from './schema-manager.js';
+import type { SchemaDefinition } from './types.js';
+
+const pgUrl = process.env.DATABASE_URL ?? process.env.SMRT_TEST_POSTGRES_URL;
+const suffix = `${process.pid}_${Math.random().toString(36).slice(2, 7)}`;
+const parents = `i2413_parents_${suffix}`;
+const children = `i2413_children_${suffix}`;
+const cycleLeft = `i2413_cycle_left_${suffix}`;
+const cycleRight = `i2413_cycle_right_${suffix}`;
+const managerLeft = `I2413_Manager_Left_${suffix}`;
+const managerRight = `I2413_Manager_Right_${suffix}`;
+
+function schema(
+  tableName: string,
+  foreignKey?: SchemaDefinition['foreignKeys'][number],
+): SchemaDefinition {
+  return {
+    tableName,
+    columns: {
+      id: { type: 'UUID', primaryKey: true },
+      ...(foreignKey
+        ? {
+            [foreignKey.column]: {
+              type: 'UUID' as const,
+              foreignKey: {
+                table: foreignKey.referencesTable,
+                column: foreignKey.referencesColumn,
+                onDelete: foreignKey.onDelete,
+                onUpdate: foreignKey.onUpdate,
+              },
+            },
+          }
+        : {}),
+    },
+    indexes: [],
+    triggers: [],
+    foreignKeys: foreignKey ? [foreignKey] : [],
+    dependencies: foreignKey ? [foreignKey.referencesTable] : [],
+    version: '2413',
+  };
+}
+
+describe.skipIf(!pgUrl)('database foreign keys on PostgreSQL (#2413)', () => {
+  let db: Awaited<ReturnType<typeof getDatabase>>;
+
+  beforeAll(async () => {
+    db = await getDatabase({
+      type: 'postgres',
+      url: pgUrl,
+      dbid: `smrt-test-2413-${randomUUID()}`,
+      max: 2,
+    } as Parameters<typeof getDatabase>[0]);
+    await db.query(
+      generateDDLForEngine(schema(parents), 'postgres').createTable,
+    );
+    await db.query(
+      generateDDLForEngine(
+        schema(children, {
+          column: 'parent_id',
+          referencesTable: parents,
+          referencesColumn: 'id',
+          onDelete: 'CASCADE',
+          onUpdate: 'CASCADE',
+        }),
+        'postgres',
+      ).createTable,
+    );
+  });
+
+  afterAll(async () => {
+    if (!db) return;
+    await db.query(`DROP TABLE IF EXISTS "${cycleLeft}" CASCADE`);
+    await db.query(`DROP TABLE IF EXISTS "${cycleRight}" CASCADE`);
+    await db.query(`DROP TABLE IF EXISTS "${managerLeft}" CASCADE`);
+    await db.query(`DROP TABLE IF EXISTS "${managerRight}" CASCADE`);
+    await db.query(`DROP TABLE IF EXISTS "${children}"`);
+    await db.query(`DROP TABLE IF EXISTS "${parents}"`);
+    await db.close?.();
+  });
+
+  it('creates the named constraint and cascades independently of the model layer', async () => {
+    const foreignKey = {
+      column: 'parent_id',
+      referencesTable: parents,
+      referencesColumn: 'id',
+      onDelete: 'CASCADE' as const,
+      onUpdate: 'CASCADE' as const,
+    };
+    const parentId = randomUUID();
+    const childId = randomUUID();
+    await db.query(`INSERT INTO "${parents}" (id) VALUES ($1)`, [parentId]);
+    await db.query(
+      `INSERT INTO "${children}" (id, parent_id) VALUES ($1, $2)`,
+      [childId, parentId],
+    );
+    await db.query(`DELETE FROM "${parents}" WHERE id = $1`, [parentId]);
+
+    expect(await db.count(children, { id: childId })).toBe(0);
+    const result = await db.query(
+      `SELECT conname FROM pg_constraint WHERE conrelid = $1::regclass AND contype = 'f'`,
+      [children],
+    );
+    expect(result.rows?.[0]?.conname).toBe(
+      foreignKeyConstraintName(children, foreignKey),
+    );
+  });
+
+  it('applies and rolls back a mutual cycle with deferred constraints', async () => {
+    const left = schema(cycleLeft, {
+      column: 'right_id',
+      referencesTable: cycleRight,
+      referencesColumn: 'id',
+      onDelete: 'NO ACTION',
+      onUpdate: 'CASCADE',
+    });
+    const right = schema(cycleRight, {
+      column: 'left_id',
+      referencesTable: cycleLeft,
+      referencesColumn: 'id',
+      onDelete: 'NO ACTION',
+      onUpdate: 'CASCADE',
+    });
+    const migration = new MigrationGenerator({
+      engine: 'postgres',
+    }).generateFromDiff(
+      {
+        has_changes: true,
+        added_tables: [right, left],
+        dropped_tables: [],
+        changes: [],
+      },
+      { name: 'issue_2413_postgres_cycle' },
+    );
+
+    for (const statement of migration.up) await db.query(statement);
+    const constraints = await db.query(
+      `SELECT count(*)::int AS count FROM pg_constraint WHERE conrelid IN ($1::regclass, $2::regclass) AND contype = 'f'`,
+      [cycleLeft, cycleRight],
+    );
+    expect(Number(constraints.rows?.[0]?.count)).toBe(2);
+
+    for (const statement of migration.down) await db.query(statement);
+    const remaining = await db.query(
+      `SELECT to_regclass($1) AS left_table, to_regclass($2) AS right_table`,
+      [cycleLeft, cycleRight],
+    );
+    expect(remaining.rows?.[0]).toMatchObject({
+      left_table: null,
+      right_table: null,
+    });
+  });
+
+  it('creates deferred cycle constraints idempotently through SchemaManager', async () => {
+    const left = schema(managerLeft, {
+      column: 'right_id',
+      referencesTable: managerRight,
+      referencesColumn: 'id',
+      onDelete: 'NO ACTION',
+      onUpdate: 'CASCADE',
+    });
+    const right = schema(managerRight, {
+      column: 'left_id',
+      referencesTable: managerLeft,
+      referencesColumn: 'id',
+      onDelete: 'NO ACTION',
+      onUpdate: 'CASCADE',
+    });
+    const manager = new SchemaManager(db, { engine: 'postgres' });
+
+    await manager.ensureTables([right, left]);
+    await manager.ensureTables([right, left]);
+
+    const constraints = await db.query(
+      `SELECT count(*)::int AS count FROM pg_constraint AS constraint_row JOIN pg_class AS table_row ON table_row.oid = constraint_row.conrelid WHERE table_row.relname IN ($1, $2) AND constraint_row.contype = 'f'`,
+      [managerLeft, managerRight],
+    );
+    expect(Number(constraints.rows?.[0]?.count)).toBe(2);
+  });
+});

--- a/packages/core/src/schema/issue-2413-foreign-keys-postgres.optional.test.ts
+++ b/packages/core/src/schema/issue-2413-foreign-keys-postgres.optional.test.ts
@@ -2,6 +2,9 @@ import { randomUUID } from 'node:crypto';
 import { getDatabase } from '@happyvertical/sql';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { MigrationGenerator } from '../migrations/generator.js';
+import { SmrtObject } from '../object.js';
+import { smrt } from '../registry.js';
+import { getTestDatabase } from '../testing/database.js';
 import { generateDDLForEngine } from './ddl/index.js';
 import { foreignKeyConstraintName } from './foreign-key-ddl.js';
 import { SchemaManager } from './schema-manager.js';
@@ -15,6 +18,10 @@ const cycleLeft = `i2413_cycle_left_${suffix}`;
 const cycleRight = `i2413_cycle_right_${suffix}`;
 const managerLeft = `I2413_Manager_Left_${suffix}`;
 const managerRight = `I2413_Manager_Right_${suffix}`;
+const helperTable = 'i2413_existing_db_helper';
+
+@smrt({ tableName: 'i2413_existing_db_helper' })
+class I2413ExistingDatabaseHelper extends SmrtObject {}
 
 function schema(
   tableName: string,
@@ -79,6 +86,7 @@ describe.skipIf(!pgUrl)('database foreign keys on PostgreSQL (#2413)', () => {
     await db.query(`DROP TABLE IF EXISTS "${cycleRight}" CASCADE`);
     await db.query(`DROP TABLE IF EXISTS "${managerLeft}" CASCADE`);
     await db.query(`DROP TABLE IF EXISTS "${managerRight}" CASCADE`);
+    await db.query(`DROP TABLE IF EXISTS "${helperTable}" CASCADE`);
     await db.query(`DROP TABLE IF EXISTS "${children}"`);
     await db.query(`DROP TABLE IF EXISTS "${parents}"`);
     await db.close?.();
@@ -109,6 +117,20 @@ describe.skipIf(!pgUrl)('database foreign keys on PostgreSQL (#2413)', () => {
     expect(result.rows?.[0]?.conname).toBe(
       foreignKeyConstraintName(children, foreignKey),
     );
+  });
+
+  it('infers PostgreSQL DDL when getTestDatabase receives only an existing db', async () => {
+    await getTestDatabase({
+      db,
+      classes: [I2413ExistingDatabaseHelper.name],
+      includeSystemTables: false,
+    });
+
+    const result = await db.query(
+      `SELECT data_type FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = $1 AND column_name = 'id'`,
+      [helperTable],
+    );
+    expect(result.rows?.[0]?.data_type).toBe('uuid');
   });
 
   it('applies and rolls back a mutual cycle with deferred constraints', async () => {

--- a/packages/core/src/schema/issue-2413-foreign-keys.test.ts
+++ b/packages/core/src/schema/issue-2413-foreign-keys.test.ts
@@ -149,11 +149,13 @@ describe('same-package foreign-key policy (#2413)', () => {
 });
 
 describe('deterministic creation planning (#2413)', () => {
-  it('preserves PostgreSQL DDL when preparing an existing test database', () => {
+  it('infers PostgreSQL DDL from an existing test database without a type override', () => {
     expect(
-      resolveTestDatabaseDDLEngine('postgres', {
-        query: async () => [],
-      } as never),
+      resolveTestDatabaseDDLEngine(
+        undefined,
+        { url: 'postgresql://localhost/smrt_test' } as never,
+        true,
+      ),
     ).toBe('postgres');
   });
 

--- a/packages/core/src/schema/issue-2413-foreign-keys.test.ts
+++ b/packages/core/src/schema/issue-2413-foreign-keys.test.ts
@@ -563,4 +563,75 @@ describe('existing-table orphan safety (#2413)', () => {
     expect(change?.sqlStatements).toBeUndefined();
     expect(change?.advisory?.message).toMatch(/Repair them, then rerun/);
   });
+
+  it('defers the orphan check when the FK column is added in the same PostgreSQL diff', async () => {
+    const mock = postgresMock(false);
+    mock.db.getTableSchema = async () => ({
+      columns: {
+        id: { name: 'id', type: 'text', primaryKey: true },
+      },
+      indexes: [],
+      foreignKeys: [],
+    });
+
+    const diff = await new SchemaComparer(mock.db as never, {
+      engineHint: 'postgres',
+    }).compare({ children: child });
+    const foreignKey = diff.changes.find(
+      (candidate) => candidate.type === 'add_foreign_key',
+    );
+
+    expect(diff.changes.some((change) => change.type === 'add_column')).toBe(
+      true,
+    );
+    expect(mock.queries.some((sql) => sql.includes('orphan_key'))).toBe(false);
+    expect(foreignKey?.sqlStatements).toEqual([
+      'ALTER TABLE "children" ADD CONSTRAINT "children_parent_id_parents_id_fkey" FOREIGN KEY ("parent_id") REFERENCES "parents" ("id") ON DELETE NO ACTION ON UPDATE CASCADE NOT VALID',
+      'ALTER TABLE "children" VALIDATE CONSTRAINT "children_parent_id_parents_id_fkey"',
+    ]);
+  });
+
+  it('normalizes accepted manifest action spellings before live comparison', async () => {
+    const mock = postgresMock(false);
+    mock.db.getTableSchema = async () => ({
+      columns: {
+        id: { name: 'id', type: 'text', primaryKey: true },
+        parent_id: { name: 'parent_id', type: 'text' },
+      },
+      indexes: [],
+      foreignKeys: [
+        {
+          column: 'parent_id',
+          referencesTable: 'parents',
+          referencesColumn: 'id',
+          onDelete: 'SET NULL',
+          onUpdate: 'CASCADE',
+        },
+      ],
+    });
+    const legacyActions = structuredClone(child);
+    legacyActions.foreignKeys[0].onDelete = 'set_null' as ForeignKeyAction;
+    legacyActions.foreignKeys[0].onUpdate = 'cascade' as ForeignKeyAction;
+
+    const diff = await new SchemaComparer(mock.db as never, {
+      engineHint: 'postgres',
+    }).compare({ children: legacyActions });
+
+    expect(
+      diff.changes.some((change) => change.type === 'add_foreign_key'),
+    ).toBe(false);
+    expect(mock.queries.some((sql) => sql.includes('orphan_key'))).toBe(false);
+  });
+
+  it('rejects invalid manifest actions during live comparison', async () => {
+    const mock = postgresMock(false);
+    const invalid = structuredClone(child);
+    invalid.foreignKeys[0].onDelete = 'surprise' as ForeignKeyAction;
+
+    await expect(
+      new SchemaComparer(mock.db as never, {
+        engineHint: 'postgres',
+      }).compare({ children: invalid }),
+    ).rejects.toThrow(/Invalid foreign-key action/);
+  });
 });

--- a/packages/core/src/schema/issue-2413-foreign-keys.test.ts
+++ b/packages/core/src/schema/issue-2413-foreign-keys.test.ts
@@ -2,6 +2,7 @@ import { getDatabase } from '@happyvertical/sql';
 import { describe, expect, it } from 'vitest';
 import { SchemaComparer } from '../migrations/differ.js';
 import { MigrationGenerator } from '../migrations/generator.js';
+import { resolveTestDatabaseDDLEngine } from '../testing/database.js';
 import { generateDDLForEngine } from './ddl/index.js';
 import {
   foreignKeyConstraintName,
@@ -148,6 +149,14 @@ describe('same-package foreign-key policy (#2413)', () => {
 });
 
 describe('deterministic creation planning (#2413)', () => {
+  it('preserves PostgreSQL DDL when preparing an existing test database', () => {
+    expect(
+      resolveTestDatabaseDDLEngine('postgres', {
+        query: async () => [],
+      } as never),
+    ).toBe('postgres');
+  });
+
   it('orders an acyclic graph parent-first on every supported engine', () => {
     const parent = schema('parents');
     const child = schema('children', {

--- a/packages/core/src/schema/issue-2413-foreign-keys.test.ts
+++ b/packages/core/src/schema/issue-2413-foreign-keys.test.ts
@@ -159,6 +159,35 @@ describe('deterministic creation planning (#2413)', () => {
     ).toBe('postgres');
   });
 
+  it('keeps explicit native DuckDB separate from JSON-on-DuckDB', () => {
+    expect(
+      resolveTestDatabaseDDLEngine('duckdb', {
+        exportTable: () => undefined,
+      } as never),
+    ).toBe('duckdb');
+    expect(
+      resolveTestDatabaseDDLEngine(
+        undefined,
+        {
+          exportTable: () => undefined,
+          inferSchemaFromJSON: () => undefined,
+        } as never,
+        true,
+      ),
+    ).toBe('json');
+    expect(
+      resolveTestDatabaseDDLEngine(
+        undefined,
+        {
+          exportTable: () => undefined,
+          getTableSchema: () => undefined,
+          alterTable: { addColumn: () => undefined },
+        } as never,
+        true,
+      ),
+    ).toBe('duckdb');
+  });
+
   it('orders an acyclic graph parent-first on every supported engine', () => {
     const parent = schema('parents');
     const child = schema('children', {

--- a/packages/core/src/schema/issue-2413-foreign-keys.test.ts
+++ b/packages/core/src/schema/issue-2413-foreign-keys.test.ts
@@ -1,0 +1,526 @@
+import { getDatabase } from '@happyvertical/sql';
+import { describe, expect, it } from 'vitest';
+import { SchemaComparer } from '../migrations/differ.js';
+import { MigrationGenerator } from '../migrations/generator.js';
+import { generateDDLForEngine } from './ddl/index.js';
+import {
+  foreignKeyConstraintName,
+  renderForeignKeyConstraint,
+  schemaForeignKeys,
+} from './foreign-key-ddl.js';
+import { planForeignKeyCreation } from './foreign-key-planner.js';
+import { resolveForeignKeyDeleteAction } from './foreign-key-policy.js';
+import { identifierByteLength, MAX_IDENTIFIER_BYTES } from './index-utils.js';
+import type { ForeignKeyAction, SchemaDefinition } from './types.js';
+
+function schema(
+  tableName: string,
+  foreignKey?: {
+    column: string;
+    table: string;
+    onDelete?: ForeignKeyAction;
+  },
+): SchemaDefinition {
+  const columns: SchemaDefinition['columns'] = {
+    id: { type: 'TEXT', primaryKey: true },
+  };
+  if (foreignKey) {
+    columns[foreignKey.column] = {
+      type: 'TEXT',
+      foreignKey: {
+        table: foreignKey.table,
+        column: 'id',
+        onDelete: foreignKey.onDelete ?? 'NO ACTION',
+        onUpdate: 'CASCADE',
+      },
+    };
+  }
+  const foreignKeys = schemaForeignKeys({ columns, foreignKeys: [] });
+  return {
+    tableName,
+    columns,
+    indexes: [],
+    triggers: [],
+    foreignKeys,
+    dependencies: foreignKeys.map((fk) => fk.referencesTable),
+    version: '2413',
+  };
+}
+
+function withoutUpdateAction(input: SchemaDefinition): SchemaDefinition {
+  const foreignKeys = schemaForeignKeys(input).map((foreignKey) => ({
+    ...foreignKey,
+    onUpdate: undefined,
+  }));
+  return {
+    ...input,
+    columns: Object.fromEntries(
+      Object.entries(input.columns).map(([name, column]) => [
+        name,
+        column.foreignKey
+          ? {
+              ...column,
+              foreignKey: { ...column.foreignKey, onUpdate: undefined },
+            }
+          : column,
+      ]),
+    ),
+    foreignKeys,
+  };
+}
+
+describe('same-package foreign-key policy (#2413)', () => {
+  it('maps declared actions, natural keys, ordinary references, and tenancy exclusions explicitly', () => {
+    expect(resolveForeignKeyDeleteAction({ declared: 'SET NULL' }).action).toBe(
+      'SET NULL',
+    );
+    expect(
+      resolveForeignKeyDeleteAction({ isConflictColumn: true }).action,
+    ).toBe('CASCADE');
+    expect(resolveForeignKeyDeleteAction({}).action).toBe('NO ACTION');
+    expect(
+      resolveForeignKeyDeleteAction({
+        isConflictColumn: true,
+        isTenantIdField: true,
+      }).action,
+    ).toBe('NO ACTION');
+  });
+
+  it('emits deterministic named constraints with the resolved action', () => {
+    const child = schema('line_items', {
+      column: 'order_id',
+      table: 'orders',
+      onDelete: 'CASCADE',
+    });
+    const name = foreignKeyConstraintName(
+      child.tableName,
+      child.foreignKeys[0],
+    );
+    const postgres = generateDDLForEngine(child, 'postgres').createTable;
+    const sqlite = generateDDLForEngine(child, 'sqlite').createTable;
+
+    expect(name).toBe('line_items_order_id_orders_id_fkey');
+    for (const ddl of [postgres, sqlite]) {
+      expect(ddl).toContain(`CONSTRAINT "${name}"`);
+      expect(ddl).toContain(
+        'FOREIGN KEY ("order_id") REFERENCES "orders" ("id") ON DELETE CASCADE ON UPDATE CASCADE',
+      );
+    }
+  });
+
+  it('bounds long constraint identifiers without losing deterministic identity', () => {
+    const child = schema(
+      'stakeholder_coordination_workshop_registration_records',
+      {
+        column: 'primary_organizational_account_identifier',
+        table: 'stakeholder_coordination_workshop_organizations',
+      },
+    );
+    const name = foreignKeyConstraintName(
+      child.tableName,
+      child.foreignKeys[0],
+    );
+    expect(identifierByteLength(name)).toBeLessThanOrEqual(
+      MAX_IDENTIFIER_BYTES,
+    );
+    expect(
+      foreignKeyConstraintName(child.tableName, child.foreignKeys[0]),
+    ).toBe(name);
+  });
+
+  it('rejects invalid manifest actions instead of interpolating them into SQL', () => {
+    expect(() =>
+      renderForeignKeyConstraint('children', {
+        column: 'parent_id',
+        referencesTable: 'parents',
+        referencesColumn: 'id',
+        onDelete: 'CASCADE; DROP TABLE parents' as ForeignKeyAction,
+      }),
+    ).toThrow(/Invalid foreign-key action/);
+    expect(() =>
+      resolveForeignKeyDeleteAction({
+        declared: 'surprise',
+        isConflictColumn: false,
+        isTenantIdField: false,
+      }),
+    ).toThrow(/Invalid foreign-key action/);
+  });
+});
+
+describe('deterministic creation planning (#2413)', () => {
+  it('orders an acyclic graph parent-first on every supported engine', () => {
+    const parent = schema('parents');
+    const child = schema('children', {
+      column: 'parent_id',
+      table: 'parents',
+    });
+    for (const engine of ['postgres', 'sqlite'] as const) {
+      expect(
+        planForeignKeyCreation([child, parent], engine).schemas.map(
+          (item) => item.tableName,
+        ),
+      ).toEqual(['parents', 'children']);
+    }
+    expect(
+      planForeignKeyCreation(
+        [withoutUpdateAction(child), parent],
+        'duckdb',
+      ).schemas.map((item) => item.tableName),
+    ).toEqual(['parents', 'children']);
+  });
+
+  it('applies the shared order in generated migration SQL', () => {
+    const parent = schema('parents');
+    const child = schema('children', {
+      column: 'parent_id',
+      table: 'parents',
+    });
+    const migration = new MigrationGenerator({ engine: 'postgres' })
+      .generateFromDiff(
+        {
+          has_changes: true,
+          added_tables: [child, parent],
+          dropped_tables: [],
+          changes: [],
+        },
+        { name: 'issue_2413_order' },
+      )
+      .up.join('\n');
+    expect(
+      migration.indexOf('CREATE TABLE IF NOT EXISTS "parents"'),
+    ).toBeLessThan(migration.indexOf('CREATE TABLE IF NOT EXISTS "children"'));
+  });
+
+  it('drops children before parents and removes deferred cycle constraints first', () => {
+    const parent = schema('parents');
+    const child = schema('children', {
+      column: 'parent_id',
+      table: 'parents',
+    });
+    const acyclic = new MigrationGenerator({ engine: 'postgres' })
+      .generateFromDiff(
+        {
+          has_changes: true,
+          added_tables: [child, parent],
+          dropped_tables: [],
+          changes: [],
+        },
+        { name: 'issue_2413_down_order' },
+      )
+      .down.join('\n');
+    expect(acyclic.indexOf('DROP TABLE IF EXISTS "children"')).toBeLessThan(
+      acyclic.indexOf('DROP TABLE IF EXISTS "parents"'),
+    );
+
+    const left = schema('left_nodes', {
+      column: 'right_id',
+      table: 'right_nodes',
+    });
+    const right = schema('right_nodes', {
+      column: 'left_id',
+      table: 'left_nodes',
+    });
+    const cyclic = new MigrationGenerator({
+      engine: 'postgres',
+    }).generateFromDiff(
+      {
+        has_changes: true,
+        added_tables: [right, left],
+        dropped_tables: [],
+        changes: [],
+      },
+      { name: 'issue_2413_cycle_down' },
+    ).down;
+    expect(cyclic.slice(0, 2)).toEqual([
+      expect.stringMatching(/^ALTER TABLE .* DROP CONSTRAINT IF EXISTS /),
+      expect.stringMatching(/^ALTER TABLE .* DROP CONSTRAINT IF EXISTS /),
+    ]);
+    expect(cyclic.slice(2).every((sql) => sql.startsWith('DROP TABLE'))).toBe(
+      true,
+    );
+  });
+
+  it('keeps SQLite cycles inline, defers PostgreSQL cycles, and refuses DuckDB cycles', () => {
+    const left = schema('left_nodes', {
+      column: 'right_id',
+      table: 'right_nodes',
+    });
+    const right = schema('right_nodes', {
+      column: 'left_id',
+      table: 'left_nodes',
+    });
+
+    const sqlite = planForeignKeyCreation([right, left], 'sqlite');
+    expect(sqlite.deferredStatements).toEqual([]);
+    expect(sqlite.schemas.every((item) => item.foreignKeys.length === 1)).toBe(
+      true,
+    );
+
+    const postgres = planForeignKeyCreation([right, left], 'postgres');
+    expect(
+      postgres.schemas.every((item) => item.foreignKeys.length === 0),
+    ).toBe(true);
+    expect(postgres.deferredStatements).toHaveLength(2);
+    expect(postgres.deferredStatements[0]).toMatch(
+      /^ALTER TABLE "left_nodes" ADD CONSTRAINT /,
+    );
+
+    expect(() =>
+      planForeignKeyCreation(
+        [withoutUpdateAction(right), withoutUpdateAction(left)],
+        'duckdb',
+      ),
+    ).toThrow(/DuckDB does not support ALTER TABLE ADD CONSTRAINT/);
+    expect(() =>
+      planForeignKeyCreation(
+        [withoutUpdateAction(right), withoutUpdateAction(left)],
+        'json',
+      ),
+    ).toThrow(
+      /\[DDL:json\].*DuckDB does not support ALTER TABLE ADD CONSTRAINT/,
+    );
+  });
+
+  it('refuses unsupported DuckDB actions and self-reference instead of emitting a green no-op', () => {
+    const cascade = schema('children', {
+      column: 'parent_id',
+      table: 'parents',
+      onDelete: 'CASCADE',
+    });
+    expect(() => planForeignKeyCreation([cascade], 'duckdb')).toThrow(
+      /DuckDB does not support/,
+    );
+    expect(() => generateDDLForEngine(cascade, 'duckdb')).toThrow(
+      /DuckDB does not support/,
+    );
+    const updateCascade = schema('children', {
+      column: 'parent_id',
+      table: 'parents',
+    });
+    expect(() => planForeignKeyCreation([updateCascade], 'duckdb')).toThrow(
+      /ON UPDATE CASCADE.*does not support/,
+    );
+    expect(() => generateDDLForEngine(updateCascade, 'duckdb')).toThrow(
+      /ON UPDATE CASCADE.*does not support/,
+    );
+    expect(() =>
+      generateDDLForEngine(
+        schema('nodes', { column: 'parent_id', table: 'nodes' }),
+        'duckdb',
+      ),
+    ).toThrow(/self-referential/);
+  });
+});
+
+describe('SQLite database enforcement (#2413)', () => {
+  it('enforces CASCADE and NO ACTION on real SQLite DDL', async () => {
+    const db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    await db.query('PRAGMA foreign_keys = ON');
+    await db.query(
+      generateDDLForEngine(schema('parents'), 'sqlite').createTable,
+    );
+    await db.query(
+      generateDDLForEngine(
+        schema('cascade_children', {
+          column: 'parent_id',
+          table: 'parents',
+          onDelete: 'CASCADE',
+        }),
+        'sqlite',
+      ).createTable,
+    );
+    await db.query(
+      generateDDLForEngine(
+        schema('guarded_children', {
+          column: 'parent_id',
+          table: 'parents',
+        }),
+        'sqlite',
+      ).createTable,
+    );
+
+    await db.query("INSERT INTO parents (id) VALUES ('cascade-parent')");
+    await db.query(
+      "INSERT INTO cascade_children (id, parent_id) VALUES ('child', 'cascade-parent')",
+    );
+    await db.query("DELETE FROM parents WHERE id = 'cascade-parent'");
+    expect(await db.count('cascade_children')).toBe(0);
+
+    await db.query("INSERT INTO parents (id) VALUES ('guarded-parent')");
+    await db.query(
+      "INSERT INTO guarded_children (id, parent_id) VALUES ('guard', 'guarded-parent')",
+    );
+    await expect(
+      db.query("DELETE FROM parents WHERE id = 'guarded-parent'"),
+    ).rejects.toThrow();
+    expect(await db.count('parents', { id: 'guarded-parent' })).toBe(1);
+  });
+
+  it('rolls back populated mutual cycles by deferring checks until commit', async () => {
+    const db = await getDatabase({ type: 'sqlite', url: ':memory:' });
+    const left = schema('rollback_left', {
+      column: 'right_id',
+      table: 'rollback_right',
+    });
+    const right = schema('rollback_right', {
+      column: 'left_id',
+      table: 'rollback_left',
+    });
+    const migration = new MigrationGenerator({
+      engine: 'sqlite',
+    }).generateFromDiff(
+      {
+        has_changes: true,
+        added_tables: [right, left],
+        dropped_tables: [],
+        changes: [],
+      },
+      { name: 'issue_2413_sqlite_cycle_down' },
+    );
+    expect(migration.down[0]).toBe('PRAGMA defer_foreign_keys = ON');
+    for (const statement of migration.up) await db.query(statement);
+    await db.query("INSERT INTO rollback_left (id) VALUES ('left')");
+    await db.query(
+      "INSERT INTO rollback_right (id, left_id) VALUES ('right', 'left')",
+    );
+    await db.query(
+      "UPDATE rollback_left SET right_id = 'right' WHERE id = 'left'",
+    );
+
+    await db.query('BEGIN');
+    for (const statement of migration.down) await db.query(statement);
+    await db.query('COMMIT');
+    const remaining = await db.query(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('rollback_left', 'rollback_right')",
+    );
+    expect(remaining.rows).toEqual([]);
+  });
+});
+
+describe('DuckDB database enforcement (#2413)', () => {
+  it('enforces its supported NO ACTION constraint and refuses unsafe actions elsewhere', async () => {
+    const db = await getDatabase({ type: 'duckdb', url: ':memory:' });
+    try {
+      await db.query(
+        generateDDLForEngine(schema('duck_parents'), 'duckdb').createTable,
+      );
+      await db.query(
+        generateDDLForEngine(
+          withoutUpdateAction(
+            schema('duck_children', {
+              column: 'parent_id',
+              table: 'duck_parents',
+            }),
+          ),
+          'duckdb',
+        ).createTable,
+      );
+
+      await db.query("INSERT INTO duck_parents (id) VALUES ('parent')");
+      await db.query(
+        "INSERT INTO duck_children (id, parent_id) VALUES ('child', 'parent')",
+      );
+      await expect(
+        db.query("DELETE FROM duck_parents WHERE id = 'parent'"),
+      ).rejects.toThrow();
+      await expect(
+        db.query(
+          "INSERT INTO duck_children (id, parent_id) VALUES ('orphan', 'missing')",
+        ),
+      ).rejects.toThrow();
+    } finally {
+      await db.close?.();
+    }
+  });
+});
+
+describe('existing-table orphan safety (#2413)', () => {
+  const child = schema('children', {
+    column: 'parent_id',
+    table: 'parents',
+  });
+
+  function postgresMock(orphan: boolean) {
+    const queries: string[] = [];
+    return {
+      queries,
+      db: {
+        url: 'postgres://fixture/issue2413',
+        query: async (sql: string) => {
+          queries.push(sql);
+          if (sql.includes('information_schema.tables')) {
+            return { rows: [{ table_name: 'children' }] };
+          }
+          if (sql.includes('orphan_key')) {
+            return { rows: orphan ? [{ orphan_key: 'missing-parent' }] : [] };
+          }
+          return { rows: [] };
+        },
+        getTableSchema: async () => ({
+          columns: {
+            id: { name: 'id', type: 'text', primaryKey: true },
+            parent_id: { name: 'parent_id', type: 'text' },
+          },
+          indexes: [],
+          foreignKeys: [],
+        }),
+      },
+    };
+  }
+
+  it('probes the exact child/parent target before adding and validating on PostgreSQL', async () => {
+    const mock = postgresMock(false);
+    const diff = await new SchemaComparer(mock.db as never, {
+      engineHint: 'postgres',
+    }).compare({ children: child });
+    const change = diff.changes.find(
+      (candidate) => candidate.type === 'add_foreign_key',
+    );
+
+    expect(mock.queries.find((sql) => sql.includes('orphan_key'))).toContain(
+      'FROM "children" LEFT JOIN "parents" ON "parents"."id" = "children"."parent_id"',
+    );
+    expect(change?.sqlStatements).toEqual([
+      'ALTER TABLE "children" ADD CONSTRAINT "children_parent_id_parents_id_fkey" FOREIGN KEY ("parent_id") REFERENCES "parents" ("id") ON DELETE NO ACTION ON UPDATE CASCADE NOT VALID',
+      'ALTER TABLE "children" VALIDATE CONSTRAINT "children_parent_id_parents_id_fkey"',
+    ]);
+  });
+
+  it('refuses automatic add when an orphan exists and returns detector/repair guidance', async () => {
+    const mock = postgresMock(true);
+    const diff = await new SchemaComparer(mock.db as never, {
+      engineHint: 'postgres',
+    }).compare({ children: child });
+    const change = diff.changes.find(
+      (candidate) => candidate.type === 'add_foreign_key',
+    );
+
+    expect(change?.sqlStatements).toBeUndefined();
+    expect(change?.advisory?.message).toMatch(/Repair them, then rerun/);
+    expect(change?.advisory?.suggestedSql).toHaveLength(2);
+    expect(change?.advisory?.suggestedSql?.[0]).toContain(
+      'FROM "children" LEFT JOIN "parents"',
+    );
+  });
+
+  it('refuses automatic add when a bare-array adapter result contains an orphan', async () => {
+    const mock = postgresMock(false);
+    const originalQuery = mock.db.query;
+    mock.db.query = async (sql: string) => {
+      if (sql.includes('orphan_key')) {
+        return [{ orphan_key: 'missing-parent' }] as never;
+      }
+      return originalQuery(sql);
+    };
+
+    const diff = await new SchemaComparer(mock.db as never, {
+      engineHint: 'postgres',
+    }).compare({ children: child });
+    const change = diff.changes.find(
+      (candidate) => candidate.type === 'add_foreign_key',
+    );
+
+    expect(change?.sqlStatements).toBeUndefined();
+    expect(change?.advisory?.message).toMatch(/Repair them, then rerun/);
+  });
+});

--- a/packages/core/src/schema/manifest-schema.ts
+++ b/packages/core/src/schema/manifest-schema.ts
@@ -137,14 +137,30 @@ export function manifestIndexesToDefinitions(
 export function manifestSchemaToDefinition(
   schema: ManifestSchemaLike,
 ): SchemaDefinition {
+  const columns = manifestColumnsToDefinitions(schema.columns);
+  const foreignKeys = Object.entries(columns).flatMap(([column, definition]) =>
+    definition.foreignKey
+      ? [
+          {
+            column,
+            referencesTable: definition.foreignKey.table,
+            referencesColumn: definition.foreignKey.column,
+            onDelete: definition.foreignKey.onDelete,
+            onUpdate: definition.foreignKey.onUpdate,
+          },
+        ]
+      : [],
+  );
   return {
     tableName: schema.tableName,
     ddl: schema.ddl,
-    columns: manifestColumnsToDefinitions(schema.columns),
+    columns,
     indexes: manifestIndexesToDefinitions(schema.indexes),
     triggers: [],
-    foreignKeys: [],
-    dependencies: [],
+    foreignKeys,
+    dependencies: foreignKeys
+      .map((foreignKey) => foreignKey.referencesTable)
+      .filter((dependency) => dependency !== schema.tableName),
     version: schema.version ?? '',
   };
 }
@@ -198,6 +214,22 @@ export function mergeSchemaDefinitionInto(
       target.indexes.push(index);
     }
   }
+  const foreignKeyKeys = new Set(
+    target.foreignKeys.map(
+      (foreignKey) =>
+        `${foreignKey.column}\0${foreignKey.referencesTable}\0${foreignKey.referencesColumn}`,
+    ),
+  );
+  for (const foreignKey of incoming.foreignKeys) {
+    const key = `${foreignKey.column}\0${foreignKey.referencesTable}\0${foreignKey.referencesColumn}`;
+    if (!foreignKeyKeys.has(key)) {
+      foreignKeyKeys.add(key);
+      target.foreignKeys.push(foreignKey);
+    }
+  }
+  target.dependencies = Array.from(
+    new Set([...target.dependencies, ...incoming.dependencies]),
+  ).sort();
 }
 
 /**

--- a/packages/core/src/schema/schema-aggregator.ts
+++ b/packages/core/src/schema/schema-aggregator.ts
@@ -38,11 +38,35 @@ import { discoverSmrtPackages } from '../manifest/discover-smrt-packages.js';
 import { loadExternalManifestSync } from '../manifest/manifest-loader.js';
 import type { SmartObjectManifest } from '../scanner/types.js';
 import type { DatabaseEngine } from './ddl/types.js';
+import { planForeignKeyCreation } from './foreign-key-planner.js';
 import {
+  type CollectedManifestTable,
   collectManifestTables,
   type ManifestColumnLike,
   renderCollectedManifestTable,
 } from './manifest-schema.js';
+
+function referencesFilteredTable(
+  ddl: string,
+  filteredTables: ReadonlySet<string>,
+): string | undefined {
+  for (const tableName of filteredTables) {
+    const quoted = tableName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const sqlQuoted = tableName
+      .replaceAll('"', '""')
+      .replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const qualifier = '(?:"(?:[^"]|"")*"|[A-Za-z_][A-Za-z0-9_$]*)';
+    if (
+      new RegExp(
+        `\\bREFERENCES\\s+(?:${qualifier}\\s*\\.\\s*)*(?:"${sqlQuoted}"|${quoted})(?![A-Za-z0-9_$"])`,
+        'i',
+      ).test(ddl)
+    ) {
+      return tableName;
+    }
+  }
+  return undefined;
+}
 
 // ============================================================================
 // Types
@@ -76,6 +100,12 @@ export interface AggregatedTable {
    * per column name, matching the rendered DDL.
    */
   columns?: Record<string, ManifestColumnLike>;
+  /** Structured schema retained so combined SQL can use dependency planning. */
+  definition: CollectedManifestTable['definition'];
+  /** Whether every contributing manifest provided structured columns. */
+  structured: boolean;
+  /** Cached DDL retained only for legacy column-less contributors. */
+  legacyDdl: string;
 }
 
 /**
@@ -212,9 +242,9 @@ export class SchemaAggregator {
     );
 
     // 4. Apply minimal filtering if requested
-    if (options.minimal) {
-      this.applyMinimalFilter(tables, options);
-    }
+    const filteredTables = options.minimal
+      ? this.applyMinimalFilter(tables, options)
+      : new Set<string>();
 
     // 5. Count STI tables and total objects
     let stiTables = 0;
@@ -227,7 +257,7 @@ export class SchemaAggregator {
     }
 
     // 6. Generate combined SQL
-    const sql = this.generateSQL(tables, options);
+    const sql = this.generateSQL(tables, options, filteredTables);
 
     return {
       tables,
@@ -350,6 +380,9 @@ export class SchemaAggregator {
         indexes: rendered.indexes,
         sources: table.sources,
         columns: manifestColumns.get(tableName),
+        definition: table.definition,
+        structured: table.structured,
+        legacyDdl: table.legacyDdl,
       });
     }
 
@@ -362,23 +395,27 @@ export class SchemaAggregator {
   private applyMinimalFilter(
     tables: Map<string, AggregatedTable>,
     options: AggregateOptions,
-  ): void {
+  ): Set<string> {
     const skipPatterns =
       options.minimalSkipPatterns || DEFAULT_MINIMAL_SKIP_PATTERNS;
     const skipTables = new Set(options.minimalSkipTables || []);
+    const removed = new Set<string>();
 
     for (const tableName of Array.from(tables.keys())) {
       if (skipTables.has(tableName)) {
         tables.delete(tableName);
+        removed.add(tableName);
         continue;
       }
       for (const pattern of skipPatterns) {
         if (pattern.test(tableName)) {
           tables.delete(tableName);
+          removed.add(tableName);
           break;
         }
       }
     }
+    return removed;
   }
 
   /**
@@ -387,6 +424,7 @@ export class SchemaAggregator {
   private generateSQL(
     tables: Map<string, AggregatedTable>,
     options: AggregateOptions,
+    filteredTables: ReadonlySet<string>,
   ): string {
     const lines: string[] = [
       '-- Combined SMRT Database Schema',
@@ -398,27 +436,79 @@ export class SchemaAggregator {
       lines.push('PRAGMA foreign_keys = ON;', '');
     }
 
-    // Sort tables by name for deterministic output
-    const sortedTables = Array.from(tables.entries()).sort((a, b) =>
-      a[0].localeCompare(b[0]),
+    const engine: DatabaseEngine =
+      options.dialect === 'sqlite' ? 'sqlite' : 'postgres';
+    if (filteredTables.size > 0) {
+      for (const table of tables.values()) {
+        const unsafeLegacyTarget =
+          !table.structured &&
+          referencesFilteredTable(table.legacyDdl, filteredTables);
+        if (unsafeLegacyTarget) {
+          throw new Error(
+            `[SchemaAggregator] Cannot safely generate minimal schema: legacy cached DDL for "${table.tableName}" references filtered table "${unsafeLegacyTarget}". Publish structured columns/foreignKeys for every contributor or keep the referenced table in the aggregate.`,
+          );
+        }
+        table.definition = {
+          ...table.definition,
+          columns: Object.fromEntries(
+            Object.entries(table.definition.columns).map(([name, column]) => [
+              name,
+              column.foreignKey && filteredTables.has(column.foreignKey.table)
+                ? { ...column, foreignKey: undefined }
+                : column,
+            ]),
+          ),
+          foreignKeys: table.definition.foreignKeys.filter(
+            (foreignKey) => !filteredTables.has(foreignKey.referencesTable),
+          ),
+          dependencies: table.definition.dependencies.filter(
+            (dependency) => !filteredTables.has(dependency),
+          ),
+        };
+      }
+    }
+    const plan = planForeignKeyCreation(
+      [...tables.values()].map((table) => table.definition),
+      engine,
     );
 
-    for (const [tableName, table] of sortedTables) {
+    for (const definition of plan.schemas) {
+      const tableName = definition.tableName;
+      const table = tables.get(tableName) as AggregatedTable;
+      const rendered = renderCollectedManifestTable(
+        {
+          tableName,
+          definition,
+          structured: table.structured,
+          legacyDdl: table.legacyDdl,
+          sources: table.sources,
+        },
+        engine,
+      );
+      // Keep the structured result and its cached presentation consistent with
+      // the executable aggregate after minimal filtering and cycle planning.
+      table.ddl = rendered.createTable;
+      table.indexes = rendered.indexes;
       lines.push(`-- Table: ${tableName}`);
       if (table.sources.length > 1) {
         lines.push(`-- STI table, sources: ${table.sources.join(', ')}`);
       } else {
         lines.push(`-- Source: ${table.sources[0]}`);
       }
-      lines.push(table.ddl);
+      lines.push(rendered.createTable);
       lines.push('');
 
-      if (table.indexes.length > 0) {
-        for (const idx of table.indexes) {
+      if (rendered.indexes.length > 0) {
+        for (const idx of rendered.indexes) {
           lines.push(idx);
         }
         lines.push('');
       }
+    }
+
+    if (plan.deferredStatements.length > 0) {
+      lines.push('-- Deferred foreign-key constraints');
+      lines.push(...plan.deferredStatements, '');
     }
 
     return lines.join('\n');

--- a/packages/core/src/schema/schema-aggregator.ts
+++ b/packages/core/src/schema/schema-aggregator.ts
@@ -475,6 +475,7 @@ export class SchemaAggregator {
     for (const definition of plan.schemas) {
       const tableName = definition.tableName;
       const table = tables.get(tableName) as AggregatedTable;
+      table.definition = definition;
       const rendered = renderCollectedManifestTable(
         {
           tableName,

--- a/packages/core/src/schema/schema-manager-branches.test.ts
+++ b/packages/core/src/schema/schema-manager-branches.test.ts
@@ -445,7 +445,7 @@ describe('SchemaManager addMissingColumns edge cases', () => {
 describe('SchemaManager dependency sorting', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('warns and proceeds when a circular dependency is detected', async () => {
+  it('creates every table in a declared dependency cycle', async () => {
     const created: string[] = [];
     const db = {
       url: 'sqlite::memory:',
@@ -469,10 +469,8 @@ describe('SchemaManager dependency sorting', () => {
     const manager = new SchemaManager(db, { engine: 'sqlite' });
     await manager.ensureTables([a, b]);
 
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Circular dependency detected involving'),
-    );
-    // Both tables still get created despite the cycle.
+    // SQLite accepts cycle constraints inline, so deterministic planning may
+    // choose either member first and still creates both safely.
     expect(created).toContain('a');
     expect(created).toContain('b');
   });
@@ -492,5 +490,174 @@ describe('SchemaManager dependency sorting', () => {
 
     const manager = new SchemaManager(db, { engine: 'sqlite' });
     await expect(manager.ensureTables([schema])).resolves.toBeUndefined();
+  });
+
+  it('adds PostgreSQL cycle constraints safely and remains idempotent', async () => {
+    const tables = new Set<string>();
+    const constraints = new Set<string>();
+    const query = vi.fn(async (sql: string, params?: unknown[]) => {
+      const create = sql.match(/^CREATE TABLE IF NOT EXISTS "([^"]+)"/);
+      if (create) tables.add(create[1]);
+      if (sql.includes('FROM pg_constraint')) {
+        return {
+          rows: constraints.has(String(params?.[1]))
+            ? [{ convalidated: true }]
+            : [],
+        };
+      }
+      if (sql.includes(' AS orphan_key ')) return { rows: [] };
+      const add = sql.match(/ADD CONSTRAINT "([^"]+)"/);
+      if (add) constraints.add(add[1]);
+      return { rows: [] };
+    });
+    const db = {
+      url: 'postgres://localhost/test',
+      query,
+      tableExists: vi.fn(async (name: string) => tables.has(name)),
+    } as any;
+    const left: SchemaDefinition = {
+      ...fullSchema('cycle_left'),
+      columns: {
+        ...fullSchema('cycle_left').columns,
+        right_id: {
+          type: 'TEXT',
+          foreignKey: {
+            table: 'cycle_right',
+            column: 'id',
+            onDelete: 'NO ACTION',
+            onUpdate: 'CASCADE',
+          },
+        },
+      },
+      dependencies: ['cycle_right'],
+    };
+    const right: SchemaDefinition = {
+      ...fullSchema('cycle_right'),
+      columns: {
+        ...fullSchema('cycle_right').columns,
+        left_id: {
+          type: 'TEXT',
+          foreignKey: {
+            table: 'cycle_left',
+            column: 'id',
+            onDelete: 'NO ACTION',
+            onUpdate: 'CASCADE',
+          },
+        },
+      },
+      dependencies: ['cycle_left'],
+    };
+
+    const manager = new SchemaManager(db, { engine: 'postgres' });
+    await manager.ensureTables([left, right]);
+    await manager.ensureTables([left, right]);
+
+    expect(constraints.size).toBe(2);
+    expect(
+      query.mock.calls.filter(([sql]) =>
+        String(sql).includes(' ADD CONSTRAINT '),
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('retries validation without re-adding an existing NOT VALID cycle constraint', async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM pg_constraint')) {
+        return { rows: [{ convalidated: false }] };
+      }
+      if (sql.includes(' AS orphan_key ')) return { rows: [] };
+      return { rows: [] };
+    });
+    const left: SchemaDefinition = {
+      ...fullSchema('pending_left'),
+      columns: {
+        ...fullSchema('pending_left').columns,
+        right_id: {
+          type: 'TEXT',
+          foreignKey: { table: 'pending_right', column: 'id' },
+        },
+      },
+      dependencies: ['pending_right'],
+    };
+    const right: SchemaDefinition = {
+      ...fullSchema('pending_right'),
+      columns: {
+        ...fullSchema('pending_right').columns,
+        left_id: {
+          type: 'TEXT',
+          foreignKey: { table: 'pending_left', column: 'id' },
+        },
+      },
+      dependencies: ['pending_left'],
+    };
+
+    await new SchemaManager(
+      {
+        url: 'postgres://localhost/test',
+        query,
+        tableExists: vi.fn(async () => true),
+      } as any,
+      { engine: 'postgres' },
+    ).ensureTables([left, right]);
+
+    expect(
+      query.mock.calls.filter(([sql]) =>
+        String(sql).includes(' ADD CONSTRAINT '),
+      ),
+    ).toHaveLength(0);
+    expect(
+      query.mock.calls.filter(([sql]) =>
+        String(sql).includes(' VALIDATE CONSTRAINT '),
+      ),
+    ).toHaveLength(2);
+  });
+
+  it('refuses a deferred PostgreSQL cycle constraint when existing rows are orphaned', async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('information_schema.columns')) {
+        return { rows: [{ column_name: 'id' }, { column_name: 'right_id' }] };
+      }
+      if (sql.includes('FROM pg_constraint')) return { rows: [] };
+      if (sql.includes(' AS orphan_key ')) {
+        return { rows: [{ orphan_key: 'missing' }] };
+      }
+      return { rows: [] };
+    });
+    const db = {
+      url: 'postgres://localhost/test',
+      query,
+      tableExists: vi.fn(async () => true),
+    } as any;
+    const left: SchemaDefinition = {
+      ...fullSchema('orphan_left'),
+      columns: {
+        ...fullSchema('orphan_left').columns,
+        right_id: {
+          type: 'TEXT',
+          foreignKey: { table: 'orphan_right', column: 'id' },
+        },
+      },
+      dependencies: ['orphan_right'],
+    };
+    const right: SchemaDefinition = {
+      ...fullSchema('orphan_right'),
+      columns: {
+        ...fullSchema('orphan_right').columns,
+        left_id: {
+          type: 'TEXT',
+          foreignKey: { table: 'orphan_left', column: 'id' },
+        },
+      },
+      dependencies: ['orphan_left'],
+    };
+
+    await expect(
+      new SchemaManager(db, { engine: 'postgres' }).ensureTables([left, right]),
+    ).rejects.toThrow(/existing rows do not match.*Repair them/);
+    expect(
+      query.mock.calls.some(([sql]) =>
+        String(sql).includes(' ADD CONSTRAINT '),
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/core/src/schema/schema-manager.ts
+++ b/packages/core/src/schema/schema-manager.ts
@@ -16,7 +16,14 @@ import {
   type EngineSpecificDDL,
   getDDLStrategy,
 } from './ddl/index.js';
-import type { SchemaDefinition } from './types.js';
+import {
+  foreignKeyConstraintName,
+  renderForeignKeyConstraint,
+  renderForeignKeyOrphanDetector,
+  renderForeignKeyOrphanRepair,
+} from './foreign-key-ddl.js';
+import { planForeignKeyCreation } from './foreign-key-planner.js';
+import type { ForeignKeyDefinition, SchemaDefinition } from './types.js';
 
 /**
  * Normalize a `db.query` result into an array of rows.
@@ -339,12 +346,62 @@ export class SchemaManager {
    * @param schemas - Array of schema definitions
    */
   async ensureTables(schemas: SchemaDefinition[]): Promise<void> {
-    // Sort by dependencies (topological sort)
-    const sorted = this.sortByDependencies(schemas);
+    const plan = planForeignKeyCreation(schemas, this.engine);
 
-    for (const schema of sorted) {
+    for (const schema of plan.schemas) {
       await this.ensureTable(schema);
     }
+    for (const { table, foreignKey } of plan.deferredConstraints) {
+      await this.ensurePostgresDeferredForeignKey(table, foreignKey);
+    }
+  }
+
+  private async ensurePostgresDeferredForeignKey(
+    tableName: string,
+    foreignKey: ForeignKeyDefinition,
+  ): Promise<void> {
+    const constraintName = foreignKeyConstraintName(tableName, foreignKey);
+    let existing: unknown;
+    try {
+      existing = await this.db.query(
+        `SELECT constraint_row.convalidated FROM pg_constraint AS constraint_row JOIN pg_class AS table_row ON table_row.oid = constraint_row.conrelid JOIN pg_namespace AS namespace_row ON namespace_row.oid = table_row.relnamespace WHERE table_row.relname = $1 AND namespace_row.nspname = current_schema() AND constraint_row.conname = $2 AND constraint_row.contype = 'f' LIMIT 1`,
+        [tableName, constraintName],
+      );
+    } catch (error) {
+      throw new Error(
+        `[SchemaManager] Cannot verify deferred foreign key ${constraintName}; refusing an unsafe duplicate/add attempt: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+    const existingRows = extractRows<{ convalidated?: boolean }>(existing);
+    if (existingRows[0]?.convalidated === true) return;
+
+    const detector = renderForeignKeyOrphanDetector(tableName, foreignKey, {
+      limitOne: true,
+    });
+    let orphanResult: unknown;
+    try {
+      orphanResult = await this.db.query(detector);
+    } catch (error) {
+      throw new Error(
+        `[SchemaManager] Cannot probe ${tableName}.${foreignKey.column} for orphan rows; refusing to add ${constraintName}. Run the detector manually: ${detector}`,
+        { cause: error },
+      );
+    }
+    if (extractRows(orphanResult).length > 0) {
+      throw new Error(
+        `[SchemaManager] Cannot add ${constraintName}: existing rows do not match ${foreignKey.referencesTable}.${foreignKey.referencesColumn}. Repair them, then retry. Suggested repair: ${renderForeignKeyOrphanRepair(tableName, foreignKey)}`,
+      );
+    }
+
+    if (existingRows.length === 0) {
+      await this.db.query(
+        `ALTER TABLE ${this.quoteIdentifier(tableName)} ADD ${renderForeignKeyConstraint(tableName, foreignKey)} NOT VALID`,
+      );
+    }
+    await this.db.query(
+      `ALTER TABLE ${this.quoteIdentifier(tableName)} VALIDATE CONSTRAINT ${this.quoteIdentifier(constraintName)}`,
+    );
   }
 
   /**
@@ -367,56 +424,6 @@ export class SchemaManager {
    */
   getEngine(): DatabaseEngine {
     return this.engine;
-  }
-
-  /**
-   * Sort schemas by dependencies (topological sort)
-   *
-   * Ensures tables are created in the correct order based on foreign key dependencies.
-   */
-  private sortByDependencies(schemas: SchemaDefinition[]): SchemaDefinition[] {
-    const byName = new Map<string, SchemaDefinition>();
-    const sorted: SchemaDefinition[] = [];
-    const visited = new Set<string>();
-    const visiting = new Set<string>();
-
-    // Index by table name
-    for (const schema of schemas) {
-      byName.set(schema.tableName, schema);
-    }
-
-    // DFS topological sort
-    const visit = (tableName: string) => {
-      if (visited.has(tableName)) return;
-      if (visiting.has(tableName)) {
-        // Circular dependency - continue anyway (FK might be nullable)
-        this.logger.warn(
-          `[SchemaManager] Circular dependency detected involving ${tableName}`,
-        );
-        return;
-      }
-
-      const schema = byName.get(tableName);
-      if (!schema) return; // External dependency, skip
-
-      visiting.add(tableName);
-
-      // Visit dependencies first
-      for (const dep of schema.dependencies || []) {
-        visit(dep);
-      }
-
-      visiting.delete(tableName);
-      visited.add(tableName);
-      sorted.push(schema);
-    };
-
-    // Visit all schemas
-    for (const schema of schemas) {
-      visit(schema.tableName);
-    }
-
-    return sorted;
   }
 }
 

--- a/packages/core/src/schema/schema-path-parity.test.ts
+++ b/packages/core/src/schema/schema-path-parity.test.ts
@@ -119,6 +119,11 @@ function buildFixtureManifest(): SmartObjectManifest {
     objectDef('ParityPost', {
       body: { type: 'text' },
       authorId: { type: 'foreignKey', related: 'ParityAuthor' },
+      archiveAuthorId: {
+        type: 'foreignKey',
+        related: 'ParityAuthor',
+        _meta: { constraint: false },
+      },
       profileId: {
         type: 'crossPackageRef',
         related: '@happyvertical/smrt-profiles:Profile',
@@ -837,6 +842,7 @@ describe('schema path parity (#2359)', () => {
 
     it('CTI references: FK + cross-package ref indexed, indexed:true honoured, inline unique kept on the column', () => {
       expect(names('parity_posts')).toEqual([
+        'parity_posts_archive_author_id_idx',
         'parity_posts_author_id_idx',
         'parity_posts_created_at_idx',
         'parity_posts_profile_id_idx',
@@ -856,6 +862,14 @@ describe('schema path parity (#2359)', () => {
       });
       expect(
         manifestSchemas.get('parity_posts')?.columns.profile_id.foreignKey,
+      ).toBeUndefined();
+      expect(
+        manifestSchemas.get('parity_posts')?.columns.archive_author_id
+          .referenceKind,
+      ).toBe('foreignKey');
+      expect(
+        manifestSchemas.get('parity_posts')?.columns.archive_author_id
+          .foreignKey,
       ).toBeUndefined();
     });
 

--- a/packages/core/src/schema/schema-path-parity.test.ts
+++ b/packages/core/src/schema/schema-path-parity.test.ts
@@ -26,7 +26,8 @@
  * This suite is the guard: for a representative set of classes it runs the
  * SAME manifest through the manifest paths, through the registry paths (after
  * `ObjectRegistry.registerFromManifest`) and through
- * `getAllSchemasAsDefinitions()`, and asserts identical column and index sets.
+ * `getAllSchemasAsDefinitions()`, and asserts identical column, foreign-key,
+ * dependency, and index sets.
  * Any generator change must keep the three legs equal — extend the fixture
  * rather than special-casing a path.
  *
@@ -42,8 +43,8 @@
  *   unconsumed vite virtual module and is not held to parity (assessment A8);
  * - custom primary keys (`@field({ primaryKey: true })`) are handled by the
  *   registry CTI path only (assessment A4, #2360);
- * - column metadata that only one family carries (`foreignKey`,
- *   `description`) is not compared; column NAME, TYPE and `referenceKind` are.
+ * - descriptive column metadata is not compared; physical foreign-key metadata
+ *   is part of the parity contract.
  */
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -383,15 +384,31 @@ function buildFixtureManifest(): SmartObjectManifest {
   };
 }
 
-/** Column view compared across paths: name → `type/referenceKind`. */
+/** Column view compared across paths, including physical FK metadata. */
 function columnSet(
-  columns: Record<string, { type: string; referenceKind?: string }>,
+  columns: Record<
+    string,
+    {
+      type: string;
+      referenceKind?: string;
+      foreignKey?: {
+        table: string;
+        column: string;
+        onDelete?: string;
+        onUpdate?: string;
+      };
+    }
+  >,
 ): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [name, col] of Object.entries(columns).sort(([a], [b]) =>
     a.localeCompare(b),
   )) {
-    out[name] = `${String(col.type).toUpperCase()}/${col.referenceKind ?? '-'}`;
+    const fk = col.foreignKey
+      ? `${col.foreignKey.table}.${col.foreignKey.column}/${col.foreignKey.onDelete ?? '-'}/${col.foreignKey.onUpdate ?? '-'}`
+      : '-';
+    out[name] =
+      `${String(col.type).toUpperCase()}/${col.referenceKind ?? '-'}/${fk}`;
   }
   return out;
 }
@@ -429,6 +446,7 @@ function manifestSchemaAsDefinition(
           notNull: col.notNull,
           unique: col.unique,
           defaultValue: col.default,
+          foreignKey: col.foreignKey ? { ...col.foreignKey } : undefined,
         },
       ]),
     ),
@@ -440,8 +458,25 @@ function manifestSchemaAsDefinition(
       jsonPath: idx.jsonPath,
     })),
     triggers: [],
-    foreignKeys: [],
-    dependencies: [],
+    foreignKeys: Object.entries(schema.columns).flatMap(
+      ([column, definition]) =>
+        definition.foreignKey
+          ? [
+              {
+                column,
+                referencesTable: definition.foreignKey.table,
+                referencesColumn: definition.foreignKey.column,
+                onDelete: definition.foreignKey.onDelete,
+                onUpdate: definition.foreignKey.onUpdate,
+              },
+            ]
+          : [],
+    ),
+    dependencies: Object.values(schema.columns)
+      .flatMap((definition) =>
+        definition.foreignKey ? [definition.foreignKey.table] : [],
+      )
+      .filter((dependency) => dependency !== schema.tableName),
     version: schema.version,
   };
 }
@@ -755,9 +790,7 @@ describe('schema path parity (#2359)', () => {
       const migrateColumns = columnSet(migrateSchemas[table]?.columns ?? {});
 
       expect(registryColumns).toEqual(manifestColumns);
-      // getAllSchemasAsDefinitions() merges the manifest schema with the
-      // registry's base columns; the NAME set must match exactly.
-      expect(Object.keys(migrateColumns)).toEqual(Object.keys(manifestColumns));
+      expect(migrateColumns).toEqual(manifestColumns);
     });
 
     it('has the same index set on the manifest, registry and migrate paths', () => {
@@ -771,6 +804,20 @@ describe('schema path parity (#2359)', () => {
 
       expect(registryIndexes).toEqual(manifestIndexes);
       expect(migrateIndexes).toEqual(manifestIndexes);
+    });
+
+    it('has the same foreign keys and dependencies on every path', () => {
+      const shape = (schema: SchemaDefinition | undefined) => ({
+        foreignKeys: [...(schema?.foreignKeys ?? [])].sort((a, b) =>
+          `${a.column}.${a.referencesTable}`.localeCompare(
+            `${b.column}.${b.referencesTable}`,
+          ),
+        ),
+        dependencies: [...(schema?.dependencies ?? [])].sort(),
+      });
+      const manifestShape = shape(manifestSchemas.get(table));
+      expect(shape(registrySchemas.get(table))).toEqual(manifestShape);
+      expect(shape(migrateSchemas[table])).toEqual(manifestShape);
     });
   });
 
@@ -799,6 +846,17 @@ describe('schema path parity (#2359)', () => {
       expect(manifestSchemas.get('parity_authors')?.columns.email.unique).toBe(
         true,
       );
+      expect(
+        manifestSchemas.get('parity_posts')?.columns.author_id.foreignKey,
+      ).toEqual({
+        table: 'parity_authors',
+        column: 'id',
+        onDelete: 'NO ACTION',
+        onUpdate: 'CASCADE',
+      });
+      expect(
+        manifestSchemas.get('parity_posts')?.columns.profile_id.foreignKey,
+      ).toBeUndefined();
     });
 
     it('tenant-scoped + custom conflict key leading with tenant_id: (tenant_id, created_at) instead of a standalone tenant index, slug lookup kept (A7, #2363)', () => {
@@ -813,6 +871,9 @@ describe('schema path parity (#2359)', () => {
       expect(names('parity_scopeds')).not.toContain(
         'parity_scopeds_tenant_id_idx',
       );
+      expect(
+        manifestSchemas.get('parity_scopeds')?.columns.tenant_id.foreignKey,
+      ).toBeUndefined();
       const ordering = idx('parity_scopeds').find(
         (i) => i.name === 'parity_scopeds_tenant_id_created_at_idx',
       );
@@ -858,6 +919,15 @@ describe('schema path parity (#2359)', () => {
         'parity_links_right_id_idx',
         'parity_links_slug_context_idx',
       ]);
+      for (const column of ['left_id', 'right_id']) {
+        expect(
+          manifestSchemas.get('parity_links')?.columns[column].foreignKey
+            ?.onDelete,
+        ).toBe('CASCADE');
+        expect(migrateSchemas.parity_links.columns[column].foreignKey).toEqual(
+          manifestSchemas.get('parity_links')?.columns[column].foreignKey,
+        );
+      }
     });
 
     it('polymorphic-association-shaped conflict key: owner lookup (meta_type, meta_id) indexed despite sitting mid-index (#2364, A3)', () => {

--- a/packages/core/src/schema/schema-path-parity.test.ts
+++ b/packages/core/src/schema/schema-path-parity.test.ts
@@ -311,7 +311,13 @@ function buildFixtureManifest(): SmartObjectManifest {
   add(
     objectDef(
       'ParityTicket',
-      { code: { type: 'text', required: true } },
+      {
+        code: {
+          type: 'foreignKey',
+          related: 'ParityAuthor.email',
+          required: true,
+        },
+      },
       {
         tableStrategy: 'sti',
         tenantScoped: { mode: 'required' },
@@ -1068,6 +1074,7 @@ describe('schema path parity (#2359)', () => {
 
     it('STI root with custom conflictColumns: honoured on both STI paths, slug lookup kept, child resolves the same key (#2360)', () => {
       expect(names('parity_tickets')).toEqual([
+        'parity_tickets_code_idx',
         'parity_tickets_meta_type_idx',
         'parity_tickets_slug_context_idx',
         'parity_tickets_tenant_id_code_idx',
@@ -1091,6 +1098,16 @@ describe('schema path parity (#2359)', () => {
       expect(
         ObjectRegistry.getConflictColumns(`${PKG}:ParityBugTicket`),
       ).toEqual(['tenant_id', 'code']);
+      for (const [leg, schema] of [
+        ['manifest', manifestSchemas.get('parity_tickets')],
+        ['registry', registrySchemas.get('parity_tickets')],
+        ['migrate', migrateSchemas.parity_tickets],
+      ] as const) {
+        expect(
+          schema?.columns.code.foreignKey?.onDelete,
+          `${leg} STI-root natural-key FK inherited by child`,
+        ).toBe('CASCADE');
+      }
     });
 
     it('STI: plain FK/xref indexes, tenant-led default key serves tenant_id, base-declared unique full, descendant-declared unique partial per class, meta JSON-path index', () => {

--- a/packages/core/src/schema/schema-path-parity.test.ts
+++ b/packages/core/src/schema/schema-path-parity.test.ts
@@ -108,10 +108,14 @@ function buildFixtureManifest(): SmartObjectManifest {
 
   // CTI with an inline-unique column (CTI keeps column-level UNIQUE).
   add(
-    objectDef('ParityAuthor', {
-      name: { type: 'text', required: true },
-      email: { type: 'text', _meta: { unique: true } },
-    }),
+    objectDef(
+      'ParityAuthor',
+      {
+        name: { type: 'text', required: true },
+        email: { type: 'text', _meta: { unique: true } },
+      },
+      { idType: 'text' },
+    ),
   );
 
   // CTI with same-package FK, cross-package ref and an `indexed: true` opt-in.
@@ -852,6 +856,12 @@ describe('schema path parity (#2359)', () => {
       expect(manifestSchemas.get('parity_authors')?.columns.email.unique).toBe(
         true,
       );
+      expect(manifestSchemas.get('parity_authors')?.columns.id.type).toBe(
+        'TEXT',
+      );
+      expect(manifestSchemas.get('parity_posts')?.columns.author_id.type).toBe(
+        'TEXT',
+      );
       expect(
         manifestSchemas.get('parity_posts')?.columns.author_id.foreignKey,
       ).toEqual({
@@ -867,6 +877,9 @@ describe('schema path parity (#2359)', () => {
         manifestSchemas.get('parity_posts')?.columns.archive_author_id
           .referenceKind,
       ).toBe('foreignKey');
+      expect(
+        manifestSchemas.get('parity_posts')?.columns.archive_author_id.type,
+      ).toBe('TEXT');
       expect(
         manifestSchemas.get('parity_posts')?.columns.archive_author_id
           .foreignKey,

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -32,12 +32,18 @@ export interface ColumnDefinition {
   foreignKey?: {
     table: string;
     column: string;
-    onDelete?: 'CASCADE' | 'SET NULL' | 'RESTRICT';
-    onUpdate?: 'CASCADE' | 'SET NULL' | 'RESTRICT';
+    onDelete?: ForeignKeyAction;
+    onUpdate?: ForeignKeyAction;
   };
   check?: string; // CHECK constraint
   description?: string;
 }
+
+export type ForeignKeyAction =
+  | 'CASCADE'
+  | 'SET NULL'
+  | 'RESTRICT'
+  | 'NO ACTION';
 
 export interface IndexDefinition {
   name: string;
@@ -110,8 +116,8 @@ export interface ForeignKeyDefinition {
   column: string;
   referencesTable: string;
   referencesColumn: string;
-  onDelete?: 'CASCADE' | 'SET NULL' | 'RESTRICT';
-  onUpdate?: 'CASCADE' | 'SET NULL' | 'RESTRICT';
+  onDelete?: ForeignKeyAction;
+  onUpdate?: ForeignKeyAction;
 }
 
 export interface SchemaDefinition {
@@ -334,6 +340,7 @@ export interface SchemaChange {
     | 'alter_column'
     | 'orphan_column'
     | 'add_index'
+    | 'add_foreign_key'
     | 'drop_index'
     | 'orphan_index'
     | 'type_mismatch'
@@ -346,6 +353,8 @@ export interface SchemaChange {
   column?: ColumnDefinition;
   /** Index definition (for add_index) */
   index?: IndexDefinition;
+  /** Foreign-key definition (for add_foreign_key). */
+  foreignKey?: ForeignKeyDefinition;
   /**
    * For type mismatches/upgrades: expected vs actual type. For
    * `alter_column`: the expected vs actual constraint rendering (e.g.

--- a/packages/core/src/schema/utils.ts
+++ b/packages/core/src/schema/utils.ts
@@ -14,6 +14,7 @@ import { ObjectRegistry } from '../registry.js';
 import type { FieldDefinition } from '../scanner/types.js';
 import { tableNameFromClass } from '../utils.js';
 import type { DatabaseEngine } from './ddl/types.js';
+import { schemaForeignKeys } from './foreign-key-ddl.js';
 import { SchemaManager } from './schema-manager.js';
 
 export {
@@ -297,9 +298,31 @@ export async function ensureSchema(
     ObjectRegistry.getAllSchemasAsDefinitions()[schemaDefinition.tableName];
   const effectiveSchemaDefinition = mergedSchemaDefinition ?? schemaDefinition;
 
+  // A single requested class can be part of a mutual FK cycle. Build the
+  // complete registered dependency closure and let SchemaManager plan it as
+  // one unit; creating the requested table alone would leave the first
+  // PostgreSQL CREATE referencing a table that does not exist (#2413).
+  const allSchemas = ObjectRegistry.getAllSchemasAsDefinitions();
+  const required = new Map<string, typeof effectiveSchemaDefinition>();
+  const collect = (schema: typeof effectiveSchemaDefinition): void => {
+    if (required.has(schema.tableName)) return;
+    required.set(schema.tableName, schema);
+    const dependencies = new Set([
+      ...schema.dependencies,
+      ...schemaForeignKeys(schema).map(
+        (foreignKey) => foreignKey.referencesTable,
+      ),
+    ]);
+    for (const dependency of dependencies) {
+      const dependencySchema = allSchemas[dependency];
+      if (dependencySchema) collect(dependencySchema);
+    }
+  };
+  collect(effectiveSchemaDefinition);
+
   const schemaManager = new SchemaManager(db, {
     skipTriggers:
       typeof (db as { exportTable?: unknown }).exportTable === 'function',
   });
-  await schemaManager.ensureTable(effectiveSchemaDefinition);
+  await schemaManager.ensureTables([...required.values()]);
 }

--- a/packages/core/src/testing/database.ts
+++ b/packages/core/src/testing/database.ts
@@ -174,8 +174,9 @@ export interface TestDatabaseOptions {
    * - 'sqlite': SQLite database
    * - 'json': JSON adapter (stores data as JSON files with DuckDB for querying)
    * - 'duckdb': Native DuckDB database
+   * - 'postgres': PostgreSQL database (normally supplied through `db`)
    */
-  type?: 'sqlite' | 'json' | 'duckdb';
+  type?: 'sqlite' | 'json' | 'duckdb' | 'postgres';
 
   /**
    * Database URL (default: ':memory:')
@@ -209,6 +210,20 @@ export interface TestDatabaseOptions {
    * fixture uses generated `ON UPDATE CASCADE`, which DuckDB cannot enforce.
    */
   omitForeignKeyConstraints?: boolean;
+}
+
+/** Resolve the DDL dialect used when preparing an existing test database. */
+export function resolveTestDatabaseDDLEngine(
+  type: NonNullable<TestDatabaseOptions['type']>,
+  db: DatabaseInterface,
+): 'sqlite' | 'json' | 'duckdb' | 'postgres' {
+  if (
+    type === 'json' ||
+    typeof (db as { exportTable?: unknown }).exportTable === 'function'
+  ) {
+    return 'json';
+  }
+  return type;
 }
 
 function omitTestForeignKeyConstraints(
@@ -348,13 +363,7 @@ export async function getTestDatabase(
 
   // Use the same schema generation as production
   const schemaGenerator = new SchemaGenerator();
-  const ddlEngine =
-    type === 'json' ||
-    typeof (db as { exportTable?: unknown }).exportTable === 'function'
-      ? 'json'
-      : type === 'duckdb'
-        ? 'duckdb'
-        : 'sqlite';
+  const ddlEngine = resolveTestDatabaseDDLEngine(type, db);
 
   // Collect every table before executing DDL so dependency ordering and cycle
   // handling are identical to production migration/schema paths (#2413).

--- a/packages/core/src/testing/database.ts
+++ b/packages/core/src/testing/database.ts
@@ -218,23 +218,45 @@ export function resolveTestDatabaseDDLEngine(
   db: DatabaseInterface,
   inferFromDatabase = false,
 ): 'sqlite' | 'json' | 'duckdb' | 'postgres' {
-  if (typeof (db as { exportTable?: unknown }).exportTable === 'function') {
+  // When this helper created the adapter, the requested type is authoritative.
+  // Native DuckDB and JSON-on-DuckDB both expose exportTable(), so capability
+  // inference must not override an explicit native DuckDB request.
+  if (!inferFromDatabase) {
+    return type ?? 'sqlite';
+  }
+
+  const configuredDb = db as DatabaseInterface & {
+    config?: { type?: string; url?: string };
+    type?: string;
+    exportTable?: unknown;
+    inferSchemaFromJSON?: unknown;
+    getTableLoadErrors?: unknown;
+  };
+
+  if (
+    typeof configuredDb.inferSchemaFromJSON === 'function' ||
+    typeof configuredDb.getTableLoadErrors === 'function'
+  ) {
     return 'json';
   }
 
-  if (inferFromDatabase) {
-    const configuredDb = db as DatabaseInterface & {
-      config?: { type?: string; url?: string };
-      type?: string;
-    };
-    return detectEngine(
-      db.url || configuredDb.config?.url || '',
-      configuredDb.type || configuredDb.config?.type,
-    );
+  if (typeof configuredDb.exportTable === 'function') {
+    // The native DuckDB adapter exposes schema evolution capabilities that the
+    // JSON adapter does not. Keep exportTable-only test doubles compatible with
+    // the historical JSON structural marker.
+    if (
+      typeof configuredDb.getTableSchema === 'function' &&
+      typeof configuredDb.alterTable?.addColumn === 'function'
+    ) {
+      return 'duckdb';
+    }
+    return 'json';
   }
 
-  if (type === 'json') return 'json';
-  return type ?? 'sqlite';
+  return detectEngine(
+    db.url || configuredDb.config?.url || '',
+    configuredDb.type || configuredDb.config?.type,
+  );
 }
 
 function omitTestForeignKeyConstraints(

--- a/packages/core/src/testing/database.ts
+++ b/packages/core/src/testing/database.ts
@@ -214,16 +214,27 @@ export interface TestDatabaseOptions {
 
 /** Resolve the DDL dialect used when preparing an existing test database. */
 export function resolveTestDatabaseDDLEngine(
-  type: NonNullable<TestDatabaseOptions['type']>,
+  type: TestDatabaseOptions['type'],
   db: DatabaseInterface,
+  inferFromDatabase = false,
 ): 'sqlite' | 'json' | 'duckdb' | 'postgres' {
-  if (
-    type === 'json' ||
-    typeof (db as { exportTable?: unknown }).exportTable === 'function'
-  ) {
+  if (typeof (db as { exportTable?: unknown }).exportTable === 'function') {
     return 'json';
   }
-  return type;
+
+  if (inferFromDatabase) {
+    const configuredDb = db as DatabaseInterface & {
+      config?: { type?: string; url?: string };
+      type?: string;
+    };
+    return detectEngine(
+      db.url || configuredDb.config?.url || '',
+      configuredDb.type || configuredDb.config?.type,
+    );
+  }
+
+  if (type === 'json') return 'json';
+  return type ?? 'sqlite';
 }
 
 function omitTestForeignKeyConstraints(
@@ -329,7 +340,7 @@ export async function getTestDatabase(
   options: TestDatabaseOptions = {},
 ): Promise<DatabaseInterface> {
   const {
-    type = 'sqlite',
+    type,
     url = ':memory:',
     db: existingDb,
     classes,
@@ -341,7 +352,7 @@ export async function getTestDatabase(
   const db =
     existingDb ??
     (await getDatabase({
-      type,
+      type: type ?? 'sqlite',
       url,
       __smrtSkipVitestSchemaPreparation: true,
     } as TestDatabaseConnectionOptions));
@@ -363,7 +374,11 @@ export async function getTestDatabase(
 
   // Use the same schema generation as production
   const schemaGenerator = new SchemaGenerator();
-  const ddlEngine = resolveTestDatabaseDDLEngine(type, db);
+  const ddlEngine = resolveTestDatabaseDDLEngine(
+    type,
+    db,
+    existingDb !== undefined,
+  );
 
   // Collect every table before executing DDL so dependency ordering and cycle
   // handling are identical to production migration/schema paths (#2413).

--- a/packages/core/src/testing/database.ts
+++ b/packages/core/src/testing/database.ts
@@ -27,7 +27,10 @@ import {
 } from '../registry/collection-resolution.js';
 import { ObjectRegistry } from '../registry.js';
 import { detectEngine } from '../schema/ddl/index.js';
+import { schemaForeignKeys } from '../schema/foreign-key-ddl.js';
+import { planForeignKeyCreation } from '../schema/foreign-key-planner.js';
 import { SchemaGenerator } from '../schema/generator.js';
+import type { SchemaDefinition } from '../schema/types.js';
 import { ensureLegacySystemTableCompatibility } from '../system/compatibility.js';
 import { getSystemTableDDL } from '../system/schema.js';
 
@@ -198,6 +201,35 @@ export interface TestDatabaseOptions {
    * System tables include _smrt_contexts, _smrt_migrations, etc.
    */
   includeSystemTables?: boolean;
+
+  /**
+   * Explicitly omit physical FK constraints for adapter/query tests whose
+   * subject is unrelated to referential enforcement. Defaults to `false`.
+   * This is required (and deliberately noisy at the call site) when a DuckDB
+   * fixture uses generated `ON UPDATE CASCADE`, which DuckDB cannot enforce.
+   */
+  omitForeignKeyConstraints?: boolean;
+}
+
+function omitTestForeignKeyConstraints(
+  schema: SchemaDefinition,
+): SchemaDefinition {
+  const foreignKeyTargets = new Set(
+    schemaForeignKeys(schema).map((foreignKey) => foreignKey.referencesTable),
+  );
+  return {
+    ...schema,
+    columns: Object.fromEntries(
+      Object.entries(schema.columns).map(([name, column]) => [
+        name,
+        column.foreignKey ? { ...column, foreignKey: undefined } : column,
+      ]),
+    ),
+    foreignKeys: [],
+    dependencies: schema.dependencies.filter(
+      (dependency) => !foreignKeyTargets.has(dependency),
+    ),
+  };
 }
 
 function resolveRequestedSchemaClassName(className: string): string {
@@ -287,6 +319,7 @@ export async function getTestDatabase(
     db: existingDb,
     classes,
     includeSystemTables = true,
+    omitForeignKeyConstraints = false,
   } = options;
 
   // Use existing database or create new one
@@ -323,8 +356,13 @@ export async function getTestDatabase(
         ? 'duckdb'
         : 'sqlite';
 
-  // Track created tables to avoid duplicates (STI base classes)
-  const createdTables = new Set<string>();
+  // Collect every table before executing DDL so dependency ordering and cycle
+  // handling are identical to production migration/schema paths (#2413).
+  const schemas = new Map<
+    string,
+    { schema: SchemaDefinition; className: string }
+  >();
+  const authoritativeSchemas = ObjectRegistry.getAllSchemasAsDefinitions();
 
   for (const className of classNames) {
     // R11: the registration carries idType (native uuid vs text); read it
@@ -339,7 +377,7 @@ export async function getTestDatabase(
     }
 
     const tableName = ObjectRegistry.getTableName(className);
-    if (!tableName || createdTables.has(tableName)) {
+    if (!tableName || schemas.has(tableName)) {
       continue;
     }
 
@@ -376,17 +414,80 @@ export async function getTestDatabase(
             runtimeSchemaConfig,
           );
 
-    // Generate DDL using generateSQL() - the single source of truth
+    // Manifest registrations can carry explicit FK actions that differ from
+    // decorator defaults. The deterministic merged table schema preserves
+    // those authoritative actions while still backfilling runtime-only fields.
+    const authoritativeSchema = authoritativeSchemas[tableName];
+    const effectiveColumns = authoritativeSchema
+      ? Object.fromEntries(
+          Object.entries(schema.columns).map(([name, column]) => {
+            const manifestColumn = authoritativeSchema.columns[name];
+            return [
+              name,
+              manifestColumn
+                ? { ...column, foreignKey: manifestColumn.foreignKey }
+                : column,
+            ];
+          }),
+        )
+      : schema.columns;
+    const effectiveForeignKeys = schemaForeignKeys({
+      columns: effectiveColumns,
+      foreignKeys: [],
+    });
+    const effectiveSchema: SchemaDefinition = {
+      ...schema,
+      columns: effectiveColumns,
+      foreignKeys: effectiveForeignKeys,
+      dependencies: effectiveForeignKeys
+        .map((foreignKey) => foreignKey.referencesTable)
+        .filter((dependency) => dependency !== tableName),
+    };
+
+    schemas.set(tableName, {
+      schema: omitForeignKeyConstraints
+        ? omitTestForeignKeyConstraints(effectiveSchema)
+        : effectiveSchema,
+      className,
+    });
+  }
+
+  // Explicitly requested test classes still need their registered parents.
+  // Add the authoritative dependency closure so a child-only request cannot
+  // emit a physical reference to a table this helper never creates.
+  const addDependencies = (schema: SchemaDefinition): void => {
+    for (const foreignKey of schemaForeignKeys(schema)) {
+      if (schemas.has(foreignKey.referencesTable)) continue;
+      const dependency = authoritativeSchemas[foreignKey.referencesTable];
+      if (!dependency) continue;
+      const effectiveDependency = omitForeignKeyConstraints
+        ? omitTestForeignKeyConstraints(dependency)
+        : dependency;
+      schemas.set(dependency.tableName, {
+        schema: effectiveDependency,
+        className: dependency.tableName,
+      });
+      addDependencies(effectiveDependency);
+    }
+  };
+  for (const { schema } of [...schemas.values()]) addDependencies(schema);
+
+  const tablePlan = planForeignKeyCreation(
+    [...schemas.values()].map(({ schema }) => schema),
+    ddlEngine,
+  );
+  const ddlStrategy = (await import('../schema/ddl/index.js')).getDDLStrategy(
+    ddlEngine,
+  );
+
+  for (const schema of tablePlan.schemas) {
+    const className = schemas.get(schema.tableName)?.className ?? 'unknown';
     const ddl = schemaGenerator.generateSQL(schema, ddlEngine);
 
     try {
       await db.query(ddl);
-      createdTables.add(tableName);
 
       // Create indexes (use DDL strategy so jsonPath / where / etc. render)
-      const ddlStrategy = (
-        await import('../schema/ddl/index.js')
-      ).getDDLStrategy(ddlEngine);
       const indexStatements = ddlStrategy.generateIndexes(schema);
       for (const indexSQL of indexStatements) {
         try {
@@ -402,7 +503,18 @@ export async function getTestDatabase(
     } catch (error) {
       // Provide helpful error message for table creation failures
       throw new Error(
-        `[getTestDatabase] Failed to create table '${tableName}' for class '${className}': ${error instanceof Error ? error.message : String(error)}`,
+        `[getTestDatabase] Failed to create table '${schema.tableName}' for class '${className}': ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+  }
+
+  for (const statement of tablePlan.deferredStatements) {
+    try {
+      await db.query(statement);
+    } catch (error) {
+      throw new Error(
+        `[getTestDatabase] Failed to add deferred foreign-key constraint: ${error instanceof Error ? error.message : String(error)} (SQL: ${statement})`,
         { cause: error },
       );
     }

--- a/packages/events/src/__tests__/event-collection.test.ts
+++ b/packages/events/src/__tests__/event-collection.test.ts
@@ -13,7 +13,12 @@ import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { Event, EventCollection } from '../index.js';
+import {
+  Event,
+  EventCollection,
+  EventSeriesCollection,
+  EventTypeCollection,
+} from '../index.js';
 
 function getTestDbUrl(name: string): string {
   return `file:${join(tmpdir(), `${name}-${randomUUID()}.db`)}`;
@@ -215,7 +220,17 @@ describe('Event hierarchy', () => {
 
 describe('EventCollection queries', () => {
   it('filters by series, place, type, status, and parent', async () => {
-    const { events } = await makeEvents('coll-filters');
+    const { dbUrl, events } = await makeEvents('coll-filters');
+    const series = await EventSeriesCollection.create({
+      db: { type: 'sqlite', url: dbUrl },
+    });
+    const types = await EventTypeCollection.create({
+      db: { type: 'sqlite', url: dbUrl },
+    });
+    await series.create({ id: 's1', name: 'Series 1' });
+    await series.create({ id: 's2', name: 'Series 2' });
+    await types.create({ id: 't1', name: 'Type 1' });
+    await types.create({ id: 't2', name: 'Type 2' });
 
     const a = await events.create({
       name: 'A',

--- a/packages/events/src/__tests__/event-participants.test.ts
+++ b/packages/events/src/__tests__/event-participants.test.ts
@@ -16,6 +16,7 @@ import {
   EventCollection,
   EventParticipant,
   EventParticipantCollection,
+  EventTypeCollection,
 } from '../index.js';
 
 function getTestDbUrl(name: string): string {
@@ -30,6 +31,21 @@ async function setup(name: string) {
   const events = await EventCollection.create({
     db: { type: 'sqlite', url: dbUrl },
   });
+  for (const eventId of [
+    'e',
+    'e1',
+    'e2',
+    'event-1',
+    'evt',
+    'g',
+    'g1',
+    'g2',
+    'g3',
+    'game',
+    'game-1',
+  ]) {
+    await events.create({ id: eventId, name: `Fixture ${eventId}` });
+  }
   return { dbUrl, participants, events };
 }
 
@@ -274,6 +290,11 @@ describe('EventParticipantCollection', () => {
     const events = await EventCollection.create({
       db: { type: 'sqlite', url: dbUrl },
     });
+    const types = await EventTypeCollection.create({
+      db: { type: 'sqlite', url: dbUrl },
+    });
+    await types.create({ id: 'type-basketball', name: 'Basketball' });
+    await types.create({ id: 'type-soccer', name: 'Soccer' });
 
     const basketball = await events.create({
       name: 'BBall',

--- a/packages/events/src/__tests__/event-series.test.ts
+++ b/packages/events/src/__tests__/event-series.test.ts
@@ -15,6 +15,7 @@ import {
   EventCollection,
   EventSeries,
   EventSeriesCollection,
+  EventTypeCollection,
 } from '../index.js';
 import type { RecurrencePattern } from '../types';
 
@@ -26,6 +27,17 @@ async function makeSeries(name: string, dbUrl = getTestDbUrl(name)) {
   const series = await EventSeriesCollection.create({
     db: { type: 'sqlite', url: dbUrl },
   });
+  const types = await EventTypeCollection.create({
+    db: { type: 'sqlite', url: dbUrl },
+  });
+  for (const [id, typeName] of [
+    ['concert', 'Concert'],
+    ['meeting', 'Meeting'],
+    ['type-x', 'Type X'],
+    ['type-y', 'Type Y'],
+  ]) {
+    await types.create({ id, name: typeName });
+  }
   return { dbUrl, series };
 }
 

--- a/packages/events/src/__tests__/events-tenant-isolation.test.ts
+++ b/packages/events/src/__tests__/events-tenant-isolation.test.ts
@@ -93,7 +93,9 @@ describe('events tenant isolation (#1600)', () => {
 
   it('EventParticipantCollection.findGlobal/findWithGlobals do not throw and stay tenant-scoped', async () => {
     const participants = await EventParticipantCollection.create({ db });
+    const events = await EventCollection.create({ db });
     await withTenant({ tenantId: 'tenant-1' }, async () => {
+      await events.create({ id: 'e1', name: 'tenant-1 parent' });
       await (
         await participants.create({
           eventId: 'e1',
@@ -104,6 +106,7 @@ describe('events tenant isolation (#1600)', () => {
       ).save();
     });
     await withTenant({ tenantId: 'tenant-2' }, async () => {
+      await events.create({ id: 'e2', name: 'tenant-2 parent' });
       await (
         await participants.create({
           eventId: 'e2',
@@ -114,6 +117,7 @@ describe('events tenant isolation (#1600)', () => {
       ).save();
     });
     await withSystemContext(async () => {
+      await events.create({ id: 'eg', name: 'global parent' });
       await (
         await participants.create({
           eventId: 'eg',

--- a/packages/facts/src/__tests__/facts-tenant-isolation.test.ts
+++ b/packages/facts/src/__tests__/facts-tenant-isolation.test.ts
@@ -42,6 +42,20 @@ const sorted = (rows: Array<Record<string, any>>, field: string): string[] =>
 describe('facts tenant isolation (#1600)', () => {
   let db: DatabaseInterface;
 
+  const seedFactParent = async (
+    facts: FactCollection,
+    id: string,
+  ): Promise<void> => {
+    await (
+      await facts.create({
+        id,
+        textRefined: id,
+        type: 'assertion',
+        status: 'active',
+      })
+    ).save();
+  };
+
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
     enableTenancy(); // default rawQueryPolicy: 'throw'
@@ -113,7 +127,9 @@ describe('facts tenant isolation (#1600)', () => {
 
   it('FactContentCollection.findGlobal/findWithGlobals do not throw and stay tenant-scoped', async () => {
     const links = await FactContentCollection.create({ db });
+    const facts = await FactCollection.create({ db });
     await withTenant({ tenantId: 'tenant-1' }, async () => {
+      await seedFactParent(facts, 't1-link');
       await (
         await links.create({
           factId: 't1-link',
@@ -123,6 +139,7 @@ describe('facts tenant isolation (#1600)', () => {
       ).save();
     });
     await withTenant({ tenantId: 'tenant-2' }, async () => {
+      await seedFactParent(facts, 't2-link');
       await (
         await links.create({
           factId: 't2-link',
@@ -132,6 +149,7 @@ describe('facts tenant isolation (#1600)', () => {
       ).save();
     });
     await withSystemContext(async () => {
+      await seedFactParent(facts, 'g-link');
       await (
         await links.create({
           factId: 'g-link',
@@ -170,17 +188,21 @@ describe('facts tenant isolation (#1600)', () => {
 
   it('FactSourceCollection.findGlobal/findWithGlobals do not throw and stay tenant-scoped', async () => {
     const sources = await FactSourceCollection.create({ db });
+    const facts = await FactCollection.create({ db });
     await withTenant({ tenantId: 'tenant-1' }, async () => {
+      await seedFactParent(facts, 'f1');
       await (
         await sources.create({ factId: 'f1', sourceTitle: 't1-source' })
       ).save();
     });
     await withTenant({ tenantId: 'tenant-2' }, async () => {
+      await seedFactParent(facts, 'f2');
       await (
         await sources.create({ factId: 'f2', sourceTitle: 't2-source' })
       ).save();
     });
     await withSystemContext(async () => {
+      await seedFactParent(facts, 'fg');
       await (
         await sources.create({ factId: 'fg', sourceTitle: 'g-source' })
       ).save();
@@ -215,7 +237,9 @@ describe('facts tenant isolation (#1600)', () => {
 
   it('FactSubjectCollection.findGlobal/findWithGlobals do not throw and stay tenant-scoped', async () => {
     const subjects = await FactSubjectCollection.create({ db });
+    const facts = await FactCollection.create({ db });
     await withTenant({ tenantId: 'tenant-1' }, async () => {
+      await seedFactParent(facts, 'f1');
       await (
         await subjects.create({
           factId: 'f1',
@@ -225,6 +249,7 @@ describe('facts tenant isolation (#1600)', () => {
       ).save();
     });
     await withTenant({ tenantId: 'tenant-2' }, async () => {
+      await seedFactParent(facts, 'f2');
       await (
         await subjects.create({
           factId: 'f2',
@@ -234,6 +259,7 @@ describe('facts tenant isolation (#1600)', () => {
       ).save();
     });
     await withSystemContext(async () => {
+      await seedFactParent(facts, 'fg');
       await (
         await subjects.create({
           factId: 'fg',
@@ -272,13 +298,17 @@ describe('facts tenant isolation (#1600)', () => {
 
   it('FactTagCollection.findGlobal/findWithGlobals do not throw and stay tenant-scoped', async () => {
     const tags = await FactTagCollection.create({ db });
+    const facts = await FactCollection.create({ db });
     await withTenant({ tenantId: 'tenant-1' }, async () => {
+      await seedFactParent(facts, 'f1');
       await (await tags.create({ factId: 'f1', tagSlug: 't1-tag' })).save();
     });
     await withTenant({ tenantId: 'tenant-2' }, async () => {
+      await seedFactParent(facts, 'f2');
       await (await tags.create({ factId: 'f2', tagSlug: 't2-tag' })).save();
     });
     await withSystemContext(async () => {
+      await seedFactParent(facts, 'fg');
       await (await tags.create({ factId: 'fg', tagSlug: 'g-tag' })).save();
     });
 

--- a/packages/fields/src/field-policy-batch.test.ts
+++ b/packages/fields/src/field-policy-batch.test.ts
@@ -14,10 +14,14 @@ import {
 } from '@happyvertical/smrt-tenancy';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-// Registers smrt-users' classes (Tenant/Membership) so
-// getTestDatabase can create the tenants table the default hierarchy loader
-// reads under an ambient tenant context.
-import { MembershipCollection } from '../../users/src/index.js';
+// Registers smrt-users' identity classes so getTestDatabase can create the
+// tenant hierarchy and physically constrained membership tables used here.
+import {
+  MembershipCollection,
+  RoleCollection,
+  TenantCollection,
+  UserCollection,
+} from '../../users/src/index.js';
 import { clearFieldPolicyCache } from './cache.js';
 import { FieldPolicyCollection } from './collections/FieldPolicyCollection.js';
 import {
@@ -71,7 +75,7 @@ describe('FieldPolicyCollection.resolveBatch', () => {
     // 'Tenant' backs the default hierarchy loader (smrt-users is installed
     // in this workspace, so resolveBatch walks the real tenant table).
     db = await getTestDatabase({
-      classes: ['FieldPolicy', 'Tenant', 'Membership'],
+      classes: ['FieldPolicy', 'Tenant', 'User', 'Role', 'Membership'],
     });
     policies = await FieldPolicyCollection.create({ db });
     objectRef = fixtureRef();
@@ -395,16 +399,31 @@ describe('FieldPolicyCollection.resolveBatch', () => {
     const otherUserId = randomUUID();
     const foreignTenantId = randomUUID();
     const foreignUserId = randomUUID();
+    const roleId = randomUUID();
+    const foreignRoleId = randomUUID();
+    const tenants = await TenantCollection.create({ db });
+    const users = await UserCollection.create({ db });
+    const roles = await RoleCollection.create({ db });
     const memberships = await MembershipCollection.create({ db });
+    await tenants.create({ id: tenantId, name: 'Managed tenant' });
+    await tenants.create({ id: foreignTenantId, name: 'Foreign tenant' });
+    await users.create({ id: otherUserId, email: 'other@example.test' });
+    await users.create({ id: foreignUserId, email: 'foreign@example.test' });
+    await roles.create({ id: roleId, tenantId, name: 'Member' });
+    await roles.create({
+      id: foreignRoleId,
+      tenantId: foreignTenantId,
+      name: 'Foreign member',
+    });
     await memberships.create({
       userId: otherUserId,
       tenantId,
-      roleId: randomUUID(),
+      roleId,
     });
     await memberships.create({
       userId: foreignUserId,
       tenantId: foreignTenantId,
-      roleId: randomUUID(),
+      roleId: foreignRoleId,
     });
     await withTenant(
       {

--- a/packages/images/src/__tests__/image-adapter-parity.test.ts
+++ b/packages/images/src/__tests__/image-adapter-parity.test.ts
@@ -258,8 +258,12 @@ describe('Image Adapter Parity', () => {
 
       beforeEach(async () => {
         dbConfig = adapterConfig.getConfig();
-        // Use getTestDatabase to create schemas automatically
-        db = await getTestDatabase(dbConfig);
+        // This suite exercises storage parity, not FK enforcement. DuckDB
+        // cannot enforce the assets package's generated CASCADE action.
+        db = await getTestDatabase({
+          ...dbConfig,
+          omitForeignKeyConstraints: dbConfig.type === 'json',
+        });
         images = await ImageCollection.create({ db });
         assets = await AssetCollection.create({ db });
       }, ADAPTER_HOOK_TIMEOUT_MS);

--- a/packages/jobs/AGENTS.md
+++ b/packages/jobs/AGENTS.md
@@ -155,7 +155,10 @@ the framework retention sweep in `@happyvertical/smrt-core`.
 - Windows (`DEFAULT_JOB_RETENTION`): completed/cancelled 7 days, failed 30
   days, events 30 days, 10 000 job rows per sweep. Events deliberately outlive
   the jobs they describe, so a job row removed at 7 days still has a readable
-  log for another three weeks.
+  log for another three weeks. `SmrtJobEvent.jobId` is therefore the explicit
+  same-package archival exception: `@foreignKey('SmrtJob', { constraint:
+  false })` retains runtime relationship metadata and its index without a
+  physical database constraint that would block parent pruning.
 - `cleanup()` counts before deleting (`rowCount` is unreliable across engines)
   and honours `dryRun`, which is what makes `smrt db:prune --dry-run` an exact
   preview. Its `(status, completed_at)` predicate is indexed by

--- a/packages/jobs/src/__tests__/job-tenancy.test.ts
+++ b/packages/jobs/src/__tests__/job-tenancy.test.ts
@@ -43,6 +43,21 @@ describe('job tenancy propagation', () => {
     expect(fields.get('workerHeartbeat')?.type).toBe('datetime');
   });
 
+  it('keeps the retained job-event relationship app-side only', async () => {
+    const fields = await ObjectRegistry.getAllFields('SmrtJobEvent');
+    const schema = ObjectRegistry.getAllSchemasAsDefinitions()._smrt_job_events;
+
+    expect(fields.get('jobId')?.type).toBe('foreignKey');
+    expect(fields.get('jobId')?._meta?.constraint).toBe(false);
+    expect(schema.columns.job_id.referenceKind).toBe('foreignKey');
+    expect(schema.columns.job_id.foreignKey).toBeUndefined();
+    expect(schema.foreignKeys).toEqual([]);
+    expect(schema.dependencies).not.toContain('_smrt_jobs');
+    expect(schema.indexes.some((index) => index.columns[0] === 'job_id')).toBe(
+      true,
+    );
+  });
+
   it('persists core job fields to the _smrt_jobs row', async () => {
     const db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
     const collection = await SmrtJobCollection.create({ db });

--- a/packages/jobs/src/__tests__/worker-liveness.test.ts
+++ b/packages/jobs/src/__tests__/worker-liveness.test.ts
@@ -183,7 +183,14 @@ describe('worker-lease recovery (#1474)', () => {
   // the adapter's rowCount reporting (always ≥1 on DuckDB) — recovery must use
   // RETURNING, not rowCount, to decide what actually transitioned.
   it('registers leases and recovers correctly on DuckDB', async () => {
-    const db = await getTestDatabase({ type: 'duckdb', url: ':memory:' });
+    const db = await getTestDatabase({
+      type: 'duckdb',
+      url: ':memory:',
+      // This scenario validates DuckDB lease timestamps/rowCount behavior,
+      // not referential enforcement. DuckDB cannot honor SMRT's default
+      // ON UPDATE CASCADE action, so the test-only schema opt-out is explicit.
+      omitForeignKeyConstraints: true,
+    });
     const collection = await SmrtJobCollection.create({ db });
     const workers = await SmrtWorkerCollection.create({ db });
 

--- a/packages/jobs/src/__tests__/worker-liveness.test.ts
+++ b/packages/jobs/src/__tests__/worker-liveness.test.ts
@@ -201,6 +201,18 @@ describe('worker-lease recovery (#1474)', () => {
     const fresh = await workers.freshLeaseWorkerKeys();
     expect(fresh.has('duck-live')).toBe(true);
 
+    await collection.create({
+      objectType: 'LivenessProbe',
+      method: 'noop',
+      args: {},
+    });
+    const claimed = await collection.claimReady({
+      workerId: 'duck-live',
+      limit: 1,
+    });
+    expect(claimed).toHaveLength(1);
+    expect(typeof claimed[0]?.id).toBe('string');
+
     const liveJob = await collection.create({
       objectType: 'LivenessProbe',
       method: 'noop',

--- a/packages/jobs/src/runner.ts
+++ b/packages/jobs/src/runner.ts
@@ -34,7 +34,11 @@ import {
   type RetentionSweeperOptions,
   startRetentionSweeper,
 } from './retention.js';
-import { type SmrtJob, SmrtJobCollection } from './smrt-job.js';
+import {
+  SMRT_JOB_PORTABLE_SELECT_COLUMNS,
+  type SmrtJob,
+  SmrtJobCollection,
+} from './smrt-job.js';
 import { type SmrtJobEvent, SmrtJobEventCollection } from './smrt-job-event.js';
 import { SmrtWorkerCollection } from './smrt-worker.js';
 import {
@@ -981,7 +985,9 @@ export class TaskRunner extends EventEmitter {
     // Worker-internal cross-tenant recovery scan; SmrtJob is @TenantScoped
     // (S5 #1402) so this raw read needs an explicit opt-in.
     const running = await this.collection.query(
-      `SELECT * FROM _smrt_jobs WHERE status = 'running'`,
+      `SELECT ${SMRT_JOB_PORTABLE_SELECT_COLUMNS}
+         FROM _smrt_jobs
+        WHERE status = 'running'`,
       [],
       { allowRawOnTenantScoped: true },
     );
@@ -1021,7 +1027,7 @@ export class TaskRunner extends EventEmitter {
               worker_heartbeat = NULL
         WHERE status = 'running'
           AND id IN (${placeholders})
-        RETURNING id`,
+        RETURNING CAST(id AS VARCHAR) AS id`,
       recoveredAt.toISOString(),
       errorMessage,
       ...orphanIds,

--- a/packages/jobs/src/smrt-job-event.ts
+++ b/packages/jobs/src/smrt-job-event.ts
@@ -85,7 +85,11 @@ export class SmrtJobEvent extends SmrtObject {
   @tenantId({ nullable: true })
   tenantId: string | null | undefined = undefined;
 
-  @foreignKey('SmrtJob', { required: true })
+  // Job events intentionally outlive completed job rows (30-day event
+  // retention vs 7-day completed-job retention). Keep the typed relationship,
+  // index, and application-side policy, but do not install a physical FK that
+  // would make the documented retention sweep impossible (#2375, #2413).
+  @foreignKey('SmrtJob', { required: true, constraint: false })
   jobId: string = '';
 
   @field({ type: 'text', required: true, default: 'log' })

--- a/packages/jobs/src/smrt-job-event.ts
+++ b/packages/jobs/src/smrt-job-event.ts
@@ -87,8 +87,9 @@ export class SmrtJobEvent extends SmrtObject {
 
   // Job events intentionally outlive completed job rows (30-day event
   // retention vs 7-day completed-job retention). Keep the typed relationship,
-  // index, and application-side policy, but do not install a physical FK that
-  // would make the documented retention sweep impossible (#2375, #2413).
+  // index, and retained job identifier, but do not install a physical FK or
+  // app-side delete action that would make the documented retention sweep
+  // impossible (#2375, #2413).
   @foreignKey('SmrtJob', { required: true, constraint: false })
   jobId: string = '';
 

--- a/packages/jobs/src/smrt-job.ts
+++ b/packages/jobs/src/smrt-job.ts
@@ -35,6 +35,24 @@ export type JobStatus =
 export type TimeoutBehavior = 'fail' | 'kill' | 'warn';
 
 /**
+ * Full job projection with a portable string identity.
+ *
+ * Native DuckDB currently exposes UUID result values as internal objects.
+ * Worker claim/recovery state is keyed by string IDs, so both paths must use
+ * this same projection instead of hydrating a raw UUID from `SELECT *`.
+ */
+export const SMRT_JOB_PORTABLE_SELECT_COLUMNS = `
+  CAST(id AS VARCHAR) AS id,
+  slug, context, created_at, updated_at, tenant_id, queue,
+  object_type, object_id, method, args, run_at,
+  priority, status, attempts, max_attempts, timeout,
+  timeout_behavior, started_at, completed_at, last_error,
+  result_pointer, task_id, task_owner_id, task_result,
+  task_input_requests, task_input_responses, retry_strategy,
+  worker_id, worker_heartbeat
+`;
+
+/**
  * Persistent job record stored in the `_smrt_jobs` system table.
  *
  * @remarks
@@ -439,7 +457,7 @@ export class SmrtJobCollection extends SmrtCollection<SmrtJob> {
               updated_at = ?
         WHERE id IN (${candidateSelect})
           AND status = 'pending'
-        RETURNING *`,
+        RETURNING ${SMRT_JOB_PORTABLE_SELECT_COLUMNS}`,
       [options.workerId, nowIso, nowIso, nowIso, ...whereParams, limit],
       // Worker-internal cross-tenant claim; tenant context is restored
       // per-job at execution (SmrtJob is now @TenantScoped, S5 #1402).

--- a/packages/ledgers/src/__tests__/ledgers-tenant-isolation.test.ts
+++ b/packages/ledgers/src/__tests__/ledgers-tenant-isolation.test.ts
@@ -144,19 +144,42 @@ describe('ledgers tenant isolation (#1600)', () => {
 
   it('JournalEntryCollection.findGlobal/findWithGlobals do not throw and stay tenant-scoped', async () => {
     const entries = await JournalEntryCollection.create({ db });
+    const journals = await JournalCollection.create({ db });
+    const accounts = await AccountCollection.create({ db });
     await withTenant({ tenantId: 'tenant-1' }, async () => {
+      await journals.create({ id: 'j1', number: 'JNL-E1' });
+      await accounts.create({ id: 'a1', number: 'E1000', name: 't1-parent' });
       await (
-        await entries.create({ journalId: 'j1', debit: 10, memo: 't1-entry' })
+        await entries.create({
+          journalId: 'j1',
+          accountId: 'a1',
+          debit: 10,
+          memo: 't1-entry',
+        })
       ).save();
     });
     await withTenant({ tenantId: 'tenant-2' }, async () => {
+      await journals.create({ id: 'j2', number: 'JNL-E2' });
+      await accounts.create({ id: 'a2', number: 'E2000', name: 't2-parent' });
       await (
-        await entries.create({ journalId: 'j2', debit: 20, memo: 't2-entry' })
+        await entries.create({
+          journalId: 'j2',
+          accountId: 'a2',
+          debit: 20,
+          memo: 't2-entry',
+        })
       ).save();
     });
     await withSystemContext(async () => {
+      await journals.create({ id: 'jg', number: 'JNL-EG' });
+      await accounts.create({ id: 'ag', number: 'E9000', name: 'g-parent' });
       await (
-        await entries.create({ journalId: 'jg', debit: 30, memo: 'g-entry' })
+        await entries.create({
+          journalId: 'jg',
+          accountId: 'ag',
+          debit: 30,
+          memo: 'g-entry',
+        })
       ).save();
     });
 

--- a/packages/messages/src/__tests__/account-message-extended.test.ts
+++ b/packages/messages/src/__tests__/account-message-extended.test.ts
@@ -36,11 +36,13 @@ import { SlackMessage } from '../models/SlackMessage';
 // registry — the same opt-in production servers perform (#1979). Its dynamic
 // SDK import resolves to the vi.mock above.
 import '../providers/slack';
+import { prepareMessageParents } from './fk-fixtures.js';
 
 let db: DatabaseInterface;
 
 beforeEach(async () => {
   db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+  await prepareMessageParents(db);
 });
 
 afterEach(async () => {

--- a/packages/messages/src/__tests__/collections.test.ts
+++ b/packages/messages/src/__tests__/collections.test.ts
@@ -36,6 +36,7 @@ import { Attachment } from '../models/Attachment';
 import { Email } from '../models/Email';
 import { EmailAccount } from '../models/EmailAccount';
 import { Message } from '../models/Message';
+import { prepareMessageParents, seedMessageParents } from './fk-fixtures.js';
 
 // ---------------------------------------------------------------------------
 // Persistence helper — initialize() then save() is the supported write path.
@@ -59,6 +60,7 @@ describe('MessageCollection', () => {
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await prepareMessageParents(db, ['acct-A', 'acct-B', 'acct-G', 'acct-T']);
     col = await MessageCollection.create({ db });
   });
 
@@ -267,6 +269,7 @@ describe('EmailCollection', () => {
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await prepareMessageParents(db, ['acct-A', 'acct-B', 'acct-G', 'acct-T']);
     col = await EmailCollection.create({ db });
   });
 
@@ -555,6 +558,7 @@ describe('EmailAccountCollection', () => {
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await prepareMessageParents(db);
     col = await EmailAccountCollection.create({ db });
   });
 
@@ -739,6 +743,7 @@ describe('AttachmentCollection', () => {
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await seedMessageParents(db, ['msg-1', 'msg-2', 'msg-G', 'msg-T']);
     col = await AttachmentCollection.create({ db });
   });
 

--- a/packages/messages/src/__tests__/email-account.test.ts
+++ b/packages/messages/src/__tests__/email-account.test.ts
@@ -41,6 +41,7 @@ import { Email } from '../models/Email';
 import { EmailAccount } from '../models/EmailAccount';
 import { EmailFolder } from '../models/EmailFolder';
 import { EmailSender } from '../senders/EmailSender';
+import { prepareMessageParents } from './fk-fixtures.js';
 
 // ---------------------------------------------------------------------------
 // Mock email-client factory (mirrors the EmailClient surface EmailAccount uses)
@@ -217,6 +218,7 @@ describe('EmailAccount DB-backed operations', () => {
 
   beforeEach(async () => {
     db = await getTestDatabase();
+    await prepareMessageParents(db);
   });
 
   afterEach(async () => {

--- a/packages/messages/src/__tests__/fk-fixtures.ts
+++ b/packages/messages/src/__tests__/fk-fixtures.ts
@@ -1,0 +1,49 @@
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { AccountCollection } from '../collections/AccountCollection.js';
+import { MessageCollection } from '../collections/MessageCollection.js';
+import { MessagingEndpointCollection } from '../collections/MessagingEndpointCollection.js';
+
+/**
+ * Complete the same-package parent side of message test schemas and seed any
+ * explicit account identifiers used by child fixtures.
+ */
+export async function prepareMessageParents(
+  db: DatabaseInterface,
+  accountIds: string[] = [],
+): Promise<void> {
+  const accounts = await AccountCollection.create({ db });
+  await MessagingEndpointCollection.create({ db });
+  for (const id of accountIds) {
+    const existing = await accounts.get({ id });
+    if (existing) continue;
+    await (
+      await accounts.create({
+        id,
+        name: `Test account ${id}`,
+        channelType: 'email',
+        providerType: 'test',
+      })
+    ).save();
+  }
+}
+
+/** Seed real Message parents for Attachment fixtures with explicit IDs. */
+export async function seedMessageParents(
+  db: DatabaseInterface,
+  messageIds: string[],
+): Promise<void> {
+  const accountId = 'attachment-parent-account';
+  await prepareMessageParents(db, [accountId]);
+  const messages = await MessageCollection.create({ db });
+  for (const id of messageIds) {
+    const existing = await messages.get({ id });
+    if (existing) continue;
+    await (
+      await messages.create({
+        id,
+        accountId,
+        subject: `Attachment parent ${id}`,
+      })
+    ).save();
+  }
+}

--- a/packages/messages/src/__tests__/message-sti.test.ts
+++ b/packages/messages/src/__tests__/message-sti.test.ts
@@ -13,12 +13,14 @@ import { Email } from '../models/Email';
 import { Message } from '../models/Message';
 import { SlackMessage } from '../models/SlackMessage';
 import { Tweet } from '../models/Tweet';
+import { prepareMessageParents } from './fk-fixtures.js';
 
 describe('Message STI Support', () => {
   let db: DatabaseInterface;
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await prepareMessageParents(db);
   });
 
   afterEach(async () => {

--- a/packages/messages/src/__tests__/messages-tenant-isolation.test.ts
+++ b/packages/messages/src/__tests__/messages-tenant-isolation.test.ts
@@ -59,10 +59,42 @@ import { Email } from '../models/Email';
 import { EmailAccount } from '../models/EmailAccount';
 import { EmailFolder } from '../models/EmailFolder';
 import { Message } from '../models/Message';
+import { prepareMessageParents } from './fk-fixtures.js';
 
 const names = (
   rows: Array<{ subject?: string; name?: string; filename?: string }>,
 ) => rows.map((r) => r.subject ?? r.name ?? r.filename ?? '').sort();
+
+async function seedTenantAccounts(db: DatabaseInterface) {
+  const accounts = await AccountCollection.create({ db });
+  await withTenant({ tenantId: 'tenant-1' }, async () => {
+    await (
+      await accounts.create({
+        id: 'a1',
+        name: 'tenant-1 parent',
+        providerType: 'test',
+      })
+    ).save();
+  });
+  await withTenant({ tenantId: 'tenant-2' }, async () => {
+    await (
+      await accounts.create({
+        id: 'a2',
+        name: 'tenant-2 parent',
+        providerType: 'test',
+      })
+    ).save();
+  });
+  await withSystemContext(async () => {
+    await (
+      await accounts.create({
+        id: 'ag',
+        name: 'global parent',
+        providerType: 'test',
+      })
+    ).save();
+  });
+}
 
 // ===========================================================================
 // EmailCollection (STI child of Message — shares the `messages` table)
@@ -75,9 +107,11 @@ describe('EmailCollection tenant isolation (#1596)', () => {
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await prepareMessageParents(db);
     emails = await EmailCollection.create({ db });
     messages = await MessageCollection.create({ db });
     enableTenancy(); // default rawQueryPolicy: 'throw'
+    await seedTenantAccounts(db);
   });
 
   afterEach(async () => {
@@ -195,6 +229,7 @@ describe('EmailAccountCollection tenant isolation (#1596)', () => {
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await prepareMessageParents(db);
     accounts = await EmailAccountCollection.create({ db });
     baseAccounts = await AccountCollection.create({ db });
     enableTenancy();
@@ -300,6 +335,7 @@ describe('Base messages collections tenant isolation (#1596)', () => {
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await prepareMessageParents(db);
     enableTenancy();
   });
 
@@ -311,6 +347,7 @@ describe('Base messages collections tenant isolation (#1596)', () => {
   });
 
   it('MessageCollection.findGlobal/findWithGlobals do not throw and return all subtypes for the tenant + globals', async () => {
+    await seedTenantAccounts(db);
     const messages = await MessageCollection.create({ db });
     const emails = await EmailCollection.create({ db });
     await withTenant({ tenantId: 'tenant-1' }, async () => {
@@ -388,7 +425,24 @@ describe('Base messages collections tenant isolation (#1596)', () => {
   });
 
   it('AttachmentCollection.findGlobal/findWithGlobals do not throw and stay tenant-scoped', async () => {
+    await seedTenantAccounts(db);
     const attachments = await AttachmentCollection.create({ db });
+    const messages = await MessageCollection.create({ db });
+    await withTenant({ tenantId: 'tenant-1' }, async () => {
+      await (
+        await messages.create({ id: 'm1', accountId: 'a1', subject: 't1' })
+      ).save();
+    });
+    await withTenant({ tenantId: 'tenant-2' }, async () => {
+      await (
+        await messages.create({ id: 'm2', accountId: 'a2', subject: 't2' })
+      ).save();
+    });
+    await withSystemContext(async () => {
+      await (
+        await messages.create({ id: 'mg', accountId: 'ag', subject: 'global' })
+      ).save();
+    });
     await withTenant({ tenantId: 'tenant-1' }, async () => {
       await (
         await attachments.create({ messageId: 'm1', filename: 't1-att' })
@@ -422,6 +476,7 @@ describe('Base messages collections tenant isolation (#1596)', () => {
   });
 
   it('EmailFolderCollection.findGlobal/findWithGlobals do not throw and stay tenant-scoped', async () => {
+    await seedTenantAccounts(db);
     const folders = await EmailFolderCollection.create({ db });
     await withTenant({ tenantId: 'tenant-1' }, async () => {
       await (

--- a/packages/messages/src/__tests__/sending.test.ts
+++ b/packages/messages/src/__tests__/sending.test.ts
@@ -11,6 +11,7 @@ import { Account } from '../models/Account';
 import { Email } from '../models/Email';
 import { Message } from '../models/Message';
 import type { SendStatus } from '../types';
+import { prepareMessageParents } from './fk-fixtures.js';
 
 // ============================================================================
 // Message Send Fields
@@ -279,6 +280,7 @@ describe('reply/forward persistence (does not overwrite original)', () => {
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await prepareMessageParents(db, ['acct-1']);
   });
 
   afterEach(async () => {

--- a/packages/messages/src/__tests__/small-models.test.ts
+++ b/packages/messages/src/__tests__/small-models.test.ts
@@ -17,12 +17,19 @@ import { Blacklist } from '../models/Blacklist';
 import { EmailAttachment } from '../models/EmailAttachment';
 import { EmailFolder } from '../models/EmailFolder';
 import { Whitelist } from '../models/Whitelist';
+import { prepareMessageParents } from './fk-fixtures.js';
 
 let db: DatabaseInterface;
 const TEST_TENANT_ID = 'test-messaging-tenant';
 
 beforeEach(async () => {
   db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+  await prepareMessageParents(db, [
+    'acct-1',
+    'acct-stats',
+    'acct-sub',
+    'acct-sys',
+  ]);
 });
 
 afterEach(async () => {

--- a/packages/personas/src/feedback.test.ts
+++ b/packages/personas/src/feedback.test.ts
@@ -11,6 +11,7 @@ import { getTestDatabase, type LearningMemory } from '@happyvertical/smrt-core';
 import { disableTenancy } from '@happyvertical/smrt-tenancy';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AgentPersonaCollection } from './agent-persona.js';
 import { Feedback, FeedbackCollection, feedbackSourceFor } from './feedback.js';
 import {
   personaLearningMemory,
@@ -29,7 +30,15 @@ describe('Feedback', () => {
   beforeEach(async () => {
     // Force a known, tenancy-off state for this file (single-fork process).
     disableTenancy();
-    db = await getTestDatabase({ classes: ['Feedback'] });
+    db = await getTestDatabase({ classes: ['AgentPersona', 'Feedback'] });
+    const personas = await AgentPersonaCollection.create({ db });
+    await personas.create({
+      id: 'persona-1',
+      tenantId: 'tenant-a',
+      agentClass: '@happyvertical/smrt-agents:Praeco',
+      name: 'feedback-fixture',
+      runAsUserId: 'user-1',
+    });
   });
 
   afterEach(async () => {

--- a/packages/profiles/src/__tests__/oidc-account-linking.test.ts
+++ b/packages/profiles/src/__tests__/oidc-account-linking.test.ts
@@ -729,6 +729,9 @@ describe('OIDC Account Linking', () => {
         ]);
 
         expect(maxActiveLookups).toBe(1);
+        expect(typeof first.profile.id).toBe('string');
+        expect(typeof first.oidcIdentity.id).toBe('string');
+        expect(typeof first.oidcIdentity.profileId).toBe('string');
         expect(second.profile.id).toBe(first.profile.id);
         expect(second.oidcIdentity.id).toBe(first.oidcIdentity.id);
         await expect(countRows(firstDb, 'profiles')).resolves.toBe(1);

--- a/packages/profiles/src/__tests__/oidc-account-linking.test.ts
+++ b/packages/profiles/src/__tests__/oidc-account-linking.test.ts
@@ -11,7 +11,7 @@ import { randomUUID } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
-import { ObjectRegistry } from '@happyvertical/smrt-core';
+import { getTestDatabase, ObjectRegistry } from '@happyvertical/smrt-core';
 import {
   type DatabaseInterface,
   getDatabase,
@@ -683,7 +683,19 @@ describe('OIDC Account Linking', () => {
 
     it('serializes one issuer/subject with different emails across independent DuckDB handles', async () => {
       const db = await getDatabase({ type: 'duckdb', url: ':memory:' });
-      await ProfileTypeCollection.create({ db });
+      // This test exercises DuckDB connection serialization, not FK actions.
+      // Use the focused test schema because DuckDB cannot honor SMRT's default
+      // ON UPDATE CASCADE contract for generated same-package constraints.
+      await getTestDatabase({
+        db,
+        classes: [
+          'ProfileType',
+          'Profile',
+          'OidcIdentity',
+          'OidcProfileEmailReservation',
+        ],
+        omitForeignKeyConstraints: true,
+      });
       await backfillProfileEmailKeys(db);
       let activeLookups = 0;
       let maxActiveLookups = 0;
@@ -1014,8 +1026,16 @@ async function runProfileMatrixScenario(
   let identityProfileId: string | undefined;
   let identityId: string | undefined;
   let emailProfileId: string | undefined;
+  const legacyOrphanScenario = scenario.identity === 'exact_missing_profile';
 
-  if (scenario.identity === 'exact_missing_profile') {
+  if (legacyOrphanScenario) {
+    // Reproduce a legacy orphan that predates #2413's physical constraint.
+    // Keep enforcement disabled through repair/rebinding because the legacy
+    // row remains orphaned until that flow has completed.
+    await db.query('PRAGMA foreign_keys = OFF');
+  }
+
+  if (legacyOrphanScenario) {
     identityId = await seedProfileMatrixIdentity(
       db,
       randomUUID(),
@@ -1151,6 +1171,9 @@ async function runProfileMatrixScenario(
     await expect(profileMatrixIdentityBindings(db, subject)).resolves.toEqual(
       identityBindingsBefore,
     );
+  }
+  if (legacyOrphanScenario) {
+    await db.query('PRAGMA foreign_keys = ON');
   }
 }
 

--- a/packages/profiles/src/__tests__/oidc-provisioning-coordinator.test.ts
+++ b/packages/profiles/src/__tests__/oidc-provisioning-coordinator.test.ts
@@ -1,3 +1,4 @@
+import { getTestDatabase } from '@happyvertical/smrt-core';
 import { getDatabase } from '@happyvertical/sql';
 import { describe, expect, it } from 'vitest';
 import { createProfileFromOidc } from '../auth/index.js';
@@ -5,7 +6,6 @@ import {
   coordinateOidcProvisioning,
   isOidcAbortedTransactionError,
 } from '../auth/oidcProvisioningCoordinator';
-import { ProfileTypeCollection } from '../collections/ProfileTypeCollection.js';
 import { backfillProfileEmailKeys } from '../migrations/backfillProfileEmailKeys.js';
 
 type DatabaseInterface = Awaited<ReturnType<typeof getDatabase>>;
@@ -155,7 +155,18 @@ describe('coordinateOidcProvisioning shared-connection ordering', () => {
       type: 'duckdb',
       url: ':memory:',
     })) as DatabaseInterface;
-    await ProfileTypeCollection.create({ db });
+    await getTestDatabase({
+      db,
+      classes: [
+        'ProfileType',
+        'Profile',
+        'OidcIdentity',
+        'OidcProfileEmailReservation',
+      ],
+      // This scenario validates statement serialization on one DuckDB handle,
+      // not referential enforcement. DuckDB cannot preserve ON UPDATE CASCADE.
+      omitForeignKeyConstraints: true,
+    });
     await backfillProfileEmailKeys(db);
 
     let inFlight = 0;

--- a/packages/profiles/src/auth/resolveIdentity.ts
+++ b/packages/profiles/src/auth/resolveIdentity.ts
@@ -459,6 +459,10 @@ async function provisionOidcProfile(
     if (!profile) {
       throw new Error('The exact OIDC identity has no linked Profile.');
     }
+    // `findBySubject()` normalizes the FK at this authentication boundary;
+    // keep the related object on that portable identity as well for native
+    // DuckDB adapters whose raw UUID values are represented as objects.
+    profile.id = requireOidcProfileId(existingIdentity.profileId);
     if (claims.email) existingIdentity.email = claims.email;
     existingIdentity.lastUsedAt = new Date();
     await existingIdentity.save();
@@ -532,6 +536,9 @@ async function rebindOidcProfileResult<
       'Committed OIDC Profile provisioning result was not found.',
     );
   }
+  profile.id = profileId;
+  oidcIdentity.id = identityId;
+  oidcIdentity.profileId = profileId;
   return { ...result, profile, oidcIdentity };
 }
 

--- a/packages/profiles/src/collections/OidcIdentityCollection.ts
+++ b/packages/profiles/src/collections/OidcIdentityCollection.ts
@@ -36,14 +36,29 @@ export class OidcIdentityCollection extends SmrtCollection<OidcIdentity> {
     issuer: string,
     subject: string,
   ): Promise<OidcIdentity | null> {
-    const matches = await this.list({
-      where: { issuer, subject },
-      limit: 2,
-    });
-    if (matches.length > 1) {
+    const result = await this.db.query(
+      `SELECT CAST(id AS VARCHAR) AS id,
+              CAST(profile_id AS VARCHAR) AS profile_id
+         FROM oidc_identities
+        WHERE issuer = ? AND subject = ?
+        LIMIT 2`,
+      issuer,
+      subject,
+    );
+    if (result.rows.length > 1) {
       throw new AmbiguousOidcIdentityError(issuer, subject);
     }
-    return matches[0] ?? null;
+    const row = result.rows[0];
+    const id = row?.id;
+    const profileId = row?.profile_id;
+    if (typeof id !== 'string' || typeof profileId !== 'string') return null;
+    const identity = await this.get({ id });
+    if (!identity) return null;
+    // Preserve portable identities at this authentication boundary when
+    // native DuckDB exposes UUID results through internal objects.
+    identity.id = id;
+    identity.profileId = profileId;
+    return identity;
   }
 
   /**

--- a/packages/profiles/src/collections/ProfileCollection.ts
+++ b/packages/profiles/src/collections/ProfileCollection.ts
@@ -110,7 +110,8 @@ export class ProfileCollection extends SmrtCollection<Profile> {
     await this.ensureEmailKeysReady();
     const result = await withSystemContext(() =>
       db.query(
-        `SELECT id, tenant_id, _meta_type, email, email_key
+        `SELECT CAST(id AS VARCHAR) AS id,
+                tenant_id, _meta_type, email, email_key
          FROM profiles
          WHERE id = ?
          LIMIT 1`,
@@ -279,7 +280,8 @@ export class ProfileCollection extends SmrtCollection<Profile> {
     await this.ensureEmailKeysReady();
     const result = await withSystemContext(async () => {
       return db.query(
-        `SELECT id, tenant_id, _meta_type, email, email_key
+        `SELECT CAST(id AS VARCHAR) AS id,
+                tenant_id, _meta_type, email, email_key
          FROM profiles
          WHERE email_key = ?
          ORDER BY created_at ASC, id ASC
@@ -389,6 +391,9 @@ export class ProfileCollection extends SmrtCollection<Profile> {
         `Profile ${profileId} could not be hydrated.`,
       );
     }
+    // Preserve the portable identity used for this lookup when native DuckDB
+    // exposes UUID result values through its internal object representation.
+    profile.id = profileId;
     return profile;
   }
 

--- a/packages/profiles/src/collections/ProfileTypeCollection.ts
+++ b/packages/profiles/src/collections/ProfileTypeCollection.ts
@@ -134,7 +134,7 @@ export class ProfileTypeCollection extends SmrtCollection<ProfileType> {
 
   private async loadGlobalBySlug(slug: string): Promise<ProfileType | null> {
     const result = await this.db.query(
-      `SELECT id
+      `SELECT CAST(id AS VARCHAR) AS id
        FROM profile_types
        WHERE slug = ?
          AND context = ''
@@ -144,6 +144,12 @@ export class ProfileTypeCollection extends SmrtCollection<ProfileType> {
       slug,
     );
     const id = result.rows[0]?.id;
-    return typeof id === 'string' ? this.get({ id }) : null;
+    if (typeof id !== 'string') return null;
+    const profileType = await this.get({ id });
+    // @happyvertical/sql 0.88 exposes native DuckDB UUID result values as an
+    // internal object. The cast above is the portable identity boundary for
+    // this lookup; retain it on the hydrated object used by provisioning.
+    if (profileType) profileType.id = id;
+    return profileType;
   }
 }

--- a/packages/projects/src/__tests__/delivery-control-plane.test.ts
+++ b/packages/projects/src/__tests__/delivery-control-plane.test.ts
@@ -1,5 +1,4 @@
-import { getTestDatabase } from '@happyvertical/smrt-core';
-import { PricingRuleCollection } from '@happyvertical/smrt-subscriptions';
+import { getTestDatabase, ObjectRegistry } from '@happyvertical/smrt-core';
 import { withTenant } from '@happyvertical/smrt-tenancy';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -24,7 +23,6 @@ import {
   type RecordServiceTimeInput,
   ServiceEvidenceService,
 } from '../services/service-evidence-service.js';
-import { SubscriptionServiceCommercialResolver } from '../services/subscription-commercial-resolver.js';
 
 describe('managed application delivery control plane (#1949)', () => {
   let db: DatabaseInterface;
@@ -716,6 +714,25 @@ describe('managed application delivery control plane (#1949)', () => {
   });
 
   it('prices approved service evidence through #1925 Client Charges', async () => {
+    // Load the external package only after the vitest plugin has registered its
+    // manifest. PricingRule has plain inferred fields, so importing its runtime
+    // class during config evaluation would leave this consumer test with only
+    // decorator metadata and an incomplete query/schema contract.
+    const subscriptionManifest = ObjectRegistry.registerPackageManifest(
+      new URL('../../../subscriptions/dist/manifest.json', import.meta.url),
+    );
+    expect(subscriptionManifest.loaded).toBe(true);
+    const [
+      { PricingRuleCollection },
+      { SubscriptionServiceCommercialResolver },
+    ] = await Promise.all([
+      import('@happyvertical/smrt-subscriptions'),
+      import('../services/subscription-commercial-resolver.js'),
+    ]);
+    await getTestDatabase({
+      db,
+      classes: ['PricingRule', 'TenantUsageMetric', 'ClientCharge'],
+    });
     const rules = await PricingRuleCollection.create({ db });
     const rule = await withTenant({ tenantId: 'tenant-1' }, () =>
       rules.create({

--- a/packages/projects/src/__tests__/projects-collections.test.ts
+++ b/packages/projects/src/__tests__/projects-collections.test.ts
@@ -69,6 +69,20 @@ function fakeRepoClient(over: Record<string, any> = {}): any {
   };
 }
 
+async function seedRepository(
+  db: DatabaseInterface,
+  id: string,
+  tenantId?: string,
+): Promise<void> {
+  const repositories = await RepositoryCollection.create({ db });
+  await repositories.create({
+    id,
+    tenantId,
+    owner: 'fixture',
+    name: id,
+  });
+}
+
 describe('smrt-projects collections', () => {
   let db: DatabaseInterface;
   let savedToken: string | undefined;
@@ -141,6 +155,8 @@ describe('smrt-projects collections', () => {
     });
 
     it('filters issues by repository, state, label, assignee, and number', async () => {
+      await seedRepository(db, 'repo-1');
+      await seedRepository(db, 'repo-2');
       const issues = await IssueCollection.create({ db });
       await (
         await issues.create({
@@ -205,6 +221,7 @@ describe('smrt-projects collections', () => {
     });
 
     it('findWithUnincorporatedFeedback() returns open issues with comments but no synthesis', async () => {
+      await seedRepository(db, 'r');
       const issues = await IssueCollection.create({ db });
       await (
         await issues.create({
@@ -239,12 +256,14 @@ describe('smrt-projects collections', () => {
     });
 
     it('findByTenant() scopes to the given tenant id', async () => {
+      await seedRepository(db, 'r-t1', 't1');
+      await seedRepository(db, 'r-t2', 't2');
       const issues = await IssueCollection.create({ db });
       await (
-        await issues.create({ repositoryId: 'r', number: 1, tenantId: 't1' })
+        await issues.create({ repositoryId: 'r-t1', number: 1, tenantId: 't1' })
       ).save();
       await (
-        await issues.create({ repositoryId: 'r', number: 2, tenantId: 't2' })
+        await issues.create({ repositoryId: 'r-t2', number: 2, tenantId: 't2' })
       ).save();
       expect((await issues.findByTenant('t1')).map((i) => i.number)).toEqual([
         1,
@@ -252,6 +271,7 @@ describe('smrt-projects collections', () => {
     });
 
     it('batchSync() syncs every issue belonging to the repository', async () => {
+      await seedRepository(db, 'repo-1');
       const issues = await IssueCollection.create({ db });
       const repo = new Repository({ db, owner: 'a', name: 'b' });
       (repo as any).id = 'repo-1';
@@ -271,6 +291,7 @@ describe('smrt-projects collections', () => {
     });
 
     it('findNeedingReview() filters open issues through the AI needsReview predicate', async () => {
+      await seedRepository(db, 'r');
       const issues = await IssueCollection.create({ db });
       await (
         await issues.create({ repositoryId: 'r', number: 1, state: 'open' })
@@ -343,6 +364,7 @@ describe('smrt-projects collections', () => {
     });
 
     it('filters PRs by open state, draft, mergeable, branch, number, and change size', async () => {
+      await seedRepository(db, 'r');
       const prs = await PullRequestCollection.create({ db });
       await (
         await prs.create({
@@ -407,17 +429,20 @@ describe('smrt-projects collections', () => {
     });
 
     it('findByTenant() scopes PRs to the tenant', async () => {
+      await seedRepository(db, 'r-t1', 't1');
+      await seedRepository(db, 'r-t2', 't2');
       const prs = await PullRequestCollection.create({ db });
       await (
-        await prs.create({ repositoryId: 'r', number: 1, tenantId: 't1' })
+        await prs.create({ repositoryId: 'r-t1', number: 1, tenantId: 't1' })
       ).save();
       await (
-        await prs.create({ repositoryId: 'r', number: 2, tenantId: 't2' })
+        await prs.create({ repositoryId: 'r-t2', number: 2, tenantId: 't2' })
       ).save();
       expect((await prs.findByTenant('t2')).map((p) => p.number)).toEqual([2]);
     });
 
     it('batchSync() and findAIReadyToMerge() fan out over PRs', async () => {
+      await seedRepository(db, 'repo-1');
       const prs = await PullRequestCollection.create({ db });
       const repo = new Repository({ db, owner: 'a', name: 'b' });
       (repo as any).id = 'repo-1';

--- a/packages/projects/src/__tests__/projects-models.test.ts
+++ b/packages/projects/src/__tests__/projects-models.test.ts
@@ -120,11 +120,15 @@ function projectClient(over: Record<string, any> = {}): any {
  * `getClient()` → mocked SDK factory) — never by reaching into `_client`.
  * Uses TOKEN_KEY, which beforeEach populates in the environment.
  */
-async function seedRepo(database: DatabaseInterface): Promise<Repository> {
+async function seedRepo(
+  database: DatabaseInterface,
+  id?: string,
+): Promise<Repository> {
   const repos = await RepositoryCollection.create({ db: database });
   const repo = await repos.create({
+    id,
     owner: 'acme',
-    name: 'widgets',
+    name: id ?? 'widgets',
     tokenConfigKey: TOKEN_KEY,
   });
   await repo.save();
@@ -347,8 +351,8 @@ describe('smrt-projects models', () => {
     });
 
     it('getRepository() throws when the referenced repository is missing', async () => {
-      const issues = await IssueCollection.create({ db });
-      const issue = await issues.create({
+      const issue = new Issue({
+        db,
         repositoryId: 'no-such-repo',
         number: 1,
       });
@@ -404,6 +408,7 @@ describe('smrt-projects models', () => {
     });
 
     it('incorporateFeedback() returns an unmodified preview when there are no comments', async () => {
+      await seedRepo(db, 'r');
       const issues = await IssueCollection.create({ db });
       const issue = await issues.create({
         repositoryId: 'r',
@@ -450,6 +455,7 @@ describe('smrt-projects models', () => {
     });
 
     it('AI predicates delegate to is()/do()', async () => {
+      await seedRepo(db, 'r');
       const issues = await IssueCollection.create({ db });
       const issue = await issues.create({ repositoryId: 'r', number: 1 });
       vi.spyOn(issue, 'is').mockResolvedValue(true);
@@ -597,6 +603,7 @@ describe('smrt-projects models', () => {
     });
 
     it('isReadyToMerge() short-circuits on draft/mergeability/state before AI', async () => {
+      await seedRepo(db, 'r');
       const prs = await PullRequestCollection.create({ db });
       expect(
         await (
@@ -626,6 +633,7 @@ describe('smrt-projects models', () => {
     });
 
     it('summarize()/suggestReviewers() delegate to do()', async () => {
+      await seedRepo(db, 'r');
       const prs = await PullRequestCollection.create({ db });
       const pr = await prs.create({
         repositoryId: 'r',

--- a/packages/projects/src/__tests__/projects-tenant-isolation.test.ts
+++ b/packages/projects/src/__tests__/projects-tenant-isolation.test.ts
@@ -95,11 +95,21 @@ describe('projects tenant isolation (#1600)', () => {
   });
 
   it('IssueCollection.findGlobal/findWithGlobals do not throw and stay tenant-scoped', async () => {
+    const repos = await RepositoryCollection.create({ db });
+    await withTenant({ tenantId: 'tenant-1' }, () =>
+      repos.create({ id: 'repo-t1', owner: 'acme', name: 't1-parent' }),
+    );
+    await withTenant({ tenantId: 'tenant-2' }, () =>
+      repos.create({ id: 'repo-t2', owner: 'acme', name: 't2-parent' }),
+    );
+    await withSystemContext(() =>
+      repos.create({ id: 'repo-global', owner: 'acme', name: 'global-parent' }),
+    );
     const issues = await IssueCollection.create({ db });
     await withTenant({ tenantId: 'tenant-1' }, async () => {
       await (
         await issues.create({
-          repositoryId: 'repo-1',
+          repositoryId: 'repo-t1',
           number: 1,
           title: 't1-issue',
         })
@@ -108,7 +118,7 @@ describe('projects tenant isolation (#1600)', () => {
     await withTenant({ tenantId: 'tenant-2' }, async () => {
       await (
         await issues.create({
-          repositoryId: 'repo-1',
+          repositoryId: 'repo-t2',
           number: 2,
           title: 't2-issue',
         })
@@ -117,7 +127,7 @@ describe('projects tenant isolation (#1600)', () => {
     await withSystemContext(async () => {
       await (
         await issues.create({
-          repositoryId: 'repo-1',
+          repositoryId: 'repo-global',
           number: 3,
           title: 'g-issue',
         })
@@ -152,20 +162,34 @@ describe('projects tenant isolation (#1600)', () => {
   });
 
   it('PullRequestCollection.findGlobal/findWithGlobals do not throw and stay tenant-scoped', async () => {
+    const repos = await RepositoryCollection.create({ db });
+    await withTenant({ tenantId: 'tenant-1' }, () =>
+      repos.create({ id: 'repo-t1', owner: 'acme', name: 't1-parent' }),
+    );
+    await withTenant({ tenantId: 'tenant-2' }, () =>
+      repos.create({ id: 'repo-t2', owner: 'acme', name: 't2-parent' }),
+    );
+    await withSystemContext(() =>
+      repos.create({ id: 'repo-global', owner: 'acme', name: 'global-parent' }),
+    );
     const prs = await PullRequestCollection.create({ db });
     await withTenant({ tenantId: 'tenant-1' }, async () => {
       await (
-        await prs.create({ repositoryId: 'repo-1', number: 1, title: 't1-pr' })
+        await prs.create({ repositoryId: 'repo-t1', number: 1, title: 't1-pr' })
       ).save();
     });
     await withTenant({ tenantId: 'tenant-2' }, async () => {
       await (
-        await prs.create({ repositoryId: 'repo-1', number: 2, title: 't2-pr' })
+        await prs.create({ repositoryId: 'repo-t2', number: 2, title: 't2-pr' })
       ).save();
     });
     await withSystemContext(async () => {
       await (
-        await prs.create({ repositoryId: 'repo-1', number: 3, title: 'g-pr' })
+        await prs.create({
+          repositoryId: 'repo-global',
+          number: 3,
+          title: 'g-pr',
+        })
       ).save();
     });
 
@@ -246,6 +270,13 @@ describe('projects tenant isolation (#1600)', () => {
   // so its tenant-global helpers never surface sibling base Issue rows, while the
   // base IssueCollection legitimately spans both subtypes. (#1600)
   it('PullRequestCollection scopes to its _meta_type — no sibling Issue rows; IssueCollection spans both', async () => {
+    const repos = await RepositoryCollection.create({ db });
+    await withTenant({ tenantId: 'tenant-1' }, () =>
+      repos.create({ id: 'repo-t1', owner: 'acme', name: 't1-parent' }),
+    );
+    await withSystemContext(() =>
+      repos.create({ id: 'repo-global', owner: 'acme', name: 'global-parent' }),
+    );
     const issues = await IssueCollection.create({ db });
     const prs = await PullRequestCollection.create({ db });
 
@@ -254,25 +285,33 @@ describe('projects tenant isolation (#1600)', () => {
     await withTenant({ tenantId: 'tenant-1' }, async () => {
       await (
         await issues.create({
-          repositoryId: 'repo-1',
+          repositoryId: 'repo-t1',
           number: 10,
           title: 't1-issue',
         })
       ).save();
       await (
-        await prs.create({ repositoryId: 'repo-1', number: 11, title: 't1-pr' })
+        await prs.create({
+          repositoryId: 'repo-t1',
+          number: 11,
+          title: 't1-pr',
+        })
       ).save();
     });
     await withSystemContext(async () => {
       await (
         await issues.create({
-          repositoryId: 'repo-1',
+          repositoryId: 'repo-global',
           number: 20,
           title: 'g-issue',
         })
       ).save();
       await (
-        await prs.create({ repositoryId: 'repo-1', number: 21, title: 'g-pr' })
+        await prs.create({
+          repositoryId: 'repo-global',
+          number: 21,
+          title: 'g-pr',
+        })
       ).save();
     });
 

--- a/packages/properties/src/__tests__/properties-tenant-isolation.test.ts
+++ b/packages/properties/src/__tests__/properties-tenant-isolation.test.ts
@@ -107,14 +107,25 @@ describe('properties tenant isolation (#1600)', () => {
 
   it('ZoneCollection.findGlobal/findWithGlobals do not throw and stay tenant-scoped', async () => {
     const zones = await ZoneCollection.create({ db });
+    const properties = await PropertyCollection.create({ db });
+    const seed = async (
+      propertyId: string,
+      domain: string,
+      zoneName: string,
+    ): Promise<void> => {
+      await (
+        await properties.create({ id: propertyId, name: domain, domain })
+      ).save();
+      await (await zones.create({ propertyId, name: zoneName })).save();
+    };
     await withTenant({ tenantId: 'tenant-1' }, async () => {
-      await (await zones.create({ propertyId: 'p1', name: 't1-zone' })).save();
+      await seed('p1', 't1.example.com', 't1-zone');
     });
     await withTenant({ tenantId: 'tenant-2' }, async () => {
-      await (await zones.create({ propertyId: 'p2', name: 't2-zone' })).save();
+      await seed('p2', 't2.example.com', 't2-zone');
     });
     await withSystemContext(async () => {
-      await (await zones.create({ propertyId: 'pg', name: 'g-zone' })).save();
+      await seed('pg', 'g.example.com', 'g-zone');
     });
 
     expect(

--- a/packages/sales/AGENTS.md
+++ b/packages/sales/AGENTS.md
@@ -53,6 +53,7 @@ Business/domain models are generally `@TenantScoped({ mode: 'optional' })` with 
 ## Gotchas
 
 - **Cents vs. rates**: `*Cents` fields are INTEGER (`= 0` defaults); `rate`/`probability`/`shareFraction` are DECIMAL (`= 0.0` defaults). Don't mix the two conventions on one field.
+- **Optional same-package foreign keys use null**: execution, supersession, earning-event, and payout references that are absent persist as `null`, never `''`; their physical database constraints remain enabled when a real id is present.
 - **Versioned terms are rows, not edits**: CommissionPlan / AttributionPolicy / ReferralAgreement amendments insert `version + 1`; active versions are save-guarded immutable.
 - **Idempotency is dedupeKey-based**: EarningEvent, Commission, and CommissionPayout carry natural keys (`conflictColumns`) — retried ingestion/settlement upserts instead of duplicating.
 - **Adjustments never rewrite**: correcting an earned/paid Commission means appending a CommissionAdjustment, not editing the Commission.

--- a/packages/sales/src/__tests__/epic-tracer.spec.ts
+++ b/packages/sales/src/__tests__/epic-tracer.spec.ts
@@ -74,6 +74,7 @@ import {
   type Referrer,
   ReferrerCollection,
 } from '../referrals/index.js';
+import { seedAgreementEvidence } from '../test-fixtures.js';
 
 /** First element or throw — keeps fixture wiring honest. */
 function first<T>(rows: T[]): T {
@@ -208,6 +209,11 @@ describe('epic tracer (#1935): referred Opportunity → explainable payable Comm
 
   beforeAll(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await seedAgreementEvidence(
+      db,
+      'agreement-execution-tracer-1',
+      'executed-agreement-tracer-1',
+    );
 
     earners = await EarnerCollection.create({ db });
     plans = await CommissionPlanCollection.create({ db });

--- a/packages/sales/src/__tests__/rounding-currency-splits.spec.ts
+++ b/packages/sales/src/__tests__/rounding-currency-splits.spec.ts
@@ -39,6 +39,7 @@ import {
   type Referrer,
   ReferrerCollection,
 } from '../referrals/index.js';
+import { seedAgreementEvidence } from '../test-fixtures.js';
 
 const NOW = new Date('2026-07-01T00:00:00Z');
 const EVENT_AT = new Date('2026-07-02T00:00:00Z');
@@ -77,6 +78,11 @@ describe('rounding, currency, splits, and attribution gates (#1932)', () => {
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await seedAgreementEvidence(
+      db,
+      'test-agreement-execution',
+      'test-executed-agreement',
+    );
     earners = await EarnerCollection.create({ db });
     plans = await CommissionPlanCollection.create({ db });
     events = await EarningEventCollection.create({ db });

--- a/packages/sales/src/agreements/__tests__/agreement-execution.test.ts
+++ b/packages/sales/src/agreements/__tests__/agreement-execution.test.ts
@@ -59,6 +59,28 @@ describe('AgreementExecutionService', () => {
     if (db && typeof db.close === 'function') await db.close();
   });
 
+  it('persists an absent supersedes reference as null', async () => {
+    await withTenant({ tenantId: TENANT }, async () => {
+      const execution = await executions.create({
+        tenantId: TENANT,
+        provider: 'fixture',
+        idempotencyKey: 'null-supersedes',
+        sourceKind: 'agreement',
+        sourceId: 'agreement-null-supersedes',
+        status: 'completed',
+      });
+      const executed = await executedAgreements.create({
+        tenantId: TENANT,
+        executionId: execution.id as string,
+        sourceKind: 'agreement',
+        sourceId: 'agreement-null-supersedes',
+        acceptedAt: new Date('2026-01-01T00:00:00.000Z'),
+      });
+      const loaded = await executedAgreements.get({ id: executed.id });
+      expect(loaded?.supersedesExecutedAgreementId).toBeNull();
+    });
+  });
+
   it('creates once, stores exact source evidence, and never persists access codes', async () => {
     await withTenant({ tenantId: TENANT }, async () => {
       const first = await service.createExecution(createInput());

--- a/packages/sales/src/agreements/__tests__/agreement-execution.test.ts
+++ b/packages/sales/src/agreements/__tests__/agreement-execution.test.ts
@@ -391,6 +391,7 @@ describe('AgreementExecutionService', () => {
       expect(executed?.auditTrailSizeBytes).toBe(AUDIT.byteLength);
       expect(executed?.auditTrailFilename).toBe('audit_trail.pdf');
       expect(executed?.signerEvidence).toContain('signer@example.test');
+      expect(executed?.supersedesExecutedAgreementId).toBeNull();
 
       if (!executed) throw new Error('expected executed agreement');
       executed.signedDocumentSha256 = 'tampered';

--- a/packages/sales/src/agreements/models/ExecutedAgreement.ts
+++ b/packages/sales/src/agreements/models/ExecutedAgreement.ts
@@ -62,7 +62,7 @@ export class ExecutedAgreement extends SmrtObject {
   effectiveTo: Date | null = null;
 
   @foreignKey('ExecutedAgreement')
-  supersedesExecutedAgreementId: string = '';
+  supersedesExecutedAgreementId: string | null = null;
 
   metadata: string = '{}';
 

--- a/packages/sales/src/agreements/services/AgreementExecutionService.ts
+++ b/packages/sales/src/agreements/services/AgreementExecutionService.ts
@@ -824,7 +824,8 @@ export class AgreementExecutionService {
       acceptedAt,
       effectiveFrom: execution.effectiveFrom ?? acceptedAt,
       effectiveTo: execution.effectiveTo,
-      supersedesExecutedAgreementId: execution.supersedesExecutedAgreementId,
+      supersedesExecutedAgreementId:
+        execution.supersedesExecutedAgreementId || null,
       metadata: execution.metadata,
     });
     await this.ensureExecutedAgreementAssociations(created.agreement);

--- a/packages/sales/src/agreements/types.ts
+++ b/packages/sales/src/agreements/types.ts
@@ -126,7 +126,7 @@ export interface ExecutedAgreementOptions extends SmrtObjectOptions {
   acceptedAt?: Date | string | number;
   effectiveFrom?: Date | string | number | null;
   effectiveTo?: Date | string | number | null;
-  supersedesExecutedAgreementId?: string;
+  supersedesExecutedAgreementId?: string | null;
   metadata?: string;
 }
 

--- a/packages/sales/src/commissions/__tests__/balance-payout.test.ts
+++ b/packages/sales/src/commissions/__tests__/balance-payout.test.ts
@@ -11,6 +11,7 @@
 import { getTestDatabase } from '@happyvertical/smrt-core';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { seedCommissionPayout } from '../../test-fixtures.js';
 import { CommissionAdjustmentCollection } from '../collections/CommissionAdjustmentCollection.js';
 import { CommissionCollection } from '../collections/CommissionCollection.js';
 import { CommissionPayoutCollection } from '../collections/CommissionPayoutCollection.js';
@@ -50,6 +51,9 @@ describe('Balances and payout batches', () => {
       payoutThresholdCents: 5000,
       payoutMethod: 'paypal',
     });
+    await seedCommissionPayout(db, earner.id as string, 'already-settled');
+    await seedCommissionPayout(db, earner.id as string, 'some-other-payout');
+    await seedCommissionPayout(db, earner.id as string, 'prior-batch');
   });
 
   afterEach(async () => {

--- a/packages/sales/src/commissions/__tests__/commission-adjustment-service.test.ts
+++ b/packages/sales/src/commissions/__tests__/commission-adjustment-service.test.ts
@@ -378,7 +378,13 @@ describe('CommissionAdjustmentService', () => {
   });
 
   it('returns an exact persisted replay on DuckDB native UUID columns', async () => {
-    const duckDb = await getTestDatabase({ type: 'duckdb', url: ':memory:' });
+    const duckDb = await getTestDatabase({
+      type: 'duckdb',
+      url: ':memory:',
+      // This UUID replay test is not a referential-enforcement lane; DuckDB
+      // cannot implement the package's generated ON UPDATE CASCADE actions.
+      omitForeignKeyConstraints: true,
+    });
     const duckTenantId = randomUUID();
     try {
       const duckEarners = await EarnerCollection.create({ db: duckDb });

--- a/packages/sales/src/commissions/__tests__/commission-adjustment-service.test.ts
+++ b/packages/sales/src/commissions/__tests__/commission-adjustment-service.test.ts
@@ -377,12 +377,14 @@ describe('CommissionAdjustmentService', () => {
     ).toHaveLength(0);
   });
 
-  it('returns an exact persisted replay on DuckDB native UUID columns', async () => {
+  it('returns an exact persisted replay on JSON-on-DuckDB storage', async () => {
     const duckDb = await getTestDatabase({
-      type: 'duckdb',
+      type: 'json',
       url: ':memory:',
-      // This UUID replay test is not a referential-enforcement lane; DuckDB
-      // cannot implement the package's generated ON UPDATE CASCADE actions.
+      // This replay test is not a referential-enforcement or native-type lane;
+      // DuckDB cannot implement the package's generated ON UPDATE CASCADE
+      // actions. Core's #2413 test-database regressions separately prove that
+      // explicit and existing native DuckDB adapters receive UUID DDL.
       omitForeignKeyConstraints: true,
     });
     const duckTenantId = randomUUID();

--- a/packages/sales/src/commissions/__tests__/commission-lifecycle.test.ts
+++ b/packages/sales/src/commissions/__tests__/commission-lifecycle.test.ts
@@ -10,6 +10,7 @@
 import { getTestDatabase } from '@happyvertical/smrt-core';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { seedCommissionPayout, seedEarningEvent } from '../../test-fixtures.js';
 import { CommissionAdjustmentCollection } from '../collections/CommissionAdjustmentCollection.js';
 import { CommissionCollection } from '../collections/CommissionCollection.js';
 import { EarnerCollection } from '../collections/EarnerCollection.js';
@@ -35,6 +36,11 @@ describe('Commission lifecycle', () => {
       displayName: 'Casey Rep',
       status: 'active',
     });
+    for (const payoutId of ['payout-1', 'payout-42', 'payout-x']) {
+      await seedCommissionPayout(db, earner.id as string, payoutId);
+    }
+    await seedEarningEvent(db, 'evt-a');
+    await seedEarningEvent(db, 'evt-b');
   });
 
   afterEach(async () => {
@@ -56,6 +62,24 @@ describe('Commission lifecycle', () => {
       ...overrides,
     });
   }
+
+  it('persists absent optional foreign keys as null', async () => {
+    const commission = await createCommission({ status: 'paid' });
+    const adjustment = await adjustments.create({
+      commissionId: commission.id as string,
+      earnerId: earner.id as string,
+      adjustmentKind: 'credit',
+      amountCents: 100,
+      currency: 'USD',
+      reason: 'null optional FK regression',
+    });
+
+    const loadedCommission = await commissions.get({ id: commission.id });
+    const loadedAdjustment = await adjustments.get({ id: adjustment.id });
+    expect(loadedCommission?.earningEventId).toBeNull();
+    expect(loadedCommission?.payoutId).toBeNull();
+    expect(loadedAdjustment?.payoutId).toBeNull();
+  });
 
   it('walks the full chain and stamps each timestamp', async () => {
     const commission = await createCommission();

--- a/packages/sales/src/commissions/__tests__/payout-source-transitions.test.ts
+++ b/packages/sales/src/commissions/__tests__/payout-source-transitions.test.ts
@@ -261,7 +261,7 @@ describe('Source-authorized payout lifecycle transitions (#1987)', () => {
       expect(refused.payout).toBeNull();
     });
 
-    it('proves adjustment ownership through the parent and fails closed when the parent cannot vouch', async () => {
+    it('proves adjustment ownership through the parent and refuses a missing parent', async () => {
       // Batch whose membership is one adjustment; its parent commission
       // belongs to NETWORK_A — authorizing against NETWORK_B must refuse.
       const parent = await createPayableCommission(NETWORK_A);
@@ -297,8 +297,9 @@ describe('Source-authorized payout lifecycle transitions (#1987)', () => {
       });
       expect(rightSource.outcome).toBe('transitioned');
 
-      // An adjustment whose parent row is unloadable can vouch for
-      // nothing: approve must refuse adjustment_parent_missing.
+      // Physical FK enforcement now prevents the orphan state before the
+      // service can observe it. Existing-orphan handling remains a migration
+      // concern; fresh writes must fail at persistence.
       const orphanBatch = await payouts.create({
         earnerId: earner.id as string,
         currency: 'USD',
@@ -309,22 +310,17 @@ describe('Source-authorized payout lifecycle transitions (#1987)', () => {
         idempotencyKey: 'adj-orphan-batch',
         ...NETWORK_A,
       });
-      await adjustments.create({
-        commissionId: '00000000-0000-4000-8000-00000000dead',
-        earnerId: earner.id as string,
-        adjustmentKind: 'credit',
-        amountCents: 120,
-        currency: 'USD',
-        reason: 'orphaned adjustment',
-        payoutId: orphanBatch.id as string,
-      });
-      const orphaned = await service.transitionPayoutForSource({
-        payoutId: orphanBatch.id as string,
-        ...NETWORK_A,
-        action: 'approve',
-      });
-      expect(orphaned.outcome).toBe('refused');
-      expect(orphaned.refusal?.reason).toBe('adjustment_parent_missing');
+      await expect(
+        adjustments.create({
+          commissionId: '00000000-0000-4000-8000-00000000dead',
+          earnerId: earner.id as string,
+          adjustmentKind: 'credit',
+          amountCents: 120,
+          currency: 'USD',
+          reason: 'orphaned adjustment',
+          payoutId: orphanBatch.id as string,
+        }),
+      ).rejects.toThrow(/FOREIGN KEY constraint failed/);
     });
 
     it('refuses memberless payouts through the source-authorized door', async () => {

--- a/packages/sales/src/commissions/models/Commission.ts
+++ b/packages/sales/src/commissions/models/Commission.ts
@@ -82,7 +82,7 @@ export class Commission extends SmrtObject {
 
   /** The {@link EarningEvent} evidence row this commission derives from. */
   @foreignKey('EarningEvent')
-  earningEventId: string = '';
+  earningEventId: string | null = null;
 
   /** Snapshot reference: plan key at calculation time. */
   planKey: string = '';
@@ -159,7 +159,7 @@ export class Commission extends SmrtObject {
    * until a payout batch stamps it.
    */
   @foreignKey('CommissionPayout')
-  payoutId: string = '';
+  payoutId: string | null = null;
 
   /** Copied from the earning event for reporting (generic source pair). */
   sourceKind: string = '';

--- a/packages/sales/src/commissions/models/CommissionAdjustment.ts
+++ b/packages/sales/src/commissions/models/CommissionAdjustment.ts
@@ -89,7 +89,7 @@ export class CommissionAdjustment extends SmrtObject {
    * until stamped. This is the ONLY field mutable after creation.
    */
   @foreignKey('CommissionPayout')
-  payoutId: string = '';
+  payoutId: string | null = null;
 
   /** Additional metadata as a JSON string. Frozen once persisted. */
   metadata: string = '{}';

--- a/packages/sales/src/commissions/services/CommissionPayoutService.ts
+++ b/packages/sales/src/commissions/services/CommissionPayoutService.ts
@@ -753,12 +753,14 @@ export class CommissionPayoutService {
 
     const membersByPayout = new Map<string, Commission[]>();
     for (const commission of members) {
+      if (!commission.payoutId) continue;
       const bucket = membersByPayout.get(commission.payoutId);
       if (bucket) bucket.push(commission);
       else membersByPayout.set(commission.payoutId, [commission]);
     }
     const adjustmentsByPayout = new Map<string, CommissionAdjustment[]>();
     for (const adjustment of memberAdjustments) {
+      if (!adjustment.payoutId) continue;
       const bucket = adjustmentsByPayout.get(adjustment.payoutId);
       if (bucket) bucket.push(adjustment);
       else adjustmentsByPayout.set(adjustment.payoutId, [adjustment]);

--- a/packages/sales/src/commissions/types.ts
+++ b/packages/sales/src/commissions/types.ts
@@ -310,7 +310,7 @@ export interface EarningEventOptions extends SmrtObjectOptions {
 export interface CommissionOptions extends SmrtObjectOptions {
   tenantId?: string | null;
   earnerId?: string;
-  earningEventId?: string;
+  earningEventId?: string | null;
   planKey?: string;
   planVersion?: number;
   componentKey?: string;
@@ -329,7 +329,7 @@ export interface CommissionOptions extends SmrtObjectOptions {
   approvedAt?: Date | string | number | null;
   payableAt?: Date | string | number | null;
   paidAt?: Date | string | number | null;
-  payoutId?: string;
+  payoutId?: string | null;
   sourceKind?: string;
   sourceId?: string;
   calculationTrace?: string;
@@ -347,7 +347,7 @@ export interface CommissionAdjustmentOptions extends SmrtObjectOptions {
   currency?: string;
   reason?: string;
   createdByProfileId?: string;
-  payoutId?: string;
+  payoutId?: string | null;
   metadata?: string;
 }
 

--- a/packages/sales/src/referrals/__tests__/agreement-execution-binding.test.ts
+++ b/packages/sales/src/referrals/__tests__/agreement-execution-binding.test.ts
@@ -125,8 +125,8 @@ describe('ReferralAgreementExecutionService', () => {
         clearingDays: 45,
         effectiveFrom: new Date('2026-09-01T00:00:00Z'),
       });
-      expect(v2.executionId).toBe('');
-      expect(v2.executedAgreementId).toBe('');
+      expect(v2.executionId).toBeNull();
+      expect(v2.executedAgreementId).toBeNull();
       const sentV2 = await service.requestSignature(requestInput(v2.id ?? ''));
       const executedV2 = await createExecuted(
         sentV2.executionId,

--- a/packages/sales/src/referrals/__tests__/commission-bridge.test.ts
+++ b/packages/sales/src/referrals/__tests__/commission-bridge.test.ts
@@ -21,6 +21,7 @@ import {
   EarnerCollection,
   EarningEventCollection,
 } from '../../commissions/index.js';
+import { seedAgreementEvidence } from '../../test-fixtures.js';
 import { AttributionPolicyCollection } from '../collections/AttributionPolicyCollection.js';
 import { ReferralAgreementCollection } from '../collections/ReferralAgreementCollection.js';
 import { ReferralCollection } from '../collections/ReferralCollection.js';
@@ -58,6 +59,11 @@ describe('ReferralCommissionService (referrals → commissions bridge)', () => {
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await seedAgreementEvidence(
+      db,
+      'test-agreement-execution',
+      'test-executed-agreement',
+    );
     referrals = await ReferralCollection.create({ db });
     snapshots = await ReferralTermSnapshotCollection.create({ db });
     referrers = await ReferrerCollection.create({ db });

--- a/packages/sales/src/referrals/__tests__/policy-and-agreement.test.ts
+++ b/packages/sales/src/referrals/__tests__/policy-and-agreement.test.ts
@@ -11,6 +11,7 @@
 import { getTestDatabase } from '@happyvertical/smrt-core';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { seedAgreementEvidence } from '../../test-fixtures.js';
 import { AttributionPolicyCollection } from '../collections/AttributionPolicyCollection.js';
 import { ReferralAgreementCollection } from '../collections/ReferralAgreementCollection.js';
 import { ReferralProgramCollection } from '../collections/ReferralProgramCollection.js';
@@ -22,6 +23,8 @@ describe('AttributionPolicy versioning', () => {
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await seedAgreementEvidence(db, 'execution-1', 'executed-1');
+    await seedAgreementEvidence(db, 'execution-2', 'executed-2');
     policies = await AttributionPolicyCollection.create({ db });
   });
 
@@ -225,6 +228,8 @@ describe('ReferralAgreement versioning', () => {
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await seedAgreementEvidence(db, 'execution-1', 'executed-1');
+    await seedAgreementEvidence(db, 'execution-2', 'executed-2');
     agreements = await ReferralAgreementCollection.create({ db });
     const referrers = await ReferrerCollection.create({ db });
     const programs = await ReferralProgramCollection.create({ db });
@@ -245,6 +250,19 @@ describe('ReferralAgreement versioning', () => {
     if (db && typeof db.close === 'function') {
       await db.close();
     }
+  });
+
+  it('persists unsigned optional execution references as null', async () => {
+    const draft = await agreements.create({
+      referrerId,
+      programId,
+      version: 1,
+      status: 'draft',
+      commissionPlanKey: 'referral-standard',
+    });
+    const loaded = await agreements.get({ id: draft.id });
+    expect(loaded?.executionId).toBeNull();
+    expect(loaded?.executedAgreementId).toBeNull();
   });
 
   it('requires a commissionPlanKey to activate', async () => {
@@ -347,8 +365,8 @@ describe('ReferralAgreement versioning', () => {
       1,
     );
 
-    expect(v2.executionId).toBe('');
-    expect(v2.executedAgreementId).toBe('');
+    expect(v2.executionId).toBeNull();
+    expect(v2.executedAgreementId).toBeNull();
     v2.bindExecution('execution-2');
     v2.bindExecutedAgreement('executed-2');
     v2.activate();
@@ -441,8 +459,8 @@ describe('ReferralAgreement versioning', () => {
     expect(amendment.commissionPlanVersion).toBe(0);
     expect(amendment.clearingDays).toBe(30);
     expect(amendment.approvalMode).toBe('auto');
-    expect(amendment.executionId).toBe('');
-    expect(amendment.executedAgreementId).toBe('');
+    expect(amendment.executionId).toBeNull();
+    expect(amendment.executedAgreementId).toBeNull();
   });
 
   it('refuses to amend a pair with no versions', async () => {

--- a/packages/sales/src/referrals/__tests__/qualification.test.ts
+++ b/packages/sales/src/referrals/__tests__/qualification.test.ts
@@ -15,6 +15,7 @@ import {
   CommissionPlanCollection,
   type CommissionPlanComponent,
 } from '../../commissions/index.js';
+import { seedAgreementEvidence } from '../../test-fixtures.js';
 import { AttributionPolicyCollection } from '../collections/AttributionPolicyCollection.js';
 import { ReferralAgreementCollection } from '../collections/ReferralAgreementCollection.js';
 import { ReferralCollection } from '../collections/ReferralCollection.js';
@@ -44,6 +45,11 @@ describe('ReferralQualificationService', () => {
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    await seedAgreementEvidence(
+      db,
+      'test-agreement-execution',
+      'test-executed-agreement',
+    );
     referrals = await ReferralCollection.create({ db });
     agreements = await ReferralAgreementCollection.create({ db });
     plans = await CommissionPlanCollection.create({ db });

--- a/packages/sales/src/referrals/__tests__/schema-and-surfaces.test.ts
+++ b/packages/sales/src/referrals/__tests__/schema-and-surfaces.test.ts
@@ -10,6 +10,8 @@ import { getTestDatabase, ObjectRegistry } from '@happyvertical/smrt-core';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ReferralCollection } from '../collections/ReferralCollection.js';
+import { ReferralProgramCollection } from '../collections/ReferralProgramCollection.js';
+import { ReferrerCollection } from '../collections/ReferrerCollection.js';
 // Side-effect import: fire every model's decorators so ObjectRegistry
 // carries the full @smrt() config (api/mcp/cli/conflictColumns) for all
 // public classes and the private click-operation fence.
@@ -152,6 +154,18 @@ describe('Referrals schema and generation surfaces', () => {
     beforeEach(async () => {
       db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
       referrals = await ReferralCollection.create({ db });
+      const referrers = await ReferrerCollection.create({ db });
+      const programs = await ReferralProgramCollection.create({ db });
+      await referrers.create({
+        id: '11111111-1111-4111-8111-111111111111',
+        profileId: 'fixture-profile',
+        displayName: 'Fixture referrer',
+      });
+      await programs.create({
+        id: '22222222-2222-4222-8222-222222222222',
+        key: 'fixture-program',
+        name: 'Fixture program',
+      });
     });
 
     afterEach(async () => {

--- a/packages/sales/src/referrals/collections/ReferralAgreementCollection.ts
+++ b/packages/sales/src/referrals/collections/ReferralAgreementCollection.ts
@@ -106,8 +106,8 @@ export class ReferralAgreementCollection extends SmrtCollection<ReferralAgreemen
           : latest.effectiveTo,
       // An amendment is a fresh unsigned version. Executed evidence belongs
       // to the exact terms that were accepted and is never copied forward.
-      executionId: '',
-      executedAgreementId: '',
+      executionId: null,
+      executedAgreementId: null,
       metadata:
         changes.metadata !== undefined
           ? JSON.stringify(changes.metadata)

--- a/packages/sales/src/referrals/models/ReferralAgreement.ts
+++ b/packages/sales/src/referrals/models/ReferralAgreement.ts
@@ -121,11 +121,11 @@ export class ReferralAgreement extends SmrtObject {
 
   /** Current provider workflow while this version is being signed. */
   @foreignKey('AgreementExecution')
-  executionId: string = '';
+  executionId: string | null = null;
 
   /** Immutable executed evidence required before this version can activate. */
   @foreignKey('ExecutedAgreement')
-  executedAgreementId: string = '';
+  executedAgreementId: string | null = null;
 
   /**
    * Free-form JSON object stored as a string. Use

--- a/packages/sales/src/referrals/types.ts
+++ b/packages/sales/src/referrals/types.ts
@@ -290,8 +290,8 @@ export interface ReferralAgreementOptions extends SmrtObjectOptions {
   commissionPlanVersion?: number;
   clearingDays?: number;
   approvalMode?: ReferralAgreementApprovalMode;
-  executionId?: string;
-  executedAgreementId?: string;
+  executionId?: string | null;
+  executedAgreementId?: string | null;
   metadata?: string;
 }
 

--- a/packages/sales/src/test-fixtures.ts
+++ b/packages/sales/src/test-fixtures.ts
@@ -1,0 +1,71 @@
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { AgreementExecutionCollection } from './agreements/collections/AgreementExecutionCollection.js';
+import { ExecutedAgreementCollection } from './agreements/collections/ExecutedAgreementCollection.js';
+import { CommissionPayoutCollection } from './commissions/collections/CommissionPayoutCollection.js';
+import { EarningEventCollection } from './commissions/collections/EarningEventCollection.js';
+
+/** Create the real execution/evidence parents referenced by agreement fixtures. */
+export async function seedAgreementEvidence(
+  db: DatabaseInterface,
+  executionId: string,
+  executedAgreementId: string,
+): Promise<void> {
+  const executions = await AgreementExecutionCollection.create({ db });
+  const executedAgreements = await ExecutedAgreementCollection.create({ db });
+  const tenantId = 'fixture-tenant';
+
+  if (!(await executions.get({ id: executionId }))) {
+    await executions.create({
+      id: executionId,
+      tenantId,
+      provider: 'fixture',
+      idempotencyKey: `fixture:${executionId}`,
+      sourceKind: 'referral_agreement',
+      sourceId: executedAgreementId,
+      status: 'completed',
+    });
+  }
+
+  if (!(await executedAgreements.get({ id: executedAgreementId }))) {
+    await executedAgreements.create({
+      id: executedAgreementId,
+      tenantId,
+      executionId,
+      sourceKind: 'referral_agreement',
+      sourceId: executedAgreementId,
+      acceptedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+  }
+}
+
+export async function seedCommissionPayout(
+  db: DatabaseInterface,
+  earnerId: string,
+  payoutId: string,
+): Promise<void> {
+  const payouts = await CommissionPayoutCollection.create({ db });
+  if (await payouts.get({ id: payoutId })) return;
+  await payouts.create({
+    id: payoutId,
+    earnerId,
+    currency: 'USD',
+    status: 'pending',
+    idempotencyKey: `fixture:${payoutId}`,
+  });
+}
+
+export async function seedEarningEvent(
+  db: DatabaseInterface,
+  eventId: string,
+): Promise<void> {
+  const events = await EarningEventCollection.create({ db });
+  if (await events.get({ id: eventId })) return;
+  await events.create({
+    id: eventId,
+    eventKind: 'fixture',
+    sourceKind: 'fixture',
+    sourceId: eventId,
+    currency: 'USD',
+    dedupeKey: `fixture:${eventId}`,
+  });
+}

--- a/packages/sales/src/test-setup.ts
+++ b/packages/sales/src/test-setup.ts
@@ -1,0 +1,3 @@
+// Load every package model before test databases are prepared so generated
+// same-package foreign keys always have their complete schema dependency graph.
+import './index.js';

--- a/packages/sales/vitest.config.ts
+++ b/packages/sales/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    setupFiles: ['./src/test-setup.ts'],
     include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
     testTimeout: 30000,
     fileParallelism: false,

--- a/packages/secrets/AGENTS.md
+++ b/packages/secrets/AGENTS.md
@@ -37,6 +37,10 @@ Secret value → encrypted with TDEK (per-tenant Data Encryption Key)
 - **Expired secrets filtered by default**: pass `includeExpired: true` to list them
 - **TenantKeyCollection.cleanupRetiredKeys()**: hard-deletes after 90 days
 - **Audit logging optional but default**: failures logged to console, not thrown
+- **Audit rows outlive secrets**: `SecretAuditLog.secretId` uses the explicit
+  same-package app-side-only FK option. It retains relationship metadata and an
+  index, but emits no physical constraint because compliance logs are retained
+  for 1-7 years while secrets may be deleted or purged during key-drift repair.
 
 ## Known exceptions to monorepo standards
 
@@ -63,4 +67,5 @@ inline comment pointing back to this section.
   `@happyvertical/smrt-tenancy` at the call site — there are no such cross-
   tenant call sites in this package today, but consumers building compliance
   tooling should adopt that pattern explicitly rather than relying on
-  decorator-implicit filtering.
+  decorator-implicit filtering. Its `secretId` relationship is also deliberately
+  app-side-only so immutable audit history can survive deletion of the secret.

--- a/packages/secrets/src/__tests__/secret-service.test.ts
+++ b/packages/secrets/src/__tests__/secret-service.test.ts
@@ -9,6 +9,7 @@
  * 5. Audit logging
  */
 
+import { ObjectRegistry } from '@happyvertical/smrt-core';
 import { getTestDatabase } from '@happyvertical/smrt-core/testing';
 import {
   disableTenancy,
@@ -65,6 +66,22 @@ describe('SecretService', () => {
   afterEach(() => {
     disableTenancy();
     delete process.env.SMRT_SECRET_MASTER_KEY;
+  });
+
+  it('keeps retained secret audit history app-side only', async () => {
+    const fields = await ObjectRegistry.getAllFields('SecretAuditLog');
+    const schema =
+      ObjectRegistry.getAllSchemasAsDefinitions().secret_audit_logs;
+
+    expect(fields.get('secretId')?.type).toBe('foreignKey');
+    expect(fields.get('secretId')?._meta?.constraint).toBe(false);
+    expect(schema.columns.secret_id.referenceKind).toBe('foreignKey');
+    expect(schema.columns.secret_id.foreignKey).toBeUndefined();
+    expect(schema.foreignKeys).toEqual([]);
+    expect(schema.dependencies).not.toContain('secrets');
+    expect(
+      schema.indexes.some((index) => index.columns[0] === 'secret_id'),
+    ).toBe(true);
   });
 
   describe('Basic operations', () => {

--- a/packages/secrets/src/models/SecretAuditLog.ts
+++ b/packages/secrets/src/models/SecretAuditLog.ts
@@ -108,9 +108,12 @@ export class SecretAuditLog extends SmrtObject {
   tenantId: string | null = null;
 
   /**
-   * ID of the secret (may be null for deleted secrets)
+   * ID of the secret (may identify a secret that has since been deleted).
+   *
+   * Compliance audit rows intentionally outlive their source secret, so this
+   * remains an app-side relationship without a physical database constraint.
    */
-  @foreignKey('Secret')
+  @foreignKey('Secret', { constraint: false })
   secretId: string | null = null;
 
   /**

--- a/packages/sites/src/__tests__/site-agent-binding-collection.test.ts
+++ b/packages/sites/src/__tests__/site-agent-binding-collection.test.ts
@@ -13,12 +13,24 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SiteAgentBindingCollection } from '../collections/SiteAgentBindingCollection';
+import { SiteCollection } from '../collections/SiteCollection';
 
 describe('SiteAgentBindingCollection', () => {
   let dbPath: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     dbPath = join(tmpdir(), `smrt-binding-collection-test-${Date.now()}.db`);
+    const sites = await SiteCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+    for (const id of ['site-1', 'site-2', 'site-3']) {
+      await sites.create({
+        id,
+        tenantId: 'tenant-1',
+        name: `Test ${id}`,
+        domain: `${id}.example.com`,
+      });
+    }
   });
 
   afterEach(() => {

--- a/packages/sites/src/__tests__/site-agent-binding.test.ts
+++ b/packages/sites/src/__tests__/site-agent-binding.test.ts
@@ -11,12 +11,24 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SiteAgentBindingCollection } from '../collections/SiteAgentBindingCollection';
+import { SiteCollection } from '../collections/SiteCollection';
 
 describe('SiteAgentBinding', () => {
   let dbPath: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     dbPath = join(tmpdir(), `smrt-binding-test-${Date.now()}.db`);
+    const sites = await SiteCollection.create({
+      db: { type: 'sqlite', url: dbPath },
+    });
+    for (const id of ['site-1', 'site-2', 'site-3', 'site-4', 'site-5']) {
+      await sites.create({
+        id,
+        tenantId: 'tenant-1',
+        name: `Test ${id}`,
+        domain: `${id}.example.com`,
+      });
+    }
   });
 
   afterEach(() => {

--- a/packages/social/src/social.spec.ts
+++ b/packages/social/src/social.spec.ts
@@ -45,6 +45,32 @@ async function withSocialTestDb<T>(
   }
 }
 
+async function seedSocialAccount(
+  db: DatabaseInterface,
+  id = 'account-1',
+): Promise<SocialAccount> {
+  const accounts = await SocialAccountCollection.create({ db });
+  return accounts.create({
+    id,
+    name: `Test account ${id}`,
+    platform: 'x',
+    status: 'disconnected',
+  });
+}
+
+async function seedSocialPost(
+  db: DatabaseInterface,
+  id = 'post-1',
+): Promise<SocialPost> {
+  const account = await seedSocialAccount(db);
+  const posts = await SocialPostCollection.create({ db });
+  return posts.create({
+    id,
+    socialAccountId: account.id!,
+    status: 'draft',
+  });
+}
+
 describe('smrt-social models', () => {
   afterEach(() => {
     disableTenancy();
@@ -185,9 +211,10 @@ describe('smrt-social models', () => {
 
   it('does not stamp dry-run or staged posts as published', async () => {
     await withSocialTestDb(async (db) => {
+      const account = await seedSocialAccount(db);
       const posts = await SocialPostCollection.create({ db });
       const post = await posts.create({
-        socialAccountId: 'account-1',
+        socialAccountId: account.id!,
         postType: 'link',
         status: 'publishing',
       });
@@ -206,10 +233,11 @@ describe('smrt-social models', () => {
 
   it('preserves an existing published timestamp when a later staged write succeeds', async () => {
     await withSocialTestDb(async (db) => {
+      const account = await seedSocialAccount(db);
       const posts = await SocialPostCollection.create({ db });
       const publishedAt = new Date('2026-05-07T12:00:00Z');
       const post = await posts.create({
-        socialAccountId: 'account-1',
+        socialAccountId: account.id!,
         postType: 'link',
         status: 'publishing',
         publishedAt,
@@ -365,24 +393,25 @@ describe('smrt-social models', () => {
 
   it('finds only posts that are due for publish', async () => {
     await withSocialTestDb(async (db) => {
+      const account = await seedSocialAccount(db);
       const posts = await SocialPostCollection.create({ db });
       const now = new Date('2026-05-08T12:00:00Z');
       const approved = await posts.create({
-        socialAccountId: 'account-1',
+        socialAccountId: account.id!,
         status: 'approved',
       });
       const scheduledDue = await posts.create({
-        socialAccountId: 'account-1',
+        socialAccountId: account.id!,
         status: 'scheduled',
         scheduledAt: new Date('2026-05-08T11:00:00Z'),
       });
       await posts.create({
-        socialAccountId: 'account-1',
+        socialAccountId: account.id!,
         status: 'scheduled',
         scheduledAt: new Date('2026-05-08T13:00:00Z'),
       });
       await posts.create({
-        socialAccountId: 'account-1',
+        socialAccountId: account.id!,
         status: 'draft',
       });
 
@@ -397,14 +426,15 @@ describe('smrt-social models', () => {
 
   it('creates drafts and records failure plus analytics lifecycle updates', async () => {
     await withSocialTestDb(async (db) => {
+      const account = await seedSocialAccount(db);
       const posts = await SocialPostCollection.create({ db });
       const syncedAt = new Date('2026-05-08T12:30:00Z');
       const draft = await posts.createDraft({
-        socialAccountId: 'account-1',
+        socialAccountId: account.id!,
         linkUrl: 'https://bentleyalberta.com/story',
       });
       const scheduled = await posts.createDraft({
-        socialAccountId: 'account-1',
+        socialAccountId: account.id!,
         mediaUrl: 'https://assets.example/video.mp4',
         scheduledAt: new Date('2026-05-08T13:00:00Z'),
       });
@@ -460,11 +490,12 @@ describe('smrt-social models', () => {
 
   it('records analytics snapshots and exposes the latest snapshot for a post', async () => {
     await withSocialTestDb(async (db) => {
+      const post = await seedSocialPost(db);
       const snapshots = await SocialPostAnalyticsSnapshotCollection.create({
         db,
       });
       await snapshots.recordSnapshot({
-        socialPostId: 'post-1',
+        socialPostId: post.id!,
         platform: 'x',
         metrics: {
           views: 10,
@@ -473,7 +504,7 @@ describe('smrt-social models', () => {
         capturedAt: new Date('2026-05-08T11:00:00Z'),
       });
       const latest = await snapshots.recordSnapshot({
-        socialPostId: 'post-1',
+        socialPostId: post.id!,
         platform: 'x',
         metrics: { views: 12 },
         raw: { public_metrics: { impression_count: 12 } },
@@ -481,7 +512,7 @@ describe('smrt-social models', () => {
       });
 
       await expect(
-        snapshots.findLatestForPost('post-1'),
+        snapshots.findLatestForPost(post.id!),
       ).resolves.toMatchObject({
         id: latest.id,
         platform: 'x',

--- a/packages/subscriptions/src/__tests__/commercial.test.ts
+++ b/packages/subscriptions/src/__tests__/commercial.test.ts
@@ -35,6 +35,21 @@ describe('commercial usage tracer', () => {
     await usage.db.close?.();
   });
 
+  async function seedUsageEvent(
+    id: string,
+    tenantId: string,
+    metricKey = 'ai.tokens',
+  ): Promise<void> {
+    await usage.create({
+      id,
+      tenantId,
+      metricKey,
+      quantity: 0,
+      windowStart: new Date('2026-07-01T00:00:00Z'),
+      windowEnd: new Date('2026-07-01T00:01:00Z'),
+    });
+  }
+
   it('keeps usage idempotent and prices an immutable effective-dated snapshot', async () => {
     const event = await service.record({
       tenantId: '11111111-1111-4111-8111-111111111111',
@@ -230,6 +245,7 @@ describe('commercial usage tracer', () => {
   });
 
   it('rejects adjustments until a charge is approved', async () => {
+    await seedUsageEvent('usage-draft', '11111111-1111-4111-8111-111111111111');
     const charge = await charges.create({
       tenantId: '11111111-1111-4111-8111-111111111111',
       usageEventId: 'usage-draft',
@@ -242,6 +258,10 @@ describe('commercial usage tracer', () => {
   });
 
   it('deduplicates concurrent sourced billing adjustments', async () => {
+    await seedUsageEvent(
+      'usage-adjustment-retry',
+      '11111111-1111-4111-8111-111111111111',
+    );
     const charge = await charges.create({
       tenantId: '11111111-1111-4111-8111-111111111111',
       usageEventId: 'usage-adjustment-retry',
@@ -504,6 +524,7 @@ describe('commercial usage tracer', () => {
       ['ai.tokens', 4],
       ['storage.bytes', 5],
     ] as const) {
+      await seedUsageEvent(`usage-${metricKey}`, tenantId, metricKey);
       await charges.create({
         tenantId,
         usageEventId: `usage-${metricKey}`,
@@ -551,6 +572,7 @@ describe('commercial usage tracer', () => {
       limitAmount: 5,
       behavior: 'block',
     });
+    await seedUsageEvent('usage-earlier-this-month', tenantId);
     await charges.create({
       tenantId,
       usageEventId: 'usage-earlier-this-month',
@@ -597,6 +619,7 @@ describe('commercial usage tracer', () => {
       ['USD', 4],
       ['EUR', 100],
     ] as const) {
+      await seedUsageEvent(`usage-${currency.toLowerCase()}`, tenantId);
       await charges.create({
         tenantId,
         usageEventId: `usage-${currency.toLowerCase()}`,
@@ -680,6 +703,7 @@ describe('commercial usage tracer', () => {
       limitAmount: 10,
       behavior: 'block',
     });
+    await seedUsageEvent('usage-approved-in-july', tenantId);
     await charges.create({
       tenantId,
       usageEventId: 'usage-approved-in-july',

--- a/packages/subscriptions/src/__tests__/polymorphic-subscriber.test.ts
+++ b/packages/subscriptions/src/__tests__/polymorphic-subscriber.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SubscriptionPlanCollection } from '../collections/SubscriptionPlanCollection.js';
 import { TenantSubscriptionCollection } from '../collections/TenantSubscriptionCollection.js';
 import { TenantUsageMetricCollection } from '../collections/TenantUsageMetricCollection.js';
 import { SubscriptionPlan } from '../models/SubscriptionPlan.js';
@@ -472,6 +473,10 @@ describe('polymorphic subscriber — TenantSubscriptionCollection conflict key',
     subs = await TenantSubscriptionCollection.create({
       db: { type: 'sqlite', url: ':memory:' },
     });
+    const plans = await SubscriptionPlanCollection.create({ db: subs.db });
+    for (const id of ['plan-mkt', 'plan-pro', 'plan-operator']) {
+      await plans.create({ id, planKey: id, name: id });
+    }
   });
 
   afterEach(async () => {

--- a/packages/support/src/services/time-entry-approval-service.test.ts
+++ b/packages/support/src/services/time-entry-approval-service.test.ts
@@ -14,6 +14,10 @@ import type { ServiceTimeEntry } from '../models/service-time-entry.js';
 import type { SupportCase } from '../models/support-case.js';
 import type { SupportPlan } from '../models/support-plan.js';
 import {
+  type SupportSpecialist,
+  SupportSpecialistCollection,
+} from '../models/support-specialist.js';
+import {
   APPROVE_TIME_ENTRY_PERMISSION,
   supportPrincipalFromPermissions,
 } from '../permissions.js';
@@ -52,6 +56,7 @@ describe('TimeEntryApprovalService', () => {
   let caseService: SupportCaseService;
   let entryService: ServiceTimeEntryService;
   let approvalService: TimeEntryApprovalService;
+  let specialists: SupportSpecialistCollection;
 
   beforeEach(async () => {
     ctx = await createIsolatedTestDbFromManifest({
@@ -66,6 +71,7 @@ describe('TimeEntryApprovalService', () => {
       db: ctx.db,
       caseService,
     });
+    specialists = await SupportSpecialistCollection.create({ db: ctx.db });
   });
 
   afterEach(async () => {
@@ -110,6 +116,16 @@ describe('TimeEntryApprovalService', () => {
       ...overrides,
     });
     return entryService.submit(entry, { byProfileId: 'profile-worker-1' });
+  }
+
+  async function specialistFor(
+    tenantId: string | null = null,
+  ): Promise<SupportSpecialist> {
+    return specialists.create({
+      tenantId,
+      profileId: 'profile-worker-1',
+      displayName: 'Worker One',
+    });
   }
 
   describe('approval paths (FR-36)', () => {
@@ -288,8 +304,9 @@ describe('TimeEntryApprovalService', () => {
 
   describe('compensation derivation (Support Compensation Plan side)', () => {
     it('prefers the specialist-specific plan over the tenant default', async () => {
+      const specialist = await specialistFor();
       await approvalService.compensationPlans.create({
-        specialistId: 'spec-1',
+        specialistId: specialist.id,
         name: 'Specific',
         hourlyRate: 4500,
         effectiveFrom: new Date('2026-01-01T00:00:00.000Z'),
@@ -307,7 +324,7 @@ describe('TimeEntryApprovalService', () => {
       );
       const supportCase = await caseUnder(plan);
       const entry = await submittedEntry(supportCase.id ?? '', {
-        specialistId: 'spec-1',
+        specialistId: specialist.id,
         durationSeconds: 7200,
       });
 
@@ -336,6 +353,7 @@ describe('TimeEntryApprovalService', () => {
     });
 
     it("never prices work with another tenant's default plan", async () => {
+      const specialist = await specialistFor('tenant-1');
       // A foreign tenant's default plan exists and is newer/richer.
       await approvalService.compensationPlans.create({
         tenantId: 'tenant-other',
@@ -358,7 +376,7 @@ describe('TimeEntryApprovalService', () => {
       );
       const supportCase = await caseUnder(plan, { tenantId: 'tenant-1' });
       const entry = await submittedEntry(supportCase.id ?? '', {
-        specialistId: 'spec-1',
+        specialistId: specialist.id,
         durationSeconds: 3600,
       });
 
@@ -374,8 +392,9 @@ describe('TimeEntryApprovalService', () => {
     });
 
     it('falls back to the tenant default when the specific plan has expired', async () => {
+      const specialist = await specialistFor();
       await approvalService.compensationPlans.create({
-        specialistId: 'spec-1',
+        specialistId: specialist.id,
         name: 'Expired specific',
         hourlyRate: 4500,
         effectiveFrom: new Date('2026-01-01T00:00:00.000Z'),
@@ -392,7 +411,7 @@ describe('TimeEntryApprovalService', () => {
       const supportCase = await caseUnder(plan);
       // Work instant (endedAt 2026-07-01) is past the specific plan's window.
       const entry = await submittedEntry(supportCase.id ?? '', {
-        specialistId: 'spec-1',
+        specialistId: specialist.id,
         durationSeconds: 7200,
       });
 
@@ -751,8 +770,9 @@ describe('TimeEntryApprovalService', () => {
   });
 
   it('records a case event carrying the charge amount and never the compensation', async () => {
+    const specialist = await specialistFor();
     await approvalService.compensationPlans.create({
-      specialistId: 'spec-1',
+      specialistId: specialist.id,
       name: 'Comp',
       hourlyRate: 4500,
     });
@@ -762,7 +782,7 @@ describe('TimeEntryApprovalService', () => {
     );
     const supportCase = await caseUnder(plan);
     const entry = await submittedEntry(supportCase.id ?? '', {
-      specialistId: 'spec-1',
+      specialistId: specialist.id,
     });
 
     const { charge, compensation, path } = await approvalService.approve(

--- a/packages/users/src/__tests__/credential-retention.test.ts
+++ b/packages/users/src/__tests__/credential-retention.test.ts
@@ -23,6 +23,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { UsersCliAuthRequestCollection } from '../collections/CliAuthRequestCollection.js';
 import { UsersMagicLinkTokenCollection } from '../collections/MagicLinkTokenCollection.js';
 import { SessionCollection } from '../collections/SessionCollection.js';
+import { TenantCollection } from '../collections/TenantCollection.js';
+import { UserCollection } from '../collections/UserCollection.js';
 import {
   CLI_AUTH_RETENTION_TASK,
   MAGIC_LINK_RETENTION_TASK,
@@ -36,6 +38,7 @@ const MINUTE_MS = 60 * 1000;
 
 let dbPath: string;
 let sessions: SessionCollection;
+let users: UserCollection;
 let tokens: UsersMagicLinkTokenCollection;
 let requests: UsersCliAuthRequestCollection;
 let db: DatabaseInterface;
@@ -45,6 +48,8 @@ beforeEach(async () => {
   dbPath = join(tmpdir(), `smrt-credential-retention-${Date.now()}.db`);
   const options = { db: { type: 'sqlite' as const, url: dbPath } };
 
+  users = await UserCollection.create(options);
+  await TenantCollection.create(options);
   sessions = await SessionCollection.create(options);
   tokens = await UsersMagicLinkTokenCollection.create(options);
   requests = await UsersCliAuthRequestCollection.create(options);
@@ -67,6 +72,11 @@ async function seedSession(options: {
   expiresAt: Date;
   status?: SessionStatus;
 }): Promise<void> {
+  const user = await users.create({
+    id: options.userId,
+    email: `${options.userId}@retention.test`,
+  });
+  await user.save();
   const session = await sessions.create({
     userId: options.userId,
     expiresAt: options.expiresAt,

--- a/packages/users/src/__tests__/session.test.ts
+++ b/packages/users/src/__tests__/session.test.ts
@@ -325,14 +325,20 @@ describe('SessionCollection', () => {
   it('should set tenant context for session', async () => {
     const user = await users.create({ email: 'tenant@example.com' });
     await user.save();
+    const tenants = await TenantCollection.create({ db: sessions.db });
+    const tenant = await tenants.create({
+      id: 'tenant-123',
+      name: 'Session Tenant',
+    });
+    await tenant.save();
 
     const session = await sessions.createSession({ userId: user.id! });
     expect(session.tenantId).toBeNull();
 
-    await sessions.setSessionTenant(session.id!, 'tenant-123');
+    await sessions.setSessionTenant(session.id!, tenant.id!);
 
     const updated = await sessions.findValidSession(session.id!);
-    expect(updated?.tenantId).toBe('tenant-123');
+    expect(updated?.tenantId).toBe(tenant.id);
   });
 
   it('should manage session data', async () => {

--- a/packages/users/src/__tests__/terminal-auth-handlers.test.ts
+++ b/packages/users/src/__tests__/terminal-auth-handlers.test.ts
@@ -11,6 +11,7 @@ import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TenantCollection } from '../collections/TenantCollection.js';
 import { UserCollection } from '../collections/UserCollection.js';
 import {
   createBearerSessionDeleteHandler,
@@ -61,7 +62,7 @@ describe('terminal-auth SvelteKit handlers', () => {
     sessionTtlSeconds: number;
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     dbPath = join(
       tmpdir(),
       `smrt-terminal-handlers-${Date.now()}-${Math.random().toString(16).slice(2)}.db`,
@@ -72,6 +73,12 @@ describe('terminal-auth SvelteKit handlers', () => {
       requestTtlSeconds: 60,
       sessionTtlSeconds: 3600,
     };
+    const tenants = await TenantCollection.create({ db: options.db });
+    const tenant = await tenants.create({
+      id: 'tenant-1',
+      name: 'Terminal Handler Tenant',
+    });
+    await tenant.save();
   });
 
   afterEach(() => {

--- a/packages/users/src/__tests__/terminal-auth.test.ts
+++ b/packages/users/src/__tests__/terminal-auth.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UsersCliAuthApproveLimitCollection } from '../collections/CliAuthApproveLimitCollection.js';
 import { UsersCliAuthRequestCollection } from '../collections/CliAuthRequestCollection.js';
 import { SessionCollection } from '../collections/SessionCollection.js';
+import { TenantCollection } from '../collections/TenantCollection.js';
 import { UserCollection } from '../collections/UserCollection.js';
 import { UsersCliAuthRequest } from '../models/CliAuthRequest.js';
 import {
@@ -36,6 +37,10 @@ describe('TerminalAuthService', () => {
     );
     const options = { db: { type: 'sqlite' as const, url: dbPath } };
 
+    users = await UserCollection.create(options);
+    const tenants = await TenantCollection.create(options);
+    const tenant = await tenants.create({ id: 'tenant-1', name: 'CLI Tenant' });
+    await tenant.save();
     service = await TerminalAuthService.create({
       ...options,
       userCodePrefix: 'WG',
@@ -43,7 +48,6 @@ describe('TerminalAuthService', () => {
       sessionTtlSeconds: 3600,
       verificationPath: '/terminal-login',
     });
-    users = await UserCollection.create(options);
     requests = await UsersCliAuthRequestCollection.create(options);
     sessions = await SessionCollection.create(options);
   });

--- a/packages/video/src/__tests__/video-collections.test.ts
+++ b/packages/video/src/__tests__/video-collections.test.ts
@@ -7,9 +7,11 @@
  */
 
 import { getTestDatabase } from '@happyvertical/smrt-core';
+import { VoiceProfile } from '@happyvertical/smrt-voice';
 import type { DatabaseInterface } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { CharacterCollection } from '../characters.js';
+import { Performer } from '../performer.js';
 import { VideoCompositionCollection } from '../video-compositions.js';
 import { VideoSequenceCollection } from '../video-sequences.js';
 import { VideoShotCharacterCollection } from '../video-shot-characters.js';
@@ -20,6 +22,12 @@ describe('video collection query helpers', () => {
 
   beforeEach(async () => {
     db = await getTestDatabase({ type: 'sqlite', url: ':memory:' });
+    const voiceProfile = new VoiceProfile({
+      db,
+      name: 'Video collection test voice',
+    });
+    await voiceProfile.initialize();
+    await voiceProfile.save();
   });
 
   afterEach(async () => {
@@ -38,9 +46,12 @@ describe('video collection query helpers', () => {
 
     it('finds shots filtered by sequence and status', async () => {
       const shots = await VideoShotCollection.create({ db });
+      const sequences = await VideoSequenceCollection.create({ db });
+      const sequence = await sequences.create({ title: 'Sequence A' });
+      await sequence.save();
       const inSeq = await shots.create({
         title: 'Shot A',
-        sequenceId: 'seq-1',
+        sequenceId: sequence.id as string,
         shotStatus: 'ready',
       });
       await inSeq.save();
@@ -51,7 +62,7 @@ describe('video collection query helpers', () => {
       });
       await standalone.save();
 
-      const bySeq = await shots.findBySequence('seq-1');
+      const bySeq = await shots.findBySequence(sequence.id as string);
       expect(bySeq.map((s) => s.title)).toEqual(['Shot A']);
 
       const ready = await shots.findByStatus('ready');
@@ -65,16 +76,21 @@ describe('video collection query helpers', () => {
   describe('VideoSequenceCollection', () => {
     it('finds sequences by composition and standalone', async () => {
       const sequences = await VideoSequenceCollection.create({ db });
+      const compositions = await VideoCompositionCollection.create({ db });
       expect(await sequences.findByComposition('comp-1')).toEqual([]);
       expect(await sequences.findStandalone()).toEqual([]);
 
+      const composition = await compositions.create({ title: 'Composition' });
+      await composition.save();
       const inComp = await sequences.create({
         title: 'Intro',
-        compositionId: 'comp-1',
+        compositionId: composition.id as string,
       });
       await inComp.save();
 
-      const byComp = await sequences.findByComposition('comp-1');
+      const byComp = await sequences.findByComposition(
+        composition.id as string,
+      );
       expect(byComp.map((s) => s.title)).toEqual(['Intro']);
     });
   });
@@ -105,19 +121,28 @@ describe('video collection query helpers', () => {
       expect(await links.findByShot('shot-1')).toEqual([]);
       expect(await links.findByCharacter('char-1')).toEqual([]);
 
+      const shots = await VideoShotCollection.create({ db });
+      const shot = await shots.create({ title: 'Linked shot' });
+      await shot.save();
+      const characters = await CharacterCollection.create({ db });
+      const character = await characters.create({ name: 'Linked character' });
+      await character.save();
+
       const link = await links.create({
-        videoShotId: 'shot-1',
-        characterId: 'char-1',
+        videoShotId: shot.id as string,
+        characterId: character.id as string,
         role: 'primary',
       });
       await link.save();
 
       expect(
-        (await links.findByShot('shot-1')).map((l) => l.characterId),
-      ).toEqual(['char-1']);
+        (await links.findByShot(shot.id as string)).map((l) => l.characterId),
+      ).toEqual([character.id]);
       expect(
-        (await links.findByCharacter('char-1')).map((l) => l.videoShotId),
-      ).toEqual(['shot-1']);
+        (await links.findByCharacter(character.id as string)).map(
+          (l) => l.videoShotId,
+        ),
+      ).toEqual([shot.id]);
     });
   });
 
@@ -128,10 +153,18 @@ describe('video collection query helpers', () => {
       expect(await characters.findByPerformer('perf-1')).toEqual([]);
       expect(await characters.findReady()).toEqual([]);
 
+      const performer = new Performer({
+        db,
+        name: 'Anchor performer',
+        tenantId: 'tenant-1',
+      });
+      await performer.initialize();
+      await performer.save();
+
       const ready = await characters.create({
         name: 'Anchor',
         tenantId: 'tenant-1',
-        performerId: 'perf-1',
+        performerId: performer.id as string,
         status: 'ready',
       });
       await ready.save();
@@ -140,7 +173,9 @@ describe('video collection query helpers', () => {
         (await characters.findByTenant('tenant-1')).map((c) => c.name),
       ).toEqual(['Anchor']);
       expect(
-        (await characters.findByPerformer('perf-1')).map((c) => c.name),
+        (await characters.findByPerformer(performer.id as string)).map(
+          (c) => c.name,
+        ),
       ).toEqual(['Anchor']);
       expect((await characters.findReady()).map((c) => c.name)).toEqual([
         'Anchor',

--- a/packages/video/src/video-owned-assets.test.ts
+++ b/packages/video/src/video-owned-assets.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { AssetCollection } from '@happyvertical/smrt-assets';
+import { VoiceProfile } from '@happyvertical/smrt-voice';
 import { describe, expect, it } from 'vitest';
 import {
   Character,
@@ -66,6 +67,14 @@ async function ensureLegacyColumn(
 
 async function createAssetFixture(dbUrl: string) {
   const dbConfig = { type: 'sqlite' as const, url: dbUrl };
+  const voiceProfile = new VoiceProfile({
+    db: dbConfig,
+    name: 'Video test voice',
+    tenantId: 'tenant-a',
+  });
+  await voiceProfile.initialize();
+  await voiceProfile.save();
+
   const assets = await AssetCollection.create({ db: dbConfig });
 
   return {

--- a/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
+++ b/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
@@ -1081,6 +1081,73 @@ describe('createIsolatedTestDbFromManifest', () => {
         }
       },
     );
+
+    it.skipIf(!process.env.DATABASE_URL)(
+      'refuses a legacy PostgreSQL cycle before applying partial DDL',
+      async () => {
+        const suffix = Date.now().toString(36);
+        const tableA = `vitest_legacy_cycle_a_${suffix}`;
+        const tableB = `vitest_legacy_cycle_b_${suffix}`;
+        const manifestPath = join(testDir, 'postgres-legacy-cycle-test.json');
+        writeFileSync(
+          manifestPath,
+          JSON.stringify({
+            objects: {
+              CycleA: {
+                className: 'CycleA',
+                schema: {
+                  tableName: tableA,
+                  ddl: `CREATE TABLE IF NOT EXISTS "${tableA}" ("id" TEXT PRIMARY KEY, "b_id" TEXT REFERENCES "${tableB}"("id"));`,
+                },
+              },
+              CycleB: {
+                className: 'CycleB',
+                schema: {
+                  tableName: tableB,
+                  ddl: `CREATE TABLE IF NOT EXISTS "${tableB}" ("id" TEXT PRIMARY KEY, "a_id" TEXT REFERENCES "${tableA}"("id"));`,
+                },
+              },
+            },
+          }),
+        );
+
+        await expect(
+          createIsolatedTestDbFromManifest({ manifestPath }),
+        ).rejects.toThrow(
+          /Cannot safely create PostgreSQL manifest schema.*legacy DDL foreign-key cycle.*No schema changes were applied/,
+        );
+
+        const probePath = join(testDir, 'postgres-legacy-cycle-probe.json');
+        writeFileSync(
+          probePath,
+          JSON.stringify({
+            objects: {
+              Probe: {
+                className: 'Probe',
+                schema: {
+                  tableName: `vitest_legacy_cycle_probe_${suffix}`,
+                  columns: {
+                    id: { type: 'TEXT', primaryKey: true, notNull: true },
+                  },
+                },
+              },
+            },
+          }),
+        );
+        const probe = await createIsolatedTestDbFromManifest({
+          manifestPath: probePath,
+        });
+        try {
+          const result = await probe.baseDb.query(
+            `SELECT to_regclass($1) AS table_a, to_regclass($2) AS table_b`,
+            [tableA, tableB],
+          );
+          expect(result.rows).toEqual([{ table_a: null, table_b: null }]);
+        } finally {
+          await probe.cleanup();
+        }
+      },
+    );
   });
 
   describe('transaction isolation', () => {

--- a/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
+++ b/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
@@ -1034,11 +1034,16 @@ describe('createIsolatedTestDbFromManifest', () => {
         };
         writeFileSync(manifestPath, JSON.stringify(manifest));
 
-        const { db, cleanup } = await createIsolatedTestDbFromManifest({
-          manifestPath,
-        });
-        try {
-          const constraints = await db.query(
+        const createCycleDb = () =>
+          createIsolatedTestDbFromManifest({ manifestPath });
+        const expectedConstraintTables = [
+          { table_name: 'vitest_cycle_a' },
+          { table_name: 'vitest_cycle_b' },
+        ];
+        const readConstraintTables = async (
+          db: Awaited<ReturnType<typeof createCycleDb>>['db'],
+        ) => {
+          const result = await db.query(
             `SELECT conrelid::regclass::text AS table_name
              FROM pg_constraint
              WHERE contype = 'f'
@@ -1048,12 +1053,31 @@ describe('createIsolatedTestDbFromManifest', () => {
                )
              ORDER BY table_name`,
           );
-          expect(constraints.rows).toEqual([
-            { table_name: 'vitest_cycle_a' },
-            { table_name: 'vitest_cycle_b' },
-          ]);
+          return result.rows;
+        };
+
+        const initial = await createCycleDb();
+        try {
+          expect(await readConstraintTables(initial.db)).toEqual(
+            expectedConstraintTables,
+          );
         } finally {
-          await cleanup();
+          await initial.cleanup();
+        }
+
+        const [repeated, concurrent] = await Promise.all([
+          createCycleDb(),
+          createCycleDb(),
+        ]);
+        try {
+          expect(await readConstraintTables(repeated.db)).toEqual(
+            expectedConstraintTables,
+          );
+          expect(await readConstraintTables(concurrent.db)).toEqual(
+            expectedConstraintTables,
+          );
+        } finally {
+          await Promise.all([repeated.cleanup(), concurrent.cleanup()]);
         }
       },
     );

--- a/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
+++ b/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
@@ -327,7 +327,7 @@ describe('createIsolatedTestDbFromManifest', () => {
             className: 'Child',
             schema: {
               tableName: 'legacy_filter_children',
-              ddl: 'CREATE TABLE "legacy_filter_children" ("id" TEXT PRIMARY KEY, "parent_id" TEXT REFERENCES "public"."legacy_filter_parents"("id"));',
+              ddl: 'CREATE TABLE "legacy_filter_children" ("id" TEXT PRIMARY KEY, "parent_id" TEXT REFERENCES "public"."legacy_filter_parents");',
             },
           },
         },
@@ -342,6 +342,44 @@ describe('createIsolatedTestDbFromManifest', () => {
       ).rejects.toThrow(
         'legacy DDL for "legacy_filter_children" references omitted table "legacy_filter_parents"',
       );
+    });
+
+    it('preserves a no-column-list legacy reference when its parent is included', async () => {
+      const manifestPath = join(testDir, 'included-legacy-foreign-key.json');
+      const manifest = {
+        objects: {
+          Parent: {
+            className: 'Parent',
+            schema: {
+              tableName: 'legacy_included_parents',
+              ddl: 'CREATE TABLE "legacy_included_parents" ("id" TEXT PRIMARY KEY);',
+            },
+          },
+          Child: {
+            className: 'Child',
+            schema: {
+              tableName: 'legacy_included_children',
+              ddl: 'CREATE TABLE "legacy_included_children" ("id" TEXT PRIMARY KEY, "parent_id" TEXT REFERENCES legacy_included_parents ON DELETE RESTRICT);',
+            },
+          },
+        },
+      };
+      writeFileSync(manifestPath, JSON.stringify(manifest));
+
+      const { db, cleanup } = await createIsolatedTestDbFromManifest({
+        manifestPath,
+        includeObjects: ['Parent', 'Child'],
+      });
+      try {
+        const foreignKeys = await db.query(
+          'PRAGMA foreign_key_list("legacy_included_children")',
+        );
+        expect(foreignKeys.rows).toEqual([
+          expect.objectContaining({ table: 'legacy_included_parents' }),
+        ]);
+      } finally {
+        await cleanup();
+      }
     });
 
     it('should filter using className even when manifest keys are namespaced (Issue #860)', async () => {

--- a/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
+++ b/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
@@ -260,6 +260,90 @@ describe('createIsolatedTestDbFromManifest', () => {
       ).rejects.toThrow('No objects with schema found matching: NonExistent');
     });
 
+    it('removes a structured foreign key when its parent is filtered out', async () => {
+      const manifestPath = join(testDir, 'filtered-foreign-key.json');
+      const manifest = {
+        objects: {
+          Parent: {
+            className: 'Parent',
+            schema: {
+              tableName: 'filtered_parents',
+              columns: {
+                id: { type: 'TEXT', primaryKey: true, notNull: true },
+              },
+            },
+          },
+          Child: {
+            className: 'Child',
+            schema: {
+              tableName: 'filtered_children',
+              columns: {
+                id: { type: 'TEXT', primaryKey: true, notNull: true },
+                parent_id: {
+                  type: 'TEXT',
+                  referenceKind: 'foreignKey',
+                  foreignKey: {
+                    table: 'filtered_parents',
+                    column: 'id',
+                    onDelete: 'NO ACTION',
+                    onUpdate: 'CASCADE',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      writeFileSync(manifestPath, JSON.stringify(manifest));
+
+      const { db, cleanup } = await createIsolatedTestDbFromManifest({
+        manifestPath,
+        includeObjects: ['Child'],
+      });
+      try {
+        await expect(db.list('filtered_children', {})).resolves.toEqual([]);
+        await expect(db.list('filtered_parents', {})).rejects.toThrow();
+        const foreignKeys = await db.query(
+          'PRAGMA foreign_key_list("filtered_children")',
+        );
+        expect(foreignKeys.rows).toEqual([]);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it('refuses filtered legacy DDL whose referenced parent is omitted', async () => {
+      const manifestPath = join(testDir, 'filtered-legacy-foreign-key.json');
+      const manifest = {
+        objects: {
+          Parent: {
+            className: 'Parent',
+            schema: {
+              tableName: 'legacy_filter_parents',
+              ddl: 'CREATE TABLE "legacy_filter_parents" ("id" TEXT PRIMARY KEY);',
+            },
+          },
+          Child: {
+            className: 'Child',
+            schema: {
+              tableName: 'legacy_filter_children',
+              ddl: 'CREATE TABLE "legacy_filter_children" ("id" TEXT PRIMARY KEY, "parent_id" TEXT REFERENCES "legacy_filter_parents"("id"));',
+            },
+          },
+        },
+      };
+      writeFileSync(manifestPath, JSON.stringify(manifest));
+
+      await expect(
+        createIsolatedTestDbFromManifest({
+          manifestPath,
+          includeObjects: ['Child'],
+        }),
+      ).rejects.toThrow(
+        'legacy DDL for "legacy_filter_children" references omitted table "legacy_filter_parents"',
+      );
+    });
+
     it('should filter using className even when manifest keys are namespaced (Issue #860)', async () => {
       const manifestPath = join(testDir, 'namespaced-filter.json');
       const manifest = {

--- a/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
+++ b/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
@@ -993,6 +993,70 @@ describe('createIsolatedTestDbFromManifest', () => {
         await cleanup();
       }
     });
+
+    it.skipIf(!process.env.DATABASE_URL)(
+      'defers structured mutual-cycle constraints on PostgreSQL',
+      async () => {
+        const manifestPath = join(testDir, 'postgres-cycle-test.json');
+        const relationship = (table: string) => ({
+          type: 'TEXT' as const,
+          referenceKind: 'foreignKey' as const,
+          foreignKey: {
+            table,
+            column: 'id',
+            onDelete: 'NO ACTION' as const,
+            onUpdate: 'CASCADE' as const,
+          },
+        });
+        const manifest = {
+          objects: {
+            CycleA: {
+              className: 'CycleA',
+              schema: {
+                tableName: 'vitest_cycle_a',
+                columns: {
+                  id: { type: 'TEXT', primaryKey: true, notNull: true },
+                  b_id: relationship('vitest_cycle_b'),
+                },
+              },
+            },
+            CycleB: {
+              className: 'CycleB',
+              schema: {
+                tableName: 'vitest_cycle_b',
+                columns: {
+                  id: { type: 'TEXT', primaryKey: true, notNull: true },
+                  a_id: relationship('vitest_cycle_a'),
+                },
+              },
+            },
+          },
+        };
+        writeFileSync(manifestPath, JSON.stringify(manifest));
+
+        const { db, cleanup } = await createIsolatedTestDbFromManifest({
+          manifestPath,
+        });
+        try {
+          const constraints = await db.query(
+            `SELECT conrelid::regclass::text AS table_name
+             FROM pg_constraint
+             WHERE contype = 'f'
+               AND conrelid IN (
+                 'vitest_cycle_a'::regclass,
+                 'vitest_cycle_b'::regclass
+               )
+             ORDER BY table_name`,
+          );
+          expect(constraints.rows).toEqual([
+            { table_name: 'vitest_cycle_a' },
+            { table_name: 'vitest_cycle_b' },
+          ]);
+        } finally {
+          await cleanup();
+        }
+      },
+    );
   });
 
   describe('transaction isolation', () => {

--- a/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
+++ b/packages/vitest/src/__tests__/test-db-from-manifest.test.ts
@@ -327,7 +327,7 @@ describe('createIsolatedTestDbFromManifest', () => {
             className: 'Child',
             schema: {
               tableName: 'legacy_filter_children',
-              ddl: 'CREATE TABLE "legacy_filter_children" ("id" TEXT PRIMARY KEY, "parent_id" TEXT REFERENCES "legacy_filter_parents"("id"));',
+              ddl: 'CREATE TABLE "legacy_filter_children" ("id" TEXT PRIMARY KEY, "parent_id" TEXT REFERENCES "public"."legacy_filter_parents"("id"));',
             },
           },
         },

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -628,11 +628,22 @@ interface TableInfo {
  */
 function extractForeignKeyDependencies(ddl: string): string[] {
   const dependencies: string[] = [];
-  // Match REFERENCES "tablename"( or REFERENCES tablename(
-  const regex = /REFERENCES\s+"?([a-zA-Z_][a-zA-Z0-9_]*)"?\s*\(/gi;
+  const identifier = '(?:"(?:[^"]|"")*"|[A-Za-z_][A-Za-z0-9_$]*)';
+  const regex = new RegExp(
+    `\\bREFERENCES\\s+((?:${identifier}\\s*\\.\\s*)*${identifier})\\s*\\(`,
+    'gi',
+  );
 
   for (const match of ddl.matchAll(regex)) {
-    const tableName = match[1];
+    const qualifiedTarget = match[1] ?? '';
+    const parts = Array.from(
+      qualifiedTarget.matchAll(/"((?:[^"]|"")*)"|([A-Za-z_][A-Za-z0-9_$]*)/g),
+    );
+    const finalIdentifier = parts.at(-1);
+    const tableName = finalIdentifier?.[1]
+      ? finalIdentifier[1].replaceAll('""', '"')
+      : finalIdentifier?.[2];
+    if (!tableName) continue;
     if (!dependencies.includes(tableName)) {
       dependencies.push(tableName);
     }

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -45,6 +45,7 @@ import {
   ensureSystemTables,
   isSmrtCollectionExtendsName,
 } from '@happyvertical/smrt-core';
+import { planForeignKeyCreation } from '@happyvertical/smrt-core/schema';
 import {
   type CollectedManifestTable,
   collectManifestTables,
@@ -471,6 +472,13 @@ export interface IsolatedTestDbResult {
 export async function createIsolatedTestDb(
   options: IsolatedTestDbOptions = {},
 ): Promise<IsolatedTestDbResult> {
+  return createIsolatedTestDbWithPostSchemaStatements(options, []);
+}
+
+async function createIsolatedTestDbWithPostSchemaStatements(
+  options: IsolatedTestDbOptions,
+  postSchemaStatements: readonly string[],
+): Promise<IsolatedTestDbResult> {
   const { schema, prefix = 'smrt-isolated' } = options;
 
   // Dynamically import getDatabase to avoid circular dependencies
@@ -507,6 +515,15 @@ export async function createIsolatedTestDb(
   // Sync schema if provided (must be done before transaction for DDL)
   if (schema && config.type !== 'sqlite') {
     await syncSchema({ db: baseDb, schema });
+  }
+
+  // PostgreSQL cycle planning removes cyclic constraints from CREATE TABLE
+  // and adds them only after every table exists. syncSchema intentionally
+  // handles schema definitions rather than arbitrary follow-up statements, so
+  // execute the planner's deferred constraints explicitly before opening the
+  // test transaction.
+  for (const statement of postSchemaStatements) {
+    await baseDb.query(statement);
   }
 
   // Transaction handles are passed to SMRT objects as already-initialized
@@ -1013,72 +1030,6 @@ function extractTablesFromManifest(
 }
 
 /**
- * Sort tables by foreign key dependencies using topological sort (Kahn's algorithm)
- *
- * Ensures referenced tables are created before tables that reference them
- */
-function sortByDependencies(tables: TableInfo[]): string[] {
-  const tableNames = new Set(tables.map((t) => t.tableName));
-  const inDegree = new Map<string, number>();
-  const graph = new Map<string, string[]>();
-
-  // Initialize
-  for (const table of tables) {
-    inDegree.set(table.tableName, 0);
-    graph.set(table.tableName, []);
-  }
-
-  // Build graph - only count dependencies that are in our table set
-  for (const table of tables) {
-    for (const dep of table.dependencies) {
-      if (tableNames.has(dep) && dep !== table.tableName) {
-        inDegree.set(table.tableName, (inDegree.get(table.tableName) || 0) + 1);
-        const edges = graph.get(dep) || [];
-        edges.push(table.tableName);
-        graph.set(dep, edges);
-      }
-    }
-  }
-
-  // Find all nodes with no incoming edges
-  const queue: string[] = [];
-  for (const [table, degree] of inDegree) {
-    if (degree === 0) {
-      queue.push(table);
-    }
-  }
-
-  // Process queue
-  const sorted: string[] = [];
-  while (queue.length > 0) {
-    const current = queue.shift();
-    if (current === undefined) break;
-    sorted.push(current);
-
-    const neighbors = graph.get(current) || [];
-    for (const neighbor of neighbors) {
-      const newDegree = (inDegree.get(neighbor) ?? 0) - 1;
-      inDegree.set(neighbor, newDegree);
-      if (newDegree === 0) {
-        queue.push(neighbor);
-      }
-    }
-  }
-
-  // Handle any remaining tables (circular dependencies)
-  // Use Set for O(1) lookups instead of O(n) Array.includes()
-  const sortedSet = new Set(sorted);
-  for (const table of tables) {
-    if (!sortedSet.has(table.tableName)) {
-      sorted.push(table.tableName);
-      sortedSet.add(table.tableName);
-    }
-  }
-
-  return sorted;
-}
-
-/**
  * Create an isolated test database with schema derived from a manifest file.
  *
  * Eliminates the need to manually write or maintain DDL in test files by
@@ -1187,13 +1138,22 @@ export async function createIsolatedTestDbFromManifest(
     );
   }
 
-  // 3. Sort by FK dependencies and render through the engine DDL strategy
-  // Use Map for O(1) lookups instead of O(n) Array.find()
+  // 3. Use the same dependency/cycle planner as every other schema path.
+  // Legacy contributors expose dependencies only through cached DDL, so carry
+  // the already-parsed TableInfo dependencies into the structured plan input.
   const tableMap = new Map(tables.map((t) => [t.tableName, t] as const));
-  const sortedTableNames = sortByDependencies(tables);
-  const rendered = sortedTableNames.flatMap((name) => {
-    const table = tableMap.get(name);
-    return table ? [renderCollectedManifestTable(table.table, adapter)] : [];
+  const plan = planForeignKeyCreation(
+    tables.map((table) => ({
+      ...table.table.definition,
+      dependencies: table.dependencies,
+    })),
+    adapter,
+  );
+  const rendered = plan.schemas.flatMap((definition) => {
+    const table = tableMap.get(definition.tableName);
+    return table
+      ? [renderCollectedManifestTable({ ...table.table, definition }, adapter)]
+      : [];
   });
 
   // CREATE TABLE statements first
@@ -1214,10 +1174,13 @@ export async function createIsolatedTestDbFromManifest(
     .join('\n');
 
   // Combine table DDL and index DDL
-  const sortedDDL = createIndexDDL
-    ? `${createTableDDL}\n\n${createIndexDDL}`
-    : createTableDDL;
+  const sortedDDL = [createTableDDL, createIndexDDL]
+    .filter(Boolean)
+    .join('\n\n');
 
   // 4. Delegate to existing function
-  return createIsolatedTestDb({ schema: sortedDDL, prefix });
+  return createIsolatedTestDbWithPostSchemaStatements(
+    { schema: sortedDDL, prefix },
+    plan.deferredStatements,
+  );
 }

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -45,7 +45,10 @@ import {
   ensureSystemTables,
   isSmrtCollectionExtendsName,
 } from '@happyvertical/smrt-core';
-import { planForeignKeyCreation } from '@happyvertical/smrt-core/schema';
+import {
+  foreignKeyConstraintName,
+  planForeignKeyCreation,
+} from '@happyvertical/smrt-core/schema';
 import {
   type CollectedManifestTable,
   collectManifestTables,
@@ -477,7 +480,7 @@ export async function createIsolatedTestDb(
 
 async function createIsolatedTestDbWithPostSchemaStatements(
   options: IsolatedTestDbOptions,
-  postSchemaStatements: readonly string[],
+  postSchemaStatements: readonly PostSchemaStatement[],
 ): Promise<IsolatedTestDbResult> {
   const { schema, prefix = 'smrt-isolated' } = options;
 
@@ -522,8 +525,33 @@ async function createIsolatedTestDbWithPostSchemaStatements(
   // handles schema definitions rather than arbitrary follow-up statements, so
   // execute the planner's deferred constraints explicitly before opening the
   // test transaction.
-  for (const statement of postSchemaStatements) {
-    await baseDb.query(statement);
+  for (const deferred of postSchemaStatements) {
+    if (
+      await postgresConstraintExists(
+        baseDb,
+        deferred.tableName,
+        deferred.constraintName,
+      )
+    ) {
+      continue;
+    }
+    try {
+      await baseDb.query(deferred.statement);
+    } catch (error) {
+      // Parallel test factories may both observe the constraint as absent.
+      // Treat the losing ADD as successful only when the exact table/name is
+      // now present; otherwise preserve the original database failure.
+      if (
+        await postgresConstraintExists(
+          baseDb,
+          deferred.tableName,
+          deferred.constraintName,
+        )
+      ) {
+        continue;
+      }
+      throw error;
+    }
   }
 
   // Transaction handles are passed to SMRT objects as already-initialized
@@ -589,6 +617,35 @@ async function createIsolatedTestDbWithPostSchemaStatements(
   };
 
   return { db, baseDb, config, cleanup };
+}
+
+interface PostSchemaStatement {
+  statement: string;
+  tableName: string;
+  constraintName: string;
+}
+
+async function postgresConstraintExists(
+  db: DatabaseInterfaceWithTransaction,
+  tableName: string,
+  constraintName: string,
+): Promise<boolean> {
+  const result = await db.query(
+    `SELECT 1
+     FROM pg_constraint AS constraint_row
+     JOIN pg_class AS table_row ON table_row.oid = constraint_row.conrelid
+     JOIN pg_namespace AS namespace_row ON namespace_row.oid = table_row.relnamespace
+     WHERE table_row.relname = $1
+       AND namespace_row.nspname = current_schema()
+       AND constraint_row.conname = $2
+       AND constraint_row.contype = 'f'
+     LIMIT 1`,
+    [tableName, constraintName],
+  );
+  const rows = Array.isArray(result)
+    ? result
+    : ((result as { rows?: unknown[] }).rows ?? []);
+  return rows.length > 0;
 }
 
 // ============================================================================
@@ -1181,6 +1238,10 @@ export async function createIsolatedTestDbFromManifest(
   // 4. Delegate to existing function
   return createIsolatedTestDbWithPostSchemaStatements(
     { schema: sortedDDL, prefix },
-    plan.deferredStatements,
+    plan.deferredConstraints.map(({ table, foreignKey }, index) => ({
+      statement: plan.deferredStatements[index] as string,
+      tableName: table,
+      constraintName: foreignKeyConstraintName(table, foreignKey),
+    })),
   );
 }

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -630,7 +630,7 @@ function extractForeignKeyDependencies(ddl: string): string[] {
   const dependencies: string[] = [];
   const identifier = '(?:"(?:[^"]|"")*"|[A-Za-z_][A-Za-z0-9_$]*)';
   const regex = new RegExp(
-    `\\bREFERENCES\\s+((?:${identifier}\\s*\\.\\s*)*${identifier})\\s*\\(`,
+    `\\bREFERENCES\\s+((?:${identifier}\\s*\\.\\s*)*${identifier})(?![A-Za-z0-9_$"]|\\s*\\.)`,
     'gi',
   );
 

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -1206,6 +1206,16 @@ export async function createIsolatedTestDbFromManifest(
     })),
     adapter,
   );
+  if (adapter === 'postgres') {
+    const unstructuredCyclicTables = plan.cyclicTables.filter(
+      (tableName) => !tableMap.get(tableName)?.table.structured,
+    );
+    if (unstructuredCyclicTables.length > 0) {
+      throw new Error(
+        `Cannot safely create PostgreSQL manifest schema: legacy DDL foreign-key cycle includes ${unstructuredCyclicTables.map((tableName) => `"${tableName}"`).join(', ')}. Regenerate a structured manifest so cyclic constraints can be deferred. No schema changes were applied.`,
+      );
+    }
+  }
   const rendered = plan.schemas.flatMap((definition) => {
     const table = tableMap.get(definition.tableName);
     return table

--- a/packages/vitest/src/test-db.ts
+++ b/packages/vitest/src/test-db.ts
@@ -962,11 +962,43 @@ function extractTablesFromManifest(
     entries.push({ schema: objectDef.schema, source: key });
   }
 
-  return Array.from(collectManifestTables(entries).values()).map((table) => ({
-    tableName: table.tableName,
-    table,
-    dependencies: collectTableDependencies(table),
-  }));
+  const collected = Array.from(collectManifestTables(entries).values());
+  const includedTables = new Set(collected.map((table) => table.tableName));
+
+  return collected.map((table) => {
+    const missingDependencies = collectTableDependencies(table).filter(
+      (dependency) => !includedTables.has(dependency),
+    );
+    if (missingDependencies.length > 0 && !table.structured) {
+      throw new Error(
+        `Cannot safely create filtered manifest schema: legacy DDL for "${table.tableName}" references omitted table "${missingDependencies[0]}". Include the referenced object or regenerate a structured manifest.`,
+      );
+    }
+
+    const definition = {
+      ...table.definition,
+      columns: Object.fromEntries(
+        Object.entries(table.definition.columns).map(([name, column]) => [
+          name,
+          column.foreignKey && !includedTables.has(column.foreignKey.table)
+            ? { ...column, foreignKey: undefined }
+            : column,
+        ]),
+      ),
+      foreignKeys: table.definition.foreignKeys.filter((foreignKey) =>
+        includedTables.has(foreignKey.referencesTable),
+      ),
+      dependencies: table.definition.dependencies.filter((dependency) =>
+        includedTables.has(dependency),
+      ),
+    };
+    const filteredTable = { ...table, definition };
+    return {
+      tableName: filteredTable.tableName,
+      table: filteredTable,
+      dependencies: collectTableDependencies(filteredTable),
+    };
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

- emit deterministic database foreign-key constraints for resolved same-package `@foreignKey` relationships while keeping tenant markers, `@crossPackageRef`, and decorator-only unresolved targets constraint-free
- share delete-action policy with app-side cascade handling, preserve the public `ON UPDATE CASCADE` default, and retain explicit manifest foreign-key authority
- order table creation deterministically, defer PostgreSQL mutual-cycle constraints, keep SQLite cycles inline, and actionable-refuse unsupported DuckDB/JSON shapes
- detect existing PostgreSQL orphans before `ADD CONSTRAINT`, recover idempotently from existing `NOT VALID` constraints, and provide repair guidance
- route the same planner through core, registry/schema manager, aggregation, test database setup, generated migrations, and CLI execution/dry-run surfaces
- roll back child-first, remove deferred PostgreSQL constraints before cycle drops, and defer SQLite checks while dropping populated cycles
- support explicit same-package archival references with `@foreignKey(Target, { constraint: false })`, retaining relationship metadata, target ID type, indexes, and the stored identifier while omitting physical DDL/dependencies and app-side delete actions
- make filtered manifest test schemas remove structured dangling constraints and fail closed for qualified or unqualified legacy `REFERENCES` targets, including valid references without a column list
- normalize optional commerce relationship IDs to SQL `NULL` while retaining physical constraints, and seed real tenant-matched parents in affected package fixtures
- keep native DuckDB job claim/recovery and OIDC identity keys string-stable at their worker/auth boundaries without reverting native UUID DDL to JSON semantics
- preserve natural-key delete-policy parity in the exported registry field helper and inherit STI-root conflict policy across every root/child manifest schema copy
- use the shared FK planner in manifest-backed test databases, explicitly install structured PostgreSQL cycle constraints idempotently, and refuse legacy unstructured PostgreSQL cycles before any partial DDL

## Breaking schema notes

- ordinary same-package references now enforce `NO ACTION`; conflict/natural-key references default to `CASCADE`
- native DuckDB test schema preparation now stays distinct from JSON-on-DuckDB and emits native UUID columns; explicit and existing-adapter regressions cover both paths
- DuckDB/JSON now refuse unsupported self-references, cycles, delete actions, and generated `ON UPDATE CASCADE` instead of silently omitting an intended constraint
- existing PostgreSQL tables must repair orphan rows before a missing constraint can be installed
- `SmrtJobEvent.jobId` is the documented archival exception because 30-day events intentionally outlive 7-day completed jobs
- `SecretAuditLog.secretId` is the documented compliance exception because 1–7 year audit rows intentionally outlive deleted or drift-purged secrets

## Validation

- Node 24.19: core full suite — 299 files / 4002 tests passed
- Node 24.19: CLI full suite — 62 files / 905 tests passed
- Node 24.19: analytics — 21 files / 293 tests; chat — 27 files passed / 1 skipped, 257 passed / 1 skipped; sales — 33 files passed / 6 skipped, 430 passed / 27 skipped
- facts — 11 files passed / 1 skipped, 155 tests passed / 3 skipped; fields — 18 files / 258 tests; images — 15 files / 146 tests
- commerce — 14 files passed / 1 skipped, 233 tests passed / 11 skipped; ledgers — 5 files / 55 tests; properties — 4 files / 41 tests
- Node 24.19: assets — 19 files / 126 tests; events — 8 / 139; jobs — 21 / 142; secrets — 1 / 43
- Node 24.19 final remediation: ads — 5 files / 34 tests; jobs — 21 / 142; profiles — 18 / 218, including direct native-DuckDB claim/recovery and independent-handle OIDC string-identity regressions
- PostgreSQL focused integration — core #2413 4 tests passed; sales 6 files / 27 tests passed (named physical constraint, DB cascade, app cascade, mutual-cycle apply/rollback, idempotent SchemaManager repeat)
- subscriptions PostgreSQL — 3 / 3 passed
- core, CLI, commerce, ledgers, properties, assets, events, jobs, and secrets build/typecheck gates
- Biome on all changed source files; strict knowledge freshness with zero warnings
- exact `ec30c9c62` compatibility rerun: vitest 60 passed / 7 skipped; users 476 / 25; messages 269 / 15; social 24 passed
- exact `ec30c9c62` live PostgreSQL: structured mutual-cycle plus legacy refusal/no-partial-DDL 2/2; core #2413 4/4
- exact `ec30c9c62`: core, CLI, vitest, users, messages, and social typecheck and build; pre-push hooks all green
- exact `ec30c9c62` projects 129/3 and personas 63/0, with real tenant-matched FK parents and complete subscriptions consumer schema metadata\n- exact-head high-risk final review on `ec30c9c62b641c64aed32a3ae8c156ae476ed759`: Codex Sol CLEAN; Claude Fable and Opus fallback both returned authenticated session-limit unavailable (recorded in delivery evidence; protected CI remains authoritative)

- exact `ec30c9c62` final fixture remediation: Content 45 files, 302 passed/6 skipped; Sites 5 files, 35 passed; real tenant-matched parents and complete schemas, with no FK opt-outs or model relaxation
- exact `ec30c9c62` live PostgreSQL: Vitest cycle/refusal 2 passed; Core migration/FK 9 passed; full Core and CLI, affected package, typecheck, build, Biome/lint, strict knowledge, and pre-push gates green
- exact-head review on `ec30c9c62b641c64aed32a3ae8c156ae476ed759`: preliminary Codex Terra CLEAN and final Codex Sol CLEAN; Claude Fable and Opus unavailable due authenticated session limit, recorded in delivery evidence

## Follow-up note

Schema comparison installs missing physical foreign keys but does not yet report or plan removal of a live constraint that a future manifest stops declaring. Main has never emitted these constraints, so this cannot strand an upgrade-time constraint in #2413. A later schema-parity change should add explicit cross-engine reporting/planning before deployed relationships transition to `constraint: false` or remove their physical constraint.

The full optional PostgreSQL sweep also exposed three unrelated existing failures: the #1758 change-feed barrier timeout, #1904 facets missing an `ON CONFLICT` unique constraint, and #2069's expected error-message mismatch. The #2413/#2371 PostgreSQL lanes are green on a fresh service.

Closes #2413

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "D6A52751-3783-4746-ADE6-E33547F76303",
  "issue": 2413,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm --filter @happyvertical/smrt-core test",
    "pnpm --filter @happyvertical/smrt-cli test",
    "pnpm --filter @happyvertical/smrt-assets test",
    "pnpm --filter @happyvertical/smrt-events test",
    "pnpm --filter @happyvertical/smrt-jobs test",
    "pnpm --filter @happyvertical/smrt-secrets test",
    "pnpm --filter @happyvertical/smrt-commerce test",
    "pnpm --filter @happyvertical/smrt-ledgers test",
    "pnpm --filter @happyvertical/smrt-properties test",
    "pnpm --filter @happyvertical/smrt-core exec vitest run src/schema/issue-2413-foreign-keys-postgres.optional.test.ts src/__tests__/issue-2371-delete-cascade-postgres.optional.test.ts",
    "pnpm --filter @happyvertical/smrt-subscriptions test:postgres",
    "pnpm --filter @happyvertical/smrt-core build",
    "pnpm --filter @happyvertical/smrt-core typecheck",
    "pnpm exec biome check <changed-source-files>",
    "pnpm knowledge:check"
  ]
}


